### PR TITLE
fix(site): serve assets from root, not /platypusgit base path

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -2,7 +2,6 @@
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({
-  site: 'https://jonassaa.github.io',
-  base: '/platypusgit',
+  site: 'https://www.platypusgit.com',
   trailingSlash: 'ignore',
 });


### PR DESCRIPTION
## Why

Site is live at custom domain **platypusgit.com** (served at root), but `site/astro.config.mjs` still targeted the old GitHub Pages project URL `jonassaa.github.io/platypusgit`. With `base: '/platypusgit'`, every asset was emitted at `/platypusgit/_astro/*.css` and `/platypusgit/logo.svg`.

At the custom domain those paths 404 — the page rendered with **zero CSS**, a broken logo, and icon glyphs as raw text.

Verified: `https://platypusgit.com/platypusgit/_astro/index.*.css` → 404, while `/_astro/index.*.css` (root) → 200. Assets are served at root; the HTML just pointed to the wrong prefix.

## Fix

- Drop `base: '/platypusgit'` → defaults to `/`, asset links become root-relative.
- Point `site` at `https://www.platypusgit.com` (canonical; apex 301s to www) for correct canonical/OG URLs.

Rebuilt locally + previewed headless: full dark theme, hero, app showcase, feature cards, footer all render correctly.

Deploy workflow uploads `site/dist` as a Pages artifact and does not touch the custom-domain setting, so the domain is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)