### PR TITLE
feat(palette): command palette / fuzzy finder (⌘P)

### DIFF
--- a/docs/superpowers/plans/2026-06-29-command-palette.md
+++ b/docs/superpowers/plans/2026-06-29-command-palette.md
@@ -1,0 +1,44 @@
+# Command palette / fuzzy finder (⌘P) — plan
+
+**Spec:** `docs/superpowers/specs/2026-06-29-command-palette-design.md`
+**Date:** 2026-06-29
+
+## Steps
+
+1. **Pure fuzzy match (TDD).**
+   - Write `src/features/palette/fuzzyMatch.test.ts` first (subsequence, case-insensitive, scoring order, indices, empty/non-match).
+   - Implement `src/features/palette/fuzzyMatch.ts` to pass.
+   - Verify: `pnpm test`.
+
+2. **Palette store.**
+   - `src/features/palette/usePaletteStore.ts` — `{ open, query, openPalette, closePalette, setQuery }`.
+
+3. **Nav intent for screen switch.**
+   - Add `{ kind: "switch-screen"; screen: string }` to `NavIntent` in `useNavStore.ts`.
+   - In `AppShell.tsx`, route `switch-screen` → `setScreen(intent.screen)` and clear intent.
+
+4. **Command palette component.**
+   - `src/features/palette/CommandPalette.tsx`:
+     - Read branches/allFiles/commits from `useRepoStore`; build command list from activity items + global actions.
+     - Run `fuzzyMatch` over candidates, sort by score, group by type, cap per group, flatten for nav.
+     - Keyboard: Arrow up/down, Enter, Esc. Mouse hover/click. Backdrop click closes.
+     - On open: focus input, reset query/active, call `refreshAllFiles()`.
+     - Selection dispatch: branch→checkout, file→diff-file intent, commit→commit-vs-wt intent, command→action or switch-screen intent.
+     - Portal to `document.body`, centered modal + backdrop, design-system styling.
+
+5. **Wire into AppShell.**
+   - Global ⌘P/Ctrl+P keydown listener (ignore inputs/textareas/contentEditable), toggles `openPalette()`.
+   - Render `<CommandPalette />` once at shell level.
+
+6. **Component test.**
+   - `src/features/palette/CommandPalette.test.tsx`: open→type→ArrowDown→Enter fires intent; Esc closes.
+
+7. **Verify all green.**
+   - `pnpm tsc --noEmit`, `pnpm test`, `pnpm vite build`. No Rust touched.
+
+## Decisions
+
+- File default action = diff (`diff-file` intent), not open-in-editor — predictable, keyboard-only.
+- Commit default action = commit-vs-working-tree diff (`commit-vs-wt`), reusing existing intent.
+- Screen switching via new `switch-screen` intent rather than hoisting screen state — keeps AppShell the single router.
+- No backend changes; `allFiles` in-memory list is the file source.

--- a/docs/superpowers/specs/2026-06-29-command-palette-design.md
+++ b/docs/superpowers/specs/2026-06-29-command-palette-design.md
@@ -1,0 +1,117 @@
+# Command palette / fuzzy finder (⌘P) — design
+
+**Status:** approved
+**Date:** 2026-06-29
+**Owner:** jonas
+**Related:** `docs/superpowers/specs/2026-04-24-centralized-branch-ui-design.md`
+
+## Why
+
+P0 feature: "Command palette / fuzzy finder (⌘P) — jump to branch, file, commit, command."
+
+platypusgit's north star is "extreme usability" for developers. Power users live on the keyboard. A single ⌘P that fuzzy-searches everything — branches, files, recent commits, app screens/commands — collapses many multi-click navigation paths into one. It mirrors the muscle memory devs already have from VS Code, Sublime, Zed.
+
+This is almost entirely a frontend feature. All data already lives in existing Zustand stores (branches, file list, commit log, activity-bar screens). No new backend git ops.
+
+## Scope
+
+### In scope (MVP)
+
+- Global ⌘P / Ctrl+P opens a centered modal fuzzy-finder overlay. Esc closes. ArrowUp/Down move selection, Enter activates. Shortcut ignored when focus is in an input/textarea/contentEditable (matches existing ⌘1…⌘9 handling).
+- One query box, mixed result list across four types:
+  - **Branch** — local + remote branches → checkout on select.
+  - **File** — every worktree file (from `allFiles`) → open in editor + diff via nav intent.
+  - **Commit** — recent commits from the log → show commit diff vs working tree via nav intent.
+  - **Command / screen** — activity-bar screens + a few global actions (Settings, Fetch, etc.) → switch screen / run action.
+- Results grouped/tagged by type, ranked by fuzzy score, capped per type.
+- Pure, testable fuzzy-match function in `features/palette/fuzzyMatch.ts` with `fuzzyMatch.test.ts`.
+
+### Out of scope (future)
+
+- Server-side / on-disk file index (uses the in-memory `allFiles` list).
+- Content search inside files.
+- Customizable command registry / user-defined commands.
+- Result preview pane.
+- Persisted recent-command MRU ordering.
+
+## Architecture
+
+Frontend-only. No `GitBackend`/Rust changes.
+
+### Fuzzy match (pure)
+
+`src/features/palette/fuzzyMatch.ts`:
+
+```ts
+export interface FuzzyResult {
+  matched: boolean;
+  score: number;          // higher = better; 0 when !matched
+  indices: number[];      // matched char positions in the target (for highlight)
+}
+export function fuzzyMatch(query: string, target: string): FuzzyResult;
+```
+
+Subsequence matcher (every query char appears in order in target). Scoring rewards:
+consecutive runs, matches at word boundaries (`/`, `-`, `_`, `.`, camelCase, start),
+and earlier matches. Empty query → `matched: true, score: 0, indices: []`. Case-insensitive.
+
+### Palette store
+
+`src/features/palette/usePaletteStore.ts` — tiny Zustand store: `{ open, query, openPalette(), closePalette(), setQuery() }`. Just open/query UI state; result data is read live from the other stores inside the component.
+
+### Result assembly
+
+`src/features/palette/CommandPalette.tsx` reads branches/allFiles/commits from `useRepoStore`, builds a static command list from the activity-bar items, runs `fuzzyMatch` over each candidate's display string, sorts, groups by type, caps each group, flattens for keyboard nav.
+
+`allFiles` is lazy — the palette triggers `refreshAllFiles()` when it opens (cheap; same call RepoBrowser uses).
+
+### Selection actions
+
+- Branch → `useRepoStore.checkoutBranch(name)`.
+- File → `useNavStore.setIntent({ kind: "diff-file", path })` (existing intent; AppShell already routes it to the diff screen) + `useRepoStore.openInEditor(path)` is NOT auto-run; default action is diff. (Keeps it predictable; open-in-editor stays a context action elsewhere.)
+- Commit → `useNavStore.setIntent({ kind: "commit-vs-wt", oid })` (existing intent → commitDiff screen).
+- Command/screen → a new nav intent kind `switch-screen` carrying the target screen id, routed in AppShell. This is the only nav-store addition.
+
+### Why a new `switch-screen` intent
+
+Screen switching currently lives in `AppShell` local state (`setScreen`), not reachable from a decoupled overlay. Rather than hoist screen state into a store, add a `NavIntent` of kind `switch-screen` so the palette stays decoupled and AppShell remains the single screen router. Consistent with the existing intent pattern.
+
+## UI / UX
+
+- Centered modal, ~560px wide, max-height ~60vh, rendered via portal to `document.body`, dimmed backdrop. Matches `BranchPicker` styling (bg-1, border-1, r-3, shadow) but centered rather than anchored.
+- Top: `PGSearchInput`, autofocused, placeholder "Search branches, files, commits, commands…".
+- Body: scroll list grouped by type with section headers (same style as BranchPicker section headers). Each row: type icon, primary label, secondary muted detail (branch upstream / file dir / commit short-oid+relative time / command shortcut). Active row highlighted with `--bg-selection`.
+- Empty query shows a default set (all commands + a few recent commits/branches) so the palette is useful with zero typing.
+- Mouse hover sets active row; click activates.
+- Backdrop click + Esc close.
+
+## State
+
+`usePaletteStore` (Zustand, colocated):
+
+```ts
+interface PaletteState {
+  open: boolean;
+  query: string;
+  openPalette: () => void;
+  closePalette: () => void;
+  setQuery: (q: string) => void;
+}
+```
+
+No cross-feature state. Result data read live from `useRepoStore`; screen switch via `useNavStore`.
+
+## Errors
+
+No new `AppError` variants. Selection actions delegate to existing store methods that already surface errors via the repo store's `error` banner.
+
+## Testing
+
+- **Frontend pure logic** — `fuzzyMatch.test.ts`: subsequence matching, case-insensitivity, ordering (boundary > mid-word, consecutive > scattered, earlier > later), non-match, empty query, index correctness.
+- **Frontend component test** — `CommandPalette.test.tsx`: opens on render when store open; typing filters; ArrowDown+Enter on a command row fires the nav intent; Esc closes. Uses existing `mockInvoke` setup.
+
+## Conventions touched
+
+- New per-feature folder `src/features/palette/` with colocated store + component + pure fn + tests — matches existing pattern.
+- One new `NavIntent` kind (`switch-screen`) added to `useNavStore` and routed in `AppShell` — matches the documented cross-screen-intent pattern.
+- Design-system imports only (`@/design`); CSS vars / Tailwind v4 tokens for styling.

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -29,6 +29,8 @@ import { SettingsScreen } from "@/screens/Settings";
 
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
+import { usePaletteStore } from "@/features/palette/usePaletteStore";
+import { CommandPalette } from "@/features/palette/CommandPalette";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { BranchChip } from "@/features/branches/BranchChip";
 import { BranchPicker } from "@/features/branches/BranchPicker";
@@ -134,7 +136,31 @@ export function AppShell() {
     return () => window.removeEventListener("keydown", onKey);
   }, [repo]);
 
+  // Global ⌘P / Ctrl+P opens the command palette. Ignored when typing in an
+  // input/textarea/contentEditable, matching the ⌘1…⌘9 handling above.
+  React.useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey)) return;
+      if (e.shiftKey || e.altKey) return;
+      if (e.key !== "p" && e.key !== "P") return;
+      const t = e.target as HTMLElement | null;
+      if (
+        t &&
+        (t.tagName === "INPUT" ||
+          t.tagName === "TEXTAREA" ||
+          t.isContentEditable)
+      ) {
+        return;
+      }
+      e.preventDefault();
+      usePaletteStore.getState().openPalette();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
   const intent = useNavStore((s) => s.intent);
+  const clearIntent = useNavStore((s) => s.clearIntent);
   React.useEffect(() => {
     if (!intent) return;
     switch (intent.kind) {
@@ -156,6 +182,10 @@ export function AppShell() {
         break;
       case "stash-diff":
         setScreen("commitDiff");
+        break;
+      case "switch-screen":
+        setScreen(intent.screen as ScreenId);
+        clearIntent();
         break;
     }
   }, [intent]);
@@ -229,6 +259,7 @@ export function AppShell() {
         <WelcomeScreen />
       )}
       <AppStatusBar />
+      <CommandPalette />
     </div>
   );
 }

--- a/src/features/nav/useNavStore.ts
+++ b/src/features/nav/useNavStore.ts
@@ -13,7 +13,8 @@ export type NavIntent =
   | { kind: "file-history"; path: string }
   | { kind: "blame"; path: string }
   | { kind: "rebase-plan"; plan: RebaseStep[] }
-  | { kind: "stash-diff"; oid: string };
+  | { kind: "stash-diff"; oid: string }
+  | { kind: "switch-screen"; screen: string };
 
 interface NavState {
   intent: NavIntent | null;

--- a/src/features/palette/CommandPalette.test.tsx
+++ b/src/features/palette/CommandPalette.test.tsx
@@ -9,6 +9,11 @@ import { useNavStore } from "@/features/nav/useNavStore";
 import { mockInvoke } from "@/test/invokeMock";
 import type { BranchInfo, CommitInfo } from "@/lib/types";
 
+// Result labels render matched chars inside emphasized <span>s, so a label's
+// text is split across child nodes. Match on the row's combined textContent.
+const rowText = (label: string) => (_content: string, el: Element | null) =>
+  el?.getAttribute("data-pal-index") != null && el.textContent?.includes(label) === true;
+
 const mkBranch = (name: string, isHead = false): BranchInfo => ({
   name,
   isHead,
@@ -84,7 +89,7 @@ describe("CommandPalette", () => {
     await user.click(input);
     await user.keyboard("History");
 
-    await waitFor(() => expect(screen.getByText("Go to History")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText(rowText("Go to History"))).toBeTruthy());
 
     await user.keyboard("{ArrowDown}{Enter}");
 
@@ -113,7 +118,7 @@ describe("CommandPalette", () => {
     await user.click(input);
     await user.keyboard("featurex");
 
-    const row = await screen.findByText("feature/x");
+    const row = await screen.findByText(rowText("feature/x"));
     await user.click(row);
 
     await waitFor(() => expect(checkedOut).toBe("feature/x"));
@@ -132,7 +137,7 @@ describe("CommandPalette", () => {
     await user.click(input);
     await user.keyboard("Fix the bug");
 
-    const row = await screen.findByText("Fix the bug");
+    const row = await screen.findByText(rowText("Fix the bug"));
     await user.click(row);
 
     await waitFor(() => {
@@ -141,6 +146,43 @@ describe("CommandPalette", () => {
         oid: "abcdef1234",
       });
     });
+  });
+
+  it("emphasizes the matched characters in a result label", async () => {
+    const user = userEvent.setup();
+    usePaletteStore.setState({ open: true, query: "" });
+    render(<CommandPalette />);
+    await screen.findByRole("dialog");
+
+    const input = screen.getByPlaceholderText(/Search branches/i);
+    await user.click(input);
+    await user.keyboard("History");
+
+    const row = await screen.findByText(rowText("Go to History"));
+    // The matched chars ("History") render inside an emphasized <span> using
+    // the accent color, so the label is split across child nodes.
+    const emphasized = Array.from(row.querySelectorAll("span")).filter((s) =>
+      (s.getAttribute("style") ?? "").includes("--color-accent"),
+    );
+    expect(emphasized.length).toBeGreaterThan(0);
+    expect(emphasized.map((s) => s.textContent).join("")).toContain("History");
+  });
+
+  it("traps Tab focus inside the dialog", async () => {
+    const user = userEvent.setup();
+    usePaletteStore.setState({ open: true, query: "" });
+    render(<CommandPalette />);
+    const dialog = await screen.findByRole("dialog");
+
+    const input = screen.getByPlaceholderText(/Search branches/i);
+    await user.click(input);
+    await user.keyboard("{Tab}");
+    // Focus must remain within the dialog rather than escaping to <body>.
+    expect(dialog.contains(document.activeElement)).toBe(true);
+    expect(document.activeElement).not.toBe(document.body);
+
+    await user.keyboard("{Shift>}{Tab}{/Shift}");
+    expect(dialog.contains(document.activeElement)).toBe(true);
   });
 
   it("closes on Escape", async () => {

--- a/src/features/palette/CommandPalette.test.tsx
+++ b/src/features/palette/CommandPalette.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { CommandPalette } from "./CommandPalette";
+import { usePaletteStore } from "./usePaletteStore";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { mockInvoke } from "@/test/invokeMock";
+import type { BranchInfo, CommitInfo } from "@/lib/types";
+
+const mkBranch = (name: string, isHead = false): BranchInfo => ({
+  name,
+  isHead,
+  isRemote: false,
+  upstream: null,
+  ahead: 0,
+  behind: 0,
+  tip: null,
+});
+
+const mkCommit = (oid: string, summary: string): CommitInfo => ({
+  oid,
+  shortOid: oid.slice(0, 7),
+  summary,
+  body: null,
+  author: "Dev",
+  email: "",
+  timestamp: 0,
+  parents: [],
+  refs: [],
+});
+
+function resetStores() {
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    status: [],
+    allFiles: [],
+    branches: [],
+    tags: [],
+    stashes: [],
+    remotes: [],
+    commits: [],
+    loading: false,
+    error: null,
+    repoState: "Clean",
+    rebaseStatus: { inProgress: false, nextIndex: 0, total: 0, pauseReason: null },
+    activity: {},
+  });
+  useNavStore.setState({ intent: null });
+  usePaletteStore.setState({ open: false, query: "" });
+  localStorage.clear();
+}
+
+describe("CommandPalette", () => {
+  beforeEach(() => {
+    resetStores();
+    mockInvoke("list_all_files", () => []);
+  });
+
+  it("renders nothing when closed", () => {
+    const { container } = render(<CommandPalette />);
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("shows command results when opened", async () => {
+    usePaletteStore.setState({ open: true, query: "" });
+    render(<CommandPalette />);
+    expect(await screen.findByRole("dialog")).toBeTruthy();
+    // Default commands are always present.
+    expect(screen.getByText("Go to History")).toBeTruthy();
+  });
+
+  it("filters by query and fires switch-screen intent on Enter", async () => {
+    const user = userEvent.setup();
+    usePaletteStore.setState({ open: true, query: "" });
+    render(<CommandPalette />);
+    await screen.findByRole("dialog");
+
+    const input = screen.getByPlaceholderText(
+      /Search branches, files, commits, commands/i,
+    );
+    await user.click(input);
+    await user.keyboard("History");
+
+    await waitFor(() => expect(screen.getByText("Go to History")).toBeTruthy());
+
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    await waitFor(() => {
+      const intent = useNavStore.getState().intent;
+      expect(intent).toEqual({ kind: "switch-screen", screen: "history" });
+    });
+    // Palette closes after activating.
+    expect(usePaletteStore.getState().open).toBe(false);
+  });
+
+  it("checks out a branch on selection", async () => {
+    const user = userEvent.setup();
+    let checkedOut: string | null = null;
+    useRepoStore.setState({
+      branches: [mkBranch("main", true), mkBranch("feature/x")],
+      checkoutBranch: async (name: string) => {
+        checkedOut = name;
+      },
+    });
+    usePaletteStore.setState({ open: true, query: "" });
+    render(<CommandPalette />);
+    await screen.findByRole("dialog");
+
+    const input = screen.getByPlaceholderText(/Search branches/i);
+    await user.click(input);
+    await user.keyboard("featurex");
+
+    const row = await screen.findByText("feature/x");
+    await user.click(row);
+
+    await waitFor(() => expect(checkedOut).toBe("feature/x"));
+  });
+
+  it("fires a commit-vs-wt intent for a commit", async () => {
+    const user = userEvent.setup();
+    useRepoStore.setState({
+      commits: [mkCommit("abcdef1234", "Fix the bug")],
+    });
+    usePaletteStore.setState({ open: true, query: "" });
+    render(<CommandPalette />);
+    await screen.findByRole("dialog");
+
+    const input = screen.getByPlaceholderText(/Search branches/i);
+    await user.click(input);
+    await user.keyboard("Fix the bug");
+
+    const row = await screen.findByText("Fix the bug");
+    await user.click(row);
+
+    await waitFor(() => {
+      expect(useNavStore.getState().intent).toEqual({
+        kind: "commit-vs-wt",
+        oid: "abcdef1234",
+      });
+    });
+  });
+
+  it("closes on Escape", async () => {
+    const user = userEvent.setup();
+    usePaletteStore.setState({ open: true, query: "" });
+    render(<CommandPalette />);
+    await screen.findByRole("dialog");
+
+    const input = screen.getByPlaceholderText(/Search branches/i);
+    await user.click(input);
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => expect(usePaletteStore.getState().open).toBe(false));
+  });
+});

--- a/src/features/palette/CommandPalette.tsx
+++ b/src/features/palette/CommandPalette.tsx
@@ -7,6 +7,42 @@ import { usePaletteStore } from "./usePaletteStore";
 import { fuzzyMatch } from "./fuzzyMatch";
 import { relativeTime } from "@/lib/derive";
 
+/**
+ * Render `text` with the characters at `indices` emphasized. Indices that fall
+ * outside the string are ignored. Empty indices → plain text.
+ */
+function highlight(text: string, indices: number[]): React.ReactNode {
+  if (indices.length === 0) return text;
+  const hit = new Set(indices);
+  const out: React.ReactNode[] = [];
+  let run = "";
+  let runHit = false;
+  const flush = (key: number) => {
+    if (run === "") return;
+    if (runHit) {
+      out.push(
+        <span
+          key={key}
+          style={{ color: "var(--color-accent)", fontWeight: 600 }}
+        >
+          {run}
+        </span>,
+      );
+    } else {
+      out.push(run);
+    }
+    run = "";
+  };
+  for (let i = 0; i < text.length; i++) {
+    const isHit = hit.has(i);
+    if (isHit !== runHit) flush(i);
+    run += text[i];
+    runHit = isHit;
+  }
+  flush(text.length);
+  return out;
+}
+
 type ResultType = "command" | "branch" | "file" | "commit";
 
 interface PaletteItem {
@@ -21,6 +57,13 @@ interface PaletteItem {
   detail?: string;
   icon: string;
   run: () => void;
+}
+
+/** A matched candidate plus the highlight positions for its rendered label. */
+interface ScoredRow {
+  item: PaletteItem;
+  score: number;
+  labelIndices: number[];
 }
 
 const TYPE_LABEL: Record<ResultType, string> = {
@@ -106,6 +149,7 @@ export function CommandPalette() {
   const [activeIndex, setActiveIndex] = React.useState(0);
   const inputRef = React.useRef<HTMLInputElement | null>(null);
   const listRef = React.useRef<HTMLDivElement | null>(null);
+  const dialogRef = React.useRef<HTMLDivElement | null>(null);
 
   // Build the full candidate set (independent of query).
   const candidates = React.useMemo<PaletteItem[]>(() => {
@@ -153,7 +197,7 @@ export function CommandPalette() {
 
   // Filter + score + group + cap, then flatten for keyboard nav.
   const { flat, groups } = React.useMemo(() => {
-    const byType: Record<ResultType, { item: PaletteItem; score: number; indices: number[] }[]> = {
+    const byType: Record<ResultType, ScoredRow[]> = {
       command: [],
       branch: [],
       file: [],
@@ -162,15 +206,18 @@ export function CommandPalette() {
     for (const item of candidates) {
       const m = fuzzyMatch(query, item.search);
       if (!m.matched) continue;
-      byType[item.type].push({ item, score: m.score, indices: m.indices });
+      // `m.indices` index into `item.search`; the row renders `item.label`,
+      // so re-run the matcher against the label to get positions we can paint.
+      const labelIndices =
+        query.length === 0 ? [] : fuzzyMatch(query, item.label).indices;
+      byType[item.type].push({ item, score: m.score, labelIndices });
     }
-    const groupsOut: { type: ResultType; rows: PaletteItem[] }[] = [];
-    const flatOut: PaletteItem[] = [];
+    const groupsOut: { type: ResultType; rows: ScoredRow[] }[] = [];
+    const flatOut: ScoredRow[] = [];
     for (const type of TYPE_ORDER) {
       const sorted = byType[type]
         .sort((a, b) => b.score - a.score)
-        .slice(0, CAP[type])
-        .map((r) => r.item);
+        .slice(0, CAP[type]);
       if (sorted.length === 0) continue;
       groupsOut.push({ type, rows: sorted });
       flatOut.push(...sorted);
@@ -205,10 +252,10 @@ export function CommandPalette() {
 
   if (!open) return null;
 
-  const activate = (item: PaletteItem | undefined) => {
-    if (!item) return;
+  const activate = (row: ScoredRow | undefined) => {
+    if (!row) return;
     closePalette();
-    item.run();
+    row.item.run();
   };
 
   const onKeyDown = (e: React.KeyboardEvent) => {
@@ -232,6 +279,36 @@ export function CommandPalette() {
       activate(flat[activeIndex]);
       return;
     }
+    if (e.key === "Tab") {
+      // Focus trap: cycle through the dialog's focusable elements instead of
+      // letting Tab escape to the background behind the modal.
+      const root = dialogRef.current;
+      if (!root) return;
+      const focusable = Array.from(
+        root.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      ).filter((el) => el.offsetParent !== null || el === document.activeElement);
+      if (focusable.length === 0) {
+        e.preventDefault();
+        inputRef.current?.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const activeEl = document.activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        if (activeEl === first || !root.contains(activeEl)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (activeEl === last || !root.contains(activeEl)) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
   };
 
   const sectionHeader = (label: string, count: number) => (
@@ -249,14 +326,15 @@ export function CommandPalette() {
     </div>
   );
 
-  const renderRow = (item: PaletteItem, flatIndex: number) => {
+  const renderRow = (row: ScoredRow, flatIndex: number) => {
+    const { item, labelIndices } = row;
     const active = flatIndex === activeIndex;
     return (
       <div
         key={item.id}
         data-pal-index={flatIndex}
         data-pal-type={item.type}
-        onClick={() => activate(item)}
+        onClick={() => activate(row)}
         onMouseEnter={() => setActiveIndex(flatIndex)}
         style={{
           display: "flex",
@@ -282,7 +360,7 @@ export function CommandPalette() {
             color: "var(--fg-0)",
           }}
         >
-          {item.label}
+          {highlight(item.label, labelIndices)}
         </span>
         {item.detail && (
           <span
@@ -328,6 +406,7 @@ export function CommandPalette() {
       }}
     >
       <div
+        ref={dialogRef}
         onKeyDown={onKeyDown}
         style={{
           width: WIDTH,

--- a/src/features/palette/CommandPalette.tsx
+++ b/src/features/palette/CommandPalette.tsx
@@ -1,0 +1,382 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { PGIcon, PGSearchInput } from "@/design";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { usePaletteStore } from "./usePaletteStore";
+import { fuzzyMatch } from "./fuzzyMatch";
+import { relativeTime } from "@/lib/derive";
+
+type ResultType = "command" | "branch" | "file" | "commit";
+
+interface PaletteItem {
+  type: ResultType;
+  /** Stable key for React + nav. */
+  id: string;
+  /** String the fuzzy matcher runs against. */
+  search: string;
+  /** Primary label shown to the user. */
+  label: string;
+  /** Optional muted secondary detail. */
+  detail?: string;
+  icon: string;
+  run: () => void;
+}
+
+const TYPE_LABEL: Record<ResultType, string> = {
+  command: "Commands",
+  branch: "Branches",
+  file: "Files",
+  commit: "Commits",
+};
+
+const TYPE_ORDER: ResultType[] = ["command", "branch", "file", "commit"];
+
+// Per-type caps so a huge repo can't drown out other types.
+const CAP: Record<ResultType, number> = {
+  command: 12,
+  branch: 8,
+  file: 12,
+  commit: 8,
+};
+
+const WIDTH = 560;
+
+/**
+ * Static app-command / screen-switch entries. Screen switches go through the
+ * `switch-screen` nav intent so the palette stays decoupled from AppShell's
+ * local screen state.
+ */
+function buildCommands(): PaletteItem[] {
+  const nav = useNavStore.getState();
+  const screen = (id: string, label: string, icon: string, shortcut?: string): PaletteItem => ({
+    type: "command",
+    id: `screen:${id}`,
+    search: `${label} ${id}`,
+    label: `Go to ${label}`,
+    detail: shortcut,
+    icon,
+    run: () => nav.setIntent({ kind: "switch-screen", screen: id }),
+  });
+  const repo = useRepoStore.getState();
+  return [
+    screen("repo", "Files", "folder", "⌘1"),
+    screen("commit", "Commit", "commit", "⌘2"),
+    screen("history", "History", "history", "⌘3"),
+    screen("branches", "Branches", "branch", "⌘4"),
+    screen("conflict", "Conflicts", "conflict", "⌘5"),
+    screen("rebase", "Rebase", "rebase", "⌘6"),
+    screen("remote", "Remotes", "link", "⌘7"),
+    screen("diff", "Diff viewer", "fileCode", "⌘8"),
+    screen("reflog", "Reflog", "clock", "⌘9"),
+    screen("settings", "Settings", "settings"),
+    {
+      type: "command",
+      id: "action:fetch-all",
+      search: "Fetch all remotes",
+      label: "Fetch all remotes",
+      icon: "fetch",
+      run: () => void repo.fetchAll(),
+    },
+    {
+      type: "command",
+      id: "action:refresh",
+      search: "Refresh repository",
+      label: "Refresh repository",
+      icon: "sync",
+      run: () => void repo.refreshAll(),
+    },
+  ];
+}
+
+export function CommandPalette() {
+  const open = usePaletteStore((s) => s.open);
+  const query = usePaletteStore((s) => s.query);
+  const setQuery = usePaletteStore((s) => s.setQuery);
+  const closePalette = usePaletteStore((s) => s.closePalette);
+
+  const repoOpen = useRepoStore((s) => !!s.current);
+  const branches = useRepoStore((s) => s.branches);
+  const allFiles = useRepoStore((s) => s.allFiles);
+  const commits = useRepoStore((s) => s.commits);
+  const checkoutBranch = useRepoStore((s) => s.checkoutBranch);
+  const refreshAllFiles = useRepoStore((s) => s.refreshAllFiles);
+  const setIntent = useNavStore((s) => s.setIntent);
+
+  const [activeIndex, setActiveIndex] = React.useState(0);
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const listRef = React.useRef<HTMLDivElement | null>(null);
+
+  // Build the full candidate set (independent of query).
+  const candidates = React.useMemo<PaletteItem[]>(() => {
+    const items: PaletteItem[] = buildCommands();
+
+    for (const b of branches) {
+      items.push({
+        type: "branch",
+        id: `branch:${b.isRemote ? "r" : "l"}:${b.name}`,
+        search: b.name,
+        label: b.name,
+        detail: b.isRemote ? "remote" : (b.upstream ?? undefined),
+        icon: "branch",
+        run: () => void checkoutBranch(b.name),
+      });
+    }
+
+    for (const f of allFiles) {
+      const slash = f.path.lastIndexOf("/");
+      items.push({
+        type: "file",
+        id: `file:${f.path}`,
+        search: f.path,
+        label: slash >= 0 ? f.path.slice(slash + 1) : f.path,
+        detail: slash >= 0 ? f.path.slice(0, slash) : undefined,
+        icon: "file",
+        run: () => setIntent({ kind: "diff-file", path: f.path }),
+      });
+    }
+
+    for (const c of commits) {
+      items.push({
+        type: "commit",
+        id: `commit:${c.oid}`,
+        search: `${c.summary} ${c.shortOid} ${c.author}`,
+        label: c.summary,
+        detail: `${c.shortOid} · ${relativeTime(c.timestamp)}`,
+        icon: "commit",
+        run: () => setIntent({ kind: "commit-vs-wt", oid: c.oid }),
+      });
+    }
+
+    return items;
+  }, [branches, allFiles, commits, checkoutBranch, setIntent]);
+
+  // Filter + score + group + cap, then flatten for keyboard nav.
+  const { flat, groups } = React.useMemo(() => {
+    const byType: Record<ResultType, { item: PaletteItem; score: number; indices: number[] }[]> = {
+      command: [],
+      branch: [],
+      file: [],
+      commit: [],
+    };
+    for (const item of candidates) {
+      const m = fuzzyMatch(query, item.search);
+      if (!m.matched) continue;
+      byType[item.type].push({ item, score: m.score, indices: m.indices });
+    }
+    const groupsOut: { type: ResultType; rows: PaletteItem[] }[] = [];
+    const flatOut: PaletteItem[] = [];
+    for (const type of TYPE_ORDER) {
+      const sorted = byType[type]
+        .sort((a, b) => b.score - a.score)
+        .slice(0, CAP[type])
+        .map((r) => r.item);
+      if (sorted.length === 0) continue;
+      groupsOut.push({ type, rows: sorted });
+      flatOut.push(...sorted);
+    }
+    return { flat: flatOut, groups: groupsOut };
+  }, [candidates, query]);
+
+  // When opened: focus input, refresh the lazy file list, reset state.
+  React.useEffect(() => {
+    if (!open) return;
+    setActiveIndex(0);
+    if (repoOpen) void refreshAllFiles();
+    const t = setTimeout(() => inputRef.current?.focus(), 0);
+    return () => clearTimeout(t);
+  }, [open, repoOpen, refreshAllFiles]);
+
+  React.useEffect(() => {
+    setActiveIndex(0);
+  }, [query]);
+
+  React.useEffect(() => {
+    if (activeIndex >= flat.length) setActiveIndex(Math.max(0, flat.length - 1));
+  }, [flat.length, activeIndex]);
+
+  // Keep the active row scrolled into view.
+  React.useEffect(() => {
+    const el = listRef.current?.querySelector<HTMLElement>(
+      `[data-pal-index="${activeIndex}"]`,
+    );
+    el?.scrollIntoView?.({ block: "nearest" });
+  }, [activeIndex]);
+
+  if (!open) return null;
+
+  const activate = (item: PaletteItem | undefined) => {
+    if (!item) return;
+    closePalette();
+    item.run();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      closePalette();
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(flat.length - 1, i + 1));
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(0, i - 1));
+      return;
+    }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      activate(flat[activeIndex]);
+      return;
+    }
+  };
+
+  const sectionHeader = (label: string, count: number) => (
+    <div
+      style={{
+        padding: "8px 12px 2px",
+        fontFamily: "var(--font-mono)",
+        fontSize: "var(--fs-10)",
+        color: "var(--fg-2)",
+        textTransform: "uppercase",
+        letterSpacing: "0.05em",
+      }}
+    >
+      {label} <span style={{ color: "var(--fg-3)" }}>({count})</span>
+    </div>
+  );
+
+  const renderRow = (item: PaletteItem, flatIndex: number) => {
+    const active = flatIndex === activeIndex;
+    return (
+      <div
+        key={item.id}
+        data-pal-index={flatIndex}
+        data-pal-type={item.type}
+        onClick={() => activate(item)}
+        onMouseEnter={() => setActiveIndex(flatIndex)}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          height: 30,
+          padding: "0 12px",
+          background: active ? "var(--bg-selection)" : "transparent",
+          cursor: "pointer",
+          fontFamily: "var(--font-mono)",
+          fontSize: "var(--fs-12)",
+        }}
+      >
+        <PGIcon name={item.icon} size={13} style={{ color: "var(--fg-2)" }} />
+        <span
+          title={item.label}
+          style={{
+            flexShrink: 0,
+            maxWidth: 360,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            color: "var(--fg-0)",
+          }}
+        >
+          {item.label}
+        </span>
+        {item.detail && (
+          <span
+            title={item.detail}
+            style={{
+              flex: 1,
+              minWidth: 0,
+              textAlign: "right",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              color: "var(--fg-3)",
+              fontSize: "var(--fs-10)",
+            }}
+          >
+            {item.detail}
+          </span>
+        )}
+      </div>
+    );
+  };
+
+  let runningIndex = 0;
+
+  const content = (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command palette"
+      onMouseDown={(e) => {
+        // Backdrop click (outside the panel) closes.
+        if (e.target === e.currentTarget) closePalette();
+      }}
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 200,
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "flex-start",
+        paddingTop: "12vh",
+        background: "rgba(0,0,0,0.45)",
+      }}
+    >
+      <div
+        onKeyDown={onKeyDown}
+        style={{
+          width: WIDTH,
+          maxWidth: "90vw",
+          maxHeight: "60vh",
+          background: "var(--bg-1)",
+          border: "1px solid var(--border-1)",
+          borderRadius: "var(--r-3)",
+          boxShadow: "0 12px 40px rgba(0,0,0,0.45)",
+          display: "flex",
+          flexDirection: "column",
+          overflow: "hidden",
+        }}
+      >
+        <div style={{ padding: 8, borderBottom: "1px solid var(--border-0)" }}>
+          <PGSearchInput
+            value={query}
+            onChange={setQuery}
+            placeholder="Search branches, files, commits, commands…"
+            inputRef={inputRef}
+          />
+        </div>
+        <div ref={listRef} style={{ flex: 1, overflow: "auto", paddingBottom: 4 }}>
+          {flat.length === 0 ? (
+            <div
+              style={{
+                padding: 16,
+                fontSize: "var(--fs-12)",
+                color: "var(--fg-3)",
+                fontFamily: "var(--font-mono)",
+              }}
+            >
+              {query ? `No matches for "${query}".` : "Type to search."}
+            </div>
+          ) : (
+            groups.map((g) => {
+              const rows = (
+                <React.Fragment key={g.type}>
+                  {sectionHeader(TYPE_LABEL[g.type], g.rows.length)}
+                  {g.rows.map((item) => renderRow(item, runningIndex++))}
+                </React.Fragment>
+              );
+              return rows;
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  return ReactDOM.createPortal(content, document.body);
+}

--- a/src/features/palette/fuzzyMatch.test.ts
+++ b/src/features/palette/fuzzyMatch.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { fuzzyMatch } from "./fuzzyMatch";
+
+describe("fuzzyMatch", () => {
+  it("matches an exact substring", () => {
+    const r = fuzzyMatch("feat", "feature/palette");
+    expect(r.matched).toBe(true);
+    expect(r.indices).toEqual([0, 1, 2, 3]);
+  });
+
+  it("matches a non-contiguous subsequence in order", () => {
+    const r = fuzzyMatch("ftp", "feature/palette");
+    expect(r.matched).toBe(true);
+    // f(0) ... t(3) ... p(8)
+    expect(r.indices[0]).toBe(0);
+    expect(r.indices.length).toBe(3);
+  });
+
+  it("is case-insensitive", () => {
+    expect(fuzzyMatch("MAIN", "origin/main").matched).toBe(true);
+    expect(fuzzyMatch("main", "ORIGIN/MAIN").matched).toBe(true);
+  });
+
+  it("fails when chars are out of order", () => {
+    expect(fuzzyMatch("tf", "feat").matched).toBe(false);
+  });
+
+  it("fails when a char is missing", () => {
+    expect(fuzzyMatch("xyz", "feature").matched).toBe(false);
+  });
+
+  it("treats empty query as a zero-score match", () => {
+    const r = fuzzyMatch("", "anything");
+    expect(r.matched).toBe(true);
+    expect(r.score).toBe(0);
+    expect(r.indices).toEqual([]);
+  });
+
+  it("scores a consecutive run higher than scattered matches", () => {
+    const consecutive = fuzzyMatch("abc", "abcxyz").score;
+    const scattered = fuzzyMatch("abc", "axbxc").score;
+    expect(consecutive).toBeGreaterThan(scattered);
+  });
+
+  it("scores a word-boundary match higher than a mid-word match", () => {
+    // 'p' at the start of a path segment vs 'p' inside a word
+    const boundary = fuzzyMatch("p", "src/palette").score;
+    const midword = fuzzyMatch("p", "wrapper").score;
+    expect(boundary).toBeGreaterThan(midword);
+  });
+
+  it("scores an earlier match higher than a later one", () => {
+    const early = fuzzyMatch("x", "xaaaa").score;
+    const late = fuzzyMatch("x", "aaaax").score;
+    expect(early).toBeGreaterThan(late);
+  });
+
+  it("returns zero score and no indices on a miss", () => {
+    const r = fuzzyMatch("zzz", "abc");
+    expect(r.matched).toBe(false);
+    expect(r.score).toBe(0);
+    expect(r.indices).toEqual([]);
+  });
+
+  it("recognizes camelCase boundaries", () => {
+    const r = fuzzyMatch("cp", "CommandPalette");
+    expect(r.matched).toBe(true);
+    // C(0), P(7)
+    expect(r.indices).toEqual([0, 7]);
+  });
+});

--- a/src/features/palette/fuzzyMatch.ts
+++ b/src/features/palette/fuzzyMatch.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure fuzzy subsequence matcher used by the command palette.
+ *
+ * A query matches a target when every query character appears in the target
+ * in order (a subsequence). Matching is case-insensitive and greedy: each
+ * query char takes the earliest available target position. Score rewards
+ * consecutive runs, matches at word boundaries (path/word separators and
+ * camelCase humps), and earlier matches — so the best-feeling hits sort first.
+ *
+ * No dependency on any store or DOM — kept pure and unit-tested.
+ */
+
+export interface FuzzyResult {
+  matched: boolean;
+  /** Higher is better. 0 when the query is empty or there's no match. */
+  score: number;
+  /** Matched character positions in `target`, for highlighting. */
+  indices: number[];
+}
+
+const SEPARATORS = new Set(["/", "\\", "-", "_", ".", " ", ":"]);
+
+function isBoundary(target: string, i: number): boolean {
+  if (i === 0) return true;
+  const prev = target[i - 1];
+  if (SEPARATORS.has(prev)) return true;
+  // camelCase hump: lower/digit followed by upper.
+  const cur = target[i];
+  const prevLower = prev === prev.toLowerCase() && prev !== prev.toUpperCase();
+  const curUpper = cur === cur.toUpperCase() && cur !== cur.toLowerCase();
+  if (prevLower && curUpper) return true;
+  return false;
+}
+
+export function fuzzyMatch(query: string, target: string): FuzzyResult {
+  if (query.length === 0) {
+    return { matched: true, score: 0, indices: [] };
+  }
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+
+  const indices: number[] = [];
+  let score = 0;
+  let ti = 0;
+  let prevMatchIndex = -2; // so a match at index 0 is not "consecutive"
+
+  for (let qi = 0; qi < q.length; qi++) {
+    const ch = q[qi];
+    const found = t.indexOf(ch, ti);
+    if (found === -1) {
+      return { matched: false, score: 0, indices: [] };
+    }
+
+    // Base point for matching a character.
+    let charScore = 1;
+    // Consecutive with the previous matched char.
+    if (found === prevMatchIndex + 1) charScore += 8;
+    // Word boundary in the original (case-preserved) target.
+    if (isBoundary(target, found)) charScore += 6;
+    // Earlier-position bonus: rewards hits near the front of the string.
+    charScore += Math.max(0, 4 - found * 0.25);
+
+    score += charScore;
+    indices.push(found);
+    prevMatchIndex = found;
+    ti = found + 1;
+  }
+
+  // Shorter targets (relative to query) are tighter matches.
+  score += Math.max(0, 6 - (target.length - query.length) * 0.1);
+
+  return { matched: true, score, indices };
+}

--- a/src/features/palette/usePaletteStore.ts
+++ b/src/features/palette/usePaletteStore.ts
@@ -1,0 +1,22 @@
+import { create } from "zustand";
+
+/**
+ * UI state for the command palette (⌘P). Holds only open/query state —
+ * result data is read live from the other feature stores by the component,
+ * so nothing here needs to know about branches/files/commits.
+ */
+interface PaletteState {
+  open: boolean;
+  query: string;
+  openPalette: () => void;
+  closePalette: () => void;
+  setQuery: (q: string) => void;
+}
+
+export const usePaletteStore = create<PaletteState>((set) => ({
+  open: false,
+  query: "",
+  openPalette: () => set({ open: true, query: "" }),
+  closePalette: () => set({ open: false }),
+  setQuery: (query) => set({ query }),
+}));


### PR DESCRIPTION
## What

Command palette / fuzzy finder (⌘P / Ctrl+P) — P0 from `features.md`.

Global modal fuzzy-finder over mixed result types:
- **Commands** — activity-bar screen switches + Fetch all / Refresh
- **Branches** — select to checkout
- **Files** — select to diff (`diff-file` nav intent)
- **Commits** — select to show commit-vs-working-tree diff

Esc / backdrop close, Arrow keys + Enter navigate, mouse hover/click. Shortcut ignored when focus in input/textarea/contentEditable (mirrors ⌘1…⌘9).

## How

- Pure subsequence scorer `src/features/palette/fuzzyMatch.ts` (TDD, case-insensitive, ranks consecutive runs / word boundaries / camelCase / earlier matches).
- `usePaletteStore` (Zustand) for open/query state.
- New `{ kind: "switch-screen" }` NavIntent routed in `AppShell`.
- Design-system only (`@/design`), portal to body, styling matches `BranchPicker`. No backend changes.

## Tests

- `pnpm tsc --noEmit` ✅
- `pnpm test` ✅ (11 fuzzyMatch + 6 CommandPalette)
- `pnpm vite build` ✅

## Follow-ups

Match-highlight span rendering, open-in-editor as secondary file action, MRU ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
