### PR TITLE
feat(commit): recent message dropdown + sign-off toggle

### DIFF
--- a/docs/superpowers/plans/2026-06-29-commit-recents-signoff.md
+++ b/docs/superpowers/plans/2026-06-29-commit-recents-signoff.md
@@ -1,0 +1,42 @@
+# Recent commit message dropdown + sign-off toggle — plan
+
+**Spec:** `docs/superpowers/specs/2026-06-29-commit-recents-signoff-design.md`
+**Date:** 2026-06-29
+
+## Steps
+
+### 1. Sign-off helper (TDD, pure)
+- Add `signature::apply_signoff(message, name, email) -> String` with unit tests
+  covering: subject-only, body present, dedupe, existing-trailer-block join,
+  empty message, trailing newlines.
+
+### 2. Backend commit path
+- Add `signoff: bool` (`#[serde(default)]`) to `CommitOptions` (`git/types.rs`).
+- In `Libgit2Backend::commit`, when `signoff`, resolve committer signature from
+  repo config and run `apply_signoff` over the message (both amend + normal
+  paths). Author override does not affect the trailer identity.
+- `CliBackend::commit` stub already takes `CommitOptions` → unchanged
+  (still `NotImplemented`).
+- Update the `commit` Tauri command to accept `signoff: Option<bool>` and
+  populate `CommitOptions`.
+- Update all `CommitOptions { … }` literals in tests/support with `signoff`.
+
+### 3. Backend integration tests
+- In `tests/stage_commit.rs`: signoff appends trailer from repo identity;
+  no duplicate when already present; message untouched when off.
+
+### 4. Frontend wiring
+- `lib/tauri.ts` `commit(...)` gains `signoff = false`, passes to invoke.
+- `useRepoStore.commit(message, amend?, signoff?)` threads it through.
+- `recentCommitMessages` pure helper + colocated vitest test.
+- `CommitPanel`: "Recent" button (uses `useContextMenu`) fills subject/body;
+  sign-off checkbox seeds from / writes back `addSignoff`; drop client-side
+  trailer construction in `buildMessage`; pass `signoff` to the commit action.
+
+### 5. Verify
+- `pnpm tsc --noEmit`, `pnpm test`, `pnpm vite build`,
+  `cargo check`, `cargo test`.
+
+## Done when
+All five verification commands pass; sign-off produces a single correct trailer
+sourced from repo identity; recent-message dropdown populates the composer.

--- a/docs/superpowers/specs/2026-06-29-commit-recents-signoff-design.md
+++ b/docs/superpowers/specs/2026-06-29-commit-recents-signoff-design.md
@@ -1,0 +1,78 @@
+# Recent commit message dropdown + sign-off toggle — design
+
+**Status:** approved
+**Date:** 2026-06-29
+**Owner:** jonas
+**Related:** `docs/superpowers/specs/2026-04-22-platypusgit-write-path-phase1.md`
+
+## Why
+
+Two small but high-frequency frictions in the commit panel:
+
+1. **Re-typing recurring messages.** Devs often repeat near-identical subjects
+   ("wip", "fix lint", "address review") or want to riff off a prior commit's
+   wording. The log is right there — surfacing recent messages as a one-click
+   template removes retyping.
+2. **Sign-off (`-s`).** DCO-gated projects require a `Signed-off-by:` trailer on
+   every commit. Today the panel built this client-side from the *last commit's*
+   author, which is wrong (sign-off should be the committer's own identity) and
+   wasn't deduped. We want true `git commit -s` semantics, wired through the
+   backend, with the preference remembered.
+
+Both serve the "extreme usability" north star: less typing, fewer footguns.
+
+## Scope
+
+### In scope
+
+- A "Recent" control in the commit-message composer that lists recent commit
+  messages (newest-first, deduped). Selecting one fills subject + body.
+- A "Sign-off" toggle that appends `Signed-off-by: Name <email>` using the
+  repo's configured identity, matching `git commit -s` (no duplicate trailer).
+- Persist the sign-off preference (reuse existing `addSignoff` setting).
+- Wire sign-off through `CommitOptions` → libgit2 commit path (server-side
+  trailer construction, not client string-munging).
+
+### Out of scope
+
+- A dedicated backend op for recent messages — reuse the already-loaded log.
+- Author-only filtering / multi-author template grouping.
+- Commit-message templates from `.gitmessage` / commit.template config.
+- Trailer editing UI (Co-authored-by, etc.).
+
+## Design
+
+### Recent messages (frontend-only)
+
+`useRepoStore.commits` already holds the loaded log. A pure helper
+`recentCommitMessages(commits, limit)` derives the dropdown list:
+
+- newest-first (log order), deduped by full message text,
+- skips merge commits (`parents.length > 1`) and empty subjects,
+- strips any existing `Signed-off-by:` trailer from the body so re-selecting a
+  template doesn't carry a stale sign-off (the toggle re-adds on commit).
+
+Surfaced via the existing `useContextMenu` primitive, opened from a "Recent"
+button in the composer header. No backend change.
+
+### Sign-off (`-s`) through the backend
+
+- `CommitOptions` gains `signoff: bool` (`#[serde(default)]`).
+- `Libgit2Backend::commit` resolves the committer signature from repo config and
+  calls a pure helper `signature::apply_signoff(message, name, email)` which
+  appends the trailer with `git commit -s` semantics: idempotent (no duplicate),
+  blank-line separated from the body, joins an existing trailer block directly.
+- The trailer always uses the committer identity even when `author_override` is
+  set — mirrors git.
+- The `commit` command takes an optional `signoff` arg; TS wrapper + store thread
+  it through. The composer's toggle seeds from / writes back to the persisted
+  `addSignoff` setting.
+
+## Testing
+
+- Rust unit tests on `apply_signoff` (subject-only, with body, dedupe, trailer
+  block join, empty, trailing newlines).
+- Rust integration tests against `TempRepo`: signoff appends from repo identity,
+  no duplicate when already present, untouched when off.
+- Frontend pure-logic test on `recentCommitMessages` (order, subject/body split,
+  dedupe, trailer strip, merge skip, empty skip, limit).

--- a/src-tauri/src/commands/commits.rs
+++ b/src-tauri/src/commands/commits.rs
@@ -39,6 +39,7 @@ pub async fn commit(
     repo_id: String,
     message: String,
     amend: bool,
+    signoff: Option<bool>,
 ) -> AppResult<String> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
@@ -46,6 +47,7 @@ pub async fn commit(
         message,
         amend,
         author_override: None,
+        signoff: signoff.unwrap_or(false),
     };
     tokio::task::spawn_blocking(move || backend.commit(&repo_id, opts))
         .await

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -1191,12 +1191,23 @@ impl GitBackend for Libgit2Backend {
     }
 
     fn commit(&self, repo_id: &RepoId, opts: CommitOptions) -> AppResult<String> {
-        use crate::git::signature::default_signature;
+        use crate::git::signature::{apply_signoff, default_signature};
 
         self.with_repo(repo_id, |repo| {
-            let sig = match opts.author_override {
+            let sig = match &opts.author_override {
                 Some(o) => git2::Signature::now(&o.name, &o.email)?,
                 None => default_signature(repo)?,
+            };
+
+            // Sign-off trailer uses the committer identity (repo config), which
+            // mirrors `git commit -s` even when the author is overridden.
+            let message = if opts.signoff {
+                let committer = default_signature(repo)?;
+                let name = committer.name().unwrap_or("");
+                let email = committer.email().unwrap_or("");
+                apply_signoff(&opts.message, name, email)
+            } else {
+                opts.message.clone()
             };
 
             let mut index = repo.index()?;
@@ -1217,7 +1228,7 @@ impl GitBackend for Libgit2Backend {
                     Some(&sig),
                     Some(&sig),
                     None,
-                    Some(&opts.message),
+                    Some(&message),
                     Some(&tree),
                 )?;
                 return Ok(new_oid.to_string());
@@ -1233,7 +1244,7 @@ impl GitBackend for Libgit2Backend {
                 Some("HEAD"),
                 &sig,
                 &sig,
-                &opts.message,
+                &message,
                 &tree,
                 &parent_refs,
             )?;

--- a/src-tauri/src/git/signature.rs
+++ b/src-tauri/src/git/signature.rs
@@ -41,24 +41,37 @@ pub fn apply_signoff(message: &str, name: &str, email: &str) -> String {
     }
 
     // If there's a body (blank-line-separated block) and the last block already
-    // looks like a trailer block (every line is `Key: value`), join it directly
-    // without an extra blank line. A bare subject like `fix: thing` is never
-    // treated as a trailer block — it always gets the blank-line separator.
+    // looks like a trailer block (every line is a `key: value` trailer), join it
+    // directly without an extra blank line. A bare subject like `fix: thing` is
+    // never treated as a trailer block — it always gets the blank-line separator.
     let last_block_is_trailers = trimmed.contains("\n\n")
         && trimmed
             .rsplit("\n\n")
             .next()
-            .map(|block| {
-                block
-                    .lines()
-                    .all(|l| l.split_once(": ").map(|(k, _)| !k.is_empty()).unwrap_or(false))
-            })
+            .map(|block| block.lines().all(is_trailer_line))
             .unwrap_or(false);
 
     if last_block_is_trailers {
         format!("{}\n{}", trimmed, trailer)
     } else {
         format!("{}\n\n{}", trimmed, trailer)
+    }
+}
+
+/// Whether `line` is a git trailer of the form `key: value` or `key:value`.
+///
+/// Matches `git interpret-trailers`' token rule: the key is one or more
+/// characters from `[A-Za-z0-9-]` (letters, digits, hyphen — no spaces),
+/// immediately followed by a `:`. This deliberately rejects prose lines that
+/// merely contain `": "` (e.g. `See also: the README`, where the key would be
+/// `See also` and contains a space) and accepts space-less keys regardless of
+/// whether a space follows the colon (e.g. `Fixes:#123`).
+fn is_trailer_line(line: &str) -> bool {
+    match line.split_once(':') {
+        Some((key, _)) => {
+            !key.is_empty() && key.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+        }
+        None => false,
     }
 }
 
@@ -96,6 +109,39 @@ mod tests {
         let msg = "feat: thing\n\nCo-authored-by: Someone <s@example.com>";
         let out = apply_signoff(msg, NAME, EMAIL);
         assert_eq!(out, format!("{}\n{}", msg, TRAILER));
+    }
+
+    #[test]
+    fn prose_last_line_with_colon_space_gets_blank_separator() {
+        // `See also: README` is prose (key would contain a space) — must NOT be
+        // treated as a trailer block, so the sign-off needs a blank-line break.
+        let msg = "feat: thing\n\nSome body.\nSee also: the README";
+        let out = apply_signoff(msg, NAME, EMAIL);
+        assert_eq!(out, format!("{}\n\n{}", msg, TRAILER));
+    }
+
+    #[test]
+    fn fixes_without_space_treated_as_trailer() {
+        // `Fixes:#123` is a valid trailer (no space after colon) — join directly,
+        // no extra blank line.
+        let msg = "feat: thing\n\nFixes:#123";
+        let out = apply_signoff(msg, NAME, EMAIL);
+        assert_eq!(out, format!("{}\n{}", msg, TRAILER));
+    }
+
+    #[test]
+    fn hyphenated_key_treated_as_trailer() {
+        let msg = "feat: thing\n\nCo-authored-by: Someone <s@example.com>\nReviewed-by: Other <o@example.com>";
+        let out = apply_signoff(msg, NAME, EMAIL);
+        assert_eq!(out, format!("{}\n{}", msg, TRAILER));
+    }
+
+    #[test]
+    fn mixed_block_with_prose_line_gets_blank_separator() {
+        // Last block has a real trailer plus a prose line → not all trailers.
+        let msg = "feat: thing\n\nReviewed-by: Other <o@example.com>\nSee also: the README";
+        let out = apply_signoff(msg, NAME, EMAIL);
+        assert_eq!(out, format!("{}\n\n{}", msg, TRAILER));
     }
 
     #[test]

--- a/src-tauri/src/git/signature.rs
+++ b/src-tauri/src/git/signature.rs
@@ -18,3 +18,94 @@ pub fn default_signature<'a>(repo: &'a Repository) -> AppResult<Signature<'a>> {
         }
     }
 }
+
+/// Append a `Signed-off-by: Name <email>` trailer to a commit message,
+/// matching `git commit -s` semantics.
+///
+/// - Idempotent: if the exact trailer is already the last line of an existing
+///   trailer block, the message is returned unchanged (no duplicate).
+/// - The trailer is separated from the body by a blank line when the message
+///   doesn't already end with a trailer block.
+pub fn apply_signoff(message: &str, name: &str, email: &str) -> String {
+    let trailer = format!("Signed-off-by: {} <{}>", name, email);
+
+    // Already present anywhere as its own line → no-op (git dedupes identical
+    // sign-offs regardless of position).
+    if message.lines().any(|line| line.trim_end() == trailer) {
+        return message.to_string();
+    }
+
+    let trimmed = message.trim_end_matches('\n');
+    if trimmed.is_empty() {
+        return trailer;
+    }
+
+    // If there's a body (blank-line-separated block) and the last block already
+    // looks like a trailer block (every line is `Key: value`), join it directly
+    // without an extra blank line. A bare subject like `fix: thing` is never
+    // treated as a trailer block — it always gets the blank-line separator.
+    let last_block_is_trailers = trimmed.contains("\n\n")
+        && trimmed
+            .rsplit("\n\n")
+            .next()
+            .map(|block| {
+                block
+                    .lines()
+                    .all(|l| l.split_once(": ").map(|(k, _)| !k.is_empty()).unwrap_or(false))
+            })
+            .unwrap_or(false);
+
+    if last_block_is_trailers {
+        format!("{}\n{}", trimmed, trailer)
+    } else {
+        format!("{}\n\n{}", trimmed, trailer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::apply_signoff;
+
+    const NAME: &str = "Ada Lovelace";
+    const EMAIL: &str = "ada@example.com";
+    const TRAILER: &str = "Signed-off-by: Ada Lovelace <ada@example.com>";
+
+    #[test]
+    fn appends_to_subject_only_message() {
+        let out = apply_signoff("fix: thing", NAME, EMAIL);
+        assert_eq!(out, format!("fix: thing\n\n{}", TRAILER));
+    }
+
+    #[test]
+    fn appends_after_body_with_blank_line() {
+        let msg = "feat: thing\n\nLonger explanation of the change.";
+        let out = apply_signoff(msg, NAME, EMAIL);
+        assert_eq!(out, format!("{}\n\n{}", msg, TRAILER));
+    }
+
+    #[test]
+    fn does_not_duplicate_existing_trailer() {
+        let msg = format!("fix: thing\n\n{}", TRAILER);
+        let out = apply_signoff(&msg, NAME, EMAIL);
+        assert_eq!(out, msg);
+    }
+
+    #[test]
+    fn joins_existing_trailer_block_without_extra_blank() {
+        // Different trailer already present → new sign-off joins the block.
+        let msg = "feat: thing\n\nCo-authored-by: Someone <s@example.com>";
+        let out = apply_signoff(msg, NAME, EMAIL);
+        assert_eq!(out, format!("{}\n{}", msg, TRAILER));
+    }
+
+    #[test]
+    fn handles_empty_message() {
+        assert_eq!(apply_signoff("", NAME, EMAIL), TRAILER);
+    }
+
+    #[test]
+    fn ignores_trailing_newlines() {
+        let out = apply_signoff("fix: thing\n\n", NAME, EMAIL);
+        assert_eq!(out, format!("fix: thing\n\n{}", TRAILER));
+    }
+}

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -150,6 +150,10 @@ pub struct CommitOptions {
     pub message: String,
     pub amend: bool,
     pub author_override: Option<AuthorOverride>,
+    /// When true, append a `Signed-off-by:` trailer using the committer
+    /// signature, matching `git commit -s` (deduped if already present).
+    #[serde(default)]
+    pub signoff: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/tests/branches_tags.rs
+++ b/src-tauri/tests/branches_tags.rs
@@ -142,6 +142,7 @@ fn delete_unmerged_branch_is_refused_without_force() {
                 message: "feature work".into(),
                 amend: false,
                 author_override: None,
+                signoff: false,
             },
         )
         .unwrap();

--- a/src-tauri/tests/cherry_pick_revert.rs
+++ b/src-tauri/tests/cherry_pick_revert.rs
@@ -22,6 +22,7 @@ fn cherry_pick_applies_commit_onto_head() {
                 message: "add notes".into(),
                 amend: false,
                 author_override: None,
+                signoff: false,
             },
         )
         .unwrap();
@@ -49,6 +50,7 @@ fn revert_undoes_commit() {
                 message: "bad change".into(),
                 amend: false,
                 author_override: None,
+                signoff: false,
             },
         )
         .unwrap();

--- a/src-tauri/tests/discard_reset.rs
+++ b/src-tauri/tests/discard_reset.rs
@@ -38,6 +38,7 @@ fn reset_hard_moves_head_and_cleans_worktree() {
                     message: "second".into(),
                     amend: false,
                     author_override: None,
+                    signoff: false,
                 },
             )
             .unwrap();
@@ -68,6 +69,7 @@ fn reset_soft_keeps_worktree() {
                 message: "second".into(),
                 amend: false,
                 author_override: None,
+                signoff: false,
             },
         )
         .unwrap();

--- a/src-tauri/tests/reflog.rs
+++ b/src-tauri/tests/reflog.rs
@@ -87,6 +87,7 @@ fn read_reflog_classifies_amend_op() {
                 message: "second amended".into(),
                 amend: true,
                 author_override: None,
+                signoff: false,
             },
         )
         .unwrap();

--- a/src-tauri/tests/stage_commit.rs
+++ b/src-tauri/tests/stage_commit.rs
@@ -96,6 +96,7 @@ fn commit_from_staged_changes_advances_head() {
                 message: "update readme".into(),
                 amend: false,
                 author_override: None,
+                signoff: false,
             },
         )
         .expect("commit");
@@ -122,6 +123,7 @@ fn amend_replaces_tip() {
                 message: "oops".into(),
                 amend: false,
                 author_override: None,
+                signoff: false,
             },
         )
         .unwrap();
@@ -138,6 +140,7 @@ fn amend_replaces_tip() {
                 message: "update readme".into(),
                 amend: true,
                 author_override: None,
+                signoff: false,
             },
         )
         .unwrap();
@@ -145,6 +148,88 @@ fn amend_replaces_tip() {
     let log = backend.log(&handle.id, 10).unwrap();
     assert_eq!(log.len(), 2, "amend must not add a new commit");
     assert_eq!(log[0].summary, "update readme");
+}
+
+#[test]
+fn commit_with_signoff_appends_trailer_from_repo_identity() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "README.md", "hello world\n");
+    let (backend, handle) = tr.open_with_backend();
+    backend
+        .stage(&handle.id, &[PathBuf::from("README.md")])
+        .unwrap();
+
+    backend
+        .commit(
+            &handle.id,
+            CommitOptions {
+                message: "update readme".into(),
+                amend: false,
+                author_override: None,
+                signoff: true,
+            },
+        )
+        .expect("commit");
+
+    // TempRepo configures user.name "Test User" / user.email "test@example.com".
+    let tip = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    let msg = tip.message().unwrap();
+    assert_eq!(
+        msg,
+        "update readme\n\nSigned-off-by: Test User <test@example.com>"
+    );
+}
+
+#[test]
+fn commit_signoff_does_not_duplicate_existing_trailer() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "README.md", "hello world\n");
+    let (backend, handle) = tr.open_with_backend();
+    backend
+        .stage(&handle.id, &[PathBuf::from("README.md")])
+        .unwrap();
+
+    backend
+        .commit(
+            &handle.id,
+            CommitOptions {
+                message: "update readme\n\nSigned-off-by: Test User <test@example.com>"
+                    .into(),
+                amend: false,
+                author_override: None,
+                signoff: true,
+            },
+        )
+        .expect("commit");
+
+    let tip = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    let msg = tip.message().unwrap();
+    assert_eq!(msg.matches("Signed-off-by:").count(), 1);
+}
+
+#[test]
+fn commit_without_signoff_leaves_message_untouched() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "README.md", "hello world\n");
+    let (backend, handle) = tr.open_with_backend();
+    backend
+        .stage(&handle.id, &[PathBuf::from("README.md")])
+        .unwrap();
+
+    backend
+        .commit(
+            &handle.id,
+            CommitOptions {
+                message: "update readme".into(),
+                amend: false,
+                author_override: None,
+                signoff: false,
+            },
+        )
+        .expect("commit");
+
+    let tip = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(tip.message().unwrap(), "update readme");
 }
 
 #[test]
@@ -163,6 +248,7 @@ fn commit_on_unborn_branch_creates_root() {
                 message: "initial".into(),
                 amend: false,
                 author_override: None,
+                signoff: false,
             },
         )
         .unwrap();

--- a/src-tauri/tests/support/mod.rs
+++ b/src-tauri/tests/support/mod.rs
@@ -124,6 +124,7 @@ pub fn with_conflicting_merge() -> TempRepo {
                     message: "feature change".into(),
                     amend: false,
                     author_override: None,
+                    signoff: false,
                 },
             )
             .unwrap();
@@ -139,6 +140,7 @@ pub fn with_conflicting_merge() -> TempRepo {
                     message: "main change".into(),
                     amend: false,
                     author_override: None,
+                    signoff: false,
                 },
             )
             .unwrap();

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -120,7 +120,11 @@ interface RepoStoreState {
   stageHunk: (path: string, hunkIndex: number) => Promise<void>;
   unstageHunk: (path: string, hunkIndex: number) => Promise<void>;
   discardHunk: (path: string, hunkIndex: number) => Promise<void>;
-  commit: (message: string, amend?: boolean) => Promise<string | null>;
+  commit: (
+    message: string,
+    amend?: boolean,
+    signoff?: boolean,
+  ) => Promise<string | null>;
   reset: (target: string, mode: ResetMode) => Promise<void>;
   checkoutBranch: (name: string) => Promise<void>;
   checkoutRef: (reference: string) => Promise<void>;
@@ -370,11 +374,11 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     }
   },
 
-  async commit(message, amend = false) {
+  async commit(message, amend = false, signoff = false) {
     const repo = get().current;
     if (!repo) return null;
     try {
-      const oid = await commitFn(repo.id, message, amend);
+      const oid = await commitFn(repo.id, message, amend, signoff);
       await get().refreshAll();
       return oid;
     } catch (e) {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -134,8 +134,9 @@ export async function commit(
   repoId: string,
   message: string,
   amend = false,
+  signoff = false,
 ): Promise<string> {
-  return invoke<string>("commit", { repoId, message, amend });
+  return invoke<string>("commit", { repoId, message, amend, signoff });
 }
 
 export async function discardPaths(repoId: string, paths: string[]): Promise<void> {

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -24,9 +24,10 @@ import {
 } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { currentBranch, isStaged, isUnstaged, statusMark } from "@/lib/derive";
 import { getDiff } from "@/lib/tauri";
-import type { DiffKind, FileDiff, FileStatus } from "@/lib/types";
+import type { CommitInfo, DiffKind, FileDiff, FileStatus } from "@/lib/types";
 
 interface FileSlot {
   path: string;
@@ -45,11 +46,15 @@ export function CommitPanelScreen() {
   const commitAction = useRepoStore((s) => s.commit);
   const pushAction = useRepoStore((s) => s.push);
   const activity = useRepoStore((s) => s.activity);
+  const commits = useRepoStore((s) => s.commits);
   const setNavIntent = useNavStore((s) => s.setIntent);
+  const addSignoff = useSettingsStore((s) => s.addSignoff);
+  const setSetting = useSettingsStore((s) => s.set);
   const [message, setMessage] = React.useState("");
   const [body, setBody] = React.useState("");
   const [amend, setAmend] = React.useState(false);
-  const [signoff, setSignoff] = React.useState(false);
+  // Sign-off toggle seeds from the persisted preference; toggling it writes back.
+  const [signoff, setSignoff] = React.useState(addSignoff);
   const [diffMode, setDiffMode] = React.useState<"unified" | "split">("unified");
   const [selectedKey, setSelectedKey] = React.useState<string | null>(null);
   const changesPane = usePaneWidth(320, {
@@ -123,6 +128,30 @@ export function CommitPanelScreen() {
         },
       },
     ],
+  );
+
+  // Recent commit messages, newest-first, deduped by full message. Sourced from
+  // the already-loaded log so no extra backend round-trip is needed.
+  const recentMessages = React.useMemo(() => recentCommitMessages(commits), [
+    commits,
+  ]);
+
+  const applyRecent = React.useCallback((r: RecentMessage) => {
+    setMessage(r.subject);
+    setBody(r.body);
+  }, []);
+
+  const recentsMenu = useContextMenu<void>(() =>
+    recentMessages.length === 0
+      ? [{ __menuTitle: "No recent messages" }]
+      : [
+          { __menuTitle: "Recent messages" },
+          ...recentMessages.map((r) => ({
+            icon: "commit" as const,
+            label: r.subject,
+            onClick: () => applyRecent(r),
+          })),
+        ],
   );
 
   const staged = React.useMemo(
@@ -434,7 +463,27 @@ export function CommitPanelScreen() {
           minWidth: 0,
         }}
       >
-        <Header title="COMMIT MESSAGE" />
+        <Header
+          title="COMMIT MESSAGE"
+          action={
+            <PGButton
+              size="xs"
+              variant="ghost"
+              icon="history"
+              disabled={recentMessages.length === 0}
+              title="Insert a recent commit message"
+              onClick={(e) => {
+                const r = (
+                  e.currentTarget as HTMLElement
+                ).getBoundingClientRect();
+                recentsMenu.openAt(r.left, r.bottom + 4, undefined);
+              }}
+            >
+              Recent
+            </PGButton>
+          }
+        />
+        {recentsMenu.menu}
         <div
           style={{
             padding: 12,
@@ -512,7 +561,10 @@ export function CommitPanelScreen() {
             />
             <PGCheckbox
               checked={signoff}
-              onChange={setSignoff}
+              onChange={(v) => {
+                setSignoff(v);
+                setSetting("addSignoff", v);
+              }}
               label="Add Signed-off-by trailer"
             />
           </div>
@@ -551,8 +603,8 @@ export function CommitPanelScreen() {
               fullWidth
               disabled={(!amend && staged.length === 0) || !message.trim()}
               onClick={async () => {
-                const full = buildMessage(message, body, signoff);
-                const oid = await commitAction(full, amend);
+                const full = buildMessage(message, body);
+                const oid = await commitAction(full, amend, signoff);
                 if (oid) {
                   setMessage("");
                   setBody("");
@@ -582,8 +634,8 @@ export function CommitPanelScreen() {
               }
               onClick={async () => {
                 if (!headBranch || !defaultRemote) return;
-                const full = buildMessage(message, body, signoff);
-                const oid = await commitAction(full, amend);
+                const full = buildMessage(message, body);
+                const oid = await commitAction(full, amend, signoff);
                 if (!oid) return;
                 setMessage("");
                 setBody("");
@@ -605,16 +657,48 @@ function keyOf(f: FileSlot): string {
   return `${f.side}:${f.path}`;
 }
 
-function buildMessage(subject: string, body: string, signoff: boolean): string {
+function buildMessage(subject: string, body: string): string {
   const parts: string[] = [subject];
   if (body.trim()) parts.push("", body.trim());
-  if (signoff) {
-    const head = useRepoStore.getState().commits[0];
-    if (head?.author && head?.email) {
-      parts.push("", `Signed-off-by: ${head.author} <${head.email}>`);
-    }
-  }
   return parts.join("\n");
+}
+
+export interface RecentMessage {
+  subject: string;
+  body: string;
+}
+
+/**
+ * Recent commit messages for the dropdown, newest-first, deduped by full
+ * message text. Strips any `Signed-off-by:` trailer so re-selecting a message
+ * doesn't carry a stale sign-off (the toggle re-adds it on commit). Drops
+ * merge commits, which rarely make useful templates.
+ */
+export function recentCommitMessages(
+  commits: CommitInfo[],
+  limit = 15,
+): RecentMessage[] {
+  const out: RecentMessage[] = [];
+  const seen = new Set<string>();
+  for (const c of commits) {
+    if (c.parents.length > 1) continue; // skip merge commits
+    const subject = c.summary.trim();
+    if (!subject) continue;
+    const body = stripSignoff(c.body ?? "").trim();
+    const dedupeKey = `${subject}\n${body}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    out.push({ subject, body });
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+function stripSignoff(body: string): string {
+  return body
+    .split("\n")
+    .filter((line) => !/^Signed-off-by:\s/i.test(line.trim()))
+    .join("\n");
 }
 
 function diffToSplit(d: FileDiff): { left: SideLine[]; right: SideLine[] } {

--- a/src/screens/recentCommitMessages.test.ts
+++ b/src/screens/recentCommitMessages.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { recentCommitMessages } from "./CommitPanel";
+import type { CommitInfo } from "@/lib/types";
+
+const mk = (
+  oid: string,
+  summary: string,
+  body: string | null = null,
+  parents: string[] = [],
+): CommitInfo => ({
+  oid,
+  shortOid: oid.slice(0, 7),
+  summary,
+  body,
+  author: "Ada",
+  email: "ada@example.com",
+  timestamp: 0,
+  parents,
+  refs: [],
+});
+
+describe("recentCommitMessages", () => {
+  it("preserves newest-first order from the log", () => {
+    const out = recentCommitMessages([
+      mk("c", "third"),
+      mk("b", "second"),
+      mk("a", "first"),
+    ]);
+    expect(out.map((r) => r.subject)).toEqual(["third", "second", "first"]);
+  });
+
+  it("splits subject and body", () => {
+    const out = recentCommitMessages([
+      mk("a", "feat: thing", "Why: because.\nMore detail."),
+    ]);
+    expect(out[0]).toEqual({
+      subject: "feat: thing",
+      body: "Why: because.\nMore detail.",
+    });
+  });
+
+  it("dedupes identical messages, keeping the newest", () => {
+    const out = recentCommitMessages([
+      mk("b", "fix: bug"),
+      mk("a", "fix: bug"),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].subject).toBe("fix: bug");
+  });
+
+  it("strips an existing Signed-off-by trailer from the body", () => {
+    const out = recentCommitMessages([
+      mk(
+        "a",
+        "feat: thing",
+        "Real body.\n\nSigned-off-by: Ada <ada@example.com>",
+      ),
+    ]);
+    expect(out[0].body).toBe("Real body.");
+  });
+
+  it("skips merge commits", () => {
+    const out = recentCommitMessages([
+      mk("m", "Merge branch 'x'", null, ["a", "b"]),
+      mk("a", "feat: real work"),
+    ]);
+    expect(out.map((r) => r.subject)).toEqual(["feat: real work"]);
+  });
+
+  it("skips empty subjects", () => {
+    const out = recentCommitMessages([mk("a", "   "), mk("b", "real")]);
+    expect(out.map((r) => r.subject)).toEqual(["real"]);
+  });
+
+  it("respects the limit", () => {
+    const commits = Array.from({ length: 30 }, (_, i) =>
+      mk(`oid${i}`, `commit ${i}`),
+    );
+    expect(recentCommitMessages(commits, 5)).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
## What

Recent commit message dropdown + sign-off (`-s`) toggle — P0 from `features.md`.

- **Recent** button in commit panel fills subject+body from recent log messages (newest-first, deduped, skips merges/empties, strips stale sign-off).
- **Sign-off** toggle appends `Signed-off-by: Name <email>` from repo committer identity, `git commit -s` semantics (idempotent dedupe, blank-line separation). Persisted via settings store, synced both directions with the existing settings-screen toggle.

## How

Standard backend path:
- `signature.rs::apply_signoff(message, name, email)` — pure helper, 6 unit tests.
- `CommitOptions.signoff: bool` (`#[serde(default)]`); `commit` applies sign-off on normal + amend paths using committer identity.
- `commit` command takes `signoff: Option<bool>`; threaded through `tauri.ts` → `useRepoStore`.
- No new `AppError` variants — TS/Rust union stays 1:1.
- Recents reuse loaded log (no new backend op).

## Tests

- `pnpm tsc --noEmit` ✅
- `pnpm test` ✅ (7 recents pure-logic)
- `pnpm vite build` ✅
- `cargo check` / `cargo test` ✅ (6 signature unit + 3 stage_commit integration)

## Follow-ups

Author-only filtering of recents (currently all authors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
