### PR TITLE
feat(browser): browse repo tree at any revision

### DIFF
--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -59,6 +59,36 @@ pub async fn read_file_content(
 }
 
 #[tauri::command]
+pub async fn list_files_at_rev(
+    state: State<'_, AppState>,
+    repo_id: String,
+    revspec: String,
+) -> AppResult<Vec<FileStatus>> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    tokio::task::spawn_blocking(move || backend.list_files_at_rev(&repo_id, &revspec))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+#[tauri::command]
+pub async fn read_file_content_at_rev(
+    state: State<'_, AppState>,
+    repo_id: String,
+    revspec: String,
+    path: String,
+) -> AppResult<FileContent> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    let path_buf = PathBuf::from(path);
+    tokio::task::spawn_blocking(move || {
+        backend.read_file_content_at_rev(&repo_id, &revspec, &path_buf)
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+#[tauri::command]
 pub async fn append_gitignore(
     state: State<'_, AppState>,
     repo_id: String,

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -57,6 +57,17 @@ impl GitBackend for CliBackend {
     fn read_file_content(&self, _repo_id: &RepoId, _path: &Path) -> AppResult<FileContent> {
         Err(AppError::NotImplemented)
     }
+    fn list_files_at_rev(&self, _repo_id: &RepoId, _revspec: &str) -> AppResult<Vec<FileStatus>> {
+        Err(AppError::NotImplemented)
+    }
+    fn read_file_content_at_rev(
+        &self,
+        _repo_id: &RepoId,
+        _revspec: &str,
+        _path: &Path,
+    ) -> AppResult<FileContent> {
+        Err(AppError::NotImplemented)
+    }
     fn diff_commits(
         &self,
         _repo_id: &RepoId,

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -948,6 +948,88 @@ impl GitBackend for Libgit2Backend {
         })
     }
 
+    fn list_files_at_rev(&self, repo_id: &RepoId, revspec: &str) -> AppResult<Vec<FileStatus>> {
+        self.with_repo(repo_id, |repo| {
+            let tree = repo
+                .revparse_single(revspec)
+                .map_err(|_| AppError::InvalidRef(revspec.to_string()))?
+                .peel_to_tree()?;
+
+            let mut out = Vec::new();
+            // Walk the tree pre-order, accumulating full paths for blobs only.
+            tree.walk(git2::TreeWalkMode::PreOrder, |root, entry| {
+                if entry.kind() == Some(git2::ObjectType::Blob) {
+                    let name = entry.name().unwrap_or("");
+                    let path = if root.is_empty() {
+                        name.to_string()
+                    } else {
+                        format!("{root}{name}")
+                    };
+                    if !path.is_empty() {
+                        out.push(FileStatus {
+                            path,
+                            worktree: StatusFlag::Unmodified,
+                            index: StatusFlag::Unmodified,
+                        });
+                    }
+                }
+                git2::TreeWalkResult::Ok
+            })?;
+            Ok(out)
+        })
+    }
+
+    fn read_file_content_at_rev(
+        &self,
+        repo_id: &RepoId,
+        revspec: &str,
+        path: &Path,
+    ) -> AppResult<FileContent> {
+        let rel = path.to_path_buf();
+        let path_str = rel.to_string_lossy().into_owned();
+        self.with_repo(repo_id, |repo| {
+            let tree = repo
+                .revparse_single(revspec)
+                .map_err(|_| AppError::InvalidRef(revspec.to_string()))?
+                .peel_to_tree()?;
+
+            let entry = tree
+                .get_path(&rel)
+                .map_err(|_| AppError::InvalidPath(format!("file not found: {path_str}")))?;
+            let obj = entry.to_object(repo)?;
+            let blob = obj
+                .as_blob()
+                .ok_or_else(|| AppError::InvalidPath(format!("not a file: {path_str}")))?;
+            let content = blob.content();
+            let size = content.len() as u64;
+            if blob.is_binary() {
+                return Ok(FileContent {
+                    path: path_str,
+                    binary: true,
+                    text: None,
+                    from_head: true,
+                    size,
+                });
+            }
+            Ok(match std::str::from_utf8(content) {
+                Ok(s) => FileContent {
+                    path: path_str,
+                    binary: false,
+                    text: Some(s.to_string()),
+                    from_head: true,
+                    size,
+                },
+                Err(_) => FileContent {
+                    path: path_str,
+                    binary: true,
+                    text: None,
+                    from_head: true,
+                    size,
+                },
+            })
+        })
+    }
+
     fn diff_commits(
         &self,
         repo_id: &RepoId,

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -38,6 +38,22 @@ pub trait GitBackend: Send + Sync {
     /// Read the full content of a file from the worktree. Falls back to the
     /// HEAD blob when the worktree copy is missing (e.g. a deleted file).
     fn read_file_content(&self, repo_id: &RepoId, path: &Path) -> AppResult<FileContent>;
+    /// List every file in the tree at `revspec` (commit, branch, tag, or any
+    /// revspec). Resolves the revspec to a tree and walks it recursively.
+    /// Returns `FileStatus` entries with both sides `Unmodified` — the tree is
+    /// a historical snapshot, not the working state. `InvalidRef` if the
+    /// revspec can't be resolved.
+    fn list_files_at_rev(&self, repo_id: &RepoId, revspec: &str) -> AppResult<Vec<FileStatus>>;
+    /// Read the content of `path` from the tree at `revspec`. `InvalidRef` if
+    /// the revspec can't be resolved; `InvalidPath` if the path isn't in that
+    /// tree. The returned `FileContent.from_head` is true (content is from a
+    /// committed tree, not the worktree).
+    fn read_file_content_at_rev(
+        &self,
+        repo_id: &RepoId,
+        revspec: &str,
+        path: &Path,
+    ) -> AppResult<FileContent>;
     fn diff_commits(
         &self,
         repo_id: &RepoId,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,8 @@ pub fn run() {
             commands::repo::get_status,
             commands::repo::list_all_files,
             commands::repo::read_file_content,
+            commands::repo::list_files_at_rev,
+            commands::repo::read_file_content_at_rev,
             commands::repo::append_gitignore,
             commands::repo::open_in_editor,
             commands::commits::get_log,

--- a/src-tauri/tests/browse_tree_at_rev.rs
+++ b/src-tauri/tests/browse_tree_at_rev.rs
@@ -1,0 +1,117 @@
+mod support;
+
+use std::path::Path;
+
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::types::StatusFlag;
+use platypusgit_lib::git::GitBackend;
+
+use support::{fs::write_file, TempRepo};
+
+/// list_files_at_rev walks the whole tree of an arbitrary revision, including
+/// nested directories, and reports every blob (Unmodified on both sides).
+#[test]
+fn lists_full_tree_at_revision() {
+    let tr = TempRepo::with_initial_commit("v1\n");
+    // Add a nested file in a second commit.
+    write_file(tr.path(), "src/main.rs", "fn main() {}\n");
+    tr.commit_all("add nested file");
+    let (backend, handle) = tr.open_with_backend();
+
+    let files = backend.list_files_at_rev(&handle.id, "HEAD").unwrap();
+    let mut paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+    paths.sort();
+    assert_eq!(paths, vec!["README.md", "src/main.rs"]);
+    assert!(files
+        .iter()
+        .all(|f| matches!(f.worktree, StatusFlag::Unmodified)));
+}
+
+/// The tree at an older revision reflects that snapshot, not HEAD.
+#[test]
+fn lists_tree_at_older_revision() {
+    let tr = TempRepo::with_initial_commit("v1\n");
+    write_file(tr.path(), "extra.txt", "later\n");
+    tr.commit_all("add extra");
+    let (backend, handle) = tr.open_with_backend();
+
+    // At HEAD~1 only README.md existed.
+    let files = backend.list_files_at_rev(&handle.id, "HEAD~1").unwrap();
+    let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+    assert_eq!(paths, vec!["README.md"]);
+}
+
+/// read_file_content_at_rev returns the historical content of a file, not the
+/// current worktree version.
+#[test]
+fn reads_historical_file_content() {
+    let tr = TempRepo::with_initial_commit("first version\n");
+    // Overwrite README in a second commit.
+    write_file(tr.path(), "README.md", "second version\n");
+    tr.commit_all("update readme");
+    let (backend, handle) = tr.open_with_backend();
+
+    let old = backend
+        .read_file_content_at_rev(&handle.id, "HEAD~1", Path::new("README.md"))
+        .unwrap();
+    assert_eq!(old.text.as_deref(), Some("first version\n"));
+    assert!(!old.binary);
+    assert!(old.from_head);
+
+    let cur = backend
+        .read_file_content_at_rev(&handle.id, "HEAD", Path::new("README.md"))
+        .unwrap();
+    assert_eq!(cur.text.as_deref(), Some("second version\n"));
+}
+
+/// A branch name resolves as a revspec for both ops.
+#[test]
+fn resolves_branch_revspec() {
+    let tr = TempRepo::with_initial_commit("main content\n");
+    let (backend, handle) = tr.open_with_backend();
+    backend.create_branch(&handle.id, "feature", None).unwrap();
+    backend.checkout_branch(&handle.id, "feature").unwrap();
+    write_file(tr.path(), "feature.txt", "on feature\n");
+    tr.commit_all("feature commit");
+
+    // Re-open so the backend sees the new ref state cleanly.
+    let (backend, handle) = tr.open_with_backend();
+    let files = backend.list_files_at_rev(&handle.id, "feature").unwrap();
+    let mut paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+    paths.sort();
+    assert_eq!(paths, vec!["README.md", "feature.txt"]);
+
+    let content = backend
+        .read_file_content_at_rev(&handle.id, "feature", Path::new("feature.txt"))
+        .unwrap();
+    assert_eq!(content.text.as_deref(), Some("on feature\n"));
+}
+
+/// An unresolvable revspec yields InvalidRef.
+#[test]
+fn rejects_unknown_revspec() {
+    let tr = TempRepo::with_initial_commit("hi\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .list_files_at_rev(&handle.id, "no-such-ref")
+        .unwrap_err();
+    assert!(matches!(err, AppError::InvalidRef(_)), "got {err:?}");
+
+    let err = backend
+        .read_file_content_at_rev(&handle.id, "no-such-ref", Path::new("README.md"))
+        .unwrap_err();
+    assert!(matches!(err, AppError::InvalidRef(_)), "got {err:?}");
+}
+
+/// A path that doesn't exist in the tree yields InvalidPath.
+#[test]
+fn rejects_missing_path_in_tree() {
+    let tr = TempRepo::with_initial_commit("hi\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .read_file_content_at_rev(&handle.id, "HEAD", Path::new("nope.txt"))
+        .unwrap_err();
+    assert!(matches!(err, AppError::InvalidPath(_)), "got {err:?}");
+}

--- a/src-tauri/tests/browse_tree_at_rev.rs
+++ b/src-tauri/tests/browse_tree_at_rev.rs
@@ -104,6 +104,25 @@ fn rejects_unknown_revspec() {
     assert!(matches!(err, AppError::InvalidRef(_)), "got {err:?}");
 }
 
+/// A binary (non-UTF8) blob comes back flagged binary with no text — locking in
+/// the non-UTF8 branch of read_file_content_at_rev.
+#[test]
+fn reads_binary_blob_at_revision() {
+    use std::fs;
+
+    let tr = TempRepo::with_initial_commit("v1\n");
+    // Write bytes containing a NUL — invalid UTF-8, so git2 treats it as binary.
+    fs::write(tr.path().join("blob.bin"), [0u8, 1, 2, 0, 255, 0xfe]).expect("write binary");
+    tr.commit_all("add binary blob");
+    let (backend, handle) = tr.open_with_backend();
+
+    let content = backend
+        .read_file_content_at_rev(&handle.id, "HEAD", Path::new("blob.bin"))
+        .unwrap();
+    assert!(content.binary, "expected binary flag set");
+    assert_eq!(content.text, None);
+}
+
 /// A path that doesn't exist in the tree yields InvalidPath.
 #[test]
 fn rejects_missing_path_in_tree() {

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import type {
   BranchInfo,
   CommitInfo,
+  FileContent,
   FileStatus,
   RebaseStatus,
   RebaseStep,
@@ -36,6 +37,8 @@ import {
   getLog,
   getStatus,
   listAllFiles,
+  listFilesAtRev as listFilesAtRevFn,
+  readFileContentAtRev as readFileContentAtRevFn,
   listBranches,
   listRemotes,
   listStashes,
@@ -112,6 +115,19 @@ interface RepoStoreState {
   openRepo: (path: string) => Promise<void>;
   refreshAll: () => Promise<void>;
   refreshAllFiles: () => Promise<void>;
+  /**
+   * List every file in the tree at `revspec` (commit/branch/tag/revspec).
+   * Returns the file list, or null on failure (error is set on the store).
+   */
+  listFilesAtRev: (revspec: string) => Promise<FileStatus[] | null>;
+  /**
+   * Read a file's content from the tree at `revspec`. Returns null on failure
+   * (error is set on the store).
+   */
+  readFileContentAtRev: (
+    revspec: string,
+    path: string,
+  ) => Promise<FileContent | null>;
   clearError: () => void;
   closeRepo: () => void;
   stage: (paths: string[]) => Promise<void>;
@@ -294,6 +310,28 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       set({ allFiles });
     } catch (e) {
       set({ error: toAppError(e) });
+    }
+  },
+
+  async listFilesAtRev(revspec) {
+    const repo = get().current;
+    if (!repo) return null;
+    try {
+      return await listFilesAtRevFn(repo.id, revspec);
+    } catch (e) {
+      set({ error: toAppError(e) });
+      return null;
+    }
+  },
+
+  async readFileContentAtRev(revspec, path) {
+    const repo = get().current;
+    if (!repo) return null;
+    try {
+      return await readFileContentAtRevFn(repo.id, revspec, path);
+    } catch (e) {
+      set({ error: toAppError(e) });
+      return null;
     }
   },
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -60,6 +60,30 @@ export async function readFileContent(
   return invoke<FileContent>("read_file_content", { repoId, path });
 }
 
+/**
+ * List every file in the tree at `revspec` (commit SHA, branch, tag, or any
+ * revspec). All entries are reported `Unmodified` — it's a historical snapshot.
+ */
+export async function listFilesAtRev(
+  repoId: string,
+  revspec: string,
+): Promise<FileStatus[]> {
+  return invoke<FileStatus[]>("list_files_at_rev", { repoId, revspec });
+}
+
+/** Read a file's content from the tree at `revspec`. */
+export async function readFileContentAtRev(
+  repoId: string,
+  revspec: string,
+  path: string,
+): Promise<FileContent> {
+  return invoke<FileContent>("read_file_content_at_rev", {
+    repoId,
+    revspec,
+    path,
+  });
+}
+
 export async function getLog(
   repoId: string,
   limit?: number,

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -8,6 +8,7 @@ import {
   PGFileTree,
   PGHunk,
   PGIconButton,
+  PGInput,
   PGPanel,
   PGResizeHandle,
   PGSearchInput,
@@ -17,6 +18,7 @@ import {
   KV,
   useContextMenu,
   usePaneWidth,
+  type ContextMenuItem,
   type DiffLineData,
   type PGFileTreeNode,
 } from "@/design";
@@ -30,7 +32,14 @@ import {
 import { highlightFile } from "@/lib/highlight";
 import { getDiff, readFileContent } from "@/lib/tauri";
 import { buildStatusTree } from "@/lib/tree";
-import type { FileContent, FileDiff, FileStatus, StatusFlag } from "@/lib/types";
+import type {
+  BranchInfo,
+  FileContent,
+  FileDiff,
+  FileStatus,
+  StatusFlag,
+  TagInfo,
+} from "@/lib/types";
 
 type SortMode = "asc" | "desc";
 type HideKind = "Untracked" | "Ignored" | "Deleted";
@@ -71,9 +80,12 @@ export function RepoBrowserScreen() {
   const status = useRepoStore((s) => s.status);
   const allFiles = useRepoStore((s) => s.allFiles);
   const branches = useRepoStore((s) => s.branches);
+  const tags = useRepoStore((s) => s.tags);
   const commits = useRepoStore((s) => s.commits);
   const loading = useRepoStore((s) => s.loading);
   const refreshAllFiles = useRepoStore((s) => s.refreshAllFiles);
+  const listFilesAtRev = useRepoStore((s) => s.listFilesAtRev);
+  const readFileContentAtRev = useRepoStore((s) => s.readFileContentAtRev);
 
   const [expanded, setExpanded] = React.useState<Record<string, boolean>>({});
   const [selected, setSelected] = React.useState<string | null>(null);
@@ -83,6 +95,12 @@ export function RepoBrowserScreen() {
   const [filterMode, setFilterMode] = React.useState<
     "all" | "changes" | "conflicts"
   >("changes");
+  // Revision being browsed. null = working tree / HEAD (default behavior).
+  // When set, the tree and previews come from that committed tree snapshot.
+  const [rev, setRev] = React.useState<string | null>(null);
+  const [revFiles, setRevFiles] = React.useState<FileStatus[]>([]);
+  const [revLoading, setRevLoading] = React.useState(false);
+  const browsingRev = rev !== null;
   const [hiddenKinds, setHiddenKinds] = React.useState<Set<HideKind>>(
     () => new Set(),
   );
@@ -109,7 +127,29 @@ export function RepoBrowserScreen() {
     }
   }, [filterMode, repo, refreshAllFiles]);
 
+  // Load the file tree of the selected revision. Clears when back to HEAD.
+  React.useEffect(() => {
+    if (!repo || rev === null) {
+      setRevFiles([]);
+      return;
+    }
+    let cancelled = false;
+    setRevLoading(true);
+    listFilesAtRev(rev)
+      .then((files) => {
+        if (!cancelled) setRevFiles(files ?? []);
+      })
+      .finally(() => {
+        if (!cancelled) setRevLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repo, rev, listFilesAtRev]);
+
   const filteredStatus = React.useMemo<FileStatus[]>(() => {
+    // Browsing a committed revision: show its whole tree, no status filtering.
+    if (browsingRev) return revFiles;
     let base: FileStatus[];
     switch (filterMode) {
       case "conflicts":
@@ -131,7 +171,7 @@ export function RepoBrowserScreen() {
     }
     if (hiddenKinds.size === 0) return base;
     return base.filter((s) => !isHidden(s, hiddenKinds));
-  }, [status, allFiles, filterMode, hiddenKinds]);
+  }, [status, allFiles, filterMode, hiddenKinds, browsingRev, revFiles]);
 
   const tree = React.useMemo<PGFileTreeNode[]>(() => {
     const t = buildStatusTree(filteredStatus);
@@ -152,12 +192,15 @@ export function RepoBrowserScreen() {
   const selectedFile = React.useMemo<FileStatus | null>(() => {
     if (!selected) return null;
     const path = selected.replace(/^\//, "");
+    if (browsingRev) {
+      return revFiles.find((s) => s.path === path) ?? null;
+    }
     return (
       status.find((s) => s.path === path) ??
       allFiles.find((s) => s.path === path) ??
       null
     );
-  }, [selected, status, allFiles]);
+  }, [selected, status, allFiles, browsingRev, revFiles]);
 
   const selectedIsUnmodified =
     !!selectedFile &&
@@ -172,7 +215,17 @@ export function RepoBrowserScreen() {
     }
     let cancelled = false;
     setDiffLoading(true);
-    if (selectedIsUnmodified) {
+    if (browsingRev && rev) {
+      // Historical snapshot: always show the file's content at that revision.
+      setDiff(null);
+      readFileContentAtRev(rev, selectedFile.path)
+        .then((c) => {
+          if (!cancelled) setFileContent(c);
+        })
+        .finally(() => {
+          if (!cancelled) setDiffLoading(false);
+        });
+    } else if (selectedIsUnmodified) {
       setDiff(null);
       readFileContent(repo.id, selectedFile.path)
         .then((c) => {
@@ -200,7 +253,7 @@ export function RepoBrowserScreen() {
     return () => {
       cancelled = true;
     };
-  }, [selectedFile?.path, selectedIsUnmodified, repo]);
+  }, [selectedFile?.path, selectedIsUnmodified, repo, browsingRev, rev, readFileContentAtRev]);
 
   const breadcrumbItems = React.useMemo(() => {
     const root = repo?.path.split("/").filter(Boolean).pop() ?? "repository";
@@ -214,23 +267,29 @@ export function RepoBrowserScreen() {
         left={<PGBreadcrumb items={breadcrumbItems} />}
         right={
           <>
-            <PGButtonGroup
-              value={filterMode}
-              onChange={(v) =>
-                setFilterMode(v as "all" | "changes" | "conflicts")
-              }
-              options={[
-                { value: "all", label: "All", icon: "folder" },
-                { value: "changes", label: "Changes", icon: "edit" },
-                {
-                  value: "conflicts",
-                  label: conflictCount > 0
-                    ? `Conflicts (${conflictCount})`
-                    : "Conflicts",
-                  icon: "conflict",
-                },
-              ]}
-            />
+            {browsingRev ? (
+              <PGBadge tone="muted" icon="history">
+                Browsing {rev}
+              </PGBadge>
+            ) : (
+              <PGButtonGroup
+                value={filterMode}
+                onChange={(v) =>
+                  setFilterMode(v as "all" | "changes" | "conflicts")
+                }
+                options={[
+                  { value: "all", label: "All", icon: "folder" },
+                  { value: "changes", label: "Changes", icon: "edit" },
+                  {
+                    value: "conflicts",
+                    label: conflictCount > 0
+                      ? `Conflicts (${conflictCount})`
+                      : "Conflicts",
+                    icon: "conflict",
+                  },
+                ]}
+              />
+            )}
             <FilterMenuButton hiddenKinds={hiddenKinds} onToggle={(k) => {
               setHiddenKinds((prev) => {
                 const next = new Set(prev);
@@ -260,9 +319,19 @@ export function RepoBrowserScreen() {
               padding: "6px 8px",
               borderBottom: "1px solid var(--border-0)",
               display: "flex",
-              gap: 4,
+              flexDirection: "column",
+              gap: 6,
             }}
           >
+            <RevisionBar
+              rev={rev}
+              onChange={(r) => {
+                setRev(r);
+                setSelected(null);
+              }}
+              branches={branches}
+              tags={tags}
+            />
             <PGSearchInput
               placeholder="Find in tree…"
               shortcut="⌘⇧F"
@@ -270,7 +339,7 @@ export function RepoBrowserScreen() {
             />
           </div>
           <div style={{ flex: 1, overflow: "auto", padding: "4px 0" }}>
-            {tree.length === 0 && !loading && (
+            {tree.length === 0 && !loading && !revLoading && (
               <div
                 style={{
                   padding: 14,
@@ -279,14 +348,16 @@ export function RepoBrowserScreen() {
                   fontFamily: "var(--font-mono)",
                 }}
               >
-                {filterMode === "all"
-                  ? "No files."
-                  : filterMode === "conflicts"
-                    ? "No conflicts."
-                    : "Working tree clean."}
+                {browsingRev
+                  ? "No files at this revision."
+                  : filterMode === "all"
+                    ? "No files."
+                    : filterMode === "conflicts"
+                      ? "No conflicts."
+                      : "Working tree clean."}
               </div>
             )}
-            {loading && tree.length === 0 && (
+            {(loading || revLoading) && tree.length === 0 && (
               <div
                 style={{
                   padding: 14,
@@ -347,15 +418,21 @@ export function RepoBrowserScreen() {
                 {fileContent?.binary && (
                   <PGBadge tone="muted">binary</PGBadge>
                 )}
-                {fileContent?.fromHead && (
-                  <PGBadge tone="muted">from HEAD</PGBadge>
+                {browsingRev ? (
+                  <PGBadge tone="muted">@ {rev}</PGBadge>
+                ) : (
+                  fileContent?.fromHead && (
+                    <PGBadge tone="muted">from HEAD</PGBadge>
+                  )
                 )}
               </>
             ) : (
               <span style={{ color: "var(--fg-3)" }}>
-                {filterMode === "all"
-                  ? "Select a file to preview its content"
-                  : "Select a changed file to preview its diff"}
+                {browsingRev
+                  ? `Select a file to view its content at ${rev}`
+                  : filterMode === "all"
+                    ? "Select a file to preview its content"
+                    : "Select a changed file to preview its diff"}
               </span>
             )}
             <div style={{ flex: 1 }} />
@@ -703,6 +780,103 @@ function reverseTree(nodes: PGFileTreeNode[]): PGFileTreeNode[] {
     n.children
       ? { ...n, children: reverseTree(n.children) }
       : n,
+  );
+}
+
+/**
+ * Revision selector for the repo browser. Default (null) browses the working
+ * tree / HEAD. Pick a branch/tag from the quick menu, or type any revspec
+ * (commit SHA, `HEAD~3`, `tag^{}`, …) and press Enter.
+ */
+function RevisionBar({
+  rev,
+  onChange,
+  branches,
+  tags,
+}: {
+  rev: string | null;
+  onChange: (rev: string | null) => void;
+  branches: BranchInfo[];
+  tags: TagInfo[];
+}) {
+  const [draft, setDraft] = React.useState(rev ?? "");
+
+  // Keep the input in sync when the rev changes from outside (e.g. quick-pick).
+  React.useEffect(() => {
+    setDraft(rev ?? "");
+  }, [rev]);
+
+  const commit = () => {
+    const v = draft.trim();
+    onChange(v === "" ? null : v);
+  };
+
+  const { openAt, menu } = useContextMenu<null>(() => {
+    const items: ContextMenuItem[] = [
+      {
+        icon: rev === null ? "check" : "history",
+        label: "Working tree (HEAD)",
+        onClick: () => onChange(null),
+      },
+    ];
+    const localBranches = branches.filter((b) => !b.isRemote);
+    if (localBranches.length) {
+      items.push({ __menuTitle: "Branches" });
+      for (const b of localBranches) {
+        items.push({
+          icon: rev === b.name ? "check" : "branch",
+          label: b.name,
+          onClick: () => onChange(b.name),
+        });
+      }
+    }
+    if (tags.length) {
+      items.push({ __menuTitle: "Tags" });
+      for (const t of tags) {
+        items.push({
+          icon: rev === t.name ? "check" : "tag",
+          label: t.name,
+          onClick: () => onChange(t.name),
+        });
+      }
+    }
+    return items;
+  });
+
+  return (
+    <div style={{ display: "flex", gap: 4, alignItems: "center" }}>
+      <PGInput
+        value={draft}
+        onChange={setDraft}
+        placeholder="HEAD"
+        icon="history"
+        size="sm"
+        mono
+        title="Browse a revision — commit SHA, branch, tag, or revspec"
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit();
+          else if (e.key === "Escape") setDraft(rev ?? "");
+        }}
+        onBlur={commit}
+        style={{ flex: 1, minWidth: 0 }}
+      />
+      <PGIconButton
+        icon="chevronDown"
+        size="sm"
+        title="Pick branch or tag"
+        active={rev !== null}
+        onClick={(e) => openAt(e.clientX, e.clientY + 4, null)}
+      />
+      {rev !== null && (
+        <PGIconButton
+          icon="x"
+          size="sm"
+          title="Back to working tree"
+          onClick={() => onChange(null)}
+        />
+      )}
+      {menu}
+    </div>
   );
 }
 

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -119,6 +119,14 @@ export function RepoBrowserScreen() {
 
   const head = currentBranch(branches);
 
+  // Reset browse state when the repo changes (switch repos / close). Otherwise
+  // the previous repo's revspec lingers, applied to the new repo — surfacing a
+  // spurious InvalidRef. Working tree (null) is the default.
+  React.useEffect(() => {
+    setRev(null);
+    setSelected(null);
+  }, [repo?.id]);
+
   // Refresh the full file list each time the user picks "All" so the tree
   // reflects newly created / deleted files.
   React.useEffect(() => {


### PR DESCRIPTION
## What

Browse full repo file tree at any commit/revision (not just HEAD) — P0 from `features.md`.

Revision bar in the RepoBrowser tree pane: mono revspec input (Enter apply, Esc/x reset) + quick-pick of local branches and tags. Default stays working-tree/HEAD. When a revision is active the tree is built from that revision and selecting a file shows its content at that revision via existing highlight/preview.

## How

Standard backend path:
- `GitBackend::list_files_at_rev(repo, revspec)` + `read_file_content_at_rev(repo, revspec, path)`.
- libgit2: `revparse_single` → `peel_to_tree`, recursive `tree.walk` (blobs, full paths); `tree.get_path` + blob read for content. Unresolvable revspec → `InvalidRef`, missing path → `InvalidPath`.
- `cli.rs` `NotImplemented` stubs; thin `spawn_blocking` commands; registered in `invoke_handler!`.
- Reuses `FileStatus`/`FileContent` + `lib/tree.ts` — no new types, `AppError` union stays 1:1.

## Tests

- `pnpm tsc --noEmit` ✅
- `pnpm test` ✅
- `pnpm vite build` ✅
- `cargo check` / `cargo test` ✅ (6 integration: full tree, older rev, historical content, branch revspec, InvalidRef, InvalidPath)

## Follow-ups

Open/Edit/Blame still act on live worktree path while browsing a revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
