### PR TITLE
feat(history): commit/log search + filters

### DIFF
--- a/src-tauri/src/commands/commits.rs
+++ b/src-tauri/src/commands/commits.rs
@@ -2,7 +2,7 @@ use tauri::State;
 
 use crate::{
     error::{AppError, AppResult},
-    git::types::{CommitInfo, CommitOptions, RepoId},
+    git::types::{CommitInfo, CommitOptions, LogFilter, RepoId},
     state::AppState,
 };
 
@@ -16,6 +16,21 @@ pub async fn get_log(
     let repo_id = RepoId(repo_id);
     let limit = limit.unwrap_or(500);
     tokio::task::spawn_blocking(move || backend.log(&repo_id, limit))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+#[tauri::command]
+pub async fn get_log_filtered(
+    state: State<'_, AppState>,
+    repo_id: String,
+    filter: LogFilter,
+    limit: Option<usize>,
+) -> AppResult<Vec<CommitInfo>> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    let limit = limit.unwrap_or(500);
+    tokio::task::spawn_blocking(move || backend.log_filtered(&repo_id, &filter, limit))
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
 }

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -5,8 +5,8 @@ use crate::error::{AppError, AppResult};
 use super::{
     types::{
         BlameLine, BranchInfo, CommitInfo, CommitOptions, ConflictSides, DiffKind, FileContent,
-        FileDiff, FileStatus, RebaseStatus, RebaseStep, ReflogEntry, RemoteInfo, RepoHandle,
-        RepoId, RepoState, ResetMode, StashInfo, StashSaveOptions, TagInfo, TagTarget,
+        FileDiff, FileStatus, LogFilter, RebaseStatus, RebaseStep, ReflogEntry, RemoteInfo,
+        RepoHandle, RepoId, RepoState, ResetMode, StashInfo, StashSaveOptions, TagInfo, TagTarget,
     },
     GitBackend,
 };
@@ -38,6 +38,14 @@ impl GitBackend for CliBackend {
         Err(AppError::NotImplemented)
     }
     fn log(&self, _repo_id: &RepoId, _limit: usize) -> AppResult<Vec<CommitInfo>> {
+        Err(AppError::NotImplemented)
+    }
+    fn log_filtered(
+        &self,
+        _repo_id: &RepoId,
+        _filter: &LogFilter,
+        _limit: usize,
+    ) -> AppResult<Vec<CommitInfo>> {
         Err(AppError::NotImplemented)
     }
     fn commits_since(&self, _repo_id: &RepoId, _base: &str) -> AppResult<Vec<CommitInfo>> {

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -14,8 +14,9 @@ use crate::error::{AppError, AppResult};
 use super::{
     types::{
         BlameLine, BranchInfo, CommitInfo, CommitOptions, ConflictSides, DiffHunk, DiffKind,
-        DiffLine, DiffLineKind, FileContent, FileDiff, FileStatus, RebaseAction, RebaseStatus,
-        RebaseStep, ReflogEntry, ReflogOp, RemoteInfo, RepoHandle, RepoId, RepoState, ResetMode,
+        DiffLine, DiffLineKind, FileContent, FileDiff, FileStatus, LogFilter, RebaseAction,
+        RebaseStatus, RebaseStep, ReflogEntry, ReflogOp, RemoteInfo, RepoHandle, RepoId, RepoState,
+        ResetMode,
         StashInfo, StashSaveOptions, StatusFlag, TagInfo, TagTarget,
     },
     GitBackend,
@@ -668,6 +669,130 @@ impl GitBackend for Libgit2Backend {
             for oid in walk.take(limit) {
                 let oid = oid?;
                 let commit = repo.find_commit(oid)?;
+                let refs: Vec<String> = ref_map
+                    .iter()
+                    .filter(|(o, _)| *o == oid)
+                    .map(|(_, name)| name.clone())
+                    .collect();
+                let mut info = commit_to_info(&commit);
+                info.refs = refs;
+                out.push(info);
+            }
+            Ok(out)
+        })
+    }
+
+    fn log_filtered(
+        &self,
+        repo_id: &RepoId,
+        filter: &LogFilter,
+        limit: usize,
+    ) -> AppResult<Vec<CommitInfo>> {
+        // No filter set → identical to a plain log walk.
+        if filter.is_empty() {
+            return self.log(repo_id, limit);
+        }
+
+        // Normalize filter terms once.
+        let message_q = filter
+            .message
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_lowercase);
+        let author_q = filter
+            .author
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_lowercase);
+        let sha_q = filter
+            .sha_prefix
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_lowercase);
+        let path_q = filter
+            .path
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(std::path::PathBuf::from);
+
+        self.with_repo(repo_id, |repo| {
+            // Unborn HEAD (no commits yet) → nothing to walk. Detect up front
+            // since push_head() surfaces this as a generic "ref not found".
+            match repo.head() {
+                Ok(_) => {}
+                Err(e)
+                    if matches!(
+                        e.code(),
+                        git2::ErrorCode::UnbornBranch | git2::ErrorCode::NotFound
+                    ) =>
+                {
+                    return Ok(Vec::new())
+                }
+                Err(e) => return Err(e.into()),
+            }
+
+            let ref_map = collect_ref_map(repo);
+            let mut walk = repo.revwalk()?;
+            walk.set_sorting(Sort::TIME | Sort::TOPOLOGICAL)?;
+            walk.push_head()?;
+
+            let mut out = Vec::new();
+            for oid in walk {
+                if out.len() >= limit {
+                    break;
+                }
+                let oid = oid?;
+                let commit = repo.find_commit(oid)?;
+
+                // sha prefix — cheap, check first.
+                if let Some(ref q) = sha_q {
+                    if !oid.to_string().starts_with(q.as_str()) {
+                        continue;
+                    }
+                }
+
+                // date range.
+                let ts = commit.time().seconds();
+                if let Some(since) = filter.since {
+                    if ts < since {
+                        continue;
+                    }
+                }
+                if let Some(until) = filter.until {
+                    if ts > until {
+                        continue;
+                    }
+                }
+
+                // author name or email.
+                if let Some(ref q) = author_q {
+                    let author = commit.author();
+                    let name = author.name().unwrap_or("").to_lowercase();
+                    let email = author.email().unwrap_or("").to_lowercase();
+                    if !name.contains(q.as_str()) && !email.contains(q.as_str()) {
+                        continue;
+                    }
+                }
+
+                // message (full message: summary + body).
+                if let Some(ref q) = message_q {
+                    let msg = commit.message().unwrap_or("").to_lowercase();
+                    if !msg.contains(q.as_str()) {
+                        continue;
+                    }
+                }
+
+                // path — most expensive, check last.
+                if let Some(ref p) = path_q {
+                    if !commit_touches_path(repo, &commit, p)? {
+                        continue;
+                    }
+                }
+
                 let refs: Vec<String> = ref_map
                     .iter()
                     .filter(|(o, _)| *o == oid)

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -2347,19 +2347,26 @@ fn commit_to_info(commit: &git2::Commit<'_>) -> CommitInfo {
 
 /// Return `true` if `commit` touched `path` relative to any of its parents.
 /// For a root commit (no parents) the path simply has to exist in the tree.
+/// True if `commit` affected `path`.
+///
+/// For a root commit (no parents), matches if the path exists in the commit's
+/// tree. For a commit with parents, matches if the commit's tree differs from
+/// *any* parent for that path. This is broader than `git log -- <path>`'s
+/// first-parent simplification: a merge commit matches when it changed the path
+/// relative to any of its parents, not just the first. Intentional for a GUI —
+/// "did this commit touch the path" is the more useful question here.
 fn commit_touches_path(
     repo: &git2::Repository,
     commit: &git2::Commit<'_>,
     path: &std::path::Path,
 ) -> AppResult<bool> {
+    let commit_tree = commit.tree()?;
     if commit.parent_count() == 0 {
-        let tree = commit.tree()?;
-        return Ok(tree.get_path(path).is_ok());
+        return Ok(commit_tree.get_path(path).is_ok());
     }
     for i in 0..commit.parent_count() {
         let parent = commit.parent(i)?;
         let parent_tree = parent.tree()?;
-        let commit_tree = commit.tree()?;
         let mut opts = git2::DiffOptions::new();
         opts.pathspec(path);
         let diff = repo.diff_tree_to_tree(

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -8,8 +8,8 @@ use std::path::{Path, PathBuf};
 use crate::error::AppResult;
 use types::{
     BlameLine, BranchInfo, CommitInfo, CommitOptions, ConflictSides, DiffKind, FileContent,
-    FileDiff, FileStatus, RebaseStatus, RebaseStep, ReflogEntry, RemoteInfo, RepoHandle, RepoId,
-    RepoState, ResetMode, StashInfo, StashSaveOptions, TagInfo, TagTarget,
+    FileDiff, FileStatus, LogFilter, RebaseStatus, RebaseStep, ReflogEntry, RemoteInfo, RepoHandle,
+    RepoId, RepoState, ResetMode, StashInfo, StashSaveOptions, TagInfo, TagTarget,
 };
 
 pub trait GitBackend: Send + Sync {
@@ -20,6 +20,16 @@ pub trait GitBackend: Send + Sync {
     /// can browse the whole worktree (ignored files are still excluded).
     fn list_all_files(&self, repo_id: &RepoId) -> AppResult<Vec<FileStatus>>;
     fn log(&self, repo_id: &RepoId, limit: usize) -> AppResult<Vec<CommitInfo>>;
+    /// Like `log`, but only returns commits matching `filter`. The `limit`
+    /// caps the number of *matching* commits returned (newest-first), so the
+    /// walk may visit more than `limit` commits to fill the result. An empty
+    /// filter behaves like `log`.
+    fn log_filtered(
+        &self,
+        repo_id: &RepoId,
+        filter: &LogFilter,
+        limit: usize,
+    ) -> AppResult<Vec<CommitInfo>>;
     /// Commits reachable from HEAD but not from `base` (the `base..HEAD` range),
     /// newest-first. `base` is any revspec — branch, tag, short or full oid.
     /// Errors with `InvalidRef` if `base` can't be resolved or is not an

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -53,7 +53,7 @@ pub struct CommitInfo {
 /// Filter applied to the commit log walk. All fields are ANDed together;
 /// an all-`None`/empty filter matches every commit (equivalent to a plain log).
 /// String matches are case-insensitive substring matches except `sha_prefix`,
-/// which matches the start of the full or short OID.
+/// which matches a prefix of the full OID (hex).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LogFilter {

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -50,6 +50,39 @@ pub struct CommitInfo {
     pub refs: Vec<String>,
 }
 
+/// Filter applied to the commit log walk. All fields are ANDed together;
+/// an all-`None`/empty filter matches every commit (equivalent to a plain log).
+/// String matches are case-insensitive substring matches except `sha_prefix`,
+/// which matches the start of the full or short OID.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogFilter {
+    /// Substring of the commit message (summary + body), case-insensitive.
+    pub message: Option<String>,
+    /// Substring of the author name OR email, case-insensitive.
+    pub author: Option<String>,
+    /// Prefix of the commit OID (hex, case-insensitive).
+    pub sha_prefix: Option<String>,
+    /// Lower bound on commit time (unix seconds, inclusive).
+    pub since: Option<i64>,
+    /// Upper bound on commit time (unix seconds, inclusive).
+    pub until: Option<i64>,
+    /// Only commits that touched this path (relative to repo root).
+    pub path: Option<String>,
+}
+
+impl LogFilter {
+    /// True when no filter dimension is set — the walk can skip per-commit checks.
+    pub fn is_empty(&self) -> bool {
+        self.message.as_deref().map(str::trim).unwrap_or("").is_empty()
+            && self.author.as_deref().map(str::trim).unwrap_or("").is_empty()
+            && self.sha_prefix.as_deref().map(str::trim).unwrap_or("").is_empty()
+            && self.since.is_none()
+            && self.until.is_none()
+            && self.path.as_deref().map(str::trim).unwrap_or("").is_empty()
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BranchInfo {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -59,6 +59,7 @@ pub fn run() {
             commands::repo::append_gitignore,
             commands::repo::open_in_editor,
             commands::commits::get_log,
+            commands::commits::get_log_filtered,
             commands::commits::commits_since,
             commands::commits::commit,
             commands::commits::file_history,

--- a/src-tauri/tests/log_filter.rs
+++ b/src-tauri/tests/log_filter.rs
@@ -228,6 +228,152 @@ fn limit_caps_matching_commits() {
     assert_eq!(summaries(&out), vec!["refactor alpha module"]);
 }
 
+// --- path filter on root / merge commits ---
+
+/// Seed a repo whose first commit (root, no parents) creates `root.txt`,
+/// then a second ordinary commit touching `b.txt`. The root commit is the
+/// `parent_count() == 0` branch of `commit_touches_path`.
+#[test]
+fn path_filter_matches_root_commit() {
+    let tr = TempRepo::fresh();
+    commit_as(&tr, "root.txt", "1\n", "root commit", "Alice", "alice@example.com", 1000);
+    commit_as(&tr, "b.txt", "1\n", "second commit", "Bob", "bob@example.com", 2000);
+    let (backend, handle) = tr.open_with_backend();
+
+    // Matching path on the root commit.
+    let hit = backend
+        .log_filtered(
+            &handle.id,
+            &LogFilter {
+                path: Some("root.txt".into()),
+                ..Default::default()
+            },
+            100,
+        )
+        .unwrap();
+    assert_eq!(summaries(&hit), vec!["root commit"]);
+
+    // Non-matching path: present in no commit's tree change set.
+    let miss = backend
+        .log_filtered(
+            &handle.id,
+            &LogFilter {
+                path: Some("nope.txt".into()),
+                ..Default::default()
+            },
+            100,
+        )
+        .unwrap();
+    assert!(miss.is_empty());
+}
+
+/// Build a merge commit whose tree differs from one parent (added `merged.txt`)
+/// but matches neither parent for an unrelated path. Exercises the
+/// OR-over-parents branch of `commit_touches_path`.
+fn seeded_with_merge() -> TempRepo {
+    let tr = TempRepo::fresh();
+
+    // All borrows of `tr.repo` are confined to this block so they drop before
+    // `tr` is returned/moved.
+    {
+        let repo = &tr.repo;
+        let sig = Signature::new("Mona", "mona@example.com", &git2::Time::new(1000, 0)).unwrap();
+
+        // Stage `files` into the index and write a commit with `parents`.
+        let stage_commit = |files: &[(&str, &str)], msg: &str, parents: &[git2::Oid]| -> git2::Oid {
+            for (name, body) in files {
+                write_file(tr.path(), name, body);
+            }
+            let mut index = repo.index().unwrap();
+            for (name, _) in files {
+                index.add_path(Path::new(name)).unwrap();
+            }
+            index.write().unwrap();
+            let tree = repo.find_tree(index.write_tree().unwrap()).unwrap();
+            let parent_commits: Vec<git2::Commit> =
+                parents.iter().map(|o| repo.find_commit(*o).unwrap()).collect();
+            let parent_refs: Vec<&git2::Commit> = parent_commits.iter().collect();
+            repo.commit(Some("HEAD"), &sig, &sig, msg, &tree, &parent_refs)
+                .unwrap()
+        };
+
+        // Root commit on main: base.txt
+        let base = stage_commit(&[("base.txt", "base\n")], "base", &[]);
+
+        // Feature branch off base: adds feature.txt
+        let base_commit = repo.find_commit(base).unwrap();
+        repo.branch("feature", &base_commit, false).unwrap();
+        drop(base_commit);
+        repo.set_head("refs/heads/feature").unwrap();
+        repo.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+            .unwrap();
+        let feat = stage_commit(&[("feature.txt", "feat\n")], "feature", &[base]);
+
+        // Back to main, add main.txt
+        repo.set_head("refs/heads/main").unwrap();
+        repo.checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+            .unwrap();
+        let main = stage_commit(&[("main.txt", "main\n")], "main work", &[base]);
+
+        // Merge feature into main; merge commit also introduces merged.txt.
+        // Tree = base + main.txt + feature.txt + merged.txt.
+        stage_commit(
+            &[("main.txt", "main\n"), ("feature.txt", "feat\n"), ("merged.txt", "merged\n")],
+            "merge feature",
+            &[main, feat],
+        );
+    }
+
+    tr
+}
+
+#[test]
+fn path_filter_matches_merge_commit() {
+    let tr = seeded_with_merge();
+    let (backend, handle) = tr.open_with_backend();
+
+    // merged.txt was introduced by the merge commit itself — differs from
+    // BOTH parents, so it matches.
+    let merged = backend
+        .log_filtered(
+            &handle.id,
+            &LogFilter {
+                path: Some("merged.txt".into()),
+                ..Default::default()
+            },
+            100,
+        )
+        .unwrap();
+    assert_eq!(summaries(&merged), vec!["merge feature"]);
+
+    // feature.txt: the merge's tree matches the feature parent but differs
+    // from the main parent → OR-over-parents matches the merge commit too.
+    let feat = backend
+        .log_filtered(
+            &handle.id,
+            &LogFilter {
+                path: Some("feature.txt".into()),
+                ..Default::default()
+            },
+            100,
+        )
+        .unwrap();
+    assert_eq!(summaries(&feat), vec!["merge feature", "feature"]);
+
+    // Non-matching path: never present anywhere → no commit matches.
+    let miss = backend
+        .log_filtered(
+            &handle.id,
+            &LogFilter {
+                path: Some("ghost.txt".into()),
+                ..Default::default()
+            },
+            100,
+        )
+        .unwrap();
+    assert!(miss.is_empty());
+}
+
 #[test]
 fn unborn_head_returns_empty() {
     let tr = TempRepo::fresh();

--- a/src-tauri/tests/log_filter.rs
+++ b/src-tauri/tests/log_filter.rs
@@ -1,0 +1,246 @@
+mod support;
+
+use std::path::Path;
+
+use git2::Signature;
+use platypusgit_lib::git::types::LogFilter;
+use platypusgit_lib::git::GitBackend;
+use support::fs::write_file;
+use support::TempRepo;
+
+/// Commit `filename`=`contents` with a specific author + message + time.
+fn commit_as(tr: &TempRepo, filename: &str, contents: &str, msg: &str, name: &str, email: &str, when: i64) {
+    write_file(tr.path(), filename, contents);
+    let mut index = tr.repo.index().unwrap();
+    index.add_path(Path::new(filename)).unwrap();
+    index.write().unwrap();
+    let tree_oid = index.write_tree().unwrap();
+    let tree = tr.repo.find_tree(tree_oid).unwrap();
+    let sig = Signature::new(name, email, &git2::Time::new(when, 0)).unwrap();
+    let parents: Vec<git2::Commit> = tr
+        .repo
+        .head()
+        .ok()
+        .and_then(|h| h.peel_to_commit().ok())
+        .into_iter()
+        .collect();
+    let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
+    tr.repo
+        .commit(Some("HEAD"), &sig, &sig, msg, &tree, &parent_refs)
+        .unwrap();
+}
+
+/// Seed a repo with four distinct commits across authors/messages/paths/times.
+fn seeded() -> TempRepo {
+    let tr = TempRepo::fresh();
+    // t=1000 — alice, touches a.txt
+    commit_as(&tr, "a.txt", "1\n", "add feature alpha", "Alice", "alice@example.com", 1000);
+    // t=2000 — bob, touches b.txt
+    commit_as(&tr, "b.txt", "1\n", "fix bug in parser", "Bob", "bob@example.com", 2000);
+    // t=3000 — alice, touches a.txt again
+    commit_as(&tr, "a.txt", "2\n", "refactor alpha module", "Alice", "alice@example.com", 3000);
+    // t=4000 — carol, touches c.txt
+    commit_as(&tr, "c.txt", "1\n", "docs: update readme", "Carol", "carol@example.com", 4000);
+    tr
+}
+
+fn summaries(commits: &[platypusgit_lib::git::types::CommitInfo]) -> Vec<String> {
+    commits.iter().map(|c| c.summary.clone()).collect()
+}
+
+#[test]
+fn empty_filter_returns_all_newest_first() {
+    let tr = seeded();
+    let (backend, handle) = tr.open_with_backend();
+    let out = backend
+        .log_filtered(&handle.id, &LogFilter::default(), 100)
+        .unwrap();
+    assert_eq!(
+        summaries(&out),
+        vec![
+            "docs: update readme",
+            "refactor alpha module",
+            "fix bug in parser",
+            "add feature alpha",
+        ]
+    );
+}
+
+#[test]
+fn filter_by_message_substring() {
+    let tr = seeded();
+    let (backend, handle) = tr.open_with_backend();
+    let filter = LogFilter {
+        message: Some("alpha".into()),
+        ..Default::default()
+    };
+    let out = backend.log_filtered(&handle.id, &filter, 100).unwrap();
+    assert_eq!(
+        summaries(&out),
+        vec!["refactor alpha module", "add feature alpha"]
+    );
+}
+
+#[test]
+fn filter_by_message_is_case_insensitive() {
+    let tr = seeded();
+    let (backend, handle) = tr.open_with_backend();
+    let filter = LogFilter {
+        message: Some("BUG".into()),
+        ..Default::default()
+    };
+    let out = backend.log_filtered(&handle.id, &filter, 100).unwrap();
+    assert_eq!(summaries(&out), vec!["fix bug in parser"]);
+}
+
+#[test]
+fn filter_by_author_name_or_email() {
+    let tr = seeded();
+    let (backend, handle) = tr.open_with_backend();
+
+    let by_name = backend
+        .log_filtered(
+            &handle.id,
+            &LogFilter {
+                author: Some("alice".into()),
+                ..Default::default()
+            },
+            100,
+        )
+        .unwrap();
+    assert_eq!(
+        summaries(&by_name),
+        vec!["refactor alpha module", "add feature alpha"]
+    );
+
+    let by_email = backend
+        .log_filtered(
+            &handle.id,
+            &LogFilter {
+                author: Some("bob@example.com".into()),
+                ..Default::default()
+            },
+            100,
+        )
+        .unwrap();
+    assert_eq!(summaries(&by_email), vec!["fix bug in parser"]);
+}
+
+#[test]
+fn filter_by_sha_prefix() {
+    let tr = seeded();
+    let (backend, handle) = tr.open_with_backend();
+    // Grab a real oid from a plain walk.
+    let all = backend
+        .log_filtered(&handle.id, &LogFilter::default(), 100)
+        .unwrap();
+    let target = &all[1]; // "refactor alpha module"
+    let prefix = &target.oid[..8];
+    let out = backend
+        .log_filtered(
+            &handle.id,
+            &LogFilter {
+                sha_prefix: Some(prefix.to_string()),
+                ..Default::default()
+            },
+            100,
+        )
+        .unwrap();
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].oid, target.oid);
+}
+
+#[test]
+fn filter_by_date_range() {
+    let tr = seeded();
+    let (backend, handle) = tr.open_with_backend();
+    // since=2000, until=3000 → bob + second alice commit.
+    let out = backend
+        .log_filtered(
+            &handle.id,
+            &LogFilter {
+                since: Some(2000),
+                until: Some(3000),
+                ..Default::default()
+            },
+            100,
+        )
+        .unwrap();
+    assert_eq!(
+        summaries(&out),
+        vec!["refactor alpha module", "fix bug in parser"]
+    );
+}
+
+#[test]
+fn filter_by_path() {
+    let tr = seeded();
+    let (backend, handle) = tr.open_with_backend();
+    let out = backend
+        .log_filtered(
+            &handle.id,
+            &LogFilter {
+                path: Some("a.txt".into()),
+                ..Default::default()
+            },
+            100,
+        )
+        .unwrap();
+    assert_eq!(
+        summaries(&out),
+        vec!["refactor alpha module", "add feature alpha"]
+    );
+}
+
+#[test]
+fn filters_are_anded_together() {
+    let tr = seeded();
+    let (backend, handle) = tr.open_with_backend();
+    // author=alice AND message contains "refactor" → only one.
+    let out = backend
+        .log_filtered(
+            &handle.id,
+            &LogFilter {
+                author: Some("alice".into()),
+                message: Some("refactor".into()),
+                ..Default::default()
+            },
+            100,
+        )
+        .unwrap();
+    assert_eq!(summaries(&out), vec!["refactor alpha module"]);
+}
+
+#[test]
+fn limit_caps_matching_commits() {
+    let tr = seeded();
+    let (backend, handle) = tr.open_with_backend();
+    let out = backend
+        .log_filtered(
+            &handle.id,
+            &LogFilter {
+                author: Some("alice".into()),
+                ..Default::default()
+            },
+            1,
+        )
+        .unwrap();
+    assert_eq!(summaries(&out), vec!["refactor alpha module"]);
+}
+
+#[test]
+fn unborn_head_returns_empty() {
+    let tr = TempRepo::fresh();
+    let (backend, handle) = tr.open_with_backend();
+    let out = backend
+        .log_filtered(
+            &handle.id,
+            &LogFilter {
+                message: Some("anything".into()),
+                ..Default::default()
+            },
+            100,
+        )
+        .unwrap();
+    assert!(out.is_empty());
+}

--- a/src/features/commits/logFilter.test.ts
+++ b/src/features/commits/logFilter.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLogFilter,
+  isFilterEmpty,
+  normalizeFilter,
+  parseQueryText,
+} from "./logFilter";
+
+describe("parseQueryText", () => {
+  it("treats plain text as a message substring", () => {
+    expect(parseQueryText("fix parser bug")).toEqual({ message: "fix parser bug" });
+  });
+
+  it("extracts author: qualifier", () => {
+    expect(parseQueryText("author:alice")).toEqual({ author: "alice" });
+  });
+
+  it("extracts path: qualifier", () => {
+    expect(parseQueryText("path:src/foo.ts")).toEqual({ path: "src/foo.ts" });
+  });
+
+  it("combines qualifier with free-text message", () => {
+    expect(parseQueryText("author:bob refactor")).toEqual({
+      author: "bob",
+      message: "refactor",
+    });
+  });
+
+  it("treats a lone hex token as a sha prefix", () => {
+    expect(parseQueryText("abc123")).toEqual({ shaPrefix: "abc123" });
+  });
+
+  it("does not treat a hex token as sha when other text is present", () => {
+    expect(parseQueryText("abc123 cleanup")).toEqual({ message: "abc123 cleanup" });
+  });
+
+  it("honors an explicit sha: qualifier even with other text", () => {
+    expect(parseQueryText("sha:deadbeef cleanup")).toEqual({
+      shaPrefix: "deadbeef",
+      message: "cleanup",
+    });
+  });
+
+  it("supports aliases (by, file, msg)", () => {
+    expect(parseQueryText("by:carol file:README.md msg:docs")).toEqual({
+      author: "carol",
+      path: "README.md",
+      message: "docs",
+    });
+  });
+
+  it("parses since/until dates to unix seconds", () => {
+    const out = parseQueryText("since:2024-01-01 until:2024-12-31");
+    // local-time midnight / end-of-day; just assert ordering + presence.
+    expect(typeof out.since).toBe("number");
+    expect(typeof out.until).toBe("number");
+    expect(out.until! > out.since!).toBe(true);
+  });
+
+  it("ignores malformed dates", () => {
+    expect(parseQueryText("since:nope")).toEqual({});
+  });
+
+  it("returns empty object for blank input", () => {
+    expect(parseQueryText("   ")).toEqual({});
+  });
+});
+
+describe("buildLogFilter", () => {
+  it("merges free text with dedicated fields", () => {
+    const f = buildLogFilter({
+      text: "parser",
+      author: "alice",
+      path: "src/lib.rs",
+    });
+    expect(f).toEqual({
+      message: "parser",
+      author: "alice",
+      path: "src/lib.rs",
+    });
+  });
+
+  it("dedicated author overrides a text qualifier", () => {
+    const f = buildLogFilter({ text: "author:fromtext", author: "fromfield" });
+    expect(f.author).toBe("fromfield");
+  });
+
+  it("applies date inputs as since/until bounds", () => {
+    const f = buildLogFilter({ sinceDate: "2024-06-01", untilDate: "2024-06-30" });
+    expect(typeof f.since).toBe("number");
+    expect(typeof f.until).toBe("number");
+    expect(f.until! > f.since!).toBe(true);
+  });
+
+  it("produces an empty filter from all-blank inputs", () => {
+    expect(buildLogFilter({ text: "  ", author: "", path: "" })).toEqual({});
+  });
+});
+
+describe("normalizeFilter / isFilterEmpty", () => {
+  it("drops blank string fields", () => {
+    expect(normalizeFilter({ message: "  ", author: "x", path: "" })).toEqual({
+      author: "x",
+    });
+  });
+
+  it("isFilterEmpty true for blank-only filter", () => {
+    expect(isFilterEmpty({ message: "", author: null, path: undefined })).toBe(true);
+  });
+
+  it("isFilterEmpty false when any field set", () => {
+    expect(isFilterEmpty({ since: 1000 })).toBe(false);
+  });
+});

--- a/src/features/commits/logFilter.ts
+++ b/src/features/commits/logFilter.ts
@@ -1,0 +1,154 @@
+import type { LogFilter } from "@/lib/types";
+
+/**
+ * Inputs from the History search bar, before they become a backend `LogFilter`.
+ * `text` is the free-text box; the rest come from dedicated controls.
+ */
+export interface LogFilterInputs {
+  /** Free text. May contain `key:value` qualifiers (see parseQueryText). */
+  text?: string;
+  author?: string;
+  path?: string;
+  /** ISO date string `YYYY-MM-DD` (date input). */
+  sinceDate?: string;
+  /** ISO date string `YYYY-MM-DD` (date input). */
+  untilDate?: string;
+}
+
+/** A SHA-ish token: hex, length 4..40. */
+const SHA_RE = /^[0-9a-f]{4,40}$/i;
+
+/**
+ * Parse a free-text query into partial filter fields. Supports `key:value`
+ * qualifiers (`author:`, `path:`, `sha:`, `since:`, `until:`, `message:`);
+ * everything else accumulates into the message substring. A bare token that
+ * looks like a SHA prefix becomes `shaPrefix` (unless other text is present).
+ *
+ * Quoting is intentionally not supported — values run to the next whitespace.
+ */
+export function parseQueryText(text: string): Partial<LogFilter> {
+  const out: Partial<LogFilter> = {};
+  const messageParts: string[] = [];
+  const bareTokens: string[] = [];
+
+  for (const tok of text.trim().split(/\s+/).filter(Boolean)) {
+    const colon = tok.indexOf(":");
+    const key = colon > 0 ? tok.slice(0, colon).toLowerCase() : "";
+    const value = colon > 0 ? tok.slice(colon + 1) : "";
+    switch (key) {
+      case "author":
+      case "by":
+        if (value) out.author = mergeTerm(out.author, value);
+        break;
+      case "path":
+      case "file":
+        if (value) out.path = value;
+        break;
+      case "sha":
+      case "commit":
+        if (value) out.shaPrefix = value;
+        break;
+      case "since":
+      case "after":
+        if (value) out.since = parseSince(value) ?? out.since;
+        break;
+      case "until":
+      case "before":
+        if (value) out.until = parseUntil(value) ?? out.until;
+        break;
+      case "message":
+      case "msg":
+        if (value) messageParts.push(value);
+        break;
+      default:
+        bareTokens.push(tok);
+    }
+  }
+
+  // A single bare token that's clearly a SHA prefix → shaPrefix; otherwise the
+  // bare tokens form the message substring.
+  if (bareTokens.length === 1 && !messageParts.length && SHA_RE.test(bareTokens[0])) {
+    out.shaPrefix = out.shaPrefix ?? bareTokens[0];
+  } else {
+    messageParts.push(...bareTokens);
+  }
+
+  const message = messageParts.join(" ").trim();
+  if (message) out.message = message;
+  return out;
+}
+
+function mergeTerm(existing: string | null | undefined, next: string): string {
+  return existing ? `${existing} ${next}` : next;
+}
+
+/** Parse `YYYY-MM-DD` to unix seconds at local 00:00:00. Returns null if invalid. */
+function parseSince(value: string): number | null {
+  return dateToUnix(value, false);
+}
+
+/** Parse `YYYY-MM-DD` to unix seconds at local 23:59:59 (end of day). */
+function parseUntil(value: string): number | null {
+  return dateToUnix(value, true);
+}
+
+function dateToUnix(value: string, endOfDay: boolean): number | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value.trim());
+  if (!m) return null;
+  const [, y, mo, d] = m;
+  const date = new Date(
+    Number(y),
+    Number(mo) - 1,
+    Number(d),
+    endOfDay ? 23 : 0,
+    endOfDay ? 59 : 0,
+    endOfDay ? 59 : 0,
+  );
+  if (Number.isNaN(date.getTime())) return null;
+  return Math.floor(date.getTime() / 1000);
+}
+
+/**
+ * Build a backend `LogFilter` from the History search controls. Combines the
+ * free-text query (which may itself carry qualifiers) with the dedicated
+ * author/path/date fields. Dedicated fields take precedence over qualifiers of
+ * the same name parsed from the text.
+ */
+export function buildLogFilter(inputs: LogFilterInputs): LogFilter {
+  const fromText = parseQueryText(inputs.text ?? "");
+  const filter: LogFilter = { ...fromText };
+
+  const author = inputs.author?.trim();
+  if (author) filter.author = author;
+
+  const path = inputs.path?.trim();
+  if (path) filter.path = path;
+
+  if (inputs.sinceDate) {
+    const since = parseSince(inputs.sinceDate);
+    if (since != null) filter.since = since;
+  }
+  if (inputs.untilDate) {
+    const until = parseUntil(inputs.untilDate);
+    if (until != null) filter.until = until;
+  }
+
+  return normalizeFilter(filter);
+}
+
+/** Drop empty/blank fields so an "empty" filter is genuinely `{}`. */
+export function normalizeFilter(filter: LogFilter): LogFilter {
+  const out: LogFilter = {};
+  if (filter.message?.trim()) out.message = filter.message.trim();
+  if (filter.author?.trim()) out.author = filter.author.trim();
+  if (filter.shaPrefix?.trim()) out.shaPrefix = filter.shaPrefix.trim();
+  if (filter.path?.trim()) out.path = filter.path.trim();
+  if (typeof filter.since === "number") out.since = filter.since;
+  if (typeof filter.until === "number") out.until = filter.until;
+  return out;
+}
+
+/** True when no filter dimension is set (matches everything). */
+export function isFilterEmpty(filter: LogFilter): boolean {
+  return Object.keys(normalizeFilter(filter)).length === 0;
+}

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -4,6 +4,7 @@ import type {
   CommitInfo,
   FileContent,
   FileStatus,
+  LogFilter,
   RebaseStatus,
   RebaseStep,
   RemoteInfo,
@@ -35,6 +36,7 @@ import {
   fetch as fetchRemote,
   fetchAll,
   getLog,
+  getLogFiltered,
   getStatus,
   listAllFiles,
   listFilesAtRev as listFilesAtRevFn,
@@ -80,6 +82,7 @@ import {
   type StashSaveOptions,
   type TagTarget,
 } from "@/lib/tauri";
+import { isFilterEmpty } from "@/features/commits/logFilter";
 import { useRecentsStore } from "./useRecentsStore";
 
 /**
@@ -106,6 +109,16 @@ interface RepoStoreState {
   stashes: StashInfo[];
   remotes: RemoteInfo[];
   commits: CommitInfo[];
+  /**
+   * Backend-filtered commit log, or null when no search is active. Kept
+   * separate from `commits` (the full HEAD log) so the History screen can fall
+   * back to the unfiltered set and apply its own client-side toggles.
+   */
+  searchResults: CommitInfo[] | null;
+  /** The active backend log filter (empty object when none). */
+  commitFilter: LogFilter;
+  /** True while a backend search is in flight. */
+  searching: boolean;
   loading: boolean;
   error: AppError | null;
   repoState: GitRepoState;
@@ -113,6 +126,11 @@ interface RepoStoreState {
   /** Active long-running ops keyed by op kind. */
   activity: RepoActivity;
   openRepo: (path: string) => Promise<void>;
+  /**
+   * Run a backend commit-log search. An empty filter clears the search and
+   * falls back to the full log. Sets `searchResults` + `commitFilter`.
+   */
+  searchCommits: (filter: LogFilter) => Promise<void>;
   refreshAll: () => Promise<void>;
   refreshAllFiles: () => Promise<void>;
   /**
@@ -225,6 +243,9 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   stashes: [],
   remotes: [],
   commits: [],
+  searchResults: null,
+  commitFilter: {},
+  searching: false,
   loading: false,
   error: null,
   repoState: "Clean",
@@ -245,10 +266,31 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         stashes: [],
         remotes: [],
         commits: [],
+        searchResults: null,
+        commitFilter: {},
       });
       await get().refreshAll();
     } catch (e) {
       set({ loading: false, error: toAppError(e) });
+    }
+  },
+
+  async searchCommits(filter) {
+    const repo = get().current;
+    if (!repo) return;
+    // Empty filter → clear the search, fall back to full log.
+    if (isFilterEmpty(filter)) {
+      set({ searchResults: null, commitFilter: {}, searching: false });
+      return;
+    }
+    set({ commitFilter: filter, searching: true });
+    try {
+      const results = await getLogFiltered(repo.id, filter, 500);
+      // Guard against a stale response overwriting a newer filter.
+      if (get().commitFilter !== filter) return;
+      set({ searchResults: results, searching: false });
+    } catch (e) {
+      set({ searching: false, error: toAppError(e) });
     }
   },
 
@@ -279,6 +321,11 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         rebaseStatus,
         loading: false,
       });
+      // Keep an active search in sync with the refreshed history.
+      const activeFilter = get().commitFilter;
+      if (!isFilterEmpty(activeFilter)) {
+        void get().searchCommits(activeFilter);
+      }
     } catch (e) {
       set({ loading: false, error: toAppError(e) });
     }
@@ -298,6 +345,9 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       stashes: [],
       remotes: [],
       commits: [],
+      searchResults: null,
+      commitFilter: {},
+      searching: false,
       error: null,
     });
   },

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -9,6 +9,7 @@ import type {
   FileContent,
   FileDiff,
   FileStatus,
+  LogFilter,
   PullMode,
   PushForce,
   RebaseStatus,
@@ -89,6 +90,19 @@ export async function getLog(
   limit?: number,
 ): Promise<CommitInfo[]> {
   return invoke<CommitInfo[]>("get_log", { repoId, limit });
+}
+
+/**
+ * Commit log filtered by `filter` (message/author/sha/date/path), newest-first.
+ * `limit` caps the number of *matching* commits. An empty filter behaves like
+ * `getLog`.
+ */
+export async function getLogFiltered(
+  repoId: string,
+  filter: LogFilter,
+  limit?: number,
+): Promise<CommitInfo[]> {
+  return invoke<CommitInfo[]>("get_log_filtered", { repoId, filter, limit });
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,7 +38,7 @@ export interface CommitInfo {
 
 /**
  * Backend commit-log filter. All set fields are ANDed. String matches are
- * case-insensitive substring matches except `shaPrefix` (matches start of OID).
+ * case-insensitive substring matches except `shaPrefix` (matches a prefix of the full OID, hex).
  * Mirrors Rust `LogFilter` in `git/types.rs`.
  */
 export interface LogFilter {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -36,6 +36,26 @@ export interface CommitInfo {
   refs: string[];
 }
 
+/**
+ * Backend commit-log filter. All set fields are ANDed. String matches are
+ * case-insensitive substring matches except `shaPrefix` (matches start of OID).
+ * Mirrors Rust `LogFilter` in `git/types.rs`.
+ */
+export interface LogFilter {
+  /** Substring of the commit message (summary + body). */
+  message?: string | null;
+  /** Substring of author name OR email. */
+  author?: string | null;
+  /** Prefix of the commit OID (hex). */
+  shaPrefix?: string | null;
+  /** Lower bound on commit time, unix seconds (inclusive). */
+  since?: number | null;
+  /** Upper bound on commit time, unix seconds (inclusive). */
+  until?: number | null;
+  /** Only commits that touched this path (relative to repo root). */
+  path?: string | null;
+}
+
 export interface BranchInfo {
   name: string;
   isHead: boolean;

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -7,6 +7,7 @@ import {
   PGCommitRow,
   PGEmpty,
   PGIconButton,
+  PGInput,
   PGResizeHandle,
   PGSearchInput,
   PGSelect,
@@ -18,6 +19,7 @@ import {
   usePaneWidth,
 } from "@/design";
 import { layoutGraph } from "@/features/commits/graphLayout";
+import { buildLogFilter, isFilterEmpty } from "@/features/commits/logFilter";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { currentBranch, mapCommitRefs, relativeTime, shortSha } from "@/lib/derive";
 import type { CommitInfo } from "@/lib/types";
@@ -25,15 +27,53 @@ import type { CommitInfo } from "@/lib/types";
 type HistoryFilterKind = "all" | "mine" | "branch";
 type RefFilter = "all" | "local";
 
+const SEARCH_DEBOUNCE_MS = 250;
+
 export function HistoryScreen() {
   const commits = useRepoStore((s) => s.commits);
+  const searchResults = useRepoStore((s) => s.searchResults);
+  const searching = useRepoStore((s) => s.searching);
+  const searchCommits = useRepoStore((s) => s.searchCommits);
   const branches = useRepoStore((s) => s.branches);
   const loading = useRepoStore((s) => s.loading);
   const [selected, setSelected] = React.useState(0);
+  // Free-text search box (supports key:value qualifiers — see logFilter.ts).
   const [filter, setFilter] = React.useState("");
+  // Dedicated structured search fields.
+  const [authorQ, setAuthorQ] = React.useState("");
+  const [pathQ, setPathQ] = React.useState("");
+  const [sinceDate, setSinceDate] = React.useState("");
+  const [untilDate, setUntilDate] = React.useState("");
+  const [advancedOpen, setAdvancedOpen] = React.useState(false);
   const [filterKind, setFilterKind] = React.useState<HistoryFilterKind>("all");
   const [refFilter, setRefFilter] = React.useState<RefFilter>("all");
   const [hideMerges, setHideMerges] = React.useState(false);
+
+  // Debounce the backend search across all search inputs.
+  const logFilter = React.useMemo(
+    () =>
+      buildLogFilter({
+        text: filter,
+        author: authorQ,
+        path: pathQ,
+        sinceDate,
+        untilDate,
+      }),
+    [filter, authorQ, pathQ, sinceDate, untilDate],
+  );
+  const filterKey = JSON.stringify(logFilter);
+  React.useEffect(() => {
+    const handle = window.setTimeout(() => {
+      void searchCommits(logFilter);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(handle);
+    // filterKey captures the filter's content; logFilter identity changes each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filterKey, searchCommits]);
+
+  const searchActive = !isFilterEmpty(logFilter);
+  // Base list: backend-filtered results when a search is active, else full log.
+  const baseCommits = searchActive ? (searchResults ?? []) : commits;
   const detailPane = usePaneWidth(440, {
     min: 280,
     max: 720,
@@ -43,7 +83,7 @@ export function HistoryScreen() {
   // Reset selection when the commit list changes shape.
   React.useEffect(() => {
     setSelected(0);
-  }, [commits.length]);
+  }, [baseCommits.length, filterKey]);
 
   const head = currentBranch(branches);
   const headName = head?.name ?? null;
@@ -62,8 +102,10 @@ export function HistoryScreen() {
     return best;
   }, [commits]);
 
+  // Text/author/path/date/sha filtering happens on the backend (baseCommits).
+  // The "mine"/"branch"/hide-merges toggles remain client-side refinements.
   const visible = React.useMemo(() => {
-    let list: CommitInfo[] = commits;
+    let list: CommitInfo[] = baseCommits;
     if (filterKind === "mine" && myEmail) {
       list = list.filter((c) => c.email === myEmail);
     } else if (filterKind === "branch" && aheadCount > 0) {
@@ -71,18 +113,8 @@ export function HistoryScreen() {
       list = list.slice(0, aheadCount);
     }
     if (hideMerges) list = list.filter((c) => c.parents.length <= 1);
-    if (filter.trim()) {
-      const q = filter.toLowerCase();
-      list = list.filter(
-        (c) =>
-          c.summary.toLowerCase().includes(q) ||
-          c.author.toLowerCase().includes(q) ||
-          c.shortOid.toLowerCase().includes(q) ||
-          c.refs.some((r) => r.toLowerCase().includes(q)),
-      );
-    }
     return list;
-  }, [commits, filter, filterKind, myEmail, hideMerges, aheadCount]);
+  }, [baseCommits, filterKind, myEmail, hideMerges, aheadCount]);
 
   const rows = React.useMemo(() => layoutGraph(visible), [visible]);
 
@@ -104,19 +136,54 @@ export function HistoryScreen() {
       onExport={exportVisible}
     />
   );
+  const clearSearch = React.useCallback(() => {
+    setFilter("");
+    setAuthorQ("");
+    setPathQ("");
+    setSinceDate("");
+    setUntilDate("");
+  }, []);
+
   const toolbarLeft = (
     <HistoryToolbarLeft
       filter={filter}
       onFilter={setFilter}
       filterKind={filterKind}
       onFilterKind={setFilterKind}
+      authorQ={authorQ}
+      onAuthorQ={setAuthorQ}
+      pathQ={pathQ}
+      onPathQ={setPathQ}
+      sinceDate={sinceDate}
+      onSinceDate={setSinceDate}
+      untilDate={untilDate}
+      onUntilDate={setUntilDate}
+      advancedOpen={advancedOpen}
+      onToggleAdvanced={() => setAdvancedOpen((v) => !v)}
+      searchActive={searchActive}
+      searching={searching}
+      matchCount={searchActive ? visible.length : null}
+      onClear={clearSearch}
     />
   );
+  const advancedPanel = advancedOpen ? (
+    <AdvancedSearchPanel
+      authorQ={authorQ}
+      onAuthorQ={setAuthorQ}
+      pathQ={pathQ}
+      onPathQ={setPathQ}
+      sinceDate={sinceDate}
+      onSinceDate={setSinceDate}
+      untilDate={untilDate}
+      onUntilDate={setUntilDate}
+    />
+  ) : null;
 
   if (!commits.length) {
     return (
       <>
         <PGToolbar left={toolbarLeft} right={toolbarRight} />
+        {advancedPanel}
         {loading ? (
           <PGEmpty icon="history" title={<PGSpinner size={18} />}>
             Loading commits…
@@ -135,6 +202,7 @@ export function HistoryScreen() {
   return (
     <>
       <PGToolbar left={toolbarLeft} right={toolbarRight} />
+      {advancedPanel}
       <div style={{ flex: 1, minHeight: 0, display: "flex" }}>
         <div
           style={{
@@ -176,7 +244,11 @@ export function HistoryScreen() {
                   fontSize: "var(--fs-12)",
                 }}
               >
-                No commits match the current filters.
+                {searching
+                  ? "Searching…"
+                  : searchActive
+                    ? "No commits match the search."
+                    : "No commits match the current filters."}
               </div>
             )}
             {visible.map((c, i) => {
@@ -350,25 +422,56 @@ function CommitActionRow({ commit }: { commit: CommitInfo }) {
   );
 }
 
-function HistoryToolbarLeft({
-  filter,
-  onFilter,
-  filterKind,
-  onFilterKind,
-}: {
+interface HistoryToolbarLeftProps {
   filter: string;
   onFilter: (v: string) => void;
   filterKind: HistoryFilterKind;
   onFilterKind: (v: HistoryFilterKind) => void;
-}) {
+  authorQ: string;
+  onAuthorQ: (v: string) => void;
+  pathQ: string;
+  onPathQ: (v: string) => void;
+  sinceDate: string;
+  onSinceDate: (v: string) => void;
+  untilDate: string;
+  onUntilDate: (v: string) => void;
+  advancedOpen: boolean;
+  onToggleAdvanced: () => void;
+  searchActive: boolean;
+  searching: boolean;
+  matchCount: number | null;
+  onClear: () => void;
+}
+
+function HistoryToolbarLeft(props: HistoryToolbarLeftProps) {
+  const {
+    filter,
+    onFilter,
+    filterKind,
+    onFilterKind,
+    advancedOpen,
+    onToggleAdvanced,
+    searchActive,
+    searching,
+    matchCount,
+    onClear,
+  } = props;
   return (
     <>
       <PGSearchInput
         value={filter}
         onChange={onFilter}
-        placeholder="Search commits, authors, refs…"
+        placeholder="Search message, author, sha, path… (e.g. author:bob)"
         shortcut="⌘F"
         style={{ width: 340 }}
+      />
+      <PGIconButton
+        icon="sort"
+        size="md"
+        title="Advanced search (author / path / date range)"
+        aria-pressed={advancedOpen}
+        onClick={onToggleAdvanced}
+        style={advancedOpen ? { color: "var(--accent)" } : undefined}
       />
       <PGButtonGroup
         value={filterKind}
@@ -379,7 +482,128 @@ function HistoryToolbarLeft({
           { value: "branch", label: "This branch" },
         ]}
       />
+      {searchActive && (
+        <>
+          <span
+            style={{
+              fontSize: "var(--fs-11)",
+              color: "var(--fg-3)",
+              fontFamily: "var(--font-mono)",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {searching
+              ? "searching…"
+              : `${matchCount} match${matchCount === 1 ? "" : "es"}`}
+          </span>
+          <PGButton size="sm" variant="ghost" icon="x" onClick={onClear}>
+            Clear
+          </PGButton>
+        </>
+      )}
     </>
+  );
+}
+
+/** Field labels reused by the advanced search strip. */
+function SearchField({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 3,
+        fontSize: "var(--fs-10)",
+        color: "var(--fg-2)",
+        textTransform: "uppercase",
+        letterSpacing: "0.05em",
+      }}
+    >
+      <span>{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function AdvancedSearchPanel(props: {
+  authorQ: string;
+  onAuthorQ: (v: string) => void;
+  pathQ: string;
+  onPathQ: (v: string) => void;
+  sinceDate: string;
+  onSinceDate: (v: string) => void;
+  untilDate: string;
+  onUntilDate: (v: string) => void;
+}) {
+  const {
+    authorQ,
+    onAuthorQ,
+    pathQ,
+    onPathQ,
+    sinceDate,
+    onSinceDate,
+    untilDate,
+    onUntilDate,
+  } = props;
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 12,
+        alignItems: "flex-end",
+        flexWrap: "wrap",
+        padding: "8px 12px",
+        background: "var(--bg-1)",
+        borderBottom: "1px solid var(--border-0)",
+        flexShrink: 0,
+      }}
+    >
+      <SearchField label="Author">
+        <PGInput
+          value={authorQ}
+          onChange={onAuthorQ}
+          placeholder="name or email"
+          icon="user"
+          size="sm"
+          style={{ width: 200 }}
+        />
+      </SearchField>
+      <SearchField label="Path">
+        <PGInput
+          value={pathQ}
+          onChange={onPathQ}
+          placeholder="src/foo.ts"
+          icon="file"
+          size="sm"
+          mono
+          style={{ width: 220 }}
+        />
+      </SearchField>
+      <SearchField label="Since">
+        <PGInput
+          type="date"
+          value={sinceDate}
+          onChange={onSinceDate}
+          size="sm"
+          style={{ width: 150 }}
+        />
+      </SearchField>
+      <SearchField label="Until">
+        <PGInput
+          type="date"
+          value={untilDate}
+          onChange={onUntilDate}
+          size="sm"
+          style={{ width: 150 }}
+        />
+      </SearchField>
+    </div>
   );
 }
 


### PR DESCRIPTION
## What

Commit/log search in History UI — P0 from `features.md`. Filter by message, author (name/email), SHA prefix, date range, and path. Backend-filtered for correctness/scale.

Debounced (250ms) search bar + advanced panel (author/path/date inputs), match count + clear. Free-text qualifiers: `author:`/`path:`/`sha:`/`since:`/`until:`/`message:` (plus aliases by/file/commit/after/before/msg); lone hex token → sha prefix.

## How

Standard backend path:
- `LogFilter` struct (`types.rs`) + `GitBackend::log_filtered`.
- libgit2 revwalk: ANDs dimensions, cheap checks first (sha/date/author/message) then path via tree-diff pathspec; unborn-HEAD detected up front; empty filter delegates to `log`. Limit caps matching commits.
- `cli.rs` stub; `get_log_filtered` command; registered in `invoke_handler!`.
- Frontend: `LogFilter` type 1:1 with Rust, `getLogFiltered` wrapper, pure `parseQueryText`/`buildLogFilter` in `features/commits/logFilter.ts`, `searchCommits` store action (separate from full log so client toggles still work; stale-response guard). Filtered results render through existing graph layout.

## Tests

- `pnpm tsc --noEmit` ✅
- `pnpm test` ✅ (18 logFilter pure-logic)
- `pnpm vite build` ✅
- `cargo check` / `cargo test` ✅ (10 log_filter integration)

## Follow-ups

Date bounds are local-time day edges; advanced toggle reuses `sort` icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
