### PR TITLE
ci+site: build Windows/Linux bundles and surface them for download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,11 @@ name: release
 
 # Releases are cut by PUBLISHING a GitHub Release: draft it in the UI, pick the
 # vX.Y.Z tag (GitHub creates the tag on publish), then publish when you're sure
-# it's good. Publishing triggers this workflow, which builds the macOS universal
-# .dmg and attaches it to that same release.
+# it's good. Publishing triggers this workflow, which builds per-platform bundles
+# and attaches them to that same release:
+#   - macOS  universal .dmg   (PlatypusGit_universal.dmg)
+#   - Windows x64 .msi         (PlatypusGit_x64.msi)
+#   - Linux  amd64 .deb + .AppImage (PlatypusGit_amd64.deb / .AppImage)
 #
 # Nothing releases on a plain push to main — you control when "latest" moves by
 # choosing when to publish. Mark a release as a "prerelease" to build + attach
@@ -110,4 +113,131 @@ jobs:
         with:
           tag_name: ${{ needs.version.outputs.tag }}
           files: src-tauri/target/universal-apple-darwin/release/bundle/dmg/PlatypusGit_universal.dmg
+          fail_on_unmatched_files: true
+
+  windows:
+    needs: version
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version.outputs.tag }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Inject version ${{ needs.version.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          v="${{ needs.version.outputs.version }}"
+          tmp="$(mktemp)"
+          jq --arg v "$v" '.version = $v' src-tauri/tauri.conf.json > "$tmp" && mv "$tmp" src-tauri/tauri.conf.json
+          jq --arg v "$v" '.version = $v' package.json > "$tmp" && mv "$tmp" package.json
+          sed -i -E "s/^version = \".*\"/version = \"$v\"/" src-tauri/Cargo.toml
+
+      - name: Install frontend deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build app
+        run: pnpm tauri build
+
+      - name: Rename bundle to stable name
+        shell: bash
+        run: |
+          set -euo pipefail
+          msi_dir="src-tauri/target/release/bundle/msi"
+          cp "$(ls "$msi_dir"/*.msi | head -n1)" "$msi_dir/PlatypusGit_x64.msi"
+
+      - name: Attach installer to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.version.outputs.tag }}
+          files: src-tauri/target/release/bundle/msi/PlatypusGit_x64.msi
+          fail_on_unmatched_files: true
+
+  linux:
+    needs: version
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version.outputs.tag }}
+
+      - name: Install system deps
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libgtk-3-dev
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Inject version ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          v="${{ needs.version.outputs.version }}"
+          tmp="$(mktemp)"
+          jq --arg v "$v" '.version = $v' src-tauri/tauri.conf.json > "$tmp" && mv "$tmp" src-tauri/tauri.conf.json
+          jq --arg v "$v" '.version = $v' package.json > "$tmp" && mv "$tmp" package.json
+          sed -i -E "s/^version = \".*\"/version = \"$v\"/" src-tauri/Cargo.toml
+
+      - name: Install frontend deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build app
+        run: pnpm tauri build
+
+      - name: Rename bundles to stable names
+        run: |
+          set -euo pipefail
+          deb_dir="src-tauri/target/release/bundle/deb"
+          appimage_dir="src-tauri/target/release/bundle/appimage"
+          cp "$(ls "$deb_dir"/*.deb | head -n1)" "$deb_dir/PlatypusGit_amd64.deb"
+          cp "$(ls "$appimage_dir"/*.AppImage | head -n1)" "$appimage_dir/PlatypusGit_amd64.AppImage"
+
+      - name: Attach bundles to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.version.outputs.tag }}
+          files: |
+            src-tauri/target/release/bundle/deb/PlatypusGit_amd64.deb
+            src-tauri/target/release/bundle/appimage/PlatypusGit_amd64.AppImage
           fail_on_unmatched_files: true

--- a/site/src/data/site.ts
+++ b/site/src/data/site.ts
@@ -12,12 +12,23 @@ export const site = {
 };
 
 // Per-OS downloads shown on the landing page. `available: false` renders a
-// non-clickable "Coming soon" button. Only macOS ships a build today.
+// non-clickable "Coming soon" button. macOS, Windows, and Linux all ship
+// builds via the release workflow.
 export const downloads = [
   { key: 'macos', label: 'macOS', anchor: '/download#macos', note: 'Apple Silicon & Intel · .dmg', available: true },
-  { key: 'windows', label: 'Windows', anchor: '/download#windows', note: 'Windows 10 & 11 · .msi', available: false },
-  { key: 'linux', label: 'Linux', anchor: '/download#linux', note: '.deb & AppImage', available: false },
+  { key: 'windows', label: 'Windows', anchor: '/download#windows', note: 'Windows 10 & 11 · .msi', available: true },
+  { key: 'linux', label: 'Linux', anchor: '/download#linux', note: '.deb & AppImage', available: true },
 ] as const;
+
+// Direct download links to the stable-named assets the release workflow
+// attaches to every published GitHub Release (releases/latest/download/...).
+const releaseAsset = (file: string) => `${site.releases}/latest/download/${file}`;
+export const assets = {
+  macosDmg: releaseAsset('PlatypusGit_universal.dmg'),
+  windowsMsi: releaseAsset('PlatypusGit_x64.msi'),
+  linuxDeb: releaseAsset('PlatypusGit_amd64.deb'),
+  linuxAppImage: releaseAsset('PlatypusGit_amd64.AppImage'),
+};
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 

--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -3,7 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import CTAButton from '../components/CTAButton.astro';
 import CodeBlock from '../components/CodeBlock.astro';
 import OsIcon from '../components/OsIcon.astro';
-import { site } from '../data/site.ts';
+import { site, assets } from '../data/site.ts';
 
 const buildSteps = `# Prerequisites: Node 22+, pnpm, Rust stable
 #   macOS:   xcode-select --install
@@ -32,9 +32,11 @@ pnpm tauri build   # produces .dmg / .msi / .deb / .AppImage`;
 
   <section class="container">
     <div class="notice">
-      <strong>No published releases yet.</strong> The commands below are the intended install paths;
-      binaries appear on the <a href={site.releases} target="_blank" rel="noopener">Releases page</a>
-      once tagged. Until then, <a href="#build">build from source</a>.
+      <strong>Builds are early pre-releases.</strong> Every published release attaches prebuilt
+      binaries for all three platforms — macOS <code>.dmg</code>, Windows <code>.msi</code>,
+      Linux <code>.deb</code> &amp; <code>.AppImage</code>. Grab the newest from the
+      <a href={site.releases} target="_blank" rel="noopener">Releases page</a>, or
+      <a href="#build">build from source</a>.
     </div>
   </section>
 
@@ -53,7 +55,8 @@ pnpm tauri build   # produces .dmg / .msi / .deb / .AppImage`;
 
     <div class="method">
       <h3>DMG</h3>
-      <p class="method-note">Download the <code>.dmg</code> from <a href={site.releases} target="_blank" rel="noopener">Releases</a> and drag <code>platypusgit.app</code> into <code>/Applications</code>.</p>
+      <p class="method-note">Download the universal <code>.dmg</code> and drag <code>platypusgit.app</code> into <code>/Applications</code>.</p>
+      <CTAButton href={assets.macosDmg} external>Download .dmg</CTAButton>
     </div>
 
     <div class="method">
@@ -72,13 +75,9 @@ pnpm tauri build   # produces .dmg / .msi / .deb / .AppImage`;
     </div>
 
     <div class="method">
-      <h3>winget</h3>
-      <CodeBlock code={'winget install platypusgit'} lang="powershell" />
-    </div>
-
-    <div class="method">
       <h3>Installer (.msi)</h3>
-      <p class="method-note">Download the <code>.msi</code> from <a href={site.releases} target="_blank" rel="noopener">Releases</a> and run it.</p>
+      <p class="method-note">Download the 64-bit <code>.msi</code> and run it.</p>
+      <CTAButton href={assets.windowsMsi} external>Download .msi</CTAButton>
     </div>
 
     <div class="method">
@@ -96,12 +95,16 @@ pnpm tauri build   # produces .dmg / .msi / .deb / .AppImage`;
 
     <div class="method">
       <h3>Debian / Ubuntu (.deb)</h3>
-      <CodeBlock code={'sudo apt install ./platypusgit_0.1.0_amd64.deb'} lang="bash" />
+      <p class="method-note">Download the package, then install it:</p>
+      <CodeBlock code={'sudo apt install ./PlatypusGit_amd64.deb'} lang="bash" />
+      <CTAButton href={assets.linuxDeb} external>Download .deb</CTAButton>
     </div>
 
     <div class="method">
       <h3>AppImage (portable)</h3>
-      <CodeBlock code={'chmod +x platypusgit_0.1.0_amd64.AppImage\n./platypusgit_0.1.0_amd64.AppImage'} lang="bash" />
+      <p class="method-note">Download, make it executable, and run — no install needed:</p>
+      <CodeBlock code={'chmod +x PlatypusGit_amd64.AppImage\n./PlatypusGit_amd64.AppImage'} lang="bash" />
+      <CTAButton href={assets.linuxAppImage} external>Download .AppImage</CTAButton>
     </div>
   </section>
 


### PR DESCRIPTION
## What

**CI** — add `windows` and `linux` jobs to `.github/workflows/release.yml` beside `macos-universal`. Publishing a GitHub Release now attaches per-platform bundles.

| Platform | Runner | Asset |
|----------|--------|-------|
| macOS | `macos-14` | `PlatypusGit_universal.dmg` (unchanged) |
| Windows | `windows-latest` | `PlatypusGit_x64.msi` |
| Linux | `ubuntu-22.04` | `PlatypusGit_amd64.deb`, `PlatypusGit_amd64.AppImage` |

**Site** — reflect the new platforms on the marketing site:
- flip Windows/Linux `available` flags on the landing download cards (were "Coming soon")
- add an `assets` helper mapping to `releases/latest/download/<stable-name>`
- replace placeholder winget/apt filenames with real stable-named direct-download buttons
- refresh the download-page notice to describe per-platform binaries

## Notes

- All CI jobs fan out from the shared `version` job, same version-injection pattern.
- Win/Linux use GNU `sed -i`; Windows inject runs under `shell: bash` so git-bash sed works. macOS job untouched.
- Linux pinned to `ubuntu-22.04` — 24.04 renames `webkit2gtk-4.1` packages and breaks AppImage tooling.
- Bundle targets are `msi, dmg, deb, appimage` (no NSIS) so Windows ships `.msi` only. Add `"nsis"` later for a `.exe`.
- Direct-download links point at `releases/latest/download/...`; they resolve once a non-prerelease is published carrying the new stable-named assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)