### PR TITLE
ci(release): also trigger on release 'released' event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,12 @@ name: release
 
 on:
   release:
-    types: [published]
+    # published: initial publish of a release/prerelease.
+    # released:  a prerelease flipped to a full release (promotion) — this
+    #            event does NOT re-fire published, so it's needed for the
+    #            "publish prerelease, then flip off prerelease to promote"
+    #            flow to build + bump the cask.
+    types: [published, released]
   workflow_dispatch: # re-run a build against an existing release tag
     inputs:
       tag:


### PR DESCRIPTION
## Why

Flipping a published prerelease → full release fires the **\`released\`** event, **not \`published\`**. The workflow only listened to \`published\`, so the documented "publish prerelease, then flip off prerelease to promote" flow never rebuilt or bumped the cask.

## Change

Add \`released\` to \`on.release.types\`.

## Trigger matrix

| Action | Events | Build | bump-cask |
|---|---|---|---|
| Publish prerelease | \`published\` (prerelease) | ✅ once | skipped (guard) |
| Flip prerelease → release | \`released\` | ✅ once | ✅ |
| Publish non-prerelease directly | \`published\` + \`released\` | runs twice | runs twice (2nd no-ops via \`git diff --quiet\`) |

Double-run only on direct non-prerelease publish; the recommended prerelease-then-flip flow fires once. Concurrency group serializes runs; bump-cask is idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)