### PR TITLE
docs: use fully-qualified Homebrew cask for macOS install

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,12 @@ A dev-first alternative to TortoiseGit with "extreme usability" as the north sta
 ### macOS (Homebrew)
 
 ```bash
-brew tap jonassaa/platypusgit
-brew install --cask --no-quarantine platypusgit
+brew install --cask jonassaa/platypusgit/platypusgit
 ```
 
-The app is ad-hoc signed but not notarized. `--no-quarantine` skips the macOS
-Gatekeeper flag so it launches with no "unidentified developer" prompt (no
-`brew trust` needed). Update with `brew upgrade --cask --greedy platypusgit`.
+The app is ad-hoc signed but not notarized. The cask clears the macOS
+Gatekeeper quarantine flag on install, so it launches with no "unidentified
+developer" prompt. Update with `brew upgrade --cask --greedy platypusgit`.
 
 ### Other platforms
 

--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -49,8 +49,8 @@ pnpm tauri build   # produces .dmg / .msi / .deb / .AppImage`;
 
     <div class="method">
       <h3>Homebrew</h3>
-      <CodeBlock code={'brew install --cask --no-quarantine jonassaa/platypusgit/platypusgit'} lang="bash" />
-      <p class="method-note">The app is ad-hoc signed but not notarized. <code>--no-quarantine</code> skips the macOS Gatekeeper flag so it launches with no "unidentified developer" prompt.</p>
+      <CodeBlock code={'brew install --cask jonassaa/platypusgit/platypusgit'} lang="bash" />
+      <p class="method-note">The app is ad-hoc signed but not notarized. The cask clears the macOS Gatekeeper quarantine flag on install, so it launches with no "unidentified developer" prompt.</p>
     </div>
 
     <div class="method">
@@ -61,7 +61,7 @@ pnpm tauri build   # produces .dmg / .msi / .deb / .AppImage`;
 
     <div class="method">
       <h3>First launch — DMG, unsigned build</h3>
-      <p class="method-note">DMG installs aren't notarized, so on first launch macOS may say the app is damaged or from an unidentified developer. Clear the quarantine flag (Homebrew's <code>--no-quarantine</code> already handles this):</p>
+      <p class="method-note">DMG installs aren't notarized, so on first launch macOS may say the app is damaged or from an unidentified developer. Clear the quarantine flag (the Homebrew cask already handles this):</p>
       <CodeBlock code={'xattr -cr /Applications/platypusgit.app'} lang="bash" />
       <p class="method-note">Or: <strong>System Settings → Privacy &amp; Security → Open Anyway</strong> for platypusgit.</p>
     </div>


### PR DESCRIPTION
Switch macOS install instructions to the fully-qualified cask command across README and the site download page.

## Changes
- `brew install --cask jonassaa/platypusgit/platypusgit` — single command, drops the separate `brew tap` step and the `--no-quarantine` flag.
- Prose updated: the cask clears the Gatekeeper quarantine flag itself, so no `--no-quarantine` needed.
- Fixed stale `--no-quarantine` mention in the DMG first-launch note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)