### PR TITLE
fix(status): dedicated error for embedded git repos instead of broken diff/stage

### DIFF
--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -44,6 +44,9 @@ pub enum AppError {
 
     #[error("network error: {0}")]
     Network(String),
+
+    #[error("'{0}' contains its own .git directory (embedded/nested repository) and can't be diffed or staged as a file — add it as a submodule or add it to .gitignore")]
+    EmbeddedRepo(String),
 }
 
 impl From<git2::Error> for AppError {

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -285,6 +285,14 @@ enum StatusSide {
     Index,
 }
 
+/// libgit2 reports an untracked directory that is itself a git repository
+/// (e.g. an unregistered submodule) as a single status entry whose path ends
+/// in `/`, since it won't recurse across a nested repo boundary. Such entries
+/// aren't diffable or stageable as a regular file.
+fn is_embedded_repo_path(p: &Path) -> bool {
+    p.to_string_lossy().ends_with('/')
+}
+
 fn map_status_flag(s: Status, side: StatusSide) -> StatusFlag {
     match side {
         StatusSide::Worktree => {
@@ -855,6 +863,9 @@ impl GitBackend for Libgit2Backend {
     }
 
     fn diff(&self, repo_id: &RepoId, path: &Path, kind: DiffKind) -> AppResult<FileDiff> {
+        if is_embedded_repo_path(path) {
+            return Err(AppError::EmbeddedRepo(path.to_string_lossy().to_string()));
+        }
         self.with_repo(repo_id, |repo| {
             let mut opts = DiffOptions::new();
             opts.pathspec(path);
@@ -1270,6 +1281,9 @@ impl GitBackend for Libgit2Backend {
     }
 
     fn stage(&self, repo_id: &RepoId, paths: &[PathBuf]) -> AppResult<()> {
+        if let Some(p) = paths.iter().find(|p| is_embedded_repo_path(p)) {
+            return Err(AppError::EmbeddedRepo(p.to_string_lossy().to_string()));
+        }
         self.with_repo(repo_id, |repo| {
             let mut index = repo.index()?;
             for p in paths {

--- a/src-tauri/tests/embedded_repo.rs
+++ b/src-tauri/tests/embedded_repo.rs
@@ -1,0 +1,57 @@
+mod support;
+
+use std::path::PathBuf;
+
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::types::DiffKind;
+use platypusgit_lib::git::GitBackend;
+
+use support::TempRepo;
+
+/// An untracked directory that is itself a git repo (e.g. a dependency
+/// vendored with its own `.git`, never registered as a submodule) shows up
+/// in status as a single entry with a trailing slash, since libgit2 won't
+/// recurse across the nested repo boundary. Diffing or staging it as if it
+/// were a regular file must fail with a clear, dedicated error rather than
+/// silently no-op-ing (diff) or bubbling up a cryptic libgit2 message (stage).
+fn make_nested_repo(tr: &TempRepo) -> String {
+    let nested_dir = tr.path().join("vendor/lib");
+    std::fs::create_dir_all(&nested_dir).unwrap();
+    git2::Repository::init(&nested_dir).unwrap();
+    std::fs::write(nested_dir.join("file.txt"), "content\n").unwrap();
+    "vendor/lib/".to_string()
+}
+
+#[test]
+fn status_reports_nested_repo_with_trailing_slash() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let expected_path = make_nested_repo(&tr);
+
+    let statuses = backend.status(&handle.id).unwrap();
+    assert!(statuses.iter().any(|s| s.path == expected_path));
+}
+
+#[test]
+fn diff_on_embedded_repo_returns_dedicated_error() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let path = make_nested_repo(&tr);
+
+    let err = backend
+        .diff(&handle.id, &PathBuf::from(&path), DiffKind::WorktreeToIndex)
+        .unwrap_err();
+    assert!(matches!(err, AppError::EmbeddedRepo(p) if p == path));
+}
+
+#[test]
+fn stage_on_embedded_repo_returns_dedicated_error() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let path = make_nested_repo(&tr);
+
+    let err = backend
+        .stage(&handle.id, &[PathBuf::from(&path)])
+        .unwrap_err();
+    assert!(matches!(err, AppError::EmbeddedRepo(p) if p == path));
+}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -12,7 +12,8 @@ export type AppError =
   | { kind: "ConflictsDetected"; message: string }
   | { kind: "NoSignature"; message?: string }
   | { kind: "Internal"; message: string }
-  | { kind: "Network"; message: string };
+  | { kind: "Network"; message: string }
+  | { kind: "EmbeddedRepo"; message: string };
 
 export function isAppError(e: unknown): e is AppError {
   return (

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -16,6 +16,7 @@ import {
   PGStatusMark,
   PGToolbar,
   KV,
+  pgFlash,
   useContextMenu,
   usePaneWidth,
   type ContextMenuItem,
@@ -29,6 +30,7 @@ import {
   relativeTime,
   statusMark,
 } from "@/lib/derive";
+import { appErrorMessage } from "@/lib/errors";
 import { highlightFile } from "@/lib/highlight";
 import { getDiff, readFileContent } from "@/lib/tauri";
 import { buildStatusTree } from "@/lib/tree";
@@ -197,17 +199,17 @@ export function RepoBrowserScreen() {
 
   // Derive the FileStatus entry that corresponds to the selected path key.
   // PGFileTree keys are path-prefixed by PG_FILETREE in the form "/a/b/c".
+  // buildStatusTree() drops empty path segments, so an embedded-repo entry
+  // (FileStatus.path ending in "/") loses its trailing slash in the key —
+  // fall back to matching it with the slash restored.
   const selectedFile = React.useMemo<FileStatus | null>(() => {
     if (!selected) return null;
     const path = selected.replace(/^\//, "");
+    const matches = (s: FileStatus) => s.path === path || s.path === `${path}/`;
     if (browsingRev) {
-      return revFiles.find((s) => s.path === path) ?? null;
+      return revFiles.find(matches) ?? null;
     }
-    return (
-      status.find((s) => s.path === path) ??
-      allFiles.find((s) => s.path === path) ??
-      null
-    );
+    return status.find(matches) ?? allFiles.find(matches) ?? null;
   }, [selected, status, allFiles, browsingRev, revFiles]);
 
   const selectedIsUnmodified =
@@ -251,8 +253,11 @@ export function RepoBrowserScreen() {
         .then((d) => {
           if (!cancelled) setDiff(d);
         })
-        .catch(() => {
-          if (!cancelled) setDiff(null);
+        .catch((e) => {
+          if (!cancelled) {
+            setDiff(null);
+            pgFlash(appErrorMessage(e));
+          }
         })
         .finally(() => {
           if (!cancelled) setDiffLoading(false);


### PR DESCRIPTION
## Summary
- Untracked dirs that are themselves git repos (vendored deps, unregistered submodules) get a status entry with a trailing slash — libgit2 won't recurse across the nested `.git` boundary. Diffing silently returned an empty diff; staging bubbled up a cryptic libgit2 "invalid path" error.
- Added `AppError::EmbeddedRepo` and short-circuit `diff()`/`stage()` to it before hitting libgit2, mirrored to `errors.ts`.
- Fixed `RepoBrowser`'s selection lookup, which stripped the trailing slash when building tree keys and could never match the entry back to its `FileStatus` (selection silently did nothing for these entries).

## Test plan
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — full suite green, including new `embedded_repo.rs` (3 tests)
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm test` — 96/96 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)