### PR TITLE
test(e2e): danger-ops suite, phase 2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,8 +57,8 @@ Four layers, each run independently:
   `src/`. Runs in jsdom with React Testing Library. The Tauri `invoke` and
   `plugin-dialog.open` calls are mocked via `src/test/setup.ts`; tests register
   per-command responses with `mockInvoke(cmd, handler)`.
-- **E2E (webview-level)** — WebdriverIO specs in `e2e/specs/` (6 files, 10
-  tests, ~6s spec time locally) drive the real debug binary: real webview →
+- **E2E (webview-level)** — WebdriverIO specs in `e2e/specs/` (10 files, 23
+  tests — 22 passing + 1 skipped pending #27) drive the real debug binary: real webview →
   real Tauri IPC → real libgit2 → temp repos built by `e2e/support/tempRepo.ts`.
   Uses the embedded WebDriver provider (`@wdio/tauri-service`) — no external
   driver or paid service — so it runs on macOS (WKWebView) and on Linux CI
@@ -76,8 +76,14 @@ Four layers, each run independently:
     Skip either piece and every driver command pays a 5s window-focus-check
     penalty (a ~13min suite instead of ~6s).
   - The driver can't synthesize a right-click: context menus are opened via
-    the in-page `jsContextMenu` helper (see `e2e/specs/status-stage.e2e.ts`);
+    the in-page `jsContextMenu` helper (see `e2e/support/app.ts`);
     everything else uses real WebDriver clicks.
+  - Danger-op flows (merge/conflict, rebase, reset, cherry-pick/revert,
+    reflog) covered by phase 2 specs. Context menus (incl. the reset hover
+    submenu) driven via `jsContextMenu`/`jsHoverMenuItem`/`jsClickMenuItem`
+    and row lookups via `changeRow`/`stagedRow`, all promoted to
+    `e2e/support/app.ts`. Fixtures: `conflictRepo`, `cherryRepo`,
+    `rebaseConflictRepo`, plus `TempRepo.hasRef`.
   - Selector conventions: `button*=Text` (PGButton span-wraps its label, so
     bare button-text selectors don't match) and tag-scoped text selectors
     (`div*=`, `span*=` — bare `*=` is partial-link-text and only matches

--- a/docs/superpowers/plans/2026-07-02-e2e-phase2.md
+++ b/docs/superpowers/plans/2026-07-02-e2e-phase2.md
@@ -1,0 +1,766 @@
+# E2E Phase 2 (Danger Ops) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Webview E2E coverage for merge/conflict, rebase, reset, cherry-pick/revert, and reflog flows, plus the `refreshAll`-on-error store fix that makes conflicted merges visible without manual refresh.
+
+**Architecture:** Builds on the Phase 1 harness (WDIO embedded provider, `e2e/support/` helpers, temp-repo fixtures). New conflict/cherry/rebase-conflict fixtures; sparse test attributes on Conflict/Rebase/History components; one behavioral fix in `useRepoStore`. Context menus (including the reset hover-submenu) driven by in-page helpers promoted to `e2e/support/`.
+
+**Tech Stack:** WebdriverIO v9, existing `@wdio/tauri-service` embedded provider stack, TypeScript, git CLI fixtures.
+
+**Spec:** `docs/superpowers/specs/2026-07-02-e2e-phase2-design.md`
+
+## Global Constraints
+
+- Branch: `test/e2e-phase2` (exists, spec committed). Never commit to `main`.
+- App changes: the ONE behavioral fix (refreshAll on merge/rebase error) + additive `data-*` attributes. Nothing else.
+- Selector conventions (established Phase 1 — violations get review-rejected): `button*=Text` (PGButton span-wraps labels); tag-scoped text selectors (`div*=`, `span*=`; bare `*=` matches anchors only); attr+text combos like `[data-branch-row]*=name` are valid; all waits carry `timeout` + `timeoutMsg`; never `pause()`; extensionless e2e imports.
+- Repo truth (`repo.git(...)`, `repo.read(...)`) is the acceptance criterion as plain `expect`s after a UI wait. Exception (Phase 1 precedent): repo-truth polling inside `waitUntil` is allowed where no UI signal exists — document each use in a comment.
+- `stubNativeDialogs({promptText, confirm})` must be called AFTER the last page (re)load (openRepo/refresh reset stubs) and BEFORE the click that triggers prompt/confirm.
+- Rebuild discipline: any `src/` change → full `pnpm test:e2e` (~3 min, Bash timeout 600000) is the ONLY valid verification; spec-only iterations may use `pnpm test:e2e:run`. Final verification of every task = the run appropriate to what changed, PASTED into the report (asserted counts = rejection).
+- Guard rails every task: `pnpm tsc --noEmit`, `pnpm exec tsc -p e2e/tsconfig.json --noEmit`, `pnpm test` (96 vitest).
+- Bash first line: `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"`.
+- Debug builds serve WebDriver on port 4445 — no dev app running during e2e.
+- Conventional Commits; squash-to-one before merge; PR + CI green before ready.
+
+## Facts from planning investigation (trust; verify only if something contradicts)
+
+- Merge triggers: BranchPicker rows (`[data-branch-row]`, `src/features/branches/BranchPicker.tsx:154-160`) have a context menu with "Merge into current" (`context-menu.tsx:515-528`), gated by `window.confirm`. Picker opens via `[data-testid="branch-chip"]`.
+- Conflicted-merge defect: `mergeBranch`/`rebaseOnto` catch arms in `src/features/repo/useRepoStore.ts` (~line 519-528) set `error` but skip the refresh the success path does — Conflicts screen (`conflict` activity id), status-bar badge (`AppShell.tsx:514-519`, text "N conflicts"), and `repoState` stay stale.
+- Conflict screen (`src/screens/Conflict.tsx`): file rows `PGConflictRow` (`git-components.tsx:1269`, name in span at :1362, NO data attrs yet); header has `Abort` (:159, window.confirm-gated) and `Finalize` (:175, disabled while unresolved>0); detail action bar `Accept ours` (:316) / `Accept theirs` (:324) / `Mark worktree as resolved` (:332). Empty state "No conflicts".
+- Rebase: started from History commit context menu — "Squash this commit into its parent" (`context-menu.tsx:448-467`, window.prompt for message) fires a `rebase-plan` NavIntent; AppShell auto-switches to the rebase screen (`AppShell.tsx:180-182`). Plan rows `PGRebaseRow` (`git-components.tsx:1561`) contain a native `<select>` (options pick/reword/edit/squash/fixup/drop). Toolbar `Start rebase` (`Rebase.tsx:280-288`); running banner (`Rebase.tsx:36-99`) shows conflict text + `Abort`/`Continue` buttons.
+- History: commit rows carry `data-testid="commit-row"` + `data-sha` (short sha as displayed). Detail panel `CommitActionRow` (`History.tsx:366-423`): `Cherry-pick` (:407, window.confirm) and `Revert` (:410, window.confirm) PGButtons. Context menu has "Reset current branch to here" SUBMENU (`context-menu.tsx:408-430`) — opens on parent-item hover (`context-menu.tsx:57-67`), children "Soft (keep changes staged)" / "Mixed (keep changes unstaged)" / "Hard (discard changes)", no confirm.
+- Context menus are React portals rendering `<div>` items with the label in an inner `<span>` — clickable by text after `jsContextMenu` opens them (right-click can't be synthesized by the driver).
+- Reflog (`src/screens/Reflog.tsx`): rows are `PGCommitRow` (same testid as History — no runtime collision, AppShell mounts one screen at a time); `Go to this point` button (:255) → `ReflogActionDialog` (`role="dialog"`, options as clickable labeled rows: "Reset branch here" / "Check out (detached)" / "Create a new branch here", footer `Cancel`/`Go`); dirty tree + jump → `DirtyTreeDialog` (`role="dialog"`, buttons "Stash them (auto-named)" / "Commit first — I'll do it manually" / "Discard them…" / `Cancel`). Dirtiness read from store `status` — file must be dirty BEFORE `openRepo` (or refresh) for the gate to fire.
+- `useReflogStore` has its own `role="alert"` error banner inside the screen; app-level banner is `AppShell.tsx:221-251` (also `role="alert"`).
+- Phase 1 helpers in `e2e/support/app.ts`: `armDriverBridge`, `resetApp`, `waitRepoLoaded`, `openRepo`, `stubNativeDialogs`, `switchScreen`. `jsContextMenu` is currently a local const in `e2e/specs/status-stage.e2e.ts:28`.
+
+## File structure
+
+```
+e2e/support/app.ts          + jsContextMenu, jsHoverMenuItem, jsClickMenuItem,
+                              changeRow, stagedRow (promoted/new helpers)
+e2e/support/tempRepo.ts     + conflictRepo, cherryRepo, rebaseConflictRepo, hasRef
+e2e/specs/merge-conflict.e2e.ts   tests 1-5
+e2e/specs/rebase.e2e.ts           tests 6-7
+e2e/specs/history-ops.e2e.ts      tests 8-11
+e2e/specs/reflog.e2e.ts           tests 12-13
+src/features/repo/useRepoStore.ts   refreshAll-on-error fix
+src/design/git-components.tsx       PGConflictRow + PGRebaseRow attrs; stash row data-stash-index
+src/screens/Conflict.tsx            button testids
+src/screens/Rebase.tsx              button testids
+src/screens/History.tsx             CommitActionRow testids
+src/screens/Branches.tsx            stash row index attr (if row lives here, see Task 1)
+package.json                        @types/node ^22
+```
+
+---
+
+### Task 1: Support-helper cleanup + ride-alongs
+
+**Files:**
+- Modify: `e2e/support/app.ts`
+- Modify: `e2e/specs/status-stage.e2e.ts` (remove local helpers, import from support)
+- Modify: `e2e/specs/commit.e2e.ts`, `e2e/specs/stash.e2e.ts` (row-factory imports)
+- Modify: `package.json` (@types/node)
+- Modify: stash row component — find it first: `grep -n "stash@{" src/screens/Branches.tsx` (~line 490 renders the row text; the row container gets the attr)
+
+**Interfaces:**
+- Produces (later tasks import these from `../support/app`):
+  - `changeRow(p: string)` / `stagedRow(p: string)` — WDIO chainable for `[data-testid="changes-list"] [data-path="${p}"]` / staged-list equivalent.
+  - `jsContextMenu(selector: string): Promise<void>` — open app context menu on the element matching a CSS selector (moved verbatim from status-stage spec).
+  - `jsClickMenuItem(label: string): Promise<void>` — click an open menu's item whose label-span text === label (moved/unified from status-stage spec's local helpers).
+  - `jsHoverMenuItem(label: string): Promise<void>` — NEW: dispatch `mouseenter` (bubbles) on the menu item whose label-span text === label, to open its hover-submenu. Implementation mirrors jsClickMenuItem but dispatches `new MouseEvent("mouseenter", {bubbles: true})` (also dispatch `mouseover` — React's onMouseEnter uses mouseover delegation) instead of `.click()`.
+  - DOM: `[data-stash-index="<n>"]` on Branches stash rows.
+
+- [ ] **Step 1: Promote helpers**
+
+Move `jsContextMenu` + menu-item click helper from `e2e/specs/status-stage.e2e.ts` into `e2e/support/app.ts` (exported, code unchanged apart from export). Add `jsHoverMenuItem` beside them:
+
+```typescript
+/** Hover a context-menu item to open its submenu (menus are portals; the
+ *  driver can't hover, so dispatch the events React listens for). */
+export async function jsHoverMenuItem(label: string): Promise<void> {
+  const ok = await browser.execute((text: string) => {
+    const spans = Array.from(document.querySelectorAll("span"));
+    const el = spans.find((s) => s.textContent === text);
+    if (!el) return false;
+    const target = el.closest("div") ?? el;
+    target.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    target.dispatchEvent(new MouseEvent("mouseenter", { bubbles: false }));
+    return true;
+  }, label);
+  if (!ok) throw new Error(`menu item not found for hover: ${label}`);
+}
+```
+
+(If the existing local click-helper differs in shape, keep ITS proven implementation and pattern-match `jsHoverMenuItem` to it. If `mouseenter`/`mouseover` fails to open the submenu when Task 5 consumes this, inspect `context-menu.tsx:57-67` for the actual handler and dispatch that event — fix lives here, not in specs.)
+
+Add row factories:
+
+```typescript
+export const changeRow = (p: string) =>
+  $(`[data-testid="changes-list"] [data-path="${p}"]`);
+export const stagedRow = (p: string) =>
+  $(`[data-testid="staged-list"] [data-path="${p}"]`);
+```
+
+- [ ] **Step 2: Update consuming specs**
+
+`status-stage.e2e.ts`: delete local copies, import `{ jsContextMenu, jsClickMenuItem, changeRow, stagedRow }` from `../support/app`. `commit.e2e.ts` / `stash.e2e.ts`: replace local row-factory consts with the import. No behavioral edits.
+
+- [ ] **Step 3: data-stash-index + @types/node**
+
+Find the stash row container in `src/screens/Branches.tsx` (renders `stash@{index}` text, ~line 490): add `data-stash-index={index}` (or whatever the loop variable is named — additive attribute only). `package.json`: `"@types/node": "^22"` then `pnpm install`.
+
+- [ ] **Step 4: Verify + commit**
+
+```bash
+pnpm test:e2e          # src changed (Branches.tsx) → full rebuild; expect 10/10
+pnpm tsc --noEmit && pnpm exec tsc -p e2e/tsconfig.json --noEmit && pnpm test
+git add -A e2e/ src/screens/Branches.tsx package.json pnpm-lock.yaml
+git commit -m "test(e2e): promote menu/row helpers to support, phase 1 ride-alongs"
+```
+
+---
+
+### Task 2: Store fix + conflict/cherry fixtures + merge specs (tests 1-2)
+
+**Files:**
+- Modify: `e2e/support/tempRepo.ts`
+- Modify: `src/features/repo/useRepoStore.ts` (~lines 519-528 and the `rebaseOnto` sibling)
+- Modify: `src/design/git-components.tsx` (`PGConflictRow` ~line 1269)
+- Create: `e2e/specs/merge-conflict.e2e.ts`
+
+**Interfaces:**
+- Consumes: `openRepo`, `stubNativeDialogs`, `switchScreen`, `jsContextMenu`, `jsClickMenuItem` from Task 1.
+- Produces:
+  - `conflictRepo(): TempRepo` — main+`clash` both edit `conflict.txt`; merging clash conflicts. Committed contents: main "ours change\n", clash "theirs change\n", base "base\n".
+  - `cherryRepo(): TempRepo` — basicRepo + unmerged branch `feature` holding one commit "feat: cherry commit" adding `cherry.txt` ("cherry\n"); `main` checked out.
+  - `TempRepo.hasRef(ref: string): boolean`.
+  - DOM: `[data-testid="conflict-row"][data-path]`.
+  - Spec-local helper `startConflictedMerge()` (Tasks 3 reuses within same file).
+
+- [ ] **Step 1: Fixtures**
+
+Append to `e2e/support/tempRepo.ts`:
+
+```typescript
+export function conflictRepo(): TempRepo {
+  const r = new TempRepo();
+  r.commitFile("conflict.txt", "base\n", "feat: base");
+  r.git("checkout", "-b", "clash");
+  r.commitFile("conflict.txt", "theirs change\n", "feat: clash edit");
+  r.git("checkout", "main");
+  r.commitFile("conflict.txt", "ours change\n", "feat: main edit");
+  return r; // merging clash into main conflicts on conflict.txt
+}
+
+export function cherryRepo(): TempRepo {
+  const r = basicRepo();
+  r.git("checkout", "-b", "feature");
+  r.commitFile("cherry.txt", "cherry\n", "feat: cherry commit");
+  r.git("checkout", "main");
+  return r; // feature is one unmerged commit ahead of shared history
+}
+```
+
+And on the `TempRepo` class:
+
+```typescript
+hasRef(ref: string): boolean {
+  try {
+    this.git("rev-parse", "-q", "--verify", ref);
+    return true;
+  } catch {
+    return false;
+  }
+}
+```
+
+- [ ] **Step 2: PGConflictRow attributes**
+
+`src/design/git-components.tsx` `PGConflictRow` (~1269): on the root div add `data-testid="conflict-row"` and `data-path={path}` (component receives the file path — check its props; it renders the name at ~1362).
+
+- [ ] **Step 3: Write the failing test (RED — proves the defect)**
+
+`e2e/specs/merge-conflict.e2e.ts`:
+
+```typescript
+import { browser, $, expect } from "@wdio/globals";
+import { conflictRepo, cherryRepo, TempRepo } from "../support/tempRepo";
+import {
+  openRepo, resetApp, switchScreen, stubNativeDialogs,
+  jsContextMenu, jsClickMenuItem,
+} from "../support/app";
+
+/** Open picker, context-menu the branch row, click "Merge into current".
+ *  window.confirm must already be stubbed. */
+async function mergeBranchViaPicker(name: string): Promise<void> {
+  await $('[data-testid="branch-chip"]').click();
+  const row = $(`[data-branch-row]*=${name}`);
+  await row.waitForDisplayed({ timeout: 10_000, timeoutMsg: `branch row ${name} missing` });
+  await jsContextMenu(`[data-branch-row]`); // see note below
+  await jsClickMenuItem("Merge into current");
+}
+
+describe("merge & conflict", () => {
+  let repo: TempRepo;
+
+  afterEach(async () => {
+    await resetApp();
+    repo.dispose();
+  });
+
+  it("merges a branch cleanly from the branch picker", async () => {
+    repo = cherryRepo();
+    await openRepo(repo.path);
+    await stubNativeDialogs({ confirm: true });
+    await mergeBranchViaPicker("feature");
+    await browser.waitUntil(
+      async () => repo.git("log", "-1", "--pretty=%s").includes("Merge branch"),
+      { timeout: 20_000, timeoutMsg: "merge commit never appeared" },
+    ); // repo-truth wait: no dedicated UI signal for merge completion
+    expect(repo.git("status", "--porcelain").trim()).toBe("");
+    expect(repo.read("cherry.txt")).toBe("cherry\n");
+  });
+
+  it("shows conflict state immediately when a merge conflicts", async () => {
+    repo = conflictRepo();
+    await openRepo(repo.path);
+    await stubNativeDialogs({ confirm: true });
+    await mergeBranchViaPicker("clash");
+    // error banner appears...
+    await $('[role="alert"]').waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "error banner never appeared",
+    });
+    // ...AND conflict state is visible WITHOUT any manual refresh:
+    await switchScreen("conflict");
+    await $('[data-testid="conflict-row"][data-path="conflict.txt"]').waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "conflict row not shown — refreshAll-on-error fix missing?",
+    });
+    expect(repo.hasRef("MERGE_HEAD")).toBe(true);
+  });
+});
+```
+
+`jsContextMenu` selector note: `[data-branch-row]` alone matches the first row — if the target branch isn't first, extend `jsContextMenu` usage with the attr+text form (`[data-branch-row]*=` is a WDIO text selector, not CSS, so the in-page helper needs a CSS-only selector). Practical approach: give the in-page helper a CSS selector plus optional exact row text — e.g. extend `jsContextMenu(selector, {text})` in `e2e/support/app.ts` to pick the matching element whose textContent includes `text`. Implement that extension in this task (it lives in support, Task 1 owns the file but this task may extend it — additive).
+
+- [ ] **Step 4: RED run**
+
+```bash
+pnpm test:e2e   # rebuild (PGConflictRow changed)
+```
+
+Expected: test 1 PASSES; test 2 FAILS at the conflict-row wait with the timeoutMsg naming the missing fix (banner appears, conflict row doesn't — store never refreshed). If test 2 fails EARLIER (banner missing, menu item missing), fix the flow first — the RED must be the documented defect, not harness breakage.
+
+- [ ] **Step 5: The store fix (GREEN)**
+
+In `src/features/repo/useRepoStore.ts`, `mergeBranch` catch (~:519-528): after recording the error, run the same refresh the success path runs (read the surrounding code — there's a `refreshAll`/equivalent used on success; call it in the catch too, awaited, still surfacing the original error state). Apply the identical pattern to `rebaseOnto`'s catch. Keep the diff minimal — no restructuring.
+
+- [ ] **Step 6: GREEN run + guard rails + commit**
+
+```bash
+pnpm test:e2e   # rebuild (store changed); expect 12/12
+pnpm tsc --noEmit && pnpm exec tsc -p e2e/tsconfig.json --noEmit && pnpm test
+git add e2e/ src/features/repo/useRepoStore.ts src/design/git-components.tsx
+git commit -m "fix(repo): refresh state when merge/rebase fails
+
+Why: conflicted merge left Conflicts screen and status badge stale until
+manual refresh; error path now refreshes like the success path. Covered by
+merge-conflict e2e spec.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+(Include the vitest store test IF one exists for mergeBranch — check `src/features/repo/*.test.ts`; if none exists, do not create one — the e2e covers it.)
+
+---
+
+### Task 3: Conflict resolution + abort (tests 3-5)
+
+**Files:**
+- Modify: `src/screens/Conflict.tsx` (button testids)
+- Modify: `e2e/specs/merge-conflict.e2e.ts` (3 more tests)
+
+**Interfaces:**
+- Consumes: `conflictRepo`, `hasRef`, `mergeBranchViaPicker` (same spec file), conflict-row attr from Task 2.
+- Produces: DOM testids `conflict-abort`, `conflict-finalize`, `accept-ours`, `accept-theirs`, `mark-resolved`.
+
+- [ ] **Step 1: Testids**
+
+`src/screens/Conflict.tsx` — add to the PGButtons (PGButton spreads rest):
+- Abort (~:159): `data-testid="conflict-abort"`
+- Finalize (~:175): `data-testid="conflict-finalize"`
+- Accept ours (~:316): `data-testid="accept-ours"`
+- Accept theirs (~:324): `data-testid="accept-theirs"`
+- Mark worktree as resolved (~:332): `data-testid="mark-resolved"`
+(The binary-file variant at ~:233-267 has its own Accept buttons — leave them; tests use the text-file path.)
+
+- [ ] **Step 2: Extend spec**
+
+Add to `merge-conflict.e2e.ts` (inside the same describe; extract the shared setup):
+
+```typescript
+/** conflictRepo + open + stub + merge clash → wait for conflict row. */
+async function startConflictedMerge(repo: TempRepo): Promise<void> {
+  await openRepo(repo.path);
+  await stubNativeDialogs({ confirm: true });
+  await mergeBranchViaPicker("clash");
+  await switchScreen("conflict");
+  await $('[data-testid="conflict-row"][data-path="conflict.txt"]').waitForDisplayed({
+    timeout: 20_000, timeoutMsg: "conflicted merge did not surface",
+  });
+}
+
+it("resolves with accept-ours and finalizes the merge", async () => {
+  repo = conflictRepo();
+  await startConflictedMerge(repo);
+  await $('[data-testid="conflict-row"][data-path="conflict.txt"]').click();
+  await $('[data-testid="accept-ours"]').waitForDisplayed({
+    timeout: 10_000, timeoutMsg: "detail action bar missing",
+  });
+  await $('[data-testid="accept-ours"]').click();
+  await $('[data-testid="mark-resolved"]').click();
+  const finalize = $('[data-testid="conflict-finalize"]');
+  await browser.waitUntil(async () => finalize.isEnabled(), {
+    timeout: 10_000, timeoutMsg: "Finalize never enabled after resolving",
+  });
+  await finalize.click();
+  await $("div*=No conflicts").waitForDisplayed({
+    timeout: 20_000, timeoutMsg: "conflict screen did not clear after finalize",
+  });
+  expect(repo.hasRef("MERGE_HEAD")).toBe(false);
+  expect(repo.read("conflict.txt")).toBe("ours change\n");
+  expect(repo.git("status", "--porcelain").trim()).toBe("");
+});
+
+it("resolves with accept-theirs", async () => {
+  repo = conflictRepo();
+  await startConflictedMerge(repo);
+  await $('[data-testid="conflict-row"][data-path="conflict.txt"]').click();
+  await $('[data-testid="accept-theirs"]').waitForDisplayed({
+    timeout: 10_000, timeoutMsg: "detail action bar missing",
+  });
+  await $('[data-testid="accept-theirs"]').click();
+  await $('[data-testid="mark-resolved"]').click();
+  await browser.waitUntil(
+    async () => $('[data-testid="conflict-finalize"]').isEnabled(),
+    { timeout: 10_000, timeoutMsg: "Finalize never enabled" },
+  );
+  await $('[data-testid="conflict-finalize"]').click();
+  await $("div*=No conflicts").waitForDisplayed({
+    timeout: 20_000, timeoutMsg: "conflict screen did not clear",
+  });
+  expect(repo.read("conflict.txt")).toBe("theirs change\n");
+});
+
+it("aborts a conflicted merge and restores the tree", async () => {
+  repo = conflictRepo();
+  await startConflictedMerge(repo);
+  await $('[data-testid="conflict-abort"]').click(); // confirm already stubbed true
+  await $("div*=No conflicts").waitForDisplayed({
+    timeout: 20_000, timeoutMsg: "abort did not clear conflict screen",
+  });
+  expect(repo.hasRef("MERGE_HEAD")).toBe(false);
+  expect(repo.read("conflict.txt")).toBe("ours change\n");
+  expect(repo.git("status", "--porcelain").trim()).toBe("");
+});
+```
+
+(Accept-ours/theirs may auto-mark resolved in the store — if `mark-resolved` click then fails because the row already left the list, make the mark-resolved click conditional on the button being present; the acceptance stays the git-truth block.)
+
+- [ ] **Step 3: Verify + commit**
+
+```bash
+pnpm test:e2e   # rebuild (Conflict.tsx changed); expect 15/15
+pnpm tsc --noEmit && pnpm exec tsc -p e2e/tsconfig.json --noEmit && pnpm test
+git add src/screens/Conflict.tsx e2e/specs/merge-conflict.e2e.ts
+git commit -m "test(e2e): conflict resolution and abort flows"
+```
+
+---
+
+### Task 4: Rebase (tests 6-7)
+
+**Files:**
+- Modify: `e2e/support/tempRepo.ts` (rebaseConflictRepo)
+- Modify: `src/design/git-components.tsx` (`PGRebaseRow` ~line 1561)
+- Modify: `src/screens/Rebase.tsx` (button testids)
+- Create: `e2e/specs/rebase.e2e.ts`
+
+**Interfaces:**
+- Consumes: `cherryRepo`, `jsContextMenu(selector, {text})`, `jsClickMenuItem`, `stubNativeDialogs`.
+- Produces: `rebaseConflictRepo(): TempRepo` (3 commits, middle-drop conflicts); DOM `rebase-row`+`data-oid`, `rebase-start`, `rebase-continue`, `rebase-abort`.
+
+- [ ] **Step 1: Fixture**
+
+```typescript
+export function rebaseConflictRepo(): TempRepo {
+  const r = new TempRepo();
+  r.commitFile("conflict.txt", "l1\n", "feat: base line");
+  r.commitFile("conflict.txt", "l1-mod\n", "feat: first edit");
+  r.commitFile("conflict.txt", "l1-final\n", "feat: second edit");
+  return r; // dropping "first edit" makes "second edit" conflict on replay
+}
+```
+
+- [ ] **Step 2: Attributes**
+
+`PGRebaseRow` (`git-components.tsx:1561`): root gets `data-testid="rebase-row"` + `data-oid={oid}` (check prop name — the row knows its commit; if the prop is `sha`/`step.oid`, use that). `Rebase.tsx`: `Start rebase` (~:280) `data-testid="rebase-start"`; banner `Abort` (~:91) `data-testid="rebase-abort"`; banner `Continue` (~:94) `data-testid="rebase-continue"`.
+
+- [ ] **Step 3: Spec**
+
+`e2e/specs/rebase.e2e.ts`:
+
+```typescript
+import { browser, $, expect } from "@wdio/globals";
+import { cherryRepo, rebaseConflictRepo, TempRepo } from "../support/tempRepo";
+import {
+  openRepo, resetApp, switchScreen, stubNativeDialogs,
+  jsContextMenu, jsClickMenuItem,
+} from "../support/app";
+
+describe("interactive rebase", () => {
+  let repo: TempRepo;
+
+  afterEach(async () => {
+    await resetApp();
+    repo.dispose();
+  });
+
+  it("squashes HEAD into its parent from the history menu", async () => {
+    repo = cherryRepo(); // main: 3 commits, HEAD = "fix: update a.txt"
+    await openRepo(repo.path);
+    await stubNativeDialogs({ promptText: "squashed by e2e" });
+    await switchScreen("history");
+    const headRow = $('[data-testid="commit-row"]*=fix: update a.txt');
+    await headRow.waitForDisplayed({ timeout: 15_000, timeoutMsg: "HEAD row missing" });
+    await jsContextMenu('[data-testid="commit-row"]', { text: "fix: update a.txt" });
+    await jsClickMenuItem("Squash this commit into its parent");
+    // AppShell auto-switches to the rebase screen with a prefilled plan
+    await $('[data-testid="rebase-row"]').waitForDisplayed({
+      timeout: 15_000, timeoutMsg: "rebase plan never appeared",
+    });
+    await $('[data-testid="rebase-start"]').click();
+    await browser.waitUntil(
+      async () => repo.git("rev-list", "--count", "HEAD").trim() === "2",
+      { timeout: 20_000, timeoutMsg: "squash rebase did not complete" },
+    ); // repo-truth wait: completion has no single UI signal
+    expect(repo.git("log", "-1", "--pretty=%B")).toContain("squashed by e2e");
+    expect(repo.git("status", "--porcelain").trim()).toBe("");
+  });
+
+  it("aborting a conflicted rebase restores HEAD", async () => {
+    repo = rebaseConflictRepo();
+    const before = repo.git("rev-parse", "HEAD").trim();
+    await openRepo(repo.path);
+    await stubNativeDialogs({ confirm: true });
+    await switchScreen("history");
+    await jsContextMenu('[data-testid="commit-row"]', { text: "feat: base line" });
+    await jsClickMenuItem("Interactive rebase from here");
+    await $('[data-testid="rebase-row"]').waitForDisplayed({
+      timeout: 15_000, timeoutMsg: "rebase plan never appeared",
+    });
+    // drop the middle commit so the last one conflicts on replay
+    const firstRow = $('[data-testid="rebase-row"]*=feat: first edit');
+    await firstRow.waitForDisplayed({ timeout: 10_000, timeoutMsg: "plan row missing" });
+    await firstRow.$("select").selectByVisibleText("drop");
+    await $('[data-testid="rebase-start"]').click();
+    await $('[data-testid="rebase-abort"]').waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "conflict banner (with Abort) never appeared",
+    });
+    await $('[data-testid="rebase-abort"]').click();
+    await browser.waitUntil(
+      async () => repo.git("rev-parse", "HEAD").trim() === before,
+      { timeout: 20_000, timeoutMsg: "abort did not restore HEAD" },
+    );
+    expect(repo.git("status", "--porcelain").trim()).toBe("");
+  });
+});
+```
+
+Fallbacks the implementer may need: `selectByVisibleText` failing on the embedded driver → in-page `select.value = "drop"; select.dispatchEvent(new Event("change", {bubbles:true}))` via browser.execute. "Interactive rebase from here" plan may include the from-commit itself or only descendants — inspect the rendered rows and adjust which row gets dropped so the CONFLICTING commit remains.
+
+- [ ] **Step 4: Verify + commit**
+
+```bash
+pnpm test:e2e   # rebuild; expect 17/17
+pnpm tsc --noEmit && pnpm exec tsc -p e2e/tsconfig.json --noEmit && pnpm test
+git add e2e/ src/design/git-components.tsx src/screens/Rebase.tsx
+git commit -m "test(e2e): interactive rebase squash and conflicted abort"
+```
+
+---
+
+### Task 5: History ops (tests 8-11)
+
+**Files:**
+- Modify: `src/screens/History.tsx` (CommitActionRow testids, ~:407/:410)
+- Create: `e2e/specs/history-ops.e2e.ts`
+
+**Interfaces:**
+- Consumes: `cherryRepo`, `jsContextMenu(selector, {text})`, `jsHoverMenuItem`, `jsClickMenuItem`, `stubNativeDialogs`.
+- Produces: DOM `commit-cherry-pick`, `commit-revert`.
+
+- [ ] **Step 1: Testids**
+
+`History.tsx` CommitActionRow: Cherry-pick button (~:407) `data-testid="commit-cherry-pick"`; Revert button (~:410) `data-testid="commit-revert"`.
+
+- [ ] **Step 2: Spec**
+
+`e2e/specs/history-ops.e2e.ts`:
+
+```typescript
+import { browser, $, expect } from "@wdio/globals";
+import { cherryRepo, TempRepo } from "../support/tempRepo";
+import {
+  openRepo, resetApp, switchScreen, stubNativeDialogs,
+  jsContextMenu, jsHoverMenuItem, jsClickMenuItem,
+} from "../support/app";
+
+describe("history danger ops", () => {
+  let repo: TempRepo;
+
+  beforeEach(async () => {
+    repo = cherryRepo();
+    await openRepo(repo.path);
+    await stubNativeDialogs({ confirm: true, promptText: "e2e" });
+    await switchScreen("history");
+    await $("span*=SUBJECT").waitForDisplayed({
+      timeout: 15_000, timeoutMsg: "history screen not ready",
+    });
+  });
+
+  afterEach(async () => {
+    await resetApp();
+    repo.dispose();
+  });
+
+  it("reset soft moves HEAD and keeps changes staged", async () => {
+    const parent = repo.git("rev-parse", "HEAD~1").trim();
+    await jsContextMenu('[data-testid="commit-row"]', { text: "feat: add b.txt" });
+    await jsHoverMenuItem("Reset current branch to here");
+    await jsClickMenuItem("Soft (keep changes staged)");
+    await browser.waitUntil(
+      async () => repo.git("rev-parse", "HEAD").trim() === parent,
+      { timeout: 20_000, timeoutMsg: "soft reset did not move HEAD" },
+    );
+    expect(repo.git("diff", "--cached", "--name-only")).toContain("a.txt");
+  });
+
+  it("reset hard moves HEAD and cleans the tree", async () => {
+    const parent = repo.git("rev-parse", "HEAD~1").trim();
+    await jsContextMenu('[data-testid="commit-row"]', { text: "feat: add b.txt" });
+    await jsHoverMenuItem("Reset current branch to here");
+    await jsClickMenuItem("Hard (discard changes)");
+    await browser.waitUntil(
+      async () => repo.git("rev-parse", "HEAD").trim() === parent,
+      { timeout: 20_000, timeoutMsg: "hard reset did not move HEAD" },
+    );
+    expect(repo.git("status", "--porcelain").trim()).toBe("");
+  });
+
+  it("cherry-picks the feature commit onto main", async () => {
+    // feature's commit isn't in main's log by default — try the All filter
+    await $("button*=All").click();
+    const row = $('[data-testid="commit-row"]*=feat: cherry commit');
+    await row.waitForDisplayed({
+      timeout: 15_000,
+      timeoutMsg: "feature commit not visible under All filter — see fallback note",
+    });
+    await row.click();
+    await $('[data-testid="commit-cherry-pick"]').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "detail action row missing",
+    });
+    await $('[data-testid="commit-cherry-pick"]').click(); // confirm stubbed
+    await browser.waitUntil(
+      async () => repo.git("log", "-1", "--pretty=%s").includes("feat: cherry commit"),
+      { timeout: 20_000, timeoutMsg: "cherry-pick commit never landed" },
+    );
+    expect(repo.read("cherry.txt")).toBe("cherry\n");
+    expect(repo.git("branch", "--show-current").trim()).toBe("main");
+  });
+
+  it("reverts HEAD", async () => {
+    const row = $('[data-testid="commit-row"]*=fix: update a.txt');
+    await row.waitForDisplayed({ timeout: 15_000, timeoutMsg: "HEAD row missing" });
+    await row.click();
+    await $('[data-testid="commit-revert"]').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "detail action row missing",
+    });
+    await $('[data-testid="commit-revert"]').click(); // confirm stubbed
+    await browser.waitUntil(
+      async () => repo.git("log", "-1", "--pretty=%s").startsWith("Revert"),
+      { timeout: 20_000, timeoutMsg: "revert commit never landed" },
+    );
+    expect(repo.read("a.txt")).toBe("alpha v1\n");
+  });
+});
+```
+
+Cherry-pick fallback (if the "All" filter is an author/branch filter that does NOT surface unmerged-branch commits — the implementer must verify): drive the History context menu path on the feature commit if visible; if History simply cannot display it, open the command palette in-page (dispatch `new KeyboardEvent("keydown", {key:"p", metaKey:true, bubbles:true})` on `window`), run its cherry-pick action, and pick the commit from the palette list ( `[data-pal-index]` rows exist). If all three paths fail, report BLOCKED with DOM evidence — do not fake the flow by shelling `git cherry-pick`.
+
+- [ ] **Step 3: Verify + commit**
+
+```bash
+pnpm test:e2e   # rebuild (History.tsx changed); expect 21/21
+pnpm tsc --noEmit && pnpm exec tsc -p e2e/tsconfig.json --noEmit && pnpm test
+git add src/screens/History.tsx e2e/specs/history-ops.e2e.ts
+git commit -m "test(e2e): reset, cherry-pick, revert flows"
+```
+
+---
+
+### Task 6: Reflog (tests 12-13)
+
+**Files:**
+- Create: `e2e/specs/reflog.e2e.ts`
+
+**Interfaces:**
+- Consumes: `basicRepo`, `openRepo`, `switchScreen`; ReflogActionDialog + DirtyTreeDialog are `role="dialog"` with unique button/label text — no new testids.
+
+- [ ] **Step 1: Spec**
+
+```typescript
+import { browser, $, expect } from "@wdio/globals";
+import { basicRepo, TempRepo } from "../support/tempRepo";
+import { openRepo, resetApp, switchScreen } from "../support/app";
+
+describe("reflog", () => {
+  let repo: TempRepo;
+
+  afterEach(async () => {
+    await resetApp();
+    repo.dispose();
+  });
+
+  async function jumpViaDialog(): Promise<void> {
+    await $("button*=Go to this point").click();
+    const dialog = $('[role="dialog"]');
+    await dialog.waitForDisplayed({ timeout: 10_000, timeoutMsg: "action dialog missing" });
+    await dialog.$("div*=Check out (detached)").click();
+    await dialog.$("button*=Go").click();
+  }
+
+  it("checks out a reflog entry detached", async () => {
+    repo = basicRepo();
+    await openRepo(repo.path);
+    await switchScreen("reflog");
+    const entry = $('[data-testid="commit-row"]*=feat: add b.txt');
+    await entry.waitForDisplayed({ timeout: 15_000, timeoutMsg: "reflog entries missing" });
+    await entry.click();
+    await jumpViaDialog();
+    await browser.waitUntil(
+      async () =>
+        (await $('[data-testid="branch-chip"]').getText()).includes("detached"),
+      { timeout: 20_000, timeoutMsg: "chip never showed detached" },
+    );
+    expect(repo.git("rev-parse", "--abbrev-ref", "HEAD").trim()).toBe("HEAD");
+  });
+
+  it("dirty tree jump offers stash and proceeds", async () => {
+    repo = basicRepo();
+    repo.write("a.txt", "dirty before jump\n"); // dirty BEFORE open so store sees it
+    await openRepo(repo.path);
+    await switchScreen("reflog");
+    const entry = $('[data-testid="commit-row"]*=feat: add b.txt');
+    await entry.waitForDisplayed({ timeout: 15_000, timeoutMsg: "reflog entries missing" });
+    await entry.click();
+    await jumpViaDialog();
+    // dirty-tree dialog intercepts the jump
+    const stashBtn = $("button*=Stash them");
+    await stashBtn.waitForDisplayed({ timeout: 10_000, timeoutMsg: "DirtyTreeDialog missing" });
+    await stashBtn.click();
+    await browser.waitUntil(
+      async () =>
+        (await $('[data-testid="branch-chip"]').getText()).includes("detached"),
+      { timeout: 20_000, timeoutMsg: "jump after stash never completed" },
+    );
+    expect(repo.git("stash", "list").trim()).not.toBe("");
+    expect(repo.git("rev-parse", "--abbrev-ref", "HEAD").trim()).toBe("HEAD");
+  });
+});
+```
+
+Note: `button*=Go` inside the dialog also matches nothing else there except Cancel — verify; if ambiguous, use exact structure (the footer's primary PGButton). "Go to this point" button and dialog "Go" coexist only before the dialog opens.
+
+- [ ] **Step 2: Verify + commit**
+
+```bash
+pnpm test:e2e:run   # spec-only; expect 23/23
+pnpm exec tsc -p e2e/tsconfig.json --noEmit && pnpm tsc --noEmit && pnpm test
+git add e2e/specs/reflog.e2e.ts
+git commit -m "test(e2e): reflog detached checkout and dirty-tree dialog"
+```
+
+---
+
+### Task 7: Docs + PR
+
+**Files:**
+- Modify: `CLAUDE.md` (Testing → E2E bullet)
+
+- [ ] **Step 1: CLAUDE.md**
+
+Update the E2E bullet's counts (6→10 spec files, 10→23 tests — use actual numbers) and append one sub-bullet:
+
+```markdown
+  - Danger-op flows (merge/conflict, rebase, reset, cherry-pick/revert,
+    reflog) covered by phase 2 specs. Context menus (incl. the reset hover
+    submenu) driven via `jsContextMenu`/`jsHoverMenuItem`/`jsClickMenuItem`
+    in `e2e/support/app.ts`. Fixtures: `conflictRepo`, `cherryRepo`,
+    `rebaseConflictRepo`.
+```
+
+- [ ] **Step 2: Full verification sweep (paste all outputs)**
+
+```bash
+pnpm tsc --noEmit && pnpm exec tsc -p e2e/tsconfig.json --noEmit && pnpm test
+cargo check --manifest-path src-tauri/Cargo.toml && cargo test --manifest-path src-tauri/Cargo.toml
+pnpm test:e2e   # full rebuild; expect 23/23
+```
+
+- [ ] **Step 3: Commit, push, PR**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: document phase 2 e2e coverage"
+git push -u origin test/e2e-phase2
+gh pr create --draft --title "test(e2e): danger-ops suite, phase 2" --body "$(cat <<'EOF'
+## Summary
+- Phase 2 E2E coverage: merge (clean/conflict/abort), conflict resolution
+  (ours/theirs/finalize), interactive rebase (squash + conflicted abort),
+  reset soft/hard, cherry-pick, revert, reflog jumps (detached + dirty-tree
+  dialog). 13 new tests across 4 new spec files (23 total).
+- Fixes stale-UI defect: mergeBranch/rebaseOnto now refreshAll on error, so
+  a conflicted merge surfaces in the Conflicts screen immediately (test 2
+  proves it red→green).
+- Helpers promoted to e2e/support (jsContextMenu + new hover-submenu
+  support); new fixtures conflictRepo/cherryRepo/rebaseConflictRepo.
+- Sparse data-* attributes on Conflict/Rebase/History components.
+
+Spec: docs/superpowers/specs/2026-07-02-e2e-phase2-design.md
+Plan: docs/superpowers/plans/2026-07-02-e2e-phase2.md
+
+## Test plan
+- [ ] pnpm test:e2e — 23/23 locally (macOS)
+- [ ] e2e workflow green (Linux)
+- [ ] tsc (root + e2e), vitest, cargo test green
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Watch CI to conclusion; debug Linux-only failures here. Squash-to-one + ready + merge handled per repo workflow after final review.
+
+---
+
+## Execution notes
+
+- Task order matters: 1 (helpers) → 2 (fix+fixtures) → 3 → 4 → 5 → 6 → 7. Tasks 4/5/6 are independent of each other but sequential execution avoids binary-rebuild races (single shared `e2e/.bin`).
+- The RED step in Task 2 is mandatory — it documents the defect the fix claims to fix. If the test can't go red for the documented reason, stop and report.
+- Every fallback listed (submenu event shape, select dispatch, cherry-pick path) is implementer-explored but support-code fixes land in `e2e/support/`, not inline in specs.
+- Suite time budget: Phase 1 runs ~6s spec time; Phase 2's real merges/rebases will add — acceptable ceiling is ~60s spec time total locally. Beyond that, flag in report.

--- a/docs/superpowers/specs/2026-07-02-e2e-phase2-design.md
+++ b/docs/superpowers/specs/2026-07-02-e2e-phase2-design.md
@@ -1,0 +1,166 @@
+# End-to-End Testing (Phase 2: danger ops) — Design
+
+Status: approved 2026-07-02
+
+## Problem
+
+Phase 1 (`2026-07-02-e2e-testing-design.md`, merged as #26) covers the read
+path and routine write path. The operations most likely to destroy user work —
+merge conflicts, rebase, reset, cherry-pick/revert, reflog jumps — have no
+webview-level coverage. These flows are also the most dialog- and
+state-machine-heavy screens in the app (Conflict, Rebase, Reflog), so wiring
+regressions there are both likelier and costlier.
+
+Investigation also surfaced an app defect: `mergeBranch` and `rebaseOnto` in
+`useRepoStore` set the error banner on failure but skip `refreshAll()`, so a
+conflicted merge leaves the Conflicts screen, status-bar badge, and
+`repoState` stale until something else refreshes. The UI lies about disk
+state. Phase 2 fixes this (approach B, approved): the error path still
+refreshes, making the in-app conflict flow both correct for users and
+testable.
+
+## Goals
+
+- Cover the six danger-op areas: merge (clean + conflict + abort), conflict
+  resolution (ours/theirs/mark-resolved/finalize), interactive rebase
+  (execute + abort), reset (soft/hard), cherry-pick + revert, reflog jumps
+  (detached checkout + dirty-tree dialog).
+- Drive real user flows in-app wherever practical; seed repo state via git
+  CLI fixtures only where in-app driving is impractical (rebase-conflict
+  setup, dirty trees).
+- Land the `refreshAll`-on-error fix with the tests that prove it.
+- Pay down Phase 1 ride-alongs first so new specs build on clean helpers.
+
+## Non-goals
+
+- Auto-switching to the Conflicts screen when a conflict appears (UX feature,
+  separate spec if wanted).
+- Remote ops, command palette coverage, settings persistence (Phase 3).
+- `run_mergetool` (spawns external tool — not driveable headlessly) and
+  `restart_conflict` coverage.
+- Multi-stash UI flows (attribute added now; specs later when needed).
+- Rebase plan reordering/reword editor coverage beyond the squash flow.
+
+## Task 0: cleanups (from Phase 1 final review, controller-triaged RIDE)
+
+- Promote `jsContextMenu` from `e2e/specs/status-stage.e2e.ts` to
+  `e2e/support/app.ts`, extended with submenu support: the commit-menu reset
+  submenu opens on parent-item hover (`context-menu.tsx:57-67`), so the
+  helper gains an optional submenu step (dispatch `mouseenter` on the parent
+  item, wait for submenu, click the child by text).
+- Move the duplicated `changeRow`/`stagedRow` selector factories
+  (3 copies across specs) into `e2e/support/app.ts`.
+- Add `data-stash-index` to the Branches-screen stash row.
+- Align `@types/node` to `^22`.
+
+## App changes
+
+1. **Fix (behavior):** in `src/features/repo/useRepoStore.ts`, the `catch`
+   arms of `mergeBranch` and `rebaseOnto` call `refreshAll()` after setting
+   `error`, so status/`repoState`/conflict rows reflect disk truth
+   immediately after a failed merge/rebase.
+2. **Test attributes (inert):**
+   - `PGConflictRow` (`git-components.tsx`): `data-testid="conflict-row"` +
+     `data-path`.
+   - Conflict screen buttons: `conflict-abort`, `conflict-finalize`,
+     `accept-ours`, `accept-theirs`, `mark-resolved`.
+   - Rebase screen: `rebase-row` + `data-sha` on `PGRebaseRow`;
+     `rebase-start`, `rebase-continue`, `rebase-abort` buttons.
+   - History `CommitActionRow`: `commit-cherry-pick`, `commit-revert`.
+   - Branches stash row: `data-stash-index`.
+   - Reflog dialogs need nothing: `role="dialog"` + unique button text.
+3. **Fix (behavior, discovered-by-test, user-approved scope addition):** in
+   `src-tauri/src/git/libgit2.rs`, `rebase_abort` only hard-reset to
+   *current* HEAD, which `rebase_start`/`advance_rebase` had already moved
+   forward — so aborting a conflicted rebase left the branch mid-rebase
+   instead of restoring its original tip. `RebaseState` now tracks the
+   pre-rebase tip in `orig_head` and `rebase_abort` restores it (mirrors
+   `git rebase --abort` restoring `ORIG_HEAD`). Tightened
+   `rebase_abort_resets_to_pre_rebase_head` in `src-tauri/tests/rebase.rs`
+   to assert the restore instead of just documenting the gap.
+
+## Fixtures (added to `e2e/support/tempRepo.ts`)
+
+- `conflictRepo()` — `main` and branch `clash` edit the same lines of
+  `conflict.txt`; merging `clash` into `main` conflicts. Used for in-app
+  conflicted merge, resolution flows, and abort.
+- `cherryRepo()` — unmerged branch `feature` with one distinct commit
+  (unique file + message) on top of shared history; `main` checked out.
+  Cherry-pick source; also serves revert/reset tests via its `main` commits.
+- `rebaseConflictRepo()` — 4 linear commits editing the same lines of
+  `conflict.txt`, dropping the middle one so the trailing pick conflicts on
+  replay. Needs 4 commits, not 3: `rebase_start` resets HEAD to the parent of
+  the first surviving (non-Drop) plan step, so a plan that only drops the
+  *older* of two commits always resets straight to the real parent of the
+  surviving pick — conflict-free by construction. The dropped commit must sit
+  strictly between two surviving picks for the second pick's cherry-pick to
+  actually diverge.
+- Dirty trees made inline via the existing `write()` helper.
+
+## Test cases (4 new spec files, ~13 tests)
+
+`merge-conflict.e2e.ts` (conflictRepo unless noted):
+1. Clean merge (cherryRepo — `feature` merges cleanly): Branches screen →
+   "Merge into current" (confirm stubbed) → `main` has no divergent history
+   from `feature`, so `git merge` fast-forwards (no merge commit); assert new
+   HEAD subject matches feature's tip commit and the tree is clean.
+2. Conflicted merge in-app: error banner (`role="alert"`) appears AND
+   status-bar conflict badge + Conflicts screen row appear without manual
+   refresh (proves the fix).
+3. Resolve via accept-ours → mark resolved → Finalize → merge commit exists,
+   `repoState` clean, `conflict.txt` content = ours (disk truth).
+4. Accept-theirs variant → content = theirs.
+5. Abort mid-merge → `MERGE_HEAD` gone, tree matches pre-merge (git truth).
+
+`rebase.e2e.ts`:
+6. Squash-into-parent from History commit context menu (prompt stubbed for
+   message) → Rebase screen shows plan → Start → `rev-list --count` drops by
+   one, squashed message correct.
+7. Rebase that conflicts (fixture): Start → banner shows conflict pause →
+   Abort → HEAD/branch restored to pre-rebase oid.
+
+`history-ops.e2e.ts` (cherryRepo):
+8. Reset soft to parent via commit context submenu → HEAD moved (git truth),
+   former commit's changes staged.
+9. Reset hard to parent → HEAD moved, tree clean.
+10. Cherry-pick feature's commit via detail-panel button (confirm stubbed) →
+    commit with same message on `main`, file present.
+    **Blocked:** backend log is HEAD-only, no UI surface shows unmerged-ref
+    commits; test lands as `it.skip`; see issue #27. Unskip when ref-scoped
+    log ships.
+11. Revert HEAD → revert commit at top, file content restored.
+
+`reflog.e2e.ts` (basicRepo):
+12. Reflog screen lists entries; select entry → "Go to this point" →
+    ReflogActionDialog → "Check out (detached)" → Go → branch chip shows
+    `(detached)`, `git symbolic-ref` fails (detached confirmed).
+13. Dirty tree + jump → DirtyTreeDialog appears → "Stash them (auto-named)"
+    → jump succeeds AND `git stash list` non-empty.
+
+Numbering note: test 1 lives in `merge-conflict.e2e.ts` but uses a
+non-conflicting fixture.
+
+## Conventions (unchanged from Phase 1)
+
+Repo truth as acceptance, UI as wait condition; `stubNativeDialogs` for
+`window.prompt`/`confirm` (heavily used: merge confirm, squash message,
+cherry-pick/revert confirms); tag-scoped text selectors; `button*=`;
+timeout+timeoutMsg everywhere; no `pause()`; spec-only iterations via
+`pnpm test:e2e:run`, any src/ change requires full `pnpm test:e2e`.
+
+## Workflow
+
+Branch `test/e2e-phase2`; small Conventional Commits; squash to one commit
+before merge; PR with CI green (e2e.yml already runs on PRs + main pushes).
+
+## Risks
+
+- Submenu-hover helper is new ground. Fallback: palette `action:reset` path
+  (deterministic nested pick, no native dialog).
+- Rebase screen uses a native `<select>` per plan row — WDIO
+  `selectByVisibleText` handles it; if the embedded driver balks, in-page
+  value-set + change-event dispatch is the fallback.
+- In-app conflicted merge depends on the store fix landing first — ordering
+  constraint the plan must respect.
+- `PGCommitRow` testid collides between History and Reflog screens — scope
+  selectors to the active screen container.

--- a/e2e/specs/commit.e2e.ts
+++ b/e2e/specs/commit.e2e.ts
@@ -1,9 +1,6 @@
 import { browser, $, expect } from "@wdio/globals";
 import { dirtyRepo, TempRepo } from "../support/tempRepo";
-import { openRepo, resetApp, switchScreen } from "../support/app";
-
-const changeRow = (p: string) =>
-  $(`[data-testid="changes-list"] [data-path="${p}"]`);
+import { changeRow, openRepo, resetApp, switchScreen } from "../support/app";
 
 describe("commit", () => {
   let repo: TempRepo;

--- a/e2e/specs/history-ops.e2e.ts
+++ b/e2e/specs/history-ops.e2e.ts
@@ -1,0 +1,113 @@
+import { browser, $, expect } from "@wdio/globals";
+import { cherryRepo, TempRepo } from "../support/tempRepo";
+import {
+  openRepo, resetApp, switchScreen, stubNativeDialogs,
+  jsContextMenu, jsHoverMenuItem, jsClickMenuItem,
+} from "../support/app";
+
+describe("history danger ops", () => {
+  let repo: TempRepo;
+
+  beforeEach(async () => {
+    repo = cherryRepo();
+    await openRepo(repo.path);
+    await stubNativeDialogs({ confirm: true, promptText: "e2e" });
+    await switchScreen("history");
+    await $("span*=SUBJECT").waitForDisplayed({
+      timeout: 15_000, timeoutMsg: "history screen not ready",
+    });
+  });
+
+  afterEach(async () => {
+    await resetApp();
+    repo.dispose();
+  });
+
+  it("reset soft moves HEAD and keeps changes staged", async () => {
+    const parent = repo.git("rev-parse", "HEAD~1").trim();
+    await jsContextMenu('[data-testid="commit-row"]', { text: "feat: add b.txt" });
+    await jsHoverMenuItem("Reset current branch to here");
+    await jsClickMenuItem("Soft (keep changes staged)");
+    await browser.waitUntil(
+      async () => repo.git("rev-parse", "HEAD").trim() === parent,
+      { timeout: 20_000, timeoutMsg: "soft reset did not move HEAD" },
+    );
+    expect(repo.git("diff", "--cached", "--name-only")).toContain("a.txt");
+  });
+
+  it("reset hard moves HEAD and cleans the tree", async () => {
+    const parent = repo.git("rev-parse", "HEAD~1").trim();
+    await jsContextMenu('[data-testid="commit-row"]', { text: "feat: add b.txt" });
+    await jsHoverMenuItem("Reset current branch to here");
+    await jsClickMenuItem("Hard (discard changes)");
+    await browser.waitUntil(
+      async () => repo.git("rev-parse", "HEAD").trim() === parent,
+      { timeout: 20_000, timeoutMsg: "hard reset did not move HEAD" },
+    );
+    expect(repo.git("status", "--porcelain").trim()).toBe("");
+  });
+
+  // BLOCKED — pending #27 (ref-scoped log).
+  //
+  // All three documented fallback paths (History "All" filter → context
+  // menu → in-page ⌘P palette) draw the commit list from the exact same
+  // frontend state, `useRepoStore.commits`, which the backend populates
+  // via a revwalk that only ever calls `push_head()` — see `log()` and
+  // `log_filtered()` in src-tauri/src/git/libgit2.rs. There is no code
+  // path anywhere in the backend that unions in other refs, so a commit
+  // that only exists on an unmerged branch (cherry.txt on `feature`) can
+  // never appear while `main` is checked out, no matter which client-side
+  // filter/search/picker is used on top of that list.
+  //
+  // Verified empirically against the live e2e build (cherryRepo, HEAD on
+  // main):
+  //   1. History screen, "All" filterKind button clicked: the rendered
+  //      `[data-testid="commit-row"]` set is exactly the 3 main-branch
+  //      commits (fix: update a.txt / feat: add b.txt / feat: add a.txt).
+  //      "feat: cherry commit" never renders — nothing to right-click for
+  //      the context-menu fallback either, since it reads the same rows.
+  //   2. In-page palette (`window.dispatchEvent(new KeyboardEvent("keydown",
+  //      {key:"p", metaKey:true, bubbles:true}))` opens
+  //      `[role="dialog"][aria-label="Command palette"]` fine) → "Cherry-pick
+  //      commit…" step lists the identical 3 commits
+  //      (`commitItems()` in features/palette/commands.ts sources
+  //      `repoState().commits`, the same array).
+  //
+  // Per the task brief: do not fake this by shelling `git cherry-pick`.
+  // Fixing it for real needs a backend change (e.g. a "log another ref"
+  // command) that's out of scope for this E2E task.
+  it.skip("cherry-picks the feature commit onto main — BLOCKED, no UI path surfaces an unmerged branch's commits (see comment above)", async () => {
+    await $("button*=All").click();
+    const row = $('[data-testid="commit-row"]*=feat: cherry commit');
+    await row.waitForDisplayed({
+      timeout: 15_000,
+      timeoutMsg: "feature commit not visible under All filter — see fallback note",
+    });
+    await row.click();
+    await $('[data-testid="commit-cherry-pick"]').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "detail action row missing",
+    });
+    await $('[data-testid="commit-cherry-pick"]').click(); // confirm stubbed
+    await browser.waitUntil(
+      async () => repo.git("log", "-1", "--pretty=%s").includes("feat: cherry commit"),
+      { timeout: 20_000, timeoutMsg: "cherry-pick commit never landed" },
+    );
+    expect(repo.read("cherry.txt")).toBe("cherry\n");
+    expect(repo.git("branch", "--show-current").trim()).toBe("main");
+  });
+
+  it("reverts HEAD", async () => {
+    const row = $('[data-testid="commit-row"]*=fix: update a.txt');
+    await row.waitForDisplayed({ timeout: 15_000, timeoutMsg: "HEAD row missing" });
+    await row.click();
+    await $('[data-testid="commit-revert"]').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "detail action row missing",
+    });
+    await $('[data-testid="commit-revert"]').click(); // confirm stubbed
+    await browser.waitUntil(
+      async () => repo.git("log", "-1", "--pretty=%s").startsWith("Revert"),
+      { timeout: 20_000, timeoutMsg: "revert commit never landed" },
+    );
+    expect(repo.read("a.txt")).toBe("alpha v1\n");
+  });
+});

--- a/e2e/specs/merge-conflict.e2e.ts
+++ b/e2e/specs/merge-conflict.e2e.ts
@@ -1,0 +1,133 @@
+import { browser, $, expect } from "@wdio/globals";
+import { conflictRepo, cherryRepo, TempRepo } from "../support/tempRepo";
+import {
+  openRepo, resetApp, switchScreen, stubNativeDialogs,
+  jsContextMenu, jsClickMenuItem,
+} from "../support/app";
+
+/** Open picker, context-menu the branch row, click "Merge into current".
+ *  window.confirm must already be stubbed. */
+async function mergeBranchViaPicker(name: string): Promise<void> {
+  await $('[data-testid="branch-chip"]').click();
+  const row = $(`[data-branch-row]*=${name}`);
+  await row.waitForDisplayed({ timeout: 10_000, timeoutMsg: `branch row ${name} missing` });
+  await jsContextMenu(`[data-branch-row]`, { text: name });
+  await jsClickMenuItem("Merge into current");
+}
+
+/** conflictRepo + open + stub + merge clash → wait for conflict row. */
+async function startConflictedMerge(repo: TempRepo): Promise<void> {
+  await openRepo(repo.path);
+  await stubNativeDialogs({ confirm: true });
+  await mergeBranchViaPicker("clash");
+  await switchScreen("conflict");
+  await $('[data-testid="conflict-row"][data-path="conflict.txt"]').waitForDisplayed({
+    timeout: 20_000, timeoutMsg: "conflicted merge did not surface",
+  });
+}
+
+describe("merge & conflict", () => {
+  let repo: TempRepo;
+
+  afterEach(async () => {
+    await resetApp();
+    repo.dispose();
+  });
+
+  it("merges a branch cleanly from the branch picker", async () => {
+    repo = cherryRepo();
+    await openRepo(repo.path);
+    await stubNativeDialogs({ confirm: true });
+    await mergeBranchViaPicker("feature");
+    // repo-truth wait: no dedicated UI signal for merge completion. `main`
+    // has no divergent history from `feature` here, so `git merge` fast-
+    // forwards (no merge commit) — wait for HEAD to land on feature's tip
+    // rather than assuming a "Merge branch" commit message.
+    await browser.waitUntil(
+      async () => repo.git("log", "-1", "--pretty=%s").trim() === "feat: cherry commit",
+      { timeout: 20_000, timeoutMsg: "merge never completed" },
+    );
+    expect(repo.git("status", "--porcelain").trim()).toBe("");
+    expect(repo.read("cherry.txt")).toBe("cherry\n");
+  });
+
+  it("shows conflict state immediately when a merge conflicts", async () => {
+    repo = conflictRepo();
+    await openRepo(repo.path);
+    await stubNativeDialogs({ confirm: true });
+    await mergeBranchViaPicker("clash");
+    // error banner appears...
+    await $('[role="alert"]').waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "error banner never appeared",
+    });
+    // ...AND conflict state is visible WITHOUT any manual refresh:
+    await switchScreen("conflict");
+    await $('[data-testid="conflict-row"][data-path="conflict.txt"]').waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "conflict row not shown — refreshAll-on-error fix missing?",
+    });
+    // ...AND the status-bar badge reflects it too (same refreshAll-on-error fix).
+    await $("span*=1 conflict").waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "status-bar conflict badge never appeared",
+    });
+    expect(repo.hasRef("MERGE_HEAD")).toBe(true);
+  });
+
+  it("resolves with accept-ours and finalizes the merge", async () => {
+    repo = conflictRepo();
+    await startConflictedMerge(repo);
+    await $('[data-testid="conflict-row"][data-path="conflict.txt"]').click();
+    await $('[data-testid="accept-ours"]').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "detail action bar missing",
+    });
+    await $('[data-testid="accept-ours"]').click();
+    // accept-ours may auto-mark the file resolved (row leaves the list) —
+    // only click mark-resolved if it's still present.
+    const markResolvedBtn = $('[data-testid="mark-resolved"]');
+    if (await markResolvedBtn.isExisting()) await markResolvedBtn.click();
+    const finalize = $('[data-testid="conflict-finalize"]');
+    await browser.waitUntil(async () => finalize.isEnabled(), {
+      timeout: 10_000, timeoutMsg: "Finalize never enabled after resolving",
+    });
+    await finalize.click();
+    await $("div*=No conflicts").waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "conflict screen did not clear after finalize",
+    });
+    expect(repo.hasRef("MERGE_HEAD")).toBe(false);
+    expect(repo.read("conflict.txt")).toBe("ours change\n");
+    expect(repo.git("status", "--porcelain").trim()).toBe("");
+  });
+
+  it("resolves with accept-theirs", async () => {
+    repo = conflictRepo();
+    await startConflictedMerge(repo);
+    await $('[data-testid="conflict-row"][data-path="conflict.txt"]').click();
+    await $('[data-testid="accept-theirs"]').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "detail action bar missing",
+    });
+    await $('[data-testid="accept-theirs"]').click();
+    const markResolvedBtn = $('[data-testid="mark-resolved"]');
+    if (await markResolvedBtn.isExisting()) await markResolvedBtn.click();
+    await browser.waitUntil(
+      async () => $('[data-testid="conflict-finalize"]').isEnabled(),
+      { timeout: 10_000, timeoutMsg: "Finalize never enabled" },
+    );
+    await $('[data-testid="conflict-finalize"]').click();
+    await $("div*=No conflicts").waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "conflict screen did not clear",
+    });
+    expect(repo.read("conflict.txt")).toBe("theirs change\n");
+  });
+
+  it("aborts a conflicted merge and restores the tree", async () => {
+    repo = conflictRepo();
+    await startConflictedMerge(repo);
+    await $('[data-testid="conflict-abort"]').click(); // confirm already stubbed true
+    await $("div*=No conflicts").waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "abort did not clear conflict screen",
+    });
+    expect(repo.hasRef("MERGE_HEAD")).toBe(false);
+    expect(repo.read("conflict.txt")).toBe("ours change\n");
+    expect(repo.git("status", "--porcelain").trim()).toBe("");
+  });
+});

--- a/e2e/specs/rebase.e2e.ts
+++ b/e2e/specs/rebase.e2e.ts
@@ -1,0 +1,90 @@
+import { browser, $, expect } from "@wdio/globals";
+import { cherryRepo, rebaseConflictRepo, TempRepo } from "../support/tempRepo";
+import {
+  openRepo, resetApp, switchScreen, stubNativeDialogs,
+  jsContextMenu, jsClickMenuItem,
+} from "../support/app";
+
+describe("interactive rebase", () => {
+  let repo: TempRepo;
+
+  afterEach(async () => {
+    await resetApp();
+    repo.dispose();
+  });
+
+  it("squashes HEAD into its parent from the history menu", async () => {
+    repo = cherryRepo(); // main: 3 commits, HEAD = "fix: update a.txt"
+    await openRepo(repo.path);
+    await stubNativeDialogs({ promptText: "squashed by e2e" });
+    await switchScreen("history");
+    const headRow = $('[data-testid="commit-row"]*=fix: update a.txt');
+    await headRow.waitForDisplayed({ timeout: 15_000, timeoutMsg: "HEAD row missing" });
+    await jsContextMenu('[data-testid="commit-row"]', { text: "fix: update a.txt" });
+    await jsClickMenuItem("Squash this commit into its parent");
+    // AppShell auto-switches to the rebase screen with a prefilled plan
+    await $('[data-testid="rebase-row"]').waitForDisplayed({
+      timeout: 15_000, timeoutMsg: "rebase plan never appeared",
+    });
+    await $('[data-testid="rebase-start"]').click();
+    await browser.waitUntil(
+      async () => repo.git("rev-list", "--count", "HEAD").trim() === "2",
+      { timeout: 20_000, timeoutMsg: "squash rebase did not complete" },
+    ); // repo-truth wait: completion has no single UI signal
+    expect(repo.git("log", "-1", "--pretty=%B")).toContain("squashed by e2e");
+    expect(repo.git("status", "--porcelain").trim()).toBe("");
+  });
+
+  it("aborting a conflicted rebase restores HEAD", async () => {
+    repo = rebaseConflictRepo();
+    const before = repo.git("rev-parse", "HEAD").trim();
+    await openRepo(repo.path);
+    await stubNativeDialogs({ confirm: true });
+    await switchScreen("history");
+    // "Interactive rebase from here" resolves its base as the target
+    // commit's parent — invoking it on the repo's ROOT commit ("feat: base
+    // line" has none) silently no-ops (menu handler bails when it can't
+    // find a base oid). Target "feat: first edit" instead: its parent is
+    // "feat: base line", a valid base, and the resulting 3-row plan covers
+    // first edit / middle edit / second edit.
+    await jsContextMenu('[data-testid="commit-row"]', { text: "feat: first edit" });
+    await jsClickMenuItem("Interactive rebase from here");
+    await $('[data-testid="rebase-row"]').waitForDisplayed({
+      timeout: 15_000, timeoutMsg: "rebase plan never appeared",
+    });
+    // Drop the MIDDLE commit so the last one conflicts on replay. Dropping
+    // the plan's first (oldest) row wouldn't work here: rebase_start resets
+    // HEAD to the parent of the first surviving (non-Drop) step, so a
+    // leading drop just shifts the reset point and never conflicts — the
+    // dropped commit has to sit between two surviving picks.
+    const dropRowText = "feat: middle edit";
+    // selectByVisibleText doesn't stick on the embedded driver (confirmed
+    // empirically: the row's action <select> stayed "pick" afterward), and
+    // passing a WebdriverIO element handle into browser.execute isn't
+    // supported here either (the tauri driver doesn't resolve it to a live
+    // DOM node) — so find the row and its <select> purely in-page by text,
+    // same technique as jsContextMenu/jsClickMenuItem, and dispatch the
+    // change event ourselves.
+    await $(`[data-testid="rebase-row"]*=${dropRowText}`).waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "plan row missing",
+    });
+    await browser.execute((rowText: string) => {
+      const rows = Array.from(document.querySelectorAll('[data-testid="rebase-row"]'));
+      const row = rows.find((r) => r.textContent?.includes(rowText));
+      const select = row?.querySelector("select") as HTMLSelectElement | null;
+      if (!select) throw new Error(`rebase row select not found: ${rowText}`);
+      select.value = "drop";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    }, dropRowText);
+    await $('[data-testid="rebase-start"]').click();
+    await $('[data-testid="rebase-abort"]').waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "conflict banner (with Abort) never appeared",
+    });
+    await $('[data-testid="rebase-abort"]').click();
+    await browser.waitUntil(
+      async () => repo.git("rev-parse", "HEAD").trim() === before,
+      { timeout: 20_000, timeoutMsg: "abort did not restore HEAD" },
+    );
+    expect(repo.git("status", "--porcelain").trim()).toBe("");
+  });
+});

--- a/e2e/specs/reflog.e2e.ts
+++ b/e2e/specs/reflog.e2e.ts
@@ -1,0 +1,62 @@
+import { browser, $, expect } from "@wdio/globals";
+import { basicRepo, TempRepo } from "../support/tempRepo";
+import { openRepo, resetApp, switchScreen } from "../support/app";
+
+describe("reflog", () => {
+  let repo: TempRepo;
+
+  afterEach(async () => {
+    await resetApp();
+    repo.dispose();
+  });
+
+  async function jumpViaDialog(): Promise<void> {
+    await $("button*=Go to this point").click();
+    const dialog = $('[role="dialog"]');
+    await dialog.waitForDisplayed({ timeout: 10_000, timeoutMsg: "action dialog missing" });
+    // Each Option renders as its own <label> wrapping a native radio input
+    // plus title/desc text — the label is the only element whose text is
+    // scoped to just this option (any ancestor <div> also contains every
+    // other option's text, so `div*=` would match the whole dialog body).
+    await dialog.$("label*=Check out (detached)").click();
+    await dialog.$("button*=Go").click();
+  }
+
+  it("checks out a reflog entry detached", async () => {
+    repo = basicRepo();
+    await openRepo(repo.path);
+    await switchScreen("reflog");
+    const entry = $('[data-testid="commit-row"]*=feat: add b.txt');
+    await entry.waitForDisplayed({ timeout: 15_000, timeoutMsg: "reflog entries missing" });
+    await entry.click();
+    await jumpViaDialog();
+    await browser.waitUntil(
+      async () =>
+        (await $('[data-testid="branch-chip"]').getText()).includes("detached"),
+      { timeout: 20_000, timeoutMsg: "chip never showed detached" },
+    );
+    expect(repo.git("rev-parse", "--abbrev-ref", "HEAD").trim()).toBe("HEAD");
+  });
+
+  it("dirty tree jump offers stash and proceeds", async () => {
+    repo = basicRepo();
+    repo.write("a.txt", "dirty before jump\n"); // dirty BEFORE open so store sees it
+    await openRepo(repo.path);
+    await switchScreen("reflog");
+    const entry = $('[data-testid="commit-row"]*=feat: add b.txt');
+    await entry.waitForDisplayed({ timeout: 15_000, timeoutMsg: "reflog entries missing" });
+    await entry.click();
+    await jumpViaDialog();
+    // dirty-tree dialog intercepts the jump
+    const stashBtn = $("button*=Stash them");
+    await stashBtn.waitForDisplayed({ timeout: 10_000, timeoutMsg: "DirtyTreeDialog missing" });
+    await stashBtn.click();
+    await browser.waitUntil(
+      async () =>
+        (await $('[data-testid="branch-chip"]').getText()).includes("detached"),
+      { timeout: 20_000, timeoutMsg: "jump after stash never completed" },
+    );
+    expect(repo.git("stash", "list").trim()).not.toBe("");
+    expect(repo.git("rev-parse", "--abbrev-ref", "HEAD").trim()).toBe("HEAD");
+  });
+});

--- a/e2e/specs/stash.e2e.ts
+++ b/e2e/specs/stash.e2e.ts
@@ -1,14 +1,12 @@
 import { $, expect } from "@wdio/globals";
 import { dirtyRepo, TempRepo } from "../support/tempRepo";
 import {
+  changeRow,
   openRepo,
   resetApp,
   stubNativeDialogs,
   switchScreen,
 } from "../support/app";
-
-const changeRow = (p: string) =>
-  $(`[data-testid="changes-list"] [data-path="${p}"]`);
 
 describe("stash", () => {
   let repo: TempRepo;

--- a/e2e/specs/status-stage.e2e.ts
+++ b/e2e/specs/status-stage.e2e.ts
@@ -1,11 +1,14 @@
 import { browser, $, expect } from "@wdio/globals";
 import { dirtyRepo, TempRepo } from "../support/tempRepo";
-import { openRepo, resetApp, switchScreen } from "../support/app";
-
-const stagedRow = (p: string) =>
-  $(`[data-testid="staged-list"] [data-path="${p}"]`);
-const changeRow = (p: string) =>
-  $(`[data-testid="changes-list"] [data-path="${p}"]`);
+import {
+  changeRow,
+  jsClickMenuItem,
+  jsContextMenu,
+  openRepo,
+  resetApp,
+  stagedRow,
+  switchScreen,
+} from "../support/app";
 
 // PGCheckbox's native <input type="checkbox"> is the only element whose
 // programmatic click reliably toggles + fires React's onChange (the visible
@@ -17,29 +20,6 @@ const rowToggle = (list: "staged-list" | "changes-list", p: string) =>
   $(
     `[data-testid="${list}"] [data-path="${p}"] [data-testid="row-toggle"] input`,
   );
-
-/** Open a context menu via an in-page `contextmenu` MouseEvent.
- *
- * This is the one interaction that cannot be a real WebDriver action: the
- * embedded driver's actions endpoint only synthesizes mousedown/mouseup/
- * click events and never `contextmenu` (verified in
- * tauri-plugin-wdio-webdriver 1.2.0 executor source and empirically —
- * `click({ button: "right" })` completes without error but no menu opens). */
-const jsContextMenu = (selector: string) =>
-  browser.execute((sel: string) => {
-    const el = document.querySelector(sel) as HTMLElement | null;
-    if (!el) throw new Error(`jsContextMenu: element not found: ${sel}`);
-    const r = el.getBoundingClientRect();
-    el.dispatchEvent(
-      new MouseEvent("contextmenu", {
-        bubbles: true,
-        cancelable: true,
-        clientX: r.x + r.width / 2,
-        clientY: r.y + r.height / 2,
-        button: 2,
-      }),
-    );
-  }, selector);
 
 describe("status & staging", () => {
   let repo: TempRepo;
@@ -91,12 +71,11 @@ describe("status & staging", () => {
     await jsContextMenu('[data-testid="changes-list"] [data-path="a.txt"]');
     // Menu items are divs with the label in an inner <span> (no native menu;
     // useContextMenu renders a portal).
-    const discardItem = $("span=Discard changes");
-    await discardItem.waitForDisplayed({
+    await $("span=Discard changes").waitForDisplayed({
       timeout: 30_000,
       timeoutMsg: "Discard changes menu item never appeared",
     });
-    await discardItem.click();
+    await jsClickMenuItem("Discard changes");
     await browser.waitUntil(
       async () => !(await changeRow("a.txt").isExisting()),
       { timeout: 30_000, timeoutMsg: "a.txt still listed after discard" },

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -13,19 +13,47 @@ import { browser, $ } from "@wdio/globals";
  * focus check, so this bootstrap itself is fast.
  *
  * Page globals reset on every (re)load — call this after each refresh and
- * once at session start (wdio.conf.ts `before` hook). */
+ * once at session start (wdio.conf.ts `before` hook).
+ *
+ * Reload race (why this isn't a one-shot execute): `browser.refresh()` can
+ * resolve before the embedded driver's "current document" actually points
+ * at the newly loaded page — the outgoing document is still fully parsed
+ * (`readyState === "complete"`) and, since `withGlobalTauri` injects
+ * `window.__TAURI__` from a head script, it ALSO still has a live
+ * `__TAURI__.core`. So a naive check succeeds instantly against the dying
+ * document: `__wdio_original_core__` gets set there, that document is torn
+ * down a moment later, and the real post-refresh document never gets armed
+ * — every command for the rest of the test then pays the 5s poll (observed:
+ * 22min instead of ~1min). `waitUntil` retrying the same check doesn't fix
+ * this by itself, because the very first attempt is the one that falsely
+ * "succeeds".
+ *
+ * There's no reliable in-page signal that survives a full document swap
+ * (window state resets on navigation, by design), so this can't be solved
+ * by polling harder inside a single armed state. Instead, callers must
+ * re-arm once they have independent proof — a real DOM query that matched —
+ * that navigation has settled on the final document. See the re-arm calls
+ * in `resetApp`/`waitRepoLoaded` below: the *first* find after a refresh may
+ * still pay a one-off slow poll (bounded — it's one element appearing), but
+ * every command after that point is guaranteed post-arm. */
 export async function armDriverBridge(): Promise<void> {
   await browser.waitUntil(
     () =>
       browser.execute(() => {
+        if (document.readyState !== "complete") return false;
         const w = window as unknown as Record<string, any>;
         const core = w.__TAURI__?.core;
         if (!core?.invoke) return false;
         w.__wdio_original_core__ = core;
-        return true;
+        // Read back via `window` (not the closed-over `core` local) so a
+        // same-tick realm teardown — the execute call's document getting
+        // swapped out between the assignment and this line — shows up as a
+        // mismatch/throw here instead of silently reporting success.
+        return w.__wdio_original_core__?.invoke === core.invoke;
       }),
     {
       timeout: 20_000,
+      interval: 100,
       timeoutMsg:
         "window.__TAURI__.core.invoke never appeared — was the e2e binary built with --config src-tauri/tauri.e2e.conf.json (withGlobalTauri)?",
     },
@@ -40,6 +68,11 @@ export async function resetApp(): Promise<void> {
     timeout: 20_000,
     timeoutMsg: "Welcome screen did not reappear after reset",
   });
+  // Re-arm: this find only succeeds once the document has settled on the
+  // real post-refresh page, which is the earliest point we can trust that
+  // an arm attempt actually lands (and stays) there. See armDriverBridge
+  // doc for why the pre-Welcome arm above can't be trusted on its own.
+  await armDriverBridge();
 }
 
 export async function waitRepoLoaded(): Promise<void> {
@@ -48,6 +81,10 @@ export async function waitRepoLoaded(): Promise<void> {
     timeout: 20_000,
     timeoutMsg: "branch chip never appeared after opening repo",
   });
+  // Re-arm here too: the syncing-poll loop below can run many iterations,
+  // and this is the first point after opening a repo where we know for
+  // certain we're on the settled document (see armDriverBridge doc).
+  await armDriverBridge();
   // initial status/log fetch done — status bar's "syncing…" PGStatusItem
   // renders its label in a <span>, so scope the text selector (bare `*=`
   // is partial-LINK-text and only matches anchors).
@@ -72,6 +109,9 @@ export async function openRepo(repoPath: string): Promise<void> {
     timeout: 20_000,
     timeoutMsg: "recent-repo row for temp repo never appeared",
   });
+  // Re-arm: same reasoning as resetApp — this find is the first proof the
+  // post-refresh document is the one that's actually current.
+  await armDriverBridge();
   await row.click();
   await waitRepoLoaded();
 }
@@ -93,4 +133,75 @@ export async function stubNativeDialogs(
 
 export async function switchScreen(id: string): Promise<void> {
   await $(`[data-activity="${id}"]`).click();
+}
+
+export const stagedRow = (p: string) =>
+  $(`[data-testid="staged-list"] [data-path="${p}"]`);
+export const changeRow = (p: string) =>
+  $(`[data-testid="changes-list"] [data-path="${p}"]`);
+
+/** Open a context menu via an in-page `contextmenu` MouseEvent.
+ *
+ * This is the one interaction that cannot be a real WebDriver action: the
+ * embedded driver's actions endpoint only synthesizes mousedown/mouseup/
+ * click events and never `contextmenu` (verified in
+ * tauri-plugin-wdio-webdriver 1.2.0 executor source and empirically —
+ * `click({ button: "right" })` completes without error but no menu opens). */
+export const jsContextMenu = (selector: string, opts?: { text?: string }) =>
+  browser.execute(
+    (sel: string, text: string | undefined) => {
+      const candidates = Array.from(document.querySelectorAll(sel));
+      const el = (
+        text
+          ? candidates.find((c) => c.textContent?.includes(text))
+          : candidates[0]
+      ) as HTMLElement | undefined;
+      if (!el) {
+        throw new Error(
+          `jsContextMenu: element not found: ${sel}${text ? ` (text: ${text})` : ""}`,
+        );
+      }
+      const r = el.getBoundingClientRect();
+      el.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          cancelable: true,
+          clientX: r.x + r.width / 2,
+          clientY: r.y + r.height / 2,
+          button: 2,
+        }),
+      );
+    },
+    selector,
+    opts?.text,
+  );
+
+/** Click an open context-menu item by its label-span text (menus are
+ *  portals rendered to document.body, so a plain CSS selector on the label
+ *  text is the reliable way to find them). */
+export async function jsClickMenuItem(label: string): Promise<void> {
+  const ok = await browser.execute((text: string) => {
+    const spans = Array.from(document.querySelectorAll("span"));
+    const el = spans.find((s) => s.textContent === text);
+    if (!el) return false;
+    const target = (el.closest("div") as HTMLElement | null) ?? (el as HTMLElement);
+    target.click();
+    return true;
+  }, label);
+  if (!ok) throw new Error(`menu item not found: ${label}`);
+}
+
+/** Hover a context-menu item to open its submenu (menus are portals; the
+ *  driver can't hover, so dispatch the events React listens for). */
+export async function jsHoverMenuItem(label: string): Promise<void> {
+  const ok = await browser.execute((text: string) => {
+    const spans = Array.from(document.querySelectorAll("span"));
+    const el = spans.find((s) => s.textContent === text);
+    if (!el) return false;
+    const target = el.closest("div") ?? el;
+    target.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    target.dispatchEvent(new MouseEvent("mouseenter", { bubbles: false }));
+    return true;
+  }, label);
+  if (!ok) throw new Error(`menu item not found for hover: ${label}`);
 }

--- a/e2e/support/tempRepo.ts
+++ b/e2e/support/tempRepo.ts
@@ -41,6 +41,15 @@ export class TempRepo {
   dispose(): void {
     rmSync(this.path, { recursive: true, force: true });
   }
+
+  hasRef(ref: string): boolean {
+    try {
+      this.git("rev-parse", "-q", "--verify", ref);
+      return true;
+    } catch {
+      return false;
+    }
+  }
 }
 
 export function makeTempRepo(): TempRepo {
@@ -71,4 +80,39 @@ export function branchyRepo(): TempRepo {
   r.git("checkout", "main");
   r.git("merge", "--no-ff", "-m", "merge feature", "feature");
   return r; // 5 commits reachable from main, two lanes in graph
+}
+
+export function conflictRepo(): TempRepo {
+  const r = new TempRepo();
+  r.commitFile("conflict.txt", "base\n", "feat: base");
+  r.git("checkout", "-b", "clash");
+  r.commitFile("conflict.txt", "theirs change\n", "feat: clash edit");
+  r.git("checkout", "main");
+  r.commitFile("conflict.txt", "ours change\n", "feat: main edit");
+  return r; // merging clash into main conflicts on conflict.txt
+}
+
+export function cherryRepo(): TempRepo {
+  const r = basicRepo();
+  r.git("checkout", "-b", "feature");
+  r.commitFile("cherry.txt", "cherry\n", "feat: cherry commit");
+  r.git("checkout", "main");
+  return r; // feature is one unmerged commit ahead of shared history
+}
+
+export function rebaseConflictRepo(): TempRepo {
+  const r = new TempRepo();
+  r.commitFile("conflict.txt", "l1\n", "feat: base line");
+  r.commitFile("conflict.txt", "l1-mod\n", "feat: first edit");
+  r.commitFile("conflict.txt", "l1-mid\n", "feat: middle edit");
+  r.commitFile("conflict.txt", "l1-final\n", "feat: second edit");
+  return r;
+  // dropping "middle edit" makes "second edit" conflict on replay. Note this
+  // needs 4 commits, not 3: rebase_start resets HEAD to the parent of the
+  // *first surviving (non-Drop) plan step*, so a plan with only two rows
+  // (drop the older, pick the newer) always resets straight to the real
+  // parent of the surviving pick — conflict-free by construction. The
+  // dropped commit must sit strictly BETWEEN two surviving picks for the
+  // second pick's cherry-pick (base = dropped commit's tree, ours = first
+  // pick's result) to actually diverge.
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
-    "@types/node": "^26.1.0",
+    "@types/node": "^22",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.2.4
-        version: 4.2.4(vite@7.3.2(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.2.4(vite@7.3.2(@types/node@22.20.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.10.1
@@ -55,8 +55,8 @@ importers:
         specifier: ^14.5.2
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
-        specifier: ^26.1.0
-        version: 26.1.0
+        specifier: ^22
+        version: 22.20.0
       '@types/react':
         specifier: ^19.1.8
         version: 19.2.14
@@ -65,10 +65,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.6.0
-        version: 4.7.0(vite@7.3.2(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.7.0(vite@7.3.2(@types/node@22.20.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
       '@wdio/cli':
         specifier: ^9.29.1
-        version: 9.29.1(@types/node@26.1.0)(expect-webdriverio@5.7.0)
+        version: 9.29.1(@types/node@22.20.0)(expect-webdriverio@5.7.0)
       '@wdio/globals':
         specifier: ^9.29.1
         version: 9.29.1(expect-webdriverio@5.7.0)(webdriverio@9.29.1)
@@ -95,10 +95,10 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^7.0.4
-        version: 7.3.2(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 7.3.2(@types/node@22.20.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@26.1.0)(jsdom@25.0.1)(vite@7.3.2(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.5(@types/node@22.20.0)(jsdom@25.0.1)(vite@7.3.2(@types/node@22.20.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
 
 packages:
 
@@ -1135,8 +1135,8 @@ packages:
   '@types/node@20.19.43':
     resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
 
-  '@types/node@26.1.0':
-    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
+  '@types/node@22.20.0':
+    resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -2974,9 +2974,6 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici-types@8.3.0:
-    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
-
   undici@6.27.0:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
@@ -3564,128 +3561,128 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@26.1.0)':
+  '@inquirer/checkbox@4.3.2(@types/node@22.20.0)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.0
 
-  '@inquirer/confirm@5.1.21(@types/node@26.1.0)':
+  '@inquirer/confirm@5.1.21(@types/node@22.20.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
     optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.0
 
-  '@inquirer/core@10.3.2(@types/node@26.1.0)':
+  '@inquirer/core@10.3.2(@types/node@22.20.0)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.0
 
-  '@inquirer/editor@4.2.23(@types/node@26.1.0)':
+  '@inquirer/editor@4.2.23(@types/node@22.20.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/external-editor': 1.0.3(@types/node@26.1.0)
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/external-editor': 1.0.3(@types/node@22.20.0)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
     optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.0
 
-  '@inquirer/expand@4.0.23(@types/node@26.1.0)':
+  '@inquirer/expand@4.0.23(@types/node@22.20.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.0
 
-  '@inquirer/external-editor@1.0.3(@types/node@26.1.0)':
+  '@inquirer/external-editor@1.0.3(@types/node@22.20.0)':
     dependencies:
       chardet: 2.2.0
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.0
 
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/input@4.3.1(@types/node@26.1.0)':
+  '@inquirer/input@4.3.1(@types/node@22.20.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
     optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.0
 
-  '@inquirer/number@3.0.23(@types/node@26.1.0)':
+  '@inquirer/number@3.0.23(@types/node@22.20.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
     optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.0
 
-  '@inquirer/password@4.0.23(@types/node@26.1.0)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
-    optionalDependencies:
-      '@types/node': 26.1.0
-
-  '@inquirer/prompts@7.10.1(@types/node@26.1.0)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@26.1.0)
-      '@inquirer/confirm': 5.1.21(@types/node@26.1.0)
-      '@inquirer/editor': 4.2.23(@types/node@26.1.0)
-      '@inquirer/expand': 4.0.23(@types/node@26.1.0)
-      '@inquirer/input': 4.3.1(@types/node@26.1.0)
-      '@inquirer/number': 3.0.23(@types/node@26.1.0)
-      '@inquirer/password': 4.0.23(@types/node@26.1.0)
-      '@inquirer/rawlist': 4.1.11(@types/node@26.1.0)
-      '@inquirer/search': 3.2.2(@types/node@26.1.0)
-      '@inquirer/select': 4.4.2(@types/node@26.1.0)
-    optionalDependencies:
-      '@types/node': 26.1.0
-
-  '@inquirer/rawlist@4.1.11(@types/node@26.1.0)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 26.1.0
-
-  '@inquirer/search@3.2.2(@types/node@26.1.0)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 26.1.0
-
-  '@inquirer/select@4.4.2(@types/node@26.1.0)':
+  '@inquirer/password@4.0.23(@types/node@22.20.0)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
+    optionalDependencies:
+      '@types/node': 22.20.0
+
+  '@inquirer/prompts@7.10.1(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@22.20.0)
+      '@inquirer/confirm': 5.1.21(@types/node@22.20.0)
+      '@inquirer/editor': 4.2.23(@types/node@22.20.0)
+      '@inquirer/expand': 4.0.23(@types/node@22.20.0)
+      '@inquirer/input': 4.3.1(@types/node@22.20.0)
+      '@inquirer/number': 3.0.23(@types/node@22.20.0)
+      '@inquirer/password': 4.0.23(@types/node@22.20.0)
+      '@inquirer/rawlist': 4.1.11(@types/node@22.20.0)
+      '@inquirer/search': 3.2.2(@types/node@22.20.0)
+      '@inquirer/select': 4.4.2(@types/node@22.20.0)
+    optionalDependencies:
+      '@types/node': 22.20.0
+
+  '@inquirer/rawlist@4.1.11(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.0
 
-  '@inquirer/type@3.0.10(@types/node@26.1.0)':
+  '@inquirer/search@3.2.2(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
+      yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.0
+
+  '@inquirer/select@4.4.2(@types/node@22.20.0)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.20.0
+
+  '@inquirer/type@3.0.10(@types/node@22.20.0)':
+    optionalDependencies:
+      '@types/node': 22.20.0
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -3706,7 +3703,7 @@ snapshots:
 
   '@jest/pattern@30.4.0':
     dependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.0
       jest-regex-util: 30.4.0
 
   '@jest/schemas@30.4.1':
@@ -3719,7 +3716,7 @@ snapshots:
       '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 26.1.0
+      '@types/node': 22.20.0
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -3912,12 +3909,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.4
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.4
 
-  '@tailwindcss/vite@4.2.4(vite@7.3.2(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.2.4(vite@7.3.2(@types/node@22.20.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.2.4
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
-      vite: 7.3.2(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.20.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@tauri-apps/api@2.10.1': {}
 
@@ -4064,9 +4061,9 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@26.1.0':
+  '@types/node@22.20.0':
     dependencies:
-      undici-types: 8.3.0
+      undici-types: 6.21.0
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -4086,7 +4083,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.0
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -4096,10 +4093,10 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.0
     optional: true
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.2(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitejs/plugin-react@4.7.0(vite@7.3.2(@types/node@22.20.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -4107,7 +4104,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.2(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.20.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4120,13 +4117,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@7.3.2(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.5(vite@7.3.2(@types/node@22.20.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.20.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -4179,7 +4176,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@wdio/cli@9.29.1(@types/node@26.1.0)(expect-webdriverio@5.7.0)':
+  '@wdio/cli@9.29.1(@types/node@22.20.0)(expect-webdriverio@5.7.0)':
     dependencies:
       '@vitest/snapshot': 2.1.9
       '@wdio/config': 9.29.1
@@ -4191,7 +4188,7 @@ snapshots:
       async-exit-hook: 2.0.1
       chalk: 5.6.2
       chokidar: 4.0.3
-      create-wdio: 9.29.1(@types/node@26.1.0)
+      create-wdio: 9.29.1(@types/node@22.20.0)
       dotenv: 17.4.2
       import-meta-resolve: 4.2.0
       lodash.flattendeep: 4.4.0
@@ -4696,7 +4693,7 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 4.7.0
 
-  create-wdio@9.29.1(@types/node@26.1.0):
+  create-wdio@9.29.1(@types/node@22.20.0):
     dependencies:
       chalk: 5.6.2
       commander: 14.0.3
@@ -4704,7 +4701,7 @@ snapshots:
       ejs: 3.1.10
       execa: 9.6.1
       import-meta-resolve: 4.2.0
-      inquirer: 12.11.1(@types/node@26.1.0)
+      inquirer: 12.11.1(@types/node@22.20.0)
       normalize-package-data: 7.0.1
       read-pkg-up: 10.1.0
       recursive-readdir: 2.2.3
@@ -5261,17 +5258,17 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  inquirer@12.11.1(@types/node@26.1.0):
+  inquirer@12.11.1(@types/node@22.20.0):
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@26.1.0)
-      '@inquirer/prompts': 7.10.1(@types/node@26.1.0)
-      '@inquirer/type': 3.0.10(@types/node@26.1.0)
+      '@inquirer/core': 10.3.2(@types/node@22.20.0)
+      '@inquirer/prompts': 7.10.1(@types/node@22.20.0)
+      '@inquirer/type': 3.0.10(@types/node@22.20.0)
       mute-stream: 2.0.0
       run-async: 4.0.6
       rxjs: 7.8.2
     optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.0
 
   ip-address@10.2.0: {}
 
@@ -5355,7 +5352,7 @@ snapshots:
   jest-mock@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 26.1.0
+      '@types/node': 22.20.0
       jest-util: 30.4.1
 
   jest-regex-util@30.4.0: {}
@@ -5363,7 +5360,7 @@ snapshots:
   jest-util@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 26.1.0
+      '@types/node': 22.20.0
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -6127,8 +6124,6 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@8.3.0: {}
-
   undici@6.27.0: {}
 
   undici@7.28.0: {}
@@ -6152,7 +6147,7 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vite@7.3.2(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@7.3.2(@types/node@22.20.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -6161,17 +6156,17 @@ snapshots:
       rollup: 4.60.2
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.0
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.1.5(@types/node@26.1.0)(jsdom@25.0.1)(vite@7.3.2(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.5(@types/node@22.20.0)(jsdom@25.0.1)(vite@7.3.2(@types/node@22.20.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@7.3.2(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.5(vite@7.3.2(@types/node@22.20.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -6188,10 +6183,10 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@26.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.20.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.0
       jsdom: 25.0.1
     transitivePeerDependencies:
       - msw

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -28,6 +28,10 @@ pub struct RebaseState {
     pub total: usize,
     pub completed: usize,
     pub pause_reason: Option<String>,
+    /// Branch tip before `rebase_start` moved it — `rebase_abort` restores
+    /// this rather than just resetting to wherever the in-progress rebase
+    /// happened to stop (see `rebase_abort` doc comment).
+    pub orig_head: String,
 }
 
 pub struct Libgit2Backend {
@@ -181,8 +185,19 @@ impl Libgit2Backend {
             };
 
             let Some(step) = step_opt else {
-                // Plan exhausted — rebase complete.
-                return self.rebase_status(repo_id);
+                // Plan exhausted — rebase complete. Capture the final status
+                // before dropping the in-memory state so this call's caller
+                // still sees the completed count, but remove the entry so a
+                // later `rebase_status` poll (banner) or `abort_operation`
+                // call doesn't treat this finished rebase as still
+                // in-progress/abortable via its now-stale `orig_head`.
+                let status = self.rebase_status(repo_id)?;
+                let mut rebases = self
+                    .rebases
+                    .lock()
+                    .map_err(|e| AppError::Internal(e.to_string()))?;
+                rebases.remove(repo_id);
+                return Ok(status);
             };
 
             match step.action {
@@ -1934,8 +1949,9 @@ impl GitBackend for Libgit2Backend {
             .ok_or_else(|| AppError::InvalidRef("rebase plan contains only drops".into()))?;
         let first_oid_str = first_step.oid.clone();
 
-        // Verify worktree is clean and reset HEAD to the parent of the first commit.
-        self.with_repo(repo_id, |repo| {
+        // Verify worktree is clean, remember the pre-rebase tip (so an abort
+        // can restore it), and reset HEAD to the parent of the first commit.
+        let orig_head = self.with_repo(repo_id, |repo| {
             let statuses = repo.statuses(None)?;
             if statuses.iter().any(|s| {
                 let b = s.status();
@@ -1951,6 +1967,8 @@ impl GitBackend for Libgit2Backend {
                 ));
             }
 
+            let orig_head = repo.head()?.peel_to_commit()?.id().to_string();
+
             let first_commit = repo
                 .revparse_single(&first_oid_str)
                 .map_err(|_| AppError::InvalidRef(first_oid_str.clone()))?
@@ -1959,7 +1977,7 @@ impl GitBackend for Libgit2Backend {
                 AppError::InvalidRef("first rebase commit has no parent".into())
             })?;
             repo.reset(parent.as_object(), git2::ResetType::Hard, None)?;
-            Ok(())
+            Ok(orig_head)
         })?;
 
         let total = plan.len();
@@ -1974,6 +1992,7 @@ impl GitBackend for Libgit2Backend {
                 total,
                 completed: 0,
                 pause_reason: None,
+                orig_head,
             },
         );
         drop(rebases);
@@ -1996,20 +2015,29 @@ impl GitBackend for Libgit2Backend {
     }
 
     fn rebase_abort(&self, repo_id: &RepoId) -> AppResult<()> {
-        // Drop in-memory state.
+        // Drop in-memory state, keeping the pre-rebase tip it recorded.
         let mut rebases = self
             .rebases
             .lock()
             .map_err(|e| AppError::Internal(e.to_string()))?;
-        rebases.remove(repo_id);
+        let orig_head = rebases.remove(repo_id).map(|s| s.orig_head);
         drop(rebases);
 
         self.with_repo(repo_id, |repo| {
             repo.cleanup_state()?;
-            if let Ok(head) = repo.head() {
-                let head_commit = head.peel_to_commit()?;
-                repo.reset(head_commit.as_object(), git2::ResetType::Hard, None)?;
-            }
+            // Restore the branch to where it was before `rebase_start` moved
+            // it, not wherever the in-progress rebase happened to stop —
+            // `rebase_start` advances the branch tip commit-by-commit as
+            // picks land, so "current HEAD" at abort time is mid-rebase
+            // progress, not the pre-rebase position (mirrors `git rebase
+            // --abort` restoring ORIG_HEAD). Fall back to current HEAD only
+            // if we somehow have no recorded state (e.g. abort called
+            // without a matching start).
+            let target = match &orig_head {
+                Some(oid) => repo.revparse_single(oid)?.peel_to_commit()?,
+                None => repo.head()?.peel_to_commit()?,
+            };
+            repo.reset(target.as_object(), git2::ResetType::Hard, None)?;
             Ok(())
         })
     }
@@ -2158,12 +2186,33 @@ impl GitBackend for Libgit2Backend {
     }
 
     fn abort_operation(&self, repo_id: &RepoId) -> AppResult<()> {
+        // If an interactive rebase is tracked for this repo, prefer its
+        // recorded pre-rebase tip (`orig_head`) as the reset target —
+        // converges this generic conflict-screen/palette abort with
+        // `rebase_abort`. Otherwise a mid-rebase abort here would hard-reset
+        // to "current HEAD", which during a paused rebase is wherever the
+        // in-progress rebase happened to stop, not the pre-rebase position.
+        // Remove the entry either way: leaving it behind would keep
+        // `rebase_status` reporting `in_progress` after this abort, and a
+        // later `rebase_abort` would then reuse the stale `orig_head` to
+        // hard-reset again — silently discarding commits made since.
+        let orig_head = {
+            let mut rebases = self
+                .rebases
+                .lock()
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+            rebases.remove(repo_id).map(|s| s.orig_head)
+        };
+
         self.with_repo(repo_id, |repo| {
-            let head = match repo.head() {
-                Ok(h) => h.peel_to_commit()?,
-                Err(_) => return Err(AppError::Unborn),
+            let target = match &orig_head {
+                Some(oid) => repo.revparse_single(oid)?.peel_to_commit()?,
+                None => match repo.head() {
+                    Ok(h) => h.peel_to_commit()?,
+                    Err(_) => return Err(AppError::Unborn),
+                },
             };
-            repo.reset(head.as_object(), git2::ResetType::Hard, None)?;
+            repo.reset(target.as_object(), git2::ResetType::Hard, None)?;
             repo.cleanup_state()?;
             Ok(())
         })

--- a/src-tauri/tests/rebase.rs
+++ b/src-tauri/tests/rebase.rs
@@ -240,14 +240,129 @@ fn rebase_abort_resets_to_pre_rebase_head() {
     let status_after = backend.rebase_status(&handle.id).unwrap();
     assert!(!status_after.in_progress, "status should show no rebase in progress");
 
-    // HEAD should be at the tip of the original history (oids[1] = last commit before rebase).
+    // HEAD should be restored to the tip of the original history — not left
+    // wherever the in-progress rebase happened to stop. `rebase_start` moves
+    // the branch tip forward commit-by-commit as picks land, so "current
+    // HEAD" at abort time is mid-rebase progress, not the pre-rebase
+    // position; `rebase_abort` must restore the recorded pre-rebase tip
+    // (mirrors `git rebase --abort` restoring ORIG_HEAD).
     let head_after = backend.log(&handle.id, 1).unwrap()[0].oid.clone();
-    // After abort, HEAD should be at the last position before the rebase reset it.
-    // The rebase reset HEAD to parent of oids[0] (= "initial") and then applied oids[0].
-    // After abort, HEAD stays at that position (abort does hard reset to current HEAD,
-    // which is oids[0] after it was applied). The test verifies the rebase state is gone.
-    let _ = head_before;
-    let _ = head_after;
-    // The important invariant: rebase_status shows in_progress=false.
-    assert!(!backend.rebase_status(&handle.id).unwrap().in_progress);
+    assert_eq!(head_after, head_before, "abort should restore the pre-rebase HEAD");
+}
+
+// ─── 8. generic abort_operation converges with rebase_abort ─────────────────
+//
+// `abort_operation` is the generic conflict-screen/palette abort — it's not
+// rebase-specific and historically just hard-reset to current HEAD +
+// cleanup_state(), without touching the `RebaseState` map. During a paused
+// rebase, "current HEAD" is wherever the in-progress rebase happened to
+// stop, not the pre-rebase tip, and the stale `RebaseState` entry left
+// behind kept `rebase_status` reporting `in_progress`. Worse, a later
+// `rebase_abort` would then use that stale entry's `orig_head` to hard-reset
+// again — discarding any commits made since this abort.
+
+#[test]
+fn abort_operation_clears_rebase_state_and_restores_pre_rebase_head() {
+    use support::fs::write_file;
+
+    // Same "pick B onto root, then pick A" conflict setup as
+    // `rebase_conflict_pauses` above.
+    let tr = TempRepo::with_initial_commit("line1\n");
+    write_file(tr.path(), "conflict.txt", "version A\n");
+    {
+        let mut index = tr.repo.index().unwrap();
+        index.add_path(std::path::Path::new("conflict.txt")).unwrap();
+        index.write().unwrap();
+        let tree_oid = index.write_tree().unwrap();
+        let tree = tr.repo.find_tree(tree_oid).unwrap();
+        let sig = git2::Signature::now("T", "t@t").unwrap();
+        let parent = tr.repo.head().unwrap().peel_to_commit().unwrap();
+        tr.repo.commit(Some("HEAD"), &sig, &sig, "commit A", &tree, &[&parent]).unwrap();
+    }
+    let oid_a = tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string();
+
+    write_file(tr.path(), "conflict.txt", "version B\n");
+    {
+        let mut index = tr.repo.index().unwrap();
+        index.add_path(std::path::Path::new("conflict.txt")).unwrap();
+        index.write().unwrap();
+        let tree_oid = index.write_tree().unwrap();
+        let tree = tr.repo.find_tree(tree_oid).unwrap();
+        let sig = git2::Signature::now("T", "t@t").unwrap();
+        let parent = tr.repo.head().unwrap().peel_to_commit().unwrap();
+        tr.repo.commit(Some("HEAD"), &sig, &sig, "commit B", &tree, &[&parent]).unwrap();
+    }
+    let oid_b = tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string();
+
+    let (backend, handle) = tr.open_with_backend();
+
+    // Pre-rebase tip — current HEAD (commit B) before `rebase_start` moves it.
+    let head_before = backend.log(&handle.id, 1).unwrap()[0].oid.clone();
+
+    let plan = vec![
+        RebaseStep { oid: oid_b.clone(), action: RebaseAction::Pick, message: None },
+        RebaseStep { oid: oid_a.clone(), action: RebaseAction::Pick, message: None },
+    ];
+    let status = backend.rebase_start(&handle.id, plan).unwrap();
+    assert!(status.in_progress, "should be paused after conflict");
+
+    // The Conflict screen / palette abort path — NOT `rebase_abort`.
+    backend.abort_operation(&handle.id).unwrap();
+
+    let status_after = backend.rebase_status(&handle.id).unwrap();
+    assert!(
+        !status_after.in_progress,
+        "abort_operation must remove the RebaseState entry, not just reset the worktree"
+    );
+
+    let head_after = backend.log(&handle.id, 1).unwrap()[0].oid.clone();
+    assert_eq!(
+        head_after, head_before,
+        "abort_operation should restore the pre-rebase HEAD (converging with rebase_abort), \
+         not wherever the in-progress rebase happened to stop"
+    );
+}
+
+// ─── 9. sweeping RebaseState on successful completion ────────────────────────
+
+#[test]
+fn rebase_completion_clears_rebase_state() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 3); // commits 0, 1, 2
+
+    let (backend, handle) = tr.open_with_backend();
+
+    // Pre-rebase tip — recorded by `rebase_start` as `orig_head`.
+    let head_before = backend.log(&handle.id, 1).unwrap()[0].oid.clone();
+
+    // Drop the middle commit so the post-rebase tip is structurally
+    // different from the pre-rebase tip (a plan that reproduces the exact
+    // same history can cherry-pick to byte-identical commits, which would
+    // make this test pass by coincidence rather than by actually exercising
+    // state removal).
+    let plan = vec![
+        step(&oids[0], RebaseAction::Pick),
+        step(&oids[1], RebaseAction::Drop),
+        step(&oids[2], RebaseAction::Pick),
+    ];
+    let status = backend.rebase_start(&handle.id, plan).unwrap();
+    assert!(!status.in_progress, "no conflicts expected, rebase should finish");
+
+    let status_after = backend.rebase_status(&handle.id).unwrap();
+    assert!(!status_after.in_progress, "no rebase in progress after completion");
+
+    let head_after_rebase = backend.log(&handle.id, 1).unwrap()[0].oid.clone();
+    assert_ne!(head_after_rebase, head_before, "sanity: dropping a commit must move the tip");
+
+    // Prove the in-memory RebaseState entry itself is gone, not just that
+    // in_progress happens to read false because completed == total: calling
+    // abort_operation on a finished rebase must be a no-op that leaves HEAD
+    // alone, not a hard reset back to the pre-rebase tip using a stale
+    // orig_head (which would silently discard the completed rebase).
+    backend.abort_operation(&handle.id).unwrap();
+    let head_after_abort = backend.log(&handle.id, 1).unwrap()[0].oid.clone();
+    assert_eq!(
+        head_after_abort, head_after_rebase,
+        "abort_operation after a completed rebase must not discard it"
+    );
 }

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -1291,6 +1291,8 @@ export function PGConflictRow({
 
   return (
     <div
+      data-testid="conflict-row"
+      data-path={path}
       onClick={onClick}
       onContextMenu={onContextMenu}
       style={{
@@ -1577,6 +1579,8 @@ export function PGRebaseRow({
   const current = actions.find((a) => a.value === action) || actions[0];
   return (
     <div
+      data-testid="rebase-row"
+      data-sha={sha}
       style={{
         display: "flex",
         alignItems: "center",

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -523,6 +523,10 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await mergeBranchFn(repo.id, name);
       await get().refreshAll();
     } catch (e) {
+      // refreshAll clears `error` as its first act, so refresh before
+      // recording the error — otherwise the two synchronous `set()` calls
+      // land in the same React batch and the error is wiped before render.
+      await get().refreshAll();
       set({ error: toAppError(e) });
     }
   },
@@ -534,6 +538,9 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await rebaseOntoFn(repo.id, upstream);
       await get().refreshAll();
     } catch (e) {
+      // See mergeBranch's catch: refresh first, error last, so it isn't
+      // batched away by refreshAll's own `error: null` reset.
+      await get().refreshAll();
       set({ error: toAppError(e) });
     }
   },
@@ -642,6 +649,9 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await cherryPick(repo.id, oid);
       await get().refreshAll();
     } catch (e) {
+      // See mergeBranch's catch: refresh first, error last, so it isn't
+      // batched away by refreshAll's own `error: null` reset.
+      await get().refreshAll();
       set({ error: toAppError(e) });
     }
   },
@@ -653,6 +663,9 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await revertFn(repo.id, oid);
       await get().refreshAll();
     } catch (e) {
+      // See mergeBranch's catch: refresh first, error last, so it isn't
+      // batched away by refreshAll's own `error: null` reset.
+      await get().refreshAll();
       set({ error: toAppError(e) });
     }
   },

--- a/src/screens/Branches.tsx
+++ b/src/screens/Branches.tsx
@@ -459,6 +459,7 @@ export function BranchesScreen() {
             {visibleStashes.map((s) => (
               <div
                 key={`stash:${s.index}`}
+                data-stash-index={s.index}
                 onClick={() => setSelection({ kind: "stash", index: s.index })}
                 onContextMenu={(e) =>
                   onStashCtx(e, { index: s.index, name: `stash@{${s.index}}` })

--- a/src/screens/Conflict.tsx
+++ b/src/screens/Conflict.tsx
@@ -161,6 +161,7 @@ function ConflictHeader({
         tone="danger"
         icon="x"
         disabled={repoState === "Clean"}
+        data-testid="conflict-abort"
         onClick={() => {
           if (
             window.confirm(
@@ -176,6 +177,7 @@ function ConflictHeader({
         variant="primary"
         icon="merge"
         disabled={unresolved > 0 || repoState === "Clean"}
+        data-testid="conflict-finalize"
         onClick={() => useRepoStore.getState().continueOperation()}
       >
         Finalize
@@ -317,6 +319,7 @@ function ConflictDetail({ path }: { path: string }) {
               size="sm"
               variant="outline"
               icon="chevronLeft"
+              data-testid="accept-ours"
               onClick={() => acceptOurs(path)}
             >
               Accept ours
@@ -325,6 +328,7 @@ function ConflictDetail({ path }: { path: string }) {
               size="sm"
               variant="outline"
               icon="chevronRight"
+              data-testid="accept-theirs"
               onClick={() => acceptTheirs(path)}
             >
               Accept theirs
@@ -333,6 +337,7 @@ function ConflictDetail({ path }: { path: string }) {
               size="sm"
               variant="primary"
               icon="check"
+              data-testid="mark-resolved"
               onClick={() => markResolved([path])}
             >
               Mark worktree as resolved

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -404,10 +404,22 @@ function CommitActionRow({ commit }: { commit: CommitInfo }) {
       <PGButton size="sm" variant="outline" icon="tag" onClick={tagHere}>
         Tag
       </PGButton>
-      <PGButton size="sm" variant="outline" icon="commit" onClick={cherryPick}>
+      <PGButton
+        size="sm"
+        variant="outline"
+        icon="commit"
+        data-testid="commit-cherry-pick"
+        onClick={cherryPick}
+      >
         Cherry-pick
       </PGButton>
-      <PGButton size="sm" variant="outline" icon="x" onClick={revert}>
+      <PGButton
+        size="sm"
+        variant="outline"
+        icon="x"
+        data-testid="commit-revert"
+        onClick={revert}
+      >
         Revert
       </PGButton>
       <PGButton

--- a/src/screens/Rebase.tsx
+++ b/src/screens/Rebase.tsx
@@ -88,10 +88,22 @@ function RebaseBanner({
       >
         {nextIndex}/{total}
       </span>
-      <PGButton size="sm" variant="outline" onClick={onAbort} icon="x">
+      <PGButton
+        size="sm"
+        variant="outline"
+        onClick={onAbort}
+        icon="x"
+        data-testid="rebase-abort"
+      >
         Abort
       </PGButton>
-      <PGButton size="sm" variant="primary" onClick={onContinue} icon="check">
+      <PGButton
+        size="sm"
+        variant="primary"
+        onClick={onContinue}
+        icon="check"
+        data-testid="rebase-continue"
+      >
         Continue
       </PGButton>
     </div>
@@ -283,6 +295,7 @@ export function RebaseScreen() {
               icon="rebase"
               onClick={handleStart}
               disabled={plan.length === 0}
+              data-testid="rebase-start"
             >
               Start rebase
             </PGButton>


### PR DESCRIPTION
## Summary
- Phase 2 E2E coverage: merge (clean/conflict/abort), conflict resolution
  (ours/theirs/finalize), interactive rebase (squash + conflicted abort),
  reset soft/hard, cherry-pick, revert, reflog jumps (detached + dirty-tree
  dialog). 4 new spec files, bringing the suite to 10 spec files / 23 tests
  (22 passing + 1 documented `it.skip`).
- **Fix (stale UI):** `mergeBranch`/`rebaseOnto` in `useRepoStore` now
  `refreshAll()` in the catch arm before setting the error, so a conflicted
  merge/rebase surfaces in the Conflicts screen and status bar immediately
  instead of waiting for an unrelated refresh (test 2 proves it red→green).
- **Fix (rebase abort):** `rebase_abort` (`src-tauri/src/git/libgit2.rs`)
  only hard-reset to *current* HEAD, which `rebase_start`/`advance_rebase`
  had already moved forward — aborting a conflicted rebase left the branch
  mid-rebase instead of restoring its original tip. `RebaseState` now
  tracks the pre-rebase tip in `orig_head` and restores it on abort
  (mirrors `git rebase --abort`/`ORIG_HEAD`). Discovered while writing the
  rebase-conflict test; tightened `rebase_abort_resets_to_pre_rebase_head`
  in `src-tauri/tests/rebase.rs` to assert it. Both fixes reviewed and
  user-approved.
- Cherry-pick test (`history-ops.e2e.ts`, test 10) is `it.skip`'d: the
  backend log is HEAD-only, so no UI surface shows a commit that only
  exists on an unmerged branch — nothing to right-click. Filed as
  #27; unskip when ref-scoped log ships.
- Helpers promoted/added to `e2e/support/app.ts`: `jsContextMenu` extended
  with hover-submenu support (`jsHoverMenuItem`/`jsClickMenuItem`), plus
  the shared `changeRow`/`stagedRow` row-selector factories. New fixtures
  in `e2e/support/tempRepo.ts`: `conflictRepo`, `cherryRepo`,
  `rebaseConflictRepo`, and `TempRepo.hasRef`.
- Sparse `data-*` attributes on Conflict/Rebase/History components.

Spec: docs/superpowers/specs/2026-07-02-e2e-phase2-design.md
Plan: docs/superpowers/plans/2026-07-02-e2e-phase2.md

## Test plan
- [x] `pnpm tsc --noEmit` + `pnpm exec tsc -p e2e/tsconfig.json --noEmit` + `pnpm test` (96 tests) — green locally
- [x] `cargo check` + `cargo test --manifest-path src-tauri/Cargo.toml` (108 tests) — green locally
- [x] `pnpm test:e2e` — 10/10 spec files, 22 passing + 1 skip (#27) locally (macOS)
- [x] e2e workflow green (Linux CI) — run 28636484876, 10/10 spec files, 22 passing + 1 skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)