### PR TITLE
docs: e2e-testing project skill + workflow learnings

### DIFF
--- a/.claude/skills/e2e-testing/SKILL.md
+++ b/.claude/skills/e2e-testing/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: e2e-testing
+description: Use when writing, debugging, or reviewing WebdriverIO e2e specs in e2e/ — adding tests, selector failures, flaky or suddenly-slow suites (5s per command, multi-minute runs), native dialog/context-menu interaction, temp-repo fixtures, or CI e2e failures.
+---
+
+# E2E Testing Playbook (platypusgit)
+
+Hard-won rules from building the suite. Every trap below bit a real implementation attempt; the fix is stated as the rule.
+
+## Commands
+
+```bash
+pnpm test:e2e        # test:e2e:build + test:e2e:run — REQUIRED after ANY src/ or src-tauri/ change
+pnpm test:e2e:run    # reuses e2e/.bin snapshot — spec-only iterations
+pnpm test:e2e:run --spec e2e/specs/<file>   # single spec
+pnpm exec tsc -p e2e/tsconfig.json --noEmit # e2e typecheck gate (root tsc EXCLUDES e2e/)
+```
+
+**Stale-binary trap:** `test:e2e:run` tests whatever binary is in `e2e/.bin/`. A green run after touching `src/` proves nothing unless a full `test:e2e` ran after the change. Plain `cargo build` silently rewrites `target/debug/platypusgit` WITHOUT `custom-protocol` (blank window) — that's why the snapshot exists. Close any running dev app first: debug builds all serve WebDriver on port 4445 and the runner may attach to the dev instance and clear its localStorage.
+
+## Driver bridge (the 5-seconds-per-command failure)
+
+The embedded driver's focus-check polls 5s for `window.__wdio_original_core__` on EVERY find/click when unarmed. `armDriverBridge()` (`e2e/support/app.ts`) hands it `window.__TAURI__.core` (exists only in e2e builds via `src-tauri/tauri.e2e.conf.json`).
+
+**Reload race:** after `browser.refresh()`, an immediate arm can land on the OUTGOING document (it also has `__TAURI__`), leaving the new page unarmed. The only trustworthy "navigation settled" signal is a matched WebDriver find. **Rule: any new `browser.refresh()` call site must wait for a real element, then call `armDriverBridge()` again** — see `resetApp`/`openRepo`/`waitRepoLoaded` for the pattern.
+
+**Flake bands:** healthy full suite ≈ 20s–2.5min. A run >5min, or single commands taking 5–30s, means the bridge is unarmed somewhere — check the newest refresh site, not the specs.
+
+## Selectors
+
+| Need | Use | Never |
+|---|---|---|
+| Button by label | `button*=Stage all` | `button=…` (PGButton wraps label in `<span>` — exact match can't hit) |
+| Text anywhere | tag-scoped: `div*=`, `span*=`, `label*=` | bare `*=text` (partial-LINK-text: anchors only) |
+| Row by identity | `[data-testid="…"][data-path="…"]` or attr+text `[data-branch-row]*=main` | index/nth selectors |
+| Dialog option | `dialog.$('label*=Option title')` | `div*=` inside dialogs (matches the outer wrapper — XPath `contains(., t)` uses concatenated descendant text) |
+
+**Substring traps (both happened):** `span*=conflict` matched the filename `conflict.txt`, making a status-badge assertion vacuous — fixed to `span*=1 conflict`. Pick text unique across the whole screen INCLUDING file names the fixture creates. `button*=Go` inside a dialog is fine only because Cancel/Go are the only buttons — verify scope before trusting short substrings.
+
+Adding hooks: `PGButton`/`PGInput` spread `...rest` (pass `data-testid` directly). `PGIconButton` does NOT (title only). Design-system rows need an explicit prop threaded. One screen mounts at a time, so testids may repeat across screens.
+
+## Native dialogs, context menus, hover
+
+WebDriver cannot drive `window.prompt`/`confirm`, right-click, or hover here.
+
+- `stubNativeDialogs({promptText, confirm})` — call AFTER the last page (re)load (reloads wipe stubs) and BEFORE the triggering click.
+- `jsContextMenu(selector, {text})` opens the app's portal context menu; `jsClickMenuItem(label)` clicks an item; `jsHoverMenuItem(label)` opens hover submenus (e.g. History → "Reset current branch to here"). All in `e2e/support/app.ts` — extend the helper there, never inline in a spec.
+
+## Fixtures & assertions
+
+Fixtures live in `e2e/support/tempRepo.ts` (`basicRepo`, `dirtyRepo`, `branchyRepo`, `conflictRepo`, `cherryRepo`, `rebaseConflictRepo`). Geometry gotchas that produced unsatisfiable assertions:
+
+- Branch-from-tip merges **fast-forward** — no merge commit exists to assert. Diverge both branches if the test needs one.
+- Interactive-rebase conflicts: `rebase_start` resets to the first surviving pick's parent, so a **leading** drop can never conflict — drop a **middle** commit.
+- The store reads status at `openRepo`; **dirty files must exist on disk BEFORE openRepo** or the UI won't know.
+- History shows HEAD-reachable commits only (issue #27) — unmerged-ref commits appear nowhere.
+- Root commit's "Interactive rebase from here" silently no-ops.
+
+**Assertion contract:** repo truth (`repo.git(...)`, `repo.read(...)`) is the acceptance, as plain `expect`s AFTER a UI wait; UI text is the wait condition. `waitUntil` on repo truth only when no UI signal exists — say so in a comment. Every wait: `timeout` + `timeoutMsg`. Never `pause()`.
+
+## Debugging
+
+1. Reproduce on one spec: `pnpm test:e2e:run --spec e2e/specs/<file>`.
+2. Inspect real DOM, don't guess: `await browser.execute(() => document.querySelector('[role="dialog"]')?.outerHTML)`.
+3. Suite slow? → flake bands above (bridge), not the spec.
+4. Selector fights >20min → capture outerHTML evidence, then fix or escalate; never fake a flow by shelling `git` for the action under test.
+
+## Before committing
+
+- src/ touched → full `pnpm test:e2e` green (paste output, not counts).
+- `pnpm exec tsc -p e2e/tsconfig.json --noEmit` + `pnpm tsc --noEmit` + `pnpm test`.
+- New refresh site → re-arm rule applied. New helper → lives in `e2e/support/`.

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ site/.astro
 # local planning notes
 features.md
 implemented-features.md
+
+# assistant session worktrees (not repo content)
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,9 @@ cargo check --manifest-path src-tauri/Cargo.toml
 cargo test --manifest-path src-tauri/Cargo.toml
 pnpm tauri build                            # production bundle (.msi/.dmg/.deb/.AppImage)
 pnpm test                                   # vitest (unit logic + component tests)
+pnpm test:e2e                               # e2e: debug build + wdio (REQUIRED after src/ changes)
+pnpm test:e2e:run                           # e2e against existing binary (spec-only iterations)
+pnpm exec tsc -p e2e/tsconfig.json --noEmit # e2e typecheck gate (root tsc excludes e2e/)
 ```
 
 ## Testing
@@ -69,41 +72,22 @@ Four layers, each run independently:
     `test:e2e:run` (wdio against that snapshot). Frontend or Rust change →
     run the full `pnpm test:e2e`; spec-only change → `pnpm test:e2e:run`
     reuses the existing binary.
-  - `src-tauri/tauri.e2e.conf.json` is a config overlay that turns on
-    `withGlobalTauri` for E2E builds only — release and regular dev builds
-    are untouched. `armDriverBridge()` (`e2e/support/app.ts`) then hands
-    `window.__TAURI__.core` to the embedded driver after every page load.
-    Skip either piece and every driver command pays a 5s window-focus-check
-    penalty (a ~13min suite instead of ~6s).
-  - The driver can't synthesize a right-click: context menus are opened via
-    the in-page `jsContextMenu` helper (see `e2e/support/app.ts`);
-    everything else uses real WebDriver clicks.
-  - Danger-op flows (merge/conflict, rebase, reset, cherry-pick/revert,
-    reflog) covered by phase 2 specs. Context menus (incl. the reset hover
-    submenu) driven via `jsContextMenu`/`jsHoverMenuItem`/`jsClickMenuItem`
-    and row lookups via `changeRow`/`stagedRow`, all promoted to
-    `e2e/support/app.ts`. Fixtures: `conflictRepo`, `cherryRepo`,
-    `rebaseConflictRepo`, plus `TempRepo.hasRef`.
-  - Selector conventions: `button*=Text` (PGButton span-wraps its label, so
-    bare button-text selectors don't match) and tag-scoped text selectors
-    (`div*=`, `span*=` — bare `*=` is partial-link-text and only matches
-    anchors). Native `window.prompt`/`window.confirm` are stubbed via
-    `stubNativeDialogs()`, since WebDriver can't drive native dialogs.
-  - Sparse `data-*` attributes added where selectors would be brittle:
-    `recent-repo` + `data-path`, `branch-chip`, `data-activity` (activity
-    bar), `staged-list`/`changes-list` + row `data-path`, `row-toggle`,
-    `commit-subject`, `commit-button`, `branch-create`, `commit-row` +
-    `data-sha`, `hunk-stage`, and `PGFileTreeRow`'s `data-path`.
-  - CI: `.github/workflows/e2e.yml` (ubuntu-latest + xvfb, on PRs to `main`
-    and on push to `main`) runs `pnpm test:e2e:build` then
-    `xvfb-run --auto-servernum pnpm test:e2e:run`.
-  - `pnpm.overrides["@wdio/native-utils"] = "2.5.0"` in `package.json` pins
-    around a broken dep pin shipped by `@wdio/tauri-service@1.2.0` — don't
-    remove it or you'll be re-bisecting this from scratch.
-  - Debug builds also serve WebDriver on port 4445. Close any running
-    `pnpm tauri dev` instance before `pnpm test:e2e:run` — otherwise the
-    service can attach to the dev instance instead of the E2E binary and
-    clear its `localStorage`.
+  - **Before writing or debugging any e2e spec, read the `e2e-testing`
+    project skill** (`.claude/skills/e2e-testing/SKILL.md`) — selector
+    conventions and traps, driver-bridge/5s-penalty rules, native-dialog
+    stubbing, fixture geometry gotchas, rebuild discipline, debugging flow.
+  - `pnpm test:e2e` = `test:e2e:build` (debug build with
+    `--features tauri/custom-protocol --config src-tauri/tauri.e2e.conf.json`,
+    snapshot → gitignored `e2e/.bin/`) + `test:e2e:run`. Any src/ or
+    src-tauri/ change requires the full `pnpm test:e2e` — `test:e2e:run`
+    silently tests the old snapshot.
+  - CI: `.github/workflows/e2e.yml` (ubuntu-latest + xvfb, PRs to `main` +
+    push to `main`).
+  - `pnpm.overrides["@wdio/native-utils"] = "2.5.0"` pins around a broken
+    dep pin in `@wdio/tauri-service@1.2.0` — don't remove.
+  - Debug builds serve WebDriver on port 4445: close any `pnpm tauri dev`
+    instance before e2e runs or the runner may attach to it and clear its
+    `localStorage`.
 
 ## Architecture
 
@@ -209,6 +193,7 @@ lib/
 
 ### State management
 - **Zustand per-feature**, not one big global store. `useRepoStore` lives in `features/repo/` because that's who owns the state.
+- **Danger-op error paths refresh first, set error last.** In `useRepoStore` catch arms (see `mergeBranch`), call `refreshAll()` BEFORE `set({ error })`: `refreshAll` starts with `set({ error: null })`, and React 18 batches same-tick sets, so the opposite order silently wipes the banner. `refreshAll` never rethrows, so the error always wins when set last. A failed git op must still refresh — the UI reflects disk truth even on error.
 - `useNavStore` handles cross-screen navigation intents — add new `NavIntent` kinds there, route in `AppShell`.
 - Cross-feature state is rare; compose in `src/store.ts` if needed — don't hoist prematurely.
 
@@ -224,6 +209,7 @@ lib/
 ### Design system
 - Import UI primitives from `@/design` (not per-file). `design/index.ts` barrel re-exports everything.
 - New shared primitive → add to appropriate file in `src/design/` and re-export via `index.ts`.
+- `PGButton`/`PGInput` spread `...rest` onto their DOM node (so `data-testid` etc. pass through); `PGIconButton` does NOT (forwards `title` only). Row components (`PGChangeRow`, `PGCommitRow`, `PGFileTreeRow`, …) need explicit prop threading for new attributes.
 - Do NOT add `src/components/ui/`. The design system lives in `src/design/`.
 
 ### Permissions (Tauri 2)
@@ -265,3 +251,4 @@ Do not create empty / merge commits. Do not amend published commits without aski
 - **Always rebase onto the latest `main` right before merging** (`git fetch origin && git rebase origin/main`, then force-push). Never merge a PR whose branch is behind `main`.
 - Resolve conflicts during rebase; force-push the branch (`--force-with-lease`) after rebasing.
 - Branch and open a PR even for assistant-driven work — don't push straight to `main`.
+- `main` may be checked out by a worktree under `.claude/worktrees/` (other assistant sessions). Then `git checkout main` and `gh pr merge --delete-branch`'s local cleanup fail with "'main' is already used by worktree" — the remote merge still succeeds. Recover with `git checkout --detach origin/main`, delete the branch manually, and leave the other worktree alone.


### PR DESCRIPTION
## Summary
- New committed project skill `.claude/skills/e2e-testing/SKILL.md` — the full e2e playbook distilled from phases 1+2: driver-bridge/5s-penalty rules incl. the reload-race re-arm-after-find discipline, selector trap table (with the two real substring incidents), native-dialog stub timing, context-menu/hover helpers, fixture geometry gotchas (fast-forward merges, middle-drop rebase conflicts, dirty-before-open), rebuild discipline, debugging flow, pre-commit checklist.
- CLAUDE.md: e2e commands (incl. the e2e tsc gate) in Common commands; E2E testing bullet slimmed to essentials + skill pointer; new conventions — store danger-op catch arms refresh-first-then-set-error (React 18 batching), PGIconButton doesn't spread rest, worktree-held `main` merge-cleanup recovery.
- `.gitignore`: `.claude/worktrees/` (assistant session worktrees).

Skill verified with two subagent scenarios (design-a-new-test + diagnose-the-5s-symptom) against baseline failures documented in the phase 1/2 task reports — both applied the conventions correctly.

## Test plan
- [x] Docs-only change; `pnpm test` unaffected
- [x] Skill retrieval/application scenarios pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)