### PR TITLE
test(e2e): remotes, palette & settings suite, phase 3 (+3 app fixes)

### DIFF
--- a/.claude/skills/e2e-testing/SKILL.md
+++ b/.claude/skills/e2e-testing/SKILL.md
@@ -45,6 +45,14 @@ WebDriver cannot drive `window.prompt`/`confirm`, right-click, or hover here.
 
 - `stubNativeDialogs({promptText, confirm})` — call AFTER the last page (re)load (reloads wipe stubs) and BEFORE the triggering click.
 - `jsContextMenu(selector, {text})` opens the app's portal context menu; `jsClickMenuItem(label)` clicks an item; `jsHoverMenuItem(label)` opens hover submenus (e.g. History → "Reset current branch to here"). All in `e2e/support/app.ts` — extend the helper there, never inline in a spec.
+- `stubNativeDialogs({promptQueue: ["a", "b"]})` — multi-prompt flows (Add
+  remote asks name THEN url; a single promptText would set name === url).
+  Confirm calls are counted: `confirmCallCount()` is the positive signal
+  that a confirm gate fired (there is no UI signal when a user "cancels").
+- Palette: `openPalette()` (js-dispatched ⌘P — the driver can't synthesize
+  Meta chords), `jsKey(paletteInput, "Enter"|"Escape")` for control keys,
+  `setValue(paletteInput)` for typing. Scope EVERY palette selector under
+  `paletteDialog` — it's portaled to body over the live screen.
 
 ## Fixtures & assertions
 
@@ -55,6 +63,12 @@ Fixtures live in `e2e/support/tempRepo.ts` (`basicRepo`, `dirtyRepo`, `branchyRe
 - The store reads status at `openRepo`; **dirty files must exist on disk BEFORE openRepo** or the UI won't know.
 - History shows HEAD-reachable commits only (issue #27) — unmerged-ref commits appear nowhere.
 - Root commit's "Interactive rebase from here" silently no-ops.
+- `remoteRepo()` pairs a work repo with a local bare `origin`. `makeBehind`
+  rewinds `refs/remotes/origin/main` so fetch has something to discover —
+  but that same rewind makes `--force-with-lease` fail ("stale info").
+  Force-push tests use `makeDiverged` (accurate remote-tracking) instead.
+- Titlebar Fetch/Pull/Push are unambiguous `button*=` targets only while a
+  non-Remote screen is active — the Remote screen adds two more sets.
 
 **Assertion contract:** repo truth (`repo.git(...)`, `repo.read(...)`) is the acceptance, as plain `expect`s AFTER a UI wait; UI text is the wait condition. `waitUntil` on repo truth only when no UI signal exists — say so in a comment. Every wait: `timeout` + `timeoutMsg`. Never `pause()`.
 
@@ -64,6 +78,11 @@ Fixtures live in `e2e/support/tempRepo.ts` (`basicRepo`, `dirtyRepo`, `branchyRe
 2. Inspect real DOM, don't guess: `await browser.execute(() => document.querySelector('[role="dialog"]')?.outerHTML)`.
 3. Suite slow? → flake bands above (bridge), not the spec.
 4. Selector fights >20min → capture outerHTML evidence, then fix or escalate; never fake a flow by shelling `git` for the action under test.
+5. "X never appeared" while the DOM provably contains X (dump outerHTML to
+   check) → focus race: another app holds foreground, WKWebView reports
+   `visibilityState: "hidden"`, and `isDisplayed()` lies. Minimize/quit
+   focus-stealing apps (e.g. Remote Desktop) and rerun; see issue on local
+   focus flake. CI (xvfb) is immune.
 
 ## Before committing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Context for future Claude sessions working on this repo. Keep it current when ar
 New feature beyond MVP slice → write new spec + plan under these folders first.
 
 Recent specs/plans (for context on current direction):
+- `2026-07-03-e2e-phase3-*` — e2e phase 3: remote/palette/settings coverage, dead-settings audit.
 - `2026-04-24-centralized-branch-ui-*` — sidebar removed, titlebar branch chip + popover picker.
 - `2026-04-23-reflog-viewer-*` — reflog screen + dirty-tree handling.
 - `2026-04-23-commit-graph-layout-*` — graph layout engine for history view.
@@ -60,8 +61,8 @@ Four layers, each run independently:
   `src/`. Runs in jsdom with React Testing Library. The Tauri `invoke` and
   `plugin-dialog.open` calls are mocked via `src/test/setup.ts`; tests register
   per-command responses with `mockInvoke(cmd, handler)`.
-- **E2E (webview-level)** — WebdriverIO specs in `e2e/specs/` (10 files, 23
-  tests — 22 passing + 1 skipped pending #27) drive the real debug binary: real webview →
+- **E2E (webview-level)** — WebdriverIO specs in `e2e/specs/` (13 files, 47
+  tests — 46 passing + 1 skipped pending #27) drive the real debug binary: real webview →
   real Tauri IPC → real libgit2 → temp repos built by `e2e/support/tempRepo.ts`.
   Uses the embedded WebDriver provider (`@wdio/tauri-service`) — no external
   driver or paid service — so it runs on macOS (WKWebView) and on Linux CI
@@ -69,18 +70,13 @@ Four layers, each run independently:
   - `pnpm test:e2e` = `test:e2e:build` (a tauri debug build with
     `--features tauri/custom-protocol --config src-tauri/tauri.e2e.conf.json`,
     snapshotting the binary to gitignored `e2e/.bin/`) followed by
-    `test:e2e:run` (wdio against that snapshot). Frontend or Rust change →
-    run the full `pnpm test:e2e`; spec-only change → `pnpm test:e2e:run`
-    reuses the existing binary.
+    `test:e2e:run` (wdio against that snapshot). Any src/ or src-tauri/
+    change requires the full `pnpm test:e2e` — `test:e2e:run` silently
+    tests the old snapshot; spec-only change → `pnpm test:e2e:run`.
   - **Before writing or debugging any e2e spec, read the `e2e-testing`
     project skill** (`.claude/skills/e2e-testing/SKILL.md`) — selector
     conventions and traps, driver-bridge/5s-penalty rules, native-dialog
     stubbing, fixture geometry gotchas, rebuild discipline, debugging flow.
-  - `pnpm test:e2e` = `test:e2e:build` (debug build with
-    `--features tauri/custom-protocol --config src-tauri/tauri.e2e.conf.json`,
-    snapshot → gitignored `e2e/.bin/`) + `test:e2e:run`. Any src/ or
-    src-tauri/ change requires the full `pnpm test:e2e` — `test:e2e:run`
-    silently tests the old snapshot.
   - CI: `.github/workflows/e2e.yml` (ubuntu-latest + xvfb, PRs to `main` +
     push to `main`).
   - `pnpm.overrides["@wdio/native-utils"] = "2.5.0"` pins around a broken

--- a/docs/superpowers/plans/2026-07-03-e2e-phase3.md
+++ b/docs/superpowers/plans/2026-07-03-e2e-phase3.md
@@ -1,0 +1,1090 @@
+# E2E Phase 3 (remotes, palette, settings) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Webview-level e2e coverage for remote operations (against a local bare repo), command-palette machinery, and settings — plus two app fixes: wire the dead remote context menu and gate force-push behind the `confirmForcePush` setting.
+
+**Architecture:** Extends the Phase 1/2 WDIO harness (`e2e/support/`). New `remoteRepo()` fixture pairs a work repo with a local bare `origin`. Two src changes (Remote-screen context menu, palette force-push gate) land before the specs that prove them. Spec: `docs/superpowers/specs/2026-07-03-e2e-phase3-design.md`.
+
+**Tech Stack:** WebdriverIO 9 + `@wdio/tauri-service` embedded provider, Mocha, TypeScript, React 18, Zustand, Tauri 2.
+
+## Global Constraints
+
+- **Read `.claude/skills/e2e-testing/SKILL.md` before writing or debugging any e2e spec.** Selector conventions, driver-bridge/5s-penalty rules, native-dialog stubbing, rebuild discipline all live there and bind every task below.
+- Bash env: prepend `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"` before any `pnpm`/`cargo` command.
+- After ANY `src/` or `src-tauri/` change, e2e proof requires the full `pnpm test:e2e` (rebuild). Spec-only iterations may use `pnpm test:e2e:run`.
+- Close any running `pnpm tauri dev` before e2e runs (port 4445 clash).
+- Repo truth (`repo.git(...)`, `pair.bareGit(...)`, `repo.read(...)`) is the acceptance assertion; UI text is the wait condition. Every wait has `timeout` + `timeoutMsg`. Never `pause()`.
+- Type gates for every task touching TS: `pnpm tsc --noEmit` and `pnpm exec tsc -p e2e/tsconfig.json --noEmit`.
+- Commit style: Conventional Commits, `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` trailer. Branch `test/e2e-phase3` (already exists, spec committed).
+- Error enum untouched — no new Rust code in this phase.
+- Exact string constants: localStorage keys `pg-settings-v2`, `pg-palette-frecency`, `pg-recent-repos`; palette dialog selector `[role="dialog"][aria-label="Command palette"]`; pull modes `"FastForward" | "Merge" | "Rebase"`; push force values `"None" | "WithLease" | "Force"`.
+
+---
+
+### Task 1: Harness — remoteRepo fixture, prompt queue, palette helpers
+
+**Files:**
+- Modify: `e2e/support/tempRepo.ts` (append after `rebaseConflictRepo`)
+- Modify: `e2e/support/app.ts` (replace `stubNativeDialogs`; append new helpers)
+
+**Interfaces:**
+- Produces: `remoteRepo(): RemotePair` with `RemotePair = { repo: TempRepo; barePath: string; bareGit: (...args: string[]) => string; dispose: () => void }`; `makeAhead(pair)`, `makeBehind(pair)`, `makeDiverged(pair)` (all `(pair: RemotePair) => void`); `stubNativeDialogs({ promptText?, confirm?, promptQueue? })` (backward compatible); `confirmCallCount(): Promise<number>`; `reopenRepo(repoPath: string): Promise<void>` (reload WITHOUT localStorage.clear); `openPalette(): Promise<void>`; `paletteDialog`/`paletteInput` selector consts; `jsKey(selector: string, key: string): Promise<void>`.
+
+- [ ] **Step 1: Add fixture to `e2e/support/tempRepo.ts`**
+
+Append:
+
+```ts
+/** Work repo + local bare repo wired as `origin` with upstream set.
+ *  No network, no credentials: the backend shells to the system git CLI,
+ *  which handles filesystem-path remotes natively. */
+export interface RemotePair {
+  repo: TempRepo;
+  barePath: string;
+  bareGit: (...args: string[]) => string;
+  dispose: () => void;
+}
+
+export function remoteRepo(): RemotePair {
+  const repo = basicRepo();
+  const barePath = mkdtempSync(path.join(tmpdir(), "pg-e2e-bare-"));
+  execFileSync("git", ["init", "--bare", "-b", "main"], { cwd: barePath });
+  repo.git("remote", "add", "origin", barePath);
+  repo.git("push", "-u", "origin", "main");
+  const bareGit = (...args: string[]) =>
+    execFileSync("git", args, { cwd: barePath, encoding: "utf8" });
+  return {
+    repo,
+    barePath,
+    bareGit,
+    dispose: () => {
+      repo.dispose();
+      rmSync(barePath, { recursive: true, force: true });
+    },
+  };
+}
+
+/** Local is 1 ahead of origin/main. Remote-tracking ref stays accurate. */
+export function makeAhead(pair: RemotePair): void {
+  pair.repo.commitFile("local.txt", "local\n", "feat: local-only commit");
+}
+
+/** Remote is 1 ahead; the app does NOT know yet.
+ *  The remote-tracking ref is rewound too, so behind=0 until a real
+ *  fetch/pull discovers the remote commit — this is what makes fetch's
+ *  effect observable. Do NOT use this variant for force-push tests:
+ *  a rewound remote-tracking ref makes --force-with-lease fail with
+ *  "stale info" (the lease compares against refs/remotes/origin/main). */
+export function makeBehind(pair: RemotePair): void {
+  pair.repo.commitFile("remote.txt", "remote\n", "feat: remote-only commit");
+  pair.repo.git("push", "origin", "main");
+  pair.repo.git("reset", "--hard", "HEAD~1");
+  pair.repo.git("update-ref", "refs/remotes/origin/main", "HEAD");
+}
+
+/** Histories diverge: remote has one commit local lacks, local has one
+ *  commit remote lacks. Remote-tracking ref stays ACCURATE (no rewind):
+ *  ahead=1/behind=1 render immediately, plain push is rejected as
+ *  non-fast-forward, and --force-with-lease passes its lease check. */
+export function makeDiverged(pair: RemotePair): void {
+  pair.repo.commitFile("remote.txt", "remote\n", "feat: remote-only commit");
+  pair.repo.git("push", "origin", "main");
+  pair.repo.git("reset", "--hard", "HEAD~1");
+  pair.repo.commitFile("diverge.txt", "diverge\n", "feat: diverging local commit");
+}
+```
+
+Call variants BEFORE `openRepo()` — the store reads status when the repo opens.
+
+- [ ] **Step 2: Extend `stubNativeDialogs` in `e2e/support/app.ts`**
+
+Replace the existing function body (keep the doc comment, extend it):
+
+```ts
+/** WebDriver can't drive native prompt/confirm — stub them in-page BEFORE the
+ *  action that triggers them. Reset by any refresh.
+ *  `promptQueue`: successive `window.prompt` calls consume queue entries in
+ *  order (Add remote fires TWO prompts: name, then URL — a single string
+ *  would set name === url). Falls back to `promptText` when drained.
+ *  Confirm calls are counted on `window.__pgConfirmCalls` — read it via
+ *  `confirmCallCount()` to prove a confirm gate fired (or didn't). */
+export async function stubNativeDialogs(
+  opts: { promptText?: string; confirm?: boolean; promptQueue?: string[] } = {},
+): Promise<void> {
+  await browser.execute(
+    (promptText: string | null, confirm: boolean, queue: string[]) => {
+      const q = [...queue];
+      (window as any).__pgConfirmCalls = 0;
+      (window as any).prompt = () => (q.length ? q.shift()! : promptText);
+      (window as any).confirm = () => {
+        (window as any).__pgConfirmCalls++;
+        return confirm;
+      };
+    },
+    opts.promptText ?? "e2e",
+    opts.confirm ?? true,
+    opts.promptQueue ?? [],
+  );
+}
+
+export function confirmCallCount(): Promise<number> {
+  return browser.execute(() => (window as any).__pgConfirmCalls ?? 0);
+}
+```
+
+Then add `reopenRepo` right after the existing `openRepo`:
+
+```ts
+/** Reload the page WITHOUT clearing localStorage, then reopen the repo via
+ *  its recent-row. This is the persistence-test primitive: `openRepo` starts
+ *  with `localStorage.clear()`, which would wipe pg-settings-v2 and defeat
+ *  any "survives reload" assertion. Follows the re-arm rule: matched find →
+ *  re-arm (see armDriverBridge doc). */
+export async function reopenRepo(repoPath: string): Promise<void> {
+  await browser.refresh();
+  await armDriverBridge();
+  const row = $(`[data-testid="recent-repo"][data-path="${repoPath}"]`);
+  await row.waitForDisplayed({
+    timeout: 20_000,
+    timeoutMsg: "recent-repo row missing after reload — recents not persisted?",
+  });
+  await armDriverBridge();
+  await row.click();
+  await waitRepoLoaded();
+}
+```
+
+- [ ] **Step 3: Add palette helpers to `e2e/support/app.ts`**
+
+Append:
+
+```ts
+/** The command palette dialog and its query input. The dialog is portaled to
+ *  document.body — always scope palette selectors under paletteDialog so they
+ *  can't match screen content behind it. */
+export const paletteDialog = '[role="dialog"][aria-label="Command palette"]';
+export const paletteInput = `${paletteDialog} input`;
+
+/** Open the palette. AppShell listens for ⌘P on `window`
+ *  (src/AppShell.tsx), so an in-page KeyboardEvent dispatch is deterministic
+ *  — no reliance on the embedded driver synthesizing Meta-key chords. */
+export async function openPalette(): Promise<void> {
+  await browser.execute(() => {
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "p", metaKey: true, bubbles: true }),
+    );
+  });
+  await $(paletteDialog).waitForDisplayed({
+    timeout: 10_000,
+    timeoutMsg: "command palette did not open on synthesized ⌘P",
+  });
+}
+
+/** Dispatch a keydown (Enter / Escape / ArrowDown / …) on an element.
+ *  CommandPalette handles keys via React onKeyDown on the dialog; a bubbling
+ *  native KeyboardEvent reaches React's root-delegated listener. Use this for
+ *  control keys; use setValue() for typing text. */
+export async function jsKey(selector: string, key: string): Promise<void> {
+  const ok = await browser.execute(
+    (sel: string, k: string) => {
+      const el = document.querySelector(sel) as HTMLElement | null;
+      if (!el) return false;
+      el.dispatchEvent(
+        new KeyboardEvent("keydown", { key: k, bubbles: true, cancelable: true }),
+      );
+      return true;
+    },
+    selector,
+    key,
+  );
+  if (!ok) throw new Error(`jsKey: element not found: ${selector}`);
+}
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `pnpm exec tsc -p e2e/tsconfig.json --noEmit`
+Expected: clean. (Fixture/helpers are exercised by Tasks 3/5/6 — no standalone runtime test exists for the harness itself; existing Phase 1/2 specs must still type-check against the widened `stubNativeDialogs` signature.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/support/tempRepo.ts e2e/support/app.ts
+git commit -m "test(e2e): remoteRepo fixture, prompt queue, palette helpers"
+```
+
+---
+
+### Task 2: Wire remote context menu (app fix 1)
+
+**Files:**
+- Modify: `src/design/git-components.tsx` (PGRemoteRow, ~line 1697)
+- Modify: `src/screens/Remote.tsx`
+
+**Interfaces:**
+- Consumes: `remoteMenuItems`, `useContextMenu` (already exported via `@/design` barrel — `design/index.ts` re-exports `./context-menu`).
+- Produces: Remote-screen rows carry `data-remote={name}` and open the existing `remoteMenuItems` menu on right-click (labels: "Fetch", "Prune stale refs", "Edit URL…", "Rename…", "Copy URL", "Remove remote"). Task 3's specs depend on the attribute and these labels.
+
+- [ ] **Step 1: Thread props through `PGRemoteRow`**
+
+In `src/design/git-components.tsx`, extend the interface and component (row components need explicit threading — CLAUDE.md convention; do NOT switch to `...rest`):
+
+```tsx
+export interface PGRemoteRowProps {
+  name: string;
+  url: string;
+  ahead?: number;
+  behind?: number;
+  syncing?: boolean;
+  onFetch?: () => void;
+  onPush?: () => void;
+  onPull?: () => void;
+  onContextMenu?: React.MouseEventHandler<HTMLDivElement>;
+  "data-remote"?: string;
+}
+
+export function PGRemoteRow({
+  name,
+  url,
+  ahead = 0,
+  behind = 0,
+  syncing,
+  onFetch,
+  onPush,
+  onPull,
+  onContextMenu,
+  "data-remote": dataRemote,
+}: PGRemoteRowProps) {
+  return (
+    <div
+      onContextMenu={onContextMenu}
+      data-remote={dataRemote}
+      style={{
+```
+
+(rest of the component unchanged).
+
+- [ ] **Step 2: Attach the menu in `src/screens/Remote.tsx`**
+
+Add imports: `remoteMenuItems`, `useContextMenu` to the existing `@/design` import block, and `import type { RemoteInfo } from "@/lib/types";`.
+
+Inside `RemoteScreen`, after the `handleAddRemote` definition:
+
+```tsx
+const { onContextMenu: onRemoteCtx, menu: remoteMenu } =
+  useContextMenu<RemoteInfo>((r) => remoteMenuItems(r));
+```
+
+In the remotes map, thread the new props:
+
+```tsx
+{remotes.map((r) => (
+  <PGRemoteRow
+    key={r.name}
+    name={r.name}
+    url={r.url ?? "(no url)"}
+    data-remote={r.name}
+    onContextMenu={(e) => onRemoteCtx(e.nativeEvent, r)}
+    ahead={0}
+    behind={0}
+```
+
+(`useContextMenu`'s callback takes a DOM `MouseEvent` — pass `e.nativeEvent`, matching how `PGChangeRow` consumers do it. If Branches.tsx passes the synthetic event directly and it type-checks, mirror whatever pattern compiles cleanly there.)
+
+After the `</div>` closing the remotes section (before the component's final closing tags), render `{remoteMenu}`.
+
+- [ ] **Step 3: Gates**
+
+Run: `pnpm tsc --noEmit && pnpm test`
+Expected: type-check clean; vitest suite green (no component test covers RemoteScreen today — behavior is proven by Task 3's e2e specs).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/design/git-components.tsx src/screens/Remote.tsx
+git commit -m "feat(remote): context menu on remote rows (fetch, prune, edit URL, rename, remove)
+
+Why: remoteMenuItems existed in context-menu.tsx but had zero call sites, so
+remote management beyond add-remote was unreachable in the UI."
+```
+
+---
+
+### Task 3: remote.e2e.ts
+
+**Files:**
+- Create: `e2e/specs/remote.e2e.ts`
+
+**Interfaces:**
+- Consumes: Task 1 fixture/helpers, Task 2 `data-remote` + menu labels.
+
+**Selector discipline for this file:** titlebar Fetch/Pull/Push buttons are the ONLY `button*=Fetch`/`button*=Pull`/`button*=Push` matches while a non-Remote screen is active. The Remote screen adds a second and third set (sync card + per-row) — so sync tests (2–4, 10) drive the titlebar from the default screen and never `switchScreen("remote")`; management tests (5–9) use the Remote screen but only click "Add remote" / context-menu items, never the ambiguous sync buttons.
+
+- [ ] **Step 1: Write the spec**
+
+```ts
+import { browser, $, expect } from "@wdio/globals";
+import {
+  remoteRepo, makeAhead, makeBehind, makeDiverged, type RemotePair,
+} from "../support/tempRepo";
+import {
+  openRepo, resetApp, switchScreen, stubNativeDialogs,
+  jsContextMenu, jsClickMenuItem,
+} from "../support/app";
+
+describe("remote operations", () => {
+  let pair: RemotePair;
+
+  afterEach(async () => {
+    await resetApp();
+    pair.dispose();
+  });
+
+  it("lists origin with url; ahead count shows on the ahead fixture", async () => {
+    pair = remoteRepo();
+    makeAhead(pair);
+    await openRepo(pair.repo.path);
+    await switchScreen("remote");
+    const row = $('[data-remote="origin"]');
+    await row.waitForDisplayed({ timeout: 10_000, timeoutMsg: "origin row missing" });
+    expect(await row.getText()).toContain(pair.barePath);
+    // Sync-status card: Upstream tile tracks origin/main, Ahead tile is 1.
+    await $("div*=origin/main").waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "upstream tile never showed origin/main",
+    });
+    await $("span*=↑1").waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "ahead indicator never appeared",
+    });
+  });
+
+  it("push advances the bare remote and clears the ahead badge", async () => {
+    pair = remoteRepo();
+    makeAhead(pair);
+    await openRepo(pair.repo.path);
+    const localHead = pair.repo.git("rev-parse", "HEAD").trim();
+    await $("button*=Push").click(); // titlebar (default screen — unambiguous)
+    // repo-truth wait: bare repo receiving the commit IS the outcome.
+    await browser.waitUntil(
+      async () => pair.bareGit("rev-parse", "main").trim() === localHead,
+      { timeout: 20_000, timeoutMsg: "bare remote never received the push" },
+    );
+    await browser.waitUntil(async () => !(await $("span*=↑1").isExisting()), {
+      timeout: 20_000, timeoutMsg: "ahead badge did not clear after push",
+    });
+  });
+
+  it("pull brings the remote-only commit into the worktree", async () => {
+    pair = remoteRepo();
+    makeBehind(pair);
+    await openRepo(pair.repo.path);
+    await $("button*=Pull").click(); // titlebar
+    // repo-truth wait: the pulled file landing on disk is the outcome.
+    await browser.waitUntil(
+      async () => {
+        try { return pair.repo.read("remote.txt") === "remote\n"; }
+        catch { return false; }
+      },
+      { timeout: 20_000, timeoutMsg: "pull never delivered remote.txt" },
+    );
+    expect(pair.repo.git("status", "--porcelain").trim()).toBe("");
+    expect(pair.repo.git("log", "-1", "--pretty=%s").trim())
+      .toBe("feat: remote-only commit");
+  });
+
+  it("fetch surfaces behind count without touching the worktree", async () => {
+    pair = remoteRepo();
+    makeBehind(pair);
+    await openRepo(pair.repo.path);
+    const headBefore = pair.repo.git("rev-parse", "HEAD").trim();
+    await $("button*=Fetch").click(); // titlebar → fetchAll
+    await $("span*=↓1").waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "behind badge never appeared after fetch",
+    });
+    expect(pair.repo.git("rev-parse", "HEAD").trim()).toBe(headBefore);
+    expect(() => pair.repo.read("remote.txt")).toThrow(); // fetch ≠ merge
+  });
+
+  it("adds a remote via the two-prompt flow", async () => {
+    pair = remoteRepo();
+    await openRepo(pair.repo.path);
+    await switchScreen("remote");
+    await stubNativeDialogs({ promptQueue: ["backup", pair.barePath] });
+    await $("button*=Add remote").click();
+    await $('[data-remote="backup"]').waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "backup remote row never appeared",
+    });
+    expect(pair.repo.git("remote", "get-url", "backup").trim()).toBe(pair.barePath);
+  });
+
+  it("removes a remote via the context menu", async () => {
+    pair = remoteRepo();
+    await openRepo(pair.repo.path);
+    await switchScreen("remote");
+    await $('[data-remote="origin"]').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "origin row missing",
+    });
+    await stubNativeDialogs({ confirm: true });
+    await jsContextMenu('[data-remote="origin"]');
+    await jsClickMenuItem("Remove remote");
+    await browser.waitUntil(
+      async () => !(await $('[data-remote="origin"]').isExisting()),
+      { timeout: 20_000, timeoutMsg: "origin row did not disappear" },
+    );
+    expect(pair.repo.git("remote").trim()).toBe("");
+  });
+
+  it("renames a remote via the context menu", async () => {
+    pair = remoteRepo();
+    await openRepo(pair.repo.path);
+    await switchScreen("remote");
+    await $('[data-remote="origin"]').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "origin row missing",
+    });
+    await stubNativeDialogs({ promptQueue: ["upstream"] });
+    await jsContextMenu('[data-remote="origin"]');
+    await jsClickMenuItem("Rename…");
+    await $('[data-remote="upstream"]').waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "renamed remote row never appeared",
+    });
+    expect(pair.repo.git("remote").trim()).toBe("upstream");
+  });
+
+  it("edits a remote URL via the context menu", async () => {
+    pair = remoteRepo();
+    await openRepo(pair.repo.path);
+    await switchScreen("remote");
+    await $('[data-remote="origin"]').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "origin row missing",
+    });
+    const newUrl = `${pair.barePath}-moved`;
+    await stubNativeDialogs({ promptQueue: [newUrl] });
+    await jsContextMenu('[data-remote="origin"]');
+    await jsClickMenuItem("Edit URL…");
+    // repo-truth wait: no dedicated UI signal beyond the row re-rendering
+    // with the new URL — wait for that, then assert git config truth.
+    await browser.waitUntil(
+      async () => (await $('[data-remote="origin"]').getText()).includes(newUrl),
+      { timeout: 20_000, timeoutMsg: "row never showed the new URL" },
+    );
+    expect(pair.repo.git("remote", "get-url", "origin").trim()).toBe(newUrl);
+  });
+
+  it("prunes stale remote-tracking refs via the context menu", async () => {
+    pair = remoteRepo();
+    // Create a remote branch (push updates the local remote-tracking ref),
+    // then delete it on the bare side so the local ref is stale.
+    pair.repo.git("push", "origin", "main:refs/heads/stale");
+    pair.bareGit("branch", "-D", "stale");
+    expect(pair.repo.hasRef("refs/remotes/origin/stale")).toBe(true);
+    await openRepo(pair.repo.path);
+    await switchScreen("remote");
+    await $('[data-remote="origin"]').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "origin row missing",
+    });
+    await jsContextMenu('[data-remote="origin"]');
+    await jsClickMenuItem("Prune stale refs");
+    // repo-truth wait: pruning has no UI signal at all — the stale
+    // remote-tracking ref disappearing IS the outcome.
+    await browser.waitUntil(
+      async () => !pair.repo.hasRef("refs/remotes/origin/stale"),
+      { timeout: 20_000, timeoutMsg: "stale ref survived prune" },
+    );
+  });
+
+  it("rejected non-fast-forward push surfaces the error banner", async () => {
+    pair = remoteRepo();
+    makeDiverged(pair);
+    await openRepo(pair.repo.path);
+    const bareBefore = pair.bareGit("rev-parse", "main").trim();
+    await $("button*=Push").click(); // titlebar, force=None
+    await $('[role="alert"]').waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "error banner never appeared for rejected push",
+    });
+    expect(await $('[role="alert"]').getText()).toContain("Network");
+    expect(pair.bareGit("rev-parse", "main").trim()).toBe(bareBefore);
+  });
+});
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `pnpm exec tsc -p e2e/tsconfig.json --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Full e2e run (Task 2 changed src/ — rebuild mandatory)**
+
+Run: `pnpm test:e2e`
+Expected: all spec files green, including the 10 new tests. Healthy full-suite band is now likely 1–4 min; >5 min means an unarmed driver bridge (see skill).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/specs/remote.e2e.ts
+git commit -m "test(e2e): remote operations against a local bare remote"
+```
+
+---
+
+### Task 4: confirmForcePush gate + PGButtonGroup aria-pressed (app fix 2)
+
+**Files:**
+- Modify: `src/features/palette/commands.ts` (force-push command, ~line 195)
+- Modify: `src/design/primitives.tsx` (PGButtonGroup)
+
+**Interfaces:**
+- Consumes: `useSettingsStore` (`src/features/settings/useSettingsStore.ts`), existing `direct`/`step`/`remoteItems` helpers in commands.ts.
+- Produces: force-push palette command consults `confirmForcePush` + `window.confirm`; `PGButtonGroup` option buttons carry `aria-pressed` (Task 6's settings spec asserts `button[aria-pressed="true"]`).
+
+- [ ] **Step 1: Gate force-push in `src/features/palette/commands.ts`**
+
+Add import at the top:
+
+```ts
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+```
+
+Replace the `action:force-push-current` item's `run` wiring. Current shape:
+
+```ts
+run: upstreamRemote
+  ? direct(() => void repo.push(upstreamRemote, name, "WithLease"))
+  : step(() => ({
+      kind: "pick", title: `Force-push ${name} to…`,
+      items: remoteItems("push", (r) => void repo.push(r, name, "WithLease")),
+    })),
+```
+
+New shape — one guard used by both paths so the pick-step variant is gated too:
+
+```ts
+const guardedForcePush = (remote: string) => {
+  if (
+    useSettingsStore.getState().confirmForcePush &&
+    !window.confirm(
+      `Force-push ${name} to ${remote} (with lease)? This overwrites the remote branch.`,
+    )
+  ) {
+    return;
+  }
+  void repo.push(remote, name, "WithLease");
+};
+```
+
+(declare it just above the `items.push({ ... "action:force-push-current" ...})` call, inside the same block where `name` is in scope), then:
+
+```ts
+run: upstreamRemote
+  ? direct(() => guardedForcePush(upstreamRemote))
+  : step(() => ({
+      kind: "pick", title: `Force-push ${name} to…`,
+      items: remoteItems("push", (r) => guardedForcePush(r)),
+    })),
+```
+
+Note: `direct()` closes the palette before running — the confirm appears after the palette closes, which is correct.
+
+- [ ] **Step 2: `aria-pressed` on `PGButtonGroup` (inert)**
+
+In `src/design/primitives.tsx`, inside `PGButtonGroup`'s option map, add one attribute to the `<button>`:
+
+```tsx
+<button
+  key={opt.value}
+  aria-pressed={active}
+  onClick={() => onChange?.(opt.value)}
+```
+
+- [ ] **Step 3: Gates**
+
+Run: `pnpm tsc --noEmit && pnpm test`
+Expected: clean + green. (Watch for import-cycle surprises: commands.ts now imports the settings store; the settings store does not import palette code, so no cycle.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/palette/commands.ts src/design/primitives.tsx
+git commit -m "fix(palette): gate force-push behind the confirmForcePush setting
+
+Why: Settings has always rendered a 'Confirm force-push' toggle (default on),
+but the palette force-push command never consulted it — the setting was inert
+and force-push ran unconfirmed. Also expose aria-pressed on PGButtonGroup so
+the active option is programmatically visible."
+```
+
+---
+
+### Task 5: palette.e2e.ts
+
+**Files:**
+- Create: `e2e/specs/palette.e2e.ts`
+
+**Interfaces:**
+- Consumes: Task 1 helpers (`openPalette`, `paletteDialog`, `paletteInput`, `jsKey`), fixtures (`basicRepo`, `branchyRepo`, `remoteRepo`+`makeBehind`).
+
+**Selector discipline:** every row/section lookup scopes under `paletteDialog` (portaled to body — unscoped text selectors can match the screen behind it). Rows: `[data-pal-index]` / `[data-pal-type]`. Type text with `setValue(paletteInput)`; control keys via `jsKey`. Activate rows by clicking them (rows set active on mouseenter; click activates) — reserve `jsKey(paletteInput, "Enter")` for input-step submission.
+
+- [ ] **Step 1: Write the spec**
+
+```ts
+import { browser, $, $$, expect } from "@wdio/globals";
+import {
+  basicRepo, branchyRepo, remoteRepo, makeBehind,
+  type TempRepo, type RemotePair,
+} from "../support/tempRepo";
+import {
+  openRepo, resetApp, openPalette, paletteDialog, paletteInput, jsKey,
+} from "../support/app";
+
+/** Click the palette row whose visible label contains `text`. */
+async function clickPaletteRow(text: string): Promise<void> {
+  const row = $(paletteDialog).$(`[data-pal-index]*=${text}`);
+  await row.waitForDisplayed({
+    timeout: 10_000, timeoutMsg: `palette row "${text}" never appeared`,
+  });
+  await row.click();
+}
+
+describe("command palette", () => {
+  let repo: TempRepo | null = null;
+  let pair: RemotePair | null = null;
+
+  afterEach(async () => {
+    await resetApp();
+    repo?.dispose(); repo = null;
+    pair?.dispose(); pair = null;
+  });
+
+  it("opens with quick actions; Escape on the root closes it", async () => {
+    repo = basicRepo();
+    await openRepo(repo.path);
+    await openPalette();
+    await $(paletteDialog).$("div*=Quick actions").waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "Quick actions section missing on empty query",
+    });
+    await jsKey(paletteInput, "Escape");
+    await browser.waitUntil(async () => !(await $(paletteDialog).isExisting()), {
+      timeout: 10_000, timeoutMsg: "palette did not close on Escape",
+    });
+  });
+
+  it("navigation command switches screens", async () => {
+    repo = basicRepo();
+    await openRepo(repo.path);
+    await openPalette();
+    await $(paletteInput).setValue("reflog");
+    await clickPaletteRow("Go to Reflog");
+    // Reuse the loaded-state wait from e2e/specs/reflog.e2e.ts (the reflog
+    // screen's entry rows) — open that file and copy its exact selector.
+    await $('[data-testid="reflog-row"], [data-sha]').waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "reflog screen never showed entries",
+    });
+  });
+
+  it("direct action: fetch-all discovers the remote commit", async () => {
+    pair = remoteRepo();
+    makeBehind(pair);
+    await openRepo(pair.repo.path);
+    await openPalette();
+    await $(paletteInput).setValue("fetch all");
+    await clickPaletteRow("Fetch all remotes");
+    await $("span*=↓1").waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "behind badge never appeared after palette fetch-all",
+    });
+  });
+
+  it("pick step: checkout branch", async () => {
+    repo = branchyRepo();
+    await openRepo(repo.path);
+    await openPalette();
+    await $(paletteInput).setValue("checkout branch");
+    await clickPaletteRow("Checkout branch…");
+    // now inside the pick step — branch rows are data-pal-type="branch"
+    const branchRow = $(paletteDialog).$('[data-pal-type="branch"]*=feature');
+    await branchRow.waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "feature branch not offered in pick step",
+    });
+    await branchRow.click();
+    await browser.waitUntil(
+      async () => repo!.git("symbolic-ref", "--short", "HEAD").trim() === "feature",
+      { timeout: 20_000, timeoutMsg: "checkout never happened" },
+    );
+    await $('[data-testid="branch-chip"]*=feature').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "branch chip did not update",
+    });
+  });
+
+  it("input step: create branch", async () => {
+    repo = basicRepo();
+    await openRepo(repo.path);
+    await openPalette();
+    await $(paletteInput).setValue("create branch");
+    await clickPaletteRow("Create branch…");
+    await $(paletteDialog).$("div*=Press Enter to confirm").waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "input step never appeared",
+    });
+    await $(paletteInput).setValue("palette-branch");
+    await jsKey(paletteInput, "Enter");
+    await browser.waitUntil(
+      async () => repo!.hasRef("refs/heads/palette-branch"),
+      { timeout: 20_000, timeoutMsg: "branch was never created" },
+    );
+  });
+
+  it("two-step danger flow: hard reset to a picked commit", async () => {
+    repo = basicRepo();
+    const target = repo.git("rev-parse", "HEAD~1").trim();
+    await openRepo(repo.path);
+    await openPalette();
+    await $(paletteInput).setValue("reset current");
+    await clickPaletteRow("Reset current branch to…");
+    await clickPaletteRow("feat: add b.txt"); // pick the HEAD~1 commit by subject
+    await clickPaletteRow("Hard");            // second step: mode pick
+    await browser.waitUntil(
+      async () => repo!.git("rev-parse", "HEAD").trim() === target,
+      { timeout: 20_000, timeoutMsg: "hard reset never moved HEAD" },
+    );
+    expect(repo.git("status", "--porcelain").trim()).toBe("");
+  });
+
+  it("chips filter results to one type", async () => {
+    repo = branchyRepo();
+    await openRepo(repo.path);
+    await openPalette();
+    await $(paletteInput).setValue("a"); // matches branches, files, commits, commands
+    await $(paletteDialog).$("button*=Branches").click();
+    await $(paletteDialog).$('[data-pal-type="branch"]').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "no branch rows under Branches chip",
+    });
+    const types = await $(paletteDialog).$$("[data-pal-type]").map(
+      (el) => el.getAttribute("data-pal-type"),
+    );
+    expect(types.length).toBeGreaterThan(0);
+    expect(types.every((t) => t === "branch")).toBe(true);
+  });
+
+  it("frecency: an executed command shows under Recent on reopen", async () => {
+    repo = basicRepo();
+    await openRepo(repo.path);
+    await openPalette();
+    await $(paletteInput).setValue("refresh repo");
+    await clickPaletteRow("Refresh repository"); // direct, safe no-op
+    await browser.waitUntil(async () => !(await $(paletteDialog).isExisting()), {
+      timeout: 10_000, timeoutMsg: "palette did not close after direct command",
+    });
+    await openPalette();
+    await $(paletteDialog).$("div*=Recent").waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "Recent section missing after command use",
+    });
+    await $(paletteDialog).$("[data-pal-index]*=Refresh repository").waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "executed command not listed under Recent",
+    });
+    const raw = await browser.execute(() =>
+      localStorage.getItem("pg-palette-frecency"),
+    );
+    expect(raw).toContain("action:refresh");
+  });
+});
+```
+
+Two selectors above are declared best-effort and MUST be verified against the real DOM before trusting a green run: the reflog loaded-state selector (copy from `e2e/specs/reflog.e2e.ts`) and `[data-pal-index]*=text` / `[data-pal-type="branch"]*=feature` (attribute+text combinators — the skill's selector table allows attr+text like `[data-branch-row]*=main`; if the rows render labels in nested spans and the combinator misses, fall back to `.$$('[data-pal-index]')` + textContent filtering via `browser.execute`). Inspect with `browser.execute(() => document.querySelector('[aria-label="Command palette"]')?.outerHTML)`.
+
+- [ ] **Step 2: Type-check**
+
+Run: `pnpm exec tsc -p e2e/tsconfig.json --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: Full e2e run (Task 4 changed src/ — rebuild mandatory)**
+
+Run: `pnpm test:e2e`
+Expected: all specs green including the 8 new tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/specs/palette.e2e.ts
+git commit -m "test(e2e): command palette machinery"
+```
+
+---
+
+### Task 6: settings.e2e.ts
+
+**Files:**
+- Create: `e2e/specs/settings.e2e.ts`
+
+**Interfaces:**
+- Consumes: Task 1 (`remoteRepo`, `makeDiverged`, `stubNativeDialogs` + `confirmCallCount`, `openPalette`, `paletteInput`, `jsKey`), Task 4 (`aria-pressed`, force-push gate).
+
+**Facts this spec relies on:**
+- Settings screen reached via the titlebar gear: `PGIconButton` with `title="Settings"` → selector `button[title="Settings"]` (PGIconButton forwards `title` only).
+- Default `defaultPullMode` is `"Rebase"`; the titlebar Pull button is the ONLY consumer of the setting.
+- Pull-mode group renders options labeled `Rebase` / `Merge` / `FF-only`.
+- The signoff checkbox lives in the CommitPanel (label "Add Signed-off-by trailer") and writes the setting back on toggle.
+- Settings persist to `localStorage["pg-settings-v2"]` synchronously on every change.
+- Force-push palette command is only offered when a branch is checked out; with an upstream it runs `direct` (no pick step).
+
+- [ ] **Step 1: Write the spec**
+
+```ts
+import { browser, $, expect } from "@wdio/globals";
+import {
+  dirtyRepo, remoteRepo, makeDiverged, type TempRepo, type RemotePair,
+} from "../support/tempRepo";
+import {
+  openRepo, reopenRepo, resetApp, stubNativeDialogs, confirmCallCount,
+  openPalette, paletteDialog, paletteInput, switchScreen, stagedRow,
+} from "../support/app";
+
+/** Open the Settings screen via the titlebar gear. */
+async function openSettings(): Promise<void> {
+  await $('button[title="Settings"]').click();
+  await $("div*=Default pull mode").waitForDisplayed({
+    timeout: 10_000, timeoutMsg: "Settings screen never appeared",
+  });
+}
+
+async function clickPaletteRow(text: string): Promise<void> {
+  const row = $(paletteDialog).$(`[data-pal-index]*=${text}`);
+  await row.waitForDisplayed({
+    timeout: 10_000, timeoutMsg: `palette row "${text}" never appeared`,
+  });
+  await row.click();
+}
+
+describe("settings", () => {
+  let repo: TempRepo | null = null;
+  let pair: RemotePair | null = null;
+
+  afterEach(async () => {
+    await resetApp();
+    repo?.dispose(); repo = null;
+    pair?.dispose(); pair = null;
+  });
+
+  it("pull mode persists across reload and FF-only refuses a diverged pull", async () => {
+    pair = remoteRepo();
+    makeDiverged(pair);
+    await openRepo(pair.repo.path);
+    await openSettings();
+    await $("button*=FF-only").click();
+    await browser.waitUntil(
+      async () => (await $('button[aria-pressed="true"]*=FF-only').isExisting()),
+      { timeout: 10_000, timeoutMsg: "FF-only never became active" },
+    );
+    // Reload WITHOUT clearing localStorage (openRepo would wipe pg-settings-v2).
+    await reopenRepo(pair.repo.path);
+    const raw = await browser.execute(() => localStorage.getItem("pg-settings-v2"));
+    expect(raw).toContain('"defaultPullMode":"FastForward"');
+    await openSettings();
+    await $('button[aria-pressed="true"]*=FF-only').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "persisted FF-only not active after reload",
+    });
+    // Behavior: titlebar Pull consumes the persisted mode; --ff-only on a
+    // diverged branch must fail and surface the error banner.
+    const headBefore = pair.repo.git("rev-parse", "HEAD").trim();
+    await switchScreen("repo"); // leave Settings so titlebar context is normal
+    await $("button*=Pull").click();
+    await $('[role="alert"]').waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "FF-only pull on diverged branch showed no error",
+    });
+    expect(pair.repo.git("rev-parse", "HEAD").trim()).toBe(headBefore);
+  });
+
+  it("Merge pull mode produces a merge commit on a diverged branch", async () => {
+    pair = remoteRepo();
+    makeDiverged(pair);
+    await openRepo(pair.repo.path);
+    await openSettings();
+    await $("button*=Merge").click();
+    await browser.waitUntil(
+      async () => (await $('button[aria-pressed="true"]*=Merge').isExisting()),
+      { timeout: 10_000, timeoutMsg: "Merge mode never became active" },
+    );
+    await switchScreen("repo");
+    await $("button*=Pull").click();
+    // repo-truth wait: merge commit (2 parents) at HEAD is the outcome.
+    await browser.waitUntil(
+      async () =>
+        pair!.repo.git("rev-list", "--parents", "-1", "HEAD").trim().split(" ").length === 3,
+      { timeout: 20_000, timeoutMsg: "no merge commit after Merge-mode pull" },
+    );
+    expect(pair.repo.read("remote.txt")).toBe("remote\n");
+    expect(pair.repo.read("diverge.txt")).toBe("diverge\n");
+  });
+
+  it("Signed-off-by trailer is appended when the commit-panel toggle is on", async () => {
+    repo = dirtyRepo(); // has staged.txt already staged
+    await openRepo(repo.path);
+    await switchScreen("commit");
+    await stagedRow("staged.txt").waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "staged file missing",
+    });
+    // Toggle "Add Signed-off-by trailer" — checkbox row in the commit panel.
+    // Inspect the real DOM for the clickable element (label text lives in a
+    // span; the PGCheckbox root or its label is the click target).
+    await $("span*=Add Signed-off-by trailer").click();
+    // Type message + commit, mirroring e2e/specs/commit.e2e.ts selectors.
+    await $('[data-testid="commit-message"]').setValue("feat: signed commit");
+    await $('[data-testid="commit-button"]').click();
+    await browser.waitUntil(
+      async () => repo!.git("log", "-1", "--pretty=%s").trim() === "feat: signed commit",
+      { timeout: 20_000, timeoutMsg: "commit never landed" },
+    );
+    expect(repo.git("log", "-1", "--pretty=%B")).toContain(
+      "Signed-off-by: E2E Tester <e2e@platypusgit.test>",
+    );
+  });
+
+  it("confirmForcePush=on + declined confirm blocks the force-push", async () => {
+    pair = remoteRepo();
+    makeDiverged(pair);
+    await openRepo(pair.repo.path);
+    const bareBefore = pair.bareGit("rev-parse", "main").trim();
+    await stubNativeDialogs({ confirm: false }); // setting defaults ON
+    await openPalette();
+    await $(paletteInput).setValue("force"); // matches label "Force-push {branch} (with lease)"
+    await clickPaletteRow("Force-push");
+    // Positive signal that the gate fired: the confirm stub was called.
+    await browser.waitUntil(async () => (await confirmCallCount()) > 0, {
+      timeout: 10_000, timeoutMsg: "confirm gate never fired",
+    });
+    expect(pair.bareGit("rev-parse", "main").trim()).toBe(bareBefore);
+  });
+
+  it("confirmForcePush=on + accepted confirm force-pushes with lease", async () => {
+    pair = remoteRepo();
+    makeDiverged(pair);
+    await openRepo(pair.repo.path);
+    const localHead = pair.repo.git("rev-parse", "HEAD").trim();
+    await stubNativeDialogs({ confirm: true });
+    await openPalette();
+    await $(paletteInput).setValue("force"); // matches label "Force-push {branch} (with lease)"
+    await clickPaletteRow("Force-push");
+    // repo-truth wait: bare main moving to the local head IS the outcome
+    // (a plain push would be rejected on this diverged fixture, so success
+    // also proves --force-with-lease was sent).
+    await browser.waitUntil(
+      async () => pair!.bareGit("rev-parse", "main").trim() === localHead,
+      { timeout: 20_000, timeoutMsg: "force-push never landed on the bare remote" },
+    );
+  });
+
+  it("confirmForcePush=off skips the confirm entirely", async () => {
+    pair = remoteRepo();
+    makeDiverged(pair);
+    await openRepo(pair.repo.path);
+    await openSettings();
+    // Toggle "Confirm force-push" off (defaults on).
+    await $("span*=Confirm force-push").click();
+    await switchScreen("repo");
+    const localHead = pair.repo.git("rev-parse", "HEAD").trim();
+    await stubNativeDialogs({ confirm: false }); // would block if consulted
+    await openPalette();
+    await $(paletteInput).setValue("force"); // matches label "Force-push {branch} (with lease)"
+    await clickPaletteRow("Force-push");
+    await browser.waitUntil(
+      async () => pair!.bareGit("rev-parse", "main").trim() === localHead,
+      { timeout: 20_000, timeoutMsg: "ungated force-push never landed" },
+    );
+    expect(await confirmCallCount()).toBe(0);
+  });
+});
+```
+
+Selector caveats to verify against the real DOM (same discipline as Task 5): the Settings-row toggle click targets (`span*=Add Signed-off-by trailer`, `span*=Confirm force-push` — the label may not be the interactive element; click the adjacent PGToggle/PGCheckbox if needed), the commit-panel testids (copy the exact ones from `e2e/specs/commit.e2e.ts` — the names above are from memory), and `div*=Default pull mode` (row label tag may differ; tag-scope to whatever the DOM shows).
+
+- [ ] **Step 2: Type-check**
+
+Run: `pnpm exec tsc -p e2e/tsconfig.json --noEmit`
+Expected: clean.
+
+- [ ] **Step 3: e2e run — spec-only change since Task 5's full build**
+
+Run: `pnpm test:e2e:run`
+Expected: all specs green including the 6 new tests. (Task 5 already rebuilt the binary after the last src/ change; if ANY src/ file changed since, run the full `pnpm test:e2e` instead.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/specs/settings.e2e.ts
+git commit -m "test(e2e): settings persistence, pull modes, signoff, force-push gate"
+```
+
+---
+
+### Task 7: Dead-settings issue + docs
+
+**Files:**
+- Modify: `.claude/skills/e2e-testing/SKILL.md`
+- Modify: `CLAUDE.md` (test-count line in the Testing section, spec list in Canonical references)
+- External: `gh issue create`
+
+- [ ] **Step 1: File the dead-settings issue**
+
+```bash
+gh issue create \
+  --title "Settings audit: several persisted settings are never consumed" \
+  --body "$(cat <<'EOF'
+Found during e2e phase 3 (spec: docs/superpowers/specs/2026-07-03-e2e-phase3-design.md).
+
+These settings are persisted (localStorage pg-settings-v2) and rendered as controls in the Settings screen, but no code reads them — toggling them changes nothing:
+
+- `autoStashBeforePull` — pull() never stashes. (Auto-stash DOES happen, but unconditionally inside checkoutBranch, independent of this setting.)
+- `pruneOnFetch` — backend fetch/fetch_all hardcode `--prune`; the toggle is ignored.
+- `signCommits` — never read (only `addSignoff` is).
+- `showWhitespaceInDiff` — never read.
+- `diffContextLines` — never read.
+- `uiDensity` — set in Settings, no consumer.
+
+`confirmForcePush` was in this list and was wired up in phase 3 (palette force-push now gates on it).
+
+Each needs a wire-or-remove decision: either implement the behavior or drop the control (a toggle that does nothing erodes trust in the rest of the screen).
+
+Related hardening note from the same investigation: `run_git` (src-tauri/src/commands/branches.rs) does not set `GIT_TERMINAL_PROMPT=0`/`GIT_ASKPASS`, so an auth-requiring remote can hang a fetch/pull/push on an invisible credential prompt. Local-path remotes are unaffected.
+EOF
+)"
+```
+
+- [ ] **Step 2: Update `.claude/skills/e2e-testing/SKILL.md`**
+
+Add to the **Native dialogs, context menus, hover** section:
+
+```markdown
+- `stubNativeDialogs({promptQueue: ["a", "b"]})` — multi-prompt flows (Add
+  remote asks name THEN url; a single promptText would set name === url).
+  Confirm calls are counted: `confirmCallCount()` is the positive signal
+  that a confirm gate fired (there is no UI signal when a user "cancels").
+- Palette: `openPalette()` (js-dispatched ⌘P — the driver can't synthesize
+  Meta chords), `jsKey(paletteInput, "Enter"|"Escape")` for control keys,
+  `setValue(paletteInput)` for typing. Scope EVERY palette selector under
+  `paletteDialog` — it's portaled to body over the live screen.
+```
+
+Add to the **Fixtures & assertions** geometry list:
+
+```markdown
+- `remoteRepo()` pairs a work repo with a local bare `origin`. `makeBehind`
+  rewinds `refs/remotes/origin/main` so fetch has something to discover —
+  but that same rewind makes `--force-with-lease` fail ("stale info").
+  Force-push tests use `makeDiverged` (accurate remote-tracking) instead.
+- Titlebar Fetch/Pull/Push are unambiguous `button*=` targets only while a
+  non-Remote screen is active — the Remote screen adds two more sets.
+```
+
+- [ ] **Step 3: Update `CLAUDE.md`**
+
+In the Testing section's E2E bullet, update the spec/test count (10 files / 23 tests → 13 files / 47 tests — adjust to the real numbers after Task 6's run). In "Canonical references", add `2026-07-03-e2e-phase3-*` to the recent specs/plans list.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/e2e-testing/SKILL.md CLAUDE.md
+git commit -m "docs: phase 3 e2e learnings in skill + CLAUDE.md; file dead-settings issue"
+```
+
+---
+
+## Completion
+
+After Task 7: final whole-branch review (superpowers:requesting-code-review), fix wave if needed, then finishing-a-development-branch — squash to one commit (`git reset --soft origin/main`), rebase onto latest `origin/main`, PR, CI green (e2e.yml runs the suite on ubuntu), squash-merge.

--- a/docs/superpowers/specs/2026-07-03-e2e-phase3-design.md
+++ b/docs/superpowers/specs/2026-07-03-e2e-phase3-design.md
@@ -1,0 +1,184 @@
+# End-to-End Testing (Phase 3: remotes, palette, settings) — Design
+
+Status: approved 2026-07-03
+
+## Problem
+
+Phases 1 (#26) and 2 (#28) cover the local read path, write path, and danger
+ops. Three surfaces remain without webview-level coverage:
+
+- **Remote operations** — fetch/pull/push and remote management. The sync
+  buttons live in the titlebar and Remote screen; regressions here brick the
+  most-used daily flows.
+- **Command palette** — its own state machine (step stack, chips, frecency)
+  with ~30 commands; nothing exercises the machinery end to end.
+- **Settings** — persisted to `localStorage["pg-settings-v2"]` and consumed
+  across the app; no test proves persistence or behavioral effect.
+
+Investigation surfaced two app defects (both approved for fixing here,
+mirroring Phase 2's approach B):
+
+1. `remoteMenuItems` in `src/design/context-menu.tsx` (Fetch / Prune / Set
+   URL / Rename / Remove) has **zero call sites** — remote management beyond
+   add-remote is unreachable in the UI even though the store and backend
+   support it.
+2. `confirmForcePush` setting is **inert**: the palette command
+   `action:force-push-current` calls `push(..., "WithLease")` with no
+   confirm gate, despite Settings rendering a "Confirm force-push" toggle
+   that defaults on.
+
+Several more settings are dead (`autoStashBeforePull`, `pruneOnFetch`,
+`signCommits`, `showWhitespaceInDiff`, `diffContextLines`, `uiDensity`) —
+out of scope; a GitHub issue records them for a wire-or-remove decision.
+
+## Goals
+
+- Cover remote ops end to end against a **local bare repository** as
+  `origin` — no network, no credentials (backend shells to the system git
+  CLI, which handles path remotes natively).
+- Cover the palette **machinery** — each interaction kind once via a
+  representative command — not the full catalog.
+- Cover settings persistence plus every setting with an observable effect
+  (`defaultPullMode`, `addSignoff`, and the newly-gated force-push confirm).
+- Land the two app fixes with the tests that prove them.
+
+## Non-goals
+
+- Auth-requiring remotes (HTTP/SSH). `run_git` sets no
+  `GIT_TERMINAL_PROMPT=0`, so such remotes could hang on a credential
+  prompt — noted in the dead-settings issue as a hardening candidate, not
+  fixed here.
+- `autoFetchEnabled`/`autoFetchMinutes` behavior (interval ≥60s; needs clock
+  mocking).
+- Theme editor modal coverage; theme assertion beyond persistence.
+- Exhaustive palette catalog (~30 commands); Phases 1/2 already prove the
+  underlying store actions for most.
+- Wiring the remaining dead settings.
+
+## App changes
+
+1. **Wire remote context menu (behavior):** `PGRemoteRow`
+   (`src/design/git-components.tsx`) gains an `onContextMenu` prop;
+   `RemoteScreen` attaches the existing `remoteMenuItems` builder. Handlers
+   call the existing store actions: `fetch`, `pruneRemote`, `setRemoteUrl`
+   (prompt prefilled semantics: single prompt for new URL), `renameRemote`
+   (prompt for new name), `removeRemote` (confirm).
+2. **Force-push confirm gate (behavior):** in
+   `src/features/palette/commands.ts`, `action:force-push-current` reads
+   `useSettingsStore`'s `confirmForcePush`; when true, `window.confirm(...)`
+   must return true before `push(..., "WithLease")` runs. When false,
+   current no-confirm behavior is preserved.
+3. **Test attributes (inert):** `data-remote={name}` on the Remote-screen
+   remote row (explicit prop threading through `PGRemoteRow`).
+4. **Fix (behavior, discovered-by-test, scope addition per Phase 2
+   precedent):** in `src/features/palette/usePaletteStore.ts`, `pushStep`
+   now sets `open: true`. The pick-item builders in `commands.ts`
+   (commitItems/branchItems/tagItems/stashItems) close the palette before
+   running `onPick`; for chained flows (reset → pick commit → pick mode,
+   rename-branch, push-tag, stash-branch) `onPick` pushed the follow-up
+   step onto a closed palette, so the step never rendered and the flow
+   silently dead-ended. Found by the two-step reset e2e (test 16); store
+   regression test added in `usePaletteStore.test.ts`.
+5. **Issue filed:** dead settings list (`autoStashBeforePull`,
+   `pruneOnFetch`, `signCommits`, `showWhitespaceInDiff`,
+   `diffContextLines`, `uiDensity`) + the `GIT_TERMINAL_PROMPT` hardening
+   note.
+
+## Harness additions
+
+- **`remoteRepo()` fixture** (`e2e/support/tempRepo.ts`): work repo plus a
+  bare sibling (`git init --bare`) added as `origin` with `main` pushed and
+  upstream set (`push -u origin main`). Returns handles to both paths; bare
+  truth asserted via `git -C <bare> rev-parse` etc. State variants built by
+  the caller with existing helpers:
+  - *ahead*: commit locally after the initial push.
+  - *behind*: commit → push → `git reset --hard HEAD~1` locally.
+  - *diverged*: behind + a fresh local commit.
+- **`stubNativeDialogs` prompt queue:** `promptQueue?: string[]` — each
+  `window.prompt` call shifts the next value (falls back to `promptText`).
+  Needed because Add remote fires two sequential prompts (name, then URL);
+  the current single-string stub would set name === URL.
+- **`openPalette()` helper** (`e2e/support/app.ts`): dispatches a
+  `KeyboardEvent` (`key: "p"`, `metaKey: true`) on `window` via
+  `browser.execute` — the AppShell handler is a JS keydown listener, so an
+  in-page dispatch is deterministic and avoids embedded-driver Meta-key
+  synthesis risk. Waits for `[role="dialog"][aria-label="Command palette"]`.
+
+## Test cases (3 new spec files, ~22 tests)
+
+`remote.e2e.ts` (remoteRepo unless noted):
+
+1. Remote screen lists `origin` with its URL; Ahead/Behind tiles reflect the
+   *ahead* variant.
+2. Push (*ahead*): titlebar Push → bare repo's `main` advances to local HEAD
+   (bare truth); ahead badge clears.
+3. Pull (*behind*): titlebar Pull → local HEAD contains the remote commit;
+   tree clean.
+4. Fetch (*behind*): titlebar Fetch → behind badge appears; worktree HEAD
+   unchanged (fetch must not touch the working branch).
+5. Add remote: prompt queue `[name, url]` → row appears with both; `git
+   remote -v` truth.
+6. Remove remote via context menu (confirm stubbed) → row gone; git truth.
+7. Rename remote via context menu (prompt) → git truth.
+8. Set URL via context menu (prompt) → `git remote get-url` truth.
+9. Prune via context menu: stale remote-tracking ref (branch deleted in
+   bare after fetch) → ref gone locally.
+10. Failed push (*diverged*, non-FF) → `role="alert"` banner with the
+    Network error; bare repo unchanged.
+
+`palette.e2e.ts` (basicRepo unless noted):
+
+11. `openPalette()` shows the dialog with Quick actions; Esc on root closes.
+12. Nav command: type "reflog" → Enter → Reflog screen active.
+13. Direct action (remoteRepo, *behind*): "Fetch all remotes" → behind badge
+    appears (observable git effect).
+14. Pick step (branchyRepo): "Checkout branch…" → pick → `git symbolic-ref`
+    truth + chip text.
+15. Input step: "Create branch…" → type name → Enter → branch exists (git
+    truth), chip shows it (autoStash checkout).
+16. Two-step danger: "Reset current branch to…" → pick parent commit → pick
+    Hard → HEAD moved (git truth), tree clean.
+17. Chips: query with mixed results → click Branches chip → only
+    `[data-pal-type="branch"]` rows listed.
+18. Frecency: run a direct command, reopen palette → Recent section lists
+    it; `localStorage["pg-palette-frecency"]` non-empty.
+
+`settings.e2e.ts` (remoteRepo *diverged* for pull/push cases):
+
+19. Persistence: set pull mode FF-only in Settings → reload (`refresh` +
+    re-arm) → Settings still shows FF-only; `pg-settings-v2` contains it.
+20. Pull mode behavior: FF-only on diverged → titlebar Pull → error banner
+    (--ff-only refuses); switch to Merge → Pull → merge commit in log (git
+    truth).
+21. addSignoff (dirtyRepo): enable → commit staged file → `Signed-off-by`
+    trailer in `git log -1` body.
+22. confirmForcePush on + confirm=false: force-push palette command → bare
+    unchanged. confirm=true → bare `main` equals local HEAD (force-with-
+    lease applied). Setting-off path: stub confirm=false anyway and assert
+    the push still succeeds — proves the gate is bypassed without risking a
+    real native confirm (which would hang the webview).
+
+## Conventions (unchanged)
+
+Repo truth as acceptance, UI as wait condition; `stubNativeDialogs` before
+trigger, after last reload; tag-scoped text selectors + `button*=`;
+timeout+timeoutMsg everywhere; no `pause()`; spec iterations via
+`pnpm test:e2e:run`, any src/ change requires full `pnpm test:e2e`. Read
+`.claude/skills/e2e-testing/SKILL.md` before writing specs.
+
+## Workflow
+
+Branch `test/e2e-phase3`; small Conventional Commits; squash to one commit
+before merge; PR with CI green.
+
+## Risks
+
+- ⌘P synthesis: mitigated by in-page KeyboardEvent dispatch; if the handler
+  ever moves to a native accelerator, helper breaks loudly (dialog wait
+  times out).
+- Prompt queue is new stub surface — keep single-string fallback so Phase 2
+  specs stay untouched.
+- Palette rows are portaled; selectors must scope to the dialog to avoid
+  matching screen content behind it.
+- `pgFlash` toasts (no-upstream paths) are bare divs auto-removed ~1.7s —
+  not asserted; tests avoid depending on them.

--- a/e2e/specs/palette.e2e.ts
+++ b/e2e/specs/palette.e2e.ts
@@ -1,0 +1,159 @@
+import { browser, $, $$, expect } from "@wdio/globals";
+import {
+  basicRepo, branchyRepo, remoteRepo, makeBehind,
+  type TempRepo, type RemotePair,
+} from "../support/tempRepo";
+import {
+  openRepo, resetApp, openPalette, paletteDialog, paletteInput, jsKey,
+} from "../support/app";
+
+/** Click the palette row whose visible label contains `text`. */
+async function clickPaletteRow(text: string): Promise<void> {
+  const row = $(paletteDialog).$(`[data-pal-index]*=${text}`);
+  await row.waitForDisplayed({
+    timeout: 10_000, timeoutMsg: `palette row "${text}" never appeared`,
+  });
+  await row.click();
+}
+
+describe("command palette", () => {
+  let repo: TempRepo | null = null;
+  let pair: RemotePair | null = null;
+
+  afterEach(async () => {
+    await resetApp();
+    repo?.dispose(); repo = null;
+    pair?.dispose(); pair = null;
+  });
+
+  it("opens with quick actions; Escape on the root closes it", async () => {
+    repo = basicRepo();
+    await openRepo(repo.path);
+    await openPalette();
+    await $(paletteDialog).$("div*=Quick actions").waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "Quick actions section missing on empty query",
+    });
+    await jsKey(paletteInput, "Escape");
+    await browser.waitUntil(async () => !(await $(paletteDialog).isExisting()), {
+      timeout: 10_000, timeoutMsg: "palette did not close on Escape",
+    });
+  });
+
+  it("navigation command switches screens", async () => {
+    repo = basicRepo();
+    await openRepo(repo.path);
+    await openPalette();
+    await $(paletteInput).setValue("reflog");
+    await clickPaletteRow("Go to Reflog");
+    // Reflog "loaded" wait copied verbatim from e2e/specs/reflog.e2e.ts: entry
+    // rows are PGCommitRow (`data-testid="commit-row"`), and basicRepo's HEAD~1
+    // commit subject ("feat: add b.txt") is reflected in its reflog message too.
+    await $('[data-testid="commit-row"]*=feat: add b.txt').waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "reflog screen never showed entries",
+    });
+  });
+
+  it("direct action: fetch-all discovers the remote commit", async () => {
+    pair = remoteRepo();
+    makeBehind(pair);
+    await openRepo(pair.repo.path);
+    await openPalette();
+    await $(paletteInput).setValue("fetch all");
+    await clickPaletteRow("Fetch all remotes");
+    await $("span*=↓1").waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "behind badge never appeared after palette fetch-all",
+    });
+  });
+
+  it("pick step: checkout branch", async () => {
+    repo = branchyRepo();
+    await openRepo(repo.path);
+    await openPalette();
+    await $(paletteInput).setValue("checkout branch");
+    await clickPaletteRow("Checkout branch…");
+    // now inside the pick step — branch rows are data-pal-type="branch"
+    const branchRow = $(paletteDialog).$('[data-pal-type="branch"]*=feature');
+    await branchRow.waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "feature branch not offered in pick step",
+    });
+    await branchRow.click();
+    await browser.waitUntil(
+      async () => repo!.git("symbolic-ref", "--short", "HEAD").trim() === "feature",
+      { timeout: 20_000, timeoutMsg: "checkout never happened" },
+    );
+    await $('[data-testid="branch-chip"]*=feature').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "branch chip did not update",
+    });
+  });
+
+  it("input step: create branch", async () => {
+    repo = basicRepo();
+    await openRepo(repo.path);
+    await openPalette();
+    await $(paletteInput).setValue("create branch");
+    await clickPaletteRow("Create branch…");
+    await $(paletteDialog).$("div*=Press Enter to confirm").waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "input step never appeared",
+    });
+    await $(paletteInput).setValue("palette-branch");
+    await jsKey(paletteInput, "Enter");
+    await browser.waitUntil(
+      async () => repo!.hasRef("refs/heads/palette-branch"),
+      { timeout: 20_000, timeoutMsg: "branch was never created" },
+    );
+  });
+
+  it("two-step danger flow: hard reset to a picked commit", async () => {
+    repo = basicRepo();
+    const target = repo.git("rev-parse", "HEAD~1").trim();
+    await openRepo(repo.path);
+    await openPalette();
+    await $(paletteInput).setValue("reset current");
+    await clickPaletteRow("Reset current branch to…");
+    await clickPaletteRow("feat: add b.txt"); // pick the HEAD~1 commit by subject
+    await clickPaletteRow("Hard");            // second step: mode pick
+    await browser.waitUntil(
+      async () => repo!.git("rev-parse", "HEAD").trim() === target,
+      { timeout: 20_000, timeoutMsg: "hard reset never moved HEAD" },
+    );
+    expect(repo.git("status", "--porcelain").trim()).toBe("");
+  });
+
+  it("chips filter results to one type", async () => {
+    repo = branchyRepo();
+    await openRepo(repo.path);
+    await openPalette();
+    await $(paletteInput).setValue("a"); // matches branches, files, commits, commands
+    await $(paletteDialog).$("button*=Branches").click();
+    await $(paletteDialog).$('[data-pal-type="branch"]').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "no branch rows under Branches chip",
+    });
+    const types = await $(paletteDialog).$$("[data-pal-type]").map(
+      (el) => el.getAttribute("data-pal-type"),
+    );
+    expect(types.length).toBeGreaterThan(0);
+    expect(types.every((t) => t === "branch")).toBe(true);
+  });
+
+  it("frecency: an executed command shows under Recent on reopen", async () => {
+    repo = basicRepo();
+    await openRepo(repo.path);
+    await openPalette();
+    await $(paletteInput).setValue("refresh repo");
+    await clickPaletteRow("Refresh repository"); // direct, safe no-op
+    await browser.waitUntil(async () => !(await $(paletteDialog).isExisting()), {
+      timeout: 10_000, timeoutMsg: "palette did not close after direct command",
+    });
+    await openPalette();
+    await $(paletteDialog).$("div*=Recent").waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "Recent section missing after command use",
+    });
+    await $(paletteDialog).$("[data-pal-index]*=Refresh repository").waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "executed command not listed under Recent",
+    });
+    const raw = await browser.execute(() =>
+      localStorage.getItem("pg-palette-frecency"),
+    );
+    expect(raw).toContain("action:refresh");
+  });
+});

--- a/e2e/specs/remote.e2e.ts
+++ b/e2e/specs/remote.e2e.ts
@@ -1,0 +1,182 @@
+import { browser, $, expect } from "@wdio/globals";
+import {
+  remoteRepo, makeAhead, makeBehind, makeDiverged, type RemotePair,
+} from "../support/tempRepo";
+import {
+  openRepo, resetApp, switchScreen, stubNativeDialogs,
+  jsContextMenu, jsClickMenuItem,
+} from "../support/app";
+
+describe("remote operations", () => {
+  let pair: RemotePair | null = null;
+
+  afterEach(async () => {
+    await resetApp();
+    pair?.dispose();
+    pair = null;
+  });
+
+  it("lists origin with url; ahead count shows on the ahead fixture", async () => {
+    pair = remoteRepo();
+    makeAhead(pair);
+    await openRepo(pair.repo.path);
+    await switchScreen("remote");
+    const row = $('[data-remote="origin"]');
+    await row.waitForDisplayed({ timeout: 10_000, timeoutMsg: "origin row missing" });
+    expect(await row.getText()).toContain(pair.barePath);
+    // Sync-status card: Upstream tile tracks origin/main, Ahead tile is 1.
+    await $("div*=origin/main").waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "upstream tile never showed origin/main",
+    });
+    await $("span*=↑1").waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "ahead indicator never appeared",
+    });
+  });
+
+  it("push advances the bare remote and clears the ahead badge", async () => {
+    pair = remoteRepo();
+    makeAhead(pair);
+    await openRepo(pair.repo.path);
+    const localHead = pair.repo.git("rev-parse", "HEAD").trim();
+    await $("button*=Push").click(); // titlebar (default screen — unambiguous)
+    // repo-truth wait: bare repo receiving the commit IS the outcome.
+    await browser.waitUntil(
+      async () => pair!.bareGit("rev-parse", "main").trim() === localHead,
+      { timeout: 20_000, timeoutMsg: "bare remote never received the push" },
+    );
+    await browser.waitUntil(async () => !(await $("span*=↑1").isExisting()), {
+      timeout: 20_000, timeoutMsg: "ahead badge did not clear after push",
+    });
+  });
+
+  it("pull brings the remote-only commit into the worktree", async () => {
+    pair = remoteRepo();
+    makeBehind(pair);
+    await openRepo(pair.repo.path);
+    await $("button*=Pull").click(); // titlebar
+    // repo-truth wait: the pulled file landing on disk is the outcome.
+    await browser.waitUntil(
+      async () => {
+        try { return pair!.repo.read("remote.txt") === "remote\n"; }
+        catch { return false; }
+      },
+      { timeout: 20_000, timeoutMsg: "pull never delivered remote.txt" },
+    );
+    expect(pair.repo.git("status", "--porcelain").trim()).toBe("");
+    expect(pair.repo.git("log", "-1", "--pretty=%s").trim())
+      .toBe("feat: remote-only commit");
+  });
+
+  it("fetch surfaces behind count without touching the worktree", async () => {
+    pair = remoteRepo();
+    makeBehind(pair);
+    await openRepo(pair.repo.path);
+    const headBefore = pair.repo.git("rev-parse", "HEAD").trim();
+    await $("button*=Fetch").click(); // titlebar → fetchAll
+    await $("span*=↓1").waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "behind badge never appeared after fetch",
+    });
+    expect(pair!.repo.git("rev-parse", "HEAD").trim()).toBe(headBefore);
+    expect(() => pair!.repo.read("remote.txt")).toThrow(); // fetch ≠ merge
+  });
+
+  it("adds a remote via the two-prompt flow", async () => {
+    pair = remoteRepo();
+    await openRepo(pair.repo.path);
+    await switchScreen("remote");
+    await stubNativeDialogs({ promptQueue: ["backup", pair.barePath] });
+    await $("button*=Add remote").click();
+    await $('[data-remote="backup"]').waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "backup remote row never appeared",
+    });
+    expect(pair.repo.git("remote", "get-url", "backup").trim()).toBe(pair.barePath);
+  });
+
+  it("removes a remote via the context menu", async () => {
+    pair = remoteRepo();
+    await openRepo(pair.repo.path);
+    await switchScreen("remote");
+    await $('[data-remote="origin"]').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "origin row missing",
+    });
+    await stubNativeDialogs({ confirm: true });
+    await jsContextMenu('[data-remote="origin"]');
+    await jsClickMenuItem("Remove remote");
+    await browser.waitUntil(
+      async () => !(await $('[data-remote="origin"]').isExisting()),
+      { timeout: 20_000, timeoutMsg: "origin row did not disappear" },
+    );
+    expect(pair.repo.git("remote").trim()).toBe("");
+  });
+
+  it("renames a remote via the context menu", async () => {
+    pair = remoteRepo();
+    await openRepo(pair.repo.path);
+    await switchScreen("remote");
+    await $('[data-remote="origin"]').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "origin row missing",
+    });
+    await stubNativeDialogs({ promptQueue: ["upstream"] });
+    await jsContextMenu('[data-remote="origin"]');
+    await jsClickMenuItem("Rename…");
+    await $('[data-remote="upstream"]').waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "renamed remote row never appeared",
+    });
+    expect(pair.repo.git("remote").trim()).toBe("upstream");
+  });
+
+  it("edits a remote URL via the context menu", async () => {
+    pair = remoteRepo();
+    await openRepo(pair.repo.path);
+    await switchScreen("remote");
+    await $('[data-remote="origin"]').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "origin row missing",
+    });
+    const newUrl = `${pair.barePath}-moved`;
+    await stubNativeDialogs({ promptQueue: [newUrl] });
+    await jsContextMenu('[data-remote="origin"]');
+    await jsClickMenuItem("Edit URL…");
+    // repo-truth wait: no dedicated UI signal beyond the row re-rendering
+    // with the new URL — wait for that, then assert git config truth.
+    await browser.waitUntil(
+      async () => (await $('[data-remote="origin"]').getText()).includes(newUrl),
+      { timeout: 20_000, timeoutMsg: "row never showed the new URL" },
+    );
+    expect(pair.repo.git("remote", "get-url", "origin").trim()).toBe(newUrl);
+  });
+
+  it("prunes stale remote-tracking refs via the context menu", async () => {
+    pair = remoteRepo();
+    // Create a remote branch (push updates the local remote-tracking ref),
+    // then delete it on the bare side so the local ref is stale.
+    pair.repo.git("push", "origin", "main:refs/heads/stale");
+    pair.bareGit("branch", "-D", "stale");
+    expect(pair.repo.hasRef("refs/remotes/origin/stale")).toBe(true);
+    await openRepo(pair.repo.path);
+    await switchScreen("remote");
+    await $('[data-remote="origin"]').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "origin row missing",
+    });
+    await jsContextMenu('[data-remote="origin"]');
+    await jsClickMenuItem("Prune stale refs");
+    // repo-truth wait: pruning has no UI signal at all — the stale
+    // remote-tracking ref disappearing IS the outcome.
+    await browser.waitUntil(
+      async () => !pair!.repo.hasRef("refs/remotes/origin/stale"),
+      { timeout: 20_000, timeoutMsg: "stale ref survived prune" },
+    );
+  });
+
+  it("rejected non-fast-forward push surfaces the error banner", async () => {
+    pair = remoteRepo();
+    makeDiverged(pair);
+    await openRepo(pair.repo.path);
+    const bareBefore = pair.bareGit("rev-parse", "main").trim();
+    await $("button*=Push").click(); // titlebar, force=None
+    await $('[role="alert"]').waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "error banner never appeared for rejected push",
+    });
+    expect(await $('[role="alert"]').getText()).toContain("Network");
+    expect(pair.bareGit("rev-parse", "main").trim()).toBe(bareBefore);
+  });
+});

--- a/e2e/specs/settings.e2e.ts
+++ b/e2e/specs/settings.e2e.ts
@@ -1,0 +1,213 @@
+import { browser, $, expect } from "@wdio/globals";
+import {
+  dirtyRepo, remoteRepo, makeDiverged, type TempRepo, type RemotePair,
+} from "../support/tempRepo";
+import {
+  openRepo, reopenRepo, resetApp, stubNativeDialogs, confirmCallCount,
+  openPalette, paletteDialog, paletteInput, switchScreen, stagedRow,
+} from "../support/app";
+
+/** Open the Settings screen via the titlebar gear. */
+async function openSettings(): Promise<void> {
+  await $('button[title="Settings"]').click();
+  await $("div*=Default pull mode").waitForDisplayed({
+    timeout: 10_000, timeoutMsg: "Settings screen never appeared",
+  });
+}
+
+async function clickPaletteRow(text: string): Promise<void> {
+  const row = $(paletteDialog).$(`[data-pal-index]*=${text}`);
+  await row.waitForDisplayed({
+    timeout: 10_000, timeoutMsg: `palette row "${text}" never appeared`,
+  });
+  await row.click();
+}
+
+/**
+ * Click a Settings-screen toggle row identified by its label text.
+ *
+ * DOM deviation from the task brief: `Row`'s label renders in a `<div>` (not
+ * a `<span>`), and — critically — that div lives in a *sibling* column from
+ * the `PGToggle` control (`Row` renders `<label-column><div/></label-column>
+ * <control-column>{control}</control-column>` as two side-by-side divs under
+ * one row div). `PGToggle` here is rendered without its own `label` prop
+ * (see `src/screens/Settings.tsx`'s "Confirm force-push" row), so there is no
+ * text node inside the actual clickable `<label>` element — clicking the
+ * row's label text does nothing. Verified via
+ * `browser.execute(() => ...outerHTML)` against the real DOM. Contrast with
+ * the CommitPanel signoff checkbox below, where `PGCheckbox` DOES render its
+ * `label` text as a `<span>` child of the same native `<label>` that wraps
+ * the hidden `<input type="checkbox">` — native label-click-forwarding makes
+ * `span*=...` work there without this helper.
+ */
+async function clickSettingsToggleRow(labelText: string): Promise<void> {
+  const ok = await browser.execute((text: string) => {
+    const divs = Array.from(document.querySelectorAll("div"));
+    const labelDiv = divs.find(
+      (d) => d.children.length === 0 && d.textContent?.trim() === text,
+    );
+    if (!labelDiv) return false;
+    // labelDiv -> (label+hint column) -> (row div, sibling holds control column)
+    const row = labelDiv.parentElement?.parentElement;
+    const toggle = row?.querySelector("label");
+    if (!toggle) return false;
+    (toggle as HTMLElement).click();
+    return true;
+  }, labelText);
+  if (!ok) throw new Error(`settings toggle row not found: ${labelText}`);
+}
+
+describe("settings", () => {
+  let repo: TempRepo | null = null;
+  let pair: RemotePair | null = null;
+
+  afterEach(async () => {
+    await resetApp();
+    repo?.dispose(); repo = null;
+    pair?.dispose(); pair = null;
+  });
+
+  it("pull mode persists across reload and FF-only refuses a diverged pull", async () => {
+    pair = remoteRepo();
+    makeDiverged(pair);
+    await openRepo(pair.repo.path);
+    await openSettings();
+    await $("button*=FF-only").click();
+    await browser.waitUntil(
+      async () => (await $('button[aria-pressed="true"]*=FF-only').isExisting()),
+      { timeout: 10_000, timeoutMsg: "FF-only never became active" },
+    );
+    // Leave Settings BEFORE reloading. AppShell's gate is
+    // `repo || screen === "settings"` (src/AppShell.tsx) and the screen id
+    // persists to localStorage["pg-screen"] outside pg-settings-v2 entirely.
+    // A reload with pg-screen still "settings" renders SettingsScreen
+    // directly on the freshly-booted (repo-less) store, bypassing
+    // WelcomeScreen's recent-repo list altogether — reopenRepo's row-click
+    // would then have nothing to find. Verified via
+    // `browser.execute(() => document.body.innerHTML)`: without this step
+    // the reload lands back on Settings with an empty recents DOM query.
+    await switchScreen("repo");
+    // Reload WITHOUT clearing localStorage (openRepo would wipe pg-settings-v2).
+    await reopenRepo(pair.repo.path);
+    const raw = await browser.execute(() => localStorage.getItem("pg-settings-v2"));
+    expect(raw).toContain('"defaultPullMode":"FastForward"');
+    await openSettings();
+    await $('button[aria-pressed="true"]*=FF-only').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "persisted FF-only not active after reload",
+    });
+    // Behavior: titlebar Pull consumes the persisted mode; --ff-only on a
+    // diverged branch must fail and surface the error banner.
+    const headBefore = pair.repo.git("rev-parse", "HEAD").trim();
+    await switchScreen("repo"); // leave Settings so titlebar context is normal
+    await $("button*=Pull").click();
+    await $('[role="alert"]').waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "FF-only pull on diverged branch showed no error",
+    });
+    expect(pair.repo.git("rev-parse", "HEAD").trim()).toBe(headBefore);
+  });
+
+  it("Merge pull mode produces a merge commit on a diverged branch", async () => {
+    pair = remoteRepo();
+    makeDiverged(pair);
+    await openRepo(pair.repo.path);
+    await openSettings();
+    await $("button*=Merge").click();
+    await browser.waitUntil(
+      async () => (await $('button[aria-pressed="true"]*=Merge').isExisting()),
+      { timeout: 10_000, timeoutMsg: "Merge mode never became active" },
+    );
+    await switchScreen("repo");
+    await $("button*=Pull").click();
+    // repo-truth wait: merge commit (2 parents) at HEAD is the outcome.
+    await browser.waitUntil(
+      async () =>
+        pair!.repo.git("rev-list", "--parents", "-1", "HEAD").trim().split(" ").length === 3,
+      { timeout: 20_000, timeoutMsg: "no merge commit after Merge-mode pull" },
+    );
+    expect(pair.repo.read("remote.txt")).toBe("remote\n");
+    expect(pair.repo.read("diverge.txt")).toBe("diverge\n");
+  });
+
+  it("Signed-off-by trailer is appended when the commit-panel toggle is on", async () => {
+    repo = dirtyRepo(); // has staged.txt already staged
+    await openRepo(repo.path);
+    await switchScreen("commit");
+    await stagedRow("staged.txt").waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "staged file missing",
+    });
+    // Toggle "Add Signed-off-by trailer": PGCheckbox renders the label text
+    // as a <span> inside the same native <label> that wraps the hidden
+    // checkbox <input> — clicking the span triggers native label-click
+    // forwarding to the input, so this works without DOM traversal (unlike
+    // the Settings PGToggle rows — see clickSettingsToggleRow above).
+    await $("span*=Add Signed-off-by trailer").click();
+    // Type message + commit, using the exact testids from commit.e2e.ts
+    // (the brief's "commit-message" was a guess; the real attribute is
+    // "commit-subject" — verified in src/screens/CommitPanel.tsx).
+    await $('[data-testid="commit-subject"]').setValue("feat: signed commit");
+    await $('[data-testid="commit-button"]').click();
+    await browser.waitUntil(
+      async () => repo!.git("log", "-1", "--pretty=%s").trim() === "feat: signed commit",
+      { timeout: 20_000, timeoutMsg: "commit never landed" },
+    );
+    expect(repo.git("log", "-1", "--pretty=%B")).toContain(
+      "Signed-off-by: E2E Tester <e2e@platypusgit.test>",
+    );
+  });
+
+  it("confirmForcePush=on + declined confirm blocks the force-push", async () => {
+    pair = remoteRepo();
+    makeDiverged(pair);
+    await openRepo(pair.repo.path);
+    const bareBefore = pair.bareGit("rev-parse", "main").trim();
+    await stubNativeDialogs({ confirm: false }); // setting defaults ON
+    await openPalette();
+    await $(paletteInput).setValue("force"); // matches label "Force-push {branch} (with lease)"
+    await clickPaletteRow("Force-push");
+    // Positive signal that the gate fired: the confirm stub was called.
+    await browser.waitUntil(async () => (await confirmCallCount()) > 0, {
+      timeout: 10_000, timeoutMsg: "confirm gate never fired",
+    });
+    expect(pair.bareGit("rev-parse", "main").trim()).toBe(bareBefore);
+  });
+
+  it("confirmForcePush=on + accepted confirm force-pushes with lease", async () => {
+    pair = remoteRepo();
+    makeDiverged(pair);
+    await openRepo(pair.repo.path);
+    const localHead = pair.repo.git("rev-parse", "HEAD").trim();
+    await stubNativeDialogs({ confirm: true });
+    await openPalette();
+    await $(paletteInput).setValue("force"); // matches label "Force-push {branch} (with lease)"
+    await clickPaletteRow("Force-push");
+    // repo-truth wait: bare main moving to the local head IS the outcome
+    // (a plain push would be rejected on this diverged fixture, so success
+    // also proves --force-with-lease was sent).
+    await browser.waitUntil(
+      async () => pair!.bareGit("rev-parse", "main").trim() === localHead,
+      { timeout: 20_000, timeoutMsg: "force-push never landed on the bare remote" },
+    );
+  });
+
+  it("confirmForcePush=off skips the confirm entirely", async () => {
+    pair = remoteRepo();
+    makeDiverged(pair);
+    await openRepo(pair.repo.path);
+    await openSettings();
+    // Toggle "Confirm force-push" off (defaults on). See clickSettingsToggleRow
+    // doc: the row label div is not inside the PGToggle's clickable <label>,
+    // so this requires the DOM-traversal helper rather than a text selector.
+    await clickSettingsToggleRow("Confirm force-push");
+    await switchScreen("repo");
+    const localHead = pair.repo.git("rev-parse", "HEAD").trim();
+    await stubNativeDialogs({ confirm: false }); // would block if consulted
+    await openPalette();
+    await $(paletteInput).setValue("force"); // matches label "Force-push {branch} (with lease)"
+    await clickPaletteRow("Force-push");
+    await browser.waitUntil(
+      async () => pair!.bareGit("rev-parse", "main").trim() === localHead,
+      { timeout: 20_000, timeoutMsg: "ungated force-push never landed" },
+    );
+    expect(await confirmCallCount()).toBe(0);
+  });
+});

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -116,19 +116,52 @@ export async function openRepo(repoPath: string): Promise<void> {
   await waitRepoLoaded();
 }
 
+/** Reload the page WITHOUT clearing localStorage, then reopen the repo via
+ *  its recent-row. This is the persistence-test primitive: `openRepo` starts
+ *  with `localStorage.clear()`, which would wipe pg-settings-v2 and defeat
+ *  any "survives reload" assertion. Follows the re-arm rule: matched find →
+ *  re-arm (see armDriverBridge doc). */
+export async function reopenRepo(repoPath: string): Promise<void> {
+  await browser.refresh();
+  await armDriverBridge();
+  const row = $(`[data-testid="recent-repo"][data-path="${repoPath}"]`);
+  await row.waitForDisplayed({
+    timeout: 20_000,
+    timeoutMsg: "recent-repo row missing after reload — recents not persisted?",
+  });
+  await armDriverBridge();
+  await row.click();
+  await waitRepoLoaded();
+}
+
 /** WebDriver can't drive native prompt/confirm — stub them in-page BEFORE the
- *  action that triggers them. Reset by any refresh. */
+ *  action that triggers them. Reset by any refresh.
+ *  `promptQueue`: successive `window.prompt` calls consume queue entries in
+ *  order (Add remote fires TWO prompts: name, then URL — a single string
+ *  would set name === url). Falls back to `promptText` when drained.
+ *  Confirm calls are counted on `window.__pgConfirmCalls` — read it via
+ *  `confirmCallCount()` to prove a confirm gate fired (or didn't). */
 export async function stubNativeDialogs(
-  opts: { promptText?: string; confirm?: boolean } = {},
+  opts: { promptText?: string; confirm?: boolean; promptQueue?: string[] } = {},
 ): Promise<void> {
   await browser.execute(
-    (promptText: string | null, confirm: boolean) => {
-      (window as any).prompt = () => promptText;
-      (window as any).confirm = () => confirm;
+    (promptText: string | null, confirm: boolean, queue: string[]) => {
+      const q = [...queue];
+      (window as any).__pgConfirmCalls = 0;
+      (window as any).prompt = () => (q.length ? q.shift()! : promptText);
+      (window as any).confirm = () => {
+        (window as any).__pgConfirmCalls++;
+        return confirm;
+      };
     },
     opts.promptText ?? "e2e",
     opts.confirm ?? true,
+    opts.promptQueue ?? [],
   );
+}
+
+export function confirmCallCount(): Promise<number> {
+  return browser.execute(() => (window as any).__pgConfirmCalls ?? 0);
 }
 
 export async function switchScreen(id: string): Promise<void> {
@@ -204,4 +237,45 @@ export async function jsHoverMenuItem(label: string): Promise<void> {
     return true;
   }, label);
   if (!ok) throw new Error(`menu item not found for hover: ${label}`);
+}
+
+/** The command palette dialog and its query input. The dialog is portaled to
+ *  document.body — always scope palette selectors under paletteDialog so they
+ *  can't match screen content behind it. */
+export const paletteDialog = '[role="dialog"][aria-label="Command palette"]';
+export const paletteInput = `${paletteDialog} input`;
+
+/** Open the palette. AppShell listens for ⌘P on `window`
+ *  (src/AppShell.tsx), so an in-page KeyboardEvent dispatch is deterministic
+ *  — no reliance on the embedded driver synthesizing Meta-key chords. */
+export async function openPalette(): Promise<void> {
+  await browser.execute(() => {
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "p", metaKey: true, bubbles: true }),
+    );
+  });
+  await $(paletteDialog).waitForDisplayed({
+    timeout: 10_000,
+    timeoutMsg: "command palette did not open on synthesized ⌘P",
+  });
+}
+
+/** Dispatch a keydown (Enter / Escape / ArrowDown / …) on an element.
+ *  CommandPalette handles keys via React onKeyDown on the dialog; a bubbling
+ *  native KeyboardEvent reaches React's root-delegated listener. Use this for
+ *  control keys; use setValue() for typing text. */
+export async function jsKey(selector: string, key: string): Promise<void> {
+  const ok = await browser.execute(
+    (sel: string, k: string) => {
+      const el = document.querySelector(sel) as HTMLElement | null;
+      if (!el) return false;
+      el.dispatchEvent(
+        new KeyboardEvent("keydown", { key: k, bubbles: true, cancelable: true }),
+      );
+      return true;
+    },
+    selector,
+    key,
+  );
+  if (!ok) throw new Error(`jsKey: element not found: ${selector}`);
 }

--- a/e2e/support/tempRepo.ts
+++ b/e2e/support/tempRepo.ts
@@ -116,3 +116,61 @@ export function rebaseConflictRepo(): TempRepo {
   // second pick's cherry-pick (base = dropped commit's tree, ours = first
   // pick's result) to actually diverge.
 }
+
+/** Work repo + local bare repo wired as `origin` with upstream set.
+ *  No network, no credentials: the backend shells to the system git CLI,
+ *  which handles filesystem-path remotes natively. */
+export interface RemotePair {
+  repo: TempRepo;
+  barePath: string;
+  bareGit: (...args: string[]) => string;
+  dispose: () => void;
+}
+
+export function remoteRepo(): RemotePair {
+  const repo = basicRepo();
+  const barePath = mkdtempSync(path.join(tmpdir(), "pg-e2e-bare-"));
+  execFileSync("git", ["init", "--bare", "-b", "main"], { cwd: barePath });
+  repo.git("remote", "add", "origin", barePath);
+  repo.git("push", "-u", "origin", "main");
+  const bareGit = (...args: string[]) =>
+    execFileSync("git", args, { cwd: barePath, encoding: "utf8" });
+  return {
+    repo,
+    barePath,
+    bareGit,
+    dispose: () => {
+      repo.dispose();
+      rmSync(barePath, { recursive: true, force: true });
+    },
+  };
+}
+
+/** Local is 1 ahead of origin/main. Remote-tracking ref stays accurate. */
+export function makeAhead(pair: RemotePair): void {
+  pair.repo.commitFile("local.txt", "local\n", "feat: local-only commit");
+}
+
+/** Remote is 1 ahead; the app does NOT know yet.
+ *  The remote-tracking ref is rewound too, so behind=0 until a real
+ *  fetch/pull discovers the remote commit — this is what makes fetch's
+ *  effect observable. Do NOT use this variant for force-push tests:
+ *  a rewound remote-tracking ref makes --force-with-lease fail with
+ *  "stale info" (the lease compares against refs/remotes/origin/main). */
+export function makeBehind(pair: RemotePair): void {
+  pair.repo.commitFile("remote.txt", "remote\n", "feat: remote-only commit");
+  pair.repo.git("push", "origin", "main");
+  pair.repo.git("reset", "--hard", "HEAD~1");
+  pair.repo.git("update-ref", "refs/remotes/origin/main", "HEAD");
+}
+
+/** Histories diverge: remote has one commit local lacks, local has one
+ *  commit remote lacks. Remote-tracking ref stays ACCURATE (no rewind):
+ *  ahead=1/behind=1 render immediately, plain push is rejected as
+ *  non-fast-forward, and --force-with-lease passes its lease check. */
+export function makeDiverged(pair: RemotePair): void {
+  pair.repo.commitFile("remote.txt", "remote\n", "feat: remote-only commit");
+  pair.repo.git("push", "origin", "main");
+  pair.repo.git("reset", "--hard", "HEAD~1");
+  pair.repo.commitFile("diverge.txt", "diverge\n", "feat: diverging local commit");
+}

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -1692,6 +1692,8 @@ export interface PGRemoteRowProps {
   onFetch?: () => void;
   onPush?: () => void;
   onPull?: () => void;
+  onContextMenu?: React.MouseEventHandler<HTMLDivElement>;
+  "data-remote"?: string;
 }
 
 export function PGRemoteRow({
@@ -1703,9 +1705,13 @@ export function PGRemoteRow({
   onFetch,
   onPush,
   onPull,
+  onContextMenu,
+  "data-remote": dataRemote,
 }: PGRemoteRowProps) {
   return (
     <div
+      onContextMenu={onContextMenu}
+      data-remote={dataRemote}
       style={{
         padding: 10,
         background: "var(--bg-1)",

--- a/src/design/primitives.tsx
+++ b/src/design/primitives.tsx
@@ -214,6 +214,7 @@ export function PGButtonGroup({ options, value, onChange, size = "md" }: PGButto
         return (
           <button
             key={opt.value}
+            aria-pressed={active}
             onClick={() => onChange?.(opt.value)}
             className="focusable"
             style={{

--- a/src/features/palette/commands.ts
+++ b/src/features/palette/commands.ts
@@ -1,6 +1,7 @@
 // src/features/palette/commands.ts
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { usePaletteStore } from "./usePaletteStore";
 import { currentBranch, relativeTime } from "@/lib/derive";
 import type { PaletteItem, PaletteStep } from "./types";
@@ -189,16 +190,27 @@ export function buildCommands(): PaletteItem[] {
             items: remoteItems("pull", (r) => void repo.pull(r, name)),
           })),
     });
+    const guardedForcePush = (remote: string) => {
+      if (
+        useSettingsStore.getState().confirmForcePush &&
+        !window.confirm(
+          `Force-push ${name} to ${remote} (with lease)? This overwrites the remote branch.`,
+        )
+      ) {
+        return;
+      }
+      void repo.push(remote, name, "WithLease");
+    };
     items.push({
       type: "command", id: "action:force-push-current",
       search: "Force push current branch with lease",
       label: `Force-push ${name} (with lease)`, danger: true,
       detail: head?.upstream ?? undefined, icon: "push",
       run: upstreamRemote
-        ? direct(() => void repo.push(upstreamRemote, name, "WithLease"))
+        ? direct(() => guardedForcePush(upstreamRemote))
         : step(() => ({
             kind: "pick", title: `Force-push ${name} to…`,
-            items: remoteItems("push", (r) => void repo.push(r, name, "WithLease")),
+            items: remoteItems("push", (r) => guardedForcePush(r)),
           })),
     });
   }

--- a/src/features/palette/usePaletteStore.test.ts
+++ b/src/features/palette/usePaletteStore.test.ts
@@ -34,6 +34,23 @@ describe("usePaletteStore", () => {
     expect(s.query).toBe("");
   });
 
+  it("pushStep reopens a closed palette (chained picks close before pushing)", () => {
+    // Chain flows (e.g. reset → pick commit → pick mode) go through item
+    // builders whose run() closes the palette before onPick pushes the next
+    // step; the pushed step must still render.
+    usePaletteStore.getState().openPalette();
+    usePaletteStore
+      .getState()
+      .pushStep({ kind: "pick", title: "Reset to commit", items: [] });
+    usePaletteStore.getState().closePalette();
+    usePaletteStore
+      .getState()
+      .pushStep({ kind: "pick", title: "Reset mode", items: [] });
+    const s = usePaletteStore.getState();
+    expect(s.open).toBe(true);
+    expect(s.stack).toHaveLength(3);
+  });
+
   it("popStep removes the top step", () => {
     usePaletteStore.getState().openPalette();
     usePaletteStore

--- a/src/features/palette/usePaletteStore.ts
+++ b/src/features/palette/usePaletteStore.ts
@@ -35,6 +35,12 @@ export const usePaletteStore = create<PaletteState>((set) => ({
   setChip: (activeChip) => set({ activeChip }),
   pushStep: (step) =>
     set((s) => ({
+      // A pushed step must be visible. Chained flows (reset → pick commit →
+      // pick mode, rename-branch → pick → input, push-tag, stash-branch) run
+      // through pick-item builders whose run() calls closePalette() before
+      // onPick pushes the follow-up step — without reopening here that step
+      // lands on a closed (unmounted) palette and is unreachable.
+      open: true,
       stack: [...s.stack, step],
       query: step.kind === "input" && step.initial != null ? step.initial : "",
     })),

--- a/src/screens/Remote.tsx
+++ b/src/screens/Remote.tsx
@@ -6,9 +6,12 @@ import {
   PGRemoteRow,
   PGSectionHeader,
   pgFlash,
+  remoteMenuItems,
+  useContextMenu,
 } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { currentBranch, totalAheadBehind } from "@/lib/derive";
+import type { RemoteInfo } from "@/lib/types";
 
 export function RemoteScreen() {
   const branches = useRepoStore((s) => s.branches);
@@ -52,6 +55,9 @@ export function RemoteScreen() {
     if (!url) return;
     store.addRemote(name, url);
   };
+
+  const { onContextMenu: onRemoteCtx, menu: remoteMenu } =
+    useContextMenu<RemoteInfo>((r) => remoteMenuItems(r));
 
   return (
     <div
@@ -223,6 +229,8 @@ export function RemoteScreen() {
               key={r.name}
               name={r.name}
               url={r.url ?? "(no url)"}
+              data-remote={r.name}
+              onContextMenu={(e) => onRemoteCtx(e, r)}
               ahead={0}
               behind={0}
               onFetch={() => store.fetch(r.name)}
@@ -247,6 +255,7 @@ export function RemoteScreen() {
           ))}
         </div>
       </div>
+      {remoteMenu}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

E2E Phase 3 (spec: `docs/superpowers/specs/2026-07-03-e2e-phase3-design.md`, plan alongside): covers the last untested surfaces, bringing the suite to **13 spec files / 47 tests** (46 passing + 1 skipped pending #27).

**New specs**
- `remote.e2e.ts` (10) — fetch/pull/push + add/remove/rename/edit-URL/prune against a **local bare origin** (no network, no creds); rejected non-FF push surfaces the error banner
- `palette.e2e.ts` (8) — open/close, nav, direct action, pick step, input step, two-step danger flow (hard reset), chips filter, frecency persistence
- `settings.e2e.ts` (6) — persistence across reload, FF-only vs Merge pull behavior on a diverged branch, Signed-off-by trailer, confirmForcePush gate (blocked / accepted / off)

**App fixes (each proven by the new tests)**
- Remote rows now open the previously dead `remoteMenuItems` context menu (had zero call sites — remote management beyond add was unreachable)
- Palette force-push gated behind the `confirmForcePush` setting (was inert; both run paths); `PGButtonGroup` exposes `aria-pressed`
- `pushStep` sets `open: true` — chained palette flows (reset → pick → mode, rename-branch, push-tag, stash-branch) silently dead-ended on a closed palette; store regression test included

**Harness** — `remoteRepo()` fixture (bare origin; ahead/behind/diverged with deliberate remote-tracking-ref semantics for the force-with-lease lease check), `stubNativeDialogs` prompt queue + confirm-call counter, `reopenRepo` (reload without wiping localStorage), `openPalette`/`jsKey`.

**Follow-ups filed**: #31 (dead settings audit), #32 (local focus-race flake — WKWebView reports hidden when another app holds foreground; CI/xvfb immune).

## Test plan

- [x] `pnpm tsc --noEmit`, `pnpm exec tsc -p e2e/tsconfig.json --noEmit`
- [x] `pnpm test` — 97/97 (incl. new pushStep regression test)
- [x] Full local e2e — 13/13 spec files, 46 passing + 1 pre-existing skip
- [ ] CI e2e green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)