### PR TITLE
fix(rebase): persist completion summary frontend-side

### DIFF
--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -123,6 +123,14 @@ interface RepoStoreState {
   error: AppError | null;
   repoState: GitRepoState;
   rebaseStatus: RebaseStatus;
+  /**
+   * Final status of the most recently completed rebase, held frontend-side.
+   * The backend sweeps RebaseState on completion (#28), so the very next
+   * refreshAll's rebase_status poll reports total: 0 — this field preserves
+   * the "N steps completed" summary for the Rebase screen. Cleared when a
+   * new rebase starts, on abort, and on repo open/close.
+   */
+  lastRebaseSummary: RebaseStatus | null;
   /** Active long-running ops keyed by op kind. */
   activity: RepoActivity;
   openRepo: (path: string) => Promise<void>;
@@ -250,6 +258,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   error: null,
   repoState: "Clean",
   rebaseStatus: DEFAULT_REBASE_STATUS,
+  lastRebaseSummary: null,
   activity: {},
 
   async openRepo(path) {
@@ -268,6 +277,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         commits: [],
         searchResults: null,
         commitFilter: {},
+        lastRebaseSummary: null,
       });
       await get().refreshAll();
     } catch (e) {
@@ -348,6 +358,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       searchResults: null,
       commitFilter: {},
       searching: false,
+      lastRebaseSummary: null,
       error: null,
     });
   },
@@ -922,7 +933,12 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return null;
     try {
       const status = await rebaseStartFn(repo.id, plan);
-      set({ rebaseStatus: status });
+      // Capture the summary before refreshAll re-polls rebase_status — the
+      // backend sweeps RebaseState on completion, so the poll returns total: 0.
+      set({
+        rebaseStatus: status,
+        lastRebaseSummary: status.inProgress ? null : status,
+      });
       await get().refreshAll();
       return status;
     } catch (e) {
@@ -936,7 +952,10 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return null;
     try {
       const status = await rebaseContinueFn(repo.id);
-      set({ rebaseStatus: status });
+      set({
+        rebaseStatus: status,
+        ...(status.inProgress ? {} : { lastRebaseSummary: status }),
+      });
       await get().refreshAll();
       return status;
     } catch (e) {
@@ -950,7 +969,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     try {
       await rebaseAbort(repo.id);
-      set({ rebaseStatus: DEFAULT_REBASE_STATUS });
+      set({ rebaseStatus: DEFAULT_REBASE_STATUS, lastRebaseSummary: null });
       await get().refreshAll();
     } catch (e) {
       set({ error: toAppError(e) });

--- a/src/screens/Rebase.test.tsx
+++ b/src/screens/Rebase.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { RebaseScreen } from "./Rebase";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { mockInvoke } from "@/test/invokeMock";
+import type { CommitInfo, RebaseStatus, RepoHandle } from "@/lib/types";
+
+const handle: RepoHandle = { id: "repo-1", path: "/tmp/fake-repo", head: "refs/heads/main" };
+
+const SWEPT_STATUS: RebaseStatus = {
+  inProgress: false,
+  nextIndex: 0,
+  total: 0,
+  pauseReason: null,
+};
+
+function makeCommit(oid: string, summary: string, parent: string): CommitInfo {
+  return {
+    oid,
+    shortOid: oid.slice(0, 7),
+    summary,
+    body: null,
+    author: "Tester",
+    email: "tester@example.com",
+    timestamp: 1_700_000_000,
+    parents: [parent],
+    refs: [],
+  };
+}
+
+const commits = [
+  makeCommit("b".repeat(40), "feat: second", "a".repeat(40)),
+  makeCommit("a".repeat(40), "feat: first", "0".repeat(40)),
+];
+
+function resetStores() {
+  useRepoStore.setState({
+    current: handle,
+    status: [],
+    allFiles: [],
+    branches: [],
+    tags: [],
+    stashes: [],
+    remotes: [],
+    commits,
+    loading: false,
+    error: null,
+    repoState: "Clean",
+    rebaseStatus: SWEPT_STATUS,
+    lastRebaseSummary: null,
+    activity: {},
+  });
+  useNavStore.setState({ intent: null });
+}
+
+function wireRefreshAllMocks(): void {
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log", () => commits);
+  mockInvoke("repo_state", () => "Clean");
+  // Post-#28 backend behavior: RebaseState is swept on completion, so the
+  // status poll right after a finished rebase reports total: 0.
+  mockInvoke("rebase_status", () => SWEPT_STATUS);
+}
+
+function seedPlanIntent(): void {
+  useNavStore.setState({
+    intent: {
+      kind: "rebase-plan",
+      plan: commits.map((c) => ({ oid: c.oid, action: "Pick", message: null })),
+    },
+  });
+}
+
+describe("RebaseScreen completion summary", () => {
+  beforeEach(() => {
+    resetStores();
+    wireRefreshAllMocks();
+  });
+
+  it("shows the summary after a completed rebase even though refreshAll re-polls a swept rebase_status", async () => {
+    mockInvoke("rebase_start", () => ({
+      inProgress: false,
+      nextIndex: 2,
+      total: 2,
+      pauseReason: null,
+    }));
+
+    seedPlanIntent();
+    render(<RebaseScreen />);
+
+    await userEvent.click(screen.getByTestId("rebase-start"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rebase-last-summary")).toHaveTextContent(
+        "Last rebase: 2 steps completed.",
+      );
+    });
+
+    // refreshAll really did clobber rebaseStatus with the swept poll…
+    const state = useRepoStore.getState();
+    expect(state.rebaseStatus).toEqual(SWEPT_STATUS);
+    // …but the summary survived frontend-side.
+    expect(state.lastRebaseSummary).toEqual({
+      inProgress: false,
+      nextIndex: 2,
+      total: 2,
+      pauseReason: null,
+    });
+
+    // Summary also survives any later refresh cycle (poll still swept).
+    await useRepoStore.getState().refreshAll();
+    expect(screen.getByTestId("rebase-last-summary")).toHaveTextContent(
+      "Last rebase: 2 steps completed.",
+    );
+  });
+
+  it("clears the summary when a new rebase starts and pauses", async () => {
+    useRepoStore.setState({
+      lastRebaseSummary: { inProgress: false, nextIndex: 2, total: 2, pauseReason: null },
+    });
+    mockInvoke("rebase_start", () => ({
+      inProgress: true,
+      nextIndex: 1,
+      total: 2,
+      pauseReason: "conflict",
+    }));
+    mockInvoke("rebase_status", () => ({
+      inProgress: true,
+      nextIndex: 1,
+      total: 2,
+      pauseReason: "conflict",
+    }));
+
+    seedPlanIntent();
+    render(<RebaseScreen />);
+
+    await userEvent.click(screen.getByTestId("rebase-start"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("rebase-last-summary")).not.toBeInTheDocument();
+    });
+    expect(useRepoStore.getState().lastRebaseSummary).toBeNull();
+  });
+
+  it("sets the summary when a paused rebase completes via continue, and abort clears it", async () => {
+    useRepoStore.setState({
+      rebaseStatus: { inProgress: true, nextIndex: 1, total: 3, pauseReason: "conflict" },
+    });
+    mockInvoke("rebase_continue", () => ({
+      inProgress: false,
+      nextIndex: 3,
+      total: 3,
+      pauseReason: null,
+    }));
+
+    render(<RebaseScreen />);
+
+    await userEvent.click(screen.getByTestId("rebase-continue"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rebase-last-summary")).toHaveTextContent(
+        "Last rebase: 3 steps completed.",
+      );
+    });
+
+    // Abort of a later rebase must not leave a stale "completed" summary.
+    mockInvoke("rebase_abort", () => null);
+    await useRepoStore.getState().rebaseAbort();
+    expect(useRepoStore.getState().lastRebaseSummary).toBeNull();
+  });
+});

--- a/src/screens/Rebase.tsx
+++ b/src/screens/Rebase.tsx
@@ -113,8 +113,15 @@ function RebaseBanner({
 // ─── Plan builder ─────────────────────────────────────────────────────────────
 
 export function RebaseScreen() {
-  const { current, commits, rebaseStatus, rebaseStart, rebaseContinue, rebaseAbort } =
-    useRepoStore();
+  const {
+    current,
+    commits,
+    rebaseStatus,
+    lastRebaseSummary,
+    rebaseStart,
+    rebaseContinue,
+    rebaseAbort,
+  } = useRepoStore();
 
   const [plan, setPlan] = useState<PlanRow[]>([]);
   const [baseLabel, setBaseLabel] = useState<string | null>(null);
@@ -203,7 +210,14 @@ export function RebaseScreen() {
       action: r.action,
       message: r.action === "Reword" || r.action === "Squash" ? (r.message || null) : null,
     }));
-    await rebaseStart(steps);
+    const status = await rebaseStart(steps);
+    // The rebase consumed the plan — clear it so the completion summary (or
+    // the in-progress banner) isn't hidden behind a stale plan builder. On
+    // failure (null) keep the plan so the user can adjust and retry.
+    if (status) {
+      setPlan([]);
+      setBaseLabel(null);
+    }
   };
 
   const handleClear = () => {
@@ -388,9 +402,12 @@ export function RebaseScreen() {
         </div>
       )}
 
-      {/* Waiting / done state when rebase just finished */}
-      {rebaseStatus.inProgress === false && rebaseStatus.total > 0 && plan.length === 0 && (
+      {/* Done state when a rebase finished — rebase_status reports total: 0
+          after the backend sweeps its state, so the summary comes from the
+          store's frontend-held lastRebaseSummary instead. */}
+      {!rebaseStatus.inProgress && lastRebaseSummary && plan.length === 0 && (
         <div
+          data-testid="rebase-last-summary"
           style={{
             padding: "8px 16px",
             borderTop: "1px solid var(--border-0)",
@@ -399,7 +416,7 @@ export function RebaseScreen() {
             color: "var(--fg-2)",
           }}
         >
-          Last rebase: {rebaseStatus.total} steps completed.
+          Last rebase: {lastRebaseSummary.total} steps completed.
         </div>
       )}
 


### PR DESCRIPTION
## Summary

PR #28 sweeps `RebaseState` on completion — correct for the data-loss hazard, but it made the Rebase screen's "Last rebase: N steps completed" block unreachable: `rebaseStart`/`rebaseContinue` briefly hold the final status, then `refreshAll` re-polls `rebase_status`, which post-sweep returns `total: 0`.

Frontend-side fix, backend sweep untouched:

- **`useRepoStore.lastRebaseSummary`** — new field capturing the final `RebaseStatus` from the `rebase_start`/`rebase_continue` return value in the same `set` as `rebaseStatus`, before `refreshAll` clobbers it. Cleared on new rebase start, abort, and repo open/close.
- **`Rebase.tsx`** — repointed the dead summary block to `lastRebaseSummary` (+ `data-testid="rebase-last-summary"`).
- **Plan cleared on successful start** — `handleStart` now clears the local plan once the rebase is accepted (kept on failure for retry). Previously a stale plan hid the summary behind the `plan.length === 0` guard even pre-#28.
- **Tests** — new `src/screens/Rebase.test.tsx` (3 component tests via `mockInvoke`): summary survives completed rebase + swept `rebase_status` re-poll (and a further manual `refreshAll`); new paused rebase clears it; continue-to-completion sets it and abort clears it.

The raw-IPC `rebase_abort` hardening gap noted in the issue is explicitly deferred, per the issue.

Closes #29

## Validation

- `pnpm tsc --noEmit` clean
- `pnpm test` — 14 files, 100 tests passed (3 new)
- No src-tauri changes; e2e runs in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)