### PR TITLE
feat(files): multi-file selection in commit panel and repo browser

### DIFF
--- a/docs/superpowers/plans/2026-07-03-multi-file-select.md
+++ b/docs/superpowers/plans/2026-07-03-multi-file-select.md
@@ -1,0 +1,73 @@
+# Multi-File Selection — Implementation Plan
+
+Spec: `docs/superpowers/specs/2026-07-03-multi-file-select-design.md`
+
+## 1. Pure selection helper
+
+`src/lib/selection.ts` (new):
+
+- `interface Selection { keys: string[]; anchor: string | null }` +
+  `emptySelection`.
+- `clickSelection(order, prev, key, { toggle, range }): Selection` — plain /
+  ctrl-toggle / shift-range semantics per spec. Range is over `order` (the
+  visible row order); unknown anchor or key degrades to plain click.
+- `pruneSelection(prev, valid: ReadonlySet<string>): Selection` — drops dead
+  keys, re-homes a dead anchor to the last surviving key. Returns `prev`
+  unchanged (same reference) when nothing changed, so it can be used in
+  `setState` without re-render churn.
+- `primarySelectedKey(sel): string | null` — anchor if still selected, else
+  last selected key. Drives the preview pane.
+
+Tests in `src/lib/selection.test.ts`.
+
+## 2. Design-system threading
+
+`src/design/git-components.tsx`:
+
+- `PGChangeRow`: `onClick?: (e: MouseEvent) => void`; render
+  `data-selected={selected ? "true" : undefined}`.
+- `PGFileTreeRow`: same `onClick` change, new `onContextMenu?`, same
+  `data-selected`.
+- `PGFileTree`: new `selectedKeys?: ReadonlySet<string>` prop (a row is
+  selected when in `selectedKeys` or equal to `selected`); `onSelect` /
+  `onActivate` gain an optional trailing `MouseEvent`; new
+  `onRowContextMenu?: (e, key, node) => void`; export `flattenFileTree`.
+
+`src/design/context-menu.tsx`: new `multiFileMenuItems({ stagedPaths,
+unstagedPaths })` — Stage/Unstage subset items, Copy paths, and a
+danger "Discard changes in N files…" gated by `window.confirm`.
+
+## 3. CommitPanel
+
+- Replace `selectedKey: string | null` with `sel: Selection`.
+- Visible order = `[...staged, ...unstaged].map(keyOf)`.
+- Row `onClick` → `clickSelection` with `toggle = e.metaKey || e.ctrlKey`,
+  `range = e.shiftKey`.
+- Prune effect on `[staged, unstaged]`; reset on `repo?.id` change.
+- Preview file = row for `primarySelectedKey(sel)`, falling back to
+  `unstaged[0] ?? staged[0]` as today.
+- Checkbox toggle: row in a multi-selection → act on all selected paths on
+  that row's side; else single path as today.
+- Context menu: clicked row in a multi-selection → `multiFileMenuItems`
+  (split by side); else collapse selection to the row + existing
+  `fileMenuItems`.
+
+## 4. RepoBrowser
+
+- Replace `selected: string | null` with `sel: Selection` over tree keys.
+- Order = `flattenFileTree(tree, expanded).map(f => f.key)`.
+- `selectedKeys` prop for multi-highlight; prune on tree change; reset on
+  repo change and rev change (existing resets keep working).
+- Preview = `primarySelectedKey`.
+- New context menu on file rows: multi-selection → `multiFileMenuItems`
+  (staged/unstaged split derived from each path's `FileStatus`); single file
+  → `fileMenuItems`. Suppressed while browsing a committed revision (no
+  worktree to stage from).
+
+## 5. Tests & validation
+
+- `src/lib/selection.test.ts` (pure) + `src/screens/CommitPanel.test.tsx`
+  (component; `mockInvoke` for `get_diff`, refresh commands, `stage_paths`,
+  `discard_paths`; `vi.spyOn(window, "confirm")` for the danger flow).
+- Gates: `pnpm tsc --noEmit`, `pnpm test`. E2E untouched (plain-click flows
+  unchanged); CI runs the suite on the PR.

--- a/docs/superpowers/specs/2026-07-03-multi-file-select-design.md
+++ b/docs/superpowers/specs/2026-07-03-multi-file-select-design.md
@@ -1,0 +1,102 @@
+# Multi-File Selection — Design
+
+Status: approved 2026-07-03 (issue #25, item 4)
+
+## Problem
+
+File lists are strictly single-select. Staging, unstaging, or discarding
+several files means clicking each one individually (or all-or-nothing via
+"Stage all"). Every serious git GUI supports Cmd/Ctrl-click and Shift-click
+multi-selection; its absence is a daily-friction gap.
+
+## Scope
+
+Frontend only. The backend path-array IPC already exists
+(`stage_paths` / `unstage_paths` / `discard_paths` in
+`src-tauri/src/commands/diff.rs`, wrapped by `stagePaths` /
+`unstagePaths` / `discardPaths` in `src/lib/tauri.ts`) and `useRepoStore`'s
+`stage` / `unstage` / `discard` actions already take `string[]`.
+
+Applies to two surfaces:
+
+- **CommitPanel** — the STAGED and CHANGES lists (`PGChangeRow`s).
+- **RepoBrowser** — the file tree (`PGFileTree` / `PGFileTreeRow`).
+
+Out of scope: History/CommitDiff file lists, drag-select, Select All
+shortcut, e2e specs (existing single-click flows are unchanged; multi-select
+e2e can follow later).
+
+## Selection model
+
+Classic desktop list semantics, implemented as a pure, tested helper
+(`src/lib/selection.ts`):
+
+- **Plain click** — selects exactly that row and sets it as the *anchor*.
+  Existing behavior preserved.
+- **Cmd/Ctrl-click** (`metaKey || ctrlKey`) — toggles the row in/out of the
+  selection. Toggling in moves the anchor to that row; toggling the anchor
+  itself out moves the anchor to the last remaining selected row.
+- **Shift-click** — replaces the selection with the contiguous range of
+  *visible* rows between the anchor and the clicked row (either direction).
+  The anchor does not move, so successive shift-clicks re-extend from the
+  same origin. No anchor yet → behaves like plain click.
+- **Pruning** — whenever the underlying row set changes (refresh, repo
+  switch, stage/unstage moving files between lists, rev/filter change in the
+  browser), selected keys that no longer exist are dropped; a vanished anchor
+  falls back to the last surviving selected row.
+
+Selection state lives in local component state per existing patterns
+(CommitPanel's `selectedKey`, RepoBrowser's `selected` today) — not in a
+store. The *primary* row (anchor, falling back to the last selected) drives
+the existing single-file preview/diff pane, so preview behavior is unchanged
+for single selection.
+
+In CommitPanel the visible row order spans STAGED then CHANGES; a shift range
+may cross the boundary. Row keys stay `side:path` so the same path staged and
+unstaged remains two distinct rows.
+
+In RepoBrowser the range is over the *flattened visible* tree rows (folders
+included in the range for selection purposes); operations only ever apply to
+paths that resolve to actual changed files, so folder keys are inert.
+
+## Multi-file operations
+
+- **Row checkbox (CommitPanel)** — toggling the checkbox of a row that is
+  part of a multi-selection stages/unstages *all selected rows on that side*.
+  Toggling an unselected row's checkbox affects only that row (unchanged).
+- **Context menu** — right-clicking a row inside the current multi-selection
+  opens a multi-file menu (`multiFileMenuItems` in
+  `src/design/context-menu.tsx`): "Stage N files", "Unstage N files",
+  "Copy paths", and "Discard changes in N files…" (danger). Right-clicking a
+  row outside the selection first collapses the selection to that row and
+  shows the existing single-file menu. Mixed selections (staged + unstaged)
+  offer both Stage and Unstage, each acting on its own subset.
+- **Discard** — multi-discard goes through the existing confirm/danger flow:
+  a `window.confirm` naming the file count, and the menu item styled
+  `danger`, matching hunk-discard's existing confirm.
+- **RepoBrowser** — file rows gain a context menu (the tree had none): the
+  single-file menu for one file, the multi-file menu for a selection.
+
+## Component changes
+
+Per the design-system rule that row components need explicit prop threading:
+
+- `PGChangeRow` — `onClick` gains the mouse event; adds `data-selected` for
+  tests/e2e.
+- `PGFileTreeRow` — `onClick` gains the mouse event; new `onContextMenu`
+  prop; adds `data-selected`.
+- `PGFileTree` — new `selectedKeys?: ReadonlySet<string>` (multi-highlight),
+  `onSelect`/`onActivate` pass the mouse event through when originating from
+  a click, new `onRowContextMenu`. `flattenFileTree` is exported so callers
+  can compute the visible row order for shift ranges. Keyboard navigation
+  (arrows/Enter) keeps plain single-select semantics.
+
+## Testing
+
+- `src/lib/selection.test.ts` — pure helper: plain click, ctrl toggle in/out,
+  anchor handoff, shift ranges both directions, shift without anchor, prune.
+- `src/screens/CommitPanel.test.tsx` — jsdom + RTL with `mockInvoke`:
+  ctrl-click toggles rows into a multi-selection, shift-click selects a
+  range, multi stage via context menu dispatches one `stage_paths` call with
+  the full path array, multi discard confirms before `discard_paths` and
+  aborts when declined.

--- a/e2e/specs/merge-conflict.e2e.ts
+++ b/e2e/specs/merge-conflict.e2e.ts
@@ -82,9 +82,17 @@ describe("merge & conflict", () => {
     });
     await $('[data-testid="accept-ours"]').click();
     // accept-ours may auto-mark the file resolved (row leaves the list) —
-    // only click mark-resolved if it's still present.
+    // only click mark-resolved if it's still present. TOCTOU guard (#35):
+    // the post-accept refresh can unmount the button between isExisting()
+    // and click() — the button vanishing IS the resolved state, so swallow
+    // the re-find failure; the finalize wait + repo-truth asserts below
+    // remain the real gates.
     const markResolvedBtn = $('[data-testid="mark-resolved"]');
-    if (await markResolvedBtn.isExisting()) await markResolvedBtn.click();
+    try {
+      if (await markResolvedBtn.isExisting()) await markResolvedBtn.click();
+    } catch {
+      // button unmounted mid-flight — file already resolved
+    }
     const finalize = $('[data-testid="conflict-finalize"]');
     await browser.waitUntil(async () => finalize.isEnabled(), {
       timeout: 10_000, timeoutMsg: "Finalize never enabled after resolving",
@@ -106,8 +114,13 @@ describe("merge & conflict", () => {
       timeout: 10_000, timeoutMsg: "detail action bar missing",
     });
     await $('[data-testid="accept-theirs"]').click();
+    // Same TOCTOU guard as the accept-ours test above (#35).
     const markResolvedBtn = $('[data-testid="mark-resolved"]');
-    if (await markResolvedBtn.isExisting()) await markResolvedBtn.click();
+    try {
+      if (await markResolvedBtn.isExisting()) await markResolvedBtn.click();
+    } catch {
+      // button unmounted mid-flight — file already resolved
+    }
     await browser.waitUntil(
       async () => $('[data-testid="conflict-finalize"]').isEnabled(),
       { timeout: 10_000, timeoutMsg: "Finalize never enabled" },

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -267,10 +267,34 @@ export const jsContextMenu = (selector: string, opts?: { text?: string }) =>
     opts?.text,
   );
 
+/** Read-only poll: wait for a menu item's label span to be in the DOM.
+ *
+ *  The portal menu renders one or two React commits AFTER the script that
+ *  triggered it returns (contextmenu dispatch → state → portal render;
+ *  hover → effect → onOpenSubmenu → submenu portal), so the item is never
+ *  present synchronously. Locally the next driver round-trip is slower than
+ *  those commits; under xvfb CI load it occasionally isn't, and a single-shot
+ *  lookup throws "menu item not found" (seen with the History reset submenu).
+ *  Bare execute is fine — the poll has no side effects. */
+async function waitForMenuItem(label: string): Promise<void> {
+  await browser.waitUntil(
+    () =>
+      browser.execute(
+        (text: string) =>
+          Array.from(document.querySelectorAll("span")).some(
+            (s) => s.textContent === text,
+          ),
+        label,
+      ),
+    { timeout: 10_000, timeoutMsg: `menu item never rendered: ${label}` },
+  );
+}
+
 /** Click an open context-menu item by its label-span text (menus are
  *  portals rendered to document.body, so a plain CSS selector on the label
  *  text is the reliable way to find them). */
 export async function jsClickMenuItem(label: string): Promise<void> {
+  await waitForMenuItem(label);
   // executeOnce: the click closes the menu, so a driver-retry re-run finds
   // no item and reports false — failing the test even though the click
   // already landed (the CI double-run flake, issue #35).
@@ -288,6 +312,7 @@ export async function jsClickMenuItem(label: string): Promise<void> {
 /** Hover a context-menu item to open its submenu (menus are portals; the
  *  driver can't hover, so dispatch the events React listens for). */
 export async function jsHoverMenuItem(label: string): Promise<void> {
+  await waitForMenuItem(label);
   const ok = await executeOnce((text: string) => {
     const spans = Array.from(document.querySelectorAll("span"));
     const el = spans.find((s) => s.textContent === text);

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -891,6 +891,78 @@ export function fileMenuItems(
   ];
 }
 
+export interface MultiFileMenuSelection {
+  /** Selected paths currently staged (index side). */
+  stagedPaths: string[];
+  /** Selected paths with unstaged (worktree) changes. */
+  unstagedPaths: string[];
+}
+
+/**
+ * Context menu for a multi-file selection. Stage/Unstage each act on their
+ * own subset so mixed selections work; discard goes through the standard
+ * confirm/danger flow before touching the worktree.
+ */
+export function multiFileMenuItems(
+  sel: MultiFileMenuSelection | null,
+): ContextMenuItem[] {
+  const stagedPaths = sel?.stagedPaths ?? [];
+  const unstagedPaths = sel?.unstagedPaths ?? [];
+  const all = [...stagedPaths, ...unstagedPaths];
+  const n = all.length;
+  const files = (c: number) => `${c} file${c === 1 ? "" : "s"}`;
+  const items: ContextMenuItem[] = [{ __menuTitle: `${files(n)} selected` }];
+  if (unstagedPaths.length) {
+    items.push({
+      icon: "plus",
+      label: `Stage ${files(unstagedPaths.length)}`,
+      onClick: () => {
+        useRepoStore.getState().stage(unstagedPaths);
+      },
+    });
+  }
+  if (stagedPaths.length) {
+    items.push({
+      icon: "minus",
+      label: `Unstage ${files(stagedPaths.length)}`,
+      onClick: () => {
+        useRepoStore.getState().unstage(stagedPaths);
+      },
+    });
+  }
+  items.push(
+    { divider: true },
+    {
+      icon: "copy",
+      label: "Copy paths",
+      onClick: () => {
+        navigator.clipboard?.writeText(all.join("\n"));
+        pgFlash("copied paths");
+      },
+    },
+  );
+  if (unstagedPaths.length) {
+    items.push(
+      { divider: true },
+      {
+        icon: "undo",
+        label: `Discard changes in ${files(unstagedPaths.length)}…`,
+        danger: true,
+        onClick: () => {
+          if (
+            window.confirm(
+              `Discard changes in ${files(unstagedPaths.length)}? The changes will be lost.`,
+            )
+          ) {
+            useRepoStore.getState().discard(unstagedPaths);
+          }
+        },
+      },
+    );
+  }
+  return items;
+}
+
 export function stashMenuItems(
   stash: { name?: string; index?: number } | null,
 ): ContextMenuItem[] {

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -34,7 +34,8 @@ export interface PGFileTreeRowProps {
   hasChildren?: boolean;
   selected?: boolean;
   onToggle?: () => void;
-  onClick?: () => void;
+  onClick?: (e: MouseEvent) => void;
+  onContextMenu?: (e: MouseEvent) => void;
   extra?: ReactNode;
   hideStatus?: boolean;
 }
@@ -50,6 +51,7 @@ export function PGFileTreeRow({
   selected,
   onToggle,
   onClick,
+  onContextMenu,
   extra,
   hideStatus,
 }: PGFileTreeRowProps) {
@@ -57,7 +59,9 @@ export function PGFileTreeRow({
   return (
     <div
       data-path={path}
+      data-selected={selected ? "true" : undefined}
       onClick={onClick}
+      onContextMenu={onContextMenu}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       style={{
@@ -136,13 +140,16 @@ export interface PGFileTreeProps {
   expanded?: Record<string, boolean>;
   onToggle?: (key: string) => void;
   selected?: string;
-  onSelect?: (key: string, node: PGFileTreeNode) => void;
+  /** Extra keys rendered as selected (multi-select). `selected` stays the primary row. */
+  selectedKeys?: ReadonlySet<string>;
+  onSelect?: (key: string, node: PGFileTreeNode, e?: MouseEvent) => void;
   /** Fired on Enter or double-click. For folders, toggles; for files, caller decides. */
   onActivate?: (key: string, node: PGFileTreeNode) => void;
+  onRowContextMenu?: (e: MouseEvent, key: string, node: PGFileTreeNode) => void;
   showStatus?: boolean;
 }
 
-interface FlatNode {
+export interface PGFileTreeFlatNode {
   key: string;
   node: PGFileTreeNode;
   indent: number;
@@ -150,11 +157,16 @@ interface FlatNode {
   isExpanded: boolean;
 }
 
-function flattenTree(
+/**
+ * Visible rows of the tree in render order — the same flattening PGFileTree
+ * renders from. Exported so callers can compute shift-click ranges over the
+ * visible row order.
+ */
+export function flattenFileTree(
   nodes: PGFileTreeNode[],
   expanded: Record<string, boolean>,
-): FlatNode[] {
-  const out: FlatNode[] = [];
+): PGFileTreeFlatNode[] {
+  const out: PGFileTreeFlatNode[] = [];
   const walk = (list: PGFileTreeNode[], indent: number, parentKey: string) => {
     for (const node of list) {
       const key = parentKey + "/" + node.name;
@@ -174,11 +186,13 @@ export function PGFileTree({
   expanded = {},
   onToggle,
   selected,
+  selectedKeys,
   onSelect,
   onActivate,
+  onRowContextMenu,
   showStatus = true,
 }: PGFileTreeProps) {
-  const flat = flattenTree(nodes, expanded);
+  const flat = flattenFileTree(nodes, expanded);
   const selectedIdx = selected
     ? flat.findIndex((f) => f.key === selected)
     : -1;
@@ -254,12 +268,18 @@ export function PGFileTree({
           hideStatus={!showStatus}
           expanded={f.isExpanded}
           hasChildren={f.hasChildren}
-          selected={selected === f.key}
-          onClick={() => {
-            onSelect?.(f.key, f.node);
-            if (f.hasChildren) onToggle?.(f.key);
+          selected={selected === f.key || !!selectedKeys?.has(f.key)}
+          onClick={(e) => {
+            onSelect?.(f.key, f.node, e);
+            if (f.hasChildren && !e.metaKey && !e.ctrlKey && !e.shiftKey)
+              onToggle?.(f.key);
           }}
           onToggle={() => onToggle?.(f.key)}
+          onContextMenu={
+            onRowContextMenu
+              ? (e) => onRowContextMenu(e, f.key, f.node)
+              : undefined
+          }
           extra={f.node.extra}
         />
       ))}
@@ -277,7 +297,7 @@ export interface PGChangeRowProps {
   staged?: boolean;
   onToggle?: (v: boolean) => void;
   selected?: boolean;
-  onClick?: () => void;
+  onClick?: (e: MouseEvent) => void;
   onContextMenu?: (e: MouseEvent) => void;
   additions?: number;
   deletions?: number;
@@ -303,6 +323,7 @@ export function PGChangeRow({
   return (
     <div
       data-path={path}
+      data-selected={selected ? "true" : undefined}
       onClick={onClick}
       onContextMenu={onContextMenu}
       onMouseEnter={() => setHover(true)}

--- a/src/lib/selection.test.ts
+++ b/src/lib/selection.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import {
+  clickSelection,
+  emptySelection,
+  primarySelectedKey,
+  pruneSelection,
+  type Selection,
+} from "./selection";
+
+const order = ["a", "b", "c", "d", "e"];
+
+describe("clickSelection", () => {
+  it("plain click selects a single row and moves the anchor", () => {
+    const s1 = clickSelection(order, emptySelection, "b");
+    expect(s1).toEqual({ keys: ["b"], anchor: "b" });
+    const s2 = clickSelection(order, s1, "d");
+    expect(s2).toEqual({ keys: ["d"], anchor: "d" });
+  });
+
+  it("ctrl-click toggles rows in and moves the anchor", () => {
+    let s: Selection = clickSelection(order, emptySelection, "a");
+    s = clickSelection(order, s, "c", { toggle: true });
+    expect(s).toEqual({ keys: ["a", "c"], anchor: "c" });
+    s = clickSelection(order, s, "e", { toggle: true });
+    expect(s).toEqual({ keys: ["a", "c", "e"], anchor: "e" });
+  });
+
+  it("ctrl-click toggles a selected row out, keeping the anchor if it survives", () => {
+    let s: Selection = { keys: ["a", "c", "e"], anchor: "e" };
+    s = clickSelection(order, s, "c", { toggle: true });
+    expect(s).toEqual({ keys: ["a", "e"], anchor: "e" });
+  });
+
+  it("ctrl-click toggling the anchor out re-homes it to the last selected row", () => {
+    let s: Selection = { keys: ["a", "c", "e"], anchor: "e" };
+    s = clickSelection(order, s, "e", { toggle: true });
+    expect(s).toEqual({ keys: ["a", "c"], anchor: "c" });
+  });
+
+  it("ctrl-click toggling the only row out empties the selection", () => {
+    const s = clickSelection(order, { keys: ["b"], anchor: "b" }, "b", {
+      toggle: true,
+    });
+    expect(s).toEqual({ keys: [], anchor: null });
+  });
+
+  it("shift-click selects the range from the anchor, forward", () => {
+    const start = clickSelection(order, emptySelection, "b");
+    const s = clickSelection(order, start, "d", { range: true });
+    expect(s).toEqual({ keys: ["b", "c", "d"], anchor: "b" });
+  });
+
+  it("shift-click selects the range from the anchor, backward", () => {
+    const start = clickSelection(order, emptySelection, "d");
+    const s = clickSelection(order, start, "a", { range: true });
+    expect(s).toEqual({ keys: ["a", "b", "c", "d"], anchor: "d" });
+  });
+
+  it("successive shift-clicks re-extend from the same anchor", () => {
+    let s = clickSelection(order, emptySelection, "c");
+    s = clickSelection(order, s, "e", { range: true });
+    expect(s.keys).toEqual(["c", "d", "e"]);
+    s = clickSelection(order, s, "a", { range: true });
+    expect(s).toEqual({ keys: ["a", "b", "c"], anchor: "c" });
+  });
+
+  it("shift-click without an anchor behaves like a plain click", () => {
+    const s = clickSelection(order, emptySelection, "c", { range: true });
+    expect(s).toEqual({ keys: ["c"], anchor: "c" });
+  });
+
+  it("shift-click with a vanished anchor degrades to plain click", () => {
+    const s = clickSelection(order, { keys: ["zz"], anchor: "zz" }, "b", {
+      range: true,
+    });
+    expect(s).toEqual({ keys: ["b"], anchor: "b" });
+  });
+
+  it("range wins when both modifiers are held", () => {
+    const start = clickSelection(order, emptySelection, "a");
+    const s = clickSelection(order, start, "c", { range: true, toggle: true });
+    expect(s.keys).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("pruneSelection", () => {
+  it("returns the same reference when nothing changed", () => {
+    const s: Selection = { keys: ["a", "b"], anchor: "a" };
+    expect(pruneSelection(s, new Set(order))).toBe(s);
+  });
+
+  it("drops keys that no longer exist", () => {
+    const s: Selection = { keys: ["a", "b", "c"], anchor: "a" };
+    expect(pruneSelection(s, new Set(["a", "c"]))).toEqual({
+      keys: ["a", "c"],
+      anchor: "a",
+    });
+  });
+
+  it("re-homes a vanished anchor to the last surviving key", () => {
+    const s: Selection = { keys: ["a", "b", "c"], anchor: "b" };
+    expect(pruneSelection(s, new Set(["a", "c"]))).toEqual({
+      keys: ["a", "c"],
+      anchor: "c",
+    });
+  });
+
+  it("empties out entirely when no keys survive", () => {
+    const s: Selection = { keys: ["a"], anchor: "a" };
+    expect(pruneSelection(s, new Set())).toEqual({ keys: [], anchor: null });
+  });
+});
+
+describe("primarySelectedKey", () => {
+  it("prefers the anchor while selected", () => {
+    expect(primarySelectedKey({ keys: ["a", "b"], anchor: "a" })).toBe("a");
+  });
+
+  it("falls back to the last selected key", () => {
+    expect(primarySelectedKey({ keys: ["a", "b"], anchor: "zz" })).toBe("b");
+  });
+
+  it("is null for an empty selection", () => {
+    expect(primarySelectedKey(emptySelection)).toBeNull();
+  });
+});

--- a/src/lib/selection.ts
+++ b/src/lib/selection.ts
@@ -1,0 +1,89 @@
+// Multi-select list semantics shared by the CommitPanel change lists and the
+// RepoBrowser file tree. Pure functions over row keys — components own the
+// state, this module owns the rules.
+//
+// Model (classic desktop list):
+// - plain click        → select exactly that row, anchor moves to it
+// - cmd/ctrl click     → toggle row in/out; toggling in moves the anchor,
+//                        toggling the anchor out re-homes it to the last
+//                        remaining selected row
+// - shift click        → replace selection with the contiguous range of
+//                        visible rows between the anchor and the clicked row;
+//                        the anchor stays put so successive shift-clicks
+//                        re-extend from the same origin
+
+export interface Selection {
+  /** Selected row keys, in click/range order, no duplicates. */
+  keys: string[];
+  /** Range origin: the last plain- or ctrl-selected row. */
+  anchor: string | null;
+}
+
+export const emptySelection: Selection = { keys: [], anchor: null };
+
+export interface ClickModifiers {
+  /** Cmd/Ctrl held — toggle the row. */
+  toggle?: boolean;
+  /** Shift held — extend a contiguous range from the anchor. */
+  range?: boolean;
+}
+
+/**
+ * Apply a click on `key` to the previous selection. `order` is the current
+ * visible row order (used for shift ranges). Range wins over toggle when both
+ * modifiers are held, matching Finder/Explorer behavior.
+ */
+export function clickSelection(
+  order: readonly string[],
+  prev: Selection,
+  key: string,
+  mods: ClickModifiers = {},
+): Selection {
+  if (mods.range) {
+    const anchor = prev.anchor ?? key;
+    const ai = order.indexOf(anchor);
+    const ki = order.indexOf(key);
+    if (ai < 0 || ki < 0) return { keys: [key], anchor: key };
+    const [lo, hi] = ai <= ki ? [ai, ki] : [ki, ai];
+    return { keys: order.slice(lo, hi + 1), anchor };
+  }
+  if (mods.toggle) {
+    if (prev.keys.includes(key)) {
+      const keys = prev.keys.filter((k) => k !== key);
+      const anchor =
+        prev.anchor === key ? (keys[keys.length - 1] ?? null) : prev.anchor;
+      return { keys, anchor };
+    }
+    return { keys: [...prev.keys, key], anchor: key };
+  }
+  return { keys: [key], anchor: key };
+}
+
+/**
+ * Drop keys that no longer exist (refresh, repo switch, files moving between
+ * lists). A vanished anchor falls back to the last surviving selected row.
+ * Returns `prev` by reference when nothing changed so callers can pass the
+ * result straight to setState without spurious re-renders.
+ */
+export function pruneSelection(
+  prev: Selection,
+  valid: ReadonlySet<string>,
+): Selection {
+  const keys = prev.keys.filter((k) => valid.has(k));
+  const anchorAlive = prev.anchor === null || valid.has(prev.anchor);
+  if (keys.length === prev.keys.length && anchorAlive) return prev;
+  const anchor =
+    prev.anchor !== null && valid.has(prev.anchor)
+      ? prev.anchor
+      : (keys[keys.length - 1] ?? null);
+  return { keys, anchor };
+}
+
+/**
+ * The row that drives the single-file preview pane: the anchor while it is
+ * still selected, otherwise the most recently selected row.
+ */
+export function primarySelectedKey(sel: Selection): string | null {
+  if (sel.anchor !== null && sel.keys.includes(sel.anchor)) return sel.anchor;
+  return sel.keys[sel.keys.length - 1] ?? null;
+}

--- a/src/screens/CommitPanel.test.tsx
+++ b/src/screens/CommitPanel.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+
+import { CommitPanelScreen } from "./CommitPanel";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+import type { FileStatus, RepoHandle } from "@/lib/types";
+
+const repo: RepoHandle = {
+  id: "repo-1",
+  path: "/tmp/fake-repo",
+  head: "refs/heads/main",
+};
+
+function modified(path: string): FileStatus {
+  return { path, worktree: { kind: "Modified" }, index: { kind: "Unmodified" } };
+}
+
+function stagedFile(path: string): FileStatus {
+  return { path, worktree: { kind: "Unmodified" }, index: { kind: "Modified" } };
+}
+
+const initialStatus = [
+  stagedFile("s.txt"),
+  modified("a.txt"),
+  modified("b.txt"),
+  modified("c.txt"),
+];
+
+function resetStore() {
+  useRepoStore.setState({
+    current: repo,
+    status: initialStatus,
+    allFiles: [],
+    branches: [],
+    tags: [],
+    stashes: [],
+    remotes: [],
+    commits: [],
+    loading: false,
+    error: null,
+    repoState: "Clean",
+    rebaseStatus: { inProgress: false, nextIndex: 0, total: 0, pauseReason: null },
+    activity: {},
+  });
+}
+
+function wireMocks() {
+  mockInvoke("get_diff", (args) => ({
+    path: args.path,
+    oldPath: null,
+    binary: false,
+    additions: 0,
+    deletions: 0,
+    hunks: [],
+  }));
+  mockInvoke("stage_paths", () => undefined);
+  mockInvoke("unstage_paths", () => undefined);
+  mockInvoke("discard_paths", () => undefined);
+  // refreshAll() after a mutation:
+  mockInvoke("get_status", () => initialStatus);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log", () => []);
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => ({
+    inProgress: false,
+    nextIndex: 0,
+    total: 0,
+    pauseReason: null,
+  }));
+}
+
+function changeRow(path: string): HTMLElement {
+  const row = screen
+    .getByTestId("changes-list")
+    .querySelector(`[data-path="${path}"]`);
+  if (!row) throw new Error(`no changes-list row for ${path}`);
+  return row as HTMLElement;
+}
+
+function selectedPaths(): string[] {
+  return Array.from(
+    screen
+      .getByTestId("changes-list")
+      .querySelectorAll('[data-selected="true"]'),
+  ).map((el) => el.getAttribute("data-path") ?? "");
+}
+
+describe("CommitPanel multi-file selection", () => {
+  beforeEach(() => {
+    resetStore();
+    wireMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("ctrl/cmd-click toggles rows in and out of the selection", async () => {
+    render(<CommitPanelScreen />);
+
+    fireEvent.click(changeRow("a.txt"));
+    expect(selectedPaths()).toEqual(["a.txt"]);
+
+    fireEvent.click(changeRow("c.txt"), { ctrlKey: true });
+    expect(selectedPaths()).toEqual(["a.txt", "c.txt"]);
+
+    // metaKey works too, and toggles back out
+    fireEvent.click(changeRow("c.txt"), { metaKey: true });
+    expect(selectedPaths()).toEqual(["a.txt"]);
+  });
+
+  it("shift-click extends a contiguous range from the anchor", async () => {
+    render(<CommitPanelScreen />);
+
+    fireEvent.click(changeRow("a.txt"));
+    fireEvent.click(changeRow("c.txt"), { shiftKey: true });
+    expect(selectedPaths()).toEqual(["a.txt", "b.txt", "c.txt"]);
+
+    // re-extend from the same anchor shrinks the range
+    fireEvent.click(changeRow("b.txt"), { shiftKey: true });
+    expect(selectedPaths()).toEqual(["a.txt", "b.txt"]);
+
+    // plain click collapses back to a single row
+    fireEvent.click(changeRow("b.txt"));
+    expect(selectedPaths()).toEqual(["b.txt"]);
+  });
+
+  it("stages the full selection via the multi-file context menu", async () => {
+    render(<CommitPanelScreen />);
+
+    fireEvent.click(changeRow("a.txt"));
+    fireEvent.click(changeRow("b.txt"), { ctrlKey: true });
+    fireEvent.contextMenu(changeRow("b.txt"));
+
+    fireEvent.click(await screen.findByText("Stage 2 files"));
+
+    await waitFor(() => {
+      const call = getInvokeCalls().find((c) => c.cmd === "stage_paths");
+      expect(call).toBeDefined();
+      expect(call!.args).toEqual({
+        repoId: "repo-1",
+        paths: ["a.txt", "b.txt"],
+      });
+    });
+  });
+
+  it("multi-file discard asks for confirmation and aborts when declined", async () => {
+    const confirm = vi
+      .spyOn(window, "confirm")
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    render(<CommitPanelScreen />);
+
+    fireEvent.click(changeRow("a.txt"));
+    fireEvent.click(changeRow("c.txt"), { shiftKey: true });
+
+    // declined → nothing dispatched
+    fireEvent.contextMenu(changeRow("b.txt"));
+    fireEvent.click(await screen.findByText("Discard changes in 3 files…"));
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(getInvokeCalls().find((c) => c.cmd === "discard_paths")).toBeUndefined();
+
+    // accepted → full path array
+    fireEvent.contextMenu(changeRow("b.txt"));
+    fireEvent.click(await screen.findByText("Discard changes in 3 files…"));
+    await waitFor(() => {
+      const call = getInvokeCalls().find((c) => c.cmd === "discard_paths");
+      expect(call).toBeDefined();
+      expect(call!.args).toEqual({
+        repoId: "repo-1",
+        paths: ["a.txt", "b.txt", "c.txt"],
+      });
+    });
+  });
+
+  it("right-click outside the selection collapses to the clicked row's single-file menu", async () => {
+    render(<CommitPanelScreen />);
+
+    fireEvent.click(changeRow("a.txt"));
+    fireEvent.click(changeRow("b.txt"), { ctrlKey: true });
+
+    fireEvent.contextMenu(changeRow("c.txt"));
+    // single-file menu, not the multi menu
+    expect(await screen.findByText("Stage")).toBeInTheDocument();
+    expect(screen.queryByText(/files selected/)).toBeNull();
+    expect(selectedPaths()).toEqual(["c.txt"]);
+  });
+
+  it("checkbox on a multi-selected row stages every selected file on that side", async () => {
+    render(<CommitPanelScreen />);
+
+    fireEvent.click(changeRow("a.txt"));
+    fireEvent.click(changeRow("b.txt"), { ctrlKey: true });
+
+    const toggle = changeRow("b.txt").querySelector(
+      '[data-testid="row-toggle"] input',
+    );
+    expect(toggle).not.toBeNull();
+    fireEvent.click(toggle!);
+
+    await waitFor(() => {
+      const call = getInvokeCalls().find((c) => c.cmd === "stage_paths");
+      expect(call).toBeDefined();
+      expect(call!.args).toEqual({
+        repoId: "repo-1",
+        paths: ["a.txt", "b.txt"],
+      });
+    });
+  });
+});

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -16,6 +16,7 @@ import {
   PGResizeHandle,
   PGTextarea,
   fileMenuItems,
+  multiFileMenuItems,
   pgFlash,
   useContextMenu,
   usePaneWidth,
@@ -26,6 +27,13 @@ import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { currentBranch, isStaged, isUnstaged, statusMark } from "@/lib/derive";
+import {
+  clickSelection,
+  emptySelection,
+  primarySelectedKey,
+  pruneSelection,
+  type Selection,
+} from "@/lib/selection";
 import { getDiff } from "@/lib/tauri";
 import type { CommitInfo, DiffKind, FileDiff, FileStatus } from "@/lib/types";
 
@@ -57,7 +65,7 @@ export function CommitPanelScreen() {
   // Sign-off toggle seeds from the persisted preference; toggling it writes back.
   const [signoff, setSignoff] = React.useState(addSignoff);
   const [diffMode, setDiffMode] = React.useState<"unified" | "split">("unified");
-  const [selectedKey, setSelectedKey] = React.useState<string | null>(null);
+  const [sel, setSel] = React.useState<Selection>(emptySelection);
   const changesPane = usePaneWidth(320, {
     min: 220,
     max: 720,
@@ -73,11 +81,15 @@ export function CommitPanelScreen() {
   const [diffError, setDiffError] = React.useState<string | null>(null);
 
   const { onContextMenu: onFileCtx, menu: fileMenu } = useContextMenu<FileSlot>(
-    (f) =>
-      fileMenuItems({
+    (f) => {
+      if (f && sel.keys.length > 1 && sel.keys.includes(keyOf(f))) {
+        return multiFileMenuItems(splitByKeys(sel.keys, staged, unstaged));
+      }
+      return fileMenuItems({
         path: f?.path,
         staged: f?.side === "staged",
-      }),
+      });
+    },
   );
 
   const moreMenu = useContextMenu<{ path: string; diff: FileDiff | null }>(
@@ -170,15 +182,64 @@ export function CommitPanelScreen() {
     [status],
   );
 
+  // Visible row order (staged block above changes block) — shift-click ranges
+  // extend over this order and may cross the staged/unstaged boundary.
+  const rowOrder = React.useMemo(
+    () => [...staged.map(keyOf), ...unstaged.map(keyOf)],
+    [staged, unstaged],
+  );
+  const selectedKeys = React.useMemo(() => new Set(sel.keys), [sel]);
+
+  // Selection is local state keyed by side:path — reset on repo switch and
+  // prune keys whose rows disappeared (refresh, stage/unstage moving files).
+  React.useEffect(() => {
+    setSel(emptySelection);
+  }, [repo?.id]);
+  React.useEffect(() => {
+    const valid = new Set(rowOrder);
+    setSel((s) => pruneSelection(s, valid));
+  }, [rowOrder]);
+
+  const onRowClick = (f: FileSlot) => (e: React.MouseEvent) => {
+    setSel((s) =>
+      clickSelection(rowOrder, s, keyOf(f), {
+        toggle: e.metaKey || e.ctrlKey,
+        range: e.shiftKey,
+      }),
+    );
+  };
+
+  // Right-click inside the multi-selection acts on it; outside collapses the
+  // selection to the clicked row first (standard desktop-list behavior).
+  const onRowContextMenu = (f: FileSlot) => (e: React.MouseEvent) => {
+    const key = keyOf(f);
+    if (!(sel.keys.length > 1 && sel.keys.includes(key))) {
+      setSel({ keys: [key], anchor: key });
+    }
+    onFileCtx(e, f);
+  };
+
+  // Checkbox on a row inside the multi-selection stages/unstages every
+  // selected row on that side; on an unselected row it stays single-file.
+  const togglePaths = (f: FileSlot): string[] => {
+    if (sel.keys.length > 1 && sel.keys.includes(keyOf(f))) {
+      const split = splitByKeys(sel.keys, staged, unstaged);
+      const paths = f.side === "staged" ? split.stagedPaths : split.unstagedPaths;
+      if (paths.length > 0) return paths;
+    }
+    return [f.path];
+  };
+
+  const primaryKey = primarySelectedKey(sel);
   const selected = React.useMemo(() => {
-    if (!selectedKey) return unstaged[0] ?? staged[0] ?? null;
+    if (!primaryKey) return unstaged[0] ?? staged[0] ?? null;
     return (
-      [...staged, ...unstaged].find((f) => keyOf(f) === selectedKey) ??
+      [...staged, ...unstaged].find((f) => keyOf(f) === primaryKey) ??
       unstaged[0] ??
       staged[0] ??
       null
     );
-  }, [selectedKey, staged, unstaged]);
+  }, [primaryKey, staged, unstaged]);
 
   React.useEffect(() => {
     if (!selected || !repo) {
@@ -279,10 +340,10 @@ export function CommitPanelScreen() {
               staged
               additions={countAdd(f.status)}
               deletions={countDel(f.status)}
-              selected={selectedKey === keyOf(f)}
-              onClick={() => setSelectedKey(keyOf(f))}
-              onContextMenu={(e) => onFileCtx(e, f)}
-              onToggle={() => unstage([f.path])}
+              selected={selectedKeys.has(keyOf(f))}
+              onClick={onRowClick(f)}
+              onContextMenu={onRowContextMenu(f)}
+              onToggle={() => unstage(togglePaths(f))}
             />
           ))}
         </div>
@@ -328,10 +389,10 @@ export function CommitPanelScreen() {
               staged={false}
               additions={countAdd(f.status)}
               deletions={countDel(f.status)}
-              selected={selectedKey === keyOf(f)}
-              onClick={() => setSelectedKey(keyOf(f))}
-              onContextMenu={(e) => onFileCtx(e, f)}
-              onToggle={() => stage([f.path])}
+              selected={selectedKeys.has(keyOf(f))}
+              onClick={onRowClick(f)}
+              onContextMenu={onRowContextMenu(f)}
+              onToggle={() => stage(togglePaths(f))}
             />
           ))}
         </div>
@@ -660,6 +721,19 @@ export function CommitPanelScreen() {
 
 function keyOf(f: FileSlot): string {
   return `${f.side}:${f.path}`;
+}
+
+/** Split the selected row keys into staged/unstaged path arrays for multi-file ops. */
+function splitByKeys(
+  keys: string[],
+  staged: FileSlot[],
+  unstaged: FileSlot[],
+): { stagedPaths: string[]; unstagedPaths: string[] } {
+  const set = new Set(keys);
+  return {
+    stagedPaths: staged.filter((f) => set.has(keyOf(f))).map((f) => f.path),
+    unstagedPaths: unstaged.filter((f) => set.has(keyOf(f))).map((f) => f.path),
+  };
 }
 
 function buildMessage(subject: string, body: string): string {

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -16,6 +16,9 @@ import {
   PGStatusMark,
   PGToolbar,
   KV,
+  fileMenuItems,
+  flattenFileTree,
+  multiFileMenuItems,
   useContextMenu,
   usePaneWidth,
   type ContextMenuItem,
@@ -27,9 +30,18 @@ import { useNavStore } from "@/features/nav/useNavStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import {
   currentBranch,
+  isStaged,
+  isUnstaged,
   relativeTime,
   statusMark,
 } from "@/lib/derive";
+import {
+  clickSelection,
+  emptySelection,
+  primarySelectedKey,
+  pruneSelection,
+  type Selection,
+} from "@/lib/selection";
 import { highlightFile } from "@/lib/highlight";
 import { getDiff, readFileContent } from "@/lib/tauri";
 import { buildStatusTree } from "@/lib/tree";
@@ -90,7 +102,7 @@ export function RepoBrowserScreen() {
   const diffContextLines = useSettingsStore((s) => s.diffContextLines);
 
   const [expanded, setExpanded] = React.useState<Record<string, boolean>>({});
-  const [selected, setSelected] = React.useState<string | null>(null);
+  const [sel, setSel] = React.useState<Selection>(emptySelection);
   const [diff, setDiff] = React.useState<FileDiff | null>(null);
   const [diffLoading, setDiffLoading] = React.useState(false);
   const [fileContent, setFileContent] = React.useState<FileContent | null>(null);
@@ -126,7 +138,7 @@ export function RepoBrowserScreen() {
   // spurious InvalidRef. Working tree (null) is the default.
   React.useEffect(() => {
     setRev(null);
-    setSelected(null);
+    setSel(emptySelection);
   }, [repo?.id]);
 
   // Refresh the full file list each time the user picks "All" so the tree
@@ -187,6 +199,75 @@ export function RepoBrowserScreen() {
     const t = buildStatusTree(filteredStatus);
     return sortMode === "desc" ? reverseTree(t) : t;
   }, [filteredStatus, sortMode]);
+
+  // Visible row order (folders included) for shift-click ranges; selection
+  // keys are PGFileTree keys of the form "/a/b/c".
+  const rowOrder = React.useMemo(
+    () => flattenFileTree(tree, expanded).map((f) => f.key),
+    [tree, expanded],
+  );
+  const selectedKeys = React.useMemo(() => new Set(sel.keys), [sel]);
+  const selected = primarySelectedKey(sel);
+
+  // Prune selection when rows disappear (filter/rev/sort change, refresh).
+  // Validity is against the full tree, not just visible rows — collapsing a
+  // folder hides rows without deselecting them.
+  React.useEffect(() => {
+    setSel((s) => pruneSelection(s, new Set(flattenAllKeys(tree))));
+  }, [tree]);
+
+  const onTreeSelect = React.useCallback(
+    (key: string, _node: PGFileTreeNode, e?: React.MouseEvent) => {
+      setSel((s) =>
+        clickSelection(rowOrder, s, key, {
+          toggle: !!e && (e.metaKey || e.ctrlKey),
+          range: !!e?.shiftKey,
+        }),
+      );
+    },
+    [rowOrder],
+  );
+
+  // Map selected tree keys to worktree statuses for multi-file operations.
+  // Folder keys simply don't resolve to a status entry, so they're inert.
+  const splitSelection = React.useCallback(
+    (keys: string[]): { stagedPaths: string[]; unstagedPaths: string[] } => {
+      const stagedPaths: string[] = [];
+      const unstagedPaths: string[] = [];
+      for (const key of keys) {
+        const path = key.replace(/^\//, "");
+        const st = status.find((s) => s.path === path);
+        if (!st) continue;
+        if (isStaged(st)) stagedPaths.push(path);
+        if (isUnstaged(st)) unstagedPaths.push(path);
+      }
+      return { stagedPaths, unstagedPaths };
+    },
+    [status],
+  );
+
+  const fileCtx = useContextMenu<{ key: string; node: PGFileTreeNode }>(
+    ({ key, node }) => {
+      if (sel.keys.length > 1 && sel.keys.includes(key)) {
+        return multiFileMenuItems(splitSelection(sel.keys));
+      }
+      if (node.children?.length) return [];
+      const path = key.replace(/^\//, "");
+      const st = status.find((s) => s.path === path);
+      return fileMenuItems({ path, staged: !!st && isStaged(st) && !isUnstaged(st) });
+    },
+  );
+
+  const onTreeContextMenu = React.useCallback(
+    (e: React.MouseEvent, key: string, node: PGFileTreeNode) => {
+      if (browsingRev) return; // committed snapshot — no worktree to act on
+      if (!(sel.keys.length > 1 && sel.keys.includes(key))) {
+        setSel({ keys: [key], anchor: key });
+      }
+      fileCtx.onContextMenu(e, { key, node });
+    },
+    [browsingRev, sel, fileCtx],
+  );
 
   const conflictCount = React.useMemo(
     () =>
@@ -337,7 +418,7 @@ export function RepoBrowserScreen() {
               rev={rev}
               onChange={(r) => {
                 setRev(r);
-                setSelected(null);
+                setSel(emptySelection);
               }}
               branches={branches}
               tags={tags}
@@ -385,9 +466,12 @@ export function RepoBrowserScreen() {
                 setExpanded((e) => ({ ...e, [k]: !e[k] }))
               }
               selected={selected ?? undefined}
-              onSelect={(k) => setSelected(k)}
-              onActivate={(k) => setSelected(k)}
+              selectedKeys={selectedKeys}
+              onSelect={onTreeSelect}
+              onActivate={(k, n) => onTreeSelect(k, n)}
+              onRowContextMenu={onTreeContextMenu}
             />
+            {fileCtx.menu}
           </div>
         </div>
         <PGResizeHandle onDrag={treePane.resize} />
@@ -782,6 +866,20 @@ function isHidden(s: FileStatus, hidden: Set<HideKind>): boolean {
     if (sides.some((x) => x.kind === k)) return true;
   }
   return false;
+}
+
+/** Every key in the tree regardless of expansion — collapsed rows stay selected. */
+function flattenAllKeys(nodes: PGFileTreeNode[]): string[] {
+  const out: string[] = [];
+  const walk = (list: PGFileTreeNode[], parentKey: string) => {
+    for (const n of list) {
+      const key = parentKey + "/" + n.name;
+      out.push(key);
+      if (n.children) walk(n.children, key);
+    }
+  };
+  walk(nodes, "");
+  return out;
 }
 
 function reverseTree(nodes: PGFileTreeNode[]): PGFileTreeNode[] {


### PR DESCRIPTION
## Summary

Multi-file selection (issue #25, item 4): Cmd/Ctrl-click toggles a row in/out of the selection, Shift-click extends a contiguous range from the anchor (last plain-clicked row), plain click keeps the existing single-select behavior. Applies to the CommitPanel STAGED/CHANGES lists and the RepoBrowser file tree.

- **Selection semantics** extracted to a pure, tested helper (`src/lib/selection.ts`): `clickSelection` / `pruneSelection` / `primarySelectedKey`. Selection state stays local component state per existing patterns; it resets on repo switch and prunes itself when rows disappear (refresh, files moving between lists, filter/rev changes).
- **Multi-file operations** wire into the existing path-array IPC (`stage_paths` / `unstage_paths` / `discard_paths` — no backend changes): toggling a checkbox on a row inside the selection stages/unstages every selected row on that side, and a new `multiFileMenuItems` context menu offers Stage/Unstage N files (mixed selections act on their own subsets), Copy paths, and Discard — gated by the existing confirm/danger flow.
- **RepoBrowser** file tree gains a context menu (single-file menu for one row, multi menu for a selection; suppressed while browsing a committed revision).
- **Design-system threading** per convention: `PGChangeRow`/`PGFileTreeRow` `onClick` now passes the mouse event, rows expose `data-selected`, `PGFileTree` grows `selectedKeys`/`onRowContextMenu`, and `flattenFileTree` is exported for visible-row-order ranges.
- The anchor row keeps driving the single-file diff/preview pane, so single-selection behavior is unchanged (existing e2e flows unaffected).

Spec: `docs/superpowers/specs/2026-07-03-multi-file-select-design.md`
Plan: `docs/superpowers/plans/2026-07-03-multi-file-select.md`

## E2E hardening (flakes surfaced on this PR's CI, both pre-existing)

Two intermittent e2e-linux failures were investigated; neither is caused by this change (the History screen mounts none of the touched components, and the `context-menu.tsx` diff is purely additive — no render-path edits):

- **history-ops `menu item not found: Soft (keep changes staged)`** — portal menus/submenus commit one or two React renders *after* the in-page script that triggers them returns, so the single-shot `jsClickMenuItem`/`jsHoverMenuItem` lookups raced the render under xvfb load. Both helpers now do a read-only wait-for-item poll before acting (side-effectful part stays `executeOnce`-guarded per #35 rules).
- **merge-conflict `mark-resolved` TOCTOU (issue #35)** — `isExisting()` sees the button, the post-accept refresh unmounts it, `click()` re-finds nothing. The conditional clicks are now wrapped in a catch: the button vanishing IS the resolved state; the finalize wait + repo-truth asserts remain the gates.

## Testing

- `pnpm tsc --noEmit` clean; `pnpm exec tsc -p e2e/tsconfig.json --noEmit` clean.
- `pnpm test`: 124 passed (24 new — 18 pure selection tests, 6 CommitPanel component tests covering ctrl-toggle, shift-range, multi-stage via context menu, confirm-gated multi-discard, selection collapse on outside right-click, multi checkbox toggle).
- E2E on CI (port 4445 owned by a parallel session locally).

refs #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)