### PR TITLE
fix(e2e): self-heal macOS focus loss so local runs stop flaking

### DIFF
--- a/.claude/skills/e2e-testing/SKILL.md
+++ b/.claude/skills/e2e-testing/SKILL.md
@@ -31,6 +31,12 @@ Two conf-level guards eliminate the historical "suite suddenly takes minutes" fl
 
 **Flake bands:** healthy full suite ≈ 30s–1.5min. Sustained runs >2.5min, or single commands taking 5–30s, mean a guard above was lost or a new refresh site skipped the settle-gate pattern — check conf + the newest refresh site, not the specs.
 
+## Focus self-heal (macOS — `ensureMacAppFocus`, don't remove)
+
+The unbundled debug binary doesn't reliably win foreground focus at launch. An unfocused/occluded WKWebView reports the page hidden (`visibilityState: "hidden"`, `hasFocus() === false`), and `isDisplayed()` then returns false for elements that ARE in the DOM — every `waitForDisplayed` dies with "... never appeared" (issue #32). The service's own self-heal can't fire: it invokes `plugin:wdio|get_window_states`, which `tauri-plugin-wdio-webdriver` 1.2.0 (latest as of 2026-07; pair pinned service+plugin) does not ship — and guard 1 above disables the check anyway.
+
+Fix in tree: `ensureMacAppFocus()` (`e2e/support/app.ts`) — if the page reports hidden/unfocused, calls the window's own `setFocus()` via the global Tauri API (tao: `makeKeyAndOrderFront` + `activateIgnoringOtherApps` — wins focus from any app, no osascript/TCC prompt) and retries until the page reports visible+focused. Runs in wdio.conf `before` (session start) and `beforeTest` (heals mid-suite steals; one cheap execute when already focused). Needs `core:window:allow-set-focus`, granted ONLY by the e2e inline capability in `src-tauri/tauri.e2e.conf.json` — prod capability set untouched. No-op off macOS; Linux CI (xvfb) never loses focus. If a future service+plugin release ships `get_window_states`, the upstream self-heal still stays disabled by guard 1 — keep `ensureMacAppFocus` regardless.
+
 ## Selectors
 
 | Need | Use | Never |
@@ -85,10 +91,12 @@ Fixtures live in `e2e/support/tempRepo.ts` (`basicRepo`, `dirtyRepo`, `branchyRe
 3. Suite slow? → flake bands above (bridge), not the spec.
 4. Selector fights >20min → capture outerHTML evidence, then fix or escalate; never fake a flow by shelling `git` for the action under test.
 5. "X never appeared" while the DOM provably contains X (dump outerHTML to
-   check) → focus race: another app holds foreground, WKWebView reports
-   `visibilityState: "hidden"`, and `isDisplayed()` lies. Minimize/quit
-   focus-stealing apps (e.g. Remote Desktop) and rerun; see issue on local
-   focus flake. CI (xvfb) is immune.
+   check) → focus race: WKWebView reports `visibilityState: "hidden"` and
+   `isDisplayed()` lies. `ensureMacAppFocus` (see focus self-heal section)
+   should heal this at session start and before each test — if it still
+   happens, check that the `before`/`beforeTest` hooks and the `e2e-focus`
+   capability (`src-tauri/tauri.e2e.conf.json`) are intact, and that the
+   binary was rebuilt after any capability change. CI (xvfb) is immune.
 
 ## Before committing
 

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -60,6 +60,61 @@ export async function armDriverBridge(): Promise<void> {
   );
 }
 
+/** macOS focus self-heal (issue #32).
+ *
+ * The e2e debug binary is unbundled and doesn't reliably win foreground
+ * focus at launch. When another app (e.g. Remote Desktop) holds foreground,
+ * WKWebView reports `document.visibilityState === "hidden"` /
+ * `document.hasFocus() === false`, and WebDriver's isDisplayed() returns
+ * false for elements that exist in the DOM — waits then die with "... never
+ * appeared". @wdio/tauri-service's own self-heal (ensureActiveWindowFocus)
+ * can't help: it invokes `plugin:wdio|get_window_states`, which
+ * tauri-plugin-wdio-webdriver 1.2.0 (latest as of 2026-07) does not ship —
+ * and our wdio.conf disables that check anyway (see guard 1 there).
+ *
+ * So we self-heal here: if the page reports unfocused/hidden, call the
+ * window's own `setFocus()` through the global Tauri API. On macOS that is
+ * tao's `makeKeyAndOrderFront` + `activateIgnoringOtherApps:YES` — forces
+ * activation over whatever app holds foreground, no Automation/TCC prompt
+ * (unlike osascript). Requires `core:window:allow-set-focus`, granted by the
+ * e2e-only inline capability in src-tauri/tauri.e2e.conf.json.
+ *
+ * No-op off macOS: Linux CI (xvfb) never loses focus and must not be
+ * touched. Cheap when already focused (one execute, no setFocus call), so
+ * it runs at session start AND before every test (wdio.conf hooks) to heal
+ * mid-suite focus steals too. Call sites assume an armed, settled page —
+ * don't call it mid-refresh. */
+export async function ensureMacAppFocus(): Promise<void> {
+  if (process.platform !== "darwin") return;
+  await browser.waitUntil(
+    () =>
+      browser.execute(() => {
+        const focused =
+          document.visibilityState === "visible" && document.hasFocus();
+        if (!focused) {
+          const w = window as unknown as Record<string, any>;
+          // Fire-and-forget: focus lands asynchronously (main-thread hop in
+          // tao); the next poll observes it. Swallow rejection so a missing
+          // permission surfaces as this wait's timeoutMsg, not an unhandled
+          // rejection in the page.
+          w.__TAURI__?.window
+            ?.getCurrentWindow?.()
+            ?.setFocus?.()
+            ?.catch?.(() => {});
+        }
+        return focused;
+      }),
+    {
+      timeout: 15_000,
+      interval: 250,
+      timeoutMsg:
+        "webview never reported visible+focused after setFocus() retries — " +
+        "is core:window:allow-set-focus granted (src-tauri/tauri.e2e.conf.json " +
+        "e2e-focus capability), and was the binary rebuilt with that config?",
+    },
+  );
+}
+
 export async function resetApp(): Promise<void> {
   await browser.execute(() => localStorage.clear());
   await browser.refresh();

--- a/e2e/wdio.conf.ts
+++ b/e2e/wdio.conf.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import type { TauriCapabilities } from "@wdio/tauri-service";
 import { $, browser } from "@wdio/globals";
-import { armDriverBridge } from "./support/app";
+import { armDriverBridge, ensureMacAppFocus } from "./support/app";
 
 // Snapshot copied by `pnpm test:e2e` after building with
 // `--features tauri/custom-protocol` (which embeds the frontend assets).
@@ -59,6 +59,15 @@ export const config: WebdriverIO.Config = {
     if (process.platform === "darwin") {
       await browser.setTimeout({ script: 2500 });
     }
+    // macOS only (no-op elsewhere): the unbundled debug binary doesn't
+    // reliably win foreground focus at launch, and an unfocused/occluded
+    // WKWebView reports the page hidden — isDisplayed() then returns false
+    // for elements that ARE in the DOM and every waitForDisplayed dies with
+    // "... never appeared" (issue #32). The service's own self-heal is a
+    // silent no-op (its plugin lacks get_window_states, and guard 1 above
+    // disables it regardless), so force activation ourselves and assert the
+    // page actually reports visible+focused before any spec runs.
+    await ensureMacAppFocus();
     // On a fresh session the webview may still be booting; openRepo() starts
     // with a browser.refresh(), which must not fire mid-boot. Wait for the
     // Welcome screen once here so every repo-opening spec is safe from the
@@ -68,14 +77,24 @@ export const config: WebdriverIO.Config = {
       timeoutMsg: "app never rendered Welcome screen",
     });
   },
+  // Heal mid-suite focus steals (another app grabbing foreground between
+  // tests): one cheap execute per test when already focused, setFocus retry
+  // loop only when the page reports hidden/unfocused. macOS only — no-op on
+  // Linux CI.
+  beforeTest: async () => {
+    await ensureMacAppFocus();
+  },
   framework: "mocha",
   mochaOpts: { ui: "bdd", timeout: 120_000 },
   waitforTimeout: 15_000,
   connectionRetryTimeout: 60_000,
   // Silence @wdio/tauri-service WARN spam: its per-command focus check invokes
-  // `plugin:wdio|get_window_states`, a companion Rust plugin this app doesn't
-  // register (single window — nothing to focus-manage), so every find/click
-  // logs "Plugin not found". The service pins its own @wdio/logger@9.18.0 — a
+  // `plugin:wdio|get_window_states`, a command tauri-plugin-wdio-webdriver
+  // 1.2.0 does not ship (checked: string absent from the crate source), so
+  // any find/click that reaches it logs "Command not found" — that missing
+  // command is also why the service's focus self-heal silently no-ops (issue
+  // #32; ensureMacAppFocus fills the gap). The service pins its own
+  // @wdio/logger@9.18.0 — a
   // separate module instance from the runner's — so a `logLevels`
   // per-scope entry never reaches it. What DOES reach it is WDIO_LOG_LEVEL,
   // seeded from `logLevel` before services load. So: default everything to

--- a/src-tauri/tauri.e2e.conf.json
+++ b/src-tauri/tauri.e2e.conf.json
@@ -1,5 +1,16 @@
 {
   "app": {
-    "withGlobalTauri": true
+    "withGlobalTauri": true,
+    "security": {
+      "capabilities": [
+        "default",
+        {
+          "identifier": "e2e-focus",
+          "description": "E2E-only: let the wdio harness force window focus (ensureMacAppFocus in e2e/support/app.ts). The unbundled debug binary doesn't reliably win foreground focus at launch; without focus WKWebView reports the page hidden and isDisplayed() lies.",
+          "windows": ["main"],
+          "permissions": ["core:window:allow-set-focus"]
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary

Local e2e runs flaked whenever another app (e.g. Remote Desktop) held foreground focus: the unbundled debug binary doesn't reliably win focus at launch, WKWebView then reports the page hidden (`visibilityState: "hidden"`, `hasFocus() === false`), and WebDriver's `isDisplayed()` returns false for elements that exist in the DOM — waits die with "... never appeared".

**Upgrade path evaluated first, none exists:** `@wdio/tauri-service` 1.2.0 and `tauri-plugin-wdio-webdriver` 1.2.0 are both the latest releases (npm dist-tag `latest` / crates.io). The service's built-in self-heal (`ensureActiveWindowFocus`) invokes `plugin:wdio|get_window_states`, and that string is absent from the entire 1.2.0 crate source — so it silently no-ops. The `@wdio/native-utils@2.5.0` override therefore stays (still pinning around `@wdio/tauri-service@1.2.0`'s broken dep pin).

**Mitigation shipped instead:**
- `ensureMacAppFocus()` (`e2e/support/app.ts`): when the page reports hidden/unfocused, calls the window's own `setFocus()` via the global Tauri API and retries until the page reports visible+focused. On macOS that is tao's `makeKeyAndOrderFront` + `activateIgnoringOtherApps:YES` — wins focus from any foreground app, no osascript/Automation-TCC prompt.
- Wired into wdio.conf `before` (session-start focus assert with retry) and `beforeTest` (heals mid-suite focus steals; one cheap execute when already focused).
- `core:window:allow-set-focus` granted only by an inline `e2e-focus` capability in `src-tauri/tauri.e2e.conf.json` — production capability set untouched.
- macOS-gated: no-op elsewhere, Linux CI (xvfb) unaffected.
- SKILL.md focus/flake sections updated to point at the self-heal instead of "minimize other apps".

Verified at runtime that the permission actually resolves in the e2e binary (temporary probe spec: `setFocus()` resolves, page reports visible+focused; probe removed before commit).

## Test plan

- [x] `pnpm exec tsc -p e2e/tsconfig.json --noEmit`
- [x] `pnpm tsc --noEmit`
- [x] Full `pnpm test:e2e` (fresh debug build + suite): 13/13 spec files, **46 passing, 1 skipped** (pending #27) in 38s — matches main's baseline
- [x] Second `pnpm test:e2e:run` pass: same result in 40s

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)