### PR TITLE
fix(settings): wire or remove dead settings; fail fast on auth prompts

### DIFF
--- a/src-tauri/src/commands/branches.rs
+++ b/src-tauri/src/commands/branches.rs
@@ -116,6 +116,11 @@ async fn get_repo_path(state: &AppState, repo_id: &RepoId) -> AppResult<std::pat
 }
 
 /// Run a git subprocess and map non-zero exit to `AppError::Network`.
+///
+/// Credential prompts are disabled (`GIT_TERMINAL_PROMPT=0` plus a no-op
+/// askpass): a subprocess has no terminal, so an auth-requiring remote would
+/// otherwise hang forever on an invisible prompt. With prompts off, git fails
+/// fast and the error surfaces through the normal `AppError::Network` path.
 async fn run_git(
     cwd: &std::path::Path,
     args: &[&str],
@@ -124,6 +129,9 @@ async fn run_git(
         .arg("-C")
         .arg(cwd)
         .args(args)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_ASKPASS", "true")
+        .env("SSH_ASKPASS", "true")
         .output()
         .await
         .map_err(|e| AppError::Io(e.to_string()))?;
@@ -135,23 +143,38 @@ async fn run_git(
     Ok(())
 }
 
+/// Build the argument list for `git fetch`. `remote = None` means all remotes.
+fn fetch_args(remote: Option<&str>, prune: bool) -> Vec<&str> {
+    let mut args = vec!["fetch"];
+    match remote {
+        Some(r) => args.push(r),
+        None => args.push("--all"),
+    }
+    if prune {
+        args.push("--prune");
+    }
+    args
+}
+
 #[tauri::command]
 pub async fn fetch(
     state: State<'_, AppState>,
     repo_id: String,
     remote: String,
+    prune: bool,
 ) -> AppResult<()> {
     let path = get_repo_path(&state, &RepoId(repo_id)).await?;
-    run_git(&path, &["fetch", remote.as_str(), "--prune"]).await
+    run_git(&path, &fetch_args(Some(remote.as_str()), prune)).await
 }
 
 #[tauri::command]
 pub async fn fetch_all(
     state: State<'_, AppState>,
     repo_id: String,
+    prune: bool,
 ) -> AppResult<()> {
     let path = get_repo_path(&state, &RepoId(repo_id)).await?;
-    run_git(&path, &["fetch", "--all", "--prune"]).await
+    run_git(&path, &fetch_args(None, prune)).await
 }
 
 #[tauri::command]
@@ -344,4 +367,21 @@ pub async fn push_delete_branch(
 ) -> AppResult<()> {
     let path = get_repo_path(&state, &RepoId(repo_id)).await?;
     run_git(&path, &["push", "--delete", remote.as_str(), name.as_str()]).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fetch_args;
+
+    #[test]
+    fn fetch_args_with_prune() {
+        assert_eq!(fetch_args(Some("origin"), true), ["fetch", "origin", "--prune"]);
+        assert_eq!(fetch_args(None, true), ["fetch", "--all", "--prune"]);
+    }
+
+    #[test]
+    fn fetch_args_without_prune() {
+        assert_eq!(fetch_args(Some("origin"), false), ["fetch", "origin"]);
+        assert_eq!(fetch_args(None, false), ["fetch", "--all"]);
+    }
 }

--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -14,13 +14,16 @@ pub async fn stage_hunk(
     repo_id: String,
     path: String,
     hunk_index: usize,
+    context_lines: u32,
 ) -> AppResult<()> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
     let path = PathBuf::from(path);
-    tokio::task::spawn_blocking(move || backend.stage_hunk(&repo_id, &path, hunk_index))
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+    tokio::task::spawn_blocking(move || {
+        backend.stage_hunk(&repo_id, &path, hunk_index, context_lines)
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
 #[tauri::command]
@@ -29,13 +32,16 @@ pub async fn unstage_hunk(
     repo_id: String,
     path: String,
     hunk_index: usize,
+    context_lines: u32,
 ) -> AppResult<()> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
     let path = PathBuf::from(path);
-    tokio::task::spawn_blocking(move || backend.unstage_hunk(&repo_id, &path, hunk_index))
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+    tokio::task::spawn_blocking(move || {
+        backend.unstage_hunk(&repo_id, &path, hunk_index, context_lines)
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
 #[tauri::command]
@@ -44,13 +50,16 @@ pub async fn discard_hunk(
     repo_id: String,
     path: String,
     hunk_index: usize,
+    context_lines: u32,
 ) -> AppResult<()> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
     let path = PathBuf::from(path);
-    tokio::task::spawn_blocking(move || backend.discard_hunk(&repo_id, &path, hunk_index))
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+    tokio::task::spawn_blocking(move || {
+        backend.discard_hunk(&repo_id, &path, hunk_index, context_lines)
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
 #[tauri::command]
@@ -59,11 +68,12 @@ pub async fn get_diff(
     repo_id: String,
     path: String,
     kind: DiffKind,
+    context_lines: u32,
 ) -> AppResult<FileDiff> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
     let path = PathBuf::from(path);
-    tokio::task::spawn_blocking(move || backend.diff(&repo_id, &path, kind))
+    tokio::task::spawn_blocking(move || backend.diff(&repo_id, &path, kind, context_lines))
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
 }
@@ -116,12 +126,15 @@ pub async fn diff_commits(
     repo_id: String,
     from_oid: String,
     to_oid: String,
+    context_lines: u32,
 ) -> AppResult<Vec<FileDiff>> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
-    tokio::task::spawn_blocking(move || backend.diff_commits(&repo_id, &from_oid, &to_oid))
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+    tokio::task::spawn_blocking(move || {
+        backend.diff_commits(&repo_id, &from_oid, &to_oid, context_lines)
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
 #[tauri::command]

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -59,7 +59,13 @@ impl GitBackend for CliBackend {
     ) -> AppResult<Vec<CommitInfo>> {
         Err(AppError::NotImplemented)
     }
-    fn diff(&self, _repo_id: &RepoId, _path: &Path, _kind: DiffKind) -> AppResult<FileDiff> {
+    fn diff(
+        &self,
+        _repo_id: &RepoId,
+        _path: &Path,
+        _kind: DiffKind,
+        _context_lines: u32,
+    ) -> AppResult<FileDiff> {
         Err(AppError::NotImplemented)
     }
     fn read_file_content(&self, _repo_id: &RepoId, _path: &Path) -> AppResult<FileContent> {
@@ -81,6 +87,7 @@ impl GitBackend for CliBackend {
         _repo_id: &RepoId,
         _from_oid: &str,
         _to_oid: &str,
+        _context_lines: u32,
     ) -> AppResult<Vec<FileDiff>> {
         Err(AppError::NotImplemented)
     }
@@ -93,13 +100,31 @@ impl GitBackend for CliBackend {
     fn discard(&self, _repo_id: &RepoId, _paths: &[PathBuf]) -> AppResult<()> {
         Err(AppError::NotImplemented)
     }
-    fn stage_hunk(&self, _repo_id: &RepoId, _path: &Path, _hunk_index: usize) -> AppResult<()> {
+    fn stage_hunk(
+        &self,
+        _repo_id: &RepoId,
+        _path: &Path,
+        _hunk_index: usize,
+        _context_lines: u32,
+    ) -> AppResult<()> {
         Err(AppError::NotImplemented)
     }
-    fn unstage_hunk(&self, _repo_id: &RepoId, _path: &Path, _hunk_index: usize) -> AppResult<()> {
+    fn unstage_hunk(
+        &self,
+        _repo_id: &RepoId,
+        _path: &Path,
+        _hunk_index: usize,
+        _context_lines: u32,
+    ) -> AppResult<()> {
         Err(AppError::NotImplemented)
     }
-    fn discard_hunk(&self, _repo_id: &RepoId, _path: &Path, _hunk_index: usize) -> AppResult<()> {
+    fn discard_hunk(
+        &self,
+        _repo_id: &RepoId,
+        _path: &Path,
+        _hunk_index: usize,
+        _context_lines: u32,
+    ) -> AppResult<()> {
         Err(AppError::NotImplemented)
     }
     fn commit(&self, _repo_id: &RepoId, _opts: CommitOptions) -> AppResult<String> {

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -869,11 +869,17 @@ impl GitBackend for Libgit2Backend {
         })
     }
 
-    fn diff(&self, repo_id: &RepoId, path: &Path, kind: DiffKind) -> AppResult<FileDiff> {
+    fn diff(
+        &self,
+        repo_id: &RepoId,
+        path: &Path,
+        kind: DiffKind,
+        context_lines: u32,
+    ) -> AppResult<FileDiff> {
         self.with_repo(repo_id, |repo| {
             let mut opts = DiffOptions::new();
             opts.pathspec(path);
-            opts.context_lines(3);
+            opts.context_lines(context_lines);
             // Include untracked files as if their full content were a new addition
             // so the diff viewer shows file contents for newly created files.
             if matches!(kind, DiffKind::WorktreeToIndex | DiffKind::WorktreeToHead) {
@@ -1175,6 +1181,7 @@ impl GitBackend for Libgit2Backend {
         repo_id: &RepoId,
         from_oid: &str,
         to_oid: &str,
+        context_lines: u32,
     ) -> AppResult<Vec<FileDiff>> {
         self.with_repo(repo_id, |repo| {
             let from = repo.revparse_single(from_oid)?.peel_to_commit()?.id();
@@ -1183,7 +1190,7 @@ impl GitBackend for Libgit2Backend {
             let to_tree = repo.find_commit(to)?.tree()?;
 
             let mut opts = DiffOptions::new();
-            opts.context_lines(3);
+            opts.context_lines(context_lines);
             let mut diff =
                 repo.diff_tree_to_tree(Some(&from_tree), Some(&to_tree), Some(&mut opts))?;
 
@@ -1337,11 +1344,17 @@ impl GitBackend for Libgit2Backend {
         })
     }
 
-    fn stage_hunk(&self, repo_id: &RepoId, path: &Path, hunk_index: usize) -> AppResult<()> {
+    fn stage_hunk(
+        &self,
+        repo_id: &RepoId,
+        path: &Path,
+        hunk_index: usize,
+        context_lines: u32,
+    ) -> AppResult<()> {
         self.with_repo(repo_id, |repo| {
             let mut opts = DiffOptions::new();
             opts.pathspec(path);
-            opts.context_lines(3);
+            opts.context_lines(context_lines);
             let diff = repo.diff_index_to_workdir(None, Some(&mut opts))?;
 
             // Find delta for path, then count hunks via Patch.
@@ -1377,12 +1390,18 @@ impl GitBackend for Libgit2Backend {
         })
     }
 
-    fn unstage_hunk(&self, repo_id: &RepoId, path: &Path, hunk_index: usize) -> AppResult<()> {
+    fn unstage_hunk(
+        &self,
+        repo_id: &RepoId,
+        path: &Path,
+        hunk_index: usize,
+        context_lines: u32,
+    ) -> AppResult<()> {
         // Build patch text from the IndexToHead diff, then `git apply --cached --reverse`.
         let patch_text = self.with_repo(repo_id, |repo| {
             let mut opts = DiffOptions::new();
             opts.pathspec(path);
-            opts.context_lines(3);
+            opts.context_lines(context_lines);
             let head_tree = match repo.head() {
                 Ok(h) => Some(h.peel_to_tree()?),
                 Err(e) if e.code() == git2::ErrorCode::UnbornBranch => None,
@@ -1397,12 +1416,18 @@ impl GitBackend for Libgit2Backend {
         git_apply(&repo_path, &["--cached", "--reverse"], &patch_text)
     }
 
-    fn discard_hunk(&self, repo_id: &RepoId, path: &Path, hunk_index: usize) -> AppResult<()> {
+    fn discard_hunk(
+        &self,
+        repo_id: &RepoId,
+        path: &Path,
+        hunk_index: usize,
+        context_lines: u32,
+    ) -> AppResult<()> {
         // Build patch text from the WorktreeToIndex diff, then `git apply --reverse`.
         let patch_text = self.with_repo(repo_id, |repo| {
             let mut opts = DiffOptions::new();
             opts.pathspec(path);
-            opts.context_lines(3);
+            opts.context_lines(context_lines);
             let diff = repo.diff_index_to_workdir(None, Some(&mut opts))?;
             let delta_index = find_delta_index(&diff, path)?;
             patch_text_for_hunk(&diff, delta_index, hunk_index)

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -44,7 +44,15 @@ pub trait GitBackend: Send + Sync {
     ) -> AppResult<Vec<CommitInfo>>;
     fn blame_file(&self, repo_id: &RepoId, path: &Path) -> AppResult<Vec<BlameLine>>;
     fn read_reflog(&self, repo_id: &RepoId) -> AppResult<Vec<ReflogEntry>>;
-    fn diff(&self, repo_id: &RepoId, path: &Path, kind: DiffKind) -> AppResult<FileDiff>;
+    /// Diff a single file. `context_lines` controls how many unchanged lines
+    /// surround each hunk (git default: 3).
+    fn diff(
+        &self,
+        repo_id: &RepoId,
+        path: &Path,
+        kind: DiffKind,
+        context_lines: u32,
+    ) -> AppResult<FileDiff>;
     /// Read the full content of a file from the worktree. Falls back to the
     /// HEAD blob when the worktree copy is missing (e.g. a deleted file).
     fn read_file_content(&self, repo_id: &RepoId, path: &Path) -> AppResult<FileContent>;
@@ -69,6 +77,7 @@ pub trait GitBackend: Send + Sync {
         repo_id: &RepoId,
         from_oid: &str,
         to_oid: &str,
+        context_lines: u32,
     ) -> AppResult<Vec<FileDiff>>;
     fn branches(&self, repo_id: &RepoId) -> AppResult<Vec<BranchInfo>>;
     fn tags(&self, repo_id: &RepoId) -> AppResult<Vec<TagInfo>>;
@@ -85,12 +94,34 @@ pub trait GitBackend: Send + Sync {
     fn discard(&self, repo_id: &RepoId, paths: &[PathBuf]) -> AppResult<()>;
 
     // === hunk-level staging ===
+    // Hunk indices are positions in the diff produced with `context_lines`.
+    // Callers MUST pass the same `context_lines` they used for the `diff` that
+    // displayed the hunks — a different context width can merge/split hunks
+    // and shift indices, applying the wrong hunk.
     /// Stage a single hunk (by index into the WorktreeToIndex diff) for `path`.
-    fn stage_hunk(&self, repo_id: &RepoId, path: &Path, hunk_index: usize) -> AppResult<()>;
+    fn stage_hunk(
+        &self,
+        repo_id: &RepoId,
+        path: &Path,
+        hunk_index: usize,
+        context_lines: u32,
+    ) -> AppResult<()>;
     /// Unstage a single hunk (by index into the IndexToHead diff) for `path`.
-    fn unstage_hunk(&self, repo_id: &RepoId, path: &Path, hunk_index: usize) -> AppResult<()>;
+    fn unstage_hunk(
+        &self,
+        repo_id: &RepoId,
+        path: &Path,
+        hunk_index: usize,
+        context_lines: u32,
+    ) -> AppResult<()>;
     /// Discard a single hunk (by index into the WorktreeToIndex diff) for `path`.
-    fn discard_hunk(&self, repo_id: &RepoId, path: &Path, hunk_index: usize) -> AppResult<()>;
+    fn discard_hunk(
+        &self,
+        repo_id: &RepoId,
+        path: &Path,
+        hunk_index: usize,
+        context_lines: u32,
+    ) -> AppResult<()>;
 
     // === commit ===
     fn commit(&self, repo_id: &RepoId, opts: CommitOptions) -> AppResult<String>;

--- a/src-tauri/tests/diff_commits_revspec.rs
+++ b/src-tauri/tests/diff_commits_revspec.rs
@@ -21,7 +21,7 @@ fn diff_commits_accepts_head_revspec() {
 
     // Should not error even though "HEAD" is not a 40-char hex OID.
     let diffs = backend
-        .diff_commits(&handle.id, &initial, "HEAD")
+        .diff_commits(&handle.id, &initial, "HEAD", 3)
         .unwrap();
     assert!(!diffs.is_empty());
 }

--- a/src-tauri/tests/hunks.rs
+++ b/src-tauri/tests/hunks.rs
@@ -69,6 +69,7 @@ fn worktree_diff_has_exactly_two_hunks_before_staging() {
             &handle.id,
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::WorktreeToIndex,
+            3,
         )
         .expect("diff");
     assert_eq!(
@@ -83,7 +84,7 @@ fn stage_hunk_0_stages_only_first_region() {
     let (_tr, backend, handle) = repo_with_two_worktree_hunks();
 
     backend
-        .stage_hunk(&handle.id, &std::path::Path::new("data.txt"), 0)
+        .stage_hunk(&handle.id, &std::path::Path::new("data.txt"), 0, 3)
         .expect("stage_hunk 0");
 
     // After staging hunk 0 the IndexToHead diff should have 1 hunk (line 3 change).
@@ -92,6 +93,7 @@ fn stage_hunk_0_stages_only_first_region() {
             &handle.id,
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::IndexToHead,
+            3,
         )
         .expect("index diff");
     assert_eq!(
@@ -106,6 +108,7 @@ fn stage_hunk_0_stages_only_first_region() {
             &handle.id,
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::WorktreeToIndex,
+            3,
         )
         .expect("worktree diff");
     assert_eq!(
@@ -128,7 +131,7 @@ fn stage_hunk_1_stages_only_second_region() {
     let (_tr, backend, handle) = repo_with_two_worktree_hunks();
 
     backend
-        .stage_hunk(&handle.id, &std::path::Path::new("data.txt"), 1)
+        .stage_hunk(&handle.id, &std::path::Path::new("data.txt"), 1, 3)
         .expect("stage_hunk 1");
 
     // IndexToHead diff: 1 hunk staged (line 17 change).
@@ -137,6 +140,7 @@ fn stage_hunk_1_stages_only_second_region() {
             &handle.id,
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::IndexToHead,
+            3,
         )
         .expect("index diff");
     assert_eq!(index_diff.hunks.len(), 1, "index should have 1 hunk (line 17)");
@@ -147,6 +151,7 @@ fn stage_hunk_1_stages_only_second_region() {
             &handle.id,
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::WorktreeToIndex,
+            3,
         )
         .expect("worktree diff");
     assert_eq!(wt_diff.hunks.len(), 1, "worktree should have 1 hunk remaining (line 3)");
@@ -174,6 +179,7 @@ fn unstage_hunk_0_removes_only_first_region_from_index() {
             &handle.id,
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::IndexToHead,
+            3,
         )
         .expect("index diff before unstage");
     assert_eq!(
@@ -184,7 +190,7 @@ fn unstage_hunk_0_removes_only_first_region_from_index() {
 
     // Unstage hunk 0 (line 3 change).
     backend
-        .unstage_hunk(&handle.id, &std::path::Path::new("data.txt"), 0)
+        .unstage_hunk(&handle.id, &std::path::Path::new("data.txt"), 0, 3)
         .expect("unstage_hunk 0");
 
     // Only 1 hunk should remain staged.
@@ -193,6 +199,7 @@ fn unstage_hunk_0_removes_only_first_region_from_index() {
             &handle.id,
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::IndexToHead,
+            3,
         )
         .expect("index diff after unstage");
     assert_eq!(
@@ -208,7 +215,7 @@ fn discard_hunk_0_reverts_only_first_region_in_worktree() {
 
     // Discard hunk 0 (line 3 change) from the worktree.
     backend
-        .discard_hunk(&handle.id, &std::path::Path::new("data.txt"), 0)
+        .discard_hunk(&handle.id, &std::path::Path::new("data.txt"), 0, 3)
         .expect("discard_hunk 0");
 
     // WorktreeToIndex diff: only 1 hunk should remain (line 17).
@@ -217,6 +224,7 @@ fn discard_hunk_0_reverts_only_first_region_in_worktree() {
             &handle.id,
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::WorktreeToIndex,
+            3,
         )
         .expect("worktree diff after discard");
     assert_eq!(
@@ -255,6 +263,7 @@ fn stage_hunk_out_of_range_returns_error() {
         &handle.id,
         &std::path::Path::new("data.txt"),
         99,
+        3,
     );
     assert!(result.is_err(), "out-of-range hunk index should return an error");
 }
@@ -289,6 +298,7 @@ fn worktree_diff_includes_untracked_file_content() {
             &handle.id,
             &std::path::Path::new("new.txt"),
             platypusgit_lib::git::types::DiffKind::WorktreeToIndex,
+            3,
         )
         .expect("diff");
 
@@ -302,4 +312,76 @@ fn worktree_diff_includes_untracked_file_content() {
         .collect();
     assert_eq!(added, vec!["alpha", "beta", "gamma"]);
     assert_eq!(diff.additions, 3);
+}
+
+#[test]
+fn context_lines_widens_hunks_and_merges_nearby_changes() {
+    // The two edits (lines 3 and 17) are 13 unchanged lines apart. With the
+    // default context of 3 they form two separate hunks; with a context of 10
+    // the context regions overlap and libgit2 merges them into one hunk.
+    let (_tr, backend, handle) = repo_with_two_worktree_hunks();
+
+    let narrow = backend
+        .diff(
+            &handle.id,
+            &std::path::Path::new("data.txt"),
+            platypusgit_lib::git::types::DiffKind::WorktreeToIndex,
+            3,
+        )
+        .expect("diff context=3");
+    assert_eq!(narrow.hunks.len(), 2, "context=3 should keep 2 separate hunks");
+
+    let wide = backend
+        .diff(
+            &handle.id,
+            &std::path::Path::new("data.txt"),
+            platypusgit_lib::git::types::DiffKind::WorktreeToIndex,
+            10,
+        )
+        .expect("diff context=10");
+    assert_eq!(wide.hunks.len(), 1, "context=10 should merge into 1 hunk");
+
+    // Zero context: hunks shrink to just the changed lines.
+    let zero = backend
+        .diff(
+            &handle.id,
+            &std::path::Path::new("data.txt"),
+            platypusgit_lib::git::types::DiffKind::WorktreeToIndex,
+            0,
+        )
+        .expect("diff context=0");
+    assert_eq!(zero.hunks.len(), 2, "context=0 keeps 2 hunks");
+    let ctx_lines = zero
+        .hunks
+        .iter()
+        .flat_map(|h| h.lines.iter())
+        .filter(|l| matches!(l.kind, platypusgit_lib::git::types::DiffLineKind::Context))
+        .count();
+    assert_eq!(ctx_lines, 0, "context=0 should include no context lines");
+}
+
+#[test]
+fn stage_hunk_with_wide_context_stages_merged_hunk() {
+    // With context=10 the two edits form ONE hunk; staging index 0 with the
+    // same context must stage both regions — proving the context width used
+    // for display is the one used for application.
+    let (_tr, backend, handle) = repo_with_two_worktree_hunks();
+
+    backend
+        .stage_hunk(&handle.id, &std::path::Path::new("data.txt"), 0, 10)
+        .expect("stage_hunk 0 with context=10");
+
+    let wt_diff = backend
+        .diff(
+            &handle.id,
+            &std::path::Path::new("data.txt"),
+            platypusgit_lib::git::types::DiffKind::WorktreeToIndex,
+            10,
+        )
+        .expect("worktree diff after staging");
+    assert_eq!(
+        wt_diff.hunks.len(),
+        0,
+        "staging the merged hunk should leave nothing unstaged"
+    );
 }

--- a/src-tauri/tests/reflog.rs
+++ b/src-tauri/tests/reflog.rs
@@ -112,7 +112,7 @@ fn diff_commits_returns_per_file_diffs_between_two_commits() {
     let grandparent_oid = commits[2].oid.clone();
 
     let diffs = backend
-        .diff_commits(&handle.id, &grandparent_oid, &head_oid)
+        .diff_commits(&handle.id, &grandparent_oid, &head_oid, 3)
         .unwrap();
 
     // grandparent -> HEAD adds two.txt and three.txt.

--- a/src/features/reflog/useReflogStore.ts
+++ b/src/features/reflog/useReflogStore.ts
@@ -11,6 +11,7 @@ import {
   stashSave,
 } from "@/lib/tauri";
 import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
 
 export type ReflogActionChoice = "reset" | "checkout" | "branch";
 
@@ -77,7 +78,12 @@ export const useReflogStore = create<ReflogState>((set, get) => ({
     }
     set({ previewLoading: true });
     try {
-      const diff = await diffCommits(repoId, head, oid);
+      const diff = await diffCommits(
+        repoId,
+        head,
+        oid,
+        useSettingsStore.getState().diffContextLines,
+      );
       set({ previewDiff: diff, previewLoading: false });
     } catch (e) {
       set({ previewLoading: false, error: toAppError(e) });

--- a/src/features/repo/useRepoStore.settings.test.ts
+++ b/src/features/repo/useRepoStore.settings.test.ts
@@ -1,0 +1,138 @@
+// Store-logic tests for the settings consumed by useRepoStore:
+// - autoStashBeforePull gates the stash → pull → pop flow
+// - pruneOnFetch is threaded into the fetch/fetch_all IPC
+// - diffContextLines is threaded into hunk-staging IPC
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+import { useRepoStore } from "./useRepoStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+
+function mockRefreshAll() {
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log", () => []);
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => null);
+}
+
+function calls(cmd: string) {
+  return getInvokeCalls().filter((c) => c.cmd === cmd);
+}
+
+/** Index of the first call of `cmd` in the invoke log (-1 if absent). */
+function callIndex(cmd: string) {
+  return getInvokeCalls().findIndex((c) => c.cmd === cmd);
+}
+
+beforeEach(() => {
+  useSettingsStore.getState().reset(); // defaults: autoStash on, prune on, ctx 3
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/tmp/repo-1", head: "main" },
+    error: null,
+  });
+  mockRefreshAll();
+});
+
+describe("pull auto-stash", () => {
+  it("stashes before pull and pops after when the tree is dirty", async () => {
+    mockInvoke("stash_save", () => "stash-oid");
+    mockInvoke("pull", () => null);
+    mockInvoke("stash_pop", () => null);
+
+    await useRepoStore.getState().pull("origin", "main", "Merge");
+
+    expect(calls("stash_save")).toHaveLength(1);
+    expect(calls("pull")).toHaveLength(1);
+    expect(calls("stash_pop")).toHaveLength(1);
+    // Order: stash → pull → pop.
+    expect(callIndex("stash_save")).toBeLessThan(callIndex("pull"));
+    expect(callIndex("pull")).toBeLessThan(callIndex("stash_pop"));
+    // Untracked files ride along, mirroring checkoutBranch's auto-stash.
+    expect(calls("stash_save")[0].args.opts.includeUntracked).toBe(true);
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("skips the pop when there was nothing to stash", async () => {
+    mockInvoke("stash_save", () => null); // clean tree
+    mockInvoke("pull", () => null);
+    mockInvoke("stash_pop", () => {
+      throw new Error("must not pop when nothing was stashed");
+    });
+
+    await useRepoStore.getState().pull("origin", "main", "Merge");
+
+    expect(calls("stash_save")).toHaveLength(1);
+    expect(calls("pull")).toHaveLength(1);
+    expect(calls("stash_pop")).toHaveLength(0);
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("does not stash at all when autoStashBeforePull is off", async () => {
+    useSettingsStore.getState().set("autoStashBeforePull", false);
+    mockInvoke("pull", () => null);
+
+    await useRepoStore.getState().pull("origin", "main", "Merge");
+
+    expect(calls("stash_save")).toHaveLength(0);
+    expect(calls("pull")).toHaveLength(1);
+  });
+
+  it("keeps the stash (no pop) and surfaces the error when the pull fails", async () => {
+    mockInvoke("stash_save", () => "stash-oid");
+    mockInvoke("pull", () => {
+      throw { kind: "Network", message: "diverged" };
+    });
+    mockInvoke("stash_pop", () => {
+      throw new Error("must not pop onto a failed pull");
+    });
+
+    await useRepoStore.getState().pull("origin", "main", "FastForward");
+
+    expect(calls("stash_pop")).toHaveLength(0);
+    expect(useRepoStore.getState().error).toEqual({
+      kind: "Network",
+      message: "diverged",
+    });
+  });
+});
+
+describe("pruneOnFetch threading", () => {
+  it("fetch passes prune=true by default", async () => {
+    mockInvoke("fetch", () => null);
+    await useRepoStore.getState().fetch("origin");
+    expect(calls("fetch")[0].args.prune).toBe(true);
+  });
+
+  it("fetch and fetchAll pass prune=false when the setting is off", async () => {
+    useSettingsStore.getState().set("pruneOnFetch", false);
+    mockInvoke("fetch", () => null);
+    mockInvoke("fetch_all", () => null);
+
+    await useRepoStore.getState().fetch("origin");
+    await useRepoStore.getState().fetchAll();
+
+    expect(calls("fetch")[0].args.prune).toBe(false);
+    expect(calls("fetch_all")[0].args.prune).toBe(false);
+  });
+});
+
+describe("diffContextLines threading", () => {
+  it("hunk ops pass the configured context width", async () => {
+    useSettingsStore.getState().set("diffContextLines", 8);
+    mockInvoke("stage_hunk", () => null);
+    mockInvoke("unstage_hunk", () => null);
+    mockInvoke("discard_hunk", () => null);
+
+    await useRepoStore.getState().stageHunk("a.txt", 0);
+    await useRepoStore.getState().unstageHunk("a.txt", 1);
+    await useRepoStore.getState().discardHunk("a.txt", 2);
+
+    expect(calls("stage_hunk")[0].args.contextLines).toBe(8);
+    expect(calls("unstage_hunk")[0].args.contextLines).toBe(8);
+    expect(calls("discard_hunk")[0].args.contextLines).toBe(8);
+  });
+});

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -83,6 +83,7 @@ import {
   type TagTarget,
 } from "@/lib/tauri";
 import { isFilterEmpty } from "@/features/commits/logFilter";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { useRecentsStore } from "./useRecentsStore";
 
 /**
@@ -429,11 +430,13 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     }
   },
 
+  // Hunk ops pass the same diffContextLines the viewers used for getDiff so
+  // the backend recomputes an identical hunk list — indices stay aligned.
   async stageHunk(path, hunkIndex) {
     const repo = get().current;
     if (!repo) return;
     try {
-      await stageHunk(repo.id, path, hunkIndex);
+      await stageHunk(repo.id, path, hunkIndex, useSettingsStore.getState().diffContextLines);
       await get().refreshAll();
     } catch (e) {
       set({ error: toAppError(e) });
@@ -444,7 +447,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     const repo = get().current;
     if (!repo) return;
     try {
-      await unstageHunk(repo.id, path, hunkIndex);
+      await unstageHunk(repo.id, path, hunkIndex, useSettingsStore.getState().diffContextLines);
       await get().refreshAll();
     } catch (e) {
       set({ error: toAppError(e) });
@@ -455,7 +458,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     const repo = get().current;
     if (!repo) return;
     try {
-      await discardHunk(repo.id, path, hunkIndex);
+      await discardHunk(repo.id, path, hunkIndex, useSettingsStore.getState().diffContextLines);
       await get().refreshAll();
     } catch (e) {
       set({ error: toAppError(e) });
@@ -743,7 +746,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     setActivity("fetch", `Fetching ${remote}…`);
     try {
-      await fetchRemote(repo.id, remote);
+      await fetchRemote(repo.id, remote, useSettingsStore.getState().pruneOnFetch);
       await get().refreshAll();
     } catch (e) {
       set({ error: toAppError(e) });
@@ -757,7 +760,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     setActivity("fetch", "Fetching all remotes…");
     try {
-      await fetchAll(repo.id);
+      await fetchAll(repo.id, useSettingsStore.getState().pruneOnFetch);
       await get().refreshAll();
     } catch (e) {
       set({ error: toAppError(e) });
@@ -771,9 +774,32 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     setActivity("pull", `Pulling ${remote}/${branch}…`);
     try {
+      // Carry over uncommitted work when the setting is on: stash → pull →
+      // pop, mirroring checkoutBranch's auto-stash. stashSave returns null
+      // when the tree is clean, so this is a no-op in the common case. If
+      // the pull fails, the stash is deliberately NOT popped — the work
+      // stays safe in the stash list rather than colliding with a conflicted
+      // worktree (same policy as checkoutBranch).
+      let stashed: string | null = null;
+      if (useSettingsStore.getState().autoStashBeforePull) {
+        setActivity("pull", "Stashing changes…");
+        stashed = await stashSave(repo.id, {
+          message: `auto: pull ${remote}/${branch}`,
+          includeUntracked: true,
+          keepIndex: false,
+        });
+        setActivity("pull", `Pulling ${remote}/${branch}…`);
+      }
       await pullRemote(repo.id, remote, branch, mode);
+      if (stashed) {
+        setActivity("pull", "Restoring stashed changes…");
+        await stashPop(repo.id, 0);
+      }
       await get().refreshAll();
     } catch (e) {
+      // See mergeBranch's catch: refresh first, error last, so it isn't
+      // batched away by refreshAll's own `error: null` reset.
+      await get().refreshAll();
       set({ error: toAppError(e) });
     } finally {
       setActivity("pull", null);

--- a/src/features/settings/useSettingsStore.test.ts
+++ b/src/features/settings/useSettingsStore.test.ts
@@ -1,0 +1,89 @@
+// Store-logic tests for the settings store: persistence shape (including the
+// removal migration for dead settings) and the uiDensity CSS-var hook.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const STORAGE_KEY = "pg-settings-v2";
+
+// The store applies theme + density at module load, so each test re-imports a
+// fresh module instance after seeding localStorage.
+async function freshStore() {
+  vi.resetModules();
+  return await import("./useSettingsStore");
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.style.removeProperty("--row-h");
+});
+
+describe("useSettingsStore persistence", () => {
+  it("loads persisted values over defaults", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ pruneOnFetch: false, diffContextLines: 8 }),
+    );
+    const { useSettingsStore } = await freshStore();
+    const s = useSettingsStore.getState();
+    expect(s.pruneOnFetch).toBe(false);
+    expect(s.diffContextLines).toBe(8);
+    // Untouched keys keep defaults.
+    expect(s.autoStashBeforePull).toBe(true);
+  });
+
+  it("drops removed settings (signCommits, showWhitespaceInDiff) from old payloads", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        signCommits: true,
+        showWhitespaceInDiff: true,
+        pruneOnFetch: false,
+      }),
+    );
+    const { useSettingsStore } = await freshStore();
+    const s = useSettingsStore.getState();
+    // Known key still honored…
+    expect(s.pruneOnFetch).toBe(false);
+    // …but stale keys don't leak into store state.
+    expect("signCommits" in s).toBe(false);
+    expect("showWhitespaceInDiff" in s).toBe(false);
+
+    // And the next persist writes a clean payload without them.
+    useSettingsStore.getState().set("pruneOnFetch", true);
+    const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}");
+    expect("signCommits" in raw).toBe(false);
+    expect("showWhitespaceInDiff" in raw).toBe(false);
+    expect(raw.pruneOnFetch).toBe(true);
+  });
+
+  it("set() persists the changed key", async () => {
+    const { useSettingsStore } = await freshStore();
+    useSettingsStore.getState().set("autoStashBeforePull", false);
+    const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}");
+    expect(raw.autoStashBeforePull).toBe(false);
+  });
+});
+
+describe("uiDensity CSS hook", () => {
+  it("applies --row-h from the persisted density at load", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiDensity: "comfortable" }));
+    await freshStore();
+    expect(document.documentElement.style.getPropertyValue("--row-h")).toBe("28px");
+    expect(document.documentElement.dataset.density).toBe("comfortable");
+  });
+
+  it("re-applies --row-h when the density setting changes", async () => {
+    const { useSettingsStore } = await freshStore();
+    expect(document.documentElement.style.getPropertyValue("--row-h")).toBe("24px");
+    useSettingsStore.getState().set("uiDensity", "comfortable");
+    expect(document.documentElement.style.getPropertyValue("--row-h")).toBe("28px");
+    useSettingsStore.getState().set("uiDensity", "compact");
+    expect(document.documentElement.style.getPropertyValue("--row-h")).toBe("24px");
+  });
+
+  it("reset() restores compact density", async () => {
+    const { useSettingsStore } = await freshStore();
+    useSettingsStore.getState().set("uiDensity", "comfortable");
+    useSettingsStore.getState().reset();
+    expect(document.documentElement.style.getPropertyValue("--row-h")).toBe("24px");
+  });
+});

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -308,10 +308,22 @@ export function applyTheme(theme: ThemeDef) {
   root.dataset.themeMode = theme.mode;
 }
 
+/** Apply UI density by writing the row-height slot to CSS vars on :root. */
+export function applyDensity(density: "compact" | "comfortable") {
+  const root = document.documentElement;
+  root.style.setProperty("--row-h", density === "comfortable" ? "28px" : "24px");
+  root.dataset.density = density;
+}
+
 // ═════════════════════════════════════════════════════════════════════════════
 // STORE
 // ═════════════════════════════════════════════════════════════════════════════
 
+// Removed settings (persisted keys are dropped by load()'s known-key filter):
+// - signCommits: GPG/SSH signing needs real key plumbing; a toggle that only
+//   pretends to sign erodes trust. Re-add together with actual signing.
+// - showWhitespaceInDiff: no cheap consumer — libgit2's whitespace flags
+//   invert the semantics and would desync hunk indices from staging.
 interface PersistedState {
   activeThemeId: string;
   customThemes: ThemeDef[];
@@ -322,9 +334,7 @@ interface PersistedState {
   pruneOnFetch: boolean;
   confirmForcePush: boolean;
   autoStashBeforePull: boolean;
-  signCommits: boolean;
   addSignoff: boolean;
-  showWhitespaceInDiff: boolean;
   diffContextLines: number;
 }
 
@@ -353,9 +363,7 @@ const DEFAULTS: PersistedState = {
   pruneOnFetch: true,
   confirmForcePush: true,
   autoStashBeforePull: true,
-  signCommits: false,
   addSignoff: false,
-  showWhitespaceInDiff: false,
   diffContextLines: 3,
 };
 
@@ -363,8 +371,17 @@ function load(): PersistedState {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return { ...DEFAULTS };
-    const parsed = JSON.parse(raw) as Partial<PersistedState>;
-    return { ...DEFAULTS, ...parsed };
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    // Only pick keys that still exist in the schema, so settings removed in
+    // newer versions (e.g. signCommits, showWhitespaceInDiff) don't leak
+    // stale properties into the store state.
+    const out = { ...DEFAULTS };
+    for (const key of Object.keys(DEFAULTS) as (keyof PersistedState)[]) {
+      if (key in parsed) {
+        (out as Record<string, unknown>)[key] = parsed[key];
+      }
+    }
+    return out;
   } catch {
     return { ...DEFAULTS };
   }
@@ -389,9 +406,7 @@ function snapshot(s: SettingsState): PersistedState {
     pruneOnFetch: s.pruneOnFetch,
     confirmForcePush: s.confirmForcePush,
     autoStashBeforePull: s.autoStashBeforePull,
-    signCommits: s.signCommits,
     addSignoff: s.addSignoff,
-    showWhitespaceInDiff: s.showWhitespaceInDiff,
     diffContextLines: s.diffContextLines,
   };
 }
@@ -616,18 +631,24 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   set(key, value) {
     set({ [key]: value } as Partial<SettingsState>);
     persist(snapshot(get()));
+    if (key === "uiDensity") {
+      applyDensity(get().uiDensity);
+    }
   },
 
   reset() {
     set({ ...DEFAULTS });
     persist(DEFAULTS);
     applyTheme(BUILTIN_THEMES[0]);
+    applyDensity(DEFAULTS.uiDensity);
   },
 }));
 
-// Apply active theme on module load so there's no flash before first render.
+// Apply active theme + density on module load so there's no flash before
+// first render.
 {
   const s = useSettingsStore.getState();
   const active = findTheme(s, s.activeThemeId) ?? BUILTIN_THEMES[0];
   applyTheme(active);
+  applyDensity(s.uiDensity);
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -137,8 +137,9 @@ export async function getDiff(
   repoId: string,
   path: string,
   kind: DiffKind = "WorktreeToIndex",
+  contextLines = 3,
 ): Promise<FileDiff> {
-  return invoke<FileDiff>("get_diff", { repoId, path, kind });
+  return invoke<FileDiff>("get_diff", { repoId, path, kind, contextLines });
 }
 
 export async function getReflog(repoId: string): Promise<ReflogEntry[]> {
@@ -156,8 +157,9 @@ export async function diffCommits(
   repoId: string,
   fromOid: string,
   toOid: string,
+  contextLines = 3,
 ): Promise<FileDiff[]> {
-  return invoke<FileDiff[]>("diff_commits", { repoId, fromOid, toOid });
+  return invoke<FileDiff[]>("diff_commits", { repoId, fromOid, toOid, contextLines });
 }
 
 export async function stagePaths(repoId: string, paths: string[]): Promise<void> {
@@ -181,28 +183,34 @@ export async function discardPaths(repoId: string, paths: string[]): Promise<voi
   return invoke<void>("discard_paths", { repoId, paths });
 }
 
+// Hunk indices refer to the diff computed with `contextLines` — always pass
+// the same value used for the getDiff() that displayed the hunks, or the
+// backend may apply the wrong hunk (context width changes hunk merging).
 export async function stageHunk(
   repoId: string,
   path: string,
   hunkIndex: number,
+  contextLines = 3,
 ): Promise<void> {
-  return invoke<void>("stage_hunk", { repoId, path, hunkIndex });
+  return invoke<void>("stage_hunk", { repoId, path, hunkIndex, contextLines });
 }
 
 export async function unstageHunk(
   repoId: string,
   path: string,
   hunkIndex: number,
+  contextLines = 3,
 ): Promise<void> {
-  return invoke<void>("unstage_hunk", { repoId, path, hunkIndex });
+  return invoke<void>("unstage_hunk", { repoId, path, hunkIndex, contextLines });
 }
 
 export async function discardHunk(
   repoId: string,
   path: string,
   hunkIndex: number,
+  contextLines = 3,
 ): Promise<void> {
-  return invoke<void>("discard_hunk", { repoId, path, hunkIndex });
+  return invoke<void>("discard_hunk", { repoId, path, hunkIndex, contextLines });
 }
 
 export type ResetMode = "Soft" | "Mixed" | "Hard";
@@ -338,13 +346,17 @@ export async function stashBranch(
 // ─── Network operations ──────────────────────────────────────────────────────
 
 /** Fetch a single remote, pruning deleted remote refs. */
-export async function fetch(repoId: string, remote: string): Promise<void> {
-  return invoke<void>("fetch", { repoId, remote });
+export async function fetch(
+  repoId: string,
+  remote: string,
+  prune = true,
+): Promise<void> {
+  return invoke<void>("fetch", { repoId, remote, prune });
 }
 
 /** Fetch all remotes, pruning deleted remote refs. */
-export async function fetchAll(repoId: string): Promise<void> {
-  return invoke<void>("fetch_all", { repoId });
+export async function fetchAll(repoId: string, prune = true): Promise<void> {
+  return invoke<void>("fetch_all", { repoId, prune });
 }
 
 /**

--- a/src/screens/CommitDiff.tsx
+++ b/src/screens/CommitDiff.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { PGEmpty, PGSpinner } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { diffCommits } from "@/lib/tauri";
 import { appErrorMessage } from "@/lib/errors";
 import type { FileDiff } from "@/lib/types";
@@ -13,6 +14,7 @@ type Target =
 
 export function CommitDiffScreen() {
   const repo = useRepoStore((s) => s.current);
+  const diffContextLines = useSettingsStore((s) => s.diffContextLines);
   const intent = useNavStore((s) => s.intent);
   const clearIntent = useNavStore((s) => s.clearIntent);
 
@@ -44,12 +46,12 @@ export function CommitDiffScreen() {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    diffCommits(repo.id, from, to)
+    diffCommits(repo.id, from, to, diffContextLines)
       .then((d) => { if (!cancelled) { setDiffs(d); setSelected(d[0]?.path ?? null); } })
       .catch((e) => { if (!cancelled) setError(appErrorMessage(e)); })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, [repo?.id, target]);
+  }, [repo?.id, target, diffContextLines]);
 
   if (!target) {
     return <PGEmpty icon="diff" title="No diff target">Pick "Compare…" from a context menu.</PGEmpty>;

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -50,6 +50,7 @@ export function CommitPanelScreen() {
   const setNavIntent = useNavStore((s) => s.setIntent);
   const addSignoff = useSettingsStore((s) => s.addSignoff);
   const setSetting = useSettingsStore((s) => s.set);
+  const diffContextLines = useSettingsStore((s) => s.diffContextLines);
   const [message, setMessage] = React.useState("");
   const [body, setBody] = React.useState("");
   const [amend, setAmend] = React.useState(false);
@@ -189,7 +190,7 @@ export function CommitPanelScreen() {
     let cancelled = false;
     setDiffLoading(true);
     setDiffError(null);
-    getDiff(repo.id, selected.path, kind)
+    getDiff(repo.id, selected.path, kind, diffContextLines)
       .then((d) => {
         if (!cancelled) setDiff(d);
       })
@@ -202,7 +203,7 @@ export function CommitPanelScreen() {
     return () => {
       cancelled = true;
     };
-  }, [selected?.path, selected?.side, repo]);
+  }, [selected?.path, selected?.side, repo, diffContextLines]);
 
   const headBranch = currentBranch(branches);
   const defaultRemote = remotes[0] ?? null;

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { statusMark } from "@/lib/derive";
 import { getDiff } from "@/lib/tauri";
 import type { FileDiff } from "@/lib/types";
@@ -25,6 +26,7 @@ import type { FileDiff } from "@/lib/types";
 export function DiffViewerScreen() {
   const repo = useRepoStore((s) => s.current);
   const status = useRepoStore((s) => s.status);
+  const diffContextLines = useSettingsStore((s) => s.diffContextLines);
   const [mode, setMode] = React.useState<"unified" | "split">("unified");
   const [wrap, setWrap] = React.useState(false);
   const [filter, setFilter] = React.useState("");
@@ -75,7 +77,7 @@ export function DiffViewerScreen() {
     }
     let cancelled = false;
     setDiffLoading(true);
-    getDiff(repo.id, current.path, "WorktreeToHead")
+    getDiff(repo.id, current.path, "WorktreeToHead", diffContextLines)
       .then((d) => {
         if (!cancelled) setDiff(d);
       })
@@ -88,7 +90,7 @@ export function DiffViewerScreen() {
     return () => {
       cancelled = true;
     };
-  }, [current?.path, repo]);
+  }, [current?.path, repo, diffContextLines]);
 
   const findFiltered = React.useMemo<FileDiff | null>(() => {
     if (!diff || !findQuery.trim()) return diff;

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import {
   currentBranch,
   relativeTime,
@@ -86,6 +87,7 @@ export function RepoBrowserScreen() {
   const refreshAllFiles = useRepoStore((s) => s.refreshAllFiles);
   const listFilesAtRev = useRepoStore((s) => s.listFilesAtRev);
   const readFileContentAtRev = useRepoStore((s) => s.readFileContentAtRev);
+  const diffContextLines = useSettingsStore((s) => s.diffContextLines);
 
   const [expanded, setExpanded] = React.useState<Record<string, boolean>>({});
   const [selected, setSelected] = React.useState<string | null>(null);
@@ -247,7 +249,7 @@ export function RepoBrowserScreen() {
         });
     } else {
       setFileContent(null);
-      getDiff(repo.id, selectedFile.path, "WorktreeToHead")
+      getDiff(repo.id, selectedFile.path, "WorktreeToHead", diffContextLines)
         .then((d) => {
           if (!cancelled) setDiff(d);
         })
@@ -261,7 +263,7 @@ export function RepoBrowserScreen() {
     return () => {
       cancelled = true;
     };
-  }, [selectedFile?.path, selectedIsUnmodified, repo, browsingRev, rev, readFileContentAtRev]);
+  }, [selectedFile?.path, selectedIsUnmodified, repo, browsingRev, rev, readFileContentAtRev, diffContextLines]);
 
   const breadcrumbItems = React.useMemo(() => {
     const root = repo?.path.split("/").filter(Boolean).pop() ?? "repository";

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -171,16 +171,6 @@ export function SettingsScreen() {
           subtitle="Defaults applied when creating a new commit."
         >
           <Row
-            label="Sign commits (GPG / SSH)"
-            hint="Adds the -S flag. Requires a signing key configured in git."
-            control={
-              <PGToggle
-                checked={s.signCommits}
-                onChange={(v) => s.set("signCommits", v)}
-              />
-            }
-          />
-          <Row
             label="Append Signed-off-by"
             hint="Appends a DCO-style trailer to every commit message."
             control={
@@ -193,16 +183,6 @@ export function SettingsScreen() {
         </Section>
 
         <Section title="Diff" subtitle="How diffs are rendered across the app.">
-          <Row
-            label="Show whitespace changes"
-            hint="Highlight whitespace-only differences in diffs."
-            control={
-              <PGToggle
-                checked={s.showWhitespaceInDiff}
-                onChange={(v) => s.set("showWhitespaceInDiff", v)}
-              />
-            }
-          />
           <Row
             label="Context lines"
             hint="Unchanged lines shown around each hunk."


### PR DESCRIPTION
Closes #31.

Every persisted-but-unread setting got a wire-or-remove decision:

| Setting | Decision | How |
|---|---|---|
| `autoStashBeforePull` | **Wired** | `useRepoStore.pull` now stashes a dirty tree first (incl. untracked) and pops after a successful pull, mirroring `checkoutBranch`'s auto-stash. On pull failure the stash is deliberately **not** popped — work stays safe in the stash list instead of colliding with a conflicted worktree. |
| `pruneOnFetch` | **Wired** | `fetch` / `fetch_all` commands take a `prune: bool` threaded from the settings store; `--prune` is no longer hardcoded. |
| `diffContextLines` | **Wired** | `context_lines` threaded through `GitBackend::{diff, diff_commits, stage_hunk, unstage_hunk, discard_hunk}` → Tauri commands → `lib/tauri.ts` → all viewer call sites. Hunk ops pass the **same** width the viewer used, so hunk indices stay aligned (wide context can merge hunks — covered by a new Rust test). |
| `uiDensity` | **Wired** | `applyDensity` writes the design system's `--row-h` CSS var (compact 24px / comfortable 28px) on load, on change, and on reset. |
| `signCommits` | **Removed** | Real GPG/SSH signing via libgit2 needs key plumbing that's out of scope; no trivial existing plumbing found. A toggle that pretends to sign erodes trust — control + store key dropped. |
| `showWhitespaceInDiff` | **Removed** | No cheap consumer: libgit2's whitespace flags invert the setting's semantics and would desync displayed hunks from staging; a frontend whitespace-only highlighter needs intraline diffing. Control + store key dropped. |

**Migration:** `load()` now filters the persisted `pg-settings-v2` payload to the current schema, so removed keys in old localStorage payloads are dropped instead of leaking into store state; the next persist writes a clean payload.

**Hardening (from the same investigation):** `run_git` sets `GIT_TERMINAL_PROMPT=0` + no-op `GIT_ASKPASS`/`SSH_ASKPASS`, so fetch/pull/push against an auth-requiring remote fails fast with a visible `Network` error instead of hanging on an invisible credential prompt.

**Tests**
- Rust: `fetch_args` unit tests (prune on/off), diff context-width tests (3 → 2 hunks, 10 → merged 1 hunk, 0 → no context lines), stage-hunk-with-wide-context alignment test. 119 passed.
- Frontend: new `useRepoStore.settings.test.ts` (auto-stash flow incl. failure path, prune threading, contextLines threading) and `useSettingsStore.test.ts` (persistence, removed-key migration, density CSS hook). 110 passed.
- `pnpm tsc --noEmit`, `pnpm exec tsc -p e2e/tsconfig.json --noEmit` clean. Existing e2e settings specs assert none of the removed rows (verified), so no spec changes needed; e2e runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)