### PR TITLE
fix(files): multi-select context menu counts unmodified files in all-files view

### DIFF
--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -900,6 +900,11 @@ export interface MultiFileMenuSelection {
   stagedPaths: string[];
   /** Selected paths with unstaged (worktree) changes. */
   unstagedPaths: string[];
+  /**
+   * Every selected file path, including unmodified files (all-files browsing).
+   * Drives the count and Copy paths. Defaults to staged ∪ unstaged.
+   */
+  paths?: string[];
 }
 
 /**
@@ -912,7 +917,7 @@ export function multiFileMenuItems(
 ): ContextMenuItem[] {
   const stagedPaths = sel?.stagedPaths ?? [];
   const unstagedPaths = sel?.unstagedPaths ?? [];
-  const all = [...stagedPaths, ...unstagedPaths];
+  const all = sel?.paths ?? [...stagedPaths, ...unstagedPaths];
   const n = all.length;
   const files = (c: number) => `${c} file${c === 1 ? "" : "s"}`;
   const items: ContextMenuItem[] = [{ __menuTitle: `${files(n)} selected` }];

--- a/src/screens/RepoBrowser.test.tsx
+++ b/src/screens/RepoBrowser.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+
+import { RepoBrowserScreen } from "./RepoBrowser";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { mockInvoke } from "@/test/invokeMock";
+import type { FileStatus, RepoHandle } from "@/lib/types";
+
+const repo: RepoHandle = {
+  id: "repo-1",
+  path: "/tmp/fake-repo",
+  head: "refs/heads/main",
+};
+
+function modified(path: string): FileStatus {
+  return { path, worktree: { kind: "Modified" }, index: { kind: "Unmodified" } };
+}
+
+function unmodified(path: string): FileStatus {
+  return {
+    path,
+    worktree: { kind: "Unmodified" },
+    index: { kind: "Unmodified" },
+  };
+}
+
+const status = [modified("a.txt")];
+const allFiles = [modified("a.txt"), unmodified("u1.txt"), unmodified("u2.txt")];
+
+function resetStore() {
+  useRepoStore.setState({
+    current: repo,
+    status,
+    allFiles: [],
+    branches: [],
+    tags: [],
+    stashes: [],
+    remotes: [],
+    commits: [],
+    loading: false,
+    error: null,
+    repoState: "Clean",
+    rebaseStatus: { inProgress: false, nextIndex: 0, total: 0, pauseReason: null },
+    activity: {},
+  });
+}
+
+function wireMocks() {
+  mockInvoke("list_all_files", () => allFiles);
+  mockInvoke("get_diff", (args) => ({
+    path: args.path,
+    oldPath: null,
+    binary: false,
+    additions: 0,
+    deletions: 0,
+    hunks: [],
+  }));
+  mockInvoke("read_file_content", (args) => ({
+    path: args.path,
+    text: "content",
+    binary: false,
+    fromHead: false,
+  }));
+}
+
+function treeRow(path: string): HTMLElement {
+  const row = document.querySelector(`[data-pg-row][data-path="${path}"]`);
+  if (!row) throw new Error(`no tree row for ${path}`);
+  return row as HTMLElement;
+}
+
+describe("RepoBrowser multi-file selection (all-files mode)", () => {
+  beforeEach(() => {
+    resetStore();
+    wireMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("multi-select of unmodified files shows the real count, not 0", async () => {
+    render(<RepoBrowserScreen />);
+
+    fireEvent.click(screen.getByText("All"));
+    await waitFor(() => treeRow("u1.txt"));
+
+    fireEvent.click(treeRow("u1.txt"));
+    fireEvent.click(treeRow("u2.txt"), { ctrlKey: true });
+    fireEvent.contextMenu(treeRow("u2.txt"));
+
+    expect(await screen.findByText("2 files selected")).toBeInTheDocument();
+    expect(screen.queryByText("0 files selected")).toBeNull();
+  });
+
+  it("mixed selection keeps stage actions for the changed subset and counts every file", async () => {
+    render(<RepoBrowserScreen />);
+
+    fireEvent.click(screen.getByText("All"));
+    await waitFor(() => treeRow("u1.txt"));
+
+    fireEvent.click(treeRow("a.txt"));
+    fireEvent.click(treeRow("u1.txt"), { ctrlKey: true });
+    fireEvent.contextMenu(treeRow("u1.txt"));
+
+    expect(await screen.findByText("2 files selected")).toBeInTheDocument();
+    expect(screen.getByText("Stage 1 file")).toBeInTheDocument();
+  });
+});

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -231,20 +231,28 @@ export function RepoBrowserScreen() {
 
   // Map selected tree keys to worktree statuses for multi-file operations.
   // Folder keys simply don't resolve to a status entry, so they're inert.
+  // In all-files mode unmodified files only exist in allFiles, not status —
+  // they carry no stage/unstage actions but still count and copy.
   const splitSelection = React.useCallback(
-    (keys: string[]): { stagedPaths: string[]; unstagedPaths: string[] } => {
+    (
+      keys: string[],
+    ): { stagedPaths: string[]; unstagedPaths: string[]; paths: string[] } => {
       const stagedPaths: string[] = [];
       const unstagedPaths: string[] = [];
+      const paths: string[] = [];
       for (const key of keys) {
         const path = key.replace(/^\//, "");
-        const st = status.find((s) => s.path === path);
+        const st =
+          status.find((s) => s.path === path) ??
+          allFiles.find((s) => s.path === path);
         if (!st) continue;
+        paths.push(path);
         if (isStaged(st)) stagedPaths.push(path);
         if (isUnstaged(st)) unstagedPaths.push(path);
       }
-      return { stagedPaths, unstagedPaths };
+      return { stagedPaths, unstagedPaths, paths };
     },
-    [status],
+    [status, allFiles],
   );
 
   const fileCtx = useContextMenu<{ key: string; node: PGFileTreeNode }>(


### PR DESCRIPTION
## Problem

Repo browser, filter set to **All**: multi-select files, right-click → menu says "0 files selected" with no actions.

## Root cause

`splitSelection` in `RepoBrowser.tsx` resolved selected tree keys against `status` (changed files only). In All mode the tree is built from `allFiles`, so unmodified files resolved to nothing — `multiFileMenuItems` counted zero paths.

## Fix

- `splitSelection` falls back to `allFiles` and returns a third array `paths` (every selected file; folder keys stay inert).
- `MultiFileMenuSelection` gains optional `paths`, used for the menu title count and Copy paths. Stage/Unstage/Discard still act only on the changed subsets.
- CommitPanel unchanged — `paths` defaults to staged ∪ unstaged.

## Tests

- New `src/screens/RepoBrowser.test.tsx`: pure-unmodified multi-select shows real count; mixed selection counts both files and keeps "Stage 1 file". Red before fix, green after.
- `pnpm test` 260/260, `pnpm tsc --noEmit` clean, `pnpm test:e2e` 15/15 spec files passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)