### PR TITLE
feat(ui): app logo on Welcome + titlebar, themeable colors

### DIFF
--- a/src/design/chrome.tsx
+++ b/src/design/chrome.tsx
@@ -1,5 +1,6 @@
 import React, { type CSSProperties, type ReactNode } from "react";
 import { PGIcon, type IconName } from "./icons";
+import { PGLogo } from "./logo";
 import { PGTooltip } from "./primitives";
 import { usePlatform } from "@/lib/platform";
 import { PGWindowControls } from "./window-controls";
@@ -59,7 +60,7 @@ export function PGTitlebar({
           color: "var(--fg-2)",
         }}
       >
-        <PGIcon name="repo" size={13} />
+        <PGLogo size={17} data-testid="pg-app-logo" title="PlatypusGit" />
         <span style={{ color: "var(--fg-0)", fontWeight: 600 }}>{repoName}</span>
         <span style={{ color: "var(--fg-3)" }}>/</span>
         {typeof branch === "string" ? (

--- a/src/design/index.ts
+++ b/src/design/index.ts
@@ -1,4 +1,5 @@
 export * from "./icons";
+export * from "./logo";
 export * from "./primitives";
 export * from "./git-components";
 export * from "./chrome";

--- a/src/design/logo.test.tsx
+++ b/src/design/logo.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { PGLogo } from "./logo";
+
+describe("PGLogo", () => {
+  it("fills the two brand shapes from the themeable --logo / --logo-2 vars", () => {
+    const { container } = render(<PGLogo />);
+    const svg = container.querySelector("svg")!;
+    expect(svg).toBeTruthy();
+    const fills = [...container.querySelectorAll("path")].map((p) =>
+      p.getAttribute("fill"),
+    );
+    // Fills track the theme's logo colors, not hardcoded values.
+    expect(fills).toContain("var(--logo)");
+    expect(fills).toContain("var(--logo-2)");
+  });
+
+  it("honors the size prop", () => {
+    const { container } = render(<PGLogo size={34} />);
+    const svg = container.querySelector("svg")!;
+    expect(svg.getAttribute("width")).toBe("34");
+    expect(svg.getAttribute("height")).toBe("34");
+  });
+
+  it("is decorative (aria-hidden) with no title", () => {
+    const { container } = render(<PGLogo />);
+    const svg = container.querySelector("svg")!;
+    expect(svg.getAttribute("aria-hidden")).toBe("true");
+    expect(svg.getAttribute("role")).toBeNull();
+  });
+
+  it("exposes an accessible image when given a title", () => {
+    const { getByRole } = render(<PGLogo title="PlatypusGit" />);
+    const svg = getByRole("img", { name: "PlatypusGit" });
+    expect(svg.getAttribute("aria-hidden")).toBeNull();
+  });
+
+  it("passes data-testid through to the svg", () => {
+    const { container } = render(<PGLogo data-testid="pg-app-logo" />);
+    expect(container.querySelector('[data-testid="pg-app-logo"]')).toBeTruthy();
+  });
+});

--- a/src/design/logo.tsx
+++ b/src/design/logo.tsx
@@ -1,0 +1,59 @@
+import type { CSSProperties } from "react";
+
+export interface PGLogoProps {
+  size?: number;
+  style?: CSSProperties;
+  className?: string;
+  /** Accessible label. When set, the mark is exposed as an image; otherwise decorative. */
+  title?: string;
+  "data-testid"?: string;
+}
+
+/**
+ * PlatypusGit brand mark — the app logo (see src-tauri/icons/logo.svg): a
+ * platypus face with a teal head and an orange bill.
+ *
+ * The two brand fills are driven by themeable CSS vars — `--logo` (head) and
+ * `--logo-2` (bill), written by the settings store's applyTheme — so the logo
+ * recolors with the active theme and is customizable in the theme editor.
+ * Defaults to the brand teal/orange. The eyes stay dark on both fills.
+ */
+export function PGLogo({
+  size = 16,
+  style,
+  className,
+  title,
+  "data-testid": testId,
+}: PGLogoProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      role={title ? "img" : undefined}
+      aria-label={title}
+      aria-hidden={title ? undefined : true}
+      className={className}
+      data-testid={testId}
+      style={{ flexShrink: 0, ...style }}
+    >
+      {title ? <title>{title}</title> : null}
+      {/* head (primary brand color) */}
+      <path
+        d="M 4 8 Q 4 4 12 4 Q 20 4 20 8 L 20 14 Q 20 15 19 15 L 5 15 Q 4 15 4 14 Z"
+        fill="var(--logo)"
+      />
+      {/* bill (secondary brand color) */}
+      <path
+        d="M 6 13 L 18 13 Q 19 13 19 14 L 18 19 Q 18 20 17 20 L 7 20 Q 6 20 6 19 L 5 14 Q 5 13 6 13 Z"
+        fill="var(--logo-2)"
+      />
+      {/* nostrils */}
+      <rect x="9.5" y="15.5" width="1.2" height="0.8" rx="0.3" fill="#000" opacity="0.35" />
+      <rect x="13.3" y="15.5" width="1.2" height="0.8" rx="0.3" fill="#000" opacity="0.35" />
+      {/* eyes */}
+      <circle cx="9" cy="9" r="0.9" fill="#161a1a" />
+      <circle cx="15" cy="9" r="0.9" fill="#161a1a" />
+    </svg>
+  );
+}

--- a/src/features/settings/useSettingsStore.test.ts
+++ b/src/features/settings/useSettingsStore.test.ts
@@ -63,6 +63,103 @@ describe("useSettingsStore persistence", () => {
   });
 });
 
+describe("logo theme slots", () => {
+  const BRAND_PRIMARY = "#3e9b91";
+  const BRAND_SECONDARY = "#e6a95a";
+
+  it("every builtin theme defaults the logo slots to the brand palette", async () => {
+    const { BUILTIN_THEMES } = await freshStore();
+    for (const t of BUILTIN_THEMES) {
+      expect(t.colors.logo).toBe(BRAND_PRIMARY);
+      expect(t.colors.logo2).toBe(BRAND_SECONDARY);
+    }
+  });
+
+  it("applyTheme writes both logo colors to --logo and --logo-2", async () => {
+    const { applyTheme, BUILTIN_THEMES } = await freshStore();
+    const theme = BUILTIN_THEMES[0];
+    applyTheme(theme);
+    const root = document.documentElement.style;
+    expect(root.getPropertyValue("--logo")).toBe(theme.colors.logo);
+    expect(root.getPropertyValue("--logo-2")).toBe(theme.colors.logo2);
+  });
+
+  it("applyTheme falls back to the brand palette when a theme has no logo colors", async () => {
+    const { applyTheme, BUILTIN_THEMES } = await freshStore();
+    const base = BUILTIN_THEMES[0];
+    const legacy = { ...base, colors: { ...base.colors } };
+    // Simulate a theme persisted before the logo slots existed.
+    delete (legacy.colors as Record<string, unknown>).logo;
+    delete (legacy.colors as Record<string, unknown>).logo2;
+    applyTheme(legacy);
+    const root = document.documentElement.style;
+    expect(root.getPropertyValue("--logo")).toBe(BRAND_PRIMARY);
+    expect(root.getPropertyValue("--logo-2")).toBe(BRAND_SECONDARY);
+  });
+
+  it("backfills the brand palette for persisted custom themes without logo slots", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        activeThemeId: "legacy-custom",
+        customThemes: [
+          {
+            id: "legacy-custom",
+            name: "Legacy",
+            mode: "dark",
+            colors: {
+              bg0: "#111111", bg1: "#161616", bg2: "#1c1c1c", bg3: "#222222",
+              bg4: "#2a2a2a", titlebar: "#141414", fg0: "#eeeeee", fg1: "#cccccc",
+              fg2: "#999999", fg3: "#777777", fg4: "#555555", border0: "#2a2a2a",
+              border1: "#333333", border2: "#444444", accent: "#ff6600",
+              accentInk: "#111111",
+              // no logo / logo2 — pre-existing custom theme
+            },
+          },
+        ],
+      }),
+    );
+    const { useSettingsStore } = await freshStore();
+    const active = useSettingsStore.getState().getActiveTheme();
+    expect(active.colors.logo).toBe(BRAND_PRIMARY);
+    expect(active.colors.logo2).toBe(BRAND_SECONDARY);
+    const root = document.documentElement.style;
+    expect(root.getPropertyValue("--logo")).toBe(BRAND_PRIMARY);
+    expect(root.getPropertyValue("--logo-2")).toBe(BRAND_SECONDARY);
+  });
+
+  it("importThemeJson falls back to the brand palette when the JSON omits logo slots", async () => {
+    const { useSettingsStore } = await freshStore();
+    const json = JSON.stringify({
+      name: "No-logo import",
+      mode: "dark",
+      colors: {
+        bg0: "#111111", bg1: "#161616", bg2: "#1c1c1c", bg3: "#222222",
+        bg4: "#2a2a2a", titlebar: "#141414", fg0: "#eeeeee", fg1: "#cccccc",
+        fg2: "#999999", fg3: "#777777", fg4: "#555555", border0: "#2a2a2a",
+        border1: "#333333", border2: "#444444", accent: "#00cc88",
+        accentInk: "#111111",
+      },
+    });
+    const imported = useSettingsStore.getState().importThemeJson(json);
+    expect(imported.colors.logo).toBe(BRAND_PRIMARY);
+    expect(imported.colors.logo2).toBe(BRAND_SECONDARY);
+  });
+
+  it("editing a logo color on a builtin duplicates and applies the CSS var", async () => {
+    const { useSettingsStore } = await freshStore();
+    useSettingsStore.getState().setActiveThemeId("dark-cool");
+    useSettingsStore.getState().updateActiveColors({ logo: "#abcdef", logo2: "#123456" });
+    const active = useSettingsStore.getState().getActiveTheme();
+    expect(active.builtin).toBeFalsy();
+    expect(active.colors.logo).toBe("#abcdef");
+    expect(active.colors.logo2).toBe("#123456");
+    const root = document.documentElement.style;
+    expect(root.getPropertyValue("--logo")).toBe("#abcdef");
+    expect(root.getPropertyValue("--logo-2")).toBe("#123456");
+  });
+});
+
 describe("uiDensity CSS hook", () => {
   it("applies --row-h from the persisted density at load", async () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiDensity: "comfortable" }));

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -7,6 +7,12 @@ const STORAGE_KEY = "pg-settings-v2";
 // THEME MODEL
 // ═════════════════════════════════════════════════════════════════════════════
 
+// Brand logo colors (src-tauri/icons/logo.svg). Used as the default for every
+// theme's logo slots and as the fallback for themes saved before the slots
+// existed.
+export const LOGO_PRIMARY = "#3e9b91"; // teal head
+export const LOGO_SECONDARY = "#e6a95a"; // orange bill
+
 export interface ThemeColors {
   bg0: string;
   bg1: string;
@@ -24,6 +30,8 @@ export interface ThemeColors {
   border2: string;
   accent: string;
   accentInk: string;
+  logo: string;
+  logo2: string;
 }
 
 export interface ThemeDef {
@@ -37,7 +45,7 @@ export interface ThemeDef {
 export const THEME_COLOR_FIELDS: {
   key: keyof ThemeColors;
   label: string;
-  group: "background" | "foreground" | "border" | "accent";
+  group: "background" | "foreground" | "border" | "accent" | "logo";
   hint?: string;
 }[] = [
   { key: "bg0", label: "Background · base", group: "background", hint: "App canvas / main content area." },
@@ -56,6 +64,8 @@ export const THEME_COLOR_FIELDS: {
   { key: "border2", label: "Border · emphasis", group: "border", hint: "Hovered / focused borders." },
   { key: "accent", label: "Accent", group: "accent", hint: "Primary actions, active tabs, focus rings." },
   { key: "accentInk", label: "Accent · on-ink", group: "accent", hint: "Text drawn *on* accent (buttons)." },
+  { key: "logo", label: "Logo · head", group: "logo", hint: "PlatypusGit mark, head fill — Welcome + titlebar." },
+  { key: "logo2", label: "Logo · bill", group: "logo", hint: "PlatypusGit mark, bill fill." },
 ];
 
 // ─── Built-in themes ─────────────────────────────────────────────────────────
@@ -83,6 +93,8 @@ export const BUILTIN_THEMES: ThemeDef[] = [
       border2: "#515764",
       accent: "#5aa8e8",
       accentInk: "#0e1a26",
+      logo: "#3e9b91",
+      logo2: "#e6a95a",
     },
   },
   {
@@ -107,6 +119,8 @@ export const BUILTIN_THEMES: ThemeDef[] = [
       border2: "#57504a",
       accent: "#e6a050",
       accentInk: "#241607",
+      logo: "#3e9b91",
+      logo2: "#e6a95a",
     },
   },
   {
@@ -131,6 +145,8 @@ export const BUILTIN_THEMES: ThemeDef[] = [
       border2: "#4c4c4c",
       accent: "#7aa7d9",
       accentInk: "#101820",
+      logo: "#3e9b91",
+      logo2: "#e6a95a",
     },
   },
   {
@@ -155,6 +171,8 @@ export const BUILTIN_THEMES: ThemeDef[] = [
       border2: "#b3bac3",
       accent: "#2563c7",
       accentInk: "#ffffff",
+      logo: "#3e9b91",
+      logo2: "#e6a95a",
     },
   },
   {
@@ -179,6 +197,8 @@ export const BUILTIN_THEMES: ThemeDef[] = [
       border2: "#4c566a",
       accent: "#88c0d0",
       accentInk: "#2e3440",
+      logo: "#3e9b91",
+      logo2: "#e6a95a",
     },
   },
   {
@@ -203,6 +223,8 @@ export const BUILTIN_THEMES: ThemeDef[] = [
       border2: "#4b4f65",
       accent: "#bd93f9",
       accentInk: "#282a36",
+      logo: "#3e9b91",
+      logo2: "#e6a95a",
     },
   },
   {
@@ -227,6 +249,8 @@ export const BUILTIN_THEMES: ThemeDef[] = [
       border2: "#1a6379",
       accent: "#268bd2",
       accentInk: "#002b36",
+      logo: "#3e9b91",
+      logo2: "#e6a95a",
     },
   },
   {
@@ -251,6 +275,8 @@ export const BUILTIN_THEMES: ThemeDef[] = [
       border2: "#665c54",
       accent: "#d79921",
       accentInk: "#1d2021",
+      logo: "#3e9b91",
+      logo2: "#e6a95a",
     },
   },
   {
@@ -275,6 +301,8 @@ export const BUILTIN_THEMES: ThemeDef[] = [
       border2: "#8c959f",
       accent: "#0969da",
       accentInk: "#ffffff",
+      logo: "#3e9b91",
+      logo2: "#e6a95a",
     },
   },
 ];
@@ -303,6 +331,10 @@ export function applyTheme(theme: ThemeDef) {
   root.style.setProperty("--border-2", c.border2);
   root.style.setProperty("--accent", c.accent);
   root.style.setProperty("--accent-ink", c.accentInk);
+  // logo colors fall back to the brand palette for themes persisted before the
+  // logo slots existed.
+  root.style.setProperty("--logo", c.logo ?? LOGO_PRIMARY);
+  root.style.setProperty("--logo-2", c.logo2 ?? LOGO_SECONDARY);
   root.style.setProperty("--ring", `0 0 0 2px ${c.accent}80`);
   root.dataset.theme = theme.id;
   root.dataset.themeMode = theme.mode;
@@ -381,6 +413,23 @@ function load(): PersistedState {
         (out as Record<string, unknown>)[key] = parsed[key];
       }
     }
+    // Backfill logo colors for custom themes saved before the slots existed,
+    // so the theme editor and CSS vars always have a value.
+    out.customThemes = out.customThemes.map((t) => {
+      if (!t.colors) return t;
+      const needs =
+        t.colors.logo === undefined || t.colors.logo2 === undefined;
+      return needs
+        ? {
+            ...t,
+            colors: {
+              ...t.colors,
+              logo: t.colors.logo ?? LOGO_PRIMARY,
+              logo2: t.colors.logo2 ?? LOGO_SECONDARY,
+            },
+          }
+        : t;
+    });
     return out;
   } catch {
     return { ...DEFAULTS };
@@ -453,9 +502,16 @@ function validateTheme(obj: unknown): ThemeDef {
   const out: Partial<ThemeColors> = {};
   for (const f of THEME_COLOR_FIELDS) {
     const raw = colors[f.key];
-    if (typeof raw !== "string") throw new Error(`Missing color: ${f.key}`);
+    if (typeof raw !== "string") {
+      // logo slots were added after the first theme format; older exports omit
+      // them. Fall back to the brand palette rather than rejecting the theme.
+      if (f.key === "logo" || f.key === "logo2") continue;
+      throw new Error(`Missing color: ${f.key}`);
+    }
     out[f.key] = sanitizeHex(raw);
   }
+  if (out.logo === undefined) out.logo = LOGO_PRIMARY;
+  if (out.logo2 === undefined) out.logo2 = LOGO_SECONDARY;
   return {
     id: `custom-imported-${Date.now().toString(36)}`,
     name,

--- a/src/index.css
+++ b/src/index.css
@@ -85,6 +85,10 @@
   --accent-5: oklch(0.72 0.15 25);
   --accent-ink: oklch(0.18 0.02 235);
 
+  /* Logo mark fills — themeable brand colors, overridden by applyTheme(). */
+  --logo: #3e9b91;   /* head */
+  --logo-2: #e6a95a; /* bill */
+
   /* ===== SEMANTIC (git states) ===== */
   --git-added: oklch(0.72 0.15 155);
   --git-added-bg: oklch(0.35 0.08 155 / 0.25);

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -801,11 +801,15 @@ function ColorEditor({
   colors: ThemeColors;
   onPatch: (p: Partial<ThemeColors>) => void;
 }) {
-  const groups: Array<{ title: string; group: "background" | "foreground" | "border" | "accent" }> = [
+  const groups: Array<{
+    title: string;
+    group: "background" | "foreground" | "border" | "accent" | "logo";
+  }> = [
     { title: "Backgrounds", group: "background" },
     { title: "Text", group: "foreground" },
     { title: "Borders", group: "border" },
     { title: "Accent", group: "accent" },
+    { title: "Logo", group: "logo" },
   ];
 
   return (

--- a/src/screens/Welcome.test.tsx
+++ b/src/screens/Welcome.test.tsx
@@ -86,6 +86,11 @@ describe("WelcomeScreen", () => {
     expect(useRecentsStore.getState().recents[0]?.path).toBe(chosenPath);
   });
 
+  it("shows the PlatypusGit logo in the hero", () => {
+    render(<WelcomeScreen />);
+    expect(screen.getByTestId("pg-welcome-logo")).toBeInTheDocument();
+  });
+
   it("does nothing when the dialog is cancelled", async () => {
     mockDialogOpen(null);
 

--- a/src/screens/Welcome.tsx
+++ b/src/screens/Welcome.tsx
@@ -1,5 +1,5 @@
 import { open } from "@tauri-apps/plugin-dialog";
-import { PGButton, PGIcon, PGIconButton, PGSpinner } from "@/design";
+import { PGButton, PGIcon, PGIconButton, PGLogo, PGSpinner } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useRecentsStore } from "@/features/repo/useRecentsStore";
 
@@ -53,15 +53,14 @@ export function WelcomeScreen() {
             width: 56,
             height: 56,
             borderRadius: "var(--r-4)",
-            background: "oklch(0.72 0.15 235 / 0.12)",
-            border: "1px solid oklch(0.72 0.15 235 / 0.35)",
+            background: "color-mix(in oklab, var(--logo) 14%, transparent)",
+            border: "1px solid color-mix(in oklab, var(--logo) 38%, transparent)",
             display: "inline-flex",
             alignItems: "center",
             justifyContent: "center",
-            color: "var(--accent)",
           }}
         >
-          <PGIcon name="repo" size={28} />
+          <PGLogo size={34} data-testid="pg-welcome-logo" title="PlatypusGit" />
         </div>
         <div>
           <div


### PR DESCRIPTION
## What

Puts the real PlatypusGit logo (`src-tauri/icons/logo.svg` — teal head, orange bill) into the UI:

- **Welcome screen** — the hero badge is now the logo.
- **Titlebar** — the logo sits in front of the repo name (replacing the generic `repo` icon).

The mark is rendered by a new `PGLogo` design-system component that inlines the logo paths so the two brand fills are driven by CSS vars.

## Themeable colors

The logo's two colors are theme slots:

- `--logo` (head) and `--logo-2` (bill), written by `applyTheme`.
- Every built-in theme defaults them to the brand teal/orange.
- Editable in the theme editor under a new **Logo** group, so any theme can recolor the mark.
- Themes/imports saved before these slots existed fall back to the brand palette (backward-compatible).

## Screenshots (faithful renders of the exact SVG + CSS)

Brand default, light theme, and two custom recolors (purple/pink, green/gold) — proving per-theme customization. Header + hero both shown.

## Testing

- `pnpm tsc --noEmit` — clean
- `pnpm test` — 272 passing (incl. new `PGLogo` + logo-theme-slot + Welcome-placement tests)
- `pnpm test:e2e` — 15/15 spec files passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)