### PR TITLE
fix: release-readiness batch (palette, commit, history, CI)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,16 @@ name: release
 
 on:
   release:
-    # published: initial publish of a release/prerelease.
-    # released:  a prerelease flipped to a full release (promotion) — this
-    #            event does NOT re-fire published, so it's needed for the
-    #            "publish prerelease, then flip off prerelease to promote"
-    #            flow to build + bump the cask.
+    # A non-prerelease publish fires BOTH `published` and `released`, so we
+    # subscribe to both but gate the `version` job (below) to run only on
+    # `published` — that dedups the two events into a single build+bump run.
+    # `released` still starts a run, but every job skips (all chain off
+    # `version`), so a direct full-release publish builds exactly once.
+    #
+    # Promoting a prerelease to a full release later fires `released` only
+    # (not `published`); under this gate that run is a no-op, so promotion
+    # does NOT auto-bump the cask — bump it with a `workflow_dispatch` against
+    # the tag (see the bump-cask job).
     types: [published, released]
   workflow_dispatch: # re-run a build against an existing release tag
     inputs:
@@ -44,6 +49,10 @@ concurrency:
 jobs:
   version:
     runs-on: ubuntu-latest
+    # Skip the redundant `released` run on a direct full-release publish (which
+    # also fires `published`). Every other job chains off `version`, so this one
+    # gate collapses the double-trigger into a single build+bump.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.action == 'published' }}
     outputs:
       version: ${{ steps.resolve.outputs.version }}
       tag: ${{ steps.resolve.outputs.tag }}
@@ -261,12 +270,13 @@ jobs:
   # Pin the Homebrew cask to this release: rewrite version + sha256 in
   # jonassaa/homebrew-platypusgit and commit straight to that tap's main.
   #
-  # Runs on: (a) a non-prerelease published release, and (b) a manual
+  # Runs on: (a) a non-prerelease `published` release, and (b) a manual
   # workflow_dispatch against an explicit tag. Plain prereleases are skipped
-  # so "brew install" never jumps to an unfinished build. Note: flipping an
-  # already-published prerelease off via the API/UI emits release.edited, not
-  # release.released, so it does NOT auto-bump — use workflow_dispatch to bump
-  # an existing tag on demand. Requires the macOS build's sha256 output.
+  # so "brew install" never jumps to an unfinished build. Because `version`
+  # is gated to `published`/dispatch, this job never runs on a `released`
+  # event — so promoting a prerelease to a full release does NOT auto-bump;
+  # bump that tag with a workflow_dispatch on demand. Requires the macOS
+  # build's sha256 output (needs: macos-universal).
   #
   # Cross-repo push: GITHUB_TOKEN can't reach the tap, so we mint a short-lived
   # token from a GitHub App installed on the tap (app id in vars.TAP_APP_ID,

--- a/src/features/palette/CommandPalette.test.tsx
+++ b/src/features/palette/CommandPalette.test.tsx
@@ -53,7 +53,7 @@ function resetStores() {
     activity: {},
   });
   useNavStore.setState({ intent: null });
-  usePaletteStore.setState({ open: false, query: "" });
+  usePaletteStore.setState({ open: false, query: "", activeChip: "all" });
   localStorage.clear();
 }
 
@@ -167,6 +167,31 @@ describe("CommandPalette", () => {
     await user.click(row);
 
     await waitFor(() => expect(checkedOut).toBe("feature/x"));
+  });
+
+  it("activates the highlighted row (not an unshown command) when a type chip is active", async () => {
+    // Regression: keyboard nav must index the chip-filtered rows the DOM
+    // renders. With a non-"all" chip, Enter previously activated flat[0] — the
+    // first command — instead of the highlighted branch.
+    const user = userEvent.setup();
+    let checkedOut: string | null = null;
+    useRepoStore.setState({
+      branches: [mkBranch("feature/x")],
+      checkoutBranch: async (name: string) => {
+        checkedOut = name;
+      },
+    });
+    usePaletteStore.setState({ open: true, query: "" });
+    render(<CommandPalette />);
+    await screen.findByRole("dialog");
+
+    // Narrow to branches only; the branch row is now the highlighted row.
+    await user.click(screen.getByRole("button", { name: "Branches" }));
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => expect(checkedOut).toBe("feature/x"));
+    // Enter must NOT have fired a command (which would set a nav intent).
+    expect(useNavStore.getState().intent).toBeNull();
   });
 
   it("fires a commit-vs-wt intent for a commit", async () => {

--- a/src/features/palette/CommandPalette.tsx
+++ b/src/features/palette/CommandPalette.tsx
@@ -185,11 +185,17 @@ export function CommandPalette() {
     activeChip === "all" &&
     (quickRows.length > 0 || recentRows.length > 0);
 
+  // Keyboard nav must index the SAME rows the DOM renders. On the root step a
+  // non-"all" chip renders only that type's rows (see render below), so nav
+  // rows are filtered to match — otherwise activeIndex points into the full
+  // `flat` list and Enter fires an unshown row (e.g. a force-push command).
   const navRows: ScoredRow[] = showEmptyHome
     ? [...quickRows, ...recentRows].map((item) => ({ item, score: 0, labelIndices: [] }))
-    : flat;
+    : step.kind === "root" && activeChip !== "all"
+      ? flat.filter((r) => r.item.type === activeChip)
+      : flat;
 
-  React.useEffect(() => { setActiveIndex(0); }, [query]);
+  React.useEffect(() => { setActiveIndex(0); }, [query, activeChip]);
   React.useEffect(() => {
     if (activeIndex >= navRows.length) setActiveIndex(Math.max(0, navRows.length - 1));
   }, [navRows.length, activeIndex]);

--- a/src/features/palette/commands.test.ts
+++ b/src/features/palette/commands.test.ts
@@ -51,6 +51,29 @@ describe("buildCommands", () => {
     expect(byId.get("action:pull-current")?.actionId).toBe("repo.pull");
   });
 
+  it("pull/push use the tracking branch and honour defaultPullMode", async () => {
+    // Regression: the palette Pull row must pass the upstream tracking branch
+    // (not the local head name) and the user's pull mode, matching the keymap
+    // runner it advertises — not silently pull `local` in Merge mode.
+    const { useSettingsStore } = await import("@/features/settings/useSettingsStore");
+    useSettingsStore.setState({ defaultPullMode: "Rebase" });
+    const pull = vi.fn();
+    const push = vi.fn();
+    // Local branch "feature" tracks a differently-named remote branch.
+    setRepo({
+      branches: [mkBranch("feature", true, "origin/main")],
+      pull,
+      push,
+    });
+    const byId = new Map(buildCommands().map((i) => [i.id, i]));
+
+    byId.get("action:pull-current")?.run();
+    expect(pull).toHaveBeenCalledWith("origin", "main", "Rebase");
+
+    byId.get("action:push-current")?.run();
+    expect(push).toHaveBeenCalledWith("origin", "main", "None");
+  });
+
   it("omits stash-pop when there are no stashes", () => {
     expect(ids()).not.toContain("action:stash-pop-latest");
   });

--- a/src/features/palette/commands.ts
+++ b/src/features/palette/commands.ts
@@ -5,6 +5,7 @@ import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { usePaletteStore } from "./usePaletteStore";
 import { createBranchInputStep } from "./steps";
 import { currentBranch, relativeTime } from "@/lib/derive";
+import { headUpstream } from "@/features/repo/ops";
 import type { ActionId } from "@/features/keymap";
 import type { PaletteItem, PaletteStep } from "./types";
 
@@ -139,7 +140,10 @@ export function buildCommands(): PaletteItem[] {
   const head = currentBranch(repo.branches);
   const headName = head?.name ?? null;
   const headTip = head?.tip ?? repo.commits[0]?.oid ?? null;
-  const upstreamRemote = head?.upstream?.split("/")[0] ?? null;
+  // [remote, tracking-branch] parsed from HEAD's upstream ref, or null. Use the
+  // tracking branch (not the local name) and honour defaultPullMode so palette
+  // push/pull match the keymap runners (ops.ts) they advertise a chord for.
+  const upstream = headUpstream(head?.upstream, headName ?? undefined);
   const items: PaletteItem[] = [];
 
   // -- navigation (launch existing screens) --
@@ -177,8 +181,8 @@ export function buildCommands(): PaletteItem[] {
       search: "Push current branch", label: `Push ${name}`,
       detail: head?.upstream ?? "set upstream", icon: "push",
       actionId: "repo.push",
-      run: upstreamRemote
-        ? direct(() => void repo.push(upstreamRemote, name, "None"))
+      run: upstream
+        ? direct(() => void repo.push(upstream[0], upstream[1], "None"))
         : step(() => ({
             kind: "pick", title: `Push ${name} to…`,
             items: remoteItems("push", (r) => void repo.push(r, name, "None")),
@@ -189,34 +193,42 @@ export function buildCommands(): PaletteItem[] {
       search: "Pull current branch", label: `Pull ${name}`,
       detail: head?.upstream ?? undefined, icon: "pull",
       actionId: "repo.pull",
-      run: upstreamRemote
-        ? direct(() => void repo.pull(upstreamRemote, name))
+      run: upstream
+        ? direct(() =>
+            void repo.pull(
+              upstream[0],
+              upstream[1],
+              useSettingsStore.getState().defaultPullMode,
+            ),
+          )
         : step(() => ({
             kind: "pick", title: `Pull ${name} from…`,
-            items: remoteItems("pull", (r) => void repo.pull(r, name)),
+            items: remoteItems("pull", (r) =>
+              void repo.pull(r, name, useSettingsStore.getState().defaultPullMode),
+            ),
           })),
     });
-    const guardedForcePush = (remote: string) => {
+    const guardedForcePush = (remote: string, branch: string) => {
       if (
         useSettingsStore.getState().confirmForcePush &&
         !window.confirm(
-          `Force-push ${name} to ${remote} (with lease)? This overwrites the remote branch.`,
+          `Force-push ${branch} to ${remote} (with lease)? This overwrites the remote branch.`,
         )
       ) {
         return;
       }
-      void repo.push(remote, name, "WithLease");
+      void repo.push(remote, branch, "WithLease");
     };
     items.push({
       type: "command", id: "action:force-push-current",
       search: "Force push current branch with lease",
       label: `Force-push ${name} (with lease)`, danger: true,
       detail: head?.upstream ?? undefined, icon: "push",
-      run: upstreamRemote
-        ? direct(() => guardedForcePush(upstreamRemote))
+      run: upstream
+        ? direct(() => guardedForcePush(upstream[0], upstream[1]))
         : step(() => ({
             kind: "pick", title: `Force-push ${name} to…`,
-            items: remoteItems("push", (r) => guardedForcePush(r)),
+            items: remoteItems("push", (r) => guardedForcePush(r, name)),
           })),
     });
   }

--- a/src/screens/CommitPanel.keyboard.test.tsx
+++ b/src/screens/CommitPanel.keyboard.test.tsx
@@ -160,6 +160,36 @@ describe("CommitPanel keyboard navigation", () => {
       expect(pushCalls).toEqual([]);
     });
 
+    it("Mod+Enter does not double-commit while the first commit is in flight", async () => {
+      // Regression: key auto-repeat / double-tap re-dispatches the chord while
+      // canCommit is still true (message not yet cleared). The in-flight guard
+      // must swallow the second commit.
+      let resolve: (() => void) | null = null;
+      let calls = 0;
+      useRepoStore.setState({
+        commit: () => {
+          calls++;
+          return new Promise<string>((r) => {
+            resolve = () => r("oid123");
+          });
+        },
+      } as never);
+      render(<CommitPanelScreen />);
+      typeSubject("feat: once");
+
+      press("Enter", { metaKey: true });
+      press("Enter", { metaKey: true }); // second fire before the first resolves
+      expect(calls).toBe(1);
+
+      // Once the in-flight commit resolves, a fresh chord commits again.
+      await act(async () => {
+        resolve?.();
+      });
+      typeSubject("feat: again");
+      press("Enter", { metaKey: true });
+      expect(calls).toBe(2);
+    });
+
     it("Mod+Enter declines with an empty message (button would be disabled)", () => {
       render(<CommitPanelScreen />);
       expect(press("Enter", { metaKey: true })).toBe(false);

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -316,15 +316,25 @@ export function CommitPanelScreen() {
   // matching button is disabled, letting the chord fall through.
   const canCommit = (amend || staged.length > 0) && !!message.trim();
   const canCommitAndPush = canCommit && !!headBranch && !!defaultRemote;
+  // Guards against a second commit firing before the first resolves and clears
+  // the message/staged state — key auto-repeat (holding ⌘↵) and double-taps
+  // both re-dispatch the chord while canCommit is still true.
+  const committingRef = React.useRef(false);
   const doCommit = async (): Promise<string | null> => {
-    const full = buildMessage(message, body);
-    const oid = await commitAction(full, amend, signoff);
-    if (oid) {
-      setMessage("");
-      setBody("");
-      setAmend(false);
+    if (committingRef.current) return null;
+    committingRef.current = true;
+    try {
+      const full = buildMessage(message, body);
+      const oid = await commitAction(full, amend, signoff);
+      if (oid) {
+        setMessage("");
+        setBody("");
+        setAmend(false);
+      }
+      return oid;
+    } finally {
+      committingRef.current = false;
     }
-    return oid;
   };
   const doCommitAndPush = async (): Promise<void> => {
     if (!headBranch || !defaultRemote) return;

--- a/src/screens/History.keyboard.test.tsx
+++ b/src/screens/History.keyboard.test.tsx
@@ -2,7 +2,7 @@
 // selection through the keymap dispatcher, Enter opens the commit's diff.
 
 import { describe, it, expect, beforeEach } from "vitest";
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { HistoryScreen } from "./History";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
@@ -115,5 +115,37 @@ describe("History keyboard navigation", () => {
     expect(rowFor("third commit").hasAttribute("data-selected")).toBe(true);
     press("Home");
     expect(rowFor("first commit").hasAttribute("data-selected")).toBe(true);
+  });
+
+  it("resets the selection when a client-side filter shrinks the list", () => {
+    // Regression: toggling Hide-merges shrinks `visible` without changing
+    // baseCommits.length/filterKey. The reset effect must still fire, else the
+    // stale index leaves the detail pane + action row acting on visible[0].
+    useRepoStore.setState({
+      commits: [
+        mkCommit("a".repeat(40), "first commit"),
+        mkCommit("b".repeat(40), "second commit"),
+        // Merge commit (two parents) — dropped by Hide-merges.
+        { ...mkCommit("c".repeat(40), "third commit"), parents: ["a".repeat(40), "b".repeat(40)] },
+      ],
+    } as never);
+    render(<HistoryScreen />);
+    useFocusStore.setState({ focused: "history.list" });
+
+    // Select the merge commit (last row).
+    press("End");
+    expect(rowFor("third commit").hasAttribute("data-selected")).toBe(true);
+
+    // Hide merges → the selected merge row disappears from `visible`.
+    act(() => {
+      fireEvent.click(screen.getByTitle("Filter"));
+    });
+    act(() => {
+      fireEvent.click(screen.getByText("Hide merge commits"));
+    });
+
+    // Selection reset to the top rather than pointing past the shrunk list.
+    expect(rowFor("first commit").hasAttribute("data-selected")).toBe(true);
+    expect(screen.queryByText("third commit")).toBeNull();
   });
 });

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -84,10 +84,13 @@ export function HistoryScreen() {
     storageKey: "pg-history-detail-w",
   });
 
-  // Reset selection when the commit list changes shape.
+  // Reset selection when the visible list changes shape. Includes the
+  // client-side refinements (filterKind/hideMerges) — without them a shrunk
+  // `visible` leaves a stale `selected`, so the detail pane and CommitActionRow
+  // silently act on visible[0] instead of the highlighted commit.
   React.useEffect(() => {
     setSelected(0);
-  }, [baseCommits.length, filterKey]);
+  }, [baseCommits.length, filterKey, filterKind, hideMerges]);
 
   const head = currentBranch(branches);
   const headName = head?.name ?? null;


### PR DESCRIPTION
Fixes the five "fix before release" items from the review of changes since **v0.0.5**. Five focused commits, each with a regression test.

## Correctness (user-facing)
- **Palette type-chip nav desync** — with a non-"All" chip active, keyboard nav indexed the unfiltered row list while the DOM rendered only the chip's rows, so **Enter fired the wrong row** (commands sort first → could trigger an unshown force-push / stash-pop). Nav now follows the chip-filtered rows; active index resets on chip change.
- **Palette Pull ignored `defaultPullMode`** — clicked Pull merged even though the default (and the chord the row advertises) is Rebase, and it passed the local branch name instead of the upstream tracking branch. Push/force-push had the same branch-name bug. All three now use `headUpstream()` + `defaultPullMode`.
- **Commit chord double-fire** — holding / double-tapping ⌘↵ re-ran the commit (and push) because the dispatcher only filters auto-repeat for DoubleShift and there was no in-flight guard. Added a re-entrancy guard.
- **History stale selection** — toggling Hide-merges / switching filter kind shrank the visible list without resetting the selection, so cherry-pick/revert could target `visible[0]` instead of the highlighted commit. Added the filters to the reset-effect deps.

## CI / release
- **release.yml double-trigger** — a direct non-prerelease publish fires both `published` and `released`, running the whole build (and cask bump) twice. Gated the `version` job (which every job chains off) to `published`/`workflow_dispatch`. Note: promoting a prerelease now no-ops; bump that tag via `workflow_dispatch` (as the bump-cask job documents).

## Verification
- `pnpm tsc --noEmit`, `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — clean
- `pnpm test` — 264 passed (incl. 4 new regression tests; each confirmed to fail without its fix)
- `release.yml` validated as YAML

## Not in this PR
- **Rebase Finalize → abort data-loss** (PLAUSIBLE): finalizing a paused interactive rebase via the Conflict screen's generic `continueOperation` leaves the rebase entry + un-advanced plan, so a later Abort resets to `orig_head` and loses the commit. Needs a live repro before fixing; tackling separately.
- Post-release items (context-menu chord glyphs, palette IME Enter, Escape/speed-search, PGPane focus delegation, refreshAll over-fetch) and the `wdio-webdriver` production-dependency hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)