### PR TITLE
feat(cli): launch from terminal with pgit [subcommand] [path]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Context for future Claude sessions working on this repo. Keep it current when ar
 New feature beyond MVP slice → write new spec + plan under these folders first.
 
 Recent specs/plans (for context on current direction):
+- `2026-07-07-cli-launch-*` — `pgit` CLI launch, single-instance forwarding, shim install (#25).
 - `2026-07-06-keymap-power-shortcuts-*` — speed-search, commit chords, F7 hunk nav.
 - `2026-07-03-ref-scoped-log-*` — History ref selector; log walk from any revspec (#27).
 - `2026-07-03-e2e-phase3-*` — e2e phase 3: remote/palette/settings coverage, dead-settings audit.
@@ -86,6 +87,10 @@ Four layers, each run independently:
   - Debug builds serve WebDriver on port 4445: close any `pnpm tauri dev`
     instance before e2e runs or the runner may attach to it and clear its
     `localStorage`.
+  - `e2e/wdio.conf.ts` sets `PLATYPUSGIT_NO_SINGLE_INSTANCE=1` before the app
+    launches — without it, `tauri-plugin-single-instance` would forward a
+    test binary's launch into any already-running platypusgit instance
+    instead of serving WebDriver.
 
 ## Architecture
 
@@ -95,6 +100,9 @@ Four layers, each run independently:
 error.rs         AppError enum (thiserror + serde-tagged) — ONLY error type crossing IPC
 state.rs         AppState { backend: Arc<dyn GitBackend> }
 lib.rs           Tauri builder + invoke_handler! registry (all commands listed there)
+cli.rs           CLI arg parsing (LaunchIntent, parse_args, resolve_repo_root),
+                 shim install/status helpers (install_shim, shim_status) —
+                 not to be confused with git/cli.rs (CliBackend) below
 git/
 ├── mod.rs       GitBackend trait — every git op, returns AppResult<T>
 ├── types.rs     RepoHandle, FileStatus, CommitInfo, BranchInfo, TagInfo, StashInfo,
@@ -106,6 +114,7 @@ git/
 commands/        Thin Tauri handlers, one file per area:
 ├── repo.rs        open_repo, get_status, list_all_files, read_file_content,
 │                  append_gitignore, open_in_editor
+├── cli.rs         take_launch_intent, cli_shim_status, install_cli_shim
 ├── commits.rs     get_log, commit, file_history
 ├── diff.rs        get_diff, stage/unstage/discard_paths, stage/unstage/discard_hunk,
 │                  diff_commits, blame_file
@@ -165,7 +174,10 @@ features/            Per-feature: components + Zustand store colocated
 │                    usePaneList (list nav + type-to-jump speed-search),
 │                    useHunkNav (F7/⇧F7 diff hunks), useSpeedSearchStore,
 │                    PGPane / FocusableScroll / CheatSheet
-└── diff/            diff-specific components
+├── diff/            diff-specific components
+└── cli/             useCliLaunch — takes the stashed first-launch intent +
+                     listens for forwarded `cli-launch` events, drives
+                     openRepo + nav screen-switch intent
 
 lib/
 ├── tauri.ts         Typed invoke() wrappers — frontend NEVER calls invoke() directly

--- a/README.md
+++ b/README.md
@@ -22,6 +22,39 @@ A dev-first alternative to TortoiseGit with "extreme usability" as the north sta
 - **Conflict resolution** — 3-way sides, accept ours/theirs, external mergetool, continue/abort
 - **Interactive rebase** — pick/reword/edit/squash/fixup/drop, continue/abort, base picker
 - **Remotes & network** — add/remove/rename/prune remotes, fetch/pull/push (with-lease/force), merge
+- **CLI launch** — `pgit` shim opens the app on a repo/screen from the terminal, single-instance forwarding to a running window
+
+## CLI
+
+Install the `pgit` shim once (Settings → Command line → Install), or link it
+manually:
+
+```bash
+sudo ln -sf <app-binary> /usr/local/bin/pgit   # macOS
+ln -sf <app-binary> ~/.local/bin/pgit          # Linux
+```
+
+(Windows: shim install isn't supported yet.)
+
+```bash
+pgit                    # plain launch — last persisted repo/screen
+pgit .                  # open repo containing cwd
+pgit ~/dev/foo          # open repo containing that path
+pgit commit             # open cwd repo, land on Commit panel
+pgit log src/           # open repo containing src/, land on History
+pgit --help             # print usage, no window
+```
+
+| subcommand | screen |
+|---|---|
+| `commit`, `status` | Commit panel |
+| `log`, `history` | History |
+| `branches` | Branches |
+
+A bare path (no recognized subcommand) just opens that repo, keeping the
+current screen. If the app is already running, a second `pgit …` invocation
+doesn't spawn another instance — it forwards the request to the running
+window, focuses it, and navigates there.
 
 ## Install
 

--- a/docs/superpowers/plans/2026-07-07-cli-launch.md
+++ b/docs/superpowers/plans/2026-07-07-cli-launch.md
@@ -1,0 +1,1120 @@
+# CLI Launch Capability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `pgit [subcommand] [path]` launches PlatypusGit with the right repo open and the right screen showing; a second invocation forwards to the running instance instead of spawning a new one.
+
+**Architecture:** The app binary itself parses argv into a `LaunchIntent` (pure Rust module, unit-tested). First launch stashes the intent in managed state; the webview pulls it once via a `take_launch_intent` command. Later invocations are intercepted by `tauri-plugin-single-instance`, which forwards argv+cwd to the running process; it emits a `cli-launch` event to the webview and focuses the window. A Settings section installs `pgit` as a symlink to the current executable.
+
+**Tech Stack:** Rust (tauri 2, tauri-plugin-single-instance 2, git2), React/TS, Zustand, vitest + RTL.
+
+**Spec:** `docs/superpowers/specs/2026-07-07-cli-launch-design.md`
+
+## Global Constraints
+
+- Branch `feat/cli-launch`; never commit to `main`; Conventional Commits.
+- Every IPC-crossing Rust fn returns `AppResult<T>`; no unwrap/panic in commands.
+- No new `AppError` variants needed (shim-install permission failure is a structured outcome, not an error).
+- Serde structs crossing IPC use `#[serde(rename_all = "camelCase")]`; TS types in `src/lib/types.ts` mirror them exactly.
+- Frontend never calls `invoke()` directly — wrappers in `src/lib/tauri.ts`.
+- Prepend `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"` to every `pnpm`/`cargo` command.
+- Screen ids are the frontend `ScreenId` strings: `commit`, `history`, `branches`.
+- Shim name is `pgit`; locations: macOS `/usr/local/bin/pgit`, Linux `~/.local/bin/pgit`, Windows unsupported.
+- Env var `PLATYPUSGIT_NO_SINGLE_INSTANCE=1` must skip the single-instance plugin (e2e + parallel dev instances).
+
+---
+
+### Task 1: Rust CLI arg parsing (`src-tauri/src/cli.rs`)
+
+**Files:**
+- Create: `src-tauri/src/cli.rs`
+- Modify: `src-tauri/src/lib.rs` (add `pub mod cli;` only)
+- Test: inline `#[cfg(test)] mod tests` in `src-tauri/src/cli.rs`
+
+**Interfaces:**
+- Produces: `cli::LaunchIntent { path: Option<PathBuf>, screen: Option<String> }` (Serialize, camelCase), `cli::Parsed { Help, Launch(Option<LaunchIntent>) }`, `cli::parse_args(args: &[String], cwd: &Path) -> Parsed`, `cli::resolve_repo_root(intent: LaunchIntent) -> LaunchIntent`, `cli::USAGE: &str`. Tasks 3 consumes all of these.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src-tauri/src/cli.rs` with the test module first (types/fns referenced but unimplemented won't compile — that's the TDD "red" for Rust; write the minimal type/fn signatures with `todo!()` bodies so tests compile, then watch them fail):
+
+```rust
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+/// What a CLI invocation asked for. `path` is absolute (resolved against the
+/// invoking shell's cwd); `screen` is a frontend ScreenId string.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LaunchIntent {
+    pub path: Option<PathBuf>,
+    pub screen: Option<String>,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Parsed {
+    Help,
+    /// `None` = plain app launch (no CLI args at all).
+    Launch(Option<LaunchIntent>),
+}
+
+pub const USAGE: &str = "\
+PlatypusGit
+
+Usage: pgit [subcommand] [path]
+
+Subcommands:
+  commit | status    open the Commit panel
+  log | history      open the History screen
+  branches           open the Branches screen
+
+With a path and no subcommand, opens the repo containing that path.
+With a subcommand and no path, uses the current directory.
+With no arguments, performs a plain app launch.
+";
+
+pub fn parse_args(args: &[String], cwd: &Path) -> Parsed {
+    todo!()
+}
+
+pub fn resolve_repo_root(intent: LaunchIntent) -> LaunchIntent {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(v: &[&str]) -> Vec<String> {
+        v.iter().map(|x| x.to_string()).collect()
+    }
+
+    #[test]
+    fn bare_launch_has_no_intent() {
+        assert_eq!(parse_args(&[], Path::new("/w")), Parsed::Launch(None));
+    }
+
+    #[test]
+    fn help_flag_wins() {
+        assert_eq!(parse_args(&s(&["--help"]), Path::new("/w")), Parsed::Help);
+        assert_eq!(parse_args(&s(&["commit", "-h"]), Path::new("/w")), Parsed::Help);
+    }
+
+    #[test]
+    fn path_only_opens_repo_without_screen() {
+        assert_eq!(
+            parse_args(&s(&["/abs/repo"]), Path::new("/w")),
+            Parsed::Launch(Some(LaunchIntent {
+                path: Some(PathBuf::from("/abs/repo")),
+                screen: None,
+            }))
+        );
+    }
+
+    #[test]
+    fn relative_path_resolves_against_cwd() {
+        assert_eq!(
+            parse_args(&s(&["sub/dir"]), Path::new("/w")),
+            Parsed::Launch(Some(LaunchIntent {
+                path: Some(PathBuf::from("/w/sub/dir")),
+                screen: None,
+            }))
+        );
+    }
+
+    #[test]
+    fn subcommand_without_path_uses_cwd() {
+        for (cmd, screen) in [
+            ("commit", "commit"),
+            ("status", "commit"),
+            ("log", "history"),
+            ("history", "history"),
+            ("branches", "branches"),
+        ] {
+            assert_eq!(
+                parse_args(&s(&[cmd]), Path::new("/w")),
+                Parsed::Launch(Some(LaunchIntent {
+                    path: Some(PathBuf::from("/w")),
+                    screen: Some(screen.to_string()),
+                })),
+                "subcommand {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn subcommand_with_path() {
+        assert_eq!(
+            parse_args(&s(&["log", "src"]), Path::new("/w")),
+            Parsed::Launch(Some(LaunchIntent {
+                path: Some(PathBuf::from("/w/src")),
+                screen: Some("history".to_string()),
+            }))
+        );
+    }
+
+    #[test]
+    fn unknown_first_token_is_a_path() {
+        assert_eq!(
+            parse_args(&s(&["foo"]), Path::new("/w")),
+            Parsed::Launch(Some(LaunchIntent {
+                path: Some(PathBuf::from("/w/foo")),
+                screen: None,
+            }))
+        );
+    }
+
+    #[test]
+    fn resolve_repo_root_finds_workdir_from_subdir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        git2::Repository::init(&root).unwrap();
+        let sub = root.join("a/b");
+        std::fs::create_dir_all(&sub).unwrap();
+        let out = resolve_repo_root(LaunchIntent {
+            path: Some(sub),
+            screen: None,
+        });
+        assert_eq!(out.path, Some(root));
+    }
+
+    #[test]
+    fn resolve_repo_root_passes_non_repo_through() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("nowhere");
+        let out = resolve_repo_root(LaunchIntent {
+            path: Some(p.clone()),
+            screen: Some("commit".into()),
+        });
+        assert_eq!(out.path, Some(p));
+        assert_eq!(out.screen, Some("commit".to_string()));
+    }
+}
+```
+
+Add `pub mod cli;` to the module list at the top of `src-tauri/src/lib.rs`.
+
+Note: `tempfile = "3"` is already in `[dev-dependencies]`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH" && cargo test --manifest-path src-tauri/Cargo.toml cli::`
+Expected: FAIL — panics with `not yet implemented` (the `todo!()`s).
+
+- [ ] **Step 3: Implement**
+
+Replace the two `todo!()` bodies:
+
+```rust
+fn screen_for(token: &str) -> Option<&'static str> {
+    match token {
+        "commit" | "status" => Some("commit"),
+        "log" | "history" => Some("history"),
+        "branches" => Some("branches"),
+        _ => None,
+    }
+}
+
+fn resolve_path(arg: &str, cwd: &Path) -> PathBuf {
+    let p = PathBuf::from(arg);
+    if p.is_absolute() {
+        p
+    } else {
+        cwd.join(p)
+    }
+}
+
+/// Parse CLI args (argv without the binary name). Pure — no filesystem
+/// access; relative paths resolve against `cwd`.
+pub fn parse_args(args: &[String], cwd: &Path) -> Parsed {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        return Parsed::Help;
+    }
+    let mut screen: Option<String> = None;
+    let mut path: Option<PathBuf> = None;
+    for (i, arg) in args.iter().enumerate() {
+        if i == 0 {
+            if let Some(s) = screen_for(arg) {
+                screen = Some(s.to_string());
+                continue;
+            }
+        }
+        if path.is_none() {
+            path = Some(resolve_path(arg, cwd));
+        }
+    }
+    if screen.is_some() && path.is_none() {
+        path = Some(cwd.to_path_buf());
+    }
+    match (path, &screen) {
+        (None, None) => Parsed::Launch(None),
+        (path, _) => Parsed::Launch(Some(LaunchIntent { path, screen })),
+    }
+}
+
+/// Widen a CLI path to its repo workdir root (backend `open` requires the
+/// root, CLI users sit in subdirectories). Non-repo paths pass through so
+/// the normal open_repo error path reports NotARepo.
+pub fn resolve_repo_root(intent: LaunchIntent) -> LaunchIntent {
+    let path = intent.path.map(|p| {
+        git2::Repository::discover(&p)
+            .ok()
+            .and_then(|r| r.workdir().map(PathBuf::from))
+            .unwrap_or(p)
+    });
+    LaunchIntent { path, ..intent }
+}
+```
+
+Gotcha: the `resolve_repo_root_finds_workdir_from_subdir` test canonicalizes the tempdir (macOS `/tmp` → `/private/tmp` symlink) and asserts against `workdir()` — `Repository::discover` returns the canonical path, and `workdir()` returns a trailing-slash-free `PathBuf`. If the assertion fails on a trailing slash, canonicalize both sides in the test rather than changing the production code.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH" && cargo test --manifest-path src-tauri/Cargo.toml cli::`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/cli.rs src-tauri/src/lib.rs
+git commit -m "feat(cli): parse pgit argv into launch intents"
+```
+
+---
+
+### Task 2: Shim install + status logic (pure part of `cli.rs`)
+
+**Files:**
+- Modify: `src-tauri/src/cli.rs` (append)
+- Test: same inline `tests` module
+
+**Interfaces:**
+- Produces: `cli::CliShimStatus { installed: bool, shim_path: String, target: String }` (Serialize, camelCase), `cli::CliInstallOutcome { installed: bool, path: String, manual_command: Option<String> }` (Serialize, camelCase), `cli::shim_status() -> CliShimStatus`, `cli::install_shim() -> CliInstallOutcome`, plus dir-parameterized internals `install_shim_at(dir, exe)` / `shim_installed_at(dir, exe)`. Task 3 wraps the two public fns in commands.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `tests` module in `src-tauri/src/cli.rs`:
+
+```rust
+    #[cfg(unix)]
+    #[test]
+    fn install_shim_creates_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe = dir.path().join("platypusgit");
+        std::fs::write(&exe, b"#!/bin/sh\n").unwrap();
+        let link = install_shim_at(dir.path(), &exe).unwrap();
+        assert_eq!(link, dir.path().join("pgit"));
+        assert_eq!(std::fs::read_link(&link).unwrap(), exe);
+        assert!(shim_installed_at(dir.path(), &exe));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn install_shim_replaces_stale_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let old = dir.path().join("old-exe");
+        let new = dir.path().join("new-exe");
+        std::fs::write(&old, b"x").unwrap();
+        std::fs::write(&new, b"x").unwrap();
+        install_shim_at(dir.path(), &old).unwrap();
+        assert!(!shim_installed_at(dir.path(), &new));
+        install_shim_at(dir.path(), &new).unwrap();
+        assert_eq!(std::fs::read_link(dir.path().join("pgit")).unwrap(), new);
+        assert!(shim_installed_at(dir.path(), &new));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shim_not_installed_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!shim_installed_at(dir.path(), Path::new("/x")));
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH" && cargo test --manifest-path src-tauri/Cargo.toml cli::`
+Expected: compile error — `install_shim_at` / `shim_installed_at` not found.
+
+- [ ] **Step 3: Implement**
+
+Append to `src-tauri/src/cli.rs` (above the tests module):
+
+```rust
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliShimStatus {
+    pub installed: bool,
+    pub shim_path: String,
+    pub target: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliInstallOutcome {
+    pub installed: bool,
+    pub path: String,
+    /// Set when we couldn't write the symlink (permissions): the command the
+    /// user should run themselves. Not an error — Settings renders it.
+    pub manual_command: Option<String>,
+}
+
+/// Where the `pgit` shim goes. None on unsupported platforms (Windows).
+pub fn default_shim_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        Some(PathBuf::from("/usr/local/bin"))
+    }
+    #[cfg(target_os = "linux")]
+    {
+        std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/bin"))
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        None
+    }
+}
+
+#[cfg(unix)]
+pub fn install_shim_at(dir: &Path, exe: &Path) -> std::io::Result<PathBuf> {
+    std::fs::create_dir_all(dir)?;
+    let link = dir.join("pgit");
+    if link.symlink_metadata().is_ok() {
+        std::fs::remove_file(&link)?;
+    }
+    std::os::unix::fs::symlink(exe, &link)?;
+    Ok(link)
+}
+
+#[cfg(unix)]
+pub fn shim_installed_at(dir: &Path, exe: &Path) -> bool {
+    std::fs::read_link(dir.join("pgit"))
+        .map(|target| target == exe)
+        .unwrap_or(false)
+}
+
+pub fn shim_status() -> CliShimStatus {
+    let exe = std::env::current_exe().unwrap_or_default();
+    let dir = default_shim_dir();
+    let shim_path = dir
+        .as_deref()
+        .map(|d| d.join("pgit").display().to_string())
+        .unwrap_or_default();
+    #[cfg(unix)]
+    let installed = dir.as_deref().is_some_and(|d| shim_installed_at(d, &exe));
+    #[cfg(not(unix))]
+    let installed = false;
+    CliShimStatus {
+        installed,
+        shim_path,
+        target: exe.display().to_string(),
+    }
+}
+
+pub fn install_shim() -> CliInstallOutcome {
+    let exe = std::env::current_exe().unwrap_or_default();
+    let Some(dir) = default_shim_dir() else {
+        return CliInstallOutcome {
+            installed: false,
+            path: String::new(),
+            manual_command: None,
+        };
+    };
+    let link_display = dir.join("pgit").display().to_string();
+    #[cfg(unix)]
+    {
+        match install_shim_at(&dir, &exe) {
+            Ok(link) => CliInstallOutcome {
+                installed: true,
+                path: link.display().to_string(),
+                manual_command: None,
+            },
+            Err(_) => CliInstallOutcome {
+                installed: false,
+                path: link_display.clone(),
+                manual_command: Some(format!(
+                    "sudo ln -sf \"{}\" \"{}\"",
+                    exe.display(),
+                    link_display
+                )),
+            },
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        CliInstallOutcome {
+            installed: false,
+            path: link_display,
+            manual_command: None,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH" && cargo test --manifest-path src-tauri/Cargo.toml cli::`
+Expected: PASS (12 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/cli.rs
+git commit -m "feat(cli): pgit shim install and status detection"
+```
+
+---
+
+### Task 3: Wire into the app — single-instance plugin, managed state, commands
+
+**Files:**
+- Modify: `src-tauri/Cargo.toml` (via `cargo add`)
+- Create: `src-tauri/src/commands/cli.rs`
+- Modify: `src-tauri/src/commands/mod.rs` (add `pub mod cli;`)
+- Modify: `src-tauri/src/lib.rs`
+
+**Interfaces:**
+- Consumes: everything `cli::` from Tasks 1–2.
+- Produces: Tauri commands `take_launch_intent() -> Option<LaunchIntent>`, `cli_shim_status() -> CliShimStatus`, `install_cli_shim() -> CliInstallOutcome`; Tauri event `cli-launch` with `LaunchIntent` payload (camelCase: `{ path, screen }`). Task 4's TS wrappers call these by exactly these names.
+
+- [ ] **Step 1: Add the plugin dependency**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo add tauri-plugin-single-instance --manifest-path src-tauri/Cargo.toml
+```
+
+No JS package and no capability change needed: the plugin has no frontend API, Rust-side `emit` needs no permission, and webview `listen` is covered by `core:default`.
+
+- [ ] **Step 2: Command handlers**
+
+Create `src-tauri/src/commands/cli.rs`:
+
+```rust
+use std::sync::Mutex;
+
+use tauri::State;
+
+use crate::{
+    cli::{self, CliInstallOutcome, CliShimStatus, LaunchIntent},
+    error::{AppError, AppResult},
+};
+
+/// First-launch CLI intent, stashed by `run()` before the webview exists.
+/// Take-once: a webview reload must not replay it.
+pub struct CliLaunchState(pub Mutex<Option<LaunchIntent>>);
+
+#[tauri::command]
+pub fn take_launch_intent(
+    state: State<'_, CliLaunchState>,
+) -> AppResult<Option<LaunchIntent>> {
+    Ok(state
+        .0
+        .lock()
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .take())
+}
+
+#[tauri::command]
+pub async fn cli_shim_status() -> AppResult<CliShimStatus> {
+    tokio::task::spawn_blocking(cli::shim_status)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))
+}
+
+#[tauri::command]
+pub async fn install_cli_shim() -> AppResult<CliInstallOutcome> {
+    tokio::task::spawn_blocking(cli::install_shim)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))
+}
+```
+
+Add `pub mod cli;` to `src-tauri/src/commands/mod.rs`.
+
+- [ ] **Step 3: Wire `run()` in `src-tauri/src/lib.rs`**
+
+At the top of `run()` (before building the backend), parse argv and handle `--help`; register the single-instance plugin FIRST (its documented requirement); manage the intent state; register the three commands.
+
+```rust
+pub fn run() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("/"));
+    let initial_intent = match cli::parse_args(&args, &cwd) {
+        cli::Parsed::Help => {
+            print!("{}", cli::USAGE);
+            return;
+        }
+        cli::Parsed::Launch(intent) => intent.map(cli::resolve_repo_root),
+    };
+
+    let backend = Arc::new(Libgit2Backend::new());
+
+    let mut builder = tauri::Builder::default();
+
+    // Single-instance must be the first registered plugin. A later `pgit …`
+    // invocation lands here in the ALREADY-RUNNING process: forward the
+    // parsed intent to the webview and surface the window. Opt-out env var
+    // for e2e runs and parallel dev instances, which must not
+    // forward-and-exit into each other.
+    if std::env::var("PLATYPUSGIT_NO_SINGLE_INSTANCE").is_err() {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
+            use tauri::{Emitter, Manager};
+            let args: Vec<String> = argv.into_iter().skip(1).collect();
+            if let cli::Parsed::Launch(Some(intent)) =
+                cli::parse_args(&args, std::path::Path::new(&cwd))
+            {
+                let intent = cli::resolve_repo_root(intent);
+                if let Err(e) = app.emit("cli-launch", &intent) {
+                    log::error!("failed to emit cli-launch: {e}");
+                }
+            }
+            if let Some(win) = app.get_webview_window("main") {
+                let _ = win.unminimize();
+                let _ = win.set_focus();
+            }
+        }));
+    }
+
+    let builder = builder
+        .plugin(
+            tauri_plugin_log::Builder::new()
+                // …existing log plugin config unchanged…
+```
+
+Then in the chain below, add alongside the existing `.manage(AppState::new(backend))`:
+
+```rust
+        .manage(commands::cli::CliLaunchState(Mutex::new(initial_intent)))
+```
+
+(`use std::sync::Mutex;` at the top of lib.rs.) And register in `invoke_handler!`:
+
+```rust
+            commands::cli::take_launch_intent,
+            commands::cli::cli_shim_status,
+            commands::cli::install_cli_shim,
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH" && cargo check --manifest-path src-tauri/Cargo.toml && cargo test --manifest-path src-tauri/Cargo.toml`
+Expected: clean check, all existing tests + 12 cli tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/src/lib.rs src-tauri/src/commands/mod.rs src-tauri/src/commands/cli.rs
+git commit -m "feat(cli): single-instance forwarding, launch-intent state, shim commands"
+```
+
+---
+
+### Task 4: Frontend — types, wrappers, `useCliLaunch` hook
+
+**Files:**
+- Modify: `src/lib/types.ts`, `src/lib/tauri.ts`
+- Create: `src/features/cli/useCliLaunch.ts`
+- Create: `src/test/eventMock.ts`; Modify: `src/test/setup.ts`
+- Modify: `src/AppShell.tsx` (mount hook)
+- Test: `src/features/cli/useCliLaunch.test.tsx`
+
+**Interfaces:**
+- Consumes: commands from Task 3 (`take_launch_intent`, event `cli-launch` with payload `{ path: string | null, screen: string | null }`).
+- Produces: `useCliLaunch()` hook (mounted once in AppShell); `LaunchIntent`, `CliShimStatus`, `CliInstallOutcome` TS types; `takeLaunchIntent()`, `cliShimStatus()`, `installCliShim()` wrappers; test helpers `emitMockEvent(event, payload)` / `resetEventMock()`. Task 5 consumes the types + wrappers.
+
+- [ ] **Step 1: Event mock for tests**
+
+Create `src/test/eventMock.ts`:
+
+```ts
+// Per-test mock of @tauri-apps/api/event. Register listeners via the mocked
+// listen(); fire them from tests with emitMockEvent(). Reset in setup.ts.
+
+type Handler = (event: { payload: unknown }) => void;
+
+const listeners = new Map<string, Set<Handler>>();
+
+export async function listen(
+  event: string,
+  handler: Handler,
+): Promise<() => void> {
+  let set = listeners.get(event);
+  if (!set) {
+    set = new Set();
+    listeners.set(event, set);
+  }
+  set.add(handler);
+  return () => {
+    set.delete(handler);
+  };
+}
+
+export function emitMockEvent(event: string, payload: unknown): void {
+  listeners.get(event)?.forEach((h) => h({ payload }));
+}
+
+export function resetEventMock(): void {
+  listeners.clear();
+}
+```
+
+In `src/test/setup.ts` add (next to the other `vi.mock` calls):
+
+```ts
+vi.mock("@tauri-apps/api/event", async () => {
+  return await import("./eventMock");
+});
+```
+
+and import + call `resetEventMock()` inside the existing `afterEach` (import at top: `import { resetEventMock } from "./eventMock";`).
+
+- [ ] **Step 2: Types + wrappers**
+
+Append to `src/lib/types.ts`:
+
+```ts
+/** CLI launch request (pgit [subcommand] [path]) — mirrors Rust cli::LaunchIntent. */
+export interface LaunchIntent {
+  path: string | null;
+  screen: string | null;
+}
+
+export interface CliShimStatus {
+  installed: boolean;
+  shimPath: string;
+  target: string;
+}
+
+export interface CliInstallOutcome {
+  installed: boolean;
+  path: string;
+  manualCommand: string | null;
+}
+```
+
+Append to `src/lib/tauri.ts` (import the three types in the existing type import):
+
+```ts
+export async function takeLaunchIntent(): Promise<LaunchIntent | null> {
+  return invoke<LaunchIntent | null>("take_launch_intent");
+}
+
+export async function cliShimStatus(): Promise<CliShimStatus> {
+  return invoke<CliShimStatus>("cli_shim_status");
+}
+
+export async function installCliShim(): Promise<CliInstallOutcome> {
+  return invoke<CliInstallOutcome>("install_cli_shim");
+}
+```
+
+- [ ] **Step 3: Write the failing hook test**
+
+Create `src/features/cli/useCliLaunch.test.tsx`:
+
+```tsx
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { mockInvoke } from "@/test/invokeMock";
+import { emitMockEvent } from "@/test/eventMock";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { useCliLaunch } from "./useCliLaunch";
+
+function Probe() {
+  useCliLaunch();
+  return null;
+}
+
+// Zustand stores are module singletons: stub openRepo per test, restore after.
+const realOpenRepo = useRepoStore.getState().openRepo;
+let openRepo: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  openRepo = vi.fn().mockResolvedValue(undefined);
+  useRepoStore.setState({ openRepo: openRepo as never });
+  useNavStore.getState().clearIntent();
+});
+
+afterEach(() => {
+  useRepoStore.setState({ openRepo: realOpenRepo });
+});
+
+describe("useCliLaunch", () => {
+  it("opens repo and switches screen from the initial intent", async () => {
+    mockInvoke("take_launch_intent", () => ({
+      path: "/tmp/repo",
+      screen: "commit",
+    }));
+    render(<Probe />);
+    await waitFor(() => expect(openRepo).toHaveBeenCalledWith("/tmp/repo"));
+    await waitFor(() =>
+      expect(useNavStore.getState().intent).toEqual({
+        kind: "switch-screen",
+        screen: "commit",
+      }),
+    );
+  });
+
+  it("path-only intent opens repo without switching screen", async () => {
+    mockInvoke("take_launch_intent", () => ({ path: "/tmp/repo", screen: null }));
+    render(<Probe />);
+    await waitFor(() => expect(openRepo).toHaveBeenCalledWith("/tmp/repo"));
+    expect(useNavStore.getState().intent).toBeNull();
+  });
+
+  it("does nothing on a plain launch (null intent)", async () => {
+    mockInvoke("take_launch_intent", () => null);
+    render(<Probe />);
+    // Give the mount effect a tick to resolve.
+    await waitFor(() => expect(openRepo).not.toHaveBeenCalled());
+    expect(useNavStore.getState().intent).toBeNull();
+  });
+
+  it("handles a forwarded cli-launch event from a second invocation", async () => {
+    mockInvoke("take_launch_intent", () => null);
+    render(<Probe />);
+    // Let the mount effect finish registering the listener.
+    await waitFor(() => expect(openRepo).not.toHaveBeenCalled());
+    emitMockEvent("cli-launch", { path: "/tmp/other", screen: "history" });
+    await waitFor(() => expect(openRepo).toHaveBeenCalledWith("/tmp/other"));
+    await waitFor(() =>
+      expect(useNavStore.getState().intent).toEqual({
+        kind: "switch-screen",
+        screen: "history",
+      }),
+    );
+  });
+});
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH" && pnpm test useCliLaunch`
+Expected: FAIL — `./useCliLaunch` module not found.
+
+- [ ] **Step 5: Implement the hook**
+
+Create `src/features/cli/useCliLaunch.ts`:
+
+```ts
+import React from "react";
+import { listen } from "@tauri-apps/api/event";
+
+import { takeLaunchIntent } from "@/lib/tauri";
+import type { LaunchIntent } from "@/lib/types";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+
+async function handleIntent(intent: LaunchIntent | null): Promise<void> {
+  if (!intent) return;
+  if (intent.path) {
+    // A failed open surfaces the normal error banner; the screen switch
+    // below is harmless alongside it.
+    await useRepoStore.getState().openRepo(intent.path);
+  }
+  if (intent.screen) {
+    useNavStore.getState().setIntent({
+      kind: "switch-screen",
+      screen: intent.screen,
+    });
+  }
+}
+
+/**
+ * CLI launch plumbing, mounted once in AppShell. Pulls the first-launch
+ * intent (take-once command), then listens for `cli-launch` events forwarded
+ * by the single-instance plugin when the user runs `pgit …` again.
+ */
+export function useCliLaunch(): void {
+  React.useEffect(() => {
+    void takeLaunchIntent().then(handleIntent);
+    const unlisten = listen<LaunchIntent>("cli-launch", (e) => {
+      void handleIntent(e.payload);
+    });
+    return () => {
+      void unlisten.then((f) => f());
+    };
+  }, []);
+}
+```
+
+Mount in `src/AppShell.tsx` — inside `AppShell()`, right after `usePreventBrowserContextMenu();`:
+
+```tsx
+  useCliLaunch();
+```
+
+with import `import { useCliLaunch } from "@/features/cli/useCliLaunch";`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH" && pnpm test useCliLaunch && pnpm tsc --noEmit`
+Expected: 4 tests PASS; typecheck clean.
+
+- [ ] **Step 7: Run the whole frontend suite**
+
+Run: `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH" && pnpm test`
+Expected: all pass (the new event mock must not break existing tests — none import `@tauri-apps/api/event` today, so no behavior change).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/types.ts src/lib/tauri.ts src/features/cli/ src/test/eventMock.ts src/test/setup.ts src/AppShell.tsx
+git commit -m "feat(cli): frontend launch-intent handling via take-once command + event"
+```
+
+---
+
+### Task 5: Settings "Command line" section
+
+**Files:**
+- Modify: `src/screens/Settings.tsx`
+- Test: `src/screens/Settings.cli.test.tsx`
+
+**Interfaces:**
+- Consumes: `cliShimStatus()`, `installCliShim()` from Task 4; existing `Section`/`Row` locals in Settings.tsx; `platform()` from `@tauri-apps/plugin-os` (already mocked to `"macos"` in tests).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/screens/Settings.cli.test.tsx`:
+
+```tsx
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { mockInvoke } from "@/test/invokeMock";
+import { SettingsScreen } from "./Settings";
+
+function mockShim(installed: boolean) {
+  mockInvoke("cli_shim_status", () => ({
+    installed,
+    shimPath: "/usr/local/bin/pgit",
+    target: "/Applications/PlatypusGit.app/Contents/MacOS/platypusgit",
+  }));
+}
+
+describe("Settings command line section", () => {
+  it("shows not-installed status and installs on click", async () => {
+    mockShim(false);
+    mockInvoke("install_cli_shim", () => ({
+      installed: true,
+      path: "/usr/local/bin/pgit",
+      manualCommand: null,
+    }));
+    render(<SettingsScreen />);
+    expect(await screen.findByText(/not installed/i)).toBeInTheDocument();
+    // Status refresh after install reports installed.
+    mockShim(true);
+    await userEvent.click(
+      screen.getByRole("button", { name: /install pgit/i }),
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/\/usr\/local\/bin\/pgit/)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/not installed/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the manual command when install lacks permissions", async () => {
+    mockShim(false);
+    mockInvoke("install_cli_shim", () => ({
+      installed: false,
+      path: "/usr/local/bin/pgit",
+      manualCommand: 'sudo ln -sf "/app/platypusgit" "/usr/local/bin/pgit"',
+    }));
+    render(<SettingsScreen />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: /install pgit/i }),
+    );
+    expect(
+      await screen.findByText(/sudo ln -sf/),
+    ).toBeInTheDocument();
+  });
+});
+```
+
+Note: `SettingsScreen` renders other sections that call stores but no invokes on mount today — if rendering trips an unmocked invoke, register that command with `mockInvoke` in the test rather than shrinking the render scope.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH" && pnpm test Settings.cli`
+Expected: FAIL — no "not installed" text / no install button.
+
+- [ ] **Step 3: Implement the section**
+
+In `src/screens/Settings.tsx`:
+
+- Imports: add `platform` from `@tauri-apps/plugin-os`; `cliShimStatus, installCliShim` from `@/lib/tauri`; `CliShimStatus` type from `@/lib/types`.
+- Render `<CliSection />` after `<KeyboardSection />` in `SettingsScreen`.
+- Add the component (near `KeyboardSection`):
+
+```tsx
+function CliSection() {
+  const isWindows = platform() === "windows";
+  const [status, setStatus] = React.useState<CliShimStatus | null>(null);
+  const [manual, setManual] = React.useState<string | null>(null);
+  const [busy, setBusy] = React.useState(false);
+
+  const refresh = React.useCallback(() => {
+    cliShimStatus()
+      .then(setStatus)
+      .catch(() => setStatus(null));
+  }, []);
+
+  React.useEffect(() => {
+    if (!isWindows) refresh();
+  }, [isWindows, refresh]);
+
+  const install = async () => {
+    setBusy(true);
+    try {
+      const out = await installCliShim();
+      if (out.installed) {
+        setManual(null);
+        pgFlash(`pgit installed at ${out.path}`);
+        refresh();
+      } else if (out.manualCommand) {
+        setManual(out.manualCommand);
+      }
+    } catch {
+      setManual(null);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Section
+      title="Command line"
+      subtitle="Launch platypusgit from a terminal: pgit [commit|status|log|history|branches] [path]."
+    >
+      {isWindows ? (
+        <Row
+          label="pgit command"
+          hint="Not yet supported on Windows. Add the install directory to PATH manually to use platypusgit.exe from a terminal."
+          control={<span />}
+        />
+      ) : (
+        <Row
+          label="pgit command"
+          hint={
+            status?.installed ? (
+              <>
+                Installed at{" "}
+                <code style={{ fontFamily: "var(--font-mono)" }}>
+                  {status.shimPath}
+                </code>
+              </>
+            ) : (
+              <>
+                Not installed.{" "}
+                {manual && (
+                  <>
+                    Automatic install failed (permissions) — run:{" "}
+                    <code
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        userSelect: "all",
+                      }}
+                    >
+                      {manual}
+                    </code>
+                  </>
+                )}
+              </>
+            )
+          }
+          control={
+            <PGButton size="sm" onClick={install} disabled={busy}>
+              {status?.installed ? "Reinstall pgit" : "Install pgit"}
+            </PGButton>
+          }
+        />
+      )}
+    </Section>
+  );
+}
+```
+
+(Both button labels match `/install pgit/i`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH" && pnpm test Settings.cli && pnpm tsc --noEmit`
+Expected: 2 tests PASS; typecheck clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/screens/Settings.tsx src/screens/Settings.cli.test.tsx
+git commit -m "feat(settings): command line section — install pgit shim"
+```
+
+---
+
+### Task 6: E2E guard, docs, full verification
+
+**Files:**
+- Modify: `e2e/wdio.conf.ts`
+- Modify: `README.md`, `implemented-features.md`, `CLAUDE.md`
+
+**Interfaces:**
+- Consumes: `PLATYPUSGIT_NO_SINGLE_INSTANCE` opt-out from Task 3.
+
+- [ ] **Step 1: Keep single-instance out of e2e runs**
+
+In `e2e/wdio.conf.ts`, right after the imports:
+
+```ts
+// The app registers tauri-plugin-single-instance; a test binary starting
+// while any platypusgit instance runs would forward-and-exit instead of
+// serving WebDriver. The env var (checked in lib.rs run()) disables the
+// plugin for children of this process.
+process.env.PLATYPUSGIT_NO_SINGLE_INSTANCE = "1";
+```
+
+Run: `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH" && pnpm exec tsc -p e2e/tsconfig.json --noEmit`
+Expected: clean.
+
+- [ ] **Step 2: Docs**
+
+- `README.md`: add a "CLI" section documenting `pgit [subcommand] [path]`, the subcommand→screen table from the spec, single-instance forwarding, and install via Settings → Command line (manual: `sudo ln -sf <app-binary> /usr/local/bin/pgit`).
+- `implemented-features.md`: add a CLI launch entry matching the file's existing format.
+- `CLAUDE.md`: add `cli.rs` + `commands/cli.rs` to the backend tree, `features/cli/` to the frontend tree, the spec to the "Recent specs/plans" list, and a note in the e2e section that wdio sets `PLATYPUSGIT_NO_SINGLE_INSTANCE=1`.
+
+- [ ] **Step 3: Full verification**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm tsc --noEmit
+pnpm test
+cargo test --manifest-path src-tauri/Cargo.toml
+pnpm test:e2e     # full rebuild — src/ AND src-tauri/ changed
+```
+
+Expected: everything green (e2e: 14 files, 50 tests). Close any running `pnpm tauri dev` first (port 4445).
+
+- [ ] **Step 4: Manual smoke test (macOS)**
+
+```bash
+# First instance with args:
+./e2e/.bin/platypusgit commit .   # from a repo dir → app opens on Commit panel
+# Second invocation while it runs (new terminal, some other repo):
+./e2e/.bin/platypusgit log ~/dev/fun/platypusgit   # running window focuses, History opens
+./e2e/.bin/platypusgit --help                      # prints usage, no window
+```
+
+(The e2e snapshot binary embeds the frontend, so it works standalone. It is a debug build — WebDriver on 4445 — so close other instances first.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/wdio.conf.ts README.md implemented-features.md CLAUDE.md
+git commit -m "test(e2e): disable single-instance in e2e; docs for pgit CLI"
+```

--- a/docs/superpowers/specs/2026-07-07-cli-launch-design.md
+++ b/docs/superpowers/specs/2026-07-07-cli-launch-design.md
@@ -1,0 +1,167 @@
+# CLI launch capability — design
+
+**Date:** 2026-07-07
+**Source:** GitHub issue #25, item 1 — "CLI launchability `platypus .` or `platypus commit`, `pgit` or something. Takes you to UI with expected page open."
+**Status:** Approved (assistant-driven, autonomous session; decisions documented below)
+
+## Goal
+
+Launch PlatypusGit from a terminal with the repo and screen you meant:
+
+```
+pgit .                 # open repo containing cwd
+pgit ~/dev/foo         # open repo containing that path
+pgit commit            # open cwd repo, land on Commit panel
+pgit log src/          # open repo containing src/, land on History
+```
+
+If the app is already running, a second `pgit …` invocation must not spawn a
+second app instance — it forwards the request to the running window, focuses
+it, and navigates there.
+
+## CLI grammar
+
+```
+pgit [subcommand] [path]
+pgit --help | -h
+```
+
+- **Bare `pgit` (no args)** — indistinguishable from a GUI launch (Finder/
+  Explorer also pass zero args), so it is treated as a plain app launch: last
+  persisted repo/screen state, no CLI intent. Use `pgit .` to open cwd.
+- **`pgit <path>`** — open the repo containing `<path>`. No screen change
+  (keep last persisted screen).
+- **`pgit <subcommand> [path]`** — open repo (path defaults to cwd), then
+  switch screen:
+
+  | subcommand | screen |
+  |---|---|
+  | `commit`, `status` | `commit` (Commit panel) |
+  | `log`, `history` | `history` |
+  | `branches` | `branches` |
+
+- An argument that is not a known subcommand is treated as a path.
+- `--help`/`-h` prints usage to stdout and exits before the GUI starts.
+- Relative paths resolve against the invoking shell's cwd (first launch:
+  process cwd; forwarded launch: the cwd reported by the single-instance
+  plugin).
+- Repo root discovery: the raw path is resolved with
+  `git2::Repository::discover` at intent-build time (backend `open` uses
+  `Repository::open`, which requires the root — CLI users will be deep in
+  subdirectories). If discovery fails, pass the raw path through and let the
+  normal `open_repo` error path surface `NotARepo` in the error banner.
+
+## Approaches considered
+
+1. **App binary parses argv + `tauri-plugin-single-instance`** *(chosen)* —
+   `pgit` is just a symlink/shim to the app binary. First instance stashes a
+   `LaunchIntent`; later invocations are forwarded (argv + cwd) by the
+   single-instance plugin to the running instance, which emits an event to the
+   webview and focuses the window. One binary, no IPC protocol to invent.
+2. Separate thin CLI binary talking to the app over a socket/deep link — more
+   moving parts, custom protocol, packaging work. YAGNI.
+3. Custom URL scheme (`pgit://…`) — doesn't give the shell UX the issue asks
+   for; still needs a shim to be typable.
+
+## Architecture
+
+### Rust
+
+- **`src-tauri/src/cli.rs`** (new): pure, unit-tested parsing.
+  - `LaunchIntent { path: Option<PathBuf>, screen: Option<String> }`
+    (serde-serializable; screen values are the frontend `ScreenId` strings).
+  - `parse_args(args: &[String], cwd: &Path) -> Parsed` where
+    `Parsed = Help | Launch(Option<LaunchIntent>)`. Takes argv *without* the
+    binary name. Pure — no filesystem access.
+  - `resolve_repo_root(intent) -> LaunchIntent` — applies
+    `Repository::discover`; separate from parsing so parsing stays pure.
+- **`lib.rs` `run()`**:
+  - Parse `std::env::args` first; `--help` prints usage and returns without
+    building the app.
+  - Register `tauri-plugin-single-instance` as the **first** plugin (its
+    requirement). Callback receives `(app, argv, cwd)`: parse, resolve, emit
+    `cli-launch` event with the intent payload, focus + unminimize the main
+    window.
+  - Skip the plugin entirely when `PLATYPUSGIT_NO_SINGLE_INSTANCE=1` — e2e
+    runs and parallel dev instances must not forward-and-exit into each other.
+  - Managed state `CliLaunch(Mutex<Option<LaunchIntent>>)` holding the
+    first-launch intent.
+- **`commands/cli.rs`** (new):
+  - `take_launch_intent() -> AppResult<Option<LaunchIntent>>` — returns and
+    clears the stashed intent (take-once semantics; a webview reload must not
+    replay it).
+  - `cli_shim_status() -> AppResult<CliShimStatus>` —
+    `{ installed: bool, shim_path: String, target: String }`; installed means
+    the shim exists and points at the current executable.
+  - `install_cli_shim() -> AppResult<CliInstallOutcome>` —
+    `{ installed: bool, path: String, manualCommand: String | null }`.
+    Success → `installed: true`. Permission failure is NOT an error: returns
+    `installed: false` + the manual command to run (e.g.
+    `sudo ln -sf <exe> /usr/local/bin/pgit`). No new `AppError` variants.
+  - Shim locations: macOS `/usr/local/bin/pgit`; Linux `~/.local/bin/pgit`.
+    Windows: install unsupported for now — UI shows a note instead of the
+    button. Core install logic factored as `install_shim_at(dir, exe)` so
+    tests can point it at a temp dir.
+
+### Frontend
+
+- `src/lib/types.ts`: `LaunchIntent`, `CliShimStatus`, `CliInstallOutcome`.
+- `src/lib/tauri.ts`: `takeLaunchIntent()`, `cliShimStatus()`,
+  `installCliShim()` wrappers.
+- **`src/features/cli/useCliLaunch.ts`** (new): hook mounted once in
+  `AppShell`.
+  - On mount: `takeLaunchIntent()`; if present, handle it.
+  - Subscribes to the `cli-launch` Tauri event for forwarded invocations.
+  - Handling: if `path` → await `useRepoStore.getState().openRepo(path)`,
+    then if `screen` → `useNavStore` `switch-screen` intent (which `AppShell`
+    already routes). Both always apply: a failed open shows the error banner
+    and the screen switch is harmless alongside it.
+- **Settings screen**: new "Command line" `Section`:
+  - Shows shim status (installed at `<path>` / not installed).
+  - Install button → `installCliShim()`; on `manualCommand` outcome, shows the
+    command to copy-run instead. Windows: explanatory note, no button.
+
+### Event flow
+
+```
+terminal: pgit commit src/
+  └─ new process → single-instance plugin → running instance
+       callback: parse(argv, cwd) → discover root → emit "cli-launch" {path, screen}
+                 focus + unminimize main window
+frontend: useCliLaunch listener → openRepo(path) → nav intent switch-screen("commit")
+```
+
+First launch is identical except the intent travels via managed state +
+`take_launch_intent` instead of the event (the webview isn't up yet when
+argv is parsed).
+
+## Error handling
+
+- Non-repo path → normal `open_repo` `NotARepo` error banner; app still opens.
+- Nonexistent path → same (`InvalidPath` from backend).
+- Unknown subcommand is a path candidate, not an error (e.g. `pgit foo` where
+  `foo/` is a directory).
+- Shim install permission failure → structured outcome with manual command,
+  rendered in Settings; never a thrown error.
+
+## Testing
+
+- **Rust unit (`cli.rs`)**: table-driven `parse_args` tests — bare, path-only,
+  each subcommand, subcommand+path, unknown-token-as-path, relative-path
+  resolution against cwd, `--help`.
+- **Rust unit**: `install_shim_at` against a temp dir — fresh install,
+  reinstall over stale symlink, status detection.
+- **Frontend component test**: `useCliLaunch` — mock `take_launch_intent` via
+  `mockInvoke`, assert `open_repo` invoked with the path and nav intent set;
+  mock the event module to assert forwarded events are handled too.
+- **E2E**: launching the binary with CLI args isn't reachable through the
+  wdio tauri-service harness — out of scope. The full existing suite must
+  stay green; wdio config gets `PLATYPUSGIT_NO_SINGLE_INSTANCE=1` in the
+  launch env so the plugin can't interfere with test runs.
+
+## Out of scope
+
+- Windows shim install (PATH manipulation / installer work).
+- `pgit diff <file>`, opening individual files, blame from CLI.
+- Man page, shell completions.
+- Deep links / URL scheme.

--- a/e2e/wdio.conf.ts
+++ b/e2e/wdio.conf.ts
@@ -3,6 +3,12 @@ import type { TauriCapabilities } from "@wdio/tauri-service";
 import { $, browser } from "@wdio/globals";
 import { armDriverBridge, ensureMacAppFocus } from "./support/app";
 
+// The app registers tauri-plugin-single-instance; a test binary starting
+// while any platypusgit instance runs would forward-and-exit instead of
+// serving WebDriver. The env var (checked in lib.rs run()) disables the
+// plugin for children of this process.
+process.env.PLATYPUSGIT_NO_SINGLE_INSTANCE = "1";
+
 // Snapshot copied by `pnpm test:e2e` after building with
 // `--features tauri/custom-protocol` (which embeds the frontend assets).
 // We don't point at src-tauri/target/debug/ directly: any plain

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -82,6 +82,126 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +369,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -505,6 +638,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -883,6 +1025,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +1086,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1070,6 +1260,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1551,6 +1754,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2630,6 +2839,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "os_info"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2669,6 +2888,12 @@ dependencies = [
  "libc",
  "system-deps 6.2.2",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2893,6 +3118,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2911,6 +3147,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-log",
  "tauri-plugin-os",
+ "tauri-plugin-single-instance",
  "tauri-plugin-wdio-webdriver",
  "tempfile",
  "thiserror 2.0.18",
@@ -2942,6 +3179,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4277,6 +4528,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-wdio-webdriver"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4818,6 +5084,17 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -5887,6 +6164,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.2",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.2",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5965,3 +6303,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.2",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 1.0.2",
+]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros", "sync", "
 tauri-plugin-log = "2.8.0"
 log = "0.4.29"
 tauri-plugin-wdio-webdriver = "1.2.0"
+tauri-plugin-single-instance = "2.4.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -1,0 +1,354 @@
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+/// What a CLI invocation asked for. `path` is absolute (resolved against the
+/// invoking shell's cwd); `screen` is a frontend ScreenId string.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LaunchIntent {
+    pub path: Option<PathBuf>,
+    pub screen: Option<String>,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Parsed {
+    Help,
+    /// `None` = plain app launch (no CLI args at all).
+    Launch(Option<LaunchIntent>),
+}
+
+pub const USAGE: &str = "\
+PlatypusGit
+
+Usage: pgit [subcommand] [path]
+
+Subcommands:
+  commit | status    open the Commit panel
+  log | history      open the History screen
+  branches           open the Branches screen
+
+With a path and no subcommand, opens the repo containing that path.
+With a subcommand and no path, uses the current directory.
+With no arguments, performs a plain app launch.
+";
+
+fn screen_for(token: &str) -> Option<&'static str> {
+    match token {
+        "commit" | "status" => Some("commit"),
+        "log" | "history" => Some("history"),
+        "branches" => Some("branches"),
+        _ => None,
+    }
+}
+
+fn resolve_path(arg: &str, cwd: &Path) -> PathBuf {
+    let p = PathBuf::from(arg);
+    if p.is_absolute() {
+        p
+    } else {
+        cwd.join(p)
+    }
+}
+
+/// Parse CLI args (argv without the binary name). Pure — no filesystem
+/// access; relative paths resolve against `cwd`.
+pub fn parse_args(args: &[String], cwd: &Path) -> Parsed {
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        return Parsed::Help;
+    }
+    let mut screen: Option<String> = None;
+    let mut path: Option<PathBuf> = None;
+    for (i, arg) in args.iter().enumerate() {
+        if i == 0 {
+            if let Some(s) = screen_for(arg) {
+                screen = Some(s.to_string());
+                continue;
+            }
+        }
+        if path.is_none() {
+            path = Some(resolve_path(arg, cwd));
+        }
+    }
+    if screen.is_some() && path.is_none() {
+        path = Some(cwd.to_path_buf());
+    }
+    match (path, &screen) {
+        (None, None) => Parsed::Launch(None),
+        (path, _) => Parsed::Launch(Some(LaunchIntent { path, screen })),
+    }
+}
+
+/// Widen a CLI path to its repo workdir root (backend `open` requires the
+/// root, CLI users sit in subdirectories). Non-repo paths pass through so
+/// the normal open_repo error path reports NotARepo.
+pub fn resolve_repo_root(intent: LaunchIntent) -> LaunchIntent {
+    let path = intent.path.map(|p| {
+        git2::Repository::discover(&p)
+            .ok()
+            .and_then(|r| r.workdir().map(PathBuf::from))
+            .unwrap_or(p)
+    });
+    LaunchIntent { path, ..intent }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliShimStatus {
+    pub installed: bool,
+    pub shim_path: String,
+    pub target: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliInstallOutcome {
+    pub installed: bool,
+    pub path: String,
+    /// Set when we couldn't write the symlink (permissions): the command the
+    /// user should run themselves. Not an error — Settings renders it.
+    pub manual_command: Option<String>,
+}
+
+/// Where the `pgit` shim goes. None on unsupported platforms (Windows).
+pub fn default_shim_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        Some(PathBuf::from("/usr/local/bin"))
+    }
+    #[cfg(target_os = "linux")]
+    {
+        std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/bin"))
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        None
+    }
+}
+
+#[cfg(unix)]
+pub fn install_shim_at(dir: &Path, exe: &Path) -> std::io::Result<PathBuf> {
+    std::fs::create_dir_all(dir)?;
+    let link = dir.join("pgit");
+    if link.symlink_metadata().is_ok() {
+        std::fs::remove_file(&link)?;
+    }
+    std::os::unix::fs::symlink(exe, &link)?;
+    Ok(link)
+}
+
+#[cfg(unix)]
+pub fn shim_installed_at(dir: &Path, exe: &Path) -> bool {
+    std::fs::read_link(dir.join("pgit"))
+        .map(|target| target == exe)
+        .unwrap_or(false)
+}
+
+pub fn shim_status() -> CliShimStatus {
+    let exe = std::env::current_exe().unwrap_or_default();
+    let dir = default_shim_dir();
+    let shim_path = dir
+        .as_deref()
+        .map(|d| d.join("pgit").display().to_string())
+        .unwrap_or_default();
+    #[cfg(unix)]
+    let installed = dir.as_deref().is_some_and(|d| shim_installed_at(d, &exe));
+    #[cfg(not(unix))]
+    let installed = false;
+    CliShimStatus {
+        installed,
+        shim_path,
+        target: exe.display().to_string(),
+    }
+}
+
+pub fn install_shim() -> CliInstallOutcome {
+    // Without our own path there's nothing to point the shim at — report
+    // not-installed rather than linking an empty path and claiming success.
+    let Ok(exe) = std::env::current_exe() else {
+        return CliInstallOutcome {
+            installed: false,
+            path: String::new(),
+            manual_command: None,
+        };
+    };
+    let Some(dir) = default_shim_dir() else {
+        return CliInstallOutcome {
+            installed: false,
+            path: String::new(),
+            manual_command: None,
+        };
+    };
+    let link_display = dir.join("pgit").display().to_string();
+    #[cfg(unix)]
+    {
+        match install_shim_at(&dir, &exe) {
+            Ok(link) => CliInstallOutcome {
+                installed: true,
+                path: link.display().to_string(),
+                manual_command: None,
+            },
+            Err(_) => CliInstallOutcome {
+                installed: false,
+                path: link_display.clone(),
+                manual_command: Some(format!(
+                    "sudo ln -sf \"{}\" \"{}\"",
+                    exe.display(),
+                    link_display
+                )),
+            },
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        CliInstallOutcome {
+            installed: false,
+            path: link_display,
+            manual_command: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(v: &[&str]) -> Vec<String> {
+        v.iter().map(|x| x.to_string()).collect()
+    }
+
+    #[test]
+    fn bare_launch_has_no_intent() {
+        assert_eq!(parse_args(&[], Path::new("/w")), Parsed::Launch(None));
+    }
+
+    #[test]
+    fn help_flag_wins() {
+        assert_eq!(parse_args(&s(&["--help"]), Path::new("/w")), Parsed::Help);
+        assert_eq!(parse_args(&s(&["commit", "-h"]), Path::new("/w")), Parsed::Help);
+    }
+
+    #[test]
+    fn path_only_opens_repo_without_screen() {
+        assert_eq!(
+            parse_args(&s(&["/abs/repo"]), Path::new("/w")),
+            Parsed::Launch(Some(LaunchIntent {
+                path: Some(PathBuf::from("/abs/repo")),
+                screen: None,
+            }))
+        );
+    }
+
+    #[test]
+    fn relative_path_resolves_against_cwd() {
+        assert_eq!(
+            parse_args(&s(&["sub/dir"]), Path::new("/w")),
+            Parsed::Launch(Some(LaunchIntent {
+                path: Some(PathBuf::from("/w/sub/dir")),
+                screen: None,
+            }))
+        );
+    }
+
+    #[test]
+    fn subcommand_without_path_uses_cwd() {
+        for (cmd, screen) in [
+            ("commit", "commit"),
+            ("status", "commit"),
+            ("log", "history"),
+            ("history", "history"),
+            ("branches", "branches"),
+        ] {
+            assert_eq!(
+                parse_args(&s(&[cmd]), Path::new("/w")),
+                Parsed::Launch(Some(LaunchIntent {
+                    path: Some(PathBuf::from("/w")),
+                    screen: Some(screen.to_string()),
+                })),
+                "subcommand {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn subcommand_with_path() {
+        assert_eq!(
+            parse_args(&s(&["log", "src"]), Path::new("/w")),
+            Parsed::Launch(Some(LaunchIntent {
+                path: Some(PathBuf::from("/w/src")),
+                screen: Some("history".to_string()),
+            }))
+        );
+    }
+
+    #[test]
+    fn unknown_first_token_is_a_path() {
+        assert_eq!(
+            parse_args(&s(&["foo"]), Path::new("/w")),
+            Parsed::Launch(Some(LaunchIntent {
+                path: Some(PathBuf::from("/w/foo")),
+                screen: None,
+            }))
+        );
+    }
+
+    #[test]
+    fn resolve_repo_root_finds_workdir_from_subdir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        git2::Repository::init(&root).unwrap();
+        let sub = root.join("a/b");
+        std::fs::create_dir_all(&sub).unwrap();
+        let out = resolve_repo_root(LaunchIntent {
+            path: Some(sub),
+            screen: None,
+        });
+        assert_eq!(out.path, Some(root));
+    }
+
+    #[test]
+    fn resolve_repo_root_passes_non_repo_through() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("nowhere");
+        let out = resolve_repo_root(LaunchIntent {
+            path: Some(p.clone()),
+            screen: Some("commit".into()),
+        });
+        assert_eq!(out.path, Some(p));
+        assert_eq!(out.screen, Some("commit".to_string()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn install_shim_creates_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe = dir.path().join("platypusgit");
+        std::fs::write(&exe, b"#!/bin/sh\n").unwrap();
+        let link = install_shim_at(dir.path(), &exe).unwrap();
+        assert_eq!(link, dir.path().join("pgit"));
+        assert_eq!(std::fs::read_link(&link).unwrap(), exe);
+        assert!(shim_installed_at(dir.path(), &exe));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn install_shim_replaces_stale_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let old = dir.path().join("old-exe");
+        let new = dir.path().join("new-exe");
+        std::fs::write(&old, b"x").unwrap();
+        std::fs::write(&new, b"x").unwrap();
+        install_shim_at(dir.path(), &old).unwrap();
+        assert!(!shim_installed_at(dir.path(), &new));
+        install_shim_at(dir.path(), &new).unwrap();
+        assert_eq!(std::fs::read_link(dir.path().join("pgit")).unwrap(), new);
+        assert!(shim_installed_at(dir.path(), &new));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shim_not_installed_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!shim_installed_at(dir.path(), Path::new("/x")));
+    }
+}

--- a/src-tauri/src/commands/cli.rs
+++ b/src-tauri/src/commands/cli.rs
@@ -1,0 +1,37 @@
+use std::sync::Mutex;
+
+use tauri::State;
+
+use crate::{
+    cli::{self, CliInstallOutcome, CliShimStatus, LaunchIntent},
+    error::{AppError, AppResult},
+};
+
+/// First-launch CLI intent, stashed by `run()` before the webview exists.
+/// Take-once: a webview reload must not replay it.
+pub struct CliLaunchState(pub Mutex<Option<LaunchIntent>>);
+
+#[tauri::command]
+pub fn take_launch_intent(
+    state: State<'_, CliLaunchState>,
+) -> AppResult<Option<LaunchIntent>> {
+    Ok(state
+        .0
+        .lock()
+        .map_err(|e| AppError::Internal(e.to_string()))?
+        .take())
+}
+
+#[tauri::command]
+pub async fn cli_shim_status() -> AppResult<CliShimStatus> {
+    tokio::task::spawn_blocking(cli::shim_status)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))
+}
+
+#[tauri::command]
+pub async fn install_cli_shim() -> AppResult<CliInstallOutcome> {
+    tokio::task::spawn_blocking(cli::install_shim)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod branches;
+pub mod cli;
 pub mod commits;
 pub mod conflict;
 pub mod diff;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,17 +1,54 @@
+pub mod cli;
 pub mod commands;
 pub mod error;
 pub mod git;
 pub mod state;
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use crate::{git::libgit2::Libgit2Backend, state::AppState};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("/"));
+    let initial_intent = match cli::parse_args(&args, &cwd) {
+        cli::Parsed::Help => {
+            print!("{}", cli::USAGE);
+            return;
+        }
+        cli::Parsed::Launch(intent) => intent.map(cli::resolve_repo_root),
+    };
+
     let backend = Arc::new(Libgit2Backend::new());
 
-    let builder = tauri::Builder::default()
+    let mut builder = tauri::Builder::default();
+
+    // Single-instance must be the first registered plugin. A later `pgit …`
+    // invocation lands here in the ALREADY-RUNNING process: forward the
+    // parsed intent to the webview and surface the window. Opt-out env var
+    // for e2e runs and parallel dev instances, which must not
+    // forward-and-exit into each other.
+    if std::env::var("PLATYPUSGIT_NO_SINGLE_INSTANCE").is_err() {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
+            use tauri::{Emitter, Manager};
+            let args: Vec<String> = argv.into_iter().skip(1).collect();
+            if let cli::Parsed::Launch(Some(intent)) =
+                cli::parse_args(&args, std::path::Path::new(&cwd))
+            {
+                let intent = cli::resolve_repo_root(intent);
+                if let Err(e) = app.emit("cli-launch", &intent) {
+                    log::error!("failed to emit cli-launch: {e}");
+                }
+            }
+            if let Some(win) = app.get_webview_window("main") {
+                let _ = win.unminimize();
+                let _ = win.set_focus();
+            }
+        }));
+    }
+
+    let builder = builder
         .plugin(
             tauri_plugin_log::Builder::new()
                 .level(log::LevelFilter::Info)
@@ -55,6 +92,7 @@ pub fn run() {
             Ok(())
         })
         .manage(AppState::new(backend))
+        .manage(commands::cli::CliLaunchState(Mutex::new(initial_intent)))
         .invoke_handler(tauri::generate_handler![
             commands::repo::open_repo,
             commands::repo::get_status,
@@ -125,6 +163,9 @@ pub fn run() {
             commands::rebase::rebase_status,
             commands::reflog::get_reflog,
             commands::reflog::checkout_detached,
+            commands::cli::take_launch_intent,
+            commands::cli::cli_shim_status,
+            commands::cli::install_cli_shim,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -30,6 +30,7 @@ import { SettingsScreen } from "@/screens/Settings";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { headUpstream } from "@/features/repo/ops";
 import { useNavStore } from "@/features/nav/useNavStore";
+import { useCliLaunch } from "@/features/cli/useCliLaunch";
 import {
   useKeymapStore,
   useFocusStore,
@@ -95,6 +96,7 @@ const ACTIVITY_ITEMS: ActivityBarItem[] = [
 
 export function AppShell() {
   usePreventBrowserContextMenu();
+  useCliLaunch();
   const repo = useRepoStore((s) => s.current);
   const error = useRepoStore((s) => s.error);
   const clearError = useRepoStore((s) => s.clearError);

--- a/src/features/cli/useCliLaunch.test.tsx
+++ b/src/features/cli/useCliLaunch.test.tsx
@@ -1,0 +1,74 @@
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { mockInvoke } from "@/test/invokeMock";
+import { emitMockEvent } from "@/test/eventMock";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { useCliLaunch } from "./useCliLaunch";
+
+function Probe() {
+  useCliLaunch();
+  return null;
+}
+
+// Zustand stores are module singletons: stub openRepo per test, restore after.
+const realOpenRepo = useRepoStore.getState().openRepo;
+let openRepo: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  openRepo = vi.fn().mockResolvedValue(undefined);
+  useRepoStore.setState({ openRepo: openRepo as never });
+  useNavStore.getState().clearIntent();
+});
+
+afterEach(() => {
+  useRepoStore.setState({ openRepo: realOpenRepo });
+});
+
+describe("useCliLaunch", () => {
+  it("opens repo and switches screen from the initial intent", async () => {
+    mockInvoke("take_launch_intent", () => ({
+      path: "/tmp/repo",
+      screen: "commit",
+    }));
+    render(<Probe />);
+    await waitFor(() => expect(openRepo).toHaveBeenCalledWith("/tmp/repo"));
+    await waitFor(() =>
+      expect(useNavStore.getState().intent).toEqual({
+        kind: "switch-screen",
+        screen: "commit",
+      }),
+    );
+  });
+
+  it("path-only intent opens repo without switching screen", async () => {
+    mockInvoke("take_launch_intent", () => ({ path: "/tmp/repo", screen: null }));
+    render(<Probe />);
+    await waitFor(() => expect(openRepo).toHaveBeenCalledWith("/tmp/repo"));
+    expect(useNavStore.getState().intent).toBeNull();
+  });
+
+  it("does nothing on a plain launch (null intent)", async () => {
+    mockInvoke("take_launch_intent", () => null);
+    render(<Probe />);
+    // Give the mount effect a tick to resolve.
+    await waitFor(() => expect(openRepo).not.toHaveBeenCalled());
+    expect(useNavStore.getState().intent).toBeNull();
+  });
+
+  it("handles a forwarded cli-launch event from a second invocation", async () => {
+    mockInvoke("take_launch_intent", () => null);
+    render(<Probe />);
+    // Let the mount effect finish registering the listener.
+    await waitFor(() => expect(openRepo).not.toHaveBeenCalled());
+    emitMockEvent("cli-launch", { path: "/tmp/other", screen: "history" });
+    await waitFor(() => expect(openRepo).toHaveBeenCalledWith("/tmp/other"));
+    await waitFor(() =>
+      expect(useNavStore.getState().intent).toEqual({
+        kind: "switch-screen",
+        screen: "history",
+      }),
+    );
+  });
+});

--- a/src/features/cli/useCliLaunch.ts
+++ b/src/features/cli/useCliLaunch.ts
@@ -1,0 +1,39 @@
+import React from "react";
+import { listen } from "@tauri-apps/api/event";
+
+import { takeLaunchIntent } from "@/lib/tauri";
+import type { LaunchIntent } from "@/lib/types";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+
+async function handleIntent(intent: LaunchIntent | null): Promise<void> {
+  if (!intent) return;
+  if (intent.path) {
+    // A failed open surfaces the normal error banner; the screen switch
+    // below is harmless alongside it.
+    await useRepoStore.getState().openRepo(intent.path);
+  }
+  if (intent.screen) {
+    useNavStore.getState().setIntent({
+      kind: "switch-screen",
+      screen: intent.screen,
+    });
+  }
+}
+
+/**
+ * CLI launch plumbing, mounted once in AppShell. Pulls the first-launch
+ * intent (take-once command), then listens for `cli-launch` events forwarded
+ * by the single-instance plugin when the user runs `pgit …` again.
+ */
+export function useCliLaunch(): void {
+  React.useEffect(() => {
+    void takeLaunchIntent().then(handleIntent);
+    const unlisten = listen<LaunchIntent>("cli-launch", (e) => {
+      void handleIntent(e.payload);
+    });
+    return () => {
+      void unlisten.then((f) => f());
+    };
+  }, []);
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -3,12 +3,15 @@ import { debug as logDebug, warn as logWarn, error as logError } from "@tauri-ap
 import type {
   BlameLine,
   BranchInfo,
+  CliInstallOutcome,
+  CliShimStatus,
   CommitInfo,
   ConflictSides,
   DiffKind,
   FileContent,
   FileDiff,
   FileStatus,
+  LaunchIntent,
   LogFilter,
   PullMode,
   PushForce,
@@ -537,4 +540,16 @@ export async function blameFile(
   path: string,
 ): Promise<BlameLine[]> {
   return invoke<BlameLine[]>("blame_file", { repoId, path });
+}
+
+export async function takeLaunchIntent(): Promise<LaunchIntent | null> {
+  return invoke<LaunchIntent | null>("take_launch_intent");
+}
+
+export async function cliShimStatus(): Promise<CliShimStatus> {
+  return invoke<CliShimStatus>("cli_shim_status");
+}
+
+export async function installCliShim(): Promise<CliInstallOutcome> {
+  return invoke<CliInstallOutcome>("install_cli_shim");
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -200,3 +200,21 @@ export interface BlameLine {
   summary: string;
   content: string;
 }
+
+/** CLI launch request (pgit [subcommand] [path]) — mirrors Rust cli::LaunchIntent. */
+export interface LaunchIntent {
+  path: string | null;
+  screen: string | null;
+}
+
+export interface CliShimStatus {
+  installed: boolean;
+  shimPath: string;
+  target: string;
+}
+
+export interface CliInstallOutcome {
+  installed: boolean;
+  path: string;
+  manualCommand: string | null;
+}

--- a/src/screens/Settings.cli.test.tsx
+++ b/src/screens/Settings.cli.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { mockInvoke } from "@/test/invokeMock";
+import { SettingsScreen } from "./Settings";
+
+function mockShim(installed: boolean) {
+  mockInvoke("cli_shim_status", () => ({
+    installed,
+    shimPath: "/usr/local/bin/pgit",
+    target: "/Applications/PlatypusGit.app/Contents/MacOS/platypusgit",
+  }));
+}
+
+describe("Settings command line section", () => {
+  it("shows not-installed status and installs on click", async () => {
+    mockShim(false);
+    mockInvoke("install_cli_shim", () => ({
+      installed: true,
+      path: "/usr/local/bin/pgit",
+      manualCommand: null,
+    }));
+    render(<SettingsScreen />);
+    expect(await screen.findByText(/not installed/i)).toBeInTheDocument();
+    // Status refresh after install reports installed.
+    mockShim(true);
+    await userEvent.click(
+      screen.getByRole("button", { name: /install pgit/i }),
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/\/usr\/local\/bin\/pgit/)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/not installed/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the manual command when install lacks permissions", async () => {
+    mockShim(false);
+    mockInvoke("install_cli_shim", () => ({
+      installed: false,
+      path: "/usr/local/bin/pgit",
+      manualCommand: 'sudo ln -sf "/app/platypusgit" "/usr/local/bin/pgit"',
+    }));
+    render(<SettingsScreen />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: /install pgit/i }),
+    );
+    expect(
+      await screen.findByText(/sudo ln -sf/),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { platform } from "@tauri-apps/plugin-os";
 import {
   PGButton,
   PGButtonGroup,
@@ -16,7 +17,8 @@ import {
   type ThemeColors,
   type ThemeDef,
 } from "@/features/settings/useSettingsStore";
-import type { PullMode } from "@/lib/tauri";
+import { cliShimStatus, installCliShim, type PullMode } from "@/lib/tauri";
+import type { CliShimStatus } from "@/lib/types";
 import { BUILTIN_PRESETS, useKeymapStore } from "@/features/keymap";
 
 export function SettingsScreen() {
@@ -202,6 +204,7 @@ export function SettingsScreen() {
         </Section>
 
         <KeyboardSection />
+        <CliSection />
       </div>
     </div>
   );
@@ -233,6 +236,100 @@ function KeyboardSection() {
           />
         }
       />
+    </Section>
+  );
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// CLI SECTION — install/status for the `pgit` shim
+// ═════════════════════════════════════════════════════════════════════════════
+
+function CliSection() {
+  const isWindows = platform() === "windows";
+  const [status, setStatus] = React.useState<CliShimStatus | null>(null);
+  const [manual, setManual] = React.useState<string | null>(null);
+  const [busy, setBusy] = React.useState(false);
+
+  const refresh = React.useCallback(() => {
+    cliShimStatus()
+      .then(setStatus)
+      .catch(() => setStatus(null));
+  }, []);
+
+  React.useEffect(() => {
+    if (!isWindows) refresh();
+  }, [isWindows, refresh]);
+
+  const install = async () => {
+    setBusy(true);
+    try {
+      const out = await installCliShim();
+      if (out.installed) {
+        setManual(null);
+        // Deliberately doesn't repeat the shim path here — the status row
+        // below shows it, and a toast echoing the same substring would
+        // outlive the row's re-render (toast lives ~1.7s) and collide with
+        // it in text queries.
+        pgFlash("pgit installed");
+        refresh();
+      } else if (out.manualCommand) {
+        setManual(out.manualCommand);
+      }
+    } catch {
+      setManual(null);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Section
+      title="Command line"
+      subtitle="Launch platypusgit from a terminal: pgit [commit|status|log|history|branches] [path]."
+    >
+      {isWindows ? (
+        <Row
+          label="pgit command"
+          hint="Not yet supported on Windows. Add the install directory to PATH manually to use platypusgit.exe from a terminal."
+          control={<span />}
+        />
+      ) : (
+        <Row
+          label="pgit command"
+          hint={
+            status?.installed ? (
+              <>
+                Installed at{" "}
+                <code style={{ fontFamily: "var(--font-mono)" }}>
+                  {status.shimPath}
+                </code>
+              </>
+            ) : (
+              <>
+                Not installed.{" "}
+                {manual && (
+                  <>
+                    Automatic install failed (permissions) — run:{" "}
+                    <code
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        userSelect: "all",
+                      }}
+                    >
+                      {manual}
+                    </code>
+                  </>
+                )}
+              </>
+            )
+          }
+          control={
+            <PGButton size="sm" onClick={install} disabled={busy}>
+              {status?.installed ? "Reinstall pgit" : "Install pgit"}
+            </PGButton>
+          }
+        />
+      )}
     </Section>
   );
 }

--- a/src/test/eventMock.ts
+++ b/src/test/eventMock.ts
@@ -1,0 +1,29 @@
+// Per-test mock of @tauri-apps/api/event. Register listeners via the mocked
+// listen(); fire them from tests with emitMockEvent(). Reset in setup.ts.
+
+type Handler = (event: { payload: unknown }) => void;
+
+const listeners = new Map<string, Set<Handler>>();
+
+export async function listen(
+  event: string,
+  handler: Handler,
+): Promise<() => void> {
+  let set = listeners.get(event);
+  if (!set) {
+    set = new Set();
+    listeners.set(event, set);
+  }
+  set.add(handler);
+  return () => {
+    set.delete(handler);
+  };
+}
+
+export function emitMockEvent(event: string, payload: unknown): void {
+  listeners.get(event)?.forEach((h) => h({ payload }));
+}
+
+export function resetEventMock(): void {
+  listeners.clear();
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -4,10 +4,15 @@ import { cleanup } from "@testing-library/react";
 
 import { resetInvokeMock } from "./invokeMock";
 import { resetDialogMock } from "./dialogMock";
+import { resetEventMock } from "./eventMock";
 
 vi.mock("@tauri-apps/api/core", async () => {
   const { invoke } = await import("./invokeMock");
   return { invoke };
+});
+
+vi.mock("@tauri-apps/api/event", async () => {
+  return await import("./eventMock");
 });
 
 vi.mock("@tauri-apps/plugin-dialog", async () => {
@@ -43,5 +48,6 @@ afterEach(() => {
   cleanup();
   resetInvokeMock();
   resetDialogMock();
+  resetEventMock();
   vi.clearAllMocks();
 });


### PR DESCRIPTION
Closes item 1 of #25 — CLI launchability.

## What

Adds a `pgit` command-line entry point:

| Command | Opens |
|---|---|
| `pgit .` / `pgit ~/repo` | repo containing that path (no screen change) |
| `pgit commit` / `pgit status` | Commit panel |
| `pgit log` / `pgit history` | History |
| `pgit branches` | Branches |
| `pgit` (no args) | plain launch (last persisted state) |
| `pgit --help` | usage, exits before GUI |

A path may follow any subcommand (`pgit log src/`); relative paths resolve against the shell's cwd, and the path is widened to its repo root via `Repository::discover`. Non-repo paths surface the normal `NotARepo` banner.

## How

- **`src-tauri/src/cli.rs`** — pure, unit-tested argv → `LaunchIntent` parsing + shim install/status logic.
- **Single instance** — first launch stashes a resolved intent in managed state; the webview pulls it once (take-once) via `take_launch_intent`. A second `pgit …` is forwarded by `tauri-plugin-single-instance`, which emits a `cli-launch` event and focuses the running window — no second app instance. `PLATYPUSGIT_NO_SINGLE_INSTANCE=1` disables the plugin (e2e + parallel dev; wdio sets it).
- **Frontend** — `useCliLaunch` hook (mounted in `AppShell`) handles the initial intent and forwarded events: opens the repo, then routes via the existing `switch-screen` nav intent.
- **Settings → Command line** — installs the `pgit` shim (symlink: `/usr/local/bin` on macOS, `~/.local/bin` on Linux; Windows shows a note). Permission failure returns a manual `sudo ln -sf …` command instead of erroring.

## Testing

- Rust unit: 12 `cli::` tests (parsing table + shim install/status against temp dirs).
- Frontend: `useCliLaunch` (4) + Settings CLI section (2), full suite 270 passing, tsc clean.
- E2E: 15/15 spec files passing with the single-instance guard active.

Spec + plan: `docs/superpowers/{specs,plans}/2026-07-07-cli-launch*`.

## Out of scope

Windows shim install (PATH work), `pgit diff <file>`, man page / completions, URL scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)