### PR TITLE
fix(rebase): complete conflict resume + stop abort data-loss

### DIFF
--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -28,6 +28,11 @@ pub struct RebaseState {
     pub total: usize,
     pub completed: usize,
     pub pause_reason: Option<String>,
+    /// The step whose cherry-pick conflicted and is awaiting resolution. Held
+    /// out of `plan` so `rebase_continue` commits the user-resolved tree
+    /// instead of re-running the cherry-pick from scratch (which would
+    /// re-conflict). Cleared once the resolved step is committed.
+    pub conflict_step: Option<RebaseStep>,
     /// Branch tip before `rebase_start` moved it — `rebase_abort` restores
     /// this rather than just resetting to wherever the in-progress rebase
     /// happened to stop (see `rebase_abort` doc comment).
@@ -95,21 +100,32 @@ impl Libgit2Backend {
     /// (we build our own commit so we can control the message, tree, etc.).
     /// Returns Ok(true) on a clean apply; Ok(false) when the pick produced
     /// conflicts (the worktree is left dirty so the user can resolve them).
-    fn pick_onto_head(&self, repo_id: &RepoId, oid: &str) -> AppResult<bool> {
+    /// Apply `oid`'s diff into the index + worktree (a cherry-pick), WITHOUT
+    /// committing. Returns `Ok(false)` when the merge left conflicts (caller
+    /// pauses for the user), `Ok(true)` when it applied cleanly and the tree is
+    /// staged ready for `finish_pick`.
+    fn start_pick(&self, repo_id: &RepoId, oid: &str) -> AppResult<bool> {
         self.with_repo(repo_id, |repo| {
             let target = repo
                 .revparse_single(oid)
                 .map_err(|_| AppError::InvalidRef(oid.to_string()))?
                 .peel_to_commit()?;
-            // Apply the diff into the index + worktree.
             repo.cherrypick(&target, None)?;
-
             let statuses = repo.statuses(None)?;
-            if statuses.iter().any(|s| s.status().is_conflicted()) {
-                return Ok(false);
-            }
+            Ok(!statuses.iter().any(|s| s.status().is_conflicted()))
+        })
+    }
 
-            // Build the commit, preserving the original author.
+    /// Commit the currently-staged tree as `oid`'s rebased commit onto HEAD,
+    /// preserving the original author + message, then clear the cherry-pick
+    /// state. Used both after a clean `start_pick` and when resuming a
+    /// conflict the user has resolved (the staged tree is then their merge).
+    fn finish_pick(&self, repo_id: &RepoId, oid: &str) -> AppResult<()> {
+        self.with_repo(repo_id, |repo| {
+            let target = repo
+                .revparse_single(oid)
+                .map_err(|_| AppError::InvalidRef(oid.to_string()))?
+                .peel_to_commit()?;
             let sig = crate::git::signature::default_signature(repo)?;
             let mut index = repo.index()?;
             let tree_oid = index.write_tree()?;
@@ -125,7 +141,7 @@ impl Libgit2Backend {
                 &[&head_commit],
             )?;
             repo.cleanup_state()?;
-            Ok(true)
+            Ok(())
         })
     }
 
@@ -136,17 +152,6 @@ impl Libgit2Backend {
             .map_err(|e| AppError::Internal(e.to_string()))?;
         if let Some(state) = rebases.get_mut(repo_id) {
             state.completed += 1;
-        }
-        Ok(())
-    }
-
-    fn push_front(&self, repo_id: &RepoId, step: RebaseStep) -> AppResult<()> {
-        let mut rebases = self
-            .rebases
-            .lock()
-            .map_err(|e| AppError::Internal(e.to_string()))?;
-        if let Some(state) = rebases.get_mut(repo_id) {
-            state.plan.push_front(step);
         }
         Ok(())
     }
@@ -168,8 +173,11 @@ impl Libgit2Backend {
     /// pauses execution (conflict / edit).
     fn advance_rebase(&self, repo_id: &RepoId) -> AppResult<RebaseStatus> {
         loop {
-            // Take the next step.
-            let step_opt = {
+            // Resume a conflict step first (its cherry-pick already ran and the
+            // user has resolved + staged the tree), else take the next planned
+            // step. A resumed step skips the cherry-pick — its tree is already
+            // the user's merge — so `finish_pick` commits that directly.
+            let (step, resuming) = {
                 let mut rebases = self
                     .rebases
                     .lock()
@@ -181,10 +189,13 @@ impl Libgit2Backend {
                     }
                 };
                 state.pause_reason = None;
-                state.plan.pop_front()
+                match state.conflict_step.take() {
+                    Some(s) => (Some(s), true),
+                    None => (state.plan.pop_front(), false),
+                }
             };
 
-            let Some(step) = step_opt else {
+            let Some(step) = step else {
                 // Plan exhausted — rebase complete. Capture the final status
                 // before dropping the in-memory state so this call's caller
                 // still sees the completed count, but remove the entry so a
@@ -200,25 +211,44 @@ impl Libgit2Backend {
                 return Ok(status);
             };
 
+            // Drop is never cherry-picked, so it is never a resume step.
+            if !resuming && step.action == RebaseAction::Drop {
+                self.bump_completed(repo_id)?;
+                continue;
+            }
+
+            // Stage the step's changes. On resume the resolved tree is already
+            // staged, so skip the (re-)cherry-pick that would re-conflict.
+            if !resuming && !self.start_pick(repo_id, &step.oid)? {
+                // Conflict: stash the step out of the plan (so continue commits
+                // the resolution rather than re-picking) and pause.
+                let mut rebases = self
+                    .rebases
+                    .lock()
+                    .map_err(|e| AppError::Internal(e.to_string()))?;
+                if let Some(state) = rebases.get_mut(repo_id) {
+                    state.conflict_step = Some(step);
+                }
+                drop(rebases);
+                return self.mark_paused(repo_id, "conflict");
+            }
+
+            // Commit the staged tree as this step's rebased commit, then apply
+            // the action's post-commit semantics.
+            self.finish_pick(repo_id, &step.oid)?;
+
             match step.action {
                 RebaseAction::Drop => {
+                    // Only reachable when resuming — a Drop never conflicts and
+                    // is handled above on the fresh path. Nothing extra to do.
                     self.bump_completed(repo_id)?;
-                    continue;
                 }
 
                 RebaseAction::Pick => {
-                    if !self.pick_onto_head(repo_id, &step.oid)? {
-                        self.push_front(repo_id, step)?;
-                        return self.mark_paused(repo_id, "conflict");
-                    }
                     self.bump_completed(repo_id)?;
                 }
 
                 RebaseAction::Reword => {
-                    if !self.pick_onto_head(repo_id, &step.oid)? {
-                        self.push_front(repo_id, step)?;
-                        return self.mark_paused(repo_id, "conflict");
-                    }
                     let new_msg = step.message.clone().unwrap_or_default();
                     self.with_repo(repo_id, |repo| {
                         let sig = crate::git::signature::default_signature(repo)?;
@@ -237,21 +267,12 @@ impl Libgit2Backend {
                 }
 
                 RebaseAction::Edit => {
-                    if !self.pick_onto_head(repo_id, &step.oid)? {
-                        self.push_front(repo_id, step)?;
-                        return self.mark_paused(repo_id, "conflict");
-                    }
                     self.bump_completed(repo_id)?;
                     return self.mark_paused(repo_id, "edit");
                 }
 
                 RebaseAction::Squash | RebaseAction::Fixup => {
                     let is_fixup = matches!(step.action, RebaseAction::Fixup);
-
-                    if !self.pick_onto_head(repo_id, &step.oid)? {
-                        self.push_front(repo_id, step)?;
-                        return self.mark_paused(repo_id, "conflict");
-                    }
 
                     self.with_repo(repo_id, |repo| {
                         let sig = crate::git::signature::default_signature(repo)?;
@@ -2046,6 +2067,7 @@ impl GitBackend for Libgit2Backend {
                 total,
                 completed: 0,
                 pause_reason: None,
+                conflict_step: None,
                 orig_head,
             },
         );

--- a/src-tauri/tests/rebase.rs
+++ b/src-tauri/tests/rebase.rs
@@ -1,7 +1,8 @@
 mod support;
 
 use platypusgit_lib::git::{
-    types::{RebaseAction, RebaseStep},
+    libgit2::Libgit2Backend,
+    types::{RebaseAction, RebaseStep, RepoHandle},
     GitBackend,
 };
 
@@ -321,6 +322,83 @@ fn abort_operation_clears_rebase_state_and_restores_pre_rebase_head() {
         "abort_operation should restore the pre-rebase HEAD (converging with rebase_abort), \
          not wherever the in-progress rebase happened to stop"
     );
+}
+
+// Build a repo where rebasing [pick B, pick A] conflicts on the second pick.
+// Both A and B add conflict.txt with different content from the same base, so
+// picking A on top of B collides. Returns (repo, backend, handle, oid_a, oid_b).
+fn conflicting_rebase_repo() -> (TempRepo, Libgit2Backend, RepoHandle, String, String) {
+    use support::fs::write_file;
+    let tr = TempRepo::with_initial_commit("line1\n");
+
+    write_file(tr.path(), "conflict.txt", "version A\n");
+    {
+        let mut index = tr.repo.index().unwrap();
+        index.add_path(std::path::Path::new("conflict.txt")).unwrap();
+        index.write().unwrap();
+        let tree_oid = index.write_tree().unwrap();
+        let tree = tr.repo.find_tree(tree_oid).unwrap();
+        let sig = git2::Signature::now("T", "t@t").unwrap();
+        let parent = tr.repo.head().unwrap().peel_to_commit().unwrap();
+        tr.repo.commit(Some("HEAD"), &sig, &sig, "commit A", &tree, &[&parent]).unwrap();
+    }
+    let oid_a = tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string();
+
+    write_file(tr.path(), "conflict.txt", "version B\n");
+    {
+        let mut index = tr.repo.index().unwrap();
+        index.add_path(std::path::Path::new("conflict.txt")).unwrap();
+        index.write().unwrap();
+        let tree_oid = index.write_tree().unwrap();
+        let tree = tr.repo.find_tree(tree_oid).unwrap();
+        let sig = git2::Signature::now("T", "t@t").unwrap();
+        let parent = tr.repo.head().unwrap().peel_to_commit().unwrap();
+        tr.repo.commit(Some("HEAD"), &sig, &sig, "commit B", &tree, &[&parent]).unwrap();
+    }
+    let oid_b = tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string();
+
+    let (backend, handle) = tr.open_with_backend();
+    (tr, backend, handle, oid_a, oid_b)
+}
+
+// ─── conflict resolve + continue actually finishes the rebase ────────────────
+//
+// After a conflicted pick, the user resolves the file and continues. The
+// rebase must COMMIT the resolved tree and advance — not re-run the cherry-pick
+// from scratch (which re-conflicts forever).
+#[test]
+fn rebase_conflict_resolve_and_continue_completes() {
+    use std::path::PathBuf;
+    use support::fs::write_file;
+
+    let (tr, backend, handle, oid_a, oid_b) = conflicting_rebase_repo();
+
+    let plan = vec![
+        step(&oid_b, RebaseAction::Pick),
+        step(&oid_a, RebaseAction::Pick),
+    ];
+    let status = backend.rebase_start(&handle.id, plan).unwrap();
+    assert!(status.in_progress, "should pause on the conflicting second pick");
+    assert_eq!(status.pause_reason.as_deref(), Some("conflict"));
+
+    // Resolve the conflict and mark it resolved (what the Conflict screen does).
+    write_file(tr.path(), "conflict.txt", "resolved\n");
+    backend
+        .mark_resolved(&handle.id, &[PathBuf::from("conflict.txt")])
+        .unwrap();
+
+    // Continue: the rebase must finish, committing the resolved tree.
+    let status2 = backend.rebase_continue(&handle.id).unwrap();
+    assert!(
+        !status2.in_progress,
+        "rebase should complete after resolving the conflict and continuing"
+    );
+
+    // The resolved content is committed at the new tip.
+    let content = std::fs::read_to_string(tr.path().join("conflict.txt")).unwrap();
+    assert_eq!(content, "resolved\n");
+    let status_after = backend.rebase_status(&handle.id).unwrap();
+    assert!(!status_after.in_progress, "no rebase in progress after completion");
 }
 
 // ─── 9. sweeping RebaseState on successful completion ────────────────────────

--- a/src/features/repo/useRepoStore.conflictRouting.test.ts
+++ b/src/features/repo/useRepoStore.conflictRouting.test.ts
@@ -1,0 +1,74 @@
+// Store-level tests: the generic conflict continue/abort must route to the
+// rebase-specific ops while an interactive rebase is in progress. Otherwise a
+// resolved rebase conflict would be committed as a standalone commit that
+// leaves the rebase half-done, and a later abort would reset to orig_head and
+// discard it (data loss).
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+import type { RebaseStatus } from "@/lib/types";
+
+const REBASING: RebaseStatus = {
+  inProgress: true,
+  nextIndex: 1,
+  total: 2,
+  pauseReason: "conflict",
+};
+const DONE: RebaseStatus = {
+  inProgress: false,
+  nextIndex: 2,
+  total: 2,
+  pauseReason: null,
+};
+
+const initial = useRepoStore.getState();
+
+function armStore(rebaseStatus: RebaseStatus) {
+  useRepoStore.setState(initial, true);
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/tmp/repo", head: "main" },
+    rebaseStatus,
+    // Isolate routing from the full refresh fan-out.
+    refreshAll: async () => {},
+  });
+}
+
+const called = (cmd: string) => getInvokeCalls().some((c) => c.cmd === cmd);
+
+describe("useRepoStore conflict continue/abort routing", () => {
+  beforeEach(() => {
+    mockInvoke("rebase_continue", () => DONE);
+    mockInvoke("rebase_abort", () => null);
+    mockInvoke("continue_operation", () => "standalone-oid");
+    mockInvoke("abort_operation", () => null);
+  });
+
+  it("continueOperation resumes the rebase when one is in progress", async () => {
+    armStore(REBASING);
+    await useRepoStore.getState().continueOperation();
+    expect(called("rebase_continue")).toBe(true);
+    expect(called("continue_operation")).toBe(false);
+  });
+
+  it("abortOperation aborts the rebase when one is in progress", async () => {
+    armStore(REBASING);
+    await useRepoStore.getState().abortOperation();
+    expect(called("rebase_abort")).toBe(true);
+    expect(called("abort_operation")).toBe(false);
+  });
+
+  it("continueOperation uses the generic op when no rebase is in progress", async () => {
+    armStore(DONE); // inProgress: false
+    await useRepoStore.getState().continueOperation();
+    expect(called("continue_operation")).toBe(true);
+    expect(called("rebase_continue")).toBe(false);
+  });
+
+  it("abortOperation uses the generic op when no rebase is in progress", async () => {
+    armStore(DONE);
+    await useRepoStore.getState().abortOperation();
+    expect(called("abort_operation")).toBe(true);
+    expect(called("rebase_abort")).toBe(false);
+  });
+});

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -958,6 +958,13 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   async abortOperation() {
     const repo = get().current;
     if (!repo) return;
+    // A paused interactive rebase must abort via rebaseAbort, which clears the
+    // RebaseState entry and restores the pre-rebase tip. The generic abort
+    // would leave that entry behind (see rebaseAbort / abort_operation).
+    if (get().rebaseStatus.inProgress) {
+      await get().rebaseAbort();
+      return;
+    }
     try {
       await abortOperation(repo.id);
       await get().refreshAll();
@@ -969,6 +976,14 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   async continueOperation() {
     const repo = get().current;
     if (!repo) return null;
+    // Resolving a conflict during an interactive rebase must continue the
+    // rebase (commit the resolved tree + advance the plan), not create a
+    // standalone commit that leaves the rebase half-done — a later abort would
+    // then reset to orig_head and silently discard the finalized commit.
+    if (get().rebaseStatus.inProgress) {
+      await get().rebaseContinue();
+      return null;
+    }
     try {
       const oid = await continueOperation(repo.id);
       await get().refreshAll();


### PR DESCRIPTION
Fixes the PLAUSIBLE data-loss finding from the release review — and a linked, more fundamental defect it exposed: the interactive-rebase conflict-resume path was broken and untested.

## Root cause (systematic-debugging)
`advance_rebase` always re-ran `repo.cherrypick` for the front step. After a user resolved a conflict, `rebase_continue` re-applied the pick from scratch and errored (`"1 uncommitted change would be overwritten by merge"`) — reproduced with a failing test. There was **no code path that commits a resolved conflict and advances the plan**. The frontend worked around this by using the generic `continueOperation` (which commits a standalone merge commit) — but that left the `RebaseState` entry + plan untouched, so a later **Abort reset `--hard` to `orig_head` and discarded the finalized commit** (the reported data-loss).

## Fix
**Backend** (`libgit2.rs`): split `pick_onto_head` into `start_pick` (cherry-pick only) and `finish_pick` (commit the staged tree). A conflicted step is held in `RebaseState.conflict_step`, out of the plan. On continue, `advance_rebase` commits the user-resolved tree via `finish_pick` and advances — instead of re-picking.

**Frontend** (`useRepoStore`): `continueOperation`/`abortOperation` now delegate to `rebaseContinue`/`rebaseAbort` when `rebaseStatus.inProgress`, so the Conflict screen's Finalize/Abort and the palette continue/abort commands all resolve a rebase conflict through the plan-aware path. Non-rebase merge/cherry-pick/revert conflicts still use the generic ops.

## Verification
- New backend test `rebase_conflict_resolve_and_continue_completes` — reproduced the failure, now passes; confirmed it fails without the fix.
- New store test `useRepoStore.conflictRouting` — continue/abort route to rebase ops while rebasing, generic ops otherwise.
- `cargo test` (all suites incl. existing drop/reword/squash/fixup/edit/abort/completion) — pass
- `pnpm test` — 268 passed · `pnpm tsc --noEmit` (src + e2e) — clean

## Note
Conflict-resume shares one code path across pick/reword/squash/fixup/edit; the regression test covers the Pick case (the reported scenario). Webview-level rebase e2e runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)