### PR TITLE
docs(site): v0.0.6 changelog, features + roadmap refresh

### DIFF
--- a/site/src/data/features.ts
+++ b/site/src/data/features.ts
@@ -20,9 +20,11 @@ export const featureGroups = [
   ]},
   { title: 'Diff & viewing', blurb: 'See exactly what changed, anywhere.', items: [
     'Worktree / index / HEAD diffs',
+    'Unified and side-by-side (split) diff views',
+    'Configurable diff context lines',
     'Commit-to-commit diffs',
     'Line-by-line blame',
-    'Repo file browser at HEAD',
+    'Repo file browser at HEAD, or any revision',
   ]},
   { title: 'Branches & tags', blurb: 'Full ref management.', items: [
     'List / create / checkout / rename / delete branches',
@@ -31,6 +33,8 @@ export const featureGroups = [
   ]},
   { title: 'History', blurb: 'Navigate the past.', items: [
     'Commit graph layout',
+    'Ref-scoped log — browse the log of any branch, tag, or revspec',
+    'Commit / log search (message, author, SHA, date, path)',
     'Per-file history',
     'Reflog viewer',
     'Detached-HEAD checkout',
@@ -61,19 +65,42 @@ export const featureGroups = [
     'Push with-lease and force',
     'Merge branches',
   ]},
+  { title: 'Navigation & keyboard', blurb: 'Keyboard-first, fast everywhere.', items: [
+    'Command palette (⌘P) — branches, files, commits, and actions',
+    'Rider-style default keymap, with a Classic preset',
+    'Type-to-jump speed-search in lists',
+    'Commit chords and F7 / ⇧F7 hunk navigation',
+    'Spatial Alt+Arrow pane focus and a ? cheat sheet',
+    '`pgit` command-line launcher — open a repo from the terminal',
+  ]},
 ];
 
 // Roadmap teaser (from features.md P0/P1 — clearly "planned")
 export const roadmap = [
-  'Side-by-side diff view + intra-line highlighting',
+  'Intra-line (word-level) diff highlighting',
   'Branch compare — branch↔branch and branch↔working tree',
   'GPG/SSH commit + tag signing with verified badge',
   'Multi-repo tabs / fast recent-repo switcher',
   'Quick merge/rebase from the branch picker',
   'Partial/hunk-level stash + rename + compare to working tree',
+  'Signed & notarized macOS / Windows builds',
 ];
 
 export const changelog = [
+  {
+    version: '0.0.6',
+    date: '2026-07-07',
+    status: 'feature',
+    notes: [
+      'Keyboard navigation — a full keymap system with a Rider-style default (Classic preset available), type-to-jump speed-search, commit chords, `F7` / `⇧F7` hunk navigation, spatial `Alt+Arrow` pane focus, and a `?` cheat sheet.',
+      '`pgit` command-line launcher — open a repo from the terminal with `pgit [subcommand] [path]`; forwards into a running instance; installable shim.',
+      'Ref-scoped history — browse the commit log of any branch, tag, or revspec and cherry-pick from unmerged refs via the History ref selector.',
+      'Command palette upgrades — an actions catalog, frecency ranking, drill-in steps, and type-filter chips (⌘P / Ctrl+P).',
+      'Multi-file selection — select several files in the commit panel or repo browser and stage / unstage / discard them from the context menu.',
+      'Settings — configurable diff context lines and UI density; non-functional toggles removed.',
+      'Fixes — interactive-rebase conflict resume now completes, and aborting no longer discards a resolved commit; the palette type chips run the highlighted row; palette Pull honours your pull-mode setting and tracking branch; the commit shortcut no longer double-commits on key-repeat; History selection resets when a filter shrinks the list.',
+    ],
+  },
   {
     version: '0.0.5',
     date: '2026-07-01',

--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -32,10 +32,11 @@ pnpm tauri build   # produces .dmg / .msi / .deb / .AppImage`;
 
   <section class="container">
     <div class="notice">
-      <strong>Builds are early pre-releases.</strong> Every published release attaches prebuilt
+      <strong>Builds are early but usable.</strong> Every published release attaches prebuilt
       binaries for all three platforms — macOS <code>.dmg</code>, Windows <code>.msi</code>,
-      Linux <code>.deb</code> &amp; <code>.AppImage</code>. Grab the newest from the
-      <a href={site.releases} target="_blank" rel="noopener">Releases page</a>, or
+      Linux <code>.deb</code> &amp; <code>.AppImage</code>. The download buttons above always
+      point at the <a href={site.releasesLatest} target="_blank" rel="noopener">latest release</a>;
+      browse <a href={site.releases} target="_blank" rel="noopener">all releases</a>, or
       <a href="#build">build from source</a>.
     </div>
   </section>


### PR DESCRIPTION
Site updates for the v0.0.6 release.

- **Changelog**: new v0.0.6 entry — keyboard navigation, `pgit` CLI launcher, ref-scoped history, command-palette upgrades, multi-file selection, settings, and the rebase/palette/history fixes.
- **Features**: added a *Navigation & keyboard* group (palette, Rider/Classic keymaps, speed-search, hunk nav, `pgit`); noted side-by-side diff + configurable context under Diff, and ref-scoped log + commit search under History.
- **Roadmap**: side-by-side diff shipped, so narrowed that item to intra-line (word-level) highlighting; added signed & notarized builds.
- **Download**: copy now points at the latest-release links (the download buttons already resolve to `releases/latest/download/...`); dropped the stale "pre-releases" wording since v0.0.6 is a full release.

`pnpm build` (astro) passes; verified the rendered changelog/features/download pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)