### PR TITLE
fix(branches): scroll refs list instead of overflowing viewport

### DIFF
--- a/e2e/specs/branches.e2e.ts
+++ b/e2e/specs/branches.e2e.ts
@@ -1,6 +1,6 @@
 import { browser, $, expect } from "@wdio/globals";
-import { basicRepo, TempRepo } from "../support/tempRepo";
-import { openRepo, resetApp } from "../support/app";
+import { basicRepo, manyRefsRepo, TempRepo } from "../support/tempRepo";
+import { openRepo, resetApp, switchScreen } from "../support/app";
 
 describe("branches", () => {
   let repo: TempRepo;
@@ -54,5 +54,71 @@ describe("branches", () => {
       { timeout: 20_000, timeoutMsg: "chip did not update back to main" },
     );
     expect(repo.git("branch", "--show-current").trim()).toBe("main");
+  });
+});
+
+describe("branches — many refs layout", () => {
+  let repo: TempRepo;
+
+  beforeEach(async () => {
+    repo = manyRefsRepo();
+    await openRepo(repo.path);
+  });
+
+  afterEach(async () => {
+    await resetApp();
+    repo.dispose();
+  });
+
+  it("scrolls the refs list internally instead of overflowing the viewport", async () => {
+    await switchScreen("branches");
+
+    const list = $('[aria-label="Refs list"]');
+    await list.waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "refs list scroll region never appeared",
+    });
+
+    // Gate: wait until the store's branch/tag fetch has populated enough rows
+    // to overflow the content area (fetch resolves after the screen mounts).
+    // scrollHeight is the total row height in both broken and fixed layouts,
+    // so this only proves the rows rendered — not that scrolling works.
+    await browser.waitUntil(
+      () =>
+        browser.execute(() => {
+          const el = document.querySelector('[aria-label="Refs list"]');
+          return !!el && el.scrollHeight > 1500;
+        }),
+      {
+        timeout: 20_000,
+        timeoutMsg: "refs list never grew tall enough to overflow",
+      },
+    );
+
+    const geom = await browser.execute(() => {
+      const el = document.querySelector(
+        '[aria-label="Refs list"]',
+      ) as HTMLElement;
+      const r = el.getBoundingClientRect();
+      return {
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
+        bottom: r.bottom,
+        innerHeight: window.innerHeight,
+      };
+    });
+
+    // The content overflows the scroll region internally — a real scrollbar,
+    // not the list stretching to full content height. Broken layout has
+    // clientHeight === scrollHeight (nothing to scroll).
+    expect(geom.scrollHeight).toBeGreaterThan(geom.clientHeight);
+
+    // The scroll region is bounded to the window: its bottom edge stays within
+    // the viewport rather than spilling past it (what pushed the toolbar and
+    // status bar off-screen before the fix).
+    expect(geom.bottom).toBeLessThanOrEqual(geom.innerHeight + 2);
+
+    // Toolbar survives — filter input still visible at the top.
+    await expect($('input[placeholder="Filter by name…"]')).toBeDisplayed();
   });
 });

--- a/e2e/support/tempRepo.ts
+++ b/e2e/support/tempRepo.ts
@@ -82,6 +82,22 @@ export function branchyRepo(): TempRepo {
   return r; // 5 commits reachable from main, two lanes in graph
 }
 
+/** Many branches and tags — enough refs to overflow the Branches screen
+ *  viewport (~700px content area, 28px rows). Regression fixture for the
+ *  list-not-scrolling bug: the refs list must scroll internally rather than
+ *  grow past the window and shove the toolbar/chrome off-screen.
+ *  `git branch`/`git tag` (no checkout) keep setup fast. */
+export function manyRefsRepo(): TempRepo {
+  const r = basicRepo();
+  for (let i = 0; i < 60; i++) {
+    r.git("branch", `feature/branch-${String(i).padStart(2, "0")}`);
+  }
+  for (let i = 0; i < 30; i++) {
+    r.git("tag", `v0.${String(i).padStart(2, "0")}.0`);
+  }
+  return r;
+}
+
 export function conflictRepo(): TempRepo {
   const r = new TempRepo();
   r.commitFile("conflict.txt", "base\n", "feat: base");

--- a/src/screens/Branches.tsx
+++ b/src/screens/Branches.tsx
@@ -242,8 +242,17 @@ export function BranchesScreen() {
         fetching={!!activity.fetch}
       />
       <div style={{ flex: 1, minHeight: 0, display: "flex" }}>
-        <PGPane id="branches.list" style={{ flex: 1, minWidth: 0 }}>
-          <FocusableScroll ariaLabel="Refs list">
+        <PGPane
+          id="branches.list"
+          style={{
+            flex: 1,
+            minWidth: 0,
+            display: "flex",
+            flexDirection: "column",
+            overflow: "hidden",
+          }}
+        >
+          <FocusableScroll ariaLabel="Refs list" style={{ flex: 1 }}>
           <div style={{ minWidth: totalWidth }}>
             <div
               style={{


### PR DESCRIPTION
## Problem

With many branches and tags, the Branches screen list grew to full content height and spilled past the window — no scrollbar, and the surrounding chrome (toolbar/status bar) pushed off-screen. Reported: "top bar squeezed away, no scroll, looks ugly."

## Root cause

`src/screens/Branches.tsx` — the `branches.list` `PGPane` was a plain relative block (`{ flex: 1, minWidth: 0 }`) with an unbounded `FocusableScroll`. Every other list screen (History, Reflog, DiffViewer) wraps its scroll region in a bounded flex column; Branches didn't. A `FocusableScroll` (`overflow: auto`) only scrolls when its height is constrained — here it auto-sized to content, so it overflowed instead of scrolling.

RED proof from the new e2e test on the unfixed binary: `scrollHeight === clientHeight === 2608px` inside an 800px window (nothing to scroll).

## Fix

- Pane → `display: flex; flexDirection: column; overflow: hidden`
- Scroll region → `flex: 1`

The list now scrolls internally and stays within the viewport, matching the other screens' pattern.

## Tests

- New `manyRefsRepo` fixture (60 branches + 30 tags) in `e2e/support/tempRepo.ts`.
- New e2e regression test in `e2e/specs/branches.e2e.ts` asserting the refs list scrolls internally (`scrollHeight > clientHeight`) and its bottom edge stays within the viewport.

## Verification

- e2e suite: 15/15 spec files pass; branches spec 2/2.
- vitest: 286/286.
- `pnpm tsc --noEmit` and e2e typecheck: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)