### PR TITLE
chore(e2e): headless e2e runner in Docker, parallel-safe across worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,50 @@ pnpm test                                   # vitest (unit logic + component tes
 pnpm test:e2e                               # full e2e: debug build + all specs (CI does this; local only rarely)
 pnpm test:e2e:build                         # rebuild debug binary snapshot only (after src/ or src-tauri/ change)
 pnpm test:e2e:run --spec e2e/specs/X.e2e.ts # run ONLY relevant spec(s) against current snapshot
+pnpm test:e2e:docker                        # headless e2e in Docker (macOS: only way to run WITHOUT a window)
 pnpm exec tsc -p e2e/tsconfig.json --noEmit # e2e typecheck gate (root tsc excludes e2e/)
 ```
+
+### Headless e2e in Docker (`pnpm test:e2e:docker`)
+
+macOS has no headless webview — a native `pnpm test:e2e` run pops a real
+WKWebView window and needs foreground focus (`ensureMacAppFocus`). To run
+headless, drive the CI stack (WebKitGTK + xvfb) in a container. Same webview
+target CI uses, so a green Docker run matches the PR gate; it does NOT prove
+the macOS WKWebView path (run native for that).
+
+Files: `Dockerfile.e2e` (mirrors `.github/workflows/e2e.yml` deps),
+`docker-compose.e2e.yml`, `e2e/docker-entrypoint.sh` (phase dispatch),
+`e2e/e2e-docker.sh` (wrapper — sets a per-worktree compose project name).
+
+```bash
+pnpm test:e2e:docker                                  # full: build binary + whole suite, headless
+pnpm test:e2e:docker full --spec e2e/specs/X.e2e.ts   # full build + one spec
+pnpm test:e2e:docker run  --spec e2e/specs/X.e2e.ts   # reuse THIS worktree's snapshot, one spec
+pnpm test:e2e:docker build                            # rebuild this worktree's snapshot only
+```
+
+First run is slow (image build + cargo compile from scratch). Reruns reuse
+cached layers + shared package caches; only changed code recompiles.
+
+**Memory:** the compose service caps `CARGO_BUILD_JOBS=2` +
+`CARGO_PROFILE_DEV_DEBUG=0` because the default ~8GB Docker VM OOM-kills rustc
+(SIGKILL) when cargo fans out one job per CPU — the GTK/WebKit crates each cost
+2–4GB to compile, so even a few overlapping blow the limit. Bump
+`CARGO_BUILD_JOBS` in `docker-compose.e2e.yml` if you give the VM more RAM
+(Docker Desktop → Settings → Resources); 2 is safe at 8GB but leaves most of
+the 14 CPUs idle during the compile.
+
+**Parallel agents / worktrees:** safe by construction. `e2e/e2e-docker.sh`
+derives `COMPOSE_PROJECT_NAME=pgit-e2e-<worktree-dir-slug>`, so each worktree
+gets its own `node_modules` / `target` / `.bin` volumes (the cargo target dir
+is NOT safe for concurrent builds → must be per-worktree). Package caches
+(pnpm store, cargo registry/git) have fixed volume names shared across all
+worktrees — concurrency-safe, so crates download once, not per-worktree. The
+WebDriver port (4445) is internal to each container, never published, so no
+host-port collisions. Different worktrees → run concurrently, no coordination.
+Same worktree → run one at a time (they'd share the target volume). Each agent
+just runs `pnpm test:e2e:docker …` from its own worktree.
 
 ## Testing
 

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,0 +1,40 @@
+# Headless e2e runner — mirrors .github/workflows/e2e.yml (ubuntu-latest +
+# WebKitGTK + xvfb). Lets macOS devs run the WebdriverIO suite headless in the
+# same webview target CI uses. NOT a production image.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Tauri/WebKitGTK build+run deps + xvfb — same apt set as the CI workflow,
+# plus curl/git/build-essential to bootstrap node & rust.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
+      librsvg2-dev patchelf xvfb \
+      curl ca-certificates git build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node 22 (matches CI setup-node)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# pnpm 9 (matches CI pnpm/action-setup version)
+RUN npm install -g pnpm@9 \
+    && pnpm config set store-dir /pnpm-store --global
+
+# Rust stable via rustup
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Fixture git identity (mirror CI "Configure git for fixtures"); the app repo
+# itself is never git-operated inside the container — temp-repo fixtures build
+# their own repos in tmp dirs.
+RUN git config --global user.name "CI" \
+    && git config --global user.email "ci@platypusgit.test" \
+    && git config --global init.defaultBranch main \
+    && git config --global --add safe.directory '*'
+
+WORKDIR /app
+
+ENTRYPOINT ["/app/e2e/docker-entrypoint.sh"]
+CMD ["full"]

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,54 @@
+# Headless e2e via Docker — replicates the CI WebKitGTK+xvfb stack locally so
+# the suite runs without a display (macOS has no headless webview). See
+# Dockerfile.e2e. Drive it via `e2e/e2e-docker.sh` (pnpm test:e2e:docker),
+# which sets a per-worktree COMPOSE_PROJECT_NAME so multiple agents can run in
+# parallel from different worktrees without colliding.
+#
+# Volume isolation strategy for parallel runs:
+#   - node_modules / target / .bin are PROJECT-scoped (default naming) — the
+#     cargo target dir is not safe for concurrent builds, so each worktree
+#     compiles into its own volume.
+#   - pnpm store + cargo registry/git have FIXED names → shared across all
+#     worktrees. Both are concurrency-safe (content-addressed store; cargo
+#     package-cache file locks), so downloads are cached once, not per-worktree.
+services:
+  e2e:
+    build:
+      context: .
+      dockerfile: Dockerfile.e2e
+    # The Docker VM (default ~8GB) OOM-kills rustc when cargo fans out one job
+    # per CPU (14 here) — aggregate peak memory blows the limit (SIGKILL/sig 9).
+    # Cap parallelism and drop debuginfo (irrelevant for an e2e binary, and the
+    # biggest per-crate memory sink) to keep peak bounded. Override JOBS higher
+    # if your VM has more RAM (Docker Desktop → Settings → Resources).
+    environment:
+      CARGO_BUILD_JOBS: "2"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+    volumes:
+      # Source is bind-mounted so host edits are picked up without a rebuild.
+      - .:/app
+      # Platform-specific dirs kept in named volumes: the Linux node_modules,
+      # cargo target, and debug-binary snapshot must NOT overwrite the host's
+      # macOS equivalents (all three are gitignored).
+      - e2e-node-modules:/app/node_modules
+      - e2e-target:/app/src-tauri/target
+      - e2e-bin:/app/e2e/.bin
+      # Persist caches across runs so only changed crates/packages rebuild.
+      - e2e-pnpm-store:/pnpm-store
+      - e2e-cargo-registry:/root/.cargo/registry
+      - e2e-cargo-git:/root/.cargo/git
+    # Default: full build + run. Override on the CLI for build/run phases.
+    command: ["full"]
+
+volumes:
+  # Project-scoped (unique per worktree via COMPOSE_PROJECT_NAME).
+  e2e-node-modules:
+  e2e-target:
+  e2e-bin:
+  # Fixed names → shared across every worktree/agent (concurrency-safe caches).
+  e2e-pnpm-store:
+    name: pgit-e2e-pnpm-store
+  e2e-cargo-registry:
+    name: pgit-e2e-cargo-registry
+  e2e-cargo-git:
+    name: pgit-e2e-cargo-git

--- a/e2e/docker-entrypoint.sh
+++ b/e2e/docker-entrypoint.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Container entrypoint for headless e2e. node_modules / target / e2e/.bin live
+# in named volumes (see docker-compose.e2e.yml) so Linux artifacts never
+# clobber the host's macOS ones. First arg selects the phase; extra args pass
+# through to wdio (e.g. --spec).
+set -euo pipefail
+
+# node_modules is a fresh volume on first run — install is a fast no-op once the
+# lockfile is satisfied.
+pnpm install --frozen-lockfile
+
+phase="${1:-full}"
+shift || true
+
+case "$phase" in
+  full)
+    pnpm test:e2e:build
+    xvfb-run --auto-servernum pnpm test:e2e:run "$@"
+    ;;
+  build)
+    pnpm test:e2e:build
+    ;;
+  run)
+    # Reuses the e2e/.bin snapshot from a prior `build`/`full`. Pass
+    # --spec e2e/specs/<file>.e2e.ts to scope.
+    xvfb-run --auto-servernum pnpm test:e2e:run "$@"
+    ;;
+  *)
+    echo "unknown phase '$phase' (expected: full | build | run)" >&2
+    exit 2
+    ;;
+esac

--- a/e2e/e2e-docker.sh
+++ b/e2e/e2e-docker.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Drive the headless-e2e container (see docker-compose.e2e.yml). Derives a
+# unique compose project name from this checkout's directory so multiple
+# agents can run the suite in parallel from different worktrees without their
+# node_modules/target/.bin volumes colliding. Package caches are shared (fixed
+# volume names in the compose file).
+#
+# Usage (args forward to the container entrypoint → wdio):
+#   e2e/e2e-docker.sh                              # full: build binary + whole suite
+#   e2e/e2e-docker.sh full --spec e2e/specs/X.e2e.ts
+#   e2e/e2e-docker.sh run  --spec e2e/specs/X.e2e.ts   # reuse this worktree's snapshot
+#   e2e/e2e-docker.sh build                        # rebuild snapshot only
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Sanitize the checkout dir name into a valid compose project slug
+# ([a-z0-9_-]). Worktree dirs like "chore+e2e-docker" → "chore-e2e-docker".
+slug="$(basename "$root" \
+  | tr '[:upper:]' '[:lower:]' \
+  | tr -c 'a-z0-9_-' '-' \
+  | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')"
+export COMPOSE_PROJECT_NAME="pgit-e2e-${slug:-default}"
+
+echo "[e2e-docker] project=${COMPOSE_PROJECT_NAME} root=${root}" >&2
+exec docker compose -f "$root/docker-compose.e2e.yml" run --rm --build e2e "$@"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test:watch": "vitest",
     "test:e2e": "pnpm test:e2e:build && pnpm test:e2e:run",
     "test:e2e:build": "pnpm tauri build --debug --no-bundle --features tauri/custom-protocol --config src-tauri/tauri.e2e.conf.json && mkdir -p e2e/.bin && cp src-tauri/target/debug/platypusgit e2e/.bin/platypusgit",
-    "test:e2e:run": "wdio run e2e/wdio.conf.ts"
+    "test:e2e:run": "wdio run e2e/wdio.conf.ts",
+    "test:e2e:docker": "e2e/e2e-docker.sh"
   },
   "dependencies": {
     "@tauri-apps/api": "^2",


### PR DESCRIPTION
## What

Adds a Docker path to run the WebdriverIO e2e suite **headless** — the only way to run it without a window on macOS (no headless webview; native runs pop a real WKWebView and need foreground focus). The container mirrors the CI stack (Ubuntu 24.04 + WebKitGTK + xvfb).

## Usage

```bash
pnpm test:e2e:docker                                # build binary + whole suite, headless
pnpm test:e2e:docker full --spec e2e/specs/X.e2e.ts # full build + one spec
pnpm test:e2e:docker run  --spec e2e/specs/X.e2e.ts # reuse this worktree's snapshot
pnpm test:e2e:docker build                          # rebuild snapshot only
```

## Files

- `Dockerfile.e2e` — mirrors `.github/workflows/e2e.yml` deps + node22/pnpm9/rust
- `docker-compose.e2e.yml` — volume isolation + memory caps
- `e2e/docker-entrypoint.sh` — phase dispatch (`full`/`build`/`run`), forwards `--spec`
- `e2e/e2e-docker.sh` — wrapper deriving per-worktree `COMPOSE_PROJECT_NAME`
- `package.json` — `test:e2e:docker` script
- `CLAUDE.md` — headless-Docker section + parallel-agent scheme + memory note

## Parallel agents across worktrees

Safe by construction: each worktree gets its own compose project → isolated `node_modules`/`target`/`.bin` volumes (the cargo target dir isn't concurrency-safe). pnpm store + cargo registry use fixed volume names shared across worktrees (concurrency-safe, so crates download once). WebDriver port 4445 is internal per container — no host collisions. Different worktrees run concurrently with zero coordination.

## Memory

The default ~8GB Docker VM OOM-kills rustc (SIGKILL) when cargo fans out one job per CPU — GTK/WebKit crates cost 2–4GB each to compile. Capped `CARGO_BUILD_JOBS=2` + `CARGO_PROFILE_DEV_DEBUG=0` to bound peak memory. Overridable for larger VMs.

## Verification

Ran `harness.e2e.ts` headless in-container: **WebKitGTK 605.1.15 linux, 3 passing, exit 0**.

Caveat: a green Docker run matches the CI/PR gate but does **not** prove the macOS WKWebView path — run native `pnpm test:e2e` for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)