### PR TITLE
feat(history): multi-select commits — combined diff + squash/cherry-pick (#54)

### DIFF
--- a/docs/superpowers/plans/2026-07-08-multi-select-commits.md
+++ b/docs/superpowers/plans/2026-07-08-multi-select-commits.md
@@ -1,0 +1,126 @@
+# Multi-Select Commits — Implementation Plan
+
+Spec: `docs/superpowers/specs/2026-07-08-multi-select-commits-design.md`
+
+TDD: pure logic and store behavior get tests first. UI gets a component test.
+
+## 1. Pure logic (tests first)
+
+`src/features/commits/planCommitSelection.ts` (new) + `.test.ts`:
+
+- `CommitSelectionPlan` interface + `planCommitSelection(commits, selectedOids)`
+  per spec. Map each selected oid to its index in `commits` (newest-first),
+  drop unknowns, sort ascending. `newestOid = commits[min]`,
+  `oldestOid = commits[max]`, `baseOid = commits[max+1]?.oid ?? null`,
+  `contiguous = max - min + 1 === indices.length`,
+  `oids = indices desc → commits[i].oid` (oldest→newest),
+  `hasMerge = any commits[i].parents.length > 1`. Empty → `null`.
+
+`src/features/commits/buildRebasePlan.ts` + `.test.ts`:
+
+- Add `| { kind: "squash-range"; oids: string[]; message: string }` to the
+  `mode` union. In the map, compute `oldestSelected` = first entry of
+  `oldestFirst` whose oid ∈ `oids`; a commit in `oids` other than
+  `oldestSelected` → `action = "Squash"`, `message = mode.message`. Everything
+  else stays `Pick`.
+
+## 2. Keymap: shift+arrow extend
+
+`src/features/keymap/actions.ts`: add `"list.extendUp"` / `"list.extendDown"`
+to the `ActionId` union and the catalog (`category: "Lists & trees"`,
+`scope: "pane"`, `suppressInInput: true`, titles "Extend selection up/down").
+
+`src/features/keymap/presets.ts`: bind `"list.extendUp": ["Shift+ArrowUp"]`,
+`"list.extendDown": ["Shift+ArrowDown"]` (shared map; check `presets.test.ts`
+for any "every action bound" assertion and satisfy it).
+
+`src/features/keymap/usePaneList.ts`: add optional `onExtendUp?: () => void`
+and `onExtendDown?: () => void`; register `list.extendUp`/`list.extendDown`
+guarded like the others (decline when the callback is absent so the chord
+falls through).
+
+## 3. Store: cherryPickMany
+
+`src/features/repo/useRepoStore.ts`: add `cherryPickMany: (oids: string[]) =>
+Promise<void>` to the interface and impl. Import the raw `cherryPick` wrapper
+(already imported). Loop `for (const oid of oids) await cherryPick(repo.id,
+oid)`, then one `refreshAll()`. Catch: `await refreshAll(); set({ error })`
+(refresh-first convention). `oids` arrive oldest→newest from the caller.
+
+Test in `useRepoStore` (or a focused `*.test.ts`): `mockInvoke("cherry_pick")`
+records oids; assert order + that a throwing pick stops the loop.
+
+## 4. Context menu: commitMultiMenuItems
+
+`src/design/context-menu.tsx`: export `commitMultiMenuItems(oids: string[]):
+ContextMenuItem[]`. Compute `planCommitSelection(useRepoStore.getState()
+.commits, oids)` inside. Items:
+
+- title `N commits`.
+- **View combined diff** → `useNavStore.setIntent({ kind: "commit-vs-commit",
+  from: plan.baseOid ?? plan.oldestOid, to: plan.newestOid })`.
+- **Cherry-pick N onto current** → `confirm` → `cherryPickMany(plan.oids)`.
+- **Squash N into one…** → disabled (grey, no-op) with a reason when
+  `!contiguous || hasMerge || !baseOid`; else `prompt` message →
+  `buildRebasePlan(commits, baseOid, { kind: "squash-range", oids, message })`
+  → `setIntent({ kind: "rebase-plan", plan })`.
+- divider, **Copy N SHAs** → clipboard join `\n`.
+
+(Menu-item disabling: reuse whatever `ContextMenuItem` supports — a `disabled`
+flag if present, else omit the item and add a titled note. Verify the type.)
+
+## 5. History screen
+
+`src/screens/History.tsx`:
+
+- State: `const [sel, setSel] = React.useState<Selection>(emptySelection)`
+  replacing `selected: number`.
+- `order = React.useMemo(() => visible.map(c => c.oid), [visible])`.
+- Prune effect: `setSel(prev => pruneSelection(prev, new Set(order)))` on
+  `order`; also reset (`emptySelection`) on `repo?.id` change. Remove the old
+  `setSelected(0)` shape-reset effect (pruning subsumes it) — but keep top
+  selection sane: when pruning empties the selection, seed to `order[0]`.
+- `primaryOid = primarySelectedKey(sel) ?? order[0] ?? null`;
+  `current = visible.find(c => c.oid === primaryOid) ?? visible[0]`.
+- `selectedIndex` for `usePaneList` = `visible.findIndex(primaryOid)`.
+  `onSelect(i)` → `setSel(clickSelection(order, sel, order[i], {}))` (plain,
+  collapses to one). `onActivate(i)`: if `sel.keys.length > 1` fire
+  `commit-vs-commit` (from base of the selection, to newest) else the existing
+  `commit-vs-wt`. `onExtendUp`/`onExtendDown`:
+  `setSel(clickSelection(order, sel, order[clamp(idx∓1)], { range: true }))`.
+- Row: `selected={sel.keys.includes(c.oid)}`,
+  `onClick={(e) => setSel(clickSelection(order, sel, c.oid, { toggle:
+  e.metaKey||e.ctrlKey, range: e.shiftKey }))}`,
+  `onContextMenu`: if `c.oid ∈ sel.keys && sel.keys.length > 1` open
+  `commitMultiMenuItems(sel.keys)`; else collapse to the row + existing single
+  menu.
+- Detail pane: when `sel.keys.length > 1`, render a multi summary + multi
+  action buttons (see below) above the existing single detail; when 1, today's
+  `PGCommitDetail` + `CommitActionRow`.
+- `CommitActionRow`: extend to accept the selection. Single → unchanged. Multi
+  → buttons wired to the same handlers as the menu (combined diff, cherry-pick
+  N, squash…, copy N). Disable squash with a titled reason via
+  `planCommitSelection`.
+
+`src/design/git-components.tsx`: `PGCommitRow` — `onClick?: (e:
+React.MouseEvent) => void` (thread the event; `data-selected`/`data-pg-row`
+already present).
+
+## 6. E2E
+
+`e2e/specs/history-ops.e2e.ts` + `multiCherryRepo` fixture. Build the
+selection with a plain row click (focuses the pane) then
+`jsChord("Shift+ArrowDown")` — the embedded driver can't synthesize modifiers,
+so the chord goes through the real keymap window listener. Two cases:
+
+- *combined diff*: select two commits on `main`, click "View combined diff",
+  assert the introduced file (`b.txt`) is listed on the CommitDiff screen.
+- *multi cherry-pick*: scope the log to `feature` (ref selector), select its
+  two commits, click "Cherry-pick 2", assert both files land on `main`.
+
+## 7. Gates
+
+`pnpm tsc --noEmit` · `pnpm test` · `pnpm vite build` · `pnpm exec tsc -p
+e2e/tsconfig.json --noEmit` · `pnpm test:e2e:run --spec
+e2e/specs/history-ops.e2e.ts`. Then squash to one Conventional Commit and open
+the PR.

--- a/docs/superpowers/specs/2026-07-08-multi-select-commits-design.md
+++ b/docs/superpowers/specs/2026-07-08-multi-select-commits-design.md
@@ -1,0 +1,158 @@
+# Multi-Select Commits — Design
+
+Status: approved 2026-07-08 (issue #54, spun out of #25)
+
+## Problem
+
+The History commit list is strictly single-select (`selected: number`). You
+can't see a **combined diff** of several commits, cherry-pick a handful onto
+the current branch in one action, or squash a contiguous range into one
+commit. Multi-file selection already shipped for the working tree (#25 /
+`2026-07-03-multi-file-select`); commits deserve the same.
+
+## Scope
+
+Frontend + one store action. No new Tauri command and no Rust change: the
+backend already has everything.
+
+- **Combined diff** — `diffCommits(repoId, from, to, ctx)` does a plain
+  tree-to-tree diff (`git diff from to`). For "everything these N commits
+  changed" pass `from = parent-of-oldest`, `to = newest`. Routed through the
+  existing `commit-vs-commit` nav intent → CommitDiff screen (same panel used
+  today for single-commit diffs).
+- **Cherry-pick a set** — the single `cherry_pick(oid)` op auto-commits on a
+  clean apply and returns `ConflictsDetected` (leaving conflicted state) on
+  conflict. A set is a store-level loop over that op, oldest→newest; a
+  conflict stops the loop and surfaces via the existing Conflict screen. No
+  batched backend op needed.
+- **Squash a contiguous range** — driven entirely through the existing
+  `rebase_start` engine. `rebase_start` resets to the first step's parent and
+  replays a plan; its Squash action re-parents each squashed commit onto the
+  previous one. So a plan of `[Pick oldest, Squash …rest, Pick …newer]`
+  collapses the selection into one commit. Reuses the `rebase-plan` nav intent
+  → Rebase screen (review + run + conflict/continue), exactly like the
+  existing single-commit "Squash into parent" menu item.
+
+Out of scope: batched-cherry-pick *resume* after a mid-set conflict (resolving
+the conflict commits that one pick; remaining picks are not auto-continued —
+documented, matches the "stop-and-surface" requirement); multi-select in other
+commit lists (FileHistory, Reflog); drag-select.
+
+## Selection model
+
+Reuse the pure `src/lib/selection.ts` helper (`Selection { keys; anchor }`,
+`clickSelection`, `pruneSelection`, `primarySelectedKey`) unchanged — keys are
+commit **oids**. Classic desktop semantics:
+
+- **Plain click** — select exactly that commit, anchor moves to it.
+- **Cmd/Ctrl-click** — toggle the commit in/out; anchor handoff per the helper.
+- **Shift-click** — contiguous range of *visible* rows between anchor and the
+  clicked row.
+- **Keyboard** — plain ↑/↓ move a single cursor (collapse to one, unchanged);
+  **Shift+↑/↓** extend the range from the anchor. Home/End unchanged.
+- **Pruning** — when `visible` changes (search, filter, refresh, repo switch),
+  drop selected oids that vanished; a dropped anchor re-homes to the last
+  surviving selection. Replaces today's `setSelected(0)` reset effect.
+
+The **primary** commit (`primarySelectedKey`, anchor-or-last) drives the
+existing detail pane, so single-selection behavior is unchanged.
+
+**Selection order lives in `visible` (the filtered list); ancestry decisions
+live in the full log.** The user selects rows in the filtered `visible` list,
+but contiguity, oldest/newest, and the rebase base must be computed against the
+store's full `commits` (real ancestry) — else hiding merges could make two
+rows look adjacent when a commit sits between them. `planCommitSelection`
+(below) does this.
+
+## planCommitSelection (pure, tested)
+
+`src/features/commits/planCommitSelection.ts`:
+
+```ts
+interface CommitSelectionPlan {
+  oids: string[];          // selected, oldest→newest, filtered to those in the log
+  oldestOid: string;
+  newestOid: string;
+  baseOid: string | null;  // parent of oldest (commits[oldestIdx+1]); null if root/not-loaded
+  contiguous: boolean;     // selected indices form one consecutive run in the log
+  hasMerge: boolean;       // any selected commit has >1 parent
+}
+planCommitSelection(commits: CommitInfo[], selectedOids: Iterable<string>): CommitSelectionPlan | null
+```
+
+`commits` is newest-first (larger index = older). Returns `null` for an empty
+selection. Everything downstream reads this: combined diff uses
+`baseOid ?? oldestOid` → `newestOid`; cherry-pick set uses `oids`; squash needs
+`contiguous && !hasMerge && baseOid != null`.
+
+## buildRebasePlan — squash-range mode
+
+Add a third mode to the tested `buildRebasePlan`:
+
+```ts
+| { kind: "squash-range"; oids: string[]; message: string }
+```
+
+Over commits newer than `fromOid` (= `baseOid`), the oldest oid in the set
+stays `Pick`, every other selected oid becomes `Squash` carrying `message`, and
+commits newer than the set stay `Pick`. Backend Squash re-parents onto the
+previous commit, so the chain collapses to one commit with `message`, then the
+newer picks replay on top. Same `fromOid ∉ commits → null` guard as today.
+
+## UI
+
+Both surfaces adapt to the selection, mirroring multi-file-select:
+
+- **Detail pane / action row** (`CommitActionRow`): 1 selected → today's
+  buttons (Branch here, Tag, Cherry-pick, Revert, Copy SHA). 2+ selected → a
+  multi summary ("N commits selected") + multi actions: **View combined diff**,
+  **Cherry-pick N commits**, **Squash N commits…** (disabled with a titled
+  reason when non-contiguous / contains a merge / base not loaded), **Copy N
+  SHAs**. Single-only actions (Branch/Tag/Revert-one) are hidden for 2+.
+- **Context menu**: right-click a row inside the multi-selection → a
+  `commitMultiMenuItems` menu (same actions). Right-click outside the selection
+  collapses to that row and shows the existing single `commitMenuItems`.
+
+Destructive/history-rewriting actions confirm first (squash goes through the
+Rebase screen's existing review-then-run; cherry-pick set confirms the count).
+On failure, refresh-then-error per the `useRepoStore` catch-arm convention.
+
+## Store
+
+One new action:
+
+```ts
+cherryPickMany(oids: string[]): Promise<void>
+```
+
+Loops the raw `cherryPick(repoId, oid)` tauri wrapper oldest→newest, refreshes
+once at the end. Catch arm: `refreshAll()` then `set({ error })` (refresh-first,
+so refreshAll's own `error: null` doesn't wipe it) — a conflicted pick leaves
+the repo in a `CherryPick` state the Conflict screen picks up.
+
+## Testing
+
+- `planCommitSelection.test.ts` — ordering, base (incl. root/not-loaded null),
+  contiguity over the true log vs a filtered selection, merge detection, empty.
+- `buildRebasePlan.test.ts` — squash-range: oldest Pick, rest Squash w/ message,
+  newer commits Pick, unknown base null.
+- `src/lib/selection.test.ts` already covers the selection helper.
+- `History.multiselect.test.tsx` — ctrl-click toggles, shift-click ranges,
+  Shift+↓ extends via the keymap, 2+ selection shows multi action row, "View
+  combined diff" fires `commit-vs-commit`, cherry-pick N confirms then calls
+  the store, squash disabled for a non-contiguous selection.
+- `useRepoStore` test — `cherryPickMany` issues N `cherry_pick` invokes in
+  oldest→newest order and stops on the conflicting one.
+- Existing `History.keyboard.test.tsx` (single-select nav) must stay green.
+- **E2E** (`history-ops.e2e.ts`): building the multi-selection uses a plain
+  row click (focuses the pane) + `jsChord("Shift+ArrowDown")` (the embedded
+  driver can't synthesize modifiers, so we dispatch the chord through the real
+  keymap listener). Two cases: *combined diff* of a 2-commit selection lists
+  the introduced file; *multi cherry-pick* of two `feature` commits lands both
+  on `main` oldest→newest (`multiCherryRepo` fixture). Backend ops themselves
+  (`diff_commits`, `cherry_pick`) thus get end-to-end coverage against real
+  libgit2.
+
+Gates: `pnpm tsc --noEmit`, `pnpm test`, `pnpm vite build`,
+`pnpm exec tsc -p e2e/tsconfig.json --noEmit`,
+`pnpm test:e2e:run --spec e2e/specs/history-ops.e2e.ts`.

--- a/e2e/specs/history-ops.e2e.ts
+++ b/e2e/specs/history-ops.e2e.ts
@@ -1,8 +1,8 @@
 import { browser, $, expect } from "@wdio/globals";
-import { cherryRepo, TempRepo } from "../support/tempRepo";
+import { cherryRepo, multiCherryRepo, TempRepo } from "../support/tempRepo";
 import {
   openRepo, resetApp, switchScreen, stubNativeDialogs,
-  jsContextMenu, jsHoverMenuItem, jsClickMenuItem, jsSelectValue,
+  jsContextMenu, jsHoverMenuItem, jsClickMenuItem, jsSelectValue, jsChord,
 } from "../support/app";
 
 describe("history danger ops", () => {
@@ -78,6 +78,25 @@ describe("history danger ops", () => {
     expect(repo.git("branch", "--show-current").trim()).toBe("main");
   });
 
+  // #54: multi-select two commits → the detail pane offers a combined diff of
+  // the whole selection (parent-of-oldest → newest), routed through the
+  // existing commit-vs-commit → CommitDiff path.
+  it("shows a combined diff of a multi-commit selection", async () => {
+    // Click HEAD row (focuses the list pane + selects it), then Shift+ArrowDown
+    // extends the range by one. jsChord: the driver can't synthesize modifiers.
+    await $('[data-testid="commit-row"]*=fix: update a.txt').click();
+    await jsChord("Shift+ArrowDown"); // extend to "feat: add b.txt"
+    await $("div*=2 commits selected").waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "multi-select detail never appeared",
+    });
+    await $("button*=View combined diff").click();
+    // Oldest selected = "feat: add b.txt" (parent "feat: add a.txt"); newest =
+    // "fix: update a.txt". The combined diff therefore introduces b.txt.
+    await $('[data-pg-row]*=b.txt').waitForDisplayed({
+      timeout: 15_000, timeoutMsg: "combined diff did not list b.txt",
+    });
+  });
+
   it("reverts HEAD", async () => {
     const row = $('[data-testid="commit-row"]*=fix: update a.txt');
     await row.waitForDisplayed({ timeout: 15_000, timeoutMsg: "HEAD row missing" });
@@ -91,5 +110,56 @@ describe("history danger ops", () => {
       { timeout: 20_000, timeoutMsg: "revert commit never landed" },
     );
     expect(repo.read("a.txt")).toBe("alpha v1\n");
+  });
+});
+
+// #54: cherry-pick a *set* of commits onto the current branch, oldest→newest,
+// via the multi-selection action row (cherryPickMany loops the single op).
+describe("history multi cherry-pick", () => {
+  let repo: TempRepo;
+
+  beforeEach(async () => {
+    repo = multiCherryRepo();
+    await openRepo(repo.path);
+    await stubNativeDialogs({ confirm: true });
+    await switchScreen("history");
+    await $("span*=SUBJECT").waitForDisplayed({
+      timeout: 15_000, timeoutMsg: "history screen not ready",
+    });
+    // Scope the log to `feature` so its two unmerged commits are browsable
+    // while `main` stays checked out (jsSelectValue — see history-ref-select).
+    await $('[data-testid="history-ref-select"]').waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "history ref selector missing",
+    });
+    await jsSelectValue('[data-testid="history-ref-select"]', "feature");
+    await $('[data-testid="commit-row"]*=feat: add d.txt').waitForDisplayed({
+      timeout: 15_000, timeoutMsg: "feature commits not visible after scoping",
+    });
+  });
+
+  afterEach(async () => {
+    await resetApp();
+    repo.dispose();
+  });
+
+  it("cherry-picks two selected commits onto main oldest→newest", async () => {
+    // Select the top two feature commits (d.txt then, extending up, c.txt).
+    await $('[data-testid="commit-row"]*=feat: add d.txt').click();
+    await jsChord("Shift+ArrowDown"); // extend to "feat: add c.txt"
+    await $("div*=2 commits selected").waitForDisplayed({
+      timeout: 10_000, timeoutMsg: "multi-select detail never appeared",
+    });
+    await $('[data-testid="multi-cherry-pick"]').click(); // confirm stubbed
+    // Both picks land on main, oldest (c) before newest (d).
+    await browser.waitUntil(
+      async () => {
+        const log = repo.git("log", "main", "--pretty=%s");
+        return log.includes("feat: add c.txt") && log.includes("feat: add d.txt");
+      },
+      { timeout: 25_000, timeoutMsg: "both cherry-picks never landed on main" },
+    );
+    expect(repo.read("c.txt")).toBe("charlie\n");
+    expect(repo.read("d.txt")).toBe("delta\n");
+    expect(repo.git("branch", "--show-current").trim()).toBe("main");
   });
 });

--- a/e2e/support/tempRepo.ts
+++ b/e2e/support/tempRepo.ts
@@ -129,6 +129,17 @@ export function cherryRepo(): TempRepo {
   return r; // feature is one unmerged commit ahead of shared history
 }
 
+export function multiCherryRepo(): TempRepo {
+  const r = basicRepo();
+  r.git("checkout", "-b", "feature");
+  // Two unmerged commits adding distinct new files — cleanly cherry-pickable
+  // onto main as a set (no overlap with main's tree, so no conflicts).
+  r.commitFile("c.txt", "charlie\n", "feat: add c.txt");
+  r.commitFile("d.txt", "delta\n", "feat: add d.txt");
+  r.git("checkout", "main");
+  return r; // feature is two unmerged commits ahead of shared history
+}
+
 export function rebaseConflictRepo(): TempRepo {
   const r = new TempRepo();
   r.commitFile("conflict.txt", "l1\n", "feat: base line");

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -4,6 +4,7 @@ import { PGIcon, type IconName } from "./icons";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { buildRebasePlan } from "@/features/commits/buildRebasePlan";
+import { planCommitSelection } from "@/features/commits/planCommitSelection";
 import { openMergeWindow } from "@/features/merge/openMergeWindow";
 import { chordFor } from "@/features/keymap";
 
@@ -492,6 +493,83 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
       onClick: () => {
         navigator.clipboard?.writeText(commit?.subject || "");
         pgFlash("copied subject");
+      },
+    },
+  ];
+}
+
+/**
+ * Context menu for a multi-commit selection in History. `oids` are the selected
+ * commit oids (any order); ancestry facts come from the full log via
+ * `planCommitSelection`, so contiguity/base reflect real history rather than
+ * the filtered view.
+ */
+export function commitMultiMenuItems(oids: string[]): ContextMenuItem[] {
+  const commits = useRepoStore.getState().commits;
+  const plan = planCommitSelection(commits, oids);
+  if (!plan) return [{ __menuTitle: "no commits" }];
+  const n = plan.oids.length;
+
+  // Squash needs a contiguous, merge-free run with a loaded parent to rebase
+  // onto. Surface the blocking reason in the (disabled) label.
+  const squashBlock = !plan.contiguous
+    ? "non-contiguous"
+    : plan.hasMerge
+      ? "contains a merge"
+      : !plan.baseOid
+        ? "oldest is root"
+        : null;
+
+  return [
+    { __menuTitle: `${n} commits` },
+    {
+      icon: "diff",
+      label: "View combined diff",
+      onClick: () => {
+        useNavStore.getState().setIntent({
+          kind: "commit-vs-commit",
+          from: plan.baseOid ?? plan.oldestOid,
+          to: plan.newestOid,
+        });
+      },
+    },
+    { divider: true },
+    {
+      icon: "rebase",
+      label: `Cherry-pick ${n} onto current`,
+      onClick: () => {
+        if (
+          window.confirm(
+            `Cherry-pick ${n} commits onto the current branch (oldest first)?`,
+          )
+        )
+          useRepoStore.getState().cherryPickMany(plan.oids);
+      },
+    },
+    {
+      icon: "squash",
+      label: squashBlock ? `Squash ${n} — ${squashBlock}` : `Squash ${n} into one…`,
+      disabled: !!squashBlock,
+      onClick: () => {
+        if (squashBlock || !plan.baseOid) return;
+        const msg = window.prompt("New commit message for the squashed commit");
+        if (!msg) return;
+        const rebasePlan = buildRebasePlan(commits, plan.baseOid, {
+          kind: "squash-range",
+          oids: plan.oids,
+          message: msg,
+        });
+        if (!rebasePlan) return;
+        useNavStore.getState().setIntent({ kind: "rebase-plan", plan: rebasePlan });
+      },
+    },
+    { divider: true },
+    {
+      icon: "copy",
+      label: `Copy ${n} SHAs`,
+      onClick: () => {
+        navigator.clipboard?.writeText(plan.oids.join("\n"));
+        pgFlash(`copied ${n} SHAs`);
       },
     },
   ];

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -1025,7 +1025,7 @@ export interface PGCommitRowProps {
   date: string;
   refs?: CommitRef[];
   selected?: boolean;
-  onClick?: () => void;
+  onClick?: (e: MouseEvent) => void;
   onContextMenu?: (e: MouseEvent) => void;
   tagged?: string;
 }

--- a/src/features/commits/buildRebasePlan.test.ts
+++ b/src/features/commits/buildRebasePlan.test.ts
@@ -29,4 +29,34 @@ describe("buildRebasePlan", () => {
   it("returns null when the base isn't in commits", () => {
     expect(buildRebasePlan(commits, "zzz", { kind: "edit-from" })).toBeNull();
   });
+
+  it("squash-range: oldest selected stays Pick, rest Squash with message", () => {
+    // Select b and c (contiguous). Base is a (parent of oldest, b). Plan
+    // covers everything newer than a: b, c, d oldest→newest.
+    expect(
+      buildRebasePlan(commits, "a", {
+        kind: "squash-range",
+        oids: ["c", "b"],
+        message: "combined",
+      }),
+    ).toEqual([
+      { oid: "b", action: "Pick", message: null }, // oldest selected = anchor
+      { oid: "c", action: "Squash", message: "combined" },
+      { oid: "d", action: "Pick", message: null }, // newer than the selection
+    ]);
+  });
+
+  it("squash-range: folds three commits, only the oldest stays Pick", () => {
+    expect(
+      buildRebasePlan(commits, "a", {
+        kind: "squash-range",
+        oids: ["b", "c", "d"],
+        message: "all",
+      }),
+    ).toEqual([
+      { oid: "b", action: "Pick", message: null },
+      { oid: "c", action: "Squash", message: "all" },
+      { oid: "d", action: "Squash", message: "all" },
+    ]);
+  });
 });

--- a/src/features/commits/buildRebasePlan.ts
+++ b/src/features/commits/buildRebasePlan.ts
@@ -9,6 +9,12 @@ import type { CommitInfo, RebaseStep, RebaseAction } from "@/lib/types";
  *   - "edit-from": every commit is a plain pick (equivalent to `rebase -i fromOid^`).
  *   - { kind: "fixup", targetOid }: target becomes "fixup".
  *   - { kind: "squash", targetOid, message }: target becomes "squash" with a custom message.
+ *   - { kind: "squash-range", oids, message }: collapse a contiguous selection
+ *     into one commit — the oldest selected oid stays "pick", every other
+ *     selected oid becomes "squash" carrying `message`; commits outside the
+ *     selection (newer than it) stay "pick". The backend squash re-parents each
+ *     squashed commit onto the previous one, so the run collapses to a single
+ *     commit with `message`.
  *
  * Returns null when the `fromOid` isn't in the rebaseable range.
  */
@@ -18,12 +24,22 @@ export function buildRebasePlan(
   mode:
     | { kind: "edit-from" }
     | { kind: "fixup"; targetOid: string }
-    | { kind: "squash"; targetOid: string; message: string },
+    | { kind: "squash"; targetOid: string; message: string }
+    | { kind: "squash-range"; oids: string[]; message: string },
 ): RebaseStep[] | null {
   const idx = commits.findIndex((c) => c.oid === fromOid);
   if (idx < 0) return null;
   const newestFirst = commits.slice(0, idx);
   const oldestFirst = newestFirst.slice().reverse();
+
+  // For a range squash, the oldest selected commit anchors the squash (stays a
+  // pick); the rest fold into it. `oldestFirst` is ancestry order, so the first
+  // selected entry it contains is the oldest.
+  const rangeSet = mode.kind === "squash-range" ? new Set(mode.oids) : null;
+  const rangeAnchor =
+    rangeSet != null
+      ? (oldestFirst.find((c) => rangeSet.has(c.oid))?.oid ?? null)
+      : null;
 
   return oldestFirst.map((c): RebaseStep => {
     let action: RebaseAction = "Pick";
@@ -31,6 +47,13 @@ export function buildRebasePlan(
     if (mode.kind === "fixup" && c.oid === mode.targetOid) {
       action = "Fixup";
     } else if (mode.kind === "squash" && c.oid === mode.targetOid) {
+      action = "Squash";
+      message = mode.message;
+    } else if (
+      mode.kind === "squash-range" &&
+      rangeSet!.has(c.oid) &&
+      c.oid !== rangeAnchor
+    ) {
       action = "Squash";
       message = mode.message;
     }

--- a/src/features/commits/planCommitSelection.test.ts
+++ b/src/features/commits/planCommitSelection.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { planCommitSelection } from "./planCommitSelection";
+import type { CommitInfo } from "@/lib/types";
+
+const mk = (oid: string, parents: string[] = []): CommitInfo => ({
+  oid, shortOid: oid.slice(0, 7), summary: oid, body: null,
+  author: "", email: "", timestamp: 0, parents, refs: [],
+});
+
+// Newest-first log: d(0) → c(1) → b(2) → a(3, root).
+const log = [mk("d", ["c"]), mk("c", ["b"]), mk("b", ["a"]), mk("a", [])];
+
+describe("planCommitSelection", () => {
+  it("returns null for an empty selection", () => {
+    expect(planCommitSelection(log, [])).toBeNull();
+  });
+
+  it("orders oids oldest→newest and finds the base (parent of oldest)", () => {
+    const plan = planCommitSelection(log, ["c", "b"])!;
+    expect(plan.oids).toEqual(["b", "c"]); // oldest first
+    expect(plan.oldestOid).toBe("b");
+    expect(plan.newestOid).toBe("c");
+    expect(plan.baseOid).toBe("a"); // commits[maxIdx+1]
+    expect(plan.contiguous).toBe(true);
+    expect(plan.hasMerge).toBe(false);
+  });
+
+  it("flags a non-contiguous selection", () => {
+    const plan = planCommitSelection(log, ["d", "b"])!; // indices 0 and 2
+    expect(plan.contiguous).toBe(false);
+    expect(plan.oldestOid).toBe("b");
+    expect(plan.newestOid).toBe("d");
+  });
+
+  it("base is null when the oldest selected is the root (no loaded parent)", () => {
+    const plan = planCommitSelection(log, ["b", "a"])!; // a is root, index 3 (last)
+    expect(plan.contiguous).toBe(true);
+    expect(plan.oldestOid).toBe("a");
+    expect(plan.baseOid).toBeNull();
+  });
+
+  it("detects a merge commit in the selection", () => {
+    const withMerge = [mk("d"), mk("c", ["b", "x"]), mk("b"), mk("a")];
+    const plan = planCommitSelection(withMerge, ["c", "b"])!;
+    expect(plan.hasMerge).toBe(true);
+  });
+
+  it("ignores oids not present in the log", () => {
+    const plan = planCommitSelection(log, ["c", "zzz"])!;
+    expect(plan.oids).toEqual(["c"]);
+    expect(plan.oldestOid).toBe("c");
+    expect(plan.newestOid).toBe("c");
+  });
+
+  it("contiguity is computed over the true log, not selection order", () => {
+    // Selecting c then b (reverse-clicked) is still contiguous ancestry.
+    expect(planCommitSelection(log, ["c", "b"])!.contiguous).toBe(true);
+    expect(planCommitSelection(log, ["b", "c"])!.contiguous).toBe(true);
+  });
+});

--- a/src/features/commits/planCommitSelection.ts
+++ b/src/features/commits/planCommitSelection.ts
@@ -1,0 +1,54 @@
+import type { CommitInfo } from "@/lib/types";
+
+/**
+ * Ancestry facts about a multi-commit selection, computed against the *full*
+ * log (`commits`, newest-first) rather than the filtered visible list — so
+ * contiguity and the rebase base reflect real ancestry even when the History
+ * view hides merges or filters commits. Drives the combined diff (base→newest),
+ * the cherry-pick set (`oids`, oldest→newest), and squash-range gating
+ * (`contiguous && !hasMerge && baseOid`).
+ */
+export interface CommitSelectionPlan {
+  /** Selected commits present in the log, ordered oldest→newest. */
+  oids: string[];
+  /** Oldest (deepest ancestor) selected commit. */
+  oldestOid: string;
+  /** Newest selected commit. */
+  newestOid: string;
+  /** Parent of the oldest selected commit (`commits[oldestIdx+1]`), or null
+   *  when it's the root or its parent isn't loaded. */
+  baseOid: string | null;
+  /** Selected indices form one consecutive run in the log. */
+  contiguous: boolean;
+  /** Any selected commit is a merge (>1 parent). */
+  hasMerge: boolean;
+}
+
+export function planCommitSelection(
+  commits: CommitInfo[],
+  selectedOids: Iterable<string>,
+): CommitSelectionPlan | null {
+  const set = new Set(selectedOids);
+  // Indices into the newest-first log; larger index = older commit.
+  const indices: number[] = [];
+  commits.forEach((c, i) => {
+    if (set.has(c.oid)) indices.push(i);
+  });
+  if (indices.length === 0) return null;
+
+  const min = Math.min(...indices); // newest
+  const max = Math.max(...indices); // oldest
+  const oids = indices
+    .slice()
+    .sort((a, b) => b - a) // oldest→newest
+    .map((i) => commits[i].oid);
+
+  return {
+    oids,
+    oldestOid: commits[max].oid,
+    newestOid: commits[min].oid,
+    baseOid: commits[max + 1]?.oid ?? null,
+    contiguous: max - min + 1 === indices.length,
+    hasMerge: indices.some((i) => commits[i].parents.length > 1),
+  };
+}

--- a/src/features/keymap/actions.ts
+++ b/src/features/keymap/actions.ts
@@ -62,6 +62,8 @@ export type ActionId =
   | "list.toggle"
   | "list.top"
   | "list.bottom"
+  | "list.extendUp"
+  | "list.extendDown"
   | "repo.fetch"
   | "repo.pull"
   | "repo.push"
@@ -194,6 +196,8 @@ export const ACTIONS: Record<ActionId, ActionDef> = {
   "list.toggle": { id: "list.toggle", title: "Toggle selection (stage/unstage)", category: "Lists & trees", scope: "pane" },
   "list.top": { id: "list.top", title: "Select first item", category: "Lists & trees", scope: "pane" },
   "list.bottom": { id: "list.bottom", title: "Select last item", category: "Lists & trees", scope: "pane" },
+  "list.extendUp": { id: "list.extendUp", title: "Extend selection up", category: "Lists & trees", scope: "pane", suppressInInput: true },
+  "list.extendDown": { id: "list.extendDown", title: "Extend selection down", category: "Lists & trees", scope: "pane", suppressInInput: true },
 
   "diff.nextChange": { id: "diff.nextChange", title: "Next change (hunk)", category: "Diff", scope: "pane" },
   "diff.prevChange": { id: "diff.prevChange", title: "Previous change (hunk)", category: "Diff", scope: "pane" },

--- a/src/features/keymap/presets.ts
+++ b/src/features/keymap/presets.ts
@@ -50,6 +50,10 @@ const COMMON = {
   "list.toggle": [" "],
   "list.top": ["Home"],
   "list.bottom": ["End"],
+  // Extend a multi-selection range (History commit list). suppressInInput keeps
+  // Shift+Arrow doing normal text selection inside inputs.
+  "list.extendUp": ["Shift+ArrowUp"],
+  "list.extendDown": ["Shift+ArrowDown"],
   // Rider NextDiff/PreviousDiff — real JetBrains bindings.
   "diff.nextChange": ["F7"],
   "diff.prevChange": ["Shift+F7"],

--- a/src/features/keymap/usePaneList.ts
+++ b/src/features/keymap/usePaneList.ts
@@ -22,6 +22,10 @@ export function usePaneList(opts: {
   onExpand?: (i: number) => void;
   onCollapse?: (i: number) => void;
   onToggle?: (i: number) => void;
+  /** Shift+↑/↓ — extend a multi-selection range from the anchor. Panes that
+   *  don't support multi-select omit these and the chord falls through. */
+  onExtendUp?: () => void;
+  onExtendDown?: () => void;
   /** Opt into speed-search: row i's searchable text. Typing (unbound
    *  printable keys) jumps the selection to the first matching row. */
   searchText?: (i: number) => string;
@@ -42,6 +46,18 @@ export function usePaneList(opts: {
   useAction("list.down", guard(() => opts.onSelect(clamp(selectedIndex + 1))), deps, reg);
   useAction("list.top", guard(() => opts.onSelect(0)), deps, reg);
   useAction("list.bottom", guard(() => opts.onSelect(count - 1)), deps, reg);
+  useAction(
+    "list.extendUp",
+    opts.onExtendUp ? guard(() => opts.onExtendUp?.()) : () => false,
+    deps,
+    reg,
+  );
+  useAction(
+    "list.extendDown",
+    opts.onExtendDown ? guard(() => opts.onExtendDown?.()) : () => false,
+    deps,
+    reg,
+  );
   useAction(
     "list.activate",
     opts.onActivate ? guard(() => opts.onActivate?.(selectedIndex)) : () => false,

--- a/src/features/repo/cherryPickMany.test.ts
+++ b/src/features/repo/cherryPickMany.test.ts
@@ -1,0 +1,58 @@
+// cherryPickMany — loops the single cherry_pick op oldest→newest, refreshes
+// once, and stops (surfacing the error) on the first conflicting pick.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { useRepoStore } from "./useRepoStore";
+import { mockInvoke, getInvokeCalls } from "@/test/invokeMock";
+
+/** Everything refreshAll() fans out to — return empties so it resolves. */
+function mockRefresh() {
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log", () => []);
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => ({
+    inProgress: false,
+    nextIndex: 0,
+    total: 0,
+    pauseReason: null,
+  }));
+}
+
+const pickedOids = () =>
+  getInvokeCalls()
+    .filter((c) => c.cmd === "cherry_pick")
+    .map((c) => c.args.oid as string);
+
+describe("cherryPickMany", () => {
+  beforeEach(() => {
+    useRepoStore.setState({
+      current: { id: "r1", path: "/repo", head: "main" },
+      error: null,
+    } as never);
+    mockRefresh();
+  });
+
+  it("cherry-picks every oid in the given (oldest→newest) order", async () => {
+    mockInvoke("cherry_pick", () => undefined);
+    await useRepoStore.getState().cherryPickMany(["old", "mid", "new"]);
+    expect(pickedOids()).toEqual(["old", "mid", "new"]);
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("stops at the first conflicting pick and surfaces the error", async () => {
+    mockInvoke("cherry_pick", (args) => {
+      if (args.oid === "mid") {
+        throw { kind: "ConflictsDetected", message: "cherry-pick produced conflicts" };
+      }
+      return undefined;
+    });
+    await useRepoStore.getState().cherryPickMany(["old", "mid", "new"]);
+    // "new" is never attempted.
+    expect(pickedOids()).toEqual(["old", "mid"]);
+    expect(useRepoStore.getState().error?.kind).toBe("ConflictsDetected");
+  });
+});

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -202,6 +202,7 @@ interface RepoStoreState {
   pushTag: (remote: string, name: string) => Promise<void>;
   pushDeleteBranch: (remote: string, name: string) => Promise<void>;
   cherryPick: (oid: string) => Promise<void>;
+  cherryPickMany: (oids: string[]) => Promise<void>;
   revert: (oid: string) => Promise<void>;
   stashSave: (opts: StashSaveOptions) => Promise<string | null>;
   stashApply: (index: number) => Promise<void>;
@@ -708,6 +709,27 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     try {
       await cherryPick(repo.id, oid);
+      await get().refreshAll();
+    } catch (e) {
+      // See mergeBranch's catch: refresh first, error last, so it isn't
+      // batched away by refreshAll's own `error: null` reset.
+      await get().refreshAll();
+      set({ error: toAppError(e) });
+    }
+  },
+
+  async cherryPickMany(oids) {
+    const repo = get().current;
+    if (!repo) return;
+    try {
+      // Apply oldest→newest (the caller orders them). Each clean pick
+      // auto-commits and moves HEAD; the next applies on top. A conflicting
+      // pick throws (ConflictsDetected), stopping the sequence and leaving the
+      // repo in a conflicted CherryPick state for the Conflict screen. Refresh
+      // once at the end rather than per pick.
+      for (const oid of oids) {
+        await cherryPick(repo.id, oid);
+      }
       await get().refreshAll();
     } catch (e) {
       // See mergeBranch's catch: refresh first, error last, so it isn't

--- a/src/screens/History.multiselect.test.tsx
+++ b/src/screens/History.multiselect.test.tsx
@@ -1,0 +1,166 @@
+// Multi-select behavior of the History screen: ctrl/shift click, Shift+Arrow
+// range extend, and the multi-commit action row (combined diff, cherry-pick
+// set, squash gating).
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { HistoryScreen } from "./History";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { useKeymapStore, useFocusStore } from "@/features/keymap";
+import type { CommitInfo } from "@/lib/types";
+
+// Newest-first linear log: a → b → c → d(root).
+const mkCommit = (oid: string, summary: string, parents: string[]): CommitInfo => ({
+  oid,
+  shortOid: oid.slice(0, 7),
+  summary,
+  body: null,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 1_700_000_000,
+  parents,
+  refs: [],
+});
+
+const A = "a".repeat(40);
+const B = "b".repeat(40);
+const C = "c".repeat(40);
+const D = "d".repeat(40);
+
+const key = (k: string, mods: Partial<KeyboardEvent> = {}) =>
+  ({
+    key: k,
+    code: "",
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...mods,
+    preventDefault() {},
+    target: document.body,
+  }) as unknown as KeyboardEvent;
+
+function press(k: string, mods: Partial<KeyboardEvent> = {}): boolean {
+  let handled = false;
+  act(() => {
+    handled = useKeymapStore.getState().dispatch(key(k, mods));
+  });
+  return handled;
+}
+
+const rowFor = (text: string) => {
+  const row = screen
+    .getAllByText(text)
+    .map((el) => el.closest("[data-pg-row]"))
+    .find((el): el is Element => el != null);
+  expect(row).toBeTruthy();
+  return row! as HTMLElement;
+};
+const isSelected = (text: string) => rowFor(text).hasAttribute("data-selected");
+
+describe("History multi-select", () => {
+  beforeEach(() => {
+    useRepoStore.setState({
+      current: { id: "r1", path: "/repo", head: "main" },
+      commits: [
+        mkCommit(A, "commit A", [B]),
+        mkCommit(B, "commit B", [C]),
+        mkCommit(C, "commit C", [D]),
+        mkCommit(D, "commit D", []),
+      ],
+      searchResults: null,
+      searching: false,
+      searchCommits: async () => {},
+      branches: [],
+      status: [],
+      loading: false,
+    } as never);
+    useNavStore.setState({ intent: null });
+    useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+    useKeymapStore.getState().setPreset("rider");
+    useFocusStore.setState({
+      focused: null,
+      panes: new Map(),
+      order: [],
+      barId: null,
+      pendingContentFocus: false,
+    });
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("ctrl-click toggles a second commit into the selection", () => {
+    render(<HistoryScreen />);
+    fireEvent.click(rowFor("commit A"));
+    fireEvent.click(rowFor("commit C"), { ctrlKey: true });
+    expect(isSelected("commit A")).toBe(true);
+    expect(isSelected("commit C")).toBe(true);
+    expect(isSelected("commit B")).toBe(false);
+    expect(screen.getByText(/2 commits selected/)).toBeInTheDocument();
+  });
+
+  it("shift-click selects a contiguous range", () => {
+    render(<HistoryScreen />);
+    fireEvent.click(rowFor("commit A"));
+    fireEvent.click(rowFor("commit C"), { shiftKey: true });
+    expect(isSelected("commit A")).toBe(true);
+    expect(isSelected("commit B")).toBe(true);
+    expect(isSelected("commit C")).toBe(true);
+    expect(isSelected("commit D")).toBe(false);
+  });
+
+  it("Shift+ArrowDown extends the selection from the anchor", () => {
+    render(<HistoryScreen />);
+    useFocusStore.setState({ focused: "history.list" });
+    // Cursor starts on the first row (A). Extend down twice → A,B,C.
+    expect(press("ArrowDown", { shiftKey: true })).toBe(true);
+    expect(press("ArrowDown", { shiftKey: true })).toBe(true);
+    expect(isSelected("commit A")).toBe(true);
+    expect(isSelected("commit B")).toBe(true);
+    expect(isSelected("commit C")).toBe(true);
+    expect(isSelected("commit D")).toBe(false);
+  });
+
+  it("View combined diff fires a commit-vs-commit intent (parent-of-oldest → newest)", () => {
+    render(<HistoryScreen />);
+    fireEvent.click(rowFor("commit A"));
+    fireEvent.click(rowFor("commit B"), { shiftKey: true }); // select A,B
+    fireEvent.click(screen.getByText("View combined diff"));
+    // Oldest selected = B (parent C), newest = A.
+    expect(useNavStore.getState().intent).toEqual({
+      kind: "commit-vs-commit",
+      from: C,
+      to: A,
+    });
+  });
+
+  it("Cherry-pick N confirms then calls cherryPickMany oldest→newest", () => {
+    const picked: string[][] = [];
+    useRepoStore.setState({
+      cherryPickMany: async (oids: string[]) => {
+        picked.push(oids);
+      },
+    } as never);
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(<HistoryScreen />);
+    fireEvent.click(rowFor("commit A"));
+    fireEvent.click(rowFor("commit B"), { shiftKey: true }); // A,B
+    fireEvent.click(screen.getByTestId("multi-cherry-pick"));
+    expect(picked).toEqual([[B, A]]); // oldest first
+  });
+
+  it("Squash is disabled for a non-contiguous selection", () => {
+    render(<HistoryScreen />);
+    fireEvent.click(rowFor("commit A"));
+    fireEvent.click(rowFor("commit C"), { ctrlKey: true }); // A + C, skipping B
+    expect(screen.getByTestId("multi-squash")).toBeDisabled();
+  });
+
+  it("Squash is enabled for a contiguous, merge-free range", () => {
+    render(<HistoryScreen />);
+    fireEvent.click(rowFor("commit A"));
+    fireEvent.click(rowFor("commit B"), { shiftKey: true }); // A,B (base = C)
+    expect(screen.getByTestId("multi-squash")).not.toBeDisabled();
+  });
+});

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -14,16 +14,26 @@ import {
   PGSpinner,
   PGToolbar,
   commitMenuItems,
+  commitMultiMenuItems,
   pgFlash,
   useContextMenu,
   usePaneWidth,
 } from "@/design";
 import { layoutGraph } from "@/features/commits/graphLayout";
 import { buildLogFilter, isFilterEmpty } from "@/features/commits/logFilter";
+import { planCommitSelection } from "@/features/commits/planCommitSelection";
+import { buildRebasePlan } from "@/features/commits/buildRebasePlan";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { PGPane, FocusableScroll, usePaneList } from "@/features/keymap";
 import { currentBranch, mapCommitRefs, relativeTime, shortSha } from "@/lib/derive";
+import {
+  clickSelection,
+  emptySelection,
+  primarySelectedKey,
+  pruneSelection,
+  type Selection,
+} from "@/lib/selection";
 import type { CommitInfo } from "@/lib/types";
 
 type HistoryFilterKind = "all" | "mine" | "branch";
@@ -40,7 +50,11 @@ export function HistoryScreen() {
   const logRef = useRepoStore((s) => s.logRef);
   const setLogRef = useRepoStore((s) => s.setLogRef);
   const loading = useRepoStore((s) => s.loading);
-  const [selected, setSelected] = React.useState(0);
+  // Multi-select over commit oids (classic list semantics, shared helper).
+  // `lead` is the active end of the range — where plain ↑/↓ move from and where
+  // Shift+↑/↓ extend — distinct from the anchor that clickSelection tracks.
+  const [sel, setSel] = React.useState<Selection>(emptySelection);
+  const [leadOid, setLeadOid] = React.useState<string | null>(null);
   // Free-text search box (supports key:value qualifiers — see logFilter.ts).
   const [filter, setFilter] = React.useState("");
   // Dedicated structured search fields.
@@ -84,19 +98,13 @@ export function HistoryScreen() {
     storageKey: "pg-history-detail-w",
   });
 
-  // Reset selection when the visible list changes shape. Includes the
-  // client-side refinements (filterKind/hideMerges) — without them a shrunk
-  // `visible` leaves a stale `selected`, so the detail pane and CommitActionRow
-  // silently act on visible[0] instead of the highlighted commit.
-  React.useEffect(() => {
-    setSelected(0);
-  }, [baseCommits.length, filterKey, filterKind, hideMerges]);
-
   const head = currentBranch(branches);
   const headName = head?.name ?? null;
   const aheadCount = head?.ahead ?? 0;
   const { onContextMenu: onCommitContext, menu: commitMenu } =
     useContextMenu<{ sha: string; subject: string }>(commitMenuItems);
+  const { onContextMenu: onCommitMulti, menu: commitMultiMenu } =
+    useContextMenu<string[]>((oids) => commitMultiMenuItems(oids));
 
   // Most-frequent author email in the loaded history — used as a "mine" heuristic
   // until we expose git config (user.email) to the frontend.
@@ -125,17 +133,64 @@ export function HistoryScreen() {
 
   const rows = React.useMemo(() => layoutGraph(visible), [visible]);
 
-  // Keyboard: ↑/↓ move the commit selection, Enter opens the commit's diff.
+  // Visible row order (oids) — the axis shift-ranges and pruning work over.
+  const order = React.useMemo(() => visible.map((c) => c.oid), [visible]);
+
+  // Drop selected oids that left the visible list (search/filter/refresh/repo
+  // switch); re-home the lead to the top and keep at least one row selected so
+  // the detail pane always has a subject. Replaces the old setSelected(0) reset.
+  React.useEffect(() => {
+    const valid = new Set(order);
+    setSel((prev) => {
+      const pruned = pruneSelection(prev, valid);
+      if (pruned.keys.length === 0 && order.length > 0) {
+        return { keys: [order[0]], anchor: order[0] };
+      }
+      return pruned;
+    });
+    setLeadOid((prev) => (prev && valid.has(prev) ? prev : (order[0] ?? null)));
+  }, [order]);
+
+  const cursorIdx = Math.max(
+    0,
+    order.indexOf(leadOid ?? primarySelectedKey(sel) ?? order[0]),
+  );
+  const clampIdx = (i: number) => Math.max(0, Math.min(order.length - 1, i));
+  const moveTo = (i: number, range: boolean) => {
+    const oid = order[clampIdx(i)];
+    if (!oid) return;
+    setSel((prev) => clickSelection(order, prev, oid, { range }));
+    setLeadOid(oid);
+  };
+
+  // Enter / "View combined diff": one commit → commit-vs-wt (unchanged); 2+ →
+  // combined diff of the whole selection (parent-of-oldest → newest).
   const setNavIntent = useNavStore((s) => s.setIntent);
+  const activateSelection = React.useCallback(() => {
+    if (sel.keys.length > 1) {
+      const plan = planCommitSelection(commits, sel.keys);
+      if (plan)
+        setNavIntent({
+          kind: "commit-vs-commit",
+          from: plan.baseOid ?? plan.oldestOid,
+          to: plan.newestOid,
+        });
+      return;
+    }
+    const oid = primarySelectedKey(sel) ?? order[cursorIdx];
+    if (oid) setNavIntent({ kind: "commit-vs-wt", oid });
+  }, [sel, commits, order, cursorIdx, setNavIntent]);
+
+  // Keyboard: ↑/↓ move a single cursor, Shift+↑/↓ extend the range, Enter opens
+  // the commit's diff (combined diff for a multi-selection).
   usePaneList({
     paneId: "history.list",
     count: visible.length,
-    selectedIndex: selected,
-    onSelect: setSelected,
-    onActivate: (i) => {
-      const c = visible[i];
-      if (c) setNavIntent({ kind: "commit-vs-wt", oid: c.oid });
-    },
+    selectedIndex: cursorIdx,
+    onSelect: (i) => moveTo(i, false),
+    onExtendUp: () => moveTo(cursorIdx - 1, true),
+    onExtendDown: () => moveTo(cursorIdx + 1, true),
+    onActivate: activateSelection,
     searchText: (i) => visible[i]?.summary ?? "",
   });
 
@@ -234,7 +289,32 @@ export function HistoryScreen() {
     );
   }
 
-  const current = visible[selected] ?? visible[0];
+  const primaryOid = primarySelectedKey(sel);
+  const current =
+    visible.find((c) => c.oid === primaryOid) ?? visible[cursorIdx] ?? visible[0];
+  const selectedSet = new Set(sel.keys);
+  const multiSelected = sel.keys.length > 1;
+
+  const onRowClick = (oid: string, e: React.MouseEvent) => {
+    setSel((prev) =>
+      clickSelection(order, prev, oid, {
+        toggle: e.metaKey || e.ctrlKey,
+        range: e.shiftKey,
+      }),
+    );
+    setLeadOid(oid);
+  };
+
+  const onRowContext = (c: CommitInfo, e: React.MouseEvent) => {
+    if (multiSelected && selectedSet.has(c.oid)) {
+      onCommitMulti(e, sel.keys);
+      return;
+    }
+    // Right-clicking outside the selection collapses to that row first.
+    setSel(clickSelection(order, sel, c.oid, {}));
+    setLeadOid(c.oid);
+    onCommitContext(e, { sha: c.oid, subject: c.summary });
+  };
 
   return (
     <>
@@ -304,11 +384,9 @@ export function HistoryScreen() {
                   author={c.author || "unknown"}
                   date={relativeTime(c.timestamp)}
                   refs={visibleRefs}
-                  selected={selected === i}
-                  onClick={() => setSelected(i)}
-                  onContextMenu={(e) =>
-                    onCommitContext(e, { sha: c.oid, subject: c.summary })
-                  }
+                  selected={selectedSet.has(c.oid)}
+                  onClick={(e) => onRowClick(c.oid, e)}
+                  onContextMenu={(e) => onRowContext(c, e)}
                 />
               );
             })}
@@ -328,7 +406,9 @@ export function HistoryScreen() {
             minWidth: 0,
           }}
         >
-          {current && (
+          {multiSelected ? (
+            <MultiCommitDetail oids={sel.keys} onCombinedDiff={activateSelection} />
+          ) : current && (
             <>
               <PGCommitDetail
                 sha={current.shortOid}
@@ -398,7 +478,157 @@ export function HistoryScreen() {
         </PGPane>
       </div>
       {commitMenu}
+      {commitMultiMenu}
     </>
+  );
+}
+
+/**
+ * Detail pane for a multi-commit selection: a summary, the selected commits,
+ * and the multi-commit actions (combined diff, cherry-pick set, squash range,
+ * copy SHAs). Ancestry gating comes from the full log via planCommitSelection.
+ */
+function MultiCommitDetail({
+  oids,
+  onCombinedDiff,
+}: {
+  oids: string[];
+  onCombinedDiff: () => void;
+}) {
+  const commits = useRepoStore((s) => s.commits);
+  const plan = React.useMemo(
+    () => planCommitSelection(commits, oids),
+    [commits, oids],
+  );
+  const byOid = React.useMemo(
+    () => new Map(commits.map((c) => [c.oid, c])),
+    [commits],
+  );
+  if (!plan) return null;
+  const n = plan.oids.length;
+
+  const squashBlock = !plan.contiguous
+    ? "non-contiguous selection"
+    : plan.hasMerge
+      ? "selection contains a merge"
+      : !plan.baseOid
+        ? "oldest commit is the root"
+        : null;
+
+  const cherryPickSet = () => {
+    if (
+      window.confirm(`Cherry-pick ${n} commits onto the current branch (oldest first)?`)
+    )
+      useRepoStore.getState().cherryPickMany(plan.oids);
+  };
+  const squashSet = () => {
+    if (squashBlock || !plan.baseOid) return;
+    const msg = window.prompt("New commit message for the squashed commit");
+    if (!msg) return;
+    const rebasePlan = buildRebasePlan(commits, plan.baseOid, {
+      kind: "squash-range",
+      oids: plan.oids,
+      message: msg,
+    });
+    if (rebasePlan)
+      useNavStore.getState().setIntent({ kind: "rebase-plan", plan: rebasePlan });
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", minHeight: 0, flex: 1 }}>
+      <div
+        style={{
+          padding: "12px 12px 4px",
+          fontFamily: "var(--font-mono)",
+          fontSize: "var(--fs-13)",
+          color: "var(--fg-0)",
+        }}
+      >
+        {n} commits selected
+      </div>
+      <div
+        style={{
+          padding: "0 12px 10px",
+          display: "flex",
+          gap: 4,
+          flexWrap: "wrap",
+        }}
+      >
+        <PGButton size="sm" variant="outline" icon="diff" onClick={onCombinedDiff}>
+          View combined diff
+        </PGButton>
+        <PGButton
+          size="sm"
+          variant="outline"
+          icon="rebase"
+          data-testid="multi-cherry-pick"
+          onClick={cherryPickSet}
+        >
+          Cherry-pick {n}
+        </PGButton>
+        <PGButton
+          size="sm"
+          variant="outline"
+          icon="squash"
+          data-testid="multi-squash"
+          disabled={!!squashBlock}
+          title={squashBlock ? `Can't squash: ${squashBlock}` : undefined}
+          onClick={squashSet}
+        >
+          Squash {n}
+        </PGButton>
+        <PGButton
+          size="sm"
+          variant="ghost"
+          icon="copy"
+          onClick={() => {
+            navigator.clipboard?.writeText(plan.oids.join("\n"));
+            pgFlash(`copied ${n} SHAs`);
+          }}
+        >
+          Copy SHAs
+        </PGButton>
+      </div>
+      <FocusableScroll
+        ariaLabel="Selected commits"
+        style={{
+          flex: 1,
+          minHeight: 0,
+          borderTop: "1px solid var(--border-0)",
+          padding: "8px 12px",
+          fontFamily: "var(--font-mono)",
+          fontSize: "var(--fs-12)",
+          display: "flex",
+          flexDirection: "column",
+          gap: 4,
+        }}
+      >
+        {/* Newest→oldest, matching the list above. */}
+        {plan.oids
+          .slice()
+          .reverse()
+          .map((oid) => {
+            const c = byOid.get(oid);
+            return (
+              <div key={oid} style={{ display: "flex", gap: 8 }}>
+                <span style={{ color: "var(--accent)" }}>
+                  {c?.shortOid ?? oid.slice(0, 7)}
+                </span>
+                <span
+                  style={{
+                    color: "var(--fg-2)",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {c?.summary ?? ""}
+                </span>
+              </div>
+            );
+          })}
+      </FocusableScroll>
+    </div>
   );
 }
 


### PR DESCRIPTION
Closes #54.

Select multiple commits in **History** to see a combined diff and run multi-commit operations, mirroring the multi-file selection UX shipped in #25.

## Behavior
- **Multi-select**: click = single, cmd/ctrl-click = toggle, shift-click = contiguous range. Keyboard: **Shift+↑/↓** extends the selection (routed through `features/keymap`, `suppressInInput` so it never hijacks text selection). Plain ↑/↓ and Enter are unchanged.
- **Combined diff**: selecting 2+ commits shows a *View combined diff* action → the existing `commit-vs-commit` intent → CommitDiff (`from = parent-of-oldest`, `to = newest`; root-commit guarded).
- **Cherry-pick a set**: applied oldest→newest, one refresh; a conflicting pick stops the sequence and surfaces via the existing Conflict screen.
- **Squash a contiguous range**: builds a `Pick oldest, Squash …rest` plan → the `rebase-plan` intent → Rebase screen (review + run + conflict/continue). Disabled with a clear reason on non-contiguous / merge-containing / root selections.
- Detail pane and the right-click context menu both adapt to the selection; single-commit-only actions stay single.

## Design notes
- **No backend / Tauri change.** `rebase_start` already resets to the first step's parent and re-parents `Squash` steps onto the previous commit, so a range plan collapses to one commit; a clean `cherry_pick` already auto-commits, so a store-level loop yields N commits. Squash reuses the existing `rebase_start` engine and Rebase screen entirely.
- Ancestry facts (oldest/newest/base/contiguity/merge) are computed against the **full log**, not the filtered view — so hiding merges can't make two rows look adjacent when a commit sits between them (`planCommitSelection`, pure + tested).
- Reuses the existing pure `src/lib/selection.ts` helper (keys = commit oids).

## Spec / plan
- `docs/superpowers/specs/2026-07-08-multi-select-commits-design.md`
- `docs/superpowers/plans/2026-07-08-multi-select-commits.md`

## Tests
- `planCommitSelection.test.ts`, `buildRebasePlan.test.ts` (squash-range) — pure logic.
- `cherryPickMany.test.ts` — store loop order + stop-on-conflict.
- `History.multiselect.test.tsx` — ctrl/shift click, Shift+↓ extend, multi action row, combined-diff intent, cherry-pick order, squash gating.
- Existing `History.keyboard.test.tsx` (single-select nav) stays green.
- **E2E** (`history-ops.e2e.ts`, `multiCherryRepo` fixture): combined diff of a 2-commit selection lists the introduced file; multi cherry-pick lands two `feature` commits on `main` oldest→newest — exercising `diff_commits` / `cherry_pick` end-to-end against real libgit2. Selection built via a row click + `jsChord("Shift+ArrowDown")`.

Gates (all green): `pnpm tsc --noEmit`, `pnpm test` (342 passed), `pnpm vite build`, `pnpm exec tsc -p e2e/tsconfig.json --noEmit`, `pnpm test:e2e:run --spec e2e/specs/history-ops.e2e.ts` (6 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)