### PR TITLE
feat(history): inline commit diff panel (Fork-style) (#53)

### DIFF
--- a/docs/superpowers/plans/2026-07-08-history-inline-commit-diff.md
+++ b/docs/superpowers/plans/2026-07-08-history-inline-commit-diff.md
@@ -1,0 +1,78 @@
+# History inline commit diff — implementation plan
+
+Spec: `docs/superpowers/specs/2026-07-08-history-inline-commit-diff-design.md`
+Issue: #53
+
+## Backend (Rust)
+
+1. **`src-tauri/src/git/mod.rs`** — add to `GitBackend`:
+   ```rust
+   fn diff_commit(&self, repo_id: &RepoId, oid: &str, context_lines: u32)
+       -> AppResult<Vec<FileDiff>>;
+   ```
+2. **`src-tauri/src/git/libgit2.rs`**
+   - Extract the delta→`FileDiff` loop from `diff_commits` into a free fn
+     `diff_to_file_diffs(diff: &mut git2::Diff) -> AppResult<Vec<FileDiff>>`
+     (renames already resolved by the caller via `find_similar`).
+   - `diff_commits` calls the helper.
+   - `diff_commit`: `revparse_single(oid).peel_to_commit()`; `to_tree =
+     commit.tree()`; `from_tree = commit.parent(0).ok().map(|p| p.tree())`
+     (None for root); `diff_tree_to_tree(from_tree.as_ref(), Some(&to_tree),
+     opts)`; `find_similar`; helper.
+3. **`src-tauri/src/git/cli.rs`** — `diff_commit` → `Err(AppError::NotImplemented)`.
+4. **`src-tauri/src/commands/diff.rs`** — `#[tauri::command] pub async fn
+   diff_commit(...)` wrapping `backend.diff_commit` in `spawn_blocking`.
+5. **`src-tauri/src/lib.rs`** — register `diff_commit` in `invoke_handler!`.
+6. **Rust test** (`src-tauri/tests/...` diff test file) — `diff_commit` on a
+   normal commit (parent..commit; only that commit's file), a root commit
+   (all-added), and a merge commit (vs first parent).
+
+## Frontend (TS)
+
+7. **`src/lib/tauri.ts`** — `diffCommit(repoId, oid, contextLines = 3)` wrapper
+   → `invoke("diff_commit", { repoId, oid, contextLines })`.
+8. **`src/features/nav/useNavStore.ts`** — add `{ kind: "commit-self"; oid: string }`.
+9. **`src/features/diff/CommitDiffPanel.tsx`** — new. Props:
+   `{ diffs, loading, error, header, paneIdPrefix, emptyLabel? }`.
+   Internal `selected` path (reset to `diffs[0]` when `diffs` changes),
+   `usePaneList` on `${prefix}.files`, `useHunkNav` on
+   `[${prefix}.files, ${prefix}.view]`. Renders the two `PGPane`s exactly as
+   `CommitDiffScreen` does today.
+10. **`src/screens/CommitDiff.tsx`** — replace the inline JSX with
+    `<CommitDiffPanel paneIdPrefix="commitDiff" ... />`; add `commit-self`
+    target fetched via `diffCommit`; header per target kind.
+11. **`src/screens/History.tsx`**
+    - `onActivate` → `setNavIntent({ kind: "commit-self", oid })`.
+    - Fetch `diffCommit(repo.id, current.oid, ctx)` on selection change,
+      cancellable; hold `{ diffs, loading, error }`.
+    - Layout state `below | beside` from `localStorage["pg-history-diff-layout"]`
+      (default `below`), toggle control in the toolbar-right.
+    - **below**: column — commit list on top, resize handle (vertical),
+      diff region below = compact metadata + action row + `CommitDiffPanel`.
+      Height via `usePaneWidth(320, { storageKey: "pg-history-diff-h" })`.
+    - **beside**: today's row layout; right pane = metadata + action row +
+      `CommitDiffPanel` (replaces the parents-only section). Width reuses
+      `pg-history-detail-w`.
+    - Panel `paneIdPrefix="history.diff"`.
+12. **`src/AppShell.tsx`** — route `commit-self` → `setScreen("commitDiff")`.
+13. **`src/design/resizable.tsx`** — `PGResizeHandle` gains `orientation`
+    (`"horizontal" | "vertical"`, default horizontal): vertical uses `clientY`,
+    `row-resize`, and a `height: 4` handle. Backward compatible.
+
+## Tests
+
+14. **`src/screens/History.keyboard.test.tsx`** — Enter now asserts
+    `{ kind: "commit-self", oid }`.
+15. **`src/screens/History.diff.test.tsx`** (new) — mock `diff_commit` invoke;
+    assert selecting a commit renders its changed files inline.
+16. **`e2e/specs/history-diff.e2e.ts`** — extend: open History, select a
+    commit, assert the inline changed-file list + a hunk appear (no screen
+    switch). Run only this spec at the end.
+
+## Verify
+
+- `pnpm tsc --noEmit`, `pnpm exec tsc -p e2e/tsconfig.json --noEmit`
+- `cargo test --manifest-path src-tauri/Cargo.toml`
+- `pnpm test`
+- `pnpm test:e2e:build` then `pnpm test:e2e:run --spec e2e/specs/history-diff.e2e.ts`
+- Then squash → PR.

--- a/docs/superpowers/specs/2026-07-08-history-inline-commit-diff-design.md
+++ b/docs/superpowers/specs/2026-07-08-history-inline-commit-diff-design.md
@@ -1,0 +1,88 @@
+# History inline commit diff (Fork-style) — design
+
+**Status:** approved
+**Date:** 2026-07-08
+**Owner:** jonas
+**Related:** issue #53 (spun out of #25). Precedes #54 (multi-select commits),
+which reuses the inline diff panel introduced here.
+
+## Why
+
+Selecting a commit in History shows only **metadata** (author, subject/body,
+parents) — reading the actual changes forces `Enter` → a full-screen jump to
+`CommitDiffScreen`. That breaks the "scan the log, read each diff" flow Fork
+nails: in Fork clicking a commit reveals its changed-files list + diff in an
+attached panel, no navigation.
+
+Worse, the current jump diffs the commit against **HEAD** (`commit-vs-wt`),
+not against its own parent — so even after the jump you don't see "what this
+commit changed."
+
+## Scope
+
+### In scope
+
+- **New backend op `diff_commit(repo_id, oid, context_lines)`** → `Vec<FileDiff>`:
+  the commit's own diff against its **first parent**. Root commit (no parent)
+  diffs against the empty tree → all-added. Merge commit diffs against the
+  first parent (git-show default). This is the correct "what changed in this
+  commit" primitive; `diff_commits(from, to)` cannot express the root case.
+  - Factor the existing delta→`FileDiff` conversion out of `diff_commits` into
+    a shared `diff_to_file_diffs` helper so both ops share one implementation.
+  - `CliBackend` gets the usual `NotImplemented` stub.
+- **New nav intent `commit-self { oid }`** — "this commit vs its first parent."
+  Distinct from `commit-vs-wt` (compare-to-working-tree, kept for the context
+  menu / palette / FileHistory callers that genuinely want it).
+- **Shared `CommitDiffPanel`** (`src/features/diff/CommitDiffPanel.tsx`):
+  presentational file-list + per-file-hunk renderer, extracted from
+  `CommitDiffScreen`'s body. Owns file selection + `useHunkNav` (F7/⇧F7)
+  internally, keyed off a caller-supplied `paneIdPrefix` so two mount sites
+  never collide in the focus store. Takes already-fetched
+  `diffs` / `loading` / `error` — fetching stays in each container.
+- **`CommitDiffScreen` refactor** — renders `CommitDiffPanel`; grows a
+  `commit-self` target that fetches via `diffCommit`. Keeps `commit-vs-wt`,
+  `commit-vs-commit`, `stash-diff` targets. Deep-link / full-screen path stays.
+- **History inline diff** — on commit selection, fetch `diffCommit(oid)` and
+  render `CommitDiffPanel` inline, alongside the existing metadata + action row.
+  - **Layout toggle below / beside**, persisted to
+    `localStorage["pg-history-diff-layout"]`. Fork-style **below** is the
+    default. Panel is resizable + persisted (`pg-history-diff-h` for below,
+    reuse `pg-history-detail-w` for beside).
+  - `Enter` (and the list `onActivate`) now fires `commit-self` — the
+    full-screen view shows the *same* diff as inline, not `commit-vs-wt`.
+- **`PGResizeHandle` gains a vertical orientation** (`orientation:
+  "horizontal" | "vertical"`, default horizontal) so the below-layout panel
+  resizes by height. `usePaneWidth` is axis-agnostic already (a clamped,
+  persisted number) — reused for height.
+
+### Out of scope
+
+- **Multi-select commits / combined range diff** — issue #54. Lands on top of
+  this panel.
+- Side-by-side (split) diff rendering — the panel keeps today's unified view;
+  a split view is a separate cross-cutting change to all diff surfaces.
+- Syntax highlighting inside the commit diff (unified view stays plain, same
+  as `CommitDiffScreen` today).
+- Changing `commit-vs-wt` semantics or the FileHistory / palette / context-menu
+  callers that use it.
+
+## Behavior
+
+- Select a commit → metadata (unchanged) + inline diff of `parent..commit`.
+- Root commit → every file shown as added. Merge commit → diff vs first parent.
+- File list: ↑/↓ move selection, type-to-jump speed-search, click to select.
+  F7/⇧F7 walk the selected file's hunks from either the file pane or the diff
+  pane — identical to `CommitDiffScreen` because it's the same component.
+- Toggle below/beside from a toolbar control; choice persists. Drag to resize;
+  size persists per layout.
+- `Enter` opens the same diff full-screen (`commitDiff` screen).
+
+## Risks / notes
+
+- Rapid ↑/↓ through the log must not hammer the backend: the inline fetch is
+  cancellable (ignore stale responses) and debounced lightly.
+- `paneIdPrefix` must be unique per mount site (`commitDiff.*` vs
+  `history.diff.*`) — the two screens never mount together, but the focus
+  store keys globally on pane id, so distinct prefixes are mandatory.
+- Danger-op convention is unaffected (read-only diffing, no `useRepoStore`
+  catch-arm changes).

--- a/e2e/specs/history-diff.e2e.ts
+++ b/e2e/specs/history-diff.e2e.ts
@@ -31,6 +31,40 @@ describe("history & diff", () => {
     await expect($("span*=merge feature")).toBeDisplayed();
   });
 
+  it("reveals the selected commit's own diff inline (no screen switch)", async () => {
+    repo = branchyRepo();
+    await openRepo(repo.path);
+    await switchScreen("history");
+
+    await browser.waitUntil(
+      async () => (await $$('[data-testid="commit-row"]').length) >= 5,
+      { timeout: 20_000, timeoutMsg: "commit rows never appeared" },
+    );
+
+    // Default selection is the top row (the "merge feature" commit). Its
+    // inline diff is against its first parent → the file the merge brought in.
+    const detail = $('[data-testid="history-detail"]');
+    await detail.waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "inline diff detail region never appeared",
+    });
+    await $('[data-testid="history-detail"] [data-path="feature.txt"]').waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "merge commit's inline changed file (feature.txt) never appeared",
+    });
+
+    // Selecting a different commit swaps the inline diff to that commit's own
+    // change — the "fix: update a.txt" commit touched a.txt.
+    await $('[data-testid="commit-row"]*=update a.txt').click();
+    await $('[data-testid="history-detail"] [data-path="a.txt"]').waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "selected commit's inline changed file (a.txt) never appeared",
+    });
+
+    // Still on History (column headers present) — no jump to the diff screen.
+    await expect($("span*=SUBJECT")).toBeDisplayed();
+  });
+
   it("shows a hunk for a modified file and stages it", async () => {
     repo = dirtyRepo();
     await openRepo(repo.path);

--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -138,6 +138,20 @@ pub async fn diff_commits(
 }
 
 #[tauri::command]
+pub async fn diff_commit(
+    state: State<'_, AppState>,
+    repo_id: String,
+    oid: String,
+    context_lines: u32,
+) -> AppResult<Vec<FileDiff>> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    tokio::task::spawn_blocking(move || backend.diff_commit(&repo_id, &oid, context_lines))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+#[tauri::command]
 pub async fn blame_file(
     state: State<'_, AppState>,
     repo_id: String,

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -97,6 +97,14 @@ impl GitBackend for CliBackend {
     ) -> AppResult<Vec<FileDiff>> {
         Err(AppError::NotImplemented)
     }
+    fn diff_commit(
+        &self,
+        _repo_id: &RepoId,
+        _oid: &str,
+        _context_lines: u32,
+    ) -> AppResult<Vec<FileDiff>> {
+        Err(AppError::NotImplemented)
+    }
     fn stage(&self, _repo_id: &RepoId, _paths: &[PathBuf]) -> AppResult<()> {
         Err(AppError::NotImplemented)
     }

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -442,6 +442,103 @@ fn patch_text_for_hunk(diff: &git2::Diff, delta_index: usize, hunk_index: usize)
     Ok(out)
 }
 
+/// Convert a computed `git2::Diff` into per-file `FileDiff`s (path, rename
+/// origin, binary flag, add/del counts, hunks). Renames must already be
+/// resolved by the caller (`find_similar`). Shared by every tree-to-tree diff
+/// op so hunk grouping stays identical.
+fn diff_to_file_diffs(diff: &git2::Diff) -> AppResult<Vec<FileDiff>> {
+    let num_deltas = diff.deltas().len();
+    let mut out: Vec<FileDiff> = Vec::with_capacity(num_deltas);
+
+    for delta_idx in 0..num_deltas {
+        let delta = diff.get_delta(delta_idx).expect("valid delta index");
+        let new_path = delta
+            .new_file()
+            .path()
+            .map(|p| p.display().to_string())
+            .unwrap_or_default();
+        let old_path_opt = delta
+            .old_file()
+            .path()
+            .map(|p| p.display().to_string())
+            .filter(|p| p != &new_path);
+        let binary = delta.new_file().is_binary() || delta.old_file().is_binary();
+
+        let mut hunks: Vec<DiffHunk> = Vec::new();
+        let mut current: Option<DiffHunk> = None;
+        let mut additions: u32 = 0;
+        let mut deletions: u32 = 0;
+
+        diff.print(DiffFormat::Patch, |d, hunk, line| {
+            if d.new_file()
+                .path()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default()
+                != new_path
+            {
+                return true;
+            }
+            if let Some(h) = hunk {
+                if current
+                    .as_ref()
+                    .map(|c| c.old_start != h.old_start() || c.new_start != h.new_start())
+                    .unwrap_or(true)
+                {
+                    if let Some(done) = current.take() {
+                        hunks.push(done);
+                    }
+                    current = Some(DiffHunk {
+                        header: std::str::from_utf8(h.header()).unwrap_or("").to_string(),
+                        old_start: h.old_start(),
+                        old_lines: h.old_lines(),
+                        new_start: h.new_start(),
+                        new_lines: h.new_lines(),
+                        lines: Vec::new(),
+                    });
+                }
+            }
+            let kind = match line.origin() {
+                '+' => {
+                    additions += 1;
+                    DiffLineKind::Addition
+                }
+                '-' => {
+                    deletions += 1;
+                    DiffLineKind::Deletion
+                }
+                'H' | 'F' => DiffLineKind::HunkHeader,
+                _ => DiffLineKind::Context,
+            };
+            if let Some(h) = current.as_mut() {
+                h.lines.push(DiffLine {
+                    kind,
+                    old_lineno: line.old_lineno(),
+                    new_lineno: line.new_lineno(),
+                    content: std::str::from_utf8(line.content())
+                        .unwrap_or("")
+                        .to_string(),
+                });
+            }
+            true
+        })?;
+
+        if let Some(done) = current.take() {
+            hunks.push(done);
+        }
+
+        out.push(FileDiff {
+            path: new_path,
+            old_path: old_path_opt,
+            binary,
+            additions,
+            deletions,
+            hunks,
+        });
+    }
+
+    Ok(out)
+}
+
 /// Run `git apply [extra_args...] -` with `patch_text` piped to stdin.
 fn git_apply(repo_path: &Path, extra_args: &[&str], patch_text: &str) -> AppResult<()> {
     use std::io::Write as _;
@@ -1248,96 +1345,38 @@ impl GitBackend for Libgit2Backend {
             find_opts.renames(true).copies(false);
             diff.find_similar(Some(&mut find_opts)).ok();
 
-            let num_deltas = diff.deltas().len();
-            let mut out: Vec<FileDiff> = Vec::with_capacity(num_deltas);
+            diff_to_file_diffs(&diff)
+        })
+    }
 
-            for delta_idx in 0..num_deltas {
-                let delta = diff.get_delta(delta_idx).expect("valid delta index");
-                let new_path = delta
-                    .new_file()
-                    .path()
-                    .map(|p| p.display().to_string())
-                    .unwrap_or_default();
-                let old_path_opt = delta
-                    .old_file()
-                    .path()
-                    .map(|p| p.display().to_string())
-                    .filter(|p| p != &new_path);
-                let binary = delta.new_file().is_binary() || delta.old_file().is_binary();
+    fn diff_commit(
+        &self,
+        repo_id: &RepoId,
+        oid: &str,
+        context_lines: u32,
+    ) -> AppResult<Vec<FileDiff>> {
+        self.with_repo(repo_id, |repo| {
+            let commit = repo.revparse_single(oid)?.peel_to_commit()?;
+            let to_tree = commit.tree()?;
+            // First parent for merges; None (empty tree) for the root commit.
+            let from_tree = match commit.parent(0) {
+                Ok(parent) => Some(parent.tree()?),
+                Err(_) => None,
+            };
 
-                let mut hunks: Vec<DiffHunk> = Vec::new();
-                let mut current: Option<DiffHunk> = None;
-                let mut additions: u32 = 0;
-                let mut deletions: u32 = 0;
+            let mut opts = DiffOptions::new();
+            opts.context_lines(context_lines);
+            let mut diff = repo.diff_tree_to_tree(
+                from_tree.as_ref(),
+                Some(&to_tree),
+                Some(&mut opts),
+            )?;
 
-                diff.print(DiffFormat::Patch, |d, hunk, line| {
-                    if d.new_file()
-                        .path()
-                        .map(|p| p.display().to_string())
-                        .unwrap_or_default()
-                        != new_path
-                    {
-                        return true;
-                    }
-                    if let Some(h) = hunk {
-                        if current
-                            .as_ref()
-                            .map(|c| c.old_start != h.old_start() || c.new_start != h.new_start())
-                            .unwrap_or(true)
-                        {
-                            if let Some(done) = current.take() {
-                                hunks.push(done);
-                            }
-                            current = Some(DiffHunk {
-                                header: std::str::from_utf8(h.header()).unwrap_or("").to_string(),
-                                old_start: h.old_start(),
-                                old_lines: h.old_lines(),
-                                new_start: h.new_start(),
-                                new_lines: h.new_lines(),
-                                lines: Vec::new(),
-                            });
-                        }
-                    }
-                    let kind = match line.origin() {
-                        '+' => {
-                            additions += 1;
-                            DiffLineKind::Addition
-                        }
-                        '-' => {
-                            deletions += 1;
-                            DiffLineKind::Deletion
-                        }
-                        'H' | 'F' => DiffLineKind::HunkHeader,
-                        _ => DiffLineKind::Context,
-                    };
-                    if let Some(h) = current.as_mut() {
-                        h.lines.push(DiffLine {
-                            kind,
-                            old_lineno: line.old_lineno(),
-                            new_lineno: line.new_lineno(),
-                            content: std::str::from_utf8(line.content())
-                                .unwrap_or("")
-                                .to_string(),
-                        });
-                    }
-                    true
-                })?;
+            let mut find_opts = DiffFindOptions::new();
+            find_opts.renames(true).copies(false);
+            diff.find_similar(Some(&mut find_opts)).ok();
 
-                if let Some(done) = current.take() {
-                    hunks.push(done);
-                }
-
-                out.push(FileDiff {
-                    path: new_path,
-                    old_path: old_path_opt,
-                    binary,
-                    additions,
-                    deletions,
-                    hunks,
-                });
-            }
-
-            Ok(out)
+            diff_to_file_diffs(&diff)
         })
     }
 

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -90,6 +90,17 @@ pub trait GitBackend: Send + Sync {
         to_oid: &str,
         context_lines: u32,
     ) -> AppResult<Vec<FileDiff>>;
+    /// Diff a single commit against its first parent — i.e. "what this commit
+    /// changed." A root commit (no parent) diffs against the empty tree
+    /// (all-added); a merge commit diffs against its first parent (git-show
+    /// default). Distinct from `diff_commits`, which cannot express the
+    /// empty-tree case for a root commit.
+    fn diff_commit(
+        &self,
+        repo_id: &RepoId,
+        oid: &str,
+        context_lines: u32,
+    ) -> AppResult<Vec<FileDiff>>;
     fn branches(&self, repo_id: &RepoId) -> AppResult<Vec<BranchInfo>>;
     fn tags(&self, repo_id: &RepoId) -> AppResult<Vec<TagInfo>>;
     fn stashes(&self, repo_id: &RepoId) -> AppResult<Vec<StashInfo>>;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -115,6 +115,7 @@ pub fn run() {
             commands::diff::unstage_hunk,
             commands::diff::discard_hunk,
             commands::diff::diff_commits,
+            commands::diff::diff_commit,
             commands::diff::blame_file,
             commands::branches::list_branches,
             commands::branches::list_tags,

--- a/src-tauri/tests/diff_commit.rs
+++ b/src-tauri/tests/diff_commit.rs
@@ -1,0 +1,95 @@
+mod support;
+
+use git2::Signature;
+use platypusgit_lib::git::GitBackend;
+use support::TempRepo;
+
+/// `diff_commit` on an ordinary commit shows only what *that* commit changed
+/// (its diff against its parent), not the accumulated tree.
+#[test]
+fn diff_commit_shows_only_that_commits_change() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    // Two more commits, each adding one file.
+    let oids = support::linear_history(&tr, 2); // file0.txt, file1.txt
+
+    let diffs = backend.diff_commit(&handle.id, &oids[1], 3).unwrap();
+
+    assert_eq!(diffs.len(), 1, "only the file this commit touched");
+    assert_eq!(diffs[0].path, "file1.txt");
+    assert!(diffs[0].additions > 0);
+    assert_eq!(diffs[0].deletions, 0);
+}
+
+/// A root commit (no parent) diffs against the empty tree → everything added.
+#[test]
+fn diff_commit_root_is_all_added() {
+    let tr = TempRepo::with_initial_commit("line1\nline2\n");
+    let (backend, handle) = tr.open_with_backend();
+    // Oldest entry in the log is the root commit.
+    let root = backend
+        .log(&handle.id, None, 10)
+        .unwrap()
+        .last()
+        .unwrap()
+        .oid
+        .clone();
+
+    let diffs = backend.diff_commit(&handle.id, &root, 3).unwrap();
+
+    let readme = diffs.iter().find(|d| d.path == "README.md").expect("README.md in root diff");
+    assert!(readme.additions >= 2, "both lines added");
+    assert_eq!(readme.deletions, 0);
+}
+
+/// A merge commit diffs against its *first* parent (git-show default): the
+/// second parent's unique work shows as the net change, the first parent's does not.
+#[test]
+fn diff_commit_merge_uses_first_parent() {
+    let tr = TempRepo::with_initial_commit("base\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    // feature branch off the initial commit, adds feat.txt.
+    backend.create_branch(&handle.id, "feature", None).unwrap();
+    backend.checkout_branch(&handle.id, "feature").unwrap();
+    // The backend's checkout wrote a fresh index to disk; tr.repo caches its
+    // own index in memory, so force it to re-read before committing through it
+    // (else the previous branch's staged files leak into this commit's tree).
+    tr.repo.index().unwrap().read(true).unwrap();
+    tr.add_commit("feat.txt", "feature\n", "feature work");
+
+    // main diverges, adds main.txt.
+    backend.checkout_branch(&handle.id, "main").unwrap();
+    tr.repo.index().unwrap().read(true).unwrap();
+    tr.add_commit("main.txt", "main\n", "main work");
+
+    // Merge feature into main (no conflict — different files). Build the merged
+    // tree in memory so we control the parent order: main tip is parent 0,
+    // feature tip parent 1 (so first-parent diffing has a distinct answer).
+    let merge_oid = {
+        let feat_commit = tr
+            .repo
+            .find_reference("refs/heads/feature")
+            .unwrap()
+            .peel_to_commit()
+            .unwrap();
+        let main_tip = tr.repo.head().unwrap().peel_to_commit().unwrap();
+        let mut merged = tr.repo.merge_commits(&main_tip, &feat_commit, None).unwrap();
+        assert!(!merged.has_conflicts(), "different files must merge cleanly");
+        let tree_oid = merged.write_tree_to(&tr.repo).unwrap();
+        let tree = tr.repo.find_tree(tree_oid).unwrap();
+        let sig = Signature::now("Test User", "test@example.com").unwrap();
+        tr.repo
+            .commit(Some("HEAD"), &sig, &sig, "merge feature", &tree, &[&main_tip, &feat_commit])
+            .unwrap()
+            .to_string()
+    };
+
+    let diffs = backend.diff_commit(&handle.id, &merge_oid, 3).unwrap();
+    let paths: Vec<&str> = diffs.iter().map(|d| d.path.as_str()).collect();
+
+    // feat.txt is what the merge brings in relative to the first parent (main).
+    assert!(paths.contains(&"feat.txt"), "merge vs first parent shows feature's file, got {paths:?}");
+    // main.txt is already in the first parent, so it's not a net change.
+    assert!(!paths.contains(&"main.txt"), "first parent's own file is not a change, got {paths:?}");
+}

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -164,6 +164,7 @@ export function AppShell() {
       case "diff-file":
         setScreen("diff");
         break;
+      case "commit-self":
       case "commit-vs-wt":
       case "commit-vs-commit":
         setScreen("commitDiff");

--- a/src/design/resizable.tsx
+++ b/src/design/resizable.tsx
@@ -9,15 +9,22 @@ export function PGResizeHandle({
   onDrag,
   onActiveChange,
   side = "right",
+  orientation = "horizontal",
 }: {
   onDrag: (deltaPx: number) => void;
   /** Called when the drag starts/stops. Useful to suspend CSS transitions. */
   onActiveChange?: (active: boolean) => void;
   /** Which side of the owning pane the handle sits on. Affects cursor only. */
-  side?: "left" | "right";
+  side?: "left" | "right" | "top" | "bottom";
+  /**
+   * Drag axis. `horizontal` (default) reports the X delta for width resizing;
+   * `vertical` reports the Y delta for height resizing (e.g. a panel below).
+   */
+  orientation?: "horizontal" | "vertical";
 }) {
+  const vertical = orientation === "vertical";
   const [active, setActive] = React.useState(false);
-  const startX = React.useRef<number | null>(null);
+  const start = React.useRef<number | null>(null);
 
   React.useEffect(() => {
     onActiveChange?.(active);
@@ -26,14 +33,15 @@ export function PGResizeHandle({
   React.useEffect(() => {
     if (!active) return;
     const onMove = (e: MouseEvent) => {
-      if (startX.current === null) return;
-      const delta = e.clientX - startX.current;
-      startX.current = e.clientX;
+      if (start.current === null) return;
+      const pos = vertical ? e.clientY : e.clientX;
+      const delta = pos - start.current;
+      start.current = pos;
       onDrag(delta);
     };
     const onUp = () => {
       setActive(false);
-      startX.current = null;
+      start.current = null;
     };
     document.addEventListener("mousemove", onMove);
     document.addEventListener("mouseup", onUp);
@@ -41,21 +49,24 @@ export function PGResizeHandle({
       document.removeEventListener("mousemove", onMove);
       document.removeEventListener("mouseup", onUp);
     };
-  }, [active, onDrag]);
+  }, [active, onDrag, vertical]);
 
   return (
     <div
       onMouseDown={(e) => {
         e.preventDefault();
-        startX.current = e.clientX;
+        start.current = vertical ? e.clientY : e.clientX;
         setActive(true);
       }}
       style={{
         flexShrink: 0,
-        width: 4,
+        width: vertical ? "auto" : 4,
+        height: vertical ? 4 : "auto",
         marginLeft: side === "right" ? -2 : 0,
         marginRight: side === "left" ? -2 : 0,
-        cursor: "col-resize",
+        marginTop: side === "bottom" ? -2 : 0,
+        marginBottom: side === "top" ? -2 : 0,
+        cursor: vertical ? "row-resize" : "col-resize",
         background: active ? "var(--accent)" : "transparent",
         transition: active ? "none" : "background var(--t-fast)",
         zIndex: 1,

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -1,0 +1,202 @@
+import React from "react";
+import { PGSpinner } from "@/design";
+import { PGPane, FocusableScroll, usePaneList, useHunkNav } from "@/features/keymap";
+import type { FileDiff } from "@/lib/types";
+
+export interface CommitDiffPanelProps {
+  diffs: FileDiff[];
+  loading: boolean;
+  error: string | null;
+  /** Small label shown atop the file list (e.g. "abc1234 → HEAD"). */
+  header: React.ReactNode;
+  /**
+   * Unique per mount site — the file/diff panes register in the global focus
+   * store under `${paneIdPrefix}.files` / `${paneIdPrefix}.view`, so two panels
+   * on screen at once must not share a prefix.
+   */
+  paneIdPrefix: string;
+  /** Shown when the diff is empty (no changed files). */
+  emptyLabel?: string;
+}
+
+/**
+ * Presentational file-list + per-file-hunk renderer for a commit diff. Owns
+ * file selection and F7/⇧F7 hunk navigation internally; the caller fetches the
+ * diffs. Mounted by both `CommitDiffScreen` (full-screen) and the History
+ * inline panel so hunk-nav and selection behave identically in both.
+ */
+export function CommitDiffPanel({
+  diffs,
+  loading,
+  error,
+  header,
+  paneIdPrefix,
+  emptyLabel = "No changes in this commit.",
+}: CommitDiffPanelProps) {
+  const filesPaneId = `${paneIdPrefix}.files`;
+  const viewPaneId = `${paneIdPrefix}.view`;
+
+  const [selected, setSelected] = React.useState<string | null>(
+    diffs[0]?.path ?? null,
+  );
+
+  // Keep the selection valid as the diff set changes (new commit selected).
+  React.useEffect(() => {
+    setSelected((prev) =>
+      prev && diffs.some((d) => d.path === prev) ? prev : (diffs[0]?.path ?? null),
+    );
+  }, [diffs]);
+
+  const selectedIndex = Math.max(0, diffs.findIndex((d) => d.path === selected));
+  usePaneList({
+    paneId: filesPaneId,
+    count: diffs.length,
+    selectedIndex,
+    onSelect: (i) => {
+      const d = diffs[i];
+      if (d) setSelected(d.path);
+    },
+    searchText: (i) => diffs[i]?.path ?? "",
+  });
+
+  // Fall back to the first file so the diff pane is populated immediately when
+  // a new diff arrives, before the selection-sync effect runs.
+  const current = diffs.find((d) => d.path === selected) ?? diffs[0] ?? null;
+
+  const hunkCursor = useHunkNav({
+    paneIds: [filesPaneId, viewPaneId],
+    count: current?.hunks.length ?? 0,
+    resetKey: selected,
+  });
+
+  return (
+    <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+      <PGPane
+        id={filesPaneId}
+        style={{
+          width: 240,
+          flexShrink: 0,
+          borderRight: "1px solid var(--border-0)",
+          fontFamily: "var(--font-mono)",
+          fontSize: "var(--fs-12)",
+          minWidth: 0,
+        }}
+      >
+        <FocusableScroll style={{ height: "100%" }} ariaLabel="Changed files">
+          <div
+            style={{
+              padding: "6px 12px",
+              borderBottom: "1px solid var(--border-0)",
+              color: "var(--fg-3)",
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {header}
+          </div>
+          {loading && (
+            <div style={{ padding: 12 }}>
+              <PGSpinner />
+            </div>
+          )}
+          {error && (
+            <div style={{ padding: 12, color: "var(--git-removed)" }}>{error}</div>
+          )}
+          {!loading && !error && diffs.length === 0 && (
+            <div style={{ padding: 12, color: "var(--fg-3)" }}>{emptyLabel}</div>
+          )}
+          {diffs.map((d) => (
+            <div
+              key={d.path}
+              onClick={() => setSelected(d.path)}
+              data-pg-row=""
+              data-selected={d.path === selected ? "" : undefined}
+              data-path={d.path}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 8,
+                padding: "4px 12px",
+                cursor: "pointer",
+              }}
+            >
+              <span
+                style={{
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {d.path}
+              </span>
+              <span style={{ flexShrink: 0, fontSize: "var(--fs-10)" }}>
+                {d.additions > 0 && (
+                  <span style={{ color: "var(--git-added)" }}>+{d.additions}</span>
+                )}{" "}
+                {d.deletions > 0 && (
+                  <span style={{ color: "var(--git-removed)" }}>−{d.deletions}</span>
+                )}
+              </span>
+            </div>
+          ))}
+        </FocusableScroll>
+      </PGPane>
+      <PGPane
+        id={viewPaneId}
+        style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column" }}
+      >
+        <FocusableScroll style={{ flex: 1, padding: 12 }} ariaLabel="Diff">
+          {current?.binary && (
+            <div style={{ color: "var(--fg-3)", fontSize: "var(--fs-12)" }}>
+              Binary file — no textual diff.
+            </div>
+          )}
+          {current &&
+            current.hunks.map((h, i) => (
+              <div
+                key={i}
+                data-hunk-index={i}
+                data-hunk-active={hunkCursor === i ? "" : undefined}
+                style={{ marginBottom: 16 }}
+              >
+                <div
+                  style={{
+                    color: "var(--fg-3)",
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "var(--fs-12)",
+                  }}
+                >
+                  {h.header}
+                </div>
+                {h.lines.map((ln, j) => (
+                  <div
+                    key={j}
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "var(--fs-12)",
+                      whiteSpace: "pre",
+                      color:
+                        ln.kind.kind === "Addition"
+                          ? "var(--git-added)"
+                          : ln.kind.kind === "Deletion"
+                            ? "var(--git-removed)"
+                            : "var(--fg-0)",
+                    }}
+                  >
+                    {ln.kind.kind === "Addition"
+                      ? "+"
+                      : ln.kind.kind === "Deletion"
+                        ? "-"
+                        : " "}
+                    {ln.content}
+                  </div>
+                ))}
+              </div>
+            ))}
+        </FocusableScroll>
+      </PGPane>
+    </div>
+  );
+}

--- a/src/features/nav/useNavStore.ts
+++ b/src/features/nav/useNavStore.ts
@@ -9,6 +9,8 @@ import type { RebaseStep } from "@/lib/types";
 export type NavIntent =
   | { kind: "diff-file"; path: string }
   | { kind: "commit-vs-wt"; oid: string }
+  // A commit's own diff (vs its first parent) — "what this commit changed."
+  | { kind: "commit-self"; oid: string }
   | { kind: "commit-vs-commit"; from: string; to: string }
   | { kind: "file-history"; path: string }
   | { kind: "blame"; path: string }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -176,6 +176,19 @@ export async function diffCommits(
   return invoke<FileDiff[]>("diff_commits", { repoId, fromOid, toOid, contextLines });
 }
 
+/**
+ * A single commit's own diff — against its first parent. Root commit (no
+ * parent) diffs against the empty tree (all-added); a merge commit diffs
+ * against its first parent. This is "what this commit changed."
+ */
+export async function diffCommit(
+  repoId: string,
+  oid: string,
+  contextLines = 3,
+): Promise<FileDiff[]> {
+  return invoke<FileDiff[]>("diff_commit", { repoId, oid, contextLines });
+}
+
 export async function stagePaths(repoId: string, paths: string[]): Promise<void> {
   return invoke<void>("stage_paths", { repoId, paths });
 }

--- a/src/screens/CommitDiff.tsx
+++ b/src/screens/CommitDiff.tsx
@@ -1,17 +1,31 @@
 import React from "react";
-import { PGEmpty, PGSpinner } from "@/design";
+import { PGEmpty } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
-import { diffCommits } from "@/lib/tauri";
+import { CommitDiffPanel } from "@/features/diff/CommitDiffPanel";
+import { diffCommit, diffCommits } from "@/lib/tauri";
 import { appErrorMessage } from "@/lib/errors";
-import { PGPane, FocusableScroll, usePaneList, useHunkNav } from "@/features/keymap";
 import type { FileDiff } from "@/lib/types";
 
 type Target =
+  | { kind: "commit-self"; oid: string }
   | { kind: "commit-vs-wt"; oid: string }
   | { kind: "commit-vs-commit"; from: string; to: string }
   | { kind: "stash-diff"; oid: string };
+
+function targetHeader(target: Target): string {
+  switch (target.kind) {
+    case "commit-self":
+      return `${target.oid.slice(0, 7)} (this commit)`;
+    case "commit-vs-wt":
+      return `${target.oid.slice(0, 7)} → HEAD`;
+    case "stash-diff":
+      return `stash ${target.oid.slice(0, 7)} → HEAD`;
+    case "commit-vs-commit":
+      return `${target.from.slice(0, 7)} → ${target.to.slice(0, 7)}`;
+  }
+}
 
 export function CommitDiffScreen() {
   const repo = useRepoStore((s) => s.current);
@@ -21,12 +35,14 @@ export function CommitDiffScreen() {
 
   const [target, setTarget] = React.useState<Target | null>(null);
   const [diffs, setDiffs] = React.useState<FileDiff[]>([]);
-  const [selected, setSelected] = React.useState<string | null>(null);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
   React.useEffect(() => {
-    if (intent?.kind === "commit-vs-wt") {
+    if (intent?.kind === "commit-self") {
+      setTarget({ kind: "commit-self", oid: intent.oid });
+      clearIntent();
+    } else if (intent?.kind === "commit-vs-wt") {
       setTarget({ kind: "commit-vs-wt", oid: intent.oid });
       clearIntent();
     } else if (intent?.kind === "commit-vs-commit") {
@@ -40,106 +56,43 @@ export function CommitDiffScreen() {
 
   React.useEffect(() => {
     if (!repo || !target) return;
-    const [from, to] =
-      target.kind === "commit-vs-wt" || target.kind === "stash-diff"
-        ? [target.oid, "HEAD"]
-        : [target.from, target.to];
     let cancelled = false;
     setLoading(true);
     setError(null);
-    diffCommits(repo.id, from, to, diffContextLines)
-      .then((d) => { if (!cancelled) { setDiffs(d); setSelected(d[0]?.path ?? null); } })
-      .catch((e) => { if (!cancelled) setError(appErrorMessage(e)); })
+    const fetch =
+      target.kind === "commit-self"
+        ? diffCommit(repo.id, target.oid, diffContextLines)
+        : diffCommits(
+            repo.id,
+            target.kind === "commit-vs-commit" ? target.from : target.oid,
+            target.kind === "commit-vs-commit" ? target.to : "HEAD",
+            diffContextLines,
+          );
+    fetch
+      .then((d) => { if (!cancelled) setDiffs(d); })
+      .catch((e) => { if (!cancelled) { setDiffs([]); setError(appErrorMessage(e)); } })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
   }, [repo?.id, target, diffContextLines]);
 
-  // Keyboard: arrows move the file selection while the list pane is focused.
-  const selectedIndex = Math.max(0, diffs.findIndex((d) => d.path === selected));
-  usePaneList({
-    paneId: "commitDiff.files",
-    count: diffs.length,
-    selectedIndex,
-    onSelect: (i) => {
-      const d = diffs[i];
-      if (d) setSelected(d.path);
-    },
-    searchText: (i) => diffs[i]?.path ?? "",
-  });
-
-  const current = diffs.find((d) => d.path === selected) ?? null;
-
-  // F7/⇧F7 walk the viewed file's hunks from either pane.
-  const hunkCursor = useHunkNav({
-    paneIds: ["commitDiff.files", "commitDiff.view"],
-    count: current?.hunks.length ?? 0,
-    resetKey: selected,
-  });
-
   if (!target) {
-    return <PGEmpty icon="diff" title="No diff target">Pick "Compare…" from a context menu.</PGEmpty>;
+    return (
+      <PGEmpty icon="diff" title="No diff target">
+        Pick &quot;Compare…&quot; from a context menu.
+      </PGEmpty>
+    );
   }
 
   return (
-    <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
-      <PGPane id="commitDiff.files" style={{
-        width: 260,
-        borderRight: "1px solid var(--border-0)",
-        fontFamily: "var(--font-mono)", fontSize: "var(--fs-12)",
-      }}>
-        <FocusableScroll style={{ height: "100%" }} ariaLabel="Changed files">
-        <div style={{ padding: "8px 12px", borderBottom: "1px solid var(--border-0)" }}>
-          {target.kind === "commit-vs-wt"
-            ? `${target.oid.slice(0, 7)} → HEAD`
-            : target.kind === "stash-diff"
-            ? `stash ${target.oid.slice(0, 7)} → HEAD`
-            : `${target.from.slice(0, 7)} → ${target.to.slice(0, 7)}`}
-        </div>
-        {loading && <div style={{ padding: 12 }}><PGSpinner /></div>}
-        {error && <div style={{ padding: 12, color: "var(--git-removed)" }}>{error}</div>}
-        {diffs.map((d) => (
-          <div
-            key={d.path}
-            onClick={() => setSelected(d.path)}
-            data-pg-row=""
-            data-selected={d.path === selected ? "" : undefined}
-            style={{
-              padding: "4px 12px",
-              cursor: "pointer",
-            }}
-          >
-            {d.path}
-          </div>
-        ))}
-        </FocusableScroll>
-      </PGPane>
-      <PGPane id="commitDiff.view" style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column" }}>
-      <FocusableScroll style={{ flex: 1, padding: 12 }} ariaLabel="Diff">
-        {current && current.hunks.map((h, i) => (
-          <div
-            key={i}
-            data-hunk-index={i}
-            data-hunk-active={hunkCursor === i ? "" : undefined}
-            style={{ marginBottom: 16 }}
-          >
-            <div style={{ color: "var(--fg-3)", fontFamily: "var(--font-mono)", fontSize: "var(--fs-12)" }}>
-              {h.header}
-            </div>
-            {h.lines.map((ln, j) => (
-              <div key={j} style={{
-                fontFamily: "var(--font-mono)", fontSize: "var(--fs-12)",
-                whiteSpace: "pre",
-                color: ln.kind.kind === "Addition" ? "var(--git-added)" :
-                       ln.kind.kind === "Deletion" ? "var(--git-removed)" : "var(--fg-0)",
-              }}>
-                {ln.kind.kind === "Addition" ? "+" : ln.kind.kind === "Deletion" ? "-" : " "}
-                {ln.content}
-              </div>
-            ))}
-          </div>
-        ))}
-      </FocusableScroll>
-      </PGPane>
-    </div>
+    <CommitDiffPanel
+      diffs={diffs}
+      loading={loading}
+      error={error}
+      header={targetHeader(target)}
+      paneIdPrefix="commitDiff"
+      emptyLabel={
+        target.kind === "commit-self" ? "No changes in this commit." : "No changes."
+      }
+    />
   );
 }

--- a/src/screens/History.diff.test.tsx
+++ b/src/screens/History.diff.test.tsx
@@ -1,0 +1,93 @@
+// The History screen renders the selected commit's own diff inline (issue #53):
+// selecting a commit fetches diff_commit and shows its changed files + hunks
+// without leaving the screen.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { HistoryScreen } from "./History";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { useKeymapStore, useFocusStore } from "@/features/keymap";
+import { mockInvoke, getInvokeCalls } from "@/test/invokeMock";
+import type { CommitInfo, FileDiff } from "@/lib/types";
+
+const mkCommit = (oid: string, summary: string, parents: string[] = []): CommitInfo => ({
+  oid,
+  shortOid: oid.slice(0, 7),
+  summary,
+  body: null,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 1_700_000_000,
+  parents,
+  refs: [],
+});
+
+const fileDiff = (path: string): FileDiff => ({
+  path,
+  oldPath: null,
+  binary: false,
+  additions: 2,
+  deletions: 0,
+  hunks: [
+    {
+      header: "@@ -0,0 +1,2 @@",
+      oldStart: 0,
+      oldLines: 0,
+      newStart: 1,
+      newLines: 2,
+      lines: [
+        { kind: { kind: "Addition" }, oldLineno: null, newLineno: 1, content: "added line\n" },
+        { kind: { kind: "Addition" }, oldLineno: null, newLineno: 2, content: "more\n" },
+      ],
+    },
+  ],
+});
+
+describe("History inline commit diff", () => {
+  beforeEach(() => {
+    useRepoStore.setState({
+      current: { id: "r1", path: "/repo", head: "main" },
+      commits: [
+        mkCommit("a".repeat(40), "second commit", ["b".repeat(40)]),
+        mkCommit("b".repeat(40), "first commit"),
+      ],
+      searchResults: null,
+      searching: false,
+      searchCommits: async () => {},
+      branches: [],
+      status: [],
+      loading: false,
+    } as never);
+    useNavStore.setState({ intent: null });
+    useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+    useKeymapStore.getState().setPreset("rider");
+    useFocusStore.setState({
+      focused: null,
+      panes: new Map(),
+      order: [],
+      barId: null,
+      pendingContentFocus: false,
+    });
+  });
+
+  it("fetches and renders the selected commit's changed files inline", async () => {
+    mockInvoke("diff_commit", () => [fileDiff("src/foo.ts"), fileDiff("README.md")]);
+
+    render(<HistoryScreen />);
+
+    // The changed-file list + the first file's hunk appear inline (no screen
+    // switch — the nav intent stays null).
+    await waitFor(() => {
+      expect(screen.getByText(/@@ -0,0 \+1,2 @@/)).toBeInTheDocument();
+    });
+    expect(screen.getByText("src/foo.ts")).toBeInTheDocument();
+    expect(screen.getByText("README.md")).toBeInTheDocument();
+
+    // Diff was fetched for the top (default-selected) commit.
+    const call = getInvokeCalls().find((c) => c.cmd === "diff_commit");
+    expect(call?.args.oid).toBe("a".repeat(40));
+    // Selecting a commit does not navigate away.
+    expect(useNavStore.getState().intent).toBeNull();
+  });
+});

--- a/src/screens/History.keyboard.test.tsx
+++ b/src/screens/History.keyboard.test.tsx
@@ -7,6 +7,7 @@ import { HistoryScreen } from "./History";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useKeymapStore, useFocusStore } from "@/features/keymap";
+import { mockInvoke } from "@/test/invokeMock";
 import type { CommitInfo } from "@/lib/types";
 
 const mkCommit = (oid: string, summary: string): CommitInfo => ({
@@ -54,6 +55,8 @@ const rowFor = (text: string) => {
 
 describe("History keyboard navigation", () => {
   beforeEach(() => {
+    // The inline diff panel fetches the selected commit's diff on selection.
+    mockInvoke("diff_commit", () => []);
     useRepoStore.setState({
       current: { id: "r1", path: "/repo", head: "main" },
       commits: [
@@ -97,13 +100,13 @@ describe("History keyboard navigation", () => {
     expect(press("ArrowDown")).toBe(false);
   });
 
-  it("Enter opens the selected commit's diff via a nav intent", () => {
+  it("Enter opens the selected commit's own diff via a nav intent", () => {
     render(<HistoryScreen />);
     useFocusStore.setState({ focused: "history.list" });
     press("ArrowDown");
     press("Enter");
     expect(useNavStore.getState().intent).toEqual({
-      kind: "commit-vs-wt",
+      kind: "commit-self",
       oid: "b".repeat(40),
     });
   });

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import {
-  PGBadge,
   PGButton,
   PGButtonGroup,
   PGCommitDetail,
@@ -25,7 +24,11 @@ import { planCommitSelection } from "@/features/commits/planCommitSelection";
 import { buildRebasePlan } from "@/features/commits/buildRebasePlan";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { CommitDiffPanel } from "@/features/diff/CommitDiffPanel";
 import { PGPane, FocusableScroll, usePaneList } from "@/features/keymap";
+import { diffCommit } from "@/lib/tauri";
+import { appErrorMessage } from "@/lib/errors";
 import { currentBranch, mapCommitRefs, relativeTime, shortSha } from "@/lib/derive";
 import {
   clickSelection,
@@ -34,12 +37,16 @@ import {
   pruneSelection,
   type Selection,
 } from "@/lib/selection";
-import type { CommitInfo } from "@/lib/types";
+import type { CommitInfo, FileDiff } from "@/lib/types";
 
 type HistoryFilterKind = "all" | "mine" | "branch";
 type RefFilter = "all" | "local";
+type DiffLayout = "below" | "beside";
 
 const SEARCH_DEBOUNCE_MS = 250;
+const DIFF_LAYOUT_KEY = "pg-history-diff-layout";
+/** Small debounce so arrow-scrolling the log doesn't fire a fetch per row. */
+const INLINE_DIFF_DEBOUNCE_MS = 100;
 
 export function HistoryScreen() {
   const commits = useRepoStore((s) => s.commits);
@@ -97,6 +104,34 @@ export function HistoryScreen() {
     max: 720,
     storageKey: "pg-history-detail-w",
   });
+  const repo = useRepoStore((s) => s.current);
+  const diffContextLines = useSettingsStore((s) => s.diffContextLines);
+  // Below-layout panel height reuses the clamped/persisted pane-size hook.
+  const detailHeight = usePaneWidth(320, {
+    min: 140,
+    max: 800,
+    storageKey: "pg-history-diff-h",
+  });
+  const [diffLayout, setDiffLayout] = React.useState<DiffLayout>(() => {
+    try {
+      return localStorage.getItem(DIFF_LAYOUT_KEY) === "beside" ? "beside" : "below";
+    } catch {
+      return "below";
+    }
+  });
+  React.useEffect(() => {
+    try {
+      localStorage.setItem(DIFF_LAYOUT_KEY, diffLayout);
+    } catch {
+      // quota errors are non-fatal
+    }
+  }, [diffLayout]);
+
+  // Inline diff of the selected commit (its own change: parent..commit). Only
+  // for a single selection — a multi-selection uses "View combined diff" (#54).
+  const [inlineDiffs, setInlineDiffs] = React.useState<FileDiff[]>([]);
+  const [inlineLoading, setInlineLoading] = React.useState(false);
+  const [inlineError, setInlineError] = React.useState<string | null>(null);
 
   const head = currentBranch(branches);
   const headName = head?.name ?? null;
@@ -163,7 +198,8 @@ export function HistoryScreen() {
     setLeadOid(oid);
   };
 
-  // Enter / "View combined diff": one commit → commit-vs-wt (unchanged); 2+ →
+  // Enter / "View combined diff": one commit → its own diff full-screen
+  // (commit-self, matching the inline panel — not commit-vs-HEAD); 2+ →
   // combined diff of the whole selection (parent-of-oldest → newest).
   const setNavIntent = useNavStore((s) => s.setIntent);
   const activateSelection = React.useCallback(() => {
@@ -178,7 +214,7 @@ export function HistoryScreen() {
       return;
     }
     const oid = primarySelectedKey(sel) ?? order[cursorIdx];
-    if (oid) setNavIntent({ kind: "commit-vs-wt", oid });
+    if (oid) setNavIntent({ kind: "commit-self", oid });
   }, [sel, commits, order, cursorIdx, setNavIntent]);
 
   // Keyboard: ↑/↓ move a single cursor, Shift+↑/↓ extend the range, Enter opens
@@ -193,6 +229,32 @@ export function HistoryScreen() {
     onActivate: activateSelection,
     searchText: (i) => visible[i]?.summary ?? "",
   });
+
+  // Single-selection commit whose own diff (parent..commit) feeds the inline
+  // panel; null while multi-selecting (that path uses the combined diff).
+  const inlineOid =
+    sel.keys.length > 1 ? null : (primarySelectedKey(sel) ?? order[cursorIdx] ?? null);
+  // Cancellable + debounced so rapid ↑/↓ through the log doesn't flood libgit2.
+  React.useEffect(() => {
+    if (!repo || !inlineOid) {
+      setInlineDiffs([]);
+      setInlineError(null);
+      setInlineLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setInlineLoading(true);
+    setInlineError(null);
+    const handle = window.setTimeout(() => {
+      diffCommit(repo.id, inlineOid, diffContextLines)
+        .then((d) => { if (!cancelled) setInlineDiffs(d); })
+        .catch((e) => {
+          if (!cancelled) { setInlineDiffs([]); setInlineError(appErrorMessage(e)); }
+        })
+        .finally(() => { if (!cancelled) setInlineLoading(false); });
+    }, INLINE_DIFF_DEBOUNCE_MS);
+    return () => { cancelled = true; window.clearTimeout(handle); };
+  }, [repo?.id, inlineOid, diffContextLines]);
 
   const exportVisible = React.useCallback(() => {
     const lines = visible.map(
@@ -225,6 +287,10 @@ export function HistoryScreen() {
       onRefFilter={setRefFilter}
       hideMerges={hideMerges}
       onHideMerges={setHideMerges}
+      diffLayout={diffLayout}
+      onToggleDiffLayout={() =>
+        setDiffLayout((l) => (l === "below" ? "beside" : "below"))
+      }
       onExport={exportVisible}
     />
   );
@@ -316,166 +382,182 @@ export function HistoryScreen() {
     onCommitContext(e, { sha: c.oid, subject: c.summary });
   };
 
+  const listPane = (
+    <PGPane
+      id="history.list"
+      style={{
+        flex: 1,
+        minWidth: 0,
+        minHeight: 0,
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "140px 70px 1fr 150px 90px",
+          height: 24,
+          background: "var(--bg-2)",
+          borderBottom: "1px solid var(--border-0)",
+          fontFamily: "var(--font-mono)",
+          fontSize: "var(--fs-10)",
+          color: "var(--fg-2)",
+          textTransform: "uppercase",
+          letterSpacing: "0.05em",
+          alignItems: "center",
+        }}
+      >
+        <span style={{ paddingLeft: 12 }}>GRAPH</span>
+        <span>SHA</span>
+        <span>SUBJECT</span>
+        <span>AUTHOR</span>
+        <span>DATE</span>
+      </div>
+      <FocusableScroll style={{ flex: 1 }} ariaLabel="Commit list">
+        {visible.length === 0 && (
+          <div
+            style={{
+              padding: 20,
+              textAlign: "center",
+              color: "var(--fg-3)",
+              fontSize: "var(--fs-12)",
+            }}
+          >
+            {searching
+              ? "Searching…"
+              : searchActive
+                ? "No commits match the search."
+                : "No commits match the current filters."}
+          </div>
+        )}
+        {visible.map((c, i) => {
+          const g = rows[i];
+          const refs = mapCommitRefs(c.refs, headName);
+          const visibleRefs =
+            refFilter === "local" ? refs.filter((r) => !r.remote) : refs;
+          return (
+            <PGCommitRow
+              key={c.oid}
+              lanes={g?.lanes}
+              node={g?.node}
+              sha={c.shortOid}
+              message={c.summary}
+              author={c.author || "unknown"}
+              date={relativeTime(c.timestamp)}
+              refs={visibleRefs}
+              selected={selectedSet.has(c.oid)}
+              onClick={(e) => onRowClick(c.oid, e)}
+              onContextMenu={(e) => onRowContext(c, e)}
+            />
+          );
+        })}
+      </FocusableScroll>
+    </PGPane>
+  );
+
+  // "parent → commit" label above the single-commit inline file list.
+  const diffHeader = current
+    ? current.parents.length > 0
+      ? `${shortSha(current.parents[0])} → ${current.shortOid}`
+      : `(root) → ${current.shortOid}`
+    : "";
+
+  const detailContent = multiSelected ? (
+    <MultiCommitDetail oids={sel.keys} onCombinedDiff={activateSelection} />
+  ) : current ? (
+    <>
+      <PGCommitDetail
+        sha={current.shortOid}
+        fullSha={current.oid}
+        subject={current.summary}
+        body={current.body ?? undefined}
+        author={current.author || "unknown"}
+        email={current.email}
+        date={relativeTime(current.timestamp)}
+        parents={current.parents.map(shortSha)}
+      />
+      <CommitActionRow commit={current} />
+      <div
+        style={{
+          borderTop: "1px solid var(--border-0)",
+          flex: 1,
+          minHeight: 0,
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <CommitDiffPanel
+          diffs={inlineDiffs}
+          loading={inlineLoading}
+          error={inlineError}
+          header={diffHeader}
+          paneIdPrefix="history.diff"
+        />
+      </div>
+    </>
+  ) : null;
+
+  const showDetail = multiSelected || !!current;
+
   return (
     <>
       <PGToolbar left={toolbarLeft} right={toolbarRight} />
       {advancedPanel}
-      <div style={{ flex: 1, minHeight: 0, display: "flex" }}>
-        <PGPane
-          id="history.list"
-          style={{
-            flex: 1,
-            minWidth: 0,
-            display: "flex",
-            flexDirection: "column",
-            overflow: "hidden",
-          }}
-        >
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "140px 70px 1fr 150px 90px",
-              height: 24,
-              background: "var(--bg-2)",
-              borderBottom: "1px solid var(--border-0)",
-              fontFamily: "var(--font-mono)",
-              fontSize: "var(--fs-10)",
-              color: "var(--fg-2)",
-              textTransform: "uppercase",
-              letterSpacing: "0.05em",
-              alignItems: "center",
-            }}
-          >
-            <span style={{ paddingLeft: 12 }}>GRAPH</span>
-            <span>SHA</span>
-            <span>SUBJECT</span>
-            <span>AUTHOR</span>
-            <span>DATE</span>
-          </div>
-          <FocusableScroll style={{ flex: 1 }} ariaLabel="Commit list">
-            {visible.length === 0 && (
-              <div
-                style={{
-                  padding: 20,
-                  textAlign: "center",
-                  color: "var(--fg-3)",
-                  fontSize: "var(--fs-12)",
-                }}
-              >
-                {searching
-                  ? "Searching…"
-                  : searchActive
-                    ? "No commits match the search."
-                    : "No commits match the current filters."}
-              </div>
-            )}
-            {visible.map((c, i) => {
-              const g = rows[i];
-              const refs = mapCommitRefs(c.refs, headName);
-              const visibleRefs =
-                refFilter === "local" ? refs.filter((r) => !r.remote) : refs;
-              return (
-                <PGCommitRow
-                  key={c.oid}
-                  lanes={g?.lanes}
-                  node={g?.node}
-                  sha={c.shortOid}
-                  message={c.summary}
-                  author={c.author || "unknown"}
-                  date={relativeTime(c.timestamp)}
-                  refs={visibleRefs}
-                  selected={selectedSet.has(c.oid)}
-                  onClick={(e) => onRowClick(c.oid, e)}
-                  onContextMenu={(e) => onRowContext(c, e)}
-                />
-              );
-            })}
-          </FocusableScroll>
-        </PGPane>
-
-        <PGResizeHandle onDrag={(d) => detailPane.resize(-d)} side="left" />
-        <PGPane
-          id="history.detail"
-          style={{
-            width: detailPane.width,
-            flexShrink: 0,
-            borderLeft: "1px solid var(--border-0)",
-            background: "var(--bg-1)",
-            display: "flex",
-            flexDirection: "column",
-            minWidth: 0,
-          }}
-        >
-          {multiSelected ? (
-            <MultiCommitDetail oids={sel.keys} onCombinedDiff={activateSelection} />
-          ) : current && (
-            <>
-              <PGCommitDetail
-                sha={current.shortOid}
-                fullSha={current.oid}
-                subject={current.summary}
-                body={current.body ?? undefined}
-                author={current.author || "unknown"}
-                email={current.email}
-                date={relativeTime(current.timestamp)}
-                parents={current.parents.map(shortSha)}
-              />
-              <CommitActionRow commit={current} />
-              <div
-                style={{
-                  borderTop: "1px solid var(--border-0)",
-                  flex: 1,
-                  minHeight: 0,
-                  display: "flex",
-                  flexDirection: "column",
-                }}
-              >
-                <div
-                  style={{
-                    height: 26,
-                    padding: "0 12px",
-                    display: "flex",
-                    alignItems: "center",
-                    fontFamily: "var(--font-mono)",
-                    fontSize: "var(--fs-11)",
-                    color: "var(--fg-1)",
-                    textTransform: "uppercase",
-                    letterSpacing: "0.05em",
-                    background: "var(--bg-2)",
-                    borderBottom: "1px solid var(--border-0)",
-                    justifyContent: "space-between",
-                  }}
-                >
-                  <span>PARENTS</span>
-                  <PGBadge tone="muted">{current.parents.length}</PGBadge>
-                </div>
-                <FocusableScroll
-                  ariaLabel="Commit parents"
-                  style={{
-                    flex: 1,
-                    padding: "8px 12px",
-                    fontFamily: "var(--font-mono)",
-                    fontSize: "var(--fs-12)",
-                    color: "var(--fg-2)",
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: 4,
-                  }}
-                >
-                  {current.parents.length === 0 && (
-                    <span style={{ color: "var(--fg-3)" }}>(initial commit)</span>
-                  )}
-                  {current.parents.map((p) => (
-                    <span key={p}>
-                      <span style={{ color: "var(--accent)" }}>{shortSha(p)}</span>{" "}
-                      <span style={{ color: "var(--fg-3)" }}>{p}</span>
-                    </span>
-                  ))}
-                </FocusableScroll>
-              </div>
-            </>
-          )}
-        </PGPane>
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          display: "flex",
+          flexDirection: diffLayout === "below" ? "column" : "row",
+        }}
+      >
+        {listPane}
+        {showDetail && diffLayout === "beside" && (
+          <>
+            <PGResizeHandle onDrag={(d) => detailPane.resize(-d)} side="left" />
+            <div
+              data-testid="history-detail"
+              style={{
+                width: detailPane.width,
+                flexShrink: 0,
+                borderLeft: "1px solid var(--border-0)",
+                background: "var(--bg-1)",
+                display: "flex",
+                flexDirection: "column",
+                minWidth: 0,
+                minHeight: 0,
+              }}
+            >
+              {detailContent}
+            </div>
+          </>
+        )}
+        {showDetail && diffLayout === "below" && (
+          <>
+            <PGResizeHandle
+              orientation="vertical"
+              side="top"
+              onDrag={(d) => detailHeight.resize(-d)}
+            />
+            <div
+              data-testid="history-detail"
+              style={{
+                height: detailHeight.width,
+                flexShrink: 0,
+                borderTop: "1px solid var(--border-0)",
+                background: "var(--bg-1)",
+                display: "flex",
+                flexDirection: "column",
+                minWidth: 0,
+                minHeight: 0,
+              }}
+            >
+              {detailContent}
+            </div>
+          </>
+        )}
       </div>
       {commitMenu}
       {commitMultiMenu}
@@ -896,6 +978,8 @@ function HistoryToolbarRight({
   onRefFilter,
   hideMerges,
   onHideMerges,
+  diffLayout,
+  onToggleDiffLayout,
   onExport,
 }: {
   logRef: string | null;
@@ -905,6 +989,8 @@ function HistoryToolbarRight({
   onRefFilter: (v: RefFilter) => void;
   hideMerges: boolean;
   onHideMerges: (v: boolean) => void;
+  diffLayout: DiffLayout;
+  onToggleDiffLayout: () => void;
   onExport: () => void;
 }) {
   const { openAt, menu } = useContextMenu<null>(() => [
@@ -939,6 +1025,18 @@ function HistoryToolbarRight({
         size="md"
         title="Filter"
         onClick={(e) => openAt(e.clientX, e.clientY + 4, null)}
+      />
+      <PGIconButton
+        icon="diff"
+        size="md"
+        title={
+          diffLayout === "below"
+            ? "Diff panel below — switch to beside"
+            : "Diff panel beside — switch to below"
+        }
+        aria-pressed={diffLayout === "beside"}
+        data-testid="history-diff-layout"
+        onClick={onToggleDiffLayout}
       />
       <PGIconButton
         icon="download"


### PR DESCRIPTION
Closes #53.

Selecting a commit in History now reveals its **own diff** (changed-file list + per-file hunks) **inline** — no screen jump. Fork's history view is the reference.

## Problem
History showed only commit *metadata*; reading changes forced `Enter` → a full-screen `CommitDiffScreen`. Worse, that screen diffed the commit against **HEAD** (`commit-vs-wt`), not its own parent — so it never showed "what this commit changed."

## What changed

**Backend**
- New `diff_commit(oid)` op: a commit's diff against its **first parent**. Root commit → empty-tree diff (all-added); merge commit → first parent (git-show default). `diff_commits(from, to)` can't express the root case.
- Factored the delta→`FileDiff` conversion out of `diff_commits` into a shared `diff_to_file_diffs` helper.
- `CliBackend` stub + command + registration. Rust tests cover normal / root / merge commits.

**Frontend**
- Shared `CommitDiffPanel` (`features/diff/`) extracted from `CommitDiffScreen` — owns file selection + F7/⇧F7 hunk nav, keyed off a `paneIdPrefix` so two mount sites never collide. `CommitDiffScreen` refactored onto it.
- History renders the panel inline alongside the metadata + action row. **Layout toggle below (Fork default) / beside**, resizable + persisted (`pg-history-diff-h` / `pg-history-detail-w`, `pg-history-diff-layout`).
- New `commit-self` nav intent (commit vs first parent). History's `Enter` now opens that same diff full-screen instead of `commit-vs-HEAD`. `commit-vs-wt` is kept for the palette / context-menu / FileHistory callers that genuinely compare against the working tree.
- `PGResizeHandle` gains a vertical orientation for the below-layout panel.

Sets up #54 (multi-select commits), which renders a combined range diff through the same panel.

## Spec / plan
- `docs/superpowers/specs/2026-07-08-history-inline-commit-diff-design.md`
- `docs/superpowers/plans/2026-07-08-history-inline-commit-diff.md`

## Verification
- `pnpm tsc --noEmit` ✓ · `pnpm exec tsc -p e2e/tsconfig.json --noEmit` ✓
- `cargo test` ✓ (incl. new `diff_commit` normal/root/merge tests)
- `pnpm test` ✓ 325 passed (incl. new `History.diff.test.tsx`, updated keyboard test)
- `pnpm test:e2e:run --spec e2e/specs/history-diff.e2e.ts` ✓ 3 passing (incl. new inline-diff spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)