### PR TITLE
docs: always branch + work in a dedicated worktree to avoid collisions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,6 +334,7 @@ Do not create empty / merge commits. Do not amend published commits without aski
 ## Branching & merge workflow
 
 - **Never commit directly to `main`.** Branch first: `feat/...`, `fix/...`, `chore/...`, `docs/...`.
+- **Always work in a dedicated git worktree, never the primary checkout.** Multiple assistant sessions run against this repo at once; sharing one working directory collides (competing index/HEAD, a rebase-in-progress from another session, `localStorage`-clearing e2e runs). Create the branch and its worktree together off latest `main`: `git fetch origin && git worktree add -b <type>/<slug> .claude/worktrees/<slug> origin/main`. Do all edits, builds, and tests there; remove it with `git worktree remove` when the PR is merged. Read-only analysis still gets its own worktree (`--detach origin/main`) so it never touches another session's state.
 - Work as a series of small, focused commits on the feature branch (Conventional Commits throughout).
 - Keep the branch current by **rebasing onto `main`**, not merging `main` in — history stays linear, no merge commits on the branch.
 - Integrate via **squash and merge** — a `main` ruleset enforces squash-only (`allowed_merge_methods: ["squash"]`); merge-commit and rebase-merge are blocked. `main` gets one commit per PR, linear history.


### PR DESCRIPTION
Adds a workflow rule to `CLAUDE.md`: always create the branch **and** its own git worktree (never the primary checkout), because multiple assistant sessions run against this repo concurrently.

**Why:** hit a live case this session — the primary checkout was mid-`git rebase origin/main` from another session (detached HEAD, `.git/rebase-merge` present). Sharing one working directory collides on index/HEAD, in-progress rebases, and `localStorage`-clearing e2e runs. Per-worktree isolation avoids it.

The note lands in the `## Branching & merge workflow` section as the second bullet, with the exact `git worktree add -b … origin/main` incantation and cleanup guidance (including `--detach origin/main` for read-only analysis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)