### PR TITLE
fix: issue #47 post-release code-review follow-ups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,9 +137,10 @@ Four layers, each run independently:
     WebKitGTK + xvfb stack) — see the "Headless e2e in Docker" section above.
   - `pnpm.overrides["@wdio/native-utils"] = "2.5.0"` pins around a broken
     dep pin in `@wdio/tauri-service@1.2.0` — don't remove.
-  - Debug builds serve WebDriver on port 4445: close any `pnpm tauri dev`
-    instance before e2e runs or the runner may attach to it and clear its
-    `localStorage`.
+  - Only `e2e`-feature builds serve WebDriver on port 4445 (the plugin is now
+    gated behind the `e2e` cargo feature, so a plain `pnpm tauri dev` no longer
+    opens it). Still: don't leave a prior e2e binary running when starting a new
+    e2e run, or the runner may attach to it and clear its `localStorage`.
   - `e2e/wdio.conf.ts` sets `PLATYPUSGIT_NO_SINGLE_INSTANCE=1` before the app
     launches — without it, `tauri-plugin-single-instance` would forward a
     test binary's launch into any already-running platypusgit instance
@@ -303,7 +304,8 @@ lib/
 - Do NOT add `src/components/ui/`. The design system lives in `src/design/`.
 
 ### Permissions (Tauri 2)
-- All permissions in `src-tauri/capabilities/default.json`. Current set: `core:default`, `core:window:allow-minimize`, `core:window:allow-toggle-maximize`, `core:window:allow-close`, `core:window:allow-start-dragging`, `core:window:allow-set-title`, `core:webview:allow-create-webview-window`, `dialog:default`, `dialog:allow-open`, `os:default`. Capability scopes `windows: ["main", "merge"]` (merge resolver runs as a second window).
+- All permissions in `src-tauri/capabilities/default.json`. Current set: `core:default`, `core:window:allow-minimize`, `core:window:allow-toggle-maximize`, `core:window:allow-close`, `core:window:allow-start-dragging`, `core:window:allow-set-title`, `core:webview:allow-create-webview-window`, `dialog:default`, `dialog:allow-open`, `os:default`, `log:default`. Capability scopes `windows: ["main", "merge"]` (merge resolver runs as a second window).
+- **E2E-only permissions** live in the inline `e2e-focus` capability in `src-tauri/tauri.e2e.conf.json`, NOT in `default.json`: `core:window:allow-set-focus` + `wdio-webdriver:default`. That capability is loaded only via `--config src-tauri/tauri.e2e.conf.json`, and the `tauri-plugin-wdio-webdriver` crate is an optional dep behind the `e2e` cargo feature (`--features …,e2e` in `test:e2e:build`), so the WebDriver bridge is never compiled into or permitted in dev/production builds.
 - New plugin: `cargo add tauri-plugin-X`, `pnpm add @tauri-apps/plugin-X`, register with `.plugin(tauri_plugin_X::init())` in `lib.rs`, add plugin permissions to capability file.
 
 ### Path aliases

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "pnpm test:e2e:build && pnpm test:e2e:run",
-    "test:e2e:build": "pnpm tauri build --debug --no-bundle --features tauri/custom-protocol --config src-tauri/tauri.e2e.conf.json && mkdir -p e2e/.bin && cp src-tauri/target/debug/platypusgit e2e/.bin/platypusgit",
+    "test:e2e:build": "pnpm tauri build --debug --no-bundle --features tauri/custom-protocol,e2e --config src-tauri/tauri.e2e.conf.json && mkdir -p e2e/.bin && cp src-tauri/target/debug/platypusgit e2e/.bin/platypusgit",
     "test:e2e:run": "wdio run e2e/wdio.conf.ts",
     "test:e2e:docker": "e2e/e2e-docker.sh"
   },

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,8 +31,17 @@ uuid = { version = "1.23.1", features = ["v4", "serde"] }
 tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros", "sync", "process"] }
 tauri-plugin-log = "2.8.0"
 log = "0.4.29"
-tauri-plugin-wdio-webdriver = "1.2.0"
+# E2E-only WebDriver bridge. Optional + feature-gated so it is NOT linked into
+# dev/production binaries — it opens a WebDriver server (port 4445) with full
+# IPC, so it must never ship. Enabled solely by the `e2e` feature (see
+# test:e2e:build). Its `wdio-webdriver:default` permission lives in the e2e
+# capability in tauri.e2e.conf.json, not the shared capabilities/default.json.
+tauri-plugin-wdio-webdriver = { version = "1.2.0", optional = true }
 tauri-plugin-single-instance = "2.4.2"
+
+[features]
+# Compile + wire the WebDriver plugin. Set only by the e2e debug build.
+e2e = ["dep:tauri-plugin-wdio-webdriver"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -14,7 +14,6 @@
     "dialog:default",
     "dialog:allow-open",
     "os:default",
-    "log:default",
-    "wdio-webdriver:default"
+    "log:default"
   ]
 }

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -575,6 +575,22 @@ fn git_apply(repo_path: &Path, extra_args: &[&str], patch_text: &str) -> AppResu
     Ok(())
 }
 
+/// Resolve a revspec (branch, tag, short/full oid, `HEAD~2`, `tag^{}`, …) to
+/// its tree, mapping any resolution failure to `InvalidRef` so the UI gets a
+/// clean "unknown revision" error rather than a stringified internal one.
+fn resolve_tree<'a>(repo: &'a Repository, revspec: &str) -> AppResult<git2::Tree<'a>> {
+    repo.revparse_single(revspec)
+        .and_then(|obj| obj.peel_to_tree())
+        .map_err(|_| AppError::InvalidRef(revspec.to_string()))
+}
+
+/// Resolve a revspec to its commit, mapping failure to `InvalidRef`.
+fn resolve_commit<'a>(repo: &'a Repository, revspec: &str) -> AppResult<git2::Commit<'a>> {
+    repo.revparse_single(revspec)
+        .and_then(|obj| obj.peel_to_commit())
+        .map_err(|_| AppError::InvalidRef(revspec.to_string()))
+}
+
 /// Push the log walk's start commit onto `walk`. `None` starts at HEAD and
 /// returns `Ok(false)` ONLY when HEAD is unborn (a fresh repo with no commits;
 /// caller returns an empty log). A missing/corrupt HEAD surfaces as an error
@@ -602,10 +618,7 @@ fn push_log_start(
             Err(e) => Err(e.into()),
         },
         Some(spec) => {
-            let commit = repo
-                .revparse_single(spec)
-                .and_then(|obj| obj.peel_to_commit())
-                .map_err(|_| AppError::InvalidRef(spec.to_string()))?;
+            let commit = resolve_commit(repo, spec)?;
             walk.push(commit.id())?;
             Ok(true)
         }
@@ -1241,10 +1254,7 @@ impl GitBackend for Libgit2Backend {
 
     fn list_files_at_rev(&self, repo_id: &RepoId, revspec: &str) -> AppResult<Vec<FileStatus>> {
         self.with_repo(repo_id, |repo| {
-            let tree = repo
-                .revparse_single(revspec)
-                .map_err(|_| AppError::InvalidRef(revspec.to_string()))?
-                .peel_to_tree()?;
+            let tree = resolve_tree(repo, revspec)?;
 
             let mut out = Vec::new();
             // Walk the tree pre-order, accumulating full paths for blobs only.
@@ -1279,10 +1289,7 @@ impl GitBackend for Libgit2Backend {
         let rel = path.to_path_buf();
         let path_str = rel.to_string_lossy().into_owned();
         self.with_repo(repo_id, |repo| {
-            let tree = repo
-                .revparse_single(revspec)
-                .map_err(|_| AppError::InvalidRef(revspec.to_string()))?
-                .peel_to_tree()?;
+            let tree = resolve_tree(repo, revspec)?;
 
             let entry = tree
                 .get_path(&rel)

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -576,31 +576,29 @@ fn git_apply(repo_path: &Path, extra_args: &[&str], patch_text: &str) -> AppResu
 }
 
 /// Push the log walk's start commit onto `walk`. `None` starts at HEAD and
-/// returns `Ok(false)` when HEAD is unborn (caller returns an empty log).
-/// `Some(spec)` starts at any revspec (branch, tag, short/full oid) peeled to
-/// a commit — `InvalidRef` when it can't be resolved. Returns `Ok(true)` when
-/// a start point was pushed.
+/// returns `Ok(false)` ONLY when HEAD is unborn (a fresh repo with no commits;
+/// caller returns an empty log). A missing/corrupt HEAD surfaces as an error
+/// instead — masking it as an empty log hides a broken repo. `Some(spec)`
+/// starts at any revspec (branch, tag, short/full oid) peeled to a commit —
+/// `InvalidRef` when it can't be resolved. Returns `Ok(true)` when a start
+/// point was pushed.
 fn push_log_start(
     repo: &Repository,
     walk: &mut git2::Revwalk,
     refspec: Option<&str>,
 ) -> AppResult<bool> {
     match refspec {
-        // Unborn HEAD (no commits yet) → nothing to walk. Detect via head()
-        // up front: push_head() surfaces it as a generic "ref not found".
         None => match repo.head() {
             Ok(_) => {
                 walk.push_head()?;
                 Ok(true)
             }
-            Err(e)
-                if matches!(
-                    e.code(),
-                    git2::ErrorCode::UnbornBranch | git2::ErrorCode::NotFound
-                ) =>
-            {
-                Ok(false)
-            }
+            // Fresh repo, HEAD points at a branch with no commits yet → nothing
+            // to walk. This is the only "empty log, not an error" case.
+            Err(e) if e.code() == git2::ErrorCode::UnbornBranch => Ok(false),
+            // NotFound (or anything else) means HEAD itself is missing/corrupt,
+            // not an unborn branch — surface it rather than reporting an empty
+            // history for a broken repo.
             Err(e) => Err(e.into()),
         },
         Some(spec) => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,8 +67,10 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_os::init());
 
-    // WebDriver server for E2E tests. Debug builds only.
-    #[cfg(debug_assertions)]
+    // WebDriver server for E2E tests. Compiled + wired ONLY under the `e2e`
+    // cargo feature (test:e2e:build) — never linked into dev/production
+    // binaries, since it opens a WebDriver server (port 4445) with full IPC.
+    #[cfg(feature = "e2e")]
     let builder = builder.plugin(tauri_plugin_wdio_webdriver::init());
 
     builder

--- a/src-tauri/tauri.e2e.conf.json
+++ b/src-tauri/tauri.e2e.conf.json
@@ -6,9 +6,9 @@
         "default",
         {
           "identifier": "e2e-focus",
-          "description": "E2E-only: let the wdio harness force window focus (ensureMacAppFocus in e2e/support/app.ts). The unbundled debug binary doesn't reliably win foreground focus at launch; without focus WKWebView reports the page hidden and isDisplayed() lies.",
+          "description": "E2E-only: enable the WebDriver bridge (tauri-plugin-wdio-webdriver, gated behind the `e2e` cargo feature) and let the wdio harness force window focus (ensureMacAppFocus in e2e/support/app.ts). The unbundled debug binary doesn't reliably win foreground focus at launch; without focus WKWebView reports the page hidden and isDisplayed() lies. This capability is ONLY loaded via tauri.e2e.conf.json, so wdio-webdriver:default never reaches dev/production builds.",
           "windows": ["main", "merge"],
-          "permissions": ["core:window:allow-set-focus"]
+          "permissions": ["core:window:allow-set-focus", "wdio-webdriver:default"]
         }
       ]
     }

--- a/src-tauri/tests/broken_head.rs
+++ b/src-tauri/tests/broken_head.rs
@@ -1,0 +1,37 @@
+mod support;
+
+use platypusgit_lib::git::GitBackend;
+use support::TempRepo;
+
+/// A truly-unborn repo (fresh `git init`, no commits) reports an EMPTY log,
+/// not an error — HEAD points at a branch that doesn't exist yet.
+#[test]
+fn unborn_head_yields_empty_log() {
+    let tr = TempRepo::fresh();
+    let (backend, handle) = tr.open_with_backend();
+
+    let out = backend.log(&handle.id, None, 100).unwrap();
+
+    assert!(out.is_empty(), "unborn repo should have an empty log");
+}
+
+/// A missing/corrupt HEAD must NOT be masked as an empty log — it's a broken
+/// repo and the History screen should surface the error. Regression guard for
+/// push_log_start swallowing NotFound alongside UnbornBranch.
+#[test]
+fn corrupt_head_errors_instead_of_empty_log() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    // Open (and cache) the repo BEFORE corrupting — open validates HEAD.
+    let (backend, handle) = tr.open_with_backend();
+
+    // Remove HEAD so `repo.head()` resolves to NotFound rather than the
+    // UnbornBranch code a fresh repo would give.
+    let head_path = tr.path().join(".git").join("HEAD");
+    std::fs::remove_file(&head_path).expect("remove .git/HEAD");
+
+    let err = backend.log(&handle.id, None, 100);
+    assert!(
+        err.is_err(),
+        "log of a repo with a missing HEAD must error, got {err:?}"
+    );
+}

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -345,7 +345,6 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
     {
       icon: "check",
       label: "Check out this commit",
-      shortcut: "⌘⇧C",
       onClick: () => {
         if (!commit?.sha) return;
         if (window.confirm(`Check out ${sha.slice(0, 7)} in detached HEAD?`))
@@ -379,7 +378,6 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
     {
       icon: "rebase",
       label: "Cherry-pick onto current",
-      shortcut: "⌘Y",
       onClick: () => {
         if (commit?.sha) useRepoStore.getState().cherryPick(commit.sha);
       },
@@ -481,7 +479,6 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
     {
       icon: "copy",
       label: "Copy SHA",
-      shortcut: "⌘C",
       onClick: () => {
         navigator.clipboard?.writeText(sha);
         pgFlash(`copied ${sha.slice(0, 7)}`);
@@ -588,7 +585,6 @@ export function branchMenuItems(
     {
       icon: "check",
       label: "Check out",
-      shortcut: "⌘⇧O",
       disabled: isCurrent,
       onClick: () => useRepoStore.getState().checkoutBranch(name),
     },
@@ -645,7 +641,6 @@ export function branchMenuItems(
     {
       icon: "edit",
       label: "Rename…",
-      shortcut: "F2",
       onClick: () => {
         const to = window.prompt("New name", name);
         if (to && to !== name) useRepoStore.getState().renameBranch(name, to);
@@ -663,7 +658,6 @@ export function branchMenuItems(
     {
       icon: "trash",
       label: "Delete",
-      shortcut: "⌫",
       danger: true,
       disabled: isCurrent,
       onClick: () => {
@@ -890,7 +884,6 @@ export function fileMenuItems(
       ? {
           icon: "minus",
           label: "Unstage",
-          shortcut: "⌘⇧U",
           onClick: () => {
             if (path) useRepoStore.getState().unstage([path]);
           },
@@ -898,7 +891,6 @@ export function fileMenuItems(
       : {
           icon: "plus",
           label: "Stage",
-          shortcut: "⌘⇧S",
           onClick: () => {
             if (path) useRepoStore.getState().stage([path]);
           },
@@ -916,7 +908,6 @@ export function fileMenuItems(
     {
       icon: "diff",
       label: "View diff",
-      shortcut: "⏎",
       onClick: () => {
         if (!path) return;
         useNavStore.getState().setIntent({ kind: "diff-file", path });
@@ -941,7 +932,6 @@ export function fileMenuItems(
     {
       icon: "edit",
       label: "Open in editor",
-      shortcut: "⌘O",
       onClick: () => {
         if (!path) return;
         useRepoStore.getState().openInEditor(path);

--- a/src/features/keymap/PGPane.tsx
+++ b/src/features/keymap/PGPane.tsx
@@ -44,9 +44,23 @@ export function PGPane({
   React.useEffect(() => {
     const el = ref.current;
     if (!focused || !el) return;
-    if (el.contains(document.activeElement)) return;
-    const target = el.querySelector<HTMLElement>("[data-pg-focus-target]") ?? el;
-    target.focus({ preventScroll: false });
+    if (!el.contains(document.activeElement)) {
+      const target = el.querySelector<HTMLElement>("[data-pg-focus-target]") ?? el;
+      target.focus({ preventScroll: false });
+    }
+    // A `[data-pg-focus-target]` may mount AFTER the pane is already focused
+    // (e.g. History's detail once a commit is selected). With no target at
+    // focus time the wrapper took focus; delegate to the target once it
+    // appears — but only while focus still sits on the wrapper, so we never
+    // yank it off a control the user tabbed to.
+    const obs = new MutationObserver(() => {
+      const node = ref.current;
+      if (!node || document.activeElement !== node) return;
+      const target = node.querySelector<HTMLElement>("[data-pg-focus-target]");
+      if (target) target.focus({ preventScroll: false });
+    });
+    obs.observe(el, { childList: true, subtree: true });
+    return () => obs.disconnect();
   }, [focused]);
 
   return (

--- a/src/features/keymap/usePaneList.ts
+++ b/src/features/keymap/usePaneList.ts
@@ -10,8 +10,10 @@
 import React from "react";
 import { useFocusStore } from "./useFocusStore";
 import { useKeymapStore } from "./useKeymapStore";
+import { useOverlayStore } from "./useOverlayStore";
 import { useSpeedSearchStore } from "./useSpeedSearchStore";
 import { useAction } from "./useAction";
+import { usePaletteStore } from "@/features/palette/usePaletteStore";
 
 export function usePaneList(opts: {
   paneId: string;
@@ -103,22 +105,50 @@ export function usePaneList(opts: {
     if (!hasSearch) return;
     return useKeymapStore.getState().registerSpeedSearch(paneId);
   }, [paneId, hasSearch]);
+
+  // Read searchText through a ref so the memo below can rebuild only when the
+  // list changes — not on the parent re-render every keystroke triggers (which
+  // recreates the inline `searchText` closure).
+  const searchTextRef = React.useRef(opts.searchText);
+  searchTextRef.current = opts.searchText;
+  // Precompute the lowercased searchable text once per list, so a speed-search
+  // session narrowing the query doesn't re-lowercase the whole list on every
+  // keystroke. Keyed on `count`: a same-length content swap mid-search is rare
+  // (you're typing, not mutating the repo) and self-heals on the next change.
+  const lowered = React.useMemo(() => {
+    const fn = searchTextRef.current;
+    if (!fn) return [];
+    const arr = new Array<string>(count);
+    for (let i = 0; i < count; i++) arr[i] = fn(i).toLowerCase();
+    return arr;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasSearch, count]);
   React.useEffect(() => {
     if (!hasSearch || !query) return;
     const q = query.toLowerCase();
-    for (let i = 0; i < count; i++) {
-      if (opts.searchText!(i).toLowerCase().includes(q)) {
+    for (let i = 0; i < lowered.length; i++) {
+      if (lowered[i].includes(q)) {
         opts.onSelect(i);
         return;
       }
     }
     // No match: leave the selection where it is (JetBrains behavior).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query]);
+  }, [query, lowered]);
   useAction(
     "app.closeOverlay",
     () => {
       if (!isFocused || !query) return false;
+      // An overlay stacked above the pane (command palette / cheat sheet) owns
+      // Escape first — closing it takes priority over clearing a lingering
+      // speed-search query. Declining here lets the overlay's own closeOverlay
+      // handler run, so Escape doesn't need a second press.
+      if (
+        usePaletteStore.getState().open ||
+        useOverlayStore.getState().cheatSheetOpen
+      ) {
+        return false;
+      }
       useSpeedSearchStore.getState().clear(paneId);
       return true;
     },

--- a/src/features/palette/CommandPalette.tsx
+++ b/src/features/palette/CommandPalette.tsx
@@ -228,6 +228,15 @@ export function CommandPalette() {
     // Keys already routed by the global dispatcher (e.g. Escape closing the
     // cheat-sheet stacked above the palette) must not double-fire here.
     if (e.defaultPrevented) return;
+    // An Enter that confirms an IME composition (CJK etc.) must not submit the
+    // step or activate a row — the composition is being committed, not the
+    // palette. keyCode 229 is the legacy signal for "still composing".
+    if (
+      e.key === "Enter" &&
+      (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229)
+    ) {
+      return;
+    }
     if (e.key === "Tab" && e.ctrlKey && step.kind === "root") {
       e.preventDefault();
       const i = CHIPS.findIndex((c) => c.kind === activeChip);

--- a/src/features/palette/CommandPalette.tsx
+++ b/src/features/palette/CommandPalette.tsx
@@ -138,8 +138,14 @@ export function CommandPalette() {
 
   // Filter + score + (root only) group + cap, then flatten for keyboard nav.
   const { flat, groups } = React.useMemo(() => {
+    // On the root step a non-"all" chip renders only its own type. Skip the
+    // other types BEFORE fuzzy-matching so a selected chip doesn't pay to score
+    // the entire candidate set (up to ~500 rows) each keystroke.
+    const chipFilter =
+      step.kind === "root" && activeChip !== "all" ? activeChip : null;
     const byType: Record<ResultType, ScoredRow[]> = { command: [], branch: [], file: [], commit: [] };
     for (const item of source) {
+      if (chipFilter && item.type !== chipFilter) continue;
       const mSearch = fuzzyMatch(query, item.search);
       const mLabel = item.search !== item.label ? fuzzyMatch(query, item.label) : mSearch;
       const best = mSearch.score >= mLabel.score ? mSearch : mLabel;
@@ -157,7 +163,7 @@ export function CommandPalette() {
       flatOut.push(...sorted);
     }
     return { flat: flatOut, groups: groupsOut };
-  }, [source, query]);
+  }, [source, query, step.kind, activeChip]);
 
   React.useEffect(() => {
     if (!open) return;

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -153,6 +153,13 @@ interface RepoStoreState {
    */
   setLogRef: (refspec: string | null) => Promise<void>;
   refreshAll: () => Promise<void>;
+  /**
+   * Lightweight refresh for index-only mutations (stage/unstage/discard and
+   * the hunk ops): re-fetches just `status` + `repoState`, skipping the full
+   * branch/tag/stash/remote enumeration and the ≤500-commit log walk that
+   * `refreshAll` does but that these ops can't change.
+   */
+  refreshStatus: () => Promise<void>;
   refreshAllFiles: () => Promise<void>;
   /**
    * List every file in the tree at `revspec` (commit/branch/tag/revspec).
@@ -389,6 +396,21 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     }
   },
 
+  async refreshStatus() {
+    const repo = get().current;
+    if (!repo) return;
+    set({ error: null });
+    try {
+      const [status, repoState] = await Promise.all([
+        getStatus(repo.id),
+        repoStateFn(repo.id),
+      ]);
+      set({ status, repoState });
+    } catch (e) {
+      set({ error: toAppError(e) });
+    }
+  },
+
   clearError() {
     set({ error: null });
   },
@@ -450,7 +472,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     try {
       await stagePaths(repo.id, paths);
-      await get().refreshAll();
+      await get().refreshStatus();
     } catch (e) {
       set({ error: toAppError(e) });
     }
@@ -461,7 +483,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     try {
       await unstagePaths(repo.id, paths);
-      await get().refreshAll();
+      await get().refreshStatus();
     } catch (e) {
       set({ error: toAppError(e) });
     }
@@ -472,7 +494,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     try {
       await discardPaths(repo.id, paths);
-      await get().refreshAll();
+      await get().refreshStatus();
     } catch (e) {
       set({ error: toAppError(e) });
     }
@@ -485,7 +507,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     try {
       await stageHunk(repo.id, path, hunkIndex, useSettingsStore.getState().diffContextLines);
-      await get().refreshAll();
+      await get().refreshStatus();
     } catch (e) {
       set({ error: toAppError(e) });
     }
@@ -496,7 +518,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     try {
       await unstageHunk(repo.id, path, hunkIndex, useSettingsStore.getState().diffContextLines);
-      await get().refreshAll();
+      await get().refreshStatus();
     } catch (e) {
       set({ error: toAppError(e) });
     }
@@ -507,7 +529,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     try {
       await discardHunk(repo.id, path, hunkIndex, useSettingsStore.getState().diffContextLines);
-      await get().refreshAll();
+      await get().refreshStatus();
     } catch (e) {
       set({ error: toAppError(e) });
     }

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -230,9 +230,12 @@ export function RepoBrowserScreen() {
   );
 
   // Map selected tree keys to worktree statuses for multi-file operations.
-  // Folder keys simply don't resolve to a status entry, so they're inert.
-  // In all-files mode unmodified files only exist in allFiles, not status —
-  // they carry no stage/unstage actions but still count and copy.
+  // A selected FOLDER key resolves to no file entry, so expand it to every
+  // visible descendant file (against the tree's source set, `filteredStatus`)
+  // — otherwise a selected folder is silently dropped from the count and from
+  // Stage/Discard, under-counting a destructive op. In all-files mode
+  // unmodified files only exist in allFiles, not status — they carry no
+  // stage/unstage actions but still count and copy.
   const splitSelection = React.useCallback(
     (
       keys: string[],
@@ -240,19 +243,32 @@ export function RepoBrowserScreen() {
       const stagedPaths: string[] = [];
       const unstagedPaths: string[] = [];
       const paths: string[] = [];
+      const seen = new Set<string>();
+      const add = (st: FileStatus) => {
+        if (seen.has(st.path)) return;
+        seen.add(st.path);
+        paths.push(st.path);
+        if (isStaged(st)) stagedPaths.push(st.path);
+        if (isUnstaged(st)) unstagedPaths.push(st.path);
+      };
       for (const key of keys) {
         const path = key.replace(/^\//, "");
         const st =
           status.find((s) => s.path === path) ??
           allFiles.find((s) => s.path === path);
-        if (!st) continue;
-        paths.push(path);
-        if (isStaged(st)) stagedPaths.push(path);
-        if (isUnstaged(st)) unstagedPaths.push(path);
+        if (st) {
+          add(st);
+          continue;
+        }
+        // Folder key: pull in every visible file beneath it.
+        const prefix = path + "/";
+        for (const child of filteredStatus) {
+          if (child.path.startsWith(prefix)) add(child);
+        }
       }
       return { stagedPaths, unstagedPaths, paths };
     },
-    [status, allFiles],
+    [status, allFiles, filteredStatus],
   );
 
   const fileCtx = useContextMenu<{ key: string; node: PGFileTreeNode }>(


### PR DESCRIPTION
Addresses #47 — the post-release code-review follow-up batch.

All **Correctness (6/6)**, **Efficiency (3/3)** and **Hardening (1/1)** items done, plus one **Cleanup** item. Four cleanup items deferred (see below). One commit per item.

## Correctness
- [x] **RepoBrowser multi-select drops folder rows** — `splitSelection` now expands a selected folder key to every visible descendant file (deduped against `filteredStatus`), so the count and Stage/Discard cover folder children.
- [x] **Context-menu chord glyphs advertise dead shortcuts** — removed every hardcoded glyph not backed by a real bound action (⌘⇧S/⌘⇧U all-files misrepresentation, plus ⌘⇧C, ⌘Y, ⌘C, ⌘⇧O, F2, ⌫, ⌘O, ⏎). Pull/Push/Fetch keep their live `chordFor()` chips.
- [x] **Palette Enter IME guard** — `onKeyDown` bails on Enter while composing (`isComposing` / keyCode 229).
- [x] **Escape swallowed by pane speed-search** — the pane's `app.closeOverlay` handler now declines when a palette/cheat-sheet overlay is open, so the overlay closes on the first Escape.
- [x] **PGPane focus delegation stale for late-mounting targets** — a `MutationObserver` delegates focus once a `[data-pg-focus-target]` mounts after the pane is already focused (guarded so it never steals focus off a control the user tabbed to).
- [x] **`push_log_start` masks a broken HEAD as an empty log** — only `UnbornBranch` yields an empty log; `NotFound`/other errors propagate. Added `TempRepo`-based tests (missing-HEAD errors, unborn stays empty).

## Efficiency
- [x] **`refreshAll` over-fetches on index-only mutations** — added `refreshStatus()` (status + repoState only); stage/unstage/discard + the three hunk ops use it instead of the full 500-commit-walk refresh.
- [x] **Palette matches the whole candidate set ignoring the active chip** — the scoring loop now skips non-active-chip items before fuzzy-matching.
- [x] **Speed-search rescans + lowercases the whole list per keystroke** — precomputed a memoized lowercased array (searchText via ref, keyed on list length) reused across keystrokes.

## Hardening
- [x] **`tauri-plugin-wdio-webdriver` links into production binaries** — now an optional dep behind an `e2e` cargo feature; plugin init gated on `#[cfg(feature = "e2e")]`; `wdio-webdriver:default` moved out of the shared `capabilities/default.json` into the e2e-only capability in `tauri.e2e.conf.json`; `test:e2e:build` passes `--features tauri/custom-protocol,e2e`. CLAUDE.md permission list updated (added `log:default`, documented the e2e-only split).

## Cleanup
- [x] **Duplicated revspec→tree/commit resolution** — extracted shared `resolve_tree`/`resolve_commit` in `libgit2.rs`.
- [ ] **`splitByKeys` (CommitPanel) vs `splitSelection` (RepoBrowser)** — deferred: the two operate on different key spaces (`side:path` vs tree path keys), so a safe unification is a larger change than this batch warranted.
- [ ] **CommandPalette rebuilds branch/commit rows inline** vs `commands.ts` — deferred.
- [ ] **`lastRebaseSummary` two-sources-of-truth** — deferred: proper fix is a backend change (retain last-completed summary until acknowledged) needing the full add-a-git-op path + tests.
- [ ] **`useHunkNav` calls hooks in a loop** — deferred: fixing the rules-of-hooks pattern correctly means restructuring registration (can't vary hook count); currently safe (sole caller passes a constant-length literal).

## Verification
- `cargo test --manifest-path src-tauri/Cargo.toml` — 25 binaries, all green, incl. new `broken_head` tests.
- `pnpm tsc --noEmit` — clean. `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — clean.
- `pnpm test` — 46 files, 343 tests pass.
- `pnpm test:e2e:build` — e2e binary builds with the feature-gated plugin + moved capability; `smoke.e2e.ts` (2) drives it over real WebDriver.
- `keyboard-shortcuts.e2e.ts` (4, incl. vertical pane focus) passes against the snapshot — validates the PGPane + multi-select changes, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
