### PR TITLE
feat(ux): issue #61 Tier 0 quick wins

### DIFF
--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -442,6 +442,41 @@ fn patch_text_for_hunk(diff: &git2::Diff, delta_index: usize, hunk_index: usize)
     Ok(out)
 }
 
+/// Per-file added/removed line counts for the working tree vs HEAD, index
+/// included, keyed by path. One diff pass + cheap `line_stats()` per delta (no
+/// full patch print). Untracked files count their whole content as additions.
+/// Keyed by both new and old paths so renames/deletions resolve either way.
+fn worktree_line_stats(repo: &Repository) -> AppResult<HashMap<String, (u32, u32)>> {
+    let mut opts = DiffOptions::new();
+    opts.include_untracked(true)
+        .recurse_untracked_dirs(true)
+        .show_untracked_content(true)
+        .include_typechange(true);
+    let head_tree = match repo.head() {
+        Ok(h) => Some(h.peel_to_tree()?),
+        Err(e) if e.code() == git2::ErrorCode::UnbornBranch => None,
+        Err(e) => return Err(e.into()),
+    };
+    let diff = repo.diff_tree_to_workdir_with_index(head_tree.as_ref(), Some(&mut opts))?;
+    let mut map: HashMap<String, (u32, u32)> = HashMap::new();
+    for idx in 0..diff.deltas().len() {
+        let Some(patch) = git2::Patch::from_diff(&diff, idx)? else {
+            continue;
+        };
+        let (_ctx, add, del) = patch.line_stats()?;
+        let counts = (add as u32, del as u32);
+        if let Some(delta) = diff.get_delta(idx) {
+            if let Some(p) = delta.new_file().path() {
+                map.insert(p.to_string_lossy().to_string(), counts);
+            }
+            if let Some(p) = delta.old_file().path() {
+                map.entry(p.to_string_lossy().to_string()).or_insert(counts);
+            }
+        }
+    }
+    Ok(map)
+}
+
 /// Convert a computed `git2::Diff` into per-file `FileDiff`s (path, rename
 /// origin, binary flag, add/del counts, hunks). Renames must already be
 /// resolved by the caller (`find_similar`). Shared by every tree-to-tree diff
@@ -792,6 +827,9 @@ impl GitBackend for Libgit2Backend {
 
     fn status(&self, repo_id: &RepoId) -> AppResult<Vec<FileStatus>> {
         self.with_repo(repo_id, |repo| {
+            // Per-file line stats (HEAD → working tree, index-aware) in one diff
+            // pass. Degrades to empty (→ 0/0 counts) rather than failing status.
+            let stats = worktree_line_stats(repo).unwrap_or_default();
             let mut opts = StatusOptions::new();
             opts.include_untracked(true)
                 .recurse_untracked_dirs(true)
@@ -801,10 +839,13 @@ impl GitBackend for Libgit2Backend {
             for entry in statuses.iter() {
                 let path = entry.path().unwrap_or("").to_string();
                 let s = entry.status();
+                let (additions, deletions) = stats.get(&path).copied().unwrap_or((0, 0));
                 out.push(FileStatus {
                     path,
                     worktree: map_status_flag(s, StatusSide::Worktree),
                     index: map_status_flag(s, StatusSide::Index),
+                    additions,
+                    deletions,
                 });
             }
             Ok(out)
@@ -830,6 +871,10 @@ impl GitBackend for Libgit2Backend {
                     path,
                     worktree: map_status_flag(s, StatusSide::Worktree),
                     index: map_status_flag(s, StatusSide::Index),
+                    // Full-file listing (incl. unmodified) doesn't compute per-file
+                    // line stats — the tree shows status marks, not counts.
+                    additions: 0,
+                    deletions: 0,
                 });
             }
             Ok(out)
@@ -1271,6 +1316,8 @@ impl GitBackend for Libgit2Backend {
                             path,
                             worktree: StatusFlag::Unmodified,
                             index: StatusFlag::Unmodified,
+                            additions: 0,
+                            deletions: 0,
                         });
                     }
                 }

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -33,6 +33,11 @@ pub struct FileStatus {
     pub path: String,
     pub worktree: StatusFlag,
     pub index: StatusFlag,
+    /// Lines added in this file vs HEAD (working tree + index combined).
+    /// 0 for unmodified/binary files and in listings that don't compute stats.
+    pub additions: u32,
+    /// Lines removed in this file vs HEAD (working tree + index combined).
+    pub deletions: u32,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src-tauri/tests/status_stats.rs
+++ b/src-tauri/tests/status_stats.rs
@@ -1,0 +1,62 @@
+mod support;
+
+use std::path::PathBuf;
+
+use platypusgit_lib::git::GitBackend;
+
+use support::{fs::write_file, TempRepo};
+
+/// A modified tracked file reports its added/removed line counts vs HEAD.
+#[test]
+fn status_reports_per_file_line_counts() {
+    let tr = TempRepo::with_initial_commit("line one\nline two\nline three\n");
+    // Drop "line two", append two new lines: +2 / -1 (line three stays context).
+    write_file(tr.path(), "README.md", "line one\nline three\nnew a\nnew b\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let status = backend.status(&handle.id).unwrap();
+    let readme = status.iter().find(|f| f.path == "README.md").unwrap();
+    assert_eq!(readme.additions, 2, "two appended lines");
+    assert_eq!(readme.deletions, 1, "line two removed");
+}
+
+/// An untracked file counts its whole content as additions.
+#[test]
+fn status_counts_untracked_file_as_additions() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "new.txt", "a\nb\nc\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let status = backend.status(&handle.id).unwrap();
+    let entry = status.iter().find(|f| f.path == "new.txt").unwrap();
+    assert_eq!(entry.additions, 3);
+    assert_eq!(entry.deletions, 0);
+}
+
+/// Staged changes still count (the diff is HEAD → working tree, index-aware).
+#[test]
+fn status_counts_staged_changes() {
+    let tr = TempRepo::with_initial_commit("a\n");
+    write_file(tr.path(), "README.md", "a\nb\n");
+    let (backend, handle) = tr.open_with_backend();
+    backend
+        .stage(&handle.id, &[PathBuf::from("README.md")])
+        .expect("stage");
+
+    let status = backend.status(&handle.id).unwrap();
+    let readme = status.iter().find(|f| f.path == "README.md").unwrap();
+    assert_eq!(readme.additions, 1);
+    assert_eq!(readme.deletions, 0);
+}
+
+/// An unmodified working tree reports zero counts (and typically no entries).
+#[test]
+fn status_unmodified_has_zero_counts() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let status = backend.status(&handle.id).unwrap();
+    for f in &status {
+        assert_eq!(f.additions, 0);
+        assert_eq!(f.deletions, 0);
+    }
+}

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -1,4 +1,3 @@
-import { open } from "@tauri-apps/plugin-dialog";
 import { listen } from "@tauri-apps/api/event";
 import React from "react";
 import {
@@ -29,7 +28,7 @@ import { BlameScreen } from "@/screens/Blame";
 import { SettingsScreen } from "@/screens/Settings";
 
 import { useRepoStore } from "@/features/repo/useRepoStore";
-import { headUpstream } from "@/features/repo/ops";
+import { headUpstream, openRepoDialog } from "@/features/repo/ops";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useCliLaunch } from "@/features/cli/useCliLaunch";
 import {
@@ -377,7 +376,6 @@ function AppTitlebar({ onOpenSettings }: { onOpenSettings: () => void }) {
   const activity = useRepoStore((s) => s.activity);
   const refresh = useRepoStore((s) => s.refreshAll);
   const close = useRepoStore((s) => s.closeRepo);
-  const openStore = useRepoStore((s) => s.openRepo);
   const store = useRepoStore();
   const defaultPullMode = useSettingsStore((s) => s.defaultPullMode);
 
@@ -394,13 +392,8 @@ function AppTitlebar({ onOpenSettings }: { onOpenSettings: () => void }) {
     null,
   );
 
-  const onOpen = async () => {
-    const selected = await open({
-      directory: true,
-      multiple: false,
-      title: "Open repository",
-    });
-    if (typeof selected === "string") await openStore(selected);
+  const onOpen = () => {
+    void openRepoDialog();
   };
 
   // Same ops the keymap default runners and palette use (features/repo/ops.ts).

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -68,6 +68,11 @@ type ScreenId =
   | "blame"
   | "settings";
 
+// Deep views are reachable ONLY via a nav intent (no activity-bar entry). They
+// carry no valid payload after a reload and have no "you are here" anchor, so
+// they must not be restored from localStorage — see the reload-guard below.
+const DEEP_VIEWS = new Set<ScreenId>(["commitDiff", "fileHistory", "blame"]);
+
 // Maps each activity-bar item id to the navigation action whose chord it shows.
 const ACTIVITY_ACTION: Record<string, ActionId> = {
   repo: "nav.files",
@@ -103,13 +108,21 @@ export function AppShell() {
   const clearError = useRepoStore((s) => s.clearError);
 
   const [screen, setScreen] = React.useState<ScreenId>(() => {
-    const saved = localStorage.getItem("pg-screen");
-    return (saved as ScreenId) || "repo";
+    const saved = localStorage.getItem("pg-screen") as ScreenId | null;
+    // Reload-guard: a persisted deep view has no intent/payload on load, so it
+    // would render a dead empty state. Fall back to Files.
+    if (!saved || DEEP_VIEWS.has(saved)) return "repo";
+    return saved;
   });
 
   React.useEffect(() => {
     localStorage.setItem("pg-screen", screen);
   }, [screen]);
+
+  // Latest screen, readable synchronously from the intent effect below without
+  // making it a dependency (so origin capture sees the pre-switch screen).
+  const screenRef = React.useRef(screen);
+  screenRef.current = screen;
 
   const autoFetchEnabled = useSettingsStore((s) => s.autoFetchEnabled);
   const autoFetchMinutes = useSettingsStore((s) => s.autoFetchMinutes);
@@ -160,6 +173,15 @@ export function AppShell() {
   const clearIntent = useNavStore((s) => s.clearIntent);
   React.useEffect(() => {
     if (!intent) return;
+    // Enter a deep view, recording the originating screen for its Back button.
+    // Don't overwrite when coming from another deep view — Back then returns
+    // to the last "real" screen instead of chaining deep views.
+    const enterDeep = (target: ScreenId) => {
+      if (!DEEP_VIEWS.has(screenRef.current)) {
+        useNavStore.getState().setDeepOrigin(screenRef.current);
+      }
+      setScreen(target);
+    };
     switch (intent.kind) {
       case "diff-file":
         setScreen("diff");
@@ -167,19 +189,19 @@ export function AppShell() {
       case "commit-self":
       case "commit-vs-wt":
       case "commit-vs-commit":
-        setScreen("commitDiff");
+        enterDeep("commitDiff");
         break;
       case "file-history":
-        setScreen("fileHistory");
+        enterDeep("fileHistory");
         break;
       case "blame":
-        setScreen("blame");
+        enterDeep("blame");
         break;
       case "rebase-plan":
         setScreen("rebase");
         break;
       case "stash-diff":
-        setScreen("commitDiff");
+        enterDeep("commitDiff");
         break;
       case "switch-screen":
         setScreen(intent.screen as ScreenId);

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -100,7 +100,7 @@ function ContextMenuItemView({
         cursor: disabled ? "default" : "pointer",
         background:
           hover && !disabled
-            ? "oklch(0.72 0.15 235 / 0.18)"
+            ? "oklch(from var(--accent) l c h / 0.18)"
             : "transparent",
         color,
       }}

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -467,7 +467,7 @@ export function PGDiffLine({ kind = "ctx", lnL, lnR, text }: DiffLineData) {
     ctx: "transparent",
     add: "var(--git-added-bg)",
     rem: "var(--git-removed-bg)",
-    hunk: "oklch(0.72 0.15 235 / 0.1)",
+    hunk: "oklch(from var(--accent) l c h / 0.1)",
     info: "var(--bg-2)",
     empty: "var(--bg-2)",
   };
@@ -603,7 +603,7 @@ function PGDiffChunk({ chunk }: { chunk: DiffChunk }) {
   const bg: Partial<Record<DiffLineKind, string>> = {
     add: "var(--git-added-bg)",
     rem: "var(--git-removed-bg)",
-    hunk: "oklch(0.72 0.15 235 / 0.1)",
+    hunk: "oklch(from var(--accent) l c h / 0.1)",
     info: "var(--bg-2)",
   };
   const borderColor: Partial<Record<DiffLineKind, string>> = {

--- a/src/design/icons.tsx
+++ b/src/design/icons.tsx
@@ -199,6 +199,8 @@ export interface PGIconProps {
   className?: string;
 }
 
+const warnedIcons = new Set<string>();
+
 export function PGIcon({
   name,
   size = 14,
@@ -208,10 +210,28 @@ export function PGIcon({
 }: PGIconProps) {
   const content = ICONS[name as IconName];
   if (!content) {
+    // Visible placeholder (dashed square) instead of a silent blank gap, so a
+    // typo'd or missing icon name is obvious. Warn once per name in dev.
+    if (import.meta.env?.DEV && !warnedIcons.has(name)) {
+      warnedIcons.add(name);
+      console.warn(`[PGIcon] unknown icon name: "${name}" — showing fallback glyph`);
+    }
     return (
-      <span
-        style={{ width: size, height: size, display: "inline-block", ...style }}
-      />
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={className}
+        style={{ flexShrink: 0, opacity: 0.6, ...style }}
+        aria-label={`unknown icon: ${name}`}
+      >
+        <rect x="2.5" y="2.5" width="11" height="11" rx="2" strokeDasharray="2 2" />
+      </svg>
     );
   }
   return (

--- a/src/design/icons.tsx
+++ b/src/design/icons.tsx
@@ -12,7 +12,7 @@ export type IconName =
   | "download" | "upload" | "link" | "lock"
   | "play" | "pause" | "star" | "copy" | "external"
   | "edit" | "trash" | "conflict" | "squash" | "drag" | "bell"
-  | "diff" | "undo" | "fix";
+  | "diff" | "undo" | "fix" | "expandAll" | "collapseAll";
 
 const ICONS: Record<IconName, ReactNode> = {
   repo: <>
@@ -185,6 +185,10 @@ const ICONS: Record<IconName, ReactNode> = {
   </>,
   undo: <path d="M6 5L3 8l3 3M3 8h7a3 3 0 0 1 0 6H8" />,
   fix: <path d="M10 2l4 4-2 2-4-4 2-2zM8 4L2 10v4h4l6-6" />,
+  // Chevrons pointing away from center = unfold (expand all).
+  expandAll: <path d="M4.5 6L8 2.5 11.5 6M4.5 10L8 13.5 11.5 10" />,
+  // Chevrons pointing toward center = fold (collapse all).
+  collapseAll: <path d="M4.5 3L8 6.5 11.5 3M4.5 13L8 9.5 11.5 13" />,
 };
 
 export interface PGIconProps {

--- a/src/design/primitives.tsx
+++ b/src/design/primitives.tsx
@@ -292,7 +292,7 @@ export function PGInput({
         padding: "0 8px",
         gap: 6,
         transition: "border-color var(--t-fast)",
-        boxShadow: focus ? "0 0 0 3px oklch(0.72 0.15 235 / 0.15)" : "none",
+        boxShadow: focus ? "0 0 0 3px oklch(from var(--accent) l c h / 0.15)" : "none",
         ...style,
       }}
     >
@@ -411,7 +411,7 @@ export function PGTextarea({
         lineHeight: "var(--lh-body)",
         outline: "none",
         transition: "border-color var(--t-fast)",
-        boxShadow: focus ? "0 0 0 3px oklch(0.72 0.15 235 / 0.15)" : "none",
+        boxShadow: focus ? "0 0 0 3px oklch(from var(--accent) l c h / 0.15)" : "none",
         ...style,
       }}
       {...rest}
@@ -643,9 +643,9 @@ export function PGBadge({
   const tones: Record<string, { bg: string; fg: string; border: string }> = {
     default: { bg: "var(--bg-3)", fg: "var(--fg-1)", border: "var(--border-1)" },
     accent: {
-      bg: "oklch(0.72 0.15 235 / 0.18)",
+      bg: "oklch(from var(--accent) l c h / 0.18)",
       fg: "var(--accent)",
-      border: "oklch(0.72 0.15 235 / 0.35)",
+      border: "oklch(from var(--accent) l c h / 0.35)",
     },
     success: {
       bg: "oklch(0.72 0.15 155 / 0.18)",

--- a/src/features/keymap/actions.test.ts
+++ b/src/features/keymap/actions.test.ts
@@ -30,6 +30,9 @@ describe("action catalog", () => {
       "commit.commit",
       "commit.commitAndPush",
       "commit.toggleAmend",
+      // RepoBrowser focuses its tree filter box while mounted; falls through
+      // on every other screen.
+      "tree.find",
     ]);
     for (const id of ALL_ACTION_IDS) {
       const d = ACTIONS[id];

--- a/src/features/keymap/actions.ts
+++ b/src/features/keymap/actions.ts
@@ -75,7 +75,8 @@ export type ActionId =
   | "commit.commit"
   | "commit.commitAndPush"
   | "commit.toggleAmend"
-  | "branch.createNew";
+  | "branch.createNew"
+  | "tree.find";
 
 export interface ActionDef {
   id: ActionId;
@@ -226,6 +227,15 @@ export const ACTIONS: Record<ActionId, ActionDef> = {
       usePaletteStore.getState().pushStep(createBranchInputStep());
       return true;
     },
+  },
+
+  // Component-handled: the Files tree registers a handler that focuses its
+  // filter box while mounted (like commit.*). Elsewhere the chord falls through.
+  "tree.find": {
+    id: "tree.find",
+    title: "Find in file tree",
+    category: "Lists & trees",
+    scope: "global",
   },
 };
 

--- a/src/features/keymap/actions.ts
+++ b/src/features/keymap/actions.ts
@@ -13,6 +13,7 @@ import { useNavStore } from "@/features/nav/useNavStore";
 import { usePaletteStore } from "@/features/palette/usePaletteStore";
 import {
   fetchAllOp,
+  openRepoOp,
   pullCurrentOp,
   pushCurrentOp,
   refreshOp,
@@ -76,7 +77,8 @@ export type ActionId =
   | "commit.commitAndPush"
   | "commit.toggleAmend"
   | "branch.createNew"
-  | "tree.find";
+  | "tree.find"
+  | "repo.open";
 
 export interface ActionDef {
   id: ActionId;
@@ -203,6 +205,7 @@ export const ACTIONS: Record<ActionId, ActionDef> = {
   "diff.nextChange": { id: "diff.nextChange", title: "Next change (hunk)", category: "Diff", scope: "pane" },
   "diff.prevChange": { id: "diff.prevChange", title: "Previous change (hunk)", category: "Diff", scope: "pane" },
 
+  "repo.open": { id: "repo.open", title: "Open repository…", category: "Repository", scope: "global", run: openRepoOp },
   "repo.fetch": { id: "repo.fetch", title: "Fetch all remotes", category: "Repository", scope: "global", run: fetchAllOp },
   "repo.pull": { id: "repo.pull", title: "Pull (update project)", category: "Repository", scope: "global", run: pullCurrentOp },
   "repo.push": { id: "repo.push", title: "Push", category: "Repository", scope: "global", run: pushCurrentOp },

--- a/src/features/keymap/presets.test.ts
+++ b/src/features/keymap/presets.test.ts
@@ -114,11 +114,12 @@ describe("platypusgit preset", () => {
 
   it("shares the rider repo-op chords (review F2/F7: the old set collided)", () => {
     // Old classic bindings sat on entrenched chords: ⌘⇧P is the VS Code
-    // command palette (a mutating push there is dangerous), ⌘⇧F is
-    // find-in-files everywhere, ⌘⇧R is browser hard-reload.
+    // command palette (a mutating push there is dangerous), ⌘⇧R is browser
+    // hard-reload — neither is bound. ⌘⇧F IS bound, but to find-in-tree, which
+    // is semantically the find-in-files chord users expect, not a mutating op.
     expect(rev.get("Mod+Shift+P")).toBeUndefined();
-    expect(rev.get("Mod+Shift+F")).toBeUndefined();
     expect(rev.get("Mod+Shift+R")).toBeUndefined();
+    expect(rev.get("Mod+Shift+F")).toEqual(["tree.find"]);
     expect(PLATYPUSGIT_PRESET.bindings["repo.push"]).toEqual(["Mod+Shift+K"]);
     expect(PLATYPUSGIT_PRESET.bindings["repo.pull"]).toEqual(["Mod+T"]);
     expect(PLATYPUSGIT_PRESET.bindings["repo.fetch"]).toEqual(["Mod+Shift+T"]);

--- a/src/features/keymap/presets.ts
+++ b/src/features/keymap/presets.ts
@@ -35,6 +35,8 @@ const POWER_SHORTCUTS = {
 
 /** Bindings shared by every preset — panes, lists, overlay. */
 const COMMON = {
+  // Open repository (the status bar advertises ⌘O). Same chord both presets.
+  "repo.open": ["Mod+O"],
   "app.closeOverlay": ["Escape"],
   "pane.focusLeft": ["Alt+ArrowLeft"],
   "pane.focusRight": ["Alt+ArrowRight"],

--- a/src/features/keymap/presets.ts
+++ b/src/features/keymap/presets.ts
@@ -57,6 +57,9 @@ const COMMON = {
   // Rider NextDiff/PreviousDiff — real JetBrains bindings.
   "diff.nextChange": ["F7"],
   "diff.prevChange": ["Shift+F7"],
+  // Find-in-tree (matches the ⌘⇧F chip on the Files tree). Component-handled
+  // by RepoBrowser; a find, not a mutating op, so ⌘⇧F muscle-memory is safe.
+  "tree.find": ["Mod+Shift+F"],
 } satisfies Partial<Record<ActionId, string[]>>;
 
 export const RIDER_PRESET: KeymapPreset = {

--- a/src/features/nav/DeepViewHeader.tsx
+++ b/src/features/nav/DeepViewHeader.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { PGIconButton } from "@/design";
+import { useNavStore } from "./useNavStore";
+
+// Friendly labels for the origin crumb. Deep views themselves never appear
+// here (they're not persisted / not valid origins).
+const SCREEN_LABELS: Record<string, string> = {
+  repo: "Files",
+  commit: "Commit",
+  history: "History",
+  branches: "Branches",
+  conflict: "Conflicts",
+  rebase: "Rebase",
+  remote: "Remotes",
+  diff: "Diff viewer",
+  reflog: "Reflog",
+  settings: "Settings",
+};
+
+/**
+ * Back + breadcrumb bar for the dead-end deep views (CommitDiff, FileHistory,
+ * Blame): they have no activity-bar entry, so without this there's no way back
+ * to where you came from. "Back" returns to `deepOrigin` (set by AppShell when
+ * it routed here), falling back to History.
+ */
+export function DeepViewHeader({ crumbs }: { crumbs: React.ReactNode[] }) {
+  const setIntent = useNavStore((s) => s.setIntent);
+  const origin = useNavStore((s) => s.deepOrigin) ?? "history";
+  const originLabel = SCREEN_LABELS[origin] ?? "Back";
+  const back = () => setIntent({ kind: "switch-screen", screen: origin });
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 6,
+        padding: "6px 10px",
+        borderBottom: "1px solid var(--border-0)",
+        background: "var(--bg-1)",
+        fontFamily: "var(--font-mono)",
+        fontSize: "var(--fs-12)",
+        flexShrink: 0,
+      }}
+    >
+      <PGIconButton
+        icon="chevronLeft"
+        size="sm"
+        title={`Back to ${originLabel}`}
+        onClick={back}
+      />
+      <button
+        onClick={back}
+        style={{
+          background: "transparent",
+          border: "none",
+          color: "var(--fg-2)",
+          cursor: "pointer",
+          font: "inherit",
+          padding: "0 2px",
+        }}
+      >
+        {originLabel}
+      </button>
+      {crumbs.map((c, i) => (
+        <React.Fragment key={i}>
+          <span style={{ color: "var(--fg-3)" }}>›</span>
+          <span
+            style={{
+              color: i === crumbs.length - 1 ? "var(--fg-0)" : "var(--fg-2)",
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {c}
+          </span>
+        </React.Fragment>
+      ))}
+    </div>
+  );
+}

--- a/src/features/nav/useNavStore.ts
+++ b/src/features/nav/useNavStore.ts
@@ -20,12 +20,21 @@ export type NavIntent =
 
 interface NavState {
   intent: NavIntent | null;
+  /**
+   * Screen to return to from a deep view (CommitDiff / FileHistory / Blame).
+   * Set by AppShell when it routes an intent into a deep view; read by the
+   * deep view's back affordance so "Back" lands where the user came from.
+   */
+  deepOrigin: string | null;
   setIntent: (i: NavIntent) => void;
   clearIntent: () => void;
+  setDeepOrigin: (screen: string | null) => void;
 }
 
 export const useNavStore = create<NavState>((set) => ({
   intent: null,
+  deepOrigin: null,
   setIntent: (intent) => set({ intent }),
   clearIntent: () => set({ intent: null }),
+  setDeepOrigin: (deepOrigin) => set({ deepOrigin }),
 }));

--- a/src/features/repo/ops.test.ts
+++ b/src/features/repo/ops.test.ts
@@ -11,11 +11,15 @@ const staged = (path: string): FileStatus => ({
   path,
   worktree: { kind: "Unmodified" },
   index: { kind: "Modified" },
+  additions: 0,
+  deletions: 0,
 });
 const unstaged = (path: string): FileStatus => ({
   path,
   worktree: { kind: "Modified" },
   index: { kind: "Unmodified" },
+  additions: 0,
+  deletions: 0,
 });
 
 describe("stageAllOp / unstageAllOp", () => {

--- a/src/features/repo/ops.ts
+++ b/src/features/repo/ops.ts
@@ -3,6 +3,7 @@
 // ran and `false` when it declined (no repo / no upstream), so keymap runners
 // can fall through cleanly.
 
+import { open } from "@tauri-apps/plugin-dialog";
 import { pgFlash } from "@/design";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { currentBranch, isStaged, isUnstaged } from "@/lib/derive";
@@ -17,6 +18,25 @@ export function headUpstream(
   const idx = upstream.indexOf("/");
   if (idx < 0) return [upstream, headName ?? upstream];
   return [upstream.slice(0, idx), upstream.slice(idx + 1)];
+}
+
+/** Show the native folder picker and open the chosen repository. Shared by the
+ *  titlebar/Welcome buttons and the ⌘O keymap action so all three agree. */
+export async function openRepoDialog(): Promise<void> {
+  const selected = await open({
+    directory: true,
+    multiple: false,
+    title: "Open repository",
+  });
+  if (typeof selected === "string") {
+    await useRepoStore.getState().openRepo(selected);
+  }
+}
+
+/** Keymap runner form of {@link openRepoDialog}. Always claims the chord. */
+export function openRepoOp(): boolean {
+  void openRepoDialog();
+  return true;
 }
 
 export function fetchAllOp(): boolean {

--- a/src/index.css
+++ b/src/index.css
@@ -173,7 +173,7 @@ textarea,
 }
 *::-webkit-scrollbar-thumb:hover { background: var(--border-2); }
 
-::selection { background: oklch(0.72 0.15 235 / 0.35); }
+::selection { background: oklch(from var(--accent) l c h / 0.35); }
 
 .focusable:focus-visible { outline: none; box-shadow: var(--ring); }
 
@@ -279,7 +279,7 @@ kbd {
   inset: 0;
   pointer-events: none;
   z-index: 10;
-  box-shadow: inset 0 0 0 1px oklch(0.72 0.15 235 / 0.85);
+  box-shadow: inset 0 0 0 1px oklch(from var(--accent) l c h / 0.85);
 }
 
 /* Selected row: dim when its pane is inactive… */

--- a/src/lib/tree.test.ts
+++ b/src/lib/tree.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { buildStatusTree } from "./tree";
+import type { FileStatus, StatusFlag } from "./types";
+
+function file(path: string, worktree: StatusFlag["kind"] = "Modified"): FileStatus {
+  return {
+    path,
+    worktree: { kind: worktree },
+    index: { kind: "Unmodified" },
+    additions: 0,
+    deletions: 0,
+  };
+}
+
+/** Names of a node's descendants, as a nested [name, children?] shape. */
+function shape(nodes: ReturnType<typeof buildStatusTree>): unknown {
+  return nodes.map((n) =>
+    n.children ? { name: n.name, children: shape(n.children) } : n.name,
+  );
+}
+
+describe("buildStatusTree — path compaction (A1)", () => {
+  it("collapses a single-child directory chain into one node", () => {
+    const tree = buildStatusTree([file("src/features/repo/store.ts")]);
+    expect(shape(tree)).toEqual([
+      { name: "src/features/repo", children: ["store.ts"] },
+    ]);
+  });
+
+  it("does NOT collapse a folder whose only child is a file", () => {
+    const tree = buildStatusTree([file("src/main.ts")]);
+    expect(shape(tree)).toEqual([{ name: "src", children: ["main.ts"] }]);
+  });
+
+  it("does NOT collapse a folder that has more than one child", () => {
+    const tree = buildStatusTree([
+      file("src/a/one.ts"),
+      file("src/b/two.ts"),
+    ]);
+    // src has two folder children → stays; each of a/b is a single-file folder.
+    expect(shape(tree)).toEqual([
+      {
+        name: "src",
+        children: [
+          { name: "a", children: ["one.ts"] },
+          { name: "b", children: ["two.ts"] },
+        ],
+      },
+    ]);
+  });
+
+  it("compacts only the single-child prefix, then stops at the branch point", () => {
+    const tree = buildStatusTree([
+      file("a/b/c/x.ts"),
+      file("a/b/c/y.ts"),
+    ]);
+    expect(shape(tree)).toEqual([
+      { name: "a/b/c", children: ["x.ts", "y.ts"] },
+    ]);
+  });
+
+  it("preserves full per-segment nesting when compact:false", () => {
+    const tree = buildStatusTree([file("src/features/repo/store.ts")], {
+      compact: false,
+    });
+    expect(shape(tree)).toEqual([
+      {
+        name: "src",
+        children: [
+          {
+            name: "features",
+            children: [{ name: "repo", children: ["store.ts"] }],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("keeps leaf status marks on compacted nodes' children", () => {
+    const tree = buildStatusTree([file("src/deep/nested/a.ts", "Added")]);
+    const leaf = tree[0].children?.[0];
+    expect(tree[0].name).toBe("src/deep/nested");
+    expect(leaf?.status).toBeTruthy();
+  });
+
+  it("expands the first level of the compacted tree by default", () => {
+    const tree = buildStatusTree([file("src/features/repo/store.ts")]);
+    expect(tree[0].defaultExpanded).toBe(true);
+  });
+});

--- a/src/lib/tree.ts
+++ b/src/lib/tree.ts
@@ -2,17 +2,50 @@ import type { PGFileTreeNode } from "@/design";
 import type { FileStatus } from "./types";
 import { statusMark } from "./derive";
 
+interface MutableNode {
+  name: string;
+  status?: string;
+  children?: MutableNode[];
+  defaultExpanded?: boolean;
+}
+
+/**
+ * Collapse single-child directory chains into one node (Fork / Sublime / IntelliJ
+ * style): a folder whose only child is another folder merges with it, joining
+ * names with `/`. A folder with a file child or multiple children is left alone,
+ * so `src/features/repo` renders as one row instead of three nested ones.
+ */
+function compactNode(node: MutableNode): MutableNode {
+  if (!node.children) return node;
+  let n: MutableNode = { ...node, children: node.children.map(compactNode) };
+  while (
+    n.children!.length === 1 &&
+    n.children![0].children &&
+    n.children![0].children.length > 0 &&
+    n.children![0].status === undefined
+  ) {
+    const child = n.children![0];
+    n = {
+      name: `${n.name}/${child.name}`,
+      children: child.children,
+      defaultExpanded: n.defaultExpanded,
+    };
+  }
+  return n;
+}
+
 /**
  * Build a tree of PGFileTreeNode from a flat list of FileStatus.
  * Folders collapse by default; the top-level first folder is expanded.
+ *
+ * `compact` (default true) merges single-child directory chains — see
+ * {@link compactNode}. Pass `{ compact: false }` for full per-segment nesting.
  */
-export function buildStatusTree(files: FileStatus[]): PGFileTreeNode[] {
-  interface MutableNode {
-    name: string;
-    status?: string;
-    children?: MutableNode[];
-    defaultExpanded?: boolean;
-  }
+export function buildStatusTree(
+  files: FileStatus[],
+  opts: { compact?: boolean } = {},
+): PGFileTreeNode[] {
+  const { compact = true } = opts;
 
   const root: MutableNode = { name: "", children: [] };
 
@@ -48,10 +81,13 @@ export function buildStatusTree(files: FileStatus[]): PGFileTreeNode[] {
   };
   sortNode(root);
 
+  let children = root.children ?? [];
+  if (compact) children = children.map(compactNode);
+
   // Expand the first level by default.
-  root.children?.forEach((c) => {
+  children.forEach((c) => {
     if (c.children?.length) c.defaultExpanded = true;
   });
 
-  return (root.children ?? []) as PGFileTreeNode[];
+  return children as PGFileTreeNode[];
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -21,6 +21,11 @@ export interface FileStatus {
   path: string;
   worktree: StatusFlag;
   index: StatusFlag;
+  /** Lines added vs HEAD (worktree + index). 0 when unmodified/binary or in
+   *  listings that don't compute stats (all-files / at-revision). */
+  additions: number;
+  /** Lines removed vs HEAD (worktree + index). */
+  deletions: number;
 }
 
 export interface CommitInfo {

--- a/src/screens/Blame.tsx
+++ b/src/screens/Blame.tsx
@@ -4,6 +4,7 @@ import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { blameFile } from "@/lib/tauri";
 import { appErrorMessage } from "@/lib/errors";
+import { DeepViewHeader } from "@/features/nav/DeepViewHeader";
 import { PGPane, FocusableScroll } from "@/features/keymap";
 import type { BlameLine } from "@/lib/types";
 
@@ -38,22 +39,18 @@ export function BlameScreen() {
 
   if (!path) {
     return (
-      <PGEmpty icon="search" title="No file selected">
-        Right-click a file and choose "Blame".
-      </PGEmpty>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
+        <DeepViewHeader crumbs={["Blame"]} />
+        <PGEmpty icon="search" title="No file selected">
+          Right-click a file and choose "Blame".
+        </PGEmpty>
+      </div>
     );
   }
 
   return (
     <PGPane id="blame.content" style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
-      <div style={{
-        padding: "8px 12px",
-        borderBottom: "1px solid var(--border-0)",
-        fontFamily: "var(--font-mono)",
-        fontSize: "var(--fs-12)",
-      }}>
-        Blame — {path}
-      </div>
+      <DeepViewHeader crumbs={[`Blame — ${path}`]} />
       {loading && <div style={{ padding: 12 }}><PGSpinner /></div>}
       {error && <div style={{ padding: 12, color: "var(--git-removed)" }}>{error}</div>}
       <FocusableScroll style={{

--- a/src/screens/CommitDiff.tsx
+++ b/src/screens/CommitDiff.tsx
@@ -4,6 +4,7 @@ import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { CommitDiffPanel } from "@/features/diff/CommitDiffPanel";
+import { DeepViewHeader } from "@/features/nav/DeepViewHeader";
 import { diffCommit, diffCommits } from "@/lib/tauri";
 import { appErrorMessage } from "@/lib/errors";
 import type { FileDiff } from "@/lib/types";
@@ -77,22 +78,28 @@ export function CommitDiffScreen() {
 
   if (!target) {
     return (
-      <PGEmpty icon="diff" title="No diff target">
-        Pick &quot;Compare…&quot; from a context menu.
-      </PGEmpty>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
+        <DeepViewHeader crumbs={["Commit diff"]} />
+        <PGEmpty icon="diff" title="No diff target">
+          Pick &quot;Compare…&quot; from a context menu.
+        </PGEmpty>
+      </div>
     );
   }
 
   return (
-    <CommitDiffPanel
-      diffs={diffs}
-      loading={loading}
-      error={error}
-      header={targetHeader(target)}
-      paneIdPrefix="commitDiff"
-      emptyLabel={
-        target.kind === "commit-self" ? "No changes in this commit." : "No changes."
-      }
-    />
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
+      <DeepViewHeader crumbs={[`Diff ${targetHeader(target)}`]} />
+      <CommitDiffPanel
+        diffs={diffs}
+        loading={loading}
+        error={error}
+        header={targetHeader(target)}
+        paneIdPrefix="commitDiff"
+        emptyLabel={
+          target.kind === "commit-self" ? "No changes in this commit." : "No changes."
+        }
+      />
+    </div>
   );
 }

--- a/src/screens/CommitPanel.keyboard.test.tsx
+++ b/src/screens/CommitPanel.keyboard.test.tsx
@@ -13,11 +13,15 @@ const staged = (path: string): FileStatus => ({
   path,
   worktree: { kind: "Unmodified" },
   index: { kind: "Modified" },
+  additions: 0,
+  deletions: 0,
 });
 const unstaged = (path: string): FileStatus => ({
   path,
   worktree: { kind: "Modified" },
   index: { kind: "Unmodified" },
+  additions: 0,
+  deletions: 0,
 });
 
 const key = (k: string, over: Partial<KeyboardEvent> = {}) =>

--- a/src/screens/CommitPanel.test.tsx
+++ b/src/screens/CommitPanel.test.tsx
@@ -13,11 +13,23 @@ const repo: RepoHandle = {
 };
 
 function modified(path: string): FileStatus {
-  return { path, worktree: { kind: "Modified" }, index: { kind: "Unmodified" } };
+  return {
+    path,
+    worktree: { kind: "Modified" },
+    index: { kind: "Unmodified" },
+    additions: 0,
+    deletions: 0,
+  };
 }
 
 function stagedFile(path: string): FileStatus {
-  return { path, worktree: { kind: "Unmodified" }, index: { kind: "Modified" } };
+  return {
+    path,
+    worktree: { kind: "Unmodified" },
+    index: { kind: "Modified" },
+    additions: 0,
+    deletions: 0,
+  };
 }
 
 const initialStatus = [

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -278,11 +278,11 @@ export function CommitPanelScreen() {
   const defaultRemote = remotes[0] ?? null;
 
   const stagedAdd = React.useMemo(
-    () => staged.reduce((s, f) => s + countAdd(f.status), 0),
+    () => staged.reduce((s, f) => s + f.status.additions, 0),
     [staged],
   );
   const stagedDel = React.useMemo(
-    () => staged.reduce((s, f) => s + countDel(f.status), 0),
+    () => staged.reduce((s, f) => s + f.status.deletions, 0),
     [staged],
   );
 
@@ -430,8 +430,8 @@ export function CommitPanelScreen() {
               path={f.path}
               status={statusMark(f.status)}
               staged
-              additions={countAdd(f.status)}
-              deletions={countDel(f.status)}
+              additions={f.status.additions}
+              deletions={f.status.deletions}
               selected={effectiveKeys.has(keyOf(f))}
               onClick={onRowClick(f)}
               onContextMenu={onRowContextMenu(f)}
@@ -483,8 +483,8 @@ export function CommitPanelScreen() {
               path={f.path}
               status={statusMark(f.status)}
               staged={false}
-              additions={countAdd(f.status)}
-              deletions={countDel(f.status)}
+              additions={f.status.additions}
+              deletions={f.status.deletions}
               selected={effectiveKeys.has(keyOf(f))}
               onClick={onRowClick(f)}
               onContextMenu={onRowContextMenu(f)}
@@ -895,16 +895,6 @@ function diffToSplit(d: FileDiff): { left: SideLine[]; right: SideLine[] } {
     }
   }
   return { left, right };
-}
-
-function countAdd(s: FileStatus): number {
-  // We don't have per-file adds/dels from the status list — surface 0
-  // unless the diff viewer exposes it. Keeping the slot keeps the UI tidy.
-  return s.worktree.kind === "Added" || s.index.kind === "Added" ? 0 : 0;
-}
-
-function countDel(s: FileStatus): number {
-  return s.worktree.kind === "Deleted" || s.index.kind === "Deleted" ? 0 : 0;
 }
 
 function toUiLine(l: {

--- a/src/screens/FileHistory.tsx
+++ b/src/screens/FileHistory.tsx
@@ -4,6 +4,7 @@ import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { fileHistory } from "@/lib/tauri";
 import { appErrorMessage } from "@/lib/errors";
+import { DeepViewHeader } from "@/features/nav/DeepViewHeader";
 import { PGPane, FocusableScroll, usePaneList } from "@/features/keymap";
 import type { CommitInfo } from "@/lib/types";
 
@@ -53,22 +54,18 @@ export function FileHistoryScreen() {
 
   if (!path) {
     return (
-      <PGEmpty icon="history" title="No file selected">
-        Right-click a file and choose "File history".
-      </PGEmpty>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
+        <DeepViewHeader crumbs={["File history"]} />
+        <PGEmpty icon="history" title="No file selected">
+          Right-click a file and choose "File history".
+        </PGEmpty>
+      </div>
     );
   }
 
   return (
     <PGPane id="fileHistory.list" style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
-      <div style={{
-        padding: "8px 12px",
-        borderBottom: "1px solid var(--border-0)",
-        fontFamily: "var(--font-mono)",
-        fontSize: "var(--fs-12)",
-      }}>
-        History — {path}
-      </div>
+      <DeepViewHeader crumbs={[`History — ${path}`]} />
       {loading && <div style={{ padding: 12 }}><PGSpinner /></div>}
       {error && <div style={{ padding: 12, color: "var(--git-removed)" }}>{error}</div>}
       {!loading && !error && commits.length === 0 && (

--- a/src/screens/RepoBrowser.test.tsx
+++ b/src/screens/RepoBrowser.test.tsx
@@ -13,7 +13,13 @@ const repo: RepoHandle = {
 };
 
 function modified(path: string): FileStatus {
-  return { path, worktree: { kind: "Modified" }, index: { kind: "Unmodified" } };
+  return {
+    path,
+    worktree: { kind: "Modified" },
+    index: { kind: "Unmodified" },
+    additions: 0,
+    deletions: 0,
+  };
 }
 
 function unmodified(path: string): FileStatus {
@@ -21,6 +27,8 @@ function unmodified(path: string): FileStatus {
     path,
     worktree: { kind: "Unmodified" },
     index: { kind: "Unmodified" },
+    additions: 0,
+    deletions: 0,
   };
 }
 

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -45,7 +45,8 @@ import {
 import { highlightFile } from "@/lib/highlight";
 import { getDiff, readFileContent } from "@/lib/tauri";
 import { buildStatusTree } from "@/lib/tree";
-import { PGPane, FocusableScroll } from "@/features/keymap";
+import { fuzzyMatch } from "@/features/palette/fuzzyMatch";
+import { PGPane, FocusableScroll, useAction } from "@/features/keymap";
 import type {
   BranchInfo,
   FileContent,
@@ -103,6 +104,8 @@ export function RepoBrowserScreen() {
   const diffContextLines = useSettingsStore((s) => s.diffContextLines);
 
   const [expanded, setExpanded] = React.useState<Record<string, boolean>>({});
+  const [treeFilter, setTreeFilter] = React.useState("");
+  const filterInputRef = React.useRef<HTMLInputElement>(null);
   const [sel, setSel] = React.useState<Selection>(emptySelection);
   const [diff, setDiff] = React.useState<FileDiff | null>(null);
   const [diffLoading, setDiffLoading] = React.useState(false);
@@ -171,44 +174,43 @@ export function RepoBrowserScreen() {
   }, [repo, rev, listFilesAtRev]);
 
   const filteredStatus = React.useMemo<FileStatus[]>(() => {
-    // Browsing a committed revision: show its whole tree, no status filtering.
-    if (browsingRev) return revFiles;
     let base: FileStatus[];
-    switch (filterMode) {
-      case "conflicts":
-        base = status.filter(
-          (s) =>
-            s.worktree.kind === "Conflicted" || s.index.kind === "Conflicted",
-        );
-        break;
-      case "changes":
-        base = status.filter(
-          (s) =>
-            s.worktree.kind !== "Unmodified" ||
-            s.index.kind !== "Unmodified",
-        );
-        break;
-      case "all":
-      default:
-        base = allFiles;
+    // Browsing a committed revision: show its whole tree, no status filtering.
+    if (browsingRev) {
+      base = revFiles;
+    } else {
+      switch (filterMode) {
+        case "conflicts":
+          base = status.filter(
+            (s) =>
+              s.worktree.kind === "Conflicted" || s.index.kind === "Conflicted",
+          );
+          break;
+        case "changes":
+          base = status.filter(
+            (s) =>
+              s.worktree.kind !== "Unmodified" ||
+              s.index.kind !== "Unmodified",
+          );
+          break;
+        case "all":
+        default:
+          base = allFiles;
+      }
+      if (hiddenKinds.size > 0) {
+        base = base.filter((s) => !isHidden(s, hiddenKinds));
+      }
     }
-    if (hiddenKinds.size === 0) return base;
-    return base.filter((s) => !isHidden(s, hiddenKinds));
-  }, [status, allFiles, filterMode, hiddenKinds, browsingRev, revFiles]);
+    // Live fuzzy filter from the "Find in tree" box — matches the full path.
+    const q = treeFilter.trim();
+    if (q) base = base.filter((s) => fuzzyMatch(q, s.path).matched);
+    return base;
+  }, [status, allFiles, filterMode, hiddenKinds, browsingRev, revFiles, treeFilter]);
 
   const tree = React.useMemo<PGFileTreeNode[]>(() => {
     const t = buildStatusTree(filteredStatus);
     return sortMode === "desc" ? reverseTree(t) : t;
   }, [filteredStatus, sortMode]);
-
-  // Visible row order (folders included) for shift-click ranges; selection
-  // keys are PGFileTree keys of the form "/a/b/c".
-  const rowOrder = React.useMemo(
-    () => flattenFileTree(tree, expanded).map((f) => f.key),
-    [tree, expanded],
-  );
-  const selectedKeys = React.useMemo(() => new Set(sel.keys), [sel]);
-  const selected = primarySelectedKey(sel);
 
   // Expand-all / collapse-all: set every folder key true / false. Collapse must
   // write explicit `false` (not clear the map) to override defaultExpanded.
@@ -220,6 +222,37 @@ export function RepoBrowserScreen() {
   const collapseAll = React.useCallback(
     () => setExpanded(Object.fromEntries(folderKeys.map((k) => [k, false]))),
     [folderKeys],
+  );
+
+  // While the filter box is active, expand every folder so matches show
+  // regardless of the persisted expand state.
+  const filtering = treeFilter.trim().length > 0;
+  const expandedForRender = React.useMemo(
+    () =>
+      filtering
+        ? Object.fromEntries(folderKeys.map((k) => [k, true]))
+        : expanded,
+    [filtering, folderKeys, expanded],
+  );
+
+  // Visible row order (folders included) for shift-click ranges; selection
+  // keys are PGFileTree keys of the form "/a/b/c".
+  const rowOrder = React.useMemo(
+    () => flattenFileTree(tree, expandedForRender).map((f) => f.key),
+    [tree, expandedForRender],
+  );
+  const selectedKeys = React.useMemo(() => new Set(sel.keys), [sel]);
+  const selected = primarySelectedKey(sel);
+
+  // ⌘⇧F focuses the filter box (chord advertised by the search chip).
+  useAction(
+    "tree.find",
+    () => {
+      filterInputRef.current?.focus();
+      filterInputRef.current?.select();
+      return true;
+    },
+    [],
   );
 
   // Prune selection when rows disappear (filter/rev/sort change, refresh).
@@ -463,6 +496,9 @@ export function RepoBrowserScreen() {
             />
             <div style={{ display: "flex", gap: 4, alignItems: "center" }}>
               <PGSearchInput
+                inputRef={filterInputRef}
+                value={treeFilter}
+                onChange={setTreeFilter}
                 placeholder="Find in tree…"
                 shortcut="⌘⇧F"
                 style={{ flex: 1, minWidth: 0 }}
@@ -491,13 +527,15 @@ export function RepoBrowserScreen() {
                   fontFamily: "var(--font-mono)",
                 }}
               >
-                {browsingRev
-                  ? "No files at this revision."
-                  : filterMode === "all"
-                    ? "No files."
-                    : filterMode === "conflicts"
-                      ? "No conflicts."
-                      : "Working tree clean."}
+                {filtering
+                  ? `No files match "${treeFilter.trim()}".`
+                  : browsingRev
+                    ? "No files at this revision."
+                    : filterMode === "all"
+                      ? "No files."
+                      : filterMode === "conflicts"
+                        ? "No conflicts."
+                        : "Working tree clean."}
               </div>
             )}
             {(loading || revLoading) && tree.length === 0 && (
@@ -513,7 +551,7 @@ export function RepoBrowserScreen() {
             )}
             <PGFileTree
               nodes={tree}
-              expanded={expanded}
+              expanded={expandedForRender}
               onToggle={(k) =>
                 setExpanded((e) => ({ ...e, [k]: !e[k] }))
               }

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -210,6 +210,18 @@ export function RepoBrowserScreen() {
   const selectedKeys = React.useMemo(() => new Set(sel.keys), [sel]);
   const selected = primarySelectedKey(sel);
 
+  // Expand-all / collapse-all: set every folder key true / false. Collapse must
+  // write explicit `false` (not clear the map) to override defaultExpanded.
+  const folderKeys = React.useMemo(() => collectFolderKeys(tree), [tree]);
+  const expandAll = React.useCallback(
+    () => setExpanded(Object.fromEntries(folderKeys.map((k) => [k, true]))),
+    [folderKeys],
+  );
+  const collapseAll = React.useCallback(
+    () => setExpanded(Object.fromEntries(folderKeys.map((k) => [k, false]))),
+    [folderKeys],
+  );
+
   // Prune selection when rows disappear (filter/rev/sort change, refresh).
   // Validity is against the full tree, not just visible rows — collapsing a
   // folder hides rows without deselecting them.
@@ -449,11 +461,25 @@ export function RepoBrowserScreen() {
               branches={branches}
               tags={tags}
             />
-            <PGSearchInput
-              placeholder="Find in tree…"
-              shortcut="⌘⇧F"
-              style={{ flex: 1, minWidth: 0 }}
-            />
+            <div style={{ display: "flex", gap: 4, alignItems: "center" }}>
+              <PGSearchInput
+                placeholder="Find in tree…"
+                shortcut="⌘⇧F"
+                style={{ flex: 1, minWidth: 0 }}
+              />
+              <PGIconButton
+                icon="expandAll"
+                size="sm"
+                title="Expand all"
+                onClick={expandAll}
+              />
+              <PGIconButton
+                icon="collapseAll"
+                size="sm"
+                title="Collapse all"
+                onClick={collapseAll}
+              />
+            </div>
           </div>
           <div style={{ flex: 1, overflow: "auto", padding: "4px 0" }}>
             {tree.length === 0 && !loading && !revLoading && (
@@ -904,6 +930,22 @@ function flattenAllKeys(nodes: PGFileTreeNode[]): string[] {
       const key = parentKey + "/" + n.name;
       out.push(key);
       if (n.children) walk(n.children, key);
+    }
+  };
+  walk(nodes, "");
+  return out;
+}
+
+/** Keys of every folder (node with children) — the set expand/collapse-all toggles. */
+function collectFolderKeys(nodes: PGFileTreeNode[]): string[] {
+  const out: string[] = [];
+  const walk = (list: PGFileTreeNode[], parentKey: string) => {
+    for (const n of list) {
+      const key = parentKey + "/" + n.name;
+      if (n.children && n.children.length) {
+        out.push(key);
+        walk(n.children, key);
+      }
     }
   };
   walk(nodes, "");

--- a/src/screens/Welcome.tsx
+++ b/src/screens/Welcome.tsx
@@ -1,7 +1,7 @@
-import { open } from "@tauri-apps/plugin-dialog";
 import { PGButton, PGIcon, PGIconButton, PGLogo, PGSpinner } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useRecentsStore } from "@/features/repo/useRecentsStore";
+import { openRepoDialog } from "@/features/repo/ops";
 
 export function WelcomeScreen() {
   const openRepo = useRepoStore((s) => s.openRepo);
@@ -9,15 +9,8 @@ export function WelcomeScreen() {
   const recents = useRecentsStore((s) => s.recents);
   const removeRecent = useRecentsStore((s) => s.removeRecent);
 
-  async function handleOpen() {
-    const selected = await open({
-      directory: true,
-      multiple: false,
-      title: "Open repository",
-    });
-    if (typeof selected === "string") {
-      await openRepo(selected);
-    }
+  function handleOpen() {
+    void openRepoDialog();
   }
 
   return (


### PR DESCRIPTION
Addresses **Tier 0 — Quick wins** of #61 (the design/UX review). Implements all 8 Tier 0 items; Tiers 1–3 remain open, so this does **not** close the issue.

## Items

- [x] **A1 — Path compaction** (`src/lib/tree.ts`): `buildStatusTree` collapses single-child directory chains (`src/features/repo` → one row). Toggleable via `{ compact: false }`; default on. Guards file children + branch points.
- [x] **A2 — Expand-all / collapse-all** (`RepoBrowser`): two buttons in the Files-tree header set every folder key true / false (collapse writes explicit `false` to beat the default first-level expansion). New `expandAll`/`collapseAll` glyphs.
- [x] **A3 — Find-in-tree filter box** (latent bug): the search input had no `value`/`onChange` and did nothing. Now a live fuzzy path filter (reuses the palette matcher) that prunes the tree + auto-expands matches. New component-handled `tree.find` action; `⌘⇧F` bound in both presets so the advertised chord is real.
- [x] **B1 — Theme accents** (theme bug): selection tint, pane-focus ring, input/textarea focus glow, accent badges, diff hunk-header bg, context-menu hover hardcoded the default blue. Swapped for the `oklch(from var(--accent) l c h / <alpha>)` relative-color pattern. (Base token defs — `--git-renamed`, `--graph-1`, `--ring` — left for B4/Tier 1's semantic remap.)
- [x] **B2 — Real per-file `+/−` counts** (latent bug): `countAdd`/`countDel` returned 0 unconditionally. Extended `FileStatus` with `additions`/`deletions`, computed once per `get_status` via a single HEAD→worktree (index-aware) diff + cheap per-delta `line_stats`. Fixes the change rows and the `+0 −0` commit summary. Listings that don't diff (all-files, at-revision) report 0.
- [x] **B3 — Unknown-icon fallback** (`icons.tsx`): renders a dashed placeholder square instead of a silent blank gap, and `console.warn`s once per name in dev.
- [x] **C1 — Deep-view back / breadcrumb + reload-guard** (latent bug): CommitDiff / FileHistory / Blame were dead ends (no back, broke on reload). Added `DeepViewHeader` (back + crumb) returning to the originating screen (tracked in `useNavStore.deepOrigin`), and a reload-guard so a persisted deep view falls back to Files.
- [x] **C2 — Bind ⌘O to Open**: the status bar advertised "⌘O to open…" but nothing was bound. Added a `repo.open` action (shared `openRepoDialog` op) bound to `⌘O` in both presets; routed the titlebar/Welcome open buttons through the same op.

## Verification

- `pnpm tsc --noEmit` — clean (root + `e2e/tsconfig.json`).
- `cargo check` / `cargo test` — clean; full Rust suite green, +4 new tests in `status_stats.rs` for B2.
- `pnpm exec vitest run` — 350/350 pass, +7 new tests in `tree.test.ts` for A1.
- e2e: relevant single-window specs exercised against a rebuilt snapshot; all selectors preserved (panes/testids/data-path unchanged).

## Notes

- Rebased onto latest `main` (picked up #25's `keyboard-shortcuts.e2e.ts` + e2e-feature port gating) — no conflicts.
- Overlap with #25: both touch `features/keymap` (I added `tree.find`/`repo.open` actions + `⌘⇧F`/`⌘O` bindings; #25 added keyboard-shortcut e2e coverage). No behavioral collision — #25's spec doesn't assert on my new chords, and my changes keep every pane/selector it relies on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
