### PR TITLE
fix(status): detect embedded git repos as data, not by path shape

### DIFF
--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -47,6 +47,9 @@ pub enum AppError {
 
     #[error("network error: {0}")]
     Network(String),
+
+    #[error("embedded repository: {0}")]
+    EmbeddedRepo(String),
 }
 
 impl From<git2::Error> for AppError {

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -321,6 +321,92 @@ enum StatusSide {
     Index,
 }
 
+// ─── Embedded (nested) repositories ──────────────────────────────────────────
+
+/// Drop the trailing separator libgit2 appends to directory status entries, so
+/// `vendor/lib/` and `vendor/lib` normalize to the same path. BOTH forms reach
+/// the backend: `status()` emits the slashed one, while the file-tree UI splits
+/// paths into segments and rebuilds the slashless one.
+fn strip_trailing_slash(path: &Path) -> PathBuf {
+    let s = path.to_string_lossy();
+    let trimmed = s.trim_end_matches(['/', '\\']);
+    PathBuf::from(trimmed)
+}
+
+/// True when `path` names a directory inside the worktree that is itself a git
+/// repository and is NOT a registered submodule.
+///
+/// Tests the actual condition — the path is opened as a repository — rather
+/// than guessing from the path's shape, because the trailing slash `status()`
+/// adds is lost before most call sites and a plain directory looks identical
+/// once it is gone.
+///
+/// It matters because libgit2 stops at the nested `.git` boundary: such a path
+/// has no diff (an empty one comes back, so the viewer shows a blank panel), no
+/// blame ("path does not exist in the given tree"), no file history (0 entries
+/// after a full revwalk), and — worst — `Index::add_path` accepts the slashless
+/// form and writes a bare `160000` gitlink with no `.gitmodules` entry, which
+/// no clone can resolve.
+///
+/// A registered submodule is deliberately excluded: its gitlink is intentional,
+/// and staging or diffing it is an ordinary submodule-pointer update that must
+/// keep working.
+fn is_embedded_repo(repo: &Repository, path: &Path) -> bool {
+    let Some(workdir) = repo.workdir() else {
+        return false;
+    };
+    let rel = strip_trailing_slash(path);
+    if rel.as_os_str().is_empty() {
+        return false;
+    }
+    // Never let a path escape the worktree (see `save_resolution` for the
+    // Windows driveless-root case that `is_absolute()` misses).
+    if rel.is_absolute()
+        || rel.components().any(|c| {
+            matches!(
+                c,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        return false;
+    }
+    let full = workdir.join(&rel);
+    if !full.is_dir() {
+        return false;
+    }
+    // `Repository::open` does not search parent directories, so a plain
+    // subdirectory of the outer repo fails here — only a real nested `.git`
+    // (directory or gitfile) succeeds.
+    if Repository::open(&full).is_err() {
+        return false;
+    }
+    !is_registered_submodule(repo, &rel)
+}
+
+/// True when `rel` is a submodule the repository actually declares, i.e. it has
+/// a `.gitmodules` entry with a URL.
+///
+/// `find_submodule` alone is not enough: libgit2 also reports a bare `160000`
+/// index entry as a submodule, and that bare gitlink is precisely the damage an
+/// accidental stage does. Only a `.gitmodules` URL makes the gitlink resolvable
+/// by a clone — without one it stays embedded, and the UI should keep saying so
+/// until the user either registers or ignores it.
+fn is_registered_submodule(repo: &Repository, rel: &Path) -> bool {
+    repo.find_submodule(&rel.to_string_lossy())
+        .ok()
+        .and_then(|sm| sm.url().map(|url| !url.is_empty()))
+        .unwrap_or(false)
+}
+
+/// `Err(AppError::EmbeddedRepo)` when `path` is an embedded repository.
+fn reject_embedded_repo(repo: &Repository, path: &Path) -> AppResult<()> {
+    if is_embedded_repo(repo, path) {
+        return Err(AppError::EmbeddedRepo(path.to_string_lossy().to_string()));
+    }
+    Ok(())
+}
+
 fn map_status_flag(s: Status, side: StatusSide) -> StatusFlag {
     match side {
         StatusSide::Worktree => {
@@ -840,12 +926,14 @@ impl GitBackend for Libgit2Backend {
                 let path = entry.path().unwrap_or("").to_string();
                 let s = entry.status();
                 let (additions, deletions) = stats.get(&path).copied().unwrap_or((0, 0));
+                let embedded = is_embedded_repo(repo, Path::new(&path));
                 out.push(FileStatus {
                     path,
                     worktree: map_status_flag(s, StatusSide::Worktree),
                     index: map_status_flag(s, StatusSide::Index),
                     additions,
                     deletions,
+                    embedded,
                 });
             }
             Ok(out)
@@ -867,6 +955,7 @@ impl GitBackend for Libgit2Backend {
                     continue;
                 }
                 let s = entry.status();
+                let embedded = is_embedded_repo(repo, Path::new(&path));
                 out.push(FileStatus {
                     path,
                     worktree: map_status_flag(s, StatusSide::Worktree),
@@ -875,6 +964,7 @@ impl GitBackend for Libgit2Backend {
                     // line stats — the tree shows status marks, not counts.
                     additions: 0,
                     deletions: 0,
+                    embedded,
                 });
             }
             Ok(out)
@@ -1080,6 +1170,9 @@ impl GitBackend for Libgit2Backend {
         context_lines: u32,
     ) -> AppResult<FileDiff> {
         self.with_repo(repo_id, |repo| {
+            // Without this the diff comes back valid but empty — a blank panel
+            // with no explanation. See `is_embedded_repo`.
+            reject_embedded_repo(repo, path)?;
             let mut opts = DiffOptions::new();
             opts.pathspec(path);
             opts.context_lines(context_lines);
@@ -1318,6 +1411,9 @@ impl GitBackend for Libgit2Backend {
                             index: StatusFlag::Unmodified,
                             additions: 0,
                             deletions: 0,
+                            // Blobs only — a committed tree never yields a
+                            // directory entry, embedded or otherwise.
+                            embedded: false,
                         });
                     }
                 }
@@ -1434,8 +1530,22 @@ impl GitBackend for Libgit2Backend {
 
     fn stage(&self, repo_id: &RepoId, paths: &[PathBuf]) -> AppResult<()> {
         self.with_repo(repo_id, |repo| {
+            // Embedded repos can't be staged (see `is_embedded_repo`), but a
+            // batch must not be all-or-nothing: "Stage all" passes every
+            // unstaged path, and rejecting the whole batch would leave the user
+            // unable to stage anything until they gitignore the nested repo.
+            // Skip them, stage the rest, and only error when nothing is left.
+            let (skipped, stageable): (Vec<&PathBuf>, Vec<&PathBuf>) =
+                paths.iter().partition(|p| is_embedded_repo(repo, p));
+            if stageable.is_empty() {
+                return match skipped.first() {
+                    Some(p) => Err(AppError::EmbeddedRepo(p.to_string_lossy().to_string())),
+                    // Empty batch — nothing asked for, nothing refused.
+                    None => Ok(()),
+                };
+            }
             let mut index = repo.index()?;
-            for p in paths {
+            for p in stageable {
                 // `add_path` treats paths as repo-relative; it handles creates and modifications.
                 // For deletions from the worktree, we need `remove_path` instead.
                 if repo.workdir().map(|w| w.join(p).exists()).unwrap_or(false) {
@@ -2466,6 +2576,9 @@ impl GitBackend for Libgit2Backend {
         limit: usize,
     ) -> AppResult<Vec<CommitInfo>> {
         self.with_repo(repo_id, |repo| {
+            // Without this the walk runs to completion and returns 0 commits —
+            // indistinguishable from a file that genuinely has no history.
+            reject_embedded_repo(repo, path)?;
             let mut revwalk = repo.revwalk()?;
             revwalk.push_head().or_else(|e| {
                 if e.code() == git2::ErrorCode::UnbornBranch {
@@ -2515,6 +2628,9 @@ impl GitBackend for Libgit2Backend {
 
     fn blame_file(&self, repo_id: &RepoId, path: &Path) -> AppResult<Vec<BlameLine>> {
         self.with_repo(repo_id, |repo| {
+            // Without this libgit2 answers with a cryptic
+            // "path 'vendor' does not exist in the given tree".
+            reject_embedded_repo(repo, path)?;
             let mut opts = git2::BlameOptions::new();
             let blame = repo.blame_file(path, Some(&mut opts))?;
 

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -38,6 +38,15 @@ pub struct FileStatus {
     pub additions: u32,
     /// Lines removed in this file vs HEAD (working tree + index combined).
     pub deletions: u32,
+    /// True when this entry is a directory that is itself a git repository and
+    /// is not a registered submodule (a vendored dependency, a stray clone).
+    /// libgit2 refuses to recurse across the nested `.git` boundary, so it
+    /// reports the directory as ONE entry — with a trailing slash — instead of
+    /// its files. Such an entry has no diff, no blame and no history, and
+    /// staging it writes a bare gitlink no clone can resolve, so the UI has to
+    /// treat the row as its own thing rather than as a file. Always false for
+    /// ordinary files and for registered submodules.
+    pub embedded: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src-tauri/tests/embedded_repo.rs
+++ b/src-tauri/tests/embedded_repo.rs
@@ -1,0 +1,358 @@
+//! An untracked directory that is itself a git repository — a dependency
+//! vendored with its own `.git`, a stray clone, a submodule someone forgot to
+//! register — is not a file, and libgit2 will not recurse across its `.git`
+//! boundary. It surfaces in status as a single entry with a trailing slash
+//! (`vendor/lib/`), the UI rebuilds the same path without the slash, and every
+//! file-shaped operation then either lies or corrupts:
+//!
+//! - `diff`         → a valid but empty FileDiff (blank panel, no error)
+//! - `file_history` → 0 commits after a full revwalk (looks like "no history")
+//! - `blame_file`   → "the path 'vendor' does not exist in the given tree"
+//! - `stage`        → "invalid path" for the slashed form, and for the
+//!                    SLASHLESS form a silent `160000` gitlink with no
+//!                    `.gitmodules` entry, which no clone can resolve
+//!
+//! These tests pin the detection (real repo probe, not a trailing-slash guess),
+//! the guards, and the batch semantics that keep "Stage all" usable.
+
+mod support;
+
+use std::path::{Path, PathBuf};
+
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::types::DiffKind;
+use platypusgit_lib::git::GitBackend;
+
+use support::TempRepo;
+
+/// Create an untracked nested repository at `vendor/lib` **with a commit**.
+///
+/// The commit is the whole point: a nested repo with an unborn HEAD makes
+/// `stage("vendor/lib")` fail on its own ("reference 'refs/heads/master' not
+/// found"), which hides the dangerous case. A real vendored dependency always
+/// has commits, and that is exactly when staging succeeds and writes a gitlink.
+fn make_embedded_repo(tr: &TempRepo) {
+    let nested_dir = tr.path().join("vendor/lib");
+    std::fs::create_dir_all(&nested_dir).unwrap();
+    let nested = git2::Repository::init(&nested_dir).unwrap();
+    std::fs::write(nested_dir.join("file.txt"), "vendored\n").unwrap();
+    let mut index = nested.index().unwrap();
+    index.add_path(Path::new("file.txt")).unwrap();
+    index.write().unwrap();
+    let tree_oid = index.write_tree().unwrap();
+    let tree = nested.find_tree(tree_oid).unwrap();
+    let sig = git2::Signature::now("Vendor", "vendor@example.com").unwrap();
+    nested
+        .commit(Some("HEAD"), &sig, &sig, "vendored code", &tree, &[])
+        .unwrap();
+}
+
+/// Index entries as `(octal mode, path)` pairs, read straight from disk.
+fn index_entries(tr: &TempRepo) -> Vec<(u32, String)> {
+    let repo = git2::Repository::open(tr.path()).unwrap();
+    let index = repo.index().unwrap();
+    index
+        .iter()
+        .map(|e| (e.mode, String::from_utf8_lossy(&e.path).to_string()))
+        .collect()
+}
+
+/// No gitlink may reach the index — that is the corruption we are preventing.
+fn assert_no_gitlink(tr: &TempRepo) {
+    let entries = index_entries(tr);
+    assert!(
+        !entries.iter().any(|(mode, _)| *mode == 0o160000),
+        "a 160000 gitlink reached the index: {entries:?}",
+    );
+}
+
+// ─── Detection ───────────────────────────────────────────────────────────────
+
+#[test]
+fn status_flags_the_embedded_repo_and_nothing_else() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    make_embedded_repo(&tr);
+    // A plain untracked directory — same shape, no `.git`. Must NOT be flagged.
+    std::fs::create_dir_all(tr.path().join("plaindir")).unwrap();
+    std::fs::write(tr.path().join("plaindir/a.txt"), "a\n").unwrap();
+
+    let statuses = backend.status(&handle.id).unwrap();
+
+    let embedded = statuses
+        .iter()
+        .find(|s| s.embedded)
+        .expect("embedded entry should be flagged");
+    assert_eq!(embedded.path, "vendor/lib/");
+
+    // libgit2 recurses into the plain directory, so it shows up as its file.
+    let plain = statuses
+        .iter()
+        .find(|s| s.path == "plaindir/a.txt")
+        .expect("plain directory should be recursed into");
+    assert!(!plain.embedded);
+
+    assert_eq!(statuses.iter().filter(|s| s.embedded).count(), 1);
+}
+
+#[test]
+fn list_all_files_flags_the_embedded_repo_too() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    make_embedded_repo(&tr);
+
+    let all = backend.list_all_files(&handle.id).unwrap();
+
+    assert!(all.iter().any(|s| s.path == "vendor/lib/" && s.embedded));
+    assert!(all.iter().any(|s| s.path == "README.md" && !s.embedded));
+}
+
+#[test]
+fn a_registered_submodule_is_not_treated_as_embedded() {
+    // A submodule's gitlink is intentional: staging and diffing it is a normal
+    // pointer update and must keep working, even though the directory is a
+    // repository of its own.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let sub_dir = tr.path().join("sub");
+    std::fs::create_dir_all(&sub_dir).unwrap();
+    let sub = git2::Repository::init(&sub_dir).unwrap();
+    std::fs::write(sub_dir.join("file.txt"), "one\n").unwrap();
+    let mut sub_index = sub.index().unwrap();
+    sub_index.add_path(Path::new("file.txt")).unwrap();
+    sub_index.write().unwrap();
+    let sub_tree = sub_index.write_tree().unwrap();
+    let sub_tree = sub.find_tree(sub_tree).unwrap();
+    let sig = git2::Signature::now("Vendor", "vendor@example.com").unwrap();
+    let first = sub
+        .commit(Some("HEAD"), &sig, &sig, "one", &sub_tree, &[])
+        .unwrap();
+
+    // Register it: gitlink in the index + a `.gitmodules` entry, then commit.
+    {
+        let repo = git2::Repository::open(tr.path()).unwrap();
+        let mut index = repo.index().unwrap();
+        index
+            .add(&git2::IndexEntry {
+                ctime: git2::IndexTime::new(0, 0),
+                mtime: git2::IndexTime::new(0, 0),
+                dev: 0,
+                ino: 0,
+                mode: 0o160000,
+                uid: 0,
+                gid: 0,
+                file_size: 0,
+                id: first,
+                flags: 0,
+                flags_extended: 0,
+                path: b"sub".to_vec(),
+            })
+            .unwrap();
+        std::fs::write(
+            tr.path().join(".gitmodules"),
+            "[submodule \"sub\"]\n\tpath = sub\n\turl = ./sub\n",
+        )
+        .unwrap();
+        index.add_path(Path::new(".gitmodules")).unwrap();
+        index.write().unwrap();
+    }
+    tr.commit_all("add submodule");
+
+    // Move the submodule's HEAD so the parent sees a pointer change.
+    let second = {
+        std::fs::write(sub_dir.join("file.txt"), "two\n").unwrap();
+        let mut sub_index = sub.index().unwrap();
+        sub_index.add_path(Path::new("file.txt")).unwrap();
+        sub_index.write().unwrap();
+        let tree = sub_index.write_tree().unwrap();
+        let tree = sub.find_tree(tree).unwrap();
+        let head = sub.head().unwrap().peel_to_commit().unwrap();
+        sub.commit(Some("HEAD"), &sig, &sig, "two", &tree, &[&head])
+            .unwrap()
+    };
+
+    let statuses = backend.status(&handle.id).unwrap();
+    let entry = statuses
+        .iter()
+        .find(|s| s.path == "sub")
+        .expect("submodule pointer change should show in status");
+    assert!(!entry.embedded, "a registered submodule is not embedded");
+
+    // The whole point: the pointer update still stages.
+    backend
+        .stage(&handle.id, &[PathBuf::from("sub")])
+        .expect("staging a submodule pointer update must keep working");
+    assert!(index_entries(&tr)
+        .iter()
+        .any(|(mode, path)| *mode == 0o160000 && path == "sub"));
+    let repo = git2::Repository::open(tr.path()).unwrap();
+    let staged_id = repo.index().unwrap().get_path(Path::new("sub"), 0).unwrap().id;
+    assert_eq!(staged_id, second, "gitlink should advance to the new commit");
+}
+
+// ─── Guards ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn stage_rejects_both_the_slashed_and_slashless_forms() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    make_embedded_repo(&tr);
+
+    // The form `status()` reports.
+    let err = backend
+        .stage(&handle.id, &[PathBuf::from("vendor/lib/")])
+        .unwrap_err();
+    assert!(matches!(err, AppError::EmbeddedRepo(p) if p == "vendor/lib/"));
+
+    // The form the file tree rebuilds — this one used to succeed silently.
+    let err = backend
+        .stage(&handle.id, &[PathBuf::from("vendor/lib")])
+        .unwrap_err();
+    assert!(matches!(err, AppError::EmbeddedRepo(p) if p == "vendor/lib"));
+
+    assert_no_gitlink(&tr);
+}
+
+#[test]
+fn diff_rejects_the_embedded_repo_instead_of_returning_an_empty_diff() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    make_embedded_repo(&tr);
+
+    for path in ["vendor/lib/", "vendor/lib"] {
+        let err = backend
+            .diff(&handle.id, &PathBuf::from(path), DiffKind::WorktreeToHead, 3)
+            .unwrap_err();
+        assert!(matches!(err, AppError::EmbeddedRepo(p) if p == path));
+    }
+}
+
+#[test]
+fn blame_rejects_the_embedded_repo() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    make_embedded_repo(&tr);
+
+    for path in ["vendor/lib/", "vendor/lib"] {
+        let err = backend.blame_file(&handle.id, &PathBuf::from(path)).unwrap_err();
+        assert!(matches!(err, AppError::EmbeddedRepo(p) if p == path));
+    }
+}
+
+#[test]
+fn file_history_rejects_the_embedded_repo_instead_of_returning_nothing() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    make_embedded_repo(&tr);
+
+    for path in ["vendor/lib/", "vendor/lib"] {
+        let err = backend
+            .file_history(&handle.id, &PathBuf::from(path), 50)
+            .unwrap_err();
+        assert!(matches!(err, AppError::EmbeddedRepo(p) if p == path));
+    }
+}
+
+#[test]
+fn guards_leave_ordinary_paths_alone() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    make_embedded_repo(&tr);
+    support::fs::write_file(tr.path(), "README.md", "hello\nworld\n");
+
+    let readme = PathBuf::from("README.md");
+    assert!(backend
+        .diff(&handle.id, &readme, DiffKind::WorktreeToHead, 3)
+        .is_ok());
+    assert!(backend.blame_file(&handle.id, &readme).is_ok());
+    assert_eq!(
+        backend.file_history(&handle.id, &readme, 50).unwrap().len(),
+        1
+    );
+    assert!(backend.stage(&handle.id, &[readme]).is_ok());
+}
+
+// ─── Batch semantics ─────────────────────────────────────────────────────────
+
+#[test]
+fn a_mixed_batch_stages_the_rest_and_skips_the_embedded_repo() {
+    // "Stage all" hands over every unstaged path verbatim, trailing slash
+    // included. One vendored repo must not block the whole batch.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    make_embedded_repo(&tr);
+    support::fs::write_file(tr.path(), "a.txt", "a\n");
+    support::fs::write_file(tr.path(), "b.txt", "b\n");
+
+    backend
+        .stage(
+            &handle.id,
+            &[
+                PathBuf::from("a.txt"),
+                PathBuf::from("vendor/lib/"),
+                PathBuf::from("b.txt"),
+            ],
+        )
+        .expect("the non-embedded paths should still stage");
+
+    let entries = index_entries(&tr);
+    let paths: Vec<&str> = entries.iter().map(|(_, p)| p.as_str()).collect();
+    assert!(paths.contains(&"a.txt"));
+    assert!(paths.contains(&"b.txt"));
+    assert!(!paths.iter().any(|p| p.starts_with("vendor/")));
+    assert_no_gitlink(&tr);
+}
+
+#[test]
+fn an_all_embedded_batch_errors() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    make_embedded_repo(&tr);
+
+    let err = backend
+        .stage(
+            &handle.id,
+            &[PathBuf::from("vendor/lib/"), PathBuf::from("vendor/lib")],
+        )
+        .unwrap_err();
+    assert!(matches!(err, AppError::EmbeddedRepo(_)));
+    assert_no_gitlink(&tr);
+}
+
+// ─── Recovery ────────────────────────────────────────────────────────────────
+
+#[test]
+fn unstage_still_removes_an_already_committed_gitlink() {
+    // `unstage` is deliberately NOT guarded: once a gitlink is in the index
+    // (staged by an older build, or by the command line), unstaging it is the
+    // only way back — a guard there would trap the user.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    make_embedded_repo(&tr);
+
+    // Plant the gitlink the way a pre-fix build would have.
+    {
+        let repo = git2::Repository::open(tr.path()).unwrap();
+        let mut index = repo.index().unwrap();
+        index.add_path(Path::new("vendor/lib")).unwrap();
+        index.write().unwrap();
+    }
+    assert!(index_entries(&tr)
+        .iter()
+        .any(|(mode, path)| *mode == 0o160000 && path == "vendor/lib"));
+
+    // Status now reports it slashless and staged — and still flags it embedded.
+    let entry = backend
+        .status(&handle.id)
+        .unwrap()
+        .into_iter()
+        .find(|s| s.path == "vendor/lib")
+        .expect("staged gitlink should show in status");
+    assert!(entry.embedded);
+
+    backend
+        .unstage(&handle.id, &[PathBuf::from("vendor/lib")])
+        .expect("unstage must stay available as the escape hatch");
+    assert_no_gitlink(&tr);
+}

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -47,7 +47,7 @@ import { UpdateChip } from "@/features/update/UpdateChip";
 import { UpdatePanel } from "@/features/update/UpdatePanel";
 import { useUpdateStore } from "@/features/update/useUpdateStore";
 import { BranchPicker } from "@/features/branches/BranchPicker";
-import { appErrorMessage } from "@/lib/errors";
+import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
 import {
   currentBranch,
   isStaged,
@@ -267,8 +267,16 @@ export function AppShell() {
             gap: 8,
           }}
         >
-          <strong>{error.kind}:</strong>
-          <span style={{ flex: 1 }}>{appErrorMessage(error)}</span>
+          {/* The backend keeps EmbeddedRepo terse like the rest of the enum;
+              the actionable half of the story lives in the UI. */}
+          <strong>
+            {error.kind === "EmbeddedRepo" ? "Embedded repository" : error.kind}:
+          </strong>
+          <span style={{ flex: 1 }}>
+            {error.kind === "EmbeddedRepo"
+              ? `${appErrorMessage(error).replace(/^embedded repository: /, "")} — ${EMBEDDED_REPO_HELP}`
+              : appErrorMessage(error)}
+          </span>
           <button
             onClick={clearError}
             style={{

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -223,6 +223,7 @@ export function PGContextMenu({
     <>
       <div
         ref={ref}
+        data-pg-menu=""
         style={menuStyle}
         onContextMenu={(e) => e.preventDefault()}
       >
@@ -873,11 +874,48 @@ export function tagMenuItems(
   ];
 }
 
+/**
+ * Menu for a row that is an embedded git repository (see FileStatus.embedded).
+ *
+ * git itself allows `git add vendor/lib` and prints an actionable warning, so a
+ * hard block with no way forward would be worse UX than the CLI. Lead with the
+ * remedy — "Add to .gitignore" is a one-liner because `appendGitignore` takes
+ * the path verbatim and libgit2 reports it with the trailing slash, which is
+ * exactly gitignore's directory syntax.
+ */
+function embeddedRepoMenuItems(path: string): ContextMenuItem[] {
+  return [
+    { __menuTitle: path || "folder" },
+    { icon: "info", label: "Embedded git repository", disabled: true },
+    {
+      icon: "trash",
+      label: "Add to .gitignore",
+      onClick: () => {
+        if (path) useRepoStore.getState().appendGitignore(path);
+      },
+    },
+    { divider: true },
+    {
+      icon: "edit",
+      label: "Open in editor",
+      onClick: () => {
+        if (path) useRepoStore.getState().openInEditor(path);
+      },
+    },
+    {
+      icon: "copy",
+      label: "Copy path",
+      onClick: () => navigator.clipboard?.writeText(path),
+    },
+  ];
+}
+
 export function fileMenuItems(
-  file: { path?: string; staged?: boolean } | null,
+  file: { path?: string; staged?: boolean; embedded?: boolean } | null,
 ): ContextMenuItem[] {
   const staged = !!file?.staged;
   const path = file?.path || "";
+  if (file?.embedded) return embeddedRepoMenuItems(path);
   return [
     { __menuTitle: path || "file" },
     staged
@@ -974,6 +1012,12 @@ export interface MultiFileMenuSelection {
    * Drives the count and Copy paths. Defaults to staged ∪ unstaged.
    */
   paths?: string[];
+  /**
+   * Selected paths that are embedded git repositories. Kept out of
+   * staged/unstaged so Stage and Discard act only on real files, and offered
+   * their own remedy instead.
+   */
+  embeddedPaths?: string[];
 }
 
 /**
@@ -986,10 +1030,23 @@ export function multiFileMenuItems(
 ): ContextMenuItem[] {
   const stagedPaths = sel?.stagedPaths ?? [];
   const unstagedPaths = sel?.unstagedPaths ?? [];
+  const embeddedPaths = sel?.embeddedPaths ?? [];
   const all = sel?.paths ?? [...stagedPaths, ...unstagedPaths];
   const n = all.length;
   const files = (c: number) => `${c} file${c === 1 ? "" : "s"}`;
   const items: ContextMenuItem[] = [{ __menuTitle: `${files(n)} selected` }];
+  if (embeddedPaths.length) {
+    items.push({
+      icon: "trash",
+      label: `Add ${embeddedPaths.length} embedded repo${
+        embeddedPaths.length === 1 ? "" : "s"
+      } to .gitignore`,
+      onClick: () => {
+        const store = useRepoStore.getState();
+        for (const p of embeddedPaths) void store.appendGitignore(p);
+      },
+    });
+  }
   if (unstagedPaths.length) {
     items.push({
       icon: "plus",

--- a/src/design/primitives.tsx
+++ b/src/design/primitives.tsx
@@ -778,19 +778,25 @@ export function PGStatusMark({
   kind: string;
   size?: number;
 }) {
-  const map: Record<string, { c: string; label: string }> = {
-    M: { c: "var(--git-modified)", label: "M" },
-    A: { c: "var(--git-added)", label: "A" },
-    D: { c: "var(--git-removed)", label: "D" },
-    R: { c: "var(--git-renamed)", label: "R" },
-    "?": { c: "var(--git-untracked)", label: "?" },
-    U: { c: "var(--git-conflict)", label: "U" },
-    C: { c: "var(--git-conflict)", label: "C" },
-    I: { c: "var(--git-ignored)", label: "I" },
+  const map: Record<string, { c: string; label: string; title: string }> = {
+    M: { c: "var(--git-modified)", label: "M", title: "Modified" },
+    A: { c: "var(--git-added)", label: "A", title: "Added" },
+    D: { c: "var(--git-removed)", label: "D", title: "Deleted" },
+    R: { c: "var(--git-renamed)", label: "R", title: "Renamed" },
+    "?": { c: "var(--git-untracked)", label: "?", title: "Untracked" },
+    U: { c: "var(--git-conflict)", label: "U", title: "Conflicted" },
+    C: { c: "var(--git-conflict)", label: "C", title: "Conflicted" },
+    I: { c: "var(--git-ignored)", label: "I", title: "Ignored" },
+    S: {
+      c: "var(--git-renamed)",
+      label: "S",
+      title: "Embedded git repository — can't be staged as a file",
+    },
   };
   const v = map[kind] || map.M;
   return (
     <span
+      title={v.title}
       style={{
         width: size,
         height: size,

--- a/src/features/repo/ops.test.ts
+++ b/src/features/repo/ops.test.ts
@@ -23,6 +23,15 @@ const unstaged = (path: string): FileStatus => ({
   deletions: 0,
   embedded: false,
 });
+/** An untracked dir that is its own git repo — reported with a trailing slash. */
+const embedded = (path: string): FileStatus => ({
+  path,
+  worktree: { kind: "Untracked" },
+  index: { kind: "Unmodified" },
+  additions: 0,
+  deletions: 0,
+  embedded: true,
+});
 
 describe("stageAllOp / unstageAllOp", () => {
   const stageCalls: string[][] = [];
@@ -59,6 +68,22 @@ describe("stageAllOp / unstageAllOp", () => {
     expect(unstageAllOp()).toBe(false);
     expect(stageCalls).toEqual([]);
     expect(unstageCalls).toEqual([]);
+  });
+
+  it("stageAllOp skips embedded git repos but still stages the rest", () => {
+    // Stage-all used to pass status() paths verbatim, so one vendored repo made
+    // the whole batch fail — the user could stage nothing until they ignored it.
+    useRepoStore.setState({
+      status: [unstaged("b.ts"), embedded("vendor/lib/")],
+    } as never);
+    expect(stageAllOp()).toBe(true);
+    expect(stageCalls).toEqual([["b.ts"]]);
+  });
+
+  it("stageAllOp declines when every unstaged entry is an embedded repo", () => {
+    useRepoStore.setState({ status: [embedded("vendor/lib/")] } as never);
+    expect(stageAllOp()).toBe(false);
+    expect(stageCalls).toEqual([]);
   });
 
   it("declines when there is nothing to move", () => {

--- a/src/features/repo/ops.test.ts
+++ b/src/features/repo/ops.test.ts
@@ -13,6 +13,7 @@ const staged = (path: string): FileStatus => ({
   index: { kind: "Modified" },
   additions: 0,
   deletions: 0,
+  embedded: false,
 });
 const unstaged = (path: string): FileStatus => ({
   path,
@@ -20,6 +21,7 @@ const unstaged = (path: string): FileStatus => ({
   index: { kind: "Unmodified" },
   additions: 0,
   deletions: 0,
+  embedded: false,
 });
 
 describe("stageAllOp / unstageAllOp", () => {

--- a/src/features/repo/ops.ts
+++ b/src/features/repo/ops.ts
@@ -7,6 +7,7 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { pgFlash } from "@/design";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { currentBranch, isStaged, isUnstaged } from "@/lib/derive";
+import type { FileStatus } from "@/lib/types";
 import { useRepoStore } from "./useRepoStore";
 
 /** Derive the [remote, branch] pair from the HEAD branch's upstream tracking ref. */
@@ -46,10 +47,30 @@ export function fetchAllOp(): boolean {
   return true;
 }
 
+/**
+ * Paths to stage from a change list: every unstaged entry except embedded git
+ * repositories, which cannot be staged as files (see FileStatus.embedded).
+ * Flashes once when something was left out, so the count silently shrinking
+ * doesn't look like a bug. The backend skips them too — this is so the user
+ * hears about it.
+ */
+export function stageablePaths(files: FileStatus[]): string[] {
+  const unstaged = files.filter(isUnstaged);
+  const embedded = unstaged.filter((f) => f.embedded);
+  if (embedded.length > 0) {
+    pgFlash(
+      `Skipped ${embedded.length} embedded git ${
+        embedded.length === 1 ? "repository" : "repositories"
+      } — add to .gitignore or register as a submodule`,
+    );
+  }
+  return unstaged.filter((f) => !f.embedded).map((f) => f.path);
+}
+
 export function stageAllOp(): boolean {
   const repo = useRepoStore.getState();
   if (!repo.current) return false;
-  const paths = repo.status.filter(isUnstaged).map((f) => f.path);
+  const paths = stageablePaths(repo.status);
   if (paths.length === 0) return false;
   void repo.stage(paths);
   return true;

--- a/src/lib/derive.ts
+++ b/src/lib/derive.ts
@@ -38,9 +38,16 @@ export function isUnstaged(s: FileStatus): boolean {
 
 /**
  * One-character status mark for UI (matches the PGStatusMark kinds).
- * Priority: conflicted > index side > worktree side.
+ * Priority: embedded repo > conflicted > index side > worktree side.
+ *
+ * An embedded repository outranks its change flags because it is not a file at
+ * all: "?" would invite the user to stage it, and staging is exactly what must
+ * not happen (see FileStatus.embedded).
  */
-export function statusMark(s: FileStatus): "M" | "A" | "D" | "R" | "?" | "U" | "I" {
+export function statusMark(
+  s: FileStatus,
+): "M" | "A" | "D" | "R" | "?" | "U" | "I" | "S" {
+  if (s.embedded) return "S";
   if (s.worktree.kind === "Conflicted" || s.index.kind === "Conflicted") return "U";
   const primary: StatusFlag =
     s.index.kind !== "Unmodified" ? s.index : s.worktree;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -13,7 +13,8 @@ export type AppError =
   | { kind: "ConflictsDetected"; message: string }
   | { kind: "NoSignature"; message?: string }
   | { kind: "Internal"; message: string }
-  | { kind: "Network"; message: string };
+  | { kind: "Network"; message: string }
+  | { kind: "EmbeddedRepo"; message: string };
 
 export function isAppError(e: unknown): e is AppError {
   return (
@@ -31,3 +32,15 @@ export function appErrorMessage(e: unknown): string {
   if (e instanceof Error) return e.message;
   return String(e);
 }
+
+export function isEmbeddedRepoError(e: unknown): boolean {
+  return isAppError(e) && e.kind === "EmbeddedRepo";
+}
+
+/**
+ * What to tell the user about an embedded repository. The backend error stays
+ * terse (`embedded repository: vendor/lib/`) like the rest of the enum —
+ * remediation prose belongs here, next to the UI that can act on it.
+ */
+export const EMBEDDED_REPO_HELP =
+  "This folder is a git repository of its own, so git can only record it as a bare pointer that nobody who clones this repo can resolve. Add it to .gitignore, or register it as a submodule.";

--- a/src/lib/tree.test.ts
+++ b/src/lib/tree.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { buildStatusTree } from "./tree";
+import type { PGFileTreeNode } from "@/design";
+import {
+  buildStatusTree,
+  findStatusByPath,
+  findStatusByTreeKey,
+  treeKeyToPath,
+} from "./tree";
 import type { FileStatus, StatusFlag } from "./types";
 
 function file(path: string, worktree: StatusFlag["kind"] = "Modified"): FileStatus {
@@ -87,5 +93,57 @@ describe("buildStatusTree — path compaction (A1)", () => {
   it("expands the first level of the compacted tree by default", () => {
     const tree = buildStatusTree([file("src/features/repo/store.ts")]);
     expect(tree[0].defaultExpanded).toBe(true);
+  });
+});
+
+/** Row keys exactly as PGFileTree/flattenFileTree builds them: parent + "/" + name. */
+function treeKeys(nodes: PGFileTreeNode[], parentKey = ""): string[] {
+  return nodes.flatMap((n) => {
+    const key = `${parentKey}/${n.name}`;
+    return [key, ...(n.children ? treeKeys(n.children, key) : [])];
+  });
+}
+
+describe("resolving a tree row key back to its FileStatus", () => {
+  // libgit2 reports an untracked directory that is itself a git repo as ONE
+  // entry with a trailing slash, because it won't recurse across the nested
+  // .git. buildStatusTree drops that slash when it splits on "/", so the row
+  // key is "/vendor/lib" while FileStatus.path is "vendor/lib/". An exact
+  // match can never find it — and the call sites that missed used to hand the
+  // slashless path straight to stage(), which wrote a silent gitlink.
+  const embedded: FileStatus = {
+    ...file("vendor/lib/", "Untracked"),
+    embedded: true,
+  };
+  const normal = file("src/main.ts");
+  const files = [normal, embedded];
+
+  it("resolves an embedded-repo entry through the key the tree actually builds", () => {
+    const keys = treeKeys(buildStatusTree(files));
+    expect(keys).toContain("/vendor/lib");
+
+    expect(findStatusByTreeKey("/vendor/lib", files)).toBe(embedded);
+  });
+
+  it("still resolves an ordinary path", () => {
+    const keys = treeKeys(buildStatusTree(files));
+    expect(keys).toContain("/src/main.ts");
+
+    expect(findStatusByTreeKey("/src/main.ts", files)).toBe(normal);
+  });
+
+  it("searches lists in order and returns undefined when nothing matches", () => {
+    expect(findStatusByTreeKey("/vendor", files)).toBeUndefined();
+    expect(findStatusByTreeKey("/src/main.ts", [], files)).toBe(normal);
+  });
+
+  it("does not confuse a folder prefix with the embedded entry", () => {
+    // "vendor" is the parent folder row, not the embedded repo itself.
+    expect(findStatusByPath(files, "vendor")).toBeUndefined();
+  });
+
+  it("strips the leading slash the tree keys carry", () => {
+    expect(treeKeyToPath("/a/b/c")).toBe("a/b/c");
+    expect(treeKeyToPath("a/b")).toBe("a/b");
   });
 });

--- a/src/lib/tree.test.ts
+++ b/src/lib/tree.test.ts
@@ -9,6 +9,7 @@ function file(path: string, worktree: StatusFlag["kind"] = "Modified"): FileStat
     index: { kind: "Unmodified" },
     additions: 0,
     deletions: 0,
+    embedded: false,
   };
 }
 

--- a/src/lib/tree.ts
+++ b/src/lib/tree.ts
@@ -91,3 +91,43 @@ export function buildStatusTree(
 
   return children as PGFileTreeNode[];
 }
+
+/**
+ * Repo-relative path for a PGFileTree row key. Keys are built by joining node
+ * names with "/" from an empty root, so they carry a leading slash: "/a/b".
+ */
+export function treeKeyToPath(key: string): string {
+  return key.replace(/^\//, "");
+}
+
+/**
+ * Find the FileStatus for a repo-relative path, tolerating the trailing slash
+ * libgit2 puts on an embedded-repo entry.
+ *
+ * {@link buildStatusTree} splits paths on "/" and drops empty segments, so
+ * `vendor/lib/` becomes the key "/vendor/lib" and an exact `s.path === path`
+ * lookup can never match it back. Every call site that maps a row key to its
+ * status must go through here, or they disagree about the same row: the ones
+ * that miss treat an embedded repo as an ordinary file (and used to stage it as
+ * a gitlink), while the ones that hit correctly refuse.
+ */
+export function findStatusByPath<T extends { path: string }>(
+  files: readonly T[],
+  path: string,
+): T | undefined {
+  const withSlash = `${path}/`;
+  return files.find((f) => f.path === path || f.path === withSlash);
+}
+
+/** {@link findStatusByPath} for a PGFileTree row key, across several lists. */
+export function findStatusByTreeKey<T extends { path: string }>(
+  key: string,
+  ...lists: readonly (readonly T[])[]
+): T | undefined {
+  const path = treeKeyToPath(key);
+  for (const list of lists) {
+    const hit = findStatusByPath(list, path);
+    if (hit) return hit;
+  }
+  return undefined;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -26,6 +26,16 @@ export interface FileStatus {
   additions: number;
   /** Lines removed vs HEAD (worktree + index). */
   deletions: number;
+  /**
+   * True when this entry is a directory that is itself a git repository and is
+   * not a registered submodule (vendored dependency, stray clone, submodule
+   * nobody registered). libgit2 will not recurse across the nested `.git`, so
+   * it reports the directory as ONE entry — with a trailing slash — instead of
+   * its files. Such a row has no diff, no blame and no history, and staging it
+   * would write a bare gitlink no clone can resolve, so the UI treats it as its
+   * own kind of thing rather than as a file.
+   */
+  embedded: boolean;
 }
 
 export interface CommitInfo {

--- a/src/screens/CommitPanel.keyboard.test.tsx
+++ b/src/screens/CommitPanel.keyboard.test.tsx
@@ -15,6 +15,7 @@ const staged = (path: string): FileStatus => ({
   index: { kind: "Modified" },
   additions: 0,
   deletions: 0,
+  embedded: false,
 });
 const unstaged = (path: string): FileStatus => ({
   path,
@@ -22,6 +23,7 @@ const unstaged = (path: string): FileStatus => ({
   index: { kind: "Unmodified" },
   additions: 0,
   deletions: 0,
+  embedded: false,
 });
 
 const key = (k: string, over: Partial<KeyboardEvent> = {}) =>

--- a/src/screens/CommitPanel.test.tsx
+++ b/src/screens/CommitPanel.test.tsx
@@ -19,6 +19,7 @@ function modified(path: string): FileStatus {
     index: { kind: "Unmodified" },
     additions: 0,
     deletions: 0,
+    embedded: false,
   };
 }
 
@@ -29,6 +30,7 @@ function stagedFile(path: string): FileStatus {
     index: { kind: "Modified" },
     additions: 0,
     deletions: 0,
+    embedded: false,
   };
 }
 

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -27,7 +27,9 @@ import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { PGPane, FocusableScroll, usePaneList, useAction } from "@/features/keymap";
+import { stageablePaths } from "@/features/repo/ops";
 import { currentBranch, isStaged, isUnstaged, statusMark } from "@/lib/derive";
+import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
 import {
   clickSelection,
   emptySelection,
@@ -89,6 +91,7 @@ export function CommitPanelScreen() {
       return fileMenuItems({
         path: f?.path,
         staged: f?.side === "staged",
+        embedded: f?.status.embedded,
       });
     },
   );
@@ -231,6 +234,15 @@ export function CommitPanelScreen() {
     return [f.path];
   };
 
+  /** Stage the row's toggle target, unless it is an embedded repo. */
+  const stageToggled = (f: FileSlot) => {
+    if (f.status.embedded) {
+      pgFlash(EMBEDDED_REPO_HELP);
+      return;
+    }
+    stage(togglePaths(f));
+  };
+
   const primaryKey = primarySelectedKey(sel);
   const selected = React.useMemo(() => {
     if (!primaryKey) return unstaged[0] ?? staged[0] ?? null;
@@ -256,15 +268,23 @@ export function CommitPanelScreen() {
     }
     const kind: DiffKind =
       selected.side === "staged" ? "IndexToHead" : "WorktreeToIndex";
+    setDiffError(null);
+    // An embedded repo has no diff — say what the row is instead of asking for
+    // one and rendering the backend's terse refusal.
+    if (selected.status.embedded) {
+      setDiff(null);
+      setDiffLoading(false);
+      setDiffError(`${selected.path} — ${EMBEDDED_REPO_HELP}`);
+      return;
+    }
     let cancelled = false;
     setDiffLoading(true);
-    setDiffError(null);
     getDiff(repo.id, selected.path, kind, diffContextLines)
       .then((d) => {
         if (!cancelled) setDiff(d);
       })
       .catch((e) => {
-        if (!cancelled) setDiffError(String(e?.message ?? e));
+        if (!cancelled) setDiffError(appErrorMessage(e));
       })
       .finally(() => {
         if (!cancelled) setDiffLoading(false);
@@ -272,7 +292,7 @@ export function CommitPanelScreen() {
     return () => {
       cancelled = true;
     };
-  }, [selected?.path, selected?.side, repo, diffContextLines]);
+  }, [selected?.path, selected?.side, selected?.status.embedded, repo, diffContextLines]);
 
   const headBranch = currentBranch(branches);
   const defaultRemote = remotes[0] ?? null;
@@ -306,7 +326,7 @@ export function CommitPanelScreen() {
       if (!f) return;
       // Space acts on the whole multi-selection when the row is part of it.
       if (f.side === "staged") unstage(togglePaths(f));
-      else stage(togglePaths(f));
+      else stageToggled(f);
     },
     searchText: (i) => combined[i]?.path ?? "",
   });
@@ -452,7 +472,7 @@ export function CommitPanelScreen() {
                 <PGButton
                   size="xs"
                   variant="ghost"
-                  onClick={() => stage(unstaged.map((f) => f.path))}
+                  onClick={() => stage(stageablePaths(status))}
                   disabled={unstaged.length === 0}
                 >
                   Stage all
@@ -488,7 +508,7 @@ export function CommitPanelScreen() {
               selected={effectiveKeys.has(keyOf(f))}
               onClick={onRowClick(f)}
               onContextMenu={onRowContextMenu(f)}
-              onToggle={() => stage(togglePaths(f))}
+              onToggle={() => stageToggled(f)}
             />
           ))}
         </FocusableScroll>
@@ -801,16 +821,28 @@ function keyOf(f: FileSlot): string {
   return `${f.side}:${f.path}`;
 }
 
-/** Split the selected row keys into staged/unstaged path arrays for multi-file ops. */
+/**
+ * Split the selected row keys into staged/unstaged path arrays for multi-file
+ * ops. Embedded git repositories go into their own bucket instead: they are not
+ * files, so Stage/Unstage/Discard must not reach them (see FileStatus.embedded).
+ */
 function splitByKeys(
   keys: string[],
   staged: FileSlot[],
   unstaged: FileSlot[],
-): { stagedPaths: string[]; unstagedPaths: string[] } {
+): { stagedPaths: string[]; unstagedPaths: string[]; embeddedPaths: string[] } {
   const set = new Set(keys);
+  const selected = [...staged, ...unstaged].filter((f) => set.has(keyOf(f)));
+  const actionable = (side: FileSlot["side"]) =>
+    selected
+      .filter((f) => f.side === side && !f.status.embedded)
+      .map((f) => f.path);
   return {
-    stagedPaths: staged.filter((f) => set.has(keyOf(f))).map((f) => f.path),
-    unstagedPaths: unstaged.filter((f) => set.has(keyOf(f))).map((f) => f.path),
+    stagedPaths: actionable("staged"),
+    unstagedPaths: actionable("unstaged"),
+    embeddedPaths: [
+      ...new Set(selected.filter((f) => f.status.embedded).map((f) => f.path)),
+    ],
   };
 }
 

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -20,6 +20,7 @@ import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { statusMark } from "@/lib/derive";
+import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
 import { getDiff } from "@/lib/tauri";
 import { PGPane, FocusableScroll, usePaneList, useHunkNav } from "@/features/keymap";
 import type { FileDiff } from "@/lib/types";
@@ -40,6 +41,7 @@ export function DiffViewerScreen() {
   const [selectedPath, setSelectedPath] = React.useState<string | null>(null);
   const [diff, setDiff] = React.useState<FileDiff | null>(null);
   const [diffLoading, setDiffLoading] = React.useState(false);
+  const [diffError, setDiffError] = React.useState<string | null>(null);
   const listPane = usePaneWidth(280, {
     min: 180,
     max: 600,
@@ -74,6 +76,14 @@ export function DiffViewerScreen() {
   React.useEffect(() => {
     if (!current || !repo) {
       setDiff(null);
+      setDiffError(null);
+      return;
+    }
+    setDiffError(null);
+    // An embedded repo has no diff to fetch — the panel below explains the row.
+    if (current.embedded) {
+      setDiff(null);
+      setDiffLoading(false);
       return;
     }
     let cancelled = false;
@@ -82,8 +92,12 @@ export function DiffViewerScreen() {
       .then((d) => {
         if (!cancelled) setDiff(d);
       })
-      .catch(() => {
-        if (!cancelled) setDiff(null);
+      .catch((e) => {
+        // Swallowing this is what left a blank panel with no explanation.
+        if (!cancelled) {
+          setDiff(null);
+          setDiffError(appErrorMessage(e));
+        }
       })
       .finally(() => {
         if (!cancelled) setDiffLoading(false);
@@ -91,7 +105,7 @@ export function DiffViewerScreen() {
     return () => {
       cancelled = true;
     };
-  }, [current?.path, repo, diffContextLines]);
+  }, [current?.path, current?.embedded, repo, diffContextLines]);
 
   const findFiltered = React.useMemo<FileDiff | null>(() => {
     if (!diff || !findQuery.trim()) return diff;
@@ -310,6 +324,19 @@ export function DiffViewerScreen() {
             >
               <PGSpinner size={14} />
             </div>
+          )}
+          {!diffLoading && current?.embedded && (
+            <PGEmpty icon="warn" title="Embedded git repository">
+              <span data-testid="diff-embedded-note">
+                <span className="mono">{current.path}</span>{" "}
+                {EMBEDDED_REPO_HELP}
+              </span>
+            </PGEmpty>
+          )}
+          {!diffLoading && !current?.embedded && diffError && (
+            <PGEmpty icon="warn" title="Couldn't load this diff">
+              <span data-testid="diff-error">{diffError}</span>
+            </PGEmpty>
           )}
           {!diffLoading && diff?.binary && (
             <PGEmpty icon="file" title="Binary file" />

--- a/src/screens/RepoBrowser.test.tsx
+++ b/src/screens/RepoBrowser.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
 
 import { RepoBrowserScreen } from "./RepoBrowser";
 import { useRepoStore } from "@/features/repo/useRepoStore";
@@ -34,10 +34,28 @@ function unmodified(path: string): FileStatus {
   };
 }
 
+/**
+ * libgit2 reports an untracked directory that is itself a git repo as ONE
+ * status entry with a TRAILING SLASH, because it won't recurse across the
+ * nested `.git`. The file tree splits paths on "/", so the row key loses that
+ * slash — which is how the slashless path used to reach stage() and write a
+ * silent gitlink.
+ */
+function embeddedRepo(path: string): FileStatus {
+  return {
+    path,
+    worktree: { kind: "Untracked" },
+    index: { kind: "Unmodified" },
+    additions: 0,
+    deletions: 0,
+    embedded: true,
+  };
+}
+
 const status = [modified("a.txt")];
 const allFiles = [modified("a.txt"), unmodified("u1.txt"), unmodified("u2.txt")];
 
-function resetStore() {
+function resetStore(over: Partial<Parameters<typeof useRepoStore.setState>[0]> = {}) {
   useRepoStore.setState({
     current: repo,
     status,
@@ -52,6 +70,7 @@ function resetStore() {
     repoState: "Clean",
     rebaseStatus: { inProgress: false, nextIndex: 0, total: 0, pauseReason: null },
     activity: {},
+    ...over,
   });
 }
 
@@ -71,6 +90,13 @@ function wireMocks() {
     binary: false,
     fromHead: false,
   }));
+}
+
+/** The open context menu, so assertions don't collide with the preview pane. */
+function contextMenu(): HTMLElement {
+  const menu = document.querySelector("[data-pg-menu]");
+  if (!menu) throw new Error("no context menu open");
+  return menu as HTMLElement;
 }
 
 function treeRow(path: string): HTMLElement {
@@ -115,5 +141,87 @@ describe("RepoBrowser multi-file selection (all-files mode)", () => {
 
     expect(await screen.findByText("2 files selected")).toBeInTheDocument();
     expect(screen.getByText("Stage 1 file")).toBeInTheDocument();
+  });
+});
+
+describe("RepoBrowser embedded git repositories", () => {
+  const stageCalls: string[][] = [];
+
+  beforeEach(() => {
+    stageCalls.length = 0;
+    resetStore({
+      status: [modified("a.txt"), embeddedRepo("vendor/lib/")],
+      stage: async (paths: string[]) => {
+        stageCalls.push(paths);
+      },
+    } as never);
+    wireMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resolves the trailing-slash entry from the slashless tree key", async () => {
+    render(<RepoBrowserScreen />);
+
+    // The tree row exists under the slashless path...
+    const row = await waitFor(() => treeRow("vendor/lib"));
+    fireEvent.click(row);
+
+    // ...and still resolves to its FileStatus, so the preview knows what it is
+    // instead of asking for a diff that comes back empty.
+    expect(await screen.findByText("Embedded git repository")).toBeInTheDocument();
+    expect(screen.getByTestId("embedded-repo-panel")).toBeInTheDocument();
+  });
+
+  it("offers .gitignore instead of Stage in the row's context menu", async () => {
+    render(<RepoBrowserScreen />);
+    const row = await waitFor(() => treeRow("vendor/lib"));
+
+    fireEvent.contextMenu(row);
+
+    const menu = await waitFor(contextMenu);
+    expect(within(menu).getByText("Add to .gitignore")).toBeInTheDocument();
+    expect(within(menu).queryByText("Stage")).toBeNull();
+    expect(within(menu).queryByText("Discard changes")).toBeNull();
+  });
+
+  it("keeps the embedded repo out of a multi-selection's Stage action", async () => {
+    render(<RepoBrowserScreen />);
+    await waitFor(() => treeRow("vendor/lib"));
+
+    fireEvent.click(treeRow("a.txt"));
+    fireEvent.click(treeRow("vendor/lib"), { ctrlKey: true });
+    fireEvent.contextMenu(treeRow("vendor/lib"));
+
+    // Both rows count, but only the real file is stageable — this used to hard
+    // error the whole batch instead.
+    const menu = await waitFor(contextMenu);
+    expect(within(menu).getByText("2 files selected")).toBeInTheDocument();
+    expect(
+      within(menu).getByText("Add 1 embedded repo to .gitignore"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(within(menu).getByText("Stage 1 file"));
+    await waitFor(() => expect(stageCalls).toEqual([["a.txt"]]));
+  });
+
+  it("keeps the trailing slash when ignoring, so .gitignore gets directory syntax", async () => {
+    const ignored: string[] = [];
+    resetStore({
+      status: [embeddedRepo("vendor/lib/")],
+      appendGitignore: async (p: string) => {
+        ignored.push(p);
+      },
+    } as never);
+    render(<RepoBrowserScreen />);
+    const row = await waitFor(() => treeRow("vendor/lib"));
+
+    fireEvent.contextMenu(row);
+    const menu = await waitFor(contextMenu);
+    fireEvent.click(within(menu).getByText("Add to .gitignore"));
+
+    await waitFor(() => expect(ignored).toEqual(["vendor/lib/"]));
   });
 });

--- a/src/screens/RepoBrowser.test.tsx
+++ b/src/screens/RepoBrowser.test.tsx
@@ -19,6 +19,7 @@ function modified(path: string): FileStatus {
     index: { kind: "Unmodified" },
     additions: 0,
     deletions: 0,
+    embedded: false,
   };
 }
 
@@ -29,6 +30,7 @@ function unmodified(path: string): FileStatus {
     index: { kind: "Unmodified" },
     additions: 0,
     deletions: 0,
+    embedded: false,
   };
 }
 

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -42,9 +42,14 @@ import {
   pruneSelection,
   type Selection,
 } from "@/lib/selection";
+import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
 import { highlightFile } from "@/lib/highlight";
 import { getDiff, readFileContent } from "@/lib/tauri";
-import { buildStatusTree } from "@/lib/tree";
+import {
+  buildStatusTree,
+  findStatusByTreeKey,
+  treeKeyToPath,
+} from "@/lib/tree";
 import { fuzzyMatch } from "@/features/palette/fuzzyMatch";
 import { PGPane, FocusableScroll, useAction } from "@/features/keymap";
 import type {
@@ -109,6 +114,7 @@ export function RepoBrowserScreen() {
   const [sel, setSel] = React.useState<Selection>(emptySelection);
   const [diff, setDiff] = React.useState<FileDiff | null>(null);
   const [diffLoading, setDiffLoading] = React.useState(false);
+  const [previewError, setPreviewError] = React.useState<string | null>(null);
   const [fileContent, setFileContent] = React.useState<FileContent | null>(null);
   const [filterMode, setFilterMode] = React.useState<
     "all" | "changes" | "conflicts"
@@ -284,34 +290,44 @@ export function RepoBrowserScreen() {
   const splitSelection = React.useCallback(
     (
       keys: string[],
-    ): { stagedPaths: string[]; unstagedPaths: string[]; paths: string[] } => {
+    ): {
+      stagedPaths: string[];
+      unstagedPaths: string[];
+      paths: string[];
+      embeddedPaths: string[];
+    } => {
       const stagedPaths: string[] = [];
       const unstagedPaths: string[] = [];
+      const embeddedPaths: string[] = [];
       const paths: string[] = [];
       const seen = new Set<string>();
       const add = (st: FileStatus) => {
         if (seen.has(st.path)) return;
         seen.add(st.path);
         paths.push(st.path);
+        // An embedded repo counts and copies like any row, but it is not a
+        // file — keep it out of the stage/unstage/discard subsets so a batch
+        // built from this selection never carries it to the backend.
+        if (st.embedded) {
+          embeddedPaths.push(st.path);
+          return;
+        }
         if (isStaged(st)) stagedPaths.push(st.path);
         if (isUnstaged(st)) unstagedPaths.push(st.path);
       };
       for (const key of keys) {
-        const path = key.replace(/^\//, "");
-        const st =
-          status.find((s) => s.path === path) ??
-          allFiles.find((s) => s.path === path);
+        const st = findStatusByTreeKey(key, status, allFiles);
         if (st) {
           add(st);
           continue;
         }
         // Folder key: pull in every visible file beneath it.
-        const prefix = path + "/";
+        const prefix = treeKeyToPath(key) + "/";
         for (const child of filteredStatus) {
           if (child.path.startsWith(prefix)) add(child);
         }
       }
-      return { stagedPaths, unstagedPaths, paths };
+      return { stagedPaths, unstagedPaths, paths, embeddedPaths };
     },
     [status, allFiles, filteredStatus],
   );
@@ -322,9 +338,16 @@ export function RepoBrowserScreen() {
         return multiFileMenuItems(splitSelection(sel.keys));
       }
       if (node.children?.length) return [];
-      const path = key.replace(/^\//, "");
-      const st = status.find((s) => s.path === path);
-      return fileMenuItems({ path, staged: !!st && isStaged(st) && !isUnstaged(st) });
+      const st = findStatusByTreeKey(key, status);
+      // Act on the status entry's own path, not the key: an embedded repo's
+      // path carries a trailing slash the key has already lost, and that slash
+      // is what makes "Add to .gitignore" write valid directory syntax.
+      const path = st?.path ?? treeKeyToPath(key);
+      return fileMenuItems({
+        path,
+        staged: !!st && isStaged(st) && !isUnstaged(st),
+        embedded: !!st?.embedded,
+      });
     },
   );
 
@@ -352,26 +375,30 @@ export function RepoBrowserScreen() {
   // PGFileTree keys are path-prefixed by PG_FILETREE in the form "/a/b/c".
   const selectedFile = React.useMemo<FileStatus | null>(() => {
     if (!selected) return null;
-    const path = selected.replace(/^\//, "");
-    if (browsingRev) {
-      return revFiles.find((s) => s.path === path) ?? null;
-    }
-    return (
-      status.find((s) => s.path === path) ??
-      allFiles.find((s) => s.path === path) ??
-      null
-    );
+    if (browsingRev) return findStatusByTreeKey(selected, revFiles) ?? null;
+    return findStatusByTreeKey(selected, status, allFiles) ?? null;
   }, [selected, status, allFiles, browsingRev, revFiles]);
 
   const selectedIsUnmodified =
     !!selectedFile &&
     selectedFile.worktree.kind === "Unmodified" &&
     selectedFile.index.kind === "Unmodified";
+  const selectedIsEmbedded = !!selectedFile?.embedded;
 
   React.useEffect(() => {
     if (!selectedFile || !repo) {
       setDiff(null);
       setFileContent(null);
+      setPreviewError(null);
+      return;
+    }
+    setPreviewError(null);
+    // An embedded repo has no diff and no content — EmbeddedRepoPanel takes
+    // over the pane, so don't ask the backend for either.
+    if (selectedFile.embedded) {
+      setDiff(null);
+      setFileContent(null);
+      setDiffLoading(false);
       return;
     }
     let cancelled = false;
@@ -404,8 +431,13 @@ export function RepoBrowserScreen() {
         .then((d) => {
           if (!cancelled) setDiff(d);
         })
-        .catch(() => {
-          if (!cancelled) setDiff(null);
+        .catch((e) => {
+          // Never swallow: a failed diff used to leave an unexplained empty
+          // pane, which was the original embedded-repo symptom.
+          if (!cancelled) {
+            setDiff(null);
+            setPreviewError(appErrorMessage(e));
+          }
         })
         .finally(() => {
           if (!cancelled) setDiffLoading(false);
@@ -414,7 +446,7 @@ export function RepoBrowserScreen() {
     return () => {
       cancelled = true;
     };
-  }, [selectedFile?.path, selectedIsUnmodified, repo, browsingRev, rev, readFileContentAtRev, diffContextLines]);
+  }, [selectedFile?.path, selectedFile?.embedded, selectedIsUnmodified, repo, browsingRev, rev, readFileContentAtRev, diffContextLines]);
 
   const breadcrumbItems = React.useMemo(() => {
     const root = repo?.path.split("/").filter(Boolean).pop() ?? "repository";
@@ -651,8 +683,12 @@ export function RepoBrowserScreen() {
               size="xs"
               variant="ghost"
               icon="history"
-              disabled={!selectedFile}
-              title="Show blame"
+              disabled={!selectedFile || selectedIsEmbedded}
+              title={
+                selectedIsEmbedded
+                  ? "Embedded git repositories have no blame"
+                  : "Show blame"
+              }
               onClick={() => {
                 if (selectedFile)
                   setNavIntent({ kind: "blame", path: selectedFile.path });
@@ -684,6 +720,14 @@ export function RepoBrowserScreen() {
               >
                 <PGSpinner size={14} />
               </div>
+            )}
+            {selectedFile && selectedIsEmbedded && (
+              <EmbeddedRepoPanel path={selectedFile.path} />
+            )}
+            {selectedFile && !diffLoading && !selectedIsEmbedded && previewError && (
+              <PGEmpty icon="warn" title="Couldn't load this file">
+                {previewError}
+              </PGEmpty>
             )}
             {selectedFile && !diffLoading && diff && !diff.binary &&
               diff.hunks.map((h, i) => (
@@ -722,7 +766,8 @@ export function RepoBrowserScreen() {
                   text={fileContent.text}
                 />
               )}
-            {selectedFile && !diffLoading && !fileContent &&
+            {selectedFile && !diffLoading && !selectedIsEmbedded && !previewError &&
+              !fileContent &&
               (!diff || diff.hunks.length === 0) && !diff?.binary && (
                 <PGEmpty icon="file" title="No diff available">
                   Couldn&apos;t produce a diff for this file.
@@ -876,6 +921,36 @@ export function RepoBrowserScreen() {
         </PGPane>
       </div>
     </>
+  );
+}
+
+/**
+ * Preview pane for an embedded git repository. There is nothing to diff, so
+ * explain what the row is and offer the way out instead of leaving the pane
+ * blank (the original bug) or dumping a raw error into the global banner.
+ */
+function EmbeddedRepoPanel({ path }: { path: string }) {
+  const appendGitignore = useRepoStore((s) => s.appendGitignore);
+  return (
+    <PGEmpty icon="warn" title="Embedded git repository">
+      <div
+        style={{ display: "flex", flexDirection: "column", gap: 10 }}
+        data-testid="embedded-repo-panel"
+      >
+        <span>
+          <span className="mono">{path}</span> {EMBEDDED_REPO_HELP}
+        </span>
+        <div>
+          <PGButton
+            size="sm"
+            icon="trash"
+            onClick={() => void appendGitignore(path)}
+          >
+            Add to .gitignore
+          </PGButton>
+        </div>
+      </div>
+    </PGEmpty>
   );
 }
 


### PR DESCRIPTION
## What

Untracked directories that are themselves git repos (vendored deps, unregistered submodules) surface in libgit2 status as a **single entry with a trailing slash** — `vendor/lib/` — because libgit2 won't recurse across the nested `.git` boundary. Diffing returned a valid-but-empty diff (blank panel, no error); staging forwarded the trailing-slash path to `Index::add_path`, which rejects it as "invalid path".

Supersedes #24, which guarded on *path shape* (`ends_with('/')`). That guard does not hold on current `main`:

```
status entries:            ["vendor/lib/"]
stage("vendor/lib/")   ->  Err(EmbeddedRepo)      # guard fires
stage("vendor/lib")    ->  Ok(())                 # guard bypassed
index entry: mode=160000 path=vendor/lib          # silent gitlink, no .gitmodules
```

The slashless form is what the UI actually passes: `tree.ts` splits paths on `/` and `git-components.tsx` rebuilds keys as `parentKey + "/" + name`, so the slash is gone before `RepoBrowser`'s `status.find` runs — it misses, and the unguarded path reaches `stage()`. Result on any vendored dep with commits: right-click → Stage silently writes a gitlink nobody can clone. Multi-select took the opposite path (slash preserved → whole batch hard-errored), so the same row corrupted on right-click and errored on ⌘-click.

## How

**Detection is data, not string shape.** `FileStatus.embedded` is populated by actually opening the directory as a repo, so both `vendor/lib/` and `vendor/lib` are caught.

- `strip_trailing_slash` / `is_embedded_repo` / `reject_embedded_repo` in `libgit2.rs`; flag populated in `status` and `list_all_files`.
- Guards on `diff`, `stage`, `blame_file`, `file_history`.
- **Registered submodules are excluded** — a legitimate registered submodule is also a directory-that-is-a-repo, and stages/diffs correctly today. Registration means a `.gitmodules` URL (`find_submodule(..).url().is_some()`); `find_submodule` alone is insufficient because libgit2 also reports a bare index gitlink — exactly the damage being prevented — as a submodule.
- **Batch ops skip-and-continue.** `stage` partitions the batch, stages the rest, and errors only when nothing is left — previously one vendored repo made "Stage all" reject everything until the user gitignored it.
- `unstage` is deliberately left open so an already-committed gitlink can still be removed.
- **Shared tree-key resolver** (`treeKeyToPath` / `findStatusByPath` / `findStatusByTreeKey` in `tree.ts`) used by `selectedFile`, `fileCtx`, and `splitSelection`, so all three agree. Lives in `tree.ts` because the slash is lost inside `buildStatusTree` — the fix sits next to its cause.
- **An affordance instead of a wall of red text.** `git` itself allows this and prints actionable submodule guidance, so a bare hard block would be worse UX than git's: embedded rows get a distinct mark, a panel with one-click "Add to .gitignore", and remedy-first context menus. `DiffViewer` previously did `.catch(() => setDiff(null))`, swallowing the error entirely — so #24's headline symptom survived on the dedicated diff screen. Fixed.
- `AppError::EmbeddedRepo` message is terse (`"embedded repository: {0}"`) per `error.rs` style; remediation prose lives in the UI.

## Testing

- **Rust** (`src-tauri/tests/embedded_repo.rs`, 11 tests) — the fixture **commits** in the nested repo, which is the case that actually corrupts; #24's fixture never did, dodging it. Covers: status/`list_all_files` flag it and nothing else; `stage` rejects **both** path forms with `assert_no_gitlink` reading the index off disk; registered submodule is *not* flagged; `diff`/`blame`/`file_history` guarded; ordinary paths unaffected; mixed batch stages the rest; all-embedded batch errors; `unstage` still removes a committed gitlink.
- **Frontend** — a trailing-slash status entry resolves through the tree-key path while normal paths still resolve. This test alone would have caught both of #24's failure modes.

```
cargo test  -> 163 passed, 0 failed
pnpm test   -> 361 passed (47 files)
pnpm tsc --noEmit -> clean
```

e2e not run locally (needs a fresh debug build); CI covers it.

## Not fixed here

`discard()` is a silent no-op for **every** untracked file (`libgit2.rs` uses `checkout_index`, which can only restore paths with index entries) — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
