### PR TITLE
fix(settings): make UI density affect every row surface (#70)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ Four layers, each run independently:
   `src/`. Runs in jsdom with React Testing Library. The Tauri `invoke` and
   `plugin-dialog.open` calls are mocked via `src/test/setup.ts`; tests register
   per-command responses with `mockInvoke(cmd, handler)`.
-- **E2E (webview-level)** — WebdriverIO specs in `e2e/specs/` (16 files, 76
+- **E2E (webview-level)** — WebdriverIO specs in `e2e/specs/` (17 files, 86
   tests, all passing) drive the real debug binary: real webview →
   real Tauri IPC → real libgit2 → temp repos built by `e2e/support/tempRepo.ts`.
   Uses the embedded WebDriver provider (`@wdio/tauri-service`) — no external
@@ -320,6 +320,18 @@ lib/
 - Tailwind v4 (CSS-first config). Theme tokens in `src/index.css` under `@theme { … }`. Use CSS vars (`var(--color-accent)`, `var(--bg-0)`, `var(--fg-0)`, `var(--git-*)`) or Tailwind arbitrary-value syntax.
 - No `tailwind.config.js` — v4 doesn't need one.
 - Inline `style={{…}}` with CSS vars is fine and used widely in chrome components.
+- **Any new list-row surface must opt into UI density**, or the Settings toggle
+  silently skips it (that's how it rotted the first time — issue #70). Write
+  `height: "calc(<base>px + var(--row-step))"`, or
+  `padding: "calc(<base>px + var(--row-step) / 2) …"` for padding-sized rows;
+  `--row-h` is the shared token for plain 24px rows. `--row-step` is 0 in
+  compact, so keep each surface's existing base and the default layout is
+  unchanged. `grep -rn 'var(--row-step)' src/` lists what participates.
+  Chrome (titlebar, status bar, toolbars, panel headers) stays fixed, as does
+  diff/code line geometry (`--lh-code` owns that). The one surface that can't
+  use the token is `PGGraphRow` — it draws in SVG user units, so `PGCommitRow`
+  feeds it the number from `useDensityStep()`; those two must stay in sync or
+  the History graph desyncs from its rows.
 
 ### Design system
 - Import UI primitives from `@/design` (not per-file). `design/index.ts` barrel re-exports everything.

--- a/e2e/specs/settings.e2e.ts
+++ b/e2e/specs/settings.e2e.ts
@@ -4,7 +4,7 @@ import {
 } from "../support/tempRepo";
 import {
   openRepo, reopenRepo, resetApp, stubNativeDialogs, confirmCallCount,
-  openPalette, paletteDialog, paletteInput, switchScreen, stagedRow,
+  openPalette, paletteDialog, paletteInput, switchScreen, stagedRow, changeRow,
   executeOnce, openSettings,
 } from "../support/app";
 
@@ -50,6 +50,58 @@ async function clickSettingsToggleRow(labelText: string): Promise<void> {
     return true;
   }, labelText);
   if (!ok) throw new Error(`settings toggle row not found: ${labelText}`);
+}
+
+/**
+ * Measure the rendered height of one row per density mechanism.
+ *
+ * There is no repo truth for a layout setting, so rendered geometry IS the
+ * acceptance here — and it can only be measured in a real webview: the tokens
+ * are `calc(Npx + var(--row-step))`, which jsdom does not resolve (the store
+ * side is unit-tested in src/features/settings/useSettingsStore.test.ts).
+ *
+ * Read-only script, so bare `browser.execute` is correct — no `executeOnce`
+ * token needed (a driver retry re-measures harmlessly).
+ */
+async function measureRows(): Promise<{
+  changeRow: number;
+  branchRow: number;
+  commitRow: number;
+  graphSvg: number;
+}> {
+  const h = (sel: string) =>
+    browser.execute((s: string) => {
+      const el = document.querySelector(s);
+      return el ? Math.round(el.getBoundingClientRect().height) : -1;
+    }, sel);
+
+  await switchScreen("commit");
+  await changeRow("a.txt").waitForDisplayed({
+    timeout: 10_000, timeoutMsg: "change row never appeared for measurement",
+  });
+  // PGChangeRow reads --row-h, the token that already existed before density
+  // was wired — this is the regression guard on the calc chain itself.
+  const changeRowH = await h('[data-testid="changes-list"] [data-path="a.txt"]');
+
+  await switchScreen("branches");
+  await $('[data-testid="branch-row"]').waitForDisplayed({
+    timeout: 10_000, timeoutMsg: "branch row never appeared for measurement",
+  });
+  const branchRowH = await h('[data-testid="branch-row"]');
+
+  await switchScreen("history");
+  await $('[data-testid="commit-row"]').waitForDisplayed({
+    timeout: 10_000, timeoutMsg: "commit row never appeared for measurement",
+  });
+  const commitRowH = await h('[data-testid="commit-row"]');
+  const graphSvgH = await h('[data-testid="commit-row"] svg');
+
+  return {
+    changeRow: changeRowH,
+    branchRow: branchRowH,
+    commitRow: commitRowH,
+    graphSvg: graphSvgH,
+  };
 }
 
 describe("settings", () => {
@@ -208,6 +260,40 @@ describe("settings", () => {
       async () => pair!.bareGit("rev-parse", "main").trim() === localHead,
       { timeout: 20_000, timeoutMsg: "force-push never landed on the bare remote" },
     );
+  });
+
+  it("UI density scales every row surface, and compact restores them", async () => {
+    repo = dirtyRepo(); // a.txt unstaged, so CommitPanel has a change row
+    await openRepo(repo.path);
+
+    const compact = await measureRows();
+    // Compact is the pre-density baseline — pinned so a future token edit
+    // can't silently reflow the default layout.
+    expect(compact).toEqual({
+      changeRow: 24, branchRow: 28, commitRow: 26, graphSvg: 26,
+    });
+
+    await openSettings();
+    await $("button*=Comfortable").click();
+    await browser.waitUntil(
+      async () => $('button[aria-pressed="true"]*=Comfortable').isExisting(),
+      { timeout: 10_000, timeoutMsg: "Comfortable never became active" },
+    );
+
+    // Every surface gains exactly the one step — including the SVG graph
+    // gutter, which draws in user units and would otherwise desync from the
+    // commit rows it sits beside.
+    expect(await measureRows()).toEqual({
+      changeRow: 28, branchRow: 32, commitRow: 30, graphSvg: 30,
+    });
+
+    await openSettings();
+    await $("button*=Compact").click();
+    await browser.waitUntil(
+      async () => $('button[aria-pressed="true"]*=Compact').isExisting(),
+      { timeout: 10_000, timeoutMsg: "Compact never became active" },
+    );
+    expect(await measureRows()).toEqual(compact);
   });
 
   it("confirmForcePush=off skips the confirm entirely", async () => {

--- a/e2e/specs/settings.e2e.ts
+++ b/e2e/specs/settings.e2e.ts
@@ -60,8 +60,9 @@ async function clickSettingsToggleRow(labelText: string): Promise<void> {
  * are `calc(Npx + var(--row-step))`, which jsdom does not resolve (the store
  * side is unit-tested in src/features/settings/useSettingsStore.test.ts).
  *
- * Read-only script, so bare `browser.execute` is correct — no `executeOnce`
- * token needed (a driver retry re-measures harmlessly).
+ * Measures via `getSize("height")` on the same elements it waits for, so a
+ * selector change surfaces as "row never appeared" rather than as a wrong
+ * height — and reuses `changeRow()` instead of restating its selector.
  */
 async function measureRows(): Promise<{
   changeRow: number;
@@ -69,38 +70,35 @@ async function measureRows(): Promise<{
   commitRow: number;
   graphSvg: number;
 }> {
-  const h = (sel: string) =>
-    browser.execute((s: string) => {
-      const el = document.querySelector(s);
-      return el ? Math.round(el.getBoundingClientRect().height) : -1;
-    }, sel);
-
   await switchScreen("commit");
-  await changeRow("a.txt").waitForDisplayed({
+  const change = changeRow("a.txt");
+  await change.waitForDisplayed({
     timeout: 10_000, timeoutMsg: "change row never appeared for measurement",
   });
   // PGChangeRow reads --row-h, the token that already existed before density
   // was wired — this is the regression guard on the calc chain itself.
-  const changeRowH = await h('[data-testid="changes-list"] [data-path="a.txt"]');
+  const changeRowH = await change.getSize("height");
 
   await switchScreen("branches");
-  await $('[data-testid="branch-row"]').waitForDisplayed({
+  const branch = $('[data-testid="branch-row"]');
+  await branch.waitForDisplayed({
     timeout: 10_000, timeoutMsg: "branch row never appeared for measurement",
   });
-  const branchRowH = await h('[data-testid="branch-row"]');
+  const branchRowH = await branch.getSize("height");
 
   await switchScreen("history");
-  await $('[data-testid="commit-row"]').waitForDisplayed({
+  const commit = $('[data-testid="commit-row"]');
+  await commit.waitForDisplayed({
     timeout: 10_000, timeoutMsg: "commit row never appeared for measurement",
   });
-  const commitRowH = await h('[data-testid="commit-row"]');
-  const graphSvgH = await h('[data-testid="commit-row"] svg');
+  const commitRowH = await commit.getSize("height");
+  const graphSvgH = await commit.$("svg").getSize("height");
 
   return {
-    changeRow: changeRowH,
-    branchRow: branchRowH,
-    commitRow: commitRowH,
-    graphSvg: graphSvgH,
+    changeRow: Math.round(changeRowH),
+    branchRow: Math.round(branchRowH),
+    commitRow: Math.round(commitRowH),
+    graphSvg: Math.round(graphSvgH),
   };
 }
 

--- a/src/design/git-components.density.test.tsx
+++ b/src/design/git-components.density.test.tsx
@@ -1,0 +1,74 @@
+// PGCommitRow is the one density surface that cannot be pure CSS: PGGraphRow
+// draws its lanes in SVG user units (`y2={height}`, bezier control points at
+// `height / 2`), so the row box and the graph gutter must agree on the SAME
+// number. A `calc()` on the row alone would desync the curves from the row
+// pitch — the most visible list in the app. These tests pin them together.
+import { describe, it, expect, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+
+import {
+  COMMIT_ROW_BASE_H,
+  PGCommitRow,
+  type GraphLane,
+  type GraphNode,
+} from "./git-components";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+
+const lanes: GraphLane[] = [{ col: 0, color: "red", kind: "line" }];
+const node: GraphNode = { col: 0, color: "red" };
+
+function renderCommitRow() {
+  const { container } = render(
+    <PGCommitRow
+      lanes={lanes}
+      node={node}
+      sha="abc1234"
+      message="feat: something"
+      author="Tester"
+      date="2026-08-11"
+    />,
+  );
+  const row = container.querySelector<HTMLElement>('[data-testid="commit-row"]')!;
+  const svg = container.querySelector("svg")!;
+  return { row, svg };
+}
+
+beforeEach(() => {
+  useSettingsStore.getState().set("uiDensity", "compact");
+});
+
+describe("PGCommitRow density", () => {
+  it("keeps the compact row at its pre-density height", () => {
+    const { row, svg } = renderCommitRow();
+    expect(COMMIT_ROW_BASE_H).toBe(26); // the pre-density height, pinned
+    expect(row.style.height).toBe(`${COMMIT_ROW_BASE_H}px`);
+    expect(svg.getAttribute("height")).toBe(`${COMMIT_ROW_BASE_H}`);
+  });
+
+  // Literal 30, not COMMIT_ROW_BASE_H + step: if either the base or the step
+  // moves, this fails rather than following along silently.
+  it("grows row and graph gutter together when density is comfortable", () => {
+    useSettingsStore.getState().set("uiDensity", "comfortable");
+    const { row, svg } = renderCommitRow();
+    expect(row.style.height).toBe("30px");
+    expect(svg.getAttribute("height")).toBe("30");
+  });
+
+  it("lets an explicit rowHeight override the density-derived height", () => {
+    const { container } = render(
+      <PGCommitRow
+        lanes={lanes}
+        node={node}
+        sha="abc1234"
+        message="m"
+        author="a"
+        date="d"
+        rowHeight={40}
+      />,
+    );
+    expect(
+      container.querySelector<HTMLElement>('[data-testid="commit-row"]')!.style.height,
+    ).toBe("40px");
+    expect(container.querySelector("svg")!.getAttribute("height")).toBe("40");
+  });
+});

--- a/src/design/git-components.density.test.tsx
+++ b/src/design/git-components.density.test.tsx
@@ -4,7 +4,7 @@
 // number. A `calc()` on the row alone would desync the curves from the row
 // pitch — the most visible list in the app. These tests pin them together.
 import { describe, it, expect, beforeEach } from "vitest";
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 
 import {
   COMMIT_ROW_BASE_H,
@@ -50,6 +50,22 @@ describe("PGCommitRow density", () => {
   it("grows row and graph gutter together when density is comfortable", () => {
     useSettingsStore.getState().set("uiDensity", "comfortable");
     const { row, svg } = renderCommitRow();
+    expect(row.style.height).toBe("30px");
+    expect(svg.getAttribute("height")).toBe("30");
+  });
+
+  // Every other test here measures a fresh mount, which a subscription-free
+  // `useSettingsStore.getState()` read would also satisfy. This one changes the
+  // setting under an ALREADY-MOUNTED row: without a real subscription the
+  // gutter would keep drawing at the old pitch until the screen remounted.
+  it("re-renders a mounted row and gutter when density changes", () => {
+    const { row, svg } = renderCommitRow();
+    expect(svg.getAttribute("height")).toBe("26");
+
+    act(() => {
+      useSettingsStore.getState().set("uiDensity", "comfortable");
+    });
+
     expect(row.style.height).toBe("30px");
     expect(svg.getAttribute("height")).toBe("30");
   });

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -11,6 +11,7 @@ import {
   PGCheckbox,
   PGSelect,
 } from "./primitives";
+import { useDensityStep } from "@/features/settings/useSettingsStore";
 
 // ═════════════════════════════════════════════════════════
 // FILE TREE
@@ -739,7 +740,7 @@ export function PGHunk({
           display: "flex",
           alignItems: "center",
           gap: 8,
-          height: 26,
+          height: "calc(26px + var(--row-step))",
           padding: "0 8px",
           background: "var(--bg-2)",
           fontFamily: "var(--font-mono)",
@@ -1028,7 +1029,15 @@ export interface PGCommitRowProps {
   onClick?: (e: MouseEvent) => void;
   onContextMenu?: (e: MouseEvent) => void;
   tagged?: string;
+  /**
+   * Row height in px. Defaults to the density-derived height. Unlike every
+   * other row surface this can't be a `--row-h` calc: PGGraphRow draws lanes
+   * in SVG user units, so the row box and the gutter must share one NUMBER.
+   */
+  rowHeight?: number;
 }
+
+export const COMMIT_ROW_BASE_H = 26;
 
 export function PGCommitRow({
   lanes,
@@ -1042,8 +1051,11 @@ export function PGCommitRow({
   onClick,
   onContextMenu,
   tagged,
+  rowHeight,
 }: PGCommitRowProps) {
   const [hover, setHover] = React.useState(false);
+  const step = useDensityStep();
+  const h = rowHeight ?? COMMIT_ROW_BASE_H + step;
   return (
     <div
       data-testid="commit-row"
@@ -1058,7 +1070,7 @@ export function PGCommitRow({
         display: "grid",
         gridTemplateColumns: "140px 70px 1fr 150px 90px",
         alignItems: "center",
-        height: 26,
+        height: h,
         background: !selected && hover ? "var(--bg-2)" : undefined,
         fontFamily: "var(--font-mono)",
         fontSize: "var(--fs-12)",
@@ -1079,7 +1091,7 @@ export function PGCommitRow({
           }}
         />
       )}
-      <PGGraphRow lanes={lanes} node={node} />
+      <PGGraphRow lanes={lanes} node={node} height={h} />
       <span style={{ color: "var(--fg-3)", fontSize: "var(--fs-11)" }}>{sha}</span>
       <div
         style={{
@@ -1347,7 +1359,7 @@ export function PGConflictRow({
           display: "flex",
           alignItems: "center",
           gap: 8,
-          padding: "8px 10px 4px",
+          padding: "calc(8px + var(--row-step) / 2) 10px calc(4px + var(--row-step) / 2)",
         }}
       >
         {resolved ? (
@@ -1609,7 +1621,7 @@ export function PGRebaseRow({
         display: "flex",
         alignItems: "center",
         gap: 8,
-        padding: "6px 10px",
+        padding: "calc(6px + var(--row-step) / 2) 10px",
         background: dragging ? "var(--bg-3)" : "var(--bg-1)",
         border: "1px solid var(--border-0)",
         borderLeft: `3px solid ${current.color}`,
@@ -1737,7 +1749,7 @@ export function PGRemoteRow({
       onContextMenu={onContextMenu}
       data-remote={dataRemote}
       style={{
-        padding: 10,
+        padding: "calc(10px + var(--row-step) / 2) 10px",
         background: "var(--bg-1)",
         border: "1px solid var(--border-0)",
         borderRadius: "var(--r-3)",

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -880,16 +880,25 @@ export interface GraphNode {
   merge?: boolean;
 }
 
+/**
+ * `height` is REQUIRED and must be the caller's actual row pitch in px.
+ *
+ * The lane geometry below is in SVG user units (`y2={height}`, bezier control
+ * points at `height / 2`), so it cannot read `--row-step` — a default here
+ * would silently draw at one pitch while density moved the rows to another,
+ * leaving lanes that don't meet between rows. Callers derive the number from
+ * `useDensityStep()`; see `PGCommitRow`.
+ */
 export function PGGraphRow({
   lanes = [],
   node,
   width = 140,
-  height = 26,
+  height,
 }: {
   lanes?: GraphLane[];
   node?: GraphNode;
   width?: number;
-  height?: number;
+  height: number;
 }) {
   return (
     <svg

--- a/src/features/branches/BranchPicker.tsx
+++ b/src/features/branches/BranchPicker.tsx
@@ -163,7 +163,7 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
           display: "flex",
           alignItems: "center",
           gap: 6,
-          height: 26,
+          height: "calc(26px + var(--row-step))",
           padding: "0 10px",
           background: active ? "var(--bg-selection)" : "transparent",
           cursor: r.kind === "local" && r.isHead ? "default" : "pointer",

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -118,7 +118,7 @@ export function CommitDiffPanel({
                 alignItems: "center",
                 justifyContent: "space-between",
                 gap: 8,
-                padding: "4px 12px",
+                padding: "calc(4px + var(--row-step) / 2) 12px",
                 cursor: "pointer",
               }}
             >

--- a/src/features/palette/CommandPalette.tsx
+++ b/src/features/palette/CommandPalette.tsx
@@ -306,7 +306,8 @@ export function CommandPalette() {
         onClick={() => activate(row)}
         onMouseEnter={() => setActiveIndex(flatIndex)}
         style={{
-          display: "flex", alignItems: "center", gap: 8, height: 30, padding: "0 12px",
+          display: "flex", alignItems: "center", gap: 8,
+          height: "calc(30px + var(--row-step))", padding: "0 12px",
           background: active ? "var(--bg-selection)" : "transparent", cursor: "pointer",
           fontFamily: "var(--font-mono)", fontSize: "var(--fs-12)",
         }}

--- a/src/features/rebase/RebaseBasePicker.tsx
+++ b/src/features/rebase/RebaseBasePicker.tsx
@@ -182,7 +182,7 @@ export function RebaseBasePicker({
           display: "flex",
           alignItems: "center",
           gap: 8,
-          height: 26,
+          height: "calc(26px + var(--row-step))",
           padding: "0 10px",
           background: active ? "var(--bg-selection)" : "transparent",
           cursor: "pointer",

--- a/src/features/settings/useSettingsStore.test.ts
+++ b/src/features/settings/useSettingsStore.test.ts
@@ -13,7 +13,7 @@ async function freshStore() {
 
 beforeEach(() => {
   localStorage.clear();
-  document.documentElement.style.removeProperty("--row-h");
+  document.documentElement.style.removeProperty("--row-step");
 });
 
 describe("useSettingsStore persistence", () => {
@@ -160,27 +160,44 @@ describe("logo theme slots", () => {
   });
 });
 
+// Density is one CSS var — `--row-step` — that every row surface adds to its
+// base geometry (index.css derives `--row-h` and friends from it). jsdom can't
+// resolve those calc()s, so the per-surface pixel results are asserted in
+// e2e/specs/settings.e2e.ts against a real webview; here we pin the var itself.
+const rowStep = () =>
+  document.documentElement.style.getPropertyValue("--row-step");
+
 describe("uiDensity CSS hook", () => {
-  it("applies --row-h from the persisted density at load", async () => {
+  it("applies --row-step from the persisted density at load", async () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiDensity: "comfortable" }));
     await freshStore();
-    expect(document.documentElement.style.getPropertyValue("--row-h")).toBe("28px");
+    expect(rowStep()).toBe("4px");
     expect(document.documentElement.dataset.density).toBe("comfortable");
   });
 
-  it("re-applies --row-h when the density setting changes", async () => {
+  it("re-applies --row-step when the density setting changes", async () => {
     const { useSettingsStore } = await freshStore();
-    expect(document.documentElement.style.getPropertyValue("--row-h")).toBe("24px");
+    expect(rowStep()).toBe("0px");
     useSettingsStore.getState().set("uiDensity", "comfortable");
-    expect(document.documentElement.style.getPropertyValue("--row-h")).toBe("28px");
+    expect(rowStep()).toBe("4px");
+    expect(document.documentElement.dataset.density).toBe("comfortable");
     useSettingsStore.getState().set("uiDensity", "compact");
-    expect(document.documentElement.style.getPropertyValue("--row-h")).toBe("24px");
+    expect(rowStep()).toBe("0px");
+    expect(document.documentElement.dataset.density).toBe("compact");
   });
 
   it("reset() restores compact density", async () => {
     const { useSettingsStore } = await freshStore();
     useSettingsStore.getState().set("uiDensity", "comfortable");
     useSettingsStore.getState().reset();
-    expect(document.documentElement.style.getPropertyValue("--row-h")).toBe("24px");
+    expect(rowStep()).toBe("0px");
+    expect(document.documentElement.dataset.density).toBe("compact");
+  });
+
+  // Compact must be a no-op delta: the pre-density layout is the compact
+  // layout, so every `calc(Npx + var(--row-step))` has to collapse to Npx.
+  it("keeps compact at a zero step so the default layout is unchanged", async () => {
+    const { DENSITY_STEP_PX } = await freshStore();
+    expect(DENSITY_STEP_PX.compact).toBe(0);
   });
 });

--- a/src/features/settings/useSettingsStore.test.ts
+++ b/src/features/settings/useSettingsStore.test.ts
@@ -200,4 +200,16 @@ describe("uiDensity CSS hook", () => {
     const { DENSITY_STEP_PX } = await freshStore();
     expect(DENSITY_STEP_PX.compact).toBe(0);
   });
+
+  // load() copies any persisted value for a known key without validating it,
+  // so an unrecognized density must degrade to compact rather than emit
+  // `--row-step: undefinedpx` — an invalid substitution makes every
+  // `calc(Npx + var(--row-step))` compute to `auto`, collapsing the height of
+  // every row in the app at once.
+  it("degrades an unrecognized persisted density to compact", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiDensity: "cozy" }));
+    await freshStore();
+    expect(rowStep()).toBe("0px");
+    expect(document.documentElement.dataset.density).toBe("compact");
+  });
 });

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -352,16 +352,35 @@ export function applyTheme(theme: ThemeDef) {
  */
 export const DENSITY_STEP_PX = { compact: 0, comfortable: 4 } as const;
 
+export type UiDensity = keyof typeof DENSITY_STEP_PX;
+
+/**
+ * Coerce a persisted density into a known one.
+ *
+ * `load()` copies any JSON value for a known key without validating it, so
+ * state can hold a density this build has never heard of — a hand-edited
+ * `pg-settings-v2`, or a value written by a newer build the user downgraded
+ * from. That must degrade to compact: an unknown key would otherwise emit
+ * `--row-step: undefinedpx`, and one invalid substitution makes every
+ * `calc(Npx + var(--row-step))` compute to `auto`, collapsing the height of
+ * every row in the app at once.
+ */
+function normalizeDensity(density: UiDensity): UiDensity {
+  return density in DENSITY_STEP_PX ? density : "compact";
+}
+
 /**
  * Apply UI density by writing the row-step slot to CSS vars on :root.
  *
- * `data-density` is also set: it's the hook for any density rule that isn't a
- * simple pixel delta, and e2e asserts against it.
+ * `data-density` is also set — a reserved hook for any future density rule
+ * that isn't a simple pixel delta. Nothing reads it today (it's asserted only
+ * in useSettingsStore.test.ts); drop it if that stays true.
  */
-export function applyDensity(density: "compact" | "comfortable") {
+export function applyDensity(density: UiDensity) {
   const root = document.documentElement;
-  root.style.setProperty("--row-step", `${DENSITY_STEP_PX[density]}px`);
-  root.dataset.density = density;
+  const d = normalizeDensity(density);
+  root.style.setProperty("--row-step", `${DENSITY_STEP_PX[d]}px`);
+  root.dataset.density = d;
 }
 
 // ═════════════════════════════════════════════════════════════════════════════
@@ -733,5 +752,5 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
  * drawing (see `PGGraphRow`), which a `calc()` cannot reach.
  */
 export function useDensityStep(): number {
-  return DENSITY_STEP_PX[useSettingsStore((s) => s.uiDensity)];
+  return DENSITY_STEP_PX[normalizeDensity(useSettingsStore((s) => s.uiDensity))];
 }

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -340,10 +340,27 @@ export function applyTheme(theme: ThemeDef) {
   root.dataset.themeMode = theme.mode;
 }
 
-/** Apply UI density by writing the row-height slot to CSS vars on :root. */
+/**
+ * Extra vertical pixels each row-ish surface adds for a given density.
+ *
+ * THE source of truth for the number. `index.css` declares `--row-step: 0px`
+ * as a pre-hydration default and derives every row token from it
+ * (`--row-h: calc(24px + var(--row-step))`, …); `applyDensity` overwrites the
+ * var from this table, so CSS never hardcodes the comfortable delta and cannot
+ * drift from the JS one. Compact is 0 by definition — comfortable is opt-in,
+ * and the default layout stays pixel-identical to the pre-density one.
+ */
+export const DENSITY_STEP_PX = { compact: 0, comfortable: 4 } as const;
+
+/**
+ * Apply UI density by writing the row-step slot to CSS vars on :root.
+ *
+ * `data-density` is also set: it's the hook for any density rule that isn't a
+ * simple pixel delta, and e2e asserts against it.
+ */
 export function applyDensity(density: "compact" | "comfortable") {
   const root = document.documentElement;
-  root.style.setProperty("--row-h", density === "comfortable" ? "28px" : "24px");
+  root.style.setProperty("--row-step", `${DENSITY_STEP_PX[density]}px`);
   root.dataset.density = density;
 }
 
@@ -707,4 +724,14 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   const active = findTheme(s, s.activeThemeId) ?? BUILTIN_THEMES[0];
   applyTheme(active);
   applyDensity(s.uiDensity);
+}
+
+/**
+ * The active density's pixel step, for surfaces that need the NUMBER rather
+ * than the `--row-step` CSS var — i.e. anything doing geometry math in JS.
+ * Prefer the CSS token everywhere it works; this exists for SVG user-unit
+ * drawing (see `PGGraphRow`), which a `calc()` cannot reach.
+ */
+export function useDensityStep(): number {
+  return DENSITY_STEP_PX[useSettingsStore((s) => s.uiDensity)];
 }

--- a/src/index.css
+++ b/src/index.css
@@ -124,8 +124,22 @@
 
   --ring: 0 0 0 2px oklch(0.72 0.15 235 / 0.5);
 
-  /* density */
-  --row-h: 24px;
+  /* ===== DENSITY =====
+   * One knob: --row-step, the extra vertical pixels a row spends in
+   * "comfortable" mode. applyDensity() (features/settings/useSettingsStore.ts)
+   * overwrites it on :root from DENSITY_STEP_PX — THE source of truth for the
+   * number — so this declaration is only the pre-hydration default.
+   *
+   * Row surfaces opt in with `calc(<their base>px + var(--row-step))`, or
+   * `calc(<base>px + var(--row-step) / 2)` for vertical padding (top+bottom
+   * each take half). Keeping each surface's own base inline means compact
+   * (step 0) renders pixel-identically to the pre-density layout, and
+   * `grep -rn 'var(--row-step)' src/` lists every density-aware surface.
+   *
+   * One surface can't use the token: PGGraphRow draws in SVG user units, so
+   * PGCommitRow feeds it the number via useDensityStep(). */
+  --row-step: 0px;
+  --row-h: calc(24px + var(--row-step));
 
   /* transitions */
   --t-fast: 80ms cubic-bezier(0.4, 0, 0.2, 1);

--- a/src/screens/Branches.tsx
+++ b/src/screens/Branches.tsx
@@ -258,7 +258,7 @@ export function BranchesScreen() {
               style={{
                 display: "grid",
                 gridTemplateColumns: gridTemplate,
-                height: 24,
+                height: "calc(24px + var(--row-step))",
                 background: "var(--bg-2)",
                 borderBottom: "1px solid var(--border-0)",
                 alignItems: "center",
@@ -309,6 +309,7 @@ export function BranchesScreen() {
                 onClick={() => setSelection({ kind: "branch", name: b.name })}
                 onContextMenu={(e) => onBranchCtx(e, b)}
                 data-pg-row=""
+                data-testid="branch-row"
                 data-selected={
                   selection?.kind === "branch" && selection.name === b.name
                     ? ""
@@ -318,7 +319,7 @@ export function BranchesScreen() {
                   display: "grid",
                   gridTemplateColumns: gridTemplate,
                   alignItems: "center",
-                  height: 28,
+                  height: "calc(28px + var(--row-step))",
                   background:
                     selection?.kind === "branch" && selection.name === b.name
                       ? undefined
@@ -457,7 +458,7 @@ export function BranchesScreen() {
                   display: "grid",
                   gridTemplateColumns: gridTemplate,
                   alignItems: "center",
-                  height: 28,
+                  height: "calc(28px + var(--row-step))",
                   fontFamily: "var(--font-mono)",
                   fontSize: "var(--fs-12)",
                   borderBottom: "1px solid oklch(0.22 0.008 260 / 0.3)",
@@ -537,7 +538,7 @@ export function BranchesScreen() {
                   display: "grid",
                   gridTemplateColumns: gridTemplate,
                   alignItems: "center",
-                  height: 28,
+                  height: "calc(28px + var(--row-step))",
                   fontFamily: "var(--font-mono)",
                   fontSize: "var(--fs-12)",
                   borderBottom: "1px solid oklch(0.22 0.008 260 / 0.3)",

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -279,7 +279,7 @@ export function DiffViewerScreen() {
                 alignItems: "center",
                 gap: 6,
                 padding: "0 10px",
-                height: 24,
+                height: "calc(24px + var(--row-step))",
                 fontFamily: "var(--font-mono)",
                 fontSize: "var(--fs-12)",
                 cursor: "pointer",

--- a/src/screens/FileHistory.tsx
+++ b/src/screens/FileHistory.tsx
@@ -81,7 +81,7 @@ export function FileHistoryScreen() {
             style={{
               display: "flex",
               gap: 10,
-              padding: "6px 12px",
+              padding: "calc(6px + var(--row-step) / 2) 12px",
               borderBottom: "1px solid var(--border-0)",
               fontFamily: "var(--font-mono)",
               fontSize: "var(--fs-12)",

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -398,7 +398,7 @@ export function HistoryScreen() {
         style={{
           display: "grid",
           gridTemplateColumns: "140px 70px 1fr 150px 90px",
-          height: 24,
+          height: "calc(24px + var(--row-step))",
           background: "var(--bg-2)",
           borderBottom: "1px solid var(--border-0)",
           fontFamily: "var(--font-mono)",

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -548,7 +548,7 @@ function AppearanceSection({ active }: { active: ThemeDef }) {
 
       <Row
         label="UI density"
-        hint="Compact matches the dense IDE feel; comfortable adds padding."
+        hint="Compact matches the dense IDE feel; comfortable gives every list row 4px more breathing room."
         control={
           <PGButtonGroup
             size="sm"

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/design";
 import {
   BUILTIN_THEMES,
+  DENSITY_STEP_PX,
   THEME_COLOR_FIELDS,
   applyTheme,
   useSettingsStore,
@@ -548,7 +549,7 @@ function AppearanceSection({ active }: { active: ThemeDef }) {
 
       <Row
         label="UI density"
-        hint="Compact matches the dense IDE feel; comfortable gives every list row 4px more breathing room."
+        hint={`Compact matches the dense IDE feel; comfortable gives every list row ${DENSITY_STEP_PX.comfortable}px more breathing room.`}
         control={
           <PGButtonGroup
             size="sm"

--- a/src/screens/Welcome.tsx
+++ b/src/screens/Welcome.tsx
@@ -137,7 +137,7 @@ export function WelcomeScreen() {
                       display: "flex",
                       alignItems: "center",
                       gap: 8,
-                      padding: "6px 8px",
+                      padding: "calc(6px + var(--row-step) / 2) 8px",
                       borderRadius: "var(--r-3)",
                       cursor: loading ? "default" : "pointer",
                       fontSize: "var(--fs-12)",


### PR DESCRIPTION
Fixes #70.

## The problem

`applyDensity` wrote `--row-h`, but only `PGFileTreeRow` and `PGChangeRow` read it — and both of those `var(--row-h)` uses predate the setting, so the wiring commit just pointed the var at the toggle. `data-density` had zero consumers. Flipping Compact ↔ Comfortable moved two lists by 4px and nothing else, while the Settings hint promised padding no surface added.

## The approach

One knob: **`--row-step`** — the extra vertical pixels a row spends in comfortable mode. `DENSITY_STEP_PX` in the settings store is the source of truth for the number; `applyDensity` writes the var from it, so `index.css` never hardcodes the comfortable delta and can't drift from the value JS uses.

Surfaces opt in with `calc(<own base>px + var(--row-step))`, or half a step on vertical padding (top+bottom each take half). Two properties fall out of that shape:

- **Compact is pixel-identical to before.** Step is 0, so every calc collapses to its original literal. No default layout shifts.
- **`grep -rn 'var(--row-step)' src/`** lists every density-aware surface, so the next person adding a list can see the convention (also written into CLAUDE.md).

Deliberately *not* done: converging the accidental 24/26/28/30 row-height spread onto one scale. That's a visual redesign that changes the default look, and it belongs with the #61 design review rather than a "make the toggle work" fix.

## Coverage

Newly density-aware: commit rows + graph gutter, History/Branches column headers, branch/tag/stash rows, DiffViewer + CommitDiff file lists, FileHistory, Welcome recents, hunk headers, conflict/rebase/remote rows, command palette, branch picker, rebase base picker. Reflog rows follow via `PGCommitRow`.

Left fixed on purpose: chrome (titlebar, status bar, toolbars, panel headers), and diff/code line geometry — `--lh-code` owns the editor surface, and inflating it would cut how much diff fits on screen.

Two corrections to the issue's own table, from reading the code more closely: the Reflog entry I listed is an error banner, not a row (Reflog's rows are `PGCommitRow`), and the issue missed `RebaseBasePicker`.

## The one surface that can't use the token

`PGGraphRow` draws lanes in SVG user units — `y2={height}`, bezier control points at `height / 2` — so a `calc()` on the row box alone would leave the curves at the old pitch while the rows grew, desyncing the graph in the app's most visible list. `PGCommitRow` resolves the step via `useDensityStep()` and feeds **one number** to both itself and the gutter. This was called out as the trap in #70 and it's what the tests are built around.

## Verification

- **Unit** (`src/design/git-components.density.test.tsx`) — pins row box and `<svg>` height together at both densities, and asserts the compact base is still 26 so a silent base change fails rather than being followed.
- **Store** (`useSettingsStore.test.ts`) — `--row-step` + `data-density` at load, on change, and after `reset()`, plus compact-step-is-zero.
- **E2E** (`settings.e2e.ts`) — jsdom can't resolve `calc()`, so a real webview measures four surfaces (change row via `--row-h`, branch row via a converted calc, commit row + SVG gutter via the numeric path) across a compact → comfortable → compact round trip. This test failed on exactly `changeRow` and `branchRow` before the conversion and passes after.
- `pnpm tsc --noEmit`, `pnpm exec tsc -p e2e/tsconfig.json --noEmit`, `pnpm test` (408 passing), full `pnpm test:e2e:docker` → **17/17 spec files, 86 tests passing**.

## Unrelated finding

`pnpm exec vitest run --sequence.shuffle` reliably fails 2 tests in `CommandPalette.test.tsx` (leaked `usePaletteStore` step-stack state between tests — the palette is still on a "Merge into current" pick step when a later test expects root). Verified pre-existing: the same seed fails identically with this branch's palette edit reverted. Default order hides it. Not touched here; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
