### PR TITLE
feat(ux): issue #61 Tier 1 — tree, theming, dialogs, attribution, whitespace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,11 @@ Four layers, each run independently:
     project skill** (`.claude/skills/e2e-testing/SKILL.md`) — selector
     conventions and traps, driver-bridge/5s-penalty rules, native-dialog
     stubbing, fixture geometry gotchas, rebuild discipline, debugging flow.
+  - `stubNativeDialogs()` keeps its name and options but no longer stubs
+    natives: since #61 C3 confirms/prompts are real in-page modals
+    (`[data-pg-dialog]`, `data-pg-dialog-kind`), so it installs an observer
+    that answers each one as it appears. Call sites are unchanged;
+    `confirmCallCount()` still counts confirm dialogs only.
   - CI: `.github/workflows/e2e.yml` (ubuntu-latest + xvfb, PRs to `main` +
     push to `main`). Headless local runs use `pnpm test:e2e:docker` (same
     WebKitGTK + xvfb stack) — see the "Headless e2e in Docker" section above.
@@ -224,8 +229,10 @@ design/              In-house design system (NOT components/ui/). Exports via de
 ├── primitives.tsx       PGButton, PGIconButton, etc.
 ├── chrome.tsx           PGTitlebar, PGActivityBar, PGStatusBar, PGStatusItem
 ├── git-components.tsx   Git-specific UI bits
-├── icons.tsx            Icon set (name-based <PGIcon>)
+├── icons.tsx            Icon set (name-based <PGIcon>), incl. file-type glyphs
 ├── context-menu.tsx     Context menu primitive
+├── dialog.tsx           PGDialogHost + pgConfirm/pgPrompt — the ONLY confirm /
+│                        prompt path (no window.confirm/prompt anywhere)
 ├── empty-state.tsx      Empty-state component
 ├── resizable.tsx        Resizable panes
 ├── ui-helpers.tsx       pgFlash, misc helpers
@@ -267,7 +274,10 @@ features/            Per-feature: components + Zustand store colocated
 │                    semver.ts (§11 precedence, hand-rolled + tested),
 │                    UpdateChip (titlebar), UpdatePanel (Escape via the
 │                    keymap's app.closeOverlay, not a local listener)
-├── diff/            diff-specific components
+├── diff/            CommitDiffPanel (shared commit-diff view) + WhitespaceToggle
+│                    (ignore-whitespace control; also owns
+│                    useHunkActionsDisabledReason — hunk staging is disabled
+│                    while whitespace is ignored, see #61 D2)
 └── cli/             useCliLaunch — takes the stashed first-launch intent +
                      listens for forwarded `cli-launch` events, drives
                      openRepo + nav screen-switch intent
@@ -278,7 +288,10 @@ lib/
 ├── errors.ts        AppError discriminated union 1:1 with Rust enum
 ├── derive.ts        Selectors: currentBranch, isStaged, isUnstaged, totalAheadBehind, …
 ├── highlight.ts     Syntax highlighting for preview/diff
-├── tree.ts          Tree-building helpers (file tree from flat paths)
+├── fileIcon.ts      path → file-type glyph + themeable tint (tested)
+├── tree.ts          buildStatusTree / buildStatusList — SAME row keys, which is
+│                    what makes the tree⇄flat toggle free of per-mode branches
+├── useTreeViewMode.ts  Persisted tree|flat preference, one key per surface
 └── recents.ts       Recent-repo persistence
 ```
 
@@ -317,8 +330,19 @@ lib/
 - Always wrap git2 work in `spawn_blocking` from Tauri commands — don't block async runtime.
 
 ### Styling
-- Tailwind v4 (CSS-first config). Theme tokens in `src/index.css` under `@theme { … }`. Use CSS vars (`var(--color-accent)`, `var(--bg-0)`, `var(--fg-0)`, `var(--git-*)`) or Tailwind arbitrary-value syntax.
+- Tailwind v4 (CSS-first config). Theme tokens are declared on plain `:root` in `src/index.css` (there is no `@theme {}` block). Use CSS vars (`var(--accent)`, `var(--bg-0)`, `var(--fg-0)`, `var(--git-*)`) or Tailwind arbitrary-value syntax.
 - No `tailwind.config.js` — v4 doesn't need one.
+- **`:root` is only the pre-hydration default for the themeable tokens.**
+  `applyTheme()` (`features/settings/useSettingsStore.ts`) is the source of
+  truth: besides the editable palette it writes `SEMANTIC_TOKENS`
+  (`--git-*`, `--graph-*`, `--accent-2..5`, `--shadow-*`) per theme **mode**,
+  and `SELECTION_TOKENS` (`--bg-selection*`) derived from `--accent`. Light
+  themes need their own calibration or diff colors, graph lanes and shadows
+  stay dark-calibrated over a light canvas (#61 B4). The `dark` column is kept
+  byte-identical to `index.css`; edit both or they drift.
+- Never hardcode the accent hue. Use `var(--accent)` or relative-color
+  `oklch(from var(--accent) l c h / <alpha>)` so custom themes carry through.
+- Fonts are vendored (`@fontsource-variable/*`), not assumed present.
 - Inline `style={{…}}` with CSS vars is fine and used widely in chrome components.
 - **Any new list-row surface must opt into UI density**, or the Settings toggle
   silently skips it (that's how it rotted the first time — issue #70). Write
@@ -338,6 +362,32 @@ lib/
 - New shared primitive → add to appropriate file in `src/design/` and re-export via `index.ts`.
 - `PGButton`/`PGInput` spread `...rest` onto their DOM node (so `data-testid` etc. pass through); `PGIconButton` does NOT (forwards `title` only). Row components (`PGChangeRow`, `PGCommitRow`, `PGFileTreeRow`, …) need explicit prop threading for new attributes.
 - Do NOT add `src/components/ui/`. The design system lives in `src/design/`.
+
+### Dialogs
+- **Never call `window.confirm` / `window.prompt`.** Use `pgConfirm` /
+  `pgPrompt` from `@/design` (`design/dialog.tsx`) — promise-shaped, so
+  `if (await pgConfirm(…))` replaces the native line directly. They match the
+  native contract: dismissal → `false`/`null`, Escape and backdrop dismiss, and
+  an empty prompt string stays distinct from `null`.
+- `PGConfirmOptions` carries `body`, `danger`, and `requireText` (type-the-name
+  gate) — use them for destructive ops instead of cramming everything into one
+  sentence.
+- A `<PGDialogHost />` must be mounted in each window (`AppShell`, `MergeWindow`);
+  with none mounted the calls resolve `false`/`null` rather than hanging.
+- Component tests that render a screen in isolation need `WithDialogs` from
+  `@/test/dialog`, or every confirmation silently reads as "cancelled".
+
+### File lists
+- Row glyph + tint come from `lib/fileIcon.ts` (`fileIconSpec(path)`) — one
+  category glyph per file type, per-extension tint from the `--graph-*` tokens.
+  Add a language by adding a map entry, not a new SVG.
+- `buildStatusTree` and `buildStatusList` (`lib/tree.ts`) emit the **same row
+  keys** (`"/" + full path`). That is what lets the tree⇄flat toggle
+  (`lib/useTreeViewMode.ts`) work without per-mode branches in selection,
+  staging, or context menus — keep it true.
+- Tree keyboard behavior belongs to the owning screen via `usePaneList`, not to
+  `PGFileTree`: a local `onKeyDown` plus the global dispatcher both answer
+  ArrowDown and the selection moves twice.
 
 ### Permissions (Tauri 2)
 - Shared permissions in `src-tauri/capabilities/default.json`. Current set: `core:default`, `core:window:allow-minimize`, `core:window:allow-toggle-maximize`, `core:window:allow-close`, `core:window:allow-start-dragging`, `core:window:allow-set-title`, `core:webview:allow-create-webview-window`, `dialog:default`, `dialog:allow-open`, `os:default`, `log:default`. Capability scopes `windows: ["main", "merge"]` (merge resolver runs as a second window).

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -242,27 +242,93 @@ export function buildExecuteOnceScript(fn: (...args: never[]) => unknown): strin
   `;
 }
 
-/** WebDriver can't drive native prompt/confirm — stub them in-page BEFORE the
- *  action that triggers them. Reset by any refresh.
- *  `promptQueue`: successive `window.prompt` calls consume queue entries in
- *  order (Add remote fires TWO prompts: name, then URL — a single string
- *  would set name === url). Falls back to `promptText` when drained.
- *  Confirm calls are counted on `window.__pgConfirmCalls` — read it via
- *  `confirmCallCount()` to prove a confirm gate fired (or didn't). */
+/** Auto-answer the app's confirm/prompt dialogs. Install BEFORE the action that
+ *  triggers them; reset by any refresh.
+ *
+ *  These used to be native `window.confirm` / `window.prompt`, which WebDriver
+ *  can't drive, so they were stubbed out. Since #61 C3 they are real in-page
+ *  modals (`[data-pg-dialog]`) that a driver CAN click — but a spec would then
+ *  have to interleave a click into every destructive action. Instead this
+ *  installs an observer that answers each dialog as it appears, so every call
+ *  site below keeps the same shape it had against the native stubs.
+ *
+ *  `promptQueue`: successive PROMPT dialogs consume queue entries in order
+ *  (Add remote fires TWO: name, then URL — a single string would set
+ *  name === url). Falls back to `promptText` when drained.
+ *  `confirm: false` dismisses instead of accepting.
+ *  Confirm dialogs are counted on `window.__pgConfirmCalls` — read it via
+ *  `confirmCallCount()` to prove a confirm gate fired (or didn't). Prompts are
+ *  not counted, matching the old native-stub behavior. */
 export async function stubNativeDialogs(
   opts: { promptText?: string; confirm?: boolean; promptQueue?: string[] } = {},
 ): Promise<void> {
   // executeOnce: a driver-retry re-run would zero __pgConfirmCalls after a
-  // confirm already fired and re-clone the prompt queue mid-consumption.
+  // confirm already fired, re-clone the prompt queue mid-consumption, and
+  // attach a second observer that double-answers every dialog.
   await executeOnce(
     (promptText: string | null, confirm: boolean, queue: string[]) => {
       const q = [...queue];
-      (window as any).__pgConfirmCalls = 0;
-      (window as any).prompt = () => (q.length ? q.shift()! : promptText);
-      (window as any).confirm = () => {
-        (window as any).__pgConfirmCalls++;
+      const w = window as any;
+      w.__pgConfirmCalls = 0;
+
+      // Natives are still stubbed: harmless, and keeps any path that has not
+      // been converted from blocking the driver.
+      w.prompt = () => (q.length ? q.shift()! : promptText);
+      w.confirm = () => {
+        w.__pgConfirmCalls++;
         return confirm;
       };
+
+      const handled = new WeakSet<Element>();
+      const testId = (root: Element, id: string) =>
+        root.querySelector<HTMLElement>(`[data-testid="${id}"]`);
+
+      const answer = () => {
+        const root = document.querySelector("[data-pg-dialog]");
+        if (!root || handled.has(root)) return;
+        handled.add(root);
+
+        if (root.getAttribute("data-pg-dialog-kind") === "confirm") {
+          w.__pgConfirmCalls++;
+        }
+
+        const input = testId(root, "dialog-input") as HTMLInputElement | null;
+        if (confirm && input) {
+          // React tracks the previous value on the DOM node, so assigning
+          // `.value` directly is swallowed as a no-op change. Go through the
+          // prototype setter, then dispatch the event React listens for.
+          const value = q.length ? q.shift()! : (promptText ?? "");
+          const setter = Object.getOwnPropertyDescriptor(
+            window.HTMLInputElement.prototype,
+            "value",
+          )?.set;
+          setter?.call(input, value);
+          input.dispatchEvent(new Event("input", { bubbles: true }));
+        }
+
+        // `requireValue` / `requireText` keep the primary button disabled until
+        // React has re-rendered with the value above, so poll briefly rather
+        // than clicking into the void.
+        const wanted = confirm ? "dialog-confirm" : "dialog-cancel";
+        let tries = 0;
+        const click = () => {
+          const live = document.querySelector("[data-pg-dialog]");
+          if (!live) return;
+          const btn = testId(live, wanted) as HTMLButtonElement | null;
+          if (btn && !btn.disabled) {
+            btn.click();
+            return;
+          }
+          if (tries++ < 50) setTimeout(click, 20);
+        };
+        setTimeout(click, 0);
+      };
+
+      // A dialog already up when this installs is answered too.
+      const obs = new MutationObserver(() => answer());
+      obs.observe(document.body, { childList: true, subtree: true });
+      w.__pgDialogObserver = obs;
+      answer();
     },
     opts.promptText ?? "e2e",
     opts.confirm ?? true,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "@codemirror/commands": "^6.10.4",
     "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.6",
+    "@fontsource-variable/inter": "5.3.0",
+    "@fontsource-variable/jetbrains-mono": "5.3.0",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-log": "^2.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       '@codemirror/view':
         specifier: ^6.43.6
         version: 6.43.6
+      '@fontsource-variable/inter':
+        specifier: 5.3.0
+        version: 5.3.0
+      '@fontsource-variable/jetbrains-mono':
+        specifier: 5.3.0
+        version: 5.3.0
       '@tauri-apps/api':
         specifier: ^2
         version: 2.10.1
@@ -564,6 +570,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fontsource-variable/inter@5.3.0':
+    resolution: {integrity: sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==}
+
+  '@fontsource-variable/jetbrains-mono@5.3.0':
+    resolution: {integrity: sha512-F32xpS2NsGYoQi2ADSkKTgpJj7ozajsGgDJ8woTnqjmIB+dxDIqImjl4pXZVEExu8UFZ2ndhmX18EBS/hdz3Lw==}
 
   '@inquirer/ansi@1.0.2':
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
@@ -3646,6 +3658,10 @@ snapshots:
 
   '@esbuild/win32-x64@0.28.1':
     optional: true
+
+  '@fontsource-variable/inter@5.3.0': {}
+
+  '@fontsource-variable/jetbrains-mono@5.3.0': {}
 
   '@inquirer/ansi@1.0.2': {}
 

--- a/src-tauri/src/commands/commits.rs
+++ b/src-tauri/src/commands/commits.rs
@@ -2,7 +2,7 @@ use tauri::State;
 
 use crate::{
     error::{AppError, AppResult},
-    git::types::{CommitInfo, CommitOptions, LogFilter, RepoId},
+    git::types::{AuthorOverride, CommitInfo, CommitOptions, LogFilter, RepoId},
     state::AppState,
 };
 
@@ -59,13 +59,17 @@ pub async fn commit(
     message: String,
     amend: bool,
     signoff: Option<bool>,
+    // "Commit as someone else" — the backend has honored this since the commit
+    // op was written; nothing sent it until #61 D1. Absent means "use the repo
+    // config identity", which is the overwhelmingly common case.
+    author_override: Option<AuthorOverride>,
 ) -> AppResult<String> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
     let opts = CommitOptions {
         message,
         amend,
-        author_override: None,
+        author_override,
         signoff: signoff.unwrap_or(false),
     };
     tokio::task::spawn_blocking(move || backend.commit(&repo_id, opts))

--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -69,11 +69,15 @@ pub async fn get_diff(
     path: String,
     kind: DiffKind,
     context_lines: u32,
+    // Viewing option only — see the `diff` doc on GitBackend. Optional so an
+    // older caller (or a test) that omits it keeps the exact git default.
+    ignore_whitespace: Option<bool>,
 ) -> AppResult<FileDiff> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
     let path = PathBuf::from(path);
-    tokio::task::spawn_blocking(move || backend.diff(&repo_id, &path, kind, context_lines))
+    let iw = ignore_whitespace.unwrap_or(false);
+    tokio::task::spawn_blocking(move || backend.diff(&repo_id, &path, kind, context_lines, iw))
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
 }
@@ -127,11 +131,13 @@ pub async fn diff_commits(
     from_oid: String,
     to_oid: String,
     context_lines: u32,
+    ignore_whitespace: Option<bool>,
 ) -> AppResult<Vec<FileDiff>> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
+    let iw = ignore_whitespace.unwrap_or(false);
     tokio::task::spawn_blocking(move || {
-        backend.diff_commits(&repo_id, &from_oid, &to_oid, context_lines)
+        backend.diff_commits(&repo_id, &from_oid, &to_oid, context_lines, iw)
     })
     .await
     .map_err(|e| AppError::Internal(e.to_string()))?
@@ -143,10 +149,12 @@ pub async fn diff_commit(
     repo_id: String,
     oid: String,
     context_lines: u32,
+    ignore_whitespace: Option<bool>,
 ) -> AppResult<Vec<FileDiff>> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
-    tokio::task::spawn_blocking(move || backend.diff_commit(&repo_id, &oid, context_lines))
+    let iw = ignore_whitespace.unwrap_or(false);
+    tokio::task::spawn_blocking(move || backend.diff_commit(&repo_id, &oid, context_lines, iw))
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
 }

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -71,6 +71,7 @@ impl GitBackend for CliBackend {
         _path: &Path,
         _kind: DiffKind,
         _context_lines: u32,
+        _ignore_whitespace: bool,
     ) -> AppResult<FileDiff> {
         Err(AppError::NotImplemented)
     }
@@ -94,6 +95,7 @@ impl GitBackend for CliBackend {
         _from_oid: &str,
         _to_oid: &str,
         _context_lines: u32,
+        _ignore_whitespace: bool,
     ) -> AppResult<Vec<FileDiff>> {
         Err(AppError::NotImplemented)
     }
@@ -102,6 +104,7 @@ impl GitBackend for CliBackend {
         _repo_id: &RepoId,
         _oid: &str,
         _context_lines: u32,
+        _ignore_whitespace: bool,
     ) -> AppResult<Vec<FileDiff>> {
         Err(AppError::NotImplemented)
     }

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -1186,6 +1186,7 @@ impl GitBackend for Libgit2Backend {
         path: &Path,
         kind: DiffKind,
         context_lines: u32,
+        ignore_whitespace: bool,
     ) -> AppResult<FileDiff> {
         self.with_repo(repo_id, |repo| {
             // Without this the diff comes back valid but empty — a blank panel
@@ -1194,6 +1195,7 @@ impl GitBackend for Libgit2Backend {
             let mut opts = DiffOptions::new();
             opts.pathspec(path);
             opts.context_lines(context_lines);
+            opts.ignore_whitespace(ignore_whitespace);
             // Include untracked files as if their full content were a new addition
             // so the diff viewer shows file contents for newly created files.
             if matches!(kind, DiffKind::WorktreeToIndex | DiffKind::WorktreeToHead) {
@@ -1495,6 +1497,7 @@ impl GitBackend for Libgit2Backend {
         from_oid: &str,
         to_oid: &str,
         context_lines: u32,
+        ignore_whitespace: bool,
     ) -> AppResult<Vec<FileDiff>> {
         self.with_repo(repo_id, |repo| {
             let from = repo.revparse_single(from_oid)?.peel_to_commit()?.id();
@@ -1504,6 +1507,7 @@ impl GitBackend for Libgit2Backend {
 
             let mut opts = DiffOptions::new();
             opts.context_lines(context_lines);
+            opts.ignore_whitespace(ignore_whitespace);
             let mut diff =
                 repo.diff_tree_to_tree(Some(&from_tree), Some(&to_tree), Some(&mut opts))?;
 
@@ -1520,6 +1524,7 @@ impl GitBackend for Libgit2Backend {
         repo_id: &RepoId,
         oid: &str,
         context_lines: u32,
+        ignore_whitespace: bool,
     ) -> AppResult<Vec<FileDiff>> {
         self.with_repo(repo_id, |repo| {
             let commit = repo.revparse_single(oid)?.peel_to_commit()?;
@@ -1532,6 +1537,7 @@ impl GitBackend for Libgit2Backend {
 
             let mut opts = DiffOptions::new();
             opts.context_lines(context_lines);
+            opts.ignore_whitespace(ignore_whitespace);
             let mut diff = repo.diff_tree_to_tree(
                 from_tree.as_ref(),
                 Some(&to_tree),

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -57,12 +57,19 @@ pub trait GitBackend: Send + Sync {
     fn read_reflog(&self, repo_id: &RepoId) -> AppResult<Vec<ReflogEntry>>;
     /// Diff a single file. `context_lines` controls how many unchanged lines
     /// surround each hunk (git default: 3).
+    ///
+    /// `ignore_whitespace` turns lines that differ only in whitespace into
+    /// context lines. It is a VIEWING option only: the hunks it produces are
+    /// not the hunks git would apply, so a hunk index taken from such a diff
+    /// must never be fed to `stage_hunk`/`unstage_hunk`/`discard_hunk` — see
+    /// the note on those.
     fn diff(
         &self,
         repo_id: &RepoId,
         path: &Path,
         kind: DiffKind,
         context_lines: u32,
+        ignore_whitespace: bool,
     ) -> AppResult<FileDiff>;
     /// Read the full content of a file from the worktree. Falls back to the
     /// HEAD blob when the worktree copy is missing (e.g. a deleted file).
@@ -89,6 +96,7 @@ pub trait GitBackend: Send + Sync {
         from_oid: &str,
         to_oid: &str,
         context_lines: u32,
+        ignore_whitespace: bool,
     ) -> AppResult<Vec<FileDiff>>;
     /// Diff a single commit against its first parent — i.e. "what this commit
     /// changed." A root commit (no parent) diffs against the empty tree
@@ -100,6 +108,7 @@ pub trait GitBackend: Send + Sync {
         repo_id: &RepoId,
         oid: &str,
         context_lines: u32,
+        ignore_whitespace: bool,
     ) -> AppResult<Vec<FileDiff>>;
     fn branches(&self, repo_id: &RepoId) -> AppResult<Vec<BranchInfo>>;
     fn tags(&self, repo_id: &RepoId) -> AppResult<Vec<TagInfo>>;
@@ -120,6 +129,11 @@ pub trait GitBackend: Send + Sync {
     // Callers MUST pass the same `context_lines` they used for the `diff` that
     // displayed the hunks — a different context width can merge/split hunks
     // and shift indices, applying the wrong hunk.
+    //
+    // For the same reason these take no `ignore_whitespace`: that flag rewrites
+    // whitespace-only changes into context lines, so its hunks neither line up
+    // with these indices nor describe a patch that would apply. The UI disables
+    // hunk staging while the whitespace-ignore toggle is on (#61 D2).
     /// Stage a single hunk (by index into the WorktreeToIndex diff) for `path`.
     fn stage_hunk(
         &self,

--- a/src-tauri/tests/diff_commit.rs
+++ b/src-tauri/tests/diff_commit.rs
@@ -13,7 +13,7 @@ fn diff_commit_shows_only_that_commits_change() {
     // Two more commits, each adding one file.
     let oids = support::linear_history(&tr, 2); // file0.txt, file1.txt
 
-    let diffs = backend.diff_commit(&handle.id, &oids[1], 3).unwrap();
+    let diffs = backend.diff_commit(&handle.id, &oids[1], 3, false).unwrap();
 
     assert_eq!(diffs.len(), 1, "only the file this commit touched");
     assert_eq!(diffs[0].path, "file1.txt");
@@ -35,7 +35,7 @@ fn diff_commit_root_is_all_added() {
         .oid
         .clone();
 
-    let diffs = backend.diff_commit(&handle.id, &root, 3).unwrap();
+    let diffs = backend.diff_commit(&handle.id, &root, 3, false).unwrap();
 
     let readme = diffs.iter().find(|d| d.path == "README.md").expect("README.md in root diff");
     assert!(readme.additions >= 2, "both lines added");
@@ -85,7 +85,7 @@ fn diff_commit_merge_uses_first_parent() {
             .to_string()
     };
 
-    let diffs = backend.diff_commit(&handle.id, &merge_oid, 3).unwrap();
+    let diffs = backend.diff_commit(&handle.id, &merge_oid, 3, false).unwrap();
     let paths: Vec<&str> = diffs.iter().map(|d| d.path.as_str()).collect();
 
     // feat.txt is what the merge brings in relative to the first parent (main).

--- a/src-tauri/tests/diff_commits_revspec.rs
+++ b/src-tauri/tests/diff_commits_revspec.rs
@@ -21,7 +21,7 @@ fn diff_commits_accepts_head_revspec() {
 
     // Should not error even though "HEAD" is not a 40-char hex OID.
     let diffs = backend
-        .diff_commits(&handle.id, &initial, "HEAD", 3)
+        .diff_commits(&handle.id, &initial, "HEAD", 3, false)
         .unwrap();
     assert!(!diffs.is_empty());
 }

--- a/src-tauri/tests/embedded_repo.rs
+++ b/src-tauri/tests/embedded_repo.rs
@@ -222,7 +222,7 @@ fn diff_rejects_the_embedded_repo_instead_of_returning_an_empty_diff() {
 
     for path in ["vendor/lib/", "vendor/lib"] {
         let err = backend
-            .diff(&handle.id, &PathBuf::from(path), DiffKind::WorktreeToHead, 3)
+            .diff(&handle.id, &PathBuf::from(path), DiffKind::WorktreeToHead, 3, false)
             .unwrap_err();
         assert!(matches!(err, AppError::EmbeddedRepo(p) if p == path));
     }
@@ -263,7 +263,7 @@ fn guards_leave_ordinary_paths_alone() {
 
     let readme = PathBuf::from("README.md");
     assert!(backend
-        .diff(&handle.id, &readme, DiffKind::WorktreeToHead, 3)
+        .diff(&handle.id, &readme, DiffKind::WorktreeToHead, 3, false)
         .is_ok());
     assert!(backend.blame_file(&handle.id, &readme).is_ok());
     assert_eq!(

--- a/src-tauri/tests/hunks.rs
+++ b/src-tauri/tests/hunks.rs
@@ -70,6 +70,7 @@ fn worktree_diff_has_exactly_two_hunks_before_staging() {
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::WorktreeToIndex,
             3,
+            false,
         )
         .expect("diff");
     assert_eq!(
@@ -94,6 +95,7 @@ fn stage_hunk_0_stages_only_first_region() {
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::IndexToHead,
             3,
+            false,
         )
         .expect("index diff");
     assert_eq!(
@@ -109,6 +111,7 @@ fn stage_hunk_0_stages_only_first_region() {
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::WorktreeToIndex,
             3,
+            false,
         )
         .expect("worktree diff");
     assert_eq!(
@@ -141,6 +144,7 @@ fn stage_hunk_1_stages_only_second_region() {
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::IndexToHead,
             3,
+            false,
         )
         .expect("index diff");
     assert_eq!(index_diff.hunks.len(), 1, "index should have 1 hunk (line 17)");
@@ -152,6 +156,7 @@ fn stage_hunk_1_stages_only_second_region() {
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::WorktreeToIndex,
             3,
+            false,
         )
         .expect("worktree diff");
     assert_eq!(wt_diff.hunks.len(), 1, "worktree should have 1 hunk remaining (line 3)");
@@ -180,6 +185,7 @@ fn unstage_hunk_0_removes_only_first_region_from_index() {
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::IndexToHead,
             3,
+            false,
         )
         .expect("index diff before unstage");
     assert_eq!(
@@ -200,6 +206,7 @@ fn unstage_hunk_0_removes_only_first_region_from_index() {
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::IndexToHead,
             3,
+            false,
         )
         .expect("index diff after unstage");
     assert_eq!(
@@ -225,6 +232,7 @@ fn discard_hunk_0_reverts_only_first_region_in_worktree() {
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::WorktreeToIndex,
             3,
+            false,
         )
         .expect("worktree diff after discard");
     assert_eq!(
@@ -299,6 +307,7 @@ fn worktree_diff_includes_untracked_file_content() {
             &std::path::Path::new("new.txt"),
             platypusgit_lib::git::types::DiffKind::WorktreeToIndex,
             3,
+            false,
         )
         .expect("diff");
 
@@ -327,6 +336,7 @@ fn context_lines_widens_hunks_and_merges_nearby_changes() {
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::WorktreeToIndex,
             3,
+            false,
         )
         .expect("diff context=3");
     assert_eq!(narrow.hunks.len(), 2, "context=3 should keep 2 separate hunks");
@@ -337,6 +347,7 @@ fn context_lines_widens_hunks_and_merges_nearby_changes() {
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::WorktreeToIndex,
             10,
+            false,
         )
         .expect("diff context=10");
     assert_eq!(wide.hunks.len(), 1, "context=10 should merge into 1 hunk");
@@ -348,6 +359,7 @@ fn context_lines_widens_hunks_and_merges_nearby_changes() {
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::WorktreeToIndex,
             0,
+            false,
         )
         .expect("diff context=0");
     assert_eq!(zero.hunks.len(), 2, "context=0 keeps 2 hunks");
@@ -377,6 +389,7 @@ fn stage_hunk_with_wide_context_stages_merged_hunk() {
             &std::path::Path::new("data.txt"),
             platypusgit_lib::git::types::DiffKind::WorktreeToIndex,
             10,
+            false,
         )
         .expect("worktree diff after staging");
     assert_eq!(

--- a/src-tauri/tests/reflog.rs
+++ b/src-tauri/tests/reflog.rs
@@ -112,7 +112,7 @@ fn diff_commits_returns_per_file_diffs_between_two_commits() {
     let grandparent_oid = commits[2].oid.clone();
 
     let diffs = backend
-        .diff_commits(&handle.id, &grandparent_oid, &head_oid, 3)
+        .diff_commits(&handle.id, &grandparent_oid, &head_oid, 3, false)
         .unwrap();
 
     // grandparent -> HEAD adds two.txt and three.txt.

--- a/src-tauri/tests/whitespace_diff.rs
+++ b/src-tauri/tests/whitespace_diff.rs
@@ -1,0 +1,173 @@
+//! `ignore_whitespace` on the diff read paths (#61 D2).
+//!
+//! The flag is a VIEWING option: it turns lines that differ only in whitespace
+//! into context lines, so reviewing a reformatted file shows only the real
+//! edits. That same rewriting is why hunk indices from such a diff must never
+//! reach `stage_hunk`/`discard_hunk` — the last test here pins the divergence
+//! that makes the UI disable hunk staging while the toggle is on.
+
+mod support;
+
+use std::path::Path;
+
+use platypusgit_lib::git::types::DiffKind;
+use platypusgit_lib::git::GitBackend;
+
+use support::{fs::write_file, TempRepo};
+
+const ORIGINAL: &str = "alpha\nbeta\ngamma\ndelta\nepsilon\nzeta\neta\ntheta\n";
+/// `beta` gains trailing whitespace and `eta` gains leading indent — no real
+/// change. `delta` is genuinely rewritten.
+const REFORMATTED: &str = "alpha\nbeta   \ngamma\nDELTA\nepsilon\nzeta\n    eta\ntheta\n";
+
+fn repo_with_reformatting() -> (
+    TempRepo,
+    platypusgit_lib::git::libgit2::Libgit2Backend,
+    platypusgit_lib::git::types::RepoHandle,
+) {
+    let tr = TempRepo::fresh();
+    write_file(tr.path(), "data.txt", ORIGINAL);
+    tr.commit_all("initial");
+    write_file(tr.path(), "data.txt", REFORMATTED);
+    let (backend, handle) = tr.open_with_backend();
+    (tr, backend, handle)
+}
+
+fn changed_lines(diff: &platypusgit_lib::git::types::FileDiff) -> Vec<String> {
+    diff.hunks
+        .iter()
+        .flat_map(|h| h.lines.iter())
+        .filter(|l| !matches!(l.kind, platypusgit_lib::git::types::DiffLineKind::Context))
+        .map(|l| l.content.trim_end_matches('\n').to_string())
+        .collect()
+}
+
+#[test]
+fn whitespace_only_changes_disappear_when_ignored() {
+    let (_tr, backend, handle) = repo_with_reformatting();
+
+    let plain = backend
+        .diff(
+            &handle.id,
+            Path::new("data.txt"),
+            DiffKind::WorktreeToHead,
+            3,
+            false,
+        )
+        .expect("plain diff");
+    let ignored = backend
+        .diff(
+            &handle.id,
+            Path::new("data.txt"),
+            DiffKind::WorktreeToHead,
+            3,
+            true,
+        )
+        .expect("whitespace-ignoring diff");
+
+    // Plain: all three edits show. Ignoring: only the real one.
+    let plain_lines = changed_lines(&plain);
+    assert!(
+        plain_lines.iter().any(|l| l.contains("beta")),
+        "plain diff should show the whitespace-only beta change: {plain_lines:?}",
+    );
+    assert!(
+        plain_lines.iter().any(|l| l.contains("eta")),
+        "plain diff should show the re-indented eta line: {plain_lines:?}",
+    );
+
+    let ignored_lines = changed_lines(&ignored);
+    assert!(
+        ignored_lines.iter().any(|l| l.contains("DELTA")),
+        "real edit must survive the whitespace filter: {ignored_lines:?}",
+    );
+    assert!(
+        !ignored_lines.iter().any(|l| l.trim() == "beta"),
+        "whitespace-only beta change should be gone: {ignored_lines:?}",
+    );
+    assert!(
+        ignored.additions < plain.additions,
+        "ignoring whitespace must reduce the counted additions ({} vs {})",
+        ignored.additions,
+        plain.additions,
+    );
+}
+
+#[test]
+fn flag_is_off_by_default_for_commit_diffs() {
+    let tr = TempRepo::fresh();
+    write_file(tr.path(), "data.txt", ORIGINAL);
+    let first = tr.commit_all("initial");
+    write_file(tr.path(), "data.txt", REFORMATTED);
+    let second = tr.commit_all("reformat");
+    let (backend, handle) = tr.open_with_backend();
+
+    let plain = backend
+        .diff_commits(
+            &handle.id,
+            &first.to_string(),
+            &second.to_string(),
+            3,
+            false,
+        )
+        .expect("plain commit diff");
+    let ignored = backend
+        .diff_commits(
+            &handle.id,
+            &first.to_string(),
+            &second.to_string(),
+            3,
+            true,
+        )
+        .expect("ignoring commit diff");
+
+    assert!(
+        ignored[0].additions < plain[0].additions,
+        "diff_commits must honor the flag ({} vs {})",
+        ignored[0].additions,
+        plain[0].additions,
+    );
+
+    // diff_commit (against first parent) honors it too.
+    let plain_one = backend
+        .diff_commit(&handle.id, &second.to_string(), 3, false)
+        .expect("plain diff_commit");
+    let ignored_one = backend
+        .diff_commit(&handle.id, &second.to_string(), 3, true)
+        .expect("ignoring diff_commit");
+    assert!(ignored_one[0].additions < plain_one[0].additions);
+}
+
+#[test]
+fn hunk_indices_diverge_from_the_ignoring_view() {
+    // This is WHY hunk staging is disabled while the toggle is on: the two
+    // views do not agree on how many hunks the file has, so an index taken
+    // from the ignoring view would apply a different hunk (or none).
+    let (_tr, backend, handle) = repo_with_reformatting();
+
+    let plain = backend
+        .diff(
+            &handle.id,
+            Path::new("data.txt"),
+            DiffKind::WorktreeToIndex,
+            0,
+            false,
+        )
+        .expect("plain diff");
+    let ignored = backend
+        .diff(
+            &handle.id,
+            Path::new("data.txt"),
+            DiffKind::WorktreeToIndex,
+            0,
+            true,
+        )
+        .expect("ignoring diff");
+
+    assert!(
+        plain.hunks.len() > ignored.hunks.len(),
+        "expected the ignoring view to collapse hunks ({} vs {})",
+        plain.hunks.len(),
+        ignored.hunks.len(),
+    );
+}

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import {
   PGActivityBar,
   PGButton,
+  PGDialogHost,
   PGIconButton,
   PGStatusBar,
   PGStatusItem,
@@ -250,6 +251,9 @@ export function AppShell() {
       }}
     >
       <AppTitlebar onOpenSettings={() => setScreen("settings")} />
+      {/* Styled confirm/prompt host — pgConfirm/pgPrompt resolve false/null
+          unless one of these is mounted. */}
+      <PGDialogHost />
       <UpdatePanel />
       <CheatSheet />
       {error && (

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -1,6 +1,7 @@
 import React, { type CSSProperties, type MouseEvent, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { PGIcon, type IconName } from "./icons";
+import { pgConfirm, pgPrompt } from "./dialog";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { buildRebasePlan } from "@/features/commits/buildRebasePlan";
@@ -17,7 +18,8 @@ export interface ContextMenuItem {
   divider?: boolean;
   __menuTitle?: string;
   submenu?: ContextMenuItem[];
-  onClick?: () => void;
+  /** May be async — the styled confirm/prompt dialogs are promise-based. */
+  onClick?: () => void | Promise<void>;
 }
 
 // Tiny toast
@@ -73,7 +75,9 @@ function ContextMenuItemView({
     if (disabled) return;
     if (hasSubmenu) return;
     e.stopPropagation();
-    item.onClick?.();
+    // Fire-and-forget: an async handler awaits a dialog long after the menu
+    // has closed, and nothing here consumes its result.
+    void item.onClick?.();
     onClose();
   };
 
@@ -346,9 +350,15 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
     {
       icon: "check",
       label: "Check out this commit",
-      onClick: () => {
+      onClick: async () => {
         if (!commit?.sha) return;
-        if (window.confirm(`Check out ${sha.slice(0, 7)} in detached HEAD?`))
+        if (
+          await pgConfirm({
+            title: `Check out ${sha.slice(0, 7)} in detached HEAD?`,
+            body: "You won't be on a branch. New commits are easy to lose unless you create one.",
+            confirmLabel: "Check out",
+          })
+        )
           useRepoStore.getState().checkoutRef(commit.sha);
       },
     },
@@ -357,7 +367,14 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
       label: "Create branch from here…",
       onClick: async () => {
         if (!commit?.sha) return;
-        const name = window.prompt("New branch name");
+        const name = await pgPrompt({
+          title: "Create branch from here",
+          body: `Branching at ${sha.slice(0, 7)}.`,
+          placeholder: "feat/my-branch",
+          confirmLabel: "Create",
+          requireValue: true,
+          mono: true,
+        });
         if (!name) return;
         await useRepoStore.getState().createBranch(name, commit.sha);
         await useRepoStore.getState().checkoutBranch(name);
@@ -366,8 +383,15 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
     {
       icon: "tag",
       label: "Create tag here…",
-      onClick: () => {
-        const name = window.prompt("Tag name");
+      onClick: async () => {
+        const name = await pgPrompt({
+          title: "Create tag here",
+          body: `Tagging ${sha.slice(0, 7)}.`,
+          placeholder: "v1.0.0",
+          confirmLabel: "Create tag",
+          requireValue: true,
+          mono: true,
+        });
         if (!name || !commit) return;
         useRepoStore.getState().createTag(name, {
           oid: commit.sha ?? "",
@@ -450,9 +474,15 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
     {
       icon: "squash",
       label: "Squash this commit into its parent",
-      onClick: () => {
+      onClick: async () => {
         if (!commit?.sha) return;
-        const msg = window.prompt("New commit message for squashed commit");
+        const msg = await pgPrompt({
+          title: "Squash into parent",
+          body: "Message for the combined commit.",
+          initialValue: commit.subject ?? "",
+          confirmLabel: "Squash",
+          requireValue: true,
+        });
         if (!msg) return;
         const commits = useRepoStore.getState().commits;
         const idx = commits.findIndex((c) => c.oid === commit.sha);
@@ -535,11 +565,13 @@ export function commitMultiMenuItems(oids: string[]): ContextMenuItem[] {
     {
       icon: "rebase",
       label: `Cherry-pick ${n} onto current`,
-      onClick: () => {
+      onClick: async () => {
         if (
-          window.confirm(
-            `Cherry-pick ${n} commits onto the current branch (oldest first)?`,
-          )
+          await pgConfirm({
+            title: `Cherry-pick ${n} commits onto the current branch?`,
+            body: "They are applied oldest first.",
+            confirmLabel: "Cherry-pick",
+          })
         )
           useRepoStore.getState().cherryPickMany(plan.oids);
       },
@@ -548,9 +580,14 @@ export function commitMultiMenuItems(oids: string[]): ContextMenuItem[] {
       icon: "squash",
       label: squashBlock ? `Squash ${n} — ${squashBlock}` : `Squash ${n} into one…`,
       disabled: !!squashBlock,
-      onClick: () => {
+      onClick: async () => {
         if (squashBlock || !plan.baseOid) return;
-        const msg = window.prompt("New commit message for the squashed commit");
+        const msg = await pgPrompt({
+          title: `Squash ${n} commits into one`,
+          body: "Message for the combined commit.",
+          confirmLabel: "Squash",
+          requireValue: true,
+        });
         if (!msg) return;
         const rebasePlan = buildRebasePlan(commits, plan.baseOid, {
           kind: "squash-range",
@@ -593,12 +630,13 @@ export function branchMenuItems(
       icon: "merge",
       label: "Merge into current",
       disabled: isCurrent,
-      onClick: () => {
+      onClick: async () => {
         if (!name) return;
         if (
-          window.confirm(
-            `Merge ${name} into the current branch?`,
-          )
+          await pgConfirm({
+            title: `Merge ${name} into the current branch?`,
+            confirmLabel: "Merge",
+          })
         )
           useRepoStore.getState().mergeBranch(name);
       },
@@ -607,12 +645,14 @@ export function branchMenuItems(
       icon: "rebase",
       label: "Rebase current onto this",
       disabled: isCurrent,
-      onClick: () => {
+      onClick: async () => {
         if (!name) return;
         if (
-          window.confirm(
-            `Rebase the current branch onto ${name}?`,
-          )
+          await pgConfirm({
+            title: `Rebase the current branch onto ${name}?`,
+            body: "Your commits are replayed on top — their SHAs change.",
+            confirmLabel: "Rebase",
+          })
         )
           useRepoStore.getState().rebaseOnto(name);
       },
@@ -642,8 +682,14 @@ export function branchMenuItems(
     {
       icon: "edit",
       label: "Rename…",
-      onClick: () => {
-        const to = window.prompt("New name", name);
+      onClick: async () => {
+        const to = await pgPrompt({
+          title: `Rename ${name}`,
+          initialValue: name,
+          confirmLabel: "Rename",
+          requireValue: true,
+          mono: true,
+        });
         if (to && to !== name) useRepoStore.getState().renameBranch(name, to);
       },
     },
@@ -661,8 +707,14 @@ export function branchMenuItems(
       label: "Delete",
       danger: true,
       disabled: isCurrent,
-      onClick: () => {
-        if (window.confirm(`Delete ${name}?`))
+      onClick: async () => {
+        if (
+          await pgConfirm({
+            title: `Delete branch ${name}?`,
+            danger: true,
+            confirmLabel: "Delete",
+          })
+        )
           useRepoStore.getState().deleteBranch(name);
       },
     },
@@ -671,8 +723,15 @@ export function branchMenuItems(
       label: "Force delete (-D)",
       danger: true,
       disabled: isCurrent,
-      onClick: () => {
-        if (window.confirm(`Force-delete ${name}? This will discard unmerged commits.`))
+      onClick: async () => {
+        if (
+          await pgConfirm({
+            title: `Force-delete branch ${name}?`,
+            body: "Unmerged commits on it are discarded and are not recoverable from the branch.",
+            danger: true,
+            confirmLabel: "Force delete",
+          })
+        )
           useRepoStore.getState().deleteBranch(name, true);
       },
     },
@@ -690,32 +749,46 @@ export function remoteBranchMenuItems(branch: { name?: string } | null): Context
     {
       icon: "branch",
       label: "Check out as new local branch…",
-      onClick: () => {
+      onClick: async () => {
         if (!name) return;
-        const localName = window.prompt("Local branch name", shortName);
+        const localName = await pgPrompt({
+          title: "Check out as new local branch",
+          body: `Tracking ${name}.`,
+          initialValue: shortName,
+          confirmLabel: "Check out",
+          requireValue: true,
+          mono: true,
+        });
         if (!localName) return;
-        (async () => {
-          await useRepoStore.getState().createBranch(localName, name);
-          await useRepoStore.getState().checkoutBranch(localName);
-        })();
+        await useRepoStore.getState().createBranch(localName, name);
+        await useRepoStore.getState().checkoutBranch(localName);
       },
     },
     {
       icon: "merge",
       label: "Merge into current",
-      onClick: () => {
+      onClick: async () => {
         if (!name) return;
-        if (window.confirm(`Merge ${name} into the current branch?`))
+        if (
+          await pgConfirm({
+            title: `Merge ${name} into the current branch?`,
+            confirmLabel: "Merge",
+          })
+        )
           useRepoStore.getState().mergeBranch(name);
       },
     },
     {
       icon: "rebase",
       label: "Rebase current onto this",
-      onClick: () => {
+      onClick: async () => {
         if (!name) return;
         if (
-          window.confirm(`Rebase the current branch onto ${name}?`)
+          await pgConfirm({
+            title: `Rebase the current branch onto ${name}?`,
+            body: "Your commits are replayed on top — their SHAs change.",
+            confirmLabel: "Rebase",
+          })
         )
           useRepoStore.getState().rebaseOnto(name);
       },
@@ -749,12 +822,16 @@ export function remoteBranchMenuItems(branch: { name?: string } | null): Context
       icon: "trash",
       label: "Delete on remote",
       danger: true,
-      onClick: () => {
+      onClick: async () => {
         if (!remoteName || !shortName) return;
         if (
-          window.confirm(
-            `Delete ${shortName} on ${remoteName}? This cannot be undone.`,
-          )
+          await pgConfirm({
+            title: `Delete ${shortName} on ${remoteName}?`,
+            body: "This deletes the branch for everyone and cannot be undone from here. Type the branch name to confirm.",
+            danger: true,
+            confirmLabel: "Delete on remote",
+            requireText: shortName,
+          })
         )
           useRepoStore.getState().pushDeleteBranch(remoteName, shortName);
       },
@@ -781,8 +858,15 @@ export function remoteMenuItems(remote: { name?: string; url?: string | null } |
     {
       icon: "edit",
       label: "Edit URL…",
-      onClick: () => {
-        const newUrl = window.prompt("New URL", url);
+      onClick: async () => {
+        const newUrl = await pgPrompt({
+          title: `URL for remote ${name}`,
+          initialValue: url,
+          placeholder: "git@github.com:owner/repo.git",
+          confirmLabel: "Save",
+          requireValue: true,
+          mono: true,
+        });
         if (newUrl && newUrl !== url)
           useRepoStore.getState().setRemoteUrl(name, newUrl);
       },
@@ -790,8 +874,14 @@ export function remoteMenuItems(remote: { name?: string; url?: string | null } |
     {
       icon: "edit",
       label: "Rename…",
-      onClick: () => {
-        const to = window.prompt("New name", name);
+      onClick: async () => {
+        const to = await pgPrompt({
+          title: `Rename remote ${name}`,
+          initialValue: name,
+          confirmLabel: "Rename",
+          requireValue: true,
+          mono: true,
+        });
         if (to && to !== name)
           useRepoStore.getState().renameRemote(name, to);
       },
@@ -809,8 +899,15 @@ export function remoteMenuItems(remote: { name?: string; url?: string | null } |
       icon: "trash",
       label: "Remove remote",
       danger: true,
-      onClick: () => {
-        if (window.confirm(`Remove remote "${name}"?`))
+      onClick: async () => {
+        if (
+          await pgConfirm({
+            title: `Remove remote "${name}"?`,
+            body: "Local branches stay; they just stop tracking it.",
+            danger: true,
+            confirmLabel: "Remove",
+          })
+        )
           useRepoStore.getState().removeRemote(name);
       },
     },
@@ -835,9 +932,16 @@ export function tagMenuItems(
     {
       icon: "branch",
       label: "Create branch from tag…",
-      onClick: () => {
+      onClick: async () => {
         if (!name) return;
-        const branchName = window.prompt("New branch name");
+        const branchName = await pgPrompt({
+          title: "Create branch from tag",
+          body: `Branching at ${name}.`,
+          placeholder: "release/1.0",
+          confirmLabel: "Create",
+          requireValue: true,
+          mono: true,
+        });
         if (!branchName) return;
         useRepoStore.getState().createBranch(branchName, name);
       },
@@ -846,9 +950,15 @@ export function tagMenuItems(
     {
       icon: "push",
       label: "Push tag to remote…",
-      onClick: () => {
+      onClick: async () => {
         if (!name) return;
-        const remote = window.prompt("Remote name", "origin");
+        const remote = await pgPrompt({
+          title: `Push tag ${name}`,
+          initialValue: "origin",
+          confirmLabel: "Push",
+          requireValue: true,
+          mono: true,
+        });
         if (!remote) return;
         useRepoStore.getState().pushTag(remote, name);
       },
@@ -866,8 +976,16 @@ export function tagMenuItems(
       icon: "trash",
       label: "Delete tag",
       danger: true,
-      onClick: () => {
-        if (name && window.confirm(`Delete tag ${name}?`))
+      onClick: async () => {
+        if (!name) return;
+        if (
+          await pgConfirm({
+            title: `Delete tag ${name}?`,
+            body: "Only the local tag — a tag already pushed stays on the remote.",
+            danger: true,
+            confirmLabel: "Delete tag",
+          })
+        )
           useRepoStore.getState().deleteTag(name);
       },
     },
@@ -996,12 +1114,15 @@ export function fileMenuItems(
           icon: "trash",
           label: "Delete file…",
           danger: true,
-          onClick: () => {
+          onClick: async () => {
             if (!path) return;
             if (
-              window.confirm(
-                `Delete ${path}? It is untracked, so this cannot be undone.`,
-              )
+              await pgConfirm({
+                title: `Delete ${path}?`,
+                body: "It is untracked — there is no copy in the index or in history, so this cannot be undone.",
+                danger: true,
+                confirmLabel: "Delete file",
+              })
             ) {
               useRepoStore.getState().discard([path]);
             }
@@ -1114,7 +1235,7 @@ export function multiFileMenuItems(
         icon: "undo",
         label: `Discard changes in ${files(unstagedPaths.length)}…`,
         danger: true,
-        onClick: () => {
+        onClick: async () => {
           const untracked = sel?.untrackedPaths ?? [];
           const deleted = untracked.length
             ? ` ${files(untracked.length)} ${
@@ -1122,9 +1243,12 @@ export function multiFileMenuItems(
               } untracked and will be deleted permanently.`
             : "";
           if (
-            window.confirm(
-              `Discard changes in ${files(unstagedPaths.length)}? The changes will be lost.${deleted}`,
-            )
+            await pgConfirm({
+              title: `Discard changes in ${files(unstagedPaths.length)}?`,
+              body: `The changes will be lost.${deleted}`,
+              danger: true,
+              confirmLabel: "Discard",
+            })
           ) {
             useRepoStore.getState().discard(unstagedPaths);
           }
@@ -1160,7 +1284,14 @@ export function stashMenuItems(
       label: "Branch from stash…",
       onClick: async () => {
         if (stash?.index == null) return;
-        const branch = window.prompt("Branch name");
+        const branch = await pgPrompt({
+          title: "Branch from stash",
+          body: `Creates a branch and applies ${name} onto it.`,
+          placeholder: "fix/from-stash",
+          confirmLabel: "Create branch",
+          requireValue: true,
+          mono: true,
+        });
         if (!branch) return;
         await useRepoStore.getState().stashBranch(stash.index, branch);
       },
@@ -1170,10 +1301,15 @@ export function stashMenuItems(
       icon: "trash",
       label: "Drop",
       danger: true,
-      onClick: () => {
+      onClick: async () => {
+        if (stash?.index == null) return;
         if (
-          stash?.index != null &&
-          window.confirm(`Drop ${name}?`)
+          await pgConfirm({
+            title: `Drop ${name}?`,
+            body: "The stashed changes are discarded.",
+            danger: true,
+            confirmLabel: "Drop",
+          })
         )
           useRepoStore.getState().stashDrop(stash.index);
       },
@@ -1235,12 +1371,15 @@ export function conflictMenuItems(conflict: { path?: string } | null): ContextMe
       icon: "undo",
       label: "Restart resolution",
       danger: true,
-      onClick: () => {
+      onClick: async () => {
         if (!conflict?.path) return;
         if (
-          window.confirm(
-            `Restart resolution for ${conflict.path}? Current edits are discarded.`,
-          )
+          await pgConfirm({
+            title: `Restart resolution for ${conflict.path}?`,
+            body: "Current edits to the conflicted file are discarded and the markers come back.",
+            danger: true,
+            confirmLabel: "Restart",
+          })
         )
           useRepoStore.getState().restartConflict(conflict.path);
       },

--- a/src/design/dialog.test.tsx
+++ b/src/design/dialog.test.tsx
@@ -1,0 +1,173 @@
+// The styled confirm/prompt primitive (#61 C3). The contract these pin is that
+// pgConfirm/pgPrompt behave like window.confirm/window.prompt at the call site,
+// so ~50 conversions could be mechanical.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { PGDialogHost, pgConfirm, pgPrompt, __resetDialogs } from "./dialog";
+
+beforeEach(() => __resetDialogs());
+afterEach(() => __resetDialogs());
+
+const clickConfirm = () =>
+  act(async () => {
+    fireEvent.click(screen.getByTestId("dialog-confirm"));
+  });
+const clickCancel = () =>
+  act(async () => {
+    fireEvent.click(screen.getByTestId("dialog-cancel"));
+  });
+
+describe("pgConfirm", () => {
+  it("resolves true on confirm and false on cancel", async () => {
+    render(<PGDialogHost />);
+
+    const yes = pgConfirm("Delete it?");
+    await screen.findByTestId("dialog-confirm");
+    await clickConfirm();
+    expect(await yes).toBe(true);
+
+    const no = pgConfirm("Delete it?");
+    await screen.findByTestId("dialog-cancel");
+    await clickCancel();
+    expect(await no).toBe(false);
+  });
+
+  it("resolves false on Escape and on a backdrop click", async () => {
+    render(<PGDialogHost />);
+
+    const esc = pgConfirm("Delete it?");
+    const dialog = await screen.findByRole("dialog");
+    await act(async () => {
+      fireEvent.keyDown(dialog, { key: "Escape" });
+    });
+    expect(await esc).toBe(false);
+
+    const backdrop = pgConfirm("Delete it?");
+    const dialog2 = await screen.findByRole("dialog");
+    await act(async () => {
+      fireEvent.mouseDown(dialog2);
+    });
+    expect(await backdrop).toBe(false);
+  });
+
+  it("resolves false rather than hanging when no host is mounted", async () => {
+    // A caller awaiting a dialog nobody can see would deadlock its handler;
+    // refusing is also the safe answer for a destructive op.
+    expect(await pgConfirm("Delete it?")).toBe(false);
+    expect(await pgPrompt("Name?")).toBeNull();
+  });
+
+  it("gates the primary button behind requireText", async () => {
+    render(<PGDialogHost />);
+    const p = pgConfirm({
+      title: "Delete branch?",
+      requireText: "main",
+      danger: true,
+    });
+    await screen.findByTestId("dialog-confirm");
+    expect(screen.getByTestId("dialog-confirm")).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId("dialog-input"), {
+      target: { value: "mai" },
+    });
+    expect(screen.getByTestId("dialog-confirm")).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId("dialog-input"), {
+      target: { value: "main" },
+    });
+    expect(screen.getByTestId("dialog-confirm")).toBeEnabled();
+    await clickConfirm();
+    expect(await p).toBe(true);
+  });
+});
+
+describe("pgPrompt", () => {
+  it("resolves the typed value, and null when dismissed", async () => {
+    render(<PGDialogHost />);
+
+    const value = pgPrompt({ title: "Branch name" });
+    await screen.findByTestId("dialog-input");
+    fireEvent.change(screen.getByTestId("dialog-input"), {
+      target: { value: "feat/x" },
+    });
+    await clickConfirm();
+    expect(await value).toBe("feat/x");
+
+    const cancelled = pgPrompt({ title: "Branch name" });
+    await screen.findByTestId("dialog-input");
+    await clickCancel();
+    expect(await cancelled).toBeNull();
+  });
+
+  it("keeps empty string distinct from null", async () => {
+    // window.prompt's contract, and real callers depend on it: an empty stash
+    // message means "no message", a dismissal means "don't stash".
+    render(<PGDialogHost />);
+    const p = pgPrompt({ title: "Stash message (optional)" });
+    await screen.findByTestId("dialog-input");
+    await clickConfirm();
+    expect(await p).toBe("");
+  });
+
+  it("prefills initialValue and blocks empty input when requireValue", async () => {
+    render(<PGDialogHost />);
+    const p = pgPrompt({
+      title: "Rename",
+      initialValue: "old-name",
+      requireValue: true,
+    });
+    await screen.findByTestId("dialog-input");
+    expect(screen.getByTestId<HTMLInputElement>("dialog-input").value).toBe(
+      "old-name",
+    );
+
+    fireEvent.change(screen.getByTestId("dialog-input"), {
+      target: { value: "   " },
+    });
+    expect(screen.getByTestId("dialog-confirm")).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId("dialog-input"), {
+      target: { value: "new-name" },
+    });
+    await clickConfirm();
+    expect(await p).toBe("new-name");
+  });
+
+  it("submits on Enter", async () => {
+    render(<PGDialogHost />);
+    const p = pgPrompt({ title: "Branch name" });
+    const input = await screen.findByTestId("dialog-input");
+    fireEvent.change(input, { target: { value: "feat/enter" } });
+    await act(async () => {
+      fireEvent.keyDown(input, { key: "Enter" });
+    });
+    expect(await p).toBe("feat/enter");
+  });
+});
+
+describe("queueing", () => {
+  it("shows one dialog at a time and settles them in order", async () => {
+    // Stacked modals cannot be dismissed predictably — the second request
+    // waits rather than covering the first.
+    render(<PGDialogHost />);
+    const first = pgConfirm({ title: "First?" });
+    const second = pgConfirm({ title: "Second?" });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("dialog-title").textContent).toBe("First?"),
+    );
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+
+    await clickConfirm();
+    expect(await first).toBe(true);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("dialog-title").textContent).toBe("Second?"),
+    );
+    await clickCancel();
+    expect(await second).toBe(false);
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/src/design/dialog.tsx
+++ b/src/design/dialog.tsx
@@ -1,0 +1,307 @@
+// Styled confirm/prompt dialogs replacing window.confirm / window.prompt
+// (#61 C3).
+//
+// Native dialogs are OS chrome dropped into a dense, themed, monospace app:
+// wrong typeface, wrong colors, no danger styling, and on some platforms they
+// steal focus from the whole window. They also cannot express what the
+// destructive ones need — a typed-name confirmation, a body distinct from the
+// title, a red primary button.
+//
+// The API is deliberately promise-shaped rather than component-shaped, because
+// every replaced call site reads `if (window.confirm(msg))` inline inside a
+// menu handler. `if (await pgConfirm(msg))` is the same line with one keyword
+// added; a <Dialog open={…}> component would have meant lifting state into ten
+// screens and rewriting each handler.
+//
+// One host renders the queue (mounted per window — main and merge both mount
+// it). Requests queue rather than stack: two dialogs at once is never what the
+// user meant, and a modal opening over a modal cannot be dismissed predictably.
+
+import React, { type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { PGButton, PGInput } from "./primitives";
+import { PGIcon } from "./icons";
+
+export interface PGConfirmOptions {
+  /** Headline. Keep it a question. */
+  title: string;
+  /** Optional detail under the title. */
+  body?: ReactNode;
+  /** Primary button label. Defaults to "Confirm" / "Delete" when danger. */
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Red primary button + warning glyph. */
+  danger?: boolean;
+  /**
+   * Require typing this exact string before the primary button enables —
+   * for the genuinely unrecoverable operations (GitKraken-style).
+   */
+  requireText?: string;
+}
+
+export interface PGPromptOptions {
+  title: string;
+  body?: ReactNode;
+  /** Prefilled value. */
+  initialValue?: string;
+  placeholder?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Reject empty input (after trimming) — the primary button stays disabled. */
+  requireValue?: boolean;
+  mono?: boolean;
+}
+
+type Request =
+  | { id: number; kind: "confirm"; opts: PGConfirmOptions; resolve: (v: boolean) => void }
+  | { id: number; kind: "prompt"; opts: PGPromptOptions; resolve: (v: string | null) => void };
+
+let nextId = 1;
+let queue: Request[] = [];
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const l of listeners) l();
+}
+
+function push(req: Request) {
+  queue = [...queue, req];
+  emit();
+}
+
+/** Settle the head of the queue and move on. */
+function settle(id: number, value: boolean | string | null) {
+  const req = queue.find((r) => r.id === id);
+  queue = queue.filter((r) => r.id !== id);
+  emit();
+  if (!req) return;
+  if (req.kind === "confirm") req.resolve(value === true);
+  else req.resolve(typeof value === "string" ? value : null);
+}
+
+/**
+ * Ask for confirmation. Resolves true only if the user confirms; Escape,
+ * backdrop click and Cancel all resolve false — same contract as
+ * `window.confirm`, so a call site only gains an `await`.
+ *
+ * Falls back to resolving false when no host is mounted, so a caller can never
+ * hang waiting on a dialog nobody can see.
+ */
+export function pgConfirm(opts: PGConfirmOptions | string): Promise<boolean> {
+  const o = typeof opts === "string" ? { title: opts } : opts;
+  if (listeners.size === 0) return Promise.resolve(false);
+  return new Promise<boolean>((resolve) => {
+    push({ id: nextId++, kind: "confirm", opts: o, resolve });
+  });
+}
+
+/**
+ * Ask for a line of text. Resolves the string, or null if dismissed — same
+ * contract as `window.prompt`, including "empty string" being a real answer
+ * distinct from null (unless `requireValue`).
+ */
+export function pgPrompt(opts: PGPromptOptions | string): Promise<string | null> {
+  const o = typeof opts === "string" ? { title: opts } : opts;
+  if (listeners.size === 0) return Promise.resolve(null);
+  return new Promise<string | null>((resolve) => {
+    push({ id: nextId++, kind: "prompt", opts: o, resolve });
+  });
+}
+
+function useQueueHead(): Request | undefined {
+  const [, force] = React.useReducer((n: number) => n + 1, 0);
+  React.useEffect(() => {
+    listeners.add(force);
+    return () => {
+      listeners.delete(force);
+    };
+  }, []);
+  return queue[0];
+}
+
+/**
+ * Renders whichever dialog is at the head of the queue. Mount exactly once per
+ * window, near the root.
+ */
+export function PGDialogHost() {
+  const req = useQueueHead();
+  if (!req) return null;
+  return <DialogView key={req.id} req={req} />;
+}
+
+function DialogView({ req }: { req: Request }) {
+  const isConfirm = req.kind === "confirm";
+  const danger = isConfirm && !!(req.opts as PGConfirmOptions).danger;
+  const requireText = isConfirm
+    ? (req.opts as PGConfirmOptions).requireText
+    : undefined;
+
+  const [value, setValue] = React.useState(
+    isConfirm ? "" : ((req.opts as PGPromptOptions).initialValue ?? ""),
+  );
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    // Focus the input if there is one, else the primary button, so Enter and
+    // Escape work without a click first.
+    const t = setTimeout(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }, 0);
+    return () => clearTimeout(t);
+  }, []);
+
+  const promptOpts = req.opts as PGPromptOptions;
+  const canSubmit = isConfirm
+    ? requireText === undefined || value === requireText
+    : !promptOpts.requireValue || value.trim().length > 0;
+
+  const cancel = () => settle(req.id, isConfirm ? false : null);
+  const accept = () => {
+    if (!canSubmit) return;
+    settle(req.id, isConfirm ? true : value);
+  };
+
+  // Escape/Enter are handled here rather than through the keymap: a modal owns
+  // the keyboard while it is up, and routing through the global dispatcher
+  // would let a pane-scoped binding answer first.
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.stopPropagation();
+      e.preventDefault();
+      cancel();
+    } else if (e.key === "Enter" && !e.shiftKey) {
+      e.stopPropagation();
+      e.preventDefault();
+      accept();
+    }
+  };
+
+  const confirmLabel =
+    (isConfirm
+      ? (req.opts as PGConfirmOptions).confirmLabel
+      : promptOpts.confirmLabel) ?? (danger ? "Delete" : "Confirm");
+  const cancelLabel =
+    (isConfirm
+      ? (req.opts as PGConfirmOptions).cancelLabel
+      : promptOpts.cancelLabel) ?? "Cancel";
+
+  return createPortal(
+    <div
+      data-pg-dialog=""
+      // Lets a driver tell "are you sure?" from "type a value" without
+      // inspecting the inputs — a requireText confirm has an input too.
+      data-pg-dialog-kind={req.kind}
+      role="dialog"
+      aria-modal="true"
+      aria-label={req.opts.title}
+      onKeyDown={onKeyDown}
+      onMouseDown={(e) => {
+        // Backdrop click cancels; clicks inside the card must not.
+        if (e.target === e.currentTarget) cancel();
+      }}
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 999998,
+        background: "oklch(0 0 0 / 0.45)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 24,
+      }}
+    >
+      <div
+        className="pg-fade-in"
+        style={{
+          width: "min(440px, 100%)",
+          background: "var(--bg-1)",
+          border: "1px solid var(--border-1)",
+          borderRadius: "var(--r-5)",
+          boxShadow: "var(--shadow-3)",
+          padding: 16,
+          display: "flex",
+          flexDirection: "column",
+          gap: 12,
+        }}
+      >
+        <div style={{ display: "flex", gap: 10, alignItems: "flex-start" }}>
+          {danger && (
+            <PGIcon
+              name="warn"
+              size={16}
+              style={{ color: "var(--git-removed)", marginTop: 2 }}
+            />
+          )}
+          <div style={{ display: "flex", flexDirection: "column", gap: 6, minWidth: 0 }}>
+            <div
+              data-testid="dialog-title"
+              style={{
+                fontSize: "var(--fs-13)",
+                fontWeight: "var(--fw-semibold)",
+                color: "var(--fg-0)",
+              }}
+            >
+              {req.opts.title}
+            </div>
+            {req.opts.body && (
+              <div
+                style={{
+                  fontSize: "var(--fs-12)",
+                  color: "var(--fg-2)",
+                  lineHeight: "var(--lh-body)",
+                  wordBreak: "break-word",
+                }}
+              >
+                {req.opts.body}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {!isConfirm && (
+          <PGInput
+            inputRef={inputRef}
+            value={value}
+            onChange={setValue}
+            placeholder={promptOpts.placeholder}
+            mono={promptOpts.mono}
+            data-testid="dialog-input"
+          />
+        )}
+        {isConfirm && requireText !== undefined && (
+          <PGInput
+            inputRef={inputRef}
+            value={value}
+            onChange={setValue}
+            placeholder={requireText}
+            mono
+            data-testid="dialog-input"
+          />
+        )}
+
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+          <PGButton size="sm" variant="ghost" onClick={cancel} data-testid="dialog-cancel">
+            {cancelLabel}
+          </PGButton>
+          <PGButton
+            size="sm"
+            variant={danger ? "danger" : "primary"}
+            disabled={!canSubmit}
+            onClick={accept}
+            data-testid="dialog-confirm"
+          >
+            {confirmLabel}
+          </PGButton>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+/** Test helper: drop any queued dialogs between cases. */
+export function __resetDialogs() {
+  queue = [];
+  emit();
+}

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -12,6 +12,7 @@ import {
   PGSelect,
 } from "./primitives";
 import { useDensityStep } from "@/features/settings/useSettingsStore";
+import { FOLDER_ICON_COLOR, fileIconSpec } from "@/lib/fileIcon";
 
 // ═════════════════════════════════════════════════════════
 // FILE TREE
@@ -24,6 +25,14 @@ export interface PGFileTreeNode {
   children?: PGFileTreeNode[];
   extra?: ReactNode;
 }
+
+/**
+ * Staged-ness of a tree row. Folders are tri-state over their descendants:
+ * "all" every stageable leaf fully staged, "none" none of them, "partial"
+ * anything in between (including a single file with both staged and unstaged
+ * changes). `undefined` means the row isn't stageable at all — no checkbox.
+ */
+export type PGStageState = "none" | "partial" | "all";
 
 export interface PGFileTreeRowProps {
   name: string;
@@ -39,6 +48,12 @@ export interface PGFileTreeRowProps {
   onContextMenu?: (e: MouseEvent) => void;
   extra?: ReactNode;
   hideStatus?: boolean;
+  /** Tri-state staging checkbox. Omit for a row that can't be staged. */
+  stageState?: PGStageState;
+  /** Reserve the checkbox column even when this row has no `stageState`, so
+   *  rows stay aligned in a tree where only some rows are stageable. */
+  stageSlot?: boolean;
+  onStageToggle?: (next: boolean) => void;
 }
 
 export function PGFileTreeRow({
@@ -55,8 +70,17 @@ export function PGFileTreeRow({
   onContextMenu,
   extra,
   hideStatus,
+  stageState,
+  stageSlot,
+  onStageToggle,
 }: PGFileTreeRowProps) {
   const [hover, setHover] = React.useState(false);
+  // Folders keep the shared accent tint; files resolve a per-type glyph + tint
+  // from their path (falling back to `name` for callers that pass no path).
+  const glyph =
+    kind === "folder"
+      ? { icon: (expanded ? "folderOpen" : "folder") as IconName, color: FOLDER_ICON_COLOR }
+      : fileIconSpec(path ?? name);
   return (
     <div
       data-path={path}
@@ -109,15 +133,24 @@ export function PGFileTreeRow({
           <PGIcon name={expanded ? "chevronDown" : "chevronRight"} size={10} />
         )}
       </span>
-      <PGIcon
-        name={
-          kind === "folder" ? (expanded ? "folderOpen" : "folder") : "file"
-        }
-        size={12}
-        style={{
-          color: kind === "folder" ? "var(--accent-4)" : "var(--fg-2)",
-        }}
-      />
+      {stageState !== undefined ? (
+        <span
+          data-testid="tree-row-toggle"
+          // The checkbox owns its click: selecting the row underneath as well
+          // would move the selection every time you stage something.
+          onClick={(e) => e.stopPropagation()}
+          style={{ display: "inline-flex", flexShrink: 0 }}
+        >
+          <PGCheckbox
+            checked={stageState === "all"}
+            indeterminate={stageState === "partial"}
+            onChange={(v) => onStageToggle?.(v)}
+          />
+        </span>
+      ) : (
+        stageSlot && <span style={{ width: 14, flexShrink: 0 }} />
+      )}
+      <PGIcon name={glyph.icon} size={12} style={{ color: glyph.color }} />
       <span
         style={{
           flex: 1,
@@ -137,15 +170,28 @@ export function PGFileTreeRow({
 export interface PGFileTreeProps {
   nodes: PGFileTreeNode[];
   expanded?: Record<string, boolean>;
-  onToggle?: (key: string) => void;
+  /**
+   * Fold/unfold a folder. `nextExpanded` is computed here rather than left to
+   * the caller: a row's current state is `expanded[key] ?? node.defaultExpanded`,
+   * so a caller writing `!expanded[key]` gets it wrong for every
+   * default-expanded folder — the first click would re-set `true` and appear
+   * to do nothing.
+   */
+  onToggle?: (key: string, nextExpanded: boolean) => void;
   selected?: string;
   /** Extra keys rendered as selected (multi-select). `selected` stays the primary row. */
   selectedKeys?: ReadonlySet<string>;
   onSelect?: (key: string, node: PGFileTreeNode, e?: MouseEvent) => void;
-  /** Fired on Enter or double-click. For folders, toggles; for files, caller decides. */
-  onActivate?: (key: string, node: PGFileTreeNode) => void;
   onRowContextMenu?: (e: MouseEvent, key: string, node: PGFileTreeNode) => void;
   showStatus?: boolean;
+  /**
+   * Staging column. Return a state per row key to render its checkbox, or
+   * `undefined` for a row that can't be staged (unmodified file, embedded
+   * repo, empty folder). Omit the prop entirely to hide the column — the
+   * reserved slot only appears once some row in the tree is stageable.
+   */
+  stageState?: (key: string, node: PGFileTreeNode) => PGStageState | undefined;
+  onStageToggle?: (key: string, node: PGFileTreeNode, next: boolean) => void;
 }
 
 export interface PGFileTreeFlatNode {
@@ -187,81 +233,30 @@ export function PGFileTree({
   selected,
   selectedKeys,
   onSelect,
-  onActivate,
   onRowContextMenu,
   showStatus = true,
+  stageState,
+  onStageToggle,
 }: PGFileTreeProps) {
   const flat = flattenFileTree(nodes, expanded);
-  const selectedIdx = selected
-    ? flat.findIndex((f) => f.key === selected)
-    : -1;
+  const rowStage = flat.map((f) => stageState?.(f.key, f.node));
+  // Reserve the checkbox column for the whole tree as soon as one row uses it,
+  // so a mixed tree (changed + unmodified files) keeps its names aligned.
+  const stageSlot = rowStage.some((s) => s !== undefined);
 
-  const focus = (idx: number) => {
-    const n = flat[idx];
-    if (!n) return;
-    onSelect?.(n.key, n.node);
-  };
-
-  const handleKey = (e: React.KeyboardEvent) => {
-    if (e.defaultPrevented) return;
-    if (flat.length === 0) return;
-    // Leave modifier+arrow combos (e.g. Alt+Arrow pane focus) to global
-    // keymap shortcuts — only handle bare arrows for in-tree navigation.
-    if (e.altKey || e.metaKey || e.ctrlKey) return;
-    const cur = selectedIdx >= 0 ? selectedIdx : 0;
-    const node = flat[cur];
-    switch (e.key) {
-      case "ArrowDown":
-        e.preventDefault();
-        focus(Math.min(cur + 1, flat.length - 1));
-        break;
-      case "ArrowUp":
-        e.preventDefault();
-        focus(Math.max(cur - 1, 0));
-        break;
-      case "ArrowRight":
-        e.preventDefault();
-        if (node?.hasChildren) {
-          if (!node.isExpanded) onToggle?.(node.key);
-          else focus(Math.min(cur + 1, flat.length - 1));
-        }
-        break;
-      case "ArrowLeft":
-        e.preventDefault();
-        if (node?.hasChildren && node.isExpanded) {
-          onToggle?.(node.key);
-        } else {
-          // move to parent if any
-          const parentKey = node?.key
-            .split("/")
-            .slice(0, -1)
-            .join("/");
-          const parentIdx = flat.findIndex((f) => f.key === parentKey);
-          if (parentIdx >= 0) focus(parentIdx);
-        }
-        break;
-      case "Enter":
-        e.preventDefault();
-        if (node) {
-          if (node.hasChildren) {
-            onToggle?.(node.key);
-          } else {
-            onActivate?.(node.key, node.node);
-          }
-        }
-        break;
-    }
-  };
-
+  // Keyboard navigation lives with the owning screen, not here: it goes
+  // through the keymap's `usePaneList` so the tree gets the same arrow keys,
+  // Home/End, Shift+Arrow ranges, Space-to-stage and type-to-jump
+  // speed-search as every flat pane, and so a bare ArrowDown isn't handled
+  // twice (once by the dispatcher, once by a local onKeyDown).
   return (
     <div
       tabIndex={0}
-      onKeyDown={handleKey}
       style={{ outline: "none" }}
       data-pg-focus-target=""
       className="focusable"
     >
-      {flat.map((f) => (
+      {flat.map((f, i) => (
         <PGFileTreeRow
           key={f.key}
           name={f.node.name}
@@ -270,15 +265,18 @@ export function PGFileTree({
           kind={f.hasChildren ? "folder" : "file"}
           status={f.node.status}
           hideStatus={!showStatus}
+          stageState={rowStage[i]}
+          stageSlot={stageSlot}
+          onStageToggle={(next) => onStageToggle?.(f.key, f.node, next)}
           expanded={f.isExpanded}
           hasChildren={f.hasChildren}
           selected={selected === f.key || !!selectedKeys?.has(f.key)}
           onClick={(e) => {
             onSelect?.(f.key, f.node, e);
             if (f.hasChildren && !e.metaKey && !e.ctrlKey && !e.shiftKey)
-              onToggle?.(f.key);
+              onToggle?.(f.key, !f.isExpanded);
           }}
-          onToggle={() => onToggle?.(f.key)}
+          onToggle={() => onToggle?.(f.key, !f.isExpanded)}
           onContextMenu={
             onRowContextMenu
               ? (e) => onRowContextMenu(e, f.key, f.node)
@@ -324,6 +322,7 @@ export function PGChangeRow({
   const parts = path.split("/");
   const file = parts.pop();
   const dir = parts.join("/");
+  const glyph = fileIconSpec(path);
   return (
     <div
       data-path={path}
@@ -371,9 +370,9 @@ export function PGChangeRow({
       )}
       <PGStatusMark kind={status} size={14} />
       <PGIcon
-        name="file"
+        name={glyph.icon}
         size={11}
-        style={{ color: "var(--fg-3)", flexShrink: 0 }}
+        style={{ color: glyph.color, flexShrink: 0 }}
       />
       <span
         style={{
@@ -722,6 +721,12 @@ export interface PGHunkProps {
   onDiscard?: () => void;
   expanded?: boolean;
   onToggle?: () => void;
+  /**
+   * Disable Stage/Discard and explain why on hover. Set while the diff is
+   * whitespace-ignoring: those hunks are a rewritten view, so their indices
+   * don't address the hunks git would apply (#61 D2).
+   */
+  actionsDisabledReason?: string;
 }
 
 export function PGHunk({
@@ -732,6 +737,7 @@ export function PGHunk({
   onDiscard,
   expanded = true,
   onToggle,
+  actionsDisabledReason,
 }: PGHunkProps) {
   return (
     <div style={{ borderBottom: "1px solid var(--border-0)" }}>
@@ -755,7 +761,14 @@ export function PGHunk({
         />
         <span style={{ color: "var(--accent)" }}>@@ {header} @@</span>
         <div style={{ flex: 1 }} />
-        <PGButton size="xs" variant="ghost" onClick={onDiscard} icon="x">
+        <PGButton
+          size="xs"
+          variant="ghost"
+          onClick={onDiscard}
+          icon="x"
+          disabled={!!actionsDisabledReason}
+          title={actionsDisabledReason}
+        >
           Discard
         </PGButton>
         <PGButton
@@ -764,6 +777,8 @@ export function PGHunk({
           variant={staged ? "outline" : "primary"}
           onClick={onStage}
           icon={staged ? "check" : "plus"}
+          disabled={!!actionsDisabledReason}
+          title={actionsDisabledReason}
         >
           {staged ? "Staged" : "Stage hunk"}
         </PGButton>

--- a/src/design/icons.tsx
+++ b/src/design/icons.tsx
@@ -3,6 +3,9 @@ import type { CSSProperties, ReactNode } from "react";
 export type IconName =
   | "repo" | "branch" | "commit" | "merge" | "fork" | "tag"
   | "folder" | "folderOpen" | "file" | "fileCode"
+  // File-type category glyphs — resolved per path by lib/fileIcon.ts.
+  | "fileData" | "fileDoc" | "fileStyle" | "fileImage" | "fileShell"
+  | "fileConfig" | "fileLock" | "fileArchive" | "fileBinary" | "fileGit"
   | "plus" | "minus" | "check" | "x"
   | "chevronRight" | "chevronDown" | "chevronUp" | "chevronLeft"
   | "search" | "settings" | "filter" | "sort" | "more"
@@ -12,7 +15,8 @@ export type IconName =
   | "download" | "upload" | "link" | "lock"
   | "play" | "pause" | "star" | "copy" | "external"
   | "edit" | "trash" | "conflict" | "squash" | "drag" | "bell"
-  | "diff" | "undo" | "fix" | "expandAll" | "collapseAll";
+  | "diff" | "undo" | "fix" | "expandAll" | "collapseAll"
+  | "viewTree" | "viewList";
 
 const ICONS: Record<IconName, ReactNode> = {
   repo: <>
@@ -54,6 +58,60 @@ const ICONS: Record<IconName, ReactNode> = {
   fileCode: <>
     <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
     <path d="M9 1.5v4h4M6 9l-1.5 1.5L6 12M10 9l1.5 1.5L10 12" />
+  </>,
+  // ── File-type category glyphs ───────────────────────────────────────────
+  // All share the `file` page outline so a mixed list reads as one family;
+  // the mark inside the page is what distinguishes the category.
+  fileData: <>
+    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
+    <path d="M9 1.5v4h4M6.5 8.5c-1 0-1 1.25-1 1.25s0 1.25 1 1.25M9.5 8.5c1 0 1 1.25 1 1.25s0 1.25-1 1.25" />
+  </>,
+  fileDoc: <>
+    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
+    <path d="M9 1.5v4h4M4.5 8.5h5M4.5 10.5h5M4.5 12.5h3" />
+  </>,
+  fileStyle: <>
+    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
+    <path d="M9 1.5v4h4M8 8.5c-1.5 1.6-2.25 2.6-2.25 3.35a2.25 2.25 0 0 0 4.5 0C10.25 11.1 9.5 10.1 8 8.5z" />
+  </>,
+  fileImage: <>
+    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
+    <path d="M9 1.5v4h4M2 12.5l3-3 2.5 2.5M9 10l1.5-1.5 2.5 2.5" />
+    <circle cx="6" cy="7.5" r=".9" />
+  </>,
+  fileShell: <>
+    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
+    <path d="M9 1.5v4h4M4.5 8.5l2 1.75-2 1.75M8 12.25h3" />
+  </>,
+  fileConfig: <>
+    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
+    <path d="M9 1.5v4h4" />
+    <circle cx="7.5" cy="10.5" r="1.6" />
+    <path d="M7.5 7.6v1.3M7.5 12.1v1.3M4.9 9v0M10.1 12v0M4.9 12v0M10.1 9v0" />
+  </>,
+  fileLock: <>
+    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
+    <path d="M9 1.5v4h4" />
+    <rect x="5" y="10" width="6" height="3.5" rx=".75" />
+    <path d="M6.25 10V9a1.75 1.75 0 0 1 3.5 0v1" />
+  </>,
+  fileArchive: <>
+    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
+    <path d="M9 1.5v4h4M6.5 2v1M8 3.5v1M6.5 5v1M8 6.5v1M6.5 8v1" />
+    <rect x="6" y="10" width="2.5" height="3" rx=".5" />
+  </>,
+  fileBinary: <>
+    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
+    <path d="M9 1.5v4h4M5 8.75l1-.5v3.5M4.75 11.75h2.5" />
+    <rect x="8.75" y="8.25" width="2.5" height="3.5" rx="1.25" />
+  </>,
+  fileGit: <>
+    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
+    <path d="M9 1.5v4h4" />
+    <circle cx="5.5" cy="8.5" r="1" />
+    <circle cx="5.5" cy="12.5" r="1" />
+    <circle cx="10" cy="9.75" r="1" />
+    <path d="M5.5 9.5v2M5.5 11c0-1.5 1.5-1.25 3.5-1.25" />
   </>,
   plus: <path d="M8 3v10M3 8h10" />,
   minus: <path d="M3 8h10" />,
@@ -189,6 +247,17 @@ const ICONS: Record<IconName, ReactNode> = {
   expandAll: <path d="M4.5 6L8 2.5 11.5 6M4.5 10L8 13.5 11.5 10" />,
   // Chevrons pointing toward center = fold (collapse all).
   collapseAll: <path d="M4.5 3L8 6.5 11.5 3M4.5 13L8 9.5 11.5 13" />,
+  // View-mode pair: an indented hierarchy vs a flat stack of rows.
+  viewTree: <>
+    <path d="M2.5 2.5v9.5M2.5 5.5h3M2.5 9h3M2.5 12.5h3" />
+    <path d="M7 2.5h6.5M7 5.5h6.5M7 9h6.5M7 12.5h6.5" />
+  </>,
+  viewList: <>
+    <circle cx="3" cy="4" r=".9" fill="currentColor" stroke="none" />
+    <circle cx="3" cy="8" r=".9" fill="currentColor" stroke="none" />
+    <circle cx="3" cy="12" r=".9" fill="currentColor" stroke="none" />
+    <path d="M6 4h8M6 8h8M6 12h8" />
+  </>,
 };
 
 export interface PGIconProps {

--- a/src/design/index.ts
+++ b/src/design/index.ts
@@ -4,6 +4,7 @@ export * from "./primitives";
 export * from "./git-components";
 export * from "./chrome";
 export * from "./context-menu";
+export * from "./dialog";
 export * from "./ui-helpers";
 export * from "./empty-state";
 export * from "./use-prevent-browser-context-menu";

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { PGSpinner } from "@/design";
+import { PGIcon, PGSpinner } from "@/design";
 import { PGPane, FocusableScroll, usePaneList, useHunkNav } from "@/features/keymap";
+import { fileIconSpec } from "@/lib/fileIcon";
+import { WhitespaceToggle } from "./WhitespaceToggle";
 import type { FileDiff } from "@/lib/types";
 
 export interface CommitDiffPanelProps {
@@ -88,12 +90,24 @@ export function CommitDiffPanel({
               padding: "6px 12px",
               borderBottom: "1px solid var(--border-0)",
               color: "var(--fg-3)",
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
             }}
           >
-            {header}
+            <span
+              style={{
+                flex: 1,
+                minWidth: 0,
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              {header}
+            </span>
+            {/* Read-only surface: no hunk staging to gate here. */}
+            <WhitespaceToggle />
           </div>
           {loading && (
             <div style={{ padding: 12 }}>
@@ -106,13 +120,19 @@ export function CommitDiffPanel({
           {!loading && !error && diffs.length === 0 && (
             <div style={{ padding: 12, color: "var(--fg-3)" }}>{emptyLabel}</div>
           )}
-          {diffs.map((d) => (
+          {diffs.map((d) => {
+            const glyph = fileIconSpec(d.path);
+            const parts = d.path.split("/");
+            const base = parts.pop();
+            const dir = parts.join("/");
+            return (
             <div
               key={d.path}
               onClick={() => setSelected(d.path)}
               data-pg-row=""
               data-selected={d.path === selected ? "" : undefined}
               data-path={d.path}
+              title={d.oldPath && d.oldPath !== d.path ? `${d.oldPath} → ${d.path}` : d.path}
               style={{
                 display: "flex",
                 alignItems: "center",
@@ -124,12 +144,44 @@ export function CommitDiffPanel({
             >
               <span
                 style={{
+                  display: "flex",
+                  alignItems: "baseline",
+                  gap: 6,
+                  minWidth: 0,
                   overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
                 }}
               >
-                {d.path}
+                <PGIcon
+                  name={glyph.icon}
+                  size={11}
+                  style={{ color: glyph.color, flexShrink: 0, alignSelf: "center" }}
+                />
+                <span
+                  style={{
+                    color: "var(--fg-0)",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    flexShrink: 0,
+                    maxWidth: "70%",
+                  }}
+                >
+                  {base}
+                </span>
+                {dir && (
+                  <span
+                    style={{
+                      color: "var(--fg-3)",
+                      fontSize: "var(--fs-10)",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                      direction: "rtl",
+                    }}
+                  >
+                    {dir}
+                  </span>
+                )}
               </span>
               <span style={{ flexShrink: 0, fontSize: "var(--fs-10)" }}>
                 {d.additions > 0 && (
@@ -140,7 +192,8 @@ export function CommitDiffPanel({
                 )}
               </span>
             </div>
-          ))}
+            );
+          })}
         </FocusableScroll>
       </PGPane>
       <PGPane

--- a/src/features/diff/WhitespaceToggle.tsx
+++ b/src/features/diff/WhitespaceToggle.tsx
@@ -1,0 +1,38 @@
+// Whitespace-ignore toggle for diff toolbars (#61 D2).
+//
+// One shared control because the setting is global and persisted: flipping it
+// in any diff surface flips it everywhere, which is what you want when you are
+// reviewing one reformatted change across several screens.
+
+import { PGIconButton } from "@/design";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+
+/** The reason hunk-level actions are unavailable, or undefined when they are. */
+export function useHunkActionsDisabledReason(): string | undefined {
+  const on = useSettingsStore((s) => s.ignoreWhitespaceInDiff);
+  return on
+    ? "Hunk staging is unavailable while whitespace is ignored — these hunks are a filtered view, not the ones git would apply."
+    : undefined;
+}
+
+export function useIgnoreWhitespace(): boolean {
+  return useSettingsStore((s) => s.ignoreWhitespaceInDiff);
+}
+
+export function WhitespaceToggle() {
+  const on = useSettingsStore((s) => s.ignoreWhitespaceInDiff);
+  const set = useSettingsStore((s) => s.set);
+  return (
+    <PGIconButton
+      icon="filter"
+      size="sm"
+      active={on}
+      title={
+        on
+          ? "Ignoring whitespace — click to show whitespace-only changes (re-enables hunk staging)"
+          : "Ignore whitespace-only changes"
+      }
+      onClick={() => set("ignoreWhitespaceInDiff", !on)}
+    />
+  );
+}

--- a/src/features/merge/MergeWindow.test.tsx
+++ b/src/features/merge/MergeWindow.test.tsx
@@ -1,8 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MergeWindow, findNextConflict } from "./MergeWindow";
 import { mockInvoke, getInvokeCalls } from "@/test/invokeMock";
+import { dialogTitle, dismissDialog, resetDialogs } from "@/test/dialog";
 import type { ConflictSides, FileStatus } from "@/lib/types";
 
 function conflictedStatus(paths: string[]): FileStatus[] {
@@ -108,6 +109,7 @@ describe("MergeWindow shell", () => {
 
 describe("MergeWindow resolution flow", () => {
   async function setup(paths = ["conflict.txt"]) {
+    resetDialogs();
     setSearch("window=merge&repoId=r1&path=conflict.txt");
     mockInvoke("get_status", () => conflictedStatus(paths));
     mockInvoke("conflict_sides", () => textSides());
@@ -191,13 +193,28 @@ describe("MergeWindow resolution flow", () => {
   });
 
   it("Escape with progress asks for confirmation", async () => {
+    // MergeWindow mounts its own PGDialogHost (separate Tauri window), so the
+    // styled confirm renders without a test wrapper.
     await setup();
     chord("1", { metaKey: true, code: "Digit1" });
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
     chord("Escape");
-    expect(confirmSpy).toHaveBeenCalled();
+
+    await waitFor(() =>
+      expect(dialogTitle()).toBe("Discard this file's merge progress?"),
+    );
     const { getCurrentWindow } = await import("@tauri-apps/api/window");
     expect(getCurrentWindow().close).not.toHaveBeenCalled();
-    confirmSpy.mockRestore();
+
+    await dismissDialog();
+    expect(getCurrentWindow().close).not.toHaveBeenCalled();
+  });
+
+  it("Escape with no progress closes without asking", async () => {
+    await setup();
+    chord("Escape");
+
+    const { getCurrentWindow } = await import("@tauri-apps/api/window");
+    await waitFor(() => expect(getCurrentWindow().close).toHaveBeenCalled());
+    expect(dialogTitle()).toBeNull();
   });
 });

--- a/src/features/merge/MergeWindow.tsx
+++ b/src/features/merge/MergeWindow.tsx
@@ -7,7 +7,14 @@
 import React from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { emit, listen } from "@tauri-apps/api/event";
-import { PGButton, PGEmpty, PGIcon, PGSpinner } from "@/design";
+import {
+  PGButton,
+  PGDialogHost,
+  PGEmpty,
+  PGIcon,
+  PGSpinner,
+  pgConfirm,
+} from "@/design";
 import {
   acceptOurs as acceptOursIpc,
   acceptTheirs as acceptTheirsIpc,
@@ -192,6 +199,7 @@ export function MergeWindow() {
   }, [canApply, model, repoId, path, advance]);
 
   // --- Close (confirm when this file has unsaved progress) ----------------
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const requestClose = React.useCallback(() => {
     const body = bodyRef.current;
     const regs = body?.regions() ?? regionStates;
@@ -199,9 +207,22 @@ export function MergeWindow() {
     const touched =
       regs.some((r) => r.resolution !== null) ||
       (editorText != null && model != null && editorText !== model.initialResult);
-    if (!touched || window.confirm("Discard this file's merge progress?")) {
+    if (!touched) {
       void getCurrentWindow().close();
+      return;
     }
+    void (async () => {
+      if (
+        await pgConfirm({
+          title: "Discard this file's merge progress?",
+          body: "Side picks and edits to the result pane are lost; the file stays conflicted.",
+          danger: true,
+          confirmLabel: "Discard",
+        })
+      ) {
+        void getCurrentWindow().close();
+      }
+    })();
   }, [regionStates, model]);
 
   // --- Chord table: window-level keydown, capture phase (beats CM keymap) --
@@ -242,6 +263,9 @@ export function MergeWindow() {
         color: "var(--fg-0)",
       }}
     >
+      {/* Own host: this is a separate Tauri window, so it cannot share the
+          main window's. */}
+      <PGDialogHost />
       <div
         style={{
           padding: "10px 14px",

--- a/src/features/palette/commands.ts
+++ b/src/features/palette/commands.ts
@@ -1,4 +1,5 @@
 // src/features/palette/commands.ts
+import { pgConfirm } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
@@ -209,15 +210,20 @@ export function buildCommands(): PaletteItem[] {
           })),
     });
     const guardedForcePush = (remote: string, branch: string) => {
-      if (
-        useSettingsStore.getState().confirmForcePush &&
-        !window.confirm(
-          `Force-push ${branch} to ${remote} (with lease)? This overwrites the remote branch.`,
-        )
-      ) {
-        return;
-      }
-      void repo.push(remote, branch, "WithLease");
+      void (async () => {
+        if (
+          useSettingsStore.getState().confirmForcePush &&
+          !(await pgConfirm({
+            title: `Force-push ${branch} to ${remote}?`,
+            body: "Overwrites the remote branch. --force-with-lease still refuses if someone else pushed since your last fetch.",
+            danger: true,
+            confirmLabel: "Force-push",
+          }))
+        ) {
+          return;
+        }
+        void repo.push(remote, branch, "WithLease");
+      })();
     };
     items.push({
       type: "command", id: "action:force-push-current",

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import type {
+  AuthorOverride,
   BranchInfo,
   CommitInfo,
   FileContent,
@@ -186,6 +187,8 @@ interface RepoStoreState {
     message: string,
     amend?: boolean,
     signoff?: boolean,
+    /** "Commit as" — null uses the repo config identity. */
+    authorOverride?: AuthorOverride | null,
   ) => Promise<string | null>;
   reset: (target: string, mode: ResetMode) => Promise<void>;
   checkoutBranch: (name: string) => Promise<void>;
@@ -546,11 +549,11 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     }
   },
 
-  async commit(message, amend = false, signoff = false) {
+  async commit(message, amend = false, signoff = false, authorOverride = null) {
     const repo = get().current;
     if (!repo) return null;
     try {
-      const oid = await commitFn(repo.id, message, amend, signoff);
+      const oid = await commitFn(repo.id, message, amend, signoff, authorOverride);
       await get().refreshAll();
       return oid;
     } catch (e) {

--- a/src/features/settings/theme.semantics.test.ts
+++ b/src/features/settings/theme.semantics.test.ts
@@ -1,0 +1,127 @@
+// Light themes must remap the semantic token sets, not just bg/fg/border/accent
+// (#61 B4). Before this, --git-*, --graph-*, --accent-2..5, --shadow-* and the
+// selection tints kept their dark calibration on a light canvas.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { BUILTIN_THEMES, applyTheme, type ThemeDef } from "./useSettingsStore";
+
+const root = () => document.documentElement;
+const token = (name: string) => root().style.getPropertyValue(name).trim();
+
+const dark = BUILTIN_THEMES.find((t) => t.id === "dark-cool")!;
+const light = BUILTIN_THEMES.find((t) => t.id === "light")!;
+const githubLight = BUILTIN_THEMES.find((t) => t.id === "github-light")!;
+
+/** The sets that used to be left behind entirely. */
+const SEMANTIC_NAMES = [
+  "--git-added",
+  "--git-added-bg",
+  "--git-added-gutter",
+  "--git-removed",
+  "--git-removed-bg",
+  "--git-removed-gutter",
+  "--git-modified",
+  "--git-modified-bg",
+  "--git-renamed",
+  "--git-conflict",
+  "--git-untracked",
+  "--git-staged",
+  "--git-ignored",
+  "--graph-1",
+  "--graph-2",
+  "--graph-3",
+  "--graph-4",
+  "--graph-5",
+  "--graph-6",
+  "--graph-7",
+  "--accent-2",
+  "--accent-3",
+  "--accent-4",
+  "--accent-5",
+  "--shadow-1",
+  "--shadow-2",
+  "--shadow-3",
+  "--shadow-inset",
+  "--bg-selection",
+  "--bg-selection-dim",
+  "--bg-selection-focused",
+];
+
+afterEach(() => {
+  // Leave the document on the default theme for other suites.
+  applyTheme(dark);
+});
+
+describe("applyTheme semantic remap (#61 B4)", () => {
+  it("writes every semantic token for a dark theme", () => {
+    applyTheme(dark);
+    for (const name of SEMANTIC_NAMES) {
+      expect(token(name), name).not.toBe("");
+    }
+  });
+
+  it("writes a DIFFERENT value for every semantic token on a light theme", () => {
+    applyTheme(dark);
+    const before = Object.fromEntries(SEMANTIC_NAMES.map((n) => [n, token(n)]));
+
+    applyTheme(light);
+    for (const name of SEMANTIC_NAMES) {
+      expect(token(name), name).not.toBe("");
+      expect(token(name), `${name} must be recalibrated for light mode`).not.toBe(
+        before[name],
+      );
+    }
+  });
+
+  it("restores the dark calibration when switching back", () => {
+    applyTheme(dark);
+    const darkTokens = Object.fromEntries(SEMANTIC_NAMES.map((n) => [n, token(n)]));
+
+    applyTheme(light);
+    applyTheme(dark);
+
+    // A stale light calibration surviving a switch back was the failure mode
+    // that made "write only on mode change" the wrong shortcut.
+    for (const name of SEMANTIC_NAMES) {
+      expect(token(name), name).toBe(darkTokens[name]);
+    }
+  });
+
+  it("uses the same light calibration for every light theme", () => {
+    applyTheme(light);
+    const a = Object.fromEntries(SEMANTIC_NAMES.map((n) => [n, token(n)]));
+    applyTheme(githubLight);
+    for (const name of SEMANTIC_NAMES) {
+      // …except the accent-derived selection tints, which follow --accent and
+      // so are theme-specific by design. They are declared relative to
+      // var(--accent), so the literal text still matches.
+      expect(token(name), name).toBe(a[name]);
+    }
+  });
+
+  it("derives selection tints from the accent, not a hardcoded hue", () => {
+    applyTheme(dark);
+    for (const name of [
+      "--bg-selection",
+      "--bg-selection-dim",
+      "--bg-selection-focused",
+    ]) {
+      expect(token(name), name).toContain("var(--accent)");
+    }
+  });
+
+  it("treats an unknown mode as dark rather than emitting nothing", () => {
+    // Persisted/imported themes are only loosely validated, so mode can be a
+    // string this build has never heard of. Half-written tokens would be worse
+    // than a wrong-but-consistent calibration.
+    applyTheme(dark);
+    const darkTokens = Object.fromEntries(SEMANTIC_NAMES.map((n) => [n, token(n)]));
+
+    applyTheme(light);
+    applyTheme({ ...dark, mode: "sepia" as unknown as ThemeDef["mode"] });
+
+    for (const name of SEMANTIC_NAMES) {
+      expect(token(name), name).toBe(darkTokens[name]);
+    }
+  });
+});

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -311,6 +311,108 @@ export const BUILTIN_THEMES: ThemeDef[] = [
 // APPLY + PERSIST
 // ═════════════════════════════════════════════════════════════════════════════
 
+/**
+ * Semantic tokens that are NOT part of the editable theme palette but still
+ * have to change with the theme's mode (#61 B4).
+ *
+ * These carry meaning of their own — diff green must stay green, graph lanes
+ * must stay mutually distinguishable — so they are deliberately not derived
+ * from the accent. What they cannot be is fixed: the dark set is calibrated
+ * for text on a dark canvas, and reusing it on a light theme leaves diff
+ * add/remove, graph lanes, branch pills and shadows washed out and low
+ * contrast. Two calibrations, picked by `theme.mode`.
+ *
+ * The dark column is byte-identical to the `:root` defaults in index.css, so
+ * every dark theme renders exactly as before.
+ */
+const SEMANTIC_TOKENS: Record<"dark" | "light", Record<string, string>> = {
+  dark: {
+    "--git-added": "oklch(0.72 0.15 155)",
+    "--git-added-bg": "oklch(0.35 0.08 155 / 0.25)",
+    "--git-added-gutter": "oklch(0.45 0.12 155 / 0.5)",
+    "--git-removed": "oklch(0.68 0.18 25)",
+    "--git-removed-bg": "oklch(0.35 0.10 25 / 0.25)",
+    "--git-removed-gutter": "oklch(0.45 0.14 25 / 0.5)",
+    "--git-modified": "oklch(0.75 0.14 75)",
+    "--git-modified-bg": "oklch(0.35 0.08 75 / 0.2)",
+    "--git-renamed": "oklch(0.72 0.15 235)",
+    "--git-conflict": "oklch(0.72 0.15 325)",
+    "--git-untracked": "oklch(0.72 0.12 295)",
+    "--git-staged": "oklch(0.72 0.15 155)",
+    "--git-ignored": "oklch(0.55 0.005 260)",
+    "--graph-1": "oklch(0.72 0.15 235)",
+    "--graph-2": "oklch(0.72 0.15 295)",
+    "--graph-3": "oklch(0.72 0.15 155)",
+    "--graph-4": "oklch(0.72 0.15 65)",
+    "--graph-5": "oklch(0.72 0.15 25)",
+    "--graph-6": "oklch(0.72 0.15 355)",
+    "--graph-7": "oklch(0.72 0.15 195)",
+    "--accent-2": "oklch(0.72 0.15 295)",
+    "--accent-3": "oklch(0.72 0.15 155)",
+    "--accent-4": "oklch(0.72 0.15 65)",
+    "--accent-5": "oklch(0.72 0.15 25)",
+    "--shadow-1": "0 1px 2px rgba(0,0,0,0.4)",
+    "--shadow-2": "0 4px 12px rgba(0,0,0,0.35)",
+    "--shadow-3": "0 12px 40px rgba(0,0,0,0.5)",
+    "--shadow-inset": "inset 0 1px 0 rgba(255,255,255,0.04)",
+  },
+  light: {
+    // Foreground hues drop to ~0.55 L so they carry contrast against a near-
+    // white canvas; the *-bg fills invert — light tints instead of dark
+    // washes — and gutters sit between the two.
+    "--git-added": "oklch(0.55 0.16 155)",
+    "--git-added-bg": "oklch(0.90 0.08 155 / 0.55)",
+    "--git-added-gutter": "oklch(0.76 0.14 155 / 0.65)",
+    "--git-removed": "oklch(0.54 0.20 25)",
+    "--git-removed-bg": "oklch(0.91 0.07 25 / 0.55)",
+    "--git-removed-gutter": "oklch(0.75 0.16 25 / 0.65)",
+    "--git-modified": "oklch(0.58 0.14 75)",
+    "--git-modified-bg": "oklch(0.91 0.08 75 / 0.5)",
+    "--git-renamed": "oklch(0.53 0.16 235)",
+    "--git-conflict": "oklch(0.53 0.19 325)",
+    "--git-untracked": "oklch(0.51 0.17 295)",
+    "--git-staged": "oklch(0.55 0.16 155)",
+    "--git-ignored": "oklch(0.66 0.005 260)",
+    "--graph-1": "oklch(0.56 0.16 235)",
+    "--graph-2": "oklch(0.54 0.17 295)",
+    "--graph-3": "oklch(0.55 0.15 155)",
+    "--graph-4": "oklch(0.60 0.14 65)",
+    "--graph-5": "oklch(0.56 0.18 25)",
+    "--graph-6": "oklch(0.55 0.18 355)",
+    "--graph-7": "oklch(0.55 0.13 195)",
+    "--accent-2": "oklch(0.54 0.17 295)",
+    "--accent-3": "oklch(0.55 0.15 155)",
+    "--accent-4": "oklch(0.60 0.14 65)",
+    "--accent-5": "oklch(0.56 0.18 25)",
+    // Dark themes cast shadows with pure black; on a light canvas that reads
+    // as grime. Tint them with the same cool ink the text uses, and lighten.
+    "--shadow-1": "0 1px 2px rgba(20,26,38,0.10)",
+    "--shadow-2": "0 4px 12px rgba(20,26,38,0.12)",
+    "--shadow-3": "0 12px 40px rgba(20,26,38,0.18)",
+    "--shadow-inset": "inset 0 1px 0 rgba(255,255,255,0.65)",
+  },
+};
+
+/**
+ * Selection tints and the focus ring genuinely ARE accent-tinted, so they are
+ * derived from `--accent` with relative-color syntax rather than tabulated —
+ * that way a custom accent carries through instead of leaving blue selection
+ * on an amber theme. Light mode substitutes a high lightness so the tint sits
+ * *behind* dark text instead of drowning it.
+ */
+const SELECTION_TOKENS: Record<"dark" | "light", Record<string, string>> = {
+  dark: {
+    "--bg-selection": "oklch(from var(--accent) 0.35 calc(c * 0.35) h / 0.4)",
+    "--bg-selection-dim": "oklch(from var(--accent) 0.35 calc(c * 0.15) h / 0.22)",
+    "--bg-selection-focused": "oklch(from var(--accent) 0.45 calc(c * 0.6) h / 0.35)",
+  },
+  light: {
+    "--bg-selection": "oklch(from var(--accent) 0.88 calc(c * 0.5) h / 0.55)",
+    "--bg-selection-dim": "oklch(from var(--accent) 0.93 calc(c * 0.3) h / 0.6)",
+    "--bg-selection-focused": "oklch(from var(--accent) 0.84 calc(c * 0.8) h / 0.6)",
+  },
+};
+
 /** Apply theme by writing every color slot to CSS vars on :root. */
 export function applyTheme(theme: ThemeDef) {
   const root = document.documentElement;
@@ -336,6 +438,16 @@ export function applyTheme(theme: ThemeDef) {
   root.style.setProperty("--logo", c.logo ?? LOGO_PRIMARY);
   root.style.setProperty("--logo-2", c.logo2 ?? LOGO_SECONDARY);
   root.style.setProperty("--ring", `0 0 0 2px ${c.accent}80`);
+  // Mode-calibrated semantics + accent-derived selection tints. Written on
+  // every apply (not only on a mode change) so switching dark → light → dark
+  // can't leave a stale calibration behind.
+  const mode = theme.mode === "light" ? "light" : "dark";
+  for (const [token, value] of Object.entries(SEMANTIC_TOKENS[mode])) {
+    root.style.setProperty(token, value);
+  }
+  for (const [token, value] of Object.entries(SELECTION_TOKENS[mode])) {
+    root.style.setProperty(token, value);
+  }
   root.dataset.theme = theme.id;
   root.dataset.themeMode = theme.mode;
 }
@@ -390,8 +502,12 @@ export function applyDensity(density: UiDensity) {
 // Removed settings (persisted keys are dropped by load()'s known-key filter):
 // - signCommits: GPG/SSH signing needs real key plumbing; a toggle that only
 //   pretends to sign erodes trust. Re-add together with actual signing.
-// - showWhitespaceInDiff: no cheap consumer — libgit2's whitespace flags
-//   invert the semantics and would desync hunk indices from staging.
+//
+// `ignoreWhitespaceInDiff` is the successor to the removed showWhitespaceInDiff.
+// The hunk-index desync that killed the first attempt is real (see the
+// whitespace_diff.rs backend test), and is handled rather than ignored: the
+// flag reaches the diff READ paths only, and every surface disables its
+// hunk-level stage/discard while it is on.
 interface PersistedState {
   activeThemeId: string;
   customThemes: ThemeDef[];
@@ -404,6 +520,7 @@ interface PersistedState {
   autoStashBeforePull: boolean;
   addSignoff: boolean;
   diffContextLines: number;
+  ignoreWhitespaceInDiff: boolean;
 }
 
 export interface SettingsState extends PersistedState {
@@ -433,6 +550,7 @@ const DEFAULTS: PersistedState = {
   autoStashBeforePull: true,
   addSignoff: false,
   diffContextLines: 3,
+  ignoreWhitespaceInDiff: false,
 };
 
 function load(): PersistedState {
@@ -493,6 +611,7 @@ function snapshot(s: SettingsState): PersistedState {
     autoStashBeforePull: s.autoStashBeforePull,
     addSignoff: s.addSignoff,
     diffContextLines: s.diffContextLines,
+    ignoreWhitespaceInDiff: s.ignoreWhitespaceInDiff,
   };
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,17 @@
 @import "tailwindcss";
 @import "highlight.js/styles/github-dark.css";
 
+/* Bundled type (#61 B5). The design is mono-forward, but the stacks below used
+ * to *name* Inter / JetBrains Mono without shipping them — on a machine that
+ * lacks both, the whole app silently fell back to system sans/mono and lost
+ * the intended look. These are the OFL-1.1 variable builds: one file per
+ * unicode-range subset, so a browser fetches only the subset it renders, and
+ * one variable axis covers every weight the UI asks for. Family names are
+ * "* Variable"; the locally-installed static names stay next in the stack so a
+ * user who has them keeps using them. */
+@import "@fontsource-variable/inter/index.css";
+@import "@fontsource-variable/jetbrains-mono/index.css";
+
 /* ============================================================
  * PlatypusGit Design Tokens
  * Dense, utilitarian, monospace-forward. Dark mode hero.
@@ -8,9 +19,9 @@
 
 :root {
   /* ===== TYPE ===== */
-  --font-sans: "Inter", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
-  --font-mono: "JetBrains Mono", "SF Mono", ui-monospace, "Menlo", Consolas, monospace;
-  --font-display: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+  --font-sans: "Inter Variable", "Inter", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  --font-mono: "JetBrains Mono Variable", "JetBrains Mono", "SF Mono", ui-monospace, "Menlo", Consolas, monospace;
+  --font-display: "JetBrains Mono Variable", "JetBrains Mono", "SF Mono", ui-monospace, monospace;
 
   --fs-10: 10px;
   --fs-11: 11px;
@@ -89,7 +100,15 @@
   --logo: #3e9b91;   /* head */
   --logo-2: #e6a95a; /* bill */
 
-  /* ===== SEMANTIC (git states) ===== */
+  /* ===== SEMANTIC (git states) =====
+   * Everything from here to --shadow-inset, plus --accent-2..5 and
+   * --bg-selection* above, is ALSO written by applyTheme()
+   * (features/settings/useSettingsStore.ts) from SEMANTIC_TOKENS /
+   * SELECTION_TOKENS, calibrated per theme mode — light themes need their own
+   * values or diff colors, graph lanes and shadows stay dark-calibrated over a
+   * light canvas. These declarations are the pre-hydration defaults only, and
+   * are kept byte-identical to the `dark` column there. Editing one without
+   * the other makes them drift. */
   --git-added: oklch(0.72 0.15 155);
   --git-added-bg: oklch(0.35 0.08 155 / 0.25);
   --git-added-gutter: oklch(0.45 0.12 155 / 0.5);

--- a/src/lib/fileIcon.test.ts
+++ b/src/lib/fileIcon.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { GENERIC_FILE_ICON, fileIconSpec } from "./fileIcon";
+
+describe("fileIconSpec", () => {
+  it("resolves by extension, case-insensitively", () => {
+    expect(fileIconSpec("src/lib/tree.ts").icon).toBe("fileCode");
+    expect(fileIconSpec("README.MD").icon).toBe("fileDoc");
+    expect(fileIconSpec("a/b/style.SCSS").icon).toBe("fileStyle");
+  });
+
+  it("tints same-category languages differently", () => {
+    // Glyph is per category, color is per language — that pairing is the whole
+    // point of the map, so a regression that collapses either is caught here.
+    const ts = fileIconSpec("main.ts");
+    const js = fileIconSpec("main.js");
+    expect(ts.icon).toBe(js.icon);
+    expect(ts.color).not.toBe(js.color);
+  });
+
+  it("prefers an exact basename over the extension", () => {
+    // package-lock.json is a lockfile, not JSON.
+    expect(fileIconSpec("package-lock.json").icon).toBe("fileLock");
+    expect(fileIconSpec("package.json").icon).toBe("fileData");
+    expect(fileIconSpec("Dockerfile").icon).toBe("fileConfig");
+    expect(fileIconSpec(".gitignore").icon).toBe("fileGit");
+  });
+
+  it("only inspects the basename", () => {
+    expect(fileIconSpec("some.rs.dir/notes.md").icon).toBe("fileDoc");
+  });
+
+  it("falls back to the generic file glyph", () => {
+    expect(fileIconSpec("mystery.qqq")).toEqual(GENERIC_FILE_ICON);
+    expect(fileIconSpec("Makefile.unknownsuffixthing")).toEqual(GENERIC_FILE_ICON);
+    expect(fileIconSpec("noextension")).toEqual(GENERIC_FILE_ICON);
+    // A leading-dot file with no second dot has no extension to read.
+    expect(fileIconSpec(".bashrc")).toEqual(GENERIC_FILE_ICON);
+  });
+
+  it("tolerates the trailing slash libgit2 puts on an embedded repo", () => {
+    expect(fileIconSpec("vendor/thing/")).toEqual(GENERIC_FILE_ICON);
+    expect(fileIconSpec("vendor/notes.md/").icon).toBe("fileDoc");
+  });
+
+  it("returns only themeable CSS custom properties as colors", () => {
+    for (const p of ["a.ts", "a.js", "a.png", "a.zip", "Cargo.lock", "x.unknown"]) {
+      expect(fileIconSpec(p).color).toMatch(/^var\(--[a-z0-9-]+\)$/);
+    }
+  });
+});

--- a/src/lib/fileIcon.ts
+++ b/src/lib/fileIcon.ts
@@ -1,0 +1,224 @@
+// File-type icon + tint resolution for every file row in the app.
+//
+// Two axes, deliberately kept separate:
+//  - GLYPH is per *category* (code / data / doc / style / image / …). Nine
+//    category glyphs stay legible at 11–12px, where a per-language logo would
+//    turn to mush, and adding a language means one map entry, not new SVG.
+//  - TINT is per *extension*, drawn from the themeable `--graph-*` lane tokens
+//    so a `.ts` and a `.rs` are still told apart at a glance and every color
+//    follows the active theme (see applyTheme's semantic remap).
+//
+// Resolution order: exact basename (lockfiles, Dockerfile, .gitignore) →
+// extension → generic `file` in `--fg-2`. Unknown types therefore render
+// exactly as they did before this map existed.
+
+import type { IconName } from "@/design/icons";
+
+export interface FileIconSpec {
+  icon: IconName;
+  /** CSS color value — always a `var(--…)` token so themes remap it. */
+  color: string;
+}
+
+const C = {
+  blue: "var(--graph-1)",
+  violet: "var(--graph-2)",
+  green: "var(--graph-3)",
+  amber: "var(--graph-4)",
+  red: "var(--graph-5)",
+  pink: "var(--graph-6)",
+  teal: "var(--graph-7)",
+  muted: "var(--fg-2)",
+  faint: "var(--fg-3)",
+} as const;
+
+export const GENERIC_FILE_ICON: FileIconSpec = { icon: "file", color: C.muted };
+export const FOLDER_ICON_COLOR = "var(--accent-4)";
+
+/** extension (no dot, lowercased) → glyph + tint. */
+const BY_EXT: Record<string, FileIconSpec> = {
+  // ── code ──────────────────────────────────────────────────────────────
+  ts: { icon: "fileCode", color: C.blue },
+  tsx: { icon: "fileCode", color: C.blue },
+  mts: { icon: "fileCode", color: C.blue },
+  cts: { icon: "fileCode", color: C.blue },
+  js: { icon: "fileCode", color: C.amber },
+  jsx: { icon: "fileCode", color: C.amber },
+  mjs: { icon: "fileCode", color: C.amber },
+  cjs: { icon: "fileCode", color: C.amber },
+  rs: { icon: "fileCode", color: C.red },
+  go: { icon: "fileCode", color: C.teal },
+  py: { icon: "fileCode", color: C.green },
+  rb: { icon: "fileCode", color: C.red },
+  java: { icon: "fileCode", color: C.red },
+  kt: { icon: "fileCode", color: C.violet },
+  kts: { icon: "fileCode", color: C.violet },
+  swift: { icon: "fileCode", color: C.red },
+  c: { icon: "fileCode", color: C.blue },
+  h: { icon: "fileCode", color: C.blue },
+  cc: { icon: "fileCode", color: C.blue },
+  cpp: { icon: "fileCode", color: C.blue },
+  hpp: { icon: "fileCode", color: C.blue },
+  cs: { icon: "fileCode", color: C.violet },
+  php: { icon: "fileCode", color: C.violet },
+  lua: { icon: "fileCode", color: C.blue },
+  ex: { icon: "fileCode", color: C.violet },
+  exs: { icon: "fileCode", color: C.violet },
+  hs: { icon: "fileCode", color: C.violet },
+  scala: { icon: "fileCode", color: C.red },
+  dart: { icon: "fileCode", color: C.teal },
+  zig: { icon: "fileCode", color: C.amber },
+  html: { icon: "fileCode", color: C.red },
+  htm: { icon: "fileCode", color: C.red },
+  vue: { icon: "fileCode", color: C.green },
+  svelte: { icon: "fileCode", color: C.red },
+  astro: { icon: "fileCode", color: C.pink },
+
+  // ── shell ─────────────────────────────────────────────────────────────
+  sh: { icon: "fileShell", color: C.green },
+  bash: { icon: "fileShell", color: C.green },
+  zsh: { icon: "fileShell", color: C.green },
+  fish: { icon: "fileShell", color: C.green },
+  ps1: { icon: "fileShell", color: C.blue },
+  bat: { icon: "fileShell", color: C.faint },
+  cmd: { icon: "fileShell", color: C.faint },
+
+  // ── data / config ─────────────────────────────────────────────────────
+  json: { icon: "fileData", color: C.amber },
+  jsonc: { icon: "fileData", color: C.amber },
+  json5: { icon: "fileData", color: C.amber },
+  yaml: { icon: "fileData", color: C.teal },
+  yml: { icon: "fileData", color: C.teal },
+  toml: { icon: "fileData", color: C.teal },
+  ini: { icon: "fileData", color: C.teal },
+  env: { icon: "fileConfig", color: C.amber },
+  conf: { icon: "fileConfig", color: C.teal },
+  cfg: { icon: "fileConfig", color: C.teal },
+  properties: { icon: "fileConfig", color: C.teal },
+  xml: { icon: "fileData", color: C.green },
+  csv: { icon: "fileData", color: C.green },
+  tsv: { icon: "fileData", color: C.green },
+  sql: { icon: "fileData", color: C.teal },
+  graphql: { icon: "fileData", color: C.pink },
+  gql: { icon: "fileData", color: C.pink },
+  proto: { icon: "fileData", color: C.blue },
+
+  // ── style ─────────────────────────────────────────────────────────────
+  css: { icon: "fileStyle", color: C.violet },
+  scss: { icon: "fileStyle", color: C.pink },
+  sass: { icon: "fileStyle", color: C.pink },
+  less: { icon: "fileStyle", color: C.violet },
+  styl: { icon: "fileStyle", color: C.violet },
+
+  // ── docs ──────────────────────────────────────────────────────────────
+  md: { icon: "fileDoc", color: C.muted },
+  mdx: { icon: "fileDoc", color: C.muted },
+  rst: { icon: "fileDoc", color: C.muted },
+  txt: { icon: "fileDoc", color: C.muted },
+  adoc: { icon: "fileDoc", color: C.muted },
+  pdf: { icon: "fileDoc", color: C.red },
+
+  // ── images ────────────────────────────────────────────────────────────
+  png: { icon: "fileImage", color: C.green },
+  jpg: { icon: "fileImage", color: C.green },
+  jpeg: { icon: "fileImage", color: C.green },
+  gif: { icon: "fileImage", color: C.green },
+  webp: { icon: "fileImage", color: C.green },
+  avif: { icon: "fileImage", color: C.green },
+  bmp: { icon: "fileImage", color: C.green },
+  ico: { icon: "fileImage", color: C.amber },
+  svg: { icon: "fileImage", color: C.amber },
+
+  // ── archives / binaries ───────────────────────────────────────────────
+  zip: { icon: "fileArchive", color: C.faint },
+  tar: { icon: "fileArchive", color: C.faint },
+  gz: { icon: "fileArchive", color: C.faint },
+  tgz: { icon: "fileArchive", color: C.faint },
+  bz2: { icon: "fileArchive", color: C.faint },
+  xz: { icon: "fileArchive", color: C.faint },
+  zst: { icon: "fileArchive", color: C.faint },
+  rar: { icon: "fileArchive", color: C.faint },
+  "7z": { icon: "fileArchive", color: C.faint },
+  exe: { icon: "fileBinary", color: C.faint },
+  dll: { icon: "fileBinary", color: C.faint },
+  so: { icon: "fileBinary", color: C.faint },
+  dylib: { icon: "fileBinary", color: C.faint },
+  wasm: { icon: "fileBinary", color: C.violet },
+  bin: { icon: "fileBinary", color: C.faint },
+  o: { icon: "fileBinary", color: C.faint },
+  a: { icon: "fileBinary", color: C.faint },
+  woff: { icon: "fileBinary", color: C.faint },
+  woff2: { icon: "fileBinary", color: C.faint },
+  ttf: { icon: "fileBinary", color: C.faint },
+  otf: { icon: "fileBinary", color: C.faint },
+  lock: { icon: "fileLock", color: C.red },
+};
+
+/**
+ * Exact basename (lowercased) → glyph + tint. Wins over the extension map, so
+ * `package-lock.json` reads as a lockfile rather than as JSON and `Dockerfile`
+ * resolves at all (it has no extension).
+ */
+const BY_NAME: Record<string, FileIconSpec> = {
+  // Lockfiles — a padlock signals "generated, don't hand-edit".
+  "package-lock.json": { icon: "fileLock", color: C.red },
+  "pnpm-lock.yaml": { icon: "fileLock", color: C.red },
+  "yarn.lock": { icon: "fileLock", color: C.red },
+  "bun.lockb": { icon: "fileLock", color: C.red },
+  "cargo.lock": { icon: "fileLock", color: C.red },
+  "poetry.lock": { icon: "fileLock", color: C.red },
+  "composer.lock": { icon: "fileLock", color: C.red },
+  "gemfile.lock": { icon: "fileLock", color: C.red },
+  "go.sum": { icon: "fileLock", color: C.red },
+
+  // Git's own dotfiles.
+  ".gitignore": { icon: "fileGit", color: C.red },
+  ".gitattributes": { icon: "fileGit", color: C.red },
+  ".gitmodules": { icon: "fileGit", color: C.red },
+  ".gitkeep": { icon: "fileGit", color: C.faint },
+  ".mailmap": { icon: "fileGit", color: C.red },
+
+  // Build / tooling entry points.
+  dockerfile: { icon: "fileConfig", color: C.blue },
+  "docker-compose.yml": { icon: "fileConfig", color: C.blue },
+  "docker-compose.yaml": { icon: "fileConfig", color: C.blue },
+  makefile: { icon: "fileConfig", color: C.amber },
+  justfile: { icon: "fileConfig", color: C.amber },
+  "cmakelists.txt": { icon: "fileConfig", color: C.amber },
+  ".editorconfig": { icon: "fileConfig", color: C.teal },
+  ".npmrc": { icon: "fileConfig", color: C.red },
+  ".nvmrc": { icon: "fileConfig", color: C.green },
+  ".dockerignore": { icon: "fileConfig", color: C.blue },
+  ".prettierrc": { icon: "fileConfig", color: C.pink },
+  ".eslintrc": { icon: "fileConfig", color: C.violet },
+
+  license: { icon: "fileDoc", color: C.amber },
+  "license.md": { icon: "fileDoc", color: C.amber },
+  "license.txt": { icon: "fileDoc", color: C.amber },
+  readme: { icon: "fileDoc", color: C.blue },
+  "readme.md": { icon: "fileDoc", color: C.blue },
+};
+
+/**
+ * Glyph + tint for a file path. Accepts a bare name or a full repo-relative
+ * path; only the basename is inspected. Directories must not be passed here —
+ * they get {@link FOLDER_ICON_COLOR} and the folder glyph at the call site.
+ */
+export function fileIconSpec(path: string): FileIconSpec {
+  // libgit2 marks an embedded repo with a trailing slash; strip it so the
+  // basename below isn't empty.
+  const clean = path.replace(/\/+$/, "");
+  const base = (clean.split("/").pop() ?? clean).toLowerCase();
+  if (!base) return GENERIC_FILE_ICON;
+
+  const byName = BY_NAME[base];
+  if (byName) return byName;
+
+  // A dotfile with no further dot (".bashrc") has no extension to speak of —
+  // `split(".").pop()` would return "bashrc" and match nothing, which is the
+  // right answer anyway, so no special case is needed beyond guarding "".
+  const dot = base.lastIndexOf(".");
+  if (dot <= 0) return GENERIC_FILE_ICON;
+  const ext = base.slice(dot + 1);
+  return BY_EXT[ext] ?? GENERIC_FILE_ICON;
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,6 +1,7 @@
 import { invoke as rawInvoke } from "@tauri-apps/api/core";
 import { debug as logDebug, warn as logWarn, error as logError } from "@tauri-apps/plugin-log";
 import type {
+  AuthorOverride,
   BlameLine,
   BranchInfo,
   CliInstallOutcome,
@@ -149,13 +150,26 @@ export async function listRemotes(repoId: string): Promise<RemoteInfo[]> {
   return invoke<RemoteInfo[]>("list_remotes", { repoId });
 }
 
+/**
+ * `ignoreWhitespace` is a VIEWING option: it folds whitespace-only changes into
+ * context. Hunk indices from such a diff do NOT line up with the ones
+ * stageHunk/discardHunk expect, so callers must disable hunk-level actions
+ * while it is on (#61 D2).
+ */
 export async function getDiff(
   repoId: string,
   path: string,
   kind: DiffKind = "WorktreeToIndex",
   contextLines = 3,
+  ignoreWhitespace = false,
 ): Promise<FileDiff> {
-  return invoke<FileDiff>("get_diff", { repoId, path, kind, contextLines });
+  return invoke<FileDiff>("get_diff", {
+    repoId,
+    path,
+    kind,
+    contextLines,
+    ignoreWhitespace,
+  });
 }
 
 export async function getReflog(repoId: string): Promise<ReflogEntry[]> {
@@ -174,8 +188,15 @@ export async function diffCommits(
   fromOid: string,
   toOid: string,
   contextLines = 3,
+  ignoreWhitespace = false,
 ): Promise<FileDiff[]> {
-  return invoke<FileDiff[]>("diff_commits", { repoId, fromOid, toOid, contextLines });
+  return invoke<FileDiff[]>("diff_commits", {
+    repoId,
+    fromOid,
+    toOid,
+    contextLines,
+    ignoreWhitespace,
+  });
 }
 
 /**
@@ -187,8 +208,14 @@ export async function diffCommit(
   repoId: string,
   oid: string,
   contextLines = 3,
+  ignoreWhitespace = false,
 ): Promise<FileDiff[]> {
-  return invoke<FileDiff[]>("diff_commit", { repoId, oid, contextLines });
+  return invoke<FileDiff[]>("diff_commit", {
+    repoId,
+    oid,
+    contextLines,
+    ignoreWhitespace,
+  });
 }
 
 export async function stagePaths(repoId: string, paths: string[]): Promise<void> {
@@ -204,8 +231,16 @@ export async function commit(
   message: string,
   amend = false,
   signoff = false,
+  /** "Commit as" — omit to use the repo config identity. */
+  authorOverride: AuthorOverride | null = null,
 ): Promise<string> {
-  return invoke<string>("commit", { repoId, message, amend, signoff });
+  return invoke<string>("commit", {
+    repoId,
+    message,
+    amend,
+    signoff,
+    authorOverride,
+  });
 }
 
 export async function discardPaths(repoId: string, paths: string[]): Promise<void> {

--- a/src/lib/tree.ts
+++ b/src/lib/tree.ts
@@ -93,6 +93,30 @@ export function buildStatusTree(
 }
 
 /**
+ * Flat counterpart of {@link buildStatusTree}: one leaf node per file, named
+ * with its full path, no nesting.
+ *
+ * Row keys come out identical to the nested build ("/" + full path), which is
+ * what lets a view flip between tree and flat without touching selection,
+ * staging state, or context menus — they all key off the same strings.
+ */
+export function buildStatusList(files: FileStatus[]): PGFileTreeNode[] {
+  return files
+    .map((f) => {
+      const hasChange =
+        f.worktree.kind !== "Unmodified" || f.index.kind !== "Unmodified";
+      return {
+        // libgit2's embedded-repo entry carries a trailing slash; the nested
+        // build drops it when splitting, so drop it here too or the two modes
+        // would disagree about one row's key.
+        name: f.path.replace(/\/+$/, ""),
+        status: hasChange ? statusMark(f) : undefined,
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
  * Repo-relative path for a PGFileTree row key. Keys are built by joining node
  * names with "/" from an empty root, so they carry a leading slash: "/a/b".
  */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -244,3 +244,13 @@ export interface UpdateInfo {
 }
 
 export type UpdateCapability = "self-update" | "notify";
+
+/**
+ * "Commit as" identity. Mirrors Rust `AuthorOverride` (git/types.rs) — it sets
+ * the commit's AUTHOR only; the committer stays the repo config identity, the
+ * same split `git commit --author` uses.
+ */
+export interface AuthorOverride {
+  name: string;
+  email: string;
+}

--- a/src/lib/useTreeViewMode.ts
+++ b/src/lib/useTreeViewMode.ts
@@ -1,0 +1,40 @@
+// Tree ⇄ flat view mode for a file list, persisted per surface (#61 A6).
+//
+// Each list keeps its own preference — flat-with-full-paths reads faster for a
+// small changeset, a tree for a large one, and the right answer differs
+// between the repo browser and the commit screen. Same shape as the pane-width
+// persistence: localStorage, best-effort, never fatal.
+
+import React from "react";
+
+export type TreeViewMode = "tree" | "flat";
+
+function read(storageKey: string, fallback: TreeViewMode): TreeViewMode {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    return raw === "tree" || raw === "flat" ? raw : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function useTreeViewMode(
+  storageKey: string,
+  fallback: TreeViewMode = "tree",
+): [TreeViewMode, (m: TreeViewMode) => void] {
+  const [mode, setMode] = React.useState<TreeViewMode>(() =>
+    read(storageKey, fallback),
+  );
+  const update = React.useCallback(
+    (m: TreeViewMode) => {
+      setMode(m);
+      try {
+        localStorage.setItem(storageKey, m);
+      } catch {
+        // non-fatal — the session just won't remember the choice
+      }
+    },
+    [storageKey],
+  );
+  return [mode, update];
+}

--- a/src/screens/Branches.tsx
+++ b/src/screens/Branches.tsx
@@ -11,6 +11,8 @@ import {
   PGToolbar,
   KV,
   branchMenuItems,
+  pgConfirm,
+  pgPrompt,
   remoteBranchMenuItems,
   stashMenuItems,
   tagMenuItems,
@@ -49,8 +51,15 @@ export function BranchesScreen() {
     "all" | "local" | "remote" | "tags" | "stashes"
   >("all");
 
-  const startCreate = () => {
-    const raw = window.prompt("New branch name");
+  const startCreate = async () => {
+    const raw = await pgPrompt({
+      title: "New branch",
+      body: "Created from the current HEAD and checked out.",
+      placeholder: "feat/my-branch",
+      confirmLabel: "Create",
+      requireValue: true,
+      mono: true,
+    });
     if (!raw) return;
     const name = raw.trim();
     if (!name) return;
@@ -794,8 +803,13 @@ function BranchActions({ branch }: { branch: BranchInfo }) {
         icon="merge"
         disabled={branch.isHead}
         title={`Merge ${branch.name} into current branch`}
-        onClick={() => {
-          if (!window.confirm(`Merge ${branch.name} into the current branch?`))
+        onClick={async () => {
+          if (
+            !(await pgConfirm({
+              title: `Merge ${branch.name} into the current branch?`,
+              confirmLabel: "Merge",
+            }))
+          )
             return;
           useRepoStore.getState().mergeBranch(branch.name);
         }}
@@ -807,11 +821,13 @@ function BranchActions({ branch }: { branch: BranchInfo }) {
         icon="rebase"
         disabled={branch.isHead}
         title={`Rebase current branch onto ${branch.name}`}
-        onClick={() => {
+        onClick={async () => {
           if (
-            !window.confirm(
-              `Rebase the current branch onto ${branch.name}? This rewrites history.`,
-            )
+            !(await pgConfirm({
+              title: `Rebase the current branch onto ${branch.name}?`,
+              body: "Your commits are replayed on top — this rewrites history, so their SHAs change.",
+              confirmLabel: "Rebase",
+            }))
           )
             return;
           useRepoStore.getState().rebaseOnto(branch.name);
@@ -824,8 +840,14 @@ function BranchActions({ branch }: { branch: BranchInfo }) {
         tone="danger"
         icon="trash"
         disabled={branch.isHead}
-        onClick={() => {
-          if (window.confirm(`Delete ${branch.name}?`))
+        onClick={async () => {
+          if (
+            await pgConfirm({
+              title: `Delete branch ${branch.name}?`,
+              danger: true,
+              confirmLabel: "Delete",
+            })
+          )
             useRepoStore.getState().deleteBranch(branch.name);
         }}
       >
@@ -897,8 +919,15 @@ function TagActions({ tag }: { tag: TagInfo }) {
         variant="ghost"
         tone="danger"
         icon="trash"
-        onClick={() => {
-          if (window.confirm(`Delete tag ${tag.name}?`))
+        onClick={async () => {
+          if (
+            await pgConfirm({
+              title: `Delete tag ${tag.name}?`,
+              body: "Only the local tag — a tag already pushed stays on the remote.",
+              danger: true,
+              confirmLabel: "Delete tag",
+            })
+          )
             useRepoStore.getState().deleteTag(tag.name);
         }}
       >
@@ -968,8 +997,15 @@ function StashActions({ stash }: { stash: StashInfo }) {
         variant="ghost"
         tone="danger"
         icon="trash"
-        onClick={() => {
-          if (window.confirm(`Drop stash@{${stash.index}}?`))
+        onClick={async () => {
+          if (
+            await pgConfirm({
+              title: `Drop stash@{${stash.index}}?`,
+              body: "The stashed changes are discarded.",
+              danger: true,
+              confirmLabel: "Drop",
+            })
+          )
             useRepoStore.getState().stashDrop(stash.index);
         }}
       >

--- a/src/screens/CommitDiff.tsx
+++ b/src/screens/CommitDiff.tsx
@@ -4,6 +4,7 @@ import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { CommitDiffPanel } from "@/features/diff/CommitDiffPanel";
+import { useIgnoreWhitespace } from "@/features/diff/WhitespaceToggle";
 import { DeepViewHeader } from "@/features/nav/DeepViewHeader";
 import { diffCommit, diffCommits } from "@/lib/tauri";
 import { appErrorMessage } from "@/lib/errors";
@@ -31,6 +32,7 @@ function targetHeader(target: Target): string {
 export function CommitDiffScreen() {
   const repo = useRepoStore((s) => s.current);
   const diffContextLines = useSettingsStore((s) => s.diffContextLines);
+  const ignoreWhitespace = useIgnoreWhitespace();
   const intent = useNavStore((s) => s.intent);
   const clearIntent = useNavStore((s) => s.clearIntent);
 
@@ -62,19 +64,20 @@ export function CommitDiffScreen() {
     setError(null);
     const fetch =
       target.kind === "commit-self"
-        ? diffCommit(repo.id, target.oid, diffContextLines)
+        ? diffCommit(repo.id, target.oid, diffContextLines, ignoreWhitespace)
         : diffCommits(
             repo.id,
             target.kind === "commit-vs-commit" ? target.from : target.oid,
             target.kind === "commit-vs-commit" ? target.to : "HEAD",
             diffContextLines,
+            ignoreWhitespace,
           );
     fetch
       .then((d) => { if (!cancelled) setDiffs(d); })
       .catch((e) => { if (!cancelled) { setDiffs([]); setError(appErrorMessage(e)); } })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, [repo?.id, target, diffContextLines]);
+  }, [repo?.id, target, diffContextLines, ignoreWhitespace]);
 
   if (!target) {
     return (

--- a/src/screens/CommitPanel.attribution.test.tsx
+++ b/src/screens/CommitPanel.attribution.test.tsx
@@ -1,0 +1,179 @@
+// Author override + Co-Authored-By trailers (#61 D1). The backend has honored
+// CommitOptions.author_override since the commit op was written; nothing sent
+// it until now.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  CommitPanelScreen,
+  coAuthorTrailers,
+  parseIdentity,
+} from "./CommitPanel";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import type { FileStatus } from "@/lib/types";
+
+const staged = (path: string): FileStatus => ({
+  path,
+  worktree: { kind: "Unmodified" },
+  index: { kind: "Modified" },
+  additions: 1,
+  deletions: 0,
+  embedded: false,
+});
+
+function setup() {
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
+    status: [staged("a.ts")],
+    branches: [],
+    remotes: [],
+    commits: [],
+    loading: false,
+  } as never);
+  mockInvoke("get_diff", () => ({
+    path: "a.ts",
+    oldPath: null,
+    binary: false,
+    additions: 0,
+    deletions: 0,
+    hunks: [],
+  }));
+  mockInvoke("commit", () => "oid123");
+  mockInvoke("get_status", () => [staged("a.ts")]);
+  render(<CommitPanelScreen />);
+}
+
+const type = (testId: string, value: string) =>
+  fireEvent.change(screen.getByTestId(testId), { target: { value } });
+
+const commitCall = () => getInvokeCalls().find((c) => c.cmd === "commit");
+
+describe("parseIdentity", () => {
+  it("accepts Name <email> and trims", () => {
+    expect(parseIdentity("  Ada Lovelace  < ada@example.com > ")).toEqual({
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+    });
+  });
+
+  it("rejects anything else", () => {
+    for (const bad of ["", "   ", "Ada Lovelace", "ada@example.com", "<a@b.c>"]) {
+      expect(parseIdentity(bad), bad).toBeNull();
+    }
+  });
+});
+
+describe("coAuthorTrailers", () => {
+  it("splits on commas and newlines, and dedupes case-insensitively", () => {
+    expect(
+      coAuthorTrailers("Ada <ada@x.com>, Grace <grace@x.com>\nADA <ADA@X.COM>"),
+    ).toEqual([
+      "Co-Authored-By: Ada <ada@x.com>",
+      "Co-Authored-By: Grace <grace@x.com>",
+    ]);
+  });
+
+  it("drops unparseable entries instead of emitting them malformed", () => {
+    // GitHub only credits a trailer it can parse.
+    expect(coAuthorTrailers("nonsense, Ada <ada@x.com>, also nonsense")).toEqual([
+      "Co-Authored-By: Ada <ada@x.com>",
+    ]);
+    expect(coAuthorTrailers("")).toEqual([]);
+  });
+});
+
+describe("CommitPanel attribution", () => {
+  beforeEach(() => {
+    resetInvokeMock();
+    setup();
+  });
+
+  it("sends no authorOverride by default", async () => {
+    type("commit-subject", "feat: plain");
+    fireEvent.click(screen.getByTestId("commit-button"));
+
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    expect(commitCall()!.args.authorOverride).toBeNull();
+    expect(commitCall()!.args.message).toBe("feat: plain");
+  });
+
+  it("sends the parsed author override", async () => {
+    type("commit-subject", "feat: as ada");
+    type("commit-author", "Ada Lovelace <ada@example.com>");
+    fireEvent.click(screen.getByTestId("commit-button"));
+
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    expect(commitCall()!.args.authorOverride).toEqual({
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+    });
+  });
+
+  it("blocks the commit while the author is half-typed", async () => {
+    type("commit-subject", "feat: blocked");
+    type("commit-author", "Ada Lovelace");
+
+    expect(screen.getByTestId("commit-button")).toBeDisabled();
+    expect(screen.getByTestId("commit-attribution").textContent).toContain(
+      "Name <email@example.com>",
+    );
+
+    // Completing it re-enables — the gate is about validity, not presence.
+    type("commit-author", "Ada Lovelace <ada@example.com>");
+    expect(screen.getByTestId("commit-button")).toBeEnabled();
+  });
+
+  it("appends Co-Authored-By trailers after a blank line", async () => {
+    type("commit-subject", "feat: pairing");
+    type("commit-coauthors", "Ada <ada@x.com>, Grace <grace@x.com>");
+    fireEvent.click(screen.getByTestId("commit-button"));
+
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    expect(commitCall()!.args.message).toBe(
+      "feat: pairing\n\nCo-Authored-By: Ada <ada@x.com>\nCo-Authored-By: Grace <grace@x.com>",
+    );
+  });
+
+  it("keeps the trailer block separate from a body", async () => {
+    type("commit-subject", "feat: pairing");
+    type("commit-body", "Why: because.");
+    type("commit-coauthors", "Ada <ada@x.com>");
+    fireEvent.click(screen.getByTestId("commit-button"));
+
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    expect(commitCall()!.args.message).toBe(
+      "feat: pairing\n\nWhy: because.\n\nCo-Authored-By: Ada <ada@x.com>",
+    );
+  });
+
+  it("does not duplicate a trailer the body already spells out", async () => {
+    type("commit-subject", "feat: pairing");
+    type("commit-body", "Co-Authored-By: Ada <ada@x.com>");
+    type("commit-coauthors", "Ada <ada@x.com>");
+    fireEvent.click(screen.getByTestId("commit-button"));
+
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    expect(commitCall()!.args.message).toBe(
+      "feat: pairing\n\nCo-Authored-By: Ada <ada@x.com>",
+    );
+  });
+
+  it("keeps attribution after a commit — pairing spans several commits", async () => {
+    type("commit-subject", "feat: one");
+    type("commit-author", "Ada Lovelace <ada@example.com>");
+    type("commit-coauthors", "Grace <grace@x.com>");
+    fireEvent.click(screen.getByTestId("commit-button"));
+
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    await waitFor(() =>
+      expect(screen.getByTestId<HTMLInputElement>("commit-subject").value).toBe(""),
+    );
+    expect(screen.getByTestId<HTMLInputElement>("commit-author").value).toBe(
+      "Ada Lovelace <ada@example.com>",
+    );
+    expect(screen.getByTestId<HTMLInputElement>("commit-coauthors").value).toBe(
+      "Grace <grace@x.com>",
+    );
+  });
+});

--- a/src/screens/CommitPanel.test.tsx
+++ b/src/screens/CommitPanel.test.tsx
@@ -4,6 +4,13 @@ import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { CommitPanelScreen } from "./CommitPanel";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+import {
+  WithDialogs,
+  acceptDialog,
+  dialogTitle,
+  dismissDialog,
+  resetDialogs,
+} from "@/test/dialog";
 import type { FileStatus, RepoHandle } from "@/lib/types";
 
 const repo: RepoHandle = {
@@ -105,6 +112,7 @@ function selectedPaths(): string[] {
 
 describe("CommitPanel multi-file selection", () => {
   beforeEach(() => {
+    resetDialogs();
     resetStore();
     wireMocks();
   });
@@ -163,11 +171,11 @@ describe("CommitPanel multi-file selection", () => {
   });
 
   it("multi-file discard asks for confirmation and aborts when declined", async () => {
-    const confirm = vi
-      .spyOn(window, "confirm")
-      .mockReturnValueOnce(false)
-      .mockReturnValueOnce(true);
-    render(<CommitPanelScreen />);
+    render(
+      <WithDialogs>
+        <CommitPanelScreen />
+      </WithDialogs>,
+    );
 
     fireEvent.click(changeRow("a.txt"));
     fireEvent.click(changeRow("c.txt"), { shiftKey: true });
@@ -175,12 +183,19 @@ describe("CommitPanel multi-file selection", () => {
     // declined → nothing dispatched
     fireEvent.contextMenu(changeRow("b.txt"));
     fireEvent.click(await screen.findByText("Discard changes in 3 files…"));
-    expect(confirm).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(dialogTitle()).toBe("Discard changes in 3 files?"),
+    );
+    await dismissDialog();
     expect(getInvokeCalls().find((c) => c.cmd === "discard_paths")).toBeUndefined();
 
     // accepted → full path array
     fireEvent.contextMenu(changeRow("b.txt"));
     fireEvent.click(await screen.findByText("Discard changes in 3 files…"));
+    await waitFor(() =>
+      expect(dialogTitle()).toBe("Discard changes in 3 files?"),
+    );
+    await acceptDialog();
     await waitFor(() => {
       const call = getInvokeCalls().find((c) => c.cmd === "discard_paths");
       expect(call).toBeDefined();

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -7,6 +7,7 @@ import {
   PGChangeRow,
   PGCheckbox,
   PGEmpty,
+  PGFileTree,
   PGHunk,
   PGIconButton,
   PGInput,
@@ -17,10 +18,14 @@ import {
   PGTextarea,
   fileMenuItems,
   multiFileMenuItems,
+  pgConfirm,
   pgFlash,
+  pgPrompt,
   useContextMenu,
   usePaneWidth,
   type DiffLineData,
+  type PGFileTreeNode,
+  type PGStageState,
   type SideLine,
 } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
@@ -44,7 +49,20 @@ import {
   type Selection,
 } from "@/lib/selection";
 import { getDiff } from "@/lib/tauri";
-import type { CommitInfo, DiffKind, FileDiff, FileStatus } from "@/lib/types";
+import {
+  WhitespaceToggle,
+  useHunkActionsDisabledReason,
+  useIgnoreWhitespace,
+} from "@/features/diff/WhitespaceToggle";
+import { buildStatusTree, findStatusByTreeKey, treeKeyToPath } from "@/lib/tree";
+import { useTreeViewMode } from "@/lib/useTreeViewMode";
+import type {
+  AuthorOverride,
+  CommitInfo,
+  DiffKind,
+  FileDiff,
+  FileStatus,
+} from "@/lib/types";
 
 interface FileSlot {
   path: string;
@@ -68,12 +86,24 @@ export function CommitPanelScreen() {
   const addSignoff = useSettingsStore((s) => s.addSignoff);
   const setSetting = useSettingsStore((s) => s.set);
   const diffContextLines = useSettingsStore((s) => s.diffContextLines);
+  const ignoreWhitespace = useIgnoreWhitespace();
+  const hunkActionsDisabled = useHunkActionsDisabledReason();
   const [message, setMessage] = React.useState("");
   const [body, setBody] = React.useState("");
   const [amend, setAmend] = React.useState(false);
   // Sign-off toggle seeds from the persisted preference; toggling it writes back.
   const [signoff, setSignoff] = React.useState(addSignoff);
+  // Attribution (#61 D1). Blank author = repo config identity, the normal case.
+  const [authorAs, setAuthorAs] = React.useState("");
+  const [coAuthors, setCoAuthors] = React.useState("");
   const [diffMode, setDiffMode] = React.useState<"unified" | "split">("unified");
+  const [viewMode, setViewMode] = useTreeViewMode("pg-commit-view-mode", "flat");
+  const [stagedExpanded, setStagedExpanded] = React.useState<
+    Record<string, boolean>
+  >({});
+  const [unstagedExpanded, setUnstagedExpanded] = React.useState<
+    Record<string, boolean>
+  >({});
   const [sel, setSel] = React.useState<Selection>(emptySelection);
   const changesPane = usePaneWidth(320, {
     min: 220,
@@ -89,10 +119,29 @@ export function CommitPanelScreen() {
   const [diffLoading, setDiffLoading] = React.useState(false);
   const [diffError, setDiffError] = React.useState<string | null>(null);
 
+  // Folder rows (tree mode only) get the batch menu over everything beneath
+  // them — stage / unstage / discard all — same as a multi-row selection.
+  const { onContextMenu: onFolderCtx, menu: folderMenu } = useContextMenu<string>(
+    (navKey) =>
+      multiFileMenuItems(
+        splitByKeys(
+          expandSelectionKeys(navKey ? [navKey] : [], staged, unstaged),
+          staged,
+          unstaged,
+        ),
+      ),
+  );
+
   const { onContextMenu: onFileCtx, menu: fileMenu } = useContextMenu<FileSlot>(
     (f) => {
       if (f && sel.keys.length > 1 && sel.keys.includes(keyOf(f))) {
-        return multiFileMenuItems(splitByKeys(sel.keys, staged, unstaged));
+        return multiFileMenuItems(
+          splitByKeys(
+            expandSelectionKeys(sel.keys, staged, unstaged),
+            staged,
+            unstaged,
+          ),
+        );
       }
       return fileMenuItems({
         path: f?.path,
@@ -201,6 +250,20 @@ export function CommitPanelScreen() {
   );
   const selectedKeys = React.useMemo(() => new Set(sel.keys), [sel]);
 
+  // ── Tree ⇄ flat (#61 A6) ──────────────────────────────────────────────────
+  // Both sections render the same rows either way; only the nesting differs.
+  // Tree keys are "/a/b" while this screen's selection keys are "side:path",
+  // so each section converts between the two at its edges — the selection
+  // model, staging and context menus stay in one key space.
+  const stagedTree = React.useMemo(
+    () => (viewMode === "tree" ? buildStatusTree(staged.map((f) => f.status)) : []),
+    [staged, viewMode],
+  );
+  const unstagedTree = React.useMemo(
+    () => (viewMode === "tree" ? buildStatusTree(unstaged.map((f) => f.status)) : []),
+    [unstaged, viewMode],
+  );
+
   // Selection is local state keyed by side:path — reset on repo switch and
   // prune keys whose rows disappeared (refresh, stage/unstage moving files).
   React.useEffect(() => {
@@ -230,11 +293,73 @@ export function CommitPanelScreen() {
     onFileCtx(e, f);
   };
 
+  // ── Tree-mode row handlers ────────────────────────────────────────────────
+  // Tree rows arrive already translated to this screen's `side:path` (or
+  // `side:dir:path`) key space, so these mirror the flat handlers above and
+  // additionally cope with a folder key having no FileSlot behind it.
+  const slotForKey = React.useCallback(
+    (navKey: string): FileSlot | null =>
+      [...staged, ...unstaged].find((f) => keyOf(f) === navKey) ?? null,
+    [staged, unstaged],
+  );
+
+  const onNavSelect = React.useCallback(
+    (navKey: string, e?: React.MouseEvent) => {
+      setSel((s) =>
+        clickSelection(rowOrder, s, navKey, {
+          toggle: !!e && (e.metaKey || e.ctrlKey),
+          // A folder is not in rowOrder, so a range through it would collapse
+          // to a single row — treat Shift on a folder as a plain click.
+          range: !!e?.shiftKey && rowOrder.includes(navKey),
+        }),
+      );
+    },
+    [rowOrder],
+  );
+
+  const onNavContextMenu = React.useCallback(
+    (e: React.MouseEvent, navKey: string) => {
+      const slot = slotForKey(navKey);
+      if (!(sel.keys.length > 1 && sel.keys.includes(navKey))) {
+        setSel({ keys: [navKey], anchor: navKey });
+      }
+      // A folder has no single-file menu — give it the batch menu over
+      // everything beneath it, matching the repo browser.
+      if (!slot) {
+        onFolderCtx(e, navKey);
+        return;
+      }
+      onFileCtx(e, slot);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [sel, slotForKey, onFileCtx],
+  );
+
+  const onNavStageToggle = React.useCallback(
+    (navKey: string, next: boolean) => {
+      const split = splitByKeys(
+        expandSelectionKeys([navKey], staged, unstaged),
+        staged,
+        unstaged,
+      );
+      if (next) {
+        if (split.unstagedPaths.length) stage(split.unstagedPaths);
+      } else if (split.stagedPaths.length) {
+        unstage(split.stagedPaths);
+      }
+    },
+    [staged, unstaged, stage, unstage],
+  );
+
   // Checkbox on a row inside the multi-selection stages/unstages every
   // selected row on that side; on an unselected row it stays single-file.
   const togglePaths = (f: FileSlot): string[] => {
     if (sel.keys.length > 1 && sel.keys.includes(keyOf(f))) {
-      const split = splitByKeys(sel.keys, staged, unstaged);
+      const split = splitByKeys(
+        expandSelectionKeys(sel.keys, staged, unstaged),
+        staged,
+        unstaged,
+      );
       const paths = f.side === "staged" ? split.stagedPaths : split.unstagedPaths;
       if (paths.length > 0) return paths;
     }
@@ -286,7 +411,7 @@ export function CommitPanelScreen() {
     }
     let cancelled = false;
     setDiffLoading(true);
-    getDiff(repo.id, selected.path, kind, diffContextLines)
+    getDiff(repo.id, selected.path, kind, diffContextLines, ignoreWhitespace)
       .then((d) => {
         if (!cancelled) setDiff(d);
       })
@@ -299,7 +424,7 @@ export function CommitPanelScreen() {
     return () => {
       cancelled = true;
     };
-  }, [selected?.path, selected?.side, selected?.status.embedded, repo, diffContextLines]);
+  }, [selected?.path, selected?.side, selected?.status.embedded, repo, diffContextLines, ignoreWhitespace]);
 
   const headBranch = currentBranch(branches);
   const defaultRemote = remotes[0] ?? null;
@@ -341,7 +466,19 @@ export function CommitPanelScreen() {
   // Commit chords (⌘↵ / ⌘⇧↵ / ⌘⇧M). Shared with the two buttons below so the
   // chord and click paths cannot drift. Handlers decline exactly when the
   // matching button is disabled, letting the chord fall through.
-  const canCommit = (amend || staged.length > 0) && !!message.trim();
+  // A typed-but-unparseable author blocks the commit rather than being silently
+  // ignored — landing the wrong author in history costs a rewrite to fix.
+  const authorIdentity = React.useMemo(
+    () => (authorAs.trim() ? parseIdentity(authorAs) : null),
+    [authorAs],
+  );
+  const authorInvalid = authorAs.trim().length > 0 && authorIdentity === null;
+  const coAuthorCount = React.useMemo(
+    () => coAuthorTrailers(coAuthors).length,
+    [coAuthors],
+  );
+  const canCommit =
+    (amend || staged.length > 0) && !!message.trim() && !authorInvalid;
   const canCommitAndPush = canCommit && !!headBranch && !!defaultRemote;
   // Guards against a second commit firing before the first resolves and clears
   // the message/staged state — key auto-repeat (holding ⌘↵) and double-taps
@@ -351,12 +488,14 @@ export function CommitPanelScreen() {
     if (committingRef.current) return null;
     committingRef.current = true;
     try {
-      const full = buildMessage(message, body);
-      const oid = await commitAction(full, amend, signoff);
+      const full = buildMessage(message, body, coAuthorTrailers(coAuthors));
+      const oid = await commitAction(full, amend, signoff, authorIdentity);
       if (oid) {
         setMessage("");
         setBody("");
         setAmend(false);
+        // Attribution is sticky: pairing usually spans several commits, so
+        // clearing it after each one would mean retyping every time.
       }
       return oid;
     } finally {
@@ -376,7 +515,7 @@ export function CommitPanelScreen() {
       void doCommit();
       return true;
     },
-    [canCommit, message, body, amend, signoff],
+    [canCommit, message, body, amend, signoff, authorIdentity, coAuthors],
   );
   useAction(
     "commit.commitAndPush",
@@ -385,7 +524,17 @@ export function CommitPanelScreen() {
       void doCommitAndPush();
       return true;
     },
-    [canCommitAndPush, message, body, amend, signoff, headBranch, defaultRemote],
+    [
+      canCommitAndPush,
+      message,
+      body,
+      amend,
+      signoff,
+      authorIdentity,
+      coAuthors,
+      headBranch,
+      defaultRemote,
+    ],
   );
   useAction(
     "commit.toggleAmend",
@@ -429,14 +578,29 @@ export function CommitPanelScreen() {
             title="STAGED"
             badge={<PGBadge tone="success">{staged.length}</PGBadge>}
             action={
-              <PGButton
-                size="xs"
-                variant="ghost"
-                onClick={() => unstage(staged.map((f) => f.path))}
-                disabled={staged.length === 0}
-              >
-                Unstage all
-              </PGButton>
+              <div style={{ display: "flex", gap: 4, alignItems: "center" }}>
+                {/* One toggle for the whole pane — both sections follow it. */}
+                <PGIconButton
+                  icon={viewMode === "tree" ? "viewTree" : "viewList"}
+                  size="sm"
+                  title={
+                    viewMode === "tree"
+                      ? "Tree view — switch to flat list"
+                      : "Flat list — switch to tree view"
+                  }
+                  onClick={() =>
+                    setViewMode(viewMode === "tree" ? "flat" : "tree")
+                  }
+                />
+                <PGButton
+                  size="xs"
+                  variant="ghost"
+                  onClick={() => unstage(staged.map((f) => f.path))}
+                  disabled={staged.length === 0}
+                >
+                  Unstage all
+                </PGButton>
+              </div>
             }
           />
           {staged.length === 0 && (
@@ -451,20 +615,36 @@ export function CommitPanelScreen() {
               Nothing staged
             </div>
           )}
-          {staged.map((f) => (
-            <PGChangeRow
-              key={`s:${f.path}`}
-              path={f.path}
-              status={statusMark(f.status)}
-              staged
-              additions={f.status.additions}
-              deletions={f.status.deletions}
-              selected={effectiveKeys.has(keyOf(f))}
-              onClick={onRowClick(f)}
-              onContextMenu={onRowContextMenu(f)}
-              onToggle={() => unstage(togglePaths(f))}
+          {viewMode === "tree" ? (
+            <SectionTree
+              side="staged"
+              nodes={stagedTree}
+              files={staged}
+              expanded={stagedExpanded}
+              onExpandedChange={(k, next) =>
+                setStagedExpanded((e) => ({ ...e, [k]: next }))
+              }
+              selectedKeys={effectiveKeys}
+              onSelect={onNavSelect}
+              onRowContextMenu={onNavContextMenu}
+              onStageToggle={onNavStageToggle}
             />
-          ))}
+          ) : (
+            staged.map((f) => (
+              <PGChangeRow
+                key={`s:${f.path}`}
+                path={f.path}
+                status={statusMark(f.status)}
+                staged
+                additions={f.status.additions}
+                deletions={f.status.deletions}
+                selected={effectiveKeys.has(keyOf(f))}
+                onClick={onRowClick(f)}
+                onContextMenu={onRowContextMenu(f)}
+                onToggle={() => unstage(togglePaths(f))}
+              />
+            ))
+          )}
         </div>
         <FocusableScroll
           testId="changes-list"
@@ -489,7 +669,12 @@ export function CommitPanelScreen() {
                   variant="ghost"
                   disabled={unstaged.length === 0 && staged.length === 0}
                   onClick={async () => {
-                    const message = window.prompt("Stash message (optional)");
+                    const message = await pgPrompt({
+                      title: "Stash changes",
+                      body: "Saves your working tree and resets it to HEAD. Untracked files are included.",
+                      placeholder: "Message (optional)",
+                      confirmLabel: "Stash",
+                    });
                     if (message === null) return;
                     await useRepoStore.getState().stashSave({
                       message: message || null,
@@ -504,20 +689,36 @@ export function CommitPanelScreen() {
             }
             border
           />
-          {unstaged.map((f) => (
-            <PGChangeRow
-              key={`u:${f.path}`}
-              path={f.path}
-              status={statusMark(f.status)}
-              staged={false}
-              additions={f.status.additions}
-              deletions={f.status.deletions}
-              selected={effectiveKeys.has(keyOf(f))}
-              onClick={onRowClick(f)}
-              onContextMenu={onRowContextMenu(f)}
-              onToggle={() => stageToggled(f)}
+          {viewMode === "tree" ? (
+            <SectionTree
+              side="unstaged"
+              nodes={unstagedTree}
+              files={unstaged}
+              expanded={unstagedExpanded}
+              onExpandedChange={(k, next) =>
+                setUnstagedExpanded((e) => ({ ...e, [k]: next }))
+              }
+              selectedKeys={effectiveKeys}
+              onSelect={onNavSelect}
+              onRowContextMenu={onNavContextMenu}
+              onStageToggle={onNavStageToggle}
             />
-          ))}
+          ) : (
+            unstaged.map((f) => (
+              <PGChangeRow
+                key={`u:${f.path}`}
+                path={f.path}
+                status={statusMark(f.status)}
+                staged={false}
+                additions={f.status.additions}
+                deletions={f.status.deletions}
+                selected={effectiveKeys.has(keyOf(f))}
+                onClick={onRowClick(f)}
+                onContextMenu={onRowContextMenu(f)}
+                onToggle={() => stageToggled(f)}
+              />
+            ))
+          )}
         </FocusableScroll>
       </PGPane>
       <PGResizeHandle onDrag={changesPane.resize} />
@@ -548,6 +749,7 @@ export function CommitPanelScreen() {
           {selected && <PGStatusMark kind={statusMark(selected.status)} />}
           <span>{selected?.path ?? "no file selected"}</span>
           <div style={{ flex: 1 }} />
+          <WhitespaceToggle />
           <PGButtonGroup
             value={diffMode}
             onChange={(v) => setDiffMode(v as typeof diffMode)}
@@ -614,6 +816,7 @@ export function CommitPanelScreen() {
                 lines={h.lines.map(toUiLine)}
                 expanded={true}
                 staged={selected?.side === "staged"}
+                actionsDisabledReason={hunkActionsDisabled}
                 onStage={() => {
                   if (!selected) return;
                   if (selected.side === "staged") {
@@ -622,9 +825,16 @@ export function CommitPanelScreen() {
                     useRepoStore.getState().stageHunk(selected.path, i);
                   }
                 }}
-                onDiscard={() => {
+                onDiscard={async () => {
                   if (!selected) return;
-                  if (window.confirm("Discard this hunk? The change will be lost.")) {
+                  if (
+                    await pgConfirm({
+                      title: "Discard this hunk?",
+                      body: `The change to ${selected.path} will be lost.`,
+                      danger: true,
+                      confirmLabel: "Discard hunk",
+                    })
+                  ) {
                     useRepoStore.getState().discardHunk(selected.path, i);
                   }
                 }}
@@ -730,6 +940,7 @@ export function CommitPanelScreen() {
               onChange={setBody}
               rows={8}
               mono
+              data-testid="commit-body"
               data-pg-focus-target=""
               className="focusable"
               style={{ flex: 1 }}
@@ -761,18 +972,54 @@ export function CommitPanelScreen() {
             />
           </div>
 
+          {/* Attribution (#61 D1). Both blank is the normal case. */}
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            <PGInput
+              value={authorAs}
+              onChange={setAuthorAs}
+              placeholder="Author — Name <email>, blank for git config"
+              icon="user"
+              size="sm"
+              mono
+              error={authorInvalid}
+              title="Commit as another author. The committer stays your git config identity, matching `git commit --author`."
+              data-testid="commit-author"
+            />
+            <PGInput
+              value={coAuthors}
+              onChange={setCoAuthors}
+              placeholder="Co-authors — Name <email>, comma-separated"
+              icon="user"
+              size="sm"
+              mono
+              title="Appended as Co-Authored-By trailers."
+              data-testid="commit-coauthors"
+            />
+          </div>
+
           <div
             style={{
               display: "flex",
               gap: 4,
               alignItems: "center",
               fontSize: "var(--fs-11)",
-              color: "var(--fg-2)",
+              color: authorInvalid ? "var(--git-removed)" : "var(--fg-2)",
               fontFamily: "var(--font-mono)",
             }}
+            data-testid="commit-attribution"
           >
-            <PGAvatar name="you" size={14} />
-            (signature will come from git config)
+            <PGAvatar name={authorIdentity?.name ?? "you"} size={14} />
+            {authorInvalid
+              ? "Author must look like: Name <email@example.com>"
+              : authorIdentity
+                ? `${authorIdentity.name} <${authorIdentity.email}> — you stay the committer`
+                : "(signature will come from git config)"}
+            {coAuthorCount > 0 && !authorInvalid && (
+              <span style={{ color: "var(--fg-3)" }}>
+                {" "}
+                +{coAuthorCount} co-author{coAuthorCount !== 1 ? "s" : ""}
+              </span>
+            )}
           </div>
           <div
             style={{
@@ -820,12 +1067,130 @@ export function CommitPanelScreen() {
         </div>
       </PGPane>
       {fileMenu}
+      {folderMenu}
     </div>
   );
 }
 
 function keyOf(f: FileSlot): string {
   return `${f.side}:${f.path}`;
+}
+
+/**
+ * Selection key for a folder row in tree mode. The `dir:` marker keeps folder
+ * keys out of the file key space (`side:path`), so nothing can mistake a
+ * directory for a file with an unlucky name.
+ */
+function dirKeyOf(side: FileSlot["side"], dirPath: string): string {
+  return `${side}:dir:${dirPath}`;
+}
+
+/**
+ * Replace any folder key with the keys of every file beneath it, so folder
+ * rows feed the same path-based ops (stage / unstage / discard / copy) as a
+ * multi-row selection. File keys pass through untouched, deduped.
+ */
+function expandSelectionKeys(
+  keys: string[],
+  staged: FileSlot[],
+  unstaged: FileSlot[],
+): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const push = (k: string) => {
+    if (seen.has(k)) return;
+    seen.add(k);
+    out.push(k);
+  };
+  for (const key of keys) {
+    const m = /^(staged|unstaged):dir:(.*)$/.exec(key);
+    if (!m) {
+      push(key);
+      continue;
+    }
+    const side = m[1] as FileSlot["side"];
+    const prefix = `${m[2]}/`;
+    for (const f of side === "staged" ? staged : unstaged) {
+      if (f.path.startsWith(prefix)) push(keyOf(f));
+    }
+  }
+  return out;
+}
+
+/**
+ * One change section (STAGED or CHANGES) rendered as a nested tree.
+ *
+ * Translates at its edges only: PGFileTree speaks "/a/b" row keys, this screen
+ * speaks `side:path`. Every file row therefore carries the exact key its flat
+ * PGChangeRow twin would, so selection, staging and the context menu behave
+ * identically in both view modes.
+ */
+function SectionTree({
+  side,
+  nodes,
+  files,
+  expanded,
+  onExpandedChange,
+  selectedKeys,
+  onSelect,
+  onRowContextMenu,
+  onStageToggle,
+}: {
+  side: FileSlot["side"];
+  nodes: PGFileTreeNode[];
+  files: FileSlot[];
+  expanded: Record<string, boolean>;
+  onExpandedChange: (key: string, next: boolean) => void;
+  selectedKeys: ReadonlySet<string>;
+  onSelect: (navKey: string, e?: React.MouseEvent) => void;
+  onRowContextMenu: (e: React.MouseEvent, navKey: string) => void;
+  onStageToggle: (navKey: string, next: boolean) => void;
+}) {
+  const navKeyFor = React.useCallback(
+    (treeKey: string): string => {
+      const slot = findStatusByTreeKey(treeKey, files);
+      return slot ? keyOf(slot) : dirKeyOf(side, treeKeyToPath(treeKey));
+    },
+    [files, side],
+  );
+
+  // Every row in a section shares that section's staged-ness: the STAGED list
+  // only holds staged work, CHANGES only unstaged. Embedded repos are the one
+  // exception — they can't be staged at all, so they get no checkbox.
+  const stageState = React.useCallback(
+    (treeKey: string): PGStageState | undefined => {
+      const slot = findStatusByTreeKey(treeKey, files);
+      if (slot?.status.embedded) return undefined;
+      return side === "staged" ? "all" : "none";
+    },
+    [files, side],
+  );
+
+  return (
+    <PGFileTree
+      nodes={nodes}
+      expanded={expanded}
+      onToggle={onExpandedChange}
+      selectedKeys={
+        new Set(
+          [...selectedKeys]
+            .filter((k) => k.startsWith(`${side}:`))
+            .map((k) =>
+              k.startsWith(`${side}:dir:`)
+                ? `/${k.slice(`${side}:dir:`.length)}`
+                : `/${k.slice(`${side}:`.length)}`,
+            )
+            // An embedded repo's status path keeps a trailing slash the row key
+            // has already lost.
+            .map((k) => k.replace(/\/+$/, "")),
+        )
+      }
+      onSelect={(treeKey, _node, e) => onSelect(navKeyFor(treeKey), e)}
+      onRowContextMenu={(e, treeKey) => onRowContextMenu(e, navKeyFor(treeKey))}
+      stageState={stageState}
+      onStageToggle={(treeKey, _node, next) => onStageToggle(navKeyFor(treeKey), next)}
+    />
+  );
 }
 
 /**
@@ -864,9 +1229,48 @@ function splitByKeys(
   };
 }
 
-function buildMessage(subject: string, body: string): string {
+/**
+ * Parse a `Name <email>` identity. Returns null for anything else, which is
+ * what gates the commit button — a half-typed author is a mistake worth
+ * catching before it lands in history, where fixing it means a rewrite.
+ */
+export function parseIdentity(raw: string): AuthorOverride | null {
+  const m = /^\s*(\S.*?)\s*<\s*([^<>\s]+@[^<>\s]+)\s*>\s*$/.exec(raw);
+  if (!m) return null;
+  return { name: m[1], email: m[2] };
+}
+
+/**
+ * `Co-Authored-By:` trailers for a comma/newline-separated list of identities.
+ * Unparseable entries are dropped rather than emitted malformed — GitHub only
+ * credits a trailer it can parse.
+ */
+export function coAuthorTrailers(raw: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const chunk of raw.split(/[\n,]/)) {
+    const id = parseIdentity(chunk);
+    if (!id) continue;
+    const line = `Co-Authored-By: ${id.name} <${id.email}>`;
+    const key = line.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(line);
+  }
+  return out;
+}
+
+function buildMessage(subject: string, body: string, coAuthors: string[] = []): string {
   const parts: string[] = [subject];
-  if (body.trim()) parts.push("", body.trim());
+  const trimmedBody = body.trim();
+  if (trimmedBody) parts.push("", trimmedBody);
+  // Trailers go in their own block after one blank line — that separation is
+  // what `git interpret-trailers` (and GitHub) key on. Skip any the body
+  // already spells out, so hand-written and generated trailers can't double up.
+  const fresh = coAuthors.filter(
+    (t) => !trimmedBody.toLowerCase().includes(t.toLowerCase()),
+  );
+  if (fresh.length) parts.push("", fresh.join("\n"));
   return parts.join("\n");
 }
 

--- a/src/screens/CommitPanel.whitespace.test.tsx
+++ b/src/screens/CommitPanel.whitespace.test.tsx
@@ -1,0 +1,105 @@
+// Whitespace-ignore toggle (#61 D2). The interesting part is not the flag
+// reaching the backend — it's that hunk staging is DISABLED while it's on.
+// libgit2's IGNORE_WHITESPACE rewrites whitespace-only changes into context
+// lines, so the hunks on screen neither line up with the indices stage_hunk
+// expects nor describe a patch that would apply (see the backend test
+// src-tauri/tests/whitespace_diff.rs). That desync is what got the first
+// attempt at this setting removed.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { CommitPanelScreen } from "./CommitPanel";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import type { FileStatus } from "@/lib/types";
+
+const unstaged = (path: string): FileStatus => ({
+  path,
+  worktree: { kind: "Modified" },
+  index: { kind: "Unmodified" },
+  additions: 1,
+  deletions: 1,
+  embedded: false,
+});
+
+const diffWithOneHunk = (path: string) => ({
+  path,
+  oldPath: null,
+  binary: false,
+  additions: 1,
+  deletions: 1,
+  hunks: [
+    {
+      header: "@@ -1,2 +1,2 @@",
+      oldStart: 1,
+      oldLines: 2,
+      newStart: 1,
+      newLines: 2,
+      lines: [
+        { kind: { kind: "Deletion" }, oldLineno: 1, newLineno: null, content: "a\n" },
+        { kind: { kind: "Addition" }, oldLineno: null, newLineno: 1, content: "b\n" },
+      ],
+    },
+  ],
+});
+
+const lastDiffCall = () =>
+  [...getInvokeCalls()].reverse().find((c) => c.cmd === "get_diff");
+
+describe("CommitPanel whitespace-ignore (#61 D2)", () => {
+  beforeEach(() => {
+    resetInvokeMock();
+    useSettingsStore.setState({ ignoreWhitespaceInDiff: false });
+    useRepoStore.setState({
+      current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
+      status: [unstaged("a.ts")],
+      branches: [],
+      remotes: [],
+      commits: [],
+      loading: false,
+    } as never);
+    mockInvoke("get_diff", (args) => diffWithOneHunk(args.path as string));
+    render(<CommitPanelScreen />);
+  });
+
+  it("sends ignoreWhitespace=false by default and allows hunk staging", async () => {
+    await waitFor(() => expect(lastDiffCall()).toBeDefined());
+    expect(lastDiffCall()!.args.ignoreWhitespace).toBe(false);
+    expect(await screen.findByTestId("hunk-stage")).toBeEnabled();
+  });
+
+  it("re-fetches with the flag and disables hunk staging when toggled on", async () => {
+    await waitFor(() => expect(lastDiffCall()).toBeDefined());
+
+    fireEvent.click(screen.getByTitle("Ignore whitespace-only changes"));
+
+    await waitFor(() =>
+      expect(lastDiffCall()!.args.ignoreWhitespace).toBe(true),
+    );
+
+    const stage = await screen.findByTestId("hunk-stage");
+    expect(stage).toBeDisabled();
+    expect(stage.getAttribute("title")).toContain("not the ones git would apply");
+  });
+
+  it("re-enables hunk staging when toggled back off", async () => {
+    await waitFor(() => expect(lastDiffCall()).toBeDefined());
+
+    fireEvent.click(screen.getByTitle("Ignore whitespace-only changes"));
+    await waitFor(async () =>
+      expect(await screen.findByTestId("hunk-stage")).toBeDisabled(),
+    );
+
+    fireEvent.click(
+      screen.getByTitle(
+        "Ignoring whitespace — click to show whitespace-only changes (re-enables hunk staging)",
+      ),
+    );
+
+    await waitFor(() =>
+      expect(lastDiffCall()!.args.ignoreWhitespace).toBe(false),
+    );
+    expect(await screen.findByTestId("hunk-stage")).toBeEnabled();
+  });
+});

--- a/src/screens/Conflict.tsx
+++ b/src/screens/Conflict.tsx
@@ -10,6 +10,7 @@ import {
   PGSectionHeader,
   PGSpinner,
   conflictMenuItems,
+  pgConfirm,
   useContextMenu,
   usePaneWidth,
 } from "@/design";
@@ -167,11 +168,14 @@ function ConflictHeader({
         icon="x"
         disabled={repoState === "Clean"}
         data-testid="conflict-abort"
-        onClick={() => {
+        onClick={async () => {
           if (
-            window.confirm(
-              "Abort the current operation? The working tree will be reset to HEAD.",
-            )
+            await pgConfirm({
+              title: "Abort the current operation?",
+              body: "The working tree is reset to HEAD and any conflict resolutions are discarded.",
+              danger: true,
+              confirmLabel: "Abort",
+            })
           )
             useRepoStore.getState().abortOperation();
         }}

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -19,6 +19,10 @@ import {
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import {
+  WhitespaceToggle,
+  useIgnoreWhitespace,
+} from "@/features/diff/WhitespaceToggle";
 import { statusMark } from "@/lib/derive";
 import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
 import { getDiff } from "@/lib/tauri";
@@ -29,6 +33,7 @@ export function DiffViewerScreen() {
   const repo = useRepoStore((s) => s.current);
   const status = useRepoStore((s) => s.status);
   const diffContextLines = useSettingsStore((s) => s.diffContextLines);
+  const ignoreWhitespace = useIgnoreWhitespace();
   const [mode, setMode] = React.useState<"unified" | "split">("unified");
   const [wrap, setWrap] = React.useState(false);
   const [filter, setFilter] = React.useState("");
@@ -88,7 +93,7 @@ export function DiffViewerScreen() {
     }
     let cancelled = false;
     setDiffLoading(true);
-    getDiff(repo.id, current.path, "WorktreeToHead", diffContextLines)
+    getDiff(repo.id, current.path, "WorktreeToHead", diffContextLines, ignoreWhitespace)
       .then((d) => {
         if (!cancelled) setDiff(d);
       })
@@ -105,7 +110,7 @@ export function DiffViewerScreen() {
     return () => {
       cancelled = true;
     };
-  }, [current?.path, current?.embedded, repo, diffContextLines]);
+  }, [current?.path, current?.embedded, repo, diffContextLines, ignoreWhitespace]);
 
   const findFiltered = React.useMemo<FileDiff | null>(() => {
     if (!diff || !findQuery.trim()) return diff;
@@ -194,6 +199,7 @@ export function DiffViewerScreen() {
         }
         right={
           <>
+            <WhitespaceToggle />
             <PGButtonGroup
               value={mode}
               onChange={(v) => setMode(v as typeof mode)}

--- a/src/screens/History.diff.test.tsx
+++ b/src/screens/History.diff.test.tsx
@@ -81,7 +81,11 @@ describe("History inline commit diff", () => {
     await waitFor(() => {
       expect(screen.getByText(/@@ -0,0 \+1,2 @@/)).toBeInTheDocument();
     });
-    expect(screen.getByText("src/foo.ts")).toBeInTheDocument();
+    // Rows render the basename and the directory in separate spans, so assert
+    // on the row's stable `data-path` rather than a single joined text node.
+    expect(document.querySelector('[data-path="src/foo.ts"]')).not.toBeNull();
+    expect(document.querySelector('[data-path="README.md"]')).not.toBeNull();
+    expect(screen.getByText("foo.ts")).toBeInTheDocument();
     expect(screen.getByText("README.md")).toBeInTheDocument();
 
     // Diff was fetched for the top (default-selected) commit.

--- a/src/screens/History.multiselect.test.tsx
+++ b/src/screens/History.multiselect.test.tsx
@@ -3,11 +3,18 @@
 // set, squash gating).
 
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { HistoryScreen } from "./History";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useKeymapStore, useFocusStore } from "@/features/keymap";
+import {
+  WithDialogs,
+  acceptDialog,
+  dialogTitle,
+  dismissDialog,
+  resetDialogs,
+} from "@/test/dialog";
 import type { CommitInfo } from "@/lib/types";
 
 // Newest-first linear log: a → b → c → d(root).
@@ -61,6 +68,7 @@ const isSelected = (text: string) => rowFor(text).hasAttribute("data-selected");
 
 describe("History multi-select", () => {
   beforeEach(() => {
+    resetDialogs();
     useRepoStore.setState({
       current: { id: "r1", path: "/repo", head: "main" },
       commits: [
@@ -135,19 +143,50 @@ describe("History multi-select", () => {
     });
   });
 
-  it("Cherry-pick N confirms then calls cherryPickMany oldest→newest", () => {
+  it("Cherry-pick N confirms then calls cherryPickMany oldest→newest", async () => {
     const picked: string[][] = [];
     useRepoStore.setState({
       cherryPickMany: async (oids: string[]) => {
         picked.push(oids);
       },
     } as never);
-    vi.spyOn(window, "confirm").mockReturnValue(true);
-    render(<HistoryScreen />);
+    render(
+      <WithDialogs>
+        <HistoryScreen />
+      </WithDialogs>,
+    );
     fireEvent.click(rowFor("commit A"));
     fireEvent.click(rowFor("commit B"), { shiftKey: true }); // A,B
     fireEvent.click(screen.getByTestId("multi-cherry-pick"));
+
+    await waitFor(() =>
+      expect(dialogTitle()).toBe(
+        "Cherry-pick 2 commits onto the current branch?",
+      ),
+    );
+    await acceptDialog();
     expect(picked).toEqual([[B, A]]); // oldest first
+  });
+
+  it("Cherry-pick N does nothing when the confirmation is dismissed", async () => {
+    const picked: string[][] = [];
+    useRepoStore.setState({
+      cherryPickMany: async (oids: string[]) => {
+        picked.push(oids);
+      },
+    } as never);
+    render(
+      <WithDialogs>
+        <HistoryScreen />
+      </WithDialogs>,
+    );
+    fireEvent.click(rowFor("commit A"));
+    fireEvent.click(rowFor("commit B"), { shiftKey: true });
+    fireEvent.click(screen.getByTestId("multi-cherry-pick"));
+
+    await waitFor(() => expect(dialogTitle()).not.toBeNull());
+    await dismissDialog();
+    expect(picked).toEqual([]);
   });
 
   it("Squash is disabled for a non-contiguous selection", () => {

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -14,7 +14,9 @@ import {
   PGToolbar,
   commitMenuItems,
   commitMultiMenuItems,
+  pgConfirm,
   pgFlash,
+  pgPrompt,
   useContextMenu,
   usePaneWidth,
 } from "@/design";
@@ -26,6 +28,7 @@ import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { CommitDiffPanel } from "@/features/diff/CommitDiffPanel";
+import { useIgnoreWhitespace } from "@/features/diff/WhitespaceToggle";
 import { PGPane, FocusableScroll, usePaneList } from "@/features/keymap";
 import { diffCommit } from "@/lib/tauri";
 import { appErrorMessage } from "@/lib/errors";
@@ -106,6 +109,7 @@ export function HistoryScreen() {
   });
   const repo = useRepoStore((s) => s.current);
   const diffContextLines = useSettingsStore((s) => s.diffContextLines);
+  const ignoreWhitespace = useIgnoreWhitespace();
   // Below-layout panel height reuses the clamped/persisted pane-size hook.
   const detailHeight = usePaneWidth(320, {
     min: 140,
@@ -246,7 +250,7 @@ export function HistoryScreen() {
     setInlineLoading(true);
     setInlineError(null);
     const handle = window.setTimeout(() => {
-      diffCommit(repo.id, inlineOid, diffContextLines)
+      diffCommit(repo.id, inlineOid, diffContextLines, ignoreWhitespace)
         .then((d) => { if (!cancelled) setInlineDiffs(d); })
         .catch((e) => {
           if (!cancelled) { setInlineDiffs([]); setInlineError(appErrorMessage(e)); }
@@ -254,7 +258,7 @@ export function HistoryScreen() {
         .finally(() => { if (!cancelled) setInlineLoading(false); });
     }, INLINE_DIFF_DEBOUNCE_MS);
     return () => { cancelled = true; window.clearTimeout(handle); };
-  }, [repo?.id, inlineOid, diffContextLines]);
+  }, [repo?.id, inlineOid, diffContextLines, ignoreWhitespace]);
 
   const exportVisible = React.useCallback(() => {
     const lines = visible.map(
@@ -597,15 +601,24 @@ function MultiCommitDetail({
         ? "oldest commit is the root"
         : null;
 
-  const cherryPickSet = () => {
+  const cherryPickSet = async () => {
     if (
-      window.confirm(`Cherry-pick ${n} commits onto the current branch (oldest first)?`)
+      await pgConfirm({
+        title: `Cherry-pick ${n} commits onto the current branch?`,
+        body: "They are applied oldest first.",
+        confirmLabel: "Cherry-pick",
+      })
     )
       useRepoStore.getState().cherryPickMany(plan.oids);
   };
-  const squashSet = () => {
+  const squashSet = async () => {
     if (squashBlock || !plan.baseOid) return;
-    const msg = window.prompt("New commit message for the squashed commit");
+    const msg = await pgPrompt({
+      title: `Squash ${n} commits into one`,
+      body: "Message for the combined commit.",
+      confirmLabel: "Squash",
+      requireValue: true,
+    });
     if (!msg) return;
     const rebasePlan = buildRebasePlan(commits, plan.baseOid, {
       kind: "squash-range",
@@ -716,27 +729,59 @@ function MultiCommitDetail({
 
 function CommitActionRow({ commit }: { commit: CommitInfo }) {
   const store = useRepoStore;
-  const branchHere = React.useCallback(() => {
-    const name = window.prompt(`Create branch at ${commit.shortOid}`);
+  const branchHere = React.useCallback(async () => {
+    const name = await pgPrompt({
+      title: "Create branch here",
+      body: `Branching at ${commit.shortOid}.`,
+      placeholder: "feat/my-branch",
+      confirmLabel: "Create",
+      requireValue: true,
+      mono: true,
+    });
     if (!name) return;
     store.getState().createBranch(name, commit.oid);
   }, [commit, store]);
-  const tagHere = React.useCallback(() => {
-    const name = window.prompt(`Tag name for ${commit.shortOid}`);
+  const tagHere = React.useCallback(async () => {
+    const name = await pgPrompt({
+      title: "Create tag here",
+      body: `Tagging ${commit.shortOid}.`,
+      placeholder: "v1.0.0",
+      confirmLabel: "Next",
+      requireValue: true,
+      mono: true,
+    });
     if (!name) return;
-    const annotation = window.prompt("Annotation (optional, leave blank for lightweight)");
+    // An empty annotation is meaningful — it makes a lightweight tag — so a
+    // blank answer must still create the tag; only a dismissal aborts.
+    const annotation = await pgPrompt({
+      title: `Annotation for ${name}`,
+      body: "Leave blank for a lightweight tag.",
+      confirmLabel: "Create tag",
+    });
+    if (annotation === null) return;
     store.getState().createTag(name, {
       oid: commit.oid,
       annotation: annotation ? annotation : null,
     });
   }, [commit, store]);
-  const cherryPick = React.useCallback(() => {
-    if (!window.confirm(`Cherry-pick ${commit.shortOid} onto current branch?`))
+  const cherryPick = React.useCallback(async () => {
+    if (
+      !(await pgConfirm({
+        title: `Cherry-pick ${commit.shortOid} onto the current branch?`,
+        confirmLabel: "Cherry-pick",
+      }))
+    )
       return;
     store.getState().cherryPick(commit.oid);
   }, [commit, store]);
-  const revert = React.useCallback(() => {
-    if (!window.confirm(`Revert ${commit.shortOid}? A new commit will be created.`))
+  const revert = React.useCallback(async () => {
+    if (
+      !(await pgConfirm({
+        title: `Revert ${commit.shortOid}?`,
+        body: "A new commit undoing its changes is created; history is not rewritten.",
+        confirmLabel: "Revert",
+      }))
+    )
       return;
     store.getState().revert(commit.oid);
   }, [commit, store]);

--- a/src/screens/Remote.tsx
+++ b/src/screens/Remote.tsx
@@ -6,6 +6,7 @@ import {
   PGRemoteRow,
   PGSectionHeader,
   pgFlash,
+  pgPrompt,
   remoteMenuItems,
   useContextMenu,
 } from "@/design";
@@ -49,10 +50,23 @@ export function RemoteScreen() {
     store.push(defaultRemote, defaultBranch);
   };
 
-  const handleAddRemote = () => {
-    const name = window.prompt("Remote name (e.g. origin)");
+  const handleAddRemote = async () => {
+    const name = await pgPrompt({
+      title: "Add remote",
+      body: "Short name you'll refer to it by.",
+      initialValue: "origin",
+      confirmLabel: "Next",
+      requireValue: true,
+      mono: true,
+    });
     if (!name) return;
-    const url = window.prompt("Remote URL");
+    const url = await pgPrompt({
+      title: `URL for "${name}"`,
+      placeholder: "git@github.com:owner/repo.git",
+      confirmLabel: "Add remote",
+      requireValue: true,
+      mono: true,
+    });
     if (!url) return;
     store.addRemote(name, url);
   };
@@ -214,7 +228,7 @@ export function RemoteScreen() {
                 size="xs"
                 variant="ghost"
                 icon="plus"
-                onClick={handleAddRemote}
+                onClick={() => void handleAddRemote()}
               >
                 Add remote
               </PGButton>

--- a/src/screens/RepoBrowser.keyboard.test.tsx
+++ b/src/screens/RepoBrowser.keyboard.test.tsx
@@ -1,0 +1,209 @@
+// Keyboard behavior of the RepoBrowser file tree (#61 A7). The tree used to
+// have a local onKeyDown that only understood bare arrows; it now routes
+// through the keymap's usePaneList, so it gets Home/End, Shift+Arrow ranges,
+// Space-to-stage and type-to-jump speed-search like every flat pane.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, render, waitFor } from "@testing-library/react";
+import { RepoBrowserScreen } from "./RepoBrowser";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import {
+  useKeymapStore,
+  useFocusStore,
+  useSpeedSearchStore,
+} from "@/features/keymap";
+import { mockInvoke } from "@/test/invokeMock";
+import type { FileStatus } from "@/lib/types";
+
+const modified = (path: string): FileStatus => ({
+  path,
+  worktree: { kind: "Modified" },
+  index: { kind: "Unmodified" },
+  additions: 0,
+  deletions: 0,
+  embedded: false,
+});
+
+const key = (k: string, over: Partial<KeyboardEvent> = {}) =>
+  ({
+    key: k,
+    code: "",
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    preventDefault() {},
+    target: document.body,
+    ...over,
+  }) as unknown as KeyboardEvent;
+
+function press(k: string, over: Partial<KeyboardEvent> = {}): boolean {
+  let handled = false;
+  act(() => {
+    handled = useKeymapStore.getState().dispatch(key(k, over));
+  });
+  return handled;
+}
+
+function row(path: string): HTMLElement {
+  const el = document.querySelector(`[data-pg-row][data-path="${path}"]`);
+  if (!el) throw new Error(`no tree row for ${path}`);
+  return el as HTMLElement;
+}
+
+const isSelected = (path: string) => row(path).hasAttribute("data-selected");
+const exists = (path: string) =>
+  !!document.querySelector(`[data-pg-row][data-path="${path}"]`);
+
+const stageCalls: string[][] = [];
+
+describe("RepoBrowser tree keyboard navigation (#61 A7)", () => {
+  beforeEach(() => {
+    stageCalls.length = 0;
+    mockInvoke("get_diff", (args) => ({
+      path: args.path as string,
+      oldPath: null,
+      binary: false,
+      additions: 0,
+      deletions: 0,
+      hunks: [],
+    }));
+    useRepoStore.setState({
+      current: { id: "r1", path: "/repo", head: "main" },
+      // Tree: /src (folder) → a.ts, b.ts ; /z.txt at top level.
+      status: [modified("src/a.ts"), modified("src/b.ts"), modified("z.txt")],
+      allFiles: [],
+      branches: [],
+      tags: [],
+      stashes: [],
+      remotes: [],
+      commits: [],
+      loading: false,
+      error: null,
+      repoState: "Clean",
+      rebaseStatus: { inProgress: false, nextIndex: 0, total: 0, pauseReason: null },
+      activity: {},
+      stage: async (paths: string[]) => {
+        stageCalls.push(paths);
+      },
+      unstage: async () => {},
+    } as never);
+    useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+    useKeymapStore.getState().setPreset("rider");
+    useSpeedSearchStore.setState({ queries: {} });
+    useFocusStore.setState({
+      focused: null,
+      panes: new Map(),
+      order: [],
+      barId: null,
+      pendingContentFocus: false,
+    });
+  });
+
+  async function mount() {
+    render(<RepoBrowserScreen />);
+    await waitFor(() => row("src"));
+    useFocusStore.setState({ focused: "repo.tree" });
+  }
+
+  it("arrows walk the visible rows, folders included", async () => {
+    await mount();
+
+    // Nothing is selected until the user acts, and the first ↓ must land on
+    // row 0 rather than skipping it.
+    expect(isSelected("src")).toBe(false);
+
+    // The first top-level folder is expanded by default: src, src/a.ts,
+    // src/b.ts, z.txt.
+    press("ArrowDown");
+    expect(isSelected("src")).toBe(true);
+    press("ArrowDown");
+    expect(isSelected("src/a.ts")).toBe(true);
+    press("ArrowDown");
+    expect(isSelected("src/b.ts")).toBe(true);
+    press("ArrowDown");
+    expect(isSelected("z.txt")).toBe(true);
+
+    // End of list clamps rather than wrapping.
+    press("ArrowDown");
+    expect(isSelected("z.txt")).toBe(true);
+  });
+
+  it("Home and End jump to the ends — chords the old handler ignored", async () => {
+    await mount();
+
+    press("End");
+    expect(isSelected("z.txt")).toBe(true);
+    press("Home");
+    expect(isSelected("src")).toBe(true);
+  });
+
+  it("left collapses a folder, right re-expands it", async () => {
+    await mount();
+    expect(exists("src/a.ts")).toBe(true);
+    press("ArrowDown"); // src
+
+    press("ArrowLeft");
+    expect(exists("src/a.ts")).toBe(false);
+    expect(isSelected("src")).toBe(true);
+
+    press("ArrowRight");
+    expect(exists("src/a.ts")).toBe(true);
+  });
+
+  it("left from a leaf jumps to its parent folder", async () => {
+    await mount();
+    press("ArrowDown"); // src
+    press("ArrowDown"); // src/a.ts
+    expect(isSelected("src/a.ts")).toBe(true);
+
+    press("ArrowLeft");
+    expect(isSelected("src")).toBe(true);
+    // The folder is still open — moving to the parent must not also collapse.
+    expect(exists("src/a.ts")).toBe(true);
+  });
+
+  it("Shift+Arrow extends a range and keeps growing it", async () => {
+    await mount();
+    press("ArrowDown"); // src
+    press("ArrowDown"); // anchor on src/a.ts
+
+    press("ArrowDown", { shiftKey: true });
+    expect(isSelected("src/a.ts")).toBe(true);
+    expect(isSelected("src/b.ts")).toBe(true);
+
+    // Repeated extends move the far end, not back to the anchor.
+    press("ArrowDown", { shiftKey: true });
+    expect(isSelected("src/a.ts")).toBe(true);
+    expect(isSelected("src/b.ts")).toBe(true);
+    expect(isSelected("z.txt")).toBe(true);
+  });
+
+  it("Space stages the selected file", async () => {
+    await mount();
+    press("ArrowDown"); // src
+    press("ArrowDown"); // src/a.ts
+
+    press(" ");
+    await waitFor(() => expect(stageCalls).toEqual([["src/a.ts"]]));
+  });
+
+  it("Space on a folder stages everything beneath it", async () => {
+    await mount();
+    press("ArrowDown"); // src
+    expect(isSelected("src")).toBe(true);
+
+    press(" ");
+    await waitFor(() =>
+      expect(stageCalls).toEqual([["src/a.ts", "src/b.ts"]]),
+    );
+  });
+
+  it("type-to-jump speed-search moves the selection to a matching path", async () => {
+    await mount();
+
+    // A bare printable key falls through to the pane's speed-search.
+    press("z", { code: "KeyZ" });
+    await waitFor(() => expect(isSelected("z.txt")).toBe(true));
+  });
+});

--- a/src/screens/RepoBrowser.staging.test.tsx
+++ b/src/screens/RepoBrowser.staging.test.tsx
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
+
+import { RepoBrowserScreen } from "./RepoBrowser";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { mockInvoke } from "@/test/invokeMock";
+import type { FileStatus, RepoHandle } from "@/lib/types";
+
+const repo: RepoHandle = {
+  id: "repo-1",
+  path: "/tmp/fake-repo",
+  head: "refs/heads/main",
+};
+
+function file(path: string, over: Partial<FileStatus> = {}): FileStatus {
+  return {
+    path,
+    worktree: { kind: "Unmodified" },
+    index: { kind: "Unmodified" },
+    additions: 0,
+    deletions: 0,
+    embedded: false,
+    ...over,
+  };
+}
+
+/** Unstaged change. */
+const modified = (p: string) => file(p, { worktree: { kind: "Modified" } });
+/** Staged-only change: index modified, worktree clean. */
+const staged = (p: string) => file(p, { index: { kind: "Modified" } });
+/** Both sides dirty — a single file that is itself "partial". */
+const bothSides = (p: string) =>
+  file(p, { worktree: { kind: "Modified" }, index: { kind: "Modified" } });
+/** libgit2 reports an embedded repo as one entry with a trailing slash. */
+const embedded = (p: string) =>
+  file(p, { worktree: { kind: "Untracked" }, embedded: true });
+
+const stageCalls: string[][] = [];
+const unstageCalls: string[][] = [];
+
+function resetStore(over: Record<string, unknown> = {}) {
+  useRepoStore.setState({
+    current: repo,
+    status: [modified("src/a.txt"), staged("src/b.txt"), embedded("vendor/lib/")],
+    allFiles: [],
+    branches: [],
+    tags: [],
+    stashes: [],
+    remotes: [],
+    commits: [],
+    loading: false,
+    error: null,
+    repoState: "Clean",
+    rebaseStatus: { inProgress: false, nextIndex: 0, total: 0, pauseReason: null },
+    activity: {},
+    stage: async (paths: string[]) => {
+      stageCalls.push(paths);
+    },
+    unstage: async (paths: string[]) => {
+      unstageCalls.push(paths);
+    },
+    ...over,
+  } as never);
+}
+
+function wireMocks() {
+  mockInvoke("list_all_files", () => [
+    modified("src/a.txt"),
+    staged("src/b.txt"),
+    file("src/untouched.txt"),
+  ]);
+  mockInvoke("get_diff", (args) => ({
+    path: args.path as string,
+    oldPath: null,
+    binary: false,
+    additions: 0,
+    deletions: 0,
+    hunks: [],
+  }));
+  mockInvoke("read_file_content", (args) => ({
+    path: args.path as string,
+    text: "content",
+    binary: false,
+    fromHead: false,
+  }));
+}
+
+function treeRow(path: string): HTMLElement {
+  const row = document.querySelector(`[data-pg-row][data-path="${path}"]`);
+  if (!row) throw new Error(`no tree row for ${path}`);
+  return row as HTMLElement;
+}
+
+function toggleOf(path: string): HTMLInputElement | null {
+  return treeRow(path).querySelector<HTMLInputElement>(
+    '[data-testid="tree-row-toggle"] input',
+  );
+}
+
+function contextMenu(): HTMLElement {
+  const menu = document.querySelector("[data-pg-menu]");
+  if (!menu) throw new Error("no context menu open");
+  return menu as HTMLElement;
+}
+
+describe("RepoBrowser tree staging (#61 A5)", () => {
+  beforeEach(() => {
+    stageCalls.length = 0;
+    unstageCalls.length = 0;
+    resetStore();
+    wireMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("stages a file straight from its tree checkbox", async () => {
+    render(<RepoBrowserScreen />);
+    await waitFor(() => treeRow("src/a.txt"));
+
+    const toggle = toggleOf("src/a.txt");
+    expect(toggle).not.toBeNull();
+    expect(toggle!.checked).toBe(false);
+    fireEvent.click(toggle!);
+
+    await waitFor(() => expect(stageCalls).toEqual([["src/a.txt"]]));
+  });
+
+  it("unstages a fully-staged file from its checkbox", async () => {
+    render(<RepoBrowserScreen />);
+    await waitFor(() => treeRow("src/b.txt"));
+
+    const toggle = toggleOf("src/b.txt");
+    expect(toggle!.checked).toBe(true);
+    fireEvent.click(toggle!);
+
+    await waitFor(() => expect(unstageCalls).toEqual([["src/b.txt"]]));
+  });
+
+  it("a partially-staged folder stages only its unstaged descendants", async () => {
+    render(<RepoBrowserScreen />);
+    const folder = await waitFor(() => treeRow("src"));
+
+    // src holds one unstaged and one staged file → tri-state, so unchecked,
+    // and clicking means "stage the rest".
+    const toggle = folder.querySelector<HTMLInputElement>(
+      '[data-testid="tree-row-toggle"] input',
+    );
+    expect(toggle).not.toBeNull();
+    expect(toggle!.checked).toBe(false);
+    fireEvent.click(toggle!);
+
+    // Already-staged src/b.txt is not re-sent.
+    await waitFor(() => expect(stageCalls).toEqual([["src/a.txt"]]));
+  });
+
+  it("a fully-staged folder reads as checked and unstages every descendant", async () => {
+    resetStore({ status: [staged("src/a.txt"), staged("src/b.txt")] });
+    render(<RepoBrowserScreen />);
+    const folder = await waitFor(() => treeRow("src"));
+
+    const toggle = folder.querySelector<HTMLInputElement>(
+      '[data-testid="tree-row-toggle"] input',
+    );
+    expect(toggle!.checked).toBe(true);
+    fireEvent.click(toggle!);
+
+    await waitFor(() =>
+      expect(unstageCalls).toEqual([["src/a.txt", "src/b.txt"]]),
+    );
+  });
+
+  it("treats a file dirty on both sides as partial, not staged", async () => {
+    resetStore({ status: [bothSides("src/a.txt")] });
+    render(<RepoBrowserScreen />);
+    await waitFor(() => treeRow("src/a.txt"));
+
+    // Checked would claim the whole file is staged when half of it isn't.
+    expect(toggleOf("src/a.txt")!.checked).toBe(false);
+    fireEvent.click(toggleOf("src/a.txt")!);
+
+    await waitFor(() => expect(stageCalls).toEqual([["src/a.txt"]]));
+  });
+
+  it("toggling a row's checkbox does not move the selection", async () => {
+    render(<RepoBrowserScreen />);
+    await waitFor(() => treeRow("src/a.txt"));
+
+    fireEvent.click(treeRow("src/b.txt"));
+    await waitFor(() =>
+      expect(treeRow("src/b.txt").getAttribute("data-selected")).toBe("true"),
+    );
+
+    fireEvent.click(toggleOf("src/a.txt")!);
+
+    expect(treeRow("src/b.txt").getAttribute("data-selected")).toBe("true");
+    expect(treeRow("src/a.txt").getAttribute("data-selected")).toBeNull();
+  });
+
+  it("offers no checkbox for an embedded repo or an unmodified file", async () => {
+    render(<RepoBrowserScreen />);
+    await waitFor(() => treeRow("vendor/lib"));
+
+    // Staging an embedded repo would write a bare gitlink — no affordance.
+    expect(toggleOf("vendor/lib")).toBeNull();
+
+    fireEvent.click(screen.getByText("All"));
+    await waitFor(() => treeRow("src/untouched.txt"));
+    expect(toggleOf("src/untouched.txt")).toBeNull();
+    // …but the changed sibling in the same tree still has one.
+    expect(toggleOf("src/a.txt")).not.toBeNull();
+  });
+
+  it("gives a folder the batch stage/discard menu instead of nothing", async () => {
+    render(<RepoBrowserScreen />);
+    const folder = await waitFor(() => treeRow("src"));
+
+    fireEvent.contextMenu(folder);
+
+    const menu = await waitFor(contextMenu);
+    expect(within(menu).getByText("2 files selected")).toBeInTheDocument();
+    expect(within(menu).getByText("Stage 1 file")).toBeInTheDocument();
+    expect(within(menu).getByText("Unstage 1 file")).toBeInTheDocument();
+  });
+});

--- a/src/screens/RepoBrowser.test.tsx
+++ b/src/screens/RepoBrowser.test.tsx
@@ -4,6 +4,13 @@ import { render, screen, waitFor, fireEvent, within } from "@testing-library/rea
 import { RepoBrowserScreen } from "./RepoBrowser";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { mockInvoke } from "@/test/invokeMock";
+import {
+  WithDialogs,
+  acceptDialog,
+  dialogTitle,
+  dismissDialog,
+  resetDialogs,
+} from "@/test/dialog";
 import type { FileStatus, RepoHandle } from "@/lib/types";
 
 const repo: RepoHandle = {
@@ -247,6 +254,7 @@ describe("RepoBrowser discarding untracked files", () => {
 
   beforeEach(() => {
     discardCalls.length = 0;
+    resetDialogs();
     resetStore({
       status: [modified("a.txt"), untracked("loose.txt")],
       discard: async (paths: string[]) => {
@@ -272,21 +280,27 @@ describe("RepoBrowser discarding untracked files", () => {
   });
 
   it("confirms before deleting an untracked file", async () => {
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(false);
-    render(<RepoBrowserScreen />);
+    render(
+      <WithDialogs>
+        <RepoBrowserScreen />
+      </WithDialogs>,
+    );
     const row = await waitFor(() => treeRow("loose.txt"));
 
     fireEvent.contextMenu(row);
     fireEvent.click(within(await waitFor(contextMenu)).getByText("Delete file…"));
 
-    expect(confirm).toHaveBeenCalledWith(
-      "Delete loose.txt? It is untracked, so this cannot be undone.",
+    await waitFor(() => expect(dialogTitle()).toBe("Delete loose.txt?"));
+    expect(screen.getByTestId("dialog-title").parentElement?.textContent).toContain(
+      "cannot be undone",
     );
+    await dismissDialog();
     expect(discardCalls).toEqual([]);
 
-    confirm.mockReturnValue(true);
     fireEvent.contextMenu(treeRow("loose.txt"));
     fireEvent.click(within(await waitFor(contextMenu)).getByText("Delete file…"));
+    await waitFor(() => expect(dialogTitle()).toBe("Delete loose.txt?"));
+    await acceptDialog();
 
     await waitFor(() => expect(discardCalls).toEqual([["loose.txt"]]));
   });
@@ -303,8 +317,11 @@ describe("RepoBrowser discarding untracked files", () => {
   });
 
   it("warns that untracked files are deleted permanently in a multi-file discard", async () => {
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(false);
-    render(<RepoBrowserScreen />);
+    render(
+      <WithDialogs>
+        <RepoBrowserScreen />
+      </WithDialogs>,
+    );
     await waitFor(() => treeRow("loose.txt"));
 
     fireEvent.click(treeRow("a.txt"));
@@ -314,9 +331,14 @@ describe("RepoBrowser discarding untracked files", () => {
     const menu = await waitFor(contextMenu);
     fireEvent.click(within(menu).getByText("Discard changes in 2 files…"));
 
-    expect(confirm).toHaveBeenCalledWith(
-      "Discard changes in 2 files? The changes will be lost. 1 file is untracked and will be deleted permanently.",
+    await waitFor(() =>
+      expect(dialogTitle()).toBe("Discard changes in 2 files?"),
     );
+    expect(screen.getByTestId("dialog-title").parentElement?.textContent).toContain(
+      "1 file is untracked and will be deleted permanently.",
+    );
+
+    await dismissDialog();
     expect(discardCalls).toEqual([]);
   });
 });

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -19,6 +19,7 @@ import {
   fileMenuItems,
   flattenFileTree,
   multiFileMenuItems,
+  pgConfirm,
   useContextMenu,
   usePaneWidth,
   type ContextMenuItem,
@@ -47,12 +48,19 @@ import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
 import { highlightFile } from "@/lib/highlight";
 import { getDiff, readFileContent } from "@/lib/tauri";
 import {
+  buildStatusList,
   buildStatusTree,
   findStatusByTreeKey,
   treeKeyToPath,
 } from "@/lib/tree";
+import { useTreeViewMode } from "@/lib/useTreeViewMode";
 import { fuzzyMatch } from "@/features/palette/fuzzyMatch";
-import { PGPane, FocusableScroll, useAction } from "@/features/keymap";
+import {
+  WhitespaceToggle,
+  useHunkActionsDisabledReason,
+  useIgnoreWhitespace,
+} from "@/features/diff/WhitespaceToggle";
+import { PGPane, FocusableScroll, useAction, usePaneList } from "@/features/keymap";
 import type {
   BranchInfo,
   FileContent,
@@ -108,11 +116,15 @@ export function RepoBrowserScreen() {
   const listFilesAtRev = useRepoStore((s) => s.listFilesAtRev);
   const readFileContentAtRev = useRepoStore((s) => s.readFileContentAtRev);
   const diffContextLines = useSettingsStore((s) => s.diffContextLines);
+  const ignoreWhitespace = useIgnoreWhitespace();
+  const hunkActionsDisabled = useHunkActionsDisabledReason();
 
   const [expanded, setExpanded] = React.useState<Record<string, boolean>>({});
   const [treeFilter, setTreeFilter] = React.useState("");
   const filterInputRef = React.useRef<HTMLInputElement>(null);
   const [sel, setSel] = React.useState<Selection>(emptySelection);
+  /** Moving end of a keyboard Shift range — see the usePaneList block below. */
+  const [leadKey, setLeadKey] = React.useState<string | null>(null);
   const [diff, setDiff] = React.useState<FileDiff | null>(null);
   const [diffLoading, setDiffLoading] = React.useState(false);
   const [previewError, setPreviewError] = React.useState<string | null>(null);
@@ -130,6 +142,7 @@ export function RepoBrowserScreen() {
     () => new Set(),
   );
   const [sortMode, setSortMode] = React.useState<SortMode>("asc");
+  const [viewMode, setViewMode] = useTreeViewMode("pg-repo-view-mode");
   const setNavIntent = useNavStore((s) => s.setIntent);
   const treePane = usePaneWidth(280, {
     min: 180,
@@ -214,10 +227,16 @@ export function RepoBrowserScreen() {
     return base;
   }, [status, allFiles, filterMode, hiddenKinds, browsingRev, revFiles, treeFilter]);
 
+  // Flat mode reuses the very same row component and row keys — only the
+  // nesting differs — so selection, staging and context menus need no
+  // per-mode branches anywhere below.
   const tree = React.useMemo<PGFileTreeNode[]>(() => {
-    const t = buildStatusTree(filteredStatus);
+    const t =
+      viewMode === "flat"
+        ? buildStatusList(filteredStatus)
+        : buildStatusTree(filteredStatus);
     return sortMode === "desc" ? reverseTree(t) : t;
-  }, [filteredStatus, sortMode]);
+  }, [filteredStatus, sortMode, viewMode]);
 
   // Expand-all / collapse-all: set every folder key true / false. Collapse must
   // write explicit `false` (not clear the map) to override defaultExpanded.
@@ -242,12 +261,13 @@ export function RepoBrowserScreen() {
     [filtering, folderKeys, expanded],
   );
 
-  // Visible row order (folders included) for shift-click ranges; selection
-  // keys are PGFileTree keys of the form "/a/b/c".
-  const rowOrder = React.useMemo(
-    () => flattenFileTree(tree, expandedForRender).map((f) => f.key),
+  // Visible rows (folders included) for shift ranges and keyboard nav;
+  // selection keys are PGFileTree keys of the form "/a/b/c".
+  const flatRows = React.useMemo(
+    () => flattenFileTree(tree, expandedForRender),
     [tree, expandedForRender],
   );
+  const rowOrder = React.useMemo(() => flatRows.map((f) => f.key), [flatRows]);
   const selectedKeys = React.useMemo(() => new Set(sel.keys), [sel]);
   const selected = primarySelectedKey(sel);
 
@@ -277,6 +297,7 @@ export function RepoBrowserScreen() {
           range: !!e?.shiftKey,
         }),
       );
+      setLeadKey(key);
     },
     [rowOrder],
   );
@@ -336,12 +357,155 @@ export function RepoBrowserScreen() {
     [status, allFiles, filteredStatus],
   );
 
+  /**
+   * Tri-state staging for every tree row, computed in one bottom-up walk.
+   *
+   * Per-row lookup would be O(rows x files) — a folder would rescan the whole
+   * status list on every render — so counts roll up from the leaves instead:
+   * a folder is "all" only when every stageable descendant is fully staged,
+   * "none" when none are, "partial" otherwise. Rows with nothing to stage
+   * (unmodified in All-files mode, embedded repos, folders holding only such
+   * rows) are absent from the map and render no checkbox.
+   */
+  const stageStates = React.useMemo(() => {
+    const out = new Map<string, "none" | "partial" | "all">();
+    // Browsing a committed snapshot: there is no worktree to stage from.
+    if (browsingRev) return out;
+    const byPath = new Map<string, FileStatus>();
+    for (const s of filteredStatus) byPath.set(s.path.replace(/\/+$/, ""), s);
+
+    type Counts = { all: number; partial: number; none: number };
+    const walk = (nodes: PGFileTreeNode[], parentKey: string): Counts => {
+      const acc: Counts = { all: 0, partial: 0, none: 0 };
+      for (const n of nodes) {
+        const key = parentKey + "/" + n.name;
+        if (n.children?.length) {
+          const c = walk(n.children, key);
+          const total = c.all + c.partial + c.none;
+          if (total > 0) {
+            out.set(
+              key,
+              c.all === total ? "all" : c.none === total ? "none" : "partial",
+            );
+          }
+          acc.all += c.all;
+          acc.partial += c.partial;
+          acc.none += c.none;
+          continue;
+        }
+        const st = byPath.get(key.replace(/^\//, ""));
+        // An embedded repo can't be staged (it would write a bare gitlink), and
+        // an unmodified file has nothing to stage.
+        if (!st || st.embedded) continue;
+        const staged = isStaged(st);
+        const unstaged = isUnstaged(st);
+        if (!staged && !unstaged) continue;
+        const state = staged ? (unstaged ? "partial" : "all") : "none";
+        out.set(key, state);
+        acc[state] += 1;
+      }
+      return acc;
+    };
+    walk(tree, "");
+    return out;
+  }, [tree, filteredStatus, browsingRev]);
+
+  const onStageToggle = React.useCallback(
+    (key: string, _node: PGFileTreeNode, next: boolean) => {
+      // Reuse the selection splitter: it already expands a folder key to every
+      // visible descendant and keeps embedded repos out of the batch.
+      const { stagedPaths, unstagedPaths } = splitSelection([key]);
+      const store = useRepoStore.getState();
+      if (next) {
+        if (unstagedPaths.length) void store.stage(unstagedPaths);
+      } else if (stagedPaths.length) {
+        void store.unstage(stagedPaths);
+      }
+    },
+    [splitSelection],
+  );
+
+  // ── Keyboard (#61 A7) ─────────────────────────────────────────────────────
+  // The tree now goes through the same `usePaneList` every flat pane uses, so
+  // it gets Home/End, Shift+Arrow ranges, Space-to-stage and type-to-jump
+  // speed-search for free instead of the bare-arrow-only handler it had.
+  //
+  // `leadKey` is the moving end of a Shift range, tracked separately from the
+  // anchor: primarySelectedKey() returns the anchor while it stays selected,
+  // so extending from it alone would make repeated Shift+↓ oscillate between
+  // two rows instead of growing the range.
+  React.useEffect(() => {
+    setLeadKey((prev) => (prev && rowOrder.includes(prev) ? prev : null));
+  }, [rowOrder]);
+
+  // -1 while nothing is selected yet, so the first ↓ lands on row 0 instead of
+  // skipping it (usePaneList clamps -1 ± 1 back into range).
+  const cursorIdx =
+    leadKey === null && selected === null
+      ? -1
+      : Math.max(0, rowOrder.indexOf(leadKey ?? selected ?? ""));
+  const moveTo = React.useCallback(
+    (i: number, range: boolean) => {
+      const key = rowOrder[Math.max(0, Math.min(rowOrder.length - 1, i))];
+      if (!key) return;
+      setSel((prev) => clickSelection(rowOrder, prev, key, { range }));
+      setLeadKey(key);
+    },
+    [rowOrder],
+  );
+
+  usePaneList({
+    paneId: "repo.tree",
+    count: rowOrder.length,
+    selectedIndex: cursorIdx,
+    onSelect: (i) => moveTo(i, false),
+    onExtendUp: () => moveTo(cursorIdx - 1, true),
+    onExtendDown: () => moveTo(cursorIdx + 1, true),
+    // → opens a collapsed folder, then walks into it; ← closes an open folder,
+    // else jumps to the parent row (standard tree semantics).
+    onExpand: (i) => {
+      const row = flatRows[i];
+      if (!row?.hasChildren) return;
+      if (!row.isExpanded) setExpanded((e) => ({ ...e, [row.key]: true }));
+      else moveTo(i + 1, false);
+    },
+    onCollapse: (i) => {
+      const row = flatRows[i];
+      if (row?.hasChildren && row.isExpanded) {
+        setExpanded((e) => ({ ...e, [row.key]: false }));
+        return;
+      }
+      const parentKey = row?.key.split("/").slice(0, -1).join("/");
+      const parentIdx = parentKey ? rowOrder.indexOf(parentKey) : -1;
+      if (parentIdx >= 0) moveTo(parentIdx, false);
+    },
+    onActivate: (i) => {
+      const row = flatRows[i];
+      if (row?.hasChildren) {
+        setExpanded((e) => ({ ...e, [row.key]: !row.isExpanded }));
+      }
+    },
+    // Space stages/unstages the row (file or whole folder), matching the
+    // checkbox it drives.
+    onToggle: (i) => {
+      const row = flatRows[i];
+      if (!row) return;
+      const state = stageStates.get(row.key);
+      if (state === undefined) return;
+      onStageToggle(row.key, row.node, state !== "all");
+    },
+    // Type-to-jump over the visible path, so "feat" lands on src/features.
+    searchText: (i) => rowOrder[i]?.replace(/^\//, "") ?? "",
+  });
+
   const fileCtx = useContextMenu<{ key: string; node: PGFileTreeNode }>(
     ({ key, node }) => {
       if (sel.keys.length > 1 && sel.keys.includes(key)) {
         return multiFileMenuItems(splitSelection(sel.keys));
       }
-      if (node.children?.length) return [];
+      // Folder: act on every file beneath it — stage / unstage / discard all,
+      // the same batch menu a multi-row selection gets.
+      if (node.children?.length) return multiFileMenuItems(splitSelection([key]));
       const st = findStatusByTreeKey(key, status);
       // Act on the status entry's own path, not the key: an embedded repo's
       // path carries a trailing slash the key has already lost, and that slash
@@ -432,7 +596,13 @@ export function RepoBrowserScreen() {
         });
     } else {
       setFileContent(null);
-      getDiff(repo.id, selectedFile.path, "WorktreeToHead", diffContextLines)
+      getDiff(
+        repo.id,
+        selectedFile.path,
+        "WorktreeToHead",
+        diffContextLines,
+        ignoreWhitespace,
+      )
         .then((d) => {
           if (!cancelled) setDiff(d);
         })
@@ -451,7 +621,7 @@ export function RepoBrowserScreen() {
     return () => {
       cancelled = true;
     };
-  }, [selectedFile?.path, selectedFile?.embedded, selectedIsUnmodified, repo, browsingRev, rev, readFileContentAtRev, diffContextLines]);
+  }, [selectedFile?.path, selectedFile?.embedded, selectedIsUnmodified, repo, browsingRev, rev, readFileContentAtRev, diffContextLines, ignoreWhitespace]);
 
   const breadcrumbItems = React.useMemo(() => {
     const root = repo?.path.split("/").filter(Boolean).pop() ?? "repository";
@@ -541,17 +711,34 @@ export function RepoBrowserScreen() {
                 style={{ flex: 1, minWidth: 0 }}
               />
               <PGIconButton
-                icon="expandAll"
+                icon={viewMode === "tree" ? "viewTree" : "viewList"}
                 size="sm"
-                title="Expand all"
-                onClick={expandAll}
+                title={
+                  viewMode === "tree"
+                    ? "Tree view — switch to flat list"
+                    : "Flat list — switch to tree view"
+                }
+                onClick={() =>
+                  setViewMode(viewMode === "tree" ? "flat" : "tree")
+                }
               />
-              <PGIconButton
-                icon="collapseAll"
-                size="sm"
-                title="Collapse all"
-                onClick={collapseAll}
-              />
+              {/* Nothing to fold in a flat list. */}
+              {viewMode === "tree" && (
+                <>
+                  <PGIconButton
+                    icon="expandAll"
+                    size="sm"
+                    title="Expand all"
+                    onClick={expandAll}
+                  />
+                  <PGIconButton
+                    icon="collapseAll"
+                    size="sm"
+                    title="Collapse all"
+                    onClick={collapseAll}
+                  />
+                </>
+              )}
             </div>
           </div>
           <div style={{ flex: 1, overflow: "auto", padding: "4px 0" }}>
@@ -589,14 +776,13 @@ export function RepoBrowserScreen() {
             <PGFileTree
               nodes={tree}
               expanded={expandedForRender}
-              onToggle={(k) =>
-                setExpanded((e) => ({ ...e, [k]: !e[k] }))
-              }
+              onToggle={(k, next) => setExpanded((e) => ({ ...e, [k]: next }))}
               selected={selected ?? undefined}
               selectedKeys={selectedKeys}
               onSelect={onTreeSelect}
-              onActivate={(k, n) => onTreeSelect(k, n)}
               onRowContextMenu={onTreeContextMenu}
+              stageState={(k) => stageStates.get(k)}
+              onStageToggle={onStageToggle}
             />
             {fileCtx.menu}
           </div>
@@ -658,6 +844,7 @@ export function RepoBrowserScreen() {
               </span>
             )}
             <div style={{ flex: 1 }} />
+            <WhitespaceToggle />
             <PGButton
               size="xs"
               variant="ghost"
@@ -742,13 +929,21 @@ export function RepoBrowserScreen() {
                   lines={h.lines.map(toUiLine)}
                   expanded={true}
                   staged={false}
+                  actionsDisabledReason={hunkActionsDisabled}
                   onStage={() => {
                     if (!selectedFile) return;
                     useRepoStore.getState().stageHunk(selectedFile.path, i);
                   }}
-                  onDiscard={() => {
+                  onDiscard={async () => {
                     if (!selectedFile) return;
-                    if (window.confirm("Discard this hunk? The change will be lost.")) {
+                    if (
+                      await pgConfirm({
+                        title: "Discard this hunk?",
+                        body: `The change to ${selectedFile.path} will be lost.`,
+                        danger: true,
+                        confirmLabel: "Discard hunk",
+                      })
+                    ) {
                       useRepoStore.getState().discardHunk(selectedFile.path, i);
                     }
                   }}

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -7,6 +7,7 @@ import {
   PGInput,
   PGSelect,
   PGToggle,
+  pgConfirm,
   pgFlash,
 } from "@/design";
 import {
@@ -200,6 +201,16 @@ export function SettingsScreen() {
                   s.set("diffContextLines", n);
                 }}
                 style={{ width: 72 }}
+              />
+            }
+          />
+          <Row
+            label="Ignore whitespace"
+            hint="Hide whitespace-only changes when reviewing reformatted code. Hunk staging is unavailable while this is on — the filtered hunks aren't the ones git would apply."
+            control={
+              <PGToggle
+                checked={s.ignoreWhitespaceInDiff}
+                onChange={(v) => s.set("ignoreWhitespaceInDiff", v)}
               />
             }
           />
@@ -451,8 +462,16 @@ function AppearanceSection({ active }: { active: ThemeDef }) {
     }
   };
 
-  const onDelete = () => {
-    if (!window.confirm(`Delete theme "${active.name}"?`)) return;
+  const onDelete = async () => {
+    if (
+      !(await pgConfirm({
+        title: `Delete theme "${active.name}"?`,
+        body: "Custom themes aren't recoverable unless you exported the file.",
+        danger: true,
+        confirmLabel: "Delete theme",
+      }))
+    )
+      return;
     s.deleteTheme(active.id);
   };
 
@@ -514,7 +533,7 @@ function AppearanceSection({ active }: { active: ThemeDef }) {
             size="sm"
             variant="default"
             icon="trash"
-            onClick={onDelete}
+            onClick={() => void onDelete()}
           >
             Delete
           </PGButton>

--- a/src/screens/viewMode.test.tsx
+++ b/src/screens/viewMode.test.tsx
@@ -1,0 +1,209 @@
+// Tree ⇄ flat toggle for both change views (#61 A6).
+//
+// The contract that makes this cheap: both modes emit the SAME row keys, so
+// selection, staging and context menus need no per-mode branches. These tests
+// pin that — a folder row appears/disappears, but file rows keep working.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
+
+import { RepoBrowserScreen } from "./RepoBrowser";
+import { CommitPanelScreen } from "./CommitPanel";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useKeymapStore, useFocusStore } from "@/features/keymap";
+import { mockInvoke } from "@/test/invokeMock";
+import type { FileStatus } from "@/lib/types";
+
+function file(path: string, over: Partial<FileStatus> = {}): FileStatus {
+  return {
+    path,
+    worktree: { kind: "Unmodified" },
+    index: { kind: "Unmodified" },
+    additions: 0,
+    deletions: 0,
+    embedded: false,
+    ...over,
+  };
+}
+const modified = (p: string) => file(p, { worktree: { kind: "Modified" } });
+
+const stageCalls: string[][] = [];
+
+function baseStore(over: Record<string, unknown> = {}) {
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    status: [modified("src/a.ts"), modified("src/b.ts"), modified("z.txt")],
+    allFiles: [],
+    branches: [],
+    tags: [],
+    stashes: [],
+    remotes: [],
+    commits: [],
+    loading: false,
+    error: null,
+    repoState: "Clean",
+    rebaseStatus: { inProgress: false, nextIndex: 0, total: 0, pauseReason: null },
+    activity: {},
+    stage: async (paths: string[]) => {
+      stageCalls.push(paths);
+    },
+    unstage: async () => {},
+    ...over,
+  } as never);
+}
+
+function wireMocks() {
+  mockInvoke("list_all_files", () => []);
+  mockInvoke("get_diff", (args) => ({
+    path: args.path as string,
+    oldPath: null,
+    binary: false,
+    additions: 0,
+    deletions: 0,
+    hunks: [],
+  }));
+  mockInvoke("read_file_content", (args) => ({
+    path: args.path as string,
+    text: "content",
+    binary: false,
+    fromHead: false,
+  }));
+}
+
+const rowFor = (path: string) =>
+  document.querySelector(`[data-pg-row][data-path="${path}"]`);
+
+const toFlat = () =>
+  fireEvent.click(screen.getByTitle("Tree view — switch to flat list"));
+const toTree = () =>
+  fireEvent.click(screen.getByTitle("Flat list — switch to tree view"));
+
+beforeEach(() => {
+  stageCalls.length = 0;
+  localStorage.clear();
+  baseStore();
+  wireMocks();
+  useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+  useKeymapStore.getState().setPreset("rider");
+  useFocusStore.setState({
+    focused: null,
+    panes: new Map(),
+    order: [],
+    barId: null,
+    pendingContentFocus: false,
+  });
+});
+
+describe("RepoBrowser tree ⇄ flat (#61 A6)", () => {
+  it("drops the folder rows in flat mode and keeps the same file rows", async () => {
+    render(<RepoBrowserScreen />);
+    await waitFor(() => expect(rowFor("src")).not.toBeNull());
+    expect(rowFor("src/a.ts")).not.toBeNull();
+
+    toFlat();
+
+    // No nesting left…
+    expect(rowFor("src")).toBeNull();
+    // …but every file is still there, under its unchanged row key.
+    expect(rowFor("src/a.ts")).not.toBeNull();
+    expect(rowFor("src/b.ts")).not.toBeNull();
+    expect(rowFor("z.txt")).not.toBeNull();
+  });
+
+  it("keeps staging working in flat mode", async () => {
+    render(<RepoBrowserScreen />);
+    await waitFor(() => expect(rowFor("src")).not.toBeNull());
+    toFlat();
+
+    const toggle = rowFor("src/a.ts")!.querySelector<HTMLInputElement>(
+      '[data-testid="tree-row-toggle"] input',
+    );
+    expect(toggle).not.toBeNull();
+    fireEvent.click(toggle!);
+
+    await waitFor(() => expect(stageCalls).toEqual([["src/a.ts"]]));
+  });
+
+  it("hides expand/collapse-all in flat mode — there is nothing to fold", async () => {
+    render(<RepoBrowserScreen />);
+    await waitFor(() => expect(rowFor("src")).not.toBeNull());
+    expect(screen.queryByTitle("Expand all")).not.toBeNull();
+
+    toFlat();
+    expect(screen.queryByTitle("Expand all")).toBeNull();
+    expect(screen.queryByTitle("Collapse all")).toBeNull();
+  });
+
+  it("remembers the choice", async () => {
+    const view = render(<RepoBrowserScreen />);
+    await waitFor(() => expect(rowFor("src")).not.toBeNull());
+    toFlat();
+    expect(localStorage.getItem("pg-repo-view-mode")).toBe("flat");
+
+    // A fresh mount comes back flat.
+    view.unmount();
+    render(<RepoBrowserScreen />);
+    await waitFor(() => expect(rowFor("src/a.ts")).not.toBeNull());
+    expect(rowFor("src")).toBeNull();
+  });
+});
+
+describe("CommitPanel tree ⇄ flat (#61 A6)", () => {
+  it("groups changes under folders in tree mode", async () => {
+    render(<CommitPanelScreen />);
+    // Defaults to the flat list this screen has always shown.
+    await waitFor(() => expect(rowFor("src/a.ts")).not.toBeNull());
+    expect(rowFor("src")).toBeNull();
+
+    toTree();
+
+    expect(rowFor("src")).not.toBeNull();
+    expect(rowFor("src/a.ts")).not.toBeNull();
+    expect(localStorage.getItem("pg-commit-view-mode")).toBe("tree");
+  });
+
+  it("stages a whole folder from its checkbox in tree mode", async () => {
+    render(<CommitPanelScreen />);
+    await waitFor(() => expect(rowFor("src/a.ts")).not.toBeNull());
+    toTree();
+
+    const toggle = rowFor("src")!.querySelector<HTMLInputElement>(
+      '[data-testid="tree-row-toggle"] input',
+    );
+    expect(toggle).not.toBeNull();
+    // Unstaged section → unchecked, so clicking means "stage everything here".
+    expect(toggle!.checked).toBe(false);
+    fireEvent.click(toggle!);
+
+    await waitFor(() => expect(stageCalls).toEqual([["src/a.ts", "src/b.ts"]]));
+  });
+
+  it("gives a folder row the batch context menu", async () => {
+    render(<CommitPanelScreen />);
+    await waitFor(() => expect(rowFor("src/a.ts")).not.toBeNull());
+    toTree();
+
+    fireEvent.contextMenu(rowFor("src")!);
+
+    const menu = await waitFor(() => {
+      const m = document.querySelector("[data-pg-menu]");
+      if (!m) throw new Error("no context menu");
+      return m as HTMLElement;
+    });
+    expect(within(menu).getByText("2 files selected")).toBeInTheDocument();
+    expect(within(menu).getByText("Stage 2 files")).toBeInTheDocument();
+  });
+
+  it("stages a single file from a tree row, same as the flat row", async () => {
+    render(<CommitPanelScreen />);
+    await waitFor(() => expect(rowFor("src/a.ts")).not.toBeNull());
+    toTree();
+
+    const toggle = rowFor("src/a.ts")!.querySelector<HTMLInputElement>(
+      '[data-testid="tree-row-toggle"] input',
+    );
+    fireEvent.click(toggle!);
+
+    await waitFor(() => expect(stageCalls).toEqual([["src/a.ts"]]));
+  });
+});

--- a/src/test/dialog.tsx
+++ b/src/test/dialog.tsx
@@ -1,0 +1,63 @@
+// Test helpers for the styled confirm/prompt dialogs (#61 C3).
+//
+// pgConfirm/pgPrompt resolve false/null when no <PGDialogHost/> is mounted, so
+// a component test that renders one screen in isolation must render the host
+// alongside it — otherwise every confirmation silently reads as "cancelled"
+// and the assertion under test never gets a chance to run.
+
+import { act, fireEvent, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { PGDialogHost, __resetDialogs } from "@/design";
+
+/** Wrap a screen under test so pgConfirm/pgPrompt can actually render. */
+export function WithDialogs({ children }: { children: ReactNode }) {
+  return (
+    <>
+      {children}
+      <PGDialogHost />
+    </>
+  );
+}
+
+/** Drop any dialog left queued by a previous case. */
+export function resetDialogs() {
+  __resetDialogs();
+}
+
+/** The open dialog's headline, or null when none is open. */
+export function dialogTitle(): string | null {
+  return screen.queryByTestId("dialog-title")?.textContent ?? null;
+}
+
+/** The open dialog's body text, or null. */
+export function dialogBody(): string | null {
+  const title = screen.queryByTestId("dialog-title");
+  return title?.parentElement?.lastElementChild === title
+    ? null
+    : (title?.parentElement?.lastElementChild?.textContent ?? null);
+}
+
+export function dialogIsOpen(): boolean {
+  return !!document.querySelector("[data-pg-dialog]");
+}
+
+/**
+ * Accept the open dialog. `value` fills the input first — required for a
+ * prompt, and for a confirm that demands a typed name.
+ */
+export async function acceptDialog(value?: string) {
+  const input = screen.queryByTestId("dialog-input");
+  if (value !== undefined && input) {
+    fireEvent.change(input, { target: { value } });
+  }
+  await act(async () => {
+    fireEvent.click(screen.getByTestId("dialog-confirm"));
+  });
+}
+
+/** Dismiss the open dialog (same outcome as Escape or the backdrop). */
+export async function dismissDialog() {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId("dialog-cancel"));
+  });
+}


### PR DESCRIPTION
Lands **all nine Tier 1 items** from #61. Tier 0 shipped in `fa398c9`; the issue's status refresh named A4+A5+A6 as the natural next PR, and the tree work pulled A7 in with it.

Closes nothing on its own — #61 stays open for Tier 2/3.

---

## Tree (A4–A7) — the stated priority

| # | What |
|---|------|
| **A4** | Per-file-type icons across every file row |
| **A5** | Staging from the tree: tri-state folder checkboxes + folder batch menu |
| **A6** | Tree ⇄ flat toggle in RepoBrowser **and** CommitPanel, persisted |
| **A7** | Tree keyboard on `usePaneList`: Home/End, Shift+Arrow ranges, Space-to-stage, speed-search |

**A4** splits the problem in two: the **glyph** is per *category* (nine of them) so it stays legible at 11–12px and adding a language is one map entry, not new SVG; the **tint** is per *extension*, drawn from the themeable `--graph-*` tokens, so `.ts` and `.rs` are still distinguishable. Unknown types resolve to the generic glyph, so nothing regresses.

**A5** computes every row's staged-ness in one bottom-up walk — a folder asking the status list for its descendants on each render is O(rows × files). Rows with nothing to stage get no checkbox but still reserve the column so names stay aligned, and an embedded repo stays out of every batch (staging one writes a bare gitlink no clone can resolve).

**A6** is nearly free because `buildStatusList` emits the **same row keys** as `buildStatusTree` (`"/" + full path`) — so selection, staging state and context menus need no per-mode branch anywhere. CommitPanel translates only at its section edges, since its key space is `side:path`.

**A7** moves keyboard handling out of `PGFileTree` and into the owning screen. A local `onKeyDown` plus the global dispatcher would both answer ArrowDown and move the selection twice; it also keeps `design/` presentational.

### Two latent bugs fixed on the way
- `onToggle` now receives the next expanded state from `PGFileTree`. Callers wrote `!expanded[key]`, which is wrong for every *default-expanded* folder — the first click on the auto-expanded top folder did nothing.
- The keyboard cursor is `-1` until something is selected, so the first ↓ lands on row 0 instead of skipping it.

---

## Visual (B4, B5)

**B4 — light themes were half-wired.** `applyTheme` only remapped bg/fg/border/accent/logo/ring, so on `light` and `github-light` the diff add/remove colors, graph lanes, branch-pill tones, `--accent-2..5` and shadows kept their **dark** calibration over a light canvas. It now also writes `SEMANTIC_TOKENS` per theme *mode*, plus `SELECTION_TOKENS` derived from `--accent` with relative-color syntax so a custom accent carries through instead of leaving blue selection on an amber theme.

Diff green stays green: the semantic sets carry their own meaning, so they're tabulated per mode rather than derived from the accent. **The dark column is byte-identical to `index.css`, so every dark theme renders exactly as before.** Tokens are rewritten on every apply — otherwise dark → light → dark leaves a stale calibration behind (pinned by a test).

**B5** vendors Inter + JetBrains Mono (OFL-1.1 variable builds, one file per unicode-range subset). The stacks *named* them without shipping them, so a machine lacking both silently fell back to system sans/mono.

---

## Flow + features (C3, D1, D2)

**C3 — all 48 native dialogs replaced.** New `PGDialogHost` + `pgConfirm`/`pgPrompt`, mounted once per window (main shell and merge resolver).

The API is deliberately **promise-shaped, not component-shaped**: every call site read `if (window.confirm(msg))` inline inside a menu handler, so `if (await pgConfirm(msg))` is the same line plus a keyword. A `<Dialog open={…}>` component would have meant lifting state into ten screens.

What the natives couldn't do, and these now do: a body distinct from the title (so "this cannot be undone" has somewhere to live), red danger styling, and **typed-name confirmation** for the unrecoverable ones — deleting a branch on the remote now asks you to type its name.

The contract matches the natives so conversions stayed mechanical: dismissal → `false`/`null`, Escape and backdrop dismiss, and an empty prompt string stays distinct from `null` (an empty stash message means "no message"; a dismissal means "don't stash").

**D1 — author override + `Co-Authored-By`.** The backend has honored `CommitOptions.author_override` since the commit op was written; the command handler hardcoded `None` and the TS wrapper never sent it. A typed-but-unparseable author **disables the commit button** rather than being silently ignored — landing the wrong author in history costs a rewrite to fix.

**D2 — whitespace-ignore toggle.** This setting was removed once before, with the note that libgit2's whitespace flags "would desync hunk indices from staging". That hazard is **real** and is now handled rather than ignored:

> `IGNORE_WHITESPACE` rewrites whitespace-only changes into *context* lines, so the hunks on screen neither line up with the indices `stage_hunk` expects nor describe a patch that would apply.

So the flag reaches the diff **read** paths only — the hunk ops deliberately don't take it — and every surface disables its hunk Stage/Discard while the toggle is on, with the reason in the button title. A new backend test (`whitespace_diff.rs`) pins the *divergence* that makes this necessary, not just the filtering.

---

## Verification

| Gate | Result |
|---|---|
| `pnpm test` | **472 passing** (+55 new) |
| `cargo test` | 30 suites green, incl. new `whitespace_diff.rs` |
| `pnpm tsc --noEmit` + e2e tsc | clean |
| `pnpm vite build` | clean |
| **Full e2e headless** (Docker: WebKitGTK + xvfb, the stack CI uses) | **17/17 spec files, 88 tests, 0 failures** |

`stubNativeDialogs` keeps its name and options but now installs an observer that answers the real in-page modal, so **no e2e spec call site changed**.

---

## Not included

Tier 2/3. Several are explicitly "spec separately" in the issue — D5 credentials, D11 PR integration, C4 multi-repo tabs.

One deliberate scope note: keyboard arrows walk **files only** in CommitPanel's tree mode (folders there are mouse-operable). RepoBrowser's tree navigates folders too, per A7. A6 as specified didn't ask for the latter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
