### PR TITLE
docs: mandate Docker for all e2e runs, never native

### DIFF
--- a/.claude/skills/e2e-testing/SKILL.md
+++ b/.claude/skills/e2e-testing/SKILL.md
@@ -9,14 +9,18 @@ Hard-won rules from building the suite. Every trap below bit a real implementati
 
 ## Commands
 
+**E2E always runs in Docker — never natively, never in a UI window.** The
+`test:e2e*` scripts below are the in-container primitives; drive them through
+the `test:e2e:docker` wrapper, never directly on the host.
+
 ```bash
-pnpm test:e2e        # test:e2e:build + test:e2e:run — REQUIRED after ANY src/ or src-tauri/ change
-pnpm test:e2e:run    # reuses e2e/.bin snapshot — spec-only iterations
-pnpm test:e2e:run --spec e2e/specs/<file>   # single spec
-pnpm exec tsc -p e2e/tsconfig.json --noEmit # e2e typecheck gate (root tsc EXCLUDES e2e/)
+pnpm test:e2e:docker full --spec e2e/specs/<file>  # build + run — REQUIRED after ANY src/ or src-tauri/ change
+pnpm test:e2e:docker run  --spec e2e/specs/<file>  # reuses this worktree's e2e/.bin snapshot — spec-only iterations
+pnpm test:e2e:docker                               # build + whole suite
+pnpm exec tsc -p e2e/tsconfig.json --noEmit        # e2e typecheck gate (root tsc EXCLUDES e2e/)
 ```
 
-**Stale-binary trap:** `test:e2e:run` tests whatever binary is in `e2e/.bin/`. A green run after touching `src/` proves nothing unless a full `test:e2e` ran after the change. Plain `cargo build` silently rewrites `target/debug/platypusgit` WITHOUT `custom-protocol` (blank window) — that's why the snapshot exists. Close any running dev app first: debug builds all serve WebDriver on port 4445 and the runner may attach to the dev instance and clear its localStorage.
+**Stale-binary trap:** the `run` phase tests whatever binary is in `e2e/.bin/`. A green run after touching `src/` proves nothing unless a `build`/`full` ran after the change. Plain `cargo build` silently rewrites `target/debug/platypusgit` WITHOUT `custom-protocol` (blank window) — that's why the snapshot exists. Close any running dev app first: debug builds all serve WebDriver on port 4445 and the runner may attach to the dev instance and clear its localStorage.
 
 **Wrong-binary trap — NATIVE runs collide across worktrees.** Port 4445 is a
 HOST port for native runs, so if any other worktree has an e2e binary running,
@@ -113,7 +117,7 @@ Fixtures live in `e2e/support/tempRepo.ts` (`basicRepo`, `dirtyRepo`, `branchyRe
 
 ## Debugging
 
-1. Reproduce on one spec: `pnpm test:e2e:run --spec e2e/specs/<file>`.
+1. Reproduce on one spec: `pnpm test:e2e:docker run --spec e2e/specs/<file>`.
 2. Inspect real DOM, don't guess: `await browser.execute(() => document.querySelector('[role="dialog"]')?.outerHTML)`.
 3. Suite slow? → flake bands above (bridge), not the spec.
 4. Selector fights >20min → capture outerHTML evidence, then fix or escalate; never fake a flow by shelling `git` for the action under test.
@@ -127,6 +131,6 @@ Fixtures live in `e2e/support/tempRepo.ts` (`basicRepo`, `dirtyRepo`, `branchyRe
 
 ## Before committing
 
-- src/ touched → full `pnpm test:e2e` green (paste output, not counts).
+- src/ touched → `pnpm test:e2e:docker full` green (paste output, not counts). Docker, never a native run.
 - `pnpm exec tsc -p e2e/tsconfig.json --noEmit` + `pnpm tsc --noEmit` + `pnpm test`.
 - New refresh site → re-arm rule applied. New helper → lives in `e2e/support/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,12 +49,18 @@ cargo test --manifest-path src-tauri/Cargo.toml
 pnpm tauri build                            # production bundle (.msi/.dmg/.deb/.AppImage)
 pnpm tauri build --no-sign                  # ...without updater signing (see note below)
 pnpm test                                   # vitest (unit logic + component tests)
-pnpm test:e2e                               # full e2e: debug build + all specs (CI does this; local only rarely)
-pnpm test:e2e:build                         # rebuild debug binary snapshot only (after src/ or src-tauri/ change)
-pnpm test:e2e:run --spec e2e/specs/X.e2e.ts # run ONLY relevant spec(s) against current snapshot
-pnpm test:e2e:docker                        # headless e2e in Docker (macOS: only way to run WITHOUT a window)
+pnpm test:e2e:docker                        # e2e — THE way to run e2e (headless, same stack as CI)
+pnpm test:e2e:docker run --spec e2e/specs/X.e2e.ts   # ...one spec against this worktree's snapshot
 pnpm exec tsc -p e2e/tsconfig.json --noEmit # e2e typecheck gate (root tsc excludes e2e/)
 ```
+
+**E2E always runs in Docker — never natively, never in a UI window.** The
+`test:e2e`, `test:e2e:build`, and `test:e2e:run` scripts are the in-container
+primitives the Docker wrapper invokes; do not run them directly on the host. A
+host run pops a real WKWebView window, needs foreground focus, is unreliable
+(multi-window specs drop the session) and slow (a full native run has taken 27
+min vs ~1 min in the healthy band) — and a green native run does not predict the
+PR gate. See "Headless e2e in Docker" below.
 
 **Local production builds need the updater signing key.** `tauri.conf.json`
 sets `plugins.updater.pubkey` + `bundle.createUpdaterArtifacts: true`, so
@@ -66,13 +72,19 @@ produces an updater artifact (msi on Windows, AppImage on Linux). Either export
 `TAURI_SIGNING_PRIVATE_KEY` (+ `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`) or build
 with `--no-sign`. CI is unaffected — release.yml passes both from repo secrets.
 
-### Headless e2e in Docker (`pnpm test:e2e:docker`)
+### Headless e2e in Docker (`pnpm test:e2e:docker`) — the only supported way
 
 macOS has no headless webview — a native `pnpm test:e2e` run pops a real
-WKWebView window and needs foreground focus (`ensureMacAppFocus`). To run
-headless, drive the CI stack (WebKitGTK + xvfb) in a container. Same webview
-target CI uses, so a green Docker run matches the PR gate; it does NOT prove
-the macOS WKWebView path (run native for that).
+WKWebView window and needs foreground focus (`ensureMacAppFocus`). So e2e runs
+headless in a container driving the CI stack (WebKitGTK + xvfb). Same webview
+target CI uses, so a green Docker run matches the PR gate.
+
+**Never run e2e natively / in a UI window** — not to "check it quickly", not for
+a single spec, not because Docker is cold. It steals foreground focus from
+whoever is at the machine, is flaky on multi-window specs, and its result
+doesn't predict CI. The one exception is a genuinely WKWebView-specific
+question, and that needs the user to ask for it explicitly; say so in the report
+when it happens.
 
 Files: `Dockerfile.e2e` (mirrors `.github/workflows/e2e.yml` deps),
 `docker-compose.e2e.yml`, `e2e/docker-entrypoint.sh` (phase dispatch),
@@ -124,22 +136,27 @@ Four layers, each run independently:
   tests, all passing) drive the real debug binary: real webview →
   real Tauri IPC → real libgit2 → temp repos built by `e2e/support/tempRepo.ts`.
   Uses the embedded WebDriver provider (`@wdio/tauri-service`) — no external
-  driver or paid service — so it runs on macOS (WKWebView) and on Linux CI
-  (WebKitGTK).
-  - `pnpm test:e2e` = `test:e2e:build` (a tauri debug build with
-    `--features tauri/custom-protocol --config src-tauri/tauri.e2e.conf.json`,
-    snapshotting the binary to gitignored `e2e/.bin/`) followed by
-    `test:e2e:run` (wdio against that snapshot).
-  - **When to run e2e locally:** only once you're DONE developing a change
-    — not on every edit during active development. And run ONLY the spec
-    file(s) relevant to what you touched, not the whole suite. CI runs the
-    full suite on the PR.
+  driver or paid service — so it runs on Linux CI (WebKitGTK) and, in the same
+  container image, locally.
+  - **ALWAYS run e2e through Docker (`pnpm test:e2e:docker …`), never
+    natively.** No host runs, no UI window. `test:e2e` /
+    `test:e2e:build` / `test:e2e:run` are the primitives the container runs:
+    `test:e2e:build` is a tauri debug build with `--features
+    tauri/custom-protocol --config src-tauri/tauri.e2e.conf.json` snapshotting
+    the binary to gitignored `e2e/.bin/`, `test:e2e:run` is wdio against that
+    snapshot. Invoke them via the Docker wrapper, not directly.
+  - **When to run e2e:** only once you're DONE developing a change — not on
+    every edit during active development. And run ONLY the spec file(s)
+    relevant to what you touched, not the whole suite. CI runs the full suite
+    on the PR.
   - **How to run the relevant spec(s):** after a src/ or src-tauri/ change,
-    rebuild the snapshot once with `pnpm test:e2e:build`, then run just the
-    affected spec(s): `pnpm test:e2e:run --spec e2e/specs/<file>.e2e.ts`
-    (repeat `--spec` for more). A spec-only change skips the rebuild — run
-    `pnpm test:e2e:run --spec …` directly. Never rely on a stale snapshot:
-    `test:e2e:run` silently tests the old binary if you skipped the rebuild.
+    rebuild this worktree's snapshot once with `pnpm test:e2e:docker build`,
+    then run just the affected spec(s): `pnpm test:e2e:docker run --spec
+    e2e/specs/<file>.e2e.ts` (repeat `--spec` for more). A spec-only change
+    skips the rebuild — run `pnpm test:e2e:docker run --spec …` directly.
+    `pnpm test:e2e:docker full --spec …` does build + run in one shot. Never
+    rely on a stale snapshot: the `run` phase silently tests the old binary if
+    you skipped the rebuild.
   - **Before writing or debugging any e2e spec, read the `e2e-testing`
     project skill** (`.claude/skills/e2e-testing/SKILL.md`) — selector
     conventions and traps, driver-bridge/5s-penalty rules, native-dialog
@@ -150,8 +167,8 @@ Four layers, each run independently:
     that answers each one as it appears. Call sites are unchanged;
     `confirmCallCount()` still counts confirm dialogs only.
   - CI: `.github/workflows/e2e.yml` (ubuntu-latest + xvfb, PRs to `main` +
-    push to `main`). Headless local runs use `pnpm test:e2e:docker` (same
-    WebKitGTK + xvfb stack) — see the "Headless e2e in Docker" section above.
+    push to `main`). Local runs use `pnpm test:e2e:docker` (same WebKitGTK +
+    xvfb stack) — see the "Headless e2e in Docker" section above.
   - `pnpm.overrides["@wdio/native-utils"] = "2.5.0"` pins around a broken
     dep pin in `@wdio/tauri-service@1.2.0` — don't remove.
   - Only `e2e`-feature builds serve WebDriver on port 4445 (the plugin is now
@@ -162,13 +179,12 @@ Four layers, each run independently:
     launches — without it, `tauri-plugin-single-instance` would forward a
     test binary's launch into any already-running platypusgit instance
     instead of serving WebDriver.
-  - **Second-window e2e is HEADLESS-ONLY** (`merge-window.e2e.ts` drives the
-    `merge` resolver window). Reliable on Linux/WebKitGTK — CI and
-    `pnpm test:e2e:docker`. On a macOS-NATIVE run it's flaky: WKWebView's
+  - Multi-window specs (`merge-window.e2e.ts` drives the `merge` resolver
+    window) are one concrete reason for the Docker-only rule: reliable on
+    Linux/WebKitGTK, broken on a macOS-native run, where WKWebView's
     foreground-focus self-heal can't hold a consistent active window across the
     second window's open/transition/close (`switchWindow` → "No window could be
-    found"). So run any multi-window spec via Docker/CI, not `pnpm test:e2e` on
-    a Mac.
+    found").
 
 ## Architecture
 


### PR DESCRIPTION
Docs-only. Makes "e2e runs in Docker, never natively / never in a UI window" the stated rule instead of an option.

**CLAUDE.md**
- Common-commands table now lists `pnpm test:e2e:docker` (+ `run --spec`) instead of the host `test:e2e` / `test:e2e:build` / `test:e2e:run` trio, with a paragraph saying those three are in-container primitives, not host commands.
- "Headless e2e in Docker" retitled *the only supported way*; drops the old "run native for that" advice and states the one narrow exception (a genuinely WKWebView-specific question, on explicit request, called out in the report).
- Testing → E2E bullets: "when to run" / "how to run the relevant spec(s)" rewritten around `test:e2e:docker build | run | full`.
- The multi-window bullet is now framed as a reason for the rule rather than a special case.

**.claude/skills/e2e-testing/SKILL.md** — CLAUDE.md mandates reading this before touching a spec, and its command block plus the "before committing" checklist still said `pnpm test:e2e` on the host. Both aligned.

Verified the documented phases against `e2e/e2e-docker.sh` + `e2e/docker-entrypoint.sh`: `full | build | run` exist, and `full`/`run` pass `--spec` through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
