### PR TITLE
test(palette): stop palette store state leaking between tests

### DIFF
--- a/src/features/palette/CommandPalette.test.tsx
+++ b/src/features/palette/CommandPalette.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { CommandPalette } from "./CommandPalette";
-import { usePaletteStore } from "./usePaletteStore";
+import { paletteInitial, usePaletteStore } from "./usePaletteStore";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { mockInvoke } from "@/test/invokeMock";
@@ -53,7 +53,12 @@ function resetStores() {
     activity: {},
   });
   useNavStore.setState({ intent: null });
-  usePaletteStore.setState({ open: false, query: "", activeChip: "all" });
+  // Every palette field, not a hand-picked subset: `stack` used to be omitted
+  // here, so a test that pushed a step (pick a branch, pick a reset mode) left
+  // it on the store and the next test rendered that step instead of root.
+  // Order-dependent, invisible in the default order, reproducible under
+  // `vitest --sequence.shuffle`.
+  usePaletteStore.setState(paletteInitial());
   localStorage.clear();
 }
 

--- a/src/features/palette/commands.test.ts
+++ b/src/features/palette/commands.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { buildCommands } from "./commands";
 import { useRepoStore } from "@/features/repo/useRepoStore";
-import { usePaletteStore } from "./usePaletteStore";
+import { paletteInitial, usePaletteStore } from "./usePaletteStore";
 import type { BranchInfo, StashInfo } from "@/lib/types";
 
 const mkBranch = (name: string, isHead = false, upstream: string | null = null): BranchInfo => ({
@@ -23,10 +23,15 @@ function setRepo(partial: Record<string, unknown>) {
 
 const ids = () => buildCommands().map((i) => i.id);
 
+// Two tests below swap `pushStep` for a collector via setState. That replaces
+// the store's real action for good, so capture it once and restore it per test
+// — `paletteInitial()` deliberately covers state fields, not actions.
+const realPushStep = usePaletteStore.getState().pushStep;
+
 describe("buildCommands", () => {
   beforeEach(() => {
     setRepo({});
-    usePaletteStore.setState({ open: true, stack: [{ kind: "root" }], query: "", activeChip: "all" });
+    usePaletteStore.setState({ ...paletteInitial(), open: true, pushStep: realPushStep });
   });
 
   it("always includes screen nav + fetch/refresh", () => {

--- a/src/features/palette/usePaletteStore.test.ts
+++ b/src/features/palette/usePaletteStore.test.ts
@@ -1,13 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { usePaletteStore } from "./usePaletteStore";
+import { paletteInitial, usePaletteStore } from "./usePaletteStore";
 
-const reset = () =>
-  usePaletteStore.setState({
-    open: false,
-    stack: [{ kind: "root" }],
-    query: "",
-    activeChip: "all",
-  });
+const reset = () => usePaletteStore.setState(paletteInitial());
 
 describe("usePaletteStore", () => {
   beforeEach(reset);

--- a/src/features/palette/usePaletteStore.ts
+++ b/src/features/palette/usePaletteStore.ts
@@ -23,13 +23,28 @@ interface PaletteState {
   popStep: () => void;
 }
 
-export const usePaletteStore = create<PaletteState>((set) => ({
+/**
+ * The palette's closed-at-root state.
+ *
+ * Exported so tests can reset every field at once. Listing the fields by hand
+ * in a test helper is how `stack` got left behind: `closePalette()` only clears
+ * `open`, so a test that pushed a step leaked it into whichever test ran next,
+ * which then rendered a pick step where it expected root. Add a field to
+ * `PaletteState` and it belongs here too.
+ */
+export const paletteInitial = (): Pick<
+  PaletteState,
+  "open" | "stack" | "query" | "activeChip"
+> => ({
   open: false,
   stack: [{ kind: "root" }],
   query: "",
   activeChip: "all",
-  openPalette: () =>
-    set({ open: true, stack: [{ kind: "root" }], query: "", activeChip: "all" }),
+});
+
+export const usePaletteStore = create<PaletteState>((set) => ({
+  ...paletteInitial(),
+  openPalette: () => set({ ...paletteInitial(), open: true }),
   closePalette: () => set({ open: false }),
   setQuery: (query) => set({ query }),
   setChip: (activeChip) => set({ activeChip }),


### PR DESCRIPTION
Found while verifying #71 (the UI density fix): `pnpm exec vitest run --sequence.shuffle` fails 1–2 tests in the palette suite, on a **different test each run**. The default order hides it entirely, so the suite has looked clean.

```
× renders live keymap chord chips on command rows
  TestingLibraryElementError: Unable to find an element with the placeholder text of: /Search branches/i
  … <div>Merge into current</div>   ← a pick step, where the test expects root
```

## Cause

`CommandPalette.test.tsx`'s `resetStores()` reset `open`, `query` and `activeChip` — but not `stack`. And `closePalette()` only clears `open`, which is correct for the app (`openPalette()` is what resets the stack, so no user-visible bug here). In tests nothing called `openPalette()`, so a test that pushed a step — pick a merge source, pick a reset mode — left it on the module-level store, and whichever test ran next rendered that pick step instead of root.

## Fix

Fix the class rather than the one field: `paletteInitial()` owns the closed-at-root state, the store spreads it for both its initial state and `openPalette()`, and all three palette test files reset from it. A new palette state field can no longer be silently missed by a hand-listed reset. It's a factory, not a const, so no two callers share (and potentially mutate) the same `stack` array.

`commands.test.ts` had the same leak one level up: two tests swap the store's `pushStep` action for a collector via `setState`, which replaces it for every later test in the file. It now captures the real action once and restores it per test — `paletteInitial()` deliberately covers state fields, not actions.

No production behavior change: `openPalette()` set exactly these four fields before and sets exactly them now.

## Verification

- Both seeds that reproduced it — `1786515304449` and `1786434411452` — now pass.
- 5 fresh `--sequence.shuffle` runs green, plus the default order: **517 tests**.
- `pnpm tsc --noEmit` clean.

Worth considering as a follow-up: running the suite shuffled in CI would keep this class from coming back, since default-order runs can't see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
