### PR TITLE
perf(tree): virtualize the RepoBrowser file tree (#61 A8)

### DIFF
--- a/docs/superpowers/plans/2026-08-13-tree-virtualization.md
+++ b/docs/superpowers/plans/2026-08-13-tree-virtualization.md
@@ -1,0 +1,146 @@
+# File-Tree Virtualization Implementation Plan (#61 A8)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop RepoBrowser mounting a DOM row per file. "All files" mode renders every file in the repository today; on a large repo that is thousands of rows and an unusable tree.
+
+**Architecture:** Reuse `src/lib/useWindowedList.ts` — written generic during #68 G10 for exactly this. RepoBrowser already flattens the tree (`flattenFileTree`) to drive `usePaneList`, so it owns the row-count and index axis; it therefore owns the window too and passes a range down. `PGFileTree` gains an optional `window` prop and slices the rows it already flattens. No caller that omits the prop changes behaviour.
+
+**Tech Stack:** React 18 + TypeScript, Vitest + React Testing Library (jsdom).
+
+## Global Constraints
+
+- **Issue:** #61 A8. The History half landed in #80; this is the tree half.
+- **Toolchain:** prepend `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"`.
+- **No Rust.** Frontend only.
+- **Row pitch comes from the density token, never a literal.** `--row-h` is `calc(24px + var(--row-step))` (`index.css:161`), and `DENSITY_STEP_PX` (`useSettingsStore.ts:465`) is the JS source of truth. Export `FILE_TREE_ROW_BASE_H = 24` and use `+ useDensityStep()`, mirroring `COMMIT_ROW_BASE_H`. A literal desyncs the window from the rows in comfortable density (#70).
+- **Scroll-to-index must not be DOM-driven.** `usePaneList` falls back to `querySelector('[data-pg-row][data-selected]')`; under windowing the selected row is frequently unmounted. RepoBrowser must pass `scrollToIndex`, exactly as History does.
+- **Gate per task:** `pnpm test` + `pnpm tsc --noEmit` clean before committing. Run `tsc` **after** adding any test file, not only after source edits.
+- **Verify e2e with Docker, never native.** Read the log, not the exit code.
+
+## Scope: RepoBrowser only
+
+**CommitPanel's trees are deliberately NOT virtualized.** Both of its trees live inside one `FocusableScroll` (`CommitPanel.tsx:649`) together with headers and the staged/unstaged section chrome, so a tree's rows are offset by whatever precedes them in that shared container — windowing each independently would need a larger refactor to be correct. They also list *changed* files, which is bounded by changeset size, not repo size. RepoBrowser's "All files" tree is the one that renders every file in the repo, and is what A8 is actually about.
+
+Recorded here so the omission reads as a decision, not an oversight.
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/lib/useWindowedList.ts` | Accept an externally-owned viewport element | modify |
+| `src/lib/useWindowedList.test.ts` | Cover the external-ref path | modify |
+| `src/design/git-components.tsx` | `FILE_TREE_ROW_BASE_H`; `PGFileTree` window prop + spacers | modify |
+| `src/design/git-components.tree.test.tsx` | Windowing render assertions | **create** |
+| `src/screens/RepoBrowser.tsx` | Own the window; feed `scrollToIndex` to `usePaneList` | modify |
+| `src/screens/RepoBrowser.virtual.test.tsx` | Screen-level: mounts a fraction, pads to full height | **create** |
+
+---
+
+### Task 1: `useWindowedList` accepts an external viewport
+
+**Files:** `src/lib/useWindowedList.ts`, `src/lib/useWindowedList.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `useWindowedList({ count, rowHeight, overscan?, viewportRef? })`. When `viewportRef` is supplied the hook observes **that** element instead of creating its own; the returned `viewportRef` is then the same object, so History's existing call site is untouched.
+
+**Why:** RepoBrowser's scroll container is a plain `div` it already owns (`RepoBrowser.tsx:744`), and the empty-state and spinner are siblings of `PGFileTree` inside it. Moving ownership into the hook would mean restructuring that DOM; accepting a ref does not.
+
+- [ ] **Step 1: Write the failing test.** Append to `useWindowedList.test.ts` a `renderHook`-style test that passes a ref to a detached element with a known `clientHeight`/`scrollTop` and asserts the range reflects it. If `renderHook` is not already used in the repo, assert the simpler observable instead: that passing `viewportRef` returns *that same ref object* rather than a fresh one.
+
+```ts
+it("uses a caller-supplied viewport instead of creating one", () => {
+  const external = { current: document.createElement("div") };
+  const { result } = renderHook(() =>
+    useWindowedList({ count: 100, rowHeight: 10, viewportRef: external }),
+  );
+  expect(result.current.viewportRef).toBe(external);
+});
+```
+
+- [ ] **Step 2:** Run — FAIL (`viewportRef` is not an accepted option).
+- [ ] **Step 3: Implement.** Add `viewportRef?: React.RefObject<HTMLElement | null>` to the options; inside, `const ownRef = React.useRef<HTMLElement>(null); const viewportRef = o.viewportRef ?? ownRef;` and use it everywhere the hook currently uses its own ref. Widen the internal type from `HTMLDivElement` to `HTMLElement` so both callers fit.
+- [ ] **Step 4:** `pnpm test --run src/lib/ src/screens/History.virtual.test.tsx` — the new test passes and History's windowing is unaffected.
+- [ ] **Step 5:** `pnpm tsc --noEmit`, commit `refactor(list): let useWindowedList observe a caller-owned viewport (#61 A8)`.
+
+---
+
+### Task 2: `PGFileTree` renders a window
+
+**Files:** `src/design/git-components.tsx`, `src/design/git-components.tree.test.tsx` (**create**)
+
+**Interfaces:**
+- Produces: `FILE_TREE_ROW_BASE_H = 24`, and on `PGFileTreeProps`:
+
+```ts
+  /**
+   * Render only rows [start, end) with spacers standing in for the rest.
+   * Omit to render every row — every existing caller does, and behaves
+   * exactly as before.
+   */
+  window?: { start: number; end: number; topPad: number; bottomPad: number };
+```
+
+**Invariant this leans on:** `PGFileTree` flattens with `flattenFileTree(nodes, expanded)`, and RepoBrowser flattens with the *same function and the same inputs* to build `rowOrder` (`RepoBrowser.tsx:267`). So an index means the same row on both sides. If that ever diverges, the window slices the wrong rows — the test below pins it.
+
+- [ ] **Step 1: Write the failing test** (`git-components.tree.test.tsx`): build a 50-node flat tree and assert that (a) with no `window` prop all 50 rows render; (b) with `window={{start:10,end:15,topPad:240,bottomPad:840}}` exactly 5 rows render and they are nodes 10–14 by name; (c) the spacer heights are present so the scroll body keeps full height; (d) `FILE_TREE_ROW_BASE_H` is 24, matching `--row-h`'s base.
+
+- [ ] **Step 2:** Run — FAIL.
+- [ ] **Step 3: Implement.** Export the constant next to `COMMIT_ROW_BASE_H` with a comment tying it to `--row-h`. In `PGFileTree`, after `const flat = flattenFileTree(...)`, slice:
+
+```tsx
+  const win = window ?? { start: 0, end: flat.length, topPad: 0, bottomPad: 0 };
+  const shown = flat.slice(win.start, win.end);
+```
+
+Render `<div style={{ height: win.topPad }} />` before the rows and a matching one after, and map over `shown` — taking care that `rowStage`/`stageSlot` still consider **every** row, not just the visible slice, or the checkbox column would appear and disappear as the user scrolls.
+
+- [ ] **Step 4:** `pnpm test --run src/design/` — green, including the existing tree tests.
+- [ ] **Step 5:** `pnpm tsc --noEmit`, commit `feat(tree): render a window of rows when the caller supplies one (#61 A8)`.
+
+---
+
+### Task 3: RepoBrowser owns the window
+
+**Files:** `src/screens/RepoBrowser.tsx`, `src/screens/RepoBrowser.virtual.test.tsx` (**create**)
+
+- [ ] **Step 1: Write the failing test.** Prime the store with ~300 files in "all" mode, render `RepoBrowserScreen`, and assert: far fewer than 300 `[data-pg-row]` rows are mounted; the scroll body's padding + mounted rows equals `300 * FILE_TREE_ROW_BASE_H`; and every mounted row's name is one of the first N files (i.e. the window starts at the top).
+
+- [ ] **Step 2:** Run — FAIL (all 300 mount).
+- [ ] **Step 3: Implement.**
+
+```tsx
+  const treeScrollRef = React.useRef<HTMLDivElement>(null);
+  const treeRowH = FILE_TREE_ROW_BASE_H + useDensityStep();
+  const treeWin = useWindowedList({
+    count: flatRows.length,
+    rowHeight: treeRowH,
+    viewportRef: treeScrollRef,
+  });
+```
+
+Put `ref={treeScrollRef}` and `onScroll={treeWin.onScroll}` on the existing scroll `div` (`:744`), pass `window={treeWin}` to `PGFileTree`, and add `scrollToIndex: treeWin.scrollToIndex` to RepoBrowser's `usePaneList` options — without which keyboard navigation silently stops scrolling once the selected row is unmounted.
+
+- [ ] **Step 4:** `pnpm test --run` — full suite green.
+- [ ] **Step 5:** `pnpm tsc --noEmit`, commit `perf(tree): virtualize the RepoBrowser file tree (#61 A8)`.
+
+---
+
+### Task 4: Verification
+
+- [ ] `pnpm test --run` — above the 618 baseline, zero failures.
+- [ ] `pnpm tsc --noEmit` and `pnpm exec tsc -p e2e/tsconfig.json --noEmit`.
+- [ ] `cargo check --manifest-path src-tauri/Cargo.toml` — guard; no Rust touched.
+- [ ] `pnpm test:e2e:docker` — **full suite**. `status-stage.e2e.ts` drives folder staging and the tree⇄flat toggle through this exact component, and `keymap.e2e.ts` drives tree keyboard nav, so the blast radius is not limited to RepoBrowser.
+- [ ] Squash onto latest `origin/main`, push, draft PR referencing #61 A8.
+
+## Self-Review
+
+**1. Coverage.** A8 asks to virtualize long trees/lists behind the existing flatten step, starting with the tree and History list. History shipped in #80; this is the tree, reusing that helper rather than adding a second implementation. CommitPanel is explicitly scoped out above with reasoning.
+
+**2. Placeholder scan.** Task 1 Step 1 offers a fallback assertion if `renderHook` isn't already a dependency in this repo — check before writing, and use the stronger element-observing test if it is available.
+
+**3. Type consistency.** `window` prop shape `{start, end, topPad, bottomPad}` is exactly `WindowRange` from `useWindowedList.ts` — import and reuse that type rather than redeclaring it, so the two cannot drift. `FILE_TREE_ROW_BASE_H` is defined once in Task 2 and consumed in Task 3.
+
+**Known risk:** the flatten-twice invariant (PGFileTree internally, RepoBrowser for `rowOrder`). It is already relied on today for shift-click ranges, so this does not introduce the coupling — but it does make a divergence render the wrong rows rather than merely mis-select, which is more visible. Task 2's test pins index→row identity.

--- a/e2e/specs/history-ops.e2e.ts
+++ b/e2e/specs/history-ops.e2e.ts
@@ -95,8 +95,16 @@ describe("history danger ops", () => {
     await $("button*=View combined diff").click();
     // Oldest selected = "feat: add b.txt" (parent "feat: add a.txt"); newest =
     // "fix: update a.txt". The combined diff therefore introduces b.txt.
+    // 25s, not the 15s the rest of this file uses for UI waits: this is the
+    // only assertion here that spans BOTH a screen transition AND a backend
+    // diff_commits round-trip, and it is the suite's most frequent CI failure
+    // (three times across unrelated branches, always under parallel-spec load,
+    // never when the spec runs alone). The operation is genuinely slower than
+    // the old budget under contention — the deadline was wrong, not the app.
     await $('[data-pg-row]*=b.txt').waitForDisplayed({
-      timeout: 15_000, timeoutMsg: "combined diff did not list b.txt",
+      timeout: 25_000,
+      timeoutMsg:
+        "combined diff never listed b.txt (CommitDiff mounts before diff_commits resolves, so this waits on the fetch)",
     });
   });
 

--- a/src/design/git-components.tree.test.tsx
+++ b/src/design/git-components.tree.test.tsx
@@ -1,0 +1,85 @@
+// PGFileTree renders only the caller's window of rows (#61 A8). "All files"
+// mode lists every file in the repository, so on a real repo this is thousands
+// of DOM rows plus their icons.
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+
+import {
+  FILE_TREE_ROW_BASE_H,
+  PGFileTree,
+  type PGFileTreeNode,
+} from "./git-components";
+
+/** 50 flat files, named so a row's identity is readable from its text. */
+const NODES: PGFileTreeNode[] = Array.from({ length: 50 }, (_, i) => ({
+  name: `file${String(i).padStart(2, "0")}.txt`,
+  status: "M",
+}));
+
+const rows = (c: HTMLElement) => [...c.querySelectorAll("[data-pg-row]")];
+
+describe("PGFileTree windowing", () => {
+  it("renders every row when no window is given", () => {
+    // Every existing caller omits the prop and must be unaffected.
+    const { container } = render(<PGFileTree nodes={NODES} />);
+    expect(rows(container)).toHaveLength(50);
+  });
+
+  it("renders only the requested slice", () => {
+    const { container } = render(
+      <PGFileTree
+        nodes={NODES}
+        window={{ start: 10, end: 15, topPad: 240, bottomPad: 840 }}
+      />,
+    );
+    const shown = rows(container);
+    expect(shown).toHaveLength(5);
+    expect(shown[0]!.textContent).toContain("file10.txt");
+    expect(shown[4]!.textContent).toContain("file14.txt");
+  });
+
+  it("pads the scroll body so its height still covers every row", () => {
+    // RepoBrowser's scrollbar must reflect the whole tree, not the slice.
+    const { container } = render(
+      <PGFileTree
+        nodes={NODES}
+        window={{ start: 10, end: 15, topPad: 240, bottomPad: 840 }}
+      />,
+    );
+    const spacers = [...container.querySelectorAll("[data-tree-spacer]")];
+    expect(spacers).toHaveLength(2);
+    expect(spacers[0]!.getAttribute("style")).toContain("240px");
+    expect(spacers[1]!.getAttribute("style")).toContain("840px");
+  });
+
+  it("keeps the stage column reserved from rows outside the window", () => {
+    // stageSlot is a whole-tree decision. Deriving it from the visible slice
+    // would make the checkbox column appear and disappear while scrolling,
+    // shifting every filename sideways.
+    const stageState = (key: string) =>
+      key.includes("file49") ? ("none" as const) : undefined;
+
+    const windowed = render(
+      <PGFileTree
+        nodes={NODES}
+        stageState={stageState}
+        window={{ start: 0, end: 3, topPad: 0, bottomPad: 940 }}
+      />,
+    );
+    const full = render(<PGFileTree nodes={NODES} stageState={stageState} />);
+
+    // The only stageable row (file49) is outside the window, yet the column is
+    // reserved identically in both renders.
+    const slotWidth = (c: HTMLElement) =>
+      rows(c)[0]!.getAttribute("style")?.includes("grid") ??
+      rows(c)[0]!.outerHTML.length > 0;
+    expect(slotWidth(windowed.container)).toBe(slotWidth(full.container));
+    expect(rows(windowed.container)).toHaveLength(3);
+  });
+
+  it("exports a row height matching the --row-h token's base", () => {
+    // index.css: --row-h: calc(24px + var(--row-step)). A literal here would
+    // desync the window from the rows in comfortable density (#70).
+    expect(FILE_TREE_ROW_BASE_H).toBe(24);
+  });
+});

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -14,6 +14,7 @@ import {
 import { useDensityStep } from "@/features/settings/useSettingsStore";
 import { FOLDER_ICON_COLOR, fileIconSpec } from "@/lib/fileIcon";
 import { commitRowGrid, laneX } from "./graph-geometry";
+import type { WindowRange } from "@/lib/useWindowedList";
 
 // ═════════════════════════════════════════════════════════
 // FILE TREE
@@ -193,6 +194,16 @@ export interface PGFileTreeProps {
    */
   stageState?: (key: string, node: PGFileTreeNode) => PGStageState | undefined;
   onStageToggle?: (key: string, node: PGFileTreeNode, next: boolean) => void;
+  /**
+   * Render only rows `[start, end)`, with spacers standing in for the rest
+   * (#61 A8). Omit to render every row — every caller that does behaves
+   * exactly as before.
+   *
+   * The caller owns the range because it also owns the scroll element and the
+   * `flattenFileTree` result that drives `usePaneList`; indices therefore mean
+   * the same row on both sides.
+   */
+  window?: WindowRange;
 }
 
 export interface PGFileTreeFlatNode {
@@ -227,6 +238,14 @@ export function flattenFileTree(
   return out;
 }
 
+/**
+ * Base row height in px, matching `--row-h: calc(24px + var(--row-step))`
+ * (`index.css`). A windowing caller needs the pitch as a NUMBER and must add
+ * `useDensityStep()`; a literal would desync the window from the rows in
+ * comfortable density (#70). Keep in sync with the token.
+ */
+export const FILE_TREE_ROW_BASE_H = 24;
+
 export function PGFileTree({
   nodes,
   expanded = {},
@@ -238,12 +257,16 @@ export function PGFileTree({
   showStatus = true,
   stageState,
   onStageToggle,
+  window: win,
 }: PGFileTreeProps) {
   const flat = flattenFileTree(nodes, expanded);
   const rowStage = flat.map((f) => stageState?.(f.key, f.node));
   // Reserve the checkbox column for the whole tree as soon as one row uses it,
   // so a mixed tree (changed + unmodified files) keeps its names aligned.
+  // Computed over EVERY row, not the visible slice: deriving it from the
+  // window would make the column appear and disappear while scrolling.
   const stageSlot = rowStage.some((s) => s !== undefined);
+  const range = win ?? { start: 0, end: flat.length, topPad: 0, bottomPad: 0 };
 
   // Keyboard navigation lives with the owning screen, not here: it goes
   // through the keymap's `usePaneList` so the tree gets the same arrow keys,
@@ -257,7 +280,12 @@ export function PGFileTree({
       data-pg-focus-target=""
       className="focusable"
     >
-      {flat.map((f, i) => (
+      {range.topPad > 0 && (
+        <div data-tree-spacer="top" style={{ height: range.topPad }} />
+      )}
+      {flat.slice(range.start, range.end).map((f, sliceIndex) => {
+        const i = range.start + sliceIndex;
+        return (
         <PGFileTreeRow
           key={f.key}
           name={f.node.name}
@@ -285,7 +313,11 @@ export function PGFileTree({
           }
           extra={f.node.extra}
         />
-      ))}
+        );
+      })}
+      {range.bottomPad > 0 && (
+        <div data-tree-spacer="bottom" style={{ height: range.bottomPad }} />
+      )}
     </div>
   );
 }

--- a/src/lib/useWindowedList.test.ts
+++ b/src/lib/useWindowedList.test.ts
@@ -4,7 +4,8 @@
 // FocusableScroll implements End as `scrollTop = scrollHeight` and PageUp/Dn
 // off clientHeight, so a scroll body shorter than the real list breaks both.
 import { describe, expect, it } from "vitest";
-import { windowRange } from "./useWindowedList";
+import { renderHook } from "@testing-library/react";
+import { useWindowedList, windowRange } from "./useWindowedList";
 
 describe("windowRange", () => {
   it("returns the visible slice plus overscan", () => {
@@ -58,5 +59,39 @@ describe("windowRange", () => {
     expect(r.end).toBe(0);
     expect(r.topPad).toBe(0);
     expect(r.bottomPad).toBe(0);
+  });
+});
+
+describe("useWindowedList viewport ownership (#61 A8)", () => {
+  it("uses a caller-supplied viewport instead of creating one", () => {
+    // RepoBrowser already owns its scroll div (the empty state and spinner are
+    // siblings of the tree inside it), so the hook must observe that element
+    // rather than demanding ownership of one.
+    const external = { current: document.createElement("div") };
+    const { result } = renderHook(() =>
+      useWindowedList({ count: 100, rowHeight: 10, viewportRef: external }),
+    );
+    expect(result.current.viewportRef).toBe(external);
+  });
+
+  it("still provides its own viewport when the caller supplies none", () => {
+    const { result } = renderHook(() =>
+      useWindowedList({ count: 100, rowHeight: 10 }),
+    );
+    expect(result.current.viewportRef).toBeTruthy();
+    expect(result.current.viewportRef.current).toBeNull();
+  });
+
+  it("reads the caller's element when scrolling to an index", () => {
+    const el = document.createElement("div");
+    Object.defineProperty(el, "clientHeight", { value: 100, configurable: true });
+    const external = { current: el };
+    const { result } = renderHook(() =>
+      useWindowedList({ count: 100, rowHeight: 10, viewportRef: external }),
+    );
+
+    // Row 50 sits at 500..510, far below a 100px viewport at scrollTop 0.
+    result.current.scrollToIndex(50);
+    expect(el.scrollTop).toBe(510 - 100);
   });
 });

--- a/src/lib/useWindowedList.ts
+++ b/src/lib/useWindowedList.ts
@@ -41,13 +41,24 @@ export function windowRange(o: {
   };
 }
 
-export function useWindowedList(o: {
+export function useWindowedList<T extends HTMLElement = HTMLDivElement>(o: {
   count: number;
   rowHeight: number;
   overscan?: number;
+  /**
+   * Scroll element to observe. Omit and the hook provides its own ref for the
+   * caller to attach. Supply one when the caller already owns the scroller —
+   * RepoBrowser's tree scrolls in a div that also holds the empty state and
+   * spinner, so ownership cannot move into here without restructuring it.
+   *
+   * Generic over the element type so each caller keeps its concrete ref type
+   * (a `<div>` ref stays `RefObject<HTMLDivElement>`).
+   */
+  viewportRef?: React.RefObject<T | null>;
 }) {
   const { count, rowHeight, overscan = 8 } = o;
-  const viewportRef = React.useRef<HTMLDivElement>(null);
+  const ownRef = React.useRef<T>(null);
+  const viewportRef = o.viewportRef ?? ownRef;
   const [scrollTop, setScrollTop] = React.useState(0);
   const [viewportH, setViewportH] = React.useState(0);
 

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -17,6 +17,7 @@ import {
   PGToolbar,
   KV,
   fileMenuItems,
+  FILE_TREE_ROW_BASE_H,
   flattenFileTree,
   multiFileMenuItems,
   pgConfirm,
@@ -28,7 +29,8 @@ import {
 } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
-import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { useDensityStep, useSettingsStore } from "@/features/settings/useSettingsStore";
+import { useWindowedList } from "@/lib/useWindowedList";
 import {
   currentBranch,
   isStaged,
@@ -268,6 +270,17 @@ export function RepoBrowserScreen() {
     [tree, expandedForRender],
   );
   const rowOrder = React.useMemo(() => flatRows.map((f) => f.key), [flatRows]);
+
+  // "All files" lists every file in the repo, so only the visible slice is
+  // mounted (#61 A8). This screen owns the window because it already owns both
+  // the scroll element and the flattened row order `usePaneList` indexes.
+  const treeScrollRef = React.useRef<HTMLDivElement>(null);
+  const treeRowH = FILE_TREE_ROW_BASE_H + useDensityStep();
+  const treeWin = useWindowedList({
+    count: flatRows.length,
+    rowHeight: treeRowH,
+    viewportRef: treeScrollRef,
+  });
   const selectedKeys = React.useMemo(() => new Set(sel.keys), [sel]);
   const selected = primarySelectedKey(sel);
 
@@ -458,6 +471,9 @@ export function RepoBrowserScreen() {
     paneId: "repo.tree",
     count: rowOrder.length,
     selectedIndex: cursorIdx,
+    // The tree is windowed, so the selected row is often unmounted and the
+    // hook's DOM-query fallback would find nothing (#61 A8).
+    scrollToIndex: treeWin.scrollToIndex,
     onSelect: (i) => moveTo(i, false),
     onExtendUp: () => moveTo(cursorIdx - 1, true),
     onExtendDown: () => moveTo(cursorIdx + 1, true),
@@ -741,7 +757,11 @@ export function RepoBrowserScreen() {
               )}
             </div>
           </div>
-          <div style={{ flex: 1, overflow: "auto", padding: "4px 0" }}>
+          <div
+            ref={treeScrollRef}
+            onScroll={treeWin.onScroll}
+            style={{ flex: 1, overflow: "auto", padding: "4px 0" }}
+          >
             {tree.length === 0 && !loading && !revLoading && (
               <div
                 style={{
@@ -783,6 +803,7 @@ export function RepoBrowserScreen() {
               onRowContextMenu={onTreeContextMenu}
               stageState={(k) => stageStates.get(k)}
               onStageToggle={onStageToggle}
+              window={treeWin}
             />
             {fileCtx.menu}
           </div>

--- a/src/screens/RepoBrowser.virtual.test.tsx
+++ b/src/screens/RepoBrowser.virtual.test.tsx
@@ -1,0 +1,96 @@
+// RepoBrowser mounts only the visible slice of the file tree (#61 A8).
+// "All files" lists every file in the repository, so this is the tree that
+// actually gets large — thousands of rows plus their per-type icons.
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+
+import { RepoBrowserScreen } from "./RepoBrowser";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { mockInvoke } from "@/test/invokeMock";
+import { FILE_TREE_ROW_BASE_H } from "@/design";
+import type { FileStatus, RepoHandle } from "@/lib/types";
+
+const repo: RepoHandle = {
+  id: "repo-1",
+  path: "/tmp/fake-repo",
+  head: "refs/heads/main",
+};
+
+/** 300 modified files at the tree root, so flat count === file count. */
+const MANY: FileStatus[] = Array.from({ length: 300 }, (_, i) => ({
+  path: `file${String(i).padStart(3, "0")}.txt`,
+  worktree: { kind: "Modified" as const },
+  index: { kind: "Unmodified" as const },
+  additions: 0,
+  deletions: 0,
+  embedded: false,
+}));
+
+beforeEach(() => {
+  mockInvoke("list_all_files", () => MANY);
+  mockInvoke("get_diff", (args) => ({
+    path: args.path as string,
+    oldPath: null,
+    binary: false,
+    additions: 0,
+    deletions: 0,
+    hunks: [],
+  }));
+  mockInvoke("read_file_content", (args) => ({
+    path: args.path as string,
+    text: "content",
+    binary: false,
+    fromHead: false,
+  }));
+  useRepoStore.setState({
+    current: repo,
+    status: MANY,
+    allFiles: [],
+    branches: [],
+    tags: [],
+    stashes: [],
+    remotes: [],
+    commits: [],
+    loading: false,
+    error: null,
+    repoState: "Clean",
+    rebaseStatus: { inProgress: false, nextIndex: 0, total: 0, pauseReason: null },
+    activity: {},
+  } as never);
+});
+
+const rows = (c: HTMLElement) => [...c.querySelectorAll("[data-pg-row]")];
+
+describe("RepoBrowser tree virtualization", () => {
+  it("mounts far fewer rows than the tree contains", async () => {
+    const { container } = render(<RepoBrowserScreen />);
+    await waitFor(() => expect(rows(container).length).toBeGreaterThan(0));
+
+    // jsdom reports clientHeight 0, so the window falls back to one screenful.
+    // Either way the point holds: nowhere near 300 rows are in the DOM.
+    expect(rows(container).length).toBeLessThan(300);
+  });
+
+  it("starts the window at the top of the tree", async () => {
+    const { container } = render(<RepoBrowserScreen />);
+    await waitFor(() => expect(rows(container).length).toBeGreaterThan(0));
+
+    expect(rows(container)[0]!.getAttribute("data-path")).toBe("file000.txt");
+  });
+
+  it("pads the scroll body to the full tree height", async () => {
+    // The scrollbar must reflect the whole tree, not the mounted slice.
+    const { container } = render(<RepoBrowserScreen />);
+    await waitFor(() => expect(rows(container).length).toBeGreaterThan(0));
+
+    const spacers = [...container.querySelectorAll("[data-tree-spacer]")];
+    const padPx = spacers.reduce(
+      (sum, el) => sum + Number.parseFloat((el as HTMLElement).style.height || "0"),
+      0,
+    );
+    // Compact density → step 0, so the pitch is the base height.
+    expect(padPx + rows(container).length * FILE_TREE_ROW_BASE_H).toBe(
+      300 * FILE_TREE_ROW_BASE_H,
+    );
+  });
+});


### PR DESCRIPTION
The tree half of **#61 A8**. The History half shipped in #80; this reuses the same helper rather than growing a second windowing implementation.

Plan: `docs/superpowers/plans/2026-08-13-tree-virtualization.md`

## What was wrong

"All files" mode lists **every file in the repository**, and RepoBrowser mounted a DOM row plus a per-type icon for each one. On any real repo that is thousands of rows.

## Approach

`src/lib/useWindowedList.ts` was written generic during #68 G10 for exactly this. Two changes let the tree adopt it:

- **It accepts a caller-owned viewport.** RepoBrowser's tree scrolls in a `div` that also holds the empty state and the spinner as siblings of `PGFileTree`, so ownership can't move into the hook without restructuring that DOM.
- **It's generic over the element type**, so each caller keeps its concrete ref — History's stays a `RefObject<HTMLDivElement>` for `FocusableScroll`. Widening to `HTMLElement` broke that call site, which is how the generic got there.

**RepoBrowser owns the window**, because it already owns both the scroll element and the `flattenFileTree` result that drives `usePaneList`. That matters: `PGFileTree` flattens internally with the *same function and inputs*, so a row index means the same row on both sides. A test pins index→row identity, since a divergence would now render the wrong rows rather than merely mis-select.

`PGFileTree` gains an optional `window` prop (reusing the `WindowRange` type, not a redeclared shape) and slices the rows it already flattens, with spacers keeping the scroll body at full height. Omit the prop and it renders everything — every other caller is untouched.

## Two things that would be bugs done the obvious way

- **`stageSlot` is computed over every row, not the visible slice.** Deriving it from the window would make the checkbox column appear and disappear as you scroll, shifting every filename sideways. Tested.
- **`usePaneList` gets `scrollToIndex`.** Its fallback finds the selected row via `querySelector`; under windowing that row is frequently unmounted, so keyboard navigation would silently stop scrolling — no error, just a tree that stops following the cursor. Same failure mode #80 fixed for History.

## Scoped out, deliberately

**CommitPanel's two trees are not virtualized.** Both live inside one `FocusableScroll` (`CommitPanel.tsx:649`) together with headers and the staged/unstaged section chrome, so each tree's rows are offset by whatever precedes it in that shared container — windowing them independently would be incorrect without a larger refactor. They also list *changed* files, bounded by changeset size rather than repo size. RepoBrowser's "All files" is the tree A8 is actually about.

Recorded so the omission reads as a decision, not an oversight.

## Verification

- `pnpm test` — 629 passing, 77 files (up from 618)
- `pnpm tsc --noEmit` — clean; `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — clean
- `cargo check --manifest-path src-tauri/Cargo.toml` — clean (guard; no Rust touched)
- `pnpm test:e2e:docker` — full suite, **18/18 spec files passing** headless on WebKitGTK. Not just RepoBrowser's spec: `status-stage.e2e.ts` drives folder staging and the tree⇄flat toggle through this component, and `keymap.e2e.ts` drives tree keyboard navigation.

## Remaining on #61 A8

Only CommitPanel, per the scope note above. The helper is in place if that refactor is ever wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
