### PR TITLE
fix(history): split commit detail panel so long messages scroll

### DIFF
--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -1357,6 +1357,9 @@ export function PGCommitDetail({
           alignItems: "center",
           gap: 8,
           marginBottom: 10,
+          // A 40-char sha is wider than a narrow detail column — wrap the row
+          // rather than force the whole panel to scroll sideways.
+          flexWrap: "wrap",
         }}
       >
         <span
@@ -1373,6 +1376,8 @@ export function PGCommitDetail({
             fontFamily: "var(--font-mono)",
             fontSize: "var(--fs-12)",
             color: "var(--accent)",
+            minWidth: 0,
+            wordBreak: "break-all",
           }}
         >
           {fullSha || sha}
@@ -1391,6 +1396,7 @@ export function PGCommitDetail({
           color: "var(--fg-0)",
           marginBottom: 6,
           lineHeight: 1.3,
+          overflowWrap: "anywhere",
         }}
       >
         {subject}
@@ -1401,6 +1407,9 @@ export function PGCommitDetail({
             color: "var(--fg-1)",
             fontSize: "var(--fs-12)",
             whiteSpace: "pre-wrap",
+            // Wrap unbreakable runs (URLs, long tokens) instead of forcing a
+            // horizontal scrollbar in a narrow column.
+            overflowWrap: "anywhere",
             marginBottom: 10,
             fontFamily: "var(--font-mono)",
             lineHeight: 1.5,

--- a/src/screens/History.detail.test.tsx
+++ b/src/screens/History.detail.test.tsx
@@ -1,0 +1,132 @@
+// The History detail panel must stay usable for a commit with a very long
+// message: the message scrolls in its own region, the action row stays
+// pinned outside that region, and the diff keeps its own space rather than
+// being pushed out of the fixed-height panel.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { HistoryScreen } from "./History";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { useKeymapStore, useFocusStore } from "@/features/keymap";
+import { mockInvoke } from "@/test/invokeMock";
+import type { CommitInfo, FileDiff } from "@/lib/types";
+
+const LONG_BODY = Array.from(
+  { length: 120 },
+  (_, i) => `body line ${i} — lorem ipsum dolor sit amet consectetur`,
+).join("\n");
+
+const commit: CommitInfo = {
+  oid: "a".repeat(40),
+  shortOid: "a".repeat(7),
+  summary: "commit with a novel for a body",
+  body: LONG_BODY,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 1_700_000_000,
+  parents: ["b".repeat(40)],
+  refs: [],
+};
+
+const fileDiff: FileDiff = {
+  path: "src/foo.ts",
+  oldPath: null,
+  binary: false,
+  additions: 1,
+  deletions: 0,
+  hunks: [
+    {
+      header: "@@ -0,0 +1,1 @@",
+      oldStart: 0,
+      oldLines: 0,
+      newStart: 1,
+      newLines: 1,
+      lines: [
+        {
+          kind: { kind: "Addition" },
+          oldLineno: null,
+          newLineno: 1,
+          content: "added line\n",
+        },
+      ],
+    },
+  ],
+};
+
+const setLayout = (layout: "below" | "beside") =>
+  localStorage.setItem("pg-history-diff-layout", layout);
+
+describe("History detail panel with a long commit message", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useRepoStore.setState({
+      current: { id: "r1", path: "/repo", head: "main" },
+      commits: [commit],
+      searchResults: null,
+      searching: false,
+      searchCommits: async () => {},
+      branches: [],
+      status: [],
+      loading: false,
+    } as never);
+    useNavStore.setState({ intent: null });
+    useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+    useKeymapStore.getState().setPreset("rider");
+    useFocusStore.setState({
+      focused: null,
+      panes: new Map(),
+      order: [],
+      barId: null,
+      pendingContentFocus: false,
+    });
+    mockInvoke("diff_commit", () => [fileDiff]);
+  });
+
+  it("scrolls the message in the below layout and keeps the diff beside it", async () => {
+    setLayout("below");
+    render(<HistoryScreen />);
+
+    const message = await screen.findByTestId("history-detail-message");
+    // Own scroll region — a 120-line body scrolls here, it does not grow the panel.
+    expect(getComputedStyle(message).overflow).toBe("auto");
+    expect(message.textContent).toContain("body line 119");
+
+    // Diff renders as a sibling of the message column, not stacked under it.
+    await waitFor(() => {
+      expect(screen.getByText(/@@ -0,0 \+1,1 @@/)).toBeInTheDocument();
+    });
+    const diffRow = document.querySelector('[data-path="src/foo.ts"]');
+    expect(diffRow).not.toBeNull();
+    expect(message.contains(diffRow)).toBe(false);
+
+    // Actions sit outside the scrolling message, so they can't scroll away.
+    const cherryPick = screen.getByTestId("commit-cherry-pick");
+    expect(message.contains(cherryPick)).toBe(false);
+
+    // Both live inside the detail panel.
+    const detail = screen.getByTestId("history-detail");
+    expect(detail.contains(message)).toBe(true);
+    expect(detail.contains(diffRow)).toBe(true);
+    expect(detail.contains(cherryPick)).toBe(true);
+  });
+
+  it("caps and scrolls the message in the beside layout", async () => {
+    setLayout("beside");
+    render(<HistoryScreen />);
+
+    const message = await screen.findByTestId("history-detail-message");
+    expect(getComputedStyle(message).overflow).toBe("auto");
+    // Capped block wrapping the message + actions leaves room for the diff.
+    const capped = message.parentElement as HTMLElement;
+    expect(capped.style.maxHeight).toBe("50%");
+    expect(capped.contains(screen.getByTestId("commit-cherry-pick"))).toBe(true);
+
+    await waitFor(() => {
+      expect(screen.getByText(/@@ -0,0 \+1,1 @@/)).toBeInTheDocument();
+    });
+    expect(message.contains(document.querySelector('[data-path="src/foo.ts"]'))).toBe(
+      false,
+    );
+  });
+});

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -137,6 +137,12 @@ export function HistoryScreen() {
     max: 800,
     storageKey: "pg-history-diff-h",
   });
+  // Width of the message column inside the below-layout detail panel.
+  const messagePane = usePaneWidth(340, {
+    min: 220,
+    max: 640,
+    storageKey: "pg-history-detail-msg-w",
+  });
   const [diffLayout, setDiffLayout] = React.useState<DiffLayout>(() => {
     try {
       return localStorage.getItem(DIFF_LAYOUT_KEY) === "beside" ? "beside" : "below";
@@ -588,39 +594,102 @@ export function HistoryScreen() {
       : `(root) → ${current.shortOid}`
     : "";
 
+  // Message + actions, sized by whoever mounts it. The message scrolls on its
+  // own and the action row is pinned below it, so an arbitrarily long commit
+  // body can never push the buttons — or the diff — out of the panel.
+  const messageBlock = current && (
+    <>
+      <FocusableScroll
+        ariaLabel="Commit message"
+        testId="history-detail-message"
+        style={{ flex: 1, minHeight: 0 }}
+      >
+        <PGCommitDetail
+          sha={current.shortOid}
+          fullSha={current.oid}
+          subject={current.summary}
+          body={current.body ?? undefined}
+          author={current.author || "unknown"}
+          email={current.email}
+          date={relativeTime(current.timestamp)}
+          parents={current.parents.map(shortSha)}
+        />
+      </FocusableScroll>
+      <CommitActionRow commit={current} />
+    </>
+  );
+
+  const diffBlock = (
+    <CommitDiffPanel
+      diffs={inlineDiffs}
+      loading={inlineLoading}
+      error={inlineError}
+      header={diffHeader}
+      paneIdPrefix="history.diff"
+    />
+  );
+
   const detailContent = multiSelected ? (
     <MultiCommitDetail oids={sel.keys} onCombinedDiff={activateSelection} />
   ) : current ? (
-    <>
-      <PGCommitDetail
-        sha={current.shortOid}
-        fullSha={current.oid}
-        subject={current.summary}
-        body={current.body ?? undefined}
-        author={current.author || "unknown"}
-        email={current.email}
-        date={relativeTime(current.timestamp)}
-        parents={current.parents.map(shortSha)}
-      />
-      <CommitActionRow commit={current} />
-      <div
-        style={{
-          borderTop: "1px solid var(--border-0)",
-          flex: 1,
-          minHeight: 0,
-          display: "flex",
-          flexDirection: "column",
-        }}
-      >
-        <CommitDiffPanel
-          diffs={inlineDiffs}
-          loading={inlineLoading}
-          error={inlineError}
-          header={diffHeader}
-          paneIdPrefix="history.diff"
-        />
+    diffLayout === "below" ? (
+      // Bottom panel is wide and short: message beside the diff, each with its
+      // own scroll, so neither one starves the other vertically.
+      <div style={{ flex: 1, minHeight: 0, minWidth: 0, display: "flex" }}>
+        <div
+          style={{
+            width: messagePane.width,
+            flexShrink: 0,
+            minWidth: 0,
+            minHeight: 0,
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          {messageBlock}
+        </div>
+        <PGResizeHandle side="right" onDrag={(d) => messagePane.resize(d)} />
+        <div
+          style={{
+            flex: 1,
+            minWidth: 0,
+            minHeight: 0,
+            display: "flex",
+            flexDirection: "column",
+            borderLeft: "1px solid var(--border-0)",
+          }}
+        >
+          {diffBlock}
+        </div>
       </div>
-    </>
+    ) : (
+      // Side panel is narrow and tall: keep the stack, but cap the message at
+      // half the height and let it scroll rather than overflow.
+      <>
+        <div
+          style={{
+            flexShrink: 0,
+            maxHeight: "50%",
+            minHeight: 0,
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          {messageBlock}
+        </div>
+        <div
+          style={{
+            borderTop: "1px solid var(--border-0)",
+            flex: 1,
+            minHeight: 0,
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          {diffBlock}
+        </div>
+      </>
+    )
   ) : null;
 
   const showDetail = multiSelected || !!current;
@@ -906,9 +975,12 @@ function CommitActionRow({ commit }: { commit: CommitInfo }) {
     store.getState().revert(commit.oid);
   }, [commit, store]);
   return (
+    // Pinned below the scrolling message, never scrolled out of reach.
     <div
       style={{
-        padding: "0 12px 10px",
+        padding: "8px 12px 10px",
+        borderTop: "1px solid var(--border-0)",
+        flexShrink: 0,
         display: "flex",
         gap: 4,
         flexWrap: "wrap",


### PR DESCRIPTION
## Problem

Clicking a commit in History opened a bottom detail panel that stacked commit message → action row → diff in one fixed-height flex column. Flex items don't shrink below their content height, so a long commit body squeezed the diff pane to nothing and spilled past the bottom of the panel, with nothing scrollable. The panel became unusable.

## Fix

- **Below (bottom) layout** — split horizontally: resizable message column on the left (min 220 / max 640, persisted as `pg-history-detail-msg-w`), `CommitDiffPanel` on the right. The message body scrolls in its own `FocusableScroll`; `CommitActionRow` is pinned beneath it, outside the scroll, so the buttons can never scroll out of reach.
- **Beside (side) layout** — a 440px column can't hold two columns, so it keeps the vertical stack, but message + actions are capped at 50% height with their own scroll. The diff always keeps its half.
- `PGCommitDetail` — header row wraps and the sha / subject / body break long tokens, so a narrow column doesn't scroll sideways.

`MultiCommitDetail` was already scroll-safe and is unchanged.

## Verification

- `pnpm vitest run` — 631 tests / 78 files pass, including new `src/screens/History.detail.test.tsx` (120-line commit body, both layouts: message region scrolls, actions and diff live outside it).
- `pnpm tsc --noEmit` — clean.
- `pnpm test:e2e:docker build` then `run --spec e2e/specs/history-diff.e2e.ts --spec e2e/specs/history-ops.e2e.ts` — 10/10 pass headless (WebKitGTK), covering the moved cherry-pick button.

Note: jsdom does no layout, so the component test pins the structure (own scroll regions, siblings not ancestors) rather than measured overflow; the geometry itself is covered by the flex rules and the Docker e2e run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)