### PR TITLE
fix(git): make WSL /mnt/c repositories openable (#83)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,10 +212,15 @@ git/
 │                ConflictSides, CommitOptions, StashSaveOptions, TagTarget, ResetMode, etc.
 ├── libgit2.rs   Libgit2Backend — active impl, most ops real
 ├── cli.rs       CliBackend — stub for ops libgit2 handles poorly (LFS, creds, complex merges)
+├── ownership.rs libgit2's dubious-ownership refusal (GIT_EOWNER, git's
+│                CVE-2022-24765 check — the WSL `/mnt/c` case): error mapping,
+│                RepoPresence probe (Present/Absent/Refused — NEVER infer
+│                "no repo" from a failed open), non-opening repo_root_for
+│                walk, and the global `safe.directory` writer
 └── signature.rs Author/committer signature helpers
 commands/        Thin Tauri handlers, one file per area:
-├── repo.rs        open_repo, get_status, list_all_files, read_file_content,
-│                  append_gitignore, open_in_editor
+├── repo.rs        open_repo, trust_repo_path, get_status, list_all_files,
+│                  read_file_content, append_gitignore, open_in_editor
 ├── cli.rs         take_launch_intent, cli_shim_status, install_cli_shim
 ├── commits.rs     get_log, commit, file_history
 ├── diff.rs        get_diff, stage/unstage/discard_paths, stage/unstage/discard_hunk,

--- a/docs/superpowers/plans/2026-08-13-wsl-dubious-ownership.md
+++ b/docs/superpowers/plans/2026-08-13-wsl-dubious-ownership.md
@@ -1,0 +1,1175 @@
+# Dubious repository ownership (WSL / `/mnt/c`) — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a repository on a filesystem libgit2 reports as owned by another user (the WSL `/mnt/c` case) openable from inside the app, via a per-repository `safe.directory` exception the user explicitly confirms.
+
+**Architecture:** A new `AppError::DubiousOwnership` names the condition so the frontend can narrow on it; a new `git/ownership.rs` module owns everything about it (error mapping, repository-presence probing, root discovery, the `safe.directory` writer); `useRepoStore.openRepo` catches the variant, confirms with the user, writes the exception, and retries — which covers every entry point (Welcome, recents, CLI launch, palette) in one place. Four existing call sites that infer "no repository here" from a failed open are corrected to distinguish "refused" from "absent".
+
+**Tech Stack:** Rust + git2 0.20.4 (libgit2 1.9.2), Tauri 2 commands, React + Zustand, vitest/RTL, `cargo test`.
+
+**Design doc:** `docs/superpowers/specs/2026-08-13-wsl-dubious-ownership-design.md`
+**Issue:** [#83](https://github.com/jonassaa/platypusgit/issues/83)
+
+## Global Constraints
+
+- Every IPC-crossing fn returns `AppResult<T>`; no `unwrap`/`panic` in commands. Add `AppError` variants rather than stringifying.
+- A new Rust `AppError` variant updates `src/lib/errors.ts` **in the same commit**. Wire format is `{ kind, message }`.
+- libgit2 1.9.2 matches `safe.directory` **exactly** (or the literal `*`); no `dir/*` glob. The key is the **working directory**, read from **global** config only.
+- Never call `git2::opts::set_verify_owner_validation(false)` in app code. It is process-global and disables CVE-2022-24765 protection for every repository.
+- Never call `window.confirm`/`window.prompt` — use `pgConfirm` from `@/design`.
+- git2 work inside Tauri commands goes through `tokio::task::spawn_blocking`.
+- Frontend never calls `invoke()` directly — add a typed wrapper in `src/lib/tauri.ts`.
+- New `GitBackend` trait method gets a `CliBackend` stub returning `AppError::NotImplemented`.
+- Run cargo/pnpm with `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"`.
+
+## File Structure
+
+**Create:**
+- `src-tauri/src/git/ownership.rs` — the whole ownership concern: `map_open_error`, `RepoPresence`/`repo_presence`, `repo_root_for`, `add_safe_directory`, `trust_path`.
+- `src-tauri/tests/dubious_ownership.rs` — its integration tests (own binary, because two of them redirect libgit2's global-config search path, which is process-global).
+- `src/features/repo/ownership.ts` — the frontend half: `confirmTrust` (the `pgConfirm` wrapper) plus the user-facing copy.
+- `src/features/repo/useRepoStore.ownership.test.ts` — store trust-and-retry tests.
+
+**Modify:**
+- `src-tauri/src/error.rs` — `DubiousOwnership(String)` variant.
+- `src-tauri/src/git/mod.rs` — declare `ownership`, add `trust_path` to the trait.
+- `src-tauri/src/git/libgit2.rs` — use `map_open_error` in `open`/`init`; fix the nested-repo probe and the init guard; implement `trust_path`.
+- `src-tauri/src/git/cli.rs` — `trust_path` stub.
+- `src-tauri/src/commands/repo.rs` — `trust_repo_path` command.
+- `src-tauri/src/commands/create.rs` — clone-target guard.
+- `src-tauri/src/cli.rs` — `resolve_repo_root` ancestor fallback.
+- `src-tauri/src/lib.rs` — register `trust_repo_path`.
+- `src/lib/errors.ts` — union member, `isDubiousOwnershipError`, `DUBIOUS_OWNERSHIP_HELP`.
+- `src/lib/tauri.ts` — `trustRepoPath` wrapper.
+- `src/features/repo/useRepoStore.ts` — trust-and-retry in `openRepo`.
+- `src/AppShell.tsx` — banner help text for the new kind.
+
+---
+
+### Task 1: Name the condition — `DubiousOwnership` + open/init mapping
+
+**Files:**
+- Modify: `src-tauri/src/error.rs`
+- Create: `src-tauri/src/git/ownership.rs`
+- Modify: `src-tauri/src/git/mod.rs` (add `pub mod ownership;`)
+- Modify: `src-tauri/src/git/libgit2.rs` (`open`, `init`)
+- Create: `src-tauri/tests/dubious_ownership.rs`
+
+**Interfaces:**
+- Produces: `AppError::DubiousOwnership(String)`; `ownership::map_open_error(path: &Path, e: &git2::Error) -> AppError`; `ownership::canonical_string(path: &Path) -> String`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src-tauri/tests/dubious_ownership.rs`:
+
+```rust
+//! libgit2 refuses to open a repository whose workdir is owned by another
+//! user (CVE-2022-24765's check, `GIT_EOWNER`). Under WSL every repo on a
+//! `/mnt/c` drvfs mount can trip it. These tests pin the error mapping, the
+//! `safe.directory` writer that remedies it, and the presence probe that
+//! keeps "refused" from reading as "absent".
+//!
+//! The refusal itself cannot be provoked here — it needs a directory owned by
+//! a different uid. So the mapping is tested against a synthetic `GIT_EOWNER`
+//! error, which is exactly the shape libgit2 returns.
+
+mod support;
+
+use std::path::Path;
+
+use git2::{ErrorClass, ErrorCode};
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::ownership;
+
+#[test]
+fn eowner_maps_to_dubious_ownership() {
+    let err = git2::Error::new(
+        ErrorCode::Owner,
+        ErrorClass::Config,
+        "repository path '/mnt/c/dev/reponame' is not owned by current user",
+    );
+    let mapped = ownership::map_open_error(Path::new("/mnt/c/dev/reponame"), &err);
+    match mapped {
+        AppError::DubiousOwnership(p) => assert!(p.ends_with("reponame"), "got {p}"),
+        other => panic!("expected DubiousOwnership, got {other:?}"),
+    }
+}
+
+#[test]
+fn missing_repo_still_maps_to_not_a_repo() {
+    let err = git2::Error::new(ErrorCode::NotFound, ErrorClass::Repository, "not found");
+    assert!(matches!(
+        ownership::map_open_error(Path::new("/tmp/nope"), &err),
+        AppError::NotARepo(_)
+    ));
+}
+
+#[test]
+fn other_failures_stay_generic() {
+    let err = git2::Error::new(ErrorCode::Invalid, ErrorClass::Repository, "broken");
+    assert!(matches!(
+        ownership::map_open_error(Path::new("/tmp/x"), &err),
+        AppError::Git(_)
+    ));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test dubious_ownership
+```
+
+Expected: FAIL — `unresolved import platypusgit_lib::git::ownership`.
+
+- [ ] **Step 3: Add the error variant**
+
+In `src-tauri/src/error.rs`, after `EmbeddedRepo`:
+
+```rust
+    /// libgit2 refused to open a repository because its working directory is
+    /// owned by a different user (`GIT_EOWNER`, the CVE-2022-24765 check).
+    /// Carries the canonicalised path, which is the exact string a
+    /// `safe.directory` exception must contain.
+    #[error("repository is owned by another user: {0}")]
+    DubiousOwnership(String),
+```
+
+- [ ] **Step 4: Write the module**
+
+Create `src-tauri/src/git/ownership.rs`:
+
+```rust
+//! Everything about libgit2's "dubious ownership" refusal.
+//!
+//! libgit2 1.9.2 validates that a repository's workdir (and gitdir, and any
+//! gitlink) is owned by the current user before opening it — git's
+//! CVE-2022-24765 check. On a WSL `/mnt/c` drvfs mount the reported owner
+//! routinely disagrees with the WSL uid even for the user's own repository,
+//! so the refusal is a normal condition here, not an attack.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::{AppError, AppResult};
+
+/// The path as libgit2 would spell it: symlinks resolved, no trailing slash,
+/// no `.` or `..`. `safe.directory` matching is exact, so the string we hand
+/// the user to trust must be the resolved one. Falls back to the input when
+/// the path cannot be canonicalised (it may not exist).
+pub fn canonical_string(path: &Path) -> String {
+    std::fs::canonicalize(path)
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .to_string()
+}
+
+/// Classify a failure from `Repository::open`.
+///
+/// `ErrorCode::Owner` is the one that must not fall through to the generic
+/// arm: it is remediable, and only a distinct variant lets the frontend offer
+/// the remedy instead of printing libgit2's sentence.
+pub fn map_open_error(path: &Path, e: &git2::Error) -> AppError {
+    match e.code() {
+        git2::ErrorCode::Owner => AppError::DubiousOwnership(canonical_string(path)),
+        git2::ErrorCode::NotFound => AppError::NotARepo(path.display().to_string()),
+        _ => AppError::Git(e.message().to_string()),
+    }
+}
+```
+
+In `src-tauri/src/git/mod.rs`, next to the other `pub mod` lines:
+
+```rust
+pub mod ownership;
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --test dubious_ownership
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 6: Route `open` and `init` through it**
+
+In `src-tauri/src/git/libgit2.rs`, replace the inline mapping in `GitBackend::open`:
+
+```rust
+        let repo = Repository::open(path).map_err(|e| ownership::map_open_error(path, &e))?;
+```
+
+`Repository::init` finishes by opening what it created, so it can return
+`GIT_EOWNER` too. In `GitBackend::init`, wherever `Repository::init_opts`/
+`Repository::init` results are mapped, use the same helper so a WSL init
+reports the actionable variant rather than a raw git string. Add the import:
+
+```rust
+use crate::git::ownership;
+```
+
+- [ ] **Step 7: Verify nothing regressed**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+Expected: all existing suites pass (`libgit2_smoke`, `clone_init`, `embedded_repo`, …).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src-tauri/src/error.rs src-tauri/src/git/ownership.rs src-tauri/src/git/mod.rs src-tauri/src/git/libgit2.rs src-tauri/tests/dubious_ownership.rs
+git commit -m "feat(git): name libgit2's dubious-ownership refusal as its own error"
+```
+
+---
+
+### Task 2: The remedy — `safe.directory` writer + `trust_repo_path` command
+
+**Files:**
+- Modify: `src-tauri/src/git/ownership.rs`
+- Modify: `src-tauri/src/git/mod.rs` (trait method)
+- Modify: `src-tauri/src/git/libgit2.rs` (impl), `src-tauri/src/git/cli.rs` (stub)
+- Modify: `src-tauri/src/commands/repo.rs`, `src-tauri/src/lib.rs`
+- Test: `src-tauri/tests/dubious_ownership.rs`
+
+**Interfaces:**
+- Consumes: `ownership::canonical_string` (Task 1).
+- Produces: `ownership::add_safe_directory(cfg: &mut git2::Config, path: &str) -> AppResult<bool>` (true = written, false = already trusted); `ownership::trust_path(path: &Path) -> AppResult<()>`; `GitBackend::trust_path(&self, path: &Path) -> AppResult<()>`; command `trust_repo_path { path: String } -> ()`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src-tauri/tests/dubious_ownership.rs`:
+
+```rust
+use std::sync::Mutex;
+
+/// libgit2's config search path is process-global; serialise the tests that
+/// move it so they cannot see each other's temp home.
+static SEARCH_PATH: Mutex<()> = Mutex::new(());
+
+/// Values of every `safe.directory` entry in `file`, in order.
+fn safe_dirs(file: &Path) -> Vec<String> {
+    let cfg = git2::Config::open(file).unwrap();
+    let mut out = Vec::new();
+    let mut entries = cfg.entries(Some("safe.directory")).unwrap();
+    while let Some(entry) = entries.next() {
+        let entry = entry.unwrap();
+        out.push(entry.value().unwrap_or_default().to_string());
+    }
+    out
+}
+
+#[test]
+fn add_safe_directory_writes_the_exact_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("gitconfig");
+    std::fs::write(&file, "").unwrap();
+    let mut cfg = git2::Config::open(&file).unwrap();
+
+    assert!(ownership::add_safe_directory(&mut cfg, "/mnt/c/dev/reponame").unwrap());
+
+    assert_eq!(safe_dirs(&file), vec!["/mnt/c/dev/reponame".to_string()]);
+}
+
+#[test]
+fn add_safe_directory_is_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("gitconfig");
+    std::fs::write(&file, "").unwrap();
+    let mut cfg = git2::Config::open(&file).unwrap();
+
+    assert!(ownership::add_safe_directory(&mut cfg, "/mnt/c/dev/reponame").unwrap());
+    // Second call reports "already trusted" and writes nothing.
+    assert!(!ownership::add_safe_directory(&mut cfg, "/mnt/c/dev/reponame").unwrap());
+
+    assert_eq!(safe_dirs(&file).len(), 1);
+}
+
+#[test]
+fn add_safe_directory_keeps_existing_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("gitconfig");
+    std::fs::write(&file, "[safe]\n\tdirectory = /home/me/other\n").unwrap();
+    let mut cfg = git2::Config::open(&file).unwrap();
+
+    ownership::add_safe_directory(&mut cfg, "/mnt/c/dev/reponame").unwrap();
+
+    assert_eq!(
+        safe_dirs(&file),
+        vec![
+            "/home/me/other".to_string(),
+            "/mnt/c/dev/reponame".to_string()
+        ]
+    );
+}
+
+#[test]
+fn add_safe_directory_accepts_a_trailing_slash_match() {
+    // libgit2 normalises config values to a trailing slash before comparing,
+    // so `/x/y/` already trusts `/x/y` — do not add a duplicate.
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("gitconfig");
+    std::fs::write(&file, "[safe]\n\tdirectory = /mnt/c/dev/reponame/\n").unwrap();
+    let mut cfg = git2::Config::open(&file).unwrap();
+
+    assert!(!ownership::add_safe_directory(&mut cfg, "/mnt/c/dev/reponame").unwrap());
+    assert_eq!(safe_dirs(&file).len(), 1);
+}
+
+#[test]
+fn add_safe_directory_respects_a_wildcard() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("gitconfig");
+    std::fs::write(&file, "[safe]\n\tdirectory = *\n").unwrap();
+    let mut cfg = git2::Config::open(&file).unwrap();
+
+    assert!(!ownership::add_safe_directory(&mut cfg, "/mnt/c/dev/reponame").unwrap());
+}
+
+#[test]
+fn trust_path_writes_to_the_global_config() {
+    let _lock = SEARCH_PATH.lock().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    // Redirect libgit2's *global* config search at this temp home so the test
+    // cannot touch the developer's real ~/.gitconfig.
+    unsafe {
+        git2::opts::set_search_path(git2::ConfigLevel::Global, home.path()).unwrap();
+    }
+
+    let repo = tempfile::tempdir().unwrap();
+    ownership::trust_path(repo.path()).unwrap();
+
+    let written = safe_dirs(&home.path().join(".gitconfig"));
+    let expected = ownership::canonical_string(repo.path());
+    assert_eq!(written, vec![expected]);
+
+    unsafe {
+        git2::opts::reset_search_path(git2::ConfigLevel::Global).unwrap();
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --test dubious_ownership
+```
+
+Expected: FAIL — `add_safe_directory` / `trust_path` not found.
+
+- [ ] **Step 3: Implement the writer**
+
+Append to `src-tauri/src/git/ownership.rs`:
+
+```rust
+/// True when `value` (a raw `safe.directory` config value) already trusts
+/// `path`. Mirrors libgit2's `validate_ownership_cb`: the literal `*` trusts
+/// everything, and a path is compared after normalising to a trailing slash.
+fn value_trusts(value: &str, path: &str) -> bool {
+    if value == "*" {
+        return true;
+    }
+    let strip = |s: &str| s.trim_end_matches('/').to_string();
+    !value.is_empty() && strip(value) == strip(path)
+}
+
+/// Add `path` to `cfg`'s `safe.directory` multivar, exactly as
+/// `git config --global --add safe.directory <path>` would.
+///
+/// Returns `false` when an entry already covers the path — re-trusting is a
+/// no-op rather than a growing pile of duplicates, because the user can reach
+/// this from any entry point and the same repo may be opened many times.
+pub fn add_safe_directory(cfg: &mut git2::Config, path: &str) -> AppResult<bool> {
+    let mut entries = cfg.entries(Some("safe.directory"))?;
+    while let Some(entry) = entries.next() {
+        let entry = entry?;
+        if value_trusts(entry.value().unwrap_or_default(), path) {
+            return Ok(false);
+        }
+    }
+    // `set_multivar` with a regexp that matches nothing appends rather than
+    // replacing — the multivar equivalent of `--add`.
+    cfg.set_multivar("safe.directory", "^$", path)?;
+    Ok(true)
+}
+
+/// The global config file, creating it when the user has none yet.
+///
+/// Writes must land in the *global* level specifically: libgit2 reads
+/// `safe.directory` from global config only, never from the repository's own
+/// config (it cannot — the repository is not open yet).
+fn global_config() -> AppResult<git2::Config> {
+    if let Ok(cfg) = git2::Config::open_default().and_then(|c| c.open_level(git2::ConfigLevel::Global))
+    {
+        return Ok(cfg);
+    }
+    let path = git2::Config::find_global().or_else(|_| {
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .ok_or_else(|| AppError::Internal("no home directory to write git config to".into()))?;
+        Ok::<PathBuf, AppError>(PathBuf::from(home).join(".gitconfig"))
+    })?;
+    if !path.exists() {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&path, "")?;
+    }
+    Ok(git2::Config::open(&path)?)
+}
+
+/// Trust `path` for this user, so libgit2 will open it despite the ownership
+/// mismatch. The user-facing half of the CVE-2022-24765 escape hatch — always
+/// call it behind an explicit confirmation.
+pub fn trust_path(path: &Path) -> AppResult<()> {
+    let canonical = canonical_string(path);
+    let mut cfg = global_config()?;
+    add_safe_directory(&mut cfg, &canonical)?;
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --test dubious_ownership
+```
+
+Expected: 9 passed.
+
+- [ ] **Step 5: Expose it through the backend trait and a command**
+
+`src-tauri/src/git/mod.rs`, in the trait next to `init`:
+
+```rust
+    /// Record `path` in the user's global `safe.directory` list so libgit2
+    /// will open it despite an ownership mismatch. Call only after the user
+    /// has explicitly confirmed — this is a security exception.
+    fn trust_path(&self, path: &Path) -> AppResult<()>;
+```
+
+`src-tauri/src/git/libgit2.rs`, in `impl GitBackend for Libgit2Backend`:
+
+```rust
+    fn trust_path(&self, path: &Path) -> AppResult<()> {
+        ownership::trust_path(path)
+    }
+```
+
+`src-tauri/src/git/cli.rs`, in `impl GitBackend for CliBackend`:
+
+```rust
+    fn trust_path(&self, _path: &Path) -> AppResult<()> {
+        Err(AppError::NotImplemented)
+    }
+```
+
+`src-tauri/src/commands/repo.rs`:
+
+```rust
+/// Add `path` to the user's global `safe.directory` list. Invoked only from
+/// the confirmation the `DubiousOwnership` error raises.
+#[tauri::command]
+pub async fn trust_repo_path(state: State<'_, AppState>, path: String) -> AppResult<()> {
+    let backend = state.backend.clone();
+    let path_buf = PathBuf::from(path);
+    tokio::task::spawn_blocking(move || backend.trust_path(&path_buf))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+```
+
+`src-tauri/src/lib.rs`, in `invoke_handler![…]`, next to `open_repo`:
+
+```rust
+            commands::repo::trust_repo_path,
+```
+
+- [ ] **Step 6: Verify it compiles and the suite is green**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/src src-tauri/tests/dubious_ownership.rs
+git commit -m "feat(git): add a confirmed safe.directory exception for refused repos"
+```
+
+---
+
+### Task 3: Stop mistaking "refused" for "absent"
+
+**Files:**
+- Modify: `src-tauri/src/git/ownership.rs`, `src-tauri/src/git/libgit2.rs`, `src-tauri/src/commands/create.rs`, `src-tauri/src/cli.rs`
+- Test: `src-tauri/tests/dubious_ownership.rs`
+
+**Interfaces:**
+- Consumes: `ownership::map_open_error` (Task 1).
+- Produces: `ownership::RepoPresence { Present, Absent, Refused }`; `ownership::repo_presence(path: &Path) -> RepoPresence`; `ownership::repo_root_for(path: &Path) -> Option<PathBuf>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src-tauri/tests/dubious_ownership.rs`:
+
+```rust
+use platypusgit_lib::git::ownership::RepoPresence;
+use support::TempRepo;
+
+#[test]
+fn repo_presence_finds_a_real_repo() {
+    let tr = TempRepo::with_initial_commit("hi\n");
+    assert_eq!(ownership::repo_presence(tr.path()), RepoPresence::Present);
+}
+
+#[test]
+fn repo_presence_reports_a_plain_directory_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    assert_eq!(ownership::repo_presence(dir.path()), RepoPresence::Absent);
+}
+
+#[test]
+fn repo_root_for_walks_up_from_a_subdirectory() {
+    let tr = TempRepo::with_initial_commit("hi\n");
+    let nested = tr.path().join("a/b/c");
+    std::fs::create_dir_all(&nested).unwrap();
+
+    let found = ownership::repo_root_for(&nested).expect("root");
+    assert_eq!(
+        ownership::canonical_string(&found),
+        ownership::canonical_string(tr.path())
+    );
+}
+
+#[test]
+fn repo_root_for_returns_none_outside_a_repo() {
+    let dir = tempfile::tempdir().unwrap();
+    assert!(ownership::repo_root_for(dir.path()).is_none());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --test dubious_ownership
+```
+
+Expected: FAIL — `RepoPresence` / `repo_presence` / `repo_root_for` not found.
+
+- [ ] **Step 3: Implement the probe and the walk**
+
+Append to `src-tauri/src/git/ownership.rs`:
+
+```rust
+/// What is actually at a path, for the call sites that only need to know
+/// whether a repository is there.
+///
+/// The distinction matters: `Repository::open(p).is_ok()` answers "no" both
+/// when there is no repository *and* when there is one we are not allowed to
+/// open. Collapsing those is what makes an ownership refusal quietly disable
+/// the embedded-repo and clone-target guards.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepoPresence {
+    /// A repository is there and openable.
+    Present,
+    /// Nothing repository-shaped is there.
+    Absent,
+    /// A repository is there, but libgit2 refused it on ownership grounds.
+    Refused,
+}
+
+impl RepoPresence {
+    /// True when a repository exists at the path, openable or not. Guards
+    /// that refuse to act on top of an existing repository want this, not
+    /// `Present` — a refused repository is still a repository.
+    pub fn exists(self) -> bool {
+        matches!(self, RepoPresence::Present | RepoPresence::Refused)
+    }
+}
+
+/// Probe `path` for a repository without walking up to its ancestors.
+pub fn repo_presence(path: &Path) -> RepoPresence {
+    match git2::Repository::open(path) {
+        Ok(_) => RepoPresence::Present,
+        Err(e) if e.code() == git2::ErrorCode::Owner => RepoPresence::Refused,
+        Err(_) => RepoPresence::Absent,
+    }
+}
+
+/// The repository root at or above `path`, found without opening anything.
+///
+/// `Repository::discover` would be the obvious tool, but it opens what it
+/// finds and therefore fails on exactly the repositories this module exists
+/// for. Looking for `.git` (a directory for a normal repo, a file for a
+/// worktree or submodule) needs no open at all.
+pub fn repo_root_for(path: &Path) -> Option<PathBuf> {
+    let start = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    start
+        .ancestors()
+        .find(|dir| dir.join(".git").exists())
+        .map(PathBuf::from)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --test dubious_ownership
+```
+
+Expected: 13 passed.
+
+- [ ] **Step 5: Fix the nested-repo probe**
+
+In `src-tauri/src/git/libgit2.rs`, the embedded-repo detection currently reads:
+
+```rust
+    if Repository::open(&full).is_err() {
+        return false;
+    }
+```
+
+Replace with:
+
+```rust
+    // A repository we are not allowed to open is still a repository. Reading
+    // `Refused` as "ordinary directory" would silently retire the
+    // embedded-repo guard on any filesystem that trips the ownership check,
+    // and staging would then write an unresolvable `160000` gitlink.
+    if !ownership::repo_presence(&full).exists() {
+        return false;
+    }
+```
+
+- [ ] **Step 6: Fix the init guard**
+
+In `src-tauri/src/git/libgit2.rs`, `GitBackend::init`, replace:
+
+```rust
+        if Repository::open(path).is_ok() {
+            return Err(AppError::InvalidPath(format!(
+                "{} is already a git repository",
+                path.display()
+            )));
+        }
+```
+
+with:
+
+```rust
+        match ownership::repo_presence(path) {
+            ownership::RepoPresence::Present => {
+                return Err(AppError::InvalidPath(format!(
+                    "{} is already a git repository",
+                    path.display()
+                )));
+            }
+            // Refusing to open is not permission to initialise over the top:
+            // say what is actually wrong so the user can trust it and retry.
+            ownership::RepoPresence::Refused => {
+                return Err(AppError::DubiousOwnership(ownership::canonical_string(path)));
+            }
+            ownership::RepoPresence::Absent => {}
+        }
+```
+
+- [ ] **Step 7: Fix the clone-target guard**
+
+In `src-tauri/src/commands/create.rs`, replace the `if let Ok(repo) = git2::Repository::open(parent)` block's condition so an ownership refusal still counts. Keep the existing message and the existing comment block above it, and append to that comment:
+
+```rust
+    // An ownership-refused directory counts too — it is a repository, we just
+    // cannot read its workdir path for the message.
+    match git2::Repository::open(parent) {
+        Ok(repo) => {
+            let enclosing = repo.workdir().unwrap_or_else(|| repo.path()).to_path_buf();
+            return Err(AppError::InvalidPath(format!(
+                "{} is already a git repository — choose a different folder to clone into",
+                enclosing.display()
+            )));
+        }
+        Err(e) if e.code() == git2::ErrorCode::Owner => {
+            return Err(AppError::InvalidPath(format!(
+                "{} is already a git repository — choose a different folder to clone into",
+                parent.display()
+            )));
+        }
+        Err(_) => {}
+    }
+```
+
+- [ ] **Step 8: Fix the CLI root resolution**
+
+In `src-tauri/src/cli.rs`, `resolve_repo_root` currently drops to the raw path
+when `discover` fails — and `discover` opens what it finds, so it fails on an
+ownership-refused repository. A subdirectory then reaches `open` and reports
+`NotARepo`, and trusting a subdirectory would not help anyway (matching is
+exact). Fall back to the non-opening walk:
+
+```rust
+pub fn resolve_repo_root(intent: LaunchIntent) -> LaunchIntent {
+    let path = intent.path.map(|p| {
+        git2::Repository::discover(&p)
+            .ok()
+            .and_then(|r| r.workdir().map(PathBuf::from))
+            // `discover` opens what it finds, so it fails on a repository
+            // refused for ownership. The walk does not open anything, which
+            // is what lets a `pgit` launch from a subdirectory of such a repo
+            // still name the root — the only path a `safe.directory` entry
+            // can match.
+            .or_else(|| crate::git::ownership::repo_root_for(&p))
+            .unwrap_or(p)
+    });
+    LaunchIntent { path, ..intent }
+}
+```
+
+- [ ] **Step 9: Run the full backend suite**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+Expected: all pass — `embedded_repo`, `clone_init` and the CLI tests cover the
+three guards' normal paths, so they are the regression net for this refactor.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src-tauri/src src-tauri/tests/dubious_ownership.rs
+git commit -m "fix(git): treat an ownership-refused directory as a repository"
+```
+
+---
+
+### Task 4: Frontend contract — error mirror, wrapper, confirmation copy
+
+**Files:**
+- Modify: `src/lib/errors.ts`, `src/lib/tauri.ts`
+- Create: `src/features/repo/ownership.ts`
+
+**Interfaces:**
+- Consumes: command `trust_repo_path` (Task 2), `AppError::DubiousOwnership` (Task 1).
+- Produces: `isDubiousOwnershipError(e)`, `dubiousOwnershipPath(e)`, `DUBIOUS_OWNERSHIP_HELP`, `trustRepoPath(path)`, `confirmTrust(path)`.
+
+- [ ] **Step 1: Mirror the variant**
+
+In `src/lib/errors.ts`, add to the union (keeping it 1:1 with the Rust enum):
+
+```ts
+  | { kind: "DubiousOwnership"; message: string }
+```
+
+and below the embedded-repo helpers:
+
+```ts
+export function isDubiousOwnershipError(e: unknown): boolean {
+  return isAppError(e) && e.kind === "DubiousOwnership";
+}
+
+/**
+ * The path the backend refused. The Rust message is
+ * `repository is owned by another user: <path>` — the prefix is stripped here
+ * for the same reason the embedded-repo prose lives here: the backend enum
+ * stays terse, the UI owns the words.
+ */
+export function dubiousOwnershipPath(e: unknown): string | null {
+  if (!isDubiousOwnershipError(e)) return null;
+  return appErrorMessage(e).replace(/^repository is owned by another user: /, "");
+}
+
+/**
+ * Why this happens and what trusting it means. git refuses to open a
+ * repository owned by someone else because that repository's own config can
+ * run commands (`core.pager`, `core.fsmonitor`) the moment it is opened. On a
+ * WSL `/mnt/c` mount the owner mismatch is an artefact of the mount, not a
+ * threat — but the app cannot tell those apart, so the user does.
+ */
+export const DUBIOUS_OWNERSHIP_HELP =
+  "git refuses to open a repository owned by another user, because opening one can run commands from its config. This is common for repositories on a Windows drive under WSL. Trusting it adds a safe.directory entry to your global git config.";
+```
+
+- [ ] **Step 2: Add the typed wrapper**
+
+In `src/lib/tauri.ts`, next to `openRepo`:
+
+```ts
+export async function trustRepoPath(path: string): Promise<void> {
+  return invoke<void>("trust_repo_path", { path });
+}
+```
+
+- [ ] **Step 3: Add the confirmation**
+
+Create `src/features/repo/ownership.ts`:
+
+```ts
+import { pgConfirm } from "@/design";
+import { DUBIOUS_OWNERSHIP_HELP } from "@/lib/errors";
+
+/**
+ * Ask before writing a `safe.directory` exception.
+ *
+ * Kept out of the store so the store's own tests can decide the answer
+ * without mounting a dialog host, and so the copy sits next to the help text
+ * rather than inside a state machine.
+ */
+export async function confirmTrust(path: string): Promise<boolean> {
+  return pgConfirm({
+    title: "Trust this repository?",
+    body: `${path}\n\n${DUBIOUS_OWNERSHIP_HELP}`,
+    confirmLabel: "Trust and open",
+  });
+}
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm tsc --noEmit
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/errors.ts src/lib/tauri.ts src/features/repo/ownership.ts
+git commit -m "feat(errors): mirror DubiousOwnership and its remedy into the frontend"
+```
+
+---
+
+### Task 5: Trust-and-retry in the store
+
+**Files:**
+- Modify: `src/features/repo/useRepoStore.ts`
+- Test: `src/features/repo/useRepoStore.ownership.test.ts`
+
+**Interfaces:**
+- Consumes: `confirmTrust` (Task 4), `trustRepoPath` (Task 4), `dubiousOwnershipPath` (Task 4).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/repo/useRepoStore.ownership.test.ts`:
+
+```ts
+// Opening a repo on a filesystem libgit2 says is owned by someone else (the
+// WSL /mnt/c case) must offer the safe.directory remedy and retry — from the
+// store, so every entry point (Welcome, recents, CLI launch, palette) gets it.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+
+const confirmTrust = vi.hoisted(() => vi.fn());
+vi.mock("@/features/repo/ownership", () => ({ confirmTrust }));
+
+const REFUSED = {
+  kind: "DubiousOwnership",
+  message: "repository is owned by another user: /mnt/c/dev/reponame",
+};
+const HANDLE = { id: "repo-1", path: "/mnt/c/dev/reponame", head: "main" };
+
+const initial = useRepoStore.getState();
+
+/** `open_repo` refuses `failures` times, then succeeds. */
+function armOpen(failures: number) {
+  let seen = 0;
+  mockInvoke("open_repo", () => {
+    if (seen++ < failures) throw REFUSED;
+    return HANDLE;
+  });
+}
+
+beforeEach(() => {
+  useRepoStore.setState(initial, true);
+  useRepoStore.setState({ refreshAll: async () => {} });
+  confirmTrust.mockReset();
+  mockInvoke("trust_repo_path", () => null);
+});
+
+const calls = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+
+describe("useRepoStore.openRepo — dubious ownership", () => {
+  it("trusts the path and retries when the user accepts", async () => {
+    armOpen(1);
+    confirmTrust.mockResolvedValue(true);
+
+    await useRepoStore.getState().openRepo("/mnt/c/dev/reponame");
+
+    expect(confirmTrust).toHaveBeenCalledWith("/mnt/c/dev/reponame");
+    expect(calls("trust_repo_path")).toHaveLength(1);
+    expect(useRepoStore.getState().current).toEqual(HANDLE);
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("leaves the error banner alone when the user declines", async () => {
+    armOpen(1);
+    confirmTrust.mockResolvedValue(false);
+
+    await useRepoStore.getState().openRepo("/mnt/c/dev/reponame");
+
+    expect(calls("trust_repo_path")).toHaveLength(0);
+    expect(useRepoStore.getState().error?.kind).toBe("DubiousOwnership");
+    expect(useRepoStore.getState().current).toBeNull();
+  });
+
+  it("does not loop when trusting fails to help", async () => {
+    armOpen(99);
+    confirmTrust.mockResolvedValue(true);
+
+    await useRepoStore.getState().openRepo("/mnt/c/dev/reponame");
+
+    // One prompt, one retry — never a second round.
+    expect(confirmTrust).toHaveBeenCalledTimes(1);
+    expect(calls("open_repo")).toHaveLength(2);
+    expect(useRepoStore.getState().error?.kind).toBe("DubiousOwnership");
+  });
+
+  it("leaves other open failures untouched", async () => {
+    mockInvoke("open_repo", () => {
+      throw { kind: "NotARepo", message: "path is not a git repository: /tmp/x" };
+    });
+
+    await useRepoStore.getState().openRepo("/tmp/x");
+
+    expect(confirmTrust).not.toHaveBeenCalled();
+    expect(useRepoStore.getState().error?.kind).toBe("NotARepo");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- src/features/repo/useRepoStore.ownership.test.ts
+```
+
+Expected: FAIL — no prompt, `trust_repo_path` never invoked.
+
+- [ ] **Step 3: Implement**
+
+In `src/features/repo/useRepoStore.ts`, add imports:
+
+```ts
+import { confirmTrust } from "@/features/repo/ownership";
+import { dubiousOwnershipPath, isDubiousOwnershipError } from "@/lib/errors";
+import { trustRepoPath } from "@/lib/tauri";
+```
+
+Rewrite the `openRepo` action so the success path is shared and the retry is
+bounded by an argument rather than by store state:
+
+```ts
+  async openRepo(path) {
+    set({ loading: true, error: null });
+    try {
+      await applyOpenedRepo(set, get, path);
+    } catch (e) {
+      // A repository libgit2 refuses on ownership grounds is remediable, and
+      // handling it here rather than per-screen covers Welcome, recents, the
+      // CLI launch and the palette at once. `mayTrust` is spent by the retry,
+      // so a trust that does not help surfaces the error instead of looping.
+      if (isDubiousOwnershipError(e)) {
+        const target = dubiousOwnershipPath(e) ?? path;
+        if (await confirmTrust(target)) {
+          try {
+            await trustRepoPath(target);
+            await applyOpenedRepo(set, get, path);
+            return;
+          } catch (retryError) {
+            set({ loading: false, error: toAppError(retryError) });
+            return;
+          }
+        }
+      }
+      set({ loading: false, error: toAppError(e) });
+    }
+  },
+```
+
+with the shared success path lifted to module scope, above `useRepoStore`:
+
+```ts
+/** Open `path` and reset the per-repo slices. Throws on failure. */
+async function applyOpenedRepo(
+  set: (partial: Partial<RepoStore>) => void,
+  get: () => RepoStore,
+  path: string,
+): Promise<void> {
+  const handle = await openRepo(path);
+  useRecentsStore.getState().addRecent(handle.path);
+  set({
+    current: handle,
+    status: [],
+    allFiles: [],
+    branches: [],
+    tags: [],
+    stashes: [],
+    remotes: [],
+    commits: [],
+    searchResults: null,
+    commitFilter: {},
+    lastRebaseSummary: null,
+    logRef: null,
+    commitCursor: null,
+    searchCursor: null,
+  });
+  await get().refreshAll();
+}
+```
+
+(Use the store's real state type in place of `RepoStore` if it is named
+differently in this file, and match the existing `set` signature.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+pnpm test -- src/features/repo/useRepoStore.ownership.test.ts
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Run the whole frontend suite**
+
+```bash
+pnpm test
+pnpm tsc --noEmit
+```
+
+Expected: green — the other `useRepoStore.*` tests are the regression net for
+the `applyOpenedRepo` extraction.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/repo/useRepoStore.ts src/features/repo/useRepoStore.ownership.test.ts
+git commit -m "feat(repo): offer the safe.directory remedy when a repo is refused"
+```
+
+---
+
+### Task 6: Say it plainly in the error banner
+
+**Files:**
+- Modify: `src/AppShell.tsx`
+
+**Interfaces:**
+- Consumes: `DUBIOUS_OWNERSHIP_HELP`, `dubiousOwnershipPath` (Task 4).
+
+- [ ] **Step 1: Extend the banner**
+
+`AppShell` already special-cases `EmbeddedRepo` to swap the enum name for a
+readable label and append help text. Give the new kind the same treatment —
+a dismissed trust prompt must not leave the user staring at libgit2's
+sentence with no idea what to do. Update the label expression:
+
+```tsx
+            {error.kind === "EmbeddedRepo"
+              ? "Embedded repository"
+              : error.kind === "DubiousOwnership"
+                ? "Repository owned by another user"
+                : error.kind}
+            :
+```
+
+and the body expression, keeping the existing embedded-repo arm:
+
+```tsx
+            {error.kind === "DubiousOwnership"
+              ? `${dubiousOwnershipPath(error)} — ${DUBIOUS_OWNERSHIP_HELP}`
+              : error.kind === "EmbeddedRepo"
+                ? `${appErrorMessage(error).replace(/^embedded repository: /, "")} — ${EMBEDDED_REPO_HELP}`
+                : appErrorMessage(error)}
+```
+
+Add `DUBIOUS_OWNERSHIP_HELP` and `dubiousOwnershipPath` to the existing
+`@/lib/errors` import.
+
+- [ ] **Step 2: Verify**
+
+```bash
+pnpm tsc --noEmit
+pnpm test
+```
+
+Expected: green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/AppShell.tsx
+git commit -m "feat(shell): explain a dubious-ownership refusal in the error banner"
+```
+
+---
+
+### Task 7: Full verification and PR
+
+- [ ] **Step 1: Run every layer**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml
+pnpm test
+pnpm tsc --noEmit
+pnpm exec tsc -p e2e/tsconfig.json --noEmit
+```
+
+Expected: all green. Record the actual counts — do not claim a pass without them.
+
+- [ ] **Step 2: Run the e2e specs the change can touch**
+
+Only `open`-path specs are affected, and only through code that is unchanged
+on a normally-owned repository. Rebuild this worktree's snapshot first,
+because `run` silently tests a stale binary:
+
+```bash
+pnpm test:e2e:docker build
+pnpm test:e2e:docker run --spec e2e/specs/smoke.e2e.ts --spec e2e/specs/create.e2e.ts
+```
+
+`smoke` covers the open path end to end; `create.e2e.ts` covers init and
+clone, whose guards Task 3 rewrites. Nothing else touches changed code.
+
+- [ ] **Step 3: Squash and open the PR**
+
+```bash
+git fetch origin
+git rebase origin/main
+git reset --soft origin/main
+git commit -m "$(cat <<'EOF'
+fix(git): make WSL /mnt/c repositories openable (#83)
+
+Why: libgit2 1.9.2 enforces git's CVE-2022-24765 ownership check, and a
+drvfs /mnt/c mount routinely reports an owner that differs from the WSL
+uid. The refusal stringified into a generic error with no way forward.
+
+Adds AppError::DubiousOwnership, a confirmed per-repository
+safe.directory exception, and corrects four call sites that read an
+ownership refusal as "no repository here" — two of which silently
+disabled a guard.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+)"
+git push -u origin fix/wsl-dubious-ownership
+```
+
+Then open the PR with a body that states: the libgit2 behaviour and why WSL
+trips it; what the user now sees (confirmation, then the repo opens); the two
+guards that were silently disabled by the old `is_ok()` probes; that
+`set_verify_owner_validation(false)` was considered and rejected; and the
+verification actually run (test counts per layer, plus which e2e specs).
+Close with `Closes #83`.

--- a/docs/superpowers/specs/2026-08-13-wsl-dubious-ownership-design.md
+++ b/docs/superpowers/specs/2026-08-13-wsl-dubious-ownership-design.md
@@ -1,0 +1,143 @@
+# Dubious repository ownership (WSL / `/mnt/c`) — design
+
+Issue: [#83](https://github.com/jonassaa/platypusgit/issues/83)
+
+## Problem
+
+Opening a repository that lives on a Windows drive from a WSL-hosted Linux
+build fails outright:
+
+```
+Git: repository path '/mnt/c/dev/reponame' is not owned by current user
+```
+
+libgit2 1.9.2 performs the same "dubious ownership" validation git added for
+CVE-2022-24765 (`validate_ownership` in `repository.c`, reached from
+`git_repository_open_ext`). It compares the owner of the working directory —
+and of the gitdir, and of any gitlink — against the current uid, and on
+mismatch fails the open with `GIT_EOWNER`.
+
+Under WSL, `/mnt/c` is a drvfs mount whose reported ownership depends on the
+mount's `uid=`/`metadata` options and the Windows-side ACL, so it routinely
+disagrees with the WSL user's uid even though the repository is the user's
+own. Keeping code on the Windows filesystem and editing it from both sides is
+an ordinary setup, and today it is a hard block: the generic error banner
+prints libgit2's sentence and there is no way forward from inside the app.
+
+## What libgit2 will accept
+
+Verified against the vendored 1.9.2 source rather than assumed, because three
+details shape the fix:
+
+- **Config key is the working directory.** `validate_ownership` checks every
+  path in `validation_paths` (workdir, gitlink, gitdir) but looks up only
+  `validation_paths[0]` — the workdir when there is one, the gitdir for a bare
+  repo. So the string that must land in `safe.directory` is the workdir root,
+  which is exactly the path the error message names.
+- **Global config only.** `validate_ownership_config` calls
+  `load_global_config`; the repository's own config is not consulted (it
+  cannot be — the repo is not open yet).
+- **Exact match or literal `*`.** `validate_ownership_cb` accepts `*`
+  (everything), the empty string (resets accumulated entries, same as git),
+  or a value that, once normalised to a trailing slash, equals the workdir.
+  The `dir/*` suffix glob newer git supports is **not** implemented in 1.9.2 —
+  so one entry per repository.
+
+## Approach
+
+Keep the security check on. Make the app actionable instead.
+
+1. **Name the condition.** A new `AppError::DubiousOwnership(String)` variant
+   carrying the canonicalised path, mirrored 1:1 into the TS union. Today
+   `ErrorCode::Owner` falls through the `NotFound` arm in
+   `Libgit2Backend::open` and stringifies into `AppError::Git`, which the
+   frontend cannot narrow on and therefore cannot remedy.
+
+   Canonicalised, not the raw input: `safe.directory` matching is exact, and
+   the caller may hand us a relative path, a trailing slash, or a symlink.
+   `std::fs::canonicalize` resolves the same way libgit2 does.
+
+2. **Offer the remedy the error implies.** A `trust_repo_path` command appends
+   the path to global `safe.directory` as a multivar — precisely what
+   `git config --global --add safe.directory <path>` does, which is what git's
+   own error text tells users to run. Idempotent: an entry that is already
+   present (in either the bare or trailing-slash form) is not duplicated.
+
+3. **Ask before doing it.** `useRepoStore.openRepo` catches
+   `DubiousOwnership` and raises a `pgConfirm` that names the directory and
+   says plainly what trusting it means and where the entry is written. On
+   accept: trust, then retry the open. On dismiss: the normal error banner,
+   carrying the help text instead of libgit2's bare sentence.
+
+   Handling this in the store rather than per-screen covers every entry point
+   at once — Welcome, recents, the `pgit` CLI launch, the palette.
+
+4. **Stop mistaking "refused" for "absent".** Four call sites ask libgit2
+   whether a repository exists by opening it and testing `is_ok()`/`is_err()`.
+   Under `GIT_EOWNER` the answer today is "no repository here", which is
+   wrong and, in two cases, unsafe:
+
+   | Site | Today under `GIT_EOWNER` | Should be |
+   | --- | --- | --- |
+   | `libgit2.rs` nested-repo probe | embedded repo reads as an ordinary directory, so `reject_embedded_repo` stops firing and staging can write an unresolvable `160000` gitlink | treat as a repository |
+   | `libgit2.rs` init guard | "not a repo yet", so `init` proceeds over an existing repository | surface the ownership error |
+   | `create.rs` clone-target guard | "not a repo", so cloning into an existing repo root is allowed | treat as a repository |
+   | `cli.rs` `resolve_repo_root` | `discover` fails, the raw path passes through, and a subdirectory launch reports `NotARepo` | walk ancestors for `.git` |
+
+   The last one matters beyond the message: trusting a *subdirectory* does
+   nothing, because matching is exact. The trust target has to be the root.
+
+## Rejected
+
+**`git2::opts::set_verify_owner_validation(false)` at startup.** It is
+`unsafe`, process-global, and permanently disables the CVE-2022-24765
+protection for every repository the app touches for the rest of the process —
+including a repository dropped into a shared or temp directory by someone
+else, whose `core.fsmonitor` or `core.pager` would then run on open. The whole
+point of the check is that the attacker controls the config. A per-path,
+user-confirmed exception costs one click and gives up nothing else.
+
+**A Settings toggle for the same thing.** Same objection, plus it would be set
+once and forgotten. If it is ever wanted it can be added later; nothing here
+forecloses it.
+
+**Trusting automatically when the path looks like `/mnt/`.** Silently
+disabling a security check based on a path prefix is the same hole with a
+narrower mouth, and it would not cover `//wsl.localhost` or network shares.
+The user should be the one to decide, once per repository.
+
+## Deviations from this design, as built
+
+- **`init` gets the same trust-and-retry as `open`.** `git_repository_init_ext`
+  finishes by opening what it created, so initialising a repository on a
+  Windows drive under WSL trips the identical check. Fixing only `open` would
+  have left the Init dialog a dead end for the same users, so
+  `useCreateStore.runInit` runs the same confirm → trust → retry.
+- **`init` maps ownership only.** It uses `map_ownership_error`, not
+  `map_open_error`: the latter turns `NotFound` into `NotARepo`, which is a
+  true statement when opening and a nonsense one when creating.
+- **The trust check folds entries in order.** libgit2 evaluates
+  `safe.directory` as a running verdict, and an empty value resets it. A
+  "does any entry match" search would call a path already trusted when a later
+  reset had cancelled it, and then silently decline to write the exception the
+  user just asked for. The append also avoids the `^$` value pattern for the
+  same reason — it matches a reset entry and would overwrite it, re-trusting
+  everything listed above.
+
+## Testing
+
+The ownership failure itself cannot be provoked in a unit test — it needs a
+directory owned by a different uid, i.e. root. What is testable, and is
+tested:
+
+- the mapping from a `GIT_EOWNER` `git2::Error` to `DubiousOwnership`, built
+  with `git2::Error::new`
+- the `safe.directory` writer against a temp global config: exact value,
+  idempotence, coexistence with existing entries
+- the ancestor walk that finds a repository root
+- the three misclassification guards, exercised through their normal
+  (non-ownership) paths so the refactor cannot regress them
+- the store's dialog-and-retry flow, with the backend mocked
+
+The uncovered gap is honest and narrow: whether a real `GIT_EOWNER` reaches
+the new arm. That is a two-line match on a stable libgit2 error code.

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -87,6 +87,12 @@ pub fn resolve_repo_root(intent: LaunchIntent) -> LaunchIntent {
         git2::Repository::discover(&p)
             .ok()
             .and_then(|r| r.workdir().map(PathBuf::from))
+            // `discover` opens what it finds, so it fails outright on a
+            // repository refused for ownership. The walk opens nothing, which
+            // is what lets a `pgit` launch from a subdirectory of such a repo
+            // still name the root — and the root is the only path a
+            // `safe.directory` entry can match.
+            .or_else(|| crate::git::ownership::repo_root_for(&p))
             .unwrap_or(p)
     });
     LaunchIntent { path, ..intent }

--- a/src-tauri/src/commands/create.rs
+++ b/src-tauri/src/commands/create.rs
@@ -114,15 +114,29 @@ pub fn validate_clone_target(parent: &Path, name: &str) -> AppResult<PathBuf> {
     // this app already detects that as data — see commit 1dddff3 and
     // `embedded_repo.rs` — with dedicated UI (`embeddedRepoMenuItems` in
     // `context-menu.tsx`) rather than a dead end.
-    if let Ok(repo) = git2::Repository::open(parent) {
-        let enclosing = repo.workdir().unwrap_or_else(|| repo.path()).to_path_buf();
-        // Lead with the remedy, same principle `embeddedRepoMenuItems`
-        // documents for embedded repos: name the repo, say what to do next,
-        // don't just refuse.
-        return Err(AppError::InvalidPath(format!(
-            "{} is already a git repository — choose a different folder to clone into",
-            enclosing.display()
-        )));
+    //
+    // An ownership-refused directory counts too: it is a repository, we just
+    // cannot read its workdir path back out for the message. Testing
+    // `open(...).is_ok()` would have skipped this guard on every `/mnt/c`
+    // repo under WSL.
+    match git2::Repository::open(parent) {
+        Ok(repo) => {
+            let enclosing = repo.workdir().unwrap_or_else(|| repo.path()).to_path_buf();
+            // Lead with the remedy, same principle `embeddedRepoMenuItems`
+            // documents for embedded repos: name the repo, say what to do next,
+            // don't just refuse.
+            return Err(AppError::InvalidPath(format!(
+                "{} is already a git repository — choose a different folder to clone into",
+                enclosing.display()
+            )));
+        }
+        Err(e) if e.code() == git2::ErrorCode::Owner => {
+            return Err(AppError::InvalidPath(format!(
+                "{} is already a git repository — choose a different folder to clone into",
+                parent.display()
+            )));
+        }
+        Err(_) => {}
     }
 
     let target = parent.join(name);

--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -20,6 +20,18 @@ pub async fn open_repo(
         .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
+/// Add `path` to the user's global `safe.directory` list, so libgit2 stops
+/// refusing it. Reached only from the confirmation an `AppError::DubiousOwnership`
+/// raises in the UI — never call it without asking first.
+#[tauri::command]
+pub async fn trust_repo_path(state: State<'_, AppState>, path: String) -> AppResult<()> {
+    let backend = state.backend.clone();
+    let path_buf = PathBuf::from(path);
+    tokio::task::spawn_blocking(move || backend.trust_path(&path_buf))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
 #[tauri::command]
 pub async fn get_status(
     state: State<'_, AppState>,

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -50,6 +50,13 @@ pub enum AppError {
 
     #[error("embedded repository: {0}")]
     EmbeddedRepo(String),
+
+    /// libgit2 refused to open a repository because its working directory is
+    /// owned by a different user (`GIT_EOWNER`, git's CVE-2022-24765 check).
+    /// Carries the canonicalised path, which is the exact string a
+    /// `safe.directory` exception has to contain.
+    #[error("repository is owned by another user: {0}")]
+    DubiousOwnership(String),
 }
 
 impl From<git2::Error> for AppError {

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -35,6 +35,9 @@ impl GitBackend for CliBackend {
     fn init(&self, _path: &Path, _initial_branch: Option<&str>) -> AppResult<RepoHandle> {
         Err(AppError::NotImplemented)
     }
+    fn trust_path(&self, _path: &Path) -> AppResult<()> {
+        Err(AppError::NotImplemented)
+    }
     fn status(&self, _repo_id: &RepoId) -> AppResult<Vec<FileStatus>> {
         Err(AppError::NotImplemented)
     }

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -10,6 +10,7 @@ use git2::{
 use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
+use crate::git::ownership;
 use crate::opener::safe_workdir_path;
 
 use super::{
@@ -386,7 +387,14 @@ fn is_embedded_repo(repo: &Repository, path: &Path) -> bool {
     // `Repository::open` does not search parent directories, so a plain
     // subdirectory of the outer repo fails here — only a real nested `.git`
     // (directory or gitfile) succeeds.
-    if Repository::open(&full).is_err() {
+    //
+    // A repository libgit2 refuses on ownership grounds is still a
+    // repository. Reading that refusal as "ordinary directory" would retire
+    // this guard on any filesystem that trips the ownership check — a nested
+    // repo on a `/mnt/c` mount under WSL — and staging would then write an
+    // unresolvable `160000` gitlink, the corruption `embedded_repo.rs` exists
+    // to prevent.
+    if !ownership::repo_presence(&full).exists() {
         return false;
     }
     !is_registered_submodule(repo, &rel)
@@ -1025,13 +1033,7 @@ impl GitBackend for Libgit2Backend {
         if !path.exists() {
             return Err(AppError::InvalidPath(path.display().to_string()));
         }
-        let repo = Repository::open(path).map_err(|e| {
-            if e.code() == git2::ErrorCode::NotFound {
-                AppError::NotARepo(path.display().to_string())
-            } else {
-                AppError::from(e)
-            }
-        })?;
+        let repo = Repository::open(path).map_err(|e| ownership::map_open_error(path, &e))?;
 
         let head = match repo.head() {
             Ok(r) => r.shorthand().map(|s| s.to_string()),
@@ -1061,6 +1063,10 @@ impl GitBackend for Libgit2Backend {
             path: workdir,
             head,
         })
+    }
+
+    fn trust_path(&self, path: &Path) -> AppResult<()> {
+        ownership::trust_path(path)
     }
 
     fn init(&self, path: &Path, initial_branch: Option<&str>) -> AppResult<RepoHandle> {
@@ -1097,11 +1103,20 @@ impl GitBackend for Libgit2Backend {
 
         // `Repository::init` on an existing repo silently reopens it. That
         // reads as success while creating nothing, so refuse up front.
-        if Repository::open(path).is_ok() {
-            return Err(AppError::InvalidPath(format!(
-                "{} is already a git repository",
-                path.display()
-            )));
+        match ownership::repo_presence(path) {
+            ownership::RepoPresence::Present => {
+                return Err(AppError::InvalidPath(format!(
+                    "{} is already a git repository",
+                    path.display()
+                )));
+            }
+            // Being unable to open it is not permission to initialise over the
+            // top of it — the old `is_ok()` test read this as "no repo yet".
+            // Say what is actually wrong so the user can trust it and retry.
+            ownership::RepoPresence::Refused => {
+                return Err(AppError::DubiousOwnership(ownership::canonical_string(path)));
+            }
+            ownership::RepoPresence::Absent => {}
         }
         // A file (not a directory) at `path` would otherwise surface as a
         // confusing "File exists (os error 17)" out of `create_dir_all` below.
@@ -1167,7 +1182,12 @@ impl GitBackend for Libgit2Backend {
         // concurrent calls so the guard → write → cleanup window is atomic
         // across the entire operation.
         let result = Repository::init_opts(path, &opts)
-            .map_err(AppError::from)
+            // `git_repository_init_ext` opens what it just created, so it can
+            // refuse on ownership grounds too — report that as the actionable
+            // variant rather than a raw git string. Only that arm: an init
+            // failing with NotFound has not learned the path "is not a git
+            // repository".
+            .map_err(|e| ownership::map_ownership_error(path, e))
             // Go through `open` so the repo lands in the backend's map with a
             // real RepoId — a handle that isn't registered 404s on the next call.
             .and_then(|_| self.open(path));

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod libgit2;
+pub mod ownership;
 pub mod signature;
 pub mod types;
 
@@ -23,6 +24,13 @@ pub trait GitBackend: Send + Sync {
     /// repository to address yet. `initial_branch` overrides the configured
     /// default; `None` resolves `init.defaultBranch`, falling back to `main`.
     fn init(&self, path: &Path, initial_branch: Option<&str>) -> AppResult<RepoHandle>;
+    /// Record `path` in the user's global `safe.directory` list so libgit2
+    /// will open it despite an ownership mismatch (`AppError::DubiousOwnership`).
+    ///
+    /// A security exception, so call it only after the user has explicitly
+    /// confirmed. Shaped like `open` rather than the `repo_id` methods: by
+    /// definition there is no open repository to address.
+    fn trust_path(&self, path: &Path) -> AppResult<()>;
     fn status(&self, repo_id: &RepoId) -> AppResult<Vec<FileStatus>>;
     /// Like `status`, but also includes tracked-but-unmodified files so UIs
     /// can browse the whole worktree (ignored files are still excluded).

--- a/src-tauri/src/git/ownership.rs
+++ b/src-tauri/src/git/ownership.rs
@@ -1,0 +1,223 @@
+//! Everything about libgit2's "dubious ownership" refusal.
+//!
+//! libgit2 1.9.2 validates that a repository's working directory (and its
+//! gitdir, and any gitlink) is owned by the current user before opening it —
+//! git's CVE-2022-24765 check. On a WSL `/mnt/c` drvfs mount the reported
+//! owner routinely disagrees with the WSL uid even for the user's own
+//! repository, so here the refusal is an ordinary condition, not an attack.
+//!
+//! Three details of the vendored implementation shape everything below, and
+//! were read out of `repository.c` rather than assumed:
+//!
+//! - the config key is `validation_paths[0]` — the **working directory** when
+//!   there is one, the gitdir for a bare repo
+//! - `validate_ownership_config` reads the **global** config only; the
+//!   repository's own config is never consulted (it cannot be — the
+//!   repository is not open yet)
+//! - `validate_ownership_cb` accepts the literal `*`, or a value that equals
+//!   the workdir once normalised to a trailing slash. The `dir/*` suffix glob
+//!   newer git supports is **not** implemented, so exceptions are per-repo.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::{AppError, AppResult};
+
+/// The path as libgit2 would spell it: symlinks resolved, no trailing slash,
+/// no `.` or `..`. `safe.directory` matching is exact, so the string handed to
+/// the user to trust has to be the resolved one. Falls back to the input when
+/// the path cannot be canonicalised — it may not exist.
+pub fn canonical_string(path: &Path) -> String {
+    std::fs::canonicalize(path)
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .to_string()
+}
+
+/// Classify a failure from `Repository::open`.
+///
+/// `ErrorCode::Owner` is the one that must not fall through to the generic
+/// arm: it is remediable, and only a distinct variant lets the frontend offer
+/// the remedy instead of printing libgit2's sentence at the user.
+pub fn map_open_error(path: &Path, e: &git2::Error) -> AppError {
+    match e.code() {
+        git2::ErrorCode::Owner => AppError::DubiousOwnership(canonical_string(path)),
+        git2::ErrorCode::NotFound => AppError::NotARepo(path.display().to_string()),
+        _ => AppError::Git(e.message().to_string()),
+    }
+}
+
+/// Map only the ownership refusal, leaving every other failure to the usual
+/// conversion.
+///
+/// `map_open_error`'s `NotFound` → `NotARepo` arm is right for opening an
+/// existing repository and wrong for anything else: an `init` that fails with
+/// `NotFound` has not discovered that the path "is not a git repository" —
+/// that was the whole point of the call.
+pub fn map_ownership_error(path: &Path, e: git2::Error) -> AppError {
+    if e.code() == git2::ErrorCode::Owner {
+        return AppError::DubiousOwnership(canonical_string(path));
+    }
+    AppError::from(e)
+}
+
+/// What is actually at a path, for the call sites that only need to know
+/// whether a repository is there.
+///
+/// The distinction matters: `Repository::open(p).is_ok()` answers "no" both
+/// when there is no repository *and* when there is one we are not allowed to
+/// open. Collapsing those is what makes an ownership refusal quietly disable
+/// the embedded-repo and clone-target guards.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepoPresence {
+    /// A repository is there and openable.
+    Present,
+    /// Nothing repository-shaped is there.
+    Absent,
+    /// A repository is there, but libgit2 refused it on ownership grounds.
+    Refused,
+}
+
+impl RepoPresence {
+    /// True when a repository exists at the path, openable or not. Guards that
+    /// refuse to act on top of an existing repository want this, not
+    /// `Present` — a refused repository is still a repository.
+    pub fn exists(self) -> bool {
+        matches!(self, RepoPresence::Present | RepoPresence::Refused)
+    }
+}
+
+/// Probe `path` for a repository, without walking up to its ancestors.
+pub fn repo_presence(path: &Path) -> RepoPresence {
+    match git2::Repository::open(path) {
+        Ok(_) => RepoPresence::Present,
+        Err(e) if e.code() == git2::ErrorCode::Owner => RepoPresence::Refused,
+        Err(_) => RepoPresence::Absent,
+    }
+}
+
+/// The repository root at or above `path`, found without opening anything.
+///
+/// `Repository::discover` would be the obvious tool, but it opens what it
+/// finds and so fails on exactly the repositories this module exists for.
+/// Looking for `.git` — a directory for a normal repo, a file for a worktree
+/// or submodule — needs no open at all.
+pub fn repo_root_for(path: &Path) -> Option<PathBuf> {
+    let start = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    start
+        .ancestors()
+        .find(|dir| dir.join(".git").exists())
+        .map(PathBuf::from)
+}
+
+/// How one `safe.directory` value moves the running verdict, mirroring
+/// libgit2's `validate_ownership_cb`.
+///
+/// The verdict is a fold over the entries in file order, not a search: an
+/// empty value *clears* everything accumulated before it (same as git), so
+/// `directory = /x` followed by `directory =` leaves `/x` untrusted. Treating
+/// this as "find any matching entry" would report a path as already trusted
+/// when it is not, and then decline to write the exception the user just
+/// asked for.
+fn apply_value(trusted: bool, value: &str, path: &str) -> bool {
+    if value.is_empty() {
+        return false;
+    }
+    if value == "*" {
+        return true;
+    }
+    fn strip(s: &str) -> &str {
+        s.trim_end_matches('/')
+    }
+    if strip(value) == strip(path) {
+        return true;
+    }
+    trusted
+}
+
+/// A value pattern no real `safe.directory` entry can equal, so
+/// `set_multivar` finds nothing to replace and appends instead — git's
+/// `--add`. The obvious `^$` is wrong here: it matches an empty value, and an
+/// empty value is a meaningful "reset" entry that must not be overwritten.
+const NEVER_MATCHES: &str = "^platypusgit-never-matches-a-config-value$";
+
+/// Add `path` to `cfg`'s `safe.directory` multivar, exactly as
+/// `git config --global --add safe.directory <path>` would.
+///
+/// Returns `false` when an entry already covers the path — re-trusting is a
+/// no-op rather than a growing pile of duplicates, since the user can reach
+/// this from any entry point and the same repository is opened many times.
+pub fn add_safe_directory(cfg: &mut git2::Config, path: &str) -> AppResult<bool> {
+    // Scoped: `entries` borrows `cfg` immutably for as long as it lives, and
+    // the write below needs it mutably.
+    let already_trusted = {
+        let mut entries = cfg.entries(Some("safe.directory"))?;
+        let mut trusted = false;
+        while let Some(entry) = entries.next() {
+            let entry = entry?;
+            trusted = apply_value(trusted, entry.value().unwrap_or_default(), path);
+        }
+        trusted
+    };
+    if already_trusted {
+        return Ok(false);
+    }
+    cfg.set_multivar("safe.directory", NEVER_MATCHES, path)?;
+    Ok(true)
+}
+
+/// Where libgit2 would read the global config, whether or not the file is
+/// there yet.
+///
+/// Deliberately not `$HOME/.gitconfig`: libgit2's global search path is
+/// configurable, and writing anywhere it does not read would leave the
+/// exception invisible to the very check we are trying to satisfy — a silent
+/// no-op that looks like success.
+fn global_config_path() -> AppResult<PathBuf> {
+    if let Ok(path) = git2::Config::find_global() {
+        return Ok(path);
+    }
+    // No file yet, so `find_global` has nothing to report. Ask libgit2 where
+    // it looks instead. The list is separator-joined, highest priority first.
+    //
+    // SAFETY: reads a libgit2 global option. Unsound only against a
+    // concurrent `set_search_path`, which nothing in this app calls.
+    let raw = unsafe { git2::opts::get_search_path(git2::ConfigLevel::Global) }
+        .map_err(|e| AppError::Git(e.message().to_string()))?;
+    let raw = raw.to_string_lossy().to_string();
+    let separator = if cfg!(windows) { ';' } else { ':' };
+    let dir = raw
+        .split(separator)
+        .find(|s| !s.is_empty())
+        .ok_or_else(|| AppError::Internal("git has no global config location".into()))?;
+    Ok(PathBuf::from(dir).join(".gitconfig"))
+}
+
+/// The global config file, creating it when the user has none yet.
+///
+/// Writes must land at the *global* level specifically: libgit2 reads
+/// `safe.directory` from global config only.
+fn global_config() -> AppResult<git2::Config> {
+    if let Ok(cfg) =
+        git2::Config::open_default().and_then(|c| c.open_level(git2::ConfigLevel::Global))
+    {
+        return Ok(cfg);
+    }
+    let path = global_config_path()?;
+    if !path.exists() {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&path, "")?;
+    }
+    Ok(git2::Config::open(&path)?)
+}
+
+/// Trust `path` for this user, so libgit2 will open it despite the ownership
+/// mismatch. The user-facing half of the CVE-2022-24765 escape hatch — only
+/// ever call it behind an explicit confirmation.
+pub fn trust_path(path: &Path) -> AppResult<()> {
+    let canonical = canonical_string(path);
+    let mut cfg = global_config()?;
+    add_safe_directory(&mut cfg, &canonical)?;
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -101,6 +101,7 @@ pub fn run() {
         .manage(commands::cli::CliLaunchState(Mutex::new(initial_intent)))
         .invoke_handler(tauri::generate_handler![
             commands::repo::open_repo,
+            commands::repo::trust_repo_path,
             commands::repo::get_status,
             commands::repo::list_all_files,
             commands::repo::read_file_content,

--- a/src-tauri/tests/dubious_ownership.rs
+++ b/src-tauri/tests/dubious_ownership.rs
@@ -1,0 +1,305 @@
+//! libgit2 refuses to open a repository whose working directory is owned by
+//! another user — git's CVE-2022-24765 check, surfacing as `GIT_EOWNER`.
+//! Under WSL, every repository on a `/mnt/c` drvfs mount can trip it, because
+//! the mount's reported ownership need not match the WSL uid.
+//!
+//! The refusal itself cannot be provoked here: it needs a directory owned by
+//! a different uid, i.e. root. So the mapping is tested against a synthetic
+//! `GIT_EOWNER` error — exactly the shape libgit2 returns — and everything
+//! downstream of it (the `safe.directory` writer, the presence probe, the
+//! non-opening root walk) is tested for real.
+
+mod support;
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use git2::{ErrorClass, ErrorCode};
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::ownership::{self, RepoPresence};
+
+use support::TempRepo;
+
+/// libgit2's config search path is process-global; serialise the tests that
+/// move it so they cannot observe each other's temp home.
+static SEARCH_PATH: Mutex<()> = Mutex::new(());
+
+/// Values of every `safe.directory` entry in `file`, in order.
+fn safe_dirs(file: &Path) -> Vec<String> {
+    let cfg = git2::Config::open(file).unwrap();
+    let mut out = Vec::new();
+    let mut entries = cfg.entries(Some("safe.directory")).unwrap();
+    while let Some(entry) = entries.next() {
+        let entry = entry.unwrap();
+        out.push(entry.value().unwrap_or_default().to_string());
+    }
+    out
+}
+
+/// An empty config file in a fresh tempdir, plus a handle to it.
+fn temp_config(contents: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let file = dir.path().join("gitconfig");
+    std::fs::write(&file, contents).unwrap();
+    (dir, file)
+}
+
+// === error mapping ===
+
+#[test]
+fn eowner_maps_to_dubious_ownership() {
+    let err = git2::Error::new(
+        ErrorCode::Owner,
+        ErrorClass::Config,
+        "repository path '/mnt/c/dev/reponame' is not owned by current user",
+    );
+    let mapped = ownership::map_open_error(Path::new("/mnt/c/dev/reponame"), &err);
+    match mapped {
+        AppError::DubiousOwnership(p) => assert!(p.ends_with("reponame"), "got {p}"),
+        other => panic!("expected DubiousOwnership, got {other:?}"),
+    }
+}
+
+#[test]
+fn missing_repo_still_maps_to_not_a_repo() {
+    let err = git2::Error::new(ErrorCode::NotFound, ErrorClass::Repository, "not found");
+    assert!(matches!(
+        ownership::map_open_error(Path::new("/tmp/nope"), &err),
+        AppError::NotARepo(_)
+    ));
+}
+
+#[test]
+fn ownership_only_mapping_leaves_not_found_generic() {
+    // `init` uses this instead of `map_open_error`: a NotFound out of init has
+    // not established that the path "is not a git repository".
+    let err = git2::Error::new(ErrorCode::NotFound, ErrorClass::Repository, "not found");
+    assert!(matches!(
+        ownership::map_ownership_error(Path::new("/tmp/nope"), err),
+        AppError::Git(_)
+    ));
+}
+
+#[test]
+fn ownership_only_mapping_still_catches_eowner() {
+    let err = git2::Error::new(ErrorCode::Owner, ErrorClass::Config, "not owned");
+    assert!(matches!(
+        ownership::map_ownership_error(Path::new("/mnt/c/dev/reponame"), err),
+        AppError::DubiousOwnership(_)
+    ));
+}
+
+#[test]
+fn other_failures_stay_generic() {
+    let err = git2::Error::new(ErrorCode::Invalid, ErrorClass::Repository, "broken");
+    assert!(matches!(
+        ownership::map_open_error(Path::new("/tmp/x"), &err),
+        AppError::Git(_)
+    ));
+}
+
+// === the safe.directory writer ===
+
+#[test]
+fn add_safe_directory_writes_the_exact_path() {
+    let (_dir, file) = temp_config("");
+    let mut cfg = git2::Config::open(&file).unwrap();
+
+    assert!(ownership::add_safe_directory(&mut cfg, "/mnt/c/dev/reponame").unwrap());
+
+    assert_eq!(safe_dirs(&file), vec!["/mnt/c/dev/reponame".to_string()]);
+}
+
+#[test]
+fn add_safe_directory_is_idempotent() {
+    let (_dir, file) = temp_config("");
+    let mut cfg = git2::Config::open(&file).unwrap();
+
+    assert!(ownership::add_safe_directory(&mut cfg, "/mnt/c/dev/reponame").unwrap());
+    // Second call reports "already trusted" and writes nothing — the user can
+    // reach this from any entry point, many times, for the same repo.
+    assert!(!ownership::add_safe_directory(&mut cfg, "/mnt/c/dev/reponame").unwrap());
+
+    assert_eq!(safe_dirs(&file).len(), 1);
+}
+
+#[test]
+fn add_safe_directory_keeps_existing_entries() {
+    let (_dir, file) = temp_config("[safe]\n\tdirectory = /home/me/other\n");
+    let mut cfg = git2::Config::open(&file).unwrap();
+
+    ownership::add_safe_directory(&mut cfg, "/mnt/c/dev/reponame").unwrap();
+
+    assert_eq!(
+        safe_dirs(&file),
+        vec![
+            "/home/me/other".to_string(),
+            "/mnt/c/dev/reponame".to_string()
+        ]
+    );
+}
+
+#[test]
+fn add_safe_directory_accepts_a_trailing_slash_match() {
+    // libgit2 normalises config values to a trailing slash before comparing,
+    // so `/x/y/` already trusts `/x/y` — adding a duplicate would be noise.
+    let (_dir, file) = temp_config("[safe]\n\tdirectory = /mnt/c/dev/reponame/\n");
+    let mut cfg = git2::Config::open(&file).unwrap();
+
+    assert!(!ownership::add_safe_directory(&mut cfg, "/mnt/c/dev/reponame").unwrap());
+    assert_eq!(safe_dirs(&file).len(), 1);
+}
+
+#[test]
+fn add_safe_directory_respects_a_wildcard() {
+    let (_dir, file) = temp_config("[safe]\n\tdirectory = *\n");
+    let mut cfg = git2::Config::open(&file).unwrap();
+
+    assert!(!ownership::add_safe_directory(&mut cfg, "/mnt/c/dev/reponame").unwrap());
+}
+
+#[test]
+fn add_safe_directory_ignores_a_reset_entry() {
+    // An empty value resets the accumulated list (same as git) — it trusts
+    // nothing, so it must not be mistaken for a match.
+    let (_dir, file) = temp_config("[safe]\n\tdirectory =\n");
+    let mut cfg = git2::Config::open(&file).unwrap();
+
+    assert!(ownership::add_safe_directory(&mut cfg, "/mnt/c/dev/reponame").unwrap());
+}
+
+#[test]
+fn a_later_reset_entry_cancels_an_earlier_match() {
+    // libgit2 folds the entries in order: `directory = /x` then `directory =`
+    // leaves /x UNtrusted. Searching for any matching entry instead would
+    // report "already trusted" and silently decline to write the exception
+    // the user just asked for — a dead end with no error.
+    let (_dir, file) = temp_config("[safe]\n\tdirectory = /mnt/c/dev/reponame\n\tdirectory =\n");
+    let mut cfg = git2::Config::open(&file).unwrap();
+
+    assert!(ownership::add_safe_directory(&mut cfg, "/mnt/c/dev/reponame").unwrap());
+}
+
+#[test]
+fn add_safe_directory_appends_past_a_reset_entry() {
+    // The append must not consume the empty entry. `set_multivar` replaces
+    // values its pattern matches, so a pattern of `^$` would overwrite the
+    // reset and silently re-trust everything listed before it.
+    let (_dir, file) = temp_config("[safe]\n\tdirectory = /home/me/other\n\tdirectory =\n");
+    let mut cfg = git2::Config::open(&file).unwrap();
+
+    ownership::add_safe_directory(&mut cfg, "/mnt/c/dev/reponame").unwrap();
+
+    assert_eq!(
+        safe_dirs(&file),
+        vec![
+            "/home/me/other".to_string(),
+            String::new(),
+            "/mnt/c/dev/reponame".to_string()
+        ]
+    );
+}
+
+#[test]
+fn a_wildcard_after_a_reset_still_trusts() {
+    let (_dir, file) = temp_config("[safe]\n\tdirectory =\n\tdirectory = *\n");
+    let mut cfg = git2::Config::open(&file).unwrap();
+
+    assert!(!ownership::add_safe_directory(&mut cfg, "/mnt/c/dev/reponame").unwrap());
+}
+
+#[test]
+fn trust_path_writes_to_the_global_config() {
+    let _lock = SEARCH_PATH.lock().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    // Redirect libgit2's *global* config search at a temp home, so the test
+    // can never touch the developer's real ~/.gitconfig.
+    unsafe {
+        git2::opts::set_search_path(git2::ConfigLevel::Global, home.path()).unwrap();
+    }
+
+    let repo = tempfile::tempdir().unwrap();
+    let result = ownership::trust_path(repo.path());
+
+    let written = safe_dirs(&home.path().join(".gitconfig"));
+    unsafe {
+        git2::opts::reset_search_path(git2::ConfigLevel::Global).unwrap();
+    }
+
+    result.unwrap();
+    assert_eq!(written, vec![ownership::canonical_string(repo.path())]);
+}
+
+#[test]
+fn trust_path_creates_a_global_config_when_there_is_none() {
+    let _lock = SEARCH_PATH.lock().unwrap();
+    let home = tempfile::tempdir().unwrap();
+    unsafe {
+        git2::opts::set_search_path(git2::ConfigLevel::Global, home.path()).unwrap();
+    }
+
+    let repo = tempfile::tempdir().unwrap();
+    let result = ownership::trust_path(repo.path());
+
+    let config_path = home.path().join(".gitconfig");
+    let exists = config_path.exists();
+    let written = exists.then(|| safe_dirs(&config_path)).unwrap_or_default();
+    unsafe {
+        git2::opts::reset_search_path(git2::ConfigLevel::Global).unwrap();
+    }
+
+    result.unwrap();
+    assert!(exists, "expected a global config to be created");
+    assert_eq!(written, vec![ownership::canonical_string(repo.path())]);
+}
+
+// === presence probe and root walk ===
+
+#[test]
+fn repo_presence_finds_a_real_repo() {
+    let tr = TempRepo::with_initial_commit("hi\n");
+    assert_eq!(ownership::repo_presence(tr.path()), RepoPresence::Present);
+}
+
+#[test]
+fn repo_presence_reports_a_plain_directory_absent() {
+    let dir = tempfile::tempdir().unwrap();
+    assert_eq!(ownership::repo_presence(dir.path()), RepoPresence::Absent);
+}
+
+#[test]
+fn presence_exists_covers_present_and_refused() {
+    // The whole point of the enum: guards ask `exists()`, not `== Present`.
+    assert!(RepoPresence::Present.exists());
+    assert!(RepoPresence::Refused.exists());
+    assert!(!RepoPresence::Absent.exists());
+}
+
+#[test]
+fn repo_root_for_walks_up_from_a_subdirectory() {
+    let tr = TempRepo::with_initial_commit("hi\n");
+    let nested = tr.path().join("a/b/c");
+    std::fs::create_dir_all(&nested).unwrap();
+
+    let found = ownership::repo_root_for(&nested).expect("root");
+    assert_eq!(
+        ownership::canonical_string(&found),
+        ownership::canonical_string(tr.path())
+    );
+}
+
+#[test]
+fn repo_root_for_finds_the_root_itself() {
+    let tr = TempRepo::with_initial_commit("hi\n");
+    let found = ownership::repo_root_for(tr.path()).expect("root");
+    assert_eq!(
+        ownership::canonical_string(&found),
+        ownership::canonical_string(tr.path())
+    );
+}
+
+#[test]
+fn repo_root_for_returns_none_outside_a_repo() {
+    let dir = tempfile::tempdir().unwrap();
+    assert!(ownership::repo_root_for(dir.path()).is_none());
+}

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -50,7 +50,12 @@ import { UpdateChip } from "@/features/update/UpdateChip";
 import { UpdatePanel } from "@/features/update/UpdatePanel";
 import { useUpdateStore } from "@/features/update/useUpdateStore";
 import { BranchPicker } from "@/features/branches/BranchPicker";
-import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
+import {
+  DUBIOUS_OWNERSHIP_HELP,
+  EMBEDDED_REPO_HELP,
+  appErrorMessage,
+  dubiousOwnershipPath,
+} from "@/lib/errors";
 import {
   currentBranch,
   isStaged,
@@ -275,15 +280,24 @@ export function AppShell() {
             gap: 8,
           }}
         >
-          {/* The backend keeps EmbeddedRepo terse like the rest of the enum;
-              the actionable half of the story lives in the UI. */}
+          {/* The backend keeps EmbeddedRepo and DubiousOwnership terse like
+              the rest of the enum; the actionable half of the story lives in
+              the UI. A dismissed trust prompt must not leave the user staring
+              at libgit2's sentence with nothing to do about it. */}
           <strong>
-            {error.kind === "EmbeddedRepo" ? "Embedded repository" : error.kind}:
+            {error.kind === "EmbeddedRepo"
+              ? "Embedded repository"
+              : error.kind === "DubiousOwnership"
+                ? "Repository owned by another user"
+                : error.kind}
+            :
           </strong>
           <span style={{ flex: 1 }}>
             {error.kind === "EmbeddedRepo"
               ? `${appErrorMessage(error).replace(/^embedded repository: /, "")} — ${EMBEDDED_REPO_HELP}`
-              : appErrorMessage(error)}
+              : error.kind === "DubiousOwnership"
+                ? `${dubiousOwnershipPath(error)} — ${DUBIOUS_OWNERSHIP_HELP}`
+                : appErrorMessage(error)}
           </span>
           <button
             onClick={clearError}

--- a/src/features/create/useCreateStore.ownership.test.ts
+++ b/src/features/create/useCreateStore.ownership.test.ts
@@ -1,0 +1,89 @@
+// Initialising a repository on a Windows drive under WSL trips the same
+// ownership check as opening one, because libgit2 opens what it just created.
+// Without the same remedy here the Init dialog is a dead end for exactly the
+// users issue #83 is about.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCreateStore } from "@/features/create/useCreateStore";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+
+const confirmTrust = vi.hoisted(() => vi.fn());
+vi.mock("@/features/repo/ownership", () => ({ confirmTrust }));
+
+const REFUSED = {
+  kind: "DubiousOwnership",
+  message: "repository is owned by another user: /mnt/c/dev/fresh",
+};
+const HANDLE = { id: "repo-1", path: "/mnt/c/dev/fresh", head: "main" };
+
+/** `init_repo` refuses `failures` times, then succeeds. */
+function armInit(failures: number) {
+  let seen = 0;
+  mockInvoke("init_repo", () => {
+    if (seen++ < failures) throw REFUSED;
+    return HANDLE;
+  });
+}
+
+const calls = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+const ARGS = { parentDir: "/mnt/c/dev", name: "fresh", branch: "main" };
+
+describe("useCreateStore.runInit — dubious ownership", () => {
+  beforeEach(() => {
+    useCreateStore.setState({ open: "init", busy: false, progress: null, error: null });
+    // The follow-up open is the repo store's business, not this test's.
+    useRepoStore.setState({ openRepo: async () => {} });
+    confirmTrust.mockReset();
+    mockInvoke("trust_repo_path", () => null);
+  });
+
+  it("trusts the path and retries when the user accepts", async () => {
+    armInit(1);
+    confirmTrust.mockResolvedValue(true);
+
+    await useCreateStore.getState().runInit(ARGS);
+
+    expect(confirmTrust).toHaveBeenCalledWith("/mnt/c/dev/fresh");
+    expect(calls("trust_repo_path")).toHaveLength(1);
+    expect(calls("init_repo")).toHaveLength(2);
+    expect(useCreateStore.getState().error).toBeNull();
+    expect(useCreateStore.getState().open).toBe("none");
+    expect(useCreateStore.getState().busy).toBe(false);
+  });
+
+  it("keeps the dialog open with the error when the user declines", async () => {
+    armInit(1);
+    confirmTrust.mockResolvedValue(false);
+
+    await useCreateStore.getState().runInit(ARGS);
+
+    expect(calls("trust_repo_path")).toHaveLength(0);
+    expect(useCreateStore.getState().open).toBe("init");
+    expect(useCreateStore.getState().error).toContain("owned by another user");
+    expect(useCreateStore.getState().busy).toBe(false);
+  });
+
+  it("does not loop when trusting fails to help", async () => {
+    armInit(99);
+    confirmTrust.mockResolvedValue(true);
+
+    await useCreateStore.getState().runInit(ARGS);
+
+    expect(confirmTrust).toHaveBeenCalledTimes(1);
+    expect(calls("init_repo")).toHaveLength(2);
+    expect(useCreateStore.getState().busy).toBe(false);
+    expect(useCreateStore.getState().error).toContain("owned by another user");
+  });
+
+  it("leaves other init failures untouched", async () => {
+    mockInvoke("init_repo", () => {
+      throw { kind: "InvalidPath", message: "/mnt/c/dev/fresh is already a git repository" };
+    });
+
+    await useCreateStore.getState().runInit(ARGS);
+
+    expect(confirmTrust).not.toHaveBeenCalled();
+    expect(useCreateStore.getState().error).toContain("already a git repository");
+  });
+});

--- a/src/features/create/useCreateStore.ts
+++ b/src/features/create/useCreateStore.ts
@@ -1,10 +1,11 @@
 import { create } from "zustand";
 
+import { confirmTrust } from "@/features/repo/ownership";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
-import { cloneRepo, initRepo } from "@/lib/tauri";
-import type { CloneProgress } from "@/lib/types";
-import { appErrorMessage } from "@/lib/errors";
+import { cloneRepo, initRepo, trustRepoPath } from "@/lib/tauri";
+import type { CloneProgress, RepoHandle } from "@/lib/types";
+import { appErrorMessage, dubiousOwnershipPath, isDubiousOwnershipError } from "@/lib/errors";
 
 type OpenDialog = "none" | "clone" | "init";
 
@@ -75,13 +76,33 @@ export const useCreateStore = create<CreateState>((set, get) => ({
 
   async runInit({ parentDir, name, branch }) {
     set({ busy: true, error: null });
-    try {
-      const path = `${parentDir}/${name}`;
-      const handle = await initRepo(path, branch);
+    const path = `${parentDir}/${name}`;
+    const finish = async (handle: RepoHandle) => {
       useSettingsStore.getState().set("lastCreateDir", parentDir);
       set({ busy: false, open: "none" });
       await useRepoStore.getState().openRepo(handle.path);
+    };
+    try {
+      await finish(await initRepo(path, branch));
     } catch (e) {
+      // Initialising on a Windows drive under WSL trips the same ownership
+      // check as opening one — libgit2 opens what it just created. Offer the
+      // same remedy here, or the Init dialog is a dead end for exactly the
+      // users issue #83 is about.
+      if (isDubiousOwnershipError(e)) {
+        const target = dubiousOwnershipPath(e) ?? path;
+        if (await confirmTrust(target)) {
+          try {
+            await trustRepoPath(target);
+            await finish(await initRepo(path, branch));
+            return;
+          } catch (retryError) {
+            set({ busy: false, error: appErrorMessage(retryError) });
+            return;
+          }
+        }
+      }
+      // Error stays in the dialog so the form keeps its values.
       set({ busy: false, error: appErrorMessage(e) });
     }
   },

--- a/src/features/repo/ownership.tsx
+++ b/src/features/repo/ownership.tsx
@@ -1,0 +1,22 @@
+import { pgConfirm } from "@/design";
+import { DUBIOUS_OWNERSHIP_HELP } from "@/lib/errors";
+
+/**
+ * Ask before writing a `safe.directory` exception for `path`.
+ *
+ * Kept out of the store on purpose: the store's tests can then decide the
+ * answer without mounting a dialog host, and the copy sits beside the help
+ * text rather than inside a state machine.
+ */
+export async function confirmTrust(path: string): Promise<boolean> {
+  return pgConfirm({
+    title: "Trust this repository?",
+    body: (
+      <>
+        <div className="mono break-all">{path}</div>
+        <p className="mt-2">{DUBIOUS_OWNERSHIP_HELP}</p>
+      </>
+    ),
+    confirmLabel: "Trust and open",
+  });
+}

--- a/src/features/repo/useRepoStore.ownership.test.ts
+++ b/src/features/repo/useRepoStore.ownership.test.ts
@@ -1,0 +1,124 @@
+// Opening a repository libgit2 says is owned by someone else (the WSL
+// /mnt/c case) must offer the safe.directory remedy and retry. It lives in
+// the store rather than a screen so every entry point — Welcome, recents, the
+// pgit CLI launch, the palette — gets it without repeating itself.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+
+const confirmTrust = vi.hoisted(() => vi.fn());
+vi.mock("@/features/repo/ownership", () => ({ confirmTrust }));
+
+const REFUSED = {
+  kind: "DubiousOwnership",
+  message: "repository is owned by another user: /mnt/c/dev/reponame",
+};
+const HANDLE = { id: "repo-1", path: "/mnt/c/dev/reponame", head: "main" };
+
+const initial = useRepoStore.getState();
+
+/** `open_repo` refuses `failures` times, then succeeds. */
+function armOpen(failures: number) {
+  let seen = 0;
+  mockInvoke("open_repo", () => {
+    if (seen++ < failures) throw REFUSED;
+    return HANDLE;
+  });
+}
+
+const calls = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+
+describe("useRepoStore.openRepo — dubious ownership", () => {
+  beforeEach(() => {
+    useRepoStore.setState(initial, true);
+    // Isolate the trust flow from the full post-open refresh fan-out.
+    useRepoStore.setState({ refreshAll: async () => {} });
+    confirmTrust.mockReset();
+    mockInvoke("trust_repo_path", () => null);
+  });
+
+  it("trusts the path and retries when the user accepts", async () => {
+    armOpen(1);
+    confirmTrust.mockResolvedValue(true);
+
+    await useRepoStore.getState().openRepo("/mnt/c/dev/reponame");
+
+    expect(confirmTrust).toHaveBeenCalledWith("/mnt/c/dev/reponame");
+    expect(calls("trust_repo_path")).toHaveLength(1);
+    expect(useRepoStore.getState().current).toEqual(HANDLE);
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("trusts the path the backend named, not the one that was asked for", async () => {
+    // The backend canonicalises; safe.directory matching is exact, so the
+    // canonical path is the only one worth writing.
+    let seen = 0;
+    mockInvoke("open_repo", () => {
+      if (seen++ === 0) {
+        throw {
+          kind: "DubiousOwnership",
+          message: "repository is owned by another user: /mnt/c/dev/reponame",
+        };
+      }
+      return HANDLE;
+    });
+    confirmTrust.mockResolvedValue(true);
+
+    await useRepoStore.getState().openRepo("/mnt/c/dev/reponame/");
+
+    expect(confirmTrust).toHaveBeenCalledWith("/mnt/c/dev/reponame");
+    expect(calls("trust_repo_path")[0]?.args).toMatchObject({
+      path: "/mnt/c/dev/reponame",
+    });
+  });
+
+  it("shows the error and writes nothing when the user declines", async () => {
+    armOpen(1);
+    confirmTrust.mockResolvedValue(false);
+
+    await useRepoStore.getState().openRepo("/mnt/c/dev/reponame");
+
+    expect(calls("trust_repo_path")).toHaveLength(0);
+    expect(useRepoStore.getState().error?.kind).toBe("DubiousOwnership");
+    expect(useRepoStore.getState().current).toBeNull();
+    expect(useRepoStore.getState().loading).toBe(false);
+  });
+
+  it("does not loop when trusting fails to help", async () => {
+    armOpen(99);
+    confirmTrust.mockResolvedValue(true);
+
+    await useRepoStore.getState().openRepo("/mnt/c/dev/reponame");
+
+    // One prompt, one retry — never a second round.
+    expect(confirmTrust).toHaveBeenCalledTimes(1);
+    expect(calls("open_repo")).toHaveLength(2);
+    expect(useRepoStore.getState().error?.kind).toBe("DubiousOwnership");
+    expect(useRepoStore.getState().loading).toBe(false);
+  });
+
+  it("surfaces a failure to write the exception", async () => {
+    armOpen(99);
+    confirmTrust.mockResolvedValue(true);
+    mockInvoke("trust_repo_path", () => {
+      throw { kind: "Io", message: "permission denied" };
+    });
+
+    await useRepoStore.getState().openRepo("/mnt/c/dev/reponame");
+
+    expect(useRepoStore.getState().error?.kind).toBe("Io");
+    expect(useRepoStore.getState().loading).toBe(false);
+  });
+
+  it("leaves other open failures untouched", async () => {
+    mockInvoke("open_repo", () => {
+      throw { kind: "NotARepo", message: "path is not a git repository: /tmp/x" };
+    });
+
+    await useRepoStore.getState().openRepo("/tmp/x");
+
+    expect(confirmTrust).not.toHaveBeenCalled();
+    expect(useRepoStore.getState().error?.kind).toBe("NotARepo");
+  });
+});

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -15,7 +15,8 @@ import type {
   TagInfo,
 } from "@/lib/types";
 import type { AppError } from "@/lib/errors";
-import { isAppError } from "@/lib/errors";
+import { dubiousOwnershipPath, isAppError, isDubiousOwnershipError } from "@/lib/errors";
+import { confirmTrust } from "@/features/repo/ownership";
 import {
   abortOperation,
   acceptOurs,
@@ -49,6 +50,7 @@ import {
   markResolved,
   mergeBranch as mergeBranchFn,
   openRepo,
+  trustRepoPath,
   pruneRemote,
   pull as pullRemote,
   push as pushRemote,
@@ -291,6 +293,28 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       return { activity: next };
     });
   };
+  /** Open `path` and reset every per-repo slice. Throws on failure. */
+  const applyOpenedRepo = async (path: string) => {
+    const handle = await openRepo(path);
+    useRecentsStore.getState().addRecent(handle.path);
+    set({
+      current: handle,
+      status: [],
+      allFiles: [],
+      branches: [],
+      tags: [],
+      stashes: [],
+      remotes: [],
+      commits: [],
+      searchResults: null,
+      commitFilter: {},
+      lastRebaseSummary: null,
+      logRef: null,
+      commitCursor: null,
+      searchCursor: null,
+    });
+    await get().refreshAll();
+  };
   return ({
   current: null,
   status: [],
@@ -317,26 +341,29 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   async openRepo(path) {
     set({ loading: true, error: null });
     try {
-      const handle = await openRepo(path);
-      useRecentsStore.getState().addRecent(handle.path);
-      set({
-        current: handle,
-        status: [],
-        allFiles: [],
-        branches: [],
-        tags: [],
-        stashes: [],
-        remotes: [],
-        commits: [],
-        searchResults: null,
-        commitFilter: {},
-        lastRebaseSummary: null,
-        logRef: null,
-        commitCursor: null,
-        searchCursor: null,
-      });
-      await get().refreshAll();
+      await applyOpenedRepo(path);
     } catch (e) {
+      // git refuses a repository owned by another user, which a Windows drive
+      // mounted under WSL routinely looks like. That refusal is remediable,
+      // and handling it here rather than per-screen covers Welcome, recents,
+      // the CLI launch and the palette at once.
+      if (isDubiousOwnershipError(e)) {
+        // Trust what the backend named — it canonicalised the path, and
+        // safe.directory matching is exact.
+        const target = dubiousOwnershipPath(e) ?? path;
+        if (await confirmTrust(target)) {
+          try {
+            await trustRepoPath(target);
+            // Deliberately not recursive: one retry. If the exception did not
+            // help, show the error rather than asking again forever.
+            await applyOpenedRepo(path);
+            return;
+          } catch (retryError) {
+            set({ loading: false, error: toAppError(retryError) });
+            return;
+          }
+        }
+      }
       set({ loading: false, error: toAppError(e) });
     }
   },

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -14,7 +14,8 @@ export type AppError =
   | { kind: "NoSignature"; message?: string }
   | { kind: "Internal"; message: string }
   | { kind: "Network"; message: string }
-  | { kind: "EmbeddedRepo"; message: string };
+  | { kind: "EmbeddedRepo"; message: string }
+  | { kind: "DubiousOwnership"; message: string };
 
 export function isAppError(e: unknown): e is AppError {
   return (
@@ -42,5 +43,30 @@ export function isEmbeddedRepoError(e: unknown): boolean {
  * terse (`embedded repository: vendor/lib/`) like the rest of the enum —
  * remediation prose belongs here, next to the UI that can act on it.
  */
+export function isDubiousOwnershipError(e: unknown): boolean {
+  return isAppError(e) && e.kind === "DubiousOwnership";
+}
+
+/**
+ * The path the backend refused, without the enum's prefix. Same split of
+ * duties as the embedded-repo helpers above: the Rust error stays terse, the
+ * words the user reads live here.
+ */
+export function dubiousOwnershipPath(e: unknown): string | null {
+  if (!isDubiousOwnershipError(e)) return null;
+  return appErrorMessage(e).replace(/^repository is owned by another user: /, "");
+}
+
+/**
+ * Why git refuses, and what accepting costs. Opening a repository runs
+ * commands its own config names (`core.pager`, `core.fsmonitor`), so a
+ * repository owned by someone else is a way to run their code — which is what
+ * the check exists to stop. On a Windows drive under WSL the owner mismatch
+ * is an artefact of how the drive is mounted, not a threat; the app cannot
+ * tell those two apart, so the user decides, once per repository.
+ */
+export const DUBIOUS_OWNERSHIP_HELP =
+  "git refuses to open a repository owned by another user, because opening one can run commands from that repository's config. This is expected for repositories on a Windows drive under WSL. Trusting it adds a safe.directory entry to your global git config.";
+
 export const EMBEDDED_REPO_HELP =
   "This folder is a git repository of its own, so git can only record it as a bare pointer that nobody who clones this repo can resolve. Add it to .gitignore, or register it as a submodule.";

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -53,6 +53,15 @@ export async function openRepo(path: string): Promise<RepoHandle> {
   return invoke<RepoHandle>("open_repo", { path });
 }
 
+/**
+ * Add `path` to the user's global `safe.directory` list so git will open it
+ * despite an ownership mismatch. Only ever call this behind an explicit
+ * confirmation — it is a security exception, not a preference.
+ */
+export async function trustRepoPath(path: string): Promise<void> {
+  return invoke<void>("trust_repo_path", { path });
+}
+
 export async function getStatus(repoId: string): Promise<FileStatus[]> {
   return invoke<FileStatus[]>("get_status", { repoId });
 }


### PR DESCRIPTION
Closes #83.

## What was broken

libgit2 1.9.2 enforces git's CVE-2022-24765 ownership check (`validate_ownership` in `repository.c`, reached from `git_repository_open_ext`): the working directory, gitdir and any gitlink must be owned by the current user, or the open fails with `GIT_EOWNER`. On WSL, `/mnt/c` is a drvfs mount whose reported ownership depends on the mount's `uid=`/`metadata` options and the Windows-side ACL, so it routinely disagrees with the WSL uid even for the user's own repository.

`Libgit2Backend::open` mapped only `NotFound`, so this stringified into a generic `AppError::Git` — an error banner reading *"repository path '/mnt/c/dev/reponame' is not owned by current user"* with no way forward. Keeping code on the Windows filesystem and editing it from both sides is an ordinary setup, and it simply did not work.

## What it does now

Opening such a repository asks:

> **Trust this repository?**
> `/mnt/c/dev/reponame`
> git refuses to open a repository owned by another user, because opening one can run commands from that repository's config. This is expected for repositories on a Windows drive under WSL. Trusting it adds a safe.directory entry to your global git config.

Accepting writes the exception and retries the open — exactly what `git config --global --add safe.directory <path>` does, which is what git's own error text tells users to run. Declining shows the same explanation in the error banner instead of libgit2's bare sentence.

The flow lives in `useRepoStore.openRepo`, so Welcome, recents, the `pgit` CLI launch and the palette all get it without repeating themselves. `useCreateStore.runInit` gets the same treatment — `git_repository_init_ext` opens what it just created, so initialising on a Windows drive trips the identical check and the Init dialog would otherwise be a dead end for the same users.

## What libgit2 will actually accept

Read out of the vendored 1.9.2 source rather than assumed — three details shaped the implementation:

- **The config key is the working directory** (`validation_paths[0]`), which is exactly the path the error message names. The backend canonicalises it, since matching is exact.
- **Global config only.** `validate_ownership_config` calls `load_global_config`; the repository's own config is never consulted.
- **Exact match or the literal `*`.** The `dir/*` suffix glob newer git supports is not implemented in 1.9.2, so exceptions are per-repository. An empty value resets the accumulated list, same as git.

That last point produced two non-obvious requirements, both pinned by tests:

- the check **folds entries in order** rather than searching for any match — `directory = /x` followed by `directory =` leaves `/x` untrusted, and a search would have reported "already trusted" and silently declined to write the exception the user just asked for
- the append uses a value pattern that cannot match anything, **not** the usual `^$` — that matches a reset entry, and `set_multivar` would overwrite it, re-trusting everything listed above it

## Guards that an ownership refusal silently disabled

Four call sites inferred "no repository here" from a failed open. Two were guards:

| Site | Before, under `GIT_EOWNER` | Now |
| --- | --- | --- |
| embedded-repo probe (`libgit2.rs`) | reads as an ordinary directory, so `reject_embedded_repo` stops firing and staging can write an unresolvable `160000` gitlink | counts as a repository |
| init guard (`libgit2.rs`) | "not a repo yet", so `init` proceeds over an existing repository | reports the ownership error |
| clone-target guard (`create.rs`) | "not a repo", so cloning into an existing repo root is allowed | counts as a repository |
| `resolve_repo_root` (`cli.rs`) | `discover` fails, raw path passes through, a subdirectory launch reports `NotARepo` | walks ancestors for `.git` without opening |

The last one matters beyond the message: trusting a *subdirectory* does nothing, because matching is exact, so the trust target has to be the root.

A new `RepoPresence { Present, Absent, Refused }` makes the distinction explicit; guards ask `.exists()`.

## Considered and rejected

`git2::opts::set_verify_owner_validation(false)` at startup. It is `unsafe`, process-global, and permanently disables the protection for every repository the app touches — including one dropped into a shared or temp directory by someone else, whose `core.pager`/`core.fsmonitor` would then run on open. The whole point of the check is that the attacker controls the config. A per-path, user-confirmed exception costs one click and gives up nothing else. Same objection to a Settings toggle, and to auto-trusting anything that looks like `/mnt/`.

## Verification

- `cargo test` — 33 test binaries, 0 failures, including a new `dubious_ownership.rs` (22 tests)
- `pnpm test` — 641 tests / 80 files, 0 failures, including 6 new store tests and 4 new create-store tests
- `pnpm tsc --noEmit` and `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — clean
- `pnpm test:e2e:docker full --spec e2e/specs/smoke.e2e.ts --spec e2e/specs/create.e2e.ts` — 2 spec files, 4 tests, passing on WebKitGTK, run against a snapshot rebuilt from this branch

**Not covered:** whether a real `GIT_EOWNER` reaches the new arm. Provoking it needs a directory owned by a different uid, i.e. root, so the mapping is tested against a synthetic `git2::Error` with `ErrorCode::Owner` — the shape libgit2 returns. Everything downstream (the `safe.directory` writer, the presence probe, the root walk) is tested for real. Worth one manual check on an actual WSL box before release.

Design and plan: `docs/superpowers/specs/2026-08-13-wsl-dubious-ownership-design.md`, `docs/superpowers/plans/2026-08-13-wsl-dubious-ownership.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
