### PR TITLE
feat(ux): issue #61 Tier 2 pt 1 — upstream, content search, skeletons

### DIFF
--- a/docs/superpowers/plans/2026-08-13-issue-61-tier2-pr1-cheap-wins.md
+++ b/docs/superpowers/plans/2026-08-13-issue-61-tier2-pr1-cheap-wins.md
@@ -1,0 +1,1451 @@
+# Issue #61 Tier 2, PR 1 — set-upstream, content log search, skeletons
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the three small independent items of #61 Tier 2 — editable branch tracking (D9), content search in the log (D10), and skeleton loaders (B6).
+
+**Architecture:** D9 follows CLAUDE.md's standard "adding a new git op" path end to end (trait → libgit2 → CliBackend stub → command → registry → TS wrapper → store → UI). D10 adds two fields to `LogFilter` and one predicate to the existing `log_filtered_page` walk, positioned last because it is the only filter that costs a diff per commit. B6 adds a presentational `PGSkeleton` primitive driving the already-defined `.pg-shimmer` keyframe and applies it at three load sites.
+
+**Tech Stack:** Rust + git2 0.20 + the new `regex` crate; React 19 + TypeScript + Zustand; vitest + React Testing Library; `cargo test` for backend integration over the `TempRepo` fixture.
+
+**Spec:** `docs/superpowers/specs/2026-08-13-issue-61-tier2-design.md`
+
+## Global Constraints
+
+- **Toolchain PATH.** Every `pnpm`/`cargo` command must be prefixed with `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"` — the Bash tool does not inherit the interactive shell rc.
+- **Node 22 + pnpm.** Never npm, never yarn.
+- **Errors:** every IPC-crossing Rust fn returns `AppResult<T>`. Add an `AppError` variant rather than stringifying. A new Rust variant updates `src/lib/errors.ts` in the **same commit**.
+- **Frontend never calls `invoke()` directly** — only via typed wrappers in `src/lib/tauri.ts`.
+- **`git2::Repository` is not `Sync`** — every git2 call from a Tauri command goes through `tokio::task::spawn_blocking`.
+- **`CliBackend` gets a `NotImplemented` stub for every new trait method** — keeps the trait shape exercised.
+- **Any new list-row surface opts into UI density:** `height: "calc(<base>px + var(--row-step))"`, or `padding: "calc(<base>px + var(--row-step) / 2) …"` for padding-sized rows. `--row-step` is 0 in compact.
+- **Never hardcode the accent hue** — use `var(--accent)` or `oklch(from var(--accent) l c h / <alpha>)`.
+- **Import UI primitives from `@/design`**, never per-file. New primitive → add file in `src/design/` and re-export from `src/design/index.ts`.
+- **Dialogs:** `pgConfirm` / `pgPrompt` from `@/design`. Never `window.confirm` / `window.prompt`.
+- **Commit style:** Conventional Commits, imperative subject under 72 chars, `Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>` trailer.
+- **E2E:** only via `pnpm test:e2e:docker`, never natively, only when done developing, only the affected specs.
+
+---
+
+### Task 1: Add the `InvalidArgument` error variant
+
+`AppError` has no variant for "the caller passed something invalid" — the closest, `InvalidRef`, is specifically about references. D10's malformed-regex case and (in PR 2) D7's empty line selection both need it.
+
+**Files:**
+- Modify: `src-tauri/src/error.rs:5-52` (enum)
+- Modify: `src/lib/errors.ts:1-17` (union)
+
+**Interfaces:**
+- Produces: `AppError::InvalidArgument(String)` in Rust; `{ kind: "InvalidArgument"; message: string }` in the TS union.
+
+- [ ] **Step 1: Add the Rust variant**
+
+In `src-tauri/src/error.rs`, directly after the `InvalidRef` variant:
+
+```rust
+    #[error("invalid argument: {0}")]
+    InvalidArgument(String),
+```
+
+- [ ] **Step 2: Mirror it in the TS union**
+
+In `src/lib/errors.ts`, directly after the `InvalidRef` line:
+
+```typescript
+  | { kind: "InvalidArgument"; message: string }
+```
+
+- [ ] **Step 3: Verify both sides compile**
+
+Run:
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo check --manifest-path src-tauri/Cargo.toml && pnpm tsc --noEmit
+```
+Expected: both succeed with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/error.rs src/lib/errors.ts
+git commit -m "feat(errors): add InvalidArgument variant
+
+Why: a malformed regex or an empty line selection is a caller-argument
+problem, not an InvalidRef and not an internal error. Mirrored into
+errors.ts the same commit, per the 1:1 convention.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: D9 backend — `set_upstream`
+
+**Files:**
+- Modify: `src-tauri/src/git/mod.rs:199-202` (trait, beside the other branch ops)
+- Modify: `src-tauri/src/git/libgit2.rs` (impl, beside `rename_branch`)
+- Modify: `src-tauri/src/git/cli.rs` (stub)
+- Test: `src-tauri/tests/branches_tags.rs` (append)
+
+**Interfaces:**
+- Produces: `fn set_upstream(&self, repo_id: &RepoId, branch: &str, upstream: Option<&str>) -> AppResult<()>` on `GitBackend`. `Some("origin/main")` sets tracking; `None` clears it. Unknown local branch or unknown remote-tracking branch → `AppError::InvalidRef`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src-tauri/tests/branches_tags.rs`:
+
+```rust
+/// Create a second repo as `origin`, fetch it, so remote-tracking refs exist.
+fn with_origin() -> (TempRepo, TempRepo) {
+    let upstream = TempRepo::with_initial_commit("hello\n");
+    let local = TempRepo::with_initial_commit("hello\n");
+    local
+        .repo
+        .remote("origin", upstream.path().to_str().unwrap())
+        .unwrap();
+    let mut remote = local.repo.find_remote("origin").unwrap();
+    remote
+        .fetch(&["refs/heads/*:refs/remotes/origin/*"], None, None)
+        .unwrap();
+    (local, upstream)
+}
+
+#[test]
+fn set_upstream_sets_tracking_branch() {
+    let (tr, _up) = with_origin();
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .set_upstream(&handle.id, "main", Some("origin/main"))
+        .expect("set upstream");
+
+    let branches = backend.branches(&handle.id).unwrap();
+    let main = branches
+        .iter()
+        .find(|b| b.name == "main" && !b.is_remote)
+        .expect("main branch");
+    assert_eq!(main.upstream.as_deref(), Some("origin/main"));
+}
+
+#[test]
+fn set_upstream_none_clears_tracking() {
+    let (tr, _up) = with_origin();
+    let (backend, handle) = tr.open_with_backend();
+    backend
+        .set_upstream(&handle.id, "main", Some("origin/main"))
+        .unwrap();
+
+    backend
+        .set_upstream(&handle.id, "main", None)
+        .expect("clear upstream");
+
+    let branches = backend.branches(&handle.id).unwrap();
+    let main = branches
+        .iter()
+        .find(|b| b.name == "main" && !b.is_remote)
+        .unwrap();
+    assert!(main.upstream.is_none(), "tracking should be cleared");
+}
+
+#[test]
+fn set_upstream_unknown_remote_branch_is_invalid_ref() {
+    let (tr, _up) = with_origin();
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .set_upstream(&handle.id, "main", Some("origin/nope"))
+        .expect_err("should reject unknown remote branch");
+
+    assert!(
+        matches!(err, platypusgit_lib::error::AppError::InvalidRef(_)),
+        "expected InvalidRef, got {err:?}"
+    );
+}
+
+#[test]
+fn set_upstream_unknown_local_branch_is_invalid_ref() {
+    let (tr, _up) = with_origin();
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .set_upstream(&handle.id, "nope", Some("origin/main"))
+        .expect_err("should reject unknown local branch");
+
+    assert!(
+        matches!(err, platypusgit_lib::error::AppError::InvalidRef(_)),
+        "expected InvalidRef, got {err:?}"
+    );
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test branches_tags 2>&1 | tail -20
+```
+Expected: compile error — `no method named set_upstream found for struct Libgit2Backend`.
+
+- [ ] **Step 3: Add the trait method**
+
+In `src-tauri/src/git/mod.rs`, immediately after the `rename_branch` line (currently `:202`):
+
+```rust
+    /// Set or clear a local branch's upstream (tracking) branch.
+    ///
+    /// `upstream` is a remote-tracking branch shorthand such as
+    /// `"origin/main"`; `None` clears tracking. Both the local branch and the
+    /// remote-tracking branch must exist — either missing is `InvalidRef`,
+    /// which is why this validates before mutating rather than letting
+    /// libgit2 fail deep inside with a stringified message.
+    fn set_upstream(
+        &self,
+        repo_id: &RepoId,
+        branch: &str,
+        upstream: Option<&str>,
+    ) -> AppResult<()>;
+```
+
+- [ ] **Step 4: Implement it in `Libgit2Backend`**
+
+In `src-tauri/src/git/libgit2.rs`, immediately after the `rename_branch` impl:
+
+```rust
+    fn set_upstream(
+        &self,
+        repo_id: &RepoId,
+        branch: &str,
+        upstream: Option<&str>,
+    ) -> AppResult<()> {
+        self.with_repo(repo_id, |repo| {
+            // Validate the remote-tracking branch BEFORE touching config, so a
+            // typo is a clean InvalidRef instead of a stringified libgit2 error.
+            if let Some(up) = upstream {
+                repo.find_branch(up, BranchType::Remote)
+                    .map_err(|_| AppError::InvalidRef(up.to_string()))?;
+            }
+            let mut local = repo
+                .find_branch(branch, BranchType::Local)
+                .map_err(|_| AppError::InvalidRef(branch.to_string()))?;
+            local.set_upstream(upstream)?;
+            Ok(())
+        })
+    }
+```
+
+- [ ] **Step 5: Add the `CliBackend` stub**
+
+In `src-tauri/src/git/cli.rs`, beside the other branch stubs:
+
+```rust
+    fn set_upstream(
+        &self,
+        _repo_id: &RepoId,
+        _branch: &str,
+        _upstream: Option<&str>,
+    ) -> AppResult<()> {
+        Err(AppError::NotImplemented)
+    }
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run:
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test branches_tags 2>&1 | tail -20
+```
+Expected: all four new tests pass, existing tests still pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/src/git/mod.rs src-tauri/src/git/libgit2.rs src-tauri/src/git/cli.rs src-tauri/tests/branches_tags.rs
+git commit -m "feat(branches): set_upstream backend op (#61 D9)
+
+Why: BranchInfo.upstream/ahead/behind were displayed but tracking could
+not be changed. Validates the remote-tracking branch before mutating so a
+typo surfaces as InvalidRef, the shape the UI already handles.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: D9 command, wrapper and store action
+
+**Files:**
+- Modify: `src-tauri/src/commands/branches.rs` (new command beside `rename_branch`)
+- Modify: `src-tauri/src/lib.rs` (`invoke_handler!` registry)
+- Modify: `src/lib/tauri.ts:353-359` (beside `renameBranch`)
+- Modify: `src/features/repo/useRepoStore.ts` (import list, interface, action beside `renameBranch:780`)
+
+**Interfaces:**
+- Consumes: `GitBackend::set_upstream` from Task 2.
+- Produces: Tauri command `set_upstream`; `setUpstream(repoId: string, branch: string, upstream: string | null): Promise<void>` in `lib/tauri.ts`; `setUpstream(branch: string, upstream: string | null): Promise<void>` on `useRepoStore`.
+
+- [ ] **Step 1: Add the Tauri command**
+
+In `src-tauri/src/commands/branches.rs`, beside the other branch commands:
+
+```rust
+#[tauri::command]
+pub async fn set_upstream(
+    state: State<'_, AppState>,
+    repo_id: String,
+    branch: String,
+    upstream: Option<String>,
+) -> AppResult<()> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    tokio::task::spawn_blocking(move || {
+        backend.set_upstream(&repo_id, &branch, upstream.as_deref())
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+}
+```
+
+- [ ] **Step 2: Register it**
+
+In `src-tauri/src/lib.rs`, add `commands::branches::set_upstream` to `invoke_handler![…]` beside `rename_branch`.
+
+- [ ] **Step 3: Add the typed wrapper**
+
+In `src/lib/tauri.ts`, directly after `renameBranch`:
+
+```typescript
+/**
+ * Set or clear a branch's upstream. `null` clears tracking; a remote-tracking
+ * shorthand such as `"origin/main"` sets it.
+ */
+export async function setUpstream(
+  repoId: string,
+  branch: string,
+  upstream: string | null,
+): Promise<void> {
+  return invoke<void>("set_upstream", { repoId, branch, upstream });
+}
+```
+
+- [ ] **Step 4: Add the store action**
+
+In `src/features/repo/useRepoStore.ts`: add `setUpstream` to the import list from `@/lib/tauri`, add to the store interface beside `renameBranch`:
+
+```typescript
+  setUpstream: (branch: string, upstream: string | null) => Promise<void>;
+```
+
+and the action beside `renameBranch` (`:780`):
+
+```typescript
+  async setUpstream(branch, upstream) {
+    const repo = get().current;
+    if (!repo) return;
+    try {
+      await setUpstream(repo.id, branch, upstream);
+      await get().refreshAll();
+    } catch (e) {
+      set({ error: toAppError(e) });
+    }
+  },
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run:
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo check --manifest-path src-tauri/Cargo.toml && pnpm tsc --noEmit
+```
+Expected: both clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/commands/branches.rs src-tauri/src/lib.rs src/lib/tauri.ts src/features/repo/useRepoStore.ts
+git commit -m "feat(branches): wire set_upstream through command and store (#61 D9)
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: D9 UI — Branches inspector and branch context menu
+
+Both entry points route through `pgPrompt`, relying on the contract that `design/dialog.tsx` already guarantees: **an empty submitted string is distinct from a cancelled dialog**. Empty clears tracking; cancel does nothing.
+
+**Files:**
+- Modify: `src/screens/Branches.tsx:766` (`Tracks` KV row) and `BranchActions` (`:789`)
+- Modify: `src/design/context-menu.tsx:613` (`branchMenuItems`)
+- Test: `src/screens/Branches.test.tsx` (create if absent)
+
+**Interfaces:**
+- Consumes: `useRepoStore().setUpstream` from Task 3; `pgPrompt` from `@/design`.
+
+- [ ] **Step 1: Write the failing component test**
+
+Create or append to `src/screens/Branches.test.tsx`. Note `WithDialogs` — without it every dialog resolves as cancelled and the assertion silently cannot pass:
+
+```tsx
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { WithDialogs } from "@/test/dialog";
+import { mockInvoke } from "@/test/setup";
+import { Branches } from "./Branches";
+
+describe("Branches upstream editing", () => {
+  it("sends the typed upstream to set_upstream", async () => {
+    const calls: unknown[] = [];
+    mockInvoke("set_upstream", (args) => {
+      calls.push(args);
+      return undefined;
+    });
+
+    render(
+      <WithDialogs>
+        <Branches />
+      </WithDialogs>,
+    );
+
+    await userEvent.click(await screen.findByText("main"));
+    await userEvent.click(screen.getByRole("button", { name: /set upstream/i }));
+    const input = await screen.findByRole("textbox");
+    await userEvent.clear(input);
+    await userEvent.type(input, "origin/main");
+    await userEvent.click(screen.getByRole("button", { name: /^ok$/i }));
+
+    await waitFor(() =>
+      expect(calls).toEqual([
+        expect.objectContaining({ branch: "main", upstream: "origin/main" }),
+      ]),
+    );
+  });
+});
+```
+
+> If `Branches` needs seeded repo state to render a branch list, seed it through `mockInvoke("list_branches", …)` and whatever `open_repo`/`get_status` responses the existing screen tests use — copy the setup from the nearest existing screen test rather than inventing one.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run:
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/screens/Branches.test.tsx 2>&1 | tail -20
+```
+Expected: FAIL — no "Set upstream" button exists.
+
+- [ ] **Step 3: Add the inspector actions**
+
+In `src/screens/Branches.tsx`, add a helper above `BranchActions`:
+
+```tsx
+/**
+ * Prompt for a branch's upstream. Empty submitted string clears tracking;
+ * a cancelled dialog (null) does nothing — the empty-vs-null distinction
+ * pgPrompt guarantees is what makes a prompt sufficient here.
+ */
+async function promptUpstream(branch: BranchInfo) {
+  const next = await pgPrompt({
+    title: `Upstream for ${branch.name}`,
+    body: "Remote-tracking branch, e.g. origin/main. Empty clears tracking.",
+    initialValue: branch.upstream ?? "",
+    placeholder: "origin/main",
+    mono: true,
+    // NOT requireValue: an empty submission is the "clear tracking" path.
+  });
+  if (next === null) return;
+  const trimmed = next.trim();
+  await useRepoStore
+    .getState()
+    .setUpstream(branch.name, trimmed === "" ? null : trimmed);
+}
+```
+
+Then in `BranchActions`, for local branches only:
+
+```tsx
+      {!branch.isRemote && (
+        <PGButton icon="link" onClick={() => void promptUpstream(branch)}>
+          Set upstream
+        </PGButton>
+      )}
+```
+
+Import `pgPrompt` from `@/design`. Use an icon name that exists in `design/icons.tsx`; if `link` is absent, pick an existing one rather than adding a glyph in this task.
+
+- [ ] **Step 4: Add the context-menu entry**
+
+In `src/design/context-menu.tsx`, inside `branchMenuItems` (`:613`), for local branches, following the existing item shape in that builder:
+
+```tsx
+    {
+      label: "Set upstream…",
+      icon: "link",
+      onSelect: () => void promptUpstreamFor(branch),
+    },
+```
+
+`branchMenuItems` builds items declaratively and does not import screens, so put `promptUpstreamFor` next to the other action helpers already used by this builder, calling `useRepoStore.getState().setUpstream` the same way. If the builder's existing items call store actions inline, match that instead of adding an indirection.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run:
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/screens/Branches.test.tsx 2>&1 | tail -20
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/screens/Branches.tsx src/design/context-menu.tsx src/screens/Branches.test.tsx
+git commit -m "feat(branches): set/clear upstream from inspector and context menu (#61 D9)
+
+Why: empty prompt string clears tracking, cancel is a no-op — the
+empty-vs-null contract pgPrompt already guarantees, which is what makes a
+prompt adequate here instead of a bespoke picker.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: D9 — first push establishes tracking
+
+`push` (`commands/branches.rs:198-218`) never passes `-u`, so a branch created in the app never gets an upstream from pushing it. Add `-u` when and only when the branch has no upstream yet.
+
+**Files:**
+- Modify: `src-tauri/src/commands/branches.rs:198-218` (`push`)
+- Test: `src-tauri/tests/network.rs` (append)
+
+**Interfaces:**
+- Consumes: `GitBackend::branches` to read current tracking.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src-tauri/tests/network.rs`. Push against a bare local repo — no network, no credentials:
+
+```rust
+#[test]
+fn push_of_untracked_branch_sets_upstream() {
+    // Bare repo acting as `origin`.
+    let bare_dir = tempfile::tempdir().unwrap();
+    git2::Repository::init_bare(bare_dir.path()).unwrap();
+
+    let tr = support::TempRepo::with_initial_commit("hello\n");
+    tr.repo
+        .remote("origin", bare_dir.path().to_str().unwrap())
+        .unwrap();
+
+    // Push with -u the same way the command does.
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(tr.path())
+        .args(["push", "-u", "origin", "main"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "push failed: {:?}", out);
+
+    let (backend, handle) = tr.open_with_backend();
+    let branches = backend.branches(&handle.id).unwrap();
+    let main = branches
+        .iter()
+        .find(|b| b.name == "main" && !b.is_remote)
+        .unwrap();
+    assert_eq!(main.upstream.as_deref(), Some("origin/main"));
+}
+```
+
+> This test pins the *behaviour we rely on* (`git push -u` leaves an upstream that `branches()` reports). The command's own branching is covered by the pure helper test in Step 3.
+
+- [ ] **Step 2: Run it**
+
+Run:
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test network 2>&1 | tail -20
+```
+Expected: PASS (it documents git's behaviour). If it fails, the local git is too old for `-u` on a file remote — stop and report rather than working around it.
+
+- [ ] **Step 3: Add a pure helper plus its test**
+
+In `src-tauri/src/commands/branches.rs`, above `push`:
+
+```rust
+/// Build `git push` args. `set_upstream` adds `-u`, which the caller passes
+/// only when the branch has no upstream yet — re-sending `-u` on every push
+/// would rewrite tracking the user may have deliberately pointed elsewhere.
+fn push_args(remote: &str, branch: &str, force: PushForce, set_upstream: bool) -> Vec<String> {
+    let mut args: Vec<String> = vec!["push".to_string()];
+    if set_upstream {
+        args.push("-u".to_string());
+    }
+    args.push(remote.to_string());
+    args.push(branch.to_string());
+    match force {
+        PushForce::None => {}
+        PushForce::WithLease => args.push("--force-with-lease".to_string()),
+        PushForce::Force => args.push("--force".to_string()),
+    }
+    args
+}
+
+#[cfg(test)]
+mod push_args_tests {
+    use super::*;
+
+    #[test]
+    fn adds_u_only_when_requested() {
+        assert_eq!(
+            push_args("origin", "main", PushForce::None, true),
+            vec!["push", "-u", "origin", "main"]
+        );
+        assert_eq!(
+            push_args("origin", "main", PushForce::None, false),
+            vec!["push", "origin", "main"]
+        );
+    }
+
+    #[test]
+    fn force_flag_comes_last() {
+        assert_eq!(
+            push_args("origin", "main", PushForce::WithLease, false),
+            vec!["push", "origin", "main", "--force-with-lease"]
+        );
+    }
+}
+```
+
+- [ ] **Step 4: Use it in `push`**
+
+Replace the body of `push` with:
+
+```rust
+    let repo_id = RepoId(repo_id);
+    let path = get_repo_path(&state, &repo_id).await?;
+
+    // -u only for a branch with no upstream yet: re-sending it on every push
+    // would silently rewrite tracking the user may have pointed elsewhere.
+    let needs_upstream = {
+        let backend = state.backend.clone();
+        let id = repo_id.clone();
+        let branch_name = branch.clone();
+        tokio::task::spawn_blocking(move || backend.branches(&id))
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?
+            .map(|bs| {
+                bs.iter()
+                    .any(|b| !b.is_remote && b.name == branch_name && b.upstream.is_none())
+            })
+            // A failure to read branches must not block the push; fall back to
+            // a plain push rather than guessing -u.
+            .unwrap_or(false)
+    };
+
+    let args = push_args(&remote, &branch, force, needs_upstream);
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    run_git(&path, &arg_refs).await
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run:
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml 2>&1 | tail -20
+```
+Expected: all pass, including `push_args_tests`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/commands/branches.rs src-tauri/tests/network.rs
+git commit -m "feat(push): set upstream on first push of an untracked branch (#61 D9)
+
+Why: -u only when the branch has no upstream — re-sending it every push
+would rewrite tracking the user may have deliberately pointed elsewhere.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: D10 backend — content predicate in the log walk
+
+**Files:**
+- Modify: `src-tauri/Cargo.toml` (add `regex`)
+- Modify: `src-tauri/src/git/types.rs` (`LogFilter` + `is_empty`)
+- Modify: `src-tauri/src/git/libgit2.rs:1304-1426` (`log_filtered_page`)
+- Test: `src-tauri/tests/log_filter.rs` (append)
+
+**Interfaces:**
+- Consumes: `AppError::InvalidArgument` from Task 1.
+- Produces: `LogFilter.content: Option<String>` and `LogFilter.content_regex: bool`. `-G` semantics: the pattern appears in a line the commit added or removed, comparing against the **first parent**.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src-tauri/tests/log_filter.rs`:
+
+```rust
+/// Repo where one commit adds a needle line and a later one removes it.
+fn needle_repo() -> TempRepo {
+    let tr = TempRepo::fresh();
+    commit_as(&tr, "a.txt", "alpha\n", "first", "Alice", "alice@example.com", 1000);
+    commit_as(&tr, "a.txt", "alpha\nNEEDLE here\n", "add needle", "Alice", "alice@example.com", 2000);
+    commit_as(&tr, "a.txt", "alpha\n", "drop needle", "Bob", "bob@example.com", 3000);
+    commit_as(&tr, "b.txt", "unrelated\n", "unrelated", "Bob", "bob@example.com", 4000);
+    tr
+}
+
+#[test]
+fn content_filter_finds_adding_and_removing_commits() {
+    let tr = needle_repo();
+    let (backend, handle) = tr.open_with_backend();
+
+    let filter = LogFilter {
+        content: Some("NEEDLE".into()),
+        ..Default::default()
+    };
+    let found = backend.log_filtered(&handle.id, &filter, None, 50).unwrap();
+
+    let subjects: Vec<&str> = found.iter().map(|c| c.summary.as_str()).collect();
+    assert!(subjects.contains(&"add needle"), "got {subjects:?}");
+    assert!(subjects.contains(&"drop needle"), "removal counts too: {subjects:?}");
+    assert!(!subjects.contains(&"unrelated"), "got {subjects:?}");
+    assert!(!subjects.contains(&"first"), "got {subjects:?}");
+}
+
+#[test]
+fn content_filter_regex_mode_matches() {
+    let tr = needle_repo();
+    let (backend, handle) = tr.open_with_backend();
+
+    let filter = LogFilter {
+        content: Some("NEE.LE".into()),
+        content_regex: true,
+        ..Default::default()
+    };
+    let found = backend.log_filtered(&handle.id, &filter, None, 50).unwrap();
+    assert_eq!(found.len(), 2, "regex should match both needle commits");
+}
+
+#[test]
+fn content_filter_substring_mode_does_not_treat_pattern_as_regex() {
+    let tr = needle_repo();
+    let (backend, handle) = tr.open_with_backend();
+
+    let filter = LogFilter {
+        content: Some("NEE.LE".into()),
+        ..Default::default()
+    };
+    let found = backend.log_filtered(&handle.id, &filter, None, 50).unwrap();
+    assert!(found.is_empty(), "substring mode must be literal");
+}
+
+#[test]
+fn content_filter_bad_regex_errors_before_walking() {
+    let tr = needle_repo();
+    let (backend, handle) = tr.open_with_backend();
+
+    let filter = LogFilter {
+        content: Some("([unclosed".into()),
+        content_regex: true,
+        ..Default::default()
+    };
+    let err = backend
+        .log_filtered(&handle.id, &filter, None, 50)
+        .expect_err("bad regex must error");
+    assert!(
+        matches!(err, platypusgit_lib::error::AppError::InvalidArgument(_)),
+        "expected InvalidArgument, got {err:?}"
+    );
+}
+
+#[test]
+fn content_filter_intersects_with_path_filter() {
+    let tr = needle_repo();
+    let (backend, handle) = tr.open_with_backend();
+
+    let filter = LogFilter {
+        content: Some("NEEDLE".into()),
+        path: Some("b.txt".into()),
+        ..Default::default()
+    };
+    let found = backend.log_filtered(&handle.id, &filter, None, 50).unwrap();
+    assert!(found.is_empty(), "needle is in a.txt, not b.txt");
+}
+```
+
+> `LogFilter` needs `#[derive(Default)]` for `..Default::default()`. If it does not derive it yet, add it in Step 3 — the existing tests construct it field-by-field and are unaffected.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run:
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test log_filter 2>&1 | tail -20
+```
+Expected: compile error — no field `content` on `LogFilter`.
+
+- [ ] **Step 3: Add the dependency and the filter fields**
+
+In `src-tauri/Cargo.toml`, in `[dependencies]`:
+
+```toml
+# Content log search (#61 D10) compiles the user's pattern once per walk.
+regex = "1"
+```
+
+In `src-tauri/src/git/types.rs`, add to `LogFilter` (and `#[derive(Default)]` if missing):
+
+```rust
+    /// Pattern that must appear in a line this commit added or removed
+    /// (git's `-G`, not `-S`: this is "the text was touched", not
+    /// "the occurrence count changed").
+    pub content: Option<String>,
+    /// Treat `content` as a regular expression rather than a literal substring.
+    #[serde(default)]
+    pub content_regex: bool,
+```
+
+and extend `is_empty`:
+
+```rust
+            && self.content.as_deref().map(str::trim).unwrap_or("").is_empty()
+```
+
+> `content_regex` alone must NOT make a filter non-empty — a regex toggle with no pattern is still no filter.
+
+- [ ] **Step 4: Add the diff-scan helper**
+
+In `src-tauri/src/git/libgit2.rs`, beside `commit_touches_path` (`:3107`):
+
+```rust
+/// Compiled content predicate: literal substring or regex.
+enum ContentMatcher {
+    Literal(String),
+    Regex(regex::Regex),
+}
+
+impl ContentMatcher {
+    fn is_match(&self, line: &str) -> bool {
+        match self {
+            ContentMatcher::Literal(s) => line.contains(s.as_str()),
+            ContentMatcher::Regex(re) => re.is_match(line),
+        }
+    }
+}
+
+/// True when `commit` added or removed a line matching `matcher` — git's `-G`.
+///
+/// Compared against the FIRST parent only, matching git's default `-G`
+/// behaviour on merges; a root commit is compared against an empty tree.
+/// `path` restricts the diff via pathspec when a path filter is active, so
+/// content and path intersect rather than union.
+fn commit_diff_matches_content(
+    repo: &git2::Repository,
+    commit: &git2::Commit<'_>,
+    matcher: &ContentMatcher,
+    path: Option<&std::path::Path>,
+) -> AppResult<bool> {
+    let commit_tree = commit.tree()?;
+    let parent_tree = match commit.parent(0) {
+        Ok(p) => Some(p.tree()?),
+        Err(_) => None,
+    };
+
+    let mut opts = git2::DiffOptions::new();
+    if let Some(p) = path {
+        opts.pathspec(p);
+    }
+    let diff = repo.diff_tree_to_tree(
+        parent_tree.as_ref(),
+        Some(&commit_tree),
+        Some(&mut opts),
+    )?;
+
+    let mut hit = false;
+    diff.foreach(
+        &mut |_, _| true,
+        None,
+        None,
+        Some(&mut |_delta, _hunk, line| {
+            // Added / removed lines only — context lines were not touched.
+            if matches!(line.origin(), '+' | '-') {
+                if let Ok(text) = std::str::from_utf8(line.content()) {
+                    if matcher.is_match(text) {
+                        hit = true;
+                    }
+                }
+            }
+            // Keep walking: `foreach` has no early exit, and a short-circuit
+            // via `false` would abort the whole diff as an error.
+            true
+        }),
+    )?;
+    Ok(hit)
+}
+```
+
+- [ ] **Step 5: Wire it into `log_filtered_page`**
+
+In `log_filtered_page`, after the `path_q` normalization (`:1336-1341`) and **before** `self.with_repo(…)`, compile the matcher once:
+
+```rust
+        // Compiled once, before any walking: a malformed pattern must fail
+        // immediately, not per commit.
+        let content_m = match filter
+            .content
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            None => None,
+            Some(pat) if filter.content_regex => Some(ContentMatcher::Regex(
+                regex::Regex::new(pat)
+                    .map_err(|e| AppError::InvalidArgument(format!("invalid regex: {e}")))?,
+            )),
+            Some(pat) => Some(ContentMatcher::Literal(pat.to_string())),
+        };
+```
+
+Then inside the walk, **after** the existing path check (`:1406-1410`) and before the ref collection:
+
+```rust
+                // content — the only filter that costs a diff per commit, so it
+                // runs last: an author- or path-scoped search only diffs the
+                // commits everything else already accepted.
+                if let Some(ref m) = content_m {
+                    if !commit_diff_matches_content(repo, &commit, m, path_q.as_deref())? {
+                        continue;
+                    }
+                }
+```
+
+- [ ] **Step 6: Run the tests**
+
+Run:
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test log_filter 2>&1 | tail -25
+```
+Expected: five new tests pass, existing `log_filter` and `log_pagination` tests still pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/src/git/types.rs src-tauri/src/git/libgit2.rs src-tauri/tests/log_filter.rs
+git commit -m "feat(log): content search over added/removed lines (#61 D10)
+
+Implements git's -G semantics — the pattern appears in a line the commit
+touched — not -S, which would need whole-blob occurrence counting on both
+sides of every candidate.
+
+Why: the predicate runs last in the walk because it is the only filter
+costing a diff per commit, and the regex compiles once before walking so a
+bad pattern fails immediately rather than per commit.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: D10 frontend — qualifier, types and the advanced panel field
+
+**Files:**
+- Modify: `src/lib/types.ts` (`LogFilter`)
+- Modify: `src/features/commits/logFilter.ts` (`parseQueryText`, `LogFilterInputs`, `buildLogFilter`, `normalizeFilter`)
+- Modify: `src/screens/History.tsx:96-110` (filter state), `:391` (panel props), `:1063` (`AdvancedSearchPanel`)
+- Test: `src/features/commits/logFilter.test.ts` (append)
+
+**Interfaces:**
+- Consumes: the Rust fields from Task 6, as `content?: string` and `contentRegex?: boolean` (serde renames to camelCase across IPC — match how `shaPrefix` is already spelled in `src/lib/types.ts`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/features/commits/logFilter.test.ts`:
+
+```typescript
+describe("content qualifier", () => {
+  it("parses content: into the content field", () => {
+    expect(parseQueryText("content:foo")).toEqual({ content: "foo" });
+  });
+
+  it("accepts contains: as an alias", () => {
+    expect(parseQueryText("contains:foo")).toEqual({ content: "foo" });
+  });
+
+  it("leaves other text as a message term", () => {
+    expect(parseQueryText("content:foo bar")).toEqual({
+      content: "foo",
+      message: "bar",
+    });
+  });
+
+  it("normalizeFilter drops a blank content and a dangling regex toggle", () => {
+    expect(normalizeFilter({ content: "   ", contentRegex: true })).toEqual({});
+  });
+
+  it("normalizeFilter keeps contentRegex only alongside a content term", () => {
+    expect(normalizeFilter({ content: "foo", contentRegex: true })).toEqual({
+      content: "foo",
+      contentRegex: true,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run:
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/features/commits/logFilter.test.ts 2>&1 | tail -20
+```
+Expected: FAIL — `content` is not produced.
+
+- [ ] **Step 3: Extend the TS type**
+
+In `src/lib/types.ts`, in `LogFilter`:
+
+```typescript
+  /** Pattern appearing in a line the commit added or removed (git `-G`). */
+  content?: string;
+  /** Treat `content` as a regular expression. */
+  contentRegex?: boolean;
+```
+
+- [ ] **Step 4: Extend the parser and builder**
+
+In `src/features/commits/logFilter.ts`, add to the `switch` in `parseQueryText`:
+
+```typescript
+      case "content":
+      case "contains":
+        if (value) out.content = value;
+        break;
+```
+
+Add to `LogFilterInputs`:
+
+```typescript
+  /** Advanced-panel "changed lines contain" field. */
+  content?: string;
+  /** Advanced-panel regex toggle for `content`. */
+  contentRegex?: boolean;
+```
+
+In `buildLogFilter`, before `return normalizeFilter(filter)`:
+
+```typescript
+  const content = inputs.content?.trim();
+  if (content) filter.content = content;
+  if (inputs.contentRegex) filter.contentRegex = true;
+```
+
+In `normalizeFilter`, alongside the other fields:
+
+```typescript
+  if (filter.content?.trim()) {
+    out.content = filter.content.trim();
+    // The toggle only means something with a pattern — a dangling regex flag
+    // would make an otherwise-empty filter look set.
+    if (filter.contentRegex) out.contentRegex = true;
+  }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run:
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/features/commits/logFilter.test.ts 2>&1 | tail -20
+```
+Expected: PASS.
+
+- [ ] **Step 6: Add the advanced-panel field**
+
+In `src/screens/History.tsx`: add state beside the existing `authorQ`/`pathQ` state (`:96-110`), pass it into `buildLogFilter`, thread it through `AdvancedSearchPanel`'s props (`:1063`), and render after the `Path` field:
+
+```tsx
+      <SearchField label="Changed lines contain">
+        <PGInput
+          value={contentQ}
+          onChange={onContentQ}
+          placeholder="needle"
+          icon="search"
+          size="sm"
+          mono
+          style={{ width: 220 }}
+        />
+      </SearchField>
+      <SearchField label="Regex">
+        <PGButton
+          size="sm"
+          aria-pressed={contentRegex}
+          onClick={() => onContentRegex(!contentRegex)}
+          style={contentRegex ? { color: "var(--accent)" } : undefined}
+        >
+          .*
+        </PGButton>
+      </SearchField>
+```
+
+The label is "Changed lines contain", not "pickaxe" — the semantics are `-G` and the UI must not oversell them.
+
+- [ ] **Step 7: Verify the type-check and full unit suite**
+
+Run:
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm tsc --noEmit && pnpm test 2>&1 | tail -20
+```
+Expected: clean type-check, all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/types.ts src/features/commits/logFilter.ts src/features/commits/logFilter.test.ts src/screens/History.tsx
+git commit -m "feat(log): content: qualifier and advanced-panel content field (#61 D10)
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: B6 — the `PGSkeleton` primitive
+
+**Files:**
+- Create: `src/design/skeleton.tsx`
+- Modify: `src/design/index.ts` (barrel)
+- Modify: `src/index.css:252-259` (reduced-motion guard)
+- Test: `src/design/skeleton.test.tsx`
+
+**Interfaces:**
+- Produces: `PGSkeleton({ width, height, radius, count, gap, rowStep, style })` — presentational only, no loading logic. `rowStep: true` sizes the block as a density-aware list row.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/design/skeleton.test.tsx`:
+
+```tsx
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PGSkeleton } from "./skeleton";
+
+describe("PGSkeleton", () => {
+  it("renders one placeholder by default", () => {
+    render(<PGSkeleton />);
+    expect(screen.getAllByTestId("pg-skeleton")).toHaveLength(1);
+  });
+
+  it("renders `count` placeholders", () => {
+    render(<PGSkeleton count={5} />);
+    expect(screen.getAllByTestId("pg-skeleton")).toHaveLength(5);
+  });
+
+  it("is hidden from assistive tech", () => {
+    render(<PGSkeleton />);
+    expect(screen.getByTestId("pg-skeleton")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+  });
+
+  it("sizes rows with the shared row token when rowStep is set", () => {
+    render(<PGSkeleton rowStep />);
+    expect(screen.getByTestId("pg-skeleton").style.height).toContain(
+      "var(--row-h)",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run:
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/design/skeleton.test.tsx 2>&1 | tail -20
+```
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement the primitive**
+
+Create `src/design/skeleton.tsx`:
+
+```tsx
+import * as React from "react";
+
+export interface PGSkeletonProps {
+  /** CSS width. Defaults to filling the container. */
+  width?: number | string;
+  /** CSS height, ignored when `rowStep` is set. */
+  height?: number | string;
+  /** Corner radius. */
+  radius?: number;
+  /** How many stacked placeholders to render. */
+  count?: number;
+  /** Gap between stacked placeholders. */
+  gap?: number;
+  /**
+   * Size each placeholder as a plain list row honouring the UI-density
+   * setting. A skeleton row that ignores density is a different height from
+   * the real row it stands in for, so the list visibly jumps when data
+   * arrives. `--row-h` is already `calc(24px + var(--row-step))`, so it is
+   * used directly — adding `var(--row-step)` on top double-counts density.
+   */
+  rowStep?: boolean;
+  style?: React.CSSProperties;
+}
+
+/**
+ * Shimmering placeholder blocks for content that is loading.
+ *
+ * Presentational only — callers decide when to show it. Uses the `.pg-shimmer`
+ * keyframe from index.css, which is suppressed under
+ * `prefers-reduced-motion: reduce`.
+ */
+export function PGSkeleton({
+  width = "100%",
+  height = 12,
+  radius = 3,
+  count = 1,
+  gap = 6,
+  rowStep = false,
+  style,
+}: PGSkeletonProps) {
+  // --row-h is already calc(24px + var(--row-step)) in index.css, so it is
+  // used as-is; re-adding the step would double-count density.
+  const blockHeight = rowStep ? "var(--row-h)" : height;
+
+  const blocks = Array.from({ length: Math.max(1, count) }, (_, i) => (
+    <div
+      key={i}
+      data-testid="pg-skeleton"
+      aria-hidden="true"
+      className="pg-shimmer"
+      style={{
+        width,
+        height: blockHeight,
+        borderRadius: radius,
+        flexShrink: 0,
+        ...style,
+      }}
+    />
+  ));
+
+  if (count <= 1) return blocks[0];
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap }}>
+      {blocks}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Export from the barrel and guard reduced motion**
+
+In `src/design/index.ts`, beside the other exports:
+
+```typescript
+export * from "./skeleton";
+```
+
+In `src/index.css`, after the existing `.pg-shimmer` rule (`:256-259`):
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .pg-shimmer {
+    animation: none;
+  }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run:
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/design/skeleton.test.tsx 2>&1 | tail -20
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/design/skeleton.tsx src/design/skeleton.test.tsx src/design/index.ts src/index.css
+git commit -m "feat(design): PGSkeleton primitive on the pg-shimmer keyframe (#61 B6)
+
+Why: .pg-shimmer has been defined and unused since it was written. rowStep
+sizes placeholders with var(--row-step) so a skeleton row matches the real
+row height under any density setting instead of making the list jump.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: B6 — apply skeletons at the three load sites
+
+**Files:**
+- Modify: `src/features/diff/CommitDiffPanel.tsx:112-119` (spinner → skeleton)
+- Modify: `src/screens/History.tsx` (commit-list initial load)
+- Modify: `src/screens/RepoBrowser.tsx` (file preview load)
+- Test: `src/features/diff/CommitDiffPanel.test.tsx` (create if absent)
+
+**Interfaces:**
+- Consumes: `PGSkeleton` from Task 8.
+
+- [ ] **Step 1: Write the failing test**
+
+Create or append to `src/features/diff/CommitDiffPanel.test.tsx`:
+
+```tsx
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CommitDiffPanel } from "./CommitDiffPanel";
+
+describe("CommitDiffPanel loading state", () => {
+  it("shows skeleton placeholders while loading", () => {
+    render(
+      <CommitDiffPanel loading diffs={[]} error={null} />,
+    );
+    expect(screen.getAllByTestId("pg-skeleton").length).toBeGreaterThan(0);
+  });
+
+  it("shows no placeholders once loaded", () => {
+    render(
+      <CommitDiffPanel loading={false} diffs={[]} error={null} />,
+    );
+    expect(screen.queryAllByTestId("pg-skeleton")).toHaveLength(0);
+  });
+});
+```
+
+> Fill in `CommitDiffPanel`'s remaining required props from its own prop type (`CommitDiffPanel.tsx:10`) — pass the minimum the component needs to render, matching how the nearest existing component test constructs props.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run:
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/features/diff/CommitDiffPanel.test.tsx 2>&1 | tail -20
+```
+Expected: FAIL — no elements with that testid (a `PGSpinner` renders instead).
+
+- [ ] **Step 3: Swap the three loading states**
+
+In `CommitDiffPanel.tsx`, replace the `PGSpinner` inside the `loading &&` branch (`:112-119`) with a stack of file-row-shaped placeholders:
+
+```tsx
+          {loading && (
+            <div style={{ padding: 12 }}>
+              <PGSkeleton count={6} rowStep />
+            </div>
+          )}
+```
+
+Drop the now-unused `PGSpinner` import if nothing else in the file uses it.
+
+In `History.tsx`, where the commit list renders its initial-load spinner, use `<PGSkeleton count={12} rowStep />`. Only for the **initial** load — a page-append must not blank the list the user is reading.
+
+In `RepoBrowser.tsx`, where the file preview renders its loading spinner, use `<PGSkeleton count={14} height={10} />` — code lines, not list rows, so no `rowStep` here (`--lh-code` owns diff/code geometry and must not be mixed with row density).
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test 2>&1 | tail -20 && pnpm tsc --noEmit
+```
+Expected: all tests pass, type-check clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/diff/CommitDiffPanel.tsx src/features/diff/CommitDiffPanel.test.tsx src/screens/History.tsx src/screens/RepoBrowser.tsx
+git commit -m "feat(ui): skeleton loaders for log, commit diff and file preview (#61 B6)
+
+Why: History uses skeletons for the initial load only — blanking the list
+on a page-append would yank content the user is already reading. The file
+preview sizes by code-line height, not row density: --lh-code owns that
+geometry.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Full gate and PR
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Run every non-e2e gate**
+
+Run:
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm tsc --noEmit \
+  && pnpm exec tsc -p e2e/tsconfig.json --noEmit \
+  && pnpm test \
+  && cargo test --manifest-path src-tauri/Cargo.toml \
+  && pnpm vite build
+```
+Expected: all five clean. Do not proceed on a failure — fix it and re-run.
+
+- [ ] **Step 2: Rebuild the e2e snapshot and run only the affected specs**
+
+`src/` and `src-tauri/` both changed, so the snapshot must be rebuilt or the run silently tests the old binary. Affected surfaces: History (log filter + skeletons), Branches (upstream).
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test:e2e:docker build
+pnpm test:e2e:docker run --spec e2e/specs/history-ops.e2e.ts --spec e2e/specs/branches.e2e.ts
+```
+
+Substitute the real spec filenames from `ls e2e/specs/` if these differ. Docker only — never a native run.
+
+- [ ] **Step 3: Squash to one commit and open the PR**
+
+```bash
+git fetch origin && git rebase origin/main
+git reset --soft origin/main
+git commit -F - <<'MSG'
+feat(ux): issue #61 Tier 2 pt 1 — upstream, content search, skeletons
+
+D9: set_upstream backend op plus UI in the Branches inspector and branch
+context menu; first push of an untracked branch now passes -u.
+D10: LogFilter gains content/contentRegex, evaluated last in the paginated
+walk with git's -G semantics; `content:`/`contains:` qualifier and an
+advanced-panel field.
+B6: PGSkeleton primitive on the previously-dead .pg-shimmer keyframe,
+applied to the log, commit diff and file preview loads.
+
+Why -G and not -S: true -S needs whole-blob occurrence counting on both
+sides of every candidate commit; -G is what "find the commit that touched
+this text" means in practice, and the UI is labelled accordingly.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+MSG
+git push -u origin HEAD
+gh pr create --fill
+```
+
+- [ ] **Step 4: Report**
+
+State what passed, what the e2e run covered, and the PR URL.
+
+---
+
+## Self-review notes
+
+**Spec coverage.** D9 → Tasks 2-5 (backend, wiring, UI, push `-u`). D10 → Tasks 6-7 (backend predicate + frontend qualifier/panel), including the `InvalidArgument` variant from Task 1, `-G` semantics, evaluation order, one-time regex compilation, and the honest UI label. B6 → Tasks 8-9 (primitive with density + reduced-motion constraints, applied at all three named load sites). The spec's testing table rows for this PR are covered by Tasks 2, 5, 6, 7, 8, 9 and the gate in Task 10.
+
+**Deliberately deferred to PR 2/3:** D7, D8 (PR 2), D5, D6 (PR 3). `AppError::InvalidArgument` lands here because D10 needs it first; D7 reuses it.
+
+**Known follow-through:** Tasks 4 and 9 both say to match the nearest existing test's prop/state setup rather than inventing one, because the exact seeding those two screens need is a detail of code the implementer will have open. Every other step carries its literal content.

--- a/docs/superpowers/specs/2026-08-13-issue-61-tier2-design.md
+++ b/docs/superpowers/specs/2026-08-13-issue-61-tier2-design.md
@@ -1,0 +1,548 @@
+# Issue #61 Tier 2 remainder — design
+
+**Issue:** #61 — B6 (skeleton loaders), D5 (credential / auth entry), D6 (GPG/SSH
+commit signing), D7 (line-level staging), D8 (word / intra-line diff),
+D9 (set-upstream), D10 (content log search).
+**Date:** 2026-08-13.
+**Status:** approved.
+
+## Problem
+
+Tier 0 and Tier 1 of #61 landed (`fa398c9`, `997e1ab`), as did D3/D4 clone+init
+(#75) and A8 virtualization (#80, #82). What remains in Tier 2 is seven items
+that fall into three unrelated failure modes:
+
+1. **Core flows silently fail.** Fetch, pull, push and clone run with
+   credential prompts hard-disabled, so any remote that needs authentication
+   fails with git's stderr and no way to answer it (D5). This is the only item
+   on the list where the app does not work, as opposed to looking unfinished.
+2. **The diff is coarser than every reference client.** Staging bottoms out at
+   the hunk, and a one-word change paints the whole line (D7, D8).
+3. **Advertised-but-absent small gaps.** Branch tracking is displayed but not
+   editable (D9), the log cannot search content (D10), commits cannot be signed
+   (D6), and `.pg-shimmer` is a defined-but-unused keyframe (B6).
+
+Tier 3 (C4 multi-repo tabs, C5 drag-and-drop, D11 PR/MR integration, D12
+submodules/LFS/worktrees/bisect) is explicitly **not** in this spec — see
+"Out of scope".
+
+## Scope
+
+Delivered as four PRs, in order. Each code PR branches off latest `main` after
+the previous one merges.
+
+| PR | Contents | Why grouped |
+|----|----------|-------------|
+| 0 | This spec + the matching plan | Reviewable independently of code |
+| 1 | D9 set-upstream, D10 content log search, B6 skeletons | Three small, independent additions with no shared machinery — cheapest first |
+| 2 | D7 line-level staging, D8 word diff | Both live in the diff row / hunk-patch machinery |
+| 3 | D5 credentials, D6 signing | Both hinge on how we shell out to real `git` and both are security-sensitive |
+
+### Out of scope, deliberately
+
+- **Tier 3.** C4, C5, D11 and D12 each change an architecture rather than add a
+  feature: C4 replaces `useRepoStore`'s single-repo model, D11 needs the
+  credential work from D5 plus a whole API integration layer. Each gets its own
+  issue and its own spec. Filing them is part of PR 0.
+- **True `-S` pickaxe semantics.** See "D10" — we implement `-G`.
+- **Signature badges on every log row.** See "D6".
+- **Storing secrets ourselves.** See "D5".
+- **Per-remote SSH key selection.** `core.sshCommand` / `-i` per remote adds
+  per-remote configuration state; D5 covers passphrase entry for whichever key
+  git already selects.
+
+---
+
+# PR 1 — D9, D10, B6
+
+## D9 — Set-upstream / branch tracking
+
+`BranchInfo.upstream`, `.ahead` and `.behind` are already computed and displayed
+(`Branches.tsx:404,766`), but there is no op to change tracking. Adding one is
+the standard path from CLAUDE.md, with no new concepts.
+
+**Backend.** New trait method:
+
+```rust
+fn set_upstream(
+    &self,
+    repo_id: &RepoId,
+    branch: &str,
+    upstream: Option<&str>,
+) -> AppResult<()>;
+```
+
+`Libgit2Backend` resolves the local branch and calls `Branch::set_upstream`.
+`Some("origin/main")` sets tracking, `None` clears it.
+
+**Validation before mutation.** libgit2 will happily fail deep inside
+`set_upstream` with a stringified error for a name that is not a
+remote-tracking branch. Resolve the candidate with
+`repo.find_branch(name, BranchType::Remote)` first and return
+`AppError::InvalidRef(name)` when it is absent, so the UI gets the same
+"unknown ref" shape it already handles everywhere else. A missing *local*
+branch is also `InvalidRef`.
+
+`CliBackend` gets a `NotImplemented` stub, keeping the trait shape exercised.
+
+**Command.** `set_upstream` in `commands/branches.rs` (thin, `spawn_blocking`),
+registered in `invoke_handler!`. TS type + `setUpstream()` wrapper in
+`lib/tauri.ts`, action on `useRepoStore` that refreshes branches after.
+
+**UI, two attach points.**
+
+- The Branches inspector's existing `Tracks` row (`Branches.tsx:766`) gains
+  "Set upstream…" and, when tracking exists, "Clear tracking".
+- The branch context menu gains the same "Set upstream…" entry.
+
+Both route through `pgPrompt` seeded with the current upstream. This uses the
+empty-vs-null contract `design/dialog.tsx` already guarantees: **an empty
+submitted string clears tracking, a cancelled dialog does nothing.** That
+distinction is the reason a prompt is adequate here and a bespoke picker is not
+worth the effort for an S-sized item.
+
+**First push establishes tracking.** A branch with no upstream currently pushes
+without `-u`, so tracking never gets set from inside the app. Push adds `-u`
+when and only when the branch being pushed has no upstream — matching what
+every reference client does, and making D9's manual path the exception rather
+than the only way to get tracking.
+
+**Tests.** Rust integration tests over `TempRepo`: set tracking to an existing
+remote branch and read it back; clear it; set to a non-existent remote branch →
+`InvalidRef`; set on a non-existent local branch → `InvalidRef`; push of an
+untracked branch leaves an upstream behind.
+
+## D10 — Content log search
+
+`LogFilter` searches message, author, sha, date and path, but not content. #81
+rewrote the walk into `log_filtered_page` with a frontier cursor, so there is
+now exactly one place a content predicate belongs.
+
+**Semantics: `-G`, not `-S`.** We implement "the pattern appears in a line the
+commit added or removed". Git's `-S` reports commits where the *number of
+occurrences* of a string changed, which requires counting occurrences across
+both full blobs of every candidate commit; `-G` is what "find the commit that
+touched this text" means in practice and costs a diff scan we are already
+positioned to do. The UI labels the field **"Changed lines contain"** rather
+than "pickaxe", so the semantics are not oversold.
+
+**Types.** `LogFilter` gains:
+
+```rust
+/// Pattern that must appear in a line this commit added or removed (`-G`).
+pub content: Option<String>,
+/// Treat `content` as a regular expression rather than a substring.
+#[serde(default)]
+pub content_regex: bool,
+```
+
+Mirrored in `src/lib/types.ts` in the same commit, per the errors/types
+convention.
+
+**Evaluation order matters.** The content predicate is the only filter that
+costs a diff per commit. It runs **last**, after message/author/sha/date/path
+have already rejected the commit, so an author-scoped content search diffs only
+that author's commits. The regex is compiled once before the walk begins, never
+per commit; a malformed pattern is reported before any walking happens.
+
+**New error variant.** `AppError` has no variant for "the caller passed
+something invalid" — the closest, `InvalidRef`, is about references
+specifically. A malformed regex here (and an empty line selection in D7) is
+exactly that case, so we add `InvalidArgument(String)`, mirrored into
+`src/lib/errors.ts` in the same commit. Per the errors convention, adding a
+variant beats stringifying into `Git`/`Internal`.
+
+**Diff scan.** For each surviving commit, diff its tree against its first
+parent (root commits diff against an empty tree) with the existing pathspec
+applied when a path filter is present, and scan added/removed lines only. A
+merge commit is compared against its first parent, matching git's default
+`-G` behaviour on merges.
+
+New Rust dependency: `regex`.
+
+**Pagination interaction.** The page-size contract from #81 is unchanged: a
+content filter makes a page slower to fill, not smaller. No cap on scanned
+commits per page — a silent cap would report "no more results" when results
+exist, which is worse than a slow page.
+
+**Frontend.** `features/commits/logFilter.ts` already parses `key:value`
+qualifiers, so `content:` and `contains:` join `author:`/`path:`/`sha:` there.
+The advanced panel gains a "Changed lines contain" field and a `.*` regex
+toggle, following the existing field layout (`History.tsx:1037`).
+
+**Tests.** Rust integration: a commit that adds a line containing the needle is
+found; an unrelated commit is not; a commit that *removes* the needle is found;
+regex mode matches and a bad pattern errors before walking; content combined
+with a path filter intersects rather than unions. Frontend unit tests for the
+new qualifier parsing.
+
+## B6 — Skeleton loaders
+
+`.pg-shimmer` (`index.css:252`) has been defined and unused since it was
+written. The issue framed this as an either/or; we build the primitive.
+
+**New `src/design/skeleton.tsx`**, barrel-exported from `design/index.ts`:
+`PGSkeleton` renders one or more shimmering placeholder blocks, taking
+width/height/radius and a count. It is presentational only — no loading logic
+of its own.
+
+**Applied at three loads:** the History commit list, `CommitDiffPanel` while a
+`diff_commits` round-trip is in flight, and the RepoBrowser file preview.
+
+**Two constraints that make it look right rather than nearly right:**
+
+- **Density.** Skeleton rows standing in for list rows must size with
+  `calc(<base>px + var(--row-step))`, per CLAUDE.md's rule for any new
+  list-row surface. Otherwise the skeleton and the real rows differ in height
+  under a non-compact density setting and the list visibly jumps when data
+  arrives.
+- **Reduced motion.** The shimmer animation is suppressed under
+  `prefers-reduced-motion: reduce`, leaving a static block.
+
+**Tests.** Component tests: a screen in its loading state renders the expected
+number of placeholders and none once loaded.
+
+---
+
+# PR 2 — D7, D8
+
+## D7 — Line-level (partial-hunk) staging
+
+Today's finest granularity is the hunk. `stage_hunk` applies a single hunk via
+libgit2's `ApplyOptions::hunk_callback`; `unstage_hunk` and `discard_hunk`
+build patch text with `patch_text_for_hunk` and pipe it to `git apply` through
+the existing `git_apply` helper. Line-level staging is the same machinery with
+a more selective patch.
+
+**Patch synthesis.** `patch_text_for_hunk` generalizes to:
+
+```rust
+fn patch_text_for_lines(
+    diff: &git2::Diff<'_>,
+    delta_index: usize,
+    hunk_index: usize,
+    selected: &[usize],       // indices of changed lines within the hunk
+    direction: PatchDirection, // Apply | Reverse
+) -> AppResult<String>;
+```
+
+The rule is the one `git add -p` uses when you edit a hunk by hand. For
+`Apply`:
+
+| Line in source hunk | In synthesized patch |
+|---|---|
+| context (` `) | context |
+| selected `-` | `-` |
+| selected `+` | `+` |
+| **unselected `-`** | **context** — we are not removing it, so it exists on both sides |
+| **unselected `+`** | **dropped** — it exists on neither side of this partial patch |
+
+For `Reverse` the two unselected rules swap: an unselected `+` becomes context
+and an unselected `-` is dropped, because reversal flips which side each line
+lands on. This is why `direction` is a parameter rather than something the
+caller handles by post-processing.
+
+The `@@` header counts are **recomputed from the synthesized body** — old count
+is context + `-`, new count is context + `+` — never copied from the source
+hunk. Copying them is the classic way to produce a patch `git apply` rejects.
+
+**Ops.** Three new trait methods and commands mirroring the hunk trio, each
+taking the selected line indices:
+
+- `stage_lines` — from the index↔worktree diff, `git_apply --cached`
+- `unstage_lines` — from the HEAD↔index diff, `git_apply --cached --reverse`
+- `discard_lines` — from the index↔worktree diff, `git_apply --reverse`
+
+An empty selection is `AppError::InvalidArgument` (the variant added in D10),
+not a silent no-op — a no-op would read as "staging is broken". An index out of
+range for the hunk is the same. A selection covering every changed line is
+allowed and is equivalent to the hunk op.
+
+**The ignore-whitespace constraint carries over.** `git/mod.rs:94-97` already
+warns that hunk indices from an ignore-whitespace diff must never be fed to the
+hunk ops, because that flag rewrites hunk boundaries. Line indices within a
+hunk are affected identically, so the line ops inherit the same rule: they take
+no `ignore_whitespace` and the UI disables them via the existing
+`useHunkActionsDisabledReason` while the toggle is on.
+
+**Frontend.** Selection state lives in the **owning diff surface**
+(CommitPanel / DiffViewer / RepoBrowser), not in `PGDiffLine`. This is the same
+rule that keeps tree keyboard handling in the screen rather than in
+`PGFileTree`: a primitive that owns its own selection plus a global dispatcher
+both answer the same input and the selection moves twice.
+
+Interaction:
+
+- Click a changed line toggles it; shift-click extends a range within the hunk.
+- `Space` toggles the focused line.
+- While a hunk has a non-empty selection, its stage/unstage button reads
+  "Stage N lines" and acts on the selection; with an empty selection it behaves
+  exactly as today.
+- `Escape` clears the selection.
+
+Selection is per-hunk and clears when the file or diff changes — a selection
+surviving a refresh would point at line indices that no longer mean the same
+thing.
+
+**Tests.** Rust integration over `TempRepo`, asserting index/worktree contents
+rather than patch text: stage one of three added lines and confirm the index
+has exactly that line while the other two stay unstaged; stage a selection that
+skips a removed line and confirm the file still contains it; discard selected
+lines only; unstage a subset. Plus a direct test that a synthesized patch's
+`@@` counts match its body. Frontend component tests for selection, the
+"Stage N lines" label, and the whitespace-toggle disable.
+
+## D8 — Word / intra-line diff
+
+**Pure function, no dependency.** New `src/lib/wordDiff.ts` computing a
+token-level diff between two strings and returning changed character ranges for
+each side. Tokenization splits into word runs, punctuation and whitespace runs;
+the diff is a token LCS. Hand-rolled to match how `graphLayout`, `buildRebasePlan`
+and `semver.ts` are done in this repo — each is a tested pure function with no
+dependency — and because a general text-diff library brings machinery we would
+use one mode of.
+
+**Rendering has nothing to collide with.** `PGDiffLine` (`git-components.tsx:498`)
+renders `text` as plain text; there is no syntax highlighting in the diff path
+(`lib/highlight.ts` is used by the file preview, not here). So intra-line spans
+can be emitted directly without reconciling two span trees.
+
+**Pairing rule.** `chunkDiffLines` groups runs **by kind**, so a removed run and
+the added run following it are two *adjacent* chunks, not one — pairing therefore
+happens across an adjacent `(rem, add)` chunk pair, and `PGDiffChunk` (which
+renders `add`/`rem` rows inline rather than delegating to `PGDiffLine`) needs
+both sides in hand. Within such a pair, the i-th removed line pairs with the
+i-th added line, for the first `min(removed, added)` lines only. A pair gets
+intra-line highlighting **only if its similarity clears a threshold**: at least
+30% of the shorter side's non-whitespace tokens are common. Below that the pair
+renders as plain whole-line add/remove. Without the gate, a run of unrelated
+rewritten lines gets highlighted at random, which reads as noise and is worse
+than no word diff.
+
+**Cost guards.** Skip word diffing and fall back to plain line colouring when
+either line exceeds 1000 characters or either side tokenizes to more than 200
+tokens — the LCS table is `O(n·m)`, so those bounds cap it at 40k cells per
+pair. A minified bundle must not be able to hang the renderer. Both numbers are
+starting values chosen to sit well above ordinary source lines; they live as
+named constants in `wordDiff.ts`, not scattered literals. Results memoize per
+line pair and are computed lazily for rendered chunks only, since these lists
+are long and windowed.
+
+**Colour.** Changed spans get a stronger tint derived from the existing tokens
+via relative colour — `oklch(from var(--git-added) …)` / `--git-removed` — so
+custom and light themes carry through, per the styling convention.
+
+**Tests.** `wordDiff.test.ts`: identical strings produce no spans; a single
+changed word produces one span on each side; insertion at start and at end;
+whitespace-only difference; a line pair below the similarity threshold produces
+nothing; the long-line guard returns the fallback; multi-byte characters map to
+correct ranges.
+
+---
+
+# PR 3 — D5, D6
+
+## D5 — Credential / auth entry
+
+Four ops shell out to real `git` with prompts hard-disabled:
+fetch / pull / push (`commands/branches.rs:132-134`) and clone
+(`commands/create.rs:235-237`). The disabling is deliberate and correct as far
+as it goes — a subprocess with no terminal would otherwise hang on an invisible
+prompt — but it means authentication cannot happen at all.
+
+### Approach: retry on failure, not prompt during the run
+
+Ops keep running prompt-less on the first attempt. When one fails, its stderr
+is classified; if the failure is an authentication failure, the frontend
+collects credentials and the op is **retried** with an askpass that already
+knows the answer. Nothing prompts mid-run, so there is no IPC between a git
+subprocess and the app window, no partially-blocked op, and the common case
+(credential helper or ssh-agent already works) is byte-for-byte what happens
+today.
+
+### Error classification
+
+`run_git`'s failure path currently maps every non-zero exit to
+`AppError::Network(stderr)`. It gains a classifier producing a new variant:
+
+```rust
+Auth { host: Option<String>, kind: AuthKind }  // AuthKind: Https | SshPassphrase | SshKey
+```
+
+Distinguished from `Network` by matching git/ssh's stable phrasings:
+`Authentication failed`, `could not read Username`,
+`terminal prompts disabled`, `Invalid username or password`,
+`Permission denied (publickey)`, `Enter passphrase for key`.
+
+**`Host key verification failed` is explicitly not an auth failure** — it stays
+`Network`, because prompting for a password cannot fix an unknown host key and
+offering to would be actively misleading. `AppError` gains the variant on the
+Rust side and `src/lib/errors.ts` in the same commit, per convention.
+
+### The askpass shim is our own binary
+
+`GIT_ASKPASS` / `SSH_ASKPASS` point at the platypusgit executable itself,
+re-invoked through a new `--askpass <prompt>` intent in `cli.rs`. The shim:
+
+1. Reads its answer from an environment variable set by the parent process.
+2. Chooses which variable by matching the prompt text git passed as argv
+   (`Username for …` vs `Password for …` vs `Enter passphrase for key …`).
+3. Prints exactly that value and exits 0. On a prompt it does not recognize, or
+   with the environment variable absent, it prints nothing and exits non-zero.
+
+This must be handled **before** the Tauri app is built in `lib.rs` — no window,
+no single-instance forwarding — so the shim is a fast process that never tries
+to become a second app instance. `SSH_ASKPASS_REQUIRE=force` makes modern
+OpenSSH use it without a `DISPLAY`.
+
+**Secrets travel in the environment, never in argv.** Argv is world-readable
+via `ps` on macOS and Linux; another user cannot read a process's environment
+on either. This mirrors the care `opener.rs` already takes about never handing
+data to a shell.
+
+### Storage: git's own helper chain
+
+We store nothing. On a successful retry where the user asked to remember, the
+credential is handed to `git credential approve`, so whichever helper the user
+already has configured (osxkeychain, manager-core, libsecret) owns it. Before
+prompting, `git credential fill` is consulted so a known credential pre-fills
+the dialog — and so a helper that already has the answer means no prompt at
+all. When no helper is configured, the credential is kept in memory for the
+remainder of the app session only, and the dialog says so.
+
+This adds no secret-storage dependency, keeps us out of the business of secret
+lifecycle, and interoperates with credentials the user already has.
+
+### One shared runner
+
+The duplicated env policy in `branches.rs` and `create.rs` collapses into a
+single `run_git_authenticated(cwd, args, creds: Option<&Credentials>)` in a new
+shared module, used by all four call sites. Clone's streaming-progress path
+keeps its own output handling; only the environment and failure classification
+are shared.
+
+### Frontend
+
+New `src/features/auth/`:
+
+- `useAuthStore` — the pending challenge (host, kind, prefilled username) and
+  the retry thunk supplied by whichever caller failed.
+- `CredentialDialog` — a `PGModal` with username, secret (masked, toggleable),
+  and a "remember" checkbox whose label reflects whether a helper exists.
+
+Callers stay generic: a network action that catches `AppError::Auth` raises the
+challenge with a closure that re-runs itself with credentials. Cancelling
+surfaces the original error through the normal banner path — and per the
+danger-op convention, `refreshAll()` runs before `set({ error })`.
+
+### Security constraints
+
+- The shim emits nothing but the requested value, and never logs.
+- Credentials never enter `AppError` messages, log output, or event payloads.
+- git stderr is **scrubbed** before it is surfaced or logged: git echoes remote
+  URLs, which can carry embedded credentials (`https://user:token@host/…`).
+- The retry sends the secret to exactly one subprocess for one op; it is not
+  cached in the store beyond the session, and never persisted by us.
+
+### Tests
+
+`AppError` classification is a pure function over stderr fixtures — one test
+per phrasing, including the host-key case asserting it stays `Network`, and the
+URL-scrubbing case. The shim's prompt-kind matching and its
+missing-variable refusal are pure functions too. Frontend component tests cover
+the dialog, the retry path, and cancellation restoring the error banner.
+E2E cannot exercise a real authenticated remote; a `file://` remote covers the
+happy path, and the auth path is deliberately not e2e-tested.
+
+## D6 — GPG / SSH commit signing
+
+### Signing
+
+`CommitOptions` gains `sign: Option<bool>` — `None` follows `commit.gpgsign`
+from config, `Some` overrides it for this commit.
+
+`commit()` currently calls `repo.commit(...)`, which cannot sign. Signing
+requires the three-step form:
+
+1. `repo.commit_create_buffer(...)` to get the commit content.
+2. Sign that buffer with the configured program.
+3. `repo.commit_signed(&buffer, &signature, Some("gpgsig"))`.
+
+**`commit_signed` does not move HEAD.** Unlike `repo.commit(Some("HEAD"), …)`,
+it only writes the object, so the signed path must update the HEAD reference
+and write the reflog entry itself, and amend must retarget rather than rely on
+`Commit::amend`. Getting this wrong produces a commit that exists but is not on
+any branch — silently losing the user's work from their point of view. The
+unsigned path stays exactly as it is today.
+
+**Program dispatch** by `gpg.format`:
+
+| `gpg.format` | Program | Signature |
+|---|---|---|
+| `openpgp` (default) | `gpg.program`, else `gpg` | detached armored signature over the buffer |
+| `ssh` | `gpg.ssh.program`, else `ssh-keygen` | `-Y sign -n git` with `user.signingkey` |
+| `x509` | — | clean unsupported error, not a panic or a silent unsigned commit |
+
+`user.signingkey` may be a key id, a path, or a literal key with a `key::`
+prefix in ssh mode; resolution handles all three. A signing failure fails the
+commit — it must never fall back to committing unsigned, because the user asked
+for a signed commit and would have no indication they did not get one.
+
+### Verification: lazy, on the selected commit
+
+New `verify_commit(repo_id, oid)` returning
+`SignatureStatus { state, signer, key }`, where state covers
+good / bad / unknown-key / expired / revoked / none. Implemented by asking git
+for `%G?`, `%GS` and `%GK` on that one commit, which reuses git's own trust
+evaluation rather than reimplementing it.
+
+It is called **only for the currently selected commit**, and its result is
+shown in `CommitDiffPanel`'s header. Badging every log row would mean a
+`gpg`/`ssh-keygen` process per walked commit, which fights #81's pagination and
+the windowed list from #80 directly.
+
+### UI
+
+- Settings: a "Sign commits" toggle, default "follow git config".
+- Commit composer: a per-commit override alongside the existing amend and
+  sign-off controls, which is where `CommitOptions.signoff` already lives.
+- `CommitDiffPanel` header: signature state for the selected commit.
+
+### Tests
+
+Config resolution (`gpg.format` → program + argument list, `signingkey`
+forms) and `%G?` parsing are pure functions, tested exhaustively against
+fixtures. The end-to-end signed-commit test generates an ssh key with
+`ssh-keygen` and signs with it — present on macOS and in the e2e image — and
+skips when `ssh-keygen` is unavailable rather than failing. Asserted: the
+commit is on HEAD with the right parent (the `commit_signed` trap), the object
+has a `gpgsig` header, and `verify_commit` reports it good.
+
+---
+
+## Testing summary
+
+| Layer | Covers |
+|---|---|
+| Rust integration (`TempRepo`) | `set_upstream` incl. `InvalidRef` paths, push `-u`, content filter incl. removals + regex + path intersection, the three line-staging ops asserted on index/worktree contents, signed commit reachable from HEAD with a `gpgsig` header |
+| Rust unit | patch `@@` counts vs body, auth stderr classification incl. host-key and URL scrubbing, askpass prompt matching, signing config resolution, `%G?` parsing |
+| Frontend unit | `wordDiff` cases, `content:` qualifier parsing |
+| Component | skeleton loading states, line selection + "Stage N lines" + whitespace disable, credential dialog and retry/cancel |
+| E2E (Docker only) | only specs covering changed surfaces; the auth path is not e2e-tested |
+
+Per CLAUDE.md, e2e runs only once a change is done, only the affected specs,
+and only via `pnpm test:e2e:docker`.
+
+## Risks
+
+- **`commit_signed` and HEAD.** The highest-consequence trap in this spec: a
+  signed commit that never becomes HEAD looks like lost work. Covered by an
+  explicit integration assertion, not just a "it committed" check.
+- **Patch synthesis correctness (D7).** A malformed partial patch either fails
+  loudly (`git apply` rejects) or, worse, stages the wrong lines. Tests assert
+  resulting index and worktree contents rather than patch text.
+- **Content search cost (D10).** Mitigated by ordering the predicate last and
+  compiling the regex once; a deliberately un-capped scan keeps results honest
+  at the cost of slower pages on large histories.
+- **Secret leakage (D5).** Env-not-argv, stderr scrubbing, and no persistence
+  of our own. Worth a `/security-review` pass on PR 3 before merge.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3223,6 +3223,7 @@ version = "0.0.0"
 dependencies = [
  "git2",
  "log",
+ "regex",
  "semver",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,6 +47,8 @@ url = "2"
 # Ditto — update discovery must use the SAME semver implementation
 # tauri-plugin-updater compares with, so the two can never disagree.
 semver = "1"
+# Content log search (#61 D10) compiles the user's pattern once per walk.
+regex = "1"
 
 [features]
 # Compile + wire the WebDriver plugin. Set only by the e2e debug build.

--- a/src-tauri/src/commands/branches.rs
+++ b/src-tauri/src/commands/branches.rs
@@ -106,6 +106,22 @@ pub async fn rename_branch(
         .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
+#[tauri::command]
+pub async fn set_upstream(
+    state: State<'_, AppState>,
+    repo_id: String,
+    branch: String,
+    upstream: Option<String>,
+) -> AppResult<()> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    tokio::task::spawn_blocking(move || {
+        backend.set_upstream(&repo_id, &branch, upstream.as_deref())
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
 /// Helper: resolve the working-directory path for an open repo.
 async fn get_repo_path(state: &AppState, repo_id: &RepoId) -> AppResult<std::path::PathBuf> {
     let backend = state.backend.clone();
@@ -194,6 +210,24 @@ pub async fn pull(
     run_git(&path, &["pull", mode_flag, remote.as_str(), branch.as_str()]).await
 }
 
+/// Build `git push` args. `set_upstream` adds `-u`, which the caller passes
+/// only when the branch has no upstream yet — re-sending `-u` on every push
+/// would rewrite tracking the user may have deliberately pointed elsewhere.
+fn push_args(remote: &str, branch: &str, force: PushForce, set_upstream: bool) -> Vec<String> {
+    let mut args: Vec<String> = vec!["push".to_string()];
+    if set_upstream {
+        args.push("-u".to_string());
+    }
+    args.push(remote.to_string());
+    args.push(branch.to_string());
+    match force {
+        PushForce::None => {}
+        PushForce::WithLease => args.push("--force-with-lease".to_string()),
+        PushForce::Force => args.push("--force".to_string()),
+    }
+    args
+}
+
 #[tauri::command]
 pub async fn push(
     state: State<'_, AppState>,
@@ -202,19 +236,59 @@ pub async fn push(
     branch: String,
     force: PushForce,
 ) -> AppResult<()> {
-    let path = get_repo_path(&state, &RepoId(repo_id)).await?;
-    let mut args: Vec<String> = vec![
-        "push".to_string(),
-        remote,
-        branch,
-    ];
-    match force {
-        PushForce::None => {}
-        PushForce::WithLease => args.push("--force-with-lease".to_string()),
-        PushForce::Force => args.push("--force".to_string()),
-    }
+    let repo_id = RepoId(repo_id);
+    let path = get_repo_path(&state, &repo_id).await?;
+
+    // -u only for a branch with no upstream yet, so the first push establishes
+    // tracking without later pushes rewriting it.
+    let needs_upstream = {
+        let backend = state.backend.clone();
+        let id = repo_id.clone();
+        let branch_name = branch.clone();
+        tokio::task::spawn_blocking(move || backend.branches(&id))
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?
+            .map(|bs| {
+                bs.iter()
+                    .any(|b| !b.is_remote && b.name == branch_name && b.upstream.is_none())
+            })
+            // Failing to read branches must not block the push: fall back to a
+            // plain push rather than guessing -u.
+            .unwrap_or(false)
+    };
+
+    let args = push_args(&remote, &branch, force, needs_upstream);
     let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     run_git(&path, &arg_refs).await
+}
+
+#[cfg(test)]
+mod push_args_tests {
+    use super::*;
+
+    #[test]
+    fn adds_u_only_when_requested() {
+        assert_eq!(
+            push_args("origin", "main", PushForce::None, true),
+            vec!["push", "-u", "origin", "main"]
+        );
+        assert_eq!(
+            push_args("origin", "main", PushForce::None, false),
+            vec!["push", "origin", "main"]
+        );
+    }
+
+    #[test]
+    fn force_flag_comes_last() {
+        assert_eq!(
+            push_args("origin", "main", PushForce::WithLease, false),
+            vec!["push", "origin", "main", "--force-with-lease"]
+        );
+        assert_eq!(
+            push_args("origin", "feat/x", PushForce::Force, true),
+            vec!["push", "-u", "origin", "feat/x", "--force"]
+        );
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -30,6 +30,9 @@ pub enum AppError {
     #[error("invalid reference: {0}")]
     InvalidRef(String),
 
+    #[error("invalid argument: {0}")]
+    InvalidArgument(String),
+
     #[error("worktree is dirty: {0}")]
     DirtyWorktree(String),
 

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -197,6 +197,14 @@ impl GitBackend for CliBackend {
     fn rename_branch(&self, _repo_id: &RepoId, _from: &str, _to: &str) -> AppResult<()> {
         Err(AppError::NotImplemented)
     }
+    fn set_upstream(
+        &self,
+        _repo_id: &RepoId,
+        _branch: &str,
+        _upstream: Option<&str>,
+    ) -> AppResult<()> {
+        Err(AppError::NotImplemented)
+    }
     fn create_tag(&self, _repo_id: &RepoId, _name: &str, _target: TagTarget) -> AppResult<()> {
         Err(AppError::NotImplemented)
     }

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -1360,6 +1360,22 @@ impl GitBackend for Libgit2Backend {
             .filter(|s| !s.is_empty())
             .map(std::path::PathBuf::from);
 
+        // Compiled once, before any walking: a malformed pattern must fail
+        // immediately, not per commit.
+        let content_m = match filter
+            .content
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            None => None,
+            Some(pat) if filter.content_regex => Some(ContentMatcher::Regex(
+                regex::Regex::new(pat)
+                    .map_err(|e| AppError::InvalidArgument(format!("invalid regex: {e}")))?,
+            )),
+            Some(pat) => Some(ContentMatcher::Literal(pat.to_string())),
+        };
+
         self.with_repo(repo_id, |repo| {
             let ref_map = collect_ref_map(repo);
             let mut walk = repo.revwalk()?;
@@ -1422,9 +1438,18 @@ impl GitBackend for Libgit2Backend {
                     }
                 }
 
-                // path — most expensive, check last.
+                // path — expensive, check late.
                 if let Some(ref p) = path_q {
                     if !commit_touches_path(repo, &commit, p)? {
+                        continue;
+                    }
+                }
+
+                // content — the only filter that costs a full diff scan per
+                // commit, so it runs LAST: an author- or path-scoped search
+                // only diffs the commits every cheaper filter already accepted.
+                if let Some(ref m) = content_m {
+                    if !commit_diff_matches_content(repo, &commit, m, path_q.as_deref())? {
                         continue;
                     }
                 }
@@ -2357,6 +2382,26 @@ impl GitBackend for Libgit2Backend {
             Ok(())
         })
     }
+    fn set_upstream(
+        &self,
+        repo_id: &RepoId,
+        branch: &str,
+        upstream: Option<&str>,
+    ) -> AppResult<()> {
+        self.with_repo(repo_id, |repo| {
+            // Validate the remote-tracking branch BEFORE touching config, so a
+            // typo is a clean InvalidRef instead of a stringified libgit2 error.
+            if let Some(up) = upstream {
+                repo.find_branch(up, BranchType::Remote)
+                    .map_err(|_| AppError::InvalidRef(up.to_string()))?;
+            }
+            let mut local = repo
+                .find_branch(branch, BranchType::Local)
+                .map_err(|_| AppError::InvalidRef(branch.to_string()))?;
+            local.set_upstream(upstream)?;
+            Ok(())
+        })
+    }
     fn create_tag(&self, repo_id: &RepoId, name: &str, target: TagTarget) -> AppResult<()> {
         self.with_repo(repo_id, |repo| {
             let obj = repo
@@ -3124,6 +3169,68 @@ fn commit_to_info(commit: &git2::Commit<'_>) -> CommitInfo {
 /// first-parent simplification: a merge commit matches when it changed the path
 /// relative to any of its parents, not just the first. Intentional for a GUI —
 /// "did this commit touch the path" is the more useful question here.
+/// Compiled content predicate: literal substring or regex (#61 D10).
+enum ContentMatcher {
+    Literal(String),
+    Regex(regex::Regex),
+}
+
+impl ContentMatcher {
+    fn is_match(&self, line: &str) -> bool {
+        match self {
+            ContentMatcher::Literal(s) => line.contains(s.as_str()),
+            ContentMatcher::Regex(re) => re.is_match(line),
+        }
+    }
+}
+
+/// True when `commit` added or removed a line matching `matcher` — git's `-G`.
+///
+/// Compared against the FIRST parent only, matching git's default `-G`
+/// behaviour on merges; a root commit is compared against an empty tree.
+/// `path` restricts the diff via pathspec when a path filter is active, so
+/// content and path intersect rather than union.
+fn commit_diff_matches_content(
+    repo: &git2::Repository,
+    commit: &git2::Commit<'_>,
+    matcher: &ContentMatcher,
+    path: Option<&std::path::Path>,
+) -> AppResult<bool> {
+    let commit_tree = commit.tree()?;
+    let parent_tree = match commit.parent(0) {
+        Ok(p) => Some(p.tree()?),
+        Err(_) => None,
+    };
+
+    let mut opts = git2::DiffOptions::new();
+    if let Some(p) = path {
+        opts.pathspec(p);
+    }
+    let diff =
+        repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), Some(&mut opts))?;
+
+    let mut hit = false;
+    diff.foreach(
+        &mut |_, _| true,
+        None,
+        None,
+        Some(&mut |_delta, _hunk, line| {
+            // Added / removed lines only — a context line was not touched.
+            if matches!(line.origin(), '+' | '-') {
+                if let Ok(text) = std::str::from_utf8(line.content()) {
+                    if matcher.is_match(text) {
+                        hit = true;
+                    }
+                }
+            }
+            // Keep walking: `foreach` has no early exit, and returning false
+            // aborts the whole diff as an error rather than short-circuiting.
+            true
+        }),
+    )?;
+    Ok(hit)
+}
+
 fn commit_touches_path(
     repo: &git2::Repository,
     commit: &git2::Commit<'_>,

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -208,6 +208,19 @@ pub trait GitBackend: Send + Sync {
     fn create_branch(&self, repo_id: &RepoId, name: &str, from: Option<&str>) -> AppResult<()>;
     fn delete_branch(&self, repo_id: &RepoId, name: &str, force: bool) -> AppResult<()>;
     fn rename_branch(&self, repo_id: &RepoId, from: &str, to: &str) -> AppResult<()>;
+    /// Set or clear a local branch's upstream (tracking) branch.
+    ///
+    /// `upstream` is a remote-tracking branch shorthand such as `"origin/main"`;
+    /// `None` clears tracking. Both the local branch and the remote-tracking
+    /// branch must exist — either missing is `InvalidRef`, which is why this
+    /// validates before mutating rather than letting libgit2 fail deep inside
+    /// with a stringified message.
+    fn set_upstream(
+        &self,
+        repo_id: &RepoId,
+        branch: &str,
+        upstream: Option<&str>,
+    ) -> AppResult<()>;
     fn create_tag(&self, repo_id: &RepoId, name: &str, target: TagTarget) -> AppResult<()>;
     fn delete_tag(&self, repo_id: &RepoId, name: &str) -> AppResult<()>;
 

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -97,6 +97,13 @@ pub struct LogFilter {
     pub until: Option<i64>,
     /// Only commits that touched this path (relative to repo root).
     pub path: Option<String>,
+    /// Pattern that must appear in a line this commit added or removed —
+    /// git's `-G`, not `-S`: "the text was touched", not "the occurrence count
+    /// changed".
+    pub content: Option<String>,
+    /// Treat `content` as a regular expression rather than a literal substring.
+    #[serde(default)]
+    pub content_regex: bool,
 }
 
 impl LogFilter {
@@ -108,6 +115,9 @@ impl LogFilter {
             && self.since.is_none()
             && self.until.is_none()
             && self.path.as_deref().map(str::trim).unwrap_or("").is_empty()
+            // `content_regex` deliberately does NOT count: a regex toggle with
+            // no pattern is still no filter.
+            && self.content.as_deref().map(str::trim).unwrap_or("").is_empty()
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -137,6 +137,7 @@ pub fn run() {
             commands::branches::create_branch,
             commands::branches::delete_branch,
             commands::branches::rename_branch,
+            commands::branches::set_upstream,
             commands::branches::fetch,
             commands::branches::fetch_all,
             commands::branches::pull,

--- a/src-tauri/tests/branches_tags.rs
+++ b/src-tauri/tests/branches_tags.rs
@@ -227,3 +227,89 @@ fn create_tag_from_abbreviated_sha() {
         .collect();
     assert!(names.iter().any(|n| n == "v0.1.0-short"));
 }
+
+/// Create a second repo as `origin`, fetch it, so remote-tracking refs exist.
+fn with_origin() -> (TempRepo, TempRepo) {
+    let upstream = TempRepo::with_initial_commit("hello\n");
+    let local = TempRepo::with_initial_commit("hello\n");
+    local
+        .repo
+        .remote("origin", upstream.path().to_str().unwrap())
+        .unwrap();
+    // Scoped: the Remote borrows local.repo, and its Drop must run before
+    // `local` is moved into the return value.
+    {
+        let mut remote = local.repo.find_remote("origin").unwrap();
+        remote
+            .fetch(&["refs/heads/*:refs/remotes/origin/*"], None, None)
+            .unwrap();
+    }
+    (local, upstream)
+}
+
+#[test]
+fn set_upstream_sets_tracking_branch() {
+    let (tr, _up) = with_origin();
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .set_upstream(&handle.id, "main", Some("origin/main"))
+        .expect("set upstream");
+
+    let branches = backend.branches(&handle.id).unwrap();
+    let main = branches
+        .iter()
+        .find(|b| b.name == "main" && !b.is_remote)
+        .expect("main branch");
+    assert_eq!(main.upstream.as_deref(), Some("origin/main"));
+}
+
+#[test]
+fn set_upstream_none_clears_tracking() {
+    let (tr, _up) = with_origin();
+    let (backend, handle) = tr.open_with_backend();
+    backend
+        .set_upstream(&handle.id, "main", Some("origin/main"))
+        .unwrap();
+
+    backend
+        .set_upstream(&handle.id, "main", None)
+        .expect("clear upstream");
+
+    let branches = backend.branches(&handle.id).unwrap();
+    let main = branches
+        .iter()
+        .find(|b| b.name == "main" && !b.is_remote)
+        .unwrap();
+    assert!(main.upstream.is_none(), "tracking should be cleared");
+}
+
+#[test]
+fn set_upstream_unknown_remote_branch_is_invalid_ref() {
+    let (tr, _up) = with_origin();
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .set_upstream(&handle.id, "main", Some("origin/nope"))
+        .expect_err("should reject unknown remote branch");
+
+    assert!(
+        matches!(err, platypusgit_lib::error::AppError::InvalidRef(_)),
+        "expected InvalidRef, got {err:?}"
+    );
+}
+
+#[test]
+fn set_upstream_unknown_local_branch_is_invalid_ref() {
+    let (tr, _up) = with_origin();
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .set_upstream(&handle.id, "nope", Some("origin/main"))
+        .expect_err("should reject unknown local branch");
+
+    assert!(
+        matches!(err, platypusgit_lib::error::AppError::InvalidRef(_)),
+        "expected InvalidRef, got {err:?}"
+    );
+}

--- a/src-tauri/tests/log_filter.rs
+++ b/src-tauri/tests/log_filter.rs
@@ -403,3 +403,121 @@ fn unborn_head_returns_empty() {
         .unwrap();
     assert!(out.is_empty());
 }
+
+// ─────────────────────────────────────────────────────────────
+// Content search — git's `-G` semantics (#61 D10)
+// ─────────────────────────────────────────────────────────────
+
+/// Repo where one commit adds a needle line and a later one removes it.
+fn needle_repo() -> TempRepo {
+    let tr = TempRepo::fresh();
+    commit_as(&tr, "a.txt", "alpha\n", "first", "Alice", "alice@example.com", 1000);
+    commit_as(
+        &tr,
+        "a.txt",
+        "alpha\nNEEDLE here\n",
+        "add needle",
+        "Alice",
+        "alice@example.com",
+        2000,
+    );
+    commit_as(&tr, "a.txt", "alpha\n", "drop needle", "Bob", "bob@example.com", 3000);
+    commit_as(&tr, "b.txt", "unrelated\n", "unrelated", "Bob", "bob@example.com", 4000);
+    tr
+}
+
+#[test]
+fn content_filter_finds_adding_and_removing_commits() {
+    let tr = needle_repo();
+    let (backend, handle) = tr.open_with_backend();
+
+    let filter = LogFilter {
+        content: Some("NEEDLE".into()),
+        ..Default::default()
+    };
+    let found = backend.log_filtered(&handle.id, &filter, None, 50).unwrap();
+
+    let subjects: Vec<&str> = found.iter().map(|c| c.summary.as_str()).collect();
+    assert!(subjects.contains(&"add needle"), "got {subjects:?}");
+    assert!(
+        subjects.contains(&"drop needle"),
+        "a removal counts too: {subjects:?}"
+    );
+    assert!(!subjects.contains(&"unrelated"), "got {subjects:?}");
+    assert!(!subjects.contains(&"first"), "got {subjects:?}");
+}
+
+#[test]
+fn content_filter_regex_mode_matches() {
+    let tr = needle_repo();
+    let (backend, handle) = tr.open_with_backend();
+
+    let filter = LogFilter {
+        content: Some("NEE.LE".into()),
+        content_regex: true,
+        ..Default::default()
+    };
+    let found = backend.log_filtered(&handle.id, &filter, None, 50).unwrap();
+    assert_eq!(found.len(), 2, "regex should match both needle commits");
+}
+
+#[test]
+fn content_filter_substring_mode_does_not_treat_pattern_as_regex() {
+    let tr = needle_repo();
+    let (backend, handle) = tr.open_with_backend();
+
+    let filter = LogFilter {
+        content: Some("NEE.LE".into()),
+        ..Default::default()
+    };
+    let found = backend.log_filtered(&handle.id, &filter, None, 50).unwrap();
+    assert!(found.is_empty(), "substring mode must be literal");
+}
+
+#[test]
+fn content_filter_bad_regex_errors_before_walking() {
+    let tr = needle_repo();
+    let (backend, handle) = tr.open_with_backend();
+
+    let filter = LogFilter {
+        content: Some("([unclosed".into()),
+        content_regex: true,
+        ..Default::default()
+    };
+    let err = backend
+        .log_filtered(&handle.id, &filter, None, 50)
+        .expect_err("bad regex must error");
+    assert!(
+        matches!(err, platypusgit_lib::error::AppError::InvalidArgument(_)),
+        "expected InvalidArgument, got {err:?}"
+    );
+}
+
+#[test]
+fn content_filter_intersects_with_path_filter() {
+    let tr = needle_repo();
+    let (backend, handle) = tr.open_with_backend();
+
+    let filter = LogFilter {
+        content: Some("NEEDLE".into()),
+        path: Some("b.txt".into()),
+        ..Default::default()
+    };
+    let found = backend.log_filtered(&handle.id, &filter, None, 50).unwrap();
+    assert!(found.is_empty(), "needle is in a.txt, not b.txt");
+}
+
+#[test]
+fn content_regex_toggle_alone_is_not_a_filter() {
+    let tr = needle_repo();
+    let (backend, handle) = tr.open_with_backend();
+
+    // A regex toggle with no pattern must not make an empty filter look set —
+    // this walks as a plain log and returns everything.
+    let filter = LogFilter {
+        content_regex: true,
+        ..Default::default()
+    };
+    let found = backend.log_filtered(&handle.id, &filter, None, 50).unwrap();
+    assert_eq!(found.len(), 4, "every commit should come back");
+}

--- a/src-tauri/tests/network.rs
+++ b/src-tauri/tests/network.rs
@@ -280,3 +280,35 @@ fn repo_path_returns_workdir() {
     // Should be a directory that exists.
     assert!(path.is_dir(), "repo_path should return an existing directory");
 }
+
+/// The behaviour `push` relies on for #61 D9: `git push -u` leaves an upstream
+/// that `branches()` then reports. The command's own decision of *when* to pass
+/// `-u` is covered by the `push_args` unit tests.
+#[test]
+fn push_with_u_leaves_an_upstream_branches_reports() {
+    let bare = BareTempRepo::new();
+    let tr = TempRepo::with_initial_commit("hello\n");
+    tr.repo
+        .remote("origin", bare.path.to_str().unwrap())
+        .unwrap();
+
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(tr.path())
+        .args(["push", "-u", "origin", "main"])
+        .output()
+        .expect("run git push");
+    assert!(
+        out.status.success(),
+        "push failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let (backend, handle) = tr.open_with_backend();
+    let branches = backend.branches(&handle.id).unwrap();
+    let main = branches
+        .iter()
+        .find(|b| b.name == "main" && !b.is_remote)
+        .expect("main branch");
+    assert_eq!(main.upstream.as_deref(), Some("origin/main"));
+}

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -694,6 +694,28 @@ export function branchMenuItems(
       },
     },
     {
+      icon: "link",
+      label: "Set upstream…",
+      onClick: async () => {
+        if (!name) return;
+        // Empty submission clears tracking, dismissal does nothing — so
+        // requireValue stays off and null is checked explicitly (#61 D9).
+        const next = await pgPrompt({
+          title: `Upstream for ${name}`,
+          body: "Remote-tracking branch, e.g. origin/main. Leave empty to clear tracking.",
+          initialValue: upstream ?? "",
+          placeholder: "origin/main",
+          confirmLabel: "Set",
+          mono: true,
+        });
+        if (next === null) return;
+        const trimmed = next.trim();
+        useRepoStore
+          .getState()
+          .setUpstream(name, trimmed === "" ? null : trimmed);
+      },
+    },
+    {
       icon: "copy",
       label: "Copy name",
       onClick: () => {

--- a/src/design/index.ts
+++ b/src/design/index.ts
@@ -12,4 +12,5 @@ export * from "./error-boundary";
 export * from "./modal";
 export * from "./use-prevent-browser-context-menu";
 export * from "./resizable";
+export * from "./skeleton";
 export * from "./window-controls";

--- a/src/design/skeleton.test.tsx
+++ b/src/design/skeleton.test.tsx
@@ -1,0 +1,52 @@
+// PGSkeleton (#61 B6) — the primitive that finally uses the .pg-shimmer
+// keyframe, which had been defined and unused since it was written.
+
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PGSkeleton } from "./skeleton";
+
+describe("PGSkeleton", () => {
+  it("renders one placeholder by default", () => {
+    render(<PGSkeleton />);
+    expect(screen.getAllByTestId("pg-skeleton")).toHaveLength(1);
+  });
+
+  it("renders `count` placeholders", () => {
+    render(<PGSkeleton count={5} />);
+    expect(screen.getAllByTestId("pg-skeleton")).toHaveLength(5);
+  });
+
+  it("is hidden from assistive tech", () => {
+    render(<PGSkeleton />);
+    expect(screen.getByTestId("pg-skeleton")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+  });
+
+  it("carries the shimmer class so the keyframe applies", () => {
+    render(<PGSkeleton />);
+    expect(screen.getByTestId("pg-skeleton").className).toContain(
+      "pg-shimmer",
+    );
+  });
+
+  it("sizes rows with the shared row token when rowStep is set", () => {
+    render(<PGSkeleton rowStep />);
+    // --row-h is already calc(24px + var(--row-step)), so a skeleton row
+    // matches a real row at any density.
+    expect(screen.getByTestId("pg-skeleton").style.height).toContain(
+      "var(--row-h)",
+    );
+  });
+
+  it("uses the explicit height when rowStep is not set", () => {
+    render(<PGSkeleton height={40} />);
+    expect(screen.getByTestId("pg-skeleton").style.height).toBe("40px");
+  });
+
+  it("treats a zero or negative count as one placeholder", () => {
+    render(<PGSkeleton count={0} />);
+    expect(screen.getAllByTestId("pg-skeleton")).toHaveLength(1);
+  });
+});

--- a/src/design/skeleton.tsx
+++ b/src/design/skeleton.tsx
@@ -1,0 +1,66 @@
+import * as React from "react";
+
+export interface PGSkeletonProps {
+  /** CSS width. Defaults to filling the container. */
+  width?: number | string;
+  /** CSS height, ignored when `rowStep` is set. */
+  height?: number | string;
+  /** Corner radius, px. */
+  radius?: number;
+  /** How many stacked placeholders to render. Values below 1 render one. */
+  count?: number;
+  /** Gap between stacked placeholders, px. */
+  gap?: number;
+  /**
+   * Size each placeholder as a plain list row honouring the UI-density
+   * setting. A skeleton row that ignores density is a different height from
+   * the real row it stands in for, so the list visibly jumps when data
+   * arrives. `--row-h` is already `calc(24px + var(--row-step))`, so it is
+   * used directly — adding `var(--row-step)` on top would double-count.
+   */
+  rowStep?: boolean;
+  style?: React.CSSProperties;
+}
+
+/**
+ * Shimmering placeholder blocks for content that is loading.
+ *
+ * Presentational only — callers decide when to show it. Uses the `.pg-shimmer`
+ * keyframe from index.css, which is suppressed under
+ * `prefers-reduced-motion: reduce`.
+ */
+export function PGSkeleton({
+  width = "100%",
+  height = 12,
+  radius = 3,
+  count = 1,
+  gap = 6,
+  rowStep = false,
+  style,
+}: PGSkeletonProps) {
+  const blockHeight = rowStep ? "var(--row-h)" : height;
+  const n = Math.max(1, Math.floor(count));
+
+  const blocks = Array.from({ length: n }, (_, i) => (
+    <div
+      key={i}
+      data-testid="pg-skeleton"
+      aria-hidden="true"
+      className="pg-shimmer"
+      style={{
+        width,
+        height: blockHeight,
+        borderRadius: radius,
+        flexShrink: 0,
+        ...style,
+      }}
+    />
+  ));
+
+  if (n === 1) return blocks[0];
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap }}>
+      {blocks}
+    </div>
+  );
+}

--- a/src/features/commits/logFilter.test.ts
+++ b/src/features/commits/logFilter.test.ts
@@ -112,3 +112,44 @@ describe("normalizeFilter / isFilterEmpty", () => {
     expect(isFilterEmpty({ since: 1000 })).toBe(false);
   });
 });
+
+// Content search (#61 D10). `-G` semantics: the pattern appears in a line the
+// commit added or removed.
+describe("content qualifier", () => {
+  it("parses content: into the content field", () => {
+    expect(parseQueryText("content:foo")).toEqual({ content: "foo" });
+  });
+
+  it("accepts contains: as an alias", () => {
+    expect(parseQueryText("contains:foo")).toEqual({ content: "foo" });
+  });
+
+  it("leaves other text as a message term", () => {
+    expect(parseQueryText("content:foo bar")).toEqual({
+      content: "foo",
+      message: "bar",
+    });
+  });
+
+  it("normalizeFilter drops a blank content and a dangling regex toggle", () => {
+    expect(normalizeFilter({ content: "   ", contentRegex: true })).toEqual({});
+  });
+
+  it("normalizeFilter keeps contentRegex only alongside a content term", () => {
+    expect(normalizeFilter({ content: "foo", contentRegex: true })).toEqual({
+      content: "foo",
+      contentRegex: true,
+    });
+  });
+
+  it("buildLogFilter carries the panel field and toggle", () => {
+    expect(buildLogFilter({ content: " needle ", contentRegex: true })).toEqual({
+      content: "needle",
+      contentRegex: true,
+    });
+  });
+
+  it("isFilterEmpty stays true for a regex toggle with no pattern", () => {
+    expect(isFilterEmpty({ contentRegex: true })).toBe(true);
+  });
+});

--- a/src/features/commits/logFilter.ts
+++ b/src/features/commits/logFilter.ts
@@ -13,6 +13,10 @@ export interface LogFilterInputs {
   sinceDate?: string;
   /** ISO date string `YYYY-MM-DD` (date input). */
   untilDate?: string;
+  /** Advanced-panel "changed lines contain" field. */
+  content?: string;
+  /** Advanced-panel regex toggle for `content`. */
+  contentRegex?: boolean;
 }
 
 /** A SHA-ish token: hex, length 4..40. */
@@ -43,6 +47,10 @@ export function parseQueryText(text: string): Partial<LogFilter> {
       case "path":
       case "file":
         if (value) out.path = value;
+        break;
+      case "content":
+      case "contains":
+        if (value) out.content = value;
         break;
       case "sha":
       case "commit":
@@ -133,6 +141,10 @@ export function buildLogFilter(inputs: LogFilterInputs): LogFilter {
     if (until != null) filter.until = until;
   }
 
+  const content = inputs.content?.trim();
+  if (content) filter.content = content;
+  if (inputs.contentRegex) filter.contentRegex = true;
+
   return normalizeFilter(filter);
 }
 
@@ -145,6 +157,12 @@ export function normalizeFilter(filter: LogFilter): LogFilter {
   if (filter.path?.trim()) out.path = filter.path.trim();
   if (typeof filter.since === "number") out.since = filter.since;
   if (typeof filter.until === "number") out.until = filter.until;
+  if (filter.content?.trim()) {
+    out.content = filter.content.trim();
+    // The toggle only means something with a pattern — a dangling regex flag
+    // would make an otherwise-empty filter look set.
+    if (filter.contentRegex) out.contentRegex = true;
+  }
   return out;
 }
 

--- a/src/features/diff/CommitDiffPanel.skeleton.test.tsx
+++ b/src/features/diff/CommitDiffPanel.skeleton.test.tsx
@@ -1,0 +1,32 @@
+// Skeleton loading state for the shared commit-diff panel (#61 B6).
+
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CommitDiffPanel } from "./CommitDiffPanel";
+
+const props = {
+  diffs: [],
+  error: null,
+  header: "abc1234 → HEAD",
+  paneIdPrefix: "test",
+};
+
+describe("CommitDiffPanel loading state", () => {
+  it("shows skeleton placeholders while loading", () => {
+    render(<CommitDiffPanel {...props} loading />);
+    expect(screen.getAllByTestId("pg-skeleton").length).toBeGreaterThan(0);
+  });
+
+  it("shows no placeholders once loaded", () => {
+    render(<CommitDiffPanel {...props} loading={false} />);
+    expect(screen.queryAllByTestId("pg-skeleton")).toHaveLength(0);
+  });
+
+  it("shows the empty label, not placeholders, for an empty diff", () => {
+    render(
+      <CommitDiffPanel {...props} loading={false} emptyLabel="Nothing here." />,
+    );
+    expect(screen.getByText("Nothing here.")).toBeTruthy();
+    expect(screen.queryAllByTestId("pg-skeleton")).toHaveLength(0);
+  });
+});

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { PGIcon, PGSpinner } from "@/design";
+import { PGIcon, PGSkeleton } from "@/design";
 import { PGPane, FocusableScroll, usePaneList, useHunkNav } from "@/features/keymap";
 import { fileIconSpec } from "@/lib/fileIcon";
 import { WhitespaceToggle } from "./WhitespaceToggle";
@@ -111,7 +111,7 @@ export function CommitDiffPanel({
           </div>
           {loading && (
             <div style={{ padding: 12 }}>
-              <PGSpinner />
+              <PGSkeleton count={6} rowStep />
             </div>
           )}
           {error && (

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -70,6 +70,7 @@ import {
   runMergetool as runMergetoolFn,
   restartConflict as restartConflictFn,
   setRemoteUrl,
+  setUpstream as setUpstreamFn,
   stageHunk,
   stagePaths,
   stashApply,
@@ -232,6 +233,8 @@ interface RepoStoreState {
   ) => Promise<boolean>;
   deleteBranch: (name: string, force?: boolean) => Promise<void>;
   renameBranch: (from: string, to: string) => Promise<void>;
+  /** Set (`"origin/main"`) or clear (`null`) a local branch's upstream. */
+  setUpstream: (branch: string, upstream: string | null) => Promise<void>;
   mergeBranch: (name: string) => Promise<void>;
   rebaseOnto: (upstream: string) => Promise<void>;
   createTag: (name: string, target: TagTarget) => Promise<void>;
@@ -809,6 +812,17 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     try {
       await renameBranch(repo.id, from, to);
+      await get().refreshAll();
+    } catch (e) {
+      set({ error: toAppError(e) });
+    }
+  },
+
+  async setUpstream(branch, upstream) {
+    const repo = get().current;
+    if (!repo) return;
+    try {
+      await setUpstreamFn(repo.id, branch, upstream);
       await get().refreshAll();
     } catch (e) {
       set({ error: toAppError(e) });

--- a/src/index.css
+++ b/src/index.css
@@ -258,6 +258,13 @@ kbd {
   background-size: 200% 100%;
   animation: pg-shimmer 1.8s ease-in-out infinite;
 }
+/* A loading placeholder must not be a moving distraction for anyone who has
+   asked the OS for less motion; the block still reads as "pending". */
+@media (prefers-reduced-motion: reduce) {
+  .pg-shimmer {
+    animation: none;
+  }
+}
 
 .pg-row  { display: flex; align-items: center; gap: 8px; }
 .pg-col  { display: flex; flex-direction: column; }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -8,6 +8,7 @@ export type AppError =
   | { kind: "NotImplemented"; message?: string }
   | { kind: "Unborn"; message?: string }
   | { kind: "InvalidRef"; message: string }
+  | { kind: "InvalidArgument"; message: string }
   | { kind: "DirtyWorktree"; message: string }
   | { kind: "NotMerged"; message: string }
   | { kind: "ConflictsDetected"; message: string }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -367,6 +367,18 @@ export async function renameBranch(
   return invoke<void>("rename_branch", { repoId, from, to });
 }
 
+/**
+ * Set or clear a branch's upstream. `null` clears tracking; a remote-tracking
+ * shorthand such as `"origin/main"` sets it.
+ */
+export async function setUpstream(
+  repoId: string,
+  branch: string,
+  upstream: string | null,
+): Promise<void> {
+  return invoke<void>("set_upstream", { repoId, branch, upstream });
+}
+
 export interface TagTarget {
   oid: string;
   annotation: string | null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -81,6 +81,13 @@ export interface LogFilter {
   until?: number | null;
   /** Only commits that touched this path (relative to repo root). */
   path?: string | null;
+  /**
+   * Pattern appearing in a line the commit added or removed (git `-G`, not
+   * `-S`: "the text was touched", not "the occurrence count changed").
+   */
+  content?: string | null;
+  /** Treat `content` as a regular expression rather than a literal substring. */
+  contentRegex?: boolean;
 }
 
 export interface BranchInfo {

--- a/src/screens/Branches.tsx
+++ b/src/screens/Branches.tsx
@@ -790,6 +790,16 @@ function BranchInspector({ branch }: { branch: BranchInfo }) {
 function BranchActions({ branch }: { branch: BranchInfo }) {
   return (
     <>
+      {!branch.isRemote && (
+        <PGButton
+          variant="outline"
+          icon="link"
+          title={`Set or clear the upstream for ${branch.name}`}
+          onClick={() => void promptUpstream(branch)}
+        >
+          Set upstream
+        </PGButton>
+      )}
       <PGButton
         variant="primary"
         icon="check"
@@ -855,6 +865,30 @@ function BranchActions({ branch }: { branch: BranchInfo }) {
       </PGButton>
     </>
   );
+}
+
+/**
+ * Prompt for a branch's upstream (#61 D9).
+ *
+ * An empty submitted string clears tracking; a dismissed prompt (null) does
+ * nothing. That empty-vs-null distinction is guaranteed by pgPrompt, and is
+ * what makes a prompt sufficient here instead of a bespoke picker — so
+ * `requireValue` must stay off.
+ */
+export async function promptUpstream(branch: BranchInfo) {
+  const next = await pgPrompt({
+    title: `Upstream for ${branch.name}`,
+    body: "Remote-tracking branch, e.g. origin/main. Leave empty to clear tracking.",
+    initialValue: branch.upstream ?? "",
+    placeholder: "origin/main",
+    confirmLabel: "Set",
+    mono: true,
+  });
+  if (next === null) return;
+  const trimmed = next.trim();
+  await useRepoStore
+    .getState()
+    .setUpstream(branch.name, trimmed === "" ? null : trimmed);
 }
 
 function TagInspector({ tag }: { tag: TagInfo }) {

--- a/src/screens/Branches.upstream.test.tsx
+++ b/src/screens/Branches.upstream.test.tsx
@@ -1,0 +1,102 @@
+// Set / clear branch upstream from the Branches inspector (#61 D9).
+//
+// The empty-vs-null contract matters here: an empty submitted prompt clears
+// tracking, a dismissed prompt does nothing at all.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BranchesScreen } from "./Branches";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import {
+  WithDialogs,
+  acceptDialog,
+  dismissDialog,
+  resetDialogs,
+} from "@/test/dialog";
+import type { BranchInfo } from "@/lib/types";
+
+const branch = (over: Partial<BranchInfo> = {}): BranchInfo => ({
+  name: "main",
+  isHead: true,
+  isRemote: false,
+  upstream: null,
+  ahead: 0,
+  behind: 0,
+  tip: "abc1234",
+  ...over,
+});
+
+function setup(over: Partial<BranchInfo> = {}, rowText = "main") {
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
+    status: [],
+    branches: [branch(over)],
+    remotes: [],
+    tags: [],
+    stashes: [],
+    commits: [],
+    loading: false,
+  } as never);
+  mockInvoke("set_upstream", () => undefined);
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => [branch(over)]);
+  render(
+    <WithDialogs>
+      <BranchesScreen />
+    </WithDialogs>,
+  );
+  // Select the branch so the inspector renders its actions.
+  fireEvent.click(screen.getByText(rowText));
+}
+
+const upstreamCall = () =>
+  getInvokeCalls().find((c) => c.cmd === "set_upstream");
+
+describe("Branches upstream editing", () => {
+  beforeEach(() => {
+    resetInvokeMock();
+    resetDialogs();
+  });
+
+  it("sends the typed upstream", async () => {
+    setup();
+    fireEvent.click(screen.getByRole("button", { name: /set upstream/i }));
+    await acceptDialog("origin/main");
+
+    await waitFor(() =>
+      expect(upstreamCall()?.args).toMatchObject({
+        branch: "main",
+        upstream: "origin/main",
+      }),
+    );
+  });
+
+  it("clears tracking on an empty submission", async () => {
+    setup({ upstream: "origin/main" });
+    fireEvent.click(screen.getByRole("button", { name: /set upstream/i }));
+    await acceptDialog("");
+
+    await waitFor(() =>
+      expect(upstreamCall()?.args).toMatchObject({
+        branch: "main",
+        upstream: null,
+      }),
+    );
+  });
+
+  it("does nothing when the prompt is dismissed", async () => {
+    setup({ upstream: "origin/main" });
+    fireEvent.click(screen.getByRole("button", { name: /set upstream/i }));
+    await dismissDialog();
+
+    expect(upstreamCall()).toBeUndefined();
+  });
+
+  it("offers no upstream action for a remote branch", () => {
+    setup({ name: "origin/main", isRemote: true, isHead: false }, "origin/main");
+    expect(
+      screen.queryByRole("button", { name: /set upstream/i }),
+    ).toBeNull();
+  });
+});

--- a/src/screens/History.hookorder.test.tsx
+++ b/src/screens/History.hookorder.test.tsx
@@ -63,7 +63,10 @@ describe("History screen when the log arrives after mount", () => {
     });
 
     render(<HistoryScreen />);
-    expect(screen.getByText(/Loading commits/i)).toBeInTheDocument();
+    // The loading state is skeleton rows rather than a text label since #61 B6,
+    // so this asserts the accessible name — same intent: the screen renders
+    // during the loading phase, before the log arrives.
+    expect(screen.getByLabelText(/Loading commits/i)).toBeInTheDocument();
 
     // The log lands — same component, second render, must use the same hooks.
     await act(async () => {

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -10,7 +10,7 @@ import {
   PGResizeHandle,
   PGSearchInput,
   PGSelect,
-  PGSpinner,
+  PGSkeleton,
   PGToolbar,
   commitMenuItems,
   commitMultiMenuItems,
@@ -93,6 +93,9 @@ export function HistoryScreen() {
   const [pathQ, setPathQ] = React.useState("");
   const [sinceDate, setSinceDate] = React.useState("");
   const [untilDate, setUntilDate] = React.useState("");
+  // Content search (#61 D10) — git `-G`: matches lines the commit touched.
+  const [contentQ, setContentQ] = React.useState("");
+  const [contentRegex, setContentRegex] = React.useState(false);
   const [advancedOpen, setAdvancedOpen] = React.useState(false);
   const [filterKind, setFilterKind] = React.useState<HistoryFilterKind>("all");
   const [refFilter, setRefFilter] = React.useState<RefFilter>("all");
@@ -107,8 +110,10 @@ export function HistoryScreen() {
         path: pathQ,
         sinceDate,
         untilDate,
+        content: contentQ,
+        contentRegex,
       }),
-    [filter, authorQ, pathQ, sinceDate, untilDate],
+    [filter, authorQ, pathQ, sinceDate, untilDate, contentQ, contentRegex],
   );
   const filterKey = JSON.stringify(logFilter);
   React.useEffect(() => {
@@ -370,6 +375,9 @@ export function HistoryScreen() {
     setPathQ("");
     setSinceDate("");
     setUntilDate("");
+    // Content too, or Clear leaves a live filter behind (#61 D10).
+    setContentQ("");
+    setContentRegex(false);
   }, []);
 
   const toolbarLeft = (
@@ -404,6 +412,10 @@ export function HistoryScreen() {
       onSinceDate={setSinceDate}
       untilDate={untilDate}
       onUntilDate={setUntilDate}
+      contentQ={contentQ}
+      onContentQ={setContentQ}
+      contentRegex={contentRegex}
+      onContentRegex={setContentRegex}
     />
   ) : null;
 
@@ -472,9 +484,16 @@ export function HistoryScreen() {
         <PGToolbar left={toolbarLeft} right={toolbarRight} />
         {advancedPanel}
         {loading ? (
-          <PGEmpty icon="history" title={<PGSpinner size={18} />}>
-            Loading commits…
-          </PGEmpty>
+          // Initial load only — this branch is reached solely when no commits
+          // are on screen yet. A page-append must never blank the list the
+          // user is already reading (#61 B6).
+          <div
+            style={{ padding: "6px 12px" }}
+            aria-busy="true"
+            aria-label="Loading commits"
+          >
+            <PGSkeleton count={12} rowStep />
+          </div>
         ) : (
           <PGEmpty icon="history" title="No commits yet">
             This repository doesn&apos;t have any commits on HEAD.
@@ -1146,6 +1165,10 @@ function AdvancedSearchPanel(props: {
   onSinceDate: (v: string) => void;
   untilDate: string;
   onUntilDate: (v: string) => void;
+  contentQ: string;
+  onContentQ: (v: string) => void;
+  contentRegex: boolean;
+  onContentRegex: (v: boolean) => void;
 }) {
   const {
     authorQ,
@@ -1156,6 +1179,10 @@ function AdvancedSearchPanel(props: {
     onSinceDate,
     untilDate,
     onUntilDate,
+    contentQ,
+    onContentQ,
+    contentRegex,
+    onContentRegex,
   } = props;
   return (
     <div
@@ -1190,6 +1217,35 @@ function AdvancedSearchPanel(props: {
           mono
           style={{ width: 220 }}
         />
+      </SearchField>
+      {/*
+        Labelled "Changed lines contain", not "pickaxe": this is git's -G
+        (the text was touched), not -S (the occurrence count changed), and the
+        UI must not oversell it (#61 D10).
+      */}
+      <SearchField label="Changed lines contain">
+        <PGInput
+          value={contentQ}
+          onChange={onContentQ}
+          placeholder="needle"
+          icon="search"
+          size="sm"
+          mono
+          style={{ width: 220 }}
+          data-testid="history-content-q"
+        />
+      </SearchField>
+      <SearchField label="Regex">
+        <PGButton
+          size="sm"
+          variant={contentRegex ? "outline" : "ghost"}
+          aria-pressed={contentRegex}
+          title="Treat the content pattern as a regular expression"
+          onClick={() => onContentRegex(!contentRegex)}
+          style={contentRegex ? { color: "var(--accent)" } : undefined}
+        >
+          .*
+        </PGButton>
       </SearchField>
       <SearchField label="Since">
         <PGInput

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -12,7 +12,7 @@ import {
   PGPanel,
   PGResizeHandle,
   PGSearchInput,
-  PGSpinner,
+  PGSkeleton,
   PGStatusMark,
   PGToolbar,
   KV,
@@ -784,13 +784,11 @@ export function RepoBrowserScreen() {
             )}
             {(loading || revLoading) && tree.length === 0 && (
               <div
-                style={{
-                  padding: 14,
-                  textAlign: "center",
-                  color: "var(--fg-2)",
-                }}
+                style={{ padding: "4px 8px" }}
+                aria-busy="true"
+                aria-label="Loading files"
               >
-                <PGSpinner size={14} />
+                <PGSkeleton count={10} rowStep />
               </div>
             )}
             <PGFileTree
@@ -924,14 +922,14 @@ export function RepoBrowserScreen() {
               </PGEmpty>
             )}
             {selectedFile && diffLoading && (
+              // Code lines, not list rows: --lh-code owns diff/preview
+              // geometry, so this deliberately does NOT use rowStep (#61 B6).
               <div
-                style={{
-                  padding: 20,
-                  textAlign: "center",
-                  color: "var(--fg-2)",
-                }}
+                style={{ padding: 12 }}
+                aria-busy="true"
+                aria-label="Loading file"
               >
-                <PGSpinner size={14} />
+                <PGSkeleton count={14} height={10} gap={5} />
               </div>
             )}
             {selectedFile && selectedIsEmbedded && (


### PR DESCRIPTION
Closes the first slice of #61 Tier 2. Spec and plan are in the diff:
`docs/superpowers/specs/2026-08-13-issue-61-tier2-design.md`,
`docs/superpowers/plans/2026-08-13-issue-61-tier2-pr1-cheap-wins.md`.

## D9 — branch tracking is editable

`BranchInfo.upstream/ahead/behind` were displayed but there was no op to change tracking.

- New `GitBackend::set_upstream(repo_id, branch, upstream: Option<&str>)`. It **validates the remote-tracking branch before mutating**, so a typo surfaces as `InvalidRef` — the shape the UI already handles — instead of a stringified libgit2 error from deep inside `set_upstream`.
- Surfaced twice: a `Set upstream` action in the Branches inspector, and `Set upstream…` in the branch context menu. Both go through `pgPrompt`, relying on the contract `design/dialog.tsx` already guarantees: **an empty submitted string clears tracking, a dismissed dialog does nothing.** That distinction is why `requireValue` stays off and why a prompt is adequate here rather than a bespoke picker.
- **First push establishes tracking.** `push` now passes `-u`, but only when the branch has no upstream yet — re-sending it on every push would rewrite tracking the user may have deliberately pointed elsewhere. A failure to read branches falls back to a plain push rather than guessing.

## D10 — content search in the log

- `LogFilter` gains `content` + `contentRegex`, evaluated inside #81's `log_filtered_page`.
- **It runs last in the walk**, after message/author/sha/date/path, because it is the only filter costing a diff per commit — so an author- or path-scoped content search only diffs commits everything cheaper already accepted.
- The regex compiles **once before walking**, so a malformed pattern fails immediately rather than per commit. `contentRegex` alone does not make a filter non-empty.
- `content:` / `contains:` qualifier in the existing free-text parser, plus a field and a `.*` toggle in the advanced panel. `clearSearch` resets both, or Clear would leave a live filter behind.

**This is `-G`, not `-S`.** True `-S` reports commits where the *occurrence count* of a string changed, which needs whole-blob counting on both sides of every candidate. `-G` — "the pattern appears in a line the commit added or removed" — is what people mean by this search, so the field is labelled **"Changed lines contain"** rather than "pickaxe".

## B6 — skeleton loaders

`.pg-shimmer` had been defined and unused since it was written; the issue framed this as use-it-or-delete-it. New `PGSkeleton` primitive, applied to the History log, `CommitDiffPanel` and the RepoBrowser file preview.

Two details that make it look right rather than nearly right:
- `rowStep` sizes placeholders from `--row-h`, which **already folds in `var(--row-step)`** — so a skeleton row matches the real row at any density instead of making the list jump when data arrives.
- History uses skeletons for the **initial load only**. That branch is reached solely when no commits are on screen, so a page-append never blanks the list the user is reading. The file preview sizes by code-line height and deliberately does *not* use `rowStep`: `--lh-code` owns that geometry.
- Shimmer is suppressed under `prefers-reduced-motion: reduce`.

## Also

`AppError::InvalidArgument` (mirrored into `errors.ts` the same commit) — needed by D10's bad-regex path and reused by D7 in the next PR.

## Verification

- `pnpm tsc --noEmit` ✓ · `pnpm exec tsc -p e2e/tsconfig.json --noEmit` ✓ · `pnpm vite build` ✓
- `pnpm test` — **652 passing** (81 files), including 12 new: 4 upstream-UI (set / clear-on-empty / no-op-on-dismiss / hidden for remote branches), 7 `content:` parsing and normalization, 7 `PGSkeleton`, 3 `CommitDiffPanel` loading.
- `cargo test` — **32/32 test binaries green**, including 11 new: 4 `set_upstream` (set, clear, unknown remote → `InvalidRef`, unknown local → `InvalidRef`), 2 `push_args`, 1 push-leaves-upstream, 6 content filter (adds *and* removals match, regex mode, literal mode is not regex, bad regex errors before walking, intersects with a path filter, dangling toggle is not a filter).
- E2E in Docker (`pnpm test:e2e:docker`), affected specs only: `history-ops` (6) + `branches` (2) — **8 passing**, WebKitGTK. Snapshot rebuilt first, since both `src/` and `src-tauri/` changed.

Rebased onto `bcf352e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)