### PR TITLE
fix(history): stop a blank window when a repo opens onto History

### DIFF
--- a/e2e/specs/open-persisted-screen.e2e.ts
+++ b/e2e/specs/open-persisted-screen.e2e.ts
@@ -1,0 +1,59 @@
+// Opening a repo lands on whatever screen was persisted from last session, not
+// necessarily Files. That path renders the screen once with empty state and
+// again when the data arrives; a hook that only runs on the second render
+// aborts the whole React root and the window goes blank.
+//
+// The rest of the suite always opens a repo onto Files and switches screens
+// afterwards, so the log is already loaded by the time History first renders —
+// which is exactly why this went unnoticed.
+import { branchyRepo, TempRepo } from "../support/tempRepo";
+import { armDriverBridge, resetApp, waitRepoLoaded } from "../support/app";
+
+describe("opening a repo onto a persisted screen", () => {
+  let repo: TempRepo;
+
+  before(() => {
+    repo = branchyRepo();
+  });
+
+  after(() => {
+    repo.dispose();
+  });
+
+  it("keeps the shell mounted when History is the restored screen", async () => {
+    await resetApp();
+
+    await browser.execute((p: string) => {
+      localStorage.setItem(
+        "pg-recent-repos",
+        JSON.stringify([{ path: p, openedAt: 1 }]),
+      );
+      localStorage.setItem("pg-screen", "history");
+    }, repo.path);
+
+    await browser.refresh();
+    await armDriverBridge();
+
+    const row = $(`[data-testid="recent-repo"][data-path="${repo.path}"]`);
+    await row.waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "recent-repo row never appeared",
+    });
+    await armDriverBridge();
+    await row.click();
+
+    // The shell surviving IS the assertion: a hook-order violation unmounts
+    // the React root, so the branch chip never appears and #root goes empty.
+    await waitRepoLoaded();
+
+    await $('[data-testid="commit-row"]').waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "History rendered no commit rows after opening the repo",
+    });
+
+    const rootChildren = await browser.execute(
+      () => document.getElementById("root")?.childElementCount ?? 0,
+    );
+    expect(rootChildren).toBeGreaterThan(0);
+  });
+});

--- a/src/AppShell.screens.test.tsx
+++ b/src/AppShell.screens.test.tsx
@@ -1,0 +1,185 @@
+// Opening a repo mounts a screen with empty state and re-renders it when the
+// data lands. Both renders must run the same hooks: React aborts the entire
+// root on a mismatch, and the window then shows nothing at all.
+//
+// Screen-level tests seed a fully populated store before rendering, so they
+// only ever exercise the second render. This one starts empty on purpose.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, render } from "@testing-library/react";
+
+import App from "./App";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useRecentsStore } from "@/features/repo/useRecentsStore";
+import { mockInvoke } from "@/test/invokeMock";
+import type { CommitInfo, FileDiff, FileStatus, RepoHandle } from "@/lib/types";
+
+const handle: RepoHandle = {
+  id: "repo-1",
+  path: "/tmp/fake-repo",
+  head: "refs/heads/main",
+};
+
+const COMMITS: CommitInfo[] = Array.from({ length: 3 }, (_, i) => ({
+  oid: `${i}`.repeat(40),
+  shortOid: `${i}`.repeat(7),
+  summary: `commit ${i}`,
+  body: i === 0 ? "a body\nover two lines" : null,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 1_700_000_000 - i * 3600,
+  parents: i < 2 ? [`${i + 1}`.repeat(40)] : [],
+  refs: i === 0 ? ["refs/heads/main"] : [],
+}));
+
+const STATUS: FileStatus[] = [
+  {
+    path: "src/a.ts",
+    worktree: { kind: "Modified" },
+    index: { kind: "Unmodified" },
+    additions: 1,
+    deletions: 0,
+    embedded: false,
+  },
+];
+
+/** `get_diff` returns one file's diff, not a list. */
+const FILE_DIFF: FileDiff = {
+  path: "src/a.ts",
+  oldPath: null,
+  binary: false,
+  additions: 1,
+  deletions: 0,
+  hunks: [
+    {
+      header: "@@ -0,0 +1,1 @@",
+      oldStart: 0,
+      oldLines: 0,
+      newStart: 1,
+      newLines: 1,
+      lines: [
+        {
+          kind: { kind: "Addition" },
+          oldLineno: null,
+          newLineno: 1,
+          content: "added line\n",
+        },
+      ],
+    },
+  ],
+};
+
+/** "All files" listings reuse FileStatus with everything unmodified. */
+const ALL_FILES: FileStatus[] = ["src/a.ts", "src/b.ts"].map((path) => ({
+  path,
+  worktree: { kind: "Unmodified" },
+  index: { kind: "Unmodified" },
+  additions: 0,
+  deletions: 0,
+  embedded: false,
+}));
+
+function wireAll(): void {
+  mockInvoke("get_status", () => STATUS);
+  mockInvoke("list_all_files", () => ALL_FILES);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: COMMITS, nextCursor: null }));
+  mockInvoke("get_log", () => COMMITS);
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => ({
+    inProgress: false,
+    nextIndex: 0,
+    total: 0,
+    pauseReason: null,
+  }));
+  mockInvoke("get_reflog", () => []);
+  mockInvoke("get_diff", () => FILE_DIFF);
+  mockInvoke("diff_commit", () => []);
+  mockInvoke("diff_commits", () => []);
+  mockInvoke("conflict_sides", () => null);
+  mockInvoke("take_launch_intent", () => null);
+  mockInvoke("cli_shim_status", () => ({ installed: false, path: null }));
+  mockInvoke("open_repo", () => handle);
+  mockInvoke("default_init_branch", () => "main");
+}
+
+/** Every screen reachable from the activity bar, i.e. every value `pg-screen`
+ *  can legitimately hold when the app restores a session. */
+const SCREENS = [
+  "repo",
+  "commit",
+  "history",
+  "branches",
+  "conflict",
+  "rebase",
+  "remote",
+  "diff",
+  "reflog",
+  "settings",
+];
+
+describe("restoring a screen while a repo's data is still loading", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useRecentsStore.setState({ recents: [] });
+    wireAll();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  for (const s of SCREENS) {
+    it(`keeps the shell mounted on "${s}" when data arrives after mount`, async () => {
+      localStorage.setItem("pg-screen", s);
+      // The store as it is the instant `openRepo` resolves: repo set, every
+      // per-repo slice still empty.
+      useRepoStore.setState({
+        current: handle,
+        status: [],
+        allFiles: [],
+        branches: [],
+        tags: [],
+        stashes: [],
+        remotes: [],
+        commits: [],
+        loading: true,
+        error: null,
+        repoState: "Clean",
+        rebaseStatus: {
+          inProgress: false,
+          nextIndex: 0,
+          total: 0,
+          pauseReason: null,
+        },
+        activity: {},
+      } as never);
+
+      const errors: string[] = [];
+      vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+        errors.push(args.map(String).join(" "));
+      });
+
+      const { container } = render(<App />);
+
+      // …and now the data lands, re-rendering the same screen.
+      await act(async () => {
+        useRepoStore.setState({
+          commits: COMMITS,
+          status: STATUS,
+          allFiles: ALL_FILES,
+          loading: false,
+        } as never);
+      });
+
+      expect(
+        errors.filter((e) => /Rendered more hooks|#310/.test(e)),
+      ).toEqual([]);
+      // A hook-order violation empties the root outright.
+      expect(container.textContent?.trim()).not.toBe("");
+    });
+  }
+});

--- a/src/design/error-boundary.test.tsx
+++ b/src/design/error-boundary.test.tsx
@@ -1,0 +1,55 @@
+// A render throw must leave a legible window, not an empty one.
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { PGErrorBoundary } from "./error-boundary";
+
+function Boom(): React.ReactNode {
+  throw new Error("Rendered more hooks than during the previous render.");
+}
+
+describe("PGErrorBoundary", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders children when nothing throws", () => {
+    render(
+      <PGErrorBoundary>
+        <div>all good</div>
+      </PGErrorBoundary>,
+    );
+    expect(screen.getByText("all good")).toBeInTheDocument();
+  });
+
+  it("shows the error message instead of an empty window", () => {
+    // React logs the caught error itself; silence it so the run stays readable.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { container } = render(
+      <PGErrorBoundary>
+        <Boom />
+      </PGErrorBoundary>,
+    );
+
+    expect(screen.getByTestId("app-error-boundary")).toBeInTheDocument();
+    expect(screen.getByText(/Rendered more hooks/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
+    // The actual regression: the window is not blank.
+    expect(container.textContent?.trim()).not.toBe("");
+  });
+
+  it("uses a caller-supplied reload action when given one", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const onReload = vi.fn();
+
+    render(
+      <PGErrorBoundary onReload={onReload}>
+        <Boom />
+      </PGErrorBoundary>,
+    );
+    screen.getByRole("button", { name: "Reload" }).click();
+
+    expect(onReload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/design/error-boundary.tsx
+++ b/src/design/error-boundary.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+
+/**
+ * Last line of defence around a whole window.
+ *
+ * React unmounts the entire root when a render throws, so without a boundary
+ * one broken screen leaves the user staring at an empty window with no message
+ * and nothing to click. Catching here trades that for the error text and
+ * a way out, which is also what makes such a bug reportable at all.
+ *
+ * Deliberately app-level and dumb: no retry-with-backoff, no per-screen
+ * boundaries. A render throw is a bug, and the useful behaviours are "say what
+ * broke" and "let me reload".
+ */
+interface Props {
+  children: React.ReactNode;
+  /** Overrides the reload action — the merge window closes instead. */
+  onReload?: () => void;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class PGErrorBoundary extends React.Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    // Keep the component stack — a minified production stack alone rarely
+    // names the screen that threw.
+    console.error("Unhandled render error:", error, info.componentStack);
+  }
+
+  render(): React.ReactNode {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+    return (
+      <div
+        role="alert"
+        data-testid="app-error-boundary"
+        style={{
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-start",
+          justifyContent: "center",
+          gap: 12,
+          padding: 32,
+          background: "var(--bg-0)",
+          color: "var(--fg-0)",
+          fontSize: "var(--fs-12)",
+          overflow: "auto",
+        }}
+      >
+        <strong style={{ fontSize: "var(--fs-14)" }}>
+          Something broke while drawing this screen
+        </strong>
+        <div style={{ color: "var(--fg-2)" }}>
+          This is a bug in platypusgit, not in your repository — nothing was
+          written to it.
+        </div>
+        <pre
+          style={{
+            fontFamily: "var(--font-mono)",
+            color: "var(--git-removed)",
+            whiteSpace: "pre-wrap",
+            overflowWrap: "anywhere",
+            margin: 0,
+            maxWidth: "100%",
+          }}
+        >
+          {error.message}
+        </pre>
+        <button
+          onClick={() => {
+            if (this.props.onReload) this.props.onReload();
+            else window.location.reload();
+          }}
+          style={{
+            background: "var(--accent)",
+            color: "var(--bg-0)",
+            border: "none",
+            borderRadius: 4,
+            padding: "6px 14px",
+            cursor: "pointer",
+            fontSize: "var(--fs-12)",
+          }}
+        >
+          Reload
+        </button>
+      </div>
+    );
+  }
+}

--- a/src/design/index.ts
+++ b/src/design/index.ts
@@ -8,6 +8,7 @@ export * from "./context-menu";
 export * from "./dialog";
 export * from "./ui-helpers";
 export * from "./empty-state";
+export * from "./error-boundary";
 export * from "./modal";
 export * from "./use-prevent-browser-context-menu";
 export * from "./resizable";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { attachConsole } from "@tauri-apps/plugin-log";
 import App from "./App";
+import { PGErrorBoundary } from "./design/error-boundary";
 import { MergeWindow } from "./features/merge/MergeWindow";
 import "./index.css";
 
@@ -18,6 +19,10 @@ const isMergeWindow =
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    {isMergeWindow ? <MergeWindow /> : <App />}
+    {/* Outermost, so a throw anywhere still leaves a window that says what
+        happened instead of an empty one. */}
+    <PGErrorBoundary>
+      {isMergeWindow ? <MergeWindow /> : <App />}
+    </PGErrorBoundary>
   </React.StrictMode>,
 );

--- a/src/screens/History.hookorder.test.tsx
+++ b/src/screens/History.hookorder.test.tsx
@@ -1,0 +1,80 @@
+// Opening a repo while History is the active screen renders the screen twice:
+// once with an empty log (the store clears `commits` on open), then again once
+// the log arrives. Those two renders must run the SAME hooks.
+//
+// They did not: an early return for the empty log sat above four hooks, so the
+// second render called more hooks than the first. React aborts the whole root
+// on that (error #310) and, with no error boundary mounted, the window went
+// blank — background colour and nothing else.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { HistoryScreen } from "./History";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { useKeymapStore } from "@/features/keymap";
+import { mockInvoke } from "@/test/invokeMock";
+import type { CommitInfo } from "@/lib/types";
+
+const commit: CommitInfo = {
+  oid: "a".repeat(40),
+  shortOid: "a".repeat(7),
+  summary: "first commit",
+  body: null,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 1_700_000_000,
+  parents: [],
+  refs: ["refs/heads/main"],
+};
+
+describe("History screen when the log arrives after mount", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // The state the repo store is in immediately after `openRepo`: a repo is
+    // current, the log has not landed yet.
+    useRepoStore.setState({
+      current: { id: "r1", path: "/repo", head: "main" },
+      commits: [],
+      searchResults: null,
+      searching: false,
+      searchCommits: async () => {},
+      branches: [],
+      status: [],
+      loading: true,
+    } as never);
+    useNavStore.setState({ intent: null });
+    useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+    mockInvoke("get_log_page", () => ({ commits: [commit], nextCursor: null }));
+    mockInvoke("diff_commit", () => []);
+    mockInvoke("get_status", () => []);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps rendering when commits load into an initially empty log", async () => {
+    // React logs the hook-order violation through console.error before it
+    // rethrows; fail loudly on it rather than letting it colour the output.
+    const errors: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    });
+
+    render(<HistoryScreen />);
+    expect(screen.getByText(/Loading commits/i)).toBeInTheDocument();
+
+    // The log lands — same component, second render, must use the same hooks.
+    await act(async () => {
+      useRepoStore.setState({ commits: [commit], loading: false } as never);
+    });
+
+    expect(
+      errors.filter((e) => /Rendered more hooks|error #310|#310/.test(e)),
+    ).toEqual([]);
+    // Summary shows in both the row and the detail panel — the point is that
+    // the screen rendered at all.
+    expect(screen.getAllByText("first commit").length).toBeGreaterThan(0);
+  });
+});

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -407,24 +407,11 @@ export function HistoryScreen() {
     />
   ) : null;
 
-  if (!commits.length) {
-    return (
-      <>
-        <PGToolbar left={toolbarLeft} right={toolbarRight} />
-        {advancedPanel}
-        {loading ? (
-          <PGEmpty icon="history" title={<PGSpinner size={18} />}>
-            Loading commits…
-          </PGEmpty>
-        ) : (
-          <PGEmpty icon="history" title="No commits yet">
-            This repository doesn&apos;t have any commits on HEAD.
-          </PGEmpty>
-        )}
-      </>
-    );
-  }
-
+  // Everything below stays ABOVE the empty-log early return: opening a repo
+  // renders this screen once with no commits and again once the log lands, and
+  // a hook that only runs on the second render aborts the whole React root
+  // ("rendered more hooks than during the previous render"), which showed up
+  // as a window with nothing in it at all.
   const primaryOid = primarySelectedKey(sel);
   const current =
     visible.find((c) => c.oid === primaryOid) ?? visible[cursorIdx] ?? visible[0];
@@ -478,6 +465,24 @@ export function HistoryScreen() {
     },
     [byOid, multiSelected, selectedSet, sel, order, onCommitMulti, onCommitContext],
   );
+
+  if (!commits.length) {
+    return (
+      <>
+        <PGToolbar left={toolbarLeft} right={toolbarRight} />
+        {advancedPanel}
+        {loading ? (
+          <PGEmpty icon="history" title={<PGSpinner size={18} />}>
+            Loading commits…
+          </PGEmpty>
+        ) : (
+          <PGEmpty icon="history" title="No commits yet">
+            This repository doesn&apos;t have any commits on HEAD.
+          </PGEmpty>
+        )}
+      </>
+    );
+  }
 
   const listPane = (
     <PGPane


### PR DESCRIPTION
Opening a repo while History was the restored screen left the whole window empty — background colour and nothing else, no titlebar, no error banner.

## Root cause

`HistoryScreen` early-returns an empty state when the log is empty, and #80 (graph v2 phase 4) added four hooks **below** that return (`onRowClick`, `byOid`, `refsByOid`, `onRowContext`).

Opening a repo renders the screen twice — once with the log still empty, once when it lands. The second render therefore called more hooks than the first, and React aborts the **entire root** on that (error #310). With no error boundary anywhere in `src/`, the result was a blank window rather than one broken screen.

Only reachable when History is already the active screen as the log arrives — i.e. when `pg-screen` was persisted to `history` from a previous session. That is why nothing caught it:

- every e2e spec opens a repo onto Files and switches screens afterwards, so the log is already loaded when History first renders;
- screen-level tests seed a populated store before rendering.

Both only ever exercise the second render.

## Changes

- **Fix:** move the four hooks above the early return in `History.tsx`. No behaviour change — they all handle an empty log already.
- **Defence in depth:** a root `PGErrorBoundary` in `main.tsx`. A render throw now shows what broke plus a Reload button instead of an empty window. The symptom being "no content at all" rather than "History is broken" was entirely down to its absence.

## Tests

Each new test fails against the unfixed code:

- `History.hookorder.test.tsx` — the specific regression.
- `AppShell.screens.test.tsx` — mounts each of the 10 restorable screens with empty state, then lands the data. This is the general form of the bug class, not just this instance.
- `error-boundary.test.tsx` — the boundary renders the message instead of nothing.
- `open-persisted-screen.e2e.ts` — the real flow: open a repo with `pg-screen` persisted to History, assert the shell survives.

## Verification

- `pnpm test` — 655 passed / 83 files
- `pnpm tsc --noEmit` — clean
- `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — clean
- `pnpm test:e2e:docker full --spec open-persisted-screen --spec history-ops --spec history-diff` — 3 spec files, 11 tests, all passing headless on WebKitGTK

Reproduced first in the real webview (root element emptied, React #310 in the console), then confirmed fixed there.

## Follow-up (not in this PR)

The project has no eslint, so `react-hooks/rules-of-hooks` — which flags exactly this pattern — has never run. Worth adding; it would have caught this at author time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
