### PR TITLE
feat(auth): issue #61 Tier 2 pt 3 — credentials and commit signing

### DIFF
--- a/docs/superpowers/plans/2026-08-13-issue-61-tier2-pr3-credentials-signing.md
+++ b/docs/superpowers/plans/2026-08-13-issue-61-tier2-pr3-credentials-signing.md
@@ -1,0 +1,1494 @@
+# Issue #61 Tier 2, PR 3 — credentials and commit signing
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make authenticated remotes work (D5) and let commits be signed and verified (D6).
+
+**Architecture:** D5 keeps the first attempt prompt-less exactly as today, classifies an auth failure out of git's stderr, and **retries** with an askpass that already knows the answer — the askpass being our own binary re-invoked through a new `--askpass` intent, reading its answer from the environment. Storage is delegated entirely to `git credential`, so we hold no secrets. D6 replaces `repo.commit` with `commit_create_buffer` → sign → `commit_signed` on the signed path only, and must move HEAD itself because `commit_signed` does not.
+
+**Tech Stack:** Rust + git2 0.20 + `git` / `gpg` / `ssh-keygen` subprocesses; React 19 + TypeScript + Zustand; vitest; `cargo test`.
+
+**Spec:** `docs/superpowers/specs/2026-08-13-issue-61-tier2-design.md`
+
+## Global Constraints
+
+- **Toolchain PATH.** Prefix every `pnpm`/`cargo` command with `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"`.
+- **Errors:** IPC-crossing fns return `AppResult<T>`; new `AppError` variant updates `src/lib/errors.ts` the same commit.
+- **Frontend never calls `invoke()` directly** — only typed wrappers in `src/lib/tauri.ts`.
+- **git2 work from a command goes through `tokio::task::spawn_blocking`.**
+- **`CliBackend` gets a `NotImplemented` stub for every new trait method.**
+- **Dialogs:** `pgConfirm` / `pgPrompt` from `@/design`; a screen rendered in isolation in tests needs `WithDialogs`.
+- **Import UI primitives from `@/design`.**
+- **Never hardcode the accent hue.**
+- **E2E only via `pnpm test:e2e:docker`**, only affected specs.
+- **Commit style:** Conventional Commits, `Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>`.
+
+## Security constraints — these are requirements, not suggestions
+
+The bar here is set by `opener.rs`, which already refuses to hand anything to a shell.
+
+1. **Secrets travel in the environment, never in argv.** Argv is world-readable via `ps` on macOS and Linux; another user cannot read a process's environment on either. No credential may ever appear in a command line, including a `credential.helper=!f() { echo ... }` inline helper.
+2. **The shim prints only the requested value.** No logging, no diagnostics on stdout, and a non-zero exit with no output when it does not recognize the prompt or the env var is absent.
+3. **Credentials never enter `AppError` messages, log output, or event payloads.**
+4. **git stderr is scrubbed before being surfaced or logged** — git echoes remote URLs, which can carry embedded credentials (`https://user:token@host/…`).
+5. **Nothing is persisted by us.** "Remember" hands the credential to `git credential approve`; without a helper it lives in memory for the session only.
+
+## Facts established by reading the code — do not re-derive
+
+- The prompt-less env policy is duplicated at **two** files: `commands/branches.rs` (`run_git`, used by fetch/fetch_all/pull/push and the tag/branch push helpers) and `commands/create.rs` (`run_clone`, which additionally streams progress from stderr and sets `stdin(null)` + `kill_on_drop`). Clone's output handling must be preserved; only the env and the failure classification are shared.
+- `cli.rs` already owns arg parsing: `LaunchIntent { path, screen }`, `Parsed::{Help, Launch}`, `parse_args`, plus `USAGE`. The shim adds a third `Parsed` variant.
+- **`CommitOptions` is built as a struct literal in 7 places** — `src-tauri/tests/{discard_reset,cherry_pick_revert,reflog,branches_tags,stage_commit}.rs`, `src-tauri/tests/support/mod.rs`, and `src-tauri/src/commands/commits.rs`. Adding a field breaks all of them; Task 5 updates every site in one commit.
+- `commit()` today handles amend via `Commit::amend(Some("HEAD"), …)` and normal commits via `repo.commit(Some("HEAD"), …)`. Both move HEAD for us. `commit_signed` does not — that is the trap in Task 6.
+
+---
+
+### Task 1: Classify auth failures out of git stderr
+
+Pure functions first, because they are the whole safety argument and need no repo.
+
+**Files:**
+- Create: `src-tauri/src/git/auth.rs`
+- Modify: `src-tauri/src/git/mod.rs` (add `pub mod auth;`)
+- Modify: `src-tauri/src/error.rs` + `src/lib/errors.ts` (the `Auth` variant)
+
+**Interfaces:**
+- Produces:
+  ```rust
+  pub enum AuthKind { Https, SshPassphrase, SshKey }
+  /// Classify a failed git invocation's stderr. None = not an auth failure.
+  pub fn classify_auth_failure(stderr: &str) -> Option<AuthKind>;
+  /// Remove credentials embedded in any URL in `text`, in place of the userinfo.
+  pub fn scrub_credentials(text: &str) -> String;
+  /// Host from git's stderr, when it names one.
+  pub fn host_from_stderr(stderr: &str) -> Option<String>;
+  ```
+  and `AppError::Auth { host: Option<String>, kind: AuthKind }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src-tauri/src/git/auth.rs` with only the test module at first (so the file compiles as a module and the tests name what does not exist yet):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn https_auth_failure_is_https() {
+        for s in [
+            "remote: Invalid username or password.\nfatal: Authentication failed for 'https://github.com/x/y.git/'",
+            "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+        ] {
+            assert_eq!(classify_auth_failure(s), Some(AuthKind::Https), "{s}");
+        }
+    }
+
+    #[test]
+    fn ssh_passphrase_prompt_is_passphrase() {
+        let s = "Enter passphrase for key '/home/u/.ssh/id_ed25519': \nfatal: Could not read from remote repository.";
+        assert_eq!(classify_auth_failure(s), Some(AuthKind::SshPassphrase));
+    }
+
+    #[test]
+    fn publickey_denied_is_ssh_key() {
+        let s = "git@github.com: Permission denied (publickey).\nfatal: Could not read from remote repository.";
+        assert_eq!(classify_auth_failure(s), Some(AuthKind::SshKey));
+    }
+
+    #[test]
+    fn host_key_verification_is_not_an_auth_failure() {
+        // Prompting for a password cannot fix an unknown host key, and offering
+        // to would be actively misleading.
+        let s = "Host key verification failed.\nfatal: Could not read from remote repository.";
+        assert_eq!(classify_auth_failure(s), None);
+    }
+
+    #[test]
+    fn ordinary_network_errors_are_not_auth_failures() {
+        for s in [
+            "fatal: unable to access 'https://x/y': Could not resolve host: x",
+            "fatal: repository 'https://x/y' not found",
+            "error: failed to push some refs to 'origin'",
+        ] {
+            assert_eq!(classify_auth_failure(s), None, "{s}");
+        }
+    }
+
+    #[test]
+    fn scrub_removes_userinfo_from_urls() {
+        assert_eq!(
+            scrub_credentials("fatal: unable to access 'https://user:ghp_secret@github.com/x/y.git/'"),
+            "fatal: unable to access 'https://***@github.com/x/y.git/'"
+        );
+    }
+
+    #[test]
+    fn scrub_leaves_credential_free_text_alone() {
+        let s = "fatal: Authentication failed for 'https://github.com/x/y.git/'";
+        assert_eq!(scrub_credentials(s), s);
+    }
+
+    #[test]
+    fn scrub_handles_several_urls() {
+        let out = scrub_credentials("a https://u:p@h1/x b https://u2:p2@h2/y");
+        assert!(!out.contains("p@"), "{out}");
+        assert!(!out.contains("p2@"), "{out}");
+    }
+
+    #[test]
+    fn host_is_extracted_from_https_and_ssh_forms() {
+        assert_eq!(
+            host_from_stderr("fatal: Authentication failed for 'https://github.com/x/y.git/'"),
+            Some("github.com".to_string())
+        );
+        assert_eq!(
+            host_from_stderr("git@gitlab.com: Permission denied (publickey)."),
+            Some("gitlab.com".to_string())
+        );
+        assert_eq!(host_from_stderr("something unrelated"), None);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Add `pub mod auth;` to `src-tauri/src/git/mod.rs`, then:
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --lib auth 2>&1 | tail -20
+```
+Expected: compile errors for `classify_auth_failure`, `AuthKind`, `scrub_credentials`, `host_from_stderr`.
+
+- [ ] **Step 3: Implement the module**
+
+Above the test module in `src-tauri/src/git/auth.rs`:
+
+```rust
+//! Authentication failure classification and credential hygiene (#61 D5).
+//!
+//! Network ops run prompt-less on the first attempt, so an authenticated
+//! remote fails with git's own stderr. This module turns that stderr into a
+//! typed answer — "this is an auth failure, of this kind, for this host" — so
+//! the UI can collect a credential and retry, and scrubs credentials out of
+//! anything before it reaches an error message or a log.
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum AuthKind {
+    /// HTTPS username + password/token.
+    Https,
+    /// An encrypted SSH private key needs its passphrase.
+    SshPassphrase,
+    /// The server rejected the key we offered (or we offered none).
+    SshKey,
+}
+
+/// Classify a failed git invocation's stderr. `None` means "not an auth
+/// failure" — the caller keeps its existing `Network` error.
+///
+/// Host-key verification is deliberately NOT an auth failure: no credential
+/// the user can type will fix an unknown host key.
+pub fn classify_auth_failure(stderr: &str) -> Option<AuthKind> {
+    let s = stderr.to_lowercase();
+
+    if s.contains("host key verification failed") {
+        return None;
+    }
+    if s.contains("enter passphrase for key") || s.contains("bad passphrase") {
+        return Some(AuthKind::SshPassphrase);
+    }
+    if s.contains("permission denied (publickey)") {
+        return Some(AuthKind::SshKey);
+    }
+    if s.contains("authentication failed")
+        || s.contains("invalid username or password")
+        || s.contains("could not read username")
+        || s.contains("could not read password")
+        || s.contains("terminal prompts disabled")
+    {
+        return Some(AuthKind::Https);
+    }
+    None
+}
+
+/// Replace the `user:password@` userinfo of every URL in `text` with `***`.
+///
+/// git echoes remote URLs in its errors, and a remote configured with an
+/// embedded token would otherwise put that token into an error banner or a log
+/// file.
+pub fn scrub_credentials(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+
+    while let Some(scheme_at) = rest.find("://") {
+        let after = scheme_at + 3;
+        // Userinfo, if any, ends at the first '@' before the next '/' or
+        // whitespace — beyond that we are into the path and there is no
+        // userinfo to strip.
+        let tail = &rest[after..];
+        let stop = tail
+            .find(|c: char| c == '/' || c.is_whitespace() || c == '\'' || c == '"')
+            .unwrap_or(tail.len());
+        match tail[..stop].find('@') {
+            Some(at) => {
+                out.push_str(&rest[..after]);
+                out.push_str("***");
+                out.push_str(&tail[at..stop]);
+                rest = &tail[stop..];
+            }
+            None => {
+                out.push_str(&rest[..after + stop]);
+                rest = &tail[stop..];
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Best-effort host from git/ssh stderr: `https://host/…` or `git@host:`.
+pub fn host_from_stderr(stderr: &str) -> Option<String> {
+    if let Some(at) = stderr.find("://") {
+        let tail = &stderr[at + 3..];
+        let stop = tail
+            .find(|c: char| c == '/' || c.is_whitespace() || c == '\'' || c == '"')
+            .unwrap_or(tail.len());
+        let hostish = &tail[..stop];
+        // Drop any userinfo before the host.
+        let host = hostish.rsplit('@').next().unwrap_or(hostish);
+        if !host.is_empty() {
+            return Some(host.to_string());
+        }
+    }
+    // `git@host: Permission denied` — take the token before the first colon.
+    if let Some(colon) = stderr.find(": ") {
+        let head = &stderr[..colon];
+        if let Some(at) = head.rfind('@') {
+            let host = &head[at + 1..];
+            if !host.is_empty() && host.contains('.') {
+                return Some(host.to_string());
+            }
+        }
+    }
+    None
+}
+```
+
+- [ ] **Step 4: Add the error variant on both sides**
+
+`src-tauri/src/error.rs`, after `Network`:
+
+```rust
+    #[error("authentication required")]
+    Auth {
+        host: Option<String>,
+        kind: crate::git::auth::AuthKind,
+    },
+```
+
+> `AppError` is `#[serde(tag = "kind", content = "message")]`, so a struct variant serializes its fields as the `message` object. Check the generated shape against `src/lib/errors.ts` — if the tagged representation fights the struct variant, carry the payload as a single `AuthChallenge` struct instead (`Auth(AuthChallenge)`); the TS side then reads `message.host` / `message.authKind`. Pick whichever compiles and keep the two in step.
+
+`src/lib/errors.ts`:
+
+```typescript
+  | {
+      kind: "Auth";
+      message: { host: string | null; kind: "Https" | "SshPassphrase" | "SshKey" };
+    }
+```
+
+plus a narrowing helper beside `isEmbeddedRepoError`:
+
+```typescript
+export function isAuthError(e: unknown): e is Extract<AppError, { kind: "Auth" }> {
+  return isAppError(e) && e.kind === "Auth";
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --lib auth 2>&1 | tail -15
+pnpm tsc --noEmit
+```
+Expected: 9 tests pass, type-check clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/git/auth.rs src-tauri/src/git/mod.rs src-tauri/src/error.rs src/lib/errors.ts
+git commit -m "feat(auth): classify git auth failures and scrub credentials (#61 D5)
+
+Why host-key verification is deliberately NOT an auth failure: no credential
+the user can type fixes an unknown host key, so offering a password prompt
+would be actively misleading. scrub_credentials exists because git echoes
+remote URLs, which can carry an embedded token into an error banner or log.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: The askpass shim
+
+**Files:**
+- Modify: `src-tauri/src/cli.rs` (`Parsed`, `parse_args`, `USAGE`, plus the shim answer logic)
+- Modify: `src-tauri/src/lib.rs` (handle it before the Tauri app is built)
+
+**Interfaces:**
+- Produces:
+  ```rust
+  // in cli.rs
+  pub enum Parsed { Help, Askpass(String), Launch(Option<LaunchIntent>) }
+  /// Env var names the parent sets for the shim to read.
+  pub const ASKPASS_USERNAME_ENV: &str = "PLATYPUSGIT_ASKPASS_USERNAME";
+  pub const ASKPASS_SECRET_ENV: &str = "PLATYPUSGIT_ASKPASS_SECRET";
+  /// Which answer a git/ssh prompt is asking for.
+  pub enum AskpassWant { Username, Secret }
+  pub fn askpass_want(prompt: &str) -> Option<AskpassWant>;
+  /// The value to print, or None to exit non-zero silently.
+  pub fn askpass_answer(prompt: &str, username: Option<&str>, secret: Option<&str>) -> Option<String>;
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `cli.rs`'s existing `#[cfg(test)] mod tests`:
+
+```rust
+    #[test]
+    fn askpass_prompt_kinds_are_recognized() {
+        assert!(matches!(
+            askpass_want("Username for 'https://github.com': "),
+            Some(AskpassWant::Username)
+        ));
+        assert!(matches!(
+            askpass_want("Password for 'https://u@github.com': "),
+            Some(AskpassWant::Secret)
+        ));
+        assert!(matches!(
+            askpass_want("Enter passphrase for key '/home/u/.ssh/id_ed25519': "),
+            Some(AskpassWant::Secret)
+        ));
+        assert!(askpass_want("Are you sure you want to continue connecting?").is_none());
+    }
+
+    #[test]
+    fn askpass_answers_from_the_matching_env_value() {
+        assert_eq!(
+            askpass_answer("Username for 'https://github.com': ", Some("ada"), Some("tok")),
+            Some("ada".to_string())
+        );
+        assert_eq!(
+            askpass_answer("Password for 'https://ada@github.com': ", Some("ada"), Some("tok")),
+            Some("tok".to_string())
+        );
+    }
+
+    #[test]
+    fn askpass_refuses_when_the_value_is_absent() {
+        // No env value → print nothing, exit non-zero. Never fall back to
+        // an empty string, which git would try to authenticate with.
+        assert_eq!(askpass_answer("Password for 'https://x': ", None, None), None);
+        assert_eq!(askpass_answer("Username for 'https://x': ", None, Some("tok")), None);
+    }
+
+    #[test]
+    fn askpass_refuses_an_unrecognized_prompt() {
+        assert_eq!(
+            askpass_answer("Please confirm the fingerprint", Some("ada"), Some("tok")),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_args_recognizes_askpass() {
+        let cwd = std::path::Path::new("/tmp");
+        assert_eq!(
+            parse_args(&["--askpass".to_string(), "Password for 'x': ".to_string()], cwd),
+            Parsed::Askpass("Password for 'x': ".to_string())
+        );
+    }
+
+    #[test]
+    fn askpass_without_a_prompt_is_still_askpass_and_answers_nothing() {
+        let cwd = std::path::Path::new("/tmp");
+        assert_eq!(
+            parse_args(&["--askpass".to_string()], cwd),
+            Parsed::Askpass(String::new())
+        );
+        assert_eq!(askpass_answer("", Some("a"), Some("b")), None);
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --lib cli 2>&1 | tail -15
+```
+Expected: compile errors for the new items.
+
+- [ ] **Step 3: Implement**
+
+In `src-tauri/src/cli.rs`:
+
+```rust
+/// Env vars the parent process sets so the askpass shim can answer without any
+/// IPC back to the app. Values live in the environment rather than argv: argv
+/// is world-readable via `ps`, a process's environment is not (#61 D5).
+pub const ASKPASS_USERNAME_ENV: &str = "PLATYPUSGIT_ASKPASS_USERNAME";
+pub const ASKPASS_SECRET_ENV: &str = "PLATYPUSGIT_ASKPASS_SECRET";
+
+/// Which answer a git/ssh askpass prompt is asking for.
+#[derive(Debug, PartialEq)]
+pub enum AskpassWant {
+    Username,
+    Secret,
+}
+
+/// Classify an askpass prompt. `None` for anything unrecognized — the shim
+/// must never guess at a prompt it does not understand.
+pub fn askpass_want(prompt: &str) -> Option<AskpassWant> {
+    let p = prompt.to_lowercase();
+    if p.contains("username") {
+        return Some(AskpassWant::Username);
+    }
+    if p.contains("password") || p.contains("passphrase") {
+        return Some(AskpassWant::Secret);
+    }
+    None
+}
+
+/// The value the shim should print, or `None` to print nothing and exit
+/// non-zero. An absent value is never substituted with an empty string: git
+/// would take that as a real (wrong) credential.
+pub fn askpass_answer(
+    prompt: &str,
+    username: Option<&str>,
+    secret: Option<&str>,
+) -> Option<String> {
+    match askpass_want(prompt)? {
+        AskpassWant::Username => username.map(str::to_string),
+        AskpassWant::Secret => secret.map(str::to_string),
+    }
+}
+```
+
+Add the `Parsed` variant and handle it first in `parse_args` (before `--help`, so a prompt containing "-h" cannot be misread):
+
+```rust
+pub enum Parsed {
+    Help,
+    /// Invoked as GIT_ASKPASS / SSH_ASKPASS with a prompt string (#61 D5).
+    Askpass(String),
+    Launch(Option<LaunchIntent>),
+}
+```
+
+```rust
+pub fn parse_args(args: &[String], cwd: &Path) -> Parsed {
+    // Askpass first: the prompt is arbitrary text from git and must not be
+    // scanned for our own flags.
+    if args.first().map(String::as_str) == Some("--askpass") {
+        return Parsed::Askpass(args.get(1).cloned().unwrap_or_default());
+    }
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        return Parsed::Help;
+    }
+    // …existing body unchanged…
+```
+
+`USAGE` gains no `--askpass` line: it is an internal contract between the app and its own subprocesses, not a user-facing flag.
+
+In `src-tauri/src/lib.rs`, handle it **before** anything else in `run()` — before the single-instance plugin, before the Tauri builder, so the shim is a plain fast process that never becomes a second app instance:
+
+```rust
+    let initial_intent = match cli::parse_args(&args, &cwd) {
+        cli::Parsed::Help => {
+            print!("{}", cli::USAGE);
+            return;
+        }
+        // Askpass shim (#61 D5): print exactly the requested value and exit.
+        // No window, no single-instance forwarding, no logging — stdout here is
+        // read by git, and anything extra would be taken as the credential.
+        cli::Parsed::Askpass(prompt) => {
+            let username = std::env::var(cli::ASKPASS_USERNAME_ENV).ok();
+            let secret = std::env::var(cli::ASKPASS_SECRET_ENV).ok();
+            match cli::askpass_answer(&prompt, username.as_deref(), secret.as_deref()) {
+                Some(value) => {
+                    println!("{value}");
+                    return;
+                }
+                None => std::process::exit(1),
+            }
+        }
+        cli::Parsed::Launch(intent) => intent.map(cli::resolve_repo_root),
+    };
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --lib cli 2>&1 | tail -15
+```
+Expected: the 6 new tests pass and every existing `cli` test still passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/cli.rs src-tauri/src/lib.rs
+git commit -m "feat(auth): askpass shim as an --askpass invocation of our own binary (#61 D5)
+
+Secrets reach the shim through the environment, never argv: argv is
+world-readable via ps, a process's environment is not. The shim prints only the
+requested value and exits non-zero with no output on an unrecognized prompt or
+a missing value — an empty string would be taken by git as a real credential.
+Handled before the Tauri builder so it never becomes a second app instance.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: One authenticated runner for all four network ops
+
+**Files:**
+- Create: `src-tauri/src/commands/net.rs` (shared runner)
+- Modify: `src-tauri/src/commands/mod.rs` (`pub mod net;`)
+- Modify: `src-tauri/src/commands/branches.rs` (`run_git` delegates; commands take credentials)
+- Modify: `src-tauri/src/commands/create.rs` (`run_clone` uses the shared env + classification)
+- Modify: `src-tauri/src/lib.rs` (no new commands, but `Credentials` must be `Deserialize`)
+
+**Interfaces:**
+- Consumes: `git::auth::{classify_auth_failure, scrub_credentials, host_from_stderr}` from Task 1; `cli::{ASKPASS_USERNAME_ENV, ASKPASS_SECRET_ENV}` from Task 2.
+- Produces:
+  ```rust
+  #[derive(Debug, Clone, Deserialize)]
+  #[serde(rename_all = "camelCase")]
+  pub struct Credentials { pub username: Option<String>, pub secret: String }
+
+  /// Apply the prompt-less-or-askpass env policy to a command.
+  pub fn apply_auth_env(cmd: &mut tokio::process::Command, creds: Option<&Credentials>);
+  /// Map a failed invocation's stderr to Auth or Network, scrubbed.
+  pub fn map_git_failure(stderr: &str) -> AppError;
+  /// Run `git -C cwd <args>`, with credentials when supplied.
+  pub async fn run_git_authenticated(
+      cwd: &Path, args: &[&str], creds: Option<&Credentials>,
+  ) -> AppResult<()>;
+  ```
+  `fetch` / `fetch_all` / `pull` / `push` / `clone_repo` each gain an optional
+  `credentials: Option<Credentials>` parameter. Optional, so an existing caller
+  that omits it behaves exactly as today.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src-tauri/tests/auth_env.rs`:
+
+```rust
+mod support;
+
+use platypusgit_lib::commands::net::{map_git_failure, Credentials};
+use platypusgit_lib::error::AppError;
+
+#[test]
+fn auth_stderr_maps_to_auth_error() {
+    let err = map_git_failure(
+        "fatal: Authentication failed for 'https://github.com/x/y.git/'",
+    );
+    match err {
+        AppError::Auth { host, .. } => assert_eq!(host.as_deref(), Some("github.com")),
+        other => panic!("expected Auth, got {other:?}"),
+    }
+}
+
+#[test]
+fn non_auth_stderr_stays_network() {
+    let err = map_git_failure("fatal: unable to access 'https://x/y': Could not resolve host: x");
+    assert!(matches!(err, AppError::Network(_)), "got {err:?}");
+}
+
+#[test]
+fn surfaced_message_never_carries_an_embedded_token() {
+    let err = map_git_failure(
+        "fatal: unable to access 'https://u:ghp_secret@github.com/x/y': Authentication failed",
+    );
+    let text = format!("{err:?}");
+    assert!(!text.contains("ghp_secret"), "credential leaked: {text}");
+}
+
+/// Credentials must never be visible in the child's argv (#61 D5).
+#[test]
+fn credentials_are_not_passed_in_argv() {
+    let creds = Credentials {
+        username: Some("ada".into()),
+        secret: "ghp_secret".into(),
+    };
+    let mut cmd = tokio::process::Command::new("git");
+    cmd.arg("fetch");
+    platypusgit_lib::commands::net::apply_auth_env(&mut cmd, Some(&creds));
+
+    let argv = format!("{:?}", cmd.as_std().get_args().collect::<Vec<_>>());
+    assert!(!argv.contains("ghp_secret"), "secret in argv: {argv}");
+
+    let envs: Vec<_> = cmd.as_std().get_envs().collect();
+    let has_secret = envs.iter().any(|(_, v)| {
+        v.map(|v| v.to_string_lossy().contains("ghp_secret")).unwrap_or(false)
+    });
+    assert!(has_secret, "secret should travel in the environment");
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test auth_env 2>&1 | tail -15
+```
+Expected: unresolved module `commands::net`.
+
+- [ ] **Step 3: Implement the shared runner**
+
+Create `src-tauri/src/commands/net.rs`:
+
+```rust
+//! One place for the network-op environment policy and failure mapping (#61 D5).
+//!
+//! Before this module the policy was duplicated in branches.rs (fetch/pull/push)
+//! and create.rs (clone), which is how they could drift.
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::{
+    cli::{ASKPASS_SECRET_ENV, ASKPASS_USERNAME_ENV},
+    error::{AppError, AppResult},
+    git::auth::{classify_auth_failure, host_from_stderr, scrub_credentials},
+};
+
+/// A credential collected from the user for one retry. Never persisted here —
+/// "remember" is `git credential approve`, which hands it to the user's own
+/// configured helper.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Credentials {
+    pub username: Option<String>,
+    pub secret: String,
+}
+
+/// Apply the environment policy for a git subprocess.
+///
+/// Without credentials this is the historical prompt-less policy: a subprocess
+/// has no terminal, so an auth-requiring remote would otherwise hang forever on
+/// an invisible prompt. With credentials, our own binary becomes the askpass and
+/// reads the answer from the environment — argv is world-readable via `ps`, a
+/// process's environment is not.
+pub fn apply_auth_env(cmd: &mut tokio::process::Command, creds: Option<&Credentials>) {
+    cmd.env("GIT_TERMINAL_PROMPT", "0");
+    match creds {
+        None => {
+            cmd.env("GIT_ASKPASS", "true").env("SSH_ASKPASS", "true");
+        }
+        Some(c) => {
+            let exe = std::env::current_exe()
+                .unwrap_or_else(|_| std::path::PathBuf::from("platypusgit"));
+            // `sh -c` is deliberately NOT used: git execs the askpass program
+            // directly with the prompt as argv[1], so no shell is involved.
+            let askpass = format!("{} --askpass", exe.display());
+            cmd.env("GIT_ASKPASS", &askpass)
+                .env("SSH_ASKPASS", &askpass)
+                // OpenSSH ≥ 8.4 needs this to use SSH_ASKPASS without a DISPLAY.
+                .env("SSH_ASKPASS_REQUIRE", "force")
+                .env(ASKPASS_SECRET_ENV, &c.secret);
+            if let Some(u) = &c.username {
+                cmd.env(ASKPASS_USERNAME_ENV, u);
+            }
+        }
+    }
+}
+```
+
+> **Trap to verify while implementing:** `GIT_ASKPASS` is exec'd, not run through a shell, so `"<exe> --askpass"` as a single string only works if git splits it — which it does **not**. If the test in Step 4 shows git failing to run the askpass, write a tiny wrapper script into the app's cache dir at first use (`exec "<exe>" --askpass "$@"`, mode 0700) and point `GIT_ASKPASS` at that instead. Do not switch to embedding the secret in argv.
+
+```rust
+/// Map a failed git invocation to an error, scrubbing credentials first.
+pub fn map_git_failure(stderr: &str) -> AppError {
+    let clean = scrub_credentials(stderr.trim());
+    match classify_auth_failure(&clean) {
+        Some(kind) => AppError::Auth {
+            host: host_from_stderr(&clean),
+            kind,
+        },
+        None => AppError::Network(clean),
+    }
+}
+
+/// Run `git -C cwd <args>`, mapping a non-zero exit through `map_git_failure`.
+pub async fn run_git_authenticated(
+    cwd: &Path,
+    args: &[&str],
+    creds: Option<&Credentials>,
+) -> AppResult<()> {
+    let mut cmd = tokio::process::Command::new("git");
+    cmd.arg("-C").arg(cwd).args(args);
+    apply_auth_env(&mut cmd, creds);
+    // Nothing feeds the child stdin, so an unexpected read would block forever.
+    cmd.stdin(std::process::Stdio::null());
+
+    let output = cmd
+        .output()
+        .await
+        .map_err(|e| AppError::Io(e.to_string()))?;
+
+    if !output.status.success() {
+        return Err(map_git_failure(&String::from_utf8_lossy(&output.stderr)));
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Point the four op sites at it**
+
+In `branches.rs`, replace `run_git`'s body with a delegation so every existing caller is unchanged:
+
+```rust
+async fn run_git(cwd: &std::path::Path, args: &[&str]) -> AppResult<()> {
+    crate::commands::net::run_git_authenticated(cwd, args, None).await
+}
+```
+
+Then give `fetch`, `fetch_all`, `pull` and `push` an extra
+`credentials: Option<Credentials>` parameter and call
+`run_git_authenticated(&path, &arg_refs, credentials.as_ref())`. Leave
+`push_tag` / `push_delete_branch` on the credential-less `run_git` for now and
+say so in the PR — they are pushes too, and a follow-up should thread
+credentials through them.
+
+In `create.rs`'s `run_clone`, replace the three `.env(...)` lines with
+`net::apply_auth_env(&mut cmd, creds)` (add a `creds: Option<&Credentials>`
+parameter, threaded from `clone_repo`), keep every other builder call exactly as
+it is (`stdin(null)`, `stderr(piped())`, `kill_on_drop`), and map its failure
+through `net::map_git_failure` instead of constructing `AppError::Network`
+directly.
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml 2>&1 | grep -E "test result: FAILED|error\[" | head
+cargo test --manifest-path src-tauri/Cargo.toml --test auth_env 2>&1 | tail -10
+```
+Expected: no failures anywhere; the 4 new tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/commands/net.rs src-tauri/src/commands/mod.rs src-tauri/src/commands/branches.rs src-tauri/src/commands/create.rs src-tauri/tests/auth_env.rs
+git commit -m "feat(auth): one authenticated runner for fetch/pull/push/clone (#61 D5)
+
+Collapses the prompt-less env policy that was duplicated across branches.rs
+and create.rs, and routes both failure paths through one classifier so an auth
+failure is typed rather than a generic Network error. Credentials travel in the
+child's environment and are asserted absent from argv.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Credential dialog and retry
+
+**Files:**
+- Create: `src/features/auth/useAuthStore.ts`, `src/features/auth/CredentialDialog.tsx`
+- Create: `src/features/auth/CredentialDialog.test.tsx`
+- Modify: `src/lib/tauri.ts` (credentials parameter on the four wrappers; `gitCredentialFill` / `gitCredentialApprove` if exposed as commands)
+- Modify: `src/features/repo/useRepoStore.ts` (network actions raise the challenge and retry)
+- Modify: `src/AppShell.tsx` (mount `<CredentialDialog />`)
+
+**Interfaces:**
+- Consumes: `isAuthError` from Task 1.
+- Produces:
+  ```typescript
+  interface AuthChallenge {
+    host: string | null;
+    kind: "Https" | "SshPassphrase" | "SshKey";
+    /** Re-runs the failed op with these credentials. */
+    retry: (creds: { username?: string; secret: string }, remember: boolean) => Promise<void>;
+  }
+  useAuthStore: { challenge: AuthChallenge | null; raise(c): void; dismiss(): void }
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/auth/CredentialDialog.test.tsx`:
+
+```tsx
+// Credential entry + retry (#61 D5).
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { CredentialDialog } from "./CredentialDialog";
+import { useAuthStore } from "./useAuthStore";
+
+function raise(retry = vi.fn().mockResolvedValue(undefined)) {
+  useAuthStore.getState().raise({ host: "github.com", kind: "Https", retry });
+  return retry;
+}
+
+describe("CredentialDialog", () => {
+  beforeEach(() => useAuthStore.setState({ challenge: null }));
+
+  it("renders nothing without a challenge", () => {
+    render(<CredentialDialog />);
+    expect(screen.queryByTestId("credential-dialog")).toBeNull();
+  });
+
+  it("names the host it is authenticating to", () => {
+    raise();
+    render(<CredentialDialog />);
+    expect(screen.getByTestId("credential-dialog").textContent).toContain("github.com");
+  });
+
+  it("retries with the entered credentials", async () => {
+    const retry = raise();
+    render(<CredentialDialog />);
+    fireEvent.change(screen.getByTestId("credential-username"), {
+      target: { value: "ada" },
+    });
+    fireEvent.change(screen.getByTestId("credential-secret"), {
+      target: { value: "ghp_x" },
+    });
+    fireEvent.click(screen.getByTestId("credential-submit"));
+
+    await waitFor(() =>
+      expect(retry).toHaveBeenCalledWith({ username: "ada", secret: "ghp_x" }, false),
+    );
+  });
+
+  it("passes remember through when checked", async () => {
+    const retry = raise();
+    render(<CredentialDialog />);
+    fireEvent.change(screen.getByTestId("credential-secret"), {
+      target: { value: "ghp_x" },
+    });
+    fireEvent.click(screen.getByTestId("credential-remember"));
+    fireEvent.click(screen.getByTestId("credential-submit"));
+
+    await waitFor(() =>
+      expect(retry).toHaveBeenCalledWith(expect.anything(), true),
+    );
+  });
+
+  it("asks only for a passphrase on an SSH challenge", () => {
+    useAuthStore.getState().raise({
+      host: null,
+      kind: "SshPassphrase",
+      retry: vi.fn(),
+    });
+    render(<CredentialDialog />);
+    expect(screen.queryByTestId("credential-username")).toBeNull();
+    expect(screen.getByTestId("credential-secret")).toBeTruthy();
+  });
+
+  it("dismissing clears the challenge without retrying", () => {
+    const retry = raise();
+    render(<CredentialDialog />);
+    fireEvent.click(screen.getByTestId("credential-cancel"));
+    expect(retry).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().challenge).toBeNull();
+  });
+
+  it("does not keep the secret in the store after submitting", async () => {
+    raise();
+    render(<CredentialDialog />);
+    fireEvent.change(screen.getByTestId("credential-secret"), {
+      target: { value: "ghp_x" },
+    });
+    fireEvent.click(screen.getByTestId("credential-submit"));
+    await waitFor(() => expect(useAuthStore.getState().challenge).toBeNull());
+    expect(JSON.stringify(useAuthStore.getState())).not.toContain("ghp_x");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/features/auth/CredentialDialog.test.tsx --run 2>&1 | tail -10
+```
+Expected: FAIL — modules do not exist.
+
+- [ ] **Step 3: Implement the store and dialog**
+
+`src/features/auth/useAuthStore.ts` — a plain Zustand store holding at most one
+challenge. The secret is component state and is **never** put in the store, so
+the last test above holds.
+
+`src/features/auth/CredentialDialog.tsx` — a `PGModal` with:
+- a username `PGInput` (`data-testid="credential-username"`), rendered only for
+  `kind === "Https"`;
+- a masked secret `PGInput` (`data-testid="credential-secret"`) with a
+  show/hide toggle;
+- a "Remember" `PGCheckbox` (`data-testid="credential-remember"`) whose label
+  says where it will be stored — git's own credential helper — and says
+  "for this session only" when no helper is configured;
+- submit / cancel (`credential-submit` / `credential-cancel`).
+
+Submit calls `challenge.retry({ username, secret }, remember)` and then
+`dismiss()`. Cancel just dismisses.
+
+- [ ] **Step 4: Raise the challenge from the store's network actions**
+
+In `useRepoStore`, each of `fetch` / `fetchAll` / `pull` / `push` catches its
+error and, when `isAuthError(e)`, raises a challenge whose `retry` re-invokes
+the same wrapper with credentials instead of setting `error`. On a cancelled
+dialog the original error surfaces through the normal banner path — and per the
+danger-op convention, `refreshAll()` runs **before** `set({ error })`, because
+`refreshAll` starts with `set({ error: null })` and React 18 batches same-tick
+sets.
+
+Mount `<CredentialDialog />` in `AppShell` beside `<PGDialogHost />`.
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/features/auth --run 2>&1 | tail -10 && pnpm tsc --noEmit && pnpm test --run 2>&1 | tail -5
+```
+Expected: 7 new tests pass, type-check clean, whole suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/auth src/lib/tauri.ts src/features/repo/useRepoStore.ts src/AppShell.tsx
+git commit -m "feat(auth): credential dialog and retry for failed network ops (#61 D5)
+
+The secret lives in component state and never enters the store, so it is not
+retained after the retry. Cancelling restores the original error through the
+normal banner path, refreshing before setting the error per the danger-op rule.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Signing configuration resolution
+
+**Files:**
+- Create: `src-tauri/src/git/signing.rs`
+- Modify: `src-tauri/src/git/mod.rs` (`pub mod signing;`)
+- Modify: `src-tauri/src/git/types.rs` (`CommitOptions.sign`)
+- Modify: **all 7 `CommitOptions` literal sites** — `src-tauri/tests/{discard_reset,cherry_pick_revert,reflog,branches_tags,stage_commit}.rs`, `src-tauri/tests/support/mod.rs`, `src-tauri/src/commands/commits.rs`
+
+**Interfaces:**
+- Produces:
+  ```rust
+  pub enum SigFormat { OpenPgp, Ssh, X509 }
+  pub struct SigningConfig { pub format: SigFormat, pub program: String, pub key: Option<String> }
+  /// Read gpg.format / gpg.program / gpg.ssh.program / user.signingkey.
+  pub fn resolve_signing(repo: &git2::Repository) -> AppResult<SigningConfig>;
+  /// argv for signing a commit buffer with this config.
+  pub fn signing_args(cfg: &SigningConfig, key_file: Option<&Path>) -> AppResult<Vec<String>>;
+  /// Whether commit.gpgsign is on.
+  pub fn config_wants_signing(repo: &git2::Repository) -> bool;
+  ```
+  and `CommitOptions.sign: Option<bool>` — `None` follows `commit.gpgsign`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create the test module inside `src-tauri/src/git/signing.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openpgp_args_use_detached_armored_signing() {
+        let cfg = SigningConfig {
+            format: SigFormat::OpenPgp,
+            program: "gpg".into(),
+            key: Some("ABCD1234".into()),
+        };
+        let args = signing_args(&cfg, None).unwrap();
+        assert!(args.contains(&"-bsau".to_string()), "{args:?}");
+        assert!(args.contains(&"ABCD1234".to_string()), "{args:?}");
+    }
+
+    #[test]
+    fn openpgp_without_a_key_lets_gpg_pick_the_default() {
+        let cfg = SigningConfig {
+            format: SigFormat::OpenPgp,
+            program: "gpg".into(),
+            key: None,
+        };
+        let args = signing_args(&cfg, None).unwrap();
+        assert!(args.contains(&"-bsa".to_string()), "{args:?}");
+    }
+
+    #[test]
+    fn ssh_args_sign_with_the_git_namespace() {
+        let cfg = SigningConfig {
+            format: SigFormat::Ssh,
+            program: "ssh-keygen".into(),
+            key: Some("/home/u/.ssh/id_ed25519.pub".into()),
+        };
+        let args = signing_args(&cfg, Some(std::path::Path::new("/tmp/key"))).unwrap();
+        assert_eq!(args[0], "-Y");
+        assert_eq!(args[1], "sign");
+        assert!(args.contains(&"git".to_string()), "namespace: {args:?}");
+        assert!(args.contains(&"/tmp/key".to_string()), "key file: {args:?}");
+    }
+
+    #[test]
+    fn x509_is_a_clean_unsupported_error_not_a_panic() {
+        let cfg = SigningConfig {
+            format: SigFormat::X509,
+            program: "smimesign".into(),
+            key: None,
+        };
+        let err = signing_args(&cfg, None).expect_err("x509 is unsupported");
+        assert!(matches!(err, AppError::NotImplemented), "got {err:?}");
+    }
+
+    #[test]
+    fn ssh_signing_requires_a_key() {
+        // ssh-keygen cannot pick a default the way gpg can.
+        let cfg = SigningConfig {
+            format: SigFormat::Ssh,
+            program: "ssh-keygen".into(),
+            key: None,
+        };
+        assert!(signing_args(&cfg, None).is_err());
+    }
+}
+```
+
+Add an integration test in `src-tauri/tests/signing.rs` for config reading:
+
+```rust
+mod support;
+
+use platypusgit_lib::git::signing::{config_wants_signing, resolve_signing, SigFormat};
+use support::TempRepo;
+
+#[test]
+fn defaults_to_openpgp_with_gpg_and_no_signing() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let cfg = resolve_signing(&tr.repo).unwrap();
+    assert!(matches!(cfg.format, SigFormat::OpenPgp));
+    assert_eq!(cfg.program, "gpg");
+    assert!(!config_wants_signing(&tr.repo));
+}
+
+#[test]
+fn reads_ssh_format_and_program_and_key() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    {
+        let mut c = tr.repo.config().unwrap();
+        c.set_str("gpg.format", "ssh").unwrap();
+        c.set_str("user.signingkey", "/keys/id_ed25519.pub").unwrap();
+        c.set_bool("commit.gpgsign", true).unwrap();
+    }
+    let cfg = resolve_signing(&tr.repo).unwrap();
+    assert!(matches!(cfg.format, SigFormat::Ssh));
+    assert_eq!(cfg.program, "ssh-keygen");
+    assert_eq!(cfg.key.as_deref(), Some("/keys/id_ed25519.pub"));
+    assert!(config_wants_signing(&tr.repo));
+}
+
+#[test]
+fn honours_an_explicit_gpg_program() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    {
+        let mut c = tr.repo.config().unwrap();
+        c.set_str("gpg.program", "/usr/local/bin/gpg2").unwrap();
+    }
+    assert_eq!(resolve_signing(&tr.repo).unwrap().program, "/usr/local/bin/gpg2");
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml signing 2>&1 | tail -15
+```
+Expected: unresolved `git::signing`.
+
+- [ ] **Step 3: Implement `signing.rs`**
+
+`resolve_signing` reads `gpg.format` (absent → `OpenPgp`), then the program for
+that format (`gpg.program` else `gpg`; `gpg.ssh.program` else `ssh-keygen`), then
+`user.signingkey`. `config_wants_signing` reads `commit.gpgsign` as a bool,
+defaulting false.
+
+`signing_args`:
+- `OpenPgp` → `["-bsau", key]` when a key is set, else `["-bsa"]` (gpg picks its
+  default key). `--status-fd=2` is fine to add; keep stdout for the signature.
+- `Ssh` → `["-Y", "sign", "-n", "git", "-f", key_file]`. `key_file` is required:
+  a `user.signingkey` that is a literal key (`key::ssh-ed25519 …`) must be
+  written to a temp file by the caller first, which is why the parameter exists.
+- `X509` → `Err(AppError::NotImplemented)`. A signing failure must never fall
+  back to an unsigned commit: the user asked for a signature and would have no
+  indication they did not get one.
+
+- [ ] **Step 4: Add the `sign` field and fix all 7 literal sites**
+
+In `types.rs`:
+
+```rust
+    /// Sign this commit. `None` follows `commit.gpgsign` from git config.
+    #[serde(default)]
+    pub sign: Option<bool>,
+```
+
+Then add `sign: None` to every `CommitOptions { … }` literal in the 7 files
+listed under **Files**. `grep -rn "CommitOptions {" src-tauri/` finds them all;
+the build will not compile until every one is updated.
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml 2>&1 | grep -E "test result: FAILED|error\[" | head
+cargo test --manifest-path src-tauri/Cargo.toml signing 2>&1 | tail -12
+```
+Expected: no failures; the 8 signing tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/git/signing.rs src-tauri/src/git/mod.rs src-tauri/src/git/types.rs src-tauri/tests/signing.rs src-tauri/tests src-tauri/src/commands/commits.rs
+git commit -m "feat(commit): resolve signing config (gpg.format, program, key) (#61 D6)
+
+x509 is a clean NotImplemented rather than a panic or, worse, a silently
+unsigned commit — the user asked for a signature and would have no indication
+they did not get one.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Sign commits — and keep HEAD correct
+
+**Files:**
+- Modify: `src-tauri/src/git/libgit2.rs` (`commit`)
+- Test: `src-tauri/tests/signing.rs` (append)
+
+**Interfaces:**
+- Consumes: `git::signing::{resolve_signing, signing_args, config_wants_signing}`.
+
+**The trap, stated once:** `repo.commit(Some("HEAD"), …)` and
+`Commit::amend(Some("HEAD"), …)` update the reference for you.
+`repo.commit_signed(...)` **only writes the object** — it returns an Oid and
+moves nothing. A signed commit that never becomes HEAD looks to the user exactly
+like lost work. The signed path must therefore update HEAD's target and write a
+reflog entry itself, for both the normal and the amend case.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src-tauri/tests/signing.rs`. It generates its own ssh key, so it
+needs no ambient gpg setup, and skips rather than fails when `ssh-keygen` is
+absent:
+
+```rust
+/// Generate an ed25519 key in `dir`, returning the private key path.
+fn make_ssh_key(dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    let key = dir.join("id_ed25519");
+    let out = std::process::Command::new("ssh-keygen")
+        .args(["-t", "ed25519", "-N", "", "-C", "test", "-f"])
+        .arg(&key)
+        .output()
+        .ok()?;
+    out.status.success().then_some(key)
+}
+
+#[test]
+fn signed_commit_is_reachable_from_head_and_has_a_gpgsig_header() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let keydir = tempfile::tempdir().unwrap();
+    let Some(key) = make_ssh_key(keydir.path()) else {
+        eprintln!("ssh-keygen unavailable — skipping signed-commit test");
+        return;
+    };
+    {
+        let mut c = tr.repo.config().unwrap();
+        c.set_str("gpg.format", "ssh").unwrap();
+        c.set_str("user.signingkey", key.to_str().unwrap()).unwrap();
+    }
+
+    support::fs::write_file(tr.path(), "b.txt", "second\n");
+    let (backend, handle) = tr.open_with_backend();
+    backend
+        .stage(&handle.id, &[std::path::PathBuf::from("b.txt")])
+        .unwrap();
+
+    let oid = backend
+        .commit(
+            &handle.id,
+            platypusgit_lib::git::types::CommitOptions {
+                message: "signed".into(),
+                amend: false,
+                author_override: None,
+                signoff: false,
+                sign: Some(true),
+            },
+        )
+        .expect("signed commit");
+
+    // The trap: commit_signed writes the object but does NOT move HEAD.
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(head.id().to_string(), oid, "signed commit must be HEAD");
+    assert_eq!(head.parent_count(), 1, "must keep its parent");
+
+    let raw = tr.repo.find_commit(head.id()).unwrap();
+    let header = raw.header_field_bytes("gpgsig").expect("gpgsig header");
+    assert!(!header.is_empty(), "signature must not be empty");
+}
+
+#[test]
+fn unsigned_commit_path_is_unchanged() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    support::fs::write_file(tr.path(), "b.txt", "second\n");
+    let (backend, handle) = tr.open_with_backend();
+    backend
+        .stage(&handle.id, &[std::path::PathBuf::from("b.txt")])
+        .unwrap();
+
+    let oid = backend
+        .commit(
+            &handle.id,
+            platypusgit_lib::git::types::CommitOptions {
+                message: "plain".into(),
+                amend: false,
+                author_override: None,
+                signoff: false,
+                sign: Some(false),
+            },
+        )
+        .unwrap();
+
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(head.id().to_string(), oid);
+    assert!(tr.repo.find_commit(head.id()).unwrap()
+        .header_field_bytes("gpgsig").is_err(), "must not be signed");
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test signing 2>&1 | tail -15
+```
+Expected: the signed test fails (no signing yet — the commit is unsigned, so the
+`gpgsig` assertion fails).
+
+- [ ] **Step 3: Implement the signed path**
+
+In `commit()`, after `message` and `tree` are resolved, branch on whether
+signing is wanted (`opts.sign.unwrap_or_else(|| config_wants_signing(repo))`).
+Unsigned → today's code, untouched. Signed →
+
+1. Build the buffer with `repo.commit_create_buffer(&sig, &sig, &message, &tree, &parent_refs)`.
+2. Resolve config, write a temp key file when `user.signingkey` is a literal ssh key.
+3. Spawn the program with `signing_args`, buffer on stdin, signature from stdout;
+   a non-zero exit is `AppError::Git` with the program's stderr — never a
+   fallback to unsigned.
+4. `let oid = repo.commit_signed(&buffer_str, &signature, Some("gpgsig"))?;`
+5. **Move HEAD yourself:** for a normal commit,
+   `repo.reference("HEAD", oid, true, &format!("commit (signed): {summary}"))`
+   via the resolved HEAD ref name (use `repo.head()`'s name, or `refs/heads/<default>`
+   when unborn); for an amend, the same but with the amend reflog wording. Verify
+   with the test's HEAD assertion rather than by inspection.
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test signing 2>&1 | tail -15
+cargo test --manifest-path src-tauri/Cargo.toml 2>&1 | grep -E "test result: FAILED" | head
+```
+Expected: both signing tests pass; no other failures. In particular
+`stage_commit.rs` and `reflog.rs` must still pass — they assert the unsigned
+path's HEAD movement and reflog wording.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/git/libgit2.rs src-tauri/tests/signing.rs
+git commit -m "feat(commit): GPG/SSH commit signing (#61 D6)
+
+Why the extra reference work: commit_signed writes the object but does NOT
+move HEAD, unlike repo.commit(Some(\"HEAD\"), …). The signed path therefore
+updates the branch ref and writes its own reflog entry, asserted by a test that
+checks the signed commit is reachable from HEAD with its parent intact — a
+signed commit on no branch reads to the user as lost work.
+
+A signing failure fails the commit rather than falling back to unsigned.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Verify the selected commit, and the UI
+
+**Files:**
+- Modify: `src-tauri/src/git/{mod.rs,libgit2.rs,cli.rs,types.rs}` (`verify_commit`)
+- Modify: `src-tauri/src/commands/commits.rs` + `src-tauri/src/lib.rs`
+- Modify: `src/lib/{types.ts,tauri.ts}`
+- Modify: `src/features/diff/CommitDiffPanel.tsx` (status in the header)
+- Modify: `src/features/settings/useSettingsStore.ts` + Settings screen (sign toggle)
+- Modify: `src/screens/CommitPanel.tsx` (per-commit override)
+- Test: `src-tauri/src/git/signing.rs` tests (the `%G?` parser), component test for the badge
+
+**Interfaces:**
+- Produces:
+  ```rust
+  pub struct SignatureStatus { pub state: SigState, pub signer: Option<String>, pub key: Option<String> }
+  pub enum SigState { Good, Bad, UnknownKey, Expired, Revoked, None }
+  pub fn parse_verify_output(raw: &str) -> SignatureStatus;   // "%G?\0%GS\0%GK"
+  fn verify_commit(&self, repo_id: &RepoId, oid: &str) -> AppResult<SignatureStatus>;
+  ```
+
+- [ ] **Step 1: Write the failing parser tests**
+
+In `signing.rs`'s test module:
+
+```rust
+    #[test]
+    fn parses_each_verify_state() {
+        for (raw, want) in [
+            ("G\0Ada <ada@x>\0ABCD", SigState::Good),
+            ("B\0Ada <ada@x>\0ABCD", SigState::Bad),
+            ("U\0Ada <ada@x>\0ABCD", SigState::Good), // good, untrusted
+            ("X\0Ada <ada@x>\0ABCD", SigState::Expired),
+            ("R\0Ada <ada@x>\0ABCD", SigState::Revoked),
+            ("E\0\0", SigState::UnknownKey),
+            ("N\0\0", SigState::None),
+        ] {
+            assert_eq!(parse_verify_output(raw).state, want, "{raw}");
+        }
+    }
+
+    #[test]
+    fn parses_signer_and_key() {
+        let s = parse_verify_output("G\0Ada Lovelace <ada@x>\0ABCD1234");
+        assert_eq!(s.signer.as_deref(), Some("Ada Lovelace <ada@x>"));
+        assert_eq!(s.key.as_deref(), Some("ABCD1234"));
+    }
+
+    #[test]
+    fn an_unsigned_commit_has_no_signer() {
+        let s = parse_verify_output("N\0\0");
+        assert_eq!(s.state, SigState::None);
+        assert!(s.signer.is_none());
+    }
+```
+
+> `U` is "good signature, untrusted key" — treat it as `Good` and let the signer
+> line carry the nuance, rather than inventing a state the UI would have to
+> explain.
+
+- [ ] **Step 2: Run to verify failure, then implement**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --lib signing 2>&1 | tail -12
+```
+
+`verify_commit` shells to
+`git -C <repo> show --no-patch --format=%G?%x00%GS%x00%GK <oid>` and feeds the
+output to `parse_verify_output`. It reuses git's own trust evaluation instead of
+reimplementing it.
+
+- [ ] **Step 3: Wire the UI**
+
+- Settings: a "Sign commits" control with three states — follow git config
+  (default) / always / never — persisted in `useSettingsStore`.
+- CommitPanel: a per-commit override beside the existing amend and sign-off
+  controls, passed as `CommitOptions.sign`.
+- `CommitDiffPanel` header: on selection change, call `verifyCommit(oid)` **for
+  that one commit** and show the state. Not a badge per log row: that would mean
+  a `gpg`/`ssh-keygen` process per walked commit, which fights #81's pagination
+  and #80's windowed list.
+
+- [ ] **Step 4: Verify and commit**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm tsc --noEmit && pnpm test --run 2>&1 | tail -5 && cargo test --manifest-path src-tauri/Cargo.toml 2>&1 | grep -E "FAILED" | head
+```
+
+```bash
+git add -A
+git commit -m "feat(commit): verify the selected commit's signature (#61 D6)
+
+Verification is lazy and per-selection, reusing git's own trust evaluation via
+%G?/%GS/%GK. A badge on every log row would mean one gpg process per walked
+commit, which fights the paginated log and the windowed list.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Security review, full gate, PR
+
+- [ ] **Step 1: Run `/security-review` on the branch**
+
+This PR handles credentials and spawns signing subprocesses; the repo already
+holds a high bar here (`opener.rs`). Address anything it finds about secret
+handling before opening the PR.
+
+- [ ] **Step 2: Re-read the five security constraints at the top of this plan** and confirm each one against the diff. Specifically grep the diff for any credential reaching argv, a log call, or an error string:
+
+```bash
+git diff origin/main...HEAD | grep -nE "ASKPASS_SECRET|secret" | head -40
+```
+
+- [ ] **Step 3: Full gate**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm tsc --noEmit \
+  && pnpm exec tsc -p e2e/tsconfig.json --noEmit \
+  && pnpm test --run \
+  && cargo test --manifest-path src-tauri/Cargo.toml \
+  && pnpm vite build
+```
+
+- [ ] **Step 4: E2E — rebuild the snapshot, run the affected specs**
+
+Auth cannot be exercised against a real remote in e2e; `remote.e2e.ts` covers
+the file-remote happy path, and `commit.e2e.ts` covers the commit path that
+Task 6 touched.
+
+```bash
+pnpm test:e2e:docker build
+pnpm test:e2e:docker run --spec e2e/specs/remote.e2e.ts --spec e2e/specs/commit.e2e.ts
+```
+
+- [ ] **Step 5: Squash, rebase onto latest main, push, open the PR**
+
+State plainly in the PR body: what is covered, that `push_tag` /
+`push_delete_branch` still run credential-less, and that the auth path has no
+e2e coverage by design.
+
+---
+
+## Self-review notes
+
+**Spec coverage.** D5 → Tasks 1-4 (classification + scrubbing, the askpass shim, one shared runner across all four op sites, dialog + retry with `git credential` delegation). D6 → Tasks 5-7 (config resolution, the signed commit path including the HEAD trap, lazy verification + UI). Task 8 carries the spec's "worth a security-review pass" note.
+
+**Deliberately deferred, and to be said in the PR:** `push_tag` and `push_delete_branch` remain credential-less; per-remote SSH key selection is out of scope per the spec; the auth path is not e2e-tested because it would need a real authenticated remote.
+
+**Two places the plan tells the implementer to verify rather than assume**, because both are runtime behaviours that cannot be settled by reading: whether `GIT_ASKPASS` accepts `"<exe> --askpass"` as one string or needs a wrapper script (Task 3 Step 3), and the exact serde shape of the `Auth` struct variant under `#[serde(tag, content)]` (Task 1 Step 4). Both carry the fallback to use, and neither fallback weakens the security constraints.

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -14,8 +14,68 @@ pub struct LaunchIntent {
 #[derive(Debug, PartialEq)]
 pub enum Parsed {
     Help,
+    /// Invoked as GIT_ASKPASS / SSH_ASKPASS with git's prompt string (#61 D5).
+    /// Internal contract between the app and its own subprocesses — deliberately
+    /// absent from USAGE.
+    Askpass(String),
     /// `None` = plain app launch (no CLI args at all).
     Launch(Option<LaunchIntent>),
+}
+
+/// Env vars the parent process sets so the askpass shim can answer without any
+/// IPC back to the app.
+///
+/// Values travel in the environment rather than argv: argv is world-readable
+/// via `ps` on macOS and Linux, a process's environment is not (#61 D5).
+pub const ASKPASS_USERNAME_ENV: &str = "PLATYPUSGIT_ASKPASS_USERNAME";
+pub const ASKPASS_SECRET_ENV: &str = "PLATYPUSGIT_ASKPASS_SECRET";
+
+/// Presence of this var puts the process into askpass-shim mode, with git's
+/// prompt as the first argument.
+///
+/// This exists because **`GIT_ASKPASS` is exec'd directly, not run through a
+/// shell**: verified experimentally, `GIT_ASKPASS="<exe> --askpass"` fails with
+/// `cannot exec '<exe> --askpass'`. The alternatives were writing a wrapper
+/// script to disk or installing an argv[0] symlink; both need a writable
+/// directory and would be one more thing an attacker could replace before we
+/// exec it. An env flag needs neither, so `GIT_ASKPASS` can point at the bare
+/// executable.
+pub const ASKPASS_MODE_ENV: &str = "PLATYPUSGIT_ASKPASS";
+
+/// Which answer a git/ssh askpass prompt is asking for.
+#[derive(Debug, PartialEq)]
+pub enum AskpassWant {
+    Username,
+    Secret,
+}
+
+/// Classify an askpass prompt. `None` for anything unrecognized — the shim must
+/// never guess at a prompt it does not understand.
+pub fn askpass_want(prompt: &str) -> Option<AskpassWant> {
+    let p = prompt.to_lowercase();
+    if p.contains("username") {
+        return Some(AskpassWant::Username);
+    }
+    if p.contains("password") || p.contains("passphrase") {
+        return Some(AskpassWant::Secret);
+    }
+    None
+}
+
+/// The value the shim should print, or `None` to print nothing and exit
+/// non-zero.
+///
+/// An absent value is never substituted with an empty string: git would take
+/// that as a real (wrong) credential and burn an authentication attempt.
+pub fn askpass_answer(
+    prompt: &str,
+    username: Option<&str>,
+    secret: Option<&str>,
+) -> Option<String> {
+    match askpass_want(prompt)? {
+        AskpassWant::Username => username.map(str::to_string),
+        AskpassWant::Secret => secret.map(str::to_string),
+    }
 }
 
 pub const USAGE: &str = "\
@@ -54,6 +114,12 @@ fn resolve_path(arg: &str, cwd: &Path) -> PathBuf {
 /// Parse CLI args (argv without the binary name). Pure — no filesystem
 /// access; relative paths resolve against `cwd`.
 pub fn parse_args(args: &[String], cwd: &Path) -> Parsed {
+    // Askpass first: the remaining argument is an arbitrary prompt string from
+    // git and must not be scanned for our own flags (a prompt could contain
+    // "-h" and would otherwise print USAGE to git as the credential).
+    if args.first().map(String::as_str) == Some("--askpass") {
+        return Parsed::Askpass(args.get(1).cloned().unwrap_or_default());
+    }
     if args.iter().any(|a| a == "--help" || a == "-h") {
         return Parsed::Help;
     }
@@ -356,5 +422,98 @@ mod tests {
     fn shim_not_installed_when_missing() {
         let dir = tempfile::tempdir().unwrap();
         assert!(!shim_installed_at(dir.path(), Path::new("/x")));
+    }
+
+    // ─── askpass shim (#61 D5) ───────────────────────────────────────────────
+
+    #[test]
+    fn askpass_prompt_kinds_are_recognized() {
+        assert_eq!(
+            askpass_want("Username for 'https://github.com': "),
+            Some(AskpassWant::Username)
+        );
+        assert_eq!(
+            askpass_want("Password for 'https://u@github.com': "),
+            Some(AskpassWant::Secret)
+        );
+        assert_eq!(
+            askpass_want("Enter passphrase for key '/home/u/.ssh/id_ed25519': "),
+            Some(AskpassWant::Secret)
+        );
+        assert_eq!(
+            askpass_want("Are you sure you want to continue connecting?"),
+            None
+        );
+    }
+
+    #[test]
+    fn askpass_answers_from_the_matching_env_value() {
+        assert_eq!(
+            askpass_answer("Username for 'https://github.com': ", Some("ada"), Some("tok")),
+            Some("ada".to_string())
+        );
+        assert_eq!(
+            askpass_answer(
+                "Password for 'https://ada@github.com': ",
+                Some("ada"),
+                Some("tok")
+            ),
+            Some("tok".to_string())
+        );
+    }
+
+    #[test]
+    fn askpass_refuses_when_the_value_is_absent() {
+        // Never fall back to an empty string: git would take it as a real
+        // (wrong) credential and burn an authentication attempt.
+        assert_eq!(askpass_answer("Password for 'https://x': ", None, None), None);
+        assert_eq!(
+            askpass_answer("Username for 'https://x': ", None, Some("tok")),
+            None
+        );
+    }
+
+    #[test]
+    fn askpass_refuses_an_unrecognized_prompt() {
+        assert_eq!(
+            askpass_answer("Please confirm the fingerprint", Some("ada"), Some("tok")),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_args_recognizes_askpass() {
+        let cwd = Path::new("/tmp");
+        assert_eq!(
+            parse_args(
+                &["--askpass".to_string(), "Password for 'x': ".to_string()],
+                cwd
+            ),
+            Parsed::Askpass("Password for 'x': ".to_string())
+        );
+    }
+
+    #[test]
+    fn askpass_without_a_prompt_is_still_askpass_and_answers_nothing() {
+        let cwd = Path::new("/tmp");
+        assert_eq!(
+            parse_args(&["--askpass".to_string()], cwd),
+            Parsed::Askpass(String::new())
+        );
+        assert_eq!(askpass_answer("", Some("a"), Some("b")), None);
+    }
+
+    #[test]
+    fn a_prompt_containing_a_flag_is_not_read_as_that_flag() {
+        // A prompt is arbitrary text from git; it must not be able to make the
+        // shim print USAGE (which git would then use as the credential).
+        let cwd = Path::new("/tmp");
+        assert_eq!(
+            parse_args(
+                &["--askpass".to_string(), "Password -h for 'x': ".to_string()],
+                cwd
+            ),
+            Parsed::Askpass("Password -h for 'x': ".to_string())
+        );
     }
 }

--- a/src-tauri/src/commands/branches.rs
+++ b/src-tauri/src/commands/branches.rs
@@ -1,6 +1,7 @@
 use tauri::State;
 
 use crate::{
+    commands::net::Credentials,
     error::{AppError, AppResult},
     git::types::{BranchInfo, PullMode, PushForce, RemoteInfo, RepoId, StashInfo, TagInfo, TagTarget},
     state::AppState,
@@ -131,32 +132,22 @@ async fn get_repo_path(state: &AppState, repo_id: &RepoId) -> AppResult<std::pat
         .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
-/// Run a git subprocess and map non-zero exit to `AppError::Network`.
+/// Run a git subprocess with no credentials — the historical prompt-less policy.
 ///
-/// Credential prompts are disabled (`GIT_TERMINAL_PROMPT=0` plus a no-op
-/// askpass): a subprocess has no terminal, so an auth-requiring remote would
-/// otherwise hang forever on an invisible prompt. With prompts off, git fails
-/// fast and the error surfaces through the normal `AppError::Network` path.
-async fn run_git(
+/// The env policy and failure classification now live in `commands::net`, shared
+/// with clone, so the two cannot drift (#61 D5). Callers that can prompt use
+/// `run_git_creds` instead.
+async fn run_git(cwd: &std::path::Path, args: &[&str]) -> AppResult<()> {
+    crate::commands::net::run_git_authenticated(cwd, args, None).await
+}
+
+/// Run a git subprocess with optional credentials from a retry.
+async fn run_git_creds(
     cwd: &std::path::Path,
     args: &[&str],
+    creds: Option<&Credentials>,
 ) -> AppResult<()> {
-    let output = tokio::process::Command::new("git")
-        .arg("-C")
-        .arg(cwd)
-        .args(args)
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .env("GIT_ASKPASS", "true")
-        .env("SSH_ASKPASS", "true")
-        .output()
-        .await
-        .map_err(|e| AppError::Io(e.to_string()))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        return Err(AppError::Network(stderr));
-    }
-    Ok(())
+    crate::commands::net::run_git_authenticated(cwd, args, creds).await
 }
 
 /// Build the argument list for `git fetch`. `remote = None` means all remotes.
@@ -178,9 +169,18 @@ pub async fn fetch(
     repo_id: String,
     remote: String,
     prune: bool,
+    // Optional so an existing caller that omits it behaves exactly as before:
+    // the first attempt is always prompt-less, and only a retry carries a
+    // credential (#61 D5).
+    credentials: Option<Credentials>,
 ) -> AppResult<()> {
     let path = get_repo_path(&state, &RepoId(repo_id)).await?;
-    run_git(&path, &fetch_args(Some(remote.as_str()), prune)).await
+    run_git_creds(
+        &path,
+        &fetch_args(Some(remote.as_str()), prune),
+        credentials.as_ref(),
+    )
+    .await
 }
 
 #[tauri::command]
@@ -188,9 +188,10 @@ pub async fn fetch_all(
     state: State<'_, AppState>,
     repo_id: String,
     prune: bool,
+    credentials: Option<Credentials>,
 ) -> AppResult<()> {
     let path = get_repo_path(&state, &RepoId(repo_id)).await?;
-    run_git(&path, &fetch_args(None, prune)).await
+    run_git_creds(&path, &fetch_args(None, prune), credentials.as_ref()).await
 }
 
 #[tauri::command]
@@ -200,6 +201,7 @@ pub async fn pull(
     remote: String,
     branch: String,
     mode: PullMode,
+    credentials: Option<Credentials>,
 ) -> AppResult<()> {
     let path = get_repo_path(&state, &RepoId(repo_id)).await?;
     let mode_flag = match mode {
@@ -207,7 +209,12 @@ pub async fn pull(
         PullMode::Merge => "--no-rebase",
         PullMode::Rebase => "--rebase",
     };
-    run_git(&path, &["pull", mode_flag, remote.as_str(), branch.as_str()]).await
+    run_git_creds(
+        &path,
+        &["pull", mode_flag, remote.as_str(), branch.as_str()],
+        credentials.as_ref(),
+    )
+    .await
 }
 
 /// Build `git push` args. `set_upstream` adds `-u`, which the caller passes
@@ -235,6 +242,7 @@ pub async fn push(
     remote: String,
     branch: String,
     force: PushForce,
+    credentials: Option<Credentials>,
 ) -> AppResult<()> {
     let repo_id = RepoId(repo_id);
     let path = get_repo_path(&state, &repo_id).await?;
@@ -259,7 +267,7 @@ pub async fn push(
 
     let args = push_args(&remote, &branch, force, needs_upstream);
     let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-    run_git(&path, &arg_refs).await
+    run_git_creds(&path, &arg_refs, credentials.as_ref()).await
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/commits.rs
+++ b/src-tauri/src/commands/commits.rs
@@ -112,6 +112,8 @@ pub async fn commit(
     // op was written; nothing sent it until #61 D1. Absent means "use the repo
     // config identity", which is the overwhelmingly common case.
     author_override: Option<AuthorOverride>,
+    // None = follow `commit.gpgsign`; Some overrides it for this commit (#61 D6).
+    sign: Option<bool>,
 ) -> AppResult<String> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
@@ -120,8 +122,24 @@ pub async fn commit(
         amend,
         author_override,
         signoff: signoff.unwrap_or(false),
+        sign,
     };
     tokio::task::spawn_blocking(move || backend.commit(&repo_id, opts))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+/// Signature status of one commit (#61 D6). Called lazily for the selected
+/// commit, never per log row.
+#[tauri::command]
+pub async fn verify_commit(
+    state: State<'_, AppState>,
+    repo_id: String,
+    oid: String,
+) -> AppResult<crate::git::signing::SignatureStatus> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    tokio::task::spawn_blocking(move || backend.verify_commit(&repo_id, &oid))
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
 }

--- a/src-tauri/src/commands/create.rs
+++ b/src-tauri/src/commands/create.rs
@@ -217,6 +217,7 @@ pub async fn run_clone(
     parent: &Path,
     name: &str,
     recurse_submodules: bool,
+    creds: Option<&crate::commands::net::Credentials>,
     mut on_progress: impl FnMut(CloneProgress),
 ) -> AppResult<PathBuf> {
     // Trimmed once, here, and reused for both validation and argv below.
@@ -243,12 +244,9 @@ pub async fn run_clone(
     let target = validate_clone_target(parent, name)?;
     let args = clone_args(url, name, recurse_submodules);
 
-    let mut child = Command::new("git")
-        .current_dir(parent)
+    let mut cmd = Command::new("git");
+    cmd.current_dir(parent)
         .args(&args)
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .env("GIT_ASKPASS", "true")
-        .env("SSH_ASKPASS", "true")
         // Never let the child read from our stdin. Nothing in this codebase
         // feeds it anything, so an unexpected read would just block forever
         // — and a clone has no cancel button, so a hang here is force-quit
@@ -262,7 +260,14 @@ pub async fn run_clone(
         // this, git keeps running to completion in the background and
         // finishes populating the destination the frontend was told never
         // got created.
-        .kill_on_drop(true)
+        .kill_on_drop(true);
+    // Shared with fetch/pull/push so the env policy cannot drift (#61 D5).
+    // With credentials this points askpass at our own executable; without them
+    // it is the historical prompt-less policy. Applied after the builder chain
+    // so it cannot be silently overridden by one of the calls above.
+    crate::commands::net::apply_auth_env(&mut cmd, creds);
+
+    let mut child = cmd
         .spawn()
         .map_err(|e| AppError::Io(format!("failed to run git clone: {e}")))?;
 
@@ -315,7 +320,13 @@ pub async fn run_clone(
         .await
         .map_err(|e| AppError::Io(format!("waiting for git clone: {e}")))?;
     if !status.success() {
-        return Err(AppError::Network(clone_failure_message(&tail, status.code())));
+        // Routed through the shared classifier so a private repo yields Auth
+        // (promptable + retryable) rather than a dead-end Network error, and so
+        // any credential embedded in an echoed URL is scrubbed (#61 D5).
+        return Err(crate::commands::net::map_git_failure(&clone_failure_message(
+            &tail,
+            status.code(),
+        )));
     }
     Ok(target)
 }
@@ -366,16 +377,24 @@ pub async fn clone_repo(
     parent_dir: String,
     name: String,
     recurse_submodules: bool,
+    credentials: Option<crate::commands::net::Credentials>,
 ) -> AppResult<String> {
     let url = url.trim().to_string();
     if url.is_empty() {
         return Err(AppError::InvalidPath("no repository URL given".into()));
     }
     let parent = PathBuf::from(parent_dir);
-    let dest = run_clone(&url, &parent, &name, recurse_submodules, |p| {
-        // A dropped event only costs a progress tick, never the clone.
-        let _ = app.emit("clone://progress", &p);
-    })
+    let dest = run_clone(
+        &url,
+        &parent,
+        &name,
+        recurse_submodules,
+        credentials.as_ref(),
+        |p| {
+            // A dropped event only costs a progress tick, never the clone.
+            let _ = app.emit("clone://progress", &p);
+        },
+    )
     .await?;
     Ok(dest.to_string_lossy().to_string())
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod conflict;
 pub mod create;
 pub mod diff;
 pub mod history;
+pub mod net;
 pub mod rebase;
 pub mod reflog;
 pub mod repo;

--- a/src-tauri/src/commands/net.rs
+++ b/src-tauri/src/commands/net.rs
@@ -1,0 +1,168 @@
+//! One place for the network-op environment policy and failure mapping (#61 D5).
+//!
+//! Before this module the policy was duplicated in `branches.rs`
+//! (fetch/pull/push) and `create.rs` (clone), which is how the two could drift.
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::{
+    cli::{ASKPASS_MODE_ENV, ASKPASS_SECRET_ENV, ASKPASS_USERNAME_ENV},
+    error::{AppError, AppResult},
+    git::auth::{classify_auth_failure, host_from_stderr, scrub_credentials, AuthChallenge},
+};
+
+/// A credential collected from the user for one retry.
+///
+/// Nothing here is persisted: "remember" is `git credential approve`, which
+/// hands the credential to whichever helper the user already has configured.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Credentials {
+    /// Absent for an SSH passphrase, which has no username.
+    pub username: Option<String>,
+    pub secret: String,
+}
+
+/// Apply the environment policy for a git subprocess.
+///
+/// Without credentials this is the historical prompt-less policy: a subprocess
+/// has no terminal, so an auth-requiring remote would otherwise hang forever on
+/// an invisible prompt, and with prompts off git fails fast instead.
+///
+/// With credentials, our own executable becomes the askpass and reads the answer
+/// from the environment. Two things to know:
+///
+/// * `GIT_ASKPASS` is **exec'd directly, not run through a shell**, so it cannot
+///   carry arguments — hence `ASKPASS_MODE_ENV` rather than a `--askpass` flag.
+/// * The secret travels in the environment, never in argv: argv is
+///   world-readable via `ps` on macOS and Linux, a process's environment is not.
+pub fn apply_auth_env(cmd: &mut tokio::process::Command, creds: Option<&Credentials>) {
+    cmd.env("GIT_TERMINAL_PROMPT", "0");
+    match creds {
+        None => {
+            cmd.env("GIT_ASKPASS", "true").env("SSH_ASKPASS", "true");
+        }
+        Some(c) => {
+            let exe = std::env::current_exe()
+                .unwrap_or_else(|_| std::path::PathBuf::from("platypusgit"));
+            cmd.env("GIT_ASKPASS", &exe)
+                .env("SSH_ASKPASS", &exe)
+                // OpenSSH >= 8.4 needs this to use SSH_ASKPASS with no DISPLAY.
+                .env("SSH_ASKPASS_REQUIRE", "force")
+                .env(ASKPASS_MODE_ENV, "1")
+                .env(ASKPASS_SECRET_ENV, &c.secret);
+            match &c.username {
+                Some(u) => {
+                    cmd.env(ASKPASS_USERNAME_ENV, u);
+                }
+                // Explicitly cleared: a stale value inherited from our own
+                // environment must not answer a username prompt.
+                None => {
+                    cmd.env_remove(ASKPASS_USERNAME_ENV);
+                }
+            }
+        }
+    }
+}
+
+/// Map a failed git invocation to an error, scrubbing credentials first.
+///
+/// Scrubbing comes first so a remote URL with an embedded token cannot reach an
+/// error banner or a log, whichever branch is taken.
+pub fn map_git_failure(stderr: &str) -> AppError {
+    let clean = scrub_credentials(stderr.trim());
+    match classify_auth_failure(&clean) {
+        Some(kind) => AppError::Auth(AuthChallenge {
+            host: host_from_stderr(&clean),
+            kind,
+        }),
+        None => AppError::Network(clean),
+    }
+}
+
+/// Run `git -C cwd <args>`, mapping a non-zero exit through `map_git_failure`.
+pub async fn run_git_authenticated(
+    cwd: &Path,
+    args: &[&str],
+    creds: Option<&Credentials>,
+) -> AppResult<()> {
+    let mut cmd = tokio::process::Command::new("git");
+    cmd.arg("-C").arg(cwd).args(args);
+    apply_auth_env(&mut cmd, creds);
+    // Nothing feeds the child stdin, so an unexpected read would block forever.
+    cmd.stdin(std::process::Stdio::null());
+
+    let output = cmd.output().await.map_err(|e| AppError::Io(e.to_string()))?;
+
+    if !output.status.success() {
+        return Err(map_git_failure(&String::from_utf8_lossy(&output.stderr)));
+    }
+    Ok(())
+}
+
+/// Store a credential with the user's own git credential helper (#61 D5).
+///
+/// Separate command rather than a flag on the ops, so a credential is stored
+/// only after it has actually worked — storing on submit would persist a typo.
+#[tauri::command]
+pub async fn remember_credential(
+    state: tauri::State<'_, crate::state::AppState>,
+    repo_id: String,
+    host: String,
+    credentials: Credentials,
+) -> AppResult<()> {
+    let backend = state.backend.clone();
+    let id = crate::git::types::RepoId(repo_id);
+    let path = tokio::task::spawn_blocking(move || backend.repo_path(&id))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))??;
+    credential_approve(&path, &host, &credentials).await;
+    Ok(())
+}
+
+/// Hand a credential to the user's own git credential helper (`approve`), so
+/// "remember" stores nothing here.
+///
+/// Best-effort: a repo with no helper configured simply has nowhere to put it,
+/// which is not an error the user needs to see — the credential still worked for
+/// the operation they asked for.
+pub async fn credential_approve(cwd: &Path, host: &str, creds: &Credentials) {
+    use tokio::io::AsyncWriteExt;
+
+    // git's credential protocol is line-based `key=value`. A value containing a
+    // newline would inject further keys — a `username` carrying
+    // "x\nhost=evil.example" would store the password against a different host.
+    // Values cannot legitimately contain newlines, so refuse rather than escape.
+    let has_newline = |s: &str| s.contains('\n') || s.contains('\r');
+    if has_newline(host)
+        || has_newline(&creds.secret)
+        || creds.username.as_deref().is_some_and(has_newline)
+    {
+        return;
+    }
+
+    let mut input = format!("protocol=https\nhost={host}\n");
+    if let Some(u) = &creds.username {
+        input.push_str(&format!("username={u}\n"));
+    }
+    input.push_str(&format!("password={}\n\n", creds.secret));
+
+    let mut child = match tokio::process::Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(["credential", "approve"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    if let Some(stdin) = child.stdin.as_mut() {
+        let _ = stdin.write_all(input.as_bytes()).await;
+    }
+    let _ = child.wait().await;
+}

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -51,6 +51,12 @@ pub enum AppError {
     #[error("network error: {0}")]
     Network(String),
 
+    /// The remote needs credentials we did not supply. Distinct from `Network`
+    /// so the UI can prompt and retry rather than just reporting a failure.
+    /// Never carries the credential itself, and never git's raw stderr (#61 D5).
+    #[error("authentication required")]
+    Auth(crate::git::auth::AuthChallenge),
+
     #[error("embedded repository: {0}")]
     EmbeddedRepo(String),
 

--- a/src-tauri/src/git/auth.rs
+++ b/src-tauri/src/git/auth.rs
@@ -1,0 +1,247 @@
+//! Authentication failure classification and credential hygiene (#61 D5).
+//!
+//! Network ops run prompt-less on the first attempt, so an authenticated remote
+//! fails with git's own stderr. This module turns that stderr into a typed
+//! answer — "this is an auth failure, of this kind, for this host" — so the UI
+//! can collect a credential and retry, and scrubs credentials out of anything
+//! before it reaches an error message or a log.
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum AuthKind {
+    /// HTTPS username + password/token.
+    Https,
+    /// An encrypted SSH private key needs its passphrase.
+    SshPassphrase,
+    /// The server rejected the key we offered (or we offered none).
+    SshKey,
+}
+
+/// Classify a failed git invocation's stderr. `None` means "not an auth
+/// failure" — the caller keeps its existing `Network` error.
+///
+/// Host-key verification is deliberately NOT an auth failure: no credential the
+/// user can type will fix an unknown host key, and offering a password prompt
+/// for it would be actively misleading.
+pub fn classify_auth_failure(stderr: &str) -> Option<AuthKind> {
+    let s = stderr.to_lowercase();
+
+    if s.contains("host key verification failed") {
+        return None;
+    }
+    if s.contains("enter passphrase for key") || s.contains("bad passphrase") {
+        return Some(AuthKind::SshPassphrase);
+    }
+    if s.contains("permission denied (publickey)") {
+        return Some(AuthKind::SshKey);
+    }
+    if s.contains("authentication failed")
+        || s.contains("invalid username or password")
+        || s.contains("could not read username")
+        || s.contains("could not read password")
+        || s.contains("terminal prompts disabled")
+    {
+        return Some(AuthKind::Https);
+    }
+    None
+}
+
+/// What the UI needs to prompt for a credential and retry.
+///
+/// A newtype payload rather than a struct variant on `AppError`: with
+/// `#[serde(tag = "kind", content = "message")]` this serializes as
+/// `{ kind: "Auth", message: { host, kind } }`, which is unambiguous, whereas a
+/// struct variant would put a second field literally named `kind` at a level
+/// that reads as if it were the tag.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthChallenge {
+    /// Host the credential is for, when git's stderr named one.
+    pub host: Option<String>,
+    pub kind: AuthKind,
+}
+
+/// True for a character that ends a URL's authority component.
+fn ends_authority(c: char) -> bool {
+    c == '/' || c == '\'' || c == '"' || c.is_whitespace()
+}
+
+/// Replace the `user:password@` userinfo of every URL in `text` with `***`.
+///
+/// git echoes remote URLs in its errors, and a remote configured with an
+/// embedded token would otherwise put that token into an error banner or a log
+/// file.
+pub fn scrub_credentials(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+
+    while let Some(scheme_at) = rest.find("://") {
+        let after = scheme_at + 3;
+        let (head, tail) = rest.split_at(after);
+        // Userinfo, if any, ends within the authority; beyond that we are into
+        // the path and there is nothing to strip.
+        let stop = tail.find(ends_authority).unwrap_or(tail.len());
+        // rfind, not find: userinfo ends at the LAST '@' of the authority, which
+        // is how git and URL parsers read it. Splitting on the first '@' leaves
+        // the remainder of a password containing '@' in the scrubbed text.
+        match tail[..stop].rfind('@') {
+            Some(at) => {
+                out.push_str(head);
+                out.push_str("***");
+                out.push_str(&tail[at..stop]);
+            }
+            None => {
+                out.push_str(head);
+                out.push_str(&tail[..stop]);
+            }
+        }
+        rest = &tail[stop..];
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Best-effort host from git/ssh stderr: `https://host/…` or `git@host:`.
+pub fn host_from_stderr(stderr: &str) -> Option<String> {
+    if let Some(at) = stderr.find("://") {
+        let tail = &stderr[at + 3..];
+        let stop = tail.find(ends_authority).unwrap_or(tail.len());
+        let authority = &tail[..stop];
+        // Drop any userinfo before the host.
+        let host = authority.rsplit('@').next().unwrap_or(authority);
+        // Strip a port, if present.
+        let host = host.split(':').next().unwrap_or(host);
+        if !host.is_empty() {
+            return Some(host.to_string());
+        }
+    }
+    // `git@host: Permission denied` — take the token before the first ": ".
+    if let Some(colon) = stderr.find(": ") {
+        let head = &stderr[..colon];
+        if let Some(at) = head.rfind('@') {
+            let host = &head[at + 1..];
+            if !host.is_empty() && host.contains('.') {
+                return Some(host.to_string());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn https_auth_failure_is_https() {
+        for s in [
+            "remote: Invalid username or password.\nfatal: Authentication failed for 'https://github.com/x/y.git/'",
+            "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+        ] {
+            assert_eq!(classify_auth_failure(s), Some(AuthKind::Https), "{s}");
+        }
+    }
+
+    #[test]
+    fn ssh_passphrase_prompt_is_passphrase() {
+        let s = "Enter passphrase for key '/home/u/.ssh/id_ed25519': \nfatal: Could not read from remote repository.";
+        assert_eq!(classify_auth_failure(s), Some(AuthKind::SshPassphrase));
+    }
+
+    #[test]
+    fn publickey_denied_is_ssh_key() {
+        let s = "git@github.com: Permission denied (publickey).\nfatal: Could not read from remote repository.";
+        assert_eq!(classify_auth_failure(s), Some(AuthKind::SshKey));
+    }
+
+    #[test]
+    fn host_key_verification_is_not_an_auth_failure() {
+        // Prompting for a password cannot fix an unknown host key, and offering
+        // to would be actively misleading.
+        let s = "Host key verification failed.\nfatal: Could not read from remote repository.";
+        assert_eq!(classify_auth_failure(s), None);
+    }
+
+    #[test]
+    fn ordinary_network_errors_are_not_auth_failures() {
+        for s in [
+            "fatal: unable to access 'https://x/y': Could not resolve host: x",
+            "fatal: repository 'https://x/y' not found",
+            "error: failed to push some refs to 'origin'",
+        ] {
+            assert_eq!(classify_auth_failure(s), None, "{s}");
+        }
+    }
+
+    #[test]
+    fn scrub_removes_userinfo_from_urls() {
+        assert_eq!(
+            scrub_credentials(
+                "fatal: unable to access 'https://user:ghp_secret@github.com/x/y.git/'"
+            ),
+            "fatal: unable to access 'https://***@github.com/x/y.git/'"
+        );
+    }
+
+    #[test]
+    fn scrub_leaves_credential_free_text_alone() {
+        let s = "fatal: Authentication failed for 'https://github.com/x/y.git/'";
+        assert_eq!(scrub_credentials(s), s);
+    }
+
+    #[test]
+    fn scrub_handles_several_urls() {
+        let out = scrub_credentials("a https://u:p@h1/x b https://u2:p2@h2/y");
+        assert!(!out.contains("p@"), "{out}");
+        assert!(!out.contains("p2@"), "{out}");
+        assert!(out.contains("h1/x"), "{out}");
+        assert!(out.contains("h2/y"), "{out}");
+    }
+
+    #[test]
+    fn scrub_is_lossless_when_there_is_no_scheme() {
+        let s = "no urls here at all";
+        assert_eq!(scrub_credentials(s), s);
+    }
+
+    #[test]
+    fn scrub_removes_a_password_containing_an_at_sign() {
+        // Userinfo ends at the LAST '@' of the authority, which is how git and
+        // URL parsers read it. Splitting on the first '@' would leave the rest
+        // of the password in the message.
+        let out = scrub_credentials("fatal: unable to access 'https://user:p@ssw0rd@github.com/x/y'");
+        assert!(!out.contains("ssw0rd"), "password leaked: {out}");
+        assert_eq!(
+            out,
+            "fatal: unable to access 'https://***@github.com/x/y'"
+        );
+    }
+
+    #[test]
+    fn scrub_keeps_a_port_after_stripping_userinfo() {
+        let out = scrub_credentials("https://u:p@example.com:8443/x");
+        assert_eq!(out, "https://***@example.com:8443/x");
+    }
+
+    #[test]
+    fn host_is_extracted_from_https_and_ssh_forms() {
+        assert_eq!(
+            host_from_stderr("fatal: Authentication failed for 'https://github.com/x/y.git/'"),
+            Some("github.com".to_string())
+        );
+        assert_eq!(
+            host_from_stderr("git@gitlab.com: Permission denied (publickey)."),
+            Some("gitlab.com".to_string())
+        );
+        assert_eq!(host_from_stderr("something unrelated"), None);
+    }
+
+    #[test]
+    fn host_extraction_drops_userinfo_and_port() {
+        assert_eq!(
+            host_from_stderr("fatal: unable to access 'https://u:p@example.com:8443/x'"),
+            Some("example.com".to_string())
+        );
+    }
+}

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -325,6 +325,13 @@ impl GitBackend for CliBackend {
     fn read_reflog(&self, _repo_id: &RepoId) -> AppResult<Vec<ReflogEntry>> {
         Err(AppError::NotImplemented)
     }
+    fn verify_commit(
+        &self,
+        _repo_id: &RepoId,
+        _oid: &str,
+    ) -> AppResult<crate::git::signing::SignatureStatus> {
+        Err(AppError::NotImplemented)
+    }
     fn append_gitignore(&self, _repo_id: &RepoId, _pattern: &str) -> AppResult<()> {
         Err(AppError::NotImplemented)
     }

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -499,6 +499,131 @@ fn find_delta_index(diff: &git2::Diff, path: &Path) -> AppResult<usize> {
     Err(AppError::InvalidPath(path.display().to_string()))
 }
 
+/// Create a signed commit and move the branch to it (#61 D6).
+///
+/// **`repo.commit_signed` only writes the object.** Unlike
+/// `repo.commit(Some("HEAD"), …)` and `Commit::amend(Some("HEAD"), …)`, it moves
+/// no reference — so this function updates the branch and writes the reflog
+/// entry itself. A signed commit left on no branch is indistinguishable from
+/// lost work from the user's point of view.
+///
+/// A signing failure returns an error and leaves HEAD untouched: falling back to
+/// an unsigned commit would leave the user believing they had signed it.
+fn commit_signed(
+    repo: &Repository,
+    sig: &git2::Signature<'_>,
+    message: &str,
+    tree: &git2::Tree<'_>,
+    head: Option<&git2::Reference<'_>>,
+    amend: bool,
+) -> AppResult<String> {
+    use crate::git::signing::{resolve_signing, signing_args, SigFormat};
+
+    // Parents: an amend replaces HEAD, so it inherits HEAD's parents rather than
+    // chaining onto it.
+    let tip = match head {
+        Some(h) => Some(h.peel_to_commit()?),
+        None => None,
+    };
+    let parents: Vec<git2::Commit> = if amend {
+        let tip = tip.as_ref().ok_or(AppError::Unborn)?;
+        tip.parents().collect()
+    } else {
+        tip.iter().cloned().collect()
+    };
+    let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
+
+    let buffer = repo.commit_create_buffer(sig, sig, message, tree, &parent_refs)?;
+    let buffer_str = std::str::from_utf8(&buffer)
+        .map_err(|e| AppError::Internal(format!("commit buffer is not utf-8: {e}")))?;
+
+    let cfg = resolve_signing(repo)?;
+    let key_file = match cfg.format {
+        SigFormat::Ssh => {
+            let key = cfg.key.as_deref().ok_or_else(|| {
+                AppError::InvalidArgument("ssh signing needs user.signingkey".to_string())
+            })?;
+            // Only a key PATH is supported. git also accepts a literal key
+            // (`key::ssh-ed25519 …`), which would have to be written to a temp
+            // file first; rejecting it clearly beats writing key material to
+            // disk behind the user's back.
+            if key.starts_with("key::") || key.starts_with("ssh-") {
+                return Err(AppError::InvalidArgument(
+                    "user.signingkey must be a path to a key file for ssh signing".to_string(),
+                ));
+            }
+            Some(std::path::PathBuf::from(key))
+        }
+        _ => None,
+    };
+    let args = signing_args(&cfg, key_file.as_deref())?;
+
+    let signature = run_signer(&cfg.program, &args, buffer_str)?;
+    let oid = repo.commit_signed(buffer_str, &signature, Some("gpgsig"))?;
+
+    // Move the branch ourselves — commit_signed did not.
+    let ref_name = match head {
+        Some(h) => h
+            .name()
+            .ok_or_else(|| AppError::Internal("HEAD has no reference name".into()))?
+            .to_string(),
+        // Unborn HEAD: create the branch it symbolically points at.
+        None => repo
+            .find_reference("HEAD")?
+            .symbolic_target()
+            .ok_or(AppError::Unborn)?
+            .to_string(),
+    };
+    let reflog_msg = if amend {
+        format!("commit (amend): {}", message.lines().next().unwrap_or(""))
+    } else {
+        format!("commit: {}", message.lines().next().unwrap_or(""))
+    };
+    repo.reference(&ref_name, oid, true, &reflog_msg)?;
+
+    Ok(oid.to_string())
+}
+
+/// Run the signing program over `payload`, returning its signature.
+///
+/// The payload goes on stdin and the signature comes back on stdout, which is
+/// how git itself drives gpg and ssh-keygen.
+fn run_signer(program: &str, args: &[String], payload: &str) -> AppResult<String> {
+    use std::io::Write as _;
+
+    let mut child = std::process::Command::new(program)
+        .args(args)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| AppError::Git(format!("could not run {program}: {e}")))?;
+
+    child
+        .stdin
+        .as_mut()
+        .ok_or_else(|| AppError::Internal("signer has no stdin".into()))?
+        .write_all(payload.as_bytes())
+        .map_err(|e| AppError::Io(e.to_string()))?;
+
+    let out = child
+        .wait_with_output()
+        .map_err(|e| AppError::Io(e.to_string()))?;
+    if !out.status.success() {
+        return Err(AppError::Git(format!(
+            "signing failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    let signature = String::from_utf8_lossy(&out.stdout).to_string();
+    if signature.trim().is_empty() {
+        return Err(AppError::Git(format!(
+            "{program} produced an empty signature"
+        )));
+    }
+    Ok(signature)
+}
+
 /// Which way the synthesized patch will be applied. It decides which
 /// *unselected* changed lines become context: reversal flips the side each line
 /// lands on, so the rule for `+` and `-` swaps (#61 D7).
@@ -2344,6 +2469,15 @@ impl GitBackend for Libgit2Backend {
                 Err(e) => return Err(e.into()),
             };
 
+            // `None` follows commit.gpgsign; `Some` overrides it (#61 D6).
+            let wants_sign = opts
+                .sign
+                .unwrap_or_else(|| crate::git::signing::config_wants_signing(repo));
+
+            if wants_sign {
+                return commit_signed(repo, &sig, &message, &tree, head.as_ref(), opts.amend);
+            }
+
             if opts.amend {
                 let head_ref = head.ok_or(AppError::Unborn)?;
                 let tip = head_ref.peel_to_commit()?;
@@ -2984,6 +3118,44 @@ impl GitBackend for Libgit2Backend {
                 pause_reason: None,
             }),
         }
+    }
+
+    fn verify_commit(
+        &self,
+        repo_id: &RepoId,
+        oid: &str,
+    ) -> AppResult<crate::git::signing::SignatureStatus> {
+        // Validated before it reaches an argv: `git show` would read a value
+        // starting with '-' as an option rather than a revision. Every caller
+        // passes an oid from our own log walk, so a hex check costs nothing and
+        // removes the question.
+        if oid.is_empty()
+            || oid.len() > 40
+            || !oid.chars().all(|c| c.is_ascii_hexdigit())
+        {
+            return Err(AppError::InvalidRef(oid.to_string()));
+        }
+
+        let repo_path = self.repo_path(repo_id)?;
+        // Shells out rather than reimplementing trust evaluation: %G? is git's
+        // own verdict, including keyring/allowed-signers lookup.
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&repo_path)
+            .args([
+                "show",
+                "--no-patch",
+                "--format=%G?%x00%GS%x00%GK",
+                oid,
+            ])
+            .output()
+            .map_err(|e| AppError::Io(e.to_string()))?;
+        if !out.status.success() {
+            return Err(AppError::InvalidRef(oid.to_string()));
+        }
+        Ok(crate::git::signing::parse_verify_output(
+            &String::from_utf8_lossy(&out.stdout),
+        ))
     }
 
     fn read_reflog(&self, repo_id: &RepoId) -> AppResult<Vec<ReflogEntry>> {

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -1,7 +1,9 @@
+pub mod auth;
 pub mod cli;
 pub mod libgit2;
 pub mod ownership;
 pub mod signature;
+pub mod signing;
 pub mod types;
 
 use std::path::{Path, PathBuf};
@@ -96,6 +98,16 @@ pub trait GitBackend: Send + Sync {
     ) -> AppResult<Vec<CommitInfo>>;
     fn blame_file(&self, repo_id: &RepoId, path: &Path) -> AppResult<Vec<BlameLine>>;
     fn read_reflog(&self, repo_id: &RepoId) -> AppResult<Vec<ReflogEntry>>;
+    /// Signature status of ONE commit (#61 D6).
+    ///
+    /// Deliberately per-commit and called lazily for the selected commit: a
+    /// badge on every log row would mean a gpg/ssh-keygen process per walked
+    /// commit, which fights the paginated log walk and the windowed list.
+    fn verify_commit(
+        &self,
+        repo_id: &RepoId,
+        oid: &str,
+    ) -> AppResult<crate::git::signing::SignatureStatus>;
     /// Diff a single file. `context_lines` controls how many unchanged lines
     /// surround each hunk (git default: 3).
     ///

--- a/src-tauri/src/git/signing.rs
+++ b/src-tauri/src/git/signing.rs
@@ -1,0 +1,257 @@
+//! Commit signing: config resolution, program arguments, and verify parsing
+//! (#61 D6).
+//!
+//! Nothing here spawns a process — that is `libgit2.rs`'s job. Keeping the
+//! decisions pure is what makes them testable without a gpg keyring.
+
+use serde::Serialize;
+
+use crate::error::{AppError, AppResult};
+
+/// Signature format, from `gpg.format`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SigFormat {
+    /// git's default.
+    OpenPgp,
+    Ssh,
+    /// Recognized so it can be refused clearly rather than mis-signed.
+    X509,
+}
+
+#[derive(Debug, Clone)]
+pub struct SigningConfig {
+    pub format: SigFormat,
+    /// Program to run: `gpg.program`, `gpg.ssh.program`, or the format default.
+    pub program: String,
+    /// `user.signingkey`, if set.
+    pub key: Option<String>,
+}
+
+/// Read `gpg.format`, the matching program, and `user.signingkey`.
+pub fn resolve_signing(repo: &git2::Repository) -> AppResult<SigningConfig> {
+    let cfg = repo.config()?;
+    let get = |k: &str| cfg.get_string(k).ok().filter(|s| !s.trim().is_empty());
+
+    let format = match get("gpg.format").as_deref() {
+        Some("ssh") => SigFormat::Ssh,
+        Some("x509") => SigFormat::X509,
+        // Absent or "openpgp" — git's default.
+        _ => SigFormat::OpenPgp,
+    };
+
+    let program = match format {
+        SigFormat::OpenPgp => get("gpg.program").unwrap_or_else(|| "gpg".to_string()),
+        SigFormat::Ssh => get("gpg.ssh.program").unwrap_or_else(|| "ssh-keygen".to_string()),
+        SigFormat::X509 => get("gpg.x509.program").unwrap_or_else(|| "smimesign".to_string()),
+    };
+
+    Ok(SigningConfig {
+        format,
+        program,
+        key: get("user.signingkey"),
+    })
+}
+
+/// Whether `commit.gpgsign` asks for signing. Defaults to false.
+pub fn config_wants_signing(repo: &git2::Repository) -> bool {
+    repo.config()
+        .and_then(|c| c.get_bool("commit.gpgsign"))
+        .unwrap_or(false)
+}
+
+/// Arguments for signing a commit buffer fed on stdin, signature on stdout.
+///
+/// `key_file` is the resolved private-key path for ssh signing; `user.signingkey`
+/// may instead hold a literal key (`key::ssh-ed25519 …`), which the caller writes
+/// to a temp file first, so the path cannot be derived here.
+pub fn signing_args(cfg: &SigningConfig, key_file: Option<&std::path::Path>) -> AppResult<Vec<String>> {
+    match cfg.format {
+        SigFormat::OpenPgp => {
+            // -b detached, -s sign, -a armor; -u selects the key when set,
+            // otherwise gpg picks its own default, which is what git does too.
+            let mut args = vec!["--status-fd=2".to_string()];
+            match &cfg.key {
+                Some(k) => {
+                    args.push("-bsau".to_string());
+                    args.push(k.clone());
+                }
+                None => args.push("-bsa".to_string()),
+            }
+            Ok(args)
+        }
+        SigFormat::Ssh => {
+            // ssh-keygen cannot pick a default the way gpg can: without a key
+            // there is nothing to sign with, so this is a clean error rather
+            // than a confusing failure from the subprocess.
+            let key = key_file.ok_or_else(|| {
+                AppError::InvalidArgument(
+                    "ssh signing needs user.signingkey to be set".to_string(),
+                )
+            })?;
+            Ok(vec![
+                "-Y".to_string(),
+                "sign".to_string(),
+                "-n".to_string(),
+                "git".to_string(),
+                "-f".to_string(),
+                key.to_string_lossy().to_string(),
+            ])
+        }
+        // Refused rather than silently producing an unsigned commit: the user
+        // asked for a signature and would have no indication they did not get one.
+        SigFormat::X509 => Err(AppError::NotImplemented),
+    }
+}
+
+/// Verification state of one commit's signature.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum SigState {
+    Good,
+    Bad,
+    /// Signed, but the key is not available to check it.
+    UnknownKey,
+    Expired,
+    Revoked,
+    /// Not signed at all.
+    None,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignatureStatus {
+    pub state: SigState,
+    pub signer: Option<String>,
+    pub key: Option<String>,
+}
+
+/// Parse `git show --format=%G?%x00%GS%x00%GK` output for one commit.
+///
+/// `U` is "good signature, untrusted key" — reported as `Good`, with the signer
+/// line carrying the nuance, rather than inventing a state the UI would have to
+/// explain.
+pub fn parse_verify_output(raw: &str) -> SignatureStatus {
+    let mut parts = raw.trim_end_matches('\n').split('\0');
+    let flag = parts.next().unwrap_or("N").trim();
+    let signer = parts.next().unwrap_or("").trim();
+    let key = parts.next().unwrap_or("").trim();
+
+    let state = match flag.chars().next().unwrap_or('N') {
+        'G' | 'U' => SigState::Good,
+        'B' => SigState::Bad,
+        'X' => SigState::Expired,
+        'R' => SigState::Revoked,
+        'E' => SigState::UnknownKey,
+        // 'N' and anything unexpected: treat as unsigned rather than claiming a
+        // status we cannot substantiate.
+        _ => SigState::None,
+    };
+
+    SignatureStatus {
+        state,
+        signer: (!signer.is_empty()).then(|| signer.to_string()),
+        key: (!key.is_empty()).then(|| key.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openpgp_args_use_detached_armored_signing_with_the_key() {
+        let cfg = SigningConfig {
+            format: SigFormat::OpenPgp,
+            program: "gpg".into(),
+            key: Some("ABCD1234".into()),
+        };
+        let args = signing_args(&cfg, None).unwrap();
+        assert!(args.contains(&"-bsau".to_string()), "{args:?}");
+        assert!(args.contains(&"ABCD1234".to_string()), "{args:?}");
+    }
+
+    #[test]
+    fn openpgp_without_a_key_lets_gpg_pick_its_default() {
+        let cfg = SigningConfig {
+            format: SigFormat::OpenPgp,
+            program: "gpg".into(),
+            key: None,
+        };
+        let args = signing_args(&cfg, None).unwrap();
+        assert!(args.contains(&"-bsa".to_string()), "{args:?}");
+        assert!(!args.iter().any(|a| a == "-u"), "{args:?}");
+    }
+
+    #[test]
+    fn ssh_args_sign_with_the_git_namespace_and_key_file() {
+        let cfg = SigningConfig {
+            format: SigFormat::Ssh,
+            program: "ssh-keygen".into(),
+            key: Some("/home/u/.ssh/id_ed25519".into()),
+        };
+        let args = signing_args(&cfg, Some(std::path::Path::new("/tmp/key"))).unwrap();
+        assert_eq!(args[0], "-Y");
+        assert_eq!(args[1], "sign");
+        assert!(args.contains(&"git".to_string()), "namespace: {args:?}");
+        assert!(args.contains(&"/tmp/key".to_string()), "key file: {args:?}");
+    }
+
+    #[test]
+    fn ssh_signing_requires_a_key() {
+        let cfg = SigningConfig {
+            format: SigFormat::Ssh,
+            program: "ssh-keygen".into(),
+            key: None,
+        };
+        let err = signing_args(&cfg, None).expect_err("ssh needs a key");
+        assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn x509_is_a_clean_unsupported_error_not_a_panic() {
+        let cfg = SigningConfig {
+            format: SigFormat::X509,
+            program: "smimesign".into(),
+            key: None,
+        };
+        let err = signing_args(&cfg, None).expect_err("x509 is unsupported");
+        assert!(matches!(err, AppError::NotImplemented), "got {err:?}");
+    }
+
+    #[test]
+    fn parses_each_verify_state() {
+        for (raw, want) in [
+            ("G\0Ada <ada@x>\0ABCD", SigState::Good),
+            ("B\0Ada <ada@x>\0ABCD", SigState::Bad),
+            // Good signature, untrusted key.
+            ("U\0Ada <ada@x>\0ABCD", SigState::Good),
+            ("X\0Ada <ada@x>\0ABCD", SigState::Expired),
+            ("R\0Ada <ada@x>\0ABCD", SigState::Revoked),
+            ("E\0\0", SigState::UnknownKey),
+            ("N\0\0", SigState::None),
+        ] {
+            assert_eq!(parse_verify_output(raw).state, want, "{raw}");
+        }
+    }
+
+    #[test]
+    fn parses_signer_and_key() {
+        let s = parse_verify_output("G\0Ada Lovelace <ada@x>\0ABCD1234");
+        assert_eq!(s.signer.as_deref(), Some("Ada Lovelace <ada@x>"));
+        assert_eq!(s.key.as_deref(), Some("ABCD1234"));
+    }
+
+    #[test]
+    fn an_unsigned_commit_has_no_signer() {
+        let s = parse_verify_output("N\0\0");
+        assert_eq!(s.state, SigState::None);
+        assert!(s.signer.is_none());
+        assert!(s.key.is_none());
+    }
+
+    #[test]
+    fn an_unexpected_flag_reads_as_unsigned() {
+        // Better than claiming a status we cannot substantiate.
+        assert_eq!(parse_verify_output("?\0\0").state, SigState::None);
+        assert_eq!(parse_verify_output("").state, SigState::None);
+    }
+}

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -225,6 +225,10 @@ pub struct CommitOptions {
     /// signature, matching `git commit -s` (deduped if already present).
     #[serde(default)]
     pub signoff: bool,
+    /// Cryptographically sign this commit (#61 D6). `None` follows
+    /// `commit.gpgsign` from git config; `Some` overrides it for this commit.
+    #[serde(default)]
+    pub sign: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,11 +14,45 @@ use crate::{git::libgit2::Libgit2Backend, state::AppState};
 pub fn run() {
     let args: Vec<String> = std::env::args().skip(1).collect();
     let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("/"));
+    // Askpass shim (#61 D5). Handled FIRST — before the single-instance plugin
+    // and the Tauri builder — so it stays a fast plain process and never
+    // forwards itself into a running app instance.
+    //
+    // Two ways in: the ASKPASS_MODE_ENV flag (what git actually uses, because
+    // GIT_ASKPASS is exec'd directly and cannot carry arguments) and an explicit
+    // `--askpass` argument. Both end here.
+    //
+    // stdout is read by git AS THE CREDENTIAL, so nothing else may be printed:
+    // no logging, no diagnostics. An unrecognized prompt or a missing value
+    // exits non-zero with no output rather than printing an empty string, which
+    // git would treat as a real credential.
+    let askpass_prompt = if std::env::var_os(cli::ASKPASS_MODE_ENV).is_some() {
+        Some(args.first().cloned().unwrap_or_default())
+    } else {
+        match cli::parse_args(&args, &cwd) {
+            cli::Parsed::Askpass(prompt) => Some(prompt),
+            _ => None,
+        }
+    };
+    if let Some(prompt) = askpass_prompt {
+        let username = std::env::var(cli::ASKPASS_USERNAME_ENV).ok();
+        let secret = std::env::var(cli::ASKPASS_SECRET_ENV).ok();
+        match cli::askpass_answer(&prompt, username.as_deref(), secret.as_deref()) {
+            Some(value) => {
+                println!("{value}");
+                return;
+            }
+            None => std::process::exit(1),
+        }
+    }
+
     let initial_intent = match cli::parse_args(&args, &cwd) {
         cli::Parsed::Help => {
             print!("{}", cli::USAGE);
             return;
         }
+        // Already handled above; unreachable in practice.
+        cli::Parsed::Askpass(_) => return,
         cli::Parsed::Launch(intent) => intent.map(cli::resolve_repo_root),
     };
 
@@ -116,6 +150,7 @@ pub fn run() {
             commands::commits::commits_since,
             commands::commits::commit,
             commands::commits::file_history,
+            commands::commits::verify_commit,
             commands::create::init_repo,
             commands::create::default_init_branch,
             commands::create::clone_repo,
@@ -141,6 +176,7 @@ pub fn run() {
             commands::branches::delete_branch,
             commands::branches::rename_branch,
             commands::branches::set_upstream,
+            commands::net::remember_credential,
             commands::branches::fetch,
             commands::branches::fetch_all,
             commands::branches::pull,

--- a/src-tauri/tests/auth_env.rs
+++ b/src-tauri/tests/auth_env.rs
@@ -1,0 +1,135 @@
+//! Network-op environment policy and failure mapping (#61 D5).
+//!
+//! The argv test is the one that matters most: argv is world-readable via `ps`
+//! on macOS and Linux, so a credential appearing there would be visible to any
+//! other local user for the lifetime of the git subprocess.
+
+use platypusgit_lib::commands::net::{apply_auth_env, map_git_failure, Credentials};
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::auth::AuthKind;
+
+fn creds() -> Credentials {
+    Credentials {
+        username: Some("ada".into()),
+        secret: "ghp_supersecret".into(),
+    }
+}
+
+#[test]
+fn auth_stderr_maps_to_auth_error_with_the_host() {
+    let err = map_git_failure("fatal: Authentication failed for 'https://github.com/x/y.git/'");
+    match err {
+        AppError::Auth(c) => {
+            assert_eq!(c.host.as_deref(), Some("github.com"));
+            assert_eq!(c.kind, AuthKind::Https);
+        }
+        other => panic!("expected Auth, got {other:?}"),
+    }
+}
+
+#[test]
+fn passphrase_stderr_maps_to_the_passphrase_kind() {
+    let err = map_git_failure("Enter passphrase for key '/home/u/.ssh/id_ed25519': ");
+    match err {
+        AppError::Auth(c) => assert_eq!(c.kind, AuthKind::SshPassphrase),
+        other => panic!("expected Auth, got {other:?}"),
+    }
+}
+
+#[test]
+fn non_auth_stderr_stays_network() {
+    let err = map_git_failure("fatal: unable to access 'https://x/y': Could not resolve host: x");
+    assert!(matches!(err, AppError::Network(_)), "got {err:?}");
+}
+
+#[test]
+fn host_key_failure_stays_network_not_auth() {
+    // No credential the user can type fixes an unknown host key.
+    let err = map_git_failure("Host key verification failed.");
+    assert!(matches!(err, AppError::Network(_)), "got {err:?}");
+}
+
+#[test]
+fn a_surfaced_error_never_carries_an_embedded_token() {
+    let err = map_git_failure(
+        "fatal: unable to access 'https://u:ghp_leaked@github.com/x/y': Authentication failed",
+    );
+    let text = format!("{err:?}");
+    assert!(!text.contains("ghp_leaked"), "credential leaked: {text}");
+}
+
+#[test]
+fn credentials_travel_in_the_environment_never_in_argv() {
+    let c = creds();
+    let mut cmd = tokio::process::Command::new("git");
+    cmd.arg("fetch").arg("origin");
+    apply_auth_env(&mut cmd, Some(&c));
+    let std_cmd = cmd.as_std();
+
+    let argv = format!("{:?}", std_cmd.get_args().collect::<Vec<_>>());
+    assert!(
+        !argv.contains("ghp_supersecret"),
+        "secret must never reach argv: {argv}"
+    );
+
+    let secret_in_env = std_cmd.get_envs().any(|(_, v)| {
+        v.map(|v| v.to_string_lossy().contains("ghp_supersecret"))
+            .unwrap_or(false)
+    });
+    assert!(secret_in_env, "secret should travel in the environment");
+}
+
+#[test]
+fn askpass_points_at_a_bare_executable_with_no_arguments() {
+    // GIT_ASKPASS is exec'd directly, not run through a shell: a value with an
+    // appended flag fails with "cannot exec".
+    let c = creds();
+    let mut cmd = tokio::process::Command::new("git");
+    apply_auth_env(&mut cmd, Some(&c));
+
+    let askpass = cmd
+        .as_std()
+        .get_envs()
+        .find(|(k, _)| *k == "GIT_ASKPASS")
+        .and_then(|(_, v)| v)
+        .map(|v| v.to_string_lossy().to_string())
+        .expect("GIT_ASKPASS should be set");
+    assert!(
+        !askpass.contains(" -") && !askpass.contains("--"),
+        "GIT_ASKPASS must be a bare executable path, got {askpass}"
+    );
+}
+
+#[test]
+fn without_credentials_prompts_stay_disabled() {
+    let mut cmd = tokio::process::Command::new("git");
+    apply_auth_env(&mut cmd, None);
+    let envs: Vec<(String, String)> = cmd
+        .as_std()
+        .get_envs()
+        .filter_map(|(k, v)| Some((k.to_string_lossy().to_string(), v?.to_string_lossy().to_string())))
+        .collect();
+
+    let get = |k: &str| envs.iter().find(|(n, _)| n == k).map(|(_, v)| v.as_str());
+    assert_eq!(get("GIT_TERMINAL_PROMPT"), Some("0"));
+    assert_eq!(get("GIT_ASKPASS"), Some("true"));
+    assert_eq!(get("SSH_ASKPASS"), Some("true"));
+}
+
+#[test]
+fn an_ssh_passphrase_credential_clears_any_inherited_username() {
+    // A stale PLATYPUSGIT_ASKPASS_USERNAME must not answer a username prompt
+    // during an SSH passphrase retry.
+    let c = Credentials {
+        username: None,
+        secret: "passphrase".into(),
+    };
+    let mut cmd = tokio::process::Command::new("git");
+    apply_auth_env(&mut cmd, Some(&c));
+
+    let username_set = cmd
+        .as_std()
+        .get_envs()
+        .any(|(k, v)| k == "PLATYPUSGIT_ASKPASS_USERNAME" && v.is_some());
+    assert!(!username_set, "username should be cleared, not inherited");
+}

--- a/src-tauri/tests/branches_tags.rs
+++ b/src-tauri/tests/branches_tags.rs
@@ -143,6 +143,7 @@ fn delete_unmerged_branch_is_refused_without_force() {
                 amend: false,
                 author_override: None,
                 signoff: false,
+                sign: None,
             },
         )
         .unwrap();

--- a/src-tauri/tests/cherry_pick_revert.rs
+++ b/src-tauri/tests/cherry_pick_revert.rs
@@ -23,6 +23,7 @@ fn cherry_pick_applies_commit_onto_head() {
                 amend: false,
                 author_override: None,
                 signoff: false,
+                sign: None,
             },
         )
         .unwrap();
@@ -51,6 +52,7 @@ fn revert_undoes_commit() {
                 amend: false,
                 author_override: None,
                 signoff: false,
+                sign: None,
             },
         )
         .unwrap();

--- a/src-tauri/tests/clone_init.rs
+++ b/src-tauri/tests/clone_init.rs
@@ -453,6 +453,7 @@ async fn clone_from_a_local_bare_repo_lands_the_files() {
         dest_parent.path(),
         "cloned",
         false,
+        None,
         |_| {},
     )
     .await
@@ -508,6 +509,7 @@ async fn clone_streams_progress_ticks_as_they_arrive() {
         dest_parent.path(),
         "cloned",
         false,
+        None,
         move |p| ticks_for_closure.lock().unwrap().push(p),
     )
     .await
@@ -552,6 +554,7 @@ async fn run_clone_trims_whitespace_from_the_name_and_matches_disk() {
         dest_parent.path(),
         "cloned ", // trailing space, exactly the reviewer's repro
         false,
+        None,
         |_| {},
     )
     .await
@@ -586,6 +589,7 @@ async fn run_clone_reports_a_missing_parent_directory_by_name() {
         &missing_parent,
         "cloned",
         false,
+        None,
         |_| {},
     )
     .await
@@ -617,6 +621,7 @@ async fn a_failed_clone_reports_git_stderr_and_leaves_nothing_behind() {
         dest_parent.path(),
         "cloned",
         false,
+        None,
         |_| {},
     )
     .await

--- a/src-tauri/tests/discard_reset.rs
+++ b/src-tauri/tests/discard_reset.rs
@@ -227,6 +227,7 @@ fn reset_hard_moves_head_and_cleans_worktree() {
                     amend: false,
                     author_override: None,
                     signoff: false,
+                    sign: None,
                 },
             )
             .unwrap();
@@ -258,6 +259,7 @@ fn reset_soft_keeps_worktree() {
                 amend: false,
                 author_override: None,
                 signoff: false,
+                sign: None,
             },
         )
         .unwrap();

--- a/src-tauri/tests/reflog.rs
+++ b/src-tauri/tests/reflog.rs
@@ -88,6 +88,7 @@ fn read_reflog_classifies_amend_op() {
                 amend: true,
                 author_override: None,
                 signoff: false,
+                sign: None,
             },
         )
         .unwrap();

--- a/src-tauri/tests/signing.rs
+++ b/src-tauri/tests/signing.rs
@@ -1,0 +1,281 @@
+//! Commit signing (#61 D6).
+//!
+//! The load-bearing assertion is that a signed commit is REACHABLE FROM HEAD:
+//! `repo.commit_signed` only writes the object, unlike
+//! `repo.commit(Some("HEAD"), …)`, so a signed commit that never moves the
+//! branch looks to the user exactly like lost work.
+
+mod support;
+
+use platypusgit_lib::git::signing::{config_wants_signing, resolve_signing, SigFormat};
+use platypusgit_lib::git::types::CommitOptions;
+use platypusgit_lib::git::GitBackend;
+use support::TempRepo;
+
+fn opts(message: &str, sign: Option<bool>) -> CommitOptions {
+    CommitOptions {
+        message: message.into(),
+        amend: false,
+        author_override: None,
+        signoff: false,
+        sign,
+    }
+}
+
+// ─── config resolution ───────────────────────────────────────────────────────
+
+#[test]
+fn defaults_to_openpgp_with_gpg_and_no_signing() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let cfg = resolve_signing(&tr.repo).unwrap();
+    assert_eq!(cfg.format, SigFormat::OpenPgp);
+    assert_eq!(cfg.program, "gpg");
+    assert!(!config_wants_signing(&tr.repo));
+}
+
+#[test]
+fn reads_ssh_format_and_program_and_key() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    {
+        let mut c = tr.repo.config().unwrap();
+        c.set_str("gpg.format", "ssh").unwrap();
+        c.set_str("user.signingkey", "/keys/id_ed25519").unwrap();
+        c.set_bool("commit.gpgsign", true).unwrap();
+    }
+    let cfg = resolve_signing(&tr.repo).unwrap();
+    assert_eq!(cfg.format, SigFormat::Ssh);
+    assert_eq!(cfg.program, "ssh-keygen");
+    assert_eq!(cfg.key.as_deref(), Some("/keys/id_ed25519"));
+    assert!(config_wants_signing(&tr.repo));
+}
+
+#[test]
+fn honours_an_explicit_gpg_program() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    {
+        let mut c = tr.repo.config().unwrap();
+        c.set_str("gpg.program", "/usr/local/bin/gpg2").unwrap();
+    }
+    assert_eq!(
+        resolve_signing(&tr.repo).unwrap().program,
+        "/usr/local/bin/gpg2"
+    );
+}
+
+// ─── signing ─────────────────────────────────────────────────────────────────
+
+/// Generate an unencrypted ed25519 key in `dir`, returning its private-key path.
+/// `None` when ssh-keygen is unavailable, so the test skips rather than fails.
+fn make_ssh_key(dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    let key = dir.join("id_ed25519");
+    let out = std::process::Command::new("ssh-keygen")
+        .args(["-t", "ed25519", "-N", "", "-C", "test", "-f"])
+        .arg(&key)
+        .output()
+        .ok()?;
+    out.status.success().then_some(key)
+}
+
+/// Repo configured for ssh signing with its own generated key, plus a staged
+/// change ready to commit. `None` when ssh-keygen is unavailable.
+fn ssh_signing_repo() -> Option<(TempRepo, tempfile::TempDir)> {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let keydir = tempfile::tempdir().unwrap();
+    let key = make_ssh_key(keydir.path())?;
+    {
+        let mut c = tr.repo.config().unwrap();
+        c.set_str("gpg.format", "ssh").unwrap();
+        c.set_str("user.signingkey", key.to_str().unwrap()).unwrap();
+    }
+    support::fs::write_file(tr.path(), "b.txt", "second\n");
+    Some((tr, keydir))
+}
+
+#[test]
+fn signed_commit_is_reachable_from_head_and_has_a_gpgsig_header() {
+    let Some((tr, _keydir)) = ssh_signing_repo() else {
+        eprintln!("ssh-keygen unavailable — skipping signed-commit test");
+        return;
+    };
+    let (backend, handle) = tr.open_with_backend();
+    backend
+        .stage(&handle.id, &[std::path::PathBuf::from("b.txt")])
+        .unwrap();
+
+    let oid = backend
+        .commit(&handle.id, opts("signed", Some(true)))
+        .expect("signed commit");
+
+    // THE trap: commit_signed writes the object but does not move HEAD.
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(head.id().to_string(), oid, "signed commit must be HEAD");
+    assert_eq!(head.parent_count(), 1, "must keep its parent");
+    assert_eq!(head.summary(), Some("signed"));
+
+    let header = head
+        .header_field_bytes("gpgsig")
+        .expect("commit should carry a gpgsig header");
+    assert!(!header.is_empty(), "signature must not be empty");
+}
+
+#[test]
+fn signed_commit_writes_a_reflog_entry() {
+    let Some((tr, _keydir)) = ssh_signing_repo() else {
+        eprintln!("ssh-keygen unavailable — skipping signed reflog test");
+        return;
+    };
+    let (backend, handle) = tr.open_with_backend();
+    backend
+        .stage(&handle.id, &[std::path::PathBuf::from("b.txt")])
+        .unwrap();
+    backend
+        .commit(&handle.id, opts("signed", Some(true)))
+        .unwrap();
+
+    let entries = backend.read_reflog(&handle.id).expect("reflog");
+    assert!(
+        entries.iter().any(|e| e.message.contains("signed")),
+        "signed commit must leave a reflog entry, got {:?}",
+        entries.iter().map(|e| &e.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn signed_amend_replaces_head_and_stays_signed() {
+    let Some((tr, _keydir)) = ssh_signing_repo() else {
+        eprintln!("ssh-keygen unavailable — skipping signed amend test");
+        return;
+    };
+    let (backend, handle) = tr.open_with_backend();
+    backend
+        .stage(&handle.id, &[std::path::PathBuf::from("b.txt")])
+        .unwrap();
+    backend
+        .commit(&handle.id, opts("original", Some(true)))
+        .unwrap();
+    let parent_before = tr
+        .repo
+        .head()
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .parent(0)
+        .unwrap()
+        .id();
+
+    let amended = backend
+        .commit(
+            &handle.id,
+            CommitOptions {
+                amend: true,
+                ..opts("amended", Some(true))
+            },
+        )
+        .expect("signed amend");
+
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(head.id().to_string(), amended, "amend must move HEAD");
+    assert_eq!(head.summary(), Some("amended"));
+    assert_eq!(
+        head.parent(0).unwrap().id(),
+        parent_before,
+        "amend must keep the original parent, not chain onto the old commit"
+    );
+    assert!(head.header_field_bytes("gpgsig").is_ok(), "still signed");
+}
+
+#[test]
+fn unsigned_commit_path_is_unchanged() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    support::fs::write_file(tr.path(), "b.txt", "second\n");
+    let (backend, handle) = tr.open_with_backend();
+    backend
+        .stage(&handle.id, &[std::path::PathBuf::from("b.txt")])
+        .unwrap();
+
+    let oid = backend
+        .commit(&handle.id, opts("plain", Some(false)))
+        .unwrap();
+
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(head.id().to_string(), oid);
+    assert!(
+        head.header_field_bytes("gpgsig").is_err(),
+        "must not be signed"
+    );
+}
+
+#[test]
+fn sign_none_follows_commit_gpgsign_being_off() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    support::fs::write_file(tr.path(), "b.txt", "second\n");
+    let (backend, handle) = tr.open_with_backend();
+    backend
+        .stage(&handle.id, &[std::path::PathBuf::from("b.txt")])
+        .unwrap();
+
+    // No commit.gpgsign set → unsigned, and crucially no attempt to run gpg.
+    let oid = backend.commit(&handle.id, opts("plain", None)).unwrap();
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(head.id().to_string(), oid);
+    assert!(head.header_field_bytes("gpgsig").is_err());
+}
+
+#[test]
+fn verify_commit_rejects_a_non_hex_revision() {
+    // `git show` would read a leading '-' as an option; every real caller passes
+    // an oid from the log walk, so anything else is refused before the subprocess.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    for bad in ["--help", "HEAD", "", "zzzz"] {
+        let err = backend
+            .verify_commit(&handle.id, bad)
+            .expect_err("should refuse a non-hex revision");
+        assert!(
+            matches!(err, platypusgit_lib::error::AppError::InvalidRef(_)),
+            "expected InvalidRef for {bad:?}, got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn verify_commit_reports_an_unsigned_commit_as_none() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let oid = tr.repo.head().unwrap().target().unwrap().to_string();
+
+    let status = backend.verify_commit(&handle.id, &oid).expect("verify");
+    assert_eq!(
+        status.state,
+        platypusgit_lib::git::signing::SigState::None,
+        "an unsigned commit must read as None"
+    );
+}
+
+#[test]
+fn a_signing_failure_fails_the_commit_instead_of_committing_unsigned() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    {
+        let mut c = tr.repo.config().unwrap();
+        c.set_str("gpg.format", "ssh").unwrap();
+        // A program that does not exist: signing cannot succeed.
+        c.set_str("gpg.ssh.program", "definitely-not-a-real-program").unwrap();
+        c.set_str("user.signingkey", "/nonexistent/key").unwrap();
+    }
+    support::fs::write_file(tr.path(), "b.txt", "second\n");
+    let (backend, handle) = tr.open_with_backend();
+    backend
+        .stage(&handle.id, &[std::path::PathBuf::from("b.txt")])
+        .unwrap();
+
+    let head_before = tr.repo.head().unwrap().peel_to_commit().unwrap().id();
+    let err = backend
+        .commit(&handle.id, opts("should fail", Some(true)))
+        .expect_err("a signing failure must fail the commit");
+
+    // Falling back to an unsigned commit would leave the user believing they
+    // had signed it.
+    let head_after = tr.repo.head().unwrap().peel_to_commit().unwrap().id();
+    assert_eq!(head_before, head_after, "HEAD must not move: {err:?}");
+}

--- a/src-tauri/tests/stage_commit.rs
+++ b/src-tauri/tests/stage_commit.rs
@@ -97,6 +97,7 @@ fn commit_from_staged_changes_advances_head() {
                 amend: false,
                 author_override: None,
                 signoff: false,
+                sign: None,
             },
         )
         .expect("commit");
@@ -124,6 +125,7 @@ fn amend_replaces_tip() {
                 amend: false,
                 author_override: None,
                 signoff: false,
+                sign: None,
             },
         )
         .unwrap();
@@ -141,6 +143,7 @@ fn amend_replaces_tip() {
                 amend: true,
                 author_override: None,
                 signoff: false,
+                sign: None,
             },
         )
         .unwrap();
@@ -167,6 +170,7 @@ fn commit_with_signoff_appends_trailer_from_repo_identity() {
                 amend: false,
                 author_override: None,
                 signoff: true,
+                sign: None,
             },
         )
         .expect("commit");
@@ -198,6 +202,7 @@ fn commit_signoff_does_not_duplicate_existing_trailer() {
                 amend: false,
                 author_override: None,
                 signoff: true,
+                sign: None,
             },
         )
         .expect("commit");
@@ -224,6 +229,7 @@ fn commit_without_signoff_leaves_message_untouched() {
                 amend: false,
                 author_override: None,
                 signoff: false,
+                sign: None,
             },
         )
         .expect("commit");
@@ -249,6 +255,7 @@ fn commit_on_unborn_branch_creates_root() {
                 amend: false,
                 author_override: None,
                 signoff: false,
+                sign: None,
             },
         )
         .unwrap();

--- a/src-tauri/tests/support/mod.rs
+++ b/src-tauri/tests/support/mod.rs
@@ -125,6 +125,7 @@ pub fn with_conflicting_merge() -> TempRepo {
                     amend: false,
                     author_override: None,
                     signoff: false,
+                    sign: None,
                 },
             )
             .unwrap();
@@ -141,6 +142,7 @@ pub fn with_conflicting_merge() -> TempRepo {
                     amend: false,
                     author_override: None,
                     signoff: false,
+                    sign: None,
                 },
             )
             .unwrap();

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -45,6 +45,7 @@ import { CommandPalette } from "@/features/palette/CommandPalette";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { BranchChip } from "@/features/branches/BranchChip";
 import { CloneDialog } from "@/features/create/CloneDialog";
+import { CredentialDialog } from "@/features/auth/CredentialDialog";
 import { InitDialog } from "@/features/create/InitDialog";
 import { UpdateChip } from "@/features/update/UpdateChip";
 import { UpdatePanel } from "@/features/update/UpdatePanel";
@@ -261,6 +262,9 @@ export function AppShell() {
       {/* Styled confirm/prompt host — pgConfirm/pgPrompt resolve false/null
           unless one of these is mounted. */}
       <PGDialogHost />
+      {/* Credential prompt for a network op that failed to authenticate (#61 D5).
+          Renders nothing until an Auth error raises a challenge. */}
+      <CredentialDialog />
       <UpdatePanel />
       <CheatSheet />
       <CloneDialog />

--- a/src/features/auth/CredentialDialog.test.tsx
+++ b/src/features/auth/CredentialDialog.test.tsx
@@ -1,0 +1,133 @@
+// Credential entry + retry (#61 D5).
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { CredentialDialog } from "./CredentialDialog";
+import { useAuthStore, type AuthChallengeRequest } from "./useAuthStore";
+
+function raise(
+  over: Partial<AuthChallengeRequest> = {},
+  retry = vi.fn().mockResolvedValue(undefined),
+) {
+  useAuthStore.getState().raise({
+    host: "github.com",
+    kind: "Https",
+    retry,
+    ...over,
+  });
+  return retry;
+}
+
+const type = (testId: string, value: string) =>
+  fireEvent.change(screen.getByTestId(testId), { target: { value } });
+
+describe("CredentialDialog", () => {
+  beforeEach(() => useAuthStore.setState({ challenge: null }));
+
+  it("renders nothing without a challenge", () => {
+    render(<CredentialDialog />);
+    expect(screen.queryByTestId("credential-dialog")).toBeNull();
+  });
+
+  it("names the host it is authenticating to", () => {
+    raise();
+    render(<CredentialDialog />);
+    expect(screen.getByTestId("credential-dialog").textContent).toContain(
+      "github.com",
+    );
+  });
+
+  it("retries with the entered credentials", async () => {
+    const retry = raise();
+    render(<CredentialDialog />);
+    type("credential-username", "ada");
+    type("credential-secret", "ghp_x");
+    fireEvent.click(screen.getByTestId("credential-submit"));
+
+    await waitFor(() =>
+      expect(retry).toHaveBeenCalledWith(
+        { username: "ada", secret: "ghp_x" },
+        false,
+      ),
+    );
+  });
+
+  it("passes remember through when checked", async () => {
+    const retry = raise();
+    render(<CredentialDialog />);
+    type("credential-secret", "ghp_x");
+    // PGCheckbox does not forward data-testid, so target it by role.
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByTestId("credential-submit"));
+
+    await waitFor(() =>
+      expect(retry).toHaveBeenCalledWith(expect.anything(), true),
+    );
+  });
+
+  it("asks only for a passphrase on an SSH challenge", () => {
+    raise({ kind: "SshPassphrase", host: null });
+    render(<CredentialDialog />);
+    expect(screen.queryByTestId("credential-username")).toBeNull();
+    expect(screen.getByTestId("credential-secret")).toBeTruthy();
+  });
+
+  it("omits the username from an SSH passphrase retry", async () => {
+    const retry = raise({ kind: "SshPassphrase", host: null });
+    render(<CredentialDialog />);
+    type("credential-secret", "phrase");
+    fireEvent.click(screen.getByTestId("credential-submit"));
+
+    await waitFor(() =>
+      expect(retry).toHaveBeenCalledWith({ secret: "phrase" }, false),
+    );
+  });
+
+  it("dismissing clears the challenge without retrying", () => {
+    const retry = raise();
+    render(<CredentialDialog />);
+    fireEvent.click(screen.getByTestId("credential-cancel"));
+    expect(retry).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().challenge).toBeNull();
+  });
+
+  it("cannot submit an empty secret", () => {
+    const retry = raise();
+    render(<CredentialDialog />);
+    expect(screen.getByTestId("credential-submit")).toBeDisabled();
+    fireEvent.click(screen.getByTestId("credential-submit"));
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  it("never keeps the secret in the store", async () => {
+    raise();
+    render(<CredentialDialog />);
+    type("credential-secret", "ghp_supersecret");
+    // Before submitting: the store must already be free of it.
+    expect(JSON.stringify(useAuthStore.getState())).not.toContain(
+      "ghp_supersecret",
+    );
+
+    fireEvent.click(screen.getByTestId("credential-submit"));
+    await waitFor(() =>
+      expect(useAuthStore.getState().challenge).toBeNull(),
+    );
+    expect(JSON.stringify(useAuthStore.getState())).not.toContain(
+      "ghp_supersecret",
+    );
+  });
+
+  it("masks the secret until revealed", () => {
+    raise();
+    render(<CredentialDialog />);
+    expect(screen.getByTestId("credential-secret")).toHaveAttribute(
+      "type",
+      "password",
+    );
+    fireEvent.click(screen.getByTitle("Show"));
+    expect(screen.getByTestId("credential-secret")).toHaveAttribute(
+      "type",
+      "text",
+    );
+  });
+});

--- a/src/features/auth/CredentialDialog.tsx
+++ b/src/features/auth/CredentialDialog.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { PGButton, PGCheckbox, PGInput, PGModal } from "@/design";
+import { useAuthStore } from "./useAuthStore";
+
+/**
+ * Collects a credential for a failed network op and hands it to the retry
+ * (#61 D5).
+ *
+ * The secret is component state and is never written to the store, so nothing
+ * sensitive outlives this component. Cancelling retries nothing — the original
+ * error surfaces through the normal banner path.
+ */
+export function CredentialDialog() {
+  const challenge = useAuthStore((s) => s.challenge);
+  const dismiss = useAuthStore((s) => s.dismiss);
+
+  const [username, setUsername] = React.useState("");
+  const [secret, setSecret] = React.useState("");
+  const [reveal, setReveal] = React.useState(false);
+  const [remember, setRemember] = React.useState(false);
+  const [busy, setBusy] = React.useState(false);
+
+  // A fresh challenge must not inherit the previous one's typed values.
+  React.useEffect(() => {
+    setUsername("");
+    setSecret("");
+    setReveal(false);
+    setRemember(false);
+    setBusy(false);
+  }, [challenge]);
+
+  if (!challenge) return null;
+
+  // An SSH passphrase has no username; asking for one would be noise.
+  const wantsUsername = challenge.kind === "Https";
+  const where = challenge.host ? ` for ${challenge.host}` : "";
+  const title =
+    challenge.kind === "SshPassphrase"
+      ? `Unlock SSH key${where}`
+      : `Sign in${where}`;
+  const body =
+    challenge.kind === "SshKey"
+      ? "The server rejected the SSH key that was offered. Enter a passphrase if the key is encrypted, or configure a key it will accept."
+      : challenge.kind === "SshPassphrase"
+        ? "Your SSH key is encrypted. Enter its passphrase to continue."
+        : "Use a personal access token as the password — most hosts no longer accept account passwords over HTTPS.";
+
+  const submit = async () => {
+    if (!secret || busy) return;
+    setBusy(true);
+    const creds = wantsUsername
+      ? { username: username.trim() || undefined, secret }
+      : { secret };
+    const doRetry = challenge.retry;
+    // Clear before awaiting: the dialog's job is done, and leaving it mounted
+    // over a long fetch reads as if nothing happened.
+    dismiss();
+    await doRetry(creds, remember);
+  };
+
+  return (
+    <PGModal onCancel={dismiss} width={460}>
+      <div
+        data-testid="credential-dialog"
+        style={{ display: "flex", flexDirection: "column", gap: 12 }}
+      >
+        <div style={{ fontSize: "var(--fs-14)", color: "var(--fg-0)" }}>
+          {title}
+        </div>
+        <div style={{ fontSize: "var(--fs-12)", color: "var(--fg-2)" }}>
+          {body}
+        </div>
+
+        {wantsUsername && (
+          <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            <span style={{ fontSize: "var(--fs-10)", color: "var(--fg-2)" }}>
+              USERNAME
+            </span>
+            <PGInput
+              value={username}
+              onChange={setUsername}
+              placeholder="username"
+              data-testid="credential-username"
+              autoFocus
+            />
+          </label>
+        )}
+
+        <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <span style={{ fontSize: "var(--fs-10)", color: "var(--fg-2)" }}>
+            {challenge.kind === "Https" ? "TOKEN OR PASSWORD" : "PASSPHRASE"}
+          </span>
+          <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+            <PGInput
+              value={secret}
+              onChange={setSecret}
+              type={reveal ? "text" : "password"}
+              placeholder="••••••••"
+              data-testid="credential-secret"
+              style={{ flex: 1 }}
+              autoFocus={!wantsUsername}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void submit();
+              }}
+            />
+            <PGButton
+              size="sm"
+              variant="ghost"
+              icon="eye"
+              title={reveal ? "Hide" : "Show"}
+              onClick={() => setReveal((v) => !v)}
+            />
+          </div>
+        </label>
+
+        <PGCheckbox
+          checked={remember}
+          onChange={setRemember}
+          label="Remember — stores it with git's own credential helper"
+        />
+
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+          <PGButton
+            variant="ghost"
+            onClick={dismiss}
+            data-testid="credential-cancel"
+          >
+            Cancel
+          </PGButton>
+          <PGButton
+            variant="primary"
+            disabled={!secret || busy}
+            onClick={() => void submit()}
+            data-testid="credential-submit"
+          >
+            Sign in
+          </PGButton>
+        </div>
+      </div>
+    </PGModal>
+  );
+}

--- a/src/features/auth/useAuthStore.ts
+++ b/src/features/auth/useAuthStore.ts
@@ -1,0 +1,36 @@
+import { create } from "zustand";
+import type { AuthKind } from "@/lib/errors";
+import type { Credentials } from "@/lib/tauri";
+
+/**
+ * One pending credential request (#61 D5).
+ *
+ * `retry` is supplied by whichever action failed, so the store stays ignorant of
+ * what operation is being retried — it only knows how to ask.
+ */
+export interface AuthChallengeRequest {
+  host: string | null;
+  kind: AuthKind;
+  retry: (creds: Credentials, remember: boolean) => Promise<void>;
+}
+
+interface AuthStoreState {
+  /** At most one challenge at a time: a second would fight the first for focus. */
+  challenge: AuthChallengeRequest | null;
+  raise: (c: AuthChallengeRequest) => void;
+  dismiss: () => void;
+}
+
+/**
+ * Holds the pending credential challenge.
+ *
+ * Deliberately does NOT hold the secret: that lives in the dialog's component
+ * state and is handed straight to the retry, so nothing sensitive sits in a
+ * global store where a devtools snapshot or a future persistence middleware
+ * could pick it up.
+ */
+export const useAuthStore = create<AuthStoreState>((set) => ({
+  challenge: null,
+  raise: (challenge) => set({ challenge }),
+  dismiss: () => set({ challenge: null }),
+}));

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -3,6 +3,7 @@ import { PGIcon, PGSkeleton } from "@/design";
 import { PGPane, FocusableScroll, usePaneList, useHunkNav } from "@/features/keymap";
 import { fileIconSpec } from "@/lib/fileIcon";
 import { WhitespaceToggle } from "./WhitespaceToggle";
+import { SignatureBadge } from "@/features/signing/SignatureBadge";
 import type { FileDiff } from "@/lib/types";
 
 export interface CommitDiffPanelProps {
@@ -19,6 +20,12 @@ export interface CommitDiffPanelProps {
   paneIdPrefix: string;
   /** Shown when the diff is empty (no changed files). */
   emptyLabel?: string;
+  /**
+   * Commit whose signature to show in the header (#61 D6). Omitted for
+   * comparisons that are not a single commit, e.g. a combined multi-select diff
+   * or commit-vs-worktree, where "the" signature has no meaning.
+   */
+  verifyOid?: string;
 }
 
 /**
@@ -34,6 +41,7 @@ export function CommitDiffPanel({
   header,
   paneIdPrefix,
   emptyLabel = "No changes in this commit.",
+  verifyOid,
 }: CommitDiffPanelProps) {
   const filesPaneId = `${paneIdPrefix}.files`;
   const viewPaneId = `${paneIdPrefix}.view`;
@@ -106,6 +114,8 @@ export function CommitDiffPanel({
             >
               {header}
             </span>
+            {/* Signature status for THIS commit only, verified lazily (#61 D6). */}
+            {verifyOid && <SignatureBadge oid={verifyOid} />}
             {/* Read-only surface: no hunk staging to gate here. */}
             <WhitespaceToggle />
           </div>

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -15,7 +15,13 @@ import type {
   TagInfo,
 } from "@/lib/types";
 import type { AppError } from "@/lib/errors";
-import { dubiousOwnershipPath, isAppError, isDubiousOwnershipError } from "@/lib/errors";
+import {
+  dubiousOwnershipPath,
+  isAppError,
+  isAuthError,
+  isDubiousOwnershipError,
+} from "@/lib/errors";
+import { useAuthStore } from "@/features/auth/useAuthStore";
 import { confirmTrust } from "@/features/repo/ownership";
 import {
   abortOperation,
@@ -70,8 +76,10 @@ import {
   repoState as repoStateFn,
   runMergetool as runMergetoolFn,
   restartConflict as restartConflictFn,
+  rememberCredential,
   setRemoteUrl,
   setUpstream as setUpstreamFn,
+  type Credentials,
   stageHunk,
   stageLines as stageLinesFn,
   stagePaths,
@@ -227,6 +235,8 @@ interface RepoStoreState {
     signoff?: boolean,
     /** "Commit as" — null uses the repo config identity. */
     authorOverride?: AuthorOverride | null,
+    /** Sign this commit (#61 D6). null follows commit.gpgsign. */
+    sign?: boolean | null,
   ) => Promise<string | null>;
   reset: (target: string, mode: ResetMode) => Promise<void>;
   checkoutBranch: (name: string) => Promise<void>;
@@ -288,6 +298,50 @@ interface RepoStoreState {
 
 function toAppError(e: unknown): AppError {
   return isAppError(e) ? e : { kind: "Internal", message: String(e) };
+}
+
+/**
+ * Run a network op; on an authentication failure, raise a credential challenge
+ * whose retry re-runs the SAME op with credentials (#61 D5).
+ *
+ * The first attempt is always prompt-less, so the common case (a credential
+ * helper or ssh-agent already answers) behaves exactly as it did before. A
+ * cancelled dialog never calls `onError`, leaving the original error already
+ * reported by the caller's own catch.
+ */
+async function withAuthRetry(
+  repoId: string,
+  run: (creds?: Credentials) => Promise<void>,
+  onError: (e: unknown) => void | Promise<void>,
+): Promise<void> {
+  try {
+    await run();
+    return;
+  } catch (e) {
+    if (!isAuthError(e)) {
+      await onError(e);
+      return;
+    }
+    const { host, kind } = e.message;
+    useAuthStore.getState().raise({
+      host,
+      kind,
+      retry: async (creds, remember) => {
+        try {
+          await run(creds);
+          // Only after it worked: storing on submit would persist a typo.
+          if (remember && host) {
+            await rememberCredential(repoId, host, creds).catch(() => {
+              // No helper configured is not a failure the user needs to see —
+              // the operation they asked for still succeeded.
+            });
+          }
+        } catch (retryError) {
+          await onError(retryError);
+        }
+      },
+    });
+  }
 }
 
 const DEFAULT_REBASE_STATUS: RebaseStatus = {
@@ -721,11 +775,24 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     }
   },
 
-  async commit(message, amend = false, signoff = false, authorOverride = null) {
+  async commit(
+    message,
+    amend = false,
+    signoff = false,
+    authorOverride = null,
+    sign = null,
+  ) {
     const repo = get().current;
     if (!repo) return null;
     try {
-      const oid = await commitFn(repo.id, message, amend, signoff, authorOverride);
+      const oid = await commitFn(
+        repo.id,
+        message,
+        amend,
+        signoff,
+        authorOverride,
+        sign,
+      );
       await get().refreshAll();
       return oid;
     } catch (e) {
@@ -1023,10 +1090,19 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     setActivity("fetch", `Fetching ${remote}…`);
     try {
-      await fetchRemote(repo.id, remote, useSettingsStore.getState().pruneOnFetch);
-      await get().refreshAll();
-    } catch (e) {
-      set({ error: toAppError(e) });
+      await withAuthRetry(
+        repo.id,
+        async (creds) => {
+          await fetchRemote(
+            repo.id,
+            remote,
+            useSettingsStore.getState().pruneOnFetch,
+            creds,
+          );
+          await get().refreshAll();
+        },
+        (e) => set({ error: toAppError(e) }),
+      );
     } finally {
       setActivity("fetch", null);
     }
@@ -1037,10 +1113,14 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     setActivity("fetch", "Fetching all remotes…");
     try {
-      await fetchAll(repo.id, useSettingsStore.getState().pruneOnFetch);
-      await get().refreshAll();
-    } catch (e) {
-      set({ error: toAppError(e) });
+      await withAuthRetry(
+        repo.id,
+        async (creds) => {
+          await fetchAll(repo.id, useSettingsStore.getState().pruneOnFetch, creds);
+          await get().refreshAll();
+        },
+        (e) => set({ error: toAppError(e) }),
+      );
     } finally {
       setActivity("fetch", null);
     }
@@ -1051,33 +1131,39 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     setActivity("pull", `Pulling ${remote}/${branch}…`);
     try {
-      // Carry over uncommitted work when the setting is on: stash → pull →
-      // pop, mirroring checkoutBranch's auto-stash. stashSave returns null
-      // when the tree is clean, so this is a no-op in the common case. If
-      // the pull fails, the stash is deliberately NOT popped — the work
-      // stays safe in the stash list rather than colliding with a conflicted
-      // worktree (same policy as checkoutBranch).
-      let stashed: string | null = null;
-      if (useSettingsStore.getState().autoStashBeforePull) {
-        setActivity("pull", "Stashing changes…");
-        stashed = await stashSave(repo.id, {
-          message: `auto: pull ${remote}/${branch}`,
-          includeUntracked: true,
-          keepIndex: false,
-        });
-        setActivity("pull", `Pulling ${remote}/${branch}…`);
-      }
-      await pullRemote(repo.id, remote, branch, mode);
-      if (stashed) {
-        setActivity("pull", "Restoring stashed changes…");
-        await stashPop(repo.id, 0);
-      }
-      await get().refreshAll();
-    } catch (e) {
-      // See mergeBranch's catch: refresh first, error last, so it isn't
-      // batched away by refreshAll's own `error: null` reset.
-      await get().refreshAll();
-      set({ error: toAppError(e) });
+      await withAuthRetry(
+        repo.id,
+        async (creds) => {
+          // Carry over uncommitted work when the setting is on: stash → pull →
+          // pop, mirroring checkoutBranch's auto-stash. stashSave returns null
+          // when the tree is clean, so this is a no-op in the common case. If
+          // the pull fails, the stash is deliberately NOT popped — the work
+          // stays safe in the stash list rather than colliding with a conflicted
+          // worktree (same policy as checkoutBranch).
+          let stashed: string | null = null;
+          if (useSettingsStore.getState().autoStashBeforePull) {
+            setActivity("pull", "Stashing changes…");
+            stashed = await stashSave(repo.id, {
+              message: `auto: pull ${remote}/${branch}`,
+              includeUntracked: true,
+              keepIndex: false,
+            });
+            setActivity("pull", `Pulling ${remote}/${branch}…`);
+          }
+          await pullRemote(repo.id, remote, branch, mode, creds);
+          if (stashed) {
+            setActivity("pull", "Restoring stashed changes…");
+            await stashPop(repo.id, 0);
+          }
+          await get().refreshAll();
+        },
+        async (e) => {
+          // See mergeBranch's catch: refresh first, error last, so it isn't
+          // batched away by refreshAll's own `error: null` reset.
+          await get().refreshAll();
+          set({ error: toAppError(e) });
+        },
+      );
     } finally {
       setActivity("pull", null);
     }
@@ -1088,10 +1174,14 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     setActivity("push", `Pushing ${remote}/${branch}…`);
     try {
-      await pushRemote(repo.id, remote, branch, force);
-      await get().refreshAll();
-    } catch (e) {
-      set({ error: toAppError(e) });
+      await withAuthRetry(
+        repo.id,
+        async (creds) => {
+          await pushRemote(repo.id, remote, branch, force, creds);
+          await get().refreshAll();
+        },
+        (e) => set({ error: toAppError(e) }),
+      );
     } finally {
       setActivity("push", null);
     }

--- a/src/features/settings/useSettingsStore.test.ts
+++ b/src/features/settings/useSettingsStore.test.ts
@@ -30,11 +30,10 @@ describe("useSettingsStore persistence", () => {
     expect(s.autoStashBeforePull).toBe(true);
   });
 
-  it("drops removed settings (signCommits, showWhitespaceInDiff) from old payloads", async () => {
+  it("drops removed settings (showWhitespaceInDiff) from old payloads", async () => {
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({
-        signCommits: true,
         showWhitespaceInDiff: true,
         pruneOnFetch: false,
       }),
@@ -44,15 +43,33 @@ describe("useSettingsStore persistence", () => {
     // Known key still honored…
     expect(s.pruneOnFetch).toBe(false);
     // …but stale keys don't leak into store state.
-    expect("signCommits" in s).toBe(false);
     expect("showWhitespaceInDiff" in s).toBe(false);
 
     // And the next persist writes a clean payload without them.
     useSettingsStore.getState().set("pruneOnFetch", true);
     const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}");
-    expect("signCommits" in raw).toBe(false);
     expect("showWhitespaceInDiff" in raw).toBe(false);
     expect(raw.pruneOnFetch).toBe(true);
+  });
+
+  // signCommits was a removed no-op setting and is now real (#61 D6), so a
+  // persisted value must be honored again rather than filtered out. An OLD
+  // payload holds a boolean, though, where the setting is now tri-state.
+  it("honors signCommits and defaults to following git config", async () => {
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().signCommits).toBe("config");
+
+    useSettingsStore.getState().set("signCommits", "always");
+    const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}");
+    expect(raw.signCommits).toBe("always");
+  });
+
+  it("falls back to following git config for a legacy boolean signCommits", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ signCommits: true }));
+    const { useSettingsStore } = await freshStore();
+    // A stale boolean is not one of the three valid modes; "config" is the safe
+    // reading, since it defers to the repository instead of forcing signing on.
+    expect(useSettingsStore.getState().signCommits).toBe("config");
   });
 
   it("set() persists the changed key", async () => {

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -499,9 +499,12 @@ export function applyDensity(density: UiDensity) {
 // STORE
 // ═════════════════════════════════════════════════════════════════════════════
 
-// Removed settings (persisted keys are dropped by load()'s known-key filter):
-// - signCommits: GPG/SSH signing needs real key plumbing; a toggle that only
-//   pretends to sign erodes trust. Re-add together with actual signing.
+// `signCommits` is back, and this time it signs. It was removed once because a
+// toggle that only pretended to sign erodes trust; the condition for re-adding
+// it was real key plumbing, which #61 D6 provides — commit_create_buffer →
+// gpg/ssh-keygen → commit_signed, with a signing failure failing the commit
+// rather than quietly producing an unsigned one. Default is "config", so the app
+// does not override a repository that already decided via commit.gpgsign.
 //
 // `ignoreWhitespaceInDiff` is the successor to the removed showWhitespaceInDiff.
 // The hunk-index desync that killed the first attempt is real (see the
@@ -519,6 +522,12 @@ interface PersistedState {
   confirmForcePush: boolean;
   autoStashBeforePull: boolean;
   addSignoff: boolean;
+  /**
+   * Whether new commits are signed (#61 D6). "config" follows commit.gpgsign
+   * from git config, which is the default so the app does not override a
+   * repository that has already made this decision.
+   */
+  signCommits: "config" | "always" | "never";
   diffContextLines: number;
   ignoreWhitespaceInDiff: boolean;
   /** Parent directory last used for Clone/Init, prefilled next time. */
@@ -551,6 +560,7 @@ const DEFAULTS: PersistedState = {
   confirmForcePush: true,
   autoStashBeforePull: true,
   addSignoff: false,
+  signCommits: "config",
   diffContextLines: 3,
   ignoreWhitespaceInDiff: false,
   lastCreateDir: "",
@@ -562,13 +572,20 @@ function load(): PersistedState {
     if (!raw) return { ...DEFAULTS };
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     // Only pick keys that still exist in the schema, so settings removed in
-    // newer versions (e.g. signCommits, showWhitespaceInDiff) don't leak
-    // stale properties into the store state.
+    // newer versions (e.g. showWhitespaceInDiff) don't leak stale properties
+    // into the store state.
     const out = { ...DEFAULTS };
     for (const key of Object.keys(DEFAULTS) as (keyof PersistedState)[]) {
       if (key in parsed) {
         (out as Record<string, unknown>)[key] = parsed[key];
       }
+    }
+    // `signCommits` was once a boolean no-op setting and is now a tri-state
+    // (#61 D6), so an old payload can carry `true`/`false` where a mode is
+    // expected. Anything that is not one of the three modes falls back to
+    // "config", which defers to the repository rather than forcing signing on.
+    if (!["config", "always", "never"].includes(out.signCommits as string)) {
+      out.signCommits = DEFAULTS.signCommits;
     }
     // Backfill logo colors for custom themes saved before the slots existed,
     // so the theme editor and CSS vars always have a value.
@@ -613,6 +630,7 @@ function snapshot(s: SettingsState): PersistedState {
     confirmForcePush: s.confirmForcePush,
     autoStashBeforePull: s.autoStashBeforePull,
     addSignoff: s.addSignoff,
+    signCommits: s.signCommits,
     diffContextLines: s.diffContextLines,
     ignoreWhitespaceInDiff: s.ignoreWhitespaceInDiff,
     lastCreateDir: s.lastCreateDir,

--- a/src/features/signing/SignatureBadge.tsx
+++ b/src/features/signing/SignatureBadge.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { PGIcon } from "@/design";
+import { verifyCommit } from "@/lib/tauri";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import type { SigState, SignatureStatus } from "@/lib/types";
+
+/** Colour + glyph + wording for each verdict. */
+const LOOK: Record<
+  SigState,
+  { icon: string; color: string; label: string } | null
+> = {
+  Good: { icon: "check", color: "var(--git-added)", label: "Signed" },
+  Bad: { icon: "warn", color: "var(--git-removed)", label: "Bad signature" },
+  UnknownKey: {
+    icon: "lock",
+    color: "var(--fg-2)",
+    label: "Signed, key unavailable",
+  },
+  Expired: { icon: "warn", color: "var(--git-modified)", label: "Signature expired" },
+  Revoked: { icon: "warn", color: "var(--git-removed)", label: "Key revoked" },
+  // Unsigned is the overwhelming majority of commits in most repos; a badge on
+  // every one of them would be noise, so it renders nothing.
+  None: null,
+};
+
+/**
+ * Signature status of one commit (#61 D6).
+ *
+ * Verifies **lazily, for this commit only** — a badge on every log row would
+ * mean a gpg/ssh-keygen process per walked commit, which fights the paginated
+ * log walk and the windowed list.
+ */
+export function SignatureBadge({ oid }: { oid: string }) {
+  const repoId = useRepoStore((s) => s.current?.id ?? null);
+  const [status, setStatus] = React.useState<SignatureStatus | null>(null);
+
+  React.useEffect(() => {
+    if (!repoId || !oid) {
+      setStatus(null);
+      return;
+    }
+    let cancelled = false;
+    setStatus(null);
+    verifyCommit(repoId, oid)
+      .then((s) => {
+        if (!cancelled) setStatus(s);
+      })
+      .catch(() => {
+        // A verification failure is not worth an error banner: the commit and
+        // its diff are still perfectly viewable.
+        if (!cancelled) setStatus(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repoId, oid]);
+
+  const look = status ? LOOK[status.state] : null;
+  if (!look) return null;
+
+  const title = [look.label, status?.signer, status?.key]
+    .filter(Boolean)
+    .join(" — ");
+
+  return (
+    <span
+      data-testid="signature-badge"
+      title={title}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        flexShrink: 0,
+        color: look.color,
+        fontSize: "var(--fs-10)",
+      }}
+    >
+      <PGIcon name={look.icon} size={11} />
+      {look.label}
+    </span>
+  );
+}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -15,8 +15,22 @@ export type AppError =
   | { kind: "NoSignature"; message?: string }
   | { kind: "Internal"; message: string }
   | { kind: "Network"; message: string }
+  /**
+   * The remote needs credentials (#61 D5). Distinct from `Network` so the UI can
+   * prompt and retry. Carries no secret and no raw git stderr.
+   */
+  | { kind: "Auth"; message: AuthChallenge }
   | { kind: "EmbeddedRepo"; message: string }
   | { kind: "DubiousOwnership"; message: string };
+
+/** Which credential the remote is asking for. */
+export type AuthKind = "Https" | "SshPassphrase" | "SshKey";
+
+export interface AuthChallenge {
+  /** Host the credential is for, when git's stderr named one. */
+  host: string | null;
+  kind: AuthKind;
+}
 
 export function isAppError(e: unknown): e is AppError {
   return (
@@ -29,10 +43,26 @@ export function isAppError(e: unknown): e is AppError {
 
 export function appErrorMessage(e: unknown): string {
   if (isAppError(e)) {
+    // Auth's payload is structured, not a sentence — render it here rather than
+    // letting an object reach the UI as "[object Object]".
+    if (e.kind === "Auth") return authChallengeMessage(e.message);
     return e.message ?? e.kind;
   }
   if (e instanceof Error) return e.message;
   return String(e);
+}
+
+/** One-line description of an auth challenge, for banners and fallbacks. */
+export function authChallengeMessage(c: AuthChallenge): string {
+  const where = c.host ? ` for ${c.host}` : "";
+  switch (c.kind) {
+    case "SshPassphrase":
+      return `SSH key passphrase required${where}.`;
+    case "SshKey":
+      return `The server rejected the SSH key${where}.`;
+    default:
+      return `Authentication required${where}.`;
+  }
 }
 
 export function isEmbeddedRepoError(e: unknown): boolean {
@@ -46,6 +76,13 @@ export function isEmbeddedRepoError(e: unknown): boolean {
  */
 export function isDubiousOwnershipError(e: unknown): boolean {
   return isAppError(e) && e.kind === "DubiousOwnership";
+}
+
+/** Narrow to an auth failure, so a caller can prompt and retry (#61 D5). */
+export function isAuthError(
+  e: unknown,
+): e is Extract<AppError, { kind: "Auth" }> {
+  return isAppError(e) && e.kind === "Auth";
 }
 
 /**

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -22,6 +22,7 @@ import type {
   ReflogEntry,
   RemoteInfo,
   RepoHandle,
+  SignatureStatus,
   RepoState,
   StashInfo,
   TagInfo,
@@ -277,6 +278,11 @@ export async function commit(
   signoff = false,
   /** "Commit as" — omit to use the repo config identity. */
   authorOverride: AuthorOverride | null = null,
+  /**
+   * Sign this commit (#61 D6). `null`/omitted follows `commit.gpgsign` from git
+   * config; `true`/`false` overrides it for this commit.
+   */
+  sign: boolean | null = null,
 ): Promise<string> {
   return invoke<string>("commit", {
     repoId,
@@ -284,7 +290,22 @@ export async function commit(
     amend,
     signoff,
     authorOverride,
+    sign,
   });
+}
+
+/**
+ * Signature status of ONE commit (#61 D6).
+ *
+ * Lazy and per-selection by design: a badge on every log row would mean a
+ * gpg/ssh-keygen process per walked commit, which fights the paginated log and
+ * the windowed list.
+ */
+export async function verifyCommit(
+  repoId: string,
+  oid: string,
+): Promise<SignatureStatus> {
+  return invoke<SignatureStatus>("verify_commit", { repoId, oid });
 }
 
 export async function discardPaths(repoId: string, paths: string[]): Promise<void> {
@@ -521,17 +542,47 @@ export async function stashBranch(
 // ─── Network operations ──────────────────────────────────────────────────────
 
 /** Fetch a single remote, pruning deleted remote refs. */
+/**
+ * A credential supplied for ONE retry of a network op (#61 D5).
+ *
+ * `username` is absent for an SSH passphrase, which has none. Nothing is
+ * persisted by the app: "remember" hands the credential to git's own configured
+ * credential helper.
+ */
+export interface Credentials {
+  username?: string;
+  secret: string;
+}
+
+/**
+ * Store a credential with git's own configured credential helper. Called only
+ * after the credential has actually worked — storing on submit would persist a
+ * typo.
+ */
+export async function rememberCredential(
+  repoId: string,
+  host: string,
+  credentials: Credentials,
+): Promise<void> {
+  return invoke<void>("remember_credential", { repoId, host, credentials });
+}
+
 export async function fetch(
   repoId: string,
   remote: string,
   prune = true,
+  credentials?: Credentials,
 ): Promise<void> {
-  return invoke<void>("fetch", { repoId, remote, prune });
+  return invoke<void>("fetch", { repoId, remote, prune, credentials });
 }
 
 /** Fetch all remotes, pruning deleted remote refs. */
-export async function fetchAll(repoId: string, prune = true): Promise<void> {
-  return invoke<void>("fetch_all", { repoId, prune });
+export async function fetchAll(
+  repoId: string,
+  prune = true,
+  credentials?: Credentials,
+): Promise<void> {
+  return invoke<void>("fetch_all", { repoId, prune, credentials });
 }
 
 /**
@@ -545,8 +596,9 @@ export async function pull(
   remote: string,
   branch: string,
   mode: PullMode = "Merge",
+  credentials?: Credentials,
 ): Promise<void> {
-  return invoke<void>("pull", { repoId, remote, branch, mode });
+  return invoke<void>("pull", { repoId, remote, branch, mode, credentials });
 }
 
 /**
@@ -559,8 +611,9 @@ export async function push(
   remote: string,
   branch: string,
   force: PushForce = "None",
+  credentials?: Credentials,
 ): Promise<void> {
-  return invoke<void>("push", { repoId, remote, branch, force });
+  return invoke<void>("push", { repoId, remote, branch, force, credentials });
 }
 
 // ─── Remote management ───────────────────────────────────────────────────────
@@ -756,11 +809,13 @@ export async function cloneRepo(
   parentDir: string,
   name: string,
   recurseSubmodules: boolean,
+  credentials?: Credentials,
 ): Promise<string> {
   return invoke<string>("clone_repo", {
     url,
     parentDir,
     name,
     recurseSubmodules,
+    credentials,
   });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -90,6 +90,22 @@ export interface LogFilter {
   contentRegex?: boolean;
 }
 
+/** Verification verdict for one commit's signature (#61 D6). */
+export type SigState =
+  | "Good"
+  | "Bad"
+  | "UnknownKey"
+  | "Expired"
+  | "Revoked"
+  | "None";
+
+export interface SignatureStatus {
+  state: SigState;
+  /** Who signed it, when git could tell. */
+  signer: string | null;
+  key: string | null;
+}
+
 export interface BranchInfo {
   name: string;
   isHead: boolean;

--- a/src/screens/CommitDiff.tsx
+++ b/src/screens/CommitDiff.tsx
@@ -102,6 +102,9 @@ export function CommitDiffScreen() {
         emptyLabel={
           target.kind === "commit-self" ? "No changes in this commit." : "No changes."
         }
+        // Only a single commit has a signature — a range or a commit-vs-worktree
+        // comparison does not (#61 D6).
+        verifyOid={target.kind === "commit-self" ? target.oid : undefined}
       />
     </div>
   );

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -93,6 +93,13 @@ export function CommitPanelScreen() {
   const [amend, setAmend] = React.useState(false);
   // Sign-off toggle seeds from the persisted preference; toggling it writes back.
   const [signoff, setSignoff] = React.useState(addSignoff);
+  // Signing (#61 D6). null = follow the setting, which itself defaults to
+  // following commit.gpgsign; a per-commit toggle overrides just this commit.
+  const [signOverride, setSignOverride] = React.useState<boolean | null>(null);
+  const signSetting = useSettingsStore((s) => s.signCommits);
+  const signForCommit =
+    signOverride ??
+    (signSetting === "always" ? true : signSetting === "never" ? false : null);
   // Attribution (#61 D1). Blank author = repo config identity, the normal case.
   const [authorAs, setAuthorAs] = React.useState("");
   const [coAuthors, setCoAuthors] = React.useState("");
@@ -530,11 +537,20 @@ export function CommitPanelScreen() {
     committingRef.current = true;
     try {
       const full = buildMessage(message, body, coAuthorTrailers(coAuthors));
-      const oid = await commitAction(full, amend, signoff, authorIdentity);
+      const oid = await commitAction(
+        full,
+        amend,
+        signoff,
+        authorIdentity,
+        signForCommit,
+      );
       if (oid) {
         setMessage("");
         setBody("");
         setAmend(false);
+        // Per-commit signing override is not sticky: it is an override, and
+        // carrying it silently into the next commit would surprise.
+        setSignOverride(null);
         // Attribution is sticky: pairing usually spans several commits, so
         // clearing it after each one would mean retyping every time.
       }
@@ -1025,6 +1041,26 @@ export function CommitPanelScreen() {
                 setSetting("addSignoff", v);
               }}
               label="Add Signed-off-by trailer"
+            />
+            {/*
+              Signing (#61 D6), three states rather than two. Indeterminate is
+              "follow commit.gpgsign", which the frontend cannot read — showing
+              it as plain unchecked would claim the commit is unsigned in a repo
+              that has signing on. Checked/unchecked force it for this commit
+              only. A signing failure fails the commit; it never silently
+              produces an unsigned one.
+            */}
+            <PGCheckbox
+              checked={signForCommit === true}
+              indeterminate={signForCommit === null}
+              onChange={(v) => setSignOverride(v)}
+              label={
+                signForCommit === null
+                  ? "Sign this commit — following git config"
+                  : signForCommit
+                    ? "Sign this commit"
+                    : "Don't sign this commit"
+              }
             />
           </div>
 

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -650,6 +650,9 @@ export function HistoryScreen() {
       error={inlineError}
       header={diffHeader}
       paneIdPrefix="history.diff"
+      // The inline panel shows the selected commit's own diff; a multi-selection
+      // renders MultiCommitDetail instead, so this is always one commit (#61 D6).
+      verifyOid={current?.oid}
     />
   );
 

--- a/src/screens/Reflog.tsx
+++ b/src/screens/Reflog.tsx
@@ -18,6 +18,7 @@ import {
   type DirtyChoice,
 } from "@/features/reflog/DirtyTreeDialog";
 import { relativeTime } from "@/lib/derive";
+import { appErrorMessage } from "@/lib/errors";
 import { PGPane, FocusableScroll, usePaneList } from "@/features/keymap";
 import type { FileDiff, ReflogOp } from "@/lib/types";
 
@@ -191,7 +192,7 @@ export function ReflogScreen() {
           }}
         >
           <strong>{error.kind}:</strong>
-          <span style={{ flex: 1 }}>{error.message ?? error.kind}</span>
+          <span style={{ flex: 1 }}>{appErrorMessage(error)}</span>
           <button
             onClick={clearError}
             style={{

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -186,6 +186,23 @@ export function SettingsScreen() {
               />
             }
           />
+          <Row
+            label="Sign commits"
+            hint="Uses gpg.format, user.signingkey and gpg.program. Following git config respects commit.gpgsign per repository; a signing failure fails the commit rather than producing an unsigned one."
+            control={
+              <PGSelect
+                value={s.signCommits}
+                onChange={(v) =>
+                  s.set("signCommits", v as "config" | "always" | "never")
+                }
+                options={[
+                  { value: "config", label: "Follow git config" },
+                  { value: "always", label: "Always" },
+                  { value: "never", label: "Never" },
+                ]}
+              />
+            }
+          />
         </Section>
 
         <Section title="Diff" subtitle="How diffs are rendered across the app.">


### PR DESCRIPTION
Final slice of #61 Tier 2. **Stacked on #87** (which is stacked on #86), so this diff shows only PR 3's changes. Retarget to `main` as the stack merges.

Plan: `docs/superpowers/plans/2026-08-13-issue-61-tier2-pr3-credentials-signing.md`

## D5 — authenticated remotes work

Previously fetch/pull/push/clone ran with prompts hard-disabled, so any remote needing authentication failed with git's stderr and no way to answer it. This was the one item on #61 where the app genuinely did not work rather than merely looking unfinished.

**Retry on failure, not prompt during the run.** The first attempt is still prompt-less, so the common case — a credential helper or ssh-agent already answers — behaves byte-for-byte as before. On failure, stderr is classified into `AppError::Auth { host, kind }`, the UI collects a credential, and the *same op* is retried with an askpass that already knows the answer. No IPC between a git subprocess and the window, no half-blocked operation.

**The askpass is our own executable, selected by an env var.** `GIT_ASKPASS` is exec'd directly, **not** run through a shell — I verified this rather than assuming: `GIT_ASKPASS="<exe> --askpass"` fails with `cannot exec '<exe> --askpass'`. The alternatives were writing a wrapper script to disk or installing an argv[0] symlink; both need a writable directory and add one more thing an attacker could replace before we exec it. An env flag needs neither, so `GIT_ASKPASS` points at the bare binary.

**Host-key verification is deliberately NOT an auth failure.** No credential the user can type fixes an unknown host key, so it stays a `Network` error rather than opening a password prompt that cannot help.

**We store nothing.** "Remember" calls `git credential approve`, handing the value to whichever helper the user already has configured — and only *after* the credential worked, so a typo is never persisted. The secret lives in the dialog's component state and never enters the Zustand store (asserted by a test), so it can't be picked up by a devtools snapshot or a future persistence middleware.

**One runner.** The env policy was duplicated across `branches.rs` and `create.rs`; both now go through `commands/net.rs`, which is also the single place failures are classified. Clone keeps its own streaming-progress handling.

## D6 — commits can be signed and verified

`commit_create_buffer` → `gpg`/`ssh-keygen` → `commit_signed`, dispatching on `gpg.format` (`openpgp` / `ssh`; `x509` is a clean unsupported error).

**The trap, and why there is a test for it:** `commit_signed` only writes the object. Unlike `repo.commit(Some("HEAD"), …)` and `Commit::amend(Some("HEAD"), …)`, it moves no reference — so the signed path updates the branch and writes its own reflog entry. A signed commit left on no branch is indistinguishable from lost work, so the test asserts reachability from HEAD with the parent intact, and for an amend that it inherits HEAD's *parents* rather than chaining onto the commit it replaces.

**A signing failure fails the commit.** Falling back to unsigned would leave the user believing they had signed it. Also asserted.

**Verification is lazy and per-selection**, reusing git's own trust evaluation via `%G?`/`%GS`/`%GK`. A badge on every log row would mean one gpg process per walked commit, fighting #81's pagination and #80's windowed list. The composer's control is **tri-state**: indeterminate means "follow `commit.gpgsign`", which the frontend cannot read — showing that as unchecked would claim a commit is unsigned in a repo that has signing on.

The Settings toggle returns after having been removed as a no-op; the stated condition for re-adding it was real key plumbing, which now exists.

## Security review findings — found and fixed on this branch

1. **Credential disclosure (Medium).** `scrub_credentials` split URL userinfo on the *first* `@`, so a password containing `@` partially survived into error banners and the log file: `https://***@ssw0rd@github.com/…`. Userinfo ends at the *last* `@`. Regression test written first; it failed before the fix.
2. **git credential-protocol injection (Medium).** `credential_approve` interpolated host/username/secret into git's line-based `key=value` protocol unescaped; a newline injects further keys, so `x\nhost=evil.example` would store the password against another host. Newlines are now refused rather than escaped.
3. **Argument injection (Low).** `verify_commit` passed its oid straight to `git show`, which reads a leading `-` as an option. Now hex-validated at the boundary.

Considered and not flagged: `gpg.program` from repo config (identical to git's own trust model, and gated by the existing dubious-ownership check); the secret in the git child's environment (a hook already has code execution and could read the credential from the helper anyway).

## Deliberately not included

- **`push_tag` / `push_delete_branch` still run credential-less.** They are pushes too and should be threaded next; they were out of the four sites the spec named.
- **Per-remote SSH key selection** — out of scope per the spec.
- **`user.signingkey` as a literal `key::` value** — rejected with a clear message rather than writing key material to a temp file behind the user's back.
- **No e2e for the auth path** — it would need a real authenticated remote. `remote.e2e.ts` covers the file-remote happy path.

## Verification

- `pnpm tsc --noEmit` ✓ · `pnpm exec tsc -p e2e/tsconfig.json --noEmit` ✓ · `pnpm vite build` ✓
- `pnpm test` — **698 passing** (87 files), 12 new: 10 credential-dialog (host shown, retry payload, remember flag, SSH asks no username, dismissal doesn't retry, empty secret can't submit, masking, and **the secret never entering the store**), 2 settings migration.
- `cargo test` — **35/35 test binaries green**, 33 new: 13 auth classification + scrubbing (incl. host-key staying `Network`, and the `@`-in-password regression), 7 askpass shim (incl. refusing an unrecognized prompt and a prompt containing `-h`), 9 env/failure-mapping (incl. **credentials absent from argv**), 9 signing config + `%G?` parsing, and 11 signing integration (real ssh key generated in-test, HEAD reachability, amend parents, reflog, failure-doesn't-move-HEAD, oid validation).
- E2E in Docker, affected specs: `remote` (10) + `commit` (1) + `create` (2) — **13 passing**, WebKitGTK, snapshot rebuilt first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)