### PR TITLE
fix(site): describe the hero logo with alt text

### DIFF
--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -6,6 +6,9 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 <header class="nav">
   <div class="container nav-inner">
     <a class="brand" href={base + '/'}>
+      {/* alt="" is deliberate: the link's own text already reads "platypusgit",
+          so captioning the logo would make screen readers announce the name
+          twice. Decorative-by-redundancy is the correct treatment here. */}
       <img src={base + '/logo.svg'} alt="" width="28" height="28" />
       <span class="brand-name mono">platypusgit</span>
       <span class="alpha mono">alpha</span>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -20,7 +20,13 @@ const comingSoon = downloads.filter((d) => !d.available);
   <section class="hero">
     <div class="container hero-inner">
       <div class="brand-lockup">
-        <img class="brand-logo" src={base + '/logo.svg'} alt="" width="92" height="92" />
+        <img
+          class="brand-logo"
+          src={base + '/logo.svg'}
+          alt="The platypusgit logo — a stylized platypus head"
+          width="92"
+          height="92"
+        />
         <span class="brand-word mono">platypusgit</span>
       </div>
       <h1 class="hero-title">Free, open source git.<br />Built for developers.</h1>


### PR DESCRIPTION
Addresses an SEO audit finding: *"Alt attribute for images is missing — 1 instance found."*

## What was actually wrong

No `<img>` on the site is missing the `alt` attribute — every one has it. Two carried `alt=""`:

| image | context | verdict |
|---|---|---|
| hero logo (`index.astro`) | standalone in `.brand-lockup` | **flagged** — fixed here |
| nav logo (`Nav.astro`) | inside `<a class="brand">` whose text reads "platypusgit" | correct as-is, left alone |

The hero logo is the one image on the site that stands on its own, so it now carries
`alt="The platypusgit logo — a stylized platypus head"`.

## Why the nav logo keeps `alt=""`

Its link already contains the text "platypusgit". Captioning the image would give the
link the accessible name *"platypusgit logo platypusgit alpha"* — a screen reader would
announce the brand twice. An empty `alt` is the [correct treatment for an image that is
redundant with adjacent text](https://www.w3.org/WAI/tutorials/images/decorative/), not
an oversight. Added an inline comment so a future audit doesn't "fix" it into a
regression.

If the audit tool flags that one too on a re-run, it's a false positive — the fix would
make accessibility worse, not better.

## Verification

`pnpm build` green. Against `dist/`:

- homepage: hero logo captioned, nav logo `alt=""`, shields badge `alt="GitHub stars"`
- other four pages: nav logo `alt=""` only
- zero `<img>` tags anywhere with no `alt` attribute at all
