### PR TITLE
ci(e2e): split the suite behind an always-reporting gate job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  e2e-linux:
+  # Decides whether the suite is worth running for this PR. Site- and docs-only
+  # changes cannot affect the app binary, so they skip a ~10 minute build.
+  #
+  # The filter runs for pull_request events only. On push and workflow_dispatch
+  # there is no reliable diff base, so `app` falls back to 'true' (a skipped
+  # step has no outputs, and the `||` picks up the empty string) and the full
+  # suite runs — main is never left untested.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.filter.outputs.app || 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: filter
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
+          echo "Changed files:"
+          echo "$changed" | sed 's/^/  /'
+          if echo "$changed" | grep -qE '^(src/|src-tauri/|e2e/|index\.html$|package\.json$|pnpm-lock\.yaml$|vite\.config\.ts$|tsconfig[a-z.]*\.json$|\.github/workflows/e2e\.yml$)'; then
+            echo "app=true" >> "$GITHUB_OUTPUT"
+            echo "-> app code touched, running the E2E suite"
+          else
+            echo "app=false" >> "$GITHUB_OUTPUT"
+            echo "-> no app code touched, skipping the E2E suite"
+          fi
+
+  e2e:
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -53,3 +87,23 @@ jobs:
 
       - name: Run E2E
         run: xvfb-run --auto-servernum pnpm test:e2e:run
+
+  # The required status check on main. It always runs and always reports, so a
+  # PR that skipped the suite is not left waiting forever on a check that never
+  # arrives — the trap that makes a path-filtered required check block a PR
+  # permanently. Keep this job's name in sync with the branch ruleset.
+  e2e-linux:
+    needs: [changes, e2e]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gate on the E2E result
+        env:
+          RESULT: ${{ needs.e2e.result }}
+        run: |
+          echo "E2E job result: $RESULT"
+          case "$RESULT" in
+            success) echo "E2E suite passed." ;;
+            skipped) echo "No app code touched — E2E suite not required for this change." ;;
+            *)       echo "E2E suite did not pass."; exit 1 ;;
+          esac


### PR DESCRIPTION
Groundwork for making GitHub auto-merge actually *schedule* a merge.

## Why

`gh pr merge --auto` only queues when something is blocking the PR. `main` currently has
no required status checks (its ruleset has `deletion`, `non_fast_forward`, `pull_request`
only), so every PR is immediately mergeable and `--auto` merges on the spot — checks still
running. Making `e2e-linux` a required check fixes that, but naively path-filtering it
would create a worse problem.

## The trap this avoids

If a required check lives in a workflow that's filtered out by `paths:`, the check never
reports and GitHub blocks the PR forever on *"Expected — Waiting for status to be
reported."* So the filtering happens at the **job** level, behind a gate job that always
reports.

## Shape

| job | when | cost |
|---|---|---|
| `changes` | always | ~10s — decides whether the PR touches app code |
| `e2e` | only when app code changed | the real ~10 min suite |
| `e2e-linux` | **always** (`if: always()`) | ~5s — fails only if `e2e` failed |

`e2e-linux` is the name to mark required. A site- or docs-only PR gets a green
`e2e-linux` in seconds; anything touching `src/`, `src-tauri/`, `e2e/`, or the root build
files runs the full suite.

Push and `workflow_dispatch` have no reliable diff base, so `app` falls back to `'true'`
there and the full suite runs — `main` is never left untested.

## Verification

- YAML parses; job graph is `changes` -> `e2e` -> `e2e-linux`.
- The path regex was exercised against realistic file sets, all matching expectations:

| changed files | `app` |
|---|---|
| `site/src/pages/index.astro` (PR #95) | `false` |
| `docs/`, `README.md`, `CLAUDE.md` | `false` |
| `site/package.json` | `false` (must not match root) |
| `src/features/repo/useRepoStore.ts` | `true` |
| `src-tauri/src/git/libgit2.rs` | `true` |
| `e2e/specs/rebase.e2e.ts` | `true` |
| `package.json`, `tsconfig.node.json` | `true` |
| `.github/workflows/e2e.yml` | `true` |

This PR touches the workflow itself, so it takes the `app=true` path and runs the full
suite against itself.

## Follow-up, not done here

`e2e/specs/rebase.e2e.ts:35` ("squashes HEAD into its parent from the history menu") is
currently flaky on `main` — it failed the runs for #85 and #95 and passed for #88 and #89,
with the same assertion each time. Marking `e2e-linux` required while that flake exists
would intermittently block app PRs, so it's worth fixing before or shortly after flipping
the ruleset.
