### PR TITLE
fix(e2e): wait for rebase completion, not an ambiguous commit count

### DIFF
--- a/e2e/specs/rebase.e2e.ts
+++ b/e2e/specs/rebase.e2e.ts
@@ -28,10 +28,19 @@ describe("interactive rebase", () => {
       timeout: 15_000, timeoutMsg: "rebase plan never appeared",
     });
     await $('[data-testid="rebase-start"]').click();
-    await browser.waitUntil(
-      async () => repo.git("rev-list", "--count", "HEAD").trim() === "2",
-      { timeout: 20_000, timeoutMsg: "squash rebase did not complete" },
-    ); // repo-truth wait: completion has no single UI signal
+    // Wait on the UI's completion signal, NOT on `rev-list --count HEAD === 2`.
+    // The plan replays as pick "feat: add b.txt" then squash "fix: update
+    // a.txt", so HEAD's commit count returns to 2 TWICE: once transiently when
+    // the pick lands (message still "feat: add b.txt"), and again once the
+    // squash rewrites the message. A count-based wait returns at whichever it
+    // polls first, and under CI load that was the intermediate state — the
+    // message assertion then read "feat: add b.txt" and the spec failed.
+    // rebase-last-summary renders only when the rebase is done and the plan is
+    // cleared, so it cannot match mid-replay.
+    await $('[data-testid="rebase-last-summary"]').waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "squash rebase never reported completion",
+    });
+    expect(repo.git("rev-list", "--count", "HEAD").trim()).toBe("2");
     expect(repo.git("log", "-1", "--pretty=%B")).toContain("squashed by e2e");
     expect(repo.git("status", "--porcelain").trim()).toBe("");
   });


### PR DESCRIPTION
Fixes the `rebase.e2e.ts` flake that has been failing CI intermittently — the blocker for
marking `e2e-linux` a required status check (#96).

## Root cause

`basicRepo` builds main as `feat: add a.txt` -> `feat: add b.txt` -> `fix: update a.txt`.
"Squash this commit into its parent" on HEAD produces the plan:

```
pick    feat: add b.txt
squash  fix: update a.txt
```

`rebase_start` resets HEAD to the parent of the first surviving pick, then replays. So
`rev-list --count HEAD` returns to **2 twice**:

| moment | count | `log -1 --pretty=%B` |
|---|---|---|
| after reset | 1 | `feat: add a.txt` |
| **after the pick lands** | **2** | **`feat: add b.txt`** |
| after the squash rewrites the message | 2 | `squashed by e2e` |

The spec waited on `rev-list --count HEAD === "2"` and asserted the message on the very
next line. Under CI load the poll landed in the middle row, producing exactly the observed
failure:

```
Error: expect(received).toContain(expected)
Expected substring: "squashed by e2e"
Received string:    "feat: add b.txt"
   at e2e/specs/rebase.e2e.ts:35:50
```

Same assertion failed the runs for #85 and #95, and passed for #88 and #89 — a race, not a
regression. This is a test bug; the app behaved correctly every time.

## Fix

Wait on `[data-testid="rebase-last-summary"]`, which renders only when
`!rebaseStatus.inProgress && lastRebaseSummary && plan.length === 0`. Traced the path:
`handleStart` -> `rebaseStart` (sets `lastRebaseSummary` since the returned status is not
in-progress) -> `setPlan([])`. It cannot match mid-replay. The commit count stays as an
assertion rather than a wait condition, which matches the suite's assertion contract: UI
signal to wait, repo truth to accept.

The spec's old comment asserted that completion had no single UI signal. It does — removed.

## Verification

- `pnpm exec tsc -p e2e/tsconfig.json --noEmit` clean.
- `pnpm test:e2e:docker full --spec e2e/specs/rebase.e2e.ts` — both specs pass, including
  `aborting a conflicted rebase restores HEAD`.
- Re-ran the spec 5 more times against the same snapshot: **5 passed, 0 failed**.

Caveat worth stating: local Docker runs don't reproduce the CI load that surfaced the race,
so the repeat greens are supporting evidence rather than proof. The primary evidence is
structural — the old wait had a provably ambiguous condition, the new one is only reachable
after the rebase finishes.
