### PR TITLE
feat(diff): make the commit-diff changed-files column resizable

### DIFF
--- a/src/design/resizable.tsx
+++ b/src/design/resizable.tsx
@@ -10,10 +10,13 @@ export function PGResizeHandle({
   onActiveChange,
   side = "right",
   orientation = "horizontal",
+  testId,
 }: {
   onDrag: (deltaPx: number) => void;
   /** Called when the drag starts/stops. Useful to suspend CSS transitions. */
   onActiveChange?: (active: boolean) => void;
+  /** `data-testid` for the handle — the drag target has no text to query by. */
+  testId?: string;
   /** Which side of the owning pane the handle sits on. Affects cursor only. */
   side?: "left" | "right" | "top" | "bottom";
   /**
@@ -53,6 +56,7 @@ export function PGResizeHandle({
 
   return (
     <div
+      data-testid={testId}
       onMouseDown={(e) => {
         e.preventDefault();
         start.current = vertical ? e.clientY : e.clientX;

--- a/src/features/diff/CommitDiffPanel.resize.test.tsx
+++ b/src/features/diff/CommitDiffPanel.resize.test.tsx
@@ -1,0 +1,78 @@
+// The changed-files column is draggable, and each mount site remembers its own
+// width (History's bottom panel is wide and short; the full-screen commit diff
+// is not, so one shared width would fit neither).
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { CommitDiffPanel } from "./CommitDiffPanel";
+
+const props = {
+  diffs: [],
+  error: null,
+  loading: false,
+  header: "abc1234 → HEAD",
+};
+
+const filesPane = (container: HTMLElement, prefix: string) =>
+  container.querySelector<HTMLElement>(`[data-pg-pane="${prefix}.files"]`)!;
+
+/** Drag the files/diff splitter by `dx` px. */
+const drag = (handle: HTMLElement, dx: number) => {
+  fireEvent.mouseDown(handle, { clientX: 100 });
+  fireEvent.mouseMove(document, { clientX: 100 + dx });
+  fireEvent.mouseUp(document);
+};
+
+describe("CommitDiffPanel files column resize", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("widens the changed-files column when the handle is dragged right", () => {
+    const { container, getByTestId } = render(
+      <CommitDiffPanel {...props} paneIdPrefix="history.diff" />,
+    );
+    expect(filesPane(container, "history.diff").style.width).toBe("240px");
+
+    drag(getByTestId("history.diff-files-resize"), 80);
+
+    expect(filesPane(container, "history.diff").style.width).toBe("320px");
+  });
+
+  it("stops at the minimum width instead of collapsing the column", () => {
+    const { container, getByTestId } = render(
+      <CommitDiffPanel {...props} paneIdPrefix="history.diff" />,
+    );
+
+    drag(getByTestId("history.diff-files-resize"), -400);
+
+    expect(filesPane(container, "history.diff").style.width).toBe("140px");
+  });
+
+  it("caps the column relative to the panel so the diff can't be pushed out", () => {
+    // The column never shrinks (flexShrink: 0), so in the narrow side-by-side
+    // History layout an unbounded drag would overflow the detail pane.
+    const { container, getByTestId } = render(
+      <CommitDiffPanel {...props} paneIdPrefix="history.diff" />,
+    );
+
+    drag(getByTestId("history.diff-files-resize"), 1000);
+
+    expect(filesPane(container, "history.diff").style.maxWidth).toBe("60%");
+  });
+
+  it("restores the dragged width on remount, per mount site", () => {
+    const first = render(
+      <CommitDiffPanel {...props} paneIdPrefix="history.diff" />,
+    );
+    drag(first.getByTestId("history.diff-files-resize"), 60);
+    first.unmount();
+
+    const again = render(
+      <CommitDiffPanel {...props} paneIdPrefix="history.diff" />,
+    );
+    expect(filesPane(again.container, "history.diff").style.width).toBe("300px");
+    again.unmount();
+
+    const other = render(<CommitDiffPanel {...props} paneIdPrefix="commitDiff" />);
+    expect(filesPane(other.container, "commitDiff").style.width).toBe("240px");
+  });
+});

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { PGIcon, PGSkeleton } from "@/design";
+import { PGIcon, PGResizeHandle, PGSkeleton, usePaneWidth } from "@/design";
 import { PGPane, FocusableScroll, usePaneList, useHunkNav } from "@/features/keymap";
 import { fileIconSpec } from "@/lib/fileIcon";
 import { WhitespaceToggle } from "./WhitespaceToggle";
@@ -79,12 +79,24 @@ export function CommitDiffPanel({
     resetKey: selected,
   });
 
+  // Per mount site: History's bottom panel is wide and short, the full-screen
+  // commit diff is not, so one shared width would fit neither.
+  const filesPane = usePaneWidth(240, {
+    min: 140,
+    max: 640,
+    storageKey: `pg-${paneIdPrefix.replace(/\./g, "-")}-files-w`,
+  });
+
   return (
     <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
       <PGPane
         id={filesPaneId}
         style={{
-          width: 240,
+          width: filesPane.width,
+          // The column never shrinks, so cap it against the panel: in the
+          // narrow side-by-side History layout a wide drag would otherwise
+          // push the diff out of the detail pane entirely.
+          maxWidth: "60%",
           flexShrink: 0,
           borderRight: "1px solid var(--border-0)",
           fontFamily: "var(--font-mono)",
@@ -206,6 +218,11 @@ export function CommitDiffPanel({
           })}
         </FocusableScroll>
       </PGPane>
+      <PGResizeHandle
+        side="right"
+        testId={`${paneIdPrefix}-files-resize`}
+        onDrag={(d) => filesPane.resize(d)}
+      />
       <PGPane
         id={viewPaneId}
         style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column" }}


### PR DESCRIPTION
The changed-files column beside a commit diff was pinned at `240px`. In History's bottom detail panel that made the file names the one thing you couldn't trade space for — the message/diff splitter was already draggable, the file list was not.

## What changed

- `CommitDiffPanel` drives its files column through `usePaneWidth` and renders a `PGResizeHandle` between the files pane and the diff pane.
- Width persists **per mount site** (`pg-history-diff-files-w`, `pg-commitDiff-files-w`). History's inline panel is wide and short, the full-screen commit diff is not — one shared width would fit neither.
- Range 140–640px, plus a `maxWidth: 60%` cap: the column keeps `flexShrink: 0` so a drag lands exactly where released, and the cap stops a wide drag from pushing the diff out of the narrow side-by-side layout.
- `PGResizeHandle` gained an optional `testId` — the drag target has no text to query by.

Both mount sites (History inline panel + full-screen commit diff) get the behavior.

## Testing

- `src/features/diff/CommitDiffPanel.resize.test.tsx` — drag widens the column, min-width clamp, panel-relative cap, and per-mount-site persistence across remount. Written first, watched fail, then implemented.
- `pnpm test` — 679 passing (87 files).
- `pnpm tsc --noEmit` — clean.
- `pnpm test:e2e:docker full --spec history-diff --spec keymap --spec keyboard-shortcuts` — 3 spec files, 31 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
