### PR TITLE
feat(commit): one message box, and amend loads the previous message

### DIFF
--- a/e2e/specs/commit.e2e.ts
+++ b/e2e/specs/commit.e2e.ts
@@ -30,12 +30,12 @@ describe("commit", () => {
       }
     );
 
-    const subjectInput = $('[data-testid="commit-subject"]');
-    await subjectInput.waitForDisplayed({
+    const messageBox = $('[data-testid="commit-message"]');
+    await messageBox.waitForDisplayed({
       timeout: 10_000,
-      timeoutMsg: "commit subject input never appeared",
+      timeoutMsg: "commit message box never appeared",
     });
-    await subjectInput.setValue("feat: e2e commit");
+    await messageBox.setValue("feat: e2e commit");
 
     const commitBtn = $('[data-testid="commit-button"]');
     await commitBtn.waitForDisplayed({
@@ -56,5 +56,41 @@ describe("commit", () => {
       "feat: e2e commit"
     );
     expect(repo.git("status", "--porcelain").trim()).toBe("");
+  });
+
+  it("amends the last commit's message from a clean tree", async () => {
+    await $("button*=Stage all").click();
+    await browser.waitUntil(
+      async () => !(await $('[data-testid="changes-list"] [data-path]').isExisting()),
+      { timeout: 20_000, timeoutMsg: "changes list should be empty after staging all" },
+    );
+    await $('[data-testid="commit-message"]').setValue("feat: typo in mesage");
+    await $('[data-testid="commit-button"]').click();
+    await $("div*=Working tree clean").waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "commit panel did not return to clean state",
+    });
+    const commitsBefore = repo.git("rev-list", "--count", "HEAD").trim();
+
+    // The clean-tree state is where a just-typed message gets fixed, so amend
+    // is reachable from it — and it arrives prefilled with HEAD's message.
+    await $('[data-testid="amend-last-commit"]').click();
+    const messageBox = $('[data-testid="commit-message"]');
+    await browser.waitUntil(
+      async () => (await messageBox.getValue()) === "feat: typo in mesage",
+      { timeout: 20_000, timeoutMsg: "amend never prefilled the previous message" },
+    );
+    await messageBox.setValue("feat: typo in message");
+    await $('[data-testid="commit-button"]').click();
+
+    await $("div*=Working tree clean").waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "commit panel did not return to clean state after amending",
+    });
+    expect(repo.git("log", "-1", "--pretty=%s").trim()).toBe(
+      "feat: typo in message",
+    );
+    // Amend rewrites, never adds — history length is the proof.
+    expect(repo.git("rev-list", "--count", "HEAD").trim()).toBe(commitsBefore);
   });
 });

--- a/e2e/specs/create.e2e.ts
+++ b/e2e/specs/create.e2e.ts
@@ -46,7 +46,7 @@ describe("clone & init", () => {
     await $('[data-testid="init-branch"]').setValue("trunk");
 
     // These are controlled React inputs (PGInput's onChange yields a plain
-    // string from a native <input>, same shape as the commit-subject and
+    // string from a native <input>, same shape as the commit-message and
     // branch-search fields other specs already drive with setValue) — but
     // the resolved-path preview only renders once the typed value actually
     // reached useState, so waiting for it here is the real proof setValue's

--- a/e2e/specs/keymap.e2e.ts
+++ b/e2e/specs/keymap.e2e.ts
@@ -17,7 +17,7 @@ import {
 } from "../support/app";
 
 const CHEAT_SHEET = "h2*=Keyboard shortcuts";
-const commitSubject = '[data-testid="commit-subject"]';
+const commitMessage = '[data-testid="commit-message"]';
 const historySelectedRow =
   '[data-pg-pane="history.list"] [data-pg-row][data-selected]';
 
@@ -100,12 +100,12 @@ describe("keymap — rider preset (default)", () => {
     repo = dirtyRepo();
     await openRepo(repo.path);
     await jsChord("Mod+K");
-    await waitScreen(commitSubject, "Commit");
+    await waitScreen(commitMessage, "Commit");
     // Bare "?" aimed at a text input must be swallowed by the input policy.
     // The cheat sheet is a TOGGLE: if this dispatch wrongly went through, the
     // window-level "?" below would toggle it back CLOSED and the wait fails —
     // the negative case is observable without a blind sleep.
-    await jsChord("?", { target: commitSubject });
+    await jsChord("?", { target: commitMessage });
     await jsChord("?");
     await $(CHEAT_SHEET).waitForDisplayed({
       timeout: 10_000,
@@ -121,8 +121,8 @@ describe("keymap — rider preset (default)", () => {
     repo = dirtyRepo();
     await openRepo(repo.path);
     await jsChord("Mod+K");
-    await waitScreen(commitSubject, "Commit");
-    await jsChord("Mod+9", { target: commitSubject });
+    await waitScreen(commitMessage, "Commit");
+    await jsChord("Mod+9", { target: commitMessage });
     await waitScreen('[data-pg-pane="history.list"]', "History (⌘9 from input)");
   });
 
@@ -130,8 +130,8 @@ describe("keymap — rider preset (default)", () => {
     repo = dirtyRepo();
     await openRepo(repo.path);
     await jsChord("Mod+K");
-    await waitScreen(commitSubject, "Commit");
-    await jsDoubleShift({ target: commitSubject });
+    await waitScreen(commitMessage, "Commit");
+    await jsDoubleShift({ target: commitMessage });
     await $(paletteDialog).waitForDisplayed({
       timeout: 10_000,
       timeoutMsg: "palette did not open on double-Shift from inside an input",
@@ -357,8 +357,8 @@ describe("keymap — rider preset (default)", () => {
     repo = dirtyRepo(); // staged.txt is already staged
     await openRepo(repo.path);
     await jsChord("Mod+K");
-    await waitScreen(commitSubject, "Commit");
-    await $(commitSubject).setValue("feat: committed via chord");
+    await waitScreen(commitMessage, "Commit");
+    await $(commitMessage).setValue("feat: committed via chord");
     await jsChord("Mod+Enter");
     // UI signal: the committed file leaves the staged list.
     await browser.waitUntil(
@@ -376,8 +376,8 @@ describe("keymap — rider preset (default)", () => {
     pair.repo.git("add", "chord.txt");
     await openRepo(pair.repo.path);
     await jsChord("Mod+K");
-    await waitScreen(commitSubject, "Commit");
-    await $(commitSubject).setValue("feat: commit and push chord");
+    await waitScreen(commitMessage, "Commit");
+    await $(commitMessage).setValue("feat: commit and push chord");
     await jsChord("Mod+Shift+Enter");
     // No single UI element spans commit→push completion — the bare remote's
     // log is the only end-to-end signal, so wait on repo truth.
@@ -392,19 +392,29 @@ describe("keymap — rider preset (default)", () => {
     );
   });
 
-  it("⌘⇧M toggles amend", async () => {
-    repo = dirtyRepo();
+  it("⌘⇧M toggles amend, swapping the draft for HEAD's message", async () => {
+    repo = dirtyRepo(); // HEAD is "fix: update a.txt"
     await openRepo(repo.path);
     await jsChord("Mod+K");
     await waitScreen('[data-testid="commit-button"]', "Commit");
+    await $(commitMessage).setValue("wip: draft");
     await jsChord("Mod+Shift+M");
     await $('[data-testid="commit-button"]*=Amend').waitForDisplayed({
       timeout: 10_000, timeoutMsg: "commit button never relabeled to Amend",
     });
+    await browser.waitUntil(
+      async () => (await $(commitMessage).getValue()) === "fix: update a.txt",
+      { timeout: 10_000, timeoutMsg: "amend never prefilled HEAD's message" },
+    );
     await jsChord("Mod+Shift+M");
     await $('[data-testid="commit-button"]*=Commit').waitForDisplayed({
       timeout: 10_000, timeoutMsg: "commit button never relabeled back to Commit",
     });
+    // The draft amend displaced comes back rather than being lost.
+    await browser.waitUntil(
+      async () => (await $(commitMessage).getValue()) === "wip: draft",
+      { timeout: 10_000, timeoutMsg: "draft never came back after unchecking amend" },
+    );
   });
 
   it("⌘N opens the create-branch step and creates the branch", async () => {

--- a/e2e/specs/settings.e2e.ts
+++ b/e2e/specs/settings.e2e.ts
@@ -213,9 +213,9 @@ describe("settings", () => {
     // the Settings PGToggle rows — see clickSettingsToggleRow above).
     await $("span*=Add Signed-off-by trailer").click();
     // Type message + commit, using the exact testids from commit.e2e.ts
-    // (the brief's "commit-message" was a guess; the real attribute is
-    // "commit-subject" — verified in src/screens/CommitPanel.tsx).
-    await $('[data-testid="commit-subject"]').setValue("feat: signed commit");
+    // ("commit-message" — one box holds subject and body, verified in
+    // src/screens/CommitPanel.tsx).
+    await $('[data-testid="commit-message"]').setValue("feat: signed commit");
     await $('[data-testid="commit-button"]').click();
     await browser.waitUntil(
       async () => repo!.git("log", "-1", "--pretty=%s").trim() === "feat: signed commit",

--- a/src/features/keymap/actions.test.ts
+++ b/src/features/keymap/actions.test.ts
@@ -24,7 +24,7 @@ describe("action catalog", () => {
   });
 
   it("global app actions all have default runners (or are component-handled)", () => {
-    // commit.* act on CommitPanel component state (message/body/amend), so
+    // commit.* act on CommitPanel component state (message/amend), so
     // the panel registers their handlers while mounted; elsewhere the chords
     // deliberately fall through. Every OTHER global action must have a
     // runner, or its chord is dead.

--- a/src/features/keymap/actions.ts
+++ b/src/features/keymap/actions.ts
@@ -234,7 +234,7 @@ export const ACTIONS: Record<ActionId, ActionDef> = {
   "repo.stageAll": { id: "repo.stageAll", title: "Stage all changes", category: "Repository", scope: "global", run: stageAllOp },
   "repo.unstageAll": { id: "repo.unstageAll", title: "Unstage all changes", category: "Repository", scope: "global", run: unstageAllOp },
 
-  // commit.* carry no default runners: the message/body/amend state is
+  // commit.* carry no default runners: the message/amend state is
   // CommitPanel component state, so the panel registers handlers while
   // mounted; on other screens the chords fall through.
   "commit.commit": { id: "commit.commit", title: "Commit staged changes", category: "Repository", scope: "global" },

--- a/src/screens/CommitPanel.amend.test.tsx
+++ b/src/screens/CommitPanel.amend.test.tsx
@@ -1,0 +1,154 @@
+// Amend prefill: checking "Amend previous commit" loads HEAD's message into the
+// composer so the button is usable and the old message is editable rather than
+// silently replaced by whatever was in the box.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { CommitPanelScreen } from "./CommitPanel";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import type { CommitInfo, FileStatus } from "@/lib/types";
+
+const staged = (path: string): FileStatus => ({
+  path,
+  worktree: { kind: "Unmodified" },
+  index: { kind: "Modified" },
+  additions: 1,
+  deletions: 0,
+  embedded: false,
+});
+
+const head: CommitInfo = {
+  oid: "aaaa111",
+  shortOid: "aaaa111",
+  summary: "feat: previous",
+  body: "Why: it was needed.",
+  author: "Ada",
+  email: "ada@x.com",
+  timestamp: 0,
+  parents: ["bbbb222"],
+  refs: [],
+};
+
+function setup(
+  opts: {
+    status?: FileStatus[];
+    headCommits?: CommitInfo[];
+    headPage?: () => Promise<{ commits: CommitInfo[]; nextCursor: null }>;
+  } = {},
+) {
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
+    status: opts.status ?? [staged("a.ts")],
+    branches: [],
+    remotes: [],
+    commits: [],
+    logRef: null,
+    loading: false,
+  } as never);
+  mockInvoke("get_diff", () => ({
+    path: "a.ts",
+    oldPath: null,
+    binary: false,
+    additions: 0,
+    deletions: 0,
+    hunks: [],
+  }));
+  mockInvoke("get_status", () => opts.status ?? [staged("a.ts")]);
+  mockInvoke("commit", () => "oid123");
+  mockInvoke(
+    "get_log_page",
+    opts.headPage ??
+      (() => ({ commits: opts.headCommits ?? [head], nextCursor: null })),
+  );
+  render(<CommitPanelScreen />);
+}
+
+const messageField = () =>
+  screen.getByTestId<HTMLTextAreaElement>("commit-message");
+const amendBox = () =>
+  screen.getByLabelText<HTMLInputElement>("Amend previous commit");
+const logPageCalls = () =>
+  getInvokeCalls().filter((c) => c.cmd === "get_log_page");
+
+describe("CommitPanel amend prefill", () => {
+  beforeEach(() => {
+    resetInvokeMock();
+  });
+
+  it("loads the previous commit message when amend is checked", async () => {
+    setup();
+
+    fireEvent.click(amendBox());
+
+    await waitFor(() =>
+      expect(messageField().value).toBe("feat: previous\n\nWhy: it was needed."),
+    );
+    expect(screen.getByTestId("commit-button")).toBeEnabled();
+    expect(screen.getByTestId("commit-button").textContent).toContain("Amend");
+  });
+
+  it("reads HEAD even while the log is scoped to another ref", async () => {
+    setup();
+    useRepoStore.setState({ logRef: "origin/feature" } as never);
+
+    fireEvent.click(amendBox());
+
+    await waitFor(() => expect(logPageCalls()).toHaveLength(1));
+    expect(logPageCalls()[0].args.refspec ?? null).toBeNull();
+    expect(logPageCalls()[0].args.limit).toBe(1);
+  });
+
+  it("restores the draft that was in the box when amend is unchecked", async () => {
+    setup();
+    fireEvent.change(messageField(), { target: { value: "wip: my draft" } });
+
+    fireEvent.click(amendBox());
+    await waitFor(() =>
+      expect(messageField().value).toBe("feat: previous\n\nWhy: it was needed."),
+    );
+    fireEvent.click(amendBox());
+
+    await waitFor(() => expect(messageField().value).toBe("wip: my draft"));
+  });
+
+  it("offers an amend affordance on a clean tree", async () => {
+    setup({ status: [] });
+
+    fireEvent.click(screen.getByTestId("amend-last-commit"));
+
+    await waitFor(() =>
+      expect(messageField().value).toBe("feat: previous\n\nWhy: it was needed."),
+    );
+    expect(screen.getByTestId("commit-button")).toBeEnabled();
+  });
+
+  it("ignores a HEAD read that lands after amend was switched back off", async () => {
+    let release = () => {};
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    setup({
+      headPage: () => gate.then(() => ({ commits: [head], nextCursor: null })),
+    });
+    fireEvent.change(messageField(), { target: { value: "wip: my draft" } });
+
+    fireEvent.click(amendBox()); // starts the HEAD read
+    fireEvent.click(amendBox()); // …and changes its mind before it lands
+    release();
+
+    await waitFor(() => expect(logPageCalls()).toHaveLength(1));
+    expect(messageField().value).toBe("wip: my draft");
+    expect(amendBox().checked).toBe(false);
+  });
+
+  it("backs the checkbox out again when there is no commit to amend", async () => {
+    setup({ headCommits: [] });
+
+    fireEvent.click(amendBox());
+
+    await waitFor(() => expect(logPageCalls()).toHaveLength(1));
+    await waitFor(() => expect(amendBox().checked).toBe(false));
+    expect(messageField().value).toBe("");
+  });
+});

--- a/src/screens/CommitPanel.attribution.test.tsx
+++ b/src/screens/CommitPanel.attribution.test.tsx
@@ -90,7 +90,7 @@ describe("CommitPanel attribution", () => {
   });
 
   it("sends no authorOverride by default", async () => {
-    type("commit-subject", "feat: plain");
+    type("commit-message", "feat: plain");
     fireEvent.click(screen.getByTestId("commit-button"));
 
     await waitFor(() => expect(commitCall()).toBeDefined());
@@ -99,7 +99,7 @@ describe("CommitPanel attribution", () => {
   });
 
   it("sends the parsed author override", async () => {
-    type("commit-subject", "feat: as ada");
+    type("commit-message", "feat: as ada");
     type("commit-author", "Ada Lovelace <ada@example.com>");
     fireEvent.click(screen.getByTestId("commit-button"));
 
@@ -111,7 +111,7 @@ describe("CommitPanel attribution", () => {
   });
 
   it("blocks the commit while the author is half-typed", async () => {
-    type("commit-subject", "feat: blocked");
+    type("commit-message", "feat: blocked");
     type("commit-author", "Ada Lovelace");
 
     expect(screen.getByTestId("commit-button")).toBeDisabled();
@@ -125,7 +125,7 @@ describe("CommitPanel attribution", () => {
   });
 
   it("appends Co-Authored-By trailers after a blank line", async () => {
-    type("commit-subject", "feat: pairing");
+    type("commit-message", "feat: pairing");
     type("commit-coauthors", "Ada <ada@x.com>, Grace <grace@x.com>");
     fireEvent.click(screen.getByTestId("commit-button"));
 
@@ -136,8 +136,7 @@ describe("CommitPanel attribution", () => {
   });
 
   it("keeps the trailer block separate from a body", async () => {
-    type("commit-subject", "feat: pairing");
-    type("commit-body", "Why: because.");
+    type("commit-message", "feat: pairing\n\nWhy: because.");
     type("commit-coauthors", "Ada <ada@x.com>");
     fireEvent.click(screen.getByTestId("commit-button"));
 
@@ -148,8 +147,7 @@ describe("CommitPanel attribution", () => {
   });
 
   it("does not duplicate a trailer the body already spells out", async () => {
-    type("commit-subject", "feat: pairing");
-    type("commit-body", "Co-Authored-By: Ada <ada@x.com>");
+    type("commit-message", "feat: pairing\n\nCo-Authored-By: Ada <ada@x.com>");
     type("commit-coauthors", "Ada <ada@x.com>");
     fireEvent.click(screen.getByTestId("commit-button"));
 
@@ -160,14 +158,14 @@ describe("CommitPanel attribution", () => {
   });
 
   it("keeps attribution after a commit — pairing spans several commits", async () => {
-    type("commit-subject", "feat: one");
+    type("commit-message", "feat: one");
     type("commit-author", "Ada Lovelace <ada@example.com>");
     type("commit-coauthors", "Grace <grace@x.com>");
     fireEvent.click(screen.getByTestId("commit-button"));
 
     await waitFor(() => expect(commitCall()).toBeDefined());
     await waitFor(() =>
-      expect(screen.getByTestId<HTMLInputElement>("commit-subject").value).toBe(""),
+      expect(screen.getByTestId<HTMLTextAreaElement>("commit-message").value).toBe(""),
     );
     expect(screen.getByTestId<HTMLInputElement>("commit-author").value).toBe(
       "Ada Lovelace <ada@example.com>",

--- a/src/screens/CommitPanel.keyboard.test.tsx
+++ b/src/screens/CommitPanel.keyboard.test.tsx
@@ -153,7 +153,7 @@ describe("CommitPanel keyboard navigation", () => {
     });
 
     const typeSubject = (text: string) => {
-      fireEvent.change(screen.getByTestId("commit-subject"), {
+      fireEvent.change(screen.getByTestId("commit-message"), {
         target: { value: text },
       });
     };

--- a/src/screens/CommitPanel.message.test.tsx
+++ b/src/screens/CommitPanel.message.test.tsx
@@ -1,0 +1,90 @@
+// One message box, not subject + body: git's message already means "first line
+// is the subject, the rest is the body", so the composer holds it that way and
+// sends it verbatim.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { CommitPanelScreen } from "./CommitPanel";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import type { FileStatus } from "@/lib/types";
+
+const staged = (path: string): FileStatus => ({
+  path,
+  worktree: { kind: "Unmodified" },
+  index: { kind: "Modified" },
+  additions: 1,
+  deletions: 0,
+  embedded: false,
+});
+
+function setup() {
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
+    status: [staged("a.ts")],
+    branches: [],
+    remotes: [],
+    commits: [],
+    logRef: null,
+    loading: false,
+  } as never);
+  mockInvoke("get_diff", () => ({
+    path: "a.ts",
+    oldPath: null,
+    binary: false,
+    additions: 0,
+    deletions: 0,
+    hunks: [],
+  }));
+  mockInvoke("get_status", () => [staged("a.ts")]);
+  mockInvoke("commit", () => "oid123");
+  render(<CommitPanelScreen />);
+}
+
+const messageField = () =>
+  screen.getByTestId<HTMLTextAreaElement>("commit-message");
+const commitCall = () => getInvokeCalls().find((c) => c.cmd === "commit");
+
+describe("CommitPanel message composer", () => {
+  beforeEach(() => {
+    resetInvokeMock();
+    setup();
+  });
+
+  it("sends the typed message verbatim, subject line and body together", async () => {
+    fireEvent.change(messageField(), {
+      target: { value: "feat: thing\n\nWhy: because.\nAlso: this." },
+    });
+    fireEvent.click(screen.getByTestId("commit-button"));
+
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    expect(commitCall()!.args.message).toBe(
+      "feat: thing\n\nWhy: because.\nAlso: this.",
+    );
+  });
+
+  it("counts only the subject line against the 50-char budget", () => {
+    fireEvent.change(messageField(), {
+      target: {
+        value: "feat: short\n\nA body line that is comfortably past fifty characters long.",
+      },
+    });
+
+    expect(screen.getByTestId("commit-subject-count").textContent).toBe("11/50");
+  });
+
+  it("trims trailing blank lines so a trailer block joins cleanly", async () => {
+    fireEvent.change(messageField(), {
+      target: { value: "feat: thing\n\nWhy: because.\n\n" },
+    });
+    fireEvent.change(screen.getByTestId("commit-coauthors"), {
+      target: { value: "Ada <ada@x.com>" },
+    });
+    fireEvent.click(screen.getByTestId("commit-button"));
+
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    expect(commitCall()!.args.message).toBe(
+      "feat: thing\n\nWhy: because.\n\nCo-Authored-By: Ada <ada@x.com>",
+    );
+  });
+});

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -48,7 +48,7 @@ import {
   pruneSelection,
   type Selection,
 } from "@/lib/selection";
-import { getDiff } from "@/lib/tauri";
+import { getDiff, getLogPage } from "@/lib/tauri";
 import {
   WhitespaceToggle,
   useHunkActionsDisabledReason,
@@ -88,9 +88,15 @@ export function CommitPanelScreen() {
   const diffContextLines = useSettingsStore((s) => s.diffContextLines);
   const ignoreWhitespace = useIgnoreWhitespace();
   const hunkActionsDisabled = useHunkActionsDisabledReason();
+  // One box for the whole commit message: first line is the subject, the rest
+  // is the body — the same shape git itself stores, so nothing is re-joined on
+  // the way out.
   const [message, setMessage] = React.useState("");
-  const [body, setBody] = React.useState("");
   const [amend, setAmend] = React.useState(false);
+  // The draft that amend's prefill displaced, restored when amend is unchecked.
+  const draftRef = React.useRef<string | null>(null);
+  // Generation counter for in-flight amend prefills (see toggleAmend).
+  const amendReqRef = React.useRef(0);
   // Sign-off toggle seeds from the persisted preference; toggling it writes back.
   const [signoff, setSignoff] = React.useState(addSignoff);
   // Signing (#61 D6). null = follow the setting, which itself defaults to
@@ -217,8 +223,7 @@ export function CommitPanelScreen() {
   ]);
 
   const applyRecent = React.useCallback((r: RecentMessage) => {
-    setMessage(r.subject);
-    setBody(r.body);
+    setMessage(r.body ? `${r.subject}\n\n${r.body}` : r.subject);
   }, []);
 
   const recentsMenu = useContextMenu<void>(() =>
@@ -525,6 +530,9 @@ export function CommitPanelScreen() {
     () => coAuthorTrailers(coAuthors).length,
     [coAuthors],
   );
+  // Only the first line counts against the 50-char subject budget; everything
+  // below it is body text nobody truncates.
+  const subjectLength = message.split("\n", 1)[0].length;
   const canCommit =
     (amend || staged.length > 0) && !!message.trim() && !authorInvalid;
   const canCommitAndPush = canCommit && !!headBranch && !!defaultRemote;
@@ -536,7 +544,7 @@ export function CommitPanelScreen() {
     if (committingRef.current) return null;
     committingRef.current = true;
     try {
-      const full = buildMessage(message, body, coAuthorTrailers(coAuthors));
+      const full = buildMessage(message, coAuthorTrailers(coAuthors));
       const oid = await commitAction(
         full,
         amend,
@@ -546,8 +554,8 @@ export function CommitPanelScreen() {
       );
       if (oid) {
         setMessage("");
-        setBody("");
         setAmend(false);
+        draftRef.current = null;
         // Per-commit signing override is not sticky: it is an override, and
         // carrying it silently into the next commit would surprise.
         setSignOverride(null);
@@ -572,7 +580,7 @@ export function CommitPanelScreen() {
       void doCommit();
       return true;
     },
-    [canCommit, message, body, amend, signoff, authorIdentity, coAuthors],
+    [canCommit, message, amend, signoff, authorIdentity, coAuthors],
   );
   useAction(
     "commit.commitAndPush",
@@ -584,7 +592,6 @@ export function CommitPanelScreen() {
     [
       canCommitAndPush,
       message,
-      body,
       amend,
       signoff,
       authorIdentity,
@@ -593,19 +600,71 @@ export function CommitPanelScreen() {
       defaultRemote,
     ],
   );
+  // Checking amend pulls HEAD's message into the box (that's the message being
+  // rewritten), stashing whatever draft was there so unchecking gives it back.
+  const toggleAmend = React.useCallback(
+    async (next: boolean) => {
+      // Every toggle voids the one before it: unchecking while the HEAD read is
+      // still in flight must not have the message replaced out from under it.
+      const req = (amendReqRef.current += 1);
+      if (!next) {
+        setAmend(false);
+        if (draftRef.current !== null) {
+          setMessage(draftRef.current);
+          draftRef.current = null;
+        }
+        return;
+      }
+      if (!repo) return;
+      setAmend(true);
+      try {
+        // HEAD, never the browsed log ref — History may be scoped to another
+        // branch, but amend always rewrites the commit this repo is sitting on.
+        const page = await getLogPage(repo.id, null, 1);
+        if (amendReqRef.current !== req) return;
+        const head = page.commits[0];
+        if (!head) {
+          setAmend(false);
+          pgFlash("No commit to amend yet");
+          return;
+        }
+        draftRef.current = message;
+        setMessage(headMessage(head));
+      } catch (e) {
+        if (amendReqRef.current !== req) return;
+        setAmend(false);
+        pgFlash(appErrorMessage(e));
+      }
+    },
+    [repo, message],
+  );
   useAction(
     "commit.toggleAmend",
     () => {
-      setAmend((a) => !a);
+      void toggleAmend(!amend);
       return true;
     },
-    [],
+    [amend, toggleAmend],
   );
 
-  if (!loading && staged.length === 0 && unstaged.length === 0) {
+  // A clean tree still has one thing worth doing: fixing the message of the
+  // commit that just landed. Checking amend brings the composer back.
+  if (!loading && staged.length === 0 && unstaged.length === 0 && !amend) {
     return (
       <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
-        <PGEmpty icon="check" title="Working tree clean">
+        <PGEmpty
+          icon="check"
+          title="Working tree clean"
+          action={
+            <PGButton
+              icon="commit"
+              onClick={() => void toggleAmend(true)}
+              data-testid="amend-last-commit"
+            >
+              Amend last commit
+            </PGButton>
+          }
+        >
           No changes to commit.
         </PGEmpty>
       </div>
@@ -965,26 +1024,6 @@ export function CommitPanelScreen() {
             flex: 1,
           }}
         >
-          <div>
-            <LabelRow
-              label="Subject"
-              right={
-                <span
-                  style={{
-                    fontSize: "var(--fs-10)",
-                    color:
-                      message.length > 50
-                        ? "var(--git-modified)"
-                        : "var(--fg-3)",
-                    fontFamily: "var(--font-mono)",
-                  }}
-                >
-                  {message.length}/50
-                </span>
-              }
-            />
-            <PGInput value={message} onChange={setMessage} mono size="lg" data-testid="commit-subject" />
-          </div>
           <div
             style={{
               flex: 1,
@@ -994,25 +1033,39 @@ export function CommitPanelScreen() {
             }}
           >
             <LabelRow
-              label="Body"
+              label="Message"
               right={
                 <span
                   style={{
+                    display: "flex",
+                    gap: 6,
                     fontSize: "var(--fs-10)",
-                    color: "var(--fg-3)",
                     fontFamily: "var(--font-mono)",
+                    color: "var(--fg-3)",
                   }}
                 >
-                  wrap at 72
+                  <span
+                    data-testid="commit-subject-count"
+                    style={{
+                      color:
+                        subjectLength > 50
+                          ? "var(--git-modified)"
+                          : "var(--fg-3)",
+                    }}
+                  >
+                    {subjectLength}/50
+                  </span>
+                  <span>wrap at 72</span>
                 </span>
               }
             />
             <PGTextarea
-              value={body}
-              onChange={setBody}
-              rows={8}
+              value={message}
+              onChange={setMessage}
+              rows={10}
               mono
-              data-testid="commit-body"
+              placeholder="Subject line, blank line, then body"
+              data-testid="commit-message"
               data-pg-focus-target=""
               className="focusable"
               style={{ flex: 1 }}
@@ -1031,7 +1084,7 @@ export function CommitPanelScreen() {
           >
             <PGCheckbox
               checked={amend}
-              onChange={setAmend}
+              onChange={(v) => void toggleAmend(v)}
               label="Amend previous commit"
             />
             <PGCheckbox
@@ -1352,18 +1405,25 @@ export function coAuthorTrailers(raw: string): string[] {
   return out;
 }
 
-function buildMessage(subject: string, body: string, coAuthors: string[] = []): string {
-  const parts: string[] = [subject];
-  const trimmedBody = body.trim();
-  if (trimmedBody) parts.push("", trimmedBody);
+function buildMessage(message: string, coAuthors: string[] = []): string {
+  const trimmed = message.trimEnd();
   // Trailers go in their own block after one blank line — that separation is
-  // what `git interpret-trailers` (and GitHub) key on. Skip any the body
+  // what `git interpret-trailers` (and GitHub) key on. Skip any the message
   // already spells out, so hand-written and generated trailers can't double up.
   const fresh = coAuthors.filter(
-    (t) => !trimmedBody.toLowerCase().includes(t.toLowerCase()),
+    (t) => !trimmed.toLowerCase().includes(t.toLowerCase()),
   );
-  if (fresh.length) parts.push("", fresh.join("\n"));
-  return parts.join("\n");
+  return fresh.length ? `${trimmed}\n\n${fresh.join("\n")}` : trimmed;
+}
+
+/**
+ * HEAD's message as the composer holds it: subject line, blank line, body.
+ * `summary` + `body` round-trip the raw message for any commit whose subject
+ * is a single line — which is every commit written to convention.
+ */
+function headMessage(c: CommitInfo): string {
+  const body = (c.body ?? "").trim();
+  return body ? `${c.summary}\n\n${body}` : c.summary;
 }
 
 export interface RecentMessage {


### PR DESCRIPTION
## What

- **Amend prefills.** Checking "Amend previous commit" reads HEAD and loads that message into the composer, so the button is usable and the message being rewritten is on screen. Unchecking restores the draft the prefill displaced. No commits yet → the checkbox backs itself out with a flash.
- **One message box.** Subject + body collapse into a single `commit-message` textarea — git already defines the message that way (first line = subject, rest = body). The message reaches the backend verbatim; co-author trailers still form their own block, and the 50-char counter now measures the first line only.
- **Amend on a clean tree.** "Working tree clean" gains an **Amend last commit** button — with nothing staged, fixing the message you just typed is the one job left, and it used to be unreachable.

## Notes

- The prefill reads **HEAD**, never the browsed log ref: History can be scoped to another branch, but amend always rewrites the commit this repo sits on.
- Rapid toggling is generation-guarded — a HEAD read that lands after amend was switched back off no longer overwrites the box (covered by a test that fails without the guard).

## Testing

- `pnpm test` — 685 passing (new `CommitPanel.amend.test.tsx`, `CommitPanel.message.test.tsx`; attribution/keyboard specs moved to the single field).
- `pnpm tsc --noEmit` + `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — clean.
- `pnpm test:e2e:docker full --spec e2e/specs/commit.e2e.ts --spec e2e/specs/keymap.e2e.ts --spec e2e/specs/settings.e2e.ts` — 3 spec files, 33 tests passing, including "amends the last commit's message from a clean tree" and "⌘⇧M toggles amend, swapping the draft for HEAD's message".

🤖 Generated with [Claude Code](https://claude.com/claude-code)