### PR TITLE
fix: correctness and data-loss fixes from the post-v0.0.7 review

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -99,11 +99,27 @@ jobs:
     steps:
       - name: Gate on the E2E result
         env:
+          FILTER: ${{ needs.changes.result }}
+          APP: ${{ needs.changes.outputs.app }}
           RESULT: ${{ needs.e2e.result }}
         run: |
-          echo "E2E job result: $RESULT"
+          echo "filter job: $FILTER / app touched: $APP / E2E job: $RESULT"
+          # A failed filter job skips `e2e` too. Without this check the gate
+          # would read that skip as "not required" and pass a PR whose suite
+          # never ran at all.
+          if [ "$FILTER" != "success" ]; then
+            echo "The change-filter job did not succeed, so the suite never ran."
+            exit 1
+          fi
           case "$RESULT" in
             success) echo "E2E suite passed." ;;
-            skipped) echo "No app code touched — E2E suite not required for this change." ;;
-            *)       echo "E2E suite did not pass."; exit 1 ;;
+            skipped)
+              # Only legitimate when the filter decided no app code was touched.
+              if [ "$APP" != "false" ]; then
+                echo "E2E suite was skipped even though app code changed."
+                exit 1
+              fi
+              echo "No app code touched — E2E suite not required for this change."
+              ;;
+            *) echo "E2E suite did not pass."; exit 1 ;;
           esac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,15 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build universal app
+        # The signing key is required even though macOS never self-updates
+        # (`capability()` returns Notify for it, and latest.json carries only the
+        # windows and linux entries): `bundle.createUpdaterArtifacts` is global,
+        # so the bundler still produces an updater artifact here — and a pubkey
+        # with no private key is a hard error, not a skip. Without this the job
+        # fails, no dmg is attached, and bump-cask (which needs it) never runs.
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: pnpm tauri build --target universal-apple-darwin
 
       - name: Rename dmg to stable name

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -421,6 +421,56 @@ fn is_registered_submodule(repo: &Repository, rel: &Path) -> bool {
 /// Directories are never index entries themselves, so `discard` needs this to
 /// tell an untracked directory (safe to delete) from a tracked one (must be
 /// restored, not removed).
+/// `is_embedded_repo`, but skipping the filesystem for entries that cannot be one.
+///
+/// `is_embedded_repo` stats every path it is handed, and `list_all_files`
+/// enumerates the ENTIRE worktree (unmodified files included) while `status()`
+/// runs after every stage, unstage, discard and hunk/line op — so that is one
+/// wasted syscall per ordinary file, on the hottest path in the app.
+///
+/// An embedded repo reaches a listing in exactly two shapes, and both are
+/// recognizable without touching disk:
+///
+/// * libgit2 would not recurse into it, so it is reported as the directory WITH a
+///   trailing slash (`embedded_repo.rs` pins `"vendor/lib/"`).
+/// * its gitlink is already in the index — staged by an older build or from the
+///   command line — in which case it is reported SLASSHLESS and the index entry
+///   carries mode `160000` (`unstage_still_removes_an_already_committed_gitlink`
+///   is the test that catches a slash-only check).
+///
+/// Anything else is an ordinary file. Index lookups are an in-memory search, so
+/// this costs no syscall.
+///
+/// Only for paths that came OUT of a listing. Operations (`stage`, `discard`,
+/// `reject_embedded_repo`) must keep calling `is_embedded_repo` directly: their
+/// path comes from the caller, which may pass either form — `embedded_repo.rs`
+/// exercises both `"vendor/lib/"` and `"vendor/lib"`.
+fn listed_entry_is_embedded_repo(
+    repo: &Repository,
+    index: Option<&git2::Index>,
+    path: &str,
+) -> bool {
+    const GITLINK_MODE: u32 = 0o160_000;
+    let could_be = path.ends_with('/')
+        || index
+            .and_then(|i| i.get_path(Path::new(path), 0))
+            .is_some_and(|e| e.mode == GITLINK_MODE);
+    if !could_be {
+        return false;
+    }
+    is_embedded_repo(repo, Path::new(path))
+}
+
+/// Whether the index tracks `rel` at ANY stage.
+///
+/// Stage 0 is the ordinary merged entry, but a **conflicted** path has no stage-0
+/// entry at all — only stages 1/2/3 (base/ours/theirs). Testing stage 0 alone
+/// therefore reads a conflicted file as untracked, which is how `discard` came to
+/// delete a merge in progress instead of restoring it.
+fn index_tracks_path(index: &git2::Index, rel: &Path) -> bool {
+    (0..=3).any(|stage| index.get_path(rel, stage).is_some())
+}
+
 fn index_has_entry_under(index: &git2::Index, rel: &Path) -> bool {
     let prefix = strip_trailing_slash(rel).to_string_lossy().to_string();
     if prefix.is_empty() {
@@ -482,6 +532,51 @@ fn map_status_flag(s: Status, side: StatusSide) -> StatusFlag {
 // ─── Hunk-level staging helpers ──────────────────────────────────────────────
 
 /// Find which delta index corresponds to `path` inside a diff.
+/// `DiffOptions` for a worktree-vs-index diff of one path, matching exactly what
+/// `diff()` builds for `DiffKind::WorktreeToIndex`.
+///
+/// The hunk/line staging ops MUST diff with the same options as the diff the user
+/// clicked on, or the hunk index and changed-line indices they were handed
+/// address different content. The untracked family is what used to be missing:
+/// without it a newly created file produces no delta at all, so
+/// `find_delta_index` returned `InvalidPath` and staging a new file's hunks or
+/// lines was impossible even though the UI offers it.
+fn worktree_index_diff_opts(path: &Path, context_lines: u32) -> DiffOptions {
+    let mut opts = DiffOptions::new();
+    opts.pathspec(path);
+    opts.context_lines(context_lines);
+    opts.include_untracked(true)
+        .recurse_untracked_dirs(true)
+        .show_untracked_content(true);
+    opts
+}
+
+/// git's on-disk octal mode for a diff entry.
+///
+/// `git2::FileMode` is an enum, so casting it to an integer yields the *variant
+/// discriminant* (0, 1, 2, …), not a mode — emitting that into a `new file mode`
+/// header made git read the entry as a gitlink and reject the patch with "corrupt
+/// patch for submodule".
+fn octal_file_mode(mode: git2::FileMode) -> u32 {
+    match mode {
+        git2::FileMode::BlobExecutable => 0o100_755,
+        git2::FileMode::Link => 0o120_000,
+        git2::FileMode::Commit => 0o160_000,
+        git2::FileMode::Tree => 0o040_000,
+        // Blob, BlobGroupWritable and Unreadable all become a regular file: a
+        // plain blob is the only thing a synthesized text patch can create.
+        _ => 0o100_644,
+    }
+}
+
+/// True when the delta has no pre-image, i.e. the patch creates the file.
+fn delta_creates_file(delta: &git2::DiffDelta<'_>) -> bool {
+    matches!(
+        delta.status(),
+        git2::Delta::Added | git2::Delta::Untracked
+    )
+}
+
 fn find_delta_index(diff: &git2::Diff, path: &Path) -> AppResult<usize> {
     for (i, delta) in diff.deltas().enumerate() {
         if let Some(p) = delta.new_file().path() {
@@ -599,16 +694,24 @@ fn run_signer(program: &str, args: &[String], payload: &str) -> AppResult<String
         .spawn()
         .map_err(|e| AppError::Git(format!("could not run {program}: {e}")))?;
 
-    child
+    // Feed stdin from a helper thread while the parent drains stdout and stderr.
+    // Writing the whole payload up front deadlocks once the child fills a pipe
+    // buffer (~64KB) it is waiting for us to read: gpg's `--status-fd=2` chatter
+    // goes to stderr, so a long commit message can leave both sides blocked.
+    let mut stdin = child
         .stdin
-        .as_mut()
-        .ok_or_else(|| AppError::Internal("signer has no stdin".into()))?
-        .write_all(payload.as_bytes())
-        .map_err(|e| AppError::Io(e.to_string()))?;
+        .take()
+        .ok_or_else(|| AppError::Internal("signer has no stdin".into()))?;
+    let buf = payload.as_bytes().to_vec();
+    let writer = std::thread::spawn(move || stdin.write_all(&buf));
 
     let out = child
         .wait_with_output()
         .map_err(|e| AppError::Io(e.to_string()))?;
+    // A signer that fails early closes stdin, which surfaces here as a broken
+    // pipe. That is not itself the failure — the exit status below is what
+    // decides, and it carries the signer's own diagnostics.
+    let _ = writer.join();
     if !out.status.success() {
         return Err(AppError::Git(format!(
             "signing failed: {}",
@@ -700,6 +803,17 @@ fn patch_text_for_lines(
         .to_string_lossy()
         .to_string();
 
+    // A file with no pre-image can only be *created* by a patch. Reversing such a
+    // patch would mean un-creating it, which a partial line selection cannot
+    // express — refuse rather than emit something `git apply` would either reject
+    // or misapply. Whole-file `discard` already deletes an untracked path.
+    let creates = delta_creates_file(&delta);
+    if creates && matches!(direction, PatchDirection::Reverse) {
+        return Err(AppError::InvalidArgument(format!(
+            "{path_str} is not tracked yet — discard the whole file instead of individual lines"
+        )));
+    }
+
     let (hunk_header, _) = patch.hunk(hunk_index).map_err(AppError::from)?;
     let old_start = hunk_header.old_start();
     let new_start = hunk_header.new_start();
@@ -775,7 +889,18 @@ fn patch_text_for_lines(
 
     let mut out = String::new();
     out.push_str(&format!("diff --git a/{p} b/{p}\n", p = path_str));
-    out.push_str(&format!("--- a/{}\n", path_str));
+    if creates {
+        // A creation patch must say so: `--- a/<path>` for a file that is not in
+        // the pre-image makes `git apply` fail ("does not exist in index"), and
+        // the hunk's old_start is 0, which is only valid against /dev/null.
+        out.push_str(&format!(
+            "new file mode {:o}\n",
+            octal_file_mode(delta.new_file().mode())
+        ));
+        out.push_str("--- /dev/null\n");
+    } else {
+        out.push_str(&format!("--- a/{}\n", path_str));
+    }
     out.push_str(&format!("+++ b/{}\n", path_str));
     // Counts are recomputed from the emitted body. Copying the source hunk's
     // header is the classic way to produce a patch `git apply` rejects.
@@ -800,35 +925,78 @@ fn patch_text_for_hunk(diff: &git2::Diff, delta_index: usize, hunk_index: usize)
 /// included, keyed by path. One diff pass + cheap `line_stats()` per delta (no
 /// full patch print). Untracked files count their whole content as additions.
 /// Keyed by both new and old paths so renames/deletions resolve either way.
-fn worktree_line_stats(repo: &Repository) -> AppResult<HashMap<String, (u32, u32)>> {
-    let mut opts = DiffOptions::new();
-    opts.include_untracked(true)
-        .recurse_untracked_dirs(true)
-        .show_untracked_content(true)
-        .include_typechange(true);
+/// Per-path `(additions, deletions)` for one diff, in a single pass.
+///
+/// Uses `Diff::foreach` rather than `Patch::from_diff` per delta: a `Patch`
+/// materializes the whole per-file patch (every line, allocated) just to read two
+/// counters off it, and `status()` is the hottest path in the app — it runs after
+/// every stage, unstage, discard and hunk/line op. The callback form walks the
+/// same lines without building any of that.
+fn diff_line_stats(diff: &git2::Diff) -> AppResult<HashMap<String, (u32, u32)>> {
+    let mut map: HashMap<String, (u32, u32)> = HashMap::new();
+    // `foreach`'s line callback reports the file it belongs to, so the delta's
+    // paths are resolved per line rather than tracked across callbacks.
+    let mut line_cb = |delta: git2::DiffDelta<'_>, _hunk: Option<git2::DiffHunk<'_>>, line: git2::DiffLine<'_>| -> bool {
+        let add = match line.origin() {
+            '+' => true,
+            '-' => false,
+            // Context and the various file-header origins are not changes.
+            _ => return true,
+        };
+        for p in [delta.new_file().path(), delta.old_file().path()]
+            .into_iter()
+            .flatten()
+        {
+            let e = map.entry(p.to_string_lossy().to_string()).or_insert((0, 0));
+            if add {
+                e.0 += 1;
+            } else {
+                e.1 += 1;
+            }
+            // A rename reports both paths; count it once, under the new name,
+            // unless there is no new name (a deletion).
+            break;
+        }
+        true
+    };
+    diff.foreach(&mut |_, _| true, None, None, Some(&mut line_cb))?;
+    Ok(map)
+}
+
+/// `(HEAD → index, index → working tree)` line stats, keyed by path.
+///
+/// Two diffs rather than one combined `diff_tree_to_workdir_with_index`, because
+/// a single number per file cannot answer both questions: the composer needs to
+/// say what the COMMIT will contain (the staged side), while the unstaged rows
+/// need what is not staged yet. Sharing one HEAD→worktree number made the
+/// composer overstate the commit whenever a staged file had further unstaged
+/// edits, and made a partially staged file show identical counts on both rows.
+///
+/// The staged diff never touches the filesystem, so the added cost over the old
+/// single pass is small; the untracked-content scan lives entirely in the
+/// unstaged half, exactly as before.
+fn side_line_stats(
+    repo: &Repository,
+) -> AppResult<(HashMap<String, (u32, u32)>, HashMap<String, (u32, u32)>)> {
     let head_tree = match repo.head() {
         Ok(h) => Some(h.peel_to_tree()?),
         Err(e) if e.code() == git2::ErrorCode::UnbornBranch => None,
         Err(e) => return Err(e.into()),
     };
-    let diff = repo.diff_tree_to_workdir_with_index(head_tree.as_ref(), Some(&mut opts))?;
-    let mut map: HashMap<String, (u32, u32)> = HashMap::new();
-    for idx in 0..diff.deltas().len() {
-        let Some(patch) = git2::Patch::from_diff(&diff, idx)? else {
-            continue;
-        };
-        let (_ctx, add, del) = patch.line_stats()?;
-        let counts = (add as u32, del as u32);
-        if let Some(delta) = diff.get_delta(idx) {
-            if let Some(p) = delta.new_file().path() {
-                map.insert(p.to_string_lossy().to_string(), counts);
-            }
-            if let Some(p) = delta.old_file().path() {
-                map.entry(p.to_string_lossy().to_string()).or_insert(counts);
-            }
-        }
-    }
-    Ok(map)
+
+    let mut staged_opts = DiffOptions::new();
+    staged_opts.include_typechange(true);
+    let staged = repo.diff_tree_to_index(head_tree.as_ref(), None, Some(&mut staged_opts))?;
+
+    let mut unstaged_opts = DiffOptions::new();
+    unstaged_opts
+        .include_untracked(true)
+        .recurse_untracked_dirs(true)
+        .show_untracked_content(true)
+        .include_typechange(true);
+    let unstaged = repo.diff_index_to_workdir(None, Some(&mut unstaged_opts))?;
+
+    Ok((diff_line_stats(&staged)?, diff_line_stats(&unstaged)?))
 }
 
 /// Convert a computed `git2::Diff` into per-file `FileDiff`s (path, rename
@@ -985,22 +1153,26 @@ fn resolve_commit<'a>(repo: &'a Repository, revspec: &str) -> AppResult<git2::Co
 /// caller returns an empty log). A missing/corrupt HEAD surfaces as an error
 /// instead — masking it as an empty log hides a broken repo. `Some(spec)`
 /// starts at any revspec (branch, tag, short/full oid) peeled to a commit —
-/// `InvalidRef` when it can't be resolved. Returns `Ok(true)` when a start
-/// point was pushed.
+/// `InvalidRef` when it can't be resolved.
+///
+/// Returns the oids actually pushed; empty means "nothing to walk". The caller
+/// needs the oids, not just a flag: a pushed start point that the page's limit
+/// stops short of has to survive into the next cursor.
 fn push_log_start(
     repo: &Repository,
     walk: &mut git2::Revwalk,
     refspec: Option<&str>,
-) -> AppResult<bool> {
+) -> AppResult<Vec<git2::Oid>> {
     match refspec {
         None => match repo.head() {
-            Ok(_) => {
-                walk.push_head()?;
-                Ok(true)
+            Ok(h) => {
+                let oid = h.peel_to_commit()?.id();
+                walk.push(oid)?;
+                Ok(vec![oid])
             }
             // Fresh repo, HEAD points at a branch with no commits yet → nothing
             // to walk. This is the only "empty log, not an error" case.
-            Err(e) if e.code() == git2::ErrorCode::UnbornBranch => Ok(false),
+            Err(e) if e.code() == git2::ErrorCode::UnbornBranch => Ok(Vec::new()),
             // NotFound (or anything else) means HEAD itself is missing/corrupt,
             // not an unborn branch — surface it rather than reporting an empty
             // history for a broken repo.
@@ -1009,7 +1181,7 @@ fn push_log_start(
         Some(spec) => {
             let commit = resolve_commit(repo, spec)?;
             walk.push(commit.id())?;
-            Ok(true)
+            Ok(vec![commit.id()])
         }
     }
 }
@@ -1038,6 +1210,21 @@ impl FrontierBuilder {
             visited: std::collections::HashSet::with_capacity(cap),
             cand_seen: std::collections::HashSet::new(),
             candidates: Vec::new(),
+        }
+    }
+
+    /// Register the walk's own start points as live lanes.
+    ///
+    /// A page can stop before reaching every pushed start point — resume from a
+    /// two-lane cursor `[A, B]` with a page size of one and only `A` is walked.
+    /// `B` is then in neither `visited` nor `candidates` (it is nobody's parent
+    /// here), so without this it would be dropped from the next cursor and every
+    /// commit reachable only through its lane would vanish from the log.
+    fn seed(&mut self, starts: &[git2::Oid]) {
+        for &oid in starts {
+            if self.cand_seen.insert(oid) {
+                self.candidates.push(oid);
+            }
         }
     }
 
@@ -1072,7 +1259,7 @@ impl FrontierBuilder {
 }
 
 /// Seed a revwalk for a page: from the cursor frontier when resuming,
-/// otherwise from `refspec`/HEAD. `Ok(false)` means "nothing to walk".
+/// otherwise from `refspec`/HEAD. An empty result means "nothing to walk".
 ///
 /// When a cursor is supplied `refspec` is deliberately ignored — the frontier
 /// already encodes which walk this continues.
@@ -1081,10 +1268,10 @@ fn push_page_start(
     walk: &mut git2::Revwalk,
     refspec: Option<&str>,
     cursor: Option<&[String]>,
-) -> AppResult<bool> {
+) -> AppResult<Vec<git2::Oid>> {
     match cursor {
         Some(frontier) if !frontier.is_empty() => {
-            let mut pushed = false;
+            let mut pushed = Vec::with_capacity(frontier.len());
             for raw in frontier {
                 let oid =
                     git2::Oid::from_str(raw).map_err(|_| AppError::InvalidRef(raw.clone()))?;
@@ -1092,7 +1279,7 @@ fn push_page_start(
                 // rather than failing the whole page.
                 if repo.find_commit(oid).is_ok() {
                     walk.push(oid)?;
-                    pushed = true;
+                    pushed.push(oid);
                 }
             }
             Ok(pushed)
@@ -1434,26 +1621,40 @@ impl GitBackend for Libgit2Backend {
 
     fn status(&self, repo_id: &RepoId) -> AppResult<Vec<FileStatus>> {
         self.with_repo(repo_id, |repo| {
-            // Per-file line stats (HEAD → working tree, index-aware) in one diff
-            // pass. Degrades to empty (→ 0/0 counts) rather than failing status.
-            let stats = worktree_line_stats(repo).unwrap_or_default();
+            // Per-file line stats for each side separately, so the staged and
+            // unstaged rows can report their own numbers. Degrades to empty
+            // (→ 0/0 counts) rather than failing status.
+            let (staged_stats, unstaged_stats) = side_line_stats(repo).unwrap_or_default();
             let mut opts = StatusOptions::new();
             opts.include_untracked(true)
                 .recurse_untracked_dirs(true)
                 .include_ignored(false);
             let statuses = repo.statuses(Some(&mut opts))?;
+            // Read once for the whole listing, not per entry: it only feeds the
+            // gitlink-mode shortcut in `listed_entry_is_embedded_repo`, so a repo
+            // whose index will not open just falls back to the slash check.
+            let index = repo.index().ok();
             let mut out = Vec::with_capacity(statuses.len());
             for entry in statuses.iter() {
                 let path = entry.path().unwrap_or("").to_string();
                 let s = entry.status();
-                let (additions, deletions) = stats.get(&path).copied().unwrap_or((0, 0));
-                let embedded = is_embedded_repo(repo, Path::new(&path));
+                let (staged_additions, staged_deletions) =
+                    staged_stats.get(&path).copied().unwrap_or((0, 0));
+                let (unstaged_additions, unstaged_deletions) =
+                    unstaged_stats.get(&path).copied().unwrap_or((0, 0));
+                let embedded = listed_entry_is_embedded_repo(repo, index.as_ref(), &path);
                 out.push(FileStatus {
                     path,
                     worktree: map_status_flag(s, StatusSide::Worktree),
                     index: map_status_flag(s, StatusSide::Index),
-                    additions,
-                    deletions,
+                    // Both sides together, for callers that want one number per
+                    // file rather than a per-side breakdown.
+                    additions: staged_additions + unstaged_additions,
+                    deletions: staged_deletions + unstaged_deletions,
+                    staged_additions,
+                    staged_deletions,
+                    unstaged_additions,
+                    unstaged_deletions,
                     embedded,
                 });
             }
@@ -1469,6 +1670,10 @@ impl GitBackend for Libgit2Backend {
                 .include_unmodified(true)
                 .include_ignored(false);
             let statuses = repo.statuses(Some(&mut opts))?;
+            // Once for the whole listing — see `status()`. This one matters most:
+            // `include_unmodified` means every file in the worktree comes through
+            // here, so a per-entry stat would be a syscall per file.
+            let index = repo.index().ok();
             let mut out = Vec::with_capacity(statuses.len());
             for entry in statuses.iter() {
                 let path = entry.path().unwrap_or("").to_string();
@@ -1476,7 +1681,7 @@ impl GitBackend for Libgit2Backend {
                     continue;
                 }
                 let s = entry.status();
-                let embedded = is_embedded_repo(repo, Path::new(&path));
+                let embedded = listed_entry_is_embedded_repo(repo, index.as_ref(), &path);
                 out.push(FileStatus {
                     path,
                     worktree: map_status_flag(s, StatusSide::Worktree),
@@ -1485,6 +1690,10 @@ impl GitBackend for Libgit2Backend {
                     // line stats — the tree shows status marks, not counts.
                     additions: 0,
                     deletions: 0,
+                    staged_additions: 0,
+                    staged_deletions: 0,
+                    unstaged_additions: 0,
+                    unstaged_deletions: 0,
                     embedded,
                 });
             }
@@ -1513,7 +1722,8 @@ impl GitBackend for Libgit2Backend {
             let ref_map = collect_ref_map(repo);
             let mut walk = repo.revwalk()?;
             walk.set_sorting(Sort::TIME | Sort::TOPOLOGICAL)?;
-            if !push_page_start(repo, &mut walk, refspec, cursor)? {
+            let starts = push_page_start(repo, &mut walk, refspec, cursor)?;
+            if starts.is_empty() {
                 return Ok(LogPage {
                     commits: Vec::new(),
                     next_cursor: None,
@@ -1522,6 +1732,7 @@ impl GitBackend for Libgit2Backend {
 
             let mut out = Vec::with_capacity(limit.min(4096));
             let mut frontier = FrontierBuilder::new(limit.min(4096));
+            frontier.seed(&starts);
             for oid in walk.by_ref().take(limit) {
                 let oid = oid?;
                 let commit = repo.find_commit(oid)?;
@@ -1615,7 +1826,8 @@ impl GitBackend for Libgit2Backend {
             let ref_map = collect_ref_map(repo);
             let mut walk = repo.revwalk()?;
             walk.set_sorting(Sort::TIME | Sort::TOPOLOGICAL)?;
-            if !push_page_start(repo, &mut walk, refspec, cursor)? {
+            let starts = push_page_start(repo, &mut walk, refspec, cursor)?;
+            if starts.is_empty() {
                 return Ok(LogPage {
                     commits: Vec::new(),
                     next_cursor: None,
@@ -1627,10 +1839,19 @@ impl GitBackend for Libgit2Backend {
             // resuming from a match's parents would skip the non-matching
             // commits between them and lose their ancestors entirely.
             let mut frontier = FrontierBuilder::new(limit.min(4096));
-            for oid in walk {
-                if out.len() >= limit {
-                    break;
-                }
+            frontier.seed(&starts);
+            // Pull from the walk ONLY while there is room for another match.
+            // `for oid in walk { if out.len() >= limit { break } … }` yields an oid
+            // first and discards it on the break, without recording it in the
+            // frontier — and a cursor start-point lost that way is in neither
+            // `visited` nor `candidates`, so `finish` omits it and every commit
+            // reachable only through that lane disappears from the log for good.
+            // `log_page` sidesteps this with `walk.by_ref().take(limit)`; the
+            // filtered walk cannot, because it decides per commit whether one
+            // counts towards the limit.
+            let mut walk = walk;
+            while out.len() < limit {
+                let Some(oid) = walk.next() else { break };
                 let oid = oid?;
                 let commit = repo.find_commit(oid)?;
                 frontier.visit(oid, commit.parent_ids());
@@ -2004,6 +2225,10 @@ impl GitBackend for Libgit2Backend {
                             index: StatusFlag::Unmodified,
                             additions: 0,
                             deletions: 0,
+                            staged_additions: 0,
+                            staged_deletions: 0,
+                            unstaged_additions: 0,
+                            unstaged_deletions: 0,
                             // Blobs only — a committed tree never yields a
                             // directory entry, embedded or otherwise.
                             embedded: false,
@@ -2218,7 +2443,10 @@ impl GitBackend for Libgit2Backend {
                 // index" must not be read as "untracked" for one: deleting
                 // `src/` because `src` isn't an entry would wipe every tracked
                 // file beneath it. Restoring is what `git checkout -- src` does.
-                if index.get_path(p, 0).is_some() || index_has_entry_under(&index, p) {
+                // Any stage counts as tracked, not just stage 0 — a conflicted
+                // path lives at stages 1/2/3, and treating it as untracked would
+                // delete the user's merge in progress.
+                if index_tracks_path(&index, p) || index_has_entry_under(&index, p) {
                     restore.push(p);
                 } else if abs.exists() {
                     delete.push(abs);
@@ -2263,10 +2491,12 @@ impl GitBackend for Libgit2Backend {
         hunk_index: usize,
         context_lines: u32,
     ) -> AppResult<()> {
-        self.with_repo(repo_id, |repo| {
-            let mut opts = DiffOptions::new();
-            opts.pathspec(path);
-            opts.context_lines(context_lines);
+        // Returns Some(patch) for a file that is not in the index yet, which has
+        // to take the `git apply --cached` route instead: libgit2's
+        // `ApplyLocation::Index` needs an existing index entry and fails outright
+        // with "index does not contain <path>".
+        let creation_patch = self.with_repo(repo_id, |repo| {
+            let mut opts = worktree_index_diff_opts(path, context_lines);
             let diff = repo.diff_index_to_workdir(None, Some(&mut opts))?;
 
             // Find delta for path, then count hunks via Patch.
@@ -2287,6 +2517,14 @@ impl GitBackend for Libgit2Backend {
                 )));
             }
 
+            let creates = diff
+                .get_delta(delta_idx)
+                .map(|d| delta_creates_file(&d))
+                .unwrap_or(false);
+            if creates {
+                return patch_text_for_hunk(&diff, delta_idx, hunk_index).map(Some);
+            }
+
             // Use ApplyOptions::hunk_callback to apply only the matching hunk.
             let mut counter: usize = 0;
             let mut apply_opts = git2::ApplyOptions::new();
@@ -2298,8 +2536,16 @@ impl GitBackend for Libgit2Backend {
 
             repo.apply(&diff, git2::ApplyLocation::Index, Some(&mut apply_opts))?;
             // apply_opts is dropped here, releasing the closure borrow.
-            Ok(())
-        })
+            Ok(None)
+        })?;
+
+        match creation_patch {
+            Some(text) => {
+                let repo_path = self.repo_path(repo_id)?;
+                git_apply(&repo_path, &["--cached"], &text)
+            }
+            None => Ok(()),
+        }
     }
 
     fn unstage_hunk(
@@ -2337,9 +2583,7 @@ impl GitBackend for Libgit2Backend {
     ) -> AppResult<()> {
         // Build patch text from the WorktreeToIndex diff, then `git apply --reverse`.
         let patch_text = self.with_repo(repo_id, |repo| {
-            let mut opts = DiffOptions::new();
-            opts.pathspec(path);
-            opts.context_lines(context_lines);
+            let mut opts = worktree_index_diff_opts(path, context_lines);
             let diff = repo.diff_index_to_workdir(None, Some(&mut opts))?;
             let delta_index = find_delta_index(&diff, path)?;
             patch_text_for_hunk(&diff, delta_index, hunk_index)
@@ -2362,9 +2606,7 @@ impl GitBackend for Libgit2Backend {
         // subset of its lines. So it synthesizes a partial patch and pipes it
         // through the same `git apply` path unstage/discard already use.
         let patch_text = self.with_repo(repo_id, |repo| {
-            let mut opts = DiffOptions::new();
-            opts.pathspec(path);
-            opts.context_lines(context_lines);
+            let mut opts = worktree_index_diff_opts(path, context_lines);
             let diff = repo.diff_index_to_workdir(None, Some(&mut opts))?;
             let delta_index = find_delta_index(&diff, path)?;
             patch_text_for_lines(
@@ -2421,9 +2663,7 @@ impl GitBackend for Libgit2Backend {
         context_lines: u32,
     ) -> AppResult<()> {
         let patch_text = self.with_repo(repo_id, |repo| {
-            let mut opts = DiffOptions::new();
-            opts.pathspec(path);
-            opts.context_lines(context_lines);
+            let mut opts = worktree_index_diff_opts(path, context_lines);
             let diff = repo.diff_index_to_workdir(None, Some(&mut opts))?;
             let delta_index = find_delta_index(&diff, path)?;
             patch_text_for_lines(

--- a/src-tauri/src/git/signing.rs
+++ b/src-tauri/src/git/signing.rs
@@ -129,6 +129,11 @@ pub struct SignatureStatus {
 /// `U` is "good signature, untrusted key" — reported as `Good`, with the signer
 /// line carrying the nuance, rather than inventing a state the UI would have to
 /// explain.
+///
+/// git's full code set is G/B/U/X/Y/R/E/N. `X` ("good signature that has
+/// expired") and `Y` ("good signature made by an expired key") are distinct codes
+/// but map to the same user-facing state: both are real signatures whose validity
+/// has lapsed. Missing `Y` reported a genuinely signed commit as unsigned.
 pub fn parse_verify_output(raw: &str) -> SignatureStatus {
     let mut parts = raw.trim_end_matches('\n').split('\0');
     let flag = parts.next().unwrap_or("N").trim();
@@ -138,7 +143,8 @@ pub fn parse_verify_output(raw: &str) -> SignatureStatus {
     let state = match flag.chars().next().unwrap_or('N') {
         'G' | 'U' => SigState::Good,
         'B' => SigState::Bad,
-        'X' => SigState::Expired,
+        // X: the signature expired. Y: the key that made it expired.
+        'X' | 'Y' => SigState::Expired,
         'R' => SigState::Revoked,
         'E' => SigState::UnknownKey,
         // 'N' and anything unexpected: treat as unsigned rather than claiming a
@@ -225,6 +231,9 @@ mod tests {
             // Good signature, untrusted key.
             ("U\0Ada <ada@x>\0ABCD", SigState::Good),
             ("X\0Ada <ada@x>\0ABCD", SigState::Expired),
+            // Good signature made by an expired key — a real signature, so it
+            // must never read as unsigned.
+            ("Y\0Ada <ada@x>\0ABCD", SigState::Expired),
             ("R\0Ada <ada@x>\0ABCD", SigState::Revoked),
             ("E\0\0", SigState::UnknownKey),
             ("N\0\0", SigState::None),

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -33,11 +33,24 @@ pub struct FileStatus {
     pub path: String,
     pub worktree: StatusFlag,
     pub index: StatusFlag,
-    /// Lines added in this file vs HEAD (working tree + index combined).
+    /// Lines added in this file, both sides combined (staged + unstaged).
     /// 0 for unmodified/binary files and in listings that don't compute stats.
     pub additions: u32,
-    /// Lines removed in this file vs HEAD (working tree + index combined).
+    /// Lines removed in this file, both sides combined (staged + unstaged).
     pub deletions: u32,
+    /// Lines added between HEAD and the INDEX — i.e. what committing would
+    /// actually record. Kept separate from the unstaged side because one number
+    /// per file cannot serve both: a partially staged file otherwise reports the
+    /// same count on its staged and unstaged rows, and the commit composer
+    /// overstates the commit by including edits that are not staged.
+    pub staged_additions: u32,
+    /// Lines removed between HEAD and the index.
+    pub staged_deletions: u32,
+    /// Lines added between the index and the WORKING TREE — i.e. what is still
+    /// unstaged.
+    pub unstaged_additions: u32,
+    /// Lines removed between the index and the working tree.
+    pub unstaged_deletions: u32,
     /// True when this entry is a directory that is itself a git repository and
     /// is not a registered submodule (a vendored dependency, a stray clone).
     /// libgit2 refuses to recurse across the nested `.git` boundary, so it

--- a/src-tauri/src/opener.rs
+++ b/src-tauri/src/opener.rs
@@ -80,22 +80,50 @@ pub fn safe_workdir_path(workdir: &Path, relative: &str) -> AppResult<PathBuf> {
     Ok(workdir.join(rel))
 }
 
+/// The launcher executable to spawn.
+///
+/// SECURITY (Windows): `CreateProcess` searches the **current directory before
+/// the system directory**, so a bare `rundll32.exe` lookup is a binary-planting
+/// hole — a cloned repository containing its own `rundll32.exe` would be run
+/// instead of the real one, and the app's cwd *is* the repository whenever it
+/// was launched by the `pgit` shim from inside one. Pin the path to
+/// `%SystemRoot%\System32` so only the real launcher can ever be spawned.
+///
+/// Written with a runtime `cfg!` rather than `#[cfg]`-gated bodies so the
+/// Windows branch is still type-checked when building on macOS and Linux.
+fn opener_program() -> std::ffi::OsString {
+    let (prog, _) = OPENER;
+    if cfg!(target_os = "windows") {
+        let root = std::env::var_os("SystemRoot")
+            .unwrap_or_else(|| std::ffi::OsString::from(r"C:\Windows"));
+        return Path::new(&root)
+            .join("System32")
+            .join(prog)
+            .into_os_string();
+    }
+    // On unix `execvp` does not search the working directory, so the PATH
+    // lookup that finds `open` / `xdg-open` is not attacker-influenced.
+    std::ffi::OsString::from(prog)
+}
+
 /// Hand `target` (a validated URL or path) to the OS default handler.
 ///
 /// Checks the child's exit status: `xdg-open` exits 3 when no handler exists,
 /// which the previous `let _ = …status()` reported as success while nothing
 /// opened.
 pub async fn open_with_default_app(target: &OsStr) -> AppResult<()> {
-    let (prog, pre) = OPENER;
-    let status = tokio::process::Command::new(prog)
+    let (_, pre) = OPENER;
+    let prog = opener_program();
+    let shown = prog.to_string_lossy().to_string();
+    let status = tokio::process::Command::new(&prog)
         .args(pre)
         .arg(target)
         .status()
         .await
-        .map_err(|e| AppError::Io(format!("failed to run {prog}: {e}")))?;
+        .map_err(|e| AppError::Io(format!("failed to run {shown}: {e}")))?;
     if !status.success() {
         return Err(AppError::Io(format!(
-            "{prog} exited with {status} while opening {}",
+            "{shown} exited with {status} while opening {}",
             target.to_string_lossy()
         )));
     }

--- a/src-tauri/tests/discard_reset.rs
+++ b/src-tauri/tests/discard_reset.rs
@@ -4,7 +4,37 @@ use std::path::{Path, PathBuf};
 
 use platypusgit_lib::error::AppError;
 use platypusgit_lib::git::GitBackend;
-use support::{fs::{read_file, write_file}, TempRepo};
+use support::{fs::{read_file, write_file}, with_conflicting_merge, TempRepo};
+
+/// A conflicted path has index entries at stages 1/2/3 and NONE at stage 0, so
+/// a stage-0-only tracked check misreads it as untracked — and discard's
+/// untracked branch deletes the file outright. Discarding a conflicted file must
+/// restore a tracked version, never remove the user's merge in progress.
+#[test]
+fn discard_restores_a_conflicted_file_instead_of_deleting_it() {
+    let tr = with_conflicting_merge();
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .discard(&handle.id, &[PathBuf::from("README.md")])
+        .expect("discard a conflicted path");
+
+    assert!(
+        tr.path().join("README.md").exists(),
+        "discard deleted a conflicted file instead of restoring it"
+    );
+    // Restoring a conflicted path re-materializes the conflict from the index
+    // stages, which is `git checkout --merge` semantics: the user's edits are
+    // thrown away and the merge they still have to resolve comes back. Both
+    // sides must survive.
+    let restored = read_file(tr.path(), "README.md");
+    assert!(restored.contains("main branch content"), "ours missing: {restored:?}");
+    assert!(
+        restored.contains("feature branch content"),
+        "theirs missing: {restored:?}"
+    );
+    assert!(restored.contains("<<<<<<<"), "no conflict markers: {restored:?}");
+}
 
 #[test]
 fn discard_restores_worktree_from_index() {

--- a/src-tauri/tests/hunks.rs
+++ b/src-tauri/tests/hunks.rs
@@ -2,6 +2,7 @@ mod support;
 
 use std::path::PathBuf;
 
+use platypusgit_lib::error::AppError;
 use platypusgit_lib::git::GitBackend;
 
 use support::{fs::write_file, TempRepo};
@@ -540,5 +541,69 @@ fn unstage_lines_removes_only_the_selected_line_from_the_index() {
         staged_content(&tr, "README.md"),
         "base\nadd2\nadd3\n",
         "only the selected line should be unstaged"
+    );
+}
+
+// ─── newly created (untracked) files ─────────────────────────────────────────
+//
+// `diff()` includes untracked content so the viewer can show a new file's
+// contents, and the UI offers hunk/line staging on what it shows. The staging
+// ops used to rebuild their diff WITHOUT the untracked options, so a new file had
+// no delta at all and every one of them failed with InvalidPath.
+
+/// Repo with one committed file plus a brand-new untracked file whose single
+/// hunk has three '+' changed lines at indices 0, 1, 2.
+fn repo_with_untracked_file() -> (TempRepo, platypusgit_lib::git::libgit2::Libgit2Backend, platypusgit_lib::git::types::RepoHandle) {
+    let tr = TempRepo::with_initial_commit("base\n");
+    write_file(tr.path(), "new.txt", "a\nb\nc\n");
+    let (backend, handle) = tr.open_with_backend();
+    (tr, backend, handle)
+}
+
+#[test]
+fn stage_lines_stages_only_the_selected_lines_of_an_untracked_file() {
+    let (tr, backend, handle) = repo_with_untracked_file();
+
+    backend
+        .stage_lines(&handle.id, &PathBuf::from("new.txt"), 0, &[0, 1], 3)
+        .expect("stage_lines on an untracked file");
+
+    assert_eq!(
+        staged_content(&tr, "new.txt"),
+        "a\nb\n",
+        "only the selected lines should reach the index"
+    );
+    // The worktree keeps the whole file.
+    assert_eq!(
+        std::fs::read_to_string(tr.path().join("new.txt")).unwrap(),
+        "a\nb\nc\n"
+    );
+}
+
+#[test]
+fn stage_hunk_stages_a_whole_untracked_file() {
+    let (tr, backend, handle) = repo_with_untracked_file();
+
+    backend
+        .stage_hunk(&handle.id, &std::path::Path::new("new.txt"), 0, 3)
+        .expect("stage_hunk on an untracked file");
+
+    assert_eq!(staged_content(&tr, "new.txt"), "a\nb\nc\n");
+}
+
+#[test]
+fn discard_lines_refuses_an_untracked_file_with_a_clear_error() {
+    // Reversing a creation patch cannot express "drop some of the lines", so this
+    // is refused rather than misapplied. Whole-file `discard` deletes an
+    // untracked path, which is the operation that actually makes sense here.
+    let (_tr, backend, handle) = repo_with_untracked_file();
+
+    let err = backend
+        .discard_lines(&handle.id, &PathBuf::from("new.txt"), 0, &[0], 3)
+        .expect_err("partial discard of an untracked file is refused");
+
+    assert!(
+        matches!(err, AppError::InvalidArgument(ref m) if m.contains("not tracked yet")),
+        "got {err:?}"
     );
 }

--- a/src-tauri/tests/log_pagination.rs
+++ b/src-tauri/tests/log_pagination.rs
@@ -131,6 +131,27 @@ fn a_merge_keeps_both_branches_alive_across_a_page_boundary() {
 }
 
 #[test]
+fn a_page_smaller_than_the_live_lane_count_keeps_every_lane() {
+    // Page size 2 above is >= the number of lanes, so every pushed start point
+    // gets walked. A page of ONE cannot: resuming from a two-lane cursor walks
+    // one lane and stops, leaving the other pushed-but-unvisited. It is nobody's
+    // parent in that page, so unless the frontier also carries its own start
+    // points forward, that lane is silently dropped and its commits never appear.
+    let tr = merged_history();
+    let (be, h) = tr.open_with_backend();
+
+    let all = be.log(&h.id, None, 1000).unwrap();
+    let paged = drain(&be, &h.id, 1);
+
+    let mut want = oids(&all);
+    let mut got = paged.clone();
+    want.sort();
+    got.sort();
+    assert_eq!(got, want, "a lane was dropped by a single-commit page");
+    assert_eq!(paged.len(), all.len(), "duplicate or missing commits");
+}
+
+#[test]
 fn paging_never_places_a_parent_before_its_child() {
     // The ordering guarantee that survives resumption, and the one the graph
     // layout actually depends on.
@@ -251,4 +272,48 @@ fn filtered_pages_cover_every_match_exactly_once() {
     }
 
     assert_eq!(paged, oids(&all));
+}
+
+#[test]
+fn filtered_pages_keep_both_lanes_of_a_merge_alive() {
+    // The linear-history test above cannot catch an over-consumed revwalk: the
+    // dropped oid is the previous commit's parent, so it survives in the frontier
+    // as a candidate anyway. A merge is what exposes it — a cursor START point
+    // pulled off the walk and discarded without being recorded is in neither
+    // `visited` nor `candidates`, so its whole lane vanishes from the log.
+    let tr = merged_history();
+    let (be, h) = tr.open_with_backend();
+    // Non-empty so this takes the filtered path (an empty filter delegates to
+    // log_page), and matches every commit in the fixture.
+    let filter = LogFilter {
+        author: Some("test@example.com".into()),
+        ..Default::default()
+    };
+
+    let all = be.log_filtered(&h.id, &filter, None, 1000).unwrap();
+    assert_eq!(all.len(), 6, "fixture should yield six commits");
+
+    // Small pages force several boundaries, each a chance to drop a lane.
+    for page in [1usize, 2, 3] {
+        let mut paged = Vec::new();
+        let mut cursor: Option<Vec<String>> = None;
+        loop {
+            let p = be
+                .log_filtered_page(&h.id, &filter, None, cursor.as_deref(), page)
+                .unwrap();
+            paged.extend(p.commits.iter().map(|c| c.oid.clone()));
+            match p.next_cursor {
+                Some(c) => cursor = Some(c),
+                None => break,
+            }
+            assert!(paged.len() < 1_000, "filtered pagination did not terminate");
+        }
+        paged.sort();
+        let mut want = oids(&all);
+        want.sort();
+        assert_eq!(
+            paged, want,
+            "page size {page} lost or duplicated commits across a merge boundary"
+        );
+    }
 }

--- a/src-tauri/tests/status_stats.rs
+++ b/src-tauri/tests/status_stats.rs
@@ -49,6 +49,42 @@ fn status_counts_staged_changes() {
     assert_eq!(readme.deletions, 0);
 }
 
+/// A partially staged file must report each side separately.
+///
+/// One combined HEAD→worktree number cannot answer both questions: the commit
+/// composer needs what committing would record (the staged side), while the
+/// unstaged row needs what is left over. Sharing one number made the composer
+/// overstate the commit and made both rows show the same count.
+#[test]
+fn status_separates_staged_from_unstaged_line_counts() {
+    let tr = TempRepo::with_initial_commit("a\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    // Stage one added line…
+    write_file(tr.path(), "README.md", "a\nstaged\n");
+    backend
+        .stage(&handle.id, &[PathBuf::from("README.md")])
+        .expect("stage");
+    // …then add two more in the worktree without staging them.
+    write_file(tr.path(), "README.md", "a\nstaged\nloose one\nloose two\n");
+
+    let status = backend.status(&handle.id).unwrap();
+    let readme = status.iter().find(|f| f.path == "README.md").unwrap();
+
+    assert_eq!(
+        (readme.staged_additions, readme.staged_deletions),
+        (1, 0),
+        "the commit would record exactly the one staged line"
+    );
+    assert_eq!(
+        (readme.unstaged_additions, readme.unstaged_deletions),
+        (2, 0),
+        "two lines are still unstaged"
+    );
+    // The combined pair stays available for callers that want one number.
+    assert_eq!((readme.additions, readme.deletions), (3, 0));
+}
+
 /// An unmodified working tree reports zero counts (and typically no entries).
 #[test]
 fn status_unmodified_has_zero_counts() {

--- a/src/features/auth/CredentialDialog.tsx
+++ b/src/features/auth/CredentialDialog.tsx
@@ -113,11 +113,18 @@ export function CredentialDialog() {
           </div>
         </label>
 
-        <PGCheckbox
-          checked={remember}
-          onChange={setRemember}
-          label="Remember — stores it with git's own credential helper"
-        />
+        {/* HTTPS only. git's credential helpers store HTTP(S) passwords; an SSH
+            key passphrase belongs in ssh-agent, and handing it to `git
+            credential approve` would file it as this host's HTTPS password —
+            the wrong secret in the wrong store, offered on the next HTTPS
+            prompt. `withAuthRetry` enforces the same rule. */}
+        {challenge.kind === "Https" && (
+          <PGCheckbox
+            checked={remember}
+            onChange={setRemember}
+            label="Remember — stores it with git's own credential helper"
+          />
+        )}
 
         <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
           <PGButton

--- a/src/features/create/useCreateStore.auth.test.ts
+++ b/src/features/create/useCreateStore.auth.test.ts
@@ -1,0 +1,138 @@
+// Cloning a private remote must be able to ask for a credential (#61 D5).
+//
+// The backend already classifies a clone failure as AppError::Auth and
+// clone_repo already accepts credentials, but runClone neither passed them nor
+// raised the challenge — so the Clone dialog printed "Authentication required"
+// with nothing to answer it, a dead end for exactly the case the credential
+// feature was built for.
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useCreateStore } from "@/features/create/useCreateStore";
+import { useAuthStore } from "@/features/auth/useAuthStore";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+
+const AUTH = {
+  kind: "Auth",
+  message: { host: "github.com", kind: "Https" },
+};
+const HANDLE = { id: "repo-9", path: "/dev/private", head: "main" };
+
+function calls(cmd: string) {
+  return getInvokeCalls().filter((c) => c.cmd === cmd);
+}
+
+/** `clone_repo` refuses without credentials, succeeds once given them. */
+function armClone() {
+  mockInvoke("clone_repo", (args) => {
+    if (!args.credentials) throw AUTH;
+    return "/dev/private";
+  });
+  mockInvoke("open_repo", () => HANDLE);
+  mockInvoke("trust_repo_path", () => undefined);
+  mockInvoke("remember_credential", () => undefined);
+  // openRepo's refresh fan-out.
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => null);
+  mockInvoke("list_all_files", () => []);
+}
+
+beforeEach(() => {
+  resetInvokeMock();
+  useAuthStore.setState({ challenge: null });
+  useCreateStore.setState({
+    open: "clone",
+    busy: false,
+    progress: null,
+    error: null,
+  });
+  useRepoStore.setState({ current: null } as never);
+});
+
+describe("clone credential retry", () => {
+  it("raises a credential challenge instead of a dead-end error", async () => {
+    armClone();
+
+    await useCreateStore.getState().runClone({
+      url: "https://github.com/me/private.git",
+      parentDir: "/dev",
+      name: "private",
+      recurseSubmodules: false,
+    });
+
+    const challenge = useAuthStore.getState().challenge;
+    expect(challenge).not.toBeNull();
+    expect(challenge?.host).toBe("github.com");
+    expect(challenge?.kind).toBe("Https");
+    // No error text: the prompt IS the answer to this failure.
+    expect(useCreateStore.getState().error).toBeNull();
+    // The dialog must stay dismissable while the prompt is up — `close()`
+    // refuses to close while busy.
+    expect(useCreateStore.getState().busy).toBe(false);
+  });
+
+  it("retries the clone with the supplied credential and closes on success", async () => {
+    armClone();
+    await useCreateStore.getState().runClone({
+      url: "https://github.com/me/private.git",
+      parentDir: "/dev",
+      name: "private",
+      recurseSubmodules: false,
+    });
+
+    await useAuthStore
+      .getState()
+      .challenge!.retry({ username: "ada", secret: "token" }, false);
+
+    expect(calls("clone_repo")).toHaveLength(2);
+    expect(calls("clone_repo")[1].args.credentials).toEqual({
+      username: "ada",
+      secret: "token",
+    });
+    expect(useCreateStore.getState().open).toBe("none");
+    expect(useCreateStore.getState().error).toBeNull();
+  });
+
+  it("remembers the credential only after the clone actually worked", async () => {
+    armClone();
+    await useCreateStore.getState().runClone({
+      url: "https://github.com/me/private.git",
+      parentDir: "/dev",
+      name: "private",
+      recurseSubmodules: false,
+    });
+
+    // Nothing stored yet — the credential has not been proven.
+    expect(calls("remember_credential")).toHaveLength(0);
+
+    await useAuthStore
+      .getState()
+      .challenge!.retry({ username: "ada", secret: "token" }, true);
+
+    expect(calls("remember_credential")).toHaveLength(1);
+    expect(calls("remember_credential")[0].args.host).toBe("github.com");
+  });
+
+  it("surfaces a non-auth failure in the dialog without prompting", async () => {
+    mockInvoke("clone_repo", () => {
+      throw { kind: "Network", message: "could not resolve host" };
+    });
+
+    await useCreateStore.getState().runClone({
+      url: "https://nope.invalid/x.git",
+      parentDir: "/dev",
+      name: "x",
+      recurseSubmodules: false,
+    });
+
+    expect(useAuthStore.getState().challenge).toBeNull();
+    expect(useCreateStore.getState().error).toContain("could not resolve host");
+    expect(useCreateStore.getState().busy).toBe(false);
+  });
+});

--- a/src/features/create/useCreateStore.ts
+++ b/src/features/create/useCreateStore.ts
@@ -3,9 +3,21 @@ import { create } from "zustand";
 import { confirmTrust } from "@/features/repo/ownership";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
-import { cloneRepo, initRepo, trustRepoPath } from "@/lib/tauri";
+import { useAuthStore } from "@/features/auth/useAuthStore";
+import {
+  cloneRepo,
+  initRepo,
+  rememberCredential,
+  trustRepoPath,
+  type Credentials,
+} from "@/lib/tauri";
 import type { CloneProgress, RepoHandle } from "@/lib/types";
-import { appErrorMessage, dubiousOwnershipPath, isDubiousOwnershipError } from "@/lib/errors";
+import {
+  appErrorMessage,
+  dubiousOwnershipPath,
+  isAuthError,
+  isDubiousOwnershipError,
+} from "@/lib/errors";
 
 type OpenDialog = "none" | "clone" | "init";
 
@@ -60,17 +72,63 @@ export const useCreateStore = create<CreateState>((set, get) => ({
 
   async runClone({ url, parentDir, name, recurseSubmodules }) {
     set({ busy: true, error: null, progress: null });
-    try {
-      const dest = await cloneRepo(url, parentDir, name, recurseSubmodules);
+
+    const attempt = async (creds?: Credentials) => {
+      const dest = await cloneRepo(url, parentDir, name, recurseSubmodules, creds);
       useSettingsStore.getState().set("lastCreateDir", parentDir);
       // busy false BEFORE close(), which refuses to close while busy.
       set({ busy: false, progress: null });
       set({ open: "none" });
       await useRepoStore.getState().openRepo(dest);
+    };
+
+    try {
+      await attempt();
     } catch (e) {
-      // Error stays in the dialog: the user needs the form still populated to
-      // fix a bad URL and retry.
-      set({ busy: false, progress: null, error: appErrorMessage(e) });
+      // A private remote is exactly what the credential flow exists for. The
+      // backend already classifies clone failures as AppError::Auth and
+      // clone_repo already takes credentials; without raising the challenge the
+      // Clone dialog just printed "Authentication required" with no way to
+      // answer it.
+      if (!isAuthError(e)) {
+        // Error stays in the dialog: the user needs the form still populated to
+        // fix a bad URL and retry.
+        set({ busy: false, progress: null, error: appErrorMessage(e) });
+        return;
+      }
+      const { host, kind } = e.message;
+      // Drop `busy` before prompting. `close()` refuses to close while busy, so
+      // staying busy would leave the Clone dialog undismissable if the user
+      // cancels the credential prompt.
+      set({ busy: false, progress: null, error: null });
+      useAuthStore.getState().raise({
+        host,
+        kind,
+        retry: async (creds, remember) => {
+          set({ busy: true, error: null, progress: null });
+          try {
+            await attempt(creds);
+            // Only after it worked, and only for HTTPS — `git credential
+            // approve` stores an HTTP(S) password. Needs the freshly opened repo
+            // to run the helper in, so this comes after `attempt` succeeded.
+            if (remember && host && kind === "Https") {
+              const repo = useRepoStore.getState().current;
+              if (repo) {
+                await rememberCredential(repo.id, host, creds).catch(() => {
+                  // No helper configured is not a failure worth surfacing — the
+                  // clone the user asked for still succeeded.
+                });
+              }
+            }
+          } catch (retryError) {
+            set({
+              busy: false,
+              progress: null,
+              error: appErrorMessage(retryError),
+            });
+          }
+        },
+      });
     }
   },
 

--- a/src/features/repo/useRepoStore.settings.test.ts
+++ b/src/features/repo/useRepoStore.settings.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
 import { useRepoStore } from "./useRepoStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { useAuthStore } from "@/features/auth/useAuthStore";
 
 function mockRefreshAll() {
   mockInvoke("get_status", () => []);
@@ -97,6 +98,76 @@ describe("pull auto-stash", () => {
       kind: "Network",
       message: "diverged",
     });
+  });
+
+  // The stash must survive an auth challenge. The first attempt stashes and then
+  // fails on credentials; the retry used to re-enter the closure with a fresh
+  // `stashed = null`, find the tree clean (the work being in the stash), pull
+  // successfully and never pop — silently leaving the user's uncommitted work in
+  // a stash they were never told about.
+  it("pops the first attempt's stash after an auth retry succeeds", async () => {
+    let pullAttempts = 0;
+    let stashes = 0;
+    // Realistic: the first save stashes the dirty tree, and any later save finds
+    // a clean tree (the work is already stashed) and so returns null.
+    mockInvoke("stash_save", () => {
+      stashes += 1;
+      return stashes === 1 ? "stash-oid" : null;
+    });
+    mockInvoke("pull", () => {
+      pullAttempts += 1;
+      if (pullAttempts === 1) {
+        throw { kind: "Auth", message: { host: "github.com", kind: "Https" } };
+      }
+      return null;
+    });
+    mockInvoke("stash_pop", () => null);
+    mockInvoke("remember_credential", () => null);
+
+    await useRepoStore.getState().pull("origin", "main", "Merge");
+
+    // The challenge is raised rather than surfaced as an error.
+    const challenge = useAuthStore.getState().challenge;
+    expect(challenge).not.toBeNull();
+    expect(calls("stash_pop")).toHaveLength(0);
+
+    await challenge!.retry({ username: "ada", secret: "token" }, false);
+
+    expect(pullAttempts).toBe(2);
+    // Exactly one stash across both attempts, and it is popped.
+    expect(calls("stash_save")).toHaveLength(1);
+    expect(calls("stash_pop")).toHaveLength(1);
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  // `git credential approve` stores an HTTP(S) password. Remembering an SSH key
+  // passphrase there files the wrong secret under protocol=https for the host,
+  // and it would then be offered at the next HTTPS prompt.
+  it("never remembers an SSH passphrase with git's credential helper", async () => {
+    let attempts = 0;
+    mockInvoke("stash_save", () => null);
+    mockInvoke("pull", () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw {
+          kind: "Auth",
+          message: { host: "github.com", kind: "SshPassphrase" },
+        };
+      }
+      return null;
+    });
+    mockInvoke("remember_credential", () => null);
+
+    await useRepoStore.getState().pull("origin", "main", "Merge");
+    const challenge = useAuthStore.getState().challenge;
+    expect(challenge?.kind).toBe("SshPassphrase");
+
+    // Even with remember explicitly requested.
+    await challenge!.retry({ secret: "key-passphrase" }, true);
+
+    expect(attempts).toBe(2);
+    expect(calls("remember_credential")).toHaveLength(0);
+    expect(useRepoStore.getState().error).toBeNull();
   });
 });
 

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -330,7 +330,11 @@ async function withAuthRetry(
         try {
           await run(creds);
           // Only after it worked: storing on submit would persist a typo.
-          if (remember && host) {
+          // HTTPS only: `git credential approve` stores an HTTP(S) password, so
+          // remembering an SSH passphrase there would file the wrong secret
+          // under `protocol=https` for this host and offer it at the next HTTPS
+          // prompt. SSH passphrases belong to ssh-agent, which we do not manage.
+          if (remember && host && kind === "Https") {
             await rememberCredential(repoId, host, creds).catch(() => {
               // No helper configured is not a failure the user needs to see —
               // the operation they asked for still succeeded.
@@ -1129,19 +1133,26 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   async pull(remote, branch, mode = "Merge") {
     const repo = get().current;
     if (!repo) return;
-    setActivity("pull", `Pulling ${remote}/${branch}…`);
-    try {
-      await withAuthRetry(
-        repo.id,
-        async (creds) => {
+    // Declared OUTSIDE the retried closure on purpose. An auth failure leaves
+    // the stash in place (see the failure policy below) and then re-runs this
+    // closure with credentials; a per-attempt variable would start at null, find
+    // the now-clean tree, pull successfully and never pop — silently stranding
+    // the user's uncommitted work in a stash they were never told about.
+    let stashed: string | null = null;
+    await withAuthRetry(
+      repo.id,
+      async (creds) => {
+        // Each attempt owns its own progress indicator: the retry runs long
+        // after the first attempt's `finally` would have cleared it.
+        setActivity("pull", `Pulling ${remote}/${branch}…`);
+        try {
           // Carry over uncommitted work when the setting is on: stash → pull →
           // pop, mirroring checkoutBranch's auto-stash. stashSave returns null
           // when the tree is clean, so this is a no-op in the common case. If
           // the pull fails, the stash is deliberately NOT popped — the work
           // stays safe in the stash list rather than colliding with a conflicted
           // worktree (same policy as checkoutBranch).
-          let stashed: string | null = null;
-          if (useSettingsStore.getState().autoStashBeforePull) {
+          if (useSettingsStore.getState().autoStashBeforePull && stashed === null) {
             setActivity("pull", "Stashing changes…");
             stashed = await stashSave(repo.id, {
               message: `auto: pull ${remote}/${branch}`,
@@ -1154,19 +1165,21 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
           if (stashed) {
             setActivity("pull", "Restoring stashed changes…");
             await stashPop(repo.id, 0);
+            // Popped — a later attempt must not pop it a second time.
+            stashed = null;
           }
           await get().refreshAll();
-        },
-        async (e) => {
-          // See mergeBranch's catch: refresh first, error last, so it isn't
-          // batched away by refreshAll's own `error: null` reset.
-          await get().refreshAll();
-          set({ error: toAppError(e) });
-        },
-      );
-    } finally {
-      setActivity("pull", null);
-    }
+        } finally {
+          setActivity("pull", null);
+        }
+      },
+      async (e) => {
+        // See mergeBranch's catch: refresh first, error last, so it isn't
+        // batched away by refreshAll's own `error: null` reset.
+        await get().refreshAll();
+        set({ error: toAppError(e) });
+      },
+    );
   },
 
   async push(remote, branch, force = "None") {

--- a/src/features/signing/SignatureBadge.test.tsx
+++ b/src/features/signing/SignatureBadge.test.tsx
@@ -1,0 +1,53 @@
+// Signature verification is a `git show` SUBPROCESS per call (#61 D6), so the
+// badge must settle before asking — arrowing through the log otherwise spawns one
+// process per row passed over, all still queued behind spawn_blocking after the
+// user has stopped. The inline commit diff beside it in the same panel already
+// debounces; this pins that the badge does too.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { SignatureBadge } from "./SignatureBadge";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+
+const GOOD = { state: "Good", signer: "Ada <ada@x>", key: "ABCD" };
+
+const verifyCalls = () => getInvokeCalls().filter((c) => c.cmd === "verify_commit");
+
+beforeEach(() => {
+  resetInvokeMock();
+  vi.useRealTimers();
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "main" },
+  } as never);
+  mockInvoke("verify_commit", () => GOOD);
+});
+
+describe("SignatureBadge", () => {
+  it("verifies and renders the verdict", async () => {
+    render(<SignatureBadge oid={"a".repeat(40)} />);
+
+    await waitFor(() => expect(screen.getByTestId("signature-badge")).toBeTruthy());
+    expect(screen.getByTestId("signature-badge").textContent).toContain("Signed");
+    expect(verifyCalls()).toHaveLength(1);
+  });
+
+  it("does not verify a commit that was only passed through", async () => {
+    // Three rows arrowed over in quick succession: only the one the user landed
+    // on is worth a subprocess.
+    const { rerender } = render(<SignatureBadge oid={"1".repeat(40)} />);
+    rerender(<SignatureBadge oid={"2".repeat(40)} />);
+    rerender(<SignatureBadge oid={"3".repeat(40)} />);
+
+    await waitFor(() => expect(verifyCalls()).toHaveLength(1));
+    expect(verifyCalls()[0].args.oid).toBe("3".repeat(40));
+  });
+
+  it("renders nothing for an unsigned commit", async () => {
+    mockInvoke("verify_commit", () => ({ state: "None", signer: null, key: null }));
+    render(<SignatureBadge oid={"b".repeat(40)} />);
+
+    await waitFor(() => expect(verifyCalls()).toHaveLength(1));
+    expect(screen.queryByTestId("signature-badge")).toBeNull();
+  });
+});

--- a/src/features/signing/SignatureBadge.tsx
+++ b/src/features/signing/SignatureBadge.tsx
@@ -24,6 +24,16 @@ const LOOK: Record<
 };
 
 /**
+ * Settle time before verifying, matching the inline commit diff rendered beside
+ * this badge in the same panel (History's INLINE_DIFF_DEBOUNCE_MS).
+ *
+ * `verify_commit` shells out to `git show`, so without this, arrowing through the
+ * log spawns one process per row passed over — all of them still queued behind
+ * `spawn_blocking` after the user has stopped moving.
+ */
+const VERIFY_DEBOUNCE_MS = 100;
+
+/**
  * Signature status of one commit (#61 D6).
  *
  * Verifies **lazily, for this commit only** — a badge on every log row would
@@ -41,17 +51,20 @@ export function SignatureBadge({ oid }: { oid: string }) {
     }
     let cancelled = false;
     setStatus(null);
-    verifyCommit(repoId, oid)
-      .then((s) => {
-        if (!cancelled) setStatus(s);
-      })
-      .catch(() => {
-        // A verification failure is not worth an error banner: the commit and
-        // its diff are still perfectly viewable.
-        if (!cancelled) setStatus(null);
-      });
+    const handle = window.setTimeout(() => {
+      verifyCommit(repoId, oid)
+        .then((s) => {
+          if (!cancelled) setStatus(s);
+        })
+        .catch(() => {
+          // A verification failure is not worth an error banner: the commit and
+          // its diff are still perfectly viewable.
+          if (!cancelled) setStatus(null);
+        });
+    }, VERIFY_DEBOUNCE_MS);
     return () => {
       cancelled = true;
+      window.clearTimeout(handle);
     };
   }, [repoId, oid]);
 

--- a/src/lib/derive.ts
+++ b/src/lib/derive.ts
@@ -126,3 +126,34 @@ export function headSummary(
 ): CommitInfo | null {
   return commits[0] ?? null;
 }
+
+/**
+ * Added-line count for ONE side of a file's changes.
+ *
+ * A file can be modified on both sides at once, and `additions` is the two
+ * combined — so rendering it on a staged row overstates what committing would
+ * record, and rendering it on both rows shows the same number twice. The
+ * per-side fields answer the question the row is actually asking.
+ *
+ * Falls back to the combined count when the per-side fields are absent, which is
+ * the case for the many `FileStatus` fixtures in tests; `get_status` always
+ * sends them.
+ */
+export function sideAdditions(
+  status: FileStatus,
+  side: "staged" | "unstaged",
+): number {
+  const own =
+    side === "staged" ? status.stagedAdditions : status.unstagedAdditions;
+  return own ?? status.additions;
+}
+
+/** Removed-line count for one side. See {@link sideAdditions}. */
+export function sideDeletions(
+  status: FileStatus,
+  side: "staged" | "unstaged",
+): number {
+  const own =
+    side === "staged" ? status.stagedDeletions : status.unstagedDeletions;
+  return own ?? status.deletions;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -21,11 +21,29 @@ export interface FileStatus {
   path: string;
   worktree: StatusFlag;
   index: StatusFlag;
-  /** Lines added vs HEAD (worktree + index). 0 when unmodified/binary or in
-   *  listings that don't compute stats (all-files / at-revision). */
+  /** Lines added, both sides combined (staged + unstaged). 0 when
+   *  unmodified/binary or in listings that don't compute stats (all-files /
+   *  at-revision). */
   additions: number;
-  /** Lines removed vs HEAD (worktree + index). */
+  /** Lines removed, both sides combined (staged + unstaged). */
   deletions: number;
+  /**
+   * Lines added between HEAD and the INDEX — what committing would record.
+   *
+   * Optional only so the many `FileStatus` fixtures in tests need not restate
+   * it; `get_status` always sends it. Prefer this and `unstagedAdditions` over
+   * the combined pair when rendering a specific side: one number per file
+   * cannot serve both, so a partially staged file would otherwise show the same
+   * counts on its staged and unstaged rows and the composer would overstate the
+   * commit.
+   */
+  stagedAdditions?: number;
+  /** Lines removed between HEAD and the index. */
+  stagedDeletions?: number;
+  /** Lines added between the index and the WORKING TREE — still unstaged. */
+  unstagedAdditions?: number;
+  /** Lines removed between the index and the working tree. */
+  unstagedDeletions?: number;
   /**
    * True when this entry is a directory that is itself a git repository and is
    * not a registered submodule (vendored dependency, stray clone, submodule

--- a/src/lib/useWindowedList.ts
+++ b/src/lib/useWindowedList.ts
@@ -62,15 +62,41 @@ export function useWindowedList<T extends HTMLElement = HTMLDivElement>(o: {
   const [scrollTop, setScrollTop] = React.useState(0);
   const [viewportH, setViewportH] = React.useState(0);
 
+  // Measure + observe the scroll element, re-binding whenever it CHANGES.
+  //
+  // Deliberately has no dependency array. A ref's `.current` is not reactive, so
+  // an `[]` effect that bailed on a null ref would never retry: a caller whose
+  // scroller mounts later (behind a loading guard) or swaps element identity
+  // would be left with viewportH === 0 forever, permanently falling back to the
+  // `rowHeight * 20` screenful in `windowRange` — a tall window renders blank
+  // below that and resizing never fixes it. Running every render costs one ref
+  // comparison, and the identity guard keeps it from re-creating the observer.
+  const observedRef = React.useRef<T | null>(null);
+  const roRef = React.useRef<ResizeObserver | null>(null);
   React.useEffect(() => {
     const el = viewportRef.current;
+    if (el === observedRef.current) return;
+    roRef.current?.disconnect();
+    roRef.current = null;
+    observedRef.current = el;
     if (!el) return;
     setViewportH(el.clientHeight);
     if (typeof ResizeObserver === "undefined") return;
     const ro = new ResizeObserver(() => setViewportH(el.clientHeight));
     ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
+    roRef.current = ro;
+  });
+
+  // Unmount-only teardown. The measuring effect above cannot own this: with no
+  // dependency array its cleanup would run after every render.
+  React.useEffect(
+    () => () => {
+      roRef.current?.disconnect();
+      roRef.current = null;
+      observedRef.current = null;
+    },
+    [],
+  );
 
   const onScroll = React.useCallback(() => {
     const el = viewportRef.current;

--- a/src/screens/CommitPanel.lineStaging.test.tsx
+++ b/src/screens/CommitPanel.lineStaging.test.tsx
@@ -137,6 +137,27 @@ describe("CommitPanel line-level staging (#61 D7)", () => {
     expect(stageLinesCall()).toBeUndefined();
   });
 
+  // After a partial stage the pane must show the NEW diff. The fetch effect keyed
+  // only on path/side/embedded, none of which change when the same file is
+  // partially staged, so the stale diff stayed on screen — and a follow-up
+  // selection then sent indices into it while the backend recomputed a fresh
+  // diff, staging different lines than the ones highlighted.
+  it("refetches the diff after a partial stage", async () => {
+    // refreshStatus fetches status and repo state together, so both must answer
+    // or it fails and never publishes the new status.
+    mockInvoke("repo_state", () => "Clean");
+    const diffCalls = () => getInvokeCalls().filter((c) => c.cmd === "get_diff");
+    const rows = await screen.findAllByTestId("diff-line-changed");
+    await waitFor(() => expect(diffCalls().length).toBeGreaterThan(0));
+    const before = diffCalls().length;
+
+    fireEvent.click(rows[0]);
+    fireEvent.click(screen.getByTestId("hunk-stage"));
+
+    await waitFor(() => expect(stageLinesCall()).toBeDefined());
+    await waitFor(() => expect(diffCalls().length).toBeGreaterThan(before));
+  });
+
   it("does not offer line selection while whitespace is ignored", async () => {
     await screen.findAllByTestId("diff-line-changed");
     fireEvent.click(screen.getByTitle("Ignore whitespace-only changes"));

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -38,6 +38,8 @@ import {
   isStaged,
   isUnstaged,
   isUntracked,
+  sideAdditions,
+  sideDeletions,
   statusMark,
 } from "@/lib/derive";
 import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
@@ -471,7 +473,23 @@ export function CommitPanelScreen() {
     return () => {
       cancelled = true;
     };
-  }, [selected?.path, selected?.side, selected?.status.embedded, repo, diffContextLines, ignoreWhitespace]);
+    // `status` is in here on purpose, as the signal that the file's staging state
+    // moved. Nothing else in this list changes when the SAME file is partially
+    // staged: path and side stay put, and additions/deletions are HEAD→worktree
+    // totals that a stage does not alter. Without it the pane kept showing the
+    // pre-stage diff, and the next line selection addressed indices into that
+    // stale diff while the backend recomputed a fresh one — staging lines other
+    // than the highlighted ones. `refreshStatus` replaces the array, so identity
+    // is the dependency; the cost is one diff fetch per status refresh.
+  }, [
+    selected?.path,
+    selected?.side,
+    selected?.status.embedded,
+    status,
+    repo,
+    diffContextLines,
+    ignoreWhitespace,
+  ]);
 
   // A line selection stops meaning the same thing once the file, the side, or
   // the diff shape changes — the indices would then address different lines.
@@ -482,12 +500,15 @@ export function CommitPanelScreen() {
   const headBranch = currentBranch(branches);
   const defaultRemote = remotes[0] ?? null;
 
+  // The composer's summary describes THE COMMIT, so it counts the staged side
+  // only. `additions`/`deletions` are both sides combined, which overstated the
+  // commit whenever a staged file had further unstaged edits.
   const stagedAdd = React.useMemo(
-    () => staged.reduce((s, f) => s + f.status.additions, 0),
+    () => staged.reduce((s, f) => s + sideAdditions(f.status, "staged"), 0),
     [staged],
   );
   const stagedDel = React.useMemo(
-    () => staged.reduce((s, f) => s + f.status.deletions, 0),
+    () => staged.reduce((s, f) => s + sideDeletions(f.status, "staged"), 0),
     [staged],
   );
 
@@ -752,8 +773,8 @@ export function CommitPanelScreen() {
                 path={f.path}
                 status={statusMark(f.status)}
                 staged
-                additions={f.status.additions}
-                deletions={f.status.deletions}
+                additions={sideAdditions(f.status, "staged")}
+                deletions={sideDeletions(f.status, "staged")}
                 selected={effectiveKeys.has(keyOf(f))}
                 onClick={onRowClick(f)}
                 onContextMenu={onRowContextMenu(f)}
@@ -826,8 +847,8 @@ export function CommitPanelScreen() {
                 path={f.path}
                 status={statusMark(f.status)}
                 staged={false}
-                additions={f.status.additions}
-                deletions={f.status.deletions}
+                additions={sideAdditions(f.status, "unstaged")}
+                deletions={sideDeletions(f.status, "unstaged")}
                 selected={effectiveKeys.has(keyOf(f))}
                 onClick={onRowClick(f)}
                 onContextMenu={onRowContextMenu(f)}

--- a/src/screens/History.pagination.test.tsx
+++ b/src/screens/History.pagination.test.tsx
@@ -1,7 +1,7 @@
 // History asks for the next page as the window nears the end of the loaded
 // list, and stops asking at the end of history (#68 G11).
 import { describe, expect, it, beforeEach, vi } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 
 import { HistoryScreen } from "./History";
 import { useRepoStore } from "@/features/repo/useRepoStore";
@@ -96,6 +96,58 @@ describe("History pagination", () => {
     await waitFor(() =>
       expect(container.querySelector('[data-testid="log-loading-more"]')).not.toBeNull(),
     );
+  });
+
+  // A client-side filter can hold `visible` shorter than the window forever —
+  // "This branch" hard-caps it at `ahead`. The end-of-list condition is then true
+  // at rest, and every completed fetch re-arms the effect, so auto-paging used to
+  // walk the entire repository 500 commits at a time without the user scrolling.
+  it("stops auto-paging when a client-side filter starves the visible list", async () => {
+    let loaded = 0;
+    // Mirrors the real action: it flips `loadingMore` around the fetch, and that
+    // toggle is what re-arms the effect after each page.
+    const loadMoreCommits = vi.fn(async () => {
+      loaded += 1;
+      useRepoStore.setState({ loadingMore: true } as never);
+      await Promise.resolve();
+      useRepoStore.setState({
+        loadingMore: false,
+        // Each page appends more history that the "This branch" cap hides anyway.
+        commits: [
+          ...(useRepoStore.getState().commits as CommitInfo[]),
+          ...Array.from({ length: 30 }, (_, i) => ({
+            ...LOG[0],
+            oid: oid(1000 + loaded * 100 + i),
+            shortOid: String(1000 + loaded * 100 + i),
+          })),
+        ],
+      } as never);
+    });
+    prime({
+      commitCursor: ["frontier-oid"],
+      loadMoreCommits,
+      branches: [
+        {
+          name: "main",
+          isHead: true,
+          isRemote: false,
+          upstream: "origin/main",
+          ahead: 2,
+          behind: 0,
+          tip: oid(0),
+        },
+      ],
+    });
+
+    const { getByText } = render(<HistoryScreen />);
+    fireEvent.click(getByText("This branch"));
+
+    // Let the effect settle and re-arm as many times as it wants to.
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Bounded: a few barren pages are fine (a sparse filter has to dig), but it
+    // must not keep paging forever.
+    expect(loadMoreCommits.mock.calls.length).toBeLessThanOrEqual(4);
   });
 
   it("paginates a filtered list from its own cursor", async () => {

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -63,6 +63,11 @@ const DIFF_LAYOUT_KEY = "pg-history-diff-layout";
  * see the bottom, rather than after they hit it (#68 G11).
  */
 const LOAD_MORE_SLACK = 8;
+
+/// How many consecutive pages that add no *visible* rows auto-paging will fetch
+/// before giving up. Bounds a starving client-side filter to a few pages instead
+/// of a walk of the whole repository.
+const MAX_BARREN_PAGES = 3;
 /** Small debounce so arrow-scrolling the log doesn't fire a fetch per row. */
 const INLINE_DIFF_DEBOUNCE_MS = 100;
 
@@ -231,10 +236,43 @@ export function HistoryScreen() {
   // Fetch the next page as the window reaches the end of the loaded list.
   // Driven by the window rather than a scroll listener so there is one source
   // of truth for "where the user is" (#68 G11 on top of G10).
+  //
+  // Bounded on purpose. `visible` is the CLIENT-side-filtered list, and a filter
+  // can hold it shorter than the window indefinitely — "This branch" hard-caps it
+  // at `ahead`, and "mine"/hide-merges can starve it just as effectively. The
+  // end-of-list condition is then satisfied at rest with no scrolling, and
+  // `loadMoreCommits` toggling `loadingMore` re-arms this effect after every
+  // page, so it would walk the entire repository a page at a time. Allow a few
+  // consecutive pages that add no visible rows (a sparse filter legitimately has
+  // to dig for matches), then stop until something actually changes.
+  const autoPage = React.useRef({ barren: 0, sawVisible: -1, sawBase: -1 });
+  React.useEffect(() => {
+    // Any change to what is being filtered is a fresh start.
+    autoPage.current = { barren: 0, sawVisible: -1, sawBase: -1 };
+  }, [filterKind, hideMerges, searchResults]);
+
   React.useEffect(() => {
     if (!hasMoreLog || loadingMore) return;
-    if (win.end >= visible.length - LOAD_MORE_SLACK) void loadMoreCommits();
-  }, [win.end, visible.length, hasMoreLog, loadingMore, loadMoreCommits]);
+    if (win.end < visible.length - LOAD_MORE_SLACK) return;
+
+    const st = autoPage.current;
+    if (st.sawBase >= 0) {
+      if (visible.length > st.sawVisible) st.barren = 0;
+      else if (baseCommits.length > st.sawBase) st.barren += 1;
+    }
+    if (st.barren >= MAX_BARREN_PAGES) return;
+
+    st.sawVisible = visible.length;
+    st.sawBase = baseCommits.length;
+    void loadMoreCommits();
+  }, [
+    win.end,
+    visible.length,
+    baseCommits.length,
+    hasMoreLog,
+    loadingMore,
+    loadMoreCommits,
+  ]);
 
   const graphW = graphWidth(maxCol);
   const graphClamped = isGraphClamped(maxCol);


### PR DESCRIPTION
A full review of the 30 commits between `v0.0.7` and `main` (251 files, ~42.5k
insertions), with a test for each fix. 15 findings, all fixed.

Grouped by what goes wrong. Most of these fail **silently** — losing data,
hiding commits, or staging something other than what was selected — and one
blocks the next release outright.

### Data loss
- **`discard` deleted a conflicted file.** A conflicted path has index entries at
  stages 1/2/3 and none at stage 0, so a stage-0-only tracked check read it as
  untracked and took the delete-untracked branch. Any stage now counts as
  tracked; restoring re-materializes the conflict (`git checkout --merge`).
- **`pull`'s auto-stash was stranded by an auth retry.** The stash variable lived
  inside the retried closure, so the retry saw a clean tree, pulled, and never
  popped — uncommitted work silently left in a stash the user was never told
  about.

### Release blocker
- **macOS release build would fail.** `createUpdaterArtifacts` + `pubkey` were
  both added after v0.0.7, but only windows/linux got
  `TAURI_SIGNING_PRIVATE_KEY`. A pubkey with no private key is a hard error → no
  dmg attached, `bump-cask` skipped, Homebrew stuck on the old version.

### Wrong content, silently
- **Stale diff after a partial stage** staged the wrong lines. The fetch effect
  had no `status` dep, and nothing else in its list changes when the same file is
  partially staged.
- **Log paging dropped whole lanes** — two causes, and fixing only the reported
  one left it failing. Draining a merged history one commit per page lost **2 of
  6 commits**. Also hit the unfiltered path.
- **`+X −Y` overstated the commit.** One count per file (HEAD→worktree) described
  the commit; split into staged/unstaged pairs.
- **git's `%G?` code `Y`** (good signature, expired key) was unhandled → a signed
  commit rendered as unsigned.

### Dead ends
- **Clone could not authenticate.** The backend already returned
  `AppError::Auth` and `clone_repo` already took credentials, but nothing raised
  the challenge — private repos printed "Authentication required" with no way to
  answer.
- **Hunk/line staging a new file was impossible** (`InvalidPath`): the staging
  diff omitted the untracked options `diff()` uses.

### Runaway work
- **History auto-paging walked the entire repository** — it compared the window
  against the *client-filtered* list, and "This branch" hard-caps that at
  `ahead`, so the condition held at rest and every page re-armed it. The
  regression test **hung** before the fix.
- `status()` built a `git2::Patch` per delta to read two counters → one
  `Diff::foreach` pass. Runs after every stage/unstage/discard/hunk/line op.
- `status()`/`list_all_files()` stat'd every entry → syscall-free short-circuit.
- `SignatureBadge` spawned a `git show` per row arrowed over → debounced.

### Hardening
- **Windows binary planting:** `rundll32.exe` came from a bare PATH lookup, and
  `CreateProcess` searches the current directory first — which *is* the repo
  under a `pgit` launch. Pinned to `%SystemRoot%\System32`.
- **SSH passphrase filed as an HTTPS password** by "Remember". HTTPS only now.
- **`run_signer` deadlock** on a large commit message once gpg's `--status-fd=2`
  filled a pipe buffer.
- **The required `e2e-linux` gate could pass without running any tests** — a
  failed change-filter job skips `e2e`, which the gate read as "not required".

### Two review claims I corrected rather than implemented
- The rename half of the staging finding **cannot happen**: both diffs set
  `pathspec(path)`, and rename pairing needs both deltas present. Verified with a
  probe — the display diff reports a rename as a plain addition. The real bug was
  untracked files, failing loudly rather than silently.
- The suggested "slash pre-check" for `is_embedded_repo` is **unsound**: a
  gitlink already in the index is reported slashless and must still be flagged.
  Implementing it as proposed failed
  `unstage_still_removes_an_already_committed_gitlink` — a guard that exists to
  prevent writing unresolvable gitlinks.

### Verification
- `pnpm tsc --noEmit` (src + e2e): clean
- `pnpm test`: **732 passing**
- `cargo test`: **334 passing**
- e2e via Docker: `commit`, `status-stage`, `history-diff`, `history-ops`,
  `merge-conflict`, `create` — all passing
- Rebased onto `main` after #99 landed, then re-verified all four layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)