### PR TITLE
docs: spec + plans for syntax highlighting, word diff everywhere, windowed diff rows

### DIFF
--- a/docs/superpowers/plans/2026-08-14-syntax-highlight-pr1-engine.md
+++ b/docs/superpowers/plans/2026-08-14-syntax-highlight-pr1-engine.md
@@ -1,0 +1,1605 @@
+# Syntax Highlighting PR1: engine, palette, first surfaces — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tokenize code with Shiki into range-shaped tokens, theme them through a `--syn-*` palette, compose them with the existing word-diff spans in one tested builder, and light up the unified diff, Blame, and the RepoBrowser preview — retiring highlight.js.
+
+**Architecture:** Shiki runs through `createHighlighterCore` with the JavaScript regex engine and lazily registered grammars. A generated *sentinel theme* assigns each palette token a unique unused hex value, so `codeToTokens` returns an identity we map to a CSS class — no baked colors, so theme-mode switches stay CSS-only. Tokens are `{start, end, cls}` ranges, made line-relative, which lets `buildLineSpans` tile a line from syntax tokens and `WordSpan`s together.
+
+**Tech Stack:** TypeScript, React 19, Zustand, Vitest + React Testing Library, `shiki@^4.4.3`, Tailwind v4 CSS variables.
+
+**Spec:** `docs/superpowers/specs/2026-08-14-syntax-highlighting-diff-virtualization-design.md`
+
+## Global Constraints
+
+- Node 22 + pnpm. Prepend `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"` to any `pnpm`/`cargo` command.
+- Never call `window.confirm`/`window.prompt`; use `pgConfirm`/`pgPrompt` from `@/design`.
+- Import UI primitives from `@/design`. Do not create `src/components/ui/`.
+- Path alias `@/` → `src/`.
+- Never hardcode the accent hue; use `var(--accent)` or `oklch(from var(--accent) …)`.
+- `applyTheme()` is the source of truth for themeable tokens. The `dark` column must stay byte-identical to `src/index.css`.
+- Diff/code row geometry is owned by `--lh-code`. Density (`--row-step`) does not apply to code rows.
+- Guard values, verbatim: `MAX_HIGHLIGHT_BYTES = 1_000_000`, `MAX_HIGHLIGHT_LINES = 20_000`, debounce for the merge result pane `120` ms (PR2).
+- Shiki facts, verbatim from the spec: `codeToTokens` returns one token array per source line; token `offset` is **document-absolute**; returned `color` values are **upper-cased**; an unregistered language throws `ShikiError`; lazy grammars require explicit static `import()` thunks.
+- Commit style: Conventional Commits, imperative subject under 72 chars, `Co-Authored-By: Claude …` trailer when the assistant drove it.
+- Do not run e2e natively. Only `pnpm test:e2e:docker`.
+
+---
+
+## File Structure
+
+**Created:**
+- `src/lib/syntax/scopes.ts` — the one table mapping palette tokens to TextMate scopes; generates both the sentinel theme and the color→class lookup.
+- `src/lib/syntax/scopes.test.ts`
+- `src/lib/syntax/langs.ts` — path → Shiki language id, plus the explicit lazy grammar map.
+- `src/lib/syntax/langs.test.ts`
+- `src/lib/syntax/shiki.ts` — highlighter singleton and `ensureLanguage`.
+- `src/lib/syntax/tokenize.ts` — `tokenizeFile`, guards, cache, and the pure absolute→line-relative conversion.
+- `src/lib/syntax/tokenize.test.ts`
+- `src/lib/syntax/useSyntax.ts` — React hook, cancels on input change.
+- `src/lib/syntax/useSyntax.test.tsx`
+- `src/lib/syntax/index.ts` — barrel.
+- `src/lib/lineSpans.ts` — `buildLineSpans`, the single place syntax and word ranges reconcile.
+- `src/lib/lineSpans.test.ts`
+
+**Modified:**
+- `src/index.css` — add `--syn-*` defaults, delete the `.hljs-*` block.
+- `src/features/settings/useSettingsStore.ts` — `SYNTAX_TOKENS` written by `applyTheme()`.
+- `src/design/git-components.tsx` — `DiffText` rewritten on `buildLineSpans`; `DiffLineData` gains `syntax?`.
+- `src/screens/DiffViewer.tsx` — feed both sides' tokens into rows.
+- `src/screens/CommitPanel.tsx` — same.
+- `src/screens/Blame.tsx` — spans instead of plain text.
+- `src/screens/RepoBrowser.tsx` — preview uses Shiki.
+- `package.json` — add `shiki`, drop `highlight.js`.
+
+**Deleted:**
+- `src/lib/highlight.ts`
+
+---
+
+### Task 1: The scope table and sentinel theme
+
+**Files:**
+- Create: `src/lib/syntax/scopes.ts`
+- Test: `src/lib/syntax/scopes.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `SYN_TOKENS: readonly SynToken[]`, `type SynToken`, `SENTINEL_THEME` (a Shiki `ThemeRegistrationRaw`-shaped object), `classForColor(color: string): string | undefined`, `SYN_CLASS_PREFIX = "syn-"`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/syntax/scopes.test.ts
+import { describe, expect, it } from "vitest";
+import {
+  SYN_TOKENS,
+  SENTINEL_THEME,
+  classForColor,
+  sentinelFor,
+} from "./scopes";
+
+describe("scopes table", () => {
+  it("gives every token a unique sentinel", () => {
+    const seen = new Set(SYN_TOKENS.map((t) => sentinelFor(t)));
+    expect(seen.size).toBe(SYN_TOKENS.length);
+  });
+
+  it("maps each sentinel back to its class", () => {
+    for (const t of SYN_TOKENS) {
+      expect(classForColor(sentinelFor(t))).toBe(`syn-${t}`);
+    }
+  });
+
+  it("matches sentinels case-insensitively, because Shiki upper-cases colours", () => {
+    const s = sentinelFor("keyword");
+    expect(classForColor(s.toUpperCase())).toBe("syn-keyword");
+    expect(classForColor(s.toLowerCase())).toBe("syn-keyword");
+  });
+
+  it("returns undefined for a colour that is not a sentinel", () => {
+    expect(classForColor("#ff00ff")).toBeUndefined();
+    expect(classForColor("")).toBeUndefined();
+  });
+
+  it("emits one theme setting per token plus a default foreground", () => {
+    // First entry is the scope-less default; the rest carry scopes.
+    expect(SENTINEL_THEME.settings[0].scope).toBeUndefined();
+    const scoped = SENTINEL_THEME.settings.slice(1);
+    expect(scoped).toHaveLength(SYN_TOKENS.length);
+    for (const s of scoped) {
+      expect(Array.isArray(s.scope)).toBe(true);
+      expect((s.scope as string[]).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("covers the scopes that matter for the repo's own languages", () => {
+    const all = SENTINEL_THEME.settings.flatMap((s) => (s.scope as string[]) ?? []);
+    for (const scope of [
+      "keyword",
+      "comment",
+      "string",
+      "constant.numeric",
+      "entity.name.function",
+      "entity.name.type",
+      "variable",
+      "entity.name.tag",
+    ]) {
+      expect(all).toContain(scope);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `export PATH="$HOME/Library/pnpm:$PATH"; pnpm vitest run src/lib/syntax/scopes.test.ts`
+Expected: FAIL — `Failed to resolve import "./scopes"`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/lib/syntax/scopes.ts
+//
+// One table drives two things: the Shiki theme we tokenize with, and the
+// colour→class lookup that turns its output back into CSS classes.
+//
+// The theme is a SENTINEL theme: each token gets a unique, otherwise-unused hex
+// value rather than a real colour. Shiki hands that value back per token, so a
+// lookup recovers which token it was without paying for `includeExplanation`,
+// which returns whole scope chains per token. Because the theme and the lookup
+// are generated from the same table, they cannot drift.
+//
+// Colours are never baked into markup: rows get `class="syn-keyword"` and the
+// palette lives in CSS, so switching theme mode never re-tokenizes.
+
+/** Palette tokens. Each becomes a `--syn-<token>` variable and a `syn-<token>` class. */
+export const SYN_TOKENS = [
+  "keyword",
+  "string",
+  "number",
+  "comment",
+  "func",
+  "type",
+  "var",
+  "punct",
+  "tag",
+  "attr",
+  "regexp",
+  "meta",
+] as const;
+
+export type SynToken = (typeof SYN_TOKENS)[number];
+
+export const SYN_CLASS_PREFIX = "syn-";
+
+/**
+ * TextMate scopes per token. Order inside a list is irrelevant; Shiki resolves
+ * the most specific match. Kept deliberately broad — a scope that no grammar
+ * emits is harmless, a missing one shows up as unstyled text.
+ */
+const SCOPES: Record<SynToken, string[]> = {
+  keyword: [
+    "keyword",
+    "storage.type",
+    "storage.modifier",
+    "keyword.operator",
+    "keyword.control",
+  ],
+  string: ["string", "string.quoted", "string.template", "constant.character.escape"],
+  number: ["constant.numeric", "constant.language"],
+  comment: ["comment", "punctuation.definition.comment"],
+  func: ["entity.name.function", "support.function", "meta.function-call"],
+  type: ["entity.name.type", "entity.name.class", "support.type", "support.class"],
+  var: ["variable", "variable.other", "variable.parameter", "meta.definition.variable"],
+  punct: ["punctuation", "meta.brace", "punctuation.separator"],
+  tag: ["entity.name.tag", "punctuation.definition.tag"],
+  attr: ["entity.other.attribute-name", "support.type.property-name", "meta.attribute"],
+  regexp: ["string.regexp", "constant.regexp"],
+  meta: ["meta.preprocessor", "keyword.other.preprocessor", "entity.name.namespace"],
+};
+
+/**
+ * Sentinel colour for a token: `#0000NN` where NN is its 1-based index. These
+ * are never rendered — they exist only to be matched by `classForColor`.
+ */
+export function sentinelFor(token: SynToken): string {
+  const n = SYN_TOKENS.indexOf(token) + 1;
+  return `#0000${n.toString(16).padStart(2, "0")}`;
+}
+
+/** Anything not scoped by the theme comes back as this, and renders unstyled. */
+const DEFAULT_FG = "#0000ff";
+
+export interface SentinelThemeSetting {
+  scope?: string[];
+  settings: { foreground: string };
+}
+
+export const SENTINEL_THEME = {
+  name: "pg-sentinel",
+  type: "dark" as const,
+  colors: { "editor.foreground": DEFAULT_FG },
+  settings: [
+    { settings: { foreground: DEFAULT_FG } },
+    ...SYN_TOKENS.map((t) => ({
+      scope: SCOPES[t],
+      settings: { foreground: sentinelFor(t) },
+    })),
+  ] as SentinelThemeSetting[],
+};
+
+const BY_COLOR = new Map<string, string>(
+  SYN_TOKENS.map((t) => [sentinelFor(t).toLowerCase(), `${SYN_CLASS_PREFIX}${t}`]),
+);
+
+/**
+ * Sentinel colour → CSS class. Lower-cases first: Shiki returns `#FFFFFF` even
+ * when the theme supplied `#ffffff`, so a case-sensitive match silently loses
+ * every token.
+ */
+export function classForColor(color: string | undefined): string | undefined {
+  if (!color) return undefined;
+  return BY_COLOR.get(color.toLowerCase());
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run src/lib/syntax/scopes.test.ts`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/syntax/scopes.ts src/lib/syntax/scopes.test.ts
+git commit -m "feat(syntax): scope table and sentinel theme for Shiki tokens"
+```
+
+---
+
+### Task 2: Language detection and the lazy grammar map
+
+**Files:**
+- Create: `src/lib/syntax/langs.ts`
+- Test: `src/lib/syntax/langs.test.ts`
+- Reference (do not edit yet): `src/lib/highlight.ts:5-79` — port its extension table and filename rules.
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `langForPath(path: string): ShikiLang | null`, `type ShikiLang`, `LANG_LOADERS: Record<ShikiLang, () => Promise<unknown>>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/syntax/langs.test.ts
+import { describe, expect, it } from "vitest";
+import { LANG_LOADERS, langForPath } from "./langs";
+
+describe("langForPath", () => {
+  it("maps by extension", () => {
+    expect(langForPath("src/a.ts")).toBe("typescript");
+    expect(langForPath("src/a.tsx")).toBe("tsx");
+    expect(langForPath("main.rs")).toBe("rust");
+    expect(langForPath("x/y/z.py")).toBe("python");
+  });
+
+  it("maps files that have no extension by name", () => {
+    expect(langForPath("Dockerfile")).toBe("docker");
+    expect(langForPath("deploy/Dockerfile")).toBe("docker");
+    expect(langForPath("Makefile")).toBe("make");
+  });
+
+  it("is case-insensitive on the basename", () => {
+    expect(langForPath("README.MD")).toBe("markdown");
+    expect(langForPath("DOCKERFILE")).toBe("docker");
+  });
+
+  it("returns null for unknown or extension-less files", () => {
+    expect(langForPath("LICENSE")).toBeNull();
+    expect(langForPath("a.unknownext")).toBeNull();
+    expect(langForPath("")).toBeNull();
+  });
+
+  it("has a loader for every language it can return", () => {
+    const langs = [
+      "typescript", "tsx", "javascript", "jsx", "rust", "python", "go",
+      "java", "kotlin", "swift", "c", "cpp", "csharp", "ruby", "php",
+      "lua", "sql", "shellscript", "json", "yaml", "toml", "xml", "html",
+      "css", "scss", "markdown", "docker", "make", "graphql", "ini", "diff",
+    ] as const;
+    for (const l of langs) {
+      expect(typeof LANG_LOADERS[l]).toBe("function");
+    }
+  });
+
+  it("never maps a path to a language with no loader", () => {
+    for (const p of ["a.ts", "a.tsx", "a.rs", "Dockerfile", "Makefile", "a.toml", "a.sh"]) {
+      const l = langForPath(p);
+      expect(l).not.toBeNull();
+      expect(LANG_LOADERS[l!]).toBeDefined();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/lib/syntax/langs.test.ts`
+Expected: FAIL — cannot resolve `./langs`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/lib/syntax/langs.ts
+//
+// Path → Shiki language, plus the grammar loaders.
+//
+// LANG_LOADERS is an EXPLICIT map of static import() calls, not
+// `import(\`shiki/langs/${lang}.mjs\`)`. A template-literal specifier is not
+// statically analysable, so Vite can neither resolve nor code-split it; written
+// out, each grammar becomes its own lazily-fetched chunk.
+//
+// Ported from the highlight.js table this replaces (src/lib/highlight.ts), with
+// Shiki's language ids: `tsx` and `jsx` are real grammars here rather than
+// aliases of typescript/javascript, and `sh` is `shellscript`.
+
+export type ShikiLang =
+  | "typescript" | "tsx" | "javascript" | "jsx" | "rust" | "python" | "go"
+  | "java" | "kotlin" | "swift" | "c" | "cpp" | "csharp" | "ruby" | "php"
+  | "lua" | "sql" | "shellscript" | "json" | "yaml" | "toml" | "xml" | "html"
+  | "css" | "scss" | "less" | "markdown" | "docker" | "make" | "graphql"
+  | "ini" | "diff" | "perl" | "r" | "objective-c";
+
+export const LANG_LOADERS: Record<ShikiLang, () => Promise<unknown>> = {
+  typescript: () => import("shiki/langs/typescript.mjs"),
+  tsx: () => import("shiki/langs/tsx.mjs"),
+  javascript: () => import("shiki/langs/javascript.mjs"),
+  jsx: () => import("shiki/langs/jsx.mjs"),
+  rust: () => import("shiki/langs/rust.mjs"),
+  python: () => import("shiki/langs/python.mjs"),
+  go: () => import("shiki/langs/go.mjs"),
+  java: () => import("shiki/langs/java.mjs"),
+  kotlin: () => import("shiki/langs/kotlin.mjs"),
+  swift: () => import("shiki/langs/swift.mjs"),
+  c: () => import("shiki/langs/c.mjs"),
+  cpp: () => import("shiki/langs/cpp.mjs"),
+  csharp: () => import("shiki/langs/csharp.mjs"),
+  ruby: () => import("shiki/langs/ruby.mjs"),
+  php: () => import("shiki/langs/php.mjs"),
+  lua: () => import("shiki/langs/lua.mjs"),
+  sql: () => import("shiki/langs/sql.mjs"),
+  shellscript: () => import("shiki/langs/shellscript.mjs"),
+  json: () => import("shiki/langs/json.mjs"),
+  yaml: () => import("shiki/langs/yaml.mjs"),
+  toml: () => import("shiki/langs/toml.mjs"),
+  xml: () => import("shiki/langs/xml.mjs"),
+  html: () => import("shiki/langs/html.mjs"),
+  css: () => import("shiki/langs/css.mjs"),
+  scss: () => import("shiki/langs/scss.mjs"),
+  less: () => import("shiki/langs/less.mjs"),
+  markdown: () => import("shiki/langs/markdown.mjs"),
+  docker: () => import("shiki/langs/docker.mjs"),
+  make: () => import("shiki/langs/make.mjs"),
+  graphql: () => import("shiki/langs/graphql.mjs"),
+  ini: () => import("shiki/langs/ini.mjs"),
+  diff: () => import("shiki/langs/diff.mjs"),
+  perl: () => import("shiki/langs/perl.mjs"),
+  r: () => import("shiki/langs/r.mjs"),
+  "objective-c": () => import("shiki/langs/objective-c.mjs"),
+};
+
+const BY_EXT: Record<string, ShikiLang> = {
+  ts: "typescript", mts: "typescript", cts: "typescript",
+  tsx: "tsx",
+  js: "javascript", mjs: "javascript", cjs: "javascript",
+  jsx: "jsx",
+  rs: "rust",
+  py: "python",
+  go: "go",
+  java: "java",
+  kt: "kotlin", kts: "kotlin",
+  swift: "swift",
+  c: "c", h: "c",
+  cpp: "cpp", cc: "cpp", cxx: "cpp", hpp: "cpp", hh: "cpp",
+  cs: "csharp",
+  rb: "ruby",
+  php: "php",
+  lua: "lua",
+  sql: "sql",
+  sh: "shellscript", bash: "shellscript", zsh: "shellscript", fish: "shellscript",
+  json: "json",
+  yaml: "yaml", yml: "yaml",
+  toml: "toml",
+  xml: "xml", svg: "xml",
+  html: "html", htm: "html",
+  css: "css",
+  scss: "scss",
+  less: "less",
+  md: "markdown", markdown: "markdown",
+  graphql: "graphql", gql: "graphql",
+  ini: "ini", conf: "ini",
+  diff: "diff", patch: "diff",
+  pl: "perl",
+  r: "r",
+  m: "objective-c", mm: "objective-c",
+  dockerfile: "docker",
+  mk: "make",
+};
+
+const BY_NAME: Record<string, ShikiLang> = {
+  dockerfile: "docker",
+  makefile: "make",
+  gnumakefile: "make",
+};
+
+export function langForPath(path: string): ShikiLang | null {
+  if (!path) return null;
+  const base = (path.split("/").pop() ?? path).toLowerCase();
+  const byName = BY_NAME[base];
+  if (byName) return byName;
+  const dot = base.lastIndexOf(".");
+  if (dot === -1) return null;
+  return BY_EXT[base.slice(dot + 1)] ?? null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run src/lib/syntax/langs.test.ts`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/syntax/langs.ts src/lib/syntax/langs.test.ts
+git commit -m "feat(syntax): path-to-language map with lazy Shiki grammar loaders"
+```
+
+---
+
+### Task 3: Add the shiki dependency and the highlighter singleton
+
+**Files:**
+- Create: `src/lib/syntax/shiki.ts`
+- Modify: `package.json`
+
+**Interfaces:**
+- Consumes: `SENTINEL_THEME` (Task 1), `LANG_LOADERS`, `ShikiLang` (Task 2).
+- Produces: `getHighlighter(): Promise<HighlighterCore>`, `ensureLanguage(lang: ShikiLang): Promise<boolean>`, `SENTINEL_THEME_NAME = "pg-sentinel"`.
+
+- [ ] **Step 1: Add the dependency**
+
+```bash
+export PATH="$HOME/Library/pnpm:$PATH"
+pnpm add shiki@^4.4.3
+```
+
+- [ ] **Step 2: Write the implementation**
+
+This task has no unit test of its own: it is a thin async singleton over a third-party API, and Task 4 covers it with the module mocked. Reviewing it means reading it.
+
+```ts
+// src/lib/syntax/shiki.ts
+//
+// The one Shiki instance. Created lazily on first tokenize so app start pays
+// nothing, and shared so grammars register once.
+//
+// engine-javascript rather than the default WASM Oniguruma engine: it avoids
+// shipping and fetching a .wasm asset through the Tauri custom protocol.
+import { createHighlighterCore, type HighlighterCore } from "shiki/core";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+import { SENTINEL_THEME } from "./scopes";
+import { LANG_LOADERS, type ShikiLang } from "./langs";
+
+export const SENTINEL_THEME_NAME = "pg-sentinel";
+
+let highlighterPromise: Promise<HighlighterCore> | null = null;
+
+export function getHighlighter(): Promise<HighlighterCore> {
+  highlighterPromise ??= createHighlighterCore({
+    themes: [SENTINEL_THEME],
+    langs: [],
+    engine: createJavaScriptRegexEngine(),
+  });
+  return highlighterPromise;
+}
+
+const loading = new Map<ShikiLang, Promise<boolean>>();
+
+/**
+ * Register a grammar if it isn't already. Resolves false when the grammar fails
+ * to load — a missing chunk must degrade to plain text, never break a diff.
+ */
+export function ensureLanguage(lang: ShikiLang): Promise<boolean> {
+  const existing = loading.get(lang);
+  if (existing) return existing;
+  const p = (async () => {
+    try {
+      const hl = await getHighlighter();
+      if (hl.getLoadedLanguages().includes(lang)) return true;
+      const mod = await LANG_LOADERS[lang]();
+      await hl.loadLanguage(mod as never);
+      return true;
+    } catch {
+      loading.delete(lang); // let a later attempt retry
+      return false;
+    }
+  })();
+  loading.set(lang, p);
+  return p;
+}
+```
+
+- [ ] **Step 3: Verify it type-checks**
+
+Run: `pnpm tsc --noEmit`
+Expected: no errors. If `loadLanguage`'s parameter type rejects the dynamic module, keep the `as never` cast — the loaders return Shiki's own grammar modules and the cast is documented above.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml src/lib/syntax/shiki.ts
+git commit -m "feat(syntax): add shiki and the highlighter singleton"
+```
+
+---
+
+### Task 4: `tokenizeFile` — guards, line-relative ranges, cache
+
+**Files:**
+- Create: `src/lib/syntax/tokenize.ts`
+- Test: `src/lib/syntax/tokenize.test.ts`
+
+**Interfaces:**
+- Consumes: `getHighlighter`, `ensureLanguage`, `SENTINEL_THEME_NAME` (Task 3), `langForPath` (Task 2), `classForColor` (Task 1).
+- Produces:
+  - `interface SyntaxToken { start: number; end: number; cls: string }`
+  - `type SyntaxLine = SyntaxToken[]`
+  - `toLineRelative(lines: {content: string; offset: number; color?: string}[][]): SyntaxLine[]`
+  - `tokenizeFile(path: string, text: string): Promise<SyntaxLine[] | null>`
+  - `MAX_HIGHLIGHT_BYTES = 1_000_000`, `MAX_HIGHLIGHT_LINES = 20_000`
+  - `clearSyntaxCache(): void` (tests only)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/syntax/tokenize.test.ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Real grammars are slow and asynchronous; this suite is about ranges, guards
+// and caching, so the highlighter is faked. The fake mimics the two Shiki
+// behaviours that bite: document-absolute offsets and upper-cased colours.
+const codeToTokens = vi.fn();
+vi.mock("./shiki", () => ({
+  SENTINEL_THEME_NAME: "pg-sentinel",
+  getHighlighter: async () => ({ codeToTokens }),
+  ensureLanguage: async () => true,
+}));
+
+import { sentinelFor } from "./scopes";
+import {
+  MAX_HIGHLIGHT_BYTES,
+  MAX_HIGHLIGHT_LINES,
+  clearSyntaxCache,
+  toLineRelative,
+  tokenizeFile,
+} from "./tokenize";
+
+const KW = sentinelFor("keyword").toUpperCase();
+
+beforeEach(() => {
+  clearSyntaxCache();
+  codeToTokens.mockReset();
+});
+
+describe("toLineRelative", () => {
+  it("rebases document-absolute offsets onto their own line", () => {
+    // "ab\ncd" — the second line's token sits at absolute offset 3.
+    const out = toLineRelative([
+      [{ content: "ab", offset: 0, color: KW }],
+      [{ content: "cd", offset: 3, color: KW }],
+    ]);
+    expect(out[0][0]).toEqual({ start: 0, end: 2, cls: "syn-keyword" });
+    expect(out[1][0]).toEqual({ start: 0, end: 2, cls: "syn-keyword" });
+  });
+
+  it("drops tokens whose colour is not a sentinel", () => {
+    const out = toLineRelative([
+      [
+        { content: "a", offset: 0, color: KW },
+        { content: "b", offset: 1, color: "#0000FF" },
+      ],
+    ]);
+    expect(out[0]).toHaveLength(1);
+    expect(out[0][0].cls).toBe("syn-keyword");
+  });
+
+  it("keeps an empty line as an empty token array", () => {
+    expect(toLineRelative([[], [{ content: "x", offset: 1, color: KW }]])).toEqual([
+      [],
+      [{ start: 0, end: 1, cls: "syn-keyword" }],
+    ]);
+  });
+});
+
+describe("tokenizeFile", () => {
+  it("returns per-line tokens for a known language", async () => {
+    codeToTokens.mockReturnValue({
+      tokens: [[{ content: "let", offset: 0, color: KW }]],
+    });
+    const out = await tokenizeFile("a.ts", "let");
+    expect(out).toEqual([[{ start: 0, end: 3, cls: "syn-keyword" }]]);
+  });
+
+  it("returns null for an unknown language without calling Shiki", async () => {
+    expect(await tokenizeFile("LICENSE", "x")).toBeNull();
+    expect(codeToTokens).not.toHaveBeenCalled();
+  });
+
+  it("returns null past the byte guard", async () => {
+    expect(await tokenizeFile("a.ts", "x".repeat(MAX_HIGHLIGHT_BYTES + 1))).toBeNull();
+    expect(codeToTokens).not.toHaveBeenCalled();
+  });
+
+  it("returns null past the line guard", async () => {
+    expect(await tokenizeFile("a.ts", "\n".repeat(MAX_HIGHLIGHT_LINES + 1))).toBeNull();
+    expect(codeToTokens).not.toHaveBeenCalled();
+  });
+
+  it("returns null when Shiki throws, rather than propagating", async () => {
+    codeToTokens.mockImplementation(() => {
+      throw new Error("Language `x` not found");
+    });
+    expect(await tokenizeFile("a.ts", "let")).toBeNull();
+  });
+
+  it("caches by path and content", async () => {
+    codeToTokens.mockReturnValue({ tokens: [[{ content: "let", offset: 0, color: KW }]] });
+    await tokenizeFile("a.ts", "let");
+    await tokenizeFile("a.ts", "let");
+    expect(codeToTokens).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-tokenizes when the content changes", async () => {
+    codeToTokens.mockReturnValue({ tokens: [[{ content: "let", offset: 0, color: KW }]] });
+    await tokenizeFile("a.ts", "let");
+    await tokenizeFile("a.ts", "let x");
+    expect(codeToTokens).toHaveBeenCalledTimes(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/lib/syntax/tokenize.test.ts`
+Expected: FAIL — cannot resolve `./tokenize`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/lib/syntax/tokenize.ts
+import { classForColor } from "./scopes";
+import { langForPath } from "./langs";
+import { SENTINEL_THEME_NAME, ensureLanguage, getHighlighter } from "./shiki";
+
+/** A syntax range over ONE line, in that line's own coordinates. */
+export interface SyntaxToken {
+  start: number;
+  end: number;
+  cls: string;
+}
+
+export type SyntaxLine = SyntaxToken[];
+
+/** Files past either guard render plain — highlighting is a nicety, not a feature. */
+export const MAX_HIGHLIGHT_BYTES = 1_000_000;
+export const MAX_HIGHLIGHT_LINES = 20_000;
+
+interface RawToken {
+  content: string;
+  offset: number;
+  color?: string;
+}
+
+/**
+ * Rebase Shiki's DOCUMENT-absolute offsets to line-relative ranges, and resolve
+ * sentinel colours to classes.
+ *
+ * The rebase is the whole point: `WordSpan` from wordDiff.ts is line-relative,
+ * and buildLineSpans intersects the two. Leaving absolute offsets in would put
+ * every line after the first out of range, silently yielding no spans.
+ */
+export function toLineRelative(lines: RawToken[][]): SyntaxLine[] {
+  return lines.map((tokens) => {
+    const base = tokens.length > 0 ? tokens[0].offset : 0;
+    const out: SyntaxLine = [];
+    for (const t of tokens) {
+      const cls = classForColor(t.color);
+      if (!cls) continue; // unscoped text renders unstyled
+      const start = t.offset - base;
+      out.push({ start, end: start + t.content.length, cls });
+    }
+    return out;
+  });
+}
+
+/** djb2. Enough to detect content change for a cache key; not a checksum. */
+function hash(s: string): string {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return (h >>> 0).toString(36);
+}
+
+const CACHE_MAX = 24;
+const cache = new Map<string, SyntaxLine[]>();
+
+export function clearSyntaxCache(): void {
+  cache.clear();
+}
+
+function remember(key: string, value: SyntaxLine[]): SyntaxLine[] {
+  cache.set(key, value);
+  if (cache.size > CACHE_MAX) {
+    // Map preserves insertion order, so the first key is the oldest.
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  return value;
+}
+
+/**
+ * Tokenize a whole file. Resolves null whenever highlighting is not available
+ * or not worth it — unknown language, oversized input, or any Shiki failure.
+ * Callers treat null as "render plain text".
+ */
+export async function tokenizeFile(
+  path: string,
+  text: string,
+): Promise<SyntaxLine[] | null> {
+  const lang = langForPath(path);
+  if (!lang) return null;
+  if (text.length > MAX_HIGHLIGHT_BYTES) return null;
+  const lineCount = text.split("\n").length;
+  if (lineCount > MAX_HIGHLIGHT_LINES) return null;
+
+  const key = `${lang}:${hash(text)}:${text.length}`;
+  const hit = cache.get(key);
+  if (hit) return hit;
+
+  if (!(await ensureLanguage(lang))) return null;
+  try {
+    const hl = await getHighlighter();
+    const { tokens } = hl.codeToTokens(text, {
+      lang,
+      theme: SENTINEL_THEME_NAME,
+    }) as { tokens: RawToken[][] };
+    return remember(key, toLineRelative(tokens));
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run src/lib/syntax/tokenize.test.ts`
+Expected: PASS, 10 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/syntax/tokenize.ts src/lib/syntax/tokenize.test.ts
+git commit -m "feat(syntax): tokenizeFile with line-relative ranges, guards and cache"
+```
+
+---
+
+### Task 5: `useSyntax` hook
+
+**Files:**
+- Create: `src/lib/syntax/useSyntax.ts`, `src/lib/syntax/index.ts`
+- Test: `src/lib/syntax/useSyntax.test.tsx`
+
+**Interfaces:**
+- Consumes: `tokenizeFile`, `SyntaxLine` (Task 4).
+- Produces: `useSyntax(path: string | null, text: string | null): SyntaxLine[] | null`; barrel re-exporting `SyntaxLine`, `SyntaxToken`, `tokenizeFile`, `useSyntax`.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/lib/syntax/useSyntax.test.tsx
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+const tokenizeFile = vi.fn();
+vi.mock("./tokenize", () => ({ tokenizeFile }));
+
+import { useSyntax } from "./useSyntax";
+
+function Probe({ path, text }: { path: string | null; text: string | null }) {
+  const syntax = useSyntax(path, text);
+  return <div data-testid="out">{syntax ? `lines:${syntax.length}` : "none"}</div>;
+}
+
+describe("useSyntax", () => {
+  it("renders plain first, then upgrades when tokens resolve", async () => {
+    let resolve: (v: unknown) => void = () => {};
+    tokenizeFile.mockReturnValue(new Promise((r) => (resolve = r)));
+    render(<Probe path="a.ts" text="let" />);
+    expect(screen.getByTestId("out")).toHaveTextContent("none");
+    resolve([[], []]);
+    await waitFor(() => expect(screen.getByTestId("out")).toHaveTextContent("lines:2"));
+  });
+
+  it("does not call the tokenizer without a path or text", () => {
+    render(<Probe path={null} text="let" />);
+    render(<Probe path="a.ts" text={null} />);
+    expect(tokenizeFile).not.toHaveBeenCalled();
+  });
+
+  it("ignores a stale resolution after the input changed", async () => {
+    let resolveFirst: (v: unknown) => void = () => {};
+    tokenizeFile.mockReturnValueOnce(new Promise((r) => (resolveFirst = r)));
+    tokenizeFile.mockResolvedValueOnce([[], [], []]);
+    const { rerender } = render(<Probe path="a.ts" text="one" />);
+    rerender(<Probe path="a.ts" text="two" />);
+    await waitFor(() => expect(screen.getByTestId("out")).toHaveTextContent("lines:3"));
+    resolveFirst([[]]); // first request finishes late
+    await waitFor(() => expect(screen.getByTestId("out")).toHaveTextContent("lines:3"));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/lib/syntax/useSyntax.test.tsx`
+Expected: FAIL — cannot resolve `./useSyntax`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/lib/syntax/useSyntax.ts
+import React from "react";
+import { tokenizeFile } from "./tokenize";
+import type { SyntaxLine } from "./tokenize";
+
+/**
+ * Tokens for a file, or null while they are pending or unavailable.
+ *
+ * Deliberately never blocks first paint: the caller renders plain text on the
+ * null, and re-renders with spans when this resolves. Span-ification does not
+ * change row geometry, so there is no layout shift to hide behind a spinner.
+ */
+export function useSyntax(
+  path: string | null,
+  text: string | null,
+): SyntaxLine[] | null {
+  const [lines, setLines] = React.useState<SyntaxLine[] | null>(null);
+
+  React.useEffect(() => {
+    setLines(null);
+    if (!path || text == null) return;
+    let cancelled = false;
+    tokenizeFile(path, text).then((result) => {
+      if (!cancelled) setLines(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [path, text]);
+
+  return lines;
+}
+```
+
+```ts
+// src/lib/syntax/index.ts
+export { tokenizeFile, type SyntaxLine, type SyntaxToken } from "./tokenize";
+export { useSyntax } from "./useSyntax";
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run src/lib/syntax/useSyntax.test.tsx`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/syntax/useSyntax.ts src/lib/syntax/useSyntax.test.tsx src/lib/syntax/index.ts
+git commit -m "feat(syntax): useSyntax hook with stale-result guarding"
+```
+
+---
+
+### Task 6: `buildLineSpans` — where syntax and word diff meet
+
+**Files:**
+- Create: `src/lib/lineSpans.ts`
+- Test: `src/lib/lineSpans.test.ts`
+
+**Interfaces:**
+- Consumes: `SyntaxToken` (Task 4), `WordSpan` from `@/lib/wordDiff` (`{ start, end, changed }`, already shipped).
+- Produces: `interface RenderSpan { start: number; end: number; cls?: string; changed: boolean }`, `buildLineSpans(text, syntax, words): RenderSpan[]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/lineSpans.test.ts
+import { describe, expect, it } from "vitest";
+import { buildLineSpans } from "./lineSpans";
+import type { SyntaxToken } from "./syntax";
+import type { WordSpan } from "./wordDiff";
+
+const syn = (start: number, end: number, cls: string): SyntaxToken => ({ start, end, cls });
+const word = (start: number, end: number, changed: boolean): WordSpan => ({ start, end, changed });
+
+/** Every span concatenated must reproduce the line exactly — the tiling contract. */
+function tiles(text: string, spans: { start: number; end: number }[]) {
+  return spans.map((s) => text.slice(s.start, s.end)).join("");
+}
+
+describe("buildLineSpans", () => {
+  it("returns one unstyled span when there is nothing to apply", () => {
+    expect(buildLineSpans("abc", null, undefined)).toEqual([
+      { start: 0, end: 3, cls: undefined, changed: false },
+    ]);
+  });
+
+  it("returns an empty array for an empty line", () => {
+    expect(buildLineSpans("", null, undefined)).toEqual([]);
+  });
+
+  it("carries syntax classes when there is no word diff", () => {
+    const out = buildLineSpans("let x", [syn(0, 3, "syn-keyword")], undefined);
+    expect(out).toEqual([
+      { start: 0, end: 3, cls: "syn-keyword", changed: false },
+      { start: 3, end: 5, cls: undefined, changed: false },
+    ]);
+    expect(tiles("let x", out)).toBe("let x");
+  });
+
+  it("carries changed flags when there is no syntax", () => {
+    const out = buildLineSpans("ab", null, [word(0, 1, true), word(1, 2, false)]);
+    expect(out).toEqual([
+      { start: 0, end: 1, cls: undefined, changed: true },
+      { start: 1, end: 2, cls: undefined, changed: false },
+    ]);
+  });
+
+  it("splits at the union of both boundary sets", () => {
+    // syntax 0-5 "syn-string"; word change 2-4. Expect 0-2, 2-4, 4-5.
+    const out = buildLineSpans("abcde", [syn(0, 5, "syn-string")], [
+      word(0, 2, false),
+      word(2, 4, true),
+      word(4, 5, false),
+    ]);
+    expect(out).toEqual([
+      { start: 0, end: 2, cls: "syn-string", changed: false },
+      { start: 2, end: 4, cls: "syn-string", changed: true },
+      { start: 4, end: 5, cls: "syn-string", changed: false },
+    ]);
+    expect(tiles("abcde", out)).toBe("abcde");
+  });
+
+  it("tiles gaps between syntax tokens", () => {
+    const out = buildLineSpans("a b", [syn(0, 1, "syn-var"), syn(2, 3, "syn-var")], undefined);
+    expect(out.map((s) => [s.start, s.end, s.cls])).toEqual([
+      [0, 1, "syn-var"],
+      [1, 2, undefined],
+      [2, 3, "syn-var"],
+    ]);
+    expect(tiles("a b", out)).toBe("a b");
+  });
+
+  it("clamps ranges that overrun the line and drops empty ones", () => {
+    const out = buildLineSpans("ab", [syn(0, 99, "syn-type"), syn(5, 5, "syn-var")], undefined);
+    expect(out).toEqual([{ start: 0, end: 2, cls: "syn-type", changed: false }]);
+  });
+
+  it("never emits a zero-width span", () => {
+    const out = buildLineSpans("abc", [syn(1, 1, "syn-var")], [word(0, 0, true)]);
+    for (const s of out) expect(s.end).toBeGreaterThan(s.start);
+    expect(tiles("abc", out)).toBe("abc");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/lib/lineSpans.test.ts`
+Expected: FAIL — cannot resolve `./lineSpans`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/lib/lineSpans.ts
+//
+// Syntax tokens and word-diff spans are two independent range sets over one
+// line. This is the ONE place they reconcile, so every renderer becomes a flat
+// spans.map() with no gap handling and no overlap reasoning.
+//
+// Output tiles the line: concatenating every span reproduces the text exactly.
+// wordDiff.ts already guarantees that property for word spans alone; this keeps
+// it once syntax joins in.
+import type { SyntaxToken } from "./syntax";
+import type { WordSpan } from "./wordDiff";
+
+export interface RenderSpan {
+  start: number;
+  end: number;
+  /** Syntax class, or undefined for text no grammar scoped. */
+  cls?: string;
+  /** True when the word diff marked this range as changed. */
+  changed: boolean;
+}
+
+export function buildLineSpans(
+  text: string,
+  syntax: SyntaxToken[] | null,
+  words: WordSpan[] | undefined,
+): RenderSpan[] {
+  const len = text.length;
+  if (len === 0) return [];
+
+  // Boundaries: line ends plus every edge of either input, clamped in range.
+  const cuts = new Set<number>([0, len]);
+  const clamp = (n: number) => Math.max(0, Math.min(len, n));
+  for (const t of syntax ?? []) {
+    cuts.add(clamp(t.start));
+    cuts.add(clamp(t.end));
+  }
+  for (const w of words ?? []) {
+    cuts.add(clamp(w.start));
+    cuts.add(clamp(w.end));
+  }
+  const edges = [...cuts].sort((a, b) => a - b);
+
+  const out: RenderSpan[] = [];
+  for (let i = 0; i + 1 < edges.length; i++) {
+    const start = edges[i];
+    const end = edges[i + 1];
+    if (end <= start) continue; // duplicate edges collapse; never emit zero width
+    // A segment lies wholly inside or wholly outside each input range, because
+    // every range edge is a cut, so testing the midpoint is exact.
+    const mid = (start + end) / 2;
+    const tok = (syntax ?? []).find((t) => t.start <= mid && mid < t.end);
+    const w = (words ?? []).find((s) => s.start <= mid && mid < s.end);
+    out.push({ start, end, cls: tok?.cls, changed: w?.changed ?? false });
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run src/lib/lineSpans.test.ts`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/lineSpans.ts src/lib/lineSpans.test.ts
+git commit -m "feat(diff): tile line spans from syntax tokens and word spans"
+```
+
+---
+
+### Task 7: The `--syn-*` palette
+
+**Files:**
+- Modify: `src/index.css` (add `--syn-*` next to the other `:root` tokens; delete the `.hljs-*` block at `src/index.css:272` onward)
+- Modify: `src/features/settings/useSettingsStore.ts` (`SEMANTIC_TOKENS` is at `:328`, `SELECTION_TOKENS` at `:403`, `applyTheme` at `:417`)
+- Test: `src/features/settings/useSettingsStore.test.ts`
+
+**Interfaces:**
+- Consumes: `SYN_TOKENS` (Task 1) — the variable names must match `--syn-<token>` for every entry.
+- Produces: `--syn-keyword|string|number|comment|func|type|var|punct|tag|attr|regexp|meta` on `:root`, plus `.syn-*` rules that read them.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/features/settings/useSettingsStore.test.ts`:
+
+```ts
+import { SYN_TOKENS } from "@/lib/syntax/scopes";
+
+describe("syntax palette", () => {
+  it("writes every --syn-* token for a dark theme", () => {
+    applyTheme({ ...DARK_THEME_FIXTURE, mode: "dark" });
+    for (const t of SYN_TOKENS) {
+      const v = document.documentElement.style.getPropertyValue(`--syn-${t}`);
+      expect(v, `--syn-${t}`).not.toBe("");
+    }
+  });
+
+  it("writes a different calibration for light mode", () => {
+    applyTheme({ ...DARK_THEME_FIXTURE, mode: "dark" });
+    const darkKeyword = document.documentElement.style.getPropertyValue("--syn-keyword");
+    applyTheme({ ...LIGHT_THEME_FIXTURE, mode: "light" });
+    const lightKeyword = document.documentElement.style.getPropertyValue("--syn-keyword");
+    expect(lightKeyword).not.toBe(darkKeyword);
+  });
+});
+```
+
+Reuse whatever theme fixtures the file already defines; if it builds themes inline, follow that style instead of inventing `*_FIXTURE` names.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/features/settings/useSettingsStore.test.ts`
+Expected: FAIL — `--syn-keyword` is `""`.
+
+- [ ] **Step 3: Add `SYNTAX_TOKENS` and write them in `applyTheme`**
+
+In `src/features/settings/useSettingsStore.ts`, after `SELECTION_TOKENS`:
+
+```ts
+/**
+ * Syntax palette, per theme MODE. Light is calibrated on its own rather than
+ * inherited: dark-calibrated syntax colours over a light canvas wash out exactly
+ * like the diff and graph tokens did (#61 B4).
+ *
+ * The dark column is byte-identical to the :root defaults in index.css. Edit
+ * both or they drift.
+ */
+const SYNTAX_TOKENS: Record<"dark" | "light", Record<string, string>> = {
+  dark: {
+    "--syn-keyword": "#ff7b72",
+    "--syn-string": "#a5d6ff",
+    "--syn-number": "#79c0ff",
+    "--syn-comment": "#8b949e",
+    "--syn-func": "#d2a8ff",
+    "--syn-type": "#7ee787",
+    "--syn-var": "#ffa657",
+    "--syn-punct": "#c9d1d9",
+    "--syn-tag": "#7ee787",
+    "--syn-attr": "#79c0ff",
+    "--syn-regexp": "#7ee787",
+    "--syn-meta": "#d2a8ff",
+  },
+  light: {
+    "--syn-keyword": "#cf222e",
+    "--syn-string": "#0a3069",
+    "--syn-number": "#0550ae",
+    "--syn-comment": "#57606a",
+    "--syn-func": "#8250df",
+    "--syn-type": "#116329",
+    "--syn-var": "#953800",
+    "--syn-punct": "#1f2328",
+    "--syn-tag": "#116329",
+    "--syn-attr": "#0550ae",
+    "--syn-regexp": "#116329",
+    "--syn-meta": "#8250df",
+  },
+};
+```
+
+In `applyTheme`, next to the existing loops (around `:445`):
+
+```ts
+  for (const [token, value] of Object.entries(SYNTAX_TOKENS[mode])) {
+    root.style.setProperty(token, value);
+  }
+```
+
+- [ ] **Step 4: Add the `:root` defaults and `.syn-*` rules to `src/index.css`**
+
+Add beside the other token declarations:
+
+```css
+  /* Syntax palette. Pre-hydration defaults only — applyTheme() is the source of
+     truth and its `dark` column must stay byte-identical to these. */
+  --syn-keyword: #ff7b72;
+  --syn-string: #a5d6ff;
+  --syn-number: #79c0ff;
+  --syn-comment: #8b949e;
+  --syn-func: #d2a8ff;
+  --syn-type: #7ee787;
+  --syn-var: #ffa657;
+  --syn-punct: #c9d1d9;
+  --syn-tag: #7ee787;
+  --syn-attr: #79c0ff;
+  --syn-regexp: #7ee787;
+  --syn-meta: #d2a8ff;
+```
+
+And, replacing the deleted `.hljs-*` block:
+
+```css
+.syn-keyword { color: var(--syn-keyword); }
+.syn-string { color: var(--syn-string); }
+.syn-number { color: var(--syn-number); }
+.syn-comment { color: var(--syn-comment); font-style: italic; }
+.syn-func { color: var(--syn-func); }
+.syn-type { color: var(--syn-type); }
+.syn-var { color: var(--syn-var); }
+.syn-punct { color: var(--syn-punct); }
+.syn-tag { color: var(--syn-tag); }
+.syn-attr { color: var(--syn-attr); }
+.syn-regexp { color: var(--syn-regexp); }
+.syn-meta { color: var(--syn-meta); }
+```
+
+Leave the `.hljs-*` deletion until Task 9, when the last consumer goes; deleting it here would strip the preview's colors for two tasks.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm vitest run src/features/settings/useSettingsStore.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/index.css src/features/settings/useSettingsStore.ts src/features/settings/useSettingsStore.test.ts
+git commit -m "feat(theme): --syn-* syntax palette written per theme mode"
+```
+
+---
+
+### Task 8: Rewrite `DiffText` on `buildLineSpans`
+
+**Files:**
+- Modify: `src/design/git-components.tsx` — `DiffLineData` at `:490`, `PGDiffLine` at `:510`, `DiffText` at `:691`, `PGHunk` at `:890`
+- Test: `src/design/wordDiffRender.test.tsx` (exists — must pass **unchanged**), plus a new `src/design/syntaxRender.test.tsx`
+
+**Interfaces:**
+- Consumes: `buildLineSpans`, `RenderSpan` (Task 6), `SyntaxLine` (Task 4).
+- Produces: `DiffLineData.syntax?: SyntaxToken[]` — per-line syntax tokens, set by the owning screen; `PGHunkProps.syntax?: { old: SyntaxLine[] | null; new: SyntaxLine[] | null }`.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/design/syntaxRender.test.tsx
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PGHunk } from "./git-components";
+import type { DiffLineData } from "./git-components";
+
+const line = (o: Partial<DiffLineData> & { kind: DiffLineData["kind"] }): DiffLineData => ({
+  text: "",
+  ...o,
+});
+
+describe("syntax spans in diff rows", () => {
+  it("wraps scoped ranges in a classed span", () => {
+    render(
+      <PGHunk
+        header="-1 +1"
+        lines={[
+          line({
+            kind: "ctx",
+            text: "let x",
+            lnL: 1,
+            lnR: 1,
+            syntax: [{ start: 0, end: 3, cls: "syn-keyword" }],
+          }),
+        ]}
+      />,
+    );
+    const kw = document.querySelector(".syn-keyword");
+    expect(kw).not.toBeNull();
+    expect(kw).toHaveTextContent("let");
+  });
+
+  it("still renders the full line text when syntax is absent", () => {
+    render(<PGHunk header="-1 +1" lines={[line({ kind: "ctx", text: "plain text", lnL: 1 })]} />);
+    expect(screen.getByText("plain text")).toBeInTheDocument();
+  });
+
+  it("combines a syntax class and a word-change mark on one range", () => {
+    // A changed range inside a scoped range must carry both.
+    render(
+      <PGHunk
+        header="-1 +1"
+        lines={[
+          line({ kind: "rem", text: "let a", lnL: 1 }),
+          line({ kind: "add", text: "let b", lnR: 1 }),
+        ]}
+        syntax={{
+          old: [[{ start: 0, end: 3, cls: "syn-keyword" }]],
+          new: [[{ start: 0, end: 3, cls: "syn-keyword" }]],
+        }}
+      />,
+    );
+    expect(document.querySelectorAll(".syn-keyword").length).toBeGreaterThan(0);
+    expect(screen.getAllByTestId("word-change").length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run both suites to verify the new one fails and the old one passes**
+
+Run: `pnpm vitest run src/design/syntaxRender.test.tsx src/design/wordDiffRender.test.tsx`
+Expected: `syntaxRender` FAILS (no `.syn-keyword`); `wordDiffRender` PASSES.
+
+- [ ] **Step 3: Implement**
+
+Add to `DiffLineData` (at `:490`):
+
+```ts
+  /**
+   * Per-line syntax tokens, line-relative. Set by the owning screen from
+   * useSyntax; undefined means "render this line unhighlighted".
+   */
+  syntax?: SyntaxToken[];
+```
+
+Replace `DiffText` (at `:691`) with:
+
+```tsx
+/**
+ * Render one line as spans, combining syntax classes and word-diff emphasis.
+ *
+ * Both come from buildLineSpans, which tiles the line — so this maps and never
+ * reasons about gaps or overlaps. The changed-span tint stays relative to the
+ * existing git tokens so custom and light themes carry through.
+ */
+function DiffText({
+  text,
+  spans,
+  syntax,
+  kind,
+}: {
+  text: string;
+  spans?: WordSpan[];
+  syntax?: SyntaxToken[];
+  kind: DiffLineKind;
+}) {
+  const rendered = React.useMemo(
+    () => buildLineSpans(text, syntax ?? null, spans),
+    [text, syntax, spans],
+  );
+  // Nothing to mark: emit the bare string so the DOM stays as light as before.
+  if (rendered.length <= 1 && !rendered[0]?.cls && !rendered[0]?.changed) {
+    return <>{text}</>;
+  }
+  const tint =
+    kind === "add"
+      ? "oklch(from var(--git-added) l c h / 0.28)"
+      : "oklch(from var(--git-removed) l c h / 0.28)";
+  return (
+    <>
+      {rendered.map((s, i) => (
+        <span
+          key={i}
+          className={s.cls}
+          data-testid={s.changed ? "word-change" : undefined}
+          style={s.changed ? { background: tint, borderRadius: 2 } : undefined}
+        >
+          {text.slice(s.start, s.end)}
+        </span>
+      ))}
+    </>
+  );
+}
+```
+
+Thread `syntax` into rows. In `PGHunkProps` add:
+
+```ts
+  /**
+   * Per-side syntax tokens for the whole file, indexed by line number - 1. A
+   * `rem` row reads `old`, `add` and `ctx` rows read `new` — see the spec's
+   * side table. Absent or short arrays simply render plain.
+   */
+  syntax?: { old: SyntaxLine[] | null; new: SyntaxLine[] | null };
+```
+
+In `PGHunk`, extend the existing memo so rows carry their tokens. Keep `withChangedIndices` first — it must number the whole hunk before anything else touches the rows:
+
+```ts
+  const chunks = React.useMemo(() => {
+    const withTokens = withChangedIndices(lines).map((l) => {
+      if (!syntax) return l;
+      const side = l.kind === "rem" ? syntax.old : syntax.new;
+      const lineNo = l.kind === "rem" ? l.lnL : (l.lnR ?? l.lnL);
+      const n = typeof lineNo === "number" ? lineNo : Number(lineNo);
+      if (!side || !Number.isFinite(n) || n < 1) return l;
+      return { ...l, syntax: side[n - 1] };
+    });
+    return withWordSpans(chunkDiffLines(withTokens));
+  }, [lines, syntax]);
+```
+
+Pass `syntax={ln.syntax}` at the `DiffText` call site (`:857`), and add the same prop to standalone `PGDiffLine` so single-row callers can use it.
+
+- [ ] **Step 4: Run both suites to verify they pass**
+
+Run: `pnpm vitest run src/design/syntaxRender.test.tsx src/design/wordDiffRender.test.tsx`
+Expected: both PASS. If `wordDiffRender` needed editing to pass, the rewrite changed behavior — revert and fix the implementation instead.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/design/git-components.tsx src/design/syntaxRender.test.tsx
+git commit -m "feat(diff): render syntax and word-diff spans from one tiling builder"
+```
+
+---
+
+### Task 9: Wire the unified diff, Blame, and the preview; drop highlight.js
+
+**Files:**
+- Modify: `src/screens/DiffViewer.tsx` (diff fetch effect at `:81-113`)
+- Modify: `src/screens/CommitPanel.tsx` (its `PGHunk` render)
+- Modify: `src/screens/Blame.tsx:58-70`
+- Modify: `src/screens/RepoBrowser.tsx:50` (import), `:1179` (`highlightFile` call), `:1194` (`className="hljs"`)
+- Modify: `src/index.css` — delete the `.hljs-*` block (`:272` onward)
+- Modify: `package.json` — remove `highlight.js`
+- Delete: `src/lib/highlight.ts`
+- Test: `src/screens/DiffViewer.syntax.test.tsx`
+
+**Interfaces:**
+- Consumes: `useSyntax` (Task 5), `PGHunkProps.syntax` (Task 8), `readFileContent`/`readFileContentAtRev` from `@/lib/tauri`.
+- Produces: no new exports.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/screens/DiffViewer.syntax.test.tsx
+import { describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { mockInvoke } from "@/test/invokeMock";
+import { DiffViewerScreen } from "./DiffViewer";
+
+// A fake tokenizer keeps this about wiring, not grammars: every line gets one
+// keyword token covering its first three characters.
+vi.mock("@/lib/syntax", async (orig) => ({
+  ...(await orig<typeof import("@/lib/syntax")>()),
+  tokenizeFile: async (_path: string, text: string) =>
+    text.split("\n").map(() => [{ start: 0, end: 3, cls: "syn-keyword" }]),
+}));
+
+describe("DiffViewer syntax", () => {
+  it("reads both sides and highlights diff rows", async () => {
+    const revs: string[] = [];
+    mockInvoke("get_status", () => [
+      { path: "a.ts", index: { kind: "Unmodified" }, worktree: { kind: "Modified" } },
+    ]);
+    mockInvoke("get_diff", () => ({
+      path: "a.ts",
+      binary: false,
+      additions: 1,
+      deletions: 1,
+      hunks: [
+        {
+          header: "@@ -1 +1 @@",
+          lines: [
+            { kind: { kind: "Deletion" }, oldLineno: 1, newLineno: null, content: "let a" },
+            { kind: { kind: "Addition" }, oldLineno: null, newLineno: 1, content: "let b" },
+          ],
+        },
+      ],
+    }));
+    mockInvoke("read_file_content", () => ({
+      path: "a.ts", binary: false, text: "let b", fromHead: false, size: 5,
+    }));
+    mockInvoke("read_file_content_at_rev", (args: { revspec: string }) => {
+      revs.push(args.revspec);
+      return { path: "a.ts", binary: false, text: "let a", fromHead: true, size: 5 };
+    });
+
+    render(<DiffViewerScreen />);
+    await waitFor(() =>
+      expect(document.querySelectorAll(".syn-keyword").length).toBeGreaterThan(0),
+    );
+    expect(revs).toContain("HEAD");
+  });
+});
+```
+
+The store may need a repo in state before the screen fetches; follow whatever pattern the existing `src/screens/*.test.tsx` files use to seed `useRepoStore`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/screens/DiffViewer.syntax.test.tsx`
+Expected: FAIL — no `.syn-keyword` nodes.
+
+- [ ] **Step 3: Implement DiffViewer**
+
+Alongside the existing diff effect, fetch both texts for the selected path and pass tokens down:
+
+```tsx
+  const [sides, setSides] = React.useState<{ old: string | null; new: string | null }>({
+    old: null,
+    new: null,
+  });
+
+  React.useEffect(() => {
+    if (!repo || !current || current.embedded) {
+      setSides({ old: null, new: null });
+      return;
+    }
+    let cancelled = false;
+    // Whole-file text per side, because a hunk is a window: a block comment
+    // opening above it would mis-colour everything below.
+    Promise.all([
+      readFileContentAtRev(repo.id, "HEAD", current.path).catch(() => null),
+      readFileContent(repo.id, current.path).catch(() => null),
+    ]).then(([o, n]) => {
+      if (!cancelled) setSides({ old: o?.text ?? null, new: n?.text ?? null });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [repo, current?.path, current?.embedded]);
+
+  const oldSyntax = useSyntax(current?.path ?? null, sides.old);
+  const newSyntax = useSyntax(current?.path ?? null, sides.new);
+  const syntax = React.useMemo(
+    () => ({ old: oldSyntax, new: newSyntax }),
+    [oldSyntax, newSyntax],
+  );
+```
+
+Pass `syntax={syntax}` to each `PGHunk` in the unified branch (`:361`). Leave the split branch alone — PR2 owns it.
+
+- [ ] **Step 4: Implement CommitPanel the same way**
+
+CommitPanel diffs the same worktree-vs-HEAD pair, so the effect and the two `useSyntax` calls are identical; pass `syntax` to its `PGHunk`s. Do not extract a shared hook yet — PR2 adds the third and fourth call sites and that is the moment to.
+
+- [ ] **Step 5: Implement Blame**
+
+Blame already holds the whole file as `lines`. Tokenize once and render spans:
+
+```tsx
+  const syntax = useSyntax(path, lines.map((l) => l.content).join("\n"));
+```
+
+Render each row's text through `buildLineSpans(l.content, syntax?.[i] ?? null, undefined)`, mapping to `<span className={s.cls}>`.
+
+- [ ] **Step 6: Implement the RepoBrowser preview and delete highlight.js**
+
+Replace the `highlightFile` memo (`:1179`) with `useSyntax(path, text)` and render per-line spans through `buildLineSpans`, dropping `className="hljs"` (`:1194`). Then:
+
+```bash
+export PATH="$HOME/Library/pnpm:$PATH"
+pnpm remove highlight.js
+git rm src/lib/highlight.ts
+```
+
+Delete the `.hljs-*` block from `src/index.css:272` onward, and confirm nothing references it:
+
+```bash
+grep -rn "hljs\|highlight.js\|lib/highlight" src/ || echo "clean"
+```
+
+- [ ] **Step 7: Run the full front-end gate**
+
+```bash
+export PATH="$HOME/Library/pnpm:$PATH"
+pnpm tsc --noEmit
+pnpm test
+```
+Expected: type-check clean; all suites pass, including the untouched `wordDiffRender.test.tsx`.
+
+- [ ] **Step 8: Run the affected e2e specs in Docker**
+
+```bash
+export PATH="$HOME/Library/pnpm:$PATH"
+pnpm test:e2e:docker build
+pnpm test:e2e:docker run --spec e2e/specs/history-diff.e2e.ts
+```
+Expected: PASS. Never run e2e natively.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add -A
+git commit -m "feat(diff): highlight unified diff, blame and preview with shiki
+
+Why: retires the highlight.js HTML-string path, which could not compose with
+word-diff spans. Whole-file tokens per side, because a hunk is a window into a
+file and a construct opening above it would mis-colour the rest."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** `lib/syntax/` (Tasks 1-5), palette (7), `buildLineSpans` (6), `DiffText` rewrite (8), unified diff + Blame + preview + highlight.js removal (9), verified Shiki contract honored in Tasks 1/3/4 (upper-cased colors, absolute offsets, `ShikiError`, explicit loader map). Deferred to PR2 by design: `pairChangedLines`, split view, `CommitDiffPanel`, merge window. Deferred to PR3: windowing. The spec's side table is implemented in Task 8's memo and asserted in Task 9's test.
+
+**Placeholders.** None: every code step carries the actual code, and the two "follow the existing pattern" notes (theme fixtures in Task 7, repo-store seeding in Task 9) point at named files rather than standing in for logic.
+
+**Type consistency.** `SyntaxToken {start, end, cls}` (Task 4) is what `buildLineSpans` consumes (6), what `DiffLineData.syntax` holds (8), and what the Task 9 mock returns. `SyntaxLine = SyntaxToken[]` is the element type of the `PGHunkProps.syntax.old/new` arrays. `WordSpan {start, end, changed}` matches the shipped `src/lib/wordDiff.ts`. `classForColor` returns `syn-<token>`, which is exactly the class the CSS in Task 7 defines and the tests in Task 8 query.

--- a/docs/superpowers/plans/2026-08-14-syntax-highlight-pr1-engine.md
+++ b/docs/superpowers/plans/2026-08-14-syntax-highlight-pr1-engine.md
@@ -10,6 +10,20 @@
 
 **Spec:** `docs/superpowers/specs/2026-08-14-syntax-highlighting-diff-virtualization-design.md`
 
+**Status: executed in #106.** Four corrections came out of running it, recorded so the
+later plans inherit them rather than rediscovering them:
+
+1. Task 2 needs the `shiki` dependency from Task 3 Step 1 — `langs.ts` references
+   `shiki/langs/*`, so install first or the suite cannot resolve the imports.
+2. A `vi.mock` factory is hoisted above the module body. A plain `const` it returns is
+   still uninitialised when the factory runs; use `vi.hoisted(...)` (Task 5).
+3. Mock `@/lib/syntax/tokenize`, not the `@/lib/syntax` barrel — the barrel does not
+   intercept `useSyntax`'s own `./tokenize` import, so the real grammar runs and the
+   fake does nothing (Task 9).
+4. Two behaviours the plan omitted and the spec promised: a rename's old side reads its
+   **old** path from `FileDiff.oldPath`, and the preview needs the old
+   trailing-newline/empty-file line rule, now `splitCodeLines` in `src/lib/codeLines.ts`.
+
 ## Global Constraints
 
 - Node 22 + pnpm. Prepend `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"` to any `pnpm`/`cargo` command.

--- a/docs/superpowers/plans/2026-08-14-syntax-highlight-pr2-remaining-surfaces.md
+++ b/docs/superpowers/plans/2026-08-14-syntax-highlight-pr2-remaining-surfaces.md
@@ -10,7 +10,19 @@
 
 **Spec:** `docs/superpowers/specs/2026-08-14-syntax-highlighting-diff-virtualization-design.md`
 
-**Depends on:** PR1 (`src/lib/syntax/`, `buildLineSpans`, `--syn-*`, the `DiffText` rewrite).
+**Depends on:** PR1 (`src/lib/syntax/`, `buildLineSpans`, `--syn-*`, the `DiffText` rewrite) — shipped in #106.
+
+**Carried over from executing PR1** (apply these here, they are not hypothetical):
+
+- Mock `@/lib/syntax/tokenize`, never the `@/lib/syntax` barrel — see the note in Task 4.
+- A `vi.mock` factory is hoisted above the module body, so a `const` it dereferences
+  must come from `vi.hoisted(...)` or it is still uninitialised when the factory runs.
+- `useDiffSyntax`'s old-side read takes the **old** path for a rename
+  (`diff?.oldPath ?? path`); HEAD has no blob at the new one. PR1 does this in both
+  screens already, so the extraction must preserve it.
+- `CommitPanel` and the two diff screens approximate the index with HEAD + worktree,
+  because there is no `read_file_content_at_index`. Keep that comment when the
+  fetching moves into `useDiffSyntax`.
 
 ## Global Constraints
 
@@ -497,8 +509,12 @@ import { mockInvoke } from "@/test/invokeMock";
 import { CommitDiffPanel } from "./CommitDiffPanel";
 import type { FileDiff } from "@/lib/types";
 
-vi.mock("@/lib/syntax", async (orig) => ({
-  ...(await orig<typeof import("@/lib/syntax")>()),
+// Mock the module useSyntax itself imports, NOT the @/lib/syntax barrel.
+// Mocking the barrel leaves the hook's own `./tokenize` import untouched, so the
+// REAL grammar runs and the fake silently does nothing — this cost a debugging
+// round during PR1.
+vi.mock("@/lib/syntax/tokenize", async (orig) => ({
+  ...(await orig<typeof import("@/lib/syntax/tokenize")>()),
   tokenizeFile: async (_p: string, text: string) =>
     text.split("\n").map(() => [{ start: 0, end: 3, cls: "syn-keyword" }]),
 }));

--- a/docs/superpowers/plans/2026-08-14-syntax-highlight-pr2-remaining-surfaces.md
+++ b/docs/superpowers/plans/2026-08-14-syntax-highlight-pr2-remaining-surfaces.md
@@ -1,0 +1,970 @@
+# Syntax Highlighting PR2: remaining surfaces — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring highlighting and word diff to the surfaces PR1 did not reach — split view (with the pairing fix that makes its columns line up), `CommitDiffPanel`, and both merge-window panes — extracting the two helpers that four call sites now need.
+
+**Architecture:** The rem↔add pairing rule moves out of `PGHunk` into `pairChangedLines`, so split view, the commit-diff panel and the hunk renderer share one definition. A `useDiffSyntax` hook replaces the two ad-hoc fetch effects PR1 left behind. The merge result pane cannot re-tokenize synchronously per keystroke, so it gets a CodeMirror `StateField` of syntax decorations refreshed on a 120 ms debounce — the same `--syn-*` classes as everywhere else.
+
+**Tech Stack:** TypeScript, React 19, CodeMirror 6 (`@codemirror/state`, `@codemirror/view`), Vitest + React Testing Library, `shiki`.
+
+**Spec:** `docs/superpowers/specs/2026-08-14-syntax-highlighting-diff-virtualization-design.md`
+
+**Depends on:** PR1 (`src/lib/syntax/`, `buildLineSpans`, `--syn-*`, the `DiffText` rewrite).
+
+## Global Constraints
+
+- Node 22 + pnpm. Prepend `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"` to any `pnpm`/`cargo` command.
+- Import UI primitives from `@/design`; path alias `@/` → `src/`.
+- Debounce for the merge result pane: `120` ms, verbatim.
+- Guards already shipped in `wordDiff.ts` and not to be re-implemented: `MAX_LINE_CHARS = 1000`, `MAX_TOKENS = 200`, `MIN_SIMILARITY = 0.3`.
+- `--lh-code` owns code-row geometry; density (`--row-step`) does not apply to code rows.
+- A `<PGDialogHost />` must be mounted per window; component tests that render a screen need `WithDialogs` from `@/test/dialog`.
+- The merge window must not gain privileged permissions. Nothing in this PR touches `src-tauri/capabilities/`.
+- Do not run e2e natively. Only `pnpm test:e2e:docker`.
+- Commit style: Conventional Commits, imperative subject under 72 chars.
+
+---
+
+## File Structure
+
+**Created:**
+- `src/lib/pairChangedLines.ts` — the rem↔add pairing rule, extracted.
+- `src/lib/pairChangedLines.test.ts`
+- `src/lib/syntax/useDiffSyntax.ts` — fetch both sides' text and tokenize both.
+- `src/features/merge/syntaxDecorations.ts` — CodeMirror syntax decoration field.
+- `src/features/merge/syntaxDecorations.test.ts`
+- `src/screens/DiffViewer.split.test.tsx`
+
+**Modified:**
+- `src/design/git-components.tsx` — `PGHunk` uses `pairChangedLines`; `SideLine` gains `spans`/`syntax`; `PGSideBySideDiff` renders spans.
+- `src/screens/DiffViewer.tsx` — `diffToSplit` pairs rem/add; split branch gets syntax.
+- `src/screens/CommitPanel.tsx` — adopt `useDiffSyntax`.
+- `src/features/diff/CommitDiffPanel.tsx` — new `syntaxRevs` prop, spans, word diff.
+- `src/screens/CommitDiff.tsx`, `src/screens/History.tsx` — pass `syntaxRevs`.
+- `src/features/merge/SidePane.tsx` — render spans.
+- `src/features/merge/MergeWindow.tsx`, `MergeBody.tsx` — thread `path` and tokens.
+- `src/features/merge/resultEditor.ts` — register the syntax field.
+
+---
+
+### Task 1: Extract `pairChangedLines`
+
+**Files:**
+- Create: `src/lib/pairChangedLines.ts`
+- Test: `src/lib/pairChangedLines.test.ts`
+- Modify: `src/design/git-components.tsx` — `withWordSpans` at `:673`
+
+**Interfaces:**
+- Consumes: `wordDiff`, `WordSpan` from `@/lib/wordDiff`.
+- Produces: `pairChangedLines(rem: string[], add: string[]): Array<{ old: WordSpan[]; new: WordSpan[] } | null>` — one entry per paired index, `null` where `wordDiff` declined.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/pairChangedLines.test.ts
+import { describe, expect, it } from "vitest";
+import { pairChangedLines } from "./pairChangedLines";
+
+describe("pairChangedLines", () => {
+  it("pairs the i-th removal with the i-th addition", () => {
+    const out = pairChangedLines(["let a = 1"], ["let a = 2"]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).not.toBeNull();
+    expect(out[0]!.old.some((s) => s.changed)).toBe(true);
+    expect(out[0]!.new.some((s) => s.changed)).toBe(true);
+  });
+
+  it("pairs only min(rem, add) lines", () => {
+    expect(pairChangedLines(["a", "b", "c"], ["a2"])).toHaveLength(1);
+    expect(pairChangedLines(["a"], ["a2", "b2", "c2"])).toHaveLength(1);
+  });
+
+  it("returns an empty array when either side is empty", () => {
+    expect(pairChangedLines([], ["a"])).toEqual([]);
+    expect(pairChangedLines(["a"], [])).toEqual([]);
+  });
+
+  it("yields null for a pair too dissimilar to be one edited line", () => {
+    // wordDiff declines below MIN_SIMILARITY; unrelated rewrites must not be
+    // highlighted at random, which reads as noise.
+    const out = pairChangedLines(
+      ["import { readFile } from 'node:fs/promises'"],
+      ["export const TOTALLY_UNRELATED = 42"],
+    );
+    expect(out[0]).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `export PATH="$HOME/Library/pnpm:$PATH"; pnpm vitest run src/lib/pairChangedLines.test.ts`
+Expected: FAIL — cannot resolve `./pairChangedLines`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/lib/pairChangedLines.ts
+//
+// The rem↔add pairing rule for intra-line diff, lifted out of PGHunk so the
+// unified hunk renderer, the split view and the commit-diff panel share ONE
+// definition instead of three that drift.
+//
+// The rule: the i-th removed line pairs with the i-th added line, for the first
+// min(rem, add) lines. wordDiff itself declines a pair that is too dissimilar to
+// be "the same line edited", and those come back null.
+import { wordDiff, type WordSpan } from "./wordDiff";
+
+export interface LinePairSpans {
+  old: WordSpan[];
+  new: WordSpan[];
+}
+
+export function pairChangedLines(
+  rem: string[],
+  add: string[],
+): Array<LinePairSpans | null> {
+  const n = Math.min(rem.length, add.length);
+  const out: Array<LinePairSpans | null> = [];
+  for (let i = 0; i < n; i++) {
+    const r = wordDiff(rem[i], add[i]);
+    out.push(r ? { old: r.old, new: r.new } : null);
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run src/lib/pairChangedLines.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Rewire `withWordSpans` onto the helper**
+
+Replace the pairing loop in `git-components.tsx:673-688` with a call, keeping the surrounding chunk walk:
+
+```ts
+function withWordSpans(chunks: DiffChunk[]): DiffChunk[] {
+  const out = chunks.map((c) => ({ ...c, lines: c.lines.map((l) => ({ ...l })) }));
+  for (let i = 0; i + 1 < out.length; i++) {
+    const rem = out[i];
+    const add = out[i + 1];
+    if (rem.kind !== "rem" || add.kind !== "add") continue;
+    const paired = pairChangedLines(
+      rem.lines.map((l) => l.text ?? ""),
+      add.lines.map((l) => l.text ?? ""),
+    );
+    paired.forEach((p, k) => {
+      if (!p) return;
+      rem.lines[k].spans = p.old;
+      add.lines[k].spans = p.new;
+    });
+  }
+  return out;
+}
+```
+
+- [ ] **Step 6: Verify the existing render test still passes untouched**
+
+Run: `pnpm vitest run src/design/wordDiffRender.test.tsx src/design/syntaxRender.test.tsx`
+Expected: both PASS with no edits to either file. This is a pure refactor; if a test needs changing, the extraction changed behavior.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/pairChangedLines.ts src/lib/pairChangedLines.test.ts src/design/git-components.tsx
+git commit -m "refactor(diff): extract pairChangedLines for reuse across surfaces"
+```
+
+---
+
+### Task 2: `useDiffSyntax`
+
+**Files:**
+- Create: `src/lib/syntax/useDiffSyntax.ts`
+- Modify: `src/lib/syntax/index.ts` (export it), `src/screens/DiffViewer.tsx`, `src/screens/CommitPanel.tsx` (replace PR1's inline effects)
+
+**Interfaces:**
+- Consumes: `useSyntax` (PR1), `readFileContent`, `readFileContentAtRev` from `@/lib/tauri`.
+- Produces: `useDiffSyntax(o: { repoId: string | null; path: string | null; oldRev: string | null; newRev: string | null }): { old: SyntaxLine[] | null; new: SyntaxLine[] | null }`. `newRev: null` means "the worktree copy".
+
+- [ ] **Step 1: Write the implementation**
+
+No dedicated unit test: it is composition over `useSyntax`, which PR1 tested, and Task 3/4's screen tests exercise it end to end. Reviewing it means reading it.
+
+```ts
+// src/lib/syntax/useDiffSyntax.ts
+import React from "react";
+import { readFileContent, readFileContentAtRev } from "@/lib/tauri";
+import { useSyntax } from "./useSyntax";
+import type { SyntaxLine } from "./tokenize";
+
+/**
+ * Tokens for both sides of a file diff.
+ *
+ * Whole-file text per side, not hunk text: a hunk is a window into a file, and a
+ * block comment or template literal opening above it would mis-colour every line
+ * below. `oldRev: null` means the side does not exist (an added file);
+ * `newRev: null` means the working-tree copy.
+ *
+ * A failed read yields no tokens for that side, and those rows render plain — a
+ * missing blob must never break a diff.
+ */
+export function useDiffSyntax(o: {
+  repoId: string | null;
+  path: string | null;
+  oldRev: string | null;
+  newRev: string | null;
+}): { old: SyntaxLine[] | null; new: SyntaxLine[] | null } {
+  const { repoId, path, oldRev, newRev } = o;
+  const [texts, setTexts] = React.useState<{ old: string | null; new: string | null }>({
+    old: null,
+    new: null,
+  });
+
+  React.useEffect(() => {
+    setTexts({ old: null, new: null });
+    if (!repoId || !path) return;
+    let cancelled = false;
+    const read = (rev: string | null) =>
+      rev === null
+        ? readFileContent(repoId, path).catch(() => null)
+        : readFileContentAtRev(repoId, rev, path).catch(() => null);
+    Promise.all([oldRev === null ? Promise.resolve(null) : read(oldRev), read(newRev)]).then(
+      ([o2, n]) => {
+        if (!cancelled) setTexts({ old: o2?.text ?? null, new: n?.text ?? null });
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [repoId, path, oldRev, newRev]);
+
+  const oldLines = useSyntax(path, texts.old);
+  const newLines = useSyntax(path, texts.new);
+  return React.useMemo(() => ({ old: oldLines, new: newLines }), [oldLines, newLines]);
+}
+```
+
+- [ ] **Step 2: Adopt it in DiffViewer and CommitPanel**
+
+Delete the inline `sides` effect and the two `useSyntax` calls PR1 added to each screen, and replace with:
+
+```ts
+  const syntax = useDiffSyntax({
+    repoId: repo?.id ?? null,
+    path: current?.path ?? null,
+    oldRev: "HEAD",
+    newRev: null, // worktree
+  });
+```
+
+- [ ] **Step 3: Verify PR1's screen test still passes**
+
+Run: `pnpm vitest run src/screens/DiffViewer.syntax.test.tsx`
+Expected: PASS unchanged — same commands, same `HEAD` revspec.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/syntax/useDiffSyntax.ts src/lib/syntax/index.ts src/screens/DiffViewer.tsx src/screens/CommitPanel.tsx
+git commit -m "refactor(syntax): share both-sides token fetching via useDiffSyntax"
+```
+
+---
+
+### Task 3: Split view — pair the columns, then highlight them
+
+**Files:**
+- Modify: `src/screens/DiffViewer.tsx` — `diffToSplit` at `:398-439`, split branch at `:370-372`
+- Modify: `src/design/git-components.tsx` — `SideLine` at `:830`, `PGSideBySideDiff` at `:836`
+- Test: `src/screens/DiffViewer.split.test.tsx`
+
+**Interfaces:**
+- Consumes: `pairChangedLines` (Task 1), `useDiffSyntax` (Task 2), `buildLineSpans` (PR1).
+- Produces: `SideLine` gains `spans?: WordSpan[]` and `syntax?: SyntaxToken[]`; `PGSideBySideDiff` unchanged in signature.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/screens/DiffViewer.split.test.tsx
+import { describe, expect, it } from "vitest";
+import { diffToSplit } from "./DiffViewer";
+import type { FileDiff } from "@/lib/types";
+
+const diff = (lines: FileDiff["hunks"][number]["lines"]): FileDiff => ({
+  path: "a.ts",
+  binary: false,
+  additions: 0,
+  deletions: 0,
+  hunks: [{ header: "@@ -1 +1 @@", lines }],
+});
+
+const rem = (n: number, content: string) => ({
+  kind: { kind: "Deletion" as const }, oldLineno: n, newLineno: null, content,
+});
+const add = (n: number, content: string) => ({
+  kind: { kind: "Addition" as const }, oldLineno: null, newLineno: n, content,
+});
+const ctx = (n: number, content: string) => ({
+  kind: { kind: "Context" as const }, oldLineno: n, newLineno: n, content,
+});
+
+describe("diffToSplit", () => {
+  it("puts a removal and its matching addition on the SAME row", () => {
+    const { left, right } = diffToSplit(diff([rem(1, "let a"), add(1, "let b")]));
+    // index 0 is the hunk header row on both sides
+    expect(left[1]).toMatchObject({ kind: "rem", text: "let a" });
+    expect(right[1]).toMatchObject({ kind: "add", text: "let b" });
+    expect(left).toHaveLength(right.length);
+  });
+
+  it("pads the shorter side when the runs are uneven", () => {
+    const { left, right } = diffToSplit(
+      diff([rem(1, "a"), rem(2, "b"), add(1, "a2")]),
+    );
+    expect(left).toHaveLength(right.length);
+    expect(right[2]).toMatchObject({ kind: "empty" });
+  });
+
+  it("attaches word spans to paired rows", () => {
+    const { left, right } = diffToSplit(diff([rem(1, "let a = 1"), add(1, "let a = 2")]));
+    expect(left[1].spans?.some((s) => s.changed)).toBe(true);
+    expect(right[1].spans?.some((s) => s.changed)).toBe(true);
+  });
+
+  it("keeps context rows aligned on both sides", () => {
+    const { left, right } = diffToSplit(diff([ctx(1, "same"), rem(2, "x"), add(2, "y")]));
+    expect(left[1]).toMatchObject({ kind: "ctx", text: "same" });
+    expect(right[1]).toMatchObject({ kind: "ctx", text: "same" });
+    expect(left).toHaveLength(right.length);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/screens/DiffViewer.split.test.tsx`
+Expected: FAIL — `diffToSplit` is not exported, and rows are unpaired.
+
+- [ ] **Step 3: Rewrite `diffToSplit`**
+
+Export it, and walk rem/add runs together instead of emitting each line independently:
+
+```ts
+/**
+ * Flatten hunks into aligned left/right columns.
+ *
+ * Removals and additions are collected as RUNS and emitted side by side, so the
+ * i-th removal shares a row with the i-th addition. Emitting each line as it
+ * came let the columns drift apart on any hunk that mixed both, and paired rows
+ * are also what intra-line word diff needs.
+ */
+export function diffToSplit(d: FileDiff | null): { left: SideLine[]; right: SideLine[] } {
+  const left: SideLine[] = [];
+  const right: SideLine[] = [];
+  if (!d) return { left, right };
+
+  for (const h of d.hunks) {
+    left.push({ kind: "info", text: h.header });
+    right.push({ kind: "info", text: h.header });
+
+    let remRun: typeof h.lines = [];
+    let addRun: typeof h.lines = [];
+
+    const flush = () => {
+      if (remRun.length === 0 && addRun.length === 0) return;
+      const paired = pairChangedLines(
+        remRun.map((l) => l.content),
+        addRun.map((l) => l.content),
+      );
+      const rows = Math.max(remRun.length, addRun.length);
+      for (let i = 0; i < rows; i++) {
+        const r = remRun[i];
+        const a = addRun[i];
+        const p = paired[i] ?? null;
+        left.push(
+          r
+            ? { kind: "rem", ln: r.oldLineno ?? undefined, text: r.content, spans: p?.old }
+            : { kind: "empty", ln: "", text: "" },
+        );
+        right.push(
+          a
+            ? { kind: "add", ln: a.newLineno ?? undefined, text: a.content, spans: p?.new }
+            : { kind: "empty", ln: "", text: "" },
+        );
+      }
+      remRun = [];
+      addRun = [];
+    };
+
+    for (const ln of h.lines) {
+      const k = ln.kind.kind;
+      if (k === "Deletion") remRun.push(ln);
+      else if (k === "Addition") addRun.push(ln);
+      else {
+        flush();
+        left.push({ kind: "ctx", ln: ln.oldLineno ?? undefined, text: ln.content });
+        right.push({ kind: "ctx", ln: ln.newLineno ?? undefined, text: ln.content });
+      }
+    }
+    flush();
+  }
+  return { left, right };
+}
+```
+
+- [ ] **Step 4: Add `spans`/`syntax` to `SideLine` and render them**
+
+In `git-components.tsx`:
+
+```ts
+export interface SideLine {
+  kind: DiffLineKind;
+  ln?: number | string;
+  text?: string;
+  /** Intra-line word spans, set by the caller's pairing pass. */
+  spans?: WordSpan[];
+  /** Line-relative syntax tokens for this row's side. */
+  syntax?: SyntaxToken[];
+}
+```
+
+In `PGSideBySideDiff`'s `col` renderer, replace the bare `{text}` with the same `DiffText` the unified renderer uses, so both paths share one span pipeline:
+
+```tsx
+<DiffText text={l.text ?? ""} spans={l.spans} syntax={l.syntax} kind={l.kind} />
+```
+
+- [ ] **Step 5: Feed syntax into the split branch of DiffViewer**
+
+The split arrays are built without tokens, so attach them where the screen renders, using the same side rule as the unified path — `rem` reads `old`, everything else reads `new`:
+
+```ts
+  const splitWithSyntax = React.useMemo(() => {
+    const attach = (rows: SideLine[], side: "old" | "new"): SideLine[] =>
+      rows.map((r) => {
+        const lines = side === "old" ? syntax.old : syntax.new;
+        const n = typeof r.ln === "number" ? r.ln : Number(r.ln);
+        if (!lines || !Number.isFinite(n) || n < 1) return r;
+        return { ...r, syntax: lines[n - 1] };
+      });
+    return { left: attach(split.left, "old"), right: attach(split.right, "new") };
+  }, [split, syntax]);
+```
+
+Render `<PGSideBySideDiff left={splitWithSyntax.left} right={splitWithSyntax.right} />`.
+
+- [ ] **Step 6: Run the tests**
+
+Run: `pnpm vitest run src/screens/DiffViewer.split.test.tsx src/screens/DiffViewer.syntax.test.tsx`
+Expected: both PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/screens/DiffViewer.tsx src/design/git-components.tsx src/screens/DiffViewer.split.test.tsx
+git commit -m "feat(diff): align split columns and give them word diff and syntax
+
+Why: emitting adds and removes independently let the two columns drift apart on
+any mixed hunk. Pairing runs fixes the alignment and is also the precondition
+for intra-line diff in split mode."
+```
+
+---
+
+### Task 4: `CommitDiffPanel`
+
+**Files:**
+- Modify: `src/features/diff/CommitDiffPanel.tsx` — props at `:9-28`, hunk rows at `:236-260`
+- Modify: `src/screens/CommitDiff.tsx`, `src/screens/History.tsx` — pass the new prop
+- Test: `src/features/diff/CommitDiffPanel.syntax.test.tsx`
+
+**Interfaces:**
+- Consumes: `useDiffSyntax` (Task 2), `pairChangedLines` (Task 1), `buildLineSpans` (PR1).
+- Produces: `CommitDiffPanelProps.syntaxRevs?: { repoId: string; oldRev: string | null; newRev: string | null }`.
+
+**Why a new prop:** the panel is presentational — the caller fetches the diffs and it never learns the repo or the revisions. Callers that know them (`CommitDiffScreen`, the History inline panel) pass them; a combined multi-select diff, where "the" old side has no meaning, omits the prop and stays plain. Reusing `PGHunk` here was considered and rejected: it carries the stage/discard chrome this read-only panel deliberately lacks.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/features/diff/CommitDiffPanel.syntax.test.tsx
+import { describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { mockInvoke } from "@/test/invokeMock";
+import { CommitDiffPanel } from "./CommitDiffPanel";
+import type { FileDiff } from "@/lib/types";
+
+vi.mock("@/lib/syntax", async (orig) => ({
+  ...(await orig<typeof import("@/lib/syntax")>()),
+  tokenizeFile: async (_p: string, text: string) =>
+    text.split("\n").map(() => [{ start: 0, end: 3, cls: "syn-keyword" }]),
+}));
+
+const diffs: FileDiff[] = [
+  {
+    path: "a.ts",
+    binary: false,
+    additions: 1,
+    deletions: 1,
+    hunks: [
+      {
+        header: "@@ -1 +1 @@",
+        lines: [
+          { kind: { kind: "Deletion" }, oldLineno: 1, newLineno: null, content: "let a" },
+          { kind: { kind: "Addition" }, oldLineno: null, newLineno: 1, content: "let b" },
+        ],
+      },
+    ],
+  },
+];
+
+describe("CommitDiffPanel syntax", () => {
+  it("highlights and word-diffs when given revs", async () => {
+    mockInvoke("read_file_content_at_rev", () => ({
+      path: "a.ts", binary: false, text: "let a", fromHead: false, size: 5,
+    }));
+    render(
+      <CommitDiffPanel
+        diffs={diffs}
+        loading={false}
+        error={null}
+        header="x → y"
+        paneIdPrefix="t"
+        syntaxRevs={{ repoId: "r1", oldRev: "p", newRev: "c" }}
+      />,
+    );
+    await waitFor(() =>
+      expect(document.querySelectorAll(".syn-keyword").length).toBeGreaterThan(0),
+    );
+    expect(document.querySelectorAll('[data-testid="word-change"]').length).toBeGreaterThan(0);
+  });
+
+  it("renders plain, and reads nothing, without revs", async () => {
+    const seen = vi.fn();
+    mockInvoke("read_file_content_at_rev", () => {
+      seen();
+      return { path: "a.ts", binary: false, text: "let a", fromHead: false, size: 5 };
+    });
+    render(
+      <CommitDiffPanel diffs={diffs} loading={false} error={null} header="x" paneIdPrefix="t2" />,
+    );
+    await waitFor(() => expect(document.querySelectorAll("[data-hunk-index]").length).toBe(1));
+    expect(seen).not.toHaveBeenCalled();
+    expect(document.querySelectorAll(".syn-keyword").length).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/features/diff/CommitDiffPanel.syntax.test.tsx`
+Expected: FAIL — `syntaxRevs` is not a prop; no spans render.
+
+- [ ] **Step 3: Implement**
+
+Add the prop, call the hook, and compute per-hunk spans for the selected file:
+
+```ts
+  const syntax = useDiffSyntax({
+    repoId: syntaxRevs?.repoId ?? null,
+    path: syntaxRevs ? (current?.path ?? null) : null,
+    oldRev: syntaxRevs?.oldRev ?? null,
+    newRev: syntaxRevs?.newRev ?? null,
+  });
+
+  /** Word spans per hunk, keyed by the line's index within that hunk. */
+  const wordSpansByHunk = React.useMemo(() => {
+    return (current?.hunks ?? []).map((h) => {
+      const spans = new Map<number, WordSpan[]>();
+      let remIdx: number[] = [];
+      let addIdx: number[] = [];
+      const flush = () => {
+        if (remIdx.length && addIdx.length) {
+          const paired = pairChangedLines(
+            remIdx.map((i) => h.lines[i].content),
+            addIdx.map((i) => h.lines[i].content),
+          );
+          paired.forEach((p, k) => {
+            if (!p) return;
+            spans.set(remIdx[k], p.old);
+            spans.set(addIdx[k], p.new);
+          });
+        }
+        remIdx = [];
+        addIdx = [];
+      };
+      h.lines.forEach((ln, i) => {
+        const k = ln.kind.kind;
+        if (k === "Deletion") remIdx.push(i);
+        else if (k === "Addition") addIdx.push(i);
+        else flush();
+      });
+      flush();
+      return spans;
+    });
+  }, [current]);
+```
+
+In the row render (`:253`), replace the bare content with spans, using the same side rule:
+
+```tsx
+{h.lines.map((ln, j) => {
+  const isRem = ln.kind.kind === "Deletion";
+  const sideLines = isRem ? syntax.old : syntax.new;
+  const lineNo = isRem ? ln.oldLineno : ln.newLineno;
+  const tokens = sideLines && lineNo ? sideLines[lineNo - 1] : undefined;
+  const spans = buildLineSpans(ln.content, tokens ?? null, wordSpansByHunk[i]?.get(j));
+  return (
+    <div key={j} /* keep the existing row styles verbatim */>
+      {spans.map((s, k) => (
+        <span
+          key={k}
+          className={s.cls}
+          data-testid={s.changed ? "word-change" : undefined}
+          style={
+            s.changed
+              ? {
+                  background: isRem
+                    ? "oklch(from var(--git-removed) l c h / 0.28)"
+                    : "oklch(from var(--git-added) l c h / 0.28)",
+                  borderRadius: 2,
+                }
+              : undefined
+          }
+        >
+          {ln.content.slice(s.start, s.end)}
+        </span>
+      ))}
+    </div>
+  );
+})}
+```
+
+- [ ] **Step 4: Pass `syntaxRevs` from the two callers that know the revs**
+
+In `CommitDiff.tsx` and the History inline panel, pass `{ repoId, oldRev: <parent sha>, newRev: <commit sha> }`. Where the screen already resolves a parent for its `diffCommit` call, reuse that value; where it compares against the worktree, pass `newRev: null`. Leave the multi-select combined diff without the prop.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `pnpm vitest run src/features/diff/CommitDiffPanel.syntax.test.tsx src/features/diff/CommitDiffPanel.resize.test.tsx src/features/diff/CommitDiffPanel.skeleton.test.tsx`
+Expected: all PASS, the two pre-existing suites unedited.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/diff/CommitDiffPanel.tsx src/features/diff/CommitDiffPanel.syntax.test.tsx src/screens/CommitDiff.tsx src/screens/History.tsx
+git commit -m "feat(diff): highlight and word-diff the commit diff panel"
+```
+
+---
+
+### Task 5: Merge window — `SidePane`
+
+**Files:**
+- Modify: `src/features/merge/SidePane.tsx` (row render around `:151-175`), `src/features/merge/MergeBody.tsx`, `src/features/merge/MergeWindow.tsx` (has `path` at `:43`)
+- Test: `src/features/merge/SidePane.syntax.test.tsx`
+
+**Interfaces:**
+- Consumes: `useSyntax` (PR1), `buildLineSpans` (PR1).
+- Produces: `SidePane` gains `syntax?: SyntaxLine[] | null`; `MergeBody` gains `path: string` and passes tokens to both panes.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/features/merge/SidePane.syntax.test.tsx
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+import { SidePane } from "./SidePane";
+
+describe("SidePane syntax", () => {
+  it("wraps scoped ranges in classed spans, indexed by line", () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(
+      <SidePane
+        side="ours"
+        lines={["let a", "let b"]}
+        conflicts={[]}
+        regionStates={[]}
+        currentConflict={null}
+        onAccept={() => {}}
+        scrollRef={ref}
+        onScroll={() => {}}
+        syntax={[
+          [{ start: 0, end: 3, cls: "syn-keyword" }],
+          [{ start: 0, end: 3, cls: "syn-keyword" }],
+        ]}
+      />,
+    );
+    expect(document.querySelectorAll(".syn-keyword")).toHaveLength(2);
+  });
+
+  it("renders plain text when there are no tokens", () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { container } = render(
+      <SidePane
+        side="theirs"
+        lines={["plain"]}
+        conflicts={[]}
+        regionStates={[]}
+        currentConflict={null}
+        onAccept={() => {}}
+        scrollRef={ref}
+        onScroll={() => {}}
+      />,
+    );
+    expect(container.textContent).toContain("plain");
+    expect(document.querySelectorAll(".syn-keyword")).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/features/merge/SidePane.syntax.test.tsx`
+Expected: FAIL — no `syntax` prop.
+
+- [ ] **Step 3: Implement**
+
+Add `syntax?: SyntaxLine[] | null` to `SidePane`'s props, and replace the line body at `:173` — currently `{lines[i] === "" ? " " : lines[i]}` — with spans, preserving the empty-line space that keeps row height uniform:
+
+```tsx
+<span style={{ flex: 1 }}>
+  {lines[i] === "" ? (
+    " "
+  ) : (
+    buildLineSpans(lines[i], syntax?.[i] ?? null, undefined).map((s, k) => (
+      <span key={k} className={s.cls}>
+        {lines[i].slice(s.start, s.end)}
+      </span>
+    ))
+  )}
+</span>
+```
+
+In `MergeWindow.tsx`, tokenize both sides from the model it already holds and pass them through `MergeBody`:
+
+```ts
+  const oursSyntax = useSyntax(path || null, model ? model.oursLines.join("\n") : null);
+  const theirsSyntax = useSyntax(path || null, model ? model.theirsLines.join("\n") : null);
+```
+
+- [ ] **Step 4: Run the merge suites**
+
+Run: `pnpm vitest run src/features/merge/`
+Expected: the new suite PASSES and `MergeBody.test.tsx` / `MergeWindow.test.tsx` pass unedited.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/merge/
+git commit -m "feat(merge): highlight the ours and theirs panes"
+```
+
+---
+
+### Task 6: Merge window — the editable result pane
+
+**Files:**
+- Create: `src/features/merge/syntaxDecorations.ts`
+- Test: `src/features/merge/syntaxDecorations.test.ts`
+- Modify: `src/features/merge/resultEditor.ts` (extensions list at `:156-173`, `createResultEditor` opts at `:144`), `src/features/merge/MergeWindow.tsx` (pass `path`)
+
+**Interfaces:**
+- Consumes: `tokenizeFile`, `SyntaxLine` (PR1); `@codemirror/state`, `@codemirror/view`.
+- Produces: `syntaxField: StateField<DecorationSet>`, `setSyntaxEffect: StateEffect<DecorationSet>`, `buildSyntaxDecorations(state: EditorState, lines: SyntaxLine[]): DecorationSet`, `syntaxHighlighting(path: string): Extension`.
+
+**Why a decoration field rather than `decorations.compute`:** the existing region decorations use `EditorView.decorations.compute`, which must be synchronous. Tokenization is async, so the tokens arrive as a `StateEffect` into a field instead, and the field maps its ranges through intervening document changes so colors do not smear while the debounce is pending.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/features/merge/syntaxDecorations.test.ts
+import { describe, expect, it } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { buildSyntaxDecorations } from "./syntaxDecorations";
+
+function count(set: ReturnType<typeof buildSyntaxDecorations>) {
+  let n = 0;
+  const iter = set.iter();
+  while (iter.value) {
+    n++;
+    iter.next();
+  }
+  return n;
+}
+
+describe("buildSyntaxDecorations", () => {
+  it("maps line-relative tokens onto absolute document ranges", () => {
+    const state = EditorState.create({ doc: "let a\nlet b" });
+    const set = buildSyntaxDecorations(state, [
+      [{ start: 0, end: 3, cls: "syn-keyword" }],
+      [{ start: 4, end: 5, cls: "syn-var" }],
+    ]);
+    expect(count(set)).toBe(2);
+    const iter = set.iter();
+    expect(iter.from).toBe(0);
+    expect(iter.to).toBe(3);
+    iter.next();
+    // Second line starts at offset 6, so 4-5 becomes 10-11.
+    expect(iter.from).toBe(10);
+    expect(iter.to).toBe(11);
+  });
+
+  it("skips tokens past the end of their line instead of throwing", () => {
+    const state = EditorState.create({ doc: "ab" });
+    const set = buildSyntaxDecorations(state, [[{ start: 0, end: 99, cls: "syn-type" }]]);
+    const iter = set.iter();
+    expect(iter.to).toBe(2);
+  });
+
+  it("ignores token lines beyond the document", () => {
+    const state = EditorState.create({ doc: "ab" });
+    const set = buildSyntaxDecorations(state, [
+      [{ start: 0, end: 1, cls: "syn-var" }],
+      [{ start: 0, end: 1, cls: "syn-var" }],
+    ]);
+    expect(count(set)).toBe(1);
+  });
+
+  it("returns an empty set for no tokens", () => {
+    const state = EditorState.create({ doc: "ab" });
+    expect(count(buildSyntaxDecorations(state, []))).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/features/merge/syntaxDecorations.test.ts`
+Expected: FAIL — cannot resolve `./syntaxDecorations`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/features/merge/syntaxDecorations.ts
+//
+// Syntax highlighting for the editable result pane.
+//
+// The region decorations next door use EditorView.decorations.compute, which is
+// synchronous. Tokenizing is not, so tokens arrive as a StateEffect into a field
+// that maps its ranges through document changes — colours therefore shift with
+// edits rather than smearing while the debounce is pending.
+import {
+  StateEffect,
+  StateField,
+  type EditorState,
+  type Extension,
+} from "@codemirror/state";
+import { Decoration, EditorView, type DecorationSet } from "@codemirror/view";
+import { tokenizeFile, type SyntaxLine } from "@/lib/syntax";
+
+/** Re-tokenizing on every keystroke is wasted work; one idle beat is enough. */
+const DEBOUNCE_MS = 120;
+
+export const setSyntaxEffect = StateEffect.define<DecorationSet>();
+
+export function buildSyntaxDecorations(
+  state: EditorState,
+  lines: SyntaxLine[],
+): DecorationSet {
+  const ranges = [];
+  const total = state.doc.lines;
+  for (let i = 0; i < lines.length && i < total; i++) {
+    const line = state.doc.line(i + 1);
+    for (const t of lines[i]) {
+      const from = line.from + t.start;
+      const to = Math.min(line.from + t.end, line.to);
+      if (to <= from) continue;
+      ranges.push(Decoration.mark({ class: t.cls }).range(from, to));
+    }
+  }
+  return Decoration.set(ranges, true);
+}
+
+const syntaxField = StateField.define<DecorationSet>({
+  create: () => Decoration.none,
+  update(deco, tr) {
+    let next = tr.docChanged ? deco.map(tr.changes) : deco;
+    for (const e of tr.effects) if (e.is(setSyntaxEffect)) next = e.value;
+    return next;
+  },
+  provide: (f) => EditorView.decorations.from(f),
+});
+
+/**
+ * Highlight the result document, re-tokenizing on a debounce after each change.
+ * A path whose language is unknown simply never produces decorations.
+ */
+export function syntaxHighlighting(path: string): Extension {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const refresh = (view: EditorView) => {
+    const text = view.state.doc.toString();
+    void tokenizeFile(path, text).then((lines) => {
+      // Bail if the document moved on: the next debounce will cover it.
+      if (!lines || view.state.doc.toString() !== text) return;
+      view.dispatch({ effects: setSyntaxEffect.of(buildSyntaxDecorations(view.state, lines)) });
+    });
+  };
+
+  return [
+    syntaxField,
+    EditorView.updateListener.of((update) => {
+      // First mount also needs one pass, hence the viewportChanged arm.
+      if (!update.docChanged && !update.viewportChanged) return;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = null;
+        refresh(update.view);
+      }, DEBOUNCE_MS);
+    }),
+  ];
+}
+```
+
+- [ ] **Step 4: Register it**
+
+In `resultEditor.ts`, add `path: string` to `createResultEditor`'s opts and put `syntaxHighlighting(path)` in the extensions array after `theme`. In `MergeWindow.tsx`, pass the `path` it already holds at `:43`.
+
+- [ ] **Step 5: Run the tests and the type gate**
+
+```bash
+export PATH="$HOME/Library/pnpm:$PATH"
+pnpm vitest run src/features/merge/
+pnpm tsc --noEmit
+pnpm test
+```
+Expected: all PASS, including `resultEditor.test.ts` unedited apart from the new required `path` argument.
+
+- [ ] **Step 6: Run the affected e2e specs in Docker**
+
+```bash
+pnpm test:e2e:docker build
+pnpm test:e2e:docker run --spec e2e/specs/merge-window.e2e.ts --spec e2e/specs/history-diff.e2e.ts
+```
+Expected: PASS. If `merge-window` reports "Apply never enabled for the second file", that is the known CI-side flake — reproduce once more before treating it as a regression.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/features/merge/
+git commit -m "feat(merge): highlight the editable result pane on a debounce
+
+Why: the result document changes on every keystroke, so it cannot use the
+synchronous decorations.compute path the region marks use. Tokens arrive as an
+effect into a mapped field, sharing the --syn-* palette with both side panes."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** `pairChangedLines` extracted (Task 1); split view pairing, alignment and word diff (Task 3); `CommitDiffPanel` (Task 4); merge `SidePane` (Task 5); merge result pane decorations at the spec's 120 ms (Task 6). The spec's per-surface text-source table is implemented by `useDiffSyntax` (Task 2) and by the two callers in Task 4. Windowing is PR3 and appears nowhere here.
+
+**Placeholders.** The two "reuse the value the screen already resolves" notes in Task 4 Step 4 point at existing call sites rather than standing in for logic; every other step carries its code.
+
+**Type consistency.** `pairChangedLines` returns `Array<LinePairSpans | null>` and every consumer indexes it positionally against the runs it passed in. `SideLine.spans` is `WordSpan[]` and `SideLine.syntax` is `SyntaxToken[]`, matching `DiffText`'s parameters from PR1. `useDiffSyntax` returns `{ old, new }` of `SyntaxLine[] | null`, which is the same shape `PGHunkProps.syntax` takes. `buildSyntaxDecorations(state, lines)` takes `SyntaxLine[]`, the element type of that same array.

--- a/docs/superpowers/plans/2026-08-14-syntax-highlight-pr3-windowed-diff-rows.md
+++ b/docs/superpowers/plans/2026-08-14-syntax-highlight-pr3-windowed-diff-rows.md
@@ -1,0 +1,933 @@
+# Syntax Highlighting PR3: windowed diff rows — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop mounting every row of a diff. Flatten a file's hunks into one row array whose heights are known, window it with exact prefix sums, and keep line-level staging, hunk navigation and collapse working — with `wrap` on falling back to rendering everything.
+
+**Architecture:** A diff is not a fixed-pitch list: a hunk header is `calc(26px + var(--row-step))` of density-aware chrome, a code row is `--fs-12 × --lh-code`. Nothing needs measuring though, because both heights are known — so `flattenDiffRows` emits rows tagged with their height and `windowVariable` slices them by prefix sum, returning the same `WindowRange` shape `useWindowedList` already produces. `PGHunk`'s internals split into a header component and a row component, which a new `PGWindowedDiff` reuses so there is no second copy of the row markup.
+
+**Tech Stack:** TypeScript, React 19, Vitest + React Testing Library, WebdriverIO (Docker only).
+
+**Spec:** `docs/superpowers/specs/2026-08-14-syntax-highlighting-diff-virtualization-design.md`
+
+**Depends on:** PR1 and PR2.
+
+## Global Constraints
+
+- Node 22 + pnpm. Prepend `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"` to any `pnpm`/`cargo` command.
+- **`changedIndex` is numbered over the whole hunk, before any windowing.** It is the wire contract shared with the backend's `Patch::line_in_hunk` (#61 D7). Numbering a slice stages the wrong line. Highest-severity constraint in the slice.
+- `--lh-code` owns code-row geometry. Density (`--row-step`) applies to the hunk header, never to code rows.
+- Never hardcode a row height in TypeScript. `--diff-row-h` is declared in CSS and read at runtime — 1.55 × 12px is 18.6px, so any literal is already wrong (#70).
+- Scroll to a row **by index**, never via `querySelector`: under windowing the target row is usually not mounted.
+- Existing test files listed as guards must pass **unedited**. Editing one to fit means the refactor changed behavior.
+- Do not run e2e natively. Only `pnpm test:e2e:docker`.
+- Commit style: Conventional Commits, imperative subject under 72 chars.
+
+---
+
+## File Structure
+
+**Created:**
+- `src/lib/diffRows.ts` — `flattenDiffRows`, `windowVariable`, and `withChangedIndices` moved here so one definition serves both the flat model and `PGHunk`.
+- `src/lib/diffRows.test.ts`
+- `src/lib/useDiffRowHeight.ts` — reads `--diff-row-h`.
+- `src/design/PGWindowedDiff.tsx` — flat row renderer taking an optional window.
+- `src/design/PGWindowedDiff.test.tsx`
+
+**Modified:**
+- `src/index.css` — declare `--diff-row-h`.
+- `src/design/git-components.tsx` — split `PGHunk` into `PGHunkHeader` + `PGDiffRow`; import `withChangedIndices`.
+- `src/design/index.ts` — export `PGWindowedDiff`.
+- `src/screens/DiffViewer.tsx` — own the window; render through `PGWindowedDiff`.
+- `src/screens/CommitPanel.tsx` — same.
+- `src/features/diff/CommitDiffPanel.tsx` — same.
+
+---
+
+### Task 1: `windowVariable` and `flattenDiffRows`
+
+**Files:**
+- Create: `src/lib/diffRows.ts`
+- Test: `src/lib/diffRows.test.ts`
+- Modify: `src/design/git-components.tsx` — move `withChangedIndices` (`:655-662`) out and import it back
+
+**Interfaces:**
+- Consumes: `DiffLineData` from `@/design`, `WindowRange` from `@/lib/useWindowedList`, `FileDiff` from `@/lib/types`.
+- Produces:
+  - `type DiffRow = { kind: "header"; hunkIndex: number; header: string; h: number } | { kind: "line"; hunkIndex: number; line: DiffLineData; h: number }`
+  - `withChangedIndices(lines: DiffLineData[]): DiffLineData[]` (moved, unchanged)
+  - `flattenDiffRows(hunks: FileDiff["hunks"], o: { headerH: number; rowH: number; collapsed?: ReadonlySet<number> }): DiffRow[]`
+  - `windowVariable(heights: number[], o: { scrollTop: number; viewportH: number; overscan: number }): WindowRange`
+  - `rowOffset(heights: number[], index: number): number`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// src/lib/diffRows.test.ts
+import { describe, expect, it } from "vitest";
+import { flattenDiffRows, rowOffset, windowVariable } from "./diffRows";
+import type { FileDiff } from "@/lib/types";
+
+const hunk = (n: number): FileDiff["hunks"][number] => ({
+  header: `@@ -${n} +${n} @@`,
+  lines: [
+    { kind: { kind: "Context" }, oldLineno: 1, newLineno: 1, content: "ctx" },
+    { kind: { kind: "Deletion" }, oldLineno: 2, newLineno: null, content: "old" },
+    { kind: { kind: "Addition" }, oldLineno: null, newLineno: 2, content: "new" },
+  ],
+});
+
+describe("flattenDiffRows", () => {
+  it("emits a header row then one row per line, per hunk", () => {
+    const rows = flattenDiffRows([hunk(1), hunk(2)], { headerH: 26, rowH: 19 });
+    expect(rows).toHaveLength(8); // 2 headers + 6 lines
+    expect(rows[0]).toMatchObject({ kind: "header", hunkIndex: 0, h: 26 });
+    expect(rows[1]).toMatchObject({ kind: "line", hunkIndex: 0, h: 19 });
+    expect(rows[4]).toMatchObject({ kind: "header", hunkIndex: 1 });
+  });
+
+  it("numbers changedIndex over the WHOLE hunk, skipping context", () => {
+    const rows = flattenDiffRows([hunk(1)], { headerH: 26, rowH: 19 });
+    const lines = rows.filter((r) => r.kind === "line");
+    expect(lines[0].kind === "line" && lines[0].line.changedIndex).toBeUndefined(); // ctx
+    expect(lines[1].kind === "line" && lines[1].line.changedIndex).toBe(0); // rem
+    expect(lines[2].kind === "line" && lines[2].line.changedIndex).toBe(1); // add
+  });
+
+  it("restarts changedIndex per hunk, because the backend counts per hunk", () => {
+    const rows = flattenDiffRows([hunk(1), hunk(2)], { headerH: 26, rowH: 19 });
+    const second = rows.filter((r) => r.kind === "line" && r.hunkIndex === 1);
+    const indices = second.map((r) => (r.kind === "line" ? r.line.changedIndex : null));
+    expect(indices).toEqual([undefined, 0, 1]);
+  });
+
+  it("omits the line rows of a collapsed hunk but keeps its header", () => {
+    const rows = flattenDiffRows([hunk(1), hunk(2)], {
+      headerH: 26,
+      rowH: 19,
+      collapsed: new Set([0]),
+    });
+    expect(rows.filter((r) => r.hunkIndex === 0)).toHaveLength(1);
+    expect(rows.filter((r) => r.hunkIndex === 1)).toHaveLength(4);
+  });
+
+  it("attaches word spans to paired rem/add rows", () => {
+    const rows = flattenDiffRows(
+      [
+        {
+          header: "@@ -1 +1 @@",
+          lines: [
+            { kind: { kind: "Deletion" }, oldLineno: 1, newLineno: null, content: "let a = 1" },
+            { kind: { kind: "Addition" }, oldLineno: null, newLineno: 1, content: "let a = 2" },
+          ],
+        },
+      ],
+      { headerH: 26, rowH: 19 },
+    );
+    const lines = rows.filter((r) => r.kind === "line");
+    expect(lines[0].kind === "line" && lines[0].line.spans?.some((s) => s.changed)).toBe(true);
+  });
+});
+
+describe("windowVariable", () => {
+  const heights = [26, 19, 19, 19, 26, 19, 19]; // 147px total
+
+  it("renders everything that fits plus overscan", () => {
+    const w = windowVariable(heights, { scrollTop: 0, viewportH: 1000, overscan: 0 });
+    expect(w.start).toBe(0);
+    expect(w.end).toBe(heights.length);
+    expect(w.topPad).toBe(0);
+    expect(w.bottomPad).toBe(0);
+  });
+
+  it("skips rows scrolled past and pads for them exactly", () => {
+    // scrollTop 45 is past rows 0 (26) and 1 (19).
+    const w = windowVariable(heights, { scrollTop: 45, viewportH: 38, overscan: 0 });
+    expect(w.start).toBe(2);
+    expect(w.topPad).toBe(45);
+  });
+
+  it("keeps topPad + rendered + bottomPad equal to the total height", () => {
+    const w = windowVariable(heights, { scrollTop: 45, viewportH: 38, overscan: 1 });
+    const rendered = heights.slice(w.start, w.end).reduce((a, b) => a + b, 0);
+    const total = heights.reduce((a, b) => a + b, 0);
+    expect(w.topPad + rendered + w.bottomPad).toBe(total);
+  });
+
+  it("handles an empty list", () => {
+    expect(windowVariable([], { scrollTop: 0, viewportH: 100, overscan: 4 })).toEqual({
+      start: 0, end: 0, topPad: 0, bottomPad: 0,
+    });
+  });
+
+  it("renders a screenful before first layout, when the viewport measures 0", () => {
+    const w = windowVariable(heights, { scrollTop: 0, viewportH: 0, overscan: 0 });
+    expect(w.end).toBeGreaterThan(0);
+  });
+});
+
+describe("rowOffset", () => {
+  it("sums the heights before an index", () => {
+    expect(rowOffset([26, 19, 19], 0)).toBe(0);
+    expect(rowOffset([26, 19, 19], 2)).toBe(45);
+    expect(rowOffset([26, 19, 19], 99)).toBe(64);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `export PATH="$HOME/Library/pnpm:$PATH"; pnpm vitest run src/lib/diffRows.test.ts`
+Expected: FAIL — cannot resolve `./diffRows`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// src/lib/diffRows.ts
+//
+// Flat row model for a file diff, plus an exact variable-height window.
+//
+// A diff mixes two row heights — a hunk header is density-aware chrome, a code
+// row is --fs-12 * --lh-code — so the fixed-pitch useWindowedList does not fit.
+// Nothing needs measuring though: both heights are KNOWN, so prefix sums give an
+// exact window with no DOM reads and no estimation.
+// `DiffLineData` is imported TYPE-ONLY on purpose. src/design/PGWindowedDiff.tsx
+// imports DiffRow from this module, so a value import of the design barrel here
+// would close a runtime require cycle; `import type` is erased and cannot.
+import type { DiffLineData } from "@/design";
+import type { WindowRange } from "./useWindowedList";
+import type { FileDiff } from "./types";
+import { pairChangedLines } from "./pairChangedLines";
+
+export type DiffRow =
+  | { kind: "header"; hunkIndex: number; header: string; h: number }
+  | { kind: "line"; hunkIndex: number; line: DiffLineData; h: number };
+
+/**
+ * Number the changed (+/-) lines of a hunk from 0, leaving context unnumbered.
+ *
+ * Moved here from git-components so the flat model and PGHunk share ONE
+ * definition. It must count exactly the add/rem rows: it is the wire contract
+ * shared with the backend's Patch::line_in_hunk, which counts +/- origins the
+ * same way, and it is numbered over the WHOLE hunk — numbering a windowed slice
+ * would address the wrong line when staging (#61 D7).
+ */
+export function withChangedIndices(lines: DiffLineData[]): DiffLineData[] {
+  let n = 0;
+  return lines.map((l) =>
+    l.kind === "add" || l.kind === "rem" ? { ...l, changedIndex: n++ } : l,
+  );
+}
+
+function toUiLine(l: FileDiff["hunks"][number]["lines"][number]): DiffLineData {
+  const k = l.kind.kind;
+  if (k === "Addition") return { kind: "add", lnR: l.newLineno ?? undefined, text: l.content };
+  if (k === "Deletion") return { kind: "rem", lnL: l.oldLineno ?? undefined, text: l.content };
+  return {
+    kind: "ctx",
+    lnL: l.oldLineno ?? undefined,
+    lnR: l.newLineno ?? undefined,
+    text: l.content,
+  };
+}
+
+/** Attach intra-line spans to adjacent rem/add runs, using the shared rule. */
+function attachWordSpans(lines: DiffLineData[]): DiffLineData[] {
+  const out = lines.map((l) => ({ ...l }));
+  let i = 0;
+  while (i < out.length) {
+    if (out[i].kind !== "rem") {
+      i++;
+      continue;
+    }
+    let r = i;
+    while (r < out.length && out[r].kind === "rem") r++;
+    let a = r;
+    while (a < out.length && out[a].kind === "add") a++;
+    const rem = out.slice(i, r);
+    const add = out.slice(r, a);
+    if (add.length > 0) {
+      const paired = pairChangedLines(
+        rem.map((l) => l.text ?? ""),
+        add.map((l) => l.text ?? ""),
+      );
+      paired.forEach((p, k) => {
+        if (!p) return;
+        out[i + k].spans = p.old;
+        out[r + k].spans = p.new;
+      });
+    }
+    i = a > i ? a : i + 1;
+  }
+  return out;
+}
+
+export function flattenDiffRows(
+  hunks: FileDiff["hunks"],
+  o: { headerH: number; rowH: number; collapsed?: ReadonlySet<number> },
+): DiffRow[] {
+  const { headerH, rowH, collapsed } = o;
+  const rows: DiffRow[] = [];
+  hunks.forEach((h, hunkIndex) => {
+    rows.push({ kind: "header", hunkIndex, header: h.header, h: headerH });
+    if (collapsed?.has(hunkIndex)) return;
+    // changedIndex FIRST, over the whole hunk, before anything slices rows.
+    const lines = attachWordSpans(withChangedIndices(h.lines.map(toUiLine)));
+    for (const line of lines) rows.push({ kind: "line", hunkIndex, line, h: rowH });
+  });
+  return rows;
+}
+
+export function rowOffset(heights: number[], index: number): number {
+  let sum = 0;
+  for (let i = 0; i < index && i < heights.length; i++) sum += heights[i];
+  return sum;
+}
+
+/**
+ * Window a list of known-height rows. Returns the same shape useWindowedList
+ * produces, so consumers and the `window?: WindowRange` prop are unchanged.
+ */
+export function windowVariable(
+  heights: number[],
+  o: { scrollTop: number; viewportH: number; overscan: number },
+): WindowRange {
+  const { scrollTop, overscan } = o;
+  if (heights.length === 0) return { start: 0, end: 0, topPad: 0, bottomPad: 0 };
+  // Before first layout the viewport measures 0. Render a screenful anyway so
+  // the list is never blank on first paint and e2e can find a row immediately.
+  const viewportH = o.viewportH || 400;
+
+  let first = 0;
+  let acc = 0;
+  while (first < heights.length && acc + heights[first] <= scrollTop) {
+    acc += heights[first];
+    first++;
+  }
+  let topSum = acc;
+  let start = first;
+  for (let k = 0; k < overscan && start > 0; k++) {
+    start--;
+    topSum -= heights[start];
+  }
+
+  let end = first;
+  let filled = acc - scrollTop; // partial height of the first visible row
+  while (end < heights.length && filled < viewportH) {
+    filled += heights[end];
+    end++;
+  }
+  for (let k = 0; k < overscan && end < heights.length; k++) end++;
+
+  const total = heights.reduce((a, b) => a + b, 0);
+  const rendered = heights.slice(start, end).reduce((a, b) => a + b, 0);
+  return { start, end, topPad: topSum, bottomPad: Math.max(0, total - topSum - rendered) };
+}
+```
+
+In `git-components.tsx`, delete the local `withChangedIndices` and import it from `@/lib/diffRows` so there is exactly one copy.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `pnpm vitest run src/lib/diffRows.test.ts src/design/wordDiffRender.test.tsx`
+Expected: `diffRows` PASSES (10 tests); `wordDiffRender` PASSES unedited.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/diffRows.ts src/lib/diffRows.test.ts src/design/git-components.tsx
+git commit -m "feat(diff): flat row model and exact variable-height window"
+```
+
+---
+
+### Task 2: `--diff-row-h` and `useDiffRowHeight`
+
+**Files:**
+- Modify: `src/index.css`
+- Create: `src/lib/useDiffRowHeight.ts`
+- Test: `src/lib/useDiffRowHeight.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `useDiffRowHeight(): number`, `DIFF_ROW_H_FALLBACK = 19`.
+
+- [ ] **Step 1: Declare the variable in CSS**
+
+Beside the other geometry tokens in `:root`:
+
+```css
+  /* Code-row pitch. Derived so --lh-code stays the single owner of code
+     geometry; read at runtime by useDiffRowHeight for the diff window's
+     arithmetic. Never restate this as a number in TS — 1.55 * 12px is 18.6px,
+     so any literal is already wrong (#70). */
+  --diff-row-h: calc(var(--fs-12) * var(--lh-code));
+```
+
+Apply it as the code row's `height` in `PGDiffRow` (Task 3), replacing `minHeight: 18`.
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+// src/lib/useDiffRowHeight.test.ts
+import { describe, expect, it } from "vitest";
+import { readDiffRowHeight, DIFF_ROW_H_FALLBACK } from "./useDiffRowHeight";
+
+describe("readDiffRowHeight", () => {
+  it("parses a px value from the custom property", () => {
+    document.documentElement.style.setProperty("--diff-row-h", "18.6px");
+    expect(readDiffRowHeight()).toBeCloseTo(18.6);
+  });
+
+  it("falls back when the property is missing or not resolvable", () => {
+    // jsdom does not evaluate calc(), so an unresolved value must not yield NaN
+    // and silently zero every row height.
+    document.documentElement.style.setProperty("--diff-row-h", "calc(12px * 1.55)");
+    expect(readDiffRowHeight()).toBe(DIFF_ROW_H_FALLBACK);
+    document.documentElement.style.removeProperty("--diff-row-h");
+    expect(readDiffRowHeight()).toBe(DIFF_ROW_H_FALLBACK);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm vitest run src/lib/useDiffRowHeight.test.ts`
+Expected: FAIL — cannot resolve `./useDiffRowHeight`.
+
+- [ ] **Step 4: Write the implementation**
+
+```ts
+// src/lib/useDiffRowHeight.ts
+import React from "react";
+import { useDensityStep } from "@/features/settings/useSettingsStore";
+
+/**
+ * Used when --diff-row-h cannot be resolved to px — notably jsdom, which does
+ * not evaluate calc(). A fallback, never the source of truth: CSS owns the real
+ * value, and returning NaN here would collapse every windowed row to zero.
+ */
+export const DIFF_ROW_H_FALLBACK = 19;
+
+export function readDiffRowHeight(): number {
+  const raw = getComputedStyle(document.documentElement)
+    .getPropertyValue("--diff-row-h")
+    .trim();
+  const n = Number.parseFloat(raw);
+  return raw.endsWith("px") && Number.isFinite(n) && n > 0 ? n : DIFF_ROW_H_FALLBACK;
+}
+
+/**
+ * Code-row pitch in px. Re-read when density changes, because a density switch
+ * is also when the theme layer rewrites geometry-adjacent tokens.
+ */
+export function useDiffRowHeight(): number {
+  const step = useDensityStep();
+  const [h, setH] = React.useState(() => readDiffRowHeight());
+  React.useEffect(() => {
+    setH(readDiffRowHeight());
+  }, [step]);
+  return h;
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm vitest run src/lib/useDiffRowHeight.test.ts`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/index.css src/lib/useDiffRowHeight.ts src/lib/useDiffRowHeight.test.ts
+git commit -m "feat(diff): derive code-row pitch from CSS instead of a literal"
+```
+
+---
+
+### Task 3: Split `PGHunk` into header and row components
+
+**Files:**
+- Modify: `src/design/git-components.tsx` — `PGHunk` at `:890`, its header block and row loop
+- Test: existing `src/design/wordDiffRender.test.tsx`, `src/design/syntaxRender.test.tsx`, `src/screens/CommitPanel.lineStaging.test.tsx` — all must pass **unedited**
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces (module-internal, plus exported for `PGWindowedDiff`):
+  - `PGHunkHeader(props: { header: string; staged?: boolean; onStage?: () => void; onDiscard?: () => void; expanded: boolean; onToggle?: () => void; actionsDisabledReason?: string; selCount: number })`
+  - `PGDiffRow(props: { line: DiffLineData; selected?: boolean; onLineClick?: (changedIndex: number, range: boolean) => void })`
+- `PGHunk`'s public props are unchanged.
+
+- [ ] **Step 1: Confirm the guard tests pass before touching anything**
+
+Run: `pnpm vitest run src/design/wordDiffRender.test.tsx src/design/syntaxRender.test.tsx src/screens/CommitPanel.lineStaging.test.tsx`
+Expected: PASS. These are the contract for the refactor; note the count.
+
+- [ ] **Step 2: Extract, without changing markup**
+
+Move the header `<div>` PGHunk renders into `PGHunkHeader`, and the per-row `<div>` into `PGDiffRow`, verbatim — same styles, same `data-testid="hunk-stage"`, same `data-pg-row` and selection attributes. Then `PGHunk` becomes:
+
+```tsx
+export function PGHunk({
+  header, lines = [], staged, onStage, onDiscard, expanded = true, onToggle,
+  actionsDisabledReason, selectedLines, onLineClick, syntax,
+}: PGHunkProps) {
+  const rows = React.useMemo(
+    () => attachSyntax(withChangedIndices(lines), syntax),
+    [lines, syntax],
+  );
+  const withSpans = React.useMemo(() => withWordSpans(chunkDiffLines(rows)), [rows]);
+  const lineClick = actionsDisabledReason ? undefined : onLineClick;
+  const selected = new Set(selectedLines ?? []);
+  return (
+    <div style={{ borderBottom: "1px solid var(--border-0)" }}>
+      <PGHunkHeader
+        header={header}
+        staged={staged}
+        onStage={onStage}
+        onDiscard={onDiscard}
+        expanded={expanded}
+        onToggle={onToggle}
+        actionsDisabledReason={actionsDisabledReason}
+        selCount={selectedLines?.length ?? 0}
+      />
+      {expanded &&
+        withSpans.flatMap((c) => c.lines).map((line, i) => (
+          <PGDiffRow
+            key={i}
+            line={line}
+            selected={line.changedIndex !== undefined && selected.has(line.changedIndex)}
+            onLineClick={lineClick}
+          />
+        ))}
+    </div>
+  );
+}
+```
+
+Set the code row's `height: "var(--diff-row-h)"` in `PGDiffRow`, replacing `minHeight: 18`.
+
+- [ ] **Step 3: Run the guard tests again**
+
+Run: `pnpm vitest run src/design/wordDiffRender.test.tsx src/design/syntaxRender.test.tsx src/screens/CommitPanel.lineStaging.test.tsx`
+Expected: PASS, same counts, **no edits to any of the three files**. If one fails, the extraction changed behavior — fix the component, not the test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/design/git-components.tsx
+git commit -m "refactor(design): split PGHunk into header and row components"
+```
+
+---
+
+### Task 4: `PGWindowedDiff`
+
+**Files:**
+- Create: `src/design/PGWindowedDiff.tsx`
+- Test: `src/design/PGWindowedDiff.test.tsx`
+- Modify: `src/design/index.ts`
+
+**Interfaces:**
+- Consumes: `DiffRow` (Task 1), `PGHunkHeader`, `PGDiffRow` (Task 3), `WindowRange`.
+- Produces: `PGWindowedDiff(props: { rows: DiffRow[]; window?: WindowRange; activeHunk?: number; collapsed?: ReadonlySet<number>; onToggleHunk?: (i: number) => void; hunkActions?: (i: number) => { staged?: boolean; onStage?: () => void; onDiscard?: () => void; actionsDisabledReason?: string }; selectedLines?: (i: number) => number[]; onLineClick?: (hunkIndex: number, changedIndex: number, range: boolean) => void })`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/design/PGWindowedDiff.test.tsx
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PGWindowedDiff } from "./PGWindowedDiff";
+import { flattenDiffRows } from "@/lib/diffRows";
+import type { FileDiff } from "@/lib/types";
+
+const bigHunk: FileDiff["hunks"] = [
+  {
+    header: "@@ -1,50 +1,50 @@",
+    lines: Array.from({ length: 50 }, (_, i) => ({
+      kind: { kind: i % 2 === 0 ? "Addition" : ("Context" as const) } as never,
+      oldLineno: i % 2 === 0 ? null : i + 1,
+      newLineno: i + 1,
+      content: `line ${i}`,
+    })),
+  },
+];
+
+const rows = flattenDiffRows(bigHunk, { headerH: 26, rowH: 19 });
+
+describe("PGWindowedDiff", () => {
+  it("renders every row when no window is given", () => {
+    render(<PGWindowedDiff rows={rows} />);
+    expect(screen.getByText("line 0")).toBeInTheDocument();
+    expect(screen.getByText("line 49")).toBeInTheDocument();
+  });
+
+  it("renders only the windowed slice, with spacers for the rest", () => {
+    render(
+      <PGWindowedDiff rows={rows} window={{ start: 0, end: 6, topPad: 0, bottomPad: 855 }} />,
+    );
+    expect(screen.getByText("line 0")).toBeInTheDocument();
+    expect(screen.queryByText("line 49")).not.toBeInTheDocument();
+    const spacer = document.querySelector('[data-pg-spacer="bottom"]') as HTMLElement;
+    expect(spacer.style.height).toBe("855px");
+  });
+
+  it("keeps changedIndex absolute in a windowed slice", () => {
+    // Rows 1.. are lines; a mid-list window must still report the hunk-wide
+    // index, or line staging targets the wrong line (#61 D7).
+    const clicks: Array<[number, number]> = [];
+    render(
+      <PGWindowedDiff
+        rows={rows}
+        window={{ start: 20, end: 26, topPad: 387, bottomPad: 500 }}
+        onLineClick={(h, c) => clicks.push([h, c])}
+      />,
+    );
+    const target = rows[20];
+    if (target.kind !== "line" || target.line.changedIndex === undefined) {
+      throw new Error("fixture must put a changed line at index 20");
+    }
+    screen.getByText(target.line.text!).click();
+    expect(clicks[0][1]).toBe(target.line.changedIndex);
+  });
+
+  it("marks the active hunk's header for hunk navigation", () => {
+    render(<PGWindowedDiff rows={rows} activeHunk={0} />);
+    const header = document.querySelector('[data-hunk-index="0"]');
+    expect(header).not.toBeNull();
+    expect(header?.getAttribute("data-hunk-active")).toBe("");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/design/PGWindowedDiff.test.tsx`
+Expected: FAIL — cannot resolve `./PGWindowedDiff`.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+// src/design/PGWindowedDiff.tsx
+//
+// Flat renderer for a file's diff rows, with an optional window.
+//
+// Reuses PGHunkHeader and PGDiffRow rather than restating their markup, so the
+// windowed and unwindowed paths cannot drift. `window` omitted renders
+// everything — that is the wrap-on case, where row heights are unknown.
+//
+// data-hunk-index stays on header rows: F7 navigation and the e2e specs address
+// hunks through it, and it must survive windowing.
+import React from "react";
+import type { DiffRow } from "@/lib/diffRows";
+import type { WindowRange } from "@/lib/useWindowedList";
+import { PGDiffRow, PGHunkHeader } from "./git-components";
+
+export interface PGWindowedDiffProps {
+  rows: DiffRow[];
+  window?: WindowRange;
+  activeHunk?: number;
+  collapsed?: ReadonlySet<number>;
+  onToggleHunk?: (hunkIndex: number) => void;
+  hunkActions?: (hunkIndex: number) => {
+    staged?: boolean;
+    onStage?: () => void;
+    onDiscard?: () => void;
+    actionsDisabledReason?: string;
+  };
+  selectedLines?: (hunkIndex: number) => number[];
+  onLineClick?: (hunkIndex: number, changedIndex: number, range: boolean) => void;
+}
+
+export function PGWindowedDiff({
+  rows,
+  window: win,
+  activeHunk,
+  collapsed,
+  onToggleHunk,
+  hunkActions,
+  selectedLines,
+  onLineClick,
+}: PGWindowedDiffProps) {
+  const start = win?.start ?? 0;
+  const end = win?.end ?? rows.length;
+  const slice = rows.slice(start, end);
+
+  return (
+    <div>
+      {win && win.topPad > 0 && (
+        <div data-pg-spacer="top" style={{ height: `${win.topPad}px` }} />
+      )}
+      {slice.map((row, i) => {
+        if (row.kind === "header") {
+          const actions = hunkActions?.(row.hunkIndex) ?? {};
+          return (
+            <div
+              key={`h${row.hunkIndex}`}
+              data-hunk-index={row.hunkIndex}
+              data-hunk-active={activeHunk === row.hunkIndex ? "" : undefined}
+            >
+              <PGHunkHeader
+                header={row.header}
+                expanded={!collapsed?.has(row.hunkIndex)}
+                onToggle={onToggleHunk ? () => onToggleHunk(row.hunkIndex) : undefined}
+                selCount={selectedLines?.(row.hunkIndex).length ?? 0}
+                {...actions}
+              />
+            </div>
+          );
+        }
+        const sel = selectedLines?.(row.hunkIndex) ?? [];
+        return (
+          <PGDiffRow
+            key={`l${start + i}`}
+            line={row.line}
+            selected={row.line.changedIndex !== undefined && sel.includes(row.line.changedIndex)}
+            onLineClick={
+              onLineClick
+                ? (changedIndex, range) => onLineClick(row.hunkIndex, changedIndex, range)
+                : undefined
+            }
+          />
+        );
+      })}
+      {win && win.bottomPad > 0 && (
+        <div data-pg-spacer="bottom" style={{ height: `${win.bottomPad}px` }} />
+      )}
+    </div>
+  );
+}
+```
+
+Export it from `src/design/index.ts`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run src/design/PGWindowedDiff.test.tsx`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/design/PGWindowedDiff.tsx src/design/PGWindowedDiff.test.tsx src/design/index.ts
+git commit -m "feat(design): PGWindowedDiff renders a windowed slice of diff rows"
+```
+
+---
+
+### Task 5: Adopt it in the three screens
+
+**Files:**
+- Modify: `src/screens/DiffViewer.tsx` (unified branch at `:350-369`), `src/screens/CommitPanel.tsx`, `src/features/diff/CommitDiffPanel.tsx`
+- Test: `src/screens/DiffViewer.window.test.tsx`
+
+**Interfaces:**
+- Consumes: `flattenDiffRows`, `windowVariable`, `rowOffset` (Task 1), `useDiffRowHeight` (Task 2), `PGWindowedDiff` (Task 4), `useDensityStep`.
+- Produces: no new exports.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// src/screens/DiffViewer.window.test.tsx
+import { describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { mockInvoke } from "@/test/invokeMock";
+import { DiffViewerScreen } from "./DiffViewer";
+
+const lines = Array.from({ length: 400 }, (_, i) => ({
+  kind: { kind: "Context" as const },
+  oldLineno: i + 1,
+  newLineno: i + 1,
+  content: `line ${i}`,
+}));
+
+function seed() {
+  mockInvoke("get_status", () => [
+    { path: "a.ts", index: { kind: "Unmodified" }, worktree: { kind: "Modified" } },
+  ]);
+  mockInvoke("get_diff", () => ({
+    path: "a.ts", binary: false, additions: 0, deletions: 0,
+    hunks: [{ header: "@@ -1,400 +1,400 @@", lines }],
+  }));
+  mockInvoke("read_file_content", () => ({
+    path: "a.ts", binary: false, text: "x", fromHead: false, size: 1,
+  }));
+  mockInvoke("read_file_content_at_rev", () => ({
+    path: "a.ts", binary: false, text: "x", fromHead: true, size: 1,
+  }));
+}
+
+describe("DiffViewer windowing", () => {
+  it("mounts far fewer rows than the diff has", async () => {
+    seed();
+    render(<DiffViewerScreen />);
+    await waitFor(() => expect(screen.getByText("line 0")).toBeInTheDocument());
+    expect(screen.queryByText("line 399")).not.toBeInTheDocument();
+  });
+
+  it("renders every row once wrap is on", async () => {
+    seed();
+    render(<DiffViewerScreen />);
+    await waitFor(() => expect(screen.getByText("line 0")).toBeInTheDocument());
+    await userEvent.click(screen.getByLabelText(/wrap/i));
+    await waitFor(() => expect(screen.getByText("line 399")).toBeInTheDocument());
+  });
+});
+```
+
+Match the wrap toggle's accessible name to whatever `PGToggle` renders; if it exposes no label, add a `data-testid` to the toggle and query that instead.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run src/screens/DiffViewer.window.test.tsx`
+Expected: FAIL — `line 399` is in the DOM, because nothing windows yet.
+
+- [ ] **Step 3: Implement in DiffViewer**
+
+```tsx
+  const rowH = useDiffRowHeight();
+  const densityStep = useDensityStep();
+  const headerH = 26 + densityStep;
+  const [collapsed, setCollapsed] = React.useState<ReadonlySet<number>>(new Set());
+
+  const rows = React.useMemo(
+    () => flattenDiffRows(findFiltered?.hunks ?? [], { headerH, rowH, collapsed }),
+    [findFiltered, headerH, rowH, collapsed],
+  );
+  const heights = React.useMemo(() => rows.map((r) => r.h), [rows]);
+
+  const scrollRef = React.useRef<HTMLDivElement>(null);
+  const [scrollTop, setScrollTop] = React.useState(0);
+  const [viewportH, setViewportH] = React.useState(0);
+  React.useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    setViewportH(el.clientHeight);
+    const ro = new ResizeObserver(() => setViewportH(el.clientHeight));
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Wrap makes row heights genuinely unknown, so windowing is off and every row
+  // renders — the documented trade-off that keeps the toggle.
+  const win = React.useMemo(
+    () => (wrap ? undefined : windowVariable(heights, { scrollTop, viewportH, overscan: 8 })),
+    [wrap, heights, scrollTop, viewportH],
+  );
+```
+
+Render the unified branch as:
+
+```tsx
+<FocusableScroll
+  style={{ flex: 1 }}
+  ariaLabel="Diff"
+  ref={scrollRef}
+  onScroll={() => setScrollTop(scrollRef.current?.scrollTop ?? 0)}
+>
+  <PGWindowedDiff rows={rows} window={win} activeHunk={hunkCursor} collapsed={collapsed}
+    onToggleHunk={(i) => setCollapsed((prev) => {
+      const next = new Set(prev);
+      next.has(i) ? next.delete(i) : next.add(i);
+      return next;
+    })} />
+</FocusableScroll>
+```
+
+If `FocusableScroll` does not forward a ref or `onScroll`, wrap it in a plain `div` that owns both rather than changing the keymap primitive.
+
+- [ ] **Step 4: Make F7 hunk navigation scroll by index**
+
+`useHunkNav` moves `hunkCursor`; scroll to the hunk's header row by offset, never by `querySelector` — under windowing that row is usually not mounted:
+
+```tsx
+  React.useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || hunkCursor == null) return;
+    const rowIndex = rows.findIndex((r) => r.kind === "header" && r.hunkIndex === hunkCursor);
+    if (rowIndex < 0) return;
+    const top = rowOffset(heights, rowIndex);
+    if (top < el.scrollTop || top > el.scrollTop + el.clientHeight - headerH) {
+      el.scrollTop = top;
+    }
+  }, [hunkCursor, rows, heights, headerH]);
+```
+
+- [ ] **Step 5: Repeat for CommitPanel and CommitDiffPanel**
+
+Same four pieces — `rowH`/`headerH`, `rows`, the scroll/window state, and `PGWindowedDiff`. CommitPanel additionally passes `hunkActions` (its stage/discard handlers, keyed by hunk index) and `selectedLines`/`onLineClick` for line staging; those handlers already exist on the screen and change only in that they now take `hunkIndex` as their first argument. `CommitDiffPanel` passes neither — it is read-only.
+
+- [ ] **Step 6: Run the full front-end gate**
+
+```bash
+export PATH="$HOME/Library/pnpm:$PATH"
+pnpm tsc --noEmit
+pnpm test
+```
+Expected: all PASS, including `CommitPanel.lineStaging.test.tsx` unedited — that suite is the guard that staging still addresses the right line.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/screens/DiffViewer.tsx src/screens/CommitPanel.tsx src/features/diff/CommitDiffPanel.tsx src/screens/DiffViewer.window.test.tsx
+git commit -m "perf(diff): window diff rows in the three diff surfaces
+
+Why: a large diff mounted every row, and syntax spans multiply the node count
+per row. Heights are known, so the window is exact arithmetic with no DOM
+measurement. Wrap makes heights unknown and falls back to rendering all rows."
+```
+
+---
+
+### Task 6: E2E
+
+**Files:**
+- Modify (only if a spec proves to need it): `e2e/specs/history-diff.e2e.ts`, `e2e/specs/keymap.e2e.ts`, `e2e/specs/keyboard-shortcuts.e2e.ts`
+
+- [ ] **Step 1: Read the e2e skill first**
+
+Read `.claude/skills/e2e-testing/SKILL.md` before touching a spec — selector conventions, the 5s-per-command penalty, and rebuild discipline.
+
+- [ ] **Step 2: Rebuild this worktree's snapshot**
+
+```bash
+export PATH="$HOME/Library/pnpm:$PATH"
+pnpm test:e2e:docker build
+```
+Never rely on a stale snapshot: the `run` phase silently tests the old binary.
+
+- [ ] **Step 3: Run the three specs that touch diff rows**
+
+```bash
+pnpm test:e2e:docker run --spec e2e/specs/history-diff.e2e.ts --spec e2e/specs/keymap.e2e.ts --spec e2e/specs/keyboard-shortcuts.e2e.ts
+```
+Expected: PASS.
+
+- [ ] **Step 4: Fix any failure at its real cause**
+
+Windowing puts rows off-DOM, so a spec that asserted on a row far down the list now needs to scroll first, or to assert against `[data-hunk-index]` which survives windowing. Prefer changing how the spec reaches the row over weakening the assertion. If a diff row genuinely cannot be reached, that is a product bug in the windowing, not a test problem.
+
+- [ ] **Step 5: Typecheck the e2e project if any spec changed**
+
+```bash
+pnpm exec tsc -p e2e/tsconfig.json --noEmit
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add e2e/
+git commit -m "test(e2e): reach diff rows through the window"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** `flattenDiffRows` and `windowVariable` (Task 1), `--diff-row-h` read rather than hardcoded (Task 2), the `PGHunk` split the spec calls for (Task 3), `PGWindowedDiff` with the `window?: WindowRange` convention (Task 4), screen adoption plus wrap fallback and index-based hunk scrolling (Task 5), the three e2e specs (Task 6). `changedIndex` before windowing is enforced in Task 1's implementation, asserted in Task 1's third test and Task 4's third test, and guarded end to end by `CommitPanel.lineStaging.test.tsx` in Task 5.
+
+**Placeholders.** Three steps say "if the existing primitive does not support X, do Y instead" (Task 5's `FocusableScroll` ref, Task 5's wrap-toggle label, Task 6's spec fixes). Each names the file and gives the fallback, so neither branch is undefined work.
+
+**Type consistency.** `DiffRow` from Task 1 is what `PGWindowedDiff.rows` takes in Task 4 and what Task 5's `flattenDiffRows` call produces. `windowVariable` returns `WindowRange` — the same type `useWindowedList` produces and `PGWindowedDiff.window` accepts. `PGHunkHeader` and `PGDiffRow`, extracted in Task 3, are consumed with exactly those prop names in Task 4. `withChangedIndices` lives only in `@/lib/diffRows` after Task 1, imported by `git-components.tsx`.

--- a/docs/superpowers/specs/2026-08-14-syntax-highlighting-diff-virtualization-design.md
+++ b/docs/superpowers/specs/2026-08-14-syntax-highlighting-diff-virtualization-design.md
@@ -1,0 +1,298 @@
+# Syntax highlighting, word diff everywhere, windowed diff rows — design
+
+Status: approved 2026-08-14.
+
+## Problem
+
+Eight render paths in the app show code, and exactly one of them highlights it:
+
+| Surface | Renderer | Syntax | Word diff | Windowed |
+| --- | --- | --- | --- | --- |
+| DiffViewer, unified | `PGHunk` | no | yes (#61 D8) | no |
+| DiffViewer, split | `PGSideBySideDiff` | no | no | no |
+| CommitPanel hunks | `PGHunk` | no | yes | no |
+| CommitDiffPanel | own rows | no | no | no |
+| Blame | own rows | no | n/a | no |
+| RepoBrowser preview | own rows | highlight.js | n/a | no |
+| Merge `SidePane` | own rows | no | no | n/a (fixed) |
+| Merge result pane | CodeMirror 6 | no (no grammars) | n/a | n/a (CM6) |
+
+The result reads cheap: a diff is undifferentiated monospace text with whole
+lines tinted red or green. Highlighting exists in exactly one place, via
+`lib/highlight.ts` and highlight.js's `common` bundle, and it gets there by
+emitting an HTML string that a hand-rolled `splitHighlightedLines` re-splits per
+line, reopening spans across newlines. That approach cannot compose with word
+diff or windowing, so it has stayed where it is.
+
+Two supporting gaps compound it. `diffToSplit` in `DiffViewer.tsx` pads the left
+and right columns independently, so side-by-side pairs drift apart on any hunk
+that mixes additions and removals. And no diff surface is windowed, though
+`useWindowedList` has existed since #61 A8 and drives both History and the file
+tree — a large diff mounts every row.
+
+## Scope
+
+In scope:
+
+- A Shiki-based tokenizer and a `--syn-*` palette contract owned by `applyTheme()`.
+- Syntax highlighting on all eight rows of the table above, including both merge
+  window panes.
+- Extending the existing `wordDiff` to split view, `CommitDiffPanel`, and merge
+  `SidePane`.
+- Windowing diff rows in DiffViewer (unified and split), CommitPanel, and
+  `CommitDiffPanel`.
+- Retiring highlight.js.
+
+Out of scope:
+
+- Any change to how diffs are computed. Hunks keep coming from libgit2 with the
+  existing `diffContextLines` and ignore-whitespace semantics.
+- Monaco. Rejected: it is an editor, not a renderer. Its `DiffEditor` computes
+  diffs from two texts, which would diverge from the libgit2 hunks that
+  line-level staging addresses; it owns its own virtual scroller, which would
+  cost the per-row staging gutter, `--row-step` density, `data-pg-row` selectors
+  and keymap pane scoping; and it wants web workers, which is friction under the
+  Tauri custom protocol.
+- A user-facing syntax theme picker. Syntax colors follow the app's theme mode.
+- New backend git ops. Everything needed already exists.
+- Windowing Blame and the RepoBrowser preview. Both render whole files today and
+  keep doing so. The preview already emits per-line spans through highlight.js,
+  so this slice does not change its DOM weight in kind, only its engine; Blame
+  does gain spans it did not have. If either measures slow on a large file, they
+  window next, through the same `WindowRange` convention — deliberately deferred
+  rather than forgotten.
+
+## Decisions
+
+**Shiki, with `engine-javascript`.** Real TextMate grammars, ~200 languages,
+lazily registered per language. The JavaScript regex engine avoids shipping a
+WASM asset through the Tauri protocol.
+
+**Tokens are classes, never inline colors.** Shiki's own HTML output bakes hex
+colors into the markup, which would force a re-tokenize on every theme-mode
+switch. Mapping scopes to `--syn-*` classes keeps mode switching CSS-only.
+
+**Tokens are ranges, not substrings.** `{ start, end, cls }` composes with
+`WordSpan`, which is also range-shaped, without either side re-slicing text.
+
+**Whole-file tokenization, not hunk-local.** A hunk is a window into a file; a
+block comment or template string that opens above the hunk mis-colors everything
+below it if tokenized in isolation. Both sides are already reachable: worktree
+text via `readFileContent`, the old side via `readFileContentAtRev`. Hunk-local
+tokenization remains the documented fallback when a read fails or a size guard
+trips.
+
+**One palette, two engines.** Shiki tokenizes the read-only surfaces. The
+editable merge result pane is a CodeMirror 6 document that changes on every
+keystroke, so it gets its tokens through a debounced decoration layer rather
+than a full re-tokenize per edit. The unifying contract is the `--syn-*`
+palette, not the engine, so all three merge panes agree on color and language
+coverage.
+
+## Architecture
+
+### `src/lib/syntax/`
+
+```
+shiki.ts      Singleton highlighter, engine-javascript, lazy grammar registration
+tokenize.ts   tokenizeFile(path, text) => Promise<SyntaxLine[] | null>
+scopes.ts     TextMate scope => --syn-* class (pure, tested)
+cache.ts      LRU keyed by path + content hash (djb2; no crypto needed)
+useSyntax.ts  React hook: SyntaxLine[] | null, cancels on path change
+```
+
+```ts
+export interface SyntaxToken { start: number; end: number; cls: string }
+export type SyntaxLine = SyntaxToken[];
+```
+
+`tokenizeFile` returns `null` rather than throwing when a guard trips —
+`MAX_HIGHLIGHT_BYTES` (1 MB) or `MAX_HIGHLIGHT_LINES` (20 000) — or when the
+path maps to no known grammar. Callers treat `null` as "render plain".
+
+`useSyntax` never blocks first paint: a surface renders plain text immediately
+and re-renders with spans when tokenization resolves. No spinner, no layout
+shift, because span-ification does not change row geometry.
+
+### Palette
+
+Roughly twelve tokens: `--syn-keyword`, `--syn-string`, `--syn-number`,
+`--syn-comment`, `--syn-func`, `--syn-type`, `--syn-var`, `--syn-punct`,
+`--syn-tag`, `--syn-attr`, `--syn-regexp`, `--syn-meta`.
+
+They are written by `applyTheme()` alongside `SEMANTIC_TOKENS`, keyed by theme
+**mode**, with light calibrated separately rather than inherited — the same rule
+that already governs `--git-*` and `--graph-*` (#61 B4). The `dark` column stays
+byte-identical to the `:root` defaults in `index.css`.
+
+This removes the hand-maintained `.hljs-*` block at `index.css:272+`, the
+`highlight.js` dependency, and `src/lib/highlight.ts`.
+
+### Which side a diff row reads
+
+A diff row is a line of one of two files, so a diff surface holds two token
+arrays and each row picks one. The rule, and it is not negotiable per-surface:
+
+| Row kind | Token source | Index |
+| --- | --- | --- |
+| `rem` | old-side tokens | `oldLineno` |
+| `add` | new-side tokens | `newLineno` |
+| `ctx` | new-side tokens | `newLineno` |
+
+Context rows read the new side because that is the text the row displays; for
+unchanged lines the two agree anyway, and falling back to the old side when
+`newLineno` is absent covers the deleted-file case. A row whose line number is
+missing, or whose index is past the token array, renders plain — never throws,
+never guesses.
+
+Each surface supplies the two texts from what it already knows:
+
+| Surface | Old side | New side |
+| --- | --- | --- |
+| DiffViewer, CommitPanel | `readFileContentAtRev(HEAD, path)` | `readFileContent(path)` |
+| CommitDiffPanel, CommitDiff | `readFileContentAtRev(parentSha, path)` | `readFileContentAtRev(sha, path)` |
+| Blame, RepoBrowser preview | n/a | text already in hand |
+| Merge `SidePane` | `conflict_sides` text already in hand | same |
+
+Added and deleted files have only one side; the missing side yields no tokens
+and those rows render plain. Renames read the old side at its old path.
+
+### Span composition — `src/lib/lineSpans.ts`
+
+The keystone unit. Syntax tokens and word-diff spans are two independent range
+sets over one line, and exactly one place should reconcile them:
+
+```ts
+export interface RenderSpan { start: number; end: number; cls?: string; changed: boolean }
+
+export function buildLineSpans(
+  text: string,
+  syntax: SyntaxToken[] | null,
+  words: WordSpan[] | undefined,
+): RenderSpan[];
+```
+
+Output tiles the line: every character is covered exactly once, in order, with
+boundaries drawn from the union of both input range sets. Renderers become a
+flat `spans.map(...)` with no gap handling — the same property `toSpans` in
+`wordDiff.ts` already establishes for word spans alone.
+
+`DiffText` in `git-components.tsx` is rewritten on top of this. It keeps
+`data-testid="word-change"` on changed spans and the existing relative tint
+derived from `--git-added` / `--git-removed`, so `wordDiffRender.test.tsx` stays
+green unchanged.
+
+### Word diff extension
+
+The algorithm is done (#61 D8) and is not touched. What spreads is the pairing
+pass that feeds it. `PGHunk`'s private `withWordSpans` encodes the rule —
+adjacent rem/add chunks pair positionally for `min(rem, add)` lines, and
+`wordDiff` itself declines pairs too dissimilar to be one edited line. That rule
+moves to `src/lib/pairChangedLines.ts` (pure, tested) so three call sites share
+one definition instead of growing three.
+
+- **Split view.** `SideLine` gains `spans?: WordSpan[]`, and `diffToSplit` gains
+  rem↔add pairing so a removal and its matching addition occupy the same row.
+  This is the fix for the existing column drift, and it is a precondition for
+  word diff in split mode rather than a separate improvement.
+- **`CommitDiffPanel`** and **merge `SidePane`** consume the same helper.
+
+### Windowing
+
+`PGFileTree` already set the convention: the design-system component accepts an
+optional `window?: WindowRange` and the screen owns the `useWindowedList` hook,
+so indices mean the same thing on both sides. `PGHunk` and `PGSideBySideDiff`
+follow it.
+
+Three constraints:
+
+1. **`changedIndex` is numbered before windowing, over the full hunk.** It is
+   the wire contract shared with the backend's `Patch::line_in_hunk` for
+   line-level staging (#61 D7). Numbering a windowed slice would silently stage
+   the wrong line. This is the highest-severity risk in the slice.
+2. **Uniform row pitch.** `useWindowedList` is fixed-pitch by design. Today's
+   hunk-header row is taller than a code row (2px padding plus two borders), so
+   header rows adopt code-row height and lose that padding. The pitch constant
+   is exported from `git-components.tsx` and consumed by both the component and
+   the screen, so the two cannot desync — the #70 lesson, and the reason
+   `PGGraphRow` takes its step as a number today.
+3. **Wrap disables windowing.** With `wrap` on, `whiteSpace: pre-wrap` makes row
+   height variable, which fixed pitch cannot express. The screen simply passes
+   no `window`, and every row renders. A very large diff with wrap on stays
+   slow; that combination is rare and this keeps the toggle.
+
+In split mode a single scroller drives both columns from one shared
+`WindowRange`. F7 hunk navigation keeps using `scrollToIndex`, never a
+`querySelector` — under windowing the target row is usually not mounted, a trap
+the hook's own doc comment already calls out.
+
+Diff/code row geometry stays governed by `--lh-code`. Density (`--row-step`)
+does not apply to these rows and must not be introduced here.
+
+### Merge window
+
+`SidePane` rows are already fixed-height and non-wrapping, deliberately, so the
+middle pane can sync scroll by line index. Tokens therefore map to rows by index
+directly, and spans flow through `buildLineSpans` like everywhere else.
+
+The result pane gets a `syntaxDecorations` CodeMirror extension: on a 120 ms
+debounce after a document change it tokenizes the current text and maps tokens
+to `Decoration.mark` with the same `--syn-*` classes. If that proves janky on a
+large conflicted file, the documented fallback is `@codemirror/lang-*` plus a
+`HighlightStyle` mapped to the same variables — incremental, but with narrower
+language coverage than the side panes, which is why it is the fallback and not
+the first choice.
+
+## Testing
+
+Pure logic, vitest:
+
+- `scopes.ts` — scope-to-token mapping, including unknown-scope fallthrough.
+- `buildLineSpans` — tiling, overlapping ranges, syntax-only, words-only,
+  neither, boundaries at line start and end.
+- `pairChangedLines` — unequal run lengths, dissimilar pairs declined, context
+  rows untouched.
+- `tokenizeFile` guards — oversized input and unknown extension both return
+  `null`.
+
+Component, vitest + RTL:
+
+- Spans render with the expected classes, and `data-testid="word-change"`
+  survives the `DiffText` rewrite.
+- A windowed `PGHunk` mounts only its slice while `changedIndex` and
+  `data-testid="hunk-stage"` still address the correct absolute line.
+- `wrap` on renders every row.
+
+Shiki is mocked in component tests with a deterministic fake tokenizer. Real
+grammar loading is slow and asynchronous in jsdom, and these tests are about
+composition, not grammar fidelity.
+
+E2E, Docker only (`pnpm test:e2e:docker`), after `pnpm test:e2e:docker build`:
+`history-diff`, `keymap`, and `keyboard-shortcuts` are the specs that touch diff
+rows, and windowing is exactly the change that can put an asserted row off-DOM.
+
+## Risks
+
+- **`changedIndex` desync under windowing** stages the wrong line. Guarded by
+  numbering before slicing, and by a component test that asserts absolute
+  indices from a windowed render.
+- **Main-thread tokenization jank** on large files. Guarded by size caps; a
+  Worker is deliberately deferred until measurement shows it is needed.
+- **Windowed rows off-DOM** break e2e assertions that scroll implicitly. Covered
+  by running the three affected specs.
+- **Hunk-header rows change height slightly** as the price of uniform pitch.
+  Intentional and visible; called out here so it is not read as a regression.
+- **Merge result pane re-tokenizes on edit.** Debounced, with a documented
+  CodeMirror-native fallback.
+
+## Success criteria
+
+1. All eight code surfaces highlight, with colors that follow the app's theme
+   mode and any custom accent.
+2. highlight.js, `lib/highlight.ts`, and the `.hljs-*` CSS block are gone.
+3. Word diff appears in split view, `CommitDiffPanel`, and merge `SidePane`, from
+   one shared pairing helper.
+4. Split view columns stay aligned across mixed add/remove hunks.
+5. Diff rows are windowed with `wrap` off; line-level staging still targets the
+   correct line in a windowed hunk.
+6. `pnpm tsc --noEmit`, `pnpm test`, and the three affected e2e specs pass.

--- a/docs/superpowers/specs/2026-08-14-syntax-highlighting-diff-virtualization-design.md
+++ b/docs/superpowers/specs/2026-08-14-syntax-highlighting-diff-virtualization-design.md
@@ -62,6 +62,18 @@ Out of scope:
   window next, through the same `WindowRange` convention — deliberately deferred
   rather than forgotten.
 
+## Delivery
+
+Three PRs, each shippable on its own, matching the `issue-61-tier2-pr*` pattern:
+
+1. **Engine and first surfaces** — `lib/syntax/`, the `--syn-*` palette,
+   `buildLineSpans`, the `DiffText` rewrite, unified diff (DiffViewer and
+   CommitPanel), Blame, RepoBrowser preview, and highlight.js removed.
+2. **Remaining surfaces** — `pairChangedLines` extracted, split-view pairing and
+   alignment, `CommitDiffPanel`, merge `SidePane`, merge result pane decorations.
+3. **Windowed diff rows** — `flattenDiffRows`, `windowVariable`, the `PGHunk`
+   split, and screen adoption.
+
 ## Decisions
 
 **Shiki, with `engine-javascript`.** Real TextMate grammars, ~200 languages,
@@ -113,6 +125,35 @@ path maps to no known grammar. Callers treat `null` as "render plain".
 `useSyntax` never blocks first paint: a surface renders plain text immediately
 and re-renders with spans when tokenization resolves. No spinner, no layout
 shift, because span-ification does not change row geometry.
+
+#### Verified Shiki contract
+
+Probed against `shiki@4.4.3` while planning, because three of these would
+otherwise be discovered as bugs:
+
+- `codeToTokens(code, { lang, theme })` returns `{ tokens: ThemedToken[][] }`,
+  one array per source line, and the line count matches the input exactly.
+- A token is `{ content, offset, color, fontStyle }`, and **`offset` is
+  document-absolute, not line-relative**. `tokenize.ts` subtracts each line's
+  start offset, because `WordSpan` is line-relative and the two must compose.
+- **Returned colors are upper-cased** regardless of the case supplied in the
+  theme, so the sentinel lookup normalizes before matching.
+- An unregistered language throws `ShikiError`, so it is catchable and becomes a
+  `null` return rather than a crash.
+- `loadLanguage(mod)` registers a grammar at runtime, which is what makes the
+  lazy per-language map work.
+
+Scope-to-token mapping uses a **sentinel theme**: one generated Shiki theme whose
+`settings` assign each `--syn-*` token a unique unused hex value, so
+`codeToTokens` hands back an identity that maps to a class by lookup. Both the
+theme and the lookup are generated from one table in `scopes.ts`, so they cannot
+drift. The alternative, `includeExplanation`, returns full scope chains per token
+and is documented as slower and larger for no gain here.
+
+Language loading is an **explicit map of static `import()` thunks**
+(`{ rust: () => import("shiki/langs/rust.mjs"), … }`). A template-literal
+specifier is not statically analyzable, so Vite could neither split nor resolve
+it.
 
 ### Palette
 
@@ -204,22 +245,54 @@ optional `window?: WindowRange` and the screen owns the `useWindowedList` hook,
 so indices mean the same thing on both sides. `PGHunk` and `PGSideBySideDiff`
 follow it.
 
-Three constraints:
+Four constraints:
 
 1. **`changedIndex` is numbered before windowing, over the full hunk.** It is
    the wire contract shared with the backend's `Patch::line_in_hunk` for
    line-level staging (#61 D7). Numbering a windowed slice would silently stage
    the wrong line. This is the highest-severity risk in the slice.
-2. **Uniform row pitch.** `useWindowedList` is fixed-pitch by design. Today's
-   hunk-header row is taller than a code row (2px padding plus two borders), so
-   header rows adopt code-row height and lose that padding. The pitch constant
-   is exported from `git-components.tsx` and consumed by both the component and
-   the screen, so the two cannot desync — the #70 lesson, and the reason
-   `PGGraphRow` takes its step as a number today.
-3. **Wrap disables windowing.** With `wrap` on, `whiteSpace: pre-wrap` makes row
-   height variable, which fixed pitch cannot express. The screen simply passes
-   no `window`, and every row renders. A very large diff with wrap on stays
+2. **A diff is not a fixed-pitch list, and it is not measured either.** A hunk
+   header is `calc(26px + var(--row-step))` of density-aware chrome carrying a
+   chevron and Stage/Discard, while a code row is `--fs-12 × --lh-code`. Two
+   pitches, so `useWindowedList` does not fit. But nothing here needs measuring:
+   both heights are known constants, so the file's rows flatten into one array
+   whose heights are computable, and an exact prefix-sum window over that array
+   is both correct and cheap. Rejected alternatives: giving headers code-row
+   height (cramps the buttons, drops the header out of density), and measuring
+   rows in the DOM (the complexity this avoids).
+3. **`--diff-row-h` becomes the single source for code-row pitch.** Declared in
+   CSS as `calc(var(--fs-12) * var(--lh-code))`, applied as the row's `height`,
+   and read once by `useDiffRowHeight()` for the window math. Deriving it in CSS
+   keeps `--lh-code` the owner of code geometry, and reading rather than
+   hardcoding avoids the #70 desync — 1.55 × 12px is 18.6px, so any literal
+   would already be wrong.
+4. **Wrap disables windowing.** With `wrap` on, `whiteSpace: pre-wrap` makes row
+   height genuinely unknown, which no amount of arithmetic recovers. The screen
+   passes no window and every row renders. A very large diff with wrap on stays
    slow; that combination is rare and this keeps the toggle.
+
+Concretely this needs a flat row model rather than `hunks.map(<PGHunk/>)`:
+
+```ts
+// src/lib/diffRows.ts
+export type DiffRow =
+  | { kind: "header"; hunkIndex: number; header: string; h: number }
+  | { kind: "line"; hunkIndex: number; line: DiffLineData; h: number };
+
+export function flattenDiffRows(
+  hunks: FileDiff["hunks"], headerH: number, rowH: number,
+): DiffRow[];
+
+export function windowVariable(
+  heights: number[], scrollTop: number, viewportH: number, overscan: number,
+): WindowRange;
+```
+
+`windowVariable` returns the same `WindowRange` shape `useWindowedList` already
+produces, so consumers and the `window?: WindowRange` prop convention are
+unchanged. `PGHunk` splits into presentational parts — a header component and a
+row renderer — so a flat window can span hunk boundaries while stage, discard,
+collapse and line selection keep working per hunk.
 
 In split mode a single scroller drives both columns from one shared
 `WindowRange`. F7 hunk navigation keeps using `scrollToIndex`, never a
@@ -280,8 +353,10 @@ rows, and windowing is exactly the change that can put an asserted row off-DOM.
   Worker is deliberately deferred until measurement shows it is needed.
 - **Windowed rows off-DOM** break e2e assertions that scroll implicitly. Covered
   by running the three affected specs.
-- **Hunk-header rows change height slightly** as the price of uniform pitch.
-  Intentional and visible; called out here so it is not read as a regression.
+- **Splitting `PGHunk` into header plus row renderer** touches a component that
+  already carries stage, discard, collapse and line selection. The split is
+  mechanical but the surface area is real; its existing tests are the guard, and
+  they must pass unchanged rather than be edited to fit.
 - **Merge result pane re-tokenizes on edit.** Debounced, with a documented
   CodeMirror-native fallback.
 


### PR DESCRIPTION
Design spec and three PR-sized implementation plans for the code/diff viewers. Docs only — no source changes.

## What it decides

**Shiki, not Monaco.** Monaco is an editor; these surfaces need a renderer we control. Its `DiffEditor` computes diffs from two texts, which would diverge from the libgit2 hunks that line-level staging addresses (#61 D7), and its own virtual scroller would cost the staging gutter, `--row-step` density, `data-pg-row` selectors and keymap pane scoping.

Shiki tokenizes to **ranges**, which is what lets syntax tokens, the shipped `WordSpan`s from #61 D8, and windowing all meet in one tested builder. Colours are never baked into markup: a generated *sentinel theme* maps scopes to `--syn-*` classes, so switching theme mode stays CSS-only.

## Scope found while planning

Eight render paths show code; exactly one highlights it. Word diff turned out to be already shipped in `PGHunk` only — so that part is extension (split view, `CommitDiffPanel`, merge `SidePane`), not new code.

Two design corrections came out of planning rather than being discovered as bugs later:

- **Windowing can't be fixed-pitch.** A hunk header is `calc(26px + var(--row-step))` of density-aware chrome with buttons in it; a code row is `--fs-12 × --lh-code` (18.6px). Both heights are *known*, though, so a flat row model plus exact prefix sums needs no DOM measurement.
- **The Shiki API was probed against 4.4.3, not remembered.** Token offsets are document-absolute (must be made line-relative to compose with `WordSpan`), returned colours are upper-cased, unknown languages throw a catchable `ShikiError`, and lazy grammars need explicit static `import()` thunks because Vite can't analyse a template-literal specifier.

## Contents

- `specs/2026-08-14-syntax-highlighting-diff-virtualization-design.md`
- `plans/2026-08-14-syntax-highlight-pr1-engine.md` — engine, `--syn-*` palette, `buildLineSpans`, unified diff + Blame + preview, highlight.js removed
- `plans/2026-08-14-syntax-highlight-pr2-remaining-surfaces.md` — `pairChangedLines`, split-view alignment, `CommitDiffPanel`, both merge panes
- `plans/2026-08-14-syntax-highlight-pr3-windowed-diff-rows.md` — `flattenDiffRows`, `windowVariable`, the `PGHunk` split, screen adoption

21 tasks, 118 TDD steps. Draft because the spec is worth a read before anyone executes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
