### PR TITLE
fix(updater): emit bundle-specific platform keys in latest.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,7 @@ jobs:
     needs: version
     runs-on: windows-latest
     outputs:
-      sig: ${{ steps.sig.outputs.sig }}
+      msi_sig: ${{ steps.sig.outputs.msi_sig }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -243,13 +243,14 @@ jobs:
             echo "Updater signature file $sig_file is empty" >&2
             exit 1
           fi
-          echo "sig=$sig" >> "$GITHUB_OUTPUT"
+          echo "msi_sig=$sig" >> "$GITHUB_OUTPUT"
 
   linux:
     needs: version
     runs-on: ubuntu-22.04
     outputs:
-      sig: ${{ steps.sig.outputs.sig }}
+      appimage_sig: ${{ steps.sig.outputs.appimage_sig }}
+      deb_sig: ${{ steps.sig.outputs.deb_sig }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -321,22 +322,36 @@ jobs:
             src-tauri/target/release/bundle/appimage/PlatypusGit_amd64.AppImage
           fail_on_unmatched_files: true
 
-      - name: Read updater signature
+      # BOTH Linux bundles are updater artifacts, so both get a signature.
+      # tauri-cli's `sign_updaters` has covered Deb (and Rpm) alongside
+      # AppImage/msi/nsis since 2.10 — the .deb.sig has therefore been produced
+      # on every release build already; we just never read it, which is why
+      # latest.json had no `linux-x86_64-deb` entry.
+      #
+      # minisign signs CONTENT, not filenames, so the stable-name `cp` above
+      # leaves both signatures valid for the renamed copies we attach.
+      - name: Read updater signatures
         id: sig
         run: |
           set -euo pipefail
-          appimage_dir="src-tauri/target/release/bundle/appimage"
-          sig_file="$(ls "$appimage_dir"/*.AppImage.sig 2>/dev/null | head -n1 || true)"
-          if [ -z "$sig_file" ] || [ ! -f "$sig_file" ]; then
-            echo "No .AppImage.sig produced — is TAURI_SIGNING_PRIVATE_KEY set?" >&2
-            exit 1
-          fi
-          sig="$(cat "$sig_file")"
-          if [ -z "$sig" ]; then
-            echo "Updater signature file $sig_file is empty" >&2
-            exit 1
-          fi
-          echo "sig=$sig" >> "$GITHUB_OUTPUT"
+          # Called directly (never in a $(...) subshell) so `exit 1` aborts the
+          # job rather than just the substitution.
+          emit() {
+            name="$1"; dir="$2"; pattern="$3"
+            file="$(ls "$dir"/$pattern 2>/dev/null | head -n1 || true)"
+            if [ -z "$file" ] || [ ! -f "$file" ]; then
+              echo "No $pattern produced in $dir — is TAURI_SIGNING_PRIVATE_KEY set?" >&2
+              exit 1
+            fi
+            sig="$(cat "$file")"
+            if [ -z "$sig" ]; then
+              echo "Updater signature file $file is empty" >&2
+              exit 1
+            fi
+            echo "$name=$sig" >> "$GITHUB_OUTPUT"
+          }
+          emit appimage_sig src-tauri/target/release/bundle/appimage '*.AppImage.sig'
+          emit deb_sig      src-tauri/target/release/bundle/deb      '*.deb.sig'
 
   # Pin the Homebrew cask to this release: rewrite version + sha256 in
   # jonassaa/homebrew-platypusgit and commit straight to that tap's main.
@@ -406,6 +421,23 @@ jobs:
   # Publish the updater manifest so tauri-plugin-updater can verify + install.
   # Points at the stable-named release assets. macOS is intentionally omitted
   # (notify-only). Skipped for plain prereleases, same gate as bump-cask.
+  #
+  # KEY LAYOUT. The plugin builds its lookup key as `{os}-{arch}-{installer}`
+  # and searches [`{os}-{arch}-{installer}`, `{os}-{arch}`] in that order, where
+  # `installer` comes from the bundle type patched into the binary at bundle
+  # time (deb / rpm / appimage / nsis / msi / app). So we publish BOTH:
+  #
+  #   - bundle-specific keys, which is what any current client actually matches.
+  #     Without `linux-x86_64-deb` a .deb install falls through to the generic
+  #     `linux-x86_64` key and is handed an *AppImage* as its payload.
+  #   - the generic `{os}-{arch}` keys, for pre-2.10 clients that don't compute
+  #     an installer suffix at all.
+  #
+  # The generic Linux key can safely stay pointed at the AppImage: every client
+  # old enough to only look there is necessarily an AppImage install, because
+  # `update::capability` has always gated Linux self-update behind the APPIMAGE
+  # env var (a .deb install gets `notify` and never invokes the plugin). Same
+  # reasoning for `windows-x86_64` -> msi, the only Windows bundle we ship.
   updater-manifest:
     needs: [version, windows, linux]
     runs-on: ubuntu-latest
@@ -417,8 +449,9 @@ jobs:
         env:
           VERSION: ${{ needs.version.outputs.version }}
           TAG: ${{ needs.version.outputs.tag }}
-          WIN_SIG: ${{ needs.windows.outputs.sig }}
-          LIN_SIG: ${{ needs.linux.outputs.sig }}
+          MSI_SIG: ${{ needs.windows.outputs.msi_sig }}
+          APPIMAGE_SIG: ${{ needs.linux.outputs.appimage_sig }}
+          DEB_SIG: ${{ needs.linux.outputs.deb_sig }}
           RELEASE_BODY: ${{ github.event.release.body }}
           RELEASE_PUBLISHED_AT: ${{ github.event.release.published_at }}
         run: |
@@ -426,7 +459,7 @@ jobs:
           # An empty signature publishes `"signature": ""`, which every client
           # rejects at install time — fail loudly instead (same guard shape as
           # bump-cask's sha256 check).
-          for name in WIN_SIG LIN_SIG; do
+          for name in MSI_SIG APPIMAGE_SIG DEB_SIG; do
             if [ -z "${!name}" ]; then
               echo "Empty updater signature ($name) — refusing to publish latest.json" >&2
               exit 1
@@ -449,17 +482,22 @@ jobs:
             --arg version "$VERSION" \
             --arg notes "$notes" \
             --arg pub_date "$pub_date" \
-            --arg win_sig "$WIN_SIG" \
-            --arg win_url "${base}/PlatypusGit_x64.msi" \
-            --arg lin_sig "$LIN_SIG" \
-            --arg lin_url "${base}/PlatypusGit_amd64.AppImage" \
+            --arg msi_sig "$MSI_SIG" \
+            --arg msi_url "${base}/PlatypusGit_x64.msi" \
+            --arg appimage_sig "$APPIMAGE_SIG" \
+            --arg appimage_url "${base}/PlatypusGit_amd64.AppImage" \
+            --arg deb_sig "$DEB_SIG" \
+            --arg deb_url "${base}/PlatypusGit_amd64.deb" \
             '{
               version: $version,
               notes: $notes,
               pub_date: $pub_date,
               platforms: {
-                "windows-x86_64": { signature: $win_sig, url: $win_url },
-                "linux-x86_64": { signature: $lin_sig, url: $lin_url }
+                "windows-x86_64":        { signature: $msi_sig,      url: $msi_url },
+                "windows-x86_64-msi":    { signature: $msi_sig,      url: $msi_url },
+                "linux-x86_64":          { signature: $appimage_sig, url: $appimage_url },
+                "linux-x86_64-appimage": { signature: $appimage_sig, url: $appimage_url },
+                "linux-x86_64-deb":      { signature: $deb_sig,      url: $deb_url }
               }
             }' > latest.json
           echo "--- latest.json ---"

--- a/src/features/update/UpdatePanel.test.tsx
+++ b/src/features/update/UpdatePanel.test.tsx
@@ -9,7 +9,8 @@ import type { Platform } from "@/lib/platform";
 import type { UpdateInfo } from "@/lib/types";
 
 // Mutable so BOTH platform arms are reachable. A module-level `() => "macos"`
-// made the Linux/.deb notify case (no brew hint) impossible to express.
+// made the Linux/.deb notify case impossible to express, which is exactly the
+// arm that shipped without a hint.
 const platformMock = vi.hoisted(() => ({ value: "macos" as Platform }));
 vi.mock("@/lib/platform", () => ({
   usePlatform: () => platformMock.value,
@@ -72,26 +73,31 @@ describe("UpdatePanel — capability + platform arms", () => {
     expect(screen.getByTestId("pg-update-action")).toHaveTextContent(
       /view release/i,
     );
-    expect(screen.getByTestId("pg-update-brew-hint")).toHaveTextContent(
+    expect(screen.getByTestId("pg-update-pkg-hint")).toHaveTextContent(
       "brew upgrade platypusgit",
     );
   });
 
-  it("notify on Linux (.deb install) offers 'View release' with NO brew hint", () => {
+  it("notify on Linux (.deb install) offers 'View release' AND the apt command", () => {
+    // Regression: this arm used to render no hint at all, so a .deb user got a
+    // "View release" button with no hint of why in-app install was unavailable.
     platformMock.value = "linux";
     seed({ capability: "notify" });
     render(<UpdatePanel />);
     expect(screen.getByTestId("pg-update-action")).toHaveTextContent(
       /view release/i,
     );
-    expect(screen.queryByTestId("pg-update-brew-hint")).toBeNull();
+    expect(screen.getByTestId("pg-update-pkg-hint")).toHaveTextContent(
+      "sudo apt install ./PlatypusGit_amd64.deb",
+    );
+    expect(screen.getByText(/package-manager installs/i)).toBeInTheDocument();
   });
 
-  it("self-update offers 'Install' and never the brew hint", () => {
+  it("self-update offers 'Install' and never a package-manager hint", () => {
     seed({ capability: "self-update" });
     render(<UpdatePanel />);
     expect(screen.getByTestId("pg-update-action")).toHaveTextContent(/install/i);
-    expect(screen.queryByTestId("pg-update-brew-hint")).toBeNull();
+    expect(screen.queryByTestId("pg-update-pkg-hint")).toBeNull();
   });
 });
 

--- a/src/features/update/UpdatePanel.tsx
+++ b/src/features/update/UpdatePanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { PGButton, PGIconButton } from "@/design";
 import { usePlatform } from "@/lib/platform";
+import { packageHint } from "./packageHint";
 import { useUpdateStore } from "./useUpdateStore";
 
 /** Dismissible panel with version, notes, and the primary update action. */
@@ -40,6 +41,7 @@ export function UpdatePanel() {
   if (!panelOpen || !info || !info.available) return null;
 
   const selfUpdate = capability === "self-update";
+  const hint = packageHint(capability, platform);
 
   return (
     <div
@@ -102,19 +104,27 @@ export function UpdatePanel() {
         </pre>
       )}
 
-      {!selfUpdate && platform === "macos" && (
-        <code
-          data-testid="pg-update-brew-hint"
-          style={{
-            fontSize: "var(--fs-11)",
-            color: "var(--fg-1)",
-            background: "var(--bg-2)",
-            borderRadius: "var(--r-2)",
-            padding: "4px 8px",
-          }}
-        >
-          brew upgrade platypusgit
-        </code>
+      {/* The notify path's only actionable content. This used to be a bare
+          macOS-gated `brew` line, so a Linux .deb install got "View release"
+          and no explanation at all. */}
+      {hint && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <span style={{ fontSize: "var(--fs-11)", color: "var(--fg-2)" }}>
+            {hint.note}
+          </span>
+          <code
+            data-testid="pg-update-pkg-hint"
+            style={{
+              fontSize: "var(--fs-11)",
+              color: "var(--fg-1)",
+              background: "var(--bg-2)",
+              borderRadius: "var(--r-2)",
+              padding: "4px 8px",
+            }}
+          >
+            {hint.command}
+          </code>
+        </div>
       )}
 
       {installing && (

--- a/src/features/update/packageHint.test.ts
+++ b/src/features/update/packageHint.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { packageHint } from "./packageHint";
+
+describe("packageHint", () => {
+  it("gives .deb users an apt command instead of a silent dead end", () => {
+    const hint = packageHint("notify", "linux");
+    expect(hint?.command).toBe("sudo apt install ./PlatypusGit_amd64.deb");
+    expect(hint?.note).toMatch(/package-manager/i);
+  });
+
+  it("keeps the Homebrew command for macOS", () => {
+    expect(packageHint("notify", "macos")?.command).toBe(
+      "brew upgrade platypusgit",
+    );
+  });
+
+  it("says nothing when the install can update itself", () => {
+    // An AppImage sets APPIMAGE, so the backend hands back `self-update` —
+    // telling that user to run apt would be actively wrong.
+    expect(packageHint("self-update", "linux")).toBeNull();
+    expect(packageHint("self-update", "macos")).toBeNull();
+  });
+
+  it("says nothing before capability has loaded", () => {
+    // `capability` is fetched once per session; a hint that flashes the wrong
+    // platform's command is worse than no hint.
+    expect(packageHint(null, "linux")).toBeNull();
+  });
+
+  it("invents no command for a platform it has no advice for", () => {
+    expect(packageHint("notify", undefined)).toBeNull();
+    // Windows is unconditionally `self-update` today; if that ever changes we
+    // fall back to silence rather than guessing an installer command.
+    expect(packageHint("notify", "windows")).toBeNull();
+  });
+});

--- a/src/features/update/packageHint.ts
+++ b/src/features/update/packageHint.ts
@@ -1,0 +1,53 @@
+import type { Platform } from "@/lib/platform";
+import type { UpdateCapability } from "@/lib/types";
+
+/**
+ * What to tell a user whose install can't swap its own binary.
+ *
+ * `capability === "notify"` means the backend decided this install defers to a
+ * package manager (see `update::capability` in Rust). Without a hint the panel
+ * showed a bare "View release" button and nothing else, so a `.deb` user had no
+ * way to know *why* the in-app install was unavailable or what to run instead —
+ * the panel was a silent dead end.
+ */
+export interface PackageHint {
+  /** One line on why in-app install is unavailable here. */
+  note: string;
+  /** Copy-pasteable upgrade command. */
+  command: string;
+}
+
+/**
+ * Hint for the notify path, or `null` when there's nothing useful to say.
+ *
+ * Returns `null` while `capability` is still loading (it's fetched once per
+ * session) rather than guessing — a hint that flashes the wrong platform's
+ * command is worse than no hint.
+ *
+ * Windows is never `notify` (`capability` returns `SelfUpdate` for it
+ * unconditionally), so it has no arm; if that ever changes this yields `null`
+ * rather than inventing a command.
+ */
+export function packageHint(
+  capability: UpdateCapability | null,
+  platform: Platform | undefined,
+): PackageHint | null {
+  if (capability !== "notify") return null;
+  switch (platform) {
+    case "macos":
+      return {
+        note: "In-app updates aren't available on macOS yet. If you installed with Homebrew:",
+        command: "brew upgrade platypusgit",
+      };
+    case "linux":
+      // Reached by .deb (and any hand-built) installs: an AppImage sets
+      // `APPIMAGE`, so it gets `self-update` and never lands here. We only
+      // publish .deb + AppImage for Linux, so apt is the right advice.
+      return {
+        note: "In-app updates aren't available for package-manager installs. Download the .deb from the release page, then:",
+        command: "sudo apt install ./PlatypusGit_amd64.deb",
+      };
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
Fixes the Linux `.deb` self-update report. Investigation confirmed the manifest gap but **corrected the mechanism** — see "Diagnosis" below, it changes what the user-visible bug actually is.

## Diagnosis

Confirmed as reported:

- `latest.json` is hand-rolled with `jq` in this workflow (not `tauri-action`), and carried exactly two keys: `windows-x86_64` → msi, `linux-x86_64` → **AppImage**.
- The plugin builds its lookup key as `{os}-{arch}-{installer}` and searches `[{os}-{arch}-{installer}, {os}-{arch}]` in that order (`tauri-plugin-updater-2.10.1/src/updater.rs:578`). With no `linux-x86_64-deb`, a deb install matches the generic key and gets an AppImage URL.

**Corrected:** that mismatch is *latent, not live*. `update::capability` (`src-tauri/src/update.rs:129-135`) returns `SelfUpdate` on Linux only when the `APPIMAGE` env var is set, so a dpkg install gets `Notify` — an explicitly tested invariant (`src-tauri/tests/update.rs:124`). `UpdatePanel.tsx` then renders "View release" and never calls the plugin. **No deb install has ever been handed an AppImage.**

And it would have been safe anyway: `install_deb` magic-byte-checks the payload first (`updater.rs:1049-1056`) and returns `InvalidUpdaterFormat` rather than `dpkg -i`-ing an AppImage.

**So what does a deb user actually hit?** The notify panel's only actionable content was a `platform === "macos"`-gated `brew` line. On Linux they got a "View release" button, no command, and no explanation of why in-app install was unavailable. A silent dead end. That is the real defect.

## Changes

1. **`latest.json` emits bundle-specific keys** — `linux-x86_64-deb`, `linux-x86_64-appimage`, `windows-x86_64-msi` — alongside the generic ones.
2. **The `.deb` signature is read.** No new signing step was needed: tauri-cli's `sign_updaters` has included `PackageType::Deb | Rpm` since 2.10 (verified at the pinned `@tauri-apps/cli-v2.10.1` tag), so `*.deb.sig` was already produced on every release build and simply never read. minisign signs content, not filenames, so the stable-name `cp` leaves it valid.
3. **Linux notify hint** — `sudo apt install ./PlatypusGit_amd64.deb` plus a line explaining why in-app install isn't available. Extracted into a pure, unit-tested `packageHint()`.

### Why the generic keys stay on the AppImage/msi

Every client old enough to look only at `linux-x86_64` is necessarily an AppImage install — precisely because `capability` has always gated deb → `Notify`. So the generic key cannot mis-serve anyone, and dropping it would break AppImage users on v0.0.1–0.0.8.

## Verification

- `pnpm tsc --noEmit` — clean.
- `pnpm test` — 741 tests / 96 files pass, including 5 new `packageHint` tests. The `UpdatePanel` Linux arm previously asserted *no* hint; it now asserts the apt command.
- **Both workflow `run:` scripts extracted from the YAML and executed verbatim** against a fake bundle tree: happy path emits both signatures; a missing `*.deb.sig` and an empty `*.deb.sig` each abort the job (confirming `exit 1` inside the `emit` helper aborts rather than just ending a subshell); an empty `DEB_SIG` is refused by the manifest guard.
- Generated `latest.json` validated by mimicking the plugin's lookup order: `installer=deb` → `linux-x86_64-deb` → `.deb`; `installer=appimage` → `linux-x86_64-appimage` → `.AppImage`; pre-2.10 generic → `.AppImage`.
- No e2e run: no spec touches the update panel, because dev builds report `0.0.0` and `discover` short-circuits before any network call, so the panel never renders under e2e.

The one thing that can't be verified from here is a real release — publishing a test release and installing the previous `.deb` on Ubuntu is still worth doing before relying on it.

## Deliberately not included

**Flipping `capability` so `.deb` installs actually self-update.** Installing a deb needs root, and the plugin's escalation chain (`updater.rs:1106-1200`) is `pkexec` → `zenity`/`kdialog` → bare `sudo dpkg -i` **with inherited stdio**. On WSL2 with no polkit agent the first two fail; the fallback then prompts for a password *in the terminal the app was launched from* while the GUI shows a spinner — and our `pgit` shim makes terminal launches a first-class path. Worth deciding separately, as flagged in the report.

**macOS auto-update.** Still no `darwin-*` key; notify-only by design. Needs a `.app.tar.gz` updater artifact, which we don't publish. Separate, larger piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
