### PR TITLE
docs(rebase): merge-commit handling for interactive rebase — spec + 3 plans

### DIFF
--- a/docs/superpowers/plans/2026-08-14-rebase-merge-commits-pr1-safety-model.md
+++ b/docs/superpowers/plans/2026-08-14-rebase-merge-commits-pr1-safety-model.md
@@ -1,0 +1,1712 @@
+# Interactive rebase over merge commits — PR1: safety and execution model
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** An interactive rebase can no longer leave a half-rewritten branch: plans are validated before the repository is touched, the replay happens on a detached HEAD with the branch ref updated only on completion, the operation's state lives on disk so Abort survives an app restart, and both the Rebase banner and the Conflict screen drive the same engine.
+
+**Architecture:** `Libgit2Backend`'s hand-rolled rebase loop keeps its shape (a `VecDeque<RebaseStep>` popped one step at a time) but gains three collaborators: `git/rebase_plan.rs` validates a plan against the repository before `rebase_start` mutates anything, `git/rebase_state.rs` owns the on-disk `.git/platypusgit-rebase.json` mirror plus `ORIG_HEAD`, and the execution model detaches HEAD for the duration so the branch ref is a single atomic move at the end. On the frontend, base derivation moves out of the context menu into `planCommitSelection`, where `parents[0]` replaces the positional `commits[idx + 1]` guess.
+
+**Tech Stack:** Rust + git2 0.20.4 (libgit2 1.9.2), serde/serde_json, Tauri 2 commands, React + Zustand, vitest/RTL, `cargo test`.
+
+**Spec:** `docs/superpowers/specs/2026-08-14-rebase-merge-commits-design.md`
+
+## Global Constraints
+
+- Every IPC-crossing fn returns `AppResult<T>`; no `unwrap`/`panic` in commands. Add `AppError` variants rather than stringifying.
+- A new Rust `AppError` variant updates `src/lib/errors.ts` **in the same commit**. Wire format is `{ kind, message }`.
+- New `GitBackend` trait methods get a `CliBackend` stub returning `AppError::NotImplemented`. (This PR adds no trait methods; keep it that way.)
+- git2 work inside Tauri commands goes through `tokio::task::spawn_blocking`.
+- Frontend never calls `invoke()` directly — typed wrapper in `src/lib/tauri.ts`.
+- Never call `window.confirm` / `window.prompt` — `pgConfirm` / `pgPrompt` from `@/design`.
+- Run cargo/pnpm with `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"`.
+- E2E only ever runs through Docker: `pnpm test:e2e:docker`. This PR adds no e2e spec.
+- Do not write git's own `.git/rebase-merge/` directory. Our state file plus `ORIG_HEAD` is the contract.
+- The seven existing tests in `src-tauri/tests/rebase.rs` must stay green throughout; they are the regression net for the execution-model change.
+
+## File Structure
+
+**Create:**
+- `src-tauri/src/git/rebase_plan.rs` — plan validation against a repository: `validate`, `merge_legal`, `short`.
+- `src-tauri/src/git/rebase_state.rs` — the on-disk mirror: `PersistedRebase`, `PersistedCurrent`, `path`, `save`, `load`, `clear`, `write_orig_head`.
+- `src-tauri/tests/rebase_validation.rs` — validation rejections, each asserting the repository did not move.
+- `src-tauri/tests/rebase_durability.rs` — detached-HEAD model, state file lifecycle, restart abort, delegation from `continue_operation` / `abort_operation`.
+- `src/features/commits/planCommitSelection.merge.test.ts` — base + contiguity on non-linear history.
+
+**Modify:**
+- `src-tauri/src/error.rs` — `InvalidRebasePlan(String)` variant.
+- `src-tauri/src/git/mod.rs` — `pub mod rebase_plan;`, `pub mod rebase_state;`.
+- `src-tauri/src/git/libgit2.rs` — `RebaseState` fields, `rebase_start` / `advance_rebase` / `rebase_continue` / `rebase_abort` / `rebase_status` / `repo_state` / `continue_operation` / `abort_operation`.
+- `src-tauri/tests/support/mod.rs` — `merge_history` fixture.
+- `src-tauri/tests/rebase.rs` — add branch-ref assertions to the existing edit-pause test.
+- `src/lib/errors.ts` — union member.
+- `src/features/commits/planCommitSelection.ts` — `baseOid` from `parents[0]`, first-parent-chain `contiguous`.
+- `src/design/context-menu.tsx` — the three single-commit entry points use the commit's parent; fixup/squash disabled on a merge with the reason in the label.
+
+---
+
+### Task 1: Reject an unexecutable plan before touching the repository
+
+**Files:**
+- Modify: `src-tauri/src/error.rs`
+- Modify: `src/lib/errors.ts`
+- Create: `src-tauri/src/git/rebase_plan.rs`
+- Modify: `src-tauri/src/git/mod.rs`
+- Modify: `src-tauri/src/git/libgit2.rs` (`rebase_start`, top of fn)
+- Modify: `src-tauri/tests/support/mod.rs`
+- Create: `src-tauri/tests/rebase_validation.rs`
+
+**Interfaces:**
+- Produces: `AppError::InvalidRebasePlan(String)`; `rebase_plan::validate(repo: &git2::Repository, plan: &[RebaseStep]) -> AppResult<()>`; `rebase_plan::merge_legal(action: RebaseAction) -> bool`; `rebase_plan::short(oid: &str) -> &str`; `support::MergeHistory { root, a, f, c, m }` and `support::merge_history(&TempRepo) -> MergeHistory`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src-tauri/tests/rebase_validation.rs`:
+
+```rust
+//! A plan the engine cannot execute must be refused before the repository is
+//! touched. The bug this pins: a merge commit in the plan used to surface
+//! libgit2's "mainline branch is not specified" error on the step that reached
+//! it — after earlier picks had already been committed and the branch tip
+//! moved.
+
+mod support;
+
+use platypusgit_lib::{
+    error::AppError,
+    git::{
+        types::{RebaseAction, RebaseStep},
+        GitBackend,
+    },
+};
+
+use support::{merge_history, TempRepo};
+
+fn step(oid: &str, action: RebaseAction) -> RebaseStep {
+    RebaseStep { oid: oid.to_string(), action, message: None }
+}
+
+/// Every rejection must leave HEAD, the branch ref, and the worktree exactly
+/// as they were.
+fn assert_untouched(tr: &TempRepo, head_before: &str) {
+    let head_now = tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string();
+    assert_eq!(head_now, head_before, "HEAD moved on a rejected plan");
+    let branch = tr
+        .repo
+        .find_reference("refs/heads/main")
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .id()
+        .to_string();
+    assert_eq!(branch, head_before, "branch ref moved on a rejected plan");
+    assert!(
+        tr.repo.statuses(None).unwrap().is_empty(),
+        "worktree dirtied by a rejected plan"
+    );
+}
+
+#[test]
+fn merge_commit_with_pick_is_rejected_before_anything_moves() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+    let head_before = h.m.clone();
+
+    let plan = vec![
+        step(&h.a, RebaseAction::Pick),
+        step(&h.f, RebaseAction::Pick),
+        step(&h.c, RebaseAction::Pick),
+        step(&h.m, RebaseAction::Pick), // the merge
+    ];
+
+    let err = backend.rebase_start(&handle.id, plan).unwrap_err();
+    match err {
+        AppError::InvalidRebasePlan(msg) => {
+            assert!(msg.contains(&h.m[..7]), "message should name the merge: {msg}");
+            assert!(msg.contains("merge"), "message should say why: {msg}");
+        }
+        other => panic!("expected InvalidRebasePlan, got {other:?}"),
+    }
+    assert_untouched(&tr, &head_before);
+    assert!(!backend.rebase_status(&handle.id).unwrap().in_progress);
+}
+
+#[test]
+fn merge_commit_may_be_dropped() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    let plan = vec![
+        step(&h.a, RebaseAction::Pick),
+        step(&h.f, RebaseAction::Pick),
+        step(&h.c, RebaseAction::Pick),
+        step(&h.m, RebaseAction::Drop),
+    ];
+
+    let status = backend.rebase_start(&handle.id, plan).unwrap();
+    assert!(!status.in_progress, "flattening plan should run to completion");
+    let summaries: Vec<String> = backend
+        .log(&handle.id, None, 20)
+        .unwrap()
+        .into_iter()
+        .map(|c| c.summary)
+        .collect();
+    assert!(summaries.iter().any(|s| s == "F on feature"));
+    assert!(!summaries.iter().any(|s| s.starts_with("Merge branch")));
+}
+
+#[test]
+fn duplicate_oid_is_rejected() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+    let head_before = h.m.clone();
+
+    let plan = vec![step(&h.a, RebaseAction::Pick), step(&h.a, RebaseAction::Pick)];
+    let err = backend.rebase_start(&handle.id, plan).unwrap_err();
+    assert!(matches!(err, AppError::InvalidRebasePlan(_)), "got {err:?}");
+    assert_untouched(&tr, &head_before);
+}
+
+#[test]
+fn unknown_oid_is_rejected() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+    let head_before = h.m.clone();
+
+    let plan = vec![step("0000000000000000000000000000000000000000", RebaseAction::Pick)];
+    let err = backend.rebase_start(&handle.id, plan).unwrap_err();
+    assert!(matches!(err, AppError::InvalidRebasePlan(_)), "got {err:?}");
+    assert_untouched(&tr, &head_before);
+}
+
+#[test]
+fn all_drop_plan_is_rejected() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+    let head_before = h.m.clone();
+
+    let plan = vec![step(&h.a, RebaseAction::Drop)];
+    let err = backend.rebase_start(&handle.id, plan).unwrap_err();
+    assert!(matches!(err, AppError::InvalidRebasePlan(_)), "got {err:?}");
+    assert_untouched(&tr, &head_before);
+}
+```
+
+Add the fixture to `src-tauri/tests/support/mod.rs` (append at the end, next to `linear_history`):
+
+```rust
+/// A repository with a merge commit in the middle of the range:
+///
+/// ```text
+/// root ── A ──── C ── M      (main)
+///          \        /
+///           ─── F ──         (feature)
+/// ```
+///
+/// `F` and `C` touch different files, so `M` is a clean merge. Returns the oids
+/// as strings, oldest first.
+pub struct MergeHistory {
+    pub root: String,
+    pub a: String,
+    pub f: String,
+    pub c: String,
+    pub m: String,
+}
+
+pub fn merge_history(tr: &TempRepo) -> MergeHistory {
+    use self::fs::write_file;
+
+    let root = tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string();
+
+    let commit = |name: &str, body: &str, msg: &str| -> String {
+        write_file(tr.path(), name, body);
+        let mut index = tr.repo.index().unwrap();
+        index.add_path(std::path::Path::new(name)).unwrap();
+        index.write().unwrap();
+        let tree = tr.repo.find_tree(index.write_tree().unwrap()).unwrap();
+        let sig = Signature::now("Test", "test@example.com").unwrap();
+        let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+        tr.repo
+            .commit(Some("HEAD"), &sig, &sig, msg, &tree, &[&head])
+            .unwrap()
+            .to_string()
+    };
+
+    let a = commit("a.txt", "a\n", "A on main");
+
+    // feature branches off A
+    let a_commit = tr.repo.find_commit(git2::Oid::from_str(&a).unwrap()).unwrap();
+    tr.repo.branch("feature", &a_commit, false).unwrap();
+    tr.repo.set_head("refs/heads/feature").unwrap();
+    tr.repo
+        .checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+        .unwrap();
+    let f = commit("f.txt", "f\n", "F on feature");
+
+    // back to main
+    tr.repo.set_head("refs/heads/main").unwrap();
+    tr.repo
+        .checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+        .unwrap();
+    let c = commit("c.txt", "c\n", "C on main");
+
+    // merge feature into main
+    let f_oid = git2::Oid::from_str(&f).unwrap();
+    let annotated = tr.repo.find_annotated_commit(f_oid).unwrap();
+    tr.repo.merge(&[&annotated], None, None).unwrap();
+    let mut index = tr.repo.index().unwrap();
+    assert!(!index.has_conflicts(), "merge_history fixture must merge cleanly");
+    let tree = tr.repo.find_tree(index.write_tree().unwrap()).unwrap();
+    let sig = Signature::now("Test", "test@example.com").unwrap();
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    let f_commit = tr.repo.find_commit(f_oid).unwrap();
+    let m = tr
+        .repo
+        .commit(
+            Some("HEAD"),
+            &sig,
+            &sig,
+            "Merge branch 'feature'",
+            &tree,
+            &[&head, &f_commit],
+        )
+        .unwrap()
+        .to_string();
+    tr.repo.cleanup_state().unwrap();
+
+    MergeHistory { root, a, f, c, m }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase_validation
+```
+
+Expected: compile error — `AppError::InvalidRebasePlan` does not exist. After the variant is added but before validation is wired, expect `merge_commit_with_pick_is_rejected_before_anything_moves` to fail with `expected InvalidRebasePlan, got Git("mainline branch is not specified but …")` and the `assert_untouched` HEAD assertion to fail — that is the bug reproduced.
+
+- [ ] **Step 3: Add the error variant (Rust + TS, same commit)**
+
+In `src-tauri/src/error.rs`, after the `DubiousOwnership` variant:
+
+```rust
+    /// A rebase plan the engine cannot execute — a merge commit carrying an
+    /// action that has no meaning for it, a duplicate or unknown oid, a plan
+    /// that drops everything. Raised by `rebase_plan::validate` *before*
+    /// `rebase_start` moves anything, so the repository is untouched when the
+    /// frontend shows it.
+    #[error("invalid rebase plan: {0}")]
+    InvalidRebasePlan(String),
+```
+
+In `src/lib/errors.ts`, add to the union (keep it 1:1 with the Rust enum):
+
+```ts
+  | { kind: "InvalidRebasePlan"; message: string }
+```
+
+- [ ] **Step 4: Write the validator**
+
+Create `src-tauri/src/git/rebase_plan.rs`:
+
+```rust
+//! Validation of an interactive-rebase plan against the repository it will run
+//! against. Every check here runs *before* `rebase_start` mutates anything: the
+//! engine used to discover an unexecutable step mid-replay, with earlier picks
+//! already committed and the branch tip already moved.
+
+use std::collections::HashSet;
+
+use git2::Repository;
+
+use crate::error::{AppError, AppResult};
+
+use super::types::{RebaseAction, RebaseStep};
+
+/// First seven hex characters, for messages.
+pub fn short(oid: &str) -> &str {
+    &oid[..oid.len().min(7)]
+}
+
+/// Actions that mean something for a commit with more than one parent.
+///
+/// PR1 allows only `Drop` (git's own default: merges are dropped and the branch
+/// is flattened). PR2 adds `MainlinePick`, PR3 adds `Merge`.
+pub fn merge_legal(action: RebaseAction) -> bool {
+    matches!(action, RebaseAction::Drop)
+}
+
+pub fn validate(repo: &Repository, plan: &[RebaseStep]) -> AppResult<()> {
+    if plan.is_empty() {
+        return Err(AppError::InvalidRebasePlan("the plan is empty".into()));
+    }
+
+    let mut seen: HashSet<&str> = HashSet::new();
+    for step in plan {
+        if !seen.insert(step.oid.as_str()) {
+            return Err(AppError::InvalidRebasePlan(format!(
+                "{} appears twice in the plan",
+                short(&step.oid)
+            )));
+        }
+
+        let commit = repo
+            .revparse_single(&step.oid)
+            .and_then(|o| o.peel_to_commit())
+            .map_err(|_| {
+                AppError::InvalidRebasePlan(format!("unknown commit {}", short(&step.oid)))
+            })?;
+
+        if commit.parent_count() > 1 && !merge_legal(step.action) {
+            return Err(AppError::InvalidRebasePlan(format!(
+                "{} is a merge commit — it can only be dropped, which flattens \
+                 the branch, or left out of the plan",
+                short(&step.oid)
+            )));
+        }
+    }
+
+    if !plan.iter().any(|s| s.action != RebaseAction::Drop) {
+        return Err(AppError::InvalidRebasePlan(
+            "the plan drops every commit — nothing would be replayed".into(),
+        ));
+    }
+
+    Ok(())
+}
+```
+
+Declare it in `src-tauri/src/git/mod.rs` next to the other module declarations:
+
+```rust
+pub mod rebase_plan;
+```
+
+`RebaseAction` needs `PartialEq` + `Copy` for the matches above; it already derives `PartialEq` (used as `step.action == RebaseAction::Drop` in `advance_rebase`). If `Copy` is missing, add `Copy` to its derive list in `src-tauri/src/git/types.rs`.
+
+- [ ] **Step 5: Call it first in `rebase_start`**
+
+In `src-tauri/src/git/libgit2.rs`, replace the empty-plan guard at the top of `rebase_start` (currently `if plan.is_empty() { … }` plus the `find(|s| s.action != RebaseAction::Drop)` lookup that raises `"rebase plan contains only drops"`) with a validation call, keeping the first-step lookup for the base:
+
+```rust
+    fn rebase_start(&self, repo_id: &RepoId, plan: Vec<RebaseStep>) -> AppResult<RebaseStatus> {
+        self.with_repo(repo_id, |repo| crate::git::rebase_plan::validate(repo, &plan))?;
+
+        // Validated above, so this cannot fail: a plan with at least one
+        // non-Drop step exists.
+        let first_step = plan
+            .iter()
+            .find(|s| s.action != RebaseAction::Drop)
+            .ok_or_else(|| AppError::InvalidRebasePlan("the plan drops every commit".into()))?;
+        let first_oid_str = first_step.oid.clone();
+        // … existing dirty-worktree check, orig_head capture, reset …
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase_validation
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase
+pnpm tsc --noEmit
+```
+
+Expected: all five new tests pass, all seven existing rebase tests still pass, typecheck clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/src/error.rs src-tauri/src/git/rebase_plan.rs src-tauri/src/git/mod.rs \
+        src-tauri/src/git/libgit2.rs src-tauri/tests/rebase_validation.rs \
+        src-tauri/tests/support/mod.rs src/lib/errors.ts
+git commit -m "fix(rebase): validate the plan before touching the repository
+
+Why: a merge commit in the plan surfaced libgit2's \"mainline branch is
+not specified\" error on the step that reached it, with earlier picks
+already committed and the branch tip already moved. Validation now runs
+first, so a rejected plan leaves HEAD, the branch, and the worktree
+untouched."
+```
+
+---
+
+### Task 2: Replay on a detached HEAD; move the branch only on completion
+
+**Files:**
+- Modify: `src-tauri/src/git/libgit2.rs` (`RebaseState`, `rebase_start`, `advance_rebase`, `rebase_abort`)
+- Create: `src-tauri/tests/rebase_durability.rs`
+- Modify: `src-tauri/tests/rebase.rs` (`rebase_edit_pauses_and_continue_resumes`)
+
+**Interfaces:**
+- Consumes: `rebase_plan::validate` (Task 1), `support::merge_history` (Task 1).
+- Produces: `RebaseState { plan, total, completed, pause_reason, conflict_step, orig_head, head_name: Option<String>, rewritten: HashMap<String, String> }`; `Libgit2Backend::finish_rebase(&self, repo_id) -> AppResult<()>` (moves the branch ref and reattaches HEAD).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src-tauri/tests/rebase_durability.rs`:
+
+```rust
+//! The execution model: a rebase replays on a detached HEAD and moves the
+//! branch ref exactly once, when the plan completes. Anything that fails or
+//! pauses mid-way therefore leaves the branch where it was.
+
+mod support;
+
+use platypusgit_lib::git::{
+    types::{RebaseAction, RebaseStep},
+    GitBackend,
+};
+
+use support::{linear_history, TempRepo};
+
+fn step(oid: &str, action: RebaseAction) -> RebaseStep {
+    RebaseStep { oid: oid.to_string(), action, message: None }
+}
+
+fn branch_tip(tr: &TempRepo, name: &str) -> String {
+    tr.repo
+        .find_reference(&format!("refs/heads/{name}"))
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .id()
+        .to_string()
+}
+
+#[test]
+fn paused_rebase_detaches_head_and_leaves_the_branch_alone() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 3);
+    let tip_before = branch_tip(&tr, "main");
+
+    let (backend, handle) = tr.open_with_backend();
+    let plan = vec![
+        step(&oids[0], RebaseAction::Pick),
+        step(&oids[1], RebaseAction::Edit), // pauses here
+        step(&oids[2], RebaseAction::Pick),
+    ];
+
+    let status = backend.rebase_start(&handle.id, plan).unwrap();
+    assert!(status.in_progress, "edit should pause the rebase");
+    assert_eq!(status.pause_reason.as_deref(), Some("edit"));
+
+    assert!(
+        tr.repo.head_detached().unwrap(),
+        "HEAD must be detached while a rebase is replaying"
+    );
+    assert_eq!(
+        branch_tip(&tr, "main"),
+        tip_before,
+        "the branch ref must not move until the plan completes"
+    );
+
+    let done = backend.rebase_continue(&handle.id).unwrap();
+    assert!(!done.in_progress, "rebase should finish after continue");
+    assert!(
+        !tr.repo.head_detached().unwrap(),
+        "HEAD must be back on the branch when the plan completes"
+    );
+    assert_eq!(
+        tr.repo.head().unwrap().name().unwrap(),
+        "refs/heads/main",
+        "HEAD should be reattached to the original branch"
+    );
+    let tip_after = branch_tip(&tr, "main");
+    assert_ne!(tip_after, tip_before, "the branch should point at the replay");
+    assert_eq!(
+        tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),
+        tip_after,
+        "HEAD and the branch must agree once the rebase is done"
+    );
+}
+
+#[test]
+fn abort_mid_rebase_restores_the_branch_and_reattaches_head() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 3);
+    let tip_before = branch_tip(&tr, "main");
+
+    let (backend, handle) = tr.open_with_backend();
+    let plan = vec![
+        step(&oids[0], RebaseAction::Pick),
+        step(&oids[1], RebaseAction::Edit),
+        step(&oids[2], RebaseAction::Pick),
+    ];
+    backend.rebase_start(&handle.id, plan).unwrap();
+
+    backend.rebase_abort(&handle.id).unwrap();
+
+    assert!(!tr.repo.head_detached().unwrap(), "abort must reattach HEAD");
+    assert_eq!(tr.repo.head().unwrap().name().unwrap(), "refs/heads/main");
+    assert_eq!(branch_tip(&tr, "main"), tip_before);
+    assert_eq!(
+        tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),
+        tip_before
+    );
+    assert!(tr.repo.statuses(None).unwrap().is_empty(), "worktree left dirty");
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase_durability
+```
+
+Expected: `paused_rebase_detaches_head_and_leaves_the_branch_alone` fails at the `head_detached` assertion — today the engine commits straight to the attached branch, so HEAD is attached and the branch tip has already moved.
+
+- [ ] **Step 3: Extend `RebaseState`**
+
+In `src-tauri/src/git/libgit2.rs`, add two fields to `RebaseState` (keep the existing doc comments):
+
+```rust
+    /// Full ref name of the branch HEAD pointed at when the rebase started
+    /// (`refs/heads/…`), or `None` when it started from a detached HEAD. The
+    /// replay runs detached; this ref is moved exactly once, when the plan
+    /// completes.
+    pub head_name: Option<String>,
+    /// Original oid → rewritten oid for every step that has run. A dropped or
+    /// skipped step maps to the HEAD it left behind, so a later step that has
+    /// to sit on top of it still resolves to a real commit.
+    pub rewritten: HashMap<String, String>,
+```
+
+- [ ] **Step 4: Detach in `rebase_start`**
+
+Replace the reset at the end of `rebase_start`'s `with_repo` closure so it records the branch and detaches instead of moving the branch:
+
+```rust
+        let (orig_head, head_name) = self.with_repo(repo_id, |repo| {
+            // … existing dirty-worktree check, unchanged …
+
+            let head_ref = repo.head()?;
+            let head_name = if repo.head_detached()? {
+                None
+            } else {
+                head_ref.name().map(|s| s.to_string())
+            };
+            let orig_head = head_ref.peel_to_commit()?.id().to_string();
+
+            let first_commit = repo
+                .revparse_single(&first_oid_str)
+                .map_err(|_| AppError::InvalidRef(first_oid_str.clone()))?
+                .peel_to_commit()?;
+            let parent = first_commit.parent(0).map_err(|_| {
+                AppError::InvalidRebasePlan(format!(
+                    "{} has no parent to rebase onto",
+                    crate::git::rebase_plan::short(&first_oid_str)
+                ))
+            })?;
+
+            // Detach first, then hard-reset: with HEAD attached, the reset
+            // would drag the branch ref along, which is exactly what must not
+            // happen until the plan completes.
+            repo.set_head_detached(parent.id())?;
+            repo.reset(parent.as_object(), git2::ResetType::Hard, None)?;
+            Ok((orig_head, head_name))
+        })?;
+```
+
+Insert both into the `RebaseState` literal: `head_name`, `rewritten: HashMap::new()`.
+
+- [ ] **Step 5: Reattach when the plan is exhausted**
+
+Add a helper next to `bump_completed` in the `impl Libgit2Backend` block:
+
+```rust
+    /// Point the original branch at the replayed history and reattach HEAD to
+    /// it. Called once, when the plan is exhausted. A rebase that started from
+    /// a detached HEAD just stays detached.
+    fn finish_rebase(&self, repo_id: &RepoId) -> AppResult<()> {
+        let head_name = {
+            let rebases = self
+                .rebases
+                .lock()
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+            rebases.get(repo_id).and_then(|s| s.head_name.clone())
+        };
+        let Some(head_name) = head_name else { return Ok(()) };
+
+        self.with_repo(repo_id, |repo| {
+            let tip = repo.head()?.peel_to_commit()?.id();
+            repo.reference(&head_name, tip, true, "rebase (finish)")?;
+            repo.set_head(&head_name)?;
+            Ok(())
+        })
+    }
+```
+
+In `advance_rebase`, call it in the plan-exhausted arm, before the status snapshot:
+
+```rust
+            let Some(step) = step else {
+                // Plan exhausted — move the branch to the replayed history and
+                // reattach HEAD before reporting, so the caller's refresh sees
+                // the finished state.
+                self.finish_rebase(repo_id)?;
+                let status = self.rebase_status(repo_id)?;
+                // … existing state removal, unchanged …
+```
+
+Also record each step's result: after `self.finish_pick(repo_id, &step.oid)?` and in the `Drop` early-continue path, insert the mapping. Add a second helper beside `bump_completed`:
+
+```rust
+    fn record_rewritten(&self, repo_id: &RepoId, old: &str) -> AppResult<()> {
+        let new = self.with_repo(repo_id, |repo| {
+            Ok(repo.head()?.peel_to_commit()?.id().to_string())
+        })?;
+        let mut rebases = self
+            .rebases
+            .lock()
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        if let Some(state) = rebases.get_mut(repo_id) {
+            state.rewritten.insert(old.to_string(), new);
+        }
+        Ok(())
+    }
+```
+
+Call `self.record_rewritten(repo_id, &step.oid)?;` immediately after the `Drop` fast-path's `bump_completed` and immediately after `finish_pick` in the main path. (PR3 is what reads the map; recording it here keeps the two changes independent.)
+
+- [ ] **Step 6: Reattach in `rebase_abort`**
+
+Replace `rebase_abort`'s body after the state removal:
+
+```rust
+        let removed = {
+            let mut rebases = self
+                .rebases
+                .lock()
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+            rebases.remove(repo_id)
+        };
+        let orig_head = removed.as_ref().map(|s| s.orig_head.clone());
+        let head_name = removed.and_then(|s| s.head_name);
+
+        self.with_repo(repo_id, |repo| {
+            repo.cleanup_state()?;
+            // The branch never moved (the replay ran detached), so abort is
+            // "put HEAD back on the branch and drop the replay".
+            match (&head_name, &orig_head) {
+                (Some(name), _) => {
+                    repo.set_head(name)?;
+                    let target = repo.head()?.peel_to_commit()?;
+                    repo.reset(target.as_object(), git2::ResetType::Hard, None)?;
+                }
+                (None, Some(oid)) => {
+                    let target = repo.revparse_single(oid)?.peel_to_commit()?;
+                    repo.set_head_detached(target.id())?;
+                    repo.reset(target.as_object(), git2::ResetType::Hard, None)?;
+                }
+                (None, None) => {
+                    let target = repo.head()?.peel_to_commit()?;
+                    repo.reset(target.as_object(), git2::ResetType::Hard, None)?;
+                }
+            }
+            Ok(())
+        })
+```
+
+- [ ] **Step 7: Run the tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase_durability
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase_validation
+```
+
+Expected: both new tests pass; the seven existing rebase tests and the five validation tests still pass. If `rebase_abort_resets_to_pre_rebase_head` or `abort_operation_clears_rebase_state_and_restores_pre_rebase_head` fails, the assertion to check is whether it inspects `HEAD` while expecting an attached branch — the branch is now the authority, and both should still hold.
+
+- [ ] **Step 8: Pin the model in the existing edit test**
+
+In `src-tauri/tests/rebase.rs`, inside `rebase_edit_pauses_and_continue_resumes`, after the pause is asserted, add:
+
+```rust
+    assert!(
+        tr.repo.head_detached().unwrap(),
+        "the replay must run on a detached HEAD"
+    );
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src-tauri/src/git/libgit2.rs src-tauri/tests/rebase_durability.rs src-tauri/tests/rebase.rs
+git commit -m "fix(rebase): replay on a detached HEAD, move the branch on completion
+
+Why: the engine committed straight to the attached branch, so a failure
+or pause left the branch pointing mid-replay and abort had to guess its
+way back. The branch ref is now a single move at the end, which is also
+what makes replaying a side branch possible at all."
+```
+
+---
+
+### Task 3: Mirror the rebase to disk so Abort survives a restart
+
+**Files:**
+- Create: `src-tauri/src/git/rebase_state.rs`
+- Modify: `src-tauri/src/git/mod.rs`
+- Modify: `src-tauri/src/git/libgit2.rs` (`rebase_start`, `advance_rebase`, `mark_paused`, `rebase_abort`, `rebase_status`, `repo_state`)
+- Modify: `src-tauri/tests/rebase_durability.rs`
+
+**Interfaces:**
+- Consumes: `RebaseState` fields from Task 2.
+- Produces: `rebase_state::PersistedRebase`, `rebase_state::PersistedCurrent`, `rebase_state::path(repo) -> PathBuf`, `rebase_state::save(repo, &PersistedRebase) -> AppResult<()>`, `rebase_state::load(repo) -> AppResult<Option<PersistedRebase>>`, `rebase_state::clear(repo) -> AppResult<()>`, `rebase_state::write_orig_head(repo, oid) -> AppResult<()>`; `Libgit2Backend::persist_rebase(&self, repo_id) -> AppResult<()>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src-tauri/tests/rebase_durability.rs`:
+
+```rust
+use platypusgit_lib::git::{libgit2::Libgit2Backend, types::RepoState};
+
+#[test]
+fn a_paused_rebase_is_visible_on_disk_and_reports_as_a_rebase() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 3);
+
+    let (backend, handle) = tr.open_with_backend();
+    let plan = vec![
+        step(&oids[0], RebaseAction::Pick),
+        step(&oids[1], RebaseAction::Edit),
+        step(&oids[2], RebaseAction::Pick),
+    ];
+    backend.rebase_start(&handle.id, plan).unwrap();
+
+    let state_file = tr.path().join(".git").join("platypusgit-rebase.json");
+    assert!(state_file.exists(), "a paused rebase must be recorded on disk");
+    assert!(
+        tr.path().join(".git").join("ORIG_HEAD").exists(),
+        "ORIG_HEAD is the CLI escape hatch and must be written"
+    );
+    assert_eq!(
+        backend.repo_state(&handle.id).unwrap(),
+        RepoState::RebaseInteractive,
+        "a paused rebase must report as a rebase, not as Clean or CherryPick"
+    );
+
+    backend.rebase_continue(&handle.id).unwrap();
+    assert!(
+        !state_file.exists(),
+        "the state file must be swept when the plan completes"
+    );
+    assert_eq!(backend.repo_state(&handle.id).unwrap(), RepoState::Clean);
+}
+
+#[test]
+fn a_restarted_app_can_still_abort() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 3);
+    let tip_before = branch_tip(&tr, "main");
+
+    {
+        let (backend, handle) = tr.open_with_backend();
+        let plan = vec![
+            step(&oids[0], RebaseAction::Pick),
+            step(&oids[1], RebaseAction::Edit),
+            step(&oids[2], RebaseAction::Pick),
+        ];
+        backend.rebase_start(&handle.id, plan).unwrap();
+    } // backend dropped — every trace of the in-memory RebaseState is gone
+
+    // A fresh backend is what the app has after a restart.
+    let backend = Libgit2Backend::new();
+    let handle = backend.open(tr.path()).unwrap();
+
+    let status = backend.rebase_status(&handle.id).unwrap();
+    assert!(
+        status.in_progress,
+        "the rebase must still be reported as in progress after a restart"
+    );
+    assert_eq!(status.total, 3);
+    assert_eq!(status.next_index, 1, "one step had completed before the pause");
+
+    backend.rebase_abort(&handle.id).unwrap();
+    assert_eq!(branch_tip(&tr, "main"), tip_before);
+    assert!(!tr.repo.head_detached().unwrap());
+    assert!(!tr.path().join(".git").join("platypusgit-rebase.json").exists());
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase_durability
+```
+
+Expected: `a_paused_rebase_is_visible_on_disk_and_reports_as_a_rebase` fails on the missing state file; `a_restarted_app_can_still_abort` fails because `rebase_status` on a fresh backend reports `in_progress: false`.
+
+- [ ] **Step 3: Write the state module**
+
+Create `src-tauri/src/git/rebase_state.rs`:
+
+```rust
+//! The on-disk mirror of an in-progress interactive rebase.
+//!
+//! The engine's `RebaseState` lives in a `HashMap` inside `Libgit2Backend`, so
+//! before this existed, closing the app during a rebase left a detached HEAD
+//! part-way through a replay with no way back but the reflog. This module keeps
+//! a JSON mirror in the gitdir and writes `ORIG_HEAD` the way git does, so both
+//! the app and the `git` CLI can recover.
+//!
+//! Deliberately NOT git's own `.git/rebase-merge/` directory: a
+//! half-compatible one would make `git status` and `git rebase --continue`
+//! claim authority over a rebase they cannot drive.
+
+use std::{collections::BTreeMap, path::PathBuf};
+
+use git2::Repository;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{AppError, AppResult};
+
+use super::types::RebaseStep;
+
+pub const FILE_NAME: &str = "platypusgit-rebase.json";
+pub const VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistedCurrent {
+    pub step: RebaseStep,
+    /// "conflict" | "edit" — mirrors `RebaseStatus.pause_reason`.
+    pub phase: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistedRebase {
+    pub version: u32,
+    /// Branch to move when the plan completes; `None` when the rebase started
+    /// from a detached HEAD.
+    pub head_name: Option<String>,
+    pub orig_head: String,
+    pub onto: String,
+    pub total: usize,
+    pub completed: usize,
+    pub remaining: Vec<RebaseStep>,
+    /// Why the rebase is paused — "conflict" | "edit" | absent. Persisted
+    /// separately from `current` because an edit pause has no held-back step:
+    /// its commit already landed.
+    pub pause_reason: Option<String>,
+    /// The step whose apply conflicted and is awaiting resolution, if any.
+    pub current: Option<PersistedCurrent>,
+    pub rewritten: BTreeMap<String, String>,
+}
+
+pub fn path(repo: &Repository) -> PathBuf {
+    repo.path().join(FILE_NAME)
+}
+
+/// Write via temp file + rename so a crash mid-write cannot leave a truncated
+/// state file that would read as "no rebase in progress".
+pub fn save(repo: &Repository, state: &PersistedRebase) -> AppResult<()> {
+    let target = path(repo);
+    let tmp = target.with_extension("json.tmp");
+    let json = serde_json::to_vec_pretty(state)
+        .map_err(|e| AppError::Internal(format!("serialising rebase state: {e}")))?;
+    std::fs::write(&tmp, json)?;
+    std::fs::rename(&tmp, &target)?;
+    Ok(())
+}
+
+/// `Ok(None)` when there is no file. A file we cannot parse is an error, not a
+/// silent "no rebase": guessing here is how a half-replayed branch would lose
+/// its way back.
+pub fn load(repo: &Repository) -> AppResult<Option<PersistedRebase>> {
+    let target = path(repo);
+    match std::fs::read(&target) {
+        Ok(bytes) => {
+            let state: PersistedRebase = serde_json::from_slice(&bytes).map_err(|e| {
+                AppError::Internal(format!("unreadable rebase state in {FILE_NAME}: {e}"))
+            })?;
+            if state.version != VERSION {
+                return Err(AppError::Internal(format!(
+                    "{FILE_NAME} was written by another version ({}), refusing to guess",
+                    state.version
+                )));
+            }
+            Ok(Some(state))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+pub fn clear(repo: &Repository) -> AppResult<()> {
+    match std::fs::remove_file(path(repo)) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// `ORIG_HEAD`, written the way git writes it before a history-rewriting
+/// operation, so `git reset --hard ORIG_HEAD` works from the CLI.
+pub fn write_orig_head(repo: &Repository, oid: &str) -> AppResult<()> {
+    let target = repo.path().join("ORIG_HEAD");
+    std::fs::write(target, format!("{oid}\n"))?;
+    Ok(())
+}
+```
+
+Declare it in `src-tauri/src/git/mod.rs`:
+
+```rust
+pub mod rebase_state;
+```
+
+- [ ] **Step 4: Persist from the engine**
+
+Add a helper next to `record_rewritten` in `src-tauri/src/git/libgit2.rs`:
+
+```rust
+    /// Mirror the in-memory rebase to the gitdir. Called after every state
+    /// transition; a missing in-memory entry means the rebase is over, so the
+    /// file goes away.
+    fn persist_rebase(&self, repo_id: &RepoId) -> AppResult<()> {
+        let snapshot = {
+            let rebases = self
+                .rebases
+                .lock()
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+            rebases.get(repo_id).map(|s| crate::git::rebase_state::PersistedRebase {
+                version: crate::git::rebase_state::VERSION,
+                head_name: s.head_name.clone(),
+                orig_head: s.orig_head.clone(),
+                onto: s.onto.clone(),
+                total: s.total,
+                completed: s.completed,
+                remaining: s.plan.iter().cloned().collect(),
+                pause_reason: s.pause_reason.clone(),
+                current: s.conflict_step.clone().map(|step| {
+                    crate::git::rebase_state::PersistedCurrent {
+                        step,
+                        phase: s.pause_reason.clone().unwrap_or_else(|| "conflict".into()),
+                    }
+                }),
+                rewritten: s.rewritten.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+            })
+        };
+
+        self.with_repo(repo_id, |repo| match &snapshot {
+            Some(state) => crate::git::rebase_state::save(repo, state),
+            None => crate::git::rebase_state::clear(repo),
+        })
+    }
+```
+
+`RebaseState` needs an `onto: String` field (the base the replay started from) for the snapshot — add it beside `orig_head`, set it in `rebase_start` to `parent.id().to_string()`, and note in its doc comment that it is what a resumed session resets to. `RebaseStep` must derive `Clone` (it already does) and `Deserialize` (it already does).
+
+Call `self.persist_rebase(repo_id)?;`:
+- at the end of `rebase_start`, right after the `rebases.insert(…)` and `drop(rebases)`, **before** `advance_rebase`;
+- at the end of `mark_paused`, before it returns the status;
+- in `advance_rebase` after each `bump_completed`;
+- in the plan-exhausted arm after the in-memory entry is removed (which clears the file).
+
+In `rebase_start`, also write `ORIG_HEAD` inside the same `with_repo` closure that captures `orig_head`:
+
+```rust
+            crate::git::rebase_state::write_orig_head(repo, &orig_head)?;
+```
+
+In `rebase_abort`, clear the file inside the existing `with_repo` closure:
+
+```rust
+            crate::git::rebase_state::clear(repo)?;
+```
+
+- [ ] **Step 5: Read the file back in `rebase_status` and `repo_state`**
+
+Replace `rebase_status`'s `None` arm so it falls back to disk:
+
+```rust
+    fn rebase_status(&self, repo_id: &RepoId) -> AppResult<RebaseStatus> {
+        let in_memory = {
+            let rebases = self
+                .rebases
+                .lock()
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+            rebases.get(repo_id).map(|state| RebaseStatus {
+                in_progress: state.completed < state.total || state.pause_reason.is_some(),
+                next_index: state.completed,
+                total: state.total,
+                pause_reason: state.pause_reason.clone(),
+            })
+        };
+        if let Some(status) = in_memory {
+            return Ok(status);
+        }
+
+        // No in-memory entry: either there is no rebase, or this process did
+        // not start it (the app was restarted mid-rebase). The state file is
+        // the authority in that case.
+        self.with_repo(repo_id, |repo| {
+            Ok(match crate::git::rebase_state::load(repo)? {
+                Some(state) => RebaseStatus {
+                    in_progress: true,
+                    next_index: state.completed,
+                    total: state.total,
+                    pause_reason: state.pause_reason,
+                },
+                None => RebaseStatus {
+                    in_progress: false,
+                    next_index: 0,
+                    total: 0,
+                    pause_reason: None,
+                },
+            })
+        })
+    }
+```
+
+And give the state file precedence in `repo_state`, so a paused pick reports as a rebase rather than as `CherryPick` (which is what libgit2 sees, because the pause leaves `CHERRY_PICK_HEAD` behind):
+
+```rust
+    fn repo_state(&self, repo_id: &RepoId) -> AppResult<RepoState> {
+        self.with_repo(repo_id, |repo| {
+            // Our own rebase wins: libgit2 only sees the CHERRY_PICK_HEAD /
+            // MERGE_HEAD a paused step leaves behind, which would report the
+            // step's mechanism instead of the operation the user started.
+            if crate::git::rebase_state::load(repo)?.is_some() {
+                return Ok(RepoState::RebaseInteractive);
+            }
+            use git2::RepositoryState as RS;
+            // … existing match, unchanged …
+        })
+    }
+```
+
+`RepoState` needs `PartialEq` for the test's `assert_eq!`; add it to the derive list in `src-tauri/src/git/types.rs` if missing (it is a plain C-like enum, so `#[derive(Debug, Clone, Copy, PartialEq, Serialize)]`).
+
+- [ ] **Step 6: Rehydrate, so a restarted app can continue as well as abort**
+
+Add a helper beside `persist_rebase` that rebuilds the in-memory state from the file:
+
+```rust
+    /// Rebuild the in-memory rebase from the state file. Used when this process
+    /// did not start the rebase — the app was restarted mid-operation — so that
+    /// Continue and Abort work the same as they would have in the original
+    /// session. Returns false when there is no rebase on disk.
+    fn rehydrate_rebase(&self, repo_id: &RepoId) -> AppResult<bool> {
+        let Some(p) = self.with_repo(repo_id, crate::git::rebase_state::load)? else {
+            return Ok(false);
+        };
+        let mut rebases = self
+            .rebases
+            .lock()
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        rebases.insert(
+            repo_id.clone(),
+            RebaseState {
+                plan: p.remaining.into_iter().collect(),
+                total: p.total,
+                completed: p.completed,
+                pause_reason: p.pause_reason,
+                conflict_step: p.current.map(|c| c.step),
+                orig_head: p.orig_head,
+                onto: p.onto,
+                head_name: p.head_name,
+                rewritten: p.rewritten.into_iter().collect(),
+            },
+        );
+        Ok(true)
+    }
+```
+
+At the top of `rebase_continue`, before the unresolved-conflict check:
+
+```rust
+        // A rebase started by an earlier session has no in-memory entry; its
+        // plan, progress, and rewritten map are all on disk.
+        let known = {
+            let rebases = self
+                .rebases
+                .lock()
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+            rebases.contains_key(repo_id)
+        };
+        if !known && !self.rehydrate_rebase(repo_id)? {
+            return Err(AppError::InvalidRef("no rebase in progress".into()));
+        }
+```
+
+`rebase_abort` also tolerates a missing entry; make it read the file so a restarted app aborts correctly:
+
+```rust
+    fn rebase_abort(&self, repo_id: &RepoId) -> AppResult<()> {
+        let removed = {
+            let mut rebases = self
+                .rebases
+                .lock()
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+            rebases.remove(repo_id)
+        };
+
+        let (orig_head, head_name) = match removed {
+            Some(s) => (Some(s.orig_head), s.head_name),
+            None => {
+                // Restarted mid-rebase: the file is all we have.
+                let persisted = self.with_repo(repo_id, crate::git::rebase_state::load)?;
+                match persisted {
+                    Some(p) => (Some(p.orig_head), p.head_name),
+                    None => (None, None),
+                }
+            }
+        };
+        // … existing reattach/reset body from Task 2, plus rebase_state::clear …
+```
+
+Then extend the restart test in `src-tauri/tests/rebase_durability.rs` so continuing after a restart is covered too — add this test below `a_restarted_app_can_still_abort`:
+
+```rust
+#[test]
+fn a_restarted_app_can_still_continue() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 3);
+
+    {
+        let (backend, handle) = tr.open_with_backend();
+        backend
+            .rebase_start(
+                &handle.id,
+                vec![
+                    step(&oids[0], RebaseAction::Pick),
+                    step(&oids[1], RebaseAction::Edit),
+                    step(&oids[2], RebaseAction::Pick),
+                ],
+            )
+            .unwrap();
+    } // restart
+
+    let backend = Libgit2Backend::new();
+    let handle = backend.open(tr.path()).unwrap();
+
+    let done = backend.rebase_continue(&handle.id).unwrap();
+    assert!(!done.in_progress, "the rehydrated plan should run to completion");
+    assert_eq!(done.total, 3);
+    assert!(!tr.repo.head_detached().unwrap(), "HEAD reattached on completion");
+    let summaries: Vec<String> = backend
+        .log(&handle.id, None, 10)
+        .unwrap()
+        .into_iter()
+        .map(|c| c.summary)
+        .collect();
+    assert_eq!(summaries[0], "commit 2", "the last step must have been replayed");
+}
+```
+
+- [ ] **Step 7: Run the tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase_durability
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase_validation
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+Expected: everything passes, including the full backend suite (`conflict.rs` and any other test that asserts `repo_state` — the new precedence only applies when our state file exists).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src-tauri/src/git/rebase_state.rs src-tauri/src/git/mod.rs src-tauri/src/git/libgit2.rs \
+        src-tauri/src/git/types.rs src-tauri/tests/rebase_durability.rs
+git commit -m "feat(rebase): mirror an in-progress rebase to the gitdir
+
+Why: abort-ability lived only in Libgit2Backend's HashMap, and
+repo_state reported Clean, so closing the app mid-rebase left a detached
+replay with no route back but the reflog. State now lives in
+.git/platypusgit-rebase.json with ORIG_HEAD alongside it, so a restarted
+app still reports the rebase and can abort it."
+```
+
+---
+
+### Task 4: One engine behind both Continue and Abort
+
+**Files:**
+- Modify: `src-tauri/src/git/libgit2.rs` (`continue_operation`, `abort_operation`)
+- Modify: `src-tauri/tests/rebase_durability.rs`
+
+**Interfaces:**
+- Consumes: `rebase_state::load` (Task 3), `rebase_continue` / `rebase_abort` (Tasks 2–3).
+- Produces: no new API — behaviour change only.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src-tauri/tests/rebase_durability.rs`:
+
+```rust
+use platypusgit_lib::git::types::ResetMode;
+use support::fs::write_file;
+use std::path::PathBuf;
+
+/// main and a rewritten history both touch `shared.txt`, so replaying the
+/// second commit conflicts.
+fn conflicting_plan_repo() -> (TempRepo, Vec<String>) {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let mut oids = Vec::new();
+    for (body, msg) in [("one\n", "first"), ("two\n", "second")] {
+        write_file(tr.path(), "shared.txt", body);
+        oids.push(tr.commit_all(msg).to_string());
+    }
+    (tr, oids)
+}
+
+#[test]
+fn continue_operation_during_a_rebase_advances_the_plan() {
+    let (tr, oids) = conflicting_plan_repo();
+    let (backend, handle) = tr.open_with_backend();
+
+    // Rewrite the first commit's content so replaying the second conflicts.
+    let plan = vec![
+        step(&oids[0], RebaseAction::Edit),
+        step(&oids[1], RebaseAction::Pick),
+    ];
+    let status = backend.rebase_start(&handle.id, plan).unwrap();
+    assert_eq!(status.pause_reason.as_deref(), Some("edit"));
+    write_file(tr.path(), "shared.txt", "diverged\n");
+    backend.stage(&handle.id, &[PathBuf::from("shared.txt")]).unwrap();
+
+    let status = backend.rebase_continue(&handle.id).unwrap();
+    assert_eq!(
+        status.pause_reason.as_deref(),
+        Some("conflict"),
+        "replaying the second commit should conflict"
+    );
+
+    // The user resolves in the Conflict screen and presses its Continue, which
+    // calls continue_operation — not rebase_continue.
+    write_file(tr.path(), "shared.txt", "resolved\n");
+    backend.stage(&handle.id, &[PathBuf::from("shared.txt")]).unwrap();
+    backend.continue_operation(&handle.id).unwrap();
+
+    let status = backend.rebase_status(&handle.id).unwrap();
+    assert!(
+        !status.in_progress,
+        "the Conflict screen's Continue must advance the plan, not just commit"
+    );
+    assert!(!tr.repo.head_detached().unwrap(), "HEAD should be reattached");
+    assert!(
+        !tr.path().join(".git").join("platypusgit-rebase.json").exists(),
+        "a completed rebase must leave no state file behind"
+    );
+    let _ = ResetMode::Hard; // keep the import honest if the helper is unused
+}
+
+#[test]
+fn abort_operation_during_a_rebase_restores_the_branch() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 3);
+    let tip_before = branch_tip(&tr, "main");
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .rebase_start(
+            &handle.id,
+            vec![
+                step(&oids[0], RebaseAction::Pick),
+                step(&oids[1], RebaseAction::Edit),
+                step(&oids[2], RebaseAction::Pick),
+            ],
+        )
+        .unwrap();
+
+    backend.abort_operation(&handle.id).unwrap();
+
+    assert_eq!(branch_tip(&tr, "main"), tip_before);
+    assert!(!tr.repo.head_detached().unwrap());
+    assert!(!backend.rebase_status(&handle.id).unwrap().in_progress);
+    assert!(!tr.path().join(".git").join("platypusgit-rebase.json").exists());
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase_durability
+```
+
+Expected: `continue_operation_during_a_rebase_advances_the_plan` fails — `continue_operation` commits the resolved tree and calls `cleanup_state`, leaving the rebase in progress with its conflict step still stashed.
+
+- [ ] **Step 3: Delegate**
+
+At the top of `continue_operation` in `src-tauri/src/git/libgit2.rs`:
+
+```rust
+    fn continue_operation(&self, repo_id: &RepoId) -> AppResult<String> {
+        // The Conflict screen and the palette both land here. When the paused
+        // operation is one of our rebases, committing the tree in isolation
+        // would advance nothing and strand the rest of the plan — so hand it to
+        // the engine that owns the plan.
+        let rebasing = {
+            let rebases = self
+                .rebases
+                .lock()
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+            rebases.contains_key(repo_id)
+        } || self.with_repo(repo_id, crate::git::rebase_state::load)?.is_some();
+
+        if rebasing {
+            self.rebase_continue(repo_id)?;
+            return self.with_repo(repo_id, |repo| {
+                Ok(repo.head()?.peel_to_commit()?.id().to_string())
+            });
+        }
+        // … existing body, unchanged …
+```
+
+And at the top of `abort_operation`, replacing its in-memory-only special case:
+
+```rust
+    fn abort_operation(&self, repo_id: &RepoId) -> AppResult<()> {
+        let rebasing = {
+            let rebases = self
+                .rebases
+                .lock()
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+            rebases.contains_key(repo_id)
+        } || self.with_repo(repo_id, crate::git::rebase_state::load)?.is_some();
+
+        if rebasing {
+            // rebase_abort restores the branch and sweeps the state file; doing
+            // it here as a plain hard reset would leave both to guesswork.
+            return self.rebase_abort(repo_id);
+        }
+        // … existing body: cleanup_state + hard reset to HEAD …
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+Expected: the whole backend suite passes, including `abort_operation_clears_rebase_state_and_restores_pre_rebase_head` in `rebase.rs`, which now exercises the delegation path.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src-tauri/src/git/libgit2.rs src-tauri/tests/rebase_durability.rs
+git commit -m "fix(rebase): route the Conflict screen's Continue through the engine
+
+Why: continue_operation committed the resolved tree and cleaned up state
+without advancing the plan, so resolving a paused pick from the Conflict
+screen instead of the Rebase banner silently stranded the rest of the
+rebase. Both entry points now drive one engine."
+```
+
+---
+
+### Task 5: Derive the base from the commit's parent, not the next log row
+
+**Files:**
+- Modify: `src/features/commits/planCommitSelection.ts`
+- Create: `src/features/commits/planCommitSelection.merge.test.ts`
+- Modify: `src/design/context-menu.tsx` (`commitMenuItems`)
+
+**Interfaces:**
+- Produces: `planCommitSelection` with `baseOid` = oldest selected commit's `parents[0]` and `contiguous` = "the selection is a first-parent chain"; `commitMenuItems` reads its base through `planCommitSelection(commits, [sha])`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/commits/planCommitSelection.merge.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { planCommitSelection } from "./planCommitSelection";
+import type { CommitInfo } from "@/lib/types";
+
+/**
+ * Newest-first log of
+ *
+ *   root ── A ──── C ── M   (main)
+ *            \        /
+ *             ─── F ──      (feature)
+ *
+ * The row after `C` is `F` — a side-branch commit, not C's parent. That is the
+ * shape the positional `commits[max + 1]` base guess got wrong.
+ */
+function graphLog(): CommitInfo[] {
+  const mk = (oid: string, summary: string, parents: string[]): CommitInfo => ({
+    oid,
+    shortOid: oid.slice(0, 7),
+    summary,
+    body: null,
+    author: "Test",
+    email: "t@e.com",
+    timestamp: 0,
+    parents,
+    refs: [],
+  });
+  return [
+    mk("m".repeat(40), "Merge branch 'feature'", ["c".repeat(40), "f".repeat(40)]),
+    mk("c".repeat(40), "C on main", ["a".repeat(40)]),
+    mk("f".repeat(40), "F on feature", ["a".repeat(40)]),
+    mk("a".repeat(40), "A on main", ["r".repeat(40)]),
+    mk("r".repeat(40), "root", []),
+  ];
+}
+
+describe("planCommitSelection on non-linear history", () => {
+  it("takes the base from the commit's first parent, not the next log row", () => {
+    const plan = planCommitSelection(graphLog(), ["c".repeat(40)]);
+    expect(plan?.baseOid).toBe("a".repeat(40));
+  });
+
+  it("reports a merge commit's base as its mainline parent", () => {
+    const plan = planCommitSelection(graphLog(), ["m".repeat(40)]);
+    expect(plan?.baseOid).toBe("c".repeat(40));
+    expect(plan?.hasMerge).toBe(true);
+  });
+
+  it("null base for a root commit", () => {
+    const plan = planCommitSelection(graphLog(), ["r".repeat(40)]);
+    expect(plan?.baseOid).toBeNull();
+  });
+
+  it("adjacent log rows on different branches are not contiguous", () => {
+    // C and F sit next to each other in the log but neither is the other's
+    // parent, so they do not form a squashable run.
+    const plan = planCommitSelection(graphLog(), ["c".repeat(40), "f".repeat(40)]);
+    expect(plan?.contiguous).toBe(false);
+  });
+
+  it("a real first-parent chain is contiguous", () => {
+    const plan = planCommitSelection(graphLog(), ["c".repeat(40), "a".repeat(40)]);
+    expect(plan?.contiguous).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/features/commits/planCommitSelection.merge.test.ts
+```
+
+Expected: the base tests fail (`baseOid` is `"fff…"` — the next log row) and `adjacent log rows on different branches are not contiguous` fails (positional adjacency reports `true`).
+
+- [ ] **Step 3: Fix the derivation**
+
+In `src/features/commits/planCommitSelection.ts`, replace the `baseOid` and `contiguous` computation in the returned object:
+
+```ts
+  const oldest = commits[max];
+
+  // The base is the oldest selected commit's FIRST PARENT, looked up by oid.
+  // It used to be `commits[max + 1]` — the next row in a graph-ordered log,
+  // which on any non-linear history is frequently a side-branch commit rather
+  // than a parent, so the rebase reset to the wrong place and silently dropped
+  // whatever sat between.
+  const baseOid = oldest.parents[0] ?? null;
+
+  // Contiguity means "these commits form an unbroken first-parent chain",
+  // which is what a range squash replays. Adjacent log rows are not enough:
+  // C and F can be neighbours while belonging to different branches.
+  const oldestFirst = indices
+    .slice()
+    .sort((a, b) => b - a)
+    .map((i) => commits[i]);
+  const contiguous = oldestFirst.every((c, i) => {
+    if (i === 0) return true;
+    return oldestFirst[i].parents[0] === oldestFirst[i - 1].oid;
+  });
+
+  return {
+    oids,
+    oldestOid: oldest.oid,
+    newestOid: commits[min].oid,
+    baseOid,
+    contiguous,
+    hasMerge: indices.some((i) => commits[i].parents.length > 1),
+  };
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/features/commits/planCommitSelection
+```
+
+Expected: the new file passes and the existing `planCommitSelection` tests still pass. If an existing test asserted a positional base on a linear log, it keeps passing — on a linear log the next row *is* the first parent.
+
+- [ ] **Step 5: Route the single-commit entry points through it**
+
+In `src/design/context-menu.tsx`, `commitMenuItems` currently computes `const base = commits[idx + 1]?.oid` three times. Replace each with the shared derivation, and make the merge cases explicit. At the top of `commitMenuItems`, after `const commits = …` is available inside the handlers, add a helper above the returned array:
+
+```tsx
+  const commits = useRepoStore.getState().commits;
+  const self = commit?.sha ? commits.find((c) => c.oid === commit.sha) ?? null : null;
+  const isMerge = (self?.parents.length ?? 0) > 1;
+  // Base for "everything after this commit" — its first parent. Never the next
+  // log row: on a graph that row is often a side branch (see
+  // planCommitSelection).
+  const baseOid = self?.parents[0] ?? null;
+```
+
+Then in the three handlers use `baseOid` instead of `commits[idx + 1]?.oid`, and gate the two folding actions on `isMerge`, following the disabled-label pattern `commitMultiMenuItems` already uses:
+
+```tsx
+    {
+      icon: "rebase",
+      label: "Interactive rebase from here",
+      disabled: !baseOid,
+      onClick: () => {
+        if (!commit?.sha || !baseOid) return;
+        const plan = buildRebasePlan(commits, baseOid, { kind: "edit-from" });
+        if (!plan || plan.length === 0) return;
+        useNavStore.getState().setIntent({ kind: "rebase-plan", plan });
+      },
+    },
+```
+
+```tsx
+    {
+      icon: "fix",
+      label: isMerge
+        ? "Fixup into parent — merge commit"
+        : "Fixup this commit into its parent",
+      disabled: isMerge || !baseOid,
+      onClick: () => { /* unchanged body, using baseOid */ },
+    },
+```
+
+```tsx
+    {
+      icon: "squash",
+      label: isMerge
+        ? "Squash into parent — merge commit"
+        : "Squash this commit into its parent",
+      disabled: isMerge || !baseOid,
+      onClick: async () => { /* unchanged body, using baseOid */ },
+    },
+```
+
+Note: `commitMenuItems` takes `{ sha?, subject? }`, so the full `CommitInfo` comes from the store lookup — the same lookup the handlers already do.
+
+- [ ] **Step 6: Verify**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm tsc --noEmit
+pnpm test
+```
+
+Expected: typecheck clean, whole frontend suite green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/features/commits/planCommitSelection.ts \
+        src/features/commits/planCommitSelection.merge.test.ts \
+        src/design/context-menu.tsx
+git commit -m "fix(rebase): take the rebase base from the commit's parent
+
+Why: the base came from commits[idx + 1] — the next row in a
+graph-ordered log. On non-linear history that row is often a
+side-branch commit, so the rebase reset to the wrong base and dropped
+whatever sat between it and the plan's first step. Squash/fixup on a
+merge commit is now disabled with the reason in the label."
+```
+
+---
+
+### Task 6: Whole-suite gate and CLAUDE.md note
+
+**Files:**
+- Modify: `CLAUDE.md` (architecture section, backend file list)
+
+- [ ] **Step 1: Run every layer**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml
+cargo check --manifest-path src-tauri/Cargo.toml
+pnpm tsc --noEmit
+pnpm test
+pnpm test:e2e:docker build
+pnpm test:e2e:docker run --spec e2e/specs/rebase.e2e.ts --spec e2e/specs/merge-conflict.e2e.ts
+```
+
+Expected: all green. The two e2e specs are the ones that touch the rebase engine and the conflict Continue/Abort path this PR rewired.
+
+- [ ] **Step 2: Document the two new modules**
+
+In `CLAUDE.md`, under `### Backend (src-tauri/src/)`, add to the `git/` listing beside `ownership.rs`:
+
+```
+├── rebase_plan.rs  Plan validation before execution — merge-legal actions,
+│                duplicate/unknown oids, all-drop plans. Runs BEFORE
+│                rebase_start touches the repo (a rejected plan must leave
+│                HEAD, the branch, and the worktree untouched)
+├── rebase_state.rs  On-disk mirror of an in-progress rebase
+│                (.git/platypusgit-rebase.json + ORIG_HEAD) so Abort survives
+│                an app restart. Deliberately NOT git's .git/rebase-merge/
+```
+
+And add a line to the "State management" or a new note under Conventions:
+
+```markdown
+- **The rebase engine replays on a detached HEAD** and moves the branch ref
+  exactly once, when the plan completes — so a failed or paused rebase never
+  leaves the branch mid-replay. `continue_operation` / `abort_operation`
+  delegate to `rebase_continue` / `rebase_abort` whenever
+  `.git/platypusgit-rebase.json` exists; the Conflict screen and the Rebase
+  banner must stay two entry points to one engine.
+```
+
+- [ ] **Step 3: Commit and open the PR**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: note the rebase engine's execution model and state file"
+git push -u origin HEAD
+gh pr create --title "fix(rebase): stop a merge commit from half-rewriting the branch" --body "$(cat <<'EOF'
+## What
+
+PR1 of three from `docs/superpowers/specs/2026-08-14-rebase-merge-commits-design.md`.
+
+A rebase plan containing a merge commit used to fail with libgit2's
+"mainline branch is not specified" error on the step that reached it —
+after earlier picks had been committed and the branch tip moved, with
+abort-ability held only in memory.
+
+- Plans are validated before the repository is touched (`git/rebase_plan.rs`,
+  new `AppError::InvalidRebasePlan`). A merge commit may be dropped
+  (git's own flattening default); any other action on it is refused up front.
+- The replay runs on a detached HEAD; the branch ref moves once, on completion.
+- `.git/platypusgit-rebase.json` + `ORIG_HEAD` mirror the operation, so a
+  restarted app still reports the rebase and can continue or abort it (the plan,
+  progress, and rewritten map are rehydrated from the file). `repo_state`
+  reports `RebaseInteractive` while it exists.
+- The Conflict screen's Continue/Abort delegate to the rebase engine instead of
+  committing the tree and stranding the plan.
+- The rebase base comes from the commit's first parent, not the next log row.
+
+## Testing
+
+`cargo test` (new: `rebase_validation.rs`, `rebase_durability.rs`), `pnpm test`
+(new: `planCommitSelection.merge.test.ts`), `pnpm tsc --noEmit`, and
+`pnpm test:e2e:docker run --spec e2e/specs/rebase.e2e.ts --spec e2e/specs/merge-conflict.e2e.ts`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-08-14-rebase-merge-commits-pr1-safety-model.md
+++ b/docs/superpowers/plans/2026-08-14-rebase-merge-commits-pr1-safety-model.md
@@ -21,7 +21,7 @@
 - Run cargo/pnpm with `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"`.
 - E2E only ever runs through Docker: `pnpm test:e2e:docker`. This PR adds no e2e spec.
 - Do not write git's own `.git/rebase-merge/` directory. Our state file plus `ORIG_HEAD` is the contract.
-- The seven existing tests in `src-tauri/tests/rebase.rs` must stay green throughout; they are the regression net for the execution-model change.
+- The ten existing tests in `src-tauri/tests/rebase.rs` must stay green throughout; they are the regression net for the execution-model change.
 
 ## File Structure
 
@@ -517,12 +517,27 @@ fn paused_rebase_detaches_head_and_leaves_the_branch_alone() {
         "refs/heads/main",
         "HEAD should be reattached to the original branch"
     );
+    // The branch points at the replayed history. Do NOT assert the tip
+    // *changed*: replaying unchanged commits onto the same base reproduces them
+    // byte for byte (same tree, message, author, and same-second committer), so
+    // the oids legitimately match the originals. The invariant is that HEAD and
+    // the branch agree, and that every step landed.
     let tip_after = branch_tip(&tr, "main");
-    assert_ne!(tip_after, tip_before, "the branch should point at the replay");
     assert_eq!(
         tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),
         tip_after,
         "HEAD and the branch must agree once the rebase is done"
+    );
+    let summaries: Vec<String> = backend
+        .log(&handle.id, None, 10)
+        .unwrap()
+        .into_iter()
+        .map(|c| c.summary)
+        .collect();
+    assert_eq!(
+        summaries,
+        vec!["commit 2", "commit 1", "commit 0", "initial"],
+        "every planned step must have been replayed onto the branch"
     );
 }
 
@@ -828,7 +843,9 @@ fn a_restarted_app_can_still_abort() {
         "the rebase must still be reported as in progress after a restart"
     );
     assert_eq!(status.total, 3);
-    assert_eq!(status.next_index, 1, "one step had completed before the pause");
+    // Two, not one: an Edit pauses *after* committing its step, so the pick and
+    // the edit have both landed by the time the rebase stops.
+    assert_eq!(status.next_index, 2, "the pick and the edit both landed");
 
     backend.rebase_abort(&handle.id).unwrap();
     assert_eq!(branch_tip(&tr, "main"), tip_before);
@@ -1236,6 +1253,13 @@ app still reports the rebase and can abort it."
 
 ### Task 4: One engine behind both Continue and Abort
 
+> **Land this together with Task 3.** Once the state file exists, the old
+> `abort_operation` (which removes only the in-memory entry) leaves a rebase that
+> `rebase_status` still reads as in progress off disk — so
+> `rebase.rs::abort_operation_clears_rebase_state_and_restores_pre_rebase_head`
+> fails between the two tasks. Implement Task 3, then Task 4, then commit once;
+> splitting them lands a knowingly-red commit.
+
 **Files:**
 - Modify: `src-tauri/src/git/libgit2.rs` (`continue_operation`, `abort_operation`)
 - Modify: `src-tauri/tests/rebase_durability.rs`
@@ -1277,8 +1301,20 @@ fn continue_operation_during_a_rebase_advances_the_plan() {
     ];
     let status = backend.rebase_start(&handle.id, plan).unwrap();
     assert_eq!(status.pause_reason.as_deref(), Some("edit"));
+
+    // What the UI does during an edit pause: AMEND the step's commit. Leaving
+    // the change merely staged is not a resolution — the next cherry-pick
+    // refuses with "1 uncommitted change would be overwritten by merge".
     write_file(tr.path(), "shared.txt", "diverged\n");
-    backend.stage(&handle.id, &[PathBuf::from("shared.txt")]).unwrap();
+    {
+        let mut index = tr.repo.index().unwrap();
+        index.add_path(std::path::Path::new("shared.txt")).unwrap();
+        index.write().unwrap();
+        let tree_oid = index.write_tree().unwrap();
+        let tree = tr.repo.find_tree(tree_oid).unwrap();
+        let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+        head.amend(Some("HEAD"), None, None, None, None, Some(&tree)).unwrap();
+    }
 
     let status = backend.rebase_continue(&handle.id).unwrap();
     assert_eq!(

--- a/docs/superpowers/plans/2026-08-14-rebase-merge-commits-pr2-flatten-mode.md
+++ b/docs/superpowers/plans/2026-08-14-rebase-merge-commits-pr2-flatten-mode.md
@@ -1,0 +1,1083 @@
+# Interactive rebase over merge commits — PR2: flatten mode
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A rebase range containing merge commits is usable: merges default to being dropped (git's own flattening behaviour), the plan says so in the row and in a warning strip above it, and a merge can alternatively be kept as one ordinary commit.
+
+**Architecture:** PR1 made a merge in the plan a hard, pre-flight rejection unless it was explicitly dropped. This PR makes the UI produce that plan by default instead of leaving the user to discover the error: `buildRebasePlan` and the Rebase screen's own plan builder mark merge rows and default them to `Drop`, the row component restricts its action list for a merge, and a new `RebaseAction::MainlinePick` (a `cherry-pick -m 1`) offers "keep the merge as one commit" for the case where the integration itself is worth a commit.
+
+**Tech Stack:** Rust + git2 0.20.4 (`CherrypickOptions::mainline`), React + Zustand, vitest/RTL, WebdriverIO (Docker only), `cargo test`.
+
+**Spec:** `docs/superpowers/specs/2026-08-14-rebase-merge-commits-design.md`
+
+**Depends on:** PR1 (`docs/superpowers/plans/2026-08-14-rebase-merge-commits-pr1-safety-model.md`) — `rebase_plan::validate`, `rebase_plan::merge_legal`, and the detached-HEAD execution model must be in place.
+
+## Global Constraints
+
+- Every IPC-crossing fn returns `AppResult<T>`; no `unwrap`/`panic` in commands.
+- A new Rust enum variant that crosses IPC updates `src/lib/types.ts` **in the same commit**.
+- Frontend never calls `invoke()` directly — typed wrapper in `src/lib/tauri.ts`.
+- Any new list-row surface opts into UI density via `--row-step`; `PGRebaseRow` already does (`padding: "calc(6px + var(--row-step) / 2) 10px"`) — keep it.
+- Never hardcode the accent hue; use `var(--accent)` / `var(--git-*)` tokens.
+- Import UI primitives from `@/design`.
+- E2E only ever runs through Docker: rebuild the snapshot with `pnpm test:e2e:docker build`, then `pnpm test:e2e:docker run --spec …`. Never natively.
+- Read `.claude/skills/e2e-testing/SKILL.md` before touching the e2e spec.
+- Run cargo/pnpm with `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"`.
+
+## File Structure
+
+**Create:**
+- `src-tauri/tests/rebase_flatten.rs` — `MainlinePick` semantics and the flattening result.
+- `src/features/commits/buildRebasePlan.merge.test.ts` — merge rows default to `Drop`.
+- `src/screens/Rebase.merge.test.tsx` — warning strip and restricted merge actions.
+
+**Modify:**
+- `src-tauri/src/git/types.rs` — `RebaseAction::MainlinePick`.
+- `src-tauri/src/git/rebase_plan.rs` — widen `merge_legal`.
+- `src-tauri/src/git/libgit2.rs` — `start_pick` takes a mainline; `advance_rebase` handles `MainlinePick`.
+- `src/lib/types.ts` — `RebaseAction` union member.
+- `src/features/commits/buildRebasePlan.ts` — merge rows become `Drop`.
+- `src/design/git-components.tsx` — `PGRebaseRow`: exact action values, `options` override, merge badge.
+- `src/screens/Rebase.tsx` — `PlanRow.isMerge`, restricted actions, warning strip.
+- `e2e/support/tempRepo.ts` — `mergeRangeRepo` fixture.
+- `e2e/specs/rebase.e2e.ts` — flatten run over a merge.
+
+---
+
+### Task 1: `MainlinePick` — keep a merge as one ordinary commit
+
+**Files:**
+- Modify: `src-tauri/src/git/types.rs`
+- Modify: `src/lib/types.ts`
+- Modify: `src-tauri/src/git/rebase_plan.rs`
+- Modify: `src-tauri/src/git/libgit2.rs`
+- Create: `src-tauri/tests/rebase_flatten.rs`
+
+**Interfaces:**
+- Consumes: `support::merge_history` and `rebase_plan::merge_legal` from PR1.
+- Produces: `RebaseAction::MainlinePick` (Rust + TS); `Libgit2Backend::start_pick(&self, repo_id: &RepoId, oid: &str, mainline: u32) -> AppResult<bool>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src-tauri/tests/rebase_flatten.rs`:
+
+```rust
+//! Flattening a range that contains a merge: either the merge is dropped (git's
+//! default — its side-branch commits are replayed individually) or it is kept
+//! as one ordinary commit carrying its diff against its first parent.
+
+mod support;
+
+use platypusgit_lib::git::{
+    types::{RebaseAction, RebaseStep},
+    GitBackend,
+};
+
+use support::{merge_history, TempRepo};
+
+fn step(oid: &str, action: RebaseAction) -> RebaseStep {
+    RebaseStep { oid: oid.to_string(), action, message: None }
+}
+
+#[test]
+fn dropping_the_merge_flattens_the_branch() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    let status = backend
+        .rebase_start(
+            &handle.id,
+            vec![
+                step(&h.a, RebaseAction::Pick),
+                step(&h.f, RebaseAction::Pick),
+                step(&h.c, RebaseAction::Pick),
+                step(&h.m, RebaseAction::Drop),
+            ],
+        )
+        .unwrap();
+    assert!(!status.in_progress);
+
+    let log = backend.log(&handle.id, None, 20).unwrap();
+    let summaries: Vec<&str> = log.iter().map(|c| c.summary.as_str()).collect();
+    assert_eq!(
+        summaries,
+        vec!["C on main", "F on feature", "A on main", "initial"],
+        "the branch should be linear, oldest last"
+    );
+    assert!(
+        log.iter().all(|c| c.parents.len() <= 1),
+        "no merge commit may survive a flattening rebase"
+    );
+    // The side branch's content is replayed, not lost.
+    assert!(tr.path().join("f.txt").exists(), "F's file must survive");
+    assert!(tr.path().join("c.txt").exists(), "C's file must survive");
+}
+
+#[test]
+fn mainline_pick_keeps_the_merge_as_one_commit() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let merge_tree = tr
+        .repo
+        .find_commit(git2::Oid::from_str(&h.m).unwrap())
+        .unwrap()
+        .tree_id();
+    let (backend, handle) = tr.open_with_backend();
+
+    // The side branch is NOT replayed on its own; the merge carries its content
+    // in as a single commit (the "I merged a topic in, keep that as one step"
+    // case).
+    let status = backend
+        .rebase_start(
+            &handle.id,
+            vec![
+                step(&h.a, RebaseAction::Pick),
+                step(&h.c, RebaseAction::Pick),
+                step(&h.m, RebaseAction::MainlinePick),
+            ],
+        )
+        .unwrap();
+    assert!(!status.in_progress, "a clean mainline pick should not pause");
+
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(head.parent_count(), 1, "the result must be an ordinary commit");
+    assert_eq!(
+        head.summary().unwrap(),
+        "Merge branch 'feature'",
+        "the merge's message is kept"
+    );
+    assert_eq!(
+        head.tree_id(),
+        merge_tree,
+        "the tree must match the original merge's tree"
+    );
+}
+
+#[test]
+fn mainline_pick_on_a_non_merge_behaves_like_pick() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    let status = backend
+        .rebase_start(
+            &handle.id,
+            vec![
+                step(&h.a, RebaseAction::Pick),
+                step(&h.c, RebaseAction::MainlinePick),
+                step(&h.m, RebaseAction::Drop),
+            ],
+        )
+        .unwrap();
+    assert!(!status.in_progress);
+    assert_eq!(
+        backend.log(&handle.id, None, 5).unwrap()[0].summary,
+        "C on main"
+    );
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase_flatten
+```
+
+Expected: compile error — `RebaseAction::MainlinePick` does not exist. (`dropping_the_merge_flattens_the_branch` passes once it compiles: PR1 already allows `Drop`.)
+
+- [ ] **Step 3: Add the action (Rust + TS)**
+
+In `src-tauri/src/git/types.rs`, extend `RebaseAction`:
+
+```rust
+pub enum RebaseAction {
+    Pick,
+    Reword,
+    Edit,
+    Squash,
+    Fixup,
+    Drop,
+    /// A merge commit applied as its diff against its **first** parent — one
+    /// ordinary commit, keeping the merge's message (`git cherry-pick -m 1`).
+    /// On a non-merge commit it is identical to `Pick`.
+    MainlinePick,
+}
+```
+
+In `src/lib/types.ts`:
+
+```ts
+export type RebaseAction =
+  | "Pick"
+  | "Reword"
+  | "Edit"
+  | "Squash"
+  | "Fixup"
+  | "Drop"
+  | "MainlinePick";
+```
+
+Widen `merge_legal` in `src-tauri/src/git/rebase_plan.rs`:
+
+```rust
+/// Actions that mean something for a commit with more than one parent.
+///
+/// `Drop` flattens (git's default), `MainlinePick` keeps the merge as one
+/// ordinary commit. PR3 adds `Merge`, which recreates it.
+pub fn merge_legal(action: RebaseAction) -> bool {
+    matches!(action, RebaseAction::Drop | RebaseAction::MainlinePick)
+}
+```
+
+Update the rejection message in `validate` to name both ways out:
+
+```rust
+            return Err(AppError::InvalidRebasePlan(format!(
+                "{} is a merge commit — it can be dropped (which flattens the \
+                 branch) or kept as one commit, but not {:?}ed",
+                short(&step.oid),
+                step.action
+            )));
+```
+
+- [ ] **Step 4: Teach the engine the mainline**
+
+In `src-tauri/src/git/libgit2.rs`, give `start_pick` a mainline parameter:
+
+```rust
+    /// Apply `oid`'s diff into the index + worktree (a cherry-pick), WITHOUT
+    /// committing. `mainline` is 0 for an ordinary commit and 1 for a merge
+    /// commit being flattened into one commit — libgit2 refuses a merge without
+    /// one ("mainline branch is not specified"), which is exactly the error a
+    /// plan containing an unhandled merge used to hit mid-replay.
+    fn start_pick(&self, repo_id: &RepoId, oid: &str, mainline: u32) -> AppResult<bool> {
+        self.with_repo(repo_id, |repo| {
+            let target = repo
+                .revparse_single(oid)
+                .map_err(|_| AppError::InvalidRef(oid.to_string()))?
+                .peel_to_commit()?;
+            let mut opts = git2::CherrypickOptions::new();
+            opts.mainline(mainline);
+            repo.cherrypick(&target, Some(&mut opts))?;
+            let statuses = repo.statuses(None)?;
+            Ok(!statuses.iter().any(|s| s.status().is_conflicted()))
+        })
+    }
+```
+
+In `advance_rebase`, compute the mainline from the action and the commit's parent count, and pass it:
+
+```rust
+            // A merge commit needs a mainline; an ordinary commit must not get
+            // one (libgit2 rejects a mainline on a single-parent commit).
+            let mainline = if step.action == RebaseAction::MainlinePick {
+                let parents = self.with_repo(repo_id, |repo| {
+                    Ok(repo
+                        .revparse_single(&step.oid)
+                        .map_err(|_| AppError::InvalidRef(step.oid.clone()))?
+                        .peel_to_commit()?
+                        .parent_count())
+                })?;
+                if parents > 1 { 1 } else { 0 }
+            } else {
+                0
+            };
+
+            if !resuming && !self.start_pick(repo_id, &step.oid, mainline)? {
+                // … existing conflict handling, unchanged …
+            }
+```
+
+Then handle the action in the post-commit `match step.action`, alongside `Pick`:
+
+```rust
+                RebaseAction::Pick | RebaseAction::MainlinePick => {
+                    self.bump_completed(repo_id)?;
+                }
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase_flatten
+cargo test --manifest-path src-tauri/Cargo.toml
+pnpm tsc --noEmit
+```
+
+Expected: three new tests pass; the whole backend suite stays green (the `start_pick` signature change touches only `advance_rebase`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/git/types.rs src-tauri/src/git/rebase_plan.rs \
+        src-tauri/src/git/libgit2.rs src-tauri/tests/rebase_flatten.rs src/lib/types.ts
+git commit -m "feat(rebase): add MainlinePick — keep a merge as one commit
+
+Why: flattening a range shouldn't force a choice between losing the
+merge entirely and replaying its side branch commit-by-commit. A
+mainline pick is git cherry-pick -m 1: the merge's diff against its
+first parent, as one ordinary commit keeping its message."
+```
+
+---
+
+### Task 2: Plans built from a range default their merge rows to `Drop`
+
+**Files:**
+- Modify: `src/features/commits/buildRebasePlan.ts`
+- Create: `src/features/commits/buildRebasePlan.merge.test.ts`
+
+**Interfaces:**
+- Produces: `buildRebasePlan` returning `Drop` for every commit with >1 parent, regardless of `mode`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/commits/buildRebasePlan.merge.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { buildRebasePlan } from "./buildRebasePlan";
+import type { CommitInfo } from "@/lib/types";
+
+function mk(oid: string, summary: string, parents: string[]): CommitInfo {
+  return {
+    oid,
+    shortOid: oid.slice(0, 7),
+    summary,
+    body: null,
+    author: "Test",
+    email: "t@e.com",
+    timestamp: 0,
+    parents,
+    refs: [],
+  };
+}
+
+const M = "m".repeat(40);
+const C = "c".repeat(40);
+const F = "f".repeat(40);
+const A = "a".repeat(40);
+const ROOT = "r".repeat(40);
+
+/** Newest-first, as the log returns it. */
+const log: CommitInfo[] = [
+  mk(M, "Merge branch 'feature'", [C, F]),
+  mk(C, "C on main", [A]),
+  mk(F, "F on feature", [A]),
+  mk(A, "A on main", [ROOT]),
+  mk(ROOT, "root", []),
+];
+
+describe("buildRebasePlan with merges in range", () => {
+  it("defaults a merge commit to Drop and keeps everything else a Pick", () => {
+    const plan = buildRebasePlan(log, A, { kind: "edit-from" });
+    expect(plan).not.toBeNull();
+    expect(plan!.map((s) => [s.oid, s.action])).toEqual([
+      [F, "Pick"],
+      [C, "Pick"],
+      [M, "Drop"],
+    ]);
+  });
+
+  it("a merge is dropped even when it is the fixup target", () => {
+    // Nothing in the UI offers this, but a plan is a plan — the backend would
+    // reject Fixup on a merge, so the builder must not produce it.
+    const plan = buildRebasePlan(log, A, { kind: "fixup", targetOid: M });
+    expect(plan!.find((s) => s.oid === M)!.action).toBe("Drop");
+  });
+
+  it("leaves a merge-free range untouched", () => {
+    const linear = [mk(C, "C", [A]), mk(A, "A", [ROOT]), mk(ROOT, "root", [])];
+    const plan = buildRebasePlan(linear, A, { kind: "edit-from" });
+    expect(plan!.map((s) => s.action)).toEqual(["Pick"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/features/commits/buildRebasePlan.merge.test.ts
+```
+
+Expected: the first two fail — every row currently comes back `"Pick"`.
+
+- [ ] **Step 3: Implement**
+
+In `src/features/commits/buildRebasePlan.ts`, extend the doc comment and the mapping. Add to the doc block, after the `mode` list:
+
+```
+ * A commit with more than one parent (a merge) is always emitted as "Drop",
+ * whatever the mode asks for: that is git's own default (`git rebase -i` drops
+ * merges and flattens the branch), and the backend refuses any other action on
+ * a merge except MainlinePick, which the user picks per row in the Rebase
+ * screen.
+```
+
+And in the `map` callback, make it the first branch:
+
+```ts
+  return oldestFirst.map((c): RebaseStep => {
+    let action: RebaseAction = "Pick";
+    let message: string | null = null;
+    if (c.parents.length > 1) {
+      action = "Drop";
+    } else if (mode.kind === "fixup" && c.oid === mode.targetOid) {
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/features/commits/buildRebasePlan
+```
+
+Expected: the new file and the existing `buildRebasePlan.test.ts` both pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/commits/buildRebasePlan.ts src/features/commits/buildRebasePlan.merge.test.ts
+git commit -m "feat(rebase): default merge rows to Drop when building a plan"
+```
+
+---
+
+### Task 3: `PGRebaseRow` speaks exact actions and marks a merge
+
+**Files:**
+- Modify: `src/design/git-components.tsx`
+- Modify: `src/screens/Rebase.tsx` (the `onActionChange` mapping only)
+
+**Interfaces:**
+- Produces: `PGRebaseRowProps { action?: RebaseAction; sha; subject; onActionChange?: (v: RebaseAction) => void; index?; dragging?; options?: RebaseAction[]; badge?: string }`, where `action` and `onActionChange` now use the exact `RebaseAction` strings (`"Pick"`, `"MainlinePick"`, …) instead of lowercase.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/design/git-components.rebaseRow.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { PGRebaseRow } from "./git-components";
+
+describe("PGRebaseRow", () => {
+  it("offers the full action list by default and reports exact action names", async () => {
+    const onActionChange = vi.fn();
+    render(
+      <PGRebaseRow sha="abc1234" subject="feat: thing" action="Pick" onActionChange={onActionChange} />,
+    );
+    const select = screen.getByRole("combobox");
+    expect([...select.querySelectorAll("option")].map((o) => o.getAttribute("value"))).toEqual([
+      "Pick",
+      "Reword",
+      "Edit",
+      "Squash",
+      "Fixup",
+      "Drop",
+    ]);
+    await userEvent.selectOptions(select, "Drop");
+    expect(onActionChange).toHaveBeenCalledWith("Drop");
+  });
+
+  it("restricts the list and shows a badge for a merge row", () => {
+    render(
+      <PGRebaseRow
+        sha="def5678"
+        subject="Merge branch 'feature'"
+        action="Drop"
+        badge="merge"
+        options={["Drop", "MainlinePick"]}
+      />,
+    );
+    const select = screen.getByRole("combobox");
+    expect([...select.querySelectorAll("option")].map((o) => o.getAttribute("value"))).toEqual([
+      "Drop",
+      "MainlinePick",
+    ]);
+    expect(screen.getByText("merge")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/design/git-components.rebaseRow.test.tsx
+```
+
+Expected: fails — option values are lowercase (`"pick"`, …), there is no `options` or `badge` prop.
+
+- [ ] **Step 3: Implement**
+
+In `src/design/git-components.tsx`, replace `PGRebaseRowProps` and the action table:
+
+```tsx
+export interface PGRebaseRowProps {
+  /** Exact `RebaseAction` string — the same value the backend consumes. */
+  action?: RebaseAction;
+  sha: string;
+  subject: string;
+  onActionChange?: (v: RebaseAction) => void;
+  index?: number;
+  dragging?: boolean;
+  /** Restrict the dropdown — a merge row cannot be reworded, edited, or folded. */
+  options?: RebaseAction[];
+  /** Short label rendered next to the sha, e.g. "merge". */
+  badge?: string;
+}
+
+const REBASE_ACTION_STYLE: Record<RebaseAction, { label: string; color: string }> = {
+  Pick: { label: "pick", color: "var(--git-added)" },
+  Reword: { label: "reword", color: "var(--accent)" },
+  Edit: { label: "edit", color: "var(--git-modified)" },
+  Squash: { label: "squash", color: "var(--accent-2)" },
+  Fixup: { label: "fixup", color: "var(--accent-2)" },
+  Drop: { label: "drop", color: "var(--git-removed)" },
+  MainlinePick: { label: "keep as one", color: "var(--accent-3)" },
+};
+
+const DEFAULT_REBASE_ACTIONS: RebaseAction[] = [
+  "Pick",
+  "Reword",
+  "Edit",
+  "Squash",
+  "Fixup",
+  "Drop",
+];
+
+export function PGRebaseRow({
+  action = "Pick",
+  sha,
+  subject,
+  onActionChange,
+  index,
+  dragging,
+  options,
+  badge,
+}: PGRebaseRowProps) {
+  const values = options ?? DEFAULT_REBASE_ACTIONS;
+  const current = REBASE_ACTION_STYLE[action] ?? REBASE_ACTION_STYLE.Pick;
+  return (
+    <div
+      data-testid="rebase-row"
+      data-sha={sha}
+      data-action={action}
+      style={{
+        // … existing style block, with the two action-dependent lines becoming:
+        opacity: action === "Drop" ? 0.5 : 1,
+        textDecoration: action === "Drop" ? "line-through" : "none",
+        borderLeft: `3px solid ${current.color}`,
+      }}
+    >
+      {/* … drag icon + index unchanged … */}
+      <PGSelect
+        value={action}
+        onChange={(v) => onActionChange?.(v as RebaseAction)}
+        size="sm"
+        options={values.map((v) => ({ value: v, label: REBASE_ACTION_STYLE[v].label }))}
+        style={{ width: 110, borderColor: current.color, color: current.color } as CSSProperties}
+      />
+      {badge && (
+        <span
+          data-testid="rebase-row-badge"
+          style={{
+            fontSize: "var(--fs-10)",
+            textTransform: "uppercase",
+            letterSpacing: "0.04em",
+            padding: "1px 5px",
+            borderRadius: "var(--r-1)",
+            border: "1px solid var(--border-1)",
+            color: "var(--fg-2)",
+            flexShrink: 0,
+          }}
+        >
+          {badge}
+        </span>
+      )}
+      {/* … sha + subject spans unchanged … */}
+    </div>
+  );
+}
+```
+
+Import the type at the top of the file if it is not already imported: `import type { RebaseAction } from "@/lib/types";`.
+
+In `src/screens/Rebase.tsx`, the case-mangling mapping goes away:
+
+```tsx
+                        action={row.action}
+                        onActionChange={(v) => updateRow(i, { action: v })}
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/design/git-components.rebaseRow.test.tsx
+pnpm test src/screens/Rebase
+pnpm tsc --noEmit
+```
+
+Expected: new component tests pass; the existing `Rebase.test.tsx` still passes; typecheck clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/design/git-components.tsx src/design/git-components.rebaseRow.test.tsx src/screens/Rebase.tsx
+git commit -m "refactor(design): PGRebaseRow takes exact RebaseAction values
+
+Why: the row lowercased its action and the screen re-capitalised the
+first letter on the way back, which cannot express a two-word action
+like MainlinePick. It now speaks the same strings the backend does, and
+accepts a restricted option list plus a badge for merge rows."
+```
+
+---
+
+### Task 4: The Rebase screen explains what will happen to the merges
+
+**Files:**
+- Modify: `src/screens/Rebase.tsx`
+- Create: `src/screens/Rebase.merge.test.tsx`
+
+**Interfaces:**
+- Consumes: `PGRebaseRow` `options` / `badge` (Task 3).
+- Produces: `PlanRow { oid, shortOid, subject, action, message, isMerge: boolean }`; a warning strip with `data-testid="rebase-merge-warning"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/screens/Rebase.merge.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { RebaseScreen } from "./Rebase";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { mockInvoke } from "@/test/invokeMock";
+import type { CommitInfo, RebaseStatus, RepoHandle } from "@/lib/types";
+
+const handle: RepoHandle = { id: "repo-1", path: "/tmp/fake-repo", head: "refs/heads/main" };
+const SWEPT: RebaseStatus = { inProgress: false, nextIndex: 0, total: 0, pauseReason: null };
+
+function mk(oid: string, summary: string, parents: string[]): CommitInfo {
+  return {
+    oid,
+    shortOid: oid.slice(0, 7),
+    summary,
+    body: null,
+    author: "Tester",
+    email: "t@e.com",
+    timestamp: 1_700_000_000,
+    parents,
+    refs: [],
+  };
+}
+
+const M = "m".repeat(40);
+const C = "c".repeat(40);
+const F = "f".repeat(40);
+const A = "a".repeat(40);
+
+const commits = [
+  mk(M, "Merge branch 'feature'", [C, F]),
+  mk(C, "C on main", [A]),
+  mk(F, "F on feature", [A]),
+  mk(A, "A on main", ["0".repeat(40)]),
+];
+
+beforeEach(() => {
+  useRepoStore.setState({
+    current: handle,
+    status: [],
+    allFiles: [],
+    branches: [],
+    tags: [],
+    stashes: [],
+    remotes: [],
+    commits,
+    loading: false,
+    error: null,
+    repoState: "Clean",
+    rebaseStatus: SWEPT,
+    lastRebaseSummary: null,
+    activity: {},
+  });
+  mockInvoke("rebase_status", () => SWEPT);
+  useNavStore.setState({
+    intent: {
+      kind: "rebase-plan",
+      plan: [
+        { oid: F, action: "Pick", message: null },
+        { oid: C, action: "Pick", message: null },
+        { oid: M, action: "Drop", message: null },
+      ],
+    },
+  });
+});
+
+describe("RebaseScreen with merge commits in the plan", () => {
+  it("warns that the merge will be flattened, counting the merges", async () => {
+    render(<RebaseScreen />);
+    const warning = await screen.findByTestId("rebase-merge-warning");
+    expect(warning.textContent).toContain("1 merge commit");
+    expect(warning.textContent).toContain("linear");
+  });
+
+  it("badges the merge row and restricts its actions", async () => {
+    render(<RebaseScreen />);
+    const rows = await screen.findAllByTestId("rebase-row");
+    const mergeRow = rows.find((r) => r.getAttribute("data-sha") === M.slice(0, 7));
+    expect(mergeRow).toBeDefined();
+    expect(mergeRow!.querySelector('[data-testid="rebase-row-badge"]')?.textContent).toBe("merge");
+    const values = [...mergeRow!.querySelectorAll("option")].map((o) => o.getAttribute("value"));
+    expect(values).toEqual(["Drop", "MainlinePick"]);
+  });
+
+  it("says nothing when the range has no merges", async () => {
+    useNavStore.setState({
+      intent: {
+        kind: "rebase-plan",
+        plan: [{ oid: C, action: "Pick", message: null }],
+      },
+    });
+    render(<RebaseScreen />);
+    await screen.findAllByTestId("rebase-row");
+    expect(screen.queryByTestId("rebase-merge-warning")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/screens/Rebase.merge.test.tsx
+```
+
+Expected: fails — no warning strip, no badge, the merge row offers all six actions.
+
+- [ ] **Step 3: Implement**
+
+In `src/screens/Rebase.tsx`:
+
+Add `isMerge` to `PlanRow` and set it in both plan sources.
+
+```tsx
+interface PlanRow {
+  oid: string;
+  shortOid: string;
+  subject: string;
+  action: RebaseAction;
+  message: string;
+  /** More than one parent — actions are restricted and the row is badged. */
+  isMerge: boolean;
+}
+
+/** Actions that mean anything for a merge row; mirrors rebase_plan::merge_legal. */
+const MERGE_ACTIONS: RebaseAction[] = ["Drop", "MainlinePick"];
+
+function commitsToPlan(commits: CommitInfo[]): PlanRow[] {
+  // Present commits oldest-first (log is newest-first).
+  return [...commits].reverse().map((c) => {
+    const isMerge = c.parents.length > 1;
+    return {
+      oid: c.oid,
+      shortOid: c.shortOid,
+      subject: c.summary,
+      // A merge defaults to Drop: that is git's own flattening behaviour, and
+      // the backend refuses anything but Drop/MainlinePick on a merge.
+      action: (isMerge ? "Drop" : "Pick") as RebaseAction,
+      message: "",
+      isMerge,
+    };
+  });
+}
+```
+
+In the NavIntent effect, carry the flag through:
+
+```tsx
+    const rows: PlanRow[] = intent.plan.map((step) => {
+      const c = byOid.get(step.oid);
+      const isMerge = (c?.parents.length ?? 0) > 1;
+      return {
+        oid: step.oid,
+        shortOid: c?.shortOid ?? step.oid.slice(0, 7),
+        subject: c?.summary ?? "",
+        action: isMerge && !MERGE_ACTIONS.includes(step.action) ? "Drop" : step.action,
+        message: step.message ?? "",
+        isMerge,
+      };
+    });
+```
+
+Add the count and the strip. Above the `return`, next to the other derived values:
+
+```tsx
+  const mergeCount = plan.filter((r) => r.isMerge).length;
+  const flattenedCount = plan.filter((r) => r.isMerge && r.action === "Drop").length;
+```
+
+And render it directly above the rows pane (inside the `!rebaseStatus.inProgress` block, after the toolbar):
+
+```tsx
+          {mergeCount > 0 && (
+            <div
+              data-testid="rebase-merge-warning"
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "6px 12px",
+                borderBottom: "1px solid var(--border-0)",
+                background: "oklch(from var(--git-modified) l c h / 0.12)",
+                color: "var(--fg-1)",
+                fontSize: "var(--fs-12)",
+              }}
+            >
+              <PGIcon name="warn" size={14} style={{ color: "var(--git-modified)" }} />
+              <span>
+                {mergeCount === 1 ? "1 merge commit" : `${mergeCount} merge commits`} in this
+                range.{" "}
+                {flattenedCount > 0 && (
+                  <>
+                    {flattenedCount === mergeCount
+                      ? "It will be"
+                      : `${flattenedCount} will be`}{" "}
+                    flattened — the branch becomes linear, and the merged
+                    commits are replayed individually.{" "}
+                  </>
+                )}
+                Choose <strong>keep as one</strong> on a merge row to keep it as a single commit
+                instead.
+              </span>
+            </div>
+          )}
+```
+
+Import `PGIcon` from `@/design` at the top of the file. The glyph is `warn` (`src/design/icons.tsx`); there is no `warning` key.
+
+Pass the restrictions to the row:
+
+```tsx
+                      <PGRebaseRow
+                        index={i + 1}
+                        sha={row.shortOid}
+                        subject={row.subject}
+                        action={row.action}
+                        badge={row.isMerge ? "merge" : undefined}
+                        options={row.isMerge ? MERGE_ACTIONS : undefined}
+                        onActionChange={(v) => updateRow(i, { action: v })}
+                      />
+```
+
+The message textarea condition stays `row.action === "Reword" || row.action === "Squash"` — neither is reachable on a merge row now.
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/screens/Rebase
+pnpm tsc --noEmit
+```
+
+Expected: the three new tests pass; the existing `Rebase.test.tsx` still passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/screens/Rebase.tsx src/screens/Rebase.merge.test.tsx
+git commit -m "feat(rebase): badge merge rows and warn that flattening is linear
+
+Why: a range containing a merge silently produced a plan the backend
+rejects. Merge rows now default to drop, are badged, offer only the two
+actions that mean anything for a merge, and the screen states up front
+that the branch becomes linear."
+```
+
+---
+
+### Task 5: E2E — a real flattening run over a merge
+
+**Files:**
+- Modify: `e2e/support/tempRepo.ts`
+- Modify: `e2e/specs/rebase.e2e.ts`
+
+**Interfaces:**
+- Produces: `mergeRangeRepo(): TempRepo` — `root → A → (feature: F) → C → M`, `main` checked out at `M`.
+
+- [ ] **Step 1: Read the e2e skill first**
+
+```bash
+cat .claude/skills/e2e-testing/SKILL.md
+```
+
+Selector conventions, the 5s-per-command penalty, native-dialog stubbing, and rebuild discipline all apply below.
+
+- [ ] **Step 2: Add the fixture**
+
+In `e2e/support/tempRepo.ts`, after `rebaseConflictRepo`, following the style of the fixtures already there (they shell out through `repo.git(...)`):
+
+```ts
+/**
+ * A range with a merge commit in the middle:
+ *
+ *   root ── A ──── C ── M   (main)
+ *            \        /
+ *             ─── F ──      (feature)
+ *
+ * F and C touch different files, so M merges cleanly. Used by the interactive
+ * rebase spec: a rebase from A must flatten M away and keep F's content.
+ */
+export function mergeRangeRepo(): TempRepo {
+  const r = new TempRepo();
+  r.commitFile("root.txt", "root\n", "feat: root");
+  r.commitFile("a.txt", "a\n", "feat: a on main");
+  r.git("checkout", "-b", "feature");
+  r.commitFile("f.txt", "f\n", "feat: f on feature");
+  r.git("checkout", "main");
+  r.commitFile("c.txt", "c\n", "feat: c on main");
+  r.git("merge", "--no-ff", "-m", "Merge branch 'feature'", "feature");
+  return r;
+}
+```
+
+`TempRepo` exposes `commitFile(rel, content, msg)`, `write`, `git`, `read`, `headSha`, `hasRef`, and `dispose` (`e2e/support/tempRepo.ts`) — the same helpers `basicRepo` and `rebaseConflictRepo` use.
+
+- [ ] **Step 3: Write the failing spec**
+
+Append to `e2e/specs/rebase.e2e.ts`, inside the existing `describe("interactive rebase")`:
+
+```ts
+  it("flattens a merge commit out of the range", async () => {
+    repo = mergeRangeRepo();
+    await openRepo(repo.path);
+    await stubNativeDialogs({ confirm: true });
+    await switchScreen("history");
+    await scrollCommitListTo("feat: a on main");
+    // "Interactive rebase from here" on A puts everything after A in the plan:
+    // F, C, and the merge M.
+    await jsContextMenu('[data-testid="commit-row"]', { text: "feat: a on main" });
+    await jsClickMenuItem("Interactive rebase from here");
+
+    const warning = $('[data-testid="rebase-merge-warning"]');
+    await warning.waitForDisplayed({
+      timeout: 15_000,
+      timeoutMsg: "merge warning never appeared for a range containing a merge",
+    });
+    expect(await warning.getText()).toContain("1 merge commit");
+
+    await $('[data-testid="rebase-start"]').click();
+    await $('[data-testid="rebase-last-summary"]').waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "flattening rebase never reported completion",
+    });
+
+    // The merge is gone, the side branch's commit and file survived, and the
+    // history is linear.
+    expect(repo.git("log", "--oneline", "--merges").trim()).toBe("");
+    expect(repo.git("log", "--format=%s").trim().split("\n")).toEqual([
+      "feat: c on main",
+      "feat: f on feature",
+      "feat: a on main",
+      "feat: root",
+    ]);
+    expect(repo.git("status", "--porcelain").trim()).toBe("");
+  });
+```
+
+Add `mergeRangeRepo` to the spec's import from `../support/tempRepo`.
+
+- [ ] **Step 4: Build the snapshot and run just this spec**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm exec tsc -p e2e/tsconfig.json --noEmit
+pnpm test:e2e:docker build
+pnpm test:e2e:docker run --spec e2e/specs/rebase.e2e.ts
+```
+
+Expected: the whole rebase spec file passes, including the new test. Never run e2e natively.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/support/tempRepo.ts e2e/specs/rebase.e2e.ts
+git commit -m "test(e2e): rebase a range containing a merge commit"
+```
+
+---
+
+### Task 6: Whole-suite gate, docs, PR
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Run every layer**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml
+pnpm tsc --noEmit
+pnpm test
+pnpm exec tsc -p e2e/tsconfig.json --noEmit
+pnpm test:e2e:docker run --spec e2e/specs/rebase.e2e.ts
+```
+
+- [ ] **Step 2: Document the flatten contract**
+
+In `CLAUDE.md`, under Conventions, extend the rebase note added by PR1:
+
+```markdown
+- **Merge commits in a rebase plan** may only be `Drop` (flatten — git's own
+  default, side-branch commits replayed individually) or `MainlinePick` (keep the
+  merge as one ordinary commit, `cherry-pick -m 1`). `rebase_plan::merge_legal`
+  is the single source of truth; `MERGE_ACTIONS` in `src/screens/Rebase.tsx`
+  mirrors it, and the two must stay in sync or the UI offers an action the
+  backend refuses.
+```
+
+- [ ] **Step 3: Commit and open the PR**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: note which rebase actions a merge commit accepts"
+git push -u origin HEAD
+gh pr create --title "feat(rebase): flatten merge commits with the plan saying so" --body "$(cat <<'EOF'
+## What
+
+PR2 of three from `docs/superpowers/specs/2026-08-14-rebase-merge-commits-design.md`.
+
+PR1 made a merge in a rebase plan a clean pre-flight rejection. This PR makes the
+UI produce a plan that works, and explains it:
+
+- Merge rows default to `Drop` — git's own flattening behaviour: the merge
+  disappears and its side-branch commits are replayed individually.
+- New `RebaseAction::MainlinePick` (`git cherry-pick -m 1`) keeps a merge as one
+  ordinary commit with its original message.
+- Merge rows are badged and offer only those two actions; a warning strip above
+  the plan states how many merges are in range and that the branch becomes linear.
+- `PGRebaseRow` now speaks exact `RebaseAction` values instead of lowercasing
+  them and re-capitalising on the way back.
+
+## Testing
+
+`cargo test` (new: `rebase_flatten.rs`), `pnpm test` (new:
+`buildRebasePlan.merge.test.ts`, `git-components.rebaseRow.test.tsx`,
+`Rebase.merge.test.tsx`), `pnpm tsc --noEmit`, and
+`pnpm test:e2e:docker run --spec e2e/specs/rebase.e2e.ts` (new flattening spec).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-08-14-rebase-merge-commits-pr3-preserve-mode.md
+++ b/docs/superpowers/plans/2026-08-14-rebase-merge-commits-pr3-preserve-mode.md
@@ -1,0 +1,1519 @@
+# Interactive rebase over merge commits — PR3: preserve mode
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** An interactive rebase can keep the branch topology: merge commits are recreated by re-merging their rewritten parents, the equivalent of `git rebase --rebase-merges`, opt-in behind a mode toggle that states its costs.
+
+**Architecture:** git needs `label` / `reset` / `merge <label>` because its todo list is a text file a human edits. This plan is generated, so topology is encoded structurally: every step may name the original commit it must be applied `onto`, and the engine resolves that through the `rewritten` map PR1 already records — every commit is implicitly its own label. A merge step additionally carries its parents beyond the first, and the engine re-merges them in the worktree, which means a conflicting recreated merge pauses through the same machinery (and the same merge resolver window) as a conflicting pick.
+
+**Tech Stack:** Rust + git2 0.20.4 (`Repository::merge`, `find_annotated_commit`), React + Zustand, vitest/RTL, WebdriverIO (Docker only), `cargo test`.
+
+**Spec:** `docs/superpowers/specs/2026-08-14-rebase-merge-commits-design.md`
+
+**Depends on:** PR1 (detached-HEAD model, `rewritten` map, `rebase_plan::validate`, durable state) and PR2 (`MainlinePick`, merge-aware plan rows, `PGRebaseRow` options/badge).
+
+## Global Constraints
+
+- Every IPC-crossing fn returns `AppResult<T>`; no `unwrap`/`panic` in commands.
+- New Rust fields that cross IPC update `src/lib/types.ts` **in the same commit**. Wire format is camelCase (`mergeParents`).
+- New Rust struct fields carry `#[serde(default)]` so a plan built by older frontend code still deserialises.
+- `rebase_plan::merge_legal` stays the single source of truth for which actions a merge accepts; `MERGE_ACTIONS` in `src/screens/Rebase.tsx` mirrors it.
+- Frontend never calls `invoke()` directly.
+- Never call `window.confirm` / `window.prompt` — `pgConfirm` / `pgPrompt` from `@/design`.
+- Any new list-row surface opts into UI density via `--row-step`.
+- E2E only through Docker: `pnpm test:e2e:docker build` then `pnpm test:e2e:docker run --spec …`. Read `.claude/skills/e2e-testing/SKILL.md` first.
+- Run cargo/pnpm with `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"`.
+- Reordering is **not** offered in preserve mode. git documents its own reorder bugs under `--rebase-merges`; a reorder that silently produces the wrong topology is worse than no reorder.
+
+## File Structure
+
+**Create:**
+- `src-tauri/tests/rebase_preserve.rs` — `onto` resets, clean recreate, conflicting recreate, octopus rejection.
+- `src/features/commits/buildPreservePlan.ts` — the topology-aware plan builder.
+- `src/features/commits/buildPreservePlan.test.ts` — its tests.
+- `src/features/rebase/useRebaseMergeMode.ts` — persisted flatten ⇄ preserve preference.
+- `src/screens/Rebase.preserve.test.tsx` — mode toggle, preserve warning, reorder lock.
+
+**Modify:**
+- `src-tauri/src/git/types.rs` — `RebaseStep.onto`, `RebaseStep.merge_parents`, `RebaseAction::Merge`.
+- `src-tauri/src/git/rebase_plan.rs` — `merge_legal` widened; `onto` and merge-parent validation.
+- `src-tauri/src/git/libgit2.rs` — base resolution per step, `apply_merge`, `finish_merge`, `rebase_start` base from `onto`.
+- `src/lib/types.ts` — `RebaseStep` fields, `RebaseAction` member.
+- `src/screens/Rebase.tsx` — mode toggle, preserve plan, warning copy, reorder lock.
+- `e2e/specs/rebase.e2e.ts` — a preserve run.
+- `CLAUDE.md` — the preserve contract.
+
+---
+
+### Task 1: `onto` — a step declares the commit it applies onto
+
+**Files:**
+- Modify: `src-tauri/src/git/types.rs`
+- Modify: `src/lib/types.ts`
+- Modify: `src-tauri/src/git/rebase_plan.rs`
+- Modify: `src-tauri/src/git/libgit2.rs`
+- Create: `src-tauri/tests/rebase_preserve.rs`
+
+**Interfaces:**
+- Consumes: `RebaseState.rewritten` and `record_rewritten` (PR1 Task 2).
+- Produces: `RebaseStep { oid, action, message, onto: Option<String>, merge_parents: Vec<String> }` (Rust) / `{ oid, action, message, onto?, mergeParents? }` (TS); `Libgit2Backend::move_to_base(&self, repo_id: &RepoId, original_oid: &str) -> AppResult<()>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src-tauri/tests/rebase_preserve.rs`:
+
+```rust
+//! Topology-aware replay. A step may name the original commit it must be
+//! applied onto; the engine resolves that through the rewritten map and resets
+//! the detached HEAD there first. That is what lets a side branch be replayed
+//! at its own branch point instead of being flattened onto the mainline.
+
+mod support;
+
+use platypusgit_lib::{
+    error::AppError,
+    git::{
+        types::{RebaseAction, RebaseStep},
+        GitBackend,
+    },
+};
+
+use support::{merge_history, TempRepo};
+
+fn pick(oid: &str) -> RebaseStep {
+    RebaseStep {
+        oid: oid.to_string(),
+        action: RebaseAction::Pick,
+        message: None,
+        onto: None,
+        merge_parents: Vec::new(),
+    }
+}
+
+fn pick_onto(oid: &str, onto: &str) -> RebaseStep {
+    RebaseStep { onto: Some(onto.to_string()), ..pick(oid) }
+}
+
+#[test]
+fn onto_replays_a_step_at_its_own_branch_point() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    // A, then F on top of A, then C back on top of A — a fork, no merge yet.
+    // Without `onto`, C would land on top of F (the previous step's result).
+    let status = backend
+        .rebase_start(
+            &handle.id,
+            vec![pick(&h.a), pick(&h.f), pick_onto(&h.c, &h.a)],
+        )
+        .unwrap();
+    assert!(!status.in_progress);
+
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(head.summary().unwrap(), "C on main");
+    assert_eq!(
+        head.parent(0).unwrap().summary().unwrap(),
+        "A on main",
+        "C must sit on the rewritten A, not on F"
+    );
+    // F is not an ancestor of the new HEAD — it was replayed on a fork that the
+    // final HEAD does not descend from.
+    assert!(!tr.path().join("f.txt").exists(), "F's fork is not checked out at HEAD");
+}
+
+#[test]
+fn onto_naming_an_unknown_commit_is_rejected() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+    let tip_before = tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string();
+
+    let err = backend
+        .rebase_start(
+            &handle.id,
+            vec![pick_onto(&h.a, "0000000000000000000000000000000000000000")],
+        )
+        .unwrap_err();
+    assert!(matches!(err, AppError::InvalidRebasePlan(_)), "got {err:?}");
+    assert_eq!(
+        tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string(),
+        tip_before,
+        "a rejected plan must not move anything"
+    );
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase_preserve
+```
+
+Expected: compile error — `RebaseStep` has no `onto` / `merge_parents`.
+
+- [ ] **Step 3: Extend the step type (Rust + TS)**
+
+In `src-tauri/src/git/types.rs`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RebaseStep {
+    /// Commit to operate on (full OID from the log).
+    pub oid: String,
+    pub action: RebaseAction,
+    /// New message for reword / squash. Ignored for other actions.
+    pub message: Option<String>,
+    /// The **original** oid this step must be applied onto. The engine resolves
+    /// it through the rewritten map and resets the detached HEAD there before
+    /// applying. `None` means "onto whatever the previous step produced", the
+    /// linear default. This is how topology is expressed without git's
+    /// label/reset todo language: every commit is implicitly its own label.
+    #[serde(default)]
+    pub onto: Option<String>,
+    /// A merge step's **original** parents beyond the first, resolved through
+    /// the rewritten map at merge time. Empty for every other action.
+    #[serde(default)]
+    pub merge_parents: Vec<String>,
+}
+```
+
+In `src/lib/types.ts`:
+
+```ts
+export interface RebaseStep {
+  oid: string;
+  action: RebaseAction;
+  message: string | null;
+  /** Original oid this step applies onto; omitted = onto the previous step. */
+  onto?: string | null;
+  /** A merge step's original parents beyond the first. */
+  mergeParents?: string[];
+}
+```
+
+Existing Rust constructions of `RebaseStep` (tests in `rebase.rs`, `rebase_validation.rs`, `rebase_flatten.rs`, `rebase_durability.rs`) need the two new fields. Update their local `step` / `step_msg` helpers once each:
+
+```rust
+fn step(oid: &str, action: RebaseAction) -> RebaseStep {
+    RebaseStep {
+        oid: oid.to_string(),
+        action,
+        message: None,
+        onto: None,
+        merge_parents: Vec::new(),
+    }
+}
+```
+
+- [ ] **Step 4: Validate `onto`**
+
+In `src-tauri/src/git/rebase_plan.rs`, inside `validate`'s loop over steps, after the merge-action check, add:
+
+```rust
+        if let Some(onto) = &step.onto {
+            let known_earlier = plan
+                .iter()
+                .take_while(|s| s.oid != step.oid)
+                .any(|s| &s.oid == onto);
+            let exists = repo
+                .revparse_single(onto)
+                .and_then(|o| o.peel_to_commit())
+                .is_ok();
+            if !known_earlier && !exists {
+                return Err(AppError::InvalidRebasePlan(format!(
+                    "{} is applied onto {}, which is neither an earlier step nor \
+                     an existing commit",
+                    short(&step.oid),
+                    short(onto)
+                )));
+            }
+        }
+```
+
+- [ ] **Step 5: Resolve the base before applying each step**
+
+In `src-tauri/src/git/libgit2.rs`, add a helper beside `record_rewritten`:
+
+```rust
+    /// Put the detached HEAD on the commit a step wants to be applied onto.
+    /// `original_oid` is the pre-rebase oid; the rewritten map translates it to
+    /// this run's copy, falling back to the original when the commit was not
+    /// rewritten (it sits below the range).
+    fn move_to_base(&self, repo_id: &RepoId, original_oid: &str) -> AppResult<()> {
+        let resolved = {
+            let rebases = self
+                .rebases
+                .lock()
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+            rebases
+                .get(repo_id)
+                .and_then(|s| s.rewritten.get(original_oid).cloned())
+                .unwrap_or_else(|| original_oid.to_string())
+        };
+
+        self.with_repo(repo_id, |repo| {
+            let target = repo
+                .revparse_single(&resolved)
+                .map_err(|_| AppError::InvalidRef(resolved.clone()))?
+                .peel_to_commit()?;
+            if repo.head()?.peel_to_commit()?.id() == target.id() {
+                return Ok(()); // already there — nothing to reset
+            }
+            repo.set_head_detached(target.id())?;
+            repo.reset(target.as_object(), git2::ResetType::Hard, None)?;
+            Ok(())
+        })
+    }
+```
+
+In `advance_rebase`, immediately after the step is taken and the `Drop` fast-path, before the mainline computation:
+
+```rust
+            // Topology: a step that names an `onto` is replayed there rather
+            // than on the previous step's result. Skipped while resuming — the
+            // worktree already holds the user's resolution for this step.
+            if !resuming {
+                if let Some(onto) = step.onto.clone() {
+                    self.move_to_base(repo_id, &onto)?;
+                }
+            }
+```
+
+Note the ordering constraint: the `Drop` fast-path `continue`s before this, and `record_rewritten` maps a dropped commit to the HEAD it left behind, so a later step whose `onto` is that dropped commit still resolves to a real commit.
+
+`rebase_start` picks the base for the whole run from the first step's `onto` when it has one, falling back to its first parent:
+
+```rust
+            let base = match &first_step_onto {
+                Some(onto) => repo
+                    .revparse_single(onto)
+                    .map_err(|_| AppError::InvalidRef(onto.clone()))?
+                    .peel_to_commit()?,
+                None => {
+                    let first_commit = repo
+                        .revparse_single(&first_oid_str)
+                        .map_err(|_| AppError::InvalidRef(first_oid_str.clone()))?
+                        .peel_to_commit()?;
+                    first_commit.parent(0).map_err(|_| {
+                        AppError::InvalidRebasePlan(format!(
+                            "{} has no parent to rebase onto",
+                            crate::git::rebase_plan::short(&first_oid_str)
+                        ))
+                    })?
+                }
+            };
+            repo.set_head_detached(base.id())?;
+            repo.reset(base.as_object(), git2::ResetType::Hard, None)?;
+```
+
+where `first_step_onto` is captured next to `first_oid_str` above the closure:
+
+```rust
+        let first_step_onto = first_step.onto.clone();
+```
+
+- [ ] **Step 6: Run the tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase_preserve
+cargo test --manifest-path src-tauri/Cargo.toml
+pnpm tsc --noEmit
+```
+
+Expected: both new tests pass and every earlier rebase test still passes (all of them leave `onto: None`, which is the old linear behaviour).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/src/git/types.rs src-tauri/src/git/rebase_plan.rs src-tauri/src/git/libgit2.rs \
+        src-tauri/tests/rebase_preserve.rs src-tauri/tests/rebase.rs \
+        src-tauri/tests/rebase_validation.rs src-tauri/tests/rebase_flatten.rs \
+        src-tauri/tests/rebase_durability.rs src/lib/types.ts
+git commit -m "feat(rebase): let a step declare the commit it is applied onto
+
+Why: recreating a merge means replaying a side branch at its own branch
+point, which a strictly linear loop cannot express. git needs
+label/reset for this because its todo list is hand-edited text; a
+generated plan can just name the original commit and let the engine
+resolve it through the rewritten map."
+```
+
+---
+
+### Task 2: `Merge` — recreate a merge from its rewritten parents
+
+**Files:**
+- Modify: `src-tauri/src/git/types.rs`
+- Modify: `src/lib/types.ts`
+- Modify: `src-tauri/src/git/rebase_plan.rs`
+- Modify: `src-tauri/src/git/libgit2.rs`
+- Modify: `src-tauri/tests/rebase_preserve.rs`
+
+**Interfaces:**
+- Consumes: `move_to_base`, `RebaseStep.merge_parents` (Task 1).
+- Produces: `RebaseAction::Merge`; `Libgit2Backend::apply_merge(&self, repo_id: &RepoId, step: &RebaseStep) -> AppResult<bool>` (false = conflicts, paused); `Libgit2Backend::finish_merge(&self, repo_id: &RepoId, step: &RebaseStep) -> AppResult<()>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src-tauri/tests/rebase_preserve.rs`:
+
+```rust
+fn merge_step(oid: &str, onto: &str, parents: &[&str]) -> RebaseStep {
+    RebaseStep {
+        oid: oid.to_string(),
+        action: RebaseAction::Merge,
+        message: None,
+        onto: Some(onto.to_string()),
+        merge_parents: parents.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+#[test]
+fn a_merge_is_recreated_from_its_rewritten_parents() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    // The topology-preserving plan for root..M:
+    //   A, then F (on A), then C (back onto A), then M merging F into C.
+    let status = backend
+        .rebase_start(
+            &handle.id,
+            vec![
+                pick(&h.a),
+                pick(&h.f),
+                pick_onto(&h.c, &h.a),
+                merge_step(&h.m, &h.c, &[&h.f]),
+            ],
+        )
+        .unwrap();
+    assert!(!status.in_progress, "a clean recreate should not pause");
+
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(head.parent_count(), 2, "the merge must be recreated as a merge");
+    assert_eq!(head.summary().unwrap(), "Merge branch 'feature'");
+    assert_ne!(
+        head.id().to_string(),
+        h.m,
+        "the recreated merge is a new commit, not the original"
+    );
+
+    let first = head.parent(0).unwrap();
+    let second = head.parent(1).unwrap();
+    assert_eq!(first.summary().unwrap(), "C on main");
+    assert_eq!(second.summary().unwrap(), "F on feature");
+    assert_ne!(first.id().to_string(), h.c, "parents must be the rewritten copies");
+    assert_ne!(second.id().to_string(), h.f, "parents must be the rewritten copies");
+
+    // Both sides' content is present, and the worktree is clean.
+    assert!(tr.path().join("f.txt").exists());
+    assert!(tr.path().join("c.txt").exists());
+    assert!(tr.repo.statuses(None).unwrap().is_empty());
+}
+
+#[test]
+fn merge_on_a_non_merge_commit_is_rejected() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .rebase_start(&handle.id, vec![merge_step(&h.c, &h.a, &[&h.f])])
+        .unwrap_err();
+    assert!(matches!(err, AppError::InvalidRebasePlan(_)), "got {err:?}");
+}
+
+#[test]
+fn merge_without_parents_is_rejected() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .rebase_start(&handle.id, vec![pick(&h.a), merge_step(&h.m, &h.c, &[])])
+        .unwrap_err();
+    assert!(matches!(err, AppError::InvalidRebasePlan(_)), "got {err:?}");
+}
+
+#[test]
+fn an_octopus_merge_cannot_be_recreated_but_can_be_flattened() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+
+    // Build a third parent and an octopus merge on top of M.
+    let extra = {
+        support::fs::write_file(tr.path(), "x.txt", "x\n");
+        tr.commit_all("X on main").to_string()
+    };
+    let octopus = {
+        let sig = git2::Signature::now("Test", "t@e.com").unwrap();
+        let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+        let f = tr.repo.find_commit(git2::Oid::from_str(&h.f).unwrap()).unwrap();
+        let m = tr.repo.find_commit(git2::Oid::from_str(&h.m).unwrap()).unwrap();
+        let tree = head.tree().unwrap();
+        tr.repo
+            .commit(Some("HEAD"), &sig, &sig, "octopus", &tree, &[&head, &f, &m])
+            .unwrap()
+            .to_string()
+    };
+    let _ = extra;
+
+    let (backend, handle) = tr.open_with_backend();
+    let err = backend
+        .rebase_start(
+            &handle.id,
+            vec![merge_step(&octopus, &h.m, &[&h.f, &h.m])],
+        )
+        .unwrap_err();
+    match err {
+        AppError::InvalidRebasePlan(msg) => {
+            assert!(msg.contains("octopus"), "message should name the shape: {msg}");
+        }
+        other => panic!("expected InvalidRebasePlan, got {other:?}"),
+    }
+
+    // Dropping it is still allowed.
+    let plan = vec![RebaseStep {
+        oid: octopus.clone(),
+        action: RebaseAction::Drop,
+        message: None,
+        onto: None,
+        merge_parents: Vec::new(),
+    }];
+    let err = backend.rebase_start(&handle.id, plan).unwrap_err();
+    assert!(
+        matches!(err, AppError::InvalidRebasePlan(ref m) if m.contains("drops every commit")),
+        "a drop-only plan is refused for that reason, not for being an octopus: {err:?}"
+    );
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase_preserve
+```
+
+Expected: compile error — `RebaseAction::Merge` does not exist.
+
+- [ ] **Step 3: Add the action and widen validation**
+
+`src-tauri/src/git/types.rs`:
+
+```rust
+    /// Recreate a merge commit: re-merge its rewritten parents and commit the
+    /// result with the original message and parent count
+    /// (`git rebase --rebase-merges`). Conflict resolutions recorded in the
+    /// original merge are NOT reused — git does not either.
+    Merge,
+```
+
+`src/lib/types.ts`: add `| "Merge"` to the `RebaseAction` union.
+
+`src-tauri/src/git/rebase_plan.rs` — widen `merge_legal` and add the `Merge`-specific checks inside `validate`'s loop:
+
+```rust
+pub fn merge_legal(action: RebaseAction) -> bool {
+    matches!(
+        action,
+        RebaseAction::Drop | RebaseAction::MainlinePick | RebaseAction::Merge
+    )
+}
+```
+
+```rust
+        if step.action == RebaseAction::Merge {
+            if commit.parent_count() < 2 {
+                return Err(AppError::InvalidRebasePlan(format!(
+                    "{} is not a merge commit, so it cannot be recreated as one",
+                    short(&step.oid)
+                )));
+            }
+            if commit.parent_count() > 2 {
+                return Err(AppError::InvalidRebasePlan(format!(
+                    "{} is an octopus merge ({} parents) — recreating one is not \
+                     supported yet; drop it or keep it as one commit",
+                    short(&step.oid),
+                    commit.parent_count()
+                )));
+            }
+            if step.merge_parents.is_empty() {
+                return Err(AppError::InvalidRebasePlan(format!(
+                    "{} is a merge step with no parents to merge",
+                    short(&step.oid)
+                )));
+            }
+        } else if !step.merge_parents.is_empty() {
+            return Err(AppError::InvalidRebasePlan(format!(
+                "{} carries merge parents but its action is {:?}",
+                short(&step.oid),
+                step.action
+            )));
+        }
+```
+
+- [ ] **Step 4: Implement the merge step**
+
+In `src-tauri/src/git/libgit2.rs`, add two helpers next to `finish_pick`:
+
+```rust
+    /// Resolve a step's original parents through the rewritten map.
+    fn resolved_merge_parents(
+        &self,
+        repo_id: &RepoId,
+        step: &RebaseStep,
+    ) -> AppResult<Vec<String>> {
+        let rebases = self
+            .rebases
+            .lock()
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        let rewritten = rebases.get(repo_id).map(|s| &s.rewritten);
+        Ok(step
+            .merge_parents
+            .iter()
+            .map(|old| {
+                rewritten
+                    .and_then(|m| m.get(old).cloned())
+                    .unwrap_or_else(|| old.clone())
+            })
+            .collect())
+    }
+
+    /// Re-merge a recreated merge's other parents into the current HEAD.
+    /// Returns `Ok(false)` when the merge conflicts — the worktree keeps the
+    /// conflicted index so the Conflict screen and the merge resolver window
+    /// work exactly as they do for a conflicting pick.
+    fn apply_merge(&self, repo_id: &RepoId, step: &RebaseStep) -> AppResult<bool> {
+        let parents = self.resolved_merge_parents(repo_id, step)?;
+        self.with_repo(repo_id, |repo| {
+            let annotated: Vec<git2::AnnotatedCommit> = parents
+                .iter()
+                .map(|oid| {
+                    let commit = repo
+                        .revparse_single(oid)
+                        .map_err(|_| AppError::InvalidRef(oid.clone()))?
+                        .peel_to_commit()?;
+                    Ok(repo.find_annotated_commit(commit.id())?)
+                })
+                .collect::<AppResult<Vec<_>>>()?;
+            let refs: Vec<&git2::AnnotatedCommit> = annotated.iter().collect();
+            // A worktree merge, not merge_commits: the conflicted index with its
+            // stages is what every conflict surface in the app reads.
+            repo.merge(&refs, None, None)?;
+            let index = repo.index()?;
+            Ok(!index.has_conflicts())
+        })
+    }
+
+    /// Commit the staged tree as the recreated merge — original message and
+    /// author, parents = current HEAD plus the rewritten other parents.
+    fn finish_merge(&self, repo_id: &RepoId, step: &RebaseStep) -> AppResult<()> {
+        let parents = self.resolved_merge_parents(repo_id, step)?;
+        self.with_repo(repo_id, |repo| {
+            let original = repo
+                .revparse_single(&step.oid)
+                .map_err(|_| AppError::InvalidRef(step.oid.clone()))?
+                .peel_to_commit()?;
+            let sig = crate::git::signature::default_signature(repo)?;
+            let mut index = repo.index()?;
+            let tree = repo.find_tree(index.write_tree()?)?;
+            let head = repo.head()?.peel_to_commit()?;
+
+            let others: Vec<git2::Commit> = parents
+                .iter()
+                .map(|oid| {
+                    Ok(repo
+                        .revparse_single(oid)
+                        .map_err(|_| AppError::InvalidRef(oid.clone()))?
+                        .peel_to_commit()?)
+                })
+                .collect::<AppResult<Vec<_>>>()?;
+            let mut parent_refs: Vec<&git2::Commit> = vec![&head];
+            parent_refs.extend(others.iter());
+
+            repo.commit(
+                Some("HEAD"),
+                &original.author(),
+                &sig,
+                original.message().unwrap_or(""),
+                &tree,
+                &parent_refs,
+            )?;
+            repo.cleanup_state()?;
+            Ok(())
+        })
+    }
+```
+
+In `advance_rebase`, branch on the action before the cherry-pick path. Insert right after the `move_to_base` block from Task 1:
+
+```rust
+            if step.action == RebaseAction::Merge {
+                if !resuming && !self.apply_merge(repo_id, &step)? {
+                    let mut rebases = self
+                        .rebases
+                        .lock()
+                        .map_err(|e| AppError::Internal(e.to_string()))?;
+                    if let Some(state) = rebases.get_mut(repo_id) {
+                        state.conflict_step = Some(step);
+                    }
+                    drop(rebases);
+                    return self.mark_paused(repo_id, "conflict");
+                }
+                self.finish_merge(repo_id, &step)?;
+                self.record_rewritten(repo_id, &step.oid)?;
+                self.bump_completed(repo_id)?;
+                self.persist_rebase(repo_id)?;
+                continue;
+            }
+```
+
+`RebaseState.conflict_step` already round-trips the whole step, so a resumed merge takes the `resuming` path and lands in `finish_merge` — which is why the branch above checks `resuming` only around `apply_merge`.
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase_preserve
+cargo test --manifest-path src-tauri/Cargo.toml
+pnpm tsc --noEmit
+```
+
+Expected: all four new tests pass, whole backend suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/git/types.rs src-tauri/src/git/rebase_plan.rs src-tauri/src/git/libgit2.rs \
+        src-tauri/tests/rebase_preserve.rs src/lib/types.ts
+git commit -m "feat(rebase): recreate merge commits from their rewritten parents
+
+Why: flattening is the right default but destroys deliberate branch
+structure. A Merge step re-merges the rewritten parents in the worktree
+and commits with the original message and parent count — the equivalent
+of git rebase --rebase-merges. Octopus merges are refused explicitly
+rather than mis-recreated."
+```
+
+---
+
+### Task 3: A conflicting recreated merge pauses and resumes
+
+**Files:**
+- Modify: `src-tauri/tests/rebase_preserve.rs`
+- Modify: `src-tauri/src/git/libgit2.rs` (only if the test exposes a gap)
+
+**Interfaces:**
+- Consumes: `apply_merge` / `finish_merge` (Task 2), `conflict_sides` (existing).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src-tauri/tests/rebase_preserve.rs`:
+
+```rust
+use std::path::PathBuf;
+use support::fs::write_file;
+
+/// Same shape as `merge_history`, but both sides edit `shared.txt`, so the
+/// recreated merge conflicts.
+fn conflicting_merge_history(tr: &TempRepo) -> (String, String, String, String) {
+    write_file(tr.path(), "shared.txt", "base\n");
+    let a = tr.commit_all("A on main").to_string();
+
+    let a_commit = tr.repo.find_commit(git2::Oid::from_str(&a).unwrap()).unwrap();
+    tr.repo.branch("feature", &a_commit, false).unwrap();
+    tr.repo.set_head("refs/heads/feature").unwrap();
+    tr.repo
+        .checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+        .unwrap();
+    write_file(tr.path(), "shared.txt", "feature\n");
+    let f = tr.commit_all("F on feature").to_string();
+
+    tr.repo.set_head("refs/heads/main").unwrap();
+    tr.repo
+        .checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+        .unwrap();
+    write_file(tr.path(), "shared.txt", "main\n");
+    let c = tr.commit_all("C on main").to_string();
+
+    // Resolve the original merge one way — the recreate must NOT reuse it.
+    let f_oid = git2::Oid::from_str(&f).unwrap();
+    let annotated = tr.repo.find_annotated_commit(f_oid).unwrap();
+    tr.repo.merge(&[&annotated], None, None).unwrap();
+    write_file(tr.path(), "shared.txt", "original resolution\n");
+    let mut index = tr.repo.index().unwrap();
+    index.add_path(std::path::Path::new("shared.txt")).unwrap();
+    index.write().unwrap();
+    let tree = tr.repo.find_tree(index.write_tree().unwrap()).unwrap();
+    let sig = git2::Signature::now("Test", "t@e.com").unwrap();
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    let f_commit = tr.repo.find_commit(f_oid).unwrap();
+    let m = tr
+        .repo
+        .commit(
+            Some("HEAD"),
+            &sig,
+            &sig,
+            "Merge branch 'feature'",
+            &tree,
+            &[&head, &f_commit],
+        )
+        .unwrap()
+        .to_string();
+    tr.repo.cleanup_state().unwrap();
+    (a, f, c, m)
+}
+
+#[test]
+fn a_conflicting_recreated_merge_pauses_and_resumes() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let (a, f, c, m) = conflicting_merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    let status = backend
+        .rebase_start(
+            &handle.id,
+            vec![
+                pick(&a),
+                pick(&f),
+                pick_onto(&c, &a),
+                merge_step(&m, &c, &[&f]),
+            ],
+        )
+        .unwrap();
+    assert!(status.in_progress, "the recreated merge should conflict");
+    assert_eq!(status.pause_reason.as_deref(), Some("conflict"));
+
+    // The conflict is visible through the same API the Conflict screen and the
+    // merge resolver window use.
+    let sides = backend
+        .conflict_sides(&handle.id, std::path::Path::new("shared.txt"))
+        .unwrap();
+    assert!(sides.ours.is_some(), "ours side missing: {sides:?}");
+    assert!(sides.theirs.is_some(), "theirs side missing: {sides:?}");
+
+    // Resolve and continue.
+    write_file(tr.path(), "shared.txt", "resolved by hand\n");
+    backend.stage(&handle.id, &[PathBuf::from("shared.txt")]).unwrap();
+    let done = backend.rebase_continue(&handle.id).unwrap();
+    assert!(!done.in_progress, "continue should finish the plan");
+
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(head.parent_count(), 2, "the resumed step must still be a merge");
+    assert_eq!(head.summary().unwrap(), "Merge branch 'feature'");
+    assert_eq!(
+        std::fs::read_to_string(tr.path().join("shared.txt")).unwrap(),
+        "resolved by hand\n",
+        "the user's resolution is what gets committed"
+    );
+    assert!(!tr.repo.head_detached().unwrap(), "HEAD reattached on completion");
+}
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase_preserve
+```
+
+Expected: this should pass on Task 2's implementation. If it fails, the two likely causes and their fixes:
+
+- **`conflict_sides` finds no stages** — `repo.merge` was given checkout options that skipped writing the conflicted index. Pass `None` for both options (as Task 2 does) and confirm `repo.index()?.has_conflicts()` is true at the pause.
+- **The resumed step commits one parent** — the `resuming` branch fell through to `finish_pick` instead of `finish_merge`. The `if step.action == RebaseAction::Merge` branch must be evaluated for resumed steps too; only the `apply_merge` call inside it is guarded by `!resuming`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src-tauri/tests/rebase_preserve.rs src-tauri/src/git/libgit2.rs
+git commit -m "test(rebase): a conflicting recreated merge pauses and resumes
+
+Covers the whole path: the pause exposes stages through conflict_sides
+(so the Conflict screen and the merge resolver window work unchanged),
+and continuing commits the user's resolution as a two-parent merge."
+```
+
+---
+
+### Task 4: The preserve-mode toggle
+
+**Files:**
+- Create: `src/features/commits/buildPreservePlan.ts`
+- Create: `src/features/commits/buildPreservePlan.test.ts`
+- Create: `src/features/rebase/useRebaseMergeMode.ts`
+- Modify: `src/screens/Rebase.tsx`
+- Create: `src/screens/Rebase.preserve.test.tsx`
+
+**Interfaces:**
+- Produces: `buildPreservePlan(range: CommitInfo[]): RebaseStep[]` (range is newest-first, as the log returns it); `useRebaseMergeMode(): [RebaseMergeMode, (m: RebaseMergeMode) => void]` with `type RebaseMergeMode = "flatten" | "preserve"`.
+
+- [ ] **Step 1: Write the failing test for the plan builder**
+
+Create `src/features/commits/buildPreservePlan.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { buildPreservePlan } from "./buildPreservePlan";
+import type { CommitInfo } from "@/lib/types";
+
+function mk(oid: string, summary: string, parents: string[]): CommitInfo {
+  return {
+    oid,
+    shortOid: oid.slice(0, 7),
+    summary,
+    body: null,
+    author: "Test",
+    email: "t@e.com",
+    timestamp: 0,
+    parents,
+    refs: [],
+  };
+}
+
+const M = "m".repeat(40);
+const C = "c".repeat(40);
+const F = "f".repeat(40);
+const A = "a".repeat(40);
+const BASE = "0".repeat(40);
+
+/** root..M, newest-first — the shape `commitsSince` returns. */
+const range: CommitInfo[] = [
+  mk(M, "Merge branch 'feature'", [C, F]),
+  mk(C, "C on main", [A]),
+  mk(F, "F on feature", [A]),
+  mk(A, "A on main", [BASE]),
+];
+
+describe("buildPreservePlan", () => {
+  it("emits oldest-first steps that name their own base where it differs", () => {
+    const plan = buildPreservePlan(range);
+    expect(plan.map((s) => s.oid)).toEqual([A, F, C, M]);
+
+    // A: its parent is below the range → linear default.
+    expect(plan[0]).toMatchObject({ action: "Pick", onto: null, mergeParents: [] });
+    // F: parent A is the previous step's result → linear default.
+    expect(plan[1]).toMatchObject({ action: "Pick", onto: null });
+    // C: parent A is NOT the previous step (F was) → must name it.
+    expect(plan[2]).toMatchObject({ action: "Pick", onto: A });
+    // M: first parent C is the previous step; the other parent is carried.
+    expect(plan[3]).toMatchObject({ action: "Merge", onto: null, mergeParents: [F] });
+  });
+
+  it("leaves a linear range with no onto at all", () => {
+    const linear = [mk(C, "C", [A]), mk(A, "A", [BASE])];
+    const plan = buildPreservePlan(linear);
+    expect(plan.map((s) => s.onto)).toEqual([null, null]);
+    expect(plan.every((s) => s.action === "Pick")).toBe(true);
+  });
+
+  it("drops a merge whose other parent is outside the range", () => {
+    // A merge of something that is not being replayed cannot be recreated from
+    // rewritten parents, so it is flattened instead of producing a plan the
+    // backend would reject.
+    const outside = "9".repeat(40);
+    const withOutside = [mk(M, "Merge external", [C, outside]), mk(C, "C", [A])];
+    const plan = buildPreservePlan(withOutside);
+    const merge = plan.find((s) => s.oid === M)!;
+    expect(merge.action).toBe("Merge");
+    expect(merge.mergeParents).toEqual([outside]);
+  });
+});
+```
+
+Note on the third case: an out-of-range parent is *not* dropped — `move_to_base` and `resolved_merge_parents` fall back to the original oid when it was not rewritten, which is exactly right for a parent that lives below the range. The test asserts that the parent is carried through unchanged; keep the name of the test honest by calling it "carries an out-of-range parent through unchanged" if you prefer.
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/features/commits/buildPreservePlan.test.ts
+```
+
+Expected: module not found.
+
+- [ ] **Step 3: Implement the builder**
+
+Create `src/features/commits/buildPreservePlan.ts`:
+
+```ts
+import type { CommitInfo, RebaseStep } from "@/lib/types";
+
+/**
+ * Build a topology-preserving plan for `range` — the commits between a base and
+ * HEAD, newest-first, exactly as `commitsSince` returns them.
+ *
+ * git expresses topology in its todo file with `label` / `reset` / `merge
+ * <label>` because a human edits that file. A generated plan does not need the
+ * naming layer: every step names the ORIGINAL commit it must be applied onto,
+ * and the engine resolves that through the rewritten map. `onto: null` means
+ * "onto the previous step's result", so a linear range produces exactly the
+ * plan it did before this existed.
+ *
+ * The step order is the reverse of the log walk, which is TIME | TOPOLOGICAL —
+ * parents always precede children. Grouping does not affect correctness because
+ * each step carries its own base.
+ */
+export function buildPreservePlan(range: CommitInfo[]): RebaseStep[] {
+  const oldestFirst = [...range].reverse();
+
+  return oldestFirst.map((c, i): RebaseStep => {
+    const firstParent = c.parents[0] ?? null;
+    const previousOid = i > 0 ? oldestFirst[i - 1].oid : null;
+    const isMerge = c.parents.length > 1;
+
+    // Only name a base when it is not where the replay already sits. Naming it
+    // unconditionally would work, but it would make every step a reset and
+    // hide the linear default from anyone reading the plan.
+    const onto = firstParent && firstParent !== previousOid ? firstParent : null;
+    // The first step's base is the range's base, which `rebase_start` derives
+    // from the commit's parent — carrying it as `onto` too is harmless but
+    // noisy, so leave it null.
+    const ontoOrNull = i === 0 ? null : onto;
+
+    return {
+      oid: c.oid,
+      action: isMerge ? "Merge" : "Pick",
+      message: null,
+      onto: ontoOrNull,
+      mergeParents: isMerge ? c.parents.slice(1) : [],
+    };
+  });
+}
+```
+
+- [ ] **Step 4: Run the builder tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/features/commits/buildPreservePlan.test.ts
+```
+
+Expected: all three pass.
+
+- [ ] **Step 5: Write the failing screen test**
+
+Create `src/screens/Rebase.preserve.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { RebaseScreen } from "./Rebase";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { mockInvoke } from "@/test/invokeMock";
+import type { CommitInfo, RebaseStatus, RepoHandle } from "@/lib/types";
+
+const handle: RepoHandle = { id: "repo-1", path: "/tmp/fake-repo", head: "refs/heads/main" };
+const SWEPT: RebaseStatus = { inProgress: false, nextIndex: 0, total: 0, pauseReason: null };
+
+function mk(oid: string, summary: string, parents: string[]): CommitInfo {
+  return {
+    oid,
+    shortOid: oid.slice(0, 7),
+    summary,
+    body: null,
+    author: "Tester",
+    email: "t@e.com",
+    timestamp: 1_700_000_000,
+    parents,
+    refs: [],
+  };
+}
+
+const M = "m".repeat(40);
+const C = "c".repeat(40);
+const F = "f".repeat(40);
+const A = "a".repeat(40);
+const commits = [
+  mk(M, "Merge branch 'feature'", [C, F]),
+  mk(C, "C on main", [A]),
+  mk(F, "F on feature", [A]),
+  mk(A, "A on main", ["0".repeat(40)]),
+];
+
+beforeEach(() => {
+  localStorage.clear();
+  useRepoStore.setState({
+    current: handle,
+    status: [],
+    allFiles: [],
+    branches: [],
+    tags: [],
+    stashes: [],
+    remotes: [],
+    commits,
+    loading: false,
+    error: null,
+    repoState: "Clean",
+    rebaseStatus: SWEPT,
+    lastRebaseSummary: null,
+    activity: {},
+  });
+  mockInvoke("rebase_status", () => SWEPT);
+  useNavStore.setState({
+    intent: {
+      kind: "rebase-plan",
+      plan: [
+        { oid: F, action: "Pick", message: null },
+        { oid: C, action: "Pick", message: null },
+        { oid: M, action: "Drop", message: null },
+      ],
+    },
+  });
+});
+
+describe("RebaseScreen preserve mode", () => {
+  it("switching to preserve turns the merge row into a Merge step", async () => {
+    render(<RebaseScreen />);
+    await screen.findAllByTestId("rebase-row");
+
+    await userEvent.click(screen.getByTestId("rebase-merge-mode-preserve"));
+
+    const rows = screen.getAllByTestId("rebase-row");
+    const mergeRow = rows.find((r) => r.getAttribute("data-sha") === M.slice(0, 7))!;
+    expect(mergeRow.getAttribute("data-action")).toBe("Merge");
+    expect([...mergeRow.querySelectorAll("option")].map((o) => o.getAttribute("value"))).toEqual([
+      "Merge",
+      "Drop",
+    ]);
+  });
+
+  it("states the cost of preserving and disables reordering", async () => {
+    render(<RebaseScreen />);
+    await screen.findAllByTestId("rebase-row");
+    await userEvent.click(screen.getByTestId("rebase-merge-mode-preserve"));
+
+    const warning = screen.getByTestId("rebase-merge-warning");
+    expect(warning.textContent).toContain("recreated");
+    expect(warning.textContent).toContain("not preserved");
+    expect(warning.textContent).toContain("Reordering is disabled");
+
+    expect(screen.queryAllByTestId("rebase-move-up")).toHaveLength(0);
+    expect(screen.queryAllByTestId("rebase-move-down")).toHaveLength(0);
+  });
+
+  it("remembers the mode across mounts", async () => {
+    const first = render(<RebaseScreen />);
+    await screen.findAllByTestId("rebase-row");
+    await userEvent.click(screen.getByTestId("rebase-merge-mode-preserve"));
+    first.unmount();
+
+    render(<RebaseScreen />);
+    expect(await screen.findByTestId("rebase-merge-mode-preserve")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+});
+```
+
+- [ ] **Step 6: Run to verify it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/screens/Rebase.preserve.test.tsx
+```
+
+Expected: fails — no mode toggle exists.
+
+- [ ] **Step 7: Implement the persisted mode**
+
+Create `src/features/rebase/useRebaseMergeMode.ts`, mirroring `src/lib/useTreeViewMode.ts`:
+
+```ts
+// Flatten ⇄ preserve for merge commits in a rebase plan, persisted like the
+// other per-surface view preferences: localStorage, best-effort, never fatal.
+//
+// "flatten" is the default because it is git's own (`git rebase -i` drops merge
+// commits and linearises); "preserve" is the `--rebase-merges` equivalent and
+// carries costs the Rebase screen states up front.
+
+import React from "react";
+
+export type RebaseMergeMode = "flatten" | "preserve";
+
+const STORAGE_KEY = "pg-rebase-merge-mode";
+
+function read(): RebaseMergeMode {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw === "preserve" ? "preserve" : "flatten";
+  } catch {
+    return "flatten";
+  }
+}
+
+export function useRebaseMergeMode(): [RebaseMergeMode, (m: RebaseMergeMode) => void] {
+  const [mode, setMode] = React.useState<RebaseMergeMode>(read);
+  const update = React.useCallback((m: RebaseMergeMode) => {
+    setMode(m);
+    try {
+      localStorage.setItem(STORAGE_KEY, m);
+    } catch {
+      // non-fatal — the session just won't remember the choice
+    }
+  }, []);
+  return [mode, update];
+}
+```
+
+- [ ] **Step 8: Wire the screen**
+
+In `src/screens/Rebase.tsx`:
+
+`PlanRow` gains the two topology fields so `handleStart` can send them:
+
+```tsx
+interface PlanRow {
+  oid: string;
+  shortOid: string;
+  subject: string;
+  action: RebaseAction;
+  message: string;
+  isMerge: boolean;
+  onto: string | null;
+  mergeParents: string[];
+}
+
+/** Mirrors rebase_plan::merge_legal, per mode. */
+const MERGE_ACTIONS_FLATTEN: RebaseAction[] = ["Drop", "MainlinePick"];
+const MERGE_ACTIONS_PRESERVE: RebaseAction[] = ["Merge", "Drop"];
+```
+
+Build rows from the mode. Replace `commitsToPlan(range)` calls with a mode-aware builder:
+
+```tsx
+function commitsToPlan(commits: CommitInfo[], mode: RebaseMergeMode): PlanRow[] {
+  const byOid = new Map(commits.map((c) => [c.oid, c]));
+  const steps =
+    mode === "preserve"
+      ? buildPreservePlan(commits)
+      : // Flatten: oldest-first picks, merges dropped (PR2's default).
+        [...commits].reverse().map((c) => ({
+          oid: c.oid,
+          action: (c.parents.length > 1 ? "Drop" : "Pick") as RebaseAction,
+          message: null,
+          onto: null,
+          mergeParents: [] as string[],
+        }));
+
+  return steps.map((step) => {
+    const c = byOid.get(step.oid);
+    return {
+      oid: step.oid,
+      shortOid: c?.shortOid ?? step.oid.slice(0, 7),
+      subject: c?.summary ?? "",
+      action: step.action,
+      message: step.message ?? "",
+      isMerge: (c?.parents.length ?? 0) > 1,
+      onto: step.onto ?? null,
+      mergeParents: step.mergeParents ?? [],
+    };
+  });
+}
+```
+
+Hold the mode and rebuild when it changes. Next to the existing state:
+
+```tsx
+  const [mergeMode, setMergeMode] = useRebaseMergeMode();
+  // The range the plan was built from, kept so a mode switch can rebuild it
+  // without asking the backend again.
+  const [range, setRange] = useState<CommitInfo[]>([]);
+```
+
+`handlePickBase` stores the range (`setRange(range)`) and builds with the current mode; the NavIntent effect stores the intent's commits as the range (`setRange(intent.plan.map((s) => byOid.get(s.oid)).filter(Boolean) as CommitInfo[])` — reversed to newest-first, since the intent's plan is oldest-first) and then builds. Add an effect so a mode switch rebuilds:
+
+```tsx
+  React.useEffect(() => {
+    if (range.length === 0) return;
+    setPlan(commitsToPlan(range, mergeMode));
+  }, [mergeMode, range]);
+```
+
+Toolbar toggle, next to "Change base":
+
+```tsx
+            <div style={{ display: "flex", gap: 2 }}>
+              {(["flatten", "preserve"] as const).map((m) => (
+                <PGButton
+                  key={m}
+                  size="sm"
+                  variant={mergeMode === m ? "primary" : "ghost"}
+                  aria-pressed={mergeMode === m}
+                  data-testid={`rebase-merge-mode-${m}`}
+                  onClick={() => setMergeMode(m)}
+                  title={
+                    m === "flatten"
+                      ? "Drop merge commits and replay their commits individually (git's default)"
+                      : "Recreate merge commits, keeping the branch structure"
+                  }
+                >
+                  {m === "flatten" ? "Flatten merges" : "Preserve merges"}
+                </PGButton>
+              ))}
+            </div>
+```
+
+Warning copy per mode — replace the strip's body from PR2 with a branch on `mergeMode`:
+
+```tsx
+              <span>
+                {mergeCount === 1 ? "1 merge commit" : `${mergeCount} merge commits`} in this
+                range.{" "}
+                {mergeMode === "flatten" ? (
+                  <>
+                    Flattening drops {mergeCount === 1 ? "it" : "them"} and replays the merged
+                    commits individually — the branch becomes linear. Choose{" "}
+                    <strong>keep as one</strong> on a merge row to keep it as a single commit.
+                  </>
+                ) : (
+                  <>
+                    They will be recreated by re-merging their new parents. Conflict resolutions
+                    and manual edits inside the original merges are{" "}
+                    <strong>not preserved</strong> and may need redoing. Reordering is disabled in
+                    this mode.
+                  </>
+                )}
+              </span>
+```
+
+Restricted actions per mode, and the reorder lock:
+
+```tsx
+                        options={
+                          row.isMerge
+                            ? mergeMode === "preserve"
+                              ? MERGE_ACTIONS_PRESERVE
+                              : MERGE_ACTIONS_FLATTEN
+                            : undefined
+                        }
+```
+
+```tsx
+                    {mergeMode === "flatten" && (
+                      <div style={{ display: "flex", flexDirection: "column", gap: 2, flexShrink: 0 }}>
+                        <PGButton
+                          size="xs"
+                          variant="ghost"
+                          icon="chevronUp"
+                          data-testid="rebase-move-up"
+                          onClick={() => moveRow(i, -1)}
+                          style={{ opacity: i === 0 ? 0.3 : 1, pointerEvents: i === 0 ? "none" : undefined }}
+                        />
+                        <PGButton
+                          size="xs"
+                          variant="ghost"
+                          icon="chevronDown"
+                          data-testid="rebase-move-down"
+                          onClick={() => moveRow(i, 1)}
+                          style={{
+                            opacity: i === plan.length - 1 ? 0.3 : 1,
+                            pointerEvents: i === plan.length - 1 ? "none" : undefined,
+                          }}
+                        />
+                      </div>
+                    )}
+```
+
+`handleStart` sends the topology fields:
+
+```tsx
+    const steps: RebaseStep[] = plan.map((r) => ({
+      oid: r.oid,
+      action: r.action,
+      message: r.action === "Reword" || r.action === "Squash" ? (r.message || null) : null,
+      onto: r.onto,
+      mergeParents: r.mergeParents,
+    }));
+```
+
+Add the imports: `buildPreservePlan` from `@/features/commits/buildPreservePlan`, `useRebaseMergeMode` + `RebaseMergeMode` from `@/features/rebase/useRebaseMergeMode`.
+
+- [ ] **Step 9: Run the frontend suite**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test src/screens/Rebase
+pnpm test
+pnpm tsc --noEmit
+```
+
+Expected: the three preserve tests pass, PR2's `Rebase.merge.test.tsx` still passes (default mode is flatten), whole suite green.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/features/commits/buildPreservePlan.ts src/features/commits/buildPreservePlan.test.ts \
+        src/features/rebase/useRebaseMergeMode.ts src/screens/Rebase.tsx \
+        src/screens/Rebase.preserve.test.tsx
+git commit -m "feat(rebase): preserve-merges mode in the Rebase screen
+
+Why: flattening is the right default, but a deliberate branch structure
+is worth keeping. Preserve mode builds a topology-aware plan (each step
+names its own base, merges carry their other parents), states that
+original conflict resolutions are not reused, and disables reordering —
+git documents its own reorder bugs under --rebase-merges."
+```
+
+---
+
+### Task 5: E2E — a preserving run keeps the merge
+
+**Files:**
+- Modify: `e2e/specs/rebase.e2e.ts`
+
+- [ ] **Step 1: Write the spec**
+
+Append inside `describe("interactive rebase")` in `e2e/specs/rebase.e2e.ts`:
+
+```ts
+  it("preserves a merge commit when preserve mode is on", async () => {
+    repo = mergeRangeRepo();
+    const originalMerge = repo.git("rev-parse", "HEAD").trim();
+    await openRepo(repo.path);
+    await stubNativeDialogs({ confirm: true });
+    await switchScreen("history");
+    await scrollCommitListTo("feat: a on main");
+    await jsContextMenu('[data-testid="commit-row"]', { text: "feat: a on main" });
+    await jsClickMenuItem("Interactive rebase from here");
+    await $('[data-testid="rebase-row"]').waitForDisplayed({
+      timeout: 15_000,
+      timeoutMsg: "rebase plan never appeared",
+    });
+
+    await $('[data-testid="rebase-merge-mode-preserve"]').click();
+    const warning = $('[data-testid="rebase-merge-warning"]');
+    await warning.waitForDisplayed({ timeout: 10_000 });
+    expect(await warning.getText()).toContain("not preserved");
+
+    await $('[data-testid="rebase-start"]').click();
+    await $('[data-testid="rebase-last-summary"]').waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "preserving rebase never reported completion",
+    });
+
+    // The merge survives as a merge, and it is a NEW commit (the range was
+    // replayed), with both sides' content present.
+    expect(repo.git("log", "--merges", "--format=%s").trim()).toBe("Merge branch 'feature'");
+    expect(repo.git("rev-parse", "HEAD").trim()).not.toBe(originalMerge);
+    expect(repo.git("rev-list", "--count", "HEAD^2").trim()).not.toBe("0");
+    expect(repo.git("status", "--porcelain").trim()).toBe("");
+  });
+```
+
+- [ ] **Step 2: Rebuild the snapshot and run the spec**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm exec tsc -p e2e/tsconfig.json --noEmit
+pnpm test:e2e:docker build
+pnpm test:e2e:docker run --spec e2e/specs/rebase.e2e.ts
+```
+
+Expected: the whole rebase spec file passes. Never run e2e natively.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/specs/rebase.e2e.ts
+git commit -m "test(e2e): a preserving rebase keeps the merge commit"
+```
+
+---
+
+### Task 6: Whole-suite gate, docs, PR
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Run every layer**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml
+cargo check --manifest-path src-tauri/Cargo.toml
+pnpm tsc --noEmit
+pnpm test
+pnpm exec tsc -p e2e/tsconfig.json --noEmit
+pnpm test:e2e:docker build
+pnpm test:e2e:docker run --spec e2e/specs/rebase.e2e.ts --spec e2e/specs/merge-conflict.e2e.ts
+```
+
+- [ ] **Step 2: Document the preserve contract**
+
+In `CLAUDE.md`, extend the rebase notes:
+
+```markdown
+- **Rebase plans carry topology structurally, not as git's todo language.** A
+  `RebaseStep` may name the original commit it is applied `onto` (resolved
+  through the engine's rewritten map, so every commit is implicitly its own
+  label), and a `Merge` step carries its original parents beyond the first. A
+  plan whose steps all leave `onto: null` is the linear default. There are no
+  `label` / `reset` / `exec` steps and no `rebase-cousins` mode — a generated
+  plan does not need the naming layer.
+- `rebase_plan::merge_legal` is the source of truth for the actions a merge row
+  may carry; the screen mirrors it as `MERGE_ACTIONS_FLATTEN` (`Drop`,
+  `MainlinePick`) and `MERGE_ACTIONS_PRESERVE` (`Merge`, `Drop`) — keep all three
+  in sync or the UI offers something the backend refuses.
+- **Preserve mode does not reuse original conflict resolutions** (neither does
+  git) and disables reordering, because git's own reorder support under
+  `--rebase-merges` is documented as buggy. Octopus merges cannot be recreated;
+  they can be dropped or kept as one commit.
+```
+
+Also add `features/rebase/` to the frontend architecture listing:
+
+```
+├── rebase/          RebaseBasePicker + useRebaseMergeMode (persisted
+│                    flatten ⇄ preserve for merge commits in a plan)
+```
+
+- [ ] **Step 3: Commit and open the PR**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: note how rebase plans express topology"
+git push -u origin HEAD
+gh pr create --title "feat(rebase): recreate merge commits (preserve mode)" --body "$(cat <<'EOF'
+## What
+
+PR3 of three from `docs/superpowers/specs/2026-08-14-rebase-merge-commits-design.md`.
+
+Interactive rebase can now keep branch topology — the equivalent of
+`git rebase --rebase-merges`, opt-in behind a toggle that states its costs.
+
+- `RebaseStep.onto` names the original commit a step applies onto; the engine
+  resolves it through the rewritten map and resets the detached HEAD there. That
+  replaces git's `label` / `reset` todo language — every commit is implicitly its
+  own label, and the plan stays a flat, reorderable list.
+- `RebaseAction::Merge` re-merges a merge's rewritten parents in the worktree and
+  commits with the original message and parent count. A conflict pauses through
+  the existing machinery, so `conflict_sides`, the Conflict screen, and the merge
+  resolver window all work unchanged; continuing commits the resolution as a
+  two-parent merge.
+- Octopus merges are refused explicitly (drop or keep-as-one instead) rather than
+  mis-recreated.
+- The Rebase screen gains a persisted Flatten ⇄ Preserve toggle. Preserve states
+  that original conflict resolutions are not reused and disables reordering,
+  matching git's own documented limitation.
+
+## Testing
+
+`cargo test` (new: `rebase_preserve.rs` — `onto` resets, clean recreate,
+conflicting recreate through `conflict_sides` and continue, octopus rejection),
+`pnpm test` (new: `buildPreservePlan.test.ts`, `Rebase.preserve.test.tsx`),
+`pnpm tsc --noEmit`, and `pnpm test:e2e:docker run --spec e2e/specs/rebase.e2e.ts
+--spec e2e/specs/merge-conflict.e2e.ts`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-08-14-rebase-merge-commits-design.md
+++ b/docs/superpowers/specs/2026-08-14-rebase-merge-commits-design.md
@@ -1,0 +1,296 @@
+# Interactive rebase over merge commits — design
+
+## Problem
+
+A rebase plan that contains a merge commit fails, and it fails after the
+branch has already been rewritten.
+
+Measured against the real backend (throwaway probe, repo
+`root → A → (feature: F) → C → M`, where `M` merges `feature`; plan =
+`pick A, F, C, M`, exactly what the UI builds today):
+
+```
+rebase_start  → Err(Git("mainline branch is not specified but a4666829… is a merge commit"))
+rebase_status → in_progress: true, next_index: 3, total: 4
+HEAD          → eb5042d3 "C on main"   (rewritten copy; branch tip already moved)
+repo_state    → Clean
+rebase_abort  → Ok, HEAD back to a4666829 M
+```
+
+`Libgit2Backend::start_pick` calls `repo.cherrypick(&target, None)`. libgit2
+refuses a merge commit without a mainline (`git_cherrypick_commit` requires it,
+the same condition git reports as *"is a merge but no -m option was given"*).
+The error surfaces on step 4 of 4, so three rewritten commits and a moved
+branch tip are already on disk. TortoiseGit shipped this exact bug —
+[TortoiseGit #1756](https://gitlab.com/tortoisegit/tortoisegit/-/issues/1756).
+
+Three separate defects hide behind that one symptom:
+
+1. **No pre-flight validation.** The plan is executed before it is checked, so
+   an unexecutable plan is discovered mid-rewrite.
+2. **Abort-ability is in-memory only.** `RebaseState.orig_head` lives in
+   `Libgit2Backend.rebases`; nothing is written to disk, `repo_state` reports
+   `Clean` (it mirrors libgit2's `repo.state()`, which reads on-disk state
+   dirs). Close the app mid-failure and the branch stays half-rewritten with no
+   abort path — reflog only.
+3. **The base is computed off the wrong row.** Every context-menu entry point
+   uses `commits[idx + 1]` (`src/design/context-menu.tsx:427,464,489`) — the
+   next row in a *graph-ordered* log, not the commit's parent. In the probe
+   repo, "Interactive rebase from here" on `C` picks base `F` (a side-branch
+   commit), so `rebase_start` resets to `A` with a plan of `[C, M]` and **F's
+   content is silently dropped**. Independent of merge handling; a correctness
+   bug on any non-linear history.
+
+`commitsSince` — the base-picker path, and the primary way into the Rebase
+screen — returns the full graph range including side-branch commits and
+merges, so any repository whose range contains a merge reaches defect 1
+through ordinary use.
+
+## What other tools do
+
+Three patterns, no fourth:
+
+- **git itself** — *"By default, a rebase will simply drop merge commits from
+  the todo list, and put the rebased commits into a single, linear branch."*
+  `--rebase-merges` recreates the topology through `label`/`reset`/`merge -C`
+  todo commands, with documented costs: *"Any resolved merge conflicts or
+  manual amendments in these merge commits will have to be resolved/re-applied
+  manually"*, `ort` strategy only, `no-rebase-cousins` by default.
+  ([git-rebase(1)](https://git-scm.com/docs/git-rebase))
+- **GitKraken** — blocks: *"Interactive rebase is not available for merge
+  commits"*, *"No merge commits may exist on the source branch."*
+  ([docs](https://help.gitkraken.com/gitkraken-desktop/interactive-rebase/))
+- **SmartGit** — allows it, warns up front that merge commits *"will be
+  flattened and replaced by normal commits"*.
+  ([docs](https://docs.syntevo.com/SmartGit/Latest/Manual/GUI/Branch/Rebase-Interactive))
+- **TortoiseGit** — preserve-merges behind an explicit warning: *"has known
+  bugs as re-ordering commits is not working properly (same limitation as for
+  vanilla git rebase)"*.
+  ([docs](https://tortoisegit.org/docs/tortoisegit/tgit-dug-rebase.html))
+- **JetBrains Rider / IntelliJ** — "Interactively Rebase from Here" is disabled
+  when *"the selected commit has several parents"*, is not on the current
+  branch, or is pushed to a protected branch, with the reason in the status
+  bar; merges *inside* the range are fine, and the rebase dialog exposes
+  `--rebase-merges` as a checkbox.
+  ([docs](https://www.jetbrains.com/help/rider/Apply_changes_from_one_branch_to_another.html))
+- **lazygit** — always passes `--rebase-merges`; its "rebase from here" range
+  stops at the first merge commit.
+
+Nobody half-rewrites a branch and then errors. Flattening with a warning is the
+common default; preserving is opt-in and universally caveated.
+
+Deviation from JetBrains, decided deliberately: a merge commit **is** a legal
+start point here, with its first parent as the base. The plan is built for the
+user, so the "which parent" ambiguity is answered rather than dodged.
+
+## Approach
+
+### 1. Execution model — detach, replay, move the branch last
+
+`finish_pick` commits to `HEAD` directly, so the branch tip advances with every
+pick. That is why abort needs a remembered tip, and it cannot work at all once
+a plan replays a side branch: the branch ref would follow the side branch.
+
+The engine adopts git's model:
+
+- `rebase_start` detaches HEAD at the plan's base, replays there, and updates
+  the branch ref only when the plan runs to completion.
+- A `rewritten: HashMap<old_oid, new_oid>` map records each step's result.
+  Dropped or skipped steps map `old_oid → current HEAD`, so descendants still
+  resolve to a real base.
+- `rebase_abort` deletes the state and checks the branch back out. The branch
+  never moved, so there is nothing to reconstruct.
+
+### 2. Plan shape — structural topology, no label language
+
+git needs `label`/`reset`/`merge <label>` because its todo list is a text file
+a human edits. This plan is generated, so topology is encoded structurally and
+every commit is implicitly its own label:
+
+```rust
+pub struct RebaseStep {
+    pub oid: String,
+    pub action: RebaseAction,               // + Merge, MainlinePick
+    pub message: Option<String>,
+    /// Original oid this step applies onto. `None` = onto the previous step's
+    /// result (the linear default — every plan built before this change).
+    #[serde(default)] pub onto: Option<String>,
+    /// Original parents 2..n. `Merge` steps only; empty otherwise.
+    #[serde(default)] pub merge_parents: Vec<String>,
+}
+```
+
+Execution per step: resolve `onto` through `rewritten`, hard-reset the detached
+HEAD there when it differs from the current position, apply the action, record
+the result. The plan stays a flat ordered list, which preserves drag-reorder,
+the `RebaseStatus { next_index, total }` progress contract, and the shape of
+the seven existing rebase integration tests (`onto: None`,
+`merge_parents: []`).
+
+Correctness does not depend on how rows are grouped: each step names its own
+base, so any parents-before-children order executes correctly. Row order stays
+the reverse of the existing `TIME | TOPOLOGICAL` walk, which guarantees that.
+
+Not adopted from git, deliberately: user-authored labels, `rebase-cousins`
+mode, `exec` steps. A GUI that generates its own plan needs none of them.
+
+### 3. Merge steps — three legal actions
+
+| Action | Semantics | Primitive |
+| --- | --- | --- |
+| `Drop` (flatten default) | The merge disappears; its side-branch commits are picked individually, producing a linear branch. Identical to plain `git rebase -i`. | existing skip path |
+| `MainlinePick` | The merge is kept as one ordinary commit carrying its diff against its first parent and its original message. | `CherrypickOptions::mainline(1)` |
+| `Merge` (recreate) | The rewritten parents are re-merged; the result is committed with n parents and the original message. | `repo.merge(&[annotated…])`, then an n-parent commit |
+
+`Merge` uses the **worktree** merge rather than in-memory `merge_commits` so
+that conflicts land in the index with stages. That makes a conflicting
+recreated merge flow into the existing conflict UI and the Rider-style merge
+resolver window unchanged: pause reason `"conflict"`, and `rebase_continue`
+commits the resolved tree with both parents. No new conflict surface.
+
+Octopus merges (>2 parents): `Drop` and `MainlinePick` are allowed; `Merge` is
+rejected with a plain message. The type carries n parents, so support is a
+later fill-in rather than a redesign.
+
+Any action other than these three on a merge commit is a validation error, not
+a runtime surprise.
+
+### 4. Durable state — abort survives a restart
+
+`.git/platypusgit-rebase.json`, written atomically (temp file + rename) at
+every step transition:
+
+```json
+{"version": 1, "headName": "refs/heads/feat/x", "origHead": "<oid>",
+ "onto": "<oid>", "remaining": [ /* steps */ ],
+ "current": {"step": {/* … */}, "phase": "conflict"},
+ "rewritten": {"<old>": "<new>"}}
+```
+
+`ORIG_HEAD` is written the way git writes it, so `git reset --hard ORIG_HEAD`
+remains a CLI escape hatch. `rebase_status` falls back to the file when the
+in-memory entry is missing, and `repo_state` reports the **existing**
+`RepoState::RebaseInteractive` variant while the file exists — so the banner,
+Continue, and Abort all survive an app restart without a new enum variant or
+any TS churn.
+
+Git's own `.git/rebase-merge/` directory is deliberately *not* written. A
+half-compatible one would make `git status` and `git rebase --continue` claim
+authority over a rebase they cannot drive; a private file plus `ORIG_HEAD` is
+honest about who owns the operation.
+
+### 5. Validation before anything moves
+
+`rebase_start` validates the whole plan, then touches the repository. Failures
+raise a new `AppError::InvalidRebasePlan(String)`, mirrored into the TS union
+in the same commit.
+
+Checks: plan non-empty; no duplicate oids; every oid resolvable; `onto` names
+either an earlier step or an existing commit; every commit with >1 parent
+carries `Merge`, `MainlinePick`, or `Drop`; `Merge` steps carry ≥1
+`merge_parents` and no more than two parents in total; the worktree is clean
+(existing check, kept). Each rejection is covered by a test that asserts HEAD
+**and** the branch ref are unchanged — that is the defect the probe exposed.
+
+### 6. One continue path, one abort path
+
+There are two ways to resume a paused operation today, and only one of them
+knows about the rebase plan. `Libgit2Backend::continue_operation` — what the
+Conflict screen and the palette call — writes the staged tree as a commit
+(two-parent when `MERGE_HEAD` exists), runs `cleanup_state`, and returns. It
+never advances the plan, so resolving a paused pick from the Conflict screen
+instead of the Rebase banner commits the resolution and leaves the rebase
+stalled with its `conflict_step` still stashed. `abort_operation` already
+special-cases the in-memory rebase entry; `continue_operation` does not.
+
+Recreated merges make the divergence worse: a paused `Merge` step has
+`MERGE_HEAD` set, so the generic path would commit a plausible-looking
+two-parent merge and then drop the rest of the plan on the floor.
+
+So: whenever the rebase state file exists, `continue_operation` delegates to
+`rebase_continue` and `abort_operation` delegates to `rebase_abort`, and the
+latter reads the state file rather than the in-memory map. One engine, two
+entry points.
+
+`repo_state` gives the state file precedence over libgit2's `repo.state()`, so
+a paused pick reports `RebaseInteractive` rather than `CherryPick` (which is
+what it reports today) and a paused recreated merge reports
+`RebaseInteractive` rather than `Merge` — matching what git reports in the same
+situation. The Conflict screen's Continue/Abort buttons gate on
+`repoState !== "Clean"`, so they keep working unchanged.
+
+### 7. Frontend
+
+- **Mode toggle** in the Rebase toolbar: `Flatten merges` (default, git's
+  behaviour) / `Preserve merges`, persisted alongside the other rebase-screen
+  preferences.
+- `buildRebasePlan` gains the mode. Flatten: merge rows get `Drop`, everything
+  else stays linear (`onto: null`). Preserve: each step's `onto` is its first
+  parent when that parent is inside the range, merge rows get `Merge` plus
+  `mergeParents`.
+- **Merge rows** carry a merge badge and a restricted action set — flatten:
+  *Drop* or *Squash into one commit* (`MainlinePick`); preserve: *Merge* or
+  *Drop*. Reword, edit, squash, and fixup are not offered for a merge.
+- **Warning strip** above the plan, following SmartGit and TortoiseGit:
+  - flatten — *"2 merge commits will be flattened — the branch becomes
+    linear."*
+  - preserve — *"Merge commits are recreated. Conflict resolutions and manual
+    edits inside them are not preserved and may need redoing. Reordering is
+    disabled."*
+- **Reordering is locked in preserve mode.** git documents its own reorder
+  bugs under `--rebase-merges`; shipping a reorder that silently produces the
+  wrong topology is worse than not offering it.
+- **Entry points** compute the base as `commit.parents[0]`, never
+  `commits[idx + 1]`. A merge commit is an allowed start point (base = its
+  mainline parent). "Fixup into parent" and "Squash into parent" stay disabled
+  on a merge commit, with the reason in the tooltip — folding a merge into its
+  parent has no coherent meaning.
+
+## Testing
+
+**Rust integration** (`src-tauri/tests/rebase_merges.rs`, real temp repos):
+
+- flatten (`Drop` the merge) → linear log, side-branch commits present, merge
+  gone;
+- `MainlinePick` → one ordinary commit whose tree equals the merge's tree and
+  whose message is the merge's;
+- `Merge` → a commit with two parents that are exactly the rewritten oids, tree
+  equal to the original merge's;
+- `Merge` with a conflict → pauses with reason `"conflict"`, `conflict_sides`
+  is populated, `rebase_continue` after resolution commits a two-parent merge;
+- every validation rejection leaves HEAD and the branch ref untouched;
+- abort with the in-memory entry dropped (a simulated restart) restores the
+  branch from the state file;
+- octopus `Merge` is rejected; octopus `MainlinePick` and `Drop` work;
+- an `onto` sequence that bounces between mainline and side branch;
+- `continue_operation` during a paused rebase advances the plan (and
+  `abort_operation` restores the branch) rather than committing and stalling.
+
+**Frontend unit** — `buildRebasePlan` in both modes: `onto` and `mergeParents`
+assignment, merge-row actions, base `parents[0]`.
+
+**Component** — warning-strip copy per mode, restricted merge action set,
+reorder controls disabled in preserve mode.
+
+**E2E** — extend `e2e/specs/rebase.e2e.ts`: a fixture repo containing a merge;
+a flatten run asserts a linear log, a preserve run asserts the merge survives.
+Docker only (`pnpm test:e2e:docker`).
+
+## Delivery
+
+Three PRs, each independently useful:
+
+1. **Safety and model** — detached-HEAD execution, durable state file +
+   `ORIG_HEAD` + `repo_state` reporting, `continue_operation` /
+   `abort_operation` delegation, pre-flight validation, the `parents[0]` base
+   fix. No new user-facing capability; the existing rebase tests stay green.
+2. **Flatten mode** — merge badges, restricted actions, warning strip,
+   `MainlinePick`.
+3. **Preserve mode** — `onto` / `merge_parents`, the `Merge` action, conflict
+   pause into the merge resolver, the mode toggle, the reorder lock.
+
+## Out of scope
+
+User-authored labels; `rebase-cousins`; `exec` steps; autosquash; recreating
+octopus merges; preserving the conflict resolutions recorded inside an original
+merge commit (git does not either — it re-runs the merge).

--- a/docs/superpowers/specs/2026-08-14-rebase-merge-commits-design.md
+++ b/docs/superpowers/specs/2026-08-14-rebase-merge-commits-design.md
@@ -243,8 +243,16 @@ situation. The Conflict screen's Continue/Abort buttons gate on
 - **Entry points** compute the base as `commit.parents[0]`, never
   `commits[idx + 1]`. A merge commit is an allowed start point (base = its
   mainline parent). "Fixup into parent" and "Squash into parent" stay disabled
-  on a merge commit, with the reason in the tooltip — folding a merge into its
-  parent has no coherent meaning.
+  on a merge commit, with the reason carried in the disabled label — the
+  pattern `commitMultiMenuItems` already uses for its squash block
+  (`"Squash 3 — contains a merge"`).
+- **`planCommitSelection` carries the same positional assumption twice** and is
+  corrected with the entry points: `baseOid` becomes the oldest selected
+  commit's `parents[0]` instead of `commits[max + 1]`, and `contiguous` requires
+  the selected rows to form a real first-parent chain rather than merely
+  occupying adjacent log rows — on a graph, the neighbouring row is often a
+  side-branch commit. The multi-select squash path already refuses a selection
+  containing a merge (`hasMerge`), which stays as-is.
 
 ## Testing
 
@@ -267,7 +275,9 @@ situation. The Conflict screen's Continue/Abort buttons gate on
   `abort_operation` restores the branch) rather than committing and stalling.
 
 **Frontend unit** — `buildRebasePlan` in both modes: `onto` and `mergeParents`
-assignment, merge-row actions, base `parents[0]`.
+assignment, merge-row actions, base `parents[0]`; `planCommitSelection` base and
+first-parent-chain contiguity on a graph where the adjacent log row belongs to a
+side branch.
 
 **Component** — warning-strip copy per mode, restricted merge action set,
 reorder controls disabled in preserve mode.


### PR DESCRIPTION
## What

Design doc plus three PR-scoped implementation plans for interactive rebase over
merge commits. **Docs only** — no code changes.

Measured starting point (throwaway probe against the real backend): a plan
containing a merge fails with libgit2's `mainline branch is not specified` error
on the step that reaches it, *after* earlier picks have been committed and the
branch tip moved. Abort-ability lives only in `Libgit2Backend`'s HashMap and
`repo_state` reports `Clean`, so closing the app mid-failure leaves a
half-rewritten branch recoverable only through the reflog. Same class of bug
TortoiseGit shipped ([#1756](https://gitlab.com/tortoisegit/tortoisegit/-/issues/1756)).

Two further defects found while planning:

- The rebase base came from `commits[idx + 1]` — the next row in a
  graph-ordered log, frequently a side-branch commit. On the probe repo,
  "Interactive rebase from here" on a mainline commit silently dropped a
  merged-in commit's content.
- `planCommitSelection` carried the same positional assumption twice: its
  `baseOid`, and a `contiguous` check that treats adjacent log rows as a
  parent chain.

## Prior art surveyed

git (drops merges by default; `--rebase-merges` recreates with documented
reorder limitations), GitKraken (blocks outright), SmartGit (flattens with a
warning), TortoiseGit (preserve behind a warning), Rider/IntelliJ (start point
may not be a merge; `--rebase-merges` checkbox), lazygit (always
`--rebase-merges`).

## Plans

1. `…-pr1-safety-model.md` — pre-flight validation (`AppError::InvalidRebasePlan`),
   detached-HEAD replay with the branch moved once on completion,
   `.git/platypusgit-rebase.json` + `ORIG_HEAD` so a restart can continue or
   abort, `continue_operation`/`abort_operation` delegating to the engine,
   parent-based base derivation.
2. `…-pr2-flatten-mode.md` — merge rows default to `Drop` (git's behaviour), new
   `MainlinePick` (`cherry-pick -m 1`), merge badges, restricted action set,
   warning strip.
3. `…-pr3-preserve-mode.md` — `onto` / `mergeParents` topology in place of git's
   `label`/`reset` todo language, `Merge` action re-merging rewritten parents,
   conflicts routed through the existing merge resolver, persisted
   Flatten ⇄ Preserve toggle with reordering locked in preserve mode.

Awaiting review before implementation starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)