### PR TITLE
feat(diff): highlight split view, commit diff and both merge panes (#104)

### DIFF
--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -1050,6 +1050,10 @@ export interface SideLine {
   kind: DiffLineKind;
   ln?: number | string;
   text?: string;
+  /** Intra-line word spans, set by the caller's pairing pass (`diffToSplit`). */
+  spans?: WordSpan[];
+  /** Line-relative syntax tokens for this row's side of the diff. */
+  syntax?: SyntaxToken[];
 }
 
 export function PGSideBySideDiff({
@@ -1114,7 +1118,12 @@ export function PGSideBySideDiff({
                       : "var(--fg-0)",
               }}
             >
-              {ln.text}
+              <DiffText
+                text={ln.text ?? ""}
+                spans={ln.spans}
+                syntax={ln.syntax}
+                kind={ln.kind}
+              />
             </span>
           </div>
         );

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -1,5 +1,6 @@
 import React, { type CSSProperties, type MouseEvent, type ReactNode } from "react";
-import { wordDiff, type WordSpan } from "@/lib/wordDiff";
+import type { WordSpan } from "@/lib/wordDiff";
+import { pairChangedLines } from "@/lib/pairChangedLines";
 import { buildLineSpans } from "@/lib/lineSpans";
 import type { SyntaxLine, SyntaxToken } from "@/lib/syntax";
 import { PGIcon, type IconName } from "./icons";
@@ -705,9 +706,8 @@ function attachSyntax(
  *
  * `chunkDiffLines` groups **by kind**, so a removed run and the added run that
  * follows it are two ADJACENT chunks — pairing crosses that pair rather than
- * happening inside one chunk. The i-th removed line pairs with the i-th added
- * line for the first `min(rem, add)` lines; `wordDiff` itself returns null for
- * a pair too dissimilar to be the same line edited, and those get no spans.
+ * happening inside one chunk. The pairing rule itself lives in
+ * `@/lib/pairChangedLines`, shared with the split view and the commit-diff panel.
  */
 function withWordSpans(chunks: DiffChunk[]): DiffChunk[] {
   const out = chunks.map((c) => ({ ...c, lines: c.lines.map((l) => ({ ...l })) }));
@@ -715,13 +715,15 @@ function withWordSpans(chunks: DiffChunk[]): DiffChunk[] {
     const rem = out[i];
     const add = out[i + 1];
     if (rem.kind !== "rem" || add.kind !== "add") continue;
-    const n = Math.min(rem.lines.length, add.lines.length);
-    for (let k = 0; k < n; k++) {
-      const r = wordDiff(rem.lines[k].text ?? "", add.lines[k].text ?? "");
-      if (!r) continue;
-      rem.lines[k].spans = r.old;
-      add.lines[k].spans = r.new;
-    }
+    const paired = pairChangedLines(
+      rem.lines.map((l) => l.text ?? ""),
+      add.lines.map((l) => l.text ?? ""),
+    );
+    paired.forEach((p, k) => {
+      if (!p) return;
+      rem.lines[k].spans = p.old;
+      add.lines[k].spans = p.new;
+    });
   }
   return out;
 }

--- a/src/features/diff/CommitDiffPanel.syntax.test.tsx
+++ b/src/features/diff/CommitDiffPanel.syntax.test.tsx
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { CommitDiffPanel } from "./CommitDiffPanel";
+import type { FileDiff } from "@/lib/types";
+
+// Mock the module useSyntax imports, NOT the @/lib/syntax barrel — the barrel
+// leaves the hook's own ./tokenize import untouched and the real grammar runs.
+vi.mock("@/lib/syntax/tokenize", async (orig) => ({
+  ...(await orig<typeof import("@/lib/syntax/tokenize")>()),
+  tokenizeFile: async (_p: string, text: string) =>
+    text.split("\n").map(() => [
+      { start: 0, end: 3, cls: text.includes("OLD") ? "syn-comment" : "syn-keyword" },
+    ]),
+}));
+
+const diffs: FileDiff[] = [
+  {
+    path: "a.ts",
+    oldPath: null,
+    binary: false,
+    additions: 1,
+    deletions: 1,
+    hunks: [
+      {
+        header: "@@ -1 +1 @@",
+        oldStart: 1,
+        oldLines: 1,
+        newStart: 1,
+        newLines: 1,
+        lines: [
+          { kind: { kind: "Deletion" }, oldLineno: 1, newLineno: null, content: "let a = 1" },
+          { kind: { kind: "Addition" }, oldLineno: null, newLineno: 1, content: "let a = 2" },
+        ],
+      },
+    ],
+  },
+];
+
+beforeEach(() => {
+  resetInvokeMock();
+  mockInvoke("read_file_content_at_rev", (args) => ({
+    path: args.path as string,
+    binary: false,
+    text: (args.revspec as string).endsWith("^") ? "let a = 1 OLD" : "let a = 2",
+    fromHead: false,
+    size: 13,
+  }));
+});
+
+describe("CommitDiffPanel syntax and word diff", () => {
+  it("highlights rows and marks intra-line changes when given revs", async () => {
+    render(
+      <CommitDiffPanel
+        diffs={diffs}
+        loading={false}
+        error={null}
+        header="x → y"
+        paneIdPrefix="t1"
+        syntaxSides={{
+          repoId: "repo-1",
+          old: { kind: "rev", rev: "abc123^" },
+          new: { kind: "rev", rev: "abc123" },
+        }}
+      />,
+    );
+    await waitFor(() =>
+      expect(document.querySelectorAll(".syn-comment").length).toBeGreaterThan(0),
+    );
+    expect(document.querySelectorAll(".syn-keyword").length).toBeGreaterThan(0);
+    expect(document.querySelectorAll('[data-testid="word-change"]').length).toBeGreaterThan(0);
+  });
+
+  it("renders plain and reads nothing without revs", async () => {
+    render(
+      <CommitDiffPanel
+        diffs={diffs}
+        loading={false}
+        error={null}
+        header="x"
+        paneIdPrefix="t2"
+      />,
+    );
+    await waitFor(() =>
+      expect(document.querySelectorAll("[data-hunk-index]").length).toBe(1),
+    );
+    expect(getInvokeCalls().some((c) => c.cmd === "read_file_content_at_rev")).toBe(false);
+    expect(document.querySelectorAll(".syn-keyword").length).toBe(0);
+    // Still shows the code, just unhighlighted.
+    expect(document.body.textContent).toContain("let a = 1");
+  });
+
+  it("reads a renamed file's old side at its old path", async () => {
+    render(
+      <CommitDiffPanel
+        diffs={[{ ...diffs[0], oldPath: "old.ts" }]}
+        loading={false}
+        error={null}
+        header="x → y"
+        paneIdPrefix="t3"
+        syntaxSides={{
+          repoId: "repo-1",
+          old: { kind: "rev", rev: "abc123^" },
+          new: { kind: "rev", rev: "abc123" },
+        }}
+      />,
+    );
+    await waitFor(() => {
+      const atOld = getInvokeCalls().filter(
+        (c) => c.cmd === "read_file_content_at_rev" && c.args.path === "old.ts",
+      );
+      expect(atOld.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -4,7 +4,54 @@ import { PGPane, FocusableScroll, usePaneList, useHunkNav } from "@/features/key
 import { fileIconSpec } from "@/lib/fileIcon";
 import { WhitespaceToggle } from "./WhitespaceToggle";
 import { SignatureBadge } from "@/features/signing/SignatureBadge";
-import type { FileDiff } from "@/lib/types";
+import { useDiffSyntax, type DiffSyntax, type SideSource } from "@/lib/syntax";
+import { buildLineSpans } from "@/lib/lineSpans";
+import { pairChangedLines } from "@/lib/pairChangedLines";
+import type { WordSpan } from "@/lib/wordDiff";
+import type { DiffLine, FileDiff } from "@/lib/types";
+
+/**
+ * One diff row's text: syntax classes plus intra-line change marks, through the
+ * same tiling builder the design-system rows use.
+ *
+ * Side rule matches everywhere else: a removal reads the old file, an addition or
+ * context row the new one.
+ */
+function CommitDiffText({
+  line,
+  syntax,
+  spans,
+}: {
+  line: DiffLine;
+  syntax: DiffSyntax;
+  spans?: WordSpan[];
+}) {
+  const isRem = line.kind.kind === "Deletion";
+  const sideLines = isRem ? syntax.old : syntax.new;
+  const lineNo = isRem ? line.oldLineno : (line.newLineno ?? line.oldLineno);
+  const tokens = sideLines && lineNo ? (sideLines[lineNo - 1] ?? null) : null;
+  const rendered = buildLineSpans(line.content, tokens, spans);
+  if (rendered.length === 1 && !rendered[0].cls && !rendered[0].changed) {
+    return <>{line.content}</>;
+  }
+  const tint = isRem
+    ? "oklch(from var(--git-removed) l c h / 0.28)"
+    : "oklch(from var(--git-added) l c h / 0.28)";
+  return (
+    <>
+      {rendered.map((s, k) => (
+        <span
+          key={k}
+          className={s.cls}
+          data-testid={s.changed ? "word-change" : undefined}
+          style={s.changed ? { background: tint, borderRadius: 2 } : undefined}
+        >
+          {line.content.slice(s.start, s.end)}
+        </span>
+      ))}
+    </>
+  );
+}
 
 export interface CommitDiffPanelProps {
   diffs: FileDiff[];
@@ -26,6 +73,16 @@ export interface CommitDiffPanelProps {
    * or commit-vs-worktree, where "the" signature has no meaning.
    */
   verifyOid?: string;
+  /**
+   * Revisions to read whole-file text from, for syntax highlighting.
+   *
+   * The panel is presentational — the caller fetches the diffs and it never
+   * learns the repo or which revisions were compared — so callers that know them
+   * pass them here. A combined multi-commit diff, where "the" old side has no
+   * meaning, omits this and renders plain. The per-file `oldPath` for renames is
+   * filled in by the panel itself, which knows the selected file.
+   */
+  syntaxSides?: { repoId: string; old: SideSource; new: SideSource };
 }
 
 /**
@@ -42,6 +99,7 @@ export function CommitDiffPanel({
   paneIdPrefix,
   emptyLabel = "No changes in this commit.",
   verifyOid,
+  syntaxSides,
 }: CommitDiffPanelProps) {
   const filesPaneId = `${paneIdPrefix}.files`;
   const viewPaneId = `${paneIdPrefix}.view`;
@@ -78,6 +136,54 @@ export function CommitDiffPanel({
     count: current?.hunks.length ?? 0,
     resetKey: selected,
   });
+
+  const syntax = useDiffSyntax({
+    repoId: syntaxSides?.repoId ?? null,
+    path: syntaxSides ? (current?.path ?? null) : null,
+    // A rename's old side lives at its old path; the panel knows it per file.
+    old: syntaxSides
+      ? syntaxSides.old.kind === "rev"
+        ? { ...syntaxSides.old, path: current?.oldPath ?? null }
+        : syntaxSides.old
+      : { kind: "none" },
+    new: syntaxSides?.new ?? { kind: "none" },
+  });
+
+  /**
+   * Word spans for the selected file, keyed hunk index → line index within that
+   * hunk. Runs of removals and additions pair positionally through the shared
+   * rule; a run with no counterpart gets nothing.
+   */
+  const wordSpansByHunk = React.useMemo(() => {
+    return (current?.hunks ?? []).map((h) => {
+      const spans = new Map<number, WordSpan[]>();
+      let remIdx: number[] = [];
+      let addIdx: number[] = [];
+      const flush = () => {
+        if (remIdx.length && addIdx.length) {
+          const paired = pairChangedLines(
+            remIdx.map((i) => h.lines[i].content),
+            addIdx.map((i) => h.lines[i].content),
+          );
+          paired.forEach((p, k) => {
+            if (!p) return;
+            spans.set(remIdx[k], p.old);
+            spans.set(addIdx[k], p.new);
+          });
+        }
+        remIdx = [];
+        addIdx = [];
+      };
+      h.lines.forEach((ln, i) => {
+        const k = ln.kind.kind;
+        if (k === "Deletion") remIdx.push(i);
+        else if (k === "Addition") addIdx.push(i);
+        else flush();
+      });
+      flush();
+      return spans;
+    });
+  }, [current]);
 
   // Per mount site: History's bottom panel is wide and short, the full-screen
   // commit diff is not, so one shared width would fit neither.
@@ -270,7 +376,11 @@ export function CommitDiffPanel({
                       : ln.kind.kind === "Deletion"
                         ? "-"
                         : " "}
-                    {ln.content}
+                    <CommitDiffText
+                      line={ln}
+                      syntax={syntax}
+                      spans={wordSpansByHunk[i]?.get(j)}
+                    />
                   </div>
                 ))}
               </div>

--- a/src/features/merge/MergeBody.tsx
+++ b/src/features/merge/MergeBody.tsx
@@ -6,6 +6,7 @@
 
 import React from "react";
 import { SidePane } from "./SidePane";
+import { useSyntax } from "@/lib/syntax";
 import { createResultEditor, type EditorHandle, type RegionState } from "./resultEditor";
 import type { MergeModel } from "./mergeModel";
 
@@ -24,8 +25,13 @@ export const MergeBody = React.forwardRef<
     // Owned by MergeWindow; optional so tests can render without a selection.
     currentConflict?: number | null;
     onRegionsChange: (r: RegionState[]) => void;
+    /**
+     * Conflicted file's path. Only used to pick a syntax grammar, so it is
+     * optional — without it all three panes render plain.
+     */
+    path?: string;
   }
->(function MergeBody({ model, currentConflict = null, onRegionsChange }, ref) {
+>(function MergeBody({ model, currentConflict = null, onRegionsChange, path }, ref) {
   const editorHost = React.useRef<HTMLDivElement>(null);
   const editor = React.useRef<EditorHandle | null>(null);
   const [regionStates, setRegionStates] = React.useState<RegionState[]>([]);
@@ -52,6 +58,13 @@ export const MergeBody = React.forwardRef<
     // model identity changes only when the file changes — full remount wanted.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [model]);
+
+  // Both side panes come from the model already in hand, so tokens need no read.
+  // Memoized on the model, whose identity changes only when the file does.
+  const oursText = React.useMemo(() => model.oursLines.join("\n"), [model]);
+  const theirsText = React.useMemo(() => model.theirsLines.join("\n"), [model]);
+  const oursSyntax = useSyntax(path ?? null, oursText);
+  const theirsSyntax = useSyntax(path ?? null, theirsText);
 
   const accept = React.useCallback((id: number, res: "ours" | "theirs" | "both") => {
     editor.current?.accept(id, res);
@@ -135,6 +148,7 @@ export const MergeBody = React.forwardRef<
         onAccept={(id) => accept(id, "ours")}
         scrollRef={oursScroll}
         onScroll={() => syncFrom("ours")}
+        syntax={oursSyntax}
       />
       <div style={{ width: 1, background: "var(--border-0)" }} />
       <div
@@ -152,6 +166,7 @@ export const MergeBody = React.forwardRef<
         onAccept={(id) => accept(id, "theirs")}
         scrollRef={theirsScroll}
         onScroll={() => syncFrom("theirs")}
+        syntax={theirsSyntax}
       />
     </div>
   );

--- a/src/features/merge/MergeBody.tsx
+++ b/src/features/merge/MergeBody.tsx
@@ -42,6 +42,7 @@ export const MergeBody = React.forwardRef<
     if (!editorHost.current) return;
     const handle = createResultEditor({
       model,
+      path,
       parent: editorHost.current,
       onChange: (r) => {
         setRegionStates(r);

--- a/src/features/merge/MergeWindow.tsx
+++ b/src/features/merge/MergeWindow.tsx
@@ -304,6 +304,7 @@ export function MergeWindow() {
           model={model}
           currentConflict={currentId}
           onRegionsChange={setRegionStates}
+          path={path}
         />
       ) : (
         <PGEmpty icon="conflict" title="Nothing to resolve">

--- a/src/features/merge/SidePane.syntax.test.tsx
+++ b/src/features/merge/SidePane.syntax.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+import { SidePane } from "./SidePane";
+
+function renderPane(props: Partial<React.ComponentProps<typeof SidePane>> = {}) {
+  const ref = React.createRef<HTMLDivElement>();
+  return render(
+    <SidePane
+      side="ours"
+      lines={["let a", "let b"]}
+      conflicts={[]}
+      regionStates={[]}
+      currentConflict={null}
+      onAccept={() => {}}
+      scrollRef={ref}
+      onScroll={() => {}}
+      {...props}
+    />,
+  );
+}
+
+describe("SidePane syntax", () => {
+  it("wraps scoped ranges in classed spans, indexed by line", () => {
+    renderPane({
+      syntax: [
+        [{ start: 0, end: 3, cls: "syn-keyword" }],
+        [{ start: 0, end: 3, cls: "syn-comment" }],
+      ],
+    });
+    expect(document.querySelector(".syn-keyword")).toHaveTextContent("let");
+    expect(document.querySelector(".syn-comment")).toHaveTextContent("let");
+  });
+
+  it("renders plain text when there are no tokens", () => {
+    const { container } = renderPane({ lines: ["plain"] });
+    expect(container.textContent).toContain("plain");
+    expect(document.querySelectorAll(".syn-keyword")).toHaveLength(0);
+  });
+
+  it("keeps the placeholder for a blank line, so row heights stay uniform", () => {
+    // Uniform row height is what lets the middle pane sync scroll by line index.
+    const { container } = renderPane({ lines: [""], syntax: [[]] });
+    const rows = container.querySelectorAll("[data-line]");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].textContent).not.toBe("");
+  });
+
+  it("ignores tokens past the end of the line list", () => {
+    renderPane({ lines: ["only"], syntax: [[], [{ start: 0, end: 2, cls: "syn-keyword" }]] });
+    expect(document.querySelectorAll(".syn-keyword")).toHaveLength(0);
+  });
+});

--- a/src/features/merge/SidePane.tsx
+++ b/src/features/merge/SidePane.tsx
@@ -5,6 +5,8 @@
 // deleted the lines) carries an accept chevron in the gutter.
 
 import React from "react";
+import { buildLineSpans } from "@/lib/lineSpans";
+import type { SyntaxLine, SyntaxToken } from "@/lib/syntax";
 import type { ConflictRegion } from "./mergeModel";
 import type { RegionState } from "./resultEditor";
 
@@ -20,6 +22,20 @@ function sideRange(side: "ours" | "theirs", c: ConflictRegion): { start: number;
   return { start: s.start, count: s.lines.length };
 }
 
+/** One side's line text, highlighted once tokens for it exist. */
+function SideText({ text, syntax }: { text: string; syntax?: SyntaxToken[] }) {
+  if (!syntax || syntax.length === 0) return <>{text}</>;
+  return (
+    <>
+      {buildLineSpans(text, syntax, undefined).map((s, i) => (
+        <span key={i} className={s.cls}>
+          {text.slice(s.start, s.end)}
+        </span>
+      ))}
+    </>
+  );
+}
+
 export function SidePane({
   side,
   lines,
@@ -29,6 +45,7 @@ export function SidePane({
   onAccept,
   scrollRef,
   onScroll,
+  syntax,
 }: {
   side: "ours" | "theirs";
   lines: string[];
@@ -38,6 +55,8 @@ export function SidePane({
   onAccept: (id: number) => void;
   scrollRef: React.RefObject<HTMLDivElement | null>;
   onScroll: () => void;
+  /** Per-line syntax tokens for this side, indexed the same as `lines`. */
+  syntax?: SyntaxLine[] | null;
 }): React.JSX.Element {
   const label = side === "ours" ? "YOURS" : "THEIRS";
   const headerColor = side === "ours" ? "var(--accent)" : "var(--accent-2, var(--fg-1))";
@@ -170,7 +189,12 @@ export function SidePane({
               <span style={{ flex: "0 0 18px", textAlign: "center" }}>
                 {startsHere != null ? chevronButton(startsHere) : null}
               </span>
-              <span style={{ flex: 1 }}>{lines[i] === "" ? " " : lines[i]}</span>
+              <span style={{ flex: 1 }}>
+                {/* U+00A0 placeholder for a blank line, not an empty span: a
+                    plain space collapses in JSX, and row heights must stay
+                    uniform or the middle pane's scroll sync drifts. */}
+                {lines[i] === "" ? " " : <SideText text={lines[i]} syntax={syntax?.[i]} />}
+              </span>
             </div>
           );
         })}

--- a/src/features/merge/resultEditor.ts
+++ b/src/features/merge/resultEditor.ts
@@ -26,6 +26,7 @@ import {
   type ConflictRegion,
   type MergeModel,
 } from "./mergeModel";
+import { syntaxHighlighting } from "./syntaxDecorations";
 
 export interface RegionState {
   id: number;
@@ -145,8 +146,13 @@ export function createResultEditor(opts: {
   model: MergeModel;
   parent: HTMLElement;
   onChange: (regions: RegionState[]) => void;
+  /**
+   * Conflicted file's path, used only to pick a syntax grammar. Optional: with
+   * none, the pane renders plain, which is what tests without a path expect.
+   */
+  path?: string;
 }): EditorHandle {
-  const { model, parent, onChange } = opts;
+  const { model, parent, onChange, path } = opts;
   const conflictById = new Map<number, ConflictRegion>(
     model.conflicts.map((c) => [c.id, c]),
   );
@@ -170,6 +176,9 @@ export function createResultEditor(opts: {
         }
       }),
       theme,
+      // Same --syn-* classes as both side panes, so all three agree on colour
+      // and on which languages they know.
+      ...(path ? [syntaxHighlighting(path)] : []),
     ],
   });
 

--- a/src/features/merge/syntaxDecorations.test.ts
+++ b/src/features/merge/syntaxDecorations.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { EditorState } from "@codemirror/state";
+import type { DecorationSet } from "@codemirror/view";
+import { buildSyntaxDecorations } from "./syntaxDecorations";
+
+function ranges(set: DecorationSet) {
+  const out: Array<{ from: number; to: number }> = [];
+  const iter = set.iter();
+  while (iter.value) {
+    out.push({ from: iter.from, to: iter.to });
+    iter.next();
+  }
+  return out;
+}
+
+describe("buildSyntaxDecorations", () => {
+  it("maps line-relative tokens onto absolute document ranges", () => {
+    const state = EditorState.create({ doc: "let a\nlet b" });
+    const set = buildSyntaxDecorations(state, [
+      [{ start: 0, end: 3, cls: "syn-keyword" }],
+      [{ start: 4, end: 5, cls: "syn-var" }],
+    ]);
+    // Second line starts at offset 6, so its 4-5 becomes 10-11.
+    expect(ranges(set)).toEqual([
+      { from: 0, to: 3 },
+      { from: 10, to: 11 },
+    ]);
+  });
+
+  it("clamps a token that overruns its line instead of bleeding into the next", () => {
+    const state = EditorState.create({ doc: "ab\ncd" });
+    const set = buildSyntaxDecorations(state, [[{ start: 0, end: 99, cls: "syn-type" }]]);
+    expect(ranges(set)).toEqual([{ from: 0, to: 2 }]);
+  });
+
+  it("ignores token lines beyond the document", () => {
+    const state = EditorState.create({ doc: "ab" });
+    const set = buildSyntaxDecorations(state, [
+      [{ start: 0, end: 1, cls: "syn-var" }],
+      [{ start: 0, end: 1, cls: "syn-var" }],
+    ]);
+    expect(ranges(set)).toHaveLength(1);
+  });
+
+  it("drops zero-width tokens, which CodeMirror rejects as mark ranges", () => {
+    const state = EditorState.create({ doc: "ab" });
+    const set = buildSyntaxDecorations(state, [[{ start: 1, end: 1, cls: "syn-var" }]]);
+    expect(ranges(set)).toHaveLength(0);
+  });
+
+  it("returns an empty set for no tokens", () => {
+    const state = EditorState.create({ doc: "ab" });
+    expect(ranges(buildSyntaxDecorations(state, []))).toHaveLength(0);
+  });
+});

--- a/src/features/merge/syntaxDecorations.ts
+++ b/src/features/merge/syntaxDecorations.ts
@@ -1,0 +1,83 @@
+// Syntax highlighting for the editable result pane.
+//
+// The region decorations next door use EditorView.decorations.compute, which is
+// synchronous. Tokenizing is not, so tokens arrive as a StateEffect into a field
+// that maps its ranges through document changes — colours therefore shift with
+// edits instead of smearing while the debounce is pending.
+import {
+  StateEffect,
+  StateField,
+  type EditorState,
+  type Extension,
+} from "@codemirror/state";
+import { Decoration, EditorView, type DecorationSet } from "@codemirror/view";
+import { tokenizeFile, type SyntaxLine } from "@/lib/syntax";
+
+/** Re-tokenizing on every keystroke is wasted work; one idle beat is enough. */
+const DEBOUNCE_MS = 120;
+
+const setSyntaxEffect = StateEffect.define<DecorationSet>();
+
+export function buildSyntaxDecorations(
+  state: EditorState,
+  lines: SyntaxLine[],
+): DecorationSet {
+  const ranges = [];
+  const total = state.doc.lines;
+  for (let i = 0; i < lines.length && i < total; i++) {
+    const line = state.doc.line(i + 1);
+    for (const t of lines[i]) {
+      const from = line.from + t.start;
+      // Clamp to the line's own end: a token overrunning it would otherwise
+      // bleed into the next line, and CodeMirror rejects zero-width marks.
+      const to = Math.min(line.from + t.end, line.to);
+      if (to <= from) continue;
+      ranges.push(Decoration.mark({ class: t.cls }).range(from, to));
+    }
+  }
+  return Decoration.set(ranges, true);
+}
+
+const syntaxField = StateField.define<DecorationSet>({
+  create: () => Decoration.none,
+  update(deco, tr) {
+    let next = tr.docChanged ? deco.map(tr.changes) : deco;
+    for (const e of tr.effects) if (e.is(setSyntaxEffect)) next = e.value;
+    return next;
+  },
+  provide: (f) => EditorView.decorations.from(f),
+});
+
+/**
+ * Highlight the result document, re-tokenizing on a debounce after each change.
+ * A path whose language is unknown simply never produces decorations.
+ */
+export function syntaxHighlighting(path: string): Extension {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const refresh = (view: EditorView) => {
+    const text = view.state.doc.toString();
+    void tokenizeFile(path, text).then((lines) => {
+      // Bail if the document moved on while tokenizing: the pending debounce
+      // covers the newer text, and applying stale ranges would mis-colour it.
+      if (!lines || view.state.doc.toString() !== text) return;
+      view.dispatch({
+        effects: setSyntaxEffect.of(buildSyntaxDecorations(view.state, lines)),
+      });
+    });
+  };
+
+  return [
+    syntaxField,
+    EditorView.updateListener.of((update) => {
+      // viewportChanged catches the first measurement after mount, where there
+      // is no document change to react to but the pane still needs colouring.
+      if (!update.docChanged && !update.viewportChanged) return;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = null;
+        refresh(update.view);
+      }, DEBOUNCE_MS);
+    }),
+  ];
+}

--- a/src/lib/pairChangedLines.test.ts
+++ b/src/lib/pairChangedLines.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { pairChangedLines } from "./pairChangedLines";
+
+describe("pairChangedLines", () => {
+  it("pairs the i-th removal with the i-th addition", () => {
+    const out = pairChangedLines(["let a = 1"], ["let a = 2"]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).not.toBeNull();
+    expect(out[0]!.old.some((s) => s.changed)).toBe(true);
+    expect(out[0]!.new.some((s) => s.changed)).toBe(true);
+  });
+
+  it("pairs only min(rem, add) lines", () => {
+    expect(pairChangedLines(["a", "b", "c"], ["a2"])).toHaveLength(1);
+    expect(pairChangedLines(["a"], ["a2", "b2", "c2"])).toHaveLength(1);
+  });
+
+  it("returns an empty array when either side is empty", () => {
+    expect(pairChangedLines([], ["a"])).toEqual([]);
+    expect(pairChangedLines(["a"], [])).toEqual([]);
+  });
+
+  it("yields null for a pair too dissimilar to be one edited line", () => {
+    // wordDiff declines below MIN_SIMILARITY: highlighting unrelated rewrites at
+    // random reads as noise and is worse than no word diff at all.
+    const out = pairChangedLines(
+      ["import { readFile } from 'node:fs/promises'"],
+      ["export const TOTALLY_UNRELATED = 42"],
+    );
+    expect(out[0]).toBeNull();
+  });
+
+  it("keeps each pair independent, so one declined pair does not shift the rest", () => {
+    const out = pairChangedLines(
+      ["let a = 1", "zzzzzzzzzzzzzzzz"],
+      ["let a = 2", "const q = [1, 2]"],
+    );
+    expect(out).toHaveLength(2);
+    expect(out[0]).not.toBeNull();
+    expect(out[1]).toBeNull();
+  });
+});

--- a/src/lib/pairChangedLines.ts
+++ b/src/lib/pairChangedLines.ts
@@ -1,0 +1,26 @@
+// The rem↔add pairing rule for intra-line diff, lifted out of PGHunk so the
+// unified hunk renderer, the split view and the commit-diff panel share ONE
+// definition instead of three that drift.
+//
+// The rule: the i-th removed line pairs with the i-th added line, for the first
+// min(rem, add) lines. wordDiff itself declines a pair too dissimilar to be "the
+// same line edited", and those come back null.
+import { wordDiff, type WordSpan } from "./wordDiff";
+
+export interface LinePairSpans {
+  old: WordSpan[];
+  new: WordSpan[];
+}
+
+export function pairChangedLines(
+  rem: string[],
+  add: string[],
+): Array<LinePairSpans | null> {
+  const n = Math.min(rem.length, add.length);
+  const out: Array<LinePairSpans | null> = [];
+  for (let i = 0; i < n; i++) {
+    const r = wordDiff(rem[i], add[i]);
+    out.push(r ? { old: r.old, new: r.new } : null);
+  }
+  return out;
+}

--- a/src/lib/syntax/index.ts
+++ b/src/lib/syntax/index.ts
@@ -1,2 +1,7 @@
 export { tokenizeFile, type SyntaxLine, type SyntaxToken } from "./tokenize";
 export { useSyntax } from "./useSyntax";
+export {
+  useDiffSyntax,
+  type DiffSyntax,
+  type SideSource,
+} from "./useDiffSyntax";

--- a/src/lib/syntax/useDiffSyntax.ts
+++ b/src/lib/syntax/useDiffSyntax.ts
@@ -1,0 +1,90 @@
+import React from "react";
+import { readFileContent, readFileContentAtRev } from "@/lib/tauri";
+import { useSyntax } from "./useSyntax";
+import type { SyntaxLine } from "./tokenize";
+
+/**
+ * Where one side of a diff gets its text.
+ *
+ * Spelled out rather than overloading `null`, which would have to mean "the
+ * worktree" on the new side and "there is no such side" on the old one — the same
+ * sentinel with two meanings is how call sites get it wrong.
+ */
+export type SideSource =
+  | { kind: "rev"; rev: string; path?: string | null }
+  | { kind: "worktree" }
+  | { kind: "none" };
+
+export interface DiffSyntax {
+  old: SyntaxLine[] | null;
+  new: SyntaxLine[] | null;
+}
+
+/** No tokens for either side. Stable identity, so it is safe in a render path. */
+const EMPTY: DiffSyntax = { old: null, new: null };
+
+/**
+ * Tokens for both sides of a file diff.
+ *
+ * Whole-file text per side, not hunk text: a hunk is a window into a file, and a
+ * block comment or template literal opening above it would mis-colour every line
+ * below.
+ *
+ * A `rev` source may carry its own `path`, which is what covers renames — HEAD has
+ * no blob at the new path, so reading it there would leave every removed line
+ * unhighlighted.
+ *
+ * A failed read yields no tokens for that side and those rows render plain: a
+ * missing blob must never break a diff.
+ *
+ * Panes that diff against the INDEX (the commit panel) cannot ask for it — there
+ * is no read_file_content_at_index — so they pass HEAD and the worktree. Those
+ * agree with the index except on a partially staged file, where being off
+ * mis-colours a line. It cannot affect what gets staged, because staging addresses
+ * lines by changedIndex, never by these tokens.
+ */
+export function useDiffSyntax(o: {
+  repoId: string | null;
+  path: string | null;
+  old: SideSource;
+  new: SideSource;
+}): DiffSyntax {
+  const { repoId, path } = o;
+  // Deps are primitives: the caller builds these objects inline every render, so
+  // depending on their identity would refetch both files on every render.
+  const oldKind = o.old.kind;
+  const oldRev = o.old.kind === "rev" ? o.old.rev : null;
+  const oldPath = (o.old.kind === "rev" ? o.old.path : null) ?? path;
+  const newKind = o.new.kind;
+  const newRev = o.new.kind === "rev" ? o.new.rev : null;
+
+  const [texts, setTexts] = React.useState<{ old: string | null; new: string | null }>({
+    old: null,
+    new: null,
+  });
+
+  React.useEffect(() => {
+    setTexts({ old: null, new: null });
+    if (!repoId || !path) return;
+    let cancelled = false;
+    const read = (kind: SideSource["kind"], rev: string | null, p: string | null) => {
+      if (kind === "none" || !p) return Promise.resolve(null);
+      if (kind === "worktree") return readFileContent(repoId, p).catch(() => null);
+      return rev ? readFileContentAtRev(repoId, rev, p).catch(() => null) : Promise.resolve(null);
+    };
+    Promise.all([read(oldKind, oldRev, oldPath), read(newKind, newRev, path)]).then(
+      ([o2, n]) => {
+        if (!cancelled) setTexts({ old: o2?.text ?? null, new: n?.text ?? null });
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [repoId, path, oldKind, oldRev, oldPath, newKind, newRev]);
+
+  const oldLines = useSyntax(path, texts.old);
+  const newLines = useSyntax(path, texts.new);
+  return React.useMemo(() => ({ old: oldLines, new: newLines }), [oldLines, newLines]);
+}
+
+export { EMPTY as EMPTY_DIFF_SYNTAX };

--- a/src/screens/CommitDiff.tsx
+++ b/src/screens/CommitDiff.tsx
@@ -105,6 +105,30 @@ export function CommitDiffScreen() {
         // Only a single commit has a signature — a range or a commit-vs-worktree
         // comparison does not (#61 D6).
         verifyOid={target.kind === "commit-self" ? target.oid : undefined}
+        // Mirrors the fetch above: a commit's own diff is against its parent
+        // (`^`, which simply fails and renders plain on a root commit, where
+        // there is no old side anyway); every other target is an explicit pair.
+        syntaxSides={
+          repo
+            ? target.kind === "commit-self"
+              ? {
+                  repoId: repo.id,
+                  old: { kind: "rev", rev: `${target.oid}^` },
+                  new: { kind: "rev", rev: target.oid },
+                }
+              : {
+                  repoId: repo.id,
+                  old: {
+                    kind: "rev",
+                    rev: target.kind === "commit-vs-commit" ? target.from : target.oid,
+                  },
+                  new: {
+                    kind: "rev",
+                    rev: target.kind === "commit-vs-commit" ? target.to : "HEAD",
+                  },
+                }
+            : undefined
+        }
       />
     </div>
   );

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -50,13 +50,8 @@ import {
   pruneSelection,
   type Selection,
 } from "@/lib/selection";
-import {
-  getDiff,
-  getLogPage,
-  readFileContent,
-  readFileContentAtRev,
-} from "@/lib/tauri";
-import { useSyntax } from "@/lib/syntax";
+import { getDiff, getLogPage } from "@/lib/tauri";
+import { useDiffSyntax } from "@/lib/syntax";
 import {
   WhitespaceToggle,
   useHunkActionsDisabledReason,
@@ -448,44 +443,15 @@ export function CommitPanelScreen() {
     return new Set(selected ? [keyOf(selected)] : []);
   }, [sel.keys.length, selectedKeys, selected]);
 
-  // Whole-file text for syntax tokens, one read per side.
-  //
-  // This pane diffs against the INDEX (IndexToHead when staged,
-  // WorktreeToIndex otherwise), and the index is not readable — there is no
-  // read_file_content_at_index. HEAD and the worktree are the two texts we can
-  // get, and they agree with the index in every case except a partially staged
-  // file. Being off there mis-colours a line; it cannot affect what gets staged,
-  // because staging addresses lines by changedIndex, never by these tokens.
-  const [sides, setSides] = React.useState<{ old: string | null; new: string | null }>({
-    old: null,
-    new: null,
+  // This pane diffs against the INDEX (IndexToHead when staged, WorktreeToIndex
+  // otherwise), which cannot be read — see the note on useDiffSyntax for why HEAD
+  // and the worktree are the right approximation and why being off is harmless.
+  const syntax = useDiffSyntax({
+    repoId: selected && !selected.status.embedded ? (repo?.id ?? null) : null,
+    path: selected?.path ?? null,
+    old: { kind: "rev", rev: "HEAD", path: diff?.oldPath },
+    new: { kind: "worktree" },
   });
-
-  React.useEffect(() => {
-    if (!repo || !selected || selected.status.embedded) {
-      setSides({ old: null, new: null });
-      return;
-    }
-    let cancelled = false;
-    // A rename's old side lives at its OLD path; HEAD has no blob at the new one.
-    const oldPath = diff?.oldPath ?? selected.path;
-    Promise.all([
-      readFileContentAtRev(repo.id, "HEAD", oldPath).catch(() => null),
-      readFileContent(repo.id, selected.path).catch(() => null),
-    ]).then(([o, n]) => {
-      if (!cancelled) setSides({ old: o?.text ?? null, new: n?.text ?? null });
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [repo, selected?.path, selected?.status.embedded, diff?.oldPath]);
-
-  const oldSyntax = useSyntax(selected?.path ?? null, sides.old);
-  const newSyntax = useSyntax(selected?.path ?? null, sides.new);
-  const syntax = React.useMemo(
-    () => ({ old: oldSyntax, new: newSyntax }),
-    [oldSyntax, newSyntax],
-  );
 
   React.useEffect(() => {
     if (!selected || !repo) {

--- a/src/screens/DiffViewer.split.test.ts
+++ b/src/screens/DiffViewer.split.test.ts
@@ -1,0 +1,82 @@
+// Split-view column alignment (and the word spans it enables).
+//
+// The old diffToSplit emitted each line as it came, padding whichever side was
+// missing — so a hunk that mixed removals and additions drifted the two columns
+// apart. Pairing runs fixes that AND is the precondition for intra-line diff,
+// which needs to know which removal goes with which addition.
+import { describe, expect, it } from "vitest";
+import { diffToSplit } from "./DiffViewer";
+import type { FileDiff } from "@/lib/types";
+
+type Line = FileDiff["hunks"][number]["lines"][number];
+
+const rem = (n: number, content: string): Line => ({
+  kind: { kind: "Deletion" }, oldLineno: n, newLineno: null, content,
+});
+const add = (n: number, content: string): Line => ({
+  kind: { kind: "Addition" }, oldLineno: null, newLineno: n, content,
+});
+const ctx = (n: number, content: string): Line => ({
+  kind: { kind: "Context" }, oldLineno: n, newLineno: n, content,
+});
+
+const diff = (lines: Line[]): FileDiff => ({
+  path: "a.ts",
+  oldPath: null,
+  binary: false,
+  additions: 0,
+  deletions: 0,
+  hunks: [
+    { header: "@@ -1 +1 @@", oldStart: 1, oldLines: 1, newStart: 1, newLines: 1, lines },
+  ],
+});
+
+describe("diffToSplit", () => {
+  it("puts a removal and its matching addition on the SAME row", () => {
+    const { left, right } = diffToSplit(diff([rem(1, "let a"), add(1, "let b")]));
+    // index 0 is the hunk header row on both sides
+    expect(left[1]).toMatchObject({ kind: "rem", text: "let a" });
+    expect(right[1]).toMatchObject({ kind: "add", text: "let b" });
+    expect(left).toHaveLength(right.length);
+  });
+
+  it("pads the shorter side when the runs are uneven", () => {
+    const { left, right } = diffToSplit(diff([rem(1, "a"), rem(2, "b"), add(1, "a2")]));
+    expect(left).toHaveLength(right.length);
+    expect(right[2]).toMatchObject({ kind: "empty" });
+  });
+
+  it("attaches word spans to paired rows", () => {
+    const { left, right } = diffToSplit(diff([rem(1, "let a = 1"), add(1, "let a = 2")]));
+    expect(left[1].spans?.some((s) => s.changed)).toBe(true);
+    expect(right[1].spans?.some((s) => s.changed)).toBe(true);
+  });
+
+  it("keeps context rows aligned on both sides", () => {
+    const { left, right } = diffToSplit(diff([ctx(1, "same"), rem(2, "x"), add(2, "y")]));
+    expect(left[1]).toMatchObject({ kind: "ctx", text: "same" });
+    expect(right[1]).toMatchObject({ kind: "ctx", text: "same" });
+    expect(left).toHaveLength(right.length);
+  });
+
+  it("keeps the columns aligned across a mixed hunk, the case that used to drift", () => {
+    const { left, right } = diffToSplit(
+      diff([
+        ctx(1, "keep"),
+        rem(2, "gone"),
+        add(2, "new1"),
+        add(3, "new2"),
+        ctx(4, "tail"),
+      ]),
+    );
+    expect(left).toHaveLength(right.length);
+    // Both columns must end on the same context line, at the same index.
+    const lastLeft = left.length - 1;
+    expect(left[lastLeft]).toMatchObject({ kind: "ctx", text: "tail" });
+    expect(right[lastLeft]).toMatchObject({ kind: "ctx", text: "tail" });
+  });
+
+  it("returns empty columns for no diff", () => {
+    expect(diffToSplit(null)).toEqual({ left: [], right: [] });
+  });
+});

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -27,6 +27,7 @@ import { statusMark } from "@/lib/derive";
 import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
 import { getDiff } from "@/lib/tauri";
 import { useDiffSyntax } from "@/lib/syntax";
+import { pairChangedLines } from "@/lib/pairChangedLines";
 import { PGPane, FocusableScroll, usePaneList, useHunkNav } from "@/features/keymap";
 import type { FileDiff } from "@/lib/types";
 
@@ -135,6 +136,23 @@ export function DiffViewerScreen() {
   }, [diff, findQuery]);
 
   const split = React.useMemo(() => diffToSplit(findFiltered), [findFiltered]);
+
+  // Same side rule as the unified path: the left column is the old file, the
+  // right the new one, and a row resolves its tokens by its own line number.
+  const splitWithSyntax = React.useMemo(() => {
+    const attach = (rows: SideLine[], lines: typeof syntax.old): SideLine[] =>
+      rows.map((r) => {
+        if (!lines || r.kind === "info" || r.kind === "empty") return r;
+        const n = typeof r.ln === "number" ? r.ln : Number(r.ln);
+        if (!Number.isFinite(n) || n < 1) return r;
+        const tokens = lines[n - 1];
+        return tokens ? { ...r, syntax: tokens } : r;
+      });
+    return {
+      left: attach(split.left, syntax.old),
+      right: attach(split.right, syntax.new),
+    };
+  }, [split, syntax]);
 
   // Keyboard: arrows move the file selection while the list pane is focused.
   const selectedIndex = Math.max(
@@ -379,7 +397,10 @@ export function DiffViewerScreen() {
             </FocusableScroll>
           )}
           {!diffLoading && findFiltered && !findFiltered.binary && mode === "split" && (
-            <PGSideBySideDiff left={split.left} right={split.right} />
+            <PGSideBySideDiff
+              left={splitWithSyntax.left}
+              right={splitWithSyntax.right}
+            />
           )}
         </PGPane>
       </div>
@@ -406,45 +427,70 @@ function toUiLine(l: {
   };
 }
 
-function diffToSplit(d: FileDiff | null): {
+/**
+ * Flatten hunks into aligned left/right columns.
+ *
+ * Removals and additions are collected as RUNS and emitted side by side, so the
+ * i-th removal shares a row with the i-th addition. Emitting each line as it came
+ * let the columns drift apart on any hunk that mixed both, and paired rows are
+ * also what intra-line word diff needs.
+ *
+ * Exported for its own test: the alignment invariant (both columns always the same
+ * length, and the same index meaning the same place in the hunk) is the kind of
+ * thing that regresses silently through the UI.
+ */
+export function diffToSplit(d: FileDiff | null): {
   left: SideLine[];
   right: SideLine[];
 } {
   const left: SideLine[] = [];
   const right: SideLine[] = [];
   if (!d) return { left, right };
+
   for (const h of d.hunks) {
     left.push({ kind: "info", text: h.header });
     right.push({ kind: "info", text: h.header });
+
+    let remRun: typeof h.lines = [];
+    let addRun: typeof h.lines = [];
+
+    const flush = () => {
+      if (remRun.length === 0 && addRun.length === 0) return;
+      const paired = pairChangedLines(
+        remRun.map((l) => l.content),
+        addRun.map((l) => l.content),
+      );
+      const rows = Math.max(remRun.length, addRun.length);
+      for (let i = 0; i < rows; i++) {
+        const r = remRun[i];
+        const a = addRun[i];
+        const p = paired[i] ?? null;
+        left.push(
+          r
+            ? { kind: "rem", ln: r.oldLineno ?? undefined, text: r.content, spans: p?.old }
+            : { kind: "empty", ln: "", text: "" },
+        );
+        right.push(
+          a
+            ? { kind: "add", ln: a.newLineno ?? undefined, text: a.content, spans: p?.new }
+            : { kind: "empty", ln: "", text: "" },
+        );
+      }
+      remRun = [];
+      addRun = [];
+    };
+
     for (const ln of h.lines) {
       const k = ln.kind.kind;
-      if (k === "Addition") {
-        left.push({ kind: "empty", ln: "", text: "" });
-        right.push({
-          kind: "add",
-          ln: ln.newLineno ?? undefined,
-          text: ln.content,
-        });
-      } else if (k === "Deletion") {
-        left.push({
-          kind: "rem",
-          ln: ln.oldLineno ?? undefined,
-          text: ln.content,
-        });
-        right.push({ kind: "empty", ln: "", text: "" });
-      } else {
-        left.push({
-          kind: "ctx",
-          ln: ln.oldLineno ?? undefined,
-          text: ln.content,
-        });
-        right.push({
-          kind: "ctx",
-          ln: ln.newLineno ?? undefined,
-          text: ln.content,
-        });
+      if (k === "Deletion") remRun.push(ln);
+      else if (k === "Addition") addRun.push(ln);
+      else {
+        flush();
+        left.push({ kind: "ctx", ln: ln.oldLineno ?? undefined, text: ln.content });
+        right.push({ kind: "ctx", ln: ln.newLineno ?? undefined, text: ln.content });
       }
     }
+    flush();
   }
   return { left, right };
 }

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -25,8 +25,8 @@ import {
 } from "@/features/diff/WhitespaceToggle";
 import { statusMark } from "@/lib/derive";
 import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
-import { getDiff, readFileContent, readFileContentAtRev } from "@/lib/tauri";
-import { useSyntax } from "@/lib/syntax";
+import { getDiff } from "@/lib/tauri";
+import { useDiffSyntax } from "@/lib/syntax";
 import { PGPane, FocusableScroll, usePaneList, useHunkNav } from "@/features/keymap";
 import type { FileDiff } from "@/lib/types";
 
@@ -113,42 +113,14 @@ export function DiffViewerScreen() {
     };
   }, [current?.path, current?.embedded, repo, diffContextLines, ignoreWhitespace]);
 
-  // Whole-file text for both sides, because a hunk is only a window into a
-  // file: a block comment or template literal opening above it would mis-colour
-  // every line below. A failed read leaves that side plain rather than breaking
-  // the diff — an added or deleted file legitimately has only one side.
-  const [sides, setSides] = React.useState<{ old: string | null; new: string | null }>({
-    old: null,
-    new: null,
+  // This screen compares the worktree against HEAD; an embedded repo has no
+  // text to read on either side.
+  const syntax = useDiffSyntax({
+    repoId: current && !current.embedded ? (repo?.id ?? null) : null,
+    path: current?.path ?? null,
+    old: { kind: "rev", rev: "HEAD", path: diff?.oldPath },
+    new: { kind: "worktree" },
   });
-
-  React.useEffect(() => {
-    if (!repo || !current || current.embedded) {
-      setSides({ old: null, new: null });
-      return;
-    }
-    let cancelled = false;
-    // A rename's old side lives at its OLD path; HEAD has no blob at the new
-    // one, so reading `current.path` there would leave every removed line
-    // unhighlighted.
-    const oldPath = diff?.oldPath ?? current.path;
-    Promise.all([
-      readFileContentAtRev(repo.id, "HEAD", oldPath).catch(() => null),
-      readFileContent(repo.id, current.path).catch(() => null),
-    ]).then(([o, n]) => {
-      if (!cancelled) setSides({ old: o?.text ?? null, new: n?.text ?? null });
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [repo, current?.path, current?.embedded, diff?.oldPath]);
-
-  const oldSyntax = useSyntax(current?.path ?? null, sides.old);
-  const newSyntax = useSyntax(current?.path ?? null, sides.new);
-  const syntax = React.useMemo(
-    () => ({ old: oldSyntax, new: newSyntax }),
-    [oldSyntax, newSyntax],
-  );
 
   const findFiltered = React.useMemo<FileDiff | null>(() => {
     if (!diff || !findQuery.trim()) return diff;

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -691,6 +691,17 @@ export function HistoryScreen() {
       // The inline panel shows the selected commit's own diff; a multi-selection
       // renders MultiCommitDetail instead, so this is always one commit (#61 D6).
       verifyOid={current?.oid}
+      // The inline panel shows one commit's own diff, so the old side is its
+      // parent — `^` fails harmlessly on a root commit, which has no old side.
+      syntaxSides={
+        repo && current
+          ? {
+              repoId: repo.id,
+              old: { kind: "rev", rev: `${current.oid}^` },
+              new: { kind: "rev", rev: current.oid },
+            }
+          : undefined
+      }
     />
   );
 


### PR DESCRIPTION
PR2 of #104, on top of #106. Brings highlighting and word diff to every code surface PR1 didn't reach, and fixes the split view's column alignment on the way.

## What changed

- **`pairChangedLines` extracted** from `PGHunk`. Three surfaces now need the same rem↔add pairing rule, so it is one tested function instead of three copies that drift.
- **`useDiffSyntax`** replaces the fetch effect PR1 left duplicated in two screens. Each side is described by an explicit `SideSource` (`rev` / `worktree` / `none`) rather than overloading `null` — that sentinel would have to mean "the worktree" on the new side and "there is no such side" on the old one, and I mis-coded exactly that before switching to the explicit type.
- **Split view now aligns.** `diffToSplit` walks removal and addition *runs* together, so the i-th removal shares a row with the i-th addition. It previously emitted each line as it came and padded the other column, which drifted the two sides apart on any hunk mixing both — the same row index meant different places in the file. Pairing is also the precondition for intra-line diff here.
- **`CommitDiffPanel`** gains `syntaxSides`. The panel is presentational and never learns which revisions it is showing, so callers that know them pass them; a combined multi-commit diff, where "the" old side has no meaning, omits it and renders plain. A commit's own diff reads its parent via `^`, which fails harmlessly on a root commit — all additions, no old side to colour.
- **Merge side panes** highlight from the text already in the model, so no extra read.
- **Merge result pane** highlights through a CodeMirror `StateField` fed by a 120 ms debounced tokenize. It cannot use the synchronous `EditorView.decorations.compute` path its conflict marks use, because tokenizing is async and the document changes on every keystroke. The field maps its ranges through intervening edits, and a result that arrives after the document moved on is discarded rather than applied to newer text. All three panes therefore share one `--syn-*` palette and one set of known languages.

## Notes for review

`SidePane`'s blank-line placeholder is a **U+00A0**, not a space — a plain space collapses in JSX, and uniform row height is what lets the middle pane sync scroll by line index. It now has a comment saying so, after four string edits failed against it.

Renames are handled per file: `useDiffSyntax`'s `rev` source carries its own path, and `CommitDiffPanel` fills it from the selected `FileDiff.oldPath`.

## Verification

- `pnpm tsc --noEmit` — clean
- `pnpm test` — 110 files, 816 tests passing. The pre-existing `wordDiffRender`, `syntaxRender`, `CommitPanel.lineStaging`, `MergeBody` and `resultEditor` suites all pass **unedited**, which is what guards the two refactors.
- `pnpm vite build` — clean
- `pnpm test:e2e:docker full --spec merge-window --spec history-diff --spec keymap` — 3 spec files, 100% in 1:18, `merge-window` included since both merge panes changed.

Remaining in #104: PR3, windowed diff rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
