### PR TITLE
fix(rebase): stop a merge commit from half-rewriting the branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,16 @@ git/
 │                RepoPresence probe (Present/Absent/Refused — NEVER infer
 │                "no repo" from a failed open), non-opening repo_root_for
 │                walk, and the global `safe.directory` writer
+├── rebase_plan.rs  Plan validation, run BEFORE `rebase_start` touches the repo:
+│                merge-legal actions, duplicate/unknown oids, all-drop plans.
+│                A rejected plan must leave HEAD, the branch ref, and the
+│                worktree untouched — that is the whole point of the module
+├── rebase_state.rs  On-disk mirror of an in-progress rebase
+│                (`.git/platypusgit-rebase.json` + `ORIG_HEAD`) so Continue and
+│                Abort survive an app restart. Deliberately NOT git's own
+│                `.git/rebase-merge/` dir — a half-compatible one would let
+│                `git status` / `git rebase --continue` claim a rebase they
+│                cannot drive
 └── signature.rs Author/committer signature helpers
 commands/        Thin Tauri handlers, one file per area:
 ├── repo.rs        open_repo, trust_repo_path, get_status, list_all_files,
@@ -352,6 +362,33 @@ lib/
 - **Danger-op error paths refresh first, set error last.** In `useRepoStore` catch arms (see `mergeBranch`), call `refreshAll()` BEFORE `set({ error })`: `refreshAll` starts with `set({ error: null })`, and React 18 batches same-tick sets, so the opposite order silently wipes the banner. `refreshAll` never rethrows, so the error always wins when set last. A failed git op must still refresh — the UI reflects disk truth even on error.
 - `useNavStore` handles cross-screen navigation intents — add new `NavIntent` kinds there, route in `AppShell`.
 - Cross-feature state is rare; compose in `src/store.ts` if needed — don't hoist prematurely.
+
+### Interactive rebase engine
+- **The plan is validated before the repository is touched.**
+  `rebase_plan::validate` runs first in `rebase_start`; anything it rejects
+  raises `AppError::InvalidRebasePlan` with HEAD, the branch ref, and the
+  worktree untouched. Before this, an unexecutable step (a merge commit, which
+  libgit2 refuses to cherry-pick without a mainline) surfaced mid-replay with
+  earlier picks already committed and the branch tip already moved.
+- **The replay runs on a detached HEAD** and moves the branch ref exactly once,
+  when the plan completes (`finish_rebase`). So a failed or paused rebase never
+  leaves the branch mid-replay, and `rebase_abort` is "put HEAD back on the
+  branch" rather than a reset to a remembered oid.
+- **`RebaseState.rewritten` maps original oid → replayed oid** for every step
+  that ran, recorded *after* the action's post-commit rewrite (reword amends,
+  squash/fixup collapse), and a dropped step maps to the HEAD it left behind.
+- **Merge commits in a plan may only be dropped** (git's own default: the merge
+  disappears and its commits are replayed individually). `rebase_plan::merge_legal`
+  is the single source of truth; any UI that offers merge-row actions mirrors it.
+- **Every transition is mirrored to `.git/platypusgit-rebase.json`**, and
+  `rebase_status` / `repo_state` fall back to it when this process did not start
+  the rebase. `repo_state` gives the file precedence over libgit2's
+  `repo.state()`, which only sees the `CHERRY_PICK_HEAD` a paused step leaves
+  behind.
+- **`continue_operation` / `abort_operation` delegate** to `rebase_continue` /
+  `rebase_abort` whenever a rebase is in progress. The Conflict screen and the
+  Rebase banner must stay two entry points to one engine: committing the
+  resolved tree without advancing the plan strands the rest of the rebase.
 
 ### Async / threading (Rust)
 - `git2::Repository` is `Send` but not `Sync`. `Libgit2Backend` holds each opened repo as `Mutex<Repository>` inside a `Mutex<HashMap<RepoId, ...>>`.

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -66,6 +66,14 @@ pub enum AppError {
     /// `safe.directory` exception has to contain.
     #[error("repository is owned by another user: {0}")]
     DubiousOwnership(String),
+
+    /// A rebase plan the engine cannot execute — a merge commit carrying an
+    /// action that has no meaning for it, a duplicate or unknown oid, a plan
+    /// that drops everything. Raised by `rebase_plan::validate` *before*
+    /// `rebase_start` moves anything, so the repository is untouched when the
+    /// frontend shows it.
+    #[error("invalid rebase plan: {0}")]
+    InvalidRebasePlan(String),
 }
 
 impl From<git2::Error> for AppError {

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -40,6 +40,19 @@ pub struct RebaseState {
     /// this rather than just resetting to wherever the in-progress rebase
     /// happened to stop (see `rebase_abort` doc comment).
     pub orig_head: String,
+    /// Full ref name of the branch HEAD pointed at when the rebase started
+    /// (`refs/heads/…`), or `None` when it started from a detached HEAD. The
+    /// replay runs detached; this ref is moved exactly once, when the plan
+    /// completes.
+    pub head_name: Option<String>,
+    /// The commit the replay started from — the base every step sits on top of
+    /// unless it says otherwise. Recorded so a resumed session knows where the
+    /// replay began.
+    pub onto: String,
+    /// Original oid → rewritten oid for every step that has run. A dropped or
+    /// skipped step maps to the HEAD it left behind, so a later step that has
+    /// to sit on top of it still resolves to a real commit.
+    pub rewritten: HashMap<String, String>,
 }
 
 pub struct Libgit2Backend {
@@ -165,6 +178,46 @@ impl Libgit2Backend {
         Ok(())
     }
 
+    /// Record what a step's commit became, so a later step that has to sit on
+    /// top of it can resolve the rewritten oid. A dropped step maps to the HEAD
+    /// it left behind.
+    fn record_rewritten(&self, repo_id: &RepoId, old: &str) -> AppResult<()> {
+        let new = self.with_repo(repo_id, |repo| {
+            Ok(repo.head()?.peel_to_commit()?.id().to_string())
+        })?;
+        let mut rebases = self
+            .rebases
+            .lock()
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        if let Some(state) = rebases.get_mut(repo_id) {
+            state.rewritten.insert(old.to_string(), new);
+        }
+        Ok(())
+    }
+
+    /// Point the original branch at the replayed history and reattach HEAD to
+    /// it. Called once, when the plan is exhausted. A rebase that started from
+    /// a detached HEAD just stays detached.
+    fn finish_rebase(&self, repo_id: &RepoId) -> AppResult<()> {
+        let head_name = {
+            let rebases = self
+                .rebases
+                .lock()
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+            rebases.get(repo_id).and_then(|s| s.head_name.clone())
+        };
+        let Some(head_name) = head_name else {
+            return Ok(());
+        };
+
+        self.with_repo(repo_id, |repo| {
+            let tip = repo.head()?.peel_to_commit()?.id();
+            repo.reference(&head_name, tip, true, "rebase (finish)")?;
+            repo.set_head(&head_name)?;
+            Ok(())
+        })
+    }
+
     fn mark_paused(&self, repo_id: &RepoId, reason: &str) -> AppResult<RebaseStatus> {
         let mut rebases = self
             .rebases
@@ -205,7 +258,11 @@ impl Libgit2Backend {
             };
 
             let Some(step) = step else {
-                // Plan exhausted — rebase complete. Capture the final status
+                // Plan exhausted — move the branch to the replayed history and
+                // reattach HEAD before reporting, so the caller's refresh sees
+                // the finished state.
+                self.finish_rebase(repo_id)?;
+                // Rebase complete. Capture the final status
                 // before dropping the in-memory state so this call's caller
                 // still sees the completed count, but remove the entry so a
                 // later `rebase_status` poll (banner) or `abort_operation`
@@ -220,9 +277,12 @@ impl Libgit2Backend {
                 return Ok(status);
             };
 
-            // Drop is never cherry-picked, so it is never a resume step.
+            // Drop is never cherry-picked, so it is never a resume step. It
+            // still maps into `rewritten` — as the HEAD it left behind — so a
+            // later step whose base was dropped resolves to a real commit.
             if !resuming && step.action == RebaseAction::Drop {
                 self.bump_completed(repo_id)?;
+                self.record_rewritten(repo_id, &step.oid)?;
                 continue;
             }
 
@@ -277,6 +337,7 @@ impl Libgit2Backend {
 
                 RebaseAction::Edit => {
                     self.bump_completed(repo_id)?;
+                    self.record_rewritten(repo_id, &step.oid)?;
                     return self.mark_paused(repo_id, "edit");
                 }
 
@@ -321,6 +382,12 @@ impl Libgit2Backend {
                     self.bump_completed(repo_id)?;
                 }
             }
+
+            // Record what this step became AFTER the action's post-commit
+            // rewrite — reword amends, squash/fixup collapse — so the map holds
+            // the oid a later step should build on rather than the intermediate
+            // commit `finish_pick` wrote.
+            self.record_rewritten(repo_id, &step.oid)?;
         }
     }
 }
@@ -3249,9 +3316,12 @@ impl GitBackend for Libgit2Backend {
             })?;
         let first_oid_str = first_step.oid.clone();
 
-        // Verify worktree is clean, remember the pre-rebase tip (so an abort
-        // can restore it), and reset HEAD to the parent of the first commit.
-        let orig_head = self.with_repo(repo_id, |repo| {
+        // Verify worktree is clean, remember the branch and its pre-rebase tip
+        // (so an abort can put both back), then DETACH at the base and replay
+        // there. The branch ref is moved exactly once, when the plan completes:
+        // committing to an attached HEAD advanced the branch step by step,
+        // which left it mid-replay whenever a step failed or paused.
+        let (orig_head, head_name, onto) = self.with_repo(repo_id, |repo| {
             let statuses = repo.statuses(None)?;
             if statuses.iter().any(|s| {
                 let b = s.status();
@@ -3267,17 +3337,30 @@ impl GitBackend for Libgit2Backend {
                 ));
             }
 
-            let orig_head = repo.head()?.peel_to_commit()?.id().to_string();
+            let head_ref = repo.head()?;
+            let head_name = if repo.head_detached()? {
+                None
+            } else {
+                head_ref.name().map(|s| s.to_string())
+            };
+            let orig_head = head_ref.peel_to_commit()?.id().to_string();
 
             let first_commit = repo
                 .revparse_single(&first_oid_str)
                 .map_err(|_| AppError::InvalidRef(first_oid_str.clone()))?
                 .peel_to_commit()?;
             let parent = first_commit.parent(0).map_err(|_| {
-                AppError::InvalidRef("first rebase commit has no parent".into())
+                AppError::InvalidRebasePlan(format!(
+                    "{} has no parent to rebase onto",
+                    crate::git::rebase_plan::short(&first_oid_str)
+                ))
             })?;
+
+            // Detach first, then hard-reset: with HEAD attached, the reset
+            // would drag the branch ref along.
+            repo.set_head_detached(parent.id())?;
             repo.reset(parent.as_object(), git2::ResetType::Hard, None)?;
-            Ok(orig_head)
+            Ok((orig_head, head_name, parent.id().to_string()))
         })?;
 
         let total = plan.len();
@@ -3294,6 +3377,9 @@ impl GitBackend for Libgit2Backend {
                 pause_reason: None,
                 conflict_step: None,
                 orig_head,
+                head_name,
+                onto,
+                rewritten: HashMap::new(),
             },
         );
         drop(rebases);
@@ -3316,29 +3402,40 @@ impl GitBackend for Libgit2Backend {
     }
 
     fn rebase_abort(&self, repo_id: &RepoId) -> AppResult<()> {
-        // Drop in-memory state, keeping the pre-rebase tip it recorded.
-        let mut rebases = self
-            .rebases
-            .lock()
-            .map_err(|e| AppError::Internal(e.to_string()))?;
-        let orig_head = rebases.remove(repo_id).map(|s| s.orig_head);
-        drop(rebases);
+        // Drop in-memory state, keeping the branch and pre-rebase tip it
+        // recorded.
+        let removed = {
+            let mut rebases = self
+                .rebases
+                .lock()
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+            rebases.remove(repo_id)
+        };
+        let orig_head = removed.as_ref().map(|s| s.orig_head.clone());
+        let head_name = removed.and_then(|s| s.head_name);
 
         self.with_repo(repo_id, |repo| {
             repo.cleanup_state()?;
-            // Restore the branch to where it was before `rebase_start` moved
-            // it, not wherever the in-progress rebase happened to stop —
-            // `rebase_start` advances the branch tip commit-by-commit as
-            // picks land, so "current HEAD" at abort time is mid-rebase
-            // progress, not the pre-rebase position (mirrors `git rebase
-            // --abort` restoring ORIG_HEAD). Fall back to current HEAD only
-            // if we somehow have no recorded state (e.g. abort called
-            // without a matching start).
-            let target = match &orig_head {
-                Some(oid) => repo.revparse_single(oid)?.peel_to_commit()?,
-                None => repo.head()?.peel_to_commit()?,
-            };
-            repo.reset(target.as_object(), git2::ResetType::Hard, None)?;
+            // The replay ran on a detached HEAD, so the branch never moved:
+            // abort is "put HEAD back on the branch and throw the replay away".
+            // A rebase started from a detached HEAD has no branch to return to,
+            // so it goes back to the tip it recorded.
+            match (&head_name, &orig_head) {
+                (Some(name), _) => {
+                    repo.set_head(name)?;
+                    let target = repo.head()?.peel_to_commit()?;
+                    repo.reset(target.as_object(), git2::ResetType::Hard, None)?;
+                }
+                (None, Some(oid)) => {
+                    let target = repo.revparse_single(oid)?.peel_to_commit()?;
+                    repo.set_head_detached(target.id())?;
+                    repo.reset(target.as_object(), git2::ResetType::Hard, None)?;
+                }
+                (None, None) => {
+                    let target = repo.head()?.peel_to_commit()?;
+                    repo.reset(target.as_object(), git2::ResetType::Hard, None)?;
+                }
+            }
             Ok(())
         })
     }

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -195,6 +195,93 @@ impl Libgit2Backend {
         Ok(())
     }
 
+    /// Mirror the in-memory rebase to the gitdir. Called after every state
+    /// transition; a missing in-memory entry means the rebase is over, so the
+    /// file goes away.
+    fn persist_rebase(&self, repo_id: &RepoId) -> AppResult<()> {
+        let snapshot = {
+            let rebases = self
+                .rebases
+                .lock()
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+            rebases
+                .get(repo_id)
+                .map(|s| crate::git::rebase_state::PersistedRebase {
+                    version: crate::git::rebase_state::VERSION,
+                    head_name: s.head_name.clone(),
+                    orig_head: s.orig_head.clone(),
+                    onto: s.onto.clone(),
+                    total: s.total,
+                    completed: s.completed,
+                    remaining: s.plan.iter().cloned().collect(),
+                    pause_reason: s.pause_reason.clone(),
+                    current: s.conflict_step.clone().map(|step| {
+                        crate::git::rebase_state::PersistedCurrent {
+                            step,
+                            phase: s.pause_reason.clone().unwrap_or_else(|| "conflict".into()),
+                        }
+                    }),
+                    rewritten: s
+                        .rewritten
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect(),
+                })
+        };
+
+        self.with_repo(repo_id, |repo| match &snapshot {
+            Some(state) => crate::git::rebase_state::save(repo, state),
+            None => crate::git::rebase_state::clear(repo),
+        })
+    }
+
+    /// Rebuild the in-memory rebase from the state file. Used when this process
+    /// did not start the rebase — the app was restarted mid-operation — so that
+    /// Continue and Abort work the same as they would have in the original
+    /// session. Returns false when there is no rebase on disk.
+    fn rehydrate_rebase(&self, repo_id: &RepoId) -> AppResult<bool> {
+        let Some(p) = self.with_repo(repo_id, crate::git::rebase_state::load)? else {
+            return Ok(false);
+        };
+        let mut rebases = self
+            .rebases
+            .lock()
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        rebases.insert(
+            repo_id.clone(),
+            RebaseState {
+                plan: p.remaining.into_iter().collect(),
+                total: p.total,
+                completed: p.completed,
+                pause_reason: p.pause_reason,
+                conflict_step: p.current.map(|c| c.step),
+                orig_head: p.orig_head,
+                head_name: p.head_name,
+                onto: p.onto,
+                rewritten: p.rewritten.into_iter().collect(),
+            },
+        );
+        Ok(true)
+    }
+
+    /// True when a rebase this backend can drive is in progress — in memory, or
+    /// recorded on disk by an earlier session.
+    fn rebase_in_progress(&self, repo_id: &RepoId) -> AppResult<bool> {
+        let in_memory = {
+            let rebases = self
+                .rebases
+                .lock()
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+            rebases.contains_key(repo_id)
+        };
+        if in_memory {
+            return Ok(true);
+        }
+        Ok(self
+            .with_repo(repo_id, crate::git::rebase_state::load)?
+            .is_some())
+    }
+
     /// Point the original branch at the replayed history and reattach HEAD to
     /// it. Called once, when the plan is exhausted. A rebase that started from
     /// a detached HEAD just stays detached.
@@ -227,6 +314,7 @@ impl Libgit2Backend {
             state.pause_reason = Some(reason.into());
         }
         drop(rebases);
+        self.persist_rebase(repo_id)?;
         self.rebase_status(repo_id)
     }
 
@@ -269,11 +357,16 @@ impl Libgit2Backend {
                 // call doesn't treat this finished rebase as still
                 // in-progress/abortable via its now-stale `orig_head`.
                 let status = self.rebase_status(repo_id)?;
-                let mut rebases = self
-                    .rebases
-                    .lock()
-                    .map_err(|e| AppError::Internal(e.to_string()))?;
-                rebases.remove(repo_id);
+                {
+                    let mut rebases = self
+                        .rebases
+                        .lock()
+                        .map_err(|e| AppError::Internal(e.to_string()))?;
+                    rebases.remove(repo_id);
+                }
+                // No in-memory entry any more, so this sweeps the state file
+                // too — the operation is over on disk as well.
+                self.persist_rebase(repo_id)?;
                 return Ok(status);
             };
 
@@ -283,6 +376,7 @@ impl Libgit2Backend {
             if !resuming && step.action == RebaseAction::Drop {
                 self.bump_completed(repo_id)?;
                 self.record_rewritten(repo_id, &step.oid)?;
+                self.persist_rebase(repo_id)?;
                 continue;
             }
 
@@ -388,6 +482,7 @@ impl Libgit2Backend {
             // the oid a later step should build on rather than the intermediate
             // commit `finish_pick` wrote.
             self.record_rewritten(repo_id, &step.oid)?;
+            self.persist_rebase(repo_id)?;
         }
     }
 }
@@ -3344,6 +3439,9 @@ impl GitBackend for Libgit2Backend {
                 head_ref.name().map(|s| s.to_string())
             };
             let orig_head = head_ref.peel_to_commit()?.id().to_string();
+            // Same escape hatch git leaves before rewriting history:
+            // `git reset --hard ORIG_HEAD` undoes this rebase from the CLI.
+            crate::git::rebase_state::write_orig_head(repo, &orig_head)?;
 
             let first_commit = repo
                 .revparse_single(&first_oid_str)
@@ -3384,10 +3482,27 @@ impl GitBackend for Libgit2Backend {
         );
         drop(rebases);
 
+        // Mirror to disk before the first step runs: a crash between here and
+        // the first commit must still be recoverable.
+        self.persist_rebase(repo_id)?;
+
         self.advance_rebase(repo_id)
     }
 
     fn rebase_continue(&self, repo_id: &RepoId) -> AppResult<RebaseStatus> {
+        // A rebase started by an earlier session has no in-memory entry; its
+        // plan, progress, and rewritten map are all on disk.
+        let known = {
+            let rebases = self
+                .rebases
+                .lock()
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+            rebases.contains_key(repo_id)
+        };
+        if !known && !self.rehydrate_rebase(repo_id)? {
+            return Err(AppError::InvalidRef("no rebase in progress".into()));
+        }
+
         // Verify no unresolved conflicts remain.
         self.with_repo(repo_id, |repo| {
             let statuses = repo.statuses(None)?;
@@ -3411,11 +3526,20 @@ impl GitBackend for Libgit2Backend {
                 .map_err(|e| AppError::Internal(e.to_string()))?;
             rebases.remove(repo_id)
         };
-        let orig_head = removed.as_ref().map(|s| s.orig_head.clone());
-        let head_name = removed.and_then(|s| s.head_name);
+        let (orig_head, head_name) = match removed {
+            Some(s) => (Some(s.orig_head), s.head_name),
+            None => {
+                // Restarted mid-rebase: the state file is all we have.
+                match self.with_repo(repo_id, crate::git::rebase_state::load)? {
+                    Some(p) => (Some(p.orig_head), p.head_name),
+                    None => (None, None),
+                }
+            }
+        };
 
         self.with_repo(repo_id, |repo| {
             repo.cleanup_state()?;
+            crate::git::rebase_state::clear(repo)?;
             // The replay ran on a detached HEAD, so the branch never moved:
             // abort is "put HEAD back on the branch and throw the replay away".
             // A rebase started from a detached HEAD has no branch to return to,
@@ -3441,24 +3565,41 @@ impl GitBackend for Libgit2Backend {
     }
 
     fn rebase_status(&self, repo_id: &RepoId) -> AppResult<RebaseStatus> {
-        let rebases = self
-            .rebases
-            .lock()
-            .map_err(|e| AppError::Internal(e.to_string()))?;
-        match rebases.get(repo_id) {
-            Some(state) => Ok(RebaseStatus {
+        let in_memory = {
+            let rebases = self
+                .rebases
+                .lock()
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+            rebases.get(repo_id).map(|state| RebaseStatus {
                 in_progress: state.completed < state.total || state.pause_reason.is_some(),
                 next_index: state.completed,
                 total: state.total,
                 pause_reason: state.pause_reason.clone(),
-            }),
-            None => Ok(RebaseStatus {
-                in_progress: false,
-                next_index: 0,
-                total: 0,
-                pause_reason: None,
-            }),
+            })
+        };
+        if let Some(status) = in_memory {
+            return Ok(status);
         }
+
+        // No in-memory entry: either there is no rebase, or this process did
+        // not start it (the app was restarted mid-rebase). The state file is
+        // the authority in that case.
+        self.with_repo(repo_id, |repo| {
+            Ok(match crate::git::rebase_state::load(repo)? {
+                Some(state) => RebaseStatus {
+                    in_progress: true,
+                    next_index: state.completed,
+                    total: state.total,
+                    pause_reason: state.pause_reason,
+                },
+                None => RebaseStatus {
+                    in_progress: false,
+                    next_index: 0,
+                    total: 0,
+                    pause_reason: None,
+                },
+            })
+        })
     }
 
     fn verify_commit(
@@ -3525,6 +3666,12 @@ impl GitBackend for Libgit2Backend {
 
     fn repo_state(&self, repo_id: &RepoId) -> AppResult<RepoState> {
         self.with_repo(repo_id, |repo| {
+            // Our own rebase wins: libgit2 only sees the CHERRY_PICK_HEAD /
+            // MERGE_HEAD a paused step leaves behind, which would report the
+            // step's mechanism instead of the operation the user started.
+            if crate::git::rebase_state::load(repo)?.is_some() {
+                return Ok(RepoState::RebaseInteractive);
+            }
             use git2::RepositoryState as RS;
             Ok(match repo.state() {
                 RS::Clean => RepoState::Clean,
@@ -3658,31 +3805,20 @@ impl GitBackend for Libgit2Backend {
     }
 
     fn abort_operation(&self, repo_id: &RepoId) -> AppResult<()> {
-        // If an interactive rebase is tracked for this repo, prefer its
-        // recorded pre-rebase tip (`orig_head`) as the reset target —
-        // converges this generic conflict-screen/palette abort with
-        // `rebase_abort`. Otherwise a mid-rebase abort here would hard-reset
-        // to "current HEAD", which during a paused rebase is wherever the
-        // in-progress rebase happened to stop, not the pre-rebase position.
-        // Remove the entry either way: leaving it behind would keep
-        // `rebase_status` reporting `in_progress` after this abort, and a
-        // later `rebase_abort` would then reuse the stale `orig_head` to
-        // hard-reset again — silently discarding commits made since.
-        let orig_head = {
-            let mut rebases = self
-                .rebases
-                .lock()
-                .map_err(|e| AppError::Internal(e.to_string()))?;
-            rebases.remove(repo_id).map(|s| s.orig_head)
-        };
+        // The Conflict screen and the palette both land here. When the paused
+        // operation is one of our rebases, hand it to the engine that owns it:
+        // `rebase_abort` puts HEAD back on the branch and sweeps the state file,
+        // while a plain hard reset here would leave both to guesswork — and
+        // would leave the on-disk state behind, so `rebase_status` would keep
+        // reporting a rebase that is over.
+        if self.rebase_in_progress(repo_id)? {
+            return self.rebase_abort(repo_id);
+        }
 
         self.with_repo(repo_id, |repo| {
-            let target = match &orig_head {
-                Some(oid) => repo.revparse_single(oid)?.peel_to_commit()?,
-                None => match repo.head() {
-                    Ok(h) => h.peel_to_commit()?,
-                    Err(_) => return Err(AppError::Unborn),
-                },
+            let target = match repo.head() {
+                Ok(h) => h.peel_to_commit()?,
+                Err(_) => return Err(AppError::Unborn),
             };
             repo.reset(target.as_object(), git2::ResetType::Hard, None)?;
             repo.cleanup_state()?;
@@ -3691,6 +3827,16 @@ impl GitBackend for Libgit2Backend {
     }
 
     fn continue_operation(&self, repo_id: &RepoId) -> AppResult<String> {
+        // Same convergence as `abort_operation`: committing the resolved tree
+        // here would advance nothing and strand the rest of the plan, so a
+        // rebase in progress goes to the engine that owns the plan.
+        if self.rebase_in_progress(repo_id)? {
+            self.rebase_continue(repo_id)?;
+            return self.with_repo(repo_id, |repo| {
+                Ok(repo.head()?.peel_to_commit()?.id().to_string())
+            });
+        }
+
         self.with_repo(repo_id, |repo| {
             let statuses = repo.statuses(None)?;
             if statuses.iter().any(|s| s.status().is_conflicted()) {

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -3234,15 +3234,19 @@ impl GitBackend for Libgit2Backend {
     }
 
     fn rebase_start(&self, repo_id: &RepoId, plan: Vec<RebaseStep>) -> AppResult<RebaseStatus> {
-        if plan.is_empty() {
-            return Err(AppError::InvalidRef("empty rebase plan".into()));
-        }
+        // Validate BEFORE touching anything. An unexecutable step used to be
+        // discovered mid-replay, with earlier picks already committed and the
+        // branch tip already moved.
+        self.with_repo(repo_id, |repo| crate::git::rebase_plan::validate(repo, &plan))?;
 
-        // Find the first non-Drop step — we need its parent as the new base.
+        // Validated above, so this cannot fail: the plan has at least one
+        // non-Drop step. We need its parent as the new base.
         let first_step = plan
             .iter()
             .find(|s| s.action != RebaseAction::Drop)
-            .ok_or_else(|| AppError::InvalidRef("rebase plan contains only drops".into()))?;
+            .ok_or_else(|| {
+                AppError::InvalidRebasePlan("the plan drops every commit".into())
+            })?;
         let first_oid_str = first_step.oid.clone();
 
         // Verify worktree is clean, remember the pre-rebase tip (so an abort

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod cli;
 pub mod libgit2;
 pub mod ownership;
+pub mod rebase_plan;
 pub mod signature;
 pub mod signing;
 pub mod types;

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -3,6 +3,7 @@ pub mod cli;
 pub mod libgit2;
 pub mod ownership;
 pub mod rebase_plan;
+pub mod rebase_state;
 pub mod signature;
 pub mod signing;
 pub mod types;

--- a/src-tauri/src/git/rebase_plan.rs
+++ b/src-tauri/src/git/rebase_plan.rs
@@ -1,0 +1,65 @@
+//! Validation of an interactive-rebase plan against the repository it will run
+//! against. Every check here runs *before* `rebase_start` mutates anything: the
+//! engine used to discover an unexecutable step mid-replay, with earlier picks
+//! already committed and the branch tip already moved.
+
+use std::collections::HashSet;
+
+use git2::Repository;
+
+use crate::error::{AppError, AppResult};
+
+use super::types::{RebaseAction, RebaseStep};
+
+/// First seven hex characters, for messages.
+pub fn short(oid: &str) -> &str {
+    &oid[..oid.len().min(7)]
+}
+
+/// Actions that mean something for a commit with more than one parent.
+///
+/// Only `Drop` for now — git's own default, which drops merges and flattens the
+/// branch. Keeping a merge as one commit and recreating it are separate actions
+/// added later; this function is the single source of truth the UI mirrors.
+pub fn merge_legal(action: RebaseAction) -> bool {
+    matches!(action, RebaseAction::Drop)
+}
+
+pub fn validate(repo: &Repository, plan: &[RebaseStep]) -> AppResult<()> {
+    if plan.is_empty() {
+        return Err(AppError::InvalidRebasePlan("the plan is empty".into()));
+    }
+
+    let mut seen: HashSet<&str> = HashSet::new();
+    for step in plan {
+        if !seen.insert(step.oid.as_str()) {
+            return Err(AppError::InvalidRebasePlan(format!(
+                "{} appears twice in the plan",
+                short(&step.oid)
+            )));
+        }
+
+        let commit = repo
+            .revparse_single(&step.oid)
+            .and_then(|o| o.peel_to_commit())
+            .map_err(|_| {
+                AppError::InvalidRebasePlan(format!("unknown commit {}", short(&step.oid)))
+            })?;
+
+        if commit.parent_count() > 1 && !merge_legal(step.action) {
+            return Err(AppError::InvalidRebasePlan(format!(
+                "{} is a merge commit — it can only be dropped, which flattens \
+                 the branch, or left out of the plan",
+                short(&step.oid)
+            )));
+        }
+    }
+
+    if !plan.iter().any(|s| s.action != RebaseAction::Drop) {
+        return Err(AppError::InvalidRebasePlan(
+            "the plan drops every commit — nothing would be replayed".into(),
+        ));
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/git/rebase_state.rs
+++ b/src-tauri/src/git/rebase_state.rs
@@ -1,0 +1,107 @@
+//! The on-disk mirror of an in-progress interactive rebase.
+//!
+//! The engine's `RebaseState` lives in a `HashMap` inside `Libgit2Backend`, so
+//! before this existed, closing the app during a rebase left a detached HEAD
+//! part-way through a replay with no way back but the reflog. This module keeps
+//! a JSON mirror in the gitdir and writes `ORIG_HEAD` the way git does, so both
+//! the app and the `git` CLI can recover.
+//!
+//! Deliberately NOT git's own `.git/rebase-merge/` directory: a
+//! half-compatible one would make `git status` and `git rebase --continue`
+//! claim authority over a rebase they cannot drive.
+
+use std::{collections::BTreeMap, path::PathBuf};
+
+use git2::Repository;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{AppError, AppResult};
+
+use super::types::RebaseStep;
+
+pub const FILE_NAME: &str = "platypusgit-rebase.json";
+pub const VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistedCurrent {
+    pub step: RebaseStep,
+    /// "conflict" | "edit" — mirrors `RebaseStatus.pause_reason`.
+    pub phase: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistedRebase {
+    pub version: u32,
+    /// Branch to move when the plan completes; `None` when the rebase started
+    /// from a detached HEAD.
+    pub head_name: Option<String>,
+    pub orig_head: String,
+    pub onto: String,
+    pub total: usize,
+    pub completed: usize,
+    pub remaining: Vec<RebaseStep>,
+    /// Why the rebase is paused — "conflict" | "edit" | absent. Persisted
+    /// separately from `current` because an edit pause has no held-back step:
+    /// its commit already landed.
+    pub pause_reason: Option<String>,
+    /// The step whose apply conflicted and is awaiting resolution, if any.
+    pub current: Option<PersistedCurrent>,
+    pub rewritten: BTreeMap<String, String>,
+}
+
+pub fn path(repo: &Repository) -> PathBuf {
+    repo.path().join(FILE_NAME)
+}
+
+/// Write via temp file + rename so a crash mid-write cannot leave a truncated
+/// state file that would read as "no rebase in progress".
+pub fn save(repo: &Repository, state: &PersistedRebase) -> AppResult<()> {
+    let target = path(repo);
+    let tmp = target.with_extension("json.tmp");
+    let json = serde_json::to_vec_pretty(state)
+        .map_err(|e| AppError::Internal(format!("serialising rebase state: {e}")))?;
+    std::fs::write(&tmp, json)?;
+    std::fs::rename(&tmp, &target)?;
+    Ok(())
+}
+
+/// `Ok(None)` when there is no file. A file we cannot parse is an error, not a
+/// silent "no rebase": guessing here is how a half-replayed branch would lose
+/// its way back.
+pub fn load(repo: &Repository) -> AppResult<Option<PersistedRebase>> {
+    let target = path(repo);
+    match std::fs::read(&target) {
+        Ok(bytes) => {
+            let state: PersistedRebase = serde_json::from_slice(&bytes).map_err(|e| {
+                AppError::Internal(format!("unreadable rebase state in {FILE_NAME}: {e}"))
+            })?;
+            if state.version != VERSION {
+                return Err(AppError::Internal(format!(
+                    "{FILE_NAME} was written by another version ({}), refusing to guess",
+                    state.version
+                )));
+            }
+            Ok(Some(state))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+pub fn clear(repo: &Repository) -> AppResult<()> {
+    match std::fs::remove_file(path(repo)) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// `ORIG_HEAD`, written the way git writes it before a history-rewriting
+/// operation, so `git reset --hard ORIG_HEAD` works from the CLI.
+pub fn write_orig_head(repo: &Repository, oid: &str) -> AppResult<()> {
+    let target = repo.path().join("ORIG_HEAD");
+    std::fs::write(target, format!("{oid}\n"))?;
+    Ok(())
+}

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -324,7 +324,7 @@ pub struct ConflictSides {
 
 // ─── Interactive rebase ───────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum RebaseAction {
     Pick,
     Reword,

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -276,7 +276,7 @@ pub struct StashSaveOptions {
 
 /// The current operation state of a repository.
 /// Mirrors `git2::RepositoryState`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum RepoState {
     Clean,
     Merge,

--- a/src-tauri/tests/rebase.rs
+++ b/src-tauri/tests/rebase.rs
@@ -134,6 +134,10 @@ fn rebase_edit_pauses_and_continue_resumes() {
     let status = backend.rebase_start(&handle.id, plan).unwrap();
     assert!(status.in_progress, "should be paused after edit");
     assert_eq!(status.pause_reason.as_deref(), Some("edit"));
+    assert!(
+        tr.repo.head_detached().unwrap(),
+        "the replay must run on a detached HEAD"
+    );
 
     // Simulate user done amending — just continue.
     let status2 = backend.rebase_continue(&handle.id).unwrap();

--- a/src-tauri/tests/rebase_durability.rs
+++ b/src-tauri/tests/rebase_durability.rs
@@ -5,7 +5,8 @@
 mod support;
 
 use platypusgit_lib::git::{
-    types::{RebaseAction, RebaseStep},
+    libgit2::Libgit2Backend,
+    types::{RebaseAction, RebaseStep, RepoState},
     GitBackend,
 };
 
@@ -130,4 +131,243 @@ fn abort_mid_rebase_restores_the_branch_and_reattaches_head() {
         tr.repo.statuses(None).unwrap().is_empty(),
         "worktree left dirty"
     );
+}
+
+// ─── on-disk state ───────────────────────────────────────────────────────────
+
+#[test]
+fn a_paused_rebase_is_visible_on_disk_and_reports_as_a_rebase() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 3);
+
+    let (backend, handle) = tr.open_with_backend();
+    let plan = vec![
+        step(&oids[0], RebaseAction::Pick),
+        step(&oids[1], RebaseAction::Edit),
+        step(&oids[2], RebaseAction::Pick),
+    ];
+    backend.rebase_start(&handle.id, plan).unwrap();
+
+    let state_file = tr.path().join(".git").join("platypusgit-rebase.json");
+    assert!(
+        state_file.exists(),
+        "a paused rebase must be recorded on disk"
+    );
+    assert!(
+        tr.path().join(".git").join("ORIG_HEAD").exists(),
+        "ORIG_HEAD is the CLI escape hatch and must be written"
+    );
+    assert_eq!(
+        backend.repo_state(&handle.id).unwrap(),
+        RepoState::RebaseInteractive,
+        "a paused rebase must report as a rebase, not as Clean or CherryPick"
+    );
+
+    backend.rebase_continue(&handle.id).unwrap();
+    assert!(
+        !state_file.exists(),
+        "the state file must be swept when the plan completes"
+    );
+    assert_eq!(backend.repo_state(&handle.id).unwrap(), RepoState::Clean);
+}
+
+#[test]
+fn a_restarted_app_can_still_abort() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 3);
+    let tip_before = branch_tip(&tr, "main");
+
+    {
+        let (backend, handle) = tr.open_with_backend();
+        let plan = vec![
+            step(&oids[0], RebaseAction::Pick),
+            step(&oids[1], RebaseAction::Edit),
+            step(&oids[2], RebaseAction::Pick),
+        ];
+        backend.rebase_start(&handle.id, plan).unwrap();
+    } // backend dropped — every trace of the in-memory RebaseState is gone
+
+    // A fresh backend is what the app has after a restart.
+    let backend = Libgit2Backend::new();
+    let handle = backend.open(tr.path()).unwrap();
+
+    let status = backend.rebase_status(&handle.id).unwrap();
+    assert!(
+        status.in_progress,
+        "the rebase must still be reported as in progress after a restart"
+    );
+    assert_eq!(status.total, 3);
+    assert_eq!(
+        status.next_index, 2,
+        "the pick and the edit both landed their commits before the pause — an \
+         edit pauses *after* committing, so it counts as completed"
+    );
+
+    backend.rebase_abort(&handle.id).unwrap();
+    assert_eq!(branch_tip(&tr, "main"), tip_before);
+    assert!(!tr.repo.head_detached().unwrap());
+    assert!(!tr
+        .path()
+        .join(".git")
+        .join("platypusgit-rebase.json")
+        .exists());
+}
+
+#[test]
+fn a_restarted_app_can_still_continue() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 3);
+
+    {
+        let (backend, handle) = tr.open_with_backend();
+        backend
+            .rebase_start(
+                &handle.id,
+                vec![
+                    step(&oids[0], RebaseAction::Pick),
+                    step(&oids[1], RebaseAction::Edit),
+                    step(&oids[2], RebaseAction::Pick),
+                ],
+            )
+            .unwrap();
+    } // restart
+
+    let backend = Libgit2Backend::new();
+    let handle = backend.open(tr.path()).unwrap();
+
+    let done = backend.rebase_continue(&handle.id).unwrap();
+    assert!(
+        !done.in_progress,
+        "the rehydrated plan should run to completion"
+    );
+    assert_eq!(done.total, 3);
+    assert!(
+        !tr.repo.head_detached().unwrap(),
+        "HEAD reattached on completion"
+    );
+    let summaries: Vec<String> = backend
+        .log(&handle.id, None, 10)
+        .unwrap()
+        .into_iter()
+        .map(|c| c.summary)
+        .collect();
+    assert_eq!(
+        summaries[0], "commit 2",
+        "the last step must have been replayed"
+    );
+}
+
+// ─── one engine behind both Continue and Abort ────────────────────────────────
+
+/// main's two commits both touch `shared.txt`, so replaying the second on a
+/// rewritten first conflicts.
+fn conflicting_plan_repo() -> (TempRepo, Vec<String>) {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let mut oids = Vec::new();
+    for (body, msg) in [("one\n", "first"), ("two\n", "second")] {
+        support::fs::write_file(tr.path(), "shared.txt", body);
+        oids.push(tr.commit_all(msg).to_string());
+    }
+    (tr, oids)
+}
+
+#[test]
+fn continue_operation_during_a_rebase_advances_the_plan() {
+    let (tr, oids) = conflicting_plan_repo();
+    let (backend, handle) = tr.open_with_backend();
+
+    // Pause on the first commit, rewrite its content so replaying the second
+    // conflicts.
+    let plan = vec![
+        step(&oids[0], RebaseAction::Edit),
+        step(&oids[1], RebaseAction::Pick),
+    ];
+    let status = backend.rebase_start(&handle.id, plan).unwrap();
+    assert_eq!(status.pause_reason.as_deref(), Some("edit"));
+
+    // What the UI does during an edit pause: amend the step's commit. Leaving
+    // changes merely staged is not a resolution — the next cherry-pick would
+    // refuse to overwrite them.
+    support::fs::write_file(tr.path(), "shared.txt", "diverged\n");
+    {
+        let mut index = tr.repo.index().unwrap();
+        index
+            .add_path(std::path::Path::new("shared.txt"))
+            .unwrap();
+        index.write().unwrap();
+        let tree_oid = index.write_tree().unwrap();
+        let tree = tr.repo.find_tree(tree_oid).unwrap();
+        let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+        head.amend(Some("HEAD"), None, None, None, None, Some(&tree))
+            .unwrap();
+    }
+
+    let status = backend.rebase_continue(&handle.id).unwrap();
+    assert_eq!(
+        status.pause_reason.as_deref(),
+        Some("conflict"),
+        "replaying the second commit should conflict"
+    );
+
+    // The user resolves in the Conflict screen and presses ITS Continue, which
+    // calls continue_operation — not rebase_continue.
+    support::fs::write_file(tr.path(), "shared.txt", "resolved\n");
+    backend
+        .stage(&handle.id, &[std::path::PathBuf::from("shared.txt")])
+        .unwrap();
+    backend.continue_operation(&handle.id).unwrap();
+
+    let status = backend.rebase_status(&handle.id).unwrap();
+    assert!(
+        !status.in_progress,
+        "the Conflict screen's Continue must advance the plan, not just commit"
+    );
+    assert!(
+        !tr.repo.head_detached().unwrap(),
+        "HEAD should be reattached once the plan completes"
+    );
+    assert!(
+        !tr.path()
+            .join(".git")
+            .join("platypusgit-rebase.json")
+            .exists(),
+        "a completed rebase must leave no state file behind"
+    );
+    let summaries: Vec<String> = backend
+        .log(&handle.id, None, 10)
+        .unwrap()
+        .into_iter()
+        .map(|c| c.summary)
+        .collect();
+    assert_eq!(summaries[0], "second", "the last step must have landed");
+}
+
+#[test]
+fn abort_operation_during_a_rebase_restores_the_branch() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 3);
+    let tip_before = branch_tip(&tr, "main");
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .rebase_start(
+            &handle.id,
+            vec![
+                step(&oids[0], RebaseAction::Pick),
+                step(&oids[1], RebaseAction::Edit),
+                step(&oids[2], RebaseAction::Pick),
+            ],
+        )
+        .unwrap();
+
+    backend.abort_operation(&handle.id).unwrap();
+
+    assert_eq!(branch_tip(&tr, "main"), tip_before);
+    assert!(!tr.repo.head_detached().unwrap());
+    assert!(!backend.rebase_status(&handle.id).unwrap().in_progress);
+    assert!(!tr
+        .path()
+        .join(".git")
+        .join("platypusgit-rebase.json")
+        .exists());
 }

--- a/src-tauri/tests/rebase_durability.rs
+++ b/src-tauri/tests/rebase_durability.rs
@@ -1,0 +1,133 @@
+//! The execution model: a rebase replays on a detached HEAD and moves the
+//! branch ref exactly once, when the plan completes. Anything that fails or
+//! pauses mid-way therefore leaves the branch where it was.
+
+mod support;
+
+use platypusgit_lib::git::{
+    types::{RebaseAction, RebaseStep},
+    GitBackend,
+};
+
+use support::{linear_history, TempRepo};
+
+fn step(oid: &str, action: RebaseAction) -> RebaseStep {
+    RebaseStep {
+        oid: oid.to_string(),
+        action,
+        message: None,
+    }
+}
+
+fn branch_tip(tr: &TempRepo, name: &str) -> String {
+    tr.repo
+        .find_reference(&format!("refs/heads/{name}"))
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .id()
+        .to_string()
+}
+
+#[test]
+fn paused_rebase_detaches_head_and_leaves_the_branch_alone() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 3);
+    let tip_before = branch_tip(&tr, "main");
+
+    let (backend, handle) = tr.open_with_backend();
+    let plan = vec![
+        step(&oids[0], RebaseAction::Pick),
+        step(&oids[1], RebaseAction::Edit), // pauses here
+        step(&oids[2], RebaseAction::Pick),
+    ];
+
+    let status = backend.rebase_start(&handle.id, plan).unwrap();
+    assert!(status.in_progress, "edit should pause the rebase");
+    assert_eq!(status.pause_reason.as_deref(), Some("edit"));
+
+    assert!(
+        tr.repo.head_detached().unwrap(),
+        "HEAD must be detached while a rebase is replaying"
+    );
+    assert_eq!(
+        branch_tip(&tr, "main"),
+        tip_before,
+        "the branch ref must not move until the plan completes"
+    );
+
+    let done = backend.rebase_continue(&handle.id).unwrap();
+    assert!(!done.in_progress, "rebase should finish after continue");
+    assert!(
+        !tr.repo.head_detached().unwrap(),
+        "HEAD must be back on the branch when the plan completes"
+    );
+    assert_eq!(
+        tr.repo.head().unwrap().name().unwrap(),
+        "refs/heads/main",
+        "HEAD should be reattached to the original branch"
+    );
+    // The branch points at the replayed history. Note the oids here are
+    // *expected* to match the originals: replaying unchanged commits onto the
+    // same base reproduces them byte for byte (same tree, message, author, and
+    // same-second committer), so the invariant to assert is that the branch and
+    // HEAD agree — not that the tip changed.
+    let tip_after = branch_tip(&tr, "main");
+    assert_eq!(
+        tr.repo
+            .head()
+            .unwrap()
+            .peel_to_commit()
+            .unwrap()
+            .id()
+            .to_string(),
+        tip_after,
+        "HEAD and the branch must agree once the rebase is done"
+    );
+    let summaries: Vec<String> = backend
+        .log(&handle.id, None, 10)
+        .unwrap()
+        .into_iter()
+        .map(|c| c.summary)
+        .collect();
+    assert_eq!(
+        summaries,
+        vec!["commit 2", "commit 1", "commit 0", "initial"],
+        "every planned step must have been replayed onto the branch"
+    );
+}
+
+#[test]
+fn abort_mid_rebase_restores_the_branch_and_reattaches_head() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 3);
+    let tip_before = branch_tip(&tr, "main");
+
+    let (backend, handle) = tr.open_with_backend();
+    let plan = vec![
+        step(&oids[0], RebaseAction::Pick),
+        step(&oids[1], RebaseAction::Edit),
+        step(&oids[2], RebaseAction::Pick),
+    ];
+    backend.rebase_start(&handle.id, plan).unwrap();
+
+    backend.rebase_abort(&handle.id).unwrap();
+
+    assert!(!tr.repo.head_detached().unwrap(), "abort must reattach HEAD");
+    assert_eq!(tr.repo.head().unwrap().name().unwrap(), "refs/heads/main");
+    assert_eq!(branch_tip(&tr, "main"), tip_before);
+    assert_eq!(
+        tr.repo
+            .head()
+            .unwrap()
+            .peel_to_commit()
+            .unwrap()
+            .id()
+            .to_string(),
+        tip_before
+    );
+    assert!(
+        tr.repo.statuses(None).unwrap().is_empty(),
+        "worktree left dirty"
+    );
+}

--- a/src-tauri/tests/rebase_validation.rs
+++ b/src-tauri/tests/rebase_validation.rs
@@ -1,0 +1,154 @@
+//! A plan the engine cannot execute must be refused before the repository is
+//! touched. The bug this pins: a merge commit in the plan used to surface
+//! libgit2's "mainline branch is not specified" error on the step that reached
+//! it — after earlier picks had already been committed and the branch tip
+//! moved.
+
+mod support;
+
+use platypusgit_lib::{
+    error::AppError,
+    git::{
+        types::{RebaseAction, RebaseStep},
+        GitBackend,
+    },
+};
+
+use support::{merge_history, TempRepo};
+
+fn step(oid: &str, action: RebaseAction) -> RebaseStep {
+    RebaseStep {
+        oid: oid.to_string(),
+        action,
+        message: None,
+    }
+}
+
+/// Every rejection must leave HEAD, the branch ref, and the worktree exactly
+/// as they were.
+fn assert_untouched(tr: &TempRepo, head_before: &str) {
+    let head_now = tr
+        .repo
+        .head()
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .id()
+        .to_string();
+    assert_eq!(head_now, head_before, "HEAD moved on a rejected plan");
+    let branch = tr
+        .repo
+        .find_reference("refs/heads/main")
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .id()
+        .to_string();
+    assert_eq!(branch, head_before, "branch ref moved on a rejected plan");
+    assert!(
+        tr.repo.statuses(None).unwrap().is_empty(),
+        "worktree dirtied by a rejected plan"
+    );
+}
+
+#[test]
+fn merge_commit_with_pick_is_rejected_before_anything_moves() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+    let head_before = h.m.clone();
+
+    let plan = vec![
+        step(&h.a, RebaseAction::Pick),
+        step(&h.f, RebaseAction::Pick),
+        step(&h.c, RebaseAction::Pick),
+        step(&h.m, RebaseAction::Pick), // the merge
+    ];
+
+    let err = backend.rebase_start(&handle.id, plan).unwrap_err();
+    match err {
+        AppError::InvalidRebasePlan(msg) => {
+            assert!(
+                msg.contains(&h.m[..7]),
+                "message should name the merge: {msg}"
+            );
+            assert!(msg.contains("merge"), "message should say why: {msg}");
+        }
+        other => panic!("expected InvalidRebasePlan, got {other:?}"),
+    }
+    assert_untouched(&tr, &head_before);
+    assert!(!backend.rebase_status(&handle.id).unwrap().in_progress);
+}
+
+#[test]
+fn merge_commit_may_be_dropped() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    let plan = vec![
+        step(&h.a, RebaseAction::Pick),
+        step(&h.f, RebaseAction::Pick),
+        step(&h.c, RebaseAction::Pick),
+        step(&h.m, RebaseAction::Drop),
+    ];
+
+    let status = backend.rebase_start(&handle.id, plan).unwrap();
+    assert!(
+        !status.in_progress,
+        "flattening plan should run to completion"
+    );
+    let summaries: Vec<String> = backend
+        .log(&handle.id, None, 20)
+        .unwrap()
+        .into_iter()
+        .map(|c| c.summary)
+        .collect();
+    assert!(summaries.iter().any(|s| s == "F on feature"));
+    assert!(!summaries.iter().any(|s| s.starts_with("Merge branch")));
+}
+
+#[test]
+fn duplicate_oid_is_rejected() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+    let head_before = h.m.clone();
+
+    let plan = vec![
+        step(&h.a, RebaseAction::Pick),
+        step(&h.a, RebaseAction::Pick),
+    ];
+    let err = backend.rebase_start(&handle.id, plan).unwrap_err();
+    assert!(matches!(err, AppError::InvalidRebasePlan(_)), "got {err:?}");
+    assert_untouched(&tr, &head_before);
+}
+
+#[test]
+fn unknown_oid_is_rejected() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+    let head_before = h.m.clone();
+
+    let plan = vec![step(
+        "0000000000000000000000000000000000000000",
+        RebaseAction::Pick,
+    )];
+    let err = backend.rebase_start(&handle.id, plan).unwrap_err();
+    assert!(matches!(err, AppError::InvalidRebasePlan(_)), "got {err:?}");
+    assert_untouched(&tr, &head_before);
+}
+
+#[test]
+fn all_drop_plan_is_rejected() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+    let head_before = h.m.clone();
+
+    let plan = vec![step(&h.a, RebaseAction::Drop)];
+    let err = backend.rebase_start(&handle.id, plan).unwrap_err();
+    assert!(matches!(err, AppError::InvalidRebasePlan(_)), "got {err:?}");
+    assert_untouched(&tr, &head_before);
+}

--- a/src-tauri/tests/support/mod.rs
+++ b/src-tauri/tests/support/mod.rs
@@ -177,6 +177,104 @@ pub fn linear_history(tr: &TempRepo, n: usize) -> Vec<String> {
     oids
 }
 
+/// A repository with a merge commit in the middle of the range:
+///
+/// ```text
+/// root ── A ──── C ── M      (main)
+///          \        /
+///           ─── F ──         (feature)
+/// ```
+///
+/// `F` and `C` touch different files, so `M` is a clean merge. Returns the oids
+/// as strings.
+pub struct MergeHistory {
+    pub root: String,
+    pub a: String,
+    pub f: String,
+    pub c: String,
+    pub m: String,
+}
+
+pub fn merge_history(tr: &TempRepo) -> MergeHistory {
+    let root = tr
+        .repo
+        .head()
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .id()
+        .to_string();
+
+    let commit = |name: &str, body: &str, msg: &str| -> String {
+        self::fs::write_file(tr.path(), name, body);
+        let mut index = tr.repo.index().unwrap();
+        index.add_path(Path::new(name)).unwrap();
+        index.write().unwrap();
+        let tree_oid = index.write_tree().unwrap();
+        let tree = tr.repo.find_tree(tree_oid).unwrap();
+        let sig = Signature::now("Test", "test@example.com").unwrap();
+        let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+        tr.repo
+            .commit(Some("HEAD"), &sig, &sig, msg, &tree, &[&head])
+            .unwrap()
+            .to_string()
+    };
+
+    let a = commit("a.txt", "a\n", "A on main");
+
+    // feature branches off A
+    {
+        let a_commit = tr
+            .repo
+            .find_commit(git2::Oid::from_str(&a).unwrap())
+            .unwrap();
+        tr.repo.branch("feature", &a_commit, false).unwrap();
+    }
+    tr.repo.set_head("refs/heads/feature").unwrap();
+    tr.repo
+        .checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+        .unwrap();
+    let f = commit("f.txt", "f\n", "F on feature");
+
+    // back to main
+    tr.repo.set_head("refs/heads/main").unwrap();
+    tr.repo
+        .checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+        .unwrap();
+    let c = commit("c.txt", "c\n", "C on main");
+
+    // merge feature into main
+    let f_oid = git2::Oid::from_str(&f).unwrap();
+    let m = {
+        let annotated = tr.repo.find_annotated_commit(f_oid).unwrap();
+        tr.repo.merge(&[&annotated], None, None).unwrap();
+        let mut index = tr.repo.index().unwrap();
+        assert!(
+            !index.has_conflicts(),
+            "merge_history fixture must merge cleanly"
+        );
+        let tree_oid = index.write_tree().unwrap();
+        let tree = tr.repo.find_tree(tree_oid).unwrap();
+        let sig = Signature::now("Test", "test@example.com").unwrap();
+        let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+        let f_commit = tr.repo.find_commit(f_oid).unwrap();
+        tr.repo
+            .commit(
+                Some("HEAD"),
+                &sig,
+                &sig,
+                "Merge branch 'feature'",
+                &tree,
+                &[&head, &f_commit],
+            )
+            .unwrap()
+            .to_string()
+    };
+    tr.repo.cleanup_state().unwrap();
+
+    MergeHistory { root, a, f, c, m }
+}
+
 /// A bare git repository in a tempdir — acts as a "remote" for network tests.
 pub struct BareTempRepo {
     pub dir: TempDir,

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -345,6 +345,16 @@ export function useContextMenu<T>(
 
 export function commitMenuItems(commit: { sha?: string; subject?: string } | null): ContextMenuItem[] {
   const sha = commit?.sha || "—";
+  // Ancestry for the rebase entry points, from the full log. The base is the
+  // commit's FIRST PARENT — never the next log row, which on a graph is often a
+  // side-branch commit (see planCommitSelection). A merge commit is a legal
+  // start point (base = its mainline parent), but folding one into its parent
+  // is not: "squash a merge into its parent" has no coherent meaning.
+  const self = commit?.sha
+    ? (useRepoStore.getState().commits.find((c) => c.oid === commit.sha) ?? null)
+    : null;
+  const isMerge = (self?.parents.length ?? 0) > 1;
+  const baseOid = self?.parents[0] ?? null;
   return [
     { __menuTitle: `commit ${sha.slice(0, 7)}` },
     {
@@ -416,17 +426,16 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
     },
     {
       icon: "rebase",
-      label: "Interactive rebase from here",
+      label: baseOid
+        ? "Interactive rebase from here"
+        : "Interactive rebase from here — root commit",
+      disabled: !baseOid,
       onClick: () => {
-        if (!commit?.sha) return;
+        if (!commit?.sha || !baseOid) return;
+        // "Rebase -i from here" means: replay everything newer than this
+        // commit's parent, this commit included.
         const commits = useRepoStore.getState().commits;
-        // "Rebase -i from here" means: rebase commits newer than target's parent.
-        // The parent of `commit.sha` in our newest-first commits list is the
-        // entry at `index + 1`.
-        const idx = commits.findIndex((c) => c.oid === commit.sha);
-        const base = commits[idx + 1]?.oid;
-        if (!base) return;
-        const plan = buildRebasePlan(commits, base, { kind: "edit-from" });
+        const plan = buildRebasePlan(commits, baseOid, { kind: "edit-from" });
         if (!plan || plan.length === 0) return;
         useNavStore.getState().setIntent({ kind: "rebase-plan", plan });
       },
@@ -456,14 +465,14 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
     },
     {
       icon: "fix",
-      label: "Fixup this commit into its parent",
+      label: isMerge
+        ? "Fixup into parent — merge commit"
+        : "Fixup this commit into its parent",
+      disabled: isMerge || !baseOid,
       onClick: () => {
-        if (!commit?.sha) return;
+        if (!commit?.sha || isMerge || !baseOid) return;
         const commits = useRepoStore.getState().commits;
-        const idx = commits.findIndex((c) => c.oid === commit.sha);
-        const base = commits[idx + 1]?.oid;
-        if (!base) return;
-        const plan = buildRebasePlan(commits, base, {
+        const plan = buildRebasePlan(commits, baseOid, {
           kind: "fixup",
           targetOid: commit.sha,
         });
@@ -473,9 +482,12 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
     },
     {
       icon: "squash",
-      label: "Squash this commit into its parent",
+      label: isMerge
+        ? "Squash into parent — merge commit"
+        : "Squash this commit into its parent",
+      disabled: isMerge || !baseOid,
       onClick: async () => {
-        if (!commit?.sha) return;
+        if (!commit?.sha || isMerge || !baseOid) return;
         const msg = await pgPrompt({
           title: "Squash into parent",
           body: "Message for the combined commit.",
@@ -485,10 +497,7 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
         });
         if (!msg) return;
         const commits = useRepoStore.getState().commits;
-        const idx = commits.findIndex((c) => c.oid === commit.sha);
-        const base = commits[idx + 1]?.oid;
-        if (!base) return;
-        const plan = buildRebasePlan(commits, base, {
+        const plan = buildRebasePlan(commits, baseOid, {
           kind: "squash",
           targetOid: commit.sha,
           message: msg,

--- a/src/features/commits/planCommitSelection.merge.test.ts
+++ b/src/features/commits/planCommitSelection.merge.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { planCommitSelection } from "./planCommitSelection";
+import type { CommitInfo } from "@/lib/types";
+
+/**
+ * Newest-first log of
+ *
+ *   root ── A ──── C ── M   (main)
+ *            \        /
+ *             ─── F ──      (feature)
+ *
+ * The row after `C` is `F` — a side-branch commit, not C's parent. That is the
+ * shape the positional `commits[max + 1]` base guess got wrong.
+ */
+function graphLog(): CommitInfo[] {
+  const mk = (oid: string, summary: string, parents: string[]): CommitInfo => ({
+    oid,
+    shortOid: oid.slice(0, 7),
+    summary,
+    body: null,
+    author: "Test",
+    email: "t@e.com",
+    timestamp: 0,
+    parents,
+    refs: [],
+  });
+  return [
+    mk("m".repeat(40), "Merge branch 'feature'", ["c".repeat(40), "f".repeat(40)]),
+    mk("c".repeat(40), "C on main", ["a".repeat(40)]),
+    mk("f".repeat(40), "F on feature", ["a".repeat(40)]),
+    mk("a".repeat(40), "A on main", ["r".repeat(40)]),
+    mk("r".repeat(40), "root", []),
+  ];
+}
+
+describe("planCommitSelection on non-linear history", () => {
+  it("takes the base from the commit's first parent, not the next log row", () => {
+    const plan = planCommitSelection(graphLog(), ["c".repeat(40)]);
+    expect(plan?.baseOid).toBe("a".repeat(40));
+  });
+
+  it("reports a merge commit's base as its mainline parent", () => {
+    const plan = planCommitSelection(graphLog(), ["m".repeat(40)]);
+    expect(plan?.baseOid).toBe("c".repeat(40));
+    expect(plan?.hasMerge).toBe(true);
+  });
+
+  it("null base for a root commit", () => {
+    const plan = planCommitSelection(graphLog(), ["r".repeat(40)]);
+    expect(plan?.baseOid).toBeNull();
+  });
+
+  it("adjacent log rows on different branches are not contiguous", () => {
+    // C and F sit next to each other in the log but neither is the other's
+    // parent, so they do not form a squashable run.
+    const plan = planCommitSelection(graphLog(), ["c".repeat(40), "f".repeat(40)]);
+    expect(plan?.contiguous).toBe(false);
+  });
+
+  it("a real first-parent chain is contiguous", () => {
+    const plan = planCommitSelection(graphLog(), ["c".repeat(40), "a".repeat(40)]);
+    expect(plan?.contiguous).toBe(true);
+  });
+});

--- a/src/features/commits/planCommitSelection.ts
+++ b/src/features/commits/planCommitSelection.ts
@@ -15,10 +15,9 @@ export interface CommitSelectionPlan {
   oldestOid: string;
   /** Newest selected commit. */
   newestOid: string;
-  /** Parent of the oldest selected commit (`commits[oldestIdx+1]`), or null
-   *  when it's the root or its parent isn't loaded. */
+  /** First parent of the oldest selected commit, or null when it's the root. */
   baseOid: string | null;
-  /** Selected indices form one consecutive run in the log. */
+  /** The selection is an unbroken first-parent chain (oldest→newest). */
   contiguous: boolean;
   /** Any selected commit is a merge (>1 parent). */
   hasMerge: boolean;
@@ -38,17 +37,33 @@ export function planCommitSelection(
 
   const min = Math.min(...indices); // newest
   const max = Math.max(...indices); // oldest
-  const oids = indices
+  const oldestFirst = indices
     .slice()
     .sort((a, b) => b - a) // oldest→newest
-    .map((i) => commits[i].oid);
+    .map((i) => commits[i]);
+  const oids = oldestFirst.map((c) => c.oid);
+  const oldest = commits[max];
+
+  // The base is the oldest selected commit's FIRST PARENT, looked up by oid. It
+  // used to be `commits[max + 1]` — the next row in a graph-ordered log, which
+  // on any non-linear history is frequently a side-branch commit rather than a
+  // parent, so a rebase reset to the wrong base and silently dropped whatever
+  // sat between.
+  const baseOid = oldest.parents[0] ?? null;
+
+  // Contiguity means "these commits form an unbroken first-parent chain", which
+  // is what a range squash replays. Adjacent log rows are not enough: C and F
+  // can be neighbours while belonging to different branches.
+  const contiguous = oldestFirst.every(
+    (c, i) => i === 0 || c.parents[0] === oldestFirst[i - 1].oid,
+  );
 
   return {
     oids,
-    oldestOid: commits[max].oid,
+    oldestOid: oldest.oid,
     newestOid: commits[min].oid,
-    baseOid: commits[max + 1]?.oid ?? null,
-    contiguous: max - min + 1 === indices.length,
+    baseOid,
+    contiguous,
     hasMerge: indices.some((i) => commits[i].parents.length > 1),
   };
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -21,7 +21,8 @@ export type AppError =
    */
   | { kind: "Auth"; message: AuthChallenge }
   | { kind: "EmbeddedRepo"; message: string }
-  | { kind: "DubiousOwnership"; message: string };
+  | { kind: "DubiousOwnership"; message: string }
+  | { kind: "InvalidRebasePlan"; message: string };
 
 /** Which credential the remote is asking for. */
 export type AuthKind = "Https" | "SshPassphrase" | "SshKey";


### PR DESCRIPTION
## What

PR1 of three from `docs/superpowers/specs/2026-08-14-rebase-merge-commits-design.md`
(spec + plans in #107).

A rebase plan containing a merge commit used to fail with libgit2's `mainline
branch is not specified` error **on the step that reached it** — after earlier
picks had been committed and the branch tip moved — with abort-ability held only
in `Libgit2Backend`'s HashMap and `repo_state` reporting `Clean`. Closing the app
at that point left a half-rewritten branch recoverable only through the reflog.

- **Plans are validated before the repository is touched** (`git/rebase_plan.rs`,
  new `AppError::InvalidRebasePlan`). A merge commit may be dropped — git's own
  flattening default — and any other action on one is refused up front. Every
  rejection is covered by a test asserting HEAD, the branch ref, and the worktree
  are unchanged.
- **The replay runs on a detached HEAD**; the branch ref moves exactly once, on
  completion. A `rewritten` map records each step's result after its post-commit
  rewrite (reword amends, squash/fixup collapse), which PR3 needs to replay a
  side branch.
- **`.git/platypusgit-rebase.json` + `ORIG_HEAD`** mirror the operation. A
  restarted app rehydrates the plan, progress, and rewritten map, so Continue and
  Abort both still work, and `repo_state` reports `RebaseInteractive` while the
  file exists — which the Conflict screen already labels "Rebase in progress",
  replacing today's misleading "Cherry-pick in progress".
- **`continue_operation` / `abort_operation` delegate to the engine.**
  `continue_operation` used to commit the resolved tree and clean up without
  advancing the plan, so resolving a paused pick from the Conflict screen instead
  of the Rebase banner silently stranded the rest of the rebase.
- **The rebase base comes from the commit's first parent**, not `commits[idx + 1]`
  — the next row in a graph-ordered log, which on non-linear history is often a
  side-branch commit, so the rebase reset to the wrong base and dropped whatever
  sat between. `planCommitSelection` carried the same assumption twice: its
  `baseOid`, and a `contiguous` check that treated adjacent log rows as a parent
  chain. A merge commit stays a legal start point (base = its mainline parent);
  fixup/squash-into-parent are disabled on one with the reason in the label.

Deliberately not git's own `.git/rebase-merge/` directory: a half-compatible one
would let `git status` and `git rebase --continue` claim authority over a rebase
they cannot drive.

## Testing

- `cargo test` — whole backend green. New: `rebase_validation.rs` (5),
  `rebase_durability.rs` (7, including restart-abort, restart-continue, and the
  Conflict-screen Continue advancing the plan). `rebase.rs` gains a
  detached-HEAD assertion.
- `pnpm test` — 798 pass. New: `planCommitSelection.merge.test.ts` (5).
- `pnpm tsc --noEmit`, `pnpm exec tsc -p e2e/tsconfig.json --noEmit`,
  `cargo check` — clean.
- `pnpm test:e2e:docker run --spec e2e/specs/rebase.e2e.ts --spec
  e2e/specs/merge-conflict.e2e.ts` — 7 passing, the two specs that exercise the
  rebase engine and the conflict Continue/Abort path this PR rewired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)