### PR TITLE
perf(diff): window diff rows with an exact variable-height window (#104)

### DIFF
--- a/src/design/PGWindowedDiff.test.tsx
+++ b/src/design/PGWindowedDiff.test.tsx
@@ -89,6 +89,22 @@ describe("PGWindowedDiff", () => {
     expect(onStage).toHaveBeenCalled();
   });
 
+  it("suppresses line selection when the hunk's actions are disabled", () => {
+    // Whitespace-ignoring diffs are a rewritten view, so their indices do not
+    // address the lines git would apply (#61 D2) — selecting must be off.
+    const onLineClick = vi.fn();
+    render(
+      <PGWindowedDiff
+        rows={rows}
+        onLineClick={onLineClick}
+        hunkActions={() => ({ actionsDisabledReason: "whitespace ignored" })}
+      />,
+    );
+    expect(document.querySelectorAll('[data-testid="diff-line-changed"]')).toHaveLength(0);
+    fireEvent.click(screen.getByText("line 0"));
+    expect(onLineClick).not.toHaveBeenCalled();
+  });
+
   it("renders no spacer when the window covers everything", () => {
     render(
       <PGWindowedDiff

--- a/src/design/PGWindowedDiff.test.tsx
+++ b/src/design/PGWindowedDiff.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { PGWindowedDiff } from "./PGWindowedDiff";
+import { flattenDiffRows } from "@/lib/diffRows";
+import type { FileDiff } from "@/lib/types";
+
+/** 50 lines, alternating addition and context, so changed indices are 0,1,2… */
+const bigHunk: FileDiff["hunks"] = [
+  {
+    header: "@@ -1,50 +1,50 @@",
+    oldStart: 1,
+    oldLines: 50,
+    newStart: 1,
+    newLines: 50,
+    lines: Array.from({ length: 50 }, (_, i) =>
+      i % 2 === 0
+        ? {
+            kind: { kind: "Addition" as const },
+            oldLineno: null,
+            newLineno: i + 1,
+            content: `line ${i}`,
+          }
+        : {
+            kind: { kind: "Context" as const },
+            oldLineno: i + 1,
+            newLineno: i + 1,
+            content: `line ${i}`,
+          },
+    ),
+  },
+];
+
+const rows = flattenDiffRows(bigHunk, { headerH: 26, rowH: 19 });
+
+describe("PGWindowedDiff", () => {
+  it("renders every row when no window is given", () => {
+    render(<PGWindowedDiff rows={rows} />);
+    expect(screen.getByText("line 0")).toBeInTheDocument();
+    expect(screen.getByText("line 49")).toBeInTheDocument();
+  });
+
+  it("renders only the windowed slice, with a spacer standing in for the rest", () => {
+    render(
+      <PGWindowedDiff rows={rows} window={{ start: 0, end: 6, topPad: 0, bottomPad: 855 }} />,
+    );
+    expect(screen.getByText("line 0")).toBeInTheDocument();
+    expect(screen.queryByText("line 49")).not.toBeInTheDocument();
+    const spacer = document.querySelector('[data-pg-spacer="bottom"]') as HTMLElement;
+    expect(spacer.style.height).toBe("855px");
+  });
+
+  it("keeps changedIndex ABSOLUTE in a mid-list slice", () => {
+    // The whole point of numbering before windowing (#61 D7): a click in a slice
+    // must report the hunk-wide index, or staging targets the wrong line.
+    const clicks: Array<[number, number]> = [];
+    const target = rows[21];
+    if (target.kind !== "line" || target.line.changedIndex === undefined) {
+      throw new Error("fixture must put a changed line at row 21");
+    }
+    render(
+      <PGWindowedDiff
+        rows={rows}
+        window={{ start: 20, end: 26, topPad: 387, bottomPad: 500 }}
+        onLineClick={(h, c) => clicks.push([h, c])}
+      />,
+    );
+    fireEvent.click(screen.getByText(target.line.text!));
+    expect(clicks).toEqual([[0, target.line.changedIndex]]);
+  });
+
+  it("marks the active hunk's header, which is how F7 navigation is addressed", () => {
+    render(<PGWindowedDiff rows={rows} activeHunk={0} />);
+    const header = document.querySelector('[data-hunk-index="0"]');
+    expect(header).not.toBeNull();
+    expect(header?.getAttribute("data-hunk-active")).toBe("");
+  });
+
+  it("routes stage and collapse per hunk index", () => {
+    const onToggleHunk = vi.fn();
+    const onStage = vi.fn();
+    render(
+      <PGWindowedDiff
+        rows={rows}
+        onToggleHunk={onToggleHunk}
+        hunkActions={() => ({ onStage })}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("hunk-stage"));
+    expect(onStage).toHaveBeenCalled();
+  });
+
+  it("renders no spacer when the window covers everything", () => {
+    render(
+      <PGWindowedDiff
+        rows={rows}
+        window={{ start: 0, end: rows.length, topPad: 0, bottomPad: 0 }}
+      />,
+    );
+    expect(document.querySelector("[data-pg-spacer]")).toBeNull();
+  });
+});

--- a/src/design/PGWindowedDiff.tsx
+++ b/src/design/PGWindowedDiff.tsx
@@ -1,0 +1,94 @@
+// Flat renderer for a file's diff rows, with an optional window.
+//
+// Reuses PGHunkHeader and PGDiffRow rather than restating their markup, so the
+// windowed and unwindowed paths cannot drift. `window` omitted renders
+// everything — that is the wrap-on case, where row heights are unknown.
+//
+// data-hunk-index stays on header rows: F7 navigation and the e2e specs address
+// hunks through it, and it must survive windowing.
+import type { DiffRow } from "@/lib/diffRows";
+import type { WindowRange } from "@/lib/useWindowedList";
+import { PGDiffRow, PGHunkHeader } from "./git-components";
+
+export interface PGWindowedDiffProps {
+  rows: DiffRow[];
+  /** Omit to render every row. */
+  window?: WindowRange;
+  /** Hunk index F7/⇧F7 currently sits on. */
+  activeHunk?: number;
+  collapsed?: ReadonlySet<number>;
+  onToggleHunk?: (hunkIndex: number) => void;
+  /** Per-hunk stage/discard wiring, looked up by hunk index. */
+  hunkActions?: (hunkIndex: number) => {
+    staged?: boolean;
+    onStage?: () => void;
+    onDiscard?: () => void;
+    actionsDisabledReason?: string;
+  };
+  /** Selected changed-line indices for a hunk (#61 D7 index space). */
+  selectedLines?: (hunkIndex: number) => number[];
+  onLineClick?: (hunkIndex: number, changedIndex: number, range: boolean) => void;
+}
+
+export function PGWindowedDiff({
+  rows,
+  window: win,
+  activeHunk,
+  collapsed,
+  onToggleHunk,
+  hunkActions,
+  selectedLines,
+  onLineClick,
+}: PGWindowedDiffProps) {
+  const start = win?.start ?? 0;
+  const end = win?.end ?? rows.length;
+  const slice = rows.slice(start, end);
+
+  return (
+    <div>
+      {win && win.topPad > 0 && (
+        <div data-pg-spacer="top" style={{ height: `${win.topPad}px` }} />
+      )}
+      {slice.map((row, i) => {
+        if (row.kind === "header") {
+          const actions = hunkActions?.(row.hunkIndex) ?? {};
+          return (
+            <div
+              key={`h${row.hunkIndex}`}
+              data-hunk-index={row.hunkIndex}
+              data-hunk-active={activeHunk === row.hunkIndex ? "" : undefined}
+            >
+              <PGHunkHeader
+                header={row.header.replace(/^@@\s*|\s*@@$/g, "").trim()}
+                expanded={!collapsed?.has(row.hunkIndex)}
+                onToggle={onToggleHunk ? () => onToggleHunk(row.hunkIndex) : undefined}
+                selCount={selectedLines?.(row.hunkIndex).length ?? 0}
+                {...actions}
+              />
+            </div>
+          );
+        }
+        const sel = selectedLines?.(row.hunkIndex) ?? [];
+        return (
+          <PGDiffRow
+            // Keyed by ABSOLUTE row index: a slice-relative key would make React
+            // reuse a different line's DOM node as the window scrolls.
+            key={`l${start + i}`}
+            line={row.line}
+            selected={
+              row.line.changedIndex != null && sel.includes(row.line.changedIndex)
+            }
+            onLineClick={
+              onLineClick
+                ? (changedIndex, range) => onLineClick(row.hunkIndex, changedIndex, range)
+                : undefined
+            }
+          />
+        );
+      })}
+      {win && win.bottomPad > 0 && (
+        <div data-pg-spacer="bottom" style={{ height: `${win.bottomPad}px` }} />
+      )}
+    </div>
+  );
+}

--- a/src/design/PGWindowedDiff.tsx
+++ b/src/design/PGWindowedDiff.tsx
@@ -69,6 +69,10 @@ export function PGWindowedDiff({
           );
         }
         const sel = selectedLines?.(row.hunkIndex) ?? [];
+        // Line selection is meaningless when the hunk's own indices don't address
+        // what git would apply — the same condition that disables Stage/Discard
+        // (#61 D2). PGHunk enforced this internally; the rule lives here now.
+        const disabled = !!hunkActions?.(row.hunkIndex).actionsDisabledReason;
         return (
           <PGDiffRow
             // Keyed by ABSOLUTE row index: a slice-relative key would make React
@@ -79,7 +83,7 @@ export function PGWindowedDiff({
               row.line.changedIndex != null && sel.includes(row.line.changedIndex)
             }
             onLineClick={
-              onLineClick
+              onLineClick && !disabled
                 ? (changedIndex, range) => onLineClick(row.hunkIndex, changedIndex, range)
                 : undefined
             }

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -941,6 +941,16 @@ export interface PGHunkProps {
   syntax?: { old: SyntaxLine[] | null; new: SyntaxLine[] | null };
 }
 
+/**
+ * One hunk, header plus all its rows, unwindowed.
+ *
+ * No screen renders this any more — they all go through `PGWindowedDiff`, which
+ * reuses the same `PGHunkHeader` and `PGDiffRow`. It survives as the single-hunk
+ * primitive and as the behavioural guard for row rendering (see
+ * wordDiffRender.test.tsx and syntaxRender.test.tsx, which pin word spans and
+ * syntax spans through this public API). Delete it only together with those
+ * tests, and only once something else pins the same behaviour.
+ */
 export function PGHunk({
   header,
   lines = [],

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -1,7 +1,6 @@
 import React, { type CSSProperties, type MouseEvent, type ReactNode } from "react";
 import type { WordSpan } from "@/lib/wordDiff";
-import { pairChangedLines } from "@/lib/pairChangedLines";
-import { withChangedIndices } from "@/lib/diffRows";
+import { withChangedIndices, withSyntax, withWordSpans } from "@/lib/diffRows";
 import { buildLineSpans } from "@/lib/lineSpans";
 import type { SyntaxLine, SyntaxToken } from "@/lib/syntax";
 import { PGIcon, type IconName } from "./icons";
@@ -642,75 +641,10 @@ export function PGDiffLine({
   );
 }
 
-interface DiffChunk {
-  kind: DiffLineKind;
-  lines: DiffLineData[];
-}
-
-function chunkDiffLines(lines: DiffLineData[]): DiffChunk[] {
-  const chunks: DiffChunk[] = [];
-  for (const ln of lines) {
-    const last = chunks[chunks.length - 1];
-    if (last && last.kind === ln.kind) {
-      last.lines.push(ln);
-    } else {
-      chunks.push({ kind: ln.kind, lines: [ln] });
-    }
-  }
-  return chunks;
-}
 
 
-/**
- * Attach each row's syntax tokens from the correct side of the diff.
- *
- * A `rem` row is a line of the OLD file and reads `old[lnL - 1]`; `add` and
- * `ctx` rows show new text and read `new[lnR - 1]`, falling back to `lnL` so a
- * deleted file's rows still resolve. Anything unresolvable is left plain rather
- * than guessed — a wrong index would colour a line with another line's tokens.
- */
-function attachSyntax(
-  lines: DiffLineData[],
-  syntax: { old: SyntaxLine[] | null; new: SyntaxLine[] | null } | undefined,
-): DiffLineData[] {
-  if (!syntax) return lines;
-  return lines.map((l) => {
-    const side = l.kind === "rem" ? syntax.old : syntax.new;
-    if (!side) return l;
-    const raw = l.kind === "rem" ? l.lnL : (l.lnR ?? l.lnL);
-    const n = typeof raw === "number" ? raw : Number(raw);
-    if (!Number.isFinite(n) || n < 1) return l;
-    const tokens = side[n - 1];
-    return tokens ? { ...l, syntax: tokens } : l;
-  });
-}
 
-/**
- * Attach intra-line word spans to adjacent rem/add chunk pairs (#61 D8).
- *
- * `chunkDiffLines` groups **by kind**, so a removed run and the added run that
- * follows it are two ADJACENT chunks — pairing crosses that pair rather than
- * happening inside one chunk. The pairing rule itself lives in
- * `@/lib/pairChangedLines`, shared with the split view and the commit-diff panel.
- */
-function withWordSpans(chunks: DiffChunk[]): DiffChunk[] {
-  const out = chunks.map((c) => ({ ...c, lines: c.lines.map((l) => ({ ...l })) }));
-  for (let i = 0; i + 1 < out.length; i++) {
-    const rem = out[i];
-    const add = out[i + 1];
-    if (rem.kind !== "rem" || add.kind !== "add") continue;
-    const paired = pairChangedLines(
-      rem.lines.map((l) => l.text ?? ""),
-      add.lines.map((l) => l.text ?? ""),
-    );
-    paired.forEach((p, k) => {
-      if (!p) return;
-      rem.lines[k].spans = p.old;
-      add.lines[k].spans = p.new;
-    });
-  }
-  return out;
-}
+
 
 /**
  * Render one line as spans, combining syntax classes and word-diff emphasis.
@@ -760,16 +694,26 @@ function DiffText({
   );
 }
 
-function PGDiffChunk({
-  chunk,
-  selectedLines,
+/**
+ * One diff row, self-contained.
+ *
+ * The add/rem background and gutter stripe used to live on a wrapper around each
+ * run of same-kind lines. They are per-row now because a windowed slice can start
+ * in the middle of a run, and there would be no wrapper to inherit from —
+ * per-row `border-left` stacks into the same continuous stripe.
+ *
+ * Exported so the windowed renderer reuses this markup rather than restating it.
+ */
+export function PGDiffRow({
+  line,
+  selected,
   onLineClick,
 }: {
-  chunk: DiffChunk;
-  selectedLines?: number[];
+  line: DiffLineData;
+  selected?: boolean;
   onLineClick?: (changedIndex: number, range: boolean) => void;
 }) {
-  const { kind, lines } = chunk;
+  const kind = line.kind;
   const bg: Partial<Record<DiffLineKind, string>> = {
     add: "var(--git-added-bg)",
     rem: "var(--git-removed-bg)",
@@ -797,34 +741,14 @@ function PGDiffChunk({
     empty: "var(--fg-3)",
   };
 
-  if (kind === "hunk" || kind === "info") {
-    return (
-      <>
-        {lines.map((ln, i) => (
-          <PGDiffLine key={i} {...ln} />
-        ))}
-      </>
-    );
-  }
+  // Header and separator rows keep their own renderer.
+  if (kind === "hunk" || kind === "info") return <PGDiffLine {...line} />;
 
+  const ln = line;
+  const selectable = onLineClick != null && ln.changedIndex != null;
+  const isSelected = selected ?? false;
   return (
-    <div
-      style={{
-        background: bg[kind] ?? "transparent",
-        borderLeft:
-          borderColor[kind] !== undefined
-            ? `2px solid ${borderColor[kind]}`
-            : "2px solid transparent",
-      }}
-    >
-      {lines.map((ln, i) => {
-        const selectable = onLineClick != null && ln.changedIndex != null;
-        const isSelected =
-          ln.changedIndex != null &&
-          (selectedLines?.includes(ln.changedIndex) ?? false);
-        return (
         <div
-          key={i}
           data-testid={selectable ? "diff-line-changed" : undefined}
           data-selected={isSelected || undefined}
           onClick={
@@ -837,11 +761,17 @@ function PGDiffChunk({
             fontFamily: "var(--font-mono)",
             fontSize: "var(--fs-12)",
             lineHeight: "var(--lh-code)",
-            minHeight: 18,
+            // Fixed pitch, read from CSS by the window's arithmetic. Was
+            // minHeight: an elastic row would put the window out of step.
+            height: "var(--diff-row-h)",
             cursor: selectable ? "pointer" : undefined,
             background: isSelected
               ? "oklch(from var(--accent) l c h / 0.18)"
-              : undefined,
+              : (bg[kind] ?? "transparent"),
+            borderLeft:
+              borderColor[kind] !== undefined
+                ? `2px solid ${borderColor[kind]}`
+                : "2px solid transparent",
           }}
         >
           <span
@@ -899,8 +829,80 @@ function PGDiffChunk({
             />
           </span>
         </div>
-        );
-      })}
+  );
+}
+
+/**
+ * A hunk's chrome bar: collapse chevron, header text, Discard and Stage.
+ *
+ * Split out of PGHunk so the windowed renderer can emit it as one row among many
+ * without duplicating the markup. Stays density-aware — it is chrome, not code.
+ */
+export function PGHunkHeader({
+  header,
+  staged,
+  onStage,
+  onDiscard,
+  expanded,
+  onToggle,
+  actionsDisabledReason,
+  selCount = 0,
+}: {
+  header: string;
+  staged?: boolean;
+  onStage?: () => void;
+  onDiscard?: () => void;
+  expanded: boolean;
+  onToggle?: () => void;
+  actionsDisabledReason?: string;
+  selCount?: number;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        height: "calc(26px + var(--row-step))",
+        padding: "0 8px",
+        background: "var(--bg-2)",
+        fontFamily: "var(--font-mono)",
+        fontSize: "var(--fs-11)",
+        color: "var(--fg-2)",
+      }}
+    >
+      <PGIconButton
+        icon={expanded ? "chevronDown" : "chevronRight"}
+        size="sm"
+        onClick={onToggle}
+      />
+      <span style={{ color: "var(--accent)" }}>@@ {header} @@</span>
+      <div style={{ flex: 1 }} />
+      <PGButton
+        size="xs"
+        variant="ghost"
+        onClick={onDiscard}
+        icon="x"
+        disabled={!!actionsDisabledReason}
+        title={actionsDisabledReason}
+      >
+        Discard
+      </PGButton>
+      <PGButton
+        data-testid="hunk-stage"
+        size="xs"
+        variant={staged ? "outline" : "primary"}
+        onClick={onStage}
+        icon={staged ? "check" : "plus"}
+        disabled={!!actionsDisabledReason}
+        title={actionsDisabledReason}
+      >
+        {selCount > 0
+          ? `${staged ? "Unstage" : "Stage"} ${selCount} lines`
+          : staged
+            ? "Staged"
+            : "Stage hunk"}
+      </PGButton>
     </div>
   );
 }
@@ -958,69 +960,35 @@ export function PGHunk({
   // withChangedIndices runs FIRST and over the whole hunk: its numbering is the
   // wire contract shared with the backend's Patch::line_in_hunk (#61 D7), so it
   // must not depend on anything the syntax pass does.
-  const chunks = React.useMemo(
-    () => withWordSpans(chunkDiffLines(attachSyntax(withChangedIndices(lines), syntax))),
+  const rows = React.useMemo(
+    () => withWordSpans(withSyntax(withChangedIndices(lines), syntax)),
     [lines, syntax],
   );
   // Line selection is meaningless when the hunk's own indices don't address
   // what git would apply — the same condition that disables Stage/Discard.
   const lineClick = actionsDisabledReason ? undefined : onLineClick;
-  const selCount = selectedLines?.length ?? 0;
   return (
     <div style={{ borderBottom: "1px solid var(--border-0)" }}>
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 8,
-          height: "calc(26px + var(--row-step))",
-          padding: "0 8px",
-          background: "var(--bg-2)",
-          fontFamily: "var(--font-mono)",
-          fontSize: "var(--fs-11)",
-          color: "var(--fg-2)",
-        }}
-      >
-        <PGIconButton
-          icon={expanded ? "chevronDown" : "chevronRight"}
-          size="sm"
-          onClick={onToggle}
-        />
-        <span style={{ color: "var(--accent)" }}>@@ {header} @@</span>
-        <div style={{ flex: 1 }} />
-        <PGButton
-          size="xs"
-          variant="ghost"
-          onClick={onDiscard}
-          icon="x"
-          disabled={!!actionsDisabledReason}
-          title={actionsDisabledReason}
-        >
-          Discard
-        </PGButton>
-        <PGButton
-          data-testid="hunk-stage"
-          size="xs"
-          variant={staged ? "outline" : "primary"}
-          onClick={onStage}
-          icon={staged ? "check" : "plus"}
-          disabled={!!actionsDisabledReason}
-          title={actionsDisabledReason}
-        >
-          {selCount > 0
-            ? `${staged ? "Unstage" : "Stage"} ${selCount} lines`
-            : staged
-              ? "Staged"
-              : "Stage hunk"}
-        </PGButton>
-      </div>
+      <PGHunkHeader
+        header={header}
+        staged={staged}
+        onStage={onStage}
+        onDiscard={onDiscard}
+        expanded={expanded}
+        onToggle={onToggle}
+        actionsDisabledReason={actionsDisabledReason}
+        selCount={selectedLines?.length ?? 0}
+      />
       {expanded && (
         <div>
-          {chunks.map((c, i) => (
-            <PGDiffChunk
+          {rows.map((line, i) => (
+            <PGDiffRow
               key={i}
-              chunk={c}
-              selectedLines={selectedLines}
+              line={line}
+              selected={
+                line.changedIndex != null &&
+                (selectedLines?.includes(line.changedIndex) ?? false)
+              }
               onLineClick={lineClick}
             />
           ))}

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -1,6 +1,7 @@
 import React, { type CSSProperties, type MouseEvent, type ReactNode } from "react";
 import type { WordSpan } from "@/lib/wordDiff";
 import { pairChangedLines } from "@/lib/pairChangedLines";
+import { withChangedIndices } from "@/lib/diffRows";
 import { buildLineSpans } from "@/lib/lineSpans";
 import type { SyntaxLine, SyntaxToken } from "@/lib/syntax";
 import { PGIcon, type IconName } from "./icons";
@@ -659,23 +660,6 @@ function chunkDiffLines(lines: DiffLineData[]): DiffChunk[] {
   return chunks;
 }
 
-/**
- * Number the changed (`+`/`-`) lines of a hunk from 0, leaving context rows
- * unnumbered (#61 D7).
- *
- * This must count exactly the add/rem rows and nothing else: it is the wire
- * contract shared with the backend, whose `Patch::line_in_hunk` counts `+`/`-`
- * origins the same way. `hunk.lines` also carries context and header rows, so
- * a plain array index would address the wrong line.
- */
-function withChangedIndices(lines: DiffLineData[]): DiffLineData[] {
-  let n = 0;
-  return lines.map((l) =>
-    l.kind === "add" || l.kind === "rem"
-      ? { ...l, changedIndex: n++ }
-      : l,
-  );
-}
 
 /**
  * Attach each row's syntax tokens from the correct side of the diff.

--- a/src/design/index.ts
+++ b/src/design/index.ts
@@ -14,3 +14,4 @@ export * from "./use-prevent-browser-context-menu";
 export * from "./resizable";
 export * from "./skeleton";
 export * from "./window-controls";
+export { PGWindowedDiff, type PGWindowedDiffProps } from "./PGWindowedDiff";

--- a/src/design/primitives.tsx
+++ b/src/design/primitives.tsx
@@ -504,11 +504,14 @@ export interface PGToggleProps {
   checked?: boolean;
   onChange?: (v: boolean) => void;
   label?: ReactNode;
+  /** Test hook, same convention as PGResizeHandle — this renders no <input>. */
+  testId?: string;
 }
 
-export function PGToggle({ checked, onChange, label }: PGToggleProps) {
+export function PGToggle({ checked, onChange, label, testId }: PGToggleProps) {
   return (
     <label
+      data-testid={testId}
       style={{
         display: "inline-flex",
         alignItems: "center",

--- a/src/index.css
+++ b/src/index.css
@@ -37,6 +37,12 @@
   --lh-body: 1.45;
   --lh-code: 1.55;
 
+  /* Code-row pitch, derived so --lh-code stays the single owner of code
+     geometry. Read at runtime by useDiffRowHeight for the diff window's
+     arithmetic — never restate it as a number in TS, since 1.55 * 12px is
+     18.6px and any literal is already wrong (#70). */
+  --diff-row-h: calc(var(--fs-12) * var(--lh-code));
+
   --fw-regular: 400;
   --fw-medium: 500;
   --fw-semibold: 600;

--- a/src/lib/diffRows.test.ts
+++ b/src/lib/diffRows.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { flattenDiffRows, rowOffset, windowVariable } from "./diffRows";
+import type { FileDiff } from "./types";
+
+const hunk = (n: number): FileDiff["hunks"][number] => ({
+  header: `@@ -${n} +${n} @@`,
+  oldStart: n,
+  oldLines: 3,
+  newStart: n,
+  newLines: 3,
+  lines: [
+    { kind: { kind: "Context" }, oldLineno: 1, newLineno: 1, content: "ctx" },
+    { kind: { kind: "Deletion" }, oldLineno: 2, newLineno: null, content: "old" },
+    { kind: { kind: "Addition" }, oldLineno: null, newLineno: 2, content: "new" },
+  ],
+});
+
+describe("flattenDiffRows", () => {
+  it("emits a header row then one row per line, per hunk", () => {
+    const rows = flattenDiffRows([hunk(1), hunk(2)], { headerH: 26, rowH: 19 });
+    expect(rows).toHaveLength(8); // 2 headers + 6 lines
+    expect(rows[0]).toMatchObject({ kind: "header", hunkIndex: 0, h: 26 });
+    expect(rows[1]).toMatchObject({ kind: "line", hunkIndex: 0, h: 19 });
+    expect(rows[4]).toMatchObject({ kind: "header", hunkIndex: 1 });
+  });
+
+  it("numbers changedIndex over the WHOLE hunk, skipping context", () => {
+    const rows = flattenDiffRows([hunk(1)], { headerH: 26, rowH: 19 });
+    const lines = rows.filter((r) => r.kind === "line");
+    expect(lines[0].kind === "line" && lines[0].line.changedIndex).toBeUndefined();
+    expect(lines[1].kind === "line" && lines[1].line.changedIndex).toBe(0);
+    expect(lines[2].kind === "line" && lines[2].line.changedIndex).toBe(1);
+  });
+
+  it("restarts changedIndex per hunk, because the backend counts per hunk", () => {
+    const rows = flattenDiffRows([hunk(1), hunk(2)], { headerH: 26, rowH: 19 });
+    const second = rows.filter((r) => r.kind === "line" && r.hunkIndex === 1);
+    expect(second.map((r) => (r.kind === "line" ? r.line.changedIndex : null))).toEqual([
+      undefined,
+      0,
+      1,
+    ]);
+  });
+
+  it("omits a collapsed hunk's line rows but keeps its header", () => {
+    const rows = flattenDiffRows([hunk(1), hunk(2)], {
+      headerH: 26,
+      rowH: 19,
+      collapsed: new Set([0]),
+    });
+    expect(rows.filter((r) => r.hunkIndex === 0)).toHaveLength(1);
+    expect(rows.filter((r) => r.hunkIndex === 1)).toHaveLength(4);
+  });
+
+  it("attaches word spans to paired rem/add rows", () => {
+    const rows = flattenDiffRows(
+      [
+        {
+          header: "@@ -1 +1 @@",
+          oldStart: 1,
+          oldLines: 1,
+          newStart: 1,
+          newLines: 1,
+          lines: [
+            { kind: { kind: "Deletion" }, oldLineno: 1, newLineno: null, content: "let a = 1" },
+            { kind: { kind: "Addition" }, oldLineno: null, newLineno: 1, content: "let a = 2" },
+          ],
+        },
+      ],
+      { headerH: 26, rowH: 19 },
+    );
+    const lines = rows.filter((r) => r.kind === "line");
+    expect(lines[0].kind === "line" && lines[0].line.spans?.some((s) => s.changed)).toBe(true);
+    expect(lines[1].kind === "line" && lines[1].line.spans?.some((s) => s.changed)).toBe(true);
+  });
+
+  it("attaches syntax tokens by side: rem from old, add and ctx from new", () => {
+    const rows = flattenDiffRows([hunk(1)], {
+      headerH: 26,
+      rowH: 19,
+      syntax: {
+        old: [[], [{ start: 0, end: 3, cls: "syn-comment" }]],
+        new: [[], [{ start: 0, end: 3, cls: "syn-keyword" }]],
+      },
+    });
+    const lines = rows.filter((r) => r.kind === "line");
+    // rem row is old line 2 → old[1]; add row is new line 2 → new[1].
+    expect(lines[1].kind === "line" && lines[1].line.syntax?.[0].cls).toBe("syn-comment");
+    expect(lines[2].kind === "line" && lines[2].line.syntax?.[0].cls).toBe("syn-keyword");
+  });
+});
+
+describe("windowVariable", () => {
+  const heights = [26, 19, 19, 19, 26, 19, 19]; // 147px total
+
+  it("renders everything that fits plus overscan", () => {
+    const w = windowVariable(heights, { scrollTop: 0, viewportH: 1000, overscan: 0 });
+    expect(w).toEqual({ start: 0, end: heights.length, topPad: 0, bottomPad: 0 });
+  });
+
+  it("skips rows scrolled past and pads for them exactly", () => {
+    const w = windowVariable(heights, { scrollTop: 45, viewportH: 38, overscan: 0 });
+    expect(w.start).toBe(2);
+    expect(w.topPad).toBe(45);
+  });
+
+  it("keeps topPad + rendered + bottomPad equal to the total height", () => {
+    for (const overscan of [0, 1, 4]) {
+      for (const scrollTop of [0, 20, 45, 100, 147]) {
+        const w = windowVariable(heights, { scrollTop, viewportH: 38, overscan });
+        const rendered = heights.slice(w.start, w.end).reduce((a, b) => a + b, 0);
+        expect(w.topPad + rendered + w.bottomPad).toBe(147);
+      }
+    }
+  });
+
+  it("handles an empty list", () => {
+    expect(windowVariable([], { scrollTop: 0, viewportH: 100, overscan: 4 })).toEqual({
+      start: 0,
+      end: 0,
+      topPad: 0,
+      bottomPad: 0,
+    });
+  });
+
+  it("renders a screenful before first layout, when the viewport measures 0", () => {
+    const w = windowVariable(heights, { scrollTop: 0, viewportH: 0, overscan: 0 });
+    expect(w.end).toBeGreaterThan(0);
+  });
+});
+
+describe("rowOffset", () => {
+  it("sums the heights before an index", () => {
+    expect(rowOffset([26, 19, 19], 0)).toBe(0);
+    expect(rowOffset([26, 19, 19], 2)).toBe(45);
+    expect(rowOffset([26, 19, 19], 99)).toBe(64);
+  });
+});

--- a/src/lib/diffRows.ts
+++ b/src/lib/diffRows.ts
@@ -52,7 +52,7 @@ function toUiLine(l: FileDiff["hunks"][number]["lines"][number]): DiffLineData {
  * Works on the flat line list rather than PGHunk's kind-grouped chunks, so it
  * scans for a removed run followed immediately by an added one.
  */
-function attachWordSpans(lines: DiffLineData[]): DiffLineData[] {
+export function withWordSpans(lines: DiffLineData[]): DiffLineData[] {
   const out = lines.map((l) => ({ ...l }));
   let i = 0;
   while (i < out.length) {
@@ -81,7 +81,7 @@ function attachWordSpans(lines: DiffLineData[]): DiffLineData[] {
 }
 
 /** Same side rule as everywhere else: rem reads the old file, add and ctx the new. */
-function attachSyntax(
+export function withSyntax(
   lines: DiffLineData[],
   syntax: { old: SyntaxLine[] | null; new: SyntaxLine[] | null } | undefined,
 ): DiffLineData[] {
@@ -112,8 +112,8 @@ export function flattenDiffRows(
     rows.push({ kind: "header", hunkIndex, header: h.header, h: headerH });
     if (collapsed?.has(hunkIndex)) return;
     // changedIndex FIRST, over the whole hunk, before anything slices rows.
-    const lines = attachWordSpans(
-      attachSyntax(withChangedIndices(h.lines.map(toUiLine)), syntax),
+    const lines = withWordSpans(
+      withSyntax(withChangedIndices(h.lines.map(toUiLine)), syntax),
     );
     for (const line of lines) rows.push({ kind: "line", hunkIndex, line, h: rowH });
   });

--- a/src/lib/diffRows.ts
+++ b/src/lib/diffRows.ts
@@ -1,0 +1,167 @@
+// Flat row model for a file diff, plus an exact variable-height window.
+//
+// A diff mixes two row heights — a hunk header is density-aware chrome, a code
+// row is --fs-12 * --lh-code — so the fixed-pitch useWindowedList does not fit.
+// Nothing needs measuring though: both heights are KNOWN, so prefix sums give an
+// exact window with no DOM reads and no estimation.
+//
+// `DiffLineData` is imported TYPE-ONLY on purpose. src/design/PGWindowedDiff.tsx
+// imports DiffRow from this module, so a value import of the design barrel here
+// would close a runtime require cycle; `import type` is erased and cannot.
+import type { DiffLineData } from "@/design";
+import type { SyntaxLine, SyntaxToken } from "./syntax";
+import type { WindowRange } from "./useWindowedList";
+import type { FileDiff } from "./types";
+import { pairChangedLines } from "./pairChangedLines";
+
+export type DiffRow =
+  | { kind: "header"; hunkIndex: number; header: string; h: number }
+  | { kind: "line"; hunkIndex: number; line: DiffLineData; h: number };
+
+/**
+ * Number the changed (+/-) lines of a hunk from 0, leaving context unnumbered.
+ *
+ * Moved here from git-components so the flat model and PGHunk share ONE
+ * definition. It must count exactly the add/rem rows: it is the wire contract
+ * shared with the backend's Patch::line_in_hunk, which counts +/- origins the
+ * same way, and it is numbered over the WHOLE hunk — numbering a windowed slice
+ * would address the wrong line when staging (#61 D7).
+ */
+export function withChangedIndices(lines: DiffLineData[]): DiffLineData[] {
+  let n = 0;
+  return lines.map((l) =>
+    l.kind === "add" || l.kind === "rem" ? { ...l, changedIndex: n++ } : l,
+  );
+}
+
+function toUiLine(l: FileDiff["hunks"][number]["lines"][number]): DiffLineData {
+  const k = l.kind.kind;
+  if (k === "Addition") return { kind: "add", lnR: l.newLineno ?? undefined, text: l.content };
+  if (k === "Deletion") return { kind: "rem", lnL: l.oldLineno ?? undefined, text: l.content };
+  return {
+    kind: "ctx",
+    lnL: l.oldLineno ?? undefined,
+    lnR: l.newLineno ?? undefined,
+    text: l.content,
+  };
+}
+
+/**
+ * Attach intra-line spans to adjacent rem/add runs, through the shared rule.
+ *
+ * Works on the flat line list rather than PGHunk's kind-grouped chunks, so it
+ * scans for a removed run followed immediately by an added one.
+ */
+function attachWordSpans(lines: DiffLineData[]): DiffLineData[] {
+  const out = lines.map((l) => ({ ...l }));
+  let i = 0;
+  while (i < out.length) {
+    if (out[i].kind !== "rem") {
+      i++;
+      continue;
+    }
+    let r = i;
+    while (r < out.length && out[r].kind === "rem") r++;
+    let a = r;
+    while (a < out.length && out[a].kind === "add") a++;
+    if (a > r) {
+      const paired = pairChangedLines(
+        out.slice(i, r).map((l) => l.text ?? ""),
+        out.slice(r, a).map((l) => l.text ?? ""),
+      );
+      paired.forEach((p, k) => {
+        if (!p) return;
+        out[i + k].spans = p.old;
+        out[r + k].spans = p.new;
+      });
+    }
+    i = a > i ? a : i + 1;
+  }
+  return out;
+}
+
+/** Same side rule as everywhere else: rem reads the old file, add and ctx the new. */
+function attachSyntax(
+  lines: DiffLineData[],
+  syntax: { old: SyntaxLine[] | null; new: SyntaxLine[] | null } | undefined,
+): DiffLineData[] {
+  if (!syntax) return lines;
+  return lines.map((l) => {
+    const side = l.kind === "rem" ? syntax.old : syntax.new;
+    if (!side) return l;
+    const raw = l.kind === "rem" ? l.lnL : (l.lnR ?? l.lnL);
+    const n = typeof raw === "number" ? raw : Number(raw);
+    if (!Number.isFinite(n) || n < 1) return l;
+    const tokens: SyntaxToken[] | undefined = side[n - 1];
+    return tokens ? { ...l, syntax: tokens } : l;
+  });
+}
+
+export function flattenDiffRows(
+  hunks: FileDiff["hunks"],
+  o: {
+    headerH: number;
+    rowH: number;
+    collapsed?: ReadonlySet<number>;
+    syntax?: { old: SyntaxLine[] | null; new: SyntaxLine[] | null };
+  },
+): DiffRow[] {
+  const { headerH, rowH, collapsed, syntax } = o;
+  const rows: DiffRow[] = [];
+  hunks.forEach((h, hunkIndex) => {
+    rows.push({ kind: "header", hunkIndex, header: h.header, h: headerH });
+    if (collapsed?.has(hunkIndex)) return;
+    // changedIndex FIRST, over the whole hunk, before anything slices rows.
+    const lines = attachWordSpans(
+      attachSyntax(withChangedIndices(h.lines.map(toUiLine)), syntax),
+    );
+    for (const line of lines) rows.push({ kind: "line", hunkIndex, line, h: rowH });
+  });
+  return rows;
+}
+
+export function rowOffset(heights: number[], index: number): number {
+  let sum = 0;
+  for (let i = 0; i < index && i < heights.length; i++) sum += heights[i];
+  return sum;
+}
+
+/**
+ * Window a list of known-height rows. Returns the same shape useWindowedList
+ * produces, so consumers and the `window?: WindowRange` prop are unchanged.
+ */
+export function windowVariable(
+  heights: number[],
+  o: { scrollTop: number; viewportH: number; overscan: number },
+): WindowRange {
+  const { scrollTop, overscan } = o;
+  if (heights.length === 0) return { start: 0, end: 0, topPad: 0, bottomPad: 0 };
+  // Before first layout the viewport measures 0. Render a screenful anyway so the
+  // list is never blank on first paint and e2e can find a row immediately.
+  const viewportH = o.viewportH || 400;
+
+  let first = 0;
+  let acc = 0;
+  while (first < heights.length && acc + heights[first] <= scrollTop) {
+    acc += heights[first];
+    first++;
+  }
+  let topPad = acc;
+  let start = first;
+  for (let k = 0; k < overscan && start > 0; k++) {
+    start--;
+    topPad -= heights[start];
+  }
+
+  let end = first;
+  let filled = acc - scrollTop; // partial height of the first visible row
+  while (end < heights.length && filled < viewportH) {
+    filled += heights[end];
+    end++;
+  }
+  for (let k = 0; k < overscan && end < heights.length; k++) end++;
+
+  const total = heights.reduce((a, b) => a + b, 0);
+  const rendered = heights.slice(start, end).reduce((a, b) => a + b, 0);
+  return { start, end, topPad, bottomPad: Math.max(0, total - topPad - rendered) };
+}

--- a/src/lib/useDiffRowHeight.test.ts
+++ b/src/lib/useDiffRowHeight.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { DIFF_ROW_H_FALLBACK, readDiffRowHeight } from "./useDiffRowHeight";
+
+afterEach(() => {
+  document.documentElement.style.removeProperty("--diff-row-h");
+});
+
+describe("readDiffRowHeight", () => {
+  it("parses a px value from the custom property", () => {
+    document.documentElement.style.setProperty("--diff-row-h", "18.6px");
+    expect(readDiffRowHeight()).toBeCloseTo(18.6);
+  });
+
+  it("falls back when the value is not resolved to px", () => {
+    // jsdom does not evaluate calc(), and a NaN here would collapse every
+    // windowed row to zero height.
+    document.documentElement.style.setProperty("--diff-row-h", "calc(12px * 1.55)");
+    expect(readDiffRowHeight()).toBe(DIFF_ROW_H_FALLBACK);
+  });
+
+  it("falls back when the property is missing", () => {
+    expect(readDiffRowHeight()).toBe(DIFF_ROW_H_FALLBACK);
+  });
+
+  it("falls back on a nonsense or non-positive value", () => {
+    document.documentElement.style.setProperty("--diff-row-h", "0px");
+    expect(readDiffRowHeight()).toBe(DIFF_ROW_H_FALLBACK);
+    document.documentElement.style.setProperty("--diff-row-h", "banana");
+    expect(readDiffRowHeight()).toBe(DIFF_ROW_H_FALLBACK);
+  });
+});

--- a/src/lib/useDiffRowHeight.ts
+++ b/src/lib/useDiffRowHeight.ts
@@ -1,0 +1,36 @@
+import React from "react";
+import { useDensityStep } from "@/features/settings/useSettingsStore";
+
+/**
+ * Used when --diff-row-h cannot be resolved to px — notably jsdom, which does not
+ * evaluate calc(). A fallback, never the source of truth: CSS owns the real value,
+ * and returning NaN here would collapse every windowed row to zero height.
+ */
+export const DIFF_ROW_H_FALLBACK = 19;
+
+export function readDiffRowHeight(): number {
+  const raw = getComputedStyle(document.documentElement)
+    .getPropertyValue("--diff-row-h")
+    .trim();
+  const n = Number.parseFloat(raw);
+  return raw.endsWith("px") && Number.isFinite(n) && n > 0 ? n : DIFF_ROW_H_FALLBACK;
+}
+
+/**
+ * Code-row pitch in px, read from CSS rather than restated here.
+ *
+ * --lh-code stays the owner of code geometry, and 1.55 × 12px is 18.6px — any
+ * literal in TypeScript would already be wrong and would desync the window from
+ * the rows it is measuring (the #70 lesson).
+ *
+ * Re-read when density changes, because that is when the theme layer rewrites
+ * geometry-adjacent tokens.
+ */
+export function useDiffRowHeight(): number {
+  const step = useDensityStep();
+  const [h, setH] = React.useState(() => readDiffRowHeight());
+  React.useEffect(() => {
+    setH(readDiffRowHeight());
+  }, [step]);
+  return h;
+}

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -8,7 +8,7 @@ import {
   PGCheckbox,
   PGEmpty,
   PGFileTree,
-  PGHunk,
+  PGWindowedDiff,
   PGIconButton,
   PGInput,
   PGSideBySideDiff,
@@ -23,14 +23,13 @@ import {
   pgPrompt,
   useContextMenu,
   usePaneWidth,
-  type DiffLineData,
   type PGFileTreeNode,
   type PGStageState,
   type SideLine,
 } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
-import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { useDensityStep, useSettingsStore } from "@/features/settings/useSettingsStore";
 import { PGPane, FocusableScroll, usePaneList, useAction } from "@/features/keymap";
 import { stageablePaths } from "@/features/repo/ops";
 import {
@@ -52,6 +51,8 @@ import {
 } from "@/lib/selection";
 import { getDiff, getLogPage } from "@/lib/tauri";
 import { useDiffSyntax } from "@/lib/syntax";
+import { flattenDiffRows, windowVariable } from "@/lib/diffRows";
+import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
 import {
   WhitespaceToggle,
   useHunkActionsDisabledReason,
@@ -452,6 +453,54 @@ export function CommitPanelScreen() {
     old: { kind: "rev", rev: "HEAD", path: diff?.oldPath },
     new: { kind: "worktree" },
   });
+
+  // ── Windowed diff rows ───────────────────────────────────────────────────
+  // No wrap toggle in this pane, so rows are always fixed-pitch and windowing is
+  // always on. Row heights are known, so the window needs no measurement.
+  const rowH = useDiffRowHeight();
+  const headerH = 26 + useDensityStep();
+  const [collapsed, setCollapsed] = React.useState<ReadonlySet<number>>(new Set());
+  const toggleHunk = React.useCallback((i: number) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(i)) next.delete(i);
+      else next.add(i);
+      return next;
+    });
+  }, []);
+  React.useEffect(() => setCollapsed(new Set()), [selected?.path, selected?.side]);
+
+  const rows = React.useMemo(
+    () =>
+      flattenDiffRows(diff && !diff.binary ? diff.hunks : [], {
+        headerH,
+        rowH,
+        collapsed,
+        syntax,
+      }),
+    [diff, headerH, rowH, collapsed, syntax],
+  );
+  const heights = React.useMemo(() => rows.map((r) => r.h), [rows]);
+  const diffScrollRef = React.useRef<HTMLDivElement>(null);
+  const [diffScrollTop, setDiffScrollTop] = React.useState(0);
+  const [diffViewportH, setDiffViewportH] = React.useState(0);
+  React.useEffect(() => {
+    const el = diffScrollRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    setDiffViewportH(el.clientHeight);
+    const ro = new ResizeObserver(() => setDiffViewportH(el.clientHeight));
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [diffMode]);
+  const win = React.useMemo(
+    () =>
+      windowVariable(heights, {
+        scrollTop: diffScrollTop,
+        viewportH: diffViewportH,
+        overscan: 8,
+      }),
+    [heights, diffScrollTop, diffViewportH],
+  );
 
   React.useEffect(() => {
     if (!selected || !repo) {
@@ -920,7 +969,12 @@ export function CommitPanelScreen() {
             }}
           />
         </div>
-        <FocusableScroll style={{ flex: 1 }} ariaLabel="Diff">
+        <FocusableScroll
+          style={{ flex: 1 }}
+          ariaLabel="Diff"
+          innerRef={diffScrollRef}
+          onScroll={() => setDiffScrollTop(diffScrollRef.current?.scrollTop ?? 0)}
+        >
           {diffLoading && (
             <div
               style={{
@@ -956,54 +1010,52 @@ export function CommitPanelScreen() {
               </PGEmpty>
             )}
           {!diffLoading && !diffError && diff && !diff.binary && diff.hunks.length > 0 &&
-            diffMode === "unified" &&
-            diff.hunks.map((h, i) => (
-              <PGHunk
-                key={i}
-                header={h.header.replace(/^@@\s*|\s*@@$/g, "").trim()}
-                lines={h.lines.map(toUiLine)}
-                expanded={true}
-                syntax={syntax}
-                staged={selected?.side === "staged"}
-                actionsDisabledReason={hunkActionsDisabled}
-                selectedLines={lineSel[i] ?? []}
-                onLineClick={(changedIndex, range) =>
-                  onLineClick(i, changedIndex, range)
-                }
-                onStage={() => {
-                  if (!selected) return;
-                  const sel = lineSel[i] ?? [];
-                  const store = useRepoStore.getState();
-                  if (selected.side === "staged") {
-                    if (sel.length) store.unstageLines(selected.path, i, sel);
-                    else store.unstageHunk(selected.path, i);
-                  } else {
-                    if (sel.length) store.stageLines(selected.path, i, sel);
-                    else store.stageHunk(selected.path, i);
-                  }
-                  clearLineSel();
-                }}
-                onDiscard={async () => {
-                  if (!selected) return;
-                  const sel = lineSel[i] ?? [];
-                  if (
-                    await pgConfirm({
-                      title: sel.length
-                        ? `Discard ${sel.length} selected line${sel.length === 1 ? "" : "s"}?`
-                        : "Discard this hunk?",
-                      body: `The change to ${selected.path} will be lost.`,
-                      danger: true,
-                      confirmLabel: sel.length ? "Discard lines" : "Discard hunk",
-                    })
-                  ) {
+            diffMode === "unified" && (
+              <PGWindowedDiff
+                rows={rows}
+                window={win}
+                collapsed={collapsed}
+                onToggleHunk={toggleHunk}
+                selectedLines={(i) => lineSel[i] ?? []}
+                onLineClick={onLineClick}
+                hunkActions={(i) => ({
+                  staged: selected?.side === "staged",
+                  actionsDisabledReason: hunkActionsDisabled,
+                  onStage: () => {
+                    if (!selected) return;
+                    const sel = lineSel[i] ?? [];
                     const store = useRepoStore.getState();
-                    if (sel.length) store.discardLines(selected.path, i, sel);
-                    else store.discardHunk(selected.path, i);
+                    if (selected.side === "staged") {
+                      if (sel.length) store.unstageLines(selected.path, i, sel);
+                      else store.unstageHunk(selected.path, i);
+                    } else {
+                      if (sel.length) store.stageLines(selected.path, i, sel);
+                      else store.stageHunk(selected.path, i);
+                    }
                     clearLineSel();
-                  }
-                }}
+                  },
+                  onDiscard: async () => {
+                    if (!selected) return;
+                    const sel = lineSel[i] ?? [];
+                    if (
+                      await pgConfirm({
+                        title: sel.length
+                          ? `Discard ${sel.length} selected line${sel.length === 1 ? "" : "s"}?`
+                          : "Discard this hunk?",
+                        body: `The change to ${selected.path} will be lost.`,
+                        danger: true,
+                        confirmLabel: sel.length ? "Discard lines" : "Discard hunk",
+                      })
+                    ) {
+                      const store = useRepoStore.getState();
+                      if (sel.length) store.discardLines(selected.path, i, sel);
+                      else store.discardHunk(selected.path, i);
+                      clearLineSel();
+                    }
+                  },
+                })}
               />
-            ))}
+            )}
           {!diffLoading && !diffError && diff && !diff.binary && diff.hunks.length > 0 &&
             diffMode === "split" && (
               <PGSideBySideDiff {...diffToSplit(diff)} />
@@ -1536,24 +1588,6 @@ function diffToSplit(d: FileDiff): { left: SideLine[]; right: SideLine[] } {
   return { left, right };
 }
 
-function toUiLine(l: {
-  kind: { kind: string };
-  oldLineno: number | null;
-  newLineno: number | null;
-  content: string;
-}): DiffLineData {
-  const k = l.kind.kind;
-  if (k === "Addition")
-    return { kind: "add", lnR: l.newLineno ?? undefined, text: l.content };
-  if (k === "Deletion")
-    return { kind: "rem", lnL: l.oldLineno ?? undefined, text: l.content };
-  return {
-    kind: "ctx",
-    lnL: l.oldLineno ?? undefined,
-    lnR: l.newLineno ?? undefined,
-    text: l.content,
-  };
-}
 
 function Header({
   title,

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -3,7 +3,7 @@ import {
   PGBadge,
   PGButtonGroup,
   PGEmpty,
-  PGHunk,
+  PGWindowedDiff,
   PGIconButton,
   PGResizeHandle,
   PGSearchInput,
@@ -13,7 +13,6 @@ import {
   PGToggle,
   PGToolbar,
   usePaneWidth,
-  type DiffLineData,
   type SideLine,
 } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
@@ -27,6 +26,9 @@ import { statusMark } from "@/lib/derive";
 import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
 import { getDiff } from "@/lib/tauri";
 import { useDiffSyntax } from "@/lib/syntax";
+import { flattenDiffRows, rowOffset, windowVariable } from "@/lib/diffRows";
+import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
+import { useDensityStep } from "@/features/settings/useSettingsStore";
 import { pairChangedLines } from "@/lib/pairChangedLines";
 import { PGPane, FocusableScroll, usePaneList, useHunkNav } from "@/features/keymap";
 import type { FileDiff } from "@/lib/types";
@@ -177,6 +179,66 @@ export function DiffViewerScreen() {
     resetKey: selectedPath,
   });
 
+  // ── Windowed rows ────────────────────────────────────────────────────────
+  const rowH = useDiffRowHeight();
+  const headerH = 26 + useDensityStep();
+  const [collapsed, setCollapsed] = React.useState<ReadonlySet<number>>(new Set());
+  const toggleHunk = React.useCallback((i: number) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(i)) next.delete(i);
+      else next.add(i);
+      return next;
+    });
+  }, []);
+  React.useEffect(() => setCollapsed(new Set()), [selectedPath]);
+
+  const rows = React.useMemo(
+    () =>
+      flattenDiffRows(findFiltered?.hunks ?? [], {
+        headerH,
+        rowH,
+        collapsed,
+        syntax,
+      }),
+    [findFiltered, headerH, rowH, collapsed, syntax],
+  );
+  const heights = React.useMemo(() => rows.map((r) => r.h), [rows]);
+
+  const scrollRef = React.useRef<HTMLDivElement>(null);
+  const [scrollTop, setScrollTop] = React.useState(0);
+  const [viewportH, setViewportH] = React.useState(0);
+  React.useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    setViewportH(el.clientHeight);
+    const ro = new ResizeObserver(() => setViewportH(el.clientHeight));
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [mode]);
+
+  // Wrap makes row heights genuinely unknown — pre-wrap rows are as tall as they
+  // need to be — so windowing is off and every row renders. A very large wrapped
+  // diff stays slow; that combination is rare and this keeps the toggle.
+  const win = React.useMemo(
+    () =>
+      wrap ? undefined : windowVariable(heights, { scrollTop, viewportH, overscan: 8 }),
+    [wrap, heights, scrollTop, viewportH],
+  );
+
+  // Scroll F7's target hunk into view BY OFFSET. A querySelector would find
+  // nothing whenever the target row is outside the window.
+  React.useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || hunkCursor == null) return;
+    const idx = rows.findIndex((r) => r.kind === "header" && r.hunkIndex === hunkCursor);
+    if (idx < 0) return;
+    const top = rowOffset(heights, idx);
+    if (top < el.scrollTop || top > el.scrollTop + el.clientHeight - headerH) {
+      el.scrollTop = top;
+    }
+  }, [hunkCursor, rows, heights, headerH]);
+
   if (status.length === 0) {
     return (
       <PGEmpty icon="fileCode" title="Nothing to diff">
@@ -236,7 +298,12 @@ export function DiffViewerScreen() {
                 { value: "split", label: "Split" },
               ]}
             />
-            <PGToggle checked={wrap} onChange={setWrap} label="Wrap" />
+            <PGToggle
+              checked={wrap}
+              onChange={setWrap}
+              label="Wrap"
+              testId="diff-wrap-toggle"
+            />
             <PGIconButton
               icon="search"
               size="md"
@@ -376,24 +443,22 @@ export function DiffViewerScreen() {
             <PGEmpty icon="file" title="Binary file" />
           )}
           {!diffLoading && findFiltered && !findFiltered.binary && mode === "unified" && (
-            <FocusableScroll style={{ flex: 1 }} ariaLabel="Diff">
+            <FocusableScroll
+              style={{ flex: 1 }}
+              ariaLabel="Diff"
+              innerRef={scrollRef}
+              onScroll={() => setScrollTop(scrollRef.current?.scrollTop ?? 0)}
+            >
               {findFiltered.hunks.length === 0 && findQuery.trim() && (
                 <PGEmpty icon="search" title="No matches" />
               )}
-              {findFiltered.hunks.map((h, i) => (
-                <div
-                  key={i}
-                  data-hunk-index={i}
-                  data-hunk-active={hunkCursor === i ? "" : undefined}
-                >
-                  <PGHunk
-                    header={h.header.replace(/^@@\s*|\s*@@$/g, "").trim()}
-                    lines={h.lines.map(toUiLine)}
-                    expanded={true}
-                    syntax={syntax}
-                  />
-                </div>
-              ))}
+              <PGWindowedDiff
+                rows={rows}
+                window={win}
+                activeHunk={hunkCursor ?? undefined}
+                collapsed={collapsed}
+                onToggleHunk={toggleHunk}
+              />
             </FocusableScroll>
           )}
           {!diffLoading && findFiltered && !findFiltered.binary && mode === "split" && (
@@ -408,24 +473,6 @@ export function DiffViewerScreen() {
   );
 }
 
-function toUiLine(l: {
-  kind: { kind: string };
-  oldLineno: number | null;
-  newLineno: number | null;
-  content: string;
-}): DiffLineData {
-  const k = l.kind.kind;
-  if (k === "Addition")
-    return { kind: "add", lnR: l.newLineno ?? undefined, text: l.content };
-  if (k === "Deletion")
-    return { kind: "rem", lnL: l.oldLineno ?? undefined, text: l.content };
-  return {
-    kind: "ctx",
-    lnL: l.oldLineno ?? undefined,
-    lnR: l.newLineno ?? undefined,
-    text: l.content,
-  };
-}
 
 /**
  * Flatten hunks into aligned left/right columns.

--- a/src/screens/DiffViewer.window.test.tsx
+++ b/src/screens/DiffViewer.window.test.tsx
@@ -1,0 +1,97 @@
+// Windowed diff rows in the DiffViewer.
+//
+// jsdom lays nothing out, so the viewport measures 0 and windowVariable falls
+// back to a screenful — enough to prove that a 400-line diff does NOT mount all
+// 400 rows, and that turning wrap on mounts every one of them.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DiffViewerScreen } from "./DiffViewer";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { WithDialogs } from "@/test/dialog";
+import type { FileStatus } from "@/lib/types";
+
+vi.mock("@/lib/syntax/tokenize", async (orig) => ({
+  ...(await orig<typeof import("@/lib/syntax/tokenize")>()),
+  tokenizeFile: async () => null, // plain rows; this suite is about windowing
+}));
+
+const LINES = 400;
+
+const unstaged = (path: string): FileStatus => ({
+  path,
+  worktree: { kind: "Modified" },
+  index: { kind: "Unmodified" },
+  additions: 0,
+  deletions: 0,
+  embedded: false,
+});
+
+const diff = (path: string) => ({
+  path,
+  oldPath: null,
+  binary: false,
+  additions: 0,
+  deletions: 0,
+  hunks: [
+    {
+      header: `@@ -1,${LINES} +1,${LINES} @@`,
+      oldStart: 1,
+      oldLines: LINES,
+      newStart: 1,
+      newLines: LINES,
+      lines: Array.from({ length: LINES }, (_, i) => ({
+        kind: { kind: "Context" as const },
+        oldLineno: i + 1,
+        newLineno: i + 1,
+        content: `line ${i}`,
+      })),
+    },
+  ],
+});
+
+beforeEach(() => {
+  resetInvokeMock();
+  useSettingsStore.setState({ ignoreWhitespaceInDiff: false });
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
+    status: [unstaged("a.ts")],
+    branches: [],
+    remotes: [],
+    commits: [],
+    loading: false,
+  } as never);
+  mockInvoke("get_status", () => [unstaged("a.ts")]);
+  mockInvoke("get_diff", (args) => diff(args.path as string));
+  mockInvoke("read_file_content", () => ({
+    path: "a.ts", binary: false, text: "x", fromHead: false, size: 1,
+  }));
+  mockInvoke("read_file_content_at_rev", () => ({
+    path: "a.ts", binary: false, text: "x", fromHead: true, size: 1,
+  }));
+  render(
+    <WithDialogs>
+      <DiffViewerScreen />
+    </WithDialogs>,
+  );
+});
+
+describe("DiffViewer windowing", () => {
+  it("mounts far fewer rows than the diff has", async () => {
+    await waitFor(() => expect(screen.getByText("line 0")).toBeInTheDocument());
+    expect(screen.queryByText(`line ${LINES - 1}`)).not.toBeInTheDocument();
+    const mounted = document.querySelectorAll("[data-pg-spacer]").length;
+    expect(mounted).toBeGreaterThan(0); // a spacer stands in for the rest
+  });
+
+  it("renders every row once wrap is on, since row height stops being known", async () => {
+    await waitFor(() => expect(screen.getByText("line 0")).toBeInTheDocument());
+    await userEvent.click(screen.getByTestId("diff-wrap-toggle"));
+    await waitFor(() =>
+      expect(screen.getByText(`line ${LINES - 1}`)).toBeInTheDocument(),
+    );
+    expect(document.querySelector("[data-pg-spacer]")).toBeNull();
+  });
+});


### PR DESCRIPTION
PR3 of #104, the last slice. Stops mounting every row of a diff.

## Why not the existing windowing helper

`useWindowedList` is fixed-pitch, and a diff has two row heights: a hunk header is `calc(26px + var(--row-step))` of density-aware chrome carrying a chevron and Stage/Discard, while a code row is `--fs-12 × --lh-code`. Forcing headers to code-row height would cram those buttons and drop them out of density.

Nothing here needs measuring, though — **both heights are known**. So the file's rows flatten into one array tagged with their heights, and `windowVariable` slices it by exact prefix sums: no DOM reads, no estimation, no measured-height bookkeeping. It returns the same `WindowRange` shape `useWindowedList` produces, so the `window?: WindowRange` convention `PGFileTree` established carries over unchanged.

## What changed

- **`src/lib/diffRows.ts`** — `DiffRow`, `flattenDiffRows`, `windowVariable`, `rowOffset`. `withChangedIndices` moves here so the flat model and `PGHunk` share one definition of the staging wire contract, and the word-span and syntax passes become shared flat transforms rather than chunk-shaped ones.
- **`--diff-row-h`** — declared in CSS as `calc(var(--fs-12) * var(--lh-code))` and read at runtime by `useDiffRowHeight`. `--lh-code` keeps ownership of code geometry, and 1.55 × 12px is 18.6px, so any literal in TypeScript would already be wrong and would desync the window from the rows (#70).
- **`PGHunk` split** into `PGHunkHeader` + `PGDiffRow`. The add/rem background and gutter stripe move from a per-run wrapper onto each row, because a windowed slice can start mid-run and would have no wrapper to inherit from; per-row `border-left` stacks into the same continuous stripe.
- **`PGWindowedDiff`** — flat renderer over those two pieces, so the windowed and unwindowed paths cannot drift. `data-hunk-index` stays on header rows (F7 and the e2e specs address hunks through it), and rows are keyed by **absolute** index so React does not reuse another line's DOM node as the window scrolls.
- **DiffViewer and CommitPanel adopt it.** F7 scrolls to a hunk by computed row offset, never `querySelector` — under windowing the target row is usually not mounted. `wrap` disables windowing, since `pre-wrap` makes row height genuinely unknown; a very large wrapped diff stays slow, which keeps the toggle honest.

## The bug the guards caught

`PGHunk` suppressed line selection when a hunk's actions were disabled — whitespace-ignoring diffs are a rewritten view whose indices do not address what git would apply (#61 D2). My flat renderer forwarded that only to the header, so selection stayed live. `CommitPanel.lineStaging.test.tsx` failed unedited, the rule moved into `PGWindowedDiff`, and there is now a component-level test pinning it too.

`changedIndex` is still numbered over the whole hunk before anything slices rows (#61 D7) — asserted in `diffRows.test.ts`, in `PGWindowedDiff.test.tsx` for a mid-list slice, and end to end by the line-staging suite.

## Deliberately not in this PR

- **`CommitDiffPanel` windowing.** Its markup is intentionally lighter than the staging diff — no line-number gutters, tighter rows for the History inline panel. Windowing it means either a second flatten implementation or adopting `PGWindowedDiff`'s look, which is a design decision rather than a mechanical one. It is read-only and has fewer nodes per row, so it is the least urgent of the three.
- **Deleting `PGHunk`,** which now has no production consumers. It survives as the single-hunk primitive and as the guard pinning word-span and syntax-span rendering — removing the safety net in the same change it is validating would be backwards. It carries a comment saying so.

## Verification

- `pnpm tsc --noEmit` — clean
- `pnpm test` — 114 files, 841 tests passing; `wordDiffRender`, `syntaxRender` and `CommitPanel.lineStaging` all pass **unedited**
- `pnpm vite build` — clean
- `pnpm test:e2e:docker full --spec history-diff --spec keymap --spec keyboard-shortcuts` — 3 spec files, 100% in 1:14, including "F7 / ⇧F7 walk the diff hunks", the assertion most exposed to rows leaving the DOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)
