### PR TITLE
feat(rebase): flatten merge commits with the plan saying so

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,9 +377,16 @@ lib/
 - **`RebaseState.rewritten` maps original oid → replayed oid** for every step
   that ran, recorded *after* the action's post-commit rewrite (reword amends,
   squash/fixup collapse), and a dropped step maps to the HEAD it left behind.
-- **Merge commits in a plan may only be dropped** (git's own default: the merge
-  disappears and its commits are replayed individually). `rebase_plan::merge_legal`
-  is the single source of truth; any UI that offers merge-row actions mirrors it.
+- **Merge commits in a plan take one of two actions**: `Drop` (flatten — git's
+  own default: the merge disappears and its commits are replayed individually)
+  or `MainlinePick` (keep the merge as one ordinary commit — `git cherry-pick
+  -m 1`, so `start_pick` passes mainline 1). `rebase_plan::merge_legal` is the
+  single source of truth; `MERGE_ACTIONS` in `src/screens/Rebase.tsx` mirrors it,
+  and the two must stay in sync or the UI offers an action the backend refuses.
+- **`PGRebaseRow` speaks exact `RebaseAction` strings** (`"Pick"`, `"Drop"`,
+  `"MainlinePick"`), not lowercased ones — a two-word action cannot survive a
+  lowercase/re-capitalise round trip. E2E specs that drive the row's `<select>`
+  in-page must set the exact value.
 - **Every transition is mirrored to `.git/platypusgit-rebase.json`**, and
   `rebase_status` / `repo_state` fall back to it when this process did not start
   the rebase. `repo_state` gives the file precedence over libgit2's

--- a/e2e/specs/rebase.e2e.ts
+++ b/e2e/specs/rebase.e2e.ts
@@ -1,5 +1,10 @@
 import { browser, $, expect } from "@wdio/globals";
-import { cherryRepo, rebaseConflictRepo, TempRepo } from "../support/tempRepo";
+import {
+  cherryRepo,
+  mergeRangeRepo,
+  rebaseConflictRepo,
+  TempRepo,
+} from "../support/tempRepo";
 import {
   openRepo, resetApp, switchScreen, stubNativeDialogs,
   jsContextMenu, jsClickMenuItem, executeOnce, scrollCommitListTo,
@@ -85,7 +90,8 @@ describe("interactive rebase", () => {
       const row = rows.find((r) => r.textContent?.includes(rowText));
       const select = row?.querySelector("select") as HTMLSelectElement | null;
       if (!select) throw new Error(`rebase row select not found: ${rowText}`);
-      select.value = "drop";
+      // Exact RebaseAction value — the row used to lowercase its options.
+      select.value = "Drop";
       select.dispatchEvent(new Event("change", { bubbles: true }));
     }, dropRowText);
     await $('[data-testid="rebase-start"]').click();
@@ -97,6 +103,46 @@ describe("interactive rebase", () => {
       async () => repo.git("rev-parse", "HEAD").trim() === before,
       { timeout: 20_000, timeoutMsg: "abort did not restore HEAD" },
     );
+    expect(repo.git("status", "--porcelain").trim()).toBe("");
+  });
+
+  it("flattens a merge commit out of the range", async () => {
+    repo = mergeRangeRepo();
+    await openRepo(repo.path);
+    await stubNativeDialogs({ confirm: true });
+    await switchScreen("history");
+    await scrollCommitListTo("feat: a on main");
+    // "Interactive rebase from here" on A puts everything after A in the plan:
+    // F, C, and the merge M. (Never invoke it on the ROOT commit — that
+    // silently no-ops.)
+    await jsContextMenu('[data-testid="commit-row"]', { text: "feat: a on main" });
+    await jsClickMenuItem("Interactive rebase from here");
+
+    const warning = $('[data-testid="rebase-merge-warning"]');
+    await warning.waitForDisplayed({
+      timeout: 15_000,
+      timeoutMsg: "merge warning never appeared for a range containing a merge",
+    });
+    expect(await warning.getText()).toContain("1 merge commit");
+
+    await $('[data-testid="rebase-start"]').click();
+    // rebase-last-summary renders only once the rebase is done and the plan is
+    // cleared, so it cannot match mid-replay.
+    await $('[data-testid="rebase-last-summary"]').waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "flattening rebase never reported completion",
+    });
+
+    // The merge is gone, the side branch's commit and file survived, and the
+    // history is linear.
+    expect(repo.git("log", "--oneline", "--merges").trim()).toBe("");
+    expect(repo.git("log", "--format=%s").trim().split("\n")).toEqual([
+      "feat: c on main",
+      "feat: f on feature",
+      "feat: a on main",
+      "feat: root",
+    ]);
+    expect(repo.read("f.txt")).toBe("f\n");
     expect(repo.git("status", "--porcelain").trim()).toBe("");
   });
 });

--- a/e2e/support/tempRepo.ts
+++ b/e2e/support/tempRepo.ts
@@ -176,6 +176,30 @@ export function rebaseConflictRepo(): TempRepo {
   // pick's result) to actually diverge.
 }
 
+/**
+ * A range with a merge commit in the middle:
+ *
+ *   root ── A ──── C ── M   (main)
+ *            \        /
+ *             ─── F ──      (feature)
+ *
+ * F and C touch different files, so M merges cleanly. `main` advances past the
+ * branch point before merging, so this is a real merge and not a fast-forward
+ * (`--no-ff` is belt-and-braces). Used by the interactive rebase spec: a rebase
+ * from A must flatten M away while keeping F's content.
+ */
+export function mergeRangeRepo(): TempRepo {
+  const r = new TempRepo();
+  r.commitFile("root.txt", "root\n", "feat: root");
+  r.commitFile("a.txt", "a\n", "feat: a on main");
+  r.git("checkout", "-b", "feature");
+  r.commitFile("f.txt", "f\n", "feat: f on feature");
+  r.git("checkout", "main");
+  r.commitFile("c.txt", "c\n", "feat: c on main");
+  r.git("merge", "--no-ff", "-m", "Merge branch 'feature'", "feature");
+  return r;
+}
+
 /** A bare repository with real commits, for driving the clone path against
  *  local disk only — no network, no credentials, no flake.
  *

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -126,13 +126,20 @@ impl Libgit2Backend {
     /// committing. Returns `Ok(false)` when the merge left conflicts (caller
     /// pauses for the user), `Ok(true)` when it applied cleanly and the tree is
     /// staged ready for `finish_pick`.
-    fn start_pick(&self, repo_id: &RepoId, oid: &str) -> AppResult<bool> {
+    /// `mainline` is 0 for an ordinary commit and 1 for a merge commit being
+    /// flattened into one commit — libgit2 refuses a merge without one
+    /// ("mainline branch is not specified"), which is exactly the error a plan
+    /// containing an unhandled merge used to hit mid-replay, and it equally
+    /// refuses a mainline on a single-parent commit.
+    fn start_pick(&self, repo_id: &RepoId, oid: &str, mainline: u32) -> AppResult<bool> {
         self.with_repo(repo_id, |repo| {
             let target = repo
                 .revparse_single(oid)
                 .map_err(|_| AppError::InvalidRef(oid.to_string()))?
                 .peel_to_commit()?;
-            repo.cherrypick(&target, None)?;
+            let mut opts = git2::CherrypickOptions::new();
+            opts.mainline(mainline);
+            repo.cherrypick(&target, Some(&mut opts))?;
             let statuses = repo.statuses(None)?;
             Ok(!statuses.iter().any(|s| s.status().is_conflicted()))
         })
@@ -380,9 +387,28 @@ impl Libgit2Backend {
                 continue;
             }
 
+            // A merge commit being kept as one commit needs a mainline; every
+            // other step must not get one.
+            let mainline = if step.action == RebaseAction::MainlinePick {
+                let parents = self.with_repo(repo_id, |repo| {
+                    Ok(repo
+                        .revparse_single(&step.oid)
+                        .map_err(|_| AppError::InvalidRef(step.oid.clone()))?
+                        .peel_to_commit()?
+                        .parent_count())
+                })?;
+                if parents > 1 {
+                    1
+                } else {
+                    0
+                }
+            } else {
+                0
+            };
+
             // Stage the step's changes. On resume the resolved tree is already
             // staged, so skip the (re-)cherry-pick that would re-conflict.
-            if !resuming && !self.start_pick(repo_id, &step.oid)? {
+            if !resuming && !self.start_pick(repo_id, &step.oid, mainline)? {
                 // Conflict: stash the step out of the plan (so continue commits
                 // the resolution rather than re-picking) and pause.
                 let mut rebases = self
@@ -407,7 +433,7 @@ impl Libgit2Backend {
                     self.bump_completed(repo_id)?;
                 }
 
-                RebaseAction::Pick => {
+                RebaseAction::Pick | RebaseAction::MainlinePick => {
                     self.bump_completed(repo_id)?;
                 }
 

--- a/src-tauri/src/git/rebase_plan.rs
+++ b/src-tauri/src/git/rebase_plan.rs
@@ -18,11 +18,12 @@ pub fn short(oid: &str) -> &str {
 
 /// Actions that mean something for a commit with more than one parent.
 ///
-/// Only `Drop` for now — git's own default, which drops merges and flattens the
-/// branch. Keeping a merge as one commit and recreating it are separate actions
-/// added later; this function is the single source of truth the UI mirrors.
+/// `Drop` flattens (git's own default: the merge disappears and its commits are
+/// replayed individually); `MainlinePick` keeps the merge as one ordinary
+/// commit. Recreating a merge is a separate action added later. This function is
+/// the single source of truth the UI mirrors.
 pub fn merge_legal(action: RebaseAction) -> bool {
-    matches!(action, RebaseAction::Drop)
+    matches!(action, RebaseAction::Drop | RebaseAction::MainlinePick)
 }
 
 pub fn validate(repo: &Repository, plan: &[RebaseStep]) -> AppResult<()> {
@@ -48,9 +49,10 @@ pub fn validate(repo: &Repository, plan: &[RebaseStep]) -> AppResult<()> {
 
         if commit.parent_count() > 1 && !merge_legal(step.action) {
             return Err(AppError::InvalidRebasePlan(format!(
-                "{} is a merge commit — it can only be dropped, which flattens \
-                 the branch, or left out of the plan",
-                short(&step.oid)
+                "{} is a merge commit — it can be dropped (which flattens the \
+                 branch) or kept as one commit, but not {:?}ed",
+                short(&step.oid),
+                step.action
             )));
         }
     }

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -332,6 +332,10 @@ pub enum RebaseAction {
     Squash,
     Fixup,
     Drop,
+    /// A merge commit applied as its diff against its **first** parent — one
+    /// ordinary commit, keeping the merge's message (`git cherry-pick -m 1`).
+    /// On a non-merge commit it is identical to `Pick`.
+    MainlinePick,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/tests/rebase_flatten.rs
+++ b/src-tauri/tests/rebase_flatten.rs
@@ -1,0 +1,125 @@
+//! Flattening a range that contains a merge: either the merge is dropped (git's
+//! default — its side-branch commits are replayed individually) or it is kept
+//! as one ordinary commit carrying its diff against its first parent.
+
+mod support;
+
+use platypusgit_lib::git::{
+    types::{RebaseAction, RebaseStep},
+    GitBackend,
+};
+
+use support::{merge_history, TempRepo};
+
+fn step(oid: &str, action: RebaseAction) -> RebaseStep {
+    RebaseStep {
+        oid: oid.to_string(),
+        action,
+        message: None,
+    }
+}
+
+#[test]
+fn dropping_the_merge_flattens_the_branch() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    let status = backend
+        .rebase_start(
+            &handle.id,
+            vec![
+                step(&h.a, RebaseAction::Pick),
+                step(&h.f, RebaseAction::Pick),
+                step(&h.c, RebaseAction::Pick),
+                step(&h.m, RebaseAction::Drop),
+            ],
+        )
+        .unwrap();
+    assert!(!status.in_progress);
+
+    let log = backend.log(&handle.id, None, 20).unwrap();
+    let summaries: Vec<&str> = log.iter().map(|c| c.summary.as_str()).collect();
+    assert_eq!(
+        summaries,
+        vec!["C on main", "F on feature", "A on main", "initial"],
+        "the branch should be linear, oldest last"
+    );
+    assert!(
+        log.iter().all(|c| c.parents.len() <= 1),
+        "no merge commit may survive a flattening rebase"
+    );
+    // The side branch's content is replayed, not lost.
+    assert!(tr.path().join("f.txt").exists(), "F's file must survive");
+    assert!(tr.path().join("c.txt").exists(), "C's file must survive");
+}
+
+#[test]
+fn mainline_pick_keeps_the_merge_as_one_commit() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let merge_tree = tr
+        .repo
+        .find_commit(git2::Oid::from_str(&h.m).unwrap())
+        .unwrap()
+        .tree_id();
+    let (backend, handle) = tr.open_with_backend();
+
+    // The side branch is NOT replayed on its own; the merge carries its content
+    // in as a single commit (the "I merged a topic in, keep that as one step"
+    // case).
+    let status = backend
+        .rebase_start(
+            &handle.id,
+            vec![
+                step(&h.a, RebaseAction::Pick),
+                step(&h.c, RebaseAction::Pick),
+                step(&h.m, RebaseAction::MainlinePick),
+            ],
+        )
+        .unwrap();
+    assert!(
+        !status.in_progress,
+        "a clean mainline pick should not pause"
+    );
+
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(
+        head.parent_count(),
+        1,
+        "the result must be an ordinary commit"
+    );
+    assert_eq!(
+        head.summary().unwrap(),
+        "Merge branch 'feature'",
+        "the merge's message is kept"
+    );
+    assert_eq!(
+        head.tree_id(),
+        merge_tree,
+        "the tree must match the original merge's tree"
+    );
+}
+
+#[test]
+fn mainline_pick_on_a_non_merge_behaves_like_pick() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    let status = backend
+        .rebase_start(
+            &handle.id,
+            vec![
+                step(&h.a, RebaseAction::Pick),
+                step(&h.c, RebaseAction::MainlinePick),
+                step(&h.m, RebaseAction::Drop),
+            ],
+        )
+        .unwrap();
+    assert!(!status.in_progress);
+    assert_eq!(
+        backend.log(&handle.id, None, 5).unwrap()[0].summary,
+        "C on main"
+    );
+}

--- a/src/design/git-components.rebaseRow.test.tsx
+++ b/src/design/git-components.rebaseRow.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { PGRebaseRow } from "./git-components";
+
+describe("PGRebaseRow", () => {
+  it("offers the full action list by default and reports exact action names", async () => {
+    const onActionChange = vi.fn();
+    render(
+      <PGRebaseRow
+        sha="abc1234"
+        subject="feat: thing"
+        action="Pick"
+        onActionChange={onActionChange}
+      />,
+    );
+    const select = screen.getByRole("combobox");
+    expect(
+      [...select.querySelectorAll("option")].map((o) => o.getAttribute("value")),
+    ).toEqual(["Pick", "Reword", "Edit", "Squash", "Fixup", "Drop"]);
+    await userEvent.selectOptions(select, "Drop");
+    expect(onActionChange).toHaveBeenCalledWith("Drop");
+  });
+
+  it("restricts the list and shows a badge for a merge row", () => {
+    render(
+      <PGRebaseRow
+        sha="def5678"
+        subject="Merge branch 'feature'"
+        action="Drop"
+        badge="merge"
+        options={["Drop", "MainlinePick"]}
+      />,
+    );
+    const select = screen.getByRole("combobox");
+    expect(
+      [...select.querySelectorAll("option")].map((o) => o.getAttribute("value")),
+    ).toEqual(["Drop", "MainlinePick"]);
+    expect(screen.getByTestId("rebase-row-badge").textContent).toBe("merge");
+  });
+});

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -19,6 +19,7 @@ import { useDensityStep } from "@/features/settings/useSettingsStore";
 import { FOLDER_ICON_COLOR, fileIconSpec } from "@/lib/fileIcon";
 import { commitRowGrid, laneX } from "./graph-geometry";
 import type { WindowRange } from "@/lib/useWindowedList";
+import type { RebaseAction } from "@/lib/types";
 
 // ═════════════════════════════════════════════════════════
 // FILE TREE
@@ -1953,35 +1954,58 @@ export function PGConflictRow({
 // ═════════════════════════════════════════════════════════
 
 export interface PGRebaseRowProps {
-  action?: string;
+  /** Exact `RebaseAction` string — the same value the backend consumes. */
+  action?: RebaseAction;
   sha: string;
   subject: string;
-  onActionChange?: (v: string) => void;
+  onActionChange?: (v: RebaseAction) => void;
   index?: number;
   dragging?: boolean;
+  /** Restrict the dropdown — a merge row cannot be reworded, edited, or folded. */
+  options?: RebaseAction[];
+  /** Short label rendered next to the sha, e.g. "merge". */
+  badge?: string;
 }
 
+/// One entry per `RebaseAction`. The row speaks the backend's exact strings: it
+/// used to lowercase them and have the caller re-capitalise the first letter on
+/// the way back, which cannot express a two-word action like MainlinePick.
+const REBASE_ACTION_STYLE: Record<RebaseAction, { label: string; color: string }> = {
+  Pick: { label: "pick", color: "var(--git-added)" },
+  Reword: { label: "reword", color: "var(--accent)" },
+  Edit: { label: "edit", color: "var(--git-modified)" },
+  Squash: { label: "squash", color: "var(--accent-2)" },
+  Fixup: { label: "fixup", color: "var(--accent-2)" },
+  Drop: { label: "drop", color: "var(--git-removed)" },
+  MainlinePick: { label: "keep as one", color: "var(--accent-3)" },
+};
+
+const DEFAULT_REBASE_ACTIONS: RebaseAction[] = [
+  "Pick",
+  "Reword",
+  "Edit",
+  "Squash",
+  "Fixup",
+  "Drop",
+];
+
 export function PGRebaseRow({
-  action = "pick",
+  action = "Pick",
   sha,
   subject,
   onActionChange,
   index,
   dragging,
+  options,
+  badge,
 }: PGRebaseRowProps) {
-  const actions = [
-    { value: "pick", label: "pick", color: "var(--git-added)" },
-    { value: "reword", label: "reword", color: "var(--accent)" },
-    { value: "edit", label: "edit", color: "var(--git-modified)" },
-    { value: "squash", label: "squash", color: "var(--accent-2)" },
-    { value: "fixup", label: "fixup", color: "var(--accent-2)" },
-    { value: "drop", label: "drop", color: "var(--git-removed)" },
-  ];
-  const current = actions.find((a) => a.value === action) || actions[0];
+  const values = options ?? DEFAULT_REBASE_ACTIONS;
+  const current = REBASE_ACTION_STYLE[action] ?? REBASE_ACTION_STYLE.Pick;
   return (
     <div
       data-testid="rebase-row"
       data-sha={sha}
+      data-action={action}
       style={{
         display: "flex",
         alignItems: "center",
@@ -1994,8 +2018,8 @@ export function PGRebaseRow({
         fontFamily: "var(--font-mono)",
         fontSize: "var(--fs-12)",
         marginBottom: 4,
-        opacity: action === "drop" ? 0.5 : 1,
-        textDecoration: action === "drop" ? "line-through" : "none",
+        opacity: action === "Drop" ? 0.5 : 1,
+        textDecoration: action === "Drop" ? "line-through" : "none",
       }}
     >
       <PGIcon
@@ -2010,11 +2034,31 @@ export function PGRebaseRow({
       </span>
       <PGSelect
         value={action}
-        onChange={onActionChange}
+        onChange={(v) => onActionChange?.(v as RebaseAction)}
         size="sm"
-        options={actions.map((a) => ({ value: a.value, label: a.label }))}
-        style={{ width: 90, borderColor: current.color, color: current.color } as CSSProperties}
+        options={values.map((v) => ({
+          value: v,
+          label: REBASE_ACTION_STYLE[v].label,
+        }))}
+        style={{ width: 110, borderColor: current.color, color: current.color } as CSSProperties}
       />
+      {badge && (
+        <span
+          data-testid="rebase-row-badge"
+          style={{
+            fontSize: "var(--fs-10)",
+            textTransform: "uppercase",
+            letterSpacing: "0.04em",
+            padding: "1px 5px",
+            borderRadius: "var(--r-1)",
+            border: "1px solid var(--border-1)",
+            color: "var(--fg-2)",
+            flexShrink: 0,
+          }}
+        >
+          {badge}
+        </span>
+      )}
       <span style={{ color: "var(--fg-3)" }}>{sha}</span>
       <span
         style={{

--- a/src/features/commits/buildRebasePlan.merge.test.ts
+++ b/src/features/commits/buildRebasePlan.merge.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { buildRebasePlan } from "./buildRebasePlan";
+import type { CommitInfo } from "@/lib/types";
+
+function mk(oid: string, summary: string, parents: string[]): CommitInfo {
+  return {
+    oid,
+    shortOid: oid.slice(0, 7),
+    summary,
+    body: null,
+    author: "Test",
+    email: "t@e.com",
+    timestamp: 0,
+    parents,
+    refs: [],
+  };
+}
+
+const M = "m".repeat(40);
+const C = "c".repeat(40);
+const F = "f".repeat(40);
+const A = "a".repeat(40);
+const ROOT = "r".repeat(40);
+
+/** Newest-first, as the log returns it. */
+const log: CommitInfo[] = [
+  mk(M, "Merge branch 'feature'", [C, F]),
+  mk(C, "C on main", [A]),
+  mk(F, "F on feature", [A]),
+  mk(A, "A on main", [ROOT]),
+  mk(ROOT, "root", []),
+];
+
+describe("buildRebasePlan with merges in range", () => {
+  it("defaults a merge commit to Drop and keeps everything else a Pick", () => {
+    const plan = buildRebasePlan(log, A, { kind: "edit-from" });
+    expect(plan).not.toBeNull();
+    expect(plan!.map((s) => [s.oid, s.action])).toEqual([
+      [F, "Pick"],
+      [C, "Pick"],
+      [M, "Drop"],
+    ]);
+  });
+
+  it("a merge is dropped even when it is the fixup target", () => {
+    // Nothing in the UI offers this, but a plan is a plan — the backend rejects
+    // Fixup on a merge, so the builder must not produce it.
+    const plan = buildRebasePlan(log, A, { kind: "fixup", targetOid: M });
+    expect(plan!.find((s) => s.oid === M)!.action).toBe("Drop");
+  });
+
+  it("leaves a merge-free range untouched", () => {
+    const linear = [mk(C, "C", [A]), mk(A, "A", [ROOT]), mk(ROOT, "root", [])];
+    const plan = buildRebasePlan(linear, A, { kind: "edit-from" });
+    expect(plan!.map((s) => s.action)).toEqual(["Pick"]);
+  });
+});

--- a/src/features/commits/buildRebasePlan.ts
+++ b/src/features/commits/buildRebasePlan.ts
@@ -16,6 +16,12 @@ import type { CommitInfo, RebaseStep, RebaseAction } from "@/lib/types";
  *     squashed commit onto the previous one, so the run collapses to a single
  *     commit with `message`.
  *
+ * A commit with more than one parent (a merge) is always emitted as "Drop",
+ * whatever the mode asks for: that is git's own default (`git rebase -i` drops
+ * merge commits and flattens the branch), and the backend refuses any other
+ * action on a merge except MainlinePick, which the user picks per row in the
+ * Rebase screen.
+ *
  * Returns null when the `fromOid` isn't in the rebaseable range.
  */
 export function buildRebasePlan(
@@ -44,7 +50,9 @@ export function buildRebasePlan(
   return oldestFirst.map((c): RebaseStep => {
     let action: RebaseAction = "Pick";
     let message: string | null = null;
-    if (mode.kind === "fixup" && c.oid === mode.targetOid) {
+    if (c.parents.length > 1) {
+      action = "Drop";
+    } else if (mode.kind === "fixup" && c.oid === mode.targetOid) {
       action = "Fixup";
     } else if (mode.kind === "squash" && c.oid === mode.targetOid) {
       action = "Squash";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -224,7 +224,15 @@ export interface ConflictSides {
 
 // ─── Interactive rebase ───────────────────────────────────────────────────────
 
-export type RebaseAction = "Pick" | "Reword" | "Edit" | "Squash" | "Fixup" | "Drop";
+export type RebaseAction =
+  | "Pick"
+  | "Reword"
+  | "Edit"
+  | "Squash"
+  | "Fixup"
+  | "Drop"
+  /** A merge commit kept as one ordinary commit — `git cherry-pick -m 1`. */
+  | "MainlinePick";
 
 export interface RebaseStep {
   oid: string;

--- a/src/screens/Rebase.merge.test.tsx
+++ b/src/screens/Rebase.merge.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { RebaseScreen } from "./Rebase";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { mockInvoke } from "@/test/invokeMock";
+import type { CommitInfo, RebaseStatus, RepoHandle } from "@/lib/types";
+
+const handle: RepoHandle = { id: "repo-1", path: "/tmp/fake-repo", head: "refs/heads/main" };
+const SWEPT: RebaseStatus = { inProgress: false, nextIndex: 0, total: 0, pauseReason: null };
+
+function mk(oid: string, summary: string, parents: string[]): CommitInfo {
+  return {
+    oid,
+    shortOid: oid.slice(0, 7),
+    summary,
+    body: null,
+    author: "Tester",
+    email: "t@e.com",
+    timestamp: 1_700_000_000,
+    parents,
+    refs: [],
+  };
+}
+
+const M = "m".repeat(40);
+const C = "c".repeat(40);
+const F = "f".repeat(40);
+const A = "a".repeat(40);
+
+const commits = [
+  mk(M, "Merge branch 'feature'", [C, F]),
+  mk(C, "C on main", [A]),
+  mk(F, "F on feature", [A]),
+  mk(A, "A on main", ["0".repeat(40)]),
+];
+
+beforeEach(() => {
+  useRepoStore.setState({
+    current: handle,
+    status: [],
+    allFiles: [],
+    branches: [],
+    tags: [],
+    stashes: [],
+    remotes: [],
+    commits,
+    loading: false,
+    error: null,
+    repoState: "Clean",
+    rebaseStatus: SWEPT,
+    lastRebaseSummary: null,
+    activity: {},
+  });
+  mockInvoke("rebase_status", () => SWEPT);
+  useNavStore.setState({
+    intent: {
+      kind: "rebase-plan",
+      plan: [
+        { oid: F, action: "Pick", message: null },
+        { oid: C, action: "Pick", message: null },
+        { oid: M, action: "Drop", message: null },
+      ],
+    },
+  });
+});
+
+describe("RebaseScreen with merge commits in the plan", () => {
+  it("warns that the merge will be flattened, counting the merges", async () => {
+    render(<RebaseScreen />);
+    const warning = await screen.findByTestId("rebase-merge-warning");
+    expect(warning.textContent).toContain("1 merge commit");
+    expect(warning.textContent).toContain("linear");
+  });
+
+  it("badges the merge row and restricts its actions", async () => {
+    render(<RebaseScreen />);
+    const rows = await screen.findAllByTestId("rebase-row");
+    const mergeRow = rows.find((r) => r.getAttribute("data-sha") === M.slice(0, 7));
+    expect(mergeRow).toBeDefined();
+    expect(
+      mergeRow!.querySelector('[data-testid="rebase-row-badge"]')?.textContent,
+    ).toBe("merge");
+    const values = [...mergeRow!.querySelectorAll("option")].map((o) =>
+      o.getAttribute("value"),
+    );
+    expect(values).toEqual(["Drop", "MainlinePick"]);
+  });
+
+  it("says nothing when the range has no merges", async () => {
+    useNavStore.setState({
+      intent: {
+        kind: "rebase-plan",
+        plan: [{ oid: C, action: "Pick", message: null }],
+      },
+    });
+    render(<RebaseScreen />);
+    await screen.findAllByTestId("rebase-row");
+    expect(screen.queryByTestId("rebase-merge-warning")).toBeNull();
+  });
+});

--- a/src/screens/Rebase.tsx
+++ b/src/screens/Rebase.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from "react";
 import { PGRebaseRow } from "@/design/git-components";
 import { PGButton } from "@/design/primitives";
-import { PGEmpty } from "@/design";
+import { PGEmpty, PGIcon } from "@/design";
 import type { CommitInfo } from "@/lib/types";
 import type { RebaseAction, RebaseStep } from "@/lib/types";
 import { commitsSince } from "@/lib/tauri";
@@ -19,17 +19,32 @@ interface PlanRow {
   subject: string;
   action: RebaseAction;
   message: string;
+  /** More than one parent — actions are restricted and the row is badged. */
+  isMerge: boolean;
 }
+
+/**
+ * Actions that mean anything for a merge row; mirrors `rebase_plan::merge_legal`
+ * on the backend. Keep the two in sync or the UI offers an action the backend
+ * refuses on submit.
+ */
+const MERGE_ACTIONS: RebaseAction[] = ["Drop", "MainlinePick"];
 
 function commitsToPlan(commits: CommitInfo[]): PlanRow[] {
   // Present commits oldest-first (log is newest-first).
-  return [...commits].reverse().map((c) => ({
-    oid: c.oid,
-    shortOid: c.shortOid,
-    subject: c.summary,
-    action: "Pick" as RebaseAction,
-    message: "",
-  }));
+  return [...commits].reverse().map((c) => {
+    const isMerge = c.parents.length > 1;
+    return {
+      oid: c.oid,
+      shortOid: c.shortOid,
+      subject: c.summary,
+      // A merge defaults to Drop: git's own flattening behaviour, and the only
+      // other action the backend accepts on one is MainlinePick.
+      action: (isMerge ? "Drop" : "Pick") as RebaseAction,
+      message: "",
+      isMerge,
+    };
+  });
 }
 
 // ─── Progress banner ─────────────────────────────────────────────────────────
@@ -162,12 +177,16 @@ export function RebaseScreen() {
     const byOid = new Map(commits.map((c) => [c.oid, c]));
     const rows: PlanRow[] = intent.plan.map((step) => {
       const c = byOid.get(step.oid);
+      const isMerge = (c?.parents.length ?? 0) > 1;
       return {
         oid: step.oid,
         shortOid: c?.shortOid ?? step.oid.slice(0, 7),
         subject: c?.summary ?? "",
-        action: step.action,
+        // A caller that hands us something the backend refuses on a merge (an
+        // older plan, a hand-built intent) gets the flattening default instead.
+        action: isMerge && !MERGE_ACTIONS.includes(step.action) ? "Drop" : step.action,
         message: step.message ?? "",
+        isMerge,
       };
     });
     setPlan(rows);
@@ -225,6 +244,9 @@ export function RebaseScreen() {
     setPlan([]);
     setBaseLabel(null);
   };
+
+  const mergeCount = plan.filter((r) => r.isMerge).length;
+  const flattenedCount = plan.filter((r) => r.isMerge && r.action === "Drop").length;
 
   if (!current) {
     return (
@@ -316,6 +338,48 @@ export function RebaseScreen() {
             </PGButton>
           </div>
 
+          {/* What happens to the merges in this range — stated before the run,
+              the way SmartGit and TortoiseGit do, rather than left for the user
+              to infer from a linear result. */}
+          {mergeCount > 0 && (
+            <div
+              data-testid="rebase-merge-warning"
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "6px 12px",
+                borderBottom: "1px solid var(--border-0)",
+                background: "oklch(from var(--git-modified) l c h / 0.12)",
+                color: "var(--fg-1)",
+                fontSize: "var(--fs-12)",
+              }}
+            >
+              <PGIcon
+                name="warn"
+                size={14}
+                style={{ color: "var(--git-modified)", flexShrink: 0 }}
+              />
+              <span>
+                {mergeCount === 1 ? "1 merge commit" : `${mergeCount} merge commits`} in
+                this range.{" "}
+                {flattenedCount > 0 && (
+                  <>
+                    {flattenedCount === mergeCount
+                      ? mergeCount === 1
+                        ? "It will be"
+                        : "They will be"
+                      : `${flattenedCount} will be`}{" "}
+                    dropped and the merged commits replayed individually — the branch
+                    becomes linear.{" "}
+                  </>
+                )}
+                Choose <strong>keep as one</strong> on a merge row to keep it as a
+                single commit instead.
+              </span>
+            </div>
+          )}
+
           {/* Rows */}
           <PGPane
             id="rebase.steps"
@@ -348,6 +412,8 @@ export function RebaseScreen() {
                         sha={row.shortOid}
                         subject={row.subject}
                         action={row.action}
+                        badge={row.isMerge ? "merge" : undefined}
+                        options={row.isMerge ? MERGE_ACTIONS : undefined}
                         onActionChange={(v) => updateRow(i, { action: v })}
                       />
                     </div>

--- a/src/screens/Rebase.tsx
+++ b/src/screens/Rebase.tsx
@@ -347,10 +347,8 @@ export function RebaseScreen() {
                         index={i + 1}
                         sha={row.shortOid}
                         subject={row.subject}
-                        action={row.action.toLowerCase()}
-                        onActionChange={(v) =>
-                          updateRow(i, { action: (v.charAt(0).toUpperCase() + v.slice(1)) as RebaseAction })
-                        }
+                        action={row.action}
+                        onActionChange={(v) => updateRow(i, { action: v })}
                       />
                     </div>
                     <div


### PR DESCRIPTION
## What

PR2 of three from `docs/superpowers/specs/2026-08-14-rebase-merge-commits-design.md`
(spec + plans in #107; PR1 landed as #110).

PR1 made a merge commit in a rebase plan a clean pre-flight rejection. This PR
makes the UI produce a plan that works, and says what it will do:

- **Merge rows default to `Drop`** — git's own behaviour: the merge disappears
  and its side-branch commits are replayed individually, giving a linear branch.
- **New `RebaseAction::MainlinePick`** (`git cherry-pick -m 1`) keeps a merge as
  one ordinary commit carrying its diff against its first parent, with the
  original message. `start_pick` now takes the mainline explicitly, since libgit2
  refuses a merge without one and equally refuses one on a single-parent commit.
- **Merge rows are badged** and offer only those two actions;
  `rebase_plan::merge_legal` stays the single source of truth and
  `MERGE_ACTIONS` in the screen mirrors it.
- **A warning strip above the plan** states how many merges are in range and that
  the branch becomes linear, following SmartGit and TortoiseGit rather than
  leaving the user to infer it from the result.
- **`PGRebaseRow` speaks exact `RebaseAction` values.** It used to lowercase them
  and have the screen re-capitalise the first letter on the way back, which
  cannot express a two-word action like `MainlinePick`.

## Testing

- `cargo test` — 38 binaries green. New `rebase_flatten.rs`: dropping the merge
  yields a linear log with the side branch's commit and file intact; a mainline
  pick produces a single-parent commit whose tree equals the original merge's and
  whose message is kept; `MainlinePick` on a non-merge behaves like `Pick`.
- `pnpm test` — 854 pass. New: `buildRebasePlan.merge.test.ts`,
  `git-components.rebaseRow.test.tsx`, `Rebase.merge.test.tsx`.
- `pnpm tsc --noEmit`, `pnpm exec tsc -p e2e/tsconfig.json --noEmit`,
  `cargo check` — clean.
- `pnpm test:e2e:docker full --spec e2e/specs/rebase.e2e.ts` — 3 passing,
  including a new end-to-end flattening run over a merge-range fixture. The
  existing drop-a-commit spec needed updating: it drove the row's `<select>` with
  the lowercase `"drop"`, which the exact-value change invalidated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)