### PR TITLE
fix(diff): highlight the repo browser's diff pane, window the commit diff, read the index (#104)

### DIFF
--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -101,6 +101,20 @@ pub async fn read_file_content_at_rev(
 }
 
 #[tauri::command]
+pub async fn read_file_content_at_index(
+    state: State<'_, AppState>,
+    repo_id: String,
+    path: String,
+) -> AppResult<FileContent> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    let path_buf = PathBuf::from(path);
+    tokio::task::spawn_blocking(move || backend.read_file_content_at_index(&repo_id, &path_buf))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+#[tauri::command]
 pub async fn append_gitignore(
     state: State<'_, AppState>,
     repo_id: String,

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -115,6 +115,13 @@ impl GitBackend for CliBackend {
     ) -> AppResult<FileContent> {
         Err(AppError::NotImplemented)
     }
+    fn read_file_content_at_index(
+        &self,
+        _repo_id: &RepoId,
+        _path: &Path,
+    ) -> AppResult<FileContent> {
+        Err(AppError::NotImplemented)
+    }
     fn diff_commits(
         &self,
         _repo_id: &RepoId,

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -2451,6 +2451,53 @@ impl GitBackend for Libgit2Backend {
         })
     }
 
+    fn read_file_content_at_index(
+        &self,
+        repo_id: &RepoId,
+        path: &Path,
+    ) -> AppResult<FileContent> {
+        let rel = path.to_path_buf();
+        let path_str = rel.to_string_lossy().into_owned();
+        self.with_repo(repo_id, |repo| {
+            let index = repo.index()?;
+            // Stage 0 is the normal, non-conflicted entry. A conflicted path has
+            // stages 1-3 and no 0, so it lands in the same "not in the index"
+            // branch as an untracked one — correct either way, because neither
+            // has a single index version to colour from.
+            let entry = index
+                .get_path(&rel, 0)
+                .ok_or_else(|| AppError::InvalidPath(format!("not in the index: {path_str}")))?;
+            let blob = repo.find_blob(entry.id)?;
+            let content = blob.content();
+            let size = content.len() as u64;
+            if blob.is_binary() {
+                return Ok(FileContent {
+                    path: path_str,
+                    binary: true,
+                    text: None,
+                    from_head: false,
+                    size,
+                });
+            }
+            Ok(match std::str::from_utf8(content) {
+                Ok(s) => FileContent {
+                    path: path_str,
+                    binary: false,
+                    text: Some(s.to_string()),
+                    from_head: false,
+                    size,
+                },
+                Err(_) => FileContent {
+                    path: path_str,
+                    binary: true,
+                    text: None,
+                    from_head: false,
+                    size,
+                },
+            })
+        })
+    }
+
     fn diff_commits(
         &self,
         repo_id: &RepoId,

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -145,6 +145,18 @@ pub trait GitBackend: Send + Sync {
         revspec: &str,
         path: &Path,
     ) -> AppResult<FileContent>;
+    /// The INDEX copy of a file — what committing would record.
+    ///
+    /// Distinct from both other readers precisely when a file is partially
+    /// staged, which is the case the commit panel could not colour correctly
+    /// while it had to approximate the index with HEAD and the worktree.
+    /// A path with no stage-0 entry (untracked, or conflicted) is an
+    /// `InvalidPath`, so the caller can fall back to rendering plain rows.
+    fn read_file_content_at_index(
+        &self,
+        repo_id: &RepoId,
+        path: &Path,
+    ) -> AppResult<FileContent>;
     fn diff_commits(
         &self,
         repo_id: &RepoId,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -141,6 +141,7 @@ pub fn run() {
             commands::repo::read_file_content,
             commands::repo::list_files_at_rev,
             commands::repo::read_file_content_at_rev,
+            commands::repo::read_file_content_at_index,
             commands::repo::append_gitignore,
             commands::repo::open_in_editor,
             commands::commits::get_log,

--- a/src-tauri/tests/read_index_content.rs
+++ b/src-tauri/tests/read_index_content.rs
@@ -1,0 +1,90 @@
+//! read_file_content_at_index — the INDEX copy of a file.
+//!
+//! The commit panel diffs against the index (IndexToHead when staged,
+//! WorktreeToIndex otherwise). Without this op its syntax tokens had to be
+//! approximated from HEAD and the worktree, which disagree with the index exactly
+//! when a file is partially staged.
+
+mod support;
+
+use std::path::Path;
+
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::GitBackend;
+
+use support::{fs::write_file, TempRepo};
+
+/// A staged edit is visible in the index while the worktree has moved on again.
+#[test]
+fn reads_the_staged_copy_not_the_worktree_or_head() {
+    let tr = TempRepo::with_initial_commit("v1\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    // Stage "v2", then edit the worktree again to "v3".
+    write_file(tr.path(), "README.md", "v2\n");
+    backend
+        .stage(&handle.id, &[Path::new("README.md").to_path_buf()])
+        .unwrap();
+    write_file(tr.path(), "README.md", "v3\n");
+
+    let index = backend
+        .read_file_content_at_index(&handle.id, Path::new("README.md"))
+        .unwrap();
+    assert_eq!(index.text.as_deref(), Some("v2\n"));
+    assert!(!index.binary);
+
+    // The other two reads must still disagree with it — that disagreement is the
+    // whole reason this op exists.
+    let worktree = backend
+        .read_file_content(&handle.id, Path::new("README.md"))
+        .unwrap();
+    assert_eq!(worktree.text.as_deref(), Some("v3\n"));
+    let head = backend
+        .read_file_content_at_rev(&handle.id, "HEAD", Path::new("README.md"))
+        .unwrap();
+    assert_eq!(head.text.as_deref(), Some("v1\n"));
+}
+
+/// With nothing staged the index still holds the committed content.
+#[test]
+fn reads_committed_content_when_nothing_is_staged() {
+    let tr = TempRepo::with_initial_commit("v1\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let index = backend
+        .read_file_content_at_index(&handle.id, Path::new("README.md"))
+        .unwrap();
+    assert_eq!(index.text.as_deref(), Some("v1\n"));
+}
+
+/// A path that is not in the index at all is an InvalidPath, not a panic — the
+/// caller renders the rows plain.
+#[test]
+fn untracked_path_is_an_error() {
+    let tr = TempRepo::with_initial_commit("v1\n");
+    write_file(tr.path(), "untracked.txt", "nope\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .read_file_content_at_index(&handle.id, Path::new("untracked.txt"))
+        .unwrap_err();
+    assert!(matches!(err, AppError::InvalidPath(_)), "got {err:?}");
+}
+
+/// Binary content is reported as binary with no text, like the other readers.
+#[test]
+fn binary_content_reports_binary() {
+    let tr = TempRepo::with_initial_commit("v1\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    std::fs::write(tr.path().join("blob.bin"), [0u8, 159, 146, 150]).unwrap();
+    backend
+        .stage(&handle.id, &[Path::new("blob.bin").to_path_buf()])
+        .unwrap();
+
+    let out = backend
+        .read_file_content_at_index(&handle.id, Path::new("blob.bin"))
+        .unwrap();
+    assert!(out.binary);
+    assert!(out.text.is_none());
+}

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -1,8 +1,7 @@
 import React, { type CSSProperties, type MouseEvent, type ReactNode } from "react";
 import type { WordSpan } from "@/lib/wordDiff";
-import { withChangedIndices, withSyntax, withWordSpans } from "@/lib/diffRows";
 import { buildLineSpans } from "@/lib/lineSpans";
-import type { SyntaxLine, SyntaxToken } from "@/lib/syntax";
+import type { SyntaxToken } from "@/lib/syntax";
 import { PGIcon, type IconName } from "./icons";
 import {
   PGBadge,
@@ -505,13 +504,12 @@ export interface DiffLineData {
   /**
    * Index among the hunk's changed (`+`/`-`) lines, counted from 0; undefined
    * for context rows. This is the index space the line-staging backend ops use
-   * (#61 D7) — assigned by `PGHunk`, not by callers.
+   * (#61 D7) — assigned by `flattenDiffRows`, not by callers.
    */
   changedIndex?: number;
   /**
-   * Line-relative syntax tokens for this row. Set by `PGHunk` from its `syntax`
-   * prop, or directly by a caller rendering a standalone `PGDiffLine`;
-   * undefined renders the line unhighlighted.
+   * Line-relative syntax tokens for this row, resolved from the correct side of
+   * the diff by `flattenDiffRows`. Undefined renders the line unhighlighted.
    */
   syntax?: SyntaxToken[];
 }
@@ -835,8 +833,8 @@ export function PGDiffRow({
 /**
  * A hunk's chrome bar: collapse chevron, header text, Discard and Stage.
  *
- * Split out of PGHunk so the windowed renderer can emit it as one row among many
- * without duplicating the markup. Stays density-aware — it is chrome, not code.
+ * Emitted by the windowed renderer as one row among many. Stays density-aware —
+ * it is chrome, not code, so --row-step applies here and never to code rows.
  */
 export function PGHunkHeader({
   header,
@@ -907,106 +905,7 @@ export function PGHunkHeader({
   );
 }
 
-export interface PGHunkProps {
-  header: string;
-  lines?: DiffLineData[];
-  staged?: boolean;
-  onStage?: () => void;
-  onDiscard?: () => void;
-  expanded?: boolean;
-  onToggle?: () => void;
-  /**
-   * Disable Stage/Discard and explain why on hover. Set while the diff is
-   * whitespace-ignoring: those hunks are a rewritten view, so their indices
-   * don't address the hunks git would apply (#61 D2). It also suppresses line
-   * selection, for the same reason (#61 D7).
-   */
-  actionsDisabledReason?: string;
-  /**
-   * Selected changed-line indices within this hunk (#61 D7). Selection STATE
-   * belongs to the owning screen, not here — a primitive owning it plus the
-   * global key dispatcher would both answer the same input and the selection
-   * would move twice.
-   */
-  selectedLines?: number[];
-  /** Called with a changed-line index; `range` is true for a shift-click. */
-  onLineClick?: (changedIndex: number, range: boolean) => void;
-  /**
-   * Per-side syntax tokens for the WHOLE file, indexed by line number - 1.
-   *
-   * A `rem` row reads `old`; `add` and `ctx` rows read `new` — context rows show
-   * the new text, and for unchanged lines the two sides agree anyway. A row whose
-   * line number is missing, or past the end of its array, renders plain.
-   */
-  syntax?: { old: SyntaxLine[] | null; new: SyntaxLine[] | null };
-}
 
-/**
- * One hunk, header plus all its rows, unwindowed.
- *
- * No screen renders this any more — they all go through `PGWindowedDiff`, which
- * reuses the same `PGHunkHeader` and `PGDiffRow`. It survives as the single-hunk
- * primitive and as the behavioural guard for row rendering (see
- * wordDiffRender.test.tsx and syntaxRender.test.tsx, which pin word spans and
- * syntax spans through this public API). Delete it only together with those
- * tests, and only once something else pins the same behaviour.
- */
-export function PGHunk({
-  header,
-  lines = [],
-  staged,
-  onStage,
-  onDiscard,
-  expanded = true,
-  onToggle,
-  actionsDisabledReason,
-  selectedLines,
-  onLineClick,
-  syntax,
-}: PGHunkProps) {
-  // Memoized: word diffing every rem/add pair on each render would repeat over
-  // lists that are long and windowed.
-  //
-  // withChangedIndices runs FIRST and over the whole hunk: its numbering is the
-  // wire contract shared with the backend's Patch::line_in_hunk (#61 D7), so it
-  // must not depend on anything the syntax pass does.
-  const rows = React.useMemo(
-    () => withWordSpans(withSyntax(withChangedIndices(lines), syntax)),
-    [lines, syntax],
-  );
-  // Line selection is meaningless when the hunk's own indices don't address
-  // what git would apply — the same condition that disables Stage/Discard.
-  const lineClick = actionsDisabledReason ? undefined : onLineClick;
-  return (
-    <div style={{ borderBottom: "1px solid var(--border-0)" }}>
-      <PGHunkHeader
-        header={header}
-        staged={staged}
-        onStage={onStage}
-        onDiscard={onDiscard}
-        expanded={expanded}
-        onToggle={onToggle}
-        actionsDisabledReason={actionsDisabledReason}
-        selCount={selectedLines?.length ?? 0}
-      />
-      {expanded && (
-        <div>
-          {rows.map((line, i) => (
-            <PGDiffRow
-              key={i}
-              line={line}
-              selected={
-                line.changedIndex != null &&
-                (selectedLines?.includes(line.changedIndex) ?? false)
-              }
-              onLineClick={lineClick}
-            />
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
 
 export interface SideLine {
   kind: DiffLineKind;

--- a/src/design/syntaxRender.test.tsx
+++ b/src/design/syntaxRender.test.tsx
@@ -1,76 +1,78 @@
+// Syntax spans in diff rows, and how they compose with word-diff marks.
+//
+// Goes through the production path: flattenDiffRows resolves each row's tokens
+// from the correct SIDE of the diff, and PGWindowedDiff renders them.
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { PGHunk } from "./git-components";
-import type { DiffLineData } from "./git-components";
+import { PGWindowedDiff } from "./PGWindowedDiff";
+import { flattenDiffRows } from "@/lib/diffRows";
+import type { SyntaxLine } from "@/lib/syntax";
+import type { FileDiff } from "@/lib/types";
 
-const line = (
-  o: Partial<DiffLineData> & { kind: DiffLineData["kind"] },
-): DiffLineData => ({ text: "", ...o });
+type Line = FileDiff["hunks"][number]["lines"][number];
+
+const rem = (n: number, content: string): Line => ({
+  kind: { kind: "Deletion" }, oldLineno: n, newLineno: null, content,
+});
+const add = (n: number, content: string): Line => ({
+  kind: { kind: "Addition" }, oldLineno: null, newLineno: n, content,
+});
+const ctx = (n: number, content: string): Line => ({
+  kind: { kind: "Context" }, oldLineno: n, newLineno: n, content,
+});
+
+function renderLines(
+  lines: Line[],
+  syntax?: { old: SyntaxLine[] | null; new: SyntaxLine[] | null },
+) {
+  const rows = flattenDiffRows(
+    [{ header: "@@ -1 +1 @@", oldStart: 1, oldLines: 1, newStart: 1, newLines: 1, lines }],
+    { headerH: 26, rowH: 19, syntax },
+  );
+  return render(<PGWindowedDiff rows={rows} />);
+}
 
 describe("syntax spans in diff rows", () => {
   it("wraps scoped ranges in a classed span", () => {
-    render(
-      <PGHunk
-        header="-1 +1"
-        lines={[
-          line({
-            kind: "ctx",
-            text: "let x",
-            lnL: 1,
-            lnR: 1,
-            syntax: [{ start: 0, end: 3, cls: "syn-keyword" }],
-          }),
-        ]}
-      />,
-    );
-    const kw = document.querySelector(".syn-keyword");
-    expect(kw).not.toBeNull();
-    expect(kw).toHaveTextContent("let");
+    renderLines([ctx(1, "let x")], {
+      old: null,
+      new: [[{ start: 0, end: 3, cls: "syn-keyword" }]],
+    });
+    expect(document.querySelector(".syn-keyword")).toHaveTextContent("let");
   });
 
   it("still renders the full line text when syntax is absent", () => {
-    render(
-      <PGHunk header="-1 +1" lines={[line({ kind: "ctx", text: "plain text", lnL: 1 })]} />,
-    );
+    renderLines([ctx(1, "plain text")]);
     expect(screen.getByText("plain text")).toBeInTheDocument();
   });
 
   it("combines a syntax class and a word-change mark on one range", () => {
-    // A changed range inside a scoped range must carry both.
-    render(
-      <PGHunk
-        header="-1 +1"
-        lines={[
-          line({ kind: "rem", text: "let a", lnL: 1 }),
-          line({ kind: "add", text: "let b", lnR: 1 }),
-        ]}
-        syntax={{
-          old: [[{ start: 0, end: 3, cls: "syn-keyword" }]],
-          new: [[{ start: 0, end: 3, cls: "syn-keyword" }]],
-        }}
-      />,
-    );
+    renderLines([rem(1, "let a"), add(1, "let b")], {
+      old: [[{ start: 0, end: 3, cls: "syn-keyword" }]],
+      new: [[{ start: 0, end: 3, cls: "syn-keyword" }]],
+    });
     expect(document.querySelectorAll(".syn-keyword").length).toBeGreaterThan(0);
     expect(screen.getAllByTestId("word-change").length).toBeGreaterThan(0);
   });
 
-  it("maps rem rows to the old side and add/ctx rows to the new side", () => {
-    // Old side scopes the whole line as a comment, new side as a keyword. The
-    // classes that land prove which array each row read.
-    render(
-      <PGHunk
-        header="-1 +1"
-        lines={[
-          line({ kind: "rem", text: "aaa", lnL: 1 }),
-          line({ kind: "add", text: "bbb", lnR: 1 }),
-        ]}
-        syntax={{
-          old: [[{ start: 0, end: 3, cls: "syn-comment" }]],
-          new: [[{ start: 0, end: 3, cls: "syn-keyword" }]],
-        }}
-      />,
-    );
+  it("maps rem rows to the old side and add rows to the new side", () => {
+    // Old side scopes its line as a comment, new side as a keyword, so the class
+    // that lands proves which array each row read.
+    renderLines([rem(1, "aaa"), add(1, "bbb")], {
+      old: [[{ start: 0, end: 3, cls: "syn-comment" }]],
+      new: [[{ start: 0, end: 3, cls: "syn-keyword" }]],
+    });
     expect(document.querySelector(".syn-comment")).toHaveTextContent("aaa");
     expect(document.querySelector(".syn-keyword")).toHaveTextContent("bbb");
+  });
+
+  it("leaves a row plain when its line number has no tokens", () => {
+    // Line 5 of the file, but only one line of tokens supplied.
+    renderLines([ctx(5, "no tokens for me")], {
+      old: null,
+      new: [[{ start: 0, end: 2, cls: "syn-keyword" }]],
+    });
+    expect(document.querySelector(".syn-keyword")).toBeNull();
+    expect(screen.getByText("no tokens for me")).toBeInTheDocument();
   });
 });

--- a/src/design/wordDiffRender.test.tsx
+++ b/src/design/wordDiffRender.test.tsx
@@ -1,78 +1,74 @@
 // Intra-line highlighting inside the unified diff (#61 D8).
 //
-// chunkDiffLines groups by kind, so a removed run and the added run after it
-// are two ADJACENT chunks — pairing crosses that pair rather than happening
-// inside one chunk. These tests pin that behaviour through PGHunk's public API.
+// Pins the whole path production takes: flattenDiffRows pairs a removed run with
+// the added run that follows it, and PGWindowedDiff renders the resulting spans.
+// (It went through PGHunk before that component was retired.)
 
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { PGHunk } from "./git-components";
+import { PGWindowedDiff } from "./PGWindowedDiff";
+import { flattenDiffRows } from "@/lib/diffRows";
+import type { FileDiff } from "@/lib/types";
 
-const pair = [
-  { kind: "rem" as const, lnL: 1, text: "const a = 1;" },
-  { kind: "add" as const, lnR: 1, text: "const a = 2;" },
-];
+type Line = FileDiff["hunks"][number]["lines"][number];
+
+const rem = (n: number, content: string): Line => ({
+  kind: { kind: "Deletion" }, oldLineno: n, newLineno: null, content,
+});
+const add = (n: number, content: string): Line => ({
+  kind: { kind: "Addition" }, oldLineno: null, newLineno: n, content,
+});
+const ctx = (n: number, content: string): Line => ({
+  kind: { kind: "Context" }, oldLineno: n, newLineno: n, content,
+});
+
+function renderLines(lines: Line[]) {
+  const rows = flattenDiffRows(
+    [{ header: "@@ -1 +1 @@", oldStart: 1, oldLines: 1, newStart: 1, newLines: 1, lines }],
+    { headerH: 26, rowH: 19 },
+  );
+  return render(<PGWindowedDiff rows={rows} />);
+}
+
+const pair = [rem(1, "const a = 1;"), add(1, "const a = 2;")];
 
 describe("word diff rendering", () => {
   it("marks only the changed token on each side", () => {
-    render(<PGHunk header="-1,1 +1,1" lines={pair} />);
+    renderLines(pair);
     const marks = screen.getAllByTestId("word-change");
     expect(marks.map((m) => m.textContent)).toEqual(["1", "2"]);
   });
 
   it("adds no marks to a context-only hunk", () => {
-    render(
-      <PGHunk
-        header="-1,1 +1,1"
-        lines={[{ kind: "ctx", lnL: 1, lnR: 1, text: "unchanged" }]}
-      />,
-    );
+    renderLines([ctx(1, "unchanged")]);
     expect(screen.queryAllByTestId("word-change")).toHaveLength(0);
   });
 
   it("adds no marks when the two lines are unrelated", () => {
-    render(
-      <PGHunk
-        header="-1,1 +1,1"
-        lines={[
-          { kind: "rem", lnL: 1, text: "alpha beta gamma" },
-          { kind: "add", lnR: 1, text: "totally different words here" },
-        ]}
-      />,
-    );
+    renderLines([rem(1, "alpha beta gamma"), add(1, "totally different words here")]);
     expect(screen.queryAllByTestId("word-change")).toHaveLength(0);
   });
 
   it("adds no marks to an addition with no removal to pair with", () => {
-    render(
-      <PGHunk
-        header="-1,0 +1,1"
-        lines={[{ kind: "add", lnR: 1, text: "brand new line" }]}
-      />,
-    );
+    renderLines([add(1, "brand new line")]);
     expect(screen.queryAllByTestId("word-change")).toHaveLength(0);
   });
 
   it("still renders the full line text when highlighting", () => {
-    // Highlighting splits a line across several spans, so assert on the
-    // rendered text content rather than looking for one matching element.
-    const { container } = render(<PGHunk header="-1,1 +1,1" lines={pair} />);
+    // Highlighting splits a line across several spans, so assert on the rendered
+    // text content rather than looking for one matching element.
+    const { container } = renderLines(pair);
     expect(container.textContent).toContain("const a = 1;");
     expect(container.textContent).toContain("const a = 2;");
   });
 
   it("pairs line-for-line across a multi-line rem/add run", () => {
-    render(
-      <PGHunk
-        header="-1,2 +1,2"
-        lines={[
-          { kind: "rem", lnL: 1, text: "let x = 1;" },
-          { kind: "rem", lnL: 2, text: "let y = 2;" },
-          { kind: "add", lnR: 1, text: "let x = 10;" },
-          { kind: "add", lnR: 2, text: "let y = 20;" },
-        ]}
-      />,
-    );
+    renderLines([
+      rem(1, "let x = 1;"),
+      rem(2, "let y = 2;"),
+      add(1, "let x = 10;"),
+      add(2, "let y = 20;"),
+    ]);
     expect(screen.getAllByTestId("word-change").map((m) => m.textContent)).toEqual([
       "1",
       "2",

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -1,42 +1,40 @@
 import React from "react";
-import { PGIcon, PGResizeHandle, PGSkeleton, usePaneWidth } from "@/design";
+import {
+  PGIcon,
+  PGResizeHandle,
+  PGSkeleton,
+  usePaneWidth,
+  type DiffLineData,
+} from "@/design";
 import { PGPane, FocusableScroll, usePaneList, useHunkNav } from "@/features/keymap";
 import { fileIconSpec } from "@/lib/fileIcon";
 import { WhitespaceToggle } from "./WhitespaceToggle";
 import { SignatureBadge } from "@/features/signing/SignatureBadge";
-import { useDiffSyntax, type DiffSyntax, type SideSource } from "@/lib/syntax";
+import { useDiffSyntax, type SideSource } from "@/lib/syntax";
+import { flattenDiffRows, windowVariable } from "@/lib/diffRows";
+import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
 import { buildLineSpans } from "@/lib/lineSpans";
-import { pairChangedLines } from "@/lib/pairChangedLines";
-import type { WordSpan } from "@/lib/wordDiff";
-import type { DiffLine, FileDiff } from "@/lib/types";
+import type { FileDiff } from "@/lib/types";
 
 /**
  * One diff row's text: syntax classes plus intra-line change marks, through the
  * same tiling builder the design-system rows use.
  *
- * Side rule matches everywhere else: a removal reads the old file, an addition or
- * context row the new one.
+ * Both inputs already sit on the row: `flattenDiffRows` attaches the word spans
+ * (via the shared pairing rule) and resolves each row's syntax from the correct
+ * side, so this only has to render.
  */
-function CommitDiffText({
-  line,
-  syntax,
-  spans,
-}: {
-  line: DiffLine;
-  syntax: DiffSyntax;
-  spans?: WordSpan[];
-}) {
-  const isRem = line.kind.kind === "Deletion";
-  const sideLines = isRem ? syntax.old : syntax.new;
-  const lineNo = isRem ? line.oldLineno : (line.newLineno ?? line.oldLineno);
-  const tokens = sideLines && lineNo ? (sideLines[lineNo - 1] ?? null) : null;
-  const rendered = buildLineSpans(line.content, tokens, spans);
+function CommitDiffRowText({ line }: { line: DiffLineData }) {
+  const text = line.text ?? "";
+  const rendered = buildLineSpans(text, line.syntax ?? null, line.spans);
+  if (rendered.length === 0) return <>{text}</>;
   if (rendered.length === 1 && !rendered[0].cls && !rendered[0].changed) {
-    return <>{line.content}</>;
+    return <>{text}</>;
   }
-  const tint = isRem
-    ? "oklch(from var(--git-removed) l c h / 0.28)"
-    : "oklch(from var(--git-added) l c h / 0.28)";
+  const tint =
+    line.kind === "rem"
+      ? "oklch(from var(--git-removed) l c h / 0.28)"
+      : "oklch(from var(--git-added) l c h / 0.28)";
   return (
     <>
       {rendered.map((s, k) => (
@@ -46,7 +44,7 @@ function CommitDiffText({
           data-testid={s.changed ? "word-change" : undefined}
           style={s.changed ? { background: tint, borderRadius: 2 } : undefined}
         >
-          {line.content.slice(s.start, s.end)}
+          {text.slice(s.start, s.end)}
         </span>
       ))}
     </>
@@ -149,41 +147,38 @@ export function CommitDiffPanel({
     new: syntaxSides?.new ?? { kind: "none" },
   });
 
-  /**
-   * Word spans for the selected file, keyed hunk index → line index within that
-   * hunk. Runs of removals and additions pair positionally through the shared
-   * rule; a run with no counterpart gets nothing.
-   */
-  const wordSpansByHunk = React.useMemo(() => {
-    return (current?.hunks ?? []).map((h) => {
-      const spans = new Map<number, WordSpan[]>();
-      let remIdx: number[] = [];
-      let addIdx: number[] = [];
-      const flush = () => {
-        if (remIdx.length && addIdx.length) {
-          const paired = pairChangedLines(
-            remIdx.map((i) => h.lines[i].content),
-            addIdx.map((i) => h.lines[i].content),
-          );
-          paired.forEach((p, k) => {
-            if (!p) return;
-            spans.set(remIdx[k], p.old);
-            spans.set(addIdx[k], p.new);
-          });
-        }
-        remIdx = [];
-        addIdx = [];
-      };
-      h.lines.forEach((ln, i) => {
-        const k = ln.kind.kind;
-        if (k === "Deletion") remIdx.push(i);
-        else if (k === "Addition") addIdx.push(i);
-        else flush();
-      });
-      flush();
-      return spans;
-    });
-  }, [current]);
+  // Flat rows + an exact window, from the SAME helpers the other diff surfaces
+  // use. The panel keeps its own lighter markup, but not its own row model:
+  // flattenDiffRows already pairs the word spans and resolves each row's syntax
+  // side, which this panel used to do by hand.
+  const rowH = useDiffRowHeight();
+  const rows = React.useMemo(
+    () =>
+      flattenDiffRows(current && !current.binary ? current.hunks : [], {
+        // This panel's hunk header is a plain text line rather than chrome with
+        // buttons, so it is one code row tall, not density-sized.
+        headerH: rowH,
+        rowH,
+        syntax,
+      }),
+    [current, rowH, syntax],
+  );
+  const heights = React.useMemo(() => rows.map((r) => r.h), [rows]);
+  const scrollRef = React.useRef<HTMLDivElement>(null);
+  const [scrollTop, setScrollTop] = React.useState(0);
+  const [viewportH, setViewportH] = React.useState(0);
+  React.useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    setViewportH(el.clientHeight);
+    const ro = new ResizeObserver(() => setViewportH(el.clientHeight));
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  const win = React.useMemo(
+    () => windowVariable(heights, { scrollTop, viewportH, overscan: 8 }),
+    [heights, scrollTop, viewportH],
+  );
 
   // Per mount site: History's bottom panel is wide and short, the full-screen
   // commit diff is not, so one shared width would fit neither.
@@ -333,58 +328,59 @@ export function CommitDiffPanel({
         id={viewPaneId}
         style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column" }}
       >
-        <FocusableScroll style={{ flex: 1, padding: 12 }} ariaLabel="Diff">
+        <FocusableScroll
+          style={{ flex: 1, padding: 12 }}
+          ariaLabel="Diff"
+          innerRef={scrollRef}
+          onScroll={() => setScrollTop(scrollRef.current?.scrollTop ?? 0)}
+        >
           {current?.binary && (
             <div style={{ color: "var(--fg-3)", fontSize: "var(--fs-12)" }}>
               Binary file — no textual diff.
             </div>
           )}
-          {current &&
-            current.hunks.map((h, i) => (
+          {win.topPad > 0 && (
+            <div data-pg-spacer="top" style={{ height: `${win.topPad}px` }} />
+          )}
+          {rows.slice(win.start, win.end).map((row, k) =>
+            row.kind === "header" ? (
               <div
-                key={i}
-                data-hunk-index={i}
-                data-hunk-active={hunkCursor === i ? "" : undefined}
-                style={{ marginBottom: 16 }}
+                key={`h${row.hunkIndex}`}
+                data-hunk-index={row.hunkIndex}
+                data-hunk-active={hunkCursor === row.hunkIndex ? "" : undefined}
+                style={{
+                  height: `var(--diff-row-h)`,
+                  color: "var(--fg-3)",
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "var(--fs-12)",
+                }}
               >
-                <div
-                  style={{
-                    color: "var(--fg-3)",
-                    fontFamily: "var(--font-mono)",
-                    fontSize: "var(--fs-12)",
-                  }}
-                >
-                  {h.header}
-                </div>
-                {h.lines.map((ln, j) => (
-                  <div
-                    key={j}
-                    style={{
-                      fontFamily: "var(--font-mono)",
-                      fontSize: "var(--fs-12)",
-                      whiteSpace: "pre",
-                      color:
-                        ln.kind.kind === "Addition"
-                          ? "var(--git-added)"
-                          : ln.kind.kind === "Deletion"
-                            ? "var(--git-removed)"
-                            : "var(--fg-0)",
-                    }}
-                  >
-                    {ln.kind.kind === "Addition"
-                      ? "+"
-                      : ln.kind.kind === "Deletion"
-                        ? "-"
-                        : " "}
-                    <CommitDiffText
-                      line={ln}
-                      syntax={syntax}
-                      spans={wordSpansByHunk[i]?.get(j)}
-                    />
-                  </div>
-                ))}
+                {row.header}
               </div>
-            ))}
+            ) : (
+              <div
+                key={`l${win.start + k}`}
+                style={{
+                  height: `var(--diff-row-h)`,
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "var(--fs-12)",
+                  whiteSpace: "pre",
+                  color:
+                    row.line.kind === "add"
+                      ? "var(--git-added)"
+                      : row.line.kind === "rem"
+                        ? "var(--git-removed)"
+                        : "var(--fg-0)",
+                }}
+              >
+                {row.line.kind === "add" ? "+" : row.line.kind === "rem" ? "-" : " "}
+                <CommitDiffRowText line={row.line} />
+              </div>
+            ),
+          )}
+          {win.bottomPad > 0 && (
+            <div data-pg-spacer="bottom" style={{ height: `${win.bottomPad}px` }} />
+          )}
         </FocusableScroll>
       </PGPane>
     </div>

--- a/src/features/diff/CommitDiffPanel.window.test.tsx
+++ b/src/features/diff/CommitDiffPanel.window.test.tsx
@@ -1,0 +1,79 @@
+// Windowed rows in the commit-diff panel.
+//
+// This panel keeps its own lighter markup — no line-number gutters, tighter rows
+// for the History inline panel — so it renders DiffRows itself instead of using
+// PGWindowedDiff. It still uses the SHARED flattenDiffRows/windowVariable, so
+// there is only one row model in the codebase.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { resetInvokeMock } from "@/test/invokeMock";
+import { CommitDiffPanel } from "./CommitDiffPanel";
+import type { FileDiff } from "@/lib/types";
+
+vi.mock("@/lib/syntax/tokenize", async (orig) => ({
+  ...(await orig<typeof import("@/lib/syntax/tokenize")>()),
+  tokenizeFile: async () => null,
+}));
+
+const LINES = 400;
+
+const diffs: FileDiff[] = [
+  {
+    path: "a.ts",
+    oldPath: null,
+    binary: false,
+    additions: 0,
+    deletions: 0,
+    hunks: [
+      {
+        header: `@@ -1,${LINES} +1,${LINES} @@`,
+        oldStart: 1,
+        oldLines: LINES,
+        newStart: 1,
+        newLines: LINES,
+        lines: Array.from({ length: LINES }, (_, i) => ({
+          kind: { kind: "Context" as const },
+          oldLineno: i + 1,
+          newLineno: i + 1,
+          content: `line ${i}`,
+        })),
+      },
+    ],
+  },
+];
+
+beforeEach(() => {
+  resetInvokeMock();
+});
+
+describe("CommitDiffPanel windowing", () => {
+  it("mounts only a slice of a long diff", async () => {
+    render(
+      <CommitDiffPanel
+        diffs={diffs}
+        loading={false}
+        error={null}
+        header="x → y"
+        paneIdPrefix="w1"
+      />,
+    );
+    await waitFor(() => expect(screen.getByText(/line 0/)).toBeInTheDocument());
+    expect(screen.queryByText(new RegExp(`line ${LINES - 1}\\b`))).not.toBeInTheDocument();
+    expect(document.querySelector("[data-pg-spacer]")).not.toBeNull();
+  });
+
+  it("still marks hunks for F7 navigation", async () => {
+    render(
+      <CommitDiffPanel
+        diffs={diffs}
+        loading={false}
+        error={null}
+        header="x → y"
+        paneIdPrefix="w2"
+      />,
+    );
+    await waitFor(() =>
+      expect(document.querySelector('[data-hunk-index="0"]')).not.toBeNull(),
+    );
+  });
+});

--- a/src/lib/syntax/useDiffSyntax.ts
+++ b/src/lib/syntax/useDiffSyntax.ts
@@ -1,5 +1,9 @@
 import React from "react";
-import { readFileContent, readFileContentAtRev } from "@/lib/tauri";
+import {
+  readFileContent,
+  readFileContentAtIndex,
+  readFileContentAtRev,
+} from "@/lib/tauri";
 import { useSyntax } from "./useSyntax";
 import type { SyntaxLine } from "./tokenize";
 
@@ -13,6 +17,7 @@ import type { SyntaxLine } from "./tokenize";
 export type SideSource =
   | { kind: "rev"; rev: string; path?: string | null }
   | { kind: "worktree" }
+  | { kind: "index" }
   | { kind: "none" };
 
 export interface DiffSyntax {
@@ -37,11 +42,9 @@ const EMPTY: DiffSyntax = { old: null, new: null };
  * A failed read yields no tokens for that side and those rows render plain: a
  * missing blob must never break a diff.
  *
- * Panes that diff against the INDEX (the commit panel) cannot ask for it — there
- * is no read_file_content_at_index — so they pass HEAD and the worktree. Those
- * agree with the index except on a partially staged file, where being off
- * mis-colours a line. It cannot affect what gets staged, because staging addresses
- * lines by changedIndex, never by these tokens.
+ * Panes that diff against the INDEX (the commit panel) ask for it directly with
+ * `{ kind: "index" }`, so a partially staged file colours from the same content
+ * its diff was computed against.
  */
 export function useDiffSyntax(o: {
   repoId: string | null;
@@ -70,6 +73,7 @@ export function useDiffSyntax(o: {
     const read = (kind: SideSource["kind"], rev: string | null, p: string | null) => {
       if (kind === "none" || !p) return Promise.resolve(null);
       if (kind === "worktree") return readFileContent(repoId, p).catch(() => null);
+      if (kind === "index") return readFileContentAtIndex(repoId, p).catch(() => null);
       return rev ? readFileContentAtRev(repoId, rev, p).catch(() => null) : Promise.resolve(null);
     };
     Promise.all([read(oldKind, oldRev, oldPath), read(newKind, newRev, path)]).then(

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -89,6 +89,22 @@ export async function listFilesAtRev(
   return invoke<FileStatus[]>("list_files_at_rev", { repoId, revspec });
 }
 
+/**
+ * Read a file's content from the INDEX — what committing would record.
+ *
+ * Differs from both other readers exactly when a file is partially staged, which
+ * is why the commit panel needs it: its diffs are against the index, so tokens
+ * taken from HEAD or the worktree could land on the wrong lines there.
+ * Rejects with `InvalidPath` for a path with no stage-0 entry (untracked, or
+ * conflicted); callers render those rows plain.
+ */
+export async function readFileContentAtIndex(
+  repoId: string,
+  path: string,
+): Promise<FileContent> {
+  return invoke<FileContent>("read_file_content_at_index", { repoId, path });
+}
+
 /** Read a file's content from the tree at `revspec`. */
 export async function readFileContentAtRev(
   repoId: string,

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -444,14 +444,18 @@ export function CommitPanelScreen() {
     return new Set(selected ? [keyOf(selected)] : []);
   }, [sel.keys.length, selectedKeys, selected]);
 
-  // This pane diffs against the INDEX (IndexToHead when staged, WorktreeToIndex
-  // otherwise), which cannot be read — see the note on useDiffSyntax for why HEAD
-  // and the worktree are the right approximation and why being off is harmless.
+  // Tokens come from exactly the two sides the diff was computed from:
+  // IndexToHead for a staged row, WorktreeToIndex otherwise. Reading the index
+  // directly is what makes a partially staged file colour correctly — HEAD and
+  // the worktree disagree with it precisely in that case.
   const syntax = useDiffSyntax({
     repoId: selected && !selected.status.embedded ? (repo?.id ?? null) : null,
     path: selected?.path ?? null,
-    old: { kind: "rev", rev: "HEAD", path: diff?.oldPath },
-    new: { kind: "worktree" },
+    old:
+      selected?.side === "staged"
+        ? { kind: "rev", rev: "HEAD", path: diff?.oldPath }
+        : { kind: "index" },
+    new: selected?.side === "staged" ? { kind: "index" } : { kind: "worktree" },
   });
 
   // ── Windowed diff rows ───────────────────────────────────────────────────

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -6,7 +6,7 @@ import {
   PGButtonGroup,
   PGEmpty,
   PGFileTree,
-  PGHunk,
+  PGWindowedDiff,
   PGIconButton,
   PGInput,
   PGPanel,
@@ -24,7 +24,6 @@ import {
   useContextMenu,
   usePaneWidth,
   type ContextMenuItem,
-  type DiffLineData,
   type PGFileTreeNode,
 } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
@@ -47,7 +46,9 @@ import {
   type Selection,
 } from "@/lib/selection";
 import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
-import { useSyntax } from "@/lib/syntax";
+import { useDiffSyntax, useSyntax } from "@/lib/syntax";
+import { flattenDiffRows, windowVariable } from "@/lib/diffRows";
+import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
 import { buildLineSpans } from "@/lib/lineSpans";
 import { splitCodeLines } from "@/lib/codeLines";
 import { getDiff, readFileContent } from "@/lib/tauri";
@@ -572,6 +573,60 @@ export function RepoBrowserScreen() {
     selectedFile.index.kind === "Unmodified";
   const selectedIsEmbedded = !!selectedFile?.embedded;
 
+  // This pane's diff pane went unhighlighted and unwindowed through the first
+  // three slices of #104 — it is a fourth diff surface that is easy to miss. It
+  // compares WorktreeToHead, same as the DiffViewer.
+  const browserSyntax = useDiffSyntax({
+    repoId: selectedFile && !selectedIsEmbedded ? (repo?.id ?? null) : null,
+    path: selectedFile?.path ?? null,
+    old: { kind: "rev", rev: "HEAD", path: diff?.oldPath },
+    new: { kind: "worktree" },
+  });
+  const diffRowH = useDiffRowHeight();
+  const diffHeaderH = 26 + useDensityStep();
+  const [collapsedHunks, setCollapsedHunks] = React.useState<ReadonlySet<number>>(
+    new Set(),
+  );
+  const toggleHunk = React.useCallback((i: number) => {
+    setCollapsedHunks((prev) => {
+      const next = new Set(prev);
+      if (next.has(i)) next.delete(i);
+      else next.add(i);
+      return next;
+    });
+  }, []);
+  const diffRows = React.useMemo(
+    () =>
+      flattenDiffRows(diff && !diff.binary ? diff.hunks : [], {
+        headerH: diffHeaderH,
+        rowH: diffRowH,
+        collapsed: collapsedHunks,
+        syntax: browserSyntax,
+      }),
+    [diff, diffHeaderH, diffRowH, collapsedHunks, browserSyntax],
+  );
+  const diffHeights = React.useMemo(() => diffRows.map((r) => r.h), [diffRows]);
+  const diffScrollRef = React.useRef<HTMLDivElement>(null);
+  const [diffScrollTop, setDiffScrollTop] = React.useState(0);
+  const [diffViewportH, setDiffViewportH] = React.useState(0);
+  React.useEffect(() => {
+    const el = diffScrollRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    setDiffViewportH(el.clientHeight);
+    const ro = new ResizeObserver(() => setDiffViewportH(el.clientHeight));
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  const diffWin = React.useMemo(
+    () =>
+      windowVariable(diffHeights, {
+        scrollTop: diffScrollTop,
+        viewportH: diffViewportH,
+        overscan: 8,
+      }),
+    [diffHeights, diffScrollTop, diffViewportH],
+  );
+
   React.useEffect(() => {
     if (!selectedFile || !repo) {
       setDiff(null);
@@ -910,7 +965,12 @@ export function RepoBrowserScreen() {
               Blame
             </PGButton>
           </div>
-          <FocusableScroll style={{ flex: 1 }} ariaLabel="File preview">
+          <FocusableScroll
+            style={{ flex: 1 }}
+            ariaLabel="File preview"
+            innerRef={diffScrollRef}
+            onScroll={() => setDiffScrollTop(diffScrollRef.current?.scrollTop ?? 0)}
+          >
             {!selectedFile && (
               <PGEmpty
                 icon="fileCode"
@@ -942,20 +1002,20 @@ export function RepoBrowserScreen() {
                 {previewError}
               </PGEmpty>
             )}
-            {selectedFile && !diffLoading && diff && !diff.binary &&
-              diff.hunks.map((h, i) => (
-                <PGHunk
-                  key={i}
-                  header={h.header.replace(/^@@\s*|\s*@@$/g, "").trim()}
-                  lines={h.lines.map(toUiLine)}
-                  expanded={true}
-                  staged={false}
-                  actionsDisabledReason={hunkActionsDisabled}
-                  onStage={() => {
+            {selectedFile && !diffLoading && diff && !diff.binary && (
+              <PGWindowedDiff
+                rows={diffRows}
+                window={diffWin}
+                collapsed={collapsedHunks}
+                onToggleHunk={toggleHunk}
+                hunkActions={(i) => ({
+                  staged: false,
+                  actionsDisabledReason: hunkActionsDisabled,
+                  onStage: () => {
                     if (!selectedFile) return;
                     useRepoStore.getState().stageHunk(selectedFile.path, i);
-                  }}
-                  onDiscard={async () => {
+                  },
+                  onDiscard: async () => {
                     if (!selectedFile) return;
                     if (
                       await pgConfirm({
@@ -967,9 +1027,10 @@ export function RepoBrowserScreen() {
                     ) {
                       useRepoStore.getState().discardHunk(selectedFile.path, i);
                     }
-                  }}
-                />
-              ))}
+                  },
+                })}
+              />
+            )}
             {selectedFile && !diffLoading && diff?.binary && (
               <PGEmpty icon="file" title="Binary file">
                 Binary diffs aren&apos;t shown.
@@ -1238,24 +1299,6 @@ function FileContentView({ path, text }: { path: string; text: string }) {
   );
 }
 
-function toUiLine(l: {
-  kind: { kind: string };
-  oldLineno: number | null;
-  newLineno: number | null;
-  content: string;
-}): DiffLineData {
-  const k = l.kind.kind;
-  if (k === "Addition")
-    return { kind: "add", lnR: l.newLineno ?? undefined, text: l.content };
-  if (k === "Deletion")
-    return { kind: "rem", lnL: l.oldLineno ?? undefined, text: l.content };
-  return {
-    kind: "ctx",
-    lnL: l.oldLineno ?? undefined,
-    lnR: l.newLineno ?? undefined,
-    text: l.content,
-  };
-}
 
 function isHidden(s: FileStatus, hidden: Set<HideKind>): boolean {
   const sides: StatusFlag[] = [s.worktree, s.index];


### PR DESCRIPTION
Follow-ups to #104, after #106/#109/#111. Two of these close real gaps in what already shipped, and one of them exists because I got a claim wrong.

## 1. The repo browser's diff pane was missed entirely

`RepoBrowser` is a **fourth** diff surface — it renders hunks with its own stage/discard — and all three merged slices skipped it: no syntax highlighting, no word diff, no windowing. PR1 highlighted that screen's *file preview*, which is exactly what disguised the gap.

It now renders through `PGWindowedDiff` like the other three, with its stage and discard wiring preserved, so it gets all three at once.

I also have to correct the record: I stated in #111 and on the issue that `PGHunk` had no production consumers left. That was false — this pane rendered it. The claim came from a grep piped through `head`, which truncated the call site. With the pane migrated, `PGHunk` genuinely is unused, so it is deleted here and its two span suites (`wordDiffRender`, `syntaxRender`) now pin the same behaviour through the production path (`flattenDiffRows` + `PGWindowedDiff`) rather than through a component nothing rendered.

## 2. `CommitDiffPanel` is windowed after all

I deferred this in #111 as needing a design decision, because windowing it looked like a choice between a second flatten implementation and giving up its lighter gutter-less look. Both horns were wrong: it only needed its own row **renderer**, not its own row **model**. Adopting the shared `flattenDiffRows` kept the look, and as a bonus deleted the panel's hand-rolled per-hunk word-span map — that pairing already happens in the shared transform.

## 3. The commit panel no longer approximates the index

New backend op `read_file_content_at_index` reads the stage-0 blob, so the commit panel's tokens come from the index its diffs were actually computed against. Previously it approximated with HEAD + worktree, which disagree with the index exactly when a file is partially staged — the one case where a line could be coloured from the wrong content. A path with no stage-0 entry (untracked, or conflicted, which has stages 1–3 and no 0) is an `InvalidPath`, so those rows fall back to plain rather than guessing.

Follows the standard op path: `GitBackend` method → `Libgit2Backend` impl → `CliBackend` stub → command → `invoke_handler!` → TS type + wrapper, with four backend tests including the partially-staged case that motivated it.

## Verification

- `pnpm tsc --noEmit` — clean
- `pnpm test` — 116 files, 849 tests
- `cargo test --manifest-path src-tauri/Cargo.toml` — full suite green, including the 4 new `read_index_content` tests
- `pnpm vite build` — clean
- `pnpm test:e2e:docker full --spec status-stage --spec history-diff --spec keymap --spec commit --spec smoke` — 5 spec files, 100% in 1:18; `status-stage` and `commit` cover the staging paths this touches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
