### PR TITLE
feat(rebase): recreate merge commits (preserve mode)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,6 +283,8 @@ features/            Per-feature: components + Zustand store colocated
 │                    file-history, blame, rebase-plan, stash-diff)
 ├── branches/        BranchChip (titlebar), BranchPicker (popover)
 ├── commits/         graphLayout + buildRebasePlan (both tested)
+├── rebase/          RebaseBasePicker + useRebaseMergeMode (persisted
+│                    flatten ⇄ preserve for merge commits in a plan)
 ├── reflog/          useReflogStore, DirtyTreeDialog, ReflogActionDialog
 ├── settings/        useSettingsStore (autoFetch, defaultPullMode, etc.)
 ├── palette/         usePaletteStore (step stack + chips), commands (catalog),
@@ -377,12 +379,32 @@ lib/
 - **`RebaseState.rewritten` maps original oid → replayed oid** for every step
   that ran, recorded *after* the action's post-commit rewrite (reword amends,
   squash/fixup collapse), and a dropped step maps to the HEAD it left behind.
-- **Merge commits in a plan take one of two actions**: `Drop` (flatten — git's
-  own default: the merge disappears and its commits are replayed individually)
-  or `MainlinePick` (keep the merge as one ordinary commit — `git cherry-pick
-  -m 1`, so `start_pick` passes mainline 1). `rebase_plan::merge_legal` is the
-  single source of truth; `MERGE_ACTIONS` in `src/screens/Rebase.tsx` mirrors it,
-  and the two must stay in sync or the UI offers an action the backend refuses.
+- **Merge commits in a plan take one of three actions**: `Drop` (flatten — git's
+  own default: the merge disappears and its commits are replayed individually),
+  `MainlinePick` (keep the merge as one ordinary commit — `git cherry-pick -m 1`,
+  so `start_pick` passes mainline 1), or `Merge` (recreate it from its rewritten
+  parents — the `--rebase-merges` equivalent). `rebase_plan::merge_legal` is the
+  single source of truth; `MERGE_ACTIONS_FLATTEN` / `MERGE_ACTIONS_PRESERVE` in
+  `src/screens/Rebase.tsx` mirror it per mode, and they must stay in sync or the
+  UI offers an action the backend refuses.
+- **Plans carry topology structurally, not as git's todo language.** A
+  `RebaseStep` may name the original commit it is applied `onto` (resolved
+  through the engine's rewritten map, so every commit is implicitly its own
+  label), and a `Merge` step carries its original parents beyond the first. A
+  plan whose steps all leave `onto: null` is the linear default. There are no
+  `label` / `reset` / `exec` steps and no `rebase-cousins` mode — a generated
+  plan does not need the naming layer.
+- **A recreated merge runs in the worktree** (`repo.merge`, not
+  `merge_commits`), so a conflict lands in the index with stages and
+  `conflict_sides`, the Conflict screen, and the merge resolver window all work
+  unchanged; `rebase_continue` then commits the resolution with both parents.
+  Conflict resolutions inside the ORIGINAL merge are not reused — neither does
+  git. Octopus merges cannot be recreated; they can be dropped or kept as one
+  commit.
+- **Preserve mode disables reordering** (git documents its own reorder bugs
+  under `--rebase-merges`), and it rebuilds a whole-range plan in place while
+  deliberately leaving a targeted plan (squash/fixup/reword) alone — rebuilding
+  one would discard the message the user typed.
 - **`PGRebaseRow` speaks exact `RebaseAction` strings** (`"Pick"`, `"Drop"`,
   `"MainlinePick"`), not lowercased ones — a two-word action cannot survive a
   lowercase/re-capitalise round trip. E2E specs that drive the row's `<select>`

--- a/e2e/specs/rebase.e2e.ts
+++ b/e2e/specs/rebase.e2e.ts
@@ -145,4 +145,61 @@ describe("interactive rebase", () => {
     expect(repo.read("f.txt")).toBe("f\n");
     expect(repo.git("status", "--porcelain").trim()).toBe("");
   });
+
+  it("preserves a merge commit when preserve mode is on", async () => {
+    repo = mergeRangeRepo();
+    const originalMerge = repo.git("rev-parse", "HEAD").trim();
+    await openRepo(repo.path);
+    await stubNativeDialogs({ confirm: true });
+    await switchScreen("history");
+    await scrollCommitListTo("feat: a on main");
+    await jsContextMenu('[data-testid="commit-row"]', { text: "feat: a on main" });
+    await jsClickMenuItem("Interactive rebase from here");
+    await $('[data-testid="rebase-row"]').waitForDisplayed({
+      timeout: 15_000,
+      timeoutMsg: "rebase plan never appeared",
+    });
+
+    await $('[data-testid="rebase-merge-mode-preserve"]').click();
+    const warning = $('[data-testid="rebase-merge-warning"]');
+    await warning.waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg: "merge warning never appeared in preserve mode",
+    });
+    await browser.waitUntil(
+      async () => (await warning.getText()).includes("not preserved"),
+      {
+        timeout: 10_000,
+        timeoutMsg: "warning never switched to the preserve-mode copy",
+      },
+    );
+
+    await $('[data-testid="rebase-start"]').click();
+    await $('[data-testid="rebase-last-summary"]').waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "preserving rebase never reported completion",
+    });
+
+    // The merge survives as a merge, with its topology intact: first parent the
+    // mainline commit, second the side branch.
+    expect(repo.git("log", "--merges", "--format=%s").trim()).toBe(
+      "Merge branch 'feature'",
+    );
+    expect(repo.git("log", "-1", "--format=%s", "HEAD^1").trim()).toBe(
+      "feat: c on main",
+    );
+    expect(repo.git("log", "-1", "--format=%s", "HEAD^2").trim()).toBe(
+      "feat: f on feature",
+    );
+    // A rebase really ran: rebase_start records the pre-rebase tip in ORIG_HEAD.
+    // Note HEAD's oid is EXPECTED to equal the original merge's — replaying
+    // unchanged commits onto the same base reproduces them byte for byte (same
+    // trees, messages, authors, and same-second committers), which is what a
+    // faithful recreate looks like. Asserting the oid changed would assert the
+    // engine corrupts something.
+    expect(repo.git("rev-parse", "ORIG_HEAD").trim()).toBe(originalMerge);
+    expect(repo.read("f.txt")).toBe("f\n");
+    expect(repo.read("c.txt")).toBe("c\n");
+    expect(repo.git("status", "--porcelain").trim()).toBe("");
+  });
 });

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -328,7 +328,15 @@ impl Libgit2Backend {
         };
 
         self.with_repo(repo_id, |repo| match &snapshot {
-            Some(state) => crate::git::rebase_state::save(repo, state),
+            Some(state) => {
+                // Re-assert ORIG_HEAD on every transition, not just at start: a
+                // hard reset writes its own ORIG_HEAD, so the resets this engine
+                // performs mid-replay (moving to a step's base, collapsing a
+                // squash) would otherwise leave a mid-rebase commit there and
+                // break `git reset --hard ORIG_HEAD` as an escape hatch.
+                crate::git::rebase_state::write_orig_head(repo, &state.orig_head)?;
+                crate::git::rebase_state::save(repo, state)
+            }
             None => crate::git::rebase_state::clear(repo),
         })
     }

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -174,6 +174,97 @@ impl Libgit2Backend {
         })
     }
 
+    /// Resolve a merge step's original parents through the rewritten map. A
+    /// parent that was not replayed (it lives below the range) keeps its own
+    /// oid.
+    fn resolved_merge_parents(
+        &self,
+        repo_id: &RepoId,
+        step: &RebaseStep,
+    ) -> AppResult<Vec<String>> {
+        let rebases = self
+            .rebases
+            .lock()
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        let rewritten = rebases.get(repo_id).map(|s| &s.rewritten);
+        Ok(step
+            .merge_parents
+            .iter()
+            .map(|old| {
+                rewritten
+                    .and_then(|m| m.get(old).cloned())
+                    .unwrap_or_else(|| old.clone())
+            })
+            .collect())
+    }
+
+    /// Re-merge a recreated merge's other parents into the current HEAD.
+    /// Returns `Ok(false)` when the merge conflicts — the worktree keeps the
+    /// conflicted index, so the Conflict screen and the merge resolver window
+    /// work exactly as they do for a conflicting pick.
+    ///
+    /// A worktree merge, not `merge_commits`: the conflicted index with its
+    /// stages is what every conflict surface in the app reads.
+    fn apply_merge(&self, repo_id: &RepoId, step: &RebaseStep) -> AppResult<bool> {
+        let parents = self.resolved_merge_parents(repo_id, step)?;
+        self.with_repo(repo_id, |repo| {
+            let annotated: Vec<git2::AnnotatedCommit> = parents
+                .iter()
+                .map(|oid| {
+                    let commit = repo
+                        .revparse_single(oid)
+                        .map_err(|_| AppError::InvalidRef(oid.clone()))?
+                        .peel_to_commit()?;
+                    Ok(repo.find_annotated_commit(commit.id())?)
+                })
+                .collect::<AppResult<Vec<_>>>()?;
+            let refs: Vec<&git2::AnnotatedCommit> = annotated.iter().collect();
+            repo.merge(&refs, None, None)?;
+            let index = repo.index()?;
+            Ok(!index.has_conflicts())
+        })
+    }
+
+    /// Commit the staged tree as the recreated merge — original message and
+    /// author, parents = current HEAD plus the rewritten other parents.
+    fn finish_merge(&self, repo_id: &RepoId, step: &RebaseStep) -> AppResult<()> {
+        let parents = self.resolved_merge_parents(repo_id, step)?;
+        self.with_repo(repo_id, |repo| {
+            let original = repo
+                .revparse_single(&step.oid)
+                .map_err(|_| AppError::InvalidRef(step.oid.clone()))?
+                .peel_to_commit()?;
+            let sig = crate::git::signature::default_signature(repo)?;
+            let mut index = repo.index()?;
+            let tree_oid = index.write_tree()?;
+            let tree = repo.find_tree(tree_oid)?;
+            let head = repo.head()?.peel_to_commit()?;
+
+            let others: Vec<git2::Commit> = parents
+                .iter()
+                .map(|oid| {
+                    Ok(repo
+                        .revparse_single(oid)
+                        .map_err(|_| AppError::InvalidRef(oid.clone()))?
+                        .peel_to_commit()?)
+                })
+                .collect::<AppResult<Vec<_>>>()?;
+            let mut parent_refs: Vec<&git2::Commit> = vec![&head];
+            parent_refs.extend(others.iter());
+
+            repo.commit(
+                Some("HEAD"),
+                &original.author(),
+                &sig,
+                original.message().unwrap_or(""),
+                &tree,
+                &parent_refs,
+            )?;
+            repo.cleanup_state()?;
+            Ok(())
+        })
+    }
+
     fn bump_completed(&self, repo_id: &RepoId) -> AppResult<()> {
         let mut rebases = self
             .rebases
@@ -426,6 +517,29 @@ impl Libgit2Backend {
                 }
             }
 
+            // A recreated merge is not a cherry-pick: it re-merges its rewritten
+            // parents. A resumed one skips the merge (the worktree already holds
+            // the user's resolution) and goes straight to committing it with
+            // both parents — which is why only `apply_merge` is guarded here.
+            if step.action == RebaseAction::Merge {
+                if !resuming && !self.apply_merge(repo_id, &step)? {
+                    let mut rebases = self
+                        .rebases
+                        .lock()
+                        .map_err(|e| AppError::Internal(e.to_string()))?;
+                    if let Some(state) = rebases.get_mut(repo_id) {
+                        state.conflict_step = Some(step);
+                    }
+                    drop(rebases);
+                    return self.mark_paused(repo_id, "conflict");
+                }
+                self.finish_merge(repo_id, &step)?;
+                self.bump_completed(repo_id)?;
+                self.record_rewritten(repo_id, &step.oid)?;
+                self.persist_rebase(repo_id)?;
+                continue;
+            }
+
             // A merge commit being kept as one commit needs a mainline; every
             // other step must not get one.
             let mainline = if step.action == RebaseAction::MainlinePick {
@@ -474,6 +588,15 @@ impl Libgit2Backend {
 
                 RebaseAction::Pick | RebaseAction::MainlinePick => {
                     self.bump_completed(repo_id)?;
+                }
+
+                RebaseAction::Merge => {
+                    // Unreachable: a Merge step is handled and `continue`d above,
+                    // because it re-merges rather than cherry-picks. Kept as an
+                    // explicit arm so adding an action forces a decision here.
+                    return Err(AppError::Internal(
+                        "merge step reached the cherry-pick path".into(),
+                    ));
                 }
 
                 RebaseAction::Reword => {

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -289,6 +289,36 @@ impl Libgit2Backend {
             .is_some())
     }
 
+    /// Put the detached HEAD on the commit a step wants to be applied onto.
+    /// `original_oid` is the pre-rebase oid; the rewritten map translates it to
+    /// this run's copy, falling back to the original when the commit was not
+    /// rewritten (it sits below the range).
+    fn move_to_base(&self, repo_id: &RepoId, original_oid: &str) -> AppResult<()> {
+        let resolved = {
+            let rebases = self
+                .rebases
+                .lock()
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+            rebases
+                .get(repo_id)
+                .and_then(|s| s.rewritten.get(original_oid).cloned())
+                .unwrap_or_else(|| original_oid.to_string())
+        };
+
+        self.with_repo(repo_id, |repo| {
+            let target = repo
+                .revparse_single(&resolved)
+                .map_err(|_| AppError::InvalidRef(resolved.clone()))?
+                .peel_to_commit()?;
+            if repo.head()?.peel_to_commit()?.id() == target.id() {
+                return Ok(()); // already there — nothing to reset
+            }
+            repo.set_head_detached(target.id())?;
+            repo.reset(target.as_object(), git2::ResetType::Hard, None)?;
+            Ok(())
+        })
+    }
+
     /// Point the original branch at the replayed history and reattach HEAD to
     /// it. Called once, when the plan is exhausted. A rebase that started from
     /// a detached HEAD just stays detached.
@@ -385,6 +415,15 @@ impl Libgit2Backend {
                 self.record_rewritten(repo_id, &step.oid)?;
                 self.persist_rebase(repo_id)?;
                 continue;
+            }
+
+            // Topology: a step that names an `onto` is replayed there rather
+            // than on the previous step's result. Skipped while resuming — the
+            // worktree already holds the user's resolution for this step.
+            if !resuming {
+                if let Some(onto) = step.onto.clone() {
+                    self.move_to_base(repo_id, &onto)?;
+                }
             }
 
             // A merge commit being kept as one commit needs a mainline; every
@@ -3436,6 +3475,7 @@ impl GitBackend for Libgit2Backend {
                 AppError::InvalidRebasePlan("the plan drops every commit".into())
             })?;
         let first_oid_str = first_step.oid.clone();
+        let first_step_onto = first_step.onto.clone();
 
         // Verify worktree is clean, remember the branch and its pre-rebase tip
         // (so an abort can put both back), then DETACH at the base and replay
@@ -3469,22 +3509,32 @@ impl GitBackend for Libgit2Backend {
             // `git reset --hard ORIG_HEAD` undoes this rebase from the CLI.
             crate::git::rebase_state::write_orig_head(repo, &orig_head)?;
 
-            let first_commit = repo
-                .revparse_single(&first_oid_str)
-                .map_err(|_| AppError::InvalidRef(first_oid_str.clone()))?
-                .peel_to_commit()?;
-            let parent = first_commit.parent(0).map_err(|_| {
-                AppError::InvalidRebasePlan(format!(
-                    "{} has no parent to rebase onto",
-                    crate::git::rebase_plan::short(&first_oid_str)
-                ))
-            })?;
+            // The run's base: what the first step says it sits on, else that
+            // commit's first parent.
+            let base = match &first_step_onto {
+                Some(onto) => repo
+                    .revparse_single(onto)
+                    .map_err(|_| AppError::InvalidRef(onto.clone()))?
+                    .peel_to_commit()?,
+                None => {
+                    let first_commit = repo
+                        .revparse_single(&first_oid_str)
+                        .map_err(|_| AppError::InvalidRef(first_oid_str.clone()))?
+                        .peel_to_commit()?;
+                    first_commit.parent(0).map_err(|_| {
+                        AppError::InvalidRebasePlan(format!(
+                            "{} has no parent to rebase onto",
+                            crate::git::rebase_plan::short(&first_oid_str)
+                        ))
+                    })?
+                }
+            };
 
             // Detach first, then hard-reset: with HEAD attached, the reset
             // would drag the branch ref along.
-            repo.set_head_detached(parent.id())?;
-            repo.reset(parent.as_object(), git2::ResetType::Hard, None)?;
-            Ok((orig_head, head_name, parent.id().to_string()))
+            repo.set_head_detached(base.id())?;
+            repo.reset(base.as_object(), git2::ResetType::Hard, None)?;
+            Ok((orig_head, head_name, base.id().to_string()))
         })?;
 
         let total = plan.len();

--- a/src-tauri/src/git/rebase_plan.rs
+++ b/src-tauri/src/git/rebase_plan.rs
@@ -47,6 +47,27 @@ pub fn validate(repo: &Repository, plan: &[RebaseStep]) -> AppResult<()> {
                 AppError::InvalidRebasePlan(format!("unknown commit {}", short(&step.oid)))
             })?;
 
+        if let Some(onto) = &step.onto {
+            // Either an earlier step (whose replayed copy the engine will have
+            // recorded by then) or a commit that already exists below the range.
+            let known_earlier = plan
+                .iter()
+                .take_while(|s| s.oid != step.oid)
+                .any(|s| &s.oid == onto);
+            let exists = repo
+                .revparse_single(onto)
+                .and_then(|o| o.peel_to_commit())
+                .is_ok();
+            if !known_earlier && !exists {
+                return Err(AppError::InvalidRebasePlan(format!(
+                    "{} is applied onto {}, which is neither an earlier step nor \
+                     an existing commit",
+                    short(&step.oid),
+                    short(onto)
+                )));
+            }
+        }
+
         if commit.parent_count() > 1 && !merge_legal(step.action) {
             return Err(AppError::InvalidRebasePlan(format!(
                 "{} is a merge commit — it can be dropped (which flattens the \

--- a/src-tauri/src/git/rebase_plan.rs
+++ b/src-tauri/src/git/rebase_plan.rs
@@ -20,10 +20,13 @@ pub fn short(oid: &str) -> &str {
 ///
 /// `Drop` flattens (git's own default: the merge disappears and its commits are
 /// replayed individually); `MainlinePick` keeps the merge as one ordinary
-/// commit. Recreating a merge is a separate action added later. This function is
-/// the single source of truth the UI mirrors.
+/// commit; `Merge` recreates it from its rewritten parents. This function is the
+/// single source of truth the UI mirrors.
 pub fn merge_legal(action: RebaseAction) -> bool {
-    matches!(action, RebaseAction::Drop | RebaseAction::MainlinePick)
+    matches!(
+        action,
+        RebaseAction::Drop | RebaseAction::MainlinePick | RebaseAction::Merge
+    )
 }
 
 pub fn validate(repo: &Repository, plan: &[RebaseStep]) -> AppResult<()> {
@@ -72,6 +75,35 @@ pub fn validate(repo: &Repository, plan: &[RebaseStep]) -> AppResult<()> {
             return Err(AppError::InvalidRebasePlan(format!(
                 "{} is a merge commit — it can be dropped (which flattens the \
                  branch) or kept as one commit, but not {:?}ed",
+                short(&step.oid),
+                step.action
+            )));
+        }
+
+        if step.action == RebaseAction::Merge {
+            if commit.parent_count() < 2 {
+                return Err(AppError::InvalidRebasePlan(format!(
+                    "{} is not a merge commit, so it cannot be recreated as one",
+                    short(&step.oid)
+                )));
+            }
+            if commit.parent_count() > 2 {
+                return Err(AppError::InvalidRebasePlan(format!(
+                    "{} is an octopus merge ({} parents) — recreating one is not \
+                     supported yet; drop it or keep it as one commit",
+                    short(&step.oid),
+                    commit.parent_count()
+                )));
+            }
+            if step.merge_parents.is_empty() {
+                return Err(AppError::InvalidRebasePlan(format!(
+                    "{} is a merge step with no parents to merge",
+                    short(&step.oid)
+                )));
+            }
+        } else if !step.merge_parents.is_empty() {
+            return Err(AppError::InvalidRebasePlan(format!(
+                "{} carries merge parents but its action is {:?}",
                 short(&step.oid),
                 step.action
             )));

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -346,6 +346,19 @@ pub struct RebaseStep {
     pub action: RebaseAction,
     /// New message for reword / squash. Ignored for other actions.
     pub message: Option<String>,
+    /// The **original** oid this step must be applied onto. The engine resolves
+    /// it through the rewritten map and resets the detached HEAD there before
+    /// applying. `None` means "onto whatever the previous step produced" — the
+    /// linear default, which is every plan built before topology existed.
+    ///
+    /// This is how a generated plan expresses topology without git's
+    /// `label`/`reset` todo language: every commit is implicitly its own label.
+    #[serde(default)]
+    pub onto: Option<String>,
+    /// A merge step's **original** parents beyond the first, resolved through
+    /// the rewritten map at merge time. Empty for every other action.
+    #[serde(default)]
+    pub merge_parents: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -336,6 +336,11 @@ pub enum RebaseAction {
     /// ordinary commit, keeping the merge's message (`git cherry-pick -m 1`).
     /// On a non-merge commit it is identical to `Pick`.
     MainlinePick,
+    /// Recreate a merge commit: re-merge its rewritten parents and commit the
+    /// result with the original message and parent count (the equivalent of
+    /// `git rebase --rebase-merges`). Conflict resolutions recorded in the
+    /// original merge are NOT reused — git does not either.
+    Merge,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/tests/rebase.rs
+++ b/src-tauri/tests/rebase.rs
@@ -11,11 +11,20 @@ use support::{linear_history, TempRepo};
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
 fn step(oid: &str, action: RebaseAction) -> RebaseStep {
-    RebaseStep { oid: oid.to_string(), action, message: None }
+    RebaseStep {
+        oid: oid.to_string(),
+        action,
+        message: None,
+        onto: None,
+        merge_parents: Vec::new(),
+    }
 }
 
 fn step_msg(oid: &str, action: RebaseAction, msg: &str) -> RebaseStep {
-    RebaseStep { oid: oid.to_string(), action, message: Some(msg.to_string()) }
+    RebaseStep {
+        message: Some(msg.to_string()),
+        ..step(oid, action)
+    }
 }
 
 // ─── 1. drop ─────────────────────────────────────────────────────────────────
@@ -213,8 +222,8 @@ fn rebase_conflict_pauses() {
 
     // Plan: pick B (so base is root), then pick A on top → conflict.
     let plan = vec![
-        RebaseStep { oid: oid_b.clone(), action: RebaseAction::Pick, message: None },
-        RebaseStep { oid: oid_a.clone(), action: RebaseAction::Pick, message: None },
+        step(&oid_b, RebaseAction::Pick),
+        step(&oid_a, RebaseAction::Pick),
     ];
 
     let status = backend.rebase_start(&handle.id, plan).unwrap();
@@ -305,8 +314,8 @@ fn abort_operation_clears_rebase_state_and_restores_pre_rebase_head() {
     let head_before = backend.log(&handle.id, None, 1).unwrap()[0].oid.clone();
 
     let plan = vec![
-        RebaseStep { oid: oid_b.clone(), action: RebaseAction::Pick, message: None },
-        RebaseStep { oid: oid_a.clone(), action: RebaseAction::Pick, message: None },
+        step(&oid_b, RebaseAction::Pick),
+        step(&oid_a, RebaseAction::Pick),
     ];
     let status = backend.rebase_start(&handle.id, plan).unwrap();
     assert!(status.in_progress, "should be paused after conflict");

--- a/src-tauri/tests/rebase_durability.rs
+++ b/src-tauri/tests/rebase_durability.rs
@@ -17,6 +17,8 @@ fn step(oid: &str, action: RebaseAction) -> RebaseStep {
         oid: oid.to_string(),
         action,
         message: None,
+        onto: None,
+        merge_parents: Vec::new(),
     }
 }
 

--- a/src-tauri/tests/rebase_flatten.rs
+++ b/src-tauri/tests/rebase_flatten.rs
@@ -16,6 +16,8 @@ fn step(oid: &str, action: RebaseAction) -> RebaseStep {
         oid: oid.to_string(),
         action,
         message: None,
+        onto: None,
+        merge_parents: Vec::new(),
     }
 }
 

--- a/src-tauri/tests/rebase_preserve.rs
+++ b/src-tauri/tests/rebase_preserve.rs
@@ -212,6 +212,38 @@ fn an_octopus_merge_cannot_be_recreated() {
     }
 }
 
+#[test]
+fn orig_head_survives_the_resets_a_preserving_replay_performs() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    // The fixture's own `git merge` wrote ORIG_HEAD (git does that), and the
+    // replay resets HEAD several times to reach each step's base — each reset
+    // writing its own ORIG_HEAD. The escape hatch documented for this engine
+    // (`git reset --hard ORIG_HEAD`) is only true if ours wins.
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .rebase_start(
+            &handle.id,
+            vec![
+                pick(&h.a),
+                pick(&h.f),
+                pick_onto(&h.c, &h.a),
+                merge_step(&h.m, &h.c, &[&h.f]),
+            ],
+        )
+        .unwrap();
+
+    let orig_head = std::fs::read_to_string(tr.path().join(".git").join("ORIG_HEAD"))
+        .unwrap()
+        .trim()
+        .to_string();
+    assert_eq!(
+        orig_head, h.m,
+        "ORIG_HEAD must name the pre-rebase tip, not a commit the replay reset through"
+    );
+}
+
 // ─── conflicting recreate ────────────────────────────────────────────────────
 
 /// Same shape as `merge_history`, but both sides edit `shared.txt`, so the

--- a/src-tauri/tests/rebase_preserve.rs
+++ b/src-tauri/tests/rebase_preserve.rs
@@ -1,0 +1,95 @@
+//! Topology-aware replay. A step may name the original commit it must be
+//! applied onto; the engine resolves that through the rewritten map and resets
+//! the detached HEAD there first. That is what lets a side branch be replayed
+//! at its own branch point instead of being flattened onto the mainline.
+
+mod support;
+
+use platypusgit_lib::{
+    error::AppError,
+    git::{
+        types::{RebaseAction, RebaseStep},
+        GitBackend,
+    },
+};
+
+use support::{merge_history, TempRepo};
+
+fn pick(oid: &str) -> RebaseStep {
+    RebaseStep {
+        oid: oid.to_string(),
+        action: RebaseAction::Pick,
+        message: None,
+        onto: None,
+        merge_parents: Vec::new(),
+    }
+}
+
+fn pick_onto(oid: &str, onto: &str) -> RebaseStep {
+    RebaseStep {
+        onto: Some(onto.to_string()),
+        ..pick(oid)
+    }
+}
+
+#[test]
+fn onto_replays_a_step_at_its_own_branch_point() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    // A, then F on top of A, then C back on top of A — a fork, no merge yet.
+    // Without `onto`, C would land on top of F (the previous step's result).
+    let status = backend
+        .rebase_start(&handle.id, vec![pick(&h.a), pick(&h.f), pick_onto(&h.c, &h.a)])
+        .unwrap();
+    assert!(!status.in_progress);
+
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(head.summary().unwrap(), "C on main");
+    assert_eq!(
+        head.parent(0).unwrap().summary().unwrap(),
+        "A on main",
+        "C must sit on the rewritten A, not on F"
+    );
+    // F was replayed on a fork the final HEAD does not descend from, so its
+    // file is not in the checked-out tree.
+    assert!(
+        !tr.path().join("f.txt").exists(),
+        "F's fork is not checked out at HEAD"
+    );
+}
+
+#[test]
+fn onto_naming_an_unknown_commit_is_rejected() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+    let tip_before = tr
+        .repo
+        .head()
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .id()
+        .to_string();
+
+    let err = backend
+        .rebase_start(
+            &handle.id,
+            vec![pick_onto(&h.a, "0000000000000000000000000000000000000000")],
+        )
+        .unwrap_err();
+    assert!(matches!(err, AppError::InvalidRebasePlan(_)), "got {err:?}");
+    assert_eq!(
+        tr.repo
+            .head()
+            .unwrap()
+            .peel_to_commit()
+            .unwrap()
+            .id()
+            .to_string(),
+        tip_before,
+        "a rejected plan must not move anything"
+    );
+}

--- a/src-tauri/tests/rebase_preserve.rs
+++ b/src-tauri/tests/rebase_preserve.rs
@@ -93,3 +93,238 @@ fn onto_naming_an_unknown_commit_is_rejected() {
         "a rejected plan must not move anything"
     );
 }
+
+// ─── recreating merges ───────────────────────────────────────────────────────
+
+fn merge_step(oid: &str, onto: &str, parents: &[&str]) -> RebaseStep {
+    RebaseStep {
+        oid: oid.to_string(),
+        action: RebaseAction::Merge,
+        message: None,
+        onto: Some(onto.to_string()),
+        merge_parents: parents.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+#[test]
+fn a_merge_is_recreated_from_its_rewritten_parents() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    // The topology-preserving plan for root..M:
+    //   A, then F (on A), then C (back onto A), then M merging F into C.
+    let status = backend
+        .rebase_start(
+            &handle.id,
+            vec![
+                pick(&h.a),
+                pick(&h.f),
+                pick_onto(&h.c, &h.a),
+                merge_step(&h.m, &h.c, &[&h.f]),
+            ],
+        )
+        .unwrap();
+    assert!(!status.in_progress, "a clean recreate should not pause");
+
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(
+        head.parent_count(),
+        2,
+        "the merge must be recreated as a merge"
+    );
+    assert_eq!(head.summary().unwrap(), "Merge branch 'feature'");
+
+    let first = head.parent(0).unwrap();
+    let second = head.parent(1).unwrap();
+    assert_eq!(first.summary().unwrap(), "C on main");
+    assert_eq!(second.summary().unwrap(), "F on feature");
+
+    // Both sides' content is present, and the worktree is clean.
+    assert!(tr.path().join("f.txt").exists());
+    assert!(tr.path().join("c.txt").exists());
+    assert!(tr.repo.statuses(None).unwrap().is_empty());
+}
+
+#[test]
+fn merge_on_a_non_merge_commit_is_rejected() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .rebase_start(&handle.id, vec![merge_step(&h.c, &h.a, &[&h.f])])
+        .unwrap_err();
+    assert!(matches!(err, AppError::InvalidRebasePlan(_)), "got {err:?}");
+}
+
+#[test]
+fn merge_without_parents_is_rejected() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .rebase_start(&handle.id, vec![pick(&h.a), merge_step(&h.m, &h.c, &[])])
+        .unwrap_err();
+    assert!(matches!(err, AppError::InvalidRebasePlan(_)), "got {err:?}");
+}
+
+#[test]
+fn an_octopus_merge_cannot_be_recreated() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = merge_history(&tr);
+
+    // A third parent and an octopus merge on top of M.
+    let octopus = {
+        let sig = git2::Signature::now("Test", "t@e.com").unwrap();
+        let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+        let f = tr
+            .repo
+            .find_commit(git2::Oid::from_str(&h.f).unwrap())
+            .unwrap();
+        let a = tr
+            .repo
+            .find_commit(git2::Oid::from_str(&h.a).unwrap())
+            .unwrap();
+        let tree = head.tree().unwrap();
+        tr.repo
+            .commit(Some("HEAD"), &sig, &sig, "octopus", &tree, &[&head, &f, &a])
+            .unwrap()
+            .to_string()
+    };
+
+    let (backend, handle) = tr.open_with_backend();
+    let err = backend
+        .rebase_start(
+            &handle.id,
+            vec![merge_step(&octopus, &h.m, &[&h.f, &h.a])],
+        )
+        .unwrap_err();
+    match err {
+        AppError::InvalidRebasePlan(msg) => {
+            assert!(
+                msg.contains("octopus"),
+                "message should name the shape: {msg}"
+            );
+        }
+        other => panic!("expected InvalidRebasePlan, got {other:?}"),
+    }
+}
+
+// ─── conflicting recreate ────────────────────────────────────────────────────
+
+/// Same shape as `merge_history`, but both sides edit `shared.txt`, so the
+/// recreated merge conflicts. The original merge is resolved one way, which the
+/// recreate must NOT reuse (neither does git).
+fn conflicting_merge_history(tr: &TempRepo) -> (String, String, String, String) {
+    use support::fs::write_file;
+
+    write_file(tr.path(), "shared.txt", "base\n");
+    let a = tr.commit_all("A on main").to_string();
+
+    let a_commit = tr
+        .repo
+        .find_commit(git2::Oid::from_str(&a).unwrap())
+        .unwrap();
+    tr.repo.branch("feature", &a_commit, false).unwrap();
+    tr.repo.set_head("refs/heads/feature").unwrap();
+    tr.repo
+        .checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+        .unwrap();
+    write_file(tr.path(), "shared.txt", "feature\n");
+    let f = tr.commit_all("F on feature").to_string();
+
+    tr.repo.set_head("refs/heads/main").unwrap();
+    tr.repo
+        .checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+        .unwrap();
+    write_file(tr.path(), "shared.txt", "main\n");
+    let c = tr.commit_all("C on main").to_string();
+
+    let f_oid = git2::Oid::from_str(&f).unwrap();
+    let m = {
+        let annotated = tr.repo.find_annotated_commit(f_oid).unwrap();
+        tr.repo.merge(&[&annotated], None, None).unwrap();
+        write_file(tr.path(), "shared.txt", "original resolution\n");
+        let mut index = tr.repo.index().unwrap();
+        index
+            .add_path(std::path::Path::new("shared.txt"))
+            .unwrap();
+        index.write().unwrap();
+        let tree_oid = index.write_tree().unwrap();
+        let tree = tr.repo.find_tree(tree_oid).unwrap();
+        let sig = git2::Signature::now("Test", "t@e.com").unwrap();
+        let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+        let f_commit = tr.repo.find_commit(f_oid).unwrap();
+        tr.repo
+            .commit(
+                Some("HEAD"),
+                &sig,
+                &sig,
+                "Merge branch 'feature'",
+                &tree,
+                &[&head, &f_commit],
+            )
+            .unwrap()
+            .to_string()
+    };
+    tr.repo.cleanup_state().unwrap();
+    (a, f, c, m)
+}
+
+#[test]
+fn a_conflicting_recreated_merge_pauses_and_resumes() {
+    use support::fs::write_file;
+
+    let tr = TempRepo::with_initial_commit("root\n");
+    let (a, f, c, m) = conflicting_merge_history(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    let status = backend
+        .rebase_start(
+            &handle.id,
+            vec![
+                pick(&a),
+                pick(&f),
+                pick_onto(&c, &a),
+                merge_step(&m, &c, &[&f]),
+            ],
+        )
+        .unwrap();
+    assert!(status.in_progress, "the recreated merge should conflict");
+    assert_eq!(status.pause_reason.as_deref(), Some("conflict"));
+
+    // The conflict is visible through the same API the Conflict screen and the
+    // merge resolver window use.
+    let sides = backend
+        .conflict_sides(&handle.id, std::path::Path::new("shared.txt"))
+        .unwrap();
+    assert!(sides.ours.is_some(), "ours side missing: {sides:?}");
+    assert!(sides.theirs.is_some(), "theirs side missing: {sides:?}");
+
+    // Resolve and continue.
+    write_file(tr.path(), "shared.txt", "resolved by hand\n");
+    backend
+        .stage(&handle.id, &[std::path::PathBuf::from("shared.txt")])
+        .unwrap();
+    let done = backend.rebase_continue(&handle.id).unwrap();
+    assert!(!done.in_progress, "continue should finish the plan");
+
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(
+        head.parent_count(),
+        2,
+        "the resumed step must still be a merge"
+    );
+    assert_eq!(head.summary().unwrap(), "Merge branch 'feature'");
+    assert_eq!(
+        std::fs::read_to_string(tr.path().join("shared.txt")).unwrap(),
+        "resolved by hand\n",
+        "the user's resolution is what gets committed, not the original merge's"
+    );
+    assert!(
+        !tr.repo.head_detached().unwrap(),
+        "HEAD reattached on completion"
+    );
+}

--- a/src-tauri/tests/rebase_validation.rs
+++ b/src-tauri/tests/rebase_validation.rs
@@ -21,6 +21,8 @@ fn step(oid: &str, action: RebaseAction) -> RebaseStep {
         oid: oid.to_string(),
         action,
         message: None,
+        onto: None,
+        merge_parents: Vec::new(),
     }
 }
 

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -1978,6 +1978,7 @@ const REBASE_ACTION_STYLE: Record<RebaseAction, { label: string; color: string }
   Fixup: { label: "fixup", color: "var(--accent-2)" },
   Drop: { label: "drop", color: "var(--git-removed)" },
   MainlinePick: { label: "keep as one", color: "var(--accent-3)" },
+  Merge: { label: "merge", color: "var(--accent-4)" },
 };
 
 const DEFAULT_REBASE_ACTIONS: RebaseAction[] = [

--- a/src/features/commits/buildPreservePlan.test.ts
+++ b/src/features/commits/buildPreservePlan.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { buildPreservePlan } from "./buildPreservePlan";
+import type { CommitInfo } from "@/lib/types";
+
+function mk(oid: string, summary: string, parents: string[]): CommitInfo {
+  return {
+    oid,
+    shortOid: oid.slice(0, 7),
+    summary,
+    body: null,
+    author: "Test",
+    email: "t@e.com",
+    timestamp: 0,
+    parents,
+    refs: [],
+  };
+}
+
+const M = "m".repeat(40);
+const C = "c".repeat(40);
+const F = "f".repeat(40);
+const A = "a".repeat(40);
+const BASE = "0".repeat(40);
+
+/** root..M, newest-first — the shape `commitsSince` returns. */
+const range: CommitInfo[] = [
+  mk(M, "Merge branch 'feature'", [C, F]),
+  mk(C, "C on main", [A]),
+  mk(F, "F on feature", [A]),
+  mk(A, "A on main", [BASE]),
+];
+
+describe("buildPreservePlan", () => {
+  it("emits oldest-first steps that name their own base where it differs", () => {
+    const plan = buildPreservePlan(range);
+    expect(plan.map((s) => s.oid)).toEqual([A, F, C, M]);
+
+    // A: its parent is below the range → linear default.
+    expect(plan[0]).toMatchObject({ action: "Pick", onto: null, mergeParents: [] });
+    // F: parent A is the previous step's result → linear default.
+    expect(plan[1]).toMatchObject({ action: "Pick", onto: null });
+    // C: parent A is NOT the previous step (F was) → must name it.
+    expect(plan[2]).toMatchObject({ action: "Pick", onto: A });
+    // M: first parent C is the previous step; the other parent is carried.
+    expect(plan[3]).toMatchObject({ action: "Merge", onto: null, mergeParents: [F] });
+  });
+
+  it("leaves a linear range with no onto at all", () => {
+    const linear = [mk(C, "C", [A]), mk(A, "A", [BASE])];
+    const plan = buildPreservePlan(linear);
+    expect(plan.map((s) => s.onto)).toEqual([null, null]);
+    expect(plan.every((s) => s.action === "Pick")).toBe(true);
+  });
+
+  it("carries an out-of-range merge parent through unchanged", () => {
+    // A parent that lives below the range was never rewritten; the engine falls
+    // back to its original oid, so the plan just passes it along.
+    const outside = "9".repeat(40);
+    const withOutside = [mk(M, "Merge external", [C, outside]), mk(C, "C", [A])];
+    const plan = buildPreservePlan(withOutside);
+    const merge = plan.find((s) => s.oid === M)!;
+    expect(merge.action).toBe("Merge");
+    expect(merge.mergeParents).toEqual([outside]);
+  });
+});

--- a/src/features/commits/buildPreservePlan.ts
+++ b/src/features/commits/buildPreservePlan.ts
@@ -1,0 +1,42 @@
+import type { CommitInfo, RebaseStep } from "@/lib/types";
+
+/**
+ * Build a topology-preserving plan for `range` — the commits between a base and
+ * HEAD, newest-first, exactly as `commitsSince` returns them.
+ *
+ * git expresses topology in its todo file with `label` / `reset` / `merge
+ * <label>` because a human edits that file. A generated plan does not need the
+ * naming layer: every step names the ORIGINAL commit it must be applied onto,
+ * and the engine resolves that through its rewritten map. `onto: null` means
+ * "onto the previous step's result", so a linear range produces exactly the plan
+ * it did before this existed.
+ *
+ * Step order is the reverse of the log walk, which is TIME | TOPOLOGICAL —
+ * parents always precede children. Grouping does not affect correctness, because
+ * each step carries its own base.
+ */
+export function buildPreservePlan(range: CommitInfo[]): RebaseStep[] {
+  const oldestFirst = [...range].reverse();
+
+  return oldestFirst.map((c, i): RebaseStep => {
+    const firstParent = c.parents[0] ?? null;
+    const previousOid = i > 0 ? oldestFirst[i - 1].oid : null;
+    const isMerge = c.parents.length > 1;
+
+    // Only name a base when it is not where the replay already sits. Naming it
+    // unconditionally would work, but it would make every step a reset and hide
+    // the linear default from anyone reading the plan. The first step's base is
+    // the range's base, which `rebase_start` derives from its first parent, so
+    // it stays null too.
+    const onto =
+      i > 0 && firstParent && firstParent !== previousOid ? firstParent : null;
+
+    return {
+      oid: c.oid,
+      action: isMerge ? "Merge" : "Pick",
+      message: null,
+      onto,
+      mergeParents: isMerge ? c.parents.slice(1) : [],
+    };
+  });
+}

--- a/src/features/rebase/useRebaseMergeMode.ts
+++ b/src/features/rebase/useRebaseMergeMode.ts
@@ -1,0 +1,33 @@
+// Flatten ⇄ preserve for merge commits in a rebase plan, persisted like the
+// other per-surface view preferences: localStorage, best-effort, never fatal.
+//
+// "flatten" is the default because it is git's own (`git rebase -i` drops merge
+// commits and linearises); "preserve" is the `--rebase-merges` equivalent and
+// carries costs the Rebase screen states up front.
+
+import React from "react";
+
+export type RebaseMergeMode = "flatten" | "preserve";
+
+const STORAGE_KEY = "pg-rebase-merge-mode";
+
+function read(): RebaseMergeMode {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "preserve" ? "preserve" : "flatten";
+  } catch {
+    return "flatten";
+  }
+}
+
+export function useRebaseMergeMode(): [RebaseMergeMode, (m: RebaseMergeMode) => void] {
+  const [mode, setMode] = React.useState<RebaseMergeMode>(read);
+  const update = React.useCallback((m: RebaseMergeMode) => {
+    setMode(m);
+    try {
+      localStorage.setItem(STORAGE_KEY, m);
+    } catch {
+      // non-fatal — the session just won't remember the choice
+    }
+  }, []);
+  return [mode, update];
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -232,7 +232,9 @@ export type RebaseAction =
   | "Fixup"
   | "Drop"
   /** A merge commit kept as one ordinary commit — `git cherry-pick -m 1`. */
-  | "MainlinePick";
+  | "MainlinePick"
+  /** A merge commit recreated from its rewritten parents (`--rebase-merges`). */
+  | "Merge";
 
 export interface RebaseStep {
   oid: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -238,6 +238,14 @@ export interface RebaseStep {
   oid: string;
   action: RebaseAction;
   message: string | null;
+  /**
+   * Original oid this step is applied onto; omitted/null = onto the previous
+   * step's result (the linear default). How a plan expresses topology without
+   * git's label/reset todo language.
+   */
+  onto?: string | null;
+  /** A merge step's original parents beyond the first. */
+  mergeParents?: string[];
 }
 
 export interface RebaseStatus {

--- a/src/screens/Rebase.preserve.test.tsx
+++ b/src/screens/Rebase.preserve.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { RebaseScreen } from "./Rebase";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { mockInvoke } from "@/test/invokeMock";
+import type { CommitInfo, RebaseStatus, RepoHandle } from "@/lib/types";
+
+const handle: RepoHandle = { id: "repo-1", path: "/tmp/fake-repo", head: "refs/heads/main" };
+const SWEPT: RebaseStatus = { inProgress: false, nextIndex: 0, total: 0, pauseReason: null };
+
+function mk(oid: string, summary: string, parents: string[]): CommitInfo {
+  return {
+    oid,
+    shortOid: oid.slice(0, 7),
+    summary,
+    body: null,
+    author: "Tester",
+    email: "t@e.com",
+    timestamp: 1_700_000_000,
+    parents,
+    refs: [],
+  };
+}
+
+const M = "m".repeat(40);
+const C = "c".repeat(40);
+const F = "f".repeat(40);
+const A = "a".repeat(40);
+const commits = [
+  mk(M, "Merge branch 'feature'", [C, F]),
+  mk(C, "C on main", [A]),
+  mk(F, "F on feature", [A]),
+  mk(A, "A on main", ["0".repeat(40)]),
+];
+
+beforeEach(() => {
+  localStorage.clear();
+  useRepoStore.setState({
+    current: handle,
+    status: [],
+    allFiles: [],
+    branches: [],
+    tags: [],
+    stashes: [],
+    remotes: [],
+    commits,
+    loading: false,
+    error: null,
+    repoState: "Clean",
+    rebaseStatus: SWEPT,
+    lastRebaseSummary: null,
+    activity: {},
+  });
+  mockInvoke("rebase_status", () => SWEPT);
+  useNavStore.setState({
+    intent: {
+      kind: "rebase-plan",
+      plan: [
+        { oid: F, action: "Pick", message: null },
+        { oid: C, action: "Pick", message: null },
+        { oid: M, action: "Drop", message: null },
+      ],
+    },
+  });
+});
+
+describe("RebaseScreen preserve mode", () => {
+  it("switching to preserve turns the merge row into a Merge step", async () => {
+    render(<RebaseScreen />);
+    await screen.findAllByTestId("rebase-row");
+
+    await userEvent.click(screen.getByTestId("rebase-merge-mode-preserve"));
+
+    const rows = screen.getAllByTestId("rebase-row");
+    const mergeRow = rows.find((r) => r.getAttribute("data-sha") === M.slice(0, 7))!;
+    expect(mergeRow.getAttribute("data-action")).toBe("Merge");
+    expect(
+      [...mergeRow.querySelectorAll("option")].map((o) => o.getAttribute("value")),
+    ).toEqual(["Merge", "Drop"]);
+  });
+
+  it("states the cost of preserving and disables reordering", async () => {
+    render(<RebaseScreen />);
+    await screen.findAllByTestId("rebase-row");
+    await userEvent.click(screen.getByTestId("rebase-merge-mode-preserve"));
+
+    const warning = screen.getByTestId("rebase-merge-warning");
+    expect(warning.textContent).toContain("recreated");
+    expect(warning.textContent).toContain("not preserved");
+    expect(warning.textContent).toContain("Reordering is disabled");
+
+    expect(screen.queryAllByTestId("rebase-move-up")).toHaveLength(0);
+    expect(screen.queryAllByTestId("rebase-move-down")).toHaveLength(0);
+  });
+
+  it("remembers the mode across mounts", async () => {
+    const first = render(<RebaseScreen />);
+    await screen.findAllByTestId("rebase-row");
+    await userEvent.click(screen.getByTestId("rebase-merge-mode-preserve"));
+    first.unmount();
+
+    render(<RebaseScreen />);
+    expect(await screen.findByTestId("rebase-merge-mode-preserve")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("flatten stays the default and keeps reordering", async () => {
+    render(<RebaseScreen />);
+    await screen.findAllByTestId("rebase-row");
+    expect(screen.getByTestId("rebase-merge-mode-flatten")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.queryAllByTestId("rebase-move-up").length).toBeGreaterThan(0);
+  });
+});

--- a/src/screens/Rebase.tsx
+++ b/src/screens/Rebase.tsx
@@ -9,6 +9,11 @@ import { appErrorMessage } from "@/lib/errors";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { RebaseBasePicker } from "@/features/rebase/RebaseBasePicker";
+import {
+  useRebaseMergeMode,
+  type RebaseMergeMode,
+} from "@/features/rebase/useRebaseMergeMode";
+import { buildPreservePlan } from "@/features/commits/buildPreservePlan";
 import { PGPane, FocusableScroll } from "@/features/keymap";
 
 // ─── Plan row state ───────────────────────────────────────────────────────────
@@ -21,6 +26,10 @@ interface PlanRow {
   message: string;
   /** More than one parent — actions are restricted and the row is badged. */
   isMerge: boolean;
+  /** Original oid this step is replayed onto; null = onto the previous step. */
+  onto: string | null;
+  /** A merge row's original parents beyond the first. */
+  mergeParents: string[];
 }
 
 /**
@@ -28,23 +37,57 @@ interface PlanRow {
  * on the backend. Keep the two in sync or the UI offers an action the backend
  * refuses on submit.
  */
-const MERGE_ACTIONS: RebaseAction[] = ["Drop", "MainlinePick"];
+const MERGE_ACTIONS_FLATTEN: RebaseAction[] = ["Drop", "MainlinePick"];
+const MERGE_ACTIONS_PRESERVE: RebaseAction[] = ["Merge", "Drop"];
 
-function commitsToPlan(commits: CommitInfo[]): PlanRow[] {
-  // Present commits oldest-first (log is newest-first).
-  return [...commits].reverse().map((c) => {
-    const isMerge = c.parents.length > 1;
+function mergeActionsFor(mode: RebaseMergeMode): RebaseAction[] {
+  return mode === "preserve" ? MERGE_ACTIONS_PRESERVE : MERGE_ACTIONS_FLATTEN;
+}
+
+/**
+ * Rows for a whole range, honouring the merge mode. Flatten drops merges (git's
+ * own behaviour, so the branch comes out linear); preserve emits a
+ * topology-aware plan where each step names the base it must sit on.
+ */
+function commitsToPlan(commits: CommitInfo[], mode: RebaseMergeMode): PlanRow[] {
+  const byOid = new Map(commits.map((c) => [c.oid, c]));
+  const steps: RebaseStep[] =
+    mode === "preserve"
+      ? buildPreservePlan(commits)
+      : // Flatten: oldest-first, merges dropped.
+        [...commits].reverse().map((c) => ({
+          oid: c.oid,
+          action: (c.parents.length > 1 ? "Drop" : "Pick") as RebaseAction,
+          message: null,
+          onto: null,
+          mergeParents: [],
+        }));
+
+  return steps.map((step) => {
+    const c = byOid.get(step.oid);
     return {
-      oid: c.oid,
-      shortOid: c.shortOid,
-      subject: c.summary,
-      // A merge defaults to Drop: git's own flattening behaviour, and the only
-      // other action the backend accepts on one is MainlinePick.
-      action: (isMerge ? "Drop" : "Pick") as RebaseAction,
-      message: "",
-      isMerge,
+      oid: step.oid,
+      shortOid: c?.shortOid ?? step.oid.slice(0, 7),
+      subject: c?.summary ?? "",
+      action: step.action,
+      message: step.message ?? "",
+      isMerge: (c?.parents.length ?? 0) > 1,
+      onto: step.onto ?? null,
+      mergeParents: step.mergeParents ?? [],
     };
   });
+}
+
+/**
+ * True when every step is a plain pick/drop with no message — the shape a whole
+ * range produces. A targeted plan (squash/fixup/reword, or one carrying a
+ * message) is NOT rebuilt when the merge mode changes: doing so would silently
+ * throw away the message the user just typed.
+ */
+function isPlainPlan(steps: RebaseStep[]): boolean {
+  return steps.every(
+    (s) => (s.action === "Pick" || s.action === "Drop") && !s.message,
+  );
 }
 
 // ─── Progress banner ─────────────────────────────────────────────────────────
@@ -140,6 +183,11 @@ export function RebaseScreen() {
   } = useRepoStore();
 
   const [plan, setPlan] = useState<PlanRow[]>([]);
+  const [mergeMode, setMergeMode] = useRebaseMergeMode();
+  // The range the plan was built from, newest-first, kept so flipping the merge
+  // mode can rebuild without asking the backend again. Empty for a targeted plan
+  // (squash/fixup/reword), which the mode must not rebuild — see isPlainPlan.
+  const [range, setRange] = useState<CommitInfo[]>([]);
   const [baseLabel, setBaseLabel] = useState<string | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pickerNotice, setPickerNotice] = useState<string | null>(null);
@@ -158,7 +206,8 @@ export function RebaseScreen() {
           setPickerNotice(`No commits between HEAD and ${baseName}.`);
           return;
         }
-        setPlan(commitsToPlan(range));
+        setRange(range);
+        setPlan(commitsToPlan(range, mergeMode));
         setBaseLabel(label);
         setPickerNotice(null);
         setPickerOpen(false);
@@ -175,20 +224,35 @@ export function RebaseScreen() {
   React.useEffect(() => {
     if (intent?.kind !== "rebase-plan") return;
     const byOid = new Map(commits.map((c) => [c.oid, c]));
-    const rows: PlanRow[] = intent.plan.map((step) => {
-      const c = byOid.get(step.oid);
-      const isMerge = (c?.parents.length ?? 0) > 1;
-      return {
-        oid: step.oid,
-        shortOid: c?.shortOid ?? step.oid.slice(0, 7),
-        subject: c?.summary ?? "",
-        // A caller that hands us something the backend refuses on a merge (an
-        // older plan, a hand-built intent) gets the flattening default instead.
-        action: isMerge && !MERGE_ACTIONS.includes(step.action) ? "Drop" : step.action,
-        message: step.message ?? "",
-        isMerge,
-      };
-    });
+    const inRange = intent.plan
+      .map((s) => byOid.get(s.oid))
+      .filter((c): c is CommitInfo => c != null);
+    // A plain whole-range plan is rebuilt from the range when the merge mode
+    // flips; a targeted one (squash/fixup/reword) is kept exactly as handed over.
+    const rebuildable = isPlainPlan(intent.plan) && inRange.length === intent.plan.length;
+    setRange(rebuildable ? [...inRange].reverse() : []);
+
+    const rows: PlanRow[] = rebuildable
+      ? commitsToPlan([...inRange].reverse(), mergeMode)
+      : intent.plan.map((step) => {
+          const c = byOid.get(step.oid);
+          const isMerge = (c?.parents.length ?? 0) > 1;
+          return {
+            oid: step.oid,
+            shortOid: c?.shortOid ?? step.oid.slice(0, 7),
+            subject: c?.summary ?? "",
+            // A caller that hands us something the backend refuses on a merge
+            // (an older plan, a hand-built intent) gets the flattening default.
+            action:
+              isMerge && !mergeActionsFor(mergeMode).includes(step.action)
+                ? "Drop"
+                : step.action,
+            message: step.message ?? "",
+            isMerge,
+            onto: step.onto ?? null,
+            mergeParents: step.mergeParents ?? [],
+          };
+        });
     setPlan(rows);
     // The base of a context-menu plan is the parent of the oldest step.
     const oldest = rows[0];
@@ -203,7 +267,13 @@ export function RebaseScreen() {
           : "selected commit",
     );
     clearIntent();
-  }, [intent, commits, clearIntent]);
+  }, [intent, commits, clearIntent, mergeMode]);
+
+  // Flipping the mode rebuilds a whole-range plan in place.
+  React.useEffect(() => {
+    if (range.length === 0) return;
+    setPlan(commitsToPlan(range, mergeMode));
+  }, [mergeMode, range]);
 
   const updateRow = useCallback(
     (index: number, patch: Partial<PlanRow>) => {
@@ -229,6 +299,8 @@ export function RebaseScreen() {
       oid: r.oid,
       action: r.action,
       message: r.action === "Reword" || r.action === "Squash" ? (r.message || null) : null,
+      onto: r.onto,
+      mergeParents: r.mergeParents,
     }));
     const status = await rebaseStart(steps);
     // The rebase consumed the plan — clear it so the completion summary (or
@@ -242,6 +314,7 @@ export function RebaseScreen() {
 
   const handleClear = () => {
     setPlan([]);
+    setRange([]);
     setBaseLabel(null);
   };
 
@@ -309,6 +382,25 @@ export function RebaseScreen() {
                 base: {baseLabel}
               </span>
             )}
+            <div style={{ display: "flex", gap: 2 }}>
+              {(["flatten", "preserve"] as const).map((m) => (
+                <PGButton
+                  key={m}
+                  size="sm"
+                  variant={mergeMode === m ? "primary" : "ghost"}
+                  aria-pressed={mergeMode === m}
+                  data-testid={`rebase-merge-mode-${m}`}
+                  onClick={() => setMergeMode(m)}
+                  title={
+                    m === "flatten"
+                      ? "Drop merge commits and replay their commits individually (git's default)"
+                      : "Recreate merge commits, keeping the branch structure"
+                  }
+                >
+                  {m === "flatten" ? "Flatten merges" : "Preserve merges"}
+                </PGButton>
+              ))}
+            </div>
             <PGButton
               size="sm"
               variant={baseLabel ? "outline" : "primary"}
@@ -363,19 +455,30 @@ export function RebaseScreen() {
               <span>
                 {mergeCount === 1 ? "1 merge commit" : `${mergeCount} merge commits`} in
                 this range.{" "}
-                {flattenedCount > 0 && (
+                {mergeMode === "flatten" ? (
                   <>
-                    {flattenedCount === mergeCount
-                      ? mergeCount === 1
-                        ? "It will be"
-                        : "They will be"
-                      : `${flattenedCount} will be`}{" "}
-                    dropped and the merged commits replayed individually — the branch
-                    becomes linear.{" "}
+                    {flattenedCount > 0 && (
+                      <>
+                        {flattenedCount === mergeCount
+                          ? mergeCount === 1
+                            ? "It will be"
+                            : "They will be"
+                          : `${flattenedCount} will be`}{" "}
+                        dropped and the merged commits replayed individually — the
+                        branch becomes linear.{" "}
+                      </>
+                    )}
+                    Choose <strong>keep as one</strong> on a merge row to keep it as a
+                    single commit instead.
+                  </>
+                ) : (
+                  <>
+                    They will be recreated by re-merging their new parents. Conflict
+                    resolutions and manual edits inside the original merges are{" "}
+                    <strong>not preserved</strong> and may need redoing. Reordering is
+                    disabled in this mode.
                   </>
                 )}
-                Choose <strong>keep as one</strong> on a merge row to keep it as a
-                single commit instead.
               </span>
             </div>
           )}
@@ -413,33 +516,41 @@ export function RebaseScreen() {
                         subject={row.subject}
                         action={row.action}
                         badge={row.isMerge ? "merge" : undefined}
-                        options={row.isMerge ? MERGE_ACTIONS : undefined}
+                        options={row.isMerge ? mergeActionsFor(mergeMode) : undefined}
                         onActionChange={(v) => updateRow(i, { action: v })}
                       />
                     </div>
-                    <div
-                      style={{
-                        display: "flex",
-                        flexDirection: "column",
-                        gap: 2,
-                        flexShrink: 0,
-                      }}
-                    >
-                      <PGButton
-                        size="xs"
-                        variant="ghost"
-                        icon="chevronUp"
-                        onClick={() => moveRow(i, -1)}
-                        style={{ opacity: i === 0 ? 0.3 : 1, pointerEvents: i === 0 ? "none" : undefined }}
-                      />
-                      <PGButton
-                        size="xs"
-                        variant="ghost"
-                        icon="chevronDown"
-                        onClick={() => moveRow(i, 1)}
-                        style={{ opacity: i === plan.length - 1 ? 0.3 : 1, pointerEvents: i === plan.length - 1 ? "none" : undefined }}
-                      />
-                    </div>
+                    {/* Reordering is not offered while preserving merges: git
+                        documents its own reorder bugs under --rebase-merges, and
+                        a reorder that silently produces the wrong topology is
+                        worse than no reorder. */}
+                    {mergeMode === "flatten" && (
+                      <div
+                        style={{
+                          display: "flex",
+                          flexDirection: "column",
+                          gap: 2,
+                          flexShrink: 0,
+                        }}
+                      >
+                        <PGButton
+                          size="xs"
+                          variant="ghost"
+                          icon="chevronUp"
+                          data-testid="rebase-move-up"
+                          onClick={() => moveRow(i, -1)}
+                          style={{ opacity: i === 0 ? 0.3 : 1, pointerEvents: i === 0 ? "none" : undefined }}
+                        />
+                        <PGButton
+                          size="xs"
+                          variant="ghost"
+                          icon="chevronDown"
+                          data-testid="rebase-move-down"
+                          onClick={() => moveRow(i, 1)}
+                          style={{ opacity: i === plan.length - 1 ? 0.3 : 1, pointerEvents: i === plan.length - 1 ? "none" : undefined }}
+                        />
+                      </div>
+                    )}
                   </div>
 
                   {/* Message textarea for reword / squash */}


### PR DESCRIPTION
## What

PR3 of three from `docs/superpowers/specs/2026-08-14-rebase-merge-commits-design.md`
(PR1 #110, PR2 #112). Interactive rebase can now keep branch topology — the
equivalent of `git rebase --rebase-merges`, opt-in behind a toggle that states its
costs.

- **`RebaseStep.onto`** names the original commit a step is applied onto; the
  engine resolves it through the rewritten map and resets the detached HEAD there
  first. That replaces git's `label` / `reset` todo language — every commit is
  implicitly its own label, so the plan stays a flat list and a linear range still
  produces exactly the plan it did before (`onto: null` throughout).
- **`RebaseAction::Merge`** re-merges a merge's rewritten parents and commits with
  the original message, author, and parent count. The merge runs in the
  **worktree**, so a conflict lands in the index with stages: `conflict_sides`,
  the Conflict screen, and the merge resolver window all work unchanged, and
  continuing commits the resolution as a two-parent merge. Resolutions recorded
  inside the original merge are not reused — git does not either.
- **Octopus merges are refused explicitly** (drop or keep-as-one instead) rather
  than mis-recreated.
- **A persisted Flatten ⇄ Preserve toggle** in the Rebase screen. Preserve states
  that original resolutions are not preserved and disables reordering, matching
  git's own documented limitation. It rebuilds a whole-range plan in place but
  deliberately leaves a targeted plan (squash/fixup/reword) alone — rebuilding
  one would discard the message the user just typed.
- **Fixes an ORIG_HEAD bug the new spec exposed:** a hard reset writes its own
  ORIG_HEAD, so the resets this engine performs mid-replay left a mid-rebase
  commit there and broke `git reset --hard ORIG_HEAD` as the escape hatch PR1
  documented. It is now re-asserted on every state transition, with a Rust guard.

## Testing

- `cargo test` — 39 binaries green. New `rebase_preserve.rs` (8): `onto` replays a
  step at its own branch point, unknown `onto` rejected before anything moves, a
  clean recreate whose parents are the rewritten copies, non-merge / no-parent /
  octopus rejections, ORIG_HEAD survives the replay's resets, and a conflicting
  recreate that pauses with `conflict_sides` populated and resumes into a
  two-parent merge.
- `pnpm test` — 861 pass. New: `buildPreservePlan.test.ts`,
  `Rebase.preserve.test.tsx`.
- `pnpm tsc --noEmit`, `pnpm exec tsc -p e2e/tsconfig.json --noEmit`,
  `cargo check` — clean.
- `pnpm test:e2e:docker full --spec e2e/specs/rebase.e2e.ts` — 4 passing,
  including a real preserving run that asserts the merge survives with its first
  parent the mainline commit and its second the side branch.

Note on oids: a faithful replay of unchanged commits onto the same base
reproduces them byte for byte, so the recreated merge legitimately keeps the
original's oid. The specs assert topology and ORIG_HEAD rather than asserting the
oid changed, which would be asserting the engine corrupts something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)