### PR TITLE
feat(history): HEAD indicator becomes six marks and a weight knob

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,7 +306,12 @@ features/            Per-feature: components + Zustand store colocated
 ├── rebase/          RebaseBasePicker + useRebaseMergeMode (persisted
 │                    flatten ⇄ preserve for merge commits in a plan)
 ├── reflog/          useReflogStore, DirtyTreeDialog, ReflogActionDialog
-├── settings/        useSettingsStore (autoFetch, defaultPullMode, etc.)
+├── settings/        useSettingsStore (autoFetch, defaultPullMode, etc.),
+│                    headMarks (the HEAD row treatment: independent marks ×
+│                    one weight, resolved to draw numbers by resolveHeadDecor —
+│                    zero means "don't draw", so PGCommitRow never reads the
+│                    mark list) + HeadMarksControl (checkbox grid, weight knob,
+│                    and a live preview built from the real PGCommitRow)
 ├── palette/         usePaletteStore (step stack + chips), commands (catalog),
 │                    frecency, CommandPalette (⌘P runner: nav + search + actions;
 │                    rows show live keymap chords via PaletteItem.actionId)

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -13,12 +13,13 @@ import {
   PGCheckbox,
   PGSelect,
 } from "./primitives";
+import { useDensityStep } from "@/features/settings/useSettingsStore";
 import {
-  useDensityStep,
-  type HeadIndicator,
-} from "@/features/settings/useSettingsStore";
+  NO_HEAD_DECOR,
+  type HeadDecor,
+} from "@/features/settings/headMarks";
 import { FOLDER_ICON_COLOR, fileIconSpec } from "@/lib/fileIcon";
-import { commitRowGrid, laneX } from "./graph-geometry";
+import { GRAPH_PAD, commitRowGrid, laneX } from "./graph-geometry";
 import type { WindowRange } from "@/lib/useWindowedList";
 import type { RebaseAction } from "@/lib/types";
 
@@ -1074,6 +1075,9 @@ export interface GraphNode {
   head?: boolean;
 }
 
+/** Radius of the HEAD ring — outside the 4px dot, so dot styles stay readable. */
+const HEAD_RING_R = 6.5;
+
 /**
  * `height` is REQUIRED and must be the caller's actual row pitch in px.
  *
@@ -1094,6 +1098,8 @@ export const PGGraphRow = React.memo(function PGGraphRow({
   width,
   height,
   clamped,
+  ringStroke = 1,
+  ringGlow = 0,
 }: {
   lanes?: GraphLane[];
   node?: GraphNode;
@@ -1101,7 +1107,27 @@ export const PGGraphRow = React.memo(function PGGraphRow({
   height: number;
   /** Lane count exceeds what the clamped width can show — fade the right edge. */
   clamped?: boolean;
+  /**
+   * Weight of the HEAD ring, from the user's head marks. `0` drops the ring
+   * entirely — the graph ring is opt-out now, not unconditional. The default is
+   * the hairline circle the graph has always drawn, so a caller with no notion
+   * of the HEAD settings renders exactly as before.
+   *
+   * Two scalars rather than one object on purpose: this component is memoized,
+   * and a `{stroke, glow}` literal built per row would be a fresh reference
+   * every render and skip the memo every time.
+   */
+  ringStroke?: number;
+  /** Width of the translucent halo under the ring. `0` for none. */
+  ringGlow?: number;
 }) {
+  // The halo is a wider stroke on the SAME circle, so its outer edge must stay
+  // inside the gutter's left pad — otherwise column 0's ring is clipped by the
+  // SVG viewport with no overflow and no warning (the #68 G1 failure mode).
+  const ringGlowW =
+    ringGlow > 0
+      ? Math.min(ringStroke + ringGlow * 1.5, (GRAPH_PAD - HEAD_RING_R - 0.5) * 2)
+      : 0;
   return (
     <svg
       width={width}
@@ -1161,17 +1187,34 @@ export const PGGraphRow = React.memo(function PGGraphRow({
       {node && (
         <>
           {/* HEAD: a double ring. The outer circle sits outside the dot rather
-              than replacing it, so hollow / solid / merge stay readable. */}
-          {node.head && (
-            <circle
-              data-graph-head="true"
-              cx={laneX(node.col)}
-              cy={height / 2}
-              r="6.5"
-              fill="none"
-              stroke={node.color}
-              strokeWidth="1"
-            />
+              than replacing it, so hollow / solid / merge stay readable. The
+              halo is a second, wider, translucent circle — not a CSS filter,
+              which is the expensive way to glow one node per row in a
+              virtualized list. */}
+          {node.head && ringStroke > 0 && (
+            <>
+              {ringGlowW > 0 && (
+                <circle
+                  data-graph-head-glow="true"
+                  cx={laneX(node.col)}
+                  cy={height / 2}
+                  r={HEAD_RING_R}
+                  fill="none"
+                  stroke={node.color}
+                  strokeWidth={ringGlowW}
+                  opacity={0.25}
+                />
+              )}
+              <circle
+                data-graph-head="true"
+                cx={laneX(node.col)}
+                cy={height / 2}
+                r={HEAD_RING_R}
+                fill="none"
+                stroke={node.color}
+                strokeWidth={ringStroke}
+              />
+            </>
           )}
           <circle
             cx={laneX(node.col)}
@@ -1281,11 +1324,19 @@ export interface PGCommitRowProps {
   /** This row is the commit HEAD points at ("you are here"). */
   isHead?: boolean;
   /**
-   * How to mark that row — the user's `headIndicator` setting. Defaults to
-   * "none" so surfaces with no notion of HEAD (Reflog, Rebase) stay unchanged.
+   * How to mark that row — the user's head marks and weight, already resolved
+   * to draw numbers by `resolveHeadDecor`. Resolve it ONCE per list render and
+   * hand every row the same object: `React.memo` compares by reference, so a
+   * fresh object per row would defeat row memoization (#68 G9).
+   *
+   * Defaults to no decoration, so surfaces with no notion of HEAD (Reflog,
+   * Rebase) stay unchanged.
    */
-  headStyle?: HeadIndicator;
+  headDecor?: HeadDecor;
 }
+
+/** Accent at an alpha, carrying whatever hue the active theme set. */
+const accentA = (alpha: number) => `oklch(from var(--accent) l c h / ${alpha})`;
 
 export const COMMIT_ROW_BASE_H = 26;
 
@@ -1306,22 +1357,29 @@ export const PGCommitRow = React.memo(function PGCommitRow({
   graphW,
   clamped,
   isHead,
-  headStyle = "none",
+  headDecor = NO_HEAD_DECOR,
 }: PGCommitRowProps) {
   const [hover, setHover] = React.useState(false);
   const step = useDensityStep();
   const h = rowHeight ?? COMMIT_ROW_BASE_H + step;
-  const headBar = !!isHead && (headStyle === "bar" || headStyle === "both");
-  const headTint = !!isHead && (headStyle === "tint" || headStyle === "both");
-  // Selection outranks the HEAD tint — the selected row must stay obvious even
-  // when it IS head, and two accent washes stacked read as neither.
+  // One gate for every mark, so "this row is not HEAD" is checked once.
+  const d = isHead && !headDecor.bare ? headDecor : NO_HEAD_DECOR;
+  // Selection outranks the HEAD wash — the selected row must stay obvious even
+  // when it IS head, and two accent washes stacked read as neither. Leaving
+  // `background` undefined is what lets the [data-selected] CSS rule apply.
   const background = selected
     ? undefined
-    : headTint
-      ? "oklch(from var(--accent) l c h / 0.16)"
+    : d.tintAlpha > 0
+      ? accentA(d.tintAlpha)
       : hover
         ? "var(--bg-2)"
         : undefined;
+  // The outline is an INSET shadow, not a border: a border would change the
+  // row's box and shift every column by its width when HEAD scrolls past.
+  const outline =
+    d.outlineW > 0
+      ? `inset 0 0 0 ${d.outlineW}px ${accentA(d.outlineAlpha)}`
+      : undefined;
   return (
     <div
       data-testid="commit-row"
@@ -1348,11 +1406,12 @@ export const PGCommitRow = React.memo(function PGCommitRow({
         cursor: "pointer",
         position: "relative",
         borderBottom: "1px solid oklch(from var(--border-0) l c h / 0.5)",
+        boxShadow: outline,
       }}
     >
       {/* HEAD's bar sits first so a selected HEAD row shows the selection bar
-          on top of it — same edge, selection wins the 2px. */}
-      {headBar && (
+          on top of it — same edge, selection wins its 2px. */}
+      {d.barW > 0 && (
         <span
           data-testid="commit-head-bar"
           style={{
@@ -1360,9 +1419,9 @@ export const PGCommitRow = React.memo(function PGCommitRow({
             left: 0,
             top: 0,
             bottom: 0,
-            width: 3,
+            width: d.barW,
             background: "var(--accent)",
-            boxShadow: "0 0 6px oklch(from var(--accent) l c h / 0.6)",
+            boxShadow: `0 0 ${d.barGlow}px ${accentA(0.65)}`,
           }}
         />
       )}
@@ -1385,6 +1444,8 @@ export const PGCommitRow = React.memo(function PGCommitRow({
           width={graphW}
           height={h}
           clamped={clamped}
+          ringStroke={d.ringStroke}
+          ringGlow={d.ringGlow}
         />
       )}
       <span style={{ color: "var(--fg-3)", fontSize: "var(--fs-11)" }}>{sha}</span>
@@ -1397,6 +1458,22 @@ export const PGCommitRow = React.memo(function PGCommitRow({
           paddingRight: 10,
         }}
       >
+        {/* Ahead of the branch pills: the one mark that says "you are here" in
+            words rather than in color, for anyone who can't separate the accent
+            wash from a hover. */}
+        {d.badge && (
+          <PGBadge
+            tone="accent"
+            style={{
+              flexShrink: 0,
+              borderColor: accentA(0.7),
+              boxShadow:
+                d.badgeGlow > 0 ? `0 0 ${d.badgeGlow}px ${accentA(0.5)}` : undefined,
+            }}
+          >
+            <span data-testid="commit-head-badge">HEAD</span>
+          </PGBadge>
+        )}
         {refs?.map((r, i) => (
           <PGBranchPill
             key={i}
@@ -1412,11 +1489,13 @@ export const PGCommitRow = React.memo(function PGCommitRow({
           </PGBadge>
         )}
         <span
+          data-testid="commit-subject"
           style={{
             color: "var(--fg-0)",
             whiteSpace: "nowrap",
             overflow: "hidden",
             textOverflow: "ellipsis",
+            fontWeight: d.subjectWeight || undefined,
           }}
         >
           {message}

--- a/src/design/primitives.tsx
+++ b/src/design/primitives.tsx
@@ -434,6 +434,8 @@ export interface PGCheckboxProps {
   label?: ReactNode;
   indeterminate?: boolean;
   disabled?: boolean;
+  /** Lands on the <label>, matching PGToggle — this component spreads no rest. */
+  testId?: string;
 }
 
 export function PGCheckbox({
@@ -442,9 +444,11 @@ export function PGCheckbox({
   label,
   indeterminate,
   disabled,
+  testId,
 }: PGCheckboxProps) {
   return (
     <label
+      data-testid={testId}
       style={{
         display: "inline-flex",
         alignItems: "center",

--- a/src/features/settings/HeadMarksControl.test.tsx
+++ b/src/features/settings/HeadMarksControl.test.tsx
@@ -1,0 +1,82 @@
+// The Settings control: toggling marks, the weight knob, and the live preview.
+//
+// The preview is the whole reason this control exists rather than a select, so
+// it is worth a test: it must show the marks on its HEAD row and NOT on the
+// ordinary row below it, or it teaches the user the wrong thing.
+import { beforeEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { HeadMarksControl } from "./HeadMarksControl";
+import { useSettingsStore } from "./useSettingsStore";
+
+const marks = () => useSettingsStore.getState().headMarks;
+const previewRows = () =>
+  screen
+    .getByTestId("head-marks-preview")
+    .querySelectorAll<HTMLElement>('[data-testid="commit-row"]');
+
+beforeEach(() => {
+  localStorage.clear();
+  useSettingsStore.getState().set("headMarks", ["bar", "tint", "ring"]);
+  useSettingsStore.getState().set("headWeight", "strong");
+});
+
+describe("HeadMarksControl", () => {
+  it("toggles a mark on and back off", async () => {
+    const user = userEvent.setup();
+    render(<HeadMarksControl />);
+
+    await user.click(screen.getByTestId("head-mark-badge"));
+    expect(marks()).toContain("badge");
+
+    await user.click(screen.getByTestId("head-mark-badge"));
+    expect(marks()).not.toContain("badge");
+  });
+
+  it("stores marks in catalog order however they are clicked", async () => {
+    const user = userEvent.setup();
+    useSettingsStore.getState().set("headMarks", []);
+    render(<HeadMarksControl />);
+
+    // Clicked back-to-front on purpose.
+    await user.click(screen.getByTestId("head-mark-ring"));
+    await user.click(screen.getByTestId("head-mark-bar"));
+    expect(marks()).toEqual(["bar", "ring"]);
+  });
+
+  it("switches weight and says what the choice means", async () => {
+    const user = userEvent.setup();
+    render(<HeadMarksControl />);
+
+    await user.click(screen.getByRole("button", { name: "Intense" }));
+    expect(useSettingsStore.getState().headWeight).toBe("intense");
+    expect(screen.getByTestId("head-weight-hint")).toHaveTextContent(/readable/i);
+  });
+
+  it("previews the marks on the HEAD row only", async () => {
+    const user = userEvent.setup();
+    useSettingsStore.getState().set("headMarks", ["badge"]);
+    render(<HeadMarksControl />);
+
+    const [headRow, plainRow] = previewRows();
+    expect(headRow.querySelector('[data-testid="commit-head-badge"]')).not.toBeNull();
+    expect(plainRow.querySelector('[data-testid="commit-head-badge"]')).toBeNull();
+
+    // …and the preview tracks the controls live, not just at mount.
+    await user.click(screen.getByTestId("head-mark-bar"));
+    expect(
+      previewRows()[0].querySelector('[data-testid="commit-head-bar"]'),
+    ).not.toBeNull();
+  });
+
+  it("previews a bare row when every mark is off", async () => {
+    useSettingsStore.getState().set("headMarks", []);
+    render(<HeadMarksControl />);
+
+    const headRow = previewRows()[0];
+    expect(headRow.querySelector('[data-testid="commit-head-bar"]')).toBeNull();
+    expect(headRow.querySelector("[data-graph-head]")).toBeNull();
+    expect(headRow.style.background).toBe("");
+  });
+});

--- a/src/features/settings/HeadMarksControl.tsx
+++ b/src/features/settings/HeadMarksControl.tsx
@@ -1,0 +1,152 @@
+// The Settings control for the HEAD row treatment: a checkbox per mark, one
+// weight knob, and a LIVE PREVIEW built from the real PGCommitRow.
+//
+// The preview is the point. The old single select ("Edge bar", "Bar +
+// highlight", …) asked the user to imagine the result from a label; with six
+// independent marks and three weights that would be hopeless. Rendering the
+// actual row component means the preview cannot drift from History either.
+import React from "react";
+
+import {
+  PGCheckbox,
+  PGButtonGroup,
+  PGCommitRow,
+  graphWidth,
+  type CommitRef,
+  type GraphLane,
+  type GraphNode,
+} from "@/design";
+
+import { useSettingsStore } from "./useSettingsStore";
+import {
+  HEAD_MARKS,
+  HEAD_MARK_HINTS,
+  HEAD_MARK_LABELS,
+  HEAD_WEIGHTS,
+  HEAD_WEIGHT_HINTS,
+  HEAD_WEIGHT_LABELS,
+  normalizeHeadMarks,
+  resolveHeadDecor,
+  type HeadMark,
+  type HeadWeight,
+} from "./headMarks";
+
+const PREVIEW_GRAPH_W = graphWidth(1);
+
+const LANE = (col: number, color: string): GraphLane => ({
+  col,
+  color,
+  kind: "line",
+});
+
+const NODE = (col: number, color: string, head: boolean): GraphNode => ({
+  col,
+  color,
+  solid: true,
+  ...(head && { head: true }),
+});
+
+const MAIN: CommitRef[] = [{ name: "main", tone: "accent", icon: "branch" }];
+
+/**
+ * Two rows, because a mark is only legible against the rows it is NOT on. The
+ * second row also carries a lane through the gutter so the graph ring's weight
+ * has something to be compared against.
+ */
+function Preview({ marks, weight }: { marks: HeadMark[]; weight: HeadWeight }) {
+  const decor = React.useMemo(() => resolveHeadDecor(marks, weight), [marks, weight]);
+  const c = "var(--graph-1)";
+  return (
+    <div
+      data-testid="head-marks-preview"
+      style={{
+        border: "1px solid var(--border-0)",
+        borderRadius: "var(--r-2)",
+        overflow: "hidden",
+        background: "var(--bg-0)",
+      }}
+    >
+      <PGCommitRow
+        lanes={[LANE(0, c)]}
+        node={NODE(0, c, true)}
+        graphW={PREVIEW_GRAPH_W}
+        sha="a1b2c3d"
+        message="feat(history): the commit you are on"
+        author="you"
+        date="now"
+        refs={MAIN}
+        isHead
+        headDecor={decor}
+      />
+      <PGCommitRow
+        lanes={[LANE(0, c)]}
+        node={NODE(0, c, false)}
+        graphW={PREVIEW_GRAPH_W}
+        sha="9f8e7d6"
+        message="fix(diff): an ordinary earlier commit"
+        author="someone"
+        date="2h"
+      />
+    </div>
+  );
+}
+
+/**
+ * Marks are stored through `normalizeHeadMarks`, so the persisted array stays in
+ * catalog order however the user clicks the boxes — a set, not a click log.
+ */
+export function HeadMarksControl() {
+  const marks = useSettingsStore((s) => s.headMarks);
+  const weight = useSettingsStore((s) => s.headWeight);
+  const set = useSettingsStore((s) => s.set);
+
+  const toggle = (m: HeadMark) => {
+    const next = marks.includes(m) ? marks.filter((x) => x !== m) : [...marks, m];
+    set("headMarks", normalizeHeadMarks(next) ?? marks);
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10, minWidth: 320 }}>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+          columnGap: 12,
+          rowGap: 6,
+        }}
+      >
+        {HEAD_MARKS.map((m) => (
+          <div key={m} title={HEAD_MARK_HINTS[m]}>
+            <PGCheckbox
+              checked={marks.includes(m)}
+              onChange={() => toggle(m)}
+              label={HEAD_MARK_LABELS[m]}
+              testId={`head-mark-${m}`}
+            />
+          </div>
+        ))}
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <span style={{ fontSize: "var(--fs-11)", color: "var(--fg-3)" }}>Weight</span>
+        <PGButtonGroup
+          size="sm"
+          value={weight}
+          onChange={(v) => set("headWeight", v as HeadWeight)}
+          options={HEAD_WEIGHTS.map((w) => ({
+            value: w,
+            label: HEAD_WEIGHT_LABELS[w],
+          }))}
+        />
+      </div>
+      <div
+        data-testid="head-weight-hint"
+        style={{ fontSize: "var(--fs-11)", color: "var(--fg-3)" }}
+      >
+        {HEAD_WEIGHT_HINTS[weight]}
+      </div>
+
+      <Preview marks={marks} weight={weight} />
+    </div>
+  );
+}

--- a/src/features/settings/headMarks.test.ts
+++ b/src/features/settings/headMarks.test.ts
@@ -1,0 +1,121 @@
+// The HEAD row treatment is marks × weight. These tests pin the two things a
+// renderer relies on: a mark that is off resolves to a ZERO (never a "draw it
+// anyway" default), and weight is monotonic — "intense" is heavier than
+// "strong" is heavier than "subtle" on every dimension at once.
+import { describe, expect, it } from "vitest";
+
+import {
+  HEAD_MARKS,
+  HEAD_WEIGHTS,
+  NO_HEAD_DECOR,
+  migrateHeadIndicator,
+  normalizeHeadMarks,
+  resolveHeadDecor,
+  type HeadMark,
+} from "./headMarks";
+
+describe("resolveHeadDecor", () => {
+  it("zeroes every dimension when no mark is chosen", () => {
+    const d = resolveHeadDecor([], "intense");
+    expect(d).toEqual(NO_HEAD_DECOR);
+    expect(d.bare).toBe(true);
+  });
+
+  it("draws only the mark asked for", () => {
+    const bar = resolveHeadDecor(["bar"], "strong");
+    expect(bar.barW).toBeGreaterThan(0);
+    expect(bar.tintAlpha).toBe(0);
+    expect(bar.outlineW).toBe(0);
+    expect(bar.badge).toBe(false);
+    expect(bar.subjectWeight).toBe(0);
+    expect(bar.ringStroke).toBe(0);
+
+    const tint = resolveHeadDecor(["tint"], "strong");
+    expect(tint.tintAlpha).toBeGreaterThan(0);
+    expect(tint.barW).toBe(0);
+  });
+
+  it("is not bare as soon as one mark is on", () => {
+    for (const m of HEAD_MARKS) {
+      expect(resolveHeadDecor([m], "subtle").bare).toBe(false);
+    }
+  });
+
+  it("scales every dimension monotonically with weight", () => {
+    const all = [...HEAD_MARKS] as HeadMark[];
+    const [subtle, strong, intense] = HEAD_WEIGHTS.map((w) =>
+      resolveHeadDecor(all, w),
+    );
+    const dims = [
+      "barW",
+      "barGlow",
+      "tintAlpha",
+      "outlineW",
+      "outlineAlpha",
+      "badgeGlow",
+      "subjectWeight",
+      "ringStroke",
+      "ringGlow",
+    ] as const;
+    for (const k of dims) {
+      expect(strong[k], k).toBeGreaterThanOrEqual(subtle[k] as number);
+      expect(intense[k], k).toBeGreaterThanOrEqual(strong[k] as number);
+    }
+    // …and strictly heavier where it matters most — a weight knob that moved
+    // nothing visible on the two headline marks would be a dead control.
+    expect(strong.barW).toBeGreaterThan(subtle.barW);
+    expect(intense.barW).toBeGreaterThan(strong.barW);
+    expect(strong.tintAlpha).toBeGreaterThan(subtle.tintAlpha);
+    expect(intense.tintAlpha).toBeGreaterThan(strong.tintAlpha);
+  });
+
+  it("keeps the wash under 0.5 so row text stays readable", () => {
+    for (const w of HEAD_WEIGHTS) {
+      expect(resolveHeadDecor(["tint"], w).tintAlpha).toBeLessThan(0.5);
+    }
+  });
+
+  it("falls back to the default weight for an unknown one", () => {
+    const bogus = resolveHeadDecor(["bar"], "nuclear" as never);
+    expect(bogus).toEqual(resolveHeadDecor(["bar"], "strong"));
+  });
+});
+
+describe("normalizeHeadMarks", () => {
+  it("rejects a non-array", () => {
+    expect(normalizeHeadMarks("bar")).toBeNull();
+    expect(normalizeHeadMarks(undefined)).toBeNull();
+    expect(normalizeHeadMarks({ bar: true })).toBeNull();
+  });
+
+  it("keeps an empty array — that is a real choice, not a missing value", () => {
+    expect(normalizeHeadMarks([])).toEqual([]);
+  });
+
+  it("drops unknown entries and dedupes", () => {
+    expect(normalizeHeadMarks(["bar", "glitter", "bar", 7])).toEqual(["bar"]);
+  });
+
+  it("returns marks in catalog order so the persisted value is stable", () => {
+    expect(normalizeHeadMarks(["ring", "tint", "bar"])).toEqual([
+      "bar",
+      "tint",
+      "ring",
+    ]);
+  });
+});
+
+describe("migrateHeadIndicator", () => {
+  it("maps every legacy value, always keeping the graph ring", () => {
+    expect(migrateHeadIndicator("none")).toEqual(["ring"]);
+    expect(migrateHeadIndicator("bar")).toEqual(["bar", "ring"]);
+    expect(migrateHeadIndicator("tint")).toEqual(["tint", "ring"]);
+    expect(migrateHeadIndicator("both")).toEqual(["bar", "tint", "ring"]);
+  });
+
+  it("returns null for anything it does not recognise", () => {
+    expect(migrateHeadIndicator("outline")).toBeNull();
+    expect(migrateHeadIndicator(undefined)).toBeNull();
+    expect(migrateHeadIndicator(3)).toBeNull();
+  });
+});

--- a/src/features/settings/headMarks.ts
+++ b/src/features/settings/headMarks.ts
@@ -1,0 +1,219 @@
+// ─── HEAD ("you are here") row treatment ─────────────────────────────────────
+//
+// Replaces the old `headIndicator` enum (none | bar | tint | both). That shape
+// had two problems the user hit directly: every COMBINATION needed its own
+// label, so the list read as jargon rather than choices, and there was no way
+// to ask for a *heavier* version of a mark you already had — the wash was
+// pinned at 0.16 alpha and the bar at 3px.
+//
+// So: independent MARKS (pick any subset) × one WEIGHT knob that scales all of
+// them together. Adding a mark is one entry in three records here plus one
+// branch in the renderer; it never multiplies the option list.
+
+/**
+ * One visual mark on the HEAD row, independent of the others.
+ *
+ * `ring` is the graph's own HEAD circle. It is a mark like the rest so it can
+ * be turned OFF too — it used to be unconditional, which meant "no indicator"
+ * was not actually reachable.
+ */
+export const HEAD_MARKS = [
+  "bar",
+  "tint",
+  "outline",
+  "badge",
+  "bold",
+  "ring",
+] as const;
+export type HeadMark = (typeof HEAD_MARKS)[number];
+
+export const HEAD_MARK_LABELS: Record<HeadMark, string> = {
+  bar: "Edge bar",
+  tint: "Row highlight",
+  outline: "Full outline",
+  badge: "HEAD badge",
+  bold: "Bold subject",
+  ring: "Graph ring",
+};
+
+export const HEAD_MARK_HINTS: Record<HeadMark, string> = {
+  bar: "Accent bar down the row's left edge.",
+  tint: "Washes the whole row in the accent color.",
+  outline: "Accent ring around the row. Still shows on the selected row, where the wash gives way.",
+  badge: "An accent HEAD pill beside the branch pills — names the state in words.",
+  bold: "Bolds the commit subject.",
+  ring: "The circle around HEAD's dot in the graph column.",
+};
+
+/** How hard every chosen mark hits. One knob, not a slider per mark. */
+export const HEAD_WEIGHTS = ["subtle", "strong", "intense"] as const;
+export type HeadWeight = (typeof HEAD_WEIGHTS)[number];
+
+export const HEAD_WEIGHT_LABELS: Record<HeadWeight, string> = {
+  subtle: "Subtle",
+  strong: "Strong",
+  intense: "Intense",
+};
+
+export const HEAD_WEIGHT_HINTS: Record<HeadWeight, string> = {
+  subtle: "About as loud as a hover — what the app shipped with.",
+  strong: "Roughly twice that. The default.",
+  intense: "As heavy as the row can go while its text stays readable.",
+};
+
+export const DEFAULT_HEAD_WEIGHT: HeadWeight = "strong";
+
+/**
+ * Marks + weight resolved to the numbers a renderer needs.
+ *
+ * Every dimension uses **zero for "don't draw"**, so a row component never
+ * consults the mark list — which is what keeps this decision in one place and
+ * lets `React.memo` compare a single stable object instead of an array.
+ */
+export interface HeadDecor {
+  /** Left edge bar width in px. */
+  barW: number;
+  /** Blur radius of the bar's glow, in px. */
+  barGlow: number;
+  /** Alpha of the full-row accent wash. */
+  tintAlpha: number;
+  /** Inset outline width in px. */
+  outlineW: number;
+  /** Alpha of that outline. */
+  outlineAlpha: number;
+  /** Draw the "HEAD" pill. */
+  badge: boolean;
+  /** Blur radius of the pill's glow, in px. */
+  badgeGlow: number;
+  /** Font weight for the commit subject; 0 means "inherit". */
+  subjectWeight: number;
+  /** Stroke width of the graph's HEAD ring, in SVG user units. */
+  ringStroke: number;
+  /**
+   * Width of the translucent halo drawn under that ring. A second circle
+   * rather than a CSS `filter` — the graph is SVG inside a virtualized list,
+   * and a per-row filter is the expensive way to draw a glow.
+   */
+  ringGlow: number;
+  /** No mark at all is on. Lets callers skip the whole treatment. */
+  bare: boolean;
+}
+
+interface WeightSpec {
+  barW: number;
+  barGlow: number;
+  tintAlpha: number;
+  outlineW: number;
+  outlineAlpha: number;
+  badgeGlow: number;
+  subjectWeight: number;
+  ringStroke: number;
+  ringGlow: number;
+}
+
+// `tintAlpha` stays under 0.5 at every weight on purpose: past roughly half,
+// an accent wash starts to fight the row's own foreground tokens and the sha /
+// author columns stop reading. "Intense" is the ceiling, not an invitation.
+const WEIGHTS: Record<HeadWeight, WeightSpec> = {
+  subtle: {
+    barW: 3,
+    barGlow: 4,
+    tintAlpha: 0.14,
+    outlineW: 1,
+    outlineAlpha: 0.45,
+    badgeGlow: 0,
+    subjectWeight: 500,
+    ringStroke: 1,
+    ringGlow: 0,
+  },
+  strong: {
+    barW: 5,
+    barGlow: 8,
+    tintAlpha: 0.28,
+    outlineW: 1,
+    outlineAlpha: 0.85,
+    badgeGlow: 4,
+    subjectWeight: 600,
+    ringStroke: 1.6,
+    ringGlow: 2,
+  },
+  intense: {
+    barW: 8,
+    barGlow: 14,
+    tintAlpha: 0.44,
+    outlineW: 2,
+    outlineAlpha: 1,
+    badgeGlow: 8,
+    subjectWeight: 700,
+    ringStroke: 2.2,
+    ringGlow: 4,
+  },
+};
+
+export const NO_HEAD_DECOR: HeadDecor = {
+  barW: 0,
+  barGlow: 0,
+  tintAlpha: 0,
+  outlineW: 0,
+  outlineAlpha: 0,
+  badge: false,
+  badgeGlow: 0,
+  subjectWeight: 0,
+  ringStroke: 0,
+  ringGlow: 0,
+  bare: true,
+};
+
+/** Resolve the user's choices into draw numbers. Pure — safe to memoize. */
+export function resolveHeadDecor(
+  marks: readonly HeadMark[],
+  weight: HeadWeight,
+): HeadDecor {
+  const w = WEIGHTS[weight] ?? WEIGHTS[DEFAULT_HEAD_WEIGHT];
+  const on = (m: HeadMark) => marks.includes(m);
+  return {
+    barW: on("bar") ? w.barW : 0,
+    barGlow: on("bar") ? w.barGlow : 0,
+    tintAlpha: on("tint") ? w.tintAlpha : 0,
+    outlineW: on("outline") ? w.outlineW : 0,
+    outlineAlpha: on("outline") ? w.outlineAlpha : 0,
+    badge: on("badge"),
+    badgeGlow: on("badge") ? w.badgeGlow : 0,
+    subjectWeight: on("bold") ? w.subjectWeight : 0,
+    ringStroke: on("ring") ? w.ringStroke : 0,
+    ringGlow: on("ring") ? w.ringGlow : 0,
+    bare: !HEAD_MARKS.some(on),
+  };
+}
+
+/**
+ * Sanitize a persisted / hand-edited mark list. Returns `null` when the value
+ * is not a list at all, so the caller can tell "absent" (use the default) from
+ * "the user turned everything off" — an empty array is a legitimate choice.
+ */
+export function normalizeHeadMarks(value: unknown): HeadMark[] | null {
+  if (!Array.isArray(value)) return null;
+  const wanted = new Set(value.filter((v): v is string => typeof v === "string"));
+  // Filtered through the catalog rather than the input, so the result is always
+  // deduped AND in a stable order — otherwise the persisted JSON churns on
+  // every toggle and a settings diff is unreadable.
+  return HEAD_MARKS.filter((m) => wanted.has(m));
+}
+
+const LEGACY: Record<string, HeadMark[]> = {
+  none: ["ring"],
+  bar: ["bar", "ring"],
+  tint: ["tint", "ring"],
+  both: ["bar", "tint", "ring"],
+};
+
+/**
+ * Map an old `headIndicator` value onto marks. `ring` is added to all four
+ * because the graph ring was unconditional back then — including under "none",
+ * whose label was literally "Graph marker only".
+ *
+ * `null` for anything unrecognised, so the caller falls through to the default.
+ */
+export function migrateHeadIndicator(legacy: unknown): HeadMark[] | null {
+  return typeof legacy === "string" ? (LEGACY[legacy] ?? null) : null;
+}

--- a/src/features/settings/useSettingsStore.test.ts
+++ b/src/features/settings/useSettingsStore.test.ts
@@ -80,6 +80,59 @@ describe("useSettingsStore persistence", () => {
   });
 });
 
+// The HEAD treatment moved from one `headIndicator` enum to marks × weight. The
+// old key is NOT in the schema any more, so the generic copy loop skips it — the
+// migration has to reach into the raw payload, and these tests are what say it
+// still does. Silently losing the setting looks identical to a fresh install.
+describe("head marks migration", () => {
+  it("carries a legacy headIndicator over to marks at the strong weight", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ headIndicator: "both" }));
+    const { useSettingsStore } = await freshStore();
+    const s = useSettingsStore.getState();
+    expect(s.headMarks).toEqual(["bar", "tint", "ring"]);
+    expect(s.headWeight).toBe("strong");
+  });
+
+  it("keeps a legacy 'none' honest — the graph ring, and nothing else", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ headIndicator: "none" }));
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().headMarks).toEqual(["ring"]);
+  });
+
+  it("prefers a stored mark list over the legacy key", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ headIndicator: "both", headMarks: ["badge"] }),
+    );
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().headMarks).toEqual(["badge"]);
+  });
+
+  it("respects an empty mark list instead of resetting to the default", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ headMarks: [] }));
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().headMarks).toEqual([]);
+  });
+
+  it("sanitizes a junk list and an unknown weight", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ headMarks: ["ring", "sparkles", "ring"], headWeight: "nuclear" }),
+    );
+    const { useSettingsStore } = await freshStore();
+    const s = useSettingsStore.getState();
+    expect(s.headMarks).toEqual(["ring"]);
+    expect(s.headWeight).toBe("strong");
+  });
+
+  it("defaults a fresh install to bar + wash + ring", async () => {
+    const { useSettingsStore } = await freshStore();
+    const s = useSettingsStore.getState();
+    expect(s.headMarks).toEqual(["bar", "tint", "ring"]);
+    expect(s.headWeight).toBe("strong");
+  });
+});
+
 describe("logo theme slots", () => {
   const BRAND_PRIMARY = "#3e9b91";
   const BRAND_SECONDARY = "#e6a95a";

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -1,5 +1,13 @@
 import { create } from "zustand";
 import type { PullMode } from "@/lib/tauri";
+import {
+  DEFAULT_HEAD_WEIGHT,
+  HEAD_WEIGHTS,
+  migrateHeadIndicator,
+  normalizeHeadMarks,
+  type HeadMark,
+  type HeadWeight,
+} from "./headMarks";
 
 const STORAGE_KEY = "pg-settings-v2";
 
@@ -538,23 +546,11 @@ export function applyDensity(density: UiDensity) {
 }
 
 // ─── HEAD ("you are here") indicator ─────────────────────────────────────────
-
-/**
- * How the commit HEAD points at is marked in History, on top of the graph's own
- * HEAD ring (part of the graph, always drawn).
- *
- * "bar" is the default: an edge bar reads at a glance without repainting a row
- * whose colors carry other meaning. "tint" is for wanting the whole row lit.
- */
-export const HEAD_INDICATORS = ["none", "bar", "tint", "both"] as const;
-export type HeadIndicator = (typeof HEAD_INDICATORS)[number];
-
-export const HEAD_INDICATOR_LABELS: Record<HeadIndicator, string> = {
-  none: "Graph marker only",
-  bar: "Edge bar",
-  tint: "Highlight row",
-  both: "Bar + highlight",
-};
+//
+// The catalog, the weight table and the resolver live in `./headMarks` — pure
+// and separately tested. Re-exported here because every existing consumer
+// already imports its HEAD types from this module.
+export * from "./headMarks";
 
 // ─── UI zoom (Mod+= / Mod+- / Mod+0, like an editor) ─────────────────────────
 
@@ -612,8 +608,13 @@ interface PersistedState {
   uiDensity: "compact" | "comfortable";
   /** Webview zoom factor — 1 is 100%. See applyZoom. */
   uiZoom: number;
-  /** How the History row you are currently on (HEAD) is marked. */
-  headIndicator: HeadIndicator;
+  /**
+   * Which marks the History row you are currently on (HEAD) carries, and how
+   * hard they hit. Two orthogonal settings rather than one enum of every
+   * combination — see ./headMarks.
+   */
+  headMarks: HeadMark[];
+  headWeight: HeadWeight;
   defaultPullMode: PullMode;
   autoFetchEnabled: boolean;
   autoFetchMinutes: number;
@@ -655,7 +656,8 @@ const DEFAULTS: PersistedState = {
   customThemes: [],
   uiDensity: "compact",
   uiZoom: 1,
-  headIndicator: "bar",
+  headMarks: ["bar", "tint", "ring"],
+  headWeight: DEFAULT_HEAD_WEIGHT,
   defaultPullMode: "Rebase",
   autoFetchEnabled: false,
   autoFetchMinutes: 5,
@@ -693,10 +695,19 @@ function load(): PersistedState {
     // A hand-edited or newer-build zoom must not survive as-is: an out-of-range
     // factor is rejected by the webview and would leave the UI unzoomable.
     out.uiZoom = normalizeZoom(Number(out.uiZoom));
-    // Same reasoning as the zoom clamp: an unknown value would silently mean
-    // "no indicator at all" in the row renderer.
-    if (!HEAD_INDICATORS.includes(out.headIndicator as HeadIndicator)) {
-      out.headIndicator = DEFAULTS.headIndicator;
+    // HEAD marks: prefer a stored list, else carry over the pre-#118 single
+    // `headIndicator` enum, else the default. Migration reads `parsed`, not
+    // `out` — the old key is gone from the schema, so the copy loop above never
+    // picked it up. Landing an upgraded install on "strong" is deliberate: the
+    // same choice as before, just at roughly twice the visibility.
+    out.headMarks =
+      normalizeHeadMarks(parsed.headMarks) ??
+      migrateHeadIndicator(parsed.headIndicator) ??
+      DEFAULTS.headMarks;
+    // Same reasoning as the zoom clamp: an unknown weight would resolve every
+    // mark to NaN and silently draw nothing.
+    if (!HEAD_WEIGHTS.includes(out.headWeight as HeadWeight)) {
+      out.headWeight = DEFAULTS.headWeight;
     }
     // Backfill logo colors for custom themes saved before the slots existed,
     // so the theme editor and CSS vars always have a value.
@@ -735,7 +746,8 @@ function snapshot(s: SettingsState): PersistedState {
     customThemes: s.customThemes,
     uiDensity: s.uiDensity,
     uiZoom: s.uiZoom,
-    headIndicator: s.headIndicator,
+    headMarks: s.headMarks,
+    headWeight: s.headWeight,
     defaultPullMode: s.defaultPullMode,
     autoFetchEnabled: s.autoFetchEnabled,
     autoFetchMinutes: s.autoFetchMinutes,

--- a/src/screens/History.head.test.tsx
+++ b/src/screens/History.head.test.tsx
@@ -1,13 +1,16 @@
-// The "you are here" (HEAD) row treatment is user-chosen: an edge bar, a whole
-// -row highlight, both, or nothing but the graph's own HEAD ring.
+// The "you are here" (HEAD) row treatment is user-chosen: any subset of six
+// marks, at one of three weights. These tests pin that each mark lands only when
+// it is on, that the weight knob actually moves pixels, and that selection still
+// outranks the wash.
 import { describe, expect, it, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 
 import { HistoryScreen } from "./History";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useKeymapStore, useFocusStore } from "@/features/keymap";
-import { useSettingsStore, type HeadIndicator } from "@/features/settings/useSettingsStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import type { HeadMark, HeadWeight } from "@/features/settings/headMarks";
 import type { CommitInfo } from "@/lib/types";
 
 const oid = (label: string) => label.repeat(40).slice(0, 40);
@@ -63,8 +66,9 @@ function primeStore() {
   });
 }
 
-async function renderWith(indicator: HeadIndicator) {
-  useSettingsStore.getState().set("headIndicator", indicator);
+async function renderWith(marks: HeadMark[], weight: HeadWeight = "strong") {
+  useSettingsStore.getState().set("headMarks", marks);
+  useSettingsStore.getState().set("headWeight", weight);
   render(<HistoryScreen />);
   await waitFor(() => expect(screen.getAllByTestId("commit-row").length).toBe(3));
   const rows = screen.getAllByTestId("commit-row");
@@ -72,44 +76,109 @@ async function renderWith(indicator: HeadIndicator) {
 }
 
 const tinted = (row: HTMLElement) => row.style.background.includes("var(--accent)");
-const bar = (row: HTMLElement) => !!row.querySelector('[data-testid="commit-head-bar"]');
+const bar = (row: HTMLElement) =>
+  row.querySelector<HTMLElement>('[data-testid="commit-head-bar"]');
+const outlined = (row: HTMLElement) => row.style.boxShadow.includes("inset");
+const badged = (row: HTMLElement) =>
+  !!row.querySelector('[data-testid="commit-head-badge"]');
+const subjectWeight = (row: HTMLElement) =>
+  row.querySelector<HTMLElement>('[data-testid="commit-subject"]')!.style.fontWeight;
+const ring = (row: HTMLElement) =>
+  row.querySelector<SVGElement>("[data-graph-head]");
+const ringGlow = (row: HTMLElement) =>
+  row.querySelector<SVGElement>("[data-graph-head-glow]");
 
-describe("History HEAD indicator", () => {
+describe("History HEAD marks", () => {
   beforeEach(primeStore);
 
   it("marks only the HEAD row", async () => {
-    const { headRow, otherRow } = await renderWith("both");
+    const { headRow, otherRow } = await renderWith(["bar", "tint"]);
     expect(headRow.dataset.head).toBe("true");
     expect(otherRow.dataset.head).toBeUndefined();
+    expect(bar(otherRow)).toBeNull();
+    expect(tinted(otherRow)).toBe(false);
   });
 
-  it("draws an edge bar and no wash for 'bar'", async () => {
-    const { headRow } = await renderWith("bar");
-    expect(bar(headRow)).toBe(true);
+  it("draws an edge bar and no wash for ['bar']", async () => {
+    const { headRow } = await renderWith(["bar"]);
+    expect(bar(headRow)).not.toBeNull();
     expect(tinted(headRow)).toBe(false);
   });
 
-  it("washes the row and draws no bar for 'tint'", async () => {
-    const { headRow } = await renderWith("tint");
+  it("washes the row and draws no bar for ['tint']", async () => {
+    const { headRow } = await renderWith(["tint"]);
     expect(tinted(headRow)).toBe(true);
-    expect(bar(headRow)).toBe(false);
+    expect(bar(headRow)).toBeNull();
   });
 
-  it("does both for 'both'", async () => {
-    const { headRow } = await renderWith("both");
-    expect(bar(headRow)).toBe(true);
-    expect(tinted(headRow)).toBe(true);
+  it("insets an accent outline for ['outline']", async () => {
+    const { headRow, otherRow } = await renderWith(["outline"]);
+    expect(outlined(headRow)).toBe(true);
+    expect(outlined(otherRow)).toBe(false);
   });
 
-  it("leaves the row alone for 'none'", async () => {
-    const { headRow } = await renderWith("none");
-    expect(bar(headRow)).toBe(false);
+  it("adds a HEAD pill for ['badge']", async () => {
+    const { headRow, otherRow } = await renderWith(["badge"]);
+    expect(badged(headRow)).toBe(true);
+    expect(badged(otherRow)).toBe(false);
+  });
+
+  it("bolds the subject for ['bold'] and leaves other rows alone", async () => {
+    const { headRow, otherRow } = await renderWith(["bold"]);
+    expect(Number(subjectWeight(headRow))).toBeGreaterThan(400);
+    expect(subjectWeight(otherRow)).toBe("");
+  });
+
+  it("draws the graph ring only when 'ring' is on", async () => {
+    const { headRow: withRing } = await renderWith(["ring"]);
+    expect(ring(withRing)).not.toBeNull();
+
+    // Unmount before the second render — two HistoryScreens in one document
+    // would make getAllByTestId return six rows.
+    cleanup();
+    primeStore();
+    const { headRow: withoutRing } = await renderWith(["bar"]);
+    expect(ring(withoutRing)).toBeNull();
+  });
+
+  it("leaves the row completely alone when no mark is on", async () => {
+    const { headRow } = await renderWith([]);
+    expect(bar(headRow)).toBeNull();
     expect(tinted(headRow)).toBe(false);
-    // Still flagged in the DOM — the graph ring is the indicator here.
+    expect(outlined(headRow)).toBe(false);
+    expect(badged(headRow)).toBe(false);
+    expect(ring(headRow)).toBeNull();
+    // Still flagged in the DOM, so a future surface can find the row.
     expect(headRow.dataset.head).toBe("true");
   });
 
-  it("lets selection outrank the wash on a selected HEAD row, keeping the bar", async () => {
+  it("makes the weight knob visible on the bar and the ring", async () => {
+    const { headRow: subtle } = await renderWith(["bar", "ring"], "subtle");
+    const subtleW = bar(subtle)!.style.width;
+    expect(ringGlow(subtle)).toBeNull(); // no halo at the lightest weight
+
+    cleanup();
+    primeStore();
+    const { headRow: intense } = await renderWith(["bar", "ring"], "intense");
+    expect(parseFloat(bar(intense)!.style.width)).toBeGreaterThan(
+      parseFloat(subtleW),
+    );
+    expect(ringGlow(intense)).not.toBeNull();
+  });
+
+  it("deepens the wash as the weight goes up", async () => {
+    const alpha = (row: HTMLElement) =>
+      Number(row.style.background.match(/\/\s*([\d.]+)\s*\)/)?.[1]);
+
+    const { headRow: subtle } = await renderWith(["tint"], "subtle");
+    const light = alpha(subtle);
+    cleanup();
+    primeStore();
+    const { headRow: intense } = await renderWith(["tint"], "intense");
+    expect(alpha(intense)).toBeGreaterThan(light);
+  });
+
+  it("lets selection outrank the wash on a selected HEAD row, keeping the other marks", async () => {
     // Point the branch at the FIRST commit, which History auto-selects — so
     // this row is both selected and HEAD.
     useRepoStore.setState({
@@ -125,7 +194,7 @@ describe("History HEAD indicator", () => {
         },
       ],
     } as never);
-    useSettingsStore.getState().set("headIndicator", "both");
+    useSettingsStore.getState().set("headMarks", ["bar", "tint", "outline", "badge"]);
     render(<HistoryScreen />);
     await waitFor(() => expect(screen.getAllByTestId("commit-row").length).toBe(3));
     const row = screen.getAllByTestId("commit-row")[0];
@@ -133,12 +202,17 @@ describe("History HEAD indicator", () => {
     expect(row.dataset.selected).toBe("true");
     expect(row.dataset.head).toBe("true");
     expect(tinted(row)).toBe(false); // selection background wins
-    expect(bar(row)).toBe(true); // …but "you are here" still reads
+    // …but "you are here" still reads. This is why 'outline' exists: unlike the
+    // wash, it survives on the selected row.
+    expect(bar(row)).not.toBeNull();
+    expect(outlined(row)).toBe(true);
+    expect(badged(row)).toBe(true);
   });
 
-  it("persists the choice", async () => {
-    await renderWith("tint");
-    const raw = localStorage.getItem("pg-settings-v2") ?? "{}";
-    expect(JSON.parse(raw).headIndicator).toBe("tint");
+  it("persists both choices", async () => {
+    await renderWith(["outline", "badge"], "intense");
+    const raw = JSON.parse(localStorage.getItem("pg-settings-v2") ?? "{}");
+    expect(raw.headMarks).toEqual(["outline", "badge"]);
+    expect(raw.headWeight).toBe("intense");
   });
 });

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -38,6 +38,7 @@ import { runRebasePlanNow } from "@/features/commits/runRebasePlan";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useDensityStep, useSettingsStore } from "@/features/settings/useSettingsStore";
+import { resolveHeadDecor } from "@/features/settings/headMarks";
 import { CommitDiffPanel } from "@/features/diff/CommitDiffPanel";
 import { useIgnoreWhitespace } from "@/features/diff/WhitespaceToggle";
 import { PGPane, FocusableScroll, usePaneList } from "@/features/keymap";
@@ -181,7 +182,14 @@ export function HistoryScreen() {
   const head = currentBranch(branches);
   const headName = head?.name ?? null;
   const headOid = head?.tip ?? null;
-  const headIndicator = useSettingsStore((s) => s.headIndicator);
+  // Resolved ONCE for the whole list: every row gets the same object reference,
+  // which is what keeps PGCommitRow's memo effective (#68 G9).
+  const headMarks = useSettingsStore((s) => s.headMarks);
+  const headWeight = useSettingsStore((s) => s.headWeight);
+  const headDecor = React.useMemo(
+    () => resolveHeadDecor(headMarks, headWeight),
+    [headMarks, headWeight],
+  );
   const { onContextMenu: onCommitContext, menu: commitMenu } =
     useContextMenu<{ sha: string; subject: string }>(commitMenuItems);
   const { onContextMenu: onCommitMulti, menu: commitMultiMenu } =
@@ -646,7 +654,7 @@ export function HistoryScreen() {
               refs={refsByOid.get(c.oid)}
               selected={selectedSet.has(c.oid)}
               isHead={c.oid === headOid}
-              headStyle={headIndicator}
+              headDecor={headDecor}
               oid={c.oid}
               onRowClick={onRowClick}
               onRowContext={onRowContext}

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -14,17 +14,15 @@ import {
 import {
   BUILTIN_THEMES,
   DENSITY_STEP_PX,
-  HEAD_INDICATORS,
-  HEAD_INDICATOR_LABELS,
   THEME_COLOR_FIELDS,
   ZOOM_MAX,
   ZOOM_MIN,
-  type HeadIndicator,
   applyTheme,
   useSettingsStore,
   type ThemeColors,
   type ThemeDef,
 } from "@/features/settings/useSettingsStore";
+import { HeadMarksControl } from "@/features/settings/HeadMarksControl";
 import { cliShimStatus, installCliShim, type PullMode } from "@/lib/tauri";
 import { useUpdateStore } from "@/features/update/useUpdateStore";
 import type { CliShimStatus } from "@/lib/types";
@@ -607,19 +605,8 @@ function AppearanceSection({ active }: { active: ThemeDef }) {
 
       <Row
         label="Current position (HEAD)"
-        hint="How History marks the commit you are on. The graph's HEAD ring is always drawn; this is the row treatment on top of it."
-        control={
-          <PGSelect
-            size="sm"
-            value={s.headIndicator}
-            onChange={(v) => s.set("headIndicator", v as HeadIndicator)}
-            data-testid="settings-head-indicator"
-            options={HEAD_INDICATORS.map((k) => ({
-              value: k,
-              label: HEAD_INDICATOR_LABELS[k],
-            }))}
-          />
-        }
+        hint="How History marks the commit you are on. Pick any combination of marks, then set how hard they hit — the preview is the real History row."
+        control={<HeadMarksControl />}
       />
 
       <Row


### PR DESCRIPTION
The HEAD indicator needed clearer options and heavier highlighting. The old
`headIndicator` enum (`none | bar | tint | both`) blocked both: it had to name
every *combination*, so the option list read as jargon rather than choices, and
there was no way to ask for a heavier version of a mark you already had — the
wash was pinned at 0.16 alpha and the bar at 3px.

## What changed

**Independent marks × one weight knob.** Six marks, any subset:

| Mark | What it does |
|---|---|
| `bar` | Accent bar down the row's left edge |
| `tint` | Washes the whole row in the accent |
| `outline` | Inset accent ring around the row |
| `badge` | An accent `HEAD` pill beside the branch pills |
| `bold` | Bolds the commit subject |
| `ring` | The circle around HEAD's dot in the graph |

…at one of three weights:

| | bar | tint α | glow | outline | ring |
|---|---|---|---|---|---|
| subtle | 3px | 0.14 | 4px | 1px @.45 | 1 |
| strong | 5px | 0.28 | 8px | 1px @.85 | 1.6 + halo |
| intense | 8px | **0.44** | 14px | 2px @1 | 2.2 + halo |

**Settings gets a live preview** built from the real `PGCommitRow` — two rows, so
a mark is legible against the row it is *not* on. With six marks and three
weights, a label alone can't communicate the result, and rendering the actual
row component means the preview cannot drift from History.

## Notes on the design

- `resolveHeadDecor` turns marks + weight into draw numbers where **zero means
  "don't draw"**, so `PGCommitRow` never reads the mark list and the precedence
  rules stay in one place. History resolves it **once per list render** so every
  row shares the object reference and row memoization survives (#68 G9); the
  ring is passed as two scalars for the same reason.
- **The graph ring is a mark now**, not unconditional — "no indicator at all"
  was previously unreachable, even under a value labelled "Graph marker only".
  Its halo is a second wider circle rather than a CSS filter (cheaper for one
  node per row in a virtualized list), capped by `GRAPH_PAD` so column 0's ring
  can't be clipped by the SVG viewport — the #68 G1 failure mode.
- **Selection still outranks the wash**, and `outline` exists for the case that
  exposed: unlike the wash, it survives on a selected HEAD row, where a second
  stacked accent wash would read as neither.
- **The wash tops out at 0.44 alpha** at every weight. Past roughly half it
  fights `--fg-0` and the sha/author columns stop reading. Intense is the
  ceiling, not an invitation.
- All colors are accent-relative (`oklch(from var(--accent) …)`), so custom and
  light themes carry through.

## Migration

The old key is gone from the schema, so the store's generic copy loop no longer
sees it — migration reads the raw payload instead. `none→[ring]`,
`bar→[bar,ring]`, `tint→[tint,ring]`, `both→[bar,tint,ring]`, all at `strong`:
the same choice as before, at roughly twice the visibility. Silently losing the
setting would look identical to a fresh install, so there are tests for it.

Fresh installs default to `[bar, tint, ring]` at `strong`.

## Verification

- `pnpm tsc --noEmit` clean; `pnpm exec tsc -p e2e/tsconfig.json --noEmit` clean.
- Full frontend suite: **963 tests / 135 files passing**, including 12 new pure
  tests for the resolver + migration, 13 for the History row treatment, and 5
  component tests for the Settings control.
- `pnpm test:e2e:docker full --spec settings --spec history-diff --spec
  history-ops --spec reflog` — **20 passing, 4/4 spec files**. That set includes
  "UI density scales every row surface", the test that would catch row-geometry
  damage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)