### PR TITLE
feat(diff): whole-file inline diff with off-main-thread highlighting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,13 +351,57 @@ lib/
 ├── types.ts         Shared types mirroring Rust types.rs
 ├── errors.ts        AppError discriminated union 1:1 with Rust enum
 ├── derive.ts        Selectors: currentBranch, isStaged, isUnstaged, totalAheadBehind, …
-├── highlight.ts     Syntax highlighting for preview/diff
+├── syntax/          Shiki highlighting, OFF the main thread (see below)
+│   ├── tokenizeCore.ts   Shiki-FREE: SyntaxLine/SyntaxToken, MAX_HIGHLIGHT_*,
+│   │                     toLineRelative, packLines/unpackLines, skipHighlight
+│   ├── tokenizeShiki.ts  The one place codeToTokens is called
+│   ├── tokenize.worker.ts  Module worker running tokenizeShiki
+│   ├── tokenize.ts       Main-thread API: LRU cache + worker client + fallback.
+│   │                     `tokenizeFile(path, text)` — null means render plain
+│   ├── useSyntax.ts / useDiffSyntax.ts  Hooks; useDiffSyntax also EXPOSES the
+│   │                     texts it reads, which whole-file mode fills gaps from
+│   └── usePrefetchSyntax.ts  Bounded idle warm-up of a commit's other files
+├── diffRows.ts      Flat DiffRow model (header | line | fill) + exact
+│                    variable-height window. `fill` = whole-file gap filler
+├── useViewportH.ts  Scroll-container height WITHOUT depending on ResizeObserver
+├── useWindowedList.ts  Fixed-pitch windowing for the plain lists
 ├── fileIcon.ts      path → file-type glyph + themeable tint (tested)
 ├── tree.ts          buildStatusTree / buildStatusList — SAME row keys, which is
 │                    what makes the tree⇄flat toggle free of per-mode branches
 ├── useTreeViewMode.ts  Persisted tree|flat preference, one key per surface
 └── recents.ts       Recent-repo persistence
 ```
+
+### Diff rendering
+
+- **One row model, one renderer.** `flattenDiffRows` (`lib/diffRows.ts`) turns a
+  `FileDiff` into a flat `DiffRow[]`; `PGWindowedDiff` renders it. All four diff
+  surfaces (Diff screen, commit panel, repo browser, commit-diff panel) go
+  through both, so word spans, syntax, staging and F7 cannot drift between them.
+- **Whole file is the default view** (`diffContextMode: "wholeFile"`), and it is
+  composed on the FRONTEND: the canonical diff is left exactly as fetched and the
+  unchanged remainder is filled in around it as `fill` rows, from text
+  `useDiffSyntax` already read. **Never get whole-file by passing a large
+  `contextLines`** — libgit2 would return one hunk covering the file, so
+  `stage_hunk` would stage everything and `changedIndex` would shift. `fill` is a
+  distinct row kind with no `hunkIndex` precisely so it cannot reach a staging
+  path. Any inconsistent gap arithmetic degrades to chunked rather than render
+  wrong line numbers; git's `+N,0` convention (the line BEFORE) is normalized in
+  `effStart`, or every filler number after such a hunk shifts by one.
+- **Hunk headers stay in whole-file mode.** They carry Stage/Discard, the
+  collapse chevron, `data-hunk-index` for F7, and the e2e selectors.
+- **Tokenization runs in a module worker.** Shiki's `codeToTokens` is synchronous
+  CPU work, so awaiting it on the main thread still janked. Tokens come back
+  packed into transferable `Int32Array`s rather than one object per token.
+  `vite.config.ts` sets **`worker: { format: "es" }`** — Shiki's grammars are
+  dynamic imports, so the worker bundle is code-split and Vite's default `iife`
+  worker format fails the production build outright. A failed worker degrades to
+  main-thread tokenizing, which is also the path jsdom component tests take.
+- **Do not measure a scroll viewport behind a `typeof ResizeObserver` guard.**
+  WebKitGTK 605 (the Linux webview, and the e2e target) has none; guarding before
+  the initial measurement leaves the height 0, `windowVariable` falls back to a
+  400px viewport, and the bottom of a taller pane renders blank. Use
+  `lib/useViewportH.ts`.
 
 ### Navigation model
 

--- a/docs/superpowers/plans/2026-08-14-whole-file-diff-and-async-highlight.md
+++ b/docs/superpowers/plans/2026-08-14-whole-file-diff-and-async-highlight.md
@@ -1,0 +1,1404 @@
+# Whole-file Diff and Async Highlight Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the inline diff show the whole file by default with a stronger changed-word highlight, and move Shiki tokenization off the main thread so switching files never janks.
+
+**Architecture:** Whole-file view is composed on the frontend by inserting a new `fill` row kind between the hunks the backend already returns — the canonical diff, its hunk indices and its `changedIndex` numbering are left completely untouched, so staging keeps addressing exactly what git would apply. Tokenization moves into a module Worker that returns tokens packed into transferable `Int32Array`s, with a mandatory main-thread fallback.
+
+**Tech Stack:** React 19 + TypeScript, Zustand, Vite module workers, Shiki (`engine-javascript`), Vitest + React Testing Library, WebdriverIO (e2e in Docker).
+
+**Spec:** `docs/superpowers/specs/2026-08-14-whole-file-diff-and-async-highlight-design.md`
+
+## Global Constraints
+
+- Toolchain: Node 22 + **pnpm** (at `~/Library/pnpm`), Rust stable at `~/.cargo/bin`. Bash tool does not inherit the interactive shell rc — prepend `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"` for every `pnpm`/`cargo` command.
+- **No Rust changes in this plan.** No new `GitBackend` method, no new Tauri command. Existing `get_diff` / `read_file_content*` are sufficient.
+- **Never derive whole-file from a large `context_lines`.** It collapses the file into hunk 0 and breaks `stage_hunk` indices and `changedIndex`. Data-loss class bug.
+- `changedIndex` must be numbered over a whole hunk before anything slices or interleaves rows (#61 D7 wire contract, mirrors the backend's `Patch::line_in_hunk`).
+- Theme tokens must be added to **both** `src/index.css` `:root` and `SEMANTIC_TOKENS` in `src/features/settings/useSettingsStore.ts`, with `light` calibrated separately. The `dark` column is kept byte-identical to `index.css`.
+- Never hardcode a hue — use `oklch(from var(--…) l c h / <alpha>)`.
+- Commit style: Conventional Commits, imperative subject under 72 chars, `Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>` trailer.
+- E2E runs **only** via `pnpm test:e2e:docker`, never natively, and only once development is finished, only for affected specs.
+
+---
+
+### Task 1: Stronger changed-word highlight tokens
+
+**Files:**
+- Modify: `src/index.css:117-123` (add two tokens after the existing `--git-*-gutter` lines)
+- Modify: `src/features/settings/useSettingsStore.ts:328-370` (`SEMANTIC_TOKENS`, both modes)
+- Modify: `src/design/git-components.tsx:678-681` (`DiffText` tint)
+- Test: `src/design/wordDiffRender.test.tsx` (existing file, add one case)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: CSS custom properties `--git-added-word` and `--git-removed-word`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/design/wordDiffRender.test.tsx`:
+
+```tsx
+it("tints changed words with the dedicated word token, not an inline alpha", () => {
+  const rows = flattenDiffRows(
+    [
+      {
+        header: "@@ -1,1 +1,1 @@",
+        oldStart: 1,
+        oldLines: 1,
+        newStart: 1,
+        newLines: 1,
+        lines: [
+          { kind: { kind: "Deletion" }, oldLineno: 1, newLineno: null, content: "const a = 1;" },
+          { kind: { kind: "Addition" }, oldLineno: null, newLineno: 1, content: "const a = 2;" },
+        ],
+      },
+    ],
+    { headerH: 26, rowH: 19 },
+  );
+  render(<PGWindowedDiff rows={rows} />);
+  const marks = screen.getAllByTestId("word-change");
+  expect(marks.length).toBeGreaterThan(0);
+  for (const m of marks) {
+    expect(m.style.background).toContain("--git-added-word");
+  }
+});
+```
+
+Note: that assertion holds for the added row; scope it to the add row by
+querying within it if the removed row's marks are also returned — read the
+existing cases in the file and follow whichever query style they already use.
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- src/design/wordDiffRender.test.tsx
+```
+
+Expected: FAIL — background contains `oklch(from var(--git-added) l c h / 0.28)`, not the token.
+
+- [ ] **Step 3: Add the tokens to `src/index.css`**
+
+After line 123 (`--git-removed-gutter: …;`) add:
+
+```css
+  /* Changed-word emphasis inside an already-tinted add/rem line. Stronger than
+     the line background on purpose: the line says "this changed", the word says
+     "this is what changed". */
+  --git-added-word: oklch(0.55 0.13 155 / 0.55);
+  --git-removed-word: oklch(0.52 0.16 25 / 0.55);
+```
+
+- [ ] **Step 4: Add the same tokens to `SEMANTIC_TOKENS`**
+
+In `src/features/settings/useSettingsStore.ts`, in the `dark` object next to
+`--git-removed-gutter`, add the two lines **byte-identical** to the CSS above:
+
+```ts
+    "--git-added-word": "oklch(0.55 0.13 155 / 0.55)",
+    "--git-removed-word": "oklch(0.52 0.16 25 / 0.55)",
+```
+
+In the `light` object add the light calibration — a light canvas needs a
+darker, more saturated word tint to separate from the pale line background:
+
+```ts
+    "--git-added-word": "oklch(0.78 0.16 155 / 0.85)",
+    "--git-removed-word": "oklch(0.78 0.17 25 / 0.85)",
+```
+
+- [ ] **Step 5: Use the tokens in `DiffText`**
+
+Replace the `tint` computation in `src/design/git-components.tsx`:
+
+```tsx
+  const tint =
+    kind === "add" ? "var(--git-added-word)" : "var(--git-removed-word)";
+```
+
+- [ ] **Step 6: Run the diff render tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- src/design/wordDiffRender.test.tsx src/design/syntaxRender.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/index.css src/features/settings/useSettingsStore.ts src/design/git-components.tsx src/design/wordDiffRender.test.tsx
+git commit -m "feat(diff): stronger changed-word highlight via its own token"
+```
+
+---
+
+### Task 2: Persist the diff view mode and add the context mode setting
+
+**Files:**
+- Modify: `src/features/settings/useSettingsStore.ts` (`PersistedState`, `DEFAULTS`, `snapshot`)
+- Modify: `src/screens/DiffViewer.tsx:41` (replace local `useState`), `:294-299` (toggle wiring)
+- Modify: `src/screens/Settings.tsx:210-225` (controls + relabel)
+- Test: `src/features/settings/useSettingsStore.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `PersistedState.diffViewMode: "inline" | "split"` (default `"inline"`) and `PersistedState.diffContextMode: "wholeFile" | "chunks"` (default `"wholeFile"`), both readable via `useSettingsStore((s) => s.diffViewMode)` and writable via `s.set("diffViewMode", v)`. Tasks 4 and 5 consume `diffContextMode`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/features/settings/useSettingsStore.test.ts`:
+
+```ts
+it("defaults to an inline, whole-file diff and round-trips both", () => {
+  const s = useSettingsStore.getState();
+  expect(s.diffViewMode).toBe("inline");
+  expect(s.diffContextMode).toBe("wholeFile");
+
+  s.set("diffViewMode", "split");
+  s.set("diffContextMode", "chunks");
+  const raw = JSON.parse(localStorage.getItem("pg-settings") as string);
+  expect(raw.diffViewMode).toBe("split");
+  expect(raw.diffContextMode).toBe("chunks");
+});
+```
+
+Read the top of the existing test file first and reuse its localStorage key
+constant and reset helper rather than hardcoding `"pg-settings"` if it exposes
+one.
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- src/features/settings/useSettingsStore.test.ts
+```
+
+Expected: FAIL — `undefined` is not `"inline"`.
+
+- [ ] **Step 3: Add the keys to the store**
+
+In `PersistedState` (next to `diffContextLines`):
+
+```ts
+  /** Inline (unified) or side-by-side. Persisted so it is a preference, not a per-visit choice. */
+  diffViewMode: "inline" | "split";
+  /**
+   * Whole file or just the changed chunks. `diffContextLines` still governs the
+   * FETCH in both modes — it is what hunk-staging indices are computed against —
+   * so this only selects whether the unchanged remainder is filled in for display.
+   */
+  diffContextMode: "wholeFile" | "chunks";
+```
+
+In `DEFAULTS`:
+
+```ts
+  diffViewMode: "inline",
+  diffContextMode: "wholeFile",
+```
+
+In `snapshot`, add both fields alongside `diffContextLines` (the function lists
+every key explicitly; a missing key silently stops persisting).
+
+Then add validation in `load()`, next to the `headIndicator` clamp — an unknown
+value must not reach the renderer:
+
+```ts
+  if (!["inline", "split"].includes(out.diffViewMode as string)) {
+    out.diffViewMode = DEFAULTS.diffViewMode;
+  }
+  if (!["wholeFile", "chunks"].includes(out.diffContextMode as string)) {
+    out.diffContextMode = DEFAULTS.diffContextMode;
+  }
+```
+
+- [ ] **Step 4: Run the test**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- src/features/settings/useSettingsStore.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Point `DiffViewer` at the setting**
+
+In `src/screens/DiffViewer.tsx`, delete the local mode state at line 41 and read
+the setting instead. The rest of the file compares against `"unified"`, so map
+the persisted name at the boundary rather than renaming 6 call sites:
+
+```tsx
+  const diffViewMode = useSettingsStore((s) => s.diffViewMode);
+  const setSetting = useSettingsStore((s) => s.set);
+  const mode = diffViewMode === "split" ? "split" : "unified";
+  const setMode = (v: string) =>
+    setSetting("diffViewMode", v === "split" ? "split" : "inline");
+```
+
+The existing `PGButtonGroup` at line 294 already calls `setMode(v)`, so its
+`onChange={(v) => setMode(v as typeof mode)}` becomes `onChange={setMode}`.
+Check line 218's `React.useEffect(..., [mode])` still type-checks.
+
+- [ ] **Step 6: Add the Settings controls**
+
+In `src/screens/Settings.tsx`, near the existing `diffContextLines` field, add a
+mode selector for each new key following the file's existing control pattern
+(read the surrounding rows and match them — the file uses its own row helpers).
+Relabel the context-lines field so it does not read as chunks-only:
+
+> Context lines — used for chunked view, and always for hunk staging
+
+- [ ] **Step 7: Type-check and run the settings tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm tsc --noEmit
+pnpm test -- src/features/settings src/screens/Settings.cli.test.tsx
+```
+
+Expected: no type errors, tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/features/settings/useSettingsStore.ts src/features/settings/useSettingsStore.test.ts src/screens/DiffViewer.tsx src/screens/Settings.tsx
+git commit -m "feat(diff): persist inline/split mode, add whole-file context setting"
+```
+
+---
+
+### Task 3: Whole-file `fill` rows in the flat row model
+
+This is the correctness-critical task. The invariant under test is that adding
+whole-file filler changes **nothing** about hunk rows.
+
+**Files:**
+- Modify: `src/lib/diffRows.ts` (add `fill` variant, `wholeFile` option, gap arithmetic)
+- Modify: `src/design/PGWindowedDiff.tsx` (render the new row kind)
+- Test: `src/lib/diffRows.test.ts`
+
+**Interfaces:**
+- Consumes: `DiffRow`, `flattenDiffRows` from Task 0 state (unchanged upstream).
+- Produces:
+  - `DiffRow` gains `| { kind: "fill"; line: DiffLineData; h: number }`
+  - `flattenDiffRows(hunks, o)` where `o` gains
+    `wholeFile?: { newText: string | null; oldText: string | null }`
+  - Consumed by Task 4.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/lib/diffRows.test.ts`. The existing file has a `hunk(n)` helper —
+read it first; these tests need explicit hunk geometry, so define a local
+builder:
+
+```ts
+function h(o: {
+  oldStart: number;
+  oldLines: number;
+  newStart: number;
+  newLines: number;
+  lines: Array<["ctx" | "add" | "rem", number | null, number | null, string]>;
+}) {
+  const kindOf = { ctx: "Context", add: "Addition", rem: "Deletion" } as const;
+  return {
+    header: `@@ -${o.oldStart},${o.oldLines} +${o.newStart},${o.newLines} @@`,
+    oldStart: o.oldStart,
+    oldLines: o.oldLines,
+    newStart: o.newStart,
+    newLines: o.newLines,
+    lines: o.lines.map(([k, ol, nl, content]) => ({
+      kind: { kind: kindOf[k] },
+      oldLineno: ol,
+      newLineno: nl,
+      content,
+    })),
+  };
+}
+
+// A 6-line file where only line 4 changed, fetched with 0 context lines.
+const oneChange = [
+  h({
+    oldStart: 4,
+    oldLines: 1,
+    newStart: 4,
+    newLines: 1,
+    lines: [
+      ["rem", 4, null, "old four"],
+      ["add", null, 4, "new four"],
+    ],
+  }),
+];
+const NEW_TEXT = "one\ntwo\nthree\nnew four\nfive\nsix";
+const OLD_TEXT = "one\ntwo\nthree\nold four\nfive\nsix";
+
+describe("flattenDiffRows whole-file mode", () => {
+  it("fills the leading, and trailing, unchanged regions", () => {
+    const rows = flattenDiffRows(oneChange, {
+      headerH: 26,
+      rowH: 19,
+      wholeFile: { newText: NEW_TEXT, oldText: OLD_TEXT },
+    });
+    const fills = rows.filter((r) => r.kind === "fill");
+    expect(fills.map((f) => f.line.text)).toEqual([
+      "one",
+      "two",
+      "three",
+      "five",
+      "six",
+    ]);
+  });
+
+  it("numbers filler rows on both sides", () => {
+    const rows = flattenDiffRows(oneChange, {
+      headerH: 26,
+      rowH: 19,
+      wholeFile: { newText: NEW_TEXT, oldText: OLD_TEXT },
+    });
+    const fills = rows.filter((r) => r.kind === "fill");
+    expect(fills.map((f) => [f.line.lnL, f.line.lnR])).toEqual([
+      [1, 1],
+      [2, 2],
+      [3, 3],
+      [5, 5],
+      [6, 6],
+    ]);
+  });
+
+  it("leaves hunk rows byte-identical to chunked mode", () => {
+    const plain = flattenDiffRows(oneChange, { headerH: 26, rowH: 19 });
+    const whole = flattenDiffRows(oneChange, {
+      headerH: 26,
+      rowH: 19,
+      wholeFile: { newText: NEW_TEXT, oldText: OLD_TEXT },
+    });
+    expect(whole.filter((r) => r.kind !== "fill")).toEqual(plain);
+  });
+
+  it("handles a pure-deletion hunk, whose new side is zero-length", () => {
+    // Old lines 4-5 deleted from a 6-line file. Git writes +3,0 — the line
+    // BEFORE the deletion — so the effective new position is 4, not 3.
+    const rows = flattenDiffRows(
+      [
+        h({
+          oldStart: 4,
+          oldLines: 2,
+          newStart: 3,
+          newLines: 0,
+          lines: [
+            ["rem", 4, null, "four"],
+            ["rem", 5, null, "five"],
+          ],
+        }),
+      ],
+      {
+        headerH: 26,
+        rowH: 19,
+        wholeFile: { newText: "one\ntwo\nthree\nsix", oldText: "one\ntwo\nthree\nfour\nfive\nsix" },
+      },
+    );
+    const fills = rows.filter((r) => r.kind === "fill");
+    expect(fills.map((f) => [f.line.lnL, f.line.lnR, f.line.text])).toEqual([
+      [1, 1, "one"],
+      [2, 2, "two"],
+      [3, 3, "three"],
+      [6, 4, "six"],
+    ]);
+  });
+
+  it("handles a pure-addition hunk, whose old side is zero-length", () => {
+    const rows = flattenDiffRows(
+      [
+        h({
+          oldStart: 3,
+          oldLines: 0,
+          newStart: 4,
+          newLines: 1,
+          lines: [["add", null, 4, "inserted"]],
+        }),
+      ],
+      {
+        headerH: 26,
+        rowH: 19,
+        wholeFile: { newText: "one\ntwo\nthree\ninserted\nfour", oldText: "one\ntwo\nthree\nfour" },
+      },
+    );
+    const fills = rows.filter((r) => r.kind === "fill");
+    expect(fills.map((f) => [f.line.lnL, f.line.lnR, f.line.text])).toEqual([
+      [1, 1, "one"],
+      [2, 2, "two"],
+      [3, 3, "three"],
+      [4, 5, "four"],
+    ]);
+  });
+
+  it("falls back to chunked rows when the text is too short to fill the gap", () => {
+    const rows = flattenDiffRows(oneChange, {
+      headerH: 26,
+      rowH: 19,
+      wholeFile: { newText: "one\ntwo", oldText: "one\ntwo" },
+    });
+    expect(rows.some((r) => r.kind === "fill")).toBe(false);
+    expect(rows).toEqual(flattenDiffRows(oneChange, { headerH: 26, rowH: 19 }));
+  });
+
+  it("falls back to chunked rows when the two sides disagree on the gap length", () => {
+    const bad = [
+      h({
+        oldStart: 4,
+        oldLines: 1,
+        newStart: 9,
+        newLines: 1,
+        lines: [
+          ["rem", 4, null, "old four"],
+          ["add", null, 9, "new four"],
+        ],
+      }),
+    ];
+    const rows = flattenDiffRows(bad, {
+      headerH: 26,
+      rowH: 19,
+      wholeFile: { newText: NEW_TEXT, oldText: OLD_TEXT },
+    });
+    expect(rows.some((r) => r.kind === "fill")).toBe(false);
+  });
+
+  it("renders chunked when there is no text at all", () => {
+    const rows = flattenDiffRows(oneChange, {
+      headerH: 26,
+      rowH: 19,
+      wholeFile: { newText: null, oldText: null },
+    });
+    expect(rows).toEqual(flattenDiffRows(oneChange, { headerH: 26, rowH: 19 }));
+  });
+});
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- src/lib/diffRows.test.ts
+```
+
+Expected: FAIL — `wholeFile` is not an accepted option, no `fill` rows produced.
+
+- [ ] **Step 3: Add the `fill` variant and the gap arithmetic**
+
+In `src/lib/diffRows.ts`, extend the row union:
+
+```ts
+export type DiffRow =
+  | { kind: "header"; hunkIndex: number; header: string; h: number }
+  | { kind: "line"; hunkIndex: number; line: DiffLineData; h: number }
+  /**
+   * An unchanged line OUTSIDE every hunk, synthesized in whole-file mode.
+   *
+   * A distinct kind rather than a `line` row with a sentinel hunkIndex: consumers
+   * look up `hunkActions(row.hunkIndex)` and wire `onLineClick(row.hunkIndex, …)`,
+   * and a sentinel number would be one missing guard away from staging the wrong
+   * hunk. This variant has no hunkIndex to get wrong.
+   */
+  | { kind: "fill"; line: DiffLineData; h: number };
+```
+
+Then add the helpers:
+
+```ts
+/**
+ * Effective 1-based file position of a hunk side, normalizing git's zero-length
+ * convention.
+ *
+ * For a pure deletion git writes `+3,0`, meaning "at the line BEFORE which
+ * nothing was added" — new content resumes at 4, not 3. Reading `newStart`
+ * literally there is an off-by-one that shifts every filler line number after
+ * the hunk.
+ */
+function effStart(start: number, lines: number): number {
+  return lines === 0 ? start + 1 : start;
+}
+
+/**
+ * Context rows covering one unchanged region. Both sides advance together
+ * because an unchanged region is identical on both.
+ *
+ * Returns null when the arithmetic does not check out — a descending range, a
+ * gap the two sides disagree about, or a line past the end of the text. A
+ * whole-file view with wrong line numbers is worse than no whole-file view, so
+ * the caller degrades to chunked instead of rendering something plausible.
+ */
+function gapRows(o: {
+  oldFrom: number;
+  newFrom: number;
+  count: number;
+  lines: string[];
+  from: number;
+  rowH: number;
+}): DiffRow[] | null {
+  const { oldFrom, newFrom, count, lines, from, rowH } = o;
+  if (count === 0) return [];
+  if (count < 0 || oldFrom < 1 || newFrom < 1 || from < 1) return null;
+  if (from - 1 + count > lines.length) return null;
+  const rows: DiffRow[] = [];
+  for (let i = 0; i < count; i++) {
+    rows.push({
+      kind: "fill",
+      h: rowH,
+      line: {
+        kind: "ctx",
+        lnL: oldFrom + i,
+        lnR: newFrom + i,
+        text: lines[from - 1 + i],
+      },
+    });
+  }
+  return rows;
+}
+```
+
+Now rewrite `flattenDiffRows` to build the hunk rows exactly as before, and
+interleave filler only when whole-file mode is on **and** every gap validates:
+
+```ts
+export function flattenDiffRows(
+  hunks: FileDiff["hunks"],
+  o: {
+    headerH: number;
+    rowH: number;
+    collapsed?: ReadonlySet<number>;
+    syntax?: { old: SyntaxLine[] | null; new: SyntaxLine[] | null };
+    /** Whole-file mode. Both texts may be null; filler needs at least one. */
+    wholeFile?: { newText: string | null; oldText: string | null };
+  },
+): DiffRow[] {
+  const { headerH, rowH, collapsed, syntax, wholeFile } = o;
+
+  const hunkRows = (h: FileDiff["hunks"][number], hunkIndex: number): DiffRow[] => {
+    const rows: DiffRow[] = [
+      { kind: "header", hunkIndex, header: h.header, h: headerH },
+    ];
+    if (collapsed?.has(hunkIndex)) return rows;
+    // changedIndex FIRST, over the whole hunk, before anything slices rows.
+    const lines = withWordSpans(
+      withSyntax(withChangedIndices(h.lines.map(toUiLine)), syntax),
+    );
+    for (const line of lines) rows.push({ kind: "line", hunkIndex, line, h: rowH });
+    return rows;
+  };
+
+  const chunked = (): DiffRow[] => hunks.flatMap(hunkRows);
+
+  // Prefer the new side; a deleted file has only the old one. Filler text is an
+  // unchanged region, so either side yields the same characters.
+  const text = wholeFile?.newText ?? wholeFile?.oldText ?? null;
+  if (!wholeFile || text == null) return chunked();
+  const useNew = wholeFile.newText != null;
+  const textLines = text.split("\n");
+  if (textLines.length > MAX_WHOLE_FILE_LINES) return chunked();
+
+  const out: DiffRow[] = [];
+  let oldAt = 1;
+  let newAt = 1;
+  for (let i = 0; i < hunks.length; i++) {
+    const h = hunks[i];
+    const oldStart = effStart(h.oldStart, h.oldLines);
+    const newStart = effStart(h.newStart, h.newLines);
+    const count = newStart - newAt;
+    // The same region on both sides must be the same length.
+    if (oldStart - oldAt !== count) return chunked();
+    const gap = gapRows({
+      oldFrom: oldAt,
+      newFrom: newAt,
+      count,
+      lines: textLines,
+      from: useNew ? newAt : oldAt,
+      rowH,
+    });
+    if (!gap) return chunked();
+    out.push(...gap, ...hunkRows(h, i));
+    oldAt = oldStart + h.oldLines;
+    newAt = newStart + h.newLines;
+  }
+
+  const tailFrom = useNew ? newAt : oldAt;
+  const tail = gapRows({
+    oldFrom: oldAt,
+    newFrom: newAt,
+    count: textLines.length - tailFrom + 1,
+    lines: textLines,
+    from: tailFrom,
+    rowH,
+  });
+  if (!tail) return chunked();
+  out.push(...tail);
+  return out;
+}
+```
+
+Add the ceiling constant near the top of the file:
+
+```ts
+/**
+ * Past this, whole-file mode stays chunked. Inserting a filler row per line of a
+ * very large file would fight the performance goal this mode is part of; it also
+ * matches the tokenizer's own MAX_HIGHLIGHT_LINES ceiling.
+ */
+export const MAX_WHOLE_FILE_LINES = 20_000;
+```
+
+- [ ] **Step 4: Render the new row kind**
+
+In `src/design/PGWindowedDiff.tsx`, inside the `slice.map` callback, add a
+branch **before** the existing header/line handling — a filler row has no hunk,
+so it gets no selection and no click wiring:
+
+```tsx
+        if (row.kind === "fill") {
+          return <PGDiffRow key={`f${start + i}`} line={row.line} />;
+        }
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- src/lib/diffRows.test.ts src/design/PGWindowedDiff.test.tsx
+pnpm tsc --noEmit
+```
+
+Expected: PASS, no type errors. If `tsc` flags an unhandled `"fill"` case in
+another consumer, add the same no-op branch there — that exhaustiveness error is
+the type system doing its job.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/diffRows.ts src/lib/diffRows.test.ts src/design/PGWindowedDiff.tsx
+git commit -m "feat(diff): compose a whole-file view from gap-filled context rows"
+```
+
+---
+
+### Task 4: Wire whole-file mode into the four diff surfaces
+
+**Files:**
+- Modify: `src/lib/syntax/useDiffSyntax.ts` (expose the texts it already reads)
+- Modify: `src/features/diff/CommitDiffPanel.tsx:138,157`
+- Modify: `src/screens/CommitPanel.tsx:453,481`
+- Modify: `src/screens/DiffViewer.tsx:121,198`
+- Modify: `src/screens/RepoBrowser.tsx:574,595`
+- Test: `src/features/diff/CommitDiffPanel.wholeFile.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `flattenDiffRows`'s `wholeFile` option and `MAX_WHOLE_FILE_LINES` from Task 3; `diffContextMode` from Task 2.
+- Produces: `DiffSyntax` gains `oldText: string | null` and `newText: string | null`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/diff/CommitDiffPanel.wholeFile.test.tsx`. Read
+`CommitDiffPanel.syntax.test.tsx` first and copy its harness — it already mocks
+`read_file_content_at_rev` and renders the panel with a diff:
+
+```tsx
+it("shows unchanged lines outside the hunk when whole-file mode is on", async () => {
+  useSettingsStore.getState().set("diffContextMode", "wholeFile");
+  mockInvoke("read_file_content_at_rev", () => ({
+    path: "a.ts",
+    binary: false,
+    text: "one\ntwo\nthree\nnew four\nfive\nsix",
+    fromHead: false,
+    size: 30,
+  }));
+  render(<CommitDiffPanel {...props} />);
+  // "six" is outside the hunk, so it can only appear via a filler row.
+  expect(await screen.findByText("six")).toBeInTheDocument();
+});
+
+it("shows only the hunk when the setting says chunks", async () => {
+  useSettingsStore.getState().set("diffContextMode", "chunks");
+  render(<CommitDiffPanel {...props} />);
+  expect(await screen.findByText("new four")).toBeInTheDocument();
+  expect(screen.queryByText("six")).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- src/features/diff/CommitDiffPanel.wholeFile.test.tsx
+```
+
+Expected: FAIL — "six" is not rendered.
+
+- [ ] **Step 3: Expose the texts from `useDiffSyntax`**
+
+`useDiffSyntax` already reads both sides' whole-file text into its `texts`
+state. Widen the returned object so whole-file mode costs no extra IPC:
+
+```ts
+export interface DiffSyntax {
+  old: SyntaxLine[] | null;
+  new: SyntaxLine[] | null;
+  /** The text the tokens came from. Exposed so whole-file mode can fill gaps
+   *  from it instead of issuing a second read of the same blob. */
+  oldText: string | null;
+  newText: string | null;
+}
+```
+
+Update the memo at the end of the hook:
+
+```ts
+  return React.useMemo(
+    () => ({ old: oldLines, new: newLines, oldText: texts.old, newText: texts.new }),
+    [oldLines, newLines, texts.old, texts.new],
+  );
+```
+
+Update `EMPTY` to `{ old: null, new: null, oldText: null, newText: null }`.
+
+- [ ] **Step 4: Thread it through each surface**
+
+The four surfaces all follow the same shape: they call `useDiffSyntax(...)` and
+pass `syntax` into `flattenDiffRows`. In each one, read the setting and pass
+`wholeFile`. `CommitDiffPanel.tsx` (around line 157) becomes:
+
+```tsx
+  const diffContextMode = useSettingsStore((s) => s.diffContextMode);
+  // …
+      flattenDiffRows(current && !current.binary ? current.hunks : [], {
+        // …existing options…
+        wholeFile:
+          diffContextMode === "wholeFile"
+            ? { newText: syntax.newText, oldText: syntax.oldText }
+            : undefined,
+      }),
+```
+
+Add `diffContextMode` and `syntax.newText` / `syntax.oldText` to that `useMemo`'s
+dependency array. Apply the identical change at
+`src/screens/CommitPanel.tsx:481`, `src/screens/RepoBrowser.tsx:595`, and
+`src/screens/DiffViewer.tsx:198`.
+
+**`DiffViewer` has one extra rule.** Its find-in-diff filter rewrites
+`findFiltered.hunks` down to matching lines only, so the result is a match list,
+not a file. Filler rows are never matches and must be suppressed while a query
+is active:
+
+```tsx
+        wholeFile:
+          diffContextMode === "wholeFile" && !findQuery.trim()
+            ? { newText: syntax.newText, oldText: syntax.oldText }
+            : undefined,
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- src/features/diff src/screens/CommitPanel.lineStaging.test.tsx src/screens/RepoBrowser.staging.test.tsx src/screens/History.diff.test.tsx
+pnpm tsc --noEmit
+```
+
+Expected: PASS. `CommitPanel.lineStaging.test.tsx` is the one that matters most —
+it pins that clicking a line stages the right index, which whole-file mode must
+not disturb.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/syntax/useDiffSyntax.ts src/features/diff src/screens/CommitPanel.tsx src/screens/DiffViewer.tsx src/screens/RepoBrowser.tsx
+git commit -m "feat(diff): show the whole file by default on every diff surface"
+```
+
+---
+
+### Task 5: Tokenize in a Worker, with a packed transfer and a main-thread fallback
+
+**Files:**
+- Create: `src/lib/syntax/tokenizeCore.ts` (worker-safe: guards, Shiki call, pack/unpack)
+- Create: `src/lib/syntax/tokenize.worker.ts`
+- Modify: `src/lib/syntax/tokenize.ts` (cache + client + fallback; keeps its signature)
+- Test: `src/lib/syntax/tokenizeCore.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `SyntaxLine`, `SyntaxToken`.
+- Produces:
+  - `tokenizeCore.ts`: `PackedSyntax`, `packLines(lines): PackedSyntax`,
+    `unpackLines(p): SyntaxLine[]`, `tokenizeToPacked(path, text): Promise<PackedSyntax | null>`,
+    plus `MAX_HIGHLIGHT_BYTES` / `MAX_HIGHLIGHT_LINES` / `toLineRelative` moved here.
+  - `tokenize.ts`: `tokenizeFile(path, text): Promise<SyntaxLine[] | null>` — signature
+    unchanged, so `useSyntax` / `useDiffSyntax` and their tests need no edits. It
+    re-exports the moved symbols so existing `from "./tokenize"` imports keep working.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/syntax/tokenizeCore.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { packLines, unpackLines, type PackedSyntax } from "./tokenizeCore";
+import type { SyntaxLine } from "./tokenize";
+
+const lines: SyntaxLine[] = [
+  [
+    { start: 0, end: 5, cls: "pg-kw" },
+    { start: 6, end: 7, cls: "pg-id" },
+  ],
+  [],
+  [{ start: 0, end: 3, cls: "pg-kw" }],
+];
+
+describe("packed syntax transfer", () => {
+  it("round-trips tokens through the flat arrays", () => {
+    expect(unpackLines(packLines(lines))).toEqual(lines);
+  });
+
+  it("dedupes class names into a table so the payload stays small", () => {
+    const p: PackedSyntax = packLines(lines);
+    expect(p.classes).toEqual(["pg-kw", "pg-id"]);
+    expect(p.data).toBeInstanceOf(Int32Array);
+  });
+
+  it("preserves empty lines", () => {
+    expect(unpackLines(packLines([[], []]))).toEqual([[], []]);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- src/lib/syntax/tokenizeCore.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `src/lib/syntax/tokenizeCore.ts`**
+
+Move `toLineRelative`, `MAX_HIGHLIGHT_BYTES` and `MAX_HIGHLIGHT_LINES` out of
+`tokenize.ts` into this file verbatim, then add:
+
+```ts
+/**
+ * Tokens flattened into transferable arrays.
+ *
+ * Returning SyntaxLine[] across the worker boundary would structured-clone
+ * hundreds of thousands of small objects for a large file, moving the cost onto
+ * the main thread instead of removing it. These two Int32Arrays are transferred
+ * zero-copy and materialized in one tight pass.
+ */
+export interface PackedSyntax {
+  /** Distinct class names; `data` stores indices into this. */
+  classes: string[];
+  /** length = lineCount + 1; token-triple index where each line starts. */
+  lineStarts: Int32Array;
+  /** Flat [start, end, classId] triples. */
+  data: Int32Array;
+}
+
+export function packLines(lines: SyntaxLine[]): PackedSyntax {
+  const classes: string[] = [];
+  const ids = new Map<string, number>();
+  let total = 0;
+  for (const l of lines) total += l.length;
+  const data = new Int32Array(total * 3);
+  const lineStarts = new Int32Array(lines.length + 1);
+  let t = 0;
+  for (let i = 0; i < lines.length; i++) {
+    lineStarts[i] = t;
+    for (const tok of lines[i]) {
+      let id = ids.get(tok.cls);
+      if (id === undefined) {
+        id = classes.length;
+        classes.push(tok.cls);
+        ids.set(tok.cls, id);
+      }
+      data[t * 3] = tok.start;
+      data[t * 3 + 1] = tok.end;
+      data[t * 3 + 2] = id;
+      t++;
+    }
+  }
+  lineStarts[lines.length] = t;
+  return { classes, lineStarts, data };
+}
+
+export function unpackLines(p: PackedSyntax): SyntaxLine[] {
+  const out: SyntaxLine[] = [];
+  for (let i = 0; i + 1 < p.lineStarts.length; i++) {
+    const line: SyntaxLine = [];
+    for (let t = p.lineStarts[i]; t < p.lineStarts[i + 1]; t++) {
+      line.push({
+        start: p.data[t * 3],
+        end: p.data[t * 3 + 1],
+        cls: p.classes[p.data[t * 3 + 2]],
+      });
+    }
+    out.push(line);
+  }
+  return out;
+}
+
+/**
+ * The actual tokenization. Runs in the worker normally, and on the main thread
+ * when no worker is available. Resolves null whenever highlighting is not
+ * available or not worth it — callers render plain text.
+ */
+export async function tokenizeToPacked(
+  path: string,
+  text: string,
+): Promise<PackedSyntax | null> {
+  const lang = langForPath(path);
+  if (!lang) return null;
+  if (text.length > MAX_HIGHLIGHT_BYTES) return null;
+  if (text.split("\n").length > MAX_HIGHLIGHT_LINES) return null;
+  if (!(await ensureLanguage(lang))) return null;
+  try {
+    const hl = await getHighlighter();
+    const { tokens } = hl.codeToTokens(text, {
+      lang,
+      theme: SENTINEL_THEME_NAME,
+    }) as { tokens: RawToken[][] };
+    return packLines(toLineRelative(tokens));
+  } catch {
+    return null;
+  }
+}
+```
+
+Import `langForPath`, `ensureLanguage`, `getHighlighter`, `SENTINEL_THEME_NAME`
+and `classForColor` here, and move the `RawToken` interface across too. This
+file must not import anything DOM-only — it runs in the worker.
+
+- [ ] **Step 4: Create the worker**
+
+`src/lib/syntax/tokenize.worker.ts`:
+
+```ts
+/// <reference lib="webworker" />
+// Tokenization runs here so a large file never blocks the main thread. Shiki is
+// configured with engine-javascript (no WASM asset), so it is worker-safe.
+import { tokenizeToPacked, type PackedSyntax } from "./tokenizeCore";
+
+export interface TokenizeRequest {
+  id: number;
+  path: string;
+  text: string;
+}
+export interface TokenizeReply {
+  id: number;
+  packed: PackedSyntax | null;
+}
+
+self.onmessage = async (e: MessageEvent<TokenizeRequest>) => {
+  const { id, path, text } = e.data;
+  const packed = await tokenizeToPacked(path, text);
+  const reply: TokenizeReply = { id, packed };
+  // Transfer the buffers rather than copying them.
+  const transfer = packed ? [packed.lineStarts.buffer, packed.data.buffer] : [];
+  (self as unknown as Worker).postMessage(reply, transfer as Transferable[]);
+};
+```
+
+- [ ] **Step 5: Rewrite `tokenize.ts` as cache + client + fallback**
+
+Keep the existing `hash`, `cache`, `CACHE_MAX`, `remember` and
+`clearSyntaxCache` exactly as they are. Replace the body of `tokenizeFile` and
+add the client:
+
+```ts
+// undefined = not tried yet, null = unavailable (fall back to this thread).
+let worker: Worker | null | undefined;
+let nextId = 1;
+const pending = new Map<number, (p: PackedSyntax | null) => void>();
+
+function disableWorker() {
+  worker?.terminate();
+  worker = null;
+  // Nobody is coming to answer these. Resolve them so no caller waits forever;
+  // they fall back to this thread on the retry below.
+  const waiting = [...pending.values()];
+  pending.clear();
+  for (const resolve of waiting) resolve(null);
+}
+
+function getWorker(): Worker | null {
+  if (worker !== undefined) return worker;
+  try {
+    const w = new Worker(new URL("./tokenize.worker.ts", import.meta.url), {
+      type: "module",
+    });
+    w.onmessage = (e: MessageEvent<TokenizeReply>) => {
+      const resolve = pending.get(e.data.id);
+      if (resolve) {
+        pending.delete(e.data.id);
+        resolve(e.data.packed);
+      }
+    };
+    // A failed script load or a worker crash lands here. Degrading to the main
+    // thread means the worst case is the behaviour we had before it existed.
+    w.onerror = disableWorker;
+    w.onmessageerror = disableWorker;
+    worker = w;
+  } catch {
+    worker = null;
+  }
+  return worker;
+}
+
+/**
+ * Tokenize a whole file. Resolves null whenever highlighting is not available
+ * or not worth it. Callers treat null as "render plain text".
+ *
+ * The heavy work happens in a Worker, so switching files while a large one is
+ * still tokenizing does not block the UI. Results are cached on THIS thread, so
+ * a hit never crosses the boundary.
+ */
+export async function tokenizeFile(
+  path: string,
+  text: string,
+): Promise<SyntaxLine[] | null> {
+  const lang = langForPath(path);
+  if (!lang) return null;
+  if (text.length > MAX_HIGHLIGHT_BYTES) return null;
+  if (text.split("\n").length > MAX_HIGHLIGHT_LINES) return null;
+
+  const key = `${lang}:${hash(text)}:${text.length}`;
+  const hit = cache.get(key);
+  if (hit) return hit;
+
+  const w = getWorker();
+  let packed: PackedSyntax | null = null;
+  if (w) {
+    const id = nextId++;
+    packed = await new Promise<PackedSyntax | null>((resolve) => {
+      pending.set(id, resolve);
+      w.postMessage({ id, path, text } satisfies TokenizeRequest);
+    });
+  }
+  // No worker, or the worker went away mid-request.
+  if (!packed && !worker) packed = await tokenizeToPacked(path, text);
+  if (!packed) return null;
+  return remember(key, unpackLines(packed));
+}
+```
+
+Re-export the moved symbols at the end of the file so existing imports keep
+working:
+
+```ts
+export {
+  toLineRelative,
+  MAX_HIGHLIGHT_BYTES,
+  MAX_HIGHLIGHT_LINES,
+} from "./tokenizeCore";
+```
+
+Note the deliberate asymmetry in the fallback condition: `!worker` is only true
+after `disableWorker` ran, so a legitimate `null` result (unknown language,
+Shiki failure) is **not** retried on the main thread.
+
+- [ ] **Step 6: Run the syntax tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- src/lib/syntax
+pnpm tsc --noEmit
+```
+
+Expected: PASS. jsdom has no `Worker`, so these exercise the main-thread
+fallback — which is exactly the path that must keep working.
+`tokenize.integration.test.ts` is the one that proves real tokens still come out.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/syntax
+git commit -m "perf(diff): tokenize syntax in a worker with a packed transfer"
+```
+
+---
+
+### Task 6: Preload neighbouring files when a commit opens
+
+**Files:**
+- Create: `src/lib/syntax/usePrefetchSyntax.ts`
+- Modify: `src/lib/syntax/index.ts` (export it)
+- Modify: `src/features/diff/CommitDiffPanel.tsx` (call it)
+- Test: `src/lib/syntax/usePrefetchSyntax.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `tokenizeFile` from Task 5, `SideSource` from `useDiffSyntax`.
+- Produces: `usePrefetchSyntax({repoId, paths, source, enabled})` — fire-and-forget, returns nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/syntax/usePrefetchSyntax.test.tsx`:
+
+```tsx
+it("prefetches at most PREFETCH_MAX files and skips the selected one", async () => {
+  const reads: string[] = [];
+  mockInvoke("read_file_content_at_rev", (args) => {
+    reads.push(args.path as string);
+    return { path: args.path, binary: false, text: "const a = 1;", fromHead: false, size: 12 };
+  });
+  renderHook(() =>
+    usePrefetchSyntax({
+      repoId: "r1",
+      paths: ["a.ts", "b.ts", "c.ts", "d.ts", "e.ts", "f.ts"],
+      source: { kind: "rev", rev: "abc" },
+      enabled: true,
+    }),
+  );
+  await waitFor(() => expect(reads.length).toBe(PREFETCH_MAX));
+  expect(reads).not.toContain("a.ts");
+});
+```
+
+Read `src/test/setup.ts` for `mockInvoke`'s exact signature before writing this.
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- src/lib/syntax/usePrefetchSyntax.test.tsx
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the hook**
+
+```ts
+import React from "react";
+import { readFileContent, readFileContentAtIndex, readFileContentAtRev } from "@/lib/tauri";
+import { tokenizeFile } from "./tokenize";
+import type { SideSource } from "./useDiffSyntax";
+
+/**
+ * How many neighbours to warm. Each one costs an IPC read, so this stays small:
+ * a 200-file commit must not fire 200 reads, and with tokenization already off
+ * the main thread this is a nicety rather than the fix for jank.
+ */
+export const PREFETCH_MAX = 4;
+
+/**
+ * Warm the token cache for the files a user is likely to open next.
+ *
+ * Runs at idle so it never competes with the file the user actually selected,
+ * and abandons everything when the commit or selection changes — a superseded
+ * prefetch that kept running would fill the LRU with files nobody asked for.
+ */
+export function usePrefetchSyntax(o: {
+  repoId: string | null;
+  /** Candidate paths, in list order. The first is assumed already loading. */
+  paths: string[];
+  source: SideSource;
+  enabled: boolean;
+}): void {
+  const { repoId, enabled } = o;
+  const kind = o.source.kind;
+  const rev = o.source.kind === "rev" ? o.source.rev : null;
+  // Join to a primitive: callers rebuild the array every render, so depending on
+  // its identity would restart the prefetch on every render.
+  const key = o.paths.join(" ");
+
+  React.useEffect(() => {
+    if (!enabled || !repoId || kind === "none") return;
+    const targets = key.split(" ").filter(Boolean).slice(1, 1 + PREFETCH_MAX);
+    if (targets.length === 0) return;
+    let cancelled = false;
+
+    const read = (p: string) => {
+      if (kind === "worktree") return readFileContent(repoId, p);
+      if (kind === "index") return readFileContentAtIndex(repoId, p);
+      return rev ? readFileContentAtRev(repoId, rev, p) : Promise.resolve(null);
+    };
+
+    const idle = (fn: () => void) =>
+      typeof requestIdleCallback === "function"
+        ? requestIdleCallback(fn)
+        : setTimeout(fn, 0);
+
+    const handle = idle(() => {
+      void (async () => {
+        for (const p of targets) {
+          if (cancelled) return;
+          try {
+            const c = await read(p);
+            if (cancelled || !c?.text) continue;
+            await tokenizeFile(p, c.text);
+          } catch {
+            // A prefetch failure is not a user-visible error — the real read
+            // will surface it if they actually open the file.
+          }
+        }
+      })();
+    });
+
+    return () => {
+      cancelled = true;
+      if (typeof cancelIdleCallback === "function") cancelIdleCallback(handle as number);
+      else clearTimeout(handle as ReturnType<typeof setTimeout>);
+    };
+  }, [repoId, kind, rev, key, enabled]);
+}
+```
+
+Export it from `src/lib/syntax/index.ts`.
+
+- [ ] **Step 4: Call it from `CommitDiffPanel`**
+
+Order the candidate list so the selected file is first (it is already loading,
+and the hook skips index 0), then its neighbours:
+
+```tsx
+  const prefetchPaths = React.useMemo(() => {
+    const others = diffs.map((d) => d.path).filter((p) => p !== current?.path);
+    return current ? [current.path, ...others] : others;
+  }, [diffs, current?.path]);
+
+  usePrefetchSyntax({
+    repoId,
+    paths: prefetchPaths,
+    source: newSide,
+    enabled: !loading && !error,
+  });
+```
+
+`newSide` is the same `SideSource` the panel already passes to `useDiffSyntax` as
+its `new` argument — hoist it to a variable if it is currently written inline.
+If `repoId` is not already in scope, read it the same way the existing
+`useDiffSyntax` call does.
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- src/lib/syntax src/features/diff
+pnpm tsc --noEmit
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/syntax src/features/diff/CommitDiffPanel.tsx
+git commit -m "perf(diff): warm the token cache for a commit's other files"
+```
+
+---
+
+### Task 7: Full verification and e2e
+
+**Files:** none modified unless a check fails.
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Full unit + component suite**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test
+```
+
+Expected: all PASS. Fix anything red before continuing — do not proceed to e2e
+on a red suite.
+
+- [ ] **Step 2: Type-check both projects**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm tsc --noEmit
+pnpm exec tsc -p e2e/tsconfig.json --noEmit
+```
+
+Expected: clean. The second is a separate gate because the root `tsc` excludes
+`e2e/`.
+
+- [ ] **Step 3: Confirm the Rust side is untouched**
+
+```bash
+git diff --stat origin/main -- src-tauri
+```
+
+Expected: empty. This plan makes no backend change; output here means something
+went wrong.
+
+- [ ] **Step 4: Build the e2e snapshot for this worktree**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test:e2e:docker build
+```
+
+Frontend changed, so the snapshot must be rebuilt — the `run` phase silently
+tests the old binary otherwise.
+
+- [ ] **Step 5: Run only the affected specs**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test:e2e:docker run --spec e2e/specs/diff.e2e.ts --spec e2e/specs/staging.e2e.ts
+```
+
+List the real filenames from `ls e2e/specs/` first and pick the diff, staging,
+commit and settings specs. Never run this natively.
+
+- [ ] **Step 6: Squash and open the PR**
+
+```bash
+git reset --soft origin/main
+git add -A
+git commit -m "feat(diff): whole-file inline diff with off-main-thread highlighting"
+git push -u origin feat/inline-whole-file-diff
+gh pr create --fill
+```
+
+Pin `origin/main`'s SHA before the reset and confirm it has not moved, so the
+squash cannot revert a concurrently merged PR.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+| --- | --- |
+| §1 Whole file as gap-filled rows | 3 (model), 4 (surfaces) |
+| §1 `fill` as a distinct row kind | 3 |
+| §1 Correctness guard / degrade to chunked | 3 (four null cases tested) |
+| §1 Text from `useDiffSyntax`, no extra IPC | 4 |
+| §2 Settings (`diffViewMode`, `diffContextMode`, relabel) | 2 |
+| §3 Stronger word tokens, both files, both modes | 1 |
+| §4 Worker + fallback | 5 |
+| §4 Packed transfer | 5 |
+| §4 Preload on commit open | 6 |
+| Edge: oversized file ceiling | 3 (`MAX_WHOLE_FILE_LINES`) |
+| Edge: find-in-diff suppresses filler | 4 |
+| Edge: binary / no text | 3 (null text → chunked), 4 |
+| Testing section | 1–6 inline, 7 full gate |
+
+Gap found and closed: the spec's edge case about surfacing a note with a "show
+whole file anyway" button for oversized files is **not** implemented — Task 3
+silently renders chunked past `MAX_WHOLE_FILE_LINES`. Rather than add UI this
+plan does not need, the ceiling is documented in the constant's comment and the
+behaviour is a safe degrade. Revisit if it proves confusing in use.
+
+**Placeholder scan:** no TBDs. Three steps deliberately say "read the existing
+file and match its pattern" (Task 1 Step 1 query style, Task 2 Step 6 Settings
+rows, Task 6 Step 4 `newSide`) because those files own conventions that must be
+followed rather than guessed; each names the exact file and what to look for.
+
+**Type consistency:** `PackedSyntax`, `packLines`, `unpackLines`,
+`tokenizeToPacked` are named identically in Tasks 5's definition and use.
+`wholeFile: { newText, oldText }` matches `DiffSyntax`'s new `newText`/`oldText`
+fields in Task 4. `MAX_WHOLE_FILE_LINES` is defined in Task 3 and referenced
+only there. `PREFETCH_MAX` is defined and asserted in Task 6.

--- a/docs/superpowers/specs/2026-08-14-whole-file-diff-and-async-highlight-design.md
+++ b/docs/superpowers/specs/2026-08-14-whole-file-diff-and-async-highlight-design.md
@@ -1,0 +1,325 @@
+# Whole-file diff, stronger word highlight, and off-main-thread tokenization
+
+Date: 2026-08-14
+
+## Context
+
+The user asked for four things:
+
+1. Inline (unified) diff as the **default** view, green backgrounds for added
+   lines and red for removed.
+2. Word-level diff keeping those line colours, but with a **stronger** highlight
+   on the changed words themselves.
+3. **Whole file** shown by default instead of just the changed chunks, with
+   chunked context available as a setting.
+4. Selecting a file and immediately moving to another must **not freeze** the
+   app while the first file's syntax highlighting is computed — plus make
+   highlighting faster generally, possibly by preloading when a commit opens.
+
+Much of the surrounding machinery already landed in #104, after this request was
+made. What exists today:
+
+- `src/lib/syntax/` — Shiki (`engine-javascript`, no WASM asset) tokenizer with a
+  24-entry LRU cache keyed `lang:hash:len`, and guards at 1 MB /
+  20 000 lines (`MAX_HIGHLIGHT_BYTES`, `MAX_HIGHLIGHT_LINES`).
+- `useSyntax(path, text)` — resolves tokens, renders plain text meanwhile.
+- `useDiffSyntax({repoId, path, old, new})` — reads **both sides' whole-file
+  text** over IPC and tokenizes each. Already used by all four diff surfaces.
+- `src/lib/diffRows.ts` — `flattenDiffRows(hunks, {headerH, rowH, collapsed,
+  syntax})` produces a flat `DiffRow[]`; `windowVariable` gives an exact
+  variable-height window over known row heights.
+- `src/design/PGWindowedDiff.tsx` — the one renderer for that row list, with
+  per-hunk stage/discard, line selection, `data-hunk-index` for F7 and e2e.
+- Line backgrounds, gutter stripes, word spans and syntax layering all render
+  through `PGDiffRow` / `buildLineSpans`.
+
+So items 1 and 2 are largely satisfied already, and the shared renderer this
+work would otherwise have had to build is in place. What remains is narrower
+than it first appeared, and this spec covers only that remainder.
+
+### What is actually still missing
+
+| Ask | State | Work |
+| --- | --- | --- |
+| Inline default | `DiffViewer` defaults to `unified` but in **ephemeral local state** (`useState`), so it is not a preference and does not persist | Persist as a setting |
+| Green/red lines | Done | — |
+| Stronger word highlight | Changed-word tint is a weak `0.28` alpha over an already-tinted line | New tokens, stronger value |
+| Whole file by default | **Not done.** Every surface renders only the hunks returned at `diffContextLines` (3) | Gap-fill rows + setting |
+| No freeze on file switch | **Not fixed.** `useSyntax` discards stale *results*, but `tokenizeFile` → `hl.codeToTokens` is synchronous CPU work on the main thread, so the cost is still paid and the UI still janks | Move tokenization to a Worker |
+| Faster / preload | Cache exists; nothing preloads | Packed transfer + bounded idle prefetch |
+
+## Goals
+
+- Whole file is the default diff view on every diff surface, including the
+  staging surface, **without changing what "stage hunk" stages**.
+- Chunked context remains available as an explicit setting.
+- Inline vs split is a persisted preference, defaulting to inline.
+- Changed words read clearly stronger than the surrounding changed line.
+- Switching files never blocks the main thread on tokenization.
+
+## Non-goals
+
+- No change to the split (side-by-side) renderer beyond it honouring the
+  persisted mode.
+- No change to the Rust backend. No new `GitBackend` method, no new command.
+  The existing `get_diff` / `read_file_content*` plumbing is sufficient.
+- The Conflict and Merge-window panes keep their current rendering.
+- No lazy per-row token materialization (see Future work).
+
+## Design
+
+### 1. Whole file as gap-filled rows
+
+The naive approach — ask libgit2 for a huge `context_lines` — is **wrong and
+must not be used**. Hunk indices are the wire contract with the backend
+(`stage_hunk(path, hunkIndex, contextLines)`), and `changedIndex` is the
+per-hunk changed-line index that line staging addresses (#61 D7). With
+whole-file context libgit2 returns a single hunk covering the file, so
+"stage hunk" would stage everything and line indices would shift. That is a
+data-loss-class bug in a git client.
+
+Instead, keep the canonical diff exactly as fetched and **compose the whole-file
+view around it**. The unchanged regions between hunks are, by definition,
+byte-identical on both sides, so they can be filled in from file text the app
+already has.
+
+`DiffRow` gains a third variant:
+
+```ts
+export type DiffRow =
+  | { kind: "header"; hunkIndex: number; header: string; h: number }
+  | { kind: "line"; hunkIndex: number; line: DiffLineData; h: number }
+  | { kind: "fill"; line: DiffLineData; h: number };
+```
+
+`fill` is a separate kind rather than a `line` row with a sentinel `hunkIndex`
+on purpose: `PGWindowedDiff` looks up `hunkActions(row.hunkIndex)` and wires
+`onLineClick(row.hunkIndex, …)`. A filler row carries no hunk, and a sentinel
+number would be one forgotten guard away from staging the wrong hunk. A
+distinct kind cannot be mistaken for a stageable row — the type checker
+enforces it at every consumer.
+
+`flattenDiffRows` takes one new option:
+
+```ts
+wholeFile?: { newText: string | null; oldText: string | null };
+```
+
+When present, it inserts `fill` rows before the first hunk, between consecutive
+hunks, and after the last hunk. For a gap following a hunk `h` and preceding
+hunk `next`:
+
+- new-side range: `[h.newStart + h.newLines, next.newStart - 1]`
+- old-side range: `[h.oldStart + h.oldLines, next.oldStart - 1]`
+- both ranges have the same length, because the region is unchanged
+- text comes from `newText`, split on `\n`, 0-indexed at `newStart - 1`
+- each filler row is `{ kind: "ctx", lnL, lnR, text }`, so it renders exactly
+  like a context line and picks up syntax through the existing `withSyntax`
+
+**Hunk headers stay.** They are the per-change-block affordance carrying
+Stage / Discard, the collapse chevron, `data-hunk-index` for F7 navigation, and
+the selectors the e2e specs address. Keeping them is what makes this "the Rider
+stage view, but showing the whole file": the file reads continuously, and each
+change block still has its own stage control. Nothing about staging changes —
+same hunks, same indices, same `changedIndex` numbering — because
+`withChangedIndices` still runs over the hunk's own lines before any filler is
+interleaved.
+
+**Correctness guard.** `composeFillRows` returns `null` if the arithmetic does
+not check out: a negative or descending range, a gap length that disagrees
+between the two sides, or a required text line beyond the end of the text. The
+caller then renders that file chunked. A whole-file view with wrong line numbers
+is worse than no whole-file view, so an inconsistency degrades visibly to the
+known-good mode rather than rendering something plausible and wrong.
+
+**Where the text comes from — no extra IPC.** `useDiffSyntax` already reads both
+sides' whole-file text to tokenize them; it just does not expose the text. It
+gains `oldText` / `newText` on its return value. Every one of the four surfaces
+already calls it, so whole-file mode costs no additional round trip. Surfaces
+that cannot get text (binary, and reads that fail) fall back to chunked.
+
+### 2. Settings
+
+Two new persisted keys, plus a relabel:
+
+- `diffViewMode: "inline" | "split"`, default `"inline"`. `DiffViewer`'s toolbar
+  toggle reads and writes this instead of local `useState`, so the choice
+  survives navigation and restart.
+- `diffContextMode: "wholeFile" | "chunks"`, default `"wholeFile"`.
+- `diffContextLines` (existing, default 3) stays and keeps its current meaning
+  for the fetch. It governs chunk size in chunked mode, and it continues to be
+  the value passed to every hunk-staging call in **both** modes — so its
+  Settings label must say it still applies, not imply it is chunks-only.
+
+`Settings.tsx` gets the two controls next to the existing context-lines field.
+
+### 3. Stronger word highlight
+
+Add `--git-added-word` / `--git-removed-word` to `:root` in `index.css` **and**
+to `SEMANTIC_TOKENS` for both `dark` and `light` in `useSettingsStore.ts` — the
+two must be edited together or they drift, and light needs its own calibration
+rather than inheriting a dark-calibrated value (#61 B4). `DiffText` uses the
+token instead of its inline `oklch(from … / 0.28)`.
+
+Values: roughly `0.55` alpha equivalent in dark and a correspondingly deeper
+tint in light, chosen so the changed word separates clearly from its line
+background while the line's own green/red stays readable. Derived from
+`--git-added` / `--git-removed` with `oklch(from …)` so custom accent themes
+carry through, per the styling convention.
+
+### 4. Off-main-thread tokenization
+
+**Root cause of the freeze.** `useSyntax` cancels stale *results*, but
+`tokenizeFile` awaits nothing before `hl.codeToTokens(text, …)`, which is
+synchronous CPU work. Selecting file A then B still runs A's tokenization to
+completion on the main thread; the `cancelled` flag only throws the answer away
+afterwards. Nothing is saved, and the jank is unchanged.
+
+**Fix: a module Worker.** Shiki is configured with `engine-javascript`, so it is
+pure JS with no WASM asset and is safe to run in a worker.
+
+- `src/lib/syntax/tokenize.worker.ts` — owns the Shiki instance, the grammar
+  loading, and `codeToTokens`. Receives `{id, path, text}`, replies
+  `{id, packed}`.
+- `src/lib/syntax/tokenizeClient.ts` — constructs the worker lazily on first
+  use, keeps the LRU cache **on the main thread** (so a hit never crosses the
+  boundary), tracks the newest request id per caller, and drops replies for
+  superseded ids. Posts `cancel` so the worker skips queued-but-superseded jobs.
+- `tokenizeFile` keeps its exact signature and null contract, so `useSyntax`,
+  `useDiffSyntax` and every existing test are unchanged.
+
+**Fallback is mandatory.** If `new Worker(...)` throws or the worker fails to
+initialize, `tokenizeClient` transparently falls back to tokenizing on the main
+thread — today's behaviour. This covers jsdom (component tests have no real
+Worker) and any webview where module workers misbehave, and means the feature
+can only improve responsiveness, never break highlighting.
+
+**Packed transfer.** Returning `SyntaxLine[]` directly would structured-clone
+hundreds of thousands of small objects for a large file, moving cost to the main
+thread instead of removing it. The worker instead returns
+
+```ts
+{ classes: string[]; lineStarts: Int32Array; data: Int32Array }
+```
+
+where `data` is a flat `[start, end, classId, …]` triple stream and
+`lineStarts` indexes into it per line. Both arrays are **transferred**
+(zero-copy). The main thread materializes `SyntaxLine[]` in one tight pass with
+no per-object clone. This is also the "make it faster" part of the ask: it is
+strictly less main-thread work than today, on top of no longer tokenizing there.
+
+**Preload on commit open.** After the selected file's tokens resolve,
+`CommitDiffPanel` idle-queues tokenization for its neighbours in the file list
+(the likely next selection) via `requestIdleCallback`, capped at 4 files and
+cancelled when the commit or selection changes. Each queued file needs its text,
+so this is also where the IPC read happens; the cap keeps a 200-file commit from
+issuing 200 reads. With the worker in place this is a nicety rather than the
+fix — switching files is already non-blocking — so it stays deliberately small.
+
+## Edge cases
+
+- **Binary file** — no text, no tokens; chunked rows as today.
+- **New file** — one hunk covering the file, so no gaps; whole-file view is
+  identical to chunked. No special case needed.
+- **Deleted file** — likewise one hunk; filler would come from `oldText` if a
+  gap ever arose. Guarded by the arithmetic check rather than special-cased.
+- **Renames** — `useDiffSyntax`'s `rev` source already carries its own `path` so
+  the old side reads the pre-rename blob; gap filling uses the new side.
+- **Whitespace-ignore** — already disables hunk staging (#61 D2). The whole-file
+  view still renders; the block affordance shows the existing disabled reason.
+  Filler rows are unaffected, since ignore-whitespace changes hunk content but
+  the ranges still describe real file lines.
+- **Oversized file** — highlighting already bails past 1 MB / 20 000 lines.
+  Whole-file **rendering** reuses that line ceiling: past
+  `MAX_HIGHLIGHT_LINES` the view stays chunked, since inserting 200 000 filler
+  rows would fight the performance goal this same change is trying to meet.
+  Surface it as a one-line note with a button to show the whole file anyway,
+  rather than silently ignoring the setting.
+- **Find-in-diff filter** (`DiffViewer`) filters hunk lines. Filler rows are not
+  matches and are suppressed while a query is active, so the result list stays a
+  list of matches.
+
+## Testing
+
+- `diffRows.test.ts` — extended: filler rows land in the right places; line
+  numbers continue correctly across gaps on both sides; `hunkIndex` and
+  `changedIndex` on real hunk rows are **byte-identical with and without**
+  whole-file mode (the staging-safety invariant); each inconsistency case
+  returns null.
+- `tokenizeClient.test.ts` — superseded ids are dropped; the main-thread
+  fallback produces the same tokens as the worker path; packed round-trip
+  reproduces the `SyntaxLine[]` the direct path yields.
+- Component: `CommitPanel` stages the **correct hunk index** from a block in
+  whole-file mode; whole-file rows appear in `CommitDiffPanel`; rapid file
+  switching ends on the second file's content.
+- `useSettingsStore.test.ts` — round-trip of the two new keys and their
+  defaults.
+- E2E: only the diff/staging specs, in Docker, once at the end
+  (`pnpm test:e2e:docker build` then `run --spec …`), per CLAUDE.md.
+
+## Risks
+
+- **Wrong hunk staged.** The one serious risk. Mitigated by making filler a
+  distinct row kind the type system keeps out of staging paths, by leaving
+  `withChangedIndices` untouched, and by the with/without-fill parity test.
+- **Module workers in WebKitGTK / WKWebView.** Mitigated by the mandatory
+  main-thread fallback — worst case is today's behaviour.
+- **Whole-file default makes big diffs heavier.** Mitigated by the existing
+  exact variable-height window (only visible rows render) plus the line ceiling.
+
+## Found during implementation
+
+Two things this design did not anticipate, both fixed in the same branch:
+
+1. **`vite.config.ts` needs `worker: { format: "es" }`.** Shiki loads each grammar
+   as a dynamic import, so the worker bundle is code-split, and Vite's default
+   `iife` worker format makes rollup fail the production build outright. Caught by
+   running `pnpm vite build`, not by any test — the dev server and vitest are both
+   happy without it.
+
+2. **A latent windowing bug, exposed by whole-file mode.** All four diff surfaces
+   measured their scroll viewport as
+
+   ```ts
+   if (!el || typeof ResizeObserver === "undefined") return;
+   setViewportH(el.clientHeight);
+   ```
+
+   The guard runs first, so on a webview with no `ResizeObserver` the initial
+   measurement never happened and the height stayed 0. `windowVariable` then fell
+   back to a 400px viewport, so rows past 400px were never mounted and the bottom
+   of a taller diff pane rendered blank. WebKitGTK 605 — the Linux webview and the
+   e2e target — is exactly such a webview. Chunked diffs are short enough to fit
+   inside the fallback, which is why it went unnoticed; whole-file diffs made the
+   row list long enough to hit it. Now `lib/useViewportH.ts`, measured
+   unconditionally, with the observer as an enhancement.
+
+   Found by the `keymap` F7 e2e spec, whose second hunk stopped rendering. That
+   spec also assumed both hunks were on screen simultaneously — true of a chunked
+   60-line fixture, not of a whole-file one — so its precondition now asserts hunk
+   0 and lets the F7 sequence prove hunk 1, which additionally exercises F7's
+   scroll-into-view for the first time.
+
+Also worth recording: the Shiki call was split into `tokenizeShiki.ts` so the main
+thread imports it only dynamically, as a fallback. That drops the main bundle from
+1046 kB to 881 kB (gzip 324 → 269 kB), since Shiki now ships only in the worker
+chunk on the normal path.
+
+## Known characteristics
+
+The worker handles requests in order, and a single `codeToTokens` call cannot be
+interrupted once started. Clicking through several files quickly therefore queues
+their tokenizations: the UI never blocks and each file's text renders immediately,
+but a later file's *colours* can wait behind an earlier large file's. Deliberately
+not solved with a main-thread queue that drops superseded jobs — resolving a
+dropped request means "this file renders plain", and getting that wrong leaves a
+file permanently uncoloured, which is worse than the latency. The bounded prefetch
+makes the common case a cache hit instead.
+
+## Future work
+
+Lazy per-row token materialization: with a windowed renderer only ~50 lines are
+on screen, so `SyntaxLine[]` could be built per visible row from the packed
+arrays instead of eagerly for the whole file. Not done here — the packed
+transfer already removes the dominant cost, and `withSyntax` currently wants an
+indexable array.

--- a/e2e/specs/keymap.e2e.ts
+++ b/e2e/specs/keymap.e2e.ts
@@ -486,8 +486,13 @@ describe("keymap — rider preset (default)", () => {
     await openRepo(repo.path);
     await jsChord("Mod+D");
     await waitScreen('[data-pg-pane="diff.files"]', "Diff");
-    await $('[data-hunk-index="1"]').waitForDisplayed({
-      timeout: 20_000, timeoutMsg: "second hunk never rendered — fixture geometry off?",
+    // Only hunk 0 is asserted up front. The diff is windowed and whole-file by
+    // default, so hunk 1 — ~50 lines further down — is not mounted until F7
+    // scrolls it into view; requiring it here would fail for a reason that has
+    // nothing to do with the keymap. The F7 sequence below proves both hunks
+    // exist, and now also that F7's scroll-into-view works.
+    await $('[data-hunk-index="0"]').waitForDisplayed({
+      timeout: 20_000, timeoutMsg: "first hunk never rendered — fixture geometry off?",
     });
     await jsChord("F7");
     await $('[data-hunk-index="0"][data-hunk-active]').waitForDisplayed({

--- a/src/design/PGWindowedDiff.tsx
+++ b/src/design/PGWindowedDiff.tsx
@@ -50,6 +50,12 @@ export function PGWindowedDiff({
         <div data-pg-spacer="top" style={{ height: `${win.topPad}px` }} />
       )}
       {slice.map((row, i) => {
+        // Whole-file filler: an unchanged line outside every hunk. It belongs to
+        // no hunk, so it gets no selection and no click target — there is no hunk
+        // index it could stage.
+        if (row.kind === "fill") {
+          return <PGDiffRow key={`f${start + i}`} line={row.line} />;
+        }
         if (row.kind === "header") {
           const actions = hunkActions?.(row.hunkIndex) ?? {};
           return (

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -651,8 +651,8 @@ export function PGDiffLine({
  * Render one line as spans, combining syntax classes and word-diff emphasis.
  *
  * Both come from buildLineSpans, which tiles the line — so this maps and never
- * reasons about gaps or overlaps. The changed-span tint stays relative to the
- * existing git tokens so custom and light themes carry through.
+ * reasons about gaps or overlaps. The changed-span tint is its own themeable
+ * token, per MODE, so a light theme can go darker where dark goes lighter.
  */
 function DiffText({
   text,
@@ -676,9 +676,7 @@ function DiffText({
     return <>{text}</>;
   }
   const tint =
-    kind === "add"
-      ? "oklch(from var(--git-added) l c h / 0.28)"
-      : "oklch(from var(--git-removed) l c h / 0.28)";
+    kind === "add" ? "var(--git-added-word)" : "var(--git-removed-word)";
   return (
     <>
       {rendered.map((s, i) => (

--- a/src/design/wordDiffRender.test.tsx
+++ b/src/design/wordDiffRender.test.tsx
@@ -62,6 +62,16 @@ describe("word diff rendering", () => {
     expect(container.textContent).toContain("const a = 2;");
   });
 
+  it("tints changed words with the dedicated word tokens", () => {
+    // The emphasis has to be a token, not an inline alpha off --git-added: a
+    // light theme needs its own calibration, and the theme editor can only reach
+    // a named token.
+    renderLines(pair);
+    const [remMark, addMark] = screen.getAllByTestId("word-change");
+    expect(remMark.style.background).toContain("--git-removed-word");
+    expect(addMark.style.background).toContain("--git-added-word");
+  });
+
   it("pairs line-for-line across a multi-line rem/add run", () => {
     renderLines([
       rem(1, "let x = 1;"),

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -9,9 +9,11 @@ import {
 import { PGPane, FocusableScroll, usePaneList, useHunkNav } from "@/features/keymap";
 import { fileIconSpec } from "@/lib/fileIcon";
 import { WhitespaceToggle } from "./WhitespaceToggle";
+import { useWholeFile } from "./useWholeFile";
 import { SignatureBadge } from "@/features/signing/SignatureBadge";
-import { useDiffSyntax, type SideSource } from "@/lib/syntax";
+import { useDiffSyntax, usePrefetchSyntax, type SideSource } from "@/lib/syntax";
 import { flattenDiffRows, windowVariable } from "@/lib/diffRows";
+import { useViewportH } from "@/lib/useViewportH";
 import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
 import { buildLineSpans } from "@/lib/lineSpans";
 import type { FileDiff } from "@/lib/types";
@@ -147,11 +149,26 @@ export function CommitDiffPanel({
     new: syntaxSides?.new ?? { kind: "none" },
   });
 
+  // Warm the token cache for the commit's other files while nothing else needs
+  // the worker, so moving down the file list usually hits the cache. The selected
+  // file goes first and the hook skips it — it is already loading above.
+  const prefetchPaths = React.useMemo(() => {
+    const others = diffs.filter((d) => d.path !== current?.path).map((d) => d.path);
+    return current ? [current.path, ...others] : others;
+  }, [diffs, current?.path]);
+  usePrefetchSyntax({
+    repoId: syntaxSides?.repoId ?? null,
+    paths: prefetchPaths,
+    source: syntaxSides?.new ?? { kind: "none" },
+    enabled: !loading && !error && !!syntaxSides,
+  });
+
   // Flat rows + an exact window, from the SAME helpers the other diff surfaces
   // use. The panel keeps its own lighter markup, but not its own row model:
   // flattenDiffRows already pairs the word spans and resolves each row's syntax
   // side, which this panel used to do by hand.
   const rowH = useDiffRowHeight();
+  const wholeFile = useWholeFile(syntax);
   const rows = React.useMemo(
     () =>
       flattenDiffRows(current && !current.binary ? current.hunks : [], {
@@ -160,21 +177,14 @@ export function CommitDiffPanel({
         headerH: rowH,
         rowH,
         syntax,
+        wholeFile,
       }),
-    [current, rowH, syntax],
+    [current, rowH, syntax, wholeFile],
   );
   const heights = React.useMemo(() => rows.map((r) => r.h), [rows]);
   const scrollRef = React.useRef<HTMLDivElement>(null);
   const [scrollTop, setScrollTop] = React.useState(0);
-  const [viewportH, setViewportH] = React.useState(0);
-  React.useEffect(() => {
-    const el = scrollRef.current;
-    if (!el || typeof ResizeObserver === "undefined") return;
-    setViewportH(el.clientHeight);
-    const ro = new ResizeObserver(() => setViewportH(el.clientHeight));
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
+  const { viewportH, remeasure } = useViewportH(scrollRef);
   const win = React.useMemo(
     () => windowVariable(heights, { scrollTop, viewportH, overscan: 8 }),
     [heights, scrollTop, viewportH],
@@ -332,7 +342,10 @@ export function CommitDiffPanel({
           style={{ flex: 1, padding: 12 }}
           ariaLabel="Diff"
           innerRef={scrollRef}
-          onScroll={() => setScrollTop(scrollRef.current?.scrollTop ?? 0)}
+          onScroll={() => {
+            setScrollTop(scrollRef.current?.scrollTop ?? 0);
+            remeasure();
+          }}
         >
           {current?.binary && (
             <div style={{ color: "var(--fg-3)", fontSize: "var(--fs-12)" }}>

--- a/src/features/diff/CommitDiffPanel.wholeFile.test.tsx
+++ b/src/features/diff/CommitDiffPanel.wholeFile.test.tsx
@@ -1,0 +1,115 @@
+// Whole-file mode in the commit diff: the unchanged remainder of the file is
+// filled in around the hunk, from the text the syntax hook already read.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { CommitDiffPanel } from "./CommitDiffPanel";
+import type { FileDiff } from "@/lib/types";
+
+// Same reasoning as CommitDiffPanel.syntax.test.tsx: mock the module useSyntax
+// imports so no real grammar loads.
+vi.mock("@/lib/syntax/tokenize", async (orig) => ({
+  ...(await orig<typeof import("@/lib/syntax/tokenize")>()),
+  tokenizeFile: async () => null,
+}));
+
+const FILE = "one\ntwo\nCHANGED\nfour\nfive";
+
+// A 5-line file whose 3rd line changed, fetched with 0 context lines.
+const diffs: FileDiff[] = [
+  {
+    path: "a.ts",
+    oldPath: null,
+    binary: false,
+    additions: 1,
+    deletions: 1,
+    hunks: [
+      {
+        header: "@@ -3,1 +3,1 @@",
+        oldStart: 3,
+        oldLines: 1,
+        newStart: 3,
+        newLines: 1,
+        lines: [
+          { kind: { kind: "Deletion" }, oldLineno: 3, newLineno: null, content: "ORIGINAL" },
+          { kind: { kind: "Addition" }, oldLineno: null, newLineno: 3, content: "CHANGED" },
+        ],
+      },
+    ],
+  },
+];
+
+const sides = {
+  repoId: "repo-1",
+  old: { kind: "rev" as const, rev: "abc123^" },
+  new: { kind: "rev" as const, rev: "abc123" },
+};
+
+beforeEach(() => {
+  resetInvokeMock();
+  useSettingsStore.getState().set("diffContextMode", "wholeFile");
+  mockInvoke("read_file_content_at_rev", (args) => ({
+    path: args.path as string,
+    binary: false,
+    text: (args.revspec as string).endsWith("^")
+      ? FILE.replace("CHANGED", "ORIGINAL")
+      : FILE,
+    fromHead: false,
+    size: FILE.length,
+  }));
+});
+
+describe("CommitDiffPanel whole-file mode", () => {
+  it("shows unchanged lines from outside the hunk", async () => {
+    render(
+      <CommitDiffPanel
+        diffs={diffs}
+        loading={false}
+        error={null}
+        header="x → y"
+        paneIdPrefix="w1"
+        syntaxSides={sides}
+      />,
+    );
+    // "five" is past the end of the hunk, so it can only appear via a filler row.
+    await waitFor(() => expect(document.body.textContent).toContain("five"));
+    expect(document.body.textContent).toContain("one");
+    expect(document.body.textContent).toContain("CHANGED");
+  });
+
+  it("shows only the hunk when the setting says chunks", async () => {
+    useSettingsStore.getState().set("diffContextMode", "chunks");
+    render(
+      <CommitDiffPanel
+        diffs={diffs}
+        loading={false}
+        error={null}
+        header="x → y"
+        paneIdPrefix="w2"
+        syntaxSides={sides}
+      />,
+    );
+    await waitFor(() => expect(document.body.textContent).toContain("CHANGED"));
+    expect(document.body.textContent).not.toContain("five");
+  });
+
+  it("still renders the hunk when there is no text to fill from", async () => {
+    resetInvokeMock();
+    mockInvoke("read_file_content_at_rev", () => {
+      throw new Error("no blob");
+    });
+    render(
+      <CommitDiffPanel
+        diffs={diffs}
+        loading={false}
+        error={null}
+        header="x → y"
+        paneIdPrefix="w3"
+        syntaxSides={sides}
+      />,
+    );
+    await waitFor(() => expect(document.body.textContent).toContain("CHANGED"));
+    expect(document.body.textContent).not.toContain("five");
+  });
+});

--- a/src/features/diff/useWholeFile.ts
+++ b/src/features/diff/useWholeFile.ts
@@ -1,0 +1,36 @@
+import React from "react";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import type { DiffSyntax } from "@/lib/syntax";
+
+/**
+ * The `wholeFile` option for `flattenDiffRows`, or undefined in chunked mode.
+ *
+ * One hook rather than the same ternary in four screens, so the surfaces cannot
+ * drift on which setting they read or which side's text they pass.
+ *
+ * The text comes from `useDiffSyntax`, which already reads both sides in full to
+ * tokenize them — so whole-file mode costs no additional IPC. Before the tokens
+ * arrive the texts are null and `flattenDiffRows` renders chunked, then fills in
+ * when they land; row geometry is the only thing that changes, and the window is
+ * recomputed from the new heights.
+ */
+export function useWholeFile(
+  syntax: DiffSyntax,
+  o?: {
+    /**
+     * Force chunked regardless of the setting. The Diff screen sets this while a
+     * find query is active: that view is a list of matching lines, and filler
+     * rows are not matches.
+     */
+    disabled?: boolean;
+  },
+): { newText: string | null; oldText: string | null } | undefined {
+  const mode = useSettingsStore((s) => s.diffContextMode);
+  const disabled = o?.disabled ?? false;
+  const { newText, oldText } = syntax;
+  return React.useMemo(
+    () =>
+      mode === "wholeFile" && !disabled ? { newText, oldText } : undefined,
+    [mode, disabled, newText, oldText],
+  );
+}

--- a/src/features/settings/useSettingsStore.test.ts
+++ b/src/features/settings/useSettingsStore.test.ts
@@ -72,6 +72,36 @@ describe("useSettingsStore persistence", () => {
     expect(useSettingsStore.getState().signCommits).toBe("config");
   });
 
+  it("defaults the diff to an inline, whole-file view", async () => {
+    const { useSettingsStore } = await freshStore();
+    const s = useSettingsStore.getState();
+    expect(s.diffViewMode).toBe("inline");
+    expect(s.diffContextMode).toBe("wholeFile");
+  });
+
+  it("persists both diff view settings", async () => {
+    const { useSettingsStore } = await freshStore();
+    useSettingsStore.getState().set("diffViewMode", "split");
+    useSettingsStore.getState().set("diffContextMode", "chunks");
+    const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}");
+    expect(raw.diffViewMode).toBe("split");
+    expect(raw.diffContextMode).toBe("chunks");
+  });
+
+  // Same reasoning as the uiDensity clamp below: load() copies a persisted value
+  // for a known key without validating it, and an unknown mode reaching the
+  // renderer would mean "neither branch" — a blank diff pane.
+  it("degrades unrecognized persisted diff modes to the defaults", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ diffViewMode: "sideways", diffContextMode: "everything" }),
+    );
+    const { useSettingsStore } = await freshStore();
+    const s = useSettingsStore.getState();
+    expect(s.diffViewMode).toBe("inline");
+    expect(s.diffContextMode).toBe("wholeFile");
+  });
+
   it("set() persists the changed key", async () => {
     const { useSettingsStore } = await freshStore();
     useSettingsStore.getState().set("autoStashBeforePull", false);

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -333,6 +333,8 @@ const SEMANTIC_TOKENS: Record<"dark" | "light", Record<string, string>> = {
     "--git-removed": "oklch(0.68 0.18 25)",
     "--git-removed-bg": "oklch(0.35 0.10 25 / 0.25)",
     "--git-removed-gutter": "oklch(0.45 0.14 25 / 0.5)",
+    "--git-added-word": "oklch(0.55 0.13 155 / 0.55)",
+    "--git-removed-word": "oklch(0.52 0.16 25 / 0.55)",
     "--git-modified": "oklch(0.75 0.14 75)",
     "--git-modified-bg": "oklch(0.35 0.08 75 / 0.2)",
     "--git-renamed": "oklch(0.72 0.15 235)",
@@ -366,6 +368,10 @@ const SEMANTIC_TOKENS: Record<"dark" | "light", Record<string, string>> = {
     "--git-removed": "oklch(0.54 0.20 25)",
     "--git-removed-bg": "oklch(0.91 0.07 25 / 0.55)",
     "--git-removed-gutter": "oklch(0.75 0.16 25 / 0.65)",
+    // The word fill has to go DARKER than the pale *-bg it sits on, where dark
+    // mode goes lighter — inheriting the dark value would wash out to invisible.
+    "--git-added-word": "oklch(0.78 0.16 155 / 0.85)",
+    "--git-removed-word": "oklch(0.78 0.17 25 / 0.85)",
     "--git-modified": "oklch(0.58 0.14 75)",
     "--git-modified-bg": "oklch(0.91 0.08 75 / 0.5)",
     "--git-renamed": "oklch(0.53 0.16 235)",
@@ -628,6 +634,21 @@ interface PersistedState {
    */
   signCommits: "config" | "always" | "never";
   diffContextLines: number;
+  /**
+   * Inline (unified) or side-by-side. Persisted so it is a preference rather
+   * than a per-visit choice — it used to live in the Diff screen's local state
+   * and reset on every navigation.
+   */
+  diffViewMode: "inline" | "split";
+  /**
+   * Whether the diff shows the whole file or only the changed chunks.
+   *
+   * `diffContextLines` still governs the FETCH in both modes: it is what hunk
+   * indices and `changedIndex` are computed against, so staging depends on it
+   * either way. This setting only selects whether the unchanged remainder of the
+   * file is filled in around those hunks for display.
+   */
+  diffContextMode: "wholeFile" | "chunks";
   ignoreWhitespaceInDiff: boolean;
   /** Parent directory last used for Clone/Init, prefilled next time. */
   lastCreateDir: string;
@@ -665,6 +686,8 @@ const DEFAULTS: PersistedState = {
   addSignoff: false,
   signCommits: "config",
   diffContextLines: 3,
+  diffViewMode: "inline",
+  diffContextMode: "wholeFile",
   ignoreWhitespaceInDiff: false,
   lastCreateDir: "",
 };
@@ -697,6 +720,14 @@ function load(): PersistedState {
     // "no indicator at all" in the row renderer.
     if (!HEAD_INDICATORS.includes(out.headIndicator as HeadIndicator)) {
       out.headIndicator = DEFAULTS.headIndicator;
+    }
+    // Same reasoning again for the two diff modes: the renderers branch on these
+    // exact strings, so an unknown value means "neither branch" — a blank pane.
+    if (!["inline", "split"].includes(out.diffViewMode as string)) {
+      out.diffViewMode = DEFAULTS.diffViewMode;
+    }
+    if (!["wholeFile", "chunks"].includes(out.diffContextMode as string)) {
+      out.diffContextMode = DEFAULTS.diffContextMode;
     }
     // Backfill logo colors for custom themes saved before the slots existed,
     // so the theme editor and CSS vars always have a value.
@@ -745,6 +776,8 @@ function snapshot(s: SettingsState): PersistedState {
     addSignoff: s.addSignoff,
     signCommits: s.signCommits,
     diffContextLines: s.diffContextLines,
+    diffViewMode: s.diffViewMode,
+    diffContextMode: s.diffContextMode,
     ignoreWhitespaceInDiff: s.ignoreWhitespaceInDiff,
     lastCreateDir: s.lastCreateDir,
   };

--- a/src/index.css
+++ b/src/index.css
@@ -122,6 +122,12 @@
   --git-removed-bg: oklch(0.35 0.10 25 / 0.25);
   --git-removed-gutter: oklch(0.45 0.14 25 / 0.5);
 
+  /* Changed-word emphasis, sitting on top of an already-tinted add/rem line.
+     Deliberately much stronger than the *-bg line fill: the line background says
+     "this line changed", the word fill says "this is what changed in it". */
+  --git-added-word: oklch(0.55 0.13 155 / 0.55);
+  --git-removed-word: oklch(0.52 0.16 25 / 0.55);
+
   --git-modified: oklch(0.75 0.14 75);
   --git-modified-bg: oklch(0.35 0.08 75 / 0.2);
 

--- a/src/lib/diffRows.test.ts
+++ b/src/lib/diffRows.test.ts
@@ -48,8 +48,8 @@ describe("flattenDiffRows", () => {
       rowH: 19,
       collapsed: new Set([0]),
     });
-    expect(rows.filter((r) => r.hunkIndex === 0)).toHaveLength(1);
-    expect(rows.filter((r) => r.hunkIndex === 1)).toHaveLength(4);
+    expect(rows.filter((r) => r.kind !== "fill" && r.hunkIndex === 0)).toHaveLength(1);
+    expect(rows.filter((r) => r.kind !== "fill" && r.hunkIndex === 1)).toHaveLength(4);
   });
 
   it("attaches word spans to paired rem/add rows", () => {
@@ -87,6 +87,258 @@ describe("flattenDiffRows", () => {
     // rem row is old line 2 → old[1]; add row is new line 2 → new[1].
     expect(lines[1].kind === "line" && lines[1].line.syntax?.[0].cls).toBe("syn-comment");
     expect(lines[2].kind === "line" && lines[2].line.syntax?.[0].cls).toBe("syn-keyword");
+  });
+});
+
+// Whole-file mode fills the unchanged remainder of the file in AROUND the hunks
+// the backend returned, rather than asking libgit2 for a huge context — that
+// would collapse the file into hunk 0 and break every stage-hunk index.
+describe("flattenDiffRows whole-file mode", () => {
+  function h(o: {
+    oldStart: number;
+    oldLines: number;
+    newStart: number;
+    newLines: number;
+    lines: Array<["ctx" | "add" | "rem", number | null, number | null, string]>;
+  }): FileDiff["hunks"][number] {
+    const kindOf = { ctx: "Context", add: "Addition", rem: "Deletion" } as const;
+    return {
+      header: `@@ -${o.oldStart},${o.oldLines} +${o.newStart},${o.newLines} @@`,
+      oldStart: o.oldStart,
+      oldLines: o.oldLines,
+      newStart: o.newStart,
+      newLines: o.newLines,
+      lines: o.lines.map(([k, ol, nl, content]) => ({
+        kind: { kind: kindOf[k] },
+        oldLineno: ol,
+        newLineno: nl,
+        content,
+      })),
+    };
+  }
+
+  // A 6-line file where only line 4 changed, fetched with 0 context lines.
+  const oneChange = [
+    h({
+      oldStart: 4,
+      oldLines: 1,
+      newStart: 4,
+      newLines: 1,
+      lines: [
+        ["rem", 4, null, "old four"],
+        ["add", null, 4, "new four"],
+      ],
+    }),
+  ];
+  const NEW_TEXT = "one\ntwo\nthree\nnew four\nfive\nsix";
+  const OLD_TEXT = "one\ntwo\nthree\nold four\nfive\nsix";
+  const whole = (
+    hunks: FileDiff["hunks"],
+    newText: string | null,
+    oldText: string | null,
+  ) =>
+    flattenDiffRows(hunks, {
+      headerH: 26,
+      rowH: 19,
+      wholeFile: { newText, oldText },
+    });
+  const fillsOf = (rows: ReturnType<typeof flattenDiffRows>) =>
+    rows.flatMap((r) => (r.kind === "fill" ? [r.line] : []));
+
+  it("fills the leading and trailing unchanged regions", () => {
+    const rows = whole(oneChange, NEW_TEXT, OLD_TEXT);
+    expect(fillsOf(rows).map((l) => l.text)).toEqual([
+      "one",
+      "two",
+      "three",
+      "five",
+      "six",
+    ]);
+  });
+
+  it("numbers filler rows on both sides", () => {
+    const rows = whole(oneChange, NEW_TEXT, OLD_TEXT);
+    expect(fillsOf(rows).map((l) => [l.lnL, l.lnR])).toEqual([
+      [1, 1],
+      [2, 2],
+      [3, 3],
+      [5, 5],
+      [6, 6],
+    ]);
+  });
+
+  // The staging-safety invariant. Filler must be purely additive: if any hunk row
+  // differs, a hunk index or changedIndex has shifted and staging would apply the
+  // wrong lines.
+  it("leaves hunk rows byte-identical to chunked mode", () => {
+    const plain = flattenDiffRows(oneChange, { headerH: 26, rowH: 19 });
+    const rows = whole(oneChange, NEW_TEXT, OLD_TEXT);
+    expect(rows.filter((r) => r.kind !== "fill")).toEqual(plain);
+  });
+
+  it("keeps filler rows out of every hunk, so they can never be staged", () => {
+    const rows = whole(oneChange, NEW_TEXT, OLD_TEXT);
+    for (const r of rows) {
+      if (r.kind === "fill") expect("hunkIndex" in r).toBe(false);
+    }
+  });
+
+  it("handles a pure-deletion hunk, whose new side is zero-length", () => {
+    // Old lines 4-5 deleted from a 6-line file. Git writes +3,0 — the line
+    // BEFORE the deletion — so new content resumes at 4, not 3. Reading newStart
+    // literally here shifts every filler number after the hunk by one.
+    const rows = whole(
+      [
+        h({
+          oldStart: 4,
+          oldLines: 2,
+          newStart: 3,
+          newLines: 0,
+          lines: [
+            ["rem", 4, null, "four"],
+            ["rem", 5, null, "five"],
+          ],
+        }),
+      ],
+      "one\ntwo\nthree\nsix",
+      "one\ntwo\nthree\nfour\nfive\nsix",
+    );
+    expect(fillsOf(rows).map((l) => [l.lnL, l.lnR, l.text])).toEqual([
+      [1, 1, "one"],
+      [2, 2, "two"],
+      [3, 3, "three"],
+      [6, 4, "six"],
+    ]);
+  });
+
+  it("handles a pure-addition hunk, whose old side is zero-length", () => {
+    const rows = whole(
+      [
+        h({
+          oldStart: 3,
+          oldLines: 0,
+          newStart: 4,
+          newLines: 1,
+          lines: [["add", null, 4, "inserted"]],
+        }),
+      ],
+      "one\ntwo\nthree\ninserted\nfour",
+      "one\ntwo\nthree\nfour",
+    );
+    expect(fillsOf(rows).map((l) => [l.lnL, l.lnR, l.text])).toEqual([
+      [1, 1, "one"],
+      [2, 2, "two"],
+      [3, 3, "three"],
+      [4, 5, "four"],
+    ]);
+  });
+
+  it("fills between two hunks", () => {
+    const rows = whole(
+      [
+        h({
+          oldStart: 2,
+          oldLines: 1,
+          newStart: 2,
+          newLines: 1,
+          lines: [
+            ["rem", 2, null, "old two"],
+            ["add", null, 2, "new two"],
+          ],
+        }),
+        h({
+          oldStart: 5,
+          oldLines: 1,
+          newStart: 5,
+          newLines: 1,
+          lines: [
+            ["rem", 5, null, "old five"],
+            ["add", null, 5, "new five"],
+          ],
+        }),
+      ],
+      "one\nnew two\nthree\nfour\nnew five\nsix",
+      "one\nold two\nthree\nfour\nold five\nsix",
+    );
+    expect(fillsOf(rows).map((l) => l.text)).toEqual([
+      "one",
+      "three",
+      "four",
+      "six",
+    ]);
+  });
+
+  it("does not invent a blank row for a file ending in a newline", () => {
+    const rows = whole(oneChange, `${NEW_TEXT}\n`, `${OLD_TEXT}\n`);
+    expect(fillsOf(rows).map((l) => l.text)).toEqual([
+      "one",
+      "two",
+      "three",
+      "five",
+      "six",
+    ]);
+  });
+
+  it("keeps a genuine blank last line", () => {
+    const rows = whole(oneChange, `${NEW_TEXT}\n\n`, `${OLD_TEXT}\n\n`);
+    expect(fillsOf(rows).map((l) => l.text)).toEqual([
+      "one",
+      "two",
+      "three",
+      "five",
+      "six",
+      "",
+    ]);
+  });
+
+  it("degrades to chunked rows when the text is too short to fill the gap", () => {
+    const rows = whole(oneChange, "one\ntwo", "one\ntwo");
+    expect(rows.some((r) => r.kind === "fill")).toBe(false);
+    expect(rows).toEqual(flattenDiffRows(oneChange, { headerH: 26, rowH: 19 }));
+  });
+
+  it("degrades to chunked rows when the two sides disagree on the gap length", () => {
+    const bad = [
+      h({
+        oldStart: 4,
+        oldLines: 1,
+        newStart: 9,
+        newLines: 1,
+        lines: [
+          ["rem", 4, null, "old four"],
+          ["add", null, 9, "new four"],
+        ],
+      }),
+    ];
+    expect(whole(bad, NEW_TEXT, OLD_TEXT).some((r) => r.kind === "fill")).toBe(false);
+  });
+
+  it("renders chunked when there is no text at all", () => {
+    expect(whole(oneChange, null, null)).toEqual(
+      flattenDiffRows(oneChange, { headerH: 26, rowH: 19 }),
+    );
+  });
+
+  it("falls back to the old side when only it has text, as for a deleted file", () => {
+    const rows = whole(oneChange, null, OLD_TEXT);
+    expect(fillsOf(rows).map((l) => l.text)).toEqual([
+      "one",
+      "two",
+      "three",
+      "five",
+      "six",
+    ]);
+  });
+
+  it("still resolves syntax tokens for filler rows", () => {
+    const rows = flattenDiffRows(oneChange, {
+      headerH: 26,
+      rowH: 19,
+      wholeFile: { newText: NEW_TEXT, oldText: OLD_TEXT },
+      // New-side line 1 is "one"; filler reads the new side.
+      syntax: { old: null, new: [[{ start: 0, end: 3, cls: "syn-keyword" }]] },
+    });
+    expect(fillsOf(rows)[0].syntax?.[0].cls).toBe("syn-keyword");
   });
 });
 

--- a/src/lib/diffRows.ts
+++ b/src/lib/diffRows.ts
@@ -16,7 +16,27 @@ import { pairChangedLines } from "./pairChangedLines";
 
 export type DiffRow =
   | { kind: "header"; hunkIndex: number; header: string; h: number }
-  | { kind: "line"; hunkIndex: number; line: DiffLineData; h: number };
+  | { kind: "line"; hunkIndex: number; line: DiffLineData; h: number }
+  /**
+   * An unchanged line from OUTSIDE every hunk, synthesized in whole-file mode.
+   *
+   * A distinct kind rather than a `line` row carrying a sentinel hunkIndex:
+   * consumers look up `hunkActions(row.hunkIndex)` and wire
+   * `onLineClick(row.hunkIndex, …)`, so a sentinel number would be one missing
+   * guard away from staging the wrong hunk. This variant has no hunkIndex to get
+   * wrong, and the type checker makes every consumer say what it does with it.
+   */
+  | { kind: "fill"; line: DiffLineData; h: number };
+
+/**
+ * Past this, whole-file mode stays chunked.
+ *
+ * Synthesizing a row per line of a very large file would fight the performance
+ * goal whole-file mode is part of. It matches the tokenizer's own
+ * MAX_HIGHLIGHT_LINES, so the ceiling where highlighting stops is also the
+ * ceiling where gap filling stops.
+ */
+export const MAX_WHOLE_FILE_LINES = 20_000;
 
 /**
  * Number the changed (+/-) lines of a hunk from 0, leaving context unnumbered.
@@ -97,6 +117,61 @@ export function withSyntax(
   });
 }
 
+/**
+ * Effective 1-based file position of a hunk side, normalizing git's zero-length
+ * convention.
+ *
+ * For a pure deletion git writes `+3,0`, meaning "at the line BEFORE which
+ * nothing was added" — new content resumes at 4, not 3. Taking `newStart`
+ * literally there is an off-by-one that shifts every filler line number after
+ * the hunk.
+ */
+function effStart(start: number, lines: number): number {
+  return lines === 0 ? start + 1 : start;
+}
+
+/**
+ * Context rows covering one unchanged region between hunks. Both sides advance
+ * together, because an unchanged region is identical on both.
+ *
+ * Returns null when the arithmetic does not check out — a descending range or a
+ * line past the end of the text. A whole-file view with wrong line numbers is
+ * worse than no whole-file view, so callers degrade to chunked rather than
+ * render something plausible and wrong.
+ */
+function gapRows(o: {
+  oldFrom: number;
+  newFrom: number;
+  count: number;
+  lines: string[];
+  from: number;
+  rowH: number;
+  syntax?: { old: SyntaxLine[] | null; new: SyntaxLine[] | null };
+  useNew: boolean;
+}): DiffRow[] | null {
+  const { oldFrom, newFrom, count, lines, from, rowH, syntax, useNew } = o;
+  if (count === 0) return [];
+  if (count < 0 || oldFrom < 1 || newFrom < 1 || from < 1) return null;
+  if (from - 1 + count > lines.length) return null;
+  const side = useNew ? syntax?.new : syntax?.old;
+  const rows: DiffRow[] = [];
+  for (let i = 0; i < count; i++) {
+    const tokens = side?.[from - 1 + i];
+    rows.push({
+      kind: "fill",
+      h: rowH,
+      line: {
+        kind: "ctx",
+        lnL: oldFrom + i,
+        lnR: newFrom + i,
+        text: lines[from - 1 + i],
+        ...(tokens ? { syntax: tokens } : {}),
+      },
+    });
+  }
+  return rows;
+}
+
 export function flattenDiffRows(
   hunks: FileDiff["hunks"],
   o: {
@@ -104,20 +179,86 @@ export function flattenDiffRows(
     rowH: number;
     collapsed?: ReadonlySet<number>;
     syntax?: { old: SyntaxLine[] | null; new: SyntaxLine[] | null };
+    /**
+     * Whole-file mode: fill the unchanged remainder of the file in around the
+     * hunks. Both texts may be null; filling needs at least one.
+     */
+    wholeFile?: { newText: string | null; oldText: string | null };
   },
 ): DiffRow[] {
-  const { headerH, rowH, collapsed, syntax } = o;
-  const rows: DiffRow[] = [];
-  hunks.forEach((h, hunkIndex) => {
-    rows.push({ kind: "header", hunkIndex, header: h.header, h: headerH });
-    if (collapsed?.has(hunkIndex)) return;
+  const { headerH, rowH, collapsed, syntax, wholeFile } = o;
+
+  const hunkRows = (h: FileDiff["hunks"][number], hunkIndex: number): DiffRow[] => {
+    const rows: DiffRow[] = [
+      { kind: "header", hunkIndex, header: h.header, h: headerH },
+    ];
+    if (collapsed?.has(hunkIndex)) return rows;
     // changedIndex FIRST, over the whole hunk, before anything slices rows.
     const lines = withWordSpans(
       withSyntax(withChangedIndices(h.lines.map(toUiLine)), syntax),
     );
     for (const line of lines) rows.push({ kind: "line", hunkIndex, line, h: rowH });
+    return rows;
+  };
+
+  const chunked = (): DiffRow[] => hunks.flatMap(hunkRows);
+
+  // Prefer the new side; a deleted file has only the old one. Either yields the
+  // same characters for an unchanged region, which is all filler ever covers.
+  const text = wholeFile?.newText ?? wholeFile?.oldText ?? null;
+  if (!wholeFile || text == null || hunks.length === 0) return chunked();
+  const useNew = wholeFile.newText != null;
+  const textLines = text.split("\n");
+  // A file ending in a newline splits to a trailing "" that is not a line git
+  // would count — left in, it renders one phantom blank row past the end of
+  // every well-formed file. Exactly one, so a genuine blank last line survives.
+  if (textLines.length > 1 && textLines[textLines.length - 1] === "") {
+    textLines.pop();
+  }
+  if (textLines.length > MAX_WHOLE_FILE_LINES) return chunked();
+
+  const out: DiffRow[] = [];
+  let oldAt = 1;
+  let newAt = 1;
+  for (let i = 0; i < hunks.length; i++) {
+    const h = hunks[i];
+    const oldStart = effStart(h.oldStart, h.oldLines);
+    const newStart = effStart(h.newStart, h.newLines);
+    const count = newStart - newAt;
+    // The same unchanged region on both sides must be the same length. When it
+    // is not, this diff is not the shape assumed here — degrade rather than
+    // guess.
+    if (oldStart - oldAt !== count) return chunked();
+    const gap = gapRows({
+      oldFrom: oldAt,
+      newFrom: newAt,
+      count,
+      lines: textLines,
+      from: useNew ? newAt : oldAt,
+      rowH,
+      syntax,
+      useNew,
+    });
+    if (!gap) return chunked();
+    out.push(...gap, ...hunkRows(h, i));
+    oldAt = oldStart + h.oldLines;
+    newAt = newStart + h.newLines;
+  }
+
+  const tailFrom = useNew ? newAt : oldAt;
+  const tail = gapRows({
+    oldFrom: oldAt,
+    newFrom: newAt,
+    count: textLines.length - tailFrom + 1,
+    lines: textLines,
+    from: tailFrom,
+    rowH,
+    syntax,
+    useNew,
   });
-  return rows;
+  if (!tail) return chunked();
+  out.push(...tail);
+  return out;
 }
 
 export function rowOffset(heights: number[], index: number): number {

--- a/src/lib/syntax/index.ts
+++ b/src/lib/syntax/index.ts
@@ -5,3 +5,4 @@ export {
   type DiffSyntax,
   type SideSource,
 } from "./useDiffSyntax";
+export { usePrefetchSyntax, PREFETCH_MAX } from "./usePrefetchSyntax";

--- a/src/lib/syntax/tokenize.ts
+++ b/src/lib/syntax/tokenize.ts
@@ -1,47 +1,17 @@
-import { classForColor } from "./scopes";
+// Main-thread entry point for syntax tokens: cache, worker client, fallback.
+//
+// The heavy work lives in tokenizeCore.ts and normally runs in tokenize.worker.ts.
+// This module's job is to keep `tokenizeFile`'s contract unchanged — same
+// signature, same "null means render plain" rule — so useSyntax, useDiffSyntax and
+// their tests did not have to learn about any of it.
+import {
+  skipHighlight,
+  unpackLines,
+  type PackedSyntax,
+  type SyntaxLine,
+} from "./tokenizeCore";
 import { langForPath } from "./langs";
-import { SENTINEL_THEME_NAME, ensureLanguage, getHighlighter } from "./shiki";
-
-/** A syntax range over ONE line, in that line's own coordinates. */
-export interface SyntaxToken {
-  start: number;
-  end: number;
-  cls: string;
-}
-
-export type SyntaxLine = SyntaxToken[];
-
-/** Files past either guard render plain — highlighting is a nicety, not a feature. */
-export const MAX_HIGHLIGHT_BYTES = 1_000_000;
-export const MAX_HIGHLIGHT_LINES = 20_000;
-
-interface RawToken {
-  content: string;
-  offset: number;
-  color?: string;
-}
-
-/**
- * Rebase Shiki's DOCUMENT-absolute offsets to line-relative ranges, and resolve
- * sentinel colours to classes.
- *
- * The rebase is the whole point: `WordSpan` from wordDiff.ts is line-relative,
- * and buildLineSpans intersects the two. Leaving absolute offsets in would put
- * every line after the first out of range, silently yielding no spans.
- */
-export function toLineRelative(lines: RawToken[][]): SyntaxLine[] {
-  return lines.map((tokens) => {
-    const base = tokens.length > 0 ? tokens[0].offset : 0;
-    const out: SyntaxLine = [];
-    for (const t of tokens) {
-      const cls = classForColor(t.color);
-      if (!cls) continue; // unscoped text renders unstyled
-      const start = t.offset - base;
-      out.push({ start, end: start + t.content.length, cls });
-    }
-    return out;
-  });
-}
+import type { TokenizeReply, TokenizeRequest } from "./tokenize.worker";
 
 /** djb2. Enough to detect content change for a cache key; not a checksum. */
 function hash(s: string): string {
@@ -67,34 +37,102 @@ function remember(key: string, value: SyntaxLine[]): SyntaxLine[] {
   return value;
 }
 
+// undefined = not tried yet, null = unavailable, so fall back to this thread.
+let worker: Worker | null | undefined;
+let nextId = 1;
+const pending = new Map<number, (p: PackedSyntax | null) => void>();
+
+/**
+ * Give up on the worker and answer everyone still waiting.
+ *
+ * Reached by a failed script load or a worker crash. Leaving the pending
+ * promises unresolved would hang every caller forever, so they are resolved
+ * null — with `worker` now null, `tokenizeFile` retries them on this thread.
+ */
+function disableWorker(): void {
+  worker?.terminate();
+  worker = null;
+  const waiting = [...pending.values()];
+  pending.clear();
+  for (const resolve of waiting) resolve(null);
+}
+
+function getWorker(): Worker | null {
+  if (worker !== undefined) return worker;
+  try {
+    const w = new Worker(new URL("./tokenize.worker.ts", import.meta.url), {
+      type: "module",
+    });
+    w.onmessage = (e: MessageEvent<TokenizeReply>) => {
+      const resolve = pending.get(e.data.id);
+      if (resolve) {
+        pending.delete(e.data.id);
+        resolve(e.data.packed);
+      }
+    };
+    // Degrading to the main thread means the worst case is the behaviour this
+    // replaced, never a diff with no highlighting at all.
+    w.onerror = disableWorker;
+    w.onmessageerror = disableWorker;
+    worker = w;
+  } catch {
+    // No Worker constructor at all — jsdom in the component tests, and any
+    // webview where module workers are unavailable.
+    worker = null;
+  }
+  return worker;
+}
+
 /**
  * Tokenize a whole file. Resolves null whenever highlighting is not available
- * or not worth it — unknown language, oversized input, or any Shiki failure.
- * Callers treat null as "render plain text".
+ * or not worth it — callers treat null as "render plain text".
+ *
+ * Results are cached on THIS thread, so a repeat never crosses the boundary and
+ * a re-render never re-tokenizes.
  */
 export async function tokenizeFile(
   path: string,
   text: string,
 ): Promise<SyntaxLine[] | null> {
   const lang = langForPath(path);
-  if (!lang) return null;
-  if (text.length > MAX_HIGHLIGHT_BYTES) return null;
-  const lineCount = text.split("\n").length;
-  if (lineCount > MAX_HIGHLIGHT_LINES) return null;
+  // Guards run here as well as in the core so an oversized or unknown file costs
+  // no worker round trip.
+  if (!lang || skipHighlight(path, text)) return null;
 
   const key = `${lang}:${hash(text)}:${text.length}`;
   const hit = cache.get(key);
   if (hit) return hit;
 
-  if (!(await ensureLanguage(lang))) return null;
-  try {
-    const hl = await getHighlighter();
-    const { tokens } = hl.codeToTokens(text, {
-      lang,
-      theme: SENTINEL_THEME_NAME,
-    }) as { tokens: RawToken[][] };
-    return remember(key, toLineRelative(tokens));
-  } catch {
-    return null;
+  const w = getWorker();
+  let packed: PackedSyntax | null = null;
+  if (w) {
+    const id = nextId++;
+    packed = await new Promise<PackedSyntax | null>((resolve) => {
+      pending.set(id, resolve);
+      w.postMessage({ id, path, text } satisfies TokenizeRequest);
+    });
   }
+  // Only when there is no worker to ask. Note the asymmetry: `!worker` is true
+  // only after disableWorker ran (or construction failed), so a legitimate null —
+  // unknown grammar, Shiki failure — is NOT retried on the main thread.
+  //
+  // Imported dynamically so Shiki stays out of the main bundle on the normal path.
+  if (!packed && !worker) {
+    const { tokenizeToPacked } = await import("./tokenizeShiki");
+    packed = await tokenizeToPacked(path, text);
+  }
+  if (!packed) return null;
+  return remember(key, unpackLines(packed));
 }
+
+export {
+  toLineRelative,
+  packLines,
+  unpackLines,
+  skipHighlight,
+  MAX_HIGHLIGHT_BYTES,
+  MAX_HIGHLIGHT_LINES,
+  type PackedSyntax,
+  type SyntaxLine,
+  type SyntaxToken,
+} from "./tokenizeCore";

--- a/src/lib/syntax/tokenize.worker.ts
+++ b/src/lib/syntax/tokenize.worker.ts
@@ -1,0 +1,35 @@
+/// <reference lib="webworker" />
+// Syntax tokenization runs HERE, not on the main thread.
+//
+// Shiki's codeToTokens is synchronous CPU work. Awaiting it on the main thread —
+// which is what this replaces — still ran it to completion there, so selecting a
+// file and immediately moving to another janked for the first file's whole cost,
+// and the "cancelled" flag only threw the answer away afterwards. Off-thread, the
+// UI stays responsive whether or not anyone still wants the result.
+//
+// Shiki is configured with engine-javascript (no WASM asset to fetch through the
+// Tauri custom protocol), so it is pure JS and safe to run here.
+import { tokenizeToPacked } from "./tokenizeShiki";
+import type { PackedSyntax } from "./tokenizeCore";
+
+export interface TokenizeRequest {
+  id: number;
+  path: string;
+  text: string;
+}
+
+export interface TokenizeReply {
+  id: number;
+  packed: PackedSyntax | null;
+}
+
+self.onmessage = async (e: MessageEvent<TokenizeRequest>) => {
+  const { id, path, text } = e.data;
+  const packed = await tokenizeToPacked(path, text);
+  const reply: TokenizeReply = { id, packed };
+  // Transfer the buffers rather than copying them across.
+  const transfer: Transferable[] = packed
+    ? [packed.lineStarts.buffer, packed.data.buffer]
+    : [];
+  (self as unknown as Worker).postMessage(reply, transfer);
+};

--- a/src/lib/syntax/tokenizeCore.test.ts
+++ b/src/lib/syntax/tokenizeCore.test.ts
@@ -1,0 +1,41 @@
+// The packed representation tokens cross the worker boundary in.
+//
+// Returning SyntaxLine[] directly would structured-clone hundreds of thousands
+// of small objects for a large file, moving the cost onto the main thread instead
+// of removing it. These tests pin that packing is lossless.
+import { describe, expect, it } from "vitest";
+import { packLines, unpackLines } from "./tokenizeCore";
+import type { SyntaxLine } from "./tokenizeCore";
+
+const lines: SyntaxLine[] = [
+  [
+    { start: 0, end: 5, cls: "syn-keyword" },
+    { start: 6, end: 7, cls: "syn-ident" },
+  ],
+  [],
+  [{ start: 0, end: 3, cls: "syn-keyword" }],
+];
+
+describe("packed syntax transfer", () => {
+  it("round-trips tokens through the flat arrays", () => {
+    expect(unpackLines(packLines(lines))).toEqual(lines);
+  });
+
+  it("dedupes class names into a table so the payload stays small", () => {
+    const p = packLines(lines);
+    expect(p.classes).toEqual(["syn-keyword", "syn-ident"]);
+    expect(p.data).toBeInstanceOf(Int32Array);
+    expect(p.lineStarts).toBeInstanceOf(Int32Array);
+    // 3 tokens total across 3 lines.
+    expect(p.data).toHaveLength(3 * 3);
+    expect(p.lineStarts).toHaveLength(lines.length + 1);
+  });
+
+  it("preserves empty lines rather than collapsing them", () => {
+    expect(unpackLines(packLines([[], [], []]))).toEqual([[], [], []]);
+  });
+
+  it("round-trips an empty file", () => {
+    expect(unpackLines(packLines([]))).toEqual([]);
+  });
+});

--- a/src/lib/syntax/tokenizeCore.ts
+++ b/src/lib/syntax/tokenizeCore.ts
@@ -1,0 +1,119 @@
+// The shapes and pure transforms syntax tokens travel in.
+//
+// Deliberately free of any Shiki import: this module is what the MAIN thread
+// loads eagerly, and pulling Shiki in here would put the whole highlighter in the
+// main bundle purely to serve a fallback that normally never runs. The Shiki call
+// itself lives in tokenizeShiki.ts, which the worker imports and the main thread
+// only imports dynamically if the worker turns out to be unavailable.
+//
+// Worker-safe by construction: nothing here touches the DOM, React, or Tauri.
+import { classForColor } from "./scopes";
+import { langForPath } from "./langs";
+
+/** A syntax range over ONE line, in that line's own coordinates. */
+export interface SyntaxToken {
+  start: number;
+  end: number;
+  cls: string;
+}
+
+export type SyntaxLine = SyntaxToken[];
+
+/** Files past either guard render plain — highlighting is a nicety, not a feature. */
+export const MAX_HIGHLIGHT_BYTES = 1_000_000;
+export const MAX_HIGHLIGHT_LINES = 20_000;
+
+/** One token as Shiki hands it back, before offsets are rebased. */
+export interface RawToken {
+  content: string;
+  offset: number;
+  color?: string;
+}
+
+/**
+ * Rebase Shiki's DOCUMENT-absolute offsets to line-relative ranges, and resolve
+ * sentinel colours to classes.
+ *
+ * The rebase is the whole point: `WordSpan` from wordDiff.ts is line-relative,
+ * and buildLineSpans intersects the two. Leaving absolute offsets in would put
+ * every line after the first out of range, silently yielding no spans.
+ */
+export function toLineRelative(lines: RawToken[][]): SyntaxLine[] {
+  return lines.map((tokens) => {
+    const base = tokens.length > 0 ? tokens[0].offset : 0;
+    const out: SyntaxLine = [];
+    for (const t of tokens) {
+      const cls = classForColor(t.color);
+      if (!cls) continue; // unscoped text renders unstyled
+      const start = t.offset - base;
+      out.push({ start, end: start + t.content.length, cls });
+    }
+    return out;
+  });
+}
+
+/**
+ * Tokens flattened into transferable arrays.
+ *
+ * Two Int32Arrays plus a small string table, so the payload is transferred
+ * zero-copy instead of structured-cloning one object per token. Materializing it
+ * back is one tight pass with no per-object allocation from the clone algorithm.
+ */
+export interface PackedSyntax {
+  /** Distinct class names. `data` stores indices into this. */
+  classes: string[];
+  /** length = lineCount + 1. Token-triple index where each line starts. */
+  lineStarts: Int32Array;
+  /** Flat [start, end, classId] triples. */
+  data: Int32Array;
+}
+
+export function packLines(lines: SyntaxLine[]): PackedSyntax {
+  const classes: string[] = [];
+  const ids = new Map<string, number>();
+  let total = 0;
+  for (const l of lines) total += l.length;
+  const data = new Int32Array(total * 3);
+  const lineStarts = new Int32Array(lines.length + 1);
+  let t = 0;
+  for (let i = 0; i < lines.length; i++) {
+    lineStarts[i] = t;
+    for (const tok of lines[i]) {
+      let id = ids.get(tok.cls);
+      if (id === undefined) {
+        id = classes.length;
+        classes.push(tok.cls);
+        ids.set(tok.cls, id);
+      }
+      data[t * 3] = tok.start;
+      data[t * 3 + 1] = tok.end;
+      data[t * 3 + 2] = id;
+      t++;
+    }
+  }
+  lineStarts[lines.length] = t;
+  return { classes, lineStarts, data };
+}
+
+export function unpackLines(p: PackedSyntax): SyntaxLine[] {
+  const out: SyntaxLine[] = [];
+  for (let i = 0; i + 1 < p.lineStarts.length; i++) {
+    const line: SyntaxLine = [];
+    for (let t = p.lineStarts[i]; t < p.lineStarts[i + 1]; t++) {
+      line.push({
+        start: p.data[t * 3],
+        end: p.data[t * 3 + 1],
+        cls: p.classes[p.data[t * 3 + 2]],
+      });
+    }
+    out.push(line);
+  }
+  return out;
+}
+
+/** True when the file is one this will not highlight, before any Shiki work. */
+export function skipHighlight(path: string, text: string): boolean {
+  if (!langForPath(path)) return true;
+  if (text.length > MAX_HIGHLIGHT_BYTES) return true;
+  return text.split("\n").length > MAX_HIGHLIGHT_LINES;
+}

--- a/src/lib/syntax/tokenizeShiki.ts
+++ b/src/lib/syntax/tokenizeShiki.ts
@@ -1,0 +1,40 @@
+// The one place Shiki is actually called.
+//
+// Split out from tokenizeCore.ts so the main bundle does not have to contain the
+// highlighter: the worker imports this eagerly, and tokenize.ts imports it
+// dynamically, only if the worker turns out to be unavailable. In the normal case
+// the main thread never loads Shiki at all.
+import { SENTINEL_THEME_NAME, ensureLanguage, getHighlighter } from "./shiki";
+import { langForPath } from "./langs";
+import {
+  packLines,
+  skipHighlight,
+  toLineRelative,
+  type PackedSyntax,
+  type RawToken,
+} from "./tokenizeCore";
+
+/**
+ * Tokenize a whole file to the packed shape.
+ *
+ * Resolves null whenever highlighting is not available or not worth it — unknown
+ * language, oversized input, or any Shiki failure. Callers render plain text.
+ */
+export async function tokenizeToPacked(
+  path: string,
+  text: string,
+): Promise<PackedSyntax | null> {
+  const lang = langForPath(path);
+  if (!lang || skipHighlight(path, text)) return null;
+  if (!(await ensureLanguage(lang))) return null;
+  try {
+    const hl = await getHighlighter();
+    const { tokens } = hl.codeToTokens(text, {
+      lang,
+      theme: SENTINEL_THEME_NAME,
+    }) as { tokens: RawToken[][] };
+    return packLines(toLineRelative(tokens));
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/syntax/tokenizeWorkerClient.test.ts
+++ b/src/lib/syntax/tokenizeWorkerClient.test.ts
@@ -1,0 +1,115 @@
+// The worker client: the path production actually takes.
+//
+// jsdom has no Worker, so the rest of the suite exercises the main-thread
+// fallback. That left the DEFAULT path untested — and a wrong message protocol
+// there fails silently, returning null and quietly dropping highlighting
+// everywhere. These tests drive the client against a fake Worker.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { sentinelFor } from "./scopes";
+import { packLines, type SyntaxLine } from "./tokenizeCore";
+
+// Reached only by the fallback; the worker paths must never call it.
+const codeToTokens = vi.fn();
+vi.mock("./shiki", () => ({
+  SENTINEL_THEME_NAME: "pg-sentinel",
+  getHighlighter: async () => ({ codeToTokens }),
+  ensureLanguage: async () => true,
+}));
+
+const KW = sentinelFor("keyword").toUpperCase();
+const TOKENS: SyntaxLine[] = [[{ start: 0, end: 3, cls: "syn-keyword" }]];
+
+// The module caches its Worker in module scope, so each test needs a fresh one.
+async function freshTokenize() {
+  vi.resetModules();
+  return await import("./tokenize");
+}
+
+interface Req {
+  id: number;
+  path: string;
+  text: string;
+}
+
+/** Answers like the real worker: asynchronously, echoing the request id. */
+class FakeWorker {
+  static requests: Req[] = [];
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessageerror: (() => void) | null = null;
+  postMessage(req: Req) {
+    FakeWorker.requests.push(req);
+    setTimeout(() => {
+      this.onmessage?.({
+        data: { id: req.id, packed: packLines(TOKENS) },
+      } as MessageEvent);
+    }, 0);
+  }
+  terminate() {}
+}
+
+/** Fails the way a worker whose script will not load does. */
+class BrokenWorker extends FakeWorker {
+  postMessage() {
+    setTimeout(() => this.onerror?.(), 0);
+  }
+}
+
+beforeEach(() => {
+  codeToTokens.mockReset();
+  codeToTokens.mockReturnValue({
+    tokens: [[{ content: "let", offset: 0, color: KW }]],
+  });
+  FakeWorker.requests = [];
+});
+
+describe("tokenize worker client", () => {
+  it("returns the worker's tokens without tokenizing on this thread", async () => {
+    vi.stubGlobal("Worker", FakeWorker);
+    const { tokenizeFile } = await freshTokenize();
+    expect(await tokenizeFile("a.ts", "let")).toEqual(TOKENS);
+    // The whole point: the main thread never ran the grammar.
+    expect(codeToTokens).not.toHaveBeenCalled();
+    expect(FakeWorker.requests).toHaveLength(1);
+    expect(FakeWorker.requests[0]).toMatchObject({ path: "a.ts", text: "let" });
+  });
+
+  it("gives each request a distinct id so replies cannot be mismatched", async () => {
+    vi.stubGlobal("Worker", FakeWorker);
+    const { tokenizeFile } = await freshTokenize();
+    await Promise.all([tokenizeFile("a.ts", "let"), tokenizeFile("a.ts", "let x")]);
+    const ids = FakeWorker.requests.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("serves a repeat from the cache instead of the worker", async () => {
+    vi.stubGlobal("Worker", FakeWorker);
+    const { tokenizeFile } = await freshTokenize();
+    await tokenizeFile("a.ts", "let");
+    await tokenizeFile("a.ts", "let");
+    expect(FakeWorker.requests).toHaveLength(1);
+  });
+
+  it("never asks the worker about a file it would not highlight", async () => {
+    vi.stubGlobal("Worker", FakeWorker);
+    const { tokenizeFile } = await freshTokenize();
+    expect(await tokenizeFile("LICENSE", "x")).toBeNull();
+    expect(FakeWorker.requests).toHaveLength(0);
+  });
+
+  it("falls back to this thread when there is no Worker at all", async () => {
+    vi.stubGlobal("Worker", undefined);
+    const { tokenizeFile } = await freshTokenize();
+    expect(await tokenizeFile("a.ts", "let")).toEqual(TOKENS);
+    expect(codeToTokens).toHaveBeenCalled();
+  });
+
+  // Without this, a crashing worker leaves the promise unresolved and every
+  // caller waits forever — a hung diff pane rather than an unhighlighted one.
+  it("answers a pending request and falls back when the worker errors", async () => {
+    vi.stubGlobal("Worker", BrokenWorker);
+    const { tokenizeFile } = await freshTokenize();
+    expect(await tokenizeFile("a.ts", "let")).toEqual(TOKENS);
+    expect(codeToTokens).toHaveBeenCalled();
+  });
+});

--- a/src/lib/syntax/useDiffSyntax.ts
+++ b/src/lib/syntax/useDiffSyntax.ts
@@ -23,10 +23,18 @@ export type SideSource =
 export interface DiffSyntax {
   old: SyntaxLine[] | null;
   new: SyntaxLine[] | null;
+  /**
+   * The text the tokens came from.
+   *
+   * Exposed so whole-file mode can fill the gaps between hunks from it rather
+   * than issuing a second read of a blob this hook already fetched.
+   */
+  oldText: string | null;
+  newText: string | null;
 }
 
 /** No tokens for either side. Stable identity, so it is safe in a render path. */
-const EMPTY: DiffSyntax = { old: null, new: null };
+const EMPTY: DiffSyntax = { old: null, new: null, oldText: null, newText: null };
 
 /**
  * Tokens for both sides of a file diff.
@@ -88,7 +96,15 @@ export function useDiffSyntax(o: {
 
   const oldLines = useSyntax(path, texts.old);
   const newLines = useSyntax(path, texts.new);
-  return React.useMemo(() => ({ old: oldLines, new: newLines }), [oldLines, newLines]);
+  return React.useMemo(
+    () => ({
+      old: oldLines,
+      new: newLines,
+      oldText: texts.old,
+      newText: texts.new,
+    }),
+    [oldLines, newLines, texts.old, texts.new],
+  );
 }
 
 export { EMPTY as EMPTY_DIFF_SYNTAX };

--- a/src/lib/syntax/usePrefetchSyntax.test.tsx
+++ b/src/lib/syntax/usePrefetchSyntax.test.tsx
@@ -1,0 +1,127 @@
+// Warming the token cache for a commit's other files.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { PREFETCH_MAX, usePrefetchSyntax } from "./usePrefetchSyntax";
+
+const tokenized: string[] = [];
+vi.mock("./tokenize", () => ({
+  tokenizeFile: async (path: string) => {
+    tokenized.push(path);
+    return null;
+  },
+}));
+
+const readPaths = () =>
+  getInvokeCalls()
+    .filter((c) => c.cmd === "read_file_content_at_rev")
+    .map((c) => c.args.path as string);
+
+beforeEach(() => {
+  resetInvokeMock();
+  tokenized.length = 0;
+  mockInvoke("read_file_content_at_rev", (args) => ({
+    path: args.path as string,
+    binary: false,
+    text: "let a = 1",
+    fromHead: false,
+    size: 9,
+  }));
+});
+
+const paths = ["a.ts", "b.ts", "c.ts", "d.ts", "e.ts", "f.ts", "g.ts"];
+
+describe("usePrefetchSyntax", () => {
+  it("warms at most PREFETCH_MAX files and skips the selected one", async () => {
+    renderHook(() =>
+      usePrefetchSyntax({
+        repoId: "r1",
+        paths,
+        source: { kind: "rev", rev: "abc" },
+        enabled: true,
+      }),
+    );
+    await waitFor(() => expect(tokenized).toHaveLength(PREFETCH_MAX));
+    // a.ts is the selected file — the panel is already loading it.
+    expect(readPaths()).not.toContain("a.ts");
+    expect(readPaths()).toEqual(["b.ts", "c.ts", "d.ts", "e.ts"]);
+  });
+
+  it("does nothing when disabled", async () => {
+    renderHook(() =>
+      usePrefetchSyntax({
+        repoId: "r1",
+        paths,
+        source: { kind: "rev", rev: "abc" },
+        enabled: false,
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    expect(readPaths()).toEqual([]);
+  });
+
+  it("does nothing without a side to read from", async () => {
+    renderHook(() =>
+      usePrefetchSyntax({
+        repoId: "r1",
+        paths,
+        source: { kind: "none" },
+        enabled: true,
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    expect(readPaths()).toEqual([]);
+  });
+
+  it("does nothing when the selected file is the only one", async () => {
+    renderHook(() =>
+      usePrefetchSyntax({
+        repoId: "r1",
+        paths: ["only.ts"],
+        source: { kind: "rev", rev: "abc" },
+        enabled: true,
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    expect(readPaths()).toEqual([]);
+  });
+
+  // A read that fails must not stop the rest of the list, and must not surface.
+  it("keeps going past a file it cannot read", async () => {
+    resetInvokeMock();
+    mockInvoke("read_file_content_at_rev", (args) => {
+      if (args.path === "b.ts") throw new Error("no blob");
+      return {
+        path: args.path as string,
+        binary: false,
+        text: "let a = 1",
+        fromHead: false,
+        size: 9,
+      };
+    });
+    renderHook(() =>
+      usePrefetchSyntax({
+        repoId: "r1",
+        paths,
+        source: { kind: "rev", rev: "abc" },
+        enabled: true,
+      }),
+    );
+    await waitFor(() => expect(tokenized).toEqual(["c.ts", "d.ts", "e.ts"]));
+  });
+
+  it("abandons the rest of the list when the commit changes", async () => {
+    const { unmount } = renderHook(() =>
+      usePrefetchSyntax({
+        repoId: "r1",
+        paths,
+        source: { kind: "rev", rev: "abc" },
+        enabled: true,
+      }),
+    );
+    unmount();
+    await new Promise((r) => setTimeout(r, 20));
+    // Cancelled before the idle callback ran, so nothing was warmed.
+    expect(tokenized).toEqual([]);
+  });
+});

--- a/src/lib/syntax/usePrefetchSyntax.ts
+++ b/src/lib/syntax/usePrefetchSyntax.ts
@@ -1,0 +1,85 @@
+import React from "react";
+import {
+  readFileContent,
+  readFileContentAtIndex,
+  readFileContentAtRev,
+} from "@/lib/tauri";
+import { tokenizeFile } from "./tokenize";
+import type { SideSource } from "./useDiffSyntax";
+
+/**
+ * How many of a commit's other files to warm.
+ *
+ * Each one costs an IPC read, so this stays small: a 200-file commit must not
+ * fire 200 reads. With tokenization already off the main thread this is a
+ * latency nicety, not the fix for jank, so it does not need to be exhaustive.
+ */
+export const PREFETCH_MAX = 4;
+
+/**
+ * Warm the token cache for the files a user is likely to open next.
+ *
+ * Runs at idle so it never competes with the file actually selected, and
+ * abandons the rest of the list when the commit or selection changes — a
+ * superseded prefetch that kept going would evict the file being looked at from
+ * a 24-entry cache.
+ *
+ * Sequential rather than parallel on purpose: the point is to use spare time, and
+ * four concurrent reads plus four queued tokenize jobs would compete with the
+ * selected file for both the IPC thread and the worker.
+ */
+export function usePrefetchSyntax(o: {
+  repoId: string | null;
+  /** Candidate paths in list order. The FIRST is skipped as already loading. */
+  paths: string[];
+  source: SideSource;
+  enabled: boolean;
+}): void {
+  const { repoId, enabled } = o;
+  const kind = o.source.kind;
+  const rev = o.source.kind === "rev" ? o.source.rev : null;
+  // Joined to a primitive: callers rebuild the array every render, so depending
+  // on its identity would restart the prefetch on every render.
+  const key = o.paths.join("\n");
+
+  React.useEffect(() => {
+    if (!enabled || !repoId || kind === "none") return;
+    const targets = key.split("\n").filter(Boolean).slice(1, 1 + PREFETCH_MAX);
+    if (targets.length === 0) return;
+    let cancelled = false;
+
+    const read = (p: string) => {
+      if (kind === "worktree") return readFileContent(repoId, p);
+      if (kind === "index") return readFileContentAtIndex(repoId, p);
+      return rev ? readFileContentAtRev(repoId, rev, p) : Promise.resolve(null);
+    };
+
+    const run = async () => {
+      for (const p of targets) {
+        if (cancelled) return;
+        try {
+          const c = await read(p);
+          if (cancelled || !c?.text) continue;
+          await tokenizeFile(p, c.text);
+        } catch {
+          // A prefetch failure is not user-visible. Opening the file for real
+          // will surface it through the normal read path.
+        }
+      }
+    };
+
+    const idle =
+      typeof requestIdleCallback === "function"
+        ? requestIdleCallback(() => void run())
+        : setTimeout(() => void run(), 0);
+
+    return () => {
+      cancelled = true;
+      if (typeof cancelIdleCallback === "function") {
+        cancelIdleCallback(idle as number);
+      } else {
+        clearTimeout(idle as ReturnType<typeof setTimeout>);
+      }
+    };
+  }, [repoId, kind, rev, key, enabled]);
+}

--- a/src/lib/useViewportH.test.tsx
+++ b/src/lib/useViewportH.test.tsx
@@ -1,0 +1,42 @@
+// The regression this hook exists for: measuring must not depend on
+// ResizeObserver. WebKitGTK 605 (the Linux webview) has none, and the previous
+// inline version guarded before its initial measurement, leaving the height 0 —
+// which made windowVariable fall back to a 400px viewport and render the bottom
+// of a taller diff pane blank.
+import { afterEach, describe, expect, it } from "vitest";
+import React from "react";
+import { renderHook } from "@testing-library/react";
+import { useViewportH } from "./useViewportH";
+
+const realRO = globalThis.ResizeObserver;
+
+afterEach(() => {
+  globalThis.ResizeObserver = realRO;
+});
+
+function refTo(height: number): React.RefObject<HTMLElement | null> {
+  const el = document.createElement("div");
+  Object.defineProperty(el, "clientHeight", { value: height, configurable: true });
+  return { current: el };
+}
+
+describe("useViewportH", () => {
+  it("measures on mount when ResizeObserver exists", () => {
+    const { result } = renderHook(() => useViewportH(refTo(704)));
+    expect(result.current.viewportH).toBe(704);
+  });
+
+  it("still measures on mount with NO ResizeObserver", () => {
+    // @ts-expect-error deliberately removing it, as the old webview does
+    delete globalThis.ResizeObserver;
+    const { result } = renderHook(() => useViewportH(refTo(704)));
+    expect(result.current.viewportH).toBe(704);
+  });
+
+  it("reports 0 for a detached ref, rather than throwing", () => {
+    const { result } = renderHook(() =>
+      useViewportH({ current: null } as React.RefObject<HTMLElement | null>),
+    );
+    expect(result.current.viewportH).toBe(0);
+  });
+});

--- a/src/lib/useViewportH.ts
+++ b/src/lib/useViewportH.ts
@@ -1,0 +1,53 @@
+import React from "react";
+
+/**
+ * Measured height of a scroll container, for the windowing helpers.
+ *
+ * Deliberately does NOT depend on ResizeObserver for correctness. Each diff
+ * surface used to write this inline as
+ *
+ *   if (!el || typeof ResizeObserver === "undefined") return;
+ *   setViewportH(el.clientHeight);
+ *
+ * — the guard came first, so on a webview without ResizeObserver the initial
+ * measurement never ran and the height stayed 0. `windowVariable` then fell back
+ * to a 400px viewport, so in a taller pane the rows past 400px were never
+ * mounted and the bottom of the diff rendered blank. WebKitGTK 605, which is the
+ * Linux webview and the e2e target, is exactly such a webview. Short chunked
+ * diffs always fit inside the fallback, which is why it went unnoticed until
+ * whole-file diffs made the row list long.
+ *
+ * `remeasure` is for the scroll handler: it reads the DOM only while the height
+ * is still unknown, so the common case costs nothing and no forced layout
+ * happens on every scroll event.
+ */
+export function useViewportH(
+  ref: React.RefObject<HTMLElement | null>,
+  /** Re-measure when any of these change — a mode switch, or a new row list. */
+  deps: React.DependencyList = [],
+): { viewportH: number; remeasure: () => void } {
+  const [viewportH, setViewportH] = React.useState(0);
+
+  const measure = React.useCallback(() => {
+    const el = ref.current;
+    if (el) setViewportH(el.clientHeight);
+  }, [ref]);
+
+  React.useEffect(() => {
+    measure();
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(() => {
+      setViewportH(el.clientHeight);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [measure, ...deps]);
+
+  const remeasure = React.useCallback(() => {
+    if (viewportH === 0) measure();
+  }, [viewportH, measure]);
+
+  return { viewportH, remeasure };
+}

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -53,12 +53,14 @@ import {
 import { getDiff, getLogPage } from "@/lib/tauri";
 import { useDiffSyntax } from "@/lib/syntax";
 import { flattenDiffRows, windowVariable } from "@/lib/diffRows";
+import { useViewportH } from "@/lib/useViewportH";
 import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
 import {
   WhitespaceToggle,
   useHunkActionsDisabledReason,
   useIgnoreWhitespace,
 } from "@/features/diff/WhitespaceToggle";
+import { useWholeFile } from "@/features/diff/useWholeFile";
 import { buildStatusTree, findStatusByTreeKey, treeKeyToPath } from "@/lib/tree";
 import { useTreeViewMode } from "@/lib/useTreeViewMode";
 import type {
@@ -476,6 +478,10 @@ export function CommitPanelScreen() {
   }, []);
   React.useEffect(() => setCollapsed(new Set()), [selected?.path, selected?.side]);
 
+  // Whole file here too, on purpose: the hunk headers stay, so each change block
+  // keeps its own Stage/Discard and line selection while the file reads
+  // continuously around them. Hunk indices are the canonical ones either way.
+  const wholeFile = useWholeFile(syntax);
   const rows = React.useMemo(
     () =>
       flattenDiffRows(diff && !diff.binary ? diff.hunks : [], {
@@ -483,21 +489,17 @@ export function CommitPanelScreen() {
         rowH,
         collapsed,
         syntax,
+        wholeFile,
       }),
-    [diff, headerH, rowH, collapsed, syntax],
+    [diff, headerH, rowH, collapsed, syntax, wholeFile],
   );
   const heights = React.useMemo(() => rows.map((r) => r.h), [rows]);
   const diffScrollRef = React.useRef<HTMLDivElement>(null);
   const [diffScrollTop, setDiffScrollTop] = React.useState(0);
-  const [diffViewportH, setDiffViewportH] = React.useState(0);
-  React.useEffect(() => {
-    const el = diffScrollRef.current;
-    if (!el || typeof ResizeObserver === "undefined") return;
-    setDiffViewportH(el.clientHeight);
-    const ro = new ResizeObserver(() => setDiffViewportH(el.clientHeight));
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [diffMode]);
+  const { viewportH: diffViewportH, remeasure: remeasureDiff } = useViewportH(
+    diffScrollRef,
+    [diffMode],
+  );
   const win = React.useMemo(
     () =>
       windowVariable(heights, {
@@ -980,7 +982,10 @@ export function CommitPanelScreen() {
           style={{ flex: 1 }}
           ariaLabel="Diff"
           innerRef={diffScrollRef}
-          onScroll={() => setDiffScrollTop(diffScrollRef.current?.scrollTop ?? 0)}
+          onScroll={() => {
+            setDiffScrollTop(diffScrollRef.current?.scrollTop ?? 0);
+            remeasureDiff();
+          }}
         >
           {diffLoading && (
             <div

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -22,11 +22,13 @@ import {
   WhitespaceToggle,
   useIgnoreWhitespace,
 } from "@/features/diff/WhitespaceToggle";
+import { useWholeFile } from "@/features/diff/useWholeFile";
 import { statusMark } from "@/lib/derive";
 import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
 import { getDiff } from "@/lib/tauri";
 import { useDiffSyntax } from "@/lib/syntax";
 import { flattenDiffRows, rowOffset, windowVariable } from "@/lib/diffRows";
+import { useViewportH } from "@/lib/useViewportH";
 import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
 import { useDensityStep } from "@/features/settings/useSettingsStore";
 import { pairChangedLines } from "@/lib/pairChangedLines";
@@ -38,7 +40,16 @@ export function DiffViewerScreen() {
   const status = useRepoStore((s) => s.status);
   const diffContextLines = useSettingsStore((s) => s.diffContextLines);
   const ignoreWhitespace = useIgnoreWhitespace();
-  const [mode, setMode] = React.useState<"unified" | "split">("unified");
+  // Persisted, so the choice is a preference rather than resetting on every
+  // navigation. The rest of this screen speaks "unified"; the setting speaks
+  // "inline". Mapping at this one boundary beats renaming every comparison.
+  const diffViewMode = useSettingsStore((s) => s.diffViewMode);
+  const setSetting = useSettingsStore((s) => s.set);
+  const mode: "unified" | "split" = diffViewMode === "split" ? "split" : "unified";
+  const setMode = React.useCallback(
+    (v: string) => setSetting("diffViewMode", v === "split" ? "split" : "inline"),
+    [setSetting],
+  );
   const [wrap, setWrap] = React.useState(false);
   const [filter, setFilter] = React.useState("");
   const [findQuery, setFindQuery] = React.useState("");
@@ -193,6 +204,10 @@ export function DiffViewerScreen() {
   }, []);
   React.useEffect(() => setCollapsed(new Set()), [selectedPath]);
 
+  // A find query rewrites the hunks down to matching lines only, so the pane
+  // becomes a list of matches rather than a file. Filler rows are never matches,
+  // so whole-file mode is suppressed while a query is active.
+  const wholeFile = useWholeFile(syntax, { disabled: !!findQuery.trim() });
   const rows = React.useMemo(
     () =>
       flattenDiffRows(findFiltered?.hunks ?? [], {
@@ -200,22 +215,15 @@ export function DiffViewerScreen() {
         rowH,
         collapsed,
         syntax,
+        wholeFile,
       }),
-    [findFiltered, headerH, rowH, collapsed, syntax],
+    [findFiltered, headerH, rowH, collapsed, syntax, wholeFile],
   );
   const heights = React.useMemo(() => rows.map((r) => r.h), [rows]);
 
   const scrollRef = React.useRef<HTMLDivElement>(null);
   const [scrollTop, setScrollTop] = React.useState(0);
-  const [viewportH, setViewportH] = React.useState(0);
-  React.useEffect(() => {
-    const el = scrollRef.current;
-    if (!el || typeof ResizeObserver === "undefined") return;
-    setViewportH(el.clientHeight);
-    const ro = new ResizeObserver(() => setViewportH(el.clientHeight));
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [mode]);
+  const { viewportH, remeasure } = useViewportH(scrollRef, [mode]);
 
   // Wrap makes row heights genuinely unknown — pre-wrap rows are as tall as they
   // need to be — so windowing is off and every row renders. A very large wrapped
@@ -292,7 +300,7 @@ export function DiffViewerScreen() {
             <WhitespaceToggle />
             <PGButtonGroup
               value={mode}
-              onChange={(v) => setMode(v as typeof mode)}
+              onChange={setMode}
               options={[
                 { value: "unified", label: "Unified" },
                 { value: "split", label: "Split" },
@@ -448,7 +456,10 @@ export function DiffViewerScreen() {
               style={{ flex: 1 }}
               ariaLabel="Diff"
               innerRef={scrollRef}
-              onScroll={() => setScrollTop(scrollRef.current?.scrollTop ?? 0)}
+              onScroll={() => {
+                setScrollTop(scrollRef.current?.scrollTop ?? 0);
+                remeasure();
+              }}
             >
               {findFiltered.hunks.length === 0 && findQuery.trim() && (
                 <PGEmpty icon="search" title="No matches" />

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -49,6 +49,7 @@ import {
 import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
 import { useDiffSyntax, useSyntax } from "@/lib/syntax";
 import { flattenDiffRows, windowVariable } from "@/lib/diffRows";
+import { useViewportH } from "@/lib/useViewportH";
 import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
 import { buildLineSpans } from "@/lib/lineSpans";
 import { splitCodeLines } from "@/lib/codeLines";
@@ -66,6 +67,7 @@ import {
   useHunkActionsDisabledReason,
   useIgnoreWhitespace,
 } from "@/features/diff/WhitespaceToggle";
+import { useWholeFile } from "@/features/diff/useWholeFile";
 import { PGPane, FocusableScroll, useAction, usePaneList } from "@/features/keymap";
 import type {
   BranchInfo,
@@ -590,6 +592,7 @@ export function RepoBrowserScreen() {
       return next;
     });
   }, []);
+  const browserWholeFile = useWholeFile(browserSyntax);
   const diffRows = React.useMemo(
     () =>
       flattenDiffRows(diff && !diff.binary ? diff.hunks : [], {
@@ -597,21 +600,15 @@ export function RepoBrowserScreen() {
         rowH: diffRowH,
         collapsed: collapsedHunks,
         syntax: browserSyntax,
+        wholeFile: browserWholeFile,
       }),
-    [diff, diffHeaderH, diffRowH, collapsedHunks, browserSyntax],
+    [diff, diffHeaderH, diffRowH, collapsedHunks, browserSyntax, browserWholeFile],
   );
   const diffHeights = React.useMemo(() => diffRows.map((r) => r.h), [diffRows]);
   const diffScrollRef = React.useRef<HTMLDivElement>(null);
   const [diffScrollTop, setDiffScrollTop] = React.useState(0);
-  const [diffViewportH, setDiffViewportH] = React.useState(0);
-  React.useEffect(() => {
-    const el = diffScrollRef.current;
-    if (!el || typeof ResizeObserver === "undefined") return;
-    setDiffViewportH(el.clientHeight);
-    const ro = new ResizeObserver(() => setDiffViewportH(el.clientHeight));
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
+  const { viewportH: diffViewportH, remeasure: remeasureDiff } =
+    useViewportH(diffScrollRef);
   const diffWin = React.useMemo(
     () =>
       windowVariable(diffHeights, {
@@ -965,7 +962,10 @@ export function RepoBrowserScreen() {
             style={{ flex: 1 }}
             ariaLabel="File preview"
             innerRef={diffScrollRef}
-            onScroll={() => setDiffScrollTop(diffScrollRef.current?.scrollTop ?? 0)}
+            onScroll={() => {
+              setDiffScrollTop(diffScrollRef.current?.scrollTop ?? 0);
+              remeasureDiff();
+            }}
           >
             {!selectedFile && (
               <PGEmpty

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -213,8 +213,38 @@ export function SettingsScreen() {
 
         <Section title="Diff" subtitle="How diffs are rendered across the app.">
           <Row
+            label="Layout"
+            hint="Inline shows one column with added and removed lines interleaved. Split shows the old and new file side by side."
+            control={
+              <PGSelect
+                value={s.diffViewMode}
+                onChange={(v) => s.set("diffViewMode", v as "inline" | "split")}
+                options={[
+                  { value: "inline", label: "Inline" },
+                  { value: "split", label: "Split" },
+                ]}
+              />
+            }
+          />
+          <Row
+            label="Show"
+            hint="Whole file reads the file top to bottom with each change in place. Changed chunks shows only the hunks and their context lines. Either way, staging still applies exactly the hunks git would."
+            control={
+              <PGSelect
+                value={s.diffContextMode}
+                onChange={(v) =>
+                  s.set("diffContextMode", v as "wholeFile" | "chunks")
+                }
+                options={[
+                  { value: "wholeFile", label: "Whole file" },
+                  { value: "chunks", label: "Changed chunks" },
+                ]}
+              />
+            }
+          />
+          <Row
             label="Context lines"
-            hint="Unchanged lines shown around each hunk."
+            hint="Unchanged lines shown around each hunk in the changed-chunks view. Also the context every hunk stage/discard is computed against, so it applies in both views."
             control={
               <PGInput
                 type="number"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,11 @@ export default defineConfig(async () => ({
     alias: { "@": path.resolve(__dirname, "./src") },
   },
   clearScreen: false,
+  // The syntax tokenizer runs in a module worker (src/lib/syntax/tokenize.worker.ts)
+  // and Shiki loads each grammar as a dynamic import, so the worker bundle is
+  // code-split. Vite's default worker format is "iife", which rollup refuses for a
+  // split build — the production build fails outright without this.
+  worker: { format: "es" },
   server: {
     port: 1420,
     strictPort: true,


### PR DESCRIPTION
Addresses all four asks in the request. Note the request predates #104, which had already landed the shared windowed renderer, Shiki highlighting and word spans — so the scope here is what was actually left. Spec: `docs/superpowers/specs/2026-08-14-whole-file-diff-and-async-highlight-design.md`.

## What changed

**Inline default, now a real preference.** The Diff screen's unified/split choice lived in local component state, so it reset on every navigation and could not be a default. It is now a persisted `diffViewMode`, defaulting to inline. Added `Layout` and `Show` controls in Settings.

**Stronger changed-word highlight.** The tint was an inline `0.28` alpha off `--git-added`/`--git-removed`, barely separating from the line background it sits on. Now `--git-added-word` / `--git-removed-word`, defined per theme **mode** — light goes darker where dark goes lighter, since inheriting the dark value washed out to invisible on a pale line fill.

**Whole file by default,** on every diff surface, with `Changed chunks` available as a setting.

**Tokenization off the main thread,** plus a bounded prefetch when a commit opens.

## Whole-file: how, and why not the obvious way

Whole file is composed on the **frontend**. It deliberately does *not* come from passing a large `contextLines`: libgit2 would return a single hunk covering the file, so `stage_hunk` would stage everything and `changedIndex` would shift — a data-loss-class bug in a git client.

Instead the canonical diff is left exactly as fetched and the unchanged remainder is filled in around it as a new `fill` row kind:

- `fill` carries **no `hunkIndex`**, so the type checker keeps it out of every staging and line-selection path. A sentinel index would have been one missing guard away from staging the wrong hunk.
- A test pins that hunk rows are **byte-identical with and without** filling — the staging-safety invariant.
- Inconsistent gap arithmetic degrades to chunked rather than rendering plausible-but-wrong line numbers.
- Git's `+N,0` convention (the line *before* which nothing was added) is normalized in `effStart`, or every filler line number after a pure-deletion hunk shifts by one.
- Text comes from `useDiffSyntax`, which already read both sides in full to tokenize them, so whole-file costs **no extra IPC**.

**Hunk headers stay** — they carry Stage/Discard, the collapse chevron, `data-hunk-index` for F7, and the e2e selectors. That is what makes this "the Rider stage view, but showing the whole file": the file reads continuously and each change block keeps its own stage control.

## Highlighting

`useSyntax` already discarded stale *results*, but Shiki's `codeToTokens` is synchronous CPU work — awaiting it on the main thread still ran the whole cost there, so selecting a file and immediately moving to another janked for the first file and the cancel only threw the answer away afterwards. It now runs in a module worker.

- Tokens come back **packed into transferable `Int32Array`s** rather than structured-cloning one object per token, which would have moved the cost to the main thread instead of removing it.
- Splitting the Shiki call into `tokenizeShiki.ts`, imported dynamically by the fallback, drops the main bundle **1046 kB → 881 kB** (gzip 324 → 269 kB).
- A failed worker construction or crash **degrades to main-thread tokenizing**, so the worst case is the previous behaviour. That is also the path jsdom component tests take, and the worker path has its own tests against a fake `Worker`.
- `vite.config.ts` needs `worker: { format: "es" }` — Shiki's grammars are dynamic imports, so the worker bundle is code-split and Vite's default `iife` format fails the production build outright.

## Bug found along the way

All four diff surfaces measured their scroll viewport as:

```ts
if (!el || typeof ResizeObserver === "undefined") return;
setViewportH(el.clientHeight);   // never ran
```

The guard came first, so on a webview without `ResizeObserver` the initial measurement never happened and the height stayed 0 — `windowVariable` then fell back to a 400px viewport and the bottom of a taller diff pane **rendered blank**. WebKitGTK 605, the Linux webview and the e2e target, is exactly such a webview. Latent because chunked diffs fit inside the fallback; whole-file diffs made the row list long enough to expose it. Now `lib/useViewportH.ts`.

Surfaced by the `keymap` F7 spec, whose second hunk stopped rendering. That spec also assumed both hunks were on screen simultaneously — true of a chunked 60-line fixture, not a whole-file one — so its precondition now asserts hunk 0 and lets the F7 sequence prove hunk 1, which additionally exercises F7's scroll-into-view for the first time.

## Verification

- `pnpm test` — **975 passing, 138 files** (baseline before this branch: 935/133).
- `pnpm tsc --noEmit` and `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — clean.
- `pnpm vite build` — clean.
- `pnpm test:e2e:docker run` — **full suite, 19/19 spec files pass.**
- No Rust changes: `git diff origin/main -- src-tauri` is empty. No new `GitBackend` method, no new command.

New tests worth noting: whole-file gap arithmetic including both zero-length-side cases and every degrade path; the with/without-fill parity invariant; the worker client against a fake `Worker`; packed round-trip; and the ResizeObserver-free measurement regression.

## Known characteristic

The worker handles requests in order and a single `codeToTokens` call cannot be interrupted once started, so clicking through several files quickly queues their tokenizations — the UI never blocks and text renders immediately, but a later file's *colours* can wait behind an earlier large file's. Deliberately not solved with a queue that drops superseded jobs: resolving a dropped request means "render this file plain", and getting that wrong leaves a file permanently uncoloured, which is worse than the latency. The prefetch makes the common case a cache hit instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185qXvxHSJzJvKXpa65sKmB
