### PR TITLE
refactor: close out the four remaining #47 cleanup items

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,10 +228,13 @@ git/
 │                worktree untouched — that is the whole point of the module
 ├── rebase_state.rs  On-disk mirror of an in-progress rebase
 │                (`.git/platypusgit-rebase.json` + `ORIG_HEAD`) so Continue and
-│                Abort survive an app restart. Deliberately NOT git's own
-│                `.git/rebase-merge/` dir — a half-compatible one would let
-│                `git status` / `git rebase --continue` claim a rebase they
-│                cannot drive
+│                Abort survive an app restart, PLUS the last completed rebase's
+│                summary in a SECOND file (`platypusgit-rebase-last.json`) —
+│                separate because everything that asks "is a rebase in
+│                progress?" answers by the first file's existence. Deliberately
+│                NOT git's own `.git/rebase-merge/` dir — a half-compatible one
+│                would let `git status` / `git rebase --continue` claim a rebase
+│                they cannot drive
 └── signature.rs Author/committer signature helpers
 commands/        Thin Tauri handlers, one file per area:
 ├── repo.rs        open_repo, trust_repo_path, get_status, list_all_files,
@@ -257,7 +260,7 @@ commands/        Thin Tauri handlers, one file per area:
 ├── conflict.rs    repo_state, conflict_sides, accept_ours/theirs, mark_resolved,
 │                  save_resolution, abort/continue_operation, run_mergetool,
 │                  restart_conflict
-├── rebase.rs      rebase_start/continue/abort/status (interactive)
+├── rebase.rs      rebase_start/continue/abort/status/acknowledge (interactive)
 ├── reflog.rs      get_reflog, checkout_detached
 └── create.rs      init_repo, default_init_branch, clone_repo (streaming
                    git clone → clone://progress events)
@@ -371,6 +374,14 @@ lib/
 ├── useViewportH.ts  Scroll-container height WITHOUT depending on ResizeObserver
 ├── useWindowedList.ts  Fixed-pitch windowing for the plain lists
 ├── fileIcon.ts      path → file-type glyph + themeable tint (tested)
+├── selection.ts     Multi-select click/range/prune model AND
+│                    `splitFileSelection` — the one place a multi-selection is
+│                    bucketed into staged/unstaged/untracked/embedded paths for
+│                    `multiFileMenuItems`. Each surface supplies only its own
+│                    key→row lookup (`sidedSelectionSource` for the commit
+│                    panel's `side:path` keys, `treeSelectionSource` for the
+│                    repo browser's `/a/b` tree keys); folder expansion and
+│                    embedded-repo bucketing live in the shared splitter
 ├── tree.ts          buildStatusTree / buildStatusList — SAME row keys, which is
 │                    what makes the tree⇄flat toggle free of per-mode branches
 ├── useTreeViewMode.ts  Persisted tree|flat preference, one key per surface
@@ -504,6 +515,15 @@ lib/
   the rebase. `repo_state` gives the file precedence over libgit2's
   `repo.state()`, which only sees the `CHERRY_PICK_HEAD` a paused step leaves
   behind.
+- **A finished rebase leaves a summary the BACKEND retains until acknowledged**
+  (`RebaseStatus.last_completed`, `.git/platypusgit-rebase-last.json`). The
+  engine sweeps `RebaseState` the instant a plan completes, so the next
+  `rebase_status` poll reports `total: 0`; the frontend used to cache the final
+  status for its "N steps completed" line and therefore had to clear that cache
+  on every abort and start path (#47). Now `rebase_start` and `rebase_abort`
+  drop the summary in the engine and `rebase_acknowledge` spends it — the
+  Rebase screen renders straight from `rebaseStatus.lastCompleted` and
+  acknowledges on unmount, holding no copy of its own.
 - **`continue_operation` / `abort_operation` delegate** to `rebase_continue` /
   `rebase_abort` whenever a rebase is in progress. The Conflict screen and the
   Rebase banner must stay two entry points to one engine: committing the

--- a/src-tauri/src/commands/rebase.rs
+++ b/src-tauri/src/commands/rebase.rs
@@ -51,3 +51,13 @@ pub async fn rebase_status(
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
 }
+
+/// Drop `RebaseStatus.last_completed` once the UI has shown it.
+#[tauri::command]
+pub async fn rebase_acknowledge(state: State<'_, AppState>, repo_id: String) -> AppResult<()> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    tokio::task::spawn_blocking(move || backend.rebase_acknowledge(&repo_id))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -329,6 +329,9 @@ impl GitBackend for CliBackend {
     fn rebase_status(&self, _repo_id: &RepoId) -> AppResult<RebaseStatus> {
         Err(AppError::NotImplemented)
     }
+    fn rebase_acknowledge(&self, _repo_id: &RepoId) -> AppResult<()> {
+        Err(AppError::NotImplemented)
+    }
     fn read_reflog(&self, _repo_id: &RepoId) -> AppResult<Vec<ReflogEntry>> {
         Err(AppError::NotImplemented)
     }

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -17,10 +17,9 @@ use super::{
     types::{
         BlameLine, BranchInfo, CommitInfo, CommitOptions, ConflictSides, DiffHunk, DiffKind,
         DiffLine, DiffLineKind, FileContent, FileDiff, FileStatus, LogFilter, LogPage,
-        RebaseAction,
-        RebaseStatus, RebaseStep, ReflogEntry, ReflogOp, RemoteInfo, RepoHandle, RepoId, RepoState,
-        ResetMode, REFSPEC_ALL,
-        StashInfo, StashSaveOptions, StatusFlag, TagInfo, TagTarget,
+        RebaseAction, RebaseStatus, RebaseStep, RebaseSummary, ReflogEntry, ReflogOp, RemoteInfo,
+        RepoHandle, RepoId, RepoState, ResetMode, StashInfo, StashSaveOptions, StatusFlag, TagInfo,
+        TagTarget, REFSPEC_ALL,
     },
     GitBackend,
 };
@@ -550,7 +549,7 @@ impl Libgit2Backend {
                 // later `rebase_status` poll (banner) or `abort_operation`
                 // call doesn't treat this finished rebase as still
                 // in-progress/abortable via its now-stale `orig_head`.
-                let status = self.rebase_status(repo_id)?;
+                let mut status = self.rebase_status(repo_id)?;
                 {
                     let mut rebases = self
                         .rebases
@@ -561,6 +560,19 @@ impl Libgit2Backend {
                 // No in-memory entry any more, so this sweeps the state file
                 // too — the operation is over on disk as well.
                 self.persist_rebase(repo_id)?;
+                // ...which is exactly why the summary is written separately:
+                // with the state gone, this is the only record that the rebase
+                // happened, and `rebase_status` keeps reporting it until the UI
+                // acknowledges it (#47). Frontend caching of this is what the
+                // retained summary replaces.
+                let summary = RebaseSummary {
+                    total: status.total,
+                    completed: status.next_index,
+                };
+                self.with_repo(repo_id, |repo| {
+                    crate::git::rebase_state::save_summary(repo, &summary)
+                })?;
+                status.last_completed = Some(summary);
                 return Ok(status);
             };
 
@@ -3779,6 +3791,10 @@ impl GitBackend for Libgit2Backend {
             // Same escape hatch git leaves before rewriting history:
             // `git reset --hard ORIG_HEAD` undoes this rebase from the CLI.
             crate::git::rebase_state::write_orig_head(repo, &orig_head)?;
+            // A new rebase supersedes whatever the last one did, so the retained
+            // summary goes now — before the replay can write a new one. This is
+            // the clearing the frontend used to have to remember (#47).
+            crate::git::rebase_state::clear_summary(repo)?;
 
             // The run's base: what the first step says it sits on, else that
             // commit's first parent.
@@ -3887,6 +3903,10 @@ impl GitBackend for Libgit2Backend {
         self.with_repo(repo_id, |repo| {
             repo.cleanup_state()?;
             crate::git::rebase_state::clear(repo)?;
+            // An abort throws the replay away, so there is nothing to report
+            // about it — and a summary left from an EARLIER rebase would read as
+            // this one's outcome.
+            crate::git::rebase_state::clear_summary(repo)?;
             // The replay ran on a detached HEAD, so the branch never moved:
             // abort is "put HEAD back on the branch and throw the replay away".
             // A rebase started from a detached HEAD has no branch to return to,
@@ -3922,31 +3942,46 @@ impl GitBackend for Libgit2Backend {
                 next_index: state.completed,
                 total: state.total,
                 pause_reason: state.pause_reason.clone(),
+                last_completed: None,
             })
         };
-        if let Some(status) = in_memory {
-            return Ok(status);
-        }
 
-        // No in-memory entry: either there is no rebase, or this process did
-        // not start it (the app was restarted mid-rebase). The state file is
-        // the authority in that case.
-        self.with_repo(repo_id, |repo| {
-            Ok(match crate::git::rebase_state::load(repo)? {
-                Some(state) => RebaseStatus {
-                    in_progress: true,
-                    next_index: state.completed,
-                    total: state.total,
-                    pause_reason: state.pause_reason,
-                },
-                None => RebaseStatus {
-                    in_progress: false,
-                    next_index: 0,
-                    total: 0,
-                    pause_reason: None,
-                },
-            })
-        })
+        let mut status = match in_memory {
+            Some(status) => status,
+            // No in-memory entry: either there is no rebase, or this process
+            // did not start it (the app was restarted mid-rebase). The state
+            // file is the authority in that case.
+            None => self.with_repo(repo_id, |repo| {
+                Ok(match crate::git::rebase_state::load(repo)? {
+                    Some(state) => RebaseStatus {
+                        in_progress: true,
+                        next_index: state.completed,
+                        total: state.total,
+                        pause_reason: state.pause_reason,
+                        last_completed: None,
+                    },
+                    None => RebaseStatus {
+                        in_progress: false,
+                        next_index: 0,
+                        total: 0,
+                        pause_reason: None,
+                        last_completed: None,
+                    },
+                })
+            })?,
+        };
+
+        // The completed-rebase summary outlives the rebase it describes, so it
+        // is read here rather than derived from state that no longer exists.
+        // It is written only on completion and dropped on start/abort/ack, so
+        // it is always absent while `in_progress` is true.
+        status.last_completed =
+            self.with_repo(repo_id, crate::git::rebase_state::load_summary)?;
+        Ok(status)
+    }
+
+    fn rebase_acknowledge(&self, repo_id: &RepoId) -> AppResult<()> {
+        self.with_repo(repo_id, crate::git::rebase_state::clear_summary)
     }
 
     fn verify_commit(

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -331,6 +331,11 @@ pub trait GitBackend: Send + Sync {
     fn rebase_continue(&self, repo_id: &RepoId) -> AppResult<RebaseStatus>;
     fn rebase_abort(&self, repo_id: &RepoId) -> AppResult<()>;
     fn rebase_status(&self, repo_id: &RepoId) -> AppResult<RebaseStatus>;
+    /// Drop the retained `RebaseStatus.last_completed` summary. Called once the
+    /// UI has shown it; without it the summary would greet the user again on
+    /// every later poll, and after a restart. Starting or aborting a rebase
+    /// drops it too, so this is the only path a plain "I've seen it" takes.
+    fn rebase_acknowledge(&self, repo_id: &RepoId) -> AppResult<()>;
 
     // === ignore ===
     /// Append a pattern to the repo's top-level `.gitignore`, creating the file

--- a/src-tauri/src/git/rebase_state.rs
+++ b/src-tauri/src/git/rebase_state.rs
@@ -17,10 +17,19 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{AppError, AppResult};
 
-use super::types::RebaseStep;
+use super::types::{RebaseStep, RebaseSummary};
 
 pub const FILE_NAME: &str = "platypusgit-rebase.json";
 pub const VERSION: u32 = 1;
+
+/// Where the last COMPLETED rebase's summary lives — deliberately a second
+/// file, not a variant inside {@link FILE_NAME}.
+///
+/// Everything that asks "is a rebase in progress?" (`repo_state`,
+/// `rebase_in_progress`, `rehydrate_rebase`) answers by the mere existence of
+/// the in-progress file. Storing a finished rebase there would make all three
+/// claim an operation that is over, and offer Continue/Abort for it.
+pub const SUMMARY_FILE_NAME: &str = "platypusgit-rebase-last.json";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -92,6 +101,60 @@ pub fn load(repo: &Repository) -> AppResult<Option<PersistedRebase>> {
 
 pub fn clear(repo: &Repository) -> AppResult<()> {
     match std::fs::remove_file(path(repo)) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+// ── Last completed rebase ───────────────────────────────────────────────────
+// A rebase's state is swept the instant its plan finishes, so nothing is left
+// to describe it one poll later. The summary is kept beside it until the UI
+// acknowledges it, which is what lets `rebase_status` keep answering "N steps
+// completed" without the frontend caching the answer and having to invalidate
+// that cache on every abort and start path (#47).
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PersistedSummary {
+    version: u32,
+    #[serde(flatten)]
+    summary: RebaseSummary,
+}
+
+pub fn summary_path(repo: &Repository) -> PathBuf {
+    repo.path().join(SUMMARY_FILE_NAME)
+}
+
+pub fn save_summary(repo: &Repository, summary: &RebaseSummary) -> AppResult<()> {
+    let target = summary_path(repo);
+    let tmp = target.with_extension("json.tmp");
+    let json = serde_json::to_vec_pretty(&PersistedSummary {
+        version: VERSION,
+        summary: *summary,
+    })
+    .map_err(|e| AppError::Internal(format!("serialising rebase summary: {e}")))?;
+    std::fs::write(&tmp, json)?;
+    std::fs::rename(&tmp, &target)?;
+    Ok(())
+}
+
+/// `Ok(None)` when there is nothing to report. Unlike the in-progress state, an
+/// unreadable summary is NOT an error: it describes an operation that already
+/// finished, so nothing is at risk in forgetting it — and failing the read would
+/// break `rebase_status` (and with it the whole refresh) over a stale note.
+pub fn load_summary(repo: &Repository) -> AppResult<Option<RebaseSummary>> {
+    let Ok(bytes) = std::fs::read(summary_path(repo)) else {
+        return Ok(None);
+    };
+    Ok(serde_json::from_slice::<PersistedSummary>(&bytes)
+        .ok()
+        .filter(|p| p.version == VERSION)
+        .map(|p| p.summary))
+}
+
+pub fn clear_summary(repo: &Repository) -> AppResult<()> {
+    match std::fs::remove_file(summary_path(repo)) {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(e.into()),

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -372,6 +372,24 @@ pub struct RebaseStep {
     pub merge_parents: Vec<String>,
 }
 
+/// What a rebase that ran to completion did, kept after the rebase itself is
+/// over so the UI can still report it.
+///
+/// The engine sweeps its `RebaseState` the moment a plan finishes, so a
+/// `rebase_status` poll one tick later has nothing left to describe. The
+/// frontend used to cache the final status for the "N steps completed" line,
+/// which meant every abort and every start path had to remember to clear that
+/// cache (#47). The backend retains this instead, until `rebase_acknowledge`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RebaseSummary {
+    /// Steps the completed plan contained.
+    pub total: usize,
+    /// Steps that ran, drops included — equal to `total` for a plan that
+    /// reached its end, which is the only way a summary is recorded.
+    pub completed: usize,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RebaseStatus {
@@ -382,6 +400,10 @@ pub struct RebaseStatus {
     pub total: usize,
     /// "conflict" | "edit" | "ok" — only meaningful when in_progress is true.
     pub pause_reason: Option<String>,
+    /// The most recently completed rebase, until it is acknowledged. Always
+    /// `None` while a rebase is in progress: starting one supersedes it, and
+    /// aborting one drops it. See {@link RebaseSummary}.
+    pub last_completed: Option<RebaseSummary>,
 }
 
 /// How to integrate fetched changes during a pull.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -216,6 +216,7 @@ pub fn run() {
             commands::rebase::rebase_continue,
             commands::rebase::rebase_abort,
             commands::rebase::rebase_status,
+            commands::rebase::rebase_acknowledge,
             commands::reflog::get_reflog,
             commands::reflog::checkout_detached,
             commands::cli::take_launch_intent,

--- a/src-tauri/tests/rebase_summary.rs
+++ b/src-tauri/tests/rebase_summary.rs
@@ -1,0 +1,253 @@
+//! The completed-rebase summary the backend retains until acknowledged (#47).
+//!
+//! The engine sweeps its `RebaseState` the moment a plan finishes, so a
+//! `rebase_status` poll one tick later has nothing left to describe. The
+//! frontend used to cache the final status for its "N steps completed" line,
+//! which put the burden of invalidating that cache on every abort and start
+//! path. These tests pin the replacement contract:
+//!
+//! - completion records a summary, and it survives repeated polls;
+//! - a NEW rebase start drops it (it describes a superseded operation);
+//! - an abort drops it (there is no outcome to report);
+//! - `rebase_acknowledge` drops it, and only once it is asked to;
+//! - it lives in its own file, so nothing that asks "is a rebase in progress?"
+//!   mistakes a finished rebase for a live one.
+
+mod support;
+
+use platypusgit_lib::git::{
+    rebase_state,
+    types::{RebaseAction, RebaseStep, RebaseSummary, RepoState},
+    GitBackend,
+};
+
+use support::{linear_history, TempRepo};
+
+fn step(oid: &str, action: RebaseAction) -> RebaseStep {
+    RebaseStep {
+        oid: oid.to_string(),
+        action,
+        message: None,
+        onto: None,
+        merge_parents: Vec::new(),
+    }
+}
+
+fn pick_all(oids: &[String]) -> Vec<RebaseStep> {
+    oids.iter().map(|o| step(o, RebaseAction::Pick)).collect()
+}
+
+#[test]
+fn a_completed_rebase_leaves_a_summary_that_survives_polling() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 3);
+    let (backend, handle) = tr.open_with_backend();
+
+    let done = backend.rebase_start(&handle.id, pick_all(&oids)).unwrap();
+    assert!(!done.in_progress, "a plain pick plan runs to completion");
+    assert_eq!(
+        done.last_completed,
+        Some(RebaseSummary {
+            total: 3,
+            completed: 3
+        }),
+        "the call that finished the rebase reports its own summary"
+    );
+
+    // The engine's state is gone — total is back to 0 — but the summary is not.
+    for _ in 0..3 {
+        let polled = backend.rebase_status(&handle.id).unwrap();
+        assert!(!polled.in_progress);
+        assert_eq!(polled.total, 0, "RebaseState really was swept");
+        assert_eq!(
+            polled.last_completed,
+            Some(RebaseSummary {
+                total: 3,
+                completed: 3
+            }),
+            "the summary must outlive the state it summarises"
+        );
+    }
+}
+
+#[test]
+fn acknowledging_drops_the_summary_and_nothing_else_does() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 2);
+    let (backend, handle) = tr.open_with_backend();
+
+    backend.rebase_start(&handle.id, pick_all(&oids)).unwrap();
+    assert!(backend
+        .rebase_status(&handle.id)
+        .unwrap()
+        .last_completed
+        .is_some());
+
+    backend.rebase_acknowledge(&handle.id).unwrap();
+    assert_eq!(
+        backend.rebase_status(&handle.id).unwrap().last_completed,
+        None,
+        "acknowledging is what spends the summary"
+    );
+
+    // Idempotent: a second acknowledge (double refresh, second window) is fine.
+    backend.rebase_acknowledge(&handle.id).unwrap();
+    assert_eq!(backend.rebase_status(&handle.id).unwrap().last_completed, None);
+}
+
+#[test]
+fn starting_a_new_rebase_drops_the_previous_summary() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 3);
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .rebase_start(&handle.id, pick_all(&oids[..2]))
+        .unwrap();
+    assert!(backend
+        .rebase_status(&handle.id)
+        .unwrap()
+        .last_completed
+        .is_some());
+
+    // A rebase that PAUSES: the previous summary must be gone from the moment
+    // the new operation begins, not merely once it finishes.
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string();
+    let paused = backend
+        .rebase_start(&handle.id, vec![step(&head, RebaseAction::Edit)])
+        .unwrap();
+    assert!(paused.in_progress, "an edit step pauses");
+    assert_eq!(
+        paused.last_completed, None,
+        "a new rebase supersedes the last one's summary"
+    );
+    assert_eq!(
+        backend.rebase_status(&handle.id).unwrap().last_completed,
+        None
+    );
+
+    // ...and finishing this one records its own.
+    let done = backend.rebase_continue(&handle.id).unwrap();
+    assert!(!done.in_progress);
+    assert_eq!(
+        done.last_completed,
+        Some(RebaseSummary {
+            total: 1,
+            completed: 1
+        })
+    );
+}
+
+#[test]
+fn aborting_drops_the_summary() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 3);
+    let (backend, handle) = tr.open_with_backend();
+
+    // One completed rebase, so there is a summary to be wrongly kept.
+    backend
+        .rebase_start(&handle.id, pick_all(&oids[..2]))
+        .unwrap();
+    assert!(backend
+        .rebase_status(&handle.id)
+        .unwrap()
+        .last_completed
+        .is_some());
+
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string();
+    backend
+        .rebase_start(&handle.id, vec![step(&head, RebaseAction::Edit)])
+        .unwrap();
+    backend.rebase_abort(&handle.id).unwrap();
+
+    let after = backend.rebase_status(&handle.id).unwrap();
+    assert!(!after.in_progress, "the abort ended the rebase");
+    assert_eq!(
+        after.last_completed, None,
+        "an abort has no outcome to report, and must not leave the earlier one \
+         standing as if it were this rebase's"
+    );
+
+    // Aborting with a fresh summary and nothing in progress clears it too.
+    backend
+        .rebase_start(&handle.id, vec![step(&oids[2], RebaseAction::Pick)])
+        .unwrap();
+    assert!(backend
+        .rebase_status(&handle.id)
+        .unwrap()
+        .last_completed
+        .is_some());
+    backend.rebase_abort(&handle.id).unwrap();
+    assert_eq!(
+        backend.rebase_status(&handle.id).unwrap().last_completed,
+        None
+    );
+}
+
+#[test]
+fn the_summary_lives_beside_the_state_file_not_inside_it() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 2);
+    let (backend, handle) = tr.open_with_backend();
+
+    backend.rebase_start(&handle.id, pick_all(&oids)).unwrap();
+
+    assert!(
+        rebase_state::summary_path(&tr.repo).exists(),
+        "completion writes the summary file"
+    );
+    assert!(
+        !rebase_state::path(&tr.repo).exists(),
+        "the in-progress state file is swept on completion"
+    );
+    // Everything that asks "is a rebase in progress?" answers by the existence
+    // of the in-progress file, so the summary must not be able to trip it.
+    assert!(
+        rebase_state::load(&tr.repo).unwrap().is_none(),
+        "no in-progress rebase is on disk"
+    );
+    assert_eq!(
+        backend.repo_state(&handle.id).unwrap(),
+        RepoState::Clean,
+        "a retained summary must not read as an open operation"
+    );
+
+    backend.rebase_acknowledge(&handle.id).unwrap();
+    assert!(!rebase_state::summary_path(&tr.repo).exists());
+}
+
+#[test]
+fn a_summary_survives_a_backend_restart() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 2);
+    {
+        let (backend, handle) = tr.open_with_backend();
+        backend.rebase_start(&handle.id, pick_all(&oids)).unwrap();
+    }
+
+    // A fresh backend has no in-memory rebase map at all: the summary is on
+    // disk for the same reason the in-progress state is.
+    let (backend, handle) = tr.open_with_backend();
+    assert_eq!(
+        backend.rebase_status(&handle.id).unwrap().last_completed,
+        Some(RebaseSummary {
+            total: 2,
+            completed: 2
+        })
+    );
+}
+
+#[test]
+fn an_unreadable_summary_is_forgotten_rather_than_failing_the_status_poll() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    // A summary describes an operation that already finished, so nothing is at
+    // risk in forgetting it — unlike the in-progress state, where guessing
+    // would strand a half-replayed branch. Failing here would instead break
+    // every refresh until the user deleted the file by hand.
+    std::fs::write(rebase_state::summary_path(&tr.repo), b"{ not json").unwrap();
+    let status = backend.rebase_status(&handle.id).unwrap();
+    assert_eq!(status.last_completed, None);
+    assert!(!status.in_progress);
+}

--- a/src/features/keymap/useAction.ts
+++ b/src/features/keymap/useAction.ts
@@ -2,23 +2,35 @@
 // mounted. Components dispatch action ids, never raw keys. Last mounted handler
 // for an action wins (innermost component handles it). Pass `paneId` for
 // pane-scoped actions — the dispatcher only delivers those while that pane
-// holds focus.
+// holds focus. `paneId` also takes a LIST of panes, so a screen whose chord
+// answers from any of its panes registers once instead of once per pane.
 
 import { useEffect } from "react";
 import { useKeymapStore, type ActionHandler } from "./useKeymapStore";
 import type { ActionId } from "./actions";
 
+/** Pane scopes are compared by CONTENT, not identity: a multi-pane caller
+ *  builds a fresh array every render, and keying the effect on the array itself
+ *  would unregister and re-register the handler on every render. Keyed by
+ *  content, the scope the effect captured always matches the current one. */
+function scopeKey(paneId: string | readonly string[] | undefined): string | undefined {
+  if (paneId === undefined || typeof paneId === "string") return paneId;
+  // NUL separator: no pane id contains one, so no two scopes collide.
+  return paneId.join("\u0000");
+}
+
 export function useAction(
   id: ActionId,
   handler: ActionHandler,
   deps: unknown[],
-  opts?: { paneId?: string },
+  opts?: { paneId?: string | readonly string[] },
 ): void {
   const paneId = opts?.paneId;
+  const paneKey = scopeKey(paneId);
   useEffect(() => {
     return useKeymapStore.getState().register(id, handler, { paneId });
     // Handler identity is captured per-deps by the caller; re-register when
     // deps change so the latest closure is invoked.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [...deps, paneId]);
+  }, [...deps, paneKey]);
 }

--- a/src/features/keymap/useHunkNav.test.tsx
+++ b/src/features/keymap/useHunkNav.test.tsx
@@ -2,7 +2,7 @@
 // clamping, scrolls the active hunk into view, resets when the viewed file
 // changes, and answers only while one of its panes holds focus.
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, render } from "@testing-library/react";
 import { useHunkNav } from "./useHunkNav";
 import { useKeymapStore } from "./useKeymapStore";
@@ -12,16 +12,14 @@ function Harness({
   count,
   resetKey,
   onCursor,
+  paneIds = ["d.files", "d.view"],
 }: {
   count: number;
   resetKey: string;
   onCursor: (c: number) => void;
+  paneIds?: string[];
 }) {
-  const cursor = useHunkNav({
-    paneIds: ["d.files", "d.view"],
-    count,
-    resetKey,
-  });
+  const cursor = useHunkNav({ paneIds, count, resetKey });
   onCursor(cursor);
   return null;
 }
@@ -46,6 +44,24 @@ function press(k: string, shift = false): boolean {
   return handled;
 }
 
+/** A pane element carrying one `[data-hunk-index]` wrapper per hunk, each with
+ *  its own scrollIntoView spy so the "first matching pane" pick is observable. */
+function mountPane(paneId: string, hunks: number[]): Map<number, () => void> {
+  const pane = document.createElement("div");
+  pane.setAttribute("data-pg-pane", paneId);
+  const spies = new Map<number, () => void>();
+  for (const i of hunks) {
+    const hunk = document.createElement("div");
+    hunk.setAttribute("data-hunk-index", String(i));
+    const spy = vi.fn();
+    hunk.scrollIntoView = spy;
+    spies.set(i, spy);
+    pane.appendChild(hunk);
+  }
+  document.body.appendChild(pane);
+  return spies;
+}
+
 describe("useHunkNav", () => {
   let cursor = -1;
   const onCursor = (c: number) => {
@@ -66,6 +82,10 @@ describe("useHunkNav", () => {
     });
   });
 
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
   it("F7 walks forward with clamping; ⇧F7 walks back", () => {
     render(<Harness count={3} resetKey="a" onCursor={onCursor} />);
     useFocusStore.setState({ focused: "d.view" });
@@ -78,19 +98,79 @@ describe("useHunkNav", () => {
     expect(cursor).toBe(2);
     press("F7", true); // Shift+F7
     expect(cursor).toBe(1);
+    press("F7", true);
+    press("F7", true); // clamp at the first hunk
+    expect(cursor).toBe(0);
   });
 
   it("answers from the file-list pane too, declines with no hunks", () => {
-    render(<Harness count={0} resetKey="a" onCursor={onCursor} />);
+    const { rerender } = render(
+      <Harness count={3} resetKey="a" onCursor={onCursor} />,
+    );
+    useFocusStore.setState({ focused: "d.files" });
+    expect(press("F7")).toBe(true);
+    expect(cursor).toBe(0);
+    // Same chord, other pane of the same screen — one registration serves both.
+    useFocusStore.setState({ focused: "d.view" });
+    expect(press("F7")).toBe(true);
+    expect(cursor).toBe(1);
+
+    rerender(<Harness count={0} resetKey="b" onCursor={onCursor} />);
     useFocusStore.setState({ focused: "d.files" });
     expect(press("F7")).toBe(false);
   });
 
-  it("declines while an unrelated pane holds focus", () => {
+  it("declines while an unrelated pane holds focus, or with no pane focused", () => {
     render(<Harness count={3} resetKey="a" onCursor={onCursor} />);
     useFocusStore.setState({ focused: "elsewhere" });
     expect(press("F7")).toBe(false);
+    expect(press("F7", true)).toBe(false);
     expect(cursor).toBe(-1);
+    useFocusStore.setState({ focused: null });
+    expect(press("F7")).toBe(false);
+    expect(cursor).toBe(-1);
+  });
+
+  it("scopes follow a changed pane list", () => {
+    const { rerender } = render(
+      <Harness
+        count={3}
+        resetKey="a"
+        onCursor={onCursor}
+        paneIds={["d.files", "d.view"]}
+      />,
+    );
+    rerender(
+      <Harness count={3} resetKey="a" onCursor={onCursor} paneIds={["d.view"]} />,
+    );
+    useFocusStore.setState({ focused: "d.files" });
+    expect(press("F7")).toBe(false);
+    expect(cursor).toBe(-1);
+    useFocusStore.setState({ focused: "d.view" });
+    expect(press("F7")).toBe(true);
+    expect(cursor).toBe(0);
+  });
+
+  it("scrolls the FIRST pane that renders the target hunk", () => {
+    const files = mountPane("d.files", [0]); // a stand-in leading pane
+    const view = mountPane("d.view", [0]);
+    render(<Harness count={2} resetKey="a" onCursor={onCursor} />);
+    useFocusStore.setState({ focused: "d.view" });
+    press("F7");
+    expect(files.get(0)).toHaveBeenCalledOnce();
+    expect(view.get(0)).not.toHaveBeenCalled();
+  });
+
+  it("falls through to a later pane when the earlier one lacks the hunk", () => {
+    mountPane("d.files", []); // file list never renders hunk wrappers
+    const view = mountPane("d.view", [0, 1]);
+    render(<Harness count={2} resetKey="a" onCursor={onCursor} />);
+    useFocusStore.setState({ focused: "d.files" });
+    press("F7");
+    expect(view.get(0)).toHaveBeenCalledOnce();
+    press("F7");
+    expect(view.get(1)).toHaveBeenCalledOnce();
+    expect(view.get(0)).toHaveBeenCalledOnce();
   });
 
   it("resets the cursor when the viewed file changes", () => {
@@ -103,5 +183,12 @@ describe("useHunkNav", () => {
     expect(cursor).toBe(1);
     rerender(<Harness count={3} resetKey="b" onCursor={onCursor} />);
     expect(cursor).toBe(-1);
+  });
+
+  it("registers one handler per action, not one per pane", () => {
+    render(<Harness count={3} resetKey="a" onCursor={onCursor} />);
+    const handlers = useKeymapStore.getState().handlers;
+    expect(handlers.get("diff.nextChange")?.length).toBe(1);
+    expect(handlers.get("diff.prevChange")?.length).toBe(1);
   });
 });

--- a/src/features/keymap/useHunkNav.ts
+++ b/src/features/keymap/useHunkNav.ts
@@ -1,6 +1,6 @@
 // useHunkNav — F7/⇧F7 diff-change navigation (Rider NextDiff/PreviousDiff).
-// Keeps a hunk cursor for a diff screen, registered for every pane the screen
-// owns (file list AND diff view), so the chord works wherever focus sits.
+// Keeps a hunk cursor for a diff screen, scoped to every pane the screen owns
+// (file list AND diff view), so the chord works wherever focus sits.
 // Cursor starts at -1: the first F7 lands on the FIRST hunk. The screen
 // renders the cursor as `data-hunk-active` on its `[data-hunk-index]` wrapper;
 // this hook scrolls that wrapper into view.
@@ -10,7 +10,7 @@ import { useAction } from "./useAction";
 
 export function useHunkNav(opts: {
   /** Panes this diff screen owns — the handler answers from any of them. */
-  paneIds: string[];
+  paneIds: readonly string[];
   /** Hunk count of the currently viewed file. */
   count: number;
   /** Cursor resets when this changes (the viewed file). */
@@ -28,6 +28,9 @@ export function useHunkNav(opts: {
     if (count === 0) return false;
     const next = Math.max(0, Math.min(count - 1, cursor + delta));
     setCursor(next);
+    // Scroll the FIRST pane that actually renders the target hunk: the file
+    // list has no `[data-hunk-index]` children at all, and a screen with two
+    // diff panes wants the leading one.
     for (const paneId of paneIds) {
       const el = document.querySelector<HTMLElement>(
         `[data-pg-pane="${paneId}"] [data-hunk-index="${next}"]`,
@@ -40,14 +43,11 @@ export function useHunkNav(opts: {
     return true;
   };
 
-  for (const paneId of paneIds) {
-    // Static list per call site — hooks-in-loop is safe and keeps one
-    // registration per (action, pane).
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useAction("diff.nextChange", go(1), [cursor, count], { paneId });
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useAction("diff.prevChange", go(-1), [cursor, count], { paneId });
-  }
+  // ONE registration per action, carrying the whole pane list as its scope —
+  // NOT a useAction call per pane, which was a rules-of-hooks violation that
+  // only held together while every caller passed a constant-length literal.
+  useAction("diff.nextChange", go(1), [cursor, count], { paneId: paneIds });
+  useAction("diff.prevChange", go(-1), [cursor, count], { paneId: paneIds });
 
   return cursor;
 }

--- a/src/features/keymap/useKeymapStore.ts
+++ b/src/features/keymap/useKeymapStore.ts
@@ -3,7 +3,8 @@
 // AppShell) calls `dispatch`, which resolves the chord to an action and invokes
 // the right handler:
 //
-//   pane-scoped actions  → innermost handler registered for the FOCUSED pane
+//   pane-scoped actions  → innermost handler whose scope covers the FOCUSED
+//                          pane (a handler may name several panes)
 //   global actions       → innermost mounted handler, else the catalog's
 //                          default runner (actions.ts)
 //
@@ -57,12 +58,21 @@ export type ActionHandler = () => boolean | void;
 
 interface HandlerEntry {
   fn: ActionHandler;
-  /** For pane-scoped actions: only runs while this pane holds focus. */
-  paneId?: string;
+  /** For pane-scoped actions: only runs while one of these panes holds focus.
+   *  Absent = unscoped (answers wherever focus sits); an empty list can never
+   *  match, so the handler never runs. */
+  paneIds?: readonly string[];
 }
 
 export interface RegisterOpts {
-  paneId?: string;
+  /** One pane, or several — a screen whose chord answers from any of the panes
+   *  it owns (F7 hunk nav from either the file list or the diff view) needs ONE
+   *  registration covering them all, not one registration per pane. */
+  paneId?: string | readonly string[];
+}
+
+function inScope(paneIds: readonly string[], focused: string | null): boolean {
+  return focused !== null && paneIds.includes(focused);
 }
 
 interface KeymapState {
@@ -158,7 +168,14 @@ export const useKeymapStore = create<KeymapState>((set, get) => {
     },
 
     register(id, handler, opts) {
-      const entry: HandlerEntry = { fn: handler, paneId: opts?.paneId };
+      const scope = opts?.paneId;
+      const paneIds =
+        scope === undefined
+          ? undefined
+          : typeof scope === "string"
+            ? [scope]
+            : scope;
+      const entry: HandlerEntry = { fn: handler, paneIds };
       const arr = get().handlers.get(id) ?? [];
       arr.push(entry);
       get().handlers.set(id, arr);
@@ -197,7 +214,7 @@ export const useKeymapStore = create<KeymapState>((set, get) => {
         let handled = false;
         for (let i = hs.length - 1; i >= 0; i--) {
           const h = hs[i];
-          if (def.scope === "pane" && h.paneId && h.paneId !== focusedPane) {
+          if (def.scope === "pane" && h.paneIds && !inScope(h.paneIds, focusedPane)) {
             continue;
           }
           if (h.fn() !== false) {

--- a/src/features/palette/CommandPalette.test.tsx
+++ b/src/features/palette/CommandPalette.test.tsx
@@ -174,6 +174,27 @@ describe("CommandPalette", () => {
     await waitFor(() => expect(checkedOut).toBe("feature/x"));
   });
 
+  it("keeps the root step's own id namespace for branch rows", async () => {
+    // The root rows and the pick-step rows come from the same builder in
+    // commands.ts, distinguished only by id prefix. That prefix is the frecency
+    // key, so a root branch row must record `branch:…`, never `pick-branch:…`.
+    const user = userEvent.setup();
+    useRepoStore.setState({
+      branches: [mkBranch("main", true), mkBranch("feature/x")],
+      checkoutBranch: async () => {},
+    });
+    usePaletteStore.setState({ open: true, query: "" });
+    render(<CommandPalette />);
+    await screen.findByRole("dialog");
+
+    await user.click(screen.getByPlaceholderText(/Search branches/i));
+    await user.keyboard("featurex");
+    await user.click(await screen.findByText(rowText("feature/x")));
+
+    const { loadFrecency } = await import("./frecency");
+    await waitFor(() => expect(loadFrecency()["branch:l:feature/x"]).toBeDefined());
+  });
+
   it("activates the highlighted row (not an unshown command) when a type chip is active", async () => {
     // Regression: keyboard nav must index the chip-filtered rows the DOM
     // renders. With a non-"all" chip, Enter previously activated flat[0] — the

--- a/src/features/palette/CommandPalette.tsx
+++ b/src/features/palette/CommandPalette.tsx
@@ -5,10 +5,9 @@ import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { usePaletteStore } from "./usePaletteStore";
 import { chordFor, useKeymapStore } from "@/features/keymap";
-import { buildCommands } from "./commands";
+import { branchItems, buildCommands, commitItems, fileItems } from "./commands";
 import { fuzzyMatch } from "./fuzzyMatch";
 import { frecencyScore, bumpFrecency, loadFrecency, recentIds } from "./frecency";
-import { relativeTime } from "@/lib/derive";
 import type { PaletteItem, ResultType } from "./types";
 
 function highlight(text: string, indices: number[]): React.ReactNode {
@@ -92,45 +91,36 @@ export function CommandPalette() {
   const dialogRef = React.useRef<HTMLDivElement | null>(null);
 
   // Root-step candidate set: commands (catalog) + live branch/file/commit rows.
-  const candidates = React.useMemo<PaletteItem[]>(() => {
-    if (step.kind !== "root") return [];
-    const items: PaletteItem[] = buildCommands();
-    for (const b of branches) {
-      items.push({
-        type: "branch",
-        id: `branch:${b.isRemote ? "r" : "l"}:${b.name}`,
-        search: b.name,
-        label: b.name,
-        detail: b.isRemote ? "remote" : (b.upstream ?? undefined),
-        icon: "branch",
-        run: () => { closePalette(); void useRepoStore.getState().checkoutBranch(b.name); },
-      });
-    }
-    for (const f of allFiles) {
-      const slash = f.path.lastIndexOf("/");
-      items.push({
-        type: "file",
-        id: `file:${f.path}`,
-        search: f.path,
-        label: slash >= 0 ? f.path.slice(slash + 1) : f.path,
-        detail: slash >= 0 ? f.path.slice(0, slash) : undefined,
-        icon: "file",
-        run: () => { closePalette(); setIntent({ kind: "diff-file", path: f.path }); },
-      });
-    }
-    for (const c of commits) {
-      items.push({
-        type: "commit",
-        id: `commit:${c.oid}`,
-        search: `${c.summary} ${c.shortOid} ${c.author}`,
-        label: c.summary,
-        detail: `${c.shortOid} · ${relativeTime(c.timestamp)}`,
-        icon: "commit",
-        run: () => { closePalette(); setIntent({ kind: "commit-vs-wt", oid: c.oid }); },
-      });
-    }
-    return items;
-  }, [step.kind, branches, allFiles, commits, closePalette, setIntent]);
+  // The row shapes come from commands.ts — same builders the pick steps use, so
+  // a row kind cannot drift between the root step and a pick step. Only the id
+  // namespace differs (root rows have their own frecency keys).
+  const candidates = React.useMemo<PaletteItem[]>(
+    () =>
+      step.kind !== "root"
+        ? []
+        : [
+            ...buildCommands(),
+            ...branchItems({
+              branches,
+              idPrefix: "branch",
+              icon: "branch",
+              onPick: (name) => void useRepoStore.getState().checkoutBranch(name),
+            }),
+            ...fileItems({
+              files: allFiles,
+              idPrefix: "file",
+              icon: "file",
+              onPick: (path) => setIntent({ kind: "diff-file", path }),
+            }),
+            ...commitItems({
+              commits,
+              idPrefix: "commit",
+              icon: "commit",
+              onPick: (oid) => setIntent({ kind: "commit-vs-wt", oid }),
+            }),
+          ],
+    [step.kind, branches, allFiles, commits, setIntent],
+  );
 
   // Source list for the active step: root → candidates; pick → step.items.
   const source: PaletteItem[] =

--- a/src/features/palette/chipPrefilter.test.tsx
+++ b/src/features/palette/chipPrefilter.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { CommandPalette } from "./CommandPalette";
+import { paletteInitial, usePaletteStore } from "./usePaletteStore";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { mockInvoke } from "@/test/invokeMock";
+import type { BranchInfo, CommitInfo, FileStatus } from "@/lib/types";
+
+// Records every string the palette hands to the fuzzy matcher. The root-step
+// candidate set is ~500 rows on a real repo, and the chip pre-filter exists so
+// a selected chip does NOT pay to score all of them on every keystroke — this
+// file pins that. Lives in its own test file so the module mock stays scoped.
+const scored = vi.hoisted(() => ({ targets: [] as string[] }));
+
+vi.mock("./fuzzyMatch", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./fuzzyMatch")>();
+  return {
+    ...actual,
+    fuzzyMatch: (query: string, target: string) => {
+      scored.targets.push(target);
+      return actual.fuzzyMatch(query, target);
+    },
+  };
+});
+
+const mkBranch = (name: string, isHead = false): BranchInfo => ({
+  name, isHead, isRemote: false, upstream: null, ahead: 0, behind: 0, tip: "deadbeef",
+});
+const mkCommit = (oid: string, summary: string): CommitInfo => ({
+  oid, shortOid: oid.slice(0, 7), summary, body: null, author: "Dev", email: "",
+  timestamp: 0, parents: [], refs: [],
+});
+const mkFile = (path: string): FileStatus => ({
+  path,
+  worktree: { kind: "Unmodified" },
+  index: { kind: "Unmodified" },
+  additions: 0,
+  deletions: 0,
+  embedded: false,
+});
+
+const FILES = [mkFile("src/alpha.ts"), mkFile("src/beta.ts")];
+
+describe("root-step chip pre-filter", () => {
+  beforeEach(() => {
+    useRepoStore.setState({
+      current: { id: "r1", path: "/repo", head: "main" },
+      status: [],
+      allFiles: FILES,
+      branches: [mkBranch("main", true), mkBranch("feature/alpha")],
+      tags: [], stashes: [], remotes: [],
+      commits: [mkCommit("abcdef1234", "alpha landed")],
+      loading: false, error: null, repoState: "Clean",
+      rebaseStatus: { inProgress: false, nextIndex: 0, total: 0, pauseReason: null },
+      activity: {},
+    });
+    useNavStore.setState({ intent: null });
+    usePaletteStore.setState(paletteInitial());
+    localStorage.clear();
+    // Opening the palette refreshes the tracked-file list, so the mock has to
+    // return the same fixture or the file rows vanish before the first keystroke.
+    mockInvoke("list_all_files", () => FILES);
+    scored.targets = [];
+  });
+
+  /** Focus the query input — a chip click leaves focus on the chip button. */
+  const focusQuery = async (user: ReturnType<typeof userEvent.setup>) => {
+    await user.click(screen.getByPlaceholderText(/Search branches/i));
+  };
+
+  it("scores only the selected chip's rows, never the whole candidate set", async () => {
+    const user = userEvent.setup();
+    usePaletteStore.getState().openPalette();
+    render(<CommandPalette />);
+    await screen.findByRole("dialog");
+
+    await user.click(screen.getByRole("button", { name: "Branches" }));
+    expect(usePaletteStore.getState().activeChip).toBe("branch");
+    await focusQuery(user);
+
+    // From here on only branch rows may be scored. A regression that builds
+    // every candidate, matches every candidate and filters at render time would
+    // put command labels ("Go to History"), file paths and commit summaries in
+    // this list.
+    scored.targets = [];
+    await user.keyboard("alpha");
+
+    expect(scored.targets.length).toBeGreaterThan(0);
+    const branchNames = new Set(["main", "feature/alpha"]);
+    expect(scored.targets.every((t) => branchNames.has(t))).toBe(true);
+  });
+
+  it("scores every type under the All chip", async () => {
+    // Counterpart to the test above: the pre-filter must not leak into the
+    // default chip, where all four types are searchable.
+    const user = userEvent.setup();
+    usePaletteStore.getState().openPalette();
+    render(<CommandPalette />);
+    await screen.findByRole("dialog");
+    await focusQuery(user);
+
+    scored.targets = [];
+    await user.keyboard("alpha");
+
+    expect(scored.targets).toContain("feature/alpha");
+    expect(scored.targets).toContain("src/alpha.ts");
+    expect(scored.targets).toContain("alpha landed abcdef1 Dev");
+    // …and the commands too (search string of the History nav row).
+    expect(scored.targets).toContain("History history go to");
+  });
+});

--- a/src/features/palette/commands.test.ts
+++ b/src/features/palette/commands.test.ts
@@ -1,13 +1,31 @@
 // src/features/palette/commands.test.ts
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { buildCommands } from "./commands";
+import { branchItems, buildCommands, commitItems, fileItems } from "./commands";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useCreateStore } from "@/features/create/useCreateStore";
 import { paletteInitial, usePaletteStore } from "./usePaletteStore";
-import type { BranchInfo, StashInfo } from "@/lib/types";
+import type { BranchInfo, CommitInfo, FileStatus, StashInfo } from "@/lib/types";
 
 const mkBranch = (name: string, isHead = false, upstream: string | null = null): BranchInfo => ({
   name, isHead, isRemote: false, upstream, ahead: 0, behind: 0, tip: "deadbeef",
+});
+
+const mkRemoteBranch = (name: string): BranchInfo => ({
+  name, isHead: false, isRemote: true, upstream: null, ahead: 0, behind: 0, tip: "deadbeef",
+});
+
+const mkCommit = (oid: string, summary: string): CommitInfo => ({
+  oid, shortOid: oid.slice(0, 7), summary, body: null, author: "Dev", email: "",
+  timestamp: 0, parents: [], refs: [],
+});
+
+const mkFile = (path: string): FileStatus => ({
+  path,
+  worktree: { kind: "Unmodified" },
+  index: { kind: "Unmodified" },
+  additions: 0,
+  deletions: 0,
+  embedded: false,
 });
 
 function setRepo(partial: Record<string, unknown>) {
@@ -28,12 +46,20 @@ const ids = () => buildCommands().map((i) => i.id);
 // the store's real action for good, so capture it once and restore it per test
 // — `paletteInitial()` deliberately covers state fields, not actions.
 const realPushStep = usePaletteStore.getState().pushStep;
+const realClosePalette = usePaletteStore.getState().closePalette;
+
+function resetStores() {
+  setRepo({});
+  usePaletteStore.setState({
+    ...paletteInitial(),
+    open: true,
+    pushStep: realPushStep,
+    closePalette: realClosePalette,
+  });
+}
 
 describe("buildCommands", () => {
-  beforeEach(() => {
-    setRepo({});
-    usePaletteStore.setState({ ...paletteInitial(), open: true, pushStep: realPushStep });
-  });
+  beforeEach(resetStores);
 
   it("always includes screen nav + fetch/refresh", () => {
     expect(ids()).toEqual(expect.arrayContaining([
@@ -160,5 +186,132 @@ describe("buildCommands", () => {
     const labels = step.items.map((i) => i.label);
     expect(labels).toContain("v1.0.0");
     expect(labels).toContain("origin/feature");
+  });
+});
+
+// The three row builders below are shared: the palette's ROOT step and the
+// pick steps both build their branch/file/commit rows through them, so these
+// tests pin the row shape (id, search, label, detail, icon) once for both.
+describe("branchItems", () => {
+  beforeEach(resetStores);
+
+  it("builds a row per branch from the live store, pick-step ids by default", () => {
+    setRepo({ branches: [mkBranch("main", true, "origin/main"), mkRemoteBranch("origin/feature")] });
+    const items = branchItems({ icon: "branch", onPick: () => {} });
+    expect(items.map((i) => i.id)).toEqual([
+      "pick-branch:l:main", "pick-branch:r:origin/feature",
+    ]);
+    expect(items.map((i) => i.type)).toEqual(["branch", "branch"]);
+    // search + label are the plain branch name; detail is the upstream, or
+    // "remote" for a remote-tracking branch.
+    expect(items.map((i) => i.search)).toEqual(["main", "origin/feature"]);
+    expect(items.map((i) => i.label)).toEqual(["main", "origin/feature"]);
+    expect(items.map((i) => i.detail)).toEqual(["origin/main", "remote"]);
+    expect(items.every((i) => i.icon === "branch")).toBe(true);
+  });
+
+  it("leaves detail undefined for a local branch with no upstream", () => {
+    setRepo({ branches: [mkBranch("wip")] });
+    expect(branchItems({ icon: "branch", onPick: () => {} })[0].detail).toBeUndefined();
+  });
+
+  it("honours an explicit branch list, filter and id namespace", () => {
+    // The root step passes its own list + `branch:` namespace; ids must not
+    // collide with the pick-step rows (they are separate frecency keys).
+    const items = branchItems({
+      branches: [mkBranch("main", true), mkBranch("feat/x")],
+      filter: (b) => !b.isHead,
+      idPrefix: "branch",
+      icon: "merge",
+      onPick: () => {},
+    });
+    expect(items.map((i) => i.id)).toEqual(["branch:l:feat/x"]);
+    expect(items[0].icon).toBe("merge");
+  });
+
+  it("run() closes the palette, then calls onPick with the branch name", () => {
+    setRepo({ branches: [mkBranch("feat/x")] });
+    const order: string[] = [];
+    usePaletteStore.setState({
+      closePalette: () => { order.push("close"); },
+    } as never);
+    branchItems({ icon: "branch", onPick: (n) => order.push(`pick:${n}`) })[0].run();
+    expect(order).toEqual(["close", "pick:feat/x"]);
+  });
+});
+
+describe("commitItems", () => {
+  beforeEach(resetStores);
+
+  it("builds a row per commit; search covers summary, short oid and author", () => {
+    setRepo({ commits: [mkCommit("abcdef1234", "Fix the bug")] });
+    const [item] = commitItems({ icon: "commit", onPick: () => {} });
+    expect(item.id).toBe("pick-commit:abcdef1234");
+    expect(item.type).toBe("commit");
+    expect(item.search).toBe("Fix the bug abcdef1 Dev");
+    expect(item.label).toBe("Fix the bug");
+    // detail is "<shortOid> · <relative time>" — pin the prefix, not the clock.
+    expect(item.detail?.startsWith("abcdef1 · ")).toBe(true);
+    expect(item.icon).toBe("commit");
+  });
+
+  it("honours an explicit commit list and id namespace", () => {
+    const items = commitItems({
+      commits: [mkCommit("abcdef1234", "Fix the bug")],
+      idPrefix: "commit",
+      icon: "history",
+      onPick: () => {},
+    });
+    expect(items.map((i) => i.id)).toEqual(["commit:abcdef1234"]);
+    expect(items[0].icon).toBe("history");
+  });
+
+  it("run() closes the palette, then calls onPick with the full oid", () => {
+    setRepo({ commits: [mkCommit("abcdef1234", "Fix the bug")] });
+    const order: string[] = [];
+    usePaletteStore.setState({ closePalette: () => { order.push("close"); } } as never);
+    commitItems({ icon: "commit", onPick: (oid) => order.push(`pick:${oid}`) })[0].run();
+    expect(order).toEqual(["close", "pick:abcdef1234"]);
+  });
+});
+
+describe("fileItems", () => {
+  beforeEach(resetStores);
+
+  it("splits the path into basename label + directory detail", () => {
+    setRepo({ allFiles: [mkFile("src/features/palette/commands.ts")] });
+    const [item] = fileItems({ icon: "file", onPick: () => {} });
+    expect(item.id).toBe("pick-file:src/features/palette/commands.ts");
+    expect(item.type).toBe("file");
+    // The whole path is searchable, not just the basename.
+    expect(item.search).toBe("src/features/palette/commands.ts");
+    expect(item.label).toBe("commands.ts");
+    expect(item.detail).toBe("src/features/palette");
+    expect(item.icon).toBe("file");
+  });
+
+  it("leaves detail undefined for a repo-root file", () => {
+    setRepo({ allFiles: [mkFile("README.md")] });
+    const [item] = fileItems({ icon: "file", onPick: () => {} });
+    expect(item.label).toBe("README.md");
+    expect(item.detail).toBeUndefined();
+  });
+
+  it("honours an explicit file list and id namespace", () => {
+    const items = fileItems({
+      files: [mkFile("a.txt")],
+      idPrefix: "file",
+      icon: "file",
+      onPick: () => {},
+    });
+    expect(items.map((i) => i.id)).toEqual(["file:a.txt"]);
+  });
+
+  it("run() closes the palette, then calls onPick with the full path", () => {
+    setRepo({ allFiles: [mkFile("src/a.txt")] });
+    const order: string[] = [];
+    usePaletteStore.setState({ closePalette: () => { order.push("close"); } } as never);
+    fileItems({ icon: "file", onPick: (p) => order.push(`pick:${p}`) })[0].run();
+    expect(order).toEqual(["close", "pick:src/a.txt"]);
   });
 });

--- a/src/features/palette/commands.ts
+++ b/src/features/palette/commands.ts
@@ -9,6 +9,7 @@ import { createBranchInputStep } from "./steps";
 import { currentBranch, isConflicted, relativeTime } from "@/lib/derive";
 import { headUpstream, resolveConflictsOp } from "@/features/repo/ops";
 import type { ActionId } from "@/features/keymap";
+import type { BranchInfo, CommitInfo, FileStatus } from "@/lib/types";
 import type { PaletteItem, PaletteStep } from "./types";
 
 const palette = () => usePaletteStore.getState();
@@ -27,36 +28,71 @@ function step(make: () => PaletteStep): () => void {
   return () => palette().pushStep(make());
 }
 
-// ---- pick-step item builders (read live store data) -----------------------
+// ---- row builders (read live store data) ----------------------------------
+//
+// One builder per row kind, shared by the palette's ROOT step (CommandPalette's
+// candidate set) and by the pick steps below. The only things that vary are the
+// id namespace, the icon, and what the row does — so those are the options.
+//
+// The id namespace matters: `PaletteItem.id` is the frecency key, and a root
+// row (`branch:…`) and a pick-step row for the same branch (`pick-branch:…`)
+// are different rows the user can invoke, so they must not share a key. The
+// default is the pick-step namespace; the root step passes its own.
 
-function branchItems(
-  predicate: (b: import("@/lib/types").BranchInfo) => boolean,
-  icon: string,
-  onPick: (name: string) => void,
-): PaletteItem[] {
-  return repoState()
-    .branches.filter(predicate)
-    .map((b) => ({
-      type: "branch" as const,
-      id: `pick-branch:${b.isRemote ? "r" : "l"}:${b.name}`,
-      search: b.name,
-      label: b.name,
-      detail: b.isRemote ? "remote" : (b.upstream ?? undefined),
-      icon,
-      run: () => {
-        palette().closePalette();
-        onPick(b.name);
-      },
-    }));
+interface RowOptions {
+  /**
+   * Id namespace — the row id is `<idPrefix>:<per-kind suffix>`. Defaults to
+   * the pick-step namespace.
+   */
+  idPrefix?: string;
+  icon: string;
 }
 
-function commitItems(
-  icon: string,
-  onPick: (oid: string) => void,
-): PaletteItem[] {
-  return repoState().commits.map((c) => ({
+export interface BranchItemsOptions extends RowOptions {
+  /** Rows to build from. Defaults to the live branch list. */
+  branches?: BranchInfo[];
+  /** Keep only matching branches. Defaults to keeping all of them. */
+  filter?: (b: BranchInfo) => boolean;
+  onPick: (name: string) => void;
+}
+
+export function branchItems({
+  branches,
+  filter,
+  idPrefix = "pick-branch",
+  icon,
+  onPick,
+}: BranchItemsOptions): PaletteItem[] {
+  const rows = branches ?? repoState().branches;
+  return (filter ? rows.filter(filter) : rows).map((b) => ({
+    type: "branch" as const,
+    id: `${idPrefix}:${b.isRemote ? "r" : "l"}:${b.name}`,
+    search: b.name,
+    label: b.name,
+    detail: b.isRemote ? "remote" : (b.upstream ?? undefined),
+    icon,
+    run: () => {
+      palette().closePalette();
+      onPick(b.name);
+    },
+  }));
+}
+
+export interface CommitItemsOptions extends RowOptions {
+  /** Rows to build from. Defaults to the live log. */
+  commits?: CommitInfo[];
+  onPick: (oid: string) => void;
+}
+
+export function commitItems({
+  commits,
+  idPrefix = "pick-commit",
+  icon,
+  onPick,
+}: CommitItemsOptions): PaletteItem[] {
+  return (commits ?? repoState().commits).map((c) => ({
     type: "commit" as const,
-    id: `pick-commit:${c.oid}`,
+    id: `${idPrefix}:${c.oid}`,
     search: `${c.summary} ${c.shortOid} ${c.author}`,
     label: c.summary,
     detail: `${c.shortOid} · ${relativeTime(c.timestamp)}`,
@@ -67,6 +103,42 @@ function commitItems(
     },
   }));
 }
+
+export interface FileItemsOptions extends RowOptions {
+  /** Rows to build from. Defaults to the live tracked-file list. */
+  files?: FileStatus[];
+  onPick: (path: string) => void;
+}
+
+/**
+ * Label is the basename, detail the directory. A file at the repo root has no
+ * directory, so its detail stays undefined rather than rendering an empty span.
+ */
+export function fileItems({
+  files,
+  idPrefix = "pick-file",
+  icon,
+  onPick,
+}: FileItemsOptions): PaletteItem[] {
+  return (files ?? repoState().allFiles).map((f) => {
+    const slash = f.path.lastIndexOf("/");
+    return {
+      type: "file" as const,
+      id: `${idPrefix}:${f.path}`,
+      search: f.path,
+      label: slash >= 0 ? f.path.slice(slash + 1) : f.path,
+      detail: slash >= 0 ? f.path.slice(0, slash) : undefined,
+      icon,
+      run: () => {
+        palette().closePalette();
+        onPick(f.path);
+      },
+    };
+  });
+}
+
+// The remaining builders are pick-step-only (the root step has no tag / stash /
+// remote row kind), so they stay on the plain positional signature.
 
 function tagItems(icon: string, onPick: (name: string) => void): PaletteItem[] {
   return repoState().tags.map((t) => ({
@@ -255,7 +327,11 @@ export function buildCommands(): PaletteItem[] {
     search: "Checkout branch switch", label: "Checkout branch…", icon: "branch",
     run: step(() => ({
       kind: "pick", title: "Checkout branch",
-      items: branchItems((b) => !b.isHead, "branch", (n) => void repo.checkoutBranch(n)),
+      items: branchItems({
+        filter: (b) => !b.isHead,
+        icon: "branch",
+        onPick: (n) => void repo.checkoutBranch(n),
+      }),
     })),
   });
   items.push({
@@ -269,7 +345,11 @@ export function buildCommands(): PaletteItem[] {
     search: "Merge branch into current", label: "Merge branch into current…", icon: "merge",
     run: step(() => ({
       kind: "pick", title: "Merge into current",
-      items: branchItems((b) => !b.isHead, "merge", (n) => void repo.mergeBranch(n)),
+      items: branchItems({
+        filter: (b) => !b.isHead,
+        icon: "merge",
+        onPick: (n) => void repo.mergeBranch(n),
+      }),
     })),
   });
   items.push({
@@ -277,7 +357,11 @@ export function buildCommands(): PaletteItem[] {
     search: "Rebase current onto branch", label: "Rebase current onto…", icon: "rebase",
     run: step(() => ({
       kind: "pick", title: "Rebase onto",
-      items: branchItems((b) => !b.isHead, "rebase", (n) => void repo.rebaseOnto(n)),
+      items: branchItems({
+        filter: (b) => !b.isHead,
+        icon: "rebase",
+        onPick: (n) => void repo.rebaseOnto(n),
+      }),
     })),
   });
   items.push({
@@ -285,8 +369,11 @@ export function buildCommands(): PaletteItem[] {
     search: "Delete branch", label: "Delete branch…", danger: true, icon: "trash",
     run: step(() => ({
       kind: "pick", title: "Delete branch",
-      items: branchItems((b) => !b.isHead && !b.isRemote, "trash", (n) =>
-        void repo.deleteBranch(n)),
+      items: branchItems({
+        filter: (b) => !b.isHead && !b.isRemote,
+        icon: "trash",
+        onPick: (n) => void repo.deleteBranch(n),
+      }),
     })),
   });
   items.push({
@@ -294,16 +381,20 @@ export function buildCommands(): PaletteItem[] {
     search: "Rename branch", label: "Rename branch…", icon: "branch",
     run: step(() => ({
       kind: "pick", title: "Rename branch",
-      items: branchItems((b) => !b.isRemote, "branch", (oldName) =>
-        palette().pushStep({
-          kind: "input", title: `Rename ${oldName}`, placeholder: "new-name",
-          initial: oldName,
-          validate: (v) => (v.trim() ? null : "Name required"),
-          onSubmit: (v) => {
-            palette().closePalette();
-            void repo.renameBranch(oldName, v.trim());
-          },
-        })),
+      items: branchItems({
+        filter: (b) => !b.isRemote,
+        icon: "branch",
+        onPick: (oldName) =>
+          palette().pushStep({
+            kind: "input", title: `Rename ${oldName}`, placeholder: "new-name",
+            initial: oldName,
+            validate: (v) => (v.trim() ? null : "Name required"),
+            onSubmit: (v) => {
+              palette().closePalette();
+              void repo.renameBranch(oldName, v.trim());
+            },
+          }),
+      }),
     })),
   });
 
@@ -332,7 +423,7 @@ export function buildCommands(): PaletteItem[] {
     search: "Cherry-pick commit", label: "Cherry-pick commit…", icon: "commit",
     run: step(() => ({
       kind: "pick", title: "Cherry-pick",
-      items: commitItems("commit", (oid) => void repo.cherryPick(oid)),
+      items: commitItems({ icon: "commit", onPick: (oid) => void repo.cherryPick(oid) }),
     })),
   });
   items.push({
@@ -340,7 +431,7 @@ export function buildCommands(): PaletteItem[] {
     search: "Revert commit", label: "Revert commit…", icon: "history",
     run: step(() => ({
       kind: "pick", title: "Revert",
-      items: commitItems("history", (oid) => void repo.revert(oid)),
+      items: commitItems({ icon: "history", onPick: (oid) => void repo.revert(oid) }),
     })),
   });
   items.push({
@@ -349,16 +440,19 @@ export function buildCommands(): PaletteItem[] {
     icon: "rebase",
     run: step(() => ({
       kind: "pick", title: "Reset to commit",
-      items: commitItems("commit", (oid) =>
-        palette().pushStep({
-          kind: "pick", title: "Reset mode",
-          items: (["Soft", "Mixed", "Hard"] as const).map((mode) => ({
-            type: "command" as const, id: `reset-mode:${mode}`,
-            search: mode, label: mode, danger: mode === "Hard",
-            icon: "rebase",
-            run: () => { palette().closePalette(); void repo.reset(oid, mode); },
-          })),
-        })),
+      items: commitItems({
+        icon: "commit",
+        onPick: (oid) =>
+          palette().pushStep({
+            kind: "pick", title: "Reset mode",
+            items: (["Soft", "Mixed", "Hard"] as const).map((mode) => ({
+              type: "command" as const, id: `reset-mode:${mode}`,
+              search: mode, label: mode, danger: mode === "Hard",
+              icon: "rebase",
+              run: () => { palette().closePalette(); void repo.reset(oid, mode); },
+            })),
+          }),
+      }),
     })),
   });
 

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -65,6 +65,7 @@ import {
   pushDeleteBranch as pushDeleteBranchFn,
   pushTag as pushTagFn,
   rebaseAbort,
+  rebaseAcknowledge as rebaseAcknowledgeFn,
   rebaseOnto as rebaseOntoFn,
   rebaseContinue as rebaseContinueFn,
   rebaseStart as rebaseStartFn,
@@ -166,15 +167,13 @@ interface RepoStoreState {
   loading: boolean;
   error: AppError | null;
   repoState: GitRepoState;
-  rebaseStatus: RebaseStatus;
   /**
-   * Final status of the most recently completed rebase, held frontend-side.
-   * The backend sweeps RebaseState on completion (#28), so the very next
-   * refreshAll's rebase_status poll reports total: 0 — this field preserves
-   * the "N steps completed" summary for the Rebase screen. Cleared when a
-   * new rebase starts, on abort, and on repo open/close.
+   * Live rebase progress AND, once a plan finishes, its retained
+   * `lastCompleted` summary — the backend keeps that until acknowledged, so the
+   * "N steps completed" line no longer needs a frontend cache that every abort
+   * and start path had to clear by hand (#47).
    */
-  lastRebaseSummary: RebaseStatus | null;
+  rebaseStatus: RebaseStatus;
   /** Active long-running ops keyed by op kind. */
   activity: RepoActivity;
   openRepo: (path: string) => Promise<void>;
@@ -294,6 +293,8 @@ interface RepoStoreState {
   rebaseStart: (plan: RebaseStep[]) => Promise<RebaseStatus | null>;
   rebaseContinue: () => Promise<RebaseStatus | null>;
   rebaseAbort: () => Promise<void>;
+  /** Drop the backend's retained completed-rebase summary once it's been shown. */
+  rebaseAcknowledge: () => Promise<void>;
   appendGitignore: (pattern: string) => Promise<void>;
   openInEditor: (relativePath: string) => Promise<void>;
 }
@@ -381,7 +382,6 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       commits: [],
       searchResults: null,
       commitFilter: {},
-      lastRebaseSummary: null,
       logRef: LOG_REF_ALL,
       commitCursor: null,
       searchCursor: null,
@@ -408,7 +408,6 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   error: null,
   repoState: "Clean",
   rebaseStatus: DEFAULT_REBASE_STATUS,
-  lastRebaseSummary: null,
   activity: {},
 
   async openRepo(path) {
@@ -613,7 +612,6 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       commitFilter: {},
       logRef: LOG_REF_ALL,
       searching: false,
-      lastRebaseSummary: null,
       error: null,
     });
   },
@@ -1361,12 +1359,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return null;
     try {
       const status = await rebaseStartFn(repo.id, plan);
-      // Capture the summary before refreshAll re-polls rebase_status — the
-      // backend sweeps RebaseState on completion, so the poll returns total: 0.
-      set({
-        rebaseStatus: status,
-        lastRebaseSummary: status.inProgress ? null : status,
-      });
+      set({ rebaseStatus: status });
       await get().refreshAll();
       return status;
     } catch (e) {
@@ -1380,10 +1373,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return null;
     try {
       const status = await rebaseContinueFn(repo.id);
-      set({
-        rebaseStatus: status,
-        ...(status.inProgress ? {} : { lastRebaseSummary: status }),
-      });
+      set({ rebaseStatus: status });
       await get().refreshAll();
       return status;
     } catch (e) {
@@ -1397,8 +1387,22 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     try {
       await rebaseAbort(repo.id);
-      set({ rebaseStatus: DEFAULT_REBASE_STATUS, lastRebaseSummary: null });
+      set({ rebaseStatus: DEFAULT_REBASE_STATUS });
       await get().refreshAll();
+    } catch (e) {
+      set({ error: toAppError(e) });
+    }
+  },
+
+  async rebaseAcknowledge() {
+    const repo = get().current;
+    if (!repo) return;
+    try {
+      await rebaseAcknowledgeFn(repo.id);
+      // Mirror the drop locally instead of a full refreshAll: acknowledging is
+      // a notice being dismissed, not a change to the repository, and a refresh
+      // here would re-walk the log on every visit to the Rebase screen.
+      set((s) => ({ rebaseStatus: { ...s.rebaseStatus, lastCompleted: null } }));
     } catch (e) {
       set({ error: toAppError(e) });
     }

--- a/src/lib/selection.test.ts
+++ b/src/lib/selection.test.ts
@@ -4,8 +4,14 @@ import {
   emptySelection,
   primarySelectedKey,
   pruneSelection,
+  sidedFileKey,
+  sidedFolderKey,
+  sidedSelectionSource,
+  splitFileSelection,
+  treeSelectionSource,
   type Selection,
 } from "./selection";
+import type { FileStatus } from "./types";
 
 const order = ["a", "b", "c", "d", "e"];
 
@@ -122,5 +128,199 @@ describe("primarySelectedKey", () => {
 
   it("is null for an empty selection", () => {
     expect(primarySelectedKey(emptySelection)).toBeNull();
+  });
+});
+
+// ── splitFileSelection ──────────────────────────────────────────────────────
+// The bucketing both multi-file surfaces feed to `multiFileMenuItems`. Folder
+// expansion and embedded-repo bucketing are correctness-critical: a folder that
+// silently drops out under-counts a destructive op, and an embedded repo that
+// leaks into a stage batch writes a bare gitlink.
+
+const fileStatus = (
+  path: string,
+  over: Partial<FileStatus> = {},
+): FileStatus => ({
+  path,
+  worktree: { kind: "Unmodified" },
+  index: { kind: "Unmodified" },
+  additions: 0,
+  deletions: 0,
+  embedded: false,
+  ...over,
+});
+
+const dirty = (path: string) =>
+  fileStatus(path, { worktree: { kind: "Modified" } });
+const inIndex = (path: string) => fileStatus(path, { index: { kind: "Modified" } });
+const bothSides = (path: string) =>
+  fileStatus(path, {
+    index: { kind: "Modified" },
+    worktree: { kind: "Modified" },
+  });
+const untracked = (path: string) =>
+  fileStatus(path, { worktree: { kind: "Untracked" } });
+/** libgit2 reports an embedded repo as one entry with a trailing slash. */
+const embeddedRepo = (path: string) =>
+  fileStatus(path, { worktree: { kind: "Untracked" }, embedded: true });
+
+describe("splitFileSelection over the tree key space", () => {
+  const status = [
+    dirty("src/a.ts"),
+    inIndex("src/b.ts"),
+    bothSides("src/c.ts"),
+    untracked("src/new.ts"),
+    embeddedRepo("vendor/lib/"),
+  ];
+  const source = treeSelectionSource(status, status);
+
+  it("buckets each side of a file's changes", () => {
+    const split = splitFileSelection(["/src/a.ts", "/src/b.ts", "/src/c.ts"], source);
+    expect(split.stagedPaths).toEqual(["src/b.ts", "src/c.ts"]);
+    expect(split.unstagedPaths).toEqual(["src/a.ts", "src/c.ts"]);
+    expect(split.paths).toEqual(["src/a.ts", "src/b.ts", "src/c.ts"]);
+    expect(split.embeddedPaths).toEqual([]);
+    expect(split.untrackedPaths).toEqual([]);
+  });
+
+  it("expands a folder key to every descendant", () => {
+    const split = splitFileSelection(["/src"], source);
+    expect(split.paths).toEqual([
+      "src/a.ts",
+      "src/b.ts",
+      "src/c.ts",
+      "src/new.ts",
+    ]);
+    expect(split.unstagedPaths).toEqual(["src/a.ts", "src/c.ts", "src/new.ts"]);
+    expect(split.stagedPaths).toEqual(["src/b.ts", "src/c.ts"]);
+  });
+
+  it("dedupes a file reachable both directly and through its folder", () => {
+    const split = splitFileSelection(["/src/a.ts", "/src"], source);
+    expect(split.paths).toEqual([
+      "src/a.ts",
+      "src/b.ts",
+      "src/c.ts",
+      "src/new.ts",
+    ]);
+    expect(split.unstagedPaths).toEqual(["src/a.ts", "src/c.ts", "src/new.ts"]);
+  });
+
+  it("names untracked paths separately so the discard confirm can warn", () => {
+    const split = splitFileSelection(["/src/new.ts", "/src/a.ts"], source);
+    expect(split.untrackedPaths).toEqual(["src/new.ts"]);
+    expect(split.unstagedPaths).toEqual(["src/new.ts", "src/a.ts"]);
+  });
+
+  it("keeps an embedded repo out of every actionable bucket but still counts it", () => {
+    // The key drops the trailing slash the way buildStatusTree does.
+    const split = splitFileSelection(["/vendor/lib", "/src/a.ts"], source);
+    expect(split.embeddedPaths).toEqual(["vendor/lib/"]);
+    expect(split.stagedPaths).toEqual([]);
+    expect(split.unstagedPaths).toEqual(["src/a.ts"]);
+    expect(split.untrackedPaths).toEqual([]);
+    expect(split.paths).toEqual(["vendor/lib/", "src/a.ts"]);
+  });
+
+  it("expands a folder against the tree's own source set, not the lookup lists", () => {
+    // All-files mode: unmodified files resolve by key but are not tree rows, so
+    // a folder must expand to the filtered set the tree actually shows.
+    const unmodified = fileStatus("src/quiet.ts");
+    const narrowed = treeSelectionSource([dirty("src/a.ts")], status, [unmodified]);
+    expect(splitFileSelection(["/src"], narrowed).paths).toEqual(["src/a.ts"]);
+    // ...while the unmodified file still resolves, counts and copies on its own.
+    const one = splitFileSelection(["/src/quiet.ts"], narrowed);
+    expect(one.paths).toEqual(["src/quiet.ts"]);
+    expect(one.stagedPaths).toEqual([]);
+    expect(one.unstagedPaths).toEqual([]);
+  });
+
+  it("yields nothing for a key that resolves to neither a row nor a folder", () => {
+    expect(splitFileSelection(["/gone.ts"], source)).toEqual({
+      stagedPaths: [],
+      unstagedPaths: [],
+      paths: [],
+      embeddedPaths: [],
+      untrackedPaths: [],
+    });
+  });
+});
+
+describe("splitFileSelection over the sided key space", () => {
+  const stagedRows = [
+    { path: "src/b.ts", status: inIndex("src/b.ts"), side: "staged" as const },
+    { path: "src/c.ts", status: bothSides("src/c.ts"), side: "staged" as const },
+  ];
+  const unstagedRows = [
+    { path: "src/a.ts", status: dirty("src/a.ts"), side: "unstaged" as const },
+    { path: "src/c.ts", status: bothSides("src/c.ts"), side: "unstaged" as const },
+    { path: "src/new.ts", status: untracked("src/new.ts"), side: "unstaged" as const },
+    { path: "vendor/lib/", status: embeddedRepo("vendor/lib/"), side: "unstaged" as const },
+  ];
+  const source = sidedSelectionSource(stagedRows, unstagedRows);
+
+  it("buckets a row by the side it stands for", () => {
+    const split = splitFileSelection(
+      [sidedFileKey("staged", "src/c.ts"), sidedFileKey("unstaged", "src/a.ts")],
+      source,
+    );
+    expect(split.stagedPaths).toEqual(["src/c.ts"]);
+    expect(split.unstagedPaths).toEqual(["src/a.ts"]);
+  });
+
+  it("keeps a file selected on both sides in both buckets", () => {
+    const split = splitFileSelection(
+      [sidedFileKey("staged", "src/c.ts"), sidedFileKey("unstaged", "src/c.ts")],
+      source,
+    );
+    expect(split.stagedPaths).toEqual(["src/c.ts"]);
+    expect(split.unstagedPaths).toEqual(["src/c.ts"]);
+    // Two rows selected, so the menu says two — same as before the unification.
+    expect(split.paths).toEqual(["src/c.ts", "src/c.ts"]);
+  });
+
+  it("expands a folder key within its own section only", () => {
+    const split = splitFileSelection([sidedFolderKey("unstaged", "src")], source);
+    expect(split.unstagedPaths).toEqual(["src/a.ts", "src/c.ts", "src/new.ts"]);
+    expect(split.stagedPaths).toEqual([]);
+    const stagedSide = splitFileSelection([sidedFolderKey("staged", "src")], source);
+    expect(stagedSide.stagedPaths).toEqual(["src/b.ts", "src/c.ts"]);
+    expect(stagedSide.unstagedPaths).toEqual([]);
+  });
+
+  it("keeps an embedded repo out of the actionable buckets", () => {
+    const split = splitFileSelection(
+      [
+        sidedFileKey("unstaged", "vendor/lib/"),
+        sidedFileKey("unstaged", "src/a.ts"),
+      ],
+      source,
+    );
+    expect(split.embeddedPaths).toEqual(["vendor/lib/"]);
+    expect(split.unstagedPaths).toEqual(["src/a.ts"]);
+    expect(split.untrackedPaths).toEqual([]);
+  });
+
+  it("reads an ambiguous key as a folder, never as a file", () => {
+    // A file literally named `dir:x` collides with the folder marker. Reading
+    // it as a folder finds nothing, which is the safe end of the ambiguity —
+    // the opposite would let a batch op reach a row the user did not pick.
+    const withColon = sidedSelectionSource(
+      [],
+      [{ path: "dir:x", status: dirty("dir:x"), side: "unstaged" as const }],
+    );
+    expect(splitFileSelection([sidedFileKey("unstaged", "dir:x")], withColon)).toEqual(
+      {
+        stagedPaths: [],
+        unstagedPaths: [],
+        paths: [],
+        embeddedPaths: [],
+        untrackedPaths: [],
+      },
+    );
+  });
+
+  it("yields nothing for a key outside the space", () => {
+    expect(splitFileSelection(["/src/a.ts"], source).paths).toEqual([]);
   });
 });

--- a/src/lib/selection.ts
+++ b/src/lib/selection.ts
@@ -2,6 +2,9 @@
 // RepoBrowser file tree. Pure functions over row keys — components own the
 // state, this module owns the rules.
 //
+// Two layers live here: the click/range/prune model (below) and, at the bottom
+// of the file, the selection → path-bucket split every multi-file op needs.
+//
 // Model (classic desktop list):
 // - plain click        → select exactly that row, anchor moves to it
 // - cmd/ctrl click     → toggle row in/out; toggling in moves the anchor,
@@ -11,6 +14,10 @@
 //                        visible rows between the anchor and the clicked row;
 //                        the anchor stays put so successive shift-clicks
 //                        re-extend from the same origin
+
+import { isStaged, isUnstaged, isUntracked } from "./derive";
+import { findStatusByTreeKey, treeKeyToPath } from "./tree";
+import type { FileStatus } from "./types";
 
 export interface Selection {
   /** Selected row keys, in click/range order, no duplicates. */
@@ -86,4 +93,178 @@ export function pruneSelection(
 export function primarySelectedKey(sel: Selection): string | null {
   if (sel.anchor !== null && sel.keys.includes(sel.anchor)) return sel.anchor;
   return sel.keys[sel.keys.length - 1] ?? null;
+}
+
+// ── Selection → path buckets ────────────────────────────────────────────────
+// `multiFileMenuItems` wants a multi-selection reduced to path arrays: what can
+// be staged, what can be unstaged, what is untracked, what is an embedded repo,
+// and everything selected (for the count and Copy paths). Two screens used to
+// compute that twice, in two key spaces, and drifted: only one of them expanded
+// a selected FOLDER to the files beneath it, which silently under-counted a
+// destructive op (#47). The rules now live here once; each surface supplies
+// only the key→row lookup its own key space needs.
+
+/** Which side of a file's changes a row stands for. */
+export type FileSide = "staged" | "unstaged";
+
+/**
+ * One selectable file row behind a selection key.
+ *
+ * `side` is set only by surfaces that split a file across two lists (the commit
+ * panel's STAGED and CHANGES sections), where each row stands for ONE side of
+ * that file's changes. Left undefined the row stands for the file as a whole
+ * and both of its sides count — what the repo browser's single tree needs.
+ */
+export interface FileSelectionRow {
+  path: string;
+  status: FileStatus;
+  side?: FileSide;
+}
+
+/** The path buckets `multiFileMenuItems` consumes. */
+export interface FileSelectionSplit {
+  stagedPaths: string[];
+  unstagedPaths: string[];
+  /** Every selected path, including embedded repos and unmodified files. */
+  paths: string[];
+  embeddedPaths: string[];
+  untrackedPaths: string[];
+}
+
+/**
+ * How one surface maps its own selection keys onto rows.
+ *
+ * Two methods because a folder key resolves to no single row: `rowFor` answers
+ * file keys, `rowsUnder` expands a folder key to the rows beneath it. A key
+ * that is neither yields nothing from both, which is how an already-vanished
+ * key drops out instead of being counted.
+ */
+export interface FileSelectionSource {
+  rowFor(key: string): FileSelectionRow | undefined;
+  rowsUnder(key: string): FileSelectionRow[];
+}
+
+/**
+ * Bucket a multi-selection into the path arrays a batch op acts on.
+ *
+ * Folder keys expand to every row beneath them, so a selected folder counts and
+ * stages/discards like the rows it contains. Rows are deduped (a file reachable
+ * both directly and through a selected ancestor is added once), preserving key
+ * order.
+ *
+ * An embedded git repository lands in `embeddedPaths` and nowhere else: it is
+ * not a file, so Stage/Unstage/Discard must never reach it (see
+ * `FileStatus.embedded`). It still counts and copies like any other row.
+ */
+export function splitFileSelection(
+  keys: readonly string[],
+  source: FileSelectionSource,
+): FileSelectionSplit {
+  const stagedPaths: string[] = [];
+  const unstagedPaths: string[] = [];
+  const embeddedPaths: string[] = [];
+  const untrackedPaths: string[] = [];
+  const paths: string[] = [];
+  const seen = new Set<string>();
+
+  const add = (row: FileSelectionRow) => {
+    // A side-split surface lists one file twice (once per side) on purpose, so
+    // dedup keys carry the side; a whole-file surface dedups by path alone.
+    const dedupKey = row.side ? `${row.side}:${row.path}` : row.path;
+    if (seen.has(dedupKey)) return;
+    seen.add(dedupKey);
+    paths.push(row.path);
+    if (row.status.embedded) {
+      embeddedPaths.push(row.path);
+      return;
+    }
+    const staged = row.side ? row.side === "staged" : isStaged(row.status);
+    const unstaged = row.side ? row.side === "unstaged" : isUnstaged(row.status);
+    if (staged) stagedPaths.push(row.path);
+    if (unstaged) unstagedPaths.push(row.path);
+    // Untracked means "git holds no copy", which is only ever a worktree-side
+    // fact — discarding one deletes it, so the confirm has to name it.
+    if (unstaged && isUntracked(row.status)) untrackedPaths.push(row.path);
+  };
+
+  for (const key of keys) {
+    const row = source.rowFor(key);
+    if (row) {
+      add(row);
+      continue;
+    }
+    for (const child of source.rowsUnder(key)) add(child);
+  }
+
+  return { stagedPaths, unstagedPaths, paths, embeddedPaths, untrackedPaths };
+}
+
+// `dir:` keeps folder keys out of the file key space, so nothing can mistake a
+// directory for a file with an unlucky name. Folder is tested FIRST: a file
+// literally named `dir:x` would otherwise be ambiguous, and reading it as a
+// folder (which finds nothing) is the safe end of that ambiguity.
+const SIDED_FOLDER_KEY = /^(staged|unstaged):dir:(.*)$/;
+const SIDED_FILE_KEY = /^(staged|unstaged):(.*)$/;
+
+/** Selection key for a file row on one side of a side-split surface. */
+export function sidedFileKey(side: FileSide, path: string): string {
+  return `${side}:${path}`;
+}
+
+/** Selection key for a folder row on one side of a side-split surface. */
+export function sidedFolderKey(side: FileSide, dirPath: string): string {
+  return `${side}:dir:${dirPath}`;
+}
+
+/**
+ * Source for the `side:path` / `side:dir:path` key space — two pre-split row
+ * lists, one per section. A folder key only ever expands within its own
+ * section, so staging a folder in CHANGES cannot reach the STAGED rows below.
+ */
+export function sidedSelectionSource(
+  staged: readonly FileSelectionRow[],
+  unstaged: readonly FileSelectionRow[],
+): FileSelectionSource {
+  const rowsOn = (side: FileSide) => (side === "staged" ? staged : unstaged);
+  return {
+    rowFor(key) {
+      if (SIDED_FOLDER_KEY.test(key)) return undefined;
+      const m = SIDED_FILE_KEY.exec(key);
+      if (!m) return undefined;
+      return rowsOn(m[1] as FileSide).find((r) => r.path === m[2]);
+    },
+    rowsUnder(key) {
+      const m = SIDED_FOLDER_KEY.exec(key);
+      if (!m) return [];
+      const prefix = `${m[2]}/`;
+      return rowsOn(m[1] as FileSide).filter((r) => r.path.startsWith(prefix));
+    },
+  };
+}
+
+/**
+ * Source for the PGFileTree `/a/b` key space over one tree.
+ *
+ * `descendants` is the tree's own source set, so a folder expands to exactly
+ * the rows that tree shows (a filter narrowing the tree narrows the batch too).
+ * `lookupLists` are searched in order for a file key — the repo browser passes
+ * `status` then `allFiles`, so an unmodified file still resolves in all-files
+ * mode even though it carries no stage/unstage action.
+ */
+export function treeSelectionSource(
+  descendants: readonly FileStatus[],
+  ...lookupLists: readonly (readonly FileStatus[])[]
+): FileSelectionSource {
+  return {
+    rowFor(key) {
+      const status = findStatusByTreeKey(key, ...lookupLists);
+      return status ? { path: status.path, status } : undefined;
+    },
+    rowsUnder(key) {
+      const prefix = `${treeKeyToPath(key)}/`;
+      return descendants
+        .filter((s) => s.path.startsWith(prefix))
+        .map((s) => ({ path: s.path, status: s }));
+    },
+  };
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -751,6 +751,16 @@ export async function rebaseStatus(repoId: string): Promise<RebaseStatus> {
   return invoke<RebaseStatus>("rebase_status", { repoId });
 }
 
+/**
+ * Drop the retained `RebaseStatus.lastCompleted` summary. The backend holds it
+ * until something has shown it, so a screen that renders the "N steps
+ * completed" line calls this — otherwise the same line reappears on every later
+ * poll and after a restart.
+ */
+export async function rebaseAcknowledge(repoId: string): Promise<void> {
+  return invoke<void>("rebase_acknowledge", { repoId });
+}
+
 export async function fileHistory(
   repoId: string,
   path: string,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -257,11 +257,33 @@ export interface RebaseStep {
   mergeParents?: string[];
 }
 
+/**
+ * What a rebase that ran to completion did, retained by the BACKEND after the
+ * rebase state itself is swept.
+ *
+ * The frontend used to cache the final status for the "N steps completed" line,
+ * which made every abort and start path responsible for clearing that cache
+ * (#47). Now `rebase_status` keeps reporting it until `rebaseAcknowledge`, and
+ * starting or aborting a rebase drops it in the engine.
+ */
+export interface RebaseSummary {
+  /** Steps the completed plan contained. */
+  total: number;
+  /** Steps that ran, drops included. Equal to `total` for a finished plan. */
+  completed: number;
+}
+
 export interface RebaseStatus {
   inProgress: boolean;
   nextIndex: number;
   total: number;
   pauseReason: string | null;
+  /**
+   * The most recently completed rebase, until acknowledged. Always absent while
+   * `inProgress` is true. Optional only so the many `RebaseStatus` fixtures in
+   * tests need not restate it; `rebase_status` always sends it.
+   */
+  lastCompleted?: RebaseSummary | null;
 }
 
 export type ReflogOp =

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -48,6 +48,10 @@ import {
   emptySelection,
   primarySelectedKey,
   pruneSelection,
+  sidedFileKey,
+  sidedFolderKey,
+  sidedSelectionSource,
+  splitFileSelection,
   type Selection,
 } from "@/lib/selection";
 import { getDiff, getLogPage } from "@/lib/tauri";
@@ -144,24 +148,14 @@ export function CommitPanelScreen() {
   const { onContextMenu: onFolderCtx, menu: folderMenu } = useContextMenu<string>(
     (navKey) =>
       multiFileMenuItems(
-        splitByKeys(
-          expandSelectionKeys(navKey ? [navKey] : [], staged, unstaged),
-          staged,
-          unstaged,
-        ),
+        splitFileSelection(navKey ? [navKey] : [], selectionSource),
       ),
   );
 
   const { onContextMenu: onFileCtx, menu: fileMenu } = useContextMenu<FileSlot>(
     (f) => {
       if (f && sel.keys.length > 1 && sel.keys.includes(keyOf(f))) {
-        return multiFileMenuItems(
-          splitByKeys(
-            expandSelectionKeys(sel.keys, staged, unstaged),
-            staged,
-            unstaged,
-          ),
-        );
+        return multiFileMenuItems(splitFileSelection(sel.keys, selectionSource));
       }
       return fileMenuItems({
         path: f?.path,
@@ -262,6 +256,14 @@ export function CommitPanelScreen() {
     [status],
   );
 
+  // Selection keys → path buckets. Folder keys expand within their own section
+  // and embedded repos stay out of the stage/unstage/discard subsets; the rules
+  // are shared with the repo browser (lib/selection) so the two cannot drift.
+  const selectionSource = React.useMemo(
+    () => sidedSelectionSource(staged, unstaged),
+    [staged, unstaged],
+  );
+
   // Visible row order (staged block above changes block) — shift-click ranges
   // extend over this order and may cross the staged/unstaged boundary.
   const rowOrder = React.useMemo(
@@ -357,29 +359,21 @@ export function CommitPanelScreen() {
 
   const onNavStageToggle = React.useCallback(
     (navKey: string, next: boolean) => {
-      const split = splitByKeys(
-        expandSelectionKeys([navKey], staged, unstaged),
-        staged,
-        unstaged,
-      );
+      const split = splitFileSelection([navKey], selectionSource);
       if (next) {
         if (split.unstagedPaths.length) stage(split.unstagedPaths);
       } else if (split.stagedPaths.length) {
         unstage(split.stagedPaths);
       }
     },
-    [staged, unstaged, stage, unstage],
+    [selectionSource, stage, unstage],
   );
 
   // Checkbox on a row inside the multi-selection stages/unstages every
   // selected row on that side; on an unselected row it stays single-file.
   const togglePaths = (f: FileSlot): string[] => {
     if (sel.keys.length > 1 && sel.keys.includes(keyOf(f))) {
-      const split = splitByKeys(
-        expandSelectionKeys(sel.keys, staged, unstaged),
-        staged,
-        unstaged,
-      );
+      const split = splitFileSelection(sel.keys, selectionSource);
       const paths = f.side === "staged" ? split.stagedPaths : split.unstagedPaths;
       if (paths.length > 0) return paths;
     }
@@ -1315,7 +1309,7 @@ export function CommitPanelScreen() {
 }
 
 function keyOf(f: FileSlot): string {
-  return `${f.side}:${f.path}`;
+  return sidedFileKey(f.side, f.path);
 }
 
 /**
@@ -1324,39 +1318,7 @@ function keyOf(f: FileSlot): string {
  * directory for a file with an unlucky name.
  */
 function dirKeyOf(side: FileSlot["side"], dirPath: string): string {
-  return `${side}:dir:${dirPath}`;
-}
-
-/**
- * Replace any folder key with the keys of every file beneath it, so folder
- * rows feed the same path-based ops (stage / unstage / discard / copy) as a
- * multi-row selection. File keys pass through untouched, deduped.
- */
-function expandSelectionKeys(
-  keys: string[],
-  staged: FileSlot[],
-  unstaged: FileSlot[],
-): string[] {
-  const out: string[] = [];
-  const seen = new Set<string>();
-  const push = (k: string) => {
-    if (seen.has(k)) return;
-    seen.add(k);
-    out.push(k);
-  };
-  for (const key of keys) {
-    const m = /^(staged|unstaged):dir:(.*)$/.exec(key);
-    if (!m) {
-      push(key);
-      continue;
-    }
-    const side = m[1] as FileSlot["side"];
-    const prefix = `${m[2]}/`;
-    for (const f of side === "staged" ? staged : unstaged) {
-      if (f.path.startsWith(prefix)) push(keyOf(f));
-    }
-  }
-  return out;
+  return sidedFolderKey(side, dirPath);
 }
 
 /**
@@ -1433,42 +1395,6 @@ function SectionTree({
       onStageToggle={(treeKey, _node, next) => onStageToggle(navKeyFor(treeKey), next)}
     />
   );
-}
-
-/**
- * Split the selected row keys into staged/unstaged path arrays for multi-file
- * ops. Embedded git repositories go into their own bucket instead: they are not
- * files, so Stage/Unstage/Discard must not reach them (see FileStatus.embedded).
- */
-function splitByKeys(
-  keys: string[],
-  staged: FileSlot[],
-  unstaged: FileSlot[],
-): {
-  stagedPaths: string[];
-  unstagedPaths: string[];
-  embeddedPaths: string[];
-  untrackedPaths: string[];
-} {
-  const set = new Set(keys);
-  const selected = [...staged, ...unstaged].filter((f) => set.has(keyOf(f)));
-  const actionable = (side: FileSlot["side"]) =>
-    selected
-      .filter((f) => f.side === side && !f.status.embedded)
-      .map((f) => f.path);
-  return {
-    stagedPaths: actionable("staged"),
-    unstagedPaths: actionable("unstaged"),
-    embeddedPaths: [
-      ...new Set(selected.filter((f) => f.status.embedded).map((f) => f.path)),
-    ],
-    untrackedPaths: selected
-      .filter(
-        (f) =>
-          f.side === "unstaged" && !f.status.embedded && isUntracked(f.status),
-      )
-      .map((f) => f.path),
-  };
 }
 
 /**

--- a/src/screens/Rebase.merge.test.tsx
+++ b/src/screens/Rebase.merge.test.tsx
@@ -50,7 +50,6 @@ beforeEach(() => {
     error: null,
     repoState: "Clean",
     rebaseStatus: SWEPT,
-    lastRebaseSummary: null,
     activity: {},
   });
   mockInvoke("rebase_status", () => SWEPT);

--- a/src/screens/Rebase.preserve.test.tsx
+++ b/src/screens/Rebase.preserve.test.tsx
@@ -51,7 +51,6 @@ beforeEach(() => {
     error: null,
     repoState: "Clean",
     rebaseStatus: SWEPT,
-    lastRebaseSummary: null,
     activity: {},
   });
   mockInvoke("rebase_status", () => SWEPT);

--- a/src/screens/Rebase.reorder.test.tsx
+++ b/src/screens/Rebase.reorder.test.tsx
@@ -55,7 +55,6 @@ function seed(): void {
     error: null,
     repoState: "Clean",
     rebaseStatus: IDLE,
-    lastRebaseSummary: null,
     activity: {},
   });
   useNavStore.setState({

--- a/src/screens/Rebase.test.tsx
+++ b/src/screens/Rebase.test.tsx
@@ -10,11 +10,13 @@ import type { CommitInfo, RebaseStatus, RepoHandle } from "@/lib/types";
 
 const handle: RepoHandle = { id: "repo-1", path: "/tmp/fake-repo", head: "refs/heads/main" };
 
+/** What `rebase_status` reports once the engine has swept its RebaseState. */
 const SWEPT_STATUS: RebaseStatus = {
   inProgress: false,
   nextIndex: 0,
   total: 0,
   pauseReason: null,
+  lastCompleted: null,
 };
 
 function makeCommit(oid: string, summary: string, parent: string): CommitInfo {
@@ -50,13 +52,22 @@ function resetStores() {
     error: null,
     repoState: "Clean",
     rebaseStatus: SWEPT_STATUS,
-    lastRebaseSummary: null,
     activity: {},
   });
   useNavStore.setState({ intent: null });
 }
 
-function wireRefreshAllMocks(): void {
+/**
+ * The backend behaviour the summary depends on: RebaseState is swept the moment
+ * a plan finishes (#28), but the completed-rebase summary is RETAINED until
+ * acknowledged (#47) — so the swept poll still carries `lastCompleted`, and
+ * `rebase_acknowledge` is what makes it stop.
+ */
+function wireRefreshAllMocks(retained: RebaseStatus["lastCompleted"] = null): {
+  ackCalls: () => number;
+} {
+  let acked = 0;
+  let held = retained;
   mockInvoke("get_status", () => []);
   mockInvoke("list_branches", () => []);
   mockInvoke("list_tags", () => []);
@@ -64,9 +75,13 @@ function wireRefreshAllMocks(): void {
   mockInvoke("list_remotes", () => []);
   mockInvoke("get_log_page", () => ({ commits, nextCursor: null }));
   mockInvoke("repo_state", () => "Clean");
-  // Post-#28 backend behavior: RebaseState is swept on completion, so the
-  // status poll right after a finished rebase reports total: 0.
-  mockInvoke("rebase_status", () => SWEPT_STATUS);
+  mockInvoke("rebase_status", () => ({ ...SWEPT_STATUS, lastCompleted: held }));
+  mockInvoke("rebase_acknowledge", () => {
+    acked += 1;
+    held = null;
+    return null;
+  });
+  return { ackCalls: () => acked };
 }
 
 function seedPlanIntent(): void {
@@ -81,15 +96,16 @@ function seedPlanIntent(): void {
 describe("RebaseScreen completion summary", () => {
   beforeEach(() => {
     resetStores();
-    wireRefreshAllMocks();
   });
 
-  it("shows the summary after a completed rebase even though refreshAll re-polls a swept rebase_status", async () => {
+  it("shows the summary from the retained backend value, not a frontend cache", async () => {
+    wireRefreshAllMocks({ total: 2, completed: 2 });
     mockInvoke("rebase_start", () => ({
       inProgress: false,
       nextIndex: 2,
       total: 2,
       pauseReason: null,
+      lastCompleted: { total: 2, completed: 2 },
     }));
 
     seedPlanIntent();
@@ -103,40 +119,57 @@ describe("RebaseScreen completion summary", () => {
       );
     });
 
-    // refreshAll really did clobber rebaseStatus with the swept poll…
+    // refreshAll really did re-poll a swept rebase_status — total is back to 0…
     const state = useRepoStore.getState();
-    expect(state.rebaseStatus).toEqual(SWEPT_STATUS);
-    // …but the summary survived frontend-side.
-    expect(state.lastRebaseSummary).toEqual({
-      inProgress: false,
-      nextIndex: 2,
-      total: 2,
-      pauseReason: null,
-    });
+    expect(state.rebaseStatus.total).toBe(0);
+    expect(state.rebaseStatus.inProgress).toBe(false);
+    // …and the summary survived because the BACKEND kept it, not the store.
+    expect(state.rebaseStatus.lastCompleted).toEqual({ total: 2, completed: 2 });
 
-    // Summary also survives any later refresh cycle (poll still swept).
+    // Still there after any later refresh cycle: nothing has acknowledged it.
     await useRepoStore.getState().refreshAll();
     expect(screen.getByTestId("rebase-last-summary")).toHaveTextContent(
       "Last rebase: 2 steps completed.",
     );
   });
 
-  it("clears the summary when a new rebase starts and pauses", async () => {
+  it("acknowledges the summary when the screen goes away, and does not show it again", async () => {
+    const { ackCalls } = wireRefreshAllMocks({ total: 3, completed: 3 });
     useRepoStore.setState({
-      lastRebaseSummary: { inProgress: false, nextIndex: 2, total: 2, pauseReason: null },
+      rebaseStatus: { ...SWEPT_STATUS, lastCompleted: { total: 3, completed: 3 } },
     });
-    mockInvoke("rebase_start", () => ({
+
+    const view = render(<RebaseScreen />);
+    expect(screen.getByTestId("rebase-last-summary")).toHaveTextContent(
+      "Last rebase: 3 steps completed.",
+    );
+    expect(ackCalls()).toBe(0);
+
+    view.unmount();
+    await waitFor(() => expect(ackCalls()).toBe(1));
+
+    // A later visit finds nothing retained — the notice is spent.
+    await useRepoStore.getState().refreshAll();
+    render(<RebaseScreen />);
+    expect(screen.queryByTestId("rebase-last-summary")).not.toBeInTheDocument();
+  });
+
+  it("shows no summary once a new rebase starts and pauses", async () => {
+    // The engine drops the summary at rebase_start, so no frontend clearing is
+    // involved — the very next status read simply has nothing to report.
+    wireRefreshAllMocks({ total: 2, completed: 2 });
+    useRepoStore.setState({
+      rebaseStatus: { ...SWEPT_STATUS, lastCompleted: { total: 2, completed: 2 } },
+    });
+    const paused: RebaseStatus = {
       inProgress: true,
       nextIndex: 1,
       total: 2,
       pauseReason: "conflict",
-    }));
-    mockInvoke("rebase_status", () => ({
-      inProgress: true,
-      nextIndex: 1,
-      total: 2,
-      pauseReason: "conflict",
-    }));
+      lastCompleted: null,
+    };
+    mockInvoke("rebase_start", () => paused);
+    mockInvoke("rebase_status", () => paused);
 
     seedPlanIntent();
     render(<RebaseScreen />);
@@ -146,18 +179,26 @@ describe("RebaseScreen completion summary", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("rebase-last-summary")).not.toBeInTheDocument();
     });
-    expect(useRepoStore.getState().lastRebaseSummary).toBeNull();
+    expect(useRepoStore.getState().rebaseStatus.lastCompleted).toBeNull();
   });
 
-  it("sets the summary when a paused rebase completes via continue, and abort clears it", async () => {
+  it("reports a paused rebase completing via continue, and an abort clears it", async () => {
+    wireRefreshAllMocks({ total: 3, completed: 3 });
     useRepoStore.setState({
-      rebaseStatus: { inProgress: true, nextIndex: 1, total: 3, pauseReason: "conflict" },
+      rebaseStatus: {
+        inProgress: true,
+        nextIndex: 1,
+        total: 3,
+        pauseReason: "conflict",
+        lastCompleted: null,
+      },
     });
     mockInvoke("rebase_continue", () => ({
       inProgress: false,
       nextIndex: 3,
       total: 3,
       pauseReason: null,
+      lastCompleted: { total: 3, completed: 3 },
     }));
 
     render(<RebaseScreen />);
@@ -170,9 +211,14 @@ describe("RebaseScreen completion summary", () => {
       );
     });
 
-    // Abort of a later rebase must not leave a stale "completed" summary.
+    // Abort must not leave a stale "completed" line: the engine clears the
+    // summary too, and the store's reset carries that through immediately.
     mockInvoke("rebase_abort", () => null);
+    mockInvoke("rebase_status", () => SWEPT_STATUS);
     await useRepoStore.getState().rebaseAbort();
-    expect(useRepoStore.getState().lastRebaseSummary).toBeNull();
+    expect(useRepoStore.getState().rebaseStatus.lastCompleted).toBeFalsy();
+    await waitFor(() => {
+      expect(screen.queryByTestId("rebase-last-summary")).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/screens/Rebase.tsx
+++ b/src/screens/Rebase.tsx
@@ -3,7 +3,7 @@ import { PGRebaseRow } from "@/design/git-components";
 import { PGButton } from "@/design/primitives";
 import { PGEmpty, PGIcon } from "@/design";
 import type { CommitInfo } from "@/lib/types";
-import type { RebaseAction, RebaseStep } from "@/lib/types";
+import type { RebaseAction, RebaseStep, RebaseSummary } from "@/lib/types";
 import { commitsSince } from "@/lib/tauri";
 import { appErrorMessage } from "@/lib/errors";
 import { useRepoStore } from "@/features/repo/useRepoStore";
@@ -177,10 +177,10 @@ export function RebaseScreen() {
     current,
     commits,
     rebaseStatus,
-    lastRebaseSummary,
     rebaseStart,
     rebaseContinue,
     rebaseAbort,
+    rebaseAcknowledge,
   } = useRepoStore();
 
   const [plan, setPlan] = useState<PlanRow[]>([]);
@@ -195,6 +195,27 @@ export function RebaseScreen() {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pickerNotice, setPickerNotice] = useState<string | null>(null);
   const [pickerAnchor, setPickerAnchor] = useState<HTMLElement | null>(null);
+
+  // The completed-rebase notice reads STRAIGHT off the backend's retained
+  // summary — no local copy. That is the whole point of the backend keeping it
+  // (#47): a frontend cache had to be cleared by hand on every start and abort
+  // path, and forgetting one left a stale "N steps completed" standing. Now the
+  // engine drops the summary when a rebase starts or aborts, so both cases
+  // clear themselves on the next status read.
+  const doneSummary: RebaseSummary | null = rebaseStatus.lastCompleted ?? null;
+
+  // Acknowledge on the way out: the summary is retained "until shown", and this
+  // screen is what shows it. Done at unmount rather than on render so a refresh
+  // cycle mid-visit can't blank the notice the user is still reading — and via a
+  // ref so the cleanup sees the latest value without re-running per poll.
+  const doneRef = React.useRef(doneSummary);
+  doneRef.current = doneSummary;
+  React.useEffect(
+    () => () => {
+      if (doneRef.current) void rebaseAcknowledge();
+    },
+    [rebaseAcknowledge],
+  );
 
   // Resolve the base through the backend so any revspec works — branch, tag,
   // full or short hash, even commits outside the loaded log window. The backend
@@ -617,10 +638,10 @@ export function RebaseScreen() {
         </div>
       )}
 
-      {/* Done state when a rebase finished — rebase_status reports total: 0
-          after the backend sweeps its state, so the summary comes from the
-          store's frontend-held lastRebaseSummary instead. */}
-      {!rebaseStatus.inProgress && lastRebaseSummary && plan.length === 0 && (
+      {/* Done state when a rebase finished. `rebase_status` reports total: 0
+          once the engine sweeps its state, so the numbers come from the
+          summary the BACKEND retains for exactly this purpose (#47). */}
+      {!rebaseStatus.inProgress && doneSummary && plan.length === 0 && (
         <div
           data-testid="rebase-last-summary"
           style={{
@@ -631,7 +652,7 @@ export function RebaseScreen() {
             color: "var(--fg-2)",
           }}
         >
-          Last rebase: {lastRebaseSummary.total} steps completed.
+          Last rebase: {doneSummary.total} steps completed.
         </div>
       )}
 

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -44,6 +44,9 @@ import {
   emptySelection,
   primarySelectedKey,
   pruneSelection,
+  splitFileSelection,
+  treeSelectionSource,
+  type FileSelectionSplit,
   type Selection,
 } from "@/lib/selection";
 import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
@@ -319,58 +322,22 @@ export function RepoBrowserScreen() {
   );
 
   // Map selected tree keys to worktree statuses for multi-file operations.
-  // A selected FOLDER key resolves to no file entry, so expand it to every
+  // A selected FOLDER key resolves to no file entry, so it expands to every
   // visible descendant file (against the tree's source set, `filteredStatus`)
   // — otherwise a selected folder is silently dropped from the count and from
   // Stage/Discard, under-counting a destructive op. In all-files mode
   // unmodified files only exist in allFiles, not status — they carry no
-  // stage/unstage actions but still count and copy.
+  // stage/unstage actions but still count and copy. The bucketing rules
+  // themselves live in lib/selection so the commit panel cannot drift from
+  // them (#47).
+  const selectionSource = React.useMemo(
+    () => treeSelectionSource(filteredStatus, status, allFiles),
+    [filteredStatus, status, allFiles],
+  );
   const splitSelection = React.useCallback(
-    (
-      keys: string[],
-    ): {
-      stagedPaths: string[];
-      unstagedPaths: string[];
-      paths: string[];
-      embeddedPaths: string[];
-      untrackedPaths: string[];
-    } => {
-      const stagedPaths: string[] = [];
-      const unstagedPaths: string[] = [];
-      const embeddedPaths: string[] = [];
-      const untrackedPaths: string[] = [];
-      const paths: string[] = [];
-      const seen = new Set<string>();
-      const add = (st: FileStatus) => {
-        if (seen.has(st.path)) return;
-        seen.add(st.path);
-        paths.push(st.path);
-        // An embedded repo counts and copies like any row, but it is not a
-        // file — keep it out of the stage/unstage/discard subsets so a batch
-        // built from this selection never carries it to the backend.
-        if (st.embedded) {
-          embeddedPaths.push(st.path);
-          return;
-        }
-        if (isStaged(st)) stagedPaths.push(st.path);
-        if (isUnstaged(st)) unstagedPaths.push(st.path);
-        if (isUntracked(st)) untrackedPaths.push(st.path);
-      };
-      for (const key of keys) {
-        const st = findStatusByTreeKey(key, status, allFiles);
-        if (st) {
-          add(st);
-          continue;
-        }
-        // Folder key: pull in every visible file beneath it.
-        const prefix = treeKeyToPath(key) + "/";
-        for (const child of filteredStatus) {
-          if (child.path.startsWith(prefix)) add(child);
-        }
-      }
-      return { stagedPaths, unstagedPaths, paths, embeddedPaths, untrackedPaths };
-    },
-    [status, allFiles, filteredStatus],
+    (keys: string[]): FileSelectionSplit =>
+      splitFileSelection(keys, selectionSource),
+    [selectionSource],
   );
 
   /**


### PR DESCRIPTION
Closes the four **Cleanup** boxes left on #47. Correctness/efficiency/hardening items there were already done.

## What changed

### 1. One selection splitter — `src/lib/selection.ts`

`splitByKeys` (`CommitPanel.tsx:1443`) and `splitSelection` (`RepoBrowser.tsx:328`) both reduced a multi-selection to the staged/unstaged/untracked/embedded path arrays `multiFileMenuItems` (`design/context-menu.tsx:1265`) consumes — and had already drifted: only the repo browser expanded a selected FOLDER to the files beneath it.

`splitFileSelection` now owns the bucketing rules. Each surface supplies only the key→row lookup its own key space needs:

- `sidedSelectionSource(staged, unstaged)` — the commit panel's `side:path` / `side:dir:path` keys, where a row stands for ONE side of a file's changes
- `treeSelectionSource(descendants, ...lookupLists)` — the repo browser's `/a/b` tree keys, where a row stands for the whole file

`CommitPanel.expandSelectionKeys` and both local splitters are gone; `keyOf`/`dirKeyOf` delegate to shared key-format helpers so the `dir:` marker lives in one place.

Both preserved behaviours are now unit-pinned rather than duplicated: folder expansion against the tree's own source set, dedup across a file reachable both directly and via an ancestor, embedded repos in their own bucket only, untracked named separately for the discard confirm, and folder-before-file key disambiguation.

### 2. Palette row builders — `src/features/palette/`

`CommandPalette.tsx` hand-built `branch`/`file`/`commit` rows that `commands.ts` already built for its pick steps. `branchItems`/`commitItems` are now exported options-object builders, `fileItems` is new, and all eight in-module pick-step call sites use them — no row kind is constructed in the component any more.

Two things genuinely differ between the root step and a pick step, so they are options, not forks: the **id namespace** (`PaletteItem.id` is the frecency key, and `branch:l:main` at the root is a different row from `pick-branch:l:main` in a merge picker) and the icon/action. Ids, `search` strings, labels, detail text, run ordering (close-then-onPick) and iteration order are byte-identical to before.

The chip pre-filter (`CommandPalette.tsx:~132`) still runs **before** fuzzy matching, so a selected chip never pays to score the whole ~500-row candidate set per keystroke. `chipPrefilter.test.tsx` pins that with a counting `fuzzyMatch` wrapper.

### 3. Backend retains the completed-rebase summary

The engine sweeps `RebaseState` the instant a plan finishes, so `rebase_status` reports `total: 0` one poll later — which is why the frontend cached the final status, and why every abort and start path had to clear that cache by hand.

Now:

- `RebaseStatus.last_completed: Option<RebaseSummary>` (`git/types.rs`)
- written by the engine on completion (`libgit2.rs` `advance_rebase`), to `.git/platypusgit-rebase-last.json` (`rebase_state.rs`: `save_summary`/`load_summary`/`clear_summary`/`summary_path`)
- dropped in the engine by `rebase_start` (a new rebase supersedes it) and `rebase_abort` (no outcome to report)
- spent by the new `rebase_acknowledge` trait method → `commands/rebase.rs` → `invoke_handler!` → `lib/tauri.ts` → `useRepoStore.rebaseAcknowledge`
- `CliBackend` stubbed `NotImplemented`

`useRepoStore.lastRebaseSummary` and all four of its manual clears are gone. `Rebase.tsx` renders straight from `rebaseStatus.lastCompleted` and acknowledges on unmount — it holds no copy at all, so start/abort clear the notice automatically.

### 4. `useHunkNav` rules-of-hooks — for real

`useAction` was called inside `for (const paneId of paneIds)` behind two `eslint-disable react-hooks/rules-of-hooks` comments. `RegisterOpts.paneId` now accepts `string | readonly string[]` and the dispatcher checks membership (`inScope`) instead of equality, so **one** registration per action covers all of a screen's panes. Both call sites (`CommitDiffPanel.tsx:134`, `DiffViewer.tsx:187`) are untouched — signature unchanged. F7/⇧F7 behaviour, per-pane scoping and the first-matching-pane scroll-into-view are all preserved.

## Decisions worth knowing before review

- **A SECOND gitdir file, not a variant inside `platypusgit-rebase.json`.** `repo_state`, `rebase_in_progress` and `rehydrate_rebase` all answer "is a rebase in progress?" by that file's mere existence. A finished rebase stored there would read as a live one and offer Continue/Abort for it. `rebase_summary.rs` has a test asserting `repo_state == Clean` with a summary retained.
- **An unreadable/foreign-version summary is forgotten, not raised.** Unlike the in-progress state — where guessing strands a half-replayed branch — a summary describes an operation that already ended, so nothing is at risk. Failing would instead break every `refreshAll` until the user deleted the file by hand.
- **Acknowledge on unmount, not on render.** Acknowledging as soon as the banner renders would blank it on the next poll; a user-facing dismiss button would be new UX. Unmount means "shown, now spent", keeps the store the single source of truth, and survives an app restart until the Rebase screen is actually visited.
- **`useAction` keys its effect on a content-derived scope key** (NUL-joined), not the array itself: a multi-pane caller builds a fresh literal each render, and identity-keying would unregister/re-register the handler every render.
- **Deliberate behaviour change:** the commit panel's multi-select count now includes embedded repos, matching the repo browser. Previously `splitByKeys` returned no `paths`, so `multiFileMenuItems` fell back to staged ∪ unstaged and read "2 files selected" for a 3-row selection containing one embedded repo. Under-counting a selection was the first correctness item on #47; the two surfaces now agree. Nothing in the test or e2e suites asserted the old text.
- **CLAUDE.md updated** (`lib/selection.ts` entry, `rebase_state.rs` entry, `commands/rebase.rs` command list, a new bullet in "Interactive rebase engine") because the on-disk layout and the shared-splitter rule are exactly the kind of thing that file exists to record. Worth a look — it is the only non-code file in the diff.

## Verification (this branch, real output)

```
pnpm tsc --noEmit                            → exit 0, no output
pnpm exec tsc -p e2e/tsconfig.json --noEmit  → exit 0, no output
pnpm test                                    → 141 files passed, 1035 tests passed, 0 failed
cargo test --manifest-path src-tauri/Cargo.toml → 376 passed, 0 failed, 0 warnings
cargo test --test rebase_summary             → 7 passed
```

Test deltas: `lib/selection.test.ts` 21→31, `palette/commands.test.ts` +13, new `palette/chipPrefilter.test.tsx` (2), `keymap/useHunkNav.test.tsx` 4→8, new `src-tauri/tests/rebase_summary.rs` (7), `screens/Rebase.test.tsx` 3→4 (rewritten to the new shape, intent kept).

Fail-before checks (both reverted after):
- removing `clear_summary` from `rebase_start` + `rebase_abort` → `starting_a_new_rebase_drops_the_previous_summary` and `aborting_drops_the_summary` fail (5 passed / 2 failed)
- removing the unmount-acknowledge effect → "acknowledges the summary when the screen goes away" fails (3 passed / 1 failed)
- restoring the old `useAction`-in-a-loop → 2 of the 8 `useHunkNav` tests fail, one with React's "rendered fewer hooks than expected"

E2E was **not** run locally (five agents compiling concurrently would OOM the 8GB Docker VM). `e2e-linux` is the gate. Specs re-read for validity:
- `rebase.e2e.ts` waits on `[data-testid="rebase-last-summary"]` after a completed rebase — still rendered, now from the retained backend value, and it stays visible for the screen's lifetime.
- `palette.e2e.ts` selectors (`[data-pal-index]`, `[data-pal-type="branch"]`, `[data-pal-chord]`, chip labels, row labels) unchanged.
- `keymap.e2e.ts` F7 test drives `jsChord` + `[data-hunk-index][data-hunk-active]` — no registration internals.
- `status-stage.e2e.ts` multi-select paths unchanged; no spec builds a multi-selection containing an embedded repo.

## Gaps

- **No eslint in this repo** (no config, no dep, nothing in `node_modules/.bin`), so "lint is clean for `useHunkNav.ts`" could not be *demonstrated* — only that both `eslint-disable react-hooks/rules-of-hooks` comments are gone and the hook calls are now unconditional and fixed-arity.
- **`action:checkout-ref` in `commands.ts` still hand-builds its remote-branch rows.** Folding them into `branchItems` would flip `data-pal-type` from `command` to `branch` and the id from `pick-ref:<name>` to `pick-branch:r:<name>` — both observable, so left alone. `tagItems`/`stashItems`/`remoteItems` keep positional signatures (pick-step-only, nothing to share).
- **`useKeymapStore.test.tsx` not extended** for the new array-scope path; it is covered indirectly through `useHunkNav.test.tsx`.
- **Leaving the Rebase screen spends the summary**, so returning to it shows no banner — where the old store-held value survived screen switches. Deliberate (that is what "until acknowledged" buys), but it is a small UX difference.
- **A CLI-driven rebase (`rebase_onto`) records no summary.** It never did; only the interactive engine writes one.
- **`.git/platypusgit-rebase-last.json` is never garbage-collected** if the Rebase screen is never opened after a completed rebase — it is a two-integer file that the next rebase start overwrites, so it is bounded, but it can outlive the interest in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3Pnr6uVf6pgYbZXh65hVU
