### PR TITLE
fix(auth,diff): credentials for tag/branch pushes, Space stages the focused diff line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,8 +322,9 @@ features/            Per-feature: components + Zustand store colocated
 │                    enforcement, DoubleShift, input policy, speed-search
 │                    fallback), useFocusStore (spatial Alt+Arrow + Tab cycling),
 │                    usePaneList (list nav + type-to-jump speed-search),
-│                    useHunkNav (F7/⇧F7 diff hunks), useSpeedSearchStore,
-│                    PGPane / FocusableScroll / CheatSheet
+│                    useHunkNav (F7/⇧F7 diff hunks), useDiffLineFocus (the
+│                    diff pane's per-LINE cursor + Space, see below),
+│                    useSpeedSearchStore, PGPane / FocusableScroll / CheatSheet
 ├── merge/           Merge resolver window — separate Tauri window (label
 │                    "merge"), routed via ?window=merge in main.tsx. mergeModel
 │                    (diff3 chunking, node-diff3), resultEditor (CM6 result pane
@@ -340,6 +341,13 @@ features/            Per-feature: components + Zustand store colocated
 │                    semver.ts (§11 precedence, hand-rolled + tested),
 │                    UpdateChip (titlebar), UpdatePanel (Escape via the
 │                    keymap's app.closeOverlay, not a local listener)
+├── auth/            Credential challenge/retry (#61 D5): useAuthStore (the one
+│                    pending challenge + the retry closure its raiser supplies —
+│                    deliberately NOT the secret) + CredentialDialog. The retry
+│                    helper is `withAuthRetry`, module-private inside
+│                    useRepoStore.ts; useCreateStore hand-rolls the same shape
+│                    for clone because it must drop `busy` before prompting and
+│                    only has a repo id after the clone succeeds.
 ├── create/          Clone + Init dialogs (PGModal), useCreateStore,
 │                    deriveRepoName. Clone shells out to real git with the
 │                    same prompt-less env as fetch/pull/push.
@@ -407,6 +415,26 @@ lib/
   the initial measurement leaves the height 0, `windowVariable` falls back to a
   400px viewport, and the bottom of a taller pane renders blank. Use
   `lib/useViewportH.ts`.
+- **Two cursors, two index spaces, and they must not be confused.** `useHunkNav`
+  keeps a HUNK cursor (F7/⇧F7, rendered as `data-hunk-active`);
+  `useDiffLineFocus` keeps a per-LINE cursor (list-nav chords + Space, rendered
+  as `data-focused`). A `DiffLineTarget` carries BOTH numbers because they are
+  different things: `rowIndex` addresses the flat `DiffRow[]` (what the focus ring
+  and `scrollTopForRow` use) and `changedIndex` addresses the hunk's changed
+  (`+`/`-`) lines (the ONLY value `stage_lines`/`unstage_lines`/`discard_lines`
+  accept). The line cursor deliberately walks changed lines only — context and
+  `fill` rows are unstageable, and skipping them is what keeps one mapping instead
+  of two. Never derive a backend index from a row index or vice versa; read
+  `changedIndex` off the row, where `flattenDiffRows` put it.
+- **Scroll a diff row into view BY OFFSET** (`scrollTopForRow`), never by
+  `querySelector` + `scrollIntoView`: the row is usually unmounted under
+  windowing, so the DOM route silently does nothing (the #68 G10 trap). It
+  no-ops for an out-of-range index or an unmeasured viewport rather than jumping
+  to the top.
+- **Line ops inherit the ignore-whitespace gate.** That flag rewrites hunk
+  boundaries, so both the click path and the keyboard cursor are switched off by
+  `useHunkActionsDisabledReason` — the keyboard must never reach what the mouse
+  cannot (#61 D2).
 
 ### Navigation model
 
@@ -428,6 +456,15 @@ lib/
   bare keys don't. `?` opens the cheat-sheet. `view.zoom*` (Mod+= / Mod+- /
   Mod+0) scales the UI through the WEBVIEW's own zoom (`applyZoom`, persisted as
   `uiZoom`), not a CSS transform — needs `core:webview:allow-set-webview-zoom`.
+- **Two PANE-scoped actions may share one chord; two global ones may not.** The
+  dispatcher's reverse map is `chord → ActionId[]` and it tries each id in turn,
+  so a declined action falls through to the next — `Space` is `list.toggle` in a
+  list pane and `diff.toggleLine` in the diff pane, resolved purely by which pane
+  holds focus. `presets.test.ts` enforces exactly that asymmetry, so prefer a
+  second catalog entry over hanging a second meaning off one action id: the cheat
+  sheet and palette then name each behavior in its own category, and the two can
+  be rebound apart. Register the pane handler as declining (`() => false`) when it
+  has nothing to act on, or it swallows the chord from the other action.
 - `useNavStore.intent` drives deep-view switches (e.g. "show this commit's diff" → sets screen to `commitDiff`). Consumers write an intent; `AppShell` effect routes the screen.
 - Settings is a screen too, reached via titlebar gear or activity-bar settings slot.
 - Conflicts are NOT a destination: `OperationBar` (driven by `repoState`), the
@@ -508,6 +545,47 @@ lib/
   `rebase_abort` whenever a rebase is in progress. The Conflict screen and the
   Rebase banner must stay two entry points to one engine: committing the
   resolved tree without advancing the plan strands the rest of the rebase.
+
+### Network ops and credentials (#61 D5)
+
+- **One runner, six call sites.** Every op that shells out to real `git` over the
+  network goes through `commands::net::run_git_authenticated` (or, for clone,
+  through its two primitives `apply_auth_env` + `map_git_failure`, because clone
+  needs a streamed stderr pipe rather than `.output()`). The six:
+  `fetch`, `fetch_all`, `pull`, `push`, `push_tag`, `push_delete_branch` in
+  `commands/branches.rs`, plus `clone_repo` in `commands/create.rs`. A new network
+  op joins them; **do not open a second auth path.** `branches.rs`'s local
+  `run_git` (merge/rebase/checkout) is the deliberately credential-less sibling.
+- **Retry, never prompt mid-run.** The first attempt is always prompt-less, so the
+  common case (helper or ssh-agent already works) is byte-for-byte what it always
+  was. A failure is classified by `git/auth.rs::classify_auth_failure`; an auth
+  failure becomes `AppError::Auth(AuthChallenge)`, the frontend raises it through
+  `useAuthStore` and re-runs the SAME closure with credentials. Host-key
+  verification failure stays `Network` on purpose — no typeable credential fixes
+  it. New store actions use `withAuthRetry` and put `refreshAll()` INSIDE the
+  retried closure.
+- **Scrub before surfacing, always.** `map_git_failure` runs `scrub_credentials`
+  first, on both branches, because git echoes remote URLs and a remote configured
+  as `https://user:token@host/…` would otherwise put the token in an error banner
+  and the log file. Userinfo ends at the LAST `@` of the authority — splitting on
+  the first leaks the tail of a password containing `@`.
+- **Secrets travel in the environment, never in argv.** Argv is world-readable via
+  `ps`. `GIT_ASKPASS` points at our own bare executable with the mode selected by
+  `PLATYPUSGIT_ASKPASS`, because `GIT_ASKPASS` is exec'd directly and cannot carry
+  arguments. The shim answers on stdout and prints nothing else, ever.
+- **End option parsing with `--` before any user-supplied value.** Remotes and ref
+  names reach these commands from prompts and lists, and a value beginning with
+  `-` is otherwise parsed as an option — `git push --receive-pack=<program>` names
+  a program git runs for the transport, so this is argument injection, not a
+  confusing error. `push_tag_args` / `push_delete_args` emit the separator and a
+  test asserts every user value lands after it. Same class as the D5 security
+  review's finding that `verify_commit` handed an oid straight to `git show`.
+  `push_args` (fetch/pull/push) does NOT yet have one — its force flag is
+  documented as coming last, which `--` would turn into a refspec, so fixing it is
+  its own change.
+- **`credential_approve` refuses values containing a newline** rather than
+  escaping them: git's credential protocol is line-based `key=value`, so a
+  newline injects further keys and could file a password against another host.
 
 ### Async / threading (Rust)
 - `git2::Repository` is `Send` but not `Sync`. `Libgit2Backend` holds each opened repo as `Mutex<Repository>` inside a `Mutex<HashMap<RepoId, ...>>`.

--- a/src-tauri/src/commands/branches.rs
+++ b/src-tauri/src/commands/branches.rs
@@ -429,15 +429,43 @@ pub async fn checkout_ref(
     run_git(&path, &["checkout", reference.as_str()]).await
 }
 
+/// Build `git push <remote> <tag>` args.
+///
+/// `--` ends option parsing before the two user-supplied values. Without it a
+/// value beginning with `-` is read as an option, and both of these come from
+/// the UI: the remote is typed into a prompt (`context-menu.tsx`), the tag name
+/// comes from the tag list. `--receive-pack=<program>` is a real `git push`
+/// option naming a program to run for the transport, so this is argument
+/// injection, not just a confusing error. Verified against git 2.50: without the
+/// separator git swallows the value as an option and then complains it has no
+/// refspec; with it, git reports `src refspec --receive-pack=… does not match
+/// any`. Same class of finding as the #61 D5 security review's third item, where
+/// `verify_commit` handed an oid straight to `git show`.
+fn push_tag_args<'a>(remote: &'a str, name: &'a str) -> Vec<&'a str> {
+    vec!["push", "--", remote, name]
+}
+
+/// Build `git push --delete <remote> <branch>` args.
+///
+/// `--delete` is ours, so it precedes the separator; see `push_tag_args` for why
+/// the separator is there at all.
+fn push_delete_args<'a>(remote: &'a str, name: &'a str) -> Vec<&'a str> {
+    vec!["push", "--delete", "--", remote, name]
+}
+
 #[tauri::command]
 pub async fn push_tag(
     state: State<'_, AppState>,
     repo_id: String,
     remote: String,
     name: String,
+    // Optional so an existing caller that omits it behaves exactly as before:
+    // the first attempt is always prompt-less, and only a retry carries a
+    // credential (#61 D5).
+    credentials: Option<Credentials>,
 ) -> AppResult<()> {
     let path = get_repo_path(&state, &RepoId(repo_id)).await?;
-    run_git(&path, &["push", remote.as_str(), name.as_str()]).await
+    run_git_creds(&path, &push_tag_args(&remote, &name), credentials.as_ref()).await
 }
 
 #[tauri::command]
@@ -446,14 +474,20 @@ pub async fn push_delete_branch(
     repo_id: String,
     remote: String,
     name: String,
+    credentials: Option<Credentials>,
 ) -> AppResult<()> {
     let path = get_repo_path(&state, &RepoId(repo_id)).await?;
-    run_git(&path, &["push", "--delete", remote.as_str(), name.as_str()]).await
+    run_git_creds(
+        &path,
+        &push_delete_args(&remote, &name),
+        credentials.as_ref(),
+    )
+    .await
 }
 
 #[cfg(test)]
 mod tests {
-    use super::fetch_args;
+    use super::{fetch_args, push_delete_args, push_tag_args};
 
     #[test]
     fn fetch_args_with_prune() {
@@ -465,5 +499,42 @@ mod tests {
     fn fetch_args_without_prune() {
         assert_eq!(fetch_args(Some("origin"), false), ["fetch", "origin"]);
         assert_eq!(fetch_args(None, false), ["fetch", "--all"]);
+    }
+
+    #[test]
+    fn push_tag_args_end_options_before_the_user_values() {
+        assert_eq!(push_tag_args("origin", "v1.2.0"), ["push", "--", "origin", "v1.2.0"]);
+    }
+
+    #[test]
+    fn push_delete_args_keep_delete_before_the_separator() {
+        // `--delete` after `--` would be pushed as a refspec named "--delete".
+        assert_eq!(
+            push_delete_args("origin", "feature/x"),
+            ["push", "--delete", "--", "origin", "feature/x"]
+        );
+    }
+
+    #[test]
+    fn a_dash_leading_value_lands_after_the_separator_not_as_an_option() {
+        // The injection this guards: `--receive-pack` names a program git runs
+        // for the transport. Both builders must keep every user-supplied value
+        // strictly after the `--`.
+        for args in [
+            push_tag_args("--receive-pack=/bin/false", "v1"),
+            push_tag_args("origin", "--receive-pack=/bin/false"),
+            push_delete_args("--receive-pack=/bin/false", "main"),
+            push_delete_args("origin", "--receive-pack=/bin/false"),
+        ] {
+            let sep = args
+                .iter()
+                .position(|a| *a == "--")
+                .expect("builders must emit an end-of-options separator");
+            let hostile = args
+                .iter()
+                .position(|a| a.starts_with("--receive-pack"))
+                .expect("test value present");
+            assert!(hostile > sep, "{args:?}");
+        }
     }
 }

--- a/src-tauri/tests/auth_env.rs
+++ b/src-tauri/tests/auth_env.rs
@@ -58,6 +58,43 @@ fn a_surfaced_error_never_carries_an_embedded_token() {
     assert!(!text.contains("ghp_leaked"), "credential leaked: {text}");
 }
 
+/// Tag push and remote-branch delete were the two pushes D5 left on the
+/// credential-less runner (#61 follow-up). They now go through the same
+/// `run_git_authenticated`, so the same classification and the same scrubbing
+/// must hold for the stderr THEY produce — which names a refspec, unlike the
+/// fetch/pull phrasings the tests above cover.
+#[test]
+fn a_failed_tag_push_is_an_auth_challenge_not_a_network_error() {
+    let err = map_git_failure(
+        "remote: Invalid username or password.\n\
+         fatal: Authentication failed for 'https://github.com/x/y.git/'\n\
+         error: failed to push some refs to 'https://github.com/x/y.git'",
+    );
+    match err {
+        AppError::Auth(c) => {
+            assert_eq!(c.host.as_deref(), Some("github.com"));
+            assert_eq!(c.kind, AuthKind::Https);
+        }
+        other => panic!("expected Auth, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_failed_branch_delete_scrubs_the_token_out_of_its_remote_url() {
+    // `git push --delete` echoes the remote URL twice — in the fatal line and in
+    // the "failed to push some refs to" line. Both must be scrubbed, or a remote
+    // configured with an embedded token puts it in the error banner and the log.
+    let err = map_git_failure(
+        "fatal: unable to access 'https://ada:ghp_leaked@github.com/x/y.git/': \
+         The requested URL returned error: 403\n\
+         error: failed to push some refs to \
+         'https://ada:ghp_leaked@github.com/x/y.git'",
+    );
+    let text = format!("{err:?}");
+    assert!(!text.contains("ghp_leaked"), "credential leaked: {text}");
+    assert!(text.contains("github.com/x/y"), "message lost its subject: {text}");
+}
+
 #[test]
 fn credentials_travel_in_the_environment_never_in_argv() {
     let c = creds();

--- a/src/design/PGWindowedDiff.tsx
+++ b/src/design/PGWindowedDiff.tsx
@@ -28,6 +28,14 @@ export interface PGWindowedDiffProps {
   /** Selected changed-line indices for a hunk (#61 D7 index space). */
   selectedLines?: (hunkIndex: number) => number[];
   onLineClick?: (hunkIndex: number, changedIndex: number, range: boolean) => void;
+  /**
+   * Flat row index the keyboard line cursor sits on (#61 D7 step 5).
+   *
+   * A ROW index rather than a (hunk, changedIndex) pair: this renderer already
+   * knows each row's absolute index, so matching is one comparison and cannot
+   * mistake a collapsed or refetched hunk's line for the focused one.
+   */
+  focusedRow?: number | null;
 }
 
 export function PGWindowedDiff({
@@ -39,6 +47,7 @@ export function PGWindowedDiff({
   hunkActions,
   selectedLines,
   onLineClick,
+  focusedRow,
 }: PGWindowedDiffProps) {
   const start = win?.start ?? 0;
   const end = win?.end ?? rows.length;
@@ -88,6 +97,7 @@ export function PGWindowedDiff({
             selected={
               row.line.changedIndex != null && sel.includes(row.line.changedIndex)
             }
+            focused={focusedRow === start + i}
             onLineClick={
               onLineClick && !disabled
                 ? (changedIndex, range) => onLineClick(row.hunkIndex, changedIndex, range)

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -707,10 +707,17 @@ function DiffText({
 export function PGDiffRow({
   line,
   selected,
+  focused,
   onLineClick,
 }: {
   line: DiffLineData;
   selected?: boolean;
+  /**
+   * The keyboard line cursor sits here (#61 D7 step 5). Distinct from
+   * `selected`: selection is a set the hunk's Stage button acts on, focus is the
+   * single line Space acts on, and the two are frequently different rows.
+   */
+  focused?: boolean;
   onLineClick?: (changedIndex: number, range: boolean) => void;
 }) {
   const kind = line.kind;
@@ -751,6 +758,7 @@ export function PGDiffRow({
         <div
           data-testid={selectable ? "diff-line-changed" : undefined}
           data-selected={isSelected || undefined}
+          data-focused={focused || undefined}
           onClick={
             selectable
               ? (e) => onLineClick!(ln.changedIndex!, e.shiftKey)
@@ -772,6 +780,12 @@ export function PGDiffRow({
               borderColor[kind] !== undefined
                 ? `2px solid ${borderColor[kind]}`
                 : "2px solid transparent",
+            // outline, not a border or extra padding: this row's height is the
+            // window's pitch, and anything that grows it puts the variable-height
+            // arithmetic out of step with what is rendered. outlineOffset pulls
+            // the ring inside so the neighbours don't clip it.
+            outline: focused ? "1px solid var(--accent)" : undefined,
+            outlineOffset: focused ? "-1px" : undefined,
           }}
         >
           <span

--- a/src/features/keymap/actions.ts
+++ b/src/features/keymap/actions.ts
@@ -82,6 +82,7 @@ export type ActionId =
   | "conflict.openResolver"
   | "diff.nextChange"
   | "diff.prevChange"
+  | "diff.toggleLine"
   | "commit.commit"
   | "commit.commitAndPush"
   | "commit.toggleAmend"
@@ -263,6 +264,13 @@ export const ACTIONS: Record<ActionId, ActionDef> = {
 
   "diff.nextChange": { id: "diff.nextChange", title: "Next change (hunk)", category: "Diff", scope: "pane" },
   "diff.prevChange": { id: "diff.prevChange", title: "Previous change (hunk)", category: "Diff", scope: "pane" },
+  // Shares the Space chord with list.toggle, which is legal: both are
+  // pane-scoped, so the dispatcher's pane filter picks exactly one of them (a
+  // declined action falls through to the next id bound to the same chord). Its
+  // own catalog entry rather than a second list.toggle handler, so the cheat
+  // sheet says "Diff / stage the focused line" instead of hiding a diff action
+  // under "Lists & trees", and so the two can be rebound apart.
+  "diff.toggleLine": { id: "diff.toggleLine", title: "Stage / unstage focused line", category: "Diff", scope: "pane" },
 
   "repo.open": { id: "repo.open", title: "Open repository…", category: "Repository", scope: "global", run: openRepoOp },
   "repo.clone": { id: "repo.clone", title: "Clone repository…", category: "Repository", scope: "global", run: cloneRepoOp },

--- a/src/features/keymap/index.ts
+++ b/src/features/keymap/index.ts
@@ -10,6 +10,7 @@ export * from "./spatial";
 export * from "./PGPane";
 export * from "./usePaneList";
 export * from "./useHunkNav";
+export * from "./useDiffLineFocus";
 export * from "./FocusableScroll";
 export * from "./chordFor";
 export * from "./CheatSheet";

--- a/src/features/keymap/presets.ts
+++ b/src/features/keymap/presets.ts
@@ -70,6 +70,11 @@ const COMMON = {
   // Rider NextDiff/PreviousDiff — real JetBrains bindings.
   "diff.nextChange": ["F7"],
   "diff.prevChange": ["Shift+F7"],
+  // Same Space as list.toggle on purpose: in the file list Space stages the row,
+  // in the diff pane it stages the focused line. One key, one meaning. Legal
+  // because both actions are pane-scoped — presets.test.ts only forbids two
+  // GLOBAL actions on one chord, and the dispatcher tries each id in turn.
+  "diff.toggleLine": [" "],
   // Find-in-tree (matches the ⌘⇧F chip on the Files tree). Component-handled
   // by RepoBrowser; a find, not a mutating op, so ⌘⇧F muscle-memory is safe.
   "tree.find": ["Mod+Shift+F"],

--- a/src/features/keymap/useDiffLineFocus.test.tsx
+++ b/src/features/keymap/useDiffLineFocus.test.tsx
@@ -1,0 +1,263 @@
+// Per-line keyboard focus for a diff pane (#61 D7 step 5).
+//
+// The load-bearing assertion is the index mapping: the cursor counts CHANGED
+// (+/-) lines only, so a hunk with context rows must still report the
+// changedIndex the backend's line ops expect. A cursor over every rendered row
+// would drift by one per context line.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, render } from "@testing-library/react";
+import { useDiffLineFocus, diffLineTargets, type DiffLineTarget } from "./useDiffLineFocus";
+import { useKeymapStore } from "./useKeymapStore";
+import { useFocusStore } from "./useFocusStore";
+import { flattenDiffRows } from "@/lib/diffRows";
+import type { FileDiff } from "@/lib/types";
+
+type Hunk = FileDiff["hunks"][number];
+
+const ctx = (n: number) => ({
+  kind: { kind: "Context" as const },
+  oldLineno: n,
+  newLineno: n,
+  content: `ctx${n}\n`,
+});
+const add = (n: number) => ({
+  kind: { kind: "Addition" as const },
+  oldLineno: null,
+  newLineno: n,
+  content: `add${n}\n`,
+});
+const rem = (n: number) => ({
+  kind: { kind: "Deletion" as const },
+  oldLineno: n,
+  newLineno: null,
+  content: `rem${n}\n`,
+});
+
+/** Context, add, context, remove, add — changed indices 0,1,2 amid context. */
+const hunkWithContext = (header: string): Hunk => ({
+  header,
+  oldStart: 1,
+  oldLines: 3,
+  newStart: 1,
+  newLines: 4,
+  lines: [ctx(1), add(2), ctx(3), rem(4), add(5)],
+});
+
+const rowsFor = (hunks: Hunk[]) =>
+  flattenDiffRows(hunks, { headerH: 26, rowH: 18 });
+
+const key = (k: string) =>
+  ({
+    key: k,
+    code: "",
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    preventDefault() {},
+    target: document.body,
+  }) as unknown as KeyboardEvent;
+
+function press(k: string): boolean {
+  let handled = false;
+  act(() => {
+    handled = useKeymapStore.getState().dispatch(key(k));
+  });
+  return handled;
+}
+
+function Harness(props: {
+  rows: ReturnType<typeof rowsFor>;
+  onToggle?: (t: DiffLineTarget) => void;
+  scrollToRow?: (i: number) => void;
+  disabled?: boolean;
+  seen: { focus: DiffLineTarget | null };
+}) {
+  const f = useDiffLineFocus({
+    paneId: "d.diff",
+    rows: props.rows,
+    resetKey: props.rows,
+    onToggle: props.onToggle,
+    scrollToRow: props.scrollToRow,
+    disabled: props.disabled,
+  });
+  props.seen.focus = f.focused;
+  return null;
+}
+
+function reset() {
+  useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+  useKeymapStore.getState().setPreset("rider");
+  useFocusStore.setState({
+    focused: null,
+    panes: new Map(),
+    order: [],
+    barId: null,
+    pendingContentFocus: false,
+  });
+}
+
+describe("diffLineTargets", () => {
+  it("numbers changed lines only, skipping context", () => {
+    const targets = diffLineTargets(rowsFor([hunkWithContext("@@ -1,3 +1,4 @@")]));
+    expect(targets.map((t) => t.changedIndex)).toEqual([0, 1, 2]);
+    // Row 0 is the hunk header, so the changed rows are 2, 4, 5 — proving the
+    // cursor's own row index and the backend's changed index are NOT the same
+    // number, which is exactly why both are carried.
+    expect(targets.map((t) => t.rowIndex)).toEqual([2, 4, 5]);
+  });
+
+  it("restarts changedIndex per hunk while rowIndex keeps rising", () => {
+    const targets = diffLineTargets(
+      rowsFor([hunkWithContext("@@ -1,3 +1,4 @@"), hunkWithContext("@@ -20,3 +20,4 @@")]),
+    );
+    expect(targets.map((t) => [t.hunkIndex, t.changedIndex])).toEqual([
+      [0, 0],
+      [0, 1],
+      [0, 2],
+      [1, 0],
+      [1, 1],
+      [1, 2],
+    ]);
+    const rowIdx = targets.map((t) => t.rowIndex);
+    expect([...rowIdx].sort((a, b) => a - b)).toEqual(rowIdx);
+  });
+
+  it("skips whole-file fill rows, which belong to no hunk", () => {
+    const rows = flattenDiffRows([hunkWithContext("@@ -1,3 +1,4 @@")], {
+      headerH: 26,
+      rowH: 18,
+      wholeFile: { newText: "ctx1\nadd2\nctx3\nadd5\nafter1\nafter2\n", oldText: null },
+    });
+    expect(rows.some((r) => r.kind === "fill")).toBe(true);
+    expect(diffLineTargets(rows).map((t) => t.changedIndex)).toEqual([0, 1, 2]);
+  });
+
+  it("has no targets in a collapsed hunk", () => {
+    const rows = flattenDiffRows([hunkWithContext("@@ -1,3 +1,4 @@")], {
+      headerH: 26,
+      rowH: 18,
+      collapsed: new Set([0]),
+    });
+    expect(diffLineTargets(rows)).toEqual([]);
+  });
+});
+
+describe("useDiffLineFocus", () => {
+  beforeEach(reset);
+
+  it("has no cursor until an arrow key moves into the lines", () => {
+    const seen = { focus: null as DiffLineTarget | null };
+    render(<Harness rows={rowsFor([hunkWithContext("@@ -1,3 +1,4 @@")])} seen={seen} />);
+    useFocusStore.setState({ focused: "d.diff" });
+    expect(seen.focus).toBeNull();
+
+    press("ArrowDown");
+    expect(seen.focus).toMatchObject({ hunkIndex: 0, changedIndex: 0 });
+    press("ArrowDown");
+    expect(seen.focus).toMatchObject({ hunkIndex: 0, changedIndex: 1 });
+    press("ArrowUp");
+    expect(seen.focus).toMatchObject({ hunkIndex: 0, changedIndex: 0 });
+  });
+
+  it("moves across the hunk boundary and clamps at both ends", () => {
+    const seen = { focus: null as DiffLineTarget | null };
+    render(
+      <Harness
+        rows={rowsFor([hunkWithContext("@@ -1,3 +1,4 @@"), hunkWithContext("@@ -20,3 +20,4 @@")])}
+        seen={seen}
+      />,
+    );
+    useFocusStore.setState({ focused: "d.diff" });
+    for (let i = 0; i < 4; i++) press("ArrowDown");
+    expect(seen.focus).toMatchObject({ hunkIndex: 1, changedIndex: 0 });
+    for (let i = 0; i < 10; i++) press("ArrowDown");
+    expect(seen.focus).toMatchObject({ hunkIndex: 1, changedIndex: 2 });
+    for (let i = 0; i < 20; i++) press("ArrowUp");
+    expect(seen.focus).toMatchObject({ hunkIndex: 0, changedIndex: 0 });
+  });
+
+  it("Space reports the focused target and is declined without a cursor", () => {
+    const onToggle = vi.fn();
+    const seen = { focus: null as DiffLineTarget | null };
+    render(
+      <Harness rows={rowsFor([hunkWithContext("@@ -1,3 +1,4 @@")])} onToggle={onToggle} seen={seen} />,
+    );
+    useFocusStore.setState({ focused: "d.diff" });
+
+    // No cursor yet: the chord must fall through rather than be swallowed.
+    expect(press(" ")).toBe(false);
+    expect(onToggle).not.toHaveBeenCalled();
+
+    press("ArrowDown");
+    press("ArrowDown");
+    expect(press(" ")).toBe(true);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    // The SECOND changed line — index 1 among +/- rows, even though a context row
+    // sits between it and the first.
+    expect(onToggle.mock.calls[0][0]).toMatchObject({ hunkIndex: 0, changedIndex: 1 });
+  });
+
+  it("answers nothing while another pane holds focus", () => {
+    const onToggle = vi.fn();
+    const seen = { focus: null as DiffLineTarget | null };
+    render(
+      <Harness rows={rowsFor([hunkWithContext("@@ -1,3 +1,4 @@")])} onToggle={onToggle} seen={seen} />,
+    );
+    useFocusStore.setState({ focused: "somewhere.else" });
+    expect(press("ArrowDown")).toBe(false);
+    expect(press(" ")).toBe(false);
+    expect(seen.focus).toBeNull();
+  });
+
+  it("offers no cursor at all while disabled (ignore-whitespace)", () => {
+    const onToggle = vi.fn();
+    const seen = { focus: null as DiffLineTarget | null };
+    render(
+      <Harness
+        rows={rowsFor([hunkWithContext("@@ -1,3 +1,4 @@")])}
+        onToggle={onToggle}
+        disabled
+        seen={seen}
+      />,
+    );
+    useFocusStore.setState({ focused: "d.diff" });
+    // count 0 → usePaneList declines, so the arrows still scroll the pane.
+    expect(press("ArrowDown")).toBe(false);
+    expect(seen.focus).toBeNull();
+    expect(press(" ")).toBe(false);
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it("scrolls by ROW index, not by the changed index", () => {
+    const scrollToRow = vi.fn();
+    const seen = { focus: null as DiffLineTarget | null };
+    render(
+      <Harness
+        rows={rowsFor([hunkWithContext("@@ -1,3 +1,4 @@")])}
+        scrollToRow={scrollToRow}
+        seen={seen}
+      />,
+    );
+    useFocusStore.setState({ focused: "d.diff" });
+    scrollToRow.mockClear();
+    press("ArrowDown");
+    // Changed index 0 lives at flat row 2 — the header and one context row are
+    // ahead of it, and scrolling addresses the rendered row.
+    expect(scrollToRow).toHaveBeenLastCalledWith(2);
+  });
+
+  it("drops a cursor that a shrinking diff left past the end", () => {
+    const seen = { focus: null as DiffLineTarget | null };
+    const two = rowsFor([hunkWithContext("@@ -1,3 +1,4 @@"), hunkWithContext("@@ -20,3 +20,4 @@")]);
+    const { rerender } = render(<Harness rows={two} seen={seen} />);
+    useFocusStore.setState({ focused: "d.diff" });
+    for (let i = 0; i < 6; i++) press("ArrowDown");
+    expect(seen.focus).toMatchObject({ hunkIndex: 1, changedIndex: 2 });
+
+    const one = rowsFor([hunkWithContext("@@ -1,3 +1,4 @@")]);
+    act(() => rerender(<Harness rows={one} seen={seen} />));
+    expect(seen.focus).toBeNull();
+  });
+});

--- a/src/features/keymap/useDiffLineFocus.ts
+++ b/src/features/keymap/useDiffLineFocus.ts
@@ -1,0 +1,141 @@
+// useDiffLineFocus — a per-line keyboard cursor for a diff pane, plus the Space
+// chord that stages/unstages the line it sits on (#61 D7, step 5).
+//
+// D7 landed line-level staging with click and shift-click only: the diff pane had
+// no per-line focus model, because useHunkNav moves a HUNK cursor, so there was
+// nothing for Space to act on. This is that missing cursor.
+//
+// The cursor walks the CHANGED (+/-) lines ONLY. Context rows and whole-file
+// `fill` rows are skipped for two reasons: Space could do nothing on them, and
+// skipping them is what keeps this cursor addressable in the ONE index space the
+// line ops speak — "index among the hunk's changed lines" (see DiffLineTarget).
+// A cursor over every rendered row would need a second mapping, and a diff in
+// whole-file mode is mostly rows that map to nothing.
+//
+// Independent of useHunkNav on purpose. F7/⇧F7 bind different actions and move a
+// different cursor, so neither claims the other's chord; the two coexist as
+// "jump to the next change block" and "step through changed lines".
+
+import React from "react";
+import type { DiffRow } from "@/lib/diffRows";
+import { useAction } from "./useAction";
+import { usePaneList } from "./usePaneList";
+
+export interface DiffLineTarget {
+  /**
+   * Index into the flat `DiffRow[]`. What the focus ring and scrolling address —
+   * NOT a value any backend op accepts.
+   */
+  rowIndex: number;
+  hunkIndex: number;
+  /**
+   * Index among the hunk's changed (`+`/`-`) lines, counted from 0. THE wire
+   * contract shared with the backend's `Patch::line_in_hunk` (#61 D7): never a
+   * plain index into `hunk.lines`, which also carries header and context rows.
+   * Read straight off the row — assigned once by `flattenDiffRows`, so this
+   * introduces no second index space.
+   */
+  changedIndex: number;
+}
+
+/** The focusable (changed) lines of a flat diff, in render order. */
+export function diffLineTargets(rows: DiffRow[]): DiffLineTarget[] {
+  const out: DiffLineTarget[] = [];
+  rows.forEach((row, rowIndex) => {
+    // `header` has no line; `fill` has no hunkIndex to stage against.
+    if (row.kind !== "line") return;
+    const changedIndex = row.line.changedIndex;
+    // Context rows are unnumbered by withChangedIndices, which is exactly the
+    // "not stageable" test.
+    if (changedIndex == null) return;
+    out.push({ rowIndex, hunkIndex: row.hunkIndex, changedIndex });
+  });
+  return out;
+}
+
+export interface DiffLineFocus {
+  targets: DiffLineTarget[];
+  /** -1 while the pane has no cursor yet. */
+  index: number;
+  focused: DiffLineTarget | null;
+}
+
+export function useDiffLineFocus(opts: {
+  paneId: string;
+  rows: DiffRow[];
+  /** Cursor resets when this changes — the viewed file, its side, or the diff. */
+  resetKey: unknown;
+  /** Space. Omit to leave the chord unclaimed for this pane. */
+  onToggle?: (t: DiffLineTarget) => void;
+  /**
+   * Scroll a flat row index into view. Windowed panes MUST supply this: the
+   * focused row is frequently unmounted, so a DOM query finds nothing and
+   * keyboard navigation silently stops scrolling (#68 G10).
+   */
+  scrollToRow?: (rowIndex: number) => void;
+  /**
+   * No cursor and no toggling — for the ignore-whitespace case, where hunk
+   * indices do not address what git would apply (#61 D2). Same gate the click
+   * path already honors, so the keyboard cannot reach what the mouse cannot.
+   */
+  disabled?: boolean;
+}): DiffLineFocus {
+  const { paneId, rows, resetKey, onToggle, scrollToRow, disabled } = opts;
+
+  const targets = React.useMemo(
+    () => (disabled ? [] : diffLineTargets(rows)),
+    [rows, disabled],
+  );
+
+  // -1 = no cursor yet, so entering the pane does not paint a ring on a line the
+  // user never asked about. usePaneList clamps, so the first ArrowUp OR
+  // ArrowDown lands on target 0 — the same entry behavior every other list has.
+  const [index, setIndex] = React.useState(-1);
+  React.useEffect(() => {
+    setIndex(-1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resetKey, disabled]);
+
+  // A shrinking diff must not leave the cursor past the end: the row it named is
+  // gone, and a stale index would stage a different line.
+  const cursor = index >= targets.length ? -1 : index;
+  const focused = cursor >= 0 ? targets[cursor] : null;
+
+  // Memoized, or usePaneList's scroll effect re-runs on every parent render —
+  // which includes every scroll event, so the pane would snap back to the cursor
+  // the moment the user scrolled away from it.
+  const scrollToIndex = React.useCallback(
+    (i: number) => {
+      const t = targets[i];
+      if (t) scrollToRow?.(t.rowIndex);
+    },
+    [targets, scrollToRow],
+  );
+
+  usePaneList({
+    paneId,
+    count: targets.length,
+    selectedIndex: cursor,
+    onSelect: setIndex,
+    // Deliberately no onToggle: usePaneList would then claim Space as
+    // `list.toggle`, and the chord would read as a list action in the cheat
+    // sheet. It registers a declining handler instead, and the dispatcher falls
+    // through to `diff.toggleLine` below.
+    scrollToIndex,
+  });
+
+  useAction(
+    "diff.toggleLine",
+    () => {
+      // Decline with no cursor, so Space is not swallowed before the user has
+      // moved into the lines.
+      if (!focused || !onToggle) return false;
+      onToggle(focused);
+      return true;
+    },
+    [focused, onToggle],
+    { paneId },
+  );
+
+  return { targets, index: cursor, focused };
+}

--- a/src/features/repo/useRepoStore.pushAuth.test.ts
+++ b/src/features/repo/useRepoStore.pushAuth.test.ts
@@ -1,0 +1,147 @@
+// Tag push and remote-branch delete take the same credential challenge/retry as
+// push/pull/fetch/clone (#61 D5 follow-up).
+//
+// D5 threaded the four network sites its spec named and left these two on the
+// credential-less runner, where an authenticated remote failed with git's stderr
+// and no way to answer it. These tests pin that they now raise a challenge, that
+// the retry carries the credential into the SAME op, and that "remember" is still
+// only honored after the op actually worked and only for HTTPS.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { useRepoStore } from "./useRepoStore";
+import { useAuthStore } from "@/features/auth/useAuthStore";
+
+function mockRefreshAll() {
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => null);
+}
+
+const calls = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+
+const httpsChallenge = () => {
+  throw { kind: "Auth", message: { host: "github.com", kind: "Https" } };
+};
+
+beforeEach(() => {
+  resetInvokeMock();
+  useAuthStore.setState({ challenge: null });
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/tmp/repo-1", head: "main" },
+    error: null,
+  });
+  mockRefreshAll();
+  mockInvoke("remember_credential", () => null);
+});
+
+describe.each([
+  ["pushTag", "push_tag", () => useRepoStore.getState().pushTag("origin", "v1.2.0")],
+  [
+    "pushDeleteBranch",
+    "push_delete_branch",
+    () => useRepoStore.getState().pushDeleteBranch("origin", "feature/x"),
+  ],
+] as const)("%s credential retry", (_name, cmd, run) => {
+  it("raises a challenge instead of a dead-end error", async () => {
+    mockInvoke(cmd, httpsChallenge);
+
+    await run();
+
+    const challenge = useAuthStore.getState().challenge;
+    expect(challenge).not.toBeNull();
+    expect(challenge?.host).toBe("github.com");
+    expect(challenge?.kind).toBe("Https");
+    // The banner stays clear: an answerable failure is a prompt, not an error.
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("retries the same op with the credential", async () => {
+    let attempts = 0;
+    mockInvoke(cmd, () => {
+      attempts += 1;
+      if (attempts === 1) httpsChallenge();
+      return null;
+    });
+
+    await run();
+    await useAuthStore
+      .getState()
+      .challenge!.retry({ username: "ada", secret: "token" }, false);
+
+    expect(attempts).toBe(2);
+    const second = calls(cmd)[1];
+    expect(second.args.credentials).toEqual({ username: "ada", secret: "token" });
+    // The first attempt is prompt-less by design.
+    expect(calls(cmd)[0].args.credentials).toBeUndefined();
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("remembers only after the op actually worked", async () => {
+    // Fails on both attempts: storing on submit would persist a typo.
+    mockInvoke(cmd, httpsChallenge);
+
+    await run();
+    await useAuthStore
+      .getState()
+      .challenge!.retry({ username: "ada", secret: "wrong" }, true);
+
+    expect(calls("remember_credential")).toHaveLength(0);
+    // The retry's own failure reaches the banner.
+    expect(useRepoStore.getState().error).not.toBeNull();
+  });
+
+  it("remembers an HTTPS credential once the retry succeeds", async () => {
+    let attempts = 0;
+    mockInvoke(cmd, () => {
+      attempts += 1;
+      if (attempts === 1) httpsChallenge();
+      return null;
+    });
+
+    await run();
+    await useAuthStore
+      .getState()
+      .challenge!.retry({ username: "ada", secret: "token" }, true);
+
+    expect(calls("remember_credential")).toHaveLength(1);
+    expect(calls("remember_credential")[0].args.host).toBe("github.com");
+  });
+
+  it("never remembers an SSH passphrase with git's credential helper", async () => {
+    // `git credential approve` stores an HTTP(S) password; an SSH passphrase
+    // filed there would be offered at the next HTTPS prompt for the host.
+    let attempts = 0;
+    mockInvoke(cmd, () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw { kind: "Auth", message: { host: "github.com", kind: "SshPassphrase" } };
+      }
+      return null;
+    });
+
+    await run();
+    expect(useAuthStore.getState().challenge?.kind).toBe("SshPassphrase");
+    await useAuthStore.getState().challenge!.retry({ secret: "key-passphrase" }, true);
+
+    expect(attempts).toBe(2);
+    expect(calls("remember_credential")).toHaveLength(0);
+  });
+
+  it("surfaces a non-auth failure without prompting", async () => {
+    mockInvoke(cmd, () => {
+      throw { kind: "Network", message: "Could not resolve host: github.com" };
+    });
+
+    await run();
+
+    expect(useAuthStore.getState().challenge).toBeNull();
+    expect(useRepoStore.getState().error).not.toBeNull();
+  });
+});

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -877,26 +877,34 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     }
   },
 
+  // Tag push and remote-branch delete are pushes, so they get the same
+  // challenge/retry as push/pull/fetch/clone. D5 threaded the four sites its
+  // spec named and left these two on the credential-less path, where an
+  // authenticated remote failed with git's stderr and no way to answer it.
   async pushTag(remote, name) {
     const repo = get().current;
     if (!repo) return;
-    try {
-      await pushTagFn(repo.id, remote, name);
-      await get().refreshAll();
-    } catch (e) {
-      set({ error: toAppError(e) });
-    }
+    await withAuthRetry(
+      repo.id,
+      async (creds) => {
+        await pushTagFn(repo.id, remote, name, creds);
+        await get().refreshAll();
+      },
+      (e) => set({ error: toAppError(e) }),
+    );
   },
 
   async pushDeleteBranch(remote, name) {
     const repo = get().current;
     if (!repo) return;
-    try {
-      await pushDeleteBranchFn(repo.id, remote, name);
-      await get().refreshAll();
-    } catch (e) {
-      set({ error: toAppError(e) });
-    }
+    await withAuthRetry(
+      repo.id,
+      async (creds) => {
+        await pushDeleteBranchFn(repo.id, remote, name, creds);
+        await get().refreshAll();
+      },
+      (e) => set({ error: toAppError(e) }),
+    );
   },
 
   async createBranch(name, from) {

--- a/src/lib/diffRows.test.ts
+++ b/src/lib/diffRows.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { flattenDiffRows, rowOffset, windowVariable } from "./diffRows";
+import {
+  flattenDiffRows,
+  rowOffset,
+  scrollTopForRow,
+  windowVariable,
+} from "./diffRows";
 import type { FileDiff } from "./types";
 
 const hunk = (n: number): FileDiff["hunks"][number] => ({
@@ -386,5 +391,51 @@ describe("rowOffset", () => {
     expect(rowOffset([26, 19, 19], 0)).toBe(0);
     expect(rowOffset([26, 19, 19], 2)).toBe(45);
     expect(rowOffset([26, 19, 19], 99)).toBe(64);
+  });
+});
+
+describe("scrollTopForRow", () => {
+  // Ten 20px rows in a 60px viewport — three rows visible at a time.
+  const hs = Array.from({ length: 10 }, () => 20);
+  const at = (index: number, scrollTop: number) =>
+    scrollTopForRow(hs, index, { scrollTop, viewportH: 60 });
+
+  it("leaves the scroll position alone when the row is already fully visible", () => {
+    // scrollTop 40 shows rows 2,3,4 (offsets 40..100).
+    expect(at(2, 40)).toBe(40);
+    expect(at(3, 40)).toBe(40);
+    expect(at(4, 40)).toBe(40);
+  });
+
+  it("scrolls up to the row's own top when it is above the viewport", () => {
+    expect(at(1, 40)).toBe(20);
+    expect(at(0, 40)).toBe(0);
+  });
+
+  it("scrolls down by the minimum that shows the row's bottom", () => {
+    // Row 5 ends at 120; a 60px viewport must start at 60, not jump to the row.
+    expect(at(5, 40)).toBe(60);
+    expect(at(9, 0)).toBe(140);
+  });
+
+  it("holds still for an out-of-range index", () => {
+    // The keyboard cursor is -1 before it has moved, and a shrinking diff can
+    // leave it past the end — neither may yank the pane to the top.
+    expect(at(-1, 40)).toBe(40);
+    expect(at(10, 40)).toBe(40);
+  });
+
+  it("holds still when the viewport has not been measured yet", () => {
+    // jsdom and the first paint both report 0; scrolling on that would compute a
+    // position from a viewport that does not exist.
+    expect(scrollTopForRow(hs, 9, { scrollTop: 40, viewportH: 0 })).toBe(40);
+  });
+
+  it("works with the diff's mixed row heights", () => {
+    // A header (26) then two code rows (18), twice.
+    const mixed = [26, 18, 18, 26, 18, 18];
+    // Row 4 spans 88..106; a 40px viewport at 0 must scroll to 66.
+    expect(scrollTopForRow(mixed, 4, { scrollTop: 0, viewportH: 40 })).toBe(66);
+    expect(scrollTopForRow(mixed, 0, { scrollTop: 66, viewportH: 40 })).toBe(0);
   });
 });

--- a/src/lib/diffRows.ts
+++ b/src/lib/diffRows.ts
@@ -268,6 +268,33 @@ export function rowOffset(heights: number[], index: number): number {
 }
 
 /**
+ * Smallest `scrollTop` that brings row `index` fully into view, or the current
+ * one when it already is.
+ *
+ * By offset, never by DOM query: a windowed diff usually has the row in question
+ * unmounted, so `scrollIntoView` on a `querySelector` result silently does
+ * nothing (the #68 G10 trap, restated for variable-height rows). Heights are
+ * known exactly, so this needs no measurement.
+ *
+ * An out-of-range index or an unmeasured viewport (`viewportH <= 0`, which is
+ * what jsdom and the first paint report) leaves the scroll position alone rather
+ * than jumping to 0.
+ */
+export function scrollTopForRow(
+  heights: number[],
+  index: number,
+  o: { scrollTop: number; viewportH: number },
+): number {
+  const { scrollTop, viewportH } = o;
+  if (index < 0 || index >= heights.length || viewportH <= 0) return scrollTop;
+  const top = rowOffset(heights, index);
+  const bottom = top + heights[index];
+  if (top < scrollTop) return top;
+  if (bottom > scrollTop + viewportH) return bottom - viewportH;
+  return scrollTop;
+}
+
+/**
  * Window a list of known-height rows. Returns the same shape useWindowedList
  * produces, so consumers and the `window?: WindowRange` prop are unchanged.
  */

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -506,20 +506,28 @@ export async function checkoutRef(
   return invoke<void>("checkout_ref", { repoId, reference });
 }
 
+/**
+ * Push one tag. Takes `credentials` like the other pushes: the first attempt is
+ * prompt-less and only a retry after an `Auth` failure carries a credential
+ * (#61 D5, extended to tag push in the D5 follow-up).
+ */
 export async function pushTag(
   repoId: string,
   remote: string,
   name: string,
+  credentials?: Credentials,
 ): Promise<void> {
-  return invoke<void>("push_tag", { repoId, remote, name });
+  return invoke<void>("push_tag", { repoId, remote, name, credentials });
 }
 
+/** Delete a branch on the remote (see `pushTag` for the credential contract). */
 export async function pushDeleteBranch(
   repoId: string,
   remote: string,
   name: string,
+  credentials?: Credentials,
 ): Promise<void> {
-  return invoke<void>("push_delete_branch", { repoId, remote, name });
+  return invoke<void>("push_delete_branch", { repoId, remote, name, credentials });
 }
 
 export interface StashSaveOptions {

--- a/src/screens/CommitPanel.lineFocus.test.tsx
+++ b/src/screens/CommitPanel.lineFocus.test.tsx
@@ -1,0 +1,277 @@
+// Space stages the focused diff line (#61 D7 step 5).
+//
+// D7 shipped click + shift-click line selection but no keyboard affordance,
+// because the diff pane had no per-line cursor. These tests pin the wiring end to
+// end: arrows move a visible cursor inside the diff pane, Space applies the
+// side-appropriate line op, and the index that reaches the backend is the index
+// among the hunk's CHANGED (+/-) lines — a leading context row must not shift it.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { CommitPanelScreen } from "./CommitPanel";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { useKeymapStore, useFocusStore } from "@/features/keymap";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { WithDialogs } from "@/test/dialog";
+import type { FileStatus } from "@/lib/types";
+
+const unstagedFile = (path: string): FileStatus => ({
+  path,
+  worktree: { kind: "Modified" },
+  index: { kind: "Unmodified" },
+  additions: 3,
+  deletions: 0,
+  embedded: false,
+});
+const stagedFile = (path: string): FileStatus => ({
+  path,
+  worktree: { kind: "Unmodified" },
+  index: { kind: "Modified" },
+  additions: 3,
+  deletions: 0,
+  embedded: false,
+});
+
+/**
+ * One hunk: a leading context row, then three additions.
+ *
+ * The context row is what makes this fixture worth having — it is row 1 of the
+ * hunk but carries no changedIndex, so a cursor that counted rendered rows would
+ * report 0 where the backend expects 1.
+ */
+const diffWithContextThenThreeAdditions = (path: string) => ({
+  path,
+  oldPath: null,
+  binary: false,
+  additions: 3,
+  deletions: 0,
+  hunks: [
+    {
+      header: "@@ -1,1 +1,4 @@",
+      oldStart: 1,
+      oldLines: 1,
+      newStart: 1,
+      newLines: 4,
+      lines: [
+        { kind: { kind: "Context" }, oldLineno: 1, newLineno: 1, content: "base\n" },
+        { kind: { kind: "Addition" }, oldLineno: null, newLineno: 2, content: "add1\n" },
+        { kind: { kind: "Addition" }, oldLineno: null, newLineno: 3, content: "add2\n" },
+        { kind: { kind: "Addition" }, oldLineno: null, newLineno: 4, content: "add3\n" },
+      ],
+    },
+  ],
+});
+
+const lastCall = (cmd: string) =>
+  [...getInvokeCalls()].reverse().find((c) => c.cmd === cmd);
+
+const key = (k: string) =>
+  ({
+    key: k,
+    code: "",
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    preventDefault() {},
+    target: document.body,
+  }) as unknown as KeyboardEvent;
+
+function press(k: string): boolean {
+  let handled = false;
+  act(() => {
+    handled = useKeymapStore.getState().dispatch(key(k));
+  });
+  return handled;
+}
+
+const changedRows = () => screen.getAllByTestId("diff-line-changed");
+const focusedRowIndex = () =>
+  changedRows().findIndex((r) => r.hasAttribute("data-focused"));
+
+/**
+ * Wait until the pane has stopped refetching its diff.
+ *
+ * Mounting produces more than one `get_diff`, and EVERY new diff resets the line
+ * cursor and clears the line selection by design — the indices would otherwise
+ * address a diff that no longer exists. Driving the keyboard before that settles
+ * lets a late resolution wipe the cursor mid-test, which is the shape of flake
+ * that bit `CommitPanel.lineStaging.test.tsx`.
+ */
+async function settleDiff() {
+  const count = () => getInvokeCalls().filter((c) => c.cmd === "get_diff").length;
+  let prev = -1;
+  while (prev !== count()) {
+    prev = count();
+    // One macrotask turn per pass: enough for a pending fetch to resolve and for
+    // the effect its result triggers to queue another.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+  }
+}
+
+/** `status` seeds the store AND answers get_status, so the two cannot disagree. */
+async function setup(status: FileStatus[]) {
+  resetInvokeMock();
+  useSettingsStore.setState({ ignoreWhitespaceInDiff: false });
+  useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+  useKeymapStore.getState().setPreset("rider");
+  useFocusStore.setState({
+    focused: null,
+    panes: new Map(),
+    order: [],
+    barId: null,
+    pendingContentFocus: false,
+  });
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
+    status,
+    branches: [],
+    remotes: [],
+    commits: [],
+    loading: false,
+  } as never);
+  mockInvoke("get_diff", (args) =>
+    diffWithContextThenThreeAdditions(args.path as string),
+  );
+  mockInvoke("get_status", () => status);
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("stage_lines", () => undefined);
+  mockInvoke("unstage_lines", () => undefined);
+  render(
+    <WithDialogs>
+      <CommitPanelScreen />
+    </WithDialogs>,
+  );
+  await screen.findAllByTestId("diff-line-changed");
+  await settleDiff();
+  // The pane must hold focus for its pane-scoped handlers to be delivered —
+  // clicking a line does this in the app (PGPane's onClickCapture).
+  act(() => {
+    useFocusStore.setState({ focused: "commit.diff" });
+  });
+}
+
+describe("CommitPanel diff-line focus (#61 D7 step 5)", () => {
+  describe("on the unstaged side", () => {
+    beforeEach(() => setup([unstagedFile("a.ts")]));
+
+    it("has no cursor until an arrow key moves into the lines", () => {
+      expect(focusedRowIndex()).toBe(-1);
+      press("ArrowDown");
+      expect(focusedRowIndex()).toBe(0);
+    });
+
+    it("moves the cursor down and up, skipping the context row", () => {
+      // Three selectable rows for four hunk lines: the context row is not one of
+      // them, so the cursor cannot land on it.
+      expect(changedRows()).toHaveLength(3);
+      press("ArrowDown");
+      press("ArrowDown");
+      expect(focusedRowIndex()).toBe(1);
+      press("ArrowDown");
+      expect(focusedRowIndex()).toBe(2);
+      // Clamps at the end rather than wrapping.
+      press("ArrowDown");
+      expect(focusedRowIndex()).toBe(2);
+      press("ArrowUp");
+      expect(focusedRowIndex()).toBe(1);
+    });
+
+    it("Space stages the focused line, numbered among changed lines", async () => {
+      press("ArrowDown");
+      press("ArrowDown");
+      expect(press(" ")).toBe(true);
+
+      await waitFor(() =>
+        expect(lastCall("stage_lines")?.args).toMatchObject({
+          path: "a.ts",
+          hunkIndex: 0,
+          // The SECOND addition. A cursor counting rendered rows would send 2
+          // here, because the context row sits at hunk-line 0.
+          selected: [1],
+        }),
+      );
+    });
+
+    it("Space with no cursor stages nothing and lets the chord fall through", () => {
+      expect(press(" ")).toBe(false);
+      expect(lastCall("stage_lines")).toBeUndefined();
+    });
+
+    it("Space acts on the whole line selection when the cursor is inside it", async () => {
+      const rows = changedRows();
+      fireEvent.click(rows[0]);
+      await waitFor(() =>
+        expect(screen.getByTestId("hunk-stage").textContent).toMatch(/1 line/i),
+      );
+      fireEvent.click(screen.getAllByTestId("diff-line-changed")[2], {
+        shiftKey: true,
+      });
+      await waitFor(() =>
+        expect(screen.getByTestId("hunk-stage").textContent).toMatch(/3 lines/i),
+      );
+
+      // Cursor onto the middle line, which the range selection covers.
+      press("ArrowDown");
+      press("ArrowDown");
+      press(" ");
+
+      // Same rule as Space on the file list, which acts on the whole
+      // multi-selection when the row is part of it.
+      await waitFor(() =>
+        expect(lastCall("stage_lines")?.args).toMatchObject({ selected: [0, 1, 2] }),
+      );
+    });
+
+    it("Space acts on the focused line alone when it is outside the selection", async () => {
+      fireEvent.click(changedRows()[0]);
+      await waitFor(() =>
+        expect(screen.getByTestId("hunk-stage").textContent).toMatch(/1 line/i),
+      );
+
+      press("ArrowDown");
+      press("ArrowDown");
+      press("ArrowDown");
+      press(" ");
+
+      await waitFor(() =>
+        expect(lastCall("stage_lines")?.args).toMatchObject({ selected: [2] }),
+      );
+    });
+
+    it("offers no cursor while whitespace is ignored", async () => {
+      fireEvent.click(screen.getByTitle("Ignore whitespace-only changes"));
+      await waitFor(() =>
+        expect(screen.queryAllByTestId("diff-line-changed")).toHaveLength(0),
+      );
+      // Same gate as the click path: these indices would not address what git
+      // applies (#61 D2).
+      expect(press(" ")).toBe(false);
+      expect(lastCall("stage_lines")).toBeUndefined();
+    });
+  });
+
+  describe("on the staged side", () => {
+    beforeEach(() => setup([stagedFile("a.ts")]));
+
+    it("Space unstages the focused line", async () => {
+      press("ArrowDown");
+      press("ArrowDown");
+      expect(press(" ")).toBe(true);
+
+      await waitFor(() =>
+        expect(lastCall("unstage_lines")?.args).toMatchObject({
+          path: "a.ts",
+          hunkIndex: 0,
+          selected: [1],
+        }),
+      );
+      // Direction comes from the row's side, exactly as the hunk header's button
+      // decides it — never from staging twice.
+      expect(lastCall("stage_lines")).toBeUndefined();
+    });
+  });
+});

--- a/src/screens/CommitPanel.lineStaging.test.tsx
+++ b/src/screens/CommitPanel.lineStaging.test.tsx
@@ -47,6 +47,9 @@ const diffWithThreeAdditions = (path: string) => ({
   ],
 });
 
+/** The hunk button's label, which is how a line selection becomes observable. */
+const selCountLabel = () => screen.getByTestId("hunk-stage").textContent ?? "";
+
 const stageLinesCall = () =>
   [...getInvokeCalls()].reverse().find((c) => c.cmd === "stage_lines");
 const stageHunkCall = () =>
@@ -82,6 +85,12 @@ describe("CommitPanel line-level staging (#61 D7)", () => {
     expect(rows).toHaveLength(3); // the context line is not selectable
 
     fireEvent.click(rows[1]); // second addition → changed index 1
+    // Wait for the selection to be observable before acting on it. The selection
+    // deliberately clears whenever `diff` changes, and the mount's diff fetch can
+    // still settle here; clicking Stage in the same tick then finds an empty
+    // selection and falls back to stage_hunk, so stage_lines is never called.
+    // Same reason the toggle-off case below waits between its two clicks.
+    await waitFor(() => expect(selCountLabel()).toMatch(/1 line/i));
     fireEvent.click(screen.getByTestId("hunk-stage"));
 
     await waitFor(() =>
@@ -96,14 +105,28 @@ describe("CommitPanel line-level staging (#61 D7)", () => {
   it("shows the selection count on the stage button", async () => {
     const rows = await screen.findAllByTestId("diff-line-changed");
     fireEvent.click(rows[0]);
-    fireEvent.click(rows[2]);
-    expect(screen.getByTestId("hunk-stage").textContent).toMatch(/2 lines/i);
+    await waitFor(() => expect(selCountLabel()).toMatch(/1 line/i));
+    fireEvent.click(screen.getAllByTestId("diff-line-changed")[2]);
+    await waitFor(() => expect(selCountLabel()).toMatch(/2 lines/i));
   });
 
   it("extends a range on shift-click", async () => {
     const rows = await screen.findAllByTestId("diff-line-changed");
     fireEvent.click(rows[0]);
-    fireEvent.click(rows[2], { shiftKey: true });
+    // Waiting for the anchor click to land, for the same reason the toggle-off
+    // case below does: the selection deliberately clears when `diff` changes, and
+    // firing both clicks synchronously lets a pending refresh land between them —
+    // the shift-click then finds no anchor and reads as a plain click on row 2.
+    // It passed by luck until a render-timing change made it fail ~1 run in 3.
+    await waitFor(() =>
+      expect(screen.getByTestId("hunk-stage").textContent).toMatch(/1 line/i),
+    );
+    fireEvent.click(screen.getAllByTestId("diff-line-changed")[2], {
+      shiftKey: true,
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("hunk-stage").textContent).toMatch(/3 lines/i),
+    );
     fireEvent.click(screen.getByTestId("hunk-stage"));
 
     await waitFor(() =>
@@ -152,6 +175,7 @@ describe("CommitPanel line-level staging (#61 D7)", () => {
     const before = diffCalls().length;
 
     fireEvent.click(rows[0]);
+    await waitFor(() => expect(selCountLabel()).toMatch(/1 line/i));
     fireEvent.click(screen.getByTestId("hunk-stage"));
 
     await waitFor(() => expect(stageLinesCall()).toBeDefined());

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -30,7 +30,14 @@ import {
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useDensityStep, useSettingsStore } from "@/features/settings/useSettingsStore";
-import { PGPane, FocusableScroll, usePaneList, useAction } from "@/features/keymap";
+import {
+  PGPane,
+  FocusableScroll,
+  usePaneList,
+  useAction,
+  useDiffLineFocus,
+  type DiffLineTarget,
+} from "@/features/keymap";
 import { stageablePaths } from "@/features/repo/ops";
 import {
   currentBranch,
@@ -52,7 +59,7 @@ import {
 } from "@/lib/selection";
 import { getDiff, getLogPage } from "@/lib/tauri";
 import { useDiffSyntax } from "@/lib/syntax";
-import { flattenDiffRows, windowVariable } from "@/lib/diffRows";
+import { flattenDiffRows, scrollTopForRow, windowVariable } from "@/lib/diffRows";
 import { useViewportH } from "@/lib/useViewportH";
 import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
 import {
@@ -565,6 +572,62 @@ export function CommitPanelScreen() {
     clearLineSel();
   }, [selected?.path, selected?.side, diff, clearLineSel]);
 
+  // ── Line-level keyboard focus (#61 D7 step 5) ────────────────────────────
+  // Scroll BY OFFSET: the focused row is usually not mounted in a windowed diff,
+  // so a DOM query would find nothing and arrow keys would stop scrolling with no
+  // error (#68 G10). clientHeight is read live so the callback's identity does
+  // not change with the viewport — usePaneList's scroll effect depends on it.
+  const scrollDiffRowIntoView = React.useCallback(
+    (rowIndex: number) => {
+      const el = diffScrollRef.current;
+      if (!el) return;
+      el.scrollTop = scrollTopForRow(heights, rowIndex, {
+        scrollTop: el.scrollTop,
+        viewportH: el.clientHeight,
+      });
+    },
+    [heights],
+  );
+
+  /**
+   * Space on the focused line, staging on the unstaged side and unstaging on the
+   * staged side — the same direction rule the hunk header's button uses.
+   *
+   * Acts on the whole line selection when the focused line is part of it, exactly
+   * as Space on the file list acts on the whole multi-selection when the row is
+   * part of it. Otherwise it acts on the focused line alone, so Space is useful
+   * without selecting anything first.
+   */
+  const toggleFocusedLine = React.useCallback(
+    (t: DiffLineTarget) => {
+      if (!selected) return;
+      const inSelection = (lineSel[t.hunkIndex] ?? []).includes(t.changedIndex);
+      // One index space throughout: whether it came from the selection or from
+      // the cursor, every element is a changedIndex.
+      const targets = inSelection ? lineSel[t.hunkIndex] : [t.changedIndex];
+      const store = useRepoStore.getState();
+      if (selected.side === "staged") {
+        store.unstageLines(selected.path, t.hunkIndex, targets);
+      } else {
+        store.stageLines(selected.path, t.hunkIndex, targets);
+      }
+      clearLineSel();
+    },
+    [selected, lineSel, clearLineSel],
+  );
+
+  const lineFocus = useDiffLineFocus({
+    paneId: "commit.diff",
+    rows,
+    // Same trigger as the selection clear above: a refetched diff renumbers.
+    resetKey: diff,
+    // Ignore-whitespace rewrites hunk boundaries, so neither the mouse nor the
+    // keyboard may address lines through indices git would not honor (#61 D2).
+    disabled: !!hunkActionsDisabled,
+    scrollToRow: scrollDiffRowIntoView,
+    onToggle: toggleFocusedLine,
+  });
+
   const headBranch = currentBranch(branches);
   const defaultRemote = remotes[0] ?? null;
 
@@ -1030,6 +1093,7 @@ export function CommitPanelScreen() {
                 onToggleHunk={toggleHunk}
                 selectedLines={(i) => lineSel[i] ?? []}
                 onLineClick={onLineClick}
+                focusedRow={lineFocus.focused?.rowIndex ?? null}
                 hunkActions={(i) => ({
                   staged: selected?.side === "staged",
                   actionsDisabledReason: hunkActionsDisabled,


### PR DESCRIPTION
Closes the two follow-ups #61 recorded in prose rather than as items. Tier 0–2 is otherwise complete, so this is the last work before that issue can close. **Do not close #61 from this PR** — the orchestrator does that.

## 1. `push_tag` / `push_delete_branch` run credential-less (#61 D5, sites five and six)

D5 (#94) threaded the four network sites its spec named. These two were explicitly deferred in the plan (`…-pr3-credentials-signing.md:767`) and against an authenticated remote they simply failed with git's stderr and no way to answer it.

Both commands now take `credentials: Option<Credentials>` and go through `run_git_creds` → `net::run_git_authenticated`, so they reuse the *existing* classification (`classify_auth_failure`), scrubbing (`scrub_credentials`), askpass shim, and approve/reject path. No second auth path. `useRepoStore.pushTag` / `.pushDeleteBranch` wrap their closures in the module-private `withAuthRetry`, with `refreshAll()` inside the closure per the store convention, so the credential dialog appears for a tag push and a remote-branch delete exactly as it does for push/pull/fetch/clone.

**No `lib.rs` change** (both commands were already registered) and **no UI call-site change** — `context-menu.tsx:915,1042`, `Branches.tsx:950` and `palette/commands.ts:395` all already went through the store, and credentials come from the dialog rather than the caller.

### The security review's three findings, checked against the new call sites

| Finding | Status at these sites |
|---|---|
| userinfo split on the *first* `@` leaking part of a password | Not reintroduced — scrubbing is `map_git_failure`'s, unchanged, `rfind('@')`. New test asserts a token in a `push --delete` stderr (which echoes the URL twice) is gone. |
| unescaped values injected into git's line-based credential protocol | Not reintroduced — these sites never touch `credential_approve`; "remember" still routes through the one `remember_credential` command, which refuses newlines. |
| an oid passed straight to `git show`, where a leading `-` reads as an option | **This one was live here** — fixed, see below. |

**Argument injection, fixed.** Both commands built `["push", remote, name]` with no end-of-options separator, and both values reach them from a `pgPrompt` or a ref list. `git push --receive-pack=<program>` names a program git runs for the transport, so a hostile value is not merely a confusing error. New `push_tag_args` / `push_delete_args` emit `--`, with `--delete` (ours) ahead of it. Verified against git 2.50.1:

```
$ git push --dry-run origin --receive-pack=/bin/false
fatal: The current branch main has no upstream branch.      # value eaten as an option

$ git push --dry-run -- origin --receive-pack=/bin/false
error: src refspec --receive-pack=/bin/false does not match any   # value is a refspec
```

**`push_args` deliberately does not get one.** Its force flag is documented (and tested) as coming *last*, which `--` would turn into a refspec. Listed under Gaps.

### Tests
- `commands/branches.rs` inline mod: `push_tag_args_end_options_before_the_user_values`, `push_delete_args_keep_delete_before_the_separator`, and `a_dash_leading_value_lands_after_the_separator_not_as_an_option` (asserts position, over all four remote/name × command combinations).
- `tests/auth_env.rs`: `a_failed_tag_push_is_an_auth_challenge_not_a_network_error` and `a_failed_branch_delete_scrubs_the_token_out_of_its_remote_url` — the stderr *these* ops produce names a refspec, unlike the fetch/pull phrasings already covered.
- `useRepoStore.pushAuth.test.ts`: 12 tests (6 × both ops via `describe.each`) — challenge raised instead of a dead-end error, retry carries the credential into the same op while attempt 1 stays prompt-less, remember only after success, remember on HTTPS success, never remember an SSH passphrase, non-auth failure surfaces without prompting.

## 2. `Space` toggles the focused diff line (#61 D7, the never-landed step 5)

New `useDiffLineFocus` (`src/features/keymap/`) sits beside `useHunkNav` as the diff pane's *line* cursor. Wired into `CommitPanel`'s `commit.diff` pane — the only surface D7 gave line staging at all.

### The index-space contract (read this before reviewing)

`DiffLineTarget` carries **two** numbers and they are not interchangeable:

- `rowIndex` — index into the flat `DiffRow[]`. What the focus ring and `scrollTopForRow` address. **No backend op accepts it.**
- `changedIndex` — index among the hunk's changed (`+`/`-`) lines. The only value `stage_lines` / `unstage_lines` / `discard_lines` accept, matching libgit2's `Patch::line_in_hunk`.

It is **read straight off the row**, where `flattenDiffRows` already put it — no second index space is introduced, and nothing derives one from the other. The cursor walks changed lines only: context and whole-file `fill` rows are unstageable, and skipping them is exactly what keeps one mapping instead of two. In the fixture with a leading context row the three changed rows sit at flat rows 2, 4, 5 while reporting changed indices 0, 1, 2 — asserted directly.

### Design decisions worth knowing

- **`diff.toggleLine` is its own catalog action sharing `Space` with `list.toggle`.** Legal and safe: the dispatcher's reverse map is `chord → ActionId[]` and tries each id in turn, and both are pane-scoped, so the pane filter picks exactly one. `presets.test.ts` only forbids two *global* actions on one chord. Its own entry means the cheat sheet says "Diff / Stage / unstage focused line" rather than hiding a diff action under "Lists & trees", and the two can be rebound apart. Order-independent: whichever id is tried first declines when its pane is not focused.
- **`usePaneList` supplies the arrows**, so line nav *is* the preset's list-nav actions; `onToggle` is deliberately omitted so its `list.toggle` registration declines and falls through to `diff.toggleLine`.
- **Space applies, it does not merely select.** The plan's step-5 sketch said "toggles the focused line"; this makes it stage/unstage, matching `Space` on the file list, which stages the row rather than selecting it. Direction comes from the row's side (unstage on staged, stage on unstaged), same rule as the hunk header's button. When the cursor is inside the hunk's line selection it acts on the whole selection — again mirroring the file list, which acts on the whole multi-selection when the row is part of it.
- **No fight with F7.** Different actions, different chords, different cursors. `CommitPanel` never called `useHunkNav` in the first place, so there is not even a shared pane.
- **Bare `Space` stays suppressed in inputs** (no `allowInInput`), so the commit-message textarea still types a space.
- **Cursor starts at −1** (no ring until you ask for one) and **declines Space** until it has moved; it resets on a new `diff` and drops itself if a shrinking diff leaves it past the end.
- **Ignore-whitespace zeroes the cursor**, the same gate the click path honors (#61 D2) — the keyboard must not reach what the mouse cannot.
- **Scroll by offset, not DOM query** (`scrollTopForRow`): the focused row is usually unmounted under windowing, so `querySelector` + `scrollIntoView` silently does nothing (the #68 G10 trap). It no-ops for an out-of-range index or an unmeasured viewport instead of yanking the pane to the top.
- **Geometry untouched.** The ring is an `outline` with negative `outlineOffset`, so the row keeps its `var(--diff-row-h)` pitch and the variable-height window arithmetic stays in step. No new list-row surface, so no `var(--row-step)` opt-in is due; diff line geometry stays owned by `--lh-code` / `--diff-row-h`.

### Tests
- `useDiffLineFocus.test.tsx` — 11 tests: `diffLineTargets` numbering (context skipped, per-hunk restart with rising row index, `fill` rows skipped, collapsed hunk empty), no cursor until an arrow, cross-hunk movement + clamping, Space reports the focused target and declines without one, silence while another pane has focus, no cursor while disabled, scrolling addresses the **row** index, and a shrinking diff dropping a stale cursor.
- `CommitPanel.lineFocus.test.tsx` — 8 tests: cursor appears only on an arrow, moves down/up skipping the context row and clamping, **Space stages the focused line as `selected: [1]`** (a row-counting cursor would send 2), Space with no cursor stages nothing, Space acts on the whole selection when inside it and on the focused line alone when outside, no cursor while whitespace is ignored, and — on the staged side — **Space unstages** with `stage_lines` never called.
- `diffRows.test.ts` — 6 tests for `scrollTopForRow` including the out-of-range, unmeasured-viewport and mixed-height cases.

### E2E
Re-read the specs this could touch; all stay valid, no spec edits.
- `keymap.e2e.ts:239` "commit panel: Space stages the selected file" clicks a change row, which focuses `commit.files` — `list.toggle` still claims Space there; the new handler is scoped to `commit.diff`.
- `keymap.e2e.ts:494` F7 hunk nav runs on the Diff screen, where nothing was wired.
- Pane-traversal hop counts are unchanged — no new pane.
- `history-diff.e2e.ts:89` `hunk-stage` on the Files screen is untouched.

## A pre-existing flake fixed in passing

`CommitPanel.lineStaging.test.tsx` fired a click and then acted on the selection in the same tick, while the mount's diff refetch — which clears the selection *by design* — was still settling. Measured, not assumed:

| | full-suite runs failing |
|---|---|
| `origin/main` (76ab765) | **2 / 10** (`stages only the clicked line`) |
| this branch | **0 / 15** |

Three cases now wait for the selection to become observable, the way the same file's toggle-off case already did after the D7 review. My new `CommitPanel.lineFocus` setup additionally waits for `get_diff` to stop refetching, since every new diff resets the line cursor.

## CLAUDE.md

Three additions: a `### Network ops and credentials (#61 D5)` section (one runner / six sites, retry-not-prompt, scrub-first, secrets-in-env, the `--` rule and `push_args`' exception, the newline refusal); the two-cursors/two-index-spaces + scroll-by-offset rules under `### Diff rendering`; and the "two pane-scoped actions may share a chord, two global ones may not" rule under the navigation model. Plus `features/auth/` and `useDiffLineFocus` in the architecture map.

## Verification

Run in this worktree, on the final commit:

| Gate | Result |
|---|---|
| `pnpm tsc --noEmit` | clean |
| `pnpm exec tsc -p e2e/tsconfig.json --noEmit` | clean |
| `pnpm test --run` | **143 files, 1040 tests, all passing** (was 1003 on main → +37) |
| `cargo test` | **41 binaries, 374 tests, 0 failed, 0 warnings** |
| `pnpm vite build` | clean |
| full-suite repeat runs | 15 consecutive, 0 CommitPanel failures |

`pnpm test:e2e:docker` was **not** run — five agents were compiling concurrently against the 8GB Docker VM, which OOM-kills rustc. `e2e-linux` on this PR is the gate.

## Gaps

- **No e2e for the auth path.** Unchanged from D5 and still deliberate: it needs a real authenticated remote. The new coverage is unit + component + Rust integration.
- **`fetch` / `pull` / `push` still lack the `--` separator.** Same argument-injection surface (their remote also comes from the UI), but `push_args` documents and tests its force flag as coming last, and `--` would reparse it as a refspec. Fixing it means reordering that builder and updating `force_flag_comes_last` — a separate change, not smuggled into this one.
- **`push_tag` pushes a bare tag name, not `refs/tags/<name>`.** Pre-existing. A tag and branch sharing a name makes the refspec ambiguous and git errors out. `--` fixes the option-injection half; fully qualifying the refspec is a behavior change with its own test surface.
- **Escape-clears-`lineSel` is still missing.** It is the other half of plan step 5 and was written, then removed: `app.closeOverlay` is a *global* action whose mounted handlers run *before* the catalog's default runner, so a pane handler would steal Escape from an open modal (the create dialog, the update panel). `usePaneList` works around this by hard-coding palette/cheat-sheet checks; replicating that here would duplicate overlay knowledge in a third place. It wants a general overlay-precedence mechanism, not a fourth copy.
- **Line focus is wired only into `CommitPanel`.** `DiffViewer` and `RepoBrowser` render `PGWindowedDiff` without `selectedLines`/`onLineClick` — D7 never gave them line staging — so a cursor there would have nothing for Space to do and would be a bare ring. The hook is generic and takes a `paneId`, so wiring them is only worth doing alongside line staging for those surfaces.
- **One unrelated flake observed:** `MergeWindow.test.tsx > CRLF multi-line conflict` failed 1 of 15 full-suite runs on this branch. Independent of this change — it exercises `mergeModel`/CM6, none of which is touched, and it passes 12/12 in isolation on both this branch and `origin/main`. Recording it rather than leaving it unmentioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3Pnr6uVf6pgYbZXh65hVU
