### PR TITLE
feat(repo): multi-repo tabs (#90)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ Recent specs/plans (for context on current direction):
 - `2026-08-14-forge-integration-*` — PR/MR integration for GitHub + GitLab (#92 / #61 D11):
   remote→forge detection, per-host API token under its OWN credential key, list /
   open / checkout / create, `pulls` screen.
+- `2026-08-14-multi-repo-tabs-*` — N repositories open in tabs; `useRepoStore`
+  holds only the ACTIVE tab's slice, `useTabsStore` owns the open set (#90).
 - `2026-08-14-conflict-flow-*` — no Conflicts screen; `repoState`-driven operation bar; resolver window owns the conflicted-file list (#108).
 - `2026-08-10-clone-init-*` — clone (streaming progress) + init repository (#61 D3/D4).
 - `2026-07-07-merge-resolver-window-*` — Rider-style separate merge window (#25 pt 2); per-conflict keyboard side selection, editable CM6 result pane.
@@ -185,6 +187,15 @@ Four layers, each run independently:
     project skill** (`.claude/skills/e2e-testing/SKILL.md`) — selector
     conventions and traps, driver-bridge/5s-penalty rules, native-dialog
     stubbing, fixture geometry gotchas, rebuild discipline, debugging flow.
+  - Opening a SECOND repository in e2e goes through `seedOpenRepos()`
+    (`pg-open-repos` + a reload), never the `+` button or ⌘O: those raise the
+    real OS folder picker, which WebDriver cannot drive. Match a tab with
+    `repoTab(path)`, which keys on the path's TAIL — `open_repo` returns the
+    canonicalised workdir, and on macOS `tmpdir()`'s `/var/folders/…` comes back
+    as `/private/var/folders/…`.
+  - `reopenRepo()` reloads WITHOUT clearing localStorage, so the session restore
+    may already have the repository open; it waits for the branch chip OR the
+    recent-repo row and only clicks the row when there is one.
   - `stubNativeDialogs()` keeps its name and options but no longer stubs
     natives: since #61 C3 confirms/prompts are real in-page modals
     (`[data-pg-dialog]`, `data-pg-dialog-kind`), so it installs an observer
@@ -316,8 +327,9 @@ git/
 │                they cannot drive
 └── signature.rs Author/committer signature helpers
 commands/        Thin Tauri handlers, one file per area:
-├── repo.rs        open_repo, trust_repo_path, get_status, list_all_files,
-│                  read_file_content, append_gitignore, open_in_editor
+├── repo.rs        open_repo, close_repo, trust_repo_path, get_status,
+│                  list_all_files, read_file_content, append_gitignore,
+│                  open_in_editor
 ├── cli.rs         take_launch_intent, cli_shim_status, install_cli_shim
 ├── commits.rs     get_log, commit, file_history. The `refspec` arg takes the
 │                  `REFSPEC_ALL` sentinel ("--all", git's own spelling) meaning
@@ -362,12 +374,16 @@ commands/        Thin Tauri handlers, one file per area:
 main.tsx             Entry point
 App.tsx              Thin wrapper around <AppShell />
 AppShell.tsx         Primary shell: titlebar (branch chip + picker, remote buttons),
-                     activity bar (screen switcher), status bar, error banner, settings
+                     repository tab strip, activity bar (screen switcher), status
+                     bar, error banner, settings. Also owns the per-tab screen
+                     (restore on switch) and keys the screen subtree by the
+                     active repository so a switch REMOUNTS it
 store.ts             Re-export hub (keep thin — no global Zustand composition)
 
 design/              In-house design system (NOT components/ui/). Exports via design/index.ts.
 ├── primitives.tsx       PGButton, PGIconButton, etc.
-├── chrome.tsx           PGTitlebar, PGActivityBar, PGStatusBar, PGStatusItem
+├── chrome.tsx           PGTitlebar, PGTabStrip (repository tabs), PGActivityBar,
+│                        PGStatusBar, PGStatusItem
 ├── git-components.tsx   Git-specific UI bits
 ├── icons.tsx            Icon set (name-based <PGIcon>), incl. file-type glyphs
 ├── context-menu.tsx     Context menu primitive
@@ -385,14 +401,24 @@ screens/             One screen per activity-bar item + modal-ish deep views:
   Worktrees, Settings
                      There is deliberately NO Conflict screen (#108): conflicts
                      are announced by OperationBar and resolved in the merge
-                     window. A retired screen id must also be dropped from
-                     AppShell's RESTORABLE set, or `pg-screen` restores it.
+                     window. Nothing restores a screen from localStorage any
+                     more, so retiring an id is just deleting it — but each TAB
+                     remembers its screen for the session (see the navigation
+                     model).
 
 features/            Per-feature: components + Zustand store colocated
-├── repo/            useRepoStore (the big one), useRecentsStore, ops (shared
-│                    keymap/palette/titlebar runners), OperationBar (the
-│                    `repoState !== "Clean"` bar under the titlebar: what
-│                    operation is open, conflicts left, Resolve/Finish/Abort)
+├── repo/            useRepoStore (the big one — but only ever ONE repository's
+│                    state: the active tab's), repoSlice (RepoSlice /
+│                    REPO_SLICE_KEYS / emptySlice — the multi-repo anti-leak
+│                    contract), repoActivity (RepoActivity, split out so
+│                    repoSlice needn't import the store), tabs.ts (pure tab-list
+│                    reducers, `labelTabs`, `pg-open-repos` persistence),
+│                    useTabsStore (the open set + activate/close/cycle + lazy
+│                    session restore), RepoTabs (the strip's wiring + its context
+│                    menu), useRecentsStore, ops (shared keymap/palette/titlebar
+│                    runners), OperationBar (the `repoState !== "Clean"` bar under
+│                    the titlebar: what operation is open, conflicts left,
+│                    Resolve/Finish/Abort)
 ├── nav/             useNavStore — cross-screen intents (diff-file, commit-vs-wt,
 │                    file-history, blame, rebase-plan, stash-diff)
 ├── branches/        BranchChip (titlebar), BranchPicker (popover)
@@ -482,8 +508,9 @@ features/            Per-feature: components + Zustand store colocated
 │                    LfsDiffNotice (what all four diff surfaces render instead of
 │                    pointer text) (#93)
 └── cli/             useCliLaunch — takes the stashed first-launch intent +
-                     listens for forwarded `cli-launch` events, drives
-                     openRepo + nav screen-switch intent
+                     listens for forwarded `cli-launch` events, opens/focuses a
+                     TAB (`useTabsStore.openRepo`, so a forwarded `pgit <path>`
+                     no longer evicts the current repo) + nav screen-switch intent
 
 lib/
 ├── tauri.ts         Typed invoke() wrappers — frontend NEVER calls invoke() directly
@@ -516,7 +543,9 @@ lib/
 ├── tree.ts          buildStatusTree / buildStatusList — SAME row keys, which is
 │                    what makes the tree⇄flat toggle free of per-mode branches
 ├── useTreeViewMode.ts  Persisted tree|flat preference, one key per surface
-└── recents.ts       Recent-repo persistence
+└── recents.ts       Recent-repo persistence (`pg-recent-repos`). The OPEN set is
+                     a separate key, `pg-open-repos`, in features/repo/tabs.ts —
+                     recents are where you have been, the open set where you are
 ```
 
 ### Diff rendering
@@ -579,7 +608,33 @@ lib/
 
 - Activity bar = primary screen switcher, History first. **Launch always lands
   on History** — there is no screen restore (the old `localStorage["pg-screen"]`
-  read AND write are gone; nothing else uses the key).
+  read AND write are gone; nothing else uses the key). A tab restored from
+  `pg-open-repos` is created on History too, so the open set persisting does not
+  resurrect screen restore.
+- **Repositories are tabs (#90).** The strip is its own row below the titlebar
+  (`PGTabStrip`, wired by `features/repo/RepoTabs`), rendered only when a
+  repository is open. Opening a repository ANYWHERE — ⌘O, a recents row, a clone,
+  an init, a forwarded `pgit …` — goes through `useTabsStore.openRepo`, which
+  focuses the existing tab for that path or adds one. `useRepoStore.openRepo` no
+  longer exists; the low-level half is `openRepoAt`.
+- **Each tab remembers its own screen, within the session only.** `enterScreen`
+  writes it (`useTabsStore.rememberScreen`); an effect on `activePath` restores
+  it, skipping first mount. Selections and scroll are NOT preserved: the screen
+  container is keyed by the active repository, so a switch remounts it. That is
+  deliberate — a retained selected-oid or selected-path from another repository
+  would render the wrong thing, or diff it.
+- **Tab chords** (`features/keymap`): `tab.next`/`tab.prev` (`Ctrl+Tab` /
+  `Mod+Tab`, both spellings so one table works on every platform),
+  `tab.close` (`Ctrl+W` / `Mod+W`), `tab.select` (`Alt+1`…`Alt+9` — one action
+  bound to nine chords, reading its digit from the chord the dispatcher passes to
+  `run`), `tab.switch` (`Mod+E`, the palette's repository switcher). The strip is
+  chrome, not a `PGPane` — it stays out of the `Alt+Arrow` spatial graph, like the
+  titlebar and status bar.
+- **`tab.select` carries `suppressInInput`, and must keep it.** `hasRealModifier`
+  makes every `Alt+…` chord dispatch while typing, but ⌥+digit IS a character on
+  macOS — and on Nordic layouts one people type — so claiming it would silently
+  eat keystrokes in the commit box. Same opt-out `pane.focus*` uses for ⌥←/⌥→.
+  Any future bare-`Alt`+printable binding needs the same flag.
 - **Screen entry focuses the screen's primary pane.** One `<PGPane primary>` per
   screen (History's commit list, Files' tree, …) declares it; `useFocusStore`
   holds it as `primaryId`, and it outranks both mount order and geometry for two
@@ -677,6 +732,43 @@ lib/
 
 ### State management
 - **Zustand per-feature**, not one big global store. `useRepoStore` lives in `features/repo/` because that's who owns the state.
+- **`useRepoStore` holds exactly ONE repository's live state: the active tab's**
+  (#90). `useTabsStore` owns the open set and freezes each inactive tab's slice;
+  switching is snapshot → hydrate → `refreshAll`. Screens keep reading
+  `s.status` / `s.commits` / `s.branches` and calling the same actions — they
+  never learn there is more than one repository open. Consequence: a background
+  tab's data is frozen at the moment you left it (no N-way log walks); its badge
+  is re-read on window focus by `refreshBadges`.
+- **Hydration is a TOTAL write, and `REPO_SLICE_KEYS` is what makes it one.**
+  `features/repo/repoSlice.ts` declares every non-function field of the store;
+  `repoSlice.test.ts` derives the live keys at runtime and fails if they diverge.
+  **A new per-repo store field must be added to `RepoSlice`/`emptySlice`** or
+  hydration silently degrades to a patch and the previous repository's value
+  survives into the next tab. `emptySlice()` is also the store's initial state and
+  what `closeRepo()` resets to — one definition, not three.
+- **Every fetch/error write in `useRepoStore` goes through `setFor(repoId, …)` /
+  `setErrorFor(repoId, …)`.** A switch is atomic but the requests in flight are
+  not: an unguarded `refreshAll` for repo A can resolve after the user moved to B
+  and write A's status, log and branches into B's slice. Same idea as the existing
+  `logRef`/`commitFilter` staleness guards, on repo identity. `useTabsStore`
+  carries the matching `activationSeq` guard for its own awaits.
+- **The dependency runs one way: `useTabsStore` → `useRepoStore`.** Don't import
+  the tab store from the repo store; the pure halves (`tabs.ts`, `repoSlice.ts`)
+  exist so neither needs to.
+- **Closing a tab evicts the repository backend-side** (`close_repo`). `open`
+  mints a fresh `RepoId` per call and nothing else removes an entry, so without
+  it every open leaks a `git2::Repository` and its file handles for the process
+  lifetime. Closing an unknown or already-closed id is a silent success by
+  contract; `close` deliberately leaves the `rebases` map alone (rehydratable
+  from `.git/platypusgit-rebase.json`).
+- **Closing a tab the merge resolver is using confirms first, then closes the
+  resolver, then evicts.** The resolver is a separate window driving IPC with that
+  `RepoId`, so evicting underneath it would fail its next call with `UnknownRepo`
+  mid-resolution. `mergeWindowHoldsRepo` / `closeMergeWindow`
+  (`features/merge/openMergeWindow.ts`) own that handshake — the latter waits for
+  the window label to disappear, because `close()` resolves when the request is
+  delivered, not when the window is gone. A live resolver this page instance
+  cannot attribute (main reloaded under it) counts as a match on purpose.
 - **Danger-op error paths refresh first, set error last.** In `useRepoStore` catch arms (see `mergeBranch`), call `refreshAll()` BEFORE `set({ error })`: `refreshAll` starts with `set({ error: null })`, and React 18 batches same-tick sets, so the opposite order silently wipes the banner. `refreshAll` never rethrows, so the error always wins when set last. A failed git op must still refresh — the UI reflects disk truth even on error.
 - `useNavStore` handles cross-screen navigation intents — add new `NavIntent` kinds there, route in `AppShell`.
 - Cross-feature state is rare; compose in `src/store.ts` if needed — don't hoist prematurely.
@@ -829,7 +921,7 @@ lib/
   the first bad commit rather than let the user read a sha off the titlebar.
 
 ### Async / threading (Rust)
-- `git2::Repository` is `Send` but not `Sync`. `Libgit2Backend` holds each opened repo as `Mutex<Repository>` inside a `Mutex<HashMap<RepoId, ...>>`.
+- `git2::Repository` is `Send` but not `Sync`. `Libgit2Backend` holds each opened repo as `Mutex<Repository>` inside a `Mutex<HashMap<RepoId, ...>>`. Several repositories are genuinely open at once (multi-repo tabs); `close` is the only thing that removes an entry.
 - Always wrap git2 work in `spawn_blocking` from Tauri commands — don't block async runtime.
 
 ### Styling

--- a/docs/superpowers/plans/2026-08-14-multi-repo-tabs-plan.md
+++ b/docs/superpowers/plans/2026-08-14-multi-repo-tabs-plan.md
@@ -1,0 +1,225 @@
+# Multi-repo tabs — implementation plan
+
+**Goal:** N repositories open at once in one window. `useRepoStore` keeps holding
+exactly one repository's live state — the active tab's — and a new
+`useTabsStore` owns the open set plus a frozen slice per inactive tab. Switching
+snapshots the outgoing slice, hydrates the incoming one, and refreshes. Every
+screen keeps reading the active repo through the API it already uses.
+
+**Architecture:** Mostly frontend. One new backend trait method + command
+(`close_repo`) so a closed tab stops leaking a `git2::Repository` — `open` mints
+a fresh UUID and never evicts today. Two new pure modules carry the risky logic
+(`repoSlice.ts` = the anti-leak contract, `tabs.ts` = list reducers +
+persistence), so the store code stays thin and the invariants are unit-testable.
+
+**Tech Stack:** React 18 + Zustand, Tauri 2 multi-window, vitest/RTL,
+WebdriverIO e2e in Docker.
+
+**Design doc:** `docs/superpowers/specs/2026-08-14-multi-repo-tabs-design.md`
+**Issue:** [#90](https://github.com/jonassaa/platypusgit/issues/90)
+
+## Global Constraints
+
+- Zustand **per feature**. `useTabsStore` lives in `features/repo/` next to the
+  store it drives; it must not absorb `useRepoStore`'s fields.
+- Dependency direction is **one way**: `useTabsStore` → `useRepoStore`. No cycle.
+  `useRepoStore` imports nothing from the tabs store.
+- Frontend never calls `invoke()` directly — typed wrapper in `src/lib/tauri.ts`.
+- Never `window.confirm`/`window.prompt` — `pgConfirm`/`pgPrompt` from `@/design`.
+  Component tests rendering a confirm need `WithDialogs` from `@/test/dialog`.
+- UI primitives from `@/design`, re-exported via `design/index.ts`. The tab strip
+  is **chrome**: fixed height, no `var(--row-step)`.
+- The fixed frame holds: the strip is `flexShrink: 0` and owns its own
+  `overflow-x: auto`. Nothing may make the document scroll.
+- Never hardcode the accent hue — `var(--accent)` / `oklch(from var(--accent) …)`.
+- Danger-op error paths refresh **before** setting `error`; the new
+  `setErrorFor` keeps that ordering.
+- `pg-screen` stays dead. Per-tab screen is session-only.
+- Run pnpm/cargo with `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"`.
+- **Do not run `pnpm test:e2e:docker`** in this pass (concurrent agents, 8GB VM).
+  CI's `e2e-linux` is the gate; specs must typecheck and their selectors must be
+  checked by reading.
+
+## File Structure
+
+**Create:**
+- `src/features/repo/repoSlice.ts` — `RepoSlice`, `REPO_SLICE_KEYS`,
+  `EMPTY_SLICE`, `sliceOf`.
+- `src/features/repo/repoSlice.test.ts`
+- `src/features/repo/tabs.ts` — `RepoTab`, list reducers, `labelTabs`,
+  `loadOpenRepos`/`saveOpenRepos`.
+- `src/features/repo/tabs.test.ts`
+- `src/features/repo/useTabsStore.ts` — the store.
+- `src/features/repo/useTabsStore.test.ts`
+- `src/features/repo/RepoTabs.tsx` — the strip's feature wiring + context menu.
+- `src/features/repo/RepoTabs.test.tsx`
+- `e2e/specs/repo-tabs.e2e.ts`
+
+**Modify:**
+- `src-tauri/src/git/mod.rs` — `GitBackend::close`.
+- `src-tauri/src/git/libgit2.rs` — implement it.
+- `src-tauri/src/git/cli.rs` — `NotImplemented` stub.
+- `src-tauri/src/commands/repo.rs` — `close_repo`.
+- `src-tauri/src/lib.rs` — register it.
+- `src-tauri/tests/repo.rs` (or the closest existing suite) — close/multi-open.
+- `src/lib/tauri.ts` — `closeRepo(repoId)` wrapper.
+- `src/features/repo/useRepoStore.ts` — slice-driven init/reset, `openRepoAt`,
+  `hydrate`, `snapshot`, `setFor`/`setErrorFor` guards; `openRepo` removed.
+- `src/design/chrome.tsx` — `PGTabStrip`, `PGTab`.
+- `src/AppShell.tsx` — render the strip, per-tab screen, keyed screen subtree,
+  restore session, "Close repo" → close tab.
+- `src/screens/Welcome.tsx`, `src/features/repo/ops.ts`,
+  `src/features/cli/useCliLaunch.ts`, `src/features/create/useCreateStore.ts` —
+  `openRepo` call sites move to the tabs store.
+- `src/features/merge/openMergeWindow.ts` — repo-guarded on-destroy refresh.
+- `src/features/keymap/actions.ts` — five `tab.*` actions; `run(chord)`.
+- `src/features/keymap/useKeymapStore.ts` — pass the chord to `run`.
+- `src/features/keymap/CheatSheet.tsx` — collapse >3 chords to `first–last`.
+- `src/features/keymap/presets.ts` — bind the five in `COMMON`.
+- `src/features/palette/commands.ts` — switch/close/close-others.
+- `src/features/cli/useCliLaunch.test.tsx`,
+  `src/features/create/useCreateStore.ownership.test.ts` — stub the new owner.
+- `e2e/support/app.ts` — `reopenRepo` tolerates a restored session; add
+  `seedOpenRepos`.
+- `CLAUDE.md` — architecture, navigation model, state conventions.
+
+---
+
+### Task 1: `close_repo` (backend)
+
+- [ ] `src-tauri/tests/` — a test that opens two repos and reads both
+      independently; a test that `close` removes the entry (next op →
+      `UnknownRepo`); a test that closing an unknown id is `Ok`.
+- [ ] `GitBackend::close(&self, repo_id: &RepoId) -> AppResult<()>`; libgit2 impl
+      `repos.remove(repo_id)` (leave `rebases` alone — see design §E); `CliBackend`
+      stub.
+- [ ] `commands::repo::close_repo`, registered in `lib.rs`, `spawn_blocking`.
+- [ ] `closeRepo(repoId)` in `src/lib/tauri.ts`.
+- [ ] `cargo test --manifest-path src-tauri/Cargo.toml`.
+
+### Task 2: `repoSlice.ts` — the anti-leak contract
+
+- [ ] `repoSlice.test.ts` first: `REPO_SLICE_KEYS` equals the store's live
+      non-function keys; `sliceOf(EMPTY_SLICE-seeded store)` round-trips;
+      `EMPTY_SLICE` has an entry for every key.
+- [ ] `repoSlice.ts`: `RepoSlice` (the 21 per-repo fields), `REPO_SLICE_KEYS`,
+      `EMPTY_SLICE`, `sliceOf(state)`.
+- [ ] `useRepoStore.ts`: initial state and `closeRepo()` both built from
+      `EMPTY_SLICE`; `applyOpenedRepo`'s reset list replaced by it. Three
+      hand-maintained copies become one.
+
+### Task 3: `useRepoStore` becomes switch-safe
+
+- [ ] `setFor(repoId, patch)` / `setErrorFor(repoId, e)` helpers; route every
+      fetch path and every action catch arm through them. Ordering convention
+      unchanged.
+- [ ] `openRepoAt(path): Promise<RepoHandle | null>` — today's `openRepo` body
+      (open, `addRecent`, reset via `EMPTY_SLICE`, `refreshAll`, dubious-ownership
+      trust retry) returning the handle instead of `void`, `null` on failure.
+- [ ] `hydrate(slice)` (total write) and `snapshot(): RepoSlice`.
+- [ ] Remove `openRepo` from the state interface. `pnpm tsc --noEmit` now lists
+      every caller — that is the point.
+- [ ] Existing store tests must pass untouched (`useRepoStore.*.test.ts`,
+      `ops.test.ts`, `cherryPickMany.test.ts`): the state shape did not change.
+
+### Task 4: `tabs.ts` — pure list logic + persistence
+
+- [ ] `tabs.test.ts` first: add dedupes by path; add-after-resolved-path merges;
+      `closeAt` picks the right neighbour (right, else left, else none); `cycle`
+      wraps both ways; `labelTabs` prefixes the parent dir only for colliding
+      names; `loadOpenRepos` tolerates garbage/missing/oversized;
+      `saveOpenRepos` caps at 20.
+- [ ] `tabs.ts`: `RepoTab`, `upsertTab`, `removeTab`, `closeNeighbour`, `cycle`,
+      `repoDisplayName`, `labelTabs`, `loadOpenRepos`, `saveOpenRepos`
+      (`pg-open-repos`).
+
+### Task 5: `useTabsStore`
+
+- [ ] `useTabsStore.test.ts` first, with `mockInvoke`:
+      - `openRepo` twice on the same path → one tab, focused.
+      - switching hydrates the incoming slice and leaves **no** field of the
+        outgoing repo behind (assert against `REPO_SLICE_KEYS`).
+      - a late `refreshAll` resolution from the previous repo does not write into
+        the new tab.
+      - a failed open leaves the previous tab active with its data.
+      - closing the active tab activates the neighbour and calls `close_repo`.
+      - closing the last tab clears the slice (Welcome) .
+      - `restoreSession` creates pending tabs and opens only the active one.
+      - `rememberScreen` survives a round trip.
+- [ ] `useTabsStore.ts`: `tabs`, `activePath`, `activationSeq`; actions
+      `openRepo`, `activate`, `close`, `closeOthers`, `closeAll`, `next`, `prev`,
+      `selectIndex`, `rememberScreen`, `refreshBadges`, `restoreSession`.
+      Persist on every mutation.
+
+### Task 6: The strip
+
+- [ ] `PGTabStrip` / `PGTab` in `design/chrome.tsx` — fixed 30px, own
+      `overflow-x: auto`, `data-testid="repo-tab-strip"`, rows
+      `data-testid="repo-tab"` + `data-path` + `data-active`, close
+      `data-testid="repo-tab-close"`, new `data-testid="repo-tab-new"`. Active tab
+      scrolled into view on change.
+- [ ] `RepoTabs.test.tsx` first: one row per tab, active marked, click switches,
+      close closes, "Close others" confirms (`WithDialogs`), dirty + conflict
+      badges render, `labelTabs` disambiguation shows through.
+- [ ] `RepoTabs.tsx`: wires `useTabsStore`, context menu (Close / Close others /
+      Close all / Copy path), `+` → `openRepoDialog`, `window` focus →
+      `refreshBadges()`.
+
+### Task 7: AppShell
+
+- [ ] Render `<RepoTabs />` between the titlebar and `OperationBar`, only with
+      tabs open.
+- [ ] Per-tab screen: `enterScreen` also `rememberScreen`s; an effect on
+      `activePath` (skipping first mount) restores the tab's screen and bumps
+      `entryTick`.
+- [ ] Key the screen container by `activePath` so per-screen local state resets
+      instead of leaking oids across repos.
+- [ ] `restoreSession()` on mount, before the CLI intent lands.
+- [ ] Titlebar "Close repo" → `useTabsStore.close(activePath)` (label kept: no
+      e2e references it, and it still closes the repo you are looking at).
+- [ ] `AppShell.screens.test.tsx` / `AppShell.screenentry.test.tsx` stay green.
+
+### Task 8: `openRepo` call-site migration
+
+- [ ] `ops.openRepoDialog`, `useCliLaunch.handleIntent`, `useCreateStore` (clone
+      + init), `Welcome.tsx` → `useTabsStore.getState().openRepo(path)`.
+- [ ] `useCliLaunch.test.tsx` and `useCreateStore.ownership.test.ts` stub
+      `useTabsStore` instead.
+- [ ] `openMergeWindow` on-destroy refresh guarded by the captured `repoId`.
+- [ ] `pnpm tsc --noEmit` clean.
+
+### Task 9: Keymap + palette
+
+- [ ] `ActionDef.run?: (chord: string) => boolean | void`; dispatcher passes the
+      resolved chord. Existing runners unchanged (they ignore it).
+- [ ] `tab.next` / `tab.prev` / `tab.close` / `tab.select` / `tab.switch` in
+      `actions.ts`, category `Repository`. `tab.select` parses its digit from the
+      chord.
+- [ ] `presets.ts`: bind all five in `COMMON` (both presets — the preset test
+      requires it). Chords per design §F.
+- [ ] `CheatSheet`: >3 chords render `first–last`.
+- [ ] `presets.test.ts` must stay green (no `Mod+Alt+<letter>`, no duplicate
+      global chord).
+- [ ] `commands.ts`: **Switch repository…** (open tabs + unopened recents),
+      **Close repository tab**, **Close other repository tabs** (confirm).
+
+### Task 10: E2E + docs + verification
+
+- [ ] `e2e/support/app.ts`: `seedOpenRepos(paths, active)`; `reopenRepo` skips the
+      recent-row click when the restored session already opened the repo
+      (otherwise every persistence spec hangs).
+- [ ] `e2e/specs/repo-tabs.e2e.ts`: two seeded tabs restore; switching changes the
+      titlebar name and the History content; `Ctrl+Tab` cycles; palette
+      **Switch repository…** lists both; closing a tab keeps the other; closing
+      the last returns to Welcome.
+- [ ] Read `open-persisted-screen.e2e.ts`, `settings.e2e.ts` and every
+      `openRepo`/`waitRepoLoaded` caller: confirm no selector moved.
+- [ ] `CLAUDE.md`: frontend tree (`useTabsStore`, `tabs.ts`, `repoSlice.ts`,
+      `RepoTabs`), backend (`close_repo`), navigation model (tabs, per-tab
+      screen, keyed remount), state-management conventions (the one-live-slice
+      rule, the `setFor` guard, the `REPO_SLICE_KEYS` contract), the new
+      localStorage key.
+- [ ] `pnpm tsc --noEmit`, `pnpm exec tsc -p e2e/tsconfig.json --noEmit`,
+      `pnpm test`, `cargo test --manifest-path src-tauri/Cargo.toml`,
+      `pnpm vite build`.
+- [ ] Squash to one Conventional Commit, push, open the PR against #90.

--- a/docs/superpowers/specs/2026-08-14-multi-repo-tabs-design.md
+++ b/docs/superpowers/specs/2026-08-14-multi-repo-tabs-design.md
@@ -1,0 +1,371 @@
+# Multi-repo tabs: one window, N open repositories
+
+**Issue:** [#90](https://github.com/jonassaa/platypusgit/issues/90) (spun out of [#61](https://github.com/jonassaa/platypusgit/issues/61) C4)
+
+## Problem
+
+`useRepoStore.current` is a single `RepoHandle`. Opening a repository *replaces*
+it — the recents row, `⌘O`, a clone, an init, and a forwarded `pgit …` launch all
+do the same destructive thing. Anyone working across two repos (app + library,
+service + infra, a review in one while committing in the other) pays a full
+reopen — backend `open`, `get_status`, `list_branches/tags/stashes/remotes`, a
+500-commit log walk, `repo_state`, `rebase_status` — every time they look at the
+other one. GitKraken, Fork and Sublime Merge all keep several repositories open
+in tabs.
+
+Three facts shape the change:
+
+1. **The backend is already multi-repo.** `Libgit2Backend` holds
+   `repos: Mutex<HashMap<RepoId, Mutex<Repository>>>` and every command takes a
+   `repo_id`. Nothing backend-side assumes one repository.
+2. **The backend also never closes one.** `open` mints `RepoId(Uuid::new_v4())`
+   and inserts; there is no `remove`, no `close_repo` command, no eviction.
+   Today that leaks one `git2::Repository` (and its open file handles / odb
+   caches) per *open*, re-opens of the same path included. With tabs the user is
+   invited to open more repositories, so the leak stops being theoretical.
+3. **`useRepoStore` is the biggest store in the app** (1428 lines, 21 state
+   fields, ~90 actions) and it is read by 34 non-test files at 199 `getState()`
+   sites plus three no-selector `useRepoStore()` subscriptions, and *seeded by 49
+   test files* via `setState`. Any change to its state shape is a change to all
+   of that.
+
+## Design
+
+### A. Store architecture: one live slice, frozen slices per tab
+
+The store keeps **exactly one repository's live state — the active tab's**. Its
+state shape, its selector API and every action signature are unchanged. What is
+new is a sibling store that owns *which* repositories are open and holds a frozen
+copy of each inactive tab's slice.
+
+```
+useTabsStore                     useRepoStore                 backend
+  tabs: RepoTab[]                  current, status, …           repos: HashMap<RepoId, …>
+  activePath                       (THE ACTIVE TAB ONLY)
+  tab.slice: RepoSlice | null  ──hydrate/snapshot──►
+```
+
+Switching tabs is: **snapshot** the live slice into the outgoing tab →
+**hydrate** the incoming tab's frozen slice into the store → `refreshAll()` so
+what you see is disk truth, not a cached view.
+
+Why this and not the two obvious alternatives:
+
+- **Not `repos: Record<RepoId, RepoSlice>` inside `useRepoStore`** (the issue's
+  own sketch). Screens read `s.status`, `s.commits`, `s.branches` directly at
+  hundreds of sites; keying the slices means either rewriting every one of them
+  or mirroring the active slice back onto the top level — two copies of the same
+  data, which is the drift bug this codebase already learned about with
+  `BranchInfo.tip`. It also doubles the store's state shape and makes it the god
+  store #90 explicitly warns against.
+- **Not a store factory per repo** (`createRepoStore(handle)` + an active-store
+  indirection). `useRepoStore` is used as a hook *and* as `useRepoStore.getState()`
+  *and* as `useRepoStore.setState()` (49 test files). Proxying all three onto a
+  swappable inner store is a shim in front of every read in the app, and the
+  tests that call `setState` before any repo exists would have nothing to target.
+
+The chosen shape costs one thing: **a background tab's data is frozen at the
+moment you left it.** That is a feature, not a regression — N repos each running
+a 500-commit log walk on every fetch is exactly the cost tabs must not add. The
+badge freshness problem is solved narrowly in §D.
+
+#### The anti-leak contract
+
+`features/repo/repoSlice.ts` (pure, no store import) declares
+`REPO_SLICE_KEYS` — the complete list of the store's **non-function** fields —
+plus `EMPTY_SLICE` and `sliceOf(state)`. `hydrate` writes *all* of them, always;
+it never patches. So the previous repo's `status` / `commits` / `branches` /
+`error` cannot survive into the next tab: there is no field a hydrate skips.
+
+A unit test derives the store's non-function keys at runtime and asserts they
+equal `REPO_SLICE_KEYS`. Adding a 22nd per-repo field without adding it to the
+slice fails that test rather than leaking silently. It also removes the three
+hand-maintained copies of the reset list that exist today (the `create()`
+initializer, `applyOpenedRepo`, `closeRepo`).
+
+#### In-flight responses (the other leak)
+
+A snapshot/hydrate switch is atomic, but the *fetches already in flight* are not.
+`refreshAll()` for repo A can resolve after the user switched to B and write A's
+`status` into B's slice. The store already guards staleness on `logRef` and
+`commitFilter`; it gains the same guard on repo identity:
+
+- `setFor(repoId, patch)` — applies only while `get().current?.id === repoId`.
+- `setErrorFor(repoId, e)` — the same guard for the error banner, so a failed op
+  in a repo you have left cannot raise a banner over the repo you are in.
+
+Every fetch path (`refreshAll`, `refreshStatus`, `refreshAllFiles`,
+`searchCommits`, `loadMoreCommits`, `setLogRef`, the three `rebase*` status
+writes) and every action catch arm routes through them. The
+"refresh-first-error-last" convention is unaffected — `setErrorFor` is still just
+a guarded `set({ error })`.
+
+`useTabsStore` carries the matching guard for its own async work: an
+`activationSeq` counter bumped on every activate/open, checked after each await,
+so two overlapping activations (session restore racing a forwarded CLI launch)
+cannot both commit.
+
+### B. Tabs
+
+```ts
+interface RepoTab {
+  /** Identity. Two tabs never share a path — a second open focuses the first. */
+  path: string;
+  /** Backend RepoId; null until the tab has actually been opened. */
+  repoId: string | null;
+  status: "pending" | "open" | "failed";
+  /** Screen this tab was last on. Session-only, never persisted. */
+  screen: string;
+  /** Frozen slice. Meaningful only for an inactive tab. */
+  slice: RepoSlice | null;
+  /** Badge counts, from the slice at snapshot time. */
+  dirty: number;
+  conflicts: number;
+}
+```
+
+**Path is the tab identity.** Opening a path that is already open focuses its tab
+instead of adding a second one — which is also what makes persistence trivial and
+kills a whole class of duplicate-tab bugs. `open` returns the *canonicalised
+workdir*, which may differ from what the user picked, so the dedupe runs twice:
+once on the requested path (fast path, no IPC) and once on the resolved path
+after a successful open (drop the newcomer, focus the incumbent).
+
+**A tab is created only after a successful open.** A failed open therefore needs
+no rollback: the store's failure path only sets `loading`/`error`, the live slice
+is untouched, and the tab you were on is still there with its data. "A failed
+open does not close the tab you were on" is a test, not a hope.
+
+**`useRepoStore.openRepo` moves to `useTabsStore.openRepo`.** It is deleted from
+the repo store, so `tsc` — not vigilance — finds every caller (`ops.openRepoDialog`,
+`useCliLaunch`, `useCreateStore` ×2, `Welcome`, two tests). What stays on the repo
+store is the low-level half it always had internally:
+`openRepoAt(path): Promise<RepoHandle | null>` (open + reset the slice + refresh +
+the dubious-ownership trust retry) and `closeRepo()` (clear the slice). The
+dependency runs one way — `useTabsStore` → `useRepoStore` — with no cycle.
+
+**Closing a tab evicts the repository backend-side** (§E). Nothing is confirmed:
+closing a tab closes a *view*, and no uncommitted work is lost by it — a confirm
+there would be a lie about the stakes. The bulk operations do confirm, because
+"Close other tabs" with six open is a click you cannot undo.
+
+**Closing the last tab** returns the window to Welcome, exactly as "Close repo"
+does today.
+
+### C. What is per-tab and what is global
+
+| Per tab | Global |
+| --- | --- |
+| The repository (`current`, `status`, `branches`, `tags`, `stashes`, `remotes`, `commits`, search + cursors, `logRef`, `repoState`, `rebaseStatus`, `activity`, `error`) | Theme + palette, UI density, zoom (`useSettingsStore`) |
+| Which screen the tab is on | Keymap preset (`useKeymapStore`) |
+| — | Pane widths / split sizes (`localStorage` per surface) |
+| — | Tree ⇄ flat view mode per surface |
+| — | Recents, update state, palette frecency |
+
+**Per-tab screen** is session-only. CLAUDE.md's rule that launch always lands on
+History and that screen restore was deliberately removed still holds: restored
+tabs are created with `screen: "history"`, `pg-screen` stays dead, and nothing
+writes it. Remembering the screen *within a session* is the thing tabs make
+necessary — leaving one tab on History and coming back to find it on Settings is
+the annoyance the removal of screen restore was about in the first place.
+
+**Per-tab selections and scroll are deliberately NOT preserved.** The screen
+subtree is keyed by the active tab path, so it remounts on every switch. That is
+what makes History's selected commit, RepoBrowser's selected file, DiffViewer's
+open diff and every windowed list's scroll offset *reset* instead of leaking the
+other repository's oids into the new tab (a selected-oid leak would render a
+"commit not found" panel at best and diff the wrong repo at worst). Switching
+A→B→A therefore loses A's selection. Recorded as a known limit, not a bug.
+
+**Pane widths stay global.** They are furniture, and per-tab furniture that
+jumps as you switch would read as a rendering bug.
+
+### D. The tab strip
+
+A dedicated row **below** the titlebar and above `OperationBar`, not inside the
+titlebar. The titlebar is already carrying the logo, repo name, branch chip,
+dirty badge, the drag region, the update chip, four network buttons and the gear;
+adding a scrolling strip to it would either shrink the drag region to nothing or
+push the buttons off a narrow window. A separate 30px row keeps
+`data-tauri-drag-region` intact and keeps the titlebar's existing e2e selectors
+(`branch-chip`, `button*=Push`, …) exactly where they are.
+
+- `PGTabStrip` + `PGTab` in `design/chrome.tsx` (chrome, so **fixed height** —
+  no `var(--row-step)`, per the density rule's chrome exemption).
+- The strip is `flexShrink: 0` with its own `overflow-x: auto`; tabs are
+  `flexShrink: 0` with a `maxWidth`. The fixed frame is preserved — the strip
+  scrolls inside itself and never widens the window. The active tab is scrolled
+  into view (`inline: "nearest"`) when it changes.
+- Rendered only when at least one tab exists, so the Welcome screen is untouched.
+- Each tab: repo name, a dirty dot with count, a conflict marker, and a close
+  affordance. Right-click gives Close / Close others / Close all / Copy path.
+- A trailing `+` opens the native folder picker (`openRepoDialog`), the same op
+  `⌘O` runs.
+- Names collide often (`api`, `web`, `docs`). `labelTabs` disambiguates by
+  prefixing the parent directory only for the names that actually collide — pure
+  function, unit-tested.
+- **Badges of inactive tabs refresh on window focus.** One `get_status` per open
+  inactive tab, on the `window` focus event only — cheap, and it covers the real
+  case (you committed in an editor, alt-tabbed back, and the other tab's dot
+  should be honest). No polling, no background log walks.
+
+The strip is chrome, not a `PGPane`: it stays out of the spatial `Alt+Arrow`
+graph, like the titlebar and the status bar. It is driven by chords and the
+palette instead.
+
+### E. Backend: `close_repo`
+
+New trait method `GitBackend::close(&self, repo_id: &RepoId) -> AppResult<()>`,
+implemented in `Libgit2Backend` as a `repos.remove(repo_id)` (dropping the
+`Repository`), stubbed `NotImplemented` in `CliBackend`, exposed as the
+`close_repo` command, called by `closeTab` best-effort (a failure is logged, not
+surfaced — the tab is going away either way).
+
+Closing is **idempotent** and closing an unknown id is **not an error**: the
+frontend may close a tab whose open failed, and turning that into an error banner
+would be noise. `with_repo` keeps returning `UnknownRepo` for *use* of a closed
+id, which is the honest answer.
+
+`close` deliberately leaves the `rebases` map alone. Its entries are keyed by a
+`RepoId` that will never be used again (a re-open mints a fresh UUID), they are
+bytes rather than file handles, and the on-disk mirror
+(`.git/platypusgit-rebase.json`) is what a re-opened repo rehydrates from — the
+path CLAUDE.md already documents and `a_restarted_app_can_still_abort` already
+pins.
+
+### F. Keyboard
+
+New actions in `features/keymap/actions.ts`, bound in **both** presets (the
+preset test requires every catalog action to have a binding in every preset):
+
+| Action | Chords | Why |
+| --- | --- | --- |
+| `tab.next` | `Ctrl+Tab`, `Mod+Tab` | The universal next-tab chord. Cross-platform by construction: on macOS `Mod+Tab` is ⌘Tab, which the OS takes and the webview never sees; on Windows/Linux physical Ctrl+Tab normalizes to `Mod+Tab` and `Ctrl+Tab` is never produced. Same trick as the existing `Ctrl+V` palette nod. |
+| `tab.prev` | `Ctrl+Shift+Tab`, `Mod+Shift+Tab` | ditto. Distinct chords from bare `Tab`/`Shift+Tab` (pane cycling), so the dispatcher cannot confuse them. |
+| `tab.close` | `Ctrl+W`, `Mod+W` | ditto. On macOS ⌘W may be claimed by Tauri's default window menu; ⌃W is the one that always reaches us. |
+| `tab.select` | `Alt+1` … `Alt+9`, **`suppressInInput`** | `Mod+1..9` is taken by screen navigation and `Mod+Alt+<digit>` is AltGr on Windows (the rule `presets.test.ts` enforces for letters applies to digits: AltGr+2/+4 type characters on Nordic layouts). Plain `Alt+<digit>` is free in both presets, and `Alt` is already this keymap's second modifier — but ⌥+digit *is a character* on macOS, and on Nordic layouts one people type, so the action carries `suppressInInput` exactly as `pane.focus*` (Alt+Arrow) does. |
+| `tab.switch` | `Mod+E` | Rider's "Recent files" chord, for the palette's repository switcher. |
+
+`tab.select` is **one** action bound to nine chords, not nine actions. That needs
+`ActionDef.run` to know *which* chord fired, so the runner signature widens to
+`run?: (chord: string) => boolean | void` and the dispatcher passes the resolved
+chord. It is additive — every existing runner ignores the argument — and it keeps
+the cheat sheet from growing nine near-identical rows. The cheat sheet also
+collapses any run of more than three chords to `first–last`, so the row reads
+`⌥1–⌥9`.
+
+`repo.open` (`⌘O`) is unchanged in name and chord but now means **open in a new
+tab**, because that is what `openRepo` now does everywhere. That is the "open
+repo in new tab" action; inventing a second one for the same behavior would be
+two rows in the cheat sheet for one key.
+
+**`tab.select` is suppressed inside text.** `hasRealModifier` treats any `Alt+…`
+chord as dispatchable while typing, which for ⌥+digit means eating a character the
+user asked for — `¡` on a US layout, and on Nordic layouts the ⌥-digit row carries
+characters people type routinely. So the action sets `suppressInInput`, the same
+opt-out `pane.focus*` uses for the macOS ⌥←/⌥→ caret jumps, and the dispatcher's
+`isEditable` covers input, textarea and contentEditable — the resolver's CodeMirror
+pane included. The cost is that repository switching by number does not work while
+a field has focus; `tab.next`/`tab.prev`/`tab.close` stay live there because their
+chords type nothing.
+
+### G. Palette
+
+- **Switch repository…** (`actionId: "tab.switch"`) — a pick step listing every
+  open tab (active one marked) *followed by* recents that are not open, which
+  open in a new tab when picked. This is also the only keyboard-reachable way to
+  open a second repository without the native folder dialog, which matters for
+  e2e: the dialog is a real OS picker there and cannot be driven.
+- **Close repository tab** (`actionId: "tab.close"`), listed only with a tab open.
+- **Close other repository tabs**, listed only with two or more, `pgConfirm`-gated.
+
+### H. Session persistence
+
+`localStorage["pg-open-repos"]` — a new key (no collision with the 20 existing
+ones), shape `{ paths: string[]; active: string | null }`, written on every tabs
+mutation, capped at 20 paths. Recents keep their own key and their own meaning:
+recents are *where you have been*, the open set is *where you are*. `openRepo`
+still calls `addRecent`, so the two stay consistent without one becoming the
+other.
+
+**Restore is lazy.** `restoreSession()` creates every persisted path as a
+`pending` tab and activates only the persisted active one; the rest open on first
+activation. Five persisted repos therefore cost one `open` + one refresh at
+launch, not five. A path that has since been deleted or moved fails its open when
+activated and its tab is marked `failed` — visible, dismissible, and not a
+startup crash.
+
+Restore runs from `AppShell` mount, before the CLI intent is handled. A forwarded
+`pgit /path` then finds the existing `pending` tab for that path and activates it
+rather than adding a duplicate.
+
+### I. CLI launch and the merge window
+
+- **A forwarded launch opens a tab.** `useCliLaunch.handleIntent` calls
+  `useTabsStore.openRepo(path)`, which focuses an existing tab or adds a new one
+  — a `pgit ~/other-repo` from a second terminal no longer evicts what you were
+  looking at. `intent.screen` still routes through `useNavStore`, and now lands
+  on the newly-focused tab because the screen switch happens after the activate.
+- **The merge window is untouched.** It is a second Tauri window with its own
+  store instance that never opens a repository; it works from `?repoId=` and
+  direct IPC wrappers, so it has no tabs, no tab strip, and no `useTabsStore`.
+  Its `merge://resolved` → `refreshAll()` path in `AppShell` still refreshes the
+  active repo, which is the repo the resolver was opened for in every reachable
+  flow. `openMergeWindow`'s on-destroy refresh gains the same repo guard as
+  everything else: it captures the `repoId` it was opened for and refreshes only
+  while that repo is still active, so closing a resolver after a tab switch no
+  longer refreshes the wrong repository.
+- **Closing a tab whose repository the resolver is using is guarded.** Since
+  `closeTab` now evicts backend-side, an unguarded close would leave the resolver
+  window issuing IPC against a dead `RepoId` mid-resolution — the one failure mode
+  this must never have. So `close` asks first, **in the main window**
+  ("Close this repository and its merge resolver?", danger, naming what is lost),
+  and on confirm calls `closeMergeWindow()`, which closes the window and **waits
+  for the label to actually disappear** before the eviction runs (`close()`
+  resolves when the request is delivered, not when the window is destroyed).
+  Declining leaves both the tab and the resolver alone.
+
+  Attribution — which repository a live resolver is on — is module state in
+  `openMergeWindow.ts`, set when the window is opened or retargeted and cleared on
+  `tauri://destroyed`. A live window this page instance cannot attribute (main
+  reloaded while the resolver stayed up) counts as a match, so the worst case is
+  one extra confirmation rather than a broken resolution.
+
+  The main-window confirm deliberately bypasses the resolver's own
+  unapplied-progress guard: the user has already been told, in the window they are
+  looking at, that unapplied picks and edits are lost.
+
+## Testing
+
+- **Rust:** `close` removes the entry and a subsequent op on the id answers
+  `UnknownRepo`; closing an unknown id succeeds; two repositories are open
+  simultaneously and read independently (the property tabs rely on, never before
+  asserted).
+- **Unit:** `repoSlice` — `REPO_SLICE_KEYS` equals the store's live non-function
+  keys (the anti-leak guard), `sliceOf`/`EMPTY_SLICE` round-trip. `tabs.ts` —
+  add/dedupe/close-neighbour-selection/cycle, `labelTabs` collision
+  disambiguation, `pg-open-repos` encode/decode incl. garbage tolerance.
+  `useTabsStore` — switching hydrates the incoming slice and leaves nothing of
+  the outgoing one; a failed open keeps the previous tab; a late `refreshAll`
+  from the previous repo does not write into the new tab (the `setFor` guard);
+  closing the active tab activates a neighbour; closing the last returns to
+  Welcome and calls `close_repo`.
+- **Component:** `RepoTabs.test.tsx` — strip renders one row per tab, marks the
+  active one, click switches, close button closes, "Close others" confirms
+  (`WithDialogs`), dirty/conflict badges render. `AppShell` — the per-tab screen
+  is restored on switch and the screen subtree remounts.
+- **E2E:** `repo-tabs.e2e.ts` — two seeded tabs restore from
+  `pg-open-repos`, switching changes the titlebar repo name and History content,
+  `Ctrl+Tab` cycles, closing a tab leaves the other active, closing the last
+  returns to Welcome. `reopenRepo` in `e2e/support/app.ts` learns that a restored
+  session may already have the repo open (it reloads *without* clearing
+  localStorage, which now restores tabs), otherwise every persistence spec would
+  hang waiting for a Welcome row that no longer renders.
+
+## Out of scope
+
+Drag-to-reorder tabs (#61 C5 territory). Splitting a repository into a second
+*window*. Cross-repo operations (compare, cherry-pick across repos). Background
+fetch for inactive tabs. Per-tab pane geometry. Restoring per-tab selections
+across a switch. A workspace/project concept above the tab set (named groups,
+`.pgit-workspace` files) — the open set is a flat list, deliberately.

--- a/e2e/specs/repo-tabs.e2e.ts
+++ b/e2e/specs/repo-tabs.e2e.ts
@@ -1,0 +1,196 @@
+// Multi-repo tabs (#90). Two repositories open at once: the strip lists both,
+// switching swaps the whole repo view, the chords cycle and close, and the open
+// set survives a reload.
+//
+// Acceptance is repo truth wherever it exists — each fixture's commit summaries
+// and branch names differ, so "the app is showing repo B" is provable from the
+// screen rather than from the tab's own highlight.
+import {
+  activeRepoTabPath,
+  armDriverBridge,
+  jsChord,
+  jsKey,
+  openPalette,
+  paletteDialog,
+  paletteInput,
+  repoTab,
+  repoTabClose,
+  repoTabCount,
+  resetApp,
+  seedOpenRepos,
+  waitRepoLoaded,
+} from "../support/app";
+import { basicRepo, branchyRepo, TempRepo } from "../support/tempRepo";
+
+/** The status bar's right slot renders the open repository's workdir — the one
+ *  place the CURRENT repo's identity is on screen verbatim. */
+function statusBarShows(repo: TempRepo) {
+  const name = repo.path.split("/").filter(Boolean).pop() as string;
+  // CHAINED, not one string: `span*=text` is wdio's partial-text form, not CSS,
+  // so a compound like `[data-testid="status-bar"] span*=x` is handed to
+  // querySelector verbatim and throws `SyntaxError: … is not a valid selector`.
+  // Scoping has to happen as a parent lookup + a child text query.
+  return $('[data-testid="status-bar"]').$(`span*=${name}`);
+}
+
+/** Every commit row's text, joined — the cheapest "which repository's history
+ *  am I looking at" probe. */
+function commitSummaries(): Promise<string> {
+  return browser.execute(() =>
+    Array.from(document.querySelectorAll('[data-testid="commit-row"]'))
+      .map((r) => r.textContent ?? "")
+      .join("\n"),
+  );
+}
+
+async function waitShowing(repo: TempRepo, what: string): Promise<void> {
+  await statusBarShows(repo).waitForDisplayed({
+    timeout: 20_000,
+    timeoutMsg: `status bar never named ${repo.path} (${what})`,
+  });
+}
+
+describe("multi-repo tabs", () => {
+  let alpha: TempRepo;
+  let beta: TempRepo;
+
+  before(() => {
+    // Different shapes so a mix-up between them is visible: `basicRepo` is
+    // linear on `main`, `branchyRepo` carries extra branches.
+    alpha = basicRepo();
+    beta = branchyRepo();
+  });
+
+  after(() => {
+    alpha.dispose();
+    beta.dispose();
+  });
+
+  it("restores the persisted open set as tabs, with only the active one loaded", async () => {
+    await resetApp();
+    await seedOpenRepos([alpha.path, beta.path], alpha.path);
+
+    await repoTab(alpha.path).waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "no tab for the first repository after restore",
+    });
+    expect(await repoTabCount()).toBe(2);
+    expect(await activeRepoTabPath()).toContain(
+      alpha.path.split("/").filter(Boolean).pop() as string,
+    );
+    await waitShowing(alpha, "restored active tab");
+  });
+
+  it("clicking a tab switches the whole repository view", async () => {
+    await resetApp();
+    await seedOpenRepos([alpha.path, beta.path], alpha.path);
+    await waitShowing(alpha, "before the switch");
+    await $('[data-testid="commit-row"]').waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "no commit rows for the first repository",
+    });
+    expect(await commitSummaries()).not.toContain("merge feature");
+
+    await repoTab(beta.path).click();
+
+    await waitShowing(beta, "after clicking the second tab");
+    // The switched-to repository's own history is what is listed now.
+    await $('[data-testid="commit-row"]').waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "no commit rows after switching tabs",
+    });
+    // beta is branchyRepo: it has a merge commit alpha (basicRepo) cannot have.
+    const summaries = await commitSummaries();
+    expect(summaries).toContain("merge feature");
+    // Repo truth: that commit really is beta's and really is not alpha's.
+    expect(beta.git("log", "--oneline")).toContain("merge feature");
+    expect(alpha.git("log", "--oneline")).not.toContain("merge feature");
+  });
+
+  it("cycles tabs with the next/prev chords", async () => {
+    await resetApp();
+    await seedOpenRepos([alpha.path, beta.path], alpha.path);
+    await waitShowing(alpha, "before cycling");
+
+    // Ctrl+Tab: on Linux/Windows the dispatcher normalizes physical Ctrl to
+    // Mod, so this resolves to Mod+Tab there — both are bound for exactly that
+    // reason (see presets.ts).
+    await jsChord("Ctrl+Tab");
+    await waitShowing(beta, "after Ctrl+Tab");
+
+    await jsChord("Ctrl+Shift+Tab");
+    await waitShowing(alpha, "after Ctrl+Shift+Tab");
+
+    // Alt+2 jumps straight to the second tab.
+    await jsChord("Alt+2");
+    await waitShowing(beta, "after Alt+2");
+  });
+
+  it("closes a tab and leaves the other one active", async () => {
+    await resetApp();
+    await seedOpenRepos([alpha.path, beta.path], beta.path);
+    await waitShowing(beta, "before closing");
+
+    await repoTabClose(beta.path).click();
+
+    await waitShowing(alpha, "after closing the active tab");
+    await browser.waitUntil(async () => (await repoTabCount()) === 1, {
+      timeout: 20_000,
+      timeoutMsg: "the closed tab is still in the strip",
+    });
+  });
+
+  it("closing the last tab returns to Welcome", async () => {
+    await resetApp();
+    await seedOpenRepos([alpha.path], alpha.path);
+    await waitShowing(alpha, "before closing the only tab");
+
+    await repoTabClose(alpha.path).click();
+
+    await $("div*=Welcome to PlatypusGit").waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "closing the last tab did not return to Welcome",
+    });
+    expect(await repoTabCount()).toBe(0);
+  });
+
+  it("the palette lists the open repositories and switches to one", async () => {
+    await resetApp();
+    await seedOpenRepos([alpha.path, beta.path], alpha.path);
+    await waitShowing(alpha, "before the palette switch");
+
+    await openPalette();
+    await $(paletteInput).setValue("Switch repository");
+    await jsKey(paletteInput, "Enter");
+
+    const betaName = beta.path.split("/").filter(Boolean).pop() as string;
+    const row = $(paletteDialog).$(`[data-pal-index]*=${betaName}`);
+    await row.waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg: "the repository switcher did not list the second repository",
+    });
+    await row.click();
+
+    await waitShowing(beta, "after picking it in the palette");
+  });
+
+  it("keeps the open set across a reload", async () => {
+    await resetApp();
+    await seedOpenRepos([alpha.path, beta.path], alpha.path);
+    await repoTab(beta.path).click();
+    await waitShowing(beta, "before the reload");
+
+    // No localStorage.clear(): the point is that pg-open-repos survives.
+    await browser.refresh();
+    await armDriverBridge();
+    await waitRepoLoaded();
+    await armDriverBridge();
+
+    await browser.waitUntil(async () => (await repoTabCount()) === 2, {
+      timeout: 20_000,
+      timeoutMsg: "the open set did not come back after the reload",
+    });
+    // …and it comes back on the tab that was active, not the first one.
+    await waitShowing(beta, "after the reload");
+  });
+});

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -180,13 +180,124 @@ export async function reopenRepo(repoPath: string): Promise<void> {
   await browser.refresh();
   await armDriverBridge();
   const row = $(`[data-testid="recent-repo"][data-path="${repoPath}"]`);
-  await row.waitForDisplayed({
-    timeout: 20_000,
-    timeoutMsg: "recent-repo row missing after reload — recents not persisted?",
-  });
+  const chip = $('[data-testid="branch-chip"]');
+  // Since #90 the OPEN SET persists too (`pg-open-repos`), and this helper
+  // deliberately keeps localStorage — so the reload may reopen the repository by
+  // itself and never render a Welcome row at all. Waiting for the row
+  // unconditionally would hang every persistence spec.
+  await browser.waitUntil(
+    async () => (await chip.isExisting()) || (await row.isExisting()),
+    {
+      timeout: 20_000,
+      timeoutMsg:
+        "after reload neither the restored repo (branch chip) nor its " +
+        "recent-repo row appeared — recents/open-set not persisted?",
+    },
+  );
   await armDriverBridge();
-  await row.click();
+  if (!(await chip.isExisting())) {
+    await row.waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "recent-repo row missing after reload — recents not persisted?",
+    });
+    await armDriverBridge();
+    await row.click();
+  }
   await waitRepoLoaded();
+}
+
+/** Seed the persisted open set (#90) and reload, so the app restores `paths` as
+ *  tabs with `active` opened. The only way to get TWO repositories open in e2e:
+ *  the `+` button and ⌘O go through the real OS folder picker, which WebDriver
+ *  cannot drive.
+ *
+ *  Recents are seeded alongside, because that is the state a real session that
+ *  opened both would have left behind — and the palette's repository switcher
+ *  reads them. */
+export async function seedOpenRepos(
+  paths: string[],
+  active: string,
+): Promise<void> {
+  // executeOnce, not bare execute: this WRITES, and a driver script-timeout
+  // (routine under xvfb) makes WebdriverIO retry the command. A retried
+  // `localStorage.clear()` landing after the setItem pair would wipe the seed
+  // and leave the app booting with no open set — which looks like a render bug
+  // in the strip rather than a lost write.
+  await executeOnce(
+    (ps: string[], act: string) => {
+      localStorage.clear();
+      localStorage.setItem(
+        "pg-recent-repos",
+        JSON.stringify(ps.map((p, i) => ({ path: p, openedAt: ps.length - i }))),
+      );
+      localStorage.setItem(
+        "pg-open-repos",
+        JSON.stringify({ paths: ps, active: act }),
+      );
+    },
+    paths,
+    active,
+  );
+  // Read the key back on BOTH sides of the reload rather than trusting the
+  // write. "Repository opens but no tab appears" has two very different causes
+  // — a clobbered seed and a strip that failed to render — and they are
+  // indistinguishable from the spec's own assertion. Naming which one happened
+  // is worth two read-only round trips.
+  const afterWrite = await browser.execute(() =>
+    localStorage.getItem("pg-open-repos"),
+  );
+  if (!afterWrite) {
+    throw new Error(
+      "seedOpenRepos: pg-open-repos is empty immediately after the write — " +
+        "the seed never landed on this document",
+    );
+  }
+  await browser.refresh();
+  await armDriverBridge();
+  const afterBoot = await browser.execute(() =>
+    localStorage.getItem("pg-open-repos"),
+  );
+  if (!afterBoot) {
+    throw new Error(
+      "seedOpenRepos: pg-open-repos was present before the reload and is gone " +
+        "after it — the seed was clobbered during boot, not mis-rendered",
+    );
+  }
+  await waitRepoLoaded();
+}
+
+/** A tab row, matched on the tail of its path.
+ *
+ *  Not the full path: `open_repo` returns the canonicalised workdir, which on
+ *  macOS turns `/var/folders/…` (what `tmpdir()` hands out) into
+ *  `/private/var/folders/…`. The temp-repo basename is unique per fixture, so
+ *  the suffix is an exact identity match without depending on symlink
+ *  resolution. */
+export function repoTab(repoPath: string) {
+  const name = repoPath.split("/").filter(Boolean).pop() ?? repoPath;
+  return $(`[data-testid="repo-tab"][data-path$="${name}"]`);
+}
+
+export function repoTabClose(repoPath: string) {
+  const name = repoPath.split("/").filter(Boolean).pop() ?? repoPath;
+  return $(`[data-testid="repo-tab-close"][data-path$="${name}"]`);
+}
+
+/** Number of open repository tabs. */
+export function repoTabCount(): Promise<number> {
+  return browser.execute(
+    () => document.querySelectorAll('[data-testid="repo-tab"]').length,
+  );
+}
+
+/** Path of the active tab, straight from the DOM. */
+export function activeRepoTabPath(): Promise<string | null> {
+  return browser.execute(
+    () =>
+      document
+        .querySelector('[data-testid="repo-tab"][data-active="true"]')
+        ?.getAttribute("data-path") ?? null,
+  );
 }
 
 /** Serial for executeOnce tokens — unique per logical call within a runner

--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -20,6 +20,19 @@ pub async fn open_repo(
         .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
+/// Forget an opened repository (a closed repository tab).
+///
+/// Best-effort by contract: an unknown id succeeds, so the frontend can close a
+/// tab whose open never completed without showing an error.
+#[tauri::command]
+pub async fn close_repo(state: State<'_, AppState>, repo_id: String) -> AppResult<()> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    tokio::task::spawn_blocking(move || backend.close(&repo_id))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
 /// Add `path` to the user's global `safe.directory` list, so libgit2 stops
 /// refusing it. Reached only from the confirmation an `AppError::DubiousOwnership`
 /// raises in the UI — never call it without asking first.

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -40,6 +40,9 @@ impl GitBackend for CliBackend {
     fn trust_path(&self, _path: &Path) -> AppResult<()> {
         Err(AppError::NotImplemented)
     }
+    fn close(&self, _repo_id: &RepoId) -> AppResult<()> {
+        Err(AppError::NotImplemented)
+    }
     fn status(&self, _repo_id: &RepoId) -> AppResult<Vec<FileStatus>> {
         Err(AppError::NotImplemented)
     }

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -1955,9 +1955,15 @@ impl GitBackend for Libgit2Backend {
         };
 
         let id = RepoId(Uuid::new_v4().to_string());
+        // `workdir()` hands back a path WITH a trailing separator. That makes
+        // `/repo` and `/repo/` two different strings for anything that keys on
+        // the handle's path — repository tabs (#90) dedupe by it, recents store
+        // it, and a `pgit <path>` launch forwards the slashless form — so the
+        // same repository could open twice under two spellings. Normalize once,
+        // here, rather than at every comparison.
         let workdir = repo
             .workdir()
-            .map(PathBuf::from)
+            .map(strip_trailing_slash)
             .unwrap_or_else(|| path.to_path_buf());
 
         let mut map = self
@@ -1975,6 +1981,21 @@ impl GitBackend for Libgit2Backend {
 
     fn trust_path(&self, path: &Path) -> AppResult<()> {
         ownership::trust_path(path)
+    }
+
+    fn close(&self, repo_id: &RepoId) -> AppResult<()> {
+        let mut map = self
+            .repos
+            .lock()
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        // Dropping the removed Mutex<Repository> here releases libgit2's file
+        // handles. An absent id is success on purpose (see the trait doc).
+        map.remove(repo_id);
+        // `rebases` is deliberately left alone: its entries are bytes, not
+        // handles, they are keyed by an id a re-open can never mint again, and
+        // an in-progress rebase rehydrates from `.git/platypusgit-rebase.json`
+        // — the same path a restarted app takes.
+        Ok(())
     }
 
     fn init(&self, path: &Path, initial_branch: Option<&str>) -> AppResult<RepoHandle> {

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -42,6 +42,19 @@ pub trait GitBackend: Send + Sync {
     /// confirmed. Shaped like `open` rather than the `repo_id` methods: by
     /// definition there is no open repository to address.
     fn trust_path(&self, path: &Path) -> AppResult<()>;
+    /// Forget an opened repository, releasing its `git2::Repository` (and with
+    /// it every file handle and odb cache it holds).
+    ///
+    /// `open` mints a fresh `RepoId` on every call and nothing else ever
+    /// removes an entry, so without this each open — a re-open of the same path
+    /// included — costs one repository for the lifetime of the process. Called
+    /// when a repository tab is closed.
+    ///
+    /// **Idempotent, and an unknown id is not an error.** The frontend may
+    /// close a tab whose open never completed; turning that into an error
+    /// banner would be noise. Using a closed id still answers `UnknownRepo`,
+    /// which is the honest response to a real mistake.
+    fn close(&self, repo_id: &RepoId) -> AppResult<()>;
     fn status(&self, repo_id: &RepoId) -> AppResult<Vec<FileStatus>>;
     /// Like `status`, but also includes tracked-but-unmodified files so UIs
     /// can browse the whole worktree (ignored files are still excluded).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -140,6 +140,7 @@ pub fn run() {
         .manage(commands::cli::CliLaunchState(Mutex::new(initial_intent)))
         .invoke_handler(tauri::generate_handler![
             commands::repo::open_repo,
+            commands::repo::close_repo,
             commands::repo::trust_repo_path,
             commands::repo::get_status,
             commands::repo::list_all_files,

--- a/src-tauri/tests/libgit2_smoke.rs
+++ b/src-tauri/tests/libgit2_smoke.rs
@@ -59,3 +59,42 @@ fn rejects_missing_path() {
         other => panic!("expected InvalidPath error, got {:?}", other),
     }
 }
+
+/// `Repository::workdir()` returns a path WITH a trailing separator, so the
+/// handle used to carry `/repo/` while every caller that asked for the repo
+/// said `/repo`. Anything keying on the handle's path then saw two different
+/// repositories: repository tabs (#90) dedupe by path, recents store it, and a
+/// `pgit <path>` launch forwards the slashless form — so the same repository
+/// could open twice under two spellings, and an e2e selector matching on the
+/// path's tail could not match at all.
+#[test]
+fn open_returns_a_workdir_without_a_trailing_separator() {
+    let backend = Libgit2Backend::new();
+    let root = repo_root();
+
+    let handle = backend.open(&root).expect("open failed");
+
+    let as_string = handle.path.to_string_lossy().into_owned();
+    assert!(
+        !as_string.ends_with('/') && !as_string.ends_with('\\'),
+        "handle path should carry no trailing separator, got {as_string:?}",
+    );
+    assert_eq!(handle.path, root, "handle path should equal the opened dir");
+}
+
+/// The dedupe property that normalization exists for: asking with a trailing
+/// separator and without must produce the same key.
+#[test]
+fn open_with_and_without_a_trailing_separator_agree() {
+    let backend = Libgit2Backend::new();
+    let root = repo_root();
+    let slashed = PathBuf::from(format!("{}/", root.display()));
+
+    let bare = backend.open(&root).expect("open(bare) failed");
+    let with_slash = backend.open(&slashed).expect("open(slashed) failed");
+
+    assert_eq!(
+        bare.path, with_slash.path,
+        "both spellings should resolve to one path",
+    );
+}

--- a/src-tauri/tests/multi_repo.rs
+++ b/src-tauri/tests/multi_repo.rs
@@ -1,0 +1,101 @@
+//! Two repositories open at once, and closing one (#90 — multi-repo tabs).
+//!
+//! The backend was always keyed by `RepoId`, but nothing asserted that two
+//! handles from one backend stay independent — the single property the tab model
+//! rests on. And `open` mints a fresh UUID with no eviction path, so `close` is
+//! what keeps a session that opens twenty repositories from holding twenty
+//! `git2::Repository` values (and their file handles) until the process exits.
+
+mod support;
+
+use platypusgit_lib::{
+    error::AppError,
+    git::{libgit2::Libgit2Backend, types::RepoId, GitBackend},
+};
+use support::{fs::write_file, TempRepo};
+
+#[test]
+fn two_repos_stay_independent() {
+    let backend = Libgit2Backend::new();
+
+    let a = TempRepo::with_initial_commit("alpha\n");
+    let b = TempRepo::with_initial_commit("beta\n");
+    // Dirty only B, so a status leak between the two would be visible.
+    write_file(b.path(), "only-in-b.txt", "x\n");
+
+    let ha = backend.open(a.path()).expect("open a");
+    let hb = backend.open(b.path()).expect("open b");
+    assert_ne!(ha.id, hb.id, "each open must mint its own RepoId");
+
+    let sa = backend.status(&ha.id).expect("status a");
+    let sb = backend.status(&hb.id).expect("status b");
+    assert!(
+        sa.is_empty(),
+        "repo A should be clean, got {:?}",
+        sa.iter().map(|s| &s.path).collect::<Vec<_>>()
+    );
+    assert!(
+        sb.iter().any(|s| s.path == "only-in-b.txt"),
+        "repo B should report its own untracked file, got {:?}",
+        sb.iter().map(|s| &s.path).collect::<Vec<_>>()
+    );
+
+    // Reading one after the other must not disturb either handle.
+    assert_eq!(
+        backend.log(&ha.id, None, 10).expect("log a").len(),
+        1,
+        "repo A log",
+    );
+    assert_eq!(
+        backend.log(&hb.id, None, 10).expect("log b").len(),
+        1,
+        "repo B log",
+    );
+}
+
+#[test]
+fn close_forgets_the_repo_and_leaves_the_other_usable() {
+    let backend = Libgit2Backend::new();
+
+    let a = TempRepo::with_initial_commit("alpha\n");
+    let b = TempRepo::with_initial_commit("beta\n");
+    let ha = backend.open(a.path()).expect("open a");
+    let hb = backend.open(b.path()).expect("open b");
+
+    backend.close(&ha.id).expect("close a");
+
+    match backend.status(&ha.id) {
+        Err(AppError::UnknownRepo(id)) => assert_eq!(id, ha.id.0),
+        other => panic!("expected UnknownRepo after close, got {other:?}"),
+    }
+    // Closing one tab must not touch the other.
+    backend.status(&hb.id).expect("repo B still open after A closed");
+}
+
+#[test]
+fn close_is_idempotent_and_unknown_ids_succeed() {
+    let backend = Libgit2Backend::new();
+    let a = TempRepo::with_initial_commit("alpha\n");
+    let ha = backend.open(a.path()).expect("open a");
+
+    backend.close(&ha.id).expect("first close");
+    // A tab closed twice, and a tab whose open never completed: both must be
+    // silent successes, or the UI would raise a banner for nothing.
+    backend.close(&ha.id).expect("second close");
+    backend
+        .close(&RepoId("never-opened".into()))
+        .expect("closing an unknown id");
+}
+
+#[test]
+fn reopening_a_closed_path_works() {
+    let backend = Libgit2Backend::new();
+    let a = TempRepo::with_initial_commit("alpha\n");
+
+    let first = backend.open(a.path()).expect("open");
+    backend.close(&first.id).expect("close");
+    let second = backend.open(a.path()).expect("reopen");
+
+    assert_ne!(first.id, second.id, "a reopen mints a new RepoId");
+    backend.status(&second.id).expect("status on the reopened repo");
+}

--- a/src/AppShell.restore.test.tsx
+++ b/src/AppShell.restore.test.tsx
@@ -1,0 +1,145 @@
+// Session restore from `pg-open-repos` (#90), driven through a real <App/> boot.
+//
+// The other tabs tests seed `useTabsStore` with `setState`, so they never
+// exercise MOUNT ORDER — AppShell's restore effect, useCliLaunch's intent, and
+// whatever else runs on first paint. That gap is exactly where an e2e failure
+// lived: the webview opened a repository (branch chip present) while the strip
+// rendered zero tabs, which no store-seeded test could see.
+//
+// So: write the key, render the app, assert the strip. Nothing is seeded into
+// the store here on purpose.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+
+import App from "./App";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useRecentsStore } from "@/features/repo/useRecentsStore";
+import { useTabsStore } from "@/features/repo/useTabsStore";
+import { emptySlice } from "@/features/repo/repoSlice";
+import { useFocusStore } from "@/features/keymap";
+import { mockInvoke } from "@/test/invokeMock";
+import type { RepoHandle } from "@/lib/types";
+
+const API: RepoHandle = { id: "r-api", path: "/dev/api", head: "refs/heads/main" };
+const WEB: RepoHandle = { id: "r-web", path: "/dev/web", head: "refs/heads/trunk" };
+
+function wire() {
+  for (const cmd of [
+    "get_status",
+    "list_all_files",
+    "list_branches",
+    "list_tags",
+    "list_stashes",
+    "list_remotes",
+    "get_reflog",
+    "diff_commit",
+    "diff_commits",
+  ]) {
+    mockInvoke(cmd, () => []);
+  }
+  mockInvoke("open_repo", (args) => (args.path === API.path ? API : WEB));
+  mockInvoke("close_repo", () => undefined);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => ({
+    inProgress: false,
+    nextIndex: 0,
+    total: 0,
+    pauseReason: null,
+  }));
+  mockInvoke("take_launch_intent", () => null);
+  mockInvoke("cli_shim_status", () => ({ installed: false, path: null }));
+  mockInvoke("get_diff", () => null);
+  mockInvoke("check_for_update", () => null);
+  mockInvoke("get_update_capability", () => ({ canSelfUpdate: false }));
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  useRecentsStore.setState({ recents: [] });
+  useFocusStore.setState({
+    focused: null,
+    panes: new Map(),
+    order: [],
+    barId: null,
+    primaryId: null,
+    pendingContentFocus: false,
+  });
+  useTabsStore.setState({
+    tabs: [],
+    activePath: null,
+    activationSeq: 0,
+    activating: null,
+  });
+  useRepoStore.setState(emptySlice() as never);
+  wire();
+});
+
+const rows = () =>
+  Array.from(document.querySelectorAll('[data-testid="repo-tab"]'));
+
+/** What e2e's `seedOpenRepos` writes, byte for byte. */
+function seedStorage(paths: string[], active: string) {
+  localStorage.setItem(
+    "pg-recent-repos",
+    JSON.stringify(paths.map((p, i) => ({ path: p, openedAt: paths.length - i }))),
+  );
+  localStorage.setItem(
+    "pg-open-repos",
+    JSON.stringify({ paths, active }),
+  );
+}
+
+describe("AppShell — restoring the persisted open set on boot", () => {
+  it("renders a tab per persisted repository", async () => {
+    seedStorage([API.path, WEB.path], API.path);
+
+    render(<App />);
+
+    await waitFor(() => expect(rows()).toHaveLength(2));
+    expect(rows().map((r) => r.getAttribute("data-path"))).toEqual([
+      API.path,
+      WEB.path,
+    ]);
+  });
+
+  it("opens ONLY the persisted active repository, and marks it active", async () => {
+    seedStorage([API.path, WEB.path], WEB.path);
+
+    render(<App />);
+
+    await waitFor(() => expect(rows()).toHaveLength(2));
+    // Lazy restore: the inactive tab stays pending, so exactly one open_repo.
+    await waitFor(() =>
+      expect(useRepoStore.getState().current?.path).toBe(WEB.path),
+    );
+    const active = rows().filter((r) => r.getAttribute("data-active") === "true");
+    expect(active.map((r) => r.getAttribute("data-path"))).toEqual([WEB.path]);
+  });
+
+  it("still shows the strip once the repository has finished opening", async () => {
+    // The e2e symptom was this pair diverging: a repository open (branch chip
+    // on screen) with no tab beside it. Assert them together.
+    seedStorage([API.path], API.path);
+
+    render(<App />);
+
+    await waitFor(() =>
+      expect(useRepoStore.getState().current?.path).toBe(API.path),
+    );
+    await waitFor(() => expect(rows()).toHaveLength(1));
+    expect(
+      document.querySelector('[data-testid="repo-tab-strip"]'),
+    ).not.toBeNull();
+  });
+
+  it("survives a boot with no persisted set (Welcome, no strip)", async () => {
+    render(<App />);
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="repo-tab-strip"]')).toBeNull(),
+    );
+    expect(rows()).toHaveLength(0);
+  });
+});

--- a/src/AppShell.tabs.test.tsx
+++ b/src/AppShell.tabs.test.tsx
@@ -1,0 +1,243 @@
+// Tabs in the shell (#90): the strip renders, each tab remembers its own screen
+// within the session, and a switch REMOUNTS the screen so one repository's
+// selections cannot show up under another's.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
+
+import App from "./App";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useRecentsStore } from "@/features/repo/useRecentsStore";
+import { useTabsStore } from "@/features/repo/useTabsStore";
+import { emptySlice } from "@/features/repo/repoSlice";
+import { newTab } from "@/features/repo/tabs";
+import { useFocusStore } from "@/features/keymap";
+import { mockInvoke } from "@/test/invokeMock";
+import type { RepoHandle } from "@/lib/types";
+
+const API: RepoHandle = { id: "r-api", path: "/dev/api", head: "refs/heads/main" };
+const WEB: RepoHandle = { id: "r-web", path: "/dev/web", head: "refs/heads/trunk" };
+
+function wire() {
+  for (const cmd of [
+    "get_status",
+    "list_all_files",
+    "list_branches",
+    "list_tags",
+    "list_stashes",
+    "list_remotes",
+    "get_reflog",
+    "diff_commit",
+    "diff_commits",
+  ]) {
+    mockInvoke(cmd, () => []);
+  }
+  mockInvoke("open_repo", (args) => (args.path === API.path ? API : WEB));
+  mockInvoke("close_repo", () => undefined);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => ({
+    inProgress: false,
+    nextIndex: 0,
+    total: 0,
+    pauseReason: null,
+  }));
+  mockInvoke("take_launch_intent", () => null);
+  mockInvoke("cli_shim_status", () => ({ installed: false, path: null }));
+  mockInvoke("get_diff", () => null);
+  mockInvoke("check_for_update", () => null);
+  mockInvoke("get_update_capability", () => ({ canSelfUpdate: false }));
+}
+
+/** Two tabs, /dev/api active and live in the repo store. */
+function seedTwoTabs() {
+  useRepoStore.setState({ ...emptySlice(), current: API } as never);
+  useTabsStore.setState({
+    tabs: [
+      newTab("/dev/api", { status: "open", repoId: "r-api" }),
+      newTab("/dev/web", {
+        status: "open",
+        repoId: "r-web",
+        slice: { ...emptySlice(), current: WEB },
+      }),
+    ],
+    activePath: "/dev/api",
+    activationSeq: 0,
+    activating: null,
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  useRecentsStore.setState({ recents: [] });
+  useFocusStore.setState({
+    focused: null,
+    panes: new Map(),
+    order: [],
+    barId: null,
+    primaryId: null,
+    pendingContentFocus: false,
+  });
+  useTabsStore.setState({
+    tabs: [],
+    activePath: null,
+    activationSeq: 0,
+    activating: null,
+  });
+  useRepoStore.setState(emptySlice() as never);
+  wire();
+});
+
+const rows = () =>
+  Array.from(document.querySelectorAll('[data-testid="repo-tab"]'));
+const activeScreen = () =>
+  document.querySelector('[data-activity][style*="var(--accent)"]');
+
+describe("AppShell — repository tabs", () => {
+  it("renders no strip until a repository is open", async () => {
+    render(<App />);
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="repo-tab-strip"]')).toBeNull(),
+    );
+  });
+
+  it("renders one tab per open repository", async () => {
+    seedTwoTabs();
+    render(<App />);
+    await waitFor(() => expect(rows()).toHaveLength(2));
+    expect(rows().map((r) => r.getAttribute("data-active"))).toEqual([
+      "true",
+      "false",
+    ]);
+  });
+
+  it("remembers each tab's screen across a switch", async () => {
+    seedTwoTabs();
+    const { container } = render(<App />);
+    await waitFor(() => expect(rows()).toHaveLength(2));
+
+    // Put /dev/api on Branches…
+    await act(async () => {
+      fireEvent.click(
+        container.querySelector('[data-activity="branches"]') as Element,
+      );
+    });
+    expect(useTabsStore.getState().tabs[0].screen).toBe("branches");
+
+    // …switch to /dev/web, which has never left History…
+    await act(async () => {
+      fireEvent.click(rows()[1]);
+    });
+    await waitFor(() =>
+      expect(useTabsStore.getState().activePath).toBe("/dev/web"),
+    );
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-activity="history"]')?.getAttribute("style"),
+      ).toContain("var(--accent)"),
+    );
+
+    // …and back: /dev/api is where we left it.
+    await act(async () => {
+      fireEvent.click(rows()[0]);
+    });
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-activity="branches"]')?.getAttribute("style"),
+      ).toContain("var(--accent)"),
+    );
+  });
+
+  it("closes the active tab from the titlebar button", async () => {
+    seedTwoTabs();
+    const { container } = render(<App />);
+    await waitFor(() => expect(rows()).toHaveLength(2));
+    const close = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent === "Close repo",
+    );
+    await act(async () => {
+      fireEvent.click(close as Element);
+    });
+    await waitFor(() =>
+      expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual([
+        "/dev/web",
+      ]),
+    );
+    expect(useTabsStore.getState().activePath).toBe("/dev/web");
+  });
+
+  it("restores the persisted session on mount, opening only the active tab", async () => {
+    localStorage.setItem(
+      "pg-open-repos",
+      JSON.stringify({ paths: ["/dev/api", "/dev/web"], active: "/dev/web" }),
+    );
+    render(<App />);
+    await waitFor(() => expect(rows()).toHaveLength(2));
+    await waitFor(() =>
+      expect(useRepoStore.getState().current?.id).toBe("r-web"),
+    );
+    expect(useTabsStore.getState().tabs[0].status).toBe("pending");
+    // Restored tabs start on History — `pg-screen` stays dead.
+    expect(useTabsStore.getState().tabs.map((t) => t.screen)).toEqual([
+      "history",
+      "history",
+    ]);
+    expect(activeScreen()?.getAttribute("data-activity")).toBe("history");
+  });
+});
+
+describe("AppShell — a tab whose repository will not open", () => {
+  it("offers retry and close instead of flashing Welcome", async () => {
+    mockInvoke("open_repo", () => {
+      throw { kind: "InvalidPath", message: "/dev/gone" };
+    });
+    localStorage.setItem(
+      "pg-open-repos",
+      JSON.stringify({ paths: ["/dev/gone"], active: "/dev/gone" }),
+    );
+
+    render(<App />);
+
+    const panel = await waitFor(() => {
+      const el = document.querySelector('[data-testid="tab-loading"]');
+      expect(el?.getAttribute("data-failed")).toBe("true");
+      return el as Element;
+    });
+    expect(panel.textContent).toContain("Could not open gone");
+    // Welcome must NOT be what a failed tab shows — the tab is still there.
+    expect(document.body.textContent).not.toContain("Welcome to PlatypusGit");
+    expect(rows()).toHaveLength(1);
+
+    const close = Array.from(panel.querySelectorAll("button")).find(
+      (b) => b.textContent === "Close tab",
+    );
+    await act(async () => {
+      fireEvent.click(close as Element);
+    });
+    await waitFor(() => expect(useTabsStore.getState().tabs).toHaveLength(0));
+    // With no tabs left, Welcome is right again.
+    await waitFor(() =>
+      expect(document.body.textContent).toContain("Welcome to PlatypusGit"),
+    );
+  });
+});
+
+// The screens map is keyed by the active repository, so a tab switch unmounts
+// the screen. Asserted through a screen that owns local selection state.
+describe("AppShell — screen remount on tab switch", () => {
+  it("remounts the screen subtree when the active repository changes", async () => {
+    seedTwoTabs();
+    render(<App />);
+    await waitFor(() => expect(rows()).toHaveLength(2));
+    const before = document.querySelector('[data-activity="history"]');
+    await act(async () => {
+      fireEvent.click(rows()[1]);
+    });
+    await waitFor(() =>
+      expect(useTabsStore.getState().activePath).toBe("/dev/web"),
+    );
+    // The activity bar lives inside the keyed subtree, so a fresh node here is
+    // proof the screens under it were rebuilt rather than reused.
+    expect(document.querySelector('[data-activity="history"]')).not.toBe(before);
+  });
+});

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -31,6 +31,8 @@ import { SubmodulesScreen } from "@/screens/Submodules";
 import { WorktreesScreen } from "@/screens/Worktrees";
 
 import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useTabsStore } from "@/features/repo/useTabsStore";
+import { RepoTabs } from "@/features/repo/RepoTabs";
 import { headUpstream, openRepoDialog } from "@/features/repo/ops";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useCliLaunch } from "@/features/cli/useCliLaunch";
@@ -144,8 +146,17 @@ export function AppShell() {
   // going on in this repo", so it is worth more than restoring wherever the
   // last session happened to end (a deep view or Settings, most annoyingly).
   // The old localStorage["pg-screen"] restore is gone with its write; nothing
-  // else reads the key.
+  // else reads the key. Tabs do not resurrect it: a restored tab is created on
+  // History too — the per-tab screen below is remembered within a session only.
   const [screen, setScreen] = React.useState<ScreenId>("history");
+
+  // Reopen last session's repositories (#90). Lazy: only the tab that was
+  // active is actually opened; the rest open when first activated. Runs before
+  // useCliLaunch's intent lands, so a forwarded `pgit <path>` focuses the
+  // restored tab for that path instead of adding a duplicate.
+  React.useEffect(() => {
+    void useTabsStore.getState().restoreSession();
+  }, []);
 
   // Latest screen, readable synchronously from the intent effect below without
   // making it a dependency (so origin capture sees the pre-switch screen).
@@ -228,10 +239,27 @@ export function AppShell() {
   const enterScreen = React.useCallback((id: ScreenId) => {
     setScreen(id);
     setEntryTick((t) => t + 1);
+    // Per-tab screen: remember where THIS repository is, so switching away and
+    // back does not dump you on History with your place lost.
+    useTabsStore.getState().rememberScreen(id);
   }, []);
   React.useEffect(() => {
     useFocusStore.getState().requestContentFocus();
   }, [screen, entryTick]);
+
+  // Restore the incoming tab's screen on every switch. Skipped on first mount
+  // so launch still lands on History (a restored tab remembers nothing).
+  const activePath = useTabsStore((s) => s.activePath);
+  const firstTabEffect = React.useRef(true);
+  React.useEffect(() => {
+    if (firstTabEffect.current) {
+      firstTabEffect.current = false;
+      return;
+    }
+    const remembered = useTabsStore.getState().activeScreen();
+    setScreen((remembered as ScreenId | null) ?? "history");
+    setEntryTick((t) => t + 1);
+  }, [activePath]);
 
   const intent = useNavStore((s) => s.intent);
   const clearIntent = useNavStore((s) => s.clearIntent);
@@ -307,6 +335,9 @@ export function AppShell() {
       }}
     >
       <AppTitlebar onOpenSettings={() => enterScreen("settings")} />
+      {/* Open repositories. Its own row: the titlebar has no space left, and
+          keeping it out of there preserves the drag region. */}
+      <RepoTabs />
       {/* Styled confirm/prompt host — pgConfirm/pgPrompt resolve false/null
           unless one of these is mounted. */}
       <PGDialogHost />
@@ -369,8 +400,18 @@ export function AppShell() {
           all need to know): the standing "a merge/rebase is open" signal, and
           the only route to the resolver now that the Conflicts tab is gone. */}
       <OperationBar />
-      {repo || screen === "settings" ? (
+      {/* A tab whose repository is not loaded yet (session restore is lazy) is
+          neither "a repo is open" nor "no repo at all" — showing Welcome there
+          would flash the landing screen on every switch into a pending tab. */}
+      {!repo && screen !== "settings" && activePath ? (
+        <TabLoadingScreen path={activePath} />
+      ) : repo || screen === "settings" ? (
         <AppBody
+          // Keyed by the active repository: a tab switch REMOUNTS the screen, so
+          // History's selected commit, RepoBrowser's selected file and every
+          // windowed list's scroll reset instead of carrying another
+          // repository's oids and paths into this one.
+          key={activePath ?? "no-repo"}
           screen={screen}
           screens={screens}
           setScreen={enterScreen}
@@ -380,6 +421,60 @@ export function AppShell() {
       )}
       <AppStatusBar />
       <CommandPalette />
+    </div>
+  );
+}
+
+/** The body while the active tab's repository is opening, or after its open was
+ *  refused. The error banner above carries the reason; this carries the way out. */
+function TabLoadingScreen({ path }: { path: string }) {
+  const failed = useTabsStore(
+    (s) => s.tabs.find((t) => t.path === path)?.status === "failed",
+  );
+  const name = path.split("/").filter(Boolean).pop() ?? path;
+  return (
+    <div
+      data-testid="tab-loading"
+      data-failed={failed ? "true" : "false"}
+      style={{
+        flex: 1,
+        minHeight: 0,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 10,
+        background: "var(--bg-0)",
+        fontFamily: "var(--font-mono)",
+        fontSize: "var(--fs-12)",
+        color: "var(--fg-2)",
+      }}
+    >
+      {failed ? (
+        <>
+          <div style={{ color: "var(--fg-0)" }}>Could not open {name}</div>
+          <div style={{ fontSize: "var(--fs-11)", color: "var(--fg-3)" }}>{path}</div>
+          <div style={{ display: "flex", gap: 8 }}>
+            <PGButton
+              size="sm"
+              variant="default"
+              icon="sync"
+              onClick={() => void useTabsStore.getState().activate(path)}
+            >
+              Retry
+            </PGButton>
+            <PGButton
+              size="sm"
+              variant="ghost"
+              onClick={() => void useTabsStore.getState().close(path)}
+            >
+              Close tab
+            </PGButton>
+          </div>
+        </>
+      ) : (
+        <div>Opening {name}…</div>
+      )}
     </div>
   );
 }
@@ -475,7 +570,7 @@ function AppTitlebar({ onOpenSettings }: { onOpenSettings: () => void }) {
   const status = useRepoStore((s) => s.status);
   const activity = useRepoStore((s) => s.activity);
   const refresh = useRepoStore((s) => s.refreshAll);
-  const close = useRepoStore((s) => s.closeRepo);
+  const activePath = useTabsStore((s) => s.activePath);
   const store = useRepoStore();
   const defaultPullMode = useSettingsStore((s) => s.defaultPullMode);
 
@@ -579,7 +674,13 @@ function AppTitlebar({ onOpenSettings }: { onOpenSettings: () => void }) {
                     margin: "0 4px",
                   }}
                 />
-                <PGButton size="sm" variant="ghost" onClick={close}>
+                <PGButton
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => {
+                    if (activePath) void useTabsStore.getState().close(activePath);
+                  }}
+                >
                   Close repo
                 </PGButton>
               </>

--- a/src/design/chrome.tsx
+++ b/src/design/chrome.tsx
@@ -95,6 +95,216 @@ export function PGTitlebar({
 }
 
 // ═════════════════════════════════════════════════════════
+// REPOSITORY TAB STRIP
+// ═════════════════════════════════════════════════════════
+
+export interface PGTabItem {
+  /** Stable key — the repository's workdir path. */
+  id: string;
+  label: string;
+  /** Full path, shown as the row's tooltip. */
+  title?: string;
+  active?: boolean;
+  /** Uncommitted-change count; renders a dot + number. */
+  dirty?: number;
+  /** Conflicted-file count; renders a conflict glyph + number. */
+  conflicts?: number;
+  /** True while this tab's repository is being opened. */
+  loading?: boolean;
+  /** The tab's open was rejected (path moved, deleted, refused). */
+  failed?: boolean;
+}
+
+/**
+ * The open-repository strip (#90). Its own row BELOW the titlebar, not inside
+ * it: the titlebar already carries the logo, repo name, branch chip, dirty
+ * badge, the drag region and five right-hand controls, and squeezing a
+ * scrolling strip in there would eat `data-tauri-drag-region` on a narrow
+ * window.
+ *
+ * Chrome, so a FIXED height — the UI-density token deliberately does not apply
+ * (see CLAUDE.md's density rule). The strip owns its own `overflow-x`, and each
+ * tab is `flexShrink: 0` with a max width, so a long tab list scrolls INSIDE
+ * the strip and can never widen the window (the shell is a fixed frame).
+ */
+export function PGTabStrip({
+  tabs,
+  onSelect,
+  onClose,
+  onNew,
+  onTabContextMenu,
+}: {
+  tabs: PGTabItem[];
+  onSelect?: (id: string) => void;
+  onClose?: (id: string) => void;
+  onNew?: () => void;
+  onTabContextMenu?: (id: string, e: React.MouseEvent) => void;
+}) {
+  const activeRef = React.useRef<HTMLDivElement | null>(null);
+  const activeId = tabs.find((t) => t.active)?.id ?? null;
+  // Keep the active tab reachable after a keyboard switch into an off-screen
+  // tab. `inline: "nearest"` scrolls the strip, never the page.
+  React.useEffect(() => {
+    // Optional call: jsdom has no scrollIntoView, and this is presentation —
+    // unlike a viewport MEASUREMENT, skipping it changes nothing but the scroll
+    // position (see CLAUDE.md on why measurements must not be guarded).
+    activeRef.current?.scrollIntoView?.({ block: "nearest", inline: "nearest" });
+  }, [activeId]);
+
+  return (
+    <div
+      data-testid="repo-tab-strip"
+      style={{
+        height: 28,
+        flexShrink: 0,
+        display: "flex",
+        alignItems: "stretch",
+        background: "var(--bg-titlebar)",
+        borderBottom: "1px solid var(--border-0)",
+        fontFamily: "var(--font-mono)",
+        fontSize: "var(--fs-11)",
+        userSelect: "none",
+      }}
+    >
+      <div
+        style={{
+          flex: 1,
+          minWidth: 0,
+          display: "flex",
+          alignItems: "stretch",
+          overflowX: "auto",
+          overflowY: "hidden",
+          scrollbarWidth: "none",
+        }}
+      >
+        {tabs.map((t) => (
+          <div
+            key={t.id}
+            ref={t.active ? activeRef : undefined}
+            data-testid="repo-tab"
+            data-path={t.id}
+            data-active={t.active ? "true" : "false"}
+            data-dirty={t.dirty ?? 0}
+            title={t.title ?? t.label}
+            onClick={() => onSelect?.(t.id)}
+            onAuxClick={(e) => {
+              // Middle-click closes, as in every tabbed thing.
+              if (e.button === 1) onClose?.(t.id);
+            }}
+            onContextMenu={(e) => onTabContextMenu?.(t.id, e)}
+            style={{
+              flexShrink: 0,
+              maxWidth: 220,
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              padding: "0 8px",
+              cursor: "pointer",
+              position: "relative",
+              background: t.active ? "var(--bg-0)" : "transparent",
+              color: t.active ? "var(--fg-0)" : "var(--fg-2)",
+              borderRight: "1px solid var(--border-0)",
+              opacity: t.failed ? 0.55 : 1,
+            }}
+          >
+            {t.active && (
+              <span
+                style={{
+                  position: "absolute",
+                  left: 0,
+                  right: 0,
+                  top: 0,
+                  height: 2,
+                  background: "var(--accent)",
+                }}
+              />
+            )}
+            <PGIcon
+              name={t.failed ? "warn" : "repo"}
+              size={11}
+              style={{
+                color: t.failed
+                  ? "var(--git-removed)"
+                  : t.active
+                    ? "var(--accent)"
+                    : "var(--fg-3)",
+              }}
+            />
+            <span
+              style={{
+                flex: 1,
+                minWidth: 0,
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              {t.label}
+            </span>
+            {!!t.conflicts && (
+              <span
+                title={`${t.conflicts} conflict${t.conflicts === 1 ? "" : "s"}`}
+                style={{ color: "var(--git-conflict)", fontSize: "var(--fs-10)" }}
+              >
+                ✕{t.conflicts}
+              </span>
+            )}
+            {!t.conflicts && !!t.dirty && (
+              <span
+                title={`${t.dirty} changed`}
+                style={{ color: "var(--git-modified)", fontSize: "var(--fs-10)" }}
+              >
+                ●{t.dirty}
+              </span>
+            )}
+            <button
+              data-testid="repo-tab-close"
+              data-path={t.id}
+              title="Close repository"
+              onClick={(e) => {
+                e.stopPropagation();
+                onClose?.(t.id);
+              }}
+              style={{
+                background: "transparent",
+                border: "none",
+                color: "var(--fg-3)",
+                cursor: "pointer",
+                padding: 0,
+                lineHeight: 1,
+                display: "flex",
+                alignItems: "center",
+              }}
+            >
+              <PGIcon name="x" size={10} />
+            </button>
+          </div>
+        ))}
+      </div>
+      <button
+        data-testid="repo-tab-new"
+        title="Open repository…"
+        onClick={onNew}
+        style={{
+          flexShrink: 0,
+          width: 28,
+          background: "transparent",
+          border: "none",
+          borderLeft: "1px solid var(--border-0)",
+          color: "var(--fg-2)",
+          cursor: "pointer",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <PGIcon name="plus" size={12} />
+      </button>
+    </div>
+  );
+}
+
+// ═════════════════════════════════════════════════════════
 // STATUS BAR
 // ═════════════════════════════════════════════════════════
 

--- a/src/features/cli/useCliLaunch.test.tsx
+++ b/src/features/cli/useCliLaunch.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { mockInvoke } from "@/test/invokeMock";
 import { emitMockEvent } from "@/test/eventMock";
-import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useTabsStore } from "@/features/repo/useTabsStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useCliLaunch } from "./useCliLaunch";
 
@@ -13,17 +13,18 @@ function Probe() {
 }
 
 // Zustand stores are module singletons: stub openRepo per test, restore after.
-const realOpenRepo = useRepoStore.getState().openRepo;
+// It lives on the TABS store since #90 — a forwarded launch opens a tab.
+const realOpenRepo = useTabsStore.getState().openRepo;
 let openRepo: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   openRepo = vi.fn().mockResolvedValue(undefined);
-  useRepoStore.setState({ openRepo: openRepo as never });
+  useTabsStore.setState({ openRepo: openRepo as never });
   useNavStore.getState().clearIntent();
 });
 
 afterEach(() => {
-  useRepoStore.setState({ openRepo: realOpenRepo });
+  useTabsStore.setState({ openRepo: realOpenRepo });
 });
 
 describe("useCliLaunch", () => {

--- a/src/features/cli/useCliLaunch.ts
+++ b/src/features/cli/useCliLaunch.ts
@@ -3,15 +3,17 @@ import { listen } from "@tauri-apps/api/event";
 
 import { takeLaunchIntent } from "@/lib/tauri";
 import type { LaunchIntent } from "@/lib/types";
-import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useTabsStore } from "@/features/repo/useTabsStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 
 async function handleIntent(intent: LaunchIntent | null): Promise<void> {
   if (!intent) return;
   if (intent.path) {
-    // A failed open surfaces the normal error banner; the screen switch
-    // below is harmless alongside it.
-    await useRepoStore.getState().openRepo(intent.path);
+    // Opens a TAB (#90): a forwarded `pgit ~/other-repo` from a second
+    // terminal focuses that repository's existing tab or adds one — it no
+    // longer evicts whatever the user was looking at. A failed open surfaces
+    // the normal error banner; the screen switch below is harmless alongside it.
+    await useTabsStore.getState().openRepo(intent.path);
   }
   if (intent.screen) {
     useNavStore.getState().setIntent({

--- a/src/features/create/useCreateStore.ownership.test.ts
+++ b/src/features/create/useCreateStore.ownership.test.ts
@@ -5,7 +5,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useCreateStore } from "@/features/create/useCreateStore";
-import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useTabsStore } from "@/features/repo/useTabsStore";
 import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
 
 const confirmTrust = vi.hoisted(() => vi.fn());
@@ -32,8 +32,8 @@ const ARGS = { parentDir: "/mnt/c/dev", name: "fresh", branch: "main" };
 describe("useCreateStore.runInit — dubious ownership", () => {
   beforeEach(() => {
     useCreateStore.setState({ open: "init", busy: false, progress: null, error: null });
-    // The follow-up open is the repo store's business, not this test's.
-    useRepoStore.setState({ openRepo: async () => {} });
+    // The follow-up open is the tab store's business, not this test's.
+    useTabsStore.setState({ openRepo: async () => {} });
     confirmTrust.mockReset();
     mockInvoke("trust_repo_path", () => null);
   });

--- a/src/features/create/useCreateStore.ts
+++ b/src/features/create/useCreateStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 import { confirmTrust } from "@/features/repo/ownership";
 import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useTabsStore } from "@/features/repo/useTabsStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { useAuthStore } from "@/features/auth/useAuthStore";
 import {
@@ -79,7 +80,7 @@ export const useCreateStore = create<CreateState>((set, get) => ({
       // busy false BEFORE close(), which refuses to close while busy.
       set({ busy: false, progress: null });
       set({ open: "none" });
-      await useRepoStore.getState().openRepo(dest);
+      await useTabsStore.getState().openRepo(dest);
     };
 
     try {
@@ -138,7 +139,7 @@ export const useCreateStore = create<CreateState>((set, get) => ({
     const finish = async (handle: RepoHandle) => {
       useSettingsStore.getState().set("lastCreateDir", parentDir);
       set({ busy: false, open: "none" });
-      await useRepoStore.getState().openRepo(handle.path);
+      await useTabsStore.getState().openRepo(handle.path);
     };
     try {
       await finish(await initRepo(path, branch));

--- a/src/features/keymap/CheatSheet.tsx
+++ b/src/features/keymap/CheatSheet.tsx
@@ -19,6 +19,15 @@ const CATEGORY_ORDER: ActionCategory[] = [
   "App",
 ];
 
+/** A whole family of chords (Alt+1…Alt+9 for `tab.select`) reads as a range, not
+ *  as nine slash-separated entries that swamp the row it belongs to. */
+function formatBindings(chords: string[]): string {
+  if (chords.length > 3) {
+    return `${formatChord(chords[0])}–${formatChord(chords[chords.length - 1])}`;
+  }
+  return chords.map((c) => formatChord(c)).join(" / ");
+}
+
 export function CheatSheet() {
   const open = useOverlayStore((s) => s.cheatSheetOpen);
   const close = useOverlayStore((s) => s.closeCheatSheet);
@@ -100,9 +109,7 @@ export function CheatSheet() {
                       fontFamily: "var(--font-mono, monospace)",
                     }}
                   >
-                    {(preset.bindings[id] ?? [])
-                      .map((c) => formatChord(c))
-                      .join(" / ")}
+                    {formatBindings(preset.bindings[id] ?? [])}
                   </span>
                 </div>
               ))}

--- a/src/features/keymap/actions.ts
+++ b/src/features/keymap/actions.ts
@@ -26,9 +26,10 @@ import {
   unstageAllOp,
 } from "@/features/repo/ops";
 import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useTabsStore } from "@/features/repo/useTabsStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { useUpdateStore } from "@/features/update/useUpdateStore";
-import { createBranchInputStep } from "@/features/palette/steps";
+import { createBranchInputStep, switchRepoStep } from "@/features/palette/steps";
 import { useFocusStore } from "./useFocusStore";
 import { useOverlayStore } from "./useOverlayStore";
 
@@ -97,7 +98,12 @@ export type ActionId =
   | "repo.open"
   | "repo.clone"
   | "repo.init"
-  | "forge.createPr";
+  | "forge.createPr"
+  | "tab.next"
+  | "tab.prev"
+  | "tab.close"
+  | "tab.select"
+  | "tab.switch";
 
 export interface ActionDef {
   id: ActionId;
@@ -112,8 +118,12 @@ export interface ActionDef {
    *  the caret (Alt+Arrow is word/paragraph movement on macOS). */
   suppressInInput?: boolean;
   /** Default runner, used when no mounted handler claims the action.
-   *  Return `false` to decline. */
-  run?: () => boolean | void;
+   *  Return `false` to decline.
+   *
+   *  Receives the chord that resolved to this action, so ONE action can serve a
+   *  family of chords (`tab.select` on Alt+1…Alt+9) instead of needing nine
+   *  catalog entries and nine cheat-sheet rows. Almost every runner ignores it. */
+  run?: (chord?: string) => boolean | void;
 }
 
 function navTo(screen: string): () => boolean {
@@ -137,6 +147,13 @@ function onInteractiveElement(): boolean {
     (tag === "A" && el.hasAttribute("href")) ||
     el.isContentEditable === true
   );
+}
+
+/** Cycle repository tabs, declining when there is nothing to cycle to. */
+function stepTab(delta: 1 | -1): boolean {
+  if (useTabsStore.getState().tabs.length < 2) return false;
+  void useTabsStore.getState().step(delta);
+  return true;
 }
 
 function cyclePane(delta: 1 | -1): () => boolean {
@@ -351,6 +368,70 @@ export const ACTIONS: Record<ActionId, ActionDef> = {
       if (useForgeStore.getState().gate() !== "ready") return false;
       useForgeStore.getState().openCreate();
       useNavStore.getState().setIntent({ kind: "switch-screen", screen: "pulls" });
+      return true;
+    },
+  },
+
+  // ── repository tabs (#90) ────────────────────────────────────────────────
+  // `repo.open` above is the "open in a new tab" action: openRepo means "open a
+  // tab" everywhere now, so a second action for the same key would be two
+  // cheat-sheet rows for one behavior.
+  "tab.next": {
+    id: "tab.next",
+    title: "Next repository tab",
+    category: "Repository",
+    scope: "global",
+    run: () => stepTab(1),
+  },
+  "tab.prev": {
+    id: "tab.prev",
+    title: "Previous repository tab",
+    category: "Repository",
+    scope: "global",
+    run: () => stepTab(-1),
+  },
+  "tab.close": {
+    id: "tab.close",
+    title: "Close repository tab",
+    category: "Repository",
+    scope: "global",
+    run: () => {
+      const path = useTabsStore.getState().activePath;
+      if (!path) return false;
+      void useTabsStore.getState().close(path);
+      return true;
+    },
+  },
+  "tab.select": {
+    id: "tab.select",
+    title: "Switch to repository 1–9",
+    category: "Repository",
+    scope: "global",
+    // suppressInInput, for the same reason Alt+Arrow carries it: ⌥+digit is a
+    // CHARACTER on macOS, and on Nordic layouts it is one people type (⌥1 "¡",
+    // and the range covers ", @, £, $ neighbours). Claiming it while a commit
+    // message, a filter box or the resolver's CodeMirror pane has focus would
+    // silently eat the keystroke. `isEditable` in the dispatcher covers input,
+    // textarea and contentEditable (CM6's editor), so all three are safe.
+    suppressInInput: true,
+    run: (chord) => {
+      // Bound to Alt+1…Alt+9; the digit IS the argument. `eventToChord` takes
+      // digits from `e.code`, so this is layout-independent. Optional because
+      // the catalog's runners are also callable directly (tests, the palette).
+      const n = Number((chord ?? "").slice((chord ?? "").lastIndexOf("+") + 1));
+      if (!Number.isInteger(n) || n < 1 || n > 9) return false;
+      if (!useTabsStore.getState().tabs[n - 1]) return false;
+      void useTabsStore.getState().selectIndex(n);
+      return true;
+    },
+  },
+  "tab.switch": {
+    id: "tab.switch",
+    title: "Switch repository…",
+    category: "Repository",
+    scope: "global",
+    run: () => {
+      usePaletteStore.getState().pushStep(switchRepoStep());
       return true;
     },
   },

--- a/src/features/keymap/presets.test.ts
+++ b/src/features/keymap/presets.test.ts
@@ -161,3 +161,42 @@ describe("platypusgit preset", () => {
     expect(PLATYPUSGIT_PRESET.bindings["palette.open"]).not.toContain("Ctrl+V");
   });
 });
+
+describe("repository tabs (#90)", () => {
+  // Every preset binds them (the catalog-coverage test above enforces that);
+  // these pin the SHAPE of the chords, which is what makes them work on every
+  // platform and stay clear of AltGr.
+  for (const preset of BUILTIN_PRESETS) {
+    it(`${preset.id}: next/prev/close carry both the literal-Ctrl and Mod forms`, () => {
+      // macOS delivers ⌃Tab/⌃W (⌘Tab is the OS app switcher, ⌘W may be Tauri's
+      // window menu); Windows/Linux normalize physical Ctrl to Mod, so only the
+      // Mod spelling is ever produced there. Both = one table, every platform.
+      expect(preset.bindings["tab.next"]).toEqual(["Ctrl+Tab", "Mod+Tab"]);
+      expect(preset.bindings["tab.prev"]).toEqual([
+        "Ctrl+Shift+Tab",
+        "Mod+Shift+Tab",
+      ]);
+      expect(preset.bindings["tab.close"]).toEqual(["Ctrl+W", "Mod+W"]);
+    });
+
+    it(`${preset.id}: tab.select is Alt+1..Alt+9, never Mod+Alt+<digit>`, () => {
+      const chords = preset.bindings["tab.select"] ?? [];
+      expect(chords).toHaveLength(9);
+      chords.forEach((c, i) => expect(c).toBe(`Alt+${i + 1}`));
+      // Ctrl+Alt is AltGr on Windows, and AltGr+2 / AltGr+4 type characters on
+      // Nordic layouts — the same hazard the Mod+Alt+<letter> rule polices.
+      for (const c of chords) expect(c).not.toMatch(/^Mod\+Alt\+/);
+    });
+
+    it(`${preset.id}: the screen numbers keep Mod+<digit> to themselves`, () => {
+      const rev = buildReverseMap(preset);
+      for (let n = 1; n <= 9; n++) {
+        expect(rev.get(`Mod+${n}`) ?? []).not.toContain("tab.select");
+      }
+    });
+
+    it(`${preset.id}: tab.switch is Rider's recent-files chord`, () => {
+      expect(preset.bindings["tab.switch"]).toEqual(["Mod+E"]);
+    });
+  }
+});

--- a/src/features/keymap/presets.ts
+++ b/src/features/keymap/presets.ts
@@ -105,6 +105,25 @@ const COMMON = {
   // failure rather than a silent shadow — which is the intended outcome.
   "nav.submodules": ["Mod+Shift+6"],
   "nav.worktrees": ["Mod+Shift+7"],
+  // Repository tabs (#90). Each of the first three carries BOTH the literal-Ctrl
+  // and the Mod form on purpose, and that makes them correct on every platform
+  // with one table: on macOS `Mod+Tab`/`Mod+W` are ⌘Tab (taken by the OS app
+  // switcher, never delivered) and ⌘W (Tauri's default window menu may claim
+  // it), so ⌃Tab/⌃W are the ones that reach us; on Windows/Linux physical Ctrl
+  // normalizes to `Mod`, so the `Ctrl+…` spellings are never produced and the
+  // `Mod+…` ones are the conventional chords. Same construction as the Ctrl+V
+  // palette nod above.
+  "tab.next": ["Ctrl+Tab", "Mod+Tab"],
+  "tab.prev": ["Ctrl+Shift+Tab", "Mod+Shift+Tab"],
+  "tab.close": ["Ctrl+W", "Mod+W"],
+  // NOT Mod+1..9 (screen navigation) and NOT Mod+Alt+<digit> — Ctrl+Alt is
+  // AltGr on Windows, and AltGr+2 / AltGr+4 type characters on Nordic layouts,
+  // exactly the hazard presets.test.ts polices for letters. Plain Alt+<digit>
+  // is unbound in both presets and Alt is already this keymap's second
+  // modifier (Alt+Arrow moves panes).
+  "tab.select": ["Alt+1", "Alt+2", "Alt+3", "Alt+4", "Alt+5", "Alt+6", "Alt+7", "Alt+8", "Alt+9"],
+  // Rider's ⌘E ("Recent files") — the palette's repository switcher.
+  "tab.switch": ["Mod+E"],
 } satisfies Partial<Record<ActionId, string[]>>;
 
 export const RIDER_PRESET: KeymapPreset = {

--- a/src/features/keymap/useKeymapStore.test.tsx
+++ b/src/features/keymap/useKeymapStore.test.tsx
@@ -302,3 +302,64 @@ describe("dispatch", () => {
     });
   });
 });
+
+// ⌥+digit is a character on macOS — and on Nordic layouts one people actually
+// type — so repository-tab selection must not claim it while text has focus
+// (#90 follow-up).
+describe("tab.select input policy", () => {
+  beforeEach(resetStores);
+
+  const altDigit = (target?: EventTarget) =>
+    key(
+      { key: "1", code: "Digit1", metaKey: false, altKey: true },
+      target ?? document.body,
+    );
+
+  it("fires outside a text field", () => {
+    const spy = vi.fn();
+    const un = useKeymapStore.getState().register("tab.select", spy);
+    expect(useKeymapStore.getState().dispatch(altDigit())).toBe(true);
+    expect(spy).toHaveBeenCalledOnce();
+    un();
+  });
+
+  it("is suppressed inside an input, a textarea and a contentEditable", () => {
+    const spy = vi.fn();
+    const un = useKeymapStore.getState().register("tab.select", spy);
+    const editable = document.createElement("div");
+    // jsdom does not derive isContentEditable from the attribute.
+    Object.defineProperty(editable, "isContentEditable", { value: true });
+
+    for (const target of [
+      document.createElement("input"),
+      document.createElement("textarea"),
+      editable,
+    ]) {
+      const prevent = vi.fn();
+      const handled = useKeymapStore
+        .getState()
+        .dispatch({ ...altDigit(target), preventDefault: prevent } as never);
+      // Unhandled AND not prevented — the character has to reach the field.
+      expect(handled).toBe(false);
+      expect(prevent).not.toHaveBeenCalled();
+    }
+    expect(spy).not.toHaveBeenCalled();
+    un();
+  });
+
+  it("leaves the tab cycling chords live while typing (they type nothing)", () => {
+    const spy = vi.fn();
+    const un = useKeymapStore.getState().register("tab.next", spy);
+    const handled = useKeymapStore
+      .getState()
+      .dispatch(
+        key(
+          { key: "Tab", code: "", metaKey: false, ctrlKey: true },
+          document.createElement("textarea"),
+        ),
+      );
+    expect(handled).toBe(true);
+    expect(spy).toHaveBeenCalledOnce();
+    un();
+  });
+});

--- a/src/features/keymap/useKeymapStore.ts
+++ b/src/features/keymap/useKeymapStore.ts
@@ -223,7 +223,11 @@ export const useKeymapStore = create<KeymapState>((set, get) => {
           }
         }
         if (!handled && def.scope === "global" && def.run) {
-          handled = def.run() !== false;
+          // The chord is passed so one action can serve a FAMILY of chords —
+          // `tab.select` is bound to Alt+1…Alt+9 and reads its digit from here
+          // rather than needing nine catalog entries. Every other runner
+          // ignores the argument.
+          handled = def.run(chord) !== false;
         }
         if (handled) {
           e.preventDefault();

--- a/src/features/merge/openMergeWindow.ts
+++ b/src/features/merge/openMergeWindow.ts
@@ -6,6 +6,67 @@ import { emit } from "@tauri-apps/api/event";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 
 /**
+ * Which repository a live resolver window is working on, as far as THIS webview
+ * knows — the window carries its `repoId` in its own URL, and main has no way to
+ * read that back. `attributed` is false when a live window was not opened by this
+ * page instance (main reloaded while the resolver stayed up), which callers must
+ * treat as "it might be any repository".
+ */
+let liveMerge: { repoId: string; attributed: boolean } | null = null;
+
+/** Test-only: forget which repository a live resolver is on, the state a fresh
+ *  page load starts from. Same shape as `__resetDialogs`. */
+export function __resetMergeAttribution(): void {
+  liveMerge = null;
+}
+
+/**
+ * True when a resolver window is live and might be resolving `repoId`.
+ *
+ * Used before evicting a repository backend-side (#90): the resolver is a
+ * separate window driving IPC with that `RepoId`, so closing its repository
+ * underneath would make its next call fail with `UnknownRepo` mid-resolution. An
+ * unattributed window counts as a match on purpose — one extra confirmation is
+ * far cheaper than breaking a conflict resolution in progress.
+ */
+export async function mergeWindowHoldsRepo(repoId: string): Promise<boolean> {
+  const existing = await WebviewWindow.getByLabel("merge");
+  if (!existing) {
+    liveMerge = null;
+    return false;
+  }
+  if (!liveMerge || !liveMerge.attributed) return true;
+  return liveMerge.repoId === repoId;
+}
+
+/**
+ * Close the resolver window and resolve once it is really gone, so the caller
+ * can safely evict the repository it was using.
+ *
+ * Deliberately bypasses the window's own unapplied-progress confirm: the caller
+ * has already asked in the main window, which is where the user's attention is.
+ */
+export async function closeMergeWindow(): Promise<void> {
+  const existing = await WebviewWindow.getByLabel("merge");
+  if (!existing) {
+    liveMerge = null;
+    return;
+  }
+  await existing.close().catch(() => {
+    // Already gone, or refused — the poll below is the real answer either way.
+  });
+  // `close()` resolves when the request is delivered, not when the window is
+  // destroyed. Evicting before then is exactly the race this function exists to
+  // avoid, so wait for the label to disappear (bounded: a stuck window must not
+  // hang the tab close forever).
+  for (let i = 0; i < 40; i++) {
+    if (!(await WebviewWindow.getByLabel("merge"))) break;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  liveMerge = null;
+}
+
+/**
  * `path` is optional: the operation bar, the status-bar count and the
  * `conflict.openResolver` chord all open the resolver on the repository rather
  * than on one file (#108), and the window then picks the first unresolved file
@@ -18,8 +79,11 @@ export async function openMergeWindow(repoId: string, path?: string): Promise<vo
     // file the user is in the middle of — see MergeWindow's listener.
     await emit("merge://open-file", { repoId, path: path ?? null });
     await existing.setFocus();
+    // A retarget changes which repository the window is on, so re-attribute it.
+    liveMerge = { repoId, attributed: true };
     return;
   }
+  liveMerge = { repoId, attributed: true };
   const params = new URLSearchParams({ window: "merge", repoId });
   if (path) params.set("path", path);
   const win = new WebviewWindow("merge", {
@@ -31,8 +95,13 @@ export async function openMergeWindow(repoId: string, path?: string): Promise<vo
     title: path ? `Resolve: ${path}` : "Resolve conflicts",
   });
   // Any exit path (Apply-through-last-file, Esc, OS close button) must leave
-  // the main window showing disk truth.
+  // the main window showing disk truth — but only for the repository this
+  // resolver was opened for. With multiple repositories open in tabs (#90) an
+  // unguarded refresh here would re-read whichever repo happens to be active by
+  // the time the window closes.
   void win.once("tauri://destroyed", () => {
+    if (liveMerge?.repoId === repoId) liveMerge = null;
+    if (useRepoStore.getState().current?.id !== repoId) return;
     void useRepoStore.getState().refreshAll();
   });
   void win.once("tauri://error", (e) => {

--- a/src/features/palette/commands.test.ts
+++ b/src/features/palette/commands.test.ts
@@ -2,6 +2,9 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { branchItems, buildCommands, commitItems, fileItems } from "./commands";
 import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useRecentsStore } from "@/features/repo/useRecentsStore";
+import { useTabsStore } from "@/features/repo/useTabsStore";
+import { newTab } from "@/features/repo/tabs";
 import { useCreateStore } from "@/features/create/useCreateStore";
 import { paletteInitial, usePaletteStore } from "./usePaletteStore";
 import type { BranchInfo, CommitInfo, FileStatus, StashInfo } from "@/lib/types";
@@ -163,6 +166,64 @@ describe("buildCommands", () => {
     expect(step.kind).toBe("pick");
     // only non-head branches offered as merge sources
     expect(step.items.map((i) => i.label)).toEqual(["feat/x"]);
+  });
+
+  describe("repository tabs (#90)", () => {
+    beforeEach(() => {
+      useTabsStore.setState({ tabs: [], activePath: null, activationSeq: 0 });
+      useRecentsStore.setState({ recents: [] });
+    });
+
+    it("always offers the switcher — it is the only keyboard route to a recent repo", () => {
+      const byId = new Map(buildCommands().map((i) => [i.id, i]));
+      expect(byId.get("action:switch-repo")?.actionId).toBe("tab.switch");
+    });
+
+    it("offers close-tab only with a repository open", () => {
+      expect(ids()).not.toContain("action:close-repo-tab");
+      useTabsStore.setState({
+        tabs: [newTab("/dev/api", { status: "open", repoId: "r1" })],
+        activePath: "/dev/api",
+      });
+      const byId = new Map(buildCommands().map((i) => [i.id, i]));
+      expect(byId.get("action:close-repo-tab")?.actionId).toBe("tab.close");
+      // A row that only ever says "nothing to close" would be permanent noise.
+      expect(ids()).not.toContain("action:close-other-repo-tabs");
+    });
+
+    it("offers close-others only with two or more tabs", () => {
+      useTabsStore.setState({
+        tabs: [
+          newTab("/dev/api", { status: "open", repoId: "r1" }),
+          newTab("/dev/web", { status: "open", repoId: "r2" }),
+        ],
+        activePath: "/dev/api",
+      });
+      expect(ids()).toContain("action:close-other-repo-tabs");
+    });
+
+    it("the switcher lists open tabs first, then unopened recents", () => {
+      useTabsStore.setState({
+        tabs: [newTab("/dev/api", { status: "open", repoId: "r1" })],
+        activePath: "/dev/api",
+      });
+      useRecentsStore.setState({
+        recents: [
+          { path: "/dev/api", openedAt: 2 },
+          { path: "/dev/old", openedAt: 1 },
+        ],
+      });
+      const pushed: unknown[] = [];
+      usePaletteStore.setState({ pushStep: (st: import("./types").PaletteStep) => pushed.push(st) } as never);
+      buildCommands().find((i) => i.id === "action:switch-repo")!.run();
+      const step = pushed[0] as { items: { id: string; label: string; detail?: string }[] };
+      // The already-open recent is not listed twice.
+      expect(step.items.map((i) => i.id)).toEqual([
+        "repo-tab:/dev/api",
+        "repo-recent:/dev/old",
+      ]);
+      expect(step.items[0].detail).toBe("current");
+    });
   });
 
   it("action:checkout-ref is always in the catalog", () => {

--- a/src/features/palette/commands.ts
+++ b/src/features/palette/commands.ts
@@ -9,8 +9,9 @@ import { useForgeStore } from "@/features/forge/useForgeStore";
 import { prNoun, prNumberLabel } from "@/features/forge/forgeLabels";
 import { useSubmodulesStore } from "@/features/submodules/useSubmodulesStore";
 import { useWorktreesStore } from "@/features/worktrees/useWorktreesStore";
+import { useTabsStore } from "@/features/repo/useTabsStore";
 import { usePaletteStore } from "./usePaletteStore";
-import { createBranchInputStep } from "./steps";
+import { createBranchInputStep, switchRepoStep } from "./steps";
 import { currentBranch, isConflicted, relativeTime } from "@/lib/derive";
 import { headUpstream, resolveConflictsOp } from "@/features/repo/ops";
 import type { ActionId } from "@/features/keymap";
@@ -263,6 +264,52 @@ export function buildCommands(): PaletteItem[] {
       run: direct(() => useCreateStore.getState().openInit()),
     },
   );
+
+  // -- repository tabs (#90) --
+  // Always listed: with one repository open it is still how you reach a recent
+  // one without the native folder dialog (the only keyboard route to it).
+  items.push({
+    type: "command", id: "action:switch-repo",
+    search: "Switch repository tab open recent",
+    label: "Switch repository…", icon: "repo", actionId: "tab.switch",
+    run: step(() => switchRepoStep()),
+  });
+  const tabs = useTabsStore.getState();
+  if (tabs.activePath) {
+    items.push({
+      type: "command", id: "action:close-repo-tab",
+      search: "Close repository tab", label: "Close repository tab",
+      icon: "x", actionId: "tab.close",
+      run: direct(() => {
+        const path = useTabsStore.getState().activePath;
+        if (path) void useTabsStore.getState().close(path);
+      }),
+    });
+  }
+  if (tabs.tabs.length > 1) {
+    const keep = tabs.activePath;
+    items.push({
+      type: "command", id: "action:close-other-repo-tabs",
+      search: "Close other repository tabs",
+      label: "Close other repository tabs", danger: true, icon: "trash",
+      run: direct(() => {
+        void (async () => {
+          if (
+            keep &&
+            (await pgConfirm({
+              title: `Close ${tabs.tabs.length - 1} other repositor${
+                tabs.tabs.length - 1 === 1 ? "y" : "ies"
+              }?`,
+              body: "Only closes the tabs — nothing on disk changes.",
+              confirmLabel: "Close others",
+            }))
+          ) {
+            await useTabsStore.getState().closeOthers(keep);
+          }
+        })();
+      }),
+    });
+  }
 
   // -- smart push / pull / force-push (need a current branch) --
   if (headName) {

--- a/src/features/palette/steps.ts
+++ b/src/features/palette/steps.ts
@@ -3,8 +3,11 @@
 // module with no keymap imports to keep the dependency graph acyclic.
 
 import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useRecentsStore } from "@/features/repo/useRecentsStore";
+import { useTabsStore } from "@/features/repo/useTabsStore";
+import { labelTabs, repoDisplayName } from "@/features/repo/tabs";
 import { usePaletteStore } from "./usePaletteStore";
-import type { PaletteStep } from "./types";
+import type { PaletteItem, PaletteStep } from "./types";
 
 /** The "Create branch" input step — used by the palette command and ⌘N. */
 export function createBranchInputStep(): PaletteStep {
@@ -20,4 +23,46 @@ export function createBranchInputStep(): PaletteStep {
         .createAndSwitchBranch(v.trim(), { autoStash: true });
     },
   };
+}
+
+/**
+ * The "Switch repository" pick step — used by the palette command and ⌘E.
+ *
+ * Lists every OPEN tab first, then the recents that are not open (which open in
+ * a new tab when picked). The second half matters beyond convenience: it is the
+ * only keyboard-reachable way to open another repository without the native
+ * folder dialog.
+ */
+export function switchRepoStep(): PaletteStep {
+  const { tabs, activePath } = useTabsStore.getState();
+  const openPaths = new Set(tabs.map((t) => t.path));
+  const labels = labelTabs(tabs);
+  const items: PaletteItem[] = tabs.map((t, i) => ({
+    type: "command" as const,
+    id: `repo-tab:${t.path}`,
+    search: `${labels[i]} ${t.path}`,
+    label: labels[i],
+    detail: t.path === activePath ? "current" : t.path,
+    icon: "repo",
+    run: () => {
+      usePaletteStore.getState().closePalette();
+      void useTabsStore.getState().activate(t.path);
+    },
+  }));
+  for (const r of useRecentsStore.getState().recents) {
+    if (openPaths.has(r.path)) continue;
+    items.push({
+      type: "command" as const,
+      id: `repo-recent:${r.path}`,
+      search: `${repoDisplayName(r.path)} ${r.path} open recent`,
+      label: repoDisplayName(r.path),
+      detail: r.path,
+      icon: "folder",
+      run: () => {
+        usePaletteStore.getState().closePalette();
+        void useTabsStore.getState().openRepo(r.path);
+      },
+    });
+  }
+  return { kind: "pick", title: "Switch repository", items };
 }

--- a/src/features/repo/RepoTabs.test.tsx
+++ b/src/features/repo/RepoTabs.test.tsx
@@ -1,0 +1,158 @@
+// The strip (#90): one row per open repository, the active one marked, and the
+// close verbs — single close silent, bulk close confirmed.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+
+import { WithDialogs, acceptDialog, dialogTitle, resetDialogs } from "@/test/dialog";
+import { RepoTabs } from "./RepoTabs";
+import { newTab, type RepoTab } from "./tabs";
+import { useTabsStore } from "./useTabsStore";
+
+// Partial: the keymap catalog imports the other ops from this module, and a
+// full replacement would break its module init.
+vi.mock("./ops", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./ops")>()),
+  openRepoDialog: vi.fn().mockResolvedValue(undefined),
+}));
+import { openRepoDialog } from "./ops";
+
+function seed(tabs: RepoTab[], activePath: string | null) {
+  useTabsStore.setState({
+    tabs,
+    activePath,
+    // Stub the async actions: this file is about the strip, not the switch.
+    activate: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    closeOthers: vi.fn().mockResolvedValue(undefined),
+    closeAll: vi.fn().mockResolvedValue(undefined),
+    refreshBadges: vi.fn().mockResolvedValue(undefined),
+  } as never);
+}
+
+const open = (path: string, over: Partial<RepoTab> = {}) =>
+  newTab(path, { status: "open", repoId: path, ...over });
+
+beforeEach(() => {
+  resetDialogs();
+  vi.mocked(openRepoDialog).mockClear();
+  useTabsStore.setState({
+    tabs: [],
+    activePath: null,
+    activationSeq: 0,
+    activating: null,
+  });
+});
+
+function rows() {
+  return Array.from(document.querySelectorAll('[data-testid="repo-tab"]'));
+}
+
+describe("RepoTabs", () => {
+  it("renders nothing without an open repository", () => {
+    render(<RepoTabs />);
+    expect(screen.queryByTestId("repo-tab-strip")).toBeNull();
+  });
+
+  it("renders one row per tab and marks the active one", () => {
+    seed([open("/dev/api"), open("/dev/web")], "/dev/web");
+    render(<RepoTabs />);
+    expect(rows().map((r) => r.getAttribute("data-path"))).toEqual([
+      "/dev/api",
+      "/dev/web",
+    ]);
+    expect(rows().map((r) => r.getAttribute("data-active"))).toEqual([
+      "false",
+      "true",
+    ]);
+    expect(screen.getByText("api")).toBeTruthy();
+    expect(screen.getByText("web")).toBeTruthy();
+  });
+
+  it("disambiguates colliding repository names by parent directory", () => {
+    seed([open("/work/acme/api"), open("/work/beta/api")], "/work/acme/api");
+    render(<RepoTabs />);
+    expect(screen.getByText("acme/api")).toBeTruthy();
+    expect(screen.getByText("beta/api")).toBeTruthy();
+  });
+
+  it("shows the dirty count, and the conflict count in its place", () => {
+    seed(
+      [open("/dev/api", { dirty: 3 }), open("/dev/web", { dirty: 2, conflicts: 1 })],
+      "/dev/api",
+    );
+    render(<RepoTabs />);
+    expect(screen.getByText("●3")).toBeTruthy();
+    // A conflict outranks the dirty dot — it is the thing that needs attention.
+    expect(screen.getByText("✕1")).toBeTruthy();
+    expect(screen.queryByText("●2")).toBeNull();
+  });
+
+  it("clicking a tab activates it", () => {
+    seed([open("/dev/api"), open("/dev/web")], "/dev/web");
+    render(<RepoTabs />);
+    fireEvent.click(rows()[0]);
+    expect(useTabsStore.getState().activate).toHaveBeenCalledWith("/dev/api");
+  });
+
+  it("the close button closes that tab without confirming", () => {
+    seed([open("/dev/api"), open("/dev/web")], "/dev/web");
+    render(<WithDialogs><RepoTabs /></WithDialogs>);
+    fireEvent.click(
+      document.querySelector('[data-testid="repo-tab-close"][data-path="/dev/api"]') as Element,
+    );
+    // Closing a tab closes a VIEW — nothing on disk is lost, so a prompt there
+    // would misrepresent the stakes.
+    expect(dialogTitle()).toBeNull();
+    expect(useTabsStore.getState().close).toHaveBeenCalledWith("/dev/api");
+  });
+
+  it("the + button opens the folder picker", () => {
+    seed([open("/dev/api")], "/dev/api");
+    render(<RepoTabs />);
+    fireEvent.click(screen.getByTestId("repo-tab-new"));
+    expect(openRepoDialog).toHaveBeenCalled();
+  });
+
+  it("close others confirms first, then closes", async () => {
+    seed([open("/dev/api"), open("/dev/web")], "/dev/api");
+    render(<WithDialogs><RepoTabs /></WithDialogs>);
+    fireEvent.contextMenu(rows()[1]);
+    await act(async () => {
+      fireEvent.click(screen.getByText("Close others"));
+    });
+    expect(dialogTitle()).toBe("Close 1 other repository?");
+    await acceptDialog();
+    expect(useTabsStore.getState().closeOthers).toHaveBeenCalledWith("/dev/web");
+  });
+
+  it("close all confirms and can be declined", async () => {
+    seed([open("/dev/api"), open("/dev/web")], "/dev/api");
+    render(<WithDialogs><RepoTabs /></WithDialogs>);
+    fireEvent.contextMenu(rows()[0]);
+    await act(async () => {
+      fireEvent.click(screen.getByText("Close all"));
+    });
+    expect(dialogTitle()).toBe("Close all 2 repositories?");
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("dialog-cancel"));
+    });
+    expect(useTabsStore.getState().closeAll).not.toHaveBeenCalled();
+  });
+
+  it("refreshes background badges when the window regains focus", () => {
+    seed([open("/dev/api"), open("/dev/web")], "/dev/api");
+    render(<RepoTabs />);
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    expect(useTabsStore.getState().refreshBadges).toHaveBeenCalled();
+  });
+
+  it("dims a tab whose repository could not be opened", () => {
+    seed([open("/dev/api"), newTab("/dev/gone", { status: "failed" })], "/dev/api");
+    render(<RepoTabs />);
+    expect(rows()[1].getAttribute("data-path")).toBe("/dev/gone");
+    expect(Number(getComputedStyle(rows()[1] as Element).opacity)).toBeLessThan(1);
+  });
+});

--- a/src/features/repo/RepoTabs.tsx
+++ b/src/features/repo/RepoTabs.tsx
@@ -1,0 +1,127 @@
+// The open-repository strip's wiring (#90): `useTabsStore` → `PGTabStrip`.
+//
+// Rendered by AppShell below the titlebar, only while at least one repository is
+// open, so the Welcome screen is untouched.
+
+import React from "react";
+
+import {
+  PGTabStrip,
+  pgConfirm,
+  pgFlash,
+  useContextMenu,
+  type ContextMenuItem,
+  type PGTabItem,
+} from "@/design";
+import { openRepoDialog } from "./ops";
+import { labelTabs } from "./tabs";
+import { useTabsStore } from "./useTabsStore";
+
+export function RepoTabs() {
+  const tabs = useTabsStore((s) => s.tabs);
+  const activePath = useTabsStore((s) => s.activePath);
+  const refreshBadges = useTabsStore((s) => s.refreshBadges);
+  // Memoized, not a store selector: `labelTabs` builds a fresh array, which as
+  // a selector result would fail zustand's identity check and re-render the
+  // strip on every unrelated store write.
+  const labels = React.useMemo(() => labelTabs(tabs), [tabs]);
+
+  // Badges for INACTIVE tabs are frozen at the moment their tab was left. One
+  // `get_status` each on window focus is what makes them honest again after you
+  // commit in an editor and alt-tab back — cheap, and no background polling.
+  React.useEffect(() => {
+    const onFocus = () => {
+      void refreshBadges();
+    };
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [refreshBadges]);
+
+  const items: PGTabItem[] = tabs.map((t, i) => ({
+    id: t.path,
+    label: labels[i] ?? t.path,
+    title: t.path,
+    active: t.path === activePath,
+    dirty: t.dirty,
+    conflicts: t.conflicts,
+    failed: t.status === "failed",
+  }));
+
+  const menu = useContextMenu<string>((path) => tabMenuItems(path, tabs.length));
+
+  if (tabs.length === 0) return null;
+
+  return (
+    <>
+      <PGTabStrip
+        tabs={items}
+        onSelect={(id) => void useTabsStore.getState().activate(id)}
+        onClose={(id) => void useTabsStore.getState().close(id)}
+        onNew={() => void openRepoDialog()}
+        onTabContextMenu={(id, e) => menu.onContextMenu(e, id)}
+      />
+      {menu.menu}
+    </>
+  );
+}
+
+/**
+ * Closing ONE tab is never confirmed — it closes a view, and nothing on disk is
+ * lost by it, so a prompt there would misrepresent the stakes. The bulk verbs
+ * are confirmed, because "close six of these" is not undoable.
+ */
+export function tabMenuItems(path: string, total: number): ContextMenuItem[] {
+  const tabs = () => useTabsStore.getState();
+  return [
+    { __menuTitle: "Repository" },
+    {
+      label: "Close",
+      icon: "x",
+      onClick: () => void tabs().close(path),
+    },
+    {
+      label: "Close others",
+      icon: "trash",
+      disabled: total < 2,
+      onClick: async () => {
+        if (
+          await pgConfirm({
+            title: `Close ${total - 1} other repositor${total - 1 === 1 ? "y" : "ies"}?`,
+            body: "Only closes the tabs — nothing on disk changes.",
+            confirmLabel: "Close others",
+          })
+        ) {
+          await tabs().closeOthers(path);
+        }
+      },
+    },
+    {
+      label: "Close all",
+      icon: "trash",
+      danger: true,
+      onClick: async () => {
+        if (
+          await pgConfirm({
+            title: `Close all ${total} repositor${total === 1 ? "y" : "ies"}?`,
+            body: "Only closes the tabs — nothing on disk changes.",
+            danger: true,
+            confirmLabel: "Close all",
+          })
+        ) {
+          await tabs().closeAll();
+        }
+      },
+    },
+    { divider: true },
+    {
+      label: "Copy path",
+      icon: "copy",
+      onClick: () => {
+        void navigator.clipboard
+          ?.writeText(path)
+          .then(() => pgFlash("Path copied"))
+          .catch(() => pgFlash("Could not copy path"));
+      },
+    },
+  ];
+}

--- a/src/features/repo/ops.ts
+++ b/src/features/repo/ops.ts
@@ -11,6 +11,7 @@ import { openMergeWindow } from "@/features/merge/openMergeWindow";
 import { currentBranch, isConflicted, isStaged, isUnstaged } from "@/lib/derive";
 import type { FileStatus } from "@/lib/types";
 import { useRepoStore } from "./useRepoStore";
+import { useTabsStore } from "./useTabsStore";
 
 /** Derive the [remote, branch] pair from the HEAD branch's upstream tracking ref. */
 export function headUpstream(
@@ -32,7 +33,7 @@ export async function openRepoDialog(): Promise<void> {
     title: "Open repository",
   });
   if (typeof selected === "string") {
-    await useRepoStore.getState().openRepo(selected);
+    await useTabsStore.getState().openRepo(selected);
   }
 }
 

--- a/src/features/repo/repoActivity.ts
+++ b/src/features/repo/repoActivity.ts
@@ -1,0 +1,16 @@
+/**
+ * Active long-running operations, keyed by operation kind. Value is the
+ * user-visible label (e.g. "Fetching origin…"). Consumers can flip button
+ * spinners with `!!activity.fetch` and render a status-bar line from the
+ * first truthy entry.
+ *
+ * Its own module so `repoSlice.ts` can name it without importing
+ * `useRepoStore` — which imports `repoSlice`.
+ */
+export interface RepoActivity {
+  fetch?: string;
+  pull?: string;
+  push?: string;
+  stash?: string;
+  branch?: string;
+}

--- a/src/features/repo/repoSlice.test.ts
+++ b/src/features/repo/repoSlice.test.ts
@@ -1,0 +1,91 @@
+// The anti-leak contract (#90). `useTabsStore` hydrates a tab by writing the
+// WHOLE slice; if a per-repo field is missing from REPO_SLICE_KEYS, hydration
+// silently becomes a patch and the previous repository's data survives into the
+// next tab. This file is what makes that a failing test instead of a bug report.
+
+import { describe, expect, it } from "vitest";
+
+import { LOG_REF_ALL } from "@/lib/types";
+import { REPO_SLICE_KEYS, emptySlice, frozenSlice, sliceOf } from "./repoSlice";
+import { useRepoStore } from "./useRepoStore";
+
+describe("repoSlice", () => {
+  it("covers every non-function field of the live store", () => {
+    const live = Object.entries(useRepoStore.getState())
+      .filter(([, v]) => typeof v !== "function")
+      .map(([k]) => k)
+      .sort();
+    expect(
+      [...REPO_SLICE_KEYS].sort(),
+      "a per-repo field exists on useRepoStore but is not in REPO_SLICE_KEYS — " +
+        "hydrating a tab would leave the previous repository's value in place. " +
+        "Add it to RepoSlice/emptySlice in repoSlice.ts.",
+    ).toEqual(live);
+  });
+
+  it("emptySlice is the no-repo state", () => {
+    const s = emptySlice();
+    expect(s.current).toBeNull();
+    expect(s.status).toEqual([]);
+    expect(s.commits).toEqual([]);
+    expect(s.searchResults).toBeNull();
+    expect(s.error).toBeNull();
+    expect(s.repoState).toBe("Clean");
+    expect(s.logRef).toBe(LOG_REF_ALL);
+    expect(s.rebaseStatus.inProgress).toBe(false);
+    expect(s.activity).toEqual({});
+  });
+
+  it("never shares mutable values between slices", () => {
+    // Two tabs holding the SAME array would make staging in one repository
+    // mutate another's cached view.
+    const a = emptySlice();
+    const b = emptySlice();
+    expect(a.status).not.toBe(b.status);
+    expect(a.activity).not.toBe(b.activity);
+    expect(a.commitFilter).not.toBe(b.commitFilter);
+  });
+
+  it("frozenSlice clears the in-flight flags but nothing else", () => {
+    // A parked `loadingMore: true` would make "load more" a permanent no-op on
+    // that tab: nothing will ever clear it, because the request it belonged to
+    // resolves into the OTHER repository's slice (and setFor drops it).
+    const busy = {
+      ...emptySlice(),
+      loading: true,
+      loadingMore: true,
+      searching: true,
+      logRef: "origin/main",
+      error: { kind: "Internal", message: "kept" } as const,
+    };
+    expect(frozenSlice(busy)).toEqual({
+      ...busy,
+      loading: false,
+      loadingMore: false,
+      searching: false,
+    });
+  });
+
+  it("sliceOf picks exactly the slice keys, ignoring actions", () => {
+    const picked = sliceOf(useRepoStore.getState());
+    expect(Object.keys(picked).sort()).toEqual([...REPO_SLICE_KEYS].sort());
+    for (const v of Object.values(picked)) {
+      expect(typeof v).not.toBe("function");
+    }
+  });
+
+  it("round-trips a seeded slice through the store", () => {
+    const seeded = {
+      ...emptySlice(),
+      current: { id: "r1", path: "/tmp/a", head: "main" },
+      status: [],
+      logRef: "origin/main",
+    };
+    useRepoStore.getState().hydrate(seeded);
+    expect(sliceOf(useRepoStore.getState())).toEqual(seeded);
+    // And hydrating an empty slice must remove every trace of it.
+    useRepoStore.getState().hydrate(emptySlice());
+    expect(useRepoStore.getState().current).toBeNull();
+    expect(useRepoStore.getState().logRef).toBe(LOG_REF_ALL);
+  });
+});

--- a/src/features/repo/repoSlice.ts
+++ b/src/features/repo/repoSlice.ts
@@ -1,0 +1,188 @@
+// The per-repository slice of `useRepoStore` — the app's multi-repo (#90)
+// anti-leak contract.
+//
+// `useRepoStore` holds exactly ONE repository's live state: the active tab's.
+// `useTabsStore` freezes the outgoing tab's slice and hydrates the incoming
+// one on every switch. That is only safe if hydration is a TOTAL write — a
+// patch would let the previous repo's `status`, `commits`, `branches` or
+// `error` survive into the next tab, which is the exact bug tabs must not
+// introduce.
+//
+// So the slice is declared here, once, as data:
+//
+//   REPO_SLICE_KEYS   every non-function field of the store
+//   emptySlice()      the no-repo-open value of each one
+//   sliceOf(state)    pick exactly those fields off a live state
+//   frozenSlice(s)    the same, normalized for parking on an inactive tab
+//
+// and `repoSlice.test.ts` derives the store's real non-function keys at runtime
+// and asserts they equal REPO_SLICE_KEYS. Adding a 22nd per-repo field without
+// listing it here fails that test instead of leaking silently.
+//
+// It also collapses what used to be three hand-maintained copies of the reset
+// list (the `create()` initializer, `applyOpenedRepo`, `closeRepo`) into one.
+
+import type {
+  BisectStatus,
+  BranchInfo,
+  CommitInfo,
+  FileStatus,
+  LogFilter,
+  RebaseStatus,
+  RemoteInfo,
+  RepoHandle,
+  RepoState as GitRepoState,
+  StashInfo,
+  TagInfo,
+} from "@/lib/types";
+import { LOG_REF_ALL } from "@/lib/types";
+import type { AppError } from "@/lib/errors";
+import type { RepoActivity } from "./repoActivity";
+
+export const DEFAULT_REBASE_STATUS: RebaseStatus = {
+  inProgress: false,
+  nextIndex: 0,
+  total: 0,
+  pauseReason: null,
+};
+
+/** No bisect, with git's default terms. Mirrors Rust `BisectStatus::idle()`. */
+export const DEFAULT_BISECT_STATUS: BisectStatus = {
+  inProgress: false,
+  startRef: null,
+  badTerm: "bad",
+  goodTerm: "good",
+  currentOid: null,
+  remaining: null,
+  steps: null,
+  firstBadOid: null,
+  goodCount: 0,
+  badCount: 0,
+  skippedCount: 0,
+};
+
+/** Every field of `useRepoStore` that belongs to one repository. */
+export interface RepoSlice {
+  current: RepoHandle | null;
+  status: FileStatus[];
+  /** Every (non-ignored) file in the worktree, populated lazily by listAllFiles. */
+  allFiles: FileStatus[];
+  branches: BranchInfo[];
+  tags: TagInfo[];
+  stashes: StashInfo[];
+  remotes: RemoteInfo[];
+  commits: CommitInfo[];
+  /**
+   * Backend-filtered commit log, or null when no search is active. Kept
+   * separate from `commits` (the full HEAD log) so the History screen can fall
+   * back to the unfiltered set and apply its own client-side toggles.
+   */
+  searchResults: CommitInfo[] | null;
+  /** The active backend log filter (empty object when none). */
+  commitFilter: LogFilter;
+  /**
+   * Revspec the log walk starts from: `LOG_REF_ALL` (the default — every branch
+   * in one graph), null for HEAD only, or any revspec. Scoping applies to
+   * `commits` AND backend searches, so every consumer of the log (History,
+   * palette pickers, context menus) sees the browsed scope's commits.
+   */
+  logRef: string | null;
+  /** True while a backend search is in flight. */
+  searching: boolean;
+  /**
+   * Resume points for the paginated log walk (#68 G11) — the frontier of every
+   * lane still awaiting a parent, NOT a single oid. null means that walk has
+   * reached the end of history.
+   *
+   * Two cursors, because clearing a search must restore the unfiltered walk's
+   * resume point: `searchCursor` belongs to `searchResults`, `commitCursor` to
+   * `commits`, and `loadMoreCommits` extends whichever list is active.
+   */
+  commitCursor: string[] | null;
+  searchCursor: string[] | null;
+  /** True while an additional page is being fetched. */
+  loadingMore: boolean;
+  loading: boolean;
+  error: AppError | null;
+  repoState: GitRepoState;
+  /**
+   * Live rebase progress AND, once a plan finishes, its retained
+   * `lastCompleted` summary — the backend keeps that until acknowledged (#47).
+   */
+  rebaseStatus: RebaseStatus;
+  /**
+   * The bisect git itself is running, if any (#93).
+   *
+   * Per-repo, so it belongs in the slice: a bisect open in one tab must not
+   * show in another's OperationBar. Read from GIT's own `.git/BISECT_*` files
+   * rather than an in-process map, so it survives a restart and picks up a
+   * bisect started in a terminal.
+   */
+  bisectStatus: BisectStatus;
+  /** Active long-running ops keyed by op kind. */
+  activity: RepoActivity;
+}
+
+/**
+ * The slice with no repository open. Also the store's initial state, the value
+ * `closeRepo()` resets to, and the base a fresh open starts from — one
+ * definition instead of three.
+ *
+ * A function, not a constant: the arrays and objects must not be shared between
+ * tabs, or staging in one repo would mutate another's cached view.
+ */
+export function emptySlice(): RepoSlice {
+  return {
+    current: null,
+    status: [],
+    allFiles: [],
+    branches: [],
+    tags: [],
+    stashes: [],
+    remotes: [],
+    commits: [],
+    searchResults: null,
+    commitFilter: {},
+    logRef: LOG_REF_ALL,
+    searching: false,
+    commitCursor: null,
+    searchCursor: null,
+    loadingMore: false,
+    loading: false,
+    error: null,
+    repoState: "Clean",
+    rebaseStatus: DEFAULT_REBASE_STATUS,
+    bisectStatus: DEFAULT_BISECT_STATUS,
+    activity: {},
+  };
+}
+
+/**
+ * The key list, derived from `emptySlice()` so it can never disagree with the
+ * shape above. Ordering is irrelevant; membership is the contract.
+ */
+export const REPO_SLICE_KEYS = Object.keys(emptySlice()) as (keyof RepoSlice)[];
+
+/**
+ * The slice as it should be PARKED on an inactive tab.
+ *
+ * The three in-flight flags are cleared: their requests were issued against the
+ * repository that is no longer active, so `setFor` will drop their responses and
+ * nothing will ever clear the flags again. Freezing `loadingMore: true` would
+ * make "load more" a permanent no-op on that tab (its re-entry guard reads the
+ * flag), and a frozen `loading`/`searching` would park a spinner forever.
+ */
+export function frozenSlice(slice: RepoSlice): RepoSlice {
+  return { ...slice, loading: false, loadingMore: false, searching: false };
+}
+
+/** Pick exactly the per-repo fields off a live store state. */
+export function sliceOf(state: RepoSlice): RepoSlice {
+  const out = {} as RepoSlice;
+  for (const key of REPO_SLICE_KEYS) {
+    // Index-assignment through the key union needs one cast; the loop is
+    // exhaustive by construction, which is what the test pins.
+    (out as unknown as Record<string, unknown>)[key] = state[key];
+  }
+  return out;
+}

--- a/src/features/repo/tabs.test.ts
+++ b/src/features/repo/tabs.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  OPEN_REPOS_KEY,
+  closeNeighbour,
+  cycle,
+  labelTabs,
+  loadOpenRepos,
+  newTab,
+  patchTab,
+  removeTab,
+  repoDisplayName,
+  saveOpenRepos,
+  upsertTab,
+  type RepoTab,
+} from "./tabs";
+
+const t = (path: string, over: Partial<RepoTab> = {}) => newTab(path, over);
+
+describe("tabs — list reducers", () => {
+  it("newTab starts pending, on History, with no slice", () => {
+    const tab = t("/a/api");
+    expect(tab.status).toBe("pending");
+    // Launch always lands on History — a restored tab is no exception.
+    expect(tab.screen).toBe("history");
+    expect(tab.slice).toBeNull();
+    expect(tab.repoId).toBeNull();
+  });
+
+  it("upsert dedupes by path and keeps position", () => {
+    let tabs = [t("/a"), t("/b"), t("/c")];
+    tabs = upsertTab(tabs, t("/b", { repoId: "r2", status: "open" }));
+    expect(tabs.map((x) => x.path)).toEqual(["/a", "/b", "/c"]);
+    expect(tabs[1].repoId).toBe("r2");
+    expect(tabs[1].status).toBe("open");
+  });
+
+  it("upsert appends an unseen path", () => {
+    const tabs = upsertTab([t("/a")], t("/b"));
+    expect(tabs.map((x) => x.path)).toEqual(["/a", "/b"]);
+  });
+
+  it("patchTab is a no-op for an unknown path", () => {
+    const tabs = [t("/a")];
+    expect(patchTab(tabs, "/nope", { dirty: 3 })).toBe(tabs);
+  });
+
+  it("removeTab drops only the named path", () => {
+    expect(removeTab([t("/a"), t("/b")], "/a").map((x) => x.path)).toEqual(["/b"]);
+  });
+
+  describe("closeNeighbour", () => {
+    it("takes the tab to the right", () => {
+      // closed index 0 of [a,b,c] → remaining [b,c] → b
+      expect(closeNeighbour([t("/b"), t("/c")], 0)?.path).toBe("/b");
+    });
+    it("falls back to the left at the end of the strip", () => {
+      // closed index 2 of [a,b,c] → remaining [a,b] → b
+      expect(closeNeighbour([t("/a"), t("/b")], 2)?.path).toBe("/b");
+    });
+    it("is null when nothing remains", () => {
+      expect(closeNeighbour([], 0)).toBeNull();
+    });
+  });
+
+  describe("cycle", () => {
+    const tabs = [t("/a"), t("/b"), t("/c")];
+    it("steps forward and wraps", () => {
+      expect(cycle(tabs, "/a", 1)).toBe("/b");
+      expect(cycle(tabs, "/c", 1)).toBe("/a");
+    });
+    it("steps back and wraps", () => {
+      expect(cycle(tabs, "/b", -1)).toBe("/a");
+      expect(cycle(tabs, "/a", -1)).toBe("/c");
+    });
+    it("lands on the first tab when nothing is active", () => {
+      expect(cycle(tabs, null, 1)).toBe("/a");
+    });
+    it("is null with no tabs", () => {
+      expect(cycle([], null, 1)).toBeNull();
+    });
+  });
+});
+
+describe("tabs — labelling", () => {
+  it("names a repo by its last path segment, separator-agnostic", () => {
+    expect(repoDisplayName("/home/me/dev/api")).toBe("api");
+    expect(repoDisplayName("/home/me/dev/api/")).toBe("api");
+    expect(repoDisplayName("C:\\dev\\api")).toBe("api");
+    expect(repoDisplayName("api")).toBe("api");
+  });
+
+  it("leaves unique names bare", () => {
+    expect(labelTabs([t("/dev/api"), t("/dev/web")])).toEqual(["api", "web"]);
+  });
+
+  it("prefixes the parent dir ONLY for colliding names", () => {
+    expect(
+      labelTabs([t("/work/acme/api"), t("/work/beta/api"), t("/work/acme/web")]),
+    ).toEqual(["acme/api", "beta/api", "web"]);
+  });
+
+  it("survives a collision at the filesystem root", () => {
+    expect(labelTabs([t("/api"), t("/x/api")])).toEqual(["api", "x/api"]);
+  });
+});
+
+describe("tabs — pg-open-repos persistence", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("round-trips the open set and the active path", () => {
+    saveOpenRepos([t("/a"), t("/b")], "/b");
+    expect(loadOpenRepos()).toEqual({ paths: ["/a", "/b"], active: "/b" });
+  });
+
+  it("is empty with nothing stored", () => {
+    expect(loadOpenRepos()).toEqual({ paths: [], active: null });
+  });
+
+  it("tolerates garbage", () => {
+    localStorage.setItem(OPEN_REPOS_KEY, "not json");
+    expect(loadOpenRepos()).toEqual({ paths: [], active: null });
+    localStorage.setItem(OPEN_REPOS_KEY, JSON.stringify([1, 2, 3]));
+    expect(loadOpenRepos()).toEqual({ paths: [], active: null });
+    localStorage.setItem(
+      OPEN_REPOS_KEY,
+      JSON.stringify({ paths: ["/a", 7, null, "/a"], active: 9 }),
+    );
+    // Non-strings and duplicates dropped; a bogus active falls back to the first.
+    expect(loadOpenRepos()).toEqual({ paths: ["/a"], active: "/a" });
+  });
+
+  it("falls back to the first path when active is not in the set", () => {
+    localStorage.setItem(
+      OPEN_REPOS_KEY,
+      JSON.stringify({ paths: ["/a", "/b"], active: "/gone" }),
+    );
+    expect(loadOpenRepos().active).toBe("/a");
+  });
+
+  it("caps the persisted set so a runaway value can't slow startup", () => {
+    const many = Array.from({ length: 40 }, (_, i) => t(`/r${i}`));
+    saveOpenRepos(many, "/r39");
+    const loaded = loadOpenRepos();
+    expect(loaded.paths).toHaveLength(20);
+    // /r39 fell outside the cap, so active follows the surviving head.
+    expect(loaded.active).toBe("/r0");
+  });
+
+  it("writes null for an active path that is not open", () => {
+    saveOpenRepos([], "/a");
+    expect(loadOpenRepos()).toEqual({ paths: [], active: null });
+  });
+});

--- a/src/features/repo/tabs.ts
+++ b/src/features/repo/tabs.ts
@@ -1,0 +1,203 @@
+// Repository tabs — the pure half (#90). List reducers, labelling, and the
+// `pg-open-repos` session file. No store, no IPC, no React: everything here is
+// a function of its arguments, which is what makes the tab invariants
+// (dedupe-by-path, neighbour selection on close, wrap-around cycling) testable
+// without a webview.
+//
+// `useTabsStore` is the thin store on top; `RepoTabs` is the strip.
+
+import type { RepoSlice } from "./repoSlice";
+
+const OPEN_REPOS_KEY = "pg-open-repos";
+/** Bound on the persisted open set. Generous — it exists so a corrupted or
+ *  runaway value can't make startup pathological, not to police workflow. */
+const OPEN_LIMIT = 20;
+
+/**
+ * One open repository.
+ *
+ * **`path` is the identity.** Two tabs never share one: opening a path that is
+ * already open focuses its tab. That is what keeps persistence trivial (a list
+ * of paths) and rules out duplicate tabs for one repository.
+ */
+export interface RepoTab {
+  path: string;
+  /** Backend `RepoId`. Null until this tab has actually been opened. */
+  repoId: string | null;
+  /**
+   * `pending` — persisted or queued, not yet opened (session restore is lazy).
+   * `open`    — live; `repoId` is set.
+   * `failed`  — its open was attempted and rejected (moved, deleted, refused).
+   */
+  status: "pending" | "open" | "failed";
+  /** Screen this tab was last on. Session-only — never persisted, so launch
+   *  still always lands on History (see CLAUDE.md's navigation model). */
+  screen: string;
+  /** Frozen store slice. Meaningful only while this tab is INACTIVE; the active
+   *  tab's live state lives in `useRepoStore`. */
+  slice: RepoSlice | null;
+  /** Badge counts, taken from the slice when the tab was left. */
+  dirty: number;
+  conflicts: number;
+}
+
+export function newTab(path: string, over: Partial<RepoTab> = {}): RepoTab {
+  return {
+    path,
+    repoId: null,
+    status: "pending",
+    // Every tab starts on History, restored tabs included.
+    screen: "history",
+    slice: null,
+    dirty: 0,
+    conflicts: 0,
+    ...over,
+  };
+}
+
+export function findTab(tabs: RepoTab[], path: string | null): RepoTab | null {
+  if (!path) return null;
+  return tabs.find((t) => t.path === path) ?? null;
+}
+
+export function indexOfTab(tabs: RepoTab[], path: string | null): number {
+  if (!path) return -1;
+  return tabs.findIndex((t) => t.path === path);
+}
+
+/**
+ * Insert or update the tab for `patch.path`. Existing tabs keep their position:
+ * re-opening a repository must not shuffle the strip under the user's cursor.
+ */
+export function upsertTab(tabs: RepoTab[], patch: RepoTab): RepoTab[] {
+  const i = indexOfTab(tabs, patch.path);
+  if (i < 0) return [...tabs, patch];
+  const next = [...tabs];
+  next[i] = { ...next[i], ...patch };
+  return next;
+}
+
+/** Apply `patch` to the tab at `path`, or return the list unchanged. */
+export function patchTab(
+  tabs: RepoTab[],
+  path: string,
+  patch: Partial<RepoTab>,
+): RepoTab[] {
+  const i = indexOfTab(tabs, path);
+  if (i < 0) return tabs;
+  const next = [...tabs];
+  next[i] = { ...next[i], ...patch };
+  return next;
+}
+
+export function removeTab(tabs: RepoTab[], path: string): RepoTab[] {
+  return tabs.filter((t) => t.path !== path);
+}
+
+/**
+ * Which tab becomes active when the one at `closedIndex` goes away: the tab to
+ * its right, else the one to its left, else none. `remaining` is the list AFTER
+ * the removal, so the right-hand neighbour has already slid into `closedIndex`.
+ */
+export function closeNeighbour(
+  remaining: RepoTab[],
+  closedIndex: number,
+): RepoTab | null {
+  if (remaining.length === 0) return null;
+  return remaining[Math.min(closedIndex, remaining.length - 1)] ?? null;
+}
+
+/** Next/previous tab path, wrapping. Null when there is nothing to cycle. */
+export function cycle(
+  tabs: RepoTab[],
+  activePath: string | null,
+  delta: 1 | -1,
+): string | null {
+  if (tabs.length === 0) return null;
+  const i = indexOfTab(tabs, activePath);
+  if (i < 0) return tabs[0].path;
+  const n = tabs.length;
+  return tabs[(((i + delta) % n) + n) % n].path;
+}
+
+/** Last non-empty path segment, or the path itself. Separator-agnostic so a
+ *  Windows path labels as well as a POSIX one. */
+export function repoDisplayName(path: string): string {
+  const segs = path.split(/[/\\]+/).filter(Boolean);
+  return segs[segs.length - 1] ?? path;
+}
+
+/** The segment before the last one, or "" at the root. */
+function parentSegment(path: string): string {
+  const segs = path.split(/[/\\]+/).filter(Boolean);
+  return segs.length >= 2 ? segs[segs.length - 2] : "";
+}
+
+/**
+ * Tab labels, disambiguated. `api`, `web` and `docs` are everywhere, so a strip
+ * of three tabs all reading `api` is useless — but prefixing EVERY tab with its
+ * parent directory is noise. Only the names that actually collide get the
+ * `parent/name` form.
+ */
+export function labelTabs(tabs: RepoTab[]): string[] {
+  const names = tabs.map((t) => repoDisplayName(t.path));
+  const seen = new Map<string, number>();
+  for (const n of names) seen.set(n, (seen.get(n) ?? 0) + 1);
+  return tabs.map((t, i) => {
+    const name = names[i];
+    if ((seen.get(name) ?? 0) < 2) return name;
+    const parent = parentSegment(t.path);
+    return parent ? `${parent}/${name}` : name;
+  });
+}
+
+// ── persistence ────────────────────────────────────────────────────────────
+//
+// Recents (`pg-recent-repos`) and the open set are deliberately separate keys
+// with separate meanings: recents are where you have BEEN, the open set is
+// where you ARE. Opening a repository still pushes a recent, so the two stay
+// consistent without one becoming the other.
+
+export interface OpenRepos {
+  paths: string[];
+  active: string | null;
+}
+
+export function loadOpenRepos(): OpenRepos {
+  try {
+    const raw = localStorage.getItem(OPEN_REPOS_KEY);
+    if (!raw) return { paths: [], active: null };
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return { paths: [], active: null };
+    const rec = parsed as Record<string, unknown>;
+    const paths = Array.isArray(rec.paths)
+      ? Array.from(
+          new Set(
+            rec.paths.filter((p): p is string => typeof p === "string" && !!p),
+          ),
+        ).slice(0, OPEN_LIMIT)
+      : [];
+    const active =
+      typeof rec.active === "string" && paths.includes(rec.active)
+        ? rec.active
+        : (paths[0] ?? null);
+    return { paths, active };
+  } catch {
+    return { paths: [], active: null };
+  }
+}
+
+export function saveOpenRepos(tabs: RepoTab[], active: string | null): void {
+  try {
+    const paths = tabs.map((t) => t.path).slice(0, OPEN_LIMIT);
+    const value: OpenRepos = {
+      paths,
+      active: active && paths.includes(active) ? active : (paths[0] ?? null),
+    };
+    localStorage.setItem(OPEN_REPOS_KEY, JSON.stringify(value));
+  } catch {
+    // quota errors are non-fatal — the session just won't restore
+  }
+}
+
+export { OPEN_REPOS_KEY, OPEN_LIMIT };

--- a/src/features/repo/useRepoStore.ownership.test.ts
+++ b/src/features/repo/useRepoStore.ownership.test.ts
@@ -42,7 +42,7 @@ describe("useRepoStore.openRepo — dubious ownership", () => {
     armOpen(1);
     confirmTrust.mockResolvedValue(true);
 
-    await useRepoStore.getState().openRepo("/mnt/c/dev/reponame");
+    await useRepoStore.getState().openRepoAt("/mnt/c/dev/reponame");
 
     expect(confirmTrust).toHaveBeenCalledWith("/mnt/c/dev/reponame");
     expect(calls("trust_repo_path")).toHaveLength(1);
@@ -65,7 +65,7 @@ describe("useRepoStore.openRepo — dubious ownership", () => {
     });
     confirmTrust.mockResolvedValue(true);
 
-    await useRepoStore.getState().openRepo("/mnt/c/dev/reponame/");
+    await useRepoStore.getState().openRepoAt("/mnt/c/dev/reponame/");
 
     expect(confirmTrust).toHaveBeenCalledWith("/mnt/c/dev/reponame");
     expect(calls("trust_repo_path")[0]?.args).toMatchObject({
@@ -77,7 +77,7 @@ describe("useRepoStore.openRepo — dubious ownership", () => {
     armOpen(1);
     confirmTrust.mockResolvedValue(false);
 
-    await useRepoStore.getState().openRepo("/mnt/c/dev/reponame");
+    await useRepoStore.getState().openRepoAt("/mnt/c/dev/reponame");
 
     expect(calls("trust_repo_path")).toHaveLength(0);
     expect(useRepoStore.getState().error?.kind).toBe("DubiousOwnership");
@@ -89,7 +89,7 @@ describe("useRepoStore.openRepo — dubious ownership", () => {
     armOpen(99);
     confirmTrust.mockResolvedValue(true);
 
-    await useRepoStore.getState().openRepo("/mnt/c/dev/reponame");
+    await useRepoStore.getState().openRepoAt("/mnt/c/dev/reponame");
 
     // One prompt, one retry — never a second round.
     expect(confirmTrust).toHaveBeenCalledTimes(1);
@@ -105,7 +105,7 @@ describe("useRepoStore.openRepo — dubious ownership", () => {
       throw { kind: "Io", message: "permission denied" };
     });
 
-    await useRepoStore.getState().openRepo("/mnt/c/dev/reponame");
+    await useRepoStore.getState().openRepoAt("/mnt/c/dev/reponame");
 
     expect(useRepoStore.getState().error?.kind).toBe("Io");
     expect(useRepoStore.getState().loading).toBe(false);
@@ -116,7 +116,7 @@ describe("useRepoStore.openRepo — dubious ownership", () => {
       throw { kind: "NotARepo", message: "path is not a git repository: /tmp/x" };
     });
 
-    await useRepoStore.getState().openRepo("/tmp/x");
+    await useRepoStore.getState().openRepoAt("/tmp/x");
 
     expect(confirmTrust).not.toHaveBeenCalled();
     expect(useRepoStore.getState().error?.kind).toBe("NotARepo");

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -2,21 +2,13 @@ import { create } from "zustand";
 import type {
   AuthorOverride,
   BisectMark,
-  BisectStatus,
-  BranchInfo,
-  CommitInfo,
   FileContent,
   FileStatus,
   LogFilter,
   RebaseStatus,
   RebaseStep,
-  RemoteInfo,
   RepoHandle,
-  RepoState as GitRepoState,
-  StashInfo,
-  TagInfo,
 } from "@/lib/types";
-import { LOG_REF_ALL } from "@/lib/types";
 import type { AppError } from "@/lib/errors";
 import {
   dubiousOwnershipPath,
@@ -108,20 +100,16 @@ import {
 import { isFilterEmpty } from "@/features/commits/logFilter";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { useRecentsStore } from "./useRecentsStore";
+import {
+  DEFAULT_BISECT_STATUS,
+  DEFAULT_REBASE_STATUS,
+  emptySlice,
+  sliceOf,
+  type RepoSlice,
+} from "./repoSlice";
+import type { RepoActivity } from "./repoActivity";
 
-/**
- * Active long-running operations, keyed by operation kind. Value is the
- * user-visible label (e.g. "Fetching origin…"). Consumers can flip button
- * spinners with `!!activity.fetch` and render a status-bar line from the
- * first truthy entry.
- */
-export interface RepoActivity {
-  fetch?: string;
-  pull?: string;
-  push?: string;
-  stash?: string;
-  branch?: string;
-}
+export type { RepoActivity } from "./repoActivity";
 
 /**
  * Commits per log page (#68 G11). Was a `500` literal repeated at four call
@@ -130,70 +118,38 @@ export interface RepoActivity {
  */
 const PAGE_SIZE = 500;
 
-interface RepoStoreState {
-  current: RepoHandle | null;
-  status: FileStatus[];
-  /** Every (non-ignored) file in the worktree, populated lazily by listAllFiles. */
-  allFiles: FileStatus[];
-  branches: BranchInfo[];
-  tags: TagInfo[];
-  stashes: StashInfo[];
-  remotes: RemoteInfo[];
-  commits: CommitInfo[];
+/**
+ * The repository store: exactly ONE repository's live state — the ACTIVE tab's
+ * (#90). Every per-repo field comes from `RepoSlice`, which `useTabsStore`
+ * freezes on the way out of a tab and hydrates on the way in. Screens keep
+ * reading `s.status` / `s.commits` / `s.branches` and calling the same actions;
+ * they never learn that there is more than one repository open.
+ *
+ * Two rules keep a tab switch from leaking:
+ *   - hydration is a TOTAL write of `RepoSlice` (see repoSlice.ts), and
+ *   - every fetch/error write goes through `setFor`/`setErrorFor`, which drop a
+ *     response that resolved after the user moved to another repository.
+ */
+interface RepoStoreState extends RepoSlice {
   /**
-   * Backend-filtered commit log, or null when no search is active. Kept
-   * separate from `commits` (the full HEAD log) so the History screen can fall
-   * back to the unfiltered set and apply its own client-side toggles.
-   */
-  searchResults: CommitInfo[] | null;
-  /** The active backend log filter (empty object when none). */
-  commitFilter: LogFilter;
-  /**
-   * Revspec the log walk starts from: `LOG_REF_ALL` (the default — every branch
-   * in one graph), null for HEAD only, or any revspec. Scoping applies to
-   * `commits` AND backend searches, so every consumer of the log (History,
-   * palette pickers, context menus) sees the browsed scope's commits.
-   */
-  logRef: string | null;
-  /** True while a backend search is in flight. */
-  searching: boolean;
-  /**
-   * Resume points for the paginated log walk (#68 G11) — the frontier of every
-   * lane still awaiting a parent, NOT a single oid. null means that walk has
-   * reached the end of history.
+   * Open `path` into the ACTIVE slice and refresh it, returning the handle (or
+   * null on failure, with the error already on the store).
    *
-   * Two cursors, because clearing a search must restore the unfiltered walk's
-   * resume point: `searchCursor` belongs to `searchResults`, `commitCursor` to
-   * `commits`, and `loadMoreCommits` extends whichever list is active.
+   * The low-level half of opening a repository: it knows nothing about tabs.
+   * `useTabsStore.openRepo` is the entry point everything else calls — it
+   * dedupes by path, creates the tab, and snapshots the outgoing one.
    */
-  commitCursor: string[] | null;
-  searchCursor: string[] | null;
-  /** True while an additional page is being fetched. */
-  loadingMore: boolean;
-  loading: boolean;
-  error: AppError | null;
-  repoState: GitRepoState;
-  /**
-   * The bisect git itself is running, if any (#93).
-   *
-   * Lives beside `repoState`/`rebaseStatus` rather than in a feature store because
-   * `OperationBar` needs it on every screen, and because — unlike `rebaseStatus`,
-   * which is an in-process map — this is read from GIT's own `.git/BISECT_*`
-   * files, so it survives a restart and picks up a bisect started in a terminal.
-   * Polled on every refresh: the backend short-circuits on one `Path::exists()`,
-   * so a repository with no bisect pays nothing.
-   */
-  bisectStatus: BisectStatus;
-  /**
-   * Live rebase progress AND, once a plan finishes, its retained
-   * `lastCompleted` summary — the backend keeps that until acknowledged, so the
-   * "N steps completed" line no longer needs a frontend cache that every abort
-   * and start path had to clear by hand (#47).
-   */
-  rebaseStatus: RebaseStatus;
-  /** Active long-running ops keyed by op kind. */
-  activity: RepoActivity;
-  openRepo: (path: string) => Promise<void>;
+  openRepoAt: (path: string) => Promise<RepoHandle | null>;
+  /** Replace every per-repo field with `slice` (activating a tab). Total write
+   *  by contract — see repoSlice.ts. */
+  hydrate: (slice: RepoSlice) => void;
+  /** Freeze the live per-repo fields (leaving a tab). */
+  snapshot: () => RepoSlice;
+  /** Put an error back on the banner. Needed because a rollback (a failed open
+   *  re-activating the tab you were on) runs a `refreshAll`, which clears
+   *  `error` as its first act — same hazard as the refresh-first-error-last
+   *  convention in the catch arms. */
+  setError: (e: AppError | null) => void;
   /**
    * Run a backend commit-log search. An empty filter clears the search and
    * falls back to the full log. Sets `searchResults` + `commitFilter`.
@@ -388,29 +344,26 @@ export async function withAuthRetry(
   }
 }
 
-const DEFAULT_REBASE_STATUS: RebaseStatus = {
-  inProgress: false,
-  nextIndex: 0,
-  total: 0,
-  pauseReason: null,
-};
-
-/** No bisect, with git's default terms. Mirrors Rust `BisectStatus::idle()`. */
-const DEFAULT_BISECT_STATUS: BisectStatus = {
-  inProgress: false,
-  startRef: null,
-  badTerm: "bad",
-  goodTerm: "good",
-  currentOid: null,
-  remaining: null,
-  steps: null,
-  firstBadOid: null,
-  goodCount: 0,
-  badCount: 0,
-  skippedCount: 0,
-};
-
 export const useRepoStore = create<RepoStoreState>((set, get) => {
+  /**
+   * Apply `patch` only while `repoId` is still the open repository (#90).
+   *
+   * A tab switch is atomic, but the fetches already in flight are not: a
+   * `refreshAll` for repo A can resolve after the user moved to B and would
+   * write A's status, log and branches into B's slice. This is the same
+   * staleness guard `logRef` and `commitFilter` already carry, on repo identity.
+   */
+  const setFor = (repoId: string, patch: Partial<RepoStoreState>) => {
+    if (get().current?.id !== repoId) return;
+    set(patch);
+  };
+  /** `setFor` for the error banner: a failure in a repository you have left
+   *  must not raise a banner over the one you are in. Keeps the
+   *  refresh-first-error-last ordering — it is still just a guarded set. */
+  const setErrorFor = (repoId: string, e: unknown) => {
+    if (get().current?.id !== repoId) return;
+    set({ error: toAppError(e) });
+  };
   const setActivity = (key: keyof RepoActivity, label: string | null) => {
     set((s) => {
       const next = { ...s.activity };
@@ -419,55 +372,23 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       return { activity: next };
     });
   };
-  /** Open `path` and reset every per-repo slice. Throws on failure. */
+  /** Open `path` into a freshly reset slice. Throws on failure. */
   const applyOpenedRepo = async (path: string) => {
     const handle = await openRepo(path);
     useRecentsStore.getState().addRecent(handle.path);
-    set({
-      current: handle,
-      status: [],
-      allFiles: [],
-      branches: [],
-      tags: [],
-      stashes: [],
-      remotes: [],
-      commits: [],
-      searchResults: null,
-      commitFilter: {},
-      bisectStatus: DEFAULT_BISECT_STATUS,
-      logRef: LOG_REF_ALL,
-      commitCursor: null,
-      searchCursor: null,
-    });
+    // Total write: every per-repo field is reset, so nothing of the previously
+    // open repository can survive into this one (see repoSlice.ts).
+    set({ ...emptySlice(), current: handle });
     await get().refreshAll();
   };
   return ({
-  current: null,
-  status: [],
-  allFiles: [],
-  branches: [],
-  tags: [],
-  stashes: [],
-  remotes: [],
-  commits: [],
-  searchResults: null,
-  commitFilter: {},
-  logRef: LOG_REF_ALL,
-  searching: false,
-  commitCursor: null,
-  searchCursor: null,
-  loadingMore: false,
-  loading: false,
-  error: null,
-  repoState: "Clean",
-  rebaseStatus: DEFAULT_REBASE_STATUS,
-  bisectStatus: DEFAULT_BISECT_STATUS,
-  activity: {},
+  ...emptySlice(),
 
-  async openRepo(path) {
+  async openRepoAt(path) {
     set({ loading: true, error: null });
     try {
       await applyOpenedRepo(path);
+      return get().current;
     } catch (e) {
       // git refuses a repository owned by another user, which a Windows drive
       // mounted under WSL routinely looks like. That refusal is remediable,
@@ -483,15 +404,31 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
             // Deliberately not recursive: one retry. If the exception did not
             // help, show the error rather than asking again forever.
             await applyOpenedRepo(path);
-            return;
+            return get().current;
           } catch (retryError) {
             set({ loading: false, error: toAppError(retryError) });
-            return;
+            return null;
           }
         }
       }
+      // A failed open leaves the slice alone: whatever tab the user was on is
+      // still there with its data, and only `loading`/`error` moved.
       set({ loading: false, error: toAppError(e) });
+      return null;
     }
+  },
+
+  hydrate(slice) {
+    // Total write, never a patch — that is the whole anti-leak contract.
+    set(slice);
+  },
+
+  snapshot() {
+    return sliceOf(get());
+  },
+
+  setError(e) {
+    set({ error: e });
   },
 
   async searchCommits(filter) {
@@ -515,13 +452,13 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       const page = await getLogFilteredPage(repo.id, filter, null, PAGE_SIZE, refspec);
       // Guard against a stale response overwriting a newer filter or scope.
       if (get().commitFilter !== filter || get().logRef !== refspec) return;
-      set({
+      setFor(repo.id, {
         searchResults: page.commits,
         searchCursor: page.nextCursor,
         searching: false,
       });
     } catch (e) {
-      set({ searching: false, error: toAppError(e) });
+      setFor(repo.id, { searching: false, error: toAppError(e) });
     }
   },
 
@@ -542,7 +479,9 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         : await getLogPage(current.id, cursor, PAGE_SIZE, refspec);
       // The list may have been replaced while the page was in flight (repo
       // switch, ref change, new search) — dropping a stale page is correct.
-      if (get().logRef !== refspec) return;
+      // A repo switch also invalidates the page: `current` is the repo this
+      // walk belongs to, not necessarily the one now open.
+      if (get().current?.id !== current.id || get().logRef !== refspec) return;
       if (searching) {
         if (get().commitFilter !== filter || get().searchResults === null) return;
         set((s) => ({
@@ -557,7 +496,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         }));
       }
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(current.id, e);
     } finally {
       set({ loadingMore: false });
     }
@@ -574,7 +513,11 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       const page = await getLogPage(repo.id, null, PAGE_SIZE, refspec);
       // Guard against a stale response overwriting a newer scope.
       if (get().logRef !== refspec) return;
-      set({ commits: page.commits, commitCursor: page.nextCursor, loading: false });
+      setFor(repo.id, {
+        commits: page.commits,
+        commitCursor: page.nextCursor,
+        loading: false,
+      });
       // Re-run an active search under the new scope.
       const activeFilter = get().commitFilter;
       if (!isFilterEmpty(activeFilter)) {
@@ -582,7 +525,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       }
     } catch (e) {
       if (get().logRef !== refspec) return;
-      set({ loading: false, error: toAppError(e) });
+      setFor(repo.id, { loading: false, error: toAppError(e) });
     }
   },
 
@@ -613,7 +556,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
             // the branch was deleted) — fall back to HEAD instead of failing
             // the whole refresh.
             if (logRef === null) throw e;
-            set({ logRef: null });
+            setFor(repo.id, { logRef: null });
             return getLogPage(repo.id, null, PAGE_SIZE);
           }),
           repoStateFn(repo.id),
@@ -625,7 +568,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
           // fallback is a bar without step counts, not a broken screen.
           bisectStatusFn(repo.id).catch(() => DEFAULT_BISECT_STATUS),
         ]);
-      set({
+      setFor(repo.id, {
         status,
         branches,
         tags,
@@ -645,7 +588,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         void get().searchCommits(activeFilter);
       }
     } catch (e) {
-      set({ loading: false, error: toAppError(e) });
+      setFor(repo.id, { loading: false, error: toAppError(e) });
     }
   },
 
@@ -663,9 +606,9 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         // Same degrade-don't-fail policy as `refreshAll`.
         bisectStatusFn(repo.id).catch(() => DEFAULT_BISECT_STATUS),
       ]);
-      set({ status, repoState, bisectStatus });
+      setFor(repo.id, { status, repoState, bisectStatus });
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -674,22 +617,9 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   },
 
   closeRepo() {
-    set({
-      current: null,
-      status: [],
-      allFiles: [],
-      branches: [],
-      tags: [],
-      stashes: [],
-      remotes: [],
-      commits: [],
-      searchResults: null,
-      commitFilter: {},
-      logRef: LOG_REF_ALL,
-      searching: false,
-      bisectStatus: DEFAULT_BISECT_STATUS,
-      error: null,
-    });
+    // Total write via emptySlice(), so a later hydrate of another tab starts
+    // from a genuinely empty slice rather than this repo's leftovers.
+    set(emptySlice());
   },
 
   async refreshAllFiles() {
@@ -697,9 +627,9 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     try {
       const allFiles = await listAllFiles(repo.id);
-      set({ allFiles });
+      setFor(repo.id, { allFiles });
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -709,7 +639,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     try {
       return await listFilesAtRevFn(repo.id, revspec);
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
       return null;
     }
   },
@@ -720,7 +650,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     try {
       return await readFileContentAtRevFn(repo.id, revspec, path);
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
       return null;
     }
   },
@@ -732,7 +662,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await stagePaths(repo.id, paths);
       await get().refreshStatus();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -743,7 +673,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await unstagePaths(repo.id, paths);
       await get().refreshStatus();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -754,7 +684,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await discardPaths(repo.id, paths);
       await get().refreshStatus();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -767,7 +697,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await stageHunk(repo.id, path, hunkIndex, useSettingsStore.getState().diffContextLines);
       await get().refreshStatus();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -778,7 +708,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await unstageHunk(repo.id, path, hunkIndex, useSettingsStore.getState().diffContextLines);
       await get().refreshStatus();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -789,7 +719,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await discardHunk(repo.id, path, hunkIndex, useSettingsStore.getState().diffContextLines);
       await get().refreshStatus();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -806,7 +736,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       );
       await get().refreshStatus();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -823,7 +753,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       );
       await get().refreshStatus();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -840,7 +770,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       );
       await get().refreshStatus();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -851,7 +781,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await resetFn(repo.id, target, mode);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -876,7 +806,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await get().refreshAll();
       return oid;
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
       return null;
     }
   },
@@ -904,7 +834,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       }
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
       await get().refreshAll();
     } finally {
       setActivity("branch", null);
@@ -918,7 +848,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await checkoutRef(repo.id, reference);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -933,7 +863,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       // recording the error — otherwise the two synchronous `set()` calls
       // land in the same React batch and the error is wiped before render.
       await get().refreshAll();
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -947,7 +877,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       // See mergeBranch's catch: refresh first, error last, so it isn't
       // batched away by refreshAll's own `error: null` reset.
       await get().refreshAll();
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -964,7 +894,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         await pushTagFn(repo.id, remote, name, creds);
         await get().refreshAll();
       },
-      (e) => set({ error: toAppError(e) }),
+      (e) => setErrorFor(repo.id, e),
     );
   },
 
@@ -977,7 +907,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         await pushDeleteBranchFn(repo.id, remote, name, creds);
         await get().refreshAll();
       },
-      (e) => set({ error: toAppError(e) }),
+      (e) => setErrorFor(repo.id, e),
     );
   },
 
@@ -988,7 +918,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await createBranch(repo.id, name, from);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -999,7 +929,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     try {
       await createBranch(repo.id, name, opts?.from);
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
       setActivity("branch", null);
       await get().refreshAll();
       return false;
@@ -1017,7 +947,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     try {
       await deleteBranch(repo.id, name, force);
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
       return;
     }
     await get().refreshAll();
@@ -1030,7 +960,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await renameBranch(repo.id, from, to);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1041,7 +971,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await setUpstreamFn(repo.id, branch, upstream);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1052,7 +982,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await createTag(repo.id, name, target);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1063,7 +993,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await deleteTag(repo.id, name);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1077,7 +1007,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       // See mergeBranch's catch: refresh first, error last, so it isn't
       // batched away by refreshAll's own `error: null` reset.
       await get().refreshAll();
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1098,7 +1028,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       // See mergeBranch's catch: refresh first, error last, so it isn't
       // batched away by refreshAll's own `error: null` reset.
       await get().refreshAll();
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1112,7 +1042,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       // See mergeBranch's catch: refresh first, error last, so it isn't
       // batched away by refreshAll's own `error: null` reset.
       await get().refreshAll();
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1124,7 +1054,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await get().refreshAll();
       return oid;
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
       return null;
     }
   },
@@ -1136,7 +1066,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await stashApply(repo.id, index);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1147,7 +1077,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await stashPop(repo.id, index);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1158,7 +1088,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await stashDrop(repo.id, index);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1169,7 +1099,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await stashBranchFn(repo.id, index, branch);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1189,7 +1119,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
           );
           await get().refreshAll();
         },
-        (e) => set({ error: toAppError(e) }),
+        (e) => setErrorFor(repo.id, e),
       );
     } finally {
       setActivity("fetch", null);
@@ -1207,7 +1137,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
           await fetchAll(repo.id, useSettingsStore.getState().pruneOnFetch, creds);
           await get().refreshAll();
         },
-        (e) => set({ error: toAppError(e) }),
+        (e) => setErrorFor(repo.id, e),
       );
     } finally {
       setActivity("fetch", null);
@@ -1261,7 +1191,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         // See mergeBranch's catch: refresh first, error last, so it isn't
         // batched away by refreshAll's own `error: null` reset.
         await get().refreshAll();
-        set({ error: toAppError(e) });
+        setErrorFor(repo.id, e);
       },
     );
   },
@@ -1277,7 +1207,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
           await pushRemote(repo.id, remote, branch, force, creds);
           await get().refreshAll();
         },
-        (e) => set({ error: toAppError(e) }),
+        (e) => setErrorFor(repo.id, e),
       );
     } finally {
       setActivity("push", null);
@@ -1291,7 +1221,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await addRemote(repo.id, name, url);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1302,7 +1232,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await removeRemote(repo.id, name);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1313,7 +1243,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await renameRemote(repo.id, from, to);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1324,7 +1254,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await setRemoteUrl(repo.id, name, url);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1335,7 +1265,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await pruneRemote(repo.id, name);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1346,7 +1276,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await acceptOurs(repo.id, path);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1357,7 +1287,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await acceptTheirs(repo.id, path);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1368,7 +1298,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await markResolved(repo.id, paths);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1386,7 +1316,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await abortOperation(repo.id);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1411,7 +1341,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       // rebase --continue` that stops on the NEXT conflict fails here with the
       // repository already moved on, so the operation bar must re-read disk.
       await get().refreshAll();
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
       return null;
     }
   },
@@ -1423,7 +1353,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await runMergetoolFn(repo.id, path);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1434,7 +1364,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await restartConflictFn(repo.id, path);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1443,11 +1373,11 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return null;
     try {
       const status = await rebaseStartFn(repo.id, plan);
-      set({ rebaseStatus: status });
+      setFor(repo.id, { rebaseStatus: status });
       await get().refreshAll();
       return status;
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
       return null;
     }
   },
@@ -1457,11 +1387,11 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return null;
     try {
       const status = await rebaseContinueFn(repo.id);
-      set({ rebaseStatus: status });
+      setFor(repo.id, { rebaseStatus: status });
       await get().refreshAll();
       return status;
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
       return null;
     }
   },
@@ -1471,10 +1401,10 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     try {
       await rebaseAbort(repo.id);
-      set({ rebaseStatus: DEFAULT_REBASE_STATUS });
+      setFor(repo.id, { rebaseStatus: DEFAULT_REBASE_STATUS });
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1486,9 +1416,11 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       // Mirror the drop locally instead of a full refreshAll: acknowledging is
       // a notice being dismissed, not a change to the repository, and a refresh
       // here would re-walk the log on every visit to the Rebase screen.
-      set((s) => ({ rebaseStatus: { ...s.rebaseStatus, lastCompleted: null } }));
+      setFor(repo.id, {
+        rebaseStatus: { ...get().rebaseStatus, lastCompleted: null },
+      });
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1541,7 +1473,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await appendGitignoreFn(repo.id, pattern);
       await get().refreshAll();
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
 
@@ -1551,7 +1483,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     try {
       await openInEditorFn(repo.id, relativePath);
     } catch (e) {
-      set({ error: toAppError(e) });
+      setErrorFor(repo.id, e);
     }
   },
   });

--- a/src/features/repo/useTabsStore.mergeGuard.test.tsx
+++ b/src/features/repo/useTabsStore.mergeGuard.test.tsx
@@ -1,0 +1,177 @@
+// Closing a tab must not pull the repository out from under a live merge
+// resolver (#90 follow-up).
+//
+// The resolver is a separate Tauri window driving IPC with this repository's
+// `RepoId`. Since closing a tab now calls `close_repo`, an unguarded close would
+// make the resolver's next call answer `UnknownRepo` mid-resolution. The chosen
+// behaviour: confirm in the MAIN window, then close the resolver and only evict
+// once it is really gone.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+
+import { PGDialogHost } from "@/design";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import {
+  acceptDialog,
+  dialogIsOpen,
+  dialogTitle,
+  dismissDialog,
+  resetDialogs,
+} from "@/test/dialog";
+import {
+  __resetMergeAttribution,
+  openMergeWindow,
+} from "@/features/merge/openMergeWindow";
+import { emptySlice } from "./repoSlice";
+import { newTab } from "./tabs";
+import { useRepoStore } from "./useRepoStore";
+import { useTabsStore } from "./useTabsStore";
+
+const API = { id: "r-api", path: "/dev/api", head: "main" };
+const WEB = { id: "r-web", path: "/dev/web", head: "main" };
+
+const getByLabel = WebviewWindow.getByLabel as unknown as ReturnType<typeof vi.fn>;
+
+function armBackend() {
+  mockInvoke("open_repo", (args) => (args.path === API.path ? API : WEB));
+  mockInvoke("close_repo", () => undefined);
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => null);
+  mockInvoke("list_all_files", () => []);
+}
+
+/** Two open tabs, /dev/api active and live. */
+function seedTwoTabs() {
+  useRepoStore.setState({ ...emptySlice(), current: API } as never);
+  useTabsStore.setState({
+    tabs: [
+      newTab("/dev/api", { status: "open", repoId: "r-api" }),
+      newTab("/dev/web", {
+        status: "open",
+        repoId: "r-web",
+        slice: { ...emptySlice(), current: WEB },
+      }),
+    ],
+    activePath: "/dev/api",
+    activationSeq: 0,
+    activating: null,
+  });
+}
+
+/** A live resolver window whose `close()` makes it disappear, so the store's
+ *  wait-for-gone poll has something real to observe. */
+function armLiveMergeWindow() {
+  const win = {
+    label: "merge",
+    close: vi.fn().mockImplementation(async () => {
+      getByLabel.mockResolvedValue(null);
+    }),
+    setFocus: vi.fn().mockResolvedValue(undefined),
+    once: vi.fn().mockResolvedValue(() => {}),
+  };
+  getByLabel.mockResolvedValue(win);
+  return win;
+}
+
+const closeRepoCalls = () =>
+  getInvokeCalls().filter((c) => c.cmd === "close_repo");
+
+beforeEach(() => {
+  localStorage.clear();
+  resetInvokeMock();
+  resetDialogs();
+  armBackend();
+  getByLabel.mockReset();
+  getByLabel.mockResolvedValue(null);
+  // Module state, so it survives between tests — a stale attribution would make
+  // the unattributed case silently test the attributed one.
+  __resetMergeAttribution();
+  seedTwoTabs();
+});
+
+describe("closing a tab with the merge resolver open", () => {
+  it("confirms first, and declining leaves the tab AND the resolver alone", async () => {
+    render(<PGDialogHost />);
+    const win = armLiveMergeWindow();
+
+    const closing = useTabsStore.getState().close("/dev/api");
+    await waitFor(() => expect(dialogIsOpen()).toBe(true));
+    expect(dialogTitle()).toBe("Close this repository and its merge resolver?");
+    await dismissDialog();
+    await closing;
+
+    // Nothing happened: no eviction, no window close, tab still there.
+    expect(closeRepoCalls()).toHaveLength(0);
+    expect(win.close).not.toHaveBeenCalled();
+    expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual([
+      "/dev/api",
+      "/dev/web",
+    ]);
+    expect(useTabsStore.getState().activePath).toBe("/dev/api");
+  });
+
+  it("closes the resolver BEFORE evicting the repository", async () => {
+    render(<PGDialogHost />);
+    const win = armLiveMergeWindow();
+
+    const closing = useTabsStore.getState().close("/dev/api");
+    await waitFor(() => expect(dialogIsOpen()).toBe(true));
+    await acceptDialog();
+    await closing;
+
+    expect(win.close).toHaveBeenCalledOnce();
+    // The eviction happened, and only after the window was gone — `close()`'s
+    // implementation is what makes getByLabel report null, so a `close_repo`
+    // issued earlier would have run against a still-live resolver.
+    expect(closeRepoCalls().map((c) => c.args.repoId)).toEqual(["r-api"]);
+    expect(await WebviewWindow.getByLabel("merge")).toBeNull();
+    expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual(["/dev/web"]);
+    expect(useTabsStore.getState().activePath).toBe("/dev/web");
+  });
+
+  it("does not prompt when the resolver belongs to another repository", async () => {
+    render(<PGDialogHost />);
+    // Attribute the window to /dev/web by opening it for that repo, then make it
+    // live. Closing /dev/api must not involve it.
+    await openMergeWindow("r-web");
+    armLiveMergeWindow();
+
+    await useTabsStore.getState().close("/dev/api");
+
+    expect(dialogIsOpen()).toBe(false);
+    expect(closeRepoCalls().map((c) => c.args.repoId)).toEqual(["r-api"]);
+    expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual(["/dev/web"]);
+  });
+
+  it("prompts for a resolver this page instance cannot attribute", async () => {
+    render(<PGDialogHost />);
+    // Main reloaded while the resolver stayed up: the window is live but nothing
+    // records which repository it is on. Prompting once beats breaking it.
+    armLiveMergeWindow();
+
+    const closing = useTabsStore.getState().close("/dev/api");
+    await waitFor(() => expect(dialogIsOpen()).toBe(true));
+    await acceptDialog();
+    await closing;
+
+    expect(closeRepoCalls().map((c) => c.args.repoId)).toEqual(["r-api"]);
+  });
+
+  it("closes normally with no resolver open", async () => {
+    render(<PGDialogHost />);
+
+    await useTabsStore.getState().close("/dev/api");
+
+    expect(dialogIsOpen()).toBe(false);
+    expect(closeRepoCalls().map((c) => c.args.repoId)).toEqual(["r-api"]);
+    expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual(["/dev/web"]);
+  });
+});

--- a/src/features/repo/useTabsStore.test.ts
+++ b/src/features/repo/useTabsStore.test.ts
@@ -1,0 +1,419 @@
+// The tab store's invariants (#90). The interesting ones are all about NOT
+// leaking: a switch must replace the whole slice, an in-flight refresh from the
+// repository you left must not land in the one you arrived at, and a failed open
+// must leave the tab you were on intact.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { REPO_SLICE_KEYS, emptySlice } from "./repoSlice";
+import { OPEN_REPOS_KEY } from "./tabs";
+import { useRepoStore } from "./useRepoStore";
+import { useTabsStore } from "./useTabsStore";
+
+const HANDLES: Record<string, { id: string; path: string; head: string }> = {
+  "/dev/api": { id: "r-api", path: "/dev/api", head: "main" },
+  "/dev/web": { id: "r-web", path: "/dev/web", head: "trunk" },
+};
+
+/** One status entry per repo, so a leak between them is visible. */
+const STATUS: Record<string, unknown[]> = {
+  "r-api": [
+    {
+      path: "api-only.txt",
+      worktree: { kind: "Modified" },
+      index: { kind: "Unmodified" },
+    },
+  ],
+  "r-web": [],
+};
+
+function armBackend() {
+  mockInvoke("open_repo", (args) => {
+    const h = HANDLES[args.path as string];
+    if (!h) throw { kind: "InvalidPath", message: args.path };
+    return h;
+  });
+  mockInvoke("close_repo", () => undefined);
+  mockInvoke("get_status", (args) => STATUS[args.repoId as string] ?? []);
+  mockInvoke("list_branches", (args) => [
+    {
+      name: args.repoId === "r-api" ? "main" : "trunk",
+      isHead: true,
+      isRemote: false,
+      upstream: null,
+      ahead: 0,
+      behind: 0,
+      tip: "0".repeat(40),
+    },
+  ]);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", (args) => ({
+    commits: [
+      {
+        oid: `${args.repoId}-c1`,
+        shortOid: "abc1234",
+        summary: `commit in ${args.repoId}`,
+        author: "a",
+        email: "a@b.c",
+        timestamp: 1,
+        parents: [],
+        refs: [],
+      },
+    ],
+    nextCursor: null,
+  }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => null);
+  mockInvoke("list_all_files", () => []);
+}
+
+function resetStores() {
+  useTabsStore.setState({
+    tabs: [],
+    activePath: null,
+    activationSeq: 0,
+    activating: null,
+  });
+  useRepoStore.setState(emptySlice());
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  resetInvokeMock();
+  armBackend();
+  resetStores();
+});
+
+const calls = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+
+describe("useTabsStore — opening", () => {
+  it("opens a repository into a tab and makes it active", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    const { tabs, activePath } = useTabsStore.getState();
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0]).toMatchObject({
+      path: "/dev/api",
+      repoId: "r-api",
+      status: "open",
+      screen: "history",
+    });
+    expect(activePath).toBe("/dev/api");
+    expect(useRepoStore.getState().current?.id).toBe("r-api");
+  });
+
+  it("opening an already-open path focuses its tab instead of duplicating it", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+    expect(useTabsStore.getState().activePath).toBe("/dev/web");
+
+    await useTabsStore.getState().openRepo("/dev/api");
+    expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual([
+      "/dev/api",
+      "/dev/web",
+    ]);
+    expect(useTabsStore.getState().activePath).toBe("/dev/api");
+  });
+
+  it("a failed open leaves the tab you were on, with its data", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    const before = useRepoStore.getState().commits;
+
+    await useTabsStore.getState().openRepo("/dev/missing");
+
+    expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual(["/dev/api"]);
+    expect(useTabsStore.getState().activePath).toBe("/dev/api");
+    expect(useRepoStore.getState().current?.id).toBe("r-api");
+    expect(useRepoStore.getState().commits).toEqual(before);
+    expect(useRepoStore.getState().error?.kind).toBe("InvalidPath");
+  });
+});
+
+describe("useTabsStore — concurrent opens", () => {
+  it("opens the repository ONCE when two requests race for the same tab", async () => {
+    let release = () => {};
+    const gate = new Promise<void>((res) => {
+      release = res;
+    });
+    mockInvoke("open_repo", async (args) => {
+      await gate;
+      return HANDLES[args.path as string];
+    });
+
+    const first = useTabsStore.getState().openRepo("/dev/api");
+    const second = useTabsStore.getState().openRepo("/dev/api");
+    release();
+    await Promise.all([first, second]);
+
+    // Two `open_repo` calls would mean two RepoIds for one repository, one of
+    // them never evicted.
+    expect(calls("open_repo")).toHaveLength(1);
+    expect(useTabsStore.getState().tabs).toHaveLength(1);
+    expect(useRepoStore.getState().current?.id).toBe("r-api");
+  });
+
+  it("evicts the handle of an open that was superseded mid-flight", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+    // Leave /dev/web and re-enter it, but supersede that open before it lands.
+    await useTabsStore.getState().activate("/dev/api");
+    useTabsStore.setState((s) => ({
+      tabs: s.tabs.map((t) =>
+        t.path === "/dev/web" ? { ...t, status: "pending", slice: null } : t,
+      ),
+    }));
+
+    let release = () => {};
+    mockInvoke("open_repo", async (args) => {
+      if (args.path === "/dev/web") {
+        await new Promise<void>((res) => {
+          release = res;
+        });
+      }
+      return HANDLES[args.path as string];
+    });
+
+    const pending = useTabsStore.getState().activate("/dev/web");
+    // Supersede it: bumping the activation counter is what a real switch does.
+    await useTabsStore.getState().activate("/dev/api");
+    release();
+    await pending;
+
+    // The abandoned handle must be closed — `open` never evicts on its own.
+    expect(calls("close_repo").map((c) => c.args.repoId)).toContain("r-web");
+    expect(useTabsStore.getState().activePath).toBe("/dev/api");
+  });
+});
+
+describe("useTabsStore — switching", () => {
+  it("hydrates the incoming slice and leaves nothing of the outgoing one", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+
+    // Every per-repo field now belongs to /dev/web.
+    const s = useRepoStore.getState();
+    expect(s.current?.id).toBe("r-web");
+    expect(s.status).toEqual([]);
+    expect(s.commits[0].oid).toBe("r-web-c1");
+    expect(s.branches[0].name).toBe("trunk");
+
+    // Going back restores the other repo's, not a blend of the two.
+    await useTabsStore.getState().activate("/dev/api");
+    const a = useRepoStore.getState();
+    expect(a.current?.id).toBe("r-api");
+    expect(a.commits[0].oid).toBe("r-api-c1");
+    expect(a.branches[0].name).toBe("main");
+    expect(a.status).toHaveLength(1);
+  });
+
+  it("snapshots every slice key on the way out", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+    const frozen = useTabsStore.getState().tabs[0].slice;
+    expect(frozen).not.toBeNull();
+    expect(Object.keys(frozen as object).sort()).toEqual(
+      [...REPO_SLICE_KEYS].sort(),
+    );
+  });
+
+  it("caches badge counts for the inactive tab", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+    expect(useTabsStore.getState().tabs[0].dirty).toBe(1);
+    expect(useTabsStore.getState().tabs[0].conflicts).toBe(0);
+  });
+
+  it("drops a refresh that resolved after the user moved to another repo", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+
+    // Start a refresh for the repo we are NOT on any more, resolving late.
+    let release = () => {};
+    mockInvoke("get_status", (args) => {
+      if (args.repoId !== "r-api") return STATUS[args.repoId as string] ?? [];
+      return new Promise<unknown[]>((res) => {
+        release = () => res(STATUS["r-api"]);
+      });
+    });
+    useRepoStore.setState({ current: HANDLES["/dev/api"] as never });
+    const pending = useRepoStore.getState().refreshAll();
+    // …and switch back to /dev/web before it lands.
+    useRepoStore.setState({ current: HANDLES["/dev/web"] as never, status: [] });
+    release();
+    await pending;
+
+    // r-api's status must NOT have been written over r-web's.
+    expect(useRepoStore.getState().current?.id).toBe("r-web");
+    expect(useRepoStore.getState().status).toEqual([]);
+  });
+
+  it("remembers each tab's screen without persisting it", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    useTabsStore.getState().rememberScreen("branches");
+    await useTabsStore.getState().openRepo("/dev/web");
+    expect(useTabsStore.getState().activeScreen()).toBe("history");
+
+    await useTabsStore.getState().activate("/dev/api");
+    expect(useTabsStore.getState().activeScreen()).toBe("branches");
+    // pg-screen stays dead: the persisted set carries paths only.
+    expect(JSON.parse(localStorage.getItem(OPEN_REPOS_KEY) as string)).toEqual({
+      paths: ["/dev/api", "/dev/web"],
+      active: "/dev/api",
+    });
+  });
+
+  it("steps between tabs, wrapping", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+    await useTabsStore.getState().step(1);
+    expect(useTabsStore.getState().activePath).toBe("/dev/api");
+    await useTabsStore.getState().step(-1);
+    expect(useTabsStore.getState().activePath).toBe("/dev/web");
+  });
+
+  it("selectIndex is 1-based and ignores out-of-range numbers", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+    await useTabsStore.getState().selectIndex(1);
+    expect(useTabsStore.getState().activePath).toBe("/dev/api");
+    await useTabsStore.getState().selectIndex(9);
+    expect(useTabsStore.getState().activePath).toBe("/dev/api");
+  });
+});
+
+describe("useTabsStore — closing", () => {
+  it("evicts the repository backend-side and activates a neighbour", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+
+    await useTabsStore.getState().close("/dev/web");
+
+    expect(calls("close_repo").map((c) => c.args.repoId)).toEqual(["r-web"]);
+    expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual(["/dev/api"]);
+    expect(useTabsStore.getState().activePath).toBe("/dev/api");
+    expect(useRepoStore.getState().current?.id).toBe("r-api");
+  });
+
+  it("closing an inactive tab leaves the active one alone", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+
+    await useTabsStore.getState().close("/dev/api");
+
+    expect(useTabsStore.getState().activePath).toBe("/dev/web");
+    expect(useRepoStore.getState().current?.id).toBe("r-web");
+  });
+
+  it("closing the last tab returns to Welcome with an empty slice", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().close("/dev/api");
+
+    expect(useTabsStore.getState().tabs).toEqual([]);
+    expect(useTabsStore.getState().activePath).toBeNull();
+    expect(useRepoStore.getState().current).toBeNull();
+    expect(useRepoStore.getState().commits).toEqual([]);
+    expect(loadPersisted()).toEqual({ paths: [], active: null });
+  });
+
+  it("closeOthers keeps exactly one tab", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+    await useTabsStore.getState().closeOthers("/dev/web");
+    expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual(["/dev/web"]);
+    expect(useTabsStore.getState().activePath).toBe("/dev/web");
+  });
+
+  it("closeAll empties the strip", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+    await useTabsStore.getState().closeAll();
+    expect(useTabsStore.getState().tabs).toEqual([]);
+    expect(useRepoStore.getState().current).toBeNull();
+  });
+});
+
+describe("useTabsStore — session restore", () => {
+  it("creates every persisted tab but opens only the active one", async () => {
+    localStorage.setItem(
+      OPEN_REPOS_KEY,
+      JSON.stringify({ paths: ["/dev/api", "/dev/web"], active: "/dev/web" }),
+    );
+
+    await useTabsStore.getState().restoreSession();
+
+    const { tabs, activePath } = useTabsStore.getState();
+    expect(tabs.map((t) => t.path)).toEqual(["/dev/api", "/dev/web"]);
+    expect(activePath).toBe("/dev/web");
+    // Lazy: five persisted repositories must cost ONE open at launch.
+    expect(calls("open_repo").map((c) => c.args.path)).toEqual(["/dev/web"]);
+    expect(tabs[0].status).toBe("pending");
+    expect(tabs[1].status).toBe("open");
+  });
+
+  it("opens a pending tab on first activation", async () => {
+    localStorage.setItem(
+      OPEN_REPOS_KEY,
+      JSON.stringify({ paths: ["/dev/api", "/dev/web"], active: "/dev/web" }),
+    );
+    await useTabsStore.getState().restoreSession();
+    await useTabsStore.getState().activate("/dev/api");
+    expect(useRepoStore.getState().current?.id).toBe("r-api");
+    expect(useTabsStore.getState().tabs[0].status).toBe("open");
+  });
+
+  it("marks a vanished path failed rather than crashing the launch", async () => {
+    localStorage.setItem(
+      OPEN_REPOS_KEY,
+      JSON.stringify({ paths: ["/dev/gone"], active: "/dev/gone" }),
+    );
+    await useTabsStore.getState().restoreSession();
+    expect(useTabsStore.getState().tabs[0].status).toBe("failed");
+    expect(useRepoStore.getState().error?.kind).toBe("InvalidPath");
+  });
+
+  it("is a no-op once tabs exist (a second mount must not duplicate them)", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    const before = useTabsStore.getState().tabs;
+    await useTabsStore.getState().restoreSession();
+    expect(useTabsStore.getState().tabs).toBe(before);
+  });
+});
+
+describe("useTabsStore — badges", () => {
+  it("re-reads status for open inactive tabs only", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+    // Something changed in the background repo while we were away.
+    mockInvoke("get_status", (args) =>
+      args.repoId === "r-api"
+        ? [
+            { path: "a", worktree: { kind: "Modified" }, index: { kind: "Unmodified" } },
+            { path: "b", worktree: { kind: "Unmodified" }, index: { kind: "Added" } },
+          ]
+        : [],
+    );
+
+    await useTabsStore.getState().refreshBadges();
+
+    expect(useTabsStore.getState().tabs[0].dirty).toBe(2);
+    // The active tab is refreshed by the repo store, not by the badge sweep.
+    expect(useTabsStore.getState().tabs[1].dirty).toBe(0);
+  });
+
+  it("swallows a failing badge read", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+    mockInvoke("get_status", (args) => {
+      if (args.repoId === "r-api") throw new Error("boom");
+      return [];
+    });
+    await expect(useTabsStore.getState().refreshBadges()).resolves.toBeUndefined();
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+});
+
+function loadPersisted() {
+  return JSON.parse(localStorage.getItem(OPEN_REPOS_KEY) as string);
+}

--- a/src/features/repo/useTabsStore.ts
+++ b/src/features/repo/useTabsStore.ts
@@ -1,0 +1,366 @@
+// Repository tabs — the store (#90). Owns WHICH repositories are open;
+// `useRepoStore` owns the ACTIVE one's data.
+//
+// The dependency runs one way — `useTabsStore` → `useRepoStore` — so there is no
+// import cycle. That is why `openRepo` lives here and not on the repo store:
+// "open a repository" is a statement about the open set, and every call site in
+// the app (⌘O, a recents row, a clone, an init, a forwarded `pgit …`) means
+// "open it in a tab".
+//
+// Switching is snapshot → hydrate → refresh:
+//   1. freeze the live slice into the outgoing tab (so coming back is instant),
+//   2. write the incoming tab's frozen slice as a WHOLE (repoSlice.ts),
+//   3. refresh, because a cached view is not disk truth.
+//
+// Two guards keep concurrency honest:
+//   - `activationSeq` — bumped on every activate/open, re-checked after each
+//     await, so a session restore racing a forwarded CLI launch cannot both win.
+//   - `useRepoStore`'s own `setFor`, which drops a fetch that resolved after the
+//     user moved on.
+
+import { create } from "zustand";
+
+import { pgConfirm } from "@/design";
+import {
+  closeMergeWindow,
+  mergeWindowHoldsRepo,
+} from "@/features/merge/openMergeWindow";
+import { closeRepo as closeRepoIpc, getStatus } from "@/lib/tauri";
+import type { RepoHandle } from "@/lib/types";
+import { isConflicted, isStaged, isUnstaged } from "@/lib/derive";
+import { warn as logWarn } from "@tauri-apps/plugin-log";
+import { emptySlice, frozenSlice, type RepoSlice } from "./repoSlice";
+import { useRepoStore } from "./useRepoStore";
+import {
+  closeNeighbour,
+  cycle,
+  findTab,
+  indexOfTab,
+  labelTabs,
+  loadOpenRepos,
+  newTab,
+  patchTab,
+  removeTab,
+  saveOpenRepos,
+  upsertTab,
+  type RepoTab,
+} from "./tabs";
+
+interface TabsState {
+  tabs: RepoTab[];
+  /** Path of the active tab, or null (no repository open → Welcome). */
+  activePath: string | null;
+  /** Monotonic activation counter — the async race guard. */
+  activationSeq: number;
+  /** Path whose open is in flight, so a second request for the SAME tab waits
+   *  instead of opening the repository twice. */
+  activating: string | null;
+  /**
+   * Open `path` in a tab: focuses the existing tab when the path is already
+   * open, otherwise opens the repository and appends a tab. The single entry
+   * point for opening a repository anywhere in the app.
+   */
+  openRepo: (path: string) => Promise<void>;
+  /** Make the tab at `path` active, opening it if it is still pending. */
+  activate: (path: string) => Promise<void>;
+  /** Close one tab, evicting its repository backend-side. */
+  close: (path: string) => Promise<void>;
+  closeOthers: (keepPath: string) => Promise<void>;
+  closeAll: () => Promise<void>;
+  /** Cycle to the next/previous tab (wrapping). */
+  step: (delta: 1 | -1) => Promise<void>;
+  /** Activate the 1-based nth tab; no-op when there are fewer. */
+  selectIndex: (oneBased: number) => Promise<void>;
+  /** Record the screen the ACTIVE tab is on (session-only). */
+  rememberScreen: (screen: string) => void;
+  /** Screen remembered for the active tab, or null. */
+  activeScreen: () => string | null;
+  /** Re-read `status` for every open INACTIVE tab so its badge is honest. */
+  refreshBadges: () => Promise<void>;
+  /** Recreate the persisted open set as pending tabs and activate the persisted
+   *  active one. Lazy: only that one repository is actually opened. */
+  restoreSession: () => Promise<void>;
+  /** Display labels, parent-disambiguated for colliding names. */
+  labels: () => string[];
+}
+
+function countsOf(slice: RepoSlice): { dirty: number; conflicts: number } {
+  return {
+    dirty: slice.status.filter((s) => isStaged(s) || isUnstaged(s)).length,
+    conflicts: slice.status.filter(isConflicted).length,
+  };
+}
+
+export const useTabsStore = create<TabsState>((set, get) => {
+  const persist = () => saveOpenRepos(get().tabs, get().activePath);
+
+  /** Freeze the live slice into the tab at `path` (it is about to lose it). */
+  const snapshotInto = (path: string) => {
+    const slice = frozenSlice(useRepoStore.getState().snapshot());
+    set((s) => ({
+      tabs: patchTab(s.tabs, path, { slice, ...countsOf(slice) }),
+    }));
+  };
+
+  /** Bump the race guard and return the token to check after each await. */
+  const beginActivation = (): number => {
+    const seq = get().activationSeq + 1;
+    set({ activationSeq: seq });
+    return seq;
+  };
+  const stillCurrent = (seq: number) => get().activationSeq === seq;
+
+  /**
+   * Make `tab` the live repository. Assumes the outgoing tab was already
+   * snapshotted. Opens the repository when the tab is pending or failed.
+   */
+  const hydrateTab = async (tab: RepoTab, seq: number) => {
+    set({ activePath: tab.path });
+    if (tab.status === "open" && tab.slice) {
+      useRepoStore.getState().hydrate(tab.slice);
+      persist();
+      // A cached view is not disk truth — the branch may have moved, or another
+      // process may have committed, since the tab was left.
+      await useRepoStore.getState().refreshAll();
+      return;
+    }
+    // Pending / failed / open-without-a-slice: clear first, so the previous
+    // repository's data is not on screen while this one loads.
+    useRepoStore.getState().hydrate({ ...emptySlice(), loading: true });
+    persist();
+    set({ activating: tab.path });
+    let handle: RepoHandle | null = null;
+    try {
+      handle = await useRepoStore.getState().openRepoAt(tab.path);
+    } finally {
+      if (get().activating === tab.path) set({ activating: null });
+    }
+    if (!stillCurrent(seq)) {
+      // Superseded mid-open (the user moved to another tab). Nobody will ever
+      // use this handle, and `open` never evicts on its own — so evict it here
+      // or it is a leaked git2::Repository for the rest of the session.
+      if (handle) {
+        void closeRepoIpc(handle.id).catch(() => {});
+      }
+      return;
+    }
+    if (!handle) {
+      set((s) => ({ tabs: patchTab(s.tabs, tab.path, { status: "failed" }) }));
+      persist();
+      return;
+    }
+    // `open` returns the canonicalised workdir, which may differ from the path
+    // we asked for. Re-key the tab onto it, dropping any tab that already had it.
+    const resolved = handle.path;
+    set((s) => {
+      let tabs = s.tabs;
+      if (resolved !== tab.path && indexOfTab(tabs, resolved) >= 0) {
+        tabs = removeTab(tabs, tab.path);
+        tabs = patchTab(tabs, resolved, {
+          repoId: handle.id,
+          status: "open",
+          slice: null,
+        });
+      } else {
+        tabs = patchTab(tabs, tab.path, {
+          path: resolved,
+          repoId: handle.id,
+          status: "open",
+          slice: null,
+        });
+      }
+      return { tabs, activePath: resolved };
+    });
+    persist();
+  };
+
+  const evict = (tab: RepoTab | null) => {
+    if (!tab?.repoId) return;
+    void closeRepoIpc(tab.repoId).catch((e) => {
+      // The tab is going away either way; a failed eviction is a leak, not a
+      // thing to interrupt the user about.
+      logWarn(`close_repo failed for ${tab.path}: ${String(e)}`);
+    });
+  };
+
+  return {
+    tabs: [],
+    activePath: null,
+    activationSeq: 0,
+    activating: null,
+
+    async openRepo(path) {
+      const existing = findTab(get().tabs, path);
+      if (existing) {
+        await get().activate(existing.path);
+        return;
+      }
+      const seq = beginActivation();
+      const outgoing = get().activePath;
+      if (outgoing) snapshotInto(outgoing);
+      // Create the tab optimistically so the strip shows where the work is
+      // going; hydrateTab marks it `failed` (and keeps the outgoing tab's data
+      // reachable) if the open is rejected.
+      set((s) => ({ tabs: upsertTab(s.tabs, newTab(path)) }));
+      const tab = findTab(get().tabs, path);
+      if (!tab) return;
+      await hydrateTab(tab, seq);
+      // A failed open leaves no tab behind: the error banner already says what
+      // happened, and an unopenable tab is a dead row the user must clean up.
+      if (!stillCurrent(seq)) return;
+      const after = findTab(get().tabs, path);
+      if (after?.status === "failed") {
+        const failure = useRepoStore.getState().error;
+        await get().close(path);
+        // `close` re-activates the tab we came from, whose `refreshAll` clears
+        // `error` first — so the banner has to be restored LAST, exactly as the
+        // store's own danger-op catch arms do it.
+        if (failure) useRepoStore.getState().setError(failure);
+      }
+    },
+
+    async activate(path) {
+      const tab = findTab(get().tabs, path);
+      if (!tab) return;
+      // An open for this very tab is already in flight — a second one would
+      // mint a second RepoId for the same repository and leak the loser.
+      if (get().activating === path) return;
+      // Already active AND actually loaded: nothing to do. The `current` check
+      // is not redundant — it is the invariant. Without it, a tab the store no
+      // longer holds (a store reset, a failed reopen) would look live and the
+      // app would sit on an empty slice forever.
+      if (
+        get().activePath === path &&
+        tab.status === "open" &&
+        useRepoStore.getState().current?.id === tab.repoId
+      ) {
+        return;
+      }
+      const seq = beginActivation();
+      const outgoing = get().activePath;
+      if (outgoing && outgoing !== path) snapshotInto(outgoing);
+      await hydrateTab(tab, seq);
+    },
+
+    async close(path) {
+      const target = findTab(get().tabs, path);
+      if (!target) return;
+      // The resolver is a SEPARATE window driving IPC with this repository's
+      // RepoId. Evicting it underneath would make the resolver's next call fail
+      // with `UnknownRepo` in the middle of a conflict resolution — so ask here,
+      // in the window the user is looking at, and close the resolver first if
+      // they agree. Declining leaves the tab open: better than a half-broken
+      // resolver.
+      if (target.repoId && (await mergeWindowHoldsRepo(target.repoId))) {
+        const go = await pgConfirm({
+          title: "Close this repository and its merge resolver?",
+          body:
+            "The resolver window is open for this repository. Closing the tab " +
+            "closes it too, and any side picks or result-pane edits not yet " +
+            "applied are lost. The files stay conflicted on disk.",
+          danger: true,
+          confirmLabel: "Close both",
+        });
+        if (!go) return;
+        await closeMergeWindow();
+      }
+      // Re-read: the confirm above is an await, and the strip may have moved.
+      const tabs = get().tabs;
+      const idx = indexOfTab(tabs, path);
+      if (idx < 0) return;
+      evict(tabs[idx]);
+      const remaining = removeTab(tabs, path);
+      const wasActive = get().activePath === path;
+      if (!wasActive) {
+        set({ tabs: remaining });
+        persist();
+        return;
+      }
+      const seq = beginActivation();
+      const next = closeNeighbour(remaining, idx);
+      set({ tabs: remaining, activePath: next?.path ?? null });
+      persist();
+      if (!next) {
+        // Back to Welcome, exactly as "Close repo" always did.
+        useRepoStore.getState().closeRepo();
+        return;
+      }
+      await hydrateTab(next, seq);
+    },
+
+    async closeOthers(keepPath) {
+      for (const t of get().tabs.filter((t) => t.path !== keepPath)) {
+        await get().close(t.path);
+      }
+      await get().activate(keepPath);
+    },
+
+    async closeAll() {
+      for (const t of [...get().tabs]) {
+        await get().close(t.path);
+      }
+    },
+
+    async step(delta) {
+      const next = cycle(get().tabs, get().activePath, delta);
+      if (next) await get().activate(next);
+    },
+
+    async selectIndex(oneBased) {
+      const tab = get().tabs[oneBased - 1];
+      if (tab) await get().activate(tab.path);
+    },
+
+    rememberScreen(screen) {
+      const path = get().activePath;
+      if (!path) return;
+      set((s) => ({ tabs: patchTab(s.tabs, path, { screen }) }));
+    },
+
+    activeScreen() {
+      return findTab(get().tabs, get().activePath)?.screen ?? null;
+    },
+
+    async refreshBadges() {
+      const active = get().activePath;
+      const targets = get().tabs.filter(
+        (t) => t.path !== active && t.status === "open" && t.repoId,
+      );
+      await Promise.all(
+        targets.map(async (t) => {
+          try {
+            const status = await getStatus(t.repoId as string);
+            set((s) => ({
+              tabs: patchTab(s.tabs, t.path, {
+                dirty: status.filter((f) => isStaged(f) || isUnstaged(f)).length,
+                conflicts: status.filter(isConflicted).length,
+                // Keep the frozen slice consistent with the badge, so coming
+                // back to the tab doesn't briefly contradict its own dot.
+                slice: s.tabs.find((x) => x.path === t.path)?.slice
+                  ? { ...(s.tabs.find((x) => x.path === t.path)!.slice as RepoSlice), status }
+                  : null,
+              }),
+            }));
+          } catch {
+            // A background badge is not worth an error banner.
+          }
+        }),
+      );
+    },
+
+    async restoreSession() {
+      if (get().tabs.length > 0) return;
+      const { paths, active } = loadOpenRepos();
+      if (paths.length === 0) return;
+      set({ tabs: paths.map((p) => newTab(p)) });
+      const target = active ?? paths[0];
+      // Lazy on purpose: five persisted repositories cost ONE open at launch,
+      // not five. The rest open when first activated.
+      await get().activate(target);
+    },
+
+    labels() {
+      return labelTabs(get().tabs);
+    },
+  };
+});

--- a/src/features/submodules/useSubmodulesStore.ts
+++ b/src/features/submodules/useSubmodulesStore.ts
@@ -13,6 +13,7 @@ import {
   submoduleUpdate,
 } from "@/lib/tauri";
 import { useRepoStore, withAuthRetry } from "@/features/repo/useRepoStore";
+import { useTabsStore } from "@/features/repo/useTabsStore";
 
 const RECURSIVE_KEY = "pg-submodule-recursive";
 
@@ -151,6 +152,6 @@ export const useSubmodulesStore = create<SubmodulesState>((set, get) => ({
     const repo = useRepoStore.getState().current;
     if (!repo) return;
     // No new backend op needed: a submodule checkout IS a repository.
-    await useRepoStore.getState().openRepo(submoduleAbsPath(repo.path, path));
+    await useTabsStore.getState().openRepo(submoduleAbsPath(repo.path, path));
   },
 }));

--- a/src/features/worktrees/useWorktreesStore.ts
+++ b/src/features/worktrees/useWorktreesStore.ts
@@ -17,6 +17,7 @@ import {
   worktreeRemove,
   worktreeUnlock,
 } from "@/lib/tauri";
+import { useTabsStore } from "@/features/repo/useTabsStore";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 
 function toAppError(e: unknown): AppError {
@@ -204,6 +205,6 @@ export const useWorktreesStore = create<WorktreesState>((set, get) => ({
   },
 
   async openAsRepo(path) {
-    await useRepoStore.getState().openRepo(path);
+    await useTabsStore.getState().openRepo(path);
   },
 }));

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -70,6 +70,18 @@ export async function openRepo(path: string): Promise<RepoHandle> {
 }
 
 /**
+ * Forget an opened repository backend-side (a closed repository tab).
+ *
+ * `open_repo` mints a fresh id every time and the backend never evicts on its
+ * own, so a session that opens N repositories holds N `git2::Repository` values
+ * — with their file handles — until it exits. Closing an already-closed or never
+ * -opened id is a silent success by contract.
+ */
+export async function closeRepo(repoId: string): Promise<void> {
+  return invoke<void>("close_repo", { repoId });
+}
+
+/**
  * Add `path` to the user's global `safe.directory` list so git will open it
  * despite an ownership mismatch. Only ever call this behind an explicit
  * confirmation — it is a security exception, not a preference.

--- a/src/screens/Welcome.tsx
+++ b/src/screens/Welcome.tsx
@@ -2,10 +2,11 @@ import { PGButton, PGIcon, PGIconButton, PGLogo, PGSpinner } from "@/design";
 import { useCreateStore } from "@/features/create/useCreateStore";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useRecentsStore } from "@/features/repo/useRecentsStore";
+import { useTabsStore } from "@/features/repo/useTabsStore";
 import { openRepoDialog } from "@/features/repo/ops";
 
 export function WelcomeScreen() {
-  const openRepo = useRepoStore((s) => s.openRepo);
+  const openRepo = useTabsStore((s) => s.openRepo);
   const loading = useRepoStore((s) => s.loading);
   const recents = useRecentsStore((s) => s.recents);
   const removeRecent = useRecentsStore((s) => s.removeRecent);


### PR DESCRIPTION
Closes the architecture half of #61 C4: N repositories open at once in one window.

## What changed

**Store architecture (the decision, and why).** `useRepoStore` is read at 199
`getState()` sites across 34 files and *seeded by 49 test files*, all against a
single-repo shape. So it still holds exactly **one** repository's live state —
the active tab's — and a new `useTabsStore` owns the open set plus a frozen
`RepoSlice` per inactive tab. A switch is **snapshot → hydrate → refresh**.
Every screen keeps reading `s.status` / `s.commits` / `s.branches` and calling
the same actions, unchanged.

The issue's own sketch (`repos: Record<RepoId, RepoSlice>` inside the store) was
rejected: it needs either a rewrite of every read site, or a mirror of the active
slice at top level — two copies of the same data, which is the drift trap
`BranchInfo.tip` already taught this codebase. A store factory per repo was
rejected too: `useRepoStore` is used as a hook *and* `getState()` *and*
`setState()`, so proxying all three is a shim in front of every read, and the
tests that `setState` before any repo exists would have nothing to target.

**Two invariants make it safe, both tested:**

- `features/repo/repoSlice.ts` declares every non-function field of the store.
  Hydration is a **total write**, never a patch — otherwise the previous repo's
  `status`/`commits`/`branches`/`error` survives into the next tab.
  `repoSlice.test.ts` derives the store's live non-function keys at runtime and
  fails if they diverge from `REPO_SLICE_KEYS`, so adding a per-repo field
  without listing it fails a test instead of leaking. It also collapses the three
  hand-maintained copies of the reset list (initializer, open, close) into one.
- `setFor(repoId, …)` / `setErrorFor(repoId, …)` guard every fetch and error
  write. A switch is atomic but the requests in flight are not: an unguarded
  `refreshAll` for repo A resolving after the user moved to B wrote A's data into
  B's slice. Same staleness guard `logRef`/`commitFilter` already carried, on
  repo identity. `useTabsStore` adds `activationSeq` + an `activating` latch for
  its own awaits, and evicts the handle of an open that was superseded
  mid-flight.

**Backend — `close_repo` (new).** `open` mints a fresh `RepoId` per call and
nothing ever removed an entry, so *every* open leaked a `git2::Repository` and
its file handles for the process lifetime. Closing a tab now evicts. Closing an
unknown/already-closed id is a silent success (a tab whose open failed), and
`close` deliberately leaves the `rebases` map alone — it rehydrates from
`.git/platypusgit-rebase.json`.

**UI.** `PGTabStrip` (design system) on its own row below the titlebar — the
titlebar has no space left and a scrolling strip in it would eat
`data-tauri-drag-region`. Fixed-height chrome, own `overflow-x`, tabs
`flexShrink: 0`, so the fixed frame holds. Per-tab dirty/conflict badges,
parent-directory disambiguation for colliding repo names, right-click
Close / Close others / Close all / Copy path, trailing `+`. Inactive badges
re-read on window focus. A pending or failed tab gets an explicit
"Opening…" / "Could not open — Retry / Close tab" body instead of flashing
Welcome.

**Per tab:** the repository and which screen it is on (session-only).
**Global:** theme, density, zoom, keymap preset, pane widths, recents.

**Persistence.** New `pg-open-repos` key (`{ paths, active }`, capped at 20).
Restore is **lazy**: five persisted repos cost one `open` at launch, not five.
Restored tabs are created on History, so `pg-screen` stays dead.

**Keyboard + palette.** `tab.next`/`tab.prev`/`tab.close` bind both the
literal-Ctrl and the Mod spelling, which is what makes one table correct on every
platform (⌘Tab is the macOS app switcher; ⌘W may be Tauri's window menu; on
Win/Linux physical Ctrl normalizes to Mod). `tab.select` is `Alt+1`…`Alt+9`, not
`Mod+Alt+<digit>` — Ctrl+Alt is AltGr and AltGr+2/+4 type characters on Nordic
layouts. `ActionDef.run` now receives the resolved chord so one action serves
nine of them (and the cheat sheet collapses a run of >3 chords to `⌥1–⌥9`).
`tab.switch` (⌘E) opens a palette picker listing open tabs then unopened
recents; palette also gains close-tab and close-others.

**CLI.** A forwarded `pgit <path>` opens or focuses a **tab** instead of evicting
the current repository.

**Merge window** is untouched: it has no open repo of its own and works from
`?repoId=` + IPC. `openMergeWindow`'s on-destroy refresh gained the repo guard so
closing a resolver after a tab switch no longer refreshes the wrong repository.

CLAUDE.md updated: architecture trees, navigation model, state-management
conventions, the new localStorage key, and the e2e notes.

## Verification (all run locally, on this branch, rebased onto `main` @ `a4d0814`)

| gate | result |
| --- | --- |
| `pnpm tsc --noEmit` | exit 0 |
| `pnpm exec tsc -p e2e/tsconfig.json --noEmit` | exit 0 |
| **`pnpm build`** (`tsc && vite build`) | **exit 0** |
| `pnpm test` | **1161 passed / 150 files**, 0 failed |
| `cargo test --manifest-path src-tauri/Cargo.toml` | **385 passed**, 0 failed |

New tests: `src-tauri/tests/multi_repo.rs` (4 — two repos independent, close
evicts, close idempotent, reopen), `repoSlice.test.ts` (7), `tabs.test.ts` (21),
`useTabsStore.test.ts` (23), `useTabsStore.mergeGuard.test.tsx` (5),
`RepoTabs.test.tsx` (11), `AppShell.tabs.test.tsx` (7), plus dispatcher
input-policy, preset-chord and palette cases. `e2e/specs/repo-tabs.e2e.ts`
(7 cases) is new and typechecks.

**E2E was NOT run locally** — several agents were compiling concurrently and the
8GB Docker VM OOM-kills rustc. `e2e-linux` on this PR is the gate. Existing specs
were checked by reading: the strip adds only new testids, no titlebar selector
moved, and the one behavioural break — `reopenRepo` reloads without clearing
localStorage, so the restored session may already have the repo open and no
Welcome row is rendered — is fixed in `e2e/support/app.ts` (waits for the branch
chip **or** the row).

## Review follow-ups (both fixed in this revision)

- **⌥1–9 no longer eats typed characters.** `tab.select` now carries
  `suppressInInput`, the same dispatcher opt-out `pane.focus*` uses for the macOS
  ⌥←/⌥→ caret jumps — `hasRealModifier` dispatches any `Alt+…` chord while
  typing, and ⌥+digit is a *character* on macOS (and on Nordic layouts one people
  type routinely). `isEditable` covers input, textarea and contentEditable, so the
  resolver's CodeMirror pane is included. Rebinding to `Mod+1`–`Mod+9` was
  rejected: those are the screen-navigation chords in both presets (and all nine
  in `platypusgit classic`), so it would have been a collision, not a move.
  `tab.next`/`tab.prev`/`tab.close` stay live while typing — their chords type
  nothing. Three cases in `useKeymapStore.test.tsx` pin it: fires outside a field,
  suppressed *and not `preventDefault`ed* inside input/textarea/contentEditable,
  and the cycling chords still fire in a textarea.
- **Closing a tab can no longer break a live resolver.** Chosen behaviour:
  confirm in the main window, then close the resolver, then evict.
  `mergeWindowHoldsRepo()` / `closeMergeWindow()` in
  `features/merge/openMergeWindow.ts` own the handshake, and `closeMergeWindow`
  **waits for the window label to disappear** before returning — `close()`
  resolves when the request is delivered, not when the window is destroyed, and
  evicting in that gap is the exact race. Declining leaves both the tab and the
  resolver untouched. Attribution (which repo a live resolver is on) is module
  state set on open/retarget and cleared on `tauri://destroyed`; a live window
  this page instance cannot attribute (main reloaded under it) counts as a match,
  so the worst case is one extra confirmation rather than a broken resolution.
  `useTabsStore.mergeGuard.test.tsx` covers decline, confirm-with-ordering
  (`close_repo` only after the window is gone), other-repo (no prompt),
  unattributed (prompt), and no-resolver.

## Gaps

- **Per-tab selections and scroll are not preserved.** The screen subtree is
  keyed by the active repository, so a switch remounts it: A→B→A loses A's
  selected commit/file and scroll offset. Deliberate — a retained selected-oid
  from another repository renders the wrong thing at best. Restoring them per tab
  would need every screen to lift its selection into the tab record.
- **Background tabs are frozen views.** No fetch, no log walk, no `repo_state`
  poll while inactive; only the dirty/conflict badge is refreshed, and only on
  window focus. An in-progress merge started elsewhere in a background repo is
  invisible until you visit its tab.
- **No drag-to-reorder** and no manual tab ordering: the strip is open-order.
  (#61 C5 territory.)
- **Auto-fetch follows the active tab only.** The interval in `AppShell` fetches
  the active repository; background tabs are not fetched.
- **A network op whose auth retry lands after a tab switch is silently dropped.**
  `setErrorFor` refuses to raise repo A's error over repo B, which is right for
  the banner but means a credential retry completed after switching reports
  nothing. Same for an op whose tab was closed mid-flight (`UnknownRepo`).
- **No workspace concept.** The open set is a flat list — no named groups, no
  `.pgit-workspace` file, no splitting a repository into a second window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3Pnr6uVf6pgYbZXh65hVU
