### PR TITLE
fix(history): remove the non-working "Mine" scope option

### DIFF
--- a/src/features/commits/graphAncestry.ts
+++ b/src/features/commits/graphAncestry.ts
@@ -16,9 +16,9 @@ import type { CommitInfo } from "@/lib/types";
  * links dashed, and terminate the lane when nothing resolves.
  *
  * Deliberately frontend-only. Only text/author/path/date/sha filtering happens
- * in the backend; `mine`, `branch`, and `hideMerges` are client-side
- * refinements over `baseCommits`, so a backend rewrite would leave all three
- * still emitting phantom lanes. The ancestry needed is already on the client —
+ * in the backend; `hideMerges` is a client-side refinement over `baseCommits`,
+ * so a backend rewrite would leave it still emitting phantom lanes. The
+ * ancestry needed is already on the client —
  * useRepoStore holds the unfiltered `commits` next to `searchResults`. See the
  * spec's "Corrections to #68".
  */

--- a/src/screens/History.scope.test.tsx
+++ b/src/screens/History.scope.test.tsx
@@ -1,6 +1,6 @@
-// The All / Mine / This branch group scopes the BACKEND walk: "All" and "Mine"
-// walk every branch (LOG_REF_ALL), "This branch" walks HEAD alone. It used to
-// approximate "this branch" client-side by slicing the top `ahead` commits.
+// The All / This branch group scopes the BACKEND walk: "All" walks every
+// branch (LOG_REF_ALL), "This branch" walks HEAD alone. It used to approximate
+// "this branch" client-side by slicing the top `ahead` commits.
 import { describe, expect, it, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
@@ -123,15 +123,12 @@ describe("History scope selector", () => {
     expect(useRepoStore.getState().logRef).toBe("main");
   });
 
-  it('"Mine" filters by author without leaving the all-branches walk', async () => {
+  it("offers no author-scoped option", async () => {
     render(<HistoryScreen />);
     await waitFor(() =>
       expect(screen.getAllByTestId("commit-row").length).toBeGreaterThan(0),
     );
 
-    fireEvent.click(screen.getByText("Mine"));
-    await new Promise((r) => setTimeout(r, 20));
-    expect(useRepoStore.getState().logRef).toBe(LOG_REF_ALL);
-    expect(logRefspecs()).toEqual([]);
+    expect(screen.queryByText("Mine")).toBeNull();
   });
 });

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -63,7 +63,7 @@ import {
 import type { CommitInfo, FileDiff } from "@/lib/types";
 import { LOG_REF_ALL } from "@/lib/types";
 
-type HistoryFilterKind = "all" | "mine" | "branch";
+type HistoryFilterKind = "all" | "branch";
 type RefFilter = "all" | "local";
 type DiffLayout = "below" | "beside";
 
@@ -206,30 +206,14 @@ export function HistoryScreen() {
   const { onContextMenu: onCommitMulti, menu: commitMultiMenu } =
     useContextMenu<string[]>((oids) => commitMultiMenuItems(oids));
 
-  // Most-frequent author email in the loaded history — used as a "mine" heuristic
-  // until we expose git config (user.email) to the frontend.
-  const myEmail = React.useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const c of commits) counts.set(c.email, (counts.get(c.email) ?? 0) + 1);
-    let best: string | null = null;
-    let n = 0;
-    for (const [k, v] of counts) if (v > n) { best = k; n = v; }
-    return best;
-  }, [commits]);
-
-  // Text/author/path/date/sha filtering happens on the backend (baseCommits).
-  // The "mine"/"branch"/hide-merges toggles remain client-side refinements.
-  // "All"/"Mine" walk every branch, "This branch" walks HEAD alone — the scope
-  // is a backend concern (see the logRef effect below), so all that is left
-  // client-side is the author refinement and hide-merges.
+  // Text/author/path/date/sha filtering happens on the backend (baseCommits),
+  // and so is the "all"/"branch" scope (see the logRef effect below), so
+  // hide-merges is all that is left client-side.
   const visible = React.useMemo(() => {
     let list: CommitInfo[] = baseCommits;
-    if (filterKind === "mine" && myEmail) {
-      list = list.filter((c) => c.email === myEmail);
-    }
     if (hideMerges) list = list.filter((c) => c.parents.length <= 1);
     return list;
-  }, [baseCommits, filterKind, myEmail, hideMerges]);
+  }, [baseCommits, hideMerges]);
 
   // Ancestry pool for parent rewriting. The UNION matters: `searchResults` has
   // no intervening commits by construction, and `commits` may not reach as deep
@@ -262,8 +246,8 @@ export function HistoryScreen() {
   // of truth for "where the user is" (#68 G11 on top of G10).
   //
   // Bounded on purpose. `visible` is the CLIENT-side-filtered list, and a filter
-  // can hold it shorter than the window indefinitely — "mine" and hide-merges
-  // can starve it however many pages the walk yields. The
+  // can hold it shorter than the window indefinitely — hide-merges can starve
+  // it however many pages the walk yields. The
   // end-of-list condition is then satisfied at rest with no scrolling, and
   // `loadMoreCommits` toggling `loadingMore` re-arms this effect after every
   // page, so it would walk the entire repository a page at a time. Allow a few
@@ -417,8 +401,8 @@ export function HistoryScreen() {
     [branches],
   );
 
-  // The All / Mine / This branch group is a SCOPE, not a client-side sieve:
-  // "All" and "Mine" walk every branch, "This branch" walks HEAD alone.
+  // The All / This branch group is a SCOPE, not a client-side sieve: "All"
+  // walks every branch, "This branch" walks HEAD alone.
   //
   // Only a CHANGE of scope rescopes the walk. Reacting to `logRef` instead
   // would fight the ref selector next door: picking a branch (or HEAD) by hand
@@ -1340,7 +1324,6 @@ function HistoryToolbarLeft(props: HistoryToolbarLeftProps) {
         onChange={(v) => onFilterKind(v as HistoryFilterKind)}
         options={[
           { value: "all", label: "All" },
-          { value: "mine", label: "Mine" },
           { value: "branch", label: "This branch" },
         ]}
       />


### PR DESCRIPTION
The History toolbar's **All / Mine / This branch** group offered **Mine**, which didn't work and sat oddly next to two walk scopes.

**Why it didn't work:** `Mine` filtered the loaded page by the *most-frequent author email in it* — a heuristic standing in for git config `user.email`, which the frontend was never given. On a repo where you're the dominant committer it filtered nothing; on any other it filtered to someone else's commits. And it read as a scope while actually being an author sieve (the real author filter lives in advanced search).

**Change:** drop the option, the `myEmail` heuristic, and the client-side author filter. `HistoryFilterKind` is now `"all" | "branch"`, so the group is purely a walk scope — all branches (`LOG_REF_ALL`) vs HEAD. `hideMerges` is the only client-side refinement left; comments in `History.tsx` and `graphAncestry.ts` updated to say so.

**Tests:** the scope spec's `"Mine" filters by author…` case becomes an assertion that no author-scoped option is offered. `pnpm tsc --noEmit` clean, `pnpm test` 1142/1142 green. No e2e spec referenced the group; `history-ops` + `history-diff` run in Docker as a regression check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185qXvxHSJzJvKXpa65sKmB