### PR TITLE
docs: correct the e2e spec count and record the Docker slot rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,23 @@ host-port collisions. Different worktrees → run concurrently, no coordination.
 Same worktree → run one at a time (they'd share the target volume). Each agent
 just runs `pnpm test:e2e:docker …` from its own worktree.
 
+Expect this on a new worktree's first run, and ignore it — it is the shared
+caches working as designed, not a misconfiguration:
+
+```
+warning: volume "pgit-e2e-pnpm-store" already exists but was created for
+project "pgit-e2e-<some-other-worktree>" (expected "pgit-e2e-<yours>").
+Use `external: true` to use an existing volume
+```
+
+**One cold container build at a time across ALL worktrees, though.** The
+concurrency note above is about correctness (separate volumes), not memory: two
+worktrees compiling GTK/WebKit at once exceeds the ~8GB VM even at
+`CARGO_BUILD_JOBS=2` each, and rustc is SIGKILLed in *both* runs. Also note
+`compose run --build` creates no container until the image build finishes, so a
+build already in flight is invisible to `docker ps` — check `docker compose ls`
+too before assuming the slot is free.
+
 ## Testing
 
 Four layers, each run independently:
@@ -138,7 +155,8 @@ Four layers, each run independently:
   `src/`. Runs in jsdom with React Testing Library. The Tauri `invoke` and
   `plugin-dialog.open` calls are mocked via `src/test/setup.ts`; tests register
   per-command responses with `mockInvoke(cmd, handler)`.
-- **E2E (webview-level)** — WebdriverIO specs in `e2e/specs/` (22 files) drive the
+- **E2E (webview-level)** — WebdriverIO specs in `e2e/specs/` (24 files; count
+  them rather than trusting this number — it has been stale twice) drive the
   real debug binary: real webview →
   real Tauri IPC → real libgit2 → temp repos built by `e2e/support/tempRepo.ts`.
   Uses the embedded WebDriver provider (`@wdio/tauri-service`) — no external


### PR DESCRIPTION
Two documentation defects that cost real time while landing #121–#127 tonight.

## The e2e spec count is stale, again

`CLAUDE.md` said **22 files**; the tree has **24**. It said 19 before that. Three PRs added specs within a day (#123 drag-and-drop, #125 pulls, #126 bisect/submodules/worktrees) and each updated the sentence for its own additions only.

Rather than write "24" and wait for the next drift, the line now tells the reader to count. A number nobody can trust is worse than no number, because it reads as verified.

## The Docker slot rules were nowhere in the file

CLAUDE.md's "Parallel agents / worktrees: safe by construction" paragraph is about **correctness** — separate `node_modules` / `target` / `.bin` volumes per worktree, shared package caches, no host-port collisions. Three sessions read it tonight as also covering **memory**, and started overlapping e2e runs. It doesn't:

- Two worktrees compiling GTK/WebKit at once exceed the ~8GB Docker VM even at `CARGO_BUILD_JOBS=2` each, and rustc is SIGKILLed in **both** runs, so two runs are lost rather than one delayed.
- `compose run --build` creates **no container until the image build finishes**, so `docker ps` shows an idle slot while a build is in flight. That is precisely how two of us started overlapping runs after each checking `docker ps` and seeing nothing. `docker compose ls` is the check that sees it.

Both are now stated where the concurrency claim is made.

## The shared-cache warning is expected output

```
warning: volume "pgit-e2e-pnpm-store" already exists but was created for
project "pgit-e2e-<some-other-worktree>" (expected "pgit-e2e-<yours>").
```

Appears on every new worktree's first run, names another worktree's project, and reads like a misconfiguration — it is the fixed-name cache volumes working as designed (crates download once, not per-worktree). Documented so nobody "fixes" it.

## Not included

The **"One runner, eleven call sites"** credential bullet is already correct on `main` — #126 fixed it, and I recounted from the merged tree to confirm: six in `branches.rs` via `run_git_creds`, `clone_repo`, forge's `FETCH` in `forge_checkout_pull_request` (its `checkout` of `FETCH_HEAD` passes `None` on purpose), `submodule_update`, and `lfs_fetch` / `lfs_pull`. Eleven.

Docs only — no source, test, or config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)