### PR TITLE
fix(settings): stop the HEAD marks control crushing its label

### DIFF
--- a/src/features/settings/HeadMarksControl.tsx
+++ b/src/features/settings/HeadMarksControl.tsx
@@ -106,11 +106,13 @@ export function HeadMarksControl() {
   };
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", gap: 10, minWidth: 320 }}>
+    <div style={{ display: "flex", flexDirection: "column", gap: 10, minWidth: 0 }}>
       <div
         style={{
           display: "grid",
-          gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+          // The Settings row is stacked, so this control spans the section. Let
+          // the checkbox columns follow that width instead of pinning two.
+          gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
           columnGap: 12,
           rowGap: 6,
         }}

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -636,6 +636,7 @@ function AppearanceSection({ active }: { active: ThemeDef }) {
       />
 
       <Row
+        stacked
         label="Current position (HEAD)"
         hint="How History marks the commit you are on. Pick any combination of marks, then set how hard they hit — the preview is the real History row."
         control={<HeadMarksControl />}
@@ -1226,21 +1227,31 @@ function Section({
   );
 }
 
+/**
+ * `stacked` puts the control on its own full-width line under the label. The
+ * inline layout gives the control whatever width it asks for (`flexShrink: 0`),
+ * which is right for a button group or a select but crushes the label column to
+ * a word per line once the control is intrinsically wide — a live preview of a
+ * real History row, say.
+ */
 function Row({
   label,
   hint,
   control,
+  stacked,
 }: {
   label: string;
   hint?: React.ReactNode;
   control: React.ReactNode;
+  stacked?: boolean;
 }) {
   return (
     <div
       style={{
         display: "flex",
-        alignItems: "flex-start",
-        gap: 16,
+        flexDirection: stacked ? "column" : "row",
+        alignItems: stacked ? "stretch" : "flex-start",
+        gap: stacked ? 10 : 16,
         padding: "12px 16px",
         borderBottom: "1px solid var(--border-0)",
       }}
@@ -1268,7 +1279,7 @@ function Row({
           </div>
         )}
       </div>
-      <div style={{ flexShrink: 0, paddingTop: 2 }}>{control}</div>
+      <div style={stacked ? { minWidth: 0 } : { flexShrink: 0, paddingTop: 2 }}>{control}</div>
     </div>
   );
 }


### PR DESCRIPTION
The Settings `Row` is inline: label+hint take `flex: 1`, the control is
`flexShrink: 0`. Right for a button group or a select — wrong for the HEAD
marks control, which carries a live preview built from the real
`PGCommitRow` and is therefore intrinsically wide. It claimed the whole
row and left the label column about one word wide, wrapping "Current
position (HEAD)" and its hint down the side of the section.

## Change

- `Row` gains a `stacked` variant: label + hint on their own full-width
  line, control beneath.
- The `Current position (HEAD)` row uses it.
- The marks grid flows its checkbox columns to the available width
  (`auto-fit, minmax(180px, 1fr)`) instead of pinning two, and the
  preview now spans the section — closer to the History row it is
  previewing, which is the point of rendering the real component.

## Testing

- `pnpm tsc --noEmit` clean.
- `pnpm vitest run src/features/settings src/screens/Settings.test.tsx` — 61 pass.
  Testids unchanged; no e2e spec touches this control.
- Not eyeballed in the real app: `pnpm tauri dev` in the worktree collided
  with a dev instance already holding port 1420.

🤖 Generated with [Claude Code](https://claude.com/claude-code)