### PR TITLE
docs(site): drop shipped quick merge/rebase from the roadmap

### DIFF
--- a/site/src/data/features.ts
+++ b/site/src/data/features.ts
@@ -38,6 +38,7 @@ export const featureGroups = [
   ]},
   { title: 'Branches & tags', blurb: 'Full ref management.', items: [
     'List / create / checkout / rename / delete branches',
+    'Merge or rebase onto any branch — local or remote — straight from the branch picker, the titlebar chip or the Branches screen',
     'Lightweight and annotated tags',
     'Push and delete tags',
   ]},
@@ -113,7 +114,6 @@ export const featureGroups = [
 export const roadmap = [
   'Branch compare — branch↔branch and branch↔working tree',
   'GPG/SSH tag signing (commit signing shipped in 0.0.8)',
-  'Quick merge/rebase from the branch picker',
   'Partial/hunk-level stash + rename + compare to working tree',
   'Signed & notarized macOS / Windows builds',
 ];


### PR DESCRIPTION
The site roadmap teaser still listed "Quick merge/rebase from the branch picker" as planned. It ships today:

- `branchMenuItems` (`src/design/context-menu.tsx:869`) has **Merge into current** and **Rebase current onto this**, both behind a `pgConfirm`; `remoteBranchMenuItems` carries the same pair, so `origin/main` works too.
- Reachable from the `BranchPicker` row three ways — right-click, the `⋯` Actions button, and `→` from the keyboard (`BranchPicker.tsx:185`) — plus the titlebar branch chip and the Branches screen.
- Graph drag-and-drop covers merge / rebase / cherry-pick as of #91.

So the line is moved out of `roadmap` and named in the shipped **Branches & tags** group instead. The local (gitignored) `features.md` / `implemented-features.md` backlog files were updated to match, and the three genuinely-planned P1 items are now tracked as #131, #132, #133.

Site-only change — the e2e path filter skips the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)