### PR TITLE
feat(tags): GPG/SSH tag signing + verified badge (#132)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -981,9 +981,15 @@ lib/
   Deliberately not hand-written serialization: the payload is then byte-for-byte
   what libgit2 would have stored, with no tagger formatting or timezone
   arithmetic of ours. Cost: the unsigned annotation is left unreferenced and
-  collected by `git gc`. **Shelling out to `git tag -s` was considered and
+  collected by `git gc`. **Shelling out to plain `git tag -s` was considered and
   rejected** — it does its own key resolution, so it would bypass `signing.rs`
-  entirely and silently accept the `key::` literals commits refuse.
+  entirely and silently accept the `key::` literals commits refuse. (A hybrid —
+  resolve here, then `git tag -s -u <key> -F -` — would keep the restriction; the
+  spec records why route (a) won anyway, so nobody re-derives a false dichotomy.)
+- **The ref write is not the only collision check.** `create_signed_tag`
+  early-returns on an existing `refs/tags/<name>` BEFORE signing: otherwise a
+  duplicate name pops pinentry, takes the passphrase, and only then fails. The
+  atomic `force = false` write stays as the real guarantee.
 - **Signing implies annotated.** A lightweight tag is a ref with no object to
   sign, so `sign: Some(true)` with no annotation is `InvalidArgument`, not a
   silent downgrade. A bare `tag.gpgsign`, though, does NOT promote a lightweight
@@ -999,6 +1005,17 @@ lib/
   parser, `tag::parse_verify_tag`, which returns the same `SignatureStatus`.
   Neither the exit status nor the text alone is sufficient: a valid signature
   from a key outside `allowedSignersFile` exits NON-ZERO while grading `G`/`U`.
+  The `[GNUPG:] ` prefix is REQUIRED when matching a gpg status token — git
+  relays gpg's status-fd output verbatim, on **stderr**, so read both streams.
+- **"No false Good" belongs to the parser.** An SSH `Good` line is refuted by a
+  non-zero exit plus `Could not verify signature`, so a signer that printed its
+  verdict before its checks cannot produce a green badge. And a key outside
+  `allowedSignersFile` (`Good "git" signature with …`, no principal) is
+  `UnknownKey` for a TAG, not `Good` — the COMMIT path still says `Good` via
+  `parse_verify_output`'s `U` mapping, which is a known gap with its own issue,
+  not something to copy. There is no SSH `Revoked` branch: git emits only
+  `Could not verify signature.` for a revoked key (measured, git 2.50.1 +
+  OpenSSH 10.2), so one would be dead code.
 - **Verdicts are lazy, presence is free.** `TagInfo.signed` is read off the tag
   object during the existing walk (no subprocess), so tag ROWS can mark a signed
   tag; the graded badge (`TagSignatureBadge`) verifies the SELECTED tag only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,9 @@ Context for future Claude sessions working on this repo. Keep it current when ar
 New feature beyond MVP slice → write new spec + plan under these folders first.
 
 Recent specs/plans (for context on current direction):
+- `2026-08-16-tag-signing-*` — GPG/SSH signed annotated tags reusing the commit
+  signing chain, `verify_tag` + badges, one create-tag dialog replacing three
+  prompts (#132).
 - `2026-08-16-branch-compare-*` — `compare` deep view: two mutable sides
   (ref↔ref or ref↔working tree), ahead/behind + both commit lists, the file diff
   through `CommitDiffPanel` (#131).
@@ -328,6 +331,17 @@ git/
 │                NOT git's own `.git/rebase-merge/` dir — a half-compatible one
 │                would let `git status` / `git rebase --continue` claim a rebase
 │                they cannot drive
+├── signing.rs   Object signing (#61 D6, #132). PURE: gpg.format → program →
+│                user.signingkey resolution, `resolve_key_file` (the ssh
+│                key-PATH restriction — `key::…` literals refused), the signer
+│                argv, and `parse_verify_output` for git's `%G?` triple.
+│                Format-agnostic about WHAT is signed — a commit buffer and a
+│                tag body are both just payloads, which is why the tag path
+│                reuses it whole instead of growing a second chain
+├── tag.rs       Tag signing's pure half (#132): armor-header detection,
+│                `append_signature`, `validate_tag_name` (the argv guard), and
+│                `parse_verify_tag` for `git verify-tag --raw` — see the
+│                tag-signing note under Conventions for why `%G?` can't be used
 └── signature.rs Author/committer signature helpers
 commands/        Thin Tauri handlers, one file per area:
 ├── repo.rs        open_repo, close_repo, trust_repo_path, get_status,
@@ -352,8 +366,8 @@ commands/        Thin Tauri handlers, one file per area:
 │                  diff_commits, diff_ref_to_workdir, blame_file
 ├── branches.rs    list_branches/tags/stashes/remotes, checkout/create/delete/rename_branch,
 │                  fetch, fetch_all, pull, push, add/remove/rename/set_url/prune remote,
-│                  create/delete/push_tag, merge_branch, rebase_onto, checkout_ref,
-│                  push_delete_branch
+│                  create/delete/push_tag, verify_tag, merge_branch, rebase_onto,
+│                  checkout_ref, push_delete_branch
 ├── history.rs     reset, cherry_pick, revert
 ├── stash.rs       stash_save/apply/pop/drop/branch
 ├── conflict.rs    repo_state, conflict_sides, accept_ours/theirs, mark_resolved,
@@ -517,6 +531,15 @@ features/            Per-feature: components + Zustand store colocated
 │                    destructive flows so the screen and the row menu cannot drift:
 │                    remove is a `pgConfirm`, and git's `DirtyWorktree` refusal
 │                    becomes a SECOND, `requireText` confirm that passes --force
+├── signing/         SignatureBadgeView + useLazyVerification (the shared
+│                    debounce-then-verify), SignatureBadge (commits, #61 D6) and
+│                    TagSignatureBadge (tags, #132). Both verify ONE object, for
+│                    the current selection — never per row
+├── tags/            useCreateTagStore + CreateTagDialog (#132): name +
+│                    annotation + three-state sign, mounted once in AppShell.
+│                    Store-driven and promise-shaped because two of its three
+│                    call sites (a context-menu item builder and a palette step)
+│                    are not React components
 ├── lfs/             useLfsStore, LfsPanel (a section on the REMOTE screen, not a
 │                    screen — `git lfs fetch/pull` are remote-object transfers),
 │                    LfsDiffNotice (what all four diff surfaces render instead of
@@ -938,6 +961,49 @@ lib/
 - **`credential_approve` refuses values containing a newline** rather than
   escaping them: git's credential protocol is line-based `key=value`, so a
   newline injects further keys and could file a password against another host.
+
+### Signing: one chain for commits and tags (#61 D6, #132)
+
+- **One chain, two callers.** `libgit2.rs::sign_payload` is
+  `resolve_signing` → `signing::resolve_key_file` → `signing_args` →
+  `run_signer`, and `commit_signed` and `create_signed_tag` both call it. Do not
+  open a second one: the ssh key-PATH restriction (`user.signingkey` must be a
+  file, `key::…` and bare `ssh-…` literals are refused rather than written to a
+  temp file) lives in `resolve_key_file`, and a private copy is how it would come
+  to hold for commits and lapse for tags.
+- **A signing failure creates nothing, ever.** Both writers put the ref update
+  LAST — `repo.commit_signed` and `tag_annotation_create`/`odb.write` move no
+  reference, so we move it ourselves, after the signature exists. An unsigned
+  fallback would leave the user believing they had signed it.
+- **`git2` has no `tag_signed`.** `create_signed_tag` builds the canonical
+  UNSIGNED annotation with `tag_annotation_create`, reads its bytes back from the
+  ODB, signs those, appends the armored signature and writes a second object.
+  Deliberately not hand-written serialization: the payload is then byte-for-byte
+  what libgit2 would have stored, with no tagger formatting or timezone
+  arithmetic of ours. Cost: the unsigned annotation is left unreferenced and
+  collected by `git gc`. **Shelling out to `git tag -s` was considered and
+  rejected** — it does its own key resolution, so it would bypass `signing.rs`
+  entirely and silently accept the `key::` literals commits refuse.
+- **Signing implies annotated.** A lightweight tag is a ref with no object to
+  sign, so `sign: Some(true)` with no annotation is `InvalidArgument`, not a
+  silent downgrade. A bare `tag.gpgsign`, though, does NOT promote a lightweight
+  tag — real `git tag v1` fails outright there (`fatal: no tag message?`), which
+  would make lightweight tags unreachable in a signing repository, and the
+  dialog's blank annotation field *means* lightweight.
+- **`commit.gpgsign` and `tag.gpgsign` are separate keys**, as in git. `sign:
+  None` follows the matching one; `Some` overrides it for that one object.
+- **`%G?` is a COMMIT format placeholder — never use it for a tag.** `git show
+  <tag> --format=%G?` reports the *commit's* signature, and
+  `for-each-ref`'s `%(signature:grade)` atom is empty for a tag object (checked
+  against git 2.50.1). `verify_tag` uses `git verify-tag --raw` and its own
+  parser, `tag::parse_verify_tag`, which returns the same `SignatureStatus`.
+  Neither the exit status nor the text alone is sufficient: a valid signature
+  from a key outside `allowedSignersFile` exits NON-ZERO while grading `G`/`U`.
+- **Verdicts are lazy, presence is free.** `TagInfo.signed` is read off the tag
+  object during the existing walk (no subprocess), so tag ROWS can mark a signed
+  tag; the graded badge (`TagSignatureBadge`) verifies the SELECTED tag only.
+  Same rule `SignatureBadge` states for the log: a verdict per row is a signer
+  process per row.
 
 ### Bisect: git's state is the only state of record (#93)
 

--- a/docs/superpowers/plans/2026-08-16-tag-signing-plan.md
+++ b/docs/superpowers/plans/2026-08-16-tag-signing-plan.md
@@ -1,0 +1,163 @@
+# Tag signing — implementation plan
+
+**Goal:** Annotated tags can be GPG/SSH signed, defaulting from `tag.gpgsign` and
+overridable per tag; a signing failure creates no tag; tags carry a signature
+state and the Branches screen shows it.
+
+**Architecture:** The signing chain in `libgit2.rs::commit_signed` is factored
+into two reusable pieces — `signing::resolve_key_file` (the SSH key-path
+restriction, now pure) and `sign_payload` (config → args → `run_signer`) — and
+the tag path calls them unchanged. A new pure `git/tag.rs` holds everything that
+can be decided without a keyring: the armor-header test, the signature append,
+the tag-name argv guard and the `git verify-tag --raw` parser. The frontend
+replaces three single-value `pgPrompt` call sites with one store-driven modal,
+and grows a tag counterpart to `SignatureBadge`.
+
+**Tech Stack:** Rust + git2/libgit2, Tauri 2 commands, React 18 + Zustand,
+vitest/RTL.
+
+**Design doc:** `docs/superpowers/specs/2026-08-16-tag-signing-spec.md`
+**Issue:** [#132](https://github.com/jonassaa/platypusgit/issues/132)
+
+## Global Constraints
+
+- Every IPC-crossing fn returns `AppResult<T>`. No new `AppError` variant is
+  needed here; if one becomes necessary, `src/lib/errors.ts` changes in the same
+  commit.
+- New git op → trait method, `Libgit2Backend` impl, `CliBackend`
+  `NotImplemented` stub, thin command, `invoke_handler!` registration, TS type +
+  `lib/tauri.ts` wrapper, store wiring. All six steps.
+- git2 work in commands goes through `spawn_blocking`.
+- Never `window.confirm` / `window.prompt` — `pgConfirm` / `pgPrompt` from
+  `@/design`. Component tests that render a dialog-using surface need
+  `WithDialogs` from `@/test/dialog`.
+- Frontend never calls `invoke()` directly.
+- New per-repo store field → `RepoSlice` / `emptySlice` (`repoSlice.test.ts`
+  enforces it). `TagInfo` is a field of the existing `tags` array, so no new key.
+- New list-row surface opts into density: `calc(<base>px + var(--row-step))`.
+  The tag row already does; the lock glyph rides inside it.
+- Never hardcode the accent hue.
+- Secrets never in argv; user-supplied values land after `--`.
+- Run pnpm/cargo with `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"`.
+- **Do not run e2e** — the orchestrator serializes it centrally.
+
+## File Structure
+
+**Create:**
+- `src-tauri/src/git/tag.rs` — pure: `has_signature_block`, `append_signature`,
+  `validate_tag_name`, `parse_verify_tag` + unit tests.
+- `src-tauri/tests/tag_signing.rs` — integration, ssh-keygen-gated.
+- `src/features/tags/useCreateTagStore.ts`
+- `src/features/tags/CreateTagDialog.tsx`
+- `src/features/tags/CreateTagDialog.test.tsx`
+- `src/features/signing/TagSignatureBadge.tsx`
+- `docs/superpowers/specs/2026-08-16-tag-signing-spec.md`
+- `docs/superpowers/plans/2026-08-16-tag-signing-plan.md`
+
+**Modify:**
+- `src-tauri/src/git/signing.rs` — `config_flag`, `config_wants_tag_signing`,
+  `resolve_key_file`, doc generalization.
+- `src-tauri/src/git/mod.rs` — `pub mod tag;`, `verify_tag` on the trait.
+- `src-tauri/src/git/types.rs` — `TagInfo.signed`, `TagTarget.sign`.
+- `src-tauri/src/git/libgit2.rs` — `sign_payload`, `create_signed_tag`,
+  `create_tag`, `tags`, `verify_tag`.
+- `src-tauri/src/git/cli.rs` — `verify_tag` stub.
+- `src-tauri/src/commands/branches.rs` — `verify_tag` command.
+- `src-tauri/src/lib.rs` — registration.
+- `src-tauri/tests/branches_tags.rs` — `TagTarget` literals gain `sign`.
+- `src/lib/types.ts`, `src/lib/tauri.ts`
+- `src/features/signing/SignatureBadge.tsx` — extract `SignatureBadgeView`.
+- `src/AppShell.tsx` — mount `<CreateTagDialog />`.
+- `src/features/keymap/actions.ts` — `app.closeOverlay` closes it.
+- `src/design/context-menu.tsx`, `src/screens/History.tsx`,
+  `src/features/palette/commands.ts` — the three call sites.
+- `src/screens/Branches.tsx` — row lock glyph + inspector badge.
+- `CLAUDE.md` — the tag-signing convention.
+
+---
+
+### Task 1: Factor the signing chain so the tag path can reuse it
+
+- [ ] `signing.rs`: `fn config_flag(repo, key) -> bool`; `config_wants_signing`
+      and a new `config_wants_tag_signing` (`tag.gpgsign`) both delegate to it.
+- [ ] `signing.rs`: move the SSH key resolution out of `commit_signed` into
+      `pub fn resolve_key_file(cfg: &SigningConfig) -> AppResult<Option<PathBuf>>`
+      — `key::` / bare `ssh-…` literals stay refused. Unit-test it there.
+- [ ] `libgit2.rs`: `fn sign_payload(repo, payload: &str) -> AppResult<String>` =
+      `resolve_signing` → `resolve_key_file` → `signing_args` → `run_signer`.
+      `commit_signed` calls it; its behaviour is unchanged.
+- [ ] `cargo test --manifest-path src-tauri/Cargo.toml` — pure refactor, existing
+      `signing.rs` tests must still pass.
+
+### Task 2: `git/tag.rs` — the pure half, tests first
+
+- [ ] `has_signature_block(message)` over git's four armor headers, anchored to a
+      line start.
+- [ ] `append_signature(body: &[u8], sig: &str) -> Vec<u8>` — one trailing
+      newline on the body, then the signature, itself newline-terminated.
+- [ ] `validate_tag_name(name) -> AppResult<()>` — refuse empty, leading `-`,
+      whitespace, control chars, `..`, `~^:?*[\`, trailing `.lock`.
+- [ ] `parse_verify_tag(raw, ok) -> SignatureStatus` per design §E, including the
+      unrecognized-failure → `UnknownKey` fallback.
+- [ ] Unit tests for all four, with the SSH strings recorded from a real
+      `git verify-tag --raw` run.
+- [ ] `mod tag;` in `git/mod.rs`.
+
+### Task 3: Write the signed tag
+
+- [ ] `types.rs`: `TagTarget.sign: Option<bool>` (`#[serde(default)]`),
+      `TagInfo.signed: bool`.
+- [ ] `libgit2.rs::create_signed_tag` — `tag_annotation_create` → `odb.read` →
+      `sign_payload` → `append_signature` → `odb.write` → `repo.reference`.
+      Comment the two traps: no ref is written by the annotation call, and the
+      ref must come last so a signing failure leaves no tag.
+- [ ] `libgit2.rs::create_tag` — resolve `want_sign` from
+      `target.sign.unwrap_or_else(config_wants_tag_signing)`; validate the name;
+      the design §C table, including `InvalidArgument` for signed-lightweight.
+- [ ] `libgit2.rs::tags` — fill `signed` from the tag object's message.
+- [ ] Fix the three `TagTarget` literals in `tests/branches_tags.rs`.
+- [ ] `tests/tag_signing.rs` per design §Testing, `ssh_signing_repo()`-gated.
+
+### Task 4: `verify_tag`
+
+- [ ] Trait method on `GitBackend`; `CliBackend` stub.
+- [ ] `Libgit2Backend::verify_tag` — validate, short-circuit unsigned without a
+      subprocess, else `git verify-tag --raw --` with `GIT_TERMINAL_PROMPT=0` and
+      a null stdin, stdout+stderr through `parse_verify_tag`.
+- [ ] `commands/branches.rs::verify_tag` + `lib.rs` registration.
+- [ ] Integration coverage in `tests/tag_signing.rs`: `Good` for a signed tag,
+      `None` for annotated-unsigned and lightweight, `InvalidRef` for a bad name.
+
+### Task 5: Frontend types + badges
+
+- [ ] `lib/types.ts`: `TagInfo.signed`. `lib/tauri.ts`: `TagTarget.sign`,
+      `verifyTag(repoId, name)`.
+- [ ] `SignatureBadge.tsx`: extract `SignatureBadgeView({ status, testId })`
+      holding `LOOK` + markup; `SignatureBadge` becomes its commit caller.
+- [ ] `TagSignatureBadge.tsx` — same debounce, `verifyTag`, `SignatureBadgeView`.
+- [ ] `Branches.tsx`: lock glyph on a `signed` tag row (title "Signed tag");
+      `TagInspector` renders `TagSignatureBadge`.
+
+### Task 6: The create-tag dialog
+
+- [ ] `useCreateTagStore` — `{ open, oid, shortOid }` + `openCreateTag(target)`
+      returning a promise that settles on submit or dismiss.
+- [ ] `CreateTagDialog` — `PGModal`, name / annotation / three-state sign
+      checkbox, sign disabled while the annotation is blank, submit calls
+      `useRepoStore.createTag`. `data-testid`s: `create-tag-name`,
+      `create-tag-annotation`, `create-tag-sign`, `create-tag-submit`.
+      Reset the form on every closed→open transition — the dialog stays mounted.
+- [ ] `AppShell.tsx`: mount it. `actions.ts`: `app.closeOverlay` closes it,
+      inserted beside the clone/init branch.
+- [ ] Repoint `design/context-menu.tsx`, `screens/History.tsx` and
+      `features/palette/commands.ts` at `openCreateTag`.
+- [ ] `CreateTagDialog.test.tsx` per design §Testing.
+
+### Task 7: Docs + verification
+
+- [ ] `CLAUDE.md`: signing section gains the tag rule (one chain, ref last,
+      lightweight cannot be signed, `%G?` is commit-only).
+- [ ] `pnpm tsc --noEmit`, `pnpm test`,
+      `cargo check --manifest-path src-tauri/Cargo.toml`,
+      `cargo test --manifest-path src-tauri/Cargo.toml`.
+- [ ] Small Conventional Commits, push, draft PR against #132. **No e2e run.**

--- a/docs/superpowers/specs/2026-08-16-tag-signing-spec.md
+++ b/docs/superpowers/specs/2026-08-16-tag-signing-spec.md
@@ -54,16 +54,16 @@ object serialization:
    produce a tag nothing can verify).
 5. `odb.write(ObjectType::Tag, bytes)` → `repo.reference("refs/tags/<name>", …)`.
 
-Why not `git tag -s`:
+Why not plain `git tag -s` (the issue's route b):
 
 - **It would bypass `signing.rs` entirely.** `git tag -s` does its own
   `gpg.format` / `user.signingkey` resolution, so `SigningConfig`,
   `signing_args`, `run_signer` and the SSH key-path restriction would all be
   unused on the tag path. The issue asks to reuse `signing.rs` wholesale, and the
   SSH restriction — `user.signingkey` must be a key *path*, `key::…` literals are
-  refused rather than written to a temp file — is **impossible to keep** through
-  `git tag -s`, which handles `key::` literals itself. Tags would silently accept
-  what commits refuse.
+  refused rather than written to a temp file — is **not kept** by `git tag -s`,
+  which handles `key::` literals itself. Tags would silently accept what commits
+  refuse.
 - **It would split the annotated path in two.** Signed and unsigned annotated
   tags would then differ in tagger resolution (`default_signature` vs git's own
   config read), in force semantics, and in what happens on a name collision.
@@ -71,6 +71,31 @@ Why not `git tag -s`:
   `append_signature`, `has_signature_block`, `validate_tag_name` and
   `parse_verify_tag` are all `#[cfg(test)]`-able with no keyring. Route (b) is
   one opaque subprocess.
+
+**Rejected alternative — route (c), a hybrid, which the issue's binary framing
+did not name.** Resolve the config *here* (`resolve_signing` + `resolve_key_file`,
+refusing `key::` and bare `ssh-…` exactly as commits do) and only then delegate
+the write:
+
+```
+git tag -s -u <resolved-key> -F - --cleanup=verbatim -- <name> <commit>
+```
+
+with the message on stdin. That preserves the whole justification above — the SSH
+restriction still holds, because we refuse before git is ever invoked — while
+removing both the hand-rolled object and the dangling one. It is a genuine
+option, and it means route (a) is chosen for **testability and payload purity**,
+not out of necessity:
+
+- the signed bytes are the ones libgit2 itself produced, so there is no second
+  serializer whose output could drift from the unsigned path's;
+- the failure modes stay ours (`AppError` from `run_signer`) instead of arriving
+  as `git tag`'s stderr needing classification;
+- the whole thing is exercisable with a stubbed signer, because we own the
+  invocation.
+
+Route (a) is what shipped; this is recorded so the next reader is not left with a
+false dichotomy.
 
 Route (a) costs one orphan object per signed tag: the unsigned annotation from
 step 1 is never referenced. It is unreachable and collected by `git gc` like any
@@ -87,6 +112,14 @@ falling back to an unsigned tag leaves the user believing they signed it. The
 ordering above is what enforces it — the ref is written **after** the signature
 exists, so every failure mode (no key, X509, missing program, non-zero exit,
 empty signature) returns an error with `refs/tags/<name>` absent.
+
+A **name collision is checked before the signer runs**, not only by the final
+`repo.reference(…, force = false)`. With `tag.gpgsign` on and a
+passphrase-protected key, re-creating an existing `v1.0.0` would otherwise raise
+pinentry, take the user's passphrase, and only then fail with "tag already
+exists" — having written two objects for nothing. The early check is an
+optimisation of the common case, not a replacement: the atomic `force = false`
+write stays, so a ref created between the two still fails.
 
 ### C. Signing implies annotated
 
@@ -181,10 +214,36 @@ git's own two shapes:
   compromising verdict wins if several appear. This mirrors git's own
   `sigcheck_gpg_status` table in `gpg-interface.c`.
 - **SSH.** `Good "git" signature for <principal> with <type> key <fp>` → `Good`
-  with signer + key; `Good "git" signature with <type> key <fp>` → also `Good`
-  (git grades it `U`, and `parse_verify_output` already maps `U` → `Good`, with
-  the nuance living in the signer line); a line naming revocation → `Revoked`;
-  `Could not verify signature.` / `Signature verification failed` → `Bad`.
+  with signer + key. `Good "git" signature with <type> key <fp>` → **`UnknownKey`**
+  (see below). `Could not verify signature.` / `Signature verification failed` →
+  `Bad`.
+
+There is deliberately **no SSH `Revoked` branch**. Measured against git 2.50.1 +
+OpenSSH 10.2, a key revoked through `gpg.ssh.revocationFile` produces exactly
+`Could not verify signature.` and exit 1 — ssh-keygen keeps the reason behind
+`debug3_fr`, so neither a `Good` line nor the word "revoked" ever reaches us. A
+`revoked`-substring branch would look prudent and be dead code. GPG revocation is
+still reported, from `REVKEYSIG`.
+
+**"No false Good" is a property of the parser, not of ssh-keygen's output
+order.** A `Good` line is refuted by a non-zero exit *plus* a
+`Could not verify signature` line, so a signer that printed its verdict before
+its checks cannot produce a green badge for a signature git rejected. The
+legitimate untrusted-key case never carries that line — an unmatched principal
+says `No principal matched.`, a missing allowed-signers file says
+`Unable to open allowed keys file …` — so the guard cannot misfire on it.
+
+**A key outside `allowedSignersFile` is `UnknownKey`, not `Good`.** The common
+SSH setup configures no allowed-signers file at all, which yields
+`Good "git" signature with ED25519 key SHA256:…` and exit 1: the signature is
+real, but nothing vouches for *whose* key made it. Rendering that as a green
+"Signed" on a release tag is precisely the claim this feature exists to make
+trustworthy, and the two shapes are distinguishable (`signature for ` names a
+principal, `signature with ` names only a fingerprint), so this is information we
+have rather than a guess. **The COMMIT path still reports it as `Good`**, because
+`parse_verify_output` maps git's `U` that way — a real gap, inherited rather than
+introduced, deliberately left for its own change rather than widened into this
+one.
 
 Unrecognized output falls back to `Good` when git exited 0 (it only does that for
 `G` and `U`) and to **`UnknownKey`** when it did not. `UnknownKey` renders as
@@ -192,6 +251,10 @@ Unrecognized output falls back to `Good` when git exited 0 (it only does that fo
 which would cry wolf, or `None`, which would show a real signature as absent.
 `SigState::None` is reserved for "there is no signature", which step 2 already
 decided.
+
+`ERRSIG` carries **no signer**: its tail is gpg's positional fields
+(`<pkalgo> <hashalgo> <sigclass> <time> <rc> <fpr>`), not a user id, and the badge
+joins the signer into its tooltip.
 
 ### F. `TagInfo.signed` is cheap; the verdict is lazy
 
@@ -234,10 +297,21 @@ existing `Git`, `InvalidArgument`, `InvalidRef`, `NotImplemented` or `Io`, so
   normalizes the trailing newline and appends exactly once;
   `has_signature_block` recognizes all four armor headers and rejects a message
   that merely mentions one mid-line; `validate_tag_name` refuses empty, leading
-  `-`, whitespace, control characters and `..`; `parse_verify_tag` maps every GPG
-  status token and both SSH "Good" shapes, plus the tamper and no-signature
-  cases — the SSH strings are **recorded from a real `git verify-tag --raw`**,
-  the GPG ones written against gpg's documented status protocol.
+  `-`, leading `.`, whitespace, control characters and `..`; `parse_verify_tag`
+  maps every GPG status token and both SSH "Good" shapes, plus the tamper,
+  refuted-Good and no-signature cases — the SSH strings are **recorded from a
+  real `git verify-tag --raw`**.
+- **Rust, GPG pipeline** (`tests/tag_signing_gpg.rs`). Hand-written status
+  fixtures under-constrain — that is how `ERRSIG`'s positional tail came to be
+  rendered as a signer name — so the OpenPGP side gets two layers. First, a
+  **stubbed `gpg.program`** (needs only `/bin/sh`, so it always runs): everything
+  but the cryptography is real — our `create_signed_tag` with the real OpenPGP
+  argv, a real tag object, a real `git verify-tag --raw`, the real parser. This
+  is what establishes the two facts the parser rests on and no unit test can:
+  git relays gpg's status lines **with** the `[GNUPG:] ` prefix, and on
+  **stderr**. Second, a **real-gpg** test against an ephemeral `GNUPGHOME` in a
+  temp dir (never the user's keyring), skipped with a printed note when gpg is
+  absent, covering `Good` end to end plus a tampered payload reading `Bad`.
 - **Rust, integration** (`tests/tag_signing.rs`): follows `tests/signing.rs`'s
   `ssh_signing_repo()` pattern — generate an ed25519 key with `ssh-keygen`, skip
   the test with a printed note when `ssh-keygen` is unavailable. Asserts a signed
@@ -260,8 +334,14 @@ existing `Git`, `InvalidArgument`, `InvalidRef`, `NotImplemented` or `Io`, so
 
 ## Out of scope
 
-Signing on the *push* path, tag verification in the History graph's ref labels, a
-`signTags` preference, X.509 (`SigFormat::X509` stays a clean `NotImplemented`,
+Bringing the COMMIT badge in line with §E's untrusted-key rule — `verify_commit`
+still grades git's `U` as `Good`, so a commit signed by a key outside
+`allowedSignersFile` shows a green "Signed". Same gap, one layer down, and
+changing `parse_verify_output` touches every commit badge; it gets its own issue
+rather than riding along here.
+
+Also out: signing on the *push* path, tag verification in the History graph's ref
+labels, a `signTags` preference, X.509 (`SigFormat::X509` stays a clean `NotImplemented`,
 as for commits), SSH `key::…` literals (still refused rather than written to
 disk), `gpg.ssh.allowedSignersFile` management, and re-signing or amending an
 existing tag.

--- a/docs/superpowers/specs/2026-08-16-tag-signing-spec.md
+++ b/docs/superpowers/specs/2026-08-16-tag-signing-spec.md
@@ -1,0 +1,267 @@
+# Tag signing: GPG/SSH signed annotated tags + a verified badge
+
+**Issue:** [#132](https://github.com/jonassaa/platypusgit/issues/132)
+
+## Problem
+
+Commit signing shipped in 0.0.8 (#61 D6) and stopped at commits. `git/signing.rs`
+resolves `gpg.format` → program → `user.signingkey`, `libgit2.rs::commit_signed`
+builds the buffer, spawns the signer, writes the object and moves the ref, and
+`verify_commit` + `SignatureStatus` back the badge in `CommitDiffPanel`.
+
+Tags got none of it:
+
+- `create_tag` is `repo.tag(name, obj, sig, msg, false)` for an annotated tag and
+  `tag_lightweight` otherwise. `tag.gpgsign` is never read; `CommitOptions.sign`
+  has no tag counterpart.
+- The three create-tag entry points (`design/context-menu.tsx:417`,
+  `screens/History.tsx:1196`, `features/palette/commands.ts:523`) are
+  single-value `pgPrompt`s. Two of them cannot even produce an annotated tag —
+  they hardcode `annotation: null`.
+- `TagInfo` is `{ name, shortOid, oid }`. Nothing can verify a tag, so the
+  Branches screen's tag rows have nothing to badge.
+
+A repository that signs every commit therefore publishes unsigned tags, and
+releases are exactly what people verify.
+
+## Design
+
+### A. How a signed tag gets written (the decision the issue defers)
+
+Two routes were on the table. **We hand-roll the object.** `git tag -s` is
+rejected.
+
+`git2` has `commit_signed` but no `tag_signed`, so route (a) means building the
+annotated-tag body, signing it, appending the armored signature and writing the
+result to the ODB — which is what git itself does in `builtin/tag.c::do_sign`.
+The hand-rolling is smaller than it sounds, because we do **not** re-derive git's
+object serialization:
+
+1. `repo.tag_annotation_create(name, target, tagger, message)` writes the
+   canonical **unsigned** tag object and returns its oid. It creates no ref — the
+   same shape as `commit_signed`, and the same trap.
+2. `odb.read(oid)` gives that object's raw bytes back. Those bytes *are* the
+   payload git signs: `object`/`type`/`tag`/`tagger` headers, a blank line, the
+   message. No hand-written tagger formatting, no timezone arithmetic, no risk of
+   producing a body that differs by a byte from the one libgit2 would have
+   written.
+3. `sign_payload` runs it through the existing `resolve_signing` →
+   `resolve_key_file` → `signing_args` → `run_signer` chain — literally the same
+   four calls `commit_signed` makes, extracted so there is one implementation.
+4. `append_signature` glues the armored signature onto the body (after
+   normalizing the message to end in exactly one `\n`, which git also does — a
+   body whose last line is not terminated would run the armor header onto it and
+   produce a tag nothing can verify).
+5. `odb.write(ObjectType::Tag, bytes)` → `repo.reference("refs/tags/<name>", …)`.
+
+Why not `git tag -s`:
+
+- **It would bypass `signing.rs` entirely.** `git tag -s` does its own
+  `gpg.format` / `user.signingkey` resolution, so `SigningConfig`,
+  `signing_args`, `run_signer` and the SSH key-path restriction would all be
+  unused on the tag path. The issue asks to reuse `signing.rs` wholesale, and the
+  SSH restriction — `user.signingkey` must be a key *path*, `key::…` literals are
+  refused rather than written to a temp file — is **impossible to keep** through
+  `git tag -s`, which handles `key::` literals itself. Tags would silently accept
+  what commits refuse.
+- **It would split the annotated path in two.** Signed and unsigned annotated
+  tags would then differ in tagger resolution (`default_signature` vs git's own
+  config read), in force semantics, and in what happens on a name collision.
+- **Testability.** Route (a) leaves the interesting parts pure:
+  `append_signature`, `has_signature_block`, `validate_tag_name` and
+  `parse_verify_tag` are all `#[cfg(test)]`-able with no keyring. Route (b) is
+  one opaque subprocess.
+
+Route (a) costs one orphan object per signed tag: the unsigned annotation from
+step 1 is never referenced. It is unreachable and collected by `git gc` like any
+other loose object, and — the point — **it never gets a ref**, so a signing
+failure at step 3 leaves no tag behind. git writes one object instead of two;
+that is the whole difference.
+
+`create_tag`'s unsigned paths are untouched, byte for byte.
+
+### B. A signing failure creates no tag
+
+Non-negotiable, and the same reasoning `commit_signed`'s doc comment gives:
+falling back to an unsigned tag leaves the user believing they signed it. The
+ordering above is what enforces it — the ref is written **after** the signature
+exists, so every failure mode (no key, X509, missing program, non-zero exit,
+empty signature) returns an error with `refs/tags/<name>` absent.
+
+### C. Signing implies annotated
+
+A lightweight tag is a ref pointing at the commit. There is no object to sign, so
+signing one is not a thing that can be done, only a thing that can be silently
+not done.
+
+| `annotation` | `sign` | Result |
+| --- | --- | --- |
+| `Some(msg)` | `Some(true)` | signed annotated tag |
+| `Some(msg)` | `Some(false)` | annotated tag, unsigned |
+| `Some(msg)` | `None` | follows `tag.gpgsign` |
+| `None` | `Some(true)` | **`InvalidArgument`** — refused, never quietly dropped |
+| `None` | `None` / `Some(false)` | lightweight tag, unsigned |
+
+The last row deliberately diverges from `git tag`. Real git treats
+`tag.gpgsign=true` as implying `-s`, which implies `-a`, so `git tag v1` in such
+a repository fails outright with `fatal: no tag message?` (verified against git
+2.50.1). Our create-tag dialog has an explicit annotation field whose blankness
+*means* lightweight, so we neither promote the tag to annotated behind the user's
+back nor make lightweight tags unreachable in a signing repository. The dialog
+disables and explains the sign toggle while the annotation is blank, so the
+refused combination is not reachable from the UI at all — the backend check is
+there for the IPC boundary, not for the button.
+
+### D. `TagTarget.sign` and the create-tag dialog
+
+`TagTarget` gains `sign: Option<bool>`, `#[serde(default)]`, with exactly
+`CommitOptions.sign`'s semantics: `None` follows git config (`tag.gpgsign` here),
+`Some` overrides it for this tag. `signing.rs` gains `config_wants_tag_signing`
+beside `config_wants_signing`; both delegate to one `config_flag` helper so the
+two keys cannot drift.
+
+Three values (name + annotation + sign) do not fit a `pgPrompt`, so the three
+call sites collapse onto one dialog:
+
+- `features/tags/useCreateTagStore.ts` — `openCreateTag(target) => Promise<void>`,
+  holding `{ open, oid, shortOid }` plus the resolve closure. Store-driven and
+  promise-shaped for the same reason `useAuthStore` is: two of the three call
+  sites (a context-menu item builder and a palette step) are not React components
+  and cannot render a modal themselves.
+- `features/tags/CreateTagDialog.tsx` — `PGModal` mounted once in `AppShell`,
+  beside `CredentialDialog` / `CloneDialog`. Name (mono, required), annotation
+  (textarea, blank = lightweight), and the **same three-state sign checkbox
+  CommitPanel uses**: checked / unchecked / indeterminate, where indeterminate is
+  "follow `tag.gpgsign`", which the frontend cannot read. Showing it as plain
+  unchecked would claim the tag is unsigned in a repository that has tag signing
+  on.
+- Escape closes it through the keymap's `app.closeOverlay`, not a local listener,
+  inserted in the same precedence chain as the clone/init dialogs.
+
+No new setting. `signCommits` has a `"config" | "always" | "never"` preference
+because the commit box is used many times a day; a tag is created rarely and
+deliberately, so the dialog starts indeterminate every time and the repository's
+own `tag.gpgsign` remains the default. A `signTags` preference can be added later
+without changing anything here.
+
+### E. Verifying a tag: `%G?` is commit-only
+
+`verify_commit` asks `git show --format=%G?%x00%GS%x00%GK`. That does **not**
+work for tags: `%G?` is a commit placeholder, and `git show <tag>` would report
+the *commit's* signature, not the tag's. `git for-each-ref
+--format='%(signature:grade)'` does not fill the gap either — verified
+empirically against git 2.50.1, the atom yields the grade for a branch ref and an
+empty string for a tag ref, because ref-filter only computes signatures for
+commits.
+
+So `verify_tag(repo_id, name)`:
+
+1. **Validate the name before it reaches an argv** (`validate_tag_name`) — same
+   class as `verify_commit`'s hex check and the D5 review's `git show` finding. A
+   value beginning with `-` would be read as an option. The argv also ends option
+   parsing with `--`.
+2. **Answer the common case without a subprocess.** Peel `refs/tags/<name>`; a
+   lightweight tag, or an annotated tag whose message carries none of git's four
+   armor headers (`-----BEGIN PGP SIGNATURE-----`, `PGP MESSAGE`,
+   `SIGNED MESSAGE`, `SSH SIGNATURE`), is `SigState::None`. Most tags in most
+   repositories are unsigned, and this is the read that keeps the badge from
+   spawning a process for each of them.
+3. Otherwise `git -C <path> verify-tag --raw -- <name>`, stdout and stderr
+   concatenated (git writes the verdict to stderr), through the pure
+   `parse_verify_tag(raw, exit_ok)`.
+
+`parse_verify_tag` returns the **existing** `SignatureStatus`, but it cannot
+reuse `parse_verify_output` — that one parses git's already-digested
+`%G?%x00%GS%x00%GK` triple, and `--raw` is the undigested signer output. It maps
+git's own two shapes:
+
+- **GPG status lines.** `BADSIG` → `Bad`, `REVKEYSIG` → `Revoked`,
+  `EXPKEYSIG`/`EXPSIG` → `Expired`, `ERRSIG` → `UnknownKey`, `GOODSIG` → `Good`,
+  taking `<keyid> <username>` off the matched line. Checked in that order so a
+  compromising verdict wins if several appear. This mirrors git's own
+  `sigcheck_gpg_status` table in `gpg-interface.c`.
+- **SSH.** `Good "git" signature for <principal> with <type> key <fp>` → `Good`
+  with signer + key; `Good "git" signature with <type> key <fp>` → also `Good`
+  (git grades it `U`, and `parse_verify_output` already maps `U` → `Good`, with
+  the nuance living in the signer line); a line naming revocation → `Revoked`;
+  `Could not verify signature.` / `Signature verification failed` → `Bad`.
+
+Unrecognized output falls back to `Good` when git exited 0 (it only does that for
+`G` and `U`) and to **`UnknownKey`** when it did not. `UnknownKey` renders as
+"Signed, key unavailable" — honest about not having checked — rather than `Bad`,
+which would cry wolf, or `None`, which would show a real signature as absent.
+`SigState::None` is reserved for "there is no signature", which step 2 already
+decided.
+
+### F. `TagInfo.signed` is cheap; the verdict is lazy
+
+`TagInfo` gains `signed: bool`, read from the tag object's own message during the
+existing `tag_foreach` walk. It costs no subprocess and no extra I/O, so
+`list_tags` stays what it was.
+
+The **verdict** is fetched lazily, exactly like commit verification, and for the
+same stated reason: `SignatureBadge`'s doc comment refuses "a badge on every log
+row" because it means one gpg/ssh-keygen process per row. The Branches screen
+renders every tag at once, so an eager verdict would be N processes on screen
+entry and N more on every refresh.
+
+Where that lands in the UI:
+
+- **Tag rows** show a lock glyph next to the tag glyph when `signed`. It states a
+  fact read from the object ("this tag carries a signature") and claims no
+  verdict, which is the only thing free information can honestly say.
+- **`TagInspector`** — the selected tag, one at a time — renders
+  `TagSignatureBadge`, which calls `verify_tag` behind the same 100 ms debounce
+  `SignatureBadge` uses and shows the real Good/Bad/Expired/Revoked/UnknownKey
+  verdict.
+
+`SignatureBadge`'s `LOOK` table and markup are extracted into
+`SignatureBadgeView` so the commit badge and the tag badge cannot drift into two
+vocabularies for one set of states.
+
+### G. What does not change
+
+`push_tag` already ends option parsing with `--` and goes through the
+credentialed runner; a signed tag is an ordinary tag object to it. `delete_tag`,
+`checkout_ref`, the tag context menu and the palette's delete/push commands are
+untouched. No new `AppError` variant is needed — every failure here is an
+existing `Git`, `InvalidArgument`, `InvalidRef`, `NotImplemented` or `Io`, so
+`src/lib/errors.ts` stays as it is.
+
+## Testing
+
+- **Rust, pure** (`git/tag.rs` unit tests, no keyring): `append_signature`
+  normalizes the trailing newline and appends exactly once;
+  `has_signature_block` recognizes all four armor headers and rejects a message
+  that merely mentions one mid-line; `validate_tag_name` refuses empty, leading
+  `-`, whitespace, control characters and `..`; `parse_verify_tag` maps every GPG
+  status token and both SSH "Good" shapes, plus the tamper and no-signature
+  cases — the SSH strings are **recorded from a real `git verify-tag --raw`**,
+  the GPG ones written against gpg's documented status protocol.
+- **Rust, integration** (`tests/tag_signing.rs`): follows `tests/signing.rs`'s
+  `ssh_signing_repo()` pattern — generate an ed25519 key with `ssh-keygen`, skip
+  the test with a printed note when `ssh-keygen` is unavailable. Asserts a signed
+  tag is a **tag object reachable through `refs/tags/<name>`** whose body carries
+  an SSH signature block; that `git tag -v` accepts it (the interop assertion —
+  our hand-rolled object has to satisfy git, not just us); that `verify_tag`
+  grades it `Good`; that a signing failure (nonexistent program) leaves **no
+  ref**; that `sign: Some(true)` with no annotation is `InvalidArgument`; that
+  `tag.gpgsign` is the default and a per-tag `Some(false)` overrides it; that
+  `TagInfo.signed` is true for a signed tag and false for annotated-unsigned and
+  lightweight ones.
+- **Frontend, component:** `CreateTagDialog.test.tsx` — a lightweight tag sends
+  `annotation: null`; an annotation enables the sign toggle and the three states
+  send `null` / `true` / `false`; blanking the annotation disables the toggle and
+  forces the payload back to unsigned. `TagSignatureBadge` reuses
+  `SignatureBadge.test.tsx`'s shape against `verify_tag`.
+- **E2E:** none. No existing spec drives tag creation, and the changed surfaces
+  (a modal replacing a prompt, a badge in an inspector) are covered at the
+  component layer.
+
+## Out of scope
+
+Signing on the *push* path, tag verification in the History graph's ref labels, a
+`signTags` preference, X.509 (`SigFormat::X509` stays a clean `NotImplemented`,
+as for commits), SSH `key::…` literals (still refused rather than written to
+disk), `gpg.ssh.allowedSignersFile` management, and re-signing or amending an
+existing tag.

--- a/site/src/data/features.ts
+++ b/site/src/data/features.ts
@@ -40,6 +40,7 @@ export const featureGroups = [
     'List / create / checkout / rename / delete branches',
     'Merge or rebase onto any branch — local or remote — straight from the branch picker, the titlebar chip or the Branches screen',
     'Lightweight and annotated tags',
+    'GPG/SSH signed tags — defaults from `tag.gpgsign`, overridable per tag, with a verification badge on the tag you select',
     'Push and delete tags',
   ]},
   { title: 'History', blurb: 'Navigate the past.', items: [
@@ -113,7 +114,6 @@ export const featureGroups = [
 // Roadmap teaser (from features.md P0/P1 — clearly "planned")
 export const roadmap = [
   'Branch compare — branch↔branch and branch↔working tree',
-  'GPG/SSH tag signing (commit signing shipped in 0.0.8)',
   'Partial/hunk-level stash + rename + compare to working tree',
   'Signed & notarized macOS / Windows builds',
 ];

--- a/src-tauri/src/commands/branches.rs
+++ b/src-tauri/src/commands/branches.rs
@@ -394,6 +394,21 @@ pub async fn delete_tag(
         .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
+/// Signature status of one tag (#132). Called lazily, for the selected tag —
+/// see the `verify_tag` doc comment on `GitBackend`.
+#[tauri::command]
+pub async fn verify_tag(
+    state: State<'_, AppState>,
+    repo_id: String,
+    name: String,
+) -> AppResult<crate::git::signing::SignatureStatus> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    tokio::task::spawn_blocking(move || backend.verify_tag(&repo_id, &name))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
 // Higher-level operations implemented via the `git` CLI (same strategy as
 // fetch/pull/push). libgit2's native merge/rebase implementations don't
 // cover all the edge cases (recursive/ort strategies, hook integration),

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -275,6 +275,13 @@ impl GitBackend for CliBackend {
     fn delete_tag(&self, _repo_id: &RepoId, _name: &str) -> AppResult<()> {
         Err(AppError::NotImplemented)
     }
+    fn verify_tag(
+        &self,
+        _repo_id: &RepoId,
+        _name: &str,
+    ) -> AppResult<crate::git::signing::SignatureStatus> {
+        Err(AppError::NotImplemented)
+    }
     fn checkout_detached(&self, _repo_id: &RepoId, _oid: &str) -> AppResult<()> {
         Err(AppError::NotImplemented)
     }

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -1060,8 +1060,6 @@ fn commit_signed(
     head: Option<&git2::Reference<'_>>,
     amend: bool,
 ) -> AppResult<String> {
-    use crate::git::signing::{resolve_signing, signing_args, SigFormat};
-
     // Parents: an amend replaces HEAD, so it inherits HEAD's parents rather than
     // chaining onto it.
     let tip = match head {
@@ -1080,28 +1078,7 @@ fn commit_signed(
     let buffer_str = std::str::from_utf8(&buffer)
         .map_err(|e| AppError::Internal(format!("commit buffer is not utf-8: {e}")))?;
 
-    let cfg = resolve_signing(repo)?;
-    let key_file = match cfg.format {
-        SigFormat::Ssh => {
-            let key = cfg.key.as_deref().ok_or_else(|| {
-                AppError::InvalidArgument("ssh signing needs user.signingkey".to_string())
-            })?;
-            // Only a key PATH is supported. git also accepts a literal key
-            // (`key::ssh-ed25519 …`), which would have to be written to a temp
-            // file first; rejecting it clearly beats writing key material to
-            // disk behind the user's back.
-            if key.starts_with("key::") || key.starts_with("ssh-") {
-                return Err(AppError::InvalidArgument(
-                    "user.signingkey must be a path to a key file for ssh signing".to_string(),
-                ));
-            }
-            Some(std::path::PathBuf::from(key))
-        }
-        _ => None,
-    };
-    let args = signing_args(&cfg, key_file.as_deref())?;
-
-    let signature = run_signer(&cfg.program, &args, buffer_str)?;
+    let signature = sign_payload(repo, buffer_str)?;
     let oid = repo.commit_signed(buffer_str, &signature, Some("gpgsig"))?;
 
     // Move the branch ourselves — commit_signed did not.
@@ -1125,6 +1102,22 @@ fn commit_signed(
     repo.reference(&ref_name, oid, true, &reflog_msg)?;
 
     Ok(oid.to_string())
+}
+
+/// Resolve the signing config and produce a detached signature over `payload`.
+///
+/// The whole chain in one place — `resolve_signing` → `resolve_key_file` →
+/// `signing_args` → `run_signer` — because a commit buffer and an annotated-tag
+/// body are the same kind of thing to a signer, and a second copy of these four
+/// lines is how the ssh key-path restriction would come to hold for commits and
+/// lapse for tags (#132).
+fn sign_payload(repo: &Repository, payload: &str) -> AppResult<String> {
+    use crate::git::signing::{resolve_key_file, resolve_signing, signing_args};
+
+    let cfg = resolve_signing(repo)?;
+    let key_file = resolve_key_file(&cfg)?;
+    let args = signing_args(&cfg, key_file.as_deref())?;
+    run_signer(&cfg.program, &args, payload)
 }
 
 /// Run the signing program over `payload`, returning its signature.

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -1129,6 +1129,15 @@ fn create_signed_tag(
     tagger: &git2::Signature<'_>,
     message: &str,
 ) -> AppResult<()> {
+    // Refuse a name collision BEFORE running the signer. The final
+    // `repo.reference(…, force = false)` would catch it too, but only after
+    // pinentry had taken the user's GPG passphrase for a tag that then fails
+    // with "tag already exists" — and after two objects had been written.
+    let refname = format!("refs/tags/{name}");
+    if repo.find_reference(&refname).is_ok() {
+        return Err(AppError::Git(format!("tag '{name}' already exists")));
+    }
+
     // Normalize BEFORE the object is created: the signature is made over the
     // object's bytes, so normalizing afterwards would sign one body and store
     // another.
@@ -1144,12 +1153,13 @@ fn create_signed_tag(
     let signed = crate::git::tag::append_signature(&body, &signature);
     let oid = odb.write(git2::ObjectType::Tag, &signed)?;
 
-    // Force is false: a name collision must fail here exactly as it does on the
-    // unsigned path (`repo.tag(…, false)`).
+    // Force is still false: the check above is an early-out for the common case,
+    // not a substitute for the atomic one. A ref created between the two must
+    // fail here, exactly as it does on the unsigned path (`repo.tag(…, false)`).
     //
     // Empty reflog message because `git tag` writes none — core.logAllRefUpdates
     // does not cover refs/tags.
-    repo.reference(&format!("refs/tags/{name}"), oid, false, "")?;
+    repo.reference(&refname, oid, false, "")?;
     Ok(())
 }
 
@@ -3888,6 +3898,10 @@ impl GitBackend for Libgit2Backend {
                 }
                 Some(msg) => {
                     let sig = crate::git::signature::default_signature(repo)?;
+                    // Same normalization the signed path applies, so one dialog
+                    // input does not produce two different objects depending on
+                    // whether it was signed. `git tag` completes the line too.
+                    let msg = crate::git::tag::normalize_message(&msg);
                     repo.tag(name, &obj, &sig, &msg, false)?;
                 }
                 None => {

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -1104,6 +1104,55 @@ fn commit_signed(
     Ok(oid.to_string())
 }
 
+/// Create a signed annotated tag and point `refs/tags/<name>` at it (#132).
+///
+/// `git2` has no `tag_signed` counterpart to `commit_signed`, so this is what
+/// git itself does in `builtin/tag.c`: build the tag body, sign it, append the
+/// armored signature, write the object. What it does **not** do is re-derive
+/// git's object serialization — `tag_annotation_create` writes the canonical
+/// unsigned object and `odb.read` hands its bytes back, so the payload is
+/// byte-for-byte what libgit2 would have stored, with no hand-written tagger
+/// formatting or timezone arithmetic.
+///
+/// **Same trap as `commit_signed`:** neither `tag_annotation_create` nor
+/// `odb.write` moves a reference. The ref is written last, on purpose — a
+/// signing failure then leaves no tag at all, rather than an unsigned one the
+/// user believes is signed.
+///
+/// Cost: the unsigned annotation from step one is left unreferenced in the ODB
+/// and collected by `git gc` like any other loose object. git writes one object
+/// where we write two; that is the whole difference.
+fn create_signed_tag(
+    repo: &Repository,
+    name: &str,
+    target: &git2::Object<'_>,
+    tagger: &git2::Signature<'_>,
+    message: &str,
+) -> AppResult<()> {
+    // Normalize BEFORE the object is created: the signature is made over the
+    // object's bytes, so normalizing afterwards would sign one body and store
+    // another.
+    let message = crate::git::tag::normalize_message(message);
+
+    let unsigned = repo.tag_annotation_create(name, target, tagger, &message)?;
+    let odb = repo.odb()?;
+    let body = odb.read(unsigned)?.data().to_vec();
+    let payload = std::str::from_utf8(&body)
+        .map_err(|e| AppError::Internal(format!("tag buffer is not utf-8: {e}")))?;
+
+    let signature = sign_payload(repo, payload)?;
+    let signed = crate::git::tag::append_signature(&body, &signature);
+    let oid = odb.write(git2::ObjectType::Tag, &signed)?;
+
+    // Force is false: a name collision must fail here exactly as it does on the
+    // unsigned path (`repo.tag(…, false)`).
+    //
+    // Empty reflog message because `git tag` writes none — core.logAllRefUpdates
+    // does not cover refs/tags.
+    repo.reference(&format!("refs/tags/{name}"), oid, false, "")?;
+    Ok(())
+}
+
 /// Resolve the signing config and produce a detached signature over `payload`.
 ///
 /// The whole chain in one place — `resolve_signing` → `resolve_key_file` →
@@ -3654,10 +3703,19 @@ impl GitBackend for Libgit2Backend {
                     .and_then(|o| o.peel(git2::ObjectType::Commit).ok())
                     .map(|c| c.id())
                     .unwrap_or(oid);
+                // Free: a lightweight tag has no tag object, and an annotated
+                // one already had to be read to peel it. No subprocess — the
+                // VERDICT costs one, which is why verify_tag is separate (#132).
+                let signed = repo
+                    .find_tag(oid)
+                    .ok()
+                    .and_then(|t| t.message().map(crate::git::tag::has_signature_block))
+                    .unwrap_or(false);
                 out.push(TagInfo {
                     name,
                     short_oid: tip_oid.to_string()[..7].to_string(),
                     oid: tip_oid.to_string(),
+                    signed,
                 });
                 true
             })?;
@@ -3814,15 +3872,41 @@ impl GitBackend for Libgit2Backend {
     }
     fn create_tag(&self, repo_id: &RepoId, name: &str, target: TagTarget) -> AppResult<()> {
         self.with_repo(repo_id, |repo| {
+            crate::git::tag::validate_tag_name(name)?;
             let obj = repo
                 .revparse_single(&target.oid)
                 .map_err(|_| AppError::InvalidRef(target.oid.clone()))?;
+            // `None` follows tag.gpgsign; `Some` overrides it (#132) — the same
+            // contract commit signing has with commit.gpgsign.
+            let want_sign = target
+                .sign
+                .unwrap_or_else(|| crate::git::signing::config_wants_tag_signing(repo));
             match target.annotation {
+                Some(msg) if want_sign => {
+                    let sig = crate::git::signature::default_signature(repo)?;
+                    create_signed_tag(repo, name, &obj, &sig, &msg)?;
+                }
                 Some(msg) => {
                     let sig = crate::git::signature::default_signature(repo)?;
                     repo.tag(name, &obj, &sig, &msg, false)?;
                 }
                 None => {
+                    // Signing implies annotated: a lightweight tag is a ref, and
+                    // there is no object to carry a signature. An explicit
+                    // request is refused rather than silently not honoured.
+                    //
+                    // A bare tag.gpgsign, though, does NOT promote the tag to
+                    // annotated — real `git tag` fails outright here ("fatal: no
+                    // tag message?"), which would make lightweight tags
+                    // unreachable in a signing repository. Our create-tag dialog
+                    // has an explicit annotation field whose blankness *means*
+                    // lightweight, so it wins.
+                    if target.sign == Some(true) {
+                        return Err(AppError::InvalidArgument(
+                            "signing a tag requires an annotation — a lightweight tag has no object to sign"
+                                .to_string(),
+                        ));
+                    }
                     repo.tag_lightweight(name, &obj, false)?;
                 }
             }
@@ -4346,6 +4430,71 @@ impl GitBackend for Libgit2Backend {
         Ok(crate::git::signing::parse_verify_output(
             &String::from_utf8_lossy(&out.stdout),
         ))
+    }
+
+    fn verify_tag(
+        &self,
+        repo_id: &RepoId,
+        name: &str,
+    ) -> AppResult<crate::git::signing::SignatureStatus> {
+        use crate::git::signing::{SigState, SignatureStatus};
+
+        // Before it reaches an argv: `git verify-tag` would read a value
+        // starting with '-' as an option, and this name comes from a text field.
+        crate::git::tag::validate_tag_name(name)?;
+
+        let unsigned = SignatureStatus {
+            state: SigState::None,
+            signer: None,
+            key: None,
+        };
+
+        // The common case costs no subprocess. Most tags in most repositories
+        // are unsigned or lightweight, and the Branches screen renders all of
+        // them; spawning a signer per row is exactly what SignatureBadge's doc
+        // comment refuses for commits.
+        let signed = self.with_repo(repo_id, |repo| {
+            let reference = repo
+                .find_reference(&format!("refs/tags/{name}"))
+                .map_err(|_| AppError::InvalidRef(name.to_string()))?;
+            let Some(oid) = reference.target() else {
+                // Symbolic: not a tag object, so nothing signed.
+                return Ok(false);
+            };
+            Ok(repo
+                .find_tag(oid)
+                .ok()
+                .and_then(|t| t.message().map(crate::git::tag::has_signature_block))
+                .unwrap_or(false))
+        })?;
+        if !signed {
+            return Ok(unsigned);
+        }
+
+        let repo_path = self.repo_path(repo_id)?;
+        // Shells out rather than reimplementing trust evaluation — same reason
+        // verify_commit does. `%G?` cannot be used here: it is a COMMIT format
+        // placeholder, so `git show <tag> --format=%G?` reports the commit's
+        // signature, and for-each-ref's %(signature:grade) atom is empty for a
+        // tag object. `git verify-tag --raw` is git's own verdict on the tag.
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&repo_path)
+            .args(["verify-tag", "--raw", "--"])
+            .arg(name)
+            // No tty: verification must never block on a prompt nobody can see.
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .stdin(std::process::Stdio::null())
+            .output()
+            .map_err(|e| AppError::Io(e.to_string()))?;
+
+        // git writes the verdict to stderr, not stdout.
+        let raw = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        Ok(crate::git::tag::parse_verify_tag(&raw, out.status.success()))
     }
 
     fn read_reflog(&self, repo_id: &RepoId) -> AppResult<Vec<ReflogEntry>> {

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -9,6 +9,7 @@ pub mod rebase_state;
 pub mod signature;
 pub mod signing;
 pub mod submodule;
+pub mod tag;
 pub mod types;
 pub mod worktree;
 

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -360,8 +360,24 @@ pub trait GitBackend: Send + Sync {
         branch: &str,
         upstream: Option<&str>,
     ) -> AppResult<()>;
+    /// Create a tag. `target.annotation` picks lightweight vs annotated and
+    /// `target.sign` picks signed vs not, defaulting to `tag.gpgsign` (#132).
+    ///
+    /// A signing failure creates **no tag**: an unsigned fallback would leave
+    /// the user believing they had signed it.
     fn create_tag(&self, repo_id: &RepoId, name: &str, target: TagTarget) -> AppResult<()>;
     fn delete_tag(&self, repo_id: &RepoId, name: &str) -> AppResult<()>;
+    /// Signature status of ONE tag (#132).
+    ///
+    /// Lazy for the same reason `verify_commit` is: a verdict for every tag row
+    /// would be a signer process per row on every refresh. `TagInfo.signed`
+    /// carries the free half — whether a signature is there at all — so the
+    /// listing needs no subprocess.
+    fn verify_tag(
+        &self,
+        repo_id: &RepoId,
+        name: &str,
+    ) -> AppResult<crate::git::signing::SignatureStatus>;
 
     // === history manipulation ===
     fn checkout_detached(&self, repo_id: &RepoId, oid: &str) -> AppResult<()>;

--- a/src-tauri/src/git/signing.rs
+++ b/src-tauri/src/git/signing.rs
@@ -1,8 +1,14 @@
-//! Commit signing: config resolution, program arguments, and verify parsing
-//! (#61 D6).
+//! Object signing: config resolution, program arguments, and verify parsing
+//! (#61 D6, extended to tags by #132).
 //!
 //! Nothing here spawns a process — that is `libgit2.rs`'s job. Keeping the
 //! decisions pure is what makes them testable without a gpg keyring.
+//!
+//! Everything below is **format-agnostic about what is being signed**: a
+//! signature is made over a payload on stdin, and a commit buffer and an
+//! annotated-tag body are both just payloads. That is why the tag path
+//! (`git/tag.rs` + `libgit2.rs::create_signed_tag`) reuses this module whole
+//! rather than growing a second key-resolution chain.
 
 use serde::Serialize;
 
@@ -52,18 +58,59 @@ pub fn resolve_signing(repo: &git2::Repository) -> AppResult<SigningConfig> {
     })
 }
 
-/// Whether `commit.gpgsign` asks for signing. Defaults to false.
-pub fn config_wants_signing(repo: &git2::Repository) -> bool {
+/// Read a boolean git-config flag, defaulting to false when absent or unreadable.
+fn config_flag(repo: &git2::Repository, key: &str) -> bool {
     repo.config()
-        .and_then(|c| c.get_bool("commit.gpgsign"))
+        .and_then(|c| c.get_bool(key))
         .unwrap_or(false)
 }
 
-/// Arguments for signing a commit buffer fed on stdin, signature on stdout.
+/// Whether `commit.gpgsign` asks for signing. Defaults to false.
+pub fn config_wants_signing(repo: &git2::Repository) -> bool {
+    config_flag(repo, "commit.gpgsign")
+}
+
+/// Whether `tag.gpgsign` asks for signing. Defaults to false (#132).
 ///
-/// `key_file` is the resolved private-key path for ssh signing; `user.signingkey`
-/// may instead hold a literal key (`key::ssh-ed25519 …`), which the caller writes
-/// to a temp file first, so the path cannot be derived here.
+/// Deliberately a **separate key** from `commit.gpgsign`, because git treats them
+/// separately: a repository that signs every commit has not thereby asked for
+/// signed tags, and vice versa.
+pub fn config_wants_tag_signing(repo: &git2::Repository) -> bool {
+    config_flag(repo, "tag.gpgsign")
+}
+
+/// The private-key path ssh signing needs, or `None` for formats that do not
+/// take one.
+///
+/// Only a key **path** is supported. git also accepts a literal key
+/// (`key::ssh-ed25519 …`), which would have to be written to a temp file first;
+/// rejecting it clearly beats writing key material to disk behind the user's
+/// back. Shared by the commit and tag paths so the restriction cannot hold on
+/// one and lapse on the other.
+pub fn resolve_key_file(cfg: &SigningConfig) -> AppResult<Option<std::path::PathBuf>> {
+    match cfg.format {
+        SigFormat::Ssh => {
+            let key = cfg.key.as_deref().ok_or_else(|| {
+                AppError::InvalidArgument("ssh signing needs user.signingkey".to_string())
+            })?;
+            if key.starts_with("key::") || key.starts_with("ssh-") {
+                return Err(AppError::InvalidArgument(
+                    "user.signingkey must be a path to a key file for ssh signing".to_string(),
+                ));
+            }
+            Ok(Some(std::path::PathBuf::from(key)))
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Arguments for signing a payload fed on stdin, signature on stdout.
+///
+/// The payload is a commit buffer or an annotated-tag body — the signer neither
+/// knows nor cares which.
+///
+/// `key_file` is the resolved private-key path for ssh signing; see
+/// [`resolve_key_file`].
 pub fn signing_args(cfg: &SigningConfig, key_file: Option<&std::path::Path>) -> AppResult<Vec<String>> {
     match cfg.format {
         SigFormat::OpenPgp => {
@@ -210,6 +257,55 @@ mod tests {
         };
         let err = signing_args(&cfg, None).expect_err("ssh needs a key");
         assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn resolve_key_file_returns_the_path_for_ssh() {
+        let cfg = SigningConfig {
+            format: SigFormat::Ssh,
+            program: "ssh-keygen".into(),
+            key: Some("/home/u/.ssh/id_ed25519".into()),
+        };
+        assert_eq!(
+            resolve_key_file(&cfg).unwrap().unwrap(),
+            std::path::PathBuf::from("/home/u/.ssh/id_ed25519")
+        );
+    }
+
+    #[test]
+    fn resolve_key_file_refuses_a_literal_ssh_key() {
+        // Supporting it would mean writing key material to a temp file behind
+        // the user's back. Both spellings git accepts are refused.
+        for literal in ["key::ssh-ed25519 AAAAC3Nz…", "ssh-ed25519 AAAAC3Nz…"] {
+            let cfg = SigningConfig {
+                format: SigFormat::Ssh,
+                program: "ssh-keygen".into(),
+                key: Some(literal.into()),
+            };
+            let err = resolve_key_file(&cfg).expect_err("literal keys are refused");
+            assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+        }
+    }
+
+    #[test]
+    fn resolve_key_file_needs_a_key_for_ssh_but_not_for_openpgp() {
+        let ssh = SigningConfig {
+            format: SigFormat::Ssh,
+            program: "ssh-keygen".into(),
+            key: None,
+        };
+        assert!(matches!(
+            resolve_key_file(&ssh),
+            Err(AppError::InvalidArgument(_))
+        ));
+
+        // gpg picks its own default key, so no path is needed.
+        let pgp = SigningConfig {
+            format: SigFormat::OpenPgp,
+            program: "gpg".into(),
+            key: None,
+        };
+        assert!(resolve_key_file(&pgp).unwrap().is_none());
     }
 
     #[test]

--- a/src-tauri/src/git/tag.rs
+++ b/src-tauri/src/git/tag.rs
@@ -79,7 +79,14 @@ pub fn validate_tag_name(name: &str) -> AppResult<()> {
     if name.starts_with('/') || name.ends_with('/') || name.contains("//") {
         return bad("a tag name cannot have an empty path component");
     }
-    if name.ends_with('.') || name.ends_with(".lock") || name.contains("/.") {
+    // A leading '.' is refused for the same reason "/." is: `check_refname_component`
+    // rejects a component beginning with a dot, and the leading one is not covered
+    // by the "/." test. `git check-ref-format refs/tags/.hidden` refuses it too.
+    if name.starts_with('.')
+        || name.ends_with('.')
+        || name.ends_with(".lock")
+        || name.contains("/.")
+    {
         return bad("invalid tag name");
     }
     if name.contains("..") || name.contains("@{") {
@@ -122,51 +129,73 @@ const GPG_STATUS: [(&str, SigState); 6] = [
 /// atom yields nothing for a tag object. `--raw` is the undigested signer output,
 /// in one of two shapes depending on `gpg.format`.
 ///
-/// `ok` is the subprocess's exit status. It is only consulted for output we do
+/// `ok` is the subprocess's exit status. It refutes an SSH `Good` line paired
+/// with an explicit failure (see below), and otherwise decides only output we do
 /// not recognize, where an exit of 0 is git's own statement that the signature
 /// graded `G` or `U`.
 pub fn parse_verify_tag(raw: &str, ok: bool) -> SignatureStatus {
     // ── GPG: [GNUPG:] <TOKEN> <keyid> <username> ──────────────────────────────
     for (token, state) in GPG_STATUS {
         if let Some(rest) = gpg_status_line(raw, token) {
-            let (key, signer) = split_key_and_signer(rest);
+            let (key, signer) = split_key_and_signer(rest, token);
             return SignatureStatus { state, signer, key };
         }
     }
 
+    // "No false Good" has to be a property of THIS function, not of the order a
+    // signer happens to print in. OpenSSH 10.2 never prints a `Good` line
+    // alongside a failure — but a build that emitted its verdict before its
+    // checks would otherwise render a green "Signed" for a signature git
+    // rejected. The legitimate untrusted-key case never carries this line: an
+    // unmatched principal says "No principal matched." and a missing
+    // allowed-signers file says "Unable to open allowed keys file …". So a failed
+    // exit PLUS this line overrides any `Good` below.
+    let refuted = !ok && raw.contains("Could not verify signature");
+
     // ── SSH: ssh-keygen's own wording, as git relays it ───────────────────────
-    for line in raw.lines() {
-        let line = line.trim();
-        // Valid signature from a principal in the allowed-signers file.
-        if let Some(rest) = line.strip_prefix("Good \"git\" signature for ") {
-            let (signer, key) = split_ssh_principal(rest);
-            return SignatureStatus {
-                state: SigState::Good,
-                signer,
-                key,
-            };
-        }
-        // Valid signature, but the key is not in the allowed-signers file. git
-        // grades this `U`, which parse_verify_output already reports as Good with
-        // the nuance in the signer line — same call here, so the two badges do
-        // not disagree about one signature.
-        if let Some(rest) = line.strip_prefix("Good \"git\" signature with ") {
-            return SignatureStatus {
-                state: SigState::Good,
-                signer: None,
-                key: ssh_key_fingerprint(rest),
-            };
+    if !refuted {
+        for line in raw.lines() {
+            let line = line.trim();
+            // Valid signature from a principal in the allowed-signers file.
+            if let Some(rest) = line.strip_prefix("Good \"git\" signature for ") {
+                let (signer, key) = split_ssh_principal(rest);
+                return SignatureStatus {
+                    state: SigState::Good,
+                    signer,
+                    key,
+                };
+            }
+            // Valid signature, but the key is in NO allowed-signers file — either
+            // none is configured (the common setup) or the principal did not
+            // match. git grades this `U`.
+            //
+            // Reported as `UnknownKey` ("Signed, key unavailable"), NOT `Good`:
+            // the signature is real but nothing here vouches for whose key made
+            // it, and a tag is what people verify before trusting a release. The
+            // two shapes are distinguishable — `signature for ` names a
+            // principal, `signature with ` names only a fingerprint — so this is
+            // information we have rather than a guess.
+            //
+            // NOTE: the COMMIT path still reports this as Good, because
+            // `parse_verify_output` maps git's `U` that way. That gap is real and
+            // deliberately not widened into this PR — see the spec.
+            if let Some(rest) = line.strip_prefix("Good \"git\" signature with ") {
+                return SignatureStatus {
+                    state: SigState::UnknownKey,
+                    signer: None,
+                    key: ssh_key_fingerprint(rest),
+                };
+            }
         }
     }
 
+    // No SSH `Revoked` branch on purpose. Measured against git 2.50.1 +
+    // OpenSSH 10.2: a key revoked through `gpg.ssh.revocationFile` produces
+    // exactly `Could not verify signature.` and exit 1 — ssh-keygen keeps the
+    // reason behind `debug3_fr`, so neither a `Good` line nor the word "revoked"
+    // ever reaches us. Matching on "revoked" looked safe and was simply dead.
+    // GPG revocation is still reported, from `REVKEYSIG` in the table above.
     let lowered = raw.to_ascii_lowercase();
-    if lowered.contains("revoked") {
-        return SignatureStatus {
-            state: SigState::Revoked,
-            signer: None,
-            key: None,
-        };
-    }
     if lowered.contains("could not verify signature")
         || lowered.contains("signature verification failed")
     {
@@ -193,26 +222,38 @@ pub fn parse_verify_tag(raw: &str, ok: bool) -> SignatureStatus {
 }
 
 /// The remainder of the first `[GNUPG:] <token>` line, if present.
+///
+/// The `[GNUPG:] ` prefix is REQUIRED, not optional. `git verify-tag --raw`
+/// relays gpg's status-fd output verbatim, so every status line carries it;
+/// accepting a bare `GOODSIG …` widened the match surface to any signer's
+/// free-text output for no benefit.
 fn gpg_status_line<'a>(raw: &'a str, token: &str) -> Option<&'a str> {
     raw.lines().find_map(|line| {
-        let line = line.trim();
-        let rest = line.strip_prefix("[GNUPG:] ").unwrap_or(line);
-        rest.strip_prefix(token)
+        line.trim()
+            .strip_prefix("[GNUPG:] ")
+            .and_then(|rest| rest.strip_prefix(token))
     })
 }
 
 /// `<keyid> <username>` → (key, signer). Either half may be absent.
-fn split_key_and_signer(rest: &str) -> (Option<String>, Option<String>) {
+///
+/// `ERRSIG` is the exception and must be passed as such: its tail is gpg's
+/// positional fields (`<pkalgo> <hashalgo> <sigclass> <time> <rc> <fpr>`), not a
+/// name, so splitting on the first space yielded `signer = "1 8 00 … 9 -"` — and
+/// `SignatureBadgeView` joins the signer into its tooltip, which then read
+/// "Signed, key unavailable — 1 8 00 1755302400 9 — 4AEE18F83AFDEB23".
+fn split_key_and_signer(rest: &str, token: &str) -> (Option<String>, Option<String>) {
     let rest = rest.trim();
-    match rest.split_once(' ') {
-        Some((key, signer)) => (
-            non_empty(key),
-            // ERRSIG's tail is positional fields, not a name; it has no spaces
-            // before them either way, so this stays a best-effort signer.
-            non_empty(signer.trim()),
-        ),
-        None => (non_empty(rest), None),
-    }
+    let (key, tail) = match rest.split_once(' ') {
+        Some((key, tail)) => (non_empty(key), tail.trim()),
+        None => (non_empty(rest), ""),
+    };
+    let signer = if token.starts_with("ERRSIG") {
+        None
+    } else {
+        non_empty(tail)
+    };
+    (key, signer)
 }
 
 /// `<principal> with <type> key <fingerprint>` → (signer, key).
@@ -316,6 +357,9 @@ mod tests {
         for bad in [
             "", "v1 0", "v1\n", "v1..v2", "v1~1", "v1^", "a:b", "v?", "v*", "a[b", "a\\b", "/v1",
             "v1/", "a//b", "v1.", "v1.lock", "a/.b", "HEAD@{0}",
+            // `git check-ref-format refs/tags/.hidden` refuses this; the "/."
+            // test above does not reach a LEADING dot.
+            ".hidden", ".v1",
         ] {
             assert!(
                 validate_tag_name(bad).is_err(),
@@ -359,6 +403,21 @@ mod tests {
         let s = parse_verify_tag(raw, false);
         assert_eq!(s.state, SigState::UnknownKey);
         assert_eq!(s.key.as_deref(), Some("4AEE18F83AFDEB23"));
+        // ERRSIG's tail is positional fields, NOT a name. Rendering it put
+        // "1 8 00 1755302400 9 -" in the badge tooltip where a signer belongs.
+        assert!(
+            s.signer.is_none(),
+            "ERRSIG has no signer, got {:?}",
+            s.signer
+        );
+    }
+
+    #[test]
+    fn a_bare_status_token_without_the_gnupg_prefix_is_not_a_verdict() {
+        // `--raw` relays gpg's status-fd lines, which always carry the prefix.
+        // Matching without it graded any signer's free text.
+        let s = parse_verify_tag("GOODSIG DEADBEEF Ada <ada@x>\n", false);
+        assert_eq!(s.state, SigState::UnknownKey, "must not grade Good");
     }
 
     #[test]
@@ -385,33 +444,57 @@ mod tests {
     }
 
     #[test]
-    fn an_ssh_key_outside_allowed_signers_is_still_a_good_signature() {
-        // git grades this `U`, which parse_verify_output maps to Good; the two
-        // badges must not disagree about one signature. Note git exits NON-ZERO
-        // here, which is why the exit status alone cannot classify.
-        let raw = "Good \"git\" signature with ED25519 key \
-                   SHA256:neE70xxhPefYQsf3pgAkuuDiavk0lCNXdE7HXGLzENI\n\
-                   No principal matched.\n";
-        let s = parse_verify_tag(raw, false);
-        assert_eq!(s.state, SigState::Good);
-        assert!(s.signer.is_none(), "no principal to name");
-        assert_eq!(
-            s.key.as_deref(),
-            Some("SHA256:neE70xxhPefYQsf3pgAkuuDiavk0lCNXdE7HXGLzENI")
-        );
+    fn an_ssh_key_outside_allowed_signers_is_not_reported_as_verified() {
+        // A real signature, but nothing vouches for whose key made it — and a tag
+        // is what people verify before trusting a release. Note git exits
+        // NON-ZERO here while grading `U`, which is why the exit status alone
+        // cannot classify either.
+        //
+        // Both spellings of "no principal": an allowed-signers file that does not
+        // list the key, and no allowed-signers file at all.
+        for raw in [
+            "Good \"git\" signature with ED25519 key \
+             SHA256:neE70xxhPefYQsf3pgAkuuDiavk0lCNXdE7HXGLzENI\n\
+             No principal matched.\n",
+            "Good \"git\" signature with ED25519 key \
+             SHA256:neE70xxhPefYQsf3pgAkuuDiavk0lCNXdE7HXGLzENI\n\
+             Unable to open allowed keys file \"\": No such file or directory\n\
+             sig_find_principals: sshsig_find_principal: No such file or directory\n\
+             No principal matched.\n",
+        ] {
+            let s = parse_verify_tag(raw, false);
+            assert_eq!(s.state, SigState::UnknownKey, "{raw}");
+            assert!(s.signer.is_none(), "no principal to name");
+            assert_eq!(
+                s.key.as_deref(),
+                Some("SHA256:neE70xxhPefYQsf3pgAkuuDiavk0lCNXdE7HXGLzENI")
+            );
+        }
     }
 
     #[test]
     fn a_tampered_ssh_signature_is_bad() {
+        // Also what a key revoked through gpg.ssh.revocationFile produces:
+        // measured against git 2.50.1 + OpenSSH 10.2, revocation yields exactly
+        // this line and exit 1 — no `Good` line and no "revoked" anywhere.
         let raw = "Could not verify signature.\n\
                    Signature verification failed: incorrect signature\n";
         assert_eq!(parse_verify_tag(raw, false).state, SigState::Bad);
+
+        let revoked = "Could not verify signature.\n";
+        assert_eq!(parse_verify_tag(revoked, false).state, SigState::Bad);
     }
 
     #[test]
-    fn a_revoked_ssh_key_reads_as_revoked_not_bad() {
-        let raw = "Signature verification failed: revoked key\n";
-        assert_eq!(parse_verify_tag(raw, false).state, SigState::Revoked);
+    fn an_explicit_failure_overrides_a_good_line_above_it() {
+        // Defence against a signer that printed its verdict before its checks:
+        // "no false Good" must hold in the parser, not in ssh-keygen's ordering.
+        let raw = "Good \"git\" signature for a@b.c with ED25519 key SHA256:abc\n\
+                   Could not verify signature.\n";
+        assert_eq!(parse_verify_tag(raw, false).state, SigState::Bad);
+        // …but a clean exit is still trusted, so the guard cannot misfire on
+        // output that merely mentions the phrase.
+        assert_eq!(parse_verify_tag(raw, true).state, SigState::Good);
     }
 
     // ─── verify parsing: fallbacks ───────────────────────────────────────────

--- a/src-tauri/src/git/tag.rs
+++ b/src-tauri/src/git/tag.rs
@@ -1,0 +1,432 @@
+//! Tag signing: the parts that can be decided without a keyring (#132).
+//!
+//! Nothing here spawns a process or opens a repository. `libgit2.rs` owns the
+//! ODB writes and the one `git verify-tag` call; this module owns the byte
+//! shuffling and the parsing, which is what makes both testable.
+
+use crate::error::{AppError, AppResult};
+use crate::git::signing::{SigState, SignatureStatus};
+
+/// The armor headers git recognizes as the start of a signature block.
+///
+/// Same set as git's `gpg-interface.c::signature_header[]`. Missing one would
+/// report a genuinely signed tag as unsigned, which is the failure mode this
+/// whole feature exists to remove.
+const SIGNATURE_HEADERS: [&str; 4] = [
+    "-----BEGIN PGP SIGNATURE-----",
+    "-----BEGIN PGP MESSAGE-----",
+    "-----BEGIN SIGNED MESSAGE-----",
+    "-----BEGIN SSH SIGNATURE-----",
+];
+
+/// Whether an annotated tag's message carries a signature block.
+///
+/// Anchored to a line start: a message that merely *mentions* an armor header
+/// mid-sentence is not a signature, and treating it as one would send us to
+/// `git verify-tag` for a tag that has nothing to verify.
+pub fn has_signature_block(message: &str) -> bool {
+    message
+        .lines()
+        .any(|line| SIGNATURE_HEADERS.contains(&line.trim_end()))
+}
+
+/// Append an armored signature to a canonical tag object body.
+///
+/// git appends the signature directly after the message, so the message must end
+/// in a newline first — without one the armor header runs onto the last message
+/// line and the tag is unverifiable by anything, including git. Exactly one
+/// newline: git's `strbuf_complete_line` adds one only when it is missing, and
+/// padding the body would change the payload the signature was made over.
+pub fn append_signature(body: &[u8], signature: &str) -> Vec<u8> {
+    let mut out = Vec::with_capacity(body.len() + signature.len() + 1);
+    out.extend_from_slice(body);
+    if !out.ends_with(b"\n") {
+        out.push(b'\n');
+    }
+    out.extend_from_slice(signature.as_bytes());
+    if !out.ends_with(b"\n") {
+        out.push(b'\n');
+    }
+    out
+}
+
+/// Ensure a tag message ends in exactly one newline, the way `git tag` does.
+///
+/// Called before the object is created, not after, because the signature is made
+/// over the object's bytes: normalizing afterwards would sign one body and store
+/// another.
+pub fn normalize_message(message: &str) -> String {
+    let trimmed = message.trim_end_matches('\n');
+    format!("{trimmed}\n")
+}
+
+/// Reject a tag name before it reaches an argv or a refname.
+///
+/// Same class as `verify_commit`'s hex check and the D5 review's `git show`
+/// finding: `git verify-tag` would read a leading `-` as an option, and the name
+/// arrives from a text field. The rest mirrors `git check-ref-format`, so a name
+/// we accept is one git can hold.
+pub fn validate_tag_name(name: &str) -> AppResult<()> {
+    let bad = |why: &str| Err(AppError::InvalidRef(format!("{name}: {why}")));
+
+    if name.is_empty() {
+        return bad("a tag needs a name");
+    }
+    // An option, not a ref, to every git command that would receive it.
+    if name.starts_with('-') {
+        return bad("a tag name cannot start with '-'");
+    }
+    if name.starts_with('/') || name.ends_with('/') || name.contains("//") {
+        return bad("a tag name cannot have an empty path component");
+    }
+    if name.ends_with('.') || name.ends_with(".lock") || name.contains("/.") {
+        return bad("invalid tag name");
+    }
+    if name.contains("..") || name.contains("@{") {
+        return bad("invalid tag name");
+    }
+    for ch in name.chars() {
+        if ch.is_whitespace() || ch.is_control() {
+            return bad("a tag name cannot contain whitespace or control characters");
+        }
+        if matches!(ch, '~' | '^' | ':' | '?' | '*' | '[' | '\\' | '\x7f') {
+            return bad("a tag name cannot contain ~ ^ : ? * [ or backslash");
+        }
+    }
+    Ok(())
+}
+
+/// GPG status tokens, in the order they are checked.
+///
+/// Mirrors git's `sigcheck_gpg_status` table (`gpg-interface.c`), except that the
+/// order puts the compromising verdicts first: gpg emits these mutually
+/// exclusively, so the order is only insurance, and the insurance should fall on
+/// the side of not calling a bad signature good.
+const GPG_STATUS: [(&str, SigState); 6] = [
+    ("BADSIG ", SigState::Bad),
+    ("REVKEYSIG ", SigState::Revoked),
+    // X: the signature expired. Y: the key that made it expired. Both are real
+    // signatures whose validity has lapsed — see parse_verify_output.
+    ("EXPKEYSIG ", SigState::Expired),
+    ("EXPSIG ", SigState::Expired),
+    // Cannot be checked at all — typically NO_PUBKEY.
+    ("ERRSIG ", SigState::UnknownKey),
+    ("GOODSIG ", SigState::Good),
+];
+
+/// Parse `git verify-tag --raw` output into the shared [`SignatureStatus`].
+///
+/// **Not** `parse_verify_output`: that one reads git's already-digested
+/// `%G?%x00%GS%x00%GK` triple, which is a commit-only format — `%G?` on a tag
+/// reports the *commit's* signature, and `for-each-ref`'s `%(signature:grade)`
+/// atom yields nothing for a tag object. `--raw` is the undigested signer output,
+/// in one of two shapes depending on `gpg.format`.
+///
+/// `ok` is the subprocess's exit status. It is only consulted for output we do
+/// not recognize, where an exit of 0 is git's own statement that the signature
+/// graded `G` or `U`.
+pub fn parse_verify_tag(raw: &str, ok: bool) -> SignatureStatus {
+    // ── GPG: [GNUPG:] <TOKEN> <keyid> <username> ──────────────────────────────
+    for (token, state) in GPG_STATUS {
+        if let Some(rest) = gpg_status_line(raw, token) {
+            let (key, signer) = split_key_and_signer(rest);
+            return SignatureStatus { state, signer, key };
+        }
+    }
+
+    // ── SSH: ssh-keygen's own wording, as git relays it ───────────────────────
+    for line in raw.lines() {
+        let line = line.trim();
+        // Valid signature from a principal in the allowed-signers file.
+        if let Some(rest) = line.strip_prefix("Good \"git\" signature for ") {
+            let (signer, key) = split_ssh_principal(rest);
+            return SignatureStatus {
+                state: SigState::Good,
+                signer,
+                key,
+            };
+        }
+        // Valid signature, but the key is not in the allowed-signers file. git
+        // grades this `U`, which parse_verify_output already reports as Good with
+        // the nuance in the signer line — same call here, so the two badges do
+        // not disagree about one signature.
+        if let Some(rest) = line.strip_prefix("Good \"git\" signature with ") {
+            return SignatureStatus {
+                state: SigState::Good,
+                signer: None,
+                key: ssh_key_fingerprint(rest),
+            };
+        }
+    }
+
+    let lowered = raw.to_ascii_lowercase();
+    if lowered.contains("revoked") {
+        return SignatureStatus {
+            state: SigState::Revoked,
+            signer: None,
+            key: None,
+        };
+    }
+    if lowered.contains("could not verify signature")
+        || lowered.contains("signature verification failed")
+    {
+        return SignatureStatus {
+            state: SigState::Bad,
+            signer: None,
+            key: None,
+        };
+    }
+
+    // Unrecognized. Callers only reach here for an object that DOES carry a
+    // signature block, so `None` would be a lie. An exit of 0 is git's own
+    // verdict of G or U; anything else is reported as "signed, could not be
+    // checked" rather than as Bad, which would cry wolf.
+    SignatureStatus {
+        state: if ok {
+            SigState::Good
+        } else {
+            SigState::UnknownKey
+        },
+        signer: None,
+        key: None,
+    }
+}
+
+/// The remainder of the first `[GNUPG:] <token>` line, if present.
+fn gpg_status_line<'a>(raw: &'a str, token: &str) -> Option<&'a str> {
+    raw.lines().find_map(|line| {
+        let line = line.trim();
+        let rest = line.strip_prefix("[GNUPG:] ").unwrap_or(line);
+        rest.strip_prefix(token)
+    })
+}
+
+/// `<keyid> <username>` → (key, signer). Either half may be absent.
+fn split_key_and_signer(rest: &str) -> (Option<String>, Option<String>) {
+    let rest = rest.trim();
+    match rest.split_once(' ') {
+        Some((key, signer)) => (
+            non_empty(key),
+            // ERRSIG's tail is positional fields, not a name; it has no spaces
+            // before them either way, so this stays a best-effort signer.
+            non_empty(signer.trim()),
+        ),
+        None => (non_empty(rest), None),
+    }
+}
+
+/// `<principal> with <type> key <fingerprint>` → (signer, key).
+fn split_ssh_principal(rest: &str) -> (Option<String>, Option<String>) {
+    match rest.split_once(" with ") {
+        Some((principal, tail)) => (non_empty(principal.trim()), ssh_key_fingerprint(tail)),
+        None => (non_empty(rest.trim()), None),
+    }
+}
+
+/// `<type> key <fingerprint>` → the fingerprint.
+fn ssh_key_fingerprint(tail: &str) -> Option<String> {
+    tail.rsplit_once(" key ")
+        .map(|(_, fp)| fp.trim())
+        .and_then(non_empty)
+}
+
+fn non_empty(s: &str) -> Option<String> {
+    (!s.trim().is_empty()).then(|| s.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ─── signature block detection ───────────────────────────────────────────
+
+    #[test]
+    fn detects_every_armor_header_git_knows() {
+        for header in SIGNATURE_HEADERS {
+            let msg = format!("release 1.0\n{header}\nabc\n");
+            assert!(has_signature_block(&msg), "{header}");
+        }
+    }
+
+    #[test]
+    fn an_unsigned_message_has_no_signature_block() {
+        assert!(!has_signature_block("release 1.0\n"));
+        assert!(!has_signature_block(""));
+    }
+
+    #[test]
+    fn a_header_mentioned_mid_line_is_not_a_signature() {
+        // Otherwise a tag whose message talks about signing would be sent to
+        // `git verify-tag` with nothing to verify.
+        assert!(!has_signature_block(
+            "we now emit -----BEGIN SSH SIGNATURE----- blocks\n"
+        ));
+    }
+
+    // ─── appending ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn append_signature_terminates_the_body_before_the_armor_header() {
+        let out = append_signature(b"tagger x\n\nmsg", "-----BEGIN SSH SIGNATURE-----\nx\n");
+        let s = String::from_utf8(out).unwrap();
+        assert!(
+            s.contains("msg\n-----BEGIN SSH SIGNATURE-----"),
+            "armor header must start its own line: {s:?}"
+        );
+    }
+
+    #[test]
+    fn append_signature_does_not_double_the_newline() {
+        let out = append_signature(b"body\n", "SIG\n");
+        assert_eq!(String::from_utf8(out).unwrap(), "body\nSIG\n");
+    }
+
+    #[test]
+    fn append_signature_terminates_an_unterminated_signature() {
+        let out = append_signature(b"body\n", "SIG");
+        assert_eq!(String::from_utf8(out).unwrap(), "body\nSIG\n");
+    }
+
+    #[test]
+    fn normalize_message_gives_exactly_one_trailing_newline() {
+        assert_eq!(normalize_message("hi"), "hi\n");
+        assert_eq!(normalize_message("hi\n"), "hi\n");
+        assert_eq!(normalize_message("hi\n\n\n"), "hi\n");
+    }
+
+    // ─── name validation ─────────────────────────────────────────────────────
+
+    #[test]
+    fn accepts_ordinary_tag_names() {
+        for ok in ["v1.0.0", "release/2026-08", "v1.0.0-rc.1", "2026.08.16"] {
+            validate_tag_name(ok).unwrap_or_else(|e| panic!("{ok} should be valid: {e:?}"));
+        }
+    }
+
+    #[test]
+    fn refuses_a_name_that_would_read_as_an_option() {
+        // `git verify-tag --raw -- -v1` still puts it after `--`, but nothing
+        // else in the app promises that, and a ref cannot start with '-' anyway.
+        let err = validate_tag_name("-v1").expect_err("leading dash");
+        assert!(matches!(err, AppError::InvalidRef(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn refuses_names_git_itself_would_refuse() {
+        for bad in [
+            "", "v1 0", "v1\n", "v1..v2", "v1~1", "v1^", "a:b", "v?", "v*", "a[b", "a\\b", "/v1",
+            "v1/", "a//b", "v1.", "v1.lock", "a/.b", "HEAD@{0}",
+        ] {
+            assert!(
+                validate_tag_name(bad).is_err(),
+                "{bad:?} should have been refused"
+            );
+        }
+    }
+
+    // ─── verify parsing: GPG ─────────────────────────────────────────────────
+
+    #[test]
+    fn parses_a_good_gpg_signature() {
+        let raw = "[GNUPG:] NEWSIG\n\
+                   [GNUPG:] GOODSIG 4AEE18F83AFDEB23 Ada Lovelace <ada@example.com>\n\
+                   [GNUPG:] VALIDSIG ABCDEF 2026-08-16\n\
+                   [GNUPG:] TRUST_ULTIMATE 0 pgp\n";
+        let s = parse_verify_tag(raw, true);
+        assert_eq!(s.state, SigState::Good);
+        assert_eq!(s.key.as_deref(), Some("4AEE18F83AFDEB23"));
+        assert_eq!(s.signer.as_deref(), Some("Ada Lovelace <ada@example.com>"));
+    }
+
+    #[test]
+    fn parses_every_gpg_verdict() {
+        for (token, want) in [
+            ("BADSIG", SigState::Bad),
+            ("EXPSIG", SigState::Expired),
+            ("EXPKEYSIG", SigState::Expired),
+            ("REVKEYSIG", SigState::Revoked),
+            ("GOODSIG", SigState::Good),
+        ] {
+            let raw = format!("[GNUPG:] {token} DEADBEEF Ada <ada@x>\n");
+            assert_eq!(parse_verify_tag(&raw, false).state, want, "{token}");
+        }
+    }
+
+    #[test]
+    fn an_unavailable_gpg_key_is_unknown_key_not_bad() {
+        let raw = "[GNUPG:] ERRSIG 4AEE18F83AFDEB23 1 8 00 1755302400 9 -\n\
+                   [GNUPG:] NO_PUBKEY 4AEE18F83AFDEB23\n";
+        let s = parse_verify_tag(raw, false);
+        assert_eq!(s.state, SigState::UnknownKey);
+        assert_eq!(s.key.as_deref(), Some("4AEE18F83AFDEB23"));
+    }
+
+    #[test]
+    fn a_bad_gpg_signature_wins_over_a_stray_goodsig() {
+        // Insurance only — gpg emits these exclusively — but it must fall on the
+        // side of not calling a bad signature good.
+        let raw = "[GNUPG:] GOODSIG AAAA Ada <ada@x>\n[GNUPG:] BADSIG BBBB Eve <eve@x>\n";
+        assert_eq!(parse_verify_tag(raw, false).state, SigState::Bad);
+    }
+
+    // ─── verify parsing: SSH (strings recorded from git 2.50.1) ──────────────
+
+    #[test]
+    fn parses_a_good_ssh_signature_from_a_known_principal() {
+        let raw = "Good \"git\" signature for a@b.c with ED25519 key \
+                   SHA256:neE70xxhPefYQsf3pgAkuuDiavk0lCNXdE7HXGLzENI\n";
+        let s = parse_verify_tag(raw, true);
+        assert_eq!(s.state, SigState::Good);
+        assert_eq!(s.signer.as_deref(), Some("a@b.c"));
+        assert_eq!(
+            s.key.as_deref(),
+            Some("SHA256:neE70xxhPefYQsf3pgAkuuDiavk0lCNXdE7HXGLzENI")
+        );
+    }
+
+    #[test]
+    fn an_ssh_key_outside_allowed_signers_is_still_a_good_signature() {
+        // git grades this `U`, which parse_verify_output maps to Good; the two
+        // badges must not disagree about one signature. Note git exits NON-ZERO
+        // here, which is why the exit status alone cannot classify.
+        let raw = "Good \"git\" signature with ED25519 key \
+                   SHA256:neE70xxhPefYQsf3pgAkuuDiavk0lCNXdE7HXGLzENI\n\
+                   No principal matched.\n";
+        let s = parse_verify_tag(raw, false);
+        assert_eq!(s.state, SigState::Good);
+        assert!(s.signer.is_none(), "no principal to name");
+        assert_eq!(
+            s.key.as_deref(),
+            Some("SHA256:neE70xxhPefYQsf3pgAkuuDiavk0lCNXdE7HXGLzENI")
+        );
+    }
+
+    #[test]
+    fn a_tampered_ssh_signature_is_bad() {
+        let raw = "Could not verify signature.\n\
+                   Signature verification failed: incorrect signature\n";
+        assert_eq!(parse_verify_tag(raw, false).state, SigState::Bad);
+    }
+
+    #[test]
+    fn a_revoked_ssh_key_reads_as_revoked_not_bad() {
+        let raw = "Signature verification failed: revoked key\n";
+        assert_eq!(parse_verify_tag(raw, false).state, SigState::Revoked);
+    }
+
+    // ─── verify parsing: fallbacks ───────────────────────────────────────────
+
+    #[test]
+    fn unrecognized_output_never_reads_as_unsigned() {
+        // The caller only gets here for an object that carries a signature
+        // block, so None would be a lie; and Bad would cry wolf.
+        assert_eq!(
+            parse_verify_tag("something new from a future git\n", false).state,
+            SigState::UnknownKey
+        );
+        assert_eq!(
+            parse_verify_tag("something new from a future git\n", true).state,
+            SigState::Good
+        );
+    }
+}

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -213,6 +213,11 @@ pub struct TagInfo {
     pub name: String,
     pub short_oid: String,
     pub oid: String,
+    /// Whether this is an annotated tag whose object carries a signature block
+    /// (#132). Read from the object during the tag walk — no subprocess, so
+    /// `list_tags` costs what it always did. It states a fact, not a verdict:
+    /// `verify_tag` is what grades the signature, lazily and one tag at a time.
+    pub signed: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -355,6 +360,15 @@ pub struct TagTarget {
     pub oid: String,
     /// None = lightweight tag; Some = annotated tag with this message.
     pub annotation: Option<String>,
+    /// Cryptographically sign this tag (#132). `None` follows `tag.gpgsign`
+    /// from git config; `Some` overrides it for this tag — the same contract
+    /// `CommitOptions.sign` has.
+    ///
+    /// Signing requires an annotation: a lightweight tag is a ref, with no
+    /// object to sign. `Some(true)` with no annotation is refused rather than
+    /// silently dropped.
+    #[serde(default)]
+    pub sign: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -198,6 +198,7 @@ pub fn run() {
             commands::branches::prune_remote,
             commands::branches::create_tag,
             commands::branches::delete_tag,
+            commands::branches::verify_tag,
             commands::branches::merge_branch,
             commands::branches::rebase_onto,
             commands::branches::checkout_ref,

--- a/src-tauri/tests/branches_tags.rs
+++ b/src-tauri/tests/branches_tags.rs
@@ -171,6 +171,7 @@ fn create_lightweight_tag() {
             TagTarget {
                 oid: head_oid,
                 annotation: None,
+                sign: None,
             },
         )
         .unwrap();
@@ -196,6 +197,7 @@ fn delete_tag_removes_it() {
             TagTarget {
                 oid: head_oid,
                 annotation: None,
+                sign: None,
             },
         )
         .unwrap();
@@ -216,7 +218,7 @@ fn create_tag_from_abbreviated_sha() {
         .create_tag(
             &handle.id,
             "v0.1.0-short",
-            TagTarget { oid: short_oid, annotation: None },
+            TagTarget { oid: short_oid, annotation: None, sign: None },
         )
         .expect("should resolve abbreviated sha");
 

--- a/src-tauri/tests/ref_compare.rs
+++ b/src-tauri/tests/ref_compare.rs
@@ -116,6 +116,7 @@ fn ref_to_workdir_accepts_branch_and_tag_revspecs() {
             TagTarget {
                 oid: head,
                 annotation: None,
+                sign: None,
             },
         )
         .unwrap();

--- a/src-tauri/tests/tag_signing.rs
+++ b/src-tauri/tests/tag_signing.rs
@@ -1,0 +1,386 @@
+//! Tag signing (#132).
+//!
+//! Two assertions carry this file. First, that a signed tag is a **tag object
+//! reachable through `refs/tags/<name>`** — `tag_annotation_create` and
+//! `odb.write` move no reference, the same trap `commit_signed` has, and a
+//! signed tag object nothing points at is invisible. Second, that **git itself
+//! accepts what we wrote**: we hand-roll the object, so `git tag -v` passing is
+//! the only thing that proves the body and its appended signature are the shape
+//! git expects, rather than merely the shape we expect.
+//!
+//! Every test that needs a real signature is gated on `ssh-keygen` being
+//! available and skips with a printed note otherwise, matching `signing.rs`.
+
+mod support;
+
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::signing::SigState;
+use platypusgit_lib::git::types::TagTarget;
+use platypusgit_lib::git::GitBackend;
+use support::TempRepo;
+
+fn annotated(oid: &str, msg: &str, sign: Option<bool>) -> TagTarget {
+    TagTarget {
+        oid: oid.to_string(),
+        annotation: Some(msg.to_string()),
+        sign,
+    }
+}
+
+fn lightweight(oid: &str, sign: Option<bool>) -> TagTarget {
+    TagTarget {
+        oid: oid.to_string(),
+        annotation: None,
+        sign,
+    }
+}
+
+/// Generate an unencrypted ed25519 key in `dir`, returning its private-key path.
+/// `None` when ssh-keygen is unavailable, so the test skips rather than fails.
+fn make_ssh_key(dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    let key = dir.join("id_ed25519");
+    let out = std::process::Command::new("ssh-keygen")
+        .args(["-t", "ed25519", "-N", "", "-C", "test", "-f"])
+        .arg(&key)
+        .output()
+        .ok()?;
+    out.status.success().then_some(key)
+}
+
+/// A repo configured for ssh signing with its own generated key, and an
+/// allowed-signers file naming it, so `git tag -v` can reach a `Good` verdict
+/// rather than only "signature present". `None` when ssh-keygen is unavailable.
+fn ssh_signing_repo() -> Option<(TempRepo, tempfile::TempDir)> {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let keydir = tempfile::tempdir().unwrap();
+    let key = make_ssh_key(keydir.path())?;
+
+    // "<principal> <keytype> <base64>" — the principal must match the tagger
+    // email TempRepo commits with, or ssh-keygen finds no principal and git
+    // grades the signature U instead of G.
+    let pubkey = std::fs::read_to_string(key.with_extension("pub")).ok()?;
+    let mut fields = pubkey.split_whitespace();
+    let (kind, blob) = (fields.next()?, fields.next()?);
+    let email = {
+        let cfg = tr.repo.config().unwrap();
+        cfg.get_string("user.email").unwrap_or_default()
+    };
+    let allowed = keydir.path().join("allowed_signers");
+    std::fs::write(&allowed, format!("{email} {kind} {blob}\n")).ok()?;
+
+    {
+        let mut c = tr.repo.config().unwrap();
+        c.set_str("gpg.format", "ssh").unwrap();
+        c.set_str("user.signingkey", key.to_str().unwrap()).unwrap();
+        c.set_str("gpg.ssh.allowedSignersFile", allowed.to_str().unwrap())
+            .unwrap();
+    }
+    Some((tr, keydir))
+}
+
+fn head_oid(tr: &TempRepo) -> String {
+    tr.repo.head().unwrap().target().unwrap().to_string()
+}
+
+// ─── writing ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn a_signed_tag_is_reachable_and_carries_a_signature_block() {
+    let Some((tr, _keydir)) = ssh_signing_repo() else {
+        eprintln!("ssh-keygen unavailable — skipping signed-tag test");
+        return;
+    };
+    let (backend, handle) = tr.open_with_backend();
+    let oid = head_oid(&tr);
+
+    backend
+        .create_tag(&handle.id, "v1.0.0", annotated(&oid, "release 1.0.0", Some(true)))
+        .expect("signed tag");
+
+    // THE trap: tag_annotation_create and odb.write move no reference.
+    let reference = tr
+        .repo
+        .find_reference("refs/tags/v1.0.0")
+        .expect("refs/tags/v1.0.0 must exist");
+    let tag = tr
+        .repo
+        .find_tag(reference.target().unwrap())
+        .expect("must be an annotated tag OBJECT, not a lightweight ref");
+
+    assert_eq!(tag.name(), Some("v1.0.0"));
+    assert_eq!(
+        tag.target_id().to_string(),
+        oid,
+        "must point at the commit it was asked to tag"
+    );
+    let message = tag.message().unwrap_or("");
+    assert!(
+        message.starts_with("release 1.0.0\n"),
+        "the message must survive intact: {message:?}"
+    );
+    assert!(
+        message.contains("-----BEGIN SSH SIGNATURE-----"),
+        "signature block missing: {message:?}"
+    );
+}
+
+#[test]
+fn git_itself_verifies_the_tag_we_wrote() {
+    // The interop assertion. We hand-roll the object, so our own parser agreeing
+    // with us proves nothing — git has to accept it.
+    let Some((tr, _keydir)) = ssh_signing_repo() else {
+        eprintln!("ssh-keygen unavailable — skipping git tag -v interop test");
+        return;
+    };
+    let (backend, handle) = tr.open_with_backend();
+    let oid = head_oid(&tr);
+    backend
+        .create_tag(&handle.id, "v2.0.0", annotated(&oid, "release 2.0.0", Some(true)))
+        .expect("signed tag");
+
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(tr.path())
+        .args(["verify-tag", "--raw", "--", "v2.0.0"])
+        .output()
+        .expect("git verify-tag");
+    assert!(
+        out.status.success(),
+        "git rejected our tag object: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn a_signing_failure_creates_no_tag() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    {
+        let mut c = tr.repo.config().unwrap();
+        c.set_str("gpg.format", "ssh").unwrap();
+        // A program that does not exist: signing cannot succeed.
+        c.set_str("gpg.ssh.program", "definitely-not-a-real-program")
+            .unwrap();
+        c.set_str("user.signingkey", "/nonexistent/key").unwrap();
+    }
+    let (backend, handle) = tr.open_with_backend();
+    let oid = head_oid(&tr);
+
+    let err = backend
+        .create_tag(&handle.id, "v1.0.0", annotated(&oid, "nope", Some(true)))
+        .expect_err("a signing failure must fail the tag");
+
+    // Falling back to an unsigned tag would leave the user believing they had
+    // signed it — the same rule commit_signed follows.
+    assert!(
+        tr.repo.find_reference("refs/tags/v1.0.0").is_err(),
+        "no ref may survive a signing failure: {err:?}"
+    );
+    assert!(
+        backend.tags(&handle.id).unwrap().is_empty(),
+        "no tag may be listed after a signing failure"
+    );
+}
+
+#[test]
+fn signing_a_lightweight_tag_is_refused_not_silently_dropped() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let oid = head_oid(&tr);
+
+    let err = backend
+        .create_tag(&handle.id, "v1.0.0", lightweight(&oid, Some(true)))
+        .expect_err("a lightweight tag has no object to sign");
+    assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+    assert!(tr.repo.find_reference("refs/tags/v1.0.0").is_err());
+}
+
+#[test]
+fn tag_gpgsign_does_not_promote_a_lightweight_tag() {
+    // Real `git tag v1` fails outright here ("fatal: no tag message?"), which
+    // would make lightweight tags unreachable in a signing repository. Our
+    // annotation field's blankness MEANS lightweight, so it wins.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    {
+        let mut c = tr.repo.config().unwrap();
+        c.set_bool("tag.gpgsign", true).unwrap();
+    }
+    let (backend, handle) = tr.open_with_backend();
+    let oid = head_oid(&tr);
+
+    backend
+        .create_tag(&handle.id, "v1.0.0", lightweight(&oid, None))
+        .expect("a lightweight tag stays reachable in a signing repo");
+
+    let tags = backend.tags(&handle.id).unwrap();
+    let tag = tags.iter().find(|t| t.name == "v1.0.0").expect("tag listed");
+    assert!(!tag.signed);
+    assert!(
+        tr.repo
+            .find_tag(tr.repo.find_reference("refs/tags/v1.0.0").unwrap().target().unwrap())
+            .is_err(),
+        "must stay lightweight — no tag object"
+    );
+}
+
+#[test]
+fn tag_gpgsign_is_the_default_for_an_annotated_tag() {
+    let Some((tr, _keydir)) = ssh_signing_repo() else {
+        eprintln!("ssh-keygen unavailable — skipping tag.gpgsign default test");
+        return;
+    };
+    {
+        let mut c = tr.repo.config().unwrap();
+        c.set_bool("tag.gpgsign", true).unwrap();
+    }
+    let (backend, handle) = tr.open_with_backend();
+    let oid = head_oid(&tr);
+
+    // sign: None follows the config…
+    backend
+        .create_tag(&handle.id, "from-config", annotated(&oid, "cfg", None))
+        .expect("tag");
+    // …and Some(false) overrides it for this tag only.
+    backend
+        .create_tag(&handle.id, "overridden", annotated(&oid, "off", Some(false)))
+        .expect("tag");
+
+    let tags = backend.tags(&handle.id).unwrap();
+    let signed = |n: &str| tags.iter().find(|t| t.name == n).expect(n).signed;
+    assert!(signed("from-config"), "tag.gpgsign must be the default");
+    assert!(!signed("overridden"), "a per-tag override must win");
+}
+
+#[test]
+fn commit_gpgsign_does_not_sign_tags() {
+    // Separate keys in git, separate keys here: a repository that signs every
+    // commit has not thereby asked for signed tags.
+    let Some((tr, _keydir)) = ssh_signing_repo() else {
+        eprintln!("ssh-keygen unavailable — skipping commit.gpgsign isolation test");
+        return;
+    };
+    {
+        let mut c = tr.repo.config().unwrap();
+        c.set_bool("commit.gpgsign", true).unwrap();
+    }
+    let (backend, handle) = tr.open_with_backend();
+    let oid = head_oid(&tr);
+
+    backend
+        .create_tag(&handle.id, "v1.0.0", annotated(&oid, "plain", None))
+        .expect("tag");
+    assert!(!backend.tags(&handle.id).unwrap()[0].signed);
+}
+
+// ─── listing ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn tag_info_reports_signed_only_for_a_signed_annotated_tag() {
+    let Some((tr, _keydir)) = ssh_signing_repo() else {
+        eprintln!("ssh-keygen unavailable — skipping TagInfo.signed test");
+        return;
+    };
+    let (backend, handle) = tr.open_with_backend();
+    let oid = head_oid(&tr);
+
+    backend
+        .create_tag(&handle.id, "signed", annotated(&oid, "s", Some(true)))
+        .unwrap();
+    backend
+        .create_tag(&handle.id, "annotated", annotated(&oid, "a", Some(false)))
+        .unwrap();
+    backend
+        .create_tag(&handle.id, "light", lightweight(&oid, None))
+        .unwrap();
+
+    let tags = backend.tags(&handle.id).unwrap();
+    let signed = |n: &str| tags.iter().find(|t| t.name == n).expect(n).signed;
+    assert!(signed("signed"));
+    assert!(!signed("annotated"));
+    assert!(!signed("light"));
+}
+
+// ─── verifying ───────────────────────────────────────────────────────────────
+
+#[test]
+fn verify_tag_grades_our_own_signature_good() {
+    let Some((tr, _keydir)) = ssh_signing_repo() else {
+        eprintln!("ssh-keygen unavailable — skipping verify_tag good test");
+        return;
+    };
+    let (backend, handle) = tr.open_with_backend();
+    let oid = head_oid(&tr);
+    backend
+        .create_tag(&handle.id, "v1.0.0", annotated(&oid, "release", Some(true)))
+        .unwrap();
+
+    let status = backend.verify_tag(&handle.id, "v1.0.0").expect("verify");
+    assert_eq!(
+        status.state,
+        SigState::Good,
+        "signer={:?} key={:?}",
+        status.signer,
+        status.key
+    );
+}
+
+#[test]
+fn verify_tag_reports_unsigned_tags_as_none() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let oid = head_oid(&tr);
+    backend
+        .create_tag(&handle.id, "annotated", annotated(&oid, "a", Some(false)))
+        .unwrap();
+    backend
+        .create_tag(&handle.id, "light", lightweight(&oid, None))
+        .unwrap();
+
+    // Both answered from the object, with no subprocess at all.
+    assert_eq!(
+        backend.verify_tag(&handle.id, "annotated").unwrap().state,
+        SigState::None
+    );
+    assert_eq!(
+        backend.verify_tag(&handle.id, "light").unwrap().state,
+        SigState::None
+    );
+}
+
+#[test]
+fn verify_tag_refuses_a_name_that_would_read_as_an_option() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    for bad in ["--help", "", "v1 0", "a..b", "v1^"] {
+        let err = backend
+            .verify_tag(&handle.id, bad)
+            .expect_err("should refuse an unusable tag name");
+        assert!(
+            matches!(err, AppError::InvalidRef(_)),
+            "expected InvalidRef for {bad:?}, got {err:?}"
+        );
+    }
+}
+
+#[test]
+fn verify_tag_reports_a_missing_tag_as_an_invalid_ref() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let err = backend
+        .verify_tag(&handle.id, "nope")
+        .expect_err("no such tag");
+    assert!(matches!(err, AppError::InvalidRef(_)), "got {err:?}");
+}
+
+#[test]
+fn create_tag_refuses_an_unusable_name_before_touching_the_repo() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let oid = head_oid(&tr);
+
+    let err = backend
+        .create_tag(&handle.id, "-rf", lightweight(&oid, None))
+        .expect_err("a tag name cannot start with '-'");
+    assert!(matches!(err, AppError::InvalidRef(_)), "got {err:?}");
+    assert!(backend.tags(&handle.id).unwrap().is_empty());
+}

--- a/src-tauri/tests/tag_signing_gpg.rs
+++ b/src-tauri/tests/tag_signing_gpg.rs
@@ -1,0 +1,461 @@
+//! GPG-side tag signing (#132).
+//!
+//! `tests/tag_signing.rs` covers the SSH format end to end, because `ssh-keygen`
+//! can mint a throwaway key in a temp dir. The OpenPGP verdict mapping was, until
+//! this file, backed only by hand-written fixtures in `git/tag.rs` — which is
+//! exactly how `ERRSIG`'s positional tail came to be rendered as a signer name.
+//!
+//! Two layers here, deliberately:
+//!
+//! 1. **Stub-`gpg.program` tests** (need only `/bin/sh`, so they always run).
+//!    Everything except the cryptography is real: our `create_signed_tag` with
+//!    the real OpenPGP `signing_args` argv, a real tag object, a real
+//!    `git verify-tag --raw`, and the real `parse_verify_tag`. This is what pins
+//!    the two facts the parser depends on and no unit test can establish — that
+//!    git relays gpg's status lines **with** the `[GNUPG:] ` prefix, and that it
+//!    writes them to **stderr**.
+//! 2. **A real-gpg test**, gated on the binary being present and run against an
+//!    **ephemeral `GNUPGHOME`** in a temp dir, so it never touches the user's
+//!    keyring. Skips with a printed note when gpg is unavailable.
+
+mod support;
+
+use platypusgit_lib::git::signing::SigState;
+use platypusgit_lib::git::types::TagTarget;
+use platypusgit_lib::git::GitBackend;
+use support::TempRepo;
+
+fn annotated(oid: &str, msg: &str) -> TagTarget {
+    TagTarget {
+        oid: oid.to_string(),
+        annotation: Some(msg.to_string()),
+        sign: Some(true),
+    }
+}
+
+fn head_oid(tr: &TempRepo) -> String {
+    tr.repo.head().unwrap().target().unwrap().to_string()
+}
+
+/// A temp dir with a short path.
+///
+/// `std::env::temp_dir()` on macOS is `/var/folders/…/T/`, long enough that a
+/// gpg-agent socket under it can exceed `sun_path`'s 108 bytes. `/tmp` keeps the
+/// real-gpg fixture below that.
+fn short_tempdir() -> tempfile::TempDir {
+    let base = std::path::Path::new("/tmp");
+    let mut b = tempfile::Builder::new();
+    let b = b.prefix("pgt");
+    if base.is_dir() {
+        b.tempdir_in(base).unwrap()
+    } else {
+        b.tempdir().unwrap()
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Layer 1 — the pipeline, with a stubbed signer
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Write an executable stub that answers as gpg does for the two invocations git
+/// and we actually make.
+///
+/// git calls `gpg.program` two ways (recorded from git 2.50.1):
+///   sign:   `--status-fd=2 -bsau <key>`, payload on stdin, armor on stdout
+///   verify: `--keyid-format=long --status-fd=1 --verify <sigfile> -`
+///
+/// `verify_status` is emitted on the status fd for the verify call; signing
+/// always succeeds, so every test starts from a real signed tag object.
+#[cfg(unix)]
+fn write_stub_gpg(
+    dir: &std::path::Path,
+    verify_status: &str,
+    verify_exit: i32,
+) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    assert!(
+        !verify_status.contains('\''),
+        "the stub embeds this in a single-quoted sh string"
+    );
+    let path = dir.join("fakegpg");
+    let script = format!(
+        "#!/bin/sh\n\
+         for a in \"$@\"; do\n\
+         \x20 if [ \"$a\" = \"--verify\" ]; then\n\
+         \x20   cat >/dev/null\n\
+         \x20   printf '%s' '{verify_status}'\n\
+         \x20   exit {verify_exit}\n\
+         \x20 fi\n\
+         done\n\
+         cat >/dev/null\n\
+         printf -- '-----BEGIN PGP SIGNATURE-----\\n\\nZmFrZXNpZw==\\n-----END PGP SIGNATURE-----\\n'\n\
+         exit 0\n"
+    );
+    std::fs::write(&path, script).unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    path
+}
+
+/// A repo whose OpenPGP signer is the stub above.
+#[cfg(unix)]
+fn stub_gpg_repo(verify_status: &str, verify_exit: i32) -> (TempRepo, tempfile::TempDir) {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let dir = short_tempdir();
+    let program = write_stub_gpg(dir.path(), verify_status, verify_exit);
+    {
+        let mut c = tr.repo.config().unwrap();
+        // gpg.format left at its default (openpgp) on purpose — this is the
+        // format the SSH tests cannot reach.
+        c.set_str("gpg.program", program.to_str().unwrap()).unwrap();
+        c.set_str("user.signingkey", "DEADBEEFCAFE1234").unwrap();
+    }
+    (tr, dir)
+}
+
+#[cfg(unix)]
+const GOOD_STATUS: &str = "[GNUPG:] NEWSIG\n\
+                           [GNUPG:] GOODSIG DEADBEEFCAFE1234 Ada Lovelace <ada@example.com>\n\
+                           [GNUPG:] VALIDSIG ABCDEF 2026-08-16\n\
+                           [GNUPG:] TRUST_ULTIMATE 0 pgp\n";
+
+#[cfg(unix)]
+#[test]
+fn an_openpgp_signed_tag_round_trips_through_real_git_verify_tag() {
+    // The load-bearing one: it proves `git verify-tag --raw` hands us gpg's
+    // status lines WITH the `[GNUPG:] ` prefix and on STDERR. `parse_verify_tag`
+    // requires the prefix and reads both streams; a unit test cannot establish
+    // either, because both are git's behaviour, not ours.
+    let (tr, _dir) = stub_gpg_repo(GOOD_STATUS, 0);
+    let (backend, handle) = tr.open_with_backend();
+    let oid = head_oid(&tr);
+
+    backend
+        .create_tag(&handle.id, "v1.0.0", annotated(&oid, "release 1.0.0"))
+        .expect("signed tag");
+
+    // The object really is an annotated tag carrying PGP armor.
+    let tags = backend.tags(&handle.id).unwrap();
+    assert!(tags.iter().any(|t| t.name == "v1.0.0" && t.signed));
+
+    let status = backend.verify_tag(&handle.id, "v1.0.0").expect("verify");
+    assert_eq!(status.state, SigState::Good);
+    assert_eq!(status.key.as_deref(), Some("DEADBEEFCAFE1234"));
+    assert_eq!(
+        status.signer.as_deref(),
+        Some("Ada Lovelace <ada@example.com>")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn an_openpgp_bad_signature_reaches_the_ui_as_bad() {
+    let (tr, _dir) = stub_gpg_repo(
+        "[GNUPG:] NEWSIG\n[GNUPG:] BADSIG DEADBEEFCAFE1234 Ada Lovelace <ada@example.com>\n",
+        1,
+    );
+    let (backend, handle) = tr.open_with_backend();
+    let oid = head_oid(&tr);
+    backend
+        .create_tag(&handle.id, "v1.0.0", annotated(&oid, "release"))
+        .unwrap();
+
+    assert_eq!(
+        backend.verify_tag(&handle.id, "v1.0.0").unwrap().state,
+        SigState::Bad
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn an_unavailable_openpgp_key_yields_unknown_key_with_no_signer() {
+    // ERRSIG's tail is gpg's positional fields, not a name. Rendering it put
+    // "1 8 00 1755302400 9 -" where the badge tooltip shows the signer — the
+    // concrete bug hand-written fixtures missed, because the unit test asserted
+    // only the key.
+    let (tr, _dir) = stub_gpg_repo(
+        "[GNUPG:] ERRSIG DEADBEEFCAFE1234 1 8 00 1755302400 9 -\n\
+         [GNUPG:] NO_PUBKEY DEADBEEFCAFE1234\n",
+        1,
+    );
+    let (backend, handle) = tr.open_with_backend();
+    let oid = head_oid(&tr);
+    backend
+        .create_tag(&handle.id, "v1.0.0", annotated(&oid, "release"))
+        .unwrap();
+
+    let status = backend.verify_tag(&handle.id, "v1.0.0").unwrap();
+    assert_eq!(status.state, SigState::UnknownKey);
+    assert_eq!(status.key.as_deref(), Some("DEADBEEFCAFE1234"));
+    assert!(
+        status.signer.is_none(),
+        "ERRSIG carries no signer, got {:?}",
+        status.signer
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn a_failing_openpgp_signer_creates_no_tag() {
+    // The stub's signing branch is bypassed by pointing at a program that is not
+    // there at all — the rule is the same one commit_signed follows.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    {
+        let mut c = tr.repo.config().unwrap();
+        c.set_str("gpg.program", "definitely-not-a-real-gpg").unwrap();
+    }
+    let (backend, handle) = tr.open_with_backend();
+    let oid = head_oid(&tr);
+
+    backend
+        .create_tag(&handle.id, "v1.0.0", annotated(&oid, "nope"))
+        .expect_err("a signing failure must fail the tag");
+    assert!(tr.repo.find_reference("refs/tags/v1.0.0").is_err());
+}
+
+#[cfg(unix)]
+#[test]
+fn a_name_collision_is_refused_before_the_signer_runs() {
+    // With a passphrase-protected key the old ordering popped pinentry, took the
+    // passphrase, and only then failed with "tag already exists". The stub logs
+    // nothing, so the assertion is the cheaper one: the tag that already exists
+    // is untouched, and the error names the collision.
+    let (tr, _dir) = stub_gpg_repo(GOOD_STATUS, 0);
+    let (backend, handle) = tr.open_with_backend();
+    let oid = head_oid(&tr);
+
+    backend
+        .create_tag(&handle.id, "v1.0.0", annotated(&oid, "first"))
+        .unwrap();
+    let first = tr
+        .repo
+        .find_reference("refs/tags/v1.0.0")
+        .unwrap()
+        .target()
+        .unwrap();
+
+    let err = backend
+        .create_tag(&handle.id, "v1.0.0", annotated(&oid, "second"))
+        .expect_err("a duplicate tag name must be refused");
+    assert!(
+        format!("{err:?}").contains("already exists"),
+        "expected a collision error, got {err:?}"
+    );
+
+    let after = tr
+        .repo
+        .find_reference("refs/tags/v1.0.0")
+        .unwrap()
+        .target()
+        .unwrap();
+    assert_eq!(first, after, "the existing tag must be untouched");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Layer 2 — real gpg, ephemeral keyring
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// A real gpg keyring in a temp `GNUPGHOME`, plus a wrapper that injects it.
+///
+/// The wrapper exists so the home never leaks into the process environment:
+/// `std::env::set_var` is global and this test binary runs its tests in
+/// parallel, so a second test could pick up this keyring. Pointing
+/// `gpg.program` at a script is race-free and reaches BOTH callers — our
+/// `run_signer` and git's own verify.
+#[cfg(unix)]
+struct GpgFixture {
+    dir: tempfile::TempDir,
+    program: std::path::PathBuf,
+    fingerprint: String,
+}
+
+#[cfg(unix)]
+impl Drop for GpgFixture {
+    fn drop(&mut self) {
+        // gpg-agent daemonizes against the ephemeral home; leave none behind.
+        let _ = std::process::Command::new("gpgconf")
+            .args(["--homedir".as_ref(), self.dir.path().as_os_str()])
+            .arg("--kill")
+            .arg("gpg-agent")
+            .output();
+    }
+}
+
+/// `None` when gpg is unavailable or key generation fails, so the test skips.
+#[cfg(unix)]
+fn real_gpg() -> Option<GpgFixture> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    // Present at all?
+    std::process::Command::new("gpg")
+        .arg("--version")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+
+    let dir = short_tempdir();
+    let home = dir.path().join("gnupg");
+    std::fs::create_dir_all(&home).ok()?;
+    std::fs::set_permissions(&home, std::fs::Permissions::from_mode(0o700)).ok()?;
+
+    // A passphrase-less signing key, so nothing ever prompts. `%no-protection`
+    // is why: without it gpg-agent would raise pinentry with no tty to draw on.
+    let params = "%no-protection\n\
+                  Key-Type: eddsa\n\
+                  Key-Curve: Ed25519\n\
+                  Key-Usage: sign\n\
+                  Name-Real: Platypus Test\n\
+                  Name-Email: test@example.invalid\n\
+                  Expire-Date: 0\n\
+                  %commit\n";
+    let params_path = dir.path().join("keyparams");
+    std::fs::write(&params_path, params).ok()?;
+
+    let gen = std::process::Command::new("gpg")
+        .arg("--homedir")
+        .arg(&home)
+        .args(["--batch", "--no-tty", "--gen-key"])
+        .arg(&params_path)
+        .output()
+        .ok()?;
+    if !gen.status.success() {
+        eprintln!(
+            "gpg key generation failed, skipping: {}",
+            String::from_utf8_lossy(&gen.stderr).trim()
+        );
+        return None;
+    }
+
+    // `--with-colons` so the fingerprint is a field, not prose.
+    let listed = std::process::Command::new("gpg")
+        .arg("--homedir")
+        .arg(&home)
+        .args(["--batch", "--with-colons", "--list-secret-keys"])
+        .output()
+        .ok()?;
+    let fingerprint = String::from_utf8_lossy(&listed.stdout)
+        .lines()
+        .find_map(|l| l.strip_prefix("fpr:"))
+        .and_then(|rest| rest.split(':').find(|f| !f.is_empty()))
+        .map(str::to_string)?;
+
+    let program = dir.path().join("gpgwrap");
+    std::fs::write(
+        &program,
+        format!(
+            "#!/bin/sh\nexport GNUPGHOME='{}'\nexec gpg --batch --no-tty \"$@\"\n",
+            home.display()
+        ),
+    )
+    .ok()?;
+    std::fs::set_permissions(&program, std::fs::Permissions::from_mode(0o755)).ok()?;
+
+    Some(GpgFixture {
+        dir,
+        program,
+        fingerprint,
+    })
+}
+
+#[cfg(unix)]
+#[test]
+fn a_real_gpg_signed_tag_verifies_good_and_git_accepts_it() {
+    let Some(gpg) = real_gpg() else {
+        eprintln!("gpg unavailable — skipping real-gpg tag test");
+        return;
+    };
+    let tr = TempRepo::with_initial_commit("hello\n");
+    {
+        let mut c = tr.repo.config().unwrap();
+        c.set_str("gpg.program", gpg.program.to_str().unwrap())
+            .unwrap();
+        c.set_str("user.signingkey", &gpg.fingerprint).unwrap();
+    }
+    let (backend, handle) = tr.open_with_backend();
+    let oid = head_oid(&tr);
+
+    backend
+        .create_tag(&handle.id, "v1.0.0", annotated(&oid, "release 1.0.0"))
+        .expect("real gpg signed tag");
+
+    // Interop: our hand-rolled object has to satisfy git, not just us.
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(tr.path())
+        .args(["verify-tag", "--raw", "--", "v1.0.0"])
+        .output()
+        .expect("git verify-tag");
+    assert!(
+        out.status.success(),
+        "git rejected our gpg-signed tag: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let status = backend.verify_tag(&handle.id, "v1.0.0").expect("verify");
+    assert_eq!(
+        status.state,
+        SigState::Good,
+        "signer={:?} key={:?}",
+        status.signer,
+        status.key
+    );
+    assert!(
+        status
+            .signer
+            .as_deref()
+            .is_some_and(|s| s.contains("Platypus Test")),
+        "signer should name the key's user id, got {:?}",
+        status.signer
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn a_tampered_real_gpg_tag_is_bad() {
+    let Some(gpg) = real_gpg() else {
+        eprintln!("gpg unavailable — skipping tampered real-gpg tag test");
+        return;
+    };
+    let tr = TempRepo::with_initial_commit("hello\n");
+    {
+        let mut c = tr.repo.config().unwrap();
+        c.set_str("gpg.program", gpg.program.to_str().unwrap())
+            .unwrap();
+        c.set_str("user.signingkey", &gpg.fingerprint).unwrap();
+    }
+    let (backend, handle) = tr.open_with_backend();
+    let oid = head_oid(&tr);
+    backend
+        .create_tag(&handle.id, "v1.0.0", annotated(&oid, "release"))
+        .unwrap();
+
+    // Rewrite the object with one message byte changed and repoint the ref. The
+    // armor is untouched, so it still reads as "signed" — the signature simply
+    // no longer covers the payload.
+    let tag_oid = tr
+        .repo
+        .find_reference("refs/tags/v1.0.0")
+        .unwrap()
+        .target()
+        .unwrap();
+    let body = tr.repo.odb().unwrap().read(tag_oid).unwrap().data().to_vec();
+    let tampered = String::from_utf8(body)
+        .unwrap()
+        .replacen("release", "relaese", 1)
+        .into_bytes();
+    let bad = tr
+        .repo
+        .odb()
+        .unwrap()
+        .write(git2::ObjectType::Tag, &tampered)
+        .unwrap();
+    tr.repo
+        .reference("refs/tags/v1.0.0", bad, true, "tamper")
+        .unwrap();
+
+    assert_eq!(
+        backend.verify_tag(&handle.id, "v1.0.0").unwrap().state,
+        SigState::Bad,
+        "a tampered payload must not read as verified"
+    );
+}

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -52,6 +52,7 @@ import { BranchChip } from "@/features/branches/BranchChip";
 import { CloneDialog } from "@/features/create/CloneDialog";
 import { CredentialDialog } from "@/features/auth/CredentialDialog";
 import { InitDialog } from "@/features/create/InitDialog";
+import { CreateTagDialog } from "@/features/tags/CreateTagDialog";
 import { OperationBar } from "@/features/repo/OperationBar";
 import { useSubmodulesStore } from "@/features/submodules/useSubmodulesStore";
 import { useWorktreesStore } from "@/features/worktrees/useWorktreesStore";
@@ -361,6 +362,10 @@ export function AppShell() {
       <CheatSheet />
       <CloneDialog />
       <InitDialog />
+      {/* Create tag (#132). Mounted here rather than in a screen because two of
+          its three call sites — a context-menu item builder and a palette step —
+          are not React components. Renders nothing until one opens it. */}
+      <CreateTagDialog />
       {error && (
         <div
           role="alert"

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/features/compare/useCompareStore";
 import { WORKDIR } from "@/features/compare/compareSides";
 import { currentBranch } from "@/lib/derive";
+import { openCreateTag } from "@/features/tags/useCreateTagStore";
 import { chordFor } from "@/features/keymap";
 
 export interface ContextMenuItem {
@@ -411,20 +412,10 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
     {
       icon: "tag",
       label: "Create tag here…",
-      onClick: async () => {
-        const name = await pgPrompt({
-          title: "Create tag here",
-          body: `Tagging ${sha.slice(0, 7)}.`,
-          placeholder: "v1.0.0",
-          confirmLabel: "Create tag",
-          requireValue: true,
-          mono: true,
-        });
-        if (!name || !commit) return;
-        useRepoStore.getState().createTag(name, {
-          oid: commit.sha ?? "",
-          annotation: null,
-        });
+      onClick: () => {
+        // The dialog carries name + annotation + signing (#132); a single-value
+        // prompt could only ever make a lightweight one.
+        if (commit?.sha) void openCreateTag({ oid: commit.sha });
       },
     },
     { divider: true },

--- a/src/features/keymap/actions.ts
+++ b/src/features/keymap/actions.ts
@@ -10,6 +10,7 @@
 // through to the browser.
 
 import { useCreateStore } from "@/features/create/useCreateStore";
+import { useCreateTagStore } from "@/features/tags/useCreateTagStore";
 import { useForgeStore } from "@/features/forge/useForgeStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { usePaletteStore } from "@/features/palette/usePaletteStore";
@@ -264,6 +265,11 @@ export const ACTIONS: Record<ActionId, ActionDef> = {
       // fall through to some other overlay action while a run is in flight.
       if (useCreateStore.getState().open !== "none") {
         useCreateStore.getState().close();
+        return true;
+      }
+      // Same stacking layer (PGModal), same rule (#132).
+      if (useCreateTagStore.getState().target) {
+        useCreateTagStore.getState().close();
         return true;
       }
       if (useUpdateStore.getState().panelOpen) {

--- a/src/features/palette/commands.ts
+++ b/src/features/palette/commands.ts
@@ -13,6 +13,7 @@ import { useTabsStore } from "@/features/repo/useTabsStore";
 import { openCompare } from "@/features/compare/useCompareStore";
 import { WORKDIR } from "@/features/compare/compareSides";
 import { orderBranchesGrouped } from "@/features/branches/orderBranches";
+import { openCreateTag } from "@/features/tags/useCreateTagStore";
 import { usePaletteStore } from "./usePaletteStore";
 import { createBranchInputStep, switchRepoStep } from "./steps";
 import { currentBranch, isConflicted, relativeTime } from "@/lib/derive";
@@ -595,18 +596,19 @@ export function buildCommands(): PaletteItem[] {
   });
 
   // -- tag ops --
-  items.push({
-    type: "command", id: "action:create-tag",
-    search: "Create tag", label: "Create tag…", icon: "tag",
-    run: step(() => ({
-      kind: "input", title: "Create tag (at HEAD)", placeholder: "v1.2.3",
-      validate: (v) => (!v.trim() ? "Tag name required" : headTip ? null : "No commit to tag"),
-      onSubmit: (v) => {
+  // Hands off to the create-tag dialog rather than taking a name inline: a tag
+  // carries three values now (name, annotation, signing), and a palette input
+  // step takes one (#132).
+  if (headTip) {
+    items.push({
+      type: "command", id: "action:create-tag",
+      search: "Create tag", label: "Create tag (at HEAD)…", icon: "tag",
+      run: () => {
         palette().closePalette();
-        if (headTip) void repo.createTag(v.trim(), { oid: headTip, annotation: null });
+        void openCreateTag({ oid: headTip });
       },
-    })),
-  });
+    });
+  }
   if (repo.tags.length) {
     items.push({
       type: "command", id: "action:delete-tag",

--- a/src/features/signing/SignatureBadge.tsx
+++ b/src/features/signing/SignatureBadge.tsx
@@ -27,47 +27,23 @@ const LOOK: Record<
  * Settle time before verifying, matching the inline commit diff rendered beside
  * this badge in the same panel (History's INLINE_DIFF_DEBOUNCE_MS).
  *
- * `verify_commit` shells out to `git show`, so without this, arrowing through the
- * log spawns one process per row passed over — all of them still queued behind
+ * Verification shells out to git, so without this, arrowing through the log
+ * spawns one process per row passed over — all of them still queued behind
  * `spawn_blocking` after the user has stopped moving.
  */
-const VERIFY_DEBOUNCE_MS = 100;
+export const VERIFY_DEBOUNCE_MS = 100;
 
 /**
- * Signature status of one commit (#61 D6).
- *
- * Verifies **lazily, for this commit only** — a badge on every log row would
- * mean a gpg/ssh-keygen process per walked commit, which fights the paginated
- * log walk and the windowed list.
+ * The rendering half of a signature badge, shared by the commit and tag badges
+ * (#132) so one set of states cannot acquire two vocabularies.
  */
-export function SignatureBadge({ oid }: { oid: string }) {
-  const repoId = useRepoStore((s) => s.current?.id ?? null);
-  const [status, setStatus] = React.useState<SignatureStatus | null>(null);
-
-  React.useEffect(() => {
-    if (!repoId || !oid) {
-      setStatus(null);
-      return;
-    }
-    let cancelled = false;
-    setStatus(null);
-    const handle = window.setTimeout(() => {
-      verifyCommit(repoId, oid)
-        .then((s) => {
-          if (!cancelled) setStatus(s);
-        })
-        .catch(() => {
-          // A verification failure is not worth an error banner: the commit and
-          // its diff are still perfectly viewable.
-          if (!cancelled) setStatus(null);
-        });
-    }, VERIFY_DEBOUNCE_MS);
-    return () => {
-      cancelled = true;
-      window.clearTimeout(handle);
-    };
-  }, [repoId, oid]);
-
+export function SignatureBadgeView({
+  status,
+  testId = "signature-badge",
+}: {
+  status: SignatureStatus | null;
+  testId?: string;
+}) {
   const look = status ? LOOK[status.state] : null;
   if (!look) return null;
 
@@ -77,7 +53,8 @@ export function SignatureBadge({ oid }: { oid: string }) {
 
   return (
     <span
-      data-testid="signature-badge"
+      data-testid={testId}
+      data-sig-state={status?.state}
       title={title}
       style={{
         display: "inline-flex",
@@ -92,4 +69,63 @@ export function SignatureBadge({ oid }: { oid: string }) {
       {look.label}
     </span>
   );
+}
+
+/**
+ * Debounced lazy verification, shared by both badges. `verify` is re-run
+ * whenever the key it closes over changes; a failure clears the status rather
+ * than raising a banner.
+ */
+export function useLazyVerification(
+  key: string | null,
+  verify: (() => Promise<SignatureStatus>) | null,
+): SignatureStatus | null {
+  const [status, setStatus] = React.useState<SignatureStatus | null>(null);
+  // Read through a ref so a caller need not memoize the closure: the effect
+  // keys on the identifier, which is what actually decides the answer.
+  const verifyRef = React.useRef(verify);
+  verifyRef.current = verify;
+
+  React.useEffect(() => {
+    const run = verifyRef.current;
+    if (!key || !run) {
+      setStatus(null);
+      return;
+    }
+    let cancelled = false;
+    setStatus(null);
+    const handle = window.setTimeout(() => {
+      run()
+        .then((s) => {
+          if (!cancelled) setStatus(s);
+        })
+        .catch(() => {
+          // A verification failure is not worth an error banner: the object and
+          // everything around it are still perfectly viewable.
+          if (!cancelled) setStatus(null);
+        });
+    }, VERIFY_DEBOUNCE_MS);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, [key]);
+
+  return status;
+}
+
+/**
+ * Signature status of one commit (#61 D6).
+ *
+ * Verifies **lazily, for this commit only** — a badge on every log row would
+ * mean a gpg/ssh-keygen process per walked commit, which fights the paginated
+ * log walk and the windowed list.
+ */
+export function SignatureBadge({ oid }: { oid: string }) {
+  const repoId = useRepoStore((s) => s.current?.id ?? null);
+  const status = useLazyVerification(
+    repoId && oid ? `${repoId}:${oid}` : null,
+    repoId && oid ? () => verifyCommit(repoId, oid) : null,
+  );
+  return <SignatureBadgeView status={status} />;
 }

--- a/src/features/signing/TagSignatureBadge.test.tsx
+++ b/src/features/signing/TagSignatureBadge.test.tsx
@@ -1,0 +1,75 @@
+// Tag verification is a `git verify-tag` SUBPROCESS per call (#132), so the
+// badge debounces exactly as the commit one does — and it renders for the
+// SELECTED tag only, which is what keeps the Branches screen from spawning one
+// process per tag row on every refresh.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { TagSignatureBadge } from "./TagSignatureBadge";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+
+const GOOD = { state: "Good", signer: "Ada <ada@x>", key: "SHA256:abc" };
+
+const verifyCalls = () => getInvokeCalls().filter((c) => c.cmd === "verify_tag");
+
+beforeEach(() => {
+  resetInvokeMock();
+  vi.useRealTimers();
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "main" },
+  } as never);
+  mockInvoke("verify_tag", () => GOOD);
+});
+
+describe("TagSignatureBadge", () => {
+  it("verifies the tag and renders the verdict", async () => {
+    render(<TagSignatureBadge name="v1.0.0" />);
+
+    await waitFor(() => expect(screen.getByTestId("tag-signature-badge")).toBeTruthy());
+    const badge = screen.getByTestId("tag-signature-badge");
+    expect(badge.textContent).toContain("Signed");
+    expect(badge.getAttribute("title")).toContain("Ada <ada@x>");
+    expect(verifyCalls()).toHaveLength(1);
+    expect(verifyCalls()[0].args.name).toBe("v1.0.0");
+  });
+
+  it("does not verify a tag that was only passed through", async () => {
+    const { rerender } = render(<TagSignatureBadge name="v1" />);
+    rerender(<TagSignatureBadge name="v2" />);
+    rerender(<TagSignatureBadge name="v3" />);
+
+    await waitFor(() => expect(verifyCalls()).toHaveLength(1));
+    expect(verifyCalls()[0].args.name).toBe("v3");
+  });
+
+  it("renders nothing for an unsigned tag", async () => {
+    mockInvoke("verify_tag", () => ({ state: "None", signer: null, key: null }));
+    render(<TagSignatureBadge name="v1.0.0" />);
+
+    await waitFor(() => expect(verifyCalls()).toHaveLength(1));
+    expect(screen.queryByTestId("tag-signature-badge")).toBeNull();
+  });
+
+  it("shows a bad signature rather than staying silent", async () => {
+    mockInvoke("verify_tag", () => ({ state: "Bad", signer: null, key: null }));
+    render(<TagSignatureBadge name="v1.0.0" />);
+
+    await waitFor(() => expect(screen.getByTestId("tag-signature-badge")).toBeTruthy());
+    expect(screen.getByTestId("tag-signature-badge").textContent).toContain(
+      "Bad signature",
+    );
+  });
+
+  it("keeps quiet when verification itself fails", async () => {
+    // Not worth an error banner: the tag and everything around it are still
+    // perfectly usable.
+    mockInvoke("verify_tag", () => {
+      throw { kind: "Git", message: "boom" };
+    });
+    render(<TagSignatureBadge name="v1.0.0" />);
+
+    await waitFor(() => expect(verifyCalls()).toHaveLength(1));
+    expect(screen.queryByTestId("tag-signature-badge")).toBeNull();
+  });
+});

--- a/src/features/signing/TagSignatureBadge.tsx
+++ b/src/features/signing/TagSignatureBadge.tsx
@@ -1,0 +1,24 @@
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { verifyTag } from "@/lib/tauri";
+import { SignatureBadgeView, useLazyVerification } from "./SignatureBadge";
+
+/**
+ * Signature status of one tag (#132).
+ *
+ * Rendered for the **selected** tag only, in the Branches inspector — never per
+ * row. The Branches screen lists every tag at once, so a verdict per row would
+ * be one `git verify-tag` process per row on every refresh, which is exactly
+ * what `SignatureBadge` refuses to do to the log. The rows instead show
+ * `TagInfo.signed`, which is read straight off the object and costs nothing.
+ *
+ * `verify_tag` still answers an unsigned or lightweight tag without a
+ * subprocess, so mounting this for one is free.
+ */
+export function TagSignatureBadge({ name }: { name: string }) {
+  const repoId = useRepoStore((s) => s.current?.id ?? null);
+  const status = useLazyVerification(
+    repoId && name ? `${repoId}:${name}` : null,
+    repoId && name ? () => verifyTag(repoId, name) : null,
+  );
+  return <SignatureBadgeView status={status} testId="tag-signature-badge" />;
+}

--- a/src/features/tags/CreateTagDialog.test.tsx
+++ b/src/features/tags/CreateTagDialog.test.tsx
@@ -1,0 +1,163 @@
+// The create-tag dialog replaced three single-value prompts (#132), and the
+// value it added is the one with teeth: signing. These pin the three states of
+// the sign toggle and the rule that ties them to the annotation — a lightweight
+// tag has no object to sign, so the payload must never claim otherwise.
+import { beforeEach, describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { CreateTagDialog } from "./CreateTagDialog";
+import { openCreateTag, useCreateTagStore } from "./useCreateTagStore";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+
+const OID = "a".repeat(40);
+
+const createCalls = () => getInvokeCalls().filter((c) => c.cmd === "create_tag");
+const lastTarget = () =>
+  createCalls()[createCalls().length - 1].args.target as {
+    oid: string;
+    annotation: string | null;
+    sign: boolean | null;
+  };
+
+beforeEach(() => {
+  resetInvokeMock();
+  useCreateTagStore.setState({ target: null });
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "main" },
+  } as never);
+  mockInvoke("create_tag", () => null);
+  // createTag calls refreshAll on the way out.
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("get_log_page", () => ({ commits: [], hasMore: false }));
+  mockInvoke("rebase_status", () => ({ inProgress: false, done: 0, total: 0 }));
+});
+
+async function openDialog() {
+  render(<CreateTagDialog />);
+  void openCreateTag({ oid: OID, shortOid: "aaaaaaa" });
+  await waitFor(() => expect(screen.getByTestId("create-tag-name")).toBeTruthy());
+}
+
+describe("CreateTagDialog", () => {
+  it("creates a lightweight tag when the annotation is blank", async () => {
+    const user = userEvent.setup();
+    await openDialog();
+
+    await user.type(screen.getByTestId("create-tag-name"), "v1.0.0");
+    await user.click(screen.getByTestId("create-tag-submit"));
+
+    await waitFor(() => expect(createCalls()).toHaveLength(1));
+    expect(createCalls()[0].args.name).toBe("v1.0.0");
+    expect(lastTarget()).toMatchObject({
+      oid: OID,
+      annotation: null,
+      // Explicitly unsigned, never null: tag.gpgsign must not be allowed to
+      // promote a lightweight tag into something the user did not ask for.
+      sign: false,
+    });
+  });
+
+  it("leaves signing to git config until it is touched", async () => {
+    const user = userEvent.setup();
+    await openDialog();
+
+    await user.type(screen.getByTestId("create-tag-name"), "v1.0.0");
+    await user.type(screen.getByTestId("create-tag-annotation"), "release");
+    await user.click(screen.getByTestId("create-tag-submit"));
+
+    await waitFor(() => expect(createCalls()).toHaveLength(1));
+    // null = follow tag.gpgsign, which the frontend cannot read. Sending false
+    // would silently override a repository that has tag signing on.
+    expect(lastTarget()).toMatchObject({ annotation: "release", sign: null });
+  });
+
+  it("sends an explicit true once the sign toggle is checked", async () => {
+    const user = userEvent.setup();
+    await openDialog();
+
+    await user.type(screen.getByTestId("create-tag-name"), "v1.0.0");
+    await user.type(screen.getByTestId("create-tag-annotation"), "release");
+    await user.click(screen.getByTestId("create-tag-sign"));
+    await user.click(screen.getByTestId("create-tag-submit"));
+
+    await waitFor(() => expect(createCalls()).toHaveLength(1));
+    expect(lastTarget().sign).toBe(true);
+  });
+
+  it("disables signing while the annotation is blank", async () => {
+    const user = userEvent.setup();
+    await openDialog();
+
+    const box = screen
+      .getByTestId("create-tag-sign")
+      .querySelector("input") as HTMLInputElement;
+    expect(box.disabled).toBe(true);
+    expect(screen.getByTestId("create-tag-sign").textContent).toContain(
+      "needs an annotation",
+    );
+
+    await user.type(screen.getByTestId("create-tag-annotation"), "release");
+    expect(box.disabled).toBe(false);
+  });
+
+  it("un-signs a tag whose annotation is blanked after checking sign", async () => {
+    // The toggle keeps its state, but the payload must follow the tag's actual
+    // shape — the backend refuses signed-lightweight, and the UI must never
+    // send a combination it refuses.
+    const user = userEvent.setup();
+    await openDialog();
+
+    await user.type(screen.getByTestId("create-tag-name"), "v1.0.0");
+    await user.type(screen.getByTestId("create-tag-annotation"), "release");
+    await user.click(screen.getByTestId("create-tag-sign"));
+    await user.clear(screen.getByTestId("create-tag-annotation"));
+    await user.click(screen.getByTestId("create-tag-submit"));
+
+    await waitFor(() => expect(createCalls()).toHaveLength(1));
+    expect(lastTarget()).toMatchObject({ annotation: null, sign: false });
+  });
+
+  it("creates nothing when dismissed, and settles its promise", async () => {
+    const user = userEvent.setup();
+    render(<CreateTagDialog />);
+    let settled = false;
+    void openCreateTag({ oid: OID }).then(() => {
+      settled = true;
+    });
+    await waitFor(() => expect(screen.getByTestId("create-tag-name")).toBeTruthy());
+
+    await user.click(screen.getByText("Cancel"));
+
+    await waitFor(() => expect(settled).toBe(true));
+    expect(createCalls()).toHaveLength(0);
+    expect(screen.queryByTestId("create-tag-name")).toBeNull();
+  });
+
+  it("does not carry a signing override into the next tag", async () => {
+    // The per-commit override is not sticky either: it is an override, and
+    // carrying it silently into the next one would surprise.
+    const user = userEvent.setup();
+    await openDialog();
+    await user.type(screen.getByTestId("create-tag-name"), "v1.0.0");
+    await user.type(screen.getByTestId("create-tag-annotation"), "release");
+    await user.click(screen.getByTestId("create-tag-sign"));
+    await user.click(screen.getByTestId("create-tag-submit"));
+    await waitFor(() => expect(createCalls()).toHaveLength(1));
+
+    void openCreateTag({ oid: OID });
+    await waitFor(() => expect(screen.getByTestId("create-tag-name")).toBeTruthy());
+    await user.type(screen.getByTestId("create-tag-name"), "v1.0.1");
+    await user.type(screen.getByTestId("create-tag-annotation"), "next");
+    await user.click(screen.getByTestId("create-tag-submit"));
+
+    await waitFor(() => expect(createCalls()).toHaveLength(2));
+    expect(lastTarget().sign).toBeNull();
+  });
+});

--- a/src/features/tags/CreateTagDialog.tsx
+++ b/src/features/tags/CreateTagDialog.tsx
@@ -1,0 +1,155 @@
+import React from "react";
+
+import { PGButton, PGCheckbox, PGInput, PGModal, PGTextarea } from "@/design";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { Field } from "@/features/create/Field";
+import { useCreateTagStore } from "./useCreateTagStore";
+
+/**
+ * Create a tag: name, annotation and signing in one place (#132).
+ *
+ * Replaces the three single-value `pgPrompt` call sites (the commit context
+ * menu, History's commit detail, the palette), which between them could not
+ * express three values — two of them hardcoded `annotation: null`, so an
+ * annotated tag was unreachable from either.
+ */
+export function CreateTagDialog() {
+  const target = useCreateTagStore((s) => s.target);
+  const close = useCreateTagStore((s) => s.close);
+  const done = useCreateTagStore((s) => s.done);
+  const createTag = useRepoStore((s) => s.createTag);
+
+  const [name, setName] = React.useState("");
+  const [annotation, setAnnotation] = React.useState("");
+  // null = follow tag.gpgsign, which the frontend cannot read; true/false
+  // override it for this tag. Same three states CommitPanel uses.
+  const [sign, setSign] = React.useState<boolean | null>(null);
+  const [busy, setBusy] = React.useState(false);
+
+  // The dialog stays mounted (AppShell renders it unconditionally; it self-gates
+  // below), so closing it is a `return null`, not an unmount — every useState
+  // here would otherwise survive to the next open. Reset on each closed→open
+  // transition. Signing in particular must not be sticky: it is an override,
+  // and carrying it into the next tag would surprise, exactly as the per-commit
+  // override does not persist between commits.
+  React.useEffect(() => {
+    if (!target) return;
+    setName("");
+    setAnnotation("");
+    setSign(null);
+    setBusy(false);
+  }, [target]);
+
+  if (!target) return null;
+
+  const annotated = annotation.trim() !== "";
+  // Signing implies annotated: a lightweight tag is a ref, with no object to
+  // carry a signature. The backend refuses the combination; the UI never offers
+  // it, so the refusal is a boundary check rather than a reachable error.
+  const effectiveSign = annotated ? sign : false;
+  const canCreate = !busy && name.trim() !== "";
+  const shortOid = target.shortOid ?? target.oid.slice(0, 7);
+
+  async function submit() {
+    if (!canCreate || !target) return;
+    setBusy(true);
+    try {
+      await createTag(name.trim(), {
+        oid: target.oid,
+        annotation: annotated ? annotation : null,
+        sign: effectiveSign,
+      });
+      // The store surfaces a failure through the error banner; either way the
+      // dialog is finished with. Leaving it open on failure would hide the
+      // banner behind the backdrop.
+      done();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <PGModal onCancel={close} dismissable={!busy}>
+      <div style={{ fontWeight: 600, marginBottom: 4 }}>Create tag</div>
+      <div
+        style={{
+          fontSize: "var(--fs-11)",
+          color: "var(--fg-2)",
+          marginBottom: 12,
+        }}
+      >
+        Tagging <span className="mono">{shortOid}</span>.
+      </div>
+
+      <Field label="Name">
+        <PGInput
+          data-testid="create-tag-name"
+          value={name}
+          onChange={setName}
+          placeholder="v1.0.0"
+          mono
+          autoFocus
+          onKeyDown={(e) => {
+            if (e.key === "Enter") void submit();
+          }}
+        />
+      </Field>
+
+      <Field label="Annotation — leave blank for a lightweight tag">
+        <PGTextarea
+          data-testid="create-tag-annotation"
+          value={annotation}
+          onChange={setAnnotation}
+          rows={3}
+          placeholder="Release notes for this tag"
+        />
+      </Field>
+
+      {/*
+        Three states rather than two, matching the commit box. Indeterminate is
+        "follow tag.gpgsign", which the frontend cannot read — showing it as
+        plain unchecked would claim the tag is unsigned in a repository that has
+        tag signing on. A signing failure fails the tag; it never silently
+        produces an unsigned one.
+      */}
+      <PGCheckbox
+        testId="create-tag-sign"
+        checked={effectiveSign === true}
+        indeterminate={annotated && sign === null}
+        disabled={!annotated}
+        onChange={(v) => setSign(v)}
+        label={
+          !annotated
+            ? "Sign this tag — needs an annotation"
+            : sign === null
+              ? "Sign this tag — following git config"
+              : sign
+                ? "Sign this tag"
+                : "Don't sign this tag"
+        }
+      />
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          gap: 8,
+          marginTop: 16,
+        }}
+      >
+        <PGButton variant="ghost" onClick={close} disabled={busy}>
+          Cancel
+        </PGButton>
+        <PGButton
+          data-testid="create-tag-submit"
+          variant="primary"
+          icon="tag"
+          disabled={!canCreate}
+          onClick={() => void submit()}
+        >
+          Create tag
+        </PGButton>
+      </div>
+    </PGModal>
+  );
+}

--- a/src/features/tags/useCreateTagStore.ts
+++ b/src/features/tags/useCreateTagStore.ts
@@ -59,7 +59,20 @@ export const useCreateTagStore = create<CreateTagState>((set) => ({
   },
 }));
 
-/** Imperative opener for non-component call sites. */
+/**
+ * Imperative opener for non-component call sites.
+ *
+ * **Needs `<CreateTagDialog />` mounted in the window** — `AppShell` mounts it,
+ * the merge resolver window does not. With no dialog mounted nothing renders and
+ * nothing clears `target`, so the promise never settles and a second call would
+ * find the store already "open". Same contract `pgConfirm`/`pgPrompt` have with
+ * `PGDialogHost`, except those resolve `false`/`null` instead of hanging.
+ *
+ * No caller awaits this today (all three use `void`), so the hang is latent
+ * rather than live — but a future `await openCreateTag(…)` from the wrong window
+ * would stall silently, which is why it is written down here rather than left to
+ * be rediscovered.
+ */
 export function openCreateTag(target: CreateTagTarget): Promise<void> {
   return useCreateTagStore.getState().openCreateTag(target);
 }

--- a/src/features/tags/useCreateTagStore.ts
+++ b/src/features/tags/useCreateTagStore.ts
@@ -1,0 +1,65 @@
+import { create } from "zustand";
+
+/** What the dialog is being opened for. */
+export interface CreateTagTarget {
+  /** Full oid of the commit to tag. */
+  oid: string;
+  /** Display sha for the dialog's subtitle. Derived when omitted. */
+  shortOid?: string;
+}
+
+interface CreateTagState {
+  target: CreateTagTarget | null;
+  /**
+   * Open the create-tag dialog for `target`. Resolves when it closes — after a
+   * successful create, or on dismissal.
+   *
+   * Promise-shaped and store-driven for the same reason `useAuthStore` is: two
+   * of the three call sites (a context-menu item builder and a palette step)
+   * are not React components and cannot render a modal themselves (#132).
+   */
+  openCreateTag: (target: CreateTagTarget) => Promise<void>;
+  /** Dismiss without creating. Also what `app.closeOverlay` calls. */
+  close: () => void;
+  /** Settle the pending promise. The dialog calls this after a create. */
+  done: () => void;
+}
+
+/**
+ * Resolver for the open dialog. Deliberately module state rather than a store
+ * field: it is a continuation, not something anything renders, and keeping it
+ * out of the store means no component re-renders when it is swapped.
+ */
+let pending: (() => void) | null = null;
+
+function settle() {
+  const resolve = pending;
+  pending = null;
+  resolve?.();
+}
+
+export const useCreateTagStore = create<CreateTagState>((set) => ({
+  target: null,
+  openCreateTag: (target) =>
+    new Promise<void>((resolve) => {
+      // A second open replaces the first rather than stacking: only one modal
+      // is ever mounted, so the earlier promise must settle or its caller waits
+      // forever.
+      settle();
+      pending = resolve;
+      set({ target });
+    }),
+  close: () => {
+    set({ target: null });
+    settle();
+  },
+  done: () => {
+    set({ target: null });
+    settle();
+  },
+}));
+
+/** Imperative opener for non-component call sites. */
+export function openCreateTag(target: CreateTagTarget): Promise<void> {
+  return useCreateTagStore.getState().openCreateTag(target);
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -558,7 +558,17 @@ export async function setUpstream(
 
 export interface TagTarget {
   oid: string;
+  /** null = lightweight tag; a string = annotated tag with this message. */
   annotation: string | null;
+  /**
+   * Sign this tag (#132). `null` follows `tag.gpgsign`; a boolean overrides it
+   * for this tag — the same contract `CommitOptions.sign` has.
+   *
+   * Signing requires an annotation: `true` with `annotation: null` is refused
+   * by the backend rather than silently dropped, because a lightweight tag is a
+   * ref with no object to sign.
+   */
+  sign?: boolean | null;
 }
 
 export async function createTag(
@@ -571,6 +581,21 @@ export async function createTag(
 
 export async function deleteTag(repoId: string, name: string): Promise<void> {
   return invoke<void>("delete_tag", { repoId, name });
+}
+
+/**
+ * Signature status of ONE tag (#132).
+ *
+ * Lazy for the same reason `verifyCommit` is: the Branches screen renders every
+ * tag at once, so a verdict per row would be a signer process per row on every
+ * refresh. `TagInfo.signed` carries the free half — whether a signature is
+ * there at all.
+ */
+export async function verifyTag(
+  repoId: string,
+  name: string,
+): Promise<SignatureStatus> {
+  return invoke<SignatureStatus>("verify_tag", { repoId, name });
 }
 
 export async function mergeBranch(repoId: string, name: string): Promise<void> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -127,7 +127,7 @@ export interface LogFilter {
   contentRegex?: boolean;
 }
 
-/** Verification verdict for one commit's signature (#61 D6). */
+/** Verification verdict for one commit's or tag's signature (#61 D6, #132). */
 export type SigState =
   | "Good"
   | "Bad"
@@ -191,6 +191,14 @@ export interface TagInfo {
   name: string;
   shortOid: string;
   oid: string;
+  /**
+   * Whether this annotated tag's object carries a signature block (#132).
+   *
+   * A fact, not a verdict — it is read straight off the object during the tag
+   * walk, so `list_tags` costs no subprocess. `verifyTag` is what grades the
+   * signature, lazily, for the selected tag.
+   */
+  signed: boolean;
 }
 
 export interface StashInfo {

--- a/src/screens/Branches.tags.test.tsx
+++ b/src/screens/Branches.tags.test.tsx
@@ -1,0 +1,81 @@
+// Tag signature surfacing in the Branches screen (#132).
+//
+// The split is the point: `TagInfo.signed` is free (read off the object during
+// the tag walk) so it can mark every row, and the graded verdict costs a
+// `git verify-tag` subprocess so it is fetched for the SELECTED tag only. A
+// verdict per row would be one process per row on every refresh, which is
+// exactly what SignatureBadge refuses to do to the log.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BranchesScreen } from "./Branches";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { WithDialogs, resetDialogs } from "@/test/dialog";
+import type { TagInfo } from "@/lib/types";
+
+const tag = (name: string, signed: boolean): TagInfo => ({
+  name,
+  shortOid: "abc1234",
+  oid: "abc1234def5678",
+  signed,
+});
+
+const TAGS = [tag("v1.0.0", true), tag("v0.9.0", false)];
+
+const verifyCalls = () => getInvokeCalls().filter((c) => c.cmd === "verify_tag");
+
+beforeEach(() => {
+  resetInvokeMock();
+  resetDialogs();
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
+    status: [],
+    branches: [],
+    remotes: [],
+    tags: TAGS,
+    stashes: [],
+    commits: [],
+    loading: false,
+  } as never);
+  mockInvoke("verify_tag", () => ({
+    state: "Good",
+    signer: "Ada <ada@x>",
+    key: "SHA256:abc",
+  }));
+  render(
+    <WithDialogs>
+      <BranchesScreen />
+    </WithDialogs>,
+  );
+});
+
+describe("Branches: tag signatures", () => {
+  it("marks a signed tag's row without verifying anything", () => {
+    // Two tags listed, one glyph — and crucially, no subprocess for either.
+    expect(screen.getAllByTestId("tag-signed-glyph")).toHaveLength(1);
+    expect(verifyCalls()).toHaveLength(0);
+  });
+
+  it("verifies only the selected signed tag", async () => {
+    fireEvent.click(screen.getByText("v1.0.0"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("tag-signature-badge")).toBeTruthy(),
+    );
+    expect(screen.getByTestId("tag-signature-badge").textContent).toContain(
+      "Signed",
+    );
+    expect(verifyCalls()).toHaveLength(1);
+    expect(verifyCalls()[0].args.name).toBe("v1.0.0");
+  });
+
+  it("does not verify an unsigned tag at all", async () => {
+    fireEvent.click(screen.getByText("v0.9.0"));
+
+    // `signed: false` came off the object, so there is nothing to ask git.
+    await waitFor(() => expect(screen.getByText("Oid")).toBeTruthy());
+    expect(screen.queryByTestId("tag-signature-badge")).toBeNull();
+    expect(verifyCalls()).toHaveLength(0);
+  });
+});

--- a/src/screens/Branches.tsx
+++ b/src/screens/Branches.tsx
@@ -22,6 +22,7 @@ import {
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { orderBranches } from "@/features/branches/orderBranches";
+import { TagSignatureBadge } from "@/features/signing/TagSignatureBadge";
 import { PGPane, FocusableScroll, usePaneList } from "@/features/keymap";
 import type { BranchInfo, StashInfo, TagInfo } from "@/lib/types";
 // `tip` is a full oid (see list_branches); these two rows show it short.
@@ -512,7 +513,21 @@ export function BranchesScreen() {
                   {t.shortOid}
                 </div>
                 <div style={{ ...cellStyle, color: "var(--fg-3)" }}>—</div>
-                <div style={{ ...cellStyle, color: "var(--fg-3)" }}>tag</div>
+                <div style={{ ...cellStyle, color: "var(--fg-3)", gap: 4 }}>
+                  {t.signed ? "signed tag" : "tag"}
+                  {/* Read off the tag object, so it costs nothing per row and
+                      claims no verdict. The graded badge is in the inspector,
+                      where exactly one tag is verified at a time (#132). */}
+                  {t.signed && (
+                    <span
+                      data-testid="tag-signed-glyph"
+                      title="This tag carries a signature"
+                      style={{ display: "inline-flex", color: "var(--fg-2)" }}
+                    >
+                      <PGIcon name="lock" size={11} />
+                    </span>
+                  )}
+                </div>
                 <div
                   style={{ ...cellStyle, justifyContent: "center", padding: 0 }}
                 >
@@ -934,6 +949,11 @@ function TagInspector({ tag }: { tag: TagInfo }) {
       </div>
       <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
         <KV k="Oid" v={<span className="mono">{tag.shortOid}</span>} />
+        {/* Verified lazily, for this one selected tag (#132) — see
+            TagSignatureBadge for why it is not on every row. */}
+        {tag.signed && (
+          <KV k="Signature" v={<TagSignatureBadge name={tag.name} />} />
+        )}
       </div>
     </>
   );

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -36,6 +36,7 @@ import { buildRebasePlan } from "@/features/commits/buildRebasePlan";
 import { combinedSquashMessage } from "@/features/commits/squashMessage";
 import { runRebasePlanNow } from "@/features/commits/runRebasePlan";
 import { useRepoStore } from "@/features/repo/useRepoStore";
+import { openCreateTag } from "@/features/tags/useCreateTagStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useDensityStep, useSettingsStore } from "@/features/settings/useSettingsStore";
 import { resolveHeadDecor } from "@/features/settings/headMarks";
@@ -1175,29 +1176,12 @@ function CommitActionRow({ commit }: { commit: CommitInfo }) {
     if (!name) return;
     store.getState().createBranch(name, commit.oid);
   }, [commit, store]);
-  const tagHere = React.useCallback(async () => {
-    const name = await pgPrompt({
-      title: "Create tag here",
-      body: `Tagging ${commit.shortOid}.`,
-      placeholder: "v1.0.0",
-      confirmLabel: "Next",
-      requireValue: true,
-      mono: true,
-    });
-    if (!name) return;
-    // An empty annotation is meaningful — it makes a lightweight tag — so a
-    // blank answer must still create the tag; only a dismissal aborts.
-    const annotation = await pgPrompt({
-      title: `Annotation for ${name}`,
-      body: "Leave blank for a lightweight tag.",
-      confirmLabel: "Create tag",
-    });
-    if (annotation === null) return;
-    store.getState().createTag(name, {
-      oid: commit.oid,
-      annotation: annotation ? annotation : null,
-    });
-  }, [commit, store]);
+  // One dialog rather than two chained prompts: signing is a third value, and a
+  // prompt chain cannot express "blank annotation means lightweight, which is
+  // also why signing is unavailable" while you are answering it (#132).
+  const tagHere = React.useCallback(() => {
+    void openCreateTag({ oid: commit.oid, shortOid: commit.shortOid });
+  }, [commit]);
   const cherryPick = React.useCallback(async () => {
     if (
       !(await pgConfirm({


### PR DESCRIPTION
Roadmap P1. Commit signing shipped in 0.0.8 (#61 D6); the tag half never did, so a repository that signs every commit still published unsigned tags — and releases are exactly what people verify.

**Spec:** `docs/superpowers/specs/2026-08-16-tag-signing-spec.md`
**Plan:** `docs/superpowers/plans/2026-08-16-tag-signing-plan.md`

## What changed

### Signing route — the decision the issue deferred

**Hand-rolled the annotated-tag object; `git tag -s` was rejected.** `git2` has `commit_signed` but no `tag_signed`, so `create_signed_tag` does what git does in `builtin/tag.c`: build the body, sign it, append the armored signature, write the object. It does *not* re-derive git's serialization — `tag_annotation_create` writes the canonical unsigned object and `odb.read` hands its bytes back, so the signed payload is byte-for-byte what libgit2 would have stored, with no hand-written tagger formatting or timezone arithmetic.

`git tag -s` was rejected because it does its own `gpg.format`/`user.signingkey` resolution: `signing.rs` would be bypassed entirely, and the SSH key-**path** restriction commits enforce (`key::…` literals refused rather than written to a temp file) is impossible to keep through it — tags would silently accept what commits refuse. It would also split the annotated path in two (different tagger resolution, force semantics, collision behaviour).

Cost: one unreferenced object per signed tag, collected by `git gc`. `tests/tag_signing.rs::git_itself_verifies_the_tag_we_wrote` runs real `git verify-tag` against our object, because our own parser agreeing with us proves nothing.

### Backend

- `signing.rs`: `resolve_key_file` extracted (the SSH restriction, now pure and unit-tested), `config_wants_tag_signing` (`tag.gpgsign`) beside `config_wants_signing`, both via one `config_flag`.
- `libgit2.rs`: `sign_payload` — the four-call chain `commit_signed` and `create_signed_tag` now share. **The ref is written last**, so a signing failure leaves no tag at all.
- New `git/tag.rs` (pure, 18 unit tests): armor-header detection, `append_signature`, `validate_tag_name` (argv guard), `parse_verify_tag`.
- `TagTarget.sign: Option<bool>` — `None` follows `tag.gpgsign`, `Some` overrides, exactly `CommitOptions.sign`. `TagInfo.signed: bool`, read off the object during the existing tag walk (no subprocess).
- New `verify_tag` command. **`%G?` cannot be used for a tag** — it is a commit placeholder, and `for-each-ref`'s `%(signature:grade)` atom is empty for a tag object (checked against git 2.50.1) — so this shells out to `git verify-tag --raw` and parses git's raw signer output into the existing `SignatureStatus`. Neither exit status nor text alone suffices: a valid signature from a key outside `allowedSignersFile` exits non-zero while grading `G`/`U`.

### Signing implies annotated

`sign: true` with no annotation is `InvalidArgument`, never a silent downgrade. A bare `tag.gpgsign` deliberately does **not** promote a lightweight tag: real `git tag v1` fails outright there (`fatal: no tag message?`), which would make lightweight tags unreachable in a signing repository, and the dialog's blank annotation field *means* lightweight. The UI disables the sign toggle while the annotation is blank, so the refused combination is unreachable.

### Frontend

- New `features/tags/CreateTagDialog` + `useCreateTagStore`, mounted once in `AppShell`, replacing the three single-value prompts (`context-menu.tsx:417`, `History.tsx:1196`, `commands.ts:523`). Two of those hardcoded `annotation: null`, so an annotated tag was unreachable from either. Store-driven and promise-shaped because two call sites are not React components. Escape goes through the keymap's `app.closeOverlay`, not a local listener.
- Three-state sign checkbox, same as the commit box: indeterminate is "follow `tag.gpgsign`", which the frontend cannot read — plain unchecked would claim the tag is unsigned in a repo that signs tags.
- `SignatureBadge` factored into `SignatureBadgeView` + `useLazyVerification`; new `TagSignatureBadge`. Tag **rows** mark `TagInfo.signed` (free, no verdict claimed); the **selected** tag's inspector shows the graded badge. A verdict per row would be one `git verify-tag` process per row on every refresh — the rule `SignatureBadge` already states for the log.

No new `AppError` variant, so `src/lib/errors.ts` is unchanged.

## How to test

```bash
export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
pnpm tsc --noEmit
pnpm test
cargo check --manifest-path src-tauri/Cargo.toml
cargo test --manifest-path src-tauri/Cargo.toml
```

All green: 1368 frontend tests / 169 files, 541 Rust tests, both typechecks (root + e2e) clean.

Manually, in a repo with `gpg.format=ssh` and `user.signingkey` pointing at a key file: History → a commit's context menu → **Create tag here…**, give it a name and an annotation, check **Sign this tag** → Branches shows a lock on the row and a **Signed** badge in the inspector. `git cat-file tag <name>` shows the signature block; `git tag -v <name>` accepts it. Point `gpg.ssh.program` at a nonexistent binary and the tag is not created at all.

**No e2e run** — no existing spec drives tag creation, and the changed surfaces are covered at the component layer. E2E is serialized centrally.

Closes #132


---

## Review round 1 — applied

All seven `SF-` items and the three `NTH-` items taken. `NTH-3` (fsck dangling noise) and `NTH-6` (checkbox cannot return to indeterminate) skipped as directed.

- **SF-1** — an SSH `Good` line is now refuted by a non-zero exit *plus* `Could not verify signature`, so "no false Good" is a property of the parser rather than of ssh-keygen's output ordering. The legitimate `U` case never carries that line (`No principal matched.` / `Unable to open allowed keys file …`), both spellings now regression-tested.
- **SF-2** — the SSH `Revoked` branch is deleted. A key revoked via `gpg.ssh.revocationFile` emits exactly `Could not verify signature.` and exit 1, so the branch was dead and its fixture was invented. Replaced with a real-output assertion; the comment records the measurement. GPG revocation still comes from `REVKEYSIG`.
- **SF-3** — `create_signed_tag` early-returns on an existing `refs/tags/<name>` before signing. The atomic `force = false` write stays as the real guarantee.
- **SF-4** — `ERRSIG` returns `signer: None`. Its tail is gpg's positional fields, which the badge tooltip was rendering as a name.
- **SF-5** — a tag signed by a key outside `allowedSignersFile` is now `UnknownKey` ("Signed, key unavailable"), not a green **Signed**. **Tags only.** The commit path's identical gap is recorded in the spec's Out-of-scope section for its own issue.
- **SF-6** — `validate_tag_name` refuses a leading `.`.
- **SF-7** — `gpg_status_line` now requires the `[GNUPG:] ` prefix, and there is a new `src-tauri/tests/tag_signing_gpg.rs`.

### The new GPG test file, and what it actually establishes

Hand-written fixtures under-constrain — SF-4 is the proof — so the OpenPGP side gets two layers:

1. **Stubbed `gpg.program`** (needs only `/bin/sh`, so it always runs). Everything but the cryptography is real: our `create_signed_tag` with the real OpenPGP argv, a real tag object, a real `git verify-tag --raw`, the real parser. This is what establishes the two facts the parser rests on and that no unit test can reach — **git relays gpg's status lines with the `[GNUPG:] ` prefix, and writes them to stderr**. Both were verified independently against git 2.50.1 before the tightening landed. Covers `GOODSIG` → Good, `BADSIG` → Bad, `ERRSIG` → UnknownKey with no signer, a failing signer creating no tag, and SF-3's collision check.
2. **Real gpg** against an **ephemeral `GNUPGHOME`** in a temp dir — never the user's keyring — injected through a wrapper script rather than `std::env::set_var`, which is process-global and would race the parallel tests. Covers `Good` end to end plus a tampered payload reading `Bad`, and kills the ephemeral `gpg-agent` on drop.

**gpg is not installed on the machine this ran on, so layer 2 SKIPPED** (with its printed note); layer 1's five tests ran for real. That is the one thing in this PR still unproven locally — it should exercise on any runner with gpg present.

- **NTH-1** — the unsigned annotated path normalizes its message too, so one dialog input cannot produce two different objects depending on whether it was signed.
- **NTH-2** — `openCreateTag`'s doc records that it needs `<CreateTagDialog />` mounted; with none, the promise never settles and `target` stays set. Latent, not live: all three call sites use `void`.
- **NTH-4** — the spec now records the **hybrid route** (resolve config here, refusing `key::` and bare `ssh-…` exactly as commits do, then delegate to `git tag -s -u <key> -F - --cleanup=verbatim`) as a rejected alternative with its reasons. Route (a) stays, but it is chosen for testability and payload purity, not necessity — the binary framing is no longer left on record.
- **NTH-5** (behaviour change worth naming): `action:create-tag` is now **hidden in an empty repository** rather than shown with a "No commit to tag" validation message.

Rebased onto `main` (picks up #134) and the site roadmap line is now moved properly — `'GPG/SSH tag signing …'` off `roadmap`, a signed-tags line onto "Branches & tags", with #134's own entry preserved.

Totals after the round: **549 Rust tests, 1368 frontend tests, all four typechecks clean.**


---

## Rebase onto `3541ef2` (branch compare #131 + branch picker ordering #135)

Four conflicts, all **import-block only** — the substantive regions of all three PRs are disjoint. Every side kept:

- `CLAUDE.md` — both spec/plan entries, ordered #132 then #131.
- `src/design/context-menu.tsx`, `src/screens/Branches.tsx`, `src/features/palette/commands.ts` — both import sets.

**#135's `branchPickStep` invariant verified intact**, not assumed: all 7 call sites still route through the constructor (8 occurrences = 1 definition + 7 calls), and no remaining `kind: "pick"` in the file is a branch picker — the others are remotes, tags, commits, stashes, worktrees, PRs and bisect. My `action:create-tag` is a plain `run:` that opens the dialog and builds no pick step at all, so it never touched that surface.

### One real breakage found, and it was invisible to `cargo check`

#131's new `src-tauri/tests/ref_compare.rs` constructs a `TagTarget` literal; #132 added a `sign` field to that struct. Neither side is wrong — they could not see each other. Fixed in its own commit.

Worth flagging: **`cargo check` does not compile test targets**, so only `cargo test` surfaces this class of conflict. Combined with `.github/workflows/` containing no `cargo test` or `pnpm test` job, a cross-PR break like this currently reaches `main` with nothing red anywhere.

Gate re-run in full on the rebased tree: **571 Rust tests, 1439 frontend tests, all four typechecks clean.** No e2e run.
