### PR TITLE
feat(branches): pin default branch, order the rest by recency (#135)

### DIFF
--- a/docs/superpowers/plans/2026-08-16-branch-picker-order-plan.md
+++ b/docs/superpowers/plans/2026-08-16-branch-picker-order-plan.md
@@ -1,0 +1,121 @@
+# Branch picker order — implementation plan
+
+**Goal:** The default branch pins to the top of every branch list; everything
+else falls in recency order, newest tip first. One backend field pair, one pure
+comparator, three call sites.
+
+**Architecture:** `BranchInfo` grows `tip_time` + `is_default`, filled by
+`Libgit2Backend::branches` from data it already reads plus one detection pass per
+call. The frontend gains `features/branches/orderBranches.ts` — pure, tested —
+adopted by `BranchPicker`, `screens/Branches` and `features/palette/commands`.
+No new `GitBackend` method, no new command, no new IPC surface, no store field.
+
+**Tech Stack:** Rust + git2, React 18 + Zustand, vitest/RTL, WebdriverIO e2e.
+
+**Design doc:** `docs/superpowers/specs/2026-08-16-branch-picker-order-spec.md`
+**Issue:** [#135](https://github.com/jonassaa/platypusgit/issues/135)
+
+## Global Constraints
+
+- `src/lib/types.ts` mirrors `src-tauri/src/git/types.rs` **in the same commit**.
+- `BranchInfo.tip` stays a full oid — do not touch it, do not shorten it.
+- Import UI primitives from `@/design`; use `@/…` path aliases.
+- New list-row surfaces opt into density (`var(--row-step)`). Nothing new here —
+  the picker row already has it; do not regress it.
+- Run pnpm/cargo with `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"`.
+- A concurrent branch (#132, tag signing) is editing `git/types.rs`,
+  `lib/types.ts` and the **tag** rows of `screens/Branches.tsx`. Keep every edit
+  additive and tightly scoped to branch ordering — no reformatting, no reordering
+  of neighbouring declarations.
+- E2E is **not** run from this branch; the orchestrator serializes it centrally.
+
+## File Structure
+
+**Create:**
+- `src/features/branches/orderBranches.ts` — `compareBranches` + `orderBranches`.
+- `src/features/branches/orderBranches.test.ts`
+- `src/features/branches/BranchPicker.test.tsx`
+
+**Modify:**
+- `src-tauri/src/git/types.rs` — two fields on `BranchInfo`.
+- `src-tauri/src/git/libgit2.rs` — `detect_default_branch`, `is_default_branch_name`, and the two new fields in `branches()`.
+- `src-tauri/tests/branches_tags.rs` — detection + `tip_time` coverage.
+- `src/lib/types.ts` — the mirror.
+- `src/features/branches/BranchPicker.tsx` — order the two memos, cursor rule, scroll-into-view.
+- `src/screens/Branches.tsx` — order the `rows` memo within local/remote groups.
+- `src/features/palette/commands.ts` — order inside `branchItems`.
+- Component/unit tests that build a typed `BranchInfo` literal — add the two fields.
+- `e2e/specs/branches.e2e.ts` — the pin assertion.
+
+---
+
+### Task 1: Backend fields + detection
+
+- [ ] `types.rs`: append `tip_time: i64` and `is_default: bool` to `BranchInfo`
+      (append only — the struct is shared with #132's neighbours).
+- [ ] `libgit2.rs`: `fn detect_default_branch(repo: &Repository) -> Option<String>`
+      — `origin` first then other remotes alphabetically, reading
+      `refs/remotes/<remote>/HEAD`'s symbolic target and stripping the
+      `refs/remotes/<remote>/` prefix; then local `main`/`master`/`trunk`; then
+      `None`. Plus `fn is_default_branch_name(name: &str, is_remote: bool,
+      default: Option<&str>) -> bool` — exact match for a local branch,
+      `split_once('/').1` for a remote one.
+- [ ] `branches()`: call detection once before the loop; keep the tip oid in a
+      binding so both `tip` (full string, unchanged) and `tip_time`
+      (`find_commit(oid)?.time().seconds()`, `0` when unresolvable) come off it.
+- [ ] `branches_tags.rs`: `tip_time` reflects the tip's committer time and
+      distinguishes two branches; `origin/HEAD` drives `is_default` on both the
+      local and the `origin/<name>` row; local `main` fallback; `master` when
+      `main` is absent; nothing marked when there is no candidate;
+      `init.defaultBranch` is ignored.
+- [ ] `cargo check` + `cargo test --manifest-path src-tauri/Cargo.toml`.
+
+### Task 2: Mirror the type, unblock the frontend
+
+- [ ] `lib/types.ts`: `tipTime: number; isDefault: boolean;` on `BranchInfo`.
+- [ ] `pnpm tsc --noEmit` — every typed `BranchInfo` literal in the test suite
+      now errors; that list *is* the mirror's blast radius. Add the two fields to
+      each, nothing else.
+
+### Task 3: The comparator
+
+- [ ] `orderBranches.test.ts` first: default first regardless of `tipTime`;
+      recency descending; ASCII name tiebreak on equal `tipTime`; a defaultless
+      list is a pure recency sort; the input array is not mutated; the output is
+      a permutation of the input (same multiset of names) — the §D guarantee that
+      the pin cannot resurrect a filtered-out row.
+- [ ] `orderBranches.ts`: `compareBranches` + a generic `orderBranches` that
+      copies before sorting.
+- [ ] `pnpm test`.
+
+### Task 4: The three surfaces
+
+- [ ] `BranchPicker.tsx`: wrap both memos' results in `orderBranches` (after the
+      filter, never before).
+- [ ] `screens/Branches.tsx`: in the `rows` memo, order each kind separately and
+      keep locals before remotes in the `all` view.
+- [ ] `commands.ts`: `branchItems` orders after applying its optional `filter`.
+- [ ] `pnpm tsc --noEmit` + `pnpm test`.
+
+### Task 5: Cursor rule + scroll-into-view (design §E)
+
+- [ ] `BranchPicker.test.tsx` first: rows come out default-first then by recency;
+      a query excluding the default does not bring it back; the cursor starts on
+      the HEAD row with an empty query; typing moves it to row 0.
+- [ ] `BranchPicker.tsx`: derive the resting index (`query === "" ? index of the
+      local HEAD row : 0`, fallback 0) and apply it on open and on every query
+      change; scroll the active row into view with `block: "nearest"` when
+      `activeIndex` changes.
+- [ ] `pnpm test`.
+
+### Task 6: E2E spec + full verification
+
+- [ ] `branches.e2e.ts`: in the `manyRefsRepo` describe, open the branch chip and
+      assert the first `[data-branch-row]` reads `main` — 60 `feature/branch-NN`
+      branches share one tip, so without the pin `feature/branch-00` would be
+      first and `main` sixtieth. Every wait carries `timeout` + `timeoutMsg`.
+- [ ] `pnpm exec tsc -p e2e/tsconfig.json --noEmit`.
+- [ ] `pnpm tsc --noEmit`, `pnpm test`, `cargo check`, `cargo test`.
+- [ ] **Not run here:** `pnpm test:e2e:docker`. Only one e2e container build may
+      run at a time across all worktrees; the orchestrator runs it centrally.
+- [ ] Conventional commits, push, draft PR against #135.

--- a/docs/superpowers/plans/2026-08-16-branch-picker-order-plan.md
+++ b/docs/superpowers/plans/2026-08-16-branch-picker-order-plan.md
@@ -51,71 +51,71 @@ No new `GitBackend` method, no new command, no new IPC surface, no store field.
 
 ### Task 1: Backend fields + detection
 
-- [ ] `types.rs`: append `tip_time: i64` and `is_default: bool` to `BranchInfo`
+- [x] `types.rs`: append `tip_time: i64` and `is_default: bool` to `BranchInfo`
       (append only — the struct is shared with #132's neighbours).
-- [ ] `libgit2.rs`: `fn detect_default_branch(repo: &Repository) -> Option<String>`
+- [x] `libgit2.rs`: `fn detect_default_branch(repo: &Repository) -> Option<String>`
       — `origin` first then other remotes alphabetically, reading
       `refs/remotes/<remote>/HEAD`'s symbolic target and stripping the
       `refs/remotes/<remote>/` prefix; then local `main`/`master`/`trunk`; then
       `None`. Plus `fn is_default_branch_name(name: &str, is_remote: bool,
       default: Option<&str>) -> bool` — exact match for a local branch,
       `split_once('/').1` for a remote one.
-- [ ] `branches()`: call detection once before the loop; keep the tip oid in a
+- [x] `branches()`: call detection once before the loop; keep the tip oid in a
       binding so both `tip` (full string, unchanged) and `tip_time`
       (`find_commit(oid)?.time().seconds()`, `0` when unresolvable) come off it.
-- [ ] `branches_tags.rs`: `tip_time` reflects the tip's committer time and
+- [x] `branches_tags.rs`: `tip_time` reflects the tip's committer time and
       distinguishes two branches; `origin/HEAD` drives `is_default` on both the
       local and the `origin/<name>` row; local `main` fallback; `master` when
       `main` is absent; nothing marked when there is no candidate;
       `init.defaultBranch` is ignored.
-- [ ] `cargo check` + `cargo test --manifest-path src-tauri/Cargo.toml`.
+- [x] `cargo check` + `cargo test --manifest-path src-tauri/Cargo.toml`.
 
 ### Task 2: Mirror the type, unblock the frontend
 
-- [ ] `lib/types.ts`: `tipTime: number; isDefault: boolean;` on `BranchInfo`.
-- [ ] `pnpm tsc --noEmit` — every typed `BranchInfo` literal in the test suite
+- [x] `lib/types.ts`: `tipTime: number; isDefault: boolean;` on `BranchInfo`.
+- [x] `pnpm tsc --noEmit` — every typed `BranchInfo` literal in the test suite
       now errors; that list *is* the mirror's blast radius. Add the two fields to
       each, nothing else.
 
 ### Task 3: The comparator
 
-- [ ] `orderBranches.test.ts` first: default first regardless of `tipTime`;
+- [x] `orderBranches.test.ts` first: default first regardless of `tipTime`;
       recency descending; ASCII name tiebreak on equal `tipTime`; a defaultless
       list is a pure recency sort; the input array is not mutated; the output is
       a permutation of the input (same multiset of names) — the §D guarantee that
       the pin cannot resurrect a filtered-out row.
-- [ ] `orderBranches.ts`: `compareBranches` + a generic `orderBranches` that
+- [x] `orderBranches.ts`: `compareBranches` + a generic `orderBranches` that
       copies before sorting.
-- [ ] `pnpm test`.
+- [x] `pnpm test`.
 
 ### Task 4: The three surfaces
 
-- [ ] `BranchPicker.tsx`: wrap both memos' results in `orderBranches` (after the
+- [x] `BranchPicker.tsx`: wrap both memos' results in `orderBranches` (after the
       filter, never before).
-- [ ] `screens/Branches.tsx`: in the `rows` memo, order each kind separately and
+- [x] `screens/Branches.tsx`: in the `rows` memo, order each kind separately and
       keep locals before remotes in the `all` view.
-- [ ] `commands.ts`: `branchItems` orders after applying its optional `filter`.
-- [ ] `pnpm tsc --noEmit` + `pnpm test`.
+- [x] `commands.ts`: `branchItems` orders after applying its optional `filter`.
+- [x] `pnpm tsc --noEmit` + `pnpm test`.
 
 ### Task 5: Cursor rule + scroll-into-view (design §E)
 
-- [ ] `BranchPicker.test.tsx` first: rows come out default-first then by recency;
+- [x] `BranchPicker.test.tsx` first: rows come out default-first then by recency;
       a query excluding the default does not bring it back; the cursor starts on
       the HEAD row with an empty query; typing moves it to row 0.
-- [ ] `BranchPicker.tsx`: derive the resting index (`query === "" ? index of the
+- [x] `BranchPicker.tsx`: derive the resting index (`query === "" ? index of the
       local HEAD row : 0`, fallback 0) and apply it on open and on every query
       change; scroll the active row into view with `block: "nearest"` when
       `activeIndex` changes.
-- [ ] `pnpm test`.
+- [x] `pnpm test`.
 
 ### Task 6: E2E spec + full verification
 
-- [ ] `branches.e2e.ts`: in the `manyRefsRepo` describe, open the branch chip and
+- [x] `branches.e2e.ts`: in the `manyRefsRepo` describe, open the branch chip and
       assert the first `[data-branch-row]` reads `main` — 60 `feature/branch-NN`
       branches share one tip, so without the pin `feature/branch-00` would be
       first and `main` sixtieth. Every wait carries `timeout` + `timeoutMsg`.
-- [ ] `pnpm exec tsc -p e2e/tsconfig.json --noEmit`.
-- [ ] `pnpm tsc --noEmit`, `pnpm test`, `cargo check`, `cargo test`.
+- [x] `pnpm exec tsc -p e2e/tsconfig.json --noEmit`.
+- [x] `pnpm tsc --noEmit`, `pnpm test`, `cargo check`, `cargo test`.
 - [ ] **Not run here:** `pnpm test:e2e:docker`. Only one e2e container build may
       run at a time across all worktrees; the orchestrator runs it centrally.
-- [ ] Conventional commits, push, draft PR against #135.
+- [x] Conventional commits, push, draft PR against #135.

--- a/docs/superpowers/specs/2026-08-16-branch-picker-order-spec.md
+++ b/docs/superpowers/specs/2026-08-16-branch-picker-order-spec.md
@@ -77,15 +77,19 @@ set per row:
   slash is correct because git forbids `/` in a remote name while allowing it in
   a branch name, so `origin/feature/x` splits as `origin` + `feature/x`.
 
-Two consequences, both accepted:
+Two consequences:
 
 - With two remotes, `origin/main` **and** `upstream/main` are both flagged. They
   are both "the default branch, on a remote", they sit adjacent at the top of one
   section, and their relative order falls through to the ordinary rules. Carrying
   a per-remote default to avoid this would add a field nothing else wants.
-- A stale `origin/HEAD` pointing at a deleted branch names something no row
-  matches, so nothing is pinned. That degrades to case 3 with no error, which is
-  why detection deliberately does **not** verify the branch exists.
+- **A remote's `HEAD` is accepted only when the ref it names still exists.**
+  `git fetch --prune` does not rewrite the symref, so a repository cloned when
+  the default was `master` keeps pointing at `refs/remotes/origin/master` forever
+  after upstream renames it. Taking that name on trust would suppress case 2 as
+  well — the perfectly good local `main` would never be considered and nothing
+  would be pinned again, permanently and silently. A dangling symref therefore
+  falls **through** to the next remote and then to the local candidates.
 
 ### C. One pure comparator, three surfaces
 
@@ -115,9 +119,20 @@ Adopted by all three surfaces, so a second ordering cannot grow:
 | `screens/Branches.tsx` | the `rows` memo — local and remote ordered **within** their groups, locals still before remotes in the `all` view |
 | `features/palette/commands.ts` | `branchItems`, after the optional `filter` |
 
-The palette's root step re-scores rows by fuzzy match + frecency, but `Array#sort`
-is stable, so with an empty query — where every candidate ties — the order
-`branchItems` produced is the order shown.
+`orderBranchesGrouped` is the second export, for a surface that renders ONE
+undivided list: it orders locals and remotes separately and concatenates. The
+picker gets that grouping from its two labelled sections and the Branches screen
+from its view split; the palette's pick steps have neither, and without it `main`
+and `origin/main` (both `isDefault`) take rows 1-2 and everything below
+interleaves by tip time.
+
+**The pin is honoured in three places, and the palette's ROOT step is not one of
+them.** `CommandPalette` adds `frecencyScore(...)` to every candidate regardless
+of query and bumps frecency on every pick, so as soon as the user has picked any
+branch from the palette that branch outranks the pinned default there — sort
+stability is irrelevant. That is correct: the root step is a relevance ranking
+over four result types, not a branch list. The pick steps, the picker and the
+Branches screen are where the ordering is a contract.
 
 `RebaseBasePicker` is deliberately left alone. It builds a mixed
 branch/commit/freeform row list under its own relevance rules and is not one of
@@ -159,6 +174,34 @@ are plainly mapped, not windowed, so the DOM route is sound here — the
 `scrollTopForRow` rule applies to the windowed diff surfaces, not to this list.
 This also makes ArrowDown past the visible area work, which it never did.
 
+The rule re-runs as the row list changes, not only on open, because the popover
+can be opened before `list_branches` resolves; a flag records whether the user
+has aimed the cursor themselves (arrows or hover) so re-running never yanks it
+out from under them.
+
+**The same argument applies to the other two surfaces, and moving a plausible
+destructive target to row 0 is what makes it their problem too.**
+
+- **The Branches screen had a phantom selection.** `flatIndex` clamped
+  `findIndex` to 0 while `selection` starts `null`, so `usePaneList` was told row
+  0 was selected with NO row rendered as highlighted — and `branches.list` is the
+  screen's primary pane, so entering the screen focuses it. Enter checked out row
+  0. `flatIndex` now stays `-1`: arrowing either way lands on row 0, and
+  `onActivate(-1)` reads past the end of the list and no-ops.
+- **The palette's branch pick steps preselected row 0.** `activeIndex` resets to
+  0 on every `pushStep`, so "⌘P, delete branch, Enter, Enter" reached
+  `deleteBranch("main")` — and `delete_branch` refuses only *unmerged* branches,
+  so the default branch (an ancestor of HEAD) deleted, unconfirmed and
+  irreversible short of the reflog. A `pick` step may now declare
+  `cursor: "none"`, which rests on nothing while its query is empty; all five
+  branch steps use it. Typing still moves the cursor to the top match, on the
+  same reasoning as the picker.
+- **Deleting a branch from the palette now confirms.** It was the only delete
+  path without a `pgConfirm` — the row menu and the Branches inspector both had
+  one. Pinning a plausible branch at row 0 is what turned that from an oversight
+  into a hazard, and CLAUDE.md mandates the confirm for destructive ops
+  regardless.
+
 ### F. HEAD does not pin
 
 The current branch stays in recency order. It is already accent-coloured and
@@ -175,14 +218,24 @@ comparator whose value is that it has one.
   `origin/HEAD`'s symbolic target, including onto `origin/<name>`; falls back to
   local `main`/`master`; `master` wins over a non-existent `main`; no default
   when none of the three exist and there is no remote HEAD; `init.defaultBranch`
-  set to something else changes nothing.
+  set to something else changes nothing; a **stale** `origin/HEAD` falls through
+  to the local candidate, and pins nothing when there is none.
 - **Frontend unit** (`orderBranches.test.ts`): default first; recency descending;
   name tiebreak on equal `tipTime`; input is not mutated; a list without a
   default is a pure recency sort; the output is a permutation of the input (the
-  §D guarantee).
+  §D guarantee); `orderBranchesGrouped` keeps every local ahead of every remote.
+  `commands.test.ts` asserts `branchItems`' order directly — it is pure, unlike
+  the rendered palette, whose frecency scoring makes it fragile to pin.
 - **Component** (`BranchPicker.test.tsx`): rows render default-first then by
   recency; a query that excludes the default does not resurrect it; the cursor
-  starts on the HEAD row with an empty query and on row 0 once a query is typed.
+  starts on the HEAD row with an empty query and on row 0 once a query is typed;
+  a branch list that arrives AFTER the popover opened still re-parks the cursor
+  on HEAD, and one the user has aimed is left alone.
+  `Branches.activate.test.tsx`: Enter with nothing selected checks nothing out,
+  and still checks out once a row is genuinely selected.
+  `CommandPalette.branchStep.test.tsx`: the Delete step rests on no row, so the
+  Enter that opened it cannot fire row 0; aiming a row then confirms before
+  deleting. All four fail on the pre-fix code.
 - **E2E** (`branches.e2e.ts`): with `manyRefsRepo` (60 `feature/branch-NN`
   branches created from one commit, plus `main`) the first `[data-branch-row]` in
   the picker is `main` — which without the pin would be `feature/branch-00`,

--- a/docs/superpowers/specs/2026-08-16-branch-picker-order-spec.md
+++ b/docs/superpowers/specs/2026-08-16-branch-picker-order-spec.md
@@ -1,0 +1,203 @@
+# Branch picker: pin the default branch, order the rest by recency
+
+**Issue:** [#135](https://github.com/jonassaa/platypusgit/issues/135)
+
+## Problem
+
+Branch lists are unordered. `Libgit2Backend::branches` (`libgit2.rs:3322`) iterates
+`repo.branches(None)` and pushes, so the frontend receives git's ref-iteration
+order — refname order, i.e. alphabetical. Nothing downstream sorts:
+`BranchPicker.tsx:47-60` filters in place, `screens/Branches.tsx:129` filters and
+splits by view, `features/palette/commands.ts:66-72` maps straight to rows.
+
+Consequences in any repo with more than a handful of branches:
+
+- `chore/bump-deps` sits above `main`. The one branch most switches return to is
+  wherever the alphabet put it.
+- A branch touched five minutes ago sits below one abandoned last year, with no
+  signal separating them.
+- The popover preselects row 0 and Enter checks it out (`BranchPicker.tsx:30`,
+  `:127`), so the alphabetically-first branch is one keystroke from being checked
+  out by accident.
+
+`BranchInfo` carries nothing time-shaped and nothing default-shaped, so neither
+ordering can be derived on the frontend. `default_branch_name()`
+(`libgit2.rs:1930`) is not the missing helper — it reads the **global**
+`init.defaultBranch` config to prefill the Init dialog and says nothing about the
+repository actually open.
+
+## Design
+
+### A. Two new `BranchInfo` fields
+
+```rust
+pub struct BranchInfo {
+    // …existing…
+    pub tip_time: i64,      // committer time of the tip, seconds since epoch
+    pub is_default: bool,   // this ref is the repository's default branch
+}
+```
+
+Mirrored as `tipTime: number` / `isDefault: boolean` in `src/lib/types.ts` in the
+same commit (the 1:1 contract). Both are **required**, not optional: the backend
+always emits them, and an optional field would let a `?? 0` creep into the
+comparator and hide a missing value as "very old".
+
+`tip_time` costs one `find_commit` per branch off the oid the loop already reads
+(`libgit2.rs:3344`), the same cost class as the `graph_ahead_behind` call already
+made per local branch. An unresolvable tip (unborn or broken ref — `tip` is
+already `Option<String>` for exactly that case) yields `0`, which sorts last.
+
+`tip` itself is untouched. It is a **full** oid and must stay one; nothing here
+reads or shortens it.
+
+### B. Default-branch detection
+
+A free function in `libgit2.rs`, run once per `branches()` call, in the issue's
+stated priority order:
+
+1. **`refs/remotes/<remote>/HEAD`'s symbolic target.** Git's own answer, written
+   by `git clone` and `git remote set-head`. `refs/remotes/origin/HEAD` →
+   `refs/remotes/origin/main` → `main`. Remotes are tried `origin` first, then
+   the rest alphabetically, so a repo with two remotes answers deterministically.
+   A non-symbolic `…/HEAD` (some setups pin it to an oid) names no branch and is
+   skipped.
+2. **The first of `main`, `master`, `trunk` that exists as a local branch.**
+3. **None** — nothing is pinned and the list is pure recency.
+
+Explicitly **not** `init.defaultBranch`: it describes branches that do not exist
+yet and would name `main` in a repo whose default is `master`.
+
+The result is a short **branch** name (`main`), not a ref. `is_default` is then
+set per row:
+
+- a local branch, when `name == default`;
+- a remote branch, when the part after the first `/` equals `default` —
+  `origin/main` pins at the top of the Remote section. Splitting on the first
+  slash is correct because git forbids `/` in a remote name while allowing it in
+  a branch name, so `origin/feature/x` splits as `origin` + `feature/x`.
+
+Two consequences, both accepted:
+
+- With two remotes, `origin/main` **and** `upstream/main` are both flagged. They
+  are both "the default branch, on a remote", they sit adjacent at the top of one
+  section, and their relative order falls through to the ordinary rules. Carrying
+  a per-remote default to avoid this would add a field nothing else wants.
+- A stale `origin/HEAD` pointing at a deleted branch names something no row
+  matches, so nothing is pinned. That degrades to case 3 with no error, which is
+  why detection deliberately does **not** verify the branch exists.
+
+### C. One pure comparator, three surfaces
+
+`src/features/branches/orderBranches.ts` — pure, unit-tested, in the style of
+`graphLayout` / `buildRebasePlan`:
+
+```ts
+export function compareBranches(a: BranchInfo, b: BranchInfo): number;
+export function orderBranches<T extends BranchInfo>(rows: readonly T[]): T[];
+```
+
+Order: **default first**, then `tipTime` **descending**, then `name` ascending as
+the tiebreaker. The tiebreaker uses plain `<`/`>` rather than `localeCompare`, so
+the result does not depend on the runtime's ICU data — several branches created
+from one commit (`git branch x`, the `manyRefsRepo` fixture) all share a
+`tipTime` and would otherwise order differently on different machines.
+
+`orderBranches` is generic over `T extends BranchInfo` so the picker's
+`Row = BranchInfo & { kind }` survives the call, and it copies before sorting —
+`useRepoStore.branches` is store state and must not be sorted in place.
+
+Adopted by all three surfaces, so a second ordering cannot grow:
+
+| Surface | Where |
+| --- | --- |
+| `BranchPicker.tsx` | inside the existing `local` / `remote` `useMemo`s, after the filter |
+| `screens/Branches.tsx` | the `rows` memo — local and remote ordered **within** their groups, locals still before remotes in the `all` view |
+| `features/palette/commands.ts` | `branchItems`, after the optional `filter` |
+
+The palette's root step re-scores rows by fuzzy match + frecency, but `Array#sort`
+is stable, so with an empty query — where every candidate ties — the order
+`branchItems` produced is the order shown.
+
+`RebaseBasePicker` is deliberately left alone. It builds a mixed
+branch/commit/freeform row list under its own relevance rules and is not one of
+the three surfaces the issue names; adopting the comparator there is a separate,
+larger question about how branches and commits interleave.
+
+### D. Ordering never resurrects a filtered-out row
+
+Every call site filters **first** and orders **second**, and `orderBranches` is a
+permutation: same length, same elements, no defaulting and no injection. So a
+query that does not match the default branch simply does not show it — the pin
+reorders what search already chose, it does not override search. Unit-tested
+directly (`orderBranches` of a list with no default returns exactly its input
+names) and at the picker level.
+
+### E. Where the cursor starts
+
+`activeIndex` starts at 0 today, so Enter checks out whatever sorts first. After
+this change that would be the default branch — a *sharper* accident than the
+alphabetical first row, because `main` is a plausible destination and the
+mistaken checkout would look intentional.
+
+**The cursor rests on the current branch while the query is empty**, falling back
+to row 0 when no row is HEAD (detached HEAD, or a filtered list). Reason:
+`checkout()` already early-returns for the HEAD row (`BranchPicker.tsx:106`), so
+opening the popover and pressing Enter does **nothing**. That is the only
+starting position where the accidental keystroke has no effect at all. First row
+and first-non-HEAD row both check something out.
+
+Once a query is typed the cursor moves to row 0, because after typing the top
+match *is* what the user is aiming at. This also fixes a latent bug: today
+`activeIndex` survives a query change and is only clamped to the new length, so
+typing while the cursor sits on row 3 leaves it pointing at an unrelated row.
+
+Resting the cursor on HEAD means it can start below the fold in a long list, so
+the active row is scrolled into view when `activeIndex` changes
+(`scrollIntoView({ block: "nearest" })` on the row element). The picker's rows
+are plainly mapped, not windowed, so the DOM route is sound here — the
+`scrollTopForRow` rule applies to the windowed diff surfaces, not to this list.
+This also makes ArrowDown past the visible area work, which it never did.
+
+### F. HEAD does not pin
+
+The current branch stays in recency order. It is already accent-coloured and
+badged `HEAD` (`BranchPicker.tsx:192`), it is the one branch the picker exists to
+*leave*, and under committer-time ordering it is usually near the top anyway
+because it is what you just committed to. Pinning it second would push the actual
+default down for no navigational gain and add a second special case to a
+comparator whose value is that it has one.
+
+## Testing
+
+- **Rust** (`src-tauri/tests/branches_tags.rs`): `tip_time` is the tip's
+  committer time and orders two branches correctly; `is_default` follows
+  `origin/HEAD`'s symbolic target, including onto `origin/<name>`; falls back to
+  local `main`/`master`; `master` wins over a non-existent `main`; no default
+  when none of the three exist and there is no remote HEAD; `init.defaultBranch`
+  set to something else changes nothing.
+- **Frontend unit** (`orderBranches.test.ts`): default first; recency descending;
+  name tiebreak on equal `tipTime`; input is not mutated; a list without a
+  default is a pure recency sort; the output is a permutation of the input (the
+  §D guarantee).
+- **Component** (`BranchPicker.test.tsx`): rows render default-first then by
+  recency; a query that excludes the default does not resurrect it; the cursor
+  starts on the HEAD row with an empty query and on row 0 once a query is typed.
+- **E2E** (`branches.e2e.ts`): with `manyRefsRepo` (60 `feature/branch-NN`
+  branches created from one commit, plus `main`) the first `[data-branch-row]` in
+  the picker is `main` — which without the pin would be `feature/branch-00`,
+  sixty rows above it.
+
+## Out of scope
+
+- **Reflog-based "last checked out" recency.** It models "branches I'm working
+  on" better, but it degrades to one entry on a fresh clone where everything else
+  ties, and remote-tracking refs have no useful reflog at all. Committer time is
+  what `git branch --sort=-committerdate` means and what every other client shows.
+  A blend (reflog order first, committer time for the rest) is a possible
+  follow-up.
+- Grouping, foldering, or a "recent branches" section.
+- A user-configurable sort order.
+- `RebaseBasePicker`'s row order (see §C).
+- Marking the default branch visually. This is ordering only; the issue is
+  explicit that HEAD's existing badge is the only ref decoration in play.

--- a/docs/superpowers/specs/2026-08-16-branch-picker-order-spec.md
+++ b/docs/superpowers/specs/2026-08-16-branch-picker-order-spec.md
@@ -193,9 +193,15 @@ destructive target to row 0 is what makes it their problem too.**
   `deleteBranch("main")` — and `delete_branch` refuses only *unmerged* branches,
   so the default branch (an ancestor of HEAD) deleted, unconfirmed and
   irreversible short of the reflog. A `pick` step may now declare
-  `cursor: "none"`, which rests on nothing while its query is empty; all five
-  branch steps use it. Typing still moves the cursor to the top match, on the
-  same reasoning as the picker.
+  `cursor: "none"`, which rests on nothing while its query is empty. Typing still
+  moves the cursor to the top match, on the same reasoning as the picker.
+
+  **The flag is set in exactly one place**, `branchPickStep` — the constructor
+  every branch step in the catalog is built from (seven of them, including
+  #131's two compare steps). Enumerating `cursor: "none"` at each call site
+  would leave the rule to be remembered by whoever adds the eighth; a
+  constructor makes the natural way to write one correct. `branchItems` stays
+  exported for the ROOT step, which builds candidates rather than a step.
 - **Deleting a branch from the palette now confirms.** It was the only delete
   path without a `pgConfirm` — the row menu and the Branches inspector both had
   one. Pinning a plausible branch at row 0 is what turned that from an oversight

--- a/e2e/specs/branches.e2e.ts
+++ b/e2e/specs/branches.e2e.ts
@@ -1,4 +1,4 @@
-import { browser, $, expect } from "@wdio/globals";
+import { browser, $, $$, expect } from "@wdio/globals";
 import { basicRepo, manyRefsRepo, TempRepo } from "../support/tempRepo";
 import { openRepo, resetApp, switchScreen } from "../support/app";
 
@@ -120,5 +120,43 @@ describe("branches — many refs layout", () => {
 
     // Toolbar survives — filter input still visible at the top.
     await expect($('input[placeholder="Filter by name…"]')).toBeDisplayed();
+  });
+
+  // #135: the default branch pins to the top of the picker. This fixture is the
+  // sharpest case for it — all 61 branches were cut from one commit, so they
+  // tie on tip time and fall back to name order, which puts `feature/branch-00`
+  // first and `main` sixty rows below the fold.
+  it("pins the default branch to the top of the branch picker", async () => {
+    const chip = $('[data-testid="branch-chip"]');
+    await chip.waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "branch chip never appeared",
+    });
+    await chip.click();
+
+    await $('input[placeholder="Switch to branch…"]').waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg: "branch search input never appeared",
+    });
+
+    // The store's branch fetch resolves after the popover mounts; wait for the
+    // full set rather than asserting against a partial list.
+    await browser.waitUntil(
+      async () => [...(await $$("[data-branch-row]"))].length > 60,
+      {
+        timeout: 20_000,
+        timeoutMsg: "picker never listed every branch",
+      },
+    );
+
+    // Read the name span directly: the row also renders a `HEAD` badge, and
+    // getText() joins the two differently across webviews.
+    const firstRow = await browser.execute(
+      () =>
+        document.querySelector("[data-branch-row]")?.querySelector("span")
+          ?.textContent ?? null,
+    );
+
+    expect(firstRow).toBe("main");
   });
 });

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -1971,6 +1971,79 @@ pub fn default_branch_name() -> String {
         .unwrap_or_else(|| "main".to_string())
 }
 
+/// Local branch names tried, in order, when no remote tells us what the
+/// default is.
+const DEFAULT_BRANCH_CANDIDATES: [&str; 3] = ["main", "master", "trunk"];
+
+/// The default branch of an OPEN repository, as a short branch name (`main`),
+/// or `None` when nothing answers.
+///
+/// Priority, per the #135 spec:
+///
+/// 1. `refs/remotes/<remote>/HEAD`'s symbolic target — git's own answer, set by
+///    `git clone` and `git remote set-head`. `origin` is tried first, then the
+///    remaining remotes alphabetically, so a repo with several answers
+///    deterministically. A non-symbolic `…/HEAD` names no branch and is skipped.
+/// 2. The first of `main`, `master`, `trunk` that exists as a local branch.
+/// 3. Nothing.
+///
+/// Deliberately NOT `init.defaultBranch` (see `default_branch_name` above):
+/// that describes branches which do not exist yet and would name `main` in a
+/// repository whose default is `master`.
+///
+/// The name is deliberately NOT verified to exist. A stale `origin/HEAD`
+/// pointing at a deleted branch then matches no row, which degrades to case 3
+/// with no error rather than failing the whole listing.
+pub fn detect_default_branch(repo: &Repository) -> Option<String> {
+    let mut remotes: Vec<String> = match repo.remotes() {
+        Ok(list) => list.iter().flatten().map(String::from).collect(),
+        Err(_) => Vec::new(),
+    };
+    // `false` sorts before `true`, so `origin` leads and the rest follow
+    // alphabetically.
+    remotes.sort_by(|a, b| (a != "origin", a).cmp(&(b != "origin", b)));
+
+    for remote in &remotes {
+        let prefix = format!("refs/remotes/{remote}/");
+        let head_ref = format!("{prefix}HEAD");
+        let Ok(reference) = repo.find_reference(&head_ref) else {
+            continue;
+        };
+        let Some(target) = reference.symbolic_target() else {
+            continue;
+        };
+        if let Some(name) = target.strip_prefix(&prefix) {
+            if !name.is_empty() && name != "HEAD" {
+                return Some(name.to_string());
+            }
+        }
+    }
+
+    DEFAULT_BRANCH_CANDIDATES
+        .iter()
+        .find(|name| repo.find_branch(name, BranchType::Local).is_ok())
+        .map(|name| (*name).to_string())
+}
+
+/// Does this branch row carry the repository's default branch?
+///
+/// A local branch matches by name. A remote branch matches on the part after
+/// the FIRST `/`: git forbids `/` in a remote name but allows it in a branch
+/// name, so `origin/feature/x` splits as `origin` + `feature/x`. With two
+/// remotes both `origin/main` and `upstream/main` match — they are both "the
+/// default branch, on a remote", and they sit adjacent at the top of the same
+/// section.
+fn is_default_branch_name(name: &str, is_remote: bool, default: Option<&str>) -> bool {
+    let Some(default) = default else {
+        return false;
+    };
+    if is_remote {
+        name.split_once('/').map(|(_, rest)| rest) == Some(default)
+    } else {
+        name == default
+    }
+}
+
 impl GitBackend for Libgit2Backend {
     fn open(&self, path: &Path) -> AppResult<RepoHandle> {
         if !path.exists() {
@@ -3500,6 +3573,9 @@ impl GitBackend for Libgit2Backend {
             let head_ref = repo.head().ok();
             let head_name = head_ref.as_ref().and_then(|r| r.shorthand()).map(String::from);
 
+            // Detected once per listing, not per branch: it walks the remotes.
+            let default_branch = detect_default_branch(repo);
+
             let mut out = Vec::new();
             let branches = repo.branches(None)?;
             for b in branches {
@@ -3517,7 +3593,16 @@ impl GitBackend for Libgit2Backend {
                 // truncated value silently never matches — no error, just a
                 // feature that quietly does nothing. Display sites shorten it
                 // themselves via `shortSha`.
-                let tip = branch.get().target().map(|o| o.to_string());
+                let tip_oid = branch.get().target();
+                let tip = tip_oid.map(|o| o.to_string());
+                // Recency for the frontend's ordering (#135). One `find_commit`
+                // off the oid just read — same cost class as the
+                // `graph_ahead_behind` below. An unresolvable tip yields 0,
+                // which sorts last under newest-first.
+                let tip_time = tip_oid
+                    .and_then(|o| repo.find_commit(o).ok())
+                    .map(|c| c.time().seconds())
+                    .unwrap_or(0);
 
                 let (upstream, ahead, behind) = if !is_remote {
                     match branch.upstream() {
@@ -3537,6 +3622,9 @@ impl GitBackend for Libgit2Backend {
                     (None, 0, 0)
                 };
 
+                let is_default =
+                    is_default_branch_name(&name, is_remote, default_branch.as_deref());
+
                 out.push(BranchInfo {
                     name,
                     is_head,
@@ -3545,6 +3633,8 @@ impl GitBackend for Libgit2Backend {
                     ahead,
                     behind,
                     tip,
+                    tip_time,
+                    is_default,
                 });
             }
             Ok(out)

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -1991,9 +1991,12 @@ const DEFAULT_BRANCH_CANDIDATES: [&str; 3] = ["main", "master", "trunk"];
 /// that describes branches which do not exist yet and would name `main` in a
 /// repository whose default is `master`.
 ///
-/// The name is deliberately NOT verified to exist. A stale `origin/HEAD`
-/// pointing at a deleted branch then matches no row, which degrades to case 3
-/// with no error rather than failing the whole listing.
+/// A remote's `HEAD` is only ACCEPTED when the ref it names still exists.
+/// `git fetch --prune` does not rewrite the symref, so a repository cloned when
+/// the default was `master` keeps pointing at `refs/remotes/origin/master`
+/// forever after upstream renames it — and taking that name on trust would
+/// suppress case 2 as well, leaving a perfectly good local `main` unpinned with
+/// nothing to explain why.
 pub fn detect_default_branch(repo: &Repository) -> Option<String> {
     let mut remotes: Vec<String> = match repo.remotes() {
         Ok(list) => list.iter().flatten().map(String::from).collect(),
@@ -2013,7 +2016,9 @@ pub fn detect_default_branch(repo: &Repository) -> Option<String> {
             continue;
         };
         if let Some(name) = target.strip_prefix(&prefix) {
-            if !name.is_empty() && name != "HEAD" {
+            // A dangling symref answers nothing. Fall through to the next
+            // remote and then to the local candidates.
+            if !name.is_empty() && name != "HEAD" && repo.find_reference(target).is_ok() {
                 return Some(name.to_string());
             }
         }

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -198,6 +198,13 @@ pub struct BranchInfo {
     pub ahead: usize,
     pub behind: usize,
     pub tip: Option<String>,
+    /// Committer time of the tip commit, seconds since the epoch. `0` when the
+    /// tip cannot be resolved (unborn or broken ref) — which sorts last under
+    /// the frontend's newest-first ordering.
+    pub tip_time: i64,
+    /// Is this ref the repository's default branch (or a remote's copy of it)?
+    /// See `libgit2::detect_default_branch` for how that is decided.
+    pub is_default: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src-tauri/tests/branches_tags.rs
+++ b/src-tauri/tests/branches_tags.rs
@@ -334,3 +334,191 @@ fn branch_tip_is_the_full_oid() {
     assert_eq!(head.tip.as_deref(), Some(head_oid.as_str()));
     assert_eq!(head_oid.len(), 40, "fixture sanity: oids are 40 chars");
 }
+
+// ---------------------------------------------------------------------------
+// Ordering data: `tip_time` + `is_default` (#135)
+//
+// The frontend sorts branch lists default-first then newest-tip-first, so both
+// fields are the only inputs to that ordering — they cannot be derived from
+// anything else `BranchInfo` carries.
+// ---------------------------------------------------------------------------
+
+/// `origin` with the given extra branches fetched, plus a symbolic
+/// `refs/remotes/origin/HEAD` pointing at `head` — what `git clone` and
+/// `git remote set-head` leave behind, which libgit2's own fetch does not.
+fn with_origin_head(extra: &[&str], head: &str) -> (TempRepo, TempRepo) {
+    let upstream = TempRepo::with_initial_commit("hello\n");
+    {
+        let tip = upstream.repo.head().unwrap().peel_to_commit().unwrap();
+        for name in extra {
+            upstream.repo.branch(name, &tip, false).unwrap();
+        }
+    }
+    let local = TempRepo::with_initial_commit("hello\n");
+    local
+        .repo
+        .remote("origin", upstream.path().to_str().unwrap())
+        .unwrap();
+    {
+        let mut remote = local.repo.find_remote("origin").unwrap();
+        remote
+            .fetch(&["refs/heads/*:refs/remotes/origin/*"], None, None)
+            .unwrap();
+    }
+    local
+        .repo
+        .reference_symbolic(
+            "refs/remotes/origin/HEAD",
+            &format!("refs/remotes/origin/{head}"),
+            true,
+            "test fixture",
+        )
+        .unwrap();
+    (local, upstream)
+}
+
+/// Move HEAD onto `keep` and delete `main`, so the `main`/`master`/`trunk`
+/// fallback has to look past its first candidate.
+fn without_main(tr: &TempRepo, keep: &str) {
+    let (backend, handle) = tr.open_with_backend();
+    let tip = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    tr.repo.branch(keep, &tip, false).unwrap();
+    backend.checkout_branch(&handle.id, keep).unwrap();
+    backend.delete_branch(&handle.id, "main", false).unwrap();
+}
+
+fn default_names(branches: &[platypusgit_lib::git::types::BranchInfo]) -> Vec<String> {
+    branches
+        .iter()
+        .filter(|b| b.is_default)
+        .map(|b| b.name.clone())
+        .collect()
+}
+
+#[test]
+fn branch_tip_time_is_the_tip_committer_time() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let head_commit = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    let head_time = head_commit.time().seconds();
+
+    // A deliberately old tip: `Signature::now()` twice in a row would tie on a
+    // one-second clock and prove nothing about ordering.
+    let old_sig =
+        git2::Signature::new("Old", "old@example.com", &git2::Time::new(1_000_000_000, 0)).unwrap();
+    let tree = head_commit.tree().unwrap();
+    let old_oid = tr
+        .repo
+        .commit(None, &old_sig, &old_sig, "old", &tree, &[&head_commit])
+        .unwrap();
+    tr.repo
+        .branch("stale", &tr.repo.find_commit(old_oid).unwrap(), false)
+        .unwrap();
+
+    let (backend, handle) = tr.open_with_backend();
+    let branches = backend.branches(&handle.id).unwrap();
+
+    let head = branches.iter().find(|b| b.name == "main").expect("main");
+    let stale = branches.iter().find(|b| b.name == "stale").expect("stale");
+
+    assert_eq!(head.tip_time, head_time);
+    assert_eq!(stale.tip_time, 1_000_000_000);
+    assert!(
+        head.tip_time > stale.tip_time,
+        "fixture sanity: the stale branch must sort older",
+    );
+}
+
+#[test]
+fn default_branch_follows_remote_head_symbolic_target() {
+    let (tr, _up) = with_origin_head(&[], "main");
+    let (backend, handle) = tr.open_with_backend();
+
+    let branches = backend.branches(&handle.id).unwrap();
+    let mut names = default_names(&branches);
+    names.sort();
+
+    // The local branch AND the remote's copy of it — the picker pins one at the
+    // top of each of its two sections.
+    assert_eq!(names, vec!["main".to_string(), "origin/main".to_string()]);
+}
+
+#[test]
+fn remote_head_outranks_the_local_main_fallback() {
+    // origin/HEAD names `release`, which exists only on the remote. `main`
+    // exists locally and must NOT be treated as the default anyway.
+    let (tr, _up) = with_origin_head(&["release"], "release");
+    let (backend, handle) = tr.open_with_backend();
+
+    let branches = backend.branches(&handle.id).unwrap();
+
+    assert_eq!(default_names(&branches), vec!["origin/release".to_string()]);
+}
+
+#[test]
+fn default_branch_falls_back_to_local_main() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let tip = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    tr.repo.branch("feature", &tip, false).unwrap();
+    let (backend, handle) = tr.open_with_backend();
+
+    let branches = backend.branches(&handle.id).unwrap();
+
+    assert_eq!(default_names(&branches), vec!["main".to_string()]);
+}
+
+/// Candidate order is `main`, `master`, `trunk` — and it is an ORDER, not a
+/// set: a repo carrying both `master` and `trunk` answers `master`. Also pins
+/// that `init.defaultBranch` is not consulted; if it were, this would answer
+/// `trunk`.
+#[test]
+fn default_branch_falls_back_to_master_before_trunk() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    without_main(&tr, "master");
+    let tip = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    tr.repo.branch("trunk", &tip, false).unwrap();
+    tr.repo
+        .config()
+        .unwrap()
+        .set_str("init.defaultBranch", "trunk")
+        .unwrap();
+
+    let (backend, handle) = tr.open_with_backend();
+    let branches = backend.branches(&handle.id).unwrap();
+
+    assert_eq!(default_names(&branches), vec!["master".to_string()]);
+}
+
+#[test]
+fn no_default_branch_when_nothing_answers() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    without_main(&tr, "dev");
+
+    let (backend, handle) = tr.open_with_backend();
+    let branches = backend.branches(&handle.id).unwrap();
+
+    assert!(
+        !branches.is_empty(),
+        "fixture sanity: the repo still has branches",
+    );
+    assert!(default_names(&branches).is_empty());
+}
+
+/// A stale `origin/HEAD` naming a branch nobody has must pin nothing rather
+/// than fail the listing — detection deliberately does not verify existence.
+#[test]
+fn stale_remote_head_pins_nothing() {
+    let (tr, _up) = with_origin_head(&[], "main");
+    tr.repo
+        .reference_symbolic(
+            "refs/remotes/origin/HEAD",
+            "refs/remotes/origin/deleted-long-ago",
+            true,
+            "test fixture",
+        )
+        .unwrap();
+
+    let (backend, handle) = tr.open_with_backend();
+    let branches = backend.branches(&handle.id).unwrap();
+
+    assert!(default_names(&branches).is_empty());
+}

--- a/src-tauri/tests/branches_tags.rs
+++ b/src-tauri/tests/branches_tags.rs
@@ -503,10 +503,15 @@ fn no_default_branch_when_nothing_answers() {
     assert!(default_names(&branches).is_empty());
 }
 
-/// A stale `origin/HEAD` naming a branch nobody has must pin nothing rather
-/// than fail the listing — detection deliberately does not verify existence.
+/// A stale `origin/HEAD` must not suppress the local fallback.
+///
+/// The real-world shape: cloned when the default was `master`, upstream renamed
+/// it to `main` and deleted `master`. `git fetch --prune` does NOT rewrite
+/// `refs/remotes/origin/HEAD`, so the symref still names a ref nobody has. If
+/// detection took that name on trust nothing would ever be pinned again, with
+/// no error to explain it.
 #[test]
-fn stale_remote_head_pins_nothing() {
+fn stale_remote_head_falls_back_to_the_local_default() {
     let (tr, _up) = with_origin_head(&[], "main");
     tr.repo
         .reference_symbolic(
@@ -519,6 +524,35 @@ fn stale_remote_head_pins_nothing() {
 
     let (backend, handle) = tr.open_with_backend();
     let branches = backend.branches(&handle.id).unwrap();
+    let mut names = default_names(&branches);
+    names.sort();
 
+    assert_eq!(names, vec!["main".to_string(), "origin/main".to_string()]);
+}
+
+/// ...and when the local fallback has nothing to offer either, nothing is
+/// pinned. Both halves matter: the previous test proves the fall-through
+/// happens, this one proves it still terminates.
+#[test]
+fn stale_remote_head_with_no_local_candidate_pins_nothing() {
+    let (tr, _up) = with_origin_head(&[], "main");
+    tr.repo
+        .reference_symbolic(
+            "refs/remotes/origin/HEAD",
+            "refs/remotes/origin/deleted-long-ago",
+            true,
+            "test fixture",
+        )
+        .unwrap();
+    without_main(&tr, "dev");
+
+    let (backend, handle) = tr.open_with_backend();
+    let branches = backend.branches(&handle.id).unwrap();
+
+    // `origin/main` is still fetched, but nothing names it as the default.
+    assert!(
+        branches.iter().any(|b| b.name == "origin/main"),
+        "fixture sanity: the remote-tracking ref is still there",
+    );
     assert!(default_names(&branches).is_empty());
 }

--- a/src/design/context-menu.compare.test.tsx
+++ b/src/design/context-menu.compare.test.tsx
@@ -28,6 +28,8 @@ const branches: BranchInfo[] = [
     ahead: 0,
     behind: 0,
     tip: "a".repeat(40),
+    tipTime: 0,
+    isDefault: false,
   },
   {
     name: "feature",
@@ -37,6 +39,8 @@ const branches: BranchInfo[] = [
     ahead: 0,
     behind: 0,
     tip: "b".repeat(40),
+    tipTime: 0,
+    isDefault: false,
   },
 ];
 

--- a/src/features/branches/BranchPicker.test.tsx
+++ b/src/features/branches/BranchPicker.test.tsx
@@ -1,0 +1,129 @@
+// Branch picker ordering + resting cursor (#135).
+//
+// The comparator itself is tested in orderBranches.test.ts; this pins that the
+// picker actually calls it, that it calls it AFTER filtering, and where the
+// keyboard cursor starts — Enter checks out the active row, so that position is
+// a correctness question, not a cosmetic one.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { BranchPicker } from "./BranchPicker";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { resetInvokeMock } from "@/test/invokeMock";
+import type { BranchInfo } from "@/lib/types";
+
+const branch = (over: Partial<BranchInfo> & { name: string }): BranchInfo => ({
+  isHead: false,
+  isRemote: false,
+  upstream: null,
+  ahead: 0,
+  behind: 0,
+  tip: "0".repeat(40),
+  tipTime: 0,
+  isDefault: false,
+  ...over,
+});
+
+let anchor: HTMLElement;
+
+function setup(branches: BranchInfo[]) {
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/feature/fresh" },
+    branches,
+  } as never);
+  return render(<BranchPicker anchor={anchor} open onClose={() => {}} />);
+}
+
+const rowNames = () =>
+  Array.from(document.querySelectorAll("[data-branch-row]")).map((el) =>
+    el.querySelector("span")?.textContent,
+  );
+
+const activeName = () =>
+  document
+    .querySelector("[data-branch-row][data-active]")
+    ?.querySelector("span")?.textContent;
+
+beforeEach(() => {
+  resetInvokeMock();
+  anchor = document.createElement("div");
+  document.body.appendChild(anchor);
+});
+
+afterEach(() => {
+  anchor.remove();
+});
+
+describe("BranchPicker ordering", () => {
+  it("pins the default branch, then orders by recency", () => {
+    setup([
+      branch({ name: "chore/old", tipTime: 50 }),
+      branch({ name: "feature/fresh", tipTime: 900, isHead: true }),
+      branch({ name: "main", tipTime: 100, isDefault: true }),
+    ]);
+
+    expect(rowNames()).toEqual(["main", "feature/fresh", "chore/old"]);
+  });
+
+  it("orders local and remote sections independently", () => {
+    setup([
+      branch({ name: "zzz-local", tipTime: 900 }),
+      branch({ name: "main", tipTime: 100, isDefault: true, isHead: true }),
+      branch({ name: "origin/zzz", tipTime: 900, isRemote: true }),
+      branch({ name: "origin/main", tipTime: 100, isRemote: true, isDefault: true }),
+    ]);
+
+    expect(rowNames()).toEqual(["main", "zzz-local", "origin/main", "origin/zzz"]);
+  });
+
+  it("does not resurrect the default branch when the query excludes it", () => {
+    setup([
+      branch({ name: "main", tipTime: 100, isDefault: true }),
+      branch({ name: "chore/old", tipTime: 50 }),
+      branch({ name: "chore/new", tipTime: 900 }),
+    ]);
+
+    fireEvent.change(screen.getByPlaceholderText("Switch to branch…"), {
+      target: { value: "chore" },
+    });
+
+    expect(rowNames()).toEqual(["chore/new", "chore/old"]);
+  });
+});
+
+describe("BranchPicker resting cursor", () => {
+  it("rests on the current branch with an empty query", () => {
+    // Enter on the HEAD row is a no-op (`checkout` early-returns), so this is
+    // the only starting position where the stray keystroke checks nothing out.
+    setup([
+      branch({ name: "main", tipTime: 100, isDefault: true }),
+      branch({ name: "feature/fresh", tipTime: 900, isHead: true }),
+    ]);
+
+    expect(activeName()).toBe("feature/fresh");
+  });
+
+  it("moves to the first row once a query is typed", () => {
+    setup([
+      branch({ name: "main", tipTime: 100, isDefault: true }),
+      branch({ name: "feature/fresh", tipTime: 900, isHead: true }),
+      branch({ name: "feature/other", tipTime: 800 }),
+    ]);
+
+    fireEvent.change(screen.getByPlaceholderText("Switch to branch…"), {
+      target: { value: "feature" },
+    });
+
+    expect(rowNames()).toEqual(["feature/fresh", "feature/other"]);
+    expect(activeName()).toBe("feature/fresh");
+  });
+
+  it("falls back to the first row when nothing is HEAD", () => {
+    setup([
+      branch({ name: "main", tipTime: 100, isDefault: true }),
+      branch({ name: "feature/fresh", tipTime: 900 }),
+    ]);
+
+    expect(activeName()).toBe("main");
+  });
+});

--- a/src/features/branches/BranchPicker.test.tsx
+++ b/src/features/branches/BranchPicker.test.tsx
@@ -6,7 +6,7 @@
 // a correctness question, not a cosmetic one.
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { BranchPicker } from "./BranchPicker";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { resetInvokeMock } from "@/test/invokeMock";
@@ -41,7 +41,7 @@ const rowNames = () =>
 
 const activeName = () =>
   document
-    .querySelector("[data-branch-row][data-active]")
+    .querySelector('[data-branch-row][data-active="true"]')
     ?.querySelector("span")?.textContent;
 
 beforeEach(() => {
@@ -123,6 +123,53 @@ describe("BranchPicker resting cursor", () => {
       branch({ name: "main", tipTime: 100, isDefault: true }),
       branch({ name: "feature/fresh", tipTime: 900 }),
     ]);
+
+    expect(activeName()).toBe("main");
+  });
+
+  // Regression: the popover can be opened before `list_branches` resolves. An
+  // effect keyed only on [open, query] ran once against an EMPTY list, landed
+  // on 0, and never re-ran — leaving the cursor on the pinned default once the
+  // branches arrived, which is the exact accident this rule exists to prevent.
+  it("re-parks on HEAD when the branch list arrives after the popover opened", () => {
+    setup([]);
+    expect(activeName()).toBeUndefined();
+
+    act(() => {
+      useRepoStore.setState({
+        branches: [
+          branch({ name: "main", tipTime: 100, isDefault: true }),
+          branch({ name: "feature/fresh", tipTime: 900, isHead: true }),
+        ],
+      } as never);
+    });
+
+    expect(rowNames()).toEqual(["main", "feature/fresh"]);
+    expect(activeName()).toBe("feature/fresh");
+  });
+
+  // ...but re-running must not undo the user's own aim, which is why the flag
+  // exists rather than a bare dependency-array change.
+  it("leaves a cursor the user moved alone when the list changes", () => {
+    setup([
+      branch({ name: "main", tipTime: 100, isDefault: true }),
+      branch({ name: "feature/fresh", tipTime: 900, isHead: true }),
+    ]);
+
+    fireEvent.keyDown(screen.getByPlaceholderText("Switch to branch…"), {
+      key: "ArrowUp",
+    });
+    expect(activeName()).toBe("main");
+
+    act(() => {
+      useRepoStore.setState({
+        branches: [
+          branch({ name: "main", tipTime: 100, isDefault: true }),
+          branch({ name: "feature/fresh", tipTime: 900, isHead: true }),
+          branch({ name: "chore/late", tipTime: 50 }),
+        ],
+      } as never);
+    });
 
     expect(activeName()).toBe("main");
   });

--- a/src/features/branches/BranchPicker.tsx
+++ b/src/features/branches/BranchPicker.tsx
@@ -67,8 +67,15 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
   );
 
   const flat = React.useMemo(() => [...local, ...remote], [local, remote]);
-  const flatRef = React.useRef(flat);
-  flatRef.current = flat;
+
+  // True once the user has aimed the cursor themselves (arrows or hover). The
+  // resting rule below must then stop moving it, or a late `list_branches`
+  // arrival would yank the cursor out from under them.
+  const aimed = React.useRef(false);
+  const aim = (next: number) => {
+    aimed.current = true;
+    setActiveIndex(next);
+  };
 
   React.useEffect(() => {
     if (!open) return;
@@ -77,24 +84,38 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
     return () => clearTimeout(t);
   }, [open]);
 
+  // The user's aim is dropped when the popover opens and whenever the query
+  // changes — both are moments where the row set is rebuilt under them. Runs
+  // before the resting effect below (effects fire in declaration order), so a
+  // query change re-parks the cursor in the same commit.
+  React.useEffect(() => {
+    aimed.current = false;
+  }, [open, query]);
+
   // Where the cursor rests before the user moves it. Enter checks out the
   // active row, so with an empty query it sits on the CURRENT branch — the one
   // row `checkout()` refuses to act on — rather than on whatever sorts first,
   // which since #135 is the pinned default branch. Once a query is typed the
   // top match IS the target, so it moves to row 0.
   //
+  // `flat` is in the deps on purpose: the popover can be opened before
+  // `list_branches` resolves, and an effect keyed only on [open, query] would
+  // run once against an EMPTY list, land on 0, and leave the cursor on the
+  // pinned default once the branches arrived — the exact accident this rule
+  // exists to prevent. `aimed` is what keeps re-running harmless.
+  //
   // Resetting on every query change also fixes a latent bug: the index used to
   // survive typing and was only clamped to the new length, leaving the cursor
   // on an unrelated row.
   React.useEffect(() => {
-    if (!open) return;
+    if (!open || aimed.current) return;
     if (query) {
       setActiveIndex(0);
       return;
     }
-    const head = flatRef.current.findIndex((r) => r.kind === "local" && r.isHead);
+    const head = flat.findIndex((r) => r.kind === "local" && r.isHead);
     setActiveIndex(head >= 0 ? head : 0);
-  }, [open, query]);
+  }, [open, query, flat]);
 
   React.useEffect(() => {
     if (activeIndex >= flat.length) setActiveIndex(Math.max(0, flat.length - 1));
@@ -154,12 +175,12 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
     }
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setActiveIndex((i) => Math.min(flat.length - 1, i + 1));
+      aim(Math.min(flat.length - 1, activeIndex + 1));
       return;
     }
     if (e.key === "ArrowUp") {
       e.preventDefault();
-      setActiveIndex((i) => Math.max(0, i - 1));
+      aim(Math.max(0, activeIndex - 1));
       return;
     }
     if (e.key === "Enter") {
@@ -194,10 +215,10 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
       <div
         key={`${r.kind}:${r.name}`}
         data-branch-row
-        data-active={active ? "" : undefined}
+        data-active={active ? "true" : "false"}
         onClick={() => checkout(r)}
         onContextMenu={(e) => handler(e, r)}
-        onMouseEnter={() => setActiveIndex(idx)}
+        onMouseEnter={() => aim(idx)}
         style={{
           display: "flex",
           alignItems: "center",

--- a/src/features/branches/BranchPicker.tsx
+++ b/src/features/branches/BranchPicker.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import type { BranchInfo } from "@/lib/types";
+import { orderBranches } from "./orderBranches";
 
 interface BranchPickerProps {
   anchor: HTMLElement | null;
@@ -44,34 +45,71 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
       remoteBranchMenuItems({ name: b?.name }),
     );
 
+  // Filter FIRST, order SECOND (#135). `orderBranches` only permutes, so the
+  // pinned default can never come back once the query has excluded it.
   const local: Row[] = React.useMemo(
     () =>
-      branches
-        .filter((b) => !b.isRemote && b.name.includes(query))
-        .map((b) => ({ ...b, kind: "local" as const })),
+      orderBranches(
+        branches
+          .filter((b) => !b.isRemote && b.name.includes(query))
+          .map((b) => ({ ...b, kind: "local" as const })),
+      ),
     [branches, query],
   );
   const remote: Row[] = React.useMemo(
     () =>
-      branches
-        .filter((b) => b.isRemote && b.name.includes(query))
-        .map((b) => ({ ...b, kind: "remote" as const })),
+      orderBranches(
+        branches
+          .filter((b) => b.isRemote && b.name.includes(query))
+          .map((b) => ({ ...b, kind: "remote" as const })),
+      ),
     [branches, query],
   );
 
   const flat = React.useMemo(() => [...local, ...remote], [local, remote]);
+  const flatRef = React.useRef(flat);
+  flatRef.current = flat;
 
   React.useEffect(() => {
     if (!open) return;
     setQuery("");
-    setActiveIndex(0);
     const t = setTimeout(() => inputRef.current?.focus(), 0);
     return () => clearTimeout(t);
   }, [open]);
 
+  // Where the cursor rests before the user moves it. Enter checks out the
+  // active row, so with an empty query it sits on the CURRENT branch — the one
+  // row `checkout()` refuses to act on — rather than on whatever sorts first,
+  // which since #135 is the pinned default branch. Once a query is typed the
+  // top match IS the target, so it moves to row 0.
+  //
+  // Resetting on every query change also fixes a latent bug: the index used to
+  // survive typing and was only clamped to the new length, leaving the cursor
+  // on an unrelated row.
+  React.useEffect(() => {
+    if (!open) return;
+    if (query) {
+      setActiveIndex(0);
+      return;
+    }
+    const head = flatRef.current.findIndex((r) => r.kind === "local" && r.isHead);
+    setActiveIndex(head >= 0 ? head : 0);
+  }, [open, query]);
+
   React.useEffect(() => {
     if (activeIndex >= flat.length) setActiveIndex(Math.max(0, flat.length - 1));
   }, [flat.length, activeIndex]);
+
+  // Keep the cursor visible. The resting position can start below the fold in a
+  // long list, and arrowing past the visible area never scrolled either. These
+  // rows are plainly mapped, not windowed, so the DOM route is sound here.
+  // Optional call: jsdom has no scrollIntoView, and this is presentation only.
+  React.useEffect(() => {
+    if (!open) return;
+    const rows =
+      popoverRef.current?.querySelectorAll<HTMLElement>("[data-branch-row]");
+    rows?.[activeIndex]?.scrollIntoView?.({ block: "nearest" });
+  }, [open, activeIndex, flat.length]);
 
   React.useEffect(() => {
     if (!open) return;
@@ -156,6 +194,7 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
       <div
         key={`${r.kind}:${r.name}`}
         data-branch-row
+        data-active={active ? "" : undefined}
         onClick={() => checkout(r)}
         onContextMenu={(e) => handler(e, r)}
         onMouseEnter={() => setActiveIndex(idx)}

--- a/src/features/branches/orderBranches.test.ts
+++ b/src/features/branches/orderBranches.test.ts
@@ -1,0 +1,111 @@
+// The one branch ordering (#135): default first, then newest tip first, then
+// name. Pure, so it is tested here rather than through any of the three
+// surfaces that call it.
+
+import { describe, it, expect } from "vitest";
+import { compareBranches, orderBranches } from "./orderBranches";
+import type { BranchInfo } from "@/lib/types";
+
+const b = (over: Partial<BranchInfo> & { name: string }): BranchInfo => ({
+  isHead: false,
+  isRemote: false,
+  upstream: null,
+  ahead: 0,
+  behind: 0,
+  tip: "0".repeat(40),
+  tipTime: 0,
+  isDefault: false,
+  ...over,
+});
+
+const names = (rows: readonly BranchInfo[]) => rows.map((r) => r.name);
+
+describe("orderBranches", () => {
+  it("pins the default branch first, however old its tip", () => {
+    const rows = orderBranches([
+      b({ name: "feature/new", tipTime: 5000 }),
+      b({ name: "main", tipTime: 1, isDefault: true }),
+      b({ name: "chore/old", tipTime: 3000 }),
+    ]);
+
+    expect(names(rows)).toEqual(["main", "feature/new", "chore/old"]);
+  });
+
+  it("orders the rest by tip time, newest first", () => {
+    const rows = orderBranches([
+      b({ name: "stale", tipTime: 100 }),
+      b({ name: "fresh", tipTime: 900 }),
+      b({ name: "middling", tipTime: 500 }),
+    ]);
+
+    expect(names(rows)).toEqual(["fresh", "middling", "stale"]);
+  });
+
+  it("breaks ties on name so equal tips order the same way every run", () => {
+    // `git branch x` off one commit gives every branch the SAME tip time, which
+    // is the common case in a fresh repo — without a tiebreaker the order would
+    // be whatever the input happened to be.
+    const rows = orderBranches([
+      b({ name: "zeta", tipTime: 42 }),
+      b({ name: "alpha", tipTime: 42 }),
+      b({ name: "mid", tipTime: 42 }),
+    ]);
+
+    expect(names(rows)).toEqual(["alpha", "mid", "zeta"]);
+  });
+
+  it("is a pure recency sort when no row is the default", () => {
+    const rows = orderBranches([
+      b({ name: "a", tipTime: 1 }),
+      b({ name: "b", tipTime: 2 }),
+    ]);
+
+    expect(names(rows)).toEqual(["b", "a"]);
+  });
+
+  it("does not mutate its input", () => {
+    const input = [b({ name: "b", tipTime: 1 }), b({ name: "a", tipTime: 2 })];
+    const before = names(input);
+
+    orderBranches(input);
+
+    expect(names(input)).toEqual(before);
+  });
+
+  // The pin must never resurrect a row search filtered out: every call site
+  // filters FIRST and orders SECOND, and ordering only permutes.
+  it("returns exactly the rows it was given — never adds the default back", () => {
+    const filtered = [
+      b({ name: "feature/one", tipTime: 10 }),
+      b({ name: "feature/two", tipTime: 20 }),
+    ];
+
+    const rows = orderBranches(filtered);
+
+    expect(rows).toHaveLength(2);
+    expect(names(rows).sort()).toEqual(["feature/one", "feature/two"]);
+  });
+
+  it("keeps extra row fields intact", () => {
+    type Row = BranchInfo & { kind: "local" | "remote" };
+    const rows: Row[] = orderBranches<Row>([
+      { ...b({ name: "b", tipTime: 1 }), kind: "local" },
+      { ...b({ name: "a", tipTime: 2 }), kind: "remote" },
+    ]);
+
+    expect(rows.map((r) => r.kind)).toEqual(["remote", "local"]);
+  });
+});
+
+describe("compareBranches", () => {
+  it("reports equality for two rows that differ in nothing it reads", () => {
+    expect(compareBranches(b({ name: "x" }), b({ name: "x" }))).toBe(0);
+  });
+
+  it("ignores isHead — the current branch is badged, not pinned", () => {
+    const head = b({ name: "wip", tipTime: 1, isHead: true });
+    const other = b({ name: "other", tipTime: 2 });
+
+    expect(compareBranches(head, other)).toBeGreaterThan(0);
+  });
+});

--- a/src/features/branches/orderBranches.test.ts
+++ b/src/features/branches/orderBranches.test.ts
@@ -3,7 +3,11 @@
 // surfaces that call it.
 
 import { describe, it, expect } from "vitest";
-import { compareBranches, orderBranches } from "./orderBranches";
+import {
+  compareBranches,
+  orderBranches,
+  orderBranchesGrouped,
+} from "./orderBranches";
 import type { BranchInfo } from "@/lib/types";
 
 const b = (over: Partial<BranchInfo> & { name: string }): BranchInfo => ({
@@ -94,6 +98,36 @@ describe("orderBranches", () => {
     ]);
 
     expect(rows.map((r) => r.kind)).toEqual(["remote", "local"]);
+  });
+});
+
+describe("orderBranchesGrouped", () => {
+  it("keeps every local ahead of every remote, ordered within each group", () => {
+    const rows = orderBranchesGrouped([
+      b({ name: "origin/zzz", tipTime: 950, isRemote: true }),
+      b({ name: "zzz-local", tipTime: 900 }),
+      b({ name: "origin/main", tipTime: 100, isRemote: true, isDefault: true }),
+      b({ name: "main", tipTime: 100, isDefault: true }),
+    ]);
+
+    // Without the grouping both defaults would take rows 1-2 and the freshest
+    // remote would outrank every stale local.
+    expect(names(rows)).toEqual([
+      "main",
+      "zzz-local",
+      "origin/main",
+      "origin/zzz",
+    ]);
+  });
+
+  it("is still only a permutation", () => {
+    const input = [
+      b({ name: "a", tipTime: 1 }),
+      b({ name: "origin/b", tipTime: 2, isRemote: true }),
+    ];
+
+    expect(names(orderBranchesGrouped(input)).sort()).toEqual(["a", "origin/b"]);
+    expect(names(input)).toEqual(["a", "origin/b"]);
   });
 });
 

--- a/src/features/branches/orderBranches.ts
+++ b/src/features/branches/orderBranches.ts
@@ -1,0 +1,37 @@
+// The single branch ordering (#135). Pure — see orderBranches.test.ts.
+//
+// Every branch list in the app goes through this: the titlebar picker, the
+// Branches screen, and the palette's branch rows. One helper is the point; a
+// second ordering somewhere else is how the three drifted apart before.
+
+import type { BranchInfo } from "@/lib/types";
+
+/**
+ * Default branch first, then newest tip first, then name ascending.
+ *
+ * `isHead` is deliberately NOT read: the current branch is already accent-
+ * coloured and badged, it is the one branch the picker exists to leave, and
+ * pinning it would push the actual default down for no navigational gain.
+ */
+export function compareBranches(a: BranchInfo, b: BranchInfo): number {
+  if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
+  if (a.tipTime !== b.tipTime) return b.tipTime - a.tipTime;
+  // Plain comparison, not localeCompare: branches cut from one commit all share
+  // a tip time, so this tiebreaker decides the visible order and must not
+  // depend on the runtime's ICU data.
+  if (a.name < b.name) return -1;
+  if (a.name > b.name) return 1;
+  return 0;
+}
+
+/**
+ * Order a branch list. Copies first — `useRepoStore.branches` is store state
+ * and must not be sorted in place.
+ *
+ * This only ever PERMUTES: same length, same rows, nothing added. Call sites
+ * filter first and order second, so a query that excludes the default branch
+ * keeps excluding it.
+ */
+export function orderBranches<T extends BranchInfo>(rows: readonly T[]): T[] {
+  return [...rows].sort(compareBranches);
+}

--- a/src/features/branches/orderBranches.ts
+++ b/src/features/branches/orderBranches.ts
@@ -35,3 +35,22 @@ export function compareBranches(a: BranchInfo, b: BranchInfo): number {
 export function orderBranches<T extends BranchInfo>(rows: readonly T[]): T[] {
   return [...rows].sort(compareBranches);
 }
+
+/**
+ * Order a MIXED list into one flat array, locals ahead of remotes and ordered
+ * within each group.
+ *
+ * The picker renders two labelled sections and the Branches screen splits by
+ * view, so both get this grouping structurally. A surface that renders one
+ * undivided list (the palette's branch steps) needs it done here instead —
+ * otherwise `main` and `origin/main` are both `isDefault` and take rows 1-2,
+ * and locals and remotes interleave by tip time below them.
+ */
+export function orderBranchesGrouped<T extends BranchInfo>(
+  rows: readonly T[],
+): T[] {
+  return [
+    ...orderBranches(rows.filter((r) => !r.isRemote)),
+    ...orderBranches(rows.filter((r) => r.isRemote)),
+  ];
+}

--- a/src/features/compare/compareSides.test.ts
+++ b/src/features/compare/compareSides.test.ts
@@ -26,6 +26,8 @@ const branch = (name: string, isHead = false): BranchInfo => ({
   ahead: 0,
   behind: 0,
   tip: "a".repeat(40),
+  tipTime: 0,
+  isDefault: false,
 });
 
 describe("sideLabel / sideKey", () => {

--- a/src/features/forge/CreatePullRequestDialog.test.tsx
+++ b/src/features/forge/CreatePullRequestDialog.test.tsx
@@ -17,6 +17,8 @@ function branch(name: string, isHead = false): BranchInfo {
     ahead: 0,
     behind: 0,
     tip: "0".repeat(40),
+    tipTime: 0,
+    isDefault: false,
   };
 }
 

--- a/src/features/palette/CommandPalette.branchStep.test.tsx
+++ b/src/features/palette/CommandPalette.branchStep.test.tsx
@@ -1,0 +1,156 @@
+// Regression: a palette branch pick step must not preselect its first row.
+//
+// #135 pins the default branch at row 0 of every branch list, and the palette
+// resets `activeIndex` to 0 on every `pushStep`. That put `main` under the
+// cursor of the Delete step, one Enter after the Enter that opened it — and
+// `delete_branch` refuses only UNMERGED branches, so the default branch (an
+// ancestor of HEAD) went without a murmur, unconfirmed and irreversible.
+//
+// Two things are pinned here: the step rests on no row, and the delete itself
+// now confirms.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { CommandPalette } from "./CommandPalette";
+import { paletteInitial, usePaletteStore } from "./usePaletteStore";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { WithDialogs, acceptDialog, resetDialogs } from "@/test/dialog";
+import type { BranchInfo } from "@/lib/types";
+
+const mkBranch = (over: Partial<BranchInfo> & { name: string }): BranchInfo => ({
+  isHead: false,
+  isRemote: false,
+  upstream: null,
+  ahead: 0,
+  behind: 0,
+  tip: null,
+  tipTime: 0,
+  isDefault: false,
+  ...over,
+});
+
+let deleted: string[] = [];
+
+function setup() {
+  deleted = [];
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "feat/y" },
+    status: [],
+    allFiles: [],
+    // `main` is the pinned default and NOT head, so it survives the step's
+    // `!b.isHead && !b.isRemote` filter and sorts to row 0.
+    branches: [
+      mkBranch({ name: "chore/x", tipTime: 900 }),
+      mkBranch({ name: "main", tipTime: 100, isDefault: true }),
+      mkBranch({ name: "feat/y", tipTime: 950, isHead: true }),
+    ],
+    tags: [],
+    stashes: [],
+    remotes: [],
+    commits: [],
+    loading: false,
+    error: null,
+    repoState: "Clean",
+    rebaseStatus: { inProgress: false, nextIndex: 0, total: 0, pauseReason: null },
+    activity: {},
+    deleteBranch: async (name: string) => {
+      deleted.push(name);
+    },
+  } as never);
+  useNavStore.setState({ intent: null });
+  usePaletteStore.setState(paletteInitial());
+  localStorage.clear();
+  mockInvoke("list_all_files", () => []);
+}
+
+const rowLabels = () =>
+  Array.from(document.querySelectorAll("[data-pal-index]")).map(
+    (el) => el.textContent ?? "",
+  );
+
+async function openDeleteStep(user: ReturnType<typeof userEvent.setup>) {
+  usePaletteStore.getState().openPalette();
+  render(
+    <WithDialogs>
+      <CommandPalette />
+    </WithDialogs>,
+  );
+  await user.keyboard("Delete branch");
+  await user.keyboard("{Enter}");
+  expect(usePaletteStore.getState().stack.at(-1)).toMatchObject({
+    kind: "pick",
+    title: "Delete branch",
+  });
+}
+
+describe("palette branch pick steps", () => {
+  beforeEach(() => {
+    resetInvokeMock();
+    resetDialogs();
+    setup();
+  });
+
+  it("rests on no row, so the Enter that opened the step cannot fire row 0", async () => {
+    const user = userEvent.setup();
+    await openDeleteStep(user);
+
+    // Row 0 IS the pinned default — that is precisely why nothing may rest there.
+    expect(rowLabels()[0]).toContain("main");
+
+    await user.keyboard("{Enter}");
+
+    // Activating a row closes the palette and raises the confirm, so "still
+    // open, no dialog" is the assertion that a row was NOT activated —
+    // `deleted` alone would be empty either way while the confirm is pending.
+    expect(usePaletteStore.getState().open).toBe(true);
+    expect(document.querySelector("[data-pg-dialog]")).toBeNull();
+    expect(deleted).toEqual([]);
+  });
+
+  it("confirms before deleting once the user aims a row", async () => {
+    const user = userEvent.setup();
+    await openDeleteStep(user);
+
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{Enter}");
+
+    // The confirm is the point: this was the one delete path with none.
+    expect(deleted).toEqual([]);
+    await acceptDialog();
+    expect(deleted).toEqual(["main"]);
+  });
+
+  it("moves the cursor to the top match once a query is typed", async () => {
+    const user = userEvent.setup();
+    await openDeleteStep(user);
+
+    await user.keyboard("chore");
+    expect(rowLabels()[0]).toContain("chore/x");
+
+    await user.keyboard("{Enter}");
+    await acceptDialog();
+
+    expect(deleted).toEqual(["chore/x"]);
+  });
+
+  it("the other branch steps decline a resting row too", async () => {
+    const user = userEvent.setup();
+    usePaletteStore.getState().openPalette();
+    render(
+      <WithDialogs>
+        <CommandPalette />
+      </WithDialogs>,
+    );
+    await user.keyboard("Checkout branch");
+    await user.keyboard("{Enter}");
+
+    const step = usePaletteStore.getState().stack.at(-1);
+    expect(step).toMatchObject({ kind: "pick", title: "Checkout branch" });
+    expect(step && "cursor" in step ? step.cursor : undefined).toBe("none");
+    expect(screen.queryByText("Checkout branch")).toBeTruthy();
+  });
+});

--- a/src/features/palette/CommandPalette.test.tsx
+++ b/src/features/palette/CommandPalette.test.tsx
@@ -22,6 +22,8 @@ const mkBranch = (name: string, isHead = false): BranchInfo => ({
   ahead: 0,
   behind: 0,
   tip: null,
+  tipTime: 0,
+  isDefault: false,
 });
 
 const mkCommit = (oid: string, summary: string): CommitInfo => ({

--- a/src/features/palette/CommandPalette.tsx
+++ b/src/features/palette/CommandPalette.tsx
@@ -162,12 +162,21 @@ export function CommandPalette() {
     return { flat: flatOut, groups: groupsOut };
   }, [source, query, step.kind, activeChip]);
 
+  // Where the cursor rests before the user aims it. A pick step may decline a
+  // resting row (`cursor: "none"`) so Enter does nothing until they do — the
+  // branch steps use it, because #135 pins the default branch at row 0 and
+  // "⌘P, delete branch, Enter, Enter" would otherwise delete `main`. Only
+  // while the query is empty: once they type, the top match IS the target.
+  const restingIndex =
+    step.kind === "pick" && step.cursor === "none" && query === "" ? -1 : 0;
+
   React.useEffect(() => {
     if (!open) return;
-    setActiveIndex(0);
+    setActiveIndex(restingIndex);
     if (repoOpen) void useRepoStore.getState().refreshAllFiles();
     const t = setTimeout(() => inputRef.current?.focus(), 0);
     return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, repoOpen, stack.length]);
 
   // Home-screen rows (computed before early return so navRows is available for effects).
@@ -198,8 +207,9 @@ export function CommandPalette() {
       ? flat.filter((r) => r.item.type === activeChip)
       : flat;
 
-  React.useEffect(() => { setActiveIndex(0); }, [query, activeChip]);
+  React.useEffect(() => { setActiveIndex(restingIndex); }, [query, activeChip, restingIndex]);
   React.useEffect(() => {
+    // -1 (no resting row) is below every length, so this leaves it alone.
     if (activeIndex >= navRows.length) setActiveIndex(Math.max(0, navRows.length - 1));
   }, [navRows.length, activeIndex]);
   React.useEffect(() => {

--- a/src/features/palette/chipPrefilter.test.tsx
+++ b/src/features/palette/chipPrefilter.test.tsx
@@ -28,6 +28,7 @@ vi.mock("./fuzzyMatch", async (importOriginal) => {
 
 const mkBranch = (name: string, isHead = false): BranchInfo => ({
   name, isHead, isRemote: false, upstream: null, ahead: 0, behind: 0, tip: "deadbeef",
+  tipTime: 0, isDefault: false,
 });
 const mkCommit = (oid: string, summary: string): CommitInfo => ({
   oid, shortOid: oid.slice(0, 7), summary, body: null, author: "Dev", email: "",

--- a/src/features/palette/commands.test.ts
+++ b/src/features/palette/commands.test.ts
@@ -13,10 +13,12 @@ import type { BranchInfo, CommitInfo, FileStatus, StashInfo } from "@/lib/types"
 
 const mkBranch = (name: string, isHead = false, upstream: string | null = null): BranchInfo => ({
   name, isHead, isRemote: false, upstream, ahead: 0, behind: 0, tip: "deadbeef",
+  tipTime: 0, isDefault: false,
 });
 
 const mkRemoteBranch = (name: string): BranchInfo => ({
   name, isHead: false, isRemote: true, upstream: null, ahead: 0, behind: 0, tip: "deadbeef",
+  tipTime: 0, isDefault: false,
 });
 
 const mkCommit = (oid: string, summary: string): CommitInfo => ({

--- a/src/features/palette/commands.test.ts
+++ b/src/features/palette/commands.test.ts
@@ -321,6 +321,46 @@ describe("branchItems", () => {
     expect(items[0].icon).toBe("merge");
   });
 
+  // #135. Nothing pinned this before: the old fixture happened to order the
+  // same way with and without the comparator, so a broken ordering would have
+  // gone unnoticed here. Assert it on `branchItems` itself — it is pure. The
+  // RENDERED palette order is deliberately not asserted anywhere: the root step
+  // adds `frecencyScore` (Date.now() + localStorage) and caps each group, so
+  // pinning that would be fragile by construction.
+  it("pins the default branch and orders the rest by recency", () => {
+    setRepo({
+      branches: [
+        { ...mkBranch("chore/old"), tipTime: 50 },
+        { ...mkBranch("main"), tipTime: 100, isDefault: true },
+        { ...mkBranch("feat/fresh"), tipTime: 900 },
+      ],
+    });
+    const items = branchItems({ icon: "branch", onPick: () => {} });
+    expect(items.map((i) => i.label)).toEqual(["main", "feat/fresh", "chore/old"]);
+  });
+
+  // The picker renders two labelled sections and the Branches screen splits by
+  // view; a pick step renders ONE list, so the grouping has to happen here or
+  // `main` and `origin/main` (both `isDefault`) take rows 1-2 and the rest
+  // interleave by tip time.
+  it("keeps locals ahead of remotes, ordering within each group", () => {
+    setRepo({
+      branches: [
+        { ...mkRemoteBranch("origin/zzz"), tipTime: 950 },
+        { ...mkBranch("zzz-local"), tipTime: 900 },
+        { ...mkRemoteBranch("origin/main"), tipTime: 100, isDefault: true },
+        { ...mkBranch("main"), tipTime: 100, isDefault: true },
+      ],
+    });
+    const items = branchItems({ icon: "branch", onPick: () => {} });
+    expect(items.map((i) => i.label)).toEqual([
+      "main",
+      "zzz-local",
+      "origin/main",
+      "origin/zzz",
+    ]);
+  });
+
   it("run() closes the palette, then calls onPick with the branch name", () => {
     setRepo({ branches: [mkBranch("feat/x")] });
     const order: string[] = [];

--- a/src/features/palette/commands.test.ts
+++ b/src/features/palette/commands.test.ts
@@ -1,6 +1,12 @@
 // src/features/palette/commands.test.ts
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { branchItems, buildCommands, commitItems, fileItems } from "./commands";
+import {
+  branchItems,
+  branchPickStep,
+  buildCommands,
+  commitItems,
+  fileItems,
+} from "./commands";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useRecentsStore } from "@/features/repo/useRecentsStore";
 import { useTabsStore } from "@/features/repo/useTabsStore";
@@ -369,6 +375,41 @@ describe("branchItems", () => {
     } as never);
     branchItems({ icon: "branch", onPick: (n) => order.push(`pick:${n}`) })[0].run();
     expect(order).toEqual(["close", "pick:feat/x"]);
+  });
+});
+
+// The structural half of #135's resting-cursor rule: one constructor sets
+// `cursor: "none"`, and every branch step in the catalog is built from it, so a
+// new one cannot silently default to preselecting the pinned default branch.
+describe("branchPickStep", () => {
+  beforeEach(resetStores);
+
+  it("always declines a resting cursor", () => {
+    setRepo({ branches: [mkBranch("main"), mkBranch("feat/x")] });
+    const s = branchPickStep({
+      title: "Do a thing",
+      icon: "branch",
+      onPick: () => {},
+    });
+    expect(s).toMatchObject({ kind: "pick", title: "Do a thing", cursor: "none" });
+    expect(s.kind === "pick" && s.items.map((i) => i.label)).toEqual([
+      "feat/x",
+      "main",
+    ]);
+  });
+
+  it("passes its row options straight through", () => {
+    setRepo({ branches: [mkBranch("main", true), mkBranch("feat/x")] });
+    const s = branchPickStep({
+      title: "T",
+      idPrefix: "pick-compare",
+      filter: (b) => !b.isHead,
+      icon: "diff",
+      onPick: () => {},
+    });
+    expect(s.kind === "pick" && s.items.map((i) => i.id)).toEqual([
+      "pick-compare:l:feat/x",
+    ]);
   });
 });
 

--- a/src/features/palette/commands.ts
+++ b/src/features/palette/commands.ts
@@ -12,7 +12,7 @@ import { useWorktreesStore } from "@/features/worktrees/useWorktreesStore";
 import { useTabsStore } from "@/features/repo/useTabsStore";
 import { openCompare } from "@/features/compare/useCompareStore";
 import { WORKDIR } from "@/features/compare/compareSides";
-import { orderBranches } from "@/features/branches/orderBranches";
+import { orderBranchesGrouped } from "@/features/branches/orderBranches";
 import { usePaletteStore } from "./usePaletteStore";
 import { createBranchInputStep, switchRepoStep } from "./steps";
 import { currentBranch, isConflicted, relativeTime } from "@/lib/derive";
@@ -73,10 +73,17 @@ export function branchItems({
   onPick,
 }: BranchItemsOptions): PaletteItem[] {
   const rows = branches ?? repoState().branches;
-  // Filter first, order second (#135). The root step re-scores rows by fuzzy
-  // match + frecency, but `Array#sort` is stable, so with an empty query — where
-  // every candidate ties — this is the order the user sees.
-  return orderBranches(filter ? rows.filter(filter) : rows).map((b) => ({
+  // Filter first, order second (#135), locals ahead of remotes — the sections
+  // the picker and Branches screen render structurally, flattened for a step
+  // that lists one undivided set.
+  //
+  // This is the order a PICK STEP shows. It is NOT what the root step shows:
+  // `CommandPalette` adds `frecencyScore` to every row regardless of query, so
+  // as soon as the user has picked any branch from the palette that branch
+  // outranks the pinned default there. The pin is honoured in the picker, the
+  // Branches screen and the pick steps; the root step is a relevance ranking
+  // and deliberately stays one.
+  return orderBranchesGrouped(filter ? rows.filter(filter) : rows).map((b) => ({
     type: "branch" as const,
     id: `${idPrefix}:${b.isRemote ? "r" : "l"}:${b.name}`,
     search: b.name,
@@ -88,6 +95,25 @@ export function branchItems({
       onPick(b.name);
     },
   }));
+}
+
+/**
+ * A pick step over BRANCH rows — the one way the catalog builds one.
+ *
+ * It exists so the resting-cursor rule cannot be forgotten at a new call site:
+ * #135 pins the default branch at row 0 of every branch list, and the palette
+ * resets `activeIndex` to 0 on every `pushStep`, so a step that preselected row
+ * 0 put `main` one Enter after the Enter that opened it — which for the Delete
+ * step reached an unconfirmed, irreversible `deleteBranch("main")`.
+ *
+ * `branchItems` stays exported for the ROOT step, which builds candidates
+ * rather than a step and has its own cursor rules.
+ */
+export function branchPickStep({
+  title,
+  ...rows
+}: BranchItemsOptions & { title: string }): PaletteStep {
+  return { kind: "pick", title, cursor: "none", items: branchItems(rows) };
 }
 
 export interface CommitItemsOptions extends RowOptions {
@@ -386,14 +412,14 @@ export function buildCommands(): PaletteItem[] {
   items.push({
     type: "command", id: "action:checkout-branch",
     search: "Checkout branch switch", label: "Checkout branch…", icon: "branch",
-    run: step(() => ({
-      kind: "pick", title: "Checkout branch",
-      items: branchItems({
+    run: step(() =>
+      branchPickStep({
+        title: "Checkout branch",
         filter: (b) => !b.isHead,
         icon: "branch",
         onPick: (n) => void repo.checkoutBranch(n),
       }),
-    })),
+    ),
   });
   items.push({
     type: "command", id: "action:create-branch",
@@ -404,26 +430,26 @@ export function buildCommands(): PaletteItem[] {
   items.push({
     type: "command", id: "action:merge",
     search: "Merge branch into current", label: "Merge branch into current…", icon: "merge",
-    run: step(() => ({
-      kind: "pick", title: "Merge into current",
-      items: branchItems({
+    run: step(() =>
+      branchPickStep({
+        title: "Merge into current",
         filter: (b) => !b.isHead,
         icon: "merge",
         onPick: (n) => void repo.mergeBranch(n),
       }),
-    })),
+    ),
   });
   items.push({
     type: "command", id: "action:rebase-onto",
     search: "Rebase current onto branch", label: "Rebase current onto…", icon: "rebase",
-    run: step(() => ({
-      kind: "pick", title: "Rebase onto",
-      items: branchItems({
+    run: step(() =>
+      branchPickStep({
+        title: "Rebase onto",
         filter: (b) => !b.isHead,
         icon: "rebase",
         onPick: (n) => void repo.rebaseOnto(n),
       }),
-    })),
+    ),
   });
   // -- compare (#131) --
   //
@@ -434,9 +460,9 @@ export function buildCommands(): PaletteItem[] {
     type: "command", id: "action:compare-refs",
     search: "Compare branch diff against current branch",
     label: "Compare with current branch…", icon: "diff",
-    run: step(() => ({
-      kind: "pick", title: "Compare with current",
-      items: branchItems({
+    run: step(() =>
+      branchPickStep({
+        title: "Compare with current",
         idPrefix: "pick-compare",
         filter: (b) => !b.isHead,
         icon: "diff",
@@ -447,39 +473,53 @@ export function buildCommands(): PaletteItem[] {
             { kind: "rev", rev: n },
           ),
       }),
-    })),
+    ),
   });
   items.push({
     type: "command", id: "action:compare-workdir",
     search: "Compare branch against working tree uncommitted",
     label: "Compare with working tree…", icon: "diff",
-    run: step(() => ({
-      kind: "pick", title: "Compare against the working tree",
-      items: branchItems({
+    run: step(() =>
+      branchPickStep({
+        title: "Compare against the working tree",
         idPrefix: "pick-compare-wt",
         icon: "diff",
         onPick: (n) => openCompare({ kind: "rev", rev: n }, WORKDIR),
       }),
-    })),
+    ),
   });
   items.push({
     type: "command", id: "action:delete-branch",
     search: "Delete branch", label: "Delete branch…", danger: true, icon: "trash",
-    run: step(() => ({
-      kind: "pick", title: "Delete branch",
-      items: branchItems({
+    run: step(() =>
+      branchPickStep({
+        title: "Delete branch",
         filter: (b) => !b.isHead && !b.isRemote,
         icon: "trash",
-        onPick: (n) => void repo.deleteBranch(n),
+        // The only delete path that did not confirm — the row menu and the
+        // Branches screen inspector both already do. Deleting a branch is
+        // irreversible short of the reflog, and `delete_branch` refuses only
+        // UNMERGED branches, so the default branch (an ancestor of HEAD) goes
+        // without a murmur.
+        onPick: async (n) => {
+          if (
+            await pgConfirm({
+              title: `Delete branch ${n}?`,
+              danger: true,
+              confirmLabel: "Delete",
+            })
+          )
+            void repo.deleteBranch(n);
+        },
       }),
-    })),
+    ),
   });
   items.push({
     type: "command", id: "action:rename-branch",
     search: "Rename branch", label: "Rename branch…", icon: "branch",
-    run: step(() => ({
-      kind: "pick", title: "Rename branch",
-      items: branchItems({
+    run: step(() =>
+      branchPickStep({
+        title: "Rename branch",
         filter: (b) => !b.isRemote,
         icon: "branch",
         onPick: (oldName) =>
@@ -493,7 +533,7 @@ export function buildCommands(): PaletteItem[] {
             },
           }),
       }),
-    })),
+    ),
   });
 
   items.push({

--- a/src/features/palette/commands.ts
+++ b/src/features/palette/commands.ts
@@ -12,6 +12,7 @@ import { useWorktreesStore } from "@/features/worktrees/useWorktreesStore";
 import { useTabsStore } from "@/features/repo/useTabsStore";
 import { openCompare } from "@/features/compare/useCompareStore";
 import { WORKDIR } from "@/features/compare/compareSides";
+import { orderBranches } from "@/features/branches/orderBranches";
 import { usePaletteStore } from "./usePaletteStore";
 import { createBranchInputStep, switchRepoStep } from "./steps";
 import { currentBranch, isConflicted, relativeTime } from "@/lib/derive";
@@ -72,7 +73,10 @@ export function branchItems({
   onPick,
 }: BranchItemsOptions): PaletteItem[] {
   const rows = branches ?? repoState().branches;
-  return (filter ? rows.filter(filter) : rows).map((b) => ({
+  // Filter first, order second (#135). The root step re-scores rows by fuzzy
+  // match + frecency, but `Array#sort` is stable, so with an empty query — where
+  // every candidate ties — this is the order the user sees.
+  return orderBranches(filter ? rows.filter(filter) : rows).map((b) => ({
     type: "branch" as const,
     id: `${idPrefix}:${b.isRemote ? "r" : "l"}:${b.name}`,
     search: b.name,

--- a/src/features/palette/types.ts
+++ b/src/features/palette/types.ts
@@ -34,7 +34,23 @@ export interface PaletteItem {
 /** One screen of the palette state machine. */
 export type PaletteStep =
   | { kind: "root" }
-  | { kind: "pick"; title: string; items: PaletteItem[] }
+  | {
+      kind: "pick";
+      title: string;
+      items: PaletteItem[];
+      /**
+       * Where the cursor rests while the step's query is empty. `"first"` (the
+       * default) preselects row 0, so Enter activates it immediately; `"none"`
+       * preselects nothing, so Enter does nothing until the user aims.
+       *
+       * Steps whose row 0 is a plausible, destructive target use `"none"` —
+       * the branch steps, since #135 pins the default branch there and
+       * "⌘P, delete branch, Enter, Enter" would otherwise land on `main`.
+       * Once a query is typed the top match IS the target and the cursor
+       * moves to row 0 either way.
+       */
+      cursor?: "first" | "none";
+    }
   | {
       kind: "input";
       title: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -178,6 +178,13 @@ export interface BranchInfo {
   ahead: number;
   behind: number;
   tip: string | null;
+  /**
+   * Committer time of the tip commit, seconds since the epoch. `0` when the tip
+   * could not be resolved, which sorts last under newest-first ordering.
+   */
+  tipTime: number;
+  /** Is this the repository's default branch (or a remote's copy of it)? */
+  isDefault: boolean;
 }
 
 export interface TagInfo {

--- a/src/screens/Branches.activate.test.tsx
+++ b/src/screens/Branches.activate.test.tsx
@@ -1,0 +1,134 @@
+// Regression: the Branches list must not activate a row nothing selected.
+//
+// `flatIndex` used to be `Math.max(0, findIndex(...))`, and `selection` starts
+// null — so `usePaneList` was told row 0 was selected while NO row rendered as
+// highlighted. `branches.list` is the screen's primary pane, so entering the
+// screen focuses it; Enter then checked out row 0, which since #135 is the
+// pinned default branch. Nothing on screen ever said it would.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { BranchesScreen } from "./Branches";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useKeymapStore, useFocusStore } from "@/features/keymap";
+import { mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { WithDialogs, resetDialogs } from "@/test/dialog";
+import type { BranchInfo } from "@/lib/types";
+
+const mkBranch = (over: Partial<BranchInfo> & { name: string }): BranchInfo => ({
+  isHead: false,
+  isRemote: false,
+  upstream: null,
+  ahead: 0,
+  behind: 0,
+  tip: "0".repeat(40),
+  tipTime: 0,
+  isDefault: false,
+  ...over,
+});
+
+const BRANCHES = [
+  mkBranch({ name: "chore/x", tipTime: 900 }),
+  mkBranch({ name: "main", tipTime: 100, isDefault: true }),
+  mkBranch({ name: "feat/y", tipTime: 950, isHead: true }),
+];
+
+let checkouts: string[] = [];
+
+const key = (k: string) =>
+  ({
+    key: k,
+    code: "",
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    preventDefault() {},
+    target: document.body,
+  }) as unknown as KeyboardEvent;
+
+/** Dispatch through the keymap store, flushing the resulting React updates. */
+function press(k: string): void {
+  act(() => {
+    useKeymapStore.getState().dispatch(key(k));
+  });
+}
+
+const branchRowNames = () =>
+  Array.from(document.querySelectorAll('[data-testid="branch-row"]')).map(
+    (el) => el.querySelector("span")?.textContent ?? "",
+  );
+
+function setup() {
+  checkouts = [];
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/feat/y" },
+    status: [],
+    branches: BRANCHES,
+    remotes: [],
+    tags: [],
+    stashes: [],
+    commits: [],
+    loading: false,
+    checkoutBranch: async (name: string) => {
+      checkouts.push(name);
+    },
+  } as never);
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => BRANCHES);
+  render(
+    <WithDialogs>
+      <BranchesScreen />
+    </WithDialogs>,
+  );
+  useFocusStore.setState({ focused: "branches.list" });
+}
+
+describe("Branches list activation", () => {
+  beforeEach(() => {
+    resetInvokeMock();
+    resetDialogs();
+    useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+    useKeymapStore.getState().setPreset("rider");
+    useFocusStore.setState({
+      focused: null,
+      panes: new Map(),
+      order: [],
+      barId: null,
+      pendingContentFocus: false,
+    });
+  });
+
+  it("checks nothing out on Enter while no row is selected", () => {
+    setup();
+
+    // Row 0 IS the pinned default — the whole reason a phantom selection here
+    // is dangerous rather than merely surprising.
+    expect(branchRowNames()[0]).toBe("main");
+    expect(document.querySelector("[data-selected]")).toBeNull();
+
+    press("Enter");
+
+    expect(checkouts).toEqual([]);
+  });
+
+  it("checks out once the user has actually selected a row", () => {
+    setup();
+
+    press("ArrowDown");
+    expect(document.querySelector("[data-selected]")).not.toBeNull();
+
+    press("Enter");
+
+    expect(checkouts).toEqual(["main"]);
+  });
+
+  it("clicking a row still selects and Enter then activates it", () => {
+    setup();
+
+    fireEvent.click(screen.getByText("chore/x"));
+    press("Enter");
+
+    expect(checkouts).toEqual(["chore/x"]);
+  });
+});

--- a/src/screens/Branches.tsx
+++ b/src/screens/Branches.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
+import { orderBranches } from "@/features/branches/orderBranches";
 import { PGPane, FocusableScroll, usePaneList } from "@/features/keymap";
 import type { BranchInfo, StashInfo, TagInfo } from "@/lib/types";
 // `tip` is a full oid (see list_branches); these two rows show it short.
@@ -132,10 +133,16 @@ export function BranchesScreen() {
       ...b,
       kind: b.isRemote ? ("remote" as const) : ("local" as const),
     }));
+    // Filter first, order second (#135) — ordering only permutes, so the pinned
+    // default branch cannot reappear once the filter has excluded it. Each kind
+    // is ordered WITHIN its group so the `all` view still lists locals before
+    // remotes rather than interleaving them by tip time.
     const filtered = list.filter((b) => b.name.includes(filter));
-    if (view === "local") return filtered.filter((b) => b.kind === "local");
-    if (view === "remote") return filtered.filter((b) => b.kind === "remote");
-    return filtered;
+    const locals = orderBranches(filtered.filter((b) => b.kind === "local"));
+    const remotes = orderBranches(filtered.filter((b) => b.kind === "remote"));
+    if (view === "local") return locals;
+    if (view === "remote") return remotes;
+    return [...locals, ...remotes];
   }, [branches, filter, view]);
 
   const visibleTags = React.useMemo(() => {

--- a/src/screens/Branches.tsx
+++ b/src/screens/Branches.tsx
@@ -171,16 +171,20 @@ export function BranchesScreen() {
     ],
     [rows, visibleTags, visibleStashes],
   );
-  const flatIndex = Math.max(
-    0,
-    flatRefs.findIndex(
-      (r) =>
-        selection &&
-        r.kind === selection.kind &&
-        (r.kind === "stash"
-          ? selection.kind === "stash" && r.index === selection.index
-          : selection.kind !== "stash" && r.name === selection.name),
-    ),
+  // -1 when nothing is selected, and it must STAY -1: this used to clamp to 0,
+  // so `list.activate` checked out row 0 while no row had ever appeared
+  // highlighted. `branches.list` is the screen's primary pane, so entering the
+  // screen focuses it — Enter was one keystroke away from checking out
+  // whatever sorted first, which since #135 is the pinned default branch.
+  // `usePaneList` handles -1: arrowing either way lands on row 0, and
+  // `onActivate(-1)` reads past the end of `flatRefs` and no-ops.
+  const flatIndex = flatRefs.findIndex(
+    (r) =>
+      selection &&
+      r.kind === selection.kind &&
+      (r.kind === "stash"
+        ? selection.kind === "stash" && r.index === selection.index
+        : selection.kind !== "stash" && r.name === selection.name),
   );
   usePaneList({
     paneId: "branches.list",

--- a/src/screens/Branches.upstream.test.tsx
+++ b/src/screens/Branches.upstream.test.tsx
@@ -24,6 +24,8 @@ const branch = (over: Partial<BranchInfo> = {}): BranchInfo => ({
   ahead: 0,
   behind: 0,
   tip: "abc1234",
+  tipTime: 0,
+  isDefault: false,
   ...over,
 });
 

--- a/src/screens/Compare.test.tsx
+++ b/src/screens/Compare.test.tsx
@@ -24,6 +24,8 @@ const branches: BranchInfo[] = [
     ahead: 0,
     behind: 0,
     tip: "a".repeat(40),
+    tipTime: 0,
+    isDefault: false,
   },
   {
     name: "feature",
@@ -33,6 +35,8 @@ const branches: BranchInfo[] = [
     ahead: 0,
     behind: 0,
     tip: "b".repeat(40),
+    tipTime: 0,
+    isDefault: false,
   },
 ];
 

--- a/src/screens/History.dnd.test.tsx
+++ b/src/screens/History.dnd.test.tsx
@@ -48,6 +48,8 @@ const branch = (name: string, isHead: boolean, tip: string): BranchInfo => ({
   ahead: 0,
   behind: 0,
   tip,
+  tipTime: 0,
+  isDefault: false,
 });
 
 function setup(opts: { repoState?: RepoState } = {}) {

--- a/src/screens/Pulls.test.tsx
+++ b/src/screens/Pulls.test.tsx
@@ -46,6 +46,8 @@ function branch(name: string, isHead = false): BranchInfo {
     ahead: 0,
     behind: 0,
     tip: "0".repeat(40),
+    tipTime: 0,
+    isDefault: false,
   };
 }
 


### PR DESCRIPTION
Closes #135

## What

Branch lists were unordered — `Libgit2Backend::branches` iterates `repo.branches(None)` and pushes, so the frontend got git's ref-iteration order (alphabetical), and nothing downstream sorted. `chore/bump-deps` sat above `main`; a branch touched five minutes ago sat below one abandoned last year.

Now: **the repository's default branch pins to the top, everything else falls in recency order (newest tip first)**, in all three surfaces that list branches.

**Backend** — `BranchInfo` gains `tip_time: i64` (committer time of the tip; one `find_commit` off the oid the loop already reads) and `is_default: bool`, mirrored in `lib/types.ts` in the same commit per the 1:1 contract. `tip` itself is untouched and stays a full oid.

Default-branch detection (`detect_default_branch`, `libgit2.rs`), in priority order:

1. `refs/remotes/<remote>/HEAD`'s symbolic target — git's own answer, written by `git clone` / `git remote set-head`. `origin` first, then other remotes alphabetically.
2. The first existing local `main` / `master` / `trunk`.
3. Nothing — no pin, pure recency.

Explicitly **not** `init.defaultBranch`: it describes branches that don't exist yet and would name `main` in a repo whose default is `master`. (`default_branch_name()` at `libgit2.rs:1930` is that config reader, for the Init dialog — deliberately not reused.)

**Frontend** — one pure, unit-tested comparator, `features/branches/orderBranches.ts`: default first, then `tipTime` descending, then `name` (plain `<`/`>`, not `localeCompare`, so branches cut from one commit order the same on every machine). Adopted by `BranchPicker.tsx`, `screens/Branches.tsx` and `features/palette/commands.ts` — one helper so a second ordering can't grow. Remote branches get the same treatment within their own section (`origin/main` pins at the top of Remote); the Branches screen orders each kind separately so the `all` view still lists locals before remotes.

**Every call site filters first and orders second**, and `orderBranches` only permutes — so the pin can never resurrect a row the query filtered out. Tested at both the helper and the picker level.

## Decisions the issue deferred to the spec

- **Recency = tip committer time** (`git branch --sort=-committerdate`). The reflog "last checked out" alternative models intent better but degrades to one entry on a fresh clone and has nothing useful for remote-tracking refs; noted as a possible follow-up.
- **The picker's cursor rests on the current branch** while the query is empty (row 0 once a query is typed). Enter checks out the active row, and `checkout()` already refuses the HEAD row — so this is the only starting position where a stray Enter does *nothing*. Starting on row 0 would have made Enter check out `main`, a sharper accident than today's alphabetical first row. This also fixes a latent bug: the index used to survive a query change and was only clamped to the new length.
- **HEAD does not pin.** It is already accent-coloured and badged, it is the branch the picker exists to *leave*, and under committer-time ordering it is usually near the top anyway.
- **Pinning never overrides search** — see above.

Consequence of the cursor rule: the active row is now scrolled into view (`block: "nearest"`), since the resting position can start below the fold. These rows are plainly mapped, not windowed, so the DOM route is sound here — the `scrollTopForRow` rule applies to the windowed diff surfaces.

## Docs

`docs/superpowers/specs/2026-08-16-branch-picker-order-spec.md` + `docs/superpowers/plans/2026-08-16-branch-picker-order-plan.md`.

## How to test

Open a repo with several branches and hit the titlebar branch chip: the default branch is row 1, the rest descend by last commit. Same on the Branches screen and in ⌘P → Checkout branch. Type a query that excludes the default — it stays gone.

Automated:

```
pnpm tsc --noEmit                                    # clean
pnpm test                                            # 168 files, 1368 tests
cargo check --manifest-path src-tauri/Cargo.toml     # clean
cargo test --manifest-path src-tauri/Cargo.toml      # all green (branches_tags: 24)
pnpm exec tsc -p e2e/tsconfig.json --noEmit          # clean
```

New coverage: 7 detection/`tip_time` cases in `src-tauri/tests/branches_tags.rs`, 9 in `orderBranches.test.ts`, 6 in `BranchPicker.test.tsx`, and one e2e case in `branches.e2e.ts` asserting the pin against `manyRefsRepo` (61 branches on one commit — without the pin `feature/branch-00` leads and `main` is sixty rows down).

**E2E was not executed on this branch** — only one e2e container build may run at a time across worktrees, so it is serialized centrally. Every existing spec that drives these rows matches on text (`[data-branch-row]*=main` in `branches.e2e.ts`, `merge-window.e2e.ts`, `merge-conflict.e2e.ts`; `[data-pal-type="branch"]*=feature` in `palette.e2e.ts`; `[data-pg-row]*=feature` in `keymap.e2e.ts`), and `settings.e2e.ts`'s `[data-testid="branch-row"]` only measures a row height — verified by reading them, none depend on order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Er25sN6pGoVJzmTBwHU2Tz