### PR TITLE
test: de-flake CommitPanel line-staging selection test

### DIFF
--- a/src/features/merge/MergeWindow.test.tsx
+++ b/src/features/merge/MergeWindow.test.tsx
@@ -185,6 +185,14 @@ describe("MergeWindow resolution flow", () => {
     mockInvoke("save_resolution", () => undefined);
     render(<MergeWindow />);
     await screen.findByTestId("merge-result");
+    // Same wait `setup` does, and for the same reason: this case builds its own
+    // fixture instead of calling it, so without this the chord below can land
+    // while regionStates is still empty and be dropped.
+    await waitFor(() =>
+      expect(screen.getByTestId("merge-conflict-counter")).toHaveTextContent(
+        /^0\//,
+      ),
+    );
     expect(screen.getByTestId("merge-apply")).toBeDisabled();
     // Accept ours on the multi-line region — pre-fix this threw a RangeError
     // (region `to` past the \r-stripped doc) so the counter never advanced.

--- a/src/screens/CommitPanel.lineFocus.test.tsx
+++ b/src/screens/CommitPanel.lineFocus.test.tsx
@@ -13,6 +13,7 @@ import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { useKeymapStore, useFocusStore } from "@/features/keymap";
 import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { settleDiff } from "@/test/settle";
 import { WithDialogs } from "@/test/dialog";
 import type { FileStatus } from "@/lib/types";
 
@@ -89,28 +90,6 @@ function press(k: string): boolean {
 const changedRows = () => screen.getAllByTestId("diff-line-changed");
 const focusedRowIndex = () =>
   changedRows().findIndex((r) => r.hasAttribute("data-focused"));
-
-/**
- * Wait until the pane has stopped refetching its diff.
- *
- * Mounting produces more than one `get_diff`, and EVERY new diff resets the line
- * cursor and clears the line selection by design — the indices would otherwise
- * address a diff that no longer exists. Driving the keyboard before that settles
- * lets a late resolution wipe the cursor mid-test, which is the shape of flake
- * that bit `CommitPanel.lineStaging.test.tsx`.
- */
-async function settleDiff() {
-  const count = () => getInvokeCalls().filter((c) => c.cmd === "get_diff").length;
-  let prev = -1;
-  while (prev !== count()) {
-    prev = count();
-    // One macrotask turn per pass: enough for a pending fetch to resolve and for
-    // the effect its result triggers to queue another.
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 0));
-    });
-  }
-}
 
 /** `status` seeds the store AND answers get_status, so the two cannot disagree. */
 async function setup(status: FileStatus[]) {

--- a/src/screens/CommitPanel.lineStaging.test.tsx
+++ b/src/screens/CommitPanel.lineStaging.test.tsx
@@ -6,11 +6,12 @@
 // additions must not shift the indices sent to the backend.
 
 import { describe, it, expect, beforeEach } from "vitest";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { CommitPanelScreen } from "./CommitPanel";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { settleDiff } from "@/test/settle";
 import { WithDialogs } from "@/test/dialog";
 import type { FileStatus } from "@/lib/types";
 
@@ -56,33 +57,6 @@ const stageLinesCall = () =>
   [...getInvokeCalls()].reverse().find((c) => c.cmd === "stage_lines");
 const stageHunkCall = () =>
   [...getInvokeCalls()].reverse().find((c) => c.cmd === "stage_hunk");
-
-/**
- * Wait until the pane has stopped refetching its diff AND React has run the
- * effects that arrival scheduled. Same helper as `CommitPanel.lineFocus.test.tsx`
- * — keep the two in step.
- *
- * `findAllByTestId` resolves the moment the rows are in the DOM, which is the
- * COMMIT of the diff render, not the end of it: React posts passive effects on
- * its own task queue, and RTL's async helpers only drain a timer task, so under
- * load the timer can win and `clearLineSel` — the effect that drops the line
- * selection whenever `diff` changes — is still pending. `fireEvent` then flushes
- * that stale clear and the click's own update into ONE render, in queue order,
- * so the clear lands last and the selection silently never happens. `act` queues
- * behind React's own task instead, so the effects are flushed before the click.
- */
-async function settleDiff() {
-  const count = () => getInvokeCalls().filter((c) => c.cmd === "get_diff").length;
-  let prev = -1;
-  while (prev !== count()) {
-    prev = count();
-    // One macrotask turn per pass: enough for a pending fetch to resolve and for
-    // the effect its result triggers to queue another.
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 0));
-    });
-  }
-}
 
 async function setup() {
   resetInvokeMock();

--- a/src/screens/CommitPanel.lineStaging.test.tsx
+++ b/src/screens/CommitPanel.lineStaging.test.tsx
@@ -6,7 +6,7 @@
 // additions must not shift the indices sent to the backend.
 
 import { describe, it, expect, beforeEach } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { CommitPanelScreen } from "./CommitPanel";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
@@ -50,12 +50,41 @@ const diffWithThreeAdditions = (path: string) => ({
 /** The hunk button's label, which is how a line selection becomes observable. */
 const selCountLabel = () => screen.getByTestId("hunk-stage").textContent ?? "";
 
+const changedRows = () => screen.getAllByTestId("diff-line-changed");
+
 const stageLinesCall = () =>
   [...getInvokeCalls()].reverse().find((c) => c.cmd === "stage_lines");
 const stageHunkCall = () =>
   [...getInvokeCalls()].reverse().find((c) => c.cmd === "stage_hunk");
 
-function setup() {
+/**
+ * Wait until the pane has stopped refetching its diff AND React has run the
+ * effects that arrival scheduled. Same helper as `CommitPanel.lineFocus.test.tsx`
+ * — keep the two in step.
+ *
+ * `findAllByTestId` resolves the moment the rows are in the DOM, which is the
+ * COMMIT of the diff render, not the end of it: React posts passive effects on
+ * its own task queue, and RTL's async helpers only drain a timer task, so under
+ * load the timer can win and `clearLineSel` — the effect that drops the line
+ * selection whenever `diff` changes — is still pending. `fireEvent` then flushes
+ * that stale clear and the click's own update into ONE render, in queue order,
+ * so the clear lands last and the selection silently never happens. `act` queues
+ * behind React's own task instead, so the effects are flushed before the click.
+ */
+async function settleDiff() {
+  const count = () => getInvokeCalls().filter((c) => c.cmd === "get_diff").length;
+  let prev = -1;
+  while (prev !== count()) {
+    prev = count();
+    // One macrotask turn per pass: enough for a pending fetch to resolve and for
+    // the effect its result triggers to queue another.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+  }
+}
+
+async function setup() {
   resetInvokeMock();
   useSettingsStore.setState({ ignoreWhitespaceInDiff: false });
   useRepoStore.setState({
@@ -75,21 +104,22 @@ function setup() {
       <CommitPanelScreen />
     </WithDialogs>,
   );
+  await screen.findAllByTestId("diff-line-changed");
+  await settleDiff();
 }
 
 describe("CommitPanel line-level staging (#61 D7)", () => {
   beforeEach(setup);
 
   it("stages only the clicked line, numbered among changed lines", async () => {
-    const rows = await screen.findAllByTestId("diff-line-changed");
+    const rows = changedRows();
     expect(rows).toHaveLength(3); // the context line is not selectable
 
     fireEvent.click(rows[1]); // second addition → changed index 1
-    // Wait for the selection to be observable before acting on it. The selection
-    // deliberately clears whenever `diff` changes, and the mount's diff fetch can
-    // still settle here; clicking Stage in the same tick then finds an empty
-    // selection and falls back to stage_hunk, so stage_lines is never called.
-    // Same reason the toggle-off case below waits between its two clicks.
+    // Wait for the selection to be observable before acting on it: clicking Stage
+    // while the selection is still empty falls back to stage_hunk, so stage_lines
+    // would never be called. Same reason the toggle-off case below waits between
+    // its two clicks.
     await waitFor(() => expect(selCountLabel()).toMatch(/1 line/i));
     fireEvent.click(screen.getByTestId("hunk-stage"));
 
@@ -103,7 +133,7 @@ describe("CommitPanel line-level staging (#61 D7)", () => {
   });
 
   it("shows the selection count on the stage button", async () => {
-    const rows = await screen.findAllByTestId("diff-line-changed");
+    const rows = changedRows();
     fireEvent.click(rows[0]);
     await waitFor(() => expect(selCountLabel()).toMatch(/1 line/i));
     fireEvent.click(screen.getAllByTestId("diff-line-changed")[2]);
@@ -111,7 +141,7 @@ describe("CommitPanel line-level staging (#61 D7)", () => {
   });
 
   it("extends a range on shift-click", async () => {
-    const rows = await screen.findAllByTestId("diff-line-changed");
+    const rows = changedRows();
     fireEvent.click(rows[0]);
     // Waiting for the anchor click to land, for the same reason the toggle-off
     // case below does: the selection deliberately clears when `diff` changes, and
@@ -135,7 +165,7 @@ describe("CommitPanel line-level staging (#61 D7)", () => {
   });
 
   it("toggles a line off when clicked twice", async () => {
-    const rows = await screen.findAllByTestId("diff-line-changed");
+    const rows = changedRows();
 
     // Waiting for the selected state between the clicks, rather than firing both
     // synchronously: the selection deliberately clears when `diff` changes, so a
@@ -153,7 +183,6 @@ describe("CommitPanel line-level staging (#61 D7)", () => {
   });
 
   it("falls back to whole-hunk staging with no selection", async () => {
-    await screen.findAllByTestId("diff-line-changed");
     fireEvent.click(screen.getByTestId("hunk-stage"));
 
     await waitFor(() => expect(stageHunkCall()).toBeDefined());
@@ -170,8 +199,8 @@ describe("CommitPanel line-level staging (#61 D7)", () => {
     // or it fails and never publishes the new status.
     mockInvoke("repo_state", () => "Clean");
     const diffCalls = () => getInvokeCalls().filter((c) => c.cmd === "get_diff");
-    const rows = await screen.findAllByTestId("diff-line-changed");
-    await waitFor(() => expect(diffCalls().length).toBeGreaterThan(0));
+    const rows = changedRows();
+    expect(diffCalls().length).toBeGreaterThan(0);
     const before = diffCalls().length;
 
     fireEvent.click(rows[0]);
@@ -183,7 +212,6 @@ describe("CommitPanel line-level staging (#61 D7)", () => {
   });
 
   it("does not offer line selection while whitespace is ignored", async () => {
-    await screen.findAllByTestId("diff-line-changed");
     fireEvent.click(screen.getByTitle("Ignore whitespace-only changes"));
 
     // Same reason hunk staging is disabled: ignore-whitespace rewrites hunk

--- a/src/test/settle.ts
+++ b/src/test/settle.ts
@@ -1,0 +1,43 @@
+// Settling a diff pane in component tests.
+//
+// Shared rather than copied: this guard is subtle enough that a second copy
+// drifts, and it is needed by every test that drives a diff surface the moment
+// its rows appear (CommitPanel's line-staging and line-focus suites today).
+
+import { act } from "@testing-library/react";
+import { getInvokeCalls } from "./invokeMock";
+
+/**
+ * Wait until the pane has stopped refetching its diff AND React has run the
+ * effects that arrival scheduled.
+ *
+ * Mounting produces more than one `get_diff`, and EVERY new diff resets the line
+ * cursor and clears the line selection by design — the indices would otherwise
+ * address a diff that no longer exists. Driving the pane before that settles lets
+ * a late resolution wipe the cursor mid-test.
+ *
+ * The second half matters just as much and is far less obvious. `findAllByTestId`
+ * resolves at the COMMIT of the render that first paints the rows, not at the end
+ * of it: React posts passive effects on its own task queue, and RTL's async
+ * helpers only drain a timer task, so under load the timer can win and the
+ * diff-keyed reset effect is still PENDING. `fireEvent` is act-wrapped and React
+ * flushes pending passive effects before it renders, so the stale reset and the
+ * interaction's own update coalesce into ONE render, applied in queue order — the
+ * reset lands last and the interaction silently never happened. `act` queues
+ * behind React's own task instead, so the effects are flushed first.
+ *
+ * Raising a `waitFor` timeout does NOT help: by the time it starts polling the
+ * state is already final and wrong, so more time only makes the failure slower.
+ */
+export async function settleDiff(): Promise<void> {
+  const count = () => getInvokeCalls().filter((c) => c.cmd === "get_diff").length;
+  let prev = -1;
+  while (prev !== count()) {
+    prev = count();
+    // One macrotask turn per pass: enough for a pending fetch to resolve and for
+    // the effect its result triggers to queue another.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+  }
+}


### PR DESCRIPTION
## The race

`CommitPanel.lineStaging.test.tsx > "stages only the clicked line, numbered among changed lines"` failed roughly 1 run in 7 of the full `pnpm test` suite, never in isolation:

```
AssertionError: expected 'Stage hunk' to match /1 line/i
  at await waitFor(() => expect(selCountLabel()).toMatch(/1 line/i))
```

The mount's `get_diff` had **already settled** — the rows cannot exist otherwise. The real race is one layer down.

`findAllByTestId` resolves at the **commit** of the render that first paints the diff rows, not at the end of it. React posts passive effects on its own task queue; RTL's async helpers only drain a timer task. Under CPU contention the timer wins, so `clearLineSel` — the effect that drops the line selection whenever `diff` changes (`CommitPanel.tsx:653`) — is still **pending** when the test clicks.

`fireEvent` is `act`-wrapped, and `performWorkOnRoot` flushes pending passive effects *before* rendering. So both updates land in **one** render, applied in queue order:

1. the click's functional updater → `{0: [1]}` (enqueued first)
2. the stale `clearLineSel` → `{}` (enqueued second, during the pre-render flush)

The clear wins. The label never changes — not even transiently — so the selection silently never happens, `waitFor(/1 line/)` times out at 1000 ms, and Stage falls back to `stage_hunk`.

Instrumented proof at a captured failure: **zero** `characterData` mutations on the button label and **no** `data-selected` change on any row, while the click still produced a full re-render. That signature is what distinguishes "set then cleared in a later render" from "coalesced into one render, clear last" — only the second produces no intermediate DOM at all.

## Why not just raise the timeout

By the time `waitFor` starts polling, the state is already final and wrong. More time cannot help; a slower CI runner would just re-expose it.

## The fix

`setup` now waits for the diff to stop refetching via `settleDiff`, whose `act` turn queues behind React's own task (`act`'s exit `enqueueTask` is FIFO with the scheduler's pending immediate), so the effects are flushed before the first click. Tests read rows via `changedRows()` instead of re-finding them.

**Five of the seven tests in that file shared the racy shape** — every one whose first click must produce a line selection — so the guard goes in `setup` rather than being sprinkled per test.

`CommitPanel.lineFocus.test.tsx` already had this helper, and its doc comment already named this flake by file. The second commit therefore extracts it to `src/test/settle.ts` so there is one copy rather than the two this PR would otherwise leave behind, carrying the original's explanation across.

## Same shape elsewhere

Audited every `await findBy*` immediately followed by a click or keypress — 24 sites. Exactly one other qualifies: the CRLF case in `MergeWindow.test.tsx` builds its own fixture instead of calling that file's `setup`, and so skipped the `regionStates` wait `setup` documents for precisely this reason. It failed once during this work's baseline runs. It now takes the same wait its three siblings already take.

That hunk is a `waitFor` on the conflict counter, **not** `settleDiff` — that file has no `get_diff` to count, and the counter reaching `0/N` is a positive DOM signal that the effect committed, which is strictly stronger than a settle. Reusing `settleDiff` there would also have left one of the file's four sites inconsistent with the other three.

Everything else either has no reset-on-async-data effect or already guards.

Production code is untouched.

## Before / after

| | full suite, unloaded | full suite, under load (6–10 CPU spinners) | targeted harness firing the interaction in the microtask right after the commit |
|---|---|---|---|
| line-staging, baseline | 12/12 green (does not reproduce) | 1 failure in 8 runs | **fails 100%** |
| line-staging, fixed | **15/15 green** | **16/16 green** | **720/720 green** |
| MergeWindow CRLF, baseline | — | 1 failure in 30 runs | **90/90 failures** |
| MergeWindow CRLF, fixed | — | no failures observed | **0/90 failures** |

A further **15/15** green full-suite runs after the helper extraction — a refactor of the guard is exactly the change that could reintroduce what it fixes, so a single green run would not have shown it.

`pnpm tsc --noEmit` clean. No e2e run (irrelevant to this change).