### PR TITLE
ci: run vitest and cargo test on PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,207 @@
+name: tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Decides which of the two suites a change can possibly affect.
+  #
+  # Unlike the E2E filter — which rebuilds the whole binary and so has to care
+  # about src/, src-tauri/ and e2e/ together, under a single `app` output —
+  # these two suites have DISJOINT inputs, so they get an output each and skip
+  # independently:
+  #   * `js`   vitest + both typechecks. Read src/, e2e/ and the JS build
+  #            config. No amount of Rust can change their result.
+  #   * `rust` cargo test. Reads src-tauri/ only. It never compiles the
+  #            frontend: asset embedding is behind the `custom-protocol`
+  #            feature, so tauri-build is happy with no dist/ present.
+  #
+  # The filter runs for pull_request events only. On push and workflow_dispatch
+  # there is no reliable diff base, so both outputs fall back to 'true' (a
+  # skipped step has no outputs, and the `||` picks up the empty string) and
+  # both suites run — main is never left untested.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      js: ${{ steps.filter.outputs.js || 'true' }}
+      rust: ${{ steps.filter.outputs.rust || 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: filter
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
+          echo "Changed files:"
+          echo "$changed" | sed 's/^/  /'
+
+          # e2e/ counts as frontend input because `tsc -p e2e/tsconfig.json`
+          # runs in the unit job — the root tsconfig excludes e2e/, so nothing
+          # else typechecks the specs.
+          if echo "$changed" | grep -qE '^(src/|e2e/|index\.html$|package\.json$|pnpm-lock\.yaml$|vite\.config\.ts$|tsconfig[a-z.]*\.json$|\.github/workflows/tests\.yml$)'; then
+            echo "js=true" >> "$GITHUB_OUTPUT"
+            echo "-> frontend sources touched, running the unit suite"
+          else
+            echo "js=false" >> "$GITHUB_OUTPUT"
+            echo "-> no frontend sources touched, skipping the unit suite"
+          fi
+
+          if echo "$changed" | grep -qE '^(src-tauri/|\.github/workflows/tests\.yml$)'; then
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+            echo "-> backend sources touched, running the Rust suite"
+          else
+            echo "rust=false" >> "$GITHUB_OUTPUT"
+            echo "-> no backend sources touched, skipping the Rust suite"
+          fi
+
+  # Frontend: both typechecks plus the vitest unit + component tests. Pure
+  # Node/jsdom — no Tauri system deps, no webview, no Rust toolchain.
+  unit:
+    needs: changes
+    if: needs.changes.outputs.js == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck src
+        run: pnpm tsc --noEmit
+
+      - name: Unit and component tests
+        run: pnpm test
+
+      # Separate command on purpose: the root tsconfig has `"exclude": ["e2e"]`,
+      # so the step above never sees the specs. This is the only place they are
+      # compiled anywhere in CI.
+      - name: Typecheck e2e specs
+        run: pnpm exec tsc -p e2e/tsconfig.json --noEmit
+
+  # Backend: the libgit2 integration suite in src-tauri/tests/, which drives
+  # every GitBackend op against real temp repos.
+  rust:
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      # Same package list e2e.yml installs, minus xvfb: linking the crate pulls
+      # in the real Tauri stack, so the -dev packages are needed at BUILD time,
+      # but the tests themselves are headless (libgit2 against temp repos, no
+      # window, no network) and never need an X server at RUNTIME.
+      - name: Install Tauri system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev \
+            libayatana-appindicator3-dev librsvg2-dev patchelf
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      # Several fixtures shell out to real `git` (rebase, clone, submodules,
+      # LFS). A bare runner has no committer identity, so those calls would
+      # fail with "Please tell me who you are" before reaching any assertion.
+      - name: Configure git for fixtures
+        run: |
+          git config --global user.name "CI"
+          git config --global user.email "ci@platypusgit.test"
+          git config --global init.defaultBranch main
+
+      - name: Cargo test
+        run: cargo test --manifest-path src-tauri/Cargo.toml
+
+  # The two gate jobs below are the ones worth adding to the branch ruleset as
+  # required checks. They always run and always report, so a PR that legitimately
+  # skipped a suite is not left waiting forever on a check that never arrives —
+  # the trap that makes a path-filtered required check block a PR permanently.
+  # Equally, they fail rather than pass when a suite was skipped for any reason
+  # OTHER than the filter clearing it, so a green tick always means the suite
+  # either ran or could not have been affected.
+  unit-tests:
+    needs: [changes, unit]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gate on the unit result
+        env:
+          FILTER: ${{ needs.changes.result }}
+          TOUCHED: ${{ needs.changes.outputs.js }}
+          RESULT: ${{ needs.unit.result }}
+        run: |
+          echo "filter job: $FILTER / frontend touched: $TOUCHED / unit job: $RESULT"
+          # A failed filter job skips `unit` too. Without this check the gate
+          # would read that skip as "not required" and pass a PR whose suite
+          # never ran at all.
+          if [ "$FILTER" != "success" ]; then
+            echo "The change-filter job did not succeed, so the suite never ran."
+            exit 1
+          fi
+          case "$RESULT" in
+            success) echo "Unit suite passed." ;;
+            skipped)
+              # Only legitimate when the filter decided no frontend code was touched.
+              if [ "$TOUCHED" != "false" ]; then
+                echo "Unit suite was skipped even though frontend code changed."
+                exit 1
+              fi
+              echo "No frontend code touched — unit suite not required for this change."
+              ;;
+            *) echo "Unit suite did not pass."; exit 1 ;;
+          esac
+
+  rust-tests:
+    needs: [changes, rust]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gate on the Rust result
+        env:
+          FILTER: ${{ needs.changes.result }}
+          TOUCHED: ${{ needs.changes.outputs.rust }}
+          RESULT: ${{ needs.rust.result }}
+        run: |
+          echo "filter job: $FILTER / backend touched: $TOUCHED / rust job: $RESULT"
+          if [ "$FILTER" != "success" ]; then
+            echo "The change-filter job did not succeed, so the suite never ran."
+            exit 1
+          fi
+          case "$RESULT" in
+            success) echo "Rust suite passed." ;;
+            skipped)
+              # Only legitimate when the filter decided no backend code was touched.
+              if [ "$TOUCHED" != "false" ]; then
+                echo "Rust suite was skipped even though backend code changed."
+                exit 1
+              fi
+              echo "No backend code touched — Rust suite not required for this change."
+              ;;
+            *) echo "Rust suite did not pass."; exit 1 ;;
+          esac

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,29 @@ Four layers, each run independently:
     second window's open/transition/close (`switchWindow` → "No window could be
     found").
 
+### What CI runs
+
+Two workflows cover the four layers, both on PRs to `main`, pushes to `main`,
+and `workflow_dispatch`:
+
+- `.github/workflows/tests.yml` — the `unit` job (`pnpm tsc --noEmit`,
+  `pnpm test`, and `pnpm exec tsc -p e2e/tsconfig.json --noEmit`, which is the
+  ONLY place the e2e specs are typechecked since the root tsconfig excludes
+  `e2e/`) and the `rust` job (`cargo test`). The Rust job installs e2e.yml's
+  Tauri `-dev` packages because linking the crate needs them, but no xvfb: the
+  integration tests drive libgit2 against temp repos, with no window and no
+  network.
+- `.github/workflows/e2e.yml` — the webview suite.
+
+Each workflow front-loads a `changes` job that diffs against the PR base and
+skips suites the change cannot affect, then reports through an always-running
+gate job (`unit-tests`, `rust-tests`, `e2e-linux`). **The gate is what a branch
+ruleset should require, never the worker job** — a required check that gets
+skipped never reports and blocks the PR forever. The gate also fails on a skip
+it cannot explain, so a green tick means the suite ran or was provably
+irrelevant. On `push`/`workflow_dispatch` there is no reliable diff base, so
+every filter output falls back to `true` and `main` is never left untested.
+
 ## Architecture
 
 ### Backend (`src-tauri/src/`)
@@ -1097,7 +1120,6 @@ lib/
 ## Things deliberately NOT in codebase
 
 - Shell integration / Finder / Explorer overlays (out of scope).
-- CI config.
 - Custom icons — Tauri defaults for now. Replace before first release.
 - Code signing config for bundles.
 - Broad test suite — unit tests exist for pure logic (graphLayout, buildRebasePlan) + libgit2 smoke. Add tests alongside each feature as built.


### PR DESCRIPTION
## The gap

Nothing on a runner ran either test suite. Grepping every existing workflow for the test commands returns nothing:

```
$ grep -rn 'cargo test\|pnpm test\b\|vitest' .github/workflows/
(no matches)
```

The only test invocations anywhere were `pnpm test:e2e:build` / `pnpm test:e2e:run` in `e2e.yml`. So:

- **~520 Rust integration tests** (52 binaries under `src-tauri/tests/`) — ran only on developer machines.
- **~1400 vitest unit + component tests** (170 files) — same.
- **The e2e typecheck gate** (`tsc -p e2e/tsconfig.json`) — verified nowhere, since the root tsconfig has `"exclude": ["e2e"]`.

The required check (`e2e-linux`) gated solely on the webview suite. Several PRs are in flight whose safety argument rests on Rust integration tests that no CI run would ever execute.

## What this adds

One workflow, `.github/workflows/tests.yml`, on `pull_request: [main]` / `push: [main]` / `workflow_dispatch`, structured to mirror `e2e.yml` (same concurrency group shape, pnpm 9 / Node 22, `dtolnay/rust-toolchain@stable`, `Swatinem/rust-cache@v2` with `workspaces: src-tauri`, same `changes` + gate-job pattern).

| job | runs |
|---|---|
| `unit` | `pnpm install --frozen-lockfile`, `pnpm tsc --noEmit`, `pnpm test`, `pnpm exec tsc -p e2e/tsconfig.json --noEmit` |
| `rust` | `cargo test --manifest-path src-tauri/Cargo.toml` |

Notes on the `rust` job:

- It installs `e2e.yml`'s Tauri `-dev` packages verbatim **minus `xvfb`** — linking the crate needs the dev packages at build time, but the tests are headless (libgit2 against temp repos; no window, and no network: `network.rs` uses a local bare repo as its "remote", `update.rs` uses fakes).
- It needs **no frontend build**. Asset embedding sits behind the `custom-protocol` feature, so `tauri-build` is happy with no `dist/` present — verified locally in a fresh worktree that never ran `pnpm build`.
- It sets the same git identity `e2e.yml` does, because ~26 fixtures shell out to real `git` and a bare runner has no committer identity.

## Path filter

`e2e.yml` has one `app` output because any of `src/`, `src-tauri/`, `e2e/` forces a binary rebuild. These two suites have **disjoint inputs**, so they get an output each and skip independently — Rust cannot change a vitest result, and `src/` cannot change a cargo one.

Dry-run of the actual regexes:

| changed | `js` | `rust` |
|---|---|---|
| `src/screens/History.tsx` | true | false |
| `src-tauri/src/git/libgit2.rs` | false | true |
| `e2e/specs/foo.e2e.ts` | true | false |
| `package.json`, `pnpm-lock.yaml`, `vite.config.ts`, `tsconfig*.json`, `index.html` | true | false |
| docs / site / README only | false | false |
| this PR (`tests.yml` + `CLAUDE.md`) | true | true |

`e2e/` counts as frontend input because the e2e typecheck runs in the `unit` job.

Both outputs keep e2e's safety property: the filter step is `if: github.event_name == 'pull_request'`, and on `push` / `workflow_dispatch` a skipped step has no outputs, so `|| 'true'` picks up the empty string and both suites run. **`main` is never left untested.**

## Gate jobs

`unit-tests` and `rust-tests` copy `e2e-linux`'s logic, which is load-bearing: they `if: always()`, so they always report (a path-filtered *required* check that gets skipped never reports and blocks the PR forever), and they **fail** when a suite was skipped for any reason other than the filter clearing it — including a failed filter job, which would otherwise skip the worker and read as "not required". Without that, a docs-only PR would report green having run nothing.

## Required checks — NOT set by this PR

Nothing was made required automatically; that is a repo-settings change and your call. To make it required, add these two job names to the `main` ruleset (id `18319179`) alongside the existing `e2e-linux`:

- `unit-tests`
- `rust-tests`

Use the **gate** names, not the worker names `unit` / `rust` — the workers are path-filtered and would hang a PR that legitimately skipped them.

## Verification

All four commands run locally on this branch, in a fresh worktree (no `node_modules`, no `target`, no `dist/`):

```
pnpm tsc --noEmit                                 exit 0
pnpm test                                         exit 0   170 files, 1394 passed
pnpm exec tsc -p e2e/tsconfig.json --noEmit       exit 0
cargo test --manifest-path src-tauri/Cargo.toml   exit 0   52 binaries, 520 passed, 0 warnings
```

No application code, tests, or `package.json` scripts were touched. This PR also changes `CLAUDE.md`, which listed CI config under "Things deliberately NOT in codebase" — stale since `e2e.yml` / `release.yml` / `site.yml` landed.

Because this PR touches `tests.yml`, both filters fire and the new workflow verifies itself on this PR.