### PR TITLE
test(e2e): wait on the UI, not repo state, in the racy specs

### DIFF
--- a/.claude/skills/e2e-testing/SKILL.md
+++ b/.claude/skills/e2e-testing/SKILL.md
@@ -128,6 +128,53 @@ repainting) can only appear after the whole backend call returned, which is
 strictly after every part of the git op. Prefer it; when you truly must wait on
 repo truth, wait on the LAST thing the command does, not the first.
 
+**And you cannot guess which part is last — read the implementation.** The
+orderings that bit this suite are all counter-intuitive, and each one made a wait
+resume mid-operation:
+
+| Op | Order | What the wrong wait cost |
+|---|---|---|
+| `git stash push` | `refs/stash` → worktree | entry present, file still dirty (#133) |
+| libgit2 hard reset | checkout → **HEAD** → index (`reset.c`) | HEAD moved, index still on the old tree → `git status` reports the file *staged* |
+| `rebase_abort` | `set_head(branch)` → hard reset | HEAD back on the branch, conflicted worktree still there (measured: `UU conflict.txt`) |
+| `git pull` (fast-forward) | worktree + index → **ref** | pulled file readable, `log -1` still the old commit |
+
+Note the last two point in OPPOSITE directions — a reset publishes its ref
+early, a fast-forward publishes it late — so "wait on HEAD" is neither safe nor
+unsafe in general. Only the UI signal is safe in general, because it needs the
+whole IPC call to have returned. Widen the window to check a suspicion: a
+20 000-file fixture turned the rebase-abort race from unobservable into 2 runs
+out of 2.
+
+**A wait must not be able to bind to the screen you are LEAVING.** Sharper than
+it sounds, because this driver makes the mistake unrecoverable. `$(sel)` resolved
+a moment before a screen switch can match a row on the outgoing screen; when
+React unmounts it, the embedded driver does **not** report the handle as stale —
+it still holds the detached node, `checkVisibility()` on it is simply `false`, so
+WebdriverIO's stale-element refetch never fires and `waitForDisplayed` polls a
+dead node until the deadline, with the row it wanted on screen the whole time.
+Load-dependent (a busier machine loses the race more often) and immune to a
+bigger timeout — `history-ops`'s `[data-pg-row]*=b.txt`, which also matched
+History's commit row for "feat: add b.txt", failed 4 runs in 10 under CPU
+contention at 25s, having already been raised from 15s for exactly this symptom.
+So, after any action that changes screens: **wait on a signal that exists only on
+the destination first** (its `DeepViewHeader` crumb — name the shas it should
+carry, so a mis-route fails there saying which pair it got), and make the follow-up
+selector unambiguous — pure CSS scoped to the destination's pane
+(`[data-pg-pane="commitDiff.files"] [data-pg-row][data-path="b.txt"]`), not
+`*=`-text that some other screen also satisfies.
+
+**A readiness signal that is also true of "not started yet" is not a readiness
+signal.** `merge-window` waited for Apply to be *disabled* to mean "the next
+file's fresh model is unresolved", but `canApply`'s `allResolved` is
+`regionStates.every(...)` — vacuously true while the list is empty — so a
+retarget goes disabled (loading) → briefly ENABLED with zero regions → disabled
+(one unresolved region). The wait was satisfied by the first, so ⌘1 could land in
+the second with no region to accept and be dropped: "Apply never enabled for the
+second file", CI-only. Wait for the counter to read `0/N` instead — a state only
+the seeded-and-unresolved model produces. Same fix, same reason, as the
+`regionStates` guard in `MergeWindow.test.tsx`.
+
 ## Debugging
 
 1. Reproduce on one spec: `pnpm test:e2e:docker run --spec e2e/specs/<file>`.

--- a/.claude/skills/e2e-testing/SKILL.md
+++ b/.claude/skills/e2e-testing/SKILL.md
@@ -146,21 +146,33 @@ whole IPC call to have returned. Widen the window to check a suspicion: a
 20 000-file fixture turned the rebase-abort race from unobservable into 2 runs
 out of 2.
 
-**A wait must not be able to bind to the screen you are LEAVING.** Sharper than
-it sounds, because this driver makes the mistake unrecoverable. `$(sel)` resolved
-a moment before a screen switch can match a row on the outgoing screen; when
-React unmounts it, the embedded driver does **not** report the handle as stale —
-it still holds the detached node, `checkVisibility()` on it is simply `false`, so
-WebdriverIO's stale-element refetch never fires and `waitForDisplayed` polls a
-dead node until the deadline, with the row it wanted on screen the whole time.
-Load-dependent (a busier machine loses the race more often) and immune to a
-bigger timeout — `history-ops`'s `[data-pg-row]*=b.txt`, which also matched
-History's commit row for "feat: add b.txt", failed 4 runs in 10 under CPU
+**A wait must not be able to bind to the screen you are LEAVING**, because
+`waitForDisplayed` cannot recover from it. `$(sel)` resolved a moment before a
+screen switch can match a row on the OUTGOING screen, and once React unmounts
+that row the wait is dead — for a reason specific to how `isDisplayed` is built,
+so don't assume the usual stale-element recovery covers you:
+
+- WebdriverIO's refetch DOES work for protocol-level element commands. Measured:
+  `getText()` on such a handle raises stale, `refetchElement` re-runs the
+  selector, `elementId` changes, and it returns the NEW row's text.
+- but `isDisplayed` doesn't go through the protocol. It is
+  `browser.execute(checkVisibility, elem)` plus a `getComputedStyle` probe, with
+  the element passed as an ARGUMENT — and a detached node answers both honestly:
+  `checkVisibility()` is `false`, `getComputedStyle()` returns empty rather than
+  throwing. No "stale element reference" is ever raised, so
+  `elementErrorHandler` has nothing to catch and never refetches.
+- so `waitForDisplayed` (which is `waitUntil(() => isDisplayed())`) polls the
+  dead node for its entire budget, with the row it wanted on screen the whole
+  time.
+
+Load-dependent (a busier machine loses the resolve-vs-swap race more often) and
+immune to a bigger timeout — `history-ops`'s `[data-pg-row]*=b.txt`, which also
+matched History's commit row for "feat: add b.txt", failed 4 runs in 10 under CPU
 contention at 25s, having already been raised from 15s for exactly this symptom.
 So, after any action that changes screens: **wait on a signal that exists only on
 the destination first** (its `DeepViewHeader` crumb — name the shas it should
-carry, so a mis-route fails there saying which pair it got), and make the follow-up
-selector unambiguous — pure CSS scoped to the destination's pane
+carry, so a mis-route fails there saying which pair it got), and make the
+follow-up selector unambiguous — pure CSS scoped to the destination's pane
 (`[data-pg-pane="commitDiff.files"] [data-pg-row][data-path="b.txt"]`), not
 `*=`-text that some other screen also satisfies.
 

--- a/e2e/specs/bisect.e2e.ts
+++ b/e2e/specs/bisect.e2e.ts
@@ -91,14 +91,26 @@ describe("bisect", () => {
 
     // One mark, and git records it.
     const before = repo.git("bisect", "log").split("\n").length;
+    const detailBefore = await $('[data-testid="operation-detail"]').getText();
     await $('[data-testid="bisect-bad"]').click();
+    // The UI, not `git bisect log`. `git bisect <term>` writes BISECT_LOG and
+    // only THEN checks out the next revision, and `bisect_mark` runs that
+    // subprocess OUTSIDE the backend's repo mutex — so resuming on the log
+    // would let the Reset below start a second `git` in this worktree while the
+    // first is still checking out, and one of them loses `.git/index.lock`. The
+    // bar's progress numbers come from the mark command's own return value, so
+    // they cannot change until the whole call returned. A fresh `$()` per poll,
+    // never a handle taken before the click: a detached node stays resolvable
+    // on this driver and would answer forever with its old text.
     await browser.waitUntil(
-      async () => repo!.git("bisect", "log").split("\n").length > before,
+      async () =>
+        (await $('[data-testid="operation-detail"]').getText()) !== detailBefore,
       {
         timeout: 20_000,
-        timeoutMsg: "git bisect log never grew after marking a revision",
+        timeoutMsg: "the bisect progress never advanced after marking a revision",
       },
     );
+    expect(repo.git("bisect", "log").split("\n").length).toBeGreaterThan(before);
 
     // Reset — NOT the generic abort, which hard-resets to the detached commit
     // being tested. It confirms first.

--- a/e2e/specs/bisect.e2e.ts
+++ b/e2e/specs/bisect.e2e.ts
@@ -99,9 +99,9 @@ describe("bisect", () => {
     // would let the Reset below start a second `git` in this worktree while the
     // first is still checking out, and one of them loses `.git/index.lock`. The
     // bar's progress numbers come from the mark command's own return value, so
-    // they cannot change until the whole call returned. A fresh `$()` per poll,
-    // never a handle taken before the click: a detached node stays resolvable
-    // on this driver and would answer forever with its old text.
+    // they cannot change until the whole call returned. A fresh `$()` per poll
+    // rather than a handle taken before the click, so the read cannot depend on
+    // WebdriverIO's stale-element refetch behaving a particular way.
     await browser.waitUntil(
       async () =>
         (await $('[data-testid="operation-detail"]').getText()) !== detailBefore,

--- a/e2e/specs/history-ops.e2e.ts
+++ b/e2e/specs/history-ops.e2e.ts
@@ -121,13 +121,16 @@ describe("history danger ops", () => {
     // History's commit row for "feat: add b.txt" — and that is what made this
     // the suite's most frequent CI failure. Resolved a moment too early (more
     // likely the busier the machine), the handle binds to a row the screen
-    // switch is about to unmount, and the embedded driver never reports that
-    // node as stale: it stays resolvable and simply answers "not displayed"
-    // forever, so WebdriverIO's stale-element refetch cannot fire. Measured:
-    // 4 failures in 10 under CPU contention with the old selector, 0 in 10 with
-    // this pair of waits, and 1/1 when the binding is forced deliberately — in
-    // every failure the real b.txt row was on screen for the whole 25s. Raising
-    // the deadline (15s → 25s, which was tried) could never have helped.
+    // switch is about to unmount, and `waitForDisplayed` cannot recover from
+    // that: `isDisplayed` is a `browser.execute(checkVisibility, elem)` with the
+    // element passed as an argument, and a DETACHED node answers honestly
+    // (`false`, and `getComputedStyle` returns empty rather than throwing), so no
+    // stale-element error is ever raised and WebdriverIO's refetch never fires.
+    // Measured: 4 failures in 10 under CPU contention with the old selector,
+    // 0 in 10 with this pair of waits, and 1/1 when the binding is forced
+    // deliberately — in every failure the real b.txt row was on screen for the
+    // whole 25s. Raising the deadline (15s → 25s, which was tried) could never
+    // have helped.
     await $(
       '[data-pg-pane="commitDiff.files"] [data-pg-row][data-path="b.txt"]',
     ).waitForDisplayed({

--- a/e2e/specs/history-ops.e2e.ts
+++ b/e2e/specs/history-ops.e2e.ts
@@ -98,19 +98,41 @@ describe("history danger ops", () => {
     await $("div*=2 commits selected").waitForDisplayed({
       timeout: 10_000, timeoutMsg: "multi-select detail never appeared",
     });
-    await $("button*=View combined diff").click();
     // Oldest selected = "feat: add b.txt" (parent "feat: add a.txt"); newest =
-    // "fix: update a.txt". The combined diff therefore introduces b.txt.
-    // 25s, not the 15s the rest of this file uses for UI waits: this is the
-    // only assertion here that spans BOTH a screen transition AND a backend
-    // diff_commits round-trip, and it is the suite's most frequent CI failure
-    // (three times across unrelated branches, always under parallel-spec load,
-    // never when the spec runs alone). The operation is genuinely slower than
-    // the old budget under contention — the deadline was wrong, not the app.
-    await $('[data-pg-row]*=b.txt').waitForDisplayed({
-      timeout: 25_000,
-      timeoutMsg:
-        "combined diff never listed b.txt (CommitDiff mounts before diff_commits resolves, so this waits on the fetch)",
+    // "fix: update a.txt". The combined diff therefore runs
+    // parent-of-oldest → newest and introduces b.txt. Both shas come from repo
+    // truth, sliced to 7 the way `targetHeader` renders them.
+    const from = repo.git("rev-parse", "HEAD~2").trim().slice(0, 7);
+    const to = repo.git("rev-parse", "HEAD").trim().slice(0, 7);
+    await $("button*=View combined diff").click();
+
+    // TWO waits, in this order, and neither is redundant.
+    //
+    // First the DESTINATION screen's own header — a signal that exists only
+    // after the transition, and one that names the pair that was routed, so a
+    // mis-routed selection fails HERE saying so, instead of as a mute timeout
+    // on a file row further down.
+    await $(`div*=Diff ${from} → ${to}`).waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: `the commit-diff header never showed ${from} → ${to}`,
+    });
+    // Then the file row, as a PURE CSS selector scoped to the commit-diff file
+    // pane. This used to be `[data-pg-row]*=b.txt`, which ALSO matches
+    // History's commit row for "feat: add b.txt" — and that is what made this
+    // the suite's most frequent CI failure. Resolved a moment too early (more
+    // likely the busier the machine), the handle binds to a row the screen
+    // switch is about to unmount, and the embedded driver never reports that
+    // node as stale: it stays resolvable and simply answers "not displayed"
+    // forever, so WebdriverIO's stale-element refetch cannot fire. Measured:
+    // 4 failures in 10 under CPU contention with the old selector, 0 in 10 with
+    // this pair of waits, and 1/1 when the binding is forced deliberately — in
+    // every failure the real b.txt row was on screen for the whole 25s. Raising
+    // the deadline (15s → 25s, which was tried) could never have helped.
+    await $(
+      '[data-pg-pane="commitDiff.files"] [data-pg-row][data-path="b.txt"]',
+    ).waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "the combined diff never listed b.txt",
     });
   });
 

--- a/e2e/specs/history-ops.e2e.ts
+++ b/e2e/specs/history-ops.e2e.ts
@@ -3,7 +3,7 @@ import { cherryRepo, multiCherryRepo, TempRepo } from "../support/tempRepo";
 import {
   openRepo, resetApp, switchScreen, stubNativeDialogs,
   jsContextMenu, jsHoverMenuItem, jsClickMenuItem, jsSelectValue, jsChord,
-  scrollCommitListTo,
+  scrollCommitListTo, waitHeadMarkerOn,
 } from "../support/app";
 
 describe("history danger ops", () => {
@@ -41,10 +41,16 @@ describe("history danger ops", () => {
     await jsContextMenu('[data-testid="commit-row"]', { text: "feat: add b.txt" });
     await jsHoverMenuItem("Reset current branch to here");
     await jsClickMenuItem("Hard (discard changes)");
-    await browser.waitUntil(
-      async () => repo.git("rev-parse", "HEAD").trim() === parent,
-      { timeout: 20_000, timeoutMsg: "hard reset did not move HEAD" },
-    );
+    // The UI, not `rev-parse HEAD` — unlike the soft case above, this reset has
+    // work left to do after the ref moves. libgit2 writes in the order
+    // checkout → HEAD → index (`reset.c`), so the branch ref is readable while
+    // the INDEX still holds the old tree, and `git status` compares against
+    // HEAD: it would report a.txt as staged and lose the race with the
+    // clean-tree assertion below. The HEAD marker moving to the parent's row
+    // can only paint after `refreshAll` re-read the branch tip, which is
+    // strictly after the whole reset call returned.
+    await waitHeadMarkerOn("feat: add b.txt");
+    expect(repo.git("rev-parse", "HEAD").trim()).toBe(parent);
     expect(repo.git("status", "--porcelain").trim()).toBe("");
   });
 

--- a/e2e/specs/merge-window.e2e.ts
+++ b/e2e/specs/merge-window.e2e.ts
@@ -176,19 +176,35 @@ describe("merge resolver window", () => {
     await expect(
       $(`[data-testid="merge-file-row"][data-path="${firstPath}"]`),
     ).toHaveAttribute("data-resolved", "true");
-    // Wait for the second file's fresh (unresolved) model to finish loading
-    // before driving it: Apply stays disabled until the new region is seeded.
-    // Sending the accept chord earlier races the async sides fetch + editor
-    // remount. try/catch treats a mid-transition window as not-ready-yet.
+    // Wait for the second file's fresh model to have SEEDED ITS REGIONS before
+    // driving it — the counter reading `0/N`, not "Apply is disabled".
+    //
+    // "Apply is disabled" is ambiguous, and the gap between its two meanings is
+    // where the CI-only "Apply never enabled for the second file" flake lived.
+    // `canApply` is `!loading && !!model && !chooser && allResolved`, and
+    // `allResolved` is `regionStates.every(...)` — which is TRUE for an empty
+    // list (deliberately: a zero-conflict auto-merge file is applyable). So the
+    // retarget goes disabled (loading) → briefly ENABLED with zero regions
+    // (model in, regionStates not seeded yet) → disabled again (one unresolved
+    // region). The old wait was satisfied by the FIRST of those, so ⌘1 could
+    // land in the second and be dropped for want of a region to accept, and
+    // Apply then never enabled. `0/N` can only be the fresh unresolved file:
+    // file one's counter read `1/1` before its Apply. try/catch treats a
+    // mid-transition window as not-ready-yet.
     await browser.waitUntil(
       async () => {
         try {
-          return !(await $('[data-testid="merge-apply"]').isEnabled());
+          return /^0\/[1-9]/.test(
+            await $('[data-testid="merge-conflict-counter"]').getText(),
+          );
         } catch {
           return false;
         }
       },
-      { timeout: 10_000, timeoutMsg: "second file never settled as unresolved" },
+      {
+        timeout: 10_000,
+        timeoutMsg: "the second file's conflict regions never seeded (counter never read 0/N)",
+      },
     );
     // Resolve the second file too (keyboard ⌘1 = take ours); window closes.
     await jsChord("Mod+1");

--- a/e2e/specs/palette.e2e.ts
+++ b/e2e/specs/palette.e2e.ts
@@ -5,6 +5,7 @@ import {
 } from "../support/tempRepo";
 import {
   openRepo, resetApp, openPalette, paletteDialog, paletteInput, jsKey,
+  waitHeadMarkerOn,
 } from "../support/app";
 
 /** Click the palette row whose visible label contains `text`. */
@@ -112,10 +113,13 @@ describe("command palette", () => {
     await clickPaletteRow("Reset current branch to…");
     await clickPaletteRow("feat: add b.txt"); // pick the HEAD~1 commit by subject
     await clickPaletteRow("Hard");            // second step: mode pick
-    await browser.waitUntil(
-      async () => repo!.git("rev-parse", "HEAD").trim() === target,
-      { timeout: 20_000, timeoutMsg: "hard reset never moved HEAD" },
-    );
+    // The UI, not `rev-parse HEAD`: libgit2's hard reset writes
+    // checkout → HEAD → index (`reset.c`), so the ref is readable while the
+    // index still holds the old tree and `git status` — which compares against
+    // HEAD — would report a.txt as staged. Same trap as history-ops.e2e.ts's
+    // hard-reset test; the HEAD marker moving can only paint after refreshAll.
+    await waitHeadMarkerOn("feat: add b.txt");
+    expect(repo.git("rev-parse", "HEAD").trim()).toBe(target);
     expect(repo.git("status", "--porcelain").trim()).toBe("");
   });
 

--- a/e2e/specs/rebase.e2e.ts
+++ b/e2e/specs/rebase.e2e.ts
@@ -92,10 +92,21 @@ describe("interactive rebase", () => {
       timeout: 20_000, timeoutMsg: "conflict banner (with Abort) never appeared",
     });
     await $('[data-testid="rebase-abort"]').click();
-    await browser.waitUntil(
-      async () => repo.git("rev-parse", "HEAD").trim() === before,
-      { timeout: 20_000, timeoutMsg: "abort did not restore HEAD" },
-    );
+    // The UI, not `rev-parse HEAD`. `rebase_abort` re-attaches HEAD to the
+    // branch FIRST (`set_head`) and only then throws the replay away with a
+    // hard reset, so HEAD reads as `before` while the conflicted worktree is
+    // still there — reproduced deliberately (a 20 000-file fixture widens the
+    // reset's checkout): at the first sample where HEAD had moved,
+    // `git status --porcelain` said `UU conflict.txt`, 2 runs out of 2, and
+    // never with the small fixture. The Abort button leaving the DOM can only
+    // happen after `rebaseAbort` awaited the backend call, so it is strictly
+    // after both halves.
+    await $('[data-testid="rebase-abort"]').waitForDisplayed({
+      reverse: true,
+      timeout: 20_000,
+      timeoutMsg: "the rebase banner never went away after Abort",
+    });
+    expect(repo.git("rev-parse", "HEAD").trim()).toBe(before);
     expect(repo.git("status", "--porcelain").trim()).toBe("");
   });
 

--- a/e2e/specs/remote.e2e.ts
+++ b/e2e/specs/remote.e2e.ts
@@ -54,14 +54,20 @@ describe("remote operations", () => {
     makeBehind(pair);
     await openRepo(pair.repo.path);
     await $("button*=Pull").click(); // titlebar
-    // repo-truth wait: the pulled file landing on disk is the outcome.
-    await browser.waitUntil(
-      async () => {
-        try { return pair!.repo.read("remote.txt") === "remote\n"; }
-        catch { return false; }
-      },
-      { timeout: 20_000, timeoutMsg: "pull never delivered remote.txt" },
-    );
+    // The UI, not the pulled file on disk. A fast-forward writes the worktree
+    // and the index FIRST and moves the ref LAST (git's `checkout_fast_forward`
+    // then `update_ref`), so remote.txt is readable while HEAD is still on the
+    // old commit — and BOTH assertions below read the ref: `git status`
+    // compares the index against HEAD (it would report remote.txt as a staged
+    // addition) and `log -1` IS the ref. `makeBehind` rewinds the
+    // remote-tracking ref too, so this commit is in no local ref before the
+    // pull and its row can only render after refreshAll.
+    await $('[data-testid="commit-row"]*=feat: remote-only commit')
+      .waitForDisplayed({
+        timeout: 20_000,
+        timeoutMsg: "the pulled commit never appeared in the log",
+      });
+    expect(pair.repo.read("remote.txt")).toBe("remote\n");
     expect(pair.repo.git("status", "--porcelain").trim()).toBe("");
     expect(pair.repo.git("log", "-1", "--pretty=%s").trim())
       .toBe("feat: remote-only commit");

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -857,3 +857,41 @@ export async function scrollCommitListTo(
     },
   );
 }
+
+/**
+ * Wait until History's HEAD marker sits on the commit whose subject contains
+ * `subject`.
+ *
+ * The UI signal for "a ref move has landed, all of it". `PGCommitRow` carries
+ * `data-head="true"` for the row matching the branch tip `refreshAll` read, so
+ * the marker can only move after the whole backend call returned — which is
+ * what makes it the right wait for an op that keeps working after the ref moves
+ * (see the hard-reset comment in history-ops.e2e.ts).
+ *
+ * An in-page query rather than a selector, for two reasons. Identity has to be
+ * part of the condition — `[data-testid="commit-row"][data-head="true"]` alone
+ * matches the row HEAD is leaving, so it is satisfied before anything happens —
+ * and WebdriverIO cannot express "two attributes AND partial text" (its
+ * extended-XPath grammar allows exactly one `[attr=value]` before `*=`, so the
+ * combined form silently degrades to an invalid CSS selector). Read-only, so
+ * bare `browser.execute` is correct.
+ */
+export async function waitHeadMarkerOn(
+  subject: string,
+  timeout = 20_000,
+): Promise<void> {
+  await browser.waitUntil(
+    () =>
+      browser.execute(
+        (want: string) =>
+          document
+            .querySelector('[data-testid="commit-row"][data-head="true"]')
+            ?.textContent?.includes(want) ?? false,
+        subject,
+      ),
+    {
+      timeout,
+      timeoutMsg: `the HEAD marker never moved to the commit matching "${subject}"`,
+    },
+  );
+}

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -875,6 +875,10 @@ export async function scrollCommitListTo(
  * extended-XPath grammar allows exactly one `[attr=value]` before `*=`, so the
  * combined form silently degrades to an invalid CSS selector). Read-only, so
  * bare `browser.execute` is correct.
+ *
+ * History is windowed, so this only works while the HEAD row is mounted — true
+ * for every small fixture, since HEAD sits at or near the top. A fixture deep
+ * enough to scroll HEAD out needs `scrollCommitListTo` first.
  */
 export async function waitHeadMarkerOn(
   subject: string,


### PR DESCRIPTION
Tests only — no production code changed, `.github/` untouched.

The stash fix (776f151) added the rule *"repo truth is the assertion, not the wait"* to the e2e skill. This is the rest of that class, plus two waits that were wrong for a related-but-different reason. Every fix is measured, not argued.

## 1. `history-ops` — "reset hard moves HEAD and cleans the tree" (latent)

**Mechanism.** libgit2's hard reset writes in the order **checkout → HEAD → index** (`reset.c`), so the branch ref is readable while `.git/index` still holds the *old* tree. `git status` compares the index against HEAD, so in that window it reports `a.txt` as **staged** — and the spec waited on `rev-parse HEAD` and then asserted a clean worktree. (Note this is *not* the ordering the bug report assumed: the checkout comes first, the index write is what lags.)

**Change.** Waits on `waitHeadMarkerOn("feat: add b.txt")` — History's `data-head` marker, which can only paint after `refreshAll` re-read the branch tip, i.e. after the whole IPC call returned. `rev-parse HEAD` becomes a plain `expect`, so nothing is lost.

**Evidence.** The window is real and was observed directly, with fs-only probes (µs granularity, ~22 000 samples per run) on a 20 000-file fixture: at the first sample where `refs/heads/main` had moved, `.git/index` still carried its pre-reset bytes — **3 runs of 3**. But it closes faster than a `git status` process can start, so the assertion itself could not be made to fail (`statusThen=""` in all three). Honest label: **hazardous by mechanism, not reproduced through the assertion.** Fixed anyway — the exposure scales with index size and the fix is one line.

## 2. `history-ops` — "shows a combined diff of a multi-commit selection" (the actual CI failure)

**Mechanism — not what the source comment claimed.** `[data-pg-row]*=b.txt` was meant to name a file row on CommitDiff. It **also matches History's commit row for "feat: add b.txt"**. Resolved a moment before the screen switch, the handle binds to a row that is about to be unmounted — and `waitForDisplayed` specifically cannot recover from that.

I first wrote this up as "the driver never reports a detached node as stale", then measured it and found that claim too broad. Probing the same handle after the switch:

- `getText()` → **raises stale, refetches, `elementId` changes**, returns the new row's text. The refetch machinery works fine for protocol-level element commands.
- `isDisplayed()` → does **not** go through the protocol. It is `browser.execute(checkVisibility, elem)` plus a `getComputedStyle` probe, with the element passed as an *argument*. A detached node answers both honestly: `checkVisibility()` is `false`, `getComputedStyle()` returns empty instead of throwing. So **no stale-element error is ever raised**, `elementErrorHandler` has nothing to catch, and no refetch happens.
- `waitForDisplayed` is `waitUntil(() => isDisplayed())`, so it polls the dead node for its whole budget — with the real row on screen the entire time.

The correction is its own commit (`fix(e2e): correct the detached-handle mechanism after measuring it`) rather than a rewritten history, so the "claimed X → measured → Y" trail stays visible.

That accounts for every part of the signature: load-dependent (a busier machine loses the resolve-vs-swap race more often), never reproducible alone, and **immune to a bigger deadline**. The 15s → 25s raise could not have helped, and the comment it left behind ("the operation is genuinely slower than the old budget — the deadline was wrong, not the app") was a misdiagnosis. Corrected in place.

**Change.** Two waits, in order: the destination's own `DeepViewHeader` crumb (`Diff <from7> → <to7>`, both shas from repo truth — so a mis-routed selection fails *there*, naming the pair it got), then the file row as a **pure CSS** selector scoped to `[data-pg-pane="commitDiff.files"]`, which no other screen can satisfy.

**Evidence.** Deterministic harness, 16 spinning CPU hogs, 10 runs per variant:

| variant | failures | detail |
|---|---|---|
| old selector | **4 / 10** | every failure a full 25s timeout, `b.txt` row present in the DOM throughout |
| new waits | **0 / 10** | 40–148 ms to satisfy |
| forced (pre-resolve the old selector while History is still mounted) | **1 / 1** | 25.0s timeout — the mechanism on demand |

## 3. Audit — every `waitUntil` in `e2e/` whose predicate reads repo truth

23 sites (counting `bareGit` and `hasRef`). Verdict rule: *hazardous iff the fact waited on is published by the git op earlier than the fact asserted (or acted on) afterwards.*

| Site | Op → waited fact | Verdict | Reason |
|---|---|---|---|
| `bisect.e2e.ts:82` | `bisect start` → `refs/bisect/bad` | benign | followed only by a UI wait; nothing later in `bisect start` is asserted |
| `bisect.e2e.ts:95` | `bisect <term>` → `bisect log` grew | **hazardous → fixed** | git writes BISECT_LOG then checks out the next revision, and `bisect_mark` runs that subprocess **outside** the backend's repo mutex — resuming here let the spec's next click start a second `git` in the same worktree, racing `.git/index.lock` |
| `history-diff.e2e.ts:100` | stage hunk → index has `a.txt` | benign | the wait **is** the acceptance; nothing asserted after it |
| `history-ops.e2e.ts:32` | soft reset → HEAD moved | benign | libgit2 soft reset is *only* the HEAD ref write; the `diff --cached` assertion is a direct consequence of that same write |
| `history-ops.e2e.ts:44` | hard reset → HEAD moved | **hazardous → fixed** | see §1 |
| `history-ops.e2e.ts:75` | cherry-pick → `log -1` | benign | the commit is the LAST step; the file content asserted after was written before it |
| `history-ops.e2e.ts:120` | revert → `log -1` | benign | same shape |
| `history-ops.e2e.ts:165` | cherry-pick ×2 → both subjects | benign | waiting for the *second* subject means both commits landed |
| `keymap.e2e.ts:413` | commit+push → bare `log -1` | benign | the remote ref update is a push's last act, and the follow-up assertion reads the same ref |
| `merge-conflict.e2e.ts:82` | FF merge → `log -1` | benign | git's fast-forward writes worktree+index then `update_ref`; the wait is on that last step |
| `palette.e2e.ts:80` | checkout → `symbolic-ref HEAD` | benign | libgit2 sets HEAD after the tree; followed only by a UI wait |
| `palette.e2e.ts:100` | create branch → `hasRef` | benign | one ref write, nothing asserted after |
| `palette.e2e.ts:115` | hard reset → HEAD moved | **hazardous → fixed** | same as `history-ops.e2e.ts:44` |
| `rebase.e2e.ts:95` | rebase abort → HEAD restored | **hazardous → fixed, reproduced** | `rebase_abort` does `set_head(branch)` **then** the hard reset, so HEAD reads restored while the conflicted worktree is still on disk |
| `remote.e2e.ts:43` | push → bare ref | benign | ref update last; followed by a UI wait |
| `remote.e2e.ts:58` | pull → `read("remote.txt")` | **hazardous → fixed** | a fast-forward writes worktree+index **first** and the ref **last**, and both assertions after read the ref (`git status` compares to HEAD; `log -1` *is* the ref) |
| `remote.e2e.ts:164` | prune → `!hasRef` | benign | the ref deletion is the whole op; nothing after |
| `settings.e2e.ts:188` | merge pull → HEAD has 2 parents | benign | a real merge commits last; the file reads asserted after were written before |
| `settings.e2e.ts:215` | commit → `log -1 %s` | benign | subject and trailer are the same object |
| `settings.e2e.ts:252` | force-push → bare ref | benign | last step, nothing after |
| `settings.e2e.ts:307` | force-push → bare ref | benign | the follow-up (`confirmCallCount`) is a page fact already settled before the push |
| `submodules.e2e.ts:58` | submodule init → `.git/config` | benign | writing that section is the whole op; nothing after |
| `worktrees.e2e.ts:114` | worktree lock → `list` says locked | benign | the reason **is** the content of the same `locked` file; followed by a UI wait for it |

**Five hazardous, all fixed. The 18 benign ones are untouched** — churning them would make this unreviewable for no gain.

Two of the five reproduce, and one is worth reading twice: **`rebase.e2e.ts:95` and `remote.e2e.ts:58` point in opposite directions.** A reset publishes its ref *early*, a fast-forward publishes it *late*. So "wait on HEAD" is neither safe nor unsafe in general, and only a UI signal is safe in general, because it needs the whole IPC call to have returned.

Rebase-abort evidence: with a 20 000-file fixture widening the reset's checkout, at the first sample where HEAD had returned to the branch, `git status --porcelain` said `UU conflict.txt` — **2 runs of 2**, and **0 of 2** with the small fixture (window under one sample).

## 4. `merge-window.e2e.ts` — yes, it shares the shape

The CI-only *"Apply never enabled for the second file"* flake is the same family, via a third variant: **a readiness signal that is also true of "not started yet".**

`canApply` is `!loading && !!model && !chooser && allResolved`, and `allResolved` is `regionStates.every(...)` — vacuously **true** for an empty list (deliberately: a zero-conflict auto-merge file must be applyable). So retargeting to the second file passes through *three* states: disabled (loading) → briefly **enabled with zero regions** (model in, regions not seeded) → disabled (one unresolved region). The spec waited for "Apply is disabled", was satisfied by the *first*, and the ⌘1 that follows could land in the second with no region to accept — dropped, so Apply never enabled.

Now waits for the conflict counter to read `0/N`, a state only a seeded-and-unresolved model produces (file one read `1/1` before its own Apply). This is precisely the guard, and the reason, that be410f1 added to `MergeWindow.test.tsx` for the same race one layer down.

Not reproduced locally (it never has been — it is CI-only), so this one rests on the mechanism plus the matching unit-level precedent. Labelled as the weaker evidence it is.

## Verification

- `pnpm test:e2e:docker run --spec` × the 5 changed specs: **5/5 spec files, 30/30 tests**
- `pnpm test:e2e:docker run` (full suite) × 3 after the fixes: **25/25 spec files each** (7m38s / 3m38s / 5m09s)
- `pnpm exec tsc -p e2e/tsconfig.json --noEmit` clean · `pnpm tsc --noEmit` clean · `pnpm test` **1463 passed / 179 files**
- Baseline before any change: full suite 25/25 (the flake does not show up on a single run — which is the whole point)

All e2e ran headless in Docker (WebKitGTK + xvfb). No native runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Er25sN6pGoVJzmTBwHU2Tz
