### PR TITLE
fix(nav): route the stash-vs-working-tree intent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -749,6 +749,19 @@ lib/
   be rebound apart. Register the pane handler as declining (`() => false`) when it
   has nothing to act on, or it swallows the chord from the other action.
 - `useNavStore.intent` drives deep-view switches (e.g. "show this commit's diff" → sets screen to `commitDiff`). Consumers write an intent; `AppShell` effect routes the screen.
+- **A new `NavIntent` kind must be routed in AppShell, and both halves of that
+  are now enforced.** The routing switch ends in `default: assertNever(intent)`,
+  so an unrouted kind is a **compile** error — `stash-vs-wt` shipped declared in
+  the union, emitted by the stash menu and fully handled by `CommitDiff` with no
+  `case` in the switch, which made the menu item do nothing at all and passed
+  review, `tsc`, unit, component and e2e tests alike (#133). The compile check
+  cannot tell a real destination from `case "x": break;`, so
+  `AppShell.navroutes.test.tsx` drives every kind through the real shell and
+  asserts the screen changed; its `EXPECTED` table is a mapped type over
+  `NavIntent["kind"]` (a union has no runtime form — the type system does the
+  enumerating), and a kind that must deliberately NOT navigate needs an entry
+  there carrying a written reason. The test reads `data-pg-screen` off AppBody,
+  which is the routed screen with no screen-internal selectors involved.
 - **Compare is a deep view, not an activity-bar screen** (#131). `ref-compare`
   routes to `compare`; the intent carries the two sides for readability but the
   SCREEN reads them from `useCompareStore`, because they stay mutable once you

--- a/src/AppShell.navroutes.test.tsx
+++ b/src/AppShell.navroutes.test.tsx
@@ -1,0 +1,235 @@
+// AppShell's nav-intent routing table — the whole table, every kind.
+//
+// `stash-vs-wt` (#133) shipped declared in `NavIntent`, emitted by the stash
+// context menu and fully handled by `CommitDiff` — with no `case` in AppShell's
+// routing switch. The menu item set an intent and nothing navigated: a feature
+// dead on arrival, past review, unit tests, component tests and e2e.
+//
+// Nothing caught it because nothing tested the ROUTING. `CommitDiff.stash`
+// renders that screen directly with the intent pre-set, so it stayed green while
+// the only way a user can reach the screen was broken.
+//
+// Two mechanisms close that, and the first is the stronger one:
+//
+//  1. AppShell's switch ends in `default: assertNever(intent)`. An unrouted kind
+//     is a COMPILE error — `pnpm tsc --noEmit`, `pnpm build`, and every editor.
+//     No test needs to run.
+//  2. This file drives each kind through the real shell and asserts the screen
+//     changed, which the compile check cannot do: a lazy `case "x": break;`
+//     satisfies the type-checker while still going nowhere.
+//
+// `EXPECTED` is a mapped type over `NavIntent["kind"]`, so a new kind fails to
+// compile here until it is given a sample and a destination. That indirection is
+// necessary: a union has no runtime representation, so the kinds cannot be
+// enumerated at run time — the type system has to do the enumerating.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, render, waitFor } from "@testing-library/react";
+
+import App from "./App";
+import type { ScreenId } from "./AppShell";
+import { useNavStore, type NavIntent } from "@/features/nav/useNavStore";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useRecentsStore } from "@/features/repo/useRecentsStore";
+import { mockInvoke } from "@/test/invokeMock";
+import type { CommitInfo, FileDiff, RepoHandle } from "@/lib/types";
+
+const handle: RepoHandle = { id: "r1", path: "/repo", head: "refs/heads/main" };
+
+const OID = "a".repeat(40);
+const OID2 = "b".repeat(40);
+
+const COMMITS: CommitInfo[] = [OID, OID2].map((oid, i) => ({
+  oid,
+  shortOid: oid.slice(0, 7),
+  summary: `commit ${i}`,
+  body: null,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 1_700_000_000 - i,
+  parents: i === 0 ? [OID2] : [],
+  refs: i === 0 ? ["refs/heads/main"] : [],
+}));
+
+const DIFF: FileDiff = {
+  path: "src/a.ts",
+  oldPath: null,
+  binary: false,
+  additions: 1,
+  deletions: 0,
+  hunks: [],
+  lfs: null,
+};
+
+/**
+ * One representative intent per kind, and the screen the shell must land on.
+ *
+ * `screen: null` declares a kind that intentionally leaves the user where they
+ * are, and the type REQUIRES a reason for it — an omission has to be argued for
+ * in writing rather than achieved by leaving a row out, which is the hole this
+ * file exists to close. There are none today: every declared intent navigates.
+ */
+type Expectation<K extends NavIntent["kind"]> = {
+  intent: Extract<NavIntent, { kind: K }>;
+} & ({ screen: ScreenId } | { screen: null; reason: string });
+
+const EXPECTED: { [K in NavIntent["kind"]]: Expectation<K> } = {
+  "diff-file": {
+    intent: { kind: "diff-file", path: "src/a.ts" },
+    screen: "diff",
+  },
+  "commit-self": {
+    intent: { kind: "commit-self", oid: OID },
+    screen: "commitDiff",
+  },
+  "commit-vs-wt": {
+    intent: { kind: "commit-vs-wt", oid: OID },
+    screen: "commitDiff",
+  },
+  "commit-vs-commit": {
+    intent: { kind: "commit-vs-commit", from: OID2, to: OID },
+    screen: "commitDiff",
+  },
+  "ref-compare": {
+    intent: {
+      kind: "ref-compare",
+      left: { kind: "rev", rev: "main" },
+      right: { kind: "workdir" },
+    },
+    screen: "compare",
+  },
+  "file-history": {
+    intent: { kind: "file-history", path: "src/a.ts" },
+    screen: "fileHistory",
+  },
+  blame: {
+    intent: { kind: "blame", path: "src/a.ts" },
+    screen: "blame",
+  },
+  "rebase-plan": {
+    intent: { kind: "rebase-plan", plan: [] },
+    screen: "rebase",
+  },
+  // The two stash comparisons (#133). `stash-vs-wt` is the regression: revert
+  // AppShell's `case "stash-vs-wt":` and this row fails with "history".
+  "stash-diff": {
+    intent: { kind: "stash-diff", oid: OID, label: "stash@{0}", untracked: false },
+    screen: "commitDiff",
+  },
+  "stash-vs-wt": {
+    intent: { kind: "stash-vs-wt", oid: OID, label: "stash@{0}", untracked: false },
+    screen: "commitDiff",
+  },
+  "switch-screen": {
+    intent: { kind: "switch-screen", screen: "branches" },
+    screen: "branches",
+  },
+};
+
+/** Everything the shell and any destination screen may reach for on mount. */
+function wire(): void {
+  for (const cmd of [
+    "get_status",
+    "list_all_files",
+    "list_branches",
+    "list_tags",
+    "list_stashes",
+    "list_remotes",
+    "list_submodules",
+    "list_worktrees",
+    "get_reflog",
+    "diff_commit",
+    "diff_commits",
+    "stash_diff",
+    "file_history",
+    "blame_file",
+    "commits_since",
+    "commits_between",
+  ]) {
+    mockInvoke(cmd, () => []);
+  }
+  mockInvoke("get_log_page", () => ({ commits: COMMITS, nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => ({
+    inProgress: false,
+    nextIndex: 0,
+    total: 0,
+    pauseReason: null,
+  }));
+  mockInvoke("take_launch_intent", () => null);
+  mockInvoke("cli_shim_status", () => ({ installed: false, path: null }));
+  mockInvoke("get_diff", () => DIFF);
+  mockInvoke("diff_ref_to_workdir", () => ({ files: [DIFF], untrackedOmitted: 0 }));
+  mockInvoke("ahead_behind", () => ({ ahead: 0, behind: 0, mergeBase: null }));
+  mockInvoke("read_file_content", () => ({ text: "", binary: false }));
+  mockInvoke("read_file_content_at_rev", () => ({ text: "", binary: false }));
+  mockInvoke("get_update_capability", () => ({ supported: false, reason: null }));
+  mockInvoke("check_for_update", () => null);
+  mockInvoke("forge_detect", () => null);
+  mockInvoke("lfs_status", () => ({ available: false, tracked: [], files: [] }));
+}
+
+/** The screen the shell routed to — see `data-pg-screen` in AppBody. */
+function currentScreen(container: HTMLElement): string | null {
+  return container
+    .querySelector("[data-pg-screen]")
+    ?.getAttribute("data-pg-screen") ?? null;
+}
+
+describe("AppShell routes every NavIntent kind", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useRecentsStore.setState({ recents: [] });
+    useNavStore.setState({ intent: null, deepOrigin: null });
+    wire();
+    useRepoStore.setState({
+      current: handle,
+      status: [],
+      allFiles: [],
+      branches: [],
+      tags: [],
+      stashes: [],
+      remotes: [],
+      commits: COMMITS,
+      loading: false,
+      error: null,
+      repoState: "Clean",
+      rebaseStatus: { inProgress: false, nextIndex: 0, total: 0, pauseReason: null },
+      activity: {},
+    } as never);
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  // A sample filed under the wrong key would leave its own kind unproven while
+  // testing another one twice. The mapped type already refuses it; this says so
+  // in a sentence a failing run can print.
+  it("files every sample under its own kind", () => {
+    for (const [kind, exp] of Object.entries(EXPECTED)) {
+      expect(exp.intent.kind).toBe(kind);
+      if (exp.screen === null) expect(exp.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  for (const [kind, exp] of Object.entries(EXPECTED) as Array<
+    [NavIntent["kind"], Expectation<NavIntent["kind"]>]
+  >) {
+    const target = exp.screen ?? "(deliberately nowhere)";
+    it(`sends "${kind}" to ${target}`, async () => {
+      const { container } = await act(async () => render(<App />));
+      // Launch always lands on History, so any change below is this intent's.
+      expect(currentScreen(container)).toBe("history");
+
+      await act(async () => {
+        useNavStore.getState().setIntent(exp.intent);
+      });
+
+      if (exp.screen === null) {
+        // Held on purpose (`reason`), not lost: assert it did NOT move.
+        expect(currentScreen(container)).toBe("history");
+      } else {
+        await waitFor(() => expect(currentScreen(container)).toBe(exp.screen));
+      }
+    });
+  }
+});

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -75,7 +75,7 @@ import {
   totalAheadBehind,
 } from "@/lib/derive";
 
-type ScreenId =
+export type ScreenId =
   | "repo"
   | "commit"
   | "history"
@@ -597,6 +597,12 @@ function AppBody({
         }}
       >
         <div
+          // The screen the shell actually routed to, readable without depending
+          // on any screen's internals — deep views have no activity-bar slot to
+          // read it off. A nav intent that reaches no `case` in the routing
+          // switch leaves this on the previous screen, which is exactly what
+          // AppShell.navroutes.test.tsx asserts against.
+          data-pg-screen={screen}
           style={{
             flex: 1,
             minWidth: 0,

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -305,7 +305,12 @@ export function AppShell() {
       case "rebase-plan":
         setScreen("rebase");
         break;
+      // Both stash comparisons are `CommitDiff` targets (#133) — the entry
+      // against its own first parent, and the entry against the working tree.
+      // They are one case because that screen's `Target` union carries both and
+      // fetches each on its own; the routing decision is identical.
       case "stash-diff":
+      case "stash-vs-wt":
         enterDeep("commitDiff");
         break;
       case "switch-screen":

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -103,6 +103,20 @@ const DEEP_VIEWS = new Set<ScreenId>([
   "blame",
 ]);
 
+/**
+ * Compile-time exhaustiveness assertion for the nav-intent routing switch
+ * below: an unrouted `NavIntent` kind reaches the `default` clause as something
+ * other than `never`, and the build fails.
+ *
+ * Runtime is deliberately a no-op. It runs inside a React effect, where
+ * throwing would take the whole window down over a value TypeScript already
+ * proved impossible — and an intent that reaches nothing is a dead menu item,
+ * not a reason to lose the user's session.
+ */
+function assertNever(value: never): void {
+  void value;
+}
+
 // Maps each activity-bar item id to the navigation action whose chord it shows.
 const ACTIVITY_ACTION: Record<string, ActionId> = {
   repo: "nav.files",
@@ -319,6 +333,17 @@ export function AppShell() {
         enterScreen(intent.screen as ScreenId);
         clearIntent();
         break;
+      default:
+        // Every `NavIntent` kind must be routed above, and this is what forces
+        // it. `stash-vs-wt` was declared in the union, emitted by the stash
+        // context menu and fully handled by `CommitDiff` — but had no case
+        // here, so the menu item set an intent and NOTHING navigated (#133).
+        // Nothing failed: not the type-checker, not the unit tests, not e2e.
+        //
+        // A kind that must deliberately leave the user where they are still
+        // needs an explicit `case … break;` saying so, plus an entry in
+        // `AppShell.navroutes.test.tsx`'s allow-list with the reason.
+        assertNever(intent);
     }
   }, [intent]);
 


### PR DESCRIPTION
## The symptom

Right-click a stash → **Compare with working tree** → nothing happens. No
screen change, no error, no banner. The menu item is dead.

`NavIntent` declares `stash-vs-wt`
(`src/features/nav/useNavStore.ts`), `openStashVsWorktree` emits it
(`src/design/context-menu.tsx`), and `CommitDiff.tsx` handles it end to end —
header, syntax sides, untracked note, and the `diff_ref_to_workdir` fetch. But
**AppShell's intent-routing switch had `case "stash-diff":` and no
`case "stash-vs-wt":`**, so the intent was set and no screen ever routed. Shipped
in #133, on `main`, not yet in a release.

## Why every test layer missed it

Nothing tested the routing table.

- **Type-checker:** a `switch` with no `default` is not exhaustiveness-checked, so
  a missing case is legal TypeScript.
- **Component tests:** `CommitDiff.stash.test.tsx` renders `CommitDiffScreen`
  *directly* with the intent pre-set — it bypasses AppShell entirely, so it stayed
  green while the only route a user has to that screen was broken.
- **E2E:** no spec drives the stash menu item.
- **Review:** the missing line sits between two lines that look exactly like it.

## What now prevents it

Two mechanisms, deliberately at different layers.

**1. A compile error (the strong one).** The routing switch ends in
`default: assertNever(intent)`. A `NavIntent` kind with no case reaches it as
something other than `never` and the build fails — in the editor, in
`pnpm tsc --noEmit`, in `pnpm build`, before any test runs. `assertNever` is a
run-time no-op on purpose: it sits inside a React effect, and throwing there would
take the window down over a value the compiler already proved impossible.

**2. A runtime test (what the compiler can't do).** The compile check cannot
distinguish a real destination from a lazy `case "x": break;`, so
`src/AppShell.navroutes.test.tsx` drives **every** kind through the real shell and
asserts the screen actually changed. Its `EXPECTED` table is a mapped type over
`NavIntent["kind"]`, so a new kind fails to compile there until it is given a
sample payload and a destination — a union has no runtime form, so the kinds
cannot be enumerated at run time and the type system has to do the enumerating.
A kind that must deliberately *not* navigate needs `screen: null` **and** a
written `reason` (required by the type); omitting a row is not available, since
that is the hole being closed. There are none today — all eleven kinds navigate.

Assertions read a new `data-pg-screen` attribute on AppBody rather than probing
each screen's internals: the four deep views have no activity-bar slot to read the
active screen off, and a per-screen selector table is the sort of thing that rots
quietly.

## Kind-by-kind audit

Every declared kind against AppShell's cases. `stash-vs-wt` was the only gap.

| `NavIntent` kind | routed before | routed now |
| --- | --- | --- |
| `diff-file` | ✅ `diff` | ✅ `diff` |
| `commit-self` | ✅ `commitDiff` | ✅ `commitDiff` |
| `commit-vs-wt` | ✅ `commitDiff` | ✅ `commitDiff` |
| `commit-vs-commit` | ✅ `commitDiff` | ✅ `commitDiff` |
| `ref-compare` | ✅ `compare` | ✅ `compare` |
| `file-history` | ✅ `fileHistory` | ✅ `fileHistory` |
| `blame` | ✅ `blame` | ✅ `blame` |
| `rebase-plan` | ✅ `rebase` | ✅ `rebase` |
| `stash-diff` | ✅ `commitDiff` | ✅ `commitDiff` |
| **`stash-vs-wt`** | ❌ **nothing** | ✅ `commitDiff` |
| `switch-screen` | ✅ payload's screen | ✅ payload's screen |

## Verification

- `pnpm tsc --noEmit` clean, `pnpm exec tsc -p e2e/tsconfig.json --noEmit` clean.
- `pnpm test` — 180 files, 1475 tests, all passing.
- **Revert-and-watch-it-fail**, both guards:
  - Remove only the routing case → `pnpm tsc --noEmit` fails with
    `TS2345: Argument of type '{ kind: "stash-vs-wt"; … }' is not assignable to
    parameter of type 'never'`.
  - Remove the case *and* the `default` clause (exactly the shape that shipped) →
    `tsc` is clean and the new suite fails one test,
    `sends "stash-vs-wt" to commitDiff` — expected `"commitDiff"`, received
    `"history"`.
- E2E not run locally: another agent holds the Docker slot. CI runs the suite here.

## Note, not fixed here

`switch-screen` still routes through `enterScreen(intent.screen as ScreenId)` — a
cast, so a screen id outside `ScreenId` would render a blank body (the same
"nothing happens" symptom, a different mechanism). Not reachable today: the CLI
maps tokens through `screen_for` in `src-tauri/src/cli.rs` and every other caller
uses a catalog-defined id. Typing that field as `ScreenId` needs `ScreenId` moved
out of `AppShell` (nav must not import the shell), so it is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Er25sN6pGoVJzmTBwHU2Tz