### PR TITLE
docs: refresh CLAUDE.md — signing, missing modules and commands, drop rotting counts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,9 @@ Recent specs/plans (for context on current direction):
 - `2026-08-16-stash-improvements-*` — path-level partial stash, stash rename
   (store a FRESH commit, then drop — see the stash convention below), and the
   two correct stash comparisons; hunk-level stash deferred with reasons (#133).
+- `2026-08-16-branch-picker-order-*` — ONE branch ordering for every branch list
+  (`features/branches/orderBranches.ts`), backed by `BranchInfo.tip_time` +
+  `is_default` (#135).
 - `2026-08-16-branch-compare-*` — `compare` deep view: two mutable sides
   (ref↔ref or ref↔working tree), ahead/behind + both commit lists, the file diff
   through `CommitDiffPanel` (#131).
@@ -166,10 +169,15 @@ Four layers, each run independently:
   `src/`. Runs in jsdom with React Testing Library. The Tauri `invoke` and
   `plugin-dialog.open` calls are mocked via `src/test/setup.ts`; tests register
   per-command responses with `mockInvoke(cmd, handler)`.
-- **E2E (webview-level)** — WebdriverIO specs in `e2e/specs/` (25 files; count
-  them rather than trusting this number — it has been stale three times) drive
-  the real debug binary: real webview →
+  - Those two layers are one vitest **project**, `unit`. `pnpm test` also runs a
+    second project, `docs` (`test/**/*.test.ts`, node env, no setup file) — the
+    coverage gate on THIS file. See "`test/` at the repo root" below. Run one
+    with `pnpm vitest run --project unit`.
+- **E2E (webview-level)** — WebdriverIO specs in `e2e/specs/`, one file per
+  feature area, driving the real debug binary: real webview →
   real Tauri IPC → real libgit2 → temp repos built by `e2e/support/tempRepo.ts`.
+  (`ls e2e/specs/` for the current set. A file count used to live here and went
+  stale three times; a number nobody can keep true is worse than no number.)
   Uses the embedded WebDriver provider (`@wdio/tauri-service`) — no external
   driver or paid service — so it runs on Linux CI (WebKitGTK) and, in the same
   container image, locally.
@@ -267,7 +275,9 @@ opener.rs        Handing URLs/paths to the OS default handler. SECURITY-critical
                  exit status is checked. Both open_url and open_in_editor use it.
 update.rs        Update discovery — semver compare (semver crate, cmp_precedence),
                  dev-build (0.0.0) short-circuit BEFORE any network call,
-                 GitHub release parsing, ureq agent w/ timeout + https_only
+                 GitHub release parsing, ureq agent w/ timeout + https_only.
+                 The LOGIC; its Tauri handlers are commands/update.rs. Two
+                 different files with the same basename — see the note there
 forge/           Forge (GitHub / GitLab) integration — PR/MR list, create, checkout,
                  CI status (#92). The trait is split into URL BUILDERS + RESPONSE
                  PARSERS, not `list_pull_requests()`, so every forge-specific line
@@ -300,6 +310,8 @@ forge/           Forge (GitHub / GitLab) integration — PR/MR list, create, che
                  force-update someone's commits away. And do NOT pass `--` to
                  `git rev-parse`: after it everything is a PATH, so every branch
                  reads as absent (regression-tested)
+main.rs          Binary entry — calls `platypusgit_lib::run()`, nothing else.
+                 Keeps the `windows_subsystem = "windows"` attribute; leave it
 lib.rs           Tauri builder + invoke_handler! registry (all commands listed there)
 cli.rs           CLI arg parsing (LaunchIntent, parse_args, resolve_repo_root),
                  shim install/status helpers (install_shim, shim_status) —
@@ -362,7 +374,14 @@ git/
 │                NOT git's own `.git/rebase-merge/` dir — a half-compatible one
 │                would let `git status` / `git rebase --continue` claim a rebase
 │                they cannot drive
-├── signing.rs   Object signing (#61 D6, #132). PURE: gpg.format → program →
+├── auth.rs      Auth-failure classification + credential hygiene (#61 D5).
+│                PURE: `classify_auth_failure` (git's stderr → `AuthKind`, or
+│                `None` for "not an auth failure" — host-key verification is
+│                deliberately in that second bucket), `AuthChallenge`, and
+│                `scrub_credentials`. See "Network ops and credentials"
+├── signing.rs   CRYPTOGRAPHIC signing — GPG/SSH (#61 D6, #132). NOT
+│                signature.rs (below); read the pair note after this tree.
+│                PURE: gpg.format → program →
 │                user.signingkey resolution, `resolve_key_file` (the ssh
 │                key-PATH restriction — `key::…` literals refused), the signer
 │                argv, and `parse_verify_output` for git's `%G?` triple.
@@ -373,13 +392,25 @@ git/
 │                `append_signature`, `validate_tag_name` (the argv guard), and
 │                `parse_verify_tag` for `git verify-tag --raw` — see the
 │                tag-signing note under Conventions for why `%G?` can't be used
-└── signature.rs Author/committer signature helpers
+└── signature.rs IDENTITY, not cryptography. `default_signature` (the
+                 `user.name` / `user.email` lookup, local → global → system,
+                 `NoSignature` when unset) and `apply_signoff` (the
+                 `Signed-off-by:` TRAILER, `git commit -s` semantics, idempotent
+                 + its trailer-line rule). Nothing here signs anything
 commands/        Thin Tauri handlers, one file per area:
 ├── repo.rs        open_repo, close_repo, trust_repo_path, get_status,
-│                  list_all_files, read_file_content, append_gitignore,
-│                  open_in_editor
+│                  list_all_files, append_gitignore, open_in_editor, and THREE
+│                  file readers that are not interchangeable:
+│                  read_file_content (the working tree, on disk),
+│                  read_file_content_at_rev + list_files_at_rev (a commit's
+│                  tree — what the repo browser reads at a revision) and
+│                  read_file_content_at_index (the STAGED blob, which is
+│                  neither of the other two whenever a file is staged and then
+│                  edited again)
 ├── cli.rs         take_launch_intent, cli_shim_status, install_cli_shim
-├── commits.rs     get_log, commit, file_history. The `refspec` arg takes the
+├── commits.rs     get_log, commit, file_history, verify_commit (one commit's
+│                  signature status, called lazily for the SELECTED commit —
+│                  never per log row). The `refspec` arg takes the
 │                  `REFSPEC_ALL` sentinel ("--all", git's own spelling) meaning
 │                  "walk every branch we know of" — local + remote-tracking heads
 │                  plus a detached HEAD, one graph. History's default scope; the
@@ -388,17 +419,42 @@ commands/        Thin Tauri handlers, one file per area:
 │                  rebase op must run it through `headAncestryOf` first (see
 │                  features/commits/headAncestry.ts) — a plan built from the raw
 │                  log replays another branch's commits onto the current one.
-│                  Also `commits_between` (`base..tip`, NO ancestry requirement —
+│                  THE LOG IS PAGED — see "The log is paged". `get_log`
+│                  is the one-shot walk; `get_log_page` /
+│                  `get_log_filtered_page` are what History actually calls, and
+│                  `get_log_filtered` is the unpaged filtered walk.
+│                  Also `commits_since` (`base..HEAD`, base must be an ANCESTOR),
+│                  `commits_between` (`base..tip`, NO ancestry requirement —
 │                  `commits_since` refuses a non-ancestor base, which is right for
 │                  a rebase base and wrong for two diverged branches) and
 │                  `ahead_behind` (counts read FROM `a` TOWARD `b`, plus the merge
 │                  base; unrelated histories are `mergeBase: null`, not an error).
-├── diff.rs        get_diff, stage/unstage/discard_paths, stage/unstage/discard_hunk,
-│                  diff_commits, diff_ref_to_workdir, blame_file
+├── diff.rs        get_diff, stage/unstage/discard_paths,
+│                  stage/unstage/discard_hunk, stage/unstage/discard_lines,
+│                  diff_ref_to_workdir, blame_file, and the two commit diffs
+│                  ONE CHARACTER apart: `diff_commit` (one oid — that commit
+│                  against its first parent, "what this commit changed") and
+│                  `diff_commits` (from_oid + to_oid — an arbitrary rev↔rev
+│                  range). Reaching for the wrong one compiles and returns a
+│                  plausible diff, so check the arity
 ├── branches.rs    list_branches/tags/stashes/remotes, checkout/create/delete/rename_branch,
-│                  fetch, fetch_all, pull, push, add/remove/rename/set_url/prune remote,
+│                  set_upstream, fetch, fetch_all, pull, push,
+│                  add/remove/rename/prune_remote, set_remote_url,
 │                  create/delete/push_tag, verify_tag, merge_branch, rebase_onto,
 │                  checkout_ref, push_delete_branch
+├── net.rs         NOT a command area — the shared network plumbing every
+│                  credentialed git shell-out goes through (`Credentials`,
+│                  `run_git_authenticated`, `apply_auth_env`, `map_git_failure`,
+│                  `credential_approve`) plus ONE registered command,
+│                  `remember_credential`: separate from the ops on purpose, so a
+│                  credential is stored only after it has actually worked rather
+│                  than on submit, which would persist a typo. See "Network ops
+│                  and credentials"
+├── update.rs      check_for_update, get_update_capability, open_url — the
+│                  handlers for the top-level `update.rs` logic. Two files named
+│                  `update.rs`: THIS one is thin Tauri commands,
+│                  `src-tauri/src/update.rs` is the semver + release-parsing
+│                  engine they call
 ├── history.rs     reset, cherry_pick, revert
 ├── stash.rs       stash_save/apply/pop/drop/branch, plus stash_save_paths
 │                  (pathspec-scoped), stash_rename and stash_diff (#133)
@@ -422,6 +478,20 @@ commands/        Thin Tauri handlers, one file per area:
                    git clone → clone://progress events)
 ```
 
+**Three pairs of near-identical filenames live in this tree, and the two halves
+of each pair do different jobs.** Check which one you want before editing:
+
+- `git/signing.rs` vs `git/signature.rs` — **cryptography vs identity.**
+  `signing.rs` resolves a GPG/SSH signer and produces or verifies a real
+  signature; `signature.rs` reads `user.name`/`user.email` and appends a
+  `Signed-off-by:` trailer. A sign-off is plain text anyone can type — it proves
+  nothing and involves no key. "Add signing" almost always means `signing.rs`.
+- `src-tauri/src/update.rs` vs `src-tauri/src/commands/update.rs` — engine vs
+  handlers. Both exist; neither is dead.
+- `src-tauri/src/cli.rs` vs `src-tauri/src/git/cli.rs` — the `pgit` launch
+  argument parser vs the `CliBackend` git implementation. (Already flagged at
+  `cli.rs` above.)
+
 ### Frontend (`src/`)
 
 ```
@@ -438,12 +508,25 @@ design/              In-house design system (NOT components/ui/). Exports via de
 ├── primitives.tsx       PGButton, PGIconButton, etc.
 ├── chrome.tsx           PGTitlebar, PGTabStrip (repository tabs), PGActivityBar,
 │                        PGStatusBar, PGStatusItem
-├── git-components.tsx   Git-specific UI bits
+├── window-controls.tsx  Minimize / maximize / close (the titlebar is ours)
+├── git-components.tsx   Git-specific UI bits — PGCommitRow, PGGraphRow,
+│                        PGChangeRow, PGFileTree(Row), PGRebaseRow, PGHunkHeader…
+├── PGWindowedDiff.tsx   The ONE diff renderer over `DiffRow[]` (see "Diff
+│                        rendering"). Reuses PGHunkHeader/PGDiffRow, so the
+│                        windowed and unwindowed paths cannot drift
+├── graph-geometry.ts    Lane geometry for the History graph in SVG user units —
+│                        the one place the lane pitch and gutter width live, so
+│                        PGGraphRow's path math and PGCommitRow's grid agree
 ├── icons.tsx            Icon set (name-based <PGIcon>), incl. file-type glyphs
+├── logo.tsx             App mark
 ├── context-menu.tsx     Context menu primitive
 ├── dialog.tsx           PGDialogHost + pgConfirm/pgPrompt — the ONLY confirm /
 │                        prompt path (no window.confirm/prompt anywhere)
 ├── empty-state.tsx      Empty-state component
+├── skeleton.tsx         Loading placeholders
+├── error-boundary.tsx   Per-window last line of defence — React unmounts the
+│                        whole root when a render throws, so without it one
+│                        broken screen leaves a blank window and no message
 ├── modal.tsx            PGModal — shared dialog shell
 ├── resizable.tsx        Resizable panes
 ├── ui-helpers.tsx       pgFlash, misc helpers
@@ -472,11 +555,26 @@ features/            Per-feature: components + Zustand store colocated
 │                    menu), useRecentsStore, ops (shared keymap/palette/titlebar
 │                    runners), OperationBar (the `repoState !== "Clean"` bar under
 │                    the titlebar: what operation is open, conflicts left,
-│                    Resolve/Finish/Abort)
+│                    Resolve/Finish/Abort), ownership (the `safe.directory`
+│                    confirm — outside the store so store tests need no dialog)
 ├── nav/             useNavStore — cross-screen intents (diff-file, commit-vs-wt,
-│                    file-history, blame, rebase-plan, stash-diff)
-├── branches/        BranchChip (titlebar), BranchPicker (popover)
-├── commits/         graphLayout + buildRebasePlan (both tested)
+│                    file-history, blame, rebase-plan, stash-diff) +
+│                    DeepViewHeader (the origin crumb a deep view goes back to)
+├── branches/        BranchChip (titlebar), BranchPicker (popover), orderBranches
+│                    (PURE, #135: default branch first, then newest `tipTime`
+│                    first, then name — a plain `<` compare, not `localeCompare`,
+│                    because branches cut from one commit share a tip time and
+│                    that tiebreaker must not depend on the runtime's ICU data).
+│                    EVERY branch list goes through it — picker, Branches screen,
+│                    palette rows; a second ordering is how those three drifted
+│                    apart before. `isHead` is deliberately NOT a sort key: the
+│                    current branch is the one branch the picker exists to leave
+├── commits/         The log's pure logic, all tested: graphLayout + laneColors +
+│                    graphAncestry + rowIdentity (the graph — #68 G2/G4/G9),
+│                    buildRebasePlan / buildPreservePlan / runRebasePlan /
+│                    planCommitSelection / squashMessage (the rebase plans), plus
+│                    headAncestry (`headAncestryOf`, see commands/commits.rs) and
+│                    logFilter (History's search inputs → a backend `LogFilter`)
 ├── rebase/          RebaseBasePicker + useRebaseMergeMode (persisted
 │                    flatten ⇄ preserve for merge commits in a plan)
 ├── dnd/             ALL drag-and-drop (#91). `useDragSource` / `useDropZone`
@@ -552,7 +650,9 @@ features/            Per-feature: components + Zustand store colocated
 │                    a feature store), useCompareStore (sides + results + the
 │                    compare mark, its own store so RepoSlice is untouched),
 │                    CompareSidePicker
-├── diff/            CommitDiffPanel (shared commit-diff view) + WhitespaceToggle
+├── diff/            CommitDiffPanel (shared commit-diff view), useWholeFile (the
+│                    `wholeFile` option for `flattenDiffRows`, or undefined in
+│                    chunked mode) + WhitespaceToggle
 │                    (ignore-whitespace control; also owns
 │                    useHunkActionsDisabledReason — hunk staging is disabled
 │                    while whitespace is ignored, see #61 D2)
@@ -589,6 +689,17 @@ lib/
 ├── syntax/          Shiki highlighting, OFF the main thread (see below)
 │   ├── tokenizeCore.ts   Shiki-FREE: SyntaxLine/SyntaxToken, MAX_HIGHLIGHT_*,
 │   │                     toLineRelative, packLines/unpackLines, skipHighlight
+│   ├── shiki.ts          The ONE Shiki instance — lazy, so app start pays
+│   │                     nothing, and shared so grammars register once.
+│   │                     engine-javascript, not WASM Oniguruma: no .wasm asset
+│   │                     to ship or fetch through the Tauri custom protocol
+│   ├── langs.ts          path → Shiki language + the grammar loaders.
+│   │                     LANG_LOADERS is an EXPLICIT map of static `import()`s —
+│   │                     a template-literal specifier is not statically
+│   │                     analysable, so Vite could neither resolve nor split it
+│   ├── scopes.ts         One table drives the SENTINEL theme we tokenize with
+│   │                     and the colour→CSS-class lookup that reads it back, so
+│   │                     token colours live in CSS, not in the tokenizer
 │   ├── tokenizeShiki.ts  The one place codeToTokens is called
 │   ├── tokenize.worker.ts  Module worker running tokenizeShiki
 │   ├── tokenize.ts       Main-thread API: LRU cache + worker client + fallback.
@@ -598,8 +709,21 @@ lib/
 │   └── usePrefetchSyntax.ts  Bounded idle warm-up of a commit's other files
 ├── diffRows.ts      Flat DiffRow model (header | line | fill) + exact
 │                    variable-height window. `fill` = whole-file gap filler
+├── wordDiff.ts      Intra-line (word) diff for one rem/add pair (#61 D8)
+├── pairChangedLines.ts  WHICH rem pairs with WHICH add — one definition shared
+│                    by the unified hunk, the split view and the commit panel
+├── lineSpans.ts     The ONE place syntax tokens and word-diff spans reconcile
+│                    into a single tiling of the line, so every renderer is a
+│                    flat `spans.map()` with no gap or overlap reasoning
+├── codeLines.ts     Split file text into DISPLAY lines — `text.split("\n")`
+│                    gets empty text and a trailing newline wrong, both visible
 ├── useViewportH.ts  Scroll-container height WITHOUT depending on ResizeObserver
 ├── useWindowedList.ts  Fixed-pitch windowing for the plain lists
+├── useDiffRowHeight.ts  Resolves `--diff-row-h` to px, with a fallback for
+│                    jsdom (which does not evaluate `calc()`); CSS stays the
+│                    source of truth — NaN here would collapse every row to zero
+├── platform.ts      `getPlatform` / `usePlatform` — the OS, resolved once and
+│                    cached (chord labels, platform-conditional chrome)
 ├── fileIcon.ts      path → file-type glyph + themeable tint (tested)
 ├── selection.ts     Multi-select click/range/prune model AND
 │                    `splitFileSelection` — the one place a multi-selection is
@@ -615,7 +739,48 @@ lib/
 └── recents.ts       Recent-repo persistence (`pg-recent-repos`). The OPEN set is
                      a separate key, `pg-open-repos`, in features/repo/tabs.ts —
                      recents are where you have been, the open set where you are
+
+test/                Component-test harness for the jsdom suite. NOT shipped
+                     code — nothing under src/ imports it at runtime:
+├── setup.ts         Vitest global setup — installs the invoke/dialog/event/
+│                    webview mocks (`mockInvoke(cmd, handler)` registers a
+│                    per-command response). jsdom-only: it shims `Range` and
+│                    runs RTL `cleanup`, so it cannot load in a node-env test
+├── invokeMock.ts / dialogMock.ts / eventMock.ts / webviewMock.ts  The mocks
+├── dialog.tsx       `WithDialogs` — a screen rendered in isolation has no
+│                    <PGDialogHost/>, so every pgConfirm silently reads as
+│                    "cancelled" without this
+└── settle.ts        The shared settle guard for tests driving a diff surface —
+                     subtle enough that a second copy drifts
 ```
+
+### `test/` at the repo root — doc invariants (#147, #150)
+
+**`test/docs.test.ts` fails the build when this document falls behind the tree.**
+It asserts that every id in `invoke_handler!`, every `src-tauri/src/**/*.rs`
+module and every `src/features/*/` directory is named somewhere in here.
+
+- It understands the compressed group notation the command lists use
+  (`stage/unstage/discard_paths`, `worktree_add/remove/lock/unlock/prune`) by
+  expanding it, so keep writing groups that way — but an irregular group it
+  cannot read will fail, and the fix is to spell that id out rather than to
+  contort the group.
+- It checks that a name is *mentioned*, not that the description is any good.
+  The prose is still on you.
+- Deliberately NOT extended to `src/screens/` or bare feature names — History,
+  Remote, diff, merge and update are ordinary words that occur all over this
+  file, so those assertions would pass for the wrong reason and could never
+  fail. Further doc invariants belong in this file; add cases, not counts.
+- **`test/` is the repo root, not `src/test/`** — the two are unrelated despite
+  the name. This suite reads `src-tauri/`, `CLAUDE.md` and `e2e/`, so it is not
+  a frontend test. `pnpm test` runs both suites as two vitest **projects**
+  (`vite.config.ts`): `unit` is jsdom + the `src/test/setup.ts` mocks, `docs` is
+  node with no setup file. That split is load-bearing — the harness above dies
+  on a missing `Range` outside jsdom, and a doc test has no use for Tauri mocks.
+- `tsconfig.json` has `include: ["src", "test"]` for the same reason. Without
+  the second entry the file still RUNS but stops being typechecked, which is a
+  silent hole rather than a visible one — a new top-level test directory needs
+  adding there as well as to `test.include`.
 
 ### Diff rendering
 
@@ -692,6 +857,37 @@ lib/
   boundaries, so both the click path and the keyboard cursor are switched off by
   `useHunkActionsDisabledReason` — the keyboard must never reach what the mouse
   cannot (#61 D2).
+
+### The log is paged (#68 G11)
+
+- **`s.commits` is a PREFIX of history, not history.** History loads one page at
+  a time (`PAGE_SIZE = 500`) and appends; `hasMoreLog` is "the cursor is not
+  null". So any logic that answers a question about the repository from
+  `s.commits` is answering it about however much has been walked so far. That is
+  fine for what is on screen and wrong for "does this commit exist" or "is X an
+  ancestor of Y" — ask the backend.
+- **The cursor is a FRONTIER — a set of oids, not one.** At a page boundary
+  several lanes are alive, each awaiting a different parent, so resuming from
+  the last emitted commit alone would silently drop every other branch.
+  `LogPage { commits, nextCursor }`; `nextCursor: null` means the walk reached
+  the true end of history.
+- **Passing a cursor makes `refspec` a no-op**, deliberately: the frontier
+  already encodes the walk it continues. Changing scope means starting a new
+  walk with no cursor, not handing the old cursor a new refspec.
+- **Two cursors, because a search must not destroy the unfiltered resume
+  point.** `commitCursor` belongs to `commits`, `searchCursor` to
+  `searchResults`, and `loadMoreCommits` extends whichever list is active
+  (`getLogPage` vs `getLogFilteredPage`). Both are `RepoSlice` fields — a tab
+  switch restores the cursor with its list, so a background tab does not silently
+  resume another repository's walk.
+- **Filtering happens on both sides and they are not the same filter.** The
+  backend `LogFilter` decides which commits count toward `limit`;
+  History then filters the loaded page again client-side (hide-merges, the text
+  box). A client filter can therefore hold the visible list shorter than the
+  window no matter how many pages arrive, which is why History's auto-paging
+  effect counts *barren* pages and stops after `MAX_BARREN_PAGES` — without that
+  bound it walks the whole repository a page at a time. Any new client-side log
+  filter inherits that trap.
 
 ### Navigation model
 
@@ -834,6 +1030,9 @@ lib/
 4. Register command name in `invoke_handler![…]` in `src-tauri/src/lib.rs`.
 5. Add TS type to `src/lib/types.ts`, wrapper to `src/lib/tauri.ts`.
 6. Wire into relevant feature's Zustand store.
+7. Add it to the `commands/<area>.rs` entry in the backend tree above —
+   `test/docs.test.ts` fails the build otherwise, and a command nobody can find
+   is a command that gets written twice.
 
 ### State management
 - **Zustand per-feature**, not one big global store. `useRepoStore` lives in `features/repo/` because that's who owns the state.
@@ -943,20 +1142,23 @@ lib/
 
 ### Network ops and credentials (#61 D5)
 
-- **One runner, eleven call sites.** Every op that shells out to real `git` over
-  the network goes through `commands::net::run_git_authenticated` (or, for clone,
-  through its two primitives `apply_auth_env` + `map_git_failure`, because clone
-  needs a streamed stderr pipe rather than `.output()`). The eleven:
+- **One runner, and every network op is on this list.** Every op that shells out
+  to real `git` over the network goes through
+  `commands::net::run_git_authenticated` (or, for clone, through its two
+  primitives `apply_auth_env` + `map_git_failure`, because clone needs a
+  streamed stderr pipe rather than `.output()`):
   `fetch`, `fetch_all`, `pull`, `push`, `push_tag`, `push_delete_branch` in
   `commands/branches.rs` (all six via its local `run_git_creds` wrapper),
   `clone_repo` in `commands/create.rs`, `forge_checkout_pull_request`'s FETCH in
   `commands/forge.rs` (#92 — its second git call, the `checkout` of `FETCH_HEAD`,
   passes `None` on purpose: the tip is already local and touches no remote), and
   — since #93 — `submodule_update` (`commands/submodule.rs`) plus `lfs_fetch` /
-  `lfs_pull` (`commands/lfs.rs`). Count them in the tree before trusting this
-  number: #92 and #93 landed within a day of each other and each rewrote the
-  sentence for its own additions only. A new network op joins them; **do not open
-  a second auth path** — on the frontend that means `useRepoStore`'s exported
+  `lfs_pull` (`commands/lfs.rs`).
+  `grep -rn 'run_git_authenticated\|run_git_creds\|apply_auth_env' src-tauri/src/`
+  is the authoritative list — a bare count used to lead this bullet and two PRs
+  landing a day apart each updated the prose for their own additions only.
+  A new network op joins them; **do not open a second auth path** — on the
+  frontend that means `useRepoStore`'s exported
   `withAuthRetry`, not a private copy, or the challenge is raised with nothing
   mounted to answer it. The deliberately credential-less siblings are
   `branches.rs`'s local `run_git` (merge/rebase/checkout) and `libgit2.rs`'s
@@ -1272,7 +1474,7 @@ lib/
 - Escape cancels any drag, from one capture-phase listener in the controller.
 
 ### Permissions (Tauri 2)
-- Shared permissions in `src-tauri/capabilities/default.json`. Current set: `core:default`, `core:window:allow-minimize`, `core:window:allow-toggle-maximize`, `core:window:allow-close`, `core:window:allow-start-dragging`, `core:window:allow-set-title`, `core:webview:allow-create-webview-window`, `dialog:default`, `dialog:allow-open`, `os:default`, `log:default`. Capability scopes `windows: ["main", "merge"]` (merge resolver runs as a second window).
+- Shared permissions in `src-tauri/capabilities/default.json`. Current set: `core:default`, `core:window:allow-minimize`, `core:window:allow-toggle-maximize`, `core:window:allow-close`, `core:window:allow-start-dragging`, `core:window:allow-set-title`, `core:webview:allow-create-webview-window`, `core:webview:allow-set-webview-zoom` (the `view.zoom*` chords), `dialog:default`, `dialog:allow-open`, `os:default`, `log:default`. Capability scopes `windows: ["main", "merge"]` (merge resolver runs as a second window).
 - **Self-update permissions are scoped narrower** — `updater:default` + `process:allow-restart` live in `src-tauri/capabilities/updater.json` with `windows: ["main"]`, NOT in `default.json`. The merge resolver window must not be able to swap the binary or relaunch the process mid-conflict. Keep new privileged permissions out of the shared capability unless both windows genuinely need them.
 - **E2E-only permissions** live in the inline `e2e-focus` capability in `src-tauri/tauri.e2e.conf.json`, NOT in `default.json`: `core:window:allow-set-focus` + `wdio-webdriver:default`. That capability is loaded only via `--config src-tauri/tauri.e2e.conf.json`, and the `tauri-plugin-wdio-webdriver` crate is an optional dep behind the `e2e` cargo feature (`--features …,e2e` in `test:e2e:build`), so the WebDriver bridge is never compiled into or permitted in dev/production builds.
 - New plugin: `cargo add tauri-plugin-X`, `pnpm add @tauri-apps/plugin-X`, register with `.plugin(tauri_plugin_X::init())` in `lib.rs`, add plugin permissions to capability file.
@@ -1284,8 +1486,17 @@ lib/
 
 - Shell integration / Finder / Explorer overlays (out of scope).
 - Custom icons — Tauri defaults for now. Replace before first release.
-- Code signing config for bundles.
-- Broad test suite — unit tests exist for pure logic (graphLayout, buildRebasePlan) + libgit2 smoke. Add tests alongside each feature as built.
+- Code signing config for bundles (distinct from the *updater* signing key, which
+  does exist — see "Common commands", and from git object signing, which is a
+  feature).
+
+Removed from this list once it stopped being true — do not re-add:
+
+- ~~CI config~~. Two workflows plus their gate jobs; see "What CI runs".
+- ~~Broad test suite~~. All four layers under "Testing" are populated and green,
+  including the Rust integration suite over real temp repos and jsdom component
+  tests for every screen. New work is expected to come with tests, and a claim
+  that this codebase has "only smoke tests" is now the opposite of the truth.
 
 ## Known placeholders
 

--- a/test/docs.test.ts
+++ b/test/docs.test.ts
@@ -1,0 +1,150 @@
+/**
+ * @vitest-environment node
+ */
+// CLAUDE.md coverage (#147, #150).
+//
+// Lives at the repo root rather than under `src/` because it asserts things
+// about `src-tauri/`, `CLAUDE.md` and `e2e/` — it is not a frontend test in any
+// sense, and `test/` is the home for further doc invariants. `vite.config.ts`
+// adds `test/**/*.test.ts` to `test.include` for exactly this directory.
+//
+// CLAUDE.md is read as authoritative by assistant sessions, so an entry that
+// silently stopped existing sends work down the wrong path. It has now drifted
+// three times in the same two ways: a whole module landed without reaching the
+// file trees, and a command landed without reaching a command list.
+//
+// Both of those are mechanically checkable from the tree itself, so they are
+// checked here instead of by hand. What is NOT checked is whether the prose is
+// any GOOD — this only asserts a name is mentioned. Passing means "somebody
+// wrote this down", never "the description is current".
+//
+// Deliberately not extended to `src/screens/` or bare feature-directory names:
+// those are ordinary English words (History, Remote, diff, merge, update) that
+// occur throughout the prose, so the assertion would pass for the wrong reason
+// and never be able to fail. A check that cannot fail is worse than no check.
+
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Vitest runs from the project root, and `import.meta.url` is not a file: URL
+// once Vite has transformed this module — so resolve against cwd, not the
+// module.
+const root = (rel: string) => resolve(process.cwd(), rel);
+const read = (rel: string) => readFileSync(root(rel), "utf8");
+
+const doc = read("CLAUDE.md");
+
+/**
+ * Every id registered in `invoke_handler!`.
+ *
+ * Text-parsed rather than derived from a build artifact: the registry is the
+ * one place a command becomes reachable from the frontend, and reading it
+ * needs no cargo run.
+ */
+function registeredCommands(): string[] {
+  const lib = read("src-tauri/src/lib.rs");
+  const start = lib.indexOf("generate_handler![");
+  expect(start, "generate_handler! not found in lib.rs").toBeGreaterThan(-1);
+  const block = lib.slice(start, lib.indexOf("])", start));
+  const ids = [...block.matchAll(/commands::[a-z_]+::([a-z_0-9]+)\s*,/g)].map(
+    (m) => m[1],
+  );
+  expect(ids.length, "parsed no command ids").toBeGreaterThan(50);
+  return [...new Set(ids)];
+}
+
+/**
+ * Expand the doc's own compressed notation into the ids it stands for.
+ *
+ * The command lists write related commands as one group — `stage/unstage/
+ * discard_paths`, `worktree_add/remove/lock/unlock/prune`, `accept_ours/theirs`
+ * — because five lines of near-identical text read worse than one. That is
+ * house style worth keeping, so the checker learns the notation rather than the
+ * document being flattened to satisfy it.
+ *
+ * Both readings are generated (shared prefix from the first segment, shared
+ * suffix from the last) at every `_` boundary, and the result is intersected
+ * with the real registry. Over-generation is safe: every candidate is built
+ * from words actually written in the file, so this can never invent a name for
+ * a command nobody documented.
+ */
+function expandGroup(group: string): string[] {
+  const segs = group.split("/");
+  const out = new Set(segs);
+  const splits = (s: string) =>
+    [...s].flatMap((c, i) => (c === "_" ? [i + 1] : []));
+
+  for (const at of splits(segs[0])) {
+    const prefix = segs[0].slice(0, at);
+    for (const seg of segs.slice(1)) out.add(prefix + seg);
+  }
+  const last = segs[segs.length - 1];
+  for (const at of splits(last)) {
+    const suffix = last.slice(at - 1);
+    for (const seg of segs.slice(0, -1)) out.add(seg + suffix);
+  }
+  return [...out];
+}
+
+function documentedCommands(): Set<string> {
+  const named = new Set(doc.match(/[a-z][a-z_0-9]*/g) ?? []);
+  for (const [group] of doc.matchAll(/[a-z][a-z_0-9]*(?:\/[a-z][a-z_0-9]*)+/g)) {
+    for (const id of expandGroup(group)) named.add(id);
+  }
+  return named;
+}
+
+describe("CLAUDE.md stays in step with the tree", () => {
+  it("names every command registered in invoke_handler!", () => {
+    const documented = documentedCommands();
+    const missing = registeredCommands().filter((id) => !documented.has(id));
+
+    expect(
+      missing,
+      `Not mentioned anywhere in CLAUDE.md: ${missing.join(", ")}.\n` +
+        "Add each to the relevant `commands/<area>.rs` entry in the backend " +
+        "tree — as a real entry saying what it is for, not appended to a bare " +
+        "list. Joining a sibling group (`stage/unstage/discard_paths`) counts; " +
+        "an irregular group the expander cannot read does not, so spell that " +
+        "id out.",
+    ).toEqual([]);
+  });
+
+  it("names every backend module", () => {
+    const walk = (rel: string): string[] =>
+      readdirSync(root(rel), { withFileTypes: true }).flatMap((e) =>
+        e.isDirectory()
+          ? walk(`${rel}${e.name}/`)
+          : e.name.endsWith(".rs")
+            ? [e.name]
+            : [],
+      );
+
+    const missing = [...new Set(walk("src-tauri/src/"))]
+      .filter((name) => !doc.includes(name))
+      .sort();
+
+    expect(
+      missing,
+      `Backend modules absent from the src-tauri/src/ tree in CLAUDE.md: ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("names every frontend feature directory", () => {
+    // Requires the qualified `features/<name>` or the tree's `── <name>/`, not
+    // the bare word — see the note at the top of this file.
+    const missing = readdirSync(root("src/features/"), {
+      withFileTypes: true,
+    })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .filter((n) => !doc.includes(`features/${n}`) && !doc.includes(`── ${n}/`))
+      .sort();
+
+    expect(
+      missing,
+      `Feature directories absent from the features/ tree in CLAUDE.md: ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
     "baseUrl": ".",
     "paths": { "@/*": ["src/*"] }
   },
-  "include": ["src"],
+  "include": ["src", "test"],
   "exclude": ["e2e"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,9 +27,30 @@ export default defineConfig(async () => ({
       : undefined,
     watch: { ignored: ["**/src-tauri/**"] },
   },
+  // Two suites, because they need different worlds. The frontend suite is jsdom
+  // and installs the Tauri mocks; the repo-level `test/` suite asserts facts
+  // about the tree (CLAUDE.md vs src-tauri/, features/, e2e/) and touches only
+  // node:fs — running it through the component harness makes it fail on jsdom
+  // globals the setup file shims (`Range`), for no benefit.
   test: {
-    environment: "jsdom",
-    include: ["src/**/*.test.{ts,tsx}"],
-    setupFiles: ["./src/test/setup.ts"],
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "unit",
+          environment: "jsdom",
+          include: ["src/**/*.test.{ts,tsx}"],
+          setupFiles: ["./src/test/setup.ts"],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "docs",
+          environment: "node",
+          include: ["test/**/*.test.ts"],
+        },
+      },
+    ],
   },
 }));


### PR DESCRIPTION
Closes #147. Closes #150.

`CLAUDE.md` had drifted from the tree in three repeating ways. This fixes the current drift, then makes the two *mechanical* classes of it impossible to reintroduce silently.

## Already fixed before this branch

The issue was verified at `d41bd8e`; `main` was five merges further on and four of those merges edited `CLAUDE.md`. So these #147 items were already resolved and needed no work: `git/signing.rs`, `src/features/signing/`, `git/tag.rs`, `git/stash.rs`, `features/compare/`, `features/tags/`, `diff_ref_to_workdir`, `commits_between`, `ahead_behind`, `verify_tag`, the three new stash commands, and the "no CI config" bullet. The spec count had also been bumped 24 → 25 by hand.

## Fixed here

**Trees.** `git/auth.rs`, `commands/net.rs`, `commands/update.rs` and `main.rs` were all absent — `auth.rs` and `net.rs` while being discussed at length in the prose. Frontend: `src/test/`, `orderBranches`, the real contents of `features/commits/`, `PGWindowedDiff`, `graph-geometry`, `error-boundary`, `window-controls`, `skeleton`, the `lib/syntax` internals (`shiki`/`langs`/`scopes`) and the `lib/` diff helpers (`wordDiff`, `lineSpans`, `pairChangedLines`, `codeLines`, `useDiffRowHeight`, `platform`).

**`signing.rs` vs `signature.rs`.** Now stated as cryptography vs identity — `signature.rs` is `user.name`/`user.email` plus the `Signed-off-by:` trailer, which proves nothing and involves no key. A note after the tree names all three confusable pairs in that tree, including `update.rs` vs `commands/update.rs` and `cli.rs` vs `git/cli.rs`.

**Commands.** Added `read_file_content_at_rev`, `read_file_content_at_index`, `list_files_at_rev`, `verify_commit`, `commits_since`, `set_upstream`, `remember_credential`, `stage/unstage/discard_lines`, and `diff_commit` next to `diff_commits` with the one-character difference called out.

**Log pagination — the biggest gap.** New "The log is paged" section: `s.commits` is a prefix of history, the cursor is a *frontier set* not an oid, passing a cursor makes `refspec` a no-op, there are two cursors so a search cannot destroy the unfiltered resume point, and client-side filtering is what makes History's barren-page bound necessary.

**Other verified-stale prose.** `core:webview:allow-set-webview-zoom` was in `default.json` but not the permissions list. The `2026-08-16-branch-picker-order-*` spec had no bullet. "Things deliberately NOT in codebase" claimed there is no broad test suite — there are 1466 frontend and 607 Rust tests; retired alongside the already-retired CI bullet, both struck through so neither comes back.

## Counts removed, not corrected — this is what closes #150

The `e2e/specs/` count had gone stale three times *while carrying its own warning about going stale*, and the network call-site count had been rewritten twice by PRs landing a day apart. Both now say what the set is for and give the command that enumerates it.

**#150's `<!-- e2e-spec-count:25 -->` marker was deliberately not implemented.** #150's own "Alternative worth weighing first" section argues for deleting the number instead, and that is the smaller permanent fix: no marker to keep in sync, no regex over prose, no test to maintain. The count served no navigational purpose — `ls e2e/specs/` answers it. So the number is gone rather than enforced. (The network list itself was verified still complete at eleven; only the number is gone.)

## The enforcement test

`test/docs.test.ts` asserts every `invoke_handler!` id, every `src-tauri/src/**/*.rs` module and every `src/features/*/` directory is named somewhere in the document.

#147 noted the compressed `stage/unstage/discard_paths` listings would need normalising first. They didn't — the checker learns the notation instead, expanding a slash group by trying shared-prefix and shared-suffix readings at every `_` boundary and intersecting with the real registry. That keeps the house style, which reads better than one line per command. Over-generation is safe: every candidate is built from words actually written in the file, so it cannot invent a name for an undocumented command. One irregular group (`add/remove/rename/set_url/prune remote`, where `set_url` → `set_remote_url` reorders words) was rewritten to the regular form rather than given an exception entry, so there is no allow-list to rot.

Deliberately **not** extended to `src/screens/` or bare feature-directory names: those are ordinary English words (History, Remote, diff, merge, update) that occur throughout the prose, so the assertion would pass for the wrong reason and could never fail.

Known limit, stated in the file: it checks a name is *mentioned*, not that the description is current. `verify_commit` would have passed before this PR on the strength of one security note while its command entry stayed wrong.

### Where it lives (per #150)

At the **repo root**, not under `src/` — it reads `src-tauri/`, `CLAUDE.md` and `e2e/`, so it is not a frontend test, and `test/` is a home for further doc invariants rather than accreting them in the frontend tree.

That needed three config changes, and the second was found by verifying rather than assuming:

1. `vite.config.ts` — the suite is now two vitest **projects**: `unit` (jsdom, `src/**/*.test.{ts,tsx}`, the Tauri mocks) and `docs` (node, `test/**/*.test.ts`, no setup file). A flat second `include` entry plus `@vitest-environment node` **does not work**: `setupFiles` still applies, and `src/test/setup.ts` touches `Range.prototype` at module scope, so the file died with `ReferenceError: Range is not defined`. Splitting into projects removes the coupling permanently instead of patching the shared frontend harness to accommodate a docs test.
2. `tsconfig.json` — `include` was `["src"]`, so at the new path the file **still ran but stopped being typechecked**. Now `["src", "test"]`. Verified by appending a deliberate type error and confirming `pnpm tsc --noEmit` fails on `test/docs.test.ts`, then removing it.
3. The docblock keeps `@vitest-environment node` as the file-local statement of intent.

## Verification

Both directions of the gate, from the new location:

- Green on the real document (3 tests pass).
- Deleting `set_upstream` and shrinking `worktree_add/remove/lock/unlock/prune` → `Not mentioned anywhere in CLAUDE.md: set_upstream, worktree_prune`.
- Removing every mention of `ownership.rs` → `Backend modules absent from the src-tauri/src/ tree`.
- Renaming the `compare/` feature entry → `Feature directories absent from the features/ tree`.

The glob change collects exactly what it should:

- `pnpm vitest list` before vs after, project prefix stripped, differs by **one line** — `src/test/claudeMd.test.ts` → `test/docs.test.ts`. 180 files both sides, nothing gained or lost.
- `docs` project collects exactly 1 file; `unit` collects 179 (1463 tests) — 179 + 1 = 180, 1463 + 3 = 1466.
- No `e2e` or `node_modules` path is collected. `e2e/` contains no `*.test.ts` at all (only `.e2e.ts`), so the new glob is doubly excluded — different directory *and* different suffix.

Gates: `pnpm tsc --noEmit` clean. `pnpm test` — 180 files, 1466 tests passing. `pnpm exec tsc -p e2e/tsconfig.json --noEmit` clean. `cargo test` — 607 tests across 57 binaries, 0 failures.

`main` moved to `0006fa4` while this was in progress. `git merge-tree` reports no conflict, and the docs gate was run against the **merged** `CLAUDE.md` (tree `fb4264a`) and passes — so this cannot turn `main` red on merge. Not rebased, since there is no conflict and `main` added no module, feature directory or `invoke_handler!` id.

E2E deliberately not run: another agent holds the Docker slot and a docs + vitest change cannot affect the webview suite. Spec files were counted with `ls e2e/specs/` (25, which is why the number is now gone rather than corrected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Er25sN6pGoVJzmTBwHU2Tz