### PR TITLE
fix(log): surface backend error kind instead of [object Object] (#146)

### DIFF
--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -102,7 +102,7 @@ pub async fn read_file_content_at_rev(
     repo_id: String,
     revspec: String,
     path: String,
-) -> AppResult<FileContent> {
+) -> AppResult<Option<FileContent>> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
     let path_buf = PathBuf::from(path);
@@ -118,7 +118,7 @@ pub async fn read_file_content_at_index(
     state: State<'_, AppState>,
     repo_id: String,
     path: String,
-) -> AppResult<FileContent> {
+) -> AppResult<Option<FileContent>> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
     let path_buf = PathBuf::from(path);

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -129,14 +129,14 @@ impl GitBackend for CliBackend {
         _repo_id: &RepoId,
         _revspec: &str,
         _path: &Path,
-    ) -> AppResult<FileContent> {
+    ) -> AppResult<Option<FileContent>> {
         Err(AppError::NotImplemented)
     }
     fn read_file_content_at_index(
         &self,
         _repo_id: &RepoId,
         _path: &Path,
-    ) -> AppResult<FileContent> {
+    ) -> AppResult<Option<FileContent>> {
         Err(AppError::NotImplemented)
     }
     fn diff_commits(

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -3093,31 +3093,38 @@ impl GitBackend for Libgit2Backend {
         repo_id: &RepoId,
         revspec: &str,
         path: &Path,
-    ) -> AppResult<FileContent> {
+    ) -> AppResult<Option<FileContent>> {
         let rel = path.to_path_buf();
         let path_str = rel.to_string_lossy().into_owned();
         self.with_repo(repo_id, |repo| {
             let tree = resolve_tree(repo, revspec)?;
 
-            let entry = tree
-                .get_path(&rel)
-                .map_err(|_| AppError::InvalidPath(format!("file not found: {path_str}")))?;
+            // No text at this path at this revision is a STATE, not a failure
+            // (#146). Every diff surface reads the OTHER side of a file it is
+            // already rendering, so an ADDED file has no old side and a DELETED
+            // one has no new side — the expected case, and the reason seven of
+            // these were logged as errors during one commit's syntax prefetch.
+            // A non-blob (a directory, or a `160000` submodule gitlink) answers
+            // the same way: there is no text to colour either.
+            let Ok(entry) = tree.get_path(&rel) else {
+                return Ok(None);
+            };
             let obj = entry.to_object(repo)?;
-            let blob = obj
-                .as_blob()
-                .ok_or_else(|| AppError::InvalidPath(format!("not a file: {path_str}")))?;
+            let Some(blob) = obj.as_blob() else {
+                return Ok(None);
+            };
             let content = blob.content();
             let size = content.len() as u64;
             if blob.is_binary() {
-                return Ok(FileContent {
+                return Ok(Some(FileContent {
                     path: path_str,
                     binary: true,
                     text: None,
                     from_head: true,
                     size,
-                });
+                }));
             }
-            Ok(match std::str::from_utf8(content) {
+            Ok(Some(match std::str::from_utf8(content) {
                 Ok(s) => FileContent {
                     path: path_str,
                     binary: false,
@@ -3132,7 +3139,7 @@ impl GitBackend for Libgit2Backend {
                     from_head: true,
                     size,
                 },
-            })
+            }))
         })
     }
 
@@ -3140,7 +3147,7 @@ impl GitBackend for Libgit2Backend {
         &self,
         repo_id: &RepoId,
         path: &Path,
-    ) -> AppResult<FileContent> {
+    ) -> AppResult<Option<FileContent>> {
         let rel = path.to_path_buf();
         let path_str = rel.to_string_lossy().into_owned();
         self.with_repo(repo_id, |repo| {
@@ -3148,23 +3155,26 @@ impl GitBackend for Libgit2Backend {
             // Stage 0 is the normal, non-conflicted entry. A conflicted path has
             // stages 1-3 and no 0, so it lands in the same "not in the index"
             // branch as an untracked one — correct either way, because neither
-            // has a single index version to colour from.
-            let entry = index
-                .get_path(&rel, 0)
-                .ok_or_else(|| AppError::InvalidPath(format!("not in the index: {path_str}")))?;
+            // has a single index version to colour from. That absence is a
+            // STATE, not a failure (#146): the commit panel asks for the index
+            // side of every row it renders, and an untracked row genuinely has
+            // none.
+            let Some(entry) = index.get_path(&rel, 0) else {
+                return Ok(None);
+            };
             let blob = repo.find_blob(entry.id)?;
             let content = blob.content();
             let size = content.len() as u64;
             if blob.is_binary() {
-                return Ok(FileContent {
+                return Ok(Some(FileContent {
                     path: path_str,
                     binary: true,
                     text: None,
                     from_head: false,
                     size,
-                });
+                }));
             }
-            Ok(match std::str::from_utf8(content) {
+            Ok(Some(match std::str::from_utf8(content) {
                 Ok(s) => FileContent {
                     path: path_str,
                     binary: false,
@@ -3179,7 +3189,7 @@ impl GitBackend for Libgit2Backend {
                     from_head: false,
                     size,
                 },
-            })
+            }))
         })
     }
 

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -181,27 +181,37 @@ pub trait GitBackend: Send + Sync {
     /// revspec can't be resolved.
     fn list_files_at_rev(&self, repo_id: &RepoId, revspec: &str) -> AppResult<Vec<FileStatus>>;
     /// Read the content of `path` from the tree at `revspec`. `InvalidRef` if
-    /// the revspec can't be resolved; `InvalidPath` if the path isn't in that
-    /// tree. The returned `FileContent.from_head` is true (content is from a
-    /// committed tree, not the worktree).
+    /// the revspec can't be resolved. The returned `FileContent.from_head` is
+    /// true (content is from a committed tree, not the worktree).
+    ///
+    /// `Ok(None)` — NOT an error — when that tree holds no text at that path:
+    /// the path is absent, or it is a directory or a submodule gitlink. Absence
+    /// is the EXPECTED answer here, because every caller is a diff surface
+    /// asking for the other side of a file it is already rendering, and an added
+    /// file has no old side. Returning `InvalidPath` instead put a routine
+    /// condition on the error path, where the frontend's shared `invoke` wrapper
+    /// logged it at ERROR (#146). A genuine failure — bad revspec, unknown
+    /// repository, unreadable object — still errors.
     fn read_file_content_at_rev(
         &self,
         repo_id: &RepoId,
         revspec: &str,
         path: &Path,
-    ) -> AppResult<FileContent>;
+    ) -> AppResult<Option<FileContent>>;
     /// The INDEX copy of a file — what committing would record.
     ///
     /// Distinct from both other readers precisely when a file is partially
     /// staged, which is the case the commit panel could not colour correctly
     /// while it had to approximate the index with HEAD and the worktree.
-    /// A path with no stage-0 entry (untracked, or conflicted) is an
-    /// `InvalidPath`, so the caller can fall back to rendering plain rows.
+    /// A path with no stage-0 entry (untracked, or conflicted) is `Ok(None)`,
+    /// not an error — the commit panel asks for the index side of every row it
+    /// renders, so an untracked row genuinely having none is the expected
+    /// answer, and the caller falls back to plain rows (#146).
     fn read_file_content_at_index(
         &self,
         repo_id: &RepoId,
         path: &Path,
-    ) -> AppResult<FileContent>;
+    ) -> AppResult<Option<FileContent>>;
     fn diff_commits(
         &self,
         repo_id: &RepoId,

--- a/src-tauri/tests/browse_tree_at_rev.rs
+++ b/src-tauri/tests/browse_tree_at_rev.rs
@@ -53,14 +53,16 @@ fn reads_historical_file_content() {
 
     let old = backend
         .read_file_content_at_rev(&handle.id, "HEAD~1", Path::new("README.md"))
-        .unwrap();
+        .unwrap()
+        .expect("README.md exists at HEAD~1");
     assert_eq!(old.text.as_deref(), Some("first version\n"));
     assert!(!old.binary);
     assert!(old.from_head);
 
     let cur = backend
         .read_file_content_at_rev(&handle.id, "HEAD", Path::new("README.md"))
-        .unwrap();
+        .unwrap()
+        .expect("README.md exists at HEAD");
     assert_eq!(cur.text.as_deref(), Some("second version\n"));
 }
 
@@ -83,7 +85,8 @@ fn resolves_branch_revspec() {
 
     let content = backend
         .read_file_content_at_rev(&handle.id, "feature", Path::new("feature.txt"))
-        .unwrap();
+        .unwrap()
+        .expect("feature.txt exists on feature");
     assert_eq!(content.text.as_deref(), Some("on feature\n"));
 }
 
@@ -118,19 +121,39 @@ fn reads_binary_blob_at_revision() {
 
     let content = backend
         .read_file_content_at_rev(&handle.id, "HEAD", Path::new("blob.bin"))
-        .unwrap();
+        .unwrap()
+        .expect("blob.bin exists at HEAD");
     assert!(content.binary, "expected binary flag set");
     assert_eq!(content.text, None);
 }
 
-/// A path that doesn't exist in the tree yields InvalidPath.
+/// A path that doesn't exist in the tree is `Ok(None)`, NOT an error (#146).
+///
+/// Every caller is a diff surface reading the OTHER side of a file it is already
+/// rendering, so an added file having no old side is the routine case. While this
+/// answered `InvalidPath`, the frontend's shared `invoke` wrapper logged one ERROR
+/// line per absent side — seven in the v0.0.11 report, from a single commit's
+/// syntax prefetch.
 #[test]
-fn rejects_missing_path_in_tree() {
+fn missing_path_in_tree_is_absent_not_an_error() {
+    let tr = TempRepo::with_initial_commit("hi\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let out = backend
+        .read_file_content_at_rev(&handle.id, "HEAD", Path::new("nope.txt"))
+        .expect("absence must not be an error");
+    assert!(out.is_none(), "expected None, got {out:?}");
+}
+
+/// ...but a GENUINE failure still errors. The two must stay distinguishable, or
+/// making absence quiet would also silence a real problem.
+#[test]
+fn a_bad_revspec_still_errors_while_absence_does_not() {
     let tr = TempRepo::with_initial_commit("hi\n");
     let (backend, handle) = tr.open_with_backend();
 
     let err = backend
-        .read_file_content_at_rev(&handle.id, "HEAD", Path::new("nope.txt"))
+        .read_file_content_at_rev(&handle.id, "no-such-ref", Path::new("nope.txt"))
         .unwrap_err();
-    assert!(matches!(err, AppError::InvalidPath(_)), "got {err:?}");
+    assert!(matches!(err, AppError::InvalidRef(_)), "got {err:?}");
 }

--- a/src-tauri/tests/read_index_content.rs
+++ b/src-tauri/tests/read_index_content.rs
@@ -10,7 +10,7 @@ mod support;
 use std::path::Path;
 
 use platypusgit_lib::error::AppError;
-use platypusgit_lib::git::GitBackend;
+use platypusgit_lib::git::{libgit2::Libgit2Backend, types::RepoId, GitBackend};
 
 use support::{fs::write_file, TempRepo};
 
@@ -29,7 +29,8 @@ fn reads_the_staged_copy_not_the_worktree_or_head() {
 
     let index = backend
         .read_file_content_at_index(&handle.id, Path::new("README.md"))
-        .unwrap();
+        .unwrap()
+        .expect("README.md is in the index");
     assert_eq!(index.text.as_deref(), Some("v2\n"));
     assert!(!index.binary);
 
@@ -41,7 +42,8 @@ fn reads_the_staged_copy_not_the_worktree_or_head() {
     assert_eq!(worktree.text.as_deref(), Some("v3\n"));
     let head = backend
         .read_file_content_at_rev(&handle.id, "HEAD", Path::new("README.md"))
-        .unwrap();
+        .unwrap()
+        .expect("README.md exists at HEAD");
     assert_eq!(head.text.as_deref(), Some("v1\n"));
 }
 
@@ -53,22 +55,35 @@ fn reads_committed_content_when_nothing_is_staged() {
 
     let index = backend
         .read_file_content_at_index(&handle.id, Path::new("README.md"))
-        .unwrap();
+        .unwrap()
+        .expect("README.md is in the index");
     assert_eq!(index.text.as_deref(), Some("v1\n"));
 }
 
-/// A path that is not in the index at all is an InvalidPath, not a panic — the
-/// caller renders the rows plain.
+/// A path that is not in the index at all is `Ok(None)`, not an error (#146) —
+/// the caller renders the rows plain. The commit panel asks for the index side of
+/// every row it draws, so an untracked row having none is the expected answer,
+/// and reporting it as `InvalidPath` put a routine condition on the error path.
 #[test]
-fn untracked_path_is_an_error() {
+fn untracked_path_is_absent_not_an_error() {
     let tr = TempRepo::with_initial_commit("v1\n");
     write_file(tr.path(), "untracked.txt", "nope\n");
     let (backend, handle) = tr.open_with_backend();
 
-    let err = backend
+    let out = backend
         .read_file_content_at_index(&handle.id, Path::new("untracked.txt"))
+        .expect("absence must not be an error");
+    assert!(out.is_none(), "expected None, got {out:?}");
+}
+
+/// ...but a GENUINE failure on the same op still errors. Absence going quiet
+/// must not take real problems with it.
+#[test]
+fn an_unknown_repo_still_errors_while_absence_does_not() {
+    let err = Libgit2Backend::new()
+        .read_file_content_at_index(&RepoId("never-opened".into()), Path::new("README.md"))
         .unwrap_err();
-    assert!(matches!(err, AppError::InvalidPath(_)), "got {err:?}");
+    assert!(matches!(err, AppError::UnknownRepo(_)), "got {err:?}");
 }
 
 /// Binary content is reported as binary with no text, like the other readers.
@@ -84,7 +99,8 @@ fn binary_content_reports_binary() {
 
     let out = backend
         .read_file_content_at_index(&handle.id, Path::new("blob.bin"))
-        .unwrap();
+        .unwrap()
+        .expect("blob.bin is staged");
     assert!(out.binary);
     assert!(out.text.is_none());
 }

--- a/src/features/lfs/useLfsStore.ts
+++ b/src/features/lfs/useLfsStore.ts
@@ -6,13 +6,13 @@
 
 import { create } from "zustand";
 import type { AppError } from "@/lib/errors";
-import { isAppError } from "@/lib/errors";
+import { describeError, isAppError } from "@/lib/errors";
 import type { LfsStatus } from "@/lib/types";
 import { lfsCheckout, lfsFetch, lfsPull, lfsStatus } from "@/lib/tauri";
 import { useRepoStore, withAuthRetry } from "@/features/repo/useRepoStore";
 
 function toAppError(e: unknown): AppError {
-  return isAppError(e) ? e : { kind: "Internal", message: String(e) };
+  return isAppError(e) ? e : { kind: "Internal", message: describeError(e) };
 }
 
 /** Human-readable byte size for a pointer's payload. */

--- a/src/features/merge/MergeWindow.tsx
+++ b/src/features/merge/MergeWindow.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/lib/tauri";
 import type { ConflictSides, FileStatus } from "@/lib/types";
 import { isConflicted } from "@/lib/derive";
+import { appErrorMessage } from "@/lib/errors";
 import { eventToChord, formatChord } from "@/features/keymap/chord";
 import { buildMergeModel } from "./mergeModel";
 import { MergeBody, type MergeBodyHandle } from "./MergeBody";
@@ -253,7 +254,10 @@ export function MergeWindow() {
       await advance();
     } catch (e) {
       console.error("save resolution failed", e);
-      setApplyError(e instanceof Error ? e.message : String(e));
+      // A rejected Tauri command is a plain `{ kind, message }` object, NOT an
+      // Error, so the `instanceof` test always failed and this banner read
+      // "[object Object]" for every failed apply (#146).
+      setApplyError(appErrorMessage(e));
     }
   }, [canApply, model, repoId, path, advance]);
 

--- a/src/features/reflog/useReflogStore.ts
+++ b/src/features/reflog/useReflogStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import type { FileDiff, ReflogEntry } from "@/lib/types";
 import type { AppError } from "@/lib/errors";
-import { isAppError } from "@/lib/errors";
+import { describeError, isAppError } from "@/lib/errors";
 import {
   checkoutDetached,
   createBranch as createBranchFn,
@@ -37,7 +37,7 @@ interface ReflogState {
 }
 
 function toAppError(e: unknown): AppError {
-  return isAppError(e) ? e : { kind: "Internal", message: String(e) };
+  return isAppError(e) ? e : { kind: "Internal", message: describeError(e) };
 }
 
 function currentRepoId(): string | null {

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -11,6 +11,7 @@ import type {
 } from "@/lib/types";
 import type { AppError } from "@/lib/errors";
 import {
+  describeError,
   dubiousOwnershipPath,
   isAppError,
   isAuthError,
@@ -299,7 +300,10 @@ interface RepoStoreState extends RepoSlice {
 }
 
 function toAppError(e: unknown): AppError {
-  return isAppError(e) ? e : { kind: "Internal", message: String(e) };
+  // `describeError`, not `String(e)`: this message is what the error banner
+  // renders, so a thrown plain object used to reach the user as
+  // "[object Object]" (#146).
+  return isAppError(e) ? e : { kind: "Internal", message: describeError(e) };
 }
 
 /**

--- a/src/features/repo/useTabsStore.ts
+++ b/src/features/repo/useTabsStore.ts
@@ -29,6 +29,7 @@ import { closeRepo as closeRepoIpc, getStatus } from "@/lib/tauri";
 import type { RepoHandle } from "@/lib/types";
 import { isConflicted, isStaged, isUnstaged } from "@/lib/derive";
 import { warn as logWarn } from "@tauri-apps/plugin-log";
+import { describeError } from "@/lib/errors";
 import { emptySlice, frozenSlice, type RepoSlice } from "./repoSlice";
 import { useRepoStore } from "./useRepoStore";
 import {
@@ -179,7 +180,7 @@ export const useTabsStore = create<TabsState>((set, get) => {
     void closeRepoIpc(tab.repoId).catch((e) => {
       // The tab is going away either way; a failed eviction is a leak, not a
       // thing to interrupt the user about.
-      logWarn(`close_repo failed for ${tab.path}: ${String(e)}`);
+      logWarn(`close_repo failed for ${tab.path}: ${describeError(e)}`);
     });
   };
 

--- a/src/features/submodules/useSubmodulesStore.ts
+++ b/src/features/submodules/useSubmodulesStore.ts
@@ -4,7 +4,7 @@
 
 import { create } from "zustand";
 import type { AppError } from "@/lib/errors";
-import { isAppError } from "@/lib/errors";
+import { describeError, isAppError } from "@/lib/errors";
 import type { SubmoduleInfo } from "@/lib/types";
 import {
   listSubmodules,
@@ -26,7 +26,7 @@ function readRecursive(): boolean {
 }
 
 function toAppError(e: unknown): AppError {
-  return isAppError(e) ? e : { kind: "Internal", message: String(e) };
+  return isAppError(e) ? e : { kind: "Internal", message: describeError(e) };
 }
 
 /** Absolute path of a submodule's checkout, for "open as repository". */

--- a/src/features/worktrees/useWorktreesStore.ts
+++ b/src/features/worktrees/useWorktreesStore.ts
@@ -7,7 +7,7 @@
 import { create } from "zustand";
 import { pgConfirm, pgPrompt } from "@/design";
 import type { AppError } from "@/lib/errors";
-import { isAppError } from "@/lib/errors";
+import { describeError, isAppError } from "@/lib/errors";
 import type { WorktreeBranch, WorktreeInfo } from "@/lib/types";
 import {
   listWorktrees,
@@ -21,7 +21,7 @@ import { useTabsStore } from "@/features/repo/useTabsStore";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 
 function toAppError(e: unknown): AppError {
-  return isAppError(e) ? e : { kind: "Internal", message: String(e) };
+  return isAppError(e) ? e : { kind: "Internal", message: describeError(e) };
 }
 
 interface WorktreesState {

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { appErrorMessage, describeError, type AppError } from "./errors";
+
+/**
+ * #146: every backend failure reached the log file as `[object Object]`, so the
+ * one artifact a bug reporter can hand over carried no reason at all. These
+ * tests pin the two contracts that gap broke:
+ *
+ *  - NOTHING, for any input shape, may render as `[object Object]`.
+ *  - An `AppError`'s `kind` must survive into the logged string, because that
+ *    discriminant is what makes a log greppable and tells you which of ~25
+ *    failure modes you are looking at.
+ */
+
+const OBJ = "[object Object]";
+
+describe("describeError", () => {
+  it("keeps an AppError's kind and its message", () => {
+    const e: AppError = { kind: "InvalidPath", message: "file not found: old.ts" };
+    const s = describeError(e);
+    expect(s).toContain("InvalidPath");
+    expect(s).toContain("file not found: old.ts");
+    expect(s).not.toContain(OBJ);
+  });
+
+  it("renders a kind whose message is absent as just the kind", () => {
+    expect(describeError({ kind: "Unborn" })).toBe("Unborn");
+    expect(describeError({ kind: "NotImplemented", message: undefined })).toBe(
+      "NotImplemented",
+    );
+  });
+
+  it("renders Auth's structured payload instead of stringifying it", () => {
+    // `Auth.message` is an object, not prose — the exact shape that produced
+    // `[object Object]` twice over.
+    const e: AppError = {
+      kind: "Auth",
+      message: { host: "github.com", kind: "Https" },
+    };
+    const s = describeError(e);
+    expect(s).toContain("Auth");
+    expect(s).toContain("github.com");
+    expect(s).not.toContain(OBJ);
+  });
+
+  it("keeps a thrown Error's name and message", () => {
+    const s = describeError(new TypeError("x is not a function"));
+    expect(s).toContain("TypeError");
+    expect(s).toContain("x is not a function");
+    expect(s).not.toContain(OBJ);
+  });
+
+  it("passes a string through", () => {
+    expect(describeError("plain failure")).toBe("plain failure");
+  });
+
+  it("names an empty string rather than logging nothing", () => {
+    expect(describeError("")).toBe("<empty string>");
+  });
+
+  it("names undefined and null rather than an empty line", () => {
+    expect(describeError(undefined)).toBe("undefined");
+    expect(describeError(null)).toBe("null");
+  });
+
+  it("serialises a plain object instead of [object Object]", () => {
+    const s = describeError({ code: 7, why: "nope" });
+    expect(s).not.toContain(OBJ);
+    expect(s).toContain("7");
+    expect(s).toContain("nope");
+  });
+
+  it("survives a circular object", () => {
+    const a: Record<string, unknown> = { name: "loop" };
+    a.self = a;
+    const s = describeError(a);
+    expect(s).not.toContain(OBJ);
+    expect(typeof s).toBe("string");
+    expect(s.length).toBeGreaterThan(0);
+  });
+
+  it("handles primitives", () => {
+    expect(describeError(42)).toBe("42");
+    expect(describeError(false)).toBe("false");
+  });
+
+  it("never returns an empty string, for any shape", () => {
+    const shapes: unknown[] = [
+      { kind: "Git", message: "bad object" },
+      { kind: "Unborn" },
+      new Error("boom"),
+      "s",
+      "",
+      undefined,
+      null,
+      0,
+      false,
+      {},
+      [],
+      Symbol("sym"),
+      () => {},
+    ];
+    for (const s of shapes) {
+      const out = describeError(s);
+      expect(out, `shape ${String(typeof s)}`).not.toContain(OBJ);
+      expect(out.length, `shape ${String(typeof s)}`).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("appErrorMessage", () => {
+  it("still renders a sentence, without the kind prefix a log wants", () => {
+    // The banner contract is unchanged: prose only, no discriminant.
+    expect(appErrorMessage({ kind: "Git", message: "bad object" })).toBe("bad object");
+  });
+
+  it("does not render a non-AppError object as [object Object]", () => {
+    expect(appErrorMessage({ code: 7 })).not.toContain(OBJ);
+  });
+});

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -68,24 +68,82 @@ export function isAppError(e: unknown): e is AppError {
   );
 }
 
-export function appErrorMessage(e: unknown): string {
-  if (isAppError(e)) {
-    // Auth's payload is structured, not a sentence — render it here rather than
-    // letting an object reach the UI as "[object Object]".
-    if (e.kind === "Auth") return authChallengeMessage(e.message);
-    // ForgeAuth carries a HOST and BranchExists carries a BRANCH NAME, not
-    // prose. Rendered raw, the banner would just read "github.com".
-    if (e.kind === "ForgeAuth") return forgeAuthMessage(e.message);
-    if (e.kind === "BranchExists")
-      return `A local branch named ${e.message} already exists.`;
-    // StaleStash carries a LABEL (`stash@{1}`) — rendered raw the banner would
-    // just read "stash@{1}" with no hint of what to do about it.
-    if (e.kind === "StaleStash")
-      return `${e.message} is no longer the entry you picked — the stash list changed. Refresh and try again.`;
-    return e.message ?? e.kind;
+/**
+ * The prose half of an `AppError` — what a human reads, with no discriminant.
+ *
+ * Empty when the variant carries no message at all (`Unborn`, `NoBisect`, …), so
+ * callers decide what to show instead: a banner falls back to the kind, a log
+ * line already has it.
+ */
+function appErrorDetail(e: AppError): string {
+  // Auth's payload is structured, not a sentence — render it here rather than
+  // letting an object reach the UI as "[object Object]".
+  if (e.kind === "Auth") return authChallengeMessage(e.message);
+  // ForgeAuth carries a HOST and BranchExists carries a BRANCH NAME, not
+  // prose. Rendered raw, the banner would just read "github.com".
+  if (e.kind === "ForgeAuth") return forgeAuthMessage(e.message);
+  if (e.kind === "BranchExists")
+    return `A local branch named ${e.message} already exists.`;
+  // StaleStash carries a LABEL (`stash@{1}`) — rendered raw the banner would
+  // just read "stash@{1}" with no hint of what to do about it.
+  if (e.kind === "StaleStash")
+    return `${e.message} is no longer the entry you picked — the stash list changed. Refresh and try again.`;
+  return e.message ?? "";
+}
+
+/**
+ * Anything that is NOT an `AppError`, rendered without ever reaching
+ * `[object Object]` (#146).
+ *
+ * `String(x)` is the trap: it is correct for every primitive and wrong for
+ * exactly the case that matters, an object carrying the reason.
+ */
+function describeUnknown(e: unknown): string {
+  if (e === undefined) return "undefined";
+  if (e === null) return "null";
+  if (typeof e === "string") return e === "" ? "<empty string>" : e;
+  if (e instanceof Error) return `${e.name}: ${e.message}`;
+  if (typeof e === "object") {
+    try {
+      const json = JSON.stringify(e);
+      // `undefined` for a non-serialisable value, "{}" when every own property
+      // was dropped — neither says more than the constructor name does.
+      if (json && json !== "{}") return json;
+    } catch {
+      // Circular. Fall through: a name beats a thrown logger.
+    }
+    const name = (e as { constructor?: { name?: string } }).constructor?.name;
+    return name ? `<${name}>` : "<object>";
   }
-  if (e instanceof Error) return e.message;
   return String(e);
+}
+
+export function appErrorMessage(e: unknown): string {
+  if (isAppError(e)) return appErrorDetail(e) || e.kind;
+  if (e instanceof Error) return e.message;
+  return describeUnknown(e);
+}
+
+/**
+ * One failure rendered for the LOG FILE, not for a banner (#146).
+ *
+ * Differs from `appErrorMessage` on purpose: a log line leads with the `kind`,
+ * because that discriminant is the greppable half and it is the first thing you
+ * need when a user hands over a log — `InvalidPath` and `Network` want entirely
+ * different follow-up questions. A banner, by contrast, must never show the
+ * enum's spelling to a user.
+ *
+ * Total over every input shape: `AppError`, `Error`, string, `undefined`,
+ * `null`, a bare object, a primitive. It never returns an empty string and
+ * never returns `[object Object]`, which is what v0.0.11 logged for every
+ * backend failure and what cost us the diagnosis in #146.
+ */
+export function describeError(e: unknown): string {
+  if (isAppError(e)) {
+    const detail = appErrorDetail(e);
+    return detail ? `${e.kind}: ${detail}` : e.kind;
+  }
+  return describeUnknown(e);
 }
 
 /** One-line description of an auth challenge, for banners and fallbacks. */

--- a/src/lib/syntax/useDiffSyntax.ts
+++ b/src/lib/syntax/useDiffSyntax.ts
@@ -47,8 +47,10 @@ const EMPTY: DiffSyntax = { old: null, new: null, oldText: null, newText: null }
  * no blob at the new path, so reading it there would leave every removed line
  * unhighlighted.
  *
- * A failed read yields no tokens for that side and those rows render plain: a
- * missing blob must never break a diff.
+ * A side with no content yields no tokens and those rows render plain: a missing
+ * blob must never break a diff. Since #146 an ABSENT blob resolves to `null`
+ * rather than rejecting, so it no longer reaches the log as an error — the
+ * `catch` below now covers only genuine failures, which still do.
  *
  * Panes that diff against the INDEX (the commit panel) ask for it directly with
  * `{ kind: "index" }`, so a partially staged file colours from the same content

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -128,23 +128,33 @@ export async function listFilesAtRev(
  * Differs from both other readers exactly when a file is partially staged, which
  * is why the commit panel needs it: its diffs are against the index, so tokens
  * taken from HEAD or the worktree could land on the wrong lines there.
- * Rejects with `InvalidPath` for a path with no stage-0 entry (untracked, or
- * conflicted); callers render those rows plain.
+ * Resolves to `null` — it does NOT reject — for a path with no stage-0 entry
+ * (untracked, or conflicted); callers render those rows plain. Absence is the
+ * expected answer, not a failure: the commit panel asks for the index side of
+ * every row it draws (#146).
  */
 export async function readFileContentAtIndex(
   repoId: string,
   path: string,
-): Promise<FileContent> {
-  return invoke<FileContent>("read_file_content_at_index", { repoId, path });
+): Promise<FileContent | null> {
+  return invoke<FileContent | null>("read_file_content_at_index", { repoId, path });
 }
 
-/** Read a file's content from the tree at `revspec`. */
+/**
+ * Read a file's content from the tree at `revspec`.
+ *
+ * Resolves to `null` when that tree holds no text at that path — absent, a
+ * directory, or a submodule gitlink. Every caller is a diff surface reading the
+ * OTHER side of a file it is already rendering, so an added file having no old
+ * side is routine and must not travel the error path (#146). A genuine failure
+ * (bad revspec, unknown repository) still rejects.
+ */
 export async function readFileContentAtRev(
   repoId: string,
   revspec: string,
   path: string,
-): Promise<FileContent> {
-  return invoke<FileContent>("read_file_content_at_rev", {
+): Promise<FileContent | null> {
+  return invoke<FileContent | null>("read_file_content_at_rev", {
     repoId,
     revspec,
     path,

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,5 +1,6 @@
 import { invoke as rawInvoke } from "@tauri-apps/api/core";
 import { debug as logDebug, warn as logWarn, error as logError } from "@tauri-apps/plugin-log";
+import { describeError } from "./errors";
 import type {
   AheadBehind,
   AuthorOverride,
@@ -62,7 +63,10 @@ async function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T
     return result;
   } catch (err) {
     const ms = Math.round(performance.now() - start);
-    logError(`invoke ${cmd} failed after ${ms}ms: ${String(err)}`);
+    // `describeError`, never `String(err)`: an AppError is an object, so the
+    // template read `[object Object]` and every backend failure in a
+    // user-supplied log carried no reason at all (#146).
+    logError(`invoke ${cmd} failed after ${ms}ms: ${describeError(err)}`);
     throw err;
   }
 }

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -25,6 +25,7 @@ import {
 import { HeadMarksControl } from "@/features/settings/HeadMarksControl";
 import { ForgeSettings } from "@/features/forge/ForgeSettings";
 import { cliShimStatus, installCliShim, type PullMode } from "@/lib/tauri";
+import { appErrorMessage } from "@/lib/errors";
 import { useUpdateStore } from "@/features/update/useUpdateStore";
 import type { CliShimStatus } from "@/lib/types";
 import { BUILTIN_PRESETS, useKeymapStore } from "@/features/keymap";
@@ -510,8 +511,7 @@ function AppearanceSection({ active }: { active: ThemeDef }) {
       const theme = s.importThemeJson(text);
       pgFlash(`Imported "${theme.name}"`);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      pgFlash(`Import failed: ${msg}`);
+      pgFlash(`Import failed: ${appErrorMessage(err)}`);
     }
   };
 


### PR DESCRIPTION
Works issue #146, which correctly separates three problems. **Two are fixed here; the freeze itself is not.** The issue must stay open for it.

## Fixed — 3. Backend errors logged as `[object Object]`

`invoke`'s catch arm used `String(err)`. A rejected Tauri command surfaces the Rust `AppError` as a plain serialized `{ kind, message }` object — never an `Error` — so every backend failure reached the log file with no reason attached. That is what made the rest of #146's log unreadable.

Adds `describeError` (log side) beside `appErrorMessage` (UI side). They differ deliberately: a log line leads with the `kind`, because that discriminant is the greppable half and the first thing you want from a user-supplied log; a banner must never show the enum's spelling. `describeError` is total over `AppError`, `Error`, string, `undefined`, `null`, bare objects, circular objects and primitives, and can return neither `[object Object]` nor an empty string — one test per shape, in `src/lib/errors.test.ts`.

Auditing for the line *shape* rather than the reported line found six more sites:

- `useTabsStore`'s `close_repo` warning — the only other `plugin-log` writer in the frontend, broken identically.
- **`MergeWindow`'s apply-error banner** — tested `e instanceof Error` before falling back to `String(e)`. That test is always false for a rejected command, so a failed `save_resolution` showed the *user* `[object Object]`. User-visible, not just logged.
- The five copies of `toAppError`, which wrote `String(e)` into the `message` the error banner renders.
- `appErrorMessage`'s own final fallback, and Settings' theme-import flash.

## Fixed — 2. The `read_file_content_at_rev` failures

The issue's hypothesis held. Verified rather than assumed:

- The backend answered `InvalidPath("file not found: …")` for a path absent from the tree — hence 2–5ms, no I/O.
- Both callers already tolerated it (`.catch(() => null)` in `useDiffSyntax`, `try`/`catch` in `usePrefetchSyntax`), but the shared `invoke` wrapper logs *before* it rethrows, so downstream tolerance could never suppress the line.
- Seven of them in one burst = one selected file plus a commit's bounded syntax prefetch (`PREFETCH_MAX = 4`), each asking for a side that legitimately did not exist. `DiffViewer` and `CommitPanel` pass `old: { kind: "rev", rev: "HEAD" }` unconditionally, so an **added** file has no old side; the prefetch reads the *new* rev, so a **deleted** file has no new side.

So it was a genuinely-expected condition mis-classified as an error. Made explicit rather than silenced: `read_file_content_at_rev` and `read_file_content_at_index` now return `Ok(None)`. A non-blob — a directory or a `160000` submodule gitlink — answers the same way, because there is no text to colour either.

`read_file_content_at_index`'s own comment already documented the absence as expected ("an untracked one — correct either way, because neither has a single index version to colour from"), which is what made the mis-classification clear.

**Genuine failures still error and still log** — that half had to keep working, and each has its own test next to the inverted absence test: a bad revspec is `InvalidRef`, an unknown repository is `UnknownRepo`. Teaching the logger to ignore `InvalidPath` from these two commands was rejected: it would also hide a real one, and would leave the backend still claiming a routine condition is a failure.

## NOT fixed — 1. The freeze

**Not reproduced, and no change here attempts to fix it.**

What the investigation did establish, though, narrows it a lot:

- `Tried to map a popup with a non-top most parent` is emitted **only by GDK's Wayland backend**. Confirmed empirically (the string is in `libgdk-3.so.0`, GTK 3.24.41, and the only GDK backend source referenced alongside it is `gdk/wayland/gdkwindow-wayland.c`) and upstream, where GTK's own issue for it states *"The x11 backend does not exhibit this issue."*
- **So the reporter was on Wayland** — the one unknown they could not answer. Worth confirming with them, but the warning is close to proof.
- **The e2e container is xvfb/X11, so it cannot reproduce this warning by construction** — not "I failed to reproduce it". Six relevant specs were run there anyway as a regression gate on the two fixes above; all pass, with zero GDK/GTK warnings in the run.
- **The log's own ordering argues the warning was not the freeze moment.** The warning is at 07:24:33; `verify_commit` and the read burst follow at 07:25:11 and 07:25:32. Those are **selection-driven** — `SignatureBadge` verifies the selected commit's oid, the reads are one selected file plus a bounded prefetch, the only focus-driven refresh (`refreshBadges`) touches `get_status` for inactive tabs only, and `autoFetchEnabled` defaults to `false`. So the app was processing user input 38s and 59s *after* the warning, and the freeze happened after the last log line with no line of its own. This matches GTK's *documented* symptom for that warning — a popup that simply fails to open — better than it matches a freeze.
- The freeze signature the reporter describes — window ignores input, process alive, must be killed — does match known GTK3/Wayland popup-grab bugs in other GTK-hosting apps (MyPaint #1161: "the whole window becomes unresponsive… pressing ESC once" recovers; Mozilla 1717451: a tooltip GTK marks visible but never maps, while a popup menu is open, hangs the UI, Wayland only). In the Firefox case the fix landed in the *application*, not GTK. But a leaked-state-that-bites-later story is speculation until someone reproduces it.

The candidate native-popup surfaces are enumerated in [a comment on #146](https://github.com/jonassaa/platypusgit/issues/146#issuecomment-5313661891). The short version: `PGSelect` renders a **real native `<select>`** (`src/design/primitives.tsx:600`) which WebKitGTK maps as a GDK popup — two of them sit on the launch screen and one per row on Rebase; History also has two `<input type="date">`; `rfd` 0.16 is linked against `gtk-sys` with **no `ashpd`**, so the folder picker is an **in-process GTK3 dialog**, not an out-of-process XDG portal; 156 `title=` attributes become WebKit tooltip popups, several of them per-row; and the merge resolver window never calls `usePreventBrowserContextMenu`, so WebKitGTK's own native context menu is reachable there, including on the editable CM6 pane.

Mitigations exist (in-page listbox instead of native `<select>`; drop per-row `title`; prevent `contextmenu` in the merge window too). All are **unproven against this bug** and deliberately not in this PR — though the merge-window context-menu gap is worth closing on its own merits.

## Verification

`pnpm tsc --noEmit`, `pnpm test` (1476 tests, 180 files), `cargo check`, `cargo test` (all suites) — green. E2E in Docker: `history-diff`, `commit`, `status-stage`, `merge-window`, `repo-tabs`, `settings` — 6 passed, 6 total.

**No auto-close keyword is present in this description, deliberately** — issue 146 must stay open for the freeze. Only its parts 2 and 3 are resolved here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Er25sN6pGoVJzmTBwHU2Tz
