### PR TITLE
fix(site): responsive layout pass across every page

### DIFF
--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -41,4 +41,17 @@ const year = 2026;
     padding-top: var(--s-6); border-top: 1px solid var(--border-0); color: var(--fg-3); font-size: 13px; }
   .footer-legal a { color: var(--fg-2); }
   .footer-legal a:hover { color: var(--accent); }
+  @media (max-width: 720px) {
+    .footer { margin-top: var(--s-12); padding: var(--s-10) 0 var(--s-8); }
+    .footer-inner { gap: var(--s-8); }
+    .footer-cols { gap: var(--s-9); }
+  }
+  @media (max-width: 480px) {
+    /* The two link columns fit side by side at 360px, but only by wrapping
+       every label onto three lines. Let them stack instead. */
+    .footer-cols { flex-wrap: wrap; gap: var(--s-7) var(--s-9); }
+    .footer-tag { max-width: none; }
+    /* Two spans in one non-wrapping row is a guaranteed overflow at 360px. */
+    .footer-legal { flex-direction: column; align-items: flex-start; gap: var(--s-2); }
+  }
 </style>

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -39,5 +39,24 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
   .nav-links a:hover { color: var(--fg-0); text-decoration: none; }
   .chip { border: 1px solid var(--border-1); padding: 5px 10px; border-radius: var(--r-4); white-space: nowrap; }
   .chip:hover { border-color: var(--accent); color: var(--accent) !important; }
-  @media (max-width: 640px) { .nav-links { gap: var(--s-4); } .nav-links a:not(.chip) { font-size: 13px; } }
+  /* The bar's natural width is ~728px including gutters, so it starts to bind
+     just under 760px. The GitHub chip is its widest single item and it is
+     repeated in the hero CTAs and the footer, so it is the first to go. */
+  @media (max-width: 760px) { .chip { display: none; } }
+  /* Four links plus the theme toggle cannot share a 360px row with the
+     wordmark — 442px of links alone forced every page to 649px and phones
+     answered by zooming out. `flex: 1 0 100%` puts the links on their own row
+     rather than letting them push the document wider; the brand keeps its
+     natural width on row one. */
+  @media (max-width: 640px) {
+    .nav-inner { flex-wrap: wrap; height: auto; row-gap: var(--s-3);
+      padding-top: var(--s-4); padding-bottom: var(--s-4); }
+    /* flex-wrap is the safety valve: the four labels plus the toggle measure
+       ~295px, so they fit a 360px screen but not a 320px one, and a longer
+       label later would make the row bind sooner. Wrapping costs a row;
+       overflowing costs the whole document. */
+    .nav-links { flex: 1 0 100%; flex-wrap: wrap; justify-content: space-between;
+      gap: var(--s-3) var(--s-4); }
+    .nav-links a:not(.chip) { font-size: 13px; }
+  }
 </style>

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -47,4 +47,20 @@ import { descriptions } from '../data/seo.ts';
   .entry-notes { list-style: none; padding: 0; margin: 0; display: grid; gap: var(--s-4); }
   .entry-notes li { color: var(--fg-1); font-size: 15px; padding-left: var(--s-5); position: relative; }
   .entry-notes li::before { content: '–'; position: absolute; left: 0; color: var(--fg-3); }
+
+  @media (max-width: 720px) {
+    .page-head { padding-top: var(--s-11); }
+    .page-head h1 { font-size: 30px; }
+    .log { margin-top: var(--s-10); gap: var(--s-8); }
+  }
+  @media (max-width: 480px) {
+    .page-head h1 { font-size: 26px; }
+    .lead { font-size: 15px; }
+    .entry { padding-left: var(--s-6); }
+    .entry-meta { gap: var(--s-3) var(--s-4); margin-bottom: var(--s-4); }
+    .ver { font-size: 16px; }
+    .date { font-size: 13px; }
+    .entry-notes { gap: var(--s-3); }
+    .entry-notes li { font-size: 14px; }
+  }
 </style>

--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -209,4 +209,29 @@ pnpm tauri build   # produces .dmg / .msi / .deb / .AppImage`;
   .build h2 { font-size: 26px; margin: 0 0 var(--s-3); }
   .build .lead { margin-bottom: var(--s-7); }
   .readme-link { margin-top: var(--s-6); font-size: 14px; }
+
+  @media (max-width: 720px) {
+    .page-head { padding-top: var(--s-11); }
+    .page-head h1 { font-size: 30px; }
+    .install-head h2, .build h2 { font-size: 22px; }
+    .install { margin-top: var(--s-10); }
+    .build { margin-top: var(--s-11); }
+    .notice { margin-top: var(--s-9); }
+    .os-tabs { margin-top: var(--s-7); }
+  }
+  /* The nav becomes two rows at this width, so an anchored section landed
+     underneath it with the 72px offset calibrated for the one-row bar. */
+  @media (max-width: 640px) {
+    .install, .build { scroll-margin-top: 96px; }
+  }
+  @media (max-width: 560px) {
+    /* Three inline tabs at 18px side padding measured ~335px — wider than a
+       360px phone's content box. A three-column grid divides the row it has
+       instead of demanding one. */
+    .os-tabs { display: grid; grid-template-columns: repeat(3, 1fr); width: 100%; }
+    .os-tab { justify-content: center; padding: 9px 4px; font-size: 13px; gap: 5px; }
+    .page-head h1 { font-size: 26px; }
+    .method { margin-top: var(--s-6); }
+    .method-primary { padding-left: var(--s-5); }
+  }
 </style>

--- a/site/src/pages/features.astro
+++ b/site/src/pages/features.astro
@@ -51,5 +51,20 @@ import { descriptions } from '../data/seo.ts';
   .roadmap-list li { display: flex; gap: var(--s-5); align-items: baseline; color: var(--fg-2); font-size: 15px; }
   .soon { font-size: 11px; color: var(--accent-2); border: 1px solid var(--border-1);
     padding: 2px 7px; border-radius: var(--r-3); flex-shrink: 0; }
-  @media (max-width: 720px) { .group { grid-template-columns: 1fr; gap: var(--s-5); } }
+  @media (max-width: 720px) {
+    .group { grid-template-columns: 1fr; gap: var(--s-5); }
+    .page-head { padding-top: var(--s-11); }
+    .page-head h1 { font-size: 30px; }
+    .groups, .roadmap { margin-top: var(--s-10); }
+  }
+  @media (max-width: 480px) {
+    .page-head h1 { font-size: 26px; }
+    .lead { font-size: 15px; }
+    .roadmap-title { font-size: 21px; }
+    .group { padding-bottom: var(--s-8); }
+    .group-head h2 { font-size: 18px; }
+    .group-list { gap: var(--s-3); }
+    .group-list li, .roadmap-list li { font-size: 14px; gap: var(--s-3); }
+    .roadmap-list { gap: var(--s-4); }
+  }
 </style>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -177,12 +177,32 @@ const comingSoon = downloads.filter((d) => !d.available);
   .why-item h3 { font-size: 18px; margin: 0 0 var(--s-3); color: var(--accent); }
   .why-item p { color: var(--fg-2); margin: 0; font-size: 15px; }
   @media (max-width: 820px) {
+    .hero { padding: var(--s-12) 0 var(--s-11); }
     .brand-word { font-size: 38px; }
     .brand-logo { width: 64px; height: 64px; }
     .hero-title { font-size: 24px; }
     .feature-grid { grid-template-columns: 1fr; }
-    .why-grid { grid-template-columns: 1fr; }
+    .why-grid { grid-template-columns: 1fr; gap: var(--s-8); }
     .os-picker { flex-direction: column; align-items: stretch; width: 100%; max-width: 320px; }
     .os-btn { align-items: center; text-align: center; }
+    .section { padding-top: var(--s-11); }
+    .showcase { padding-top: var(--s-11); }
+    .why { margin-top: var(--s-12); padding: var(--s-11) 0; }
+  }
+  @media (max-width: 480px) {
+    /* "platypusgit" is one unbreakable word in a monospace face: at 38px it is
+       ~250px, which with the logo overran a 320px content box. */
+    .brand-lockup { gap: var(--s-4); margin-bottom: var(--s-6); }
+    .brand-word { font-size: 26px; }
+    .brand-logo { width: 48px; height: 48px; }
+    .hero-title { font-size: 21px; }
+    .hero-sub { font-size: 15px; margin-bottom: var(--s-7); }
+    .section-title { font-size: 21px; margin-bottom: var(--s-8); }
+    .showcase-sub { font-size: 15px; }
+    .hero-trust { gap: var(--s-4) var(--s-5); }
+    /* The tag is flex-shrink: 0, so side by side it squeezed the sentence into
+       a one-word-per-line column. */
+    .dev-notice { flex-direction: column; align-items: flex-start; gap: var(--s-4);
+      padding: var(--s-5); }
   }
 </style>

--- a/site/src/pages/support.astro
+++ b/site/src/pages/support.astro
@@ -73,5 +73,16 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
     padding: var(--s-7); display: flex; flex-direction: column; align-items: flex-start; }
   .way h2 { font-size: 19px; margin: 0 0 var(--s-4); color: var(--accent); }
   .way p { color: var(--fg-2); font-size: 15px; line-height: 1.6; margin: 0 0 var(--s-6); flex: 1; }
-  @media (max-width: 720px) { .ways { grid-template-columns: 1fr; } }
+  @media (max-width: 720px) {
+    .ways { grid-template-columns: 1fr; gap: var(--s-6); margin-top: var(--s-10); }
+    .page-head { padding-top: var(--s-11); }
+    .page-head h1 { font-size: 30px; }
+  }
+  @media (max-width: 480px) {
+    .page-head h1 { font-size: 24px; }
+    .lead { font-size: 15px; }
+    .way { padding: var(--s-6); }
+    .way h2 { font-size: 17px; }
+    .way p { font-size: 14px; margin-bottom: var(--s-5); }
+  }
 </style>

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -111,11 +111,18 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-h1, h2, h3 { font-family: var(--font-display); letter-spacing: -0.02em; line-height: 1.15; }
+/* Headings are set in a monospace display face, where a long single word is
+   both unbreakable and ~0.6em per character. break-word only fires when the
+   word would otherwise overflow, so wider viewports render identically. */
+h1, h2, h3 { font-family: var(--font-display); letter-spacing: -0.02em; line-height: 1.15;
+  overflow-wrap: break-word; }
 a { color: var(--accent); text-decoration: none; }
 a:hover { text-decoration: underline; }
 code, .mono { font-family: var(--font-mono); }
 .container { max-width: var(--maxw); margin: 0 auto; padding: 0 var(--s-7); }
+/* 40px of gutter out of a 360px screen is 11% of it. Only narrow viewports are
+   affected — every layout above 480px keeps the 20px gutter. */
+@media (max-width: 480px) { .container { padding: 0 var(--s-6); } }
 ::selection { background: oklch(0.68 0.09 185 / 0.3); }
 *::-webkit-scrollbar { width: 10px; height: 10px; }
 *::-webkit-scrollbar-thumb { background: var(--border-1); border-radius: 10px; border: 2px solid var(--bg-0); }


### PR DESCRIPTION
This is **half (b) of #145** — the responsive pass. It deliberately does **not** do half (a).

`#145` asks for two things: replace `AppShowcase.astro` with a real screenshot, and lay the site out for a phone. They are independent, and only the second one can land today: `site/public/screenshots/` still holds nothing but a `.gitkeep`, and `site.yml` deploys on push to `main`, so deleting the showcase before the images exist would ship a broken hero. **The issue stays open** for the showcase swap.

## What was wrong

The site had six media queries in total and none of them covered the nav. Its links row measured **442px**, forcing the document to **649px on every page**. At 360px a phone does not answer that with a scrollbar — it shrink-to-fits the whole page to ~55% scale, so every page was zoomed out and the nav's last link sat off-screen. That single component is why all five pages measured identically before.

## Measured, not eyeballed

Headless Chrome (CDP) against the built `dist`, comparing `documentElement.scrollWidth` to `clientWidth` — **not** `innerWidth`, which counts the 10px scrollbar and would swallow any overflow up to 10px as a false pass. The `phone` column is `window.innerWidth` under mobile emulation: when it exceeds the device width, that is Chrome zooming the page out to fit.

`content` is the width the layout demands; `vp` is the content box available.

| page | 360 before | 360 after | 390 before | 390 after | 768 before | 768 after |
|---|---|---|---|---|---|---|
| index | 649 vs 350 → **+299** | 350 vs 350 → 0 | 649 vs 380 → **+269** | 380 vs 380 → 0 | 758 vs 758 → 0 | 0 |
| features | 649 vs 350 → **+299** | 0 | 649 vs 380 → **+269** | 0 | 0 | 0 |
| download | 649 vs 350 → **+299** | 0 | 649 vs 380 → **+269** | 0 | 0 | 0 |
| changelog | 649 vs 350 → **+299** | 0 | 649 vs 380 → **+269** | 0 | 0 | 0 |
| support | 649 vs 350 → **+299** | 0 | 649 vs 380 → **+269** | 0 | 0 | 0 |

Identical in **dark and light** — every failing combination failed in both, every passing one passes in both. The two themes differ only in token values, and the geometry dumps confirm no layout depends on them.

Phone visual viewport (the zoom-out): **649px before at both 360 and 390, on every page → exactly the device width after.**

- **Acceptance matrix (5 pages x {360, 390, 768} x {dark, light}): 0/30 clean → 30/30 clean.**
- Wider sweep, 23 viewport widths from 320 to 1024, same matrix: **230/230 clean** — so nothing breaks *between* the breakpoints either.
- All 20 `#macos` / `#windows` / `#linux` / `#build` anchor cases on `/download/` land below the sticky nav at 360 / 390 / 600 / 768 / 1280.

## Desktop is provably unchanged

A dump of every element's layout box (tag, class, x, y, w, h — 7,398 lines) at **1280 / 1024 / 900 in both themes** is **byte-identical** to the same dump from `main`. No rule in this PR fires above 760px. (PNG hashing was tried first and rejected: the light theme's gradients do not encode reproducibly, so it reported differences on an identical build.)

## Per page

- **`Nav.astro`** — the GitHub chip goes at 760px, where the bar starts to bind; it is repeated in the hero CTAs and the footer, so nothing is lost. Below 640px the links take their own row (`flex: 1 0 100%`) instead of pushing the document wider, and they may wrap, so a longer label later cannot reintroduce the overflow. The bar is 83px tall there, 57px above.
- **`Footer.astro`** — the legal row was two spans in a non-wrapping flex row, a guaranteed overflow at 360px. It stacks below 480px, as do the two link columns.
- **`index.astro`** — `platypusgit` is one unbreakable word in a monospace face, so the 38px wordmark plus the logo overran a 320px content box. New 480px step for the wordmark, hero copy, section titles, and the in-development notice (whose `flex-shrink: 0` tag had squeezed its sentence into one word per line). The existing 820px block also drops the 120px hero padding.
- **`download.astro`** (had none) — three inline OS tabs measured ~335px; they become a three-column grid that divides the row it has instead of demanding one. Section anchors take a 96px scroll offset below 640px, where the nav is two rows — the old 72px was calibrated for the one-row bar. Code blocks were already `overflow-x: auto` and stay contained.
- **`changelog.astro`** (had none) — type scale and spacing steps at 720/480.
- **`features.astro`**, **`support.astro`** — their grids already collapsed at 720px; added the type scale and spacing steps.
- **`tokens.css`** — 16px gutters below 480px (40px of gutter is 11% of a 360px screen), and `overflow-wrap: break-word` on headings as a backstop for the monospace display face. Both are inside a narrow media query or fire only when a word would otherwise overflow, which is why the desktop dump is unchanged.

## AppShowcase: measured, then left alone

The issue calls it "the worst offender on narrow screens". Measured, it is **not** an overflow offender: `.win` carries its own `overflow: hidden`, so the showcase contributes **0px** of document overflow at 360px. What it does is **clip** its own content — the branch pills, author column and status-bar path are cut off mid-row, and it already has 900px and 680px breakpoints of its own.

Making the clipped part reachable would mean changing `.win`'s `overflow: hidden`, i.e. editing the file the other PR deletes — a merge conflict for a component with days to live. So no change, and no stopgap wrapper either: an `overflow-x: auto` wrapper has nothing to scroll while the inner box clips itself. It is ugly for one more PR and it costs the reader nothing measurable.

## What remains for #145

- [ ] Capture light + dark screenshots of the current app on History
- [ ] Replace `AppShowcase.astro` with a `<picture>`-based component; delete `repoMock.ts` and the duplicated `graphLayout.ts`
- [x] Responsive pass over `index`, `download`, `changelog`, `features`, `support`, `Nav`, `Footer`
- [x] Verify at 360 / 390 / 768 with no horizontal overflow

## Verification

Built exactly as `.github/workflows/site.yml` does:

```
cd site && pnpm install --frozen-lockfile && pnpm build   # 5 pages, clean
```

Root `pnpm tsc --noEmit` does not apply: the root `tsconfig.json` is `include: ["src"]`, so `site/` is outside it, and this change is CSS only — no TypeScript touched. `site/` has its own tsconfig and is covered by `astro build`. No e2e run: the marketing site is not in the e2e suite.