### PR TITLE
feat(cli): install pgit as part of app installation (#144)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,10 @@ Context for future Claude sessions working on this repo. Keep it current when ar
 New feature beyond MVP slice → write new spec + plan under these folders first.
 
 Recent specs/plans (for context on current direction):
+- `2026-08-17-pgit-cli-packaging-*` — `pgit` installed by every channel that
+  offers a hook (Homebrew cask, `.deb`, `.msi`), copy-paste scripts for the ones
+  that don't, and the ownership contract that keeps a package-managed `pgit` and
+  an app-installed one from fighting (#144).
 - `2026-08-16-tag-signing-*` — GPG/SSH signed annotated tags reusing the commit
   signing chain, `verify_tag` + badges, one create-tag dialog replacing three
   prompts (#132).
@@ -301,9 +305,19 @@ forge/           Forge (GitHub / GitLab) integration — PR/MR list, create, che
                  `git rev-parse`: after it everything is a PATH, so every branch
                  reads as absent (regression-tested)
 lib.rs           Tauri builder + invoke_handler! registry (all commands listed there)
-cli.rs           CLI arg parsing (LaunchIntent, parse_args, resolve_repo_root),
-                 shim install/status helpers (install_shim, shim_status) —
-                 not to be confused with git/cli.rs (CliBackend) below
+cli.rs           CLI arg parsing (LaunchIntent, parse_args, resolve_repo_root)
+                 and the whole `pgit` shim story (#144): the PURE core
+                 (shim_dirs_for / package_shim_paths_for / path_dirs /
+                 shim_scan_order / references_app / classify_sighting /
+                 plan_install) plus the impure shim_status / install_shim over
+                 it. `ShimOs` is an explicit parameter, not a `cfg!` at the
+                 point of use, so all three platform tables are testable from
+                 any host — two of the three cannot be exercised otherwise.
+                 Not to be confused with git/cli.rs (CliBackend) below
+windows/         add-user-path.ps1 — the per-user PATH append, `include_str!`'d
+                 as `WINDOWS_PATH_SCRIPT` and fed to powershell on stdin
+deb/             pgit (the /usr/bin wrapper, committed 100755) + postinst
+wix/             pgit-cli.wxs (the MSI component) + pgit.cmd
 git/
 ├── mod.rs       GitBackend trait — every git op, returns AppResult<T>
 ├── types.rs     RepoHandle, FileStatus, CommitInfo, BranchInfo, TagInfo, StashInfo,
@@ -1270,6 +1284,86 @@ lib/
   chevrons; graph merge/rebase/cherry-pick → the branch/commit context menus, the
   palette, and the Branches screen. A new gesture without one is not done.
 - Escape cancels any drag, from one capture-phase listener in the controller.
+
+### CLI packaging: `pgit` per channel (#144)
+
+- **Where `pgit` lands, per channel.** Homebrew cask: a `binary` stanza symlinks
+  the app binary into the brew prefix. `.deb`: `/usr/bin/pgit`, a wrapper
+  exec'ing `/usr/bin/platypusgit`, shipped via `bundle.linux.deb.files`.
+  `.msi`: `<INSTALLDIR>\pgit.cmd` plus `INSTALLDIR` on the machine PATH, via a
+  WiX fragment. `.dmg` and AppImage have **no hook at all** — a drag-install runs
+  no code and an AppImage is never installed — so they get Settings → Command
+  line and `scripts/install-pgit.sh`.
+- **Three parties can own `pgit`, and `shim_status` says which.**
+  `CliShimSource` is `app` (a directory we write) / `package` (launches us from
+  anywhere else) / `foreign` (does not launch us) / `none`, and `installed` means
+  *`pgit` is present and launches this app*. **A `package` shim is never
+  overwritten and never offered for overwrite** — `plan_install` enforces it in
+  the backend, not only by hiding the button, so a future caller (palette,
+  first-run prompt) cannot reintroduce the fight.
+- The scan order is **our dirs → known package paths → PATH**, deliberately.
+  Ours first is what the Reinstall button depends on; "what would a shell
+  actually run" is answered separately by `pathState`, not by reordering.
+- **Recognition needs three probes**, because the channels ship three kinds of
+  file: a symlink to `current_exe()`, a symlink named after the binary, and a
+  small wrapper script mentioning it. That last one is why the deb wrapper spells
+  its target absolutely instead of using `dirname "$0"`. Text reads are capped at
+  4 KiB and non-UTF-8 counts as "no".
+- **On an Intel Mac, Homebrew's prefix IS `/usr/local/bin`** — also our first
+  shim dir — so a cask symlink classifies `app`. Accepted, not a bug: both are
+  symlinks to the same target, and `plan_install` returns `KeepExisting` when the
+  link already points at us, so Reinstall cannot clobber a brew-managed link.
+- **macOS installs no longer need sudo.** `shim_dirs_for` is an ordered list and
+  `install_shim` takes the first one it can write; attempting the write IS the
+  writability test (a separate probe would only add a TOCTOU). `/usr/local/bin`
+  stays first because it is the only default-PATH entry, so existing installs are
+  untouched; everyone else falls through to `~/.local/bin` and the off-PATH state
+  is *reported* with the line that fixes it, never hidden.
+- **The Windows PATH write is PowerShell on purpose**, and both traps are load
+  bearing: `setx` truncates at 1024 characters and `setx PATH "%PATH%;…"` writes
+  the MERGED machine+user PATH into the user PATH; and a bare
+  `[Environment]::SetEnvironmentVariable(…, 'User')` rewrites a `REG_EXPAND_SZ`
+  PATH as `REG_SZ` with `%USERPROFILE%` permanently expanded. So the value is
+  read `DoNotExpandEnvironmentNames` and written back with `GetValueKind`'s
+  answer. The directory travels in `PGIT_BIN_DIR`, never argv — `-Command` takes
+  a script and a path is user-controlled text.
+- **Four traps in `src-tauri/wix/pgit-cli.wxs`**, each a way to fail the Windows
+  release job and ship a release with no `.msi`. They are documented in the file
+  itself; the short version: no doubled opening brace anywhere (the bundler
+  renders fragments through Handlebars and then *discards* the result, so a
+  malformed expression fails the build and a well-formed one is silently
+  dropped); the `$(var.Win64)` preamble is **copied** because candle defines are
+  per source file; `Source` uses `$(sys.SOURCEFILEDIR)` because candle's cwd is
+  `target/release/wix/<arch>`; and `light` runs **without `-sval`**, so ICE
+  validation is live — match `main.wxs`'s own component shapes rather than
+  inventing one.
+- **The exec bit on `/usr/bin/pgit` survives the bundler**, verified in source
+  rather than assumed: git stores `100755`, `fs_utils::copy_file` is
+  `std::fs::copy` (which copies permission bits), and tar-rs's
+  `HeaderMode::Deterministic` *propagates* the user execute bit on Unix
+  (`0o100 & mode` → `0o755`) instead of flattening to `0644`. Its Windows branch
+  does not, but the `.deb` is built on `ubuntu-22.04`. `deb/postinst` is the belt
+  for that brace and stays minimal: **a postinst exiting non-zero fails
+  `dpkg -i` for the whole package.**
+- **Uninstall needs no code.** Each channel's remover already deletes what it
+  shipped. There is deliberately no `postrm` (a package must not delete files it
+  did not ship) and no uninstall command (after an uninstall there is no app to
+  run one).
+- **`release.yml` is not involved.** All of this is additive bundle config;
+  `bundle.targets`, `createUpdaterArtifacts`, the updater `pubkey` and the
+  signing config are untouched. `bump-cask` rewrites the tap's cask with two
+  `sed -i -E` expressions anchored on `^  version "` and `^  sha256 "`, so the
+  cask's `binary` stanza matches neither anchor and the version bump keeps
+  working.
+- **Test seams are deliberate, and named as such**: `PGIT_APP_SEARCH_ROOT` /
+  `PGIT_UNAME` in `install-pgit.sh` and `PGIT_POSTINST_PREFIX` in `deb/postinst`
+  exist because three of five channels cannot be exercised on a developer
+  machine. Nothing in normal use sets them.
+- **`scripts/install-pgit.sh` must stay `curl … | sh`-safe**: POSIX `sh`,
+  `set -eu`, and it never reads stdin — stdin IS the script, so there can be no
+  prompts and every choice is a flag or an env var. Watch `set -e` around
+  `[ … ] && cmd` as a function's or loop body's last command, and feed loops from
+  a here-doc rather than a pipe when they assign to an outer variable.
 
 ### Permissions (Tauri 2)
 - Shared permissions in `src-tauri/capabilities/default.json`. Current set: `core:default`, `core:window:allow-minimize`, `core:window:allow-toggle-maximize`, `core:window:allow-close`, `core:window:allow-start-dragging`, `core:window:allow-set-title`, `core:webview:allow-create-webview-window`, `dialog:default`, `dialog:allow-open`, `os:default`, `log:default`. Capability scopes `windows: ["main", "merge"]` (merge resolver runs as a second window).

--- a/docs/superpowers/plans/2026-08-17-pgit-cli-packaging-plan.md
+++ b/docs/superpowers/plans/2026-08-17-pgit-cli-packaging-plan.md
@@ -1,0 +1,204 @@
+# `pgit` CLI packaging — implementation plan
+
+**Goal:** `pgit` is present after installing the app on every channel that gives
+us a hook (Homebrew cask, `.deb`, `.msi`), a documented one-liner script covers
+the ones that don't (`.dmg`, AppImage), Settings → Command line works on Windows,
+and a package-managed `pgit` is reported as *installed* rather than overwritten.
+
+**Architecture:** `src-tauri/src/cli.rs` keeps ownership of the shim. Its
+single-answer `default_shim_dir` / `shim_installed_at` pair becomes a small pure
+core — an ordered candidate list, a `PATH` splitter, a scan order, and one
+`references_app` predicate — with the impure `shim_status` / `install_shim`
+reduced to probing that core. Packaging is additive config only:
+`bundle.linux.deb.files` + `postInstallScript` for the deb wrapper, and
+`bundle.windows.wix.fragmentPaths` + `componentRefs` for a WiX fragment.
+`release.yml` is not touched.
+
+**Tech Stack:** Rust (no new crates), Tauri 2 bundler config, WiX v3 fragment,
+POSIX `sh`, PowerShell 5.1+, React 18 + Zustand, vitest/RTL.
+
+**Design doc:** `docs/superpowers/specs/2026-08-17-pgit-cli-packaging-spec.md`
+**Issue:** [#144](https://github.com/jonassaa/platypusgit/issues/144)
+
+## Global Constraints
+
+- Every IPC-crossing fn returns `AppResult<T>`. No new `AppError` variant is
+  expected; if one appears, `src/lib/errors.ts` changes in the same commit.
+- `CliShimStatus` / `CliInstallOutcome` gain fields → `src/lib/types.ts` in the
+  same commit. `installed` / `shimPath` / `target` / `path` / `manualCommand`
+  keep their names and meanings so the existing Settings test keeps passing.
+- Frontend never calls `invoke()` directly — `lib/tauri.ts` wrappers only.
+- New Rust work in commands stays inside `spawn_blocking` (already true for both
+  CLI commands).
+- No `window.confirm` / `window.prompt`.
+- **`release.yml`, `bundle.targets`, `createUpdaterArtifacts`, the updater
+  `pubkey` and the signing config are untouched.** Bundle config changes are
+  additive keys only.
+- The WiX fragment contains no `{{` (Handlebars renders and discards it) and no
+  preprocessor variable it does not define itself.
+- `src-tauri/deb/pgit` must be committed mode `100755`.
+- The `.sh` must be safe under `curl … | sh`: `set -eu`, no bashisms, never reads
+  stdin.
+- Secrets/paths reach a spawned shell through the environment, not argv.
+- Run pnpm/cargo with `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"`.
+- **Do not run e2e** — no spec here touches a webview flow that a spec covers,
+  and the Docker slot is shared.
+- Do not edit `site/` (#145 owns it) and do not touch the tap repo.
+
+## File Structure
+
+**Create:**
+- `src-tauri/deb/pgit` — the `/usr/bin/pgit` wrapper (mode 755)
+- `src-tauri/deb/postinst` — guarded `chmod` (mode 755)
+- `src-tauri/wix/pgit-cli.wxs` — the `PgitCli` component fragment
+- `src-tauri/wix/pgit.cmd` — the MSI shim
+- `scripts/install-pgit.sh`
+- `scripts/install-pgit.ps1`
+- `docs/superpowers/specs/2026-08-17-pgit-cli-packaging-spec.md`
+- `docs/superpowers/plans/2026-08-17-pgit-cli-packaging-plan.md`
+
+**Modify:**
+- `src-tauri/src/cli.rs` — the pure core, `CliShimSource`, `CliPathState`,
+  rewritten `shim_status` / `install_shim`, Windows `install_shim_at`, tests
+- `src-tauri/tauri.conf.json` — `linux.deb.files` + `postInstallScript`,
+  `windows.wix.fragmentPaths` + `componentRefs`
+- `src/lib/types.ts` — the two new fields on each struct
+- `src/screens/Settings.tsx` — the four `source` states, the Windows path
+- `src/screens/Settings.cli.test.tsx` — the new states
+- `CLAUDE.md` — the packaging convention
+
+## Phases
+
+### Phase 1 — the ownership contract in `cli.rs` (pure core + tests)
+
+The whole change hangs off this, so it lands first and alone.
+
+1. `SHIM_NAME` (`"pgit"` / `"pgit.cmd"`), `MAIN_BINARY` (`"platypusgit"`).
+2. `CliShimSource { None, App, Package, Foreign }` and
+   `CliPathState { OnPath, OffPath }`, both `Serialize` + `camelCase`.
+3. Pure fns, each taking its inputs rather than reading the environment:
+   - `app_shim_dirs_from(home: Option<&Path>, local_app_data: Option<&Path>) -> Vec<PathBuf>`
+     — per-OS order from spec §D.
+   - `path_dirs(path_var: Option<&OsStr>) -> Vec<PathBuf>` — split on the
+     platform separator, drop empties.
+   - `shim_scan_order(app_dirs, package_paths, path_dirs) -> Vec<PathBuf>` —
+     app dirs' shims, then package paths, then `PATH` dirs' shims, deduplicated,
+     order preserved.
+   - `references_app(link: Option<&Path>, text: Option<&str>, exe: &Path, main_binary: &str) -> bool`
+     — the three probes from spec §A.
+   - `classify_sighting(path, app_dirs, link, text, exe, main_binary) -> CliShimSource`.
+   - `dir_on_path(dir: &Path, path_dirs: &[PathBuf]) -> CliPathState`.
+4. Thin impure wrappers that read the environment: `app_shim_dirs()`,
+   `package_shim_paths(exe)`, `read_sighting(path) -> Option<(link, text)>` with
+   the 4 KiB / UTF-8 cap.
+5. Tests (no filesystem where avoidable):
+   - the deb wrapper's text classifies `Package` from `/usr/bin/pgit`
+   - a symlink to `exe` inside an app dir classifies `App`
+   - a symlink to `exe` **outside** the app dirs classifies `Package`
+   - a symlink to something else, and a script with no mention, classify `Foreign`
+   - a non-UTF-8 / oversized file classifies `Foreign`, never panics
+   - scan order: app dirs before package paths before `PATH`; duplicates collapse
+   - `path_dirs` drops empty entries and honours the platform separator
+   - `dir_on_path` is exact-dir, not prefix
+
+**Verify:** `cargo test --manifest-path src-tauri/Cargo.toml`.
+
+### Phase 2 — `shim_status` / `install_shim` on the new core
+
+1. `shim_status()` walks `shim_scan_order`, takes the first sighting that
+   `references_app`, and reports `source` + `pathState` + `shimPath`. First
+   non-referencing sighting → `Foreign`. Nothing → `None`, with `shimPath` and
+   `pathState` describing the first app shim dir.
+2. `install_shim()`:
+   - `Package` → early return `installed: true`, no write (the contract, enforced
+     in the backend and not only by a hidden button).
+   - `App` whose link already equals `exe` → early return, no write (the
+     Homebrew-ambiguity guard).
+   - otherwise try each app shim dir in order; first success wins; `pathState`
+     from the dir that won.
+   - all fail → the existing `sudo ln -sf` `manualCommand`, unchanged.
+3. `#[cfg(windows)] install_shim_at` writes `pgit.cmd` (`"<exe>" %*`) instead of
+   a symlink, and `#[cfg(windows)] add_user_path(dir)` shells out to PowerShell
+   with the directory in `PGIT_BIN_DIR` (spec §F).
+4. Integration tests in `src-tauri/tests/` where a temp dir is needed:
+   a package-managed sighting makes `install_shim` a no-op; a stale `App` link is
+   replaced; an identical `App` link is left byte-identical.
+
+**Verify:** `cargo test`, `cargo check`.
+
+### Phase 3 — deb packaging
+
+1. `src-tauri/deb/pgit` + `src-tauri/deb/postinst`, both `chmod 755` and
+   committed as `100755` (confirm with `git ls-files -s`).
+2. `tauri.conf.json`: `linux.deb.files` + `postInstallScript`.
+3. Verify what can be verified here: `dash -n` both files; run the postinst
+   against a temp fixture (with the path parameterised for the test) and assert
+   it chmods only when needed and exits 0 for a non-`configure` argument; assert
+   the wrapper's text is classified `Package` by the Phase 1 predicate.
+
+**Verify:** `dash -n`, the fixture run, `git ls-files -s`, and that
+`pnpm tauri build --no-sign` still parses the config on macOS.
+
+### Phase 4 — MSI packaging
+
+1. `src-tauri/wix/pgit.cmd`.
+2. `src-tauri/wix/pgit-cli.wxs` — the `<?if $(sys.BUILDARCH)?>` preamble copied
+   from `main.wxs`, one `Component Id="PgitCli"` with a fixed GUID, the `File`
+   via `$(sys.SOURCEFILEDIR)`, the `Environment` PATH entry.
+3. `tauri.conf.json`: `fragmentPaths` + `componentRefs`.
+4. Verify: `xmllint --noout`, `xmllint --schema` against WiX v3's `wix.xsd`, and
+   a grep proving there is no `{{` anywhere in the fragment.
+
+**Verify:** the two `xmllint` runs, the grep, and `pnpm tauri build --no-sign`.
+
+### Phase 5 — the scripts
+
+1. `scripts/install-pgit.sh` — spec §G. Structure it so every filesystem root is
+   overridable (`PLATYPUSGIT_APP`, `PGIT_BIN_DIR`, `PGIT_PATH_HINT`) precisely so
+   it is testable without an install.
+2. `scripts/install-pgit.ps1` — spec §F/§G, with the PATH append factored into a
+   pure `Get-UpdatedPath` so it can be exercised by `pwsh` on macOS.
+3. Verify: `dash -n` + `bash -n`; real runs against fixtures for
+   already-installed / fresh-install / package-managed-present / `--dry-run` /
+   `--help`; `pwsh` parse check via `[Parser]::ParseFile`; `Get-UpdatedPath`
+   driven through its cases under `pwsh`.
+
+**Verify:** the runs above.
+
+### Phase 6 — Settings
+
+1. `src/lib/types.ts`: `source: CliShimSource`, `pathState: CliPathState` on
+   `CliShimStatus`; `pathState` on `CliInstallOutcome`.
+2. `Settings.tsx` `CliSection`: drop the `isWindows` dead branch entirely and
+   render off `source` —
+   - `package` → "Installed by your package manager at `<path>`", no button
+   - `app` → "Installed at `<path>`" + Reinstall, plus the `offPath` line naming
+     the directory to add
+   - `foreign` → "A different `pgit` is on your PATH at `<path>`" + Install
+   - `none` → Install, plus the pre-warning when the target dir is off `PATH`
+3. Component tests for all four, plus a `pathState: "offPath"` render.
+
+**Verify:** `pnpm tsc --noEmit`, `pnpm test`.
+
+### Phase 7 — docs + wrap-up
+
+1. `CLAUDE.md`: a "CLI packaging" convention paragraph — where `pgit` lands per
+   channel, the ownership contract, the four WiX fragment traps, the deb exec-bit
+   chain, and "do not touch `release.yml` for this".
+2. Full verification sweep, then squash to focused Conventional Commits and open
+   the draft PR.
+
+**Verify:** `pnpm tsc --noEmit`, `pnpm test`, `cargo check`, `cargo test`.
+
+## Risks
+
+- **The WiX fragment is the only file here that can break a release for every
+  platform's users**, because a candle/light failure fails the whole Windows job
+  and the release ends up with no `.msi`. Mitigations: mirror `main.wxs`'s own
+  patterns, define every preprocessor variable used, schema-validate locally, and
+  state in the report that compilation is unproven.
+- The `postinst` can fail `dpkg -i` for the whole package. Mitigation: it touches
+  one path, guards on existence, and exits 0 for every non-`configure` argument.
+- The Windows PATH write can damage a user's `PATH`. Mitigation: no `setx`,
+  registry value kind preserved, idempotent, and a failure is reported rather
+  than retried differently.

--- a/docs/superpowers/specs/2026-08-17-pgit-cli-packaging-spec.md
+++ b/docs/superpowers/specs/2026-08-17-pgit-cli-packaging-spec.md
@@ -1,0 +1,401 @@
+# `pgit` as part of app installation, on every channel
+
+**Issue:** [#144](https://github.com/jonassaa/platypusgit/issues/144)
+
+## Problem
+
+`pgit` exists (`2026-07-07-cli-launch-*`, #25) but only arrives if the user finds
+Settings → Command line and clicks Install:
+
+- **macOS** — `default_shim_dir()` is `/usr/local/bin`, which is root-owned (and
+  on Apple Silicon usually absent). `install_shim` therefore fails for most
+  users and hands back a `sudo ln -sf …` line to paste. That paste line is the
+  product's whole answer today.
+- **Windows** — `default_shim_dir()` returns `None`, `shim_status().installed` is
+  hardcoded `false`, and Settings renders a dead row: *"Not yet supported on
+  Windows."*
+- **Linux** — `~/.local/bin` works, but nothing put it there; a `.deb` install
+  leaves the user with no `pgit`.
+- **Every channel** — the app ships no packaging hook at all, so the CLI is
+  never present after an install.
+
+And the piece that has to be settled before any of the three layers is written:
+a package-managed `pgit` and an app-installed `pgit` must not fight. Today
+`shim_status` answers exactly one question — *is `<default_shim_dir>/pgit` a
+symlink to `current_exe()`* — so a `.deb` user with a perfectly working
+`/usr/bin/pgit` is told "Not installed" and offered a button that writes a second
+copy somewhere else.
+
+## Design
+
+### A. The contract: who owns `pgit` (settle this first)
+
+Three parties can put a `pgit` on the user's PATH, and the app is only one of
+them:
+
+| Party | Where it writes | Removed by |
+| --- | --- | --- |
+| A package/installer | Homebrew: `$(brew --prefix)/bin/pgit`. deb: `/usr/bin/pgit`. MSI: `<INSTALLDIR>\pgit.cmd` | the package manager / MSI uninstall |
+| The app itself (Settings → Command line) | the first writable **app shim dir** (§D) | Settings, or by hand |
+| Somebody else | anywhere | them |
+
+`shim_status` grows a `source` field naming which of those it found, and
+`installed` widens to mean *`pgit` is present and launches this app* — the
+question the user is actually asking:
+
+```rust
+pub enum CliShimSource { None, App, Package, Foreign }
+```
+
+- **`App`** — a shim in one of the app's own shim dirs that references this app.
+  Settings offers Reinstall.
+- **`Package`** — a shim outside those dirs that references this app.
+  `installed: true`, and **Settings offers no install button at all**: the
+  package owns the file, the app must not write a second one, and it must not
+  offer to. `install_shim()` is *also* a no-op success in this state, so the
+  contract holds even if a future caller (palette, first-run prompt) forgets.
+- **`Foreign`** — a `pgit` exists but does not reference this app.
+  `installed: false`; Settings says so and still allows an install, because the
+  app writes to its own dir and never over the stranger's file.
+- **`None`** — nothing found.
+
+**Scan order — app dirs, then known package paths, then `PATH` in order.** Ours
+comes first deliberately: "did *we* install this" is the question the Reinstall
+button depends on, and a user who has both a deb-shipped and a self-installed
+`pgit` is honestly in the `App` state (they did install one). What a shell would
+actually run is reported separately, as `pathState`, rather than by reordering the
+scan:
+
+```rust
+pub enum CliPathState { OnPath, OffPath }
+```
+
+`pathState` is the found shim's directory measured against `PATH`. With nothing
+found it describes the directory an install *would* target, so Settings can warn
+before the click rather than after it.
+
+**A shim "references this app"** if any of the following holds — one pure
+predicate, three probes, because the three channels ship three different kinds of
+file:
+
+1. it is a symlink whose target is `current_exe()` (self-install, Homebrew cask);
+2. it is a symlink whose target's file name is the main binary name (a Homebrew
+   symlink surviving an app move);
+3. it is a small text file whose contents mention the main binary name (the deb
+   wrapper's `exec /usr/bin/platypusgit`, the MSI's `%~dp0platypusgit.exe`).
+
+Probe 3 is capped at 4 KiB and non-UTF-8 reads as "no" — this must never become a
+reason to slurp an arbitrary file off `PATH`.
+
+**Accepted ambiguity, recorded so nobody re-derives it as a bug.** On an Intel
+Mac, Homebrew's prefix *is* `/usr/local/bin`, which is also the app's first shim
+dir. A cask-installed `pgit` there is indistinguishable from a self-installed one
+and is classified `App`. It is harmless: both are symlinks to the same target, and
+`install_shim` **returns early without touching the filesystem when the existing
+link already points at `exe`**, so Reinstall cannot clobber a Homebrew-managed
+symlink. Apple Silicon (`/opt/homebrew/bin`) has no ambiguity and classifies
+`Package`.
+
+### B. Uninstall
+
+Nothing new is written to answer it — each channel's own remover already does:
+
+| Channel | On uninstall |
+| --- | --- |
+| Homebrew cask | `brew uninstall` removes the `binary` symlink |
+| `.deb` | dpkg ships `/usr/bin/pgit` in `data.tar`, so `apt remove` deletes it |
+| `.msi` | the component's file and its `Environment` PATH entry are both `Permanent="no"` → rolled back |
+| `.dmg` / AppImage / self-installed | the app's own symlink survives; it is a dangling symlink in the user's own `~/.local/bin`, which is the same thing every other hand-installed CLI leaves. **Not** removed by the app, because the app is gone |
+
+Deliberately **no** `postrm` and **no** uninstall command: a package that deletes
+files it did not ship is a policy violation, and the app cannot run code after it
+has been deleted.
+
+### C. `.deb` — `/usr/bin/pgit` as a wrapper
+
+```json
+"deb": {
+  "files": { "/usr/bin/pgit": "deb/pgit" },
+  "postInstallScript": "deb/postinst"
+}
+```
+
+`src-tauri/deb/pgit` is four lines: `#!/bin/sh` and
+`exec /usr/bin/platypusgit "$@"`. The target is spelled **absolutely rather than
+via `dirname "$0"`** on purpose — it is what the §A probe-3 classifier greps for,
+and dpkg installs the wrapper at exactly one path anyway.
+
+Why a wrapper and not a symlink: `deb.files` is copied with
+`fs_utils::copy_file` → `std::fs::copy`, which **follows** symlinks. A symlink
+source would duplicate the whole binary into the package.
+
+**The exec bit — verified in the bundler, not assumed.** The chain is three links
+and every one of them was read:
+
+1. git stores the mode. `src-tauri/deb/pgit` is committed `100755`, so an
+   `actions/checkout` on the Linux runner writes it executable.
+2. `fs_utils::copy_file` is `fs::copy`, documented to copy the permission bits.
+3. `debian.rs::create_tar_from_dir` sets
+   `header.set_metadata_in_mode(&stat, HeaderMode::Deterministic)`. tar-rs's
+   Deterministic branch is *not* a blanket 0644 — on Unix it is
+   `if meta.is_dir() || (0o100 & meta.mode() == 0o100) { 0o755 } else { 0o644 }`,
+   i.e. **it propagates the user execute bit**. The Windows branch of the same
+   function does not, but the `.deb` is built on `ubuntu-22.04`.
+
+So the exec bit survives. It cannot be *observed* to survive without building a
+`.deb`, which needs Linux — hence `deb/postinst`, whose only job is a guarded
+`chmod`:
+
+```sh
+if [ -e /usr/bin/pgit ] && [ ! -x /usr/bin/pgit ]; then chmod 0755 /usr/bin/pgit; fi
+```
+
+It is a belt for a brace that source-reading says is already fastened, and it is
+written so it cannot fail an install: it touches one path, only when that path
+exists and lacks the bit, and it exits 0 for every `postinst` argument other than
+`configure`. A `postinst` that exits non-zero fails `dpkg -i` for the whole
+package, so this file's blast radius is the entire Linux release — it stays this
+small.
+
+`deb.files` is copied in `package_debian`, **not** in `generate_data`, and the
+AppImage bundler only calls the latter — so neither the wrapper nor the postinst
+reaches the AppImage. AppImage stays script-only, as the issue's table says.
+
+### D. macOS + Linux: no-sudo by default
+
+`default_shim_dir() -> Option<PathBuf>` becomes `app_shim_dirs() -> Vec<PathBuf>`,
+ordered most-preferred first, and `install_shim` takes the first one it can
+actually write:
+
+| OS | Order | Why |
+| --- | --- | --- |
+| macOS | `/usr/local/bin`, `~/.local/bin`, `~/bin` | `/usr/local/bin` is the only one on the default `PATH`, and where every existing install already is. It is tried *first* and skipped when unwritable, so existing users are unaffected and everyone else lands sudo-free |
+| Linux | `~/.local/bin`, `~/bin` | unchanged first entry |
+| Windows | `%LOCALAPPDATA%\PlatypusGit\bin` | per-user, no admin, and the dir we add to the per-user PATH (§F) |
+
+There is **no writability pre-probe**: `install_shim` attempts each candidate and
+takes the first success, which is the only honest test of "can I write here" and
+avoids a TOCTOU between probe and write. The `sudo ln -sf` fallback stays for the
+case where *every* candidate fails, but with `~/.local/bin` in the list that is
+now a genuine edge case (no `$HOME`) rather than the common path.
+
+The cost: a `~/.local/bin` install is usually **off** `PATH` on macOS. That is
+reported (`pathState: "offPath"`), not hidden, and Settings renders the one-line
+shell export next to it. A wrong-but-on-PATH location (`/usr/local/bin` via
+sudo) is not a better answer than a right-but-off-PATH one plus the line that
+fixes it.
+
+### E. `.msi` — a WiX fragment
+
+```json
+"wix": {
+  "language": ["en-US"],
+  "fragmentPaths": ["wix/pgit-cli.wxs"],
+  "componentRefs": ["PgitCli"]
+}
+```
+
+`src-tauri/wix/pgit.cmd`:
+
+```
+@echo off
+"%~dp0platypusgit.exe" %*
+```
+
+`%~dp0` is the batch file's own directory, so the shim is self-locating and no
+install path is baked in. The release binary is `windows_subsystem = "windows"`,
+so `cmd` does not block on it, and `tauri-plugin-single-instance` forwards the
+args into a running instance — `pgit .` from a terminal opens a tab.
+
+The fragment installs that file into `INSTALLDIR` and appends `INSTALLDIR` to the
+machine `PATH`:
+
+```xml
+<DirectoryRef Id="INSTALLDIR">
+  <Component Id="PgitCli" Guid="{fixed}" Win64="$(var.Win64)">
+    <File Id="PgitCmd" Name="pgit.cmd" Source="$(sys.SOURCEFILEDIR)pgit.cmd" KeyPath="yes" />
+    <Environment Id="PgitPath" Name="PATH" Value="[INSTALLDIR]" Part="last"
+                 Action="set" System="yes" Permanent="no" />
+  </Component>
+</DirectoryRef>
+```
+
+Five things about that markup are load-bearing, and each is a way the **release
+build for every platform's users** breaks if it is got wrong. All five were
+checked against `tauri-bundler`'s `msi/mod.rs` + `msi/main.wxs` at `dev` and
+against the WiX v3 `wix.xsd`, not assumed:
+
+1. **`Source` must not be a bare relative path.** `run_candle` runs with
+   `current_dir` = `target/release/wix/<arch>`, so `Source="pgit.cmd"` would
+   resolve there and fail. `$(sys.SOURCEFILEDIR)` is candle's built-in for the
+   compiling source file's directory (trailing separator included) — i.e.
+   `src-tauri/wix/`. The other candidate, `-dSourceDir`, is passed by the bundler
+   but points at the *main binary file*, not a directory.
+2. **No Handlebars braces.** `msi/mod.rs` renders every fragment through
+   Handlebars before compiling — and then **discards the result**, passing the
+   raw file to candle (the render exists only to sniff which `-ext` DLLs the
+   file needs). So `{{…}}` is neither substituted nor safe: a malformed
+   expression fails the render, and a well-formed one is silently dropped. The
+   fragment therefore contains no `{{`.
+3. **`$(var.Win64)` is defined per source file.** `main.wxs` defines it in a
+   `<?if $(sys.BUILDARCH)?>` preamble, which does *not* carry into a separate
+   `.wxs`. The fragment repeats that preamble verbatim — candle is invoked with
+   `-arch <arch>` for every input, so `$(sys.BUILDARCH)` is set. Copying the
+   preamble rather than dropping the attribute keeps this component's bitness
+   identical to the components `main.wxs` already puts in `INSTALLDIR`, so it
+   inherits whatever ICE verdict the shipping MSI already gets. `light` runs
+   **without `-sval`**, so ICE validation is live and an ICE *error* would fail
+   the build — matching the existing components is the low-risk choice.
+4. **`componentRefs` lands the component in `main.wxs`'s `Feature Id="External"`.**
+   That feature carries no `Level`; `wix.xsd` declares `Level` as optional
+   (`xs:integer`, no `use="required"`), so it defaults to installed.
+5. **`Environment` is core WiX**, not `WixUtilExtension`, so no extra `-ext` is
+   needed — and the bundler passes `WixUtilExtension.dll` anyway.
+   `Action="set"` + `Part="last"` is the documented append form (`[~];value`);
+   `Permanent="no"` is what makes uninstall remove it.
+
+`INSTALLDIR` is under Program Files and the package is `perMachine`, so the
+`System="yes"` write is already elevated. It puts `platypusgit.exe` on `PATH`
+too, which is fine.
+
+### F. Windows in-app install (replacing the dead row)
+
+An MSI user never needs this — §A classifies `<INSTALLDIR>\pgit.cmd` as
+`Package` and Settings shows no button. It exists for the Windows installs the
+MSI does not cover: a build from source, a future portable/unpacked layout, and
+an MSI install whose PATH change has not reached the running shell.
+
+Two halves, and only the first is done natively:
+
+1. **The file.** Write `%LOCALAPPDATA%\PlatypusGit\bin\pgit.cmd` containing
+   `"<current_exe>" %*`. Windows has no symlink without elevation or Developer
+   Mode, so the shim is a `.cmd` here, not a link — which is also why
+   `install_shim_at` splits into a Unix (symlink) and a Windows (write file)
+   implementation rather than growing a branch inside one.
+2. **The per-user PATH.** Delegated to PowerShell, and the reasons are specific:
+
+   - **`setx` is disqualified.** It truncates at 1024 characters and, worse,
+     `setx PATH "%PATH%;…"` writes the *merged* machine+user PATH into the user
+     PATH. It is the single most common way to destroy a Windows PATH.
+   - **`[Environment]::SetEnvironmentVariable(…, 'User')` alone is not enough.**
+     If `HKCU\Environment\Path` is `REG_EXPAND_SZ` containing `%USERPROFILE%`,
+     .NET writes back `REG_SZ` with the variables **expanded**, permanently. So
+     the write goes through `Microsoft.Win32.Registry` with
+     `DoNotExpandEnvironmentNames` on the read and `GetValueKind`'s answer
+     preserved on the write.
+   - It is idempotent: an entry already present (case-insensitive, trailing
+     separators normalised) is left alone.
+   - `WM_SETTINGCHANGE` is broadcast so new shells see it without a logoff.
+
+   The directory reaches PowerShell **through the environment, not argv** —
+   `$env:PGIT_BIN_DIR` — the same rule the credential code follows, here for
+   injection rather than secrecy: a path is user-controlled text and
+   `-Command` is a script.
+
+   If that half fails, the file half still succeeded: the outcome reports
+   `pathState: "offPath"` and Settings names the directory to add. A failed PATH
+   write is not a failed install.
+
+`CliInstallOutcome` grows `pathState` for this; `manualCommand` keeps its exact
+current meaning (the file could not be written at all).
+
+### G. The copy-paste scripts
+
+`scripts/install-pgit.sh` (macOS + Linux, POSIX `sh`) and
+`scripts/install-pgit.ps1` (Windows). Both do what §D/§F do, for the channels
+with no hook (`.dmg`, AppImage, zip) and for anyone who would rather run a
+command than open Settings.
+
+Shared shape:
+
+- **Locate the app**, don't ask. macOS: `/Applications`, `~/Applications`,
+  then `PATH`. Linux: `/usr/bin/platypusgit`, `/usr/local/bin/platypusgit`,
+  `$APPIMAGE`, then `PATH`. Overridable with `PLATYPUSGIT_APP` — which is also
+  what makes the script testable on a machine with no install.
+- **Refuse to fight a package.** If a `pgit` already on `PATH` references the
+  app, print where it is and exit 0 without writing. Same rule as §A, in the
+  other language.
+- **Prefer no sudo**: `PGIT_BIN_DIR` override, else the first writable of
+  `~/.local/bin`, `~/bin`, `/usr/local/bin`; report `PATH` state and print the
+  one line that fixes it.
+- **Safe under `curl … | sh`**: `set -eu`, no bashisms, and **no reading from
+  stdin** — stdin is the script. So no prompts, ever; every choice is a flag or
+  an env var.
+- `--help`, and `--dry-run` so a user can see what it would do before it does it.
+
+The `.ps1` additionally owns the registry-kind-preserving PATH append described
+in §F.
+
+### H. Two items specified here and landed elsewhere
+
+**The Homebrew cask** lives in `jonassaa/homebrew-platypusgit`. One line, after
+the existing `app` stanza:
+
+```ruby
+binary "#{appdir}/PlatypusGit.app/Contents/MacOS/platypusgit", target: "pgit"
+```
+
+`brew` symlinks it into `#{HOMEBREW_PREFIX}/bin` — already on `PATH`, no sudo,
+removed by `brew uninstall`. §A then classifies it `Package` (or `App` on Intel,
+per the recorded ambiguity).
+
+**`release.yml`'s `bump-cask` job keeps working.** It rewrites the cask with two
+`sed -i -E` expressions anchored on `^  version "` and `^  sha256 "`. A
+`  binary "…"` line matches neither anchor, changes neither line's shape, and is
+inserted below both. **No change to `release.yml` is needed and none is made** —
+the bundle keys added by §C and §E are additive config, and `bundle.targets`,
+`createUpdaterArtifacts`, the updater `pubkey` and the signing config are
+untouched.
+
+**The site** (`platypusgit.com`) needs, in `site/` — owned by #145, not this
+change:
+
+- `scripts/install-pgit.sh` and `scripts/install-pgit.ps1` served from the static
+  root. They must not be copied by hand: a prebuild step in `site/package.json`
+  should copy them out of `scripts/` into `site/public/`, or they will drift from
+  the repo copies the moment one is edited.
+- On `/download`, per platform:
+  `curl -fsSL https://platypusgit.com/install-pgit.sh | sh` (macOS/Linux) and
+  `irm https://platypusgit.com/install-pgit.ps1 | iex` (Windows), each with the
+  note that Homebrew, the `.deb` and the `.msi` already install `pgit` and the
+  script is for the other routes.
+
+## Rejected alternatives
+
+- **A symlink in `deb.files`** — `fs::copy` follows symlinks, so it would embed a
+  second copy of the binary in the package.
+- **Shipping `pgit.cmd` through `bundle.resources`** instead of a WiX `File`.
+  It would remove the `$(sys.SOURCEFILEDIR)` question, but `resources` is not
+  per-platform, so a Windows `.cmd` would ship inside the macOS `.app` and the
+  `.deb`. The fragment needs authoring for the PATH entry regardless, so
+  resources buys nothing and costs a stray file on two other channels.
+- **A `bin` subdirectory under `INSTALLDIR` on PATH** instead of `INSTALLDIR`
+  itself — tidier (only `pgit.cmd` on PATH) but a second `Directory` element in
+  the highest-risk file in the change, for no user-visible gain.
+- **`setx`** for the Windows PATH — truncation at 1024 chars and machine/user
+  PATH merging. §F.
+- **A `winreg` / `windows-sys` dependency** for the PATH write instead of
+  PowerShell. It is the technically cleaner call, but it adds a Windows-only
+  crate for one registry write that the `.ps1` has to implement anyway, and the
+  duplicate would be the thing that drifts. Worth revisiting if the app ever
+  needs a second registry write.
+- **A `postrm` that removes a self-installed shim** — the package must not
+  delete files it did not ship, and after an uninstall there is no app to run.
+- **Reordering the §A scan so `PATH` wins** — it answers "what does `pgit` run"
+  at the cost of "did we install this", which is what the Reinstall button needs.
+  `pathState` answers the first question without giving up the second.
+
+## Verification reality
+
+This is macOS. Three of the five channels cannot be exercised here, and the
+matching honesty requirement is part of the spec, not an afterthought:
+
+| Channel | Verifiable here | Not verifiable here |
+| --- | --- | --- |
+| Homebrew cask | the `bump-cask` sed anchors, by reading the live cask | the stanza itself (different repo, #144 keeps it) |
+| `.dmg` / in-app (macOS) | end to end — `install-pgit.sh` against a fixture app, `shim_status`/`install_shim` unit + integration tests, `pnpm tauri build --no-sign` | — |
+| `.deb` | the bundler's exec-bit chain by source reading; `dash -n` + a real run of the wrapper and the postinst | that `dpkg -i` produces an executable `/usr/bin/pgit` |
+| `.msi` | XML well-formedness + `xmllint --schema wix.xsd`; no `{{`; the config parses | candle/light/ICE actually compiling it; the PATH entry; uninstall rollback |
+| Windows in-app | `pwsh` parses the script; the pure PATH-append function under `pwsh` on macOS | the registry write, the `WM_SETTINGCHANGE` broadcast, `pgit.cmd` resolution |
+
+Anything in the right column is reported as unproven, never as working.

--- a/scripts/install-pgit.ps1
+++ b/scripts/install-pgit.ps1
@@ -1,0 +1,228 @@
+<#
+.SYNOPSIS
+    Install the `pgit` CLI for an already-installed platypusgit (Windows).
+
+.DESCRIPTION
+    For the Windows installs the .msi does not cover: a build from source, an
+    unpacked/portable layout, or an .msi whose PATH change has not reached the
+    shell you are in. The .msi already ships `pgit.cmd` in its install directory
+    and puts that directory on the machine PATH — this script detects that and
+    refuses to write a second one.
+
+        irm https://platypusgit.com/install-pgit.ps1 | iex
+
+    Writes a `pgit.cmd` shim into %LOCALAPPDATA%\PlatypusGit\bin (per user, no
+    admin) and appends that directory to the current user's PATH.
+
+    Windows has no symlink without elevation or Developer Mode, so the shim is a
+    `.cmd`, not a link. The PATH append deliberately avoids two traps:
+
+      * `setx` truncates at 1024 characters, and `setx PATH "%PATH%;..."` writes
+        the MERGED machine+user PATH into the user PATH.
+      * a bare [Environment]::SetEnvironmentVariable(..., 'User') rewrites a
+        REG_EXPAND_SZ PATH as REG_SZ with %USERPROFILE% and friends EXPANDED,
+        permanently. So the value is read unexpanded and written back with the
+        registry kind it already had.
+
+    Mirrors src-tauri/windows/add-user-path.ps1, which the app's own Settings
+    screen runs. Issue: https://github.com/jonassaa/platypusgit/issues/144
+
+.PARAMETER App
+    The platypusgit.exe to point `pgit` at. Auto-detected when omitted.
+
+.PARAMETER BinDir
+    Where to write pgit.cmd. Defaults to %LOCALAPPDATA%\PlatypusGit\bin.
+
+.PARAMETER DryRun
+    Print what would happen and change nothing.
+#>
+[CmdletBinding()]
+param(
+    [string] $App = $env:PLATYPUSGIT_APP,
+    [string] $BinDir = $env:PGIT_BIN_DIR,
+    [switch] $DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$BinaryName = 'platypusgit'
+$ExeName = "$BinaryName.exe"
+$ShimName = 'pgit.cmd'
+$MaxShimBytes = 4096
+
+# ─── pure helpers (exercised by the repo's verification, off Windows) ─────────
+
+function Get-ShimBody {
+    # Matches cli.rs::shim_cmd_body. %* forwards every argument; the release
+    # binary is windows_subsystem = "windows", so cmd does not block on it.
+    param([Parameter(Mandatory = $true)] [string] $ExePath)
+    return "@echo off`r`n`"$ExePath`" %*`r`n"
+}
+
+function Get-UpdatedPath {
+    # The new PATH string, or $null when $Dir is already in it.
+    param(
+        [AllowEmptyString()] [AllowNull()] [string] $Current,
+        [Parameter(Mandatory = $true)] [string] $Dir
+    )
+
+    $needle = $Dir.Trim().Trim('"').TrimEnd('\', '/')
+    if ([string]::IsNullOrWhiteSpace($needle)) { throw 'Refusing to add an empty PATH entry' }
+
+    $parts = @()
+    if (-not [string]::IsNullOrEmpty($Current)) { $parts = @($Current -split ';') }
+
+    foreach ($part in $parts) {
+        if ($part.Trim().Trim('"').TrimEnd('\', '/') -ieq $needle) { return $null }
+    }
+
+    $kept = @($parts | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    return (@($kept) + $needle) -join ';'
+}
+
+function Test-ReferencesApp {
+    # The same probe cli.rs and install-pgit.sh use: a small wrapper naming our
+    # binary. Windows has no symlink case worth handling here.
+    param([Parameter(Mandatory = $true)] [string] $Path)
+
+    try {
+        $item = Get-Item -LiteralPath $Path -ErrorAction Stop
+    } catch {
+        return $false
+    }
+    if ($item.PSIsContainer -or $item.Length -gt $MaxShimBytes) { return $false }
+    try {
+        return (Get-Content -LiteralPath $Path -Raw -ErrorAction Stop) -match [regex]::Escape($BinaryName)
+    } catch {
+        return $false
+    }
+}
+
+# ─── locate the app ──────────────────────────────────────────────────────────
+
+function Find-App {
+    $candidates = New-Object System.Collections.Generic.List[string]
+
+    # The MSI records its install directory; DisplayName is matched rather than
+    # a manufacturer key, which tauri derives from the bundle identifier.
+    $uninstallRoots = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*',
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*',
+        'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*'
+    )
+    foreach ($root in $uninstallRoots) {
+        try {
+            Get-ItemProperty -Path $root -ErrorAction SilentlyContinue |
+                Where-Object { $_.DisplayName -like 'PlatypusGit*' -and $_.InstallLocation } |
+                ForEach-Object { $candidates.Add((Join-Path $_.InstallLocation $ExeName)) }
+        } catch { }
+    }
+
+    foreach ($base in @($env:ProgramFiles, ${env:ProgramFiles(x86)}, $env:LOCALAPPDATA)) {
+        if ($base) { $candidates.Add((Join-Path $base "PlatypusGit\$ExeName")) }
+    }
+
+    foreach ($candidate in $candidates) {
+        if ($candidate -and (Test-Path -LiteralPath $candidate -PathType Leaf)) { return $candidate }
+    }
+
+    $onPath = Get-Command $ExeName -ErrorAction SilentlyContinue
+    if ($onPath) { return $onPath.Source }
+    return $null
+}
+
+if ([string]::IsNullOrWhiteSpace($App)) { $App = Find-App }
+if ([string]::IsNullOrWhiteSpace($App)) {
+    throw "Cannot find $ExeName — install PlatypusGit first, or pass -App <path>."
+}
+if (-not (Test-Path -LiteralPath $App -PathType Leaf)) { throw "$App does not exist." }
+$App = (Resolve-Path -LiteralPath $App).Path
+
+# ─── is a `pgit` already here? ───────────────────────────────────────────────
+
+$existing = Get-Command 'pgit' -ErrorAction SilentlyContinue
+if ($existing -and (Test-ReferencesApp $existing.Source)) {
+    Write-Host "pgit is already installed at $($existing.Source) — nothing to do."
+    Write-Host "It runs: $App"
+    return
+}
+if ($existing) {
+    Write-Warning "A different 'pgit' is already on your PATH at $($existing.Source)."
+    Write-Warning 'It will not be touched; ours goes in its own directory below.'
+}
+
+# ─── write the shim ──────────────────────────────────────────────────────────
+
+if ([string]::IsNullOrWhiteSpace($BinDir)) {
+    if (-not $env:LOCALAPPDATA) { throw 'LOCALAPPDATA is not set — pass -BinDir <path>.' }
+    $BinDir = Join-Path $env:LOCALAPPDATA 'PlatypusGit\bin'
+}
+
+$shimPath = Join-Path $BinDir $ShimName
+$body = Get-ShimBody -ExePath $App
+
+if ($DryRun) {
+    Write-Host "would write: $shimPath"
+    Write-Host "would run:   $App"
+    Write-Host "would add to your user PATH: $BinDir"
+    return
+}
+
+New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+# No BOM: cmd.exe treats a UTF-8 BOM as part of the first command.
+[System.IO.File]::WriteAllText($shimPath, $body, (New-Object System.Text.UTF8Encoding $false))
+Write-Host "Installed: $shimPath -> $App"
+
+# ─── put it on the user's PATH ───────────────────────────────────────────────
+
+function Send-EnvironmentChange {
+    $signature = @'
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+'@
+    try {
+        $native = Add-Type -MemberDefinition $signature -Name 'PgitInstallNative' -Namespace 'PlatypusGit' -PassThru
+        $unused = [UIntPtr]::Zero
+        # HWND_BROADCAST, WM_SETTINGCHANGE, SMTO_ABORTIFHUNG, 5s.
+        [void] $native::SendMessageTimeout([IntPtr] 0xffff, 0x1A, [UIntPtr]::Zero, 'Environment', 2, 5000, [ref] $unused)
+    } catch {
+        Write-Verbose "PATH broadcast failed: $_"
+    }
+}
+
+function Add-UserPathEntry {
+    param([Parameter(Mandatory = $true)] [string] $Dir)
+
+    $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
+    if ($null -eq $key) { throw 'Cannot open HKCU\Environment for writing.' }
+    try {
+        $kind = [Microsoft.Win32.RegistryValueKind]::ExpandString
+        try { $kind = $key.GetValueKind('Path') } catch { }
+
+        $current = [string] $key.GetValue(
+            'Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+
+        $updated = Get-UpdatedPath -Current $current -Dir $Dir
+        if ($null -eq $updated) { return 'already-present' }
+
+        $key.SetValue('Path', $updated, $kind)
+        return 'added'
+    } finally {
+        $key.Dispose()
+    }
+}
+
+try {
+    $outcome = Add-UserPathEntry -Dir $BinDir
+    if ($outcome -eq 'added') {
+        Send-EnvironmentChange
+        Write-Host "Added $BinDir to your user PATH. Open a new terminal, then: pgit --help"
+    } else {
+        Write-Host "$BinDir is already on your user PATH. Run: pgit --help"
+    }
+} catch {
+    # The shim exists either way — a failed PATH write is not a failed install.
+    Write-Warning "Could not update your PATH: $_"
+    Write-Warning "Add this directory to your PATH yourself: $BinDir"
+}

--- a/scripts/install-pgit.sh
+++ b/scripts/install-pgit.sh
@@ -1,0 +1,238 @@
+#!/bin/sh
+# Install the `pgit` CLI for an already-installed platypusgit (macOS + Linux).
+#
+# For the channels that give us no install hook: the macOS .dmg (a drag-install
+# runs no code) and the Linux AppImage (self-contained, never installed).
+# Homebrew, the .deb and the .msi already ship `pgit` — this script recognises
+# that and refuses to write a second one.
+#
+#   curl -fsSL https://platypusgit.com/install-pgit.sh | sh
+#
+# Safe under `curl | sh` by construction: POSIX sh, `set -eu`, and it NEVER
+# reads stdin — stdin is the script itself, so there are no prompts and every
+# choice is a flag or an environment variable.
+#
+# Issue: https://github.com/jonassaa/platypusgit/issues/144
+set -eu
+
+BINARY_NAME=platypusgit
+SHIM_NAME=pgit
+MAX_SHIM_BYTES=4096
+
+APP="${PLATYPUSGIT_APP:-}"
+BIN_DIR="${PGIT_BIN_DIR:-}"
+DRY_RUN=no
+
+# Test seams. Three of the five install channels cannot be exercised on a
+# developer's own machine, so the app search is parameterised rather than left
+# unverifiable: the repo's harness points these at a fixture tree and drives the
+# real detection for both platforms. Same idea as PGIT_POSTINST_PREFIX in
+# src-tauri/deb/postinst. Nothing in normal use sets either.
+SEARCH_ROOT="${PGIT_APP_SEARCH_ROOT:-}"
+# A failing `uname` must not abort the script under `set -e`; an unknown
+# system falls through to the Linux/other search list.
+UNAME_S="${PGIT_UNAME:-$(uname -s 2>/dev/null || echo unknown)}"
+
+usage() {
+    cat <<'USAGE'
+Usage: install-pgit.sh [options]
+
+Links the `pgit` command to an installed platypusgit. Prefers a directory you
+already own, so it never needs sudo.
+
+Options:
+  --app PATH       the platypusgit executable (or .AppImage) to link to
+  --bin-dir DIR    where to put `pgit`
+  --dry-run        print what would happen and change nothing
+  -h, --help       this text
+
+Environment:
+  PLATYPUSGIT_APP  same as --app
+  PGIT_BIN_DIR     same as --bin-dir
+
+Homebrew, the .deb and the .msi install `pgit` themselves; this script detects
+an existing one and exits without touching it.
+USAGE
+}
+
+say() { printf '%s\n' "$*"; }
+warn() { printf '%s\n' "$*" >&2; }
+die() {
+    warn "install-pgit: $*"
+    exit 1
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --app)
+            [ $# -ge 2 ] || die "--app needs a path"
+            APP="$2"
+            shift 2
+            ;;
+        --app=*) APP="${1#--app=}"; shift ;;
+        --bin-dir)
+            [ $# -ge 2 ] || die "--bin-dir needs a path"
+            BIN_DIR="$2"
+            shift 2
+            ;;
+        --bin-dir=*) BIN_DIR="${1#--bin-dir=}"; shift ;;
+        --dry-run) DRY_RUN=yes; shift ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *) die "unknown option: $1 (try --help)" ;;
+    esac
+done
+
+# ─── locate the app ──────────────────────────────────────────────────────────
+
+candidate_apps() {
+    case "$UNAME_S" in
+        Darwin)
+            printf '%s\n' \
+                "$SEARCH_ROOT/Applications/PlatypusGit.app/Contents/MacOS/$BINARY_NAME" \
+                "${HOME:-}/Applications/PlatypusGit.app/Contents/MacOS/$BINARY_NAME"
+            ;;
+        *)
+            printf '%s\n' \
+                "$SEARCH_ROOT/usr/bin/$BINARY_NAME" \
+                "$SEARCH_ROOT/usr/local/bin/$BINARY_NAME" \
+                "$SEARCH_ROOT/opt/$BINARY_NAME/$BINARY_NAME"
+            # Set only inside a running AppImage, but free to honour.
+            if [ -n "${APPIMAGE:-}" ]; then
+                printf '%s\n' "$APPIMAGE"
+            fi
+            ;;
+    esac
+}
+
+find_app() {
+    # The `while` is on the right of a pipe, so it runs in a subshell and its
+    # `break` cannot reach this function — capture its output instead.
+    _found="$(candidate_apps | while IFS= read -r candidate; do
+        if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+            printf '%s\n' "$candidate"
+            break
+        fi
+    done)"
+    if [ -n "$_found" ]; then
+        printf '%s\n' "$_found"
+        return 0
+    fi
+    command -v "$BINARY_NAME" 2>/dev/null || true
+}
+
+if [ -z "$APP" ]; then
+    APP="$(find_app)"
+fi
+[ -n "$APP" ] || die "cannot find platypusgit — install the app first, or pass --app PATH"
+[ -x "$APP" ] || die "$APP is not an executable"
+
+# ─── is a `pgit` already here, and is it ours? ───────────────────────────────
+
+# Same three probes cli.rs uses: a symlink to the app, a symlink named after the
+# binary, or a small wrapper script mentioning the binary.
+references_app() {
+    _path="$1"
+    if [ -L "$_path" ]; then
+        _target="$(readlink "$_path")"
+        case "$_target" in
+            "$APP") return 0 ;;
+        esac
+        case "$(basename "$_target")" in
+            "$BINARY_NAME" | "$BINARY_NAME".*) return 0 ;;
+        esac
+    fi
+    if [ -f "$_path" ] && [ ! -L "$_path" ]; then
+        _size="$(wc -c <"$_path" 2>/dev/null || echo 0)"
+        if [ "$_size" -le "$MAX_SHIM_BYTES" ] && grep -q "$BINARY_NAME" "$_path" 2>/dev/null; then
+            return 0
+        fi
+    fi
+    return 1
+}
+
+existing="$(command -v "$SHIM_NAME" 2>/dev/null || true)"
+if [ -n "$existing" ] && references_app "$existing"; then
+    say "pgit is already installed at $existing — nothing to do."
+    say "It runs: $APP"
+    exit 0
+fi
+if [ -n "$existing" ]; then
+    warn "install-pgit: a different '$SHIM_NAME' is already on your PATH at $existing."
+    warn "install-pgit: it will not be touched; ours goes in its own directory below."
+fi
+
+# ─── pick a directory ────────────────────────────────────────────────────────
+
+on_path() {
+    case ":${PATH}:" in
+        *":$1:"*) return 0 ;;
+    esac
+    return 1
+}
+
+usable_dir() {
+    # Creating it IS the writability test — a separate probe would only add a
+    # race between probe and write.
+    [ -d "$1" ] || mkdir -p "$1" 2>/dev/null || return 1
+    [ -w "$1" ] || return 1
+    return 0
+}
+
+candidate_dirs() {
+    printf '%s\n' "${HOME:-}/.local/bin" "${HOME:-}/bin" "/usr/local/bin"
+}
+
+if [ -n "$BIN_DIR" ]; then
+    usable_dir "$BIN_DIR" || die "cannot write to $BIN_DIR"
+else
+    # Among the writable ones, prefer a directory already on PATH. A here-doc
+    # (not a pipe) feeds the loop, so the assignment lands in THIS shell.
+    for pass in on-path any; do
+        while IFS= read -r dir; do
+            [ -n "$dir" ] || continue
+            # A relative candidate means $HOME was unset; skip rather than
+            # creating ./.local/bin wherever the user happened to be.
+            case "$dir" in /*) ;; *) continue ;; esac
+            if [ "$pass" = on-path ] && ! on_path "$dir"; then
+                continue
+            fi
+            if usable_dir "$dir"; then
+                BIN_DIR="$dir"
+                break
+            fi
+        done <<EOF
+$(candidate_dirs)
+EOF
+        if [ -n "$BIN_DIR" ]; then
+            break
+        fi
+    done
+fi
+[ -n "$BIN_DIR" ] || die "no writable directory found for $SHIM_NAME (try --bin-dir DIR)"
+
+TARGET="$BIN_DIR/$SHIM_NAME"
+
+if [ "$DRY_RUN" = yes ]; then
+    say "would link: $TARGET -> $APP"
+    if on_path "$BIN_DIR"; then
+        say "$BIN_DIR is on your PATH."
+    else
+        say "$BIN_DIR is NOT on your PATH."
+    fi
+    exit 0
+fi
+
+rm -f "$TARGET"
+ln -s "$APP" "$TARGET"
+say "Installed: $TARGET -> $APP"
+
+if on_path "$BIN_DIR"; then
+    say "Run it with: $SHIM_NAME --help"
+else
+    say ""
+    say "$BIN_DIR is not on your PATH. Add it, then reopen your shell:"
+    say "  echo 'export PATH=\"$BIN_DIR:\$PATH\"' >> ~/.zshrc   # or ~/.bashrc"
+fi

--- a/src-tauri/deb/pgit
+++ b/src-tauri/deb/pgit
@@ -1,0 +1,13 @@
+#!/bin/sh
+# The `pgit` CLI, as shipped by the platypusgit .deb (#144).
+#
+# Installed at /usr/bin/pgit via `bundle.linux.deb.files`, so dpkg tracks it and
+# `apt remove` deletes it. A symlink is not an option: the bundler copies
+# `deb.files` with std::fs::copy, which FOLLOWS symlinks and would embed a
+# second copy of the binary in the package.
+#
+# The target is spelled absolutely rather than derived from `dirname "$0"`
+# because cli.rs's shim classifier greps this file for the binary name to tell a
+# package-managed pgit from a self-installed one. dpkg installs it at exactly
+# one path anyway.
+exec /usr/bin/platypusgit "$@"

--- a/src-tauri/deb/postinst
+++ b/src-tauri/deb/postinst
@@ -1,0 +1,32 @@
+#!/bin/sh
+# platypusgit .deb postinst (#144). One job: make sure /usr/bin/pgit is
+# executable.
+#
+# It should already be. The chain was read in the bundler rather than assumed:
+# the wrapper is committed 100755, `fs_utils::copy_file` is std::fs::copy (which
+# copies permission bits), and debian.rs builds data.tar with
+# `HeaderMode::Deterministic`, whose Unix branch is
+#   if meta.is_dir() || (0o100 & meta.mode() == 0o100) { 0o755 } else { 0o644 }
+# — i.e. it propagates the user execute bit rather than flattening to 0644.
+#
+# This file is the belt for that brace, because none of it is observable without
+# building a .deb on Linux. It is deliberately tiny: a postinst that exits
+# non-zero fails `dpkg -i` for the WHOLE package, so its blast radius is every
+# Linux install. It touches one path, only when that path exists and lacks the
+# bit, and it does nothing at all for any argument other than `configure`.
+#
+# PGIT_POSTINST_PREFIX exists so the logic can be exercised against a fixture on
+# a machine that cannot build a .deb. dpkg never sets it.
+set -e
+
+if [ "${1:-configure}" != "configure" ]; then
+    exit 0
+fi
+
+shim="${PGIT_POSTINST_PREFIX:-}/usr/bin/pgit"
+
+if [ -f "$shim" ] && [ ! -x "$shim" ]; then
+    chmod 0755 "$shim"
+fi
+
+exit 0

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -164,12 +164,75 @@ pub fn resolve_repo_root(intent: LaunchIntent) -> LaunchIntent {
     LaunchIntent { path, ..intent }
 }
 
+// ─── the `pgit` shim: who owns it (#144) ─────────────────────────────────────
+//
+// Three parties can put a `pgit` on the user's PATH — a package (Homebrew cask,
+// `.deb`, `.msi`), this app's Settings screen, and somebody else — and they must
+// not fight. `shim_status` therefore answers "is `pgit` present and does it
+// launch THIS app", not "is <one dir>/pgit a symlink to me", and `install_shim`
+// refuses to write a second copy when a package already ships one. See
+// `docs/superpowers/specs/2026-08-17-pgit-cli-packaging-spec.md` §A.
+
+/// The file name a `pgit` entry point has. Windows has no symlink without
+/// elevation or Developer Mode, so the shim is a `.cmd` there and a symlink
+/// everywhere else — which is also why `install_shim_at` has two `cfg`
+/// implementations rather than one with a branch inside it.
+#[cfg(windows)]
+pub const SHIM_NAME: &str = "pgit.cmd";
+#[cfg(not(windows))]
+pub const SHIM_NAME: &str = "pgit";
+
+/// The app binary's name, as every channel installs it. Taken from Cargo rather
+/// than written out: the classifier greps for it, so a drift here would silently
+/// stop recognising a package-managed shim.
+pub const MAIN_BINARY: &str = env!("CARGO_PKG_NAME");
+
+/// A shim file that is text (a wrapper script) is read to see whether it names
+/// our binary. Capped, and non-UTF-8 reads as "no" — this must never become a
+/// reason to slurp an arbitrary file found on PATH.
+const MAX_SHIM_TEXT: u64 = 4096;
+
+/// Who put the `pgit` we found there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CliShimSource {
+    /// Nothing found.
+    None,
+    /// One of *our* shim dirs, referencing this app. Settings offers Reinstall.
+    App,
+    /// Outside our dirs, referencing this app — a package manager or installer
+    /// owns the file. Settings offers no install, and `install_shim` is a no-op
+    /// success, so the contract holds even for a caller that forgets.
+    Package,
+    /// A `pgit` exists but does not launch this app. We never touch it.
+    Foreign,
+}
+
+/// Whether the directory holding (or about to hold) the shim is reachable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CliPathState {
+    /// On the PATH this process sees.
+    OnPath,
+    /// Not on it, and nothing was done about that.
+    OffPath,
+    /// Just added to the user's persistent PATH; already-open shells still need
+    /// a restart. Only ever produced by an install, never by a status read.
+    PathAdded,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CliShimStatus {
+    /// `pgit` is present and launches this app — `App` or `Package`.
     pub installed: bool,
+    /// The shim we found, or (when none was) where an install would put one.
     pub shim_path: String,
     pub target: String,
+    pub source: CliShimSource,
+    /// For `App`/`Package`, the found shim's directory. For `Foreign`/`None`,
+    /// the directory an install would target.
+    pub path_state: CliPathState,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -177,31 +240,234 @@ pub struct CliShimStatus {
 pub struct CliInstallOutcome {
     pub installed: bool,
     pub path: String,
-    /// Set when we couldn't write the symlink (permissions): the command the
+    /// Set when we couldn't write the shim at all (permissions): the command the
     /// user should run themselves. Not an error — Settings renders it.
     pub manual_command: Option<String>,
+    pub path_state: CliPathState,
 }
 
-/// Where the `pgit` shim goes. None on unsupported platforms (Windows).
-pub fn default_shim_dir() -> Option<PathBuf> {
-    #[cfg(target_os = "macos")]
-    {
-        Some(PathBuf::from("/usr/local/bin"))
+/// The OS whose shim-directory table applies. Explicit rather than `cfg!` at the
+/// point of use so all three tables are testable from any host — two of the
+/// three cannot otherwise be exercised at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShimOs {
+    Macos,
+    Linux,
+    Windows,
+    Other,
+}
+
+pub const CURRENT_SHIM_OS: ShimOs = if cfg!(target_os = "macos") {
+    ShimOs::Macos
+} else if cfg!(target_os = "linux") {
+    ShimOs::Linux
+} else if cfg!(windows) {
+    ShimOs::Windows
+} else {
+    ShimOs::Other
+};
+
+/// Directories the app itself may write the shim into, most preferred first.
+///
+/// macOS leads with `/usr/local/bin` because it is the only entry on the default
+/// PATH and where every existing install already is — but it is *tried*, not
+/// assumed: `install_shim` walks this list and takes the first one it can write,
+/// so a machine where it is root-owned (any stock Apple Silicon Mac) falls
+/// through to `~/.local/bin` with no sudo. That fallback is usually off PATH,
+/// which is reported rather than hidden.
+pub fn shim_dirs_for(
+    os: ShimOs,
+    home: Option<&Path>,
+    local_app_data: Option<&Path>,
+) -> Vec<PathBuf> {
+    match os {
+        ShimOs::Macos => {
+            let mut dirs = vec![PathBuf::from("/usr/local/bin")];
+            if let Some(home) = home {
+                dirs.push(home.join(".local/bin"));
+                dirs.push(home.join("bin"));
+            }
+            dirs
+        }
+        ShimOs::Linux | ShimOs::Other => home
+            .map(|home| vec![home.join(".local/bin"), home.join("bin")])
+            .unwrap_or_default(),
+        // Per-user, no admin, and the directory `add_user_path` appends.
+        ShimOs::Windows => local_app_data
+            .map(|dir| vec![dir.join("PlatypusGit").join("bin")])
+            .unwrap_or_default(),
     }
-    #[cfg(target_os = "linux")]
-    {
-        std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/bin"))
+}
+
+/// Paths a package or installer owns. We never write these, only recognise them.
+///
+/// `exe_dir` covers the MSI (`<INSTALLDIR>\pgit.cmd`) and is probed directly
+/// rather than via PATH, because the MSI's machine-PATH entry may not have
+/// reached this process's environment yet.
+pub fn package_shim_paths_for(os: ShimOs, exe_dir: Option<&Path>) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(dir) = exe_dir {
+        paths.push(dir.join(SHIM_NAME));
     }
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-    {
+    if matches!(os, ShimOs::Linux | ShimOs::Other) {
+        paths.push(PathBuf::from("/usr/bin").join(SHIM_NAME));
+    }
+    paths
+}
+
+/// PATH entries in order, empty entries dropped (an empty entry means "cwd",
+/// which is never where a shim lives and would make the scan order nonsense).
+pub fn path_dirs(path_var: Option<&std::ffi::OsStr>) -> Vec<PathBuf> {
+    match path_var {
+        Some(value) => std::env::split_paths(value)
+            .filter(|p| !p.as_os_str().is_empty())
+            .collect(),
+        None => Vec::new(),
+    }
+}
+
+/// Every place to look, in the order it is looked at: our own dirs, then known
+/// package paths, then PATH. Ours comes first because "did *we* install this" is
+/// what the Reinstall button depends on; what a shell would actually run is
+/// reported separately as `path_state` rather than by reordering this.
+pub fn shim_scan_order(
+    app_dirs: &[PathBuf],
+    package_paths: &[PathBuf],
+    path_dirs: &[PathBuf],
+) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    let push = |out: &mut Vec<PathBuf>, candidate: PathBuf| {
+        if !out.contains(&candidate) {
+            out.push(candidate);
+        }
+    };
+    for dir in app_dirs {
+        push(&mut out, dir.join(SHIM_NAME));
+    }
+    for path in package_paths {
+        push(&mut out, path.clone());
+    }
+    for dir in path_dirs {
+        push(&mut out, dir.join(SHIM_NAME));
+    }
+    out
+}
+
+/// Does this shim launch our app? Three probes, because the three channels ship
+/// three different kinds of file: a symlink to us (self-install, Homebrew cask),
+/// a symlink whose name is our binary (a cask symlink surviving an app move),
+/// and a wrapper script mentioning our binary (the deb wrapper, the MSI `.cmd`).
+pub fn references_app(
+    link: Option<&Path>,
+    text: Option<&str>,
+    exe: &Path,
+    main_binary: &str,
+) -> bool {
+    if let Some(link) = link {
+        if link == exe {
+            return true;
+        }
+        if link
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .is_some_and(|stem| stem.eq_ignore_ascii_case(main_binary))
+        {
+            return true;
+        }
+    }
+    text.is_some_and(|text| text.contains(main_binary))
+}
+
+/// `App` when the shim sits in a directory we write, `Package` when it launches
+/// us from anywhere else, `Foreign` when it does not launch us at all.
+pub fn classify_sighting(
+    path: &Path,
+    app_dirs: &[PathBuf],
+    link: Option<&Path>,
+    text: Option<&str>,
+    exe: &Path,
+    main_binary: &str,
+) -> CliShimSource {
+    if !references_app(link, text, exe, main_binary) {
+        return CliShimSource::Foreign;
+    }
+    let ours = path
+        .parent()
+        .is_some_and(|parent| app_dirs.iter().any(|dir| dir == parent));
+    if ours {
+        CliShimSource::App
+    } else {
+        CliShimSource::Package
+    }
+}
+
+/// Exact directory match, never a prefix: `/usr/local/binaries` is not
+/// `/usr/local/bin`.
+pub fn dir_on_path(dir: &Path, path_dirs: &[PathBuf]) -> CliPathState {
+    if path_dirs.iter().any(|entry| entry == dir) {
+        CliPathState::OnPath
+    } else {
+        CliPathState::OffPath
+    }
+}
+
+/// What we could read about a shim file. `None` means "nothing is there".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShimSighting {
+    pub path: PathBuf,
+    /// Symlink target, absolutised against the link's own directory (a relative
+    /// symlink would otherwise never compare equal to `current_exe()`).
+    pub link: Option<PathBuf>,
+    pub text: Option<String>,
+}
+
+fn probe_shim(path: &Path) -> Option<ShimSighting> {
+    let meta = std::fs::symlink_metadata(path).ok()?;
+    if meta.file_type().is_symlink() {
+        let link = std::fs::read_link(path).ok().map(|target| {
+            if target.is_absolute() {
+                target
+            } else {
+                path.parent().map(|dir| dir.join(&target)).unwrap_or(target)
+            }
+        });
+        return Some(ShimSighting {
+            path: path.to_path_buf(),
+            link,
+            text: None,
+        });
+    }
+    let text = if meta.is_file() && meta.len() <= MAX_SHIM_TEXT {
+        std::fs::read(path)
+            .ok()
+            .and_then(|bytes| String::from_utf8(bytes).ok())
+    } else {
         None
-    }
+    };
+    Some(ShimSighting {
+        path: path.to_path_buf(),
+        link: None,
+        text,
+    })
+}
+
+/// Directories this app may write the shim into, for the running platform.
+pub fn app_shim_dirs() -> Vec<PathBuf> {
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from);
+    let local_app_data = std::env::var_os("LOCALAPPDATA").map(PathBuf::from);
+    shim_dirs_for(CURRENT_SHIM_OS, home.as_deref(), local_app_data.as_deref())
+}
+
+fn current_path_dirs() -> Vec<PathBuf> {
+    path_dirs(std::env::var_os("PATH").as_deref())
 }
 
 #[cfg(unix)]
 pub fn install_shim_at(dir: &Path, exe: &Path) -> std::io::Result<PathBuf> {
     std::fs::create_dir_all(dir)?;
-    let link = dir.join("pgit");
+    let link = dir.join(SHIM_NAME);
     if link.symlink_metadata().is_ok() {
         std::fs::remove_file(&link)?;
     }
@@ -209,75 +475,228 @@ pub fn install_shim_at(dir: &Path, exe: &Path) -> std::io::Result<PathBuf> {
     Ok(link)
 }
 
+/// The `pgit.cmd` body. Pure, and deliberately not `cfg`-gated so it is testable
+/// on any host.
+pub fn shim_cmd_body(exe: &Path) -> String {
+    format!("@echo off\r\n\"{}\" %*\r\n", exe.display())
+}
+
+#[cfg(windows)]
+pub fn install_shim_at(dir: &Path, exe: &Path) -> std::io::Result<PathBuf> {
+    std::fs::create_dir_all(dir)?;
+    let shim = dir.join(SHIM_NAME);
+    std::fs::write(&shim, shim_cmd_body(exe))?;
+    Ok(shim)
+}
+
 #[cfg(unix)]
 pub fn shim_installed_at(dir: &Path, exe: &Path) -> bool {
-    std::fs::read_link(dir.join("pgit"))
+    std::fs::read_link(dir.join(SHIM_NAME))
         .map(|target| target == exe)
         .unwrap_or(false)
 }
 
+#[cfg(windows)]
+pub fn shim_installed_at(dir: &Path, exe: &Path) -> bool {
+    std::fs::read_to_string(dir.join(SHIM_NAME))
+        .map(|body| body == shim_cmd_body(exe))
+        .unwrap_or(false)
+}
+
+/// The PATH-appending half of a Windows install. See the script's own header for
+/// why it is PowerShell and not `setx` or a bare
+/// `[Environment]::SetEnvironmentVariable`.
+pub const WINDOWS_PATH_SCRIPT: &str = include_str!("../windows/add-user-path.ps1");
+
+/// Append `dir` to the user's persistent PATH. Best effort: a failure means the
+/// file half still succeeded and the caller reports `OffPath`.
+#[cfg(windows)]
+fn add_user_path(dir: &Path) -> bool {
+    use std::io::Write;
+    use std::os::windows::process::CommandExt;
+    use std::process::{Command, Stdio};
+
+    // The directory travels in the environment, not argv: `-Command` takes a
+    // script, and a path is user-controlled text.
+    let child = Command::new("powershell.exe")
+        .args(["-NoProfile", "-NonInteractive", "-Command", "-"])
+        .env("PGIT_BIN_DIR", dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .creation_flags(0x0800_0000) // CREATE_NO_WINDOW — no console flash
+        .spawn();
+    let Ok(mut child) = child else {
+        return false;
+    };
+    if let Some(stdin) = child.stdin.as_mut() {
+        if stdin.write_all(WINDOWS_PATH_SCRIPT.as_bytes()).is_err() {
+            return false;
+        }
+    }
+    drop(child.stdin.take());
+    child.wait().map(|status| status.success()).unwrap_or(false)
+}
+
 pub fn shim_status() -> CliShimStatus {
     let exe = std::env::current_exe().unwrap_or_default();
-    let dir = default_shim_dir();
-    let shim_path = dir
+    let app_dirs = app_shim_dirs();
+    let package_paths = package_shim_paths_for(CURRENT_SHIM_OS, exe.parent());
+    let path_dirs = current_path_dirs();
+
+    let mut foreign: Option<PathBuf> = None;
+    for candidate in shim_scan_order(&app_dirs, &package_paths, &path_dirs) {
+        let Some(sighting) = probe_shim(&candidate) else {
+            continue;
+        };
+        match classify_sighting(
+            &sighting.path,
+            &app_dirs,
+            sighting.link.as_deref(),
+            sighting.text.as_deref(),
+            &exe,
+            MAIN_BINARY,
+        ) {
+            source @ (CliShimSource::App | CliShimSource::Package) => {
+                let path_state = sighting
+                    .path
+                    .parent()
+                    .map(|dir| dir_on_path(dir, &path_dirs))
+                    .unwrap_or(CliPathState::OffPath);
+                return CliShimStatus {
+                    installed: true,
+                    shim_path: sighting.path.display().to_string(),
+                    target: exe.display().to_string(),
+                    source,
+                    path_state,
+                };
+            }
+            // Remember the first stranger but keep looking: ours may be further
+            // down the order.
+            CliShimSource::Foreign => foreign = foreign.or(Some(sighting.path)),
+            CliShimSource::None => {}
+        }
+    }
+
+    // Nothing of ours. Report where an install would go, so Settings can warn
+    // about an off-PATH target before the click rather than after it.
+    let target_dir = app_dirs.first().cloned();
+    let path_state = target_dir
         .as_deref()
-        .map(|d| d.join("pgit").display().to_string())
-        .unwrap_or_default();
-    #[cfg(unix)]
-    let installed = dir.as_deref().is_some_and(|d| shim_installed_at(d, &exe));
-    #[cfg(not(unix))]
-    let installed = false;
+        .map(|dir| dir_on_path(dir, &path_dirs))
+        .unwrap_or(CliPathState::OffPath);
+    let (shim_path, source) = match foreign {
+        Some(path) => (path, CliShimSource::Foreign),
+        None => (
+            target_dir.map(|dir| dir.join(SHIM_NAME)).unwrap_or_default(),
+            CliShimSource::None,
+        ),
+    };
     CliShimStatus {
-        installed,
-        shim_path,
+        installed: false,
+        shim_path: shim_path.display().to_string(),
         target: exe.display().to_string(),
+        source,
+        path_state,
+    }
+}
+
+/// What an install should do about a `pgit` that is already there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallPlan {
+    /// Report the existing shim and touch nothing.
+    KeepExisting,
+    /// Write our own shim.
+    Write,
+}
+
+/// The install decision, pure — so "a package-managed `pgit` is never
+/// overwritten" is testable without a filesystem or a real installation.
+///
+/// `existing_matches_exe` only matters for `App`: on an Intel Mac Homebrew's
+/// prefix IS `/usr/local/bin`, which is also our first shim dir, so a cask
+/// symlink classifies `App`. Skipping the rewrite when the link already points
+/// at us is what keeps Reinstall from touching a brew-managed link.
+pub fn plan_install(source: CliShimSource, existing_matches_exe: bool) -> InstallPlan {
+    match source {
+        CliShimSource::Package => InstallPlan::KeepExisting,
+        CliShimSource::App if existing_matches_exe => InstallPlan::KeepExisting,
+        _ => InstallPlan::Write,
     }
 }
 
 pub fn install_shim() -> CliInstallOutcome {
-    // Without our own path there's nothing to point the shim at — report
-    // not-installed rather than linking an empty path and claiming success.
-    let Ok(exe) = std::env::current_exe() else {
+    let status = shim_status();
+
+    // Without our own path there's nothing to point the shim at — but a package
+    // shim needs no path of ours, so answer that first.
+    let exe = std::env::current_exe().ok();
+    let existing_matches_exe = exe.as_deref().is_some_and(|exe| {
+        Path::new(&status.shim_path)
+            .parent()
+            .is_some_and(|dir| shim_installed_at(dir, exe))
+    });
+
+    if plan_install(status.source, existing_matches_exe) == InstallPlan::KeepExisting {
+        return CliInstallOutcome {
+            installed: true,
+            path: status.shim_path,
+            manual_command: None,
+            path_state: status.path_state,
+        };
+    }
+
+    let Some(exe) = exe else {
         return CliInstallOutcome {
             installed: false,
             path: String::new(),
             manual_command: None,
+            path_state: CliPathState::OffPath,
         };
     };
-    let Some(dir) = default_shim_dir() else {
-        return CliInstallOutcome {
-            installed: false,
-            path: String::new(),
-            manual_command: None,
-        };
-    };
-    let link_display = dir.join("pgit").display().to_string();
-    #[cfg(unix)]
-    {
-        match install_shim_at(&dir, &exe) {
-            Ok(link) => CliInstallOutcome {
+
+    let dirs = app_shim_dirs();
+    let path_dirs = current_path_dirs();
+    for dir in &dirs {
+        // Attempting the write IS the writability test — a separate probe would
+        // only add a TOCTOU between probe and write.
+        if let Ok(shim) = install_shim_at(dir, &exe) {
+            #[allow(unused_mut)]
+            let mut path_state = dir_on_path(dir, &path_dirs);
+            #[cfg(windows)]
+            if path_state == CliPathState::OffPath && add_user_path(dir) {
+                path_state = CliPathState::PathAdded;
+            }
+            return CliInstallOutcome {
                 installed: true,
-                path: link.display().to_string(),
+                path: shim.display().to_string(),
                 manual_command: None,
-            },
-            Err(_) => CliInstallOutcome {
-                installed: false,
-                path: link_display.clone(),
-                manual_command: Some(format!(
-                    "sudo ln -sf \"{}\" \"{}\"",
-                    exe.display(),
-                    link_display
-                )),
-            },
+                path_state,
+            };
         }
     }
-    #[cfg(not(unix))]
-    {
-        CliInstallOutcome {
-            installed: false,
-            path: link_display,
-            manual_command: None,
-        }
+
+    // Nothing writable anywhere. On unix that is now a genuine edge case (no
+    // `$HOME`), so the sudo line stays as the last resort it always was.
+    let fallback = dirs.first().map(|dir| dir.join(SHIM_NAME));
+    let path = fallback
+        .as_deref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+    let manual_command = if cfg!(unix) && !path.is_empty() {
+        Some(format!("sudo ln -sf \"{}\" \"{}\"", exe.display(), path))
+    } else {
+        None
+    };
+    let path_state = dirs
+        .first()
+        .map(|dir| dir_on_path(dir, &path_dirs))
+        .unwrap_or(CliPathState::OffPath);
+    CliInstallOutcome {
+        installed: false,
+        path,
+        manual_command,
+        path_state,
     }
 }
 
@@ -515,5 +934,313 @@ mod tests {
             ),
             Parsed::Askpass("Password -h for 'x': ".to_string())
         );
+    }
+    // ─── the ownership contract (#144) ───────────────────────────────────────
+    //
+    // Every table below is exercised for all three OSes from whatever host runs
+    // the suite: two of the three cannot be exercised any other way.
+
+    fn dirs(v: &[&str]) -> Vec<PathBuf> {
+        v.iter().map(PathBuf::from).collect()
+    }
+
+    #[test]
+    fn macos_prefers_usr_local_bin_then_falls_back_under_home() {
+        assert_eq!(
+            shim_dirs_for(ShimOs::Macos, Some(Path::new("/Users/ada")), None),
+            dirs(&["/usr/local/bin", "/Users/ada/.local/bin", "/Users/ada/bin"])
+        );
+    }
+
+    #[test]
+    fn macos_still_offers_usr_local_bin_without_a_home() {
+        assert_eq!(
+            shim_dirs_for(ShimOs::Macos, None, None),
+            dirs(&["/usr/local/bin"])
+        );
+    }
+
+    #[test]
+    fn linux_stays_under_home_and_never_names_a_root_owned_dir() {
+        let out = shim_dirs_for(ShimOs::Linux, Some(Path::new("/home/ada")), None);
+        assert_eq!(out, dirs(&["/home/ada/.local/bin", "/home/ada/bin"]));
+        assert!(
+            !out.iter().any(|d| d.starts_with("/usr")),
+            "a sudo-requiring dir must never be an app shim dir on Linux"
+        );
+    }
+
+    #[test]
+    fn windows_uses_a_per_user_dir_and_nothing_without_localappdata() {
+        // Compared against the same `join` the table uses: a host running this
+        // test joins with `/`, and the point of the assertion is the SHAPE
+        // (LOCALAPPDATA/PlatypusGit/bin, and never a Program Files path that
+        // would need admin), not the separator.
+        let local = Path::new("C:\\Users\\ada\\AppData\\Local");
+        assert_eq!(
+            shim_dirs_for(ShimOs::Windows, None, Some(local)),
+            vec![local.join("PlatypusGit").join("bin")]
+        );
+        assert!(shim_dirs_for(ShimOs::Windows, Some(Path::new("C:\\Users\\ada")), None).is_empty());
+    }
+
+    #[test]
+    fn package_paths_cover_the_deb_on_linux_and_the_install_dir_everywhere() {
+        let exe_dir = PathBuf::from("/opt/pg");
+        let linux = package_shim_paths_for(ShimOs::Linux, Some(&exe_dir));
+        assert!(linux.contains(&PathBuf::from("/usr/bin").join(SHIM_NAME)));
+        assert!(linux.contains(&exe_dir.join(SHIM_NAME)));
+        // macOS has no packaged path of its own — Homebrew's prefix varies by
+        // architecture, so it is found through PATH instead.
+        assert_eq!(
+            package_shim_paths_for(ShimOs::Macos, Some(&exe_dir)),
+            vec![exe_dir.join(SHIM_NAME)]
+        );
+        assert!(package_shim_paths_for(ShimOs::Macos, None).is_empty());
+    }
+
+    #[test]
+    fn path_dirs_drops_empty_entries() {
+        let joined = std::env::join_paths([Path::new("/a"), Path::new("/b")]).unwrap();
+        assert_eq!(path_dirs(Some(&joined)), dirs(&["/a", "/b"]));
+        assert!(path_dirs(None).is_empty());
+        // An empty entry means "cwd", which is never where a shim lives.
+        let sep = if cfg!(windows) { ";;" } else { "::" };
+        let raw = std::ffi::OsString::from(format!("/a{sep}/b"));
+        assert_eq!(path_dirs(Some(&raw)), dirs(&["/a", "/b"]));
+    }
+
+    #[test]
+    fn scan_order_is_ours_then_package_then_path_and_deduplicates() {
+        let app = dirs(&["/home/ada/.local/bin", "/home/ada/bin"]);
+        let pkg = dirs(&["/usr/bin/pgit"]);
+        let path = dirs(&["/usr/bin", "/home/ada/.local/bin"]);
+        let order = shim_scan_order(&app, &pkg, &path);
+        assert_eq!(
+            order,
+            vec![
+                PathBuf::from("/home/ada/.local/bin").join(SHIM_NAME),
+                PathBuf::from("/home/ada/bin").join(SHIM_NAME),
+                PathBuf::from("/usr/bin/pgit"),
+                PathBuf::from("/usr/bin").join(SHIM_NAME),
+            ]
+            .into_iter()
+            // On Windows `/usr/bin/pgit` and `/usr/bin/pgit.cmd` differ, on unix
+            // they collapse — assert the shape, not the platform's arithmetic.
+            .fold(Vec::new(), |mut acc: Vec<PathBuf>, p| {
+                if !acc.contains(&p) {
+                    acc.push(p);
+                }
+                acc
+            })
+        );
+    }
+
+    #[test]
+    fn a_symlink_to_us_in_our_own_dir_is_ours() {
+        let app = dirs(&["/home/ada/.local/bin"]);
+        let exe = Path::new("/opt/pg/platypusgit");
+        assert_eq!(
+            classify_sighting(
+                Path::new("/home/ada/.local/bin/pgit"),
+                &app,
+                Some(exe),
+                None,
+                exe,
+                "platypusgit"
+            ),
+            CliShimSource::App
+        );
+    }
+
+    #[test]
+    fn a_symlink_to_us_from_a_brew_prefix_is_package_managed() {
+        // The Homebrew cask's `binary` stanza symlinks the app binary into
+        // `$(brew --prefix)/bin`, which is not a dir we ever write.
+        let app = dirs(&["/usr/local/bin", "/Users/ada/.local/bin"]);
+        let exe = Path::new("/Applications/PlatypusGit.app/Contents/MacOS/platypusgit");
+        assert_eq!(
+            classify_sighting(
+                Path::new("/opt/homebrew/bin/pgit"),
+                &app,
+                Some(exe),
+                None,
+                exe,
+                "platypusgit"
+            ),
+            CliShimSource::Package
+        );
+    }
+
+    #[test]
+    fn the_deb_wrapper_script_is_package_managed() {
+        // What `src-tauri/deb/pgit` actually contains. It names the binary
+        // absolutely on purpose — this probe is why.
+        let wrapper = "#!/bin/sh\nexec /usr/bin/platypusgit \"$@\"\n";
+        let app = dirs(&["/home/ada/.local/bin"]);
+        assert_eq!(
+            classify_sighting(
+                Path::new("/usr/bin/pgit"),
+                &app,
+                None,
+                Some(wrapper),
+                Path::new("/usr/bin/platypusgit"),
+                "platypusgit"
+            ),
+            CliShimSource::Package
+        );
+    }
+
+    #[test]
+    fn the_msi_cmd_shim_is_package_managed() {
+        let body = shim_cmd_body(Path::new("C:\\Program Files\\PlatypusGit\\platypusgit.exe"));
+        let app = dirs(&["C:\\Users\\ada\\AppData\\Local\\PlatypusGit\\bin"]);
+        assert_eq!(
+            classify_sighting(
+                Path::new("C:\\Program Files\\PlatypusGit\\pgit.cmd"),
+                &app,
+                None,
+                Some(&body),
+                Path::new("C:\\Program Files\\PlatypusGit\\platypusgit.exe"),
+                "platypusgit"
+            ),
+            CliShimSource::Package
+        );
+    }
+
+    #[test]
+    fn a_stranger_is_foreign_and_is_never_claimed() {
+        let app = dirs(&["/home/ada/.local/bin"]);
+        let exe = Path::new("/opt/pg/platypusgit");
+        // Someone else's script...
+        assert_eq!(
+            classify_sighting(
+                Path::new("/usr/local/bin/pgit"),
+                &app,
+                None,
+                Some("#!/bin/sh\nexec /usr/bin/gitk \"$@\"\n"),
+                exe,
+                "platypusgit"
+            ),
+            CliShimSource::Foreign
+        );
+        // ...and someone else's symlink, even inside a dir we write.
+        assert_eq!(
+            classify_sighting(
+                Path::new("/home/ada/.local/bin/pgit"),
+                &app,
+                Some(Path::new("/usr/bin/gitk")),
+                None,
+                exe,
+                "platypusgit"
+            ),
+            CliShimSource::Foreign
+        );
+    }
+
+    #[test]
+    fn a_binary_or_oversized_shim_reads_as_foreign_not_a_panic() {
+        // `text: None` is what `probe_shim` yields for non-UTF-8 or >4 KiB.
+        assert_eq!(
+            classify_sighting(
+                Path::new("/usr/local/bin/pgit"),
+                &dirs(&["/home/ada/.local/bin"]),
+                None,
+                None,
+                Path::new("/opt/pg/platypusgit"),
+                "platypusgit"
+            ),
+            CliShimSource::Foreign
+        );
+    }
+
+    #[test]
+    fn a_relative_symlink_still_resolves_to_us() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let exe = dir.join("platypusgit");
+        std::fs::write(&exe, b"x").unwrap();
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink("platypusgit", dir.join(SHIM_NAME)).unwrap();
+            let sighting = probe_shim(&dir.join(SHIM_NAME)).unwrap();
+            assert_eq!(sighting.link.as_deref(), Some(exe.as_path()));
+            assert!(references_app(
+                sighting.link.as_deref(),
+                None,
+                &exe,
+                "platypusgit"
+            ));
+        }
+    }
+
+    #[test]
+    fn dir_on_path_is_exact_not_a_prefix() {
+        let path = dirs(&["/usr/local/binaries", "/opt/bin"]);
+        assert_eq!(
+            dir_on_path(Path::new("/usr/local/bin"), &path),
+            CliPathState::OffPath
+        );
+        assert_eq!(dir_on_path(Path::new("/opt/bin"), &path), CliPathState::OnPath);
+    }
+
+    #[test]
+    fn the_cmd_shim_quotes_the_exe_and_forwards_every_argument() {
+        let body = shim_cmd_body(Path::new("C:\\Program Files\\PlatypusGit\\platypusgit.exe"));
+        assert!(body.starts_with("@echo off\r\n"));
+        assert!(body.contains("\"C:\\Program Files\\PlatypusGit\\platypusgit.exe\" %*"));
+    }
+
+    #[test]
+    fn the_windows_path_script_is_embedded_and_reads_its_dir_from_the_environment() {
+        // `include_str!` silently succeeding on the wrong file would leave the
+        // Windows PATH half dead; and the directory must never reach argv.
+        assert!(WINDOWS_PATH_SCRIPT.contains("PGIT_BIN_DIR"));
+        assert!(WINDOWS_PATH_SCRIPT.contains("Add-UserPathEntry"));
+        // The registry kind is preserved and the value read unexpanded, or a
+        // REG_EXPAND_SZ PATH containing %USERPROFILE% is destroyed on write.
+        assert!(WINDOWS_PATH_SCRIPT.contains("DoNotExpandEnvironmentNames"));
+        assert!(WINDOWS_PATH_SCRIPT.contains("GetValueKind"));
+        // `setx` truncates at 1024 chars and merges the machine PATH into the
+        // user PATH — it may be named in the rationale, never invoked.
+        assert!(!WINDOWS_PATH_SCRIPT
+            .lines()
+            .any(|line| line.trim_start().starts_with("setx")));
+    }
+
+    #[test]
+    fn a_package_managed_pgit_is_never_overwritten() {
+        // The whole point of #144's last note: a shim shipped by Homebrew, dpkg
+        // or the MSI is reported as installed, not offered for replacement.
+        assert_eq!(
+            plan_install(CliShimSource::Package, false),
+            InstallPlan::KeepExisting
+        );
+        assert_eq!(
+            plan_install(CliShimSource::Package, true),
+            InstallPlan::KeepExisting
+        );
+    }
+
+    #[test]
+    fn our_own_correct_shim_is_left_byte_identical() {
+        assert_eq!(plan_install(CliShimSource::App, true), InstallPlan::KeepExisting);
+    }
+
+    #[test]
+    fn a_stale_absent_or_foreign_shim_is_written() {
+        // A stale link of ours, nothing at all, and a stranger all mean "write
+        // ours" — the stranger's file is in a directory we do not write, so
+        // ours goes somewhere else rather than over it.
+        assert_eq!(plan_install(CliShimSource::App, false), InstallPlan::Write);
+        assert_eq!(plan_install(CliShimSource::None, false), InstallPlan::Write);
+        assert_eq!(plan_install(CliShimSource::Foreign, false), InstallPlan::Write);
+    }
+
+    #[test]
+    fn the_main_binary_name_matches_the_installed_binary() {
+        // Every channel installs the Cargo bin name: /usr/bin/platypusgit,
+        // <INSTALLDIR>\platypusgit.exe, PlatypusGit.app/Contents/MacOS/platypusgit.
+        assert_eq!(MAIN_BINARY, "platypusgit");
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -63,12 +63,16 @@
     },
     "windows": {
       "wix": {
-        "language": ["en-US"]
+        "language": ["en-US"],
+        "fragmentPaths": ["wix/pgit-cli.wxs"],
+        "componentRefs": ["PgitCli"]
       }
     },
     "linux": {
       "deb": {
-        "depends": []
+        "depends": [],
+        "files": { "/usr/bin/pgit": "deb/pgit" },
+        "postInstallScript": "deb/postinst"
       },
       "appimage": {
         "bundleMediaFramework": false

--- a/src-tauri/windows/add-user-path.ps1
+++ b/src-tauri/windows/add-user-path.ps1
@@ -1,0 +1,92 @@
+# Append one directory to the CURRENT USER's persistent PATH (#144).
+#
+# Run by `cli::add_user_path` (fed on stdin, so nothing here is ever quoted into
+# an argv) and mirrored by `scripts/install-pgit.ps1`. Prints `added`,
+# `already-present`, or throws.
+#
+# The directory arrives in $env:PGIT_BIN_DIR, never as an argument: a path is
+# user-controlled text and -Command takes a *script*, so an argument would be an
+# injection vector. Same rule the credential code follows, here for injection
+# rather than secrecy.
+#
+# Why not `setx`: it truncates at 1024 characters, and `setx PATH "%PATH%;..."`
+# writes the MERGED machine+user PATH into the user PATH. It is the most common
+# way to destroy a Windows PATH.
+#
+# Why not [Environment]::SetEnvironmentVariable(..., 'User') on its own: when
+# HKCU\Environment\Path is REG_EXPAND_SZ containing %USERPROFILE%, .NET writes
+# it back as REG_SZ with the variables EXPANDED, permanently. So the value is
+# read unexpanded and written back with the kind it already had.
+
+$ErrorActionPreference = 'Stop'
+
+function Get-UpdatedPath {
+    # Pure: the new PATH string, or $null when $Dir is already in it. Split out
+    # so it can be exercised without a registry (see the repo's verification
+    # notes — it is the only half of this file testable off Windows).
+    param(
+        [AllowEmptyString()] [string] $Current,
+        [Parameter(Mandatory = $true)] [string] $Dir
+    )
+
+    $needle = $Dir.Trim().Trim('"').TrimEnd('\', '/')
+    if ([string]::IsNullOrWhiteSpace($needle)) { throw 'Refusing to add an empty PATH entry' }
+
+    $parts = @()
+    if (-not [string]::IsNullOrEmpty($Current)) { $parts = @($Current -split ';') }
+
+    foreach ($part in $parts) {
+        if ($part.Trim().Trim('"').TrimEnd('\', '/') -ieq $needle) { return $null }
+    }
+
+    $kept = @($parts | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    return (@($kept) + $needle) -join ';'
+}
+
+function Send-EnvironmentChange {
+    # Tell already-running processes (Explorer, and therefore every shell it
+    # launches from now on) to re-read the environment. Best effort: without it
+    # the change is real but invisible until the next sign-in.
+    $signature = @'
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+'@
+    try {
+        $native = Add-Type -MemberDefinition $signature -Name 'PgitEnvNative' -Namespace 'PlatypusGit' -PassThru
+        $unused = [UIntPtr]::Zero
+        # HWND_BROADCAST, WM_SETTINGCHANGE, SMTO_ABORTIFHUNG, 5s.
+        [void] $native::SendMessageTimeout([IntPtr] 0xffff, 0x1A, [UIntPtr]::Zero, 'Environment', 2, 5000, [ref] $unused)
+    } catch {
+        Write-Verbose "PATH broadcast failed: $_"
+    }
+}
+
+function Add-UserPathEntry {
+    param([Parameter(Mandatory = $true)] [string] $Dir)
+
+    $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
+    if ($null -eq $key) { throw 'Cannot open HKCU\Environment for writing' }
+    try {
+        $kind = [Microsoft.Win32.RegistryValueKind]::ExpandString
+        try { $kind = $key.GetValueKind('Path') } catch { }
+
+        $current = [string] $key.GetValue(
+            'Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+
+        $updated = Get-UpdatedPath -Current $current -Dir $Dir
+        if ($null -eq $updated) { return 'already-present' }
+
+        $key.SetValue('Path', $updated, $kind)
+        return 'added'
+    } finally {
+        $key.Dispose()
+    }
+}
+
+# `. add-user-path.ps1` with no PGIT_BIN_DIR set loads the functions and does
+# nothing, which is how the pure half is tested.
+if (-not [string]::IsNullOrWhiteSpace($env:PGIT_BIN_DIR)) {
+    $outcome = Add-UserPathEntry -Dir $env:PGIT_BIN_DIR
+    if ($outcome -eq 'added') { Send-EnvironmentChange }
+    Write-Output $outcome
+}

--- a/src-tauri/wix/pgit-cli.wxs
+++ b/src-tauri/wix/pgit-cli.wxs
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Installs the `pgit` CLI shim into INSTALLDIR and puts INSTALLDIR on the machine
+  PATH (#144). Wired in through bundle.windows.wix.fragmentPaths +
+  componentRefs, which lands this component in main.wxs's
+  `Feature Id="External"`.
+
+  This is the highest-risk file in the change: a candle or light failure fails
+  the whole Windows release job, and the release then ships with no .msi at all.
+  Four things below are therefore deliberate, each checked against
+  tauri-bundler's msi/mod.rs + msi/main.wxs and the WiX v3 wix.xsd:
+
+  1. NO HANDLEBARS. The bundler renders every fragment through Handlebars and
+     then DISCARDS the result, passing the raw file to candle (the render exists
+     only to sniff which -ext DLLs the file needs). So a double-brace
+     expression is neither substituted nor safe here: a malformed one fails the
+     render and a well-formed one is silently dropped. This file contains no
+     doubled opening brace anywhere, comments included.
+
+  2. THE $(var.Win64) PREAMBLE IS COPIED, NOT INHERITED. candle's preprocessor
+     defines are per source file, so main.wxs's own <?if $(sys.BUILDARCH)?>
+     block does not reach this one. candle IS invoked with `-arch <arch>` for
+     every input, so $(sys.BUILDARCH) is set. Repeating the preamble keeps this
+     component's bitness identical to the components main.wxs already places in
+     INSTALLDIR — light runs WITHOUT -sval, so ICE validation is live and an ICE
+     error would fail the build. Matching the existing components is the
+     low-risk option.
+
+  3. Source USES $(sys.SOURCEFILEDIR). run_candle sets current_dir to
+     target/release/wix/<arch>, so a bare relative path would resolve there and
+     fail. $(sys.SOURCEFILEDIR) is candle's built-in for the compiling file's own
+     directory, trailing separator included — i.e. src-tauri/wix/. The bundler
+     also passes -dSourceDir, but that names the main binary FILE, not a
+     directory.
+
+  4. <Environment> IS CORE WiX, not WixUtilExtension, so no extra -ext is
+     needed. Action="set" with Part="last" is the documented append form
+     ([~];value); Permanent="no" is what makes uninstall remove the entry again.
+     INSTALLDIR is under Program Files and the package is perMachine, so the
+     System="yes" write is already elevated.
+
+  The GUID is fixed rather than "*" so it stays stable across upgrades.
+-->
+<?if $(sys.BUILDARCH)="x86"?>
+    <?define Win64 = "no" ?>
+<?elseif $(sys.BUILDARCH)="x64"?>
+    <?define Win64 = "yes" ?>
+<?elseif $(sys.BUILDARCH)="arm64"?>
+    <?define Win64 = "yes" ?>
+<?else?>
+    <?error Unsupported value of sys.BUILDARCH=$(sys.BUILDARCH)?>
+<?endif?>
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment>
+        <DirectoryRef Id="INSTALLDIR">
+            <Component Id="PgitCli" Guid="747F47F3-FA90-459C-AB77-1B9A5D40A033" Win64="$(var.Win64)">
+                <File Id="PgitCmd"
+                      Name="pgit.cmd"
+                      Source="$(sys.SOURCEFILEDIR)pgit.cmd"
+                      KeyPath="yes" />
+                <Environment Id="PgitPathEntry"
+                             Name="PATH"
+                             Value="[INSTALLDIR]"
+                             Part="last"
+                             Action="set"
+                             System="yes"
+                             Permanent="no" />
+            </Component>
+        </DirectoryRef>
+    </Fragment>
+</Wix>

--- a/src-tauri/wix/pgit.cmd
+++ b/src-tauri/wix/pgit.cmd
@@ -1,0 +1,8 @@
+@echo off
+rem The `pgit` CLI, as shipped by the platypusgit .msi (#144).
+rem
+rem %~dp0 is this file's own directory (with a trailing backslash), so the shim
+rem is self-locating and no install path is baked into it. The release binary is
+rem windows_subsystem = "windows", so cmd does not block on it, and
+rem tauri-plugin-single-instance forwards the arguments into a running instance.
+"%~dp0platypusgit.exe" %*

--- a/src/AppShell.restore.test.tsx
+++ b/src/AppShell.restore.test.tsx
@@ -49,7 +49,13 @@ function wire() {
     pauseReason: null,
   }));
   mockInvoke("take_launch_intent", () => null);
-  mockInvoke("cli_shim_status", () => ({ installed: false, path: null }));
+  mockInvoke("cli_shim_status", () => ({
+    installed: false,
+    shimPath: "",
+    target: "",
+    source: "none",
+    pathState: "offPath",
+  }));
   mockInvoke("get_diff", () => null);
   mockInvoke("check_for_update", () => null);
   mockInvoke("get_update_capability", () => ({ canSelfUpdate: false }));

--- a/src/AppShell.screenentry.test.tsx
+++ b/src/AppShell.screenentry.test.tsx
@@ -49,7 +49,13 @@ function wire() {
     pauseReason: null,
   }));
   mockInvoke("take_launch_intent", () => null);
-  mockInvoke("cli_shim_status", () => ({ installed: false, path: null }));
+  mockInvoke("cli_shim_status", () => ({
+    installed: false,
+    shimPath: "",
+    target: "",
+    source: "none",
+    pathState: "offPath",
+  }));
   mockInvoke("get_diff", () => null);
 }
 

--- a/src/AppShell.screens.test.tsx
+++ b/src/AppShell.screens.test.tsx
@@ -101,7 +101,13 @@ function wireAll(): void {
   mockInvoke("diff_commits", () => []);
   mockInvoke("conflict_sides", () => null);
   mockInvoke("take_launch_intent", () => null);
-  mockInvoke("cli_shim_status", () => ({ installed: false, path: null }));
+  mockInvoke("cli_shim_status", () => ({
+    installed: false,
+    shimPath: "",
+    target: "",
+    source: "none",
+    pathState: "offPath",
+  }));
   mockInvoke("open_repo", () => handle);
   mockInvoke("default_init_branch", () => "main");
 }

--- a/src/AppShell.tabs.test.tsx
+++ b/src/AppShell.tabs.test.tsx
@@ -43,7 +43,13 @@ function wire() {
     pauseReason: null,
   }));
   mockInvoke("take_launch_intent", () => null);
-  mockInvoke("cli_shim_status", () => ({ installed: false, path: null }));
+  mockInvoke("cli_shim_status", () => ({
+    installed: false,
+    shimPath: "",
+    target: "",
+    source: "none",
+    pathState: "offPath",
+  }));
   mockInvoke("get_diff", () => null);
   mockInvoke("check_for_update", () => null);
   mockInvoke("get_update_capability", () => ({ canSelfUpdate: false }));

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -407,16 +407,35 @@ export interface LaunchIntent {
   screen: string | null;
 }
 
+/**
+ * Who owns the `pgit` on the user's PATH (#144) — mirrors Rust
+ * `cli::CliShimSource`. `package` is the contract that matters: a shim shipped
+ * by Homebrew, dpkg or the MSI counts as installed and is never overwritten.
+ */
+export type CliShimSource = "none" | "app" | "package" | "foreign";
+
+/**
+ * Whether the shim's directory is reachable — mirrors `cli::CliPathState`.
+ * `pathAdded` is produced only by an install (the persistent PATH was just
+ * written, so already-open shells still need a restart), never by a status read.
+ */
+export type CliPathState = "onPath" | "offPath" | "pathAdded";
+
 export interface CliShimStatus {
+  /** `pgit` is present and launches this app — i.e. source is app or package. */
   installed: boolean;
+  /** Where it is, or (with none found) where an install would put one. */
   shimPath: string;
   target: string;
+  source: CliShimSource;
+  pathState: CliPathState;
 }
 
 export interface CliInstallOutcome {
   installed: boolean;
   path: string;
   manualCommand: string | null;
+  pathState: CliPathState;
 }
 
 export interface UpdateInfo {

--- a/src/screens/Settings.cli.test.tsx
+++ b/src/screens/Settings.cli.test.tsx
@@ -3,50 +3,138 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
 import { mockInvoke } from "@/test/invokeMock";
+import type { CliPathState, CliShimSource } from "@/lib/types";
 import { SettingsScreen } from "./Settings";
 
-function mockShim(installed: boolean) {
+function mockShim(
+  source: CliShimSource,
+  opts: { shimPath?: string; pathState?: CliPathState } = {},
+) {
   mockInvoke("cli_shim_status", () => ({
-    installed,
-    shimPath: "/usr/local/bin/pgit",
+    installed: source === "app" || source === "package",
+    shimPath: opts.shimPath ?? "/usr/local/bin/pgit",
     target: "/Applications/PlatypusGit.app/Contents/MacOS/platypusgit",
+    source,
+    pathState: opts.pathState ?? "onPath",
   }));
 }
 
 describe("Settings command line section", () => {
   it("shows not-installed status and installs on click", async () => {
-    mockShim(false);
+    mockShim("none");
     mockInvoke("install_cli_shim", () => ({
       installed: true,
       path: "/usr/local/bin/pgit",
       manualCommand: null,
+      pathState: "onPath",
     }));
     render(<SettingsScreen />);
     expect(await screen.findByText(/not installed/i)).toBeInTheDocument();
     // Status refresh after install reports installed.
-    mockShim(true);
+    mockShim("app");
     await userEvent.click(
       screen.getByRole("button", { name: /install pgit/i }),
     );
     await waitFor(() =>
-      expect(screen.getByText(/\/usr\/local\/bin\/pgit/)).toBeInTheDocument(),
+      expect(screen.getByText("/usr/local/bin/pgit")).toBeInTheDocument(),
     );
     expect(screen.queryByText(/not installed/i)).not.toBeInTheDocument();
   });
 
   it("shows the manual command when install lacks permissions", async () => {
-    mockShim(false);
+    mockShim("none");
     mockInvoke("install_cli_shim", () => ({
       installed: false,
       path: "/usr/local/bin/pgit",
       manualCommand: 'sudo ln -sf "/app/platypusgit" "/usr/local/bin/pgit"',
+      pathState: "onPath",
     }));
     render(<SettingsScreen />);
     await userEvent.click(
       await screen.findByRole("button", { name: /install pgit/i }),
     );
+    expect(await screen.findByText(/sudo ln -sf/)).toBeInTheDocument();
+  });
+
+  // ─── the ownership contract (#144) ─────────────────────────────────────────
+
+  it("reports a package-managed pgit as installed and offers no button", async () => {
+    // The whole point of #144's last note: dpkg / Homebrew / the MSI own the
+    // file, so there must be nothing here that would overwrite it.
+    mockShim("package", { shimPath: "/usr/bin/pgit" });
+    render(<SettingsScreen />);
     expect(
-      await screen.findByText(/sudo ln -sf/),
+      await screen.findByText(/installed by your package manager/i),
     ).toBeInTheDocument();
+    expect(screen.getByText("/usr/bin/pgit")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /install pgit/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /reinstall pgit/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("names a stranger's pgit without claiming it, and still offers an install", async () => {
+    mockShim("foreign", { shimPath: "/opt/somewhere/pgit" });
+    render(<SettingsScreen />);
+    expect(await screen.findByText(/not installed/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/is already on your PATH at/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("/opt/somewhere/pgit")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /install pgit/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("offers Reinstall for a shim we installed ourselves", async () => {
+    mockShim("app", { shimPath: "/home/ada/.local/bin/pgit" });
+    render(<SettingsScreen />);
+    expect(
+      await screen.findByRole("button", { name: /reinstall pgit/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("names the directory to add when the shim is off PATH", async () => {
+    // Installed but unusable is the macOS ~/.local/bin case — it must not read
+    // as a plain success.
+    mockShim("app", {
+      shimPath: "/Users/ada/.local/bin/pgit",
+      pathState: "offPath",
+    });
+    render(<SettingsScreen />);
+    expect(
+      await screen.findByText(/is not on your PATH/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('export PATH="/Users/ada/.local/bin:$PATH"'),
+    ).toBeInTheDocument();
+  });
+
+  it("tells the user to open a new terminal after a PATH write", async () => {
+    mockShim("none", { shimPath: "C:\\Users\\ada\\AppData\\Local\\PlatypusGit\\bin\\pgit" });
+    mockInvoke("install_cli_shim", () => ({
+      installed: true,
+      path: "C:\\Users\\ada\\AppData\\Local\\PlatypusGit\\bin\\pgit.cmd",
+      manualCommand: null,
+      pathState: "pathAdded",
+    }));
+    render(<SettingsScreen />);
+    await userEvent.click(
+      await screen.findByRole("button", { name: /install pgit/i }),
+    );
+    expect(await screen.findByText(/open a new terminal/i)).toBeInTheDocument();
+  });
+
+  it("never suggests a PATH edit for a package-managed shim", async () => {
+    // The package put it on PATH; an offPath reading there would be our bug,
+    // not something to hand the user a shell line about.
+    mockShim("package", { shimPath: "/usr/bin/pgit", pathState: "offPath" });
+    render(<SettingsScreen />);
+    expect(
+      await screen.findByText(/installed by your package manager/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/is not on your PATH/i)).not.toBeInTheDocument();
   });
 });

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { platform } from "@tauri-apps/plugin-os";
 import {
   PGButton,
   PGButtonGroup,
@@ -26,7 +25,7 @@ import { HeadMarksControl } from "@/features/settings/HeadMarksControl";
 import { ForgeSettings } from "@/features/forge/ForgeSettings";
 import { cliShimStatus, installCliShim, type PullMode } from "@/lib/tauri";
 import { useUpdateStore } from "@/features/update/useUpdateStore";
-import type { CliShimStatus } from "@/lib/types";
+import type { CliPathState, CliShimStatus } from "@/lib/types";
 import { BUILTIN_PRESETS, useKeymapStore } from "@/features/keymap";
 
 export function SettingsScreen() {
@@ -312,9 +311,9 @@ function KeyboardSection() {
 // ═════════════════════════════════════════════════════════════════════════════
 
 function CliSection() {
-  const isWindows = platform() === "windows";
   const [status, setStatus] = React.useState<CliShimStatus | null>(null);
   const [manual, setManual] = React.useState<string | null>(null);
+  const [pathState, setPathState] = React.useState<CliPathState | null>(null);
   const [busy, setBusy] = React.useState(false);
 
   const refresh = React.useCallback(() => {
@@ -323,9 +322,10 @@ function CliSection() {
       .catch(() => setStatus(null));
   }, []);
 
-  React.useEffect(() => {
-    if (!isWindows) refresh();
-  }, [isWindows, refresh]);
+  // No platform gate any more (#144): Windows writes a pgit.cmd and appends the
+  // per-user PATH, so the old "not yet supported" row is gone rather than
+  // conditional.
+  React.useEffect(refresh, [refresh]);
 
   const install = async () => {
     setBusy(true);
@@ -333,6 +333,7 @@ function CliSection() {
       const out = await installCliShim();
       if (out.installed) {
         setManual(null);
+        setPathState(out.pathState);
         // Deliberately doesn't repeat the shim path here — the status row
         // below shows it, and a toast echoing the same substring would
         // outlive the row's re-render (toast lives ~1.7s) and collide with
@@ -349,55 +350,114 @@ function CliSection() {
     }
   };
 
+  const source = status?.source ?? "none";
+  // A package manager owns the file — offering to overwrite it is the one thing
+  // #144 says must not happen, so there is no button at all in that state.
+  const packaged = source === "package";
+  const effectivePathState = pathState ?? status?.pathState ?? null;
+
   return (
     <Section
       title="Command line"
       subtitle="Launch platypusgit from a terminal: pgit [commit|status|log|history|branches] [path]."
     >
-      {isWindows ? (
-        <Row
-          label="pgit command"
-          hint="Not yet supported on Windows. Add the install directory to PATH manually to use platypusgit.exe from a terminal."
-          control={<span />}
-        />
-      ) : (
-        <Row
-          label="pgit command"
-          hint={
-            status?.installed ? (
+      <Row
+        label="pgit command"
+        hint={
+          <>
+            {packaged ? (
               <>
-                Installed at{" "}
-                <code style={{ fontFamily: "var(--font-mono)" }}>
-                  {status.shimPath}
-                </code>
+                Installed by your package manager at{" "}
+                <Mono>{status?.shimPath}</Mono>. Updating platypusgit updates it
+                too.
+              </>
+            ) : source === "app" ? (
+              <>
+                Installed at <Mono>{status?.shimPath}</Mono>
               </>
             ) : (
               <>
                 Not installed.{" "}
+                {source === "foreign" && (
+                  <>
+                    A different <Mono>pgit</Mono> is already on your PATH at{" "}
+                    <Mono>{status?.shimPath}</Mono> — it will not be touched.{" "}
+                  </>
+                )}
                 {manual && (
                   <>
                     Automatic install failed (permissions) — run:{" "}
-                    <code
-                      style={{
-                        fontFamily: "var(--font-mono)",
-                        userSelect: "all",
-                      }}
-                    >
-                      {manual}
-                    </code>
+                    <Mono selectable>{manual}</Mono>
                   </>
                 )}
               </>
-            )
-          }
-          control={
+            )}
+            <PathNote
+              state={packaged ? null : effectivePathState}
+              shimPath={status?.shimPath}
+            />
+          </>
+        }
+        control={
+          packaged ? (
+            <span />
+          ) : (
             <PGButton size="sm" onClick={install} disabled={busy}>
-              {status?.installed ? "Reinstall pgit" : "Install pgit"}
+              {source === "app" ? "Reinstall pgit" : "Install pgit"}
             </PGButton>
-          }
-        />
-      )}
+          )
+        }
+      />
     </Section>
+  );
+}
+
+function Mono({
+  children,
+  selectable,
+}: {
+  children: React.ReactNode;
+  selectable?: boolean;
+}) {
+  return (
+    <code
+      style={{
+        fontFamily: "var(--font-mono)",
+        ...(selectable ? { userSelect: "all" as const } : null),
+      }}
+    >
+      {children}
+    </code>
+  );
+}
+
+/**
+ * The PATH half of the answer. A shim in a directory the shell cannot see is
+ * installed but unusable, so the state is surfaced with the line that fixes it
+ * rather than hidden behind a successful install.
+ */
+function PathNote({
+  state,
+  shimPath,
+}: {
+  state: CliPathState | null;
+  shimPath?: string;
+}) {
+  if (state === null || state === "onPath") return null;
+  // dirname, without importing a path helper for one call.
+  const dir = shimPath?.replace(/[/\\][^/\\]*$/, "") ?? "";
+  if (state === "pathAdded") {
+    return (
+      <div style={{ marginTop: 4 }}>
+        Added <Mono>{dir}</Mono> to your PATH — open a new terminal.
+      </div>
+    );
+  }
+  return (
+    <div style={{ marginTop: 4 }}>
+      <Mono>{dir}</Mono> is not on your PATH. Add it:{" "}
+      <Mono selectable>{`export PATH="${dir}:$PATH"`}</Mono>
+    </div>
   );
 }
 


### PR DESCRIPTION
Part of issue 144. That issue stays OPEN: the Homebrew cask `binary` stanza
lives in another repository, serving the install scripts from the site is held
for a separate PR, and each channel still needs end-to-end verification on a
real Windows and Linux install.
`pgit` now arrives with the app on every channel that offers a hook, has a
copy-paste script for the two that don't, and Settings → Command line works on
Windows instead of rendering "Not yet supported".

Spec: `docs/superpowers/specs/2026-08-17-pgit-cli-packaging-spec.md`
Plan: `docs/superpowers/plans/2026-08-17-pgit-cli-packaging-plan.md`

## The contract, settled first

`shim_status` answered one question — *is `<one dir>/pgit` a symlink to me* — so a
`.deb` user with a working `/usr/bin/pgit` was told "Not installed" and offered a
button that writes a second copy somewhere else. It now scans our own dirs, then
known package paths, then `PATH`, and reports which of three parties owns what it
found:

| `CliShimSource` | meaning | Settings |
| --- | --- | --- |
| `package` | launches this app from a directory we do not write (Homebrew, dpkg, MSI) | installed, **no button at all** |
| `app` | one of our own shim dirs | installed, Reinstall |
| `foreign` | a `pgit` that is not ours | not installed; names it, never touches it |
| `none` | nothing found | not installed, Install |

`installed` now means *`pgit` is present and launches this app*. The refusal lives
in the backend too (`plan_install`), not only in the hidden button, so a future
caller cannot reintroduce the fight. `pathState` answers the separate question of
whether the shell can actually see it.

## Per channel

- **`.deb`** — `/usr/bin/pgit`, a wrapper `exec`'ing `/usr/bin/platypusgit`, via
  `bundle.linux.deb.files`, plus a `postInstallScript` that guarantees the exec
  bit. A symlink is not an option: the bundler copies `deb.files` with
  `std::fs::copy`, which follows symlinks and would embed a second copy of the
  binary.
- **`.msi`** — a WiX fragment installing `pgit.cmd` into `INSTALLDIR` and
  appending `INSTALLDIR` to the machine `PATH`, both `Permanent="no"` so uninstall
  rolls them back. Wired through `wix.fragmentPaths` + `componentRefs`.
- **macOS + Linux scripts** — `scripts/install-pgit.sh` and
  `scripts/install-pgit.ps1`. Both locate the app rather than asking, refuse to
  write a second `pgit` when a package already shipped one, and prefer a directory
  the user owns.
- **macOS in-app** — no more `sudo ln -sf` paste line. The shim dirs are an
  ordered list and the first writable one wins: `/usr/local/bin` stays first (it
  is the only default-`PATH` entry, and where existing installs are), and a stock
  Apple Silicon Mac falls through to `~/.local/bin`. Off-`PATH` is *reported* with
  the line that fixes it rather than hidden behind a successful install.
- **Windows in-app** — writes `%LOCALAPPDATA%\PlatypusGit\bin\pgit.cmd` and
  appends the per-user `PATH`. Not `setx` (truncates at 1024 chars, and
  `setx PATH "%PATH%;…"` writes the merged machine+user `PATH` into the user
  `PATH`) and not a bare `[Environment]::SetEnvironmentVariable(…, 'User')` (it
  rewrites a `REG_EXPAND_SZ` `PATH` as `REG_SZ` with `%USERPROFILE%` permanently
  expanded). The value is read `DoNotExpandEnvironmentNames` and written back with
  `GetValueKind`'s answer. The directory travels in `PGIT_BIN_DIR`, never argv.

## Deliberately NOT in this PR — keep #144 open

- **The Homebrew cask `binary` stanza.** It is a PR to
  `jonassaa/homebrew-platypusgit`. The exact line is written down in the spec
  (§H) and nothing was pushed to that repo.
- **Serving the scripts from platypusgit.com** + the `curl … | sh` one-liner on
  the download page. `site/` is being reworked under #145, so this PR does not
  touch it; the spec (§H) records what the page needs and that a prebuild step
  must copy the scripts out of `scripts/` rather than duplicating them.
- **End-to-end verification of each channel**, which needs a real Windows and a
  real Linux install. See the table below.

## Release-pipeline safety

`release.yml` is **not touched**, and neither are `bundle.targets`,
`createUpdaterArtifacts`, the updater `pubkey` or the signing config — the bundle
changes are additive keys only.

`bump-cask` rewrites the tap's cask with two `sed -i -E` expressions anchored on
`^  version "` and `^  sha256 "`. Checked concretely, not reasoned about: the live
cask was fetched, the proposed `binary` stanza inserted below the `app` stanza,
and both seds applied verbatim — they change exactly the version and sha256 lines
and nothing else. The `binary` line matches neither anchor.

## Verified vs unproven

This was built on macOS. Three of five channels cannot be exercised here, so:

| | Verified, and how | Unproven — needs |
| --- | --- | --- |
| **macOS (.dmg / in-app)** | `pnpm tauri build --no-sign` bundles; 21/21 script cases under dash, bash and zsh against fixtures, including a real `cat script \| sh` run; 142 Rust unit tests | — |
| **Homebrew cask** | the `bump-cask` sed compatibility, against the live cask | the stanza itself (different repo) |
| **`.deb`** | the exec-bit chain read in `tauri-bundler` + `tar-rs` source (`HeaderMode::Deterministic` propagates the user execute bit on Unix); wrapper committed `100755`; `dash -n` + a real fixture run of the postinst (644→755, idempotent, exits 0 for a non-`configure` arg) | that `dpkg -i` yields an executable `/usr/bin/pgit`, and that `apt remove` deletes it |
| **`.msi`** | `xmllint --noout` + `xmllint --schema` against WiX v3's `wix.xsd`; a grep proving no doubled opening brace anywhere (the bundler renders fragments through Handlebars); the config keys validated against the published tauri schema | candle/light/ICE actually compiling it, the `PATH` entry appearing, and uninstall rolling both back |
| **Windows in-app** | the `.ps1` and `add-user-path.ps1` parse under `pwsh`; 11 unit cases over the pure halves (`Get-UpdatedPath`, `Get-ShimBody`, wrapper detection, no-BOM write) run under `pwsh` on macOS | the registry write, the `WM_SETTINGCHANGE` broadcast, `powershell.exe` spawning with `CREATE_NO_WINDOW`, and `pgit.cmd` resolving |

## Verification run

```
pnpm tsc --noEmit                                     OK
pnpm exec tsc -p e2e/tsconfig.json --noEmit           OK
pnpm test                          179 files, 1469 tests passed
cargo check                                           clean, no warnings
cargo test                         all suites green (142 lib unit tests)
pnpm tauri build --no-sign                            bundles the .dmg
```

e2e was not run locally (no spec touches this surface, and the Docker slot is
shared) — CI runs the full suite on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Er25sN6pGoVJzmTBwHU2Tz

