### PR TITLE
fix(errors): close the gaps left by #151

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -810,6 +810,30 @@ lib/
 - `ForgeAuth` is deliberately separate from `Auth`: `Auth` means "git needs a
   credential for this remote, prompt and retry", so reusing it for a bad API token
   would pop the transport-credential dialog for a problem only Settings can fix.
+- **Two formatters, two voices, and the wrong one is a bug either way** (#146).
+  `describeError` is for the LOG FILE and leads with the `kind`; `appErrorMessage`
+  is for a BANNER and never shows the enum's spelling. `toAppError`
+  (`lib/errors.ts`, one definition for the five stores whose `error` field is an
+  `AppError`) wraps with `appErrorMessage` — a banner reading "TypeError: x is not
+  a function" is developer text. Stores whose `error` is a plain string call
+  `appErrorMessage` directly and need no wrapper.
+- **Neither formatter may throw, and neither may assume `message` is a string.**
+  `invoke` logs a failure BEFORE it rethrows it, so an exception raised inside the
+  logger *replaces* the original rejection — `isAuthError` then fails to narrow and
+  no credential prompt is raised. And `isAppError` accepts any object with a string
+  `kind`, while `Auth` proves the enum itself can carry a struct, so a payload of
+  the wrong shape must be coerced (`describeUnknown`), never interpolated. Both
+  are pinned in `errors.test.ts` + `tauri.errors.test.ts`.
+- **"No text at this path" is a STATE for all three file-content readers**
+  (`read_file_content`, `_at_rev`, `_at_index`), and each one needs an explicit
+  non-blob KIND test to honour it. A `160000` gitlink's oid names a commit in the
+  SUBMODULE's object database, so looking the entry's object up answers "object not
+  found" — which is what all three did for every click on a submodule row until
+  `tests/file_content_absence.rs`. Absence is answered `Ok(None)` because every
+  caller is a diff or preview surface reading one side of something it is already
+  rendering; a genuine failure (bad revspec, unknown repository, unreadable file)
+  still errors. On the frontend the sentinel is `null`, NOT `""` — whole-file mode
+  bails on `null` and would compose a file out of an empty string.
 
 ### Forge tokens are NOT git credentials (#92)
 - `commands/net.rs::Credentials` answers git's askpass prompt for one

--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -74,7 +74,7 @@ pub async fn read_file_content(
     state: State<'_, AppState>,
     repo_id: String,
     path: String,
-) -> AppResult<FileContent> {
+) -> AppResult<Option<FileContent>> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
     let path_buf = PathBuf::from(path);

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -118,7 +118,11 @@ impl GitBackend for CliBackend {
     ) -> AppResult<FileDiff> {
         Err(AppError::NotImplemented)
     }
-    fn read_file_content(&self, _repo_id: &RepoId, _path: &Path) -> AppResult<FileContent> {
+    fn read_file_content(
+        &self,
+        _repo_id: &RepoId,
+        _path: &Path,
+    ) -> AppResult<Option<FileContent>> {
         Err(AppError::NotImplemented)
     }
     fn list_files_at_rev(&self, _repo_id: &RepoId, _revspec: &str) -> AppResult<Vec<FileStatus>> {

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -2976,7 +2976,7 @@ impl GitBackend for Libgit2Backend {
         })
     }
 
-    fn read_file_content(&self, repo_id: &RepoId, path: &Path) -> AppResult<FileContent> {
+    fn read_file_content(&self, repo_id: &RepoId, path: &Path) -> AppResult<Option<FileContent>> {
         let rel = path.to_path_buf();
         let path_str = rel.to_string_lossy().into_owned();
         self.with_repo(repo_id, |repo| {
@@ -2987,7 +2987,7 @@ impl GitBackend for Libgit2Backend {
             if abs.is_file() {
                 let bytes = std::fs::read(&abs)?;
                 let size = bytes.len() as u64;
-                return Ok(match std::str::from_utf8(&bytes) {
+                return Ok(Some(match std::str::from_utf8(&bytes) {
                     Ok(s) => FileContent {
                         path: path_str,
                         binary: false,
@@ -3002,49 +3002,57 @@ impl GitBackend for Libgit2Backend {
                         from_head: false,
                         size,
                     },
-                });
+                }));
             }
 
             // Fallback: read from HEAD blob (for deleted files).
             let head = repo.head().ok().and_then(|h| h.peel_to_tree().ok());
             if let Some(tree) = head {
                 if let Ok(entry) = tree.get_path(&rel) {
-                    let obj = entry.to_object(repo)?;
-                    if let Some(blob) = obj.as_blob() {
-                        let content = blob.content();
-                        let size = content.len() as u64;
-                        if blob.is_binary() {
-                            return Ok(FileContent {
-                                path: path_str,
-                                binary: true,
-                                text: None,
-                                from_head: true,
-                                size,
-                            });
+                    // KIND before lookup, as in `read_file_content_at_rev`: a
+                    // `160000` gitlink's oid is a commit this repository does not
+                    // hold, so `to_object` errored for every click on a clean
+                    // submodule row.
+                    if entry.kind() == Some(git2::ObjectType::Blob) {
+                        let obj = entry.to_object(repo)?;
+                        if let Some(blob) = obj.as_blob() {
+                            let content = blob.content();
+                            let size = content.len() as u64;
+                            if blob.is_binary() {
+                                return Ok(Some(FileContent {
+                                    path: path_str,
+                                    binary: true,
+                                    text: None,
+                                    from_head: true,
+                                    size,
+                                }));
+                            }
+                            return Ok(Some(match std::str::from_utf8(content) {
+                                Ok(s) => FileContent {
+                                    path: path_str,
+                                    binary: false,
+                                    text: Some(s.to_string()),
+                                    from_head: true,
+                                    size,
+                                },
+                                Err(_) => FileContent {
+                                    path: path_str,
+                                    binary: true,
+                                    text: None,
+                                    from_head: true,
+                                    size,
+                                },
+                            }));
                         }
-                        return Ok(match std::str::from_utf8(content) {
-                            Ok(s) => FileContent {
-                                path: path_str,
-                                binary: false,
-                                text: Some(s.to_string()),
-                                from_head: true,
-                                size,
-                            },
-                            Err(_) => FileContent {
-                                path: path_str,
-                                binary: true,
-                                text: None,
-                                from_head: true,
-                                size,
-                            },
-                        });
                     }
                 }
             }
 
-            Err(AppError::InvalidPath(format!(
-                "file not found: {path_str}"
-            )))
+            // Neither the worktree nor HEAD holds text at this path: a submodule
+            // or plain directory, or a file that vanished after the status
+            // snapshot the caller is rendering. A STATE, not a failure (#146) —
+            // see the trait doc.
+            Ok(None)
         })
     }
 
@@ -3109,6 +3117,15 @@ impl GitBackend for Libgit2Backend {
             let Ok(entry) = tree.get_path(&rel) else {
                 return Ok(None);
             };
+            // Test the entry's KIND before looking the object up. A gitlink's oid
+            // names a commit in the SUBMODULE's object database, which this
+            // repository does not hold, so `to_object` failed with "object not
+            // found" and the `as_blob` guard below never got the chance — #151
+            // documented the gitlink as answering `Ok(None)` while it actually
+            // errored. `kind()` reads the entry's filemode, no ODB lookup.
+            if entry.kind() != Some(git2::ObjectType::Blob) {
+                return Ok(None);
+            }
             let obj = entry.to_object(repo)?;
             let Some(blob) = obj.as_blob() else {
                 return Ok(None);
@@ -3162,6 +3179,16 @@ impl GitBackend for Libgit2Backend {
             let Some(entry) = index.get_path(&rel, 0) else {
                 return Ok(None);
             };
+            // A `160000` gitlink DOES have a stage-0 entry, so the guard above
+            // never fires for a submodule — and its oid names a commit in the
+            // SUBMODULE's object database, so `find_blob` failed with "object not
+            // found", once per selection of a submodule row in the commit panel.
+            // Same answer as the other two readers: a non-blob has no text to
+            // colour. (The index holds no tree entries, so a gitlink is the only
+            // non-blob mode reachable here.)
+            if entry.mode == u32::from(git2::FileMode::Commit) {
+                return Ok(None);
+            }
             let blob = repo.find_blob(entry.id)?;
             let content = blob.content();
             let size = content.len() as u64;

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -173,7 +173,18 @@ pub trait GitBackend: Send + Sync {
     ) -> AppResult<FileDiff>;
     /// Read the full content of a file from the worktree. Falls back to the
     /// HEAD blob when the worktree copy is missing (e.g. a deleted file).
-    fn read_file_content(&self, repo_id: &RepoId, path: &Path) -> AppResult<FileContent>;
+    ///
+    /// `Ok(None)` — NOT an error — when neither side holds text at that path:
+    /// a directory, a `160000` submodule gitlink, or a file that vanished after
+    /// the status snapshot the caller is rendering. The HEAD fallback does not
+    /// make those anomalous, because it only recovers a BLOB: a clean submodule
+    /// row in the Files screen is an ordinary click, and it used to cost three
+    /// ERROR lines in the log (this reader twice, `_at_rev` once) for a pane that
+    /// then silently rendered nothing anyway (#146). Every caller is a diff or
+    /// preview surface that already treats "no text" as "render plain".
+    /// A genuine failure — unknown repository, bare repository, an unreadable
+    /// file — still errors.
+    fn read_file_content(&self, repo_id: &RepoId, path: &Path) -> AppResult<Option<FileContent>>;
     /// List every file in the tree at `revspec` (commit, branch, tag, or any
     /// revspec). Resolves the revspec to a tree and walks it recursively.
     /// Returns `FileStatus` entries with both sides `Unmodified` — the tree is
@@ -192,6 +203,12 @@ pub trait GitBackend: Send + Sync {
     /// condition on the error path, where the frontend's shared `invoke` wrapper
     /// logged it at ERROR (#146). A genuine failure — bad revspec, unknown
     /// repository, unreadable object — still errors.
+    ///
+    /// The gitlink half of that needs an explicit KIND test, and #151 claimed it
+    /// without one: a gitlink's oid names a commit in the SUBMODULE's object
+    /// database, so looking the entry's object up fails with "object not found"
+    /// before any `as_blob` guard can answer. Pinned by
+    /// `tests/file_content_absence.rs`.
     fn read_file_content_at_rev(
         &self,
         repo_id: &RepoId,
@@ -206,7 +223,11 @@ pub trait GitBackend: Send + Sync {
     /// A path with no stage-0 entry (untracked, or conflicted) is `Ok(None)`,
     /// not an error — the commit panel asks for the index side of every row it
     /// renders, so an untracked row genuinely having none is the expected
-    /// answer, and the caller falls back to plain rows (#146).
+    /// answer, and the caller falls back to plain rows (#146). A `160000`
+    /// submodule gitlink is also `Ok(None)`, and needs its own test: it DOES
+    /// have a stage-0 entry, so the absence guard never fires, and its oid is a
+    /// commit in the submodule's object database — `find_blob` on it errored
+    /// once per selection until this was guarded.
     fn read_file_content_at_index(
         &self,
         repo_id: &RepoId,

--- a/src-tauri/tests/file_content_absence.rs
+++ b/src-tauri/tests/file_content_absence.rs
@@ -1,0 +1,147 @@
+//! "There is no text at this path" is a STATE for all three file-content
+//! readers — a #146 follow-up.
+//!
+//! #151 made `read_file_content_at_rev` and `read_file_content_at_index` answer
+//! `Ok(None)` for an absent path and documented that a `160000` submodule gitlink
+//! "answers the same way". It did not: a gitlink's oid names a commit in the
+//! SUBMODULE's object database, which the superproject does not hold, so
+//!
+//!   * `_at_rev` failed in `entry.to_object()` — BEFORE its `as_blob()` guard,
+//!   * `_at_index` failed in `find_blob()`, having no non-blob guard at all, and
+//!   * `read_file_content` failed in the same `to_object()` inside its HEAD
+//!     fallback, never reaching the `InvalidPath` its docs described.
+//!
+//! All three answered `Git("object not found - no match for id (…)")`, once per
+//! click on a submodule row — the exact noise class #146 exists to remove, in the
+//! commands #151 rewrote. These tests pin every reader's answer against a real
+//! submodule rather than against the docs.
+
+mod support;
+
+use std::path::Path;
+
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::{libgit2::Libgit2Backend, types::RepoId, GitBackend};
+
+use support::{fs::write_file, with_submodule, SubmoduleFixture, TempRepo};
+
+/// A repository with `src/main.rs`, so a DIRECTORY exists in both the worktree
+/// and HEAD's tree.
+fn with_nested_file() -> TempRepo {
+    let tr = TempRepo::with_initial_commit("v1\n");
+    write_file(tr.path(), "src/main.rs", "fn main() {}\n");
+    tr.commit_all("add nested file");
+    tr
+}
+
+// ── The gitlink: one path, three readers, three separate failures ────────────
+
+/// The Files screen lists a clean submodule (`list_all_files` reports it with
+/// `submodule: true`, `embedded: false`) and clicking it reads the worktree copy
+/// of a DIRECTORY.
+#[test]
+fn worktree_reader_answers_none_for_a_clean_submodule() {
+    let fx = with_submodule();
+    let (backend, handle) = fx.outer.open_with_backend();
+
+    let out = backend
+        .read_file_content(&handle.id, Path::new(SubmoduleFixture::SUB_PATH))
+        .expect("a gitlink must not be an error");
+    assert!(out.is_none(), "expected None, got {out:?}");
+}
+
+/// The commit panel asks for the INDEX side of every row it renders, and a
+/// gitlink DOES have a stage-0 entry (`160000 <oid> 0  vendor/inner`) — so the
+/// `get_path(_, 0)` absence guard never fires and `find_blob` got the commit oid.
+#[test]
+fn index_reader_answers_none_for_a_submodule_gitlink() {
+    let fx = with_submodule();
+    let (backend, handle) = fx.outer.open_with_backend();
+
+    let out = backend
+        .read_file_content_at_index(&handle.id, Path::new(SubmoduleFixture::SUB_PATH))
+        .expect("a gitlink must not be an error");
+    assert!(out.is_none(), "expected None, got {out:?}");
+}
+
+/// Every diff surface reads a `{ kind: "rev", rev: "HEAD" }` old side
+/// unconditionally, so this fires for the same click as the two above.
+#[test]
+fn rev_reader_answers_none_for_a_submodule_gitlink() {
+    let fx = with_submodule();
+    let (backend, handle) = fx.outer.open_with_backend();
+
+    let out = backend
+        .read_file_content_at_rev(&handle.id, "HEAD", Path::new(SubmoduleFixture::SUB_PATH))
+        .expect("a gitlink must not be an error");
+    assert!(out.is_none(), "expected None, got {out:?}");
+}
+
+// ── The worktree reader's other absences ────────────────────────────────────
+
+/// A path that is in neither the worktree nor HEAD. `get_status` /
+/// `list_all_files` are snapshots, so a file deleted between the listing and the
+/// read is routine — and both diff-surface callers already fall back to plain
+/// rows.
+#[test]
+fn worktree_reader_answers_none_for_an_absent_path() {
+    let tr = TempRepo::with_initial_commit("v1\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let out = backend
+        .read_file_content(&handle.id, Path::new("nope.txt"))
+        .expect("absence must not be an error");
+    assert!(out.is_none(), "expected None, got {out:?}");
+}
+
+/// A directory: not a file in the worktree, and a tree in HEAD. Same answer
+/// `read_file_content_at_rev` already gave.
+#[test]
+fn worktree_reader_answers_none_for_a_directory() {
+    let tr = with_nested_file();
+    let (backend, handle) = tr.open_with_backend();
+
+    let out = backend
+        .read_file_content(&handle.id, Path::new("src"))
+        .expect("a directory must not be an error");
+    assert!(out.is_none(), "expected None, got {out:?}");
+}
+
+#[test]
+fn rev_reader_answers_none_for_a_directory() {
+    let tr = with_nested_file();
+    let (backend, handle) = tr.open_with_backend();
+
+    let out = backend
+        .read_file_content_at_rev(&handle.id, "HEAD", Path::new("src"))
+        .expect("a directory must not be an error");
+    assert!(out.is_none(), "expected None, got {out:?}");
+}
+
+// ── What must NOT go quiet along with absence ───────────────────────────────
+
+/// The HEAD fallback is the reason `read_file_content` can colour a DELETED
+/// file's removed lines. Absence answering `Ok(None)` must not swallow it.
+#[test]
+fn worktree_reader_still_falls_back_to_head_for_a_deleted_file() {
+    let tr = TempRepo::with_initial_commit("committed\n");
+    std::fs::remove_file(tr.path().join("README.md")).unwrap();
+    let (backend, handle) = tr.open_with_backend();
+
+    let out = backend
+        .read_file_content(&handle.id, Path::new("README.md"))
+        .unwrap()
+        .expect("a deleted file still has HEAD content");
+    assert_eq!(out.text.as_deref(), Some("committed\n"));
+    assert!(out.from_head, "the content came from HEAD, not the worktree");
+}
+
+/// A genuine failure still errors on the same op — otherwise quieting absence
+/// would quiet real problems too.
+#[test]
+fn worktree_reader_still_errors_for_an_unknown_repo() {
+    let err = Libgit2Backend::new()
+        .read_file_content(&RepoId("never-opened".into()), Path::new("README.md"))
+        .unwrap_err();
+    assert!(matches!(err, AppError::UnknownRepo(_)), "got {err:?}");
+}

--- a/src-tauri/tests/read_index_content.rs
+++ b/src-tauri/tests/read_index_content.rs
@@ -38,7 +38,8 @@ fn reads_the_staged_copy_not_the_worktree_or_head() {
     // whole reason this op exists.
     let worktree = backend
         .read_file_content(&handle.id, Path::new("README.md"))
-        .unwrap();
+        .unwrap()
+        .expect("README.md is in the worktree");
     assert_eq!(worktree.text.as_deref(), Some("v3\n"));
     let head = backend
         .read_file_content_at_rev(&handle.id, "HEAD", Path::new("README.md"))

--- a/src/design/error-boundary.test.tsx
+++ b/src/design/error-boundary.test.tsx
@@ -1,6 +1,7 @@
 // A render throw must leave a legible window, not an empty one.
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { error as logError } from "@tauri-apps/plugin-log";
 
 import { PGErrorBoundary } from "./error-boundary";
 
@@ -37,6 +38,30 @@ describe("PGErrorBoundary", () => {
     expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
     // The actual regression: the window is not blank.
     expect(container.textContent?.trim()).not.toBe("");
+  });
+
+  /**
+   * The console is not a diagnostic channel for a shipped app: #146's reporter
+   * handed over the Rust log file, which is the only artifact they had. An
+   * unhandled render error is the single most valuable line that file could
+   * carry, and it was the one place that wrote to the console only.
+   */
+  it("writes the failure to the log file, not just the console", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(logError).mockClear();
+
+    render(
+      <PGErrorBoundary>
+        <Boom />
+      </PGErrorBoundary>,
+    );
+
+    expect(logError).toHaveBeenCalledTimes(1);
+    const line = String(vi.mocked(logError).mock.calls[0][0]);
+    expect(line).toContain("Rendered more hooks");
+    // The component stack is what names the screen that threw; a minified
+    // production stack alone rarely does.
+    expect(line).toContain("Boom");
   });
 
   it("uses a caller-supplied reload action when given one", async () => {

--- a/src/design/error-boundary.tsx
+++ b/src/design/error-boundary.tsx
@@ -1,4 +1,7 @@
 import React from "react";
+import { error as logError } from "@tauri-apps/plugin-log";
+
+import { describeError } from "@/lib/errors";
 
 /**
  * Last line of defence around a whole window.
@@ -33,6 +36,16 @@ export class PGErrorBoundary extends React.Component<Props, State> {
     // Keep the component stack — a minified production stack alone rarely
     // names the screen that threw.
     console.error("Unhandled render error:", error, info.componentStack);
+    // And to the LOG FILE, which is the only artifact a reporter can hand over:
+    // #146 was diagnosed (and mis-diagnosed) entirely from one, and a Linux user
+    // will never open a devtools console. `describeError` for the same reason
+    // `invoke` uses it — the throw need not be an `Error`, and this is a log line
+    // rather than a banner, so leading with the kind is right here.
+    logError(
+      `unhandled render error: ${describeError(error)}${
+        info.componentStack ? ` | component stack: ${info.componentStack}` : ""
+      }`,
+    );
   }
 
   render(): React.ReactNode {

--- a/src/features/diff/CommitDiffPanel.wholeFile.test.tsx
+++ b/src/features/diff/CommitDiffPanel.wholeFile.test.tsx
@@ -94,7 +94,28 @@ describe("CommitDiffPanel whole-file mode", () => {
     expect(document.body.textContent).not.toContain("five");
   });
 
-  it("still renders the hunk when there is no text to fill from", async () => {
+  // The realistic absence since #151: the command RESOLVES with null instead of
+  // rejecting, so the `catch` the throw-mock below exercises is never entered.
+  // Nothing covered that path, which is the one every added or deleted file takes.
+  it("still renders the hunk when the read resolves absent", async () => {
+    resetInvokeMock();
+    mockInvoke("read_file_content_at_rev", () => null);
+    render(
+      <CommitDiffPanel
+        diffs={diffs}
+        loading={false}
+        error={null}
+        header="x → y"
+        paneIdPrefix="w4"
+        syntaxSides={sides}
+      />,
+    );
+    await waitFor(() => expect(document.body.textContent).toContain("CHANGED"));
+    // No text on either side means no filler — not a whole file filled from "".
+    expect(document.body.textContent).not.toContain("five");
+  });
+
+  it("still renders the hunk when the read rejects", async () => {
     resetInvokeMock();
     mockInvoke("read_file_content_at_rev", () => {
       throw new Error("no blob");

--- a/src/features/lfs/useLfsStore.ts
+++ b/src/features/lfs/useLfsStore.ts
@@ -6,14 +6,10 @@
 
 import { create } from "zustand";
 import type { AppError } from "@/lib/errors";
-import { appErrorMessage, isAppError } from "@/lib/errors";
+import { toAppError } from "@/lib/errors";
 import type { LfsStatus } from "@/lib/types";
 import { lfsCheckout, lfsFetch, lfsPull, lfsStatus } from "@/lib/tauri";
 import { useRepoStore, withAuthRetry } from "@/features/repo/useRepoStore";
-
-function toAppError(e: unknown): AppError {
-  return isAppError(e) ? e : { kind: "Internal", message: appErrorMessage(e) };
-}
 
 /** Human-readable byte size for a pointer's payload. */
 export function formatBytes(bytes: number): string {

--- a/src/features/lfs/useLfsStore.ts
+++ b/src/features/lfs/useLfsStore.ts
@@ -6,13 +6,13 @@
 
 import { create } from "zustand";
 import type { AppError } from "@/lib/errors";
-import { describeError, isAppError } from "@/lib/errors";
+import { appErrorMessage, isAppError } from "@/lib/errors";
 import type { LfsStatus } from "@/lib/types";
 import { lfsCheckout, lfsFetch, lfsPull, lfsStatus } from "@/lib/tauri";
 import { useRepoStore, withAuthRetry } from "@/features/repo/useRepoStore";
 
 function toAppError(e: unknown): AppError {
-  return isAppError(e) ? e : { kind: "Internal", message: describeError(e) };
+  return isAppError(e) ? e : { kind: "Internal", message: appErrorMessage(e) };
 }
 
 /** Human-readable byte size for a pointer's payload. */

--- a/src/features/merge/MergeWindow.test.tsx
+++ b/src/features/merge/MergeWindow.test.tsx
@@ -95,6 +95,28 @@ describe("MergeWindow shell", () => {
     );
   });
 
+  // The chooser is the resolver's ONLY path for a binary or deleted-side
+  // conflict, so a swallowed failure looks exactly like a dead button. #151
+  // fixed this same bug 300 lines above, in Apply's catch arm, and left this one.
+  it("reports a failed chooser resolution instead of swallowing it", async () => {
+    setSearch("window=merge&repoId=r1&path=blob.bin");
+    mockInvoke("get_status", () => conflictedStatus(["blob.bin"]));
+    mockInvoke("conflict_sides", () => ({
+      path: "blob.bin", base: null, ours: null, theirs: null, binary: true,
+    }));
+    mockInvoke("accept_ours", () => {
+      // A rejected Tauri command: a plain `{ kind, message }`, never an Error.
+      throw { kind: "Git", message: "index is locked" };
+    });
+    render(<MergeWindow />);
+    await screen.findByTestId("merge-chooser");
+    await userEvent.click(screen.getByTestId("chooser-take-ours"));
+    const banner = await screen.findByRole("alert");
+    expect(banner).toHaveTextContent("index is locked");
+    // ...and the button is usable again, not left disabled by a dead `busy`.
+    expect(screen.getByTestId("chooser-take-ours")).not.toBeDisabled();
+  });
+
   it("shows deleted-side chooser labels when ours is null", async () => {
     setSearch("window=merge&repoId=r1&path=gone.txt");
     mockInvoke("get_status", () => conflictedStatus(["gone.txt"]));

--- a/src/features/merge/MergeWindow.tsx
+++ b/src/features/merge/MergeWindow.tsx
@@ -426,7 +426,13 @@ export function MergeWindow() {
               <PGSpinner size={18} />
             </div>
           ) : chooser ? (
-            <ChooserPanel sides={sides!} repoId={repoId} path={path} onResolved={advance} />
+            <ChooserPanel
+              sides={sides!}
+              repoId={repoId}
+              path={path}
+              onResolved={advance}
+              onError={setApplyError}
+            />
           ) : model ? (
             <MergeBody
               key={path}
@@ -540,11 +546,14 @@ function ChooserPanel({
   repoId,
   path,
   onResolved,
+  onError,
 }: {
   sides: ConflictSides;
   repoId: string;
   path: string;
   onResolved: () => Promise<void>;
+  /** Surface a failure in the window's shared banner; `null` clears it. */
+  onError: (message: string | null) => void;
 }) {
   const [busy, setBusy] = React.useState(false);
   const oursLabel = sides.binary
@@ -560,11 +569,17 @@ function ChooserPanel({
   const pick = async (side: "ours" | "theirs") => {
     setBusy(true);
     try {
+      onError(null);
       if (side === "ours") await acceptOursIpc(repoId, path);
       else await acceptTheirsIpc(repoId, path);
       await onResolved();
     } catch (e) {
+      // These two buttons are the ONLY way to resolve a binary or deleted-side
+      // conflict, so a console-only failure looks exactly like a dead button.
+      // Same banner Apply uses, and `appErrorMessage` for the same reason: a
+      // rejected command is a plain `{ kind, message }`, never an Error (#146).
       console.error("chooser resolution failed", e);
+      onError(appErrorMessage(e));
     } finally {
       setBusy(false);
     }

--- a/src/features/reflog/useReflogStore.ts
+++ b/src/features/reflog/useReflogStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import type { FileDiff, ReflogEntry } from "@/lib/types";
 import type { AppError } from "@/lib/errors";
-import { appErrorMessage, isAppError } from "@/lib/errors";
+import { toAppError } from "@/lib/errors";
 import {
   checkoutDetached,
   createBranch as createBranchFn,
@@ -34,10 +34,6 @@ interface ReflogState {
   rememberAction: (a: ReflogActionChoice) => void;
   clearRememberedAction: () => void;
   clearError: () => void;
-}
-
-function toAppError(e: unknown): AppError {
-  return isAppError(e) ? e : { kind: "Internal", message: appErrorMessage(e) };
 }
 
 function currentRepoId(): string | null {

--- a/src/features/reflog/useReflogStore.ts
+++ b/src/features/reflog/useReflogStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import type { FileDiff, ReflogEntry } from "@/lib/types";
 import type { AppError } from "@/lib/errors";
-import { describeError, isAppError } from "@/lib/errors";
+import { appErrorMessage, isAppError } from "@/lib/errors";
 import {
   checkoutDetached,
   createBranch as createBranchFn,
@@ -37,7 +37,7 @@ interface ReflogState {
 }
 
 function toAppError(e: unknown): AppError {
-  return isAppError(e) ? e : { kind: "Internal", message: describeError(e) };
+  return isAppError(e) ? e : { kind: "Internal", message: appErrorMessage(e) };
 }
 
 function currentRepoId(): string | null {

--- a/src/features/repo/useRepoStore.errorText.test.ts
+++ b/src/features/repo/useRepoStore.errorText.test.ts
@@ -1,0 +1,47 @@
+// What the error BANNER reads for a throw that is not an AppError.
+//
+// #151 pointed the five `toAppError` copies at `describeError`, which formats for
+// the LOG FILE — it leads with a discriminant on purpose. That fixed the actual
+// bug (a plain object read "[object Object]") but also put "TypeError: " in front
+// of every banner message from a thrown JS Error, which is developer text in a
+// place four other stores already use `appErrorMessage` for.
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { mockInvoke } from "@/test/invokeMock";
+
+const HANDLE = { id: "repo-1", path: "/tmp/r", head: "main" };
+const initial = useRepoStore.getState();
+
+/** A store action whose IPC throws `thrown`, run against an open repository. */
+async function stageThrowing(thrown: unknown) {
+  useRepoStore.setState({ ...initial, current: HANDLE }, true);
+  useRepoStore.setState({ refreshStatus: async () => {} });
+  mockInvoke("stage_paths", () => {
+    throw thrown;
+  });
+  await useRepoStore.getState().stage(["a.txt"]);
+  return useRepoStore.getState().error;
+}
+
+describe("useRepoStore's error banner text", () => {
+  beforeEach(() => {
+    useRepoStore.setState(initial, true);
+  });
+
+  it("shows a thrown Error's prose without the class name a log line wants", async () => {
+    const err = await stageThrowing(new TypeError("x is not a function"));
+    expect(err).toEqual({ kind: "Internal", message: "x is not a function" });
+  });
+
+  it("still renders a plain thrown object's reason — the #146 bug", async () => {
+    const err = await stageThrowing({ code: 7, why: "nope" });
+    expect(err?.message).not.toContain("[object Object]");
+    expect(err?.message).toContain("nope");
+  });
+
+  it("passes a real AppError through untouched", async () => {
+    const app = { kind: "Git", message: "index is locked" };
+    expect(await stageThrowing(app)).toEqual(app);
+  });
+});

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -11,7 +11,7 @@ import type {
 } from "@/lib/types";
 import type { AppError } from "@/lib/errors";
 import {
-  describeError,
+  appErrorMessage,
   dubiousOwnershipPath,
   isAppError,
   isAuthError,
@@ -305,10 +305,13 @@ interface RepoStoreState extends RepoSlice {
 }
 
 function toAppError(e: unknown): AppError {
-  // `describeError`, not `String(e)`: this message is what the error banner
-  // renders, so a thrown plain object used to reach the user as
-  // "[object Object]" (#146).
-  return isAppError(e) ? e : { kind: "Internal", message: describeError(e) };
+  // `appErrorMessage`, not `String(e)` and not `describeError`: this message is
+  // what the error BANNER renders. `String(e)` reached the user as
+  // "[object Object]" for a rejected command (#146); `describeError` formats for
+  // the log file, so it leads with a discriminant — "TypeError: x is not a
+  // function" is developer text in a banner. Both fix the actual bug; only one
+  // is the right voice, and it is the one four other stores already use.
+  return isAppError(e) ? e : { kind: "Internal", message: appErrorMessage(e) };
 }
 
 /**

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -184,8 +184,13 @@ interface RepoStoreState extends RepoSlice {
    */
   listFilesAtRev: (revspec: string) => Promise<FileStatus[] | null>;
   /**
-   * Read a file's content from the tree at `revspec`. Returns null on failure
-   * (error is set on the store).
+   * Read a file's content from the tree at `revspec`.
+   *
+   * `null` means one of two things, and the caller cannot tell them apart from
+   * the value alone: that tree holds no text at that path (absent, a directory,
+   * a submodule gitlink — a STATE since #146, nothing set on the store), or the
+   * read failed and `error` is now set. Both render the same empty pane, which
+   * is why one sentinel is enough here; read `error` if you need to distinguish.
    */
   readFileContentAtRev: (
     revspec: string,

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -11,11 +11,10 @@ import type {
 } from "@/lib/types";
 import type { AppError } from "@/lib/errors";
 import {
-  appErrorMessage,
   dubiousOwnershipPath,
-  isAppError,
   isAuthError,
   isDubiousOwnershipError,
+  toAppError,
 } from "@/lib/errors";
 import { useAuthStore } from "@/features/auth/useAuthStore";
 import { confirmTrust } from "@/features/repo/ownership";
@@ -302,16 +301,6 @@ interface RepoStoreState extends RepoSlice {
   bisectReset: () => Promise<void>;
   appendGitignore: (pattern: string) => Promise<void>;
   openInEditor: (relativePath: string) => Promise<void>;
-}
-
-function toAppError(e: unknown): AppError {
-  // `appErrorMessage`, not `String(e)` and not `describeError`: this message is
-  // what the error BANNER renders. `String(e)` reached the user as
-  // "[object Object]" for a rejected command (#146); `describeError` formats for
-  // the log file, so it leads with a discriminant — "TypeError: x is not a
-  // function" is developer text in a banner. Both fix the actual bug; only one
-  // is the right voice, and it is the one four other stores already use.
-  return isAppError(e) ? e : { kind: "Internal", message: appErrorMessage(e) };
 }
 
 /**

--- a/src/features/submodules/useSubmodulesStore.ts
+++ b/src/features/submodules/useSubmodulesStore.ts
@@ -4,7 +4,7 @@
 
 import { create } from "zustand";
 import type { AppError } from "@/lib/errors";
-import { appErrorMessage, isAppError } from "@/lib/errors";
+import { toAppError } from "@/lib/errors";
 import type { SubmoduleInfo } from "@/lib/types";
 import {
   listSubmodules,
@@ -23,10 +23,6 @@ function readRecursive(): boolean {
   } catch {
     return false;
   }
-}
-
-function toAppError(e: unknown): AppError {
-  return isAppError(e) ? e : { kind: "Internal", message: appErrorMessage(e) };
 }
 
 /** Absolute path of a submodule's checkout, for "open as repository". */

--- a/src/features/submodules/useSubmodulesStore.ts
+++ b/src/features/submodules/useSubmodulesStore.ts
@@ -4,7 +4,7 @@
 
 import { create } from "zustand";
 import type { AppError } from "@/lib/errors";
-import { describeError, isAppError } from "@/lib/errors";
+import { appErrorMessage, isAppError } from "@/lib/errors";
 import type { SubmoduleInfo } from "@/lib/types";
 import {
   listSubmodules,
@@ -26,7 +26,7 @@ function readRecursive(): boolean {
 }
 
 function toAppError(e: unknown): AppError {
-  return isAppError(e) ? e : { kind: "Internal", message: describeError(e) };
+  return isAppError(e) ? e : { kind: "Internal", message: appErrorMessage(e) };
 }
 
 /** Absolute path of a submodule's checkout, for "open as repository". */

--- a/src/features/worktrees/useWorktreesStore.ts
+++ b/src/features/worktrees/useWorktreesStore.ts
@@ -7,7 +7,7 @@
 import { create } from "zustand";
 import { pgConfirm, pgPrompt } from "@/design";
 import type { AppError } from "@/lib/errors";
-import { describeError, isAppError } from "@/lib/errors";
+import { appErrorMessage, isAppError } from "@/lib/errors";
 import type { WorktreeBranch, WorktreeInfo } from "@/lib/types";
 import {
   listWorktrees,
@@ -21,7 +21,7 @@ import { useTabsStore } from "@/features/repo/useTabsStore";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 
 function toAppError(e: unknown): AppError {
-  return isAppError(e) ? e : { kind: "Internal", message: describeError(e) };
+  return isAppError(e) ? e : { kind: "Internal", message: appErrorMessage(e) };
 }
 
 interface WorktreesState {

--- a/src/features/worktrees/useWorktreesStore.ts
+++ b/src/features/worktrees/useWorktreesStore.ts
@@ -7,7 +7,7 @@
 import { create } from "zustand";
 import { pgConfirm, pgPrompt } from "@/design";
 import type { AppError } from "@/lib/errors";
-import { appErrorMessage, isAppError } from "@/lib/errors";
+import { toAppError } from "@/lib/errors";
 import type { WorktreeBranch, WorktreeInfo } from "@/lib/types";
 import {
   listWorktrees,
@@ -19,10 +19,6 @@ import {
 } from "@/lib/tauri";
 import { useTabsStore } from "@/features/repo/useTabsStore";
 import { useRepoStore } from "@/features/repo/useRepoStore";
-
-function toAppError(e: unknown): AppError {
-  return isAppError(e) ? e : { kind: "Internal", message: appErrorMessage(e) };
-}
 
 interface WorktreesState {
   items: WorktreeInfo[];

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -108,6 +108,75 @@ describe("describeError", () => {
   });
 });
 
+/**
+ * The three shapes the original 13 tests skipped, all reachable TODAY: every one
+ * of them goes through `appErrorDetail`, whose `e.message ?? ""` assumed a
+ * string. `isAppError` accepts any object carrying a string `kind`, so a foreign
+ * object qualifies — and the moment Rust grows a second struct-payload variant
+ * (`Auth` is the first) a real one does too.
+ */
+describe("an AppError whose message is not a string", () => {
+  const nested = { kind: "Git", message: { nested: true } };
+
+  it("does not reach the log as [object Object]", () => {
+    // Pre-fix this returned literally "Git: [object Object]" — the one string
+    // describeError's own docstring says it can never return.
+    const s = describeError(nested);
+    expect(s).not.toContain(OBJ);
+    expect(s).toContain("Git");
+    expect(s).toContain("nested");
+  });
+
+  it("does not reach a banner as a non-string", () => {
+    // Pre-fix this returned the OBJECT itself from a function typed `: string`
+    // — "Objects are not valid as a React child" in a banner, "[object Object]"
+    // in a template.
+    const m = appErrorMessage(nested);
+    expect(typeof m).toBe("string");
+    expect(m).not.toContain(OBJ);
+  });
+
+  it("keeps a struct payload's own rendering for the variants that have one", () => {
+    // The shape guards must not cost Auth its sentence.
+    expect(appErrorMessage({ kind: "Auth", message: { host: "h", kind: "Https" } })).toContain(
+      "h",
+    );
+    expect(appErrorMessage({ kind: "BranchExists", message: "feat/x" })).toContain("feat/x");
+  });
+});
+
+describe("an AppError whose message getter throws", () => {
+  const hostile = () => ({
+    kind: "Git",
+    get message(): string {
+      throw new Error("payload is a trap");
+    },
+  });
+
+  /**
+   * The dangerous one. `invoke` logs BEFORE it rethrows, so an exception raised
+   * INSIDE the logger replaces the original rejection: `isAuthError` downstream
+   * then fails to narrow and no credential prompt is raised — a network op just
+   * fails instead of asking for a password.
+   */
+  it("does not propagate out of describeError", () => {
+    let s = "";
+    expect(() => {
+      s = describeError(hostile());
+    }).not.toThrow();
+    expect(s).toContain("Git");
+    expect(s).not.toContain(OBJ);
+  });
+
+  it("does not propagate out of appErrorMessage either", () => {
+    let m = "";
+    expect(() => {
+      m = appErrorMessage(hostile());
+    }).not.toThrow();
+    expect(m.length).toBeGreaterThan(0);
+  });
+});
+
 describe("appErrorMessage", () => {
   it("still renders a sentence, without the kind prefix a log wants", () => {
     // The banner contract is unchanged: prose only, no discriminant.

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { appErrorMessage, describeError, type AppError } from "./errors";
+import { appErrorMessage, describeError, toAppError, type AppError } from "./errors";
 
 /**
  * #146: every backend failure reached the log file as `[object Object]`, so the
@@ -174,6 +174,28 @@ describe("an AppError whose message getter throws", () => {
       m = appErrorMessage(hostile());
     }).not.toThrow();
     expect(m.length).toBeGreaterThan(0);
+  });
+});
+
+describe("toAppError", () => {
+  it("passes a rejected command through with its identity intact", () => {
+    // Identity, not just shape: five `is*Error` narrowings key off `kind`, and a
+    // rewrapped Internal would defeat every one of them.
+    const app: AppError = { kind: "Auth", message: { host: "h", kind: "Https" } };
+    expect(toAppError(app)).toBe(app);
+  });
+
+  it("wraps anything else as Internal with the banner's wording", () => {
+    expect(toAppError(new TypeError("x is not a function"))).toEqual({
+      kind: "Internal",
+      message: "x is not a function",
+    });
+  });
+
+  it("never wraps a plain object as [object Object] — the #146 bug", () => {
+    const wrapped = toAppError({ code: 7, why: "nope" });
+    expect(wrapped.message).not.toContain(OBJ);
+    expect(wrapped.message).toContain("nope");
   });
 });
 

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -136,6 +136,16 @@ describe("an AppError whose message is not a string", () => {
     expect(m).not.toContain(OBJ);
   });
 
+  it("says something even when the kind itself is empty", () => {
+    // `isAppError` accepts `kind: ""` — it only checks the TYPE — so an empty
+    // kind and an empty message together used to compose the empty string the
+    // docstring promises never to return.
+    expect(describeError({ kind: "", message: "" })).not.toBe("");
+    expect(appErrorMessage({ kind: "", message: "" })).not.toBe("");
+    // A real message still wins, with no stray ": " prefix from the empty kind.
+    expect(describeError({ kind: "", message: "boom" })).toBe("boom");
+  });
+
   it("keeps a struct payload's own rendering for the variants that have one", () => {
     // The shape guards must not cost Auth its sentence.
     expect(appErrorMessage({ kind: "Auth", message: { host: "h", kind: "Https" } })).toContain(

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -152,7 +152,9 @@ function describeUnknown(e: unknown): string {
 
 export function appErrorMessage(e: unknown): string {
   try {
-    if (isAppError(e)) return appErrorDetail(e) || e.kind;
+    // `|| e.kind` is the no-prose fallback; `|| describeUnknown` catches an
+    // empty kind too, so a banner can never be blank.
+    if (isAppError(e)) return appErrorDetail(e) || e.kind || describeUnknown(e);
     if (e instanceof Error) return e.message;
     return describeUnknown(e);
   } catch {
@@ -211,7 +213,11 @@ export function describeError(e: unknown): string {
   try {
     if (isAppError(e)) {
       const detail = appErrorDetail(e);
-      return detail ? `${e.kind}: ${detail}` : e.kind;
+      // `isAppError` only checks that `kind` is a STRING, so it can be empty —
+      // and an empty kind with an empty message composed the one thing this
+      // function promises never to return. Fall back to the object itself.
+      if (detail) return e.kind ? `${e.kind}: ${detail}` : detail;
+      return e.kind || describeUnknown(e);
     }
     return describeUnknown(e);
   } catch {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -74,21 +74,53 @@ export function isAppError(e: unknown): e is AppError {
  * Empty when the variant carries no message at all (`Unborn`, `NoBisect`, …), so
  * callers decide what to show instead: a banner falls back to the kind, a log
  * line already has it.
+ *
+ * ALWAYS a string, whatever the payload is. `isAppError` accepts any object with
+ * a string `kind`, so `message` is only a string by convention — and `Auth`
+ * proves the enum itself can carry a struct. The old `e.message ?? ""` therefore
+ * returned an object for any shape without a case below: `[object Object]` in a
+ * log line, and "Objects are not valid as a React child" in a banner.
  */
 function appErrorDetail(e: AppError): string {
-  // Auth's payload is structured, not a sentence — render it here rather than
-  // letting an object reach the UI as "[object Object]".
-  if (e.kind === "Auth") return authChallengeMessage(e.message);
+  // ONE guarded read, so every branch below works on a value that is already in
+  // hand. A `message` getter that throws must not escape — see `describeError`.
+  let message: unknown;
+  try {
+    message = (e as { message?: unknown }).message;
+  } catch {
+    // Unreadable reads as "no prose available", same as a variant that carries
+    // none: both consumers then fall back to the kind, which is the whole
+    // reason that fallback exists.
+    return "";
+  }
+  // Each variant that carries a STRUCT or an IDENTIFIER instead of prose renders
+  // it here — and checks the shape it needs first, so a payload of the wrong
+  // type falls through to the generic tail instead of being mis-read.
+  //
+  // Auth's payload is structured, not a sentence.
+  if (e.kind === "Auth" && typeof message === "object" && message !== null) {
+    return authChallengeMessage(message as AuthChallenge);
+  }
   // ForgeAuth carries a HOST and BranchExists carries a BRANCH NAME, not
   // prose. Rendered raw, the banner would just read "github.com".
-  if (e.kind === "ForgeAuth") return forgeAuthMessage(e.message);
-  if (e.kind === "BranchExists")
-    return `A local branch named ${e.message} already exists.`;
+  if (e.kind === "ForgeAuth" && typeof message === "string") {
+    return forgeAuthMessage(message);
+  }
+  if (e.kind === "BranchExists" && typeof message === "string") {
+    return `A local branch named ${message} already exists.`;
+  }
   // StaleStash carries a LABEL (`stash@{1}`) — rendered raw the banner would
   // just read "stash@{1}" with no hint of what to do about it.
-  if (e.kind === "StaleStash")
-    return `${e.message} is no longer the entry you picked — the stash list changed. Refresh and try again.`;
-  return e.message ?? "";
+  if (e.kind === "StaleStash" && typeof message === "string") {
+    return `${message} is no longer the entry you picked — the stash list changed. Refresh and try again.`;
+  }
+  if (message === undefined || message === null) return "";
+  if (typeof message === "string") return message;
+  // Anything else: a future Rust variant carrying a struct with no case above,
+  // or a foreign object that merely satisfies `isAppError`. `describeUnknown` is
+  // what keeps the return type honest and "[object Object]" out of both the log
+  // file and the DOM.
+  return describeUnknown(message);
 }
 
 /**
@@ -119,9 +151,16 @@ function describeUnknown(e: unknown): string {
 }
 
 export function appErrorMessage(e: unknown): string {
-  if (isAppError(e)) return appErrorDetail(e) || e.kind;
-  if (e instanceof Error) return e.message;
-  return describeUnknown(e);
+  try {
+    if (isAppError(e)) return appErrorDetail(e) || e.kind;
+    if (e instanceof Error) return e.message;
+    return describeUnknown(e);
+  } catch {
+    // Same reason `describeError` is total: this runs in catch arms and in
+    // render, so throwing here would either replace the failure being reported
+    // or take the whole screen down with it.
+    return "The error could not be read.";
+  }
 }
 
 /**
@@ -134,16 +173,28 @@ export function appErrorMessage(e: unknown): string {
  * enum's spelling to a user.
  *
  * Total over every input shape: `AppError`, `Error`, string, `undefined`,
- * `null`, a bare object, a primitive. It never returns an empty string and
- * never returns `[object Object]`, which is what v0.0.11 logged for every
- * backend failure and what cost us the diagnosis in #146.
+ * `null`, a bare object, a primitive, an `AppError` whose message is not a
+ * string. It never returns an empty string and never returns `[object Object]`,
+ * which is what v0.0.11 logged for every backend failure and what cost us the
+ * diagnosis in #146.
+ *
+ * And it NEVER THROWS, which matters more than the formatting: `invoke` logs a
+ * failure and then rethrows it, in that order, so an exception raised in here
+ * would replace the original rejection — `isAuthError` would stop narrowing and
+ * a network op would fail silently instead of raising the credential prompt.
+ * Hence the catch-all: an unreadable payload (a throwing getter, an exotic
+ * proxy) costs a vague line, not the diagnosis.
  */
 export function describeError(e: unknown): string {
-  if (isAppError(e)) {
-    const detail = appErrorDetail(e);
-    return detail ? `${e.kind}: ${detail}` : e.kind;
+  try {
+    if (isAppError(e)) {
+      const detail = appErrorDetail(e);
+      return detail ? `${e.kind}: ${detail}` : e.kind;
+    }
+    return describeUnknown(e);
+  } catch {
+    return "<unreadable error>";
   }
-  return describeUnknown(e);
 }
 
 /** One-line description of an auth challenge, for banners and fallbacks. */

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -164,6 +164,28 @@ export function appErrorMessage(e: unknown): string {
 }
 
 /**
+ * Any throw as an `AppError`, for a store whose `error` field is one.
+ *
+ * A rejected Tauri command already IS an `AppError` and passes through with its
+ * identity intact — callers narrow on `kind` (`isAuthError`,
+ * `isLfsUnavailableError`, `isBranchExistsError`, `isDubiousOwnershipError`), and
+ * rewrapping it as `Internal` would defeat every one of them. Anything else — a
+ * bug in our own code, a rejected non-command promise — becomes `Internal`
+ * carrying `appErrorMessage`'s prose, because that string is what a BANNER
+ * renders, not a log line.
+ *
+ * One definition for the five stores that hold an `AppError`: `useRepoStore`,
+ * `useReflogStore`, `useWorktreesStore`, `useSubmodulesStore`, `useLfsStore`. It
+ * was five byte-identical copies, and #151 had to edit all five to change this
+ * one line. Stores whose `error` is a plain string (`useForgeStore`,
+ * `useCompareStore`, `useCreateStore`, `useUpdateStore`) call `appErrorMessage`
+ * directly and need nothing from here.
+ */
+export function toAppError(e: unknown): AppError {
+  return isAppError(e) ? e : { kind: "Internal", message: appErrorMessage(e) };
+}
+
+/**
  * One failure rendered for the LOG FILE, not for a banner (#146).
  *
  * Differs from `appErrorMessage` on purpose: a log line leads with the `kind`,

--- a/src/lib/syntax/useDiffSyntax.test.tsx
+++ b/src/lib/syntax/useDiffSyntax.test.tsx
@@ -1,0 +1,63 @@
+// The texts `useDiffSyntax` exposes are what whole-file mode fills gaps from, so
+// the ABSENT sentinel matters as much as the tokens.
+//
+// `null` is what `flattenDiffRows` bails on ("no text to fill from" → render the
+// hunks alone). An empty string is not the same thing: it says "this file has one
+// blank line", so a `?? ""` here would send whole-file mode off to compose a file
+// from nothing. Since #151 an absent side RESOLVES rather than rejecting, so this
+// sentinel is now on the common path (an added file's old side, a deleted file's
+// new side, a submodule, a directory).
+import { describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+import { mockInvoke } from "@/test/invokeMock";
+import { useDiffSyntax } from "./useDiffSyntax";
+
+vi.mock("./tokenize", async (orig) => ({
+  ...(await orig<typeof import("./tokenize")>()),
+  tokenizeFile: async () => null,
+}));
+
+describe("useDiffSyntax's exposed texts", () => {
+  it("keeps an absent side null rather than an empty string", async () => {
+    mockInvoke("read_file_content_at_rev", () => null);
+    mockInvoke("read_file_content", () => ({
+      path: "a.ts",
+      binary: false,
+      text: "one\ntwo\n",
+      fromHead: false,
+      size: 8,
+    }));
+
+    const { result } = renderHook(() =>
+      useDiffSyntax({
+        repoId: "r1",
+        path: "a.ts",
+        old: { kind: "rev", rev: "HEAD" },
+        new: { kind: "worktree" },
+      }),
+    );
+
+    await waitFor(() => expect(result.current.newText).toBe("one\ntwo\n"));
+    expect(result.current.oldText).toBeNull();
+  });
+
+  it("keeps a rejected side null too", async () => {
+    mockInvoke("read_file_content_at_rev", () => {
+      throw { kind: "UnknownRepo", message: "r1" };
+    });
+    mockInvoke("read_file_content", () => null);
+
+    const { result } = renderHook(() =>
+      useDiffSyntax({
+        repoId: "r1",
+        path: "a.ts",
+        old: { kind: "rev", rev: "HEAD" },
+        new: { kind: "worktree" },
+      }),
+    );
+
+    await waitFor(() => expect(result.current.oldText).toBeNull());
+    expect(result.current.newText).toBeNull();
+  });
+});

--- a/src/lib/syntax/useDiffSyntax.ts
+++ b/src/lib/syntax/useDiffSyntax.ts
@@ -49,7 +49,8 @@ const EMPTY: DiffSyntax = { old: null, new: null, oldText: null, newText: null }
  *
  * A side with no content yields no tokens and those rows render plain: a missing
  * blob must never break a diff. Since #146 an ABSENT blob resolves to `null`
- * rather than rejecting, so it no longer reaches the log as an error — the
+ * rather than rejecting — for all three readers, the worktree one included, so a
+ * submodule or directory row no longer reaches the log as an error either. The
  * `catch` below now covers only genuine failures, which still do.
  *
  * Panes that diff against the INDEX (the commit panel) ask for it directly with

--- a/src/lib/tauri.errors.test.ts
+++ b/src/lib/tauri.errors.test.ts
@@ -1,0 +1,41 @@
+// The shared invoke() wrapper logs a failure and then RETHROWS it. Those two
+// steps are in that order, so anything the logger can throw replaces the
+// rejection every caller downstream narrows on — `isAuthError` stops matching
+// and the credential dialog is never raised (#146 follow-up).
+import { describe, it, expect, vi } from "vitest";
+import { error as logError } from "@tauri-apps/plugin-log";
+
+import { mockInvoke } from "@/test/invokeMock";
+import { getStatus } from "./tauri";
+
+describe("invoke's failure logging", () => {
+  it("rethrows the ORIGINAL rejection even for an error the logger cannot read", async () => {
+    const hostile = {
+      kind: "Auth",
+      get message(): never {
+        throw new Error("payload is a trap");
+      },
+    };
+    mockInvoke("get_status", () => {
+      throw hostile;
+    });
+
+    // Identity, not shape: the caller must get the very object the command
+    // rejected with, or narrowing on it is meaningless.
+    await expect(getStatus("r1")).rejects.toBe(hostile);
+    expect(logError).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(logError).mock.calls[0][0]).toContain("get_status");
+  });
+
+  it("logs a plain rejected object with its reason, not [object Object]", async () => {
+    mockInvoke("get_status", () => {
+      throw { kind: "InvalidPath", message: "file not found: old.ts" };
+    });
+
+    await expect(getStatus("r1")).rejects.toBeTruthy();
+    const line = String(vi.mocked(logError).mock.calls[0][0]);
+    expect(line).toContain("InvalidPath");
+    expect(line).toContain("file not found: old.ts");
+    expect(line).not.toContain("[object Object]");
+  });
+});

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -104,11 +104,22 @@ export async function listAllFiles(repoId: string): Promise<FileStatus[]> {
   return invoke<FileStatus[]>("list_all_files", { repoId });
 }
 
+/**
+ * Read a file's content from the worktree, falling back to the HEAD blob for a
+ * deleted file.
+ *
+ * Resolves to `null` — it does NOT reject — when neither side holds text: a
+ * directory, a submodule gitlink, or a path that vanished after the status
+ * snapshot the caller is rendering. The HEAD fallback only recovers a BLOB, so
+ * clicking a clean submodule row was routine and still cost ERROR lines in the
+ * log for a pane that rendered nothing either way (#146). A genuine failure
+ * (unknown repository, unreadable file) still rejects.
+ */
 export async function readFileContent(
   repoId: string,
   path: string,
-): Promise<FileContent> {
-  return invoke<FileContent>("read_file_content", { repoId, path });
+): Promise<FileContent | null> {
+  return invoke<FileContent | null>("read_file_content", { repoId, path });
 }
 
 /**


### PR DESCRIPTION
Follow-up to PR 151 (already merged), which fixed the `[object Object]` logging and
made two absent-file reads answer `Ok(None)`. An adversarial review found the fix
incomplete in six ways — including that the new code's own documentation asserted
things that were false. Referring to the issue as "issue 146" in prose deliberately:
it must stay open for the unreproduced freeze, and no part of it is addressed here.

Every fix below was watched failing first. Evidence is quoted per finding.

## 1. `describeError`'s "never `[object Object]`" invariant was false

`appErrorDetail`'s `e.message ?? ""` assumed a string. Three shapes broke it, and
all three are reachable today — `isAppError` accepts any object carrying a string
`kind`, and `Auth` proves the enum itself can carry a struct:

| input | before | after |
| --- | --- | --- |
| `describeError({kind:"Git", message:{nested:true}})` | `"Git: [object Object]"` | `"Git: {\"nested\":true}"` |
| `appErrorMessage(same)` | the OBJECT, `typeof "object"`, from a function typed `: string` | a string |
| a `message` getter that throws | **propagated out of `describeError`** | `"Git"` |

The third is the dangerous one. `invoke` logs a failure and *then* rethrows it, so
an exception raised inside the logger replaces the original rejection: `isAuthError`
stops narrowing downstream and no credential prompt is raised — a network op just
fails instead of asking for a password. `tauri.errors.test.ts` now pins that the
wrapper rethrows the **identical** object for an error the logger cannot read.

Each special-cased variant checks the payload shape it needs before reading it;
anything else is coerced through `describeUnknown`; both formatters are
exception-safe.

## 2 + 3. All three file-content readers errored on a submodule gitlink

One commit, because it turned out to be one root cause in three places rather than
the two the review found. Probed against a real submodule fixture before touching
anything:

```
ls-files:          160000 a0891571… 0  vendor/inner
worktree(gitlink): Err(Git("object not found - no match for id (a0891571…)"))
index(gitlink):    Err(Git("object not found - no match for id (a0891571…)"))
rev(gitlink):      Err(Git("object not found - no match for id (a0891571…)"))
```

A gitlink's oid names a commit in the **submodule's** object database, which the
superproject does not hold — so the entry's KIND has to be tested before the object
is looked up. `_at_index` had no non-blob guard at all; `_at_rev` had one, but
`entry.to_object()` runs first and fails before it; `read_file_content` fails in the
same call inside its HEAD fallback.

Two corrections to the review's own model, both verified: `_at_rev` was **not**
already safe here (its `as_blob()` guard is unreachable for a gitlink), and
`read_file_content` answered `Git`, not `InvalidPath`. The docs PR 151 added claimed
a gitlink "answers the same way" as an absent path for all of them; it did not for
any of them.

**Decision on the worktree reader:** `Ok(None)`, joining the other two. PR 151 left
it erroring on the reasoning that its HEAD fallback makes remaining absences
anomalous — but that fallback only recovers a **blob**. Clicking a clean submodule
row in the Files screen is an ordinary action and cost **three** ERROR lines per
click (this reader twice — the pane's own read plus `useDiffSyntax`'s new side — and
`_at_rev` once for the old side) for a pane that silently rendered nothing either
way. Same for a directory row, and for a file that vanished after the status
snapshot the caller is rendering. Every caller of all three readers is a diff or
preview surface that already treats "no text" as "render plain", so the asymmetry
had no defence beyond scope-limiting. Genuine failures still error: unknown
repository, bare repository, unreadable file, bad revspec — each with a test, plus
one pinning that the deleted-file HEAD fallback still works.

## 4. The merge chooser swallowed its failures

"Keep our version" / "Take theirs" reported nothing to the user and nothing to the
log file. It is the resolver's only path for a binary or deleted-side conflict, so a
failed `accept_ours` looked exactly like a dead button. Routed through the window's
existing apply-error banner, the way PR 151 fixed the identical bug in Apply's catch
arm 300 lines above.

## 5. `toAppError` used the log formatter for banner text

Two commits, deliberately split.

**Behaviour** — the five copies now use `appErrorMessage`, matching the four stores
that already did. A thrown `Error` reaches the banner as `"x is not a function"`
instead of `"TypeError: x is not a function"`. For the plain-object case that was
the actual bug the two formatters are byte-identical, so that fix stays intact.

**Consolidation** — one `toAppError` in `lib/errors.ts`. Five imports, no behaviour
change, and PR 151 had to edit all five copies to change the single line inside them.

## 6. The error boundary now writes to the log file

`componentDidCatch` was console-only, which never reaches the Rust log — the one
artifact a reporter can hand over, and the only one issue 146's reporter had.

Also closes the two absence gaps nothing asserted: `CommitDiffPanel`'s whole-file
composer with a read that RESOLVES null (the realistic path since PR 151 — the
throw-mock beside it never enters the same branch), and `useDiffSyntax` keeping an
absent side's text `null` rather than `""`. The second is the one that bites: a later
tidy-up to `o2?.text ?? ""` would tell whole-file mode the file is one blank line
rather than unknown. Verified by making that edit and watching both new cases fail.

## Also

- `useRepoStore.readFileContentAtRev`'s JSDoc no longer claims `null` means failure
  only; it now also means absent.
- CLAUDE.md records the three invariants PR 151 broke without contradicting anything
  written down: which formatter a banner uses versus a log line, that neither may
  throw or assume `message` is a string, and that "no text at this path" needs an
  explicit non-blob test in each reader.

## Verification

`pnpm tsc --noEmit`, `pnpm test` (1506 tests, 184 files), `pnpm exec tsc -p
e2e/tsconfig.json --noEmit`, `cargo check`, `cargo test` (58 suites, 0 failures) —
all green. E2E not run locally: another agent holds the Docker slot, so CI's
`e2e-linux` is the gate.

Draft, and no auto-close keyword is present in this description by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Er25sN6pGoVJzmTBwHU2Tz
