### PR TITLE
fix(merge): suppress the native context menu in the resolver window

### DIFF
--- a/src/features/merge/MergeWindow.test.tsx
+++ b/src/features/merge/MergeWindow.test.tsx
@@ -80,6 +80,26 @@ describe("MergeWindow shell", () => {
     ).toBe(true);
   });
 
+  // The resolver runs in its OWN window, so it has its own document and
+  // AppShell's `usePreventBrowserContextMenu` never applied to it. On Linux the
+  // menu that leaked through is WebKitGTK's native GtkMenu — a real GDK popup,
+  // with spell-check and input-method submenus on the editable result pane.
+  it("suppresses the native context menu, including over the result pane", async () => {
+    setSearch("window=merge&repoId=r1&path=conflict.txt");
+    mockInvoke("get_status", () => conflictedStatus(["conflict.txt"]));
+    mockInvoke("conflict_sides", () => textSides());
+    render(<MergeWindow />);
+    await waitFor(() =>
+      expect(screen.getByTestId("merge-file-path")).toHaveTextContent("conflict.txt"),
+    );
+
+    for (const target of [document.body, screen.getByTestId("merge-file-path")]) {
+      const ev = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+      target.dispatchEvent(ev);
+      expect(ev.defaultPrevented).toBe(true);
+    }
+  });
+
   it("shows the chooser for binary conflicts and resolves via accept_theirs", async () => {
     setSearch("window=merge&repoId=r1&path=blob.bin");
     mockInvoke("get_status", () => conflictedStatus(["blob.bin"]));

--- a/src/features/merge/MergeWindow.tsx
+++ b/src/features/merge/MergeWindow.tsx
@@ -16,6 +16,7 @@ import {
   PGSpinner,
   pgConfirm,
   usePaneWidth,
+  usePreventBrowserContextMenu,
 } from "@/design";
 import { MergeFileList, type MergeFile } from "./FileList";
 import {
@@ -39,6 +40,14 @@ export function findNextConflict(status: FileStatus[], current: string): string 
 }
 
 export function MergeWindow() {
+  // Each WINDOW needs its own listener — the hook is document-scoped and this
+  // window has its own document, so `AppShell`'s call covers only the main one.
+  // Without it WebKitGTK's native context menu was reachable throughout the
+  // resolver, including on the editable result pane, where right-click also
+  // opens spell-check and input-method SUBMENUS. On Linux that is a real
+  // GtkMenu (a native GDK popup), so it is also the one surface in this window
+  // that could take a toolkit grab mid-conflict-resolution.
+  usePreventBrowserContextMenu();
   const params = new URLSearchParams(window.location.search);
   const [repoId, setRepoId] = React.useState(params.get("repoId") ?? "");
   const [path, setPath] = React.useState(params.get("path") ?? "");


### PR DESCRIPTION
`usePreventBrowserContextMenu` was called only in `AppShell` (`src/AppShell.tsx:161`). The hook attaches a **`document`**-level `contextmenu` listener, and the merge resolver is a separate Tauri window with its own document — so nothing in that window ever prevented the native menu.

Same per-window rule CLAUDE.md already states for `PGDialogHost`: *"A `<PGDialogHost />` must be mounted in each window (`AppShell`, `MergeWindow`)"*. This is the second hook with that property, and it was mounted in one window instead of both.

## Why this matters beyond the inconsistency

On Linux, WebKitGTK's default context menu is a real **GtkMenu** — a native GDK popup, and on the editable CM6 result pane it carries nested spell-check and input-method submenus. So it was:

- the one surface in the resolver window that can take a toolkit grab, and
- reachable **mid-conflict-resolution**, over an editor holding merged work that exists nowhere else on disk yet.

It surfaced while investigating the Linux freeze in issue 146. **It is not a fix for that freeze** and is not claimed as one — nested native popups are simply not something this window should be able to open, on any platform. On macOS and Windows the same right-click produced a platform menu offering Reload and Inspect Element over a half-resolved conflict, which is its own reason.

Our own menus are unaffected: they are in-page React portals, and `useContextMenu` already calls `stopPropagation`, so the document-level handler never sees those events. `FileList`'s row menu still opens — covered by the existing `MergeWindow.filelist` tests, which pass.

## Test

`MergeWindow.test.tsx` dispatches a cancelable `contextmenu` at both the document body and a pane inside the resolver, and asserts `defaultPrevented` on each. Verified it fails with the hook call removed:

```
FAIL src/features/merge/MergeWindow.test.tsx > MergeWindow shell >
     suppresses the native context menu, including over the result pane
     99| expect(ev.defaultPrevented).toBe(true);
Tests  1 failed | 13 passed (14)
```

## Verification

`pnpm tsc --noEmit` clean; `pnpm test` 1517 passed / 185 files. Rust untouched. E2E in Docker: `merge-window.e2e.ts` — the spec that drives this window.

Scope is one hook call plus its test. Issue 146 stays open for the freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Er25sN6pGoVJzmTBwHU2Tz
