### PR TITLE
feat(history): view the diff of a commit selection from the menu and Mod+D (#158)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -958,6 +958,17 @@ module and every `src/features/*/` directory is named somewhere in here.
   sheet and palette then name each behavior in its own category, and the two can
   be rebound apart. Register the pane handler as declining (`() => false`) when it
   has nothing to act on, or it swallows the chord from the other action.
+- **A pane action may also share a chord with a GLOBAL one — but then the BINDING
+  ORDER is load-bearing** (#158). `Mod+D` is `diff.viewCombined` in
+  `history.list` and `nav.diff` everywhere else. A global action with a default
+  runner never declines, so tried first it shadows the pane action permanently and
+  silently; the pane entry must come earlier in the preset table (`COMMON` is
+  spread before the per-preset `nav.*`, which is why it lands there), and
+  `presets.test.ts` pins the resulting `rev.get("Mod+D")` order. The pane
+  handler's decline is then what keeps the global chord working — and since
+  History always has one commit selected, "decline" there means *fewer than two*,
+  not "nothing selected": claiming the single case would take `Mod+D` away from the
+  Diff viewer on the launch screen.
 - `useNavStore.intent` drives deep-view switches (e.g. "show this commit's diff" → sets screen to `commitDiff`). Consumers write an intent; `AppShell` effect routes the screen.
 - **A new `NavIntent` kind must be routed in AppShell, and both halves of that
   are now enforced.** The routing switch ends in `default: assertNever(intent)`,

--- a/e2e/specs/history-diff.e2e.ts
+++ b/e2e/specs/history-diff.e2e.ts
@@ -2,6 +2,8 @@ import { browser, $, $$, expect } from "@wdio/globals";
 import { basicRepo, branchyRepo, dirtyRepo, TempRepo } from "../support/tempRepo";
 import {
   commitListTotal,
+  jsClickMenuItem,
+  jsContextMenu,
   openRepo,
   resetApp,
   scrollCommitListTo,
@@ -156,5 +158,82 @@ describe("history & diff", () => {
       ...(await rows[1]!.$$('svg [data-lane-kind="half-bot"], svg [data-lane-kind="line"]')),
     ];
     expect(trailing).toHaveLength(0);
+  });
+});
+
+// #158 — the diff entries on History's commit context menus. Appended as its own
+// block so it merges cleanly alongside concurrent work in this file.
+//
+// Before #158 the single-commit menu's only diff-shaped entry was "Compare with
+// HEAD" (that commit against the working tree), so right-clicking ONE commit and
+// right-clicking SEVERAL offered two different comparisons. "View diff" is the
+// commit's own diff — parent..commit, what Enter on the row and the inline panel
+// already show — and it pairs with the selection's "View combined diff".
+describe("history — the commit menu's diff entries (#158)", () => {
+  let repo: TempRepo;
+
+  afterEach(async () => {
+    await resetApp();
+    repo.dispose();
+  });
+
+  it('"View diff" opens the commit\'s own diff (parent..commit)', async () => {
+    repo = basicRepo();
+    // basicRepo, oldest first: "feat: add a.txt", "feat: add b.txt",
+    // "fix: update a.txt". The MIDDLE commit is the one to pick: it added b.txt
+    // and nothing since touched that file, so b.txt on screen can only come
+    // from parent..commit — "Compare with HEAD" would show a.txt (changed by
+    // the newer commit) and no b.txt at all.
+    const sha = repo.git("rev-parse", "--short=7", "HEAD~1").trim();
+    await openRepo(repo.path);
+    await switchScreen("history");
+    await $("span*=SUBJECT").waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "history column headers never appeared",
+    });
+    await scrollCommitListTo("feat: add b.txt");
+
+    await jsContextMenu('[data-testid="commit-row"]', { text: "feat: add b.txt" });
+    // Exact span text, so this can never match "View combined diff".
+    await jsClickMenuItem("View diff");
+
+    // The destination's own header first — it names the commit that was routed,
+    // so a mis-routed intent fails here rather than as a mute timeout on a file
+    // row (the lesson history-ops.e2e.ts records at length).
+    await $(`div*=Diff ${sha} (this commit)`).waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: `the commit-diff header never showed ${sha} (this commit)`,
+    });
+    // Then the file row, scoped to the commit-diff file pane: a bare
+    // `[data-pg-row]*=b.txt` would also match History's own row for
+    // "feat: add b.txt", which the screen switch is about to unmount.
+    await $(
+      '[data-pg-pane="commitDiff.files"] [data-pg-row][data-path="b.txt"]',
+    ).waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "the commit's own diff never listed b.txt",
+    });
+  });
+
+  it('"Compare with HEAD" is still there beside it, and still compares with the working tree', async () => {
+    repo = basicRepo();
+    const sha = repo.git("rev-parse", "--short=7", "HEAD~1").trim();
+    await openRepo(repo.path);
+    await switchScreen("history");
+    await $("span*=SUBJECT").waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "history column headers never appeared",
+    });
+    await scrollCommitListTo("feat: add b.txt");
+
+    await jsContextMenu('[data-testid="commit-row"]', { text: "feat: add b.txt" });
+    await jsClickMenuItem("Compare with HEAD");
+
+    // Its own header spelling — proof the two entries route differently rather
+    // than one having quietly replaced the other.
+    await $(`div*=Diff ${sha} → HEAD`).waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: `the commit-diff header never showed ${sha} → HEAD`,
+    });
   });
 });

--- a/e2e/specs/keymap.e2e.ts
+++ b/e2e/specs/keymap.e2e.ts
@@ -527,3 +527,94 @@ describe("keymap — rider preset (default)", () => {
     await waitScreen('[data-pg-pane="commit.files"]', "Commit (classic ⌘2)");
   });
 });
+
+// ⌘D over the History commit list (#158). Appended as its own block so it merges
+// cleanly alongside concurrent work in this file.
+//
+// The chord carries TWO actions: the pane-scoped `diff.viewCombined` (this
+// list's combined diff) and the global `nav.diff` (go to the Diff viewer). The
+// dispatcher tries them in order and stops at the first that does not decline,
+// so both halves need proving in the real app: the claim, and — more
+// importantly — the fall-through, since History is the launch screen and a
+// handler that swallowed ⌘D there would strand the Diff viewer.
+describe("keymap — ⌘D over the History commit list (#158)", () => {
+  let repo: TempRepo | null = null;
+
+  afterEach(async () => {
+    await resetApp();
+    repo?.dispose(); repo = null;
+  });
+
+  it("⌘D on a multi-selection opens the combined diff of the range", async () => {
+    repo = basicRepo();
+    // Rows are newest-first: "fix: update a.txt" (HEAD), "feat: add b.txt",
+    // "feat: add a.txt" (root). Selecting the first two makes the range
+    // parent-of-oldest → newest = root → HEAD.
+    const from = repo.git("rev-parse", "--short=7", "HEAD~2").trim();
+    const to = repo.git("rev-parse", "--short=7", "HEAD").trim();
+    await openRepo(repo.path);
+    await waitScreen('[data-pg-pane="history.list"]', "History");
+    await waitFocusedPane("history.list", "opening a repo should focus the commit list");
+
+    // Keyboard-only, so nothing about this depends on a click also moving focus.
+    await jsChord("Home");
+    await waitHistorySelection("fix: update a.txt", "Home");
+    await jsChord("Shift+ArrowDown");
+    // NOT waitHistorySelection: two rows now carry [data-selected], and that
+    // helper reads the FIRST one — which is still the row Home landed on. The
+    // multi-selection detail pane is the signal that the range exists.
+    await waitScreen("div*=2 commits selected", "multi-selection detail");
+
+    await jsChord("Mod+D");
+    await $(`div*=Diff ${from} → ${to}`).waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: `⌘D never routed the selection's combined diff (${from} → ${to})`,
+    });
+    // b.txt is added inside that range, so it can only appear if the range —
+    // not one commit — was diffed.
+    await $(
+      '[data-pg-pane="commitDiff.files"] [data-pg-row][data-path="b.txt"]',
+    ).waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "the combined diff never listed b.txt",
+    });
+  });
+
+  // THE fall-through. One commit is always selected in History, so if the pane
+  // handler claimed "anything selected" this would land on the commit diff and
+  // ⌘D would never reach the Diff viewer from the screen the app opens on.
+  it("⌘D with a single commit selected still reaches the Diff viewer", async () => {
+    // dirtyRepo: the Diff screen renders "Nothing to diff" on a clean tree, so
+    // its panes only exist when there are changes.
+    repo = dirtyRepo();
+    await openRepo(repo.path);
+    await waitScreen('[data-pg-pane="history.list"]', "History");
+    await waitFocusedPane("history.list", "opening a repo should focus the commit list");
+    await jsChord("Home"); // exactly one row selected
+
+    await jsChord("Mod+D");
+    await waitScreen('[data-pg-pane="diff.files"]', "Diff (⌘D, single selection)");
+  });
+
+  // ...and the pane scope itself: the selection is still two commits here, so
+  // only the dispatcher's pane filter can be what keeps the chord global.
+  it("⌘D from outside the list reaches the Diff viewer even with a multi-selection", async () => {
+    repo = dirtyRepo();
+    await openRepo(repo.path);
+    await waitScreen('[data-pg-pane="history.list"]', "History");
+    await waitFocusedPane("history.list", "opening a repo should focus the commit list");
+    await jsChord("Home");
+    await jsChord("Shift+ArrowDown");
+    // Same reason as above: with two rows selected the selected-row helper
+    // reads the first of them, so the detail pane is the honest signal.
+    await waitScreen("div*=2 commits selected", "multi-selection detail");
+
+    // Off the list without changing the selection: the activity bar is the
+    // nearest focusable thing to its left.
+    await jsChord("Alt+ArrowLeft");
+    await waitFocusedPane("activitybar", "Alt+ArrowLeft should reach the activity bar");
+
+    await jsChord("Mod+D");
+    await waitScreen('[data-pg-pane="diff.files"]', "Diff (⌘D, off the commit list)");
+  });
+});

--- a/src/design/context-menu.commitdiff.test.tsx
+++ b/src/design/context-menu.commitdiff.test.tsx
@@ -1,0 +1,111 @@
+// The diff entries on the History commit menus (#158). One commit and several
+// commits used to be offered different comparisons: a single commit's only
+// diff-shaped item was "Compare with HEAD" (commit vs the working tree), while a
+// selection got "View combined diff" (a range). The commit's OWN diff — what
+// Enter and the inline panel show — was in no menu at all.
+
+import { describe, it, expect, beforeEach } from "vitest";
+
+import {
+  commitMenuItems,
+  commitMultiMenuItems,
+  type ContextMenuItem,
+} from "./context-menu";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import type { CommitInfo } from "@/lib/types";
+
+const A = "a".repeat(40);
+const B = "b".repeat(40);
+const C = "c".repeat(40);
+const D = "d".repeat(40);
+
+const mk = (oid: string, summary: string, parents: string[]): CommitInfo => ({
+  oid,
+  shortOid: oid.slice(0, 7),
+  summary,
+  body: null,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 1_700_000_000,
+  parents,
+  refs: [],
+});
+
+// Newest-first, as the log is: A → B → C → D(root).
+const COMMITS = [
+  mk(A, "commit A", [B]),
+  mk(B, "commit B", [C]),
+  mk(C, "commit C", [D]),
+  mk(D, "commit D", []),
+];
+
+function labeled(items: ContextMenuItem[], label: string): ContextMenuItem {
+  const found = items.find((i) => i.label === label);
+  expect(found, `no menu item labelled "${label}"`).toBeTruthy();
+  return found!;
+}
+
+beforeEach(() => {
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    commits: COMMITS,
+    status: [],
+    branches: [
+      {
+        name: "main",
+        isHead: true,
+        isRemote: false,
+        upstream: null,
+        ahead: 0,
+        behind: 0,
+        tip: A,
+      },
+    ],
+    loading: false,
+  } as never);
+  useNavStore.setState({ intent: null });
+});
+
+describe("one commit's context menu", () => {
+  it('"View diff" opens the commit\'s own diff (commit-self), like Enter on the row', () => {
+    labeled(commitMenuItems({ sha: B, subject: "commit B" }), "View diff").onClick?.();
+    expect(useNavStore.getState().intent).toEqual({ kind: "commit-self", oid: B });
+  });
+
+  it('keeps "Compare with HEAD" — a different comparison, not a duplicate', () => {
+    const items = commitMenuItems({ sha: B, subject: "commit B" });
+    labeled(items, "Compare with HEAD").onClick?.();
+    expect(useNavStore.getState().intent).toEqual({ kind: "commit-vs-wt", oid: B });
+  });
+
+  it("offers View diff before Compare with HEAD (own diff is the common case)", () => {
+    const labels = commitMenuItems({ sha: B, subject: "commit B" })
+      .map((i) => i.label)
+      .filter((l): l is string => typeof l === "string");
+    expect(labels.indexOf("View diff")).toBeGreaterThanOrEqual(0);
+    expect(labels.indexOf("View diff")).toBeLessThan(
+      labels.indexOf("Compare with HEAD"),
+    );
+  });
+
+  it("does nothing without a sha rather than firing a bad intent", () => {
+    labeled(commitMenuItems(null), "View diff").onClick?.();
+    expect(useNavStore.getState().intent).toBeNull();
+  });
+});
+
+describe("the label pair", () => {
+  // "View diff" / "View combined diff" read as one family, and "combined" then
+  // carries information: this one spans a range. Renaming the multi item to
+  // "View diff" too would hide exactly the fact the range note surfaces.
+  it('a selection keeps "View combined diff", so "combined" marks the difference', () => {
+    const items = commitMultiMenuItems([A, B]);
+    labeled(items, "View combined diff").onClick?.();
+    expect(useNavStore.getState().intent).toEqual({
+      kind: "commit-vs-commit",
+      from: C,
+      to: A,
+    });
+  });
+});

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -526,6 +526,21 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
       },
     },
     { divider: true },
+    // The commit's OWN diff (parent..commit) — what Enter on the row and the
+    // inline panel already show, and what "View combined diff" shows for a
+    // selection of several (#158). Until this existed the menu's only
+    // diff-shaped entry was the one below, so right-clicking one commit and
+    // right-clicking three offered two different comparisons.
+    {
+      icon: "diff",
+      label: "View diff",
+      onClick: () => {
+        if (!commit?.sha) return;
+        useNavStore.getState().setIntent({ kind: "commit-self", oid: commit.sha });
+      },
+    },
+    // Kept alongside it: a genuinely different question — this commit's tree
+    // against the working tree, not against its parent.
     {
       icon: "diff",
       label: "Compare with HEAD",

--- a/src/features/keymap/actions.ts
+++ b/src/features/keymap/actions.ts
@@ -89,6 +89,7 @@ export type ActionId =
   | "diff.nextChange"
   | "diff.prevChange"
   | "diff.toggleLine"
+  | "diff.viewCombined"
   | "commit.commit"
   | "commit.commitAndPush"
   | "commit.toggleAmend"
@@ -309,6 +310,21 @@ export const ACTIONS: Record<ActionId, ActionDef> = {
   // sheet says "Diff / stage the focused line" instead of hiding a diff action
   // under "Lists & trees", and so the two can be rebound apart.
   "diff.toggleLine": { id: "diff.toggleLine", title: "Stage / unstage focused line", category: "Diff", scope: "pane" },
+  // #158. Shares Mod+D with the GLOBAL nav.diff, which is legal in exactly one
+  // direction: this action is pane-scoped, so the dispatcher only offers it while
+  // the History commit list holds focus, and when its handler declines the chord
+  // falls through to nav.diff's default runner (presets.test.ts forbids two
+  // GLOBAL actions on one chord, not this pairing — the same asymmetry that lets
+  // Space mean list.toggle in a list and diff.toggleLine in a diff).
+  //
+  // Its own catalog entry rather than a second meaning hung off nav.diff, so the
+  // cheat sheet names both behaviors and the two can be rebound apart.
+  //
+  // The handler (History.tsx) claims a MULTI-commit selection only. One selected
+  // commit already has its diff on screen inline and on Enter, and History is the
+  // launch screen — claiming the single case there would leave the Diff viewer
+  // with no chord anywhere a user starts.
+  "diff.viewCombined": { id: "diff.viewCombined", title: "View combined diff of selected commits", category: "Diff", scope: "pane" },
 
   "repo.open": { id: "repo.open", title: "Open repository…", category: "Repository", scope: "global", run: openRepoOp },
   "repo.clone": { id: "repo.clone", title: "Clone repository…", category: "Repository", scope: "global", run: cloneRepoOp },

--- a/src/features/keymap/presets.test.ts
+++ b/src/features/keymap/presets.test.ts
@@ -162,6 +162,36 @@ describe("platypusgit preset", () => {
   });
 });
 
+// #158. Mod+D carries two actions: the global "go to the Diff viewer" and the
+// History commit list's combined diff. The dispatcher tries the ids in the order
+// buildReverseMap produced them and stops at the first that does not decline —
+// and nav.diff is global WITH a default runner, so it NEVER declines. Tried
+// first it would shadow the pane action permanently and silently; tried second it
+// is the fallback the pane action's decline needs. That ordering is a fact about
+// the preset TABLES (COMMON is spread before nav.diff), invisible at the call
+// site, so it is pinned here.
+describe("Mod+D is shared between a pane action and a global one (#158)", () => {
+  for (const preset of BUILTIN_PRESETS) {
+    it(`${preset.id}: offers the pane action before any global one`, () => {
+      const ids = buildReverseMap(preset).get("Mod+D") ?? [];
+      expect(ids[0]).toBe("diff.viewCombined");
+      expect(ACTIONS["diff.viewCombined"].scope).toBe("pane");
+      const globals = ids.filter((id) => ACTIONS[id].scope === "global");
+      // Classic binds nav.diff to Mod+8, so there is nothing global on Mod+D
+      // there; rider has exactly nav.diff. Either way every global id must sort
+      // after the pane one.
+      for (const g of globals) expect(ids.indexOf(g)).toBeGreaterThan(0);
+    });
+  }
+
+  it("rider: the fallback behind the pane action is the Diff viewer", () => {
+    expect(buildReverseMap(RIDER_PRESET).get("Mod+D")).toEqual([
+      "diff.viewCombined",
+      "nav.diff",
+    ]);
+  });
+});
+
 describe("repository tabs (#90)", () => {
   // Every preset binds them (the catalog-coverage test above enforces that);
   // these pin the SHAPE of the chords, which is what makes them work on every

--- a/src/features/keymap/presets.ts
+++ b/src/features/keymap/presets.ts
@@ -75,6 +75,21 @@ const COMMON = {
   // because both actions are pane-scoped — presets.test.ts only forbids two
   // GLOBAL actions on one chord, and the dispatcher tries each id in turn.
   "diff.toggleLine": [" "],
+  // The History selection's combined diff, on the same Mod+D as nav.diff (#158).
+  // Legal because this one is pane-scoped: the dispatcher tries each id bound to
+  // a chord in turn, and the pane handler declines unless the commit list has
+  // focus with 2+ commits selected — so Mod+D still reaches the Diff viewer
+  // everywhere else. Rider's ⌘D is "Show diff", which is what both do.
+  //
+  // ORDER IS LOAD-BEARING: buildReverseMap walks Object.entries, so this entry
+  // must come BEFORE nav.diff's, and it does because COMMON is spread first in
+  // both presets. nav.diff is global WITH a default runner, so it never
+  // declines — tried first it would shadow this action permanently. Pinned by
+  // "Mod+D offers the pane action before the global one" in presets.test.ts.
+  //
+  // Bound in classic too (every catalog action must be), where nav.diff lives on
+  // Mod+8 and Mod+D is otherwise free.
+  "diff.viewCombined": ["Mod+D"],
   // Pull / merge requests (#92). The shifted-digit family is already where
   // screens without a primary number live (nav.reflog is ⌘⇧9 in rider), and
   // ⌘⇧8 is free in both presets — classic's asserted ⌘8 = Diff stays put.

--- a/src/screens/History.diffchord.test.tsx
+++ b/src/screens/History.diffchord.test.tsx
@@ -1,0 +1,169 @@
+// Mod+D over the History commit list (#158). The chord carries TWO actions: the
+// pane-scoped `diff.viewCombined` (this list's combined diff) and the global
+// `nav.diff` (go to the Diff viewer). The dispatcher tries them in order and
+// stops at the first that does not decline, so the DECLINE is the load-bearing
+// half: a handler that claimed the chord unconditionally would strand the Diff
+// viewer everywhere a History list happens to hold focus — which, History being
+// the launch screen, is most of the time.
+//
+// Hence the four cases below: claim only with 2+ commits selected, decline with
+// one, decline with none, and never answer from another pane.
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { HistoryScreen } from "./History";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { useKeymapStore, useFocusStore } from "@/features/keymap";
+import type { CommitInfo } from "@/lib/types";
+
+const mkCommit = (oid: string, summary: string, parents: string[]): CommitInfo => ({
+  oid,
+  shortOid: oid.slice(0, 7),
+  summary,
+  body: null,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 1_700_000_000,
+  parents,
+  refs: [],
+});
+
+const A = "a".repeat(40);
+const B = "b".repeat(40);
+const C = "c".repeat(40);
+const D = "d".repeat(40);
+
+/** Newest-first linear log: a → b → c → d(root). */
+const COMMITS = [
+  mkCommit(A, "commit A", [B]),
+  mkCommit(B, "commit B", [C]),
+  mkCommit(C, "commit C", [D]),
+  mkCommit(D, "commit D", []),
+];
+
+/** ⌘D / Ctrl+D. The base key comes from `code`, not `key` (see chord.ts). */
+function pressModD(): boolean {
+  let handled = false;
+  act(() => {
+    handled = useKeymapStore.getState().dispatch({
+      key: "d",
+      code: "KeyD",
+      metaKey: true,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: false,
+      preventDefault() {},
+      target: document.body,
+    } as unknown as KeyboardEvent);
+  });
+  return handled;
+}
+
+const rowFor = (text: string) => {
+  const row = screen
+    .getAllByText(text)
+    .map((el) => el.closest("[data-pg-row]"))
+    .find((el): el is Element => el != null);
+  expect(row).toBeTruthy();
+  return row! as HTMLElement;
+};
+
+function setupStore(commits: CommitInfo[]): void {
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    commits,
+    searchResults: null,
+    searching: false,
+    searchCommits: async () => {},
+    branches: [],
+    status: [],
+    loading: false,
+  } as never);
+  useNavStore.setState({ intent: null });
+  useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+  useKeymapStore.getState().setPreset("rider");
+  useFocusStore.setState({
+    focused: null,
+    panes: new Map(),
+    order: [],
+    barId: null,
+    pendingContentFocus: false,
+  });
+}
+
+describe("History Mod+D", () => {
+  beforeEach(() => setupStore(COMMITS));
+  afterEach(() => vi.restoreAllMocks());
+
+  it("opens the combined diff of a multi-selection (parent-of-oldest → newest)", () => {
+    render(<HistoryScreen />);
+    fireEvent.click(rowFor("commit A"));
+    fireEvent.click(rowFor("commit B"), { shiftKey: true }); // A + B
+    useFocusStore.setState({ focused: "history.list" });
+
+    expect(pressModD()).toBe(true);
+    // Oldest selected = B (parent C), newest = A — the same intent Enter and
+    // "View combined diff" produce.
+    expect(useNavStore.getState().intent).toEqual({
+      kind: "commit-vs-commit",
+      from: C,
+      to: A,
+    });
+  });
+
+  // THE regression this file exists for. One commit is always selected in
+  // History, so a handler that treated "a selection" as "anything selected"
+  // would take Mod+D away from the Diff viewer on the launch screen.
+  it("declines with one commit selected — nav.diff still reaches the Diff viewer", () => {
+    render(<HistoryScreen />);
+    fireEvent.click(rowFor("commit A"));
+    useFocusStore.setState({ focused: "history.list" });
+
+    expect(pressModD()).toBe(true); // handled — by the GLOBAL fallback
+    expect(useNavStore.getState().intent).toEqual({
+      kind: "switch-screen",
+      screen: "diff",
+    });
+  });
+
+  it("declines with nothing selected (empty log) — nav.diff still fires", () => {
+    setupStore([]);
+    render(<HistoryScreen />);
+    useFocusStore.setState({ focused: "history.list" });
+
+    expect(pressModD()).toBe(true);
+    expect(useNavStore.getState().intent).toEqual({
+      kind: "switch-screen",
+      screen: "diff",
+    });
+  });
+
+  // Pane scope, not selection state: the selection is still two commits here, so
+  // only the dispatcher's pane filter can be what keeps the chord global.
+  it("never answers from another pane, even with a multi-selection live", () => {
+    render(<HistoryScreen />);
+    fireEvent.click(rowFor("commit A"));
+    fireEvent.click(rowFor("commit B"), { shiftKey: true }); // A + B
+    useFocusStore.setState({ focused: "history.detail" });
+
+    expect(pressModD()).toBe(true);
+    expect(useNavStore.getState().intent).toEqual({
+      kind: "switch-screen",
+      screen: "diff",
+    });
+  });
+
+  it("and not with no pane focused at all", () => {
+    render(<HistoryScreen />);
+    fireEvent.click(rowFor("commit A"));
+    fireEvent.click(rowFor("commit B"), { shiftKey: true });
+    useFocusStore.setState({ focused: null });
+
+    expect(pressModD()).toBe(true);
+    expect(useNavStore.getState().intent).toEqual({
+      kind: "switch-screen",
+      screen: "diff",
+    });
+  });
+});

--- a/src/screens/History.multiselect.test.tsx
+++ b/src/screens/History.multiselect.test.tsx
@@ -202,4 +202,24 @@ describe("History multi-select", () => {
     fireEvent.click(rowFor("commit B"), { shiftKey: true }); // A,B (base = C)
     expect(screen.getByTestId("multi-squash")).not.toBeDisabled();
   });
+
+  // #158. The combined diff is a RANGE diff (parent-of-oldest → newest), so a
+  // scattered selection quietly includes the commits in between. Squash refuses
+  // such a selection and says why; the diff cannot refuse it — a range is the
+  // only thing two trees can be compared as — so it says so instead.
+  it("says a non-contiguous selection's combined diff covers the whole range", () => {
+    render(<HistoryScreen />);
+    fireEvent.click(rowFor("commit A"));
+    fireEvent.click(rowFor("commit C"), { ctrlKey: true }); // A + C, skipping B
+    const note = screen.getByTestId("multi-range-note");
+    // Oldest selected is C, so the range starts at its parent D.
+    expect(note.textContent).toContain(`${D.slice(0, 7)}..${A.slice(0, 7)}`);
+  });
+
+  it("stays quiet when the selection IS the range", () => {
+    render(<HistoryScreen />);
+    fireEvent.click(rowFor("commit A"));
+    fireEvent.click(rowFor("commit B"), { shiftKey: true }); // A,B — unbroken
+    expect(screen.queryByTestId("multi-range-note")).toBeNull();
+  });
 });

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -42,7 +42,7 @@ import { useDensityStep, useSettingsStore } from "@/features/settings/useSetting
 import { resolveHeadDecor } from "@/features/settings/headMarks";
 import { CommitDiffPanel } from "@/features/diff/CommitDiffPanel";
 import { useIgnoreWhitespace } from "@/features/diff/WhitespaceToggle";
-import { PGPane, FocusableScroll, usePaneList } from "@/features/keymap";
+import { PGPane, FocusableScroll, useAction, usePaneList } from "@/features/keymap";
 import {
   resolveGraphDrop,
   useDragSource,
@@ -351,6 +351,28 @@ export function HistoryScreen() {
     // hook's DOM-query fallback would find nothing (#68 G10).
     scrollToIndex: win.scrollToIndex,
   });
+
+  // Mod+D on a multi-selection: the same combined diff Enter and the menu open
+  // (#158). Pane-scoped and SHARING the chord with the global nav.diff, so this
+  // handler must DECLINE whenever it has nothing selection-shaped to show —
+  // returning true unconditionally would swallow Mod+D and strand the Diff
+  // viewer, which is why the decline is the tested half.
+  //
+  // "Nothing to show" is fewer than TWO commits: History keeps one row selected
+  // at all times, whose diff is already on screen inline and one Enter away, and
+  // History is the launch screen — so claiming the single-commit case would take
+  // Mod+D away from the Diff viewer for anyone who has not navigated elsewhere.
+  // Zero happens on an empty log.
+  useAction(
+    "diff.viewCombined",
+    () => {
+      if (sel.keys.length < 2) return false;
+      activateSelection();
+      return true;
+    },
+    [sel.keys, activateSelection],
+    { paneId: "history.list" },
+  );
 
   // Single-selection commit whose own diff (parent..commit) feeds the inline
   // panel; null while multi-selecting (that path uses the combined diff).

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -1076,6 +1076,30 @@ function MultiCommitDetail({
       >
         {n} commits selected
       </div>
+      {/* A combined diff is a RANGE diff: parent-of-oldest → newest, which is the
+          only thing two trees can be compared as. So a selection that is not an
+          unbroken first-parent chain silently includes whatever sits between the
+          picked commits, and until now nothing said so (#158). Keyed on
+          plan.contiguous rather than a count: "how many commits are in the range"
+          cannot be answered from the loaded log, which is a graph-ordered PREFIX
+          of history across every branch (#68 G11) — a number derived from row
+          distance would be confidently wrong. */}
+      {!plan.contiguous && (
+        <div
+          data-testid="multi-range-note"
+          style={{
+            padding: "0 12px 6px",
+            fontSize: "var(--fs-12)",
+            color: "var(--fg-2)",
+          }}
+        >
+          Combined diff covers the whole range{" "}
+          <span style={{ fontFamily: "var(--font-mono)" }}>
+            {shortSha(plan.baseOid ?? plan.oldestOid)}..{shortSha(plan.newestOid)}
+          </span>
+          , including commits between the selected ones.
+        </div>
+      )}
       <div
         style={{
           padding: "0 12px 10px",


### PR DESCRIPTION
Work on issue 158 — "view the diff of a commit selection" made consistent from the History context menu and `Mod+D`. Most of the machinery was already there from #54; this is the three gaps that issue names, plus the one open question it asks to decide.

## Gap 1 — a single commit had no "View diff"

The commit menu offered **Compare with HEAD** (`commit-vs-wt`) and nothing else diff-shaped, so right-clicking ONE commit and right-clicking SEVERAL offered two different comparisons. Added **View diff** → `{ kind: "commit-self", oid }`, exactly what Enter on the row and the inline panel already show. **Compare with HEAD stays** — a different question, and both are pinned to route apart.

## Gap 2 — `Mod+D` ignored the selection

New catalog entry `diff.viewCombined`, `scope: "pane"`, scoped to `history.list`, sharing `Mod+D` with the global `nav.diff` and running the same `activateSelection`. Its own entry rather than a second meaning on `nav.diff`, so the cheat sheet names both and they can be rebound apart.

**The handler declines below TWO selected commits, not below one.** History keeps a row selected at all times, that commit's diff is already inline and one Enter away, and History is the launch screen — claiming the single case would leave the Diff viewer with no chord anywhere a user starts, and would break the shipped behaviour `keymap.e2e.ts` already relies on (`Mod+D` from a freshly opened repo reaching `diff.files`). Zero happens on an empty log.

**Binding order is load-bearing and now pinned.** `buildReverseMap` walks `Object.entries`, and a global action with a default runner never declines — tried first it would shadow the pane action permanently and silently. The pane binding therefore lives in `COMMON`, which is spread before each preset's `nav.*`, and `presets.test.ts` asserts `rev.get("Mod+D") === ["diff.viewCombined", "nav.diff"]` in rider plus pane-before-global in both presets. `presets.test.ts`'s existing global-collision rule is untouched and still passes: it filters to `scope === "global"` and requires at most one, which is exactly the asymmetry this design leans on.

## Gap 3 — labels

Kept **View diff** / **View combined diff**. The menu title above the single item already reads `commit <sha>`, so "this commit's" would be redundant; the pair reads as one family and "combined" then carries information — this one spans a range. Renaming the multi item to "View diff" too would hide precisely the fact the next section surfaces.

## Non-contiguous selections — surfaced, not left

`planCommitSelection` produces a range (parent-of-oldest → newest), so a scattered ctrl-click selection silently includes commits nobody picked. Squash refuses such a selection and names the reason; a range diff cannot refuse it, so the multi-selection detail pane now says so and names the range (`ddddddd..aaaaaaa`) when the selection is not an unbroken first-parent chain.

Keyed on `plan.contiguous`, deliberately not on a count: "how many commits are in the range" cannot be answered from the loaded log, which is a graph-ordered PREFIX of history across every branch (#68 G11), so a number derived from row distance would be confidently wrong.

## How the decline path is proved

`src/screens/History.diffchord.test.tsx` drives the real dispatcher over the real screen:

- 2 selected + `history.list` focused → `commit-vs-commit` intent (the claim).
- **1 selected** + `history.list` focused → `switch-screen: diff` — `nav.diff` still fires.
- **0 selected** (empty log) + `history.list` focused → `switch-screen: diff`.
- 2 selected but focus on `history.detail` → `switch-screen: diff` (pane scope, not selection state).
- 2 selected with no pane focused → `switch-screen: diff`.

Both halves were mutation-checked rather than assumed: relaxing the guard to `< 1` fails the single-selection case, and dropping `paneId` fails both other-pane cases.

## Tests

`pnpm tsc --noEmit`, `pnpm test` (187 files / 1532 tests), `pnpm exec tsc -p e2e/tsconfig.json --noEmit` all green.

E2E specs are appended as their own `describe` blocks touching no existing test — additive so they rebase cleanly alongside the concurrent hunk-header work in the same two files. They were **not run locally**: another session holds the Docker e2e slot and two cold container builds OOM the VM. CI runs them here.
