### PR TITLE
feat(ui): container-relative clamp for resizable panes (#162)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -548,7 +548,10 @@ design/              In-house design system (NOT components/ui/). Exports via de
 │                        whole root when a render throws, so without it one
 │                        broken screen leaves a blank window and no message
 ├── modal.tsx            PGModal — shared dialog shell
-├── resizable.tsx        Resizable panes
+├── resizable.tsx        Resizable panes — PGResizeHandle + usePaneSize (the
+│                        container-relative clamp; see "Resizable panes")
+├── paneSize.ts          That clamp as PURE arithmetic: paneMaxSize /
+│                        clampPaneSize, PANE_HANDLE_PX, DEFAULT_SIBLING_MIN
 ├── ui-helpers.tsx       pgFlash, misc helpers
 └── use-prevent-browser-context-menu.ts
 
@@ -744,6 +747,12 @@ lib/
 ├── codeLines.ts     Split file text into DISPLAY lines — `text.split("\n")`
 │                    gets empty text and a trailing newline wrong, both visible
 ├── useViewportH.ts  Scroll-container height WITHOUT depending on ResizeObserver
+├── useElementSize.ts  The same rule generalised to BOTH axes, for the pane
+│                    clamp: a ref CALLBACK (so a remounted container is
+│                    re-measured with no deps list), measured on attach BEFORE
+│                    any capability check, then kept fresh by `window`'s resize
+│                    event, a ResizeObserver when there is one, and a bounded
+│                    rAF poll while it still reads 0
 ├── useWindowedList.ts  Fixed-pitch windowing for the plain lists
 ├── useDiffRowHeight.ts  Resolves `--diff-row-h` to px, with a fallback for
 │                    jsdom (which does not evaluate `calc()`); CSS stays the
@@ -776,6 +785,10 @@ test/                Component-test harness for the jsdom suite. NOT shipped
 ├── dialog.tsx       `WithDialogs` — a screen rendered in isolation has no
 │                    <PGDialogHost/>, so every pgConfirm silently reads as
 │                    "cancelled" without this
+├── elementSize.ts   `stubContainerSize` / `stubContainerWidth` — jsdom performs
+│                    no layout, so every `clientWidth` is 0, which is exactly
+│                    the "unmeasured" branch of the pane clamp. A test that wants
+│                    the CLAMPED branch has to say what the container measures
 └── settle.ts        The shared settle guard for tests driving a diff surface —
                      subtle enough that a second copy drifts
 ```
@@ -896,7 +909,9 @@ module and every `src/features/*/` directory is named somewhere in here.
   WebKitGTK 605 (the Linux webview, and the e2e target) has none; guarding before
   the initial measurement leaves the height 0, `windowVariable` falls back to a
   400px viewport, and the bottom of a taller pane renders blank. Use
-  `lib/useViewportH.ts`.
+  `lib/useViewportH.ts` — or `lib/useElementSize.ts` when the answer is a
+  container's width, or both axes (#162). Any new measurement obeys the same
+  order: read first, observe second.
 - **Two cursors, two index spaces, and they must not be confused.** `useHunkNav`
   keeps a HUNK cursor (F7/⇧F7, rendered as `data-hunk-active` on the hunk's
   ANCHOR row — its first changed line, marked `hunkAnchor` by `flattenDiffRows`;
@@ -1514,6 +1529,52 @@ module and every `src/features/*/` directory is named somewhere in here.
 - New shared primitive → add to appropriate file in `src/design/` and re-export via `index.ts`.
 - `PGButton`/`PGInput` spread `...rest` onto their DOM node (so `data-testid` etc. pass through); `PGIconButton` does NOT (forwards `title` only). Row components (`PGChangeRow`, `PGCommitRow`, `PGFileTreeRow`, …) need explicit prop threading for new attributes.
 - Do NOT add `src/components/ui/`. The design system lives in `src/design/`.
+
+### Resizable panes (#162)
+
+- **A pane has no fixed maximum. It has a sibling with a floor.** Every
+  `usePaneSize` call site declares `min` for itself and `siblingMin` for what is
+  left over, and the cap is derived: `container - siblingMin - reserve - handle`
+  (`design/paneSize.ts`, pure + tested). The old hard-coded maxima (520…800px)
+  were arbitrary on a large display and still did not prevent the failure they
+  existed for — `PGResizeHandle` sits BETWEEN the panes and every flexible
+  sibling is `flex: 1; minWidth: 0`, so a sibling squeezed to zero puts the handle
+  at the container edge and the drag cannot be reversed. Raising a constant moves
+  that cliff; a sibling floor removes it.
+- **The hook names its AXIS, because it sizes heights too** (History's bottom
+  detail panel, Compare's commit lists). It reads `container[axis]` from a
+  `useElementSize` result, so one measured container can serve two panes on two
+  axes — which is why it is `usePaneSize`, not `usePaneWidth`, and why a call site
+  that reads `.width` for a height is now impossible rather than merely ugly.
+- **Preference and effective size are two values, and that is the whole safety
+  argument.** The persisted number is the user's PREFERENCE; the rendered size is
+  that preference clamped, derived during render. So a container that changed is
+  honoured on the next paint with no effect and no second pass (two panes in a
+  three-pane layout cannot oscillate against each other's clamp), and opening a
+  720px panel on a 1280px laptop narrows it WITHOUT overwriting what the external
+  monitor earned. Nothing derived from a measurement is ever stored.
+- **An unmeasured container (0) means "no constraint known", never "no space".**
+  `container - siblingMin` is negative there, so clamping against it drives every
+  pane to its minimum — and the persist path would then destroy the stored size.
+  `paneMaxSize` returns `Infinity` until a real measurement lands; only the floor
+  applies in the meantime. This is the trap the change lives or dies on, pinned in
+  `paneSize.test.ts` and `resizable.test.tsx` (jsdom has no layout, so the default
+  test environment IS the unmeasured case — see `src/test/elementSize.ts`).
+- **A three-pane container is asymmetric on purpose.** The pane declared first
+  reserves the other fixed pane's MINIMUM; the second reserves the first's ACTUAL
+  size. Both reserving actual sizes would be circular; both reserving minimums
+  would let the two of them squeeze the flexible middle below its floor. The
+  arithmetic that the middle still keeps exactly its floor is a test, not a
+  comment (`paneSize.test.ts`'s three-pane invariant).
+- **Double-clicking a handle resets that pane to its `initial`** — the standard
+  editor gesture, and the recovery net for a persisted size that outlived its
+  layout. Wire `onReset={pane.reset}` on every handle.
+- E2E covers what jsdom cannot: that the measurement ARRIVES on a webview with no
+  `ResizeObserver` (`e2e/specs/resizable-panes.e2e.ts`). The pane drag has its own
+  helper, `jsDragHandle` — this is the one drag in the app that is mouse events on
+  `document`, not the `features/dnd` pointer primitive, and the grab has to be its
+  own driver round trip because the document listeners are registered by an effect
+  the mousedown schedules.
 
 ### Dialogs
 - **Never call `window.confirm` / `window.prompt`.** Use `pgConfirm` /

--- a/e2e/specs/resizable-panes.e2e.ts
+++ b/e2e/specs/resizable-panes.e2e.ts
@@ -1,0 +1,180 @@
+import { browser, $, expect } from "@wdio/globals";
+import { dirtyRepo, TempRepo } from "../support/tempRepo";
+import {
+  jsDoubleClick,
+  jsDragHandle,
+  openRepo,
+  resetApp,
+  switchScreen,
+} from "../support/app";
+
+/**
+ * Container-relative pane clamp (#162), on the real webview.
+ *
+ * This lives in e2e rather than jsdom for one reason: **the clamp needs a
+ * measurement, and jsdom has none.** The component tests stub `clientWidth` to
+ * exercise the arithmetic; only a real webview can show that the measurement
+ * itself arrives — and WebKitGTK 605, which is what CI and the Docker image run,
+ * has no `ResizeObserver`, which is exactly the environment where a first
+ * measurement placed behind a capability check would silently never happen.
+ *
+ * Each test drags a pane far past its old hard-coded maximum and then asserts
+ * the two halves of the invariant:
+ *
+ * 1. the pane really did grow past that old ceiling — it is gone, not raised;
+ * 2. the sibling still holds its floor, so the handle BETWEEN them is still on
+ *    screen and still draggable. Skip the initial measurement and this is the
+ *    assertion that fails: the clamp goes unbounded, the sibling is squeezed to
+ *    zero, and the drag becomes unrecoverable — the failure the issue is about.
+ */
+
+/** Measured content extent of a pane's flex container, on one axis. */
+function containerExtent(paneSelector: string, axis: "width" | "height") {
+  return browser.execute(
+    (sel: string, prop: string) => {
+      const pane = document.querySelector(sel);
+      const parent = pane?.parentElement as HTMLElement | null | undefined;
+      if (!parent) return 0;
+      return prop === "width" ? parent.clientWidth : parent.clientHeight;
+    },
+    paneSelector,
+    axis,
+  );
+}
+
+/** `getSize` after waiting for the drag's re-render to land.
+ *
+ * A `mousemove` is a CONTINUOUS event, so React schedules its update rather than
+ * flushing it inside the dispatch — the width is asserted, never assumed. */
+async function waitSize(
+  selector: string,
+  axis: "width" | "height",
+  predicate: (n: number) => boolean,
+  what: string,
+): Promise<number> {
+  await browser.waitUntil(
+    async () => predicate(await $(selector).getSize(axis)),
+    { timeout: 10_000, timeoutMsg: what },
+  );
+  return $(selector).getSize(axis);
+}
+
+const filesPane = '[data-pg-pane="diff.files"]';
+const diffPane = '[data-pg-pane="diff.view"]';
+const listHandle = '[data-testid="diff-list-resize"]';
+
+/** The Diff screen's file list: default 280, min 180, old hard cap 600. */
+const DIFF_LIST_DEFAULT = 280;
+const DIFF_LIST_OLD_MAX = 600;
+/** What the Diff screen reserves for the diff beside the list. */
+const DIFF_VIEW_MIN = 360;
+/** `PANE_HANDLE_PX` — the handle needs room too, and the clamp accounts for it. */
+const HANDLE = 4;
+/** Rounding + a 1px pane border; the assertions are about px, not sub-px. */
+const SLOP = 3;
+
+/** History's bottom detail panel keeps this much commit list above it. */
+const HISTORY_LIST_MIN_H = 200;
+
+describe("resizable panes", () => {
+  let repo: TempRepo;
+
+  afterEach(async () => {
+    await resetApp();
+    repo.dispose();
+  });
+
+  it("drags the file list past its old 600px cap while the diff keeps its floor", async () => {
+    repo = dirtyRepo();
+    await openRepo(repo.path);
+    await switchScreen("diff");
+    await $(filesPane).waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "Diff screen's file list pane never appeared",
+    });
+
+    const container = await containerExtent(filesPane, "width");
+    // Precondition, asserted rather than assumed: the window has to be wide
+    // enough that the OLD ceiling was the binding constraint, or this test
+    // proves nothing about having removed it.
+    expect(container).toBeGreaterThan(DIFF_LIST_OLD_MAX + DIFF_VIEW_MIN);
+
+    // Far more than any container can grant — the clamp decides where it lands.
+    await jsDragHandle(listHandle, 2000);
+
+    // The old ceiling is gone, and the new one is the container minus what the
+    // diff needs. The pane's own min never enters into it at this width.
+    const expected = container - DIFF_VIEW_MIN - HANDLE;
+    const listW = await waitSize(
+      filesPane,
+      "width",
+      (n) => n > DIFF_LIST_OLD_MAX,
+      `file list never grew past its old ${DIFF_LIST_OLD_MAX}px cap`,
+    );
+    expect(Math.abs(listW - expected)).toBeLessThanOrEqual(SLOP);
+
+    // The other half: the diff is still there, at its floor. A skipped
+    // measurement lands this at 0 with the handle off the container's edge.
+    const diffW = await $(diffPane).getSize("width");
+    expect(diffW).toBeGreaterThanOrEqual(DIFF_VIEW_MIN);
+    // Nothing overflowed the container: the two panes plus the handle fill it.
+    expect(listW + diffW).toBeLessThanOrEqual(container + SLOP);
+
+    // Still reversible — the whole point of keeping the sibling non-zero.
+    await jsDragHandle(listHandle, -300);
+    const narrowed = await waitSize(
+      filesPane,
+      "width",
+      (n) => Math.abs(n - (listW - 300)) <= SLOP,
+      "dragging the handle back never narrowed the file list",
+    );
+    expect(await $(diffPane).getSize("width")).toBeGreaterThan(diffW);
+    expect(narrowed).toBeLessThan(listW);
+
+    // Double-click resets that pane to its default.
+    await jsDoubleClick(listHandle);
+    await waitSize(
+      filesPane,
+      "width",
+      (n) => Math.abs(n - DIFF_LIST_DEFAULT) <= SLOP,
+      `double-clicking the handle never reset the pane to ${DIFF_LIST_DEFAULT}px`,
+    );
+  });
+
+  it("clamps History's bottom panel against the container's HEIGHT", async () => {
+    // The same hook sizes a pane vertically here, and reading the wrong axis is
+    // invisible in a wide-and-short window until you over-drag: a width-derived
+    // cap would let the panel grow past the whole viewport and take the commit
+    // list with it.
+    repo = dirtyRepo();
+    await openRepo(repo.path);
+    await switchScreen("history");
+    const handle = '[data-testid="history-detail-resize"]';
+    await $(handle).waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "History's detail panel resize handle never appeared",
+    });
+
+    const detail = '[data-testid="history-detail"]';
+    const containerH = await containerExtent(detail, "height");
+    const containerW = await containerExtent(detail, "width");
+    // The window is wider than it is tall, so a width-derived clamp would be
+    // visibly wrong — which is what makes this an axis test.
+    expect(containerW).toBeGreaterThan(containerH);
+
+    // The handle sits ABOVE the panel it sizes, so dragging UP grows it.
+    await jsDragHandle(handle, -2000, "y");
+
+    const expected = containerH - HISTORY_LIST_MIN_H - HANDLE;
+    const detailH = await waitSize(
+      detail,
+      "height",
+      (n) => Math.abs(n - expected) <= SLOP,
+      `detail panel never settled at ${expected}px (container ${containerH}px)`,
+    );
+    expect(detailH).toBeLessThan(containerH);
+    expect(
+      await $('[data-pg-pane="history.list"]').getSize("height"),
+    ).toBeGreaterThanOrEqual(HISTORY_LIST_MIN_H);
+  });
+});

--- a/e2e/specs/resizable-panes.e2e.ts
+++ b/e2e/specs/resizable-panes.e2e.ts
@@ -26,6 +26,10 @@ import {
  *    screen and still draggable. Skip the initial measurement and this is the
  *    assertion that fails: the clamp goes unbounded, the sibling is squeezed to
  *    zero, and the drag becomes unrecoverable — the failure the issue is about.
+ *
+ * Unusually for this suite there is no repo truth to accept against: nothing here
+ * touches git, so the rendered geometry IS the behaviour under test. The repo is
+ * a fixture only because the screens need something to list.
  */
 
 /** Measured content extent of a pane's flex container, on one axis. */

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -809,6 +809,87 @@ export async function jsDrag(fromSel: string, toSel: string): Promise<void> {
   if (!ok) throw new Error(`jsDrag: element not found (${fromSel} -> ${toSel})`);
 }
 
+/**
+ * Drag a `PGResizeHandle` by `delta` px along its axis.
+ *
+ * Separate from `jsDrag`, for two reasons. The pane handle is the one drag
+ * gesture in the app that is NOT the pointer-event primitive from
+ * `features/dnd`: it takes `mousedown` on itself and then `mousemove` /
+ * `mouseup` on `document`, so a `pointermove` on the handle reaches nothing.
+ *
+ * And the grab must be its OWN round trip. Those document listeners are
+ * registered by an effect that the mousedown's state update schedules, and React
+ * runs passive effects after the commit rather than inside the dispatch — so a
+ * mousemove fired in the same task lands before the listener exists, silently
+ * does nothing, and leaves the handle stuck in its dragging state with no
+ * mouseup ever delivered. A second driver command is a whole event-loop turn
+ * later, which is all the effect needs.
+ *
+ * One move is enough once armed: the handler tracks the previous position and
+ * reports the delta between them, so a single 2000px move is a 2000px delta.
+ */
+export async function jsDragHandle(
+  selector: string,
+  delta: number,
+  axis: "x" | "y" = "x",
+): Promise<void> {
+  // executeOnce on both halves: a driver-retry re-run would re-grab or re-apply.
+  const from = await executeOnce((sel: string) => {
+    const el = document.querySelector(sel) as HTMLElement | null;
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    const p = { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+    el.dispatchEvent(
+      new MouseEvent("mousedown", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        clientX: p.x,
+        clientY: p.y,
+      }),
+    );
+    return p;
+  }, selector);
+  if (!from) throw new Error(`jsDragHandle: element not found (${selector})`);
+
+  const to =
+    axis === "y" ? { x: from.x, y: from.y + delta } : { x: from.x + delta, y: from.y };
+  await executeOnce((p: { x: number; y: number }) => {
+    for (const type of ["mousemove", "mouseup"]) {
+      document.dispatchEvent(
+        new MouseEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          button: 0,
+          clientX: p.x,
+          clientY: p.y,
+        }),
+      );
+    }
+    return true;
+  }, to);
+}
+
+/** In-page `dblclick` — the pane handle's reset gesture. */
+export async function jsDoubleClick(selector: string): Promise<void> {
+  const ok = await executeOnce((sel: string) => {
+    const el = document.querySelector(sel) as HTMLElement | null;
+    if (!el) return false;
+    const r = el.getBoundingClientRect();
+    el.dispatchEvent(
+      new MouseEvent("dblclick", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        clientX: r.left + r.width / 2,
+        clientY: r.top + r.height / 2,
+      }),
+    );
+    return true;
+  }, selector);
+  if (!ok) throw new Error(`jsDoubleClick: element not found (${selector})`);
+}
+
 /** Full length of the windowed History list, from the container's data-total. */
 export async function commitListTotal(): Promise<number> {
   const raw = await $('[data-testid="commit-list"]').getAttribute("data-total");

--- a/src/design/paneSize.test.ts
+++ b/src/design/paneSize.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampPaneSize,
+  DEFAULT_SIBLING_MIN,
+  PANE_HANDLE_PX,
+  paneMaxSize,
+} from "./paneSize";
+
+// The clamp is the whole of #162: the maximum is the container minus what the
+// other side needs, so there is no arbitrary ceiling — and the two cases that
+// break it if they are wrong are an UNMEASURED container (0) and a container
+// too small to satisfy both floors.
+describe("paneMaxSize", () => {
+  const base = { min: 180, siblingMin: 320, container: 1200 };
+
+  it("is the container minus the sibling floor and the handle", () => {
+    expect(paneMaxSize(base)).toBe(1200 - 320 - PANE_HANDLE_PX);
+  });
+
+  it("grows with the container — there is no fixed ceiling", () => {
+    const small = paneMaxSize({ ...base, container: 1200 });
+    const large = paneMaxSize({ ...base, container: 5120 });
+    expect(large).toBe(small + (5120 - 1200));
+    // The old hard-coded maxima topped out at 800px for the largest pane.
+    expect(large).toBeGreaterThan(800);
+  });
+
+  it("subtracts the other fixed panes in a three-pane container", () => {
+    // RepoBrowser: tree | handle | preview (flexible) | handle | inspector.
+    const reserve = 260 + PANE_HANDLE_PX;
+    expect(paneMaxSize({ ...base, reserve })).toBe(
+      1200 - 320 - reserve - PANE_HANDLE_PX,
+    );
+  });
+
+  // The negative case. container - siblingMin - handle is below `min` (and can
+  // be negative outright); the pane's own floor has to win, or a narrow window
+  // collapses every pane to nothing and takes the handle off screen with it.
+  it("never returns less than the pane's own minimum", () => {
+    expect(paneMaxSize({ ...base, container: 400 })).toBe(180);
+    expect(paneMaxSize({ ...base, container: 1 })).toBe(180);
+    expect(paneMaxSize({ min: 180, siblingMin: 320, container: 300 })).toBe(180);
+  });
+
+  // The unmeasured case. 0 is "we do not know yet", NOT "no space": returning
+  // `container - siblingMin` here would be negative, so every clamp would snap
+  // to `min` and the persist path would write that over the user's size.
+  it("is unbounded while the container is unmeasured", () => {
+    expect(paneMaxSize({ ...base, container: 0 })).toBe(Infinity);
+    expect(paneMaxSize({ ...base, container: -1 })).toBe(Infinity);
+    expect(paneMaxSize({ ...base, container: NaN })).toBe(Infinity);
+  });
+});
+
+describe("clampPaneSize", () => {
+  const clamp = { min: 180, siblingMin: 320, container: 1200 };
+
+  it("passes a size that already fits", () => {
+    expect(clampPaneSize(400, clamp)).toBe(400);
+  });
+
+  it("caps at the container-relative maximum", () => {
+    expect(clampPaneSize(5000, clamp)).toBe(1200 - 320 - PANE_HANDLE_PX);
+  });
+
+  it("floors at the minimum", () => {
+    expect(clampPaneSize(10, clamp)).toBe(180);
+  });
+
+  it("leaves an oversized value alone while the container is unmeasured", () => {
+    // A size persisted on a big display, read back before layout: it must
+    // survive to be clamped by a REAL measurement, not by a 0.
+    expect(clampPaneSize(720, { ...clamp, container: 0 })).toBe(720);
+  });
+
+  it("collapses to the minimum when the container cannot fit both floors", () => {
+    expect(clampPaneSize(720, { ...clamp, container: 400 })).toBe(180);
+  });
+
+  it("falls back to the minimum for a non-finite size", () => {
+    // A localStorage value can be anything; NaN in a style is an invisible pane.
+    expect(clampPaneSize(NaN, clamp)).toBe(180);
+  });
+
+  it("has a defensible sibling default", () => {
+    expect(clampPaneSize(5000, { min: 180, container: 1200, siblingMin: DEFAULT_SIBLING_MIN }))
+      .toBe(1200 - DEFAULT_SIBLING_MIN - PANE_HANDLE_PX);
+  });
+});
+
+// The three-pane layouts (RepoBrowser, CommitPanel) let the pane declared FIRST
+// reserve only the second one's minimum, while the second reserves the first's
+// actual size. That asymmetry is what keeps the two clamps from being circular —
+// and this is the arithmetic proving the flexible middle still keeps its floor
+// when the first pane takes everything it is allowed to.
+describe("three-pane invariant", () => {
+  it("leaves the middle pane its minimum even at the first pane's maximum", () => {
+    const container = 1200;
+    const middleMin = 320;
+    const first = { min: 220, siblingMin: middleMin };
+    const second = { min: 280, siblingMin: middleMin };
+
+    const firstMax = paneMaxSize({
+      ...first,
+      reserve: second.min + PANE_HANDLE_PX,
+      container,
+    });
+    // The second pane re-clamps against the first pane's NEW size in the same
+    // render, so read its cap from `firstMax`, not from its own preference.
+    const secondMax = paneMaxSize({
+      ...second,
+      reserve: firstMax + PANE_HANDLE_PX,
+      container,
+    });
+    const middle = container - firstMax - secondMax - 2 * PANE_HANDLE_PX;
+
+    expect(secondMax).toBe(second.min);
+    expect(middle).toBe(middleMin);
+  });
+});

--- a/src/design/paneSize.ts
+++ b/src/design/paneSize.ts
@@ -1,0 +1,79 @@
+/**
+ * The pane clamp, as pure arithmetic (#162).
+ *
+ * A resizable pane used to carry a hard-coded pixel maximum, which is arbitrary
+ * on a large display and — worse — was still not enough to keep the layout
+ * recoverable on a small one. The constraint that actually matters is not "how
+ * big may this pane be" but "how small may the REST of the container get": the
+ * handle sits BETWEEN the two panes and every flexible sibling is
+ * `flex: 1; minWidth: 0`, so once the sibling reaches zero the handle is at (or
+ * past) the container edge and the drag cannot be reversed.
+ *
+ * Expressed that way the ceiling disappears on its own:
+ *
+ *     max = container - siblingMin - reserve - handle
+ *
+ * `container` is 0 until a real measurement lands (see `useElementSize`), and
+ * that case is NOT the same as "no space" — clamping against 0 would drive every
+ * pane to its minimum and, if the result were stored, corrupt the persisted size.
+ * So an unmeasured container yields `Infinity`: the floor still applies, the
+ * ceiling waits.
+ */
+
+/** `PGResizeHandle`'s thickness. The handle needs room too. */
+export const PANE_HANDLE_PX = 4;
+
+/**
+ * Fallback floor for the flexible side of a split. Call sites should say what
+ * their own sibling needs; this is only a defensible default for one that does
+ * not, and matches the old default `min`.
+ */
+export const DEFAULT_SIBLING_MIN = 160;
+
+export type PaneClamp = {
+  /** Floor for the pane being sized. Beats `siblingMin` when they conflict. */
+  min: number;
+  /** Floor for the flexible neighbour that shares the container. */
+  siblingMin: number;
+  /**
+   * Extent already spoken for by OTHER fixed-size panes in the same container,
+   * their handles included. A three-pane layout (RepoBrowser, CommitPanel) needs
+   * this: "the rest of the container" is then a flexible middle pane plus a
+   * second fixed one.
+   */
+  reserve?: number;
+  /** Handle thickness; `PANE_HANDLE_PX` unless a call site differs. */
+  handle?: number;
+  /** Measured container extent on this pane's axis. 0 = not measured yet. */
+  container: number;
+};
+
+/**
+ * Largest this pane may be while its neighbours keep their floors.
+ *
+ * `Infinity` while the container is unmeasured — deliberately unbounded rather
+ * than "0 minus the floors", which is negative and would collapse the layout.
+ * When the container is genuinely too small for `min + siblingMin + …`, the
+ * pane's own `min` wins: the result is `min`, never something smaller.
+ */
+export function paneMaxSize({
+  min,
+  siblingMin,
+  reserve = 0,
+  handle = PANE_HANDLE_PX,
+  container,
+}: PaneClamp): number {
+  if (!Number.isFinite(container) || container <= 0) return Infinity;
+  return Math.max(min, container - siblingMin - reserve - handle);
+}
+
+/**
+ * `size` brought inside `[min, paneMaxSize(...)]`.
+ *
+ * A non-finite size falls back to `min` rather than propagating NaN through a
+ * style — a stored value can be anything.
+ */
+export function clampPaneSize(size: number, clamp: PaneClamp): number {
+  if (!Number.isFinite(size)) return clamp.min;
+  return Math.min(paneMaxSize(clamp), Math.max(clamp.min, size));
+}

--- a/src/design/resizable.test.tsx
+++ b/src/design/resizable.test.tsx
@@ -1,0 +1,170 @@
+// The pane hook end to end: measurement → clamp → persistence (#162). The pure
+// arithmetic is pinned in paneSize.test.ts; this file is about the three things
+// only a mounted component can show — that a real measurement reaches the clamp,
+// that an UNMEASURED container leaves the stored value alone, and that a
+// container which changes size re-clamps without a ResizeObserver.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render } from "@testing-library/react";
+import { stubContainerSize } from "@/test/elementSize";
+import { PGResizeHandle, usePaneSize } from "./resizable";
+import { useElementSize } from "@/lib/useElementSize";
+
+const KEY = "pg-test-pane-w";
+
+function Split({
+  axis = "width",
+  initial = 300,
+  min = 180,
+  siblingMin = 320,
+}: {
+  axis?: "width" | "height";
+  initial?: number;
+  min?: number;
+  siblingMin?: number;
+}) {
+  const layout = useElementSize();
+  const pane = usePaneSize(initial, {
+    axis,
+    container: layout,
+    min,
+    siblingMin,
+    storageKey: KEY,
+  });
+  return (
+    <div ref={layout.ref} data-testid="container">
+      <div
+        data-testid="pane"
+        style={axis === "width" ? { width: pane.size } : { height: pane.size }}
+      />
+      <PGResizeHandle
+        testId="handle"
+        orientation={axis === "width" ? "horizontal" : "vertical"}
+        onDrag={pane.resize}
+        onReset={pane.reset}
+      />
+      <div data-testid="sibling" style={{ flex: 1, minWidth: 0 }} />
+    </div>
+  );
+}
+
+const paneSize = (el: HTMLElement, axis: "width" | "height" = "width") =>
+  el.style[axis];
+
+const drag = (handle: HTMLElement, delta: number, axis: "x" | "y" = "x") => {
+  const from = axis === "x" ? { clientX: 100 } : { clientY: 100 };
+  const to =
+    axis === "x" ? { clientX: 100 + delta } : { clientY: 100 + delta };
+  fireEvent.mouseDown(handle, from);
+  fireEvent.mouseMove(document, to);
+  fireEvent.mouseUp(document);
+};
+
+describe("usePaneSize", () => {
+  let restore: (() => void) | null = null;
+
+  beforeEach(() => localStorage.clear());
+  afterEach(() => {
+    restore?.();
+    restore = null;
+  });
+
+  it("drags past every old fixed maximum when the container allows it", () => {
+    restore = stubContainerSize({ width: 2400 });
+    const { getByTestId } = render(<Split />);
+
+    drag(getByTestId("handle"), 4000);
+
+    // 2400 − 320 − 4. The largest hard-coded ceiling in the app was 800px.
+    expect(paneSize(getByTestId("pane"))).toBe("2076px");
+  });
+
+  it("leaves a stored size that outgrew the container alone until measured", () => {
+    localStorage.setItem(KEY, "1800");
+    const { getByTestId } = render(<Split />); // jsdom: container measures 0
+
+    expect(paneSize(getByTestId("pane"))).toBe("1800px");
+    // The critical half: a clamp against 0 would have rewritten this to 180.
+    expect(localStorage.getItem(KEY)).toBe("1800");
+  });
+
+  it("renders a too-large stored size clamped, without overwriting it", () => {
+    // Persist 1800 on an external monitor, reopen at 1280: the panel comes back
+    // narrowed, but the preference the big display earned is still on disk, so
+    // it returns in full when the window does.
+    localStorage.setItem(KEY, "1800");
+    restore = stubContainerSize({ width: 1280 });
+    const { getByTestId } = render(<Split />);
+
+    expect(paneSize(getByTestId("pane"))).toBe("956px");
+    expect(localStorage.getItem(KEY)).toBe("1800");
+  });
+
+  it("re-clamps on a window resize, with no ResizeObserver in sight", () => {
+    const noResizeObserver = vi
+      .spyOn(globalThis, "ResizeObserver", "get")
+      .mockReturnValue(undefined as unknown as typeof ResizeObserver);
+    try {
+      restore = stubContainerSize({ width: 2000 });
+      const { getByTestId } = render(<Split />);
+      drag(getByTestId("handle"), 4000);
+      expect(paneSize(getByTestId("pane"))).toBe("1676px");
+
+      // The window moves to a smaller display.
+      restore();
+      restore = stubContainerSize({ width: 900 });
+      act(() => {
+        window.dispatchEvent(new Event("resize"));
+      });
+
+      // 900 − 320 − 4: narrowed, and the sibling still has its floor, so the
+      // handle between them is still on screen and still draggable.
+      expect(paneSize(getByTestId("pane"))).toBe("576px");
+    } finally {
+      noResizeObserver.mockRestore();
+    }
+  });
+
+  it("keeps the pane's own minimum when the container cannot fit both floors", () => {
+    restore = stubContainerSize({ width: 300 });
+    const { getByTestId } = render(<Split />);
+
+    // 300 − 320 − 4 is negative; `min` wins rather than the pane vanishing.
+    expect(paneSize(getByTestId("pane"))).toBe("180px");
+  });
+
+  it("persists a dragged size", () => {
+    restore = stubContainerSize({ width: 1600 });
+    const { getByTestId, unmount } = render(<Split />);
+    drag(getByTestId("handle"), 100);
+    expect(localStorage.getItem(KEY)).toBe("400");
+    unmount();
+
+    const again = render(<Split />);
+    expect(paneSize(again.getByTestId("pane"))).toBe("400px");
+  });
+
+  it("resets to the initial size on a double-click of the handle", () => {
+    restore = stubContainerSize({ width: 1600 });
+    const { getByTestId } = render(<Split />);
+    drag(getByTestId("handle"), 200);
+    expect(paneSize(getByTestId("pane"))).toBe("500px");
+
+    fireEvent.doubleClick(getByTestId("handle"));
+
+    expect(paneSize(getByTestId("pane"))).toBe("300px");
+    expect(localStorage.getItem(KEY)).toBe("300");
+  });
+
+  it("reads the axis it was told, not always the width", () => {
+    // The hook sizes History's bottom panel and Compare's commit lists too. A
+    // width-only measurement would clamp those against the wrong dimension —
+    // here a tall, narrow container would cap a height pane at 180.
+    restore = stubContainerSize({ width: 200, height: 1200 });
+    const { getByTestId } = render(<Split axis="height" initial={300} />);
+
+    drag(getByTestId("handle"), 4000, "y");
+
+    expect(paneSize(getByTestId("pane"), "height")).toBe("876px");
+  });
+});

--- a/src/design/resizable.tsx
+++ b/src/design/resizable.tsx
@@ -1,18 +1,37 @@
 import React from "react";
+import { type ElementSize } from "@/lib/useElementSize";
+import { clampPaneSize, DEFAULT_SIBLING_MIN, PANE_HANDLE_PX } from "./paneSize";
+
+export {
+  clampPaneSize,
+  DEFAULT_SIBLING_MIN,
+  PANE_HANDLE_PX,
+  paneMaxSize,
+} from "./paneSize";
+export type { PaneClamp } from "./paneSize";
 
 /**
- * Drag handle for resizing a sibling pane. Call `usePaneWidth(initial, storageKey?)`
- * in the parent, apply `width` to the pane, and render `<PGResizeHandle onDrag={onDrag} />`
- * immediately after it.
+ * Drag handle for resizing a sibling pane. Measure the container with
+ * `useElementSize`, call `usePaneSize(initial, { axis, container, … })` in the
+ * parent, apply `size` to the pane, and render
+ * `<PGResizeHandle onDrag={pane.resize} onReset={pane.reset} />` immediately
+ * after it.
  */
 export function PGResizeHandle({
   onDrag,
+  onReset,
   onActiveChange,
   side = "right",
   orientation = "horizontal",
   testId,
 }: {
   onDrag: (deltaPx: number) => void;
+  /**
+   * Double-click the handle to put the pane back to its `initial` — the standard
+   * editor gesture, and the recovery net for a persisted size that outlived the
+   * layout which produced it (#162).
+   */
+  onReset?: () => void;
   /** Called when the drag starts/stops. Useful to suspend CSS transitions. */
   onActiveChange?: (active: boolean) => void;
   /** `data-testid` for the handle — the drag target has no text to query by. */
@@ -57,15 +76,20 @@ export function PGResizeHandle({
   return (
     <div
       data-testid={testId}
+      data-pg-resize-handle=""
+      title={onReset ? "Drag to resize · double-click to reset" : undefined}
       onMouseDown={(e) => {
         e.preventDefault();
         start.current = vertical ? e.clientY : e.clientX;
         setActive(true);
       }}
+      // `preventDefault` on mousedown suppresses selection and focus, not the
+      // click pair the UA derives from it, so dblclick still arrives here.
+      onDoubleClick={onReset}
       style={{
         flexShrink: 0,
-        width: vertical ? "auto" : 4,
-        height: vertical ? 4 : "auto",
+        width: vertical ? "auto" : PANE_HANDLE_PX,
+        height: vertical ? PANE_HANDLE_PX : "auto",
         marginLeft: side === "right" ? -2 : 0,
         marginRight: side === "left" ? -2 : 0,
         marginTop: side === "bottom" ? -2 : 0,
@@ -88,39 +112,113 @@ export function PGResizeHandle({
   );
 }
 
-export function usePaneWidth(
-  initial: number,
-  opts?: { min?: number; max?: number; storageKey?: string },
-) {
-  const min = opts?.min ?? 160;
-  const max = opts?.max ?? 800;
-  const key = opts?.storageKey;
+export type PaneSizeOptions = {
+  /**
+   * Which container dimension bounds this pane. Named rather than inferred: the
+   * hook is used for HEIGHTS as well (History's bottom detail panel, Compare's
+   * commit lists), and reading the wrong axis is exactly the bug the old
+   * `usePaneWidth` name hid.
+   */
+  axis: "width" | "height";
+  /** The measured flex container this pane and its sibling share. */
+  container: Pick<ElementSize, "width" | "height">;
+  /** Floor for this pane. */
+  min?: number;
+  /** Floor for the flexible sibling that shares the container. */
+  siblingMin?: number;
+  /** Other fixed-size panes in the same container + their handles, in px. */
+  reserve?: number;
+  /** Handle thickness, if a call site differs from `PANE_HANDLE_PX`. */
+  handle?: number;
+  /** `localStorage` key for the user's preferred size. */
+  storageKey?: string;
+};
 
-  const [width, setWidth] = React.useState<number>(() => {
-    if (!key) return initial;
+export type PaneSize = {
+  /** What to render: the preference, clamped to what the container allows. */
+  size: number;
+  /** Apply a drag delta. */
+  resize: (delta: number) => void;
+  /** Back to `initial` — the handle's double-click. */
+  reset: () => void;
+};
+
+/**
+ * A resizable pane's size: the user's PREFERENCE, persisted, and the EFFECTIVE
+ * size it renders at once the container has been measured (#162).
+ *
+ * Those two are deliberately separate values, and the split is what makes the
+ * container-relative clamp safe:
+ *
+ * - the effective size is derived during render, so a container that changed
+ *   (window resized, moved to a smaller display, panel opened beside it) is
+ *   honoured on the very next paint with no effect, no second render pass, and
+ *   no chance of two panes oscillating against each other's clamp;
+ * - only a drag or a reset writes the preference, so opening a 720px-wide panel
+ *   on a 1280px laptop shows it narrowed but does NOT overwrite the size the
+ *   external monitor earned. Nothing derived from a measurement is ever stored.
+ *
+ * While the container is unmeasured (0 — see `useElementSize`) the ceiling is
+ * `Infinity`: only the floor applies, and the stored value is left exactly as it
+ * was read. That is the one case that must not guess, because a clamp against 0
+ * is a clamp to `min` for every pane at once.
+ */
+export function usePaneSize(
+  initial: number,
+  opts: PaneSizeOptions,
+): PaneSize {
+  const {
+    axis,
+    container,
+    min = 160,
+    siblingMin = DEFAULT_SIBLING_MIN,
+    reserve = 0,
+    handle = PANE_HANDLE_PX,
+    storageKey,
+  } = opts;
+  const containerSize = container[axis];
+  const clamp = React.useMemo(
+    () => ({ min, siblingMin, reserve, handle, container: containerSize }),
+    [min, siblingMin, reserve, handle, containerSize],
+  );
+
+  // The PREFERENCE. Read from storage floored at `min` only — never capped,
+  // because no measurement exists this early and capping against 0 would both
+  // collapse the pane and (via the persist effect) destroy the stored value.
+  const [preferred, setPreferred] = React.useState<number>(() => {
+    if (!storageKey) return initial;
     try {
-      const raw = localStorage.getItem(key);
+      const raw = localStorage.getItem(storageKey);
       const n = raw ? parseInt(raw, 10) : NaN;
-      return Number.isFinite(n) ? Math.min(max, Math.max(min, n)) : initial;
+      return Number.isFinite(n) ? Math.max(min, n) : initial;
     } catch {
       return initial;
     }
   });
 
   React.useEffect(() => {
-    if (!key) return;
+    if (!storageKey) return;
     try {
-      localStorage.setItem(key, String(width));
+      localStorage.setItem(storageKey, String(Math.round(preferred)));
     } catch {
       // quota errors are non-fatal
     }
-  }, [width, key]);
+  }, [preferred, storageKey]);
 
+  const size = clampPaneSize(preferred, clamp);
+
+  // A drag starts from what is ON SCREEN (the clamped size), not from a
+  // preference the container is currently overruling.
   const resize = React.useCallback(
     (delta: number) =>
-      setWidth((w) => Math.min(max, Math.max(min, w + delta))),
-    [min, max],
+      setPreferred((prev) => clampPaneSize(clampPaneSize(prev, clamp) + delta, clamp)),
+    [clamp],
   );
 
-  return { width, resize };
+  const reset = React.useCallback(
+    () => setPreferred(initial),
+    [initial],
+  );
+
+  return { size, resize, reset };
 }

--- a/src/features/diff/CommitDiffPanel.resize.test.tsx
+++ b/src/features/diff/CommitDiffPanel.resize.test.tsx
@@ -4,6 +4,7 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import { fireEvent, render } from "@testing-library/react";
+import { stubContainerWidth } from "@/test/elementSize";
 import { CommitDiffPanel } from "./CommitDiffPanel";
 
 const props = {
@@ -47,16 +48,47 @@ describe("CommitDiffPanel files column resize", () => {
     expect(filesPane(container, "history.diff").style.width).toBe("140px");
   });
 
-  it("caps the column relative to the panel so the diff can't be pushed out", () => {
+  it("caps the column relative to the measured panel, not at a fixed number", () => {
     // The column never shrinks (flexShrink: 0), so in the narrow side-by-side
-    // History layout an unbounded drag would overflow the detail pane.
-    const { container, getByTestId } = render(
+    // History layout an unbounded drag would overflow the detail pane. The cap is
+    // the panel's own width minus what the diff needs — no constant involved.
+    const restore = stubContainerWidth(900);
+    try {
+      const { container, getByTestId } = render(
+        <CommitDiffPanel {...props} paneIdPrefix="history.diff" />,
+      );
+
+      drag(getByTestId("history.diff-files-resize"), 1000);
+
+      // 900 − 200 (the diff's floor) − 4 (the handle).
+      expect(filesPane(container, "history.diff").style.width).toBe("696px");
+    } finally {
+      restore();
+    }
+  });
+
+  it("leaves a stored width alone while the panel is unmeasured", () => {
+    // The trap: with no measurement, `container - siblingMin` is negative, so a
+    // clamp here would collapse the column AND persist the collapse.
+    localStorage.setItem("pg-history-diff-files-w", "900");
+    const { container } = render(
       <CommitDiffPanel {...props} paneIdPrefix="history.diff" />,
     );
 
-    drag(getByTestId("history.diff-files-resize"), 1000);
+    expect(filesPane(container, "history.diff").style.width).toBe("900px");
+    expect(localStorage.getItem("pg-history-diff-files-w")).toBe("900");
+  });
 
-    expect(filesPane(container, "history.diff").style.maxWidth).toBe("60%");
+  it("double-clicking the handle resets the column to its default", () => {
+    const { container, getByTestId } = render(
+      <CommitDiffPanel {...props} paneIdPrefix="history.diff" />,
+    );
+    drag(getByTestId("history.diff-files-resize"), 120);
+    expect(filesPane(container, "history.diff").style.width).toBe("360px");
+
+    fireEvent.doubleClick(getByTestId("history.diff-files-resize"));
+
+    expect(filesPane(container, "history.diff").style.width).toBe("240px");
   });
 
   it("restores the dragged width on remount, per mount site", () => {

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -4,9 +4,10 @@ import {
   PGIcon,
   PGResizeHandle,
   PGSkeleton,
-  usePaneWidth,
+  usePaneSize,
   type DiffLineData,
 } from "@/design";
+import { useElementSize } from "@/lib/useElementSize";
 import { PGPane, FocusableScroll, usePaneList, useHunkNav } from "@/features/keymap";
 import { fileIconSpec } from "@/lib/fileIcon";
 import { WhitespaceToggle } from "./WhitespaceToggle";
@@ -220,22 +221,30 @@ export function CommitDiffPanel({
 
   // Per mount site: History's bottom panel is wide and short, the full-screen
   // commit diff is not, so one shared width would fit neither.
-  const filesPane = usePaneWidth(240, {
+  const layout = useElementSize();
+  const filesPane = usePaneSize(240, {
+    axis: "width",
+    container: layout,
     min: 140,
-    max: 640,
+    // The diff this is a list OF keeps a readable column. That floor replaces the
+    // old `maxWidth: "60%"` on the pane: a CSS cap held the RENDERED width while
+    // the dragged number kept growing, so the handle drifted away from the box it
+    // was sizing. A measured clamp is the same protection without the lie (#162).
+    //
+    // 200 rather than the ~360 a full-screen diff would like, because this panel
+    // also mounts inside History's 440px-wide beside layout, where the two floors
+    // plus the handle are the whole container: a larger number there would shove
+    // the file column down to its own minimum and shrink a list that fits today.
+    siblingMin: 200,
     storageKey: `pg-${paneIdPrefix.replace(/\./g, "-")}-files-w`,
   });
 
   return (
-    <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+    <div ref={layout.ref} style={{ flex: 1, display: "flex", minHeight: 0 }}>
       <PGPane
         id={filesPaneId}
         style={{
-          width: filesPane.width,
-          // The column never shrinks, so cap it against the panel: in the
-          // narrow side-by-side History layout a wide drag would otherwise
-          // push the diff out of the detail pane entirely.
-          maxWidth: "60%",
+          width: filesPane.size,
           flexShrink: 0,
           borderRight: "1px solid var(--border-0)",
           fontFamily: "var(--font-mono)",
@@ -361,6 +370,7 @@ export function CommitDiffPanel({
         side="right"
         testId={`${paneIdPrefix}-files-resize`}
         onDrag={(d) => filesPane.resize(d)}
+        onReset={filesPane.reset}
       />
       <PGPane
         id={viewPaneId}

--- a/src/features/merge/MergeWindow.tsx
+++ b/src/features/merge/MergeWindow.tsx
@@ -15,9 +15,10 @@ import {
   PGResizeHandle,
   PGSpinner,
   pgConfirm,
-  usePaneWidth,
+  usePaneSize,
   usePreventBrowserContextMenu,
 } from "@/design";
+import { useElementSize } from "@/lib/useElementSize";
 import { MergeFileList, type MergeFile } from "./FileList";
 import {
   acceptOurs as acceptOursIpc,
@@ -61,9 +62,15 @@ export function MergeWindow() {
   // Bumped when the open file changed on disk without being resolved (a
   // "Restart resolution" brings its markers back), to re-fetch its sides.
   const [reloadKey, setReloadKey] = React.useState(0);
-  const listPane = usePaneWidth(260, {
+  // The body beside the list is the three-pane resolver (ours | result | theirs),
+  // so its floor is what three code columns need — but nothing caps the list
+  // beyond that (#162).
+  const layout = useElementSize();
+  const listPane = usePaneSize(260, {
+    axis: "width",
+    container: layout,
     min: 180,
-    max: 520,
+    siblingMin: 480,
     storageKey: "pg-merge-list-w",
   });
 
@@ -406,19 +413,19 @@ export function MergeWindow() {
         )}
       </div>
 
-      <div style={{ flex: 1, minHeight: 0, display: "flex" }}>
+      <div ref={layout.ref} style={{ flex: 1, minHeight: 0, display: "flex" }}>
         {files.length > 0 && (
           <>
             <MergeFileList
               files={files}
               current={path}
               repoId={repoId}
-              width={listPane.width}
+              width={listPane.size}
               onSelect={requestSwitchTo}
               onResolved={(p) => void onFileResolved(p)}
               onChanged={(p) => void onFileChanged(p)}
             />
-            <PGResizeHandle onDrag={listPane.resize} />
+            <PGResizeHandle onDrag={listPane.resize} onReset={listPane.reset} />
           </>
         )}
         <div

--- a/src/lib/useElementSize.ts
+++ b/src/lib/useElementSize.ts
@@ -1,0 +1,114 @@
+import React from "react";
+
+/**
+ * How many frames to keep re-reading an element that measured 0. A pre-layout
+ * read is normally fixed by the very next frame; the bound is what keeps a
+ * genuinely hidden container (`display: none`, a collapsed detail panel) from
+ * polling for the lifetime of the mount.
+ */
+const MAX_MEASURE_FRAMES = 10;
+
+export type ElementSize = {
+  /**
+   * Attach to the element to measure. A ref CALLBACK, not a RefObject, so a
+   * container that unmounts and remounts (History's detail panel switching
+   * between the below/beside layouts) is re-measured and re-observed without
+   * the caller having to maintain a dependency list.
+   */
+  ref: (node: HTMLElement | null) => void;
+  /** `clientWidth`, or 0 while unmeasured. */
+  width: number;
+  /** `clientHeight`, or 0 while unmeasured. */
+  height: number;
+};
+
+/**
+ * Measured content box of an element, on BOTH axes — the width analogue of
+ * `useViewportH`, generalised.
+ *
+ * Same rule as that hook, for the same reason: **the first measurement never
+ * sits behind a `typeof ResizeObserver` guard.** WebKitGTK 605 (the Linux
+ * webview, and the e2e target) has no `ResizeObserver`, so a guard placed before
+ * the initial read leaves the size 0 forever there — and 0 is not a harmless
+ * "unknown" for a pane clamp: `container - siblingMin` goes negative, every
+ * clamp collapses to its minimum, and a persisted size would be overwritten with
+ * that. So the read comes first and the observer is a bonus.
+ *
+ * Three things can deliver a new measurement, in order of how much they cover:
+ *
+ * 1. `window`'s `resize` event — universal, and the case the pane clamp exists
+ *    for (a window moved to a smaller display, or resized). This is the whole
+ *    re-clamp path on a webview with no `ResizeObserver`.
+ * 2. `ResizeObserver`, when the webview has one — catches a container that
+ *    changed size without the window changing (a sibling panel appearing).
+ * 3. A bounded `requestAnimationFrame` poll while the size still reads 0 —
+ *    covers a commit-time read that landed before layout, which is otherwise
+ *    invisible to both of the above.
+ *
+ * 0 means "not measured yet" and callers must treat it as "no constraint known",
+ * never as "no space".
+ */
+export function useElementSize(): ElementSize {
+  const [size, setSize] = React.useState<{ width: number; height: number }>({
+    width: 0,
+    height: 0,
+  });
+  // The node lives in state as well as being measured on attach, so the effect
+  // below re-runs (re-observes, re-measures) when the element is replaced.
+  const [node, setNode] = React.useState<HTMLElement | null>(null);
+
+  const apply = React.useCallback((el: HTMLElement | null) => {
+    if (!el) return;
+    const width = el.clientWidth;
+    const height = el.clientHeight;
+    setSize((prev) =>
+      prev.width === width && prev.height === height ? prev : { width, height },
+    );
+  }, []);
+
+  const ref = React.useCallback(
+    (next: HTMLElement | null) => {
+      setNode(next);
+      // Measure on attach — before any capability check, and before paint, so a
+      // clamp has a real number on the first render that can use one.
+      apply(next);
+    },
+    [apply],
+  );
+
+  React.useEffect(() => {
+    if (!node) return;
+    const measure = () => apply(node);
+    // Again after paint: the attach-time read can precede layout.
+    measure();
+
+    window.addEventListener("resize", measure);
+    let ro: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== "undefined") {
+      ro = new ResizeObserver(measure);
+      ro.observe(node);
+    }
+
+    let raf = 0;
+    let frames = 0;
+    const canAnimate = typeof requestAnimationFrame === "function";
+    const poll = () => {
+      raf = 0;
+      measure();
+      if (node.clientWidth > 0 && node.clientHeight > 0) return;
+      if (++frames >= MAX_MEASURE_FRAMES) return;
+      raf = requestAnimationFrame(poll);
+    };
+    if (canAnimate && (node.clientWidth === 0 || node.clientHeight === 0)) {
+      raf = requestAnimationFrame(poll);
+    }
+
+    return () => {
+      window.removeEventListener("resize", measure);
+      ro?.disconnect();
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [node, apply]);
+
+  return { ref, width: size.width, height: size.height };
+}

--- a/src/screens/Branches.tsx
+++ b/src/screens/Branches.tsx
@@ -21,8 +21,9 @@ import {
   type StashMenuTarget,
   tagMenuItems,
   useContextMenu,
-  usePaneWidth,
+  usePaneSize,
 } from "@/design";
+import { useElementSize } from "@/lib/useElementSize";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { orderBranches } from "@/features/branches/orderBranches";
 import { TagSignatureBadge } from "@/features/signing/TagSignatureBadge";
@@ -96,9 +97,14 @@ export function BranchesScreen() {
 
   const [widths, setWidths] = React.useState(() => COLS.map((c) => c.initial));
   const gridTemplate = widths.map((w) => `${w}px`).join(" ");
-  const inspectorPane = usePaneWidth(320, {
+  // The refs table keeps its five columns readable; beyond that the inspector may
+  // take whatever the window offers (#162).
+  const layout = useElementSize();
+  const inspectorPane = usePaneSize(320, {
+    axis: "width",
+    container: layout,
     min: 220,
-    max: 560,
+    siblingMin: 420,
     storageKey: "pg-branches-inspector-w",
   });
   const totalWidth = widths.reduce((a, b) => a + b, 0);
@@ -265,7 +271,7 @@ export function BranchesScreen() {
         onFetchAll={fetchAllOp}
         fetching={!!activity.fetch}
       />
-      <div style={{ flex: 1, minHeight: 0, display: "flex" }}>
+      <div ref={layout.ref} style={{ flex: 1, minHeight: 0, display: "flex" }}>
         <PGPane
           id="branches.list"
           primary
@@ -637,12 +643,13 @@ export function BranchesScreen() {
 
         <PGResizeHandle
           onDrag={(d) => inspectorPane.resize(-d)}
+          onReset={inspectorPane.reset}
           side="left"
         />
         <PGPane
           id="branches.detail"
           style={{
-            width: inspectorPane.width,
+            width: inspectorPane.size,
             borderLeft: "1px solid var(--border-0)",
             background: "var(--bg-1)",
             display: "flex",

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -22,7 +22,8 @@ import {
   pgFlash,
   pgPrompt,
   useContextMenu,
-  usePaneWidth,
+  usePaneSize,
+  PANE_HANDLE_PX,
   type PGFileTreeNode,
   type PGStageState,
   type SideLine,
@@ -73,6 +74,7 @@ import {
   windowVariable,
 } from "@/lib/diffRows";
 import { useViewportH } from "@/lib/useViewportH";
+import { useElementSize } from "@/lib/useElementSize";
 import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
 import {
   WhitespaceToggle,
@@ -95,6 +97,11 @@ import type {
   FileDiff,
   FileStatus,
 } from "@/lib/types";
+
+/** The middle column renders a diff — a code column is its reason to exist. */
+const DIFF_MIN_W = 360;
+/** The composer's floor, and what the changes list reserves for it. */
+const COMPOSER_MIN_W = 280;
 
 interface FileSlot {
   path: string;
@@ -150,14 +157,25 @@ export function CommitPanelScreen() {
     Record<string, boolean>
   >({});
   const [sel, setSel] = React.useState<Selection>(emptySelection);
-  const changesPane = usePaneWidth(320, {
+  // Three panes: changes | diff (flexible) | composer (#162). Same asymmetry
+  // RepoBrowser uses — the first pane reserves the composer's MINIMUM, the
+  // composer reserves the changes list's ACTUAL size, so the two clamps are not
+  // circular and the diff column keeps its floor either way.
+  const layout = useElementSize();
+  const changesPane = usePaneSize(320, {
+    axis: "width",
+    container: layout,
     min: 220,
-    max: 720,
+    siblingMin: DIFF_MIN_W,
+    reserve: COMPOSER_MIN_W + PANE_HANDLE_PX,
     storageKey: "pg-commit-changes-w",
   });
-  const composerPane = usePaneWidth(360, {
-    min: 280,
-    max: 640,
+  const composerPane = usePaneSize(360, {
+    axis: "width",
+    container: layout,
+    min: COMPOSER_MIN_W,
+    siblingMin: DIFF_MIN_W,
+    reserve: changesPane.size + PANE_HANDLE_PX,
     storageKey: "pg-commit-composer-w",
   });
   const [diff, setDiff] = React.useState<FileDiff | null>(null);
@@ -1005,13 +1023,13 @@ export function CommitPanelScreen() {
   }
 
   return (
-    <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+    <div ref={layout.ref} style={{ flex: 1, display: "flex", minHeight: 0 }}>
       {/* Column 1: change list */}
       <PGPane
         id="commit.files"
         primary
         style={{
-          width: changesPane.width,
+          width: changesPane.size,
           flexShrink: 0,
           background: "var(--bg-1)",
           borderRight: "1px solid var(--border-0)",
@@ -1187,7 +1205,7 @@ export function CommitPanelScreen() {
           </div>
         </FocusableScroll>
       </PGPane>
-      <PGResizeHandle onDrag={changesPane.resize} />
+      <PGResizeHandle onDrag={changesPane.resize} onReset={changesPane.reset} />
 
       {/* Column 2: diff */}
       <PGPane
@@ -1308,13 +1326,17 @@ export function CommitPanelScreen() {
         {moreMenu.menu}
       </PGPane>
 
-      <PGResizeHandle onDrag={(d) => composerPane.resize(-d)} side="left" />
+      <PGResizeHandle
+        onDrag={(d) => composerPane.resize(-d)}
+        onReset={composerPane.reset}
+        side="left"
+      />
 
       {/* Column 3: message composer */}
       <PGPane
         id="commit.message"
         style={{
-          width: composerPane.width,
+          width: composerPane.size,
           flexShrink: 0,
           background: "var(--bg-1)",
           borderLeft: "1px solid var(--border-0)",

--- a/src/screens/Compare.tsx
+++ b/src/screens/Compare.tsx
@@ -16,8 +16,9 @@ import {
   PGIcon,
   PGIconButton,
   PGResizeHandle,
-  usePaneWidth,
+  usePaneSize,
 } from "@/design";
+import { useElementSize } from "@/lib/useElementSize";
 import { DeepViewHeader } from "@/features/nav/DeepViewHeader";
 import { CommitDiffPanel } from "@/features/diff/CommitDiffPanel";
 import { useIgnoreWhitespace } from "@/features/diff/WhitespaceToggle";
@@ -203,9 +204,14 @@ export function CompareScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [repo?.id, leftKey, rightKey, diffContextLines, ignoreWhitespace]);
 
-  const listsHeight = usePaneWidth(200, {
+  // Vertical split: the two commit lists above, the file diff below. The lists
+  // may take the whole column height the diff does not need (#162).
+  const layout = useElementSize();
+  const listsHeight = usePaneSize(200, {
+    axis: "height",
+    container: layout,
     min: 90,
-    max: 600,
+    siblingMin: 220,
     storageKey: "pg-compare-lists-h",
   });
 
@@ -347,12 +353,15 @@ export function CompareScreen() {
         </div>
       )}
 
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
+      <div
+        ref={layout.ref}
+        style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}
+      >
         {showLists && (
           <>
             <div
               style={{
-                height: listsHeight.width,
+                height: listsHeight.size,
                 flexShrink: 0,
                 display: "flex",
                 minHeight: 0,
@@ -389,6 +398,7 @@ export function CompareScreen() {
               side="bottom"
               testId="compare-lists-resize"
               onDrag={(d) => listsHeight.resize(d)}
+              onReset={listsHeight.reset}
             />
           </>
         )}

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -12,7 +12,7 @@ import {
   PGStatusMark,
   PGToggle,
   PGToolbar,
-  usePaneWidth,
+  usePaneSize,
   type SideLine,
 } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
@@ -35,6 +35,7 @@ import {
   windowVariable,
 } from "@/lib/diffRows";
 import { useViewportH } from "@/lib/useViewportH";
+import { useElementSize } from "@/lib/useElementSize";
 import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
 import { useDensityStep } from "@/features/settings/useSettingsStore";
 import { pairChangedLines } from "@/lib/pairChangedLines";
@@ -68,9 +69,14 @@ export function DiffViewerScreen() {
   const [diff, setDiff] = React.useState<FileDiff | null>(null);
   const [diffLoading, setDiffLoading] = React.useState(false);
   const [diffError, setDiffError] = React.useState<string | null>(null);
-  const listPane = usePaneWidth(280, {
+  // The file list may take everything the split allows, as long as the diff it
+  // is a list OF keeps enough width to read a line of code (#162).
+  const layout = useElementSize();
+  const listPane = usePaneSize(280, {
+    axis: "width",
+    container: layout,
     min: 180,
-    max: 600,
+    siblingMin: 360,
     storageKey: "pg-diff-list-w",
   });
 
@@ -363,6 +369,7 @@ export function DiffViewerScreen() {
         </div>
       )}
       <div
+        ref={layout.ref}
         style={{
           flex: 1,
           minHeight: 0,
@@ -374,7 +381,7 @@ export function DiffViewerScreen() {
           id="diff.files"
           primary
           style={{
-            width: listPane.width,
+            width: listPane.size,
             flexShrink: 0,
             borderRight: "1px solid var(--border-0)",
             background: "var(--bg-1)",
@@ -418,7 +425,11 @@ export function DiffViewerScreen() {
           ))}
           </FocusableScroll>
         </PGPane>
-        <PGResizeHandle onDrag={listPane.resize} />
+        <PGResizeHandle
+          testId="diff-list-resize"
+          onDrag={listPane.resize}
+          onReset={listPane.reset}
+        />
         <PGPane
           id="diff.view"
           style={{

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -23,12 +23,13 @@ import {
   pgFlash,
   pgPrompt,
   useContextMenu,
-  usePaneWidth,
+  usePaneSize,
   type CommitRef,
 } from "@/design";
 import { layoutGraph } from "@/features/commits/graphLayout";
 import { createRowCache } from "@/features/commits/rowIdentity";
 import { useWindowedList } from "@/lib/useWindowedList";
+import { useElementSize } from "@/lib/useElementSize";
 import { buildLogFilter, isFilterEmpty } from "@/features/commits/logFilter";
 import { planCommitSelection } from "@/features/commits/planCommitSelection";
 import { headAncestryOf } from "@/features/commits/headAncestry";
@@ -84,6 +85,16 @@ const LOAD_MORE_SLACK = 8;
 const MAX_BARREN_PAGES = 3;
 /** Small debounce so arrow-scrolling the log doesn't fire a fetch per row. */
 const INLINE_DIFF_DEBOUNCE_MS = 100;
+
+/**
+ * Floors for what is left over when a detail panel is dragged open (#162). The
+ * commit list is a graph plus a message column, so it needs real width; below
+ * layout it only has to keep a few rows visible.
+ */
+const COMMIT_LIST_MIN_W = 420;
+const COMMIT_LIST_MIN_H = 200;
+/** The diff beside the message inside the below-layout detail panel. */
+const DETAIL_DIFF_MIN_W = 320;
 
 export function HistoryScreen() {
   const commits = useRepoStore((s) => s.commits);
@@ -150,24 +161,36 @@ export function HistoryScreen() {
   const searchActive = !isFilterEmpty(logFilter);
   // Base list: backend-filtered results when a search is active, else full log.
   const baseCommits = searchActive ? (searchResults ?? []) : commits;
-  const detailPane = usePaneWidth(440, {
+  // The layout container serves BOTH the beside-layout detail width and the
+  // below-layout detail height, so one measurement feeds two axes (#162).
+  const layout = useElementSize();
+  const detailPane = usePaneSize(440, {
+    axis: "width",
+    container: layout,
     min: 280,
-    max: 720,
+    siblingMin: COMMIT_LIST_MIN_W,
     storageKey: "pg-history-detail-w",
   });
   const repo = useRepoStore((s) => s.current);
   const diffContextLines = useSettingsStore((s) => s.diffContextLines);
   const ignoreWhitespace = useIgnoreWhitespace();
-  // Below-layout panel height reuses the clamped/persisted pane-size hook.
-  const detailHeight = usePaneWidth(320, {
+  // Below-layout panel height reuses the clamped/persisted pane-size hook — on
+  // the HEIGHT axis, which is why the hook names its axis rather than assuming.
+  const detailHeight = usePaneSize(320, {
+    axis: "height",
+    container: layout,
     min: 140,
-    max: 800,
+    siblingMin: COMMIT_LIST_MIN_H,
     storageKey: "pg-history-diff-h",
   });
-  // Width of the message column inside the below-layout detail panel.
-  const messagePane = usePaneWidth(340, {
+  // Width of the message column inside the below-layout detail panel. Its
+  // container is that panel, not the screen, so it measures separately.
+  const detailLayout = useElementSize();
+  const messagePane = usePaneSize(340, {
+    axis: "width",
+    container: detailLayout,
     min: 220,
-    max: 640,
+    siblingMin: DETAIL_DIFF_MIN_W,
     storageKey: "pg-history-detail-msg-w",
   });
   const [diffLayout, setDiffLayout] = React.useState<DiffLayout>(() => {
@@ -879,10 +902,13 @@ export function HistoryScreen() {
     diffLayout === "below" ? (
       // Bottom panel is wide and short: message beside the diff, each with its
       // own scroll, so neither one starves the other vertically.
-      <div style={{ flex: 1, minHeight: 0, minWidth: 0, display: "flex" }}>
+      <div
+        ref={detailLayout.ref}
+        style={{ flex: 1, minHeight: 0, minWidth: 0, display: "flex" }}
+      >
         <div
           style={{
-            width: messagePane.width,
+            width: messagePane.size,
             flexShrink: 0,
             minWidth: 0,
             minHeight: 0,
@@ -892,7 +918,11 @@ export function HistoryScreen() {
         >
           {messageBlock}
         </div>
-        <PGResizeHandle side="right" onDrag={(d) => messagePane.resize(d)} />
+        <PGResizeHandle
+          side="right"
+          onDrag={(d) => messagePane.resize(d)}
+          onReset={messagePane.reset}
+        />
         <div
           style={{
             flex: 1,
@@ -943,6 +973,7 @@ export function HistoryScreen() {
       <PGToolbar left={toolbarLeft} right={toolbarRight} />
       {advancedPanel}
       <div
+        ref={layout.ref}
         style={{
           flex: 1,
           minHeight: 0,
@@ -953,11 +984,15 @@ export function HistoryScreen() {
         {listPane}
         {showDetail && diffLayout === "beside" && (
           <>
-            <PGResizeHandle onDrag={(d) => detailPane.resize(-d)} side="left" />
+            <PGResizeHandle
+              onDrag={(d) => detailPane.resize(-d)}
+              onReset={detailPane.reset}
+              side="left"
+            />
             <div
               data-testid="history-detail"
               style={{
-                width: detailPane.width,
+                width: detailPane.size,
                 flexShrink: 0,
                 borderLeft: "1px solid var(--border-0)",
                 background: "var(--bg-1)",
@@ -976,12 +1011,14 @@ export function HistoryScreen() {
             <PGResizeHandle
               orientation="vertical"
               side="top"
+              testId="history-detail-resize"
               onDrag={(d) => detailHeight.resize(-d)}
+              onReset={detailHeight.reset}
             />
             <div
               data-testid="history-detail"
               style={{
-                height: detailHeight.width,
+                height: detailHeight.size,
                 flexShrink: 0,
                 borderTop: "1px solid var(--border-0)",
                 background: "var(--bg-1)",

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -22,7 +22,8 @@ import {
   multiFileMenuItems,
   pgConfirm,
   useContextMenu,
-  usePaneWidth,
+  usePaneSize,
+  PANE_HANDLE_PX,
   type ContextMenuItem,
   type PGFileTreeNode,
 } from "@/design";
@@ -60,6 +61,7 @@ import {
   windowVariable,
 } from "@/lib/diffRows";
 import { useViewportH } from "@/lib/useViewportH";
+import { useElementSize } from "@/lib/useElementSize";
 import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
 import { buildLineSpans } from "@/lib/lineSpans";
 import { splitCodeLines } from "@/lib/codeLines";
@@ -97,6 +99,11 @@ import type {
 
 type SortMode = "asc" | "desc";
 type HideKind = "Untracked" | "Ignored" | "Deleted";
+
+/** The middle pane holds a file preview or a diff — it needs a code column. */
+const PREVIEW_MIN_W = 360;
+/** The inspector is a label/value list; this is its floor as well as its reserve. */
+const INSPECTOR_MIN_W = 200;
 
 function PGBreadcrumb({ items }: { items: string[] }) {
   return (
@@ -169,14 +176,27 @@ export function RepoBrowserScreen() {
   const [sortMode, setSortMode] = React.useState<SortMode>("asc");
   const [viewMode, setViewMode] = useTreeViewMode("pg-repo-view-mode");
   const setNavIntent = useNavStore((s) => s.setIntent);
-  const treePane = usePaneWidth(280, {
+  // Three panes in one container: tree | preview (flexible) | inspector (#162).
+  // So each fixed pane caps itself against the preview's floor AND the other
+  // fixed pane. The tree reserves the inspector's MINIMUM while the inspector
+  // reserves the tree's ACTUAL size — one side has to be static or the two
+  // clamps would be circular, and yielding to the tree keeps the preview's floor
+  // exact (see paneSize.test.ts's three-pane invariant).
+  const layout = useElementSize();
+  const treePane = usePaneSize(280, {
+    axis: "width",
+    container: layout,
     min: 180,
-    max: 600,
+    siblingMin: PREVIEW_MIN_W,
+    reserve: INSPECTOR_MIN_W + PANE_HANDLE_PX,
     storageKey: "pg-repo-tree-w",
   });
-  const inspectorPane = usePaneWidth(260, {
-    min: 200,
-    max: 520,
+  const inspectorPane = usePaneSize(260, {
+    axis: "width",
+    container: layout,
+    min: INSPECTOR_MIN_W,
+    siblingMin: PREVIEW_MIN_W,
+    reserve: treePane.size + PANE_HANDLE_PX,
     storageKey: "pg-repo-inspector-w",
   });
 
@@ -836,13 +856,13 @@ export function RepoBrowserScreen() {
           </>
         }
       />
-      <div style={{ flex: 1, minHeight: 0, display: "flex" }}>
+      <div ref={layout.ref} style={{ flex: 1, minHeight: 0, display: "flex" }}>
         {/* File tree */}
         <PGPane
           id="repo.tree"
           primary
           style={{
-            width: treePane.width,
+            width: treePane.size,
             flexShrink: 0,
             borderRight: "1px solid var(--border-0)",
             display: "flex",
@@ -960,7 +980,7 @@ export function RepoBrowserScreen() {
           </div>
           <StageDropBar onDrop={onStageBarDrop} />
         </PGPane>
-        <PGResizeHandle onDrag={treePane.resize} />
+        <PGResizeHandle onDrag={treePane.resize} onReset={treePane.reset} />
 
         {/* Preview + meta */}
         <PGPane
@@ -1149,6 +1169,7 @@ export function RepoBrowserScreen() {
 
         <PGResizeHandle
           onDrag={(d) => inspectorPane.resize(-d)}
+          onReset={inspectorPane.reset}
           side="left"
         />
 
@@ -1156,7 +1177,7 @@ export function RepoBrowserScreen() {
         <PGPane
           id="repo.inspector"
           style={{
-            width: inspectorPane.width,
+            width: inspectorPane.size,
             flexShrink: 0,
             borderLeft: "1px solid var(--border-0)",
             background: "var(--bg-1)",

--- a/src/test/elementSize.ts
+++ b/src/test/elementSize.ts
@@ -1,0 +1,39 @@
+/**
+ * Give jsdom a layout, for the tests that need one.
+ *
+ * jsdom performs no layout, so `clientWidth` / `clientHeight` are 0 for every
+ * element — which is the "unmeasured container" case `usePaneSize` deliberately
+ * treats as "no constraint known" (#162). That makes the default jsdom run the
+ * right harness for the unmeasured path and useless for the clamped one, so a
+ * test that wants the clamp has to say what the container measures.
+ *
+ * Patches the prototype rather than one node because the element under test is
+ * reached through a ref callback, so there is nothing to patch before render.
+ * Always call the returned restore in a `finally` — a leaked getter makes every
+ * later test in the file think it has a viewport.
+ */
+export function stubContainerSize(size: {
+  width?: number;
+  height?: number;
+}): () => void {
+  const patched: Array<"clientWidth" | "clientHeight"> = [];
+  const define = (prop: "clientWidth" | "clientHeight", value: number) => {
+    Object.defineProperty(HTMLElement.prototype, prop, {
+      configurable: true,
+      get: () => value,
+    });
+    patched.push(prop);
+  };
+  if (size.width !== undefined) define("clientWidth", size.width);
+  if (size.height !== undefined) define("clientHeight", size.height);
+  return () => {
+    for (const prop of patched) {
+      // Deleting the own property exposes jsdom's Element.prototype getter again.
+      delete (HTMLElement.prototype as unknown as Record<string, unknown>)[prop];
+    }
+  };
+}
+
+/** `stubContainerSize` for the common width-only case. */
+export const stubContainerWidth = (width: number) =>
+  stubContainerSize({ width });


### PR DESCRIPTION
Implements issue 162.

## What changes

A resizable pane no longer has a maximum. Its **sibling** has a minimum, and the
maximum derives from that:

```
max = container - siblingMin - reserve - handle
```

So a pane can use every pixel a large display offers, while the sibling always
keeps enough width (or height) to hold the handle and be dragged back — the
unrecoverable drag is structurally impossible instead of avoided by guesswork.
The 12 hard-coded maxima (520…800px) are gone.

## Pieces

- **`src/design/paneSize.ts`** — the clamp as pure, tested arithmetic
  (`paneMaxSize` / `clampPaneSize`, `PANE_HANDLE_PX`, `DEFAULT_SIBLING_MIN`).
- **`src/lib/useElementSize.ts`** — the container measurement, both axes: the
  width analogue of `useViewportH`, generalised. Same rule for the same reason —
  the first read is never behind a `typeof ResizeObserver` guard, because
  WebKitGTK 605 has none. Kept fresh by `window`'s `resize` event (the entire
  re-clamp path on a webview with no `ResizeObserver`), by a `ResizeObserver`
  when one exists, and by a bounded `requestAnimationFrame` poll while the size
  still reads 0. A ref **callback**, so a container that unmounts and remounts
  (History's below/beside layouts) is re-measured with no dependency list.
- **`usePaneWidth` → `usePaneSize`, which names its AXIS.** Two call sites
  already used the hook for heights (`History`'s bottom detail panel,
  `Compare`'s commit lists), and a container-relative clamp must read the right
  dimension. It takes the measured container and reads `container[axis]`, so one
  measurement serves two panes on two axes.
- **Preference and effective size are two values.** The persisted number is the
  user's preference; the rendered size is that preference clamped, derived during
  render. Consequences: a changed container is honoured on the next paint with no
  effect and no second pass (so two panes in a three-pane layout cannot
  oscillate against each other's clamp), and reopening a 720px panel on a 1280px
  laptop shows it narrowed **without overwriting** the size the external monitor
  earned. Nothing derived from a measurement is ever stored.
- **An unmeasured container (0) means "no constraint known", never "no space".**
  `paneMaxSize` returns `Infinity` until a real measurement lands; only the floor
  applies. Clamping against 0 would drive every pane to its minimum and the
  persist path would then destroy the stored size — the trap the change lives or
  dies on.
- **Double-click a handle to reset that pane to its `initial`.**
- **`CommitDiffPanel`'s `maxWidth: "60%"` is removed** — a CSS cap held the
  rendered width while the dragged number kept growing, so the handle drifted
  away from the box it was sizing. A measured clamp is the same protection
  without the lie.

## Call sites: 12, not 13

The issue's prose says thirteen; its own table lists twelve, and twelve is what
the tree has (`History` holds three of them, `RepoBrowser` and `CommitPanel` two
each). Each now declares a sibling floor:

| Pane | axis | min | siblingMin | reserve |
| --- | --- | --- | --- | --- |
| `MergeWindow` file list | width | 180 | 480 (ours / result / theirs) | — |
| `CommitDiffPanel` files | width | 140 | 200 | — |
| `RepoBrowser` tree | width | 180 | 360 (preview) | inspector min + handle |
| `RepoBrowser` inspector | width | 200 | 360 (preview) | tree size + handle |
| `CommitPanel` changes | width | 220 | 360 (diff) | composer min + handle |
| `CommitPanel` composer | width | 280 | 360 (diff) | changes size + handle |
| `DiffViewer` list | width | 180 | 360 (diff) | — |
| `Compare` lists | **height** | 90 | 220 (diff panel) | — |
| `History` detail | width | 280 | 420 (commit list) | — |
| `History` detail | **height** | 140 | 200 (commit list) | — |
| `History` message column | width | 220 | 320 (diff) | — |
| `Branches` inspector | width | 220 | 420 (refs table) | — |

`CommitDiffPanel` gets 200 rather than the ~360 a full-screen diff would like
because that panel also mounts inside History's 440px-wide beside layout, where
the two floors plus the handle are the whole container.

**A three-pane container is asymmetric on purpose.** The pane declared first
reserves the other fixed pane's *minimum*; the second reserves the first's
*actual* size. Both reserving actual sizes is circular; both reserving minimums
lets the pair squeeze the flexible middle below its floor. That the middle keeps
exactly its floor at the first pane's maximum is a test, not a comment.

## Persisted values

Same keys, same units. A value stored under the old constants was ≤ its old
maximum, so it loads unchanged in any normally sized window; one below the floor
is raised as before; one larger than the container now allows renders clamped and
stays on disk intact. A non-numeric value still falls back to `initial`.

## Tests

- `src/design/paneSize.test.ts` — 13 cases over the arithmetic, including the two
  that break it: a container smaller than `min + siblingMin + handle` (the pane's
  own floor wins; the raw subtraction is negative) and an unmeasured container
  (unbounded, stored value untouched).
- `src/design/resizable.test.tsx` — the hook mounted: a drag past every old
  ceiling, a too-large stored size rendered clamped while `localStorage` keeps
  it, a re-clamp driven by a `window` resize **with `ResizeObserver` mocked
  away**, the double-click reset, and an axis case where a width-derived clamp
  would give the wrong answer.
- `src/features/diff/CommitDiffPanel.resize.test.tsx` — the `60%` assertion is
  replaced by the container-relative one, plus the unmeasured-container case and
  the reset.
- `src/test/elementSize.ts` — `stubContainerSize`, because jsdom performs no
  layout, so the default test environment *is* the unmeasured branch.
- `e2e/specs/resizable-panes.e2e.ts` — what jsdom cannot cover: that the
  measurement **arrives** on a real webview with no `ResizeObserver`. Drags a
  pane far past its old cap and asserts both halves — the pane grew past the
  ceiling, and the sibling still holds its floor with the handle still draggable
  back. Skip the initial measurement and the second assertion fails. The second
  case drags on the height axis in a window wider than it is tall.

## Verification

`pnpm tsc --noEmit`, `pnpm test` (190 files, 1575 tests), and
`pnpm exec tsc -p e2e/tsconfig.json --noEmit` all pass locally.

**The e2e suite has not been run locally** — another agent held the Docker slot,
and the rule is Docker or nothing. The new spec has therefore only been
typechecked here; CI's `e2e-linux` job is the first real execution, on the
WebKitGTK + xvfb stack where the measurement trap actually lives.
