### PR TITLE
fix(history): Mod+D shows a single selected commit's diff (#164)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1020,10 +1020,11 @@ module and every `src/features/*/` directory is named somewhere in here.
   silently; the pane entry must come earlier in the preset table (`COMMON` is
   spread before the per-preset `nav.*`, which is why it lands there), and
   `presets.test.ts` pins the resulting `rev.get("Mod+D")` order. The pane
-  handler's decline is then what keeps the global chord working — and since
-  History always has one commit selected, "decline" there means *fewer than two*,
-  not "nothing selected": claiming the single case would take `Mod+D` away from the
-  Diff viewer on the launch screen.
+  handler's decline is then what keeps the global chord working — in History that
+  means an EMPTY selection, i.e. an empty log and nothing else (#164). It shipped
+  with a floor of *two* to keep `Mod+D` → Diff viewer on the launch screen; one
+  commit now routes to its own diff, because #158 asked for "a commit or commits"
+  and Rider's ⌘D on a selected commit shows that commit's diff.
 - `useNavStore.intent` drives deep-view switches (e.g. "show this commit's diff" → sets screen to `commitDiff`). Consumers write an intent; `AppShell` effect routes the screen.
 - **A new `NavIntent` kind must be routed in AppShell, and both halves of that
   are now enforced.** The routing switch ends in `default: assertNever(intent)`,

--- a/e2e/specs/keymap.e2e.ts
+++ b/e2e/specs/keymap.e2e.ts
@@ -532,11 +532,13 @@ describe("keymap — rider preset (default)", () => {
 // cleanly alongside concurrent work in this file.
 //
 // The chord carries TWO actions: the pane-scoped `diff.viewCombined` (this
-// list's combined diff) and the global `nav.diff` (go to the Diff viewer). The
+// list's selection diff) and the global `nav.diff` (go to the Diff viewer). The
 // dispatcher tries them in order and stops at the first that does not decline,
 // so both halves need proving in the real app: the claim, and — more
-// importantly — the fall-through, since History is the launch screen and a
-// handler that swallowed ⌘D there would strand the Diff viewer.
+// importantly — the fall-through, which is now what the LAST case proves, from
+// another pane. #164 lowered the claim from 2+ commits to any non-empty
+// selection, so the list itself no longer declines on a live repository; one
+// commit routes to its own diff, exactly as Enter does.
 describe("keymap — ⌘D over the History commit list (#158)", () => {
   let repo: TempRepo | null = null;
 
@@ -580,20 +582,43 @@ describe("keymap — ⌘D over the History commit list (#158)", () => {
     });
   });
 
-  // THE fall-through. One commit is always selected in History, so if the pane
-  // handler claimed "anything selected" this would land on the commit diff and
-  // ⌘D would never reach the Diff viewer from the screen the app opens on.
-  it("⌘D with a single commit selected still reaches the Diff viewer", async () => {
-    // dirtyRepo: the Diff screen renders "Nothing to diff" on a clean tree, so
-    // its panes only exist when there are changes.
-    repo = dirtyRepo();
+  // The single-commit case, claimed since #164: ⌘D on one selected commit opens
+  // THAT commit's own diff (parent..commit) — the same commit-self view Enter and
+  // the commit menu's "View diff" give, not the Diff viewer and not
+  // commit-vs-HEAD.
+  it("⌘D with a single commit selected opens that commit's own diff", async () => {
+    repo = basicRepo();
+    // basicRepo, newest-first: "fix: update a.txt" (HEAD), "feat: add b.txt",
+    // "feat: add a.txt" (root). The MIDDLE commit is the one to select: it added
+    // b.txt and nothing since touched that file, so b.txt on screen can only come
+    // from parent..commit — commit-vs-HEAD would show a.txt and no b.txt at all,
+    // and the Diff viewer would show the (clean) working tree.
+    const sha = repo.git("rev-parse", "--short=7", "HEAD~1").trim();
     await openRepo(repo.path);
     await waitScreen('[data-pg-pane="history.list"]', "History");
     await waitFocusedPane("history.list", "opening a repo should focus the commit list");
-    await jsChord("Home"); // exactly one row selected
+
+    // Keyboard-only, like the case above, so nothing here depends on a click.
+    await jsChord("Home");
+    await waitHistorySelection("fix: update a.txt", "Home");
+    await jsChord("ArrowDown"); // exactly one row selected: the middle commit
+    await waitHistorySelection("feat: add b.txt", "ArrowDown");
 
     await jsChord("Mod+D");
-    await waitScreen('[data-pg-pane="diff.files"]', "Diff (⌘D, single selection)");
+    // The destination's own header first — it names the commit that was routed,
+    // so a mis-route fails here rather than as a mute timeout on a file row.
+    await $(`div*=Diff ${sha} (this commit)`).waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: `⌘D never routed the single commit's own diff (${sha})`,
+    });
+    // Pane-scoped CSS, not `*=`-text: a bare match on b.txt would also hit
+    // History's own commit row for "feat: add b.txt", which is being unmounted.
+    await $(
+      '[data-pg-pane="commitDiff.files"] [data-pg-row][data-path="b.txt"]',
+    ).waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "the commit's own diff never listed b.txt",
+    });
   });
 
   // ...and the pane scope itself: the selection is still two commits here, so

--- a/e2e/specs/keymap.e2e.ts
+++ b/e2e/specs/keymap.e2e.ts
@@ -13,7 +13,7 @@ import {
 import {
   openRepo, resetApp, jsChord, jsDoubleShift, jsKey, jsSelectValue,
   focusedPaneId, paletteDialog, paletteInput, changeRow, stagedRow,
-  scrollCommitListTo,
+  scrollCommitListTo, switchScreen,
 } from "../support/app";
 
 const CHEAT_SHEET = "h2*=Keyboard shortcuts";
@@ -71,6 +71,10 @@ describe("keymap — rider preset (default)", () => {
       { chord: "Mod+4", marker: '[data-pg-pane="branches.list"]', label: "Branches (⌘4)" },
       { chord: "Mod+6", marker: '[data-testid="rebase-start"]', label: "Rebase (⌘6)" },
       { chord: "Mod+7", marker: '[data-pg-pane="remote.list"]', label: "Remotes (⌘7)" },
+      // ⌘D reaches the Diff viewer here because the step BEFORE it leaves focus
+      // on the Remotes screen. From the History list the pane-scoped
+      // diff.viewCombined claims the chord instead (#164), so do not reorder
+      // this step to follow ⌘9.
       { chord: "Mod+D", marker: '[data-pg-pane="diff.files"]', label: "Diff (⌘D)" },
       { chord: "Mod+Shift+9", marker: '[data-pg-pane="reflog.list"]', label: "Reflog (⌘⇧9)" },
       { chord: "Mod+,", marker: "div*=Choose a keymap preset", label: "Settings (⌘,)" },
@@ -484,7 +488,12 @@ describe("keymap — rider preset (default)", () => {
     lines[57] = "line 58 CHANGED";
     repo.write("big.txt", lines.join("\n") + "\n");
     await openRepo(repo.path);
-    await jsChord("Mod+D");
+    // The activity bar, NOT ⌘D: since #164 that chord opens the selected
+    // commit's own diff from History, and this test is about F7, so how it
+    // reaches the Diff screen is incidental. Both routes call AppShell's
+    // enterScreen, so focus still lands on the primary pane (diff.files), which
+    // is one of useHunkNav's paneIds — F7 is pane-scoped.
+    await switchScreen("diff");
     await waitScreen('[data-pg-pane="diff.files"]', "Diff");
     // Only hunk 0 is asserted up front. The diff is windowed and whole-file by
     // default, so hunk 1 — ~50 lines further down — is not mounted until F7

--- a/src/features/keymap/actions.ts
+++ b/src/features/keymap/actions.ts
@@ -322,11 +322,13 @@ export const ACTIONS: Record<ActionId, ActionDef> = {
   // Its own catalog entry rather than a second meaning hung off nav.diff, so the
   // cheat sheet names both behaviors and the two can be rebound apart.
   //
-  // The handler (History.tsx) claims a MULTI-commit selection only. One selected
-  // commit already has its diff on screen inline and on Enter, and History is the
-  // launch screen — claiming the single case there would leave the Diff viewer
-  // with no chord anywhere a user starts.
-  "diff.viewCombined": { id: "diff.viewCombined", title: "View combined diff of selected commits", category: "Diff", scope: "pane" },
+  // The handler (History.tsx) claims ANY non-empty commit selection — one commit
+  // routes to its own diff, 2+ to the combined diff of the range, exactly as
+  // Enter does (#164). It declines only on an empty log, which is what keeps the
+  // fall-through to nav.diff alive there. The id keeps its "combined" spelling
+  // (rebindings and presets.test.ts are keyed on it); the title does not, because
+  // the single-commit case is not a combined anything.
+  "diff.viewCombined": { id: "diff.viewCombined", title: "View diff of selected commits", category: "Diff", scope: "pane" },
   // The keyboard half of the hunk gutter cluster (#157). The `@@` banner's
   // Stage/Discard buttons were reachable by mouse only — Tab is pane traversal, so
   // DOM focus never enters a pane's buttons — and the cluster that replaced them

--- a/src/features/keymap/presets.ts
+++ b/src/features/keymap/presets.ts
@@ -75,10 +75,10 @@ const COMMON = {
   // because both actions are pane-scoped — presets.test.ts only forbids two
   // GLOBAL actions on one chord, and the dispatcher tries each id in turn.
   "diff.toggleLine": [" "],
-  // The History selection's combined diff, on the same Mod+D as nav.diff (#158).
-  // Legal because this one is pane-scoped: the dispatcher tries each id bound to
-  // a chord in turn, and the pane handler declines unless the commit list has
-  // focus with 2+ commits selected — so Mod+D still reaches the Diff viewer
+  // The History selection's diff, on the same Mod+D as nav.diff (#158). Legal
+  // because this one is pane-scoped: the dispatcher tries each id bound to a
+  // chord in turn, and the pane handler declines unless the commit list has focus
+  // with something selected (#164) — so Mod+D still reaches the Diff viewer
   // everywhere else. Rider's ⌘D is "Show diff", which is what both do.
   //
   // ORDER IS LOAD-BEARING: buildReverseMap walks Object.entries, so this entry

--- a/src/screens/History.diffchord.test.tsx
+++ b/src/screens/History.diffchord.test.tsx
@@ -1,13 +1,15 @@
-// Mod+D over the History commit list (#158). The chord carries TWO actions: the
-// pane-scoped `diff.viewCombined` (this list's combined diff) and the global
-// `nav.diff` (go to the Diff viewer). The dispatcher tries them in order and
-// stops at the first that does not decline, so the DECLINE is the load-bearing
-// half: a handler that claimed the chord unconditionally would strand the Diff
-// viewer everywhere a History list happens to hold focus — which, History being
-// the launch screen, is most of the time.
+// Mod+D over the History commit list (#158, #164). The chord carries TWO
+// actions: the pane-scoped `diff.viewCombined` (this list's selection diff) and
+// the global `nav.diff` (go to the Diff viewer). The dispatcher tries them in
+// order and stops at the first that does not decline, so the DECLINE is the
+// load-bearing half: a handler that claimed the chord unconditionally would
+// strand the Diff viewer everywhere a History list happens to hold focus — which,
+// History being the launch screen, is most of the time.
 //
-// Hence the four cases below: claim only with 2+ commits selected, decline with
-// one, decline with none, and never answer from another pane.
+// #164 lowered the claim from 2+ commits to ANY non-empty selection, so the only
+// remaining decline is an empty log. That makes the cases below: route one commit
+// to its own diff and 2+ to the combined range diff, decline with nothing
+// selected, and never answer from another pane whatever is selected.
 
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { act, fireEvent, render, screen } from "@testing-library/react";
@@ -112,27 +114,40 @@ describe("History Mod+D", () => {
     });
   });
 
-  // THE regression this file exists for. One commit is always selected in
-  // History, so a handler that treated "a selection" as "anything selected"
-  // would take Mod+D away from the Diff viewer on the launch screen.
-  it("declines with one commit selected — nav.diff still reaches the Diff viewer", () => {
+  // #164: one commit is claimed too, and it routes to the SAME commit-self intent
+  // Enter and the single commit's "View diff" produce — NOT commit-vs-HEAD, and
+  // not the Diff viewer. This is the case the shipped floor of two declined.
+  it("opens a single selected commit's own diff (commit-self, as Enter does)", () => {
     render(<HistoryScreen />);
     fireEvent.click(rowFor("commit A"));
     useFocusStore.setState({ focused: "history.list" });
 
-    expect(pressModD()).toBe(true); // handled — by the GLOBAL fallback
-    expect(useNavStore.getState().intent).toEqual({
-      kind: "switch-screen",
-      screen: "diff",
-    });
+    expect(pressModD()).toBe(true);
+    expect(useNavStore.getState().intent).toEqual({ kind: "commit-self", oid: A });
   });
 
+  // The accepted cost of #164, pinned rather than left implicit: History seeds a
+  // selection on the newest row, so the chord is claimed on the launch screen with
+  // nothing clicked. Mod+D reaching the Diff viewer from History is what was
+  // traded away — every other pane still has it (see the cases below).
+  it("claims the seeded selection too, with no row ever clicked", () => {
+    render(<HistoryScreen />);
+    useFocusStore.setState({ focused: "history.list" });
+
+    expect(pressModD()).toBe(true);
+    expect(useNavStore.getState().intent).toEqual({ kind: "commit-self", oid: A });
+  });
+
+  // THE regression this file exists for, and after #164 the only decline left.
+  // An empty selection happens on an empty log ONLY — the pruning effect re-seeds
+  // order[0] whenever the log has rows — so this is the whole of what keeps the
+  // chord from being swallowed inside the History list.
   it("declines with nothing selected (empty log) — nav.diff still fires", () => {
     setupStore([]);
     render(<HistoryScreen />);
     useFocusStore.setState({ focused: "history.list" });
 
-    expect(pressModD()).toBe(true);
+    expect(pressModD()).toBe(true); // handled — by the GLOBAL fallback
     expect(useNavStore.getState().intent).toEqual({
       kind: "switch-screen",
       screen: "diff",

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -352,21 +352,27 @@ export function HistoryScreen() {
     scrollToIndex: win.scrollToIndex,
   });
 
-  // Mod+D on a multi-selection: the same combined diff Enter and the menu open
-  // (#158). Pane-scoped and SHARING the chord with the global nav.diff, so this
-  // handler must DECLINE whenever it has nothing selection-shaped to show —
-  // returning true unconditionally would swallow Mod+D and strand the Diff
-  // viewer, which is why the decline is the tested half.
+  // Mod+D on the commit selection: the same diff Enter and the commit menu open
+  // — one commit → its own diff, 2+ → the combined diff of the range (#158).
+  // Pane-scoped and SHARING the chord with the global nav.diff, so this handler
+  // must DECLINE whenever it has nothing to show — returning true
+  // unconditionally would swallow Mod+D and strand the Diff viewer, which is why
+  // the decline is still the tested half.
   //
-  // "Nothing to show" is fewer than TWO commits: History keeps one row selected
-  // at all times, whose diff is already on screen inline and one Enter away, and
-  // History is the launch screen — so claiming the single-commit case would take
-  // Mod+D away from the Diff viewer for anyone who has not navigated elsewhere.
-  // Zero happens on an empty log.
+  // It used to decline below TWO commits, to keep Mod+D → Diff viewer on the
+  // launch screen. That floor was the deviation, not the fidelity (#164): #158
+  // asked for "a commit or commits", and Rider's ⌘D on a selected commit in the
+  // Log shows THAT commit's diff, so context-sensitivity is the behaviour being
+  // imitated. Mod+D still reaches the Diff viewer from every other pane, plus
+  // the activity bar and the palette.
+  //
+  // So "nothing to show" is an EMPTY selection — which means an empty log and
+  // nothing else, since the pruning effect above re-seeds order[0] whenever the
+  // log has rows. That is what lets the guard be a count rather than a probe.
   useAction(
     "diff.viewCombined",
     () => {
-      if (sel.keys.length < 2) return false;
+      if (sel.keys.length < 1) return false;
       activateSelection();
       return true;
     },


### PR DESCRIPTION
Issue 164, Option A. `Mod+D` in the History list declined below TWO selected
commits, so one selected commit fell through to the global `nav.diff` and
switched to the Diff viewer — which reads as "nothing happened". The guard is now
`< 1`, and one commit routes to the same `commit-self` intent Enter and the
commit menu's "View diff" already produce.

## Why this reverses a deliberate choice

The floor of two was recorded and argued for, not an oversight. It was still the
wrong call:

- The original request (issue 158) was "when selecting a commit **or commits**".
  The floor served only the plural.
- It is **more faithful to the Rider preset, not less**. In Rider, ⌘D on a
  selected commit in the Log shows that commit's diff — context-sensitivity is
  the behaviour being imitated, so the floor was the deviation.
- Its stated cost is real and accepted: `Mod+D` no longer means "go to the Diff
  viewer" from the History list, which is the screen the app launches on. It
  keeps that meaning from every other pane, plus the activity bar and the
  palette.

Option B (distinguishing an explicit selection from the default cursor) was
rejected: it needs state History does not keep, and inferring "did the user mean
this selection" is fragile.

## The decline is still the load-bearing half

`diff.viewCombined` is pane-scoped and shares `Mod+D` with the **global**
`nav.diff`; the dispatcher tries ids in order and a declining handler falls
through. So a handler that claimed the chord unconditionally would strand the
Diff viewer wherever a History list holds focus.

What is left of the decline is an **empty selection** — which means an empty log
and nothing else, because the pruning effect above the handler re-seeds
`order[0]` whenever the log has rows. That invariant is what lets the guard stay
a count rather than a probe.

Both directions were mutation-checked:

| Mutation | Result |
|---|---|
| delete the `if (sel.keys.length < 1) return false;` line | "declines with nothing selected (empty log)" fails — intent is `null`, nothing reached `nav.diff` |
| drop `{ paneId: "history.list" }` | both other-pane cases fail — they receive the multi-selection's `commit-vs-commit` intent instead of `switch-screen: diff` |

## Untouched on purpose

- **`presets.test.ts`** — pins `rev.get("Mod+D") === ["diff.viewCombined",
  "nav.diff"]`. `COMMON` still spreads before each preset's `nav.*`; nothing was
  reordered. Passing.
- **`keymap.e2e.ts`'s "⌘D from outside the list reaches the Diff viewer even
  with a multi-selection"** — the evidence the fall-through survives.
  Accommodating it would have defeated the point.
- **`keymap.e2e.ts`'s screen-switching walk**, which also presses ⌘D. Verified
  rather than assumed: it arrives from `Mod+7` (Remotes), and `AppShell` renders
  exactly one screen (`{screens[screen]}`), so `HistoryScreen` is unmounted and
  `useAction`'s effect cleanup has already unregistered the handler. Even if it
  were mounted, the Remote screen's primary pane is `remote.detail`, so the
  dispatcher's `inScope` filter would skip it. Two independent reasons; the
  second is the one the existing "never answers from another pane" component test
  exercises directly.

## Changed tests

- `History.diffchord.test.tsx` — the single-selection case now asserts the
  `commit-self` intent. Added a case for the **seeded** selection (no row ever
  clicked), because that is the launch-screen trade being made and leaving it
  implicit is how it would get silently reverted.
- `keymap.e2e.ts` — replaced "⌘D with a single commit selected still reaches the
  Diff viewer" with "…opens that commit's own diff". It selects the MIDDLE commit
  of `basicRepo`: `b.txt` is added there and nothing since touches it, so `b.txt`
  on screen can only come from `parent..commit` — commit-vs-HEAD would show
  `a.txt` alone, and the Diff viewer the clean working tree. Waits on the
  commit-diff header (which names the sha) before the file row, and scopes the
  row to `commitDiff.files` so it cannot bind to History's own row for the same
  subject on the outgoing screen.

Comment blocks in `History.tsx`, `actions.ts` and `presets.ts` and the CLAUDE.md
note all argued for the old floor; each now records the actual reasoning. The
action id keeps its `viewCombined` spelling (rebindings and `presets.test.ts` are
keyed on it); its catalog title drops "combined", since one commit's diff is not
a combined anything.

## A second test depended on the old behaviour (fixed)

`e2e-linux` failed on the first push, and it was a real regression, not a flake:

```
✖ F7 / ⇧F7 walk the diff hunks
Error: Diff screen marker never appeared: [data-pg-pane="diff.files"]
```

That test reached the Diff viewer by pressing ⌘D straight after `openRepo` — from
History, with one row auto-selected — so it broke for exactly the reason this PR
changes. The issue's claim that only one test asserted the old behaviour was
wrong, and the first audit checked the tests the issue *named* rather than
sweeping every place the chord is pressed. When a change removes a meaning from a
chord, the surface to audit is every press site.

Fixed by changing the **route, not the assertion**: the test is about F7, and how
it reaches the Diff screen is incidental. It now uses the existing
`switchScreen("diff")` helper (the activity bar), as many other specs already do.
Both routes call `AppShell`'s `enterScreen`, so `entryTick` still fires
`requestContentFocus()` and focus lands on the primary pane `diff.files` — one of
`useHunkNav`'s `paneIds`, which matters because F7 is pane-scoped. Fixture, hunk
geometry and the F7 sequence are byte-identical, including the windowing comment
about hunk 1 not being mounted up front. The assertion was deliberately **not**
weakened to accept either screen — that would pass whichever screen ⌘D opened,
which is the vacuous-assertion trap.

## The full sweep

Every `Mod+D` / `⌘D` / `KeyD` dispatch site in `e2e/` and `src/`:

| Site | Expects | Why still right |
|---|---|---|
| `keymap.e2e.ts` screen walk | Diff viewer | Arrives from `Mod+7` (Remotes). `AppShell` renders one screen, so `HistoryScreen` is unmounted and its handler unregistered; and the Remote screen's primary pane is `remote.detail`, so the pane filter would decline anyway. Comment added warning not to reorder the step after ⌘9. |
| `keymap.e2e.ts` F7 hunk walk | Diff viewer | **Was broken.** Now routed via the activity bar. |
| `keymap.e2e.ts` multi-selection | combined range diff | Unchanged behaviour — 2+ was always claimed. |
| `keymap.e2e.ts` single commit | that commit's own diff | The new contract. |
| `keymap.e2e.ts` off the commit list | Diff viewer | `Alt+ArrowLeft` moves focus to the activity bar, so the pane filter declines. Untouched. |
| `History.diffchord.test.tsx` × 5 | `commit-self` ×2, `switch-screen: diff` ×3 | The claim, the seeded-selection claim, the empty-log decline, and two pane-filter cases. |

Everything else matching those patterns is a comment or a binding-table
declaration. `presets.test.ts` performs no dispatch — it asserts the tables only.
The only e2e waits on the `diff.files` pane are the three rows above;
`keyboard-shortcuts.e2e.ts`'s `history.diff.files` is History's inline diff pane,
unrelated.

## Verification

`pnpm tsc --noEmit`, `pnpm exec tsc -p e2e/tsconfig.json --noEmit`, and
`pnpm test` (188 files, 1553 tests) all green.

E2E in Docker on the real webview (WebKitGTK 605.1.15 + xvfb, the same stack CI
uses), snapshot rebuilt first — `keymap.e2e.ts` **27 passing, 1 skipped, 0
failing** in 41s (a healthy band). The skip is the pre-existing `darwin`-only ⌃V
platform gate. Named confirmations:

```
✓ nav chords switch screens (⌘K, ⌘9, ⌘D, ⌘1/4/6/7, ⌘⇧9, ⌘,)
✓ F7 / ⇧F7 walk the diff hunks
✓ ⌘D on a multi-selection opens the combined diff of the range
✓ ⌘D with a single commit selected opens that commit's own diff
✓ ⌘D from outside the list reaches the Diff viewer even with a multi-selection
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Er25sN6pGoVJzmTBwHU2Tz
