### PR TITLE
feat(cli): detach pgit from the terminal on launch (#163)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,6 +329,11 @@ cli.rs           CLI arg parsing (LaunchIntent, parse_args, resolve_repo_root)
                  point of use, so all three platform tables are testable from
                  any host — two of the three cannot be exercised otherwise.
                  Not to be confused with git/cli.rs (CliBackend) below
+detach.rs        Handing the terminal back on a `pgit …` launch (#163):
+                 `should_detach` (PURE — the whole gate, and the reason the
+                 askpass path still authenticates) + `spawn_detached`, the
+                 re-exec that carries argv and cwd into a child with no stdio
+                 and its own session. See "The `pgit` launch detaches"
 windows/         add-user-path.ps1 — the per-user PATH append, `include_str!`'d
                  as `WINDOWS_PATH_SCRIPT` and fed to powershell on stdin
 deb/             pgit (the /usr/bin wrapper, committed 100755) + postinst
@@ -1669,6 +1674,41 @@ module and every `src/features/*/` directory is named somewhere in here.
   prompts and every choice is a flag or an env var. Watch `set -e` around
   `[ … ] && cmd` as a function's or loop body's last command, and feed loops from
   a here-doc rather than a pipe when they assign to an outer variable.
+
+### The `pgit` launch detaches — and one variant must not (#163)
+
+- **`pgit .` hands the prompt straight back**, like `code .`. The detach is in
+  the BINARY (`detach.rs`, called from one site in `lib.rs::run`), not in the
+  shims: two of the four shapes are symlinks to this executable, so there is no
+  script to put a `&` in, and `setsid` does not exist on macOS.
+- **`Parsed::Askpass` must never detach, and that is the whole risk of this
+  feature.** git runs this binary as `GIT_ASKPASS` and reads the credential from
+  its stdout, **synchronously**; a process that spawned a child and exited hands
+  git an empty credential, so every authenticated fetch, pull and push fails with
+  nothing in any error to trace it back to. `should_detach` therefore answers
+  yes for `Parsed::Launch` only, and additionally refuses while
+  `ASKPASS_MODE_ENV` is set — git's prompt string parses as a *path*, so a
+  reordering that let it reach the gate would otherwise read as a launch.
+  `Parsed::Help` stays synchronous for the same reason at a lower stake.
+- **`GIT_ASKPASS` points at the bare executable, never at the `pgit` shim**, and
+  since this landed there are two independent reasons: `GIT_ASKPASS` is exec'd
+  directly and cannot carry arguments (#61 D5), *and* `pgit` now detaches.
+- **It re-execs; it does not `fork()` and carry on.** macOS forbids using
+  CoreFoundation, AppKit or WebKit's XPC services in a forked child that has not
+  `exec`'d (fork(2) says so outright), and the child here IS the GUI. cwd is
+  passed to it explicitly even though an exec'd child inherits it, because
+  `parse_args` resolves `pgit ../other-repo` against it.
+- **Gated on stdout being a terminal**, so Finder, the Dock, a `.desktop` entry
+  and the e2e harness's pipes are untouched. Consequence worth knowing:
+  `pgit . > file` still blocks, by design.
+- **Windows is deliberately unchanged.** The release binary is GUI-subsystem, so
+  `cmd.exe` and PowerShell already return; Git Bash waits, but its stdout is an
+  MSYS named pipe that `IsTerminal` reports as not a terminal, so the gate would
+  refuse there anyway. Fixing that shell needs a Windows machine to verify on.
+- `tests/cli_detach.rs` drives the real binary through a **pty** for the two
+  paths that must stay synchronous, and `git credential fill` — git's own
+  credential machinery, offline — for the credentialed one. A pure-function test
+  cannot show that git still gets its answer.
 
 ### Permissions (Tauri 2)
 - Shared permissions in `src-tauri/capabilities/default.json`. Current set: `core:default`, `core:window:allow-minimize`, `core:window:allow-toggle-maximize`, `core:window:allow-close`, `core:window:allow-start-dragging`, `core:window:allow-set-title`, `core:webview:allow-create-webview-window`, `core:webview:allow-set-webview-zoom` (the `view.zoom*` chords), `dialog:default`, `dialog:allow-open`, `os:default`, `log:default`. Capability scopes `windows: ["main", "merge"]` (merge resolver runs as a second window).

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3222,6 +3222,7 @@ name = "platypusgit"
 version = "0.0.0"
 dependencies = [
  "git2",
+ "libc",
  "log",
  "regex",
  "semver",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,10 +50,22 @@ semver = "1"
 # Content log search (#61 D10) compiles the user's pattern once per walk.
 regex = "1"
 
+# `setsid()` between fork and exec, for the detached `pgit` launch (#163) —
+# nothing in std reaches it (`Command::process_group` only makes a new process
+# group, which leaves the app attached to the terminal it was launched from).
+# Already in the tree transitively, so this declares it rather than adding it.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [features]
 # Compile + wire the WebDriver plugin. Set only by the e2e debug build.
 e2e = ["dep:tauri-plugin-wdio-webdriver"]
 
 [dev-dependencies]
 tempfile = "3"
+
+# The detach tests drive the real binary through a pty, which is the only way to
+# prove the tty gate does not capture the askpass and --help paths.
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"
 

--- a/src-tauri/src/commands/net.rs
+++ b/src-tauri/src/commands/net.rs
@@ -38,6 +38,11 @@ pub struct Credentials {
 ///   carry arguments — hence `ASKPASS_MODE_ENV` rather than a `--askpass` flag.
 /// * The secret travels in the environment, never in argv: argv is
 ///   world-readable via `ps` on macOS and Linux, a process's environment is not.
+/// * It points at the **bare executable**, never at the installed `pgit` shim
+///   (which on every Unix channel is a symlink to this same binary): `pgit`
+///   detaches from the terminal on launch, and git reads the credential from the
+///   askpass's stdout synchronously. See `detach::should_detach` and the fork
+///   site in `lib.rs::run`.
 pub fn apply_auth_env(cmd: &mut tokio::process::Command, creds: Option<&Credentials>) {
     cmd.env("GIT_TERMINAL_PROMPT", "0");
     match creds {

--- a/src-tauri/src/detach.rs
+++ b/src-tauri/src/detach.rs
@@ -1,0 +1,247 @@
+//! Handing the terminal back on a `pgit …` launch (#163).
+//!
+//! `pgit .` used to hold the terminal for as long as the app stayed open, and
+//! `Ctrl+C` killed it. It cannot be fixed in the shims: every channel that
+//! installs `pgit` installs either a **symlink to this very binary** (the Unix
+//! self-install and the Homebrew cask's `binary` stanza) or a wrapper whose one
+//! line is `exec /usr/bin/platypusgit "$@"` — a symlink has no script to put a
+//! `&` in, and `setsid` does not exist on macOS. So the detach lives here, in
+//! the one place all four shim shapes pass through.
+//!
+//! ## What must NOT detach
+//!
+//! `should_detach` is the whole gate, and `Parsed::Launch` is the only variant
+//! it says yes to. The dangerous one is `Parsed::Askpass`: git runs this binary
+//! as `GIT_ASKPASS` and reads the credential from **its stdout, synchronously**,
+//! so a process that spawned a child and exited would hand git an empty
+//! credential and every authenticated fetch/pull/push would fail with nothing to
+//! trace it back to. `Parsed::Help` must stay synchronous too, or `USAGE` is
+//! printed by a child whose stdout is `/dev/null`.
+//!
+//! ## Why this re-execs instead of calling `fork()`
+//!
+//! A bare `fork()` keeps the GUI in a child that never `exec`s, and macOS
+//! forbids exactly that: fork(2) says "all APIs, including Core Foundation and
+//! Objective-C frameworks, are subject to this restriction" until one of the
+//! `exec` functions is called, and CoreFoundation is already initialised by the
+//! time `main` runs in a process linked against AppKit and WebKit. The child
+//! here *is* the GUI, so it gets a clean process image instead. `exec` also
+//! costs nothing we care about: the parent has done no Tauri, AppKit or libgit2
+//! work at the point the decision is made.
+//!
+//! ## Room left for `--wait`
+//!
+//! `code --wait` blocks until the window closes so it can serve as `$EDITOR`
+//! (issue 163 records it as out of scope). Nothing here consumes a flag —
+//! `DETACHED_ENV` is an environment variable — so the flag namespace is
+//! untouched. Whoever adds `--wait` gives it its own `Parsed` shape and
+//! `should_detach` refuses it, the same way it refuses `Help`.
+
+use std::path::Path;
+
+use crate::cli::Parsed;
+
+/// Set in the re-executed child's environment so it can never detach again.
+///
+/// The tty check would already stop it (the child's stdout is `/dev/null`), but
+/// a launcher is not a place to rely on one condition: this makes the recursion
+/// impossible rather than merely unlikely.
+pub const DETACHED_ENV: &str = "PLATYPUSGIT_DETACHED";
+
+/// Everything outside the parsed arguments that the decision depends on.
+///
+/// Passed in rather than read, so every combination is unit-testable — this is
+/// the one function in the app whose wrong answer is invisible until somebody's
+/// push stops authenticating.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LaunchEnv {
+    /// Whether stdout is a terminal. A launch from Finder, the Dock or a
+    /// `.desktop` entry has no terminal to hand back and must be untouched.
+    pub stdout_is_terminal: bool,
+    /// Whether `ASKPASS_MODE_ENV` is set — i.e. git is running us as its
+    /// askpass. Belt to `Parsed::Askpass`'s brace: git's prompt string is
+    /// arbitrary text and parses as a *path*, so a reordering that let it reach
+    /// this gate would otherwise read as a `Launch`.
+    pub askpass_mode: bool,
+    /// Whether we are already the detached child.
+    pub already_detached: bool,
+}
+
+impl LaunchEnv {
+    /// Read the real environment.
+    pub fn current() -> Self {
+        use std::io::IsTerminal;
+        Self {
+            stdout_is_terminal: std::io::stdout().is_terminal(),
+            askpass_mode: std::env::var_os(crate::cli::ASKPASS_MODE_ENV).is_some(),
+            already_detached: std::env::var_os(DETACHED_ENV).is_some(),
+        }
+    }
+}
+
+/// Whether this invocation should hand the terminal back. PURE.
+pub fn should_detach(parsed: &Parsed, env: LaunchEnv) -> bool {
+    // Askpass answers git on stdout and Help prints USAGE; both are synchronous
+    // by contract. Only a launch has a window to go on living behind it.
+    matches!(parsed, Parsed::Launch(_))
+        && env.stdout_is_terminal
+        && !env.askpass_mode
+        && !env.already_detached
+}
+
+/// Whether the caller is now the process that should keep going.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Detached {
+    /// A detached child owns the launch. Return from `main` — exit 0, like
+    /// `code .`.
+    Yes,
+    /// Nothing was detached; carry on in the foreground exactly as before.
+    No,
+}
+
+/// Re-exec this binary detached from the terminal, with the same arguments.
+///
+/// `cwd` is passed to the child explicitly even though an exec'd child inherits
+/// it: `parse_args` resolves a relative path against it, so `pgit ../other-repo`
+/// depends on the child seeing the shell's directory and not on an inheritance
+/// rule holding.
+#[cfg(unix)]
+pub fn detach(cwd: &Path) -> Detached {
+    let exe = match std::env::current_exe() {
+        Ok(e) => e,
+        Err(_) => return Detached::No,
+    };
+    let args: Vec<std::ffi::OsString> = std::env::args_os().skip(1).collect();
+    match spawn_detached(&exe, &args, cwd) {
+        Ok(()) => Detached::Yes,
+        // Degrade to the old behaviour rather than failing to launch. One line
+        // on stderr because the visible symptom (the terminal stays held) is
+        // otherwise unattributable.
+        Err(e) => {
+            eprintln!(
+                "platypusgit: could not detach from the terminal ({e}); staying in the foreground"
+            );
+            Detached::No
+        }
+    }
+}
+
+/// Windows is deliberately untouched (issue 163).
+///
+/// The release binary is GUI-subsystem (`windows_subsystem = "windows"` in
+/// `main.rs`), so `cmd.exe` and PowerShell already return the prompt without
+/// waiting. Git Bash does wait — but its stdout is an MSYS named pipe, which
+/// `IsTerminal` reports as *not* a terminal, so the tty gate would refuse to
+/// detach there anyway. Fixing that shell needs a Windows machine to verify on.
+#[cfg(not(unix))]
+pub fn detach(_cwd: &Path) -> Detached {
+    Detached::No
+}
+
+/// Spawn `exe` with `args`, in `cwd`, with no terminal and no stdio.
+///
+/// Separate from [`detach`] so tests can drive the mechanism with a probe
+/// program instead of the app binary — re-executing the app would open a window,
+/// and re-executing the test harness would fork-bomb it.
+#[cfg(unix)]
+pub fn spawn_detached(exe: &Path, args: &[std::ffi::OsString], cwd: &Path) -> std::io::Result<()> {
+    use std::os::unix::process::CommandExt;
+    use std::process::{Command, Stdio};
+
+    let mut cmd = Command::new(exe);
+    cmd.args(args)
+        .current_dir(cwd)
+        .env(DETACHED_ENV, "1")
+        // Or the app keeps writing into a terminal the user believes it has
+        // left. Only tauri-plugin-log's Stdout target lands here; its LogDir
+        // target opens its own file and is unaffected.
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    // SAFETY: `pre_exec` runs in the forked child before `exec`, where only
+    // syscalls are legal. `setsid` is one, and it is what puts the app in a new
+    // session with no controlling terminal — so closing the terminal window
+    // cannot SIGHUP it, and Ctrl+C in that terminal cannot reach it.
+    unsafe {
+        cmd.pre_exec(|| {
+            libc::setsid();
+            Ok(())
+        });
+    }
+    // `Command::spawn` reports a failed exec back through its own pipe, so an
+    // unlaunchable child is an Err here rather than a silent orphan. The handle
+    // is dropped without waiting: `Child::drop` neither kills nor reaps, and the
+    // parent is about to exit, so the child is reparented to init.
+    cmd.spawn().map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::LaunchIntent;
+    use std::path::PathBuf;
+
+    fn env(stdout_is_terminal: bool) -> LaunchEnv {
+        LaunchEnv {
+            stdout_is_terminal,
+            askpass_mode: false,
+            already_detached: false,
+        }
+    }
+
+    fn launch() -> Parsed {
+        Parsed::Launch(Some(LaunchIntent {
+            path: Some(PathBuf::from("/repo")),
+            screen: None,
+        }))
+    }
+
+    #[test]
+    fn a_terminal_launch_detaches() {
+        assert!(should_detach(&launch(), env(true)));
+        assert!(should_detach(&Parsed::Launch(None), env(true)));
+    }
+
+    #[test]
+    fn a_launch_with_no_terminal_stays_in_the_foreground() {
+        // Finder, the Dock, a .desktop entry, and the e2e harness's pipes.
+        assert!(!should_detach(&launch(), env(false)));
+    }
+
+    #[test]
+    fn askpass_never_detaches() {
+        // git reads the credential from our stdout, synchronously. Detaching
+        // here hands it an empty credential and breaks every authenticated
+        // fetch, pull and push with no visible cause.
+        let prompt = Parsed::Askpass("Password for 'https://example.invalid': ".into());
+        assert!(!should_detach(&prompt, env(true)));
+        assert!(!should_detach(&prompt, env(false)));
+    }
+
+    #[test]
+    fn askpass_mode_never_detaches_even_if_the_prompt_parsed_as_a_launch() {
+        // git's prompt is arbitrary text and parse_args reads an unrecognised
+        // token as a path, so this is what a reordering would look like.
+        let e = LaunchEnv {
+            askpass_mode: true,
+            ..env(true)
+        };
+        assert!(!should_detach(&launch(), e));
+    }
+
+    #[test]
+    fn help_never_detaches() {
+        // USAGE must reach the terminal that asked for it.
+        assert!(!should_detach(&Parsed::Help, env(true)));
+        assert!(!should_detach(&Parsed::Help, env(false)));
+    }
+
+    #[test]
+    fn the_detached_child_does_not_detach_again() {
+        let e = LaunchEnv {
+            already_detached: true,
+            ..env(true)
+        };
+        assert!(!should_detach(&launch(), e));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cli;
 pub mod commands;
+pub mod detach;
 pub mod error;
 pub mod forge;
 pub mod git;
@@ -47,7 +48,31 @@ pub fn run() {
         }
     }
 
-    let initial_intent = match cli::parse_args(&args, &cwd) {
+    let parsed = cli::parse_args(&args, &cwd);
+
+    // Hand the terminal back on a `pgit …` launch (#163) — the ONE fork site.
+    //
+    // ⚠️ Gated on `Parsed::Launch` and nothing else, because git runs THIS
+    // BINARY as its `GIT_ASKPASS` (see commands/net.rs::apply_auth_env) and
+    // reads the credential from its stdout, synchronously. A process that
+    // spawned a child and exited would hand git an empty credential, and every
+    // authenticated fetch, pull and push would fail with nothing to trace it
+    // back to. `Parsed::Help` must stay synchronous for the same reason at a
+    // lower stake: `USAGE` printed by a detached child goes to /dev/null.
+    //
+    // ⚠️ And this is why `GIT_ASKPASS` points at the BARE EXECUTABLE rather than
+    // at the installed `pgit` shim, which on every Unix channel is a symlink to
+    // this same binary: `pgit` now detaches. Pointing the askpass at it — an
+    // otherwise reasonable-looking simplification — reintroduces exactly the
+    // failure above. (The original reason is that `GIT_ASKPASS` is exec'd
+    // directly and cannot carry arguments; both reasons must hold.)
+    if detach::should_detach(&parsed, detach::LaunchEnv::current())
+        && detach::detach(&cwd) == detach::Detached::Yes
+    {
+        return;
+    }
+
+    let initial_intent = match parsed {
         cli::Parsed::Help => {
             print!("{}", cli::USAGE);
             return;

--- a/src-tauri/tests/cli_detach.rs
+++ b/src-tauri/tests/cli_detach.rs
@@ -1,0 +1,374 @@
+//! The detached `pgit` launch (#163) — and, above all, the three things that
+//! must NOT detach.
+//!
+//! `detach::should_detach`'s unit tests cover the decision table. These drive
+//! the REAL binary, because the decision is only half of it: the askpass path
+//! has to keep answering git on its own stdout, synchronously, and no unit test
+//! of a pure function can show that.
+//!
+//! Two of the tests run the binary with a **real terminal** on its stdout (a
+//! pty), which is the condition the detach is gated on — so they fail if the
+//! gate ever widens to cover askpass or `--help`.
+#![cfg(unix)]
+
+use std::ffi::{CString, OsString};
+use std::io::{Read, Write};
+use std::os::fd::FromRawFd;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use platypusgit_lib::cli::{ASKPASS_MODE_ENV, ASKPASS_SECRET_ENV, ASKPASS_USERNAME_ENV, USAGE};
+use platypusgit_lib::commands::net::{apply_auth_env, Credentials};
+use platypusgit_lib::detach::{spawn_detached, DETACHED_ENV};
+
+/// The real app binary — the same file every `pgit` shim points at.
+const EXE: &str = env!("CARGO_BIN_EXE_platypusgit");
+
+// ─────────────────────────────────────────────────────────────
+// A real terminal on the child's stdout
+// ─────────────────────────────────────────────────────────────
+
+struct PtyRun {
+    output: String,
+    code: Option<i32>,
+}
+
+/// Run `cmd` with a freshly allocated pty on its stdout and stderr, so
+/// `IsTerminal` inside the child answers *yes*.
+///
+/// Two traps, both hit while writing this:
+///
+/// * The master is drained on a **thread**, not after `wait`. A pty buffer holds
+///   about a kilobyte, so a child printing `USAGE` could otherwise fill it and
+///   block against a parent blocked in `wait`.
+/// * The master is **non-blocking**, and the reader stops when the child is
+///   gone rather than at end-of-file. macOS does not report EOF on a master whose
+///   slaves have all closed — the slave could be reopened — so a read there
+///   blocks forever, where Linux raises EIO.
+fn run_in_pty(mut cmd: Command) -> PtyRun {
+    unsafe {
+        let master = libc::posix_openpt(libc::O_RDWR | libc::O_NOCTTY);
+        assert!(master >= 0, "posix_openpt failed");
+        assert_eq!(libc::grantpt(master), 0, "grantpt failed");
+        assert_eq!(libc::unlockpt(master), 0, "unlockpt failed");
+        let name = libc::ptsname(master);
+        assert!(!name.is_null(), "ptsname failed");
+        let slave_path = CString::new(std::ffi::CStr::from_ptr(name).to_bytes()).unwrap();
+        let slave = libc::open(slave_path.as_ptr(), libc::O_RDWR | libc::O_NOCTTY);
+        assert!(slave >= 0, "open slave pty failed");
+
+        let out = libc::dup(slave);
+        let err = libc::dup(slave);
+        assert!(out >= 0 && err >= 0, "dup slave pty failed");
+
+        let mut child = cmd
+            .stdin(Stdio::null())
+            .stdout(Stdio::from_raw_fd(out))
+            .stderr(Stdio::from_raw_fd(err))
+            .spawn()
+            .expect("spawn the app binary");
+        // Our own copy must go, or the child is not the only writer left.
+        libc::close(slave);
+        assert_eq!(
+            libc::fcntl(master, libc::F_SETFL, libc::O_NONBLOCK),
+            0,
+            "set the pty master non-blocking"
+        );
+
+        let mut master_file = std::fs::File::from_raw_fd(master);
+        let gone = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let reader = {
+            let gone = gone.clone();
+            std::thread::spawn(move || {
+                let mut buf = Vec::new();
+                let mut chunk = [0u8; 4096];
+                loop {
+                    match master_file.read(&mut chunk) {
+                        Ok(0) => break,
+                        Ok(n) => buf.extend_from_slice(&chunk[..n]),
+                        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                            // Nothing buffered: done only if the writer is gone.
+                            if gone.load(std::sync::atomic::Ordering::SeqCst) {
+                                break;
+                            }
+                            std::thread::sleep(std::time::Duration::from_millis(5));
+                        }
+                        Err(_) => break,
+                    }
+                }
+                buf
+            })
+        };
+        let status = child.wait().expect("wait for the app binary");
+        gone.store(true, std::sync::atomic::Ordering::SeqCst);
+        let buf = reader.join().expect("pty reader thread");
+        PtyRun {
+            // A terminal translates \n into \r\n on the way out.
+            output: String::from_utf8_lossy(&buf).replace("\r\n", "\n"),
+            code: status.code(),
+        }
+    }
+}
+
+/// A launch would detach here, so every one of these must be cleared: an
+/// inherited value would answer the very question the test is asking.
+fn clean_env(cmd: &mut Command) {
+    cmd.env_remove(ASKPASS_MODE_ENV)
+        .env_remove(ASKPASS_USERNAME_ENV)
+        .env_remove(ASKPASS_SECRET_ENV)
+        .env_remove(DETACHED_ENV);
+}
+
+#[test]
+fn askpass_answers_on_stdout_even_with_a_terminal_attached() {
+    let mut cmd = Command::new(EXE);
+    clean_env(&mut cmd);
+    cmd.arg("Password for 'https://example.invalid': ")
+        .env(ASKPASS_MODE_ENV, "1")
+        .env(ASKPASS_SECRET_ENV, "s3cr3t-through-a-pty");
+
+    let run = run_in_pty(cmd);
+
+    assert_eq!(run.code, Some(0), "askpass output was: {:?}", run.output);
+    assert_eq!(
+        run.output.trim_end(),
+        "s3cr3t-through-a-pty",
+        "git reads the credential from this stdout, synchronously — a detached \
+         askpass writes nothing and every authenticated fetch/pull/push fails"
+    );
+}
+
+#[test]
+fn a_username_prompt_is_answered_too_with_a_terminal_attached() {
+    let mut cmd = Command::new(EXE);
+    clean_env(&mut cmd);
+    cmd.arg("Username for 'https://example.invalid': ")
+        .env(ASKPASS_MODE_ENV, "1")
+        .env(ASKPASS_USERNAME_ENV, "ada")
+        .env(ASKPASS_SECRET_ENV, "s3cr3t-through-a-pty");
+
+    let run = run_in_pty(cmd);
+
+    assert_eq!(run.code, Some(0));
+    assert_eq!(run.output.trim_end(), "ada");
+}
+
+#[test]
+fn an_unrecognised_prompt_still_exits_nonzero_with_no_output() {
+    // The pre-existing contract: never print an empty string, which git would
+    // take as a real credential. A detach would have exited 0 with no output.
+    let mut cmd = Command::new(EXE);
+    clean_env(&mut cmd);
+    cmd.arg("Some prompt we do not understand: ")
+        .env(ASKPASS_MODE_ENV, "1")
+        .env(ASKPASS_SECRET_ENV, "s3cr3t-through-a-pty");
+
+    let run = run_in_pty(cmd);
+
+    assert_eq!(run.code, Some(1));
+    assert_eq!(run.output.trim(), "");
+}
+
+#[test]
+fn help_prints_usage_and_exits_even_with_a_terminal_attached() {
+    let mut cmd = Command::new(EXE);
+    clean_env(&mut cmd);
+    cmd.arg("--help");
+
+    let run = run_in_pty(cmd);
+
+    assert_eq!(run.code, Some(0));
+    assert_eq!(
+        run.output, USAGE,
+        "USAGE must reach the terminal that asked for it, not a detached \
+         child's /dev/null"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────
+// The credentialed regression test: real git → the real binary
+// ─────────────────────────────────────────────────────────────
+
+/// `git credential fill` is git's own credential machinery, offline: with no
+/// helper to answer it, it prompts through `GIT_ASKPASS` exactly as a 401'd
+/// fetch/pull/push does, and reads the answer from the child's stdout —
+/// synchronously, one line per prompt.
+///
+/// The environment comes from the production `apply_auth_env`, so this is the
+/// real policy and not a hand-rolled imitation of it. `GIT_ASKPASS` is the one
+/// value overridden: `apply_auth_env` points it at `current_exe()`, which under
+/// `cargo test` is the test harness, and the point here is to drive the app
+/// binary.
+#[test]
+fn a_credentialed_git_prompt_is_answered_by_the_real_binary() {
+    let git_available = std::process::Command::new("git")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !git_available {
+        eprintln!("SKIP: git not on PATH");
+        return;
+    }
+    let home = tempfile::tempdir().expect("tempdir");
+
+    let creds = Credentials {
+        username: Some("ada".into()),
+        secret: "ghp_supersecret".into(),
+    };
+    let mut cmd = tokio::process::Command::new("git");
+    cmd.arg("-c")
+        // Belt to the isolated config's brace: a helper would answer without
+        // ever consulting the askpass, and the test would pass for nothing.
+        .arg("credential.helper=")
+        .args(["credential", "fill"]);
+    apply_auth_env(&mut cmd, Some(&creds));
+    cmd.env("GIT_ASKPASS", EXE)
+        .env("SSH_ASKPASS", EXE)
+        // No system, global or repo config, and a cwd that is not a repository.
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("HOME", home.path())
+        .current_dir(home.path());
+
+    let mut child = cmd
+        .into_std()
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn git credential fill");
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(b"protocol=https\nhost=example.invalid\n\n")
+        .expect("write the credential request");
+    let out = child.wait_with_output().expect("git credential fill");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "git credential fill failed: {stderr}\n{stdout}"
+    );
+    // GIT_TERMINAL_PROMPT=0 is part of the same policy, so these two lines can
+    // only have come from the askpass shim.
+    assert!(
+        stdout.contains("username=ada"),
+        "git did not get the username from the askpass shim: {stdout}"
+    );
+    assert!(
+        stdout.contains("password=ghp_supersecret"),
+        "git did not get the password from the askpass shim: {stdout}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────
+// The detach mechanism itself
+// ─────────────────────────────────────────────────────────────
+
+/// A probe standing in for the app: it records what a detached child actually
+/// inherits, then writes it to a **relative** path — the same thing
+/// `pgit ../other-repo` depends on.
+///
+/// Every value is read before the output redirect, since a command substitution
+/// would replace fd 1 with a pipe and the stdout answers would describe that
+/// pipe instead of what was inherited.
+const PROBE: &str = r#"#!/bin/sh
+out=$1
+delay=$2
+if [ -t 1 ]; then stdout_tty=yes; else stdout_tty=no; fi
+if [ -c /dev/fd/1 ]; then stdout_chardev=yes; else stdout_chardev=no; fi
+if [ -t 0 ]; then stdin_tty=yes; else stdin_tty=no; fi
+pgid=$(ps -o pgid= -p $$ 2>/dev/null | tr -d ' ')
+cwd=$(pwd)
+sleep "$delay"
+printf 'cwd=%s\nstdout_tty=%s\nstdout_chardev=%s\nstdin_tty=%s\npgid=%s\n' \
+  "$cwd" "$stdout_tty" "$stdout_chardev" "$stdin_tty" "$pgid" > "$out"
+"#;
+
+fn field(text: &str, key: &str) -> String {
+    text.lines()
+        .find_map(|l| l.strip_prefix(&format!("{key}=")))
+        .unwrap_or_else(|| panic!("no {key} in probe output:\n{text}"))
+        .to_string()
+}
+
+fn wait_for(path: &Path) -> String {
+    for _ in 0..200 {
+        if let Ok(text) = std::fs::read_to_string(path) {
+            if text.contains("pgid=") {
+                return text;
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    panic!("the detached child never wrote {}", path.display());
+}
+
+#[test]
+fn a_detached_child_keeps_the_cwd_and_loses_the_terminal() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // getcwd() answers with the physical path, and on macOS a tempdir's
+    // /var/folders/… is a symlink to /private/var/folders/….
+    let cwd = dir.path().canonicalize().expect("canonicalize tempdir");
+    let script = cwd.join("probe.sh");
+    std::fs::write(&script, PROBE).expect("write the probe");
+
+    let args: Vec<OsString> = vec![
+        script.clone().into(),
+        // Relative: only resolvable if the child's cwd is what we asked for.
+        OsString::from("probe.txt"),
+        OsString::from("1"),
+    ];
+    spawn_detached(Path::new("/bin/sh"), &args, &cwd).expect("spawn_detached");
+
+    let out: PathBuf = cwd.join("probe.txt");
+    assert!(
+        !out.exists(),
+        "spawn_detached returned only after the child finished — it must hand \
+         the prompt back immediately"
+    );
+
+    let text = wait_for(&out);
+    assert_eq!(
+        field(&text, "cwd"),
+        cwd.to_string_lossy(),
+        "the child must inherit the invoking shell's directory"
+    );
+    assert_eq!(field(&text, "stdout_tty"), "no", "stdout still a terminal");
+    assert_eq!(field(&text, "stdin_tty"), "no", "stdin still a terminal");
+    assert_eq!(
+        field(&text, "stdout_chardev"),
+        "yes",
+        "a char device that is no terminal is /dev/null; a pipe or a file is not"
+    );
+
+    // setsid: a new session, so closing the terminal cannot SIGHUP the app and
+    // Ctrl+C in it cannot reach it.
+    let pgid = field(&text, "pgid");
+    if pgid.is_empty() {
+        eprintln!("SKIP session check: `ps -o pgid=` produced nothing");
+    } else {
+        let ours = unsafe { libc::getpgrp() };
+        assert_ne!(
+            pgid,
+            ours.to_string(),
+            "the detached child stayed in our process group"
+        );
+    }
+}
+
+#[test]
+fn an_unlaunchable_child_is_an_error_not_a_silent_orphan() {
+    // What makes the caller able to fall back to a foreground launch instead of
+    // exiting 0 with nothing running.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let err = spawn_detached(
+        Path::new("/nonexistent/platypusgit-detach-probe"),
+        &[],
+        dir.path(),
+    );
+    assert!(err.is_err(), "a failed exec must be reported");
+}


### PR DESCRIPTION
Addresses issue 163. `pgit .` now hands the prompt straight back, like `code .`, instead of holding the terminal for as long as the app is open and dying to `Ctrl+C`.

## Where the detach sits, and what it is gated on

One site: `lib.rs::run`, immediately after the askpass early-return and before any Tauri, AppKit or libgit2 work. The decision is `detach::should_detach(&parsed, LaunchEnv::current())` — pure, with the environment passed in, so every combination is unit-tested. It says yes only when **all** of these hold:

- the parse is `Parsed::Launch(_)`,
- stdout is a terminal (Finder, the Dock, a `.desktop` entry and the e2e harness's pipes are untouched),
- `PLATYPUSGIT_ASKPASS` is not set,
- `PLATYPUSGIT_DETACHED` is not set (the child cannot detach again).

`Parsed::Askpass` therefore reaches today's code path untouched — it is still handled *above* the detach site, and the gate refuses it twice over. That matters more than anything else here: git runs this same binary as its `GIT_ASKPASS` and reads the credential from its **stdout, synchronously**, so a process that spawned a child and exited would hand git an empty credential and break every authenticated fetch, pull and push with nothing in any error to trace it back to. `Parsed::Help` stays synchronous too, so `USAGE` reaches the terminal that asked for it.

The comment at the fork site records the second-order trap as well: `GIT_ASKPASS` points at the bare executable rather than at the installed `pgit` shim (a symlink to this same binary on every Unix channel) *because* `pgit` now detaches. A later "simplification" pointing it at the shim reintroduces exactly the failure above.

## Why in the binary, and why re-exec

Two of the four shim shapes are symlinks to this executable (the Unix self-install and the Homebrew cask's `binary` stanza), so there is no script to put a `&` in, and `setsid` does not exist on macOS. One decision in the binary covers all four.

It re-execs rather than calling `fork()` and carrying on: macOS's `fork(2)` forbids using Core Foundation, Objective-C frameworks — and so WebKit's XPC services — in a forked child that has not `exec`'d, and the child here *is* the GUI. CoreFoundation is already initialised before `main` in a process linked against AppKit and WebKit, so a bare fork would be exactly the unsupported case. cwd is passed to the child explicitly even though an exec'd child inherits it, because `parse_args` resolves `pgit ../other-repo` against it. `setsid` runs between fork and exec (`pre_exec`), so the app has no controlling terminal.

A failed spawn degrades to a foreground launch with one line on stderr, rather than exiting 0 with nothing running.

## Verification

`cargo check`, `cargo test` (full suite green, 7 new integration tests + 6 new unit tests), `pnpm tsc --noEmit`, `pnpm test` (1552 tests). E2E was not run — another agent held the Docker slot, and this change is outside the webview.

**The two reproduction cases, kept apart deliberately.** `tauri-plugin-single-instance` forwards a second invocation and exits, so with the app already open *every* `pgit .` has always returned instantly. Measured with the real debug binary in a pty (`script -q /dev/null`):

| case | conditions | result |
| --- | --- | --- |
| first launch, forwarding **impossible** (`PLATYPUSGIT_NO_SINGLE_INSTANCE=1`) | detach active | parent `exit=0` after **0.02s**; child alive with `ppid=1`, its own pgid |
| same, relative path `../` from a subdirectory | detach active | parent `exit=0` after **0.04s**; child alive |
| same, detach suppressed (`PLATYPUSGIT_DETACHED=1`) | today's behaviour | **still holding the terminal after 6s** |
| second invocation, app already running | detach suppressed | `exit=0` after 0.06s |
| second invocation, app already running | detach active | `exit=0` after 0.03s |

The last two rows are the trap: with an instance open, both behave identically, so only the first three rows say anything.

**cwd and stdio, read off the live detached child:**

```
child cwd: /private/var/folders/…/repo/sub     (launched as `pgit ../` from repo/sub)
expected : /private/var/folders/…/repo/sub
0r CHR 3,2 /dev/null    1w CHR 3,2 /dev/null    2w CHR 3,2 /dev/null
```

Fd 1 had 74 bytes written to it — output that used to land in the user's terminal. **File logging is unaffected**: the detached child's `platypusgit starting v0.0.0` line appears in `~/Library/Logs/…/platypusgit.log` at the launch timestamp, because only `tauri-plugin-log`'s `Stdout` target goes to `/dev/null` while its `LogDir` target opens its own file.

**The credentialed regression test.** `tests/cli_detach.rs` drives `git credential fill` — git's own credential machinery, offline, with the environment built by the production `apply_auth_env` — and asserts git gets `username=ada` and `password=…` from the real binary, with `GIT_TERMINAL_PROMPT=0` set so the answers can only have come from the askpass. Honest caveat: that test still passes with the gate removed, because git gives the askpass a **pipe** for stdout, so the tty check is false there anyway. What pins the gate is the pty tests. With the detach hoisted above the askpass early-return and the gate dropped, all three of those fail with empty output — the exact silent failure:

```
askpass_answers_on_stdout_even_with_a_terminal_attached ... FAILED
  left: ""   right: "s3cr3t-through-a-pty"
a_username_prompt_is_answered_too_with_a_terminal_attached ... FAILED
help_prints_usage_and_exits_even_with_a_terminal_attached ... FAILED
```

With the gate in place, all seven pass.

## Not verified: Windows

I have no Windows machine, so the `.cmd` shim in `cmd.exe`, PowerShell and Git Bash is **unverified** and the code deliberately changes nothing there (`detach` is `#[cfg(unix)]`; the non-unix arm returns "not detached"). What I believe happens, and why: the release binary is GUI-subsystem (`windows_subsystem = "windows"`), so `cmd.exe` and PowerShell return the prompt without waiting; Git Bash does wait, but its stdout is an MSYS named pipe that Rust's `IsTerminal` reports as *not* a terminal, so a tty-gated detach would refuse there regardless. Fixing that shell needs someone on Windows to measure it.

## Known, deliberate consequences

- `pgit . > file` still blocks, because stdout is then not a terminal. That is the gate the issue asks for.
- With the app already running, a `pgit .` now spawns a short-lived detached child that forwards the intent and exits — one extra process, and the forwarded cwd is still correct because it is passed explicitly.
- `--wait` (the `$EDITOR` use case the issue records as out of scope) is still cleanly reachable: nothing here consumes a flag, `PLATYPUSGIT_DETACHED` is an environment variable, and `should_detach` takes the parsed variant — so `--wait` gets its own `Parsed` shape and is refused there the same way `Help` is. The module doc says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Er25sN6pGoVJzmTBwHU2Tz
