### PR TITLE
perf: blazing-fast highlighting, diff pipeline, scroll, and backend paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -775,6 +775,9 @@ lib/
 │                    event, a ResizeObserver when there is one, and a bounded
 │                    rAF poll while it still reads 0
 ├── useWindowedList.ts  Fixed-pitch windowing for the plain lists
+├── useVariableWindow.ts  Scroll → windowVariable state for the diff surfaces;
+│                    updates state only when the window RANGE changes, so
+│                    scrolling inside the overscan band costs zero re-renders
 ├── useDiffRowHeight.ts  Resolves `--diff-row-h` to px, with a fallback for
 │                    jsdom (which does not evaluate `calc()`); CSS stays the
 │                    source of truth — NaN here would collapse every row to zero
@@ -1568,7 +1571,7 @@ module and every `src/features/*/` directory is named somewhere in here.
   the first bad commit rather than let the user read a sha off the titlebar.
 
 ### Async / threading (Rust)
-- `git2::Repository` is `Send` but not `Sync`. `Libgit2Backend` holds each opened repo as `Mutex<Repository>` inside a `Mutex<HashMap<RepoId, ...>>`. Several repositories are genuinely open at once (multi-repo tabs); `close` is the only thing that removes an entry.
+- `git2::Repository` is `Send` but not `Sync`. `Libgit2Backend` holds each opened repo as `Arc<Mutex<Repository>>` inside a `Mutex<HashMap<RepoId, ...>>` — `with_repo` clones the Arc and RELEASES the map lock before running the op, so different repositories run in parallel while same-repo ops still serialize on the inner mutex (which the stash TOCTOU note relies on). Several repositories are genuinely open at once (multi-repo tabs); `close` is the only thing that removes an entry.
 - Always wrap git2 work in `spawn_blocking` from Tauri commands — don't block async runtime.
 
 ### Styling

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@codemirror/view": "^6.43.6",
     "@fontsource-variable/inter": "5.3.0",
     "@fontsource-variable/jetbrains-mono": "5.3.0",
+    "@shikijs/langs-precompiled": "4.4.3",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-log": "^2.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@fontsource-variable/jetbrains-mono':
         specifier: 5.3.0
         version: 5.3.0
+      '@shikijs/langs-precompiled':
+        specifier: 4.4.3
+        version: 4.4.3
       '@tauri-apps/api':
         specifier: ^2
         version: 2.10.1
@@ -819,79 +822,66 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -936,6 +926,10 @@ packages:
 
   '@shikijs/engine-oniguruma@4.4.3':
     resolution: {integrity: sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs-precompiled@4.4.3':
+    resolution: {integrity: sha512-i3+91QcqVBji2mlCinQpHQyoZfciaWsHCuv5XZwMXGEmSAMCW0oCdrWp+zMKLf0CwHd9XT+E5RBDJ0RY1USWCw==}
     engines: {node: '>=20'}
 
   '@shikijs/langs@4.4.3':
@@ -1005,28 +999,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -1087,35 +1077,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.10.1':
     resolution: {integrity: sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.10.1':
     resolution: {integrity: sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.10.1':
     resolution: {integrity: sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.10.1':
     resolution: {integrity: sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.10.1':
     resolution: {integrity: sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==}
@@ -2420,28 +2405,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -4112,6 +4093,11 @@ snapshots:
     dependencies:
       '@shikijs/types': 4.4.3
       '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs-precompiled@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+      oniguruma-to-es: 4.3.6
 
   '@shikijs/langs@4.4.3':
     dependencies:

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{HashMap, VecDeque},
     path::{Component, Path, PathBuf},
-    sync::Mutex,
+    sync::{Arc, Mutex},
 };
 
 use git2::{
@@ -56,7 +56,7 @@ pub struct RebaseState {
 }
 
 pub struct Libgit2Backend {
-    repos: Mutex<HashMap<RepoId, Mutex<Repository>>>,
+    repos: Mutex<HashMap<RepoId, Arc<Mutex<Repository>>>>,
     rebases: Mutex<HashMap<RepoId, RebaseState>>,
     /// Serializes the guard → write → cleanup window in `init` to prevent two
     /// concurrent calls on the same path from interfering. Without this lock, call
@@ -74,18 +74,31 @@ impl Libgit2Backend {
         }
     }
 
-    fn with_repo<F, T>(&self, repo_id: &RepoId, f: F) -> AppResult<T>
-    where
-        F: FnOnce(&Repository) -> AppResult<T>,
-    {
+    /// Clone the repo's own `Arc<Mutex<_>>` out of the map and RELEASE the map
+    /// lock before running `f`. The map guard used to stay alive for the whole
+    /// operation, so every git op in the process — any repository, any window —
+    /// serialized on one mutex: a 500-commit log walk in one tab blocked a
+    /// status refresh in another, and `refreshAll`'s parallel commands ran
+    /// strictly one after another. Same-repo ops still serialize on the inner
+    /// mutex (`git2::Repository` is Send but not Sync — that part is
+    /// load-bearing, e.g. the stash TOCTOU note relies on it); different repos
+    /// now genuinely run in parallel.
+    fn repo_cell(&self, repo_id: &RepoId) -> AppResult<Arc<Mutex<Repository>>> {
         let map = self
             .repos
             .lock()
             .map_err(|e| AppError::Internal(e.to_string()))?;
-        let repo_cell = map
-            .get(repo_id)
-            .ok_or_else(|| AppError::UnknownRepo(repo_id.0.clone()))?;
-        let repo = repo_cell
+        map.get(repo_id)
+            .cloned()
+            .ok_or_else(|| AppError::UnknownRepo(repo_id.0.clone()))
+    }
+
+    fn with_repo<F, T>(&self, repo_id: &RepoId, f: F) -> AppResult<T>
+    where
+        F: FnOnce(&Repository) -> AppResult<T>,
+    {
+        let cell = self.repo_cell(repo_id)?;
+        let repo = cell
             .lock()
             .map_err(|e| AppError::Internal(e.to_string()))?;
         f(&repo)
@@ -95,14 +108,8 @@ impl Libgit2Backend {
     where
         F: FnOnce(&mut Repository) -> AppResult<T>,
     {
-        let map = self
-            .repos
-            .lock()
-            .map_err(|e| AppError::Internal(e.to_string()))?;
-        let repo_cell = map
-            .get(repo_id)
-            .ok_or_else(|| AppError::UnknownRepo(repo_id.0.clone()))?;
-        let mut repo = repo_cell
+        let cell = self.repo_cell(repo_id)?;
+        let mut repo = cell
             .lock()
             .map_err(|e| AppError::Internal(e.to_string()))?;
         f(&mut repo)
@@ -1060,6 +1067,13 @@ fn map_status_flag(s: Status, side: StatusSide) -> StatusFlag {
 fn worktree_index_diff_opts(path: &Path, context_lines: u32) -> DiffOptions {
     let mut opts = DiffOptions::new();
     opts.pathspec(path);
+    // The pathspec is one concrete file from the status listing, never a glob.
+    // Without this flag libgit2 treats the pathspec as a POST-filter: the diff
+    // still readdirs and lstats the whole worktree (and descends every
+    // untracked directory, given the untracked family below) only to throw all
+    // but one file away. With it, the iterators prune to the path — and a file
+    // literally named `*.rs` stops glob-matching its siblings.
+    opts.disable_pathspec_match(true);
     opts.context_lines(context_lines);
     opts.include_untracked(true)
         .recurse_untracked_dirs(true)
@@ -1561,7 +1575,12 @@ fn side_line_stats(
         .include_untracked(true)
         .recurse_untracked_dirs(true)
         .show_untracked_content(true)
-        .include_typechange(true);
+        .include_typechange(true)
+        // Refresh the index's stat cache while walking, exactly as `git status`
+        // does: a file whose stat data went stale (checkout, clock, touch) gets
+        // re-hashed ONCE here instead of on every later status/diff. This runs
+        // after every stage/unstage/discard, so the difference compounds.
+        .update_index(true);
     let unstaged = repo.diff_index_to_workdir(None, Some(&mut unstaged_opts))?;
 
     Ok((diff_line_stats(&staged)?, diff_line_stats(&unstaged)?))
@@ -1574,6 +1593,9 @@ fn side_line_stats(
 fn diff_to_file_diffs(diff: &git2::Diff) -> AppResult<Vec<FileDiff>> {
     let num_deltas = diff.deltas().len();
     let mut out: Vec<FileDiff> = Vec::with_capacity(num_deltas);
+    // Each delta's new-file path, kept as a Path for the callback to compare
+    // against without building a String per printed line.
+    let mut paths: Vec<Option<std::path::PathBuf>> = Vec::with_capacity(num_deltas);
 
     for delta_idx in 0..num_deltas {
         let delta = diff.get_delta(delta_idx).expect("valid delta index");
@@ -1594,88 +1616,101 @@ fn diff_to_file_diffs(diff: &git2::Diff) -> AppResult<Vec<FileDiff>> {
         // learns; the callback can only ever turn this true, never back.
         // Without it an untracked PNG came through as N added lines of
         // `from_utf8(...).unwrap_or("")` mojibake instead of "binary file".
-        let mut binary = delta.new_file().is_binary() || delta.old_file().is_binary();
-
-        let mut hunks: Vec<DiffHunk> = Vec::new();
-        let mut current: Option<DiffHunk> = None;
-        let mut additions: u32 = 0;
-        let mut deletions: u32 = 0;
-
-        diff.print(DiffFormat::Patch, |d, hunk, line| {
-            if d.new_file()
-                .path()
-                .map(|p| p.display().to_string())
-                .unwrap_or_default()
-                != new_path
-            {
-                return true;
-            }
-            if d.flags().contains(git2::DiffFlags::BINARY) {
-                binary = true;
-                return true;
-            }
-            if let Some(h) = hunk {
-                if current
-                    .as_ref()
-                    .map(|c| c.old_start != h.old_start() || c.new_start != h.new_start())
-                    .unwrap_or(true)
-                {
-                    if let Some(done) = current.take() {
-                        hunks.push(done);
-                    }
-                    current = Some(DiffHunk {
-                        header: std::str::from_utf8(h.header()).unwrap_or("").to_string(),
-                        old_start: h.old_start(),
-                        old_lines: h.old_lines(),
-                        new_start: h.new_start(),
-                        new_lines: h.new_lines(),
-                        lines: Vec::new(),
-                    });
-                }
-            }
-            let kind = match line.origin() {
-                '+' => {
-                    additions += 1;
-                    DiffLineKind::Addition
-                }
-                '-' => {
-                    deletions += 1;
-                    DiffLineKind::Deletion
-                }
-                'H' | 'F' => DiffLineKind::HunkHeader,
-                _ => DiffLineKind::Context,
-            };
-            if let Some(h) = current.as_mut() {
-                h.lines.push(DiffLine {
-                    kind,
-                    old_lineno: line.old_lineno(),
-                    new_lineno: line.new_lineno(),
-                    content: std::str::from_utf8(line.content())
-                        .unwrap_or("")
-                        .to_string(),
-                });
-            }
-            true
-        })?;
-
-        if let Some(done) = current.take() {
-            hunks.push(done);
-        }
-
-        let mut file_diff = FileDiff {
+        let binary = delta.new_file().is_binary() || delta.old_file().is_binary();
+        paths.push(delta.new_file().path().map(|p| p.to_path_buf()));
+        out.push(FileDiff {
             path: new_path,
             old_path: old_path_opt,
             binary,
-            additions,
-            deletions,
-            hunks,
+            additions: 0,
+            deletions: 0,
+            hunks: Vec::new(),
             lfs: None,
+        });
+    }
+
+    // ONE print pass for the whole diff. `git_diff_print` generates each
+    // delta's patch — full blob load + xdiff — as it goes, so printing inside a
+    // per-delta loop and filtering by path (the previous shape) generated every
+    // file's patch once per file: O(deltas²) blob loads for a commit diff.
+    // Deltas are printed in order, so the callback tracks which delta it is in
+    // and appends to that entry.
+    let mut idx: usize = 0;
+    let mut current: Option<DiffHunk> = None;
+    diff.print(DiffFormat::Patch, |d, hunk, line| {
+        let d_path = d.new_file().path();
+        if paths.get(idx).map(|p| p.as_deref()) != Some(d_path) {
+            // A new delta begins: flush the previous one's open hunk, then
+            // advance to the entry this callback belongs to (a delta that
+            // printed nothing is skipped over here).
+            if let Some(done) = current.take() {
+                out[idx].hunks.push(done);
+            }
+            while idx < out.len() && paths[idx].as_deref() != d_path {
+                idx += 1;
+            }
+            if idx >= out.len() {
+                return true; // not a known delta; nothing to record it against
+            }
+        }
+        if d.flags().contains(git2::DiffFlags::BINARY) {
+            out[idx].binary = true;
+            return true;
+        }
+        if let Some(h) = hunk {
+            if current
+                .as_ref()
+                .map(|c| c.old_start != h.old_start() || c.new_start != h.new_start())
+                .unwrap_or(true)
+            {
+                if let Some(done) = current.take() {
+                    out[idx].hunks.push(done);
+                }
+                current = Some(DiffHunk {
+                    header: std::str::from_utf8(h.header()).unwrap_or("").to_string(),
+                    old_start: h.old_start(),
+                    old_lines: h.old_lines(),
+                    new_start: h.new_start(),
+                    new_lines: h.new_lines(),
+                    lines: Vec::new(),
+                });
+            }
+        }
+        let kind = match line.origin() {
+            '+' => {
+                out[idx].additions += 1;
+                DiffLineKind::Addition
+            }
+            '-' => {
+                out[idx].deletions += 1;
+                DiffLineKind::Deletion
+            }
+            'H' | 'F' => DiffLineKind::HunkHeader,
+            _ => DiffLineKind::Context,
         };
+        if let Some(h) = current.as_mut() {
+            h.lines.push(DiffLine {
+                kind,
+                old_lineno: line.old_lineno(),
+                new_lineno: line.new_lineno(),
+                content: std::str::from_utf8(line.content())
+                    .unwrap_or("")
+                    .to_string(),
+            });
+        }
+        true
+    })?;
+    if idx < out.len() {
+        if let Some(done) = current.take() {
+            out[idx].hunks.push(done);
+        }
+    }
+
+    for file_diff in &mut out {
         // Derived from the diff just built — no extra I/O (#93). Both commit-diff
         // paths come through here, so they cannot disagree with `diff()` about what
         // an LFS pointer diff is.
-        crate::git::lfs::annotate(&mut file_diff);
-        out.push(file_diff);
+        crate::git::lfs::annotate(file_diff);
     }
 
     Ok(out)
@@ -1840,9 +1875,13 @@ fn push_log_start(
             for glob in ["refs/heads/*", "refs/remotes/*/*"] {
                 if let Ok(refs) = repo.references_glob(glob) {
                     for r in refs.flatten() {
-                        // A remote's symbolic HEAD (refs/remotes/origin/HEAD)
-                        // peels to a tip already pushed — dedup handles it.
-                        if let Ok(commit) = r.peel_to_commit() {
+                        // A head's or remote head's target IS the commit oid —
+                        // no peel (an object read per ref, per page) needed.
+                        if let Some(oid) = r.target() {
+                            push(oid, walk)?;
+                        } else if let Ok(commit) = r.peel_to_commit() {
+                            // A remote's symbolic HEAD (refs/remotes/origin/HEAD)
+                            // peels to a tip already pushed — dedup handles it.
                             push(commit.id(), walk)?;
                         }
                     }
@@ -1918,7 +1957,12 @@ impl FrontierBuilder {
                 continue;
             }
             // Absent in a shallow/grafted clone → not a resumable point.
-            if repo.find_commit(p).is_ok() {
+            // odb.exists is an index probe; find_commit parsed the object.
+            let exists = repo
+                .odb()
+                .map(|odb| odb.exists(p))
+                .unwrap_or_else(|_| repo.find_commit(p).is_ok());
+            if exists {
                 out.push(p.to_string());
             }
         }
@@ -1961,23 +2005,36 @@ fn push_page_start(
 }
 
 /// Map git2's per-ref lookup by target OID. Scans once per log call.
-fn collect_ref_map(repo: &Repository) -> Vec<(git2::Oid, String)> {
-    let mut out = Vec::new();
+fn collect_ref_map(repo: &Repository) -> HashMap<git2::Oid, Vec<String>> {
+    // A map, not a list: every log walk decorates each of its rows from this,
+    // and a linear scan per row was O(refs x rows) with a clone per hit.
+    let mut out: HashMap<git2::Oid, Vec<String>> = HashMap::new();
     if let Ok(refs) = repo.references() {
         for r in refs.flatten() {
             let name = match r.shorthand() {
                 Some(n) => n.to_string(),
                 None => continue,
             };
-            // Peel annotated tags to the commit they point at.
-            if let Ok(peeled) = r.peel(git2::ObjectType::Commit) {
-                if let Some(c) = peeled.as_commit() {
-                    out.push((c.id(), name));
-                    continue;
+            // Peel annotated tags to the commit they point at. Only TAGS: a
+            // branch or remote ref's target already IS the commit oid, and
+            // peeling costs an object read per ref — thousands, on a repo with
+            // many remote branches, on every page fetch.
+            if r.is_tag() {
+                if let Ok(peeled) = r.peel(git2::ObjectType::Commit) {
+                    if let Some(c) = peeled.as_commit() {
+                        out.entry(c.id()).or_default().push(name);
+                        continue;
+                    }
                 }
             }
             if let Some(oid) = r.target() {
-                out.push((oid, name));
+                out.entry(oid).or_default().push(name);
+            } else if let Ok(peeled) = r.peel(git2::ObjectType::Commit) {
+                // Symbolic refs (origin/HEAD) have no direct target; resolve
+                // them the way the old always-peel did so their pill survives.
+                if let Some(c) = peeled.as_commit() {
+                    out.entry(c.id()).or_default().push(name);
+                }
             }
         }
     }
@@ -2234,7 +2291,7 @@ impl GitBackend for Libgit2Backend {
             .repos
             .lock()
             .map_err(|e| AppError::Internal(e.to_string()))?;
-        map.insert(id.clone(), Mutex::new(repo));
+        map.insert(id.clone(), Arc::new(Mutex::new(repo)));
 
         Ok(RepoHandle {
             id,
@@ -2252,8 +2309,9 @@ impl GitBackend for Libgit2Backend {
             .repos
             .lock()
             .map_err(|e| AppError::Internal(e.to_string()))?;
-        // Dropping the removed Mutex<Repository> here releases libgit2's file
-        // handles. An absent id is success on purpose (see the trait doc).
+        // Dropping the removed Arc<Mutex<Repository>> here releases libgit2's
+        // file handles once any in-flight op's clone finishes. An absent id is
+        // success on purpose (see the trait doc).
         map.remove(repo_id);
         // `rebases` is deliberately left alone: its entries are bytes, not
         // handles, they are keyed by an id a re-open can never mint again, and
@@ -2399,7 +2457,10 @@ impl GitBackend for Libgit2Backend {
             let mut opts = StatusOptions::new();
             opts.include_untracked(true)
                 .recurse_untracked_dirs(true)
-                .include_ignored(false);
+                .include_ignored(false)
+                // Same-result, cheaper next time: refresh the stat cache the
+                // way `git status` itself does (see side_line_stats).
+                .update_index(true);
             let statuses = repo.statuses(Some(&mut opts))?;
             // Read once for the whole listing, not per entry: it only feeds the
             // gitlink-mode shortcut in `listed_entry_is_embedded_repo`, so a repo
@@ -2516,11 +2577,7 @@ impl GitBackend for Libgit2Backend {
             for oid in walk.by_ref().take(limit) {
                 let oid = oid?;
                 let commit = repo.find_commit(oid)?;
-                let refs: Vec<String> = ref_map
-                    .iter()
-                    .filter(|(o, _)| *o == oid)
-                    .map(|(_, name)| name.clone())
-                    .collect();
+                let refs: Vec<String> = ref_map.get(&oid).cloned().unwrap_or_default();
                 let mut info = commit_to_info(&commit);
                 info.refs = refs;
                 frontier.visit(oid, commit.parent_ids());
@@ -2636,9 +2693,11 @@ impl GitBackend for Libgit2Backend {
                 let commit = repo.find_commit(oid)?;
                 frontier.visit(oid, commit.parent_ids());
 
-                // sha prefix — cheap, check first.
+                // sha prefix — cheap, check first. Compared nibble-by-nibble
+                // off the raw bytes: `oid.to_string()` allocated 40 hex chars
+                // for EVERY commit the walk visits, matching or not.
                 if let Some(ref q) = sha_q {
-                    if !oid.to_string().starts_with(q.as_str()) {
+                    if !oid_has_hex_prefix(&oid, q) {
                         continue;
                     }
                 }
@@ -2690,11 +2749,7 @@ impl GitBackend for Libgit2Backend {
                     }
                 }
 
-                let refs: Vec<String> = ref_map
-                    .iter()
-                    .filter(|(o, _)| *o == oid)
-                    .map(|(_, name)| name.clone())
-                    .collect();
+                let refs: Vec<String> = ref_map.get(&oid).cloned().unwrap_or_default();
                 let mut info = commit_to_info(&commit);
                 info.refs = refs;
                 out.push(info);
@@ -2741,11 +2796,7 @@ impl GitBackend for Libgit2Backend {
             for oid in walk {
                 let oid = oid?;
                 let commit = repo.find_commit(oid)?;
-                let refs: Vec<String> = ref_map
-                    .iter()
-                    .filter(|(o, _)| *o == oid)
-                    .map(|(_, name)| name.clone())
-                    .collect();
+                let refs: Vec<String> = ref_map.get(&oid).cloned().unwrap_or_default();
                 let mut info = commit_to_info(&commit);
                 info.refs = refs;
                 out.push(info);
@@ -2782,11 +2833,7 @@ impl GitBackend for Libgit2Backend {
                 }
                 let oid = oid?;
                 let commit = repo.find_commit(oid)?;
-                let refs: Vec<String> = ref_map
-                    .iter()
-                    .filter(|(o, _)| *o == oid)
-                    .map(|(_, name)| name.clone())
-                    .collect();
+                let refs: Vec<String> = ref_map.get(&oid).cloned().unwrap_or_default();
                 let mut info = commit_to_info(&commit);
                 info.refs = refs;
                 out.push(info);
@@ -2829,6 +2876,9 @@ impl GitBackend for Libgit2Backend {
             reject_embedded_repo(repo, path)?;
             let mut opts = DiffOptions::new();
             opts.pathspec(path);
+            // One concrete path — prune the walk to it instead of post-filtering
+            // a whole-worktree diff (see worktree_index_diff_opts).
+            opts.disable_pathspec_match(true);
             opts.context_lines(context_lines);
             opts.ignore_whitespace(ignore_whitespace);
             // Include untracked files as if their full content were a new addition
@@ -2872,12 +2922,14 @@ impl GitBackend for Libgit2Backend {
             let mut hunks: Vec<DiffHunk> = Vec::new();
 
             diff.print(DiffFormat::Patch, |delta, hunk, line| {
-                let new_path = delta
-                    .new_file()
-                    .path()
-                    .map(|p| p.to_string_lossy().to_string());
+                // Paths are read once, on the first callback — building the
+                // String on every printed line allocated twice per line for a
+                // value that never changes within a single-path diff.
                 if current_path.is_none() {
-                    current_path = new_path.clone();
+                    current_path = delta
+                        .new_file()
+                        .path()
+                        .map(|p| p.to_string_lossy().to_string());
                     old_path = delta
                         .old_file()
                         .path()
@@ -2905,17 +2957,15 @@ impl GitBackend for Libgit2Backend {
                 if let Some(h) = hunk {
                     // Compare the stored header (newline-stripped) against the
                     // raw header bytes (also stripped) so lines within the same
-                    // hunk don't create duplicate DiffHunk entries.
-                    let raw_header_trimmed = h
-                        .header()
-                        .iter()
-                        .copied()
-                        .collect::<Vec<u8>>();
-                    let raw_header_trimmed = raw_header_trimmed
+                    // hunk don't create duplicate DiffHunk entries. Trim the
+                    // borrowed bytes in place — collecting them into a fresh
+                    // Vec allocated once per printed line.
+                    let raw = h.header();
+                    let raw_header_trimmed = raw
                         .iter()
                         .rposition(|&b| b != b'\n')
-                        .map(|i| &raw_header_trimmed[..=i])
-                        .unwrap_or(&raw_header_trimmed);
+                        .map(|i| &raw[..=i])
+                        .unwrap_or(raw);
                     let is_new_hunk = hunks
                         .last()
                         .map(|last| last.header.as_bytes() != raw_header_trimmed)
@@ -2987,11 +3037,13 @@ impl GitBackend for Libgit2Backend {
             if abs.is_file() {
                 let bytes = std::fs::read(&abs)?;
                 let size = bytes.len() as u64;
-                return Ok(Some(match std::str::from_utf8(&bytes) {
+                // String::from_utf8 MOVES the buffer on success — from_utf8 +
+                // to_string held two full copies of every opened file.
+                return Ok(Some(match String::from_utf8(bytes) {
                     Ok(s) => FileContent {
                         path: path_str,
                         binary: false,
-                        text: Some(s.to_string()),
+                        text: Some(s),
                         from_head: false,
                         size,
                     },
@@ -3570,6 +3622,7 @@ impl GitBackend for Libgit2Backend {
         let patch_text = self.with_repo(repo_id, |repo| {
             let mut opts = DiffOptions::new();
             opts.pathspec(path);
+            opts.disable_pathspec_match(true);
             opts.context_lines(context_lines);
             let head_tree = match repo.head() {
                 Ok(h) => Some(h.peel_to_tree()?),
@@ -3644,6 +3697,7 @@ impl GitBackend for Libgit2Backend {
         let patch_text = self.with_repo(repo_id, |repo| {
             let mut opts = DiffOptions::new();
             opts.pathspec(path);
+            opts.disable_pathspec_match(true);
             opts.context_lines(context_lines);
             let head_tree = match repo.head() {
                 Ok(h) => Some(h.peel_to_tree()?),
@@ -3802,6 +3856,10 @@ impl GitBackend for Libgit2Backend {
                         Ok(up) => {
                             let up_name = up.name().ok().flatten().map(String::from);
                             let counts = match (branch.get().target(), up.get().target()) {
+                                // In-sync (the common case for most rows) needs
+                                // no graph walk — graph_ahead_behind is a
+                                // merge-base computation per branch per refresh.
+                                (Some(local), Some(remote)) if local == remote => (0, 0),
                                 (Some(local), Some(remote)) => repo
                                     .graph_ahead_behind(local, remote)
                                     .unwrap_or((0, 0)),
@@ -3842,25 +3900,28 @@ impl GitBackend for Libgit2Backend {
                     .unwrap_or("")
                     .trim_start_matches("refs/tags/")
                     .to_string();
-                // Peel annotated tags to the commit.
-                let tip_oid = repo
-                    .find_object(oid, None)
-                    .ok()
+                // Peel annotated tags to the commit. Keep the object around:
+                // `signed` below reads the same tag object, and looking it up
+                // again (the old `find_tag`) was a second ODB read per tag.
+                let obj = repo.find_object(oid, None).ok();
+                let tip_oid = obj
+                    .as_ref()
                     .and_then(|o| o.peel(git2::ObjectType::Commit).ok())
                     .map(|c| c.id())
                     .unwrap_or(oid);
                 // Free: a lightweight tag has no tag object, and an annotated
                 // one already had to be read to peel it. No subprocess — the
                 // VERDICT costs one, which is why verify_tag is separate (#132).
-                let signed = repo
-                    .find_tag(oid)
-                    .ok()
+                let signed = obj
+                    .as_ref()
+                    .and_then(|o| o.as_tag())
                     .and_then(|t| t.message().map(crate::git::tag::has_signature_block))
                     .unwrap_or(false);
+                let oid_str = tip_oid.to_string();
                 out.push(TagInfo {
                     name,
-                    short_oid: tip_oid.to_string()[..7].to_string(),
-                    oid: tip_oid.to_string(),
+                    short_oid: oid_str[..7].to_string(),
+                    oid: oid_str,
                     signed,
                 });
                 true
@@ -3882,10 +3943,12 @@ impl GitBackend for Libgit2Backend {
             })?;
             let out = raw
                 .into_iter()
-                .map(|(index, oid, message)| StashInfo {
+                .map(|(index, oid, message)| {
+                    let oid_str = oid.to_string();
+                    StashInfo {
                     index,
-                    short_oid: oid.to_string()[..7].to_string(),
-                    oid: oid.to_string(),
+                    short_oid: oid_str[..7].to_string(),
+                    oid: oid_str,
                     message,
                     // An unreadable entry is reported as carrying no untracked
                     // side rather than taking the whole list down with it —
@@ -3894,7 +3957,7 @@ impl GitBackend for Libgit2Backend {
                         .find_commit(oid)
                         .map(|c| c.parent_count() > 2)
                         .unwrap_or(false),
-                })
+                }})
                 .collect();
             Ok(out)
         })
@@ -4682,13 +4745,16 @@ impl GitBackend for Libgit2Backend {
             })
         };
 
-        let mut status = match in_memory {
-            Some(status) => status,
-            // No in-memory entry: either there is no rebase, or this process
-            // did not start it (the app was restarted mid-rebase). The state
-            // file is the authority in that case.
-            None => self.with_repo(repo_id, |repo| {
-                Ok(match crate::git::rebase_state::load(repo)? {
+        // ONE repo-lock acquisition for both small file reads (state + summary);
+        // this is polled by every refreshStatus, so a second acquisition was a
+        // second queue-up behind whatever op the repo is busy with.
+        self.with_repo(repo_id, |repo| {
+            let mut status = match in_memory {
+                Some(status) => status,
+                // No in-memory entry: either there is no rebase, or this process
+                // did not start it (the app was restarted mid-rebase). The state
+                // file is the authority in that case.
+                None => match crate::git::rebase_state::load(repo)? {
                     Some(state) => RebaseStatus {
                         in_progress: true,
                         next_index: state.completed,
@@ -4703,17 +4769,16 @@ impl GitBackend for Libgit2Backend {
                         pause_reason: None,
                         last_completed: None,
                     },
-                })
-            })?,
-        };
+                },
+            };
 
-        // The completed-rebase summary outlives the rebase it describes, so it
-        // is read here rather than derived from state that no longer exists.
-        // It is written only on completion and dropped on start/abort/ack, so
-        // it is always absent while `in_progress` is true.
-        status.last_completed =
-            self.with_repo(repo_id, crate::git::rebase_state::load_summary)?;
-        Ok(status)
+            // The completed-rebase summary outlives the rebase it describes, so it
+            // is read here rather than derived from state that no longer exists.
+            // It is written only on completion and dropped on start/abort/ack, so
+            // it is always absent while `in_progress` is true.
+            status.last_completed = crate::git::rebase_state::load_summary(repo)?;
+            Ok(status)
+        })
     }
 
     fn rebase_acknowledge(&self, repo_id: &RepoId) -> AppResult<()> {
@@ -5544,18 +5609,42 @@ fn run_git_capture_env(
 
 /// Build a `CommitInfo` from a git2 commit. The `refs` field is left empty;
 /// callers that need ref labels (e.g. `log`) fill it in separately.
+/// Does `oid`'s lowercase hex spelling start with `prefix`? Allocation-free
+/// equivalent of `oid.to_string().starts_with(prefix)` for an already
+/// lowercased prefix (the filter lowercases its query once, up front).
+fn oid_has_hex_prefix(oid: &git2::Oid, prefix: &str) -> bool {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let bytes = oid.as_bytes();
+    for (i, pc) in prefix.bytes().enumerate() {
+        if i / 2 >= bytes.len() {
+            return false;
+        }
+        let b = bytes[i / 2];
+        let nibble = if i % 2 == 0 { b >> 4 } else { b & 0xf };
+        if pc != HEX[nibble as usize] {
+            return false;
+        }
+    }
+    true
+}
+
 fn commit_to_info(commit: &git2::Commit<'_>) -> CommitInfo {
-    let oid = commit.id();
+    // Runs once per row, 500 rows per page: stringify the oid once and derive
+    // `body` from the borrowed message instead of allocating the whole message
+    // only to slice it.
+    let oid = commit.id().to_string();
+    let short_oid = oid[..7].to_string();
     let summary = commit.summary().unwrap_or("").to_string();
-    let full_message = commit.message().unwrap_or("").to_string();
-    let body = full_message
+    let body = commit
+        .message()
+        .unwrap_or("")
         .split_once("\n\n")
         .map(|(_, rest)| rest.trim_end().to_string())
         .filter(|s| !s.is_empty());
     let author = commit.author();
     CommitInfo {
-        oid: oid.to_string(),
-        short_oid: oid.to_string()[..7].to_string(),
+        oid,
+        short_oid,
         summary,
         body,
         author: author.name().unwrap_or("").to_string(),
@@ -5646,6 +5735,36 @@ fn commit_touches_path(
     let commit_tree = commit.tree()?;
     if commit.parent_count() == 0 {
         return Ok(commit_tree.get_path(path).is_ok());
+    }
+    // Fast path for a literal path (no pathspec magic — which is what
+    // file_history always passes, and what the History path filter usually
+    // holds): look the entry up in each tree and compare (oid, filemode).
+    // Exactly equivalent to the diff for a concrete file or directory — a
+    // directory's tree oid differs iff anything beneath it differs, and a
+    // filemode-only change differs in the mode — but with no per-parent
+    // whole-tree diff, which made file_history O(commits × tree size).
+    // A trailing slash also takes the slow path: the pathspec's leading-dir
+    // rule accepts "src/", tree lookup spells it "src".
+    let literal = path
+        .to_str()
+        .map(|s| !s.contains(['*', '?', '[', '\\']) && !s.ends_with('/'))
+        .unwrap_or(false);
+    if literal {
+        let ours = commit_tree
+            .get_path(path)
+            .ok()
+            .map(|e| (e.id(), e.filemode()));
+        for i in 0..commit.parent_count() {
+            let parent_tree = commit.parent(i)?.tree()?;
+            let theirs = parent_tree
+                .get_path(path)
+                .ok()
+                .map(|e| (e.id(), e.filemode()));
+            if ours != theirs {
+                return Ok(true);
+            }
+        }
+        return Ok(false);
     }
     for i in 0..commit.parent_count() {
         let parent = commit.parent(i)?;

--- a/src-tauri/tests/hunks.rs
+++ b/src-tauri/tests/hunks.rs
@@ -607,3 +607,46 @@ fn discard_lines_refuses_an_untracked_file_with_a_clear_error() {
         "got {err:?}"
     );
 }
+
+#[test]
+fn a_glob_special_filename_diffs_as_a_literal_path() {
+    // The single-path diff ops set disable_pathspec_match: the pathspec names
+    // one concrete file from the status listing, never a glob. This pins the
+    // two things that flag changes: a file literally named like a glob still
+    // resolves to ITSELF (fnmatch would have let `*.txt` match siblings), and
+    // an untracked file still produces its creation diff (the untracked family
+    // in worktree_index_diff_opts keeps working with the pruned walk).
+    let tr = TempRepo::fresh();
+    write_file(tr.path(), "*.txt", "star\n");
+    write_file(tr.path(), "other.txt", "other\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let diff = backend
+        .diff(
+            &handle.id,
+            &PathBuf::from("*.txt"),
+            platypusgit_lib::git::types::DiffKind::WorktreeToHead,
+            3,
+            false,
+        )
+        .expect("diff of a glob-special literal filename");
+
+    assert_eq!(diff.path, "*.txt");
+    assert_eq!(diff.additions, 1, "only the file itself, not glob matches");
+    let lines: Vec<_> = diff
+        .hunks
+        .iter()
+        .flat_map(|h| h.lines.iter())
+        .map(|l| l.content.trim_end().to_string())
+        .collect();
+    assert!(lines.contains(&"star".to_string()), "got {lines:?}");
+    assert!(
+        !lines.contains(&"other".to_string()),
+        "the pathspec must not fnmatch other.txt: {lines:?}"
+    );
+
+    // And staging by hunk — the worktree_index_diff_opts path — still finds it.
+    backend
+        .stage_hunk(&handle.id, &PathBuf::from("*.txt"), 0, 3)
+        .expect("stage_hunk on the glob-special filename");
+}

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -60,6 +60,7 @@ import { openMergeWindow } from "@/features/merge/openMergeWindow";
 import { UpdateChip } from "@/features/update/UpdateChip";
 import { UpdatePanel } from "@/features/update/UpdatePanel";
 import { useUpdateStore } from "@/features/update/useUpdateStore";
+import { warmSyntax } from "@/lib/syntax";
 import { BranchPicker } from "@/features/branches/BranchPicker";
 import {
   DUBIOUS_OWNERSHIP_HELP,
@@ -238,6 +239,15 @@ export function AppShell() {
       void useUpdateStore.getState().check(false);
     }, 2000);
     return () => clearTimeout(t);
+  }, []);
+
+  // Warm the syntax worker at idle, so the first file the user opens pays only
+  // its own grammar + tokenize rather than worker spawn + Shiki set-up too.
+  // Idle, not launch: highlighting must never compete with first paint.
+  React.useEffect(() => {
+    if (typeof requestIdleCallback !== "function") return;
+    const id = requestIdleCallback(() => warmSyntax());
+    return () => cancelIdleCallback(id);
   }, []);
 
   // The merge resolver window stages resolutions out-of-band; reflect them.
@@ -625,7 +635,6 @@ function AppTitlebar({ onOpenSettings }: { onOpenSettings: () => void }) {
   const activity = useRepoStore((s) => s.activity);
   const refresh = useRepoStore((s) => s.refreshAll);
   const activePath = useTabsStore((s) => s.activePath);
-  const store = useRepoStore();
   const defaultPullMode = useSettingsStore((s) => s.defaultPullMode);
 
   const head = currentBranch(branches);
@@ -646,8 +655,12 @@ function AppTitlebar({ onOpenSettings }: { onOpenSettings: () => void }) {
   };
 
   // Same ops the keymap default runners and palette use (features/repo/ops.ts).
+  // getState(), not a hook: these run inside event handlers, so they need no
+  // subscription — the selector-less `useRepoStore()` that used to sit here
+  // re-rendered the whole titlebar (BranchChip, UpdateChip, picker) on EVERY
+  // store write, including per-page log appends and loading flags.
   const onFetch = () => {
-    store.fetchAll();
+    useRepoStore.getState().fetchAll();
   };
 
   const onPull = () => {
@@ -655,7 +668,7 @@ function AppTitlebar({ onOpenSettings }: { onOpenSettings: () => void }) {
       pgFlash("No upstream configured for current branch");
       return;
     }
-    store.pull(upstream[0], upstream[1], defaultPullMode);
+    useRepoStore.getState().pull(upstream[0], upstream[1], defaultPullMode);
   };
 
   const onPush = () => {
@@ -663,7 +676,7 @@ function AppTitlebar({ onOpenSettings }: { onOpenSettings: () => void }) {
       pgFlash("No upstream configured — run git push -u origin <branch> first");
       return;
     }
-    store.push(upstream[0], upstream[1]);
+    useRepoStore.getState().push(upstream[0], upstream[1]);
   };
 
   return (

--- a/src/design/PGWindowedDiff.tsx
+++ b/src/design/PGWindowedDiff.tsx
@@ -8,6 +8,7 @@
 // navigation and the e2e specs address hunks through — live on each hunk's ANCHOR
 // row, the first changed line, marked as such by flattenDiffRows. The hunk's
 // Stage/Discard cluster is pinned to that same row.
+import React from "react";
 import type { DiffRow } from "@/lib/diffRows";
 import type { WindowRange } from "@/lib/useWindowedList";
 import { PGDiffRow, PGFoldSeparator, PGHunkActions } from "./git-components";
@@ -57,6 +58,26 @@ export function PGWindowedDiff({
   const end = win?.end ?? rows.length;
   const slice = rows.slice(start, end);
 
+  // Stable per-hunk click handlers, so PGDiffRow's React.memo holds: an inline
+  // closure per row would hand every row a fresh prop each render and re-render
+  // the whole window slice for any parent state change. Each wrapper's identity
+  // is permanent (keyed by hunk index) and it reads the LATEST onLineClick
+  // through a ref at call time, so no row ever sees a stale handler.
+  const onLineClickRef = React.useRef(onLineClick);
+  onLineClickRef.current = onLineClick;
+  const hunkClickHandlers = React.useRef(
+    new Map<number, (changedIndex: number, range: boolean) => void>(),
+  );
+  const clickHandlerFor = (hunkIndex: number) => {
+    let h = hunkClickHandlers.current.get(hunkIndex);
+    if (!h) {
+      h = (changedIndex, range) =>
+        onLineClickRef.current?.(hunkIndex, changedIndex, range);
+      hunkClickHandlers.current.set(hunkIndex, h);
+    }
+    return h;
+  };
+
   return (
     <div>
       {win && win.topPad > 0 && (
@@ -96,9 +117,7 @@ export function PGWindowedDiff({
             }
             focused={focusedRow === start + i}
             onLineClick={
-              onLineClick && !disabled
-                ? (changedIndex, range) => onLineClick(row.hunkIndex, changedIndex, range)
-                : undefined
+              onLineClick && !disabled ? clickHandlerFor(row.hunkIndex) : undefined
             }
           />
         );

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -281,13 +281,21 @@ export function PGFileTree({
   onStageToggle,
   window: win,
 }: PGFileTreeProps) {
-  const flat = flattenFileTree(nodes, expanded);
-  const rowStage = flat.map((f) => stageState?.(f.key, f.node));
+  // Memoized: in "all files" mode `nodes` covers the whole worktree, and
+  // re-walking tens of thousands of nodes per render — twice, since the owning
+  // screen usually flattened the same tree for its own keyboard list — is what
+  // made large trees scroll poorly even though only ~40 rows are mounted.
+  const flat = React.useMemo(() => flattenFileTree(nodes, expanded), [nodes, expanded]);
   // Reserve the checkbox column for the whole tree as soon as one row uses it,
   // so a mixed tree (changed + unmodified files) keeps its names aligned.
   // Computed over EVERY row, not the visible slice: deriving it from the
-  // window would make the column appear and disappear while scrolling.
-  const stageSlot = rowStage.some((s) => s !== undefined);
+  // window would make the column appear and disappear while scrolling. Memoized
+  // so the full walk reruns only when the tree or the callback changes — which
+  // needs callers to pass a STABLE stageState (they do; keep it that way).
+  const stageSlot = React.useMemo(
+    () => flat.some((f) => stageState?.(f.key, f.node) !== undefined),
+    [flat, stageState],
+  );
   const range = win ?? { start: 0, end: flat.length, topPad: 0, bottomPad: 0 };
 
   // Keyboard navigation lives with the owning screen, not here: it goes
@@ -305,8 +313,7 @@ export function PGFileTree({
       {range.topPad > 0 && (
         <div data-tree-spacer="top" style={{ height: range.topPad }} />
       )}
-      {flat.slice(range.start, range.end).map((f, sliceIndex) => {
-        const i = range.start + sliceIndex;
+      {flat.slice(range.start, range.end).map((f) => {
         return (
         <PGFileTreeRow
           key={f.key}
@@ -318,7 +325,7 @@ export function PGFileTree({
           }
           status={f.node.status}
           hideStatus={!showStatus}
-          stageState={rowStage[i]}
+          stageState={stageState?.(f.key, f.node)}
           stageSlot={stageSlot}
           onStageToggle={(next) => onStageToggle?.(f.key, f.node, next)}
           expanded={f.isExpanded}
@@ -698,7 +705,34 @@ function DiffText({
  *
  * Exported so the windowed renderer reuses this markup rather than restating it.
  */
-export function PGDiffRow({
+// PGDiffRow's per-kind lookup tables, at module scope: they are constant, and a
+// windowed diff renders dozens of rows per frame — four fresh objects per row
+// per render was pure allocator churn.
+const DIFF_ROW_BG: Partial<Record<DiffLineKind, string>> = {
+  add: "var(--git-added-bg)",
+  rem: "var(--git-removed-bg)",
+  info: "var(--bg-2)",
+};
+const DIFF_ROW_BORDER: Partial<Record<DiffLineKind, string>> = {
+  add: "var(--git-added-gutter)",
+  rem: "var(--git-removed-gutter)",
+};
+const DIFF_ROW_MARKER: Record<DiffLineKind, string> = {
+  add: "+",
+  rem: "−",
+  ctx: " ",
+  info: "i",
+  empty: "",
+};
+const DIFF_ROW_TEXT_COLOR: Record<DiffLineKind, string> = {
+  ctx: "var(--fg-0)",
+  add: "var(--git-added)",
+  rem: "var(--git-removed)",
+  info: "var(--fg-2)",
+  empty: "var(--fg-3)",
+};
+
+export const PGDiffRow = React.memo(function PGDiffRow({
   line,
   selected,
   focused,
@@ -715,29 +749,10 @@ export function PGDiffRow({
   onLineClick?: (changedIndex: number, range: boolean) => void;
 }) {
   const kind = line.kind;
-  const bg: Partial<Record<DiffLineKind, string>> = {
-    add: "var(--git-added-bg)",
-    rem: "var(--git-removed-bg)",
-    info: "var(--bg-2)",
-  };
-  const borderColor: Partial<Record<DiffLineKind, string>> = {
-    add: "var(--git-added-gutter)",
-    rem: "var(--git-removed-gutter)",
-  };
-  const marker: Record<DiffLineKind, string> = {
-    add: "+",
-    rem: "−",
-    ctx: " ",
-    info: "i",
-    empty: "",
-  };
-  const textColor: Record<DiffLineKind, string> = {
-    ctx: "var(--fg-0)",
-    add: "var(--git-added)",
-    rem: "var(--git-removed)",
-    info: "var(--fg-2)",
-    empty: "var(--fg-3)",
-  };
+  const bg = DIFF_ROW_BG;
+  const borderColor = DIFF_ROW_BORDER;
+  const marker = DIFF_ROW_MARKER;
+  const textColor = DIFF_ROW_TEXT_COLOR;
 
   // A separator row keeps its own renderer. `flattenDiffRows` produces no `info`
   // rows — the split view does, through PGSideBySideDiff — so this is the total
@@ -837,7 +852,7 @@ export function PGDiffRow({
           </span>
         </div>
   );
-}
+});
 
 /** Shared button shape for the two hunk-action controls. */
 function hunkActionStyle(disabled: boolean): React.CSSProperties {

--- a/src/design/resizable.test.tsx
+++ b/src/design/resizable.test.tsx
@@ -133,27 +133,39 @@ describe("usePaneSize", () => {
     expect(paneSize(getByTestId("pane"))).toBe("180px");
   });
 
-  it("persists a dragged size", () => {
+  it("persists a dragged size — debounced, and flushed by unmount", () => {
     restore = stubContainerSize({ width: 1600 });
     const { getByTestId, unmount } = render(<Split />);
     drag(getByTestId("handle"), 100);
-    expect(localStorage.getItem(KEY)).toBe("400");
-    unmount();
+    // Deliberately NOT on disk yet: the write is debounced off the drag, so a
+    // mousemove never pays a synchronous localStorage.setItem.
+    expect(localStorage.getItem(KEY)).toBeNull();
+    unmount(); // a pending write is flushed rather than lost
 
+    expect(localStorage.getItem(KEY)).toBe("400");
     const again = render(<Split />);
     expect(paneSize(again.getByTestId("pane"))).toBe("400px");
   });
 
   it("resets to the initial size on a double-click of the handle", () => {
-    restore = stubContainerSize({ width: 1600 });
-    const { getByTestId } = render(<Split />);
-    drag(getByTestId("handle"), 200);
-    expect(paneSize(getByTestId("pane"))).toBe("500px");
+    vi.useFakeTimers();
+    try {
+      restore = stubContainerSize({ width: 1600 });
+      const { getByTestId } = render(<Split />);
+      drag(getByTestId("handle"), 200);
+      expect(paneSize(getByTestId("pane"))).toBe("500px");
 
-    fireEvent.doubleClick(getByTestId("handle"));
+      fireEvent.doubleClick(getByTestId("handle"));
 
-    expect(paneSize(getByTestId("pane"))).toBe("300px");
-    expect(localStorage.getItem(KEY)).toBe("300");
+      expect(paneSize(getByTestId("pane"))).toBe("300px");
+      // The trailing debounce write lands once the drag settles.
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(localStorage.getItem(KEY)).toBe("300");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("reads the axis it was told, not always the width", () => {

--- a/src/design/resizable.tsx
+++ b/src/design/resizable.tsx
@@ -196,14 +196,43 @@ export function usePaneSize(
     }
   });
 
+  // Debounced: `preferred` changes on every mousemove of a drag, and
+  // localStorage.setItem is a synchronous disk write — per-move persistence
+  // stuttered the drag itself. Trailing write only: the last timer fires after
+  // the drag settles, and unmount flushes whatever is still pending. The timer
+  // reads the latest value through a ref so rescheduling never has to flush.
+  const persistTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latest = React.useRef({ storageKey, preferred });
+  latest.current = { storageKey, preferred };
   React.useEffect(() => {
     if (!storageKey) return;
-    try {
-      localStorage.setItem(storageKey, String(Math.round(preferred)));
-    } catch {
-      // quota errors are non-fatal
-    }
+    if (persistTimer.current) clearTimeout(persistTimer.current);
+    persistTimer.current = setTimeout(() => {
+      persistTimer.current = null;
+      try {
+        localStorage.setItem(storageKey, String(Math.round(latest.current.preferred)));
+      } catch {
+        // quota errors are non-fatal
+      }
+    }, 250);
   }, [preferred, storageKey]);
+  React.useEffect(
+    () => () => {
+      // Unmount with a write still pending: flush it rather than lose it.
+      if (persistTimer.current) {
+        clearTimeout(persistTimer.current);
+        persistTimer.current = null;
+        const { storageKey: k, preferred: w } = latest.current;
+        if (!k) return;
+        try {
+          localStorage.setItem(k, String(Math.round(w)));
+        } catch {
+          // quota errors are non-fatal
+        }
+      }
+    },
+    [],
+  );
 
   const size = clampPaneSize(preferred, clamp);
 

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -8,7 +8,7 @@ import {
   type DiffLineData,
 } from "@/design";
 import { useElementSize } from "@/lib/useElementSize";
-import { DiffMinimap } from "./DiffMinimap";
+import { MinimapGutter } from "./DiffMinimap";
 import { PGPane, FocusableScroll, usePaneList, useHunkNav } from "@/features/keymap";
 import { fileIconSpec } from "@/lib/fileIcon";
 import { WhitespaceToggle } from "./WhitespaceToggle";
@@ -19,8 +19,8 @@ import {
   flattenDiffRows,
   hunkAnchorRows,
   scrollTopForRow,
-  windowVariable,
 } from "@/lib/diffRows";
+import { useVariableWindow } from "@/lib/useVariableWindow";
 import { useViewportH } from "@/lib/useViewportH";
 import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
 import { buildLineSpans } from "@/lib/lineSpans";
@@ -36,9 +36,19 @@ import { LfsDiffNotice } from "@/features/lfs/LfsDiffNotice";
  * (via the shared pairing rule) and resolves each row's syntax from the correct
  * side, so this only has to render.
  */
-function CommitDiffRowText({ line }: { line: DiffLineData }) {
+const CommitDiffRowText = React.memo(function CommitDiffRowText({
+  line,
+}: {
+  line: DiffLineData;
+}) {
   const text = line.text ?? "";
-  const rendered = buildLineSpans(text, line.syntax ?? null, line.spans);
+  // Memoized (and the component memo'd on the row's stable identity): this
+  // panel renders a window of rows per frame and the span tiling is the only
+  // non-trivial work per row.
+  const rendered = React.useMemo(
+    () => buildLineSpans(text, line.syntax ?? null, line.spans),
+    [text, line.syntax, line.spans],
+  );
   if (rendered.length === 0) return <>{text}</>;
   if (rendered.length === 1 && !rendered[0].cls && !rendered[0].changed) {
     return <>{text}</>;
@@ -61,7 +71,7 @@ function CommitDiffRowText({ line }: { line: DiffLineData }) {
       ))}
     </>
   );
-}
+});
 
 export interface CommitDiffPanelProps {
   diffs: FileDiff[];
@@ -191,17 +201,17 @@ export function CommitDiffPanel({
   );
   const heights = React.useMemo(() => rows.map((r) => r.h), [rows]);
   const scrollRef = React.useRef<HTMLDivElement>(null);
-  const [scrollTop, setScrollTop] = React.useState(0);
   const { viewportH, remeasure } = useViewportH(scrollRef);
   // Measured on the WRAPPER holding the scroll area and the minimap, so adding
   // the gutter cannot change the width that decides whether to add it (#161).
   // This is the panel that most often falls UNDER the threshold — History's
   // beside layout is ~480px — and it does so by width, not by being this panel.
   const diffBox = useElementSize();
-  const win = React.useMemo(
-    () => windowVariable(heights, { scrollTop, viewportH, overscan: 8 }),
-    [heights, scrollTop, viewportH],
-  );
+  const { win, onScroll: onDiffScroll } = useVariableWindow({
+    heights,
+    viewportH,
+    scrollRef,
+  });
 
   // F7/⇧F7. The cursor lands on each hunk's ANCHOR row — its first changed line —
   // and scrolling goes BY OFFSET, because that row is usually unmounted (#157).
@@ -391,7 +401,7 @@ export function CommitDiffPanel({
           ariaLabel="Diff"
           innerRef={scrollRef}
           onScroll={() => {
-            setScrollTop(scrollRef.current?.scrollTop ?? 0);
+            onDiffScroll();
             remeasure();
           }}
         >
@@ -472,14 +482,12 @@ export function CommitDiffPanel({
             <div data-pg-spacer="bottom" style={{ height: `${win.bottomPad}px` }} />
           )}
         </FocusableScroll>
-        <DiffMinimap
+        <MinimapGutter
           rows={rows}
           heights={heights}
           rowH={rowH}
-          scrollTop={scrollTop}
           viewportH={viewportH}
           scrollRef={scrollRef}
-          onScrollTop={setScrollTop}
           containerWidth={diffBox.width}
           containerHeight={diffBox.height}
         />

--- a/src/features/diff/DiffMinimap.tsx
+++ b/src/features/diff/DiffMinimap.tsx
@@ -179,6 +179,57 @@ export interface DiffMinimapProps {
   testId?: string;
 }
 
+/**
+ * DiffMinimap with the per-pixel scroll tracking held INSIDE the gutter.
+ *
+ * The band must follow every scroll frame, but that is the only thing on a
+ * diff surface that does — the row window moves at most once per row of
+ * scroll (useVariableWindow). So this wrapper subscribes to the scroll
+ * element's own `scroll` event and keeps `scrollTop` as ITS state: per-pixel
+ * scrolling re-renders this small component (a canvas repaint), never the
+ * owning screen. DiffMinimap's controlled API is untouched — a caller that
+ * wants to drive `scrollTop` itself still can.
+ */
+export function MinimapGutter(
+  props: Omit<DiffMinimapProps, "scrollTop" | "onScrollTop">,
+) {
+  const { scrollRef } = props;
+  const [scrollTop, setScrollTop] = React.useState(0);
+  // No dependency array, identity-guarded, listener kept in a ref: a ref's
+  // `.current` is not reactive and the scroll element mounts after this (same
+  // reasoning as useWindowedList's observer binding). The cleanup must NOT be
+  // returned from the no-deps effect — React would run it before every render
+  // and the identity guard's early return would never re-attach.
+  const boundRef = React.useRef<HTMLElement | null>(null);
+  const handlerRef = React.useRef<(() => void) | null>(null);
+  React.useEffect(() => {
+    const el = scrollRef.current;
+    if (el === boundRef.current) return;
+    if (boundRef.current && handlerRef.current) {
+      boundRef.current.removeEventListener("scroll", handlerRef.current);
+    }
+    boundRef.current = el;
+    handlerRef.current = null;
+    if (!el) return;
+    setScrollTop(el.scrollTop);
+    const onScroll = () => setScrollTop(el.scrollTop);
+    handlerRef.current = onScroll;
+    el.addEventListener("scroll", onScroll, { passive: true });
+  });
+  // Unmount-only teardown; the binding effect above cannot own it (see note).
+  React.useEffect(
+    () => () => {
+      if (boundRef.current && handlerRef.current) {
+        boundRef.current.removeEventListener("scroll", handlerRef.current);
+      }
+      boundRef.current = null;
+      handlerRef.current = null;
+    },
+    [],
+  );
+  return <DiffMinimap {...props} scrollTop={scrollTop} onScrollTop={setScrollTop} />;
+}
+
 export function DiffMinimap({
   rows,
   heights,

--- a/src/features/palette/CommandPalette.tsx
+++ b/src/features/palette/CommandPalette.tsx
@@ -101,9 +101,14 @@ export function CommandPalette() {
   // The row shapes come from commands.ts — same builders the pick steps use, so
   // a row kind cannot drift between the root step and a pick step. Only the id
   // namespace differs (root rows have their own frecency keys).
+  // Gated on `open`: this component is always mounted (AppShell), and its
+  // inputs — `commits`, `allFiles` — change on every refresh and page load.
+  // Without the gate, every git op rebuilt one row object + closure per tracked
+  // file and loaded commit, then the scoring memo below sorted them, all for a
+  // palette nobody could see. Closed ⇒ empty; the real list builds on open.
   const candidates = React.useMemo<PaletteItem[]>(
     () =>
-      step.kind !== "root"
+      !open || step.kind !== "root"
         ? []
         : [
             ...buildCommands(),
@@ -126,7 +131,7 @@ export function CommandPalette() {
               onPick: (oid) => setIntent({ kind: "commit-vs-wt", oid }),
             }),
           ],
-    [step.kind, branches, allFiles, commits, setIntent],
+    [open, step.kind, branches, allFiles, commits, setIntent],
   );
 
   // Source list for the active step: root → candidates; pick → step.items.

--- a/src/lib/diffRows.ts
+++ b/src/lib/diffRows.ts
@@ -260,23 +260,35 @@ export interface FlattenDiffOptions {
   expandedGaps?: ReadonlySet<number>;
 }
 
-export function flattenDiffRows(
-  hunks: FileDiff["hunks"],
-  o: FlattenDiffOptions,
-): DiffRow[] {
-  const { rowH, foldH, syntax, text, gaps = "fold", expandedGaps } = o;
+/**
+ * Per-hunk base lines (kind mapping, changedIndex, word spans) and each hunk's
+ * anchor index, cached by the hunks ARRAY's identity.
+ *
+ * None of it depends on syntax, row heights, or gap mode — yet flattenDiffRows
+ * is re-run for every one of those (tokens arriving per side, a gap expanded, a
+ * density change), and the word diff's LCS is by far the most expensive step of
+ * the flatten. One diff object is flattened several times over its life; its
+ * hunks array never changes identity, so this computes the invariant part once.
+ * Weak, so a superseded diff's lines go with it.
+ */
+const baseLinesCache = new WeakMap<
+  FileDiff["hunks"],
+  { lines: DiffLineData[]; anchor: number }[]
+>();
 
-  const hunkRows = (h: FileDiff["hunks"][number], hunkIndex: number): DiffRow[] => {
+function baseHunkLines(
+  hunks: FileDiff["hunks"],
+): { lines: DiffLineData[]; anchor: number }[] {
+  const hit = baseLinesCache.get(hunks);
+  if (hit) return hit;
+  const computed = hunks.map((h) => {
     // Header lines are dropped BEFORE the numbering pass, which cannot renumber
     // anything: withChangedIndices counts `+`/`-` only and a header is neither.
     // Asserted in diffRows.test.ts rather than assumed — changedIndex is the one
     // index the line-staging ops accept.
     // Then changedIndex, over the whole hunk, before anything slices rows.
     const lines = withWordSpans(
-      withSyntax(
-        withChangedIndices(h.lines.filter(isFileContent).map(toUiLine)),
-        syntax,
-      ),
+      withChangedIndices(h.lines.filter(isFileContent).map(toUiLine)),
     );
     // The hunk's anchor is its first CHANGED row — F7 means "go to the next
     // change", and the Stage/Discard cluster belongs at the change block's top.
@@ -285,6 +297,25 @@ export function flattenDiffRows(
     // unconditionally, or F7 and the actions lose a reachable host.
     let anchor = lines.findIndex((l) => l.kind === "add" || l.kind === "rem");
     if (anchor < 0 && lines.length > 0) anchor = 0;
+    return { lines, anchor };
+  });
+  baseLinesCache.set(hunks, computed);
+  return computed;
+}
+
+export function flattenDiffRows(
+  hunks: FileDiff["hunks"],
+  o: FlattenDiffOptions,
+): DiffRow[] {
+  const { rowH, foldH, syntax, text, gaps = "fold", expandedGaps } = o;
+
+  const base = baseHunkLines(hunks);
+  const hunkRows = (_h: FileDiff["hunks"][number], hunkIndex: number): DiffRow[] => {
+    const { lines: baseLines, anchor } = base[hunkIndex];
+    // Syntax is the one per-flatten input, applied over the cached base. Safe to
+    // attach AFTER the word spans: withSyntax spreads each line it touches, so
+    // spans and changedIndex ride along untouched.
+    const lines = withSyntax(baseLines, syntax);
     return lines.map((line, i) => ({
       kind: "line" as const,
       hunkIndex,

--- a/src/lib/lineSpans.ts
+++ b/src/lib/lineSpans.ts
@@ -17,6 +17,39 @@ export interface RenderSpan {
   changed: boolean;
 }
 
+interface Range {
+  start: number;
+  end: number;
+}
+
+/** Ranges sorted by start, clamped into [0, len]; zero-width ones dropped. */
+function normalized<T extends Range>(
+  ranges: readonly T[] | undefined | null,
+  len: number,
+): readonly T[] {
+  if (!ranges || ranges.length === 0) return [];
+  // Fast path: both producers (Shiki tokens, wordDiff tilings) already emit
+  // in-bounds, sorted, non-empty ranges — return the array as-is, no copies.
+  let clean = true;
+  let prev = 0;
+  for (const r of ranges) {
+    if (r.start < prev || r.end <= r.start || r.start < 0 || r.end > len) {
+      clean = false;
+      break;
+    }
+    prev = r.start;
+  }
+  if (clean) return ranges;
+  const out: T[] = [];
+  for (const r of ranges) {
+    const start = Math.max(0, Math.min(len, r.start));
+    const end = Math.max(0, Math.min(len, r.end));
+    if (end > start) out.push({ ...r, start, end });
+  }
+  out.sort((a, b) => a.start - b.start);
+  return out;
+}
+
 export function buildLineSpans(
   text: string,
   syntax: SyntaxToken[] | null,
@@ -25,29 +58,39 @@ export function buildLineSpans(
   const len = text.length;
   if (len === 0) return [];
 
-  // Boundaries: line ends plus every edge of either input, clamped in range.
+  // Both inputs arrive sorted and non-overlapping (Shiki emits tokens in
+  // order; wordDiff emits a tiling), so a single merge walk resolves each
+  // segment — but sortedness is re-established here rather than assumed, since
+  // this is a public helper and a `.find` scan per segment was the alternative.
+  const syn = normalized(syntax, len);
+  const wrd = normalized(words, len);
+
+  // Boundaries: line ends plus every edge of either input.
   const cuts = new Set<number>([0, len]);
-  const clamp = (n: number) => Math.max(0, Math.min(len, n));
-  for (const t of syntax ?? []) {
-    cuts.add(clamp(t.start));
-    cuts.add(clamp(t.end));
+  for (const t of syn) {
+    cuts.add(t.start);
+    cuts.add(t.end);
   }
-  for (const w of words ?? []) {
-    cuts.add(clamp(w.start));
-    cuts.add(clamp(w.end));
+  for (const w of wrd) {
+    cuts.add(w.start);
+    cuts.add(w.end);
   }
   const edges = [...cuts].sort((a, b) => a - b);
 
   const out: RenderSpan[] = [];
+  let si = 0;
+  let wi = 0;
   for (let i = 0; i + 1 < edges.length; i++) {
     const start = edges[i];
     const end = edges[i + 1];
-    if (end <= start) continue; // duplicate edges collapse; never emit zero width
     // A segment lies wholly inside or wholly outside each input range, because
-    // every range edge is a cut, so testing the midpoint is exact.
+    // every range edge is a cut, so testing the midpoint is exact. The walk
+    // advances two cursors instead of scanning each list per segment.
     const mid = (start + end) / 2;
-    const tok = (syntax ?? []).find((t) => t.start <= mid && mid < t.end);
-    const w = (words ?? []).find((s) => s.start <= mid && mid < s.end);
+    while (si < syn.length && syn[si].end <= mid) si++;
+    while (wi < wrd.length && wrd[wi].end <= mid) wi++;
+    const tok = si < syn.length && syn[si].start <= mid ? syn[si] : undefined;
+    const w = wi < wrd.length && wrd[wi].start <= mid ? wrd[wi] : undefined;
     out.push({ start, end, cls: tok?.cls, changed: w?.changed ?? false });
   }
   return out;

--- a/src/lib/syntax/index.ts
+++ b/src/lib/syntax/index.ts
@@ -1,4 +1,10 @@
-export { tokenizeFile, type SyntaxLine, type SyntaxToken } from "./tokenize";
+export {
+  tokenizeFile,
+  peekTokens,
+  warmSyntax,
+  type SyntaxLine,
+  type SyntaxToken,
+} from "./tokenize";
 export { useSyntax } from "./useSyntax";
 export {
   useDiffSyntax,

--- a/src/lib/syntax/langs.ts
+++ b/src/lib/syntax/langs.ts
@@ -1,9 +1,17 @@
 // Path → Shiki language, plus the grammar loaders.
 //
 // LANG_LOADERS is an EXPLICIT map of static import() calls, not
-// `import(`shiki/langs/${lang}.mjs`)`. A template-literal specifier is not
+// `import(`…/${lang}.mjs`)`. A template-literal specifier is not
 // statically analysable, so Vite can neither resolve nor code-split it; written
 // out, each grammar becomes its own lazily-fetched chunk.
+//
+// The grammars come from @shikijs/langs-precompiled, paired with
+// createJavaScriptRawEngine in shiki.ts: the regexes are already translated to
+// native JS RegExp at package build time, so loading a grammar skips the
+// oniguruma-to-es translation the plain JS engine runs per pattern — the
+// dominant cost of the first highlight in each language — and the translator
+// itself stays out of the bundle. Every language below exists in the
+// precompiled set (verified against @shikijs/langs-precompiled@4.4.3).
 //
 // Ported from the highlight.js table this replaces (src/lib/highlight.ts), with
 // Shiki's language ids: `tsx` and `jsx` are real grammars here rather than
@@ -17,41 +25,41 @@ export type ShikiLang =
   | "ini" | "diff" | "perl" | "r" | "objective-c";
 
 export const LANG_LOADERS: Record<ShikiLang, () => Promise<unknown>> = {
-  typescript: () => import("shiki/langs/typescript.mjs"),
-  tsx: () => import("shiki/langs/tsx.mjs"),
-  javascript: () => import("shiki/langs/javascript.mjs"),
-  jsx: () => import("shiki/langs/jsx.mjs"),
-  rust: () => import("shiki/langs/rust.mjs"),
-  python: () => import("shiki/langs/python.mjs"),
-  go: () => import("shiki/langs/go.mjs"),
-  java: () => import("shiki/langs/java.mjs"),
-  kotlin: () => import("shiki/langs/kotlin.mjs"),
-  swift: () => import("shiki/langs/swift.mjs"),
-  c: () => import("shiki/langs/c.mjs"),
-  cpp: () => import("shiki/langs/cpp.mjs"),
-  csharp: () => import("shiki/langs/csharp.mjs"),
-  ruby: () => import("shiki/langs/ruby.mjs"),
-  php: () => import("shiki/langs/php.mjs"),
-  lua: () => import("shiki/langs/lua.mjs"),
-  sql: () => import("shiki/langs/sql.mjs"),
-  shellscript: () => import("shiki/langs/shellscript.mjs"),
-  json: () => import("shiki/langs/json.mjs"),
-  yaml: () => import("shiki/langs/yaml.mjs"),
-  toml: () => import("shiki/langs/toml.mjs"),
-  xml: () => import("shiki/langs/xml.mjs"),
-  html: () => import("shiki/langs/html.mjs"),
-  css: () => import("shiki/langs/css.mjs"),
-  scss: () => import("shiki/langs/scss.mjs"),
-  less: () => import("shiki/langs/less.mjs"),
-  markdown: () => import("shiki/langs/markdown.mjs"),
-  docker: () => import("shiki/langs/docker.mjs"),
-  make: () => import("shiki/langs/make.mjs"),
-  graphql: () => import("shiki/langs/graphql.mjs"),
-  ini: () => import("shiki/langs/ini.mjs"),
-  diff: () => import("shiki/langs/diff.mjs"),
-  perl: () => import("shiki/langs/perl.mjs"),
-  r: () => import("shiki/langs/r.mjs"),
-  "objective-c": () => import("shiki/langs/objective-c.mjs"),
+  typescript: () => import("@shikijs/langs-precompiled/typescript"),
+  tsx: () => import("@shikijs/langs-precompiled/tsx"),
+  javascript: () => import("@shikijs/langs-precompiled/javascript"),
+  jsx: () => import("@shikijs/langs-precompiled/jsx"),
+  rust: () => import("@shikijs/langs-precompiled/rust"),
+  python: () => import("@shikijs/langs-precompiled/python"),
+  go: () => import("@shikijs/langs-precompiled/go"),
+  java: () => import("@shikijs/langs-precompiled/java"),
+  kotlin: () => import("@shikijs/langs-precompiled/kotlin"),
+  swift: () => import("@shikijs/langs-precompiled/swift"),
+  c: () => import("@shikijs/langs-precompiled/c"),
+  cpp: () => import("@shikijs/langs-precompiled/cpp"),
+  csharp: () => import("@shikijs/langs-precompiled/csharp"),
+  ruby: () => import("@shikijs/langs-precompiled/ruby"),
+  php: () => import("@shikijs/langs-precompiled/php"),
+  lua: () => import("@shikijs/langs-precompiled/lua"),
+  sql: () => import("@shikijs/langs-precompiled/sql"),
+  shellscript: () => import("@shikijs/langs-precompiled/shellscript"),
+  json: () => import("@shikijs/langs-precompiled/json"),
+  yaml: () => import("@shikijs/langs-precompiled/yaml"),
+  toml: () => import("@shikijs/langs-precompiled/toml"),
+  xml: () => import("@shikijs/langs-precompiled/xml"),
+  html: () => import("@shikijs/langs-precompiled/html"),
+  css: () => import("@shikijs/langs-precompiled/css"),
+  scss: () => import("@shikijs/langs-precompiled/scss"),
+  less: () => import("@shikijs/langs-precompiled/less"),
+  markdown: () => import("@shikijs/langs-precompiled/markdown"),
+  docker: () => import("@shikijs/langs-precompiled/docker"),
+  make: () => import("@shikijs/langs-precompiled/make"),
+  graphql: () => import("@shikijs/langs-precompiled/graphql"),
+  ini: () => import("@shikijs/langs-precompiled/ini"),
+  diff: () => import("@shikijs/langs-precompiled/diff"),
+  perl: () => import("@shikijs/langs-precompiled/perl"),
+  r: () => import("@shikijs/langs-precompiled/r"),
+  "objective-c": () => import("@shikijs/langs-precompiled/objective-c"),
 };
 
 const BY_EXT: Record<string, ShikiLang> = {

--- a/src/lib/syntax/shiki.ts
+++ b/src/lib/syntax/shiki.ts
@@ -2,9 +2,15 @@
 // nothing, and shared so grammars register once.
 //
 // engine-javascript rather than the default WASM Oniguruma engine: it avoids
-// shipping and fetching a .wasm asset through the Tauri custom protocol.
+// shipping and fetching a .wasm asset through the Tauri custom protocol. The
+// RAW variant specifically, because every grammar in langs.ts comes from
+// @shikijs/langs-precompiled: the regexes are native JS RegExp already, so the
+// per-pattern oniguruma-to-es translation (and its bundle weight) is skipped
+// entirely. The raw engine only accepts precompiled grammars — a plain
+// shiki/langs grammar must not be loaded through it, which langs.ts guarantees
+// by importing exclusively from the precompiled package.
 import { createHighlighterCore, type HighlighterCore } from "shiki/core";
-import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+import { createJavaScriptRawEngine } from "shiki/engine/javascript";
 import { SENTINEL_THEME } from "./scopes";
 import { LANG_LOADERS, type ShikiLang } from "./langs";
 
@@ -16,7 +22,7 @@ export function getHighlighter(): Promise<HighlighterCore> {
   highlighterPromise ??= createHighlighterCore({
     themes: [SENTINEL_THEME],
     langs: [],
-    engine: createJavaScriptRegexEngine(),
+    engine: createJavaScriptRawEngine(),
   });
   return highlighterPromise;
 }

--- a/src/lib/syntax/tokenize.ts
+++ b/src/lib/syntax/tokenize.ts
@@ -20,7 +20,11 @@ function hash(s: string): string {
   return (h >>> 0).toString(36);
 }
 
-const CACHE_MAX = 24;
+// Tokens are line-relative ranges plus a small class table — a fraction of the
+// source text's own size — so a larger cache is nearly free and every hit skips
+// a full Shiki pass. 64 comfortably covers both sides of a commit's files plus
+// the prefetch warm-up without evicting what the user is looking at.
+const CACHE_MAX = 64;
 const cache = new Map<string, SyntaxLine[]>();
 
 export function clearSyntaxCache(): void {
@@ -35,6 +39,25 @@ function remember(key: string, value: SyntaxLine[]): SyntaxLine[] {
     if (oldest !== undefined) cache.delete(oldest);
   }
   return value;
+}
+
+function cacheKey(path: string, text: string): string | null {
+  const lang = langForPath(path);
+  if (!lang || skipHighlight(path, text)) return null;
+  return `${lang}:${hash(text)}:${text.length}`;
+}
+
+/**
+ * Synchronous cache lookup: the tokens for this exact content, if a previous
+ * call already produced them, else null.
+ *
+ * Lets useSyntax hand cached tokens to the FIRST render of a revisited file
+ * instead of painting plain and re-rendering when the promise resolves — the
+ * async path exists for tokenizing, not for reading a Map.
+ */
+export function peekTokens(path: string, text: string): SyntaxLine[] | null {
+  const key = cacheKey(path, text);
+  return key ? (cache.get(key) ?? null) : null;
 }
 
 // undefined = not tried yet, null = unavailable, so fall back to this thread.
@@ -90,39 +113,70 @@ function getWorker(): Worker | null {
  * Results are cached on THIS thread, so a repeat never crosses the boundary and
  * a re-render never re-tokenizes.
  */
+/**
+ * In-flight requests by cache key, so two callers asking for the same content
+ * (both diff sides of an unmodified file, a prefetch racing the real open, two
+ * surfaces showing one file) share a single tokenize instead of queueing the
+ * identical job on the worker twice.
+ */
+const inFlight = new Map<string, Promise<SyntaxLine[] | null>>();
+
 export async function tokenizeFile(
   path: string,
   text: string,
 ): Promise<SyntaxLine[] | null> {
-  const lang = langForPath(path);
   // Guards run here as well as in the core so an oversized or unknown file costs
   // no worker round trip.
-  if (!lang || skipHighlight(path, text)) return null;
+  const key = cacheKey(path, text);
+  if (!key) return null;
 
-  const key = `${lang}:${hash(text)}:${text.length}`;
   const hit = cache.get(key);
   if (hit) return hit;
+  const running = inFlight.get(key);
+  if (running) return running;
 
+  const job = (async () => {
+    const w = getWorker();
+    let packed: PackedSyntax | null = null;
+    if (w) {
+      const id = nextId++;
+      packed = await new Promise<PackedSyntax | null>((resolve) => {
+        pending.set(id, resolve);
+        w.postMessage({ id, path, text } satisfies TokenizeRequest);
+      });
+    }
+    // Only when there is no worker to ask. Note the asymmetry: `!worker` is true
+    // only after disableWorker ran (or construction failed), so a legitimate null —
+    // unknown grammar, Shiki failure — is NOT retried on the main thread.
+    //
+    // Imported dynamically so Shiki stays out of the main bundle on the normal path.
+    if (!packed && !worker) {
+      const { tokenizeToPacked } = await import("./tokenizeShiki");
+      packed = await tokenizeToPacked(path, text);
+    }
+    if (!packed) return null;
+    return remember(key, unpackLines(packed));
+  })();
+  inFlight.set(key, job);
+  try {
+    return await job;
+  } finally {
+    inFlight.delete(key);
+  }
+}
+
+/**
+ * Spin the tokenize worker up and let it initialize Shiki, at a moment nothing
+ * needs it yet. Idempotent and fire-and-forget: the app shell calls this once
+ * at idle after launch, so the first file the user actually opens pays only its
+ * own grammar load + tokenize instead of worker spawn + engine set-up too.
+ */
+export function warmSyntax(): void {
   const w = getWorker();
-  let packed: PackedSyntax | null = null;
-  if (w) {
-    const id = nextId++;
-    packed = await new Promise<PackedSyntax | null>((resolve) => {
-      pending.set(id, resolve);
-      w.postMessage({ id, path, text } satisfies TokenizeRequest);
-    });
-  }
-  // Only when there is no worker to ask. Note the asymmetry: `!worker` is true
-  // only after disableWorker ran (or construction failed), so a legitimate null —
-  // unknown grammar, Shiki failure — is NOT retried on the main thread.
-  //
-  // Imported dynamically so Shiki stays out of the main bundle on the normal path.
-  if (!packed && !worker) {
-    const { tokenizeToPacked } = await import("./tokenizeShiki");
-    packed = await tokenizeToPacked(path, text);
-  }
-  if (!packed) return null;
-  return remember(key, unpackLines(packed));
+  if (!w) return;
+  const id = nextId++;
+  pending.set(id, () => undefined);
+  w.postMessage({ id, path: "", text: "", warm: true } satisfies TokenizeRequest);
 }
 
 export {

--- a/src/lib/syntax/tokenize.worker.ts
+++ b/src/lib/syntax/tokenize.worker.ts
@@ -10,12 +10,19 @@
 // Shiki is configured with engine-javascript (no WASM asset to fetch through the
 // Tauri custom protocol), so it is pure JS and safe to run here.
 import { tokenizeToPacked } from "./tokenizeShiki";
+import { getHighlighter } from "./shiki";
 import type { PackedSyntax } from "./tokenizeCore";
 
 export interface TokenizeRequest {
   id: number;
   path: string;
   text: string;
+  /**
+   * Initialize the highlighter (Shiki core + the sentinel theme) and reply
+   * null without tokenizing anything. Sent at idle after launch so the first
+   * real request pays only its own grammar + tokenize, not the engine set-up.
+   */
+  warm?: boolean;
 }
 
 export interface TokenizeReply {
@@ -24,7 +31,12 @@ export interface TokenizeReply {
 }
 
 self.onmessage = async (e: MessageEvent<TokenizeRequest>) => {
-  const { id, path, text } = e.data;
+  const { id, path, text, warm } = e.data;
+  if (warm) {
+    await getHighlighter().catch(() => undefined);
+    (self as unknown as Worker).postMessage({ id, packed: null } satisfies TokenizeReply);
+    return;
+  }
   const packed = await tokenizeToPacked(path, text);
   const reply: TokenizeReply = { id, packed };
   // Transfer the buffers rather than copying them across.

--- a/src/lib/syntax/tokenizeCore.ts
+++ b/src/lib/syntax/tokenizeCore.ts
@@ -115,5 +115,12 @@ export function unpackLines(p: PackedSyntax): SyntaxLine[] {
 export function skipHighlight(path: string, text: string): boolean {
   if (!langForPath(path)) return true;
   if (text.length > MAX_HIGHLIGHT_BYTES) return true;
-  return text.split("\n").length > MAX_HIGHLIGHT_LINES;
+  // Count separators instead of split("\n"): the split allocates one string per
+  // line — tens of thousands for exactly the files this guard exists to reject —
+  // and this runs on every tokenize request, twice (main-thread guard + core).
+  let lines = 1;
+  for (let at = text.indexOf("\n"); at !== -1; at = text.indexOf("\n", at + 1)) {
+    if (++lines > MAX_HIGHLIGHT_LINES) return true;
+  }
+  return false;
 }

--- a/src/lib/syntax/useSyntax.test.tsx
+++ b/src/lib/syntax/useSyntax.test.tsx
@@ -3,8 +3,11 @@ import { render, screen, waitFor } from "@testing-library/react";
 
 // vi.hoisted, because vi.mock's factory is hoisted above the module body: a
 // plain `const` above would still be uninitialised when the factory returns it.
-const { tokenizeFile } = vi.hoisted(() => ({ tokenizeFile: vi.fn() }));
-vi.mock("./tokenize", () => ({ tokenizeFile }));
+const { tokenizeFile, peekTokens } = vi.hoisted(() => ({
+  tokenizeFile: vi.fn(),
+  peekTokens: vi.fn(),
+}));
+vi.mock("./tokenize", () => ({ tokenizeFile, peekTokens }));
 
 import { useSyntax } from "./useSyntax";
 
@@ -21,6 +24,14 @@ describe("useSyntax", () => {
     expect(screen.getByTestId("out")).toHaveTextContent("none");
     resolve([[], []]);
     await waitFor(() => expect(screen.getByTestId("out")).toHaveTextContent("lines:2"));
+  });
+
+  it("returns cached tokens on the FIRST render, with no tokenize call", () => {
+    tokenizeFile.mockReset();
+    peekTokens.mockReturnValueOnce([[], []]);
+    render(<Probe path="a.ts" text="let" />);
+    expect(screen.getByTestId("out")).toHaveTextContent("lines:2");
+    expect(tokenizeFile).not.toHaveBeenCalled();
   });
 
   it("does not call the tokenizer without a path or text", () => {

--- a/src/lib/syntax/useSyntax.ts
+++ b/src/lib/syntax/useSyntax.ts
@@ -1,6 +1,12 @@
 import React from "react";
-import { tokenizeFile } from "./tokenize";
+import { peekTokens, tokenizeFile } from "./tokenize";
 import type { SyntaxLine } from "./tokenize";
+
+interface Resolved {
+  path: string;
+  text: string;
+  lines: SyntaxLine[] | null;
+}
 
 /**
  * Tokens for a file, or null while they are pending or unavailable.
@@ -8,24 +14,35 @@ import type { SyntaxLine } from "./tokenize";
  * Deliberately never blocks first paint: the caller renders plain text on the
  * null, and re-renders with spans when this resolves. Span-ification does not
  * change row geometry, so there is no layout shift to hide behind a spinner.
+ *
+ * Already-cached tokens are read SYNCHRONOUSLY (peekTokens), so revisiting a
+ * file highlights on the first paint with no plain-text flash and no extra
+ * render pass. The async state is keyed by the (path, text) it answered, which
+ * also keeps a stale resolution — or the previous file's tokens during the one
+ * render before an effect could clear them — from ever being returned against
+ * different text.
  */
 export function useSyntax(
   path: string | null,
   text: string | null,
 ): SyntaxLine[] | null {
-  const [lines, setLines] = React.useState<SyntaxLine[] | null>(null);
+  const cached = React.useMemo(
+    () => (path && text != null ? peekTokens(path, text) : null),
+    [path, text],
+  );
+  const [res, setRes] = React.useState<Resolved | null>(null);
 
   React.useEffect(() => {
-    setLines(null);
-    if (!path || text == null) return;
+    if (cached || !path || text == null) return;
     let cancelled = false;
-    tokenizeFile(path, text).then((result) => {
-      if (!cancelled) setLines(result);
+    tokenizeFile(path, text).then((lines) => {
+      if (!cancelled) setRes({ path, text, lines });
     });
     return () => {
       cancelled = true;
     };
-  }, [path, text]);
+  }, [path, text, cached]);
 
-  return lines;
+  if (cached) return cached;
+  return res && res.path === path && res.text === text ? res.lines : null;
 }

--- a/src/lib/useVariableWindow.ts
+++ b/src/lib/useVariableWindow.ts
@@ -1,0 +1,76 @@
+// Scroll → window state for the variable-height diff surfaces, without a
+// re-render per scroll pixel.
+//
+// The four diff surfaces used to keep raw `scrollTop` in state and derive the
+// window in a memo: correct, but a trackpad fires 100+ scroll events a second
+// and every one re-rendered the whole owning screen — toolbar, file list and
+// all — even though the derived window only changes when the scroll crosses a
+// row boundary (and with overscan, usually not even then). This hook keeps
+// scrollTop in a ref and stores the WINDOW, updating state only when the range
+// actually differs, so scrolling inside the overscan band costs zero renders.
+import React from "react";
+import { windowVariable } from "./diffRows";
+import type { WindowRange } from "./useWindowedList";
+
+function sameRange(a: WindowRange, b: WindowRange): boolean {
+  return (
+    a.start === b.start &&
+    a.end === b.end &&
+    a.topPad === b.topPad &&
+    a.bottomPad === b.bottomPad
+  );
+}
+
+/**
+ * Exact variable-height window over `heights`, bound to a scroll container.
+ *
+ * Returns the window plus the scroll handler to attach. The window is
+ * recomputed on scroll (from the ref, no state write unless it changed) and
+ * whenever `heights` / `viewportH` change (new file, syntax arrival, layout).
+ */
+export function useVariableWindow(o: {
+  heights: number[];
+  viewportH: number;
+  overscan?: number;
+  scrollRef: React.RefObject<HTMLElement | null>;
+}): { win: WindowRange; onScroll: () => void } {
+  const { heights, viewportH, overscan = 8, scrollRef } = o;
+  const scrollTopRef = React.useRef(0);
+  const [win, setWin] = React.useState<WindowRange>(() =>
+    windowVariable(heights, { scrollTop: 0, viewportH, overscan }),
+  );
+
+  // Inputs changed (rows rebuilt, viewport measured): recompute DURING render —
+  // React's derive-state-in-render pattern — so a new file's rows are never
+  // committed against the previous file's window, even for one frame. An
+  // effect here would paint that stale frame first.
+  const prev = React.useRef({ heights, viewportH, overscan });
+  if (
+    prev.current.heights !== heights ||
+    prev.current.viewportH !== viewportH ||
+    prev.current.overscan !== overscan
+  ) {
+    prev.current = { heights, viewportH, overscan };
+    scrollTopRef.current = scrollRef.current?.scrollTop ?? scrollTopRef.current;
+    const next = windowVariable(heights, {
+      scrollTop: scrollTopRef.current,
+      viewportH,
+      overscan,
+    });
+    if (!sameRange(win, next)) setWin(next);
+  }
+
+  const onScroll = React.useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    scrollTopRef.current = el.scrollTop;
+    const next = windowVariable(heights, {
+      scrollTop: el.scrollTop,
+      viewportH,
+      overscan,
+    });
+    setWin((p) => (sameRange(p, next) ? p : next));
+  }, [heights, viewportH, overscan, scrollRef]);
+
+  return { win, onScroll };
+}

--- a/src/lib/useWindowedList.ts
+++ b/src/lib/useWindowedList.ts
@@ -100,8 +100,16 @@ export function useWindowedList<T extends HTMLElement = HTMLDivElement>(o: {
 
   const onScroll = React.useCallback(() => {
     const el = viewportRef.current;
-    if (el) setScrollTop(el.scrollTop);
-  }, []);
+    if (!el) return;
+    // Quantize to the row pitch: windowRange only ever reads
+    // Math.floor(scrollTop / rowHeight), so two positions inside the same row
+    // produce byte-identical windows — but a raw setScrollTop re-rendered the
+    // whole owning screen for every one of the 100+ scroll events per second a
+    // trackpad fires. Snapping first makes the state (and so the render) change
+    // only when the window actually can.
+    const quantized = Math.floor(el.scrollTop / rowHeight) * rowHeight;
+    setScrollTop((prev) => (prev === quantized ? prev : quantized));
+  }, [rowHeight]);
 
   /**
    * Scroll a row into view BY INDEX. Must not go through the DOM: under

--- a/src/lib/wordDiff.ts
+++ b/src/lib/wordDiff.ts
@@ -41,19 +41,29 @@ function tokenize(text: string): Token[] {
   return out;
 }
 
-/** Classic LCS table over token text. Returns matched index pairs. */
+/**
+ * Classic LCS table over token text. Returns matched index pairs.
+ *
+ * The table is one flat Int32Array rather than an array of arrays: a single
+ * allocation the engine zero-fills, indexed by row stride, instead of n+1 heap
+ * arrays with per-row bounds objects. Same DP, same tie-breaking, same pairs —
+ * this runs once per changed line pair in every diff, so its constant factor is
+ * a large share of what a diff costs to flatten.
+ */
 function lcsPairs(a: Token[], b: Token[]): Array<[number, number]> {
   const n = a.length;
   const m = b.length;
-  const table: number[][] = Array.from({ length: n + 1 }, () =>
-    new Array<number>(m + 1).fill(0),
-  );
+  const w = m + 1;
+  const table = new Int32Array((n + 1) * w);
   for (let i = n - 1; i >= 0; i--) {
+    const ai = a[i].text;
+    const row = i * w;
+    const below = row + w;
     for (let j = m - 1; j >= 0; j--) {
-      table[i][j] =
-        a[i].text === b[j].text
-          ? table[i + 1][j + 1] + 1
-          : Math.max(table[i + 1][j], table[i][j + 1]);
+      table[row + j] =
+        ai === b[j].text
+          ? table[below + j + 1] + 1
+          : Math.max(table[below + j], table[row + j + 1]);
     }
   }
   const pairs: Array<[number, number]> = [];
@@ -64,7 +74,7 @@ function lcsPairs(a: Token[], b: Token[]): Array<[number, number]> {
       pairs.push([i, j]);
       i++;
       j++;
-    } else if (table[i + 1][j] >= table[i][j + 1]) {
+    } else if (table[(i + 1) * w + j] >= table[i * w + j + 1]) {
       i++;
     } else {
       j++;

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -71,11 +71,11 @@ import {
   flattenDiffRows,
   hunkAnchorRows,
   scrollTopForRow,
-  windowVariable,
 } from "@/lib/diffRows";
+import { useVariableWindow } from "@/lib/useVariableWindow";
 import { useViewportH } from "@/lib/useViewportH";
 import { useElementSize } from "@/lib/useElementSize";
-import { DiffMinimap } from "@/features/diff/DiffMinimap";
+import { MinimapGutter } from "@/features/diff/DiffMinimap";
 import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
 import {
   WhitespaceToggle,
@@ -605,8 +605,14 @@ export function CommitPanelScreen() {
     [diff, foldH, rowH, syntax, diffText, gaps, expandedGaps],
   );
   const heights = React.useMemo(() => rows.map((r) => r.h), [rows]);
+  // Split mode's model, memoized: computed inline in JSX it re-derived the
+  // whole two-column model (word diff included) on every render of this panel
+  // — which happens per keystroke in the commit message box.
+  const split = React.useMemo(
+    () => (diffMode === "split" && isTextualDiff(diff) && diff ? diffToSplit(diff) : null),
+    [diffMode, diff],
+  );
   const diffScrollRef = React.useRef<HTMLDivElement>(null);
-  const [diffScrollTop, setDiffScrollTop] = React.useState(0);
   const { viewportH: diffViewportH, remeasure: remeasureDiff } = useViewportH(
     diffScrollRef,
     [diffMode],
@@ -614,15 +620,11 @@ export function CommitPanelScreen() {
   // Measured on the WRAPPER holding the scroll area and the minimap, so adding
   // the gutter cannot change the width that decides whether to add it (#161).
   const diffBox = useElementSize();
-  const win = React.useMemo(
-    () =>
-      windowVariable(heights, {
-        scrollTop: diffScrollTop,
-        viewportH: diffViewportH,
-        overscan: 8,
-      }),
-    [heights, diffScrollTop, diffViewportH],
-  );
+  const { win, onScroll: onDiffScroll } = useVariableWindow({
+    heights,
+    viewportH: diffViewportH,
+    scrollRef: diffScrollRef,
+  });
 
   React.useEffect(() => {
     if (!selected || !repo) {
@@ -1269,7 +1271,7 @@ export function CommitPanelScreen() {
           ariaLabel="Diff"
           innerRef={diffScrollRef}
           onScroll={() => {
-            setDiffScrollTop(diffScrollRef.current?.scrollTop ?? 0);
+            onDiffScroll();
             remeasureDiff();
           }}
         >
@@ -1327,19 +1329,17 @@ export function CommitPanelScreen() {
               />
             )}
           {!diffLoading && !diffError && isTextualDiff(diff) && diff && diff.hunks.length > 0 &&
-            diffMode === "split" && (
-              <PGSideBySideDiff {...diffToSplit(diff)} />
+            diffMode === "split" && split && (
+              <PGSideBySideDiff {...split} />
             )}
         </FocusableScroll>
         {diffMode === "unified" && (
-          <DiffMinimap
+          <MinimapGutter
             rows={rows}
             heights={heights}
             rowH={rowH}
-            scrollTop={diffScrollTop}
             viewportH={diffViewportH}
             scrollRef={diffScrollRef}
-            onScrollTop={setDiffScrollTop}
             containerWidth={diffBox.width}
             containerHeight={diffBox.height}
           />
@@ -1662,12 +1662,22 @@ function SectionTree({
   onRowContextMenu: (e: React.MouseEvent, navKey: string) => void;
   onStageToggle: (navKey: string, next: boolean) => void;
 }) {
+  // Tree key → slot, built once per file list. findStatusByTreeKey is a linear
+  // scan, and PGFileTree asks stageState for every row — per-row .find made the
+  // section quadratic in changed files, paid on every keystroke in the message
+  // box (the whole panel re-renders per keystroke).
+  const slotByTreeKey = React.useMemo(() => {
+    const out = new Map<string, FileSlot>();
+    for (const f of files) out.set(`/${f.path.replace(/\/+$/, "")}`, f);
+    return out;
+  }, [files]);
+
   const navKeyFor = React.useCallback(
     (treeKey: string): string => {
-      const slot = findStatusByTreeKey(treeKey, files);
+      const slot = slotByTreeKey.get(treeKey);
       return slot ? keyOf(slot) : dirKeyOf(side, treeKeyToPath(treeKey));
     },
-    [files, side],
+    [slotByTreeKey, side],
   );
 
   // Every row in a section shares that section's staged-ness: the STAGED list
@@ -1675,11 +1685,28 @@ function SectionTree({
   // exception — they can't be staged at all, so they get no checkbox.
   const stageState = React.useCallback(
     (treeKey: string): PGStageState | undefined => {
-      const slot = findStatusByTreeKey(treeKey, files);
+      const slot = slotByTreeKey.get(treeKey);
       if (slot?.status.embedded) return undefined;
       return side === "staged" ? "all" : "none";
     },
-    [files, side],
+    [slotByTreeKey, side],
+  );
+
+  const treeSelectedKeys = React.useMemo(
+    () =>
+      new Set(
+        [...selectedKeys]
+          .filter((k) => k.startsWith(`${side}:`))
+          .map((k) =>
+            k.startsWith(`${side}:dir:`)
+              ? `/${k.slice(`${side}:dir:`.length)}`
+              : `/${k.slice(`${side}:`.length)}`,
+          )
+          // An embedded repo's status path keeps a trailing slash the row key
+          // has already lost.
+          .map((k) => k.replace(/\/+$/, "")),
+      ),
+    [selectedKeys, side],
   );
 
   return (
@@ -1687,20 +1714,7 @@ function SectionTree({
       nodes={nodes}
       expanded={expanded}
       onToggle={onExpandedChange}
-      selectedKeys={
-        new Set(
-          [...selectedKeys]
-            .filter((k) => k.startsWith(`${side}:`))
-            .map((k) =>
-              k.startsWith(`${side}:dir:`)
-                ? `/${k.slice(`${side}:dir:`.length)}`
-                : `/${k.slice(`${side}:`.length)}`,
-            )
-            // An embedded repo's status path keeps a trailing slash the row key
-            // has already lost.
-            .map((k) => k.replace(/\/+$/, "")),
-        )
-      }
+      selectedKeys={treeSelectedKeys}
       onSelect={(treeKey, _node, e) => onSelect(navKeyFor(treeKey), e)}
       onRowContextMenu={(e, treeKey) => onRowContextMenu(e, navKeyFor(treeKey))}
       stageState={stageState}

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -28,15 +28,11 @@ import { LfsDiffNotice } from "@/features/lfs/LfsDiffNotice";
 import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
 import { getDiff } from "@/lib/tauri";
 import { useDiffSyntax } from "@/lib/syntax";
-import {
-  flattenDiffRows,
-  hunkAnchorRows,
-  rowOffset,
-  windowVariable,
-} from "@/lib/diffRows";
+import { flattenDiffRows, hunkAnchorRows, rowOffset } from "@/lib/diffRows";
+import { useVariableWindow } from "@/lib/useVariableWindow";
 import { useViewportH } from "@/lib/useViewportH";
 import { useElementSize } from "@/lib/useElementSize";
-import { DiffMinimap } from "@/features/diff/DiffMinimap";
+import { MinimapGutter } from "@/features/diff/DiffMinimap";
 import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
 import { useDensityStep } from "@/features/settings/useSettingsStore";
 import { pairChangedLines } from "@/lib/pairChangedLines";
@@ -222,22 +218,22 @@ export function DiffViewerScreen() {
   const heights = React.useMemo(() => rows.map((r) => r.h), [rows]);
 
   const scrollRef = React.useRef<HTMLDivElement>(null);
-  const [scrollTop, setScrollTop] = React.useState(0);
   const { viewportH, remeasure } = useViewportH(scrollRef, [mode]);
   // The minimap gutter sits BESIDE the scroll container (panes own their
   // scrolling), so it needs the wrapper's box — and the wrapper is what is
   // measured, not the scroll area, so showing the gutter cannot change the width
   // that decides whether to show it (#161).
   const diffBox = useElementSize();
+  const { win: varWin, onScroll: onDiffScroll } = useVariableWindow({
+    heights,
+    viewportH,
+    scrollRef,
+  });
 
   // Wrap makes row heights genuinely unknown — pre-wrap rows are as tall as they
   // need to be — so windowing is off and every row renders. A very large wrapped
   // diff stays slow; that combination is rare and this keeps the toggle.
-  const win = React.useMemo(
-    () =>
-      wrap ? undefined : windowVariable(heights, { scrollTop, viewportH, overscan: 8 }),
-    [wrap, heights, scrollTop, viewportH],
-  );
+  const win = wrap ? undefined : varWin;
 
   // F7/⇧F7 walk the viewed file's hunks from either pane. Scroll to the hunk's
   // ANCHOR row BY OFFSET (#157): a querySelector would find nothing whenever that
@@ -487,7 +483,7 @@ export function DiffViewerScreen() {
                 ariaLabel="Diff"
                 innerRef={scrollRef}
                 onScroll={() => {
-                  setScrollTop(scrollRef.current?.scrollTop ?? 0);
+                  onDiffScroll();
                   remeasure();
                 }}
               >
@@ -505,14 +501,12 @@ export function DiffViewerScreen() {
                   windowing is off — so `heights` no longer describes the rendered
                   file and a scrub would land on the wrong line. No gutter there. */}
               {!wrap && (
-                <DiffMinimap
+                <MinimapGutter
                   rows={rows}
                   heights={heights}
                   rowH={rowH}
-                  scrollTop={scrollTop}
                   viewportH={viewportH}
                   scrollRef={scrollRef}
-                  onScrollTop={setScrollTop}
                   containerWidth={diffBox.width}
                   containerHeight={diffBox.height}
                 />

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -148,7 +148,7 @@ export function HistoryScreen() {
       }),
     [filter, authorQ, pathQ, sinceDate, untilDate, contentQ, contentRegex],
   );
-  const filterKey = JSON.stringify(logFilter);
+  const filterKey = React.useMemo(() => JSON.stringify(logFilter), [logFilter]);
   React.useEffect(() => {
     const handle = window.setTimeout(() => {
       void searchCommits(logFilter);
@@ -193,6 +193,21 @@ export function HistoryScreen() {
     siblingMin: DETAIL_DIFF_MIN_W,
     storageKey: "pg-history-detail-msg-w",
   });
+
+  // Stable drag handlers: PGResizeHandle re-registers its document listeners
+  // whenever onDrag changes identity, and a drag re-renders this screen per
+  // mousemove — inline arrows meant a listener rebind per move.
+  const onMessagePaneDrag = messagePane.resize;
+  const detailPaneResize = detailPane.resize;
+  const onDetailPaneDrag = React.useCallback(
+    (d: number) => detailPaneResize(-d),
+    [detailPaneResize],
+  );
+  const detailHeightResize = detailHeight.resize;
+  const onDetailHeightDrag = React.useCallback(
+    (d: number) => detailHeightResize(-d),
+    [detailHeightResize],
+  );
   const [diffLayout, setDiffLayout] = React.useState<DiffLayout>(() => {
     try {
       return localStorage.getItem(DIFF_LAYOUT_KEY) === "beside" ? "beside" : "below";
@@ -227,8 +242,11 @@ export function HistoryScreen() {
   );
   const { onContextMenu: onCommitContext, menu: commitMenu } =
     useContextMenu<{ sha: string; subject: string }>(commitMenuItems);
+  // The imported builder directly — an inline arrow here changed onCommitMulti's
+  // identity every render, which cascaded through onRowContext into every row
+  // and made PGCommitRow's memo dead (#68 G9, regressed).
   const { onContextMenu: onCommitMulti, menu: commitMultiMenu } =
-    useContextMenu<string[]>((oids) => commitMultiMenuItems(oids));
+    useContextMenu<string[]>(commitMultiMenuItems);
 
   // Text/author/path/date/sha filtering happens on the backend (baseCommits),
   // and so is the "all"/"branch" scope (see the logRef effect below), so
@@ -254,9 +272,10 @@ export function HistoryScreen() {
 
   // Re-layout on every search keystroke would otherwise hand each row a fresh
   // lanes/node object and re-render all 500 SVGs, even where nothing moved.
-  const rowCache = React.useRef(createRowCache());
+  const rowCache = React.useRef<ReturnType<typeof createRowCache> | null>(null);
+  rowCache.current ??= createRowCache();
   const rows = React.useMemo(
-    () => rowCache.current.stabilize(visible, rawRows),
+    () => rowCache.current!.stabilize(visible, rawRows),
     [visible, rawRows],
   );
 
@@ -541,9 +560,10 @@ export function HistoryScreen() {
   // ("rendered more hooks than during the previous render"), which showed up
   // as a window with nothing in it at all.
   const primaryOid = primarySelectedKey(sel);
-  const current =
-    visible.find((c) => c.oid === primaryOid) ?? visible[cursorIdx] ?? visible[0];
-  const selectedSet = new Set(sel.keys);
+  // selectedSet memoized on the keys array: a fresh Set per render was a
+  // dependency of onRowContext, handing every visible row a new prop each
+  // render and silently disabling PGCommitRow's memo.
+  const selectedSet = React.useMemo(() => new Set(sel.keys), [sel.keys]);
   const multiSelected = sel.keys.length > 1;
 
   // Both row handlers are shared across every row and stable across renders —
@@ -566,6 +586,10 @@ export function HistoryScreen() {
     () => new Map(visible.map((c) => [c.oid, c])),
     [visible],
   );
+  const current =
+    (primaryOid ? byOid.get(primaryOid) : undefined) ??
+    visible[cursorIdx] ??
+    visible[0];
 
   // Ref pills, built once per commit instead of twice per row per render
   // (mapCommitRefs allocated an array, then .filter() allocated another).
@@ -926,7 +950,7 @@ export function HistoryScreen() {
         </div>
         <PGResizeHandle
           side="right"
-          onDrag={(d) => messagePane.resize(d)}
+          onDrag={onMessagePaneDrag}
           onReset={messagePane.reset}
         />
         <div
@@ -991,7 +1015,7 @@ export function HistoryScreen() {
         {showDetail && diffLayout === "beside" && (
           <>
             <PGResizeHandle
-              onDrag={(d) => detailPane.resize(-d)}
+              onDrag={onDetailPaneDrag}
               onReset={detailPane.reset}
               side="left"
             />
@@ -1018,7 +1042,7 @@ export function HistoryScreen() {
               orientation="vertical"
               side="top"
               testId="history-detail-resize"
-              onDrag={(d) => detailHeight.resize(-d)}
+              onDrag={onDetailHeightDrag}
               onReset={detailHeight.reset}
             />
             <div

--- a/src/screens/Rebase.tsx
+++ b/src/screens/Rebase.tsx
@@ -173,15 +173,16 @@ function RebaseBanner({
 // ─── Plan builder ─────────────────────────────────────────────────────────────
 
 export function RebaseScreen() {
-  const {
-    current,
-    commits,
-    rebaseStatus,
-    rebaseStart,
-    rebaseContinue,
-    rebaseAbort,
-    rebaseAcknowledge,
-  } = useRepoStore();
+  const current = useRepoStore((s) => s.current);
+  const commits = useRepoStore((s) => s.commits);
+  const rebaseStatus = useRepoStore((s) => s.rebaseStatus);
+  // Store actions are stable identities; selecting them individually keeps this
+  // screen from re-rendering on every unrelated store write (the selector-less
+  // destructure subscribed to the whole store).
+  const rebaseStart = useRepoStore((s) => s.rebaseStart);
+  const rebaseContinue = useRepoStore((s) => s.rebaseContinue);
+  const rebaseAbort = useRepoStore((s) => s.rebaseAbort);
+  const rebaseAcknowledge = useRepoStore((s) => s.rebaseAcknowledge);
 
   const [plan, setPlan] = useState<PlanRow[]>([]);
   const [mergeMode, setMergeMode] = useRebaseMergeMode();

--- a/src/screens/Remote.tsx
+++ b/src/screens/Remote.tsx
@@ -19,7 +19,9 @@ import type { RemoteInfo } from "@/lib/types";
 export function RemoteScreen() {
   const branches = useRepoStore((s) => s.branches);
   const remotes = useRepoStore((s) => s.remotes);
-  const store = useRepoStore();
+  // Actions only run inside event handlers, so read them off getState() — the
+  // selector-less useRepoStore() re-rendered this screen on every store write.
+  const store = useRepoStore.getState;
 
   const head = currentBranch(branches);
   const { ahead, behind } = totalAheadBehind(branches);
@@ -33,14 +35,14 @@ export function RemoteScreen() {
     return [head.upstream.slice(0, idx), head.upstream.slice(idx + 1)];
   })();
 
-  const handleFetchAll = () => store.fetchAll();
+  const handleFetchAll = () => store().fetchAll();
 
   const handlePull = () => {
     if (!defaultRemote || !defaultBranch) {
       pgFlash("No upstream configured for current branch");
       return;
     }
-    store.pull(defaultRemote, defaultBranch);
+    store().pull(defaultRemote, defaultBranch);
   };
 
   const handlePush = () => {
@@ -48,7 +50,7 @@ export function RemoteScreen() {
       pgFlash("No upstream configured — run git push -u origin <branch> first");
       return;
     }
-    store.push(defaultRemote, defaultBranch);
+    store().push(defaultRemote, defaultBranch);
   };
 
   const handleAddRemote = async () => {
@@ -69,7 +71,7 @@ export function RemoteScreen() {
       mono: true,
     });
     if (!url) return;
-    store.addRemote(name, url);
+    store().addRemote(name, url);
   };
 
   const { onContextMenu: onRemoteCtx, menu: remoteMenu } =
@@ -254,7 +256,7 @@ export function RemoteScreen() {
               onContextMenu={(e) => onRemoteCtx(e, r)}
               ahead={0}
               behind={0}
-              onFetch={() => store.fetch(r.name)}
+              onFetch={() => store().fetch(r.name)}
               onPull={() => {
                 // Pull the current branch from this remote (uses HEAD branch name).
                 const branch = head?.name;
@@ -262,7 +264,7 @@ export function RemoteScreen() {
                   pgFlash("No branch checked out");
                   return;
                 }
-                store.pull(r.name, branch);
+                store().pull(r.name, branch);
               }}
               onPush={() => {
                 const branch = head?.name;
@@ -270,7 +272,7 @@ export function RemoteScreen() {
                   pgFlash("No branch checked out");
                   return;
                 }
-                store.push(r.name, branch);
+                store().push(r.name, branch);
               }}
             />
           ))}

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -58,11 +58,11 @@ import {
   flattenDiffRows,
   hunkAnchorRows,
   scrollTopForRow,
-  windowVariable,
 } from "@/lib/diffRows";
+import { useVariableWindow } from "@/lib/useVariableWindow";
 import { useViewportH } from "@/lib/useViewportH";
 import { useElementSize } from "@/lib/useElementSize";
-import { DiffMinimap } from "@/features/diff/DiffMinimap";
+import { MinimapGutter } from "@/features/diff/DiffMinimap";
 import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
 import { buildLineSpans } from "@/lib/lineSpans";
 import { splitCodeLines } from "@/lib/codeLines";
@@ -428,6 +428,14 @@ export function RepoBrowserScreen() {
     return out;
   }, [tree, filteredStatus, browsingRev]);
 
+  // Stable identity: PGFileTree memoizes its checkbox-column scan on this
+  // callback, so an inline arrow here would re-run that whole-tree walk on
+  // every render of this screen.
+  const stageStateForKey = React.useCallback(
+    (k: string) => stageStates.get(k),
+    [stageStates],
+  );
+
   const onStageToggle = React.useCallback(
     (key: string, _node: PGFileTreeNode, next: boolean) => {
       // Reuse the selection splitter: it already expands a folder key to every
@@ -662,12 +670,16 @@ export function RepoBrowserScreen() {
   );
   const diffHeights = React.useMemo(() => diffRows.map((r) => r.h), [diffRows]);
   const diffScrollRef = React.useRef<HTMLDivElement>(null);
-  const [diffScrollTop, setDiffScrollTop] = React.useState(0);
   const { viewportH: diffViewportH, remeasure: remeasureDiff } =
     useViewportH(diffScrollRef);
   // Measured on the WRAPPER holding the scroll area and the minimap, so adding
   // the gutter cannot change the width that decides whether to add it (#161).
   const diffBox = useElementSize();
+  const { win: diffWin, onScroll: onDiffScroll } = useVariableWindow({
+    heights: diffHeights,
+    viewportH: diffViewportH,
+    scrollRef: diffScrollRef,
+  });
   // ── Hunk cursor + hunk-level chords (#157) ───────────────────────────────
   // This pane had no F7 either; the `@@` banner's Stage/Discard was mouse-only.
   // Scroll BY OFFSET — the anchor row is usually unmounted under windowing.
@@ -733,16 +745,6 @@ export function RepoBrowserScreen() {
     },
     [hunkCursor, hunkActionsDisabled, discardHunkAt],
     { paneId: "repo.preview" },
-  );
-
-  const diffWin = React.useMemo(
-    () =>
-      windowVariable(diffHeights, {
-        scrollTop: diffScrollTop,
-        viewportH: diffViewportH,
-        overscan: 8,
-      }),
-    [diffHeights, diffScrollTop, diffViewportH],
   );
 
   React.useEffect(() => {
@@ -976,7 +978,7 @@ export function RepoBrowserScreen() {
               selectedKeys={selectedKeys}
               onSelect={onTreeSelect}
               onRowContextMenu={onTreeContextMenu}
-              stageState={(k) => stageStates.get(k)}
+              stageState={stageStateForKey}
               onStageToggle={onStageToggle}
               window={treeWin}
             />
@@ -1096,7 +1098,7 @@ export function RepoBrowserScreen() {
             ariaLabel="File preview"
             innerRef={diffScrollRef}
             onScroll={() => {
-              setDiffScrollTop(diffScrollRef.current?.scrollTop ?? 0);
+              onDiffScroll();
               remeasureDiff();
             }}
           >
@@ -1176,14 +1178,12 @@ export function RepoBrowserScreen() {
           {/* Only for a DIFF: this pane also renders plain file content, which has
               no row model and no heights array for a gutter to derive from. */}
           {selectedFile && !diffLoading && isTextualDiff(diff) && diff && (
-            <DiffMinimap
+            <MinimapGutter
               rows={diffRows}
               heights={diffHeights}
               rowH={diffRowH}
-              scrollTop={diffScrollTop}
               viewportH={diffViewportH}
               scrollRef={diffScrollRef}
-              onScrollTop={setDiffScrollTop}
               containerWidth={diffBox.width}
               containerHeight={diffBox.height}
             />


### PR DESCRIPTION
Performance-only pass: no features added, removed, or changed — same UI, same behavior, measured against the same tests. Every layer is green: `tsc`, 1646 unit/component/docs tests, all Rust suites (incl. a new pathspec regression test), e2e typecheck, production `vite build`, and the affected e2e specs (`history-diff`, `status-stage`, `commit`, `palette`, `history-ops`) headless in Docker.

## Syntax highlighting (the headline)

- **Precompiled grammars** (`@shikijs/langs-precompiled` + `createJavaScriptRawEngine`): grammar regexes are native `RegExp` at package build time, so the first highlight in each language skips the whole oniguruma-to-es translation, and the translator drops out of the worker bundle. All 35 languages verified present in the precompiled set.
- **Worker warm-up at idle** after launch: the first file opened pays only its own grammar + tokenize, not worker spawn + Shiki set-up.
- **Synchronous cache reads** (`peekTokens`): a revisited file highlights on the FIRST paint — no plain-text flash, no extra render pass (which used to re-run the whole diff flatten). Async results are keyed by `(path, text)`, so stale tokens can never render against different text.
- In-flight tokenize dedup, LRU 24 → 64, and `skipHighlight` counts newlines instead of allocating one string per line of exactly the oversized files it rejects.

## Diff pipeline

- **Word-diff computed once per diff**: the per-hunk base lines (kind mapping, `changedIndex`, word spans) are cached by the hunks array's identity in a WeakMap. `flattenDiffRows` re-runs on every syntax arrival / gap expansion / density change, and the LCS was its dominant cost — for inputs that never change across those re-runs.
- LCS on one flat `Int32Array`; `buildLineSpans` is a two-cursor merge walk with a no-copy fast path.

## Scroll & rendering

- **Zero re-renders while scrolling inside the overscan band.** New `lib/useVariableWindow` keeps `scrollTop` in a ref and stores only the derived window, updating state when the *range* changes (derived in render, so a new file's rows never paint against the old window). Wired into all four variable-height diff surfaces; `useWindowedList` quantizes to the row pitch for History and the file trees. Previously every scroll *pixel* re-rendered the whole owning screen at trackpad event rate.
- The **minimap** (#161) keeps its per-frame band tracking via a new self-tracking `MinimapGutter` wrapper that subscribes to the scroll element itself — only the small gutter re-renders per pixel, never the screen. `DiffMinimap`'s controlled API is untouched.
- `PGDiffRow` is memoized (module-scope style tables, permanent per-hunk click handlers in `PGWindowedDiff`), so a window shift re-renders only the rows that entered it.
- History's `PGCommitRow` memo was dead (#68 G9 regressed): `selectedSet` was rebuilt and the multi-select menu builder re-created every render, cascading fresh props into every visible row on any state change. Fixed, plus lazy rowCache init, memoized `filterKey`, `byOid` lookups, stable resize handlers.
- `PGFileTree` memoizes its flatten + checkbox-column scan (all-files mode re-walked the whole worktree per render, twice); CommitPanel's `SectionTree` replaces a per-row linear `findStatusByTreeKey` (quadratic in changed files, paid per message-box keystroke) with one Map, and memoizes the split-view model.
- `CommandPalette` gates candidate building + scoring on `open` — always mounted, it re-built and re-sorted one row per tracked file and loaded commit after every refresh, invisibly.
- `AppTitlebar` / `Remote` / `Rebase` drop selector-less whole-store subscriptions (the titlebar re-rendered on every store write, log-page appends included).
- `usePaneSize` debounces its per-mousemove `localStorage` write (flushed on unmount; tests updated to pin the debounced contract).

## Backend (Rust)

- **`diff_to_file_diffs` was O(deltas²)**: it ran `diff.print` once per delta and filtered by path, and `git_diff_print` regenerates every file's patch (blob load + xdiff) per call. Now one pass appends to the right entry as deltas stream by. Hits every commit-diff surface (History inline panel, CommitDiff, Compare, stash diff).
- **Per-repo locks**: the repos map guard was held for the whole operation, so every git op in the process serialized on one global mutex — a log walk in one tab blocked a status refresh in another, and `refreshAll`'s parallel commands ran strictly sequentially. The map now stores `Arc<Mutex<Repository>>`; same-repo ops still serialize on the inner mutex (the stash TOCTOU handling relies on that).
- **Single-path diffs set `disable_pathspec_match`**: without it the pathspec is a post-filter and every diff open / hunk / line op walked the whole worktree (untracked dirs included). Also fixes a real edge — a file literally named `*.txt` no longer glob-matches its siblings — pinned by a new test in `tests/hunks.rs`.
- `status()` + `side_line_stats` set `update_index`, as `git status` itself does: stale stat entries re-hash once, not on every later refresh (paid after every stage/unstage/discard).
- `commit_touches_path` answers literal paths (file history, most path filters) by tree-entry `(oid, filemode)` comparison instead of a whole-tree diff per parent per commit; globs keep the pathspec diff.
- `collect_ref_map` returns a `HashMap<Oid, Vec<String>>` (was a Vec scanned per log row — O(refs × rows)) and peels tags only; `push_log_start` reads branch targets without peeling.
- Allocation trims along the log walk: `commit_to_info` (×500/page), raw-byte sha-prefix compare in the filtered walk, `tags()`/`stashes()`/`branches()` listings (incl. skipping the ahead/behind graph walk when local == upstream), `odb.exists` frontier probe, one-lock `rebase_status`, `String::from_utf8` buffer move in `read_file_content`.

## Notes

- `CLAUDE.md` updated where architecture notes changed (per-repo locking, new `lib/useVariableWindow.ts`).
- Rebased onto the minimap/pane-sizing main; the debounced-persist tests in `resizable.test.tsx` were updated to assert the debounce + unmount-flush contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
