### PR TITLE
fix(win): no console flash — CREATE_NO_WINDOW on git shell-outs (#172)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1552,6 +1552,44 @@ module and every `src/features/*/` directory is named somewhere in here.
   instrument applied to a case git owns (the `bisect.rs` reasoning). Building it
   needs its own spec; do not stub an affordance for it in the meantime.
 
+### Spawning processes (issue 172)
+
+- **Never write `Command::new` outside `src-tauri/src/proc.rs`.**
+  `tests/spawn_no_window.rs` fails the build if you do, and the allow-list it
+  carries names the two files that may (the module itself, and `detach.rs`'s
+  `#[cfg(unix)]` re-exec) with the reason.
+- The reason is Windows. `main.rs` sets `windows_subsystem = "windows"`, so a
+  **release** build is a GUI-subsystem process with no console; every
+  console-subsystem child (`git.exe`, `gpg.exe`, `powershell.exe`) is therefore
+  given a *fresh* console with a visible `conhost.exe` window unless it is created
+  with `CREATE_NO_WINDOW`. It reproduces only in a release/bundled build — a debug
+  build already owns a console and children inherit it, so `pnpm tauri dev`
+  concludes there is no bug.
+- **Constructors, not a `no_window(&mut cmd)` helper.** A helper is something a new
+  spawn site can forget, and 19 of 20 did. `proc::git(workdir)` /
+  `proc::git_async(workdir)` hand back a `Command` that already carries the flag,
+  `GIT_TERMINAL_PROMPT=0` and a closed stdin; `proc::git_async_in(dir)` is the
+  clone shape (working directory instead of `-C`, because the repository does not
+  exist yet); `proc::program(prog)` / `proc::program_async(prog)` apply the flag and
+  nothing else, for children that are not git and own their stdio (the signing
+  program pipes all three streams). A caller that pipes stdin overrides the
+  constructor's `null` afterwards — later builder calls win.
+- **The two console-KEEPING exceptions are deliberate**:
+  `proc::git_async_keeping_console` (`git mergetool`) and
+  `proc::program_async_keeping_console` (`$VISUAL`/`$EDITOR`). A console mergetool
+  or `EDITOR=vim` *is* a terminal program: silencing it leaves an invisible process
+  holding the file with `status().await` never returning and no cancel button. The
+  asymmetry decides it — a stray console window is cosmetic, an invisible editor is
+  Task Manager. The guard test allow-lists both call sites by name, so a third one
+  is an argued decision rather than a copy-paste.
+- **Decide with libgit2 before you spawn.** `verify_commit` shelled out
+  unconditionally, so an unsigned commit — which renders NO badge — cost a console
+  flash per commit selected in History. It now reads the `gpgsig` header through
+  `extract_signature` first and answers `SigState::None` with no subprocess at all,
+  the same pre-check `verify_tag` has had since #132. That is a cost win on every
+  platform, not a Windows workaround, and the same question is worth asking of any
+  new shell-out.
+
 ### Bisect: git's state is the only state of record (#93)
 
 - **There is no `.git/platypusgit-bisect.json`, and there must not be.** Every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,6 +288,11 @@ update.rs        Update discovery — semver compare (semver crate, cmp_preceden
                  GitHub release parsing, ureq agent w/ timeout + https_only.
                  The LOGIC; its Tauri handlers are commands/update.rs. Two
                  different files with the same basename — see the note there
+proc.rs          THE ONLY sanctioned way to spawn a child process (issue 172):
+                 `git` / `git_async` / `git_async_in` (+ CREATE_NO_WINDOW,
+                 GIT_TERMINAL_PROMPT=0, stdin closed), `program` /
+                 `program_async` (flag only), and the two
+                 `*_keeping_console` exceptions. See "Spawning processes"
 forge/           Forge (GitHub / GitLab) integration — PR/MR list, create, checkout,
                  CI status (#92). The trait is split into URL BUILDERS + RESPONSE
                  PARSERS, not `list_pull_requests()`, so every forge-specific line

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -513,18 +513,20 @@ pub const WINDOWS_PATH_SCRIPT: &str = include_str!("../windows/add-user-path.ps1
 #[cfg(windows)]
 fn add_user_path(dir: &Path) -> bool {
     use std::io::Write;
-    use std::os::windows::process::CommandExt;
-    use std::process::{Command, Stdio};
+    use std::process::Stdio;
 
     // The directory travels in the environment, not argv: `-Command` takes a
     // script, and a path is user-controlled text.
-    let child = Command::new("powershell.exe")
+    //
+    // CREATE_NO_WINDOW comes from `proc::program` — this call site had it
+    // hand-rolled first, and its comment named the failure mode that then went
+    // ungeneralised across the other 19 spawn sites (issue 172).
+    let child = crate::proc::program("powershell.exe")
         .args(["-NoProfile", "-NonInteractive", "-Command", "-"])
         .env("PGIT_BIN_DIR", dir)
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .creation_flags(0x0800_0000) // CREATE_NO_WINDOW — no console flash
         .spawn();
     let Ok(mut child) = child else {
         return false;

--- a/src-tauri/src/commands/conflict.rs
+++ b/src-tauri/src/commands/conflict.rs
@@ -132,9 +132,13 @@ pub async fn run_mergetool(
     .await
     .map_err(|e| AppError::Internal(e.to_string()))??;
 
-    let status = tokio::process::Command::new("git")
-        .arg("-C")
-        .arg(&workdir)
+    // DELIBERATELY not silenced on Windows: `git mergetool` launches the tool the
+    // user configured, and a console mergetool (vimdiff) is a terminal program
+    // that needs the console it is given. See `proc::git_async_keeping_console`
+    // for the full reasoning — this is an exception with a rationale, not an
+    // oversight, and `tests/spawn_no_window.rs` allow-lists it by name so it
+    // cannot be "fixed" into consistency by accident (issue 172).
+    let status = crate::proc::git_async_keeping_console(&workdir)
         .arg("mergetool")
         .arg("--no-prompt")
         .arg("--")
@@ -164,9 +168,7 @@ pub async fn restart_conflict(
     .await
     .map_err(|e| AppError::Internal(e.to_string()))??;
 
-    let status = tokio::process::Command::new("git")
-        .arg("-C")
-        .arg(&workdir)
+    let status = crate::proc::git_async(&workdir)
         .arg("checkout")
         .arg("--merge")
         .arg("--")

--- a/src-tauri/src/commands/create.rs
+++ b/src-tauri/src/commands/create.rs
@@ -2,7 +2,6 @@ use std::path::{Component, Path, PathBuf};
 
 use tauri::{AppHandle, Emitter, State};
 use tokio::io::AsyncReadExt;
-use tokio::process::Command;
 
 use crate::{
     error::{AppError, AppResult},
@@ -244,9 +243,11 @@ pub async fn run_clone(
     let target = validate_clone_target(parent, name)?;
     let args = clone_args(url, name, recurse_submodules);
 
-    let mut cmd = Command::new("git");
-    cmd.current_dir(parent)
-        .args(&args)
+    // `git_async_in` and not `git_async`: a clone's working directory is the
+    // PARENT of a repository that does not exist yet, so there is nothing for
+    // `-C` to name. It carries CREATE_NO_WINDOW and the prompt-less policy.
+    let mut cmd = crate::proc::git_async_in(parent);
+    cmd.args(&args)
         // Never let the child read from our stdin. Nothing in this codebase
         // feeds it anything, so an unexpected read would just block forever
         // — and a clone has no cancel button, so a hang here is force-quit

--- a/src-tauri/src/commands/net.rs
+++ b/src-tauri/src/commands/net.rs
@@ -93,11 +93,14 @@ pub async fn run_git_authenticated(
     args: &[&str],
     creds: Option<&Credentials>,
 ) -> AppResult<()> {
-    let mut cmd = tokio::process::Command::new("git");
-    cmd.arg("-C").arg(cwd).args(args);
+    // `proc::git_async` carries GIT_TERMINAL_PROMPT=0 (which `apply_auth_env`
+    // sets too), a closed stdin — nothing feeds it, so an unexpected read would
+    // block forever — and, on Windows, CREATE_NO_WINDOW: without it every fetch,
+    // pull and push flashed a console, including the ones auto-fetch runs on a
+    // timer with no user action at all (issue 172).
+    let mut cmd = crate::proc::git_async(cwd);
+    cmd.args(args);
     apply_auth_env(&mut cmd, creds);
-    // Nothing feeds the child stdin, so an unexpected read would block forever.
-    cmd.stdin(std::process::Stdio::null());
 
     let output = cmd.output().await.map_err(|e| AppError::Io(e.to_string()))?;
 
@@ -154,10 +157,9 @@ pub async fn credential_approve(cwd: &Path, host: &str, creds: &Credentials) {
     }
     input.push_str(&format!("password={}\n\n", creds.secret));
 
-    let mut child = match tokio::process::Command::new("git")
-        .arg("-C")
-        .arg(cwd)
+    let mut child = match crate::proc::git_async(cwd)
         .args(["credential", "approve"])
+        // Overrides the constructor's closed stdin: the credential is fed here.
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())

--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -165,7 +165,11 @@ pub async fn open_in_editor(
         let mut parts = editor.split_whitespace();
         let prog = parts.next().unwrap_or("");
         let args: Vec<&str> = parts.collect();
-        let status = tokio::process::Command::new(prog)
+        // DELIBERATELY not silenced on Windows: `EDITOR=vim` names a console
+        // program, and hiding its console leaves an invisible editor holding the
+        // file with no way to reach it. See
+        // `proc::program_async_keeping_console` (issue 172).
+        let status = crate::proc::program_async_keeping_console(prog)
             .args(&args)
             .arg(&abs)
             .status()

--- a/src-tauri/src/forge/checkout.rs
+++ b/src-tauri/src/forge/checkout.rs
@@ -58,16 +58,13 @@ pub fn checkout_args(local: &str, exists: bool) -> Vec<&str> {
 /// `refs/heads/`, so it can never begin with `-`, and the name has already been
 /// through `validate_ref_name`.
 pub async fn branch_exists(cwd: &Path, name: &str) -> AppResult<bool> {
-    let status = tokio::process::Command::new("git")
-        .arg("-C")
-        .arg(cwd)
+    let status = crate::proc::git_async(cwd)
         .args([
             "rev-parse",
             "--verify",
             "--quiet",
             &format!("refs/heads/{name}"),
         ])
-        .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()

--- a/src-tauri/src/forge/token.rs
+++ b/src-tauri/src/forge/token.rs
@@ -137,11 +137,10 @@ fn credential_input(host: &str, token: Option<&Secret>) -> AppResult<String> {
 /// that answers with an empty string: `GIT_ASKPASS=true` would hand git an empty
 /// password, which `fill` would then report as a stored empty token.
 async fn run_credential(verb: &str, input: &str, want_stdout: bool) -> AppResult<Option<String>> {
-    let mut cmd = tokio::process::Command::new("git");
-    cmd.arg("-C")
-        .arg(credential_cwd())
-        .args(["credential", verb])
-        .env("GIT_TERMINAL_PROMPT", "0")
+    // `proc::git_async` supplies GIT_TERMINAL_PROMPT=0 and CREATE_NO_WINDOW; the
+    // askpass below is this runner's own, and deliberately not the shared one.
+    let mut cmd = crate::proc::git_async(&credential_cwd());
+    cmd.args(["credential", verb])
         // `false` exits non-zero on unix; on Windows there is no such builtin,
         // so name a path that cannot exist — git treats a failed askpass the
         // same way, and falls through to the (disabled) terminal prompt.
@@ -153,6 +152,7 @@ async fn run_credential(verb: &str, input: &str, want_stdout: bool) -> AppResult
                 "false"
             },
         )
+        // Overrides the constructor's closed stdin: the protocol goes in here.
         .stdin(Stdio::piped())
         .stderr(Stdio::null());
     cmd.stdout(if want_stdout {

--- a/src-tauri/src/git/bisect.rs
+++ b/src-tauri/src/git/bisect.rs
@@ -16,7 +16,6 @@
 //! for free, and a bisect the user started in a terminal is picked up unchanged.
 
 use std::path::Path;
-use std::process::{Command, Stdio};
 
 use git2::Repository;
 
@@ -186,14 +185,7 @@ fn run_bisect_vars(workdir: &Path, bad_ref: &str, good_refs: &[String]) -> Bisec
         args.push("--not".into());
         args.extend(good_refs.iter().cloned());
     }
-    let Ok(out) = Command::new("git")
-        .arg("-C")
-        .arg(workdir)
-        .args(&args)
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .stdin(Stdio::null())
-        .output()
-    else {
+    let Ok(out) = crate::proc::git(workdir).args(&args).output() else {
         return BisectVars::default();
     };
     if !out.status.success() {
@@ -233,16 +225,14 @@ pub fn mark_word(mark: BisectMark, bad_term: &str, good_term: &str) -> String {
 /// there and exits 0, so callers re-read the state afterwards rather than trying to
 /// infer anything from the exit code.
 pub fn run(workdir: &Path, args: &[String]) -> AppResult<String> {
-    let out = Command::new("git")
-        .arg("-C")
-        .arg(workdir)
+    let out = crate::proc::git(workdir)
         .arg("bisect")
         .args(args)
-        // No tty here, and `git bisect` can want a pager for the culprit's diff.
-        .env("GIT_TERMINAL_PROMPT", "0")
+        // `git bisect` can want a pager for the culprit's diff, and there is no
+        // tty for one. (The no-tty half — GIT_TERMINAL_PROMPT=0 and a closed
+        // stdin — comes from `proc::git`.)
         .env("GIT_PAGER", "cat")
         .env("PAGER", "cat")
-        .stdin(Stdio::null())
         .output()
         .map_err(|e| AppError::Io(e.to_string()))?;
     if !out.status.success() {

--- a/src-tauri/src/git/lfs.rs
+++ b/src-tauri/src/git/lfs.rs
@@ -12,7 +12,6 @@
 //!   diff's own lines and no subprocess or extra read is needed.
 
 use std::path::Path;
-use std::process::{Command, Stdio};
 
 use git2::Repository;
 
@@ -187,12 +186,8 @@ pub fn declared_patterns(repo: &Repository) -> Vec<String> {
 /// *git* can find it, including a git-lfs installed somewhere only git's exec-path
 /// knows about.
 pub fn version(cwd: &Path) -> Option<String> {
-    let out = Command::new("git")
-        .arg("-C")
-        .arg(cwd)
+    let out = crate::proc::git(cwd)
         .args(["lfs", "version"])
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .stdin(Stdio::null())
         .output()
         .ok()?;
     if !out.status.success() {

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -370,17 +370,14 @@ impl Libgit2Backend {
     /// `git rebase --continue` / `--abort` in the worktree.
     fn run_rebase_flag(&self, repo_id: &RepoId, flag: &str) -> AppResult<()> {
         let repo_path = self.repo_path(repo_id)?;
-        let out = std::process::Command::new("git")
-            .arg("-C")
-            .arg(&repo_path)
+        let out = crate::proc::git(&repo_path)
             .args(["rebase", flag])
             // `--continue` commits the resolved tree, and git opens an editor
             // for the message unless told not to. There is no tty here, so an
-            // editor would block forever.
+            // editor would block forever. (`GIT_TERMINAL_PROMPT=0` and the
+            // closed stdin come from `proc::git`.)
             .env("GIT_EDITOR", "true")
             .env("GIT_SEQUENCE_EDITOR", "true")
-            .env("GIT_TERMINAL_PROMPT", "0")
-            .stdin(std::process::Stdio::null())
             .output()
             .map_err(|e| AppError::Io(e.to_string()))?;
         if !out.status.success() {
@@ -1268,7 +1265,15 @@ fn sign_payload(repo: &Repository, payload: &str) -> AppResult<String> {
 fn run_signer(program: &str, args: &[String], payload: &str) -> AppResult<String> {
     use std::io::Write as _;
 
-    let mut child = std::process::Command::new(program)
+    // `proc::program` and not `proc::git`: the payload goes in on stdin, so the
+    // prompt-less policy's closed stdin would be exactly wrong here.
+    //
+    // Windows caveat, deliberately not resolved by assertion (issue 172): the
+    // flag stops gpg/ssh-keygen being given a console of its own, and a gpg key
+    // with a passphrase asks for it through PINENTRY — Gpg4win's default is the
+    // GUI `pinentry-w32`, which is unaffected, but a curses pinentry would want a
+    // terminal this GUI-subsystem process never had one to give it either way.
+    let mut child = crate::proc::program(program)
         .args(args)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
@@ -1719,9 +1724,7 @@ fn diff_to_file_diffs(diff: &git2::Diff) -> AppResult<Vec<FileDiff>> {
 /// Run `git apply [extra_args...] -` with `patch_text` piped to stdin.
 fn git_apply(repo_path: &Path, extra_args: &[&str], patch_text: &str) -> AppResult<()> {
     use std::io::Write as _;
-    let mut child = std::process::Command::new("git")
-        .arg("-C")
-        .arg(repo_path)
+    let mut child = crate::proc::git(repo_path)
         .arg("apply")
         .args(extra_args)
         .arg("--whitespace=nowarn")
@@ -4527,9 +4530,7 @@ impl GitBackend for Libgit2Backend {
     fn prune_remote(&self, repo_id: &RepoId, name: &str) -> AppResult<()> {
         // We need the path synchronously here (called from spawn_blocking context).
         let path = self.repo_path(repo_id)?;
-        let output = std::process::Command::new("git")
-            .arg("-C")
-            .arg(&path)
+        let output = crate::proc::git(&path)
             .arg("remote")
             .arg("prune")
             .arg(name)
@@ -4804,9 +4805,10 @@ impl GitBackend for Libgit2Backend {
         let repo_path = self.repo_path(repo_id)?;
         // Shells out rather than reimplementing trust evaluation: %G? is git's
         // own verdict, including keyring/allowed-signers lookup.
-        let out = std::process::Command::new("git")
-            .arg("-C")
-            .arg(&repo_path)
+        let out = crate::proc::git(&repo_path)
+            // `proc::git` carries GIT_TERMINAL_PROMPT=0 and a closed stdin:
+            // verification must never block on a prompt nobody can see, and
+            // `spawn_blocking` offers no cancellation if it did.
             .args([
                 "show",
                 "--no-patch",
@@ -4868,14 +4870,11 @@ impl GitBackend for Libgit2Backend {
         // placeholder, so `git show <tag> --format=%G?` reports the commit's
         // signature, and for-each-ref's %(signature:grade) atom is empty for a
         // tag object. `git verify-tag --raw` is git's own verdict on the tag.
-        let out = std::process::Command::new("git")
-            .arg("-C")
-            .arg(&repo_path)
+        // No tty: verification must never block on a prompt nobody can see —
+        // `proc::git` carries GIT_TERMINAL_PROMPT=0 and a closed stdin.
+        let out = crate::proc::git(&repo_path)
             .args(["verify-tag", "--raw", "--"])
             .arg(name)
-            // No tty: verification must never block on a prompt nobody can see.
-            .env("GIT_TERMINAL_PROMPT", "0")
-            .stdin(std::process::Stdio::null())
             .output()
             .map_err(|e| AppError::Io(e.to_string()))?;
 
@@ -5582,18 +5581,18 @@ fn run_git_capture_env(
     args: &[String],
     env: &[(&str, &str)],
 ) -> Result<String, String> {
-    let mut cmd = std::process::Command::new("git");
-    cmd.arg("-C").arg(workdir).args(args);
+    // No tty: `proc::git` supplies GIT_TERMINAL_PROMPT=0 and a closed stdin, so
+    // an auth-requiring remote fails fast instead of hanging forever on a prompt
+    // nobody can see. The askpass pair is this runner's own addition — a helper
+    // that would otherwise pop its own UI must fail instead.
+    let mut cmd = crate::proc::git(workdir);
+    cmd.args(args);
     for (k, v) in env {
         cmd.env(k, v);
     }
     let out = cmd
-        // No tty: without this an auth-requiring remote hangs forever on a prompt
-        // nobody can see.
-        .env("GIT_TERMINAL_PROMPT", "0")
         .env("GIT_ASKPASS", "true")
         .env("SSH_ASKPASS", "true")
-        .stdin(std::process::Stdio::null())
         .output()
         .map_err(|e| e.to_string())?;
     if !out.status.success() {

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -4791,6 +4791,8 @@ impl GitBackend for Libgit2Backend {
         repo_id: &RepoId,
         oid: &str,
     ) -> AppResult<crate::git::signing::SignatureStatus> {
+        use crate::git::signing::{SigState, SignatureStatus};
+
         // Validated before it reaches an argv: `git show` would read a value
         // starting with '-' as an option rather than a revision. Every caller
         // passes an oid from our own log walk, so a hex check costs nothing and
@@ -4800,6 +4802,43 @@ impl GitBackend for Libgit2Backend {
             || !oid.chars().all(|c| c.is_ascii_hexdigit())
         {
             return Err(AppError::InvalidRef(oid.to_string()));
+        }
+
+        let unsigned = SignatureStatus {
+            state: SigState::None,
+            signer: None,
+            key: None,
+        };
+
+        // The common case costs no subprocess (issue 172). Most commits in most
+        // repositories are unsigned, `LOOK.None` renders NOTHING, and on Windows
+        // a GUI-subsystem release build pays a visible console window per
+        // `git show` — so the reported symptom was one console flash per commit
+        // selected, for a badge that never appeared. `verify_tag` below has had
+        // this pre-check since #132; this is the same shape.
+        //
+        // Resolving the revision here also does two other jobs: an unknown
+        // object is `InvalidRef` before anything is spawned (which is what the
+        // hex check above could only approximate), and what reaches argv is a
+        // full oid we produced, not caller text — the same reason
+        // `bisect::resolve` exists.
+        let (full_oid, signed) = self.with_repo(repo_id, |repo| {
+            let commit = repo
+                .revparse_single(oid)
+                .and_then(|obj| obj.peel_to_commit())
+                .map_err(|_| AppError::InvalidRef(oid.to_string()))?;
+            let id = commit.id();
+            // `gpgsig` is the header git writes for every signature FORMAT —
+            // openpgp, ssh and x509 all land there. `gpgsig-sha256` is the
+            // sha256-object-format spelling, checked so a signed commit in such a
+            // repository can never read as unsigned.
+            let signed = ["gpgsig", "gpgsig-sha256"]
+                .iter()
+                .any(|field| repo.extract_signature(&id, Some(field)).is_ok());
+            Ok((id.to_string(), signed))
+        })?;
+        if !signed {
+            return Ok(unsigned);
         }
 
         let repo_path = self.repo_path(repo_id)?;
@@ -4813,12 +4852,21 @@ impl GitBackend for Libgit2Backend {
                 "show",
                 "--no-patch",
                 "--format=%G?%x00%GS%x00%GK",
-                oid,
+                &full_oid,
             ])
             .output()
             .map_err(|e| AppError::Io(e.to_string()))?;
         if !out.status.success() {
-            return Err(AppError::InvalidRef(oid.to_string()));
+            // git's own message, not `InvalidRef(oid)`: the object is known to
+            // exist (resolved above), so a failure here is git or the signer
+            // — a broken gpg install used to be reported as a bad object id.
+            let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            let detail = if stderr.is_empty() {
+                String::from_utf8_lossy(&out.stdout).trim().to_string()
+            } else {
+                stderr
+            };
+            return Err(AppError::Git(format!("git show --format=%G?: {detail}")));
         }
         Ok(crate::git::signing::parse_verify_output(
             &String::from_utf8_lossy(&out.stdout),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ pub mod error;
 pub mod forge;
 pub mod git;
 pub mod opener;
+pub mod proc;
 pub mod state;
 pub mod update;
 

--- a/src-tauri/src/opener.rs
+++ b/src-tauri/src/opener.rs
@@ -115,7 +115,10 @@ pub async fn open_with_default_app(target: &OsStr) -> AppResult<()> {
     let (_, pre) = OPENER;
     let prog = opener_program();
     let shown = prog.to_string_lossy().to_string();
-    let status = tokio::process::Command::new(&prog)
+    // `rundll32.exe` is GUI-subsystem, so CREATE_NO_WINDOW is documented as
+    // ignored for it — routed through `proc` anyway, because "the only sanctioned
+    // way to spawn" is worth more than the one site's exemption (issue 172).
+    let status = crate::proc::program_async(&prog)
         .args(pre)
         .arg(target)
         .status()

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -1,0 +1,248 @@
+//! The one sanctioned way to spawn a child process (issue 172).
+//!
+//! # Why this module exists
+//!
+//! `main.rs` sets `#![cfg_attr(not(debug_assertions), windows_subsystem =
+//! "windows")]`, so a **release** build is a GUI-subsystem process with no
+//! console attached. When such a process `CreateProcess`es a *console*-subsystem
+//! child — and `git.exe`, `gpg.exe`, `powershell.exe` all are — Windows
+//! allocates a fresh console for it and starts `conhost.exe` to host it. That
+//! console's window is visible unless the child is created with
+//! `CREATE_NO_WINDOW` (`0x0800_0000`).
+//!
+//! The symptom was a console window flashing on every commit selection in
+//! History (`verify_commit`'s `git show --format=%G?`), but the same flash rode
+//! along on hunk staging (`git apply`), the LFS availability probe, every
+//! `bisect_status` read, and — with auto-fetch on — a timer with no user action
+//! at all. It reproduces **only in a release/bundled build**: a debug build is
+//! console-subsystem, already owns a console, and children inherit it.
+//!
+//! # Why constructors rather than a `no_window(&mut cmd)` helper
+//!
+//! A helper is something a new spawn site can forget. There were 20 spawn sites
+//! and exactly one remembered. So the flag is applied *by the only functions that
+//! hand out a `Command` at all*, and `tests/spawn_no_window.rs` fails the build
+//! if a raw `Command::new` appears anywhere outside this file. A twenty-first
+//! spawn site inherits the fix instead of reopening the issue.
+//!
+//! `std::process::Command` and `tokio::process::Command` are unrelated types
+//! (std's `creation_flags` comes from the `CommandExt` trait, tokio's is an
+//! inherent `#[cfg(windows)]` method), so each gets its own constructor rather
+//! than one taking a trait object.
+//!
+//! # The two deliberate exceptions
+//!
+//! [`git_async_keeping_console`] and [`program_async_keeping_console`] exist for
+//! the two children that are **interactive terminal programs on purpose**. See
+//! their doc comments; the guard test allow-lists their call sites by name, so
+//! adding a third is a deliberate act with a test to update, not an omission.
+
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::Stdio;
+
+/// `CREATE_NO_WINDOW` — "the process is a console application that is being run
+/// without a console window", i.e. no console is created and no `conhost.exe`
+/// window appears. Documented as ignored when the child is not a console
+/// application, so it is harmless on a GUI-subsystem child.
+///
+/// Spelled out rather than pulled from `windows-sys` to keep this module free of
+/// a platform dependency; the value is part of the stable Win32 ABI.
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// Apply the no-console flag. No-op off Windows.
+#[cfg(windows)]
+fn silence(cmd: &mut std::process::Command) {
+    use std::os::windows::process::CommandExt;
+    cmd.creation_flags(CREATE_NO_WINDOW);
+}
+
+/// Non-Windows sibling, so every call site compiles unconditionally.
+#[cfg(not(windows))]
+fn silence(_cmd: &mut std::process::Command) {}
+
+/// Apply the no-console flag to a tokio command. No-op off Windows.
+#[cfg(windows)]
+fn silence_async(cmd: &mut tokio::process::Command) {
+    cmd.creation_flags(CREATE_NO_WINDOW);
+}
+
+#[cfg(not(windows))]
+fn silence_async(_cmd: &mut tokio::process::Command) {}
+
+/// Spawn `prog` with no console window.
+///
+/// Nothing else is applied: this is for children that are not git and whose
+/// stdio policy is their caller's business (the signing program pipes all three
+/// streams; `rundll32` inherits them).
+pub fn program(prog: impl AsRef<OsStr>) -> std::process::Command {
+    let mut cmd = std::process::Command::new(prog);
+    silence(&mut cmd);
+    cmd
+}
+
+/// [`program`], async.
+pub fn program_async(prog: impl AsRef<OsStr>) -> tokio::process::Command {
+    let mut cmd = tokio::process::Command::new(prog);
+    silence_async(&mut cmd);
+    cmd
+}
+
+/// The prompt-less policy every non-interactive git shell-out in this codebase
+/// wants, in one place.
+///
+/// * `GIT_TERMINAL_PROMPT=0` — a subprocess of a GUI app has no terminal, so an
+///   auth-requiring remote would otherwise hang forever on a prompt nobody can
+///   see; with prompts off git fails fast and the failure is classifiable.
+/// * `stdin` closed — nothing here feeds a child's stdin, so an unexpected read
+///   blocks forever. A caller that *does* pipe stdin (`git apply`,
+///   `git credential`) overrides it afterwards; later builder calls win.
+fn prompt_less(cmd: &mut std::process::Command) {
+    cmd.env("GIT_TERMINAL_PROMPT", "0").stdin(Stdio::null());
+}
+
+fn prompt_less_async(cmd: &mut tokio::process::Command) {
+    cmd.env("GIT_TERMINAL_PROMPT", "0").stdin(Stdio::null());
+}
+
+/// `git -C <workdir>`, with no console window and the prompt-less policy above.
+///
+/// Sync, because every caller is already inside `spawn_blocking` (commands wrap
+/// the whole backend call).
+pub fn git(workdir: &Path) -> std::process::Command {
+    let mut cmd = program("git");
+    cmd.arg("-C").arg(workdir);
+    prompt_less(&mut cmd);
+    cmd
+}
+
+/// [`git`], async.
+pub fn git_async(workdir: &Path) -> tokio::process::Command {
+    let mut cmd = program_async("git");
+    cmd.arg("-C").arg(workdir);
+    prompt_less_async(&mut cmd);
+    cmd
+}
+
+/// `git` run **with `dir` as its working directory** rather than `-C dir`.
+///
+/// For `clone`, whose working directory is the *parent* of a repository that does
+/// not exist yet — `-C` would have to name a directory git is about to create.
+pub fn git_async_in(dir: &Path) -> tokio::process::Command {
+    let mut cmd = program_async("git");
+    cmd.current_dir(dir);
+    prompt_less_async(&mut cmd);
+    cmd
+}
+
+/// `git -C <workdir>` **keeping its console**, and inheriting stdio.
+///
+/// The one caller is `run_mergetool`. `git mergetool` launches the tool the user
+/// configured, and a console mergetool (`vimdiff`, `nvimdiff`, `emerge`) *is* a
+/// terminal program: silencing it would leave an invisible, unfocusable process
+/// holding the conflicted file open, with `status().await` never returning and no
+/// cancel button anywhere in the UI. The visible console is worse-looking and
+/// strictly more usable.
+///
+/// The asymmetry that decides it: silencing costs a console window for GUI
+/// mergetools (cosmetic — and `CREATE_NO_WINDOW` is ignored for them anyway,
+/// they are not console applications), while not silencing costs a console
+/// window for console mergetools (which is the window they need). Only one of
+/// those two mistakes is unrecoverable, so we make the other one.
+///
+/// This is also the path a user reaches *by asking for their own tool* —
+/// platypusgit has its own resolver window for everyone else — so a terminal
+/// appearing is closer to expected than surprising.
+///
+/// No prompt-less policy either: an interactive tool needs its stdin.
+pub fn git_async_keeping_console(workdir: &Path) -> tokio::process::Command {
+    let mut cmd = tokio::process::Command::new("git");
+    cmd.arg("-C").arg(workdir);
+    cmd
+}
+
+/// Spawn `prog` **keeping its console**, inheriting stdio.
+///
+/// The one caller is `open_in_editor`, running `$VISUAL` / `$EDITOR`. Same
+/// asymmetry as [`git_async_keeping_console`]: `EDITOR=vim` names a console
+/// program, and hiding its console makes the editor invisible while it holds the
+/// file — the user's next move would be Task Manager. A GUI editor is unaffected
+/// either way, because the flag does not apply to non-console applications.
+///
+/// A batch-file shim (`code.cmd`) is the one case that would genuinely benefit,
+/// since `cmd.exe` is a console application; that is a cosmetic flash traded
+/// against an unrecoverable one, so it loses.
+pub fn program_async_keeping_console(prog: impl AsRef<OsStr>) -> tokio::process::Command {
+    tokio::process::Command::new(prog)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `Command`'s getters are the only way to see a builder's decisions without
+    /// running it, and they are what makes the policy assertable off Windows.
+    fn envs(cmd: &std::process::Command) -> Vec<(String, Option<String>)> {
+        cmd.get_envs()
+            .map(|(k, v)| {
+                (
+                    k.to_string_lossy().to_string(),
+                    v.map(|v| v.to_string_lossy().to_string()),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn git_runs_git_in_the_workdir_prompt_less() {
+        let cmd = git(Path::new("/tmp/repo"));
+        assert_eq!(cmd.get_program(), "git");
+        let args: Vec<_> = cmd.get_args().collect();
+        assert_eq!(args, vec![OsStr::new("-C"), OsStr::new("/tmp/repo")]);
+        assert!(
+            envs(&cmd).contains(&("GIT_TERMINAL_PROMPT".into(), Some("0".into()))),
+            "{:?}",
+            envs(&cmd)
+        );
+    }
+
+    #[test]
+    fn git_async_matches_the_sync_constructor() {
+        let cmd = git_async(Path::new("/tmp/repo"));
+        let std = cmd.as_std();
+        assert_eq!(std.get_program(), "git");
+        let args: Vec<_> = std.get_args().collect();
+        assert_eq!(args, vec![OsStr::new("-C"), OsStr::new("/tmp/repo")]);
+        assert!(envs(std).contains(&("GIT_TERMINAL_PROMPT".into(), Some("0".into()))));
+    }
+
+    #[test]
+    fn git_async_in_sets_a_working_directory_instead_of_dash_c() {
+        let cmd = git_async_in(Path::new("/tmp/parent"));
+        let std = cmd.as_std();
+        assert_eq!(std.get_current_dir(), Some(Path::new("/tmp/parent")));
+        assert_eq!(std.get_args().count(), 0, "no -C for the clone path");
+    }
+
+    #[test]
+    fn the_console_keeping_constructors_apply_no_policy() {
+        // Whatever else changes, these two must not acquire a stdin(null) or a
+        // GIT_TERMINAL_PROMPT: an interactive child needs its terminal.
+        let cmd = git_async_keeping_console(Path::new("/tmp/repo"));
+        assert!(envs(cmd.as_std()).is_empty(), "mergetool keeps its env");
+
+        let cmd = program_async_keeping_console("vim");
+        assert_eq!(cmd.as_std().get_program(), "vim");
+        assert!(envs(cmd.as_std()).is_empty());
+    }
+
+    #[test]
+    fn program_applies_nothing_but_the_flag() {
+        // The signer pipes all three streams itself, so the constructor must not
+        // close stdin under it.
+        let cmd = program("gpg");
+        assert_eq!(cmd.get_program(), "gpg");
+        assert!(envs(&cmd).is_empty());
+    }
+}

--- a/src-tauri/tests/signing.rs
+++ b/src-tauri/tests/signing.rs
@@ -253,6 +253,103 @@ fn verify_commit_reports_an_unsigned_commit_as_none() {
     );
 }
 
+/// `ssh_signing_repo`, plus an allowed-signers file naming the generated key, so
+/// `%G?` can reach a `Good` verdict rather than only "signature present" — git
+/// grades an ssh signature it cannot attribute as `U` or refuses it outright.
+/// Mirrors `tag_signing.rs`'s fixture.
+fn ssh_signing_repo_with_allowed_signers() -> Option<(TempRepo, tempfile::TempDir)> {
+    let (tr, keydir) = ssh_signing_repo()?;
+    let key = keydir.path().join("id_ed25519");
+
+    // "<principal> <keytype> <base64>" — the principal must match the committer
+    // email TempRepo uses, or ssh-keygen finds no principal for it.
+    let pubkey = std::fs::read_to_string(key.with_extension("pub")).ok()?;
+    let mut fields = pubkey.split_whitespace();
+    let (kind, blob) = (fields.next()?, fields.next()?);
+    let email = tr
+        .repo
+        .config()
+        .unwrap()
+        .get_string("user.email")
+        .unwrap_or_default();
+    let allowed = keydir.path().join("allowed_signers");
+    std::fs::write(&allowed, format!("{email} {kind} {blob}\n")).ok()?;
+    tr.repo
+        .config()
+        .unwrap()
+        .set_str("gpg.ssh.allowedSignersFile", allowed.to_str().unwrap())
+        .unwrap();
+    Some((tr, keydir))
+}
+
+/// The other half of the issue-172 pre-check: skipping the subprocess for
+/// unsigned commits must not skip it for signed ones. `verify_commit` still
+/// shells out to `git show --format=%G?` and still reports git's own verdict.
+#[test]
+fn verify_commit_grades_our_own_signature_good() {
+    let Some((tr, _keydir)) = ssh_signing_repo_with_allowed_signers() else {
+        eprintln!("ssh-keygen unavailable — skipping verify_commit good test");
+        return;
+    };
+    let (backend, handle) = tr.open_with_backend();
+    backend
+        .stage(&handle.id, &[std::path::PathBuf::from("b.txt")])
+        .unwrap();
+    let oid = backend
+        .commit(&handle.id, opts("signed", Some(true)))
+        .expect("signed commit");
+
+    let status = backend.verify_commit(&handle.id, &oid).expect("verify");
+    assert_eq!(
+        status.state,
+        platypusgit_lib::git::signing::SigState::Good,
+        "signer={:?} key={:?}",
+        status.signer,
+        status.key
+    );
+}
+
+/// The pre-check reads the commit HEADER, not the signature's validity: a commit
+/// carrying `gpgsig` must reach git even when what it carries is nonsense, or a
+/// tampered signature would silently read as "unsigned" instead of `Bad`.
+#[test]
+fn verify_commit_does_not_report_a_broken_signature_as_unsigned() {
+    let Some((tr, _keydir)) = ssh_signing_repo_with_allowed_signers() else {
+        eprintln!("ssh-keygen unavailable — skipping broken-signature test");
+        return;
+    };
+    let (backend, handle) = tr.open_with_backend();
+
+    // A commit object whose gpgsig header holds garbage.
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    let buf = tr
+        .repo
+        .commit_create_buffer(
+            &head.author(),
+            &head.committer(),
+            "tampered",
+            &head.tree().unwrap(),
+            &[&head],
+        )
+        .unwrap();
+    let oid = tr
+        .repo
+        .commit_signed(
+            std::str::from_utf8(&buf).unwrap(),
+            "-----BEGIN SSH SIGNATURE-----\ngarbage\n-----END SSH SIGNATURE-----\n",
+            None,
+        )
+        .unwrap()
+        .to_string();
+
+    let state = backend.verify_commit(&handle.id, &oid).expect("verify").state;
+    assert_ne!(
+        state,
+        platypusgit_lib::git::signing::SigState::None,
+        "a commit carrying a gpgsig header must never grade as unsigned"
+    );
+}
+
 #[test]
 fn a_signing_failure_fails_the_commit_instead_of_committing_unsigned() {
     let tr = TempRepo::with_initial_commit("hello\n");

--- a/src-tauri/tests/spawn_no_window.rs
+++ b/src-tauri/tests/spawn_no_window.rs
@@ -1,0 +1,225 @@
+//! The structural half of issue 172: **no raw process spawn outside
+//! `src/proc.rs`**.
+//!
+//! The Windows console flash was not one bug, it was 19 spawn sites and one that
+//! remembered the flag. A one-time sweep of the other 19 would regress the first
+//! time someone adds a twentieth, silently, in a build nobody runs on Windows —
+//! which is exactly how it shipped. So the flag lives in constructors and this
+//! test fails if a `Command::new` appears anywhere else.
+//!
+//! Same shape as `test/docs.test.ts`, which reads the `invoke_handler!` registry
+//! and fails when a command is undocumented: the guard is a test over the source
+//! text, because the property is about what the source *may contain*.
+//!
+//! Limits, stated honestly: this greps. It catches `Command::new` in every
+//! spelling in use (`std::process::`, `tokio::process::`, imported bare), and it
+//! catches a hand-rolled `creation_flags`. It would not catch someone building a
+//! `Command` by other means. That is a deliberate act, not an oversight, and the
+//! reviewer of such a change has this file to read.
+
+use std::path::{Path, PathBuf};
+
+/// Files allowed to contain raw `Command::new`, with the count expected and the
+/// reason. A new spawn in one of these files fails the count, so an exception
+/// covers what it was granted for and nothing more.
+const RAW_SPAWN_ALLOWED: &[(&str, usize, &str)] = &[
+    (
+        "src/proc.rs",
+        4,
+        "The module that OWNS spawning. Its four constructors are the raw sites: \
+         `program`, `program_async`, and the two `*_keeping_console` exceptions.",
+    ),
+    (
+        "src/detach.rs",
+        1,
+        "`spawn_detached` is `#[cfg(unix)]` — it re-execs the app under `setsid` \
+         to hand a terminal back on a `pgit …` launch (#163). Windows is \
+         deliberately untouched there (see its `#[cfg(not(unix))]` sibling), so \
+         no Windows console can be created by it.",
+    ),
+];
+
+/// Call sites of the constructors that deliberately KEEP a child's console, with
+/// the reason each is an exception. Adding a third means editing this list, which
+/// is the point: `CREATE_NO_WINDOW` on an interactive terminal program leaves an
+/// invisible process holding a file open, so the exceptions must be argued, not
+/// inherited.
+const CONSOLE_KEEPING_CALLERS: &[(&str, &str, &str)] = &[
+    (
+        "src/commands/conflict.rs",
+        "crate::proc::git_async_keeping_console(",
+        "`git mergetool` launches the tool the USER configured. A console \
+         mergetool (vimdiff) needs its console; silencing it would leave an \
+         invisible process holding the conflicted file with `status().await` \
+         never returning and no cancel button in the UI. A GUI mergetool is \
+         unaffected either way — the flag does not apply to non-console apps.",
+    ),
+    (
+        "src/commands/repo.rs",
+        "crate::proc::program_async_keeping_console(",
+        "`$VISUAL`/`$EDITOR`. `EDITOR=vim` names a console program, and hiding \
+         its console makes the editor invisible while it holds the file — the \
+         user's next move would be Task Manager. The cosmetic flash a batch-file \
+         shim (`code.cmd`) would avoid does not outweigh that.",
+    ),
+];
+
+fn src_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+fn rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).expect("read src dir") {
+        let path = entry.expect("dir entry").path();
+        if path.is_dir() {
+            rust_files(&path, out);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Every `.rs` file under `src/`, as (path relative to the crate root, contents).
+fn sources() -> Vec<(String, String)> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut files = Vec::new();
+    rust_files(&src_root(), &mut files);
+    files.sort();
+    files
+        .into_iter()
+        .map(|p| {
+            let rel = p
+                .strip_prefix(root)
+                .expect("under the crate root")
+                .to_string_lossy()
+                // So the allow-list reads the same on Windows.
+                .replace('\\', "/");
+            (rel, std::fs::read_to_string(&p).expect("read source"))
+        })
+        .collect()
+}
+
+/// Comment lines are not code. Without this the module doc in `proc.rs`, which
+/// explains the rule, would count as breaking it.
+fn is_comment(line: &str) -> bool {
+    let t = line.trim_start();
+    t.starts_with("//") || t.starts_with("/*") || t.starts_with('*')
+}
+
+fn count_code_occurrences(body: &str, needle: &str) -> usize {
+    body.lines()
+        .filter(|l| !is_comment(l))
+        .map(|l| l.matches(needle).count())
+        .sum()
+}
+
+fn allowance(rel: &str) -> Option<(usize, &'static str)> {
+    RAW_SPAWN_ALLOWED
+        .iter()
+        .find(|(f, _, _)| *f == rel)
+        .map(|(_, n, why)| (*n, *why))
+}
+
+#[test]
+fn no_raw_command_new_outside_the_proc_module() {
+    let mut offenders: Vec<String> = Vec::new();
+
+    for (rel, body) in sources() {
+        let found = count_code_occurrences(&body, "Command::new");
+        let allowed = allowance(&rel);
+        match allowed {
+            None if found > 0 => offenders.push(format!(
+                "{rel}: {found} raw `Command::new`. Use a `crate::proc::…` \
+                 constructor so the child inherits CREATE_NO_WINDOW on Windows; \
+                 if this spawn genuinely must keep its console, add it to \
+                 CONSOLE_KEEPING_CALLERS with a reason."
+            )),
+            Some((expected, why)) if found != expected => offenders.push(format!(
+                "{rel}: {found} raw `Command::new`, allow-listed for {expected}. \
+                 The exception exists because: {why}"
+            )),
+            _ => {}
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "raw process spawns outside src/proc.rs (issue 172):\n  {}",
+        offenders.join("\n  ")
+    );
+}
+
+#[test]
+fn the_console_keeping_exceptions_are_exactly_the_allow_listed_ones() {
+    const MARKERS: [&str; 2] = [
+        "crate::proc::git_async_keeping_console(",
+        "crate::proc::program_async_keeping_console(",
+    ];
+
+    let sources = sources();
+    let mut total = 0usize;
+    let mut unexpected: Vec<String> = Vec::new();
+
+    for (rel, body) in &sources {
+        for marker in MARKERS {
+            let found = count_code_occurrences(body, marker);
+            total += found;
+            if found > 0
+                && !CONSOLE_KEEPING_CALLERS
+                    .iter()
+                    .any(|(f, m, _)| f == rel && *m == marker)
+            {
+                unexpected.push(format!("{rel} calls {marker}"));
+            }
+        }
+    }
+
+    assert!(
+        unexpected.is_empty(),
+        "a new spawn deliberately keeps its Windows console, which needs a \
+         reason in CONSOLE_KEEPING_CALLERS:\n  {}",
+        unexpected.join("\n  ")
+    );
+    assert_eq!(
+        total,
+        CONSOLE_KEEPING_CALLERS.len(),
+        "expected exactly {} console-keeping call site(s); the allow-list and the \
+         code have drifted",
+        CONSOLE_KEEPING_CALLERS.len()
+    );
+
+    // And each allow-listed exception is still there — a dead entry would let a
+    // future one be added without argument.
+    for (rel, marker, why) in CONSOLE_KEEPING_CALLERS {
+        let body = sources
+            .iter()
+            .find(|(f, _)| f == rel)
+            .map(|(_, b)| b)
+            .unwrap_or_else(|| panic!("{rel} is allow-listed but does not exist"));
+        assert_eq!(
+            count_code_occurrences(body, marker),
+            1,
+            "{rel} should call {marker} exactly once. Reason on record: {why}"
+        );
+    }
+}
+
+#[test]
+fn the_windows_creation_flag_is_set_in_one_place_only() {
+    // The pre-172 state was one hand-rolled `creation_flags(0x0800_0000)` in
+    // cli.rs and 19 sites without one. A second hand-rolled flag is the start of
+    // that again.
+    for (rel, body) in sources() {
+        if rel == "src/proc.rs" {
+            continue;
+        }
+        for needle in ["creation_flags", "0x0800_0000", "0x08000000"] {
+            assert_eq!(
+                count_code_occurrences(&body, needle),
+                0,
+                "{rel} sets the Windows creation flag by hand ({needle}); it \
+                 belongs in src/proc.rs so every spawn site inherits it"
+            );
+        }
+    }
+}

--- a/src-tauri/tests/verify_commit_no_spawn.rs
+++ b/src-tauri/tests/verify_commit_no_spawn.rs
@@ -1,0 +1,154 @@
+//! `verify_commit` must not spawn anything for an **unsigned** commit (issue 172).
+//!
+//! Why this is worth its own test binary: the only way to observe "no process was
+//! spawned" is to control `PATH`, and `PATH` is process-global while cargo runs a
+//! binary's tests on parallel threads. One `#[test]` per binary, so the
+//! environment mutation cannot race a sibling.
+//!
+//! The stub `git` on `PATH` records that it ran and then fails, which gives three
+//! assertions from one fixture:
+//!
+//! 1. the stub is reachable at all (proving a spawn WOULD be observed),
+//! 2. an unsigned commit produces `SigState::None` with the stub untouched,
+//! 3. a commit that DOES carry a signature still reaches the subprocess — the
+//!    pre-check is a pre-check, not a blanket short-circuit — and git's own
+//!    message survives into the error instead of being replaced by
+//!    `InvalidRef(oid)`.
+//!
+//! The Windows console flash this removes cannot be observed from here; what can
+//! be observed, on every platform, is that the process is not spawned at all.
+
+mod support;
+
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::signing::SigState;
+use platypusgit_lib::git::GitBackend;
+use support::TempRepo;
+
+/// A `git` on `PATH` that touches `marker` and exits non-zero with a message.
+///
+/// Unix-only: Rust's `Command::new("git")` resolves through `CreateProcess` on
+/// Windows, which appends `.exe` and would not find a `.cmd` shim, so a stub
+/// there means compiling a real executable. The invariant under test is
+/// platform-independent, so the test skips instead.
+#[cfg(unix)]
+fn stub_git(dir: &std::path::Path, marker: &std::path::Path) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let git = dir.join("git");
+    std::fs::write(
+        &git,
+        format!(
+            "#!/bin/sh\n\
+             : > '{}'\n\
+             echo 'stub git: gpg is not installed' >&2\n\
+             exit 1\n",
+            marker.display()
+        ),
+    )
+    .expect("write stub git");
+    std::fs::set_permissions(&git, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod stub git");
+    git
+}
+
+#[cfg(unix)]
+#[test]
+fn an_unsigned_commit_is_verified_without_spawning_git() {
+    let bindir = tempfile::tempdir().expect("bindir");
+    let marker = bindir.path().join("git-ran");
+    stub_git(bindir.path(), &marker);
+
+    // The repository is built entirely through libgit2, so nothing about the
+    // fixture itself needs the real git binary.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let unsigned_oid = tr.repo.head().unwrap().target().unwrap().to_string();
+
+    // A commit object carrying a `gpgsig` header. The signature is not a real
+    // one — the pre-check reads the HEADER, and what happens after it is a
+    // subprocess this test wants to catch, not verify.
+    let signed_oid = {
+        let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+        let buf = tr
+            .repo
+            .commit_create_buffer(
+                &head.author(),
+                &head.committer(),
+                "signed",
+                &head.tree().unwrap(),
+                &[&head],
+            )
+            .unwrap();
+        let content = std::str::from_utf8(&buf).unwrap().to_string();
+        tr.repo
+            .commit_signed(&content, "-----BEGIN SSH SIGNATURE-----\nnope\n", None)
+            .expect("write a commit with a gpgsig header")
+            .to_string()
+    };
+
+    std::env::set_var("PATH", bindir.path());
+
+    // ── the fixture proves itself: a spawn IS observable ─────────────────────
+    let probe = std::process::Command::new("git")
+        .arg("--version")
+        .output()
+        .expect("the stub git must be reachable on PATH");
+    assert!(!probe.status.success(), "the stub git should exit non-zero");
+    assert!(
+        marker.exists(),
+        "fixture is broken: running git left no marker, so this test could not \
+         detect a spawn"
+    );
+    std::fs::remove_file(&marker).expect("reset the marker");
+
+    // ── the fix: no subprocess for an unsigned commit ────────────────────────
+    let status = backend
+        .verify_commit(&handle.id, &unsigned_oid)
+        .expect("an unsigned commit must verify without git");
+    assert_eq!(status.state, SigState::None);
+    assert!(status.signer.is_none());
+    assert!(
+        !marker.exists(),
+        "verify_commit spawned git for an UNSIGNED commit — that spawn is the \
+         console flash reported in issue 172, once per commit selected in History"
+    );
+
+    // ── a hex oid that is not in the repository still fails, still no spawn ──
+    let missing = "0".repeat(40);
+    let err = backend
+        .verify_commit(&handle.id, &missing)
+        .expect_err("an unknown object must not read as unsigned");
+    assert!(
+        matches!(err, AppError::InvalidRef(_)),
+        "expected InvalidRef, got {err:?}"
+    );
+    assert!(
+        !marker.exists(),
+        "an unresolvable revision must be refused before anything is spawned"
+    );
+
+    // ── a SIGNED commit still goes to git, and git's message survives ────────
+    let err = backend
+        .verify_commit(&handle.id, &signed_oid)
+        .expect_err("the stub git fails, so this must be an error");
+    assert!(
+        marker.exists(),
+        "a signed commit must still reach `git show --format=%G?` — the \
+         pre-check is not allowed to answer for it"
+    );
+    match err {
+        AppError::Git(msg) => assert!(
+            msg.contains("gpg is not installed"),
+            "git's own message must survive instead of being replaced by an \
+             InvalidRef: {msg}"
+        ),
+        other => panic!("expected AppError::Git carrying git's message, got {other:?}"),
+    }
+}
+
+#[cfg(not(unix))]
+#[test]
+fn an_unsigned_commit_is_verified_without_spawning_git() {
+    eprintln!("PATH-stubbed spawn detection is unix-only — skipping");
+}


### PR DESCRIPTION
Addresses issue 172. **Deliberately left open** — the actual Windows behaviour
needs a Windows release build, and the issue lists exactly what to check.

## What changed

### 1. `verify_commit` no longer spawns anything for an unsigned commit

The reported symptom. `verify_commit` shelled out to
`git show --no-patch --format=%G?` unconditionally; most commits in most
repositories are unsigned, and `SigState::None` renders *no badge*, so the
common case paid a subprocess for a UI element that never appeared — and on
Windows a console flash per commit selected in History.

It now reads the commit's `gpgsig` header through libgit2
(`Repository::extract_signature`, both the `gpgsig` and `gpgsig-sha256`
spellings) and answers `None` with no subprocess. `verify_tag` has had exactly
this pre-check since #132.

**Not a Windows workaround** — a process saved per selection on every platform,
which is why it is first.

Resolving the revision through libgit2 first also folds in the two unrelated
defects the issue found in the same function:

* it set **neither** `GIT_TERMINAL_PROMPT=0` **nor** `stdin(null)` — the only git
  shell-out in `libgit2.rs` to lack both. Both now arrive with `proc::git`.
* on failure it discarded git's message and returned `AppError::InvalidRef(oid)`
  regardless of cause, so **a broken gpg install was reported as a bad object
  id**. It now carries git's own message; an unknown object is still
  `InvalidRef`, now decided *before* anything is spawned.

### 2. `src-tauri/src/proc.rs` — the only sanctioned way to spawn

Constructors, not a `no_window(&mut cmd)` helper, because a helper is what 19 of
20 spawn sites forgot:

| Constructor | Applies |
| --- | --- |
| `git(workdir)` / `git_async(workdir)` | `git -C workdir` + `CREATE_NO_WINDOW` + `GIT_TERMINAL_PROMPT=0` + closed stdin |
| `git_async_in(dir)` | same, but a working directory instead of `-C` — the clone shape, since the repository does not exist yet |
| `program(prog)` / `program_async(prog)` | the flag only, for children that own their stdio (the signing program pipes all three streams) |
| `git_async_keeping_console` / `program_async_keeping_console` | nothing — the two deliberate exceptions below |

`std::process::Command` and `tokio::process::Command` are unrelated types (std's
`creation_flags` comes from the `CommandExt` trait, tokio's is an inherent
`#[cfg(windows)]` method), so each gets its own constructor. The Windows bodies
are `#[cfg(windows)]` with no-op siblings, so all 20 call sites compile
unconditionally.

### 3. All 20 spawn sites routed through it

Silenced (17): `opener.rs` (rundll32 — GUI-subsystem, so the flag is a no-op
there; routed anyway), `cli.rs` (the PowerShell PATH install, which had the flag
hand-rolled and now inherits it), `net.rs` × 2 (`run_git_authenticated` and
`git credential approve`), `create.rs` (clone), `conflict.rs`
(`git checkout --merge`), `forge/token.rs` (`git credential`),
`forge/checkout.rs` (`git rev-parse`), `libgit2.rs` × 6 (`git rebase
--continue/--abort`, the signing program, `git apply`, `git remote prune`,
`git show --format=%G?`, `git verify-tag`, `run_git_capture_env`), `lfs.rs`
(`git lfs version`), `bisect.rs` × 2 (`rev-list --bisect-vars`, `git bisect`).

`detach.rs`'s re-exec is `#[cfg(unix)]`, so it creates no Windows console and is
allow-listed rather than converted.

### 4. The two exceptions, argued rather than omitted

`git mergetool` and `$VISUAL`/`$EDITOR` keep their consoles, via separately
**named** constructors so the inconsistency reads as intentional at the call
site.

The asymmetry that decides it: `EDITOR=vim` and a console mergetool (`vimdiff`)
*are* terminal programs. Silencing one leaves an invisible process holding the
user's file open, with `status().await` never returning and no cancel button
anywhere in the UI. Not silencing costs a console window — for GUI tools a no-op
(the flag does not apply to non-console applications), for console tools the
window they need. A stray console is cosmetic; an invisible editor is Task
Manager. Only one of those two mistakes is recoverable, so we make the other one.
`run_mergetool` is also the path a user reaches *by asking for their own tool* —
platypusgit has its own resolver window for everyone else.

### 5. A guard, so the 21st site cannot regress it

`src-tauri/tests/spawn_no_window.rs`, same shape as `test/docs.test.ts`:

* no `Command::new` outside `src/proc.rs`, with an allow-list carrying each
  exempt file's expected count **and its reason** — so an exception covers what
  it was granted and nothing more;
* the console-keeping constructors are called from exactly the two allow-listed
  sites, each with its rationale on record;
* nobody hand-rolls `creation_flags` again.

Verified to fail: adding a raw spawn to `git/bisect.rs` is caught by name with
what to use instead, and a third `*_keeping_console` call site is caught
demanding a reason in the allow-list.

## Verified here

| Gate | Result |
| --- | --- |
| `cargo check` | clean |
| `cargo test` | 61 test binaries, 0 failures (incl. 3 new guard tests, 1 new no-spawn test, 2 new signing tests) |
| `pnpm tsc --noEmit` | clean |
| `pnpm test` | 1646 passed |
| `pnpm exec tsc -p e2e/tsconfig.json` | clean |
| **no process spawned for an unsigned commit** | proven — a PATH-stubbed `git` records that it ran, proves itself reachable first, and stays untouched. Fails without the pre-check. |
| **a signed commit still verifies** | proven — an ssh-signed commit with an allowed-signers file grades `Good`; a `gpgsig` holding garbage never grades as unsigned |
| **`#[cfg(windows)]` bodies typecheck** | proven against a real `x86_64-pc-windows-msvc` target in an isolated crate (with a negative control), because the crate itself cannot be cross-checked here — libz-sys and vendored openssl need MSVC headers |

E2E deliberately not run: nothing here touches the webview.

## NOT verified — needs a Windows release build

Everything about the actual flash. Listing it rather than claiming it, because a
confident claim about a build nobody ran is how this shipped.

* that the flash is `conhost.exe` for `git.exe` and disappears with the flag;
* **open question:** whether `gpg`/`ssh-keygen` **grandchildren** still flash for
  a *signed* commit once the parent is silenced. Sources disagree on whether
  `CREATE_NO_WINDOW` suppresses a console entirely or merely hides the host
  window, and on whether Git for Windows passes the flag to its own children.
  Not resolved by assertion here. The pre-check removes the common case
  regardless, since it is the *unsigned* path that spawned for nothing;
* that a credentialed fetch/push still authenticates through the askpass shim.
  The reasoning is unchanged — git reads an askpass answer over a pipe it sets
  up, not through a console, and the shim is our own GUI-subsystem binary which
  is never allocated a console anyway — but it wants confirming;
* whether a passphrase-protected gpg key still prompts. Gpg4win's default
  `pinentry-w32` is a GUI dialog and unaffected; a curses pinentry would want a
  terminal this GUI-subsystem process never had one to give. Noted in the code at
  `run_signer`;
* that the PowerShell PATH install is still silent now that its flag comes from
  `proc::program`;
* whether a console `$EDITOR` / mergetool are usable today, which is the evidence
  behind the two exceptions.

Also out of scope and unaudited: `tauri-plugin-updater` spawns the installer
(msiexec/NSIS) inside the plugin, which this crate does not control.

## Not done

The issue's third recommendation — caching verdicts in `useLazyVerification` so
revisiting a commit is free — is untouched and still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Er25sN6pGoVJzmTBwHU2Tz
