### PR TITLE
fix(repo): one RepoId per path when a CLI path is already open (#177)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1312,6 +1312,64 @@ module and every `src/features/*/` directory is named somewhere in here.
   lifetime. Closing an unknown or already-closed id is a silent success by
   contract; `close` deliberately leaves the `rebases` map alone (rehydratable
   from `.git/platypusgit-rebase.json`).
+- **One path is one `RepoId`, and the dedupe happens BEFORE `open_repo`** (issue
+  177). Two producers spell a workdir differently — libgit2's `workdir()` carries
+  a trailing separator, `open` answers without one — and `path` is a tab's
+  identity, so compared raw `/repo/` and `/repo` are two repositories. A launch
+  with a path already in the restored open set therefore opened it twice: the
+  session restore and `useCliLaunch` are two independent openers, and the loser's
+  `RepoId` was left in `useRepoStore.current` after the tab layer evicted it, so
+  every later call answered `UnknownRepo` with no banner (the diff pane silently
+  dead for the session, because `useLazyVerification` swallows its half).
+  Normalize through `git::repo_path_key` (Rust — `open` and
+  `cli::resolve_repo_root` both go through it) and `tabs.ts`'s `repoPathKey`
+  (every path entering the tab layer, `pg-open-repos` included). Note
+  `PathBuf`'s own `==` is component-based and reports the two spellings EQUAL, so
+  a Rust test that compares paths cannot see this — assert on the string form.
+- **`openRepoAt` adopts a handle only if it is still wanted, and closes it
+  otherwise.** It takes a `stillWanted` predicate — REQUIRED, not defaulted —
+  re-asked after `open_repo` resolves and before the first write; `hydrateTab`
+  passes its `stillCurrent(seq)`. A switch to an ALREADY-OPEN tab supersedes an
+  in-flight open without starting one, so the repo store cannot see that for
+  itself, and adopting first and cleaning up afterwards is what made the orphan
+  reachable. A default plus a monotonic `openSeq` counter in the store was tried
+  and REJECTED: it is a second, weaker answer to the question `stillWanted`
+  already answers, no test could tell it apart, and it gets the answer wrong when
+  one activation opens twice — the ownership-trust retry bumps the counter past a
+  concurrent, still-current activation's in-flight open, which is then discarded
+  and its tab marked failed. One authoritative guard, enforced by the signature.
+  `openRepoAt` returns the handle IT opened, never `get().current`: handing back
+  the winner's handle would have the caller evict the live repository as the
+  abandoned one.
+- **Two moments can strand a handle, and each has its own eviction.** Superseded
+  BEFORE adoption is `openRepoAt`'s (above). Superseded DURING the `refreshAll`
+  that follows adoption is `hydrateTab`'s `!stillCurrent(seq)` arm — the store has
+  already answered `stillWanted` by then, and `hydrateTab` returns before
+  recording the `repoId` on the tab, so nothing else could ever reach that handle.
+  A third case is a re-key: only the BACKEND can resolve a symlinked spelling
+  (`/var/x` → `/private/var/x`), so two tabs can still exist for one repository
+  and the surviving one may already hold a live `RepoId` — `hydrateTab` evicts the
+  displaced tab rather than overwriting its id. Every one of the three has a test
+  whose failing path was verified by mutation; an eviction leaks silently, so an
+  untested guard here is indistinguishable from no guard.
+- **`init_repo` answers with a REGISTERED `RepoId`, so `useCreateStore` evicts
+  it.** `Libgit2Backend::init` finishes by calling `self.open` (a handle that is
+  not in the map 404s on the next call), and `runInit` then hands the path to
+  `useTabsStore.openRepo`, which mints a second id for it — every "New
+  repository…" leaked one `git2::Repository` for the process lifetime. Nothing
+  reads that handle past its `path`, so it is closed BEFORE delegating. `clone_repo`
+  is unaffected: it answers with the destination PATH, not a handle. A future
+  command that returns a `RepoHandle` the frontend does not itself adopt inherits
+  this obligation.
+- **Compare paths on the TAB's own key, never the caller's spelling.**
+  `findTab`/`indexOfTab`/`removeTab` normalize, so a caller holding `/repo/` finds
+  the tab and then used to slip past every raw `===` after it: `activate`'s
+  `activating` guard (the one that keeps the launch race down to one open),
+  `close`'s `wasActive` (the tab left the strip while `activePath` went on naming
+  it, so the store sat on a repository it had just evicted) and `closeOthers`'s
+  filter (which matched nothing and closed the repository it was told to keep).
+  `openRepo` forwards its RAW argument to `close` on a failed open, so this is
+  reachable, not hypothetical.
 - **Closing a tab the merge resolver is using confirms first, then closes the
   resolver, then evicts.** The resolver is a separate window driving IPC with that
   `RepoId`, so evicting underneath it would fail its next call with `UnknownRepo`

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -152,7 +152,14 @@ pub fn resolve_repo_root(intent: LaunchIntent) -> LaunchIntent {
     let path = intent.path.map(|p| {
         git2::Repository::discover(&p)
             .ok()
-            .and_then(|r| r.workdir().map(PathBuf::from))
+            // Through `repo_path_key`, because `workdir()` carries a trailing
+            // separator and this path crosses IPC as a STRING that the frontend
+            // compares against the one `open` returns. Spelled `/repo/` here it
+            // matches no open tab, so a launch with a path already in the
+            // restored open set opens the repository a second time and orphans
+            // one of the two `RepoId`s (#177). `PathBuf`'s own `==` is
+            // component-based and hides this — only the string form shows it.
+            .and_then(|r| r.workdir().map(crate::git::repo_path_key))
             // `discover` opens what it finds, so it fails outright on a
             // repository refused for ownership. The walk opens nothing, which
             // is what lets a `pgit` launch from a subdirectory of such a repo
@@ -797,6 +804,27 @@ mod tests {
             screen: None,
         });
         assert_eq!(out.path, Some(root));
+    }
+
+    #[test]
+    fn resolve_repo_root_spells_the_root_exactly_as_open_does() {
+        // libgit2's `workdir()` returns a path WITH a trailing separator, and a
+        // `LaunchIntent.path` crosses IPC as a STRING — so the frontend would
+        // compare "/repo/" against the "/repo" `open` hands back and conclude the
+        // repository is not open yet (#177). `PathBuf`'s own `==` is
+        // component-based and reports the two equal, which is why this has to
+        // assert on the string form.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        git2::Repository::init(&root).unwrap();
+        let sub = root.join("a/b");
+        std::fs::create_dir_all(&sub).unwrap();
+        let out = resolve_repo_root(LaunchIntent {
+            path: Some(sub),
+            screen: None,
+        });
+        let spelled = out.path.unwrap().to_string_lossy().to_string();
+        assert_eq!(spelled, root.to_string_lossy());
     }
 
     #[test]

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -2282,12 +2282,14 @@ impl GitBackend for Libgit2Backend {
         // `workdir()` hands back a path WITH a trailing separator. That makes
         // `/repo` and `/repo/` two different strings for anything that keys on
         // the handle's path — repository tabs (#90) dedupe by it, recents store
-        // it, and a `pgit <path>` launch forwards the slashless form — so the
-        // same repository could open twice under two spellings. Normalize once,
-        // here, rather than at every comparison.
+        // it — so the same repository could open twice under two spellings.
+        // Normalize through the SHARED `repo_path_key`, not a local copy: a
+        // `pgit <path>` launch reads the same `workdir()` in
+        // `cli::resolve_repo_root`, and the two spellings must agree or the
+        // frontend opens the repository a second time (#177).
         let workdir = repo
             .workdir()
-            .map(strip_trailing_slash)
+            .map(super::repo_path_key)
             .unwrap_or_else(|| path.to_path_buf());
 
         let mut map = self

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -29,6 +29,34 @@ use types::{
 };
 
 
+/// The one spelling of a repository's workdir path.
+///
+/// libgit2's `workdir()` hands back a path WITH a trailing separator, so the
+/// same repository has two spellings — `/repo/` and `/repo` — and every
+/// consumer that keys on the path treats them as two repositories: repository
+/// tabs (#90) dedupe by it, recents store it, the `pg-open-repos` session file
+/// persists it.
+///
+/// `open` normalizes through here, and so must every OTHER producer of a
+/// repository path — otherwise two producers disagree, the frontend concludes
+/// the repository is not open yet, and one `git2::Repository` gets opened twice
+/// under two names with two `RepoId`s, one of which nothing will ever close
+/// (#177). The other producer is `cli::resolve_repo_root`, which reads the same
+/// `workdir()`.
+///
+/// A path that is ONLY separators (`/`, or a bare Windows drive root) is left
+/// alone: trimming it yields a different path — `""` or a drive-relative `C:` —
+/// rather than a tidier spelling of the same one.
+pub fn repo_path_key(path: &Path) -> PathBuf {
+    let s = path.to_string_lossy();
+    let trimmed = s.trim_end_matches(['/', '\\']);
+    if trimmed.is_empty() || trimmed.ends_with(':') {
+        return path.to_path_buf();
+    }
+    PathBuf::from(trimmed)
+}
+
+
 pub trait GitBackend: Send + Sync {
     // === existing reads ===
     fn open(&self, path: &Path) -> AppResult<RepoHandle>;
@@ -583,4 +611,33 @@ pub trait GitBackend: Send + Sync {
     /// `git bisect reset` — return to `BISECT_START`. NOT `abort_operation`, which
     /// hard-resets to HEAD and mid-bisect that is a detached test commit.
     fn bisect_reset(&self, repo_id: &RepoId) -> AppResult<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repo_path_key_strips_the_trailing_separator() {
+        // The #177 asymmetry: libgit2's `workdir()` spelling vs `open`'s.
+        assert_eq!(repo_path_key(Path::new("/dev/api/")), PathBuf::from("/dev/api"));
+        assert_eq!(repo_path_key(Path::new("/dev/api//")), PathBuf::from("/dev/api"));
+        assert_eq!(repo_path_key(Path::new("/dev/api")), PathBuf::from("/dev/api"));
+        assert_eq!(
+            repo_path_key(Path::new("C:\\dev\\api\\")),
+            PathBuf::from("C:\\dev\\api")
+        );
+    }
+
+    #[test]
+    fn repo_path_key_leaves_a_separators_only_path_alone() {
+        // Trimming these yields a DIFFERENT path — "" is nothing at all, and a
+        // bare `C:` is drive-RELATIVE — so the tidier spelling would be a lie.
+        // Asserted on the STRING form: `PathBuf`'s own `==` is component-based
+        // and would report `/dev/api/` and `/dev/api` equal, which is exactly
+        // how the trailing separator crossed IPC unnoticed.
+        assert_eq!(repo_path_key(Path::new("/")).to_string_lossy(), "/");
+        assert_eq!(repo_path_key(Path::new("//")).to_string_lossy(), "//");
+        assert_eq!(repo_path_key(Path::new("C:\\")).to_string_lossy(), "C:\\");
+    }
 }

--- a/src/features/create/useCreateStore.init.test.ts
+++ b/src/features/create/useCreateStore.init.test.ts
@@ -1,0 +1,44 @@
+// `init_repo` opens what it just created, so it answers with a REGISTERED
+// RepoId — and the store then hands the path to the tab layer, whose own open
+// mints a SECOND one, because `open` never reuses an entry (only `close_repo`
+// removes one). Unless the handle init answered with is evicted it is a
+// git2::Repository, and its file handles, held for the life of the process:
+// the same leak issue 177 reports, reached through the New-repository door
+// rather than the launch one.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useTabsStore } from "@/features/repo/useTabsStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+
+import { useCreateStore } from "./useCreateStore";
+
+const HANDLE = { id: "repo-init-1", path: "/dev/fresh", head: "main" };
+const calls = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+const openRepo = vi.fn(async () => {});
+
+beforeEach(() => {
+  resetInvokeMock();
+  openRepo.mockClear();
+  useCreateStore.setState({ open: "init", busy: false, progress: null, error: null });
+  // The tab layer's own open is its business (and covered by its own tests);
+  // what this file asserts is that the store does not leave the handle it was
+  // handed behind when it delegates.
+  useTabsStore.setState({ openRepo });
+  mockInvoke("init_repo", () => HANDLE);
+  mockInvoke("close_repo", () => undefined);
+});
+
+describe("useCreateStore.runInit — one RepoId per repository", () => {
+  it("evicts the handle init answered with before delegating to the tab layer", async () => {
+    await useCreateStore.getState().runInit({
+      parentDir: "/dev",
+      name: "fresh",
+      branch: "main",
+    });
+
+    expect(openRepo).toHaveBeenCalledWith("/dev/fresh");
+    expect(calls("close_repo").map((c) => c.args.repoId)).toEqual(["repo-init-1"]);
+    expect(useCreateStore.getState().error).toBeNull();
+    expect(useCreateStore.getState().open).toBe("none");
+  });
+});

--- a/src/features/create/useCreateStore.ts
+++ b/src/features/create/useCreateStore.ts
@@ -7,6 +7,7 @@ import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { useAuthStore } from "@/features/auth/useAuthStore";
 import {
   cloneRepo,
+  closeRepo as closeRepoIpc,
   initRepo,
   rememberCredential,
   trustRepoPath,
@@ -139,7 +140,16 @@ export const useCreateStore = create<CreateState>((set, get) => ({
     const finish = async (handle: RepoHandle) => {
       useSettingsStore.getState().set("lastCreateDir", parentDir);
       set({ busy: false, open: "none" });
-      await useTabsStore.getState().openRepo(handle.path);
+      // `init_repo` goes through `open` so the repository lands in the backend's
+      // map, which means the handle it answers with is a REGISTERED RepoId — and
+      // `openRepo` below mints a second one for the same path, because `open`
+      // never reuses an entry and only `close_repo` removes one. Nothing here
+      // reads the handle past its path, so evict it BEFORE delegating, or it is a
+      // git2::Repository held for the life of the process (issue 177's leak,
+      // through the New-repository door instead of the launch one).
+      const path = handle.path;
+      await closeRepoIpc(handle.id).catch(() => {});
+      await useTabsStore.getState().openRepo(path);
     };
     try {
       await finish(await initRepo(path, branch));

--- a/src/features/repo/tabs.test.ts
+++ b/src/features/repo/tabs.test.ts
@@ -7,9 +7,12 @@ import {
   labelTabs,
   loadOpenRepos,
   newTab,
+  findTab,
+  indexOfTab,
   patchTab,
   removeTab,
   repoDisplayName,
+  repoPathKey,
   saveOpenRepos,
   upsertTab,
   type RepoTab,
@@ -79,6 +82,44 @@ describe("tabs — list reducers", () => {
     it("is null with no tabs", () => {
       expect(cycle([], null, 1)).toBeNull();
     });
+  });
+});
+
+describe("tabs — path identity (#177)", () => {
+  it("one spelling for a repository, whatever the producer wrote", () => {
+    // libgit2's `workdir()` — and so a `pgit <path>` launch intent — carries a
+    // trailing separator; `open_repo` answers without one.
+    expect(repoPathKey("/dev/api/")).toBe("/dev/api");
+    expect(repoPathKey("/dev/api//")).toBe("/dev/api");
+    expect(repoPathKey("C:\\dev\\api\\")).toBe("C:\\dev\\api");
+    expect(repoPathKey("/dev/api")).toBe("/dev/api");
+  });
+
+  it("leaves a separators-only path alone", () => {
+    // Trimming would make these a DIFFERENT path, not a tidier spelling: "" is
+    // nothing, and a bare `C:` is drive-RELATIVE on Windows.
+    expect(repoPathKey("/")).toBe("/");
+    expect(repoPathKey("C:\\")).toBe("C:\\");
+  });
+
+  it("two spellings of one repository are ONE tab", () => {
+    let tabs = [t("/dev/api")];
+    // The bug: this second spelling used to append a second tab, and its open
+    // minted a second RepoId that nothing ever closed.
+    tabs = upsertTab(tabs, t("/dev/api/"));
+    expect(tabs).toHaveLength(1);
+    expect(indexOfTab(tabs, "/dev/api/")).toBe(0);
+    expect(findTab(tabs, "/dev/api/")?.path).toBe("/dev/api");
+    expect(removeTab(tabs, "/dev/api/")).toEqual([]);
+    expect(patchTab(tabs, "/dev/api/", { repoId: "r1" })[0].repoId).toBe("r1");
+  });
+
+  it("a persisted set holding both spellings restores as one repository", () => {
+    localStorage.setItem(
+      OPEN_REPOS_KEY,
+      JSON.stringify({ paths: ["/dev/api", "/dev/api/"], active: "/dev/api/" }),
+    );
+    expect(loadOpenRepos()).toEqual({ paths: ["/dev/api"], active: "/dev/api" });
   });
 });
 

--- a/src/features/repo/tabs.ts
+++ b/src/features/repo/tabs.ts
@@ -41,9 +41,35 @@ export interface RepoTab {
   conflicts: number;
 }
 
+/**
+ * The one spelling of a repository path on this side of the IPC boundary.
+ *
+ * `path` is a tab's identity, and the app receives paths from several producers
+ * that do not agree on their spelling: `open_repo` returns the workdir with its
+ * trailing separator stripped, a `pgit <path>` launch intent used to forward it
+ * WITH one (#177), and a user-typed or dropped path can carry any number of
+ * them. Compared raw, `/repo/` and `/repo` are two repositories — so the second
+ * spelling opened the same repository again, minting a `RepoId` nothing would
+ * ever close and leaving the store pointing at the losing one.
+ *
+ * Every path entering the tab layer goes through here, so no producer's
+ * spelling can split one repository into two tabs. This is deliberately NOT
+ * canonicalisation — a webview cannot resolve symlinks — the backend owns that
+ * and `open`'s answer is what a tab is finally re-keyed onto.
+ *
+ * A path that is only separators is left alone: trimming `/` yields `""`, and
+ * trimming a Windows drive root yields a drive-RELATIVE `C:`, so both would be
+ * a different path rather than a tidier spelling of the same one.
+ */
+export function repoPathKey(path: string): string {
+  const trimmed = path.replace(/[/\\]+$/, "");
+  if (!trimmed || trimmed.endsWith(":")) return path;
+  return trimmed;
+}
+
 export function newTab(path: string, over: Partial<RepoTab> = {}): RepoTab {
   return {
-    path,
+    path: repoPathKey(path),
     repoId: null,
     status: "pending",
     // Every tab starts on History, restored tabs included.
@@ -57,12 +83,14 @@ export function newTab(path: string, over: Partial<RepoTab> = {}): RepoTab {
 
 export function findTab(tabs: RepoTab[], path: string | null): RepoTab | null {
   if (!path) return null;
-  return tabs.find((t) => t.path === path) ?? null;
+  const key = repoPathKey(path);
+  return tabs.find((t) => t.path === key) ?? null;
 }
 
 export function indexOfTab(tabs: RepoTab[], path: string | null): number {
   if (!path) return -1;
-  return tabs.findIndex((t) => t.path === path);
+  const key = repoPathKey(path);
+  return tabs.findIndex((t) => t.path === key);
 }
 
 /**
@@ -70,10 +98,11 @@ export function indexOfTab(tabs: RepoTab[], path: string | null): number {
  * re-opening a repository must not shuffle the strip under the user's cursor.
  */
 export function upsertTab(tabs: RepoTab[], patch: RepoTab): RepoTab[] {
-  const i = indexOfTab(tabs, patch.path);
-  if (i < 0) return [...tabs, patch];
+  const entry = { ...patch, path: repoPathKey(patch.path) };
+  const i = indexOfTab(tabs, entry.path);
+  if (i < 0) return [...tabs, entry];
   const next = [...tabs];
-  next[i] = { ...next[i], ...patch };
+  next[i] = { ...next[i], ...entry };
   return next;
 }
 
@@ -86,12 +115,19 @@ export function patchTab(
   const i = indexOfTab(tabs, path);
   if (i < 0) return tabs;
   const next = [...tabs];
-  next[i] = { ...next[i], ...patch };
+  // A re-key (`open` answered with a different spelling) goes through the same
+  // normalisation as any other incoming path.
+  next[i] = {
+    ...next[i],
+    ...patch,
+    ...(patch.path === undefined ? {} : { path: repoPathKey(patch.path) }),
+  };
   return next;
 }
 
 export function removeTab(tabs: RepoTab[], path: string): RepoTab[] {
-  return tabs.filter((t) => t.path !== path);
+  const key = repoPathKey(path);
+  return tabs.filter((t) => t.path !== key);
 }
 
 /**
@@ -170,17 +206,22 @@ export function loadOpenRepos(): OpenRepos {
     const parsed = JSON.parse(raw) as unknown;
     if (!parsed || typeof parsed !== "object") return { paths: [], active: null };
     const rec = parsed as Record<string, unknown>;
+    // Normalize on the way in, and dedupe AFTER: a set written by an older
+    // build (or by two producers disagreeing about the trailing separator) can
+    // hold the same repository twice under two spellings, and restoring both
+    // would open it twice — the very thing #177 was.
     const paths = Array.isArray(rec.paths)
       ? Array.from(
           new Set(
-            rec.paths.filter((p): p is string => typeof p === "string" && !!p),
+            rec.paths
+              .filter((p): p is string => typeof p === "string" && !!p)
+              .map(repoPathKey),
           ),
         ).slice(0, OPEN_LIMIT)
       : [];
+    const activeKey = typeof rec.active === "string" ? repoPathKey(rec.active) : null;
     const active =
-      typeof rec.active === "string" && paths.includes(rec.active)
-        ? rec.active
-        : (paths[0] ?? null);
+      activeKey && paths.includes(activeKey) ? activeKey : (paths[0] ?? null);
     return { paths, active };
   } catch {
     return { paths: [], active: null };
@@ -189,10 +230,11 @@ export function loadOpenRepos(): OpenRepos {
 
 export function saveOpenRepos(tabs: RepoTab[], active: string | null): void {
   try {
-    const paths = tabs.map((t) => t.path).slice(0, OPEN_LIMIT);
+    const paths = tabs.map((t) => repoPathKey(t.path)).slice(0, OPEN_LIMIT);
+    const activeKey = active ? repoPathKey(active) : null;
     const value: OpenRepos = {
       paths,
-      active: active && paths.includes(active) ? active : (paths[0] ?? null),
+      active: activeKey && paths.includes(activeKey) ? activeKey : (paths[0] ?? null),
     };
     localStorage.setItem(OPEN_REPOS_KEY, JSON.stringify(value));
   } catch {

--- a/src/features/repo/useRepoStore.ownership.test.ts
+++ b/src/features/repo/useRepoStore.ownership.test.ts
@@ -42,7 +42,7 @@ describe("useRepoStore.openRepo — dubious ownership", () => {
     armOpen(1);
     confirmTrust.mockResolvedValue(true);
 
-    await useRepoStore.getState().openRepoAt("/mnt/c/dev/reponame");
+    await useRepoStore.getState().openRepoAt("/mnt/c/dev/reponame", () => true);
 
     expect(confirmTrust).toHaveBeenCalledWith("/mnt/c/dev/reponame");
     expect(calls("trust_repo_path")).toHaveLength(1);
@@ -65,7 +65,7 @@ describe("useRepoStore.openRepo — dubious ownership", () => {
     });
     confirmTrust.mockResolvedValue(true);
 
-    await useRepoStore.getState().openRepoAt("/mnt/c/dev/reponame/");
+    await useRepoStore.getState().openRepoAt("/mnt/c/dev/reponame/", () => true);
 
     expect(confirmTrust).toHaveBeenCalledWith("/mnt/c/dev/reponame");
     expect(calls("trust_repo_path")[0]?.args).toMatchObject({
@@ -77,7 +77,7 @@ describe("useRepoStore.openRepo — dubious ownership", () => {
     armOpen(1);
     confirmTrust.mockResolvedValue(false);
 
-    await useRepoStore.getState().openRepoAt("/mnt/c/dev/reponame");
+    await useRepoStore.getState().openRepoAt("/mnt/c/dev/reponame", () => true);
 
     expect(calls("trust_repo_path")).toHaveLength(0);
     expect(useRepoStore.getState().error?.kind).toBe("DubiousOwnership");
@@ -89,7 +89,7 @@ describe("useRepoStore.openRepo — dubious ownership", () => {
     armOpen(99);
     confirmTrust.mockResolvedValue(true);
 
-    await useRepoStore.getState().openRepoAt("/mnt/c/dev/reponame");
+    await useRepoStore.getState().openRepoAt("/mnt/c/dev/reponame", () => true);
 
     // One prompt, one retry — never a second round.
     expect(confirmTrust).toHaveBeenCalledTimes(1);
@@ -105,7 +105,7 @@ describe("useRepoStore.openRepo — dubious ownership", () => {
       throw { kind: "Io", message: "permission denied" };
     });
 
-    await useRepoStore.getState().openRepoAt("/mnt/c/dev/reponame");
+    await useRepoStore.getState().openRepoAt("/mnt/c/dev/reponame", () => true);
 
     expect(useRepoStore.getState().error?.kind).toBe("Io");
     expect(useRepoStore.getState().loading).toBe(false);
@@ -116,7 +116,7 @@ describe("useRepoStore.openRepo — dubious ownership", () => {
       throw { kind: "NotARepo", message: "path is not a git repository: /tmp/x" };
     });
 
-    await useRepoStore.getState().openRepoAt("/tmp/x");
+    await useRepoStore.getState().openRepoAt("/tmp/x", () => true);
 
     expect(confirmTrust).not.toHaveBeenCalled();
     expect(useRepoStore.getState().error?.kind).toBe("NotARepo");

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -56,6 +56,7 @@ import {
   markResolved,
   mergeBranch as mergeBranchFn,
   openRepo,
+  closeRepo as closeRepoIpc,
   trustRepoPath,
   pruneRemote,
   pull as pullRemote,
@@ -141,7 +142,28 @@ interface RepoStoreState extends RepoSlice {
    * `useTabsStore.openRepo` is the entry point everything else calls — it
    * dedupes by path, creates the tab, and snapshots the outgoing one.
    */
-  openRepoAt: (path: string) => Promise<RepoHandle | null>;
+  /**
+   * Open `path` and adopt it as the live repository.
+   *
+   * `stillWanted` is re-asked AFTER the open resolves and BEFORE anything is
+   * written: only the caller knows whether the user has moved on in the
+   * meantime, and adopting a repository nobody is looking at is what left the
+   * store holding a handle the tab layer then evicted (#177). Answer `false`
+   * and the handle is closed and `null` returned, with the slice untouched.
+   *
+   * REQUIRED, deliberately: the store cannot answer this question for itself,
+   * and a caller that omitted the predicate would silently reinstate the bug.
+   * A default (`() => true`) plus a counter in here was tried and dropped — the
+   * counter is a second, weaker answer to the same question, and it gets the
+   * answer WRONG when one activation opens twice: the ownership-trust retry
+   * bumps it past a concurrent, still-current activation's in-flight open, which
+   * is then discarded and its tab marked failed. One authoritative guard,
+   * enforced by the signature.
+   */
+  openRepoAt: (
+    path: string,
+    stillWanted: () => boolean,
+  ) => Promise<RepoHandle | null>;
   /** Replace every per-repo field with `slice` (activating a tab). Total write
    *  by contract — see repoSlice.ts. */
   hydrate: (slice: RepoSlice) => void;
@@ -389,23 +411,53 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       return { activity: next };
     });
   };
-  /** Open `path` into a freshly reset slice. Throws on failure. */
-  const applyOpenedRepo = async (path: string) => {
+  /**
+   * Open `path` into a freshly reset slice. Throws on failure.
+   *
+   * Answers null WITHOUT writing anything when the open turned out to be
+   * unwanted by the time it resolved. `open_repo` mints a fresh `RepoId` per
+   * call and only `close_repo` ever removes one, so two opens in flight at once
+   * (a session restore racing a `pgit <path>` launch intent, #177) are two live
+   * `git2::Repository`s of which exactly one is wanted. Whichever RESOLVED last
+   * used to win `current` regardless of which was asked for last — so the
+   * loser's handle became the store's open repository and was then evicted by
+   * the tab layer, leaving every later call answering `UnknownRepo` for the rest
+   * of the session with no banner to explain it (the diff pane silently dead,
+   * because `useLazyVerification` swallows its half).
+   *
+   * The guard sits BEFORE the first write on purpose: adopting first and
+   * cleaning up afterwards is exactly what made the orphan reachable.
+   */
+  const applyOpenedRepo = async (
+    path: string,
+    stillWanted: () => boolean,
+  ): Promise<RepoHandle | null> => {
     const handle = await openRepo(path);
+    if (!stillWanted()) {
+      // Nobody will ever use this handle and `open` never evicts on its own, so
+      // close it here — this is the only moment at which it is both known to be
+      // unwanted and still known at all.
+      void closeRepoIpc(handle.id).catch(() => {});
+      return null;
+    }
     useRecentsStore.getState().addRecent(handle.path);
     // Total write: every per-repo field is reset, so nothing of the previously
     // open repository can survive into this one (see repoSlice.ts).
     set({ ...emptySlice(), current: handle });
     await get().refreshAll();
+    return handle;
   };
   return ({
   ...emptySlice(),
 
-  async openRepoAt(path) {
+  async openRepoAt(path, stillWanted) {
     set({ loading: true, error: null });
     try {
-      await applyOpenedRepo(path);
-      return get().current;
+      // The handle THIS call opened, never `get().current`: a superseded open
+      // resolves with the winner's repository sitting in `current`, and handing
+      // that back would have the caller evict the live repository as if it were
+      // the abandoned one (#177).
+      return await applyOpenedRepo(path, stillWanted);
     } catch (e) {
       // git refuses a repository owned by another user, which a Windows drive
       // mounted under WSL routinely looks like. That refusal is remediable,
@@ -420,8 +472,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
             await trustRepoPath(target);
             // Deliberately not recursive: one retry. If the exception did not
             // help, show the error rather than asking again forever.
-            await applyOpenedRepo(path);
-            return get().current;
+            return await applyOpenedRepo(path, stillWanted);
           } catch (retryError) {
             set({ loading: false, error: toAppError(retryError) });
             return null;

--- a/src/features/repo/useTabsStore.cliLaunch.test.tsx
+++ b/src/features/repo/useTabsStore.cliLaunch.test.tsx
@@ -1,0 +1,134 @@
+// The launch path, where TWO independent openers run at once (#177).
+//
+// A `pgit <path>` launch stashes an intent that `useCliLaunch` takes on mount,
+// and `AppShell` restores `pg-open-repos` in the very next effect. Neither
+// opener reproduces the bug alone — that is the whole point of driving both here
+// — so the Probe below mirrors AppShell's effect ORDER rather than testing the
+// two stores separately:
+//
+//   useCliLaunch();                                  // registered first
+//   useEffect(() => { restoreSession(); }, []);      // runs second
+//
+// `open_repo` mints a DISTINCT id per call, exactly as the backend does, so a
+// second open is visible as a second `RepoId` — and a `RepoId` nothing closes is
+// a `git2::Repository` held for the life of the process.
+
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { useCliLaunch } from "@/features/cli/useCliLaunch";
+import { emptySlice } from "./repoSlice";
+import { OPEN_REPOS_KEY, repoPathKey } from "./tabs";
+import { useRepoStore } from "./useRepoStore";
+import { useTabsStore } from "./useTabsStore";
+
+/** Mirrors AppShell: the CLI hook's effect is registered before the restore. */
+function Probe() {
+  useCliLaunch();
+  React.useEffect(() => {
+    void useTabsStore.getState().restoreSession();
+  }, []);
+  return null;
+}
+
+let nextId = 0;
+/** Gate keyed by the path asked for, so one open can be made to resolve last. */
+let gates: Record<string, Promise<void>> = {};
+
+function armBackend() {
+  nextId = 0;
+  gates = {};
+  mockInvoke("open_repo", async (args) => {
+    const asked = args.path as string;
+    await gates[asked];
+    // What the real backend answers: a fresh RepoId every call, and the workdir
+    // in ITS spelling — trailing separator stripped (git/mod.rs::repo_path_key).
+    return { id: `r-${++nextId}`, path: repoPathKey(asked), head: "main" };
+  });
+  mockInvoke("close_repo", () => undefined);
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => null);
+  mockInvoke("list_all_files", () => []);
+}
+
+function seedOpenRepos(paths: string[], active: string) {
+  localStorage.setItem(OPEN_REPOS_KEY, JSON.stringify({ paths, active }));
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  resetInvokeMock();
+  armBackend();
+  useTabsStore.setState({
+    tabs: [],
+    activePath: null,
+    activationSeq: 0,
+    activating: null,
+  });
+  useRepoStore.setState(emptySlice());
+});
+
+const calls = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+const closedIds = () => calls("close_repo").map((c) => c.args.repoId as string);
+
+describe("launch: a CLI path already in the restored open set", () => {
+  it("opens the repository ONCE, even spelled with a trailing separator", async () => {
+    seedOpenRepos(["/dev/api"], "/dev/api");
+    // The spelling `resolve_repo_root` produced before #177: libgit2's
+    // `workdir()`, trailing separator and all. Compared raw it matches no tab.
+    mockInvoke("take_launch_intent", () => ({ path: "/dev/api/", screen: null }));
+
+    render(<Probe />);
+    // Settle: a repository is live and nothing is still loading. Deliberately
+    // NOT "the first tab is open" — under a duplicate open the strip passes
+    // through states where that is briefly true, and the count below is the
+    // assertion that matters.
+    await waitFor(() => {
+      expect(useRepoStore.getState().current).not.toBeNull();
+      expect(useRepoStore.getState().loading).toBe(false);
+    });
+
+    expect(calls("open_repo")).toHaveLength(1);
+    expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual(["/dev/api"]);
+    // Nothing to clean up, because nothing was opened twice.
+    expect(closedIds()).toEqual([]);
+    // And the store points at the repository the tab holds — the symptom was a
+    // `current` the backend had already forgotten (`UnknownRepo` per click).
+    const live = useRepoStore.getState().current;
+    expect(live?.id).toBe(useTabsStore.getState().tabs[0].repoId);
+    expect(closedIds()).not.toContain(live?.id);
+  });
+
+  it("leaves no orphan when the two openers ask for DIFFERENT repositories", async () => {
+    // The restore's open resolves LAST — the ordering that used to leave the
+    // store holding a handle the tab layer then evicted.
+    let release = () => {};
+    gates["/dev/api"] = new Promise<void>((res) => {
+      release = res;
+    });
+    seedOpenRepos(["/dev/api"], "/dev/api");
+    mockInvoke("take_launch_intent", () => ({ path: "/dev/web", screen: null }));
+
+    render(<Probe />);
+    await waitFor(() => expect(useTabsStore.getState().activePath).toBe("/dev/web"));
+    const winner = useRepoStore.getState().current?.id;
+    expect(winner).toBeTruthy();
+
+    release();
+    await waitFor(() => expect(calls("open_repo")).toHaveLength(2));
+    await waitFor(() => expect(closedIds()).toHaveLength(1));
+
+    // The loser is evicted; the winner is untouched and still the live repo.
+    expect(useRepoStore.getState().current?.id).toBe(winner);
+    expect(closedIds()).not.toContain(winner);
+    expect(useTabsStore.getState().activePath).toBe("/dev/web");
+  });
+});

--- a/src/features/repo/useTabsStore.test.ts
+++ b/src/features/repo/useTabsStore.test.ts
@@ -3,7 +3,7 @@
 // repository you left must not land in the one you arrived at, and a failed open
 // must leave the tab you were on intact.
 
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
 import { REPO_SLICE_KEYS, emptySlice } from "./repoSlice";
@@ -184,6 +184,112 @@ describe("useTabsStore — concurrent opens", () => {
     // The abandoned handle must be closed — `open` never evicts on its own.
     expect(calls("close_repo").map((c) => c.args.repoId)).toContain("r-web");
     expect(useTabsStore.getState().activePath).toBe("/dev/api");
+  });
+
+  it("evicts the handle when the switch lands DURING the refresh that follows the open", async () => {
+    // The SECOND moment a superseded open needs cleaning up, and the one the
+    // repo store's own `stillWanted` guard cannot cover: the handle has already
+    // been adopted and `refreshAll` is in flight, so the switch arrives after
+    // the last question the store gets to ask. `hydrateTab` then returns before
+    // recording the repoId on the tab, so nothing else can ever reach this
+    // handle — it is a git2::Repository held for the life of the process.
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+    await useTabsStore.getState().activate("/dev/api");
+    // Back to pending, so re-entering /dev/web opens the repository rather than
+    // replaying its frozen slice.
+    useTabsStore.setState((s) => ({
+      tabs: s.tabs.map((t) =>
+        t.path === "/dev/web"
+          ? { ...t, status: "pending", slice: null, repoId: null }
+          : t,
+      ),
+    }));
+
+    // Hold the REFRESH, not the open: that is what puts the supersession after
+    // the adoption instead of before it.
+    let release = () => {};
+    mockInvoke("get_status", async (args) => {
+      if (args.repoId === "r-web") {
+        await new Promise<void>((res) => {
+          release = res;
+        });
+      }
+      return STATUS[args.repoId as string] ?? [];
+    });
+
+    const pending = useTabsStore.getState().activate("/dev/web");
+    // Adopted: `current` is the new handle, mid-refresh.
+    await vi.waitFor(() =>
+      expect(useRepoStore.getState().current?.id).toBe("r-web"),
+    );
+    await useTabsStore.getState().activate("/dev/api");
+    release();
+    await pending;
+
+    expect(calls("close_repo").map((c) => c.args.repoId)).toEqual(["r-web"]);
+    expect(useTabsStore.getState().activePath).toBe("/dev/api");
+    expect(useRepoStore.getState().current?.id).toBe("r-api");
+    // Nothing recorded the evicted id, which is why only this branch can free it.
+    expect(
+      useTabsStore.getState().tabs.find((t) => t.path === "/dev/web")?.repoId,
+    ).toBeNull();
+  });
+});
+
+describe("useTabsStore — one RepoId per repository (#177)", () => {
+  it("evicts the handle a re-key displaces", async () => {
+    // Only the BACKEND can resolve a symlinked spelling, so the frontend cannot
+    // know these are one repository until `open` answers — and then the tab it
+    // re-keys onto already holds a live RepoId of its own.
+    mockInvoke("open_repo", (args) => {
+      const asked = args.path as string;
+      const canonical = asked === "/dev/link" ? "/dev/real" : asked;
+      return { id: `r-${asked}`, path: canonical, head: "main" };
+    });
+
+    await useTabsStore.getState().openRepo("/dev/real");
+    expect(useTabsStore.getState().tabs[0].repoId).toBe("r-/dev/real");
+
+    await useTabsStore.getState().openRepo("/dev/link");
+
+    // One tab, the newer RepoId — and the displaced one closed rather than left
+    // holding a git2::Repository for the life of the process.
+    expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual(["/dev/real"]);
+    expect(useTabsStore.getState().tabs[0].repoId).toBe("r-/dev/link");
+    expect(calls("close_repo").map((c) => c.args.repoId)).toEqual(["r-/dev/real"]);
+    expect(useRepoStore.getState().current?.id).toBe("r-/dev/link");
+  });
+
+  it("closes and keeps the TAB, not the caller's spelling of it", async () => {
+    // `openRepo`'s own failed-open cleanup forwards the raw argument, so a
+    // producer's `/repo/` reaches `close` directly. Compared raw, the tab was
+    // removed while `activePath` stayed pointing at it — and `current` was left
+    // holding the repository just evicted, which is the #177 symptom arrived at
+    // from the other direction.
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+    await useTabsStore.getState().close("/dev/web/");
+    expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual(["/dev/api"]);
+    expect(useTabsStore.getState().activePath).toBe("/dev/api");
+    expect(useRepoStore.getState().current?.id).toBe("r-api");
+  });
+
+  it("keeps the right tab when closeOthers is named with another spelling", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+    await useTabsStore.getState().closeOthers("/dev/api/");
+    expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual(["/dev/api"]);
+    expect(useTabsStore.getState().activePath).toBe("/dev/api");
+    expect(useRepoStore.getState().current?.id).toBe("r-api");
+  });
+
+  it("focuses the tab instead of re-opening when the spelling only differs by a trailing separator", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/api/");
+    expect(calls("open_repo")).toHaveLength(1);
+    expect(useTabsStore.getState().tabs).toHaveLength(1);
+    expect(calls("close_repo")).toHaveLength(0);
   });
 });
 

--- a/src/features/repo/useTabsStore.ts
+++ b/src/features/repo/useTabsStore.ts
@@ -12,11 +12,17 @@
 //   2. write the incoming tab's frozen slice as a WHOLE (repoSlice.ts),
 //   3. refresh, because a cached view is not disk truth.
 //
-// Two guards keep concurrency honest:
+// Four guards keep concurrency honest, and #177 is what each of the last three
+// costs when it is missing:
 //   - `activationSeq` — bumped on every activate/open, re-checked after each
 //     await, so a session restore racing a forwarded CLI launch cannot both win.
 //   - `useRepoStore`'s own `setFor`, which drops a fetch that resolved after the
 //     user moved on.
+//   - `repoPathKey` (tabs.ts) — path identity, so two producers spelling one
+//     workdir differently cannot open the repository twice.
+//   - the `stillWanted` predicate handed to `openRepoAt`, re-asked at the moment
+//     the open resolves: a switch to an already-open tab supersedes an in-flight
+//     open without starting one, which the repo store cannot see for itself.
 
 import { create } from "zustand";
 
@@ -42,6 +48,7 @@ import {
   newTab,
   patchTab,
   removeTab,
+  repoPathKey,
   saveOpenRepos,
   upsertTab,
   type RepoTab,
@@ -60,6 +67,11 @@ interface TabsState {
    * Open `path` in a tab: focuses the existing tab when the path is already
    * open, otherwise opens the repository and appends a tab. The single entry
    * point for opening a repository anywhere in the app.
+   *
+   * "Already open" is decided on the NORMALIZED path (`repoPathKey`), so two
+   * producers spelling one repository differently — a restored `pg-open-repos`
+   * entry and a `pgit <path>` launch intent, say — focus one tab instead of
+   * opening the repository twice (#177).
    */
   openRepo: (path: string) => Promise<void>;
   /** Make the tab at `path` active, opening it if it is still pending. */
@@ -132,14 +144,23 @@ export const useTabsStore = create<TabsState>((set, get) => {
     set({ activating: tab.path });
     let handle: RepoHandle | null = null;
     try {
-      handle = await useRepoStore.getState().openRepoAt(tab.path);
+      // The predicate is re-asked at the moment the open resolves, before the
+      // repo store adopts it: a switch to an ALREADY-OPEN tab supersedes this
+      // open without starting one of its own, so the store cannot see that for
+      // itself and would otherwise make this handle `current` after the winner
+      // had already hydrated (#177). It then closes the handle and answers null.
+      handle = await useRepoStore
+        .getState()
+        .openRepoAt(tab.path, () => stillCurrent(seq));
     } finally {
       if (get().activating === tab.path) set({ activating: null });
     }
     if (!stillCurrent(seq)) {
-      // Superseded mid-open (the user moved to another tab). Nobody will ever
-      // use this handle, and `open` never evicts on its own — so evict it here
-      // or it is a leaked git2::Repository for the rest of the session.
+      // Superseded AFTER the adoption (the refresh inside the open is awaited,
+      // so the user can move on during it). `current` has since been overwritten
+      // by whoever superseded us, so the handle is unreachable — and `open`
+      // never evicts on its own, so evict it here or it is a leaked
+      // git2::Repository for the rest of the session.
       if (handle) {
         void closeRepoIpc(handle.id).catch(() => {});
       }
@@ -153,6 +174,15 @@ export const useTabsStore = create<TabsState>((set, get) => {
     // `open` returns the canonicalised workdir, which may differ from the path
     // we asked for. Re-key the tab onto it, dropping any tab that already had it.
     const resolved = handle.path;
+    // That drop is where the LAST orphan lived. `repoPathKey` settles every
+    // spelling the frontend can settle, but only the backend can resolve a
+    // symlinked one (`/var/x` → `/private/var/x` on macOS), so two tabs can still
+    // exist for one repository — and re-keying used to overwrite the surviving
+    // tab's `repoId` with this one, abandoning a `git2::Repository` for the rest
+    // of the process. Evict it: this is the "close the loser when the duplicate
+    // open could not be prevented" case, and it is the only one left.
+    const displaced = resolved === tab.path ? null : findTab(get().tabs, resolved);
+    if (displaced?.repoId && displaced.repoId !== handle.id) evict(displaced);
     set((s) => {
       let tabs = s.tabs;
       if (resolved !== tab.path && indexOfTab(tabs, resolved) >= 0) {
@@ -223,15 +253,20 @@ export const useTabsStore = create<TabsState>((set, get) => {
     async activate(path) {
       const tab = findTab(get().tabs, path);
       if (!tab) return;
+      // Every comparison below is against `tab.path`, the NORMALIZED key, never
+      // the caller's spelling of it: `findTab` normalizes, so a caller holding
+      // `/repo/` finds the tab and then slipped past both guards (#177). The
+      // first of them is what keeps the launch race down to one open.
+      //
       // An open for this very tab is already in flight — a second one would
       // mint a second RepoId for the same repository and leak the loser.
-      if (get().activating === path) return;
+      if (get().activating === tab.path) return;
       // Already active AND actually loaded: nothing to do. The `current` check
       // is not redundant — it is the invariant. Without it, a tab the store no
       // longer holds (a store reset, a failed reopen) would look live and the
       // app would sit on an empty slice forever.
       if (
-        get().activePath === path &&
+        get().activePath === tab.path &&
         tab.status === "open" &&
         useRepoStore.getState().current?.id === tab.repoId
       ) {
@@ -239,7 +274,7 @@ export const useTabsStore = create<TabsState>((set, get) => {
       }
       const seq = beginActivation();
       const outgoing = get().activePath;
-      if (outgoing && outgoing !== path) snapshotInto(outgoing);
+      if (outgoing && outgoing !== tab.path) snapshotInto(outgoing);
       await hydrateTab(tab, seq);
     },
 
@@ -266,12 +301,16 @@ export const useTabsStore = create<TabsState>((set, get) => {
         await closeMergeWindow();
       }
       // Re-read: the confirm above is an await, and the strip may have moved.
+      // Keyed on `target.path` throughout, for the reason `activate` gives:
+      // `openRepo`'s failed-open cleanup forwards its RAW argument here, so a
+      // `/repo/` would have been removed from the strip while `activePath` went
+      // on naming it — leaving the store on a repository this call just evicted.
       const tabs = get().tabs;
-      const idx = indexOfTab(tabs, path);
+      const idx = indexOfTab(tabs, target.path);
       if (idx < 0) return;
       evict(tabs[idx]);
-      const remaining = removeTab(tabs, path);
-      const wasActive = get().activePath === path;
+      const remaining = removeTab(tabs, target.path);
+      const wasActive = get().activePath === target.path;
       if (!wasActive) {
         set({ tabs: remaining });
         persist();
@@ -290,10 +329,13 @@ export const useTabsStore = create<TabsState>((set, get) => {
     },
 
     async closeOthers(keepPath) {
-      for (const t of get().tabs.filter((t) => t.path !== keepPath)) {
+      // Normalized first: an unnormalized spelling matches no tab, so the filter
+      // kept nothing and this closed the repository it was asked to keep (#177).
+      const keep = repoPathKey(keepPath);
+      for (const t of get().tabs.filter((t) => t.path !== keep)) {
         await get().close(t.path);
       }
-      await get().activate(keepPath);
+      await get().activate(keep);
     },
 
     async closeAll() {


### PR DESCRIPTION
Addresses the double-open reported in issue 177: launching with a repository path
already in the restored open set opened it twice, minting two backend `RepoId`s
for one path, and the frontend kept referencing the loser — so every commit
selection answered `UnknownRepo` on `diff_commit` / `verify_commit` with no
banner (the diff pane silently dead for the session), while the orphaned id held
a `git2::Repository` for the life of the process.

## Where the asymmetry actually is

Measured on macOS, not assumed. Both `Repository::open` and `Repository::discover`
already expand symlinks identically (`/var/…` → `/private/var/…`), so the
`/private` prefix the report flags as a suspect is **not** the cause — the two
producers agree on it. What they disagreed on is the trailing separator:
libgit2's `workdir()` returns `/repo/`, `open_repo` stripped it, and
`cli::resolve_repo_root` did not. Compared raw, the launch intent's `/repo/`
matched no tab in the restored `/repo` open set.

That canonicalisation lives inside libgit2, which is why grepping our own tree
for `canonicalize` on the repo path finds nothing.

`PathBuf`'s own `==` is component-based and reports `/repo/` and `/repo` **equal**,
so a Rust test that compares paths cannot see this. The pre-existing sibling test
does exactly that and passes against the bug; the new one asserts on the string
form.

## Second bug, same launch

Deduping is not sufficient. `openRepoAt` returned `get().current` rather than the
handle it had opened, and wrote `current` whenever its open landed — so with two
opens in flight the late loser overwrote the live repository *and* handed the
caller the winner's handle to evict. That is the dead `current` in the report.
This prevents adoption rather than cleaning up after it: a required `stillWanted`
predicate, re-asked once the open lands and before the first write.

## The bug is wider than reported

Auditing whether an orphan was still reachable turned up three more doors, none
of them in the report:

- **`init_repo` leaks on every "New repository…".** `Libgit2Backend::init`
  finishes by calling `self.open`, so its `RepoHandle` is a registered `RepoId`;
  `runInit` then handed the path to `useTabsStore.openRepo`, which minted a
  second one. (`clone_repo` is unaffected — it answers with a path, not a handle.)
- **A backend re-key overwrote a live `repoId`.** Only the backend can expand a
  symlinked spelling, so two tabs for one repository stay possible; `hydrateTab`
  now evicts the tab it displaces.
- **A switch landing during the refresh that follows adoption** — the one moment
  `stillWanted` cannot cover — had an eviction on `main` with **no test at all**.

Plus three raw path comparisons that survived the dedupe: `activate`'s
`activating` guard (the one keeping the launch race down to one open), `close`'s
`wasActive` (the tab left the strip while `activePath` went on naming it, so the
store sat on a repository it had just evicted) and `closeOthers`'s filter (which
matched nothing and closed the repository it was told to keep). `openRepo`
forwards its raw argument to `close` on a failed open, so these are reachable,
not hypothetical.

## Mutation-checked, both halves

Every guard was reverted individually against the final tree and the suite re-run.

Dedupe:

| mutant | failing tests |
| --- | --- |
| `cli::resolve_repo_root` stops normalizing | 1 (`resolve_repo_root_spells_the_root_exactly_as_open_does`) |
| `tabs.ts::repoPathKey` becomes the identity | 7 |

Eviction — the half with no symptom when it regresses:

| mutant | failing tests |
| --- | --- |
| `openRepoAt` drops the close | 2 |
| `openRepoAt` drops the whole guard | 1 (`current` is the loser, `r-2` not `r-1`) |
| `hydrateTab` drops the post-adoption close | 1 |
| `hydrateTab` drops the displaced-tab close | 1 |
| `runInit` drops the init-handle close | 1 |

The regression test drives **both openers together** —
`useTabsStore.cliLaunch.test.tsx` mirrors AppShell's effect order (`useCliLaunch`
registered first, `restoreSession` second) with `open_repo` minting a distinct id
per call, because neither opener reproduces this alone.

## Rejected from the inherited work

A monotonic `openSeq` counter in `useRepoStore`. No test could tell it apart from
`stillWanted`, and it answers wrongly when one activation opens twice: the
ownership-trust retry bumps it past a concurrent, still-current activation's
in-flight open, which is then discarded and its tab marked failed. Making
`stillWanted` a required parameter removes the "future caller forgets it" hole at
compile time, which is what the counter was really for. CLAUDE.md records it as
rejected so it is not re-derived as an obvious improvement.

## Not a backend op

`git::repo_path_key` is a free function shared by two existing producers. The
`GitBackend` trait is unchanged, no command was added, and nothing new crosses
IPC — so the six-step path does not apply and `test/docs.test.ts` needs no new
name.

## Verification

`pnpm tsc --noEmit`, `pnpm exec tsc -p e2e/tsconfig.json --noEmit`,
`cargo check` — all clean. `pnpm test` 1661 passed / 195 files.
`cargo test` 666 passed, 0 failed.

No e2e run: this is reproducible at the store level, and an e2e harness cannot
easily stage "a restored tab plus a CLI launch intent" — the launch intent is
consumed once, before the window the driver can reach. No spec added for that
reason.

## Left alone, deliberately

`restoreSession` early-returns when a tab already exists, so a CLI launch that
won the race would drop the rest of the persisted open set (and `persist()` would
then overwrite it). AppShell's effect order means restore always wins today, and
this is a different bug from the one under discussion — worth its own issue rather
than a drive-by here.
