### PR TITLE
feat(history): check out a commit's own branch from its context menu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -602,9 +602,11 @@ features/            Per-feature: components + Zustand store colocated
 │                    because branches cut from one commit share a tip time and
 │                    that tiebreaker must not depend on the runtime's ICU data).
 │                    EVERY branch list goes through it — picker, Branches screen,
-│                    palette rows; a second ordering is how those three drifted
-│                    apart before. `isHead` is deliberately NOT a sort key: the
-│                    current branch is the one branch the picker exists to leave
+│                    palette rows, the commit menu's "check out the branch that is
+│                    on this commit" group (#179); a second ordering is how the
+│                    first three drifted apart before. `isHead` is deliberately
+│                    NOT a sort key: the current branch is the one branch the
+│                    picker exists to leave
 ├── commits/         The log's pure logic, all tested: graphLayout + laneColors +
 │                    graphAncestry + rowIdentity (the graph — #68 G2/G4/G9),
 │                    buildRebasePlan / buildPreservePlan / runRebasePlan /

--- a/src/design/context-menu.commitcheckout.test.tsx
+++ b/src/design/context-menu.commitcheckout.test.tsx
@@ -1,0 +1,282 @@
+// Checking out a commit's OWN branch from the History commit menu (#179).
+//
+// The menu offered "Check out this commit" (detached HEAD) and "Create branch
+// from here…", so a commit that already had a branch on it had no way to check
+// THAT branch out — you had to leave for the branch chip, the Branches screen or
+// the palette. Checking the branch out is almost always the intent on such a
+// commit, so it now sits ABOVE the detached entry, which stays.
+//
+// The traps this file pins:
+//   - `BranchInfo.tip` is a FULL oid. It was once truncated to 7 chars and every
+//     comparison against `CommitInfo.oid` failed silently, so the match is on
+//     full oids and a 7-char prefix must NOT produce entries.
+//   - a remote-only ref must never silently detach — it goes through the
+//     create-tracking-branch prompt, `createBranch(local, remote)` then
+//     `checkoutBranch(local)`.
+//   - the payload stayed `{ sha, subject }`: the branches come from the store,
+//     so a caller passing no refs still gets today's menu.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { commitMenuItems, type ContextMenuItem } from "./context-menu";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { WithDialogs, acceptDialog, resetDialogs } from "@/test/dialog";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+import type { BranchInfo, CommitInfo } from "@/lib/types";
+
+const A = "a".repeat(40);
+const B = "b".repeat(40);
+const C = "c".repeat(40);
+
+const mk = (oid: string, parents: string[]): CommitInfo => ({
+  oid,
+  shortOid: oid.slice(0, 7),
+  summary: `commit ${oid.slice(0, 1)}`,
+  body: null,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 1_700_000_000,
+  parents,
+  refs: [],
+});
+
+const COMMITS = [mk(A, [B]), mk(B, [C]), mk(C, [])];
+
+const branch = (over: Partial<BranchInfo> & { name: string }): BranchInfo => ({
+  isHead: false,
+  isRemote: false,
+  upstream: null,
+  ahead: 0,
+  behind: 0,
+  tip: null,
+  tipTime: 0,
+  isDefault: false,
+  ...over,
+});
+
+function setBranches(branches: BranchInfo[]) {
+  useRepoStore.setState({ branches } as never);
+}
+
+const labels = (items: ContextMenuItem[]) =>
+  items.map((i) => (typeof i.label === "string" ? i.label : "")).filter(Boolean);
+
+function labeled(items: ContextMenuItem[], label: string): ContextMenuItem {
+  const found = items.find((i) => i.label === label);
+  expect(found, `no menu item labelled "${label}"`).toBeTruthy();
+  return found!;
+}
+
+/** Every call the store's checkoutBranch makes, in order. */
+const invokedCmds = () => getInvokeCalls().map((c) => c.cmd);
+const checkoutCalls = () =>
+  getInvokeCalls().filter((c) => c.cmd === "checkout_branch");
+const createCalls = () =>
+  getInvokeCalls().filter((c) => c.cmd === "create_branch");
+
+beforeEach(() => {
+  resetDialogs();
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    commits: COMMITS,
+    status: [],
+    branches: [],
+    loading: false,
+  } as never);
+  // checkoutBranch is stash → checkout → pop → refreshAll, so the whole
+  // refresh fan-out has to answer or the action throws before checking out.
+  mockInvoke("stash_save", () => null);
+  mockInvoke("checkout_branch", () => undefined);
+  mockInvoke("create_branch", () => undefined);
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: COMMITS, nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => ({
+    inProgress: false,
+    nextIndex: 0,
+    total: 0,
+    pauseReason: null,
+  }));
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("no branch on the commit", () => {
+  it("leaves the menu exactly as it was — no checkout-branch entry at all", () => {
+    setBranches([branch({ name: "main", isHead: true, tip: A })]);
+    const items = commitMenuItems({ sha: B, subject: "commit B" });
+    expect(labels(items).filter((l) => l.startsWith("Check out"))).toEqual([
+      "Check out this commit",
+    ]);
+  });
+
+  it("degrades with no branches loaded, which is the payload-compat case", () => {
+    setBranches([]);
+    const items = commitMenuItems({ sha: A, subject: "commit A" });
+    expect(labels(items)).toContain("Check out this commit");
+    expect(labels(items).some((l) => l.includes('"'))).toBe(false);
+  });
+
+  it("offers nothing for a commit with no sha", () => {
+    setBranches([branch({ name: "main", tip: A })]);
+    expect(labels(commitMenuItems(null)).filter((l) => l.startsWith("Check out"))).toEqual([
+      "Check out this commit",
+    ]);
+  });
+});
+
+describe("one branch on the commit", () => {
+  it("offers it inline, above the detached-HEAD entry", () => {
+    setBranches([
+      branch({ name: "main", isHead: true, tip: C }),
+      branch({ name: "feature", tip: A }),
+    ]);
+    const l = labels(commitMenuItems({ sha: A, subject: "commit A" }));
+    expect(l).toContain('Check out "feature"');
+    expect(l.indexOf('Check out "feature"')).toBeLessThan(
+      l.indexOf("Check out this commit"),
+    );
+    // Inline, not wrapped in a submenu.
+    expect(l).not.toContain("Check out branch");
+  });
+
+  it("checks the branch out through the store's one checkout path", async () => {
+    setBranches([
+      branch({ name: "main", isHead: true, tip: C }),
+      branch({ name: "feature", tip: A }),
+    ]);
+    await labeled(
+      commitMenuItems({ sha: A, subject: "commit A" }),
+      'Check out "feature"',
+    ).onClick?.();
+    await waitFor(() => expect(checkoutCalls()).toHaveLength(1));
+    expect(checkoutCalls()[0].args).toMatchObject({ name: "feature" });
+    // The auto-stash half of checkoutBranch, i.e. it really is that action and
+    // not a second checkout path bolted onto the menu.
+    expect(invokedCmds().indexOf("stash_save")).toBeLessThan(
+      invokedCmds().indexOf("checkout_branch"),
+    );
+  });
+
+  it("lists the CURRENT branch disabled rather than hiding it", () => {
+    setBranches([branch({ name: "main", isHead: true, tip: A })]);
+    const items = commitMenuItems({ sha: A, subject: "commit A" });
+    const entry = labeled(items, 'Check out "main" — current branch');
+    expect(entry.disabled).toBe(true);
+  });
+
+  it("matches on the FULL oid — a 7-char prefix is not a branch tip", () => {
+    // The truncation regression: BranchInfo.tip was once 7 chars and every
+    // comparison against CommitInfo.oid silently failed.
+    setBranches([branch({ name: "feature", tip: A.slice(0, 7) })]);
+    const l = labels(commitMenuItems({ sha: A, subject: "commit A" }));
+    expect(l.filter((x) => x.startsWith("Check out"))).toEqual([
+      "Check out this commit",
+    ]);
+  });
+
+  it("does not match a null tip against a commit", () => {
+    setBranches([branch({ name: "unborn", tip: null })]);
+    const l = labels(commitMenuItems({ sha: A, subject: "commit A" }));
+    expect(l.filter((x) => x.startsWith("Check out"))).toEqual([
+      "Check out this commit",
+    ]);
+  });
+});
+
+describe("a remote-only ref on the commit", () => {
+  it("creates a tracking branch and checks THAT out — it never detaches", async () => {
+    setBranches([
+      branch({ name: "main", isHead: true, tip: C }),
+      branch({ name: "origin/feature", isRemote: true, tip: A }),
+    ]);
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
+    const entry = labeled(
+      commitMenuItems({ sha: A, subject: "commit A" }),
+      'Check out "origin/feature" as a new local branch…',
+    );
+    void entry.onClick?.();
+
+    // The prompt defaults to the ref name WITHOUT its remote prefix.
+    const input = (await screen.findByTestId("dialog-input")) as HTMLInputElement;
+    expect(input.value).toBe("feature");
+    await acceptDialog();
+    await waitFor(() => expect(createCalls()).toHaveLength(1));
+    expect(createCalls()[0].args).toMatchObject({
+      name: "feature",
+      from: "origin/feature",
+    });
+    await waitFor(() => expect(checkoutCalls()).toHaveLength(1));
+    expect(checkoutCalls()[0].args).toMatchObject({ name: "feature" });
+    // A bare checkout of the remote ref would have detached HEAD.
+    expect(invokedCmds()).not.toContain("checkout_ref");
+  });
+
+  it("drops a remote whose local counterpart is at the same commit", () => {
+    // `main` and `origin/main` on one commit is the everyday case; offering both
+    // would make the common commit a two-item submenu whose second entry only
+    // ever prompts for a name that is already taken.
+    setBranches([
+      branch({ name: "main", tip: A }),
+      branch({ name: "origin/main", isRemote: true, tip: A }),
+    ]);
+    const l = labels(commitMenuItems({ sha: A, subject: "commit A" }));
+    expect(l).toContain('Check out "main"');
+    expect(l).not.toContain('Check out "origin/main" as a new local branch…');
+    expect(l).not.toContain("Check out branch");
+  });
+
+  it("keeps a remote whose local counterpart is somewhere ELSE", () => {
+    setBranches([
+      branch({ name: "main", isHead: true, tip: C }),
+      branch({ name: "origin/main", isRemote: true, tip: A }),
+    ]);
+    const l = labels(commitMenuItems({ sha: A, subject: "commit A" }));
+    expect(l).toContain('Check out "origin/main" as a new local branch…');
+  });
+});
+
+describe("several branches on the commit", () => {
+  it("collapses them into one submenu instead of a row each", () => {
+    setBranches([
+      branch({ name: "main", isHead: true, tip: A }),
+      branch({ name: "feature", tip: A }),
+      branch({ name: "origin/other", isRemote: true, tip: A }),
+    ]);
+    const items = commitMenuItems({ sha: A, subject: "commit A" });
+    const group = labeled(items, "Check out branch");
+    expect(labels(group.submenu ?? [])).toEqual([
+      // Locals before remotes, each in the ONE branch ordering (#135) — here
+      // equal tipTime, so name ascending.
+      'Check out "feature"',
+      'Check out "main" — current branch',
+      'Check out "origin/other" as a new local branch…',
+    ]);
+    // No loose duplicates left at the top level.
+    expect(labels(items).filter((l) => l.startsWith("Check out"))).toEqual([
+      "Check out branch",
+      "Check out this commit",
+    ]);
+  });
+
+  it("puts the group above the detached-HEAD entry too", () => {
+    setBranches([
+      branch({ name: "one", tip: A }),
+      branch({ name: "two", tip: A }),
+    ]);
+    const l = labels(commitMenuItems({ sha: A, subject: "commit A" }));
+    expect(l.indexOf("Check out branch")).toBeGreaterThanOrEqual(0);
+    expect(l.indexOf("Check out branch")).toBeLessThan(
+      l.indexOf("Check out this commit"),
+    );
+  });
+});

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -11,7 +11,8 @@ import { planCommitSelection } from "@/features/commits/planCommitSelection";
 import { headAncestryOf } from "@/features/commits/headAncestry";
 import { runRebasePlanNow } from "@/features/commits/runRebasePlan";
 import { combinedSquashMessage } from "@/features/commits/squashMessage";
-import type { CommitInfo } from "@/lib/types";
+import type { BranchInfo, CommitInfo } from "@/lib/types";
+import { orderBranchesGrouped } from "@/features/branches/orderBranches";
 import { openMergeWindow } from "@/features/merge/openMergeWindow";
 import {
   markedRefFor,
@@ -376,6 +377,10 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
   const baseOid = self?.parents[0] ?? null;
   return [
     { __menuTitle: `commit ${sha.slice(0, 7)}` },
+    // ABOVE the detached-HEAD entry (#179): when a branch is here, checking it
+    // out is both the safer and the far more common intent, and the detached
+    // entry stays for when it genuinely is what you want.
+    ...checkoutBranchItems(commit?.sha),
     {
       icon: "check",
       label: "Check out this commit",
@@ -590,6 +595,86 @@ function byOid(commits: CommitInfo[]): Map<string, CommitInfo> {
 function ancestryLog(): CommitInfo[] {
   const { commits, branches } = useRepoStore.getState();
   return headAncestryOf(commits, branches);
+}
+
+/**
+ * The branch refs pointing exactly AT one commit (#179) — what "check out the
+ * branch that is already here" is built from.
+ *
+ * Read off `useRepoStore.branches`, NOT off `CommitInfo.refs`: the store rows
+ * carry `isHead` / `isRemote` / `upstream`, which is what lets the current
+ * branch be disabled and a remote-only ref be routed through the
+ * tracking-branch flow instead of a silent detach. `mapCommitRefs`' names are
+ * display strings and lossy on purpose — HEAD reads `HEAD→main` and a remote
+ * ref is split into name + remote — so they are no use for naming an op.
+ *
+ * `BranchInfo.tip` is a FULL oid and is compared as one. It was once truncated
+ * to 7 chars and every comparison against `CommitInfo.oid` then failed
+ * silently, so never shorten either side here — `shortSha` belongs at display
+ * sites, and a prefix match would put a foreign branch on the menu. Both
+ * nullable ends are then stated rather than relied on: an unresolvable `tip` and
+ * a commit with no sha are both "no branch here", and writing that out is
+ * cheaper than re-deriving that `null === undefined` happens to be false.
+ *
+ * DELIBERATELY blind to History's `refFilter`. That control hides remote ref
+ * PILLS — a display choice about a crowded row — and hiding a pill must not
+ * remove an action from a menu; a user who narrowed the pills to "local" has
+ * said nothing about which branches they may check out. Deriving from the store
+ * rather than from History's filtered pill list makes that structural instead
+ * of a promise: the filter is never in scope here.
+ */
+function branchesAtCommit(oid: string | null | undefined): BranchInfo[] {
+  if (!oid) return [];
+  const at = useRepoStore.getState().branches.filter((b) => !!b.tip && b.tip === oid);
+  // Locals ahead of remotes, each group in the ONE branch ordering (#135).
+  // This renders as an undivided list, so the grouping has to happen here.
+  const ordered = orderBranchesGrouped(at);
+  // A remote ref whose local counterpart is at this very commit adds nothing:
+  // the local branch is already offered and checking it out lands on the same
+  // tree, while the remote entry would only prompt for a name already taken.
+  // Narrow on purpose — same commit AND same short name.
+  const locals = new Set(ordered.filter((b) => !b.isRemote).map((b) => b.name));
+  return ordered.filter(
+    (b) => !b.isRemote || !locals.has(withoutRemotePrefix(b.name)),
+  );
+}
+
+/**
+ * "Check out the branch that is on this commit" for a commit's context menu
+ * (#179).
+ *
+ * One branch → an inline entry; several → a submenu, so a commit carrying five
+ * refs does not push the rest of the menu off screen. EMPTY when no branch is
+ * here, which is what keeps `commitMenuItems` byte-identical to before for
+ * every other commit — and why the payload needed no new field.
+ */
+function checkoutBranchItems(oid: string | null | undefined): ContextMenuItem[] {
+  const entries: ContextMenuItem[] = branchesAtCommit(oid).map((b) =>
+    b.isRemote
+      ? {
+          icon: "branch",
+          label: `Check out "${b.name}" as a new local branch…`,
+          // Never a bare checkout: `origin/foo` is not a local branch, so
+          // checking the ref out would detach HEAD — the very thing the entry
+          // above the detached one exists to avoid.
+          onClick: () => checkoutRemoteAsLocalBranch(b.name),
+        }
+      : {
+          icon: "check",
+          // The current branch is LISTED rather than hidden — matching
+          // branchMenuItems' `disabled: isCurrent` — so "you are already here"
+          // reads off the menu instead of being an absence to interpret.
+          label: b.isHead
+            ? `Check out "${b.name}" — current branch`
+            : `Check out "${b.name}"`,
+          disabled: b.isHead,
+          // checkoutBranch owns auto-stash → checkout → pop and its own
+          // activity label. There is exactly one checkout path.
+          onClick: () => useRepoStore.getState().checkoutBranch(b.name),
+        },
+  );
+  if (entries.length <= 1) return entries;
+  return [{ icon: "check", label: "Check out branch", submenu: entries }];
 }
 
 /**
@@ -1085,31 +1170,47 @@ export function branchMenuItems(
   ];
 }
 
+/** `origin/feat/x` → `feat/x`. The remote prefix is the FIRST segment only. */
+function withoutRemotePrefix(name: string): string {
+  const i = name.indexOf("/");
+  return i >= 0 ? name.slice(i + 1) : name;
+}
+
+/**
+ * Check a remote-tracking ref out by creating a local branch that tracks it.
+ *
+ * ONE definition, shared by the remote-branch menu and the commit menu's remote
+ * entry (#179): a bare `checkoutRef("origin/foo")` would silently DETACH, which
+ * is the whole reason this flow exists, so a second copy is how one of the two
+ * call sites would come to detach.
+ */
+async function checkoutRemoteAsLocalBranch(name: string) {
+  if (!name) return;
+  const localName = await pgPrompt({
+    title: "Check out as new local branch",
+    body: `Tracking ${name}.`,
+    initialValue: withoutRemotePrefix(name),
+    confirmLabel: "Check out",
+    requireValue: true,
+    mono: true,
+  });
+  if (!localName) return;
+  await useRepoStore.getState().createBranch(localName, name);
+  await useRepoStore.getState().checkoutBranch(localName);
+}
+
 export function remoteBranchMenuItems(branch: { name?: string } | null): ContextMenuItem[] {
   const name = branch?.name || "";
   // name is like "origin/feature" — parse out the remote prefix
   const slashIdx = name.indexOf("/");
   const remoteName = slashIdx >= 0 ? name.slice(0, slashIdx) : name;
-  const shortName = slashIdx >= 0 ? name.slice(slashIdx + 1) : name;
+  const shortName = withoutRemotePrefix(name);
   return [
     { __menuTitle: name || "remote branch" },
     {
       icon: "branch",
       label: "Check out as new local branch…",
-      onClick: async () => {
-        if (!name) return;
-        const localName = await pgPrompt({
-          title: "Check out as new local branch",
-          body: `Tracking ${name}.`,
-          initialValue: shortName,
-          confirmLabel: "Check out",
-          requireValue: true,
-          mono: true,
-        });
-        if (!localName) return;
-        await useRepoStore.getState().createBranch(localName, name);
-        await useRepoStore.getState().checkoutBranch(localName);
-      },
+      onClick: () => checkoutRemoteAsLocalBranch(name),
     },
     {
       icon: "merge",


### PR DESCRIPTION
Implements issue 179.

Right-clicking a commit in History offered **Check out this commit** (detached
HEAD) and **Create branch from here…**, but a commit that already had a branch
on it had no way to check *that* branch out — you had to leave for the branch
chip, the Branches screen or the palette.

## What it does

- one branch on the commit → an inline entry, `Check out "main"`
- several → a `Check out branch` submenu
- both sit **above** the detached-HEAD entry, which stays — checking the branch
  out is the safer and far more common intent on a commit that has one
- the **current** branch is listed **disabled** (`Check out "main" — current
  branch`), matching `branchMenuItems`' `disabled: isCurrent`
- a **remote-only** ref gets `Check out "origin/feature" as a new local
  branch…`, which goes through the create-tracking-branch prompt →
  `createBranch(local, remote)` → `checkoutBranch(local)`. It never detaches.

## Decisions

**Branches come from the store, not the payload.** `commitMenuItems` reads
`useRepoStore.getState().branches` filtered on `tip === oid`. The store rows
carry `isHead` / `isRemote` / `upstream`, which is exactly what the disabled
current branch and the remote-ref routing need; `mapCommitRefs`' names are
display strings and lossy on purpose (HEAD reads `HEAD→main`, a remote ref is
split into name + remote), so they cannot name an op. Consequence: the payload
stayed `{ sha, subject }` — no new field, and a caller with no branches loaded
gets today's menu unchanged. Both existing call sites
(`context-menu.squash.test.tsx`, `context-menu.commitdiff.test.tsx`) are
untouched.

**`refFilter` is deliberately ignored — and structurally so.** History's ref
filter ("local" vs all) hides remote ref *pills*: a display choice about a
crowded row. Hiding a pill must not remove an action from a menu — a user who
narrowed the pills has said nothing about which branches they may check out. By
deriving from the store rather than from History's filtered pill list, the
filter is never in scope in the builder, so this is a property of the code
rather than a promise. Written up in the `branchesAtCommit` doc comment.

**Full-oid comparison.** `BranchInfo.tip` is compared as the full oid it is. It
was once truncated to 7 chars and every comparison against `CommitInfo.oid`
failed silently (History's HEAD indicator and the graph's HEAD ring both stopped
drawing); a regression test pins that a 7-char prefix yields no entries.

**One ordering.** The list goes through `orderBranchesGrouped` (#135) — locals
ahead of remotes, each group in the one branch ordering. It renders undivided, so
the grouping is done at this call site, as the palette's branch steps do.

**One checkout path.** Local entries call `useRepoStore.checkoutBranch`, which
already owns auto-stash → checkout → pop and its activity state. The remote flow
was extracted out of `remoteBranchMenuItems` into one shared
`checkoutRemoteAsLocalBranch`, so neither of the two call sites can drift into
detaching.

**Judgement call not settled by the issue:** a remote ref whose **local
counterpart is at the same commit** is dropped. `main` + `origin/main` on one
commit is the everyday case, and offering both would turn it into a two-item
submenu whose second entry only ever prompts for a name that is already taken —
while checking out the local branch lands on the identical tree. The filter is
narrow (same commit *and* same short name); a remote whose local counterpart is
elsewhere is still offered. Both directions are tested.

Tags stay out of scope: a tag cannot be checked out without detaching, and
detaching is already offered.

## Tests

New `src/design/context-menu.commitcheckout.test.tsx`, 13 cases: the empty /
payload-compat cases, inline vs submenu, ordering inside the submenu, position
above the detached entry, the disabled current branch, the full-oid match, the
null tip, the remote tracking-branch flow end to end (prompt default, then
`create_branch` then `checkout_branch`, and never `checkout_ref`), and both
sides of the local/remote dedupe.

**Mutation-checked.** Eight deliberate breakages; seven were caught by exactly
the intended case — truncating the tip comparison to 7 chars, swapping the
remote entry for a bare `checkoutRef` (the silent detach), dropping
`disabled: b.isHead`, moving the group below the detached entry, never
collapsing into a submenu, removing the local/remote dedupe, and skipping
`orderBranchesGrouped`. The eighth showed the nullable-end guards
(`if (!oid) return []` + `!!b.tip`) are **not** behaviourally observable with
well-typed inputs, since `null === undefined` is false either way — so the doc
comment was corrected to stop claiming they were load-bearing, and the null-tip
test was re-verified against a realistic mutation shape (`(b.tip ?? oid) === oid`,
which would put every unresolved branch on every commit) that it does catch.

## Gates

- `pnpm tsc --noEmit` — clean
- `pnpm test` — 194 files, 1662 tests, all passing
- `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — clean

No e2e run: no spec drives the History commit context menu (the only `Check out`
in `e2e/` is the reflog dialog, untouched), and no Rust changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Er25sN6pGoVJzmTBwHU2Tz
