### PR TITLE
ci(e2e): shard the suite across four runners, one build

### DIFF
--- a/.claude/skills/e2e-testing/SKILL.md
+++ b/.claude/skills/e2e-testing/SKILL.md
@@ -17,8 +17,18 @@ the `test:e2e:docker` wrapper, never directly on the host.
 pnpm test:e2e:docker full --spec e2e/specs/<file>  # build + run — REQUIRED after ANY src/ or src-tauri/ change
 pnpm test:e2e:docker run  --spec e2e/specs/<file>  # reuses this worktree's e2e/.bin snapshot — spec-only iterations
 pnpm test:e2e:docker                               # build + whole suite
+E2E_SHARD=2 E2E_SHARDS=4 pnpm test:e2e:docker run  # replay ONE CI shard (issue 189)
 pnpm exec tsc -p e2e/tsconfig.json --noEmit        # e2e typecheck gate (root tsc EXCLUDES e2e/)
 ```
+
+**CI runs the suite in four shards, one build.** `e2e/shardSpecs.ts` derives the
+slice from the files on disk and packs by measured duration, so a spec you ADD
+needs no edit there — it is picked up and weighted at the suite mean. Two things
+follow for debugging: a shard's log opens with the exact spec list it ran (replay
+it with `--spec`, or with the `E2E_SHARD` pair above), and `strategy` in
+`.github/workflows/e2e.yml` is where the shard count lives — `test/shardSpecs.test.ts`
+fails if the matrix and the splitter ever disagree about what runs. Unsharded
+(every local run) the conf keeps its plain glob.
 
 **Stale-binary trap:** the `run` phase tests whatever binary is in `e2e/.bin/`. A green run after touching `src/` proves nothing unless a `build`/`full` ran after the change. Plain `cargo build` silently rewrites `target/debug/platypusgit` WITHOUT `custom-protocol` (blank window) — that's why the snapshot exists. Close any running dev app first: debug builds all serve WebDriver on port 4445 and the runner may attach to the dev instance and clear its localStorage.
 
@@ -56,7 +66,29 @@ Two conf-level guards eliminate the historical "suite suddenly takes minutes" fl
 
 **Reload race:** after `browser.refresh()`, an immediate arm can land on the OUTGOING document (it also has `__TAURI__`), leaving the new page unarmed. The only trustworthy "navigation settled" signal is a matched WebDriver find. **Rule: any new `browser.refresh()` call site must wait for a real element, then call `armDriverBridge()` again** — see `resetApp`/`openRepo`/`waitRepoLoaded` for the pattern.
 
-**Flake bands:** healthy full suite ≈ 30s–1.5min. Sustained runs >2.5min, or single commands taking 5–30s, mean a guard above was lost or a new refresh site skipped the settle-gate pattern — check conf + the newest refresh site, not the specs.
+**Flake bands:** healthy full suite ≈ 30s–1.5min on macOS/WKWebView. Sustained runs >2.5min, or single commands taking 5–30s, mean a guard above was lost or a new refresh site skipped the settle-gate pattern — check conf + the newest refresh site, not the specs.
+
+**Under xvfb the band is different, and guard 2 does NOT apply there — so a
+stall costs the full 30s.** Measured (issue 189, run 32242497631): the whole
+suite is ~530s of spec time, and roughly **eight ~30s stalls** are inside that
+number. Every spec over 30s comes out as `n × 30` plus small change — `keymap`
+140s, `repo-tabs` 96s, `palette` 66s, then four in the 32–37s band — while the 18
+files with few refreshes total under 60s. WHICH specs pay moves run to run,
+because it is the reload race, not the spec. So:
+
+- **A ~30s multiple in a spec time is the race, not your selector.** Do not go
+  hunting a 5s selector penalty for it.
+- **Every `browser.refresh()` you add is another roll of that die.** Adding one
+  per spec file (a `resetApp()` in the conf `before` hook) took the suite from
+  528s to **1064s** — measured, run 32246987758, and reverted. Prefer a
+  no-navigation alternative whenever one exists.
+- Under the stalls the residual cost is real work: the heavy specs call
+  `openRepo()` once per `it()` (`keymap` 28×), and one of those is refresh +
+  re-arm + repo open + syncing settle.
+
+A per-shard time near its own `WEIGHTS` entry (`e2e/shardSpecs.ts`) is healthy; a
+3× jump on a shard whose specs you did not touch is the bridge or a new refresh
+site, and that is when to reread this section.
 
 ## Focus self-heal (macOS — `ensureMacAppFocus`, don't remove)
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,9 +11,43 @@ concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
 
+# TWO apt lists, split by what the job actually does — and with four shards the
+# split is what makes sharding pay off at all.
+#
+# The build job LINKS the crate, so it needs the -dev packages and patchelf. The
+# shard jobs only RUN the binary the build job produced, so they need the
+# runtime libraries and xvfb, and nothing else. With ONE job the comment that
+# used to sit here was right that a single list was cheaper than "a split list
+# is a thing to get wrong"; with five jobs it inverts. MEASURED in run
+# 32257418277: the -dev set is 61.5 MB of packages on this image, and
+# `azure.archive.ubuntu.com` throttles per runner at wildly different rates —
+# the same 61.5 MB took 13 s on shard 3, 2 min 14 s on shard 2, 8 min 14 s on
+# shard 4 and 10 min 24 s on shard 1. Five draws from that distribution and the
+# gate waits for the slowest, which is the whole reason the first sharded run
+# came out at 19 min 20 s against 11 min 56 s unsharded.
+#
+# So the shards do not talk to an Ubuntu mirror at all: the build job resolves
+# the runtime closure with apt and ships the .debs as an artifact, and each
+# shard installs them offline. One mirror draw per run instead of five, and no
+# `apt-get update` in the shards either.
+#
+# The runtime names are RESOLVED, not guessed: they are what `apt-cache depends
+# <the -dev package>` names on ubuntu-24.04, which is where `libgtk-3-0t64`
+# comes from (Ubuntu 24.04 renamed it for the 64-bit time_t transition). They
+# are consumed only on the same runner image that resolved them, so there is no
+# hardcoded-name-vs-future-image trap: a name a later image drops fails the
+# BUILD job by name, and the shards' `ldd` check is the second net.
+env:
+  TAURI_APT_BUILD_DEPS: >-
+    libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev
+    librsvg2-dev patchelf
+  TAURI_APT_RUN_DEPS: >-
+    libwebkit2gtk-4.1-0 libgtk-3-0t64 libayatana-appindicator3-1
+    librsvg2-2 xvfb
+
 jobs:
   # Decides whether the suite is worth running for this PR. Site- and docs-only
-  # changes cannot affect the app binary, so they skip a ~10 minute build.
+  # changes cannot affect the app binary, so they skip the build and every shard.
   #
   # The filter runs for pull_request events only. On push and workflow_dispatch
   # there is no reliable diff base, so `app` falls back to 'true' (a skipped
@@ -44,19 +78,63 @@ jobs:
             echo "-> no app code touched, skipping the E2E suite"
           fi
 
-  e2e:
+  # Build the debug binary ONCE and hand it to the shards as an artifact
+  # (issue 189). The binary is identical for every shard, so building it per
+  # shard would spend the ~50s cargo link N times to produce N identical files.
+  # This job needs no xvfb: nothing runs the app here.
+  build:
     needs: changes
     if: needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Tauri system deps
+      # apt runs twice here, in this order, and the order is the point:
+      #
+      #  1. the shards' RUNTIME closure is resolved and DOWNLOADED into an
+      #     archive directory, without installing it. This has to come first:
+      #     after the -dev install those packages are already installed, so apt
+      #     would have nothing to fetch and the artifact would be empty.
+      #  2. the -dev set is installed for linking, reusing the SAME archive
+      #     directory, so every .deb fetched in step 1 is reused instead of
+      #     downloaded twice. Measured on this image: 57 .debs / 44.6 MB staged,
+      #     after which the -dev install fetched 14.5 MB of its 59.1 MB.
+      #
+      # `APT::Sandbox::User=root` is required because apt drops to the `_apt`
+      # user to download and cannot write a runner-owned directory, and
+      # `partial/` has to exist before apt will use the directory at all.
+      #
+      # A package already present on the runner image is not fetched, and does
+      # not need to be: the shards run the same `ubuntu-latest` image.
+      - name: Install Tauri build deps, stage the shards' runtime libs
         run: |
+          mkdir -p apt-cache/partial apt-runtime
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev \
-            libayatana-appindicator3-dev librsvg2-dev patchelf xvfb
+          sudo apt-get install -y --no-install-recommends --download-only \
+            -o APT::Sandbox::User=root \
+            -o Dir::Cache::archives="$GITHUB_WORKSPACE/apt-cache" \
+            $TAURI_APT_RUN_DEPS
+          cp apt-cache/*.deb apt-runtime/
+          echo "staged $(ls apt-runtime/*.deb | wc -l) runtime .debs" \
+            "($(du -sh apt-runtime | cut -f1))"
+          sudo apt-get install -y --no-install-recommends \
+            -o APT::Sandbox::User=root \
+            -o Dir::Cache::archives="$GITHUB_WORKSPACE/apt-cache" \
+            $TAURI_APT_BUILD_DEPS
+
+      # NOT a dot-prefixed directory: `upload-artifact` defaults to
+      # `include-hidden-files: false` and silently matches nothing under one, so
+      # `.apt-runtime/*.deb` failed the upload with 57 staged .debs on disk.
+      - name: Upload the shards' runtime libs
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-runtime-libs
+          path: apt-runtime/*.deb
+          retention-days: 1
+          # An empty set here would turn into four shards failing on a glob that
+          # matched nothing, so fail where the cause is.
+          if-no-files-found: error
 
       - uses: pnpm/action-setup@v4
         with:
@@ -76,24 +154,121 @@ jobs:
       - name: Install deps
         run: pnpm install --frozen-lockfile
 
+      - name: Build E2E binary
+        run: pnpm test:e2e:build
+
+      - name: Upload E2E binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-binary
+          path: e2e/.bin/platypusgit
+          # One PR's worth. The shards consume it minutes later and nothing
+          # else ever wants it again.
+          retention-days: 1
+          # A silently empty artifact would turn into four confusing
+          # "app never rendered Welcome screen" failures instead of one here.
+          if-no-files-found: error
+
+  # The suite, split across runners. `maxInstances` has to stay 1 (an
+  # e2e-feature binary serves WebDriver on a fixed port, so two app instances in
+  # one container collide), so parallelism happens here, one wdio process per
+  # runner. `e2e/shardSpecs.ts` decides the slice, weighted by MEASURED per-spec
+  # duration — wdio's own `--shard` splits by file count, which put three of the
+  # four slowest specs in one slice.
+  #
+  # No Rust toolchain and no rust-cache: this job only runs the binary the build
+  # job produced.
+  e2e:
+    needs: [changes, build]
+    if: needs.changes.outputs.app == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      # Every shard reports, so one broken spec does not hide the state of the
+      # other three. They run in parallel, so this costs no wall clock.
+      fail-fast: false
+      matrix:
+        # THE shard count, and the only place it is written down: the run step
+        # below reads the total from `strategy.job-total`. Keep it on one line —
+        # test/shardSpecs.test.ts reads this array to check that every spec on
+        # disk lands in exactly one shard.
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download the runtime libs
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-runtime-libs
+          path: apt-runtime
+
+      # Offline on purpose — see the env block. Every .deb was resolved by the
+      # build job against this same runner image, so there is no `apt-get
+      # update` and no mirror in this job's path.
+      #
+      # `--no-install-recommends` is load-bearing rather than cosmetic here: the
+      # image ships package lists, so apt would otherwise try to satisfy
+      # Recommends over the network and put the mirror back in the path.
+      # `--allow-downgrades` covers the one case this shape can hit — the runner
+      # image rolling between the build job and a shard, leaving the shard with a
+      # newer build of one of these libs than the .deb carries.
+      - name: Install Tauri runtime deps
+        run: |
+          sudo apt-get install -y --no-install-recommends --allow-downgrades \
+            ./apt-runtime/*.deb
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Download E2E binary
+        uses: actions/download-artifact@v4
+        with:
+          name: e2e-binary
+          path: e2e/.bin
+
+      # The artifact format does not carry the exec bit. The `ldd` check is the
+      # net under the split apt lists: a runtime set that does not match what
+      # the binary was linked against becomes ONE named failure here instead of
+      # four shards each reporting "app never rendered the Welcome screen".
+      - name: Restore the exec bit and check the runtime libs
+        run: |
+          chmod +x e2e/.bin/platypusgit
+          if ldd e2e/.bin/platypusgit | grep 'not found'; then
+            echo "::error::Missing runtime libraries — TAURI_APT_RUN_DEPS does" \
+                 "not cover what this binary was linked against."
+            exit 1
+          fi
+
       - name: Configure git for fixtures
         run: |
           git config --global user.name "CI"
           git config --global user.email "ci@platypusgit.test"
           git config --global init.defaultBranch main
 
-      - name: Build E2E binary
-        run: pnpm test:e2e:build
-
-      - name: Run E2E
+      - name: Run E2E (shard ${{ matrix.shard }} of ${{ strategy.job-total }})
+        env:
+          E2E_SHARD: ${{ matrix.shard }}
+          E2E_SHARDS: ${{ strategy.job-total }}
         run: xvfb-run --auto-servernum pnpm test:e2e:run
 
   # The required status check on main. It always runs and always reports, so a
   # PR that skipped the suite is not left waiting forever on a check that never
   # arrives — the trap that makes a path-filtered required check block a PR
   # permanently. Keep this job's name in sync with the branch ruleset.
+  #
+  # Sharding did not change what the ruleset requires: this gate is still the
+  # only required check, and it now needs the build plus every shard.
   e2e-linux:
-    needs: [changes, e2e]
+    needs: [changes, build, e2e]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -101,25 +276,41 @@ jobs:
         env:
           FILTER: ${{ needs.changes.result }}
           APP: ${{ needs.changes.outputs.app }}
-          RESULT: ${{ needs.e2e.result }}
+          BUILD: ${{ needs.build.result }}
+          SHARDS: ${{ needs.e2e.result }}
         run: |
-          echo "filter job: $FILTER / app touched: $APP / E2E job: $RESULT"
-          # A failed filter job skips `e2e` too. Without this check the gate
-          # would read that skip as "not required" and pass a PR whose suite
-          # never ran at all.
+          echo "filter job: $FILTER / app touched: $APP"
+          echo "build job: $BUILD / shard jobs (aggregate): $SHARDS"
+          # A failed filter job skips everything downstream. Without this check
+          # the gate would read that skip as "not required" and pass a PR whose
+          # suite never ran at all.
           if [ "$FILTER" != "success" ]; then
             echo "The change-filter job did not succeed, so the suite never ran."
             exit 1
           fi
-          case "$RESULT" in
-            success) echo "E2E suite passed." ;;
-            skipped)
-              # Only legitimate when the filter decided no app code was touched.
-              if [ "$APP" != "false" ]; then
-                echo "E2E suite was skipped even though app code changed."
-                exit 1
-              fi
-              echo "No app code touched — E2E suite not required for this change."
-              ;;
-            *) echo "E2E suite did not pass."; exit 1 ;;
-          esac
+          if [ "$APP" = "false" ]; then
+            # The one legitimate skip. Both downstream jobs carry the same `if`,
+            # so anything other than a clean double skip means the workflow has
+            # been edited into a shape this gate cannot vouch for.
+            if [ "$BUILD" != "skipped" ] || [ "$SHARDS" != "skipped" ]; then
+              echo "No app code touched, but build=$BUILD shards=$SHARDS —" \
+                   "expected both to be skipped."
+              exit 1
+            fi
+            echo "No app code touched — E2E suite not required for this change."
+            exit 0
+          fi
+          if [ "$BUILD" != "success" ]; then
+            echo "The E2E binary did not build ($BUILD), so no shard ran."
+            exit 1
+          fi
+          # `needs.<matrix job>.result` is the AGGREGATE across the matrix:
+          # 'success' only when EVERY shard succeeded, 'failure' as soon as one
+          # of them fails. So this single comparison is "all shards passed" —
+          # and a 'skipped' here is unexplained by construction, because app
+          # code changed and the build succeeded.
+          if [ "$SHARDS" != "success" ]; then
+            echo "At least one E2E shard did not pass ($SHARDS)."
+            exit 1
+          fi
+          echo "Every E2E shard passed."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,15 @@ jobs:
           # e2e/ counts as frontend input because `tsc -p e2e/tsconfig.json`
           # runs in the unit job — the root tsconfig excludes e2e/, so nothing
           # else typechecks the specs.
-          if echo "$changed" | grep -qE '^(src/|e2e/|index\.html$|package\.json$|pnpm-lock\.yaml$|vite\.config\.ts$|tsconfig[a-z.]*\.json$|\.github/workflows/tests\.yml$)'; then
+          #
+          # The last three entries are the INPUTS the `docs` vitest project
+          # reads, not frontend sources, and each one was skippable by exactly
+          # the change it exists to police: `test/` holds both suites,
+          # `docs.test.ts` asserts CLAUDE.md matches the tree, and
+          # `shardSpecs.test.ts` asserts e2e.yml's shard matrix covers every
+          # spec. Without them here, editing only CLAUDE.md or only the matrix
+          # skipped its own guard and reported green (issue 189).
+          if echo "$changed" | grep -qE '^(src/|e2e/|test/|index\.html$|package\.json$|pnpm-lock\.yaml$|vite\.config\.ts$|tsconfig[a-z.]*\.json$|CLAUDE\.md$|\.github/workflows/(tests|e2e)\.yml$)'; then
             echo "js=true" >> "$GITHUB_OUTPUT"
             echo "-> frontend sources touched, running the unit suite"
           else

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,7 +233,8 @@ Four layers, each run independently:
     that answers each one as it appears. Call sites are unchanged;
     `confirmCallCount()` still counts confirm dialogs only.
   - CI: `.github/workflows/e2e.yml` (ubuntu-latest + xvfb, PRs to `main` +
-    push to `main`). Local runs use `pnpm test:e2e:docker` (same WebKitGTK +
+    push to `main`) — **one build, four sharded runners**; see "The e2e gate is
+    sharded" below. Local runs use `pnpm test:e2e:docker` (same WebKitGTK +
     xvfb stack) — see the "Headless e2e in Docker" section above.
   - `pnpm.overrides["@wdio/native-utils"] = "2.5.0"` pins around a broken
     dep pin in `@wdio/tauri-service@1.2.0` — don't remove.
@@ -266,6 +267,15 @@ and `workflow_dispatch`:
   network.
 - `.github/workflows/e2e.yml` — the webview suite.
 
+**A path filter must list the suite's INPUTS, not just its sources.** `tests.yml`'s
+`js` filter also matches `test/`, `CLAUDE.md` and `.github/workflows/e2e.yml`,
+because the `docs` vitest project reads all three — and each was skippable by
+exactly the change it polices: a CLAUDE.md-only edit skipped `docs.test.ts`
+(whose whole job is "CLAUDE.md matches the tree"), and an e2e-matrix-only edit
+skipped `shardSpecs.test.ts` (whose whole job is "the matrix covers every
+spec"). Both reported green. Any new assertion about a file outside `src/` has
+to put that file in the filter, or the guard is decorative.
+
 Each workflow front-loads a `changes` job that diffs against the PR base and
 skips suites the change cannot affect, then reports through an always-running
 gate job (`unit-tests`, `rust-tests`, `e2e-linux`). **The gate is what a branch
@@ -274,6 +284,118 @@ skipped never reports and blocks the PR forever. The gate also fails on a skip
 it cannot explain, so a green tick means the suite ran or was provably
 irrelevant. On `push`/`workflow_dispatch` there is no reliable diff base, so
 every filter output falls back to `true` and `main` is never left untested.
+
+**The push-to-`main` e2e run is a deliberate duplicate, not an oversight**
+(issue 189, option D). The same suite runs on the PR and again on the squash
+merge. It is not waste: required checks are non-strict and the merge is a
+squash, so the tree that lands on `main` can differ from the tree the PR tested
+— the push run is the only thing that ever tests `main` itself. It blocks
+nobody, `concurrency: cancel-in-progress` already collapses a burst of merges
+into one run, and sharding roughly halved what it costs. Moving it to nightly
+would trade "green main, known within minutes" for "broken main, found up to a
+day later, then bisect the merges" — the same failure mode the issue rejects for
+release-only e2e, at a smaller scale. Revisit only if runner minutes actually
+become the constraint.
+
+### The e2e gate is sharded (issue 189)
+
+`e2e.yml` is three jobs, and the shape is load-bearing:
+
+- **`build`** compiles the debug binary once and uploads `e2e/.bin/platypusgit`
+  as an artifact. The binary is identical for every shard, so building per shard
+  would spend the ~50 s cargo link N times over. The shard jobs then need no
+  Rust toolchain and no `rust-cache` at all — they only run what this produced.
+  The artifact format drops the exec bit, so each shard `chmod +x`es it.
+- **`e2e`** is a matrix of four runners. `maxInstances` must stay **1** — an
+  `e2e`-feature binary serves WebDriver on a fixed port, so two app instances in
+  one container collide — which is exactly why parallelism lives across
+  *runners*, one wdio process each. The matrix array in the workflow is the ONLY
+  place the shard count is written down; the run step reads the total from
+  `strategy.job-total` and passes `E2E_SHARD` / `E2E_SHARDS`. `fail-fast: false`,
+  so one broken spec does not hide the other three shards' state.
+**The two apt lists are what makes four runners cheaper than one**, and a single
+list was the first sharded run's whole regression. `TAURI_APT_BUILD_DEPS` is the
+`-dev` set plus `patchelf`, installed only by `build`, which links the crate.
+`TAURI_APT_RUN_DEPS` is the RUNTIME closure — `libwebkit2gtk-4.1-0`,
+`libgtk-3-0t64` (Ubuntu 24.04's 64-bit time_t rename), `libayatana-appindicator3-1`,
+`librsvg2-2`, `xvfb` — and no shard fetches it from a mirror: `build` resolves it
+with `apt-get --download-only` BEFORE its own `-dev` install (after, those
+packages are installed and apt would fetch nothing), into the same archive
+directory the `-dev` install then reuses, and ships the `.deb`s as a second
+artifact each shard installs offline with `apt-get install ./*.deb`. Reason:
+`azure.archive.ubuntu.com` throttles per runner, unpredictably — the SAME 61.5 MB
+of `-dev` packages took 13 s, 2 min 14 s, 8 min 14 s and **10 min 24 s** across
+one run's four shards — and a matrix job waits for the slowest draw. So it is one
+mirror draw per run instead of five, and no `apt-get update` in a shard at all.
+`ldd` on the downloaded binary is the second net: a runtime list that stops
+covering what the build linked fails ONE named step instead of four shards
+reporting "app never rendered the Welcome screen".
+
+- **`e2e-linux`** is unchanged in NAME and still the only required check on
+  `main`'s ruleset — sharding needed no ruleset edit, only a longer `needs:`. It
+  fails on a skip it cannot explain: a `changes` job that did not succeed, a
+  build that did not succeed, or a shard aggregate that is anything but
+  `success`. `needs.<matrix job>.result` is the AGGREGATE, so one comparison
+  already means "every shard passed".
+
+**The split is derived, never listed** (`e2e/shardSpecs.ts`, invariants in
+`test/shardSpecs.test.ts`). `listSpecFiles` walks `e2e/specs/`, so a spec added
+or renamed by another change is picked up with no edit; `shardSpecs` then packs
+by MEASURED per-spec duration (longest-processing-time-first, deterministic ties
+on the path). wdio's own `--shard x/y` was rejected because it slices the
+*alphabetical* list by count, and measured against this suite that put `keymap`,
+`palette` and `history-ops` in one slice — 256 s against 43 s for the lightest.
+`WEIGHTS` is a HINT with provenance in its comment, not a manifest: an unlisted
+spec gets `DEFAULT_WEIGHT` and still runs, a stale entry is dead weight, and
+neither can drop a spec. Re-measure when the distribution has visibly drifted.
+
+**LPT's bound is `max ≤ ideal + heaviest`, so the heaviest single spec is the
+gate's floor.** `keymap.e2e.ts` is 140 s of the suite's ~530 s, so four shards
+already sit at that floor and a fifth runner buys nothing — the next lever is
+splitting that file, not adding shards. And the reason it costs 140 s is
+structural, not a lost selector: it calls `openRepo()` once per `it()` (28
+times), and one `openRepo` is a refresh + re-arm + a repo open + the syncing
+settle, ~5 s under xvfb. The same shape holds for `repo-tabs` (10 `resetApp`s)
+and `palette` (8 `openRepo`s).
+
+**Every spec file LEAVES a cleared `localStorage`, and that is what makes any
+grouping safe.** A spec file gets a fresh app PROCESS but not a fresh app data
+dir, so `pg-open-repos` survives into the next spec and makes its launch restore
+a repository instead of rendering Welcome — the screen the conf `before` hook and
+every `openRepo` wait for. Before sharding that never bit only because the two
+specs that leave the key behind (`repo-tabs`, `open-persisted-screen`) also
+dispose their temp repos, so the restore fails and Welcome renders anyway — a
+property of two *other* files. The conf's `after` hook now clears the key, so the
+guarantee is structural.
+
+**It clears at the END, with no refresh, and that placement is the whole point.**
+Doing the same clear in `before` — where it reads more naturally — needs a
+`browser.refresh()` to un-restore the repository, and that MEASURED at 528 s →
+**1064 s** for the suite (run `32246987758`): one extra refresh per spec file
+re-rolls the reload race, and every loss is a full **30 s** stall because the W3C
+script timeout is uncapped on Linux. Clearing after the last test needs no
+navigation at all. Any future "just reset the app between specs" idea inherits
+this: on this suite a refresh costs ~30 s times the probability of losing that
+race, not the ~1 s a page reload looks like.
+
+**Those 30 s stalls are the suite's real cost, and they are not selector
+failures.** Serial baseline (run `32242497631`): 528 s of spec time, of which
+roughly **eight** ~30 s stalls — every spec over 30 s is `n × 30` plus small
+change, and which specs pay moves run to run. The mechanism is already documented
+in `wdio.conf.ts` guard 2: an `execute()` landing mid-document-swap has its
+completion handler dropped, the driver waits the FULL script timeout, and the
+caller retries. macOS caps that at 2.5 s; **Linux does not cap it at all**, which
+is why a stall there is 30 s rather than invisible. Capping it on Linux is the
+biggest single lever left on the gate and is deliberately NOT done here: the
+comment's objection (a truncated-but-completed script gets retried, double-running
+side effects) is what `executeOnce` exists to neutralise, so the change is
+plausible — but it re-opens a documented CI flake class and needs its own
+verification runs, not a drive-by.
+
+Reproduce one CI shard locally: `E2E_SHARD=2 E2E_SHARDS=4 pnpm test:e2e:docker
+run` (`docker-compose.e2e.yml` threads both through). With neither set — every
+ordinary local and Docker run — `specs` keeps its plain glob and the run is
+byte-for-byte what it was.
 
 ## Architecture
 
@@ -863,6 +985,15 @@ module and every `src/features/*/` directory is named somewhere in here.
   Remote, diff, merge and update are ordinary words that occur all over this
   file, so those assertions would pass for the wrong reason and could never
   fail. Further doc invariants belong in this file; add cases, not counts.
+- **`test/shardSpecs.test.ts` is the second tree invariant here** (issue 189),
+  and it guards a SILENT failure: a spec that lands in no CI shard simply never
+  runs and the gate goes green. It reads the real `e2e/specs/` directory and the
+  real `shard: [...]` matrix out of `.github/workflows/e2e.yml`, then asserts the
+  split is a partition — every spec in exactly one shard, no shard empty, stable
+  run to run, and an unmeasured (newly added) spec still placed. That is why the
+  matrix array must stay on one line. Same reason it lives in `test/` rather than
+  beside the module: it asserts a fact about the tree and about `.github/`, and
+  it needs node, not the jsdom harness.
 - **`test/` is the repo root, not `src/test/`** — the two are unrelated despite
   the name. This suite reads `src-tauri/`, `CLAUDE.md` and `e2e/`, so it is not
   a frontend test. `pnpm test` runs both suites as two vitest **projects**

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -5,8 +5,10 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Tauri/WebKitGTK build+run deps + xvfb — same apt set as the CI workflow,
-# plus curl/git/build-essential to bootstrap node & rust.
+# Tauri/WebKitGTK build+run deps + xvfb, plus curl/git/build-essential to
+# bootstrap node & rust. This container does BOTH phases in one image, so it
+# installs the union: CI's `TAURI_APT_BUILD_DEPS` (whose Depends already pull the
+# runtime libs) plus xvfb, which CI now installs only in the shard jobs.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
       librsvg2-dev patchelf xvfb \

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -24,6 +24,11 @@ services:
     environment:
       CARGO_BUILD_JOBS: "2"
       CARGO_PROFILE_DEV_DEBUG: "0"
+      # Reproduce ONE CI shard locally: `E2E_SHARD=2 E2E_SHARDS=4 pnpm
+      # test:e2e:docker run`. Unset on the host means unset in the container,
+      # which is the unsharded whole-suite run (issue 189).
+      E2E_SHARD: "${E2E_SHARD:-}"
+      E2E_SHARDS: "${E2E_SHARDS:-}"
     volumes:
       # Source is bind-mounted so host edits are picked up without a rebuild.
       - .:/app

--- a/e2e/shardSpecs.ts
+++ b/e2e/shardSpecs.ts
@@ -1,0 +1,191 @@
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Splitting the e2e suite across CI runners (issue 189).
+ *
+ * The suite is not slow because it does too much — it is slow because
+ * `wdio.conf.ts` must keep `maxInstances: 1`. Every spec file gets its own
+ * WebDriver session, and an e2e-feature app binary serves WebDriver on a fixed
+ * port (4445), so two app instances in one container fight over it. Parallelism
+ * therefore has to happen across *runners*, one wdio process each.
+ *
+ * WebdriverIO's own `--shard x/y` exists, but it slices the alphabetical spec
+ * list into equal-COUNT chunks (`ConfigParser.shard`). Measured against this
+ * suite that is nearly the worst possible split: `keymap` (140 s), `palette`
+ * (66 s) and `history-ops` (35 s) are alphabetical neighbours, so shard 2 of 4
+ * came out at 256 s against 43 s for shard 4 — the critical path barely moves.
+ * So this module packs by measured DURATION instead.
+ *
+ * Two properties matter more than the balance, and both are tested in
+ * `test/shardSpecs.test.ts`:
+ *
+ * - **The spec list is derived from disk, never written down.** `listSpecFiles`
+ *   walks `e2e/specs/`, so a spec added, renamed or deleted by another change
+ *   is picked up with no edit here. A hardcoded filename list is how a
+ *   concurrent PR would silently drop its own new spec from CI.
+ * - **The split is a partition.** For any shard count, every spec runs in
+ *   exactly one shard. `WEIGHTS` below only decides *which* one.
+ *
+ * `WEIGHTS` is therefore a HINT, not a manifest: an entry that no longer
+ * matches a file is dead weight and an unlisted spec gets `DEFAULT_WEIGHT`.
+ * Either way the suite still runs whole; only the balance degrades. Re-measure
+ * it when the distribution has visibly drifted — see the header of `WEIGHTS`
+ * for how.
+ */
+
+/** Wall-clock seconds per spec file, RUNNING → PASSED (so app launch, the
+ *  conf `before` hook and teardown are all in the number, not just mocha's
+ *  own total).
+ *
+ *  Measured from GitHub Actions run 32242497631 (push to `main`, 2026-08-19,
+ *  ubuntu-latest + xvfb, warm caches). Re-measure with:
+ *
+ *      gh run view <id> --log \
+ *        | grep -E '\[0-[0-9]+\] (RUNNING|PASSED) in' \
+ *        | ...   # pair each RUNNING with its PASSED and diff the timestamps
+ *
+ *  Keys are BASENAMES, so a spec moved into a subdirectory keeps its weight. */
+export const WEIGHTS: Readonly<Record<string, number>> = {
+  "keymap.e2e.ts": 139.6,
+  "repo-tabs.e2e.ts": 96.1,
+  "palette.e2e.ts": 66.1,
+  "settings.e2e.ts": 37.3,
+  "history-diff.e2e.ts": 36.9,
+  "history-ops.e2e.ts": 34.9,
+  "stash.e2e.ts": 32.8,
+  "bisect.e2e.ts": 32.3,
+  "remote.e2e.ts": 7.5,
+  "merge-window.e2e.ts": 7.4,
+  "status-stage.e2e.ts": 5.3,
+  "merge-conflict.e2e.ts": 4.5,
+  "rebase.e2e.ts": 3.8,
+  "branches.e2e.ts": 3.5,
+  "keyboard-shortcuts.e2e.ts": 3.1,
+  "drag-and-drop.e2e.ts": 3.1,
+  "commit.e2e.ts": 2.1,
+  "worktrees.e2e.ts": 2.0,
+  "reflog.e2e.ts": 1.8,
+  "submodules.e2e.ts": 1.7,
+  "resizable-panes.e2e.ts": 1.7,
+  "smoke.e2e.ts": 1.6,
+  "create.e2e.ts": 1.3,
+  "pulls.e2e.ts": 1.1,
+  "open-persisted-screen.e2e.ts": 0.8,
+  "harness.e2e.ts": 0.3,
+};
+
+/** What an unmeasured spec is assumed to cost.
+ *
+ *  The suite MEAN, not the median. The median spec is ~3 s and the mean ~20 s,
+ *  because the distribution is dominated by a handful of long files — so
+ *  guessing the median would routinely stack a genuinely slow new spec on top
+ *  of an already-heavy shard, while guessing the mean only mis-balances a fast
+ *  one. Being wrong here costs seconds of imbalance, never a dropped spec. */
+export const DEFAULT_WEIGHT = 20;
+
+export function weightOf(specPath: string): number {
+  const base = specPath.split(/[\\/]/).pop() ?? specPath;
+  return WEIGHTS[base] ?? DEFAULT_WEIGHT;
+}
+
+/**
+ * The subset of `specs` that shard `shard` of `total` should run (both
+ * one-based, matching `--shard x/y` and the workflow matrix).
+ *
+ * Longest-processing-time-first bin packing: heaviest spec first, each one onto
+ * whichever shard is currently lightest. LPT's bound is
+ * `max ≤ ideal + heaviest`, which is why the heaviest single spec sets the
+ * floor for the whole gate no matter how many runners are thrown at it — at
+ * the time of measuring that is `keymap.e2e.ts` at 140 s, and splitting THAT
+ * file is the next lever, not more shards.
+ *
+ * Deterministic by construction, so a spec lands in the same shard run to run
+ * and a shard failure is reproducible: ordering ties break on the path, and the
+ * lightest-shard tie breaks on the lowest shard index. The returned list is
+ * restored to the input's sorted order, so specs still run alphabetically
+ * within a shard — the same relative order as an unsharded run.
+ */
+export function shardSpecs(
+  specs: readonly string[],
+  shard: number,
+  total: number,
+): string[] {
+  if (!Number.isInteger(total) || total < 1) {
+    throw new Error(`shard total must be a positive integer, got ${total}`);
+  }
+  if (!Number.isInteger(shard) || shard < 1 || shard > total) {
+    throw new Error(`shard must be an integer in 1..${total}, got ${shard}`);
+  }
+
+  const sorted = [...specs].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  if (total === 1) return sorted;
+
+  const order = [...sorted].sort((a, b) => {
+    const d = weightOf(b) - weightOf(a);
+    return d !== 0 ? d : a < b ? -1 : 1;
+  });
+
+  const loads = new Array<number>(total).fill(0);
+  const bins: string[][] = Array.from({ length: total }, () => []);
+  for (const spec of order) {
+    let pick = 0;
+    for (let i = 1; i < total; i += 1) {
+      if (loads[i] < loads[pick]) pick = i;
+    }
+    bins[pick].push(spec);
+    loads[pick] += weightOf(spec);
+  }
+
+  const mine = new Set(bins[shard - 1]);
+  return sorted.filter((s) => mine.has(s));
+}
+
+/**
+ * Every spec file under `dir`, recursively, as absolute paths.
+ *
+ * Mirrors `wdio.conf.ts`'s `./specs/**` + `*.e2e.ts` glob rather than assuming
+ * the directory is flat, so the two cannot disagree about what the suite is.
+ * Kept in this module (and not inlined in the conf) so the shard invariants can
+ * be asserted against the REAL tree from `test/`.
+ */
+export function listSpecFiles(dir: string): string[] {
+  const out: string[] = [];
+  const walk = (d: string): void => {
+    for (const entry of readdirSync(d, { withFileTypes: true })) {
+      const full = join(d, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith(".e2e.ts")) out.push(full);
+    }
+  };
+  walk(dir);
+  return out.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+/** `E2E_SHARD` / `E2E_SHARDS` parsed, or null when this run is not sharded.
+ *
+ *  Env rather than a CLI flag because both the CI workflow and
+ *  `docker-compose.e2e.yml` already thread env into the run, and because the
+ *  conf must be able to keep its plain glob when nothing is set — an unsharded
+ *  run has to stay byte-for-byte what it was. */
+export function shardFromEnv(
+  env: Record<string, string | undefined>,
+): { shard: number; total: number } | null {
+  const rawShard = env.E2E_SHARD?.trim();
+  const rawTotal = env.E2E_SHARDS?.trim();
+  if (!rawShard && !rawTotal) return null;
+  if (!rawShard || !rawTotal) {
+    throw new Error(
+      "E2E_SHARD and E2E_SHARDS must be set together " +
+        `(got E2E_SHARD=${rawShard ?? "<unset>"} E2E_SHARDS=${rawTotal ?? "<unset>"})`,
+    );
+  }
+  const shard = Number(rawShard);
+  const total = Number(rawTotal);
+  if (!Number.isInteger(shard) || !Number.isInteger(total)) {
+    throw new Error(
+      `E2E_SHARD / E2E_SHARDS must be integers (got "${rawShard}" / "${rawTotal}")`,
+    );
+  }
+  return { shard, total };
+}

--- a/e2e/wdio.conf.ts
+++ b/e2e/wdio.conf.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import type { TauriCapabilities } from "@wdio/tauri-service";
 import { $, browser } from "@wdio/globals";
 import { armDriverBridge, ensureMacAppFocus } from "./support/app";
+import { listSpecFiles, shardFromEnv, shardSpecs } from "./shardSpecs";
 
 // The app registers tauri-plugin-single-instance; a test binary starting
 // while any platypusgit instance runs would forward-and-exit instead of
@@ -24,9 +25,39 @@ const tauriCapability: TauriCapabilities = {
   },
 };
 
+// One runner cannot run two app instances (an e2e-feature binary serves
+// WebDriver on a fixed port), so `maxInstances` has to stay 1 and the suite is
+// parallelised across CI RUNNERS instead: the workflow's matrix sets E2E_SHARD /
+// E2E_SHARDS and each job runs its own slice (issue 189). With neither set —
+// every local and Docker run — `specs` keeps the plain glob and the run is
+// byte-for-byte what it was. See e2e/shardSpecs.ts for the split itself.
+const shard = shardFromEnv(process.env);
+const specs = shard
+  ? shardSpecs(
+      listSpecFiles(path.resolve(import.meta.dirname, "./specs")),
+      shard.shard,
+      shard.total,
+    )
+  : ["./specs/**/*.e2e.ts"];
+
+if (shard) {
+  // The one line that makes a shard failure reproducible: it names the exact
+  // slice, so `--spec` can replay it locally.
+  console.log(
+    `[e2e] shard ${shard.shard}/${shard.total}: ${specs.length} spec(s)\n` +
+      specs.map((s) => `  ${path.basename(s)}`).join("\n"),
+  );
+  if (specs.length === 0) {
+    throw new Error(
+      `shard ${shard.shard}/${shard.total} resolved to no specs — more shards ` +
+        "than spec files, or e2e/specs/ is empty",
+    );
+  }
+}
+
 export const config: WebdriverIO.Config = {
   runner: "local",
-  specs: ["./specs/**/*.e2e.ts"],
+  specs,
   maxInstances: 1,
   capabilities: [tauriCapability],
   services: [
@@ -82,6 +113,31 @@ export const config: WebdriverIO.Config = {
       timeout: 30_000,
       timeoutMsg: "app never rendered Welcome screen",
     });
+  },
+  // Leave the slate clean for the NEXT spec file in this job.
+  //
+  // A spec file gets a fresh app PROCESS but not a fresh app data dir, so
+  // localStorage survives between spec files — and `pg-open-repos` makes the
+  // next launch restore a repository instead of rendering Welcome, the screen
+  // the `before` hook above and every `openRepo` wait for. Two specs leave that
+  // key behind (`repo-tabs`, `open-persisted-screen`); today it never bites only
+  // because they also dispose their temp repos, so the restore fails and Welcome
+  // renders anyway. That is a property of two OTHER files, and sharding changes
+  // which spec follows which — so clear it here and the guarantee is structural.
+  //
+  // Deliberately at the END, and deliberately with NO refresh. Doing it in
+  // `before` instead cost ~30s per spec file and nearly DOUBLED the suite
+  // (measured: 528s -> 1064s over run 32246987758): the extra `browser.refresh()`
+  // re-rolled the reload race the conf documents above, and on Linux the W3C
+  // script timeout is uncapped, so each loss is a full 30s stall. Clearing
+  // after the last test needs no navigation, so it adds no refresh and no roll.
+  after: async () => {
+    try {
+      await browser.execute(() => localStorage.clear());
+    } catch {
+      // Session already gone (crashed spec). The next launch inherits whatever
+      // is on disk — exactly the pre-existing behaviour, so nothing to do.
+    }
   },
   // Heal mid-suite focus steals (another app grabbing foreground between
   // tests): one cheap execute per test when already focused, setFocus retry

--- a/test/shardSpecs.test.ts
+++ b/test/shardSpecs.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  DEFAULT_WEIGHT,
+  listSpecFiles,
+  shardFromEnv,
+  shardSpecs,
+  weightOf,
+} from "../e2e/shardSpecs";
+
+/**
+ * The e2e suite is sharded across CI runners (issue 189), and the shard split is
+ * the one piece of CI plumbing whose failure mode is SILENT: a spec that lands
+ * in no shard simply never runs, and the gate goes green.
+ *
+ * So this suite asserts the split is a partition of what is actually on disk,
+ * for the shard count the workflow actually uses. It lives in `test/` for the
+ * same reason `docs.test.ts` does — it asserts a fact about the tree (and about
+ * `.github/`), not about the frontend, and it needs node rather than the jsdom
+ * component harness.
+ */
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+const SPECS_DIR = path.join(REPO_ROOT, "e2e", "specs");
+const WORKFLOW = path.join(REPO_ROOT, ".github", "workflows", "e2e.yml");
+
+/** The shard count from the workflow matrix — the ONE place it is written down
+ *  (the run step reads its total from `strategy.job-total`). Regex rather than a
+ *  YAML parser to avoid a dependency for one line; the matrix therefore has to
+ *  keep the array on one line, which the workflow comment says. */
+function matrixShards(): number[] {
+  const yaml = readFileSync(WORKFLOW, "utf8");
+  const m = yaml.match(/^\s*shard:\s*\[([^\]]*)\]\s*$/m);
+  if (!m) {
+    throw new Error(
+      "no single-line `shard: [ ... ]` matrix found in .github/workflows/e2e.yml — " +
+        "the e2e matrix moved or was reformatted, so this suite can no longer " +
+        "check that every spec lands in a shard",
+    );
+  }
+  return m[1]
+    .split(",")
+    .map((s) => Number(s.trim()))
+    .filter((n) => !Number.isNaN(n));
+}
+
+/** Every spec runs exactly once across shards 1..total. */
+function partitionOf(specs: string[], total: number): string[] {
+  const seen: string[] = [];
+  for (let shard = 1; shard <= total; shard += 1) {
+    seen.push(...shardSpecs(specs, shard, total));
+  }
+  return seen;
+}
+
+describe("e2e shard split", () => {
+  const specs = listSpecFiles(SPECS_DIR);
+
+  it("finds the spec files on disk", () => {
+    // A walk that silently returns nothing would make every partition
+    // assertion below vacuously true.
+    expect(specs.length).toBeGreaterThan(10);
+    expect(specs.every((s) => s.endsWith(".e2e.ts"))).toBe(true);
+  });
+
+  it("is a partition of the real suite at the workflow's shard count", () => {
+    const shards = matrixShards();
+    // 1..N, in order — the run step passes `matrix.shard` straight through as
+    // the one-based shard number, so a gap or a zero would skip a slice.
+    expect(shards).toEqual(shards.map((_, i) => i + 1));
+
+    const seen = partitionOf(specs, shards.length);
+    expect([...seen].sort()).toEqual([...specs].sort());
+    expect(new Set(seen).size).toBe(specs.length);
+  });
+
+  it("is a partition at every shard count up to the spec count", () => {
+    for (let total = 1; total <= specs.length; total += 1) {
+      const seen = partitionOf(specs, total);
+      expect(new Set(seen).size, `total=${total}`).toBe(specs.length);
+      expect(seen.length, `total=${total}`).toBe(specs.length);
+      // No shard may be empty while there are at least as many specs as
+      // shards, or a runner would spin up to test nothing.
+      for (let shard = 1; shard <= total; shard += 1) {
+        expect(
+          shardSpecs(specs, shard, total).length,
+          `shard ${shard}/${total}`,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("keeps a spec in the same shard run to run", () => {
+    expect(shardSpecs(specs, 2, 4)).toEqual(shardSpecs(specs, 2, 4));
+    // ...and independent of the order the caller happened to walk the dir in.
+    expect(shardSpecs([...specs].reverse(), 2, 4)).toEqual(
+      shardSpecs(specs, 2, 4),
+    );
+  });
+
+  it("runs specs in the same relative order as an unsharded run", () => {
+    const mine = shardSpecs(specs, 3, 4);
+    expect(mine).toEqual(specs.filter((s) => mine.includes(s)));
+  });
+
+  it("still runs a spec nobody has measured", () => {
+    // The invariant that lets a concurrent PR add a spec without touching
+    // WEIGHTS: an unmeasured file is weighted, placed and run like any other.
+    const added = path.join(SPECS_DIR, "brand-new-feature.e2e.ts");
+    expect(weightOf(added)).toBe(DEFAULT_WEIGHT);
+    const withNew = [...specs, added].sort();
+    const seen = partitionOf(withNew, 4);
+    expect(seen.filter((s) => s === added)).toEqual([added]);
+    expect(new Set(seen).size).toBe(withNew.length);
+  });
+
+  it("balances by measured duration, not by file count", () => {
+    // The whole reason this module exists instead of wdio's own `--shard`.
+    // LPT's guarantee is max ≤ ideal + heaviest, so assert exactly that — a
+    // packer that dumped everything into shard 1 would blow it, and so would
+    // one that split alphabetically.
+    const total = 4;
+    const loads: number[] = [];
+    for (let shard = 1; shard <= total; shard += 1) {
+      loads.push(
+        shardSpecs(specs, shard, total).reduce((n, s) => n + weightOf(s), 0),
+      );
+    }
+    const sum = loads.reduce((a, b) => a + b, 0);
+    const heaviest = Math.max(...specs.map(weightOf));
+    expect(Math.max(...loads)).toBeLessThanOrEqual(sum / total + heaviest);
+    // And every runner gets real work: the lightest shard is not a rounding
+    // error next to the ideal.
+    expect(Math.min(...loads)).toBeGreaterThan(0);
+  });
+
+  it("rejects a shard number outside the matrix", () => {
+    expect(() => shardSpecs(specs, 0, 4)).toThrow();
+    expect(() => shardSpecs(specs, 5, 4)).toThrow();
+    expect(() => shardSpecs(specs, 1, 0)).toThrow();
+    expect(() => shardSpecs(specs, 1.5, 4)).toThrow();
+  });
+});
+
+describe("shardFromEnv", () => {
+  it("is null when nothing is set, so a local run keeps the plain glob", () => {
+    expect(shardFromEnv({})).toBeNull();
+    expect(shardFromEnv({ E2E_SHARD: "", E2E_SHARDS: "" })).toBeNull();
+  });
+
+  it("parses a matrix pair", () => {
+    expect(shardFromEnv({ E2E_SHARD: "2", E2E_SHARDS: "4" })).toEqual({
+      shard: 2,
+      total: 4,
+    });
+  });
+
+  it("refuses a half-configured run rather than silently running everything", () => {
+    // Half-set means an editing mistake in the workflow. Running the WHOLE
+    // suite in all four jobs would still be green, so it has to be loud.
+    expect(() => shardFromEnv({ E2E_SHARD: "2" })).toThrow(/together/);
+    expect(() => shardFromEnv({ E2E_SHARDS: "4" })).toThrow(/together/);
+    expect(() =>
+      shardFromEnv({ E2E_SHARD: "one", E2E_SHARDS: "4" }),
+    ).toThrow(/integers/);
+  });
+});


### PR DESCRIPTION
The e2e gate dominated the PR feedback loop at ~11 min. Measured from run
`32242497631`: build **50 s**, suite **594 s** — so the suite, not the build,
and `maxInstances: 1` is why. It cannot go up (an `e2e`-feature binary serves
WebDriver on a fixed port, so two app instances in one container collide), so
this parallelises across *runners*.

## Measured per-spec durations first (issue 189 item B)

Wall clock `RUNNING` → `PASSED` per spec file from run `32242497631`, so app
launch, the conf `before` hook and teardown are all in the number:

| spec | s | | spec | s |
|---|---:|---|---|---:|
| keymap | 139.6 | | rebase | 3.8 |
| repo-tabs | 96.1 | | branches | 3.5 |
| palette | 66.1 | | keyboard-shortcuts | 3.1 |
| settings | 37.3 | | drag-and-drop | 3.1 |
| history-diff | 36.9 | | commit | 2.1 |
| history-ops | 34.9 | | worktrees | 2.0 |
| stash | 32.8 | | reflog | 1.8 |
| bisect | 32.3 | | submodules | 1.7 |
| remote | 7.5 | | resizable-panes | 1.7 |
| merge-window | 7.4 | | smoke | 1.6 |
| status-stage | 5.3 | | create | 1.3 |
| merge-conflict | 4.5 | | pulls | 1.1 |
| | | | open-persisted-screen | 0.8 |
| | | | harness | 0.3 |

528 s of spec time, and **eight files are 90 % of it**. No egregious offender to
fix: no `pause()`, no reverse-wait timeouts, no doomed selector, both conf
speed guards intact. The cost is structural — the heavy specs call `openRepo()`
once per `it()` (keymap 28×, palette 8×, repo-tabs 10× `resetApp`), and one of
those is a refresh + re-arm + repo open + syncing settle, ~5 s under xvfb.
Fixing *that* means sharing a repo across tests, which trades away per-test
isolation and collides with two concurrent PRs editing `e2e/specs/` — recorded
as the next lever, not done here.

## The change

- **`build`** compiles the debug binary once and uploads `e2e/.bin/platypusgit`
  as an artifact. The shard jobs need no Rust toolchain and no `rust-cache` at
  all; they `chmod +x` it, since the artifact format drops the exec bit.
- **`e2e`** is a matrix of four runners, `fail-fast: false` so one broken spec
  does not hide the other three shards. The matrix array is the ONLY place the
  shard count is written down — the run step reads its total from
  `strategy.job-total`.
- **`e2e-linux`** keeps its exact name and stays the only required check, so
  **no ruleset edit is needed**. It now needs `changes`, `build` and `e2e`, and
  still fails on any skip it cannot explain. `needs.<matrix job>.result` is the
  aggregate, so one comparison already means "every shard passed".

### The split is derived, not listed

`e2e/shardSpecs.ts`: `listSpecFiles` walks `e2e/specs/`, `shardSpecs` packs by
measured duration (longest-processing-time-first, ties on the path, so it is
deterministic and a spec lands in the same shard run to run). wdio's own
`--shard x/y` was rejected — it slices the *alphabetical* list by count, which
measured **256 s vs 43 s** here because `keymap`, `palette` and `history-ops`
are alphabetical neighbours.

`WEIGHTS` is a hint with provenance in its comment, not a manifest: an unlisted
spec gets the suite mean and still runs, a stale entry is dead weight, and
neither can drop a spec. `test/shardSpecs.test.ts` reads the real spec
directory and the real `shard: [...]` matrix out of the workflow and asserts the
split is a partition — which is the one failure mode here that would otherwise
be silent *and* green.

LPT's bound is `max ≤ ideal + heaviest`, so `keymap` at 140 s is the gate's
floor: four shards already sit there (139.6 / 129.5 / 129.6 / 129.9) and a
fifth runner buys nothing.

### Spec independence, confirmed by making it true

A spec file gets a fresh app *process* but not a fresh app *data dir*, so
`localStorage` survives between spec files — and `pg-open-repos` makes the next
launch restore a repository instead of rendering Welcome, the screen the conf
`before` hook and every `openRepo` wait for. Today that never bites only
because the two specs that leave the key behind (`repo-tabs`,
`open-persisted-screen`) also dispose their temp repos, so the restore fails and
Welcome renders anyway. That is a property of two *other* files, and sharding
changes which spec follows which — so the `before` hook now ends with
`resetApp(30_000)`. One refresh per spec file (~1 s, ~11 s on the largest
shard); independence becomes structural instead of incidental.

### Option D — the duplicate push-to-`main` run

**Kept, deliberately.** Required checks are non-strict and merges are squashes,
so the tree that lands on `main` can differ from the tree the PR tested; the
push run is the only thing that ever tests `main` itself. It blocks nobody,
`concurrency: cancel-in-progress` already collapses a burst of merges into one
run, and sharding roughly halved what it costs. Moving it to nightly would
trade "green main, known in minutes" for "broken main, found up to a day later,
then bisect the merges" — the same failure mode issue 189 rejects for
release-only e2e, at a smaller scale. Reasoning recorded in CLAUDE.md so it is
not re-litigated silently.

Release-only e2e is **not** implemented, as the issue argues against it and it
would need `unit-tests`/`rust-tests` promoted to required first.

## Verification

- `pnpm exec tsc -p e2e/tsconfig.json --noEmit`, `pnpm tsc --noEmit`,
  `pnpm test` (197 files / 1689 tests) all green.
- Gate behaviour is being exercised on this PR in three shapes: all shards
  pass, one shard forced to fail, and a legitimately skipped suite.

Refs issue 189