### PR TITLE
feat(rebase): interactive rebase onto any commit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,10 @@ Context for future Claude sessions working on this repo. Keep it current when ar
 New feature beyond MVP slice → write new spec + plan under these folders first.
 
 Recent specs/plans (for context on current direction):
+- `2026-08-19-rebase-onto-any-commit-*` — interactive rebase onto a base the
+  branch does not descend from: the range from `commitsBetween` with an
+  `aheadBehind`-derived limit, the base attached to the plan's first non-Drop
+  step at SUBMIT, and a `rebase-onto` NavIntent behind three menu items (186).
 - `2026-08-18-diff-minimap-*` — the scrubable canvas gutter down the side of every
   diff: per-line bars from the flat `DiffRow[]` + heights, a viewport band, click /
   drag scrubbing, and one measured width below which it hides (#161 part 2).
@@ -594,7 +598,7 @@ features/            Per-feature: components + Zustand store colocated
 │                    Resolve/Finish/Abort), ownership (the `safe.directory`
 │                    confirm — outside the store so store tests need no dialog)
 ├── nav/             useNavStore — cross-screen intents (diff-file, commit-vs-wt,
-│                    file-history, blame, rebase-plan, stash-diff) +
+│                    file-history, blame, rebase-plan, rebase-onto, stash-diff) +
 │                    DeepViewHeader (the origin crumb a deep view goes back to)
 ├── branches/        BranchChip (titlebar), BranchPicker (popover), orderBranches
 │                    (PURE, #135: default branch first, then newest `tipTime`
@@ -609,7 +613,8 @@ features/            Per-feature: components + Zustand store colocated
 │                    picker exists to leave
 ├── commits/         The log's pure logic, all tested: graphLayout + laneColors +
 │                    graphAncestry + rowIdentity (the graph — #68 G2/G4/G9),
-│                    buildRebasePlan / buildPreservePlan / runRebasePlan /
+│                    buildRebasePlan / buildPreservePlan / withPlanBase /
+│                    runRebasePlan /
 │                    planCommitSelection / squashMessage (the rebase plans), plus
 │                    headAncestry (`headAncestryOf`, see commands/commits.rs) and
 │                    logFilter (History's search inputs → a backend `LogFilter`)
@@ -1391,6 +1396,35 @@ module and every `src/features/*/` directory is named somewhere in here.
   worktree untouched. Before this, an unexecutable step (a merge commit, which
   libgit2 refuses to cherry-pick without a mainline) surfaced mid-replay with
   earlier picks already committed and the branch tip already moved.
+- **A plan may name a base the branch does not descend from — that is
+  `git rebase --onto`** (186). `rebase_plan::validate` accepts any existing
+  commit as an `onto`, with **no ancestry requirement**, so the diverged case
+  needed no engine change at all. Four things follow:
+  - **`onto` reaches the run through TWO sites, and either one alone places the
+    first step**: `rebase_start`'s initial `set_head_detached` (base =
+    `first_step.onto`, else that commit's first parent) and `advance_rebase`'s
+    per-step `move_to_base`. Verified by mutation — killing one leaves
+    `tests/rebase_onto_new_base.rs` green; only killing both replays the branch
+    on its own root. Anyone changing where a run starts has to find both.
+  - The base is attached at **submit**, by `withPlanBase`
+    (`features/commits/withPlanBase.ts`), never when the rows are built. Flatten
+    mode lets the user reorder, and the base belongs to whichever step ends up
+    first — baked into a row, a drag would carry it away. That is a bug which
+    PREDATES the diverged base: with every row's `onto` null, a reordered plan
+    detached at the new first step's own parent, i.e. the middle of its own
+    range. The Rebase screen therefore tracks a base for EVERY plan it can
+    submit, including one seeded by `Interactive rebase from here`; null (a root
+    commit, or an oldest step outside the loaded log) keeps the parent fallback.
+  - The frontend range is `commitsBetween(base, HEAD)` when the base is diverged
+    and `commitsSince` when it is an ancestor, chosen by `aheadBehind`'s
+    `behind === 0` (nothing reachable from the base is missing from HEAD — that
+    IS "ancestor"). **`commits_since` is not loosened** — its ancestor
+    requirement is the on-branch flow's invariant, and keeping the split leaves
+    it its only caller instead of making it dead code.
+  - `commits_between`'s handler defaults `limit` to **200** and breaks at the
+    cap, so the limit is derived from `aheadBehind`'s exact `ahead` and the
+    length is verified. A truncated plan leaves commits unreplayed and still
+    moves the branch ref, so a mismatch is refused rather than planned.
 - **The replay runs on a detached HEAD** and moves the branch ref exactly once,
   when the plan completes (`finish_rebase`). So a failed or paused rebase never
   leaves the branch mid-replay, and `rebase_abort` is "put HEAD back on the

--- a/docs/superpowers/plans/2026-08-19-rebase-onto-any-commit-plan.md
+++ b/docs/superpowers/plans/2026-08-19-rebase-onto-any-commit-plan.md
@@ -1,0 +1,1351 @@
+# Interactive rebase onto any commit — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pick any commit or branch as a new base and replay the current branch onto it through the interactive Rebase screen — `git rebase -i <newbase>`.
+
+**Architecture:** The backend already does this: `rebase_start` takes the run's base from the first non-Drop step's `onto`, and `rebase_plan::validate` accepts an `onto` below the range with no ancestry check. So the work is (a) a range from `commitsBetween` instead of `commitsSince` when the base is diverged, with the limit derived from `aheadBehind` so a plan can never be silently truncated, (b) one pure helper that attaches the base to the plan's first non-Drop step at submit time, and (c) a new `rebase-onto` NavIntent plus three context-menu entry points.
+
+**Tech Stack:** Rust (git2/libgit2) + Tauri 2 backend; React 19 + TypeScript + Zustand frontend; vitest (jsdom + node projects); `cargo test` integration suite over real temp repos.
+
+**Spec:** `docs/superpowers/specs/2026-08-19-rebase-onto-any-commit-spec.md`
+
+## Global Constraints
+
+- Toolchain: Node 22 + **pnpm** (at `~/Library/pnpm`), Rust stable at `~/.cargo/bin`. Every shell step must be prefixed with `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"`.
+- Gates, all four: `pnpm tsc --noEmit`, `pnpm test`, `pnpm exec tsc -p e2e/tsconfig.json --noEmit`, `cargo test --manifest-path src-tauri/Cargo.toml`.
+- **Do NOT loosen `commits_since`.** Its ancestor requirement is an invariant of the on-branch flow.
+- **`BranchInfo.tip` is a FULL oid.** Never shorten it at the source; `shortSha` belongs at display sites only.
+- Frontend never calls `invoke()` directly — only the typed wrappers in `src/lib/tauri.ts`.
+- Every new `NavIntent` kind needs a `case` in `AppShell.tsx`'s routing switch **and** a row in `AppShell.navroutes.test.tsx`'s `EXPECTED` table. Both are compile-enforced.
+- Any new row surface opts into UI density via `var(--row-step)`. (Nothing here adds a list row; the two new strips are chrome, which stays fixed.)
+- E2E runs **only** through `pnpm test:e2e:docker` — never natively. One cold container build at a time across all worktrees.
+- Commit style: Conventional Commits, imperative subject under 72 chars, `Co-Authored-By: Claude …` trailer.
+
+---
+
+## File Structure
+
+**Create**
+
+| File | Responsibility |
+| --- | --- |
+| `src/features/commits/withPlanBase.ts` | PURE: attach a run's base to a plan's first non-Drop step. |
+| `src/features/commits/withPlanBase.test.ts` | Its unit tests (node-grade pure logic). |
+| `src/screens/Rebase.onto.test.tsx` | Component tests for the diverged-base flow on the Rebase screen. |
+| `src-tauri/tests/rebase_onto_new_base.rs` | Rust integration: replay a branch onto a genuinely diverged base. |
+
+**Modify**
+
+| File | Change |
+| --- | --- |
+| `src/features/nav/useNavStore.ts` | Add the `rebase-onto` intent kind. |
+| `src/AppShell.tsx` | Route `rebase-onto` → `rebase`. |
+| `src/AppShell.navroutes.test.tsx` | `EXPECTED` row for `rebase-onto`. |
+| `src/screens/Rebase.tsx` | One `resolveBase` path (aheadBehind → commitsSince/commitsBetween), `baseRev`/`baseStats`/`baseNotice` state, the summary strip, the out-of-picker notice strip, `withPlanBase` at submit. |
+| `src/features/rebase/RebaseBasePicker.tsx` | Delete the dead `invalidOids` prop. |
+| `src/design/context-menu.tsx` | Three new menu items + a `branchTipOid` helper. |
+| `src/features/commits/buildPreservePlan.ts` | Doc comment: the first step's base now comes from `withPlanBase`. |
+| `CLAUDE.md` | Spec/plan list entry, the interactive-rebase-engine bullets, the nav-intent list. |
+| `e2e/specs/rebase.e2e.ts` | One case for the new flow (Task 8, gated on a cheap fixture). |
+
+---
+
+### Task 1: `withPlanBase` — the pure base attachment
+
+**Files:**
+- Create: `src/features/commits/withPlanBase.ts`
+- Test: `src/features/commits/withPlanBase.test.ts`
+
+**Interfaces:**
+- Consumes: `RebaseStep`, `RebaseAction` from `@/lib/types`.
+- Produces: `withPlanBase(steps: RebaseStep[], baseOid: string | null): RebaseStep[]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/commits/withPlanBase.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { withPlanBase } from "./withPlanBase";
+import type { RebaseStep } from "@/lib/types";
+
+const A = "a".repeat(40);
+const B = "b".repeat(40);
+const C = "c".repeat(40);
+const BASE = "9".repeat(40);
+
+function step(oid: string, over: Partial<RebaseStep> = {}): RebaseStep {
+  return { oid, action: "Pick", message: null, onto: null, mergeParents: [], ...over };
+}
+
+describe("withPlanBase", () => {
+  it("names the base on the first step and leaves the rest linear", () => {
+    const out = withPlanBase([step(A), step(B), step(C)], BASE);
+    expect(out.map((s) => s.onto)).toEqual([BASE, null, null]);
+  });
+
+  it("skips leading drops — the engine reads the first NON-Drop step", () => {
+    const out = withPlanBase(
+      [step(A, { action: "Drop" }), step(B), step(C)],
+      BASE,
+    );
+    expect(out.map((s) => s.onto)).toEqual([null, BASE, null]);
+  });
+
+  it("leaves an intermediate step's own base alone (the preserve case)", () => {
+    const out = withPlanBase([step(A), step(B, { onto: A }), step(C)], BASE);
+    expect(out.map((s) => s.onto)).toEqual([BASE, A, null]);
+  });
+
+  it("overwrites the first step's own base — a picked base outranks it", () => {
+    const out = withPlanBase([step(A, { onto: C }), step(B)], BASE);
+    expect(out[0].onto).toBe(BASE);
+  });
+
+  it("is the identity when no base is known", () => {
+    const plan = [step(A), step(B)];
+    expect(withPlanBase(plan, null)).toBe(plan);
+  });
+
+  it("is the identity for an all-Drop plan (the backend refuses it anyway)", () => {
+    const plan = [step(A, { action: "Drop" }), step(B, { action: "Drop" })];
+    expect(withPlanBase(plan, BASE).map((s) => s.onto)).toEqual([null, null]);
+  });
+
+  it("does not mutate its input", () => {
+    const plan = [step(A), step(B)];
+    withPlanBase(plan, BASE);
+    expect(plan[0].onto).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm vitest run --project unit src/features/commits/withPlanBase.test.ts
+```
+
+Expected: FAIL — `Failed to resolve import "./withPlanBase"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/features/commits/withPlanBase.ts`:
+
+```ts
+import type { RebaseStep } from "@/lib/types";
+
+/**
+ * Attach a run's base to a plan: `onto: baseOid` on the FIRST non-Drop step.
+ *
+ * `rebase_start` takes the run's base from exactly that step's `onto`, falling
+ * back to its first parent when there is none (`libgit2.rs`). Naming the base
+ * explicitly is what makes a plan `git rebase --onto <base>` — the whole reason a
+ * diverged base works at all — and `rebase_plan::validate` accepts any existing
+ * commit there, with no ancestry requirement.
+ *
+ * Call this at SUBMIT, never when the rows are built. Flatten mode lets the user
+ * reorder the plan, and the base belongs to the plan's first step rather than to
+ * the row that happened to be first when it was built: pinned at build time, a
+ * row dragged out of first place would take the base with it and the run would
+ * detach somewhere else.
+ *
+ * `baseOid: null` means "nothing better than the engine's parent fallback is
+ * known" (a root commit, or an oldest step outside the loaded log) and returns
+ * the plan untouched. `baseOid` may be any revspec — an oid, a prefix, a branch
+ * name — because both the validator and the engine `revparse_single` it.
+ */
+export function withPlanBase(
+  steps: RebaseStep[],
+  baseOid: string | null,
+): RebaseStep[] {
+  if (!baseOid) return steps;
+  const first = steps.findIndex((s) => s.action !== "Drop");
+  if (first < 0) return steps;
+  return steps.map((s, i) => (i === first ? { ...s, onto: baseOid } : s));
+}
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+```bash
+pnpm vitest run --project unit src/features/commits/withPlanBase.test.ts
+```
+
+Expected: 7 passing.
+
+- [ ] **Step 5: Mutation-check**
+
+Change `s.action !== "Drop"` to `true` (i.e. `const first = 0;`), re-run, and
+confirm the leading-drops test fails. Restore. Then change the returned object to
+`{ ...s }` (no `onto`), re-run, confirm the first two tests fail. Restore.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/commits/withPlanBase.ts src/features/commits/withPlanBase.test.ts
+git commit -m "feat(rebase): pure helper naming a plan's base on its first step"
+```
+
+---
+
+### Task 2: The `rebase-onto` NavIntent and its routing
+
+**Files:**
+- Modify: `src/features/nav/useNavStore.ts` (the `NavIntent` union)
+- Modify: `src/AppShell.tsx` (the routing switch, near `case "rebase-plan":`)
+- Test: `src/AppShell.navroutes.test.tsx` (the `EXPECTED` table)
+
+**Interfaces:**
+- Produces: `{ kind: "rebase-onto"; base: string; label: string }` on `NavIntent`. `base` is any revspec (full oid preferred); `label` is display text — for a commit `"abc1234 — subject"`, for a branch its name.
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/AppShell.navroutes.test.tsx`, add to `EXPECTED` right after the
+`"rebase-plan"` row:
+
+```ts
+  // The diverged-base flow (186). The intent names a base and nothing else —
+  // the SCREEN resolves the range, because the log is paged and a branch menu
+  // has no commit list at all.
+  "rebase-onto": {
+    intent: { kind: "rebase-onto", base: OID2, label: "other" },
+    screen: "rebase",
+  },
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm vitest run --project unit src/AppShell.navroutes.test.tsx
+```
+
+Expected: FAIL — TypeScript rejects `"rebase-onto"` as an unknown key of the
+mapped type (and, once the union has it, the run fails on `assertNever`).
+
+- [ ] **Step 3: Add the kind and route it**
+
+In `src/features/nav/useNavStore.ts`, after the `rebase-plan` member:
+
+```ts
+  | { kind: "rebase-plan"; plan: RebaseStep[] }
+  /**
+   * Replay the current branch onto a NEW base, interactively (186) — the
+   * `git rebase -i <newbase>` half. `base` is any revspec (a full oid where the
+   * caller has one, else a branch name); `label` is what to call it on screen.
+   *
+   * Deliberately NOT a `rebase-plan` carrying a base: the range is `base..HEAD`
+   * and only the backend can walk it. The log is PAGED, so a plan assembled from
+   * `useRepoStore.commits` would silently come up short for exactly the diverged
+   * bases this exists for — and a branch context menu has a name, not commits.
+   */
+  | { kind: "rebase-onto"; base: string; label: string }
+```
+
+In `src/AppShell.tsx`, extend the existing case:
+
+```ts
+      case "rebase-plan":
+      // The base-only variant (186). Same destination: the Rebase screen owns
+      // the range walk and the plan either way.
+      case "rebase-onto":
+        setScreen("rebase");
+        break;
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+```bash
+pnpm vitest run --project unit src/AppShell.navroutes.test.tsx
+```
+
+Expected: all rows pass, including `sends "rebase-onto" to rebase`.
+
+- [ ] **Step 5: Mutation-check**
+
+Delete `case "rebase-onto":` from `AppShell.tsx` and re-run: the row must fail
+with `expected "history" to be "rebase"` (and `tsc` must fail on `assertNever`).
+Restore.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/nav/useNavStore.ts src/AppShell.tsx src/AppShell.navroutes.test.tsx
+git commit -m "feat(nav): rebase-onto intent routed to the Rebase screen"
+```
+
+---
+
+### Task 3: The Rebase screen resolves any base
+
+**Files:**
+- Modify: `src/screens/Rebase.tsx`
+- Test: `src/screens/Rebase.onto.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `withPlanBase` (Task 1); `rebase-onto` (Task 2); `aheadBehind`, `commitsBetween`, `commitsSince` from `@/lib/tauri`; `AheadBehind` from `@/lib/types`.
+- Produces: `data-testid="rebase-base-summary"` and `data-testid="rebase-base-notice"` on the screen.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/screens/Rebase.onto.test.tsx`:
+
+```tsx
+// The diverged-base flow (186): a `rebase-onto` intent names a base, the screen
+// walks `base..HEAD` on the backend, and the submitted plan carries that base on
+// its first non-Drop step.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { RebaseScreen } from "./Rebase";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { mockInvoke } from "@/test/invokeMock";
+import type { CommitInfo, RebaseStatus, RebaseStep, RepoHandle } from "@/lib/types";
+
+const handle: RepoHandle = { id: "repo-1", path: "/tmp/fake-repo", head: "refs/heads/main" };
+
+const SWEPT: RebaseStatus = {
+  inProgress: false,
+  nextIndex: 0,
+  total: 0,
+  pauseReason: null,
+  lastCompleted: null,
+};
+
+const BASE = "9".repeat(40);
+const ROOT = "0".repeat(40);
+
+function mk(oid: string, summary: string, parent: string): CommitInfo {
+  return {
+    oid,
+    shortOid: oid.slice(0, 7),
+    summary,
+    body: null,
+    author: "Tester",
+    email: "t@example.com",
+    timestamp: 1_700_000_000,
+    parents: [parent],
+    refs: [],
+  };
+}
+
+/** `base..HEAD`, newest-first — what `commits_between` returns. */
+const RANGE = [
+  mk("c".repeat(40), "feat: third", "b".repeat(40)),
+  mk("b".repeat(40), "feat: second", "a".repeat(40)),
+  mk("a".repeat(40), "feat: first", ROOT),
+];
+
+/** Records what the screen actually submitted. */
+function wire(opts: {
+  ahead: number;
+  behind: number;
+  mergeBase: string | null;
+  range?: CommitInfo[];
+}): { started: () => RebaseStep[][]; betweenLimits: () => Array<number | undefined> } {
+  const started: RebaseStep[][] = [];
+  const betweenLimits: Array<number | undefined> = [];
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: RANGE, nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => SWEPT);
+  mockInvoke("ahead_behind", () => ({
+    ahead: opts.ahead,
+    behind: opts.behind,
+    mergeBase: opts.mergeBase,
+  }));
+  mockInvoke("commits_between", (args) => {
+    betweenLimits.push((args as { limit?: number }).limit);
+    return opts.range ?? RANGE;
+  });
+  mockInvoke("commits_since", () => opts.range ?? RANGE);
+  mockInvoke("rebase_start", (args) => {
+    started.push((args as { plan: RebaseStep[] }).plan);
+    return SWEPT;
+  });
+  return { started: () => started, betweenLimits: () => betweenLimits };
+}
+
+function seedOntoIntent(): void {
+  useNavStore.setState({ intent: { kind: "rebase-onto", base: BASE, label: "other" } });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+  useRepoStore.setState({
+    current: handle,
+    status: [],
+    allFiles: [],
+    branches: [],
+    tags: [],
+    stashes: [],
+    remotes: [],
+    commits: RANGE,
+    loading: false,
+    error: null,
+    repoState: "Clean",
+    rebaseStatus: SWEPT,
+    activity: {},
+  } as never);
+  useNavStore.setState({ intent: null });
+});
+
+describe("RebaseScreen — a diverged base", () => {
+  it("plans base..HEAD and submits the base on the first step", async () => {
+    const rec = wire({ ahead: 3, behind: 2, mergeBase: ROOT });
+    seedOntoIntent();
+    render(<RebaseScreen />);
+
+    await waitFor(() => expect(screen.getAllByText(/feat: /)).toHaveLength(3));
+    // The limit is derived from `ahead`, never left to the handler's default of
+    // 200 — a truncated plan would drop commits and still move the branch ref.
+    expect(rec.betweenLimits()).toEqual([4]);
+
+    await userEvent.click(screen.getByTestId("rebase-start"));
+
+    await waitFor(() => expect(rec.started()).toHaveLength(1));
+    const plan = rec.started()[0];
+    expect(plan.map((s) => s.oid)).toEqual([
+      "a".repeat(40),
+      "b".repeat(40),
+      "c".repeat(40),
+    ]);
+    expect(plan.map((s) => s.onto)).toEqual([BASE, null, null]);
+  });
+
+  it("states what will be replayed, including the merge base", async () => {
+    wire({ ahead: 3, behind: 2, mergeBase: ROOT });
+    seedOntoIntent();
+    render(<RebaseScreen />);
+
+    const strip = await screen.findByTestId("rebase-base-summary");
+    expect(strip).toHaveTextContent("3 commits will be replayed onto other.");
+    expect(strip).toHaveTextContent("other has 2 commits this branch does not.");
+    expect(strip).toHaveTextContent(`Merge base ${ROOT.slice(0, 7)}.`);
+  });
+
+  it("warns when the histories are unrelated", async () => {
+    wire({ ahead: 3, behind: 2, mergeBase: null });
+    seedOntoIntent();
+    render(<RebaseScreen />);
+
+    const strip = await screen.findByTestId("rebase-base-summary");
+    expect(strip).toHaveTextContent("No common ancestor");
+  });
+
+  it("shows a visible notice and no plan when there is nothing to replay", async () => {
+    const rec = wire({ ahead: 0, behind: 4, mergeBase: ROOT });
+    seedOntoIntent();
+    render(<RebaseScreen />);
+
+    // The picker is CLOSED here — an intent has no anchor — so the notice has to
+    // live on the screen or the menu item would fail in total silence.
+    const notice = await screen.findByTestId("rebase-base-notice");
+    expect(notice).toHaveTextContent("No commits between HEAD and other.");
+    expect(screen.getByTestId("rebase-start")).toBeDisabled();
+    expect(rec.betweenLimits()).toEqual([]);
+  });
+
+  it("refuses a partial range rather than planning a truncated rebase", async () => {
+    wire({ ahead: 3, behind: 2, mergeBase: ROOT, range: RANGE.slice(0, 2) });
+    seedOntoIntent();
+    render(<RebaseScreen />);
+
+    const notice = await screen.findByTestId("rebase-base-notice");
+    expect(notice).toHaveTextContent("partial rebase");
+    expect(screen.getByTestId("rebase-start")).toBeDisabled();
+  });
+
+  it("keeps the base on the first step after a reorder", async () => {
+    const rec = wire({ ahead: 3, behind: 2, mergeBase: ROOT });
+    seedOntoIntent();
+    render(<RebaseScreen />);
+
+    await waitFor(() => expect(screen.getAllByTestId("rebase-move-up")).toHaveLength(3));
+    // Move the newest commit (row 3) to the top. Without withPlanBase running at
+    // SUBMIT, the base would still be sitting on the row that used to be first.
+    await userEvent.click(screen.getAllByTestId("rebase-move-up")[2]);
+    await userEvent.click(screen.getAllByTestId("rebase-move-up")[1]);
+
+    await userEvent.click(screen.getByTestId("rebase-start"));
+    await waitFor(() => expect(rec.started()).toHaveLength(1));
+    const plan = rec.started()[0];
+    expect(plan[0].oid).toBe("c".repeat(40));
+    expect(plan.map((s) => s.onto)).toEqual([BASE, null, null]);
+  });
+
+  it("uses commits_since — not commits_between — for an ancestor base", async () => {
+    const rec = wire({ ahead: 3, behind: 0, mergeBase: BASE });
+    seedOntoIntent();
+    render(<RebaseScreen />);
+
+    await waitFor(() => expect(screen.getAllByText(/feat: /)).toHaveLength(3));
+    expect(rec.betweenLimits()).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm vitest run --project unit src/screens/Rebase.onto.test.tsx
+```
+
+Expected: FAIL — no `rebase-base-summary`, no plan built (the screen ignores the
+new intent kind).
+
+- [ ] **Step 3: Implement — imports and state**
+
+In `src/screens/Rebase.tsx`, replace the `commitsSince` import line with:
+
+```ts
+import { aheadBehind, commitsBetween, commitsSince } from "@/lib/tauri";
+```
+
+Add `AheadBehind` to the type import from `@/lib/types`, and import the helper:
+
+```ts
+import { withPlanBase } from "@/features/commits/withPlanBase";
+```
+
+Replace the `baseLabel` / `pickerNotice` state declarations with:
+
+```ts
+  const [baseLabel, setBaseLabel] = useState<string | null>(null);
+  /**
+   * The revspec the run detaches at, carried to submit by `withPlanBase`. Any
+   * revspec is legal (a full oid where we have one, a prefix from the picker's
+   * hash row, a branch name from a branch menu) because both the validator and
+   * the engine `revparse_single` it. Null means "use the engine's parent
+   * fallback" — a root commit, or an oldest step outside the loaded log.
+   */
+  const [baseRev, setBaseRev] = useState<string | null>(null);
+  /** Counts for the summary strip; only a RESOLVED base has them. */
+  const [baseStats, setBaseStats] = useState<AheadBehind | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [baseNotice, setBaseNotice] = useState<string | null>(null);
+  const [pickerAnchor, setPickerAnchor] = useState<HTMLElement | null>(null);
+```
+
+- [ ] **Step 4: Implement — the one `resolveBase` path**
+
+Replace the whole `handlePickBase` callback with:
+
+```ts
+  /**
+   * Resolve a base to a range and a plan. ONE path for the picker and for a
+   * `rebase-onto` intent, so the strip's counts and the plan can never describe
+   * different ranges.
+   *
+   * `aheadBehind` comes first because its answer chooses the primitive, with no
+   * failed round trip:
+   *   - ahead === 0  → nothing to replay (base is HEAD, or a descendant of it).
+   *   - behind === 0 → base is an ANCESTOR of HEAD, by graph_ahead_behind's own
+   *     definition: nothing reachable from base is missing from HEAD. That is
+   *     `commitsSince`'s domain — the unchanged path, and the one primitive that
+   *     enforces the invariant, so it keeps its only caller.
+   *   - behind > 0   → diverged (or unrelated): `commitsBetween`, which requires
+   *     no ancestry (#131).
+   *
+   * `commits_between`'s handler defaults `limit` to 200 and simply breaks at the
+   * cap, so the limit is derived from the exact count and the length is verified.
+   * A silently truncated plan would leave commits unreplayed and still move the
+   * branch ref — refuse instead.
+   */
+  const resolveBase = useCallback(
+    async (rev: string, label: string) => {
+      if (!current) return;
+      const baseName = label.split(" — ")[0];
+      try {
+        const stats = await aheadBehind(current.id, rev, "HEAD");
+        if (stats.ahead === 0) {
+          setBaseNotice(`No commits between HEAD and ${baseName}.`);
+          return;
+        }
+        const next =
+          stats.behind === 0
+            ? await commitsSince(current.id, rev)
+            : await commitsBetween(current.id, rev, "HEAD", stats.ahead + 1);
+        if (next.length !== stats.ahead) {
+          setBaseNotice(
+            `Read ${next.length} of ${stats.ahead} commits between ${baseName} and HEAD — refusing to plan a partial rebase.`,
+          );
+          return;
+        }
+        setRange(next);
+        setPlan(commitsToPlan(next, mergeMode));
+        setBaseRev(rev);
+        setBaseLabel(label);
+        setBaseStats(stats);
+        setBaseNotice(null);
+        setPickerOpen(false);
+      } catch (e) {
+        setBaseNotice(appErrorMessage(e));
+      }
+    },
+    [current, mergeMode],
+  );
+```
+
+- [ ] **Step 5: Implement — handle the intent, and remember every plan's base**
+
+In the existing `rebase-plan` effect, change the guard and add the new branch at
+the top:
+
+```ts
+  React.useEffect(() => {
+    if (intent?.kind === "rebase-onto") {
+      void resolveBase(intent.base, intent.label);
+      clearIntent();
+      return;
+    }
+    if (intent?.kind !== "rebase-plan") return;
+```
+
+Further down in the same effect, where the base label is derived, also store the
+oid — a plan whose base is known cannot have it moved by a reorder:
+
+```ts
+    setBaseRev(baseOid ?? null);
+    setBaseStats(null);
+    setBaseNotice(null);
+    setBaseLabel(
+```
+
+and add `resolveBase` to that effect's dependency array.
+
+In `handleClear`, reset the new state too:
+
+```ts
+  const handleClear = () => {
+    setPlan([]);
+    setRange([]);
+    setBaseLabel(null);
+    setBaseRev(null);
+    setBaseStats(null);
+    setBaseNotice(null);
+  };
+```
+
+and in `handleStart`'s success arm add `setBaseRev(null); setBaseStats(null);`
+beside the existing `setBaseLabel(null)`.
+
+- [ ] **Step 6: Implement — attach the base at submit**
+
+In `handleStart`, wrap the mapped steps:
+
+```ts
+    // The base rides on the plan's FIRST non-Drop step, attached HERE rather than
+    // when the rows were built: flatten mode lets the user reorder, and
+    // `rebase_start` reads the base off whatever step ends up first.
+    const steps: RebaseStep[] = withPlanBase(
+      plan.map((r) => ({
+        oid: r.oid,
+        action: r.action,
+        message:
+          r.action === "Reword" || r.action === "Squash" ? r.message || null : null,
+        onto: r.onto,
+        mergeParents: r.mergeParents,
+      })),
+      baseRev,
+    );
+```
+
+- [ ] **Step 7: Implement — the two strips**
+
+Immediately after the toolbar `</div>` and before the merge-count banner:
+
+```tsx
+          {/* What will be replayed. Once the base can be diverged, "everything
+              newer than the base" stops being obvious — so say how many commits,
+              what the base adds, and where the two histories met. */}
+          {baseStats && baseLabel && plan.length > 0 && (
+            <div
+              data-testid="rebase-base-summary"
+              style={{
+                padding: "6px 12px",
+                borderBottom: "1px solid var(--border-0)",
+                background: "var(--bg-1)",
+                color: "var(--fg-2)",
+                fontSize: "var(--fs-12)",
+              }}
+            >
+              {baseStats.ahead === 1
+                ? "1 commit will be replayed onto "
+                : `${baseStats.ahead} commits will be replayed onto `}
+              {baseLabel.split(" — ")[0]}.
+              {baseStats.behind > 0 && (
+                <>
+                  {" "}
+                  {baseLabel.split(" — ")[0]} has {baseStats.behind}{" "}
+                  {baseStats.behind === 1 ? "commit" : "commits"} this branch does not.
+                </>
+              )}
+              {baseStats.behind > 0 && baseStats.mergeBase && (
+                <> Merge base {baseStats.mergeBase.slice(0, 7)}.</>
+              )}
+              {baseStats.mergeBase === null && (
+                <> No common ancestor — the whole branch will be replayed.</>
+              )}
+            </div>
+          )}
+
+          {/* A base can also fail to resolve, and the picker is not always open
+              to say so: a context-menu intent has no anchor, so without this the
+              menu item would do nothing at all and explain nothing. */}
+          {baseNotice && !pickerOpen && (
+            <div
+              data-testid="rebase-base-notice"
+              style={{
+                padding: "6px 12px",
+                borderBottom: "1px solid var(--git-conflict)",
+                background: "oklch(from var(--git-conflict) l c h / 0.12)",
+                color: "var(--fg-0)",
+                fontSize: "var(--fs-12)",
+              }}
+            >
+              {baseNotice}
+            </div>
+          )}
+```
+
+Finally, rewire the picker's props at the bottom of the file and the toolbar
+button's notice reset:
+
+```tsx
+      <RebaseBasePicker
+        anchor={pickerAnchor}
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        onPick={resolveBase}
+        notice={baseNotice}
+      />
+```
+
+and in the "New rebase" / "Change base" button's `onClick`, replace
+`setPickerNotice(null)` with `setBaseNotice(null)`.
+
+- [ ] **Step 8: Run the tests**
+
+```bash
+pnpm vitest run --project unit src/screens/Rebase.onto.test.tsx src/screens/Rebase.test.tsx src/screens/Rebase.merge.test.tsx src/screens/Rebase.preserve.test.tsx src/screens/Rebase.reorder.test.tsx
+```
+
+Expected: all pass. (The existing four suites must stay green — `handleStart` now
+attaches a base for intent plans too.)
+
+- [ ] **Step 9: Mutation-check**
+
+1. Change `stats.ahead + 1` to `undefined` (handler default 200): the
+   `betweenLimits` assertion must fail.
+2. Delete the `next.length !== stats.ahead` guard: the "refuses a partial range"
+   test must fail.
+3. Move `withPlanBase` from `handleStart` into `commitsToPlan`: the reorder test
+   must fail.
+4. Render the notice strip only when `pickerOpen`: the "nothing to replay" and
+   "partial range" tests must fail.
+
+Restore after each.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/screens/Rebase.tsx src/screens/Rebase.onto.test.tsx
+git commit -m "feat(rebase): plan a rebase onto any base, diverged or not"
+```
+
+---
+
+### Task 4: Delete the dead `invalidOids` prop
+
+**Files:**
+- Modify: `src/features/rebase/RebaseBasePicker.tsx`
+
+**Interfaces:**
+- Produces: `RebaseBasePicker` with no `invalidOids` prop.
+
+- [ ] **Step 1: Confirm it is dead**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+grep -rn "invalidOids" src/
+```
+
+Expected: only the three lines inside `RebaseBasePicker.tsx` — declaration,
+destructure, and the `ineligible` read. No call site passes it.
+
+- [ ] **Step 2: Remove it**
+
+Delete from the `Props` interface:
+
+```ts
+  /** OIDs that are not on the current branch's history — used to mark rows as ineligible. */
+  invalidOids?: Set<string>;
+```
+
+Delete `invalidOids,` from the destructured parameter list, and in `renderRow`
+delete the `ineligible` line, the `title={ineligible ? … : undefined}` attribute
+and the `opacity: ineligible ? 0.5 : 1` style. Add above `Props`:
+
+```ts
+// There is deliberately no "ineligible row" state (186). A prop for it existed
+// and nothing ever passed it — and what it encoded, "not on the current branch's
+// history", is now the primary reason to pick a base at all, so a live version
+// would grey out exactly the rows this picker exists to offer. The genuine
+// refusals (nothing to replay, an unresolvable revspec) are backend answers and
+// arrive through `notice`.
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+pnpm tsc --noEmit && grep -rn "invalidOids" src/ ; echo "exit=$?"
+```
+
+Expected: `tsc` clean, `grep` finds nothing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/rebase/RebaseBasePicker.tsx
+git commit -m "refactor(rebase): drop the base picker's never-passed invalidOids"
+```
+
+---
+
+### Task 5: Three entry points
+
+**Files:**
+- Modify: `src/design/context-menu.tsx`
+
+**Interfaces:**
+- Consumes: `rebase-onto` (Task 2).
+- Produces: a module-local `branchTipOid(name: string): string | null`.
+
+- [ ] **Step 1: Add the tip lookup helper**
+
+Next to `ancestryLog()` in `src/design/context-menu.tsx`:
+
+```ts
+/**
+ * A branch's tip oid, for menu items that must name a fixed commit rather than a
+ * moving ref (186). `BranchInfo.tip` is a FULL oid and is used as one — it was
+ * once truncated to 7 chars and every comparison against `CommitInfo.oid` then
+ * failed silently. Null when the branch is unknown or its tip is unresolvable;
+ * the caller then falls back to the NAME, which the backend revparses anyway.
+ */
+function branchTipOid(name: string): string | null {
+  return useRepoStore.getState().branches.find((b) => b.name === name)?.tip ?? null;
+}
+```
+
+- [ ] **Step 2: The commit-menu item**
+
+In `commitMenuItems`, immediately after the `Interactive rebase from here` item:
+
+```ts
+    {
+      icon: "rebase",
+      // The OTHER half of interactive rebase (186), and a genuinely different
+      // action: "from here" makes the clicked commit the OLDEST REPLAYED commit
+      // (base = its parent); this makes it the NEW BASE, which is not in the plan
+      // at all. Disabled for a commit already on this branch, mirroring
+      // branchMenuItems' `disabled: isCurrent` — replaying onto your own ancestor
+      // is a no-op, and the item above is what that flow wants. So the two are
+      // never both enabled for one commit.
+      label: onBranch
+        ? "Rebase current branch onto this — already on this branch"
+        : "Rebase current branch onto this…",
+      disabled: onBranch || !commit?.sha,
+      onClick: () => {
+        if (!commit?.sha) return;
+        useNavStore.getState().setIntent({
+          kind: "rebase-onto",
+          base: commit.sha,
+          label: `${sha.slice(0, 7)} — ${commit.subject ?? ""}`.trim(),
+        });
+      },
+    },
+```
+
+- [ ] **Step 3: The local-branch item**
+
+In `branchMenuItems`, immediately after the existing `Rebase current onto this`:
+
+```ts
+    {
+      icon: "rebase",
+      // No confirm, unlike the non-interactive sibling above: this rewrites
+      // nothing. It opens a plan, and `Start rebase` is the destructive step.
+      label: "Rebase current onto this — interactive…",
+      disabled: isCurrent,
+      onClick: () => {
+        if (!name) return;
+        useNavStore.getState().setIntent({
+          kind: "rebase-onto",
+          base: branchTipOid(name) ?? name,
+          label: name,
+        });
+      },
+    },
+```
+
+- [ ] **Step 4: The remote-branch item**
+
+In `remoteBranchMenuItems`, immediately after its `Rebase current onto this`:
+
+```ts
+    {
+      icon: "rebase",
+      // Never disabled — a remote-tracking branch is never the current branch.
+      label: "Rebase current onto this — interactive…",
+      onClick: () => {
+        if (!name) return;
+        useNavStore.getState().setIntent({
+          kind: "rebase-onto",
+          base: branchTipOid(name) ?? name,
+          label: name,
+        });
+      },
+    },
+```
+
+- [ ] **Step 5: Verify**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm tsc --noEmit && pnpm vitest run --project unit
+```
+
+Expected: clean, and the whole `unit` project green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/design/context-menu.tsx
+git commit -m "feat(history): rebase the current branch onto any commit or branch"
+```
+
+---
+
+### Task 6: Rust integration — a genuinely diverged base
+
+**Files:**
+- Create: `src-tauri/tests/rebase_onto_new_base.rs`
+
+**Interfaces:**
+- Consumes: `support::TempRepo` (`with_initial_commit`, `open_with_backend`, `path`, `repo`), `support::git_in`, `GitBackend`, `RebaseAction`, `RebaseStep`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src-tauri/tests/rebase_onto_new_base.rs`:
+
+```rust
+//! `git rebase -i <newbase>` — replaying a branch onto a base it does NOT
+//! descend from (186).
+//!
+//! The engine already supports this: `rebase_start` takes the run's base from
+//! the first non-Drop step's `onto`, and `rebase_plan::validate` accepts any
+//! existing commit there with no ancestry requirement. These tests pin that,
+//! because nothing else exercises an `onto` below the range — and pin the range
+//! primitive split too: `commits_between` answers for a diverged pair,
+//! `commits_since` refuses, and that refusal is deliberate.
+
+mod support;
+
+use platypusgit_lib::git::{
+    types::{RebaseAction, RebaseStep},
+    GitBackend,
+};
+
+use support::{git_in, TempRepo};
+
+/// ```text
+/// root ── A ── D ── E   (main, HEAD)
+///     \
+///      ─ B ── C         (other)
+/// ```
+/// Every commit touches its own file, so nothing conflicts.
+struct Diverged {
+    root: String,
+    other_tip: String,
+    main_tip: String,
+}
+
+fn diverged(tr: &TempRepo) -> Diverged {
+    let root = git_in(tr.path(), &["rev-parse", "HEAD"]).trim().to_string();
+
+    git_in(tr.path(), &["checkout", "-b", "other"]);
+    tr.add_commit("b.txt", "b\n", "B on other");
+    tr.add_commit("c.txt", "c\n", "C on other");
+    let other_tip = git_in(tr.path(), &["rev-parse", "HEAD"]).trim().to_string();
+
+    git_in(tr.path(), &["checkout", "main"]);
+    tr.add_commit("a.txt", "a\n", "A on main");
+    tr.add_commit("d.txt", "d\n", "D on main");
+    tr.add_commit("e.txt", "e\n", "E on main");
+    let main_tip = git_in(tr.path(), &["rev-parse", "HEAD"]).trim().to_string();
+
+    Diverged { root, other_tip, main_tip }
+}
+
+fn step(oid: &str, onto: Option<&str>) -> RebaseStep {
+    RebaseStep {
+        oid: oid.to_string(),
+        action: RebaseAction::Pick,
+        message: None,
+        onto: onto.map(|s| s.to_string()),
+        merge_parents: Vec::new(),
+    }
+}
+
+#[test]
+fn commits_between_is_the_range_and_commits_since_refuses_it() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = diverged(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    let range = backend
+        .commits_between(&handle.id, &h.other_tip, "HEAD", 100)
+        .unwrap();
+    let summaries: Vec<&str> = range.iter().map(|c| c.summary.as_str()).collect();
+    assert_eq!(
+        summaries,
+        vec!["E on main", "D on main", "A on main"],
+        "base..HEAD is HEAD's commits not reachable from the new base"
+    );
+
+    // The invariant that stays: a rebase base for the ON-BRANCH flow must be an
+    // ancestor. Loosening this is explicitly out of scope.
+    assert!(
+        backend.commits_since(&handle.id, &h.other_tip).is_err(),
+        "commits_since must keep refusing a non-ancestor base"
+    );
+}
+
+#[test]
+fn replays_the_branch_onto_a_diverged_base() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = diverged(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    let range = backend
+        .commits_between(&handle.id, &h.other_tip, "HEAD", 100)
+        .unwrap();
+    // Oldest-first, with the new base named on the first step — the plan shape
+    // the Rebase screen submits.
+    let mut plan: Vec<RebaseStep> = range
+        .iter()
+        .rev()
+        .map(|c| step(&c.oid, None))
+        .collect();
+    plan[0].onto = Some(h.other_tip.clone());
+
+    let status = backend.rebase_start(&handle.id, plan).unwrap();
+    assert!(!status.in_progress, "a clean replay finishes in one call");
+
+    let log = git_in(tr.path(), &["log", "--format=%s"]);
+    assert_eq!(
+        log.trim().split('\n').collect::<Vec<_>>(),
+        vec!["E on main", "D on main", "A on main", "C on other", "B on other", "initial"],
+        "main must sit on top of other's tip"
+    );
+
+    // The branch ref moved, exactly once, and HEAD is attached to it again.
+    assert_eq!(
+        git_in(tr.path(), &["symbolic-ref", "HEAD"]).trim(),
+        "refs/heads/main"
+    );
+    assert_eq!(
+        git_in(tr.path(), &["rev-parse", "ORIG_HEAD"]).trim(),
+        h.main_tip,
+        "ORIG_HEAD is the pre-rebase tip — `git reset --hard ORIG_HEAD` undoes this"
+    );
+    assert_eq!(git_in(tr.path(), &["status", "--porcelain"]).trim(), "");
+    // Both sides' content survives.
+    for f in ["a.txt", "b.txt", "c.txt", "d.txt", "e.txt"] {
+        assert!(tr.path().join(f).exists(), "{f} must exist after the replay");
+    }
+    // `other` itself is untouched.
+    assert_eq!(
+        git_in(tr.path(), &["rev-parse", "other"]).trim(),
+        h.other_tip
+    );
+    assert_ne!(h.root, h.other_tip);
+}
+
+#[test]
+fn a_short_prefix_and_a_branch_name_both_work_as_the_new_base() {
+    // The base picker's free-form hash row and the branch menus hand over a
+    // PREFIX and a NAME, not a full oid — and after this feature that is the
+    // common path, because a diverged base is usually outside the loaded log.
+    // Both `ahead_behind` and `rebase_start` revparse whatever they are given.
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = diverged(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    let by_oid = backend.ahead_behind(&handle.id, &h.other_tip, "HEAD").unwrap();
+    let by_prefix = backend
+        .ahead_behind(&handle.id, &h.other_tip[..7], "HEAD")
+        .unwrap();
+    let by_name = backend.ahead_behind(&handle.id, "other", "HEAD").unwrap();
+    assert_eq!(by_oid.ahead, 3);
+    assert_eq!(by_oid.behind, 2);
+    assert_eq!(by_oid.merge_base, Some(h.root.clone()));
+    assert_eq!(by_prefix.ahead, by_oid.ahead);
+    assert_eq!(by_name.ahead, by_oid.ahead);
+
+    let range = backend
+        .commits_between(&handle.id, &h.other_tip[..7], "HEAD", 100)
+        .unwrap();
+    assert_eq!(range.len(), 3);
+
+    let mut plan: Vec<RebaseStep> = range.iter().rev().map(|c| step(&c.oid, None)).collect();
+    plan[0].onto = Some(h.other_tip[..7].to_string());
+    backend.rebase_start(&handle.id, plan).unwrap();
+
+    assert_eq!(
+        git_in(tr.path(), &["rev-parse", "HEAD~3"]).trim(),
+        h.other_tip,
+        "a 7-char prefix must land on the same base as the full oid"
+    );
+}
+```
+
+- [ ] **Step 2: Run it and confirm it fails or passes for the right reason**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test rebase_onto_new_base
+```
+
+These tests characterise existing backend behaviour, so they are expected to
+PASS on the first run. That is the point of Step 3: prove they can fail.
+
+- [ ] **Step 3: Mutation-check**
+
+In `src-tauri/src/git/libgit2.rs`'s `rebase_start`, temporarily replace
+`let first_step_onto = first_step.onto.clone();` with
+`let first_step_onto: Option<String> = None;` — i.e. ignore the plan's base.
+Re-run: `replays_the_branch_onto_a_diverged_base` and
+`a_short_prefix_and_a_branch_name_both_work_as_the_new_base` must both fail.
+Restore.
+
+Then, in `commits_between`, temporarily add an ancestry check mirroring
+`commits_since`'s and confirm
+`commits_between_is_the_range_and_commits_since_refuses_it` fails. Restore.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/tests/rebase_onto_new_base.rs
+git commit -m "test(rebase): pin replaying a branch onto a diverged base"
+```
+
+---
+
+### Task 7: Documentation
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `src/features/commits/buildPreservePlan.ts` (doc comment only)
+
+- [ ] **Step 1: The spec/plan list**
+
+In `CLAUDE.md`'s "Recent specs/plans" list, add above the `2026-08-18-diff-minimap-*`
+entry:
+
+```markdown
+- `2026-08-19-rebase-onto-any-commit-*` — interactive rebase onto a base the
+  branch does not descend from: the range from `commitsBetween` with an
+  `aheadBehind`-derived limit, the base attached to the plan's first non-Drop
+  step at SUBMIT, and a `rebase-onto` NavIntent behind three menu items (186).
+```
+
+- [ ] **Step 2: The interactive-rebase-engine section**
+
+In `CLAUDE.md`'s "Interactive rebase engine" section, after the "The plan is
+validated before the repository is touched" bullet, add:
+
+```markdown
+- **A plan may name a base the branch does not descend from — that is
+  `git rebase --onto`** (186). `rebase_start` reads the run's base off the FIRST
+  non-Drop step's `onto` and `rebase_plan::validate` accepts any existing commit
+  there, with no ancestry requirement, so the diverged case needed no engine
+  change. Three consequences:
+  - The base is attached at **submit**, by `withPlanBase`
+    (`features/commits/withPlanBase.ts`), never when the rows are built. Flatten
+    mode lets the user reorder, and the base belongs to whichever step ends up
+    first — baked into a row, a drag would carry it away, which is a bug that
+    predates the diverged base (a reordered plan used to detach at the middle of
+    its own range).
+  - The frontend range is `commitsBetween(base, HEAD)` when the base is diverged
+    and `commitsSince` when it is an ancestor, chosen by `aheadBehind`'s
+    `behind === 0`. **`commits_since` is not loosened** — its ancestor
+    requirement is the on-branch flow's invariant, and this keeps it its only
+    caller.
+  - `commits_between`'s handler defaults `limit` to **200** and breaks at the cap,
+    so the limit is derived from `aheadBehind`'s exact `ahead` and the length is
+    verified. A truncated plan leaves commits unreplayed and still moves the
+    branch ref, so a mismatch is refused rather than planned.
+```
+
+- [ ] **Step 3: The nav-intent list**
+
+In the `features/nav/` line of the frontend tree, extend the parenthesised list:
+
+```
+├── nav/             useNavStore — cross-screen intents (diff-file, commit-vs-wt,
+│                    file-history, blame, rebase-plan, rebase-onto, stash-diff) +
+```
+
+- [ ] **Step 4: `buildPreservePlan`'s comment**
+
+In `src/features/commits/buildPreservePlan.ts`, replace the last sentence of the
+`onto` comment with:
+
+```
+    // Only name a base when it is not where the replay already sits. Naming it
+    // unconditionally would work, but it would make every step a reset and hide
+    // the linear default from anyone reading the plan. The FIRST step stays null
+    // here on purpose: its base is the range's base, which the Rebase screen
+    // attaches with `withPlanBase` at submit (186) — and which `rebase_start`
+    // derives from the first parent when nothing names it.
+```
+
+- [ ] **Step 5: Verify the doc invariants still hold**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm vitest run --project docs
+```
+
+Expected: green. (No new `invoke_handler!` id, no new Rust module, no new
+`src/features/*` directory, so the coverage assertions are unaffected — this run
+is the proof, not the assumption.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CLAUDE.md src/features/commits/buildPreservePlan.ts
+git commit -m "docs: interactive rebase onto a diverged base"
+```
+
+---
+
+### Task 8: E2E and the full gate
+
+**Files:**
+- Modify: `e2e/specs/rebase.e2e.ts`
+
+- [ ] **Step 1: Read the e2e skill first**
+
+Read `.claude/skills/e2e-testing/SKILL.md` before touching the spec — selector
+conventions, the 5s driver-bridge penalty, fixture geometry, rebuild discipline.
+
+- [ ] **Step 2: Add one case**
+
+Append to `e2e/specs/rebase.e2e.ts`'s `describe("interactive rebase")`, following
+the file's own fixture and menu helpers:
+
+```ts
+  it("replays the branch onto a diverged commit", async () => {
+    // main and other diverge off a common root; the new base is other's tip,
+    // which is NOT on main — the case every existing test cannot reach.
+    // Drive History's commit menu → "Rebase current branch onto this…", then
+    // Start rebase, then assert `git log` puts main's commits on top of other's.
+  });
+```
+
+Fill it in against the file's existing helpers. If the repo fixture needed for a
+diverged branch is not cheap to build with what `e2e/support/tempRepo.ts` already
+offers, **skip this step** and record that in the PR description — the routing is
+already proven by `AppShell.navroutes.test.tsx` (which drives the real shell) and
+the engine by Task 6.
+
+- [ ] **Step 3: Check the Docker build slot is free**
+
+```bash
+docker compose ls; docker ps
+```
+
+Another agent may hold it. Only one cold container build at a time across ALL
+worktrees — wait if one is in flight (`compose run --build` creates no container
+until the image build finishes, so a build in progress is invisible to
+`docker ps` alone).
+
+- [ ] **Step 4: Build the snapshot and run the spec**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test:e2e:docker build
+pnpm test:e2e:docker run --spec e2e/specs/rebase.e2e.ts
+```
+
+Expected: green. `src/` changed, so the rebuild is mandatory — the `run` phase
+silently tests the old binary otherwise.
+
+- [ ] **Step 5: Run every gate**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm tsc --noEmit
+pnpm test
+pnpm exec tsc -p e2e/tsconfig.json --noEmit
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+- [ ] **Step 6: Squash and open the PR**
+
+```bash
+git fetch origin
+git reset --soft origin/main
+git commit -m "feat(rebase): interactive rebase onto any commit"
+git push -u origin feat/rebase-onto-any-commit
+gh pr create --title "feat(rebase): interactive rebase onto any commit" --body "…"
+```
+
+**The PR body and commit message must never put `close`/`closes`/`closed`/
+`fix`/`fixes`/`fixed`/`resolve`/`resolves`/`resolved` immediately before
+`#186`** — GitHub ignores negations, so even "Does not close #186" closes it.
+Write "issue 186", no `#`. Verify:
+
+```bash
+gh pr view <n> --json closingIssuesReferences
+```
+
+Expected: an empty array.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Decision 1 → Task 3 Step 4. Decision 2 → Task 3 Steps 4 + 9.
+Decision 3 → Tasks 1 and 3 (Steps 5–6). Decision 4 → Task 2. Decision 5 → Task 5.
+Decision 6 → Task 4. Decision 7 → Task 3 Step 7. Decision 8 → Task 3 Step 7 plus
+Task 3's test list. Out-of-scope items are asserted where they matter: Task 6's
+first test pins that `commits_since` still refuses. Testing section → Tasks 1, 3,
+6, 8.
+
+**Placeholders.** Task 8 Step 2 is the one deliberately open step: an e2e body
+cannot be written without the spec file's helpers in front of the writer, and the
+step says exactly what to build, what to assert, and what to do (and record) if
+the fixture is not cheap. Everything else carries real code.
+
+**Type consistency.** `withPlanBase(steps, baseOid)` is defined in Task 1 and
+called with `(mappedSteps, baseRev)` in Task 3 — `baseRev` is
+`string | null`, matching. `AheadBehind` is `{ ahead, behind, mergeBase }`
+(`src/lib/types.ts`) and only those three fields are read. `RebaseStep.onto` is
+`string | null | undefined`; every construction passes an explicit value.
+`branchTipOid` returns `string | null` and both call sites use `?? name`.

--- a/docs/superpowers/specs/2026-08-19-rebase-onto-any-commit-spec.md
+++ b/docs/superpowers/specs/2026-08-19-rebase-onto-any-commit-spec.md
@@ -1,0 +1,260 @@
+# Interactive rebase onto any commit (issue 186)
+
+Status: approved for implementation.
+Issue: [186](https://github.com/jonassaa/platypusgit/issues/186).
+
+## Goal
+
+Pick a new base **anywhere** — a diverged branch, a commit on another line of
+history, a bare hash — and replay this branch's commits onto it with the
+pick/squash/reword/drop plan on screen first. `git rebase -i <newbase>`, which is
+the half of interactive rebase TortoiseGit has and this app does not.
+
+Today the only way to move a branch onto a diverged base is `rebaseOnto(name)`,
+which shells out to real `git rebase` and offers no plan at all. The interactive
+path refuses any base that is not already an ancestor of HEAD.
+
+## What already works, verified in the tree
+
+The issue's central claim holds. Confirmed by reading the code, not by trusting
+the issue:
+
+- `rebase_start` (`src-tauri/src/git/libgit2.rs`) takes the run's base from
+  **`first_step.onto`**, falling back to the first non-Drop step's first parent
+  only when `onto` is `None`. It then `set_head_detached(base)` + hard-reset and
+  replays there, moving the branch ref exactly once on completion.
+- `rebase_plan::validate` accepts an `onto` that is "either an earlier step or a
+  commit that already exists" — `revparse_single(onto).peel_to_commit().is_ok()`.
+  **No ancestry check exists anywhere in the validator.**
+- So a plan whose first non-Drop step carries `onto: <newBase>` already *is*
+  `git rebase --onto`. Abort, continue, the on-disk mirror and the completion
+  summary are all indifferent to where the base sits.
+- **One correction to the issue, found by mutation while writing the Rust test:**
+  `onto` reaches the run through **two** sites, not one. Besides
+  `rebase_start`'s initial detach, `advance_rebase` calls `move_to_base` for any
+  step that names an `onto`. Either one alone places the first step — disabling
+  each in turn left the new tests green, and only disabling both replayed the
+  branch on its own root. Recorded in the test file and in CLAUDE.md, because a
+  future change to where a run starts has to find both.
+
+Two consequences worth stating up front, because they shape the design:
+
+1. **The backend needs no change for the feature itself.** Everything below is
+   the range computation, the plan's base, and the entry points.
+2. `onto` is resolved with `revparse_single`, so it accepts **any revspec** — a
+   full oid, a 4–40 char prefix, a branch name. That is what makes the picker's
+   free-form hex row and the branch menus work with no new command.
+
+## What is missing
+
+- **The range.** The Rebase screen resolves its base through `commitsSince`,
+  which refuses a non-ancestor (`"<base> is not an ancestor of HEAD"`).
+- **The base on the plan.** Nothing ever sets `onto` on the first step, so the
+  engine always falls back to the first non-Drop step's parent.
+- **Entry points.** History's commit menu disables `Interactive rebase from here`
+  for any commit off HEAD's ancestry; the branch menus offer only the
+  non-interactive `Rebase current onto this`.
+
+## The decisions
+
+### 1. Range: `commitsBetween` for a diverged base, `commitsSince` kept for an ancestor — chosen by a count, not by a failed call
+
+`commitsBetween(base, HEAD)` is `base..tip` with **no ancestry requirement**
+(#131), which is exactly what git replays: HEAD's commits not reachable from the
+new base. `commitsSince` is **not loosened** — its ancestor requirement is a real
+invariant for the on-branch flow and the issue says so.
+
+The screen already has to call `aheadBehind(base, "HEAD")` for the header (below),
+and that answer decides the primitive with no wasted round trip:
+
+- `ahead === 0` → nothing to replay. Notice, no plan. (Covers `base === HEAD` and
+  a base that is a *descendant* of HEAD.)
+- `behind === 0` → `base` is an ancestor of HEAD, by `graph_ahead_behind`'s own
+  definition: nothing reachable from `base` is missing from HEAD. Use
+  `commitsSince` — the existing path, byte-identical to today.
+- `behind > 0` → diverged (or unrelated). Use `commitsBetween`.
+
+Two primitives rather than one is deliberate. Collapsing to `commitsBetween`
+everywhere would work — the walks are identical for an ancestor base — but it
+would change the common case for no gain, and it would leave `commits_since` with
+**no caller anywhere in the app**, forcing either dead code or an unrelated
+deletion of a registered command, its trait method, its integration test and its
+CLAUDE.md entry. Keeping the strict primitive on the flow whose invariant it
+encodes is the smaller and more honest change.
+
+### 2. Truncation is made impossible, because a truncated rebase plan destroys commits
+
+`commits_between`'s Tauri handler defaults `limit` to **200** (`commands/commits.rs`)
+and the walk simply `break`s at the cap. A silently truncated plan is the worst
+failure this feature could have: the missing commits are not replayed, and the
+branch ref moves anyway.
+
+So the limit is derived from the exact count and the result is verified:
+
+```
+limit = stats.ahead + 1        // +1 so an over-long answer is detectable too
+refuse unless range.length === stats.ahead
+```
+
+A mismatch cannot happen unless the repository changed between the two calls, and
+the answer to that is a notice — never a plan. There is deliberately **no
+arbitrary cap** on the plan's length: `commitsSince` never had one, so capping
+would newly refuse on-branch rebases that work today, and the header's count
+(below) is what makes a 3000-row plan visible before Start rather than surprising.
+
+### 3. The base rides on the plan's first non-Drop step, and it is attached at SUBMIT
+
+A new pure function, `withPlanBase(steps, baseOid)` (`src/features/commits/`),
+sets `onto: baseOid` on the first step whose action is not `Drop` and leaves every
+other step alone. `baseOid: null` is the identity.
+
+**At submit, not at build,** because flatten mode lets the user reorder the plan.
+Baked into the rows at build time, the base would stay pinned to whichever row was
+first when the plan was made; dragged to second place, the run would detach
+somewhere else entirely. `rebase_start` reads the first non-Drop step of the plan
+it is handed, so the base has to be attached to whatever that turns out to be.
+
+This closes a **pre-existing bug that has nothing to do with a diverged base.**
+Today every flatten row carries `onto: null`, so moving the newest commit to the
+top of the plan makes `rebase_start` detach at *its* parent — the second-newest
+commit — and replay the whole range onto the middle of itself. So the base is
+tracked for **every** plan this screen can submit, including one seeded by
+`Interactive rebase from here`: that path already computes the base (the oldest
+step's first parent) to render the `base:` label, and now stores it as well.
+Where it cannot be determined — a root commit, or an oldest step outside the
+loaded log — `baseOid` stays null and today's parent fallback applies unchanged.
+
+`buildPreservePlan` keeps assigning intermediate `onto` values from inside the
+range; only its first step is affected, and its `i > 0` guard already leaves that
+one `null`. One helper serves both modes, so flatten and preserve cannot drift on
+where a run starts.
+
+### 4. A second `NavIntent` kind: `rebase-onto`, carrying a revspec
+
+```ts
+| { kind: "rebase-onto"; base: string; label: string }
+```
+
+Routed to the `rebase` screen in AppShell, with a row in
+`AppShell.navroutes.test.tsx`'s `EXPECTED` table (a new kind fails to compile
+without one — twice over).
+
+**Not** an extension of `rebase-plan` with an added base, because the menus
+cannot build the plan:
+
+- The range is `base..HEAD`, computed by the backend. **The log is paged** —
+  `s.commits` is a prefix of history — so a frontend that assembled the range from
+  the store would silently produce a short plan for exactly the diverged bases
+  this feature exists for.
+- A branch context menu has a name, not a commit list.
+
+The intent therefore names the base and nothing else; the screen resolves it
+through the one `resolveBase` path the picker uses, so the header's numbers and
+the plan can never describe different ranges.
+
+**This is a second action, not a re-enable of the first.** `Interactive rebase
+from here` makes the clicked commit the *oldest replayed commit* (base = its
+parent, commit included). `rebase-onto` makes it the *new base*, which is **not in
+the plan**. Merging them into one item would make the same click mean two things.
+
+### 5. Entry points
+
+- **History commit menu**, immediately after `Interactive rebase from here`:
+  `Rebase current branch onto this…`, **disabled when the commit is on the
+  current branch's ancestry** — labelled `— already on this branch`, mirroring
+  `branchMenuItems`' `disabled: isCurrent`. For an on-branch ancestor the replay
+  is a no-op, and the item directly above is what that flow wants; the two are
+  therefore never both enabled for one commit, so there is no ambiguity about
+  which one a click hit.
+- **Local branch menu**, after the existing non-interactive `Rebase current onto
+  this`: `Rebase current onto this — interactive…`, `disabled: isCurrent`.
+- **Remote branch menu**: the same item, never disabled (a remote branch is never
+  current).
+- **No confirmation dialog** on any of the three, unlike the non-interactive
+  sibling: this rewrites nothing — it opens a plan, and `Start rebase` is the
+  destructive step, already behind its own button.
+- Both branch items pass the branch's **`tip`** (a FULL oid, read off
+  `useRepoStore.branches` — `BranchInfo.tip` is documented as full and must not be
+  shortened) and fall back to the branch NAME as a revspec when the tip is
+  unknown. A fixed oid means the plan, its counts and the run all describe one
+  commit even if a concurrent fetch moves the ref; the name is kept as the label.
+- **No palette entry and no keyboard chord.** The Rebase screen's own base picker
+  is the keyboard route and after this change it accepts any base, so nothing is
+  reachable by mouse only. A palette step would need its own commit picker, which
+  is a separate feature.
+
+### 6. `RebaseBasePicker.invalidOids` is deleted
+
+Nothing has ever passed it. Worse, what it encoded — "not on the current branch's
+history" — is now the **primary** use case, so a live version would grey out
+precisely the rows this feature exists to enable. And there is no longer any
+statically invalid base: every row either produces a plan or produces a backend
+answer with a real reason (`ahead === 0`, an unresolvable revspec), delivered
+through the notice that is already wired. The prop, its `ineligible` opacity and
+its tooltip go.
+
+### 7. The header states what will be replayed
+
+Once the base can be diverged, "everything newer than the base" stops being
+obvious, so `aheadBehind(base, HEAD)` (#131) is rendered as its own thin strip
+under the toolbar (`data-testid="rebase-base-summary"`), not squeezed into the
+already-crowded toolbar row:
+
+- always: `N commits will be replayed onto <base>.`
+- when `behind > 0`: `<base> has M commits this branch does not.`
+- when `behind > 0` and `mergeBase` is set: `Merge base <short>.` — omitted for
+  an ancestor base, where the merge base *is* the base and saying so is noise.
+- when `mergeBase` is null: `No common ancestor — the whole branch will be
+  replayed.` Unrelated histories are a state, not an error (git allows the
+  rebase); the strip is what makes the consequence visible before Start.
+
+The strip appears only for a resolved base, so an `Interactive rebase from here`
+plan (which has counts nobody asked the backend for) shows no strip.
+
+### 8. A base-resolution notice must be visible outside the picker
+
+`pickerNotice` renders only inside the picker popover, which needs an open state
+and an anchor. An intent from a context menu has neither, so a failed resolution
+would have been **completely silent** — the menu item would do nothing at all,
+which is the `stash-vs-wt` failure mode `AppShell.navroutes.test.tsx` exists to
+prevent, one layer lower.
+
+One state (renamed `baseNotice`, since it is the screen's now and not the
+picker's), rendered in two places that cannot both be visible: passed to the
+picker while it is open — it stays open on failure, so a bad hash can be retried
+on the spot — and rendered as a strip when it is closed.
+
+## Out of scope
+
+- **Auto-stash.** `rebase_start` already refuses a dirty worktree
+  (`DirtyWorktree`, "commit or stash before rebasing"); the issue puts auto-stash
+  outside this change.
+- **Loosening `commitsSince`.** See decision 1.
+- **Merges inside the replayed range.** Unchanged: flatten drops them (git's own
+  default), preserve recreates them. The mode toggle stays visible in this flow
+  precisely because a diverged base makes it likelier to matter.
+- **Rewriting the split view's `@@` separator, the palette's rebase steps, or
+  anything else the base picker touches.**
+
+## Testing
+
+- **Pure (`vitest`)** — `withPlanBase`: sets `onto` on the first non-Drop step;
+  skips leading Drops; leaves other steps' `onto` untouched (the preserve case);
+  identity for a null base and for an all-Drop plan; does not mutate its input.
+- **Component (`jsdom`)** — the Rebase screen driven by a `rebase-onto` intent:
+  the plan is built from `commits_between` with an `ahead`-derived limit; the
+  summary strip's three sentences; `ahead === 0` yields a visible notice and no
+  plan; a length mismatch refuses rather than planning a partial rebase; and
+  after a reorder the submitted plan carries `onto` on the **new** first row.
+- **Rust integration** — a genuinely diverged base: two branches off a common
+  root, `commits_between` as the range, `rebase_start` with `onto` on the first
+  step. Asserts the resulting history, that the branch ref moved and HEAD is
+  attached to it, that `ORIG_HEAD` is the pre-rebase tip, and that the side
+  branch's files survive. Plus the free-form path: a 7-char prefix and a branch
+  name are accepted as `onto` and land on the same commit as the full oid — that
+  is the "check the free-form path resolves through the backend" item, and it is
+  the *common* path now that a diverged base is usually outside the loaded log.
+- **E2E** — `e2e/specs/rebase.e2e.ts` covers this screen and is run for the
+  change. A new case drives the History menu's new item on a diverged commit if
+  the fixture is cheap; the routing itself is already proven by
+  `AppShell.navroutes.test.tsx`, which drives the real shell.

--- a/e2e/specs/rebase.e2e.ts
+++ b/e2e/specs/rebase.e2e.ts
@@ -1,6 +1,7 @@
 import { browser, $, expect } from "@wdio/globals";
 import {
   cherryRepo,
+  divergedRepo,
   mergeRangeRepo,
   rebaseConflictRepo,
   TempRepo,
@@ -220,6 +221,66 @@ describe("interactive rebase", () => {
     expect(repo.git("rev-parse", "ORIG_HEAD").trim()).toBe(originalMerge);
     expect(repo.read("f.txt")).toBe("f\n");
     expect(repo.read("c.txt")).toBe("c\n");
+    expect(repo.git("status", "--porcelain").trim()).toBe("");
+  });
+  it("replays the branch onto a diverged commit", async () => {
+    // The half of interactive rebase the old menu item cannot reach (186): the
+    // clicked commit is the NEW BASE and is not in the plan, so it does not have
+    // to be on HEAD's ancestry.
+    repo = divergedRepo();
+    const before = repo.git("rev-parse", "HEAD").trim();
+    const newBase = repo.git("rev-parse", "other").trim();
+    await openRepo(repo.path);
+    await switchScreen("history");
+
+    await scrollCommitListTo("feat: c on other");
+    await $('[data-testid="commit-row"]*=feat: c on other').waitForDisplayed({
+      timeout: 15_000,
+      timeoutMsg: "other's tip never appeared in History",
+    });
+    await jsContextMenu('[data-testid="commit-row"]', { text: "feat: c on other" });
+    // The OLD item must be off on this row — the two are complements, never both
+    // enabled for one commit.
+    await $('span=Interactive rebase from here — not on this branch').waitForExist({
+      timeout: 10_000,
+      timeoutMsg: "the on-branch-only item was not shown as unavailable",
+    });
+    await jsClickMenuItem("Rebase current branch onto this…");
+
+    // Wait on a signal that exists ONLY on the Rebase screen, before touching
+    // anything else: the summary strip, which is rendered from the backend's own
+    // ahead/behind counts for the base just picked.
+    const summary = $('[data-testid="rebase-base-summary"]');
+    await summary.waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "the Rebase screen never explained what would be replayed",
+    });
+    await expect(summary).toHaveText(
+      expect.stringContaining("3 commits will be replayed onto"),
+    );
+    await expect(summary).toHaveText(
+      expect.stringContaining("has 2 commits this branch does not"),
+    );
+
+    await $('[data-testid="rebase-start"]').click();
+    await $('[data-testid="rebase-last-summary"]').waitForDisplayed({
+      timeout: 30_000,
+      timeoutMsg: "the rebase onto a diverged base never reported completion",
+    });
+
+    // main now sits on top of other's tip, with both sides' content present.
+    expect(repo.git("log", "--format=%s").trim().split("\n")).toEqual([
+      "feat: e on main",
+      "feat: d on main",
+      "feat: a on main",
+      "feat: c on other",
+      "feat: b on other",
+      "feat: root",
+    ]);
+    expect(repo.git("rev-parse", "HEAD~3").trim()).toBe(newBase);
+    expect(repo.git("symbolic-ref", "HEAD").trim()).toBe("refs/heads/main");
+    expect(repo.git("rev-parse", "other").trim()).toBe(newBase);
+    expect(repo.git("rev-parse", "ORIG_HEAD").trim()).toBe(before);
     expect(repo.git("status", "--porcelain").trim()).toBe("");
   });
 });

--- a/e2e/support/tempRepo.ts
+++ b/e2e/support/tempRepo.ts
@@ -226,6 +226,35 @@ export function mergeRangeRepo(): TempRepo {
   return r;
 }
 
+/**
+ * Two branches diverged off a common root — the shape `git rebase -i <newbase>`
+ * exists for (186):
+ *
+ *   root ── A ── D ── E   (main, HEAD)
+ *       \
+ *        ─ B ── C         (other)
+ *
+ * Every commit touches its own file, so a replay of main onto `other` is
+ * conflict-free. `other`'s tip is NOT on HEAD's ancestry, which is exactly what
+ * every other rebase fixture here cannot express — and what disables the old
+ * "Interactive rebase from here" item on that row.
+ *
+ * History's default scope is `--all`, so `other`'s commits are on screen with no
+ * ref-selector step.
+ */
+export function divergedRepo(): TempRepo {
+  const r = new TempRepo();
+  r.commitFile("root.txt", "root\n", "feat: root");
+  r.git("checkout", "-b", "other");
+  r.commitFile("b.txt", "b\n", "feat: b on other");
+  r.commitFile("c.txt", "c\n", "feat: c on other");
+  r.git("checkout", "main");
+  r.commitFile("a.txt", "a\n", "feat: a on main");
+  r.commitFile("d.txt", "d\n", "feat: d on main");
+  r.commitFile("e.txt", "e\n", "feat: e on main");
+  return r;
+}
+
 /** A bare repository with real commits, for driving the clone path against
  *  local disk only — no network, no credentials, no flake.
  *

--- a/src-tauri/tests/rebase_onto_new_base.rs
+++ b/src-tauri/tests/rebase_onto_new_base.rs
@@ -1,0 +1,206 @@
+//! `git rebase -i <newbase>` — replaying a branch onto a base it does NOT
+//! descend from (186).
+//!
+//! The engine already supports this: `rebase_start` takes the run's base from
+//! the first non-Drop step's `onto`, and `rebase_plan::validate` accepts any
+//! existing commit there with no ancestry requirement. These tests pin that,
+//! because nothing else exercises an `onto` below the range — and pin the range
+//! primitive split too: `commits_between` answers for a diverged pair,
+//! `commits_since` refuses, and that refusal is deliberate.
+//!
+//! **`onto` reaches the run through TWO mechanisms, and either one alone is
+//! enough for the first step.** Measured by mutation while writing this file:
+//! disabling `rebase_start`'s `first_step.onto` detach leaves the tests green,
+//! because `advance_rebase` also calls `move_to_base` for any step that names an
+//! `onto`; disabling that instead is likewise green, because the initial detach
+//! already placed it. Only killing both turns the log into
+//! `E, D, A, initial` — main replayed on its own root with the new base
+//! nowhere in it. So a reader chasing "where does the base get used" must find
+//! both sites, and a test that only breaks one has proved nothing.
+
+mod support;
+
+use platypusgit_lib::git::{
+    types::{RebaseAction, RebaseStep},
+    GitBackend,
+};
+
+use support::{git_in, TempRepo};
+
+/// ```text
+/// root ── A ── D ── E   (main, HEAD)
+///     \
+///      ─ B ── C         (other)
+/// ```
+/// Every commit touches its own file, so nothing conflicts.
+struct Diverged {
+    root: String,
+    other_tip: String,
+    main_tip: String,
+}
+
+fn diverged(tr: &TempRepo) -> Diverged {
+    // Built with the real CLI, not `TempRepo::add_commit`: that helper commits
+    // through the fixture's OWN cached `git2::Index`, which a `git checkout` run
+    // beside it does not invalidate — so the branch swap left it holding the other
+    // branch's entries and the next commit's tree carried files the worktree did
+    // not have. `rebase_start` then refused the whole thing as DirtyWorktree.
+    let commit = |name: &str, body: &str, msg: &str| -> String {
+        support::fs::write_file(tr.path(), name, body);
+        git_in(tr.path(), &["add", "--", name]);
+        git_in(tr.path(), &["commit", "-m", msg]);
+        git_in(tr.path(), &["rev-parse", "HEAD"]).trim().to_string()
+    };
+
+    let root = git_in(tr.path(), &["rev-parse", "HEAD"]).trim().to_string();
+
+    git_in(tr.path(), &["checkout", "-b", "other"]);
+    commit("b.txt", "b\n", "B on other");
+    let other_tip = commit("c.txt", "c\n", "C on other");
+
+    git_in(tr.path(), &["checkout", "main"]);
+    commit("a.txt", "a\n", "A on main");
+    commit("d.txt", "d\n", "D on main");
+    let main_tip = commit("e.txt", "e\n", "E on main");
+
+    assert_eq!(
+        git_in(tr.path(), &["status", "--porcelain"]).trim(),
+        "",
+        "the fixture must leave a clean worktree — rebase_start refuses a dirty one"
+    );
+
+    Diverged {
+        root,
+        other_tip,
+        main_tip,
+    }
+}
+
+fn step(oid: &str, onto: Option<&str>) -> RebaseStep {
+    RebaseStep {
+        oid: oid.to_string(),
+        action: RebaseAction::Pick,
+        message: None,
+        onto: onto.map(|s| s.to_string()),
+        merge_parents: Vec::new(),
+    }
+}
+
+#[test]
+fn commits_between_is_the_range_and_commits_since_refuses_it() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = diverged(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    let range = backend
+        .commits_between(&handle.id, &h.other_tip, "HEAD", 100)
+        .unwrap();
+    let summaries: Vec<&str> = range.iter().map(|c| c.summary.as_str()).collect();
+    assert_eq!(
+        summaries,
+        vec!["E on main", "D on main", "A on main"],
+        "base..HEAD is HEAD's commits not reachable from the new base"
+    );
+
+    // The invariant that stays: a rebase base for the ON-BRANCH flow must be an
+    // ancestor. Loosening this is explicitly out of scope.
+    assert!(
+        backend.commits_since(&handle.id, &h.other_tip).is_err(),
+        "commits_since must keep refusing a non-ancestor base"
+    );
+}
+
+#[test]
+fn replays_the_branch_onto_a_diverged_base() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = diverged(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    let range = backend
+        .commits_between(&handle.id, &h.other_tip, "HEAD", 100)
+        .unwrap();
+    // Oldest-first, with the new base named on the first step — the plan shape
+    // the Rebase screen submits.
+    let mut plan: Vec<RebaseStep> = range.iter().rev().map(|c| step(&c.oid, None)).collect();
+    plan[0].onto = Some(h.other_tip.clone());
+
+    let status = backend.rebase_start(&handle.id, plan).unwrap();
+    assert!(!status.in_progress, "a clean replay finishes in one call");
+
+    let log = git_in(tr.path(), &["log", "--format=%s"]);
+    assert_eq!(
+        log.trim().split('\n').collect::<Vec<_>>(),
+        vec![
+            "E on main",
+            "D on main",
+            "A on main",
+            "C on other",
+            "B on other",
+            "initial"
+        ],
+        "main must sit on top of other's tip"
+    );
+
+    // The branch ref moved, exactly once, and HEAD is attached to it again.
+    assert_eq!(
+        git_in(tr.path(), &["symbolic-ref", "HEAD"]).trim(),
+        "refs/heads/main"
+    );
+    assert_eq!(
+        git_in(tr.path(), &["rev-parse", "ORIG_HEAD"]).trim(),
+        h.main_tip,
+        "ORIG_HEAD is the pre-rebase tip — `git reset --hard ORIG_HEAD` undoes this"
+    );
+    assert_eq!(git_in(tr.path(), &["status", "--porcelain"]).trim(), "");
+    // Both sides' content survives.
+    for f in ["a.txt", "b.txt", "c.txt", "d.txt", "e.txt"] {
+        assert!(tr.path().join(f).exists(), "{f} must exist after the replay");
+    }
+    // `other` itself is untouched.
+    assert_eq!(
+        git_in(tr.path(), &["rev-parse", "other"]).trim(),
+        h.other_tip
+    );
+    assert_ne!(h.root, h.other_tip);
+}
+
+#[test]
+fn a_short_prefix_and_a_branch_name_both_work_as_the_new_base() {
+    // The base picker's free-form hash row and the branch menus hand over a
+    // PREFIX and a NAME, not a full oid — and after this feature that is the
+    // common path, because a diverged base is usually outside the loaded log.
+    // Both `ahead_behind` and `rebase_start` revparse whatever they are given.
+    let tr = TempRepo::with_initial_commit("root\n");
+    let h = diverged(&tr);
+    let (backend, handle) = tr.open_with_backend();
+
+    let by_oid = backend
+        .ahead_behind(&handle.id, &h.other_tip, "HEAD")
+        .unwrap();
+    let by_prefix = backend
+        .ahead_behind(&handle.id, &h.other_tip[..7], "HEAD")
+        .unwrap();
+    let by_name = backend.ahead_behind(&handle.id, "other", "HEAD").unwrap();
+    assert_eq!(by_oid.ahead, 3, "three commits on main are not on other");
+    assert_eq!(by_oid.behind, 2, "two commits on other are not on main");
+    assert_eq!(by_oid.merge_base, Some(h.root.clone()));
+    assert_eq!(by_prefix.ahead, by_oid.ahead);
+    assert_eq!(by_prefix.behind, by_oid.behind);
+    assert_eq!(by_name.ahead, by_oid.ahead);
+    assert_eq!(by_name.behind, by_oid.behind);
+
+    let range = backend
+        .commits_between(&handle.id, &h.other_tip[..7], "HEAD", 100)
+        .unwrap();
+    assert_eq!(range.len(), 3);
+
+    let mut plan: Vec<RebaseStep> = range.iter().rev().map(|c| step(&c.oid, None)).collect();
+    plan[0].onto = Some(h.other_tip[..7].to_string());
+    backend.rebase_start(&handle.id, plan).unwrap();
+
+    assert_eq!(
+        git_in(tr.path(), &["rev-parse", "HEAD~3"]).trim(),
+        h.other_tip,
+        "a 7-char prefix must land on the same base as the full oid"
+    );
+}

--- a/src/AppShell.navroutes.test.tsx
+++ b/src/AppShell.navroutes.test.tsx
@@ -110,6 +110,13 @@ const EXPECTED: { [K in NavIntent["kind"]]: Expectation<K> } = {
     intent: { kind: "rebase-plan", plan: [] },
     screen: "rebase",
   },
+  // The diverged-base flow (186). The intent names a base and nothing else —
+  // the SCREEN resolves the range, because the log is paged and a branch menu
+  // has no commit list at all.
+  "rebase-onto": {
+    intent: { kind: "rebase-onto", base: OID2, label: "other" },
+    screen: "rebase",
+  },
   // The two stash comparisons (#133). `stash-vs-wt` is the regression: revert
   // AppShell's `case "stash-vs-wt":` and this row fails with "history".
   "stash-diff": {

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -327,6 +327,9 @@ export function AppShell() {
         enterDeep("blame");
         break;
       case "rebase-plan":
+      // The base-only variant (186). Same destination: the Rebase screen owns
+      // the range walk and the plan either way.
+      case "rebase-onto":
         setScreen("rebase");
         break;
       // Both stash comparisons are `CommitDiff` targets (#133) — the entry

--- a/src/design/context-menu.rebaseOnto.test.tsx
+++ b/src/design/context-menu.rebaseOnto.test.tsx
@@ -1,0 +1,174 @@
+// "Rebase current onto this — interactive" from the three menus that can name a
+// new base (186).
+//
+// The traps this file pins:
+//   - it is a SECOND action, not a re-enable of "Interactive rebase from here".
+//     That one makes the clicked commit the oldest replayed commit; this one makes
+//     it the new BASE, which is not in the plan. So the two are never both enabled
+//     for one commit: the new item is disabled precisely when the old one is not.
+//   - the branch items name the branch's `tip`, a FULL oid, so the plan and its
+//     counts describe one fixed commit even if a fetch moves the ref. `tip` was
+//     once truncated to 7 chars, so nothing here may shorten it.
+//   - an unknown branch falls back to the NAME as a revspec rather than emitting
+//     a `base: null` the screen would have to special-case.
+
+import { describe, it, expect, beforeEach } from "vitest";
+
+import {
+  branchMenuItems,
+  commitMenuItems,
+  remoteBranchMenuItems,
+  type ContextMenuItem,
+} from "./context-menu";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import type { BranchInfo, CommitInfo } from "@/lib/types";
+
+const HEAD_OID = "a".repeat(40);
+const MID = "b".repeat(40);
+const ROOT = "d".repeat(40);
+const OFF_BRANCH = "f".repeat(40);
+
+const mk = (oid: string, parents: string[]): CommitInfo => ({
+  oid,
+  shortOid: oid.slice(0, 7),
+  summary: `commit ${oid.slice(0, 1)}`,
+  body: null,
+  author: "Dev",
+  email: "dev@example.com",
+  timestamp: 1_700_000_000,
+  parents,
+  refs: [],
+});
+
+const branch = (over: Partial<BranchInfo> & { name: string }): BranchInfo => ({
+  isHead: false,
+  isRemote: false,
+  upstream: null,
+  ahead: 0,
+  behind: 0,
+  tip: null,
+  tipTime: 0,
+  isDefault: false,
+  ...over,
+});
+
+/**
+ * HEAD is `main` at HEAD_OID; OFF_BRANCH is loaded but unreachable from it.
+ * MID is on-branch AND has a parent — "Interactive rebase from here" needs one,
+ * so a root commit could not stand in for it.
+ */
+const COMMITS = [
+  mk(HEAD_OID, [MID]),
+  mk(OFF_BRANCH, [MID]),
+  mk(MID, [ROOT]),
+  mk(ROOT, []),
+];
+
+const OTHER_TIP = "c".repeat(40);
+
+function labeled(items: ContextMenuItem[], label: string): ContextMenuItem {
+  const found = items.find((i) => i.label === label);
+  expect(found, `no menu item labelled "${label}"`).toBeTruthy();
+  return found!;
+}
+
+const ONTO_LABEL = "Rebase current onto this — interactive…";
+
+beforeEach(() => {
+  useNavStore.setState({ intent: null });
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    commits: COMMITS,
+    status: [],
+    branches: [
+      branch({ name: "main", isHead: true, tip: HEAD_OID }),
+      branch({ name: "other", tip: OTHER_TIP }),
+      branch({ name: "origin/other", isRemote: true, tip: OTHER_TIP }),
+    ],
+    loading: false,
+  } as never);
+});
+
+describe("commit menu", () => {
+  it("names an off-branch commit as the new base", () => {
+    const items = commitMenuItems({ sha: OFF_BRANCH, subject: "commit f" });
+    const item = labeled(items, "Rebase current branch onto this…");
+    expect(item.disabled).toBeFalsy();
+
+    item.onClick?.();
+    expect(useNavStore.getState().intent).toEqual({
+      kind: "rebase-onto",
+      base: OFF_BRANCH,
+      label: `${OFF_BRANCH.slice(0, 7)} — commit f`,
+    });
+  });
+
+  it("is disabled — and says why — for a commit already on this branch", () => {
+    const items = commitMenuItems({ sha: MID, subject: "commit b" });
+    const item = labeled(
+      items,
+      "Rebase current branch onto this — already on this branch",
+    );
+    expect(item.disabled).toBe(true);
+  });
+
+  it("is the complement of 'Interactive rebase from here', never its twin", () => {
+    // On-branch: the old item works, the new one is off.
+    const onBranch = commitMenuItems({ sha: MID, subject: "commit b" });
+    expect(labeled(onBranch, "Interactive rebase from here").disabled).toBeFalsy();
+    // Off-branch: exactly the other way round.
+    const offBranch = commitMenuItems({ sha: OFF_BRANCH, subject: "commit f" });
+    expect(
+      labeled(offBranch, "Interactive rebase from here — not on this branch")
+        .disabled,
+    ).toBe(true);
+    expect(
+      labeled(offBranch, "Rebase current branch onto this…").disabled,
+    ).toBeFalsy();
+  });
+});
+
+describe("branch menus", () => {
+  it("names a local branch's FULL tip oid, not its name and not a prefix", () => {
+    const item = labeled(branchMenuItems({ name: "other" }), ONTO_LABEL);
+    expect(item.disabled).toBeFalsy();
+
+    item.onClick?.();
+    expect(useNavStore.getState().intent).toEqual({
+      kind: "rebase-onto",
+      base: OTHER_TIP,
+      label: "other",
+    });
+  });
+
+  it("is disabled for the current branch — rebasing onto yourself is a no-op", () => {
+    const item = labeled(
+      branchMenuItems({ name: "main", current: true }),
+      ONTO_LABEL,
+    );
+    expect(item.disabled).toBe(true);
+  });
+
+  it("names a remote branch's tip, and is never disabled", () => {
+    const item = labeled(remoteBranchMenuItems({ name: "origin/other" }), ONTO_LABEL);
+    expect(item.disabled).toBeFalsy();
+
+    item.onClick?.();
+    expect(useNavStore.getState().intent).toEqual({
+      kind: "rebase-onto",
+      base: OTHER_TIP,
+      label: "origin/other",
+    });
+  });
+
+  it("falls back to the branch name when its tip is unknown", () => {
+    useRepoStore.setState({ branches: [] } as never);
+    labeled(branchMenuItems({ name: "other" }), ONTO_LABEL).onClick?.();
+    expect(useNavStore.getState().intent).toEqual({
+      kind: "rebase-onto",
+      base: "other",
+      label: "other",
+    });
+  });
+});

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -455,6 +455,28 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
         useNavStore.getState().setIntent({ kind: "rebase-plan", plan });
       },
     },
+    {
+      icon: "rebase",
+      // The OTHER half of interactive rebase (186), and a genuinely different
+      // action: "from here" makes the clicked commit the OLDEST REPLAYED commit
+      // (base = its parent); this makes it the NEW BASE, which is not in the plan
+      // at all. Disabled for a commit already on this branch, mirroring
+      // branchMenuItems' `disabled: isCurrent` — replaying onto your own ancestor
+      // is a no-op, and the item above is what that flow wants. So the two are
+      // never both enabled for one commit.
+      label: onBranch
+        ? "Rebase current branch onto this — already on this branch"
+        : "Rebase current branch onto this…",
+      disabled: onBranch || !commit?.sha,
+      onClick: () => {
+        if (!commit?.sha) return;
+        useNavStore.getState().setIntent({
+          kind: "rebase-onto",
+          base: commit.sha,
+          label: `${sha.slice(0, 7)} — ${commit.subject ?? ""}`.trim(),
+        });
+      },
+    },
     { divider: true },
     {
       icon: "edit",
@@ -595,6 +617,17 @@ function byOid(commits: CommitInfo[]): Map<string, CommitInfo> {
 function ancestryLog(): CommitInfo[] {
   const { commits, branches } = useRepoStore.getState();
   return headAncestryOf(commits, branches);
+}
+
+/**
+ * A branch's tip oid, for menu items that must name a fixed commit rather than a
+ * moving ref (186). `BranchInfo.tip` is a FULL oid and is used as one — it was
+ * once truncated to 7 chars and every comparison against `CommitInfo.oid` then
+ * failed silently. Null when the branch is unknown or its tip is unresolvable;
+ * the caller then falls back to the NAME, which the backend revparses anyway.
+ */
+function branchTipOid(name: string): string | null {
+  return useRepoStore.getState().branches.find((b) => b.name === name)?.tip ?? null;
 }
 
 /**
@@ -1065,6 +1098,21 @@ export function branchMenuItems(
           useRepoStore.getState().rebaseOnto(name);
       },
     },
+    {
+      icon: "rebase",
+      // No confirm, unlike the non-interactive sibling above: this rewrites
+      // nothing. It opens a plan, and `Start rebase` is the destructive step.
+      label: "Rebase current onto this — interactive…",
+      disabled: isCurrent,
+      onClick: () => {
+        if (!name) return;
+        useNavStore.getState().setIntent({
+          kind: "rebase-onto",
+          base: branchTipOid(name) ?? name,
+          label: name,
+        });
+      },
+    },
     { divider: true },
     ...compareMenuItems({ name, isCurrent }),
     { divider: true },
@@ -1239,6 +1287,19 @@ export function remoteBranchMenuItems(branch: { name?: string } | null): Context
           })
         )
           useRepoStore.getState().rebaseOnto(name);
+      },
+    },
+    {
+      icon: "rebase",
+      // Never disabled — a remote-tracking branch is never the current branch.
+      label: "Rebase current onto this — interactive…",
+      onClick: () => {
+        if (!name) return;
+        useNavStore.getState().setIntent({
+          kind: "rebase-onto",
+          base: branchTipOid(name) ?? name,
+          label: name,
+        });
       },
     },
     { divider: true },

--- a/src/features/commits/buildPreservePlan.ts
+++ b/src/features/commits/buildPreservePlan.ts
@@ -25,9 +25,10 @@ export function buildPreservePlan(range: CommitInfo[]): RebaseStep[] {
 
     // Only name a base when it is not where the replay already sits. Naming it
     // unconditionally would work, but it would make every step a reset and hide
-    // the linear default from anyone reading the plan. The first step's base is
-    // the range's base, which `rebase_start` derives from its first parent, so
-    // it stays null too.
+    // the linear default from anyone reading the plan. The FIRST step stays null
+    // here on purpose: its base is the range's base, which the Rebase screen
+    // attaches with `withPlanBase` at submit (186) — and which `rebase_start`
+    // derives from the first parent when nothing names it.
     const onto =
       i > 0 && firstParent && firstParent !== previousOid ? firstParent : null;
 

--- a/src/features/commits/withPlanBase.test.ts
+++ b/src/features/commits/withPlanBase.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { withPlanBase } from "./withPlanBase";
+import type { RebaseStep } from "@/lib/types";
+
+const A = "a".repeat(40);
+const B = "b".repeat(40);
+const C = "c".repeat(40);
+const BASE = "9".repeat(40);
+
+function step(oid: string, over: Partial<RebaseStep> = {}): RebaseStep {
+  return { oid, action: "Pick", message: null, onto: null, mergeParents: [], ...over };
+}
+
+describe("withPlanBase", () => {
+  it("names the base on the first step and leaves the rest linear", () => {
+    const out = withPlanBase([step(A), step(B), step(C)], BASE);
+    expect(out.map((s) => s.onto)).toEqual([BASE, null, null]);
+  });
+
+  it("skips leading drops — the engine reads the first NON-Drop step", () => {
+    const out = withPlanBase([step(A, { action: "Drop" }), step(B), step(C)], BASE);
+    expect(out.map((s) => s.onto)).toEqual([null, BASE, null]);
+  });
+
+  it("leaves an intermediate step's own base alone (the preserve case)", () => {
+    const out = withPlanBase([step(A), step(B, { onto: A }), step(C)], BASE);
+    expect(out.map((s) => s.onto)).toEqual([BASE, A, null]);
+  });
+
+  it("overwrites the first step's own base — a picked base outranks it", () => {
+    const out = withPlanBase([step(A, { onto: C }), step(B)], BASE);
+    expect(out[0].onto).toBe(BASE);
+  });
+
+  it("is the identity when no base is known", () => {
+    const plan = [step(A), step(B)];
+    expect(withPlanBase(plan, null)).toBe(plan);
+  });
+
+  it("is the identity for an all-Drop plan (the backend refuses it anyway)", () => {
+    const plan = [step(A, { action: "Drop" }), step(B, { action: "Drop" })];
+    expect(withPlanBase(plan, BASE).map((s) => s.onto)).toEqual([null, null]);
+  });
+
+  it("does not mutate its input", () => {
+    const plan = [step(A), step(B)];
+    withPlanBase(plan, BASE);
+    expect(plan[0].onto).toBeNull();
+  });
+});

--- a/src/features/commits/withPlanBase.ts
+++ b/src/features/commits/withPlanBase.ts
@@ -1,0 +1,31 @@
+import type { RebaseStep } from "@/lib/types";
+
+/**
+ * Attach a run's base to a plan: `onto: baseOid` on the FIRST non-Drop step.
+ *
+ * `rebase_start` takes the run's base from exactly that step's `onto`, falling
+ * back to its first parent when there is none (`libgit2.rs`). Naming the base
+ * explicitly is what makes a plan `git rebase --onto <base>` — the whole reason a
+ * diverged base works at all — and `rebase_plan::validate` accepts any existing
+ * commit there, with no ancestry requirement.
+ *
+ * Call this at SUBMIT, never when the rows are built. Flatten mode lets the user
+ * reorder the plan, and the base belongs to the plan's first step rather than to
+ * the row that happened to be first when it was built: pinned at build time, a
+ * row dragged out of first place would take the base with it and the run would
+ * detach somewhere else entirely.
+ *
+ * `baseOid: null` means "nothing better than the engine's parent fallback is
+ * known" (a root commit, or an oldest step outside the loaded log) and returns
+ * the plan untouched. `baseOid` may be any revspec — an oid, a prefix, a branch
+ * name — because both the validator and the engine `revparse_single` it.
+ */
+export function withPlanBase(
+  steps: RebaseStep[],
+  baseOid: string | null,
+): RebaseStep[] {
+  if (!baseOid) return steps;
+  const first = steps.findIndex((s) => s.action !== "Drop");
+  if (first < 0) return steps;
+  return steps.map((s, i) => (i === first ? { ...s, onto: baseOid } : s));
+}

--- a/src/features/nav/useNavStore.ts
+++ b/src/features/nav/useNavStore.ts
@@ -23,6 +23,17 @@ export type NavIntent =
   | { kind: "blame"; path: string }
   | { kind: "rebase-plan"; plan: RebaseStep[] }
   /**
+   * Replay the current branch onto a NEW base, interactively (186) — the
+   * `git rebase -i <newbase>` half. `base` is any revspec (a full oid where the
+   * caller has one, else a branch name); `label` is what to call it on screen.
+   *
+   * Deliberately NOT a `rebase-plan` carrying a base: the range is `base..HEAD`
+   * and only the backend can walk it. The log is PAGED, so a plan assembled from
+   * `useRepoStore.commits` would silently come up short for exactly the diverged
+   * bases this exists for — and a branch context menu has a name, not commits.
+   */
+  | { kind: "rebase-onto"; base: string; label: string }
+  /**
    * A stash comparison (#133). Two targets, one screen.
    *
    * `oid` is the FULL stash-commit oid, never `stash@{N}` and never the index:

--- a/src/features/rebase/RebaseBasePicker.tsx
+++ b/src/features/rebase/RebaseBasePicker.tsx
@@ -18,6 +18,13 @@ interface Row {
   commit?: CommitInfo;
 }
 
+// There is deliberately no "ineligible row" state (186). A prop for it existed
+// and nothing ever passed it — and what it encoded, "not on the current branch's
+// history", is now the primary reason to pick a base at all, so a live version
+// would grey out exactly the rows this picker exists to offer. The genuine
+// refusals (nothing to replay, an unresolvable revspec) are backend answers and
+// arrive through `notice`.
+
 interface Props {
   anchor: HTMLElement | null;
   open: boolean;
@@ -25,8 +32,6 @@ interface Props {
   onPick: (oid: string, label: string) => void;
   /** Optional notice shown above the search input (e.g. error). */
   notice?: string | null;
-  /** OIDs that are not on the current branch's history — used to mark rows as ineligible. */
-  invalidOids?: Set<string>;
 }
 
 const WIDTH = 460;
@@ -40,7 +45,6 @@ export function RebaseBasePicker({
   onClose,
   onPick,
   notice,
-  invalidOids,
 }: Props) {
   const branches = useRepoStore((s) => s.branches);
   const commits = useRepoStore((s) => s.commits);
@@ -169,7 +173,6 @@ export function RebaseBasePicker({
 
   const renderRow = (r: Row, idx: number) => {
     const active = idx === activeIndex;
-    const ineligible = invalidOids?.has(r.oid) ?? false;
     const iconName =
       r.kind === "branchLocal" || r.kind === "branchRemote" ? "branch" : "commit";
     return (
@@ -177,7 +180,6 @@ export function RebaseBasePicker({
         key={`${r.kind}:${r.oid}:${r.label}`}
         onClick={() => pick(r)}
         onMouseEnter={() => setActiveIndex(idx)}
-        title={ineligible ? "Not on current branch's history" : undefined}
         style={{
           display: "flex",
           alignItems: "center",
@@ -188,7 +190,6 @@ export function RebaseBasePicker({
           cursor: "pointer",
           fontFamily: "var(--font-mono)",
           fontSize: "var(--fs-12)",
-          opacity: ineligible ? 0.5 : 1,
         }}
       >
         <PGIcon

--- a/src/screens/Rebase.onto.test.tsx
+++ b/src/screens/Rebase.onto.test.tsx
@@ -1,0 +1,194 @@
+// The diverged-base flow (186): a `rebase-onto` intent names a base, the screen
+// walks `base..HEAD` on the backend, and the submitted plan carries that base on
+// its first non-Drop step.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { RebaseScreen } from "./Rebase";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { mockInvoke } from "@/test/invokeMock";
+import type { CommitInfo, RebaseStatus, RebaseStep, RepoHandle } from "@/lib/types";
+
+const handle: RepoHandle = { id: "repo-1", path: "/tmp/fake-repo", head: "refs/heads/main" };
+
+const SWEPT: RebaseStatus = {
+  inProgress: false,
+  nextIndex: 0,
+  total: 0,
+  pauseReason: null,
+  lastCompleted: null,
+};
+
+const BASE = "9".repeat(40);
+const ROOT = "0".repeat(40);
+const A = "a".repeat(40);
+const B = "b".repeat(40);
+const C = "c".repeat(40);
+
+function mk(oid: string, summary: string, parent: string): CommitInfo {
+  return {
+    oid,
+    shortOid: oid.slice(0, 7),
+    summary,
+    body: null,
+    author: "Tester",
+    email: "t@example.com",
+    timestamp: 1_700_000_000,
+    parents: [parent],
+    refs: [],
+  };
+}
+
+/** `base..HEAD`, newest-first — what `commits_between` returns. */
+const RANGE = [mk(C, "feat: third", B), mk(B, "feat: second", A), mk(A, "feat: first", ROOT)];
+
+/** Records what the screen actually submitted, and how it asked for the range. */
+function wire(opts: {
+  ahead: number;
+  behind: number;
+  mergeBase: string | null;
+  range?: CommitInfo[];
+}): { started: () => RebaseStep[][]; betweenLimits: () => Array<number | undefined> } {
+  const started: RebaseStep[][] = [];
+  const betweenLimits: Array<number | undefined> = [];
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: RANGE, nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => SWEPT);
+  mockInvoke("ahead_behind", () => ({
+    ahead: opts.ahead,
+    behind: opts.behind,
+    mergeBase: opts.mergeBase,
+  }));
+  mockInvoke("commits_between", (args) => {
+    betweenLimits.push((args as { limit?: number }).limit);
+    return opts.range ?? RANGE;
+  });
+  mockInvoke("commits_since", () => opts.range ?? RANGE);
+  mockInvoke("rebase_start", (args) => {
+    started.push((args as { plan: RebaseStep[] }).plan);
+    return SWEPT;
+  });
+  return { started: () => started, betweenLimits: () => betweenLimits };
+}
+
+function seedOntoIntent(): void {
+  useNavStore.setState({ intent: { kind: "rebase-onto", base: BASE, label: "other" } });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+  useRepoStore.setState({
+    current: handle,
+    status: [],
+    allFiles: [],
+    branches: [],
+    tags: [],
+    stashes: [],
+    remotes: [],
+    commits: RANGE,
+    loading: false,
+    error: null,
+    repoState: "Clean",
+    rebaseStatus: SWEPT,
+    activity: {},
+  } as never);
+  useNavStore.setState({ intent: null });
+});
+
+describe("RebaseScreen — a diverged base", () => {
+  it("plans base..HEAD and submits the base on the first step", async () => {
+    const rec = wire({ ahead: 3, behind: 2, mergeBase: ROOT });
+    seedOntoIntent();
+    render(<RebaseScreen />);
+
+    await waitFor(() => expect(screen.getAllByText(/feat: /)).toHaveLength(3));
+    // The limit is derived from `ahead`, never left to the handler's default of
+    // 200 — a truncated plan would drop commits and still move the branch ref.
+    expect(rec.betweenLimits()).toEqual([4]);
+
+    await userEvent.click(screen.getByTestId("rebase-start"));
+
+    await waitFor(() => expect(rec.started()).toHaveLength(1));
+    const plan = rec.started()[0];
+    expect(plan.map((s) => s.oid)).toEqual([A, B, C]);
+    expect(plan.map((s) => s.onto)).toEqual([BASE, null, null]);
+  });
+
+  it("states what will be replayed, including the merge base", async () => {
+    wire({ ahead: 3, behind: 2, mergeBase: ROOT });
+    seedOntoIntent();
+    render(<RebaseScreen />);
+
+    const strip = await screen.findByTestId("rebase-base-summary");
+    expect(strip).toHaveTextContent("3 commits will be replayed onto other.");
+    expect(strip).toHaveTextContent("other has 2 commits this branch does not.");
+    expect(strip).toHaveTextContent(`Merge base ${ROOT.slice(0, 7)}.`);
+  });
+
+  it("warns when the histories are unrelated", async () => {
+    wire({ ahead: 3, behind: 2, mergeBase: null });
+    seedOntoIntent();
+    render(<RebaseScreen />);
+
+    const strip = await screen.findByTestId("rebase-base-summary");
+    expect(strip).toHaveTextContent("No common ancestor");
+  });
+
+  it("shows a visible notice and no plan when there is nothing to replay", async () => {
+    const rec = wire({ ahead: 0, behind: 4, mergeBase: ROOT });
+    seedOntoIntent();
+    render(<RebaseScreen />);
+
+    // The picker is CLOSED here — an intent has no anchor — so the notice has to
+    // live on the screen or the menu item would fail in total silence.
+    const notice = await screen.findByTestId("rebase-base-notice");
+    expect(notice).toHaveTextContent("No commits between HEAD and other.");
+    expect(screen.getByTestId("rebase-start")).toBeDisabled();
+    expect(rec.betweenLimits()).toEqual([]);
+  });
+
+  it("refuses a partial range rather than planning a truncated rebase", async () => {
+    wire({ ahead: 3, behind: 2, mergeBase: ROOT, range: RANGE.slice(0, 2) });
+    seedOntoIntent();
+    render(<RebaseScreen />);
+
+    const notice = await screen.findByTestId("rebase-base-notice");
+    expect(notice).toHaveTextContent("partial rebase");
+    expect(screen.getByTestId("rebase-start")).toBeDisabled();
+  });
+
+  it("keeps the base on the first step after a reorder", async () => {
+    const rec = wire({ ahead: 3, behind: 2, mergeBase: ROOT });
+    seedOntoIntent();
+    render(<RebaseScreen />);
+
+    await waitFor(() => expect(screen.getAllByTestId("rebase-move-up")).toHaveLength(3));
+    // Move the newest commit (row 3) to the top. Without withPlanBase running at
+    // SUBMIT, the base would still be sitting on the row that used to be first.
+    await userEvent.click(screen.getAllByTestId("rebase-move-up")[2]);
+    await userEvent.click(screen.getAllByTestId("rebase-move-up")[1]);
+
+    await userEvent.click(screen.getByTestId("rebase-start"));
+    await waitFor(() => expect(rec.started()).toHaveLength(1));
+    const plan = rec.started()[0];
+    expect(plan[0].oid).toBe(C);
+    expect(plan.map((s) => s.onto)).toEqual([BASE, null, null]);
+  });
+
+  it("uses commits_since — not commits_between — for an ancestor base", async () => {
+    const rec = wire({ ahead: 3, behind: 0, mergeBase: BASE });
+    seedOntoIntent();
+    render(<RebaseScreen />);
+
+    await waitFor(() => expect(screen.getAllByText(/feat: /)).toHaveLength(3));
+    expect(rec.betweenLimits()).toEqual([]);
+  });
+});

--- a/src/screens/Rebase.tsx
+++ b/src/screens/Rebase.tsx
@@ -2,9 +2,9 @@ import React, { useState, useCallback } from "react";
 import { PGRebaseRow } from "@/design/git-components";
 import { PGButton } from "@/design/primitives";
 import { PGEmpty, PGIcon } from "@/design";
-import type { CommitInfo } from "@/lib/types";
+import type { AheadBehind, CommitInfo } from "@/lib/types";
 import type { RebaseAction, RebaseStep, RebaseSummary } from "@/lib/types";
-import { commitsSince } from "@/lib/tauri";
+import { aheadBehind, commitsBetween, commitsSince } from "@/lib/tauri";
 import { appErrorMessage } from "@/lib/errors";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
@@ -14,6 +14,7 @@ import {
   type RebaseMergeMode,
 } from "@/features/rebase/useRebaseMergeMode";
 import { buildPreservePlan } from "@/features/commits/buildPreservePlan";
+import { withPlanBase } from "@/features/commits/withPlanBase";
 import { useRowReorder } from "@/features/dnd";
 import { PGPane, FocusableScroll, useAction, usePaneList } from "@/features/keymap";
 
@@ -193,8 +194,18 @@ export function RebaseScreen() {
   // The drag needs the scroll element to auto-scroll near the edges.
   const planScrollRef = React.useRef<HTMLDivElement>(null);
   const [baseLabel, setBaseLabel] = useState<string | null>(null);
+  /**
+   * The revspec the run detaches at, carried to submit by `withPlanBase`. Any
+   * revspec is legal (a full oid where we have one, a prefix from the picker's
+   * hash row, a branch name from a branch menu) because both the validator and
+   * the engine `revparse_single` it. Null means "use the engine's parent
+   * fallback" — a root commit, or an oldest step outside the loaded log.
+   */
+  const [baseRev, setBaseRev] = useState<string | null>(null);
+  /** Counts for the summary strip; only a RESOLVED base has them. */
+  const [baseStats, setBaseStats] = useState<AheadBehind | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
-  const [pickerNotice, setPickerNotice] = useState<string | null>(null);
+  const [baseNotice, setBaseNotice] = useState<string | null>(null);
   const [pickerAnchor, setPickerAnchor] = useState<HTMLElement | null>(null);
 
   // The completed-rebase notice reads STRAIGHT off the backend's retained
@@ -218,35 +229,72 @@ export function RebaseScreen() {
     [rebaseAcknowledge],
   );
 
-  // Resolve the base through the backend so any revspec works — branch, tag,
-  // full or short hash, even commits outside the loaded log window. The backend
-  // returns base..HEAD (newest-first) and rejects a base that isn't an ancestor.
-  const handlePickBase = useCallback(
-    async (oid: string, label: string) => {
+  /**
+   * Resolve a base to a range and a plan. ONE path for the picker and for a
+   * `rebase-onto` intent, so the strip's counts and the plan can never describe
+   * different ranges. Any revspec works — branch, tag, full or short hash, even
+   * a commit outside the loaded log window.
+   *
+   * `aheadBehind` comes first because its answer chooses the range primitive,
+   * with no failed round trip:
+   *   - ahead === 0  → nothing to replay (base is HEAD, or a descendant of it).
+   *   - behind === 0 → base is an ANCESTOR of HEAD, by graph_ahead_behind's own
+   *     definition: nothing reachable from base is missing from HEAD. That is
+   *     `commitsSince`'s domain — the unchanged path, and the one primitive that
+   *     ENFORCES the invariant, so it keeps its only caller.
+   *   - behind > 0   → diverged (or unrelated): `commitsBetween`, which requires
+   *     no ancestry at all (#131). That is what makes a new base anywhere work.
+   *
+   * `commits_between`'s handler defaults `limit` to 200 and simply breaks at the
+   * cap, so the limit is derived from the exact count and the length is verified.
+   * A silently truncated plan would leave commits unreplayed and still move the
+   * branch ref — refuse instead.
+   */
+  const resolveBase = useCallback(
+    async (rev: string, label: string) => {
       if (!current) return;
       const baseName = label.split(" — ")[0];
       try {
-        const range = await commitsSince(current.id, oid);
-        if (range.length === 0) {
-          setPickerNotice(`No commits between HEAD and ${baseName}.`);
+        const stats = await aheadBehind(current.id, rev, "HEAD");
+        if (stats.ahead === 0) {
+          setBaseNotice(`No commits between HEAD and ${baseName}.`);
           return;
         }
-        setRange(range);
-        setPlan(commitsToPlan(range, mergeMode));
+        const next =
+          stats.behind === 0
+            ? await commitsSince(current.id, rev)
+            : await commitsBetween(current.id, rev, "HEAD", stats.ahead + 1);
+        if (next.length !== stats.ahead) {
+          setBaseNotice(
+            `Read ${next.length} of ${stats.ahead} commits between ${baseName} and HEAD — refusing to plan a partial rebase.`,
+          );
+          return;
+        }
+        setRange(next);
+        setPlan(commitsToPlan(next, mergeMode));
+        setBaseRev(rev);
         setBaseLabel(label);
-        setPickerNotice(null);
+        setBaseStats(stats);
+        setBaseNotice(null);
         setPickerOpen(false);
       } catch (e) {
-        setPickerNotice(appErrorMessage(e));
+        setBaseNotice(appErrorMessage(e));
       }
     },
-    [current],
+    [current, mergeMode],
   );
 
   // Seed the plan from a NavIntent when the context menu fires rebase-plan.
   const intent = useNavStore((s) => s.intent);
   const clearIntent = useNavStore((s) => s.clearIntent);
   React.useEffect(() => {
+    // The base-only variant (186): the SCREEN walks the range, because the log is
+    // paged and a branch menu hands over a name rather than commits.
+    if (intent?.kind === "rebase-onto") {
+      void resolveBase(intent.base, intent.label);
+      clearIntent();
+      return;
+    }
     if (intent?.kind !== "rebase-plan") return;
     const byOid = new Map(commits.map((c) => [c.oid, c]));
     const inRange = intent.plan
@@ -284,6 +332,13 @@ export function RebaseScreen() {
     const oldestCommit = oldest ? byOid.get(oldest.oid) : null;
     const baseOid = oldestCommit?.parents[0];
     const baseCommit = baseOid ? byOid.get(baseOid) : null;
+    // Remember the base for THIS plan too, not just for the label: `handleStart`
+    // pins it to the plan's first non-Drop step, which is what keeps a reorder
+    // from moving where the run detaches. Null (a root commit, or an oldest step
+    // outside the loaded log) leaves the engine's parent fallback in charge.
+    setBaseRev(baseOid ?? null);
+    setBaseStats(null);
+    setBaseNotice(null);
     setBaseLabel(
       baseCommit
         ? `${baseCommit.shortOid} — ${baseCommit.summary}`
@@ -292,7 +347,7 @@ export function RebaseScreen() {
           : "selected commit",
     );
     clearIntent();
-  }, [intent, commits, clearIntent, mergeMode]);
+  }, [intent, commits, clearIntent, mergeMode, resolveBase]);
 
   // Flipping the mode rebuilds a whole-range plan in place.
   React.useEffect(() => {
@@ -376,13 +431,19 @@ export function RebaseScreen() {
   });
 
   const handleStart = async () => {
-    const steps: RebaseStep[] = plan.map((r) => ({
-      oid: r.oid,
-      action: r.action,
-      message: r.action === "Reword" || r.action === "Squash" ? (r.message || null) : null,
-      onto: r.onto,
-      mergeParents: r.mergeParents,
-    }));
+    // The base rides on the plan's FIRST non-Drop step, attached HERE rather than
+    // when the rows were built: flatten mode lets the user reorder, and
+    // `rebase_start` reads the base off whatever step ends up first.
+    const steps: RebaseStep[] = withPlanBase(
+      plan.map((r) => ({
+        oid: r.oid,
+        action: r.action,
+        message: r.action === "Reword" || r.action === "Squash" ? (r.message || null) : null,
+        onto: r.onto,
+        mergeParents: r.mergeParents,
+      })),
+      baseRev,
+    );
     const status = await rebaseStart(steps);
     // The rebase consumed the plan — clear it so the completion summary (or
     // the in-progress banner) isn't hidden behind a stale plan builder. On
@@ -390,6 +451,8 @@ export function RebaseScreen() {
     if (status) {
       setPlan([]);
       setBaseLabel(null);
+      setBaseRev(null);
+      setBaseStats(null);
     }
   };
 
@@ -397,6 +460,9 @@ export function RebaseScreen() {
     setPlan([]);
     setRange([]);
     setBaseLabel(null);
+    setBaseRev(null);
+    setBaseStats(null);
+    setBaseNotice(null);
   };
 
   const mergeCount = plan.filter((r) => r.isMerge).length;
@@ -488,7 +554,7 @@ export function RebaseScreen() {
               icon="search"
               onClick={(e) => {
                 setPickerAnchor(e.currentTarget);
-                setPickerNotice(null);
+                setBaseNotice(null);
                 setPickerOpen((v) => !v);
               }}
             >
@@ -510,6 +576,62 @@ export function RebaseScreen() {
               Start rebase
             </PGButton>
           </div>
+
+          {/* What will be replayed. Once the base can be diverged, "everything
+              newer than the base" stops being obvious — so state how many commits
+              go over, what the base adds, and where the two histories met. */}
+          {baseStats && baseLabel && plan.length > 0 && (
+            <div
+              data-testid="rebase-base-summary"
+              style={{
+                padding: "6px 12px",
+                borderBottom: "1px solid var(--border-0)",
+                background: "var(--bg-1)",
+                color: "var(--fg-2)",
+                fontSize: "var(--fs-12)",
+              }}
+            >
+              {baseStats.ahead === 1
+                ? "1 commit will be replayed onto "
+                : `${baseStats.ahead} commits will be replayed onto `}
+              {baseLabel.split(" — ")[0]}.
+              {baseStats.behind > 0 && (
+                <>
+                  {" "}
+                  {baseLabel.split(" — ")[0]} has {baseStats.behind}{" "}
+                  {baseStats.behind === 1 ? "commit" : "commits"} this branch does
+                  not.
+                </>
+              )}
+              {/* The merge base only tells you something once the two sides have
+                  diverged — for an ancestor base it IS the base. */}
+              {baseStats.behind > 0 && baseStats.mergeBase && (
+                <> Merge base {baseStats.mergeBase.slice(0, 7)}.</>
+              )}
+              {baseStats.mergeBase === null && (
+                <> No common ancestor — the whole branch will be replayed.</>
+              )}
+            </div>
+          )}
+
+          {/* A base can also fail to resolve, and the picker is not always open to
+              say so: a context-menu intent has no anchor, so without this the menu
+              item would do nothing at all and explain nothing. One state, two
+              places that cannot both be on screen. */}
+          {baseNotice && !pickerOpen && (
+            <div
+              data-testid="rebase-base-notice"
+              style={{
+                padding: "6px 12px",
+                borderBottom: "1px solid var(--git-conflict)",
+                background: "oklch(from var(--git-conflict) l c h / 0.12)",
+                color: "var(--fg-0)",
+                fontSize: "var(--fs-12)",
+              }}
+            >
+              {baseNotice}
+            </div>
+          )}
 
           {/* What happens to the merges in this range — stated before the run,
               the way SmartGit and TortoiseGit do, rather than left for the user
@@ -734,8 +856,8 @@ export function RebaseScreen() {
         anchor={pickerAnchor}
         open={pickerOpen}
         onClose={() => setPickerOpen(false)}
-        onPick={handlePickBase}
-        notice={pickerNotice}
+        onPick={resolveBase}
+        notice={baseNotice}
       />
     </div>
   );


### PR DESCRIPTION
Implements issue 186: pick a new base **anywhere** — a diverged branch, a commit on
another line of history, a bare hash — and replay this branch's commits onto it with
the pick/squash/reword/drop plan on screen first. `git rebase -i <newbase>`, the half
of interactive rebase TortoiseGit has and this app did not.

Spec: `docs/superpowers/specs/2026-08-19-rebase-onto-any-commit-spec.md`
Plan: `docs/superpowers/plans/2026-08-19-rebase-onto-any-commit-plan.md`

## The engine needed no change

Verified in the tree before designing around it: `rebase_start` takes the run's base
from the first non-Drop step's `onto`, and `rebase_plan::validate` accepts any
existing commit there with **no ancestry requirement**. So a plan whose first
non-Drop step names a commit below the range already *is* `git rebase --onto`.

**One correction to the issue, found by mutation testing:** `onto` reaches the run
through **two** sites, not one — `rebase_start`'s initial detach *and*
`advance_rebase`'s per-step `move_to_base`. Either alone places the first step
(killing each in turn left the new Rust tests green; only killing both replayed the
branch on its own root). Recorded in the test file and in CLAUDE.md, because a future
change to where a run starts has to find both.

## What changed

- **`withPlanBase`** (`features/commits/`, pure + tested) — sets `onto` on the plan's
  first non-Drop step. Applied at **submit**, not when the rows are built, because
  flatten mode lets the user reorder and `rebase_start` reads the base off whatever
  step ends up first. That closes a **pre-existing bug**: with every flatten row's
  `onto` null, dragging a commit to the top made the run detach at *its* parent — the
  middle of its own range. The screen therefore tracks a base for every plan it can
  submit, including one seeded by "Interactive rebase from here".
- **One `resolveBase` path** on the Rebase screen for the picker and for the new
  intent. `aheadBehind(base, HEAD)` runs first and its answer picks the range
  primitive: `commitsSince` when `behind === 0` (an ancestor — the unchanged path),
  `commitsBetween` otherwise. **`commits_since` is deliberately not loosened**; the
  split also keeps it its only caller instead of turning it into dead code.
- **Truncation made impossible.** `commits_between`'s handler defaults `limit` to
  **200** and breaks at the cap, so a long range would come back short — a plan that
  leaves commits unreplayed and still moves the branch ref. The limit is derived from
  `aheadBehind`'s exact `ahead` and the length is verified; a mismatch is refused.
- **A `rebase-onto` NavIntent** carrying a revspec, routed to the Rebase screen. Not
  an extension of `rebase-plan`: the log is paged, so a frontend-assembled range
  would silently come up short for exactly the diverged bases this is for, and a
  branch menu has a name rather than commits.
- **Three entry points** — the History commit menu (`Rebase current branch onto
  this…`, disabled for a commit already on this branch, so it and "Interactive rebase
  from here" are never both enabled), plus the local and remote branch menus
  (`Rebase current onto this — interactive…`). The branch items name the branch's
  **tip oid**, so the plan, its counts and the run all describe one commit even if a
  concurrent fetch moves the ref. No confirm dialog: this rewrites nothing, and
  `Start rebase` is the destructive step.
- **A summary strip** (`rebase-base-summary`) states how many commits will be
  replayed, what the base adds, and the merge base — or that there is no common
  ancestor. Once the base can be diverged, "everything newer than the base" is no
  longer obvious.
- **A notice strip** (`rebase-base-notice`) for when a base fails to resolve.
  `pickerNotice` only ever rendered inside the popover, which a context-menu intent
  never opens — without this the menu item would fail in total silence, one layer
  below what `AppShell.navroutes.test.tsx` exists to prevent.
- **`RebaseBasePicker.invalidOids` deleted.** Nothing ever passed it, and what it
  encoded — "not on the current branch's history" — is now the primary reason to pick
  a base, so a live version would grey out exactly the rows the picker exists to
  offer.

## Tests

- Pure: `withPlanBase.test.ts` (7).
- Component: `Rebase.onto.test.tsx` (7 — the derived limit, the strip's three
  sentences, the unrelated-histories warning, a visible notice for an empty range, a
  refused partial range, the base surviving a reorder, and the ancestor path still
  using `commits_since`) and `context-menu.rebaseOnto.test.tsx` (7).
- Routing: a `rebase-onto` row in `AppShell.navroutes.test.tsx`'s `EXPECTED` table.
- Rust: `tests/rebase_onto_new_base.rs` (3) — the range, the replay onto a genuinely
  diverged base (history, branch ref, `ORIG_HEAD`, both sides' files), and a 7-char
  prefix plus a branch name accepted as the new base.
- E2E: a case in `rebase.e2e.ts` over a new `divergedRepo` fixture.

Every new test was mutation-checked: the implementation was broken, the failure
observed, and the change reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Er25sN6pGoVJzmTBwHU2Tz
