### PR TITLE
feat(diff): open at the first change, and carry F7 into the next file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -565,7 +565,8 @@ design/              In-house design system (NOT components/ui/). Exports via de
 │                        container-relative clamp; see "Resizable panes")
 ├── paneSize.ts          That clamp as PURE arithmetic: paneMaxSize /
 │                        clampPaneSize, PANE_HANDLE_PX, DEFAULT_SIBLING_MIN
-├── ui-helpers.tsx       pgFlash, misc helpers
+├── ui-helpers.tsx       pgFlash (ONE reused toast element — it used to append a
+│                        node per call) + PG_FLASH_MS, misc helpers
 └── use-prevent-browser-context-menu.ts
 
 screens/             One screen per activity-bar item + modal-ish deep views:
@@ -639,7 +640,9 @@ features/            Per-feature: components + Zustand store colocated
 │                    enforcement, DoubleShift, input policy, speed-search
 │                    fallback), useFocusStore (spatial Alt+Arrow + Tab cycling),
 │                    usePaneList (list nav + type-to-jump speed-search),
-│                    useHunkNav (F7/⇧F7 diff hunks), useDiffLineFocus (the
+│                    useHunkNav (F7/⇧F7 diff hunks — and opening a diff AT its
+│                    first change + carrying F7 into the next file, issue 188),
+│                    useDiffLineFocus (the
 │                    diff pane's per-LINE cursor + Space, see below),
 │                    useSpeedSearchStore, PGPane / FocusableScroll / CheatSheet
 ├── merge/           Merge resolver window — separate Tauri window (label
@@ -694,7 +697,9 @@ features/            Per-feature: components + Zustand store colocated
 │                    `gaps` + `text` options for `flattenDiffRows` — one hook so
 │                    four surfaces cannot drift on which setting they read; plus
 │                    useExpandedGaps, the fold separator's expand state, which
-│                    took the retired per-hunk `collapsed` set's place)
+│                    took the retired per-hunk `collapsed` set's place; plus
+│                    `diffOpenReady`, the one answer to "is the row model final
+│                    enough to scroll to the first change?" — issue 188)
 │                    + WhitespaceToggle
 │                    (ignore-whitespace control; also owns
 │                    useHunkActionsDisabledReason — hunk staging is disabled
@@ -784,7 +789,9 @@ lib/
 ├── useWindowedList.ts  Fixed-pitch windowing for the plain lists
 ├── useVariableWindow.ts  Scroll → windowVariable state for the diff surfaces;
 │                    updates state only when the window RANGE changes, so
-│                    scrolling inside the overscan band costs zero re-renders
+│                    scrolling inside the overscan band costs zero re-renders.
+│                    Also `scrollTo`, which a PROGRAMMATIC scroll goes through —
+│                    see the note below on why an assignment is not an event
 ├── useDiffRowHeight.ts  Resolves `--diff-row-h` to px, with a fallback for
 │                    jsdom (which does not evaluate `calc()`); CSS stays the
 │                    source of truth — NaN here would collapse every row to zero
@@ -994,6 +1001,37 @@ module and every `src/features/*/` directory is named somewhere in here.
   `lib/useViewportH.ts` — or `lib/useElementSize.ts` when the answer is a
   container's width, or both axes (#162). Any new measurement obeys the same
   order: read first, observe second.
+- **And "read first" has a second half: the container usually mounts AFTER the
+  hook** (issue 188). Every diff surface renders its scroll container only once
+  the diff has arrived (`isTextualDiff(diff) && …`), so `useViewportH`'s
+  mount-time `measure()` read `ref.current === null`, its effect never ran again
+  (deps unchanged), and there was no element to observe even where
+  `ResizeObserver` exists. The height therefore stayed 0 until the reader
+  scrolled — `remeasure()` in the scroll handler is what quietly rescued it —
+  which meant that on the Linux webview the pane windowed against the 400px
+  fallback on first paint, and every consumer that treats 0 as "unmeasured"
+  (`scrollTopForRow`, `diffOpenReady`) was simply switched off. `useViewportH`
+  now carries a node-attach effect with no dep array: it compares `ref.current`
+  to the node it last saw and measures on a change, plus `useElementSize`'s
+  bounded rAF poll for a read that lands before layout. **A `RefObject`-taking
+  measurement hook cannot know when its element appears; it has to look.** This
+  is why the auto-open needed a Docker e2e run to be believed — it worked on
+  macOS/WKWebView (which has `ResizeObserver`, though even there the observer was
+  never attached) and did nothing at all on WebKitGTK.
+- **A container that goes AWAY reports 0 too, and that is load-bearing.** Every
+  diff surface unmounts its scroll container while `diffLoading`, and the diff and
+  the file text can both land before that flag clears — so there is a render where
+  every other readiness term is satisfied and `scrollRef.current` is `null`. With
+  `useViewportH` keeping its last known height, the issue-188 auto-open fired into
+  a pane that was not on screen: the scroll silently did nothing (there was no
+  element), the once-per-file budget was spent, and the file stayed at line 1. 0 is
+  the honest answer for "not any more" as well as "not yet", and it is the one term
+  that comes BACK when the container does, which is what makes the open happen at
+  the right moment instead of never. Note the failure was invisible to every other
+  consumer — `windowVariable` falls back to 400px and nothing renders anyway — so
+  it took a probe on the real webview to find, printing the readiness terms as a
+  `data-` attribute. (`PGPane` does not spread `...rest`, so such a probe has to go
+  on a plain element.)
 - **Two cursors, two index spaces, and they must not be confused.** `useHunkNav`
   keeps a HUNK cursor (F7/⇧F7, rendered as `data-hunk-active` on the hunk's
   ANCHOR row — its first changed line, marked `hunkAnchor` by `flattenDiffRows`;
@@ -1014,11 +1052,88 @@ module and every `src/features/*/` directory is named somewhere in here.
   `querySelector` + `scrollIntoView` survives only as the fallback for an
   unwindowed caller and its unit test. A line row is unmounted far more often
   than a header row was.
+- **A diff OPENS at its first change, and F7 carries into the next file** (issue
+  188). Both live in `useHunkNav`, not in the four screens that call it — the rule
+  F7 itself records: implemented per screen, two of the four silently went without
+  it for as long as they existed (#157). Five parts, each of which cost something:
+  - **The auto-open waits for `diffOpenReady`** (`features/diff/useDiffGaps.ts`),
+    which is where all four surfaces answer "may I scroll yet?" identically: the
+    row model belongs to the file now SHOWING (`diffFor === showing` — a switch
+    renders once with the outgoing diff still in state, because the fetch is
+    async, and auto-opening there spends the once-per-file budget on a row model
+    about to be replaced; measured on WebKitGTK as "the second file opens at line
+    1 every time"), rows exist, the viewport is MEASURED (0 is unmeasured, never
+    "no space"), and in whole-file mode the file TEXT has landed. The commit
+    panel's identity carries the SIDE as well as the path, because the two sides
+    of one file are two different diffs. Do NOT solve the staleness by keying the
+    hook's `resetKey` to the diff instead: a diff is refetched whenever the status
+    changes, so staging a hunk would then yank the reader back to the first
+    change. That last term is the non-obvious
+    one — until the text arrives `flattenDiffRows` degrades to fold separators, so
+    every anchor row sits near the top and is about to move tens of screens down;
+    scrolling before that puts the reader back at line 1, which is the bug being
+    fixed. A fill-mode diff whose two sides BOTH read as null text never settles
+    and keeps the old no-scroll behaviour: "not loaded yet" and "there is no text"
+    are the same value, and guessing wrong is worse than not moving.
+  - **The cursor starts at 0 only when the auto-open actually ran**, so
+    `data-hunk-active` and the scroll position can never disagree. Everything else
+    keeps -1 — and the backward edge test is `cursor === 0`, not `cursor <= 0`, or
+    a ⇧F7 on a file that never auto-opened would announce the previous file
+    instead of landing on hunk 0 the way it always has.
+  - **The reader wins, and a MISS costs nothing.** Two separate flags, and the
+    distinction is the whole robustness argument. `readerActed` is set by any
+    F7/⇧F7 press and locks the file for the rest of its life, so nothing that
+    settles later can yank someone who has already moved. `opened` is spent only
+    by a reveal that CONFIRMED it landed — every surface's `scrollToHunk` now
+    returns a boolean, checking `el.scrollTop` against what it asked for, because
+    a container mid-refetch clamps the write and a missing one swallows it
+    entirely. A miss therefore leaves the budget alone and the next qualifying
+    render tries again; and `ready` going false RETURNS the budget outright, since
+    a scroll container that unmounts and comes back has lost its position and the
+    first change is the right place to be again. Spending the budget on a miss is
+    exactly how the second file came to open at line 1 with its cursor claiming
+    hunk 0 — visible only on the e2e webview, and only under load, which is why
+    the probe was needed. `scrollToHunk`'s reveal-only guard stays, so a first
+    change already on screen does not jump.
+  - **Crossing files is the `files` prop, and the HOOK owns the arithmetic**:
+    `{ count, index, select }` per surface, and the hook decides legality
+    (`index ± 1` inside the list), so "stop at the ends, never cycle" has one
+    implementation. `select` must move the FILE-LIST selection, not just the diff
+    pane, or the two panes disagree about which file is open. Omitting `files`
+    keeps the old clamp — which is `RepoBrowser`, deliberately: its pane lists
+    every tracked file, not a changed set, so "the next file" would mean a
+    DIFFERENT list from the one on screen (and it can be showing a revision, where
+    the pane is a preview). `CommitPanel` DOES cross the staged/unstaged boundary,
+    because `usePaneList` already treats the two sections as one list in that
+    order, and two orderings for two keyboards is the drift a shared list prevents.
+  - **The hint names its own chord, and the arming expires with it.**
+    `chordFor("diff.nextChange")`, never the literal "F7" — bindings are
+    rebindable and there are two presets. The armed state lives exactly
+    `PG_FLASH_MS`, so an F7 pressed minutes later cannot teleport the reader out
+    of the file. `pgFlash` is SINGLE-INSTANCE for the same feature: it appended a
+    fresh node per call with no dedup, and a "press it again" hint is the one
+    message guaranteed to be raised twice in a row onto one fixed position.
 - **Scroll a diff row into view BY OFFSET** (`scrollTopForRow`), never by
   `querySelector` + `scrollIntoView`: the row is usually unmounted under
   windowing, so the DOM route silently does nothing (the #68 G10 trap). It
   no-ops for an out-of-range index or an unmeasured viewport rather than jumping
   to the top.
+- **A programmatic `scrollTop` write is not a scroll event, and the windowed range
+  does not update by itself** (issue 188). MEASURED on WebKitGTK 605 under xvfb: an
+  `el.scrollTop = 1881` assignment made inside an effect left the DOM scrolled while
+  `win` still described the TOP of the file — `start: 0`, one spacer — for SECONDS,
+  until an unrelated re-render recomputed it. The row being scrolled to is unmounted
+  for that whole time, so F7's `data-hunk-active`, the line cursor's focus ring and
+  the auto-open at the first change each appear to do nothing at all, on the engine
+  CI runs. It looks fine most of the time because the syntax tokens usually land
+  right after and rebuild `heights`, which recomputes the window from the ref during
+  render — but a token-cache hit removes even that, which is exactly what a second
+  file with identical text produced. So every programmatic diff scroll goes through
+  `useVariableWindow`'s `scrollTo`, which assigns AND publishes the new window in one
+  call; a real user scroll still arrives through `onScroll`. Two sites still write
+  `scrollTop` directly and inherit the hazard — `FocusableScroll`'s Home/End and
+  `DiffMinimap`'s scrub — and are named in that hook's own comment as follow-ups
+  rather than drive-bys.
 - **The minimap gutter derives from the ROW MODEL, never the DOM** (#161). Rows are
   windowed, so most of the file is unmounted; the gutter is painted from
   `DiffRow[]` + `heights` alone (`lib/diffMinimap.ts`, pure and tested in node) and

--- a/e2e/specs/diff-nav.e2e.ts
+++ b/e2e/specs/diff-nav.e2e.ts
@@ -1,0 +1,157 @@
+// Diff navigation: a diff opens AT its first change, and F7 carries on into the
+// next file instead of dead-ending (issue 188).
+//
+// Both halves need a real webview, and for the same reason: they depend on a
+// MEASURED viewport. `useHunkNav`'s auto-open is gated on `diffOpenReady`, whose
+// viewport term is 0 in jsdom (no layout) and 0 on WebKitGTK too until the first
+// measurement lands — and WebKitGTK 605 has no ResizeObserver, so the measurement
+// arriving at all is exactly what a component test cannot show. The scroll itself
+// is offset-based over the whole-file row model, so the number this asserts
+// (`scrollTop > 0`) can only be produced by real heights over a real viewport.
+//
+// Chords go through jsChord (window-level keydown — the embedded driver cannot
+// synthesize F7 reliably through the actions endpoint, and the app listens on
+// window either way); everything downstream of AppShell's listener is real app
+// code.
+
+import { browser, $, $$, expect } from "@wdio/globals";
+import { basicRepo, type TempRepo } from "../support/tempRepo";
+import {
+  openRepo,
+  resetApp,
+  jsChord,
+  switchScreen,
+  watchFlashes,
+  flashLog,
+  waitForSelector,
+} from "../support/app";
+
+const filesPane = '[data-pg-pane="diff.files"]';
+const fileRows = `${filesPane} [data-pg-row]`;
+const selectedRow = `${filesPane} [data-pg-row][data-selected]`;
+// FocusableScroll's ariaLabel — the diff pane's own scroll container.
+const diffScroll = '[aria-label="Diff"]';
+const activeHunk = (i: number) => `[data-hunk-index="${i}"][data-hunk-active]`;
+
+const FILES = ["one.txt", "two.txt"] as const;
+const LINES = 260;
+const body = () => Array.from({ length: LINES }, (_, i) => `line ${i + 1}`);
+
+/**
+ * Two files, each with two changes and the FIRST one 100 lines down.
+ *
+ * Deep on purpose: whole-file mode renders every line, so ~100 diff rows (well
+ * over 1500px) sit above the first change while the e2e window is 1200×800 — it
+ * cannot be on screen at rest, so `scrollTop > 0` can only mean something scrolled
+ * to it. Two hunks per file so F7 has somewhere to go inside the file before it
+ * reaches the end of one, and the changes are 100 lines apart so no plausible
+ * context width merges them into one hunk.
+ */
+function deepChangeRepo(): TempRepo {
+  const r = basicRepo();
+  for (const f of FILES) r.commitFile(f, body().join("\n") + "\n", `feat: add ${f}`);
+  for (const f of FILES) {
+    const l = body();
+    l[99] = "line 100 CHANGED";
+    l[199] = "line 200 CHANGED";
+    r.write(f, l.join("\n") + "\n");
+  }
+  return r;
+}
+
+/** The file list's rendered order, which is `get_status`'s, not the fixture's. */
+async function listedFiles(): Promise<string[]> {
+  const rows = await $$(fileRows);
+  const out: string[] = [];
+  for (const row of rows) out.push((await row.getText()).trim());
+  return out;
+}
+
+async function openDiffScreen(repo: TempRepo): Promise<void> {
+  await openRepo(repo.path);
+  // The activity bar rather than a chord: how the screen is reached is incidental
+  // here, and both routes go through AppShell's enterScreen, so focus lands on
+  // the primary pane (diff.files) — one of useHunkNav's paneIds, and F7 is
+  // pane-scoped.
+  await switchScreen("diff");
+  await $(filesPane).waitForDisplayed({
+    timeout: 20_000,
+    timeoutMsg: "Diff screen never appeared",
+  });
+}
+
+describe("diff navigation (issue 188)", () => {
+  let repo: TempRepo;
+
+  afterEach(async () => {
+    repo?.dispose();
+    await resetApp();
+  });
+
+  it("opens a diff scrolled to its first change, with that change marked", async () => {
+    repo = deepChangeRepo();
+    await openDiffScreen(repo);
+
+    await waitForSelector(
+      activeHunk(0),
+      "the diff did not open marked at its first change",
+    );
+    // The mark alone would also be true of a cursor that moved with no scroll, so
+    // assert the pane actually moved. The first change is 100 lines down.
+    const scrollTop = await browser.execute(
+      (sel: string) => document.querySelector(sel)?.scrollTop ?? -1,
+      diffScroll,
+    );
+    expect(scrollTop).toBeGreaterThan(0);
+  });
+
+  it("F7 carries into the next file at its first change, and stops at the last", async () => {
+    repo = deepChangeRepo();
+    await openDiffScreen(repo);
+    await waitForSelector(
+      activeHunk(0),
+      "the diff did not open marked at its first change",
+    );
+    const listed = await listedFiles();
+    expect(listed.length).toBe(2);
+    const [first, second] = listed;
+    await watchFlashes();
+
+    // Inside the file first: the cursor opened on change 1, so one F7 reaches the
+    // last change rather than the second.
+    await jsChord("F7");
+    await waitForSelector(activeHunk(1), "F7 did not advance to the second change");
+
+    // At the last change, F7 announces the crossing WITHOUT performing it. Before
+    // issue 188 this press was a silent no-op that still claimed the chord.
+    await jsChord("F7");
+    expect(await $(selectedRow).getText()).toContain(first);
+    const hint = await flashLog();
+    expect(hint[hint.length - 1]).toContain("again for the next file");
+
+    // The next press opens the next file, moving the FILE LIST selection too.
+    await jsChord("F7");
+    await browser.waitUntil(
+      async () => (await $(selectedRow).getText()).includes(second),
+      {
+        timeout: 10_000,
+        timeoutMsg: `F7 did not carry from ${first} into ${second}`,
+      },
+    );
+    await waitForSelector(
+      activeHunk(0),
+      "the next file did not open at its first change",
+    );
+
+    // ...and the end of the LIST stops, rather than cycling back to the first file.
+    await jsChord("F7");
+    await waitForSelector(
+      activeHunk(1),
+      "F7 did not advance inside the second file",
+    );
+    await jsChord("F7");
+    const last = await flashLog();
+    expect(last[last.length - 1]).toBe("Last file — no more changes");
+    expect(await $(selectedRow).getText()).toContain(second);
+  });
+});

--- a/e2e/specs/keymap.e2e.ts
+++ b/e2e/specs/keymap.e2e.ts
@@ -500,16 +500,18 @@ describe("keymap — rider preset (default)", () => {
     // scrolls it into view; requiring it here would fail for a reason that has
     // nothing to do with the keymap. The F7 sequence below proves both hunks
     // exist, and now also that F7's scroll-into-view works.
-    await $('[data-hunk-index="0"]').waitForDisplayed({
+    //
+    // Hunk 0 arrives ALREADY ACTIVE since issue 188: the screen opens at its
+    // first change, so the cursor starts there rather than at -1 and the first
+    // F7 moves to the SECOND change (Rider's behaviour). That the diff opens
+    // there at all is diff-nav.e2e.ts's subject; this test's subject is that
+    // F7/⇧F7 still walk from wherever the cursor is.
+    await $('[data-hunk-index="0"][data-hunk-active]').waitForDisplayed({
       timeout: 20_000, timeoutMsg: "first hunk never rendered — fixture geometry off?",
     });
     await jsChord("F7");
-    await $('[data-hunk-index="0"][data-hunk-active]').waitForDisplayed({
-      timeout: 10_000, timeoutMsg: "first F7 did not activate hunk 0",
-    });
-    await jsChord("F7");
     await $('[data-hunk-index="1"][data-hunk-active]').waitForDisplayed({
-      timeout: 10_000, timeoutMsg: "second F7 did not advance to hunk 1",
+      timeout: 10_000, timeoutMsg: "F7 did not advance to hunk 1",
     });
     await jsChord("Shift+F7");
     await $('[data-hunk-index="0"][data-hunk-active]').waitForDisplayed({

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -1056,3 +1056,77 @@ export async function diffRowInk(paneId: string): Promise<DiffRowInk> {
     };
   }, paneId)) as DiffRowInk;
 }
+
+/**
+ * Start recording every `pgFlash` toast the page raises, into `window.__pgFlashLog`.
+ *
+ * The toast removes itself after `PG_FLASH_MS` (1.7s) and reuses ONE element, so
+ * reading it in a round trip of its own is a race the moment CI is loaded — and a
+ * missed read is indistinguishable from a toast that never appeared. A recorder
+ * installed BEFORE the action turns that into an exact assertion: the keymap
+ * dispatcher runs synchronously on keydown and `pgFlash` appends synchronously
+ * inside it, so the mutation has landed by the time the dispatching script returns.
+ *
+ * Read-only observer, so no `executeOnce` token is needed for correctness — but it
+ * keeps one anyway, since a retry that re-installed the observer would double
+ * every entry from then on.
+ *
+ * Wiped by any reload; install after `openRepo`.
+ */
+export const watchFlashes = (): Promise<boolean> =>
+  executeOnce(() => {
+    const w = window as unknown as { __pgFlashLog?: string[] };
+    if (w.__pgFlashLog) return true;
+    const log: string[] = (w.__pgFlashLog = []);
+    // Sample on ANY body mutation rather than matching added nodes: the second
+    // flash reuses the element and only replaces its text node, so an
+    // added-node-only observer would see the first toast and nothing after it.
+    const sample = () => {
+      const t = document.querySelector("[data-pg-flash]")?.textContent ?? null;
+      if (t !== null && t !== log[log.length - 1]) log.push(t);
+    };
+    new MutationObserver(sample).observe(document.body, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+    return true;
+  });
+
+/** Toasts recorded since `watchFlashes()`, oldest first. Consecutive identical
+ *  messages collapse to one entry — assert on the LAST, not on the length. */
+export const flashLog = (): Promise<string[]> =>
+  browser.execute(
+    () => (window as unknown as { __pgFlashLog?: string[] }).__pgFlashLog ?? [],
+  );
+
+/**
+ * Wait for a selector to MATCH IN THE PAGE, re-querying it in page on each poll.
+ *
+ * For anything WINDOWING can mount and unmount — a diff row, its
+ * `[data-hunk-active]` marker — this is the wait to use rather than
+ * `waitForDisplayed`. That helper is `waitUntil(() => isDisplayed())` over an
+ * element HANDLE, and `isDisplayed` passes the handle into an in-page script:
+ * a detached node answers "not displayed" honestly instead of raising stale, so
+ * WebdriverIO's error handler never refetches and the wait can poll a dead node
+ * for its whole budget while the row it was looking for is on screen. A selector
+ * re-evaluated in page has nothing to bind to and cannot go stale.
+ *
+ * Read-only, so it stays on bare `browser.execute` (see `executeOnce`).
+ */
+export function waitForSelector(
+  selector: string,
+  timeoutMsg: string,
+  timeout = 20_000,
+): Promise<true | void> {
+  return browser.waitUntil(
+    async () =>
+      Boolean(
+        await browser.execute(
+          (sel: string) => !!document.querySelector(sel),
+          selector,
+        ),
+      ),
+    { timeout, timeoutMsg },
+  );
+}

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -23,6 +23,10 @@ import { WORKDIR } from "@/features/compare/compareSides";
 import { currentBranch } from "@/lib/derive";
 import { openCreateTag } from "@/features/tags/useCreateTagStore";
 import { chordFor } from "@/features/keymap";
+// pgFlash lives in ui-helpers.tsx — a toast is not a context-menu concern, and
+// keeping it out of this module is what lets features/keymap import it without
+// closing a cycle back through this file (which imports chordFor from there).
+import { pgFlash } from "./ui-helpers";
 
 export interface ContextMenuItem {
   label?: ReactNode;
@@ -35,27 +39,6 @@ export interface ContextMenuItem {
   submenu?: ContextMenuItem[];
   /** May be async — the styled confirm/prompt dialogs are promise-based. */
   onClick?: () => void | Promise<void>;
-}
-
-// Tiny toast
-export function pgFlash(msg: string) {
-  const el = document.createElement("div");
-  el.textContent = msg;
-  el.style.cssText = `
-    position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
-    background: var(--bg-3); color: var(--fg-0);
-    border: 1px solid var(--border-1); border-radius: var(--r-3);
-    padding: 6px 12px; font-size: var(--fs-12);
-    font-family: var(--font-mono);
-    box-shadow: var(--shadow-2); z-index: 999999;
-    animation: pg-fade-in 160ms ease-out;
-  `;
-  document.body.appendChild(el);
-  setTimeout(() => {
-    el.style.transition = "opacity 200ms";
-    el.style.opacity = "0";
-  }, 1400);
-  setTimeout(() => el.remove(), 1700);
 }
 
 function ContextMenuItemView({

--- a/src/design/ui-helpers.tsx
+++ b/src/design/ui-helpers.tsx
@@ -33,3 +33,66 @@ export function KV({ k, v }: { k: ReactNode; v: ReactNode }) {
     </div>
   );
 }
+
+/**
+ * Total lifetime of a `pgFlash` toast, in ms — visible, then faded out and gone.
+ *
+ * Exported because a hint that says "press F7 again" is a promise about a window
+ * of time: `useHunkNav` arms its cross-into-the-next-file state for exactly as
+ * long as the toast that announced it is on screen, so a press minutes later
+ * cannot teleport the reader out of the file they are looking at.
+ */
+const FLASH_VISIBLE_MS = 1400;
+const FLASH_FADE_MS = 200;
+export const PG_FLASH_MS = 1700; // visible, then the fade, then a little slack
+
+/**
+ * Tiny bottom toast.
+ *
+ * ONE element, reused. It used to append a fresh node per call with no dedup, so
+ * two calls in quick succession stacked two toasts at the same fixed position,
+ * drawn on top of each other — which is exactly what a "press the chord again"
+ * hint invites. Re-showing replaces the text and restarts both timers instead.
+ */
+let flashEl: HTMLDivElement | null = null;
+let flashTimers: ReturnType<typeof setTimeout>[] = [];
+
+export function pgFlash(msg: string) {
+  for (const t of flashTimers) clearTimeout(t);
+  flashTimers = [];
+  // `isConnected` covers the window a test (or a React root swap) cleared the
+  // body under us: the module-level handle would otherwise point at an orphan.
+  if (!flashEl || !flashEl.isConnected) {
+    flashEl = document.createElement("div");
+    flashEl.setAttribute("data-pg-flash", "");
+    flashEl.style.cssText = `
+      position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
+      background: var(--bg-3); color: var(--fg-0);
+      border: 1px solid var(--border-1); border-radius: var(--r-3);
+      padding: 6px 12px; font-size: var(--fs-12);
+      font-family: var(--font-mono);
+      box-shadow: var(--shadow-2); z-index: 999999;
+      animation: pg-fade-in 160ms ease-out;
+    `;
+    // The entrance animation only plays on insert, so a reused element changes
+    // its text without re-animating. That is the point: a second message on the
+    // same toast should read as an update, not as a new toast.
+    document.body.appendChild(flashEl);
+  }
+  const el = flashEl;
+  el.textContent = msg;
+  el.style.transition = "";
+  el.style.opacity = "1";
+  flashTimers.push(
+    setTimeout(() => {
+      el.style.transition = `opacity ${FLASH_FADE_MS}ms`;
+      el.style.opacity = "0";
+    }, FLASH_VISIBLE_MS),
+  );
+  flashTimers.push(
+    setTimeout(() => {
+      el.remove();
+      if (flashEl === el) flashEl = null;
+    }, PG_FLASH_MS),
+  );
+}

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -12,7 +12,7 @@ import { MinimapGutter } from "./DiffMinimap";
 import { PGPane, FocusableScroll, usePaneList, useHunkNav } from "@/features/keymap";
 import { fileIconSpec } from "@/lib/fileIcon";
 import { WhitespaceToggle } from "./WhitespaceToggle";
-import { useDiffGaps, useExpandedGaps } from "./useDiffGaps";
+import { diffOpenReady, useDiffGaps, useExpandedGaps } from "./useDiffGaps";
 import { SignatureBadge } from "@/features/signing/SignatureBadge";
 import { useDiffSyntax, usePrefetchSyntax, type SideSource } from "@/lib/syntax";
 import {
@@ -207,7 +207,11 @@ export function CommitDiffPanel({
   // This is the panel that most often falls UNDER the threshold — History's
   // beside layout is ~480px — and it does so by width, not by being this panel.
   const diffBox = useElementSize();
-  const { win, onScroll: onDiffScroll } = useVariableWindow({
+  const {
+    win,
+    onScroll: onDiffScroll,
+    scrollTo: scrollDiffTo,
+  } = useVariableWindow({
     heights,
     viewportH,
     scrollRef,
@@ -217,22 +221,49 @@ export function CommitDiffPanel({
   // and scrolling goes BY OFFSET, because that row is usually unmounted (#157).
   const anchorRows = React.useMemo(() => hunkAnchorRows(rows), [rows]);
   const scrollToHunk = React.useCallback(
-    (hunkIndex: number) => {
+    (hunkIndex: number): boolean => {
       const el = scrollRef.current;
       const rowIndex = anchorRows[hunkIndex];
-      if (!el || rowIndex == null || rowIndex < 0) return;
-      el.scrollTop = scrollTopForRow(heights, rowIndex, {
+      if (!el || rowIndex == null || rowIndex < 0) return false;
+      // Through the window's own setter — see `useVariableWindow.scrollTo`.
+      const want = scrollTopForRow(heights, rowIndex, {
         scrollTop: el.scrollTop,
         viewportH: el.clientHeight,
       });
+      scrollDiffTo(want);
+      // Confirm the write: a container shorter than the offset CLAMPS it (a pane
+      // mid-refetch is), and a reveal that did not land must not count as this
+      // file having been opened — see `useHunkNav`'s `scrollToHunk`.
+      return Math.abs(el.scrollTop - want) <= 1;
     },
-    [anchorRows, heights],
+    [anchorRows, heights, scrollDiffTo],
   );
   const hunkCursor = useHunkNav({
     paneIds: [filesPaneId, viewPaneId],
     count: current?.hunks.length ?? 0,
     resetKey: selected,
     scrollToHunk,
+    ready: diffOpenReady({
+      // `current` falls back to `diffs[0]` while `selected` is still the previous
+      // commit's file, so these disagree for exactly the renders where the row
+      // model is not the selection's yet.
+      diffFor: current?.path,
+      showing: selected,
+      rowCount: rows.length,
+      viewportH,
+      gaps,
+      text: diffText,
+    }),
+    // This panel's list is the commit's own changed files, and it owns the
+    // selection, so moving it moves both panes (issue 188).
+    files: {
+      count: diffs.length,
+      index: diffs.findIndex((d) => d.path === current?.path),
+      select: (i) => {
+        const d = diffs[i];
+        if (d) setSelected(d.path);
+      },
+    },
   });
 
   // Per mount site: History's bottom panel is wide and short, the full-screen

--- a/src/features/diff/useDiffGaps.test.ts
+++ b/src/features/diff/useDiffGaps.test.ts
@@ -1,0 +1,66 @@
+// diffOpenReady — the one gate the four diff surfaces answer "may I scroll to the
+// first change yet?" with (issue 188). Pure, so it is tested directly rather than
+// through a screen: each of the three conditions it enforces is a bug that shipped
+// somewhere else in this codebase first.
+
+import { describe, it, expect } from "vitest";
+import { diffOpenReady } from "./useDiffGaps";
+
+const text = (o?: { newText?: string | null; oldText?: string | null }) => ({
+  newText: o?.newText ?? null,
+  oldText: o?.oldText ?? null,
+});
+
+/** The fresh, measured, chunked base case — each test perturbs one term. */
+const ready = (o: Partial<Parameters<typeof diffOpenReady>[0]>) =>
+  diffOpenReady({
+    diffFor: "a.ts",
+    showing: "a.ts",
+    rowCount: 12,
+    viewportH: 600,
+    gaps: "fold",
+    text: text(),
+    ...o,
+  });
+
+describe("diffOpenReady", () => {
+  it("is ready in chunked mode as soon as rows and a measured viewport are in", () => {
+    expect(ready({})).toBe(true);
+  });
+
+  it("is not ready with no rows — an identical, binary or LFS diff must not scroll", () => {
+    expect(ready({ rowCount: 0 })).toBe(false);
+  });
+
+  // The one only a real webview found: a file switch renders once with the
+  // OUTGOING diff still in state, and auto-opening there spends the once-per-file
+  // budget on a row model that is about to be replaced.
+  it("is not ready while the row model still belongs to the file being left", () => {
+    expect(ready({ diffFor: "a.ts", showing: "b.ts" })).toBe(false);
+    // Nothing fetched yet is not "fresh" either, however the surface spells it.
+    expect(ready({ diffFor: null, showing: null })).toBe(false);
+    expect(ready({ diffFor: undefined, showing: undefined })).toBe(false);
+  });
+
+  it("treats an UNMEASURED viewport (0) as not ready, never as no space", () => {
+    // The trap: `scrollTopForRow` no-ops on viewportH <= 0, so scrolling here
+    // would silently do nothing while the cursor claimed to have moved — and
+    // WebKitGTK 605 has no ResizeObserver, so 0 is the normal first reading.
+    expect(ready({ viewportH: 0 })).toBe(false);
+    expect(ready({ viewportH: -1 })).toBe(false);
+  });
+
+  it("waits for the file text in whole-file mode, on either side", () => {
+    // Fill mode with no text degrades to fold separators, so every anchor row is
+    // near the top and about to move far down once the text lands.
+    expect(ready({ gaps: "fill" })).toBe(false);
+    expect(ready({ gaps: "fill", text: text({ newText: "a\nb\n" }) })).toBe(true);
+    // A DELETED file has only the old side, which is the side flattenDiffRows
+    // falls back to — so it settles too.
+    expect(ready({ gaps: "fill", text: text({ oldText: "a\nb\n" }) })).toBe(true);
+  });
+
+  it("counts empty text as text — a file can honestly be empty", () => {
+    expect(ready({ gaps: "fill", text: text({ newText: "" }) })).toBe(true);
+  });
+});

--- a/src/features/diff/useDiffGaps.ts
+++ b/src/features/diff/useDiffGaps.ts
@@ -70,3 +70,64 @@ export function useExpandedGaps(resetKey: unknown): {
   }, []);
   return { expanded, expand };
 }
+
+/**
+ * May a diff surface auto-scroll to its first change yet? (issue 188)
+ *
+ * One answer for the four surfaces, next to the hook that already keeps them from
+ * drifting on which gap mode they read — the same inputs decide both.
+ *
+ * Four conditions, each of which cost something to learn:
+ *
+ * - **Rows.** Nothing to scroll to in an empty row model: an identical file, a
+ *   binary one, an LFS pointer. Those must not scroll at all.
+ * - **A MEASURED viewport.** 0 means UNMEASURED, never "no space" — WebKitGTK 605
+ *   has no ResizeObserver, and `scrollTopForRow` deliberately no-ops on a
+ *   viewport of 0 rather than jumping to the top. Read first, observe second.
+ * - **A settled row model.** Whole-file mode ("fill") renders fold separators
+ *   until the file text arrives and then fills every gap in, which moves every
+ *   anchor row far down the list. Scrolling to the first change before that lands
+ *   on a row that is about to move, i.e. back at the top of the file — the exact
+ *   bug this is meant to fix. Chunked mode ("fold") never waits: its geometry
+ *   does not depend on the text.
+ *
+ * Consequence worth knowing: a fill-mode diff whose two sides BOTH read as null
+ * text never settles, so it keeps today's behaviour (no auto-open) rather than
+ * risking a scroll to a row that may still move. "Not loaded yet" and "there is
+ * no text" are the same value here, and guessing wrong is worse than not moving.
+ *
+ * The FOURTH condition, `diffFor === showing`, is the one that only a real webview
+ * found. A file switch renders once with the OUTGOING diff still in state — the
+ * fetch is async, so `rows`, `count` and (for one commit) even the file text all
+ * still describe the file being left — while `resetKey` has already changed. The
+ * auto-open would fire there, spend its once-per-file budget on the wrong row
+ * model, and then decline to run again when the real one arrived, leaving the pane
+ * scrolled to an offset that means nothing in it. MEASURED on WebKitGTK: the
+ * second file opened at line 1 every time. Note this must NOT be solved by keying
+ * the hook's `resetKey` to the diff instead — a diff is refetched whenever the
+ * status changes, so staging a hunk would then yank the reader back to the first
+ * change.
+ */
+export function diffOpenReady(o: {
+  /**
+   * Identity of the file the ROW MODEL was built from — `FileDiff.path`, plus
+   * whatever else the surface keys its fetch on (the commit panel also has a
+   * SIDE, and the two sides of one file are two different diffs).
+   */
+  diffFor: string | null | undefined;
+  /** Identity of the file the surface is showing — the hook's own `resetKey`. */
+  showing: string | null | undefined;
+  /** Length of the flattened `DiffRow[]`. */
+  rowCount: number;
+  /** Measured height of the scroll container. 0 = unmeasured. */
+  viewportH: number;
+  gaps: "fill" | "fold";
+  text: { newText: string | null; oldText: string | null };
+}): boolean {
+  if (!o.diffFor || o.diffFor !== o.showing) return false;
+  if (o.rowCount === 0 || o.viewportH <= 0) return false;
+  if (o.gaps === "fold") return true;
+  // Same side preference `flattenDiffRows` uses: the new side, or the old one for
+  // a deleted file.
+  return o.text.newText !== null || o.text.oldText !== null;
+}

--- a/src/features/keymap/useHunkNav.test.tsx
+++ b/src/features/keymap/useHunkNav.test.tsx
@@ -1,28 +1,87 @@
 // useHunkNav — F7/⇧F7 hunk cursor for diff panes: advances/retreats with
 // clamping, scrolls the active hunk into view, resets when the viewed file
-// changes, and answers only while one of its panes holds focus.
+// changes, and answers only while one of its panes holds focus. Plus the issue
+// 188 behaviours: opening a file AT its first change, and carrying F7 into the
+// next file once the current one is exhausted.
 
+import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, render } from "@testing-library/react";
 import { useHunkNav } from "./useHunkNav";
 import { useKeymapStore } from "./useKeymapStore";
 import { useFocusStore } from "./useFocusStore";
+import { PG_FLASH_MS } from "@/design/ui-helpers";
 
 function Harness({
   count,
   resetKey,
   onCursor,
   paneIds = ["d.files", "d.view"],
+  ready,
+  scrollToHunk,
 }: {
   count: number;
   resetKey: string;
   onCursor: (c: number) => void;
   paneIds?: string[];
+  ready?: boolean;
+  scrollToHunk?: (i: number) => void;
 }) {
-  const cursor = useHunkNav({ paneIds, count, resetKey });
+  const cursor = useHunkNav({ paneIds, count, resetKey, ready, scrollToHunk });
   onCursor(cursor);
   return null;
 }
+
+/**
+ * A surface with a FILE LIST, so F7 can carry out of the current file.
+ *
+ * Stateful on purpose: the crossing is only real if selecting the next file
+ * actually changes what the hook is looking at, which is what makes the landing
+ * edge (first change forward, LAST change backward) observable.
+ */
+function FileHarness({
+  hunksPerFile,
+  ready = true,
+  onCursor,
+  onSelect,
+  scrollToHunk,
+  startIndex = 0,
+}: {
+  hunksPerFile: number[];
+  ready?: boolean;
+  onCursor: (c: number) => void;
+  onSelect?: (i: number) => void;
+  scrollToHunk?: (i: number) => void;
+  startIndex?: number;
+}) {
+  const [index, setIndex] = React.useState(startIndex);
+  const cursor = useHunkNav({
+    paneIds: ["d.view"],
+    count: hunksPerFile[index] ?? 0,
+    resetKey: `file:${index}`,
+    ready,
+    // Defaulted, and never omitted: a caller with no `scrollToHunk` falls back to
+    // a DOM query, which reports FALSE when the row is not mounted — and this
+    // harness renders no rows, so the auto-open would never land. A surface that
+    // scrolls and reports nothing is the shape being modelled here.
+    scrollToHunk: scrollToHunk ?? (() => {}),
+    files: {
+      count: hunksPerFile.length,
+      index,
+      select: (i) => {
+        onSelect?.(i);
+        setIndex(i);
+      },
+    },
+  });
+  onCursor(cursor);
+  return <div data-testid="file-index">{index}</div>;
+}
+
+/** The one toast element, if one is up. `null` means nothing was flashed. */
+const flashText = (): string | null =>
+  document.querySelector("[data-pg-flash]")?.textContent ?? null;
+const flashCount = () => document.querySelectorAll("[data-pg-flash]").length;
 
 const key = (k: string, shift = false) =>
   ({
@@ -183,6 +242,307 @@ describe("useHunkNav", () => {
     expect(cursor).toBe(1);
     rerender(<Harness count={3} resetKey="b" onCursor={onCursor} />);
     expect(cursor).toBe(-1);
+  });
+
+  // ── Opening a diff AT its first change (issue 188, part 1) ──────────────
+
+  it("opens at the first change and marks it, once the caller says it is ready", () => {
+    const scrollToHunk = vi.fn();
+    render(
+      <Harness
+        count={3}
+        resetKey="a"
+        onCursor={onCursor}
+        ready
+        scrollToHunk={scrollToHunk}
+      />,
+    );
+    expect(scrollToHunk).toHaveBeenCalledWith(0);
+    // The cursor and the scroll position must agree: 0, not -1.
+    expect(cursor).toBe(0);
+    // ...so F7 now moves to the SECOND change, Rider-style.
+    useFocusStore.setState({ focused: "d.view" });
+    press("F7");
+    expect(cursor).toBe(1);
+  });
+
+  it("does NOT auto-open while the surface is not ready (an unmeasured viewport)", () => {
+    const scrollToHunk = vi.fn();
+    const { rerender } = render(
+      <Harness
+        count={3}
+        resetKey="a"
+        onCursor={onCursor}
+        ready={false}
+        scrollToHunk={scrollToHunk}
+      />,
+    );
+    expect(scrollToHunk).not.toHaveBeenCalled();
+    expect(cursor).toBe(-1);
+    // ...and the first F7 still lands on the first change, as it always did.
+    useFocusStore.setState({ focused: "d.view" });
+    press("F7");
+    expect(cursor).toBe(0);
+    // Measurement arriving later must not re-open a file the reader has moved in.
+    rerender(
+      <Harness
+        count={3}
+        resetKey="a"
+        onCursor={onCursor}
+        ready
+        scrollToHunk={scrollToHunk}
+      />,
+    );
+    expect(scrollToHunk).toHaveBeenCalledTimes(1); // the F7, not an auto-open
+  });
+
+  it("auto-opens once per file, not once per row-model change", () => {
+    const first = vi.fn();
+    const { rerender } = render(
+      <Harness count={3} resetKey="a" onCursor={onCursor} ready scrollToHunk={first} />,
+    );
+    expect(first).toHaveBeenCalledTimes(1);
+    // A fresh callback identity is what a settled row model looks like from here
+    // (heights changed) — it must not yank the reader back to the first change.
+    const second = vi.fn();
+    rerender(
+      <Harness count={3} resetKey="a" onCursor={onCursor} ready scrollToHunk={second} />,
+    );
+    expect(second).not.toHaveBeenCalled();
+    expect(cursor).toBe(0);
+    // A different FILE does auto-open again.
+    const third = vi.fn();
+    rerender(
+      <Harness count={2} resetKey="b" onCursor={onCursor} ready scrollToHunk={third} />,
+    );
+    expect(third).toHaveBeenCalledWith(0);
+  });
+
+  it("does not spend the open on a reveal that could not land", () => {
+    // A pane that cannot be addressed yet — no scroll container, a row that is not
+    // mounted — must leave the budget alone, or the cursor claims a position the
+    // pane never took. This is how the file opened at line 1 with `cur: 0` on the
+    // e2e webview.
+    let landed = false;
+    const scrollToHunk = vi.fn(() => landed);
+    const { rerender } = render(
+      <Harness count={3} resetKey="a" onCursor={onCursor} ready scrollToHunk={scrollToHunk} />,
+    );
+    expect(scrollToHunk).toHaveBeenCalledWith(0);
+    expect(cursor).toBe(-1); // it did NOT land, so nothing is claimed
+
+    landed = true;
+    // Any later qualifying render tries again — here a fresh callback identity,
+    // which is what a settled row model looks like from the hook's side.
+    rerender(
+      <Harness
+        count={3}
+        resetKey="a"
+        onCursor={onCursor}
+        ready
+        scrollToHunk={vi.fn(() => true)}
+      />,
+    );
+    expect(cursor).toBe(0);
+  });
+
+  it("re-opens after the pane goes away and comes back", () => {
+    // A diff surface unmounts its scroll container to refetch, and a container that
+    // returns has lost its scroll position — so the first change is the right place
+    // to be again, and re-opening there is not a yank.
+    const scrollToHunk = vi.fn(() => true);
+    const props = (ready: boolean) => (
+      <Harness
+        count={3}
+        resetKey="a"
+        onCursor={onCursor}
+        ready={ready}
+        scrollToHunk={scrollToHunk}
+      />
+    );
+    const { rerender } = render(props(true));
+    expect(scrollToHunk).toHaveBeenCalledTimes(1);
+    rerender(props(false)); // pane unmounts (its measurement reads 0)
+    rerender(props(true)); // ...and is back
+    expect(scrollToHunk).toHaveBeenCalledTimes(2);
+    expect(cursor).toBe(0);
+  });
+
+  it("but a reader who has moved the cursor keeps it across that round trip", () => {
+    const scrollToHunk = vi.fn(() => true);
+    const props = (ready: boolean) => (
+      <Harness
+        count={3}
+        resetKey="a"
+        onCursor={onCursor}
+        ready={ready}
+        scrollToHunk={scrollToHunk}
+      />
+    );
+    const { rerender } = render(props(true));
+    useFocusStore.setState({ focused: "d.view" });
+    press("F7");
+    expect(cursor).toBe(1);
+    scrollToHunk.mockClear();
+    rerender(props(false));
+    rerender(props(true));
+    expect(scrollToHunk).not.toHaveBeenCalled();
+    expect(cursor).toBe(1);
+  });
+
+  it("does not scroll a file with no hunks at all (binary, LFS, identical)", () => {
+    const scrollToHunk = vi.fn();
+    render(
+      <Harness count={0} resetKey="a" onCursor={onCursor} ready scrollToHunk={scrollToHunk} />,
+    );
+    expect(scrollToHunk).not.toHaveBeenCalled();
+    expect(cursor).toBe(-1);
+  });
+
+  // ── F7 carries into the next file (issue 188, part 2) ────────────────────
+
+  it("flashes a chord-named hint on the last hunk WITHOUT moving files", () => {
+    const select = vi.fn();
+    render(
+      <FileHarness hunksPerFile={[2, 2]} onCursor={onCursor} onSelect={select} />,
+    );
+    useFocusStore.setState({ focused: "d.view" });
+    press("F7"); // auto-opened at 0 → 1, the last hunk
+    expect(cursor).toBe(1);
+    expect(flashText()).toBeNull();
+
+    expect(press("F7")).toBe(true);
+    // The bug this replaces returned `true` and did NOTHING — so the assertions
+    // that matter are that a hint appeared and that the file did NOT change.
+    expect(flashText()).toBe("No more changes — press F7 again for the next file");
+    expect(select).not.toHaveBeenCalled();
+    expect(cursor).toBe(1);
+  });
+
+  it("the next press opens the next file AT ITS FIRST change", () => {
+    const select = vi.fn();
+    const scrollToHunk = vi.fn();
+    const { getByTestId } = render(
+      <FileHarness
+        hunksPerFile={[2, 3]}
+        onCursor={onCursor}
+        onSelect={select}
+        scrollToHunk={scrollToHunk}
+      />,
+    );
+    useFocusStore.setState({ focused: "d.view" });
+    press("F7"); // → hunk 1 (last)
+    press("F7"); // arms + flashes
+    scrollToHunk.mockClear();
+    press("F7"); // crosses
+    expect(select).toHaveBeenCalledWith(1);
+    expect(getByTestId("file-index").textContent).toBe("1");
+    expect(cursor).toBe(0);
+    expect(scrollToHunk).toHaveBeenCalledWith(0);
+  });
+
+  it("forgets the arming once the hint has expired", () => {
+    vi.useFakeTimers();
+    try {
+      const select = vi.fn();
+      render(
+        <FileHarness hunksPerFile={[2, 2]} onCursor={onCursor} onSelect={select} />,
+      );
+      useFocusStore.setState({ focused: "d.view" });
+      press("F7"); // → last hunk
+      press("F7"); // arms
+      act(() => {
+        vi.advanceTimersByTime(PG_FLASH_MS + 1);
+      });
+      press("F7"); // too late — re-arms rather than teleporting out of the file
+      expect(select).not.toHaveBeenCalled();
+      expect(flashText()).toBe(
+        "No more changes — press F7 again for the next file",
+      );
+      // ...and the press after THAT one crosses, since it is inside the window.
+      press("F7");
+      expect(select).toHaveBeenCalledWith(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("⇧F7 crosses backwards and lands on the previous file's LAST change", () => {
+    const select = vi.fn();
+    const scrollToHunk = vi.fn();
+    render(
+      <FileHarness
+        hunksPerFile={[4, 2]}
+        startIndex={1}
+        onCursor={onCursor}
+        onSelect={select}
+        scrollToHunk={scrollToHunk}
+      />,
+    );
+    useFocusStore.setState({ focused: "d.view" });
+    expect(cursor).toBe(0); // auto-opened at the first change
+    expect(press("F7", true)).toBe(true);
+    // "Shift+F7", not a hardcoded "⇧F7" or "F7": the label is formatted from the
+    // live binding, and this test environment is not a Mac.
+    expect(flashText()).toBe(
+      "No more changes — press Shift+F7 again for the previous file",
+    );
+    expect(select).not.toHaveBeenCalled();
+    scrollToHunk.mockClear();
+    press("F7", true);
+    expect(select).toHaveBeenCalledWith(0);
+    // The previous file has 4 hunks and we arrived from below, so we land on the
+    // LAST one — not on hunk 0, which is where the auto-open would put us.
+    expect(cursor).toBe(3);
+    expect(scrollToHunk).toHaveBeenCalledWith(3);
+  });
+
+  it("stops at each end of the list instead of cycling", () => {
+    const select = vi.fn();
+    render(
+      <FileHarness hunksPerFile={[2]} onCursor={onCursor} onSelect={select} />,
+    );
+    useFocusStore.setState({ focused: "d.view" });
+    press("F7"); // → last hunk of the only file
+    expect(press("F7")).toBe(true);
+    // One press says the list has ended — the reader is not made to ask twice
+    // just to learn there is nothing there.
+    expect(flashText()).toBe("Last file — no more changes");
+    press("F7");
+    expect(select).not.toHaveBeenCalled();
+
+    press("F7", true); // back to hunk 0
+    press("F7", true);
+    expect(flashText()).toBe("First file — no earlier changes");
+    press("F7", true);
+    expect(select).not.toHaveBeenCalled();
+  });
+
+  it("keeps the old clamp, and says nothing, when the caller supplies no file list", () => {
+    render(
+      <Harness
+        count={2}
+        resetKey="a"
+        onCursor={onCursor}
+        ready
+        scrollToHunk={() => {}}
+      />,
+    );
+    useFocusStore.setState({ focused: "d.view" });
+    press("F7");
+    expect(cursor).toBe(1);
+    expect(press("F7")).toBe(true);
+    expect(cursor).toBe(1);
+    expect(flashText()).toBeNull();
+  });
+
+  it("reuses ONE toast element however many times it is flashed", () => {
+    render(<FileHarness hunksPerFile={[1]} onCursor={onCursor} />);
+    useFocusStore.setState({ focused: "d.view" });
+    press("F7");
+    press("F7");
+    press("F7");
+    expect(flashCount()).toBe(1);
   });
 
   it("registers one handler per action, not one per pane", () => {

--- a/src/features/keymap/useHunkNav.ts
+++ b/src/features/keymap/useHunkNav.ts
@@ -1,18 +1,64 @@
 // useHunkNav — F7/⇧F7 diff-change navigation (Rider NextDiff/PreviousDiff).
 // Keeps a hunk cursor for a diff screen, scoped to every pane the screen owns
 // (file list AND diff view), so the chord works wherever focus sits.
-// Cursor starts at -1: the first F7 lands on the FIRST hunk. The screen
-// renders the cursor as `data-hunk-active` on its `[data-hunk-index]` wrapper —
-// since #157 that is the hunk's first CHANGED row, which is what "next change"
-// actually means.
+//
+// The screen renders the cursor as `data-hunk-active` on its `[data-hunk-index]`
+// wrapper — since #157 that is the hunk's first CHANGED row, which is what "next
+// change" actually means.
+//
+// Three behaviours live here rather than in the four screens that call it
+// (`DiffViewer`, `CommitPanel`, `CommitDiffPanel`, `RepoBrowser`) — implementing
+// any of them per screen is how F7 came to be missing from two of them for as
+// long as both existed (issue 188, #157):
+//
+//  1. AUTO-OPEN. Whole file is the default view, so a diff otherwise opens on
+//     line 1 of unchanged context. Once the caller says the row model is final
+//     (`ready`), the first change is revealed and the cursor is set to it, so the
+//     highlight and the scroll position can never disagree. `ready` must include a
+//     MEASURED viewport: an unmeasured one reads 0 and must not count (read first,
+//     observe second — WebKitGTK 605 has no ResizeObserver).
+//  2. CARRY INTO THE NEXT FILE. On the last hunk, F7 flashes a hint naming its own
+//     chord; a second press within the hint's lifetime opens the next file at its
+//     FIRST change. ⇧F7 mirrors it — previous file, landing on its LAST change.
+//     The armed state expires with the hint, so a press minutes later cannot
+//     teleport the reader out of the file they are looking at. A caller that
+//     supplies no `files` keeps the old clamp.
+//  3. STOP AT THE ENDS. The last file's last hunk flashes and stays put; there is
+//     no wrap-around. Silently re-showing a file already reviewed is worse.
 //
 // Scrolling goes through the caller's `scrollToHunk` when it supplies one, and it
 // must: under windowing the anchor row is usually unmounted, so the DOM route
-// below silently does nothing (the #68 G10 trap). That fallback survives only for
-// an unwindowed caller and this hook's own unit test.
+// below silently does nothing (the #68 G10 trap). That fallback survives for an
+// unwindowed caller (the Diff screen's Wrap mode, where `heights` no longer
+// describes the rendered rows) and this hook's own unit test.
 
 import React from "react";
 import { useAction } from "./useAction";
+import { chordFor } from "./chordFor";
+import { pgFlash, PG_FLASH_MS } from "@/design/ui-helpers";
+
+/**
+ * The caller's own file list, and the only thing that makes F7 cross files.
+ *
+ * The hook decides whether a crossing is legal (`index ± 1` inside the list) so
+ * the "stop at the ends, never cycle" rule has one implementation instead of
+ * four. `index < 0` means the shown file is not in the list, which is the same
+ * answer as having no list: today's clamp.
+ */
+export interface HunkNavFiles {
+  /** How many files the surface's list holds. */
+  count: number;
+  /** Index of the file currently shown, or -1 when it is not in the list. */
+  index: number;
+  /**
+   * Show the file at `index`. MUST move the file-list selection, not just the
+   * diff pane — otherwise the two panes disagree about which file is open.
+   */
+  select: (index: number) => void;
+}
+
+/** Which end of the next file's hunks to land on. */
+type Landing = "first" | "last";
 
 export function useHunkNav(opts: {
   /** Panes this diff screen owns — the handler answers from any of them. */
@@ -24,37 +70,168 @@ export function useHunkNav(opts: {
   /**
    * Scroll a hunk into view BY OFFSET — build it from `hunkAnchorRows` +
    * `scrollTopForRow`. Windowed panes MUST supply this.
+   *
+   * Return `false` when the hunk could not be addressed — no scroll container, no
+   * anchor row, or a write the container was too short to accept. The auto-open
+   * reads that: a reveal that did not land must not be counted as this file having
+   * been opened, or the pane keeps the cursor's promise without keeping its
+   * position. Returning nothing means "assume it landed" — for a caller that has
+   * no way to check. The DOM fallback below reports whether it found the row.
    */
-  scrollToHunk?: (hunkIndex: number) => void;
+  scrollToHunk?: (hunkIndex: number) => boolean | void;
+  /**
+   * Rows, heights and a MEASURED viewport are all in, and the row model for this
+   * file is final — see `diffOpenReady`, which is where the four surfaces answer
+   * it identically. Only then is the auto-open safe: whole-file mode renders fold
+   * separators until the file text lands and fills them in, and scrolling to the
+   * first change before that lands on a row that is about to move.
+   *
+   * "Measured" also means the scroll container is THERE — the surfaces unmount it
+   * while the next diff is in flight, and a reveal into a pane that does not exist
+   * is a silent no-op that still spends this open. `useViewportH` answers 0 in
+   * that window, which is what `diffOpenReady` reads.
+   */
+  ready?: boolean;
+  /** Supply to let F7 carry into the next file. Omit to keep the old clamp. */
+  files?: HunkNavFiles;
 }): number {
-  const { paneIds, count, resetKey, scrollToHunk } = opts;
+  const { paneIds, count, resetKey, scrollToHunk, ready = false, files } = opts;
   const [cursor, setCursor] = React.useState(-1);
+
+  // Read by the key handlers, which run long after any render, so a ref keeps a
+  // freshly-built `files` object from re-registering the actions every render.
+  const filesRef = React.useRef(files);
+  React.useEffect(() => {
+    filesRef.current = files;
+  });
+
+  // Which end of the NEXT file to land on, and the request that sets it. Two refs
+  // because a crossing sets its intent BEFORE the file changes: `pending` is
+  // handed to `landing` by the very reset the crossing causes, so a file with no
+  // hunks at all consumes it rather than passing it on to the file after that.
+  const landing = React.useRef<Landing>("first");
+  const pending = React.useRef<Landing | null>(null);
+  /** Armed to cross, and when — the arming expires with the hint that announced it. */
+  const armed = React.useRef<{ dir: 1 | -1; at: number } | null>(null);
+  /** The auto-open has LANDED for this file, while the pane has stayed ready. */
+  const opened = React.useRef(false);
+  /** The reader has moved the cursor in this file — from here on it is theirs. */
+  const readerActed = React.useRef(false);
 
   React.useEffect(() => {
     setCursor(-1);
+    armed.current = null;
+    opened.current = false;
+    readerActed.current = false;
+    landing.current = pending.current ?? "first";
+    pending.current = null;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resetKey]);
 
-  const go = (delta: 1 | -1) => (): boolean => {
-    if (count === 0) return false;
-    const next = Math.max(0, Math.min(count - 1, cursor + delta));
-    setCursor(next);
-    if (scrollToHunk) {
-      scrollToHunk(next);
-      return true;
-    }
+  /** Did the hunk actually get addressed? See `scrollToHunk`. */
+  const reveal = (hunkIndex: number): boolean => {
+    if (scrollToHunk) return scrollToHunk(hunkIndex) !== false;
     // Fallback for an unwindowed pane. Scroll the FIRST pane that actually
     // renders the target hunk: the file list has no `[data-hunk-index]` children
     // at all, and a screen with two diff panes wants the leading one.
     for (const paneId of paneIds) {
       const el = document.querySelector<HTMLElement>(
-        `[data-pg-pane="${paneId}"] [data-hunk-index="${next}"]`,
+        `[data-pg-pane="${paneId}"] [data-hunk-index="${hunkIndex}"]`,
       );
       if (el) {
         el.scrollIntoView?.({ block: "start" });
-        break;
+        return true;
       }
     }
+    return false;
+  };
+
+  // Open the file AT its first change (or its last, when ⇧F7 arrived here from
+  // the file below).
+  //
+  // Two guards decide when this may run, and they are NOT the same guard:
+  //
+  // - `opened` is spent only by a reveal that LANDED, so a render where the pane
+  //   cannot be addressed yet leaves the budget alone and the next qualifying
+  //   render tries again. Spending it on a miss is how the second file came to
+  //   open at line 1 with its cursor claiming otherwise.
+  // - `ready` going false again RETURNS the budget. A diff surface unmounts its
+  //   scroll container to refetch, and a container that comes back has lost its
+  //   scroll position — so opening at the first change again is the correct answer
+  //   there, not a yank: there is nothing left to preserve. `readerActed` is what
+  //   keeps a reader's own cursor across the same round trip.
+  //
+  // Once it has landed, a later re-render — text arriving, a gap expanded, a
+  // manual scroll — never moves the reader again.
+  React.useEffect(() => {
+    if (!ready) {
+      // The pane cannot be addressed right now — most often because a diff surface
+      // unmounted its scroll container to refetch. Return the budget: a container
+      // that comes back has lost its scroll position, so the first change is the
+      // right place to be again. The reader's own guard below is what keeps THEIR
+      // cursor across the same round trip, so this needs no second check.
+      opened.current = false;
+      return;
+    }
+    if (count === 0 || opened.current || readerActed.current) return;
+    const target = landing.current === "last" ? count - 1 : 0;
+    if (!reveal(target)) return;
+    landing.current = "first";
+    opened.current = true;
+    setCursor(target);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ready, count, resetKey, scrollToHunk]);
+
+  const go = (delta: 1 | -1) => (): boolean => {
+    if (count === 0) return false;
+    // The reader has taken this file over, so nothing that settles LATER may
+    // auto-open on top of them. (The crossing below re-arms it for the file it
+    // moves to: the reset effect runs after this handler and clears the flag.)
+    readerActed.current = true;
+    const list = filesRef.current;
+    // `cursor === 0` rather than `cursor <= 0`: an untouched cursor (-1) means the
+    // auto-open did not run, and the first ⇧F7 must still land on hunk 0 there
+    // rather than announce there is nothing above it.
+    const atEdge = delta === 1 ? cursor >= count - 1 : cursor === 0;
+    if (atEdge && list && list.index >= 0) {
+      const to = list.index + delta;
+      const crossable = to >= 0 && to < list.count;
+      const now = Date.now();
+      const isArmed =
+        !!armed.current &&
+        armed.current.dir === delta &&
+        now - armed.current.at <= PG_FLASH_MS;
+      if (isArmed && crossable) {
+        armed.current = null;
+        // Coming from below, land on the previous file's LAST change.
+        pending.current = delta === 1 ? "first" : "last";
+        list.select(to);
+        return true;
+      }
+      if (!crossable) {
+        // Nothing to arm for — say so on the FIRST press rather than making the
+        // reader ask twice to learn the list has ended.
+        armed.current = null;
+        pgFlash(
+          delta === 1
+            ? "Last file — no more changes"
+            : "First file — no earlier changes",
+        );
+        return true;
+      }
+      armed.current = { dir: delta, at: now };
+      const chord = chordFor(delta === 1 ? "diff.nextChange" : "diff.prevChange");
+      pgFlash(
+        `No more changes — press ${chord} again for the ${
+          delta === 1 ? "next" : "previous"
+        } file`,
+      );
+      return true;
+    }
+    armed.current = null;
+    const next = Math.max(0, Math.min(count - 1, cursor + delta));
+    setCursor(next);
+    reveal(next);
     return true;
   };
 

--- a/src/lib/useVariableWindow.test.tsx
+++ b/src/lib/useVariableWindow.test.tsx
@@ -1,0 +1,53 @@
+// `scrollTo` publishes the new window itself, rather than waiting for the engine
+// to dispatch a scroll event for a programmatic `scrollTop` write.
+//
+// The regression it exists for (issue 188): MEASURED on WebKitGTK 605 under xvfb,
+// an `el.scrollTop = …` assignment made inside an effect left `win` describing the
+// TOP of the file for seconds — so the row being scrolled to stayed UNMOUNTED, and
+// F7's `data-hunk-active`, the line cursor's focus ring and the auto-open at the
+// first change all appeared to do nothing at all. Which is precisely what a scroll
+// event NOT arriving looks like, so the test dispatches none.
+
+import { describe, expect, it } from "vitest";
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { useVariableWindow } from "./useVariableWindow";
+import { stubContainerSize } from "@/test/elementSize";
+
+const ROW = 20;
+const ROWS = 500;
+const heights = Array.from({ length: ROWS }, () => ROW);
+
+function Harness({ onState }: { onState: (s: { start: number; scrollTo: (t: number) => void }) => void }) {
+  const ref = React.useRef<HTMLDivElement | null>(null);
+  const { win, scrollTo } = useVariableWindow({
+    heights,
+    // A measured viewport, so `windowVariable` uses it rather than its 400px
+    // pre-layout fallback.
+    viewportH: 400,
+    scrollRef: ref,
+  });
+  onState({ start: win.start, scrollTo });
+  return <div ref={ref} />;
+}
+
+describe("useVariableWindow", () => {
+  it("scrollTo republishes the window with NO scroll event", () => {
+    // jsdom performs no layout, so the container must be told what it measures —
+    // and `scrollTop` is writable on an HTMLElement there, which is all this needs.
+    const restore = stubContainerSize({ height: 400 });
+    try {
+      let state = { start: -1, scrollTo: (_t: number) => {} };
+      render(<Harness onState={(s) => (state = s)} />);
+      expect(state.start).toBe(0);
+
+      // Row 300 sits at 6000px. No `dispatchEvent("scroll")` anywhere below: the
+      // window must move on the strength of the call alone.
+      act(() => state.scrollTo(300 * ROW));
+      expect(state.start).toBeGreaterThan(280);
+      expect(state.start).toBeLessThanOrEqual(300);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/src/lib/useVariableWindow.ts
+++ b/src/lib/useVariableWindow.ts
@@ -24,16 +24,34 @@ function sameRange(a: WindowRange, b: WindowRange): boolean {
 /**
  * Exact variable-height window over `heights`, bound to a scroll container.
  *
- * Returns the window plus the scroll handler to attach. The window is
- * recomputed on scroll (from the ref, no state write unless it changed) and
- * whenever `heights` / `viewportH` change (new file, syntax arrival, layout).
+ * Returns the window, the scroll handler to attach, and `scrollTo` — which a
+ * PROGRAMMATIC scroll should go through. The window is recomputed on scroll (from
+ * the ref, no state write unless it changed) and whenever `heights` / `viewportH`
+ * change (new file, syntax arrival, layout).
+ *
+ * **A programmatic `scrollTop` write is not a scroll event you can count on**, and
+ * that is why `scrollTo` exists (issue 188). MEASURED on WebKitGTK 605 under xvfb:
+ * an `el.scrollTop = 1881` assignment made inside an effect left the DOM scrolled
+ * and `win` still describing the TOP of the file — start 0, one spacer — for
+ * seconds, until an unrelated re-render happened to recompute it during render.
+ * The target row is unmounted for that whole time, so anything waiting on it (F7's
+ * `data-hunk-active`, the line cursor's focus ring, the issue-188 auto-open) sees
+ * nothing at all, on the engine CI runs. It works often enough elsewhere to look
+ * fine: the syntax tokens usually land right after and rebuild `heights`, which
+ * recomputes the window from the ref — but a cache hit removes even that.
+ *
+ * Two programmatic scrolls still write `scrollTop` directly and inherit the same
+ * hazard, both outside this change's blast radius and neither yet observed to
+ * misbehave: `FocusableScroll`'s Home/End and `DiffMinimap`'s scrub. Both would
+ * need this handle threaded to them; route them through here when one of them is
+ * next touched rather than as a drive-by.
  */
 export function useVariableWindow(o: {
   heights: number[];
   viewportH: number;
   overscan?: number;
   scrollRef: React.RefObject<HTMLElement | null>;
-}): { win: WindowRange; onScroll: () => void } {
+}): { win: WindowRange; onScroll: () => void; scrollTo: (top: number) => void } {
   const { heights, viewportH, overscan = 8, scrollRef } = o;
   const scrollTopRef = React.useRef(0);
   const [win, setWin] = React.useState<WindowRange>(() =>
@@ -72,5 +90,18 @@ export function useVariableWindow(o: {
     setWin((p) => (sameRange(p, next) ? p : next));
   }, [heights, viewportH, overscan, scrollRef]);
 
-  return { win, onScroll };
+  // Assign AND publish, in one call, so a programmatic scroll never depends on
+  // the engine dispatching an event for it. A real user scroll still arrives
+  // through `onScroll`; this is the same computation, just not waiting.
+  const scrollTo = React.useCallback(
+    (top: number) => {
+      const el = scrollRef.current;
+      if (!el) return;
+      el.scrollTop = top;
+      onScroll();
+    },
+    [onScroll, scrollRef],
+  );
+
+  return { win, onScroll, scrollTo };
 }

--- a/src/lib/useViewportH.test.tsx
+++ b/src/lib/useViewportH.test.tsx
@@ -5,8 +5,9 @@
 // of a taller diff pane blank.
 import { afterEach, describe, expect, it } from "vitest";
 import React from "react";
-import { renderHook } from "@testing-library/react";
+import { act, render, renderHook } from "@testing-library/react";
 import { useViewportH } from "./useViewportH";
+import { stubContainerSize } from "@/test/elementSize";
 
 const realRO = globalThis.ResizeObserver;
 
@@ -31,6 +32,64 @@ describe("useViewportH", () => {
     delete globalThis.ResizeObserver;
     const { result } = renderHook(() => useViewportH(refTo(704)));
     expect(result.current.viewportH).toBe(704);
+  });
+
+  // The other half of the same trap: every diff surface renders its scroll
+  // container only once the diff has ARRIVED, so the mount-time measurement reads
+  // a null ref and the mount-time effect never runs again — its deps have not
+  // changed, and there was no element to observe either. The height then stayed 0
+  // until the reader scrolled, which silently switched off everything that treats
+  // 0 as "unmeasured" (`scrollTopForRow`, and the issue-188 auto-open).
+  it("measures a container that mounts LATER, with no ResizeObserver and no dep change", () => {
+    // @ts-expect-error deliberately removing it, as the old webview does
+    delete globalThis.ResizeObserver;
+    const restore = stubContainerSize({ height: 704 });
+    try {
+      let flip = () => {};
+      let seen = -1;
+      function Harness() {
+        const ref = React.useRef<HTMLDivElement | null>(null);
+        const [ready, setReady] = React.useState(false);
+        flip = () => setReady(true);
+        seen = useViewportH(ref).viewportH;
+        // Deliberately NO deps argument, and the container is absent at mount —
+        // exactly the shape all four diff surfaces have.
+        return ready ? <div ref={ref} /> : null;
+      }
+      render(<Harness />);
+      expect(seen).toBe(0);
+      act(() => flip());
+      expect(seen).toBe(704);
+    } finally {
+      restore();
+    }
+  });
+
+  // The diff surfaces unmount their scroll container while the next file's diff is
+  // in flight, and a stale height there reads as "measured" to everything that
+  // gates on it — which is how the issue-188 auto-open came to fire into a pane
+  // that was not on screen.
+  it("goes back to 0 when the container UNMOUNTS, rather than keeping its height", () => {
+    const restore = stubContainerSize({ height: 704 });
+    try {
+      let flip = () => {};
+      let seen = -1;
+      function Harness() {
+        const ref = React.useRef<HTMLDivElement | null>(null);
+        const [shown, setShown] = React.useState(true);
+        flip = () => setShown((v) => !v);
+        seen = useViewportH(ref).viewportH;
+        return shown ? <div ref={ref} /> : null;
+      }
+      render(<Harness />);
+      expect(seen).toBe(704);
+      act(() => flip()); // container goes away
+      expect(seen).toBe(0);
+      act(() => flip()); // ...and comes back
+      expect(seen).toBe(704);
+    } finally {
+      restore();
+    }
   });
 
   it("reports 0 for a detached ref, rather than throwing", () => {

--- a/src/lib/useViewportH.ts
+++ b/src/lib/useViewportH.ts
@@ -1,6 +1,14 @@
 import React from "react";
 
 /**
+ * How many frames to keep re-reading a container that measured 0 — the same
+ * bound, for the same reason, as `useElementSize`'s: a pre-layout read is fixed
+ * by the next frame, and the bound is what stops a genuinely hidden container
+ * from polling for the lifetime of the mount.
+ */
+const MAX_MEASURE_FRAMES = 10;
+
+/**
  * Measured height of a scroll container, for the windowing helpers.
  *
  * Deliberately does NOT depend on ResizeObserver for correctness. Each diff
@@ -20,6 +28,23 @@ import React from "react";
  * `remeasure` is for the scroll handler: it reads the DOM only while the height
  * is still unknown, so the common case costs nothing and no forced layout
  * happens on every scroll event.
+ *
+ * **The container usually mounts AFTER this hook does**, and that is the second
+ * half of the same trap. Every diff surface renders its scroll container only
+ * once the diff has arrived (`isTextualDiff(diff) && …`), so the mount-time
+ * `measure()` reads a `ref.current` of `null` and the mount-time effect never
+ * runs again: its deps have not changed. On a webview WITH `ResizeObserver`
+ * there is no observer either — there was no element to observe. So the height
+ * stayed 0 until the reader happened to scroll (which is what `remeasure`
+ * rescues), `windowVariable` fell back to its 400px viewport, and anything that
+ * treats 0 as "not measured" (`scrollTopForRow`, `diffOpenReady`) simply never
+ * fired. Hence the node-attach effect below: it runs after EVERY render, does
+ * nothing but compare `ref.current` to the node it last saw, and measures when
+ * that changes — the RefObject equivalent of `useElementSize`'s ref callback,
+ * plus that hook's bounded rAF poll for a read that lands before layout.
+ *
+ * 0 therefore means "no measured container right now", covering both "not yet"
+ * and "not any more" — never "no space". Callers must treat it that way.
  */
 export function useViewportH(
   ref: React.RefObject<HTMLElement | null>,
@@ -32,6 +57,47 @@ export function useViewportH(
     const el = ref.current;
     if (el) setViewportH(el.clientHeight);
   }, [ref]);
+
+  // Node-attach detection, on EVERY render — see the note above. Cheap: one
+  // property read and one comparison unless the element actually changed, and
+  // `setViewportH` with an equal number is a no-op React bails out of, so this
+  // cannot loop.
+  const seen = React.useRef<HTMLElement | null>(null);
+  React.useEffect(() => {
+    const el = ref.current;
+    if (el === seen.current) return;
+    seen.current = el;
+    // A container that goes AWAY reports 0, i.e. UNMEASURED — not its last known
+    // height. Keeping the stale number is what let the issue-188 auto-open fire
+    // into a pane that was not on screen: the diff surfaces unmount their scroll
+    // container while `diffLoading`, the diff and the file text can both land
+    // before that flag clears, and every other readiness term was then satisfied
+    // with `scrollRef.current === null`. The scroll silently did nothing, the
+    // once-per-file budget was spent, and the file stayed at line 1. 0 is the
+    // honest answer and it is the one term that comes BACK when the container
+    // does, which is what makes the open retry at the right moment.
+    if (!el) {
+      setViewportH(0);
+      return;
+    }
+    // Effects run after the DOM is committed, so this forces layout and reads
+    // the real box — the same thing useElementSize's attach-time read relies on.
+    setViewportH(el.clientHeight);
+    if (el.clientHeight > 0 || typeof requestAnimationFrame !== "function") return;
+    let raf = 0;
+    let frames = 0;
+    const poll = () => {
+      raf = 0;
+      if (ref.current !== el) return;
+      setViewportH(el.clientHeight);
+      if (el.clientHeight > 0 || ++frames >= MAX_MEASURE_FRAMES) return;
+      raf = requestAnimationFrame(poll);
+    };
+    raf = requestAnimationFrame(poll);
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+    };
+  });
 
   React.useEffect(() => {
     measure();

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -82,7 +82,11 @@ import {
   useHunkActionsDisabledReason,
   useIgnoreWhitespace,
 } from "@/features/diff/WhitespaceToggle";
-import { useDiffGaps, useExpandedGaps } from "@/features/diff/useDiffGaps";
+import {
+  diffOpenReady,
+  useDiffGaps,
+  useExpandedGaps,
+} from "@/features/diff/useDiffGaps";
 import { buildStatusTree, findStatusByTreeKey, treeKeyToPath } from "@/lib/tree";
 import { useTreeViewMode } from "@/lib/useTreeViewMode";
 import {
@@ -620,17 +624,30 @@ export function CommitPanelScreen() {
   // Measured on the WRAPPER holding the scroll area and the minimap, so adding
   // the gutter cannot change the width that decides whether to add it (#161).
   const diffBox = useElementSize();
-  const { win, onScroll: onDiffScroll } = useVariableWindow({
+  const {
+    win,
+    onScroll: onDiffScroll,
+    scrollTo: scrollDiffTo,
+  } = useVariableWindow({
     heights,
     viewportH: diffViewportH,
     scrollRef: diffScrollRef,
   });
 
+  // The file+side the diff in state was FETCHED for. The two sides of one file are
+  // two different diffs, so a path alone cannot say whether `diff` is the
+  // selection's yet — and `diffOpenReady` needs to know, or the auto-open spends
+  // itself on the outgoing side's row model (issue 188).
+  const selKey = `${selected?.path ?? ""}:${selected?.side ?? ""}`;
+  const [diffFor, setDiffFor] = React.useState<string | null>(null);
+
   React.useEffect(() => {
     if (!selected || !repo) {
       setDiff(null);
+      setDiffFor(null);
       return;
     }
+    const key = `${selected.path}:${selected.side}`;
     const kind: DiffKind =
       selected.side === "staged" ? "IndexToHead" : "WorktreeToIndex";
     setDiffError(null);
@@ -638,6 +655,7 @@ export function CommitPanelScreen() {
     // one and rendering the backend's terse refusal.
     if (selected.status.embedded) {
       setDiff(null);
+      setDiffFor(null);
       setDiffLoading(false);
       setDiffError(`${selected.path} — ${EMBEDDED_REPO_HELP}`);
       return;
@@ -646,10 +664,16 @@ export function CommitPanelScreen() {
     setDiffLoading(true);
     getDiff(repo.id, selected.path, kind, diffContextLines, ignoreWhitespace)
       .then((d) => {
-        if (!cancelled) setDiff(d);
+        if (!cancelled) {
+          setDiff(d);
+          setDiffFor(key);
+        }
       })
       .catch((e) => {
-        if (!cancelled) setDiffError(appErrorMessage(e));
+        if (!cancelled) {
+          setDiffFor(null);
+          setDiffError(appErrorMessage(e));
+        }
       })
       .finally(() => {
         if (!cancelled) setDiffLoading(false);
@@ -686,16 +710,26 @@ export function CommitPanelScreen() {
   // so a DOM query would find nothing and arrow keys would stop scrolling with no
   // error (#68 G10). clientHeight is read live so the callback's identity does
   // not change with the viewport — usePaneList's scroll effect depends on it.
+  /** True when the row was actually addressed — see `useHunkNav`'s `scrollToHunk`. */
   const scrollDiffRowIntoView = React.useCallback(
-    (rowIndex: number) => {
+    (rowIndex: number): boolean => {
       const el = diffScrollRef.current;
-      if (!el) return;
-      el.scrollTop = scrollTopForRow(heights, rowIndex, {
+      if (!el) return false;
+      // Through the window's own setter — see `useVariableWindow.scrollTo`: a bare
+      // assignment leaves the rendered range at the old position until the engine
+      // dispatches a scroll event, and the row being scrolled to stays unmounted
+      // until it does (issue 188).
+      const want = scrollTopForRow(heights, rowIndex, {
         scrollTop: el.scrollTop,
         viewportH: el.clientHeight,
       });
+      scrollDiffTo(want);
+      // Confirm the write: a container shorter than the offset CLAMPS it (a pane
+      // mid-refetch is), and a reveal that did not land must not count as this
+      // file having been opened — see `useHunkNav`'s `scrollToHunk`.
+      return Math.abs(el.scrollTop - want) <= 1;
     },
-    [heights],
+    [heights, scrollDiffTo],
   );
 
   /**
@@ -737,29 +771,69 @@ export function CommitPanelScreen() {
     onToggle: toggleFocusedLine,
   });
 
+  // ONE list across both sections, staged first — the rendered order. Declared
+  // here because both `usePaneList` (arrows) and `useHunkNav` (F7 carrying into
+  // the next file, issue 188) address the same list: two orderings for two
+  // keyboards is exactly the drift a shared list prevents.
+  const combined = React.useMemo(() => [...staged, ...unstaged], [staged, unstaged]);
+  const combinedIndex = Math.max(
+    0,
+    combined.findIndex((f) => selected && keyOf(f) === keyOf(selected)),
+  );
+
   // ── Hunk cursor + hunk-level chords (#157) ───────────────────────────────
   // This pane had no F7 at all before, so the `@@` banner's Stage/Discard was
   // mouse-only. Both now hang off the hunk cursor.
   const anchorRows = React.useMemo(() => hunkAnchorRows(rows), [rows]);
   const scrollToHunk = React.useCallback(
-    (hunkIndex: number) => {
+    (hunkIndex: number): boolean => {
       const rowIndex = anchorRows[hunkIndex];
-      if (rowIndex == null || rowIndex < 0) return;
-      scrollDiffRowIntoView(rowIndex);
+      if (rowIndex == null || rowIndex < 0) return false;
+      return scrollDiffRowIntoView(rowIndex);
     },
     [anchorRows, scrollDiffRowIntoView],
   );
   const hunkCursor = useHunkNav({
     paneIds: ["commit.diff"],
     count: isTextualDiff(diff) && diff ? diff.hunks.length : 0,
-    resetKey: `${selected?.path ?? ""}:${selected?.side ?? ""}`,
+    resetKey: selKey,
     scrollToHunk,
+    // Split mode renders no unified scroll container, and `useViewportH` keeps the
+    // last height it read rather than resetting to 0 when that element goes away.
+    ready:
+      diffMode !== "split" &&
+      diffOpenReady({
+        diffFor,
+        showing: selKey,
+        rowCount: rows.length,
+        viewportH: diffViewportH,
+        gaps,
+        text: diffText,
+      }),
+    // F7 CROSSES the staged/unstaged boundary, because `usePaneList` already
+    // treats the two sections as one list in this order — the arrows do it, so
+    // stopping the diff cursor at each end would be a second answer to the same
+    // question. `combined` is that one list (issue 188).
+    files: {
+      count: combined.length,
+      index: combined.findIndex((f) => selected && keyOf(f) === keyOf(selected)),
+      select: (i) => {
+        const f = combined[i];
+        if (f) setSel({ keys: [keyOf(f)], anchor: keyOf(f) });
+      },
+    },
   });
 
   /**
-   * Which hunk a hunk-level chord acts on: the F7 cursor when it has moved, else
+   * Which hunk a hunk-level chord acts on: the F7 cursor when there is one, else
    * the hunk the line cursor sits in. `null` declines the chord rather than
    * guessing at hunk 0 — Discard is destructive.
+   *
+   * Since issue 188 the cursor is usually 0 the moment the pane opens, because
+   * the diff opens AT its first change. That is not the guess this guard was
+   * written against: the cursor is marked (`data-hunk-active`) and scrolled to,
+   * so it is the hunk the reader is looking at. The `null` arm still covers the
+   * cases where nothing auto-opened — an unmeasured pane, or no hunks at all.
    */
   const chordHunk =
     hunkCursor >= 0 ? hunkCursor : (lineFocus.focused?.hunkIndex ?? null);
@@ -850,11 +924,6 @@ export function CommitPanelScreen() {
 
   // Keyboard: one selection across both sections (staged first, matching the
   // rendered order). Space stages/unstages the selected file, Rider-style.
-  const combined = React.useMemo(() => [...staged, ...unstaged], [staged, unstaged]);
-  const combinedIndex = Math.max(
-    0,
-    combined.findIndex((f) => selected && keyOf(f) === keyOf(selected)),
-  );
   usePaneList({
     paneId: "commit.files",
     count: combined.length,

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -22,7 +22,11 @@ import {
   WhitespaceToggle,
   useIgnoreWhitespace,
 } from "@/features/diff/WhitespaceToggle";
-import { useDiffGaps, useExpandedGaps } from "@/features/diff/useDiffGaps";
+import {
+  diffOpenReady,
+  useDiffGaps,
+  useExpandedGaps,
+} from "@/features/diff/useDiffGaps";
 import { isTextualDiff, statusMark } from "@/lib/derive";
 import { LfsDiffNotice } from "@/features/lfs/LfsDiffNotice";
 import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
@@ -224,7 +228,11 @@ export function DiffViewerScreen() {
   // measured, not the scroll area, so showing the gutter cannot change the width
   // that decides whether to show it (#161).
   const diffBox = useElementSize();
-  const { win: varWin, onScroll: onDiffScroll } = useVariableWindow({
+  const {
+    win: varWin,
+    onScroll: onDiffScroll,
+    scrollTo: scrollDiffTo,
+  } = useVariableWindow({
     heights,
     viewportH,
     scrollRef,
@@ -247,16 +255,25 @@ export function DiffViewerScreen() {
   // row is outside the window, which for a line row is most of the time.
   const anchorRows = React.useMemo(() => hunkAnchorRows(rows), [rows]);
   const scrollToHunk = React.useCallback(
-    (hunkIndex: number) => {
+    (hunkIndex: number): boolean => {
       const el = scrollRef.current;
       const idx = anchorRows[hunkIndex];
-      if (!el || idx == null || idx < 0) return;
-      const top = rowOffset(heights, idx);
-      if (top < el.scrollTop || top > el.scrollTop + el.clientHeight - rowH) {
-        el.scrollTop = top;
+      if (!el || idx == null || idx < 0) return false;
+      const want = rowOffset(heights, idx);
+      // Reveal-only: a first change already on screen must not jump.
+      if (want >= el.scrollTop && want <= el.scrollTop + el.clientHeight - rowH) {
+        return true;
       }
+      // Through the window's own setter: a bare `el.scrollTop = …` leaves the
+      // rendered range describing the old position until the engine gets round
+      // to a scroll event, which on WebKitGTK can be seconds (issue 188).
+      scrollDiffTo(want);
+      // Confirm the write: a container shorter than the offset CLAMPS it (a pane
+      // mid-refetch is), and a reveal that did not land must not count as this
+      // file having been opened — see `useHunkNav`'s `scrollToHunk`.
+      return Math.abs(el.scrollTop - want) <= 1;
     },
-    [anchorRows, heights, rowH],
+    [anchorRows, heights, rowH, scrollDiffTo],
   );
   const hunkCursor = useHunkNav({
     paneIds: ["diff.files", "diff.view"],
@@ -268,6 +285,32 @@ export function DiffViewerScreen() {
     // which is exactly correct here: with windowing off, every anchor row is
     // mounted, so `scrollIntoView` cannot silently no-op (the #68 G10 trap).
     scrollToHunk: wrap ? undefined : scrollToHunk,
+    // Split mode has no unified scroll container, and `useViewportH` keeps the
+    // last height it managed to read rather than resetting to 0 when the element
+    // goes away — so the mode is part of the question, not just the measurement.
+    ready:
+      mode === "unified" &&
+      diffOpenReady({
+        // The row model still describes the OUTGOING file for the render right
+        // after a switch — the fetch is async — and auto-opening there would burn
+        // the once-per-file budget on it.
+        diffFor: diff?.path,
+        showing: selectedPath,
+        rowCount: rows.length,
+        viewportH,
+        gaps,
+        text: diffText,
+      }),
+    // This screen's list is the filtered changed-file list — the one the pane
+    // beside the diff renders, so moving `selectedPath` moves both.
+    files: {
+      count: filtered.length,
+      index: filtered.findIndex((f) => f.path === selectedPath),
+      select: (i) => {
+        const f = filtered[i];
+        if (f) setSelectedPath(f.path);
+      },
+    },
   });
 
   if (status.length === 0) {

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -81,7 +81,11 @@ import {
   useHunkActionsDisabledReason,
   useIgnoreWhitespace,
 } from "@/features/diff/WhitespaceToggle";
-import { useDiffGaps, useExpandedGaps } from "@/features/diff/useDiffGaps";
+import {
+  diffOpenReady,
+  useDiffGaps,
+  useExpandedGaps,
+} from "@/features/diff/useDiffGaps";
 import {
   PGPane,
   FocusableScroll,
@@ -675,7 +679,11 @@ export function RepoBrowserScreen() {
   // Measured on the WRAPPER holding the scroll area and the minimap, so adding
   // the gutter cannot change the width that decides whether to add it (#161).
   const diffBox = useElementSize();
-  const { win: diffWin, onScroll: onDiffScroll } = useVariableWindow({
+  const {
+    win: diffWin,
+    onScroll: onDiffScroll,
+    scrollTo: scrollDiffTo,
+  } = useVariableWindow({
     heights: diffHeights,
     viewportH: diffViewportH,
     scrollRef: diffScrollRef,
@@ -685,22 +693,46 @@ export function RepoBrowserScreen() {
   // Scroll BY OFFSET — the anchor row is usually unmounted under windowing.
   const diffAnchorRows = React.useMemo(() => hunkAnchorRows(diffRows), [diffRows]);
   const scrollToHunk = React.useCallback(
-    (hunkIndex: number) => {
+    (hunkIndex: number): boolean => {
       const el = diffScrollRef.current;
       const rowIndex = diffAnchorRows[hunkIndex];
-      if (!el || rowIndex == null || rowIndex < 0) return;
-      el.scrollTop = scrollTopForRow(diffHeights, rowIndex, {
+      if (!el || rowIndex == null || rowIndex < 0) return false;
+      // Through the window's own setter — see `useVariableWindow.scrollTo`.
+      const want = scrollTopForRow(diffHeights, rowIndex, {
         scrollTop: el.scrollTop,
         viewportH: el.clientHeight,
       });
+      scrollDiffTo(want);
+      // Confirm the write: a container shorter than the offset CLAMPS it (a pane
+      // mid-refetch is), and a reveal that did not land must not count as this
+      // file having been opened — see `useHunkNav`'s `scrollToHunk`.
+      return Math.abs(el.scrollTop - want) <= 1;
     },
-    [diffAnchorRows, diffHeights],
+    [diffAnchorRows, diffHeights, scrollDiffTo],
   );
   const hunkCursor = useHunkNav({
     paneIds: ["repo.tree", "repo.preview"],
     count: isTextualDiff(diff) && diff ? diff.hunks.length : 0,
     resetKey: selectedFile?.path ?? null,
     scrollToHunk,
+    ready: diffOpenReady({
+      // The fetch is async, so this pane renders once with the outgoing file's
+      // rows while the selection already names the new one.
+      diffFor: diff?.path,
+      showing: selectedFile?.path,
+      rowCount: diffRows.length,
+      viewportH: diffViewportH,
+      gaps: browserGaps,
+      text: browserText,
+    }),
+    // NO `files` here, deliberately (issue 188). This pane's list is a TREE of
+    // every tracked file, not a changed set, so "the next file" would have to mean
+    // "the next file with changes" — a different list from the one the tree
+    // renders and the one the reader is navigating, so the selection would jump
+    // past rows they never asked to skip. It can also be showing a REVISION,
+    // where the pane is a preview rather than a change set, and a tree's "next"
+    // is not even defined without expanding folders. F7 stays inside the file
+    // here; the changed-file surfaces are where crossing belongs.
   });
   const stageHunkAt = React.useCallback((i: number) => {
     const path = selectedFile?.path;
@@ -724,8 +756,11 @@ export function RepoBrowserScreen() {
     },
     [selectedFile?.path],
   );
-  // Decline rather than guess at hunk 0 when the cursor has not moved: Discard is
+  // Decline rather than guess at hunk 0 when there is no cursor at all: Discard is
   // destructive, and ignore-whitespace makes hunk indices unusable (#61 D2).
+  // Since issue 188 an opened diff usually HAS a cursor at 0 — marked and scrolled
+  // to, so acting on it is not a guess. `< 0` still covers an unmeasured pane and
+  // a diff with no hunks.
   useAction(
     "diff.stageHunk",
     () => {


### PR DESCRIPTION
Implements issue 188 — both halves.

## What changes for the reader

**A diff opens at its first change.** Whole file is the default view, so a diff
used to open on line 1 of unchanged context and reading one began by scrolling to
hunt for the change. The pane now reveals the first change and marks it
(`data-hunk-active`). That also fixes the latent bug the issue names as a side
effect: the scroll container is reused across file switches and nothing reset
`scrollTop`, so moving from a long file into a short one landed you near the
bottom of the new one.

**F7 carries into the next file.** On the last hunk, F7 flashes *"No more changes
— press F7 again for the next file"* — the chord comes from the live keymap
(`chordFor`), never a literal — and the next press inside the hint's lifetime
opens the next file at its first change, moving the FILE LIST selection with it.
`⇧F7` mirrors it: previous file, landing on its **last** change. Each end of the
list flashes ("Last file — no more changes" / "First file — no earlier changes")
and stays put. No wrap-around.

Both live in `useHunkNav`, which all four diff surfaces already call, so none of
them can be left behind the way F7 itself was until #157.

## The three decisions the issue deliberately leaves open

**1. Where the hunk cursor starts: `0`, but only when the reveal actually landed.**
The issue's recommendation, taken, with the "actually happened" part made
load-bearing rather than aspirational. If the pane cannot be addressed — no scroll
container yet, an anchor row that is not mounted, a write a short container clamps
— the cursor stays at `-1` and the open is retried on the next qualifying render.
So `data-hunk-active` and the scroll position can never disagree; a mark on hunk 0
means the pane is showing hunk 0. This is not theoretical: spending the open on a
reveal that silently missed is exactly how the second file came to open at line 1
with its cursor claiming hunk 0, and only the webview showed it.

Consequence worth naming: `CommitPanel` and `RepoBrowser` gate their hunk-level
chords on `hunkCursor >= 0`, so `Mod+Shift+H` / `Mod+Shift+Backspace` now act on
hunk 0 without an F7 press first. That was previously refused as "a guess"; it is
no longer one — the cursor is marked and scrolled to, so it is the hunk the reader
is looking at. The comments at both sites say so, and the `null` arm still covers
"nothing auto-opened".

**2. `CommitPanel` — F7 CROSSES the staged/unstaged boundary.** `usePaneList`
already treats the two sections as ONE list in the rendered order (staged above
changes) and registers once over `combined`; the arrows have always walked from the
last staged file into the first unstaged one. Stopping the diff cursor at each end
would be a second answer to the same question, which is the exact drift a shared
list exists to prevent — so F7 reads the same `combined` list the arrows do. Its
`combined`/`combinedIndex` declaration moved up so both hooks address one list
rather than two copies.

**3. `RepoBrowser` sits OUT of file crossing** (it still opens at the first
change). Its pane lists every tracked file, not a changed set, so "the next file"
would have to mean "the next file with changes" — a different list from the one the
tree renders and from the one the reader is navigating, so the selection would jump
past rows they never asked to skip. It can also be showing a REVISION, where the
pane is a preview rather than a change set, and "next" in a tree with collapsed
folders is not even well defined. It simply passes no `files`, which is the
documented way to keep the old clamp.

## Three measurement bugs had to be fixed first

None of the above worked on WebKitGTK — the Linux webview and the e2e/CI target —
and each cause was invisible to every consumer that already tolerates a `0`:

1. **`useViewportH` measured once, at mount.** Every diff surface renders its
   scroll container only after the diff arrives, so the mount-time read found
   `ref.current === null`, the effect never ran again (its deps had not changed),
   and there was no element to observe either. The height stayed 0 until the reader
   happened to scroll (`remeasure` in the scroll handler was quietly rescuing it),
   which also means windowing has been falling back to its 400px viewport on first
   paint there. It now re-measures when the node it last saw changes, plus
   `useElementSize`'s bounded rAF poll.
2. **…and it kept that height when the container went AWAY.** The surfaces unmount
   it while `diffLoading`, and the diff and the file text can both land before that
   clears — so there is a render where every readiness term is satisfied with
   `scrollRef.current === null`. 0 is the honest answer for "not any more" as well
   as "not yet", and it is the term that comes *back* when the container does,
   which is what makes the open happen at the right moment instead of never.
3. **A programmatic `scrollTop` write is not a scroll event.** Measured: an
   assignment made inside an effect left the windowed range describing the top of
   the file — `start: 0`, one spacer — for *seconds*, so the row being scrolled to
   stayed unmounted. Hence `useVariableWindow.scrollTo`, which assigns and
   publishes the new window in one call; every programmatic diff scroll goes
   through it. `FocusableScroll`'s Home/End and `DiffMinimap`'s scrub still write
   directly and inherit the hazard; both are named as follow-ups in that hook's
   comment rather than fixed as drive-bys.

`pgFlash` also moves to `design/ui-helpers.tsx` — where CLAUDE.md already said it
lived — and becomes single-instance. It appended a fresh node per call with no
dedup, and "press it again" is the one hint guaranteed to be raised twice onto the
same fixed position. Moving it also keeps `features/keymap` from importing
`design/context-menu`, which imports `chordFor` back out of `features/keymap`.

## Tests

- `useHunkNav.test.tsx` — 22 cases now: auto-open (and that it does NOT fire while
  the surface is unready, i.e. an unmeasured viewport), once-per-file, a reveal that
  could not land, re-opening after the pane goes away, a reader's cursor surviving
  the same round trip, the exhausted → armed → crossed sequence, arming EXPIRY
  (fake timers past `PG_FLASH_MS`), the backward crossing landing on the previous
  file's LAST change, stopping at each end, the no-`files` clamp, and one toast
  element across repeated presses.
- `useDiffGaps.test.ts` (new) — `diffOpenReady`'s four terms as a pure function,
  including that an unmeasured viewport is not "no space" and that a stale row model
  is not ready.
- `useVariableWindow.test.tsx` (new) — `scrollTo` republishes the window with **no**
  scroll event dispatched anywhere in the test.
- `useViewportH.test.tsx` — a container that mounts LATER with no `ResizeObserver`
  and no dep change; and one that unmounts reporting 0 rather than its last height.
- `e2e/specs/diff-nav.e2e.ts` (new) — on the real webview: the diff opens marked at
  its first change with `scrollTop > 0` (the change is 100 lines down, so it cannot
  be on screen at rest), and F7 walks to the last change, flashes without moving
  files, then carries into the next file at its first change and stops at the end of
  the list. `keymap.e2e.ts`'s F7 test is updated for the new starting cursor.
- Two e2e helpers added: `watchFlashes`/`flashLog` (a toast lives 1.7s and reusing
  one element makes a separate read a race) and `waitForSelector` (re-queries in
  page, so it cannot bind to a row windowing is about to unmount — the trap the e2e
  skill documents).

Every new test was mutation-checked: the implementation was broken, the specific
test was confirmed to fail, and it was restored. Details in the task report,
including that the end-of-list bug being fixed was a *silent* no-op that still
returned `true`, so the tests assert the hint and the unchanged selection rather
than "F7 did not crash".

## Gates

`pnpm tsc --noEmit`, `pnpm test` (198 files / 1701 tests), `pnpm exec tsc -p
e2e/tsconfig.json --noEmit`, and the full Docker e2e suite — all green.

Refs issue 188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Er25sN6pGoVJzmTBwHU2Tz
