### PR TITLE
fix(cli): never detach the launch in a dev build

### DIFF
--- a/docs/dev/distribution.md
+++ b/docs/dev/distribution.md
@@ -69,7 +69,7 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   function's last command, and feed loops from here-docs when they assign outer
   variables.
 
-## The `pgit` launch detaches — one variant must not (#163)
+## The `pgit` launch detaches — except where it must not (#163, #197)
 
 - **`pgit .` hands the prompt straight back**, like `code .`. The detach is in
   the BINARY (`detach.rs`, one call site in `lib.rs::run`) — two shim shapes
@@ -90,6 +90,16 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   the e2e harness's pipes are untouched. `pgit . > file` blocks, by design.
   Windows deliberately unchanged: the GUI-subsystem binary already returns in
   cmd/PowerShell, and Git Bash's MSYS pipe fails `IsTerminal` anyway.
+- **A dev build never detaches, whatever the arguments say (#197).** `tauri dev`
+  inherits the developer's terminal to the app it spawns, so the tty gate says
+  yes — and the parent exiting 0 is how the CLI learns the app closed: it stops
+  the vite dev server that a dev build's webview loads `devUrl` from, leaving a
+  `setsid`'d orphan pointed at a closed port. It reads as `tauri dev` returning
+  instantly and the window never painting. The term is `tauri::is_dev()`
+  (`!cfg!(feature = "custom-protocol")`), which is the exact condition and not a
+  proxy: the same flag chooses `devUrl` over the embedded assets. `cargo run`
+  stays in the foreground for the same reason; the e2e build sets
+  `tauri/custom-protocol` and is unchanged (its stdio is a pipe anyway).
 - `tests/cli_detach.rs` drives the real binary through a **pty** for the
   must-stay-synchronous paths and `git credential fill` (offline) for the
   credentialed one — a pure-function test cannot show git still gets its

--- a/src-tauri/src/detach.rs
+++ b/src-tauri/src/detach.rs
@@ -18,6 +18,17 @@
 //! trace it back to. `Parsed::Help` must stay synchronous too, or `USAGE` is
 //! printed by a child whose stdout is `/dev/null`.
 //!
+//! A **dev build** must not detach either, whatever the arguments say (#197).
+//! `tauri dev` runs the app as its own child with the developer's terminal
+//! inherited, so the tty gate says yes — and the parent exiting 0 is exactly how
+//! the CLI learns the app has closed: it stops the vite dev server that a dev
+//! build's webview loads `devUrl` from, and returns the prompt. What is left is
+//! a setsid'd orphan whose frontend is a closed port — a window that never
+//! paints, with no Ctrl+C, no HMR and no rebuild on change. `tauri::is_dev()` is
+//! the exact test and not a proxy: the same flag chooses `devUrl` over the
+//! embedded assets, so it is true precisely when our frontend belongs to a
+//! server that is about to die with the CLI.
+//!
 //! ## Why this re-execs instead of calling `fork()`
 //!
 //! A bare `fork()` keeps the GUI in a child that never `exec`s, and macOS
@@ -65,6 +76,10 @@ pub struct LaunchEnv {
     pub askpass_mode: bool,
     /// Whether we are already the detached child.
     pub already_detached: bool,
+    /// Whether this is a dev build — one whose webview loads `devUrl` from the
+    /// dev server that `tauri dev` owns and kills on the way out. Compile-time,
+    /// so it cannot be forced from the environment (see the module docs).
+    pub dev_build: bool,
 }
 
 impl LaunchEnv {
@@ -75,6 +90,10 @@ impl LaunchEnv {
             stdout_is_terminal: std::io::stdout().is_terminal(),
             askpass_mode: std::env::var_os(crate::cli::ASKPASS_MODE_ENV).is_some(),
             already_detached: std::env::var_os(DETACHED_ENV).is_some(),
+            // `tauri::is_dev()` is `!cfg!(feature = "custom-protocol")` — the
+            // feature the Tauri CLI adds for a bundle build and leaves off for
+            // `tauri dev`, and the same one Tauri reads to pick `devUrl`.
+            dev_build: tauri::is_dev(),
         }
     }
 }
@@ -87,6 +106,7 @@ pub fn should_detach(parsed: &Parsed, env: LaunchEnv) -> bool {
         && env.stdout_is_terminal
         && !env.askpass_mode
         && !env.already_detached
+        && !env.dev_build
 }
 
 /// Whether the caller is now the process that should keep going.
@@ -186,6 +206,9 @@ mod tests {
             stdout_is_terminal,
             askpass_mode: false,
             already_detached: false,
+            // A shipped build: the frontend is embedded, so no dev server dies
+            // when the launching command returns.
+            dev_build: false,
         }
     }
 
@@ -243,5 +266,19 @@ mod tests {
             ..env(true)
         };
         assert!(!should_detach(&launch(), e));
+    }
+
+    #[test]
+    fn a_dev_build_never_detaches() {
+        // `tauri dev` inherits the developer's terminal to the app, so the tty
+        // gate says yes — and the parent exiting 0 is how the CLI learns the app
+        // closed, so it stops the dev server this build's webview loads from.
+        // The detached child is then an orphan showing an empty window.
+        let e = LaunchEnv {
+            dev_build: true,
+            ..env(true)
+        };
+        assert!(!should_detach(&launch(), e));
+        assert!(!should_detach(&Parsed::Launch(None), e));
     }
 }


### PR DESCRIPTION
`pnpm tauri dev` / `npx tauri dev` returned to the prompt within seconds of
launching, leaving a window that never painted. Closes #197.

## Cause

The #163 launch detach fires in dev builds. `tauri dev` runs the app as its own
child with the developer's terminal inherited, so `should_detach` sees
`Parsed::Launch(None)` with `stdout_is_terminal == true`, re-execs the app
detached and returns 0. Exiting 0 is how the Tauri CLI learns the app closed, so
it shuts down and takes the vite dev server on 1420 with it — and a dev build's
webview loads `devUrl` from that server. What survives is a `setsid`'d orphan
whose frontend is a closed port: no paint, no Ctrl+C, no HMR, no rebuild.

## Fix

`should_detach` gains a `dev_build` term from `tauri::is_dev()`. That is the
exact condition and not a proxy: the same `custom-protocol` flag chooses `devUrl`
over the embedded assets, so it is true precisely when the frontend belongs to a
server that dies with the CLI. Shipped bundles set the flag and are untouched —
`pgit .` still hands the prompt straight back. The e2e build sets
`tauri/custom-protocol` too (and runs on pipes), so it is unchanged.

## Verified

Both runs drive the real `pnpm tauri dev` with a **pty** on its stdout — the
condition the detach is gated on — via the same probe:

| | before (main) | after |
|---|---|---|
| `tauri dev` after 12s | exited, code 0 | still in the foreground |
| app process | PPID 1, own session — orphan | child of `tauri.js dev`, launcher's pgroup |
| vite on 1420 | gone | LISTEN + webview ESTABLISHED |
| app log | `starting v0.0.0`, then nothing | `invoke …@http://localhost:1420/src/lib/tauri.ts` — frontend live |
| Ctrl+C | app leaked, unreachable | app and dev server both exit |

Gates: `cargo test` 670 tests / 62 suites green (including the pty-driven
`tests/cli_detach.rs`, which pins that askpass and `--help` still never detach),
`pnpm test` 1768 green, `pnpm tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
