### PR TITLE
feat(update): make the package-manager command copyable

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -291,6 +291,14 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   comparison against `CommitInfo.oid` failed silently (HEAD indicator, graph
   ring, `headAncestryOf` degraded to "the whole log"). `shortSha` at display
   sites only.
+- **Text is unselectable app-wide.** `body` sets `user-select: none` (it makes
+  the shell feel native); only inputs, `contenteditable`, and `.pg-selectable`
+  opt back in. So any string a user may need to lift out by hand — a command,
+  a path, an error — needs `className="pg-selectable"`, and ideally a copy
+  button beside it too (`PGIconButton icon="copy"` + `pgFlash`), because a
+  string inside a click-outside-to-close popover is gone by the second drag.
+  The update panel's package-manager command shipped as a bare `<code>`: the
+  notify path's only actionable content, unselectable and uncopyable.
 - **New list-row surfaces must opt into UI density** (issue #70):
   `height: "calc(<base>px + var(--row-step))"` (or `/ 2` for padding-sized
   rows); `--row-h` for plain 24px rows. `--row-step` is 0 in compact, so each

--- a/src/features/update/UpdatePanel.test.tsx
+++ b/src/features/update/UpdatePanel.test.tsx
@@ -182,3 +182,61 @@ describe("UpdatePanel — status surfaces", () => {
     expect(screen.getByText(/Downloading/)).toHaveTextContent("42%");
   });
 });
+
+describe("UpdatePanel — the package-manager command is copyable", () => {
+  // `body` sets `user-select: none` (src/index.css), so before this the notify
+  // path's command could neither be selected nor copied: the panel's only
+  // actionable content had to be retyped by hand.
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    platformMock.value = "macos";
+    seed({});
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+  });
+
+  it("copies the brew command on macOS", async () => {
+    render(<UpdatePanel />);
+    await userEvent.click(screen.getByTitle(/copy command/i));
+    expect(writeText).toHaveBeenCalledWith("brew upgrade platypusgit");
+  });
+
+  it("copies the apt command on Linux", async () => {
+    platformMock.value = "linux";
+    seed({});
+    render(<UpdatePanel />);
+    await userEvent.click(screen.getByTitle(/copy command/i));
+    expect(writeText).toHaveBeenCalledWith(
+      "sudo apt install ./PlatypusGit_amd64.deb",
+    );
+  });
+
+  it("keeps the command selectable by hand as well", () => {
+    render(<UpdatePanel />);
+    // `pg-selectable` is the escape hatch from the app-wide `user-select: none`.
+    expect(screen.getByTestId("pg-update-pkg-hint")).toHaveClass(
+      "pg-selectable",
+    );
+  });
+
+  it("offers no copy button when there is no command to copy", () => {
+    seed({ capability: "self-update" });
+    render(<UpdatePanel />);
+    expect(screen.queryByTitle(/copy command/i)).toBeNull();
+  });
+
+  it("says so instead of failing silently when the clipboard write rejects", async () => {
+    writeText.mockRejectedValue(new Error("denied"));
+    render(<UpdatePanel />);
+    await userEvent.click(screen.getByTitle(/copy command/i));
+    await vi.waitFor(() =>
+      expect(document.querySelector("[data-pg-flash]")?.textContent).toMatch(
+        /could not copy/i,
+      ),
+    );
+  });
+});

--- a/src/features/update/UpdatePanel.tsx
+++ b/src/features/update/UpdatePanel.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { PGButton, PGIconButton } from "@/design";
+import { PGButton, PGIconButton, pgFlash } from "@/design";
 import { usePlatform } from "@/lib/platform";
 import { packageHint } from "./packageHint";
 import { useUpdateStore } from "./useUpdateStore";
@@ -112,18 +112,50 @@ export function UpdatePanel() {
           <span style={{ fontSize: "var(--fs-11)", color: "var(--fg-2)" }}>
             {hint.note}
           </span>
-          <code
-            data-testid="pg-update-pkg-hint"
+          {/* The command has to be able to LEAVE the panel — it is the only
+              thing a notify-path user can act on. `body` sets
+              `user-select: none`, so the bare <code> could neither be selected
+              nor copied: advice you had to retype by hand, character-exact,
+              from a popover that closes on the next click outside it. Hence
+              both routes: the copy button, and `pg-selectable` for a manual
+              drag-select of part of it. */}
+          <div
             style={{
-              fontSize: "var(--fs-11)",
-              color: "var(--fg-1)",
+              display: "flex",
+              alignItems: "center",
+              gap: 4,
               background: "var(--bg-2)",
               borderRadius: "var(--r-2)",
-              padding: "4px 8px",
+              padding: "2px 2px 2px 8px",
             }}
           >
-            {hint.command}
-          </code>
+            <code
+              data-testid="pg-update-pkg-hint"
+              className="mono pg-selectable"
+              style={{
+                flex: 1,
+                minWidth: 0,
+                fontSize: "var(--fs-11)",
+                color: "var(--fg-1)",
+                whiteSpace: "pre",
+                overflowX: "auto",
+                cursor: "text",
+              }}
+            >
+              {hint.command}
+            </code>
+            <PGIconButton
+              icon="copy"
+              size="sm"
+              title="Copy command"
+              onClick={() => {
+                void navigator.clipboard
+                  ?.writeText(hint.command)
+                  .then(() => pgFlash("copied command"))
+                  .catch(() => pgFlash("could not copy command"));
+              }}
+            />
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
The update popup's macOS/Linux upgrade command (`brew upgrade platypusgit`, `sudo apt install ./PlatypusGit_amd64.deb`) was a bare `<code>` element. `body` sets `user-select: none`, so it could not be selected *or* copied — the notify path's only actionable content had to be retyped character-exact, from a popover that closes on the next click outside it.

- copy button beside the command (`PGIconButton icon="copy"`, `pgFlash` confirms; failure says so instead of going quiet)
- the `<code>` gets `pg-selectable` so a manual drag-select of part of the command still works, and scrolls horizontally instead of wrapping
- 5 component tests: both platform arms copy the right string, the self-update path offers no button, the selectable opt-in is pinned, and a rejected clipboard write surfaces

`docs/dev/frontend.md` gains a Styling bullet on the app-wide `user-select: none` — the trap was undocumented, and `.pg-selectable` existed in `index.css` with zero users.

**Verification:** `pnpm test` — 1773 passed (206 files); `pnpm tsc --noEmit` clean. No e2e run: nothing in `e2e/` touches `pg-update-*`, and this is a frontend-only component change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
