### PR TITLE
fix(diff): park F7's target four lines below the top of the pane

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -81,6 +81,26 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   windowing and the DOM route silently does nothing (the #68 G10 trap). F7
   scrolls by offset too (`hunkAnchorRows`); the DOM fallback survives only for
   unwindowed callers.
+- **Three scroll semantics, and they are not interchangeable.**
+  `scrollTopForRow` REVEALS (smallest move that shows the row, no-op when it is
+  already visible) — the LINE cursor's, because a cursor stepping one row should
+  scroll one row. `scrubScrollTop` (`lib/diffMinimap.ts`) POSITIONS a viewport
+  around a row. `scrollTopForAnchor` PARKS: the row lands `HUNK_LEAD_ROWS × rowH`
+  px below the top of the viewport, ALWAYS — off screen, at an edge, or already
+  comfortably visible. That is F7/⇧F7's landing and the auto-open's, and the
+  unconditional move is the point: under reveal semantics F7 walking forward
+  pinned every change to the BOTTOM edge with no following context, and one
+  keypress meant two different things depending on where the last one left the
+  pane. Three details are load-bearing: the lead is PIXELS (the height of the
+  four preceding rows would let one tall fold separator eat it); the result is
+  clamped to `[0, sum(heights) − viewportH]`, because overshooting is clamped by
+  the DOM and every `scrollToHunk` reads `scrollTop !== want` as "the reveal did
+  not land", costing the file its auto-open; and the lead itself is capped at
+  `viewportH − rowH` so a short pane degrades to "flush with the top" rather than
+  parking the target off its own bottom edge. `DiffViewer`'s wrap mode measures
+  the mounted row's rect instead (heights describe nothing there) — same rule,
+  different ruler. The merge window's F7 walks conflict regions through
+  CodeMirror and shares none of this.
 - **A diff OPENS at its first change, and F7 carries into the next file**
   (issue 188). Both live in `useHunkNav`, not per screen. The parts:
   - The auto-open waits on `diffOpenReady` (`features/diff/useDiffGaps.ts`):

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -18,7 +18,7 @@ import { useDiffSyntax, usePrefetchSyntax, type SideSource } from "@/lib/syntax"
 import {
   flattenDiffRows,
   hunkAnchorRows,
-  scrollTopForRow,
+  scrollTopForAnchor,
 } from "@/lib/diffRows";
 import { useVariableWindow } from "@/lib/useVariableWindow";
 import { useViewportH } from "@/lib/useViewportH";
@@ -240,9 +240,12 @@ export function CommitDiffPanel({
       const rowIndex = anchorRows[hunkIndex];
       if (!el || rowIndex == null || rowIndex < 0) return false;
       // Through the window's own setter — see `useVariableWindow.scrollTo`.
-      const want = scrollTopForRow(heights, rowIndex, {
+      // PARKED a fixed lead below the top, never merely revealed: see
+      // `scrollTopForAnchor`.
+      const want = scrollTopForAnchor(heights, rowIndex, {
         scrollTop: el.scrollTop,
         viewportH: el.clientHeight,
+        rowH,
       });
       scrollDiffTo(want);
       // Confirm the write: a container shorter than the offset CLAMPS it (a pane
@@ -250,7 +253,7 @@ export function CommitDiffPanel({
       // file having been opened — see `useHunkNav`'s `scrollToHunk`.
       return Math.abs(el.scrollTop - want) <= 1;
     },
-    [anchorRows, heights, scrollDiffTo],
+    [anchorRows, heights, rowH, scrollDiffTo],
   );
   const hunkCursor = useHunkNav({
     paneIds: [filesPaneId, viewPaneId],

--- a/src/features/diff/CommitDiffPanel.window.test.tsx
+++ b/src/features/diff/CommitDiffPanel.window.test.tsx
@@ -5,9 +5,13 @@
 // PGWindowedDiff. It still uses the SHARED flattenDiffRows/windowVariable, so
 // there is only one row model in the codebase.
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { resetInvokeMock } from "@/test/invokeMock";
 import { CommitDiffPanel } from "./CommitDiffPanel";
+import { useFocusStore } from "@/features/keymap/useFocusStore";
+import { useKeymapStore } from "@/features/keymap/useKeymapStore";
+import { HUNK_LEAD_ROWS } from "@/lib/diffRows";
+import { DIFF_ROW_H_FALLBACK } from "@/lib/useDiffRowHeight";
 import type { FileDiff } from "@/lib/types";
 
 vi.mock("@/lib/syntax/tokenize", async (orig) => ({
@@ -78,8 +82,75 @@ const withHeaderLine: FileDiff[] = [
   },
 ];
 
+/**
+ * One hunk starting at line 1, so the row model is exactly its lines and the
+ * anchor's row index is known: 40 context rows, then the change.
+ */
+const ANCHOR_ROW = 40;
+const deepChange: FileDiff[] = [
+  {
+    path: "c.ts",
+    oldPath: null,
+    binary: false,
+    additions: 1,
+    deletions: 0,
+    hunks: [
+      {
+        header: "@@ -1,80 +1,81 @@",
+        oldStart: 1,
+        oldLines: 80,
+        newStart: 1,
+        newLines: 81,
+        lines: [
+          ...Array.from({ length: ANCHOR_ROW }, (_, i) => ({
+            kind: { kind: "Context" as const },
+            oldLineno: i + 1,
+            newLineno: i + 1,
+            content: `before ${i}`,
+          })),
+          {
+            kind: { kind: "Addition" as const },
+            oldLineno: null,
+            newLineno: ANCHOR_ROW + 1,
+            content: "the change",
+          },
+          ...Array.from({ length: ANCHOR_ROW }, (_, i) => ({
+            kind: { kind: "Context" as const },
+            oldLineno: ANCHOR_ROW + i + 1,
+            newLineno: ANCHOR_ROW + i + 2,
+            content: `after ${i}`,
+          })),
+        ],
+      },
+    ],
+  },
+];
+
+/** jsdom lays nothing out: give the scroll container a real geometry. */
+function stubScroll(el: Element, o: { viewportH: number; contentH: number }) {
+  let top = 0;
+  Object.defineProperty(el, "clientHeight", { configurable: true, value: o.viewportH });
+  Object.defineProperty(el, "scrollHeight", { configurable: true, value: o.contentH });
+  Object.defineProperty(el, "scrollTop", {
+    configurable: true,
+    get: () => top,
+    set: (v: number) => {
+      top = v;
+    },
+  });
+}
+
 beforeEach(() => {
   resetInvokeMock();
+  useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+  useKeymapStore.getState().setPreset("rider");
+  useFocusStore.setState({
+    focused: null,
+    panes: new Map(),
+    order: [],
+    barId: null,
+    pendingContentFocus: false,
+  });
 });
 
 describe("CommitDiffPanel windowing", () => {
@@ -128,5 +199,44 @@ describe("CommitDiffPanel windowing", () => {
     // The anchor is the added line — the row F7 lands on and the row index the
     // header line used to occupy.
     expect(document.querySelector('[data-hunk-index="0"]')?.textContent).toContain("added");
+  });
+
+  it("PARKS an F7 target a fixed lead below the top, not at the viewport edge", async () => {
+    render(
+      <CommitDiffPanel
+        diffs={deepChange}
+        loading={false}
+        error={null}
+        header="x → y"
+        paneIdPrefix="w4"
+      />,
+    );
+    // The anchor row is 40 rows down and windowed OUT — which is exactly the
+    // case that made offset arithmetic mandatory here (#68 G10). Wait for the
+    // rows that ARE mounted instead.
+    await waitFor(() => expect(screen.getByText(/before 0/)).toBeInTheDocument());
+    const el = document.querySelector('[aria-label="Diff"]')!;
+    const rowH = DIFF_ROW_H_FALLBACK;
+    stubScroll(el, { viewportH: 10 * rowH, contentH: 81 * rowH });
+
+    useFocusStore.setState({ focused: "w4.view" });
+    act(() => {
+      useKeymapStore.getState().dispatch({
+        key: "F7",
+        code: "",
+        metaKey: false,
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: false,
+        preventDefault() {},
+        target: document.body,
+      } as unknown as KeyboardEvent);
+    });
+
+    // The anchor sits at row 40. Reveal semantics would have stopped at the
+    // smallest scroll that shows it — the row pinned to the BOTTOM edge, at
+    // 41 * rowH - viewportH. Parking puts it HUNK_LEAD_ROWS rows below the top,
+    // every time, whichever direction F7 arrived from.
+    expect(el.scrollTop).toBe((ANCHOR_ROW - HUNK_LEAD_ROWS) * rowH);
   });
 });

--- a/src/lib/diffRows.test.ts
+++ b/src/lib/diffRows.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   flattenDiffRows,
+  HUNK_LEAD_ROWS,
   hunkAnchorRows,
   rowOffset,
+  scrollTopForAnchor,
   scrollTopForRow,
   windowVariable,
   type DiffRow,
@@ -678,5 +680,64 @@ describe("scrollTopForRow", () => {
     // Row 4 spans 88..106; a 40px viewport at 0 must scroll to 66.
     expect(scrollTopForRow(mixed, 4, { scrollTop: 0, viewportH: 40 })).toBe(66);
     expect(scrollTopForRow(mixed, 0, { scrollTop: 66, viewportH: 40 })).toBe(0);
+  });
+});
+
+describe("scrollTopForAnchor", () => {
+  // Twenty 20px rows (400px of content) in a 200px viewport, so the 4-row
+  // lead-in (80px) fits with room to spare either side.
+  const hs = Array.from({ length: 20 }, () => 20);
+  const park = (index: number, scrollTop = 0, viewportH = 200) =>
+    scrollTopForAnchor(hs, index, { scrollTop, viewportH, rowH: 20 });
+
+  it("parks the anchor a fixed lead below the top of the viewport", () => {
+    // Row 9 starts at 180; four 20px rows of lead-in put the viewport at 100.
+    expect(park(9)).toBe(180 - HUNK_LEAD_ROWS * 20);
+  });
+
+  it("repositions a row that is ALREADY visible", () => {
+    // The whole point, and where this parts company with scrollTopForRow: F7
+    // must put the change in the same physical spot every time, not leave it
+    // wherever the previous scroll happened to strand it.
+    expect(scrollTopForRow(hs, 7, { scrollTop: 100, viewportH: 200 })).toBe(100);
+    expect(park(7, 100)).toBe(60);
+  });
+
+  it("clamps at the top of the file rather than scrolling negative", () => {
+    expect(park(0)).toBe(0);
+    expect(park(2, 300)).toBe(0);
+  });
+
+  it("clamps at the end of the file, where the lead cannot be honoured", () => {
+    // Row 19 starts at 380; 400px of content in a 200px viewport tops out at
+    // 200, so the last hunk sits lower than the lead asks for. Overshooting
+    // here would be CLAMPED BY THE DOM, and scrollToHunk reads that mismatch as
+    // "the reveal did not land" — which quietly costs the file its auto-open.
+    expect(park(19)).toBe(200);
+  });
+
+  it("caps the lead so a short pane cannot hide the anchor", () => {
+    // A 60px viewport with the full 80px lead would put row 9 (offset 180) at
+    // scrollTop 100 — showing 100..160, with the anchor off the bottom. The cap
+    // keeps one row of the anchor on screen at every viewport size.
+    expect(park(9, 0, 60)).toBe(140);
+    // One row tall: no lead at all, anchor flush with the top.
+    expect(park(9, 0, 20)).toBe(180);
+  });
+
+  it("measures the lead in PIXELS, not in preceding rows", () => {
+    // A header (26) then two code rows (18), twice. Row 4 starts at 88; the four
+    // rows above it are 88px tall together, which would eat the entire lead and
+    // park the anchor at the top. 4 x rowH is 72, so 16 is the answer.
+    const mixed = [26, 18, 18, 26, 18, 18];
+    expect(scrollTopForAnchor(mixed, 4, { scrollTop: 0, viewportH: 100, rowH: 18 })).toBe(16);
+  });
+
+  it("holds still for an out-of-range index or an unmeasured viewport", () => {
+    // Same guards as scrollTopForRow: jsdom and the first paint both report a
+    // 0px viewport, and the auto-open leans on this to try again later.
+    expect(park(-1, 40)).toBe(40);
+    expect(park(20, 40)).toBe(40);
+    expect(scrollTopForAnchor(hs, 9, { scrollTop: 40, viewportH: 0, rowH: 20 })).toBe(40);
   });
 });

--- a/src/lib/diffRows.ts
+++ b/src/lib/diffRows.ts
@@ -483,6 +483,63 @@ export function scrollTopForRow(
   return scrollTop;
 }
 
+/** Rows of lead-in `scrollTopForAnchor` keeps above its target. */
+export const HUNK_LEAD_ROWS = 4;
+
+/**
+ * Scroll position that PARKS row `index` a fixed lead below the top of the
+ * viewport — F7/⇧F7's landing, and the file auto-open's.
+ *
+ * Three scroll semantics now live side by side, and they are not
+ * interchangeable:
+ *
+ * - `scrollTopForRow` REVEALS: the smallest move that brings a row into view,
+ *   unchanged when it already is. The line cursor wants exactly that — a cursor
+ *   stepping one row should scroll one row.
+ * - `scrubScrollTop` (`diffMinimap.ts`) POSITIONS a viewport around a row.
+ * - this one PARKS: the target always lands in the same physical spot, whether
+ *   it was off screen, at the bottom edge, or already comfortably visible. That
+ *   unconditional move is the point — under "reveal" semantics F7 walking
+ *   forward leaves each change pinned to the BOTTOM edge with no following
+ *   context, and the reader's eyes have to hunt for it after every press.
+ *
+ * The lead is `HUNK_LEAD_ROWS * rowH` PIXELS rather than the height of the four
+ * preceding rows: a tall fold separator directly above a hunk would otherwise
+ * eat the whole lead and park the change at the top after all.
+ *
+ * Two clamps make it total:
+ *
+ * - The result stays inside `[0, contentH - viewportH]`. Overshooting the end of
+ *   the document is not harmless: the DOM clamps the write, and every caller's
+ *   `scrollToHunk` reads `scrollTop !== want` as "the reveal did not land",
+ *   which costs the file its once-per-file auto-open. `contentH` is the sum of
+ *   `heights` — TRUE BY CONSTRUCTION, since `PGWindowedDiff` renders exactly
+ *   `topPad + rows + bottomPad` into the scroll container. Putting padding or a
+ *   sticky child in there would break this.
+ * - The lead itself is capped at `viewportH - rowH`, so a pane shorter than the
+ *   lead (a squeezed preview split) cannot park the target off its own bottom
+ *   edge. It degrades to "flush with the top", never to "not on screen".
+ *
+ * An out-of-range index or an unmeasured viewport (`viewportH <= 0`) leaves the
+ * scroll position alone, exactly as `scrollTopForRow` does — `diffOpenReady` and
+ * the auto-open both lean on that to try again on a later render.
+ */
+export function scrollTopForAnchor(
+  heights: number[],
+  index: number,
+  o: { scrollTop: number; viewportH: number; rowH: number },
+): number {
+  const { scrollTop, viewportH, rowH } = o;
+  if (index < 0 || index >= heights.length || viewportH <= 0) return scrollTop;
+  const lead = Math.min(
+    HUNK_LEAD_ROWS * Math.max(0, rowH),
+    Math.max(0, viewportH - rowH),
+  );
+  const contentH = heights.reduce((a, h) => a + h, 0);
+  const max = Math.max(0, contentH - viewportH);
+  return Math.min(Math.max(0, rowOffset(heights, index) - lead), max);
+}
+
 /**
  * Window a list of known-height rows. Returns the same shape useWindowedList
  * produces, so consumers and the `window?: WindowRange` prop are unchanged.

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -70,6 +70,7 @@ import { useDiffSyntax } from "@/lib/syntax";
 import {
   flattenDiffRows,
   hunkAnchorRows,
+  scrollTopForAnchor,
   scrollTopForRow,
 } from "@/lib/diffRows";
 import { useVariableWindow } from "@/lib/useVariableWindow";
@@ -733,6 +734,28 @@ export function CommitPanelScreen() {
   );
 
   /**
+   * The same write with PARKING semantics — F7's landing, not the line cursor's.
+   *
+   * The two must not share one helper: a line cursor stepping one row should
+   * scroll one row (reveal), while F7 puts every change in the same physical
+   * spot whether or not it was already visible (park). See `scrollTopForAnchor`.
+   */
+  const parkDiffRow = React.useCallback(
+    (rowIndex: number): boolean => {
+      const el = diffScrollRef.current;
+      if (!el) return false;
+      const want = scrollTopForAnchor(heights, rowIndex, {
+        scrollTop: el.scrollTop,
+        viewportH: el.clientHeight,
+        rowH,
+      });
+      scrollDiffTo(want);
+      return Math.abs(el.scrollTop - want) <= 1;
+    },
+    [heights, rowH, scrollDiffTo],
+  );
+
+  /**
    * Space on the focused line, staging on the unstaged side and unstaging on the
    * staged side — the same direction rule the hunk header's button uses.
    *
@@ -789,9 +812,9 @@ export function CommitPanelScreen() {
     (hunkIndex: number): boolean => {
       const rowIndex = anchorRows[hunkIndex];
       if (rowIndex == null || rowIndex < 0) return false;
-      return scrollDiffRowIntoView(rowIndex);
+      return parkDiffRow(rowIndex);
     },
-    [anchorRows, scrollDiffRowIntoView],
+    [anchorRows, parkDiffRow],
   );
   const hunkCursor = useHunkNav({
     paneIds: ["commit.diff"],

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -32,7 +32,12 @@ import { LfsDiffNotice } from "@/features/lfs/LfsDiffNotice";
 import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
 import { getDiff } from "@/lib/tauri";
 import { useDiffSyntax } from "@/lib/syntax";
-import { flattenDiffRows, hunkAnchorRows, rowOffset } from "@/lib/diffRows";
+import {
+  flattenDiffRows,
+  HUNK_LEAD_ROWS,
+  hunkAnchorRows,
+  scrollTopForAnchor,
+} from "@/lib/diffRows";
 import { useVariableWindow } from "@/lib/useVariableWindow";
 import { useViewportH } from "@/lib/useViewportH";
 import { useElementSize } from "@/lib/useElementSize";
@@ -259,11 +264,15 @@ export function DiffViewerScreen() {
       const el = scrollRef.current;
       const idx = anchorRows[hunkIndex];
       if (!el || idx == null || idx < 0) return false;
-      const want = rowOffset(heights, idx);
-      // Reveal-only: a first change already on screen must not jump.
-      if (want >= el.scrollTop && want <= el.scrollTop + el.clientHeight - rowH) {
-        return true;
-      }
+      // PARKED a fixed lead below the top — see `scrollTopForAnchor`. This screen
+      // used to skip the scroll entirely for a hunk already on screen, which is
+      // how one keypress came to mean two different things depending on where the
+      // previous one left the pane.
+      const want = scrollTopForAnchor(heights, idx, {
+        scrollTop: el.scrollTop,
+        viewportH: el.clientHeight,
+        rowH,
+      });
       // Through the window's own setter: a bare `el.scrollTop = …` leaves the
       // rendered range describing the old position until the engine gets round
       // to a scroll event, which on WebKitGTK can be seconds (issue 188).
@@ -275,16 +284,44 @@ export function DiffViewerScreen() {
     },
     [anchorRows, heights, rowH, scrollDiffTo],
   );
+
+  // Wrap mode, where `heights` no longer describes the rendered rows and the
+  // offset arithmetic above would land on the wrong line. Windowing is off here,
+  // so every anchor row is MOUNTED and the DOM can be measured directly — the one
+  // situation in which a querySelector cannot silently no-op (the #68 G10 trap).
+  // Measured through bounding rects rather than `offsetTop`, which is relative to
+  // whichever ancestor happens to be positioned.
+  //
+  // `useHunkNav`'s own fallback would do `scrollIntoView({block: "start"})` and
+  // park the change flush against the top edge; this keeps the lead-in every other
+  // mode gives.
+  const scrollToHunkInWrap = React.useCallback(
+    (hunkIndex: number): boolean => {
+      const el = scrollRef.current;
+      const row = el?.querySelector<HTMLElement>(`[data-hunk-index="${hunkIndex}"]`);
+      if (!el || !row) return false;
+      const lead = Math.min(
+        HUNK_LEAD_ROWS * rowH,
+        Math.max(0, el.clientHeight - rowH),
+      );
+      const top =
+        el.scrollTop + row.getBoundingClientRect().top - el.getBoundingClientRect().top;
+      const want = Math.max(
+        0,
+        Math.min(top - lead, el.scrollHeight - el.clientHeight),
+      );
+      scrollDiffTo(want);
+      return Math.abs(el.scrollTop - want) <= 1;
+    },
+    [rowH, scrollDiffTo],
+  );
   const hunkCursor = useHunkNav({
     paneIds: ["diff.files", "diff.view"],
     count: findFiltered?.hunks.length ?? 0,
     resetKey: selectedPath,
-    // Wrap mode: `heights` no longer describes the rendered rows, so an
-    // offset-based scroll lands on the wrong line — the same reason the window and
-    // the minimap are off. Omitting it takes useHunkNav's documented DOM fallback,
-    // which is exactly correct here: with windowing off, every anchor row is
-    // mounted, so `scrollIntoView` cannot silently no-op (the #68 G10 trap).
-    scrollToHunk: wrap ? undefined : scrollToHunk,
+    // Wrap mode measures the mounted row instead of trusting `heights` — same
+    // parking rule, different ruler.
+    scrollToHunk: wrap ? scrollToHunkInWrap : scrollToHunk,
     // Split mode has no unified scroll container, and `useViewportH` keeps the
     // last height it managed to read rather than resetting to 0 when the element
     // goes away — so the mode is part of the question, not just the measurement.

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -57,7 +57,7 @@ import { useDiffSyntax, useSyntax } from "@/lib/syntax";
 import {
   flattenDiffRows,
   hunkAnchorRows,
-  scrollTopForRow,
+  scrollTopForAnchor,
 } from "@/lib/diffRows";
 import { useVariableWindow } from "@/lib/useVariableWindow";
 import { useViewportH } from "@/lib/useViewportH";
@@ -698,9 +698,12 @@ export function RepoBrowserScreen() {
       const rowIndex = diffAnchorRows[hunkIndex];
       if (!el || rowIndex == null || rowIndex < 0) return false;
       // Through the window's own setter — see `useVariableWindow.scrollTo`.
-      const want = scrollTopForRow(diffHeights, rowIndex, {
+      // PARKED a fixed lead below the top, never merely revealed: see
+      // `scrollTopForAnchor`.
+      const want = scrollTopForAnchor(diffHeights, rowIndex, {
         scrollTop: el.scrollTop,
         viewportH: el.clientHeight,
+        rowH: diffRowH,
       });
       scrollDiffTo(want);
       // Confirm the write: a container shorter than the offset CLAMPS it (a pane
@@ -708,7 +711,7 @@ export function RepoBrowserScreen() {
       // file having been opened — see `useHunkNav`'s `scrollToHunk`.
       return Math.abs(el.scrollTop - want) <= 1;
     },
-    [diffAnchorRows, diffHeights, scrollDiffTo],
+    [diffAnchorRows, diffHeights, diffRowH, scrollDiffTo],
   );
   const hunkCursor = useHunkNav({
     paneIds: ["repo.tree", "repo.preview"],


### PR DESCRIPTION
F7/⇧F7 scrolled through `scrollTopForRow`, whose contract is *the smallest move that reveals a row* — so walking forward pinned every change to the **bottom** edge with no following context, and `DiffViewer` skipped the scroll entirely when the hunk was already visible. One keypress meant two different things depending on where the previous one left the pane.

`scrollTopForAnchor` parks instead: the hunk's anchor row (its first changed line) lands `HUNK_LEAD_ROWS × rowH` px below the top of the viewport, always — off screen, at an edge, or already comfortably visible. Same rule for the auto-open that lands a freshly-opened file on its first change, and for the next-file carry.

**Why a second function rather than a mode on the existing one:** the reveal contract still belongs to the LINE cursor — a cursor stepping one row should scroll one row — and `diffMinimap.ts` already documents a third semantic (positioning). Three names, three jobs.

Three details are load-bearing and are commented as such:

- The lead is **pixels**, not the height of the four preceding rows — a tall fold separator directly above a hunk would otherwise eat the whole lead.
- The result is clamped to `[0, sum(heights) − viewportH]`. Overshooting is clamped by the DOM, and every surface's `scrollToHunk` reads `scrollTop !== want` as "the reveal did not land" — which would quietly cost the file its once-per-file auto-open.
- The lead itself is capped at `viewportH − rowH`, so a pane shorter than the lead degrades to "flush with the top" instead of parking the target off its own bottom edge.

`DiffViewer`'s wrap mode measures the mounted row's rect (windowing is off there, so `heights` describe nothing) — same parking rule, different ruler. It used to fall through to `useHunkNav`'s `scrollIntoView({block: "start"})`, which had no lead at all.

Out of scope, unchanged: the merge window's F7 (conflict regions through CodeMirror, no shared machinery) and `DiffViewer` split mode (no unified scroll container — F7 there already scrolled nothing).

## Testing

- 7 unit tests for `scrollTopForAnchor`: the lead, both clamps, the short-pane cap, pixels-not-rows, and the hold-still guards for an out-of-range index / unmeasured viewport.
- A wiring test driving a real F7 through `CommitDiffPanel` with stubbed geometry. Mutation-checked: reverting the panel to `scrollTopForRow` fails it with `expected 589 to be 684` — 589 being exactly the old bottom-edge landing.
- `pnpm tsc --noEmit` clean; `pnpm test` 1784/1784.
- Docker e2e: `diff-nav` 2/2, `keymap` 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)