### PR TITLE
feat(diff): make diff text selectable, and copyable past the window

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,11 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
 - **Diff surfaces:** one row model (`flattenDiffRows`); gate text rendering on
   `isTextualDiff`, scroll by offset (never `scrollIntoView` under windowing),
   measure viewports with `lib/useViewportH`/`useElementSize` (read first,
-  observe second — WebKitGTK has no `ResizeObserver`). (`docs/dev/frontend.md`)
+  observe second — WebKitGTK has no `ResizeObserver`). New row markup keeps the
+  selection split: code cell `.pg-selectable`, line numbers and `+`/`−` marker
+  `user-select: none`. A selection cannot leave the rendered window, so copying a
+  long range goes through `lib/diffCopy.ts` (`diff.copy` / the right-click menu),
+  and `Mod+C` must keep declining to the native copy. (`docs/dev/frontend.md`)
 - **The log is paged** — `s.commits` is a prefix of history, never the answer
   to "does X exist / is X an ancestor"; ask the backend.
   (`docs/dev/frontend.md`)

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -54,6 +54,44 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   type back — silent truncation is worse than the overflow.
 - **Gate text rendering on `isTextualDiff(diff)`, not `!diff.binary`** (#93) —
   an LFS pointer is honestly text; the surfaces render `LfsDiffNotice` instead.
+- **Diff CODE is selectable; diff CHROME is not.** `body` is `user-select: none`
+  (native desktop feel), so each row's code cell opts back in with
+  `.pg-selectable` (`index.css`) while the line-number cells and the `+`/`−`
+  marker keep `user-select: none`. That split is the whole feature: a selection
+  that swept up the gutters would paste as text you have to clean by hand. Every
+  new diff row markup has to make the same split — `CommitDiffPanel`'s marker was
+  a loose text node and had to be wrapped in a span to get it.
+  - **A mouse selection cannot leave the rendered window.** The surfaces are
+    windowed, so rows outside the viewport are not in the document and a drag
+    stops at its edge (overscan 8). This is why `diff.copy` (`Mod+C`) and
+    `diffCopyMenuItems` (right-click, wired into all four surfaces) build their
+    text from the ROW MODEL instead — `lib/diffCopy.ts`, reusing `isFileContent`
+    so `changedIndex` cannot drift from what the renderer numbered. Copying a
+    long range has no other path; a surface that forgets the menu is a surface
+    where it silently cannot be done, which `test/diffCopyMenu.test.ts` fails the
+    build over.
+  - **`Mod+C` must keep meaning "copy".** `diff.copy` DECLINES (returns `false`)
+    whenever a text selection exists and whenever nothing is selected, so the
+    chord goes unhandled, the dispatcher skips `preventDefault`, and the
+    webview's native copy runs. It is pane-scoped and `suppressInInput`, so it
+    never reaches the commit-message textarea or another screen.
+  - **A drag-select ends in a `click`**, on the row the pointer came up over — so
+    `PGDiffRow`'s handler bails on a non-collapsed selection, or copying a line
+    would stage it. No false positives: `mousedown` collapses any earlier
+    selection before `click` runs, so a genuine click always sees a collapsed one.
+  - **Opting text back in defeats a body-level `user-select: none`**, because a
+    class beats an inherited value. `dragController` relied on exactly that body
+    style to stop a row drag from selecting as it moved (it cannot
+    `preventDefault` a pointerdown that may still end up a click), so it now also
+    sets `data-pg-dragging` on `body`, which `index.css` uses to suppress
+    `.pg-selectable` for the duration. `PGResizeHandle` needs none of this — it
+    `preventDefault`s its mousedown, so no selection ever starts. Any future
+    "nothing is selectable right now" state has to reach the opted-in cells the
+    same way.
+  - Pinned by `src/design/diffSelection.test.tsx` (+ `src/test/selectionText.ts`,
+    which walks the tree the way an engine serialises a copy) and, because the
+    granting rule lives in a stylesheet and gutter exclusion is an engine
+    behaviour, by `e2e/specs/diff-selection.e2e.ts` in the real webview.
 - **Tokenization runs in a module worker** (Shiki's `codeToTokens` is sync CPU);
   tokens return as transferable `Int32Array`s. `vite.config.ts` sets
   `worker: { format: "es" }` — the grammars are dynamic imports and the default

--- a/e2e/specs/diff-selection.e2e.ts
+++ b/e2e/specs/diff-selection.e2e.ts
@@ -1,0 +1,220 @@
+// Diff text is selectable, and what a copy yields is CODE — no line numbers and
+// no +/- markers.
+//
+// This needs a real webview and cannot be faked in jsdom, for two reasons:
+//
+//  1. The rule that grants selection lives in a STYLESHEET (`.pg-selectable` in
+//     index.css, opting back in from the app-wide `user-select: none` on body).
+//     jsdom applies no stylesheet, so a component test can only assert the class
+//     is present — never that the cascade actually resolves to a selectable cell
+//     in the engine that ships.
+//  2. Whether `user-select: none` on the gutters really keeps them OUT of a copy
+//     is an engine behaviour, and a WebKit soft spot historically. The component
+//     tests model it (`src/test/selectionText.ts` walks the tree the way an engine
+//     would); only this spec measures it.
+//
+// The fixture is deliberately DIGIT-FREE — every code line is a word — so "the
+// copied text contains no digit" is an exact statement about line numbers having
+// been excluded, with nothing in the code that could satisfy it by accident.
+//
+// The selection itself is set through the Range API in-page rather than a pointer
+// drag: the embedded driver cannot synthesize a reliable press-move-release over
+// a windowed list (the same reason `jsContextMenu` and `jsChord` exist), and the
+// engine's copy serialisation is what is under test, not its hit-testing.
+
+import { browser, $, expect } from "@wdio/globals";
+import { basicRepo, type TempRepo } from "../support/tempRepo";
+import {
+  openRepo,
+  resetApp,
+  switchScreen,
+  executeOnce,
+  jsContextMenu,
+  jsClickMenuItem,
+  waitForSelector,
+} from "../support/app";
+
+const filesPane = '[data-pg-pane="diff.files"]';
+const diffScroll = '[aria-label="Diff"]';
+const codeCell = `${diffScroll} .pg-selectable`;
+
+const WORDS = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot"];
+
+/**
+ * One tracked file of words, with one word changed.
+ *
+ * No digits anywhere in the content, so the gutters' line numbers are the only
+ * possible source of a digit in anything copied out of this diff.
+ */
+function wordsRepo(): TempRepo {
+  const r = basicRepo();
+  r.commitFile("words.txt", WORDS.join("\n") + "\n", "feat: add words");
+  const next = [...WORDS];
+  next[2] = "gamma";
+  r.write("words.txt", next.join("\n") + "\n");
+  return r;
+}
+
+async function openWordsDiff(repo: TempRepo): Promise<void> {
+  await openRepo(repo.path);
+  await switchScreen("diff");
+  await $(filesPane).waitForDisplayed({
+    timeout: 20_000,
+    timeoutMsg: "Diff screen never appeared",
+  });
+  // No click: words.txt is the fixture's ONLY change, and the Diff screen selects
+  // its first file itself (the row comes up `data-selected`), so the diff is
+  // already open. This screen's file rows carry no `data-path` either — they are
+  // a status mark plus a name — so there would be nothing unambiguous to click,
+  // and `*=` text cannot be appended to a descendant chain in the first place.
+  await waitForSelector(
+    `${filesPane} [data-pg-row][data-selected]`,
+    "the Diff screen never auto-selected a file",
+  );
+  await waitForSelector(codeCell, "the diff never rendered a selectable code cell");
+  // Guard the fixture: everything below reads this one file's diff.
+  expect(await $(`${filesPane} [data-pg-row][data-selected]`).getText()).toContain(
+    "words.txt",
+  );
+}
+
+/** The engine's computed `user-select` for the first match of `sel`. */
+function computedUserSelect(sel: string): Promise<string | null> {
+  return browser.execute((s: string) => {
+    const el = document.querySelector(s);
+    if (!el) return null;
+    const cs = getComputedStyle(el);
+    return cs.userSelect || cs.webkitUserSelect || null;
+  }, sel);
+}
+
+/**
+ * Select every diff row and return the engine's TWO serialisations of it.
+ *
+ * `Selection.toString()` is the one that matters: in WebKit it is the selection's
+ * plain-text rendering, and it honours `user-select` — which is what a copy puts
+ * on the clipboard. `Range.toString()` is the raw text-node walk and ignores CSS
+ * entirely. Returning both lets the assertions prove the exclusion is CAUSED by
+ * `user-select: none` rather than by a DOM that never held the numbers: the raw
+ * walk still sees them, the selection does not.
+ *
+ * Not read from a `copy` event: per the Clipboard API a copy/cut event's
+ * `clipboardData` starts EMPTY (it is write-only, for handlers overriding the
+ * payload), so `getData` there returns "" no matter what the selection holds —
+ * measured on WebKitGTK 605 before this was rewritten.
+ */
+function selectAllAndSerialise(
+  scrollSel: string,
+): Promise<{ selection: string; rawWalk: string }> {
+  return executeOnce((sel: string) => {
+    const scroller = document.querySelector(sel);
+    if (!scroller) throw new Error(`no diff scroller for ${sel}`);
+    const range = document.createRange();
+    range.selectNodeContents(scroller);
+    const selection = window.getSelection();
+    if (!selection) throw new Error("no selection object");
+    selection.removeAllRanges();
+    selection.addRange(range);
+    return { selection: selection.toString(), rawWalk: range.toString() };
+  }, scrollSel);
+}
+
+/** Record what the app asks the clipboard to hold, without touching the real one. */
+function recordClipboard(): Promise<null> {
+  return executeOnce(() => {
+    const w = window as unknown as { __pgCopied?: string[] };
+    w.__pgCopied = [];
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: (t: string) => {
+          w.__pgCopied!.push(t);
+          return Promise.resolve();
+        },
+      },
+    });
+    return null;
+  });
+}
+
+function recordedCopies(): Promise<string[]> {
+  return browser.execute(
+    () => (window as unknown as { __pgCopied?: string[] }).__pgCopied ?? [],
+  );
+}
+
+describe("diff text selection", () => {
+  let repo: TempRepo;
+
+  afterEach(async () => {
+    repo?.dispose();
+    await resetApp();
+  });
+
+  it("resolves the stylesheet to selectable code and unselectable gutters", async () => {
+    repo = wordsRepo();
+    await openWordsDiff(repo);
+
+    // The two halves of the contract, as the shipping engine resolves them. The
+    // body rule (`user-select: none`) is what makes the second half the default,
+    // so the first is the one that proves `.pg-selectable` is reaching the cell.
+    expect(await computedUserSelect(codeCell)).toBe("text");
+
+    const gutter = await browser.execute((sel: string) => {
+      const cell = document.querySelector(sel);
+      const row = cell?.parentElement;
+      const first = row?.firstElementChild as HTMLElement | undefined;
+      if (!first) return null;
+      const cs = getComputedStyle(first);
+      return cs.userSelect || cs.webkitUserSelect || null;
+    }, codeCell);
+    expect(gutter).toBe("none");
+  });
+
+  it("serialises a selection to the code alone, one row per line", async () => {
+    repo = wordsRepo();
+    await openWordsDiff(repo);
+
+    const { selection, rawWalk } = await selectAllAndSerialise(diffScroll);
+
+    // Whole-file view, so every line of the file is a row: the unchanged ones,
+    // then the change as removed-then-added. Rows come out newline-separated, so
+    // this pastes as source rather than as one smeared line.
+    expect(selection).toBe("alpha\nbravo\ncharlie\ngamma\ndelta\necho\nfoxtrot\n");
+
+    // Restating the above as the properties that matter, so a failure says which
+    // half broke. Every line number is a digit and the fixture has none, which is
+    // what makes the digit check exact.
+    expect(selection).not.toMatch(/[0-9]/);
+    expect(selection).not.toContain("+");
+    // U+2212 MINUS SIGN — what PGDiffRow renders for a removed line, not "-".
+    expect(selection).not.toContain("−");
+
+    // The proof that `user-select: none` is what did it: the raw text-node walk
+    // over the SAME range ignores CSS, and still sees the line numbers. If this
+    // ever matches the selection, the gutters stopped being excluded and the
+    // checks above went vacuous.
+    expect(rawWalk).toMatch(/[0-9]/);
+    expect(rawWalk).not.toBe(selection);
+  });
+
+  it("copies the whole file's diff from the context menu", async () => {
+    repo = wordsRepo();
+    await openWordsDiff(repo);
+    await recordClipboard();
+
+    await jsContextMenu(diffScroll);
+    await jsClickMenuItem("Copy file diff as text");
+
+    await browser.waitUntil(async () => (await recordedCopies()).length > 0, {
+      timeout: 10_000,
+      timeoutMsg: "the copy menu item never reached the clipboard",
+    });
+    const [text] = await recordedCopies();
+    // Patch shape here, unlike a selection: hunk header, and the +/- prefixes
+    // that make it applicable.
+    expect(text).toContain("@@");
+    expect(text).toContain("-charlie");
+    expect(text).toContain("+gamma");
+  });
+});

--- a/src/design/context-menu.diffcopy.test.tsx
+++ b/src/design/context-menu.diffcopy.test.tsx
@@ -1,0 +1,137 @@
+// The copy entries on a diff's own context menu.
+//
+// A mouse selection in a diff stops at the rendered window, so right-clicking is
+// the discoverable way to copy more than a screenful. The menu offers whichever
+// of the three selections the reader actually has — the text they dragged over,
+// the diff lines they clicked, or the whole file — and never an entry that would
+// put an empty string on the clipboard.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { diffCopyMenuItems, type ContextMenuItem } from "./context-menu";
+import type { FileDiff } from "@/lib/types";
+
+const diff: FileDiff = {
+  path: "a.ts",
+  oldPath: null,
+  binary: false,
+  additions: 2,
+  deletions: 1,
+  hunks: [
+    {
+      header: "@@ -1,2 +1,3 @@",
+      oldStart: 1,
+      oldLines: 2,
+      newStart: 1,
+      newLines: 3,
+      lines: [
+        { kind: { kind: "Context" }, oldLineno: 1, newLineno: 1, content: "base\n" },
+        { kind: { kind: "Deletion" }, oldLineno: 2, newLineno: null, content: "gone\n" },
+        { kind: { kind: "Addition" }, oldLineno: null, newLineno: 2, content: "add1\n" },
+        { kind: { kind: "Addition" }, oldLineno: null, newLineno: 3, content: "add2\n" },
+      ],
+    },
+  ],
+};
+
+const copied: string[] = [];
+
+const labels = (items: ContextMenuItem[]) =>
+  items.filter((i) => !i.divider && !i.__menuTitle).map((i) => String(i.label));
+
+const click = async (items: ContextMenuItem[], label: string) => {
+  const item = items.find((i) => String(i.label) === label);
+  expect(item, `no menu item labelled ${label}`).toBeDefined();
+  await item!.onClick?.();
+};
+
+/** Put a real, non-collapsed selection over `text` in the document. */
+function selectText(text: string) {
+  const host = document.createElement("div");
+  host.textContent = text;
+  document.body.appendChild(host);
+  const range = document.createRange();
+  range.selectNodeContents(host);
+  const sel = window.getSelection()!;
+  sel.removeAllRanges();
+  sel.addRange(range);
+  expect(sel.isCollapsed).toBe(false);
+}
+
+beforeEach(() => {
+  copied.length = 0;
+  window.getSelection()?.removeAllRanges();
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: vi.fn((t: string) => void copied.push(t)) },
+  });
+});
+
+afterEach(() => {
+  window.getSelection()?.removeAllRanges();
+  document.body.innerHTML = "";
+});
+
+describe("diffCopyMenuItems", () => {
+  it("offers only the whole file when nothing is selected", () => {
+    expect(labels(diffCopyMenuItems({ diff }))).toEqual(["Copy file diff as text"]);
+  });
+
+  it("copies the whole file as a patch, headers and prefixes included", async () => {
+    await click(diffCopyMenuItems({ diff }), "Copy file diff as text");
+    expect(copied).toEqual([
+      ["@@ -1,2 +1,3 @@", " base", "-gone", "+add1", "+add2"].join("\n"),
+    ]);
+  });
+
+  it("offers the dragged text when there is a text selection", () => {
+    selectText("some code");
+    expect(labels(diffCopyMenuItems({ diff }))).toEqual([
+      "Copy",
+      "Copy file diff as text",
+    ]);
+  });
+
+  it("copies exactly the dragged text", async () => {
+    selectText("some code");
+    await click(diffCopyMenuItems({ diff }), "Copy");
+    expect(copied).toEqual(["some code"]);
+  });
+
+  it("names the line selection by its size", () => {
+    expect(labels(diffCopyMenuItems({ diff, lineSel: { 0: [1, 2] } }))).toEqual([
+      "Copy 2 selected lines",
+      "Copy file diff as text",
+    ]);
+    expect(labels(diffCopyMenuItems({ diff, lineSel: { 0: [1] } }))).toContain(
+      "Copy 1 selected line",
+    );
+  });
+
+  it("copies the selected lines as bare code", async () => {
+    await click(
+      diffCopyMenuItems({ diff, lineSel: { 0: [0, 2] } }),
+      "Copy 2 selected lines",
+    );
+    expect(copied).toEqual(["gone\nadd2"]);
+  });
+
+  it("offers all three when both kinds of selection exist", () => {
+    selectText("some code");
+    expect(labels(diffCopyMenuItems({ diff, lineSel: { 0: [1] } }))).toEqual([
+      "Copy",
+      "Copy 1 selected line",
+      "Copy file diff as text",
+    ]);
+  });
+
+  it("offers nothing without a diff — an empty menu never opens", () => {
+    expect(diffCopyMenuItems({ diff: null })).toEqual([]);
+    expect(diffCopyMenuItems(null)).toEqual([]);
+  });
+
+  it("ignores an empty line selection", () => {
+    expect(labels(diffCopyMenuItems({ diff, lineSel: { 0: [] } }))).toEqual([
+      "Copy file diff as text",
+    ]);
+  });
+});

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -11,7 +11,8 @@ import { planCommitSelection } from "@/features/commits/planCommitSelection";
 import { headAncestryOf } from "@/features/commits/headAncestry";
 import { runRebasePlanNow } from "@/features/commits/runRebasePlan";
 import { combinedSquashMessage } from "@/features/commits/squashMessage";
-import type { BranchInfo, CommitInfo } from "@/lib/types";
+import type { BranchInfo, CommitInfo, FileDiff } from "@/lib/types";
+import { fileDiffToText, selectedLinesToText } from "@/lib/diffCopy";
 import { orderBranchesGrouped } from "@/features/branches/orderBranches";
 import { openMergeWindow } from "@/features/merge/openMergeWindow";
 import {
@@ -340,6 +341,76 @@ export function useContextMenu<T>(
 // ═════════════════════════════════════════════════════════
 // CONTEXT MENU CONFIGS
 // ═════════════════════════════════════════════════════════
+
+/** What a diff surface knows about the selections a reader could copy. */
+export interface DiffCopyTarget {
+  diff: FileDiff | null;
+  /**
+   * The surface's line selection, hunk index → selected `changedIndex` values.
+   * Omitted by the read-only surfaces, which have no line selection to offer.
+   */
+  lineSel?: Record<number, number[]>;
+}
+
+/**
+ * The copy entries for a diff's own context menu, shared by all four diff
+ * surfaces.
+ *
+ * Right-click is the discoverable half of `diff.copy` (Mod+C): the diff is
+ * windowed, so a mouse selection cannot reach past the rendered rows, and
+ * without these entries there is no way at all to copy a range longer than a
+ * screenful.
+ *
+ * Only the selections that EXIST are offered — an entry that copied an empty
+ * string would be worse than no entry. The text-selection check reads the live
+ * selection, which is correct here because a right-click does not clear one:
+ * this builder runs from the `contextmenu` handler, while the drag's selection
+ * is still on screen.
+ */
+export function diffCopyMenuItems(
+  target: DiffCopyTarget | null,
+): ContextMenuItem[] {
+  const diff = target?.diff;
+  if (!diff) return [];
+  const items: ContextMenuItem[] = [];
+
+  const textSel = window.getSelection();
+  const dragged = textSel && !textSel.isCollapsed ? textSel.toString() : "";
+  if (dragged) {
+    items.push({
+      icon: "copy",
+      label: "Copy",
+      onClick: () => {
+        navigator.clipboard?.writeText(dragged);
+        pgFlash("copied selection");
+      },
+    });
+  }
+
+  const lineSel = target?.lineSel ?? {};
+  const lineCount = Object.values(lineSel).reduce((n, l) => n + l.length, 0);
+  if (lineCount > 0) {
+    items.push({
+      icon: "copy",
+      label: `Copy ${lineCount} selected line${lineCount === 1 ? "" : "s"}`,
+      onClick: () => {
+        navigator.clipboard?.writeText(selectedLinesToText(diff, lineSel));
+        pgFlash(`copied ${lineCount} line${lineCount === 1 ? "" : "s"}`);
+      },
+    });
+  }
+
+  items.push({
+    icon: "copy",
+    label: "Copy file diff as text",
+    onClick: () => {
+      navigator.clipboard?.writeText(fileDiffToText(diff));
+      pgFlash("copied diff");
+    },
+  });
+
+  return items;
+}
 
 export function commitMenuItems(commit: { sha?: string; subject?: string } | null): ContextMenuItem[] {
   const sha = commit?.sha || "—";

--- a/src/design/diffSelection.test.tsx
+++ b/src/design/diffSelection.test.tsx
@@ -1,0 +1,136 @@
+// Diff text is selectable; diff CHROME is not.
+//
+// The app sets `user-select: none` on `body` (index.css) for a native desktop
+// feel, so every surface that wants selectable text opts back in. In a diff that
+// opt-in is deliberately narrow: the code, and nothing else. A selection that
+// swept up the line numbers and the +/- marker would paste as something you have
+// to clean by hand, which defeats the point of being able to copy it.
+//
+// Asserted on the class rather than a computed style because jsdom applies no
+// stylesheet — so this file also pins what `.pg-selectable` MEANS in index.css.
+// The end-to-end proof, in a real WebKit, is e2e/specs/diff-selection.e2e.ts.
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { PGWindowedDiff } from "./PGWindowedDiff";
+import { PGDiffLine, PGSideBySideDiff } from "./git-components";
+import { selectionText } from "@/test/selectionText";
+import { flattenDiffRows } from "@/lib/diffRows";
+import type { FileDiff } from "@/lib/types";
+
+type Line = FileDiff["hunks"][number]["lines"][number];
+
+const lines: Line[] = [
+  { kind: { kind: "Context" }, oldLineno: 1, newLineno: 1, content: "ctx line" },
+  { kind: { kind: "Deletion" }, oldLineno: 2, newLineno: null, content: "removed line" },
+  { kind: { kind: "Addition" }, oldLineno: null, newLineno: 2, content: "added line" },
+];
+
+const rows = () =>
+  flattenDiffRows(
+    [{ header: "@@ -1,2 +1,2 @@", oldStart: 1, oldLines: 2, newStart: 1, newLines: 2, lines }],
+    { foldH: 22, rowH: 19 },
+  );
+
+/** Every element that opts into selection, by the one class that grants it. */
+const selectable = (root: HTMLElement) => root.querySelectorAll(".pg-selectable");
+
+describe(".pg-selectable, the class these surfaces rely on", () => {
+  it("grants text selection in index.css, prefixed and not", () => {
+    const css = fs.readFileSync(
+      path.join(process.cwd(), "src/index.css"),
+      "utf8",
+    );
+    const rule = css.match(/\.pg-selectable\s*\{[^}]*\}|[^}]*\.pg-selectable[^{]*\{[^}]*\}/);
+    expect(rule, ".pg-selectable must exist in index.css").not.toBeNull();
+    expect(rule![0]).toContain("user-select: text");
+    expect(rule![0]).toContain("-webkit-user-select: text");
+  });
+});
+
+describe("PGDiffRow selection (unified diff — DiffViewer, CommitPanel, Compare)", () => {
+  it("makes each row's code text selectable", () => {
+    const { container } = render(<PGWindowedDiff rows={rows()} />);
+    expect([...selectable(container)].map((el) => el.textContent)).toEqual([
+      "ctx line",
+      "removed line",
+      "added line",
+    ]);
+  });
+
+  it("copies the code and none of the chrome", () => {
+    const { container } = render(<PGWindowedDiff rows={rows()} />);
+    // Rows are block-level, so a real engine separates them by a newline; jsdom
+    // has no layout, hence the concatenation. What matters is what is IN it.
+    expect(selectionText(container)).toBe("ctx lineremoved lineadded line");
+  });
+});
+
+describe("PGDiffLine selection (the separator/info renderer)", () => {
+  it("makes its code text selectable and its gutters not", () => {
+    const { container } = render(
+      <PGDiffLine kind="add" lnL={undefined} lnR={7} text="added line" />,
+    );
+    expect([...selectable(container)].map((el) => el.textContent)).toEqual([
+      "added line",
+    ]);
+    expect(selectionText(container)).toBe("added line");
+  });
+});
+
+describe("selecting text vs staging a line", () => {
+  afterEach(() => window.getSelection()?.removeAllRanges());
+
+  const clickFirstChanged = (onLineClick: (h: number, c: number) => void) => {
+    const r = render(<PGWindowedDiff rows={rows()} onLineClick={onLineClick} />);
+    const changed = r.container.querySelectorAll('[data-testid="diff-line-changed"]');
+    return { ...r, changed };
+  };
+
+  it("still stages the line a plain click lands on", () => {
+    const clicks: number[][] = [];
+    const { changed } = clickFirstChanged((h, c) => clicks.push([h, c]));
+    fireEvent.click(changed[0]);
+    expect(clicks).toEqual([[0, 0]]);
+  });
+
+  // The click that ends a drag-selection fires on the row the pointer came up
+  // over, so without this guard copying a line would silently stage it. A plain
+  // click cannot trip the guard: mousedown collapses any existing selection
+  // before the click event runs, so only a drag arrives here with text selected.
+  it("does not stage the line a drag-selection ended on", () => {
+    const clicks: number[][] = [];
+    const { container, changed } = clickFirstChanged((h, c) => clicks.push([h, c]));
+    const range = document.createRange();
+    range.selectNodeContents(container.querySelector(".pg-selectable")!);
+    window.getSelection()!.addRange(range);
+    fireEvent.click(changed[0]);
+    expect(clicks).toEqual([]);
+  });
+});
+
+describe("PGSideBySideDiff selection (split view)", () => {
+  it("makes both columns' code text selectable", () => {
+    const { container } = render(
+      <PGSideBySideDiff
+        left={[{ kind: "rem", ln: 2, text: "removed line" }]}
+        right={[{ kind: "add", ln: 2, text: "added line" }]}
+      />,
+    );
+    expect([...selectable(container)].map((el) => el.textContent)).toEqual([
+      "removed line",
+      "added line",
+    ]);
+  });
+
+  it("copies each column's code and neither line number", () => {
+    const { container } = render(
+      <PGSideBySideDiff
+        left={[{ kind: "rem", ln: 2, text: "removed line" }]}
+        right={[{ kind: "add", ln: 2, text: "added line" }]}
+      />,
+    );
+    expect(selectionText(container)).toBe("removed lineadded line");
+  });
+});

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -630,7 +630,11 @@ export function PGDiffLine({
       >
         {marker[kind]}
       </span>
+      {/* The one selectable cell in the row: the code, without the gutters
+          above, so a copied block pastes as source. `.pg-selectable` (index.css)
+          opts back in from the app-wide `user-select: none`. */}
       <span
+        className="pg-selectable"
         style={{
           flex: 1,
           whiteSpace: "pre-wrap",
@@ -778,7 +782,17 @@ export const PGDiffRow = React.memo(function PGDiffRow({
           data-focused={focused || undefined}
           onClick={
             selectable
-              ? (e) => onLineClick!(ln.changedIndex!, e.shiftKey)
+              ? (e) => {
+                  // The click that ends a drag fires on the row the pointer came
+                  // up over, so copying a line by dragging across it would
+                  // otherwise stage that line too. A selection means the gesture
+                  // was a drag, not a click: mousedown collapses any earlier
+                  // selection before this runs, so a genuine click always sees a
+                  // collapsed one and never trips this.
+                  const sel = window.getSelection();
+                  if (sel && !sel.isCollapsed) return;
+                  onLineClick!(ln.changedIndex!, e.shiftKey);
+                }
               : undefined
           }
           style={{
@@ -861,7 +875,12 @@ export const PGDiffRow = React.memo(function PGDiffRow({
           >
             {marker[kind]}
           </span>
+          {/* Selectable, unlike the three gutter cells above: a drag over the
+              diff yields bare code, no line numbers and no +/- marker. Windowing
+              caps how far one selection can reach (only the rendered rows are in
+              the DOM) - `diff.copy` is the path for anything longer. */}
           <span
+            className="pg-selectable"
             style={{
               flex: 1,
               // `pre`, not `pre-wrap`: this row's height is the window's pitch,
@@ -1085,9 +1104,17 @@ export interface SideLine {
 export function PGSideBySideDiff({
   left = [],
   right = [],
+  onContextMenu,
 }: {
   left?: SideLine[];
   right?: SideLine[];
+  /**
+   * Right-click anywhere in either column — the diff copy menu. A prop rather
+   * than a wrapper element at the call sites: this component's root already holds
+   * the `flex: 1; min-height: 0` slot, and an extra div in that chain is a layout
+   * change for nothing.
+   */
+  onContextMenu?: React.MouseEventHandler<HTMLDivElement>;
 }) {
   const col = (lines: SideLine[], side: "l" | "r") => (
     <div
@@ -1127,11 +1154,16 @@ export function PGSideBySideDiff({
                 color: "var(--fg-3)",
                 borderRight: "1px solid var(--border-0)",
                 flexShrink: 0,
+                // Out of every selection, like the unified view's gutters: a
+                // selection dragged down a split column is code, not code with a
+                // line number wedged into each row.
+                userSelect: "none",
               }}
             >
               {ln.ln ?? ""}
             </span>
             <span
+              className="pg-selectable"
               style={{
                 flex: 1,
                 padding: "0 8px",
@@ -1157,7 +1189,10 @@ export function PGSideBySideDiff({
     </div>
   );
   return (
-    <div style={{ display: "flex", flex: 1, minHeight: 0 }}>
+    <div
+      style={{ display: "flex", flex: 1, minHeight: 0 }}
+      onContextMenu={onContextMenu}
+    >
       {col(left, "l")}
       {col(right, "r")}
     </div>

--- a/src/features/diff/CommitDiffPanel.selection.test.tsx
+++ b/src/features/diff/CommitDiffPanel.selection.test.tsx
@@ -1,0 +1,82 @@
+// CommitDiffPanel is the fourth diff surface and the only one with its own row
+// markup (the other three go through PGDiffRow). The selection contract is the
+// same one src/design/diffSelection.test.tsx pins for those: the code is
+// selectable, the +/- marker is not, so a copied block pastes as source.
+//
+// This panel has no line-number gutter, so its marker is the whole of its
+// chrome — and it used to be a bare text node inside the row, which a selection
+// would have swept up.
+import { beforeEach, describe, expect, it } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { resetInvokeMock } from "@/test/invokeMock";
+import { selectionText } from "@/test/selectionText";
+import { CommitDiffPanel } from "./CommitDiffPanel";
+import type { FileDiff } from "@/lib/types";
+
+const diffs: FileDiff[] = [
+  {
+    path: "a.ts",
+    oldPath: null,
+    binary: false,
+    additions: 1,
+    deletions: 1,
+    hunks: [
+      {
+        header: "@@ -1,2 +1,2 @@",
+        oldStart: 1,
+        oldLines: 2,
+        newStart: 1,
+        newLines: 2,
+        lines: [
+          { kind: { kind: "Context" }, oldLineno: 1, newLineno: 1, content: "ctx line" },
+          { kind: { kind: "Deletion" }, oldLineno: 2, newLineno: null, content: "removed line" },
+          { kind: { kind: "Addition" }, oldLineno: null, newLineno: 2, content: "added line" },
+        ],
+      },
+    ],
+  },
+];
+
+beforeEach(() => {
+  resetInvokeMock();
+});
+
+async function renderPanel(paneIdPrefix: string) {
+  const r = render(
+    <CommitDiffPanel
+      diffs={diffs}
+      loading={false}
+      error={null}
+      header="x → y"
+      paneIdPrefix={paneIdPrefix}
+    />,
+  );
+  await waitFor(() =>
+    expect(r.container.querySelectorAll("[data-hunk-index]").length).toBe(1),
+  );
+  return r;
+}
+
+describe("CommitDiffPanel selection", () => {
+  it("makes each row's code text selectable", async () => {
+    const { container } = await renderPanel("sel1");
+    expect(
+      [...container.querySelectorAll(".pg-selectable")].map((el) => el.textContent),
+    ).toEqual(["ctx line", "removed line", "added line"]);
+  });
+
+  it("copies the code and none of the +/- markers", async () => {
+    const { container } = await renderPanel("sel2");
+    const copied = selectionText(container);
+    expect(copied).toContain("removed line");
+    expect(copied).toContain("added line");
+    expect(copied).not.toContain("-removed");
+    expect(copied).not.toContain("+added");
+  });
+
+  it("still shows the marker on screen", async () => {
+    const { container } = await renderPanel("sel3");
+    expect(container.textContent).toContain("-removed line");
+    expect(container.textContent).toContain("+added line");
+  });
+});

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -4,6 +4,8 @@ import {
   PGIcon,
   PGResizeHandle,
   PGSkeleton,
+  diffCopyMenuItems,
+  useContextMenu,
   usePaneSize,
   type DiffLineData,
 } from "@/design";
@@ -164,6 +166,13 @@ export function CommitDiffPanel({
   // Fall back to the first file so the diff pane is populated immediately when
   // a new diff arrives, before the selection-sync effect runs.
   const current = shown.find((d) => d.path === selected) ?? shown[0] ?? null;
+
+  // Right-click to copy. This panel is the read-only diff behind Compare,
+  // CommitDiff and History, so there is no line selection to offer — the dragged
+  // text and the whole file, which is the part a windowed selection cannot reach.
+  const diffCopyMenu = useContextMenu<void>(() =>
+    diffCopyMenuItems({ diff: current }),
+  );
 
   const syntax = useDiffSyntax({
     repoId: syntaxSides?.repoId ?? null,
@@ -452,6 +461,7 @@ export function CommitDiffPanel({
             onDiffScroll();
             remeasure();
           }}
+          onContextMenu={(e) => diffCopyMenu.onContextMenu(e, undefined)}
         >
           {loading && (
             // Code lines, not list rows: --lh-code owns diff geometry, so this
@@ -520,8 +530,16 @@ export function CommitDiffPanel({
                         : "var(--fg-0)",
                 }}
               >
-                {kind === "add" ? "+" : kind === "rem" ? "-" : " "}
-                <CommitDiffRowText line={row.line} />
+                {/* The marker is this panel's whole gutter (there are no line
+                    numbers here), and it is chrome: out of every selection, so a
+                    drag over the diff copies bare code. Was a loose text node,
+                    which a selection swept up. */}
+                <span style={{ userSelect: "none" }}>
+                  {kind === "add" ? "+" : kind === "rem" ? "-" : " "}
+                </span>
+                <span className="pg-selectable">
+                  <CommitDiffRowText line={row.line} />
+                </span>
               </div>
             );
             // The anchor row is where F7 addresses this hunk, since #157.
@@ -550,6 +568,7 @@ export function CommitDiffPanel({
           containerHeight={diffBox.height}
         />
         </div>
+        {diffCopyMenu.menu}
       </PGPane>
     </div>
   );

--- a/src/features/dnd/dnd.selection.test.tsx
+++ b/src/features/dnd/dnd.selection.test.tsx
@@ -1,0 +1,117 @@
+// A drag must not smear a text selection across the diff.
+//
+// `beginDrag` does not `preventDefault` on pointerdown (it cannot: the gesture is
+// only a drag once it clears the slop, and until then the event still has to
+// behave like a click), so the guard against selecting while dragging has always
+// been `document.body.style.userSelect = "none"`.
+//
+// That guard stopped being sufficient the moment the diff opted its code cells
+// back IN with `.pg-selectable` — a class on the span beats an inherited value
+// from body, so dragging a file row across the diff would select code. The body
+// marker plus the `[data-pg-dragging]` rule in index.css is what restores it.
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, render } from "@testing-library/react";
+import { beginDrag, useDragStore } from "./dragController";
+
+const DRAGGING_ATTR = "data-pg-dragging";
+
+// MouseEvent, not PointerEvent: jsdom ships no PointerEvent constructor, and the
+// controller only reads button/clientX/clientY/pointerId — the same shape
+// dnd.test.tsx uses. `pointerId` rides along as an extra property, which is what
+// `onMove`'s identity check compares.
+function pointer(type: string, x: number, y: number): MouseEvent {
+  const e = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+    clientX: x,
+    clientY: y,
+  });
+  Object.defineProperty(e, "pointerId", { value: 1 });
+  return e;
+}
+
+function Row() {
+  return (
+    <div
+      data-testid="row"
+      onPointerDown={(e) =>
+        beginDrag(e, {
+          kind: "files",
+          side: "unstaged",
+          paths: ["a.txt"],
+          label: "a.txt",
+        })
+      }
+    >
+      a.txt
+    </div>
+  );
+}
+
+beforeEach(() => {
+  useDragStore.setState({ payload: null, overId: null });
+  document.body.style.userSelect = "";
+  document.body.removeAttribute(DRAGGING_ATTR);
+});
+
+describe("a drag suppresses selection everywhere, including opted-in text", () => {
+  it("marks the document while the drag is live and clears it on drop", () => {
+    const { getByTestId } = render(<Row />);
+    const row = getByTestId("row");
+
+    act(() => {
+      row.dispatchEvent(pointer("pointerdown", 10, 10));
+    });
+    // Below the slop this is still a click, so nothing is suppressed yet.
+    expect(document.body.hasAttribute(DRAGGING_ATTR)).toBe(false);
+
+    act(() => {
+      row.dispatchEvent(pointer("pointermove", 60, 60));
+    });
+    expect(document.body.hasAttribute(DRAGGING_ATTR)).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(pointer("pointerup", 60, 60));
+    });
+    expect(document.body.hasAttribute(DRAGGING_ATTR)).toBe(false);
+  });
+
+  it("clears the mark when the drag is cancelled rather than dropped", () => {
+    const { getByTestId } = render(<Row />);
+    const row = getByTestId("row");
+    act(() => {
+      row.dispatchEvent(pointer("pointerdown", 10, 10));
+      row.dispatchEvent(pointer("pointermove", 60, 60));
+    });
+    expect(document.body.hasAttribute(DRAGGING_ATTR)).toBe(true);
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+    expect(document.body.hasAttribute(DRAGGING_ATTR)).toBe(false);
+  });
+
+  // The marker only does anything because of this rule, and jsdom applies no
+  // stylesheet — so pin the rule itself, the way diffSelection.test.tsx pins
+  // `.pg-selectable`.
+  it("is backed by a rule that overrides .pg-selectable", () => {
+    const css = fs.readFileSync(
+      path.join(process.cwd(), "src/index.css"),
+      "utf8",
+    );
+    const rule = css.match(
+      /body\[data-pg-dragging\][^{]*\.pg-selectable[^{]*\{[^}]*\}/,
+    );
+    expect(
+      rule,
+      "index.css must suppress .pg-selectable while a drag is live",
+    ).not.toBeNull();
+    expect(rule![0]).toContain("user-select: none");
+    expect(rule![0]).toContain("-webkit-user-select: none");
+  });
+});

--- a/src/features/dnd/dragController.ts
+++ b/src/features/dnd/dragController.ts
@@ -202,6 +202,7 @@ function teardown(g: Gesture) {
   mark(g, null);
   removeGhost();
   document.body.style.userSelect = "";
+  document.body.removeAttribute("data-pg-dragging");
   document.body.style.cursor = "";
   window.removeEventListener("pointermove", onMove);
   window.removeEventListener("pointerup", onUp);
@@ -224,6 +225,12 @@ function onMove(e: PointerEvent) {
       return;
     g.moved = true;
     document.body.style.userSelect = "none";
+    // …and the attribute, which is what reaches text that opted back IN to
+    // selection (`.pg-selectable`, the diff's code cells). The inline style above
+    // only sets what body's descendants INHERIT, and a class beats inheritance —
+    // so without this, dragging a row across the diff selects code. See the
+    // `body[data-pg-dragging]` rule in index.css.
+    document.body.setAttribute("data-pg-dragging", "");
     document.body.style.cursor = "grabbing";
     showGhost(g.payload.label, e.clientX, e.clientY);
     useDragStore.setState({ payload: g.payload });

--- a/src/features/keymap/FocusableScroll.tsx
+++ b/src/features/keymap/FocusableScroll.tsx
@@ -16,6 +16,7 @@ export function FocusableScroll({
   testId,
   innerRef,
   onScroll,
+  onContextMenu,
 }: {
   children: React.ReactNode;
   className?: string;
@@ -30,6 +31,12 @@ export function FocusableScroll({
    */
   innerRef?: React.RefObject<HTMLDivElement | null>;
   onScroll?: React.UIEventHandler<HTMLDivElement>;
+  /**
+   * Right-click anywhere in the region. The diff panes use it for their copy
+   * menu, which has to hang off the scroller rather than a row: a diff's rows
+   * are windowed and a reader may right-click the padding below the last one.
+   */
+  onContextMenu?: React.MouseEventHandler<HTMLDivElement>;
 }) {
   const ownRef = React.useRef<HTMLDivElement>(null);
   const ref = innerRef ?? ownRef;
@@ -84,6 +91,7 @@ export function FocusableScroll({
       data-testid={testId}
       onKeyDown={onKeyDown}
       onScroll={onScroll}
+      onContextMenu={onContextMenu}
       style={{ outline: "none", overflow: "auto", ...style }}
     >
       {children}

--- a/src/features/keymap/actions.ts
+++ b/src/features/keymap/actions.ts
@@ -92,6 +92,7 @@ export type ActionId =
   | "diff.viewCombined"
   | "diff.stageHunk"
   | "diff.discardHunk"
+  | "diff.copy"
   | "commit.commit"
   | "commit.commitAndPush"
   | "commit.toggleAmend"
@@ -337,6 +338,21 @@ export const ACTIONS: Record<ActionId, ActionDef> = {
   // no default runner, like the commit.* family.
   "diff.stageHunk": { id: "diff.stageHunk", title: "Stage / unstage hunk", category: "Diff", scope: "pane" },
   "diff.discardHunk": { id: "diff.discardHunk", title: "Discard hunk", category: "Diff", scope: "pane" },
+  // Mod+C over a diff, and it must not stop meaning "copy".
+  //
+  // It exists because the diff surfaces are windowed: only the rendered rows are
+  // in the document, so a mouse selection cannot reach past them, and there was
+  // no way at all to copy a long range. This action copies the selected diff
+  // LINES straight from the row model instead, so the length of the range is
+  // irrelevant.
+  //
+  // Its handler DECLINES (returns false) whenever a text selection exists, and
+  // whenever no lines are selected — declining leaves the chord unhandled, the
+  // dispatcher skips preventDefault, and the webview's own copy runs on the
+  // selection exactly as it would in any other app. Pane-scoped, so it is only
+  // ever offered while a diff pane holds focus; `suppressInInput` keeps it away
+  // from the commit-message textarea, where Mod+C is the caret's.
+  "diff.copy": { id: "diff.copy", title: "Copy selected diff lines", category: "Diff", scope: "pane", suppressInInput: true },
 
   "repo.open": { id: "repo.open", title: "Open repository…", category: "Repository", scope: "global", run: openRepoOp },
   "repo.clone": { id: "repo.clone", title: "Clone repository…", category: "Repository", scope: "global", run: cloneRepoOp },

--- a/src/features/keymap/presets.ts
+++ b/src/features/keymap/presets.ts
@@ -75,6 +75,14 @@ const COMMON = {
   // because both actions are pane-scoped — presets.test.ts only forbids two
   // GLOBAL actions on one chord, and the dispatcher tries each id in turn.
   "diff.toggleLine": [" "],
+  // The ordinary copy key, deliberately. `diff.copy`'s whole job is to extend
+  // Mod+C to a selection the DOM cannot hold — the diff's selected LINES, which
+  // outlive the rendered window — so putting it anywhere else would be a second
+  // key for something the reader already knows how to ask for. It declines
+  // whenever there IS a text selection (and whenever nothing is selected at all),
+  // which leaves the chord unhandled and the webview's native copy in charge, so
+  // this binding never takes Mod+C away from anything.
+  "diff.copy": ["Mod+C"],
   // The History selection's diff, on the same Mod+D as nav.diff (#158). Legal
   // because this one is pane-scoped: the dispatcher tries each id bound to a
   // chord in turn, and the pane handler declines unless the commit list has focus

--- a/src/index.css
+++ b/src/index.css
@@ -233,6 +233,20 @@ textarea,
   -webkit-user-select: text;
 }
 
+/* While a pointer drag is live, nothing is selectable — not even the cells that
+   opted back in above.
+ *
+ * `dragController` has always set `user-select: none` on body for this, because
+ * `beginDrag` cannot preventDefault a pointerdown that is still allowed to end up
+ * a click. That inherited value stopped being enough once the diff's code cells
+ * took a class of their own (a class beats an inherited value), so dragging a file
+ * row across the diff smeared a selection over the code. This rule is the same
+ * intent, at a specificity that reaches the opted-in cells. */
+body[data-pg-dragging] .pg-selectable {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
 .mono { font-family: var(--font-mono); font-feature-settings: "calt", "liga"; }
 .display { font-family: var(--font-display); letter-spacing: -0.01em; }
 

--- a/src/lib/diffCopy.test.ts
+++ b/src/lib/diffCopy.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { fileDiffToText, selectedLinesToText } from "./diffCopy";
+import type { FileDiff } from "./types";
+
+/**
+ * A hunk whose lines carry their trailing newline, the way the backend emits
+ * them — `content` is git's raw line, so every builder here has to normalise it
+ * rather than assume one shape.
+ */
+const hunk = (n: number): FileDiff["hunks"][number] => ({
+  header: `@@ -${n},3 +${n},3 @@`,
+  oldStart: n,
+  oldLines: 3,
+  newStart: n,
+  newLines: 3,
+  lines: [
+    { kind: { kind: "Context" }, oldLineno: n, newLineno: n, content: "ctx\n" },
+    { kind: { kind: "Deletion" }, oldLineno: n + 1, newLineno: null, content: "old\n" },
+    { kind: { kind: "Addition" }, oldLineno: null, newLineno: n + 1, content: "new\n" },
+  ],
+});
+
+const diff = (hunks: FileDiff["hunks"]): FileDiff => ({
+  path: "a.ts",
+  oldPath: null,
+  binary: false,
+  additions: 1,
+  deletions: 1,
+  hunks,
+});
+
+describe("fileDiffToText", () => {
+  it("prefixes each line and keeps the hunk header", () => {
+    expect(fileDiffToText(diff([hunk(1)]))).toBe(
+      ["@@ -1,3 +1,3 @@", " ctx", "-old", "+new"].join("\n"),
+    );
+  });
+
+  it("separates hunks by one newline, with no blank line between them", () => {
+    expect(fileDiffToText(diff([hunk(1), hunk(10)]))).toBe(
+      [
+        "@@ -1,3 +1,3 @@",
+        " ctx",
+        "-old",
+        "+new",
+        "@@ -10,3 +10,3 @@",
+        " ctx",
+        "-old",
+        "+new",
+      ].join("\n"),
+    );
+  });
+
+  // The commit-diff builder keeps libgit2's `'H'` line inside `hunks[].lines`
+  // (CLAUDE.md: the two backend builders disagree). Emitting it would print the
+  // `@@` range twice — once as the header, once as a space-prefixed body line.
+  it("drops a HunkHeader line from the body rather than printing @@ twice", () => {
+    const h = hunk(1);
+    h.lines.unshift({
+      kind: { kind: "HunkHeader" },
+      oldLineno: null,
+      newLineno: null,
+      content: "@@ -1,3 +1,3 @@\n",
+    });
+    expect(fileDiffToText(diff([h]))).toBe(
+      ["@@ -1,3 +1,3 @@", " ctx", "-old", "+new"].join("\n"),
+    );
+  });
+
+  it("keeps a line that has no trailing newline intact", () => {
+    const h = hunk(1);
+    h.lines[2] = {
+      kind: { kind: "Addition" },
+      oldLineno: null,
+      newLineno: 2,
+      content: "no-eol",
+    };
+    expect(fileDiffToText(diff([h]))).toBe(
+      ["@@ -1,3 +1,3 @@", " ctx", "-old", "+no-eol"].join("\n"),
+    );
+  });
+
+  it("is empty for a diff with no hunks", () => {
+    expect(fileDiffToText(diff([]))).toBe("");
+  });
+});
+
+describe("selectedLinesToText", () => {
+  // changedIndex counts ADD/REM lines only, per hunk, after the header is
+  // dropped — the same index space the line-staging ops accept.
+  it("returns the bare code of the selected changed lines, no +/- prefix", () => {
+    expect(selectedLinesToText(diff([hunk(1)]), { 0: [0, 1] })).toBe("old\nnew");
+  });
+
+  it("takes one line without its neighbours", () => {
+    expect(selectedLinesToText(diff([hunk(1)]), { 0: [1] })).toBe("new");
+  });
+
+  it("orders by hunk, then by changedIndex, whatever order the set is in", () => {
+    expect(
+      selectedLinesToText(diff([hunk(1), hunk(10)]), { 1: [1, 0], 0: [1] }),
+    ).toBe("new\nold\nnew");
+  });
+
+  it("ignores a changedIndex no line carries", () => {
+    expect(selectedLinesToText(diff([hunk(1)]), { 0: [0, 99] })).toBe("old");
+  });
+
+  it("ignores a hunk index the diff does not have", () => {
+    expect(selectedLinesToText(diff([hunk(1)]), { 7: [0] })).toBe("");
+  });
+
+  it("is empty when nothing is selected", () => {
+    expect(selectedLinesToText(diff([hunk(1)]), {})).toBe("");
+  });
+
+  // A HunkHeader line is not a change, so it must not consume a changedIndex —
+  // otherwise every selection in a commit diff copies the line below the one
+  // the reader clicked.
+  it("does not let a HunkHeader line shift the changedIndex numbering", () => {
+    const h = hunk(1);
+    h.lines.unshift({
+      kind: { kind: "HunkHeader" },
+      oldLineno: null,
+      newLineno: null,
+      content: "@@ -1,3 +1,3 @@\n",
+    });
+    expect(selectedLinesToText(diff([h]), { 0: [0] })).toBe("old");
+  });
+});

--- a/src/lib/diffCopy.ts
+++ b/src/lib/diffCopy.ts
@@ -1,0 +1,84 @@
+// Clipboard text for a diff, built from the MODEL rather than the DOM.
+//
+// Why this exists at all: every diff surface is windowed, so only about a
+// screenful of rows is in the document at any moment. A mouse selection
+// therefore cannot reach past the rendered window — drag far enough and the
+// anchor row unmounts and the selection collapses. These builders are what
+// `diff.copy` and the diff context menu use to put an arbitrarily long range on
+// the clipboard regardless of what is on screen.
+//
+// Both functions normalise line endings themselves: `DiffLine.content` is git's
+// raw line, so it usually carries a trailing "\n" but does NOT for a file with
+// no newline at EOF. Stripping and re-joining is the only way to get a
+// predictable result out of both.
+import { isFileContent } from "./diffRows";
+import type { FileDiff } from "./types";
+
+/** git's raw line, minus the trailing newline it usually carries. */
+function bare(content: string): string {
+  return content.replace(/\r?\n$/, "");
+}
+
+/**
+ * The whole file's diff as patch-shaped text: each hunk's `@@` header, then its
+ * lines under the usual ` `/`-`/`+` prefixes.
+ *
+ * `isFileContent` — shared with the row model — is what keeps the `@@` range
+ * from being printed twice. The commit-diff builder leaves libgit2's
+ * `HunkHeader` line inside `hunks[].lines`, and as a non-add/rem kind it would
+ * otherwise come out space-prefixed directly under the real header.
+ *
+ * No trailing newline: these builders promise "the lines, newline-separated",
+ * and one rule for both of them beats a special case per caller.
+ */
+export function fileDiffToText(diff: FileDiff): string {
+  const out: string[] = [];
+  for (const h of diff.hunks) {
+    out.push(h.header);
+    for (const l of h.lines) {
+      if (!isFileContent(l)) continue;
+      const k = l.kind.kind;
+      const prefix = k === "Addition" ? "+" : k === "Deletion" ? "-" : " ";
+      out.push(`${prefix}${bare(l.content)}`);
+    }
+  }
+  return out.join("\n");
+}
+
+/**
+ * Just the selected changed lines, as bare code — no `+`/`-` prefix and no line
+ * numbers, so the result pastes into a source file as-is. That is the same
+ * promise the on-screen selection makes, where the gutters are `user-select:
+ * none`.
+ *
+ * `sel` is keyed the way `CommitPanel`'s `lineSel` is: hunk index → the
+ * `changedIndex` values selected in it. `changedIndex` counts add/rem lines only,
+ * per hunk, after `isFileContent` has dropped the header — reproduced here
+ * through the same predicate rather than re-derived, because a numbering that
+ * drifts from the row model's would copy the line below the one the reader
+ * clicked.
+ *
+ * Output order is hunk order, then `changedIndex` order, whatever order the
+ * caller's arrays happen to be in: a shift-click range and a set of scattered
+ * ctrl-clicks should paste as the file reads.
+ */
+export function selectedLinesToText(
+  diff: FileDiff,
+  sel: Record<number, number[]>,
+): string {
+  const out: string[] = [];
+  for (let hunkIndex = 0; hunkIndex < diff.hunks.length; hunkIndex++) {
+    const want = sel[hunkIndex];
+    if (!want || want.length === 0) continue;
+    const wanted = new Set(want);
+    let changedIndex = 0;
+    for (const l of diff.hunks[hunkIndex].lines) {
+      if (!isFileContent(l)) continue;
+      const k = l.kind.kind;
+      if (k !== "Addition" && k !== "Deletion") continue;
+      if (wanted.has(changedIndex)) out.push(bare(l.content));
+      changedIndex++;
+    }
+  }
+  return out.join("\n");
+}

--- a/src/lib/diffRows.ts
+++ b/src/lib/diffRows.ts
@@ -112,7 +112,7 @@ export function withChangedIndices(lines: DiffLineData[]): DiffLineData[] {
  * side of a diff and to size a candidate pointer, so this is a frontend-side drop
  * and not a backend change.
  */
-function isFileContent(l: FileDiff["hunks"][number]["lines"][number]): boolean {
+export function isFileContent(l: FileDiff["hunks"][number]["lines"][number]): boolean {
   return l.kind.kind !== "HunkHeader";
 }
 

--- a/src/screens/CommitPanel.copy.test.tsx
+++ b/src/screens/CommitPanel.copy.test.tsx
@@ -1,0 +1,197 @@
+// Mod+C in the diff pane: copy WHAT IS SELECTED, and nothing clever.
+//
+// The diff surfaces are windowed, so a mouse selection cannot reach past the
+// rendered rows. `diff.copy` is the path that can: it copies the selected diff
+// LINES from the model, however many there are and wherever they are.
+//
+// The contract that matters most here is the declining, not the copying. Mod+C
+// must stay the ordinary copy key: whenever there is a text selection, or
+// nothing is selected at all, or focus is anywhere but a diff pane, this action
+// steps aside (`dispatch` returns false → no preventDefault) and the webview's
+// native copy runs untouched.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { CommitPanelScreen } from "./CommitPanel";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { useKeymapStore, useFocusStore } from "@/features/keymap";
+import { mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { settleDiff } from "@/test/settle";
+import { WithDialogs } from "@/test/dialog";
+import type { FileStatus } from "@/lib/types";
+
+const unstaged = (path: string): FileStatus => ({
+  path,
+  worktree: { kind: "Modified" },
+  index: { kind: "Unmodified" },
+  additions: 3,
+  deletions: 0,
+  embedded: false,
+});
+
+/** A leading context line then three additions → changed indices 0,1,2. */
+const diff = (path: string) => ({
+  path,
+  oldPath: null,
+  binary: false,
+  additions: 3,
+  deletions: 0,
+  hunks: [
+    {
+      header: "@@ -1,1 +1,4 @@",
+      oldStart: 1,
+      oldLines: 1,
+      newStart: 1,
+      newLines: 4,
+      lines: [
+        { kind: { kind: "Context" }, oldLineno: 1, newLineno: 1, content: "base\n" },
+        { kind: { kind: "Addition" }, oldLineno: null, newLineno: 2, content: "add1\n" },
+        { kind: { kind: "Addition" }, oldLineno: null, newLineno: 3, content: "add2\n" },
+        { kind: { kind: "Addition" }, oldLineno: null, newLineno: 4, content: "add3\n" },
+      ],
+    },
+  ],
+});
+
+const copied: string[] = [];
+
+/** The Mod+C keydown, as the real dispatcher sees it. */
+const copyChord = (target: EventTarget = document.body) =>
+  ({
+    key: "c",
+    code: "KeyC",
+    metaKey: true,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    preventDefault() {},
+    target,
+  }) as unknown as KeyboardEvent;
+
+function press(e: KeyboardEvent): boolean {
+  let handled = false;
+  act(() => {
+    handled = useKeymapStore.getState().dispatch(e);
+  });
+  return handled;
+}
+
+const changedRows = () => screen.getAllByTestId("diff-line-changed");
+const selCountLabel = () => screen.getByTestId("hunk-stage").textContent ?? "";
+
+/** Select `n` changed lines, waiting for each to register. */
+async function selectLines(indices: number[]) {
+  for (const [i, idx] of indices.entries()) {
+    fireEvent.click(changedRows()[idx]);
+    const want = new RegExp(`${i + 1} lines?`, "i");
+    await waitFor(() => expect(selCountLabel()).toMatch(want));
+  }
+}
+
+async function setup() {
+  resetInvokeMock();
+  copied.length = 0;
+  window.getSelection()?.removeAllRanges();
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: vi.fn((t: string) => void copied.push(t)) },
+  });
+  useSettingsStore.setState({ ignoreWhitespaceInDiff: false });
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
+    status: [unstaged("a.ts")],
+    branches: [],
+    remotes: [],
+    commits: [],
+    loading: false,
+  } as never);
+  mockInvoke("get_diff", (args) => diff(args.path as string));
+  mockInvoke("get_status", () => [unstaged("a.ts")]);
+  mockInvoke("stage_lines", () => undefined);
+  render(
+    <WithDialogs>
+      <CommitPanelScreen />
+    </WithDialogs>,
+  );
+  await screen.findAllByTestId("diff-line-changed");
+  await settleDiff();
+  act(() => {
+    useFocusStore.setState({ focused: "commit.diff" });
+  });
+}
+
+describe("Mod+C in the CommitPanel diff", () => {
+  beforeEach(setup);
+
+  it("copies the selected lines as bare code, in file order", async () => {
+    await selectLines([2, 0]);
+    expect(press(copyChord())).toBe(true);
+    expect(copied).toEqual(["add1\nadd3"]);
+  });
+
+  it("copies one selected line", async () => {
+    await selectLines([1]);
+    expect(press(copyChord())).toBe(true);
+    expect(copied).toEqual(["add2"]);
+  });
+
+  // Every case below must DECLINE, so that Mod+C keeps meaning "copy" — a
+  // handled chord would preventDefault and swallow the native copy.
+  it("declines to the native copy when text is selected", async () => {
+    await selectLines([0]);
+    const code = [...document.querySelectorAll(".pg-selectable")].find(
+      (el) => (el.textContent ?? "").length > 0,
+    )!;
+    const range = document.createRange();
+    range.selectNodeContents(code);
+    const sel = window.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(range);
+    // The premise of the test, asserted rather than assumed: without a live text
+    // selection there is nothing for the action to stand aside for.
+    expect(sel.isCollapsed).toBe(false);
+    expect(press(copyChord())).toBe(false);
+    expect(copied).toEqual([]);
+  });
+
+  it("declines when no lines are selected", () => {
+    expect(press(copyChord())).toBe(false);
+    expect(copied).toEqual([]);
+  });
+
+  it("declines when focus is on another pane", async () => {
+    await selectLines([0]);
+    act(() => {
+      useFocusStore.setState({ focused: "commit.files" });
+    });
+    expect(press(copyChord())).toBe(false);
+    expect(copied).toEqual([]);
+  });
+
+  // Right-click is the discoverable half of the same capability: a reader who
+  // never learns the chord still has to be able to copy more than a screenful.
+  it("offers the line selection on the diff's context menu", async () => {
+    await selectLines([0, 1]);
+    fireEvent.contextMenu(screen.getByLabelText("Diff"));
+    expect(await screen.findByText("Copy 2 selected lines")).toBeTruthy();
+    expect(screen.getByText("Copy file diff as text")).toBeTruthy();
+  });
+
+  it("copies the whole file from that menu", async () => {
+    fireEvent.contextMenu(screen.getByLabelText("Diff"));
+    fireEvent.click(await screen.findByText("Copy file diff as text"));
+    expect(copied).toEqual([
+      ["@@ -1,1 +1,4 @@", " base", "+add1", "+add2", "+add3"].join("\n"),
+    ]);
+  });
+
+  it("declines inside a textarea, so typing a message copies normally", async () => {
+    await selectLines([0]);
+    const ta = document.createElement("textarea");
+    document.body.appendChild(ta);
+    expect(press(copyChord(ta))).toBe(false);
+    expect(copied).toEqual([]);
+    ta.remove();
+  });
+});

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -22,6 +22,7 @@ import {
   pgFlash,
   pgPrompt,
   useContextMenu,
+  diffCopyMenuItems,
   usePaneSize,
   PANE_HANDLE_PX,
   type PGFileTreeNode,
@@ -73,6 +74,7 @@ import {
   scrollTopForAnchor,
   scrollTopForRow,
 } from "@/lib/diffRows";
+import { fileDiffToText, selectedLinesToText } from "@/lib/diffCopy";
 import { useVariableWindow } from "@/lib/useVariableWindow";
 import { useViewportH } from "@/lib/useViewportH";
 import { useElementSize } from "@/lib/useElementSize";
@@ -230,19 +232,7 @@ export function CommitPanelScreen() {
         label: "Copy diff as text",
         onClick: () => {
           if (!p?.diff) return;
-          const text = p.diff.hunks
-            .map(
-              (h) =>
-                `${h.header}\n${h.lines
-                  .map((ln) => {
-                    const k = ln.kind.kind;
-                    const prefix = k === "Addition" ? "+" : k === "Deletion" ? "-" : " ";
-                    return `${prefix}${ln.content}`;
-                  })
-                  .join("")}`,
-            )
-            .join("\n");
-          navigator.clipboard?.writeText(text);
+          navigator.clipboard?.writeText(fileDiffToText(p.diff));
           pgFlash("copied diff");
         },
       },
@@ -930,6 +920,39 @@ export function CommitPanelScreen() {
     { paneId: "commit.diff" },
   );
 
+  // Right-click anywhere in the diff: the discoverable half of `diff.copy`. This
+  // is the one surface with a line selection, so it is the one whose menu can
+  // offer it.
+  const diffCopyMenu = useContextMenu<void>(() =>
+    diffCopyMenuItems({ diff, lineSel }),
+  );
+
+  // Mod+C over the diff: copy the LINE selection, which a DOM selection cannot
+  // express — the diff is windowed, so the rows outside the viewport are not in
+  // the document and a mouse selection stops at the window's edge.
+  //
+  // Declines in both of the cases where the reader means the ordinary copy: when
+  // text is selected (the drag they just finished — the webview copies it, and
+  // gets the gutters' `user-select: none` treatment for free), and when nothing
+  // is selected at all. Declining is what keeps Mod+C from being swallowed here:
+  // the dispatcher only calls preventDefault on a handled chord.
+  useAction(
+    "diff.copy",
+    () => {
+      const textSel = window.getSelection();
+      if (textSel && !textSel.isCollapsed) return false;
+      if (!diff) return false;
+      const text = selectedLinesToText(diff, lineSel);
+      if (!text) return false;
+      navigator.clipboard?.writeText(text);
+      const n = text.split("\n").length;
+      pgFlash(`copied ${n} line${n === 1 ? "" : "s"}`);
+      return true;
+    },
+    [diff, lineSel],
+    { paneId: "commit.diff" },
+  );
+
   const headBranch = currentBranch(branches);
   const defaultRemote = remotes[0] ?? null;
 
@@ -1366,6 +1389,7 @@ export function CommitPanelScreen() {
             onDiffScroll();
             remeasureDiff();
           }}
+          onContextMenu={(e) => diffCopyMenu.onContextMenu(e, undefined)}
         >
           {diffLoading && (
             <div
@@ -1438,6 +1462,7 @@ export function CommitPanelScreen() {
         )}
         </div>
         {moreMenu.menu}
+        {diffCopyMenu.menu}
       </PGPane>
 
       <PGResizeHandle

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -12,6 +12,8 @@ import {
   PGStatusMark,
   PGToggle,
   PGToolbar,
+  diffCopyMenuItems,
+  useContextMenu,
   usePaneSize,
   type SideLine,
 } from "@/design";
@@ -165,6 +167,14 @@ export function DiffViewerScreen() {
       .filter((h) => h.lines.length > 0);
     return { ...diff, hunks };
   }, [diff, findQuery]);
+
+  // Right-click to copy. A read-only surface, so there is no line selection to
+  // offer — just the dragged text and the whole file, which is the part a
+  // windowed selection cannot reach. Built off `findFiltered` so Find narrowing
+  // the diff narrows what "copy the file" means, matching what is on screen.
+  const diffCopyMenu = useContextMenu<void>(() =>
+    diffCopyMenuItems({ diff: findFiltered }),
+  );
 
   const split = React.useMemo(() => diffToSplit(findFiltered), [findFiltered]);
 
@@ -578,6 +588,7 @@ export function DiffViewerScreen() {
                   onDiffScroll();
                   remeasure();
                 }}
+                onContextMenu={(e) => diffCopyMenu.onContextMenu(e, undefined)}
               >
                 {findFiltered.hunks.length === 0 && findQuery.trim() && (
                   <PGEmpty icon="search" title="No matches" />
@@ -610,8 +621,10 @@ export function DiffViewerScreen() {
             <PGSideBySideDiff
               left={splitWithSyntax.left}
               right={splitWithSyntax.right}
+              onContextMenu={(e) => diffCopyMenu.onContextMenu(e, undefined)}
             />
           )}
+          {diffCopyMenu.menu}
         </PGPane>
       </div>
     </>

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -21,6 +21,7 @@ import {
   flattenFileTree,
   multiFileMenuItems,
   pgConfirm,
+  diffCopyMenuItems,
   useContextMenu,
   usePaneSize,
   PANE_HANDLE_PX,
@@ -587,6 +588,11 @@ export function RepoBrowserScreen() {
     searchText: (i) => rowOrder[i]?.replace(/^\//, "") ?? "",
   });
 
+  // Right-click in the preview pane to copy. Read-only, so no line selection to
+  // offer — the dragged text and the whole file, which is the part a windowed
+  // selection cannot reach.
+  const diffCopyMenu = useContextMenu<void>(() => diffCopyMenuItems({ diff }));
+
   const fileCtx = useContextMenu<{ key: string; node: PGFileTreeNode }>(
     ({ key, node }) => {
       if (sel.keys.length > 1 && sel.keys.includes(key)) {
@@ -1021,6 +1027,7 @@ export function RepoBrowserScreen() {
               window={treeWin}
             />
             {fileCtx.menu}
+            {diffCopyMenu.menu}
           </div>
           <StageDropBar onDrop={onStageBarDrop} />
         </PGPane>
@@ -1139,6 +1146,7 @@ export function RepoBrowserScreen() {
               onDiffScroll();
               remeasureDiff();
             }}
+            onContextMenu={(e) => diffCopyMenu.onContextMenu(e, undefined)}
           >
             {!selectedFile && (
               <PGEmpty

--- a/src/test/selectionText.ts
+++ b/src/test/selectionText.ts
@@ -1,0 +1,28 @@
+/**
+ * What a select-all-and-copy over `root` would put on the clipboard.
+ *
+ * jsdom applies no stylesheet and implements no selection, so a test cannot ask
+ * it what a drag would pick up. This walks the tree the way the engine does
+ * instead: a text node counts unless something between it and `root` switches
+ * selection off.
+ *
+ * Deliberately models INLINE `user-select` only. That is what the diff rows use
+ * for their gutters (`git-components.tsx`), and it keeps the helper honest about
+ * its own limits: a rule that lives in a stylesheet is invisible here, so the
+ * class that GRANTS selection (`.pg-selectable`) is asserted separately, and the
+ * end-to-end proof lives in the e2e suite against a real WebKit.
+ */
+export function selectionText(root: Element): string {
+  let out = "";
+  const walk = (node: Node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      out += node.textContent ?? "";
+      return;
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) return;
+    if ((node as HTMLElement).style?.userSelect === "none") return;
+    for (const child of node.childNodes) walk(child);
+  };
+  for (const child of root.childNodes) walk(child);
+  return out;
+}

--- a/test/diffCopyMenu.test.ts
+++ b/test/diffCopyMenu.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment node
+ */
+// "Every diff surface offers the copy menu."
+//
+// A diff's text is selectable, but the surfaces are WINDOWED: only the rendered
+// rows are in the document, so a mouse selection stops at the edge of the
+// viewport and there is no way to drag over a range longer than a screenful.
+// `diffCopyMenuItems` is the answer to that, and a surface that forgets to wire
+// it is a surface where a long diff simply cannot be copied — which looks like
+// nothing at all, not like a bug, until someone tries.
+//
+// So this guards the wiring rather than the behaviour: the behaviour is pinned by
+// `src/design/context-menu.diffcopy.test.tsx` (the builder), and end to end by
+// `src/screens/CommitPanel.copy.test.tsx` and
+// `src/features/diff/CommitDiffPanel.selection.test.tsx`. What no rendering test
+// can catch is a FIFTH diff surface arriving without the menu, which is exactly
+// the mistake this file fails the build for.
+//
+// Lives at the repo root, beside `nativeSelect.test.ts`, because it reads source
+// TEXT rather than rendering anything — a node test in the `docs` vitest project.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Every file that renders diff rows.
+ *
+ * Three go through `PGWindowedDiff`; `CommitDiffPanel` has its own lighter
+ * markup and is itself rendered by Compare, CommitDiff and History, so wiring it
+ * once covers those three screens.
+ */
+const DIFF_SURFACES = [
+  "src/screens/CommitPanel.tsx",
+  "src/screens/DiffViewer.tsx",
+  "src/screens/RepoBrowser.tsx",
+  "src/features/diff/CommitDiffPanel.tsx",
+];
+
+const read = (p: string) => readFileSync(resolve(process.cwd(), p), "utf8");
+
+describe("the diff copy menu reaches every diff surface", () => {
+  it.each(DIFF_SURFACES)("%s builds the copy menu", (file) => {
+    expect(read(file)).toContain("diffCopyMenuItems");
+  });
+
+  it.each(DIFF_SURFACES)("%s opens it on right-click", (file) => {
+    expect(read(file)).toContain("onContextMenu");
+  });
+
+  // The list above is only as good as its completeness, so pin what defines it:
+  // if a new file starts rendering diff rows, it has to be named here too.
+  it("names every PGWindowedDiff caller", () => {
+    const callers = DIFF_SURFACES.filter((f) => read(f).includes("PGWindowedDiff"));
+    expect(callers.sort()).toEqual(
+      [
+        "src/screens/CommitPanel.tsx",
+        "src/screens/DiffViewer.tsx",
+        "src/screens/RepoBrowser.tsx",
+      ].sort(),
+    );
+  });
+});


### PR DESCRIPTION
The diff viewers were unselectable: `body` is `user-select: none` for a native desktop feel, and no diff surface opted back in. Each row's code cell now carries `.pg-selectable` — the escape hatch `index.css` already defined and nothing used — while the line-number cells and the `+`/`−` marker keep `user-select: none`, so a copied block pastes as source rather than as text you have to clean by hand.

All four surfaces get it, including `CommitDiffPanel`, whose marker was a loose text node a selection swept up.

## Copying past the window

A mouse selection cannot leave the rendered window: the surfaces are windowed, so rows outside the viewport are not in the document and a drag stops at the edge (overscan 8). Two paths build their text from the **row model** instead, which has no such ceiling:

- **`diff.copy` (Mod+C)** — copies the line selection, any size.
- **A right-click menu** on every diff surface — *Copy* / *Copy N selected lines* / *Copy file diff as text*.

**Mod+C keeps meaning "copy".** `diff.copy` declines whenever a text selection exists and whenever nothing is selected, which leaves the chord unhandled so the dispatcher skips `preventDefault` and the webview's own copy runs. Pane-scoped and `suppressInInput` on top, so it never reaches an input or another screen. Four tests pin the declining, which is the half that matters.

A drag-select also ends in a `click` on the row the pointer came up over, so `PGDiffRow` bails on a non-collapsed selection — otherwise copying a line would stage it.

## Two defects fixed on the way

- **`Copy diff as text` printed the `@@` range twice** on a commit diff: it mapped over every line including libgit2's `HunkHeader`, which came out space-prefixed directly under the real header. The shared builder drops it through the same `isFileContent` the row model uses, so `changedIndex` cannot drift from what the renderer numbered either.
- **Opting text back in defeats a body-level `user-select: none`**, because a class beats an inherited value. `dragController` relied on exactly that to stop a row drag from selecting as it moved (it cannot `preventDefault` a pointerdown that may still end up a click), so dragging a file row across the diff would have smeared a selection over the code. It now also marks `body[data-pg-dragging]`, which `index.css` uses to suppress the opted-in cells for the drag's duration.

## Verification

- `pnpm test` — 1836 tests / 213 files green; `pnpm tsc --noEmit` and the e2e typecheck clean.
- `pnpm test:e2e:docker` — full suite, **28/28 spec files passing**. The new spec was then re-certified with a rebuild against the final tree.

Both halves of the feature are engine behaviour a jsdom test cannot reach — the granting rule lives in a stylesheet, and whether `user-select: none` keeps the gutters out of a copy is up to the engine — so `e2e/specs/diff-selection.e2e.ts` measures it in real WebKitGTK. A selection over the diff serialises to the code alone, one row per line, and the spec asserts the raw `Range.toString()` walk **still sees** the line numbers, proving the exclusion is caused by `user-select` rather than by a DOM that never held them.

(An earlier attempt read the payload from a `copy` event; per the Clipboard API that `clipboardData` starts empty and write-only, so it measured nothing. Noted in the spec so it isn't retried.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)