### PR TITLE
fix(diff): centre F7's target change in the pane

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -123,22 +123,48 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   `scrollTopForRow` REVEALS (smallest move that shows the row, no-op when it is
   already visible) — the LINE cursor's, because a cursor stepping one row should
   scroll one row. `scrubScrollTop` (`lib/diffMinimap.ts`) POSITIONS a viewport
-  around a row. `scrollTopForAnchor` PARKS: the row lands `HUNK_LEAD_ROWS × rowH`
-  px below the top of the viewport, ALWAYS — off screen, at an edge, or already
-  comfortably visible. That is F7/⇧F7's landing and the auto-open's, and the
-  unconditional move is the point: under reveal semantics F7 walking forward
-  pinned every change to the BOTTOM edge with no following context, and one
-  keypress meant two different things depending on where the last one left the
-  pane. Three details are load-bearing: the lead is PIXELS (the height of the
-  four preceding rows would let one tall fold separator eat it); the result is
-  clamped to `[0, sum(heights) − viewportH]`, because overshooting is clamped by
-  the DOM and every `scrollToHunk` reads `scrollTop !== want` as "the reveal did
-  not land", costing the file its auto-open; and the lead itself is capped at
-  `viewportH − rowH` so a short pane degrades to "flush with the top" rather than
-  parking the target off its own bottom edge. `DiffViewer`'s wrap mode measures
-  the mounted row's rect instead (heights describe nothing there) — same rule,
-  different ruler. The merge window's F7 walks conflict regions through
-  CodeMirror and shares none of this.
+  around a row. `scrollTopForHunk` CENTRES: the midpoint of the hunk's changed
+  extent lands on the midpoint of the viewport, ALWAYS — off screen, at an edge,
+  or already comfortably visible. That is F7/⇧F7's landing and the auto-open's,
+  and the unconditional move is the point: under reveal semantics F7 walking
+  forward pinned every change to the BOTTOM edge with no following context, and
+  one keypress meant two different things depending on where the last one left
+  the pane. The visible consequence is that F7 scrolls even when the next hunk
+  was already on screen — accepted, in exchange for every change landing in the
+  same place.
+- **The extent is `hunkExtentRows`: a hunk's FIRST changed row through its
+  LAST**, context between two change runs included (git merges runs less than
+  2 × `-U` apart into one hunk, so an extent is not necessarily solid `+`/`-`).
+  Not the whole hunk — its leading and trailing context would drag the midpoint
+  off the change. `first` is the anchor row, so this subsumed the old
+  `hunkAnchorRows`. Both ends are stamped into the DOM (`data-hunk-index`,
+  `data-hunk-last-index`); one row wears both markers for a one-line change.
+  Five details in `scrollTopForHunk` are load-bearing:
+  - A change TALLER than the viewport cannot be centred without hiding its own
+    start, so it degrades to parking its top `HUNK_LEAD_ROWS × rowH` px down.
+    That is the only surviving use of the constant, and the `extentH >
+    viewportH` test is deliberately a hard branch: the tempting branchless form
+    `min(centre, top − lead)` starts top-parking at `extentH > viewportH − 2 ×
+    lead` and shoves the bottom of a change that still fits off the screen.
+  - That lead is PIXELS — the height of the four preceding rows would let one
+    tall fold separator eat it — and is capped at `viewportH − rowH`, so a short
+    pane degrades to "flush with the top", never to "not on screen".
+  - The result snaps to a row boundary (ties DOWN), so neither edge of the
+    viewport shows a half-sliced line, as every `rowOffset`-based target always
+    did.
+  - It is then clamped to `[0, sum(heights) − viewportH]`: overshooting is
+    clamped by the DOM, and every `scrollToHunk` reads `scrollTop !== want` as
+    "the reveal did not land", costing the file its auto-open.
+  - That clamp is also why a hunk within half a viewport of either END of the
+    file does not land centred. Nothing is wrong; no scroll position would put
+    it there. Buying one with scroll-past-end padding would break
+    `contentH === sum(heights)`, which is true by construction only because
+    `PGWindowedDiff` renders exactly `topPad + rows + bottomPad`.
+
+  `DiffViewer`'s wrap mode measures the two marked rows' rects instead (heights
+  describe nothing there) — same rule, different ruler, minus the row-boundary
+  snap, since wrapped rows have no uniform pitch to snap to. The merge window's
+  F7 walks conflict regions through CodeMirror and shares none of this.
 - **A diff OPENS at its first change, and F7 carries into the next file**
   (issue 188). Both live in `useHunkNav`, not per screen. The parts:
   - The auto-open waits on `diffOpenReady` (`features/diff/useDiffGaps.ts`):

--- a/src/design/PGWindowedDiff.test.tsx
+++ b/src/design/PGWindowedDiff.test.tsx
@@ -91,6 +91,21 @@ describe("PGWindowedDiff", () => {
     expect(anchor?.textContent).toContain("line 0");
   });
 
+  it("marks the extent's LAST changed row too, which is what wrap mode measures", () => {
+    // The far end of the span F7 centres. `heights` describes nothing in wrap
+    // mode, so the DOM is the only ruler there — and every row between the two
+    // markers is anonymous.
+    render(<PGWindowedDiff rows={rows} />);
+    const last = document.querySelectorAll('[data-hunk-last-index="0"]');
+    expect(last).toHaveLength(1);
+    // Row 48 is the fixture's final addition; row 49 is context and is outside
+    // the extent.
+    expect(last[0].textContent).toContain("line 48");
+    // It is NOT the anchor host: the cursor and the action cluster stay on the
+    // first changed row.
+    expect(last[0].getAttribute("data-hunk-index")).toBeNull();
+  });
+
   it("puts exactly one anchor host in the DOM per hunk", () => {
     render(<PGWindowedDiff rows={rows} />);
     expect(document.querySelectorAll("[data-hunk-index]")).toHaveLength(1);

--- a/src/design/PGWindowedDiff.tsx
+++ b/src/design/PGWindowedDiff.tsx
@@ -134,20 +134,27 @@ export function PGWindowedDiff({
             }
           />
         );
-        if (!row.hunkAnchor) return line;
+        if (!row.hunkAnchor && !row.hunkLast) return line;
         // The anchor row is the hunk's addressable host: F7's cursor lands here
-        // and the action cluster hangs off it. `position: relative` only — the
-        // wrapper must not add height, or the window's arithmetic goes out of
-        // step with what is rendered.
+        // and the action cluster hangs off it. The LAST changed row is the far
+        // end of the extent F7 centres, and gets a marker of its own so wrap
+        // mode — which has no usable `heights` — can measure that extent from
+        // the DOM. One row carries both markers when the hunk changes a single
+        // line, which is why this is one branch and not two. `position:
+        // relative` only — the wrapper must not add height, or the window's
+        // arithmetic goes out of step with what is rendered.
         return (
           <div
             key={`a${start + i}`}
-            data-hunk-index={row.hunkIndex}
-            data-hunk-active={activeHunk === row.hunkIndex ? "" : undefined}
+            data-hunk-index={row.hunkAnchor ? row.hunkIndex : undefined}
+            data-hunk-active={
+              row.hunkAnchor && activeHunk === row.hunkIndex ? "" : undefined
+            }
+            data-hunk-last-index={row.hunkLast ? row.hunkIndex : undefined}
             style={{ position: "relative" }}
           >
             {line}
-            {actions && (actions.onStage || actions.onDiscard) && (
+            {row.hunkAnchor && actions && (actions.onStage || actions.onDiscard) && (
               <PGHunkActions
                 {...actions}
                 selCount={sel.length}

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -19,8 +19,8 @@ import { SignatureBadge } from "@/features/signing/SignatureBadge";
 import { useDiffSyntax, usePrefetchSyntax, type SideSource } from "@/lib/syntax";
 import {
   flattenDiffRows,
-  hunkAnchorRows,
-  scrollTopForAnchor,
+  hunkExtentRows,
+  scrollTopForHunk,
 } from "@/lib/diffRows";
 import { useVariableWindow } from "@/lib/useVariableWindow";
 import { useViewportH } from "@/lib/useViewportH";
@@ -242,16 +242,15 @@ export function CommitDiffPanel({
 
   // F7/⇧F7. The cursor lands on each hunk's ANCHOR row — its first changed line —
   // and scrolling goes BY OFFSET, because that row is usually unmounted (#157).
-  const anchorRows = React.useMemo(() => hunkAnchorRows(rows), [rows]);
+  const extents = React.useMemo(() => hunkExtentRows(rows), [rows]);
   const scrollToHunk = React.useCallback(
     (hunkIndex: number): boolean => {
       const el = scrollRef.current;
-      const rowIndex = anchorRows[hunkIndex];
-      if (!el || rowIndex == null || rowIndex < 0) return false;
+      const extent = extents[hunkIndex];
+      if (!el || extent == null || extent.first < 0) return false;
       // Through the window's own setter — see `useVariableWindow.scrollTo`.
-      // PARKED a fixed lead below the top, never merely revealed: see
-      // `scrollTopForAnchor`.
-      const want = scrollTopForAnchor(heights, rowIndex, {
+      // CENTRED on the change, never merely revealed: see `scrollTopForHunk`.
+      const want = scrollTopForHunk(heights, extent, {
         scrollTop: el.scrollTop,
         viewportH: el.clientHeight,
         rowH,
@@ -262,7 +261,7 @@ export function CommitDiffPanel({
       // file having been opened — see `useHunkNav`'s `scrollToHunk`.
       return Math.abs(el.scrollTop - want) <= 1;
     },
-    [anchorRows, heights, rowH, scrollDiffTo],
+    [extents, heights, rowH, scrollDiffTo],
   );
   const hunkCursor = useHunkNav({
     paneIds: [filesPaneId, viewPaneId],

--- a/src/features/diff/CommitDiffPanel.window.test.tsx
+++ b/src/features/diff/CommitDiffPanel.window.test.tsx
@@ -10,7 +10,7 @@ import { resetInvokeMock } from "@/test/invokeMock";
 import { CommitDiffPanel } from "./CommitDiffPanel";
 import { useFocusStore } from "@/features/keymap/useFocusStore";
 import { useKeymapStore } from "@/features/keymap/useKeymapStore";
-import { HUNK_LEAD_ROWS } from "@/lib/diffRows";
+
 import { DIFF_ROW_H_FALLBACK } from "@/lib/useDiffRowHeight";
 import type { FileDiff } from "@/lib/types";
 
@@ -201,7 +201,7 @@ describe("CommitDiffPanel windowing", () => {
     expect(document.querySelector('[data-hunk-index="0"]')?.textContent).toContain("added");
   });
 
-  it("PARKS an F7 target a fixed lead below the top, not at the viewport edge", async () => {
+  it("CENTRES an F7 target in the viewport, not at either edge", async () => {
     render(
       <CommitDiffPanel
         diffs={deepChange}
@@ -233,10 +233,12 @@ describe("CommitDiffPanel windowing", () => {
       } as unknown as KeyboardEvent);
     });
 
-    // The anchor sits at row 40. Reveal semantics would have stopped at the
-    // smallest scroll that shows it — the row pinned to the BOTTOM edge, at
-    // 41 * rowH - viewportH. Parking puts it HUNK_LEAD_ROWS rows below the top,
-    // every time, whichever direction F7 arrived from.
-    expect(el.scrollTop).toBe((ANCHOR_ROW - HUNK_LEAD_ROWS) * rowH);
+    // The change is one row at index 40, in a ten-row viewport. Reveal semantics
+    // would have stopped at the smallest scroll that shows it — the row pinned to
+    // the BOTTOM edge, at 41 * rowH - viewportH. Centring puts it five rows down
+    // instead, every time and whichever direction F7 arrived from. (The exact
+    // centre is 35.5 rows; ties snap DOWN to a row boundary, so no line renders
+    // half-sliced.)
+    expect(el.scrollTop).toBe((ANCHOR_ROW - 5) * rowH);
   });
 });

--- a/src/features/keymap/useHunkNav.ts
+++ b/src/features/keymap/useHunkNav.ts
@@ -68,8 +68,8 @@ export function useHunkNav(opts: {
   /** Cursor resets when this changes (the viewed file). */
   resetKey: unknown;
   /**
-   * Scroll a hunk into view BY OFFSET — build it from `hunkAnchorRows` +
-   * `scrollTopForRow`. Windowed panes MUST supply this.
+   * Scroll a hunk into view BY OFFSET — build it from `hunkExtentRows` +
+   * `scrollTopForHunk`. Windowed panes MUST supply this.
    *
    * Return `false` when the hunk could not be addressed — no scroll container, no
    * anchor row, or a write the container was too short to accept. The auto-open

--- a/src/lib/diffRows.test.ts
+++ b/src/lib/diffRows.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   flattenDiffRows,
   HUNK_LEAD_ROWS,
-  hunkAnchorRows,
+  hunkExtentRows,
   rowOffset,
-  scrollTopForAnchor,
+  scrollTopForHunk,
   scrollTopForRow,
   windowVariable,
   type DiffRow,
@@ -182,17 +182,20 @@ describe("flattenDiffRows hunk-header lines", () => {
   /**
    * `rowIndex` DOES shift, and that is fine — it is derived. But every surface
    * derives its heights array from `rows` too (`rows.map((r) => r.h)`), and
-   * `scrollTopForRow` / `hunkAnchorRows` / F7 all address the flat array, so the
+   * `scrollTopForRow` / `hunkExtentRows` / F7 all address the flat array, so the
    * two must be built from the same filtered list. A stale heights array is what
    * renders a blank strip or scrolls to the wrong row.
    */
-  it("keeps the heights array and the anchor map in step with the filtered rows", () => {
+  it("keeps the heights array and the extent map in step with the filtered rows", () => {
     const rows = flattenDiffRows([headered(1), headered(2)], { foldH: 22, rowH: 19 });
     const heights = rows.map((r) => r.h);
     expect(heights).toEqual([19, 19, 19, 19, 19, 19]);
-    // Anchors at the two rem rows — not at rows 2 and 5, where they would sit if
-    // the header rows were still occupying an index each.
-    expect(hunkAnchorRows(rows)).toEqual([1, 4]);
+    // Extents start at the two rem rows — not at rows 2 and 5, where they would
+    // sit if the header rows were still occupying an index each.
+    expect(hunkExtentRows(rows)).toEqual([
+      { first: 1, last: 2 },
+      { first: 4, last: 5 },
+    ]);
     expect(rowOffset(heights, 4)).toBe(76);
     expect(scrollTopForRow(heights, 4, { scrollTop: 0, viewportH: 40 })).toBe(55);
   });
@@ -218,15 +221,15 @@ describe("flattenDiffRows hunk-header lines", () => {
     expect(withHeader.filter((r) => r.kind === "fill")).toHaveLength(5);
   });
 
-  it("leaves a header-only hunk with no rows and no anchor to address", () => {
+  it("leaves a header-only hunk with no rows and no extent to address", () => {
     // Not something git emits — but the guard matters, because `scrollToHunk`
-    // and the action cluster both look a hunk index up in the anchor map.
+    // and the action cluster both look a hunk index up in the extent map.
     const rows = flattenDiffRows([{ ...hunk(1), lines: [header(1)] }], {
       foldH: 22,
       rowH: 19,
     });
     expect(rows).toEqual([]);
-    expect(hunkAnchorRows(rows)).toEqual([]);
+    expect(hunkExtentRows(rows)).toEqual([]);
   });
 });
 
@@ -558,7 +561,7 @@ describe("flattenDiffRows fold separators", () => {
   });
 });
 
-describe("hunkAnchorRows", () => {
+describe("hunkExtentRows", () => {
   const hunkAt = (n: number): FileDiff["hunks"][number] => ({
     header: `@@ -${n},1 +${n},1 @@`,
     oldStart: n,
@@ -572,21 +575,89 @@ describe("hunkAnchorRows", () => {
     ],
   });
 
-  it("maps each hunk index to its anchor's FLAT row index", () => {
+  it("brackets each hunk's FIRST and LAST changed rows, in FLAT row indices", () => {
     // Gap rows shift the flat indices, which is exactly why F7 cannot compute
     // this itself from a hunk index.
     const rows = flattenDiffRows([hunkAt(4), hunkAt(9)], { foldH: 22, rowH: 19 });
-    const anchors = hunkAnchorRows(rows);
-    expect(anchors).toHaveLength(2);
-    for (const [hunkIndex, rowIndex] of anchors.entries()) {
-      const row = rows[rowIndex];
-      expect(row.kind === "line" && row.hunkIndex).toBe(hunkIndex);
-      expect(row.kind === "line" && row.hunkAnchor).toBe(true);
+    const extents = hunkExtentRows(rows);
+    expect(extents).toHaveLength(2);
+    for (const [hunkIndex, { first, last }] of extents.entries()) {
+      const a = rows[first];
+      const b = rows[last];
+      expect(a.kind === "line" && a.hunkIndex).toBe(hunkIndex);
+      expect(a.kind === "line" && a.hunkAnchor).toBe(true);
+      expect(b.kind === "line" && b.hunkIndex).toBe(hunkIndex);
+      expect(b.kind === "line" && b.hunkLast).toBe(true);
+      // The del and the add. The LEADING context row is outside the extent —
+      // centring the whole hunk instead would drag the midpoint off the change
+      // by however many lines `-U` happened to emit.
+      expect(last - first).toBe(1);
     }
   });
 
+  it("collapses to a single row when the hunk changes one line", () => {
+    const rows = flattenDiffRows(
+      [
+        {
+          header: "@@ -4,1 +4,1 @@",
+          oldStart: 4,
+          oldLines: 1,
+          newStart: 4,
+          newLines: 1,
+          lines: [
+            { kind: { kind: "Context" }, oldLineno: 3, newLineno: 3, content: "before" },
+            { kind: { kind: "Addition" }, oldLineno: null, newLineno: 4, content: "new" },
+            { kind: { kind: "Context" }, oldLineno: 4, newLineno: 5, content: "after" },
+          ],
+        },
+      ],
+      { foldH: 22, rowH: 19 },
+    );
+    const [extent] = hunkExtentRows(rows);
+    // One row wears both markers — which is why PGWindowedDiff stamps them from
+    // a single branch, and why wrap mode's `last` lookup may return the anchor.
+    expect(extent.first).toBe(extent.last);
+    const row = rows[extent.first];
+    expect(row.kind === "line" && row.hunkAnchor).toBe(true);
+    expect(row.kind === "line" && row.hunkLast).toBe(true);
+    // The TRAILING context row is outside it, for the same reason as the leading
+    // one — otherwise every extent would be three lines longer than its change.
+    expect(extent.last).toBe(rows.length - 2);
+  });
+
+  it("spans the CONTEXT sitting between two change runs in one hunk", () => {
+    // git merges runs less than 2 x -U apart into a single hunk, so an extent is
+    // NOT necessarily a solid block of +/-. F7 addresses the hunk and
+    // Stage/Discard act on all of it, so the unchanged rows in the middle are
+    // part of what gets centred.
+    const rows = flattenDiffRows(
+      [
+        {
+          header: "@@ -1,7 +1,7 @@",
+          oldStart: 1,
+          oldLines: 7,
+          newStart: 1,
+          newLines: 7,
+          lines: [
+            { kind: { kind: "Context" }, oldLineno: 1, newLineno: 1, content: "a" },
+            { kind: { kind: "Deletion" }, oldLineno: 2, newLineno: null, content: "b" },
+            { kind: { kind: "Context" }, oldLineno: 3, newLineno: 2, content: "c" },
+            { kind: { kind: "Context" }, oldLineno: 4, newLineno: 3, content: "d" },
+            { kind: { kind: "Context" }, oldLineno: 5, newLineno: 4, content: "e" },
+            { kind: { kind: "Addition" }, oldLineno: null, newLineno: 5, content: "f" },
+            { kind: { kind: "Context" }, oldLineno: 6, newLineno: 6, content: "g" },
+          ],
+        },
+      ],
+      { foldH: 22, rowH: 19 },
+    );
+    const [extent] = hunkExtentRows(rows);
+    // del, ctx, ctx, ctx, add — five rows, with a context row at the very middle.
+    expect(extent.last - extent.first).toBe(4);
+  });
+
   it("is empty for an empty diff", () => {
-    expect(hunkAnchorRows([])).toEqual([]);
+    expect(hunkExtentRows([])).toEqual([]);
   });
 });
 
@@ -683,61 +754,115 @@ describe("scrollTopForRow", () => {
   });
 });
 
-describe("scrollTopForAnchor", () => {
-  // Twenty 20px rows (400px of content) in a 200px viewport, so the 4-row
-  // lead-in (80px) fits with room to spare either side.
+describe("scrollTopForHunk", () => {
+  // Twenty 20px rows (400px of content) in a 200px, ten-row viewport.
   const hs = Array.from({ length: 20 }, () => 20);
-  const park = (index: number, scrollTop = 0, viewportH = 200) =>
-    scrollTopForAnchor(hs, index, { scrollTop, viewportH, rowH: 20 });
+  const centre = (first: number, last: number, scrollTop = 0, viewportH = 200) =>
+    scrollTopForHunk(hs, { first, last }, { scrollTop, viewportH, rowH: 20 });
 
-  it("parks the anchor a fixed lead below the top of the viewport", () => {
-    // Row 9 starts at 180; four 20px rows of lead-in put the viewport at 100.
-    expect(park(9)).toBe(180 - HUNK_LEAD_ROWS * 20);
+  it("puts the middle of the change on the middle of the viewport", () => {
+    // Rows 8-9 span 160..200, so their midpoint is 180. A 200px viewport starting
+    // at 80 is centred on 180 too.
+    expect(centre(8, 9)).toBe(80);
   });
 
-  it("repositions a row that is ALREADY visible", () => {
-    // The whole point, and where this parts company with scrollTopForRow: F7
-    // must put the change in the same physical spot every time, not leave it
-    // wherever the previous scroll happened to strand it.
-    expect(scrollTopForRow(hs, 7, { scrollTop: 100, viewportH: 200 })).toBe(100);
-    expect(park(7, 100)).toBe(60);
+  it("centres the WHOLE extent, not its first row", () => {
+    // Same starting row, different amounts of change below it: the answer moves,
+    // which is the whole difference between this and parking the anchor.
+    expect(centre(8, 9)).toBe(80);
+    expect(centre(8, 13)).toBe(120);
+  });
+
+  it("repositions a change that is ALREADY fully visible", () => {
+    // Where this parts company with scrollTopForRow: F7 puts the change in the
+    // same physical spot every time, rather than leaving it wherever the previous
+    // scroll happened to strand it — bottom edge, top edge, or anywhere else.
+    expect(scrollTopForRow(hs, 8, { scrollTop: 100, viewportH: 200 })).toBe(100);
+    expect(centre(8, 9, 100)).toBe(80);
   });
 
   it("clamps at the top of the file rather than scrolling negative", () => {
-    expect(park(0)).toBe(0);
-    expect(park(2, 300)).toBe(0);
+    expect(centre(0, 1)).toBe(0);
+    expect(centre(1, 2, 300)).toBe(0);
   });
 
-  it("clamps at the end of the file, where the lead cannot be honoured", () => {
-    // Row 19 starts at 380; 400px of content in a 200px viewport tops out at
-    // 200, so the last hunk sits lower than the lead asks for. Overshooting
-    // here would be CLAMPED BY THE DOM, and scrollToHunk reads that mismatch as
-    // "the reveal did not land" — which quietly costs the file its auto-open.
-    expect(park(19)).toBe(200);
+  it("clamps at the end of the file, where nothing could centre it", () => {
+    // Rows 18-19 want scrollTop 280; 400px of content in a 200px viewport tops
+    // out at 200, so the last hunks in a file land low rather than centred. There
+    // is no scroll position that would centre them, and buying one with
+    // scroll-past-end space would cost the `contentH === sum(heights)` invariant
+    // that windowing depends on. Overshooting is worse than useless: the DOM
+    // CLAMPS the write, and scrollToHunk reads the mismatch as "the reveal did
+    // not land", quietly costing the file its auto-open.
+    expect(centre(18, 19)).toBe(200);
   });
 
-  it("caps the lead so a short pane cannot hide the anchor", () => {
+  it("falls back to a lead-in above a change TALLER than the viewport", () => {
+    // Rows 8-19 are 240px of change in a 200px viewport: centring would hide the
+    // start of it, so the top parks HUNK_LEAD_ROWS rows down instead and the
+    // reader scrolls from the beginning.
+    expect(centre(8, 19)).toBe((8 - HUNK_LEAD_ROWS) * 20);
+  });
+
+  it("switches to that fallback ONLY when the change cannot fit", () => {
+    // Exactly ten rows fills the viewport exactly: still centred, flush at both
+    // edges.
+    expect(centre(5, 14)).toBe(100);
+    // Eleven rows cannot, so it top-parks: 100 - 4 x 20.
+    expect(centre(5, 15)).toBe(20);
+    // Eight rows fit with 40px to spare, and MUST still centre. The tempting
+    // branchless form `min(centre, top - lead)` fails exactly here — it would
+    // answer 20 and shove the bottom of a change that fits off the screen.
+    expect(centre(5, 12)).toBe(80);
+  });
+
+  it("caps the lead so a short pane cannot hide the change", () => {
     // A 60px viewport with the full 80px lead would put row 9 (offset 180) at
-    // scrollTop 100 — showing 100..160, with the anchor off the bottom. The cap
-    // keeps one row of the anchor on screen at every viewport size.
-    expect(park(9, 0, 60)).toBe(140);
-    // One row tall: no lead at all, anchor flush with the top.
-    expect(park(9, 0, 20)).toBe(180);
+    // scrollTop 100 — showing 100..160, with the change off the bottom.
+    expect(centre(9, 15, 0, 60)).toBe(140);
+    // One row tall: no lead at all, change flush with the top.
+    expect(centre(9, 15, 0, 20)).toBe(180);
   });
 
   it("measures the lead in PIXELS, not in preceding rows", () => {
-    // A header (26) then two code rows (18), twice. Row 4 starts at 88; the four
-    // rows above it are 88px tall together, which would eat the entire lead and
-    // park the anchor at the top. 4 x rowH is 72, so 16 is the answer.
-    const mixed = [26, 18, 18, 26, 18, 18];
-    expect(scrollTopForAnchor(mixed, 4, { scrollTop: 0, viewportH: 100, rowH: 18 })).toBe(16);
+    // A header (26) then two code rows (18), then another header, then ten code
+    // rows. The extent is rows 4-13 — 180px of change in a 100px viewport, so the
+    // lead-in branch applies. Row 4 starts at 88, and the four rows above it are
+    // 88px tall together: a rows-based lead would eat the whole thing and answer
+    // 0, flush with the top. 4 x rowH is 72px, which asks for 16 and snaps to the
+    // row boundary at 26.
+    const mixed = [26, 18, 18, 26, ...Array.from({ length: 10 }, () => 18)];
+    expect(scrollTopForHunk(mixed, { first: 4, last: 13 }, {
+      scrollTop: 0,
+      viewportH: 100,
+      rowH: 18,
+    })).toBe(26);
   });
 
-  it("holds still for an out-of-range index or an unmeasured viewport", () => {
+  it("snaps to a row boundary so neither edge shows a sliced line", () => {
+    // Row 3 of [26,18,18,18,18,18] starts at 62; centring one 18px row in a 60px
+    // viewport asks for 41, which is 15px into row 1. The nearest boundary is 44.
+    const mixed = [26, 18, 18, 18, 18, 18];
+    expect(scrollTopForHunk(mixed, { first: 3, last: 3 }, {
+      scrollTop: 0,
+      viewportH: 60,
+      rowH: 18,
+    })).toBe(44);
+    // Uniform rows: a one-row change in a ten-row viewport centres half a row off
+    // a boundary, and ties resolve DOWN so the answer is stable.
+    expect(centre(8, 8)).toBe(60);
+  });
+
+  it("holds still for an out-of-range extent or an unmeasured viewport", () => {
     // Same guards as scrollTopForRow: jsdom and the first paint both report a
     // 0px viewport, and the auto-open leans on this to try again later.
-    expect(park(-1, 40)).toBe(40);
-    expect(park(20, 40)).toBe(40);
-    expect(scrollTopForAnchor(hs, 9, { scrollTop: 40, viewportH: 0, rowH: 20 })).toBe(40);
+    expect(centre(-1, -1, 40)).toBe(40);
+    expect(centre(20, 20, 40)).toBe(40);
+    expect(centre(9, 8, 40)).toBe(40);
+    expect(scrollTopForHunk(hs, { first: 9, last: 9 }, {
+      scrollTop: 40,
+      viewportH: 0,
+      rowH: 20,
+    })).toBe(40);
   });
 });

--- a/src/lib/diffRows.ts
+++ b/src/lib/diffRows.ts
@@ -35,6 +35,16 @@ export type DiffRow =
        * other, and this flag reaches no backend op.
        */
       hunkAnchor?: true;
+      /**
+       * This row is its hunk's LAST changed (`+`/`-`) row — the other end of the
+       * extent F7 centres. Exactly one row per hunk carries it, and it is the
+       * ANCHOR ITSELF for a hunk that changes a single line.
+       *
+       * Hosts `data-hunk-last-index`, which is the only way `DiffViewer`'s wrap
+       * mode can measure the extent: `heights` describes nothing there, and every
+       * other row in the hunk is anonymous in the DOM.
+       */
+      hunkLast?: true;
     }
   /**
    * An unchanged line from OUTSIDE every hunk, synthesized in whole-file mode
@@ -273,12 +283,12 @@ export interface FlattenDiffOptions {
  */
 const baseLinesCache = new WeakMap<
   FileDiff["hunks"],
-  { lines: DiffLineData[]; anchor: number }[]
+  { lines: DiffLineData[]; anchor: number; last: number }[]
 >();
 
 function baseHunkLines(
   hunks: FileDiff["hunks"],
-): { lines: DiffLineData[]; anchor: number }[] {
+): { lines: DiffLineData[]; anchor: number; last: number }[] {
   const hit = baseLinesCache.get(hunks);
   if (hit) return hit;
   const computed = hunks.map((h) => {
@@ -292,12 +302,29 @@ function baseHunkLines(
     );
     // The hunk's anchor is its first CHANGED row — F7 means "go to the next
     // change", and the Stage/Discard cluster belongs at the change block's top.
+    // `last` is its final changed row; the two bracket the extent F7 centres.
+    //
+    // The span between them can hold CONTEXT: git merges change runs less than
+    // 2 x -U apart into one hunk, so a hunk is not necessarily one solid block of
+    // `+`/`-`. Centring the whole bracket is deliberate — F7 addresses a hunk and
+    // Stage/Discard act on all of it — but it does mean the row at the exact
+    // middle is sometimes an unchanged one.
+    //
     // A hunk with no changed row is not something git emits, but a caller can
-    // construct one, so fall back to the first row: exactly one anchor per hunk,
-    // unconditionally, or F7 and the actions lose a reachable host.
-    let anchor = lines.findIndex((l) => l.kind === "add" || l.kind === "rem");
-    if (anchor < 0 && lines.length > 0) anchor = 0;
-    return { lines, anchor };
+    // construct one, so fall back to the first row: exactly one anchor and one
+    // extent end per hunk, unconditionally, or F7 and the actions lose a
+    // reachable host.
+    const isChanged = (l: DiffLineData) => l.kind === "add" || l.kind === "rem";
+    let anchor = lines.findIndex(isChanged);
+    let last = anchor;
+    for (let i = lines.length - 1; i > anchor; i--) {
+      if (isChanged(lines[i])) {
+        last = i;
+        break;
+      }
+    }
+    if (anchor < 0 && lines.length > 0) anchor = last = 0;
+    return { lines, anchor, last };
   });
   baseLinesCache.set(hunks, computed);
   return computed;
@@ -311,7 +338,7 @@ export function flattenDiffRows(
 
   const base = baseHunkLines(hunks);
   const hunkRows = (_h: FileDiff["hunks"][number], hunkIndex: number): DiffRow[] => {
-    const { lines: baseLines, anchor } = base[hunkIndex];
+    const { lines: baseLines, anchor, last } = base[hunkIndex];
     // Syntax is the one per-flatten input, applied over the cached base. Safe to
     // attach AFTER the word spans: withSyntax spreads each line it touches, so
     // spans and changedIndex ride along untouched.
@@ -322,6 +349,7 @@ export function flattenDiffRows(
       line,
       h: rowH,
       ...(i === anchor ? { hunkAnchor: true as const } : {}),
+      ...(i === last ? { hunkLast: true as const } : {}),
     }));
   };
 
@@ -433,19 +461,34 @@ export function flattenDiffRows(
 }
 
 /**
- * Flat row index of each hunk's anchor row, indexed by hunk index; `-1` for a
+ * The two flat row indices bracketing a hunk's CHANGED rows.
+ *
+ * `first` is the ANCHOR row — the one that hosts `data-hunk-index` and the
+ * Stage/Discard cluster — so this subsumes the old anchor-only lookup rather
+ * than sitting beside it.
+ */
+export interface HunkExtent {
+  /** Flat index of the hunk's first changed row; `-1` when it has no rows. */
+  first: number;
+  /** Flat index of its last changed row; equals `first` for a one-line change. */
+  last: number;
+}
+
+/**
+ * Each hunk's extent, indexed by hunk index; `{ first: -1, last: -1 }` for a
  * hunk with no rows at all.
  *
- * The one mapping F7 needs: `useHunkNav` moves a HUNK cursor, and scrolling it
- * into view must go through `scrollTopForRow`, which addresses the flat array.
- * Shared so every diff surface resolves it the same way.
+ * The one mapping F7 needs: `useHunkNav` moves a HUNK cursor, and putting that
+ * hunk on screen goes through `scrollTopForHunk`, which addresses the flat
+ * array. Shared so every diff surface resolves it the same way.
  */
-export function hunkAnchorRows(rows: DiffRow[]): number[] {
-  const out: number[] = [];
+export function hunkExtentRows(rows: DiffRow[]): HunkExtent[] {
+  const out: HunkExtent[] = [];
   rows.forEach((row, i) => {
-    if (row.kind !== "line" || !row.hunkAnchor) return;
-    while (out.length <= row.hunkIndex) out.push(-1);
-    out[row.hunkIndex] = i;
+    if (row.kind !== "line") return;
+    while (out.length <= row.hunkIndex) out.push({ first: -1, last: -1 });
+    if (row.hunkAnchor) out[row.hunkIndex].first = i;
+    if (row.hunkLast) out[row.hunkIndex].last = i;
   });
   return out;
 }
@@ -483,61 +526,112 @@ export function scrollTopForRow(
   return scrollTop;
 }
 
-/** Rows of lead-in `scrollTopForAnchor` keeps above its target. */
+/** Rows of lead-in kept above a change too tall to centre. */
 export const HUNK_LEAD_ROWS = 4;
 
 /**
- * Scroll position that PARKS row `index` a fixed lead below the top of the
- * viewport — F7/⇧F7's landing, and the file auto-open's.
+ * Largest row boundary at or below `y`, or the next one up when that is nearer.
+ *
+ * Every scroll target in a diff has always been an exact `rowOffset`, so rows
+ * render crisp; a true centre lands mid-row and slices the viewport's top and
+ * bottom lines in half. Snapping keeps the pixels clean. Ties go DOWN, so the
+ * answer is stable for a given `y`.
+ */
+function nearestRowBoundary(heights: number[], y: number): number {
+  if (y <= 0) return 0;
+  let acc = 0;
+  for (let i = 0; i < heights.length; i++) {
+    const next = acc + heights[i];
+    if (next > y) return y - acc <= next - y ? acc : next;
+    acc = next;
+  }
+  return acc;
+}
+
+/**
+ * Scroll position that CENTRES a hunk's changed extent in the viewport — F7/⇧F7's
+ * landing, and the file auto-open's.
  *
  * Three scroll semantics now live side by side, and they are not
  * interchangeable:
  *
  * - `scrollTopForRow` REVEALS: the smallest move that brings a row into view,
- *   unchanged when it already is. The line cursor wants exactly that — a cursor
+ *   unchanged when it already is. The LINE cursor wants exactly that — a cursor
  *   stepping one row should scroll one row.
  * - `scrubScrollTop` (`diffMinimap.ts`) POSITIONS a viewport around a row.
- * - this one PARKS: the target always lands in the same physical spot, whether
- *   it was off screen, at the bottom edge, or already comfortably visible. That
- *   unconditional move is the point — under "reveal" semantics F7 walking
- *   forward leaves each change pinned to the BOTTOM edge with no following
- *   context, and the reader's eyes have to hunt for it after every press.
+ * - this one CENTRES: the extent's midpoint lands on the viewport's midpoint,
+ *   whether the change was off screen, at an edge, or already comfortably
+ *   visible. That unconditional move is the point — under reveal semantics F7
+ *   walking forward left each change pinned to the BOTTOM edge with no following
+ *   context, and one keypress meant two different things depending on where the
+ *   previous one had left the pane.
  *
- * The lead is `HUNK_LEAD_ROWS * rowH` PIXELS rather than the height of the four
- * preceding rows: a tall fold separator directly above a hunk would otherwise
- * eat the whole lead and park the change at the top after all.
+ * The extent is the hunk's FIRST changed row through its LAST, any context
+ * between two change runs included (see `baseHunkLines`). NOT the whole hunk:
+ * git's leading and trailing context would drag the midpoint off the change by
+ * however many lines `-U` happened to emit.
  *
- * Two clamps make it total:
+ * A change TALLER than the viewport cannot be centred without hiding its own
+ * start, so it degrades to parking its top `HUNK_LEAD_ROWS` rows below the top
+ * edge — the reader lands at the beginning of the change, with a hint of file
+ * above it, and scrolls down. That branch is the only surviving use of the
+ * constant, and it is deliberately a hard `extentH > viewportH` test. Making the
+ * transition continuous (`min(centre, top - lead)`) is the obvious refactor and
+ * is wrong: the arithmetic makes it start top-parking at
+ * `extentH > viewportH - 2 x lead`, pushing the bottom of an extent off screen
+ * while that extent still fits.
  *
- * - The result stays inside `[0, contentH - viewportH]`. Overshooting the end of
+ * Three details are load-bearing:
+ *
+ * - The lead is `HUNK_LEAD_ROWS * rowH` PIXELS rather than the height of the
+ *   four preceding rows: a tall fold separator directly above a hunk would
+ *   otherwise eat the whole lead and park the change at the top after all. It is
+ *   capped at `viewportH - rowH`, so a pane shorter than the lead degrades to
+ *   "flush with the top", never to "not on screen".
+ * - The result snaps to a row boundary, so neither edge of the viewport shows a
+ *   half-sliced line.
+ * - It is then clamped into `[0, contentH - viewportH]`. Overshooting the end of
  *   the document is not harmless: the DOM clamps the write, and every caller's
  *   `scrollToHunk` reads `scrollTop !== want` as "the reveal did not land",
  *   which costs the file its once-per-file auto-open. `contentH` is the sum of
  *   `heights` — TRUE BY CONSTRUCTION, since `PGWindowedDiff` renders exactly
  *   `topPad + rows + bottomPad` into the scroll container. Putting padding or a
- *   sticky child in there would break this.
- * - The lead itself is capped at `viewportH - rowH`, so a pane shorter than the
- *   lead (a squeezed preview split) cannot park the target off its own bottom
- *   edge. It degrades to "flush with the top", never to "not on screen".
+ *   sticky child in there would break this. The clamp is also why a hunk within
+ *   half a viewport of either END of the file does not land centred: no scroll
+ *   position would put it there, and inventing scroll-past-end space to buy one
+ *   would cost the invariant above. F7 still moves the cursor; the pane simply
+ *   has nowhere left to go, and everything is on screen anyway.
  *
- * An out-of-range index or an unmeasured viewport (`viewportH <= 0`) leaves the
- * scroll position alone, exactly as `scrollTopForRow` does — `diffOpenReady` and
- * the auto-open both lean on that to try again on a later render.
+ * An out-of-range extent or an unmeasured viewport (`viewportH <= 0`, which is
+ * what jsdom and the first paint report) leaves the scroll position alone,
+ * exactly as `scrollTopForRow` does — `diffOpenReady` and the auto-open both
+ * lean on that to try again on a later render.
  */
-export function scrollTopForAnchor(
+export function scrollTopForHunk(
   heights: number[],
-  index: number,
+  extent: HunkExtent,
   o: { scrollTop: number; viewportH: number; rowH: number },
 ): number {
   const { scrollTop, viewportH, rowH } = o;
-  if (index < 0 || index >= heights.length || viewportH <= 0) return scrollTop;
+  const { first, last } = extent;
+  if (first < 0 || last < first || last >= heights.length || viewportH <= 0) {
+    return scrollTop;
+  }
+  const top = rowOffset(heights, first);
+  let extentH = 0;
+  for (let i = first; i <= last; i++) extentH += heights[i];
+
   const lead = Math.min(
     HUNK_LEAD_ROWS * Math.max(0, rowH),
     Math.max(0, viewportH - rowH),
   );
+  const want = extentH > viewportH ? top - lead : top + extentH / 2 - viewportH / 2;
+
   const contentH = heights.reduce((a, h) => a + h, 0);
-  const max = Math.max(0, contentH - viewportH);
-  return Math.min(Math.max(0, rowOffset(heights, index) - lead), max);
+  return Math.min(
+    Math.max(0, nearestRowBoundary(heights, want)),
+    Math.max(0, contentH - viewportH),
+  );
 }
 
 /**

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -70,9 +70,10 @@ import { getDiff, getLogPage } from "@/lib/tauri";
 import { useDiffSyntax } from "@/lib/syntax";
 import {
   flattenDiffRows,
-  hunkAnchorRows,
-  scrollTopForAnchor,
+  hunkExtentRows,
+  scrollTopForHunk,
   scrollTopForRow,
+  type HunkExtent,
 } from "@/lib/diffRows";
 import { fileDiffToText, selectedLinesToText } from "@/lib/diffCopy";
 import { useVariableWindow } from "@/lib/useVariableWindow";
@@ -724,17 +725,17 @@ export function CommitPanelScreen() {
   );
 
   /**
-   * The same write with PARKING semantics — F7's landing, not the line cursor's.
+   * The same write with CENTRING semantics — F7's landing, not the line cursor's.
    *
    * The two must not share one helper: a line cursor stepping one row should
    * scroll one row (reveal), while F7 puts every change in the same physical
-   * spot whether or not it was already visible (park). See `scrollTopForAnchor`.
+   * spot whether or not it was already visible (centre). See `scrollTopForHunk`.
    */
-  const parkDiffRow = React.useCallback(
-    (rowIndex: number): boolean => {
+  const centreDiffExtent = React.useCallback(
+    (extent: HunkExtent): boolean => {
       const el = diffScrollRef.current;
       if (!el) return false;
-      const want = scrollTopForAnchor(heights, rowIndex, {
+      const want = scrollTopForHunk(heights, extent, {
         scrollTop: el.scrollTop,
         viewportH: el.clientHeight,
         rowH,
@@ -797,14 +798,14 @@ export function CommitPanelScreen() {
   // ── Hunk cursor + hunk-level chords (#157) ───────────────────────────────
   // This pane had no F7 at all before, so the `@@` banner's Stage/Discard was
   // mouse-only. Both now hang off the hunk cursor.
-  const anchorRows = React.useMemo(() => hunkAnchorRows(rows), [rows]);
+  const extents = React.useMemo(() => hunkExtentRows(rows), [rows]);
   const scrollToHunk = React.useCallback(
     (hunkIndex: number): boolean => {
-      const rowIndex = anchorRows[hunkIndex];
-      if (rowIndex == null || rowIndex < 0) return false;
-      return parkDiffRow(rowIndex);
+      const extent = extents[hunkIndex];
+      if (extent == null || extent.first < 0) return false;
+      return centreDiffExtent(extent);
     },
-    [anchorRows, parkDiffRow],
+    [extents, centreDiffExtent],
   );
   const hunkCursor = useHunkNav({
     paneIds: ["commit.diff"],

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -37,8 +37,8 @@ import { useDiffSyntax } from "@/lib/syntax";
 import {
   flattenDiffRows,
   HUNK_LEAD_ROWS,
-  hunkAnchorRows,
-  scrollTopForAnchor,
+  hunkExtentRows,
+  scrollTopForHunk,
 } from "@/lib/diffRows";
 import { useVariableWindow } from "@/lib/useVariableWindow";
 import { useViewportH } from "@/lib/useViewportH";
@@ -268,17 +268,17 @@ export function DiffViewerScreen() {
   // F7/⇧F7 walk the viewed file's hunks from either pane. Scroll to the hunk's
   // ANCHOR row BY OFFSET (#157): a querySelector would find nothing whenever that
   // row is outside the window, which for a line row is most of the time.
-  const anchorRows = React.useMemo(() => hunkAnchorRows(rows), [rows]);
+  const extents = React.useMemo(() => hunkExtentRows(rows), [rows]);
   const scrollToHunk = React.useCallback(
     (hunkIndex: number): boolean => {
       const el = scrollRef.current;
-      const idx = anchorRows[hunkIndex];
-      if (!el || idx == null || idx < 0) return false;
-      // PARKED a fixed lead below the top — see `scrollTopForAnchor`. This screen
-      // used to skip the scroll entirely for a hunk already on screen, which is
-      // how one keypress came to mean two different things depending on where the
+      const extent = extents[hunkIndex];
+      if (!el || extent == null || extent.first < 0) return false;
+      // CENTRED on the change — see `scrollTopForHunk`. This screen used to skip
+      // the scroll entirely for a hunk already on screen, which is how one
+      // keypress came to mean two different things depending on where the
       // previous one left the pane.
-      const want = scrollTopForAnchor(heights, idx, {
+      const want = scrollTopForHunk(heights, extent, {
         scrollTop: el.scrollTop,
         viewportH: el.clientHeight,
         rowH,
@@ -292,36 +292,49 @@ export function DiffViewerScreen() {
       // file having been opened — see `useHunkNav`'s `scrollToHunk`.
       return Math.abs(el.scrollTop - want) <= 1;
     },
-    [anchorRows, heights, rowH, scrollDiffTo],
+    [extents, heights, rowH, scrollDiffTo],
   );
 
   // Wrap mode, where `heights` no longer describes the rendered rows and the
   // offset arithmetic above would land on the wrong line. Windowing is off here,
-  // so every anchor row is MOUNTED and the DOM can be measured directly — the one
-  // situation in which a querySelector cannot silently no-op (the #68 G10 trap).
-  // Measured through bounding rects rather than `offsetTop`, which is relative to
-  // whichever ancestor happens to be positioned.
+  // so every row of the extent is MOUNTED and the DOM can be measured directly —
+  // the one situation in which a querySelector cannot silently no-op (the #68 G10
+  // trap). Measured through bounding rects rather than `offsetTop`, which is
+  // relative to whichever ancestor happens to be positioned.
   //
-  // `useHunkNav`'s own fallback would do `scrollIntoView({block: "start"})` and
-  // park the change flush against the top edge; this keeps the lead-in every other
-  // mode gives.
+  // Same rule as `scrollTopForHunk`, different ruler: centre the extent, degrade
+  // to a lead-in above its top when it is taller than the pane. `useHunkNav`'s own
+  // fallback would do `scrollIntoView({block: "start"})` and pin the change flush
+  // against the top edge instead.
   const scrollToHunkInWrap = React.useCallback(
     (hunkIndex: number): boolean => {
       const el = scrollRef.current;
-      const row = el?.querySelector<HTMLElement>(`[data-hunk-index="${hunkIndex}"]`);
-      if (!el || !row) return false;
-      const lead = Math.min(
-        HUNK_LEAD_ROWS * rowH,
-        Math.max(0, el.clientHeight - rowH),
-      );
-      const top =
-        el.scrollTop + row.getBoundingClientRect().top - el.getBoundingClientRect().top;
-      const want = Math.max(
+      const first = el?.querySelector<HTMLElement>(`[data-hunk-index="${hunkIndex}"]`);
+      // `data-hunk-last-index` rides the same wrapper when the hunk changes one
+      // line, and its own when it changes more. Falling back to the anchor keeps
+      // this a scroll rather than a no-op if the markers ever come apart.
+      const last =
+        el?.querySelector<HTMLElement>(`[data-hunk-last-index="${hunkIndex}"]`) ??
+        first;
+      if (!el || !first || !last) return false;
+      // Content coordinates: the container's own top, corrected for how far it is
+      // already scrolled.
+      const base = el.getBoundingClientRect().top - el.scrollTop;
+      const top = first.getBoundingClientRect().top - base;
+      const extentH = last.getBoundingClientRect().bottom - base - top;
+      const viewportH = el.clientHeight;
+      const lead = Math.min(HUNK_LEAD_ROWS * rowH, Math.max(0, viewportH - rowH));
+      const want =
+        extentH > viewportH ? top - lead : top + extentH / 2 - viewportH / 2;
+      // No row-boundary snap here, unlike `scrollTopForHunk`: wrapped rows have no
+      // uniform pitch, and `heights` — the only list of boundaries there is —
+      // describes nothing in this mode.
+      const clamped = Math.max(
         0,
-        Math.min(top - lead, el.scrollHeight - el.clientHeight),
+        Math.min(Math.round(want), el.scrollHeight - viewportH),
       );
-      scrollDiffTo(want);
-      return Math.abs(el.scrollTop - want) <= 1;
+      scrollDiffTo(clamped);
+      return Math.abs(el.scrollTop - clamped) <= 1;
     },
     [rowH, scrollDiffTo],
   );
@@ -329,8 +342,8 @@ export function DiffViewerScreen() {
     paneIds: ["diff.files", "diff.view"],
     count: findFiltered?.hunks.length ?? 0,
     resetKey: selectedPath,
-    // Wrap mode measures the mounted row instead of trusting `heights` — same
-    // parking rule, different ruler.
+    // Wrap mode measures the mounted rows instead of trusting `heights` — same
+    // centring rule, different ruler.
     scrollToHunk: wrap ? scrollToHunkInWrap : scrollToHunk,
     // Split mode has no unified scroll container, and `useViewportH` keeps the
     // last height it managed to read rather than resetting to 0 when the element

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -57,8 +57,8 @@ import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
 import { useDiffSyntax, useSyntax } from "@/lib/syntax";
 import {
   flattenDiffRows,
-  hunkAnchorRows,
-  scrollTopForAnchor,
+  hunkExtentRows,
+  scrollTopForHunk,
 } from "@/lib/diffRows";
 import { useVariableWindow } from "@/lib/useVariableWindow";
 import { useViewportH } from "@/lib/useViewportH";
@@ -697,16 +697,15 @@ export function RepoBrowserScreen() {
   // ── Hunk cursor + hunk-level chords (#157) ───────────────────────────────
   // This pane had no F7 either; the `@@` banner's Stage/Discard was mouse-only.
   // Scroll BY OFFSET — the anchor row is usually unmounted under windowing.
-  const diffAnchorRows = React.useMemo(() => hunkAnchorRows(diffRows), [diffRows]);
+  const diffExtents = React.useMemo(() => hunkExtentRows(diffRows), [diffRows]);
   const scrollToHunk = React.useCallback(
     (hunkIndex: number): boolean => {
       const el = diffScrollRef.current;
-      const rowIndex = diffAnchorRows[hunkIndex];
-      if (!el || rowIndex == null || rowIndex < 0) return false;
+      const extent = diffExtents[hunkIndex];
+      if (!el || extent == null || extent.first < 0) return false;
       // Through the window's own setter — see `useVariableWindow.scrollTo`.
-      // PARKED a fixed lead below the top, never merely revealed: see
-      // `scrollTopForAnchor`.
-      const want = scrollTopForAnchor(diffHeights, rowIndex, {
+      // CENTRED on the change, never merely revealed: see `scrollTopForHunk`.
+      const want = scrollTopForHunk(diffHeights, extent, {
         scrollTop: el.scrollTop,
         viewportH: el.clientHeight,
         rowH: diffRowH,
@@ -717,7 +716,7 @@ export function RepoBrowserScreen() {
       // file having been opened — see `useHunkNav`'s `scrollToHunk`.
       return Math.abs(el.scrollTop - want) <= 1;
     },
-    [diffAnchorRows, diffHeights, diffRowH, scrollDiffTo],
+    [diffExtents, diffHeights, diffRowH, scrollDiffTo],
   );
   const hunkCursor = useHunkNav({
     paneIds: ["repo.tree", "repo.preview"],


### PR DESCRIPTION
F7/⇧F7 and the file auto-open now put the **middle of a hunk's changed extent on the middle of the viewport**, replacing the fixed four-row lead-in from #202.

### Why

The lead-in answered "one keypress must mean one thing", but it answered with a constant. A two-line change and a forty-line one both landed with their first row four rows down, so the big one ran off the bottom with nothing following it on screen. Centring the whole extent — first changed row through last, any context between two change runs included — keeps context on both sides of the change at every size.

### What changed

- `hunkExtentRows` replaces `hunkAnchorRows`: both ends of the change rather than just the anchor, carried by a `hunkLast` row flag mirroring `hunkAnchor`. `scrollTopForHunk` replaces `scrollTopForAnchor`.
- A change **taller than the viewport** cannot be centred without hiding its own start, so it degrades to the old lead-in above its top row — now `HUNK_LEAD_ROWS`' only use. The `extentH > viewportH` test is deliberately a hard branch: the tempting branchless `min(centre, top - lead)` form starts top-parking while the change still fits, shoving its bottom off screen.
- The result **snaps to a row boundary**, so neither edge of the viewport shows a half-sliced line, as every `rowOffset`-based target always did.
- **Wrap mode** measures the two marked rows' rects instead of `heights`. `data-hunk-last-index` is new, and rides the anchor's own wrapper when a hunk changes a single line.

### Deliberate consequences

- F7 still scrolls **even when the next hunk was already on screen**. That is the price of every change landing in the same place; the alternative (skip when already fully visible) is what #202 was written to kill.
- A hunk within half a viewport of **either end of the file** still cannot land centred. No scroll position would put it there, and buying one with scroll-past-end padding would break `contentH === sum(heights)`, which windowing depends on.

### Testing

- `pnpm tsc --noEmit` clean; `pnpm exec tsc -p e2e/tsconfig.json --noEmit` clean.
- `pnpm test` — 1843 passing, including 17 rewritten/new cases on `scrollTopForHunk` + `hunkExtentRows` and the `data-hunk-last-index` marker.
- e2e in Docker: `diff-nav` 2 passing, `keymap` 27 passing (incl. `F7 / ⇧F7 walk the diff hunks`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
