### PR TITLE
feat(cli): add pgit --version / -V

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ pgit ~/dev/foo          # open repo containing that path
 pgit commit             # open cwd repo, land on Commit panel
 pgit log src/           # open repo containing src/, land on History
 pgit --help             # print usage, no window
+pgit --version          # print version, no window
 ```
 
 | subcommand | screen |

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -14,6 +14,7 @@ pub struct LaunchIntent {
 #[derive(Debug, PartialEq)]
 pub enum Parsed {
     Help,
+    Version,
     /// Invoked as GIT_ASKPASS / SSH_ASKPASS with git's prompt string (#61 D5).
     /// Internal contract between the app and its own subprocesses — deliberately
     /// absent from USAGE.
@@ -88,10 +89,23 @@ Subcommands:
   log | history      open the History screen
   branches           open the Branches screen
 
+Options:
+  -h, --help         print this help and exit
+  -V, --version      print the version and exit
+
 With a path and no subcommand, opens the repo containing that path.
 With a subcommand and no path, uses the current directory.
 With no arguments, performs a plain app launch.
 ";
+
+/// `pgit --version` output. Reads `CARGO_PKG_VERSION` at compile time — the
+/// release workflow rewrites `src-tauri/Cargo.toml`'s `version` field to the
+/// release tag before building (`.github/workflows/release.yml`), the same
+/// way it rewrites `tauri.conf.json`, so a released binary reports the real
+/// version rather than the repo's `0.0.0` placeholder.
+pub fn version_line() -> String {
+    format!("PlatypusGit {}\n", env!("CARGO_PKG_VERSION"))
+}
 
 fn screen_for(token: &str) -> Option<&'static str> {
     match token {
@@ -122,6 +136,9 @@ pub fn parse_args(args: &[String], cwd: &Path) -> Parsed {
     }
     if args.iter().any(|a| a == "--help" || a == "-h") {
         return Parsed::Help;
+    }
+    if args.iter().any(|a| a == "--version" || a == "-V") {
+        return Parsed::Version;
     }
     let mut screen: Option<String> = None;
     let mut path: Option<PathBuf> = None;
@@ -729,6 +746,19 @@ mod tests {
     }
 
     #[test]
+    fn version_flag_wins() {
+        assert_eq!(
+            parse_args(&s(&["--version"]), Path::new("/w")),
+            Parsed::Version
+        );
+        assert_eq!(parse_args(&s(&["-V"]), Path::new("/w")), Parsed::Version);
+        assert_eq!(
+            parse_args(&s(&["commit", "--version"]), Path::new("/w")),
+            Parsed::Version
+        );
+    }
+
+    #[test]
     fn path_only_opens_repo_without_screen() {
         assert_eq!(
             parse_args(&s(&["/abs/repo"]), Path::new("/w")),
@@ -965,6 +995,20 @@ mod tests {
             Parsed::Askpass("Password -h for 'x': ".to_string())
         );
     }
+
+    #[test]
+    fn a_prompt_containing_the_version_flag_is_not_read_as_that_flag() {
+        // Same hazard as above, for -V/--version.
+        let cwd = Path::new("/tmp");
+        assert_eq!(
+            parse_args(
+                &["--askpass".to_string(), "Password -V for 'x': ".to_string()],
+                cwd
+            ),
+            Parsed::Askpass("Password -V for 'x': ".to_string())
+        );
+    }
+
     // ─── the ownership contract (#144) ───────────────────────────────────────
     //
     // Every table below is exercised for all three OSes from whatever host runs

--- a/src-tauri/src/detach.rs
+++ b/src-tauri/src/detach.rs
@@ -15,8 +15,9 @@
 //! as `GIT_ASKPASS` and reads the credential from **its stdout, synchronously**,
 //! so a process that spawned a child and exited would hand git an empty
 //! credential and every authenticated fetch/pull/push would fail with nothing to
-//! trace it back to. `Parsed::Help` must stay synchronous too, or `USAGE` is
-//! printed by a child whose stdout is `/dev/null`.
+//! trace it back to. `Parsed::Help` and `Parsed::Version` must stay
+//! synchronous too, or their output is printed by a child whose stdout is
+//! `/dev/null`.
 //!
 //! A **dev build** must not detach either, whatever the arguments say (#197).
 //! `tauri dev` runs the app as its own child with the developer's terminal
@@ -257,6 +258,13 @@ mod tests {
         // USAGE must reach the terminal that asked for it.
         assert!(!should_detach(&Parsed::Help, env(true)));
         assert!(!should_detach(&Parsed::Help, env(false)));
+    }
+
+    #[test]
+    fn version_never_detaches() {
+        // The version line must reach the terminal that asked for it.
+        assert!(!should_detach(&Parsed::Version, env(true)));
+        assert!(!should_detach(&Parsed::Version, env(false)));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -58,8 +58,9 @@ pub fn run() {
     // reads the credential from its stdout, synchronously. A process that
     // spawned a child and exited would hand git an empty credential, and every
     // authenticated fetch, pull and push would fail with nothing to trace it
-    // back to. `Parsed::Help` must stay synchronous for the same reason at a
-    // lower stake: `USAGE` printed by a detached child goes to /dev/null.
+    // back to. `Parsed::Help` and `Parsed::Version` must stay synchronous for
+    // the same reason at a lower stake: their output printed by a detached
+    // child goes to /dev/null.
     //
     // ⚠️ And this is why `GIT_ASKPASS` points at the BARE EXECUTABLE rather than
     // at the installed `pgit` shim, which on every Unix channel is a symlink to
@@ -76,6 +77,10 @@ pub fn run() {
     let initial_intent = match parsed {
         cli::Parsed::Help => {
             print!("{}", cli::USAGE);
+            return;
+        }
+        cli::Parsed::Version => {
+            print!("{}", cli::version_line());
             return;
         }
         // Already handled above; unreachable in practice.


### PR DESCRIPTION
## Summary

`pgit --help` works; `pgit --version` did not — it fell through to path handling and launched the app on a repo named `--version`. This mirrors the existing `--help` path exactly:

- Adds `Parsed::Version` next to `Parsed::Help`.
- `parse_args` recognizes `--version` / `-V`, checked **after** the `--askpass` early return, so an askpass prompt (arbitrary text from git) is never scanned for our own flags — a table-driven test pins that a prompt containing `-V` is not read as the flag, mirroring the existing `-h` case.
- Prints `PlatypusGit <version>` and exits without opening a window, same as `Help`.
- Exempt from the launch detach the same way `Parsed::Help` already is (`should_detach` only ever says yes to `Parsed::Launch`, so this needed no logic change there — just an update to the doc comments and a mirrored test).
- Adds a `--version`/`-h` "Options" block to `USAGE` and a line to the README's CLI example list.

**Version source:** `env!("CARGO_PKG_VERSION")`. `src-tauri/Cargo.toml` says `0.0.0` in the repo, but `.github/workflows/release.yml` rewrites it (`sed -i ... src-tauri/Cargo.toml`) alongside `tauri.conf.json` before every release build, so a released binary reports the real tag rather than the placeholder.

## Tests

Added to the existing table-driven blocks in `src-tauri/src/cli.rs`:
- `version_flag_wins` — `--version`, `-V`, and `--version` after a subcommand token.
- `a_prompt_containing_the_version_flag_is_not_read_as_that_flag` — an askpass prompt containing `-V` stays a literal prompt.

Added to `src-tauri/src/detach.rs`:
- `version_never_detaches`, mirroring `help_never_detaches`.

## Test plan

- `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 160 passed, 0 failed.
- `cargo check --manifest-path src-tauri/Cargo.toml` — clean.
- `pnpm tsc --noEmit` — clean (no frontend changes needed).
- `pnpm vitest run` — 213 files / 1843 tests passed (includes the doc/tree invariants project).

Fixes #213

---
This PR was prepared with AI assistance (Claude); the diff was reviewed and all listed test commands were run and observed to pass before opening.