### PR TITLE
feat(repo): name the active repository and branch in the window title

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -99,9 +99,11 @@ git/
                  (user.name/email lookup, NoSignature when unset) and
                  apply_signoff (Signed-off-by trailer, idempotent)
 commands/        Thin Tauri handlers, one file per area:
-├── repo.rs      open_repo, close_repo, trust_repo_path, get_status,
-│                list_all_files, append_gitignore, open_in_editor, and THREE
-│                distinct file readers: read_file_content (working tree),
+├── repo.rs      open_repo, close_repo, trust_repo_path, get_status, head_info
+│                (HEAD's branch/oid, re-polled every refresh — unlike
+│                RepoHandle.head, which open_repo sets once), list_all_files,
+│                append_gitignore, open_in_editor, and THREE distinct file
+│                readers: read_file_content (working tree),
 │                read_file_content_at_rev + list_files_at_rev (a commit's tree),
 │                read_file_content_at_index (the STAGED blob)
 ├── cli.rs       take_launch_intent, cli_shim_status, install_cli_shim

--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -4,7 +4,7 @@ use tauri::State;
 
 use crate::{
     error::{AppError, AppResult},
-    git::types::{FileContent, FileStatus, RepoHandle, RepoId},
+    git::types::{FileContent, FileStatus, HeadInfo, RepoHandle, RepoId},
     state::AppState,
 };
 
@@ -41,6 +41,18 @@ pub async fn trust_repo_path(state: State<'_, AppState>, path: String) -> AppRes
     let backend = state.backend.clone();
     let path_buf = PathBuf::from(path);
     tokio::task::spawn_blocking(move || backend.trust_path(&path_buf))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+/// HEAD's current branch/oid, meant to be re-polled on every refresh — unlike
+/// `RepoHandle.head`, which `open_repo` sets once and the frontend must not
+/// treat as live after a checkout (#217).
+#[tauri::command]
+pub async fn head_info(state: State<'_, AppState>, repo_id: String) -> AppResult<HeadInfo> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    tokio::task::spawn_blocking(move || backend.head_info(&repo_id))
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
 }

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -6,7 +6,7 @@ use super::{
     types::{
         AheadBehind, BisectMark, BisectStatus, BlameLine, BranchInfo, CommitInfo, CommitOptions, ConflictSides,
         DiffKind, FileContent,
-        FileDiff, FileStatus, LfsStatus, LogFilter, LogPage, RebaseStatus, RebaseStep, ReflogEntry,
+        FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage, RebaseStatus, RebaseStep, ReflogEntry,
         RemoteInfo, RepoHandle, RepoId, RepoState, ResetMode, StashInfo, StashSaveOptions,
         SubmoduleInfo, TagInfo,
         TagTarget, WorkdirDiff, WorktreeBranch, WorktreeInfo,
@@ -359,6 +359,9 @@ impl GitBackend for CliBackend {
         Err(AppError::NotImplemented)
     }
     fn repo_state(&self, _repo_id: &RepoId) -> AppResult<RepoState> {
+        Err(AppError::NotImplemented)
+    }
+    fn head_info(&self, _repo_id: &RepoId) -> AppResult<HeadInfo> {
         Err(AppError::NotImplemented)
     }
     fn conflict_sides(&self, _repo_id: &RepoId, _path: &Path) -> AppResult<ConflictSides> {

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -17,7 +17,7 @@ use super::{
     types::{
         AheadBehind, BisectMark, BisectStatus,
         BlameLine, BranchInfo, CommitInfo, CommitOptions, ConflictSides, DiffHunk, DiffKind,
-        DiffLine, DiffLineKind, FileContent, FileDiff, FileStatus, LfsStatus, LogFilter, LogPage,
+        DiffLine, DiffLineKind, FileContent, FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage,
         RebaseAction, RebaseStatus, RebaseStep, RebaseSummary, ReflogEntry, ReflogOp, RemoteInfo,
         RepoHandle, RepoId, RepoState, ResetMode, StashInfo, StashSaveOptions, StatusFlag,
         SubmoduleInfo, TagInfo, TagTarget, WorkdirDiff, WorktreeBranch, WorktreeInfo, REFSPEC_ALL,
@@ -4984,6 +4984,25 @@ impl GitBackend for Libgit2Backend {
                 RS::ApplyMailbox => RepoState::ApplyMailbox,
                 RS::ApplyMailboxOrRebase => RepoState::ApplyMailboxOrRebase,
             })
+        })
+    }
+
+    fn head_info(&self, repo_id: &RepoId) -> AppResult<HeadInfo> {
+        self.with_repo(repo_id, |repo| {
+            // Same split `WorktreeInfo`'s listing already uses: `head()` errors
+            // on an unborn branch (leaving both fields `None`), and a detached
+            // HEAD resolves to a reference literally named "HEAD" whose
+            // `shorthand()` is "HEAD" itself, not a branch — `is_branch()` is
+            // what actually distinguishes the two, not presence of a name.
+            let head = repo.head().ok();
+            let branch = head
+                .as_ref()
+                .filter(|h| h.is_branch())
+                .and_then(|h| h.shorthand().map(str::to_string));
+            let head_oid = head
+                .and_then(|h| h.peel_to_commit().ok())
+                .map(|c| c.id().to_string());
+            Ok(HeadInfo { branch, head_oid })
         })
     }
 

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -21,7 +21,7 @@ use types::{
     AheadBehind,
     BisectMark, BisectStatus, BlameLine, BranchInfo, CommitInfo, CommitOptions, ConflictSides,
     DiffKind, FileContent,
-    FileDiff, FileStatus, LfsStatus, LogFilter, LogPage, RebaseStatus, RebaseStep, ReflogEntry,
+    FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage, RebaseStatus, RebaseStep, ReflogEntry,
     RemoteInfo,
     RepoHandle,
     RepoId, RepoState, ResetMode, StashInfo, StashSaveOptions, SubmoduleInfo, TagInfo, TagTarget,
@@ -511,6 +511,9 @@ pub trait GitBackend: Send + Sync {
     // === conflict resolution ===
     /// Return the current operation state of the repo (Merge, CherryPick, etc.).
     fn repo_state(&self, repo_id: &RepoId) -> AppResult<RepoState>;
+    /// Return HEAD's current branch/oid, refreshed on demand rather than only
+    /// at `open` (#217).
+    fn head_info(&self, repo_id: &RepoId) -> AppResult<HeadInfo>;
     /// Read the three index stages for a conflicted file (base/ours/theirs).
     fn conflict_sides(&self, repo_id: &RepoId, path: &Path) -> AppResult<ConflictSides>;
     /// Write stage 2 (ours) to the worktree file and stage it.

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -417,6 +417,18 @@ pub enum RepoState {
     ApplyMailboxOrRebase,
 }
 
+/// Current HEAD identity, refreshed on every `refreshAll` (#217) so the
+/// window title can follow checkouts rather than the one-shot value `open`
+/// returns on `RepoHandle`. Same branch/oid split `WorktreeInfo` already
+/// uses: `branch` is `None` on a detached HEAD, `head_oid` is `None` only on
+/// an unborn branch (a fresh `git init` with no commits).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HeadInfo {
+    pub branch: Option<String>,
+    pub head_oid: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BlameLine {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -169,6 +169,7 @@ pub fn run() {
             commands::repo::close_repo,
             commands::repo::trust_repo_path,
             commands::repo::get_status,
+            commands::repo::head_info,
             commands::repo::list_all_files,
             commands::repo::read_file_content,
             commands::repo::list_files_at_rev,

--- a/src-tauri/tests/head_info.rs
+++ b/src-tauri/tests/head_info.rs
@@ -1,0 +1,34 @@
+mod support;
+
+use platypusgit_lib::git::GitBackend;
+use support::TempRepo;
+
+#[test]
+fn on_a_branch_reports_the_branch_and_the_tip_oid() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let info = backend.head_info(&handle.id).expect("head_info");
+    assert_eq!(info.branch.as_deref(), Some("main"));
+    let expected_oid = tr.repo.head().unwrap().target().unwrap().to_string();
+    assert_eq!(info.head_oid.as_deref(), Some(expected_oid.as_str()));
+}
+
+#[test]
+fn detached_head_reports_no_branch_but_the_oid() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let oid = tr.repo.head().unwrap().target().unwrap();
+    tr.repo.set_head_detached(oid).unwrap();
+    let (backend, handle) = tr.open_with_backend();
+    let info = backend.head_info(&handle.id).expect("head_info");
+    assert_eq!(info.branch, None);
+    assert_eq!(info.head_oid.as_deref(), Some(oid.to_string().as_str()));
+}
+
+#[test]
+fn unborn_branch_reports_neither_branch_nor_oid() {
+    let tr = TempRepo::fresh();
+    let (backend, handle) = tr.open_with_backend();
+    let info = backend.head_info(&handle.id).expect("head_info");
+    assert_eq!(info.branch, None);
+    assert_eq!(info.head_oid, None);
+}

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -37,6 +37,7 @@ import { useTabsStore } from "@/features/repo/useTabsStore";
 import { RepoTabs } from "@/features/repo/RepoTabs";
 import { headUpstream, openRepoDialog } from "@/features/repo/ops";
 import { windowTitleFor } from "@/features/repo/windowTitle";
+import { indexOfTab, labelTabs } from "@/features/repo/tabs";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useCliLaunch } from "@/features/cli/useCliLaunch";
 import {
@@ -297,17 +298,25 @@ export function AppShell() {
 
   // Name the active repository and its checked-out branch in the OS window
   // title (#217) — otherwise every window/tab reads as the identical
-  // "PlatypusGit" in the window switcher, dock, and Mission Control. `tabs`
-  // (for the disambiguated label) and `headInfo` (which follows checkouts,
-  // unlike `repo.head`) are both already live state; this effect only
-  // reacts to them, the same shape `MergeWindow.tsx` uses for its own title.
-  const tabs = useTabsStore((s) => s.tabs);
+  // "PlatypusGit" in the window switcher, dock, and Mission Control.
+  // `headInfo` follows checkouts, unlike `repo.head`; the same shape
+  // `MergeWindow.tsx` uses for its own title.
+  //
+  // The label is derived INSIDE the selector so what this component
+  // subscribes to is a string, which zustand compares by value. Selecting
+  // `s.tabs` instead would re-render the whole shell (titlebar, RepoTabs,
+  // the dialogs, AppBody, CommandPalette) on every write to any tab —
+  // `refreshBadges()` patches one tab per inactive repo on each window
+  // focus, so alt-tabbing back would cost a full-tree render per open tab.
+  // Same lesson as the `useRepoStore()` note further down this file.
+  const repoLabel = useTabsStore((s) => {
+    const i = indexOfTab(s.tabs, s.activePath);
+    return i < 0 ? null : labelTabs(s.tabs)[i] ?? null;
+  });
   const headInfo = useRepoStore((s) => s.headInfo);
   React.useEffect(() => {
-    const index = tabs.findIndex((t) => t.path === activePath);
-    const repoLabel = index >= 0 ? useTabsStore.getState().labels()[index] : null;
     void getCurrentWindow().setTitle(windowTitleFor(repoLabel, headInfo));
-  }, [tabs, activePath, headInfo]);
+  }, [repoLabel, headInfo]);
 
   const intent = useNavStore((s) => s.intent);
   const clearIntent = useNavStore((s) => s.clearIntent);

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -1,4 +1,5 @@
 import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import React from "react";
 import {
   PGActivityBar,
@@ -35,6 +36,7 @@ import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useTabsStore } from "@/features/repo/useTabsStore";
 import { RepoTabs } from "@/features/repo/RepoTabs";
 import { headUpstream, openRepoDialog } from "@/features/repo/ops";
+import { windowTitleFor } from "@/features/repo/windowTitle";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useCliLaunch } from "@/features/cli/useCliLaunch";
 import {
@@ -292,6 +294,20 @@ export function AppShell() {
     setScreen((remembered as ScreenId | null) ?? "history");
     setEntryTick((t) => t + 1);
   }, [activePath]);
+
+  // Name the active repository and its checked-out branch in the OS window
+  // title (#217) — otherwise every window/tab reads as the identical
+  // "PlatypusGit" in the window switcher, dock, and Mission Control. `tabs`
+  // (for the disambiguated label) and `headInfo` (which follows checkouts,
+  // unlike `repo.head`) are both already live state; this effect only
+  // reacts to them, the same shape `MergeWindow.tsx` uses for its own title.
+  const tabs = useTabsStore((s) => s.tabs);
+  const headInfo = useRepoStore((s) => s.headInfo);
+  React.useEffect(() => {
+    const index = tabs.findIndex((t) => t.path === activePath);
+    const repoLabel = index >= 0 ? useTabsStore.getState().labels()[index] : null;
+    void getCurrentWindow().setTitle(windowTitleFor(repoLabel, headInfo));
+  }, [tabs, activePath, headInfo]);
 
   const intent = useNavStore((s) => s.intent);
   const clearIntent = useNavStore((s) => s.clearIntent);

--- a/src/AppShell.windowTitle.test.tsx
+++ b/src/AppShell.windowTitle.test.tsx
@@ -1,0 +1,171 @@
+// The OS window title names the active repository and its checked-out
+// branch (#217) — otherwise every window shows the identical "PlatypusGit"
+// in the window switcher, dock, and Mission Control.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+import App from "./App";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useRecentsStore } from "@/features/repo/useRecentsStore";
+import { useTabsStore } from "@/features/repo/useTabsStore";
+import { emptySlice } from "@/features/repo/repoSlice";
+import { newTab } from "@/features/repo/tabs";
+import { useFocusStore } from "@/features/keymap";
+import { mockInvoke } from "@/test/invokeMock";
+import type { HeadInfo, RepoHandle } from "@/lib/types";
+
+const REPO: RepoHandle = { id: "r-1", path: "/dev/myrepo", head: "main" };
+
+function wire() {
+  for (const cmd of [
+    "get_status",
+    "list_all_files",
+    "list_branches",
+    "list_tags",
+    "list_stashes",
+    "list_remotes",
+    "get_reflog",
+    "diff_commit",
+    "diff_commits",
+  ]) {
+    mockInvoke(cmd, () => []);
+  }
+  mockInvoke("open_repo", () => REPO);
+  mockInvoke("close_repo", () => undefined);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => ({
+    inProgress: false,
+    nextIndex: 0,
+    total: 0,
+    pauseReason: null,
+  }));
+  mockInvoke("head_info", (): HeadInfo => ({ branch: "main", headOid: "a".repeat(40) }));
+  mockInvoke("take_launch_intent", () => null);
+  mockInvoke("cli_shim_status", () => ({
+    installed: false,
+    shimPath: "",
+    target: "",
+    source: "none",
+    pathState: "offPath",
+  }));
+  mockInvoke("get_diff", () => null);
+  mockInvoke("check_for_update", () => null);
+  mockInvoke("get_update_capability", () => ({ canSelfUpdate: false }));
+}
+
+function currentTitle(): string {
+  const win = getCurrentWindow();
+  const calls = (win.setTitle as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+  return calls[calls.length - 1]?.[0] as string;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  useRecentsStore.setState({ recents: [] });
+  useFocusStore.setState({
+    focused: null,
+    panes: new Map(),
+    order: [],
+    barId: null,
+    primaryId: null,
+    pendingContentFocus: false,
+  });
+  useTabsStore.setState({
+    tabs: [],
+    activePath: null,
+    activationSeq: 0,
+    activating: null,
+  });
+  useRepoStore.setState(emptySlice() as never);
+  (getCurrentWindow().setTitle as unknown as { mockClear: () => void }).mockClear();
+  wire();
+});
+
+describe("AppShell — window title", () => {
+  it("is just the app name with no repo open", async () => {
+    render(<App />);
+    await waitFor(() => expect(currentTitle()).toBe("PlatypusGit"));
+  });
+
+  it("names the repo and its branch once a repo is open", async () => {
+    useRepoStore.setState({
+      ...emptySlice(),
+      current: REPO,
+      headInfo: { branch: "main", headOid: "a".repeat(40) },
+    } as never);
+    useTabsStore.setState({
+      tabs: [newTab("/dev/myrepo", { status: "open", repoId: "r-1" })],
+      activePath: "/dev/myrepo",
+      activationSeq: 0,
+      activating: null,
+    });
+    render(<App />);
+    await waitFor(() =>
+      expect(currentTitle()).toBe("myrepo — main — PlatypusGit"),
+    );
+  });
+
+  it("shows the short oid on a detached HEAD instead of an empty segment", async () => {
+    useRepoStore.setState({
+      ...emptySlice(),
+      current: REPO,
+      headInfo: { branch: null, headOid: "abc1234def5678" },
+    } as never);
+    useTabsStore.setState({
+      tabs: [newTab("/dev/myrepo", { status: "open", repoId: "r-1" })],
+      activePath: "/dev/myrepo",
+      activationSeq: 0,
+      activating: null,
+    });
+    render(<App />);
+    await waitFor(() =>
+      expect(currentTitle()).toBe("myrepo — abc1234 — PlatypusGit"),
+    );
+  });
+
+  it("drops the branch segment on an unborn branch", async () => {
+    useRepoStore.setState({
+      ...emptySlice(),
+      current: REPO,
+      headInfo: { branch: null, headOid: null },
+    } as never);
+    useTabsStore.setState({
+      tabs: [newTab("/dev/myrepo", { status: "open", repoId: "r-1" })],
+      activePath: "/dev/myrepo",
+      activationSeq: 0,
+      activating: null,
+    });
+    render(<App />);
+    await waitFor(() => expect(currentTitle()).toBe("myrepo — PlatypusGit"));
+  });
+
+  it("returns to the app name alone after the repo closes", async () => {
+    useRepoStore.setState({
+      ...emptySlice(),
+      current: REPO,
+      headInfo: { branch: "main", headOid: "a".repeat(40) },
+    } as never);
+    useTabsStore.setState({
+      tabs: [newTab("/dev/myrepo", { status: "open", repoId: "r-1" })],
+      activePath: "/dev/myrepo",
+      activationSeq: 0,
+      activating: null,
+    });
+    render(<App />);
+    await waitFor(() =>
+      expect(currentTitle()).toBe("myrepo — main — PlatypusGit"),
+    );
+
+    useRepoStore.setState(emptySlice() as never);
+    useTabsStore.setState({
+      tabs: [],
+      activePath: null,
+      activationSeq: 0,
+      activating: null,
+    });
+    await waitFor(() => expect(currentTitle()).toBe("PlatypusGit"));
+  });
+});

--- a/src/features/repo/repoSlice.ts
+++ b/src/features/repo/repoSlice.ts
@@ -27,6 +27,7 @@ import type {
   BranchInfo,
   CommitInfo,
   FileStatus,
+  HeadInfo,
   LogFilter,
   RebaseStatus,
   RemoteInfo,
@@ -64,6 +65,12 @@ export const DEFAULT_BISECT_STATUS: BisectStatus = {
 /** Every field of `useRepoStore` that belongs to one repository. */
 export interface RepoSlice {
   current: RepoHandle | null;
+  /**
+   * HEAD's current branch/oid, re-fetched on every `refreshAll` (#217) —
+   * unlike `current.head`, which `open` sets once and does not follow a
+   * checkout within the session.
+   */
+  headInfo: HeadInfo | null;
   status: FileStatus[];
   /** Every (non-ignored) file in the worktree, populated lazily by listAllFiles. */
   allFiles: FileStatus[];
@@ -134,6 +141,7 @@ export interface RepoSlice {
 export function emptySlice(): RepoSlice {
   return {
     current: null,
+    headInfo: null,
     status: [],
     allFiles: [],
     branches: [],

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -46,6 +46,7 @@ import {
   getLogFilteredPage,
   getLogPage,
   getStatus,
+  headInfo as headInfoFn,
   listAllFiles,
   listFilesAtRev as listFilesAtRevFn,
   readFileContentAtRev as readFileContentAtRevFn,
@@ -613,6 +614,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         repoState,
         rebaseStatus,
         bisectStatus,
+        headInfo,
       ] = await Promise.all([
           getStatus(repo.id),
           listBranches(repo.id),
@@ -635,6 +637,9 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
           // the same reasoning as the browsed-ref fallback above. The cost of the
           // fallback is a bar without step counts, not a broken screen.
           bisectStatusFn(repo.id).catch(() => DEFAULT_BISECT_STATUS),
+          // Same degrade-don't-fail policy: the window title (#217) falls back
+          // to just the repo name rather than losing the whole refresh.
+          headInfoFn(repo.id).catch(() => null),
         ]);
       setFor(repo.id, {
         status,
@@ -648,6 +653,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         repoState,
         rebaseStatus,
         bisectStatus,
+        headInfo,
         loading: false,
       });
       // Keep an active search in sync with the refreshed history.

--- a/src/features/repo/windowTitle.test.ts
+++ b/src/features/repo/windowTitle.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { windowTitleFor } from "./windowTitle";
+
+describe("windowTitleFor", () => {
+  it("is just the app name with no repo open", () => {
+    expect(windowTitleFor(null, null)).toBe("PlatypusGit");
+  });
+
+  it("puts the branch between the repo name and the app name", () => {
+    expect(windowTitleFor("myrepo", { branch: "main", headOid: "abc123" })).toBe(
+      "myrepo — main — PlatypusGit",
+    );
+  });
+
+  it("falls back to the short oid on a detached HEAD", () => {
+    expect(
+      windowTitleFor("myrepo", {
+        branch: null,
+        headOid: "a1b2c3d4e5f6",
+      }),
+    ).toBe("myrepo — a1b2c3d — PlatypusGit");
+  });
+
+  it("drops the branch segment on an unborn branch (no commits yet)", () => {
+    expect(windowTitleFor("myrepo", { branch: null, headOid: null })).toBe(
+      "myrepo — PlatypusGit",
+    );
+  });
+
+  it("drops the branch segment when head info has not loaded yet", () => {
+    expect(windowTitleFor("myrepo", null)).toBe("myrepo — PlatypusGit");
+  });
+});

--- a/src/features/repo/windowTitle.ts
+++ b/src/features/repo/windowTitle.ts
@@ -1,0 +1,30 @@
+import type { HeadInfo } from "@/lib/types";
+
+/** How many hex characters of a full oid the title shows (#217). Matches the
+ *  short-oid length used elsewhere in the app (`shortOid` on `CommitInfo`). */
+const SHORT_OID_LEN = 7;
+
+/**
+ * The OS window title for the active repository (#217).
+ *
+ * Pure so the effect that calls `setTitle` carries no fallback logic of its
+ * own — the four cases below are exactly the ones a window switcher, dock, or
+ * Mission Control needs to tell repositories apart:
+ *
+ *   - No repo open              → "PlatypusGit"
+ *   - On a branch                → "myrepo — main — PlatypusGit"
+ *   - Detached HEAD               → "myrepo — a1b2c3d — PlatypusGit"
+ *   - Unborn branch (no commits) → "myrepo — PlatypusGit"
+ *
+ * The repo name comes first and the app name last: window switchers and
+ * taskbar tooltips truncate from the right, so the part that distinguishes
+ * windows has to lead.
+ */
+export function windowTitleFor(
+  repoLabel: string | null,
+  head: HeadInfo | null,
+): string {
+  if (!repoLabel) return "PlatypusGit";
+  const branch = head?.branch ?? (head?.headOid ? head.headOid.slice(0, SHORT_OID_LEN) : null);
+  return branch ? `${repoLabel} — ${branch} — PlatypusGit` : `${repoLabel} — PlatypusGit`;
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -23,6 +23,7 @@ import type {
   ForgeKind,
   ForgeRepo,
   ForgeTokenStatus,
+  HeadInfo,
   LaunchIntent,
   LfsStatus,
   LogFilter,
@@ -98,6 +99,15 @@ export async function trustRepoPath(path: string): Promise<void> {
 
 export async function getStatus(repoId: string): Promise<FileStatus[]> {
   return invoke<FileStatus[]>("get_status", { repoId });
+}
+
+/**
+ * HEAD's current branch/oid. Unlike `RepoHandle.head` (set once by
+ * `openRepo`), this is meant to be re-polled on every refresh so it follows
+ * checkouts within the session (#217).
+ */
+export async function headInfo(repoId: string): Promise<HeadInfo> {
+  return invoke<HeadInfo>("head_info", { repoId });
 }
 
 export async function listAllFiles(repoId: string): Promise<FileStatus[]> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -306,6 +306,17 @@ export type RepoState =
   | "ApplyMailbox"
   | "ApplyMailboxOrRebase";
 
+/**
+ * Current HEAD identity, refreshed on every `refreshAll` (#217) — unlike
+ * `RepoHandle.head`, which `open_repo` sets once and goes stale after a
+ * checkout. `branch` is `null` on a detached HEAD; `headOid` is `null` only
+ * on an unborn branch (a fresh `git init` with no commits).
+ */
+export interface HeadInfo {
+  branch: string | null;
+  headOid: string | null;
+}
+
 export interface ConflictSides {
   path: string;
   base: string | null;


### PR DESCRIPTION
## Summary

The window title was the static string `"PlatypusGit"`. With several repos open in tabs, or the app sitting among other windows, the OS window switcher, dock/taskbar, and Mission Control all show identical entries.

- `myrepo — main — PlatypusGit` — on a branch
- `myrepo — a1b2c3d — PlatypusGit` — detached HEAD, short oid instead of an empty segment
- `myrepo — PlatypusGit` — unborn branch (fresh `git init`, no commits yet)
- `PlatypusGit` — no repo open (Welcome)

Repo name first, app name last: window switchers and taskbar tooltips truncate from the right, so the part that distinguishes windows has to lead.

## Why a new backend field

`RepoHandle.head` (set once by `open_repo`) does not follow a checkout within the session — nothing in the app re-fetches it after `checkoutBranch`/`checkoutRef`/rebase etc., only `refreshAll`'s already-live fields (`branches`, `status`, …) do. Relying on it directly for the title would silently go stale on exactly the case the issue calls out as regression-prone (detached HEAD after a checkout).

So this adds `head_info` (`src-tauri/src/commands/repo.rs`), a small read mirroring the branch/oid split `WorktreeInfo`'s own worktree listing already uses (`branch: Option<String>`, `head_oid: Option<String>` — `branch` is `None` on a detached HEAD, `head_oid` is `None` only when unborn). It's called alongside the rest of `refreshAll`'s `Promise.all` in `useRepoStore.ts`, degrading to `null` on failure rather than failing the whole refresh (same policy as `bisect_status`).

Note: `repo.head()`'s `shorthand()` returns the literal string `"HEAD"` on a detached HEAD (not an oid) — confirmed with a throwaway git2 probe — so `is_branch()` is what actually distinguishes "on a branch" from "detached", not just presence of a name.

## Implementation

- `src-tauri/src/git/types.rs` — `HeadInfo { branch, head_oid }`.
- `src-tauri/src/git/mod.rs` / `libgit2.rs` / `cli.rs` — trait method, implementation, `NotImplemented` stub (standard `GitBackend` op pattern).
- `src-tauri/src/commands/repo.rs` + `lib.rs` invoke_handler — `head_info` command.
- `src/lib/types.ts` / `tauri.ts` — TS mirror + wrapper.
- `src/features/repo/repoSlice.ts` / `useRepoStore.ts` — new `headInfo` slice field, refreshed in `refreshAll`.
- `src/features/repo/windowTitle.ts` — pure `windowTitleFor(repoLabel, head)`, so the effect carries no fallback logic of its own.
- `src/AppShell.tsx` — an effect reacting to the active tab's disambiguated label (`useTabsStore`'s existing `labels()` — previously unused anywhere in the app) and `headInfo`, calling `getCurrentWindow().setTitle(...)` the same way `MergeWindow.tsx` already does for its own window.
- `docs/dev/architecture.md` — new command listed under `commands/repo.rs`.

## Tests

- `src-tauri/tests/head_info.rs` — three backend cases: on a branch, detached HEAD, unborn branch.
- `src/features/repo/windowTitle.test.ts` — all five title-format cases as pure-function unit tests.
- `src/AppShell.windowTitle.test.tsx` — component test using the existing `setTitle` mock (`src/test/setup.ts`), covering no-repo, on-branch, detached, unborn, and repo-close.

## Test plan

- `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 157 passed, 0 failed.
- `cargo test --manifest-path src-tauri/Cargo.toml --test head_info` — 3 passed.
- `pnpm tsc --noEmit` — clean.
- `pnpm vitest run` — 215 files / 1853 tests passed (includes doc/tree invariants).

Fixes #217

---
This PR was prepared with AI assistance (Claude); the diff was reviewed and all listed test commands were run and observed to pass before opening.