### PR TITLE
feat(cli): add subcommand aliases for 7 more screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,15 @@ pgit --help             # print usage, no window
 |---|---|
 | `commit`, `status` | Commit panel |
 | `log`, `history` | History |
-| `branches` | Branches |
+| `branches`, `branch` | Branches |
+| `files`, `browse`, `tree` | Files |
+| `rebase` | Rebase |
+| `remote`, `remotes` | Remotes |
+| `pr`, `prs`, `pulls` | Pull requests |
+| `reflog` | Reflog |
+| `submodules` | Submodules |
+| `worktrees` | Worktrees |
+| `settings`, `config` | Settings |
 
 A bare path (no recognized subcommand) just opens that repo, keeping the
 current screen. If the app is already running, a second `pgit …` invocation

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -84,9 +84,17 @@ PlatypusGit
 Usage: pgit [subcommand] [path]
 
 Subcommands:
-  commit | status    open the Commit panel
-  log | history      open the History screen
-  branches           open the Branches screen
+  commit | status           open the Commit panel
+  log | history             open the History screen
+  branches | branch         open the Branches screen
+  files | browse | tree     open the Files screen
+  rebase                    open the Rebase screen
+  remote | remotes          open the Remotes screen
+  pr | prs | pulls          open the Pull requests screen
+  reflog                    open the Reflog screen
+  submodules                open the Submodules screen
+  worktrees                 open the Worktrees screen
+  settings | config         open Settings
 
 With a path and no subcommand, opens the repo containing that path.
 With a subcommand and no path, uses the current directory.
@@ -97,7 +105,15 @@ fn screen_for(token: &str) -> Option<&'static str> {
     match token {
         "commit" | "status" => Some("commit"),
         "log" | "history" => Some("history"),
-        "branches" => Some("branches"),
+        "branches" | "branch" => Some("branches"),
+        "files" | "browse" | "tree" => Some("repo"),
+        "rebase" => Some("rebase"),
+        "remote" | "remotes" => Some("remote"),
+        "pr" | "prs" | "pulls" => Some("pulls"),
+        "reflog" => Some("reflog"),
+        "submodules" => Some("submodules"),
+        "worktrees" => Some("worktrees"),
+        "settings" | "config" => Some("settings"),
         _ => None,
     }
 }
@@ -758,6 +774,21 @@ mod tests {
             ("log", "history"),
             ("history", "history"),
             ("branches", "branches"),
+            ("branch", "branches"),
+            ("files", "repo"),
+            ("browse", "repo"),
+            ("tree", "repo"),
+            ("rebase", "rebase"),
+            ("remote", "remote"),
+            ("remotes", "remote"),
+            ("pr", "pulls"),
+            ("prs", "pulls"),
+            ("pulls", "pulls"),
+            ("reflog", "reflog"),
+            ("submodules", "submodules"),
+            ("worktrees", "worktrees"),
+            ("settings", "settings"),
+            ("config", "settings"),
         ] {
             assert_eq!(
                 parse_args(&s(&[cmd]), Path::new("/w")),


### PR DESCRIPTION
## Summary

`pgit` reached only `commit`/`status`, `log`/`history`, and `branches` — a quarter of the app's 11 top-level screens — and a bare `pgit branch` (singular, an easy typo) fell through to path handling instead of being recognised as a subcommand.

Extends `screen_for` (`src-tauri/src/cli.rs`) with the remaining `ACTIVITY_ITEMS`/`ScreenId` targets, exactly the table from the issue:

| subcommand | screen |
|---|---|
| `branch` (alias) | `branches` |
| `files`, `browse`, `tree` | `repo` |
| `rebase` | `rebase` |
| `remote`, `remotes` | `remote` |
| `pr`, `prs`, `pulls` | `pulls` |
| `reflog` | `reflog` |
| `submodules` | `submodules` |
| `worktrees` | `worktrees` |
| `settings`, `config` | `settings` |

Every screen string was checked against `ScreenId` in `src/AppShell.tsx` (`repo`, `commit`, `history`, `branches`, `rebase`, `remote`, `pulls`, `reflog`, `submodules`, `worktrees`, `settings`) to avoid the "typo compiles on both sides, fails silently at runtime" trap the issue warns about.

## Scope

Deliberately following the issue's own boundary rather than expanding it:

- **Deep views** (`diff`, `commitDiff`, `compare`, `fileHistory`, `blame`) are out of scope — they need a payload (a commit, a file, a revision) that `AppShell` doesn't restore, exactly as the issue says. Note this also means the `diff` viewer screen itself (which sits at the top level of `ACTIVITY_ITEMS`, unlike the other deep views) is intentionally left out too, matching the issue's table, which does not list it.
- **The "typo-detection" idea** the issue raises (print usage + exit non-zero for an unrecognised token that is clearly not a path) is **not implemented here**. Doing it properly needs a filesystem existence check inside `parse_args`, which is documented as "Pure — no filesystem access" by design — changing that is a bigger, separate change with its own regression surface (it would also change today's `unknown_first_token_is_a_path` behavior for anyone with a path-like directory name). Better scoped as its own follow-up issue, which is consistent with this issue's own framing ("Argue your choice in the PR" / "a good separate issue" language used for the similarly-scoped `blame` case).

## Tests

Added every new alias to the existing `(token, screen)` table-driven test in `src-tauri/src/cli.rs` (`subcommand_without_path_uses_cwd`), plus the `USAGE` constant and the README's subcommand table.

## Test plan

- `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 157 passed, 0 failed (41 in `cli::`).
- `cargo check --manifest-path src-tauri/Cargo.toml` — clean.
- `pnpm tsc --noEmit` — clean (no `src/` changes needed).
- `pnpm vitest run` — 213 files / 1843 tests passed (includes doc/tree invariants).

Fixes #216

---
This PR was prepared with AI assistance (Claude); the diff was reviewed and all listed test commands were run and observed to pass before opening.