### PR TITLE
feat(shell): name the active repository and branch in the window title

### DIFF
--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -1,4 +1,5 @@
 import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import React from "react";
 import {
   PGActivityBar,
@@ -74,6 +75,7 @@ import {
   isStaged,
   isUnstaged,
   totalAheadBehind,
+  windowTitle,
 } from "@/lib/derive";
 
 export type ScreenId =
@@ -162,8 +164,19 @@ export function AppShell() {
   usePreventBrowserContextMenu();
   useCliLaunch();
   const repo = useRepoStore((s) => s.current);
+  const branches = useRepoStore((s) => s.branches);
   const error = useRepoStore((s) => s.error);
   const clearError = useRepoStore((s) => s.clearError);
+
+  // Keep the OS window title naming the active repository and branch (#217):
+  // window switchers, the dock/taskbar and Mission Control otherwise show
+  // identical "PlatypusGit" entries for every open repo. `windowTitle` already
+  // covers detached HEAD (short OID) and unborn (repo name only); this effect
+  // just follows whatever it derives across tab switches, checkouts and close.
+  const title = windowTitle(repo?.path ?? null, branches, repo?.head ?? null);
+  React.useEffect(() => {
+    void getCurrentWindow().setTitle(title);
+  }, [title]);
 
   // Launch always lands on History — it is the screen that answers "what is
   // going on in this repo", so it is worth more than restoring wherever the

--- a/src/AppShell.windowtitle.test.tsx
+++ b/src/AppShell.windowtitle.test.tsx
@@ -1,0 +1,170 @@
+// The OS window title names the active repository and branch (#217), so
+// window switchers, the dock/taskbar and Mission Control stop showing
+// identical "PlatypusGit" entries for every open window.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, render, waitFor } from "@testing-library/react";
+
+import App from "./App";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useRecentsStore } from "@/features/repo/useRecentsStore";
+import { useTabsStore } from "@/features/repo/useTabsStore";
+import { emptySlice } from "@/features/repo/repoSlice";
+import { newTab } from "@/features/repo/tabs";
+import { useFocusStore } from "@/features/keymap";
+import { mockInvoke } from "@/test/invokeMock";
+import type { BranchInfo, RepoHandle } from "@/lib/types";
+
+function branch(over: Partial<BranchInfo> = {}): BranchInfo {
+  return {
+    name: "main",
+    isHead: true,
+    isRemote: false,
+    upstream: null,
+    ahead: 0,
+    behind: 0,
+    tip: "deadbeefcafe",
+    tipTime: 0,
+    isDefault: true,
+    ...over,
+  };
+}
+
+function wire() {
+  for (const cmd of [
+    "get_status",
+    "list_all_files",
+    "list_branches",
+    "list_tags",
+    "list_stashes",
+    "list_remotes",
+    "get_reflog",
+    "diff_commit",
+    "diff_commits",
+  ]) {
+    mockInvoke(cmd, () => []);
+  }
+  mockInvoke("close_repo", () => undefined);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => ({
+    inProgress: false,
+    nextIndex: 0,
+    total: 0,
+    pauseReason: null,
+  }));
+  mockInvoke("take_launch_intent", () => null);
+  mockInvoke("cli_shim_status", () => ({
+    installed: false,
+    shimPath: "",
+    target: "",
+    source: "none",
+    pathState: "offPath",
+  }));
+  mockInvoke("get_diff", () => null);
+  mockInvoke("check_for_update", () => null);
+  mockInvoke("get_update_capability", () => ({ canSelfUpdate: false }));
+}
+
+/** Seed one already-open tab, bypassing the async open flow — same shortcut
+ *  `AppShell.tabs.test.tsx`'s `seedTwoTabs` uses. */
+function seedOpenTab(handle: RepoHandle, branches: BranchInfo[]) {
+  useRepoStore.setState({ ...emptySlice(), current: handle, branches } as never);
+  useTabsStore.setState({
+    tabs: [newTab(handle.path, { status: "open", repoId: handle.id })],
+    activePath: handle.path,
+    activationSeq: 0,
+    activating: null,
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  useRecentsStore.setState({ recents: [] });
+  useFocusStore.setState({
+    focused: null,
+    panes: new Map(),
+    order: [],
+    barId: null,
+    primaryId: null,
+    pendingContentFocus: false,
+  });
+  useTabsStore.setState({
+    tabs: [],
+    activePath: null,
+    activationSeq: 0,
+    activating: null,
+  });
+  useRepoStore.setState(emptySlice() as never);
+  wire();
+});
+
+describe("AppShell — window title (#217)", () => {
+  it("is just the app name with no repo open (Welcome)", async () => {
+    render(<App />);
+    const { getCurrentWindow } = await import("@tauri-apps/api/window");
+    await waitFor(() =>
+      expect(getCurrentWindow().setTitle).toHaveBeenCalledWith("PlatypusGit"),
+    );
+  });
+
+  it("names the repository and its checked-out branch", async () => {
+    seedOpenTab({ id: "r1", path: "/dev/myrepo", head: "main" }, [
+      branch({ name: "main", isHead: true }),
+    ]);
+    render(<App />);
+    const { getCurrentWindow } = await import("@tauri-apps/api/window");
+    await waitFor(() =>
+      expect(getCurrentWindow().setTitle).toHaveBeenCalledWith(
+        "myrepo — main — PlatypusGit",
+      ),
+    );
+  });
+
+  it("shows the short OID instead of an empty segment when detached", async () => {
+    // No branch has isHead — same as a real detached checkout, where nothing
+    // in `branches` names the current position.
+    seedOpenTab({ id: "r1", path: "/dev/myrepo", head: "abc1234567890" }, [
+      branch({ name: "main", isHead: false }),
+    ]);
+    render(<App />);
+    const { getCurrentWindow } = await import("@tauri-apps/api/window");
+    await waitFor(() =>
+      expect(getCurrentWindow().setTitle).toHaveBeenCalledWith(
+        "myrepo — abc1234 — PlatypusGit",
+      ),
+    );
+  });
+
+  it("omits the branch segment for an unborn branch (fresh init, no commits)", async () => {
+    seedOpenTab({ id: "r1", path: "/dev/myrepo", head: null }, []);
+    render(<App />);
+    const { getCurrentWindow } = await import("@tauri-apps/api/window");
+    await waitFor(() =>
+      expect(getCurrentWindow().setTitle).toHaveBeenCalledWith(
+        "myrepo — PlatypusGit",
+      ),
+    );
+  });
+
+  it("follows a tab close back to the app name", async () => {
+    seedOpenTab({ id: "r1", path: "/dev/myrepo", head: "main" }, [
+      branch({ name: "main", isHead: true }),
+    ]);
+    render(<App />);
+    const { getCurrentWindow } = await import("@tauri-apps/api/window");
+    await waitFor(() =>
+      expect(getCurrentWindow().setTitle).toHaveBeenCalledWith(
+        "myrepo — main — PlatypusGit",
+      ),
+    );
+
+    await act(async () => {
+      await useTabsStore.getState().close("/dev/myrepo");
+    });
+
+    await waitFor(() =>
+      expect(getCurrentWindow().setTitle).toHaveBeenCalledWith("PlatypusGit"),
+    );
+  });
+});

--- a/src/lib/derive.test.ts
+++ b/src/lib/derive.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { windowTitle } from "./derive";
+import type { BranchInfo } from "./types";
+
+function branch(over: Partial<BranchInfo> = {}): BranchInfo {
+  return {
+    name: "main",
+    isHead: true,
+    isRemote: false,
+    upstream: null,
+    ahead: 0,
+    behind: 0,
+    tip: "deadbeefcafe",
+    tipTime: 0,
+    isDefault: true,
+    ...over,
+  };
+}
+
+describe("windowTitle", () => {
+  it("is just the app name with no repo open", () => {
+    expect(windowTitle(null, [], null)).toBe("PlatypusGit");
+  });
+
+  it("names the repo and its checked-out branch, name last", () => {
+    expect(
+      windowTitle("/Users/dev/myrepo", [branch({ name: "main" })], "main"),
+    ).toBe("myrepo — main — PlatypusGit");
+  });
+
+  it("falls back to the short OID when detached (no branch has isHead)", () => {
+    expect(
+      windowTitle(
+        "/Users/dev/myrepo",
+        [branch({ isHead: false })],
+        "abc1234567890",
+      ),
+    ).toBe("myrepo — abc1234 — PlatypusGit");
+  });
+
+  it("omits the branch segment for an unborn branch (no commits, no OID)", () => {
+    expect(windowTitle("/Users/dev/myrepo", [], null)).toBe(
+      "myrepo — PlatypusGit",
+    );
+  });
+
+  it("strips a trailing slash from the workdir when naming the repo", () => {
+    expect(windowTitle("/Users/dev/myrepo/", [branch()], "main")).toBe(
+      "myrepo — main — PlatypusGit",
+    );
+  });
+});

--- a/src/lib/derive.ts
+++ b/src/lib/derive.ts
@@ -110,6 +110,30 @@ export function currentBranch(branches: BranchInfo[]): BranchInfo | null {
   return branches.find((b) => b.isHead) ?? null;
 }
 
+/**
+ * The main window's title for the active repository: `name — branch —
+ * PlatypusGit`, so window switchers (which truncate from the right) show the
+ * part that distinguishes windows first. `null` `repoPath` (no repo open, or
+ * the Welcome screen) is just `PlatypusGit`.
+ *
+ * Detached HEAD has no entry in `branches` (nothing there has `isHead`), so
+ * the branch segment falls back to `headOid` — the short OID `RepoHandle.head`
+ * already carries in that case (see `BranchChip`, which reads the same field
+ * the same way). Unborn (a fresh `git init`, no commits) has neither a branch
+ * nor a `headOid`, so the branch segment is omitted rather than shown empty.
+ */
+export function windowTitle(
+  repoPath: string | null,
+  branches: BranchInfo[],
+  headOid: string | null,
+): string {
+  if (!repoPath) return "PlatypusGit";
+  const repoName = repoPath.split("/").filter(Boolean).pop() ?? repoPath;
+  const head = currentBranch(branches);
+  const branch = head ? head.name : headOid ? shortSha(headOid) : null;
+  return branch ? `${repoName} — ${branch} — PlatypusGit` : `${repoName} — PlatypusGit`;
+}
+
 export function localBranches(branches: BranchInfo[]): BranchInfo[] {
   return branches.filter((b) => !b.isRemote);
 }


### PR DESCRIPTION
## Summary
- The window title was always the static `"PlatypusGit"`, so window switchers, the dock/taskbar and Mission Control showed identical entries for every open repo/window.
- Added `windowTitle` (`src/lib/derive.ts`), a pure function composing `name — branch — PlatypusGit` (project name last, so it survives the right-truncation window switchers apply):
  - On a branch: the branch name.
  - Detached HEAD: falls back to the short OID, via the same `RepoHandle.head` field `BranchChip` already reads the same way (branch shorthand when on a branch, short OID when detached, `null` when unborn).
  - Unborn branch (fresh `git init`, no commits): branch segment omitted rather than shown empty.
  - No repo open: just `PlatypusGit`.
- `AppShell` derives the title from `useRepoStore`'s `current`/`branches` and syncs it via `getCurrentWindow().setTitle` in an effect — no new store plumbing, so it follows tab switches, branch checkouts and repo close automatically (same mechanism `MergeWindow.tsx` already uses for its own title).

Closes #217

## Test plan
- [x] `pnpm tsc --noEmit` — clean
- [x] Added `src/lib/derive.test.ts` — unit coverage for all four `windowTitle` cases (named branch, detached/short-OID, unborn/no-commits, no-repo)
- [x] Added `src/AppShell.windowtitle.test.tsx` — component coverage asserting `getCurrentWindow().setTitle` is called correctly on mount, on opening a repo, for detached HEAD, for an unborn branch, and on tab close (mirrors the existing `setTitle` mocking `MergeWindow.test.tsx` already uses)
- [x] Full suite: `pnpm test` — 215 test files, 1853 tests, all passing (no regressions)
- [ ] Did not run `pnpm test:e2e:docker` (Docker-based e2e) — out of scope per the issue ("small, frontend-only... a component test can assert the exact title... without touching Tauri") and not available in my sandbox; flagging honestly rather than claiming it.