### PR TITLE
docs: comparison table vs GitKraken / Fork / Sourcetree / TortoiseGit

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,43 @@ Every route, per platform, with the Gatekeeper and update notes spelled out:
 - **Native, not a bundled browser.** A small Tauri binary with real OS windows on all three platforms.
 - **Keyboard-first and dense.** A Rider-style default keymap, a command palette, type-to-jump lists, hunk navigation and staging without touching the mouse — a dev-first TortoiseGit alternative that assumes you know git.
 
+## How it compares
+
+| | Price | Account | Telemetry | Platforms | Licence |
+|---|---|---|---|---|---|
+| **platypusgit** | Free | None | None | macOS · Windows · Linux | GPL-3.0 |
+| [GitKraken Desktop](https://www.gitkraken.com/pricing) | Free for local and public repos — **a paid seat for private ones** | GitKraken account | Usage analytics **plus the folder and file names where you keep your code** | macOS · Windows · Linux | Proprietary |
+| [Fork](https://fork.dev/) | **$59.99** once, up to 3 machines | None | None — crash reports only | macOS · Windows | Proprietary |
+| [Sourcetree](https://www.sourcetreeapp.com/) | Free | **Atlassian account required** | Anonymous usage data, opt-out | macOS · Windows | Proprietary |
+| [TortoiseGit](https://tortoisegit.org/) | Free | None | Crash dumps, unless disabled at install | **Windows only** | GPL-2.0 |
+
+**Under the hood:** GitKraken ships as an Electron app. Fork, Sourcetree and
+TortoiseGit are native. platypusgit is a Tauri binary that uses the OS webview
+rather than bundling a browser of its own.
+
+**Checked against each vendor's own pages on 25 August 2026.** Prices and
+privacy policies change, so every claim above links to the source it came from —
+re-check any cell in a minute. A cell that has gone stale is a bug worth
+[reporting](https://github.com/jonassaa/platypusgit/issues/new).
+
+<details>
+<summary><b>Sources, claim by claim</b></summary>
+
+- **GitKraken Desktop** — [pricing](https://www.gitkraken.com/pricing); ["always free to use with local and public cloud-hosted repos"](https://www.gitkraken.com/git-client), while on the free plan ["private repos will be inaccessible"](https://help.gitkraken.com/gitkraken-desktop/gitkraken-account-site-faq/). One free [GitKraken account](https://help.gitkraken.com/gk-dev/gk-dev-account/) spans Desktop, GitLens and the CLI, created at gitkraken.dev or from inside the app, and private-repo access hangs off a paid subscription on it. Telemetry, from [their privacy policy](https://www.gitkraken.com/privacy) verbatim: "when you use any of our applications, we store some usage analytics, the directory, folder and file names on your device where you store your code, and any crash reports sent from your client." Electron: ["delivered across platforms as an Electron application"](https://www.gitkraken.com/blog/nodegit-libgit2).
+- **Fork** — [$59.99 with a free evaluation](https://fork.dev/); the [licence](https://fork.dev/license): "License key may be used by one user on up to 3 machines at a time on both Mac and Windows operating systems." On telemetry, Fork's developer on their public tracker in June 2023: ["Fork doesn't send any telemetry or analytics"](https://github.com/fork-dev/Tracker/issues/1910) — the crash handler is wired for crashes only, with the analytics module explicitly disabled — and again in January 2024: ["Fork doesn't call home and has no telemetry. So we don't have a privacy policy as we have nothing to declare."](https://github.com/fork-dev/Tracker/issues/2046) No Linux build; [that request is still open](https://github.com/fork-dev/Tracker/issues/153).
+- **Sourcetree** — [free, "for Windows and Mac"](https://www.sourcetreeapp.com/). The account, from Atlassian's install guide: ["You need an Atlassian account to use Sourcetree."](https://confluence.atlassian.com/get-started-with-sourcetree/install-sourcetree-847359094.html) Usage data is collected under [Atlassian's privacy policy](https://www.atlassian.com/legal/privacy-policy) and switched off in the app's options; setup once *required* it, per [Atlassian's own bug report](https://jira.atlassian.com/browse/SRCTREEWIN-10821).
+- **TortoiseGit** — ["developed under the GPL"](https://tortoisegit.org/about/), specifically [GPLv2 in the source tree](https://github.com/TortoiseGit/TortoiseGit/blob/master/LICENSE). Windows only, needs a command-line git, and ["Windows 10 version 1607 or newer is required"](https://tortoisegit.org/support/faq/). It ["includes a crash reporter (if not disabled on installation), which automatically uploads crash dumps to drdump.com"](https://tortoisegit.org/support/).
+- **platypusgit** — [GPL-3.0](./LICENSE). No analytics dependency in `package.json` or `src-tauri/Cargo.toml`, and no analytics SDK in `src/` or `src-tauri/`. Nothing to sign in to: the only credential prompts are git's own, and the optional pull-request integration uses a token you paste yourself, kept by your git credential helper (`src-tauri/src/forge/`). The only outbound traffic is your git remotes, the update check, and forge APIs you configured. [#226](https://github.com/jonassaa/platypusgit/issues/226) adds a guard test so this cannot regress quietly.
+
+</details>
+
+**Where we are behind.** We are 0.0.x and the youngest tool on this list:
+installers that warn on first launch, manual updates on Windows and Linux, and
+changed images shown as "binary" rather than a preview — the full list is under
+[Status](#status). Two of the gaps are deliberate rather than unfinished: no
+Mercurial, and no Finder/Explorer shell integration, which is the thing
+TortoiseGit exists for.
+
 ## Features
 
 - **Start anywhere** — open a repository, clone one (submodules included, with progress), or init a new one, and keep the ones you use in the recent list.
@@ -132,7 +169,8 @@ is implemented, not a roadmap). Known gaps, stated plainly:
 
 - macOS builds are ad-hoc signed and not notarized; the Windows `.msi` is not code-signed.
 - No `winget`/`scoop`/apt repository yet, so on Windows and Linux install and update are a manual download ([#187](https://github.com/jonassaa/platypusgit/issues/187)).
-- Standalone GUI only. Shell integration — Finder/Explorer icon overlays and context menus — is out of scope.
+- Changed images are reported as binary rather than previewed side by side ([#224](https://github.com/jonassaa/platypusgit/issues/224)).
+- Standalone GUI only. Shell integration — Finder/Explorer icon overlays and context menus — is out of scope. So is Mercurial.
 
 Found a bug or want a feature? [Open an issue](https://github.com/jonassaa/platypusgit/issues).
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -160,6 +160,17 @@ Rules that keep the gates honest:
 - **`test/nativeSelect.test.ts`** is a SOURCE invariant: no `<select>`/`<option>`
   in shipped `src/` (issue 146) — the failure is invisible on macOS/Windows.
   Comments stripped first; test files out of scope.
+- **`test/comparison.test.ts`** keeps the competitor comparison (#210) from
+  existing twice. `site/src/data/comparison.json` is the source of truth; the
+  site renders it through `comparison.ts`, and the test parses the README's
+  "How it compares" table and compares it cell by cell, plus the checked-on
+  date, the runtime note, and every vendor source URL. It strips markdown
+  emphasis and links and collapses whitespace, so the README stays free to bold
+  a cell and wrap its prose. It reads the JSON with `node:fs` rather than
+  importing `comparison.ts` — that module sits under `site/`, whose tsconfig
+  extends Astro's, and the root package has no astro to resolve it with. What it
+  cannot check is whether the claims are still TRUE: that is what the date is
+  for, so re-read the vendors' pages before moving `checkedOn`.
 - **`test/e2eSelectors.test.ts`** guards the `[data-testid="X"]*=text` trap:
   WebdriverIO compiles it to a SUBSTRING attribute test plus an innermost-match
   condition, so any other testid containing `X` makes the outer element match

--- a/site/src/data/comparison.json
+++ b/site/src/data/comparison.json
@@ -1,0 +1,104 @@
+{
+  "checkedOn": "25 August 2026",
+  "runtimeNote": "GitKraken ships as an Electron app. Fork, Sourcetree and TortoiseGit are native. platypusgit is a Tauri binary that uses the OS webview rather than bundling a browser of its own.",
+  "rows": [
+    {
+      "name": "platypusgit",
+      "us": true,
+      "price": "Free",
+      "account": "None",
+      "telemetry": "None",
+      "platforms": "macOS · Windows · Linux",
+      "licence": "GPL-3.0"
+    },
+    {
+      "name": "GitKraken Desktop",
+      "href": "https://www.gitkraken.com/pricing",
+      "price": "Free for local and public repos — a paid seat for private ones",
+      "account": "GitKraken account",
+      "telemetry": "Usage analytics plus the folder and file names where you keep your code",
+      "platforms": "macOS · Windows · Linux",
+      "licence": "Proprietary"
+    },
+    {
+      "name": "Fork",
+      "href": "https://fork.dev/",
+      "price": "$59.99 once, up to 3 machines",
+      "account": "None",
+      "telemetry": "None — crash reports only",
+      "platforms": "macOS · Windows",
+      "licence": "Proprietary"
+    },
+    {
+      "name": "Sourcetree",
+      "href": "https://www.sourcetreeapp.com/",
+      "price": "Free",
+      "account": "Atlassian account required",
+      "telemetry": "Anonymous usage data, opt-out",
+      "platforms": "macOS · Windows",
+      "licence": "Proprietary"
+    },
+    {
+      "name": "TortoiseGit",
+      "href": "https://tortoisegit.org/",
+      "price": "Free",
+      "account": "None",
+      "telemetry": "Crash dumps, unless disabled at install",
+      "platforms": "Windows only",
+      "licence": "GPL-2.0"
+    }
+  ],
+  "sources": [
+    {
+      "vendor": "GitKraken Desktop",
+      "links": [
+        { "label": "pricing", "url": "https://www.gitkraken.com/pricing" },
+        { "label": "free with local and public repos", "url": "https://www.gitkraken.com/git-client" },
+        {
+          "label": "private repos inaccessible on the free plan",
+          "url": "https://help.gitkraken.com/gitkraken-desktop/gitkraken-account-site-faq/"
+        },
+        { "label": "the GitKraken account", "url": "https://help.gitkraken.com/gk-dev/gk-dev-account/" },
+        { "label": "privacy policy", "url": "https://www.gitkraken.com/privacy" },
+        { "label": "built on Electron", "url": "https://www.gitkraken.com/blog/nodegit-libgit2" }
+      ]
+    },
+    {
+      "vendor": "Fork",
+      "links": [
+        { "label": "price", "url": "https://fork.dev/" },
+        { "label": "licence — three machines", "url": "https://fork.dev/license" },
+        { "label": "no telemetry (2023)", "url": "https://github.com/fork-dev/Tracker/issues/1910" },
+        {
+          "label": "no telemetry, so no privacy policy (2024)",
+          "url": "https://github.com/fork-dev/Tracker/issues/2046"
+        },
+        { "label": "Linux still unsupported", "url": "https://github.com/fork-dev/Tracker/issues/153" }
+      ]
+    },
+    {
+      "vendor": "Sourcetree",
+      "links": [
+        { "label": "free, Windows and Mac", "url": "https://www.sourcetreeapp.com/" },
+        {
+          "label": "\"You need an Atlassian account to use Sourcetree\"",
+          "url": "https://confluence.atlassian.com/get-started-with-sourcetree/install-sourcetree-847359094.html"
+        },
+        { "label": "Atlassian's privacy policy", "url": "https://www.atlassian.com/legal/privacy-policy" },
+        { "label": "usage statistics in setup", "url": "https://jira.atlassian.com/browse/SRCTREEWIN-10821" }
+      ]
+    },
+    {
+      "vendor": "TortoiseGit",
+      "links": [
+        { "label": "developed under the GPL", "url": "https://tortoisegit.org/about/" },
+        {
+          "label": "GPLv2 in the source tree",
+          "url": "https://github.com/TortoiseGit/TortoiseGit/blob/master/LICENSE"
+        },
+        { "label": "Windows 10 1607+, needs command-line git", "url": "https://tortoisegit.org/support/faq/" },
+        { "label": "crash dumps to drdump.com", "url": "https://tortoisegit.org/support/" }
+      ]
+    }
+  ]
+}

--- a/site/src/data/comparison.ts
+++ b/site/src/data/comparison.ts
@@ -1,0 +1,52 @@
+// The competitor comparison (#210), shown twice: as a markdown table in the
+// README and as a real table on /features.
+//
+// THE CELLS LIVE IN `comparison.json`, not here. `test/comparison.test.ts` (the
+// root vitest `docs` project) reads that JSON and fails the build when the
+// README's table, its checked-on date, its runtime note, or its source links
+// disagree with it. JSON rather than a TS literal only because the root package
+// cannot import this directory's TypeScript — the site's tsconfig extends
+// Astro's, which the root package does not have. This file adds the types the
+// site renders against, and is where the reasoning is written down.
+//
+// Every claim about another vendor cites that vendor's own page. When you
+// re-verify, re-read those pages, fix the cells, and then move `checkedOn` —
+// never move the date without re-reading, because the date IS the claim. A
+// comparison table is the first thing a competitor's users fact-check, and a
+// cell that is quietly wrong costs more than no table at all.
+//
+// Keep our own row conservative. Understating our maturity costs nothing.
+
+import data from './comparison.json';
+
+export type ComparisonRow = {
+  /** Product name. `us: true` marks our row so surfaces can style it. */
+  name: string;
+  /** Vendor home or pricing page. Absent for our own row. */
+  href?: string;
+  us?: boolean;
+  price: string;
+  account: string;
+  telemetry: string;
+  platforms: string;
+  licence: string;
+};
+
+export type ComparisonSource = {
+  vendor: string;
+  /** Label → the vendor page that backs the cells above. */
+  links: { label: string; url: string }[];
+};
+
+/** The day the cells were last read off the vendors' own pages. */
+export const checkedOn: string = data.checkedOn;
+
+/**
+ * The one claim that does not fit a cell. Kept beside the table so the README
+ * and the site make it in the same words.
+ */
+export const runtimeNote: string = data.runtimeNote;
+
+export const comparisonRows: ComparisonRow[] = data.rows;
+
+export const comparisonSources: ComparisonSource[] = data.sources;

--- a/site/src/pages/features.astro
+++ b/site/src/pages/features.astro
@@ -3,6 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import Screenshot from '../components/Screenshot.astro';
 import { site } from '../data/site.ts';
 import { featureGroups, roadmap } from '../data/features.ts';
+import { checkedOn, comparisonRows, comparisonSources, runtimeNote } from '../data/comparison.ts';
 import { descriptions } from '../data/seo.ts';
 
 // Keyed by group TITLE, not index: the group order in features.ts changes as
@@ -31,6 +32,77 @@ const shotAfterGroup: Record<string, { name: string; alt: string; caption: strin
       alt="The platypusgit window with no repository open. A centred card reads “Welcome to PlatypusGit — open, clone, or create a repository to get started”, above an Open repository button and, below it, Clone repository and New repository buttons. A line under them reads “Pick any directory containing a .git folder.” The status bar reads “No repository open” on the left and “⌘O to open…” on the right."
       caption="Where every session starts: point it at a directory that already has a .git folder, clone a remote, or create a repository from nothing."
     />
+  </section>
+
+  <section class="container compare">
+    <h2 class="compare-title">How it compares</h2>
+    <p class="lead">
+      Checked against each vendor's own pages on {checkedOn}. Prices and privacy
+      policies change, so every claim links to the page it came from — any cell
+      here can be re-checked in a minute.
+    </p>
+
+    <div class="compare-scroll">
+      <table class="compare-table">
+        <thead>
+          <tr>
+            <th scope="col"><span class="sr-only">Client</span></th>
+            <th scope="col">Price</th>
+            <th scope="col">Account</th>
+            <th scope="col">Telemetry</th>
+            <th scope="col">Platforms</th>
+            <th scope="col">Licence</th>
+          </tr>
+        </thead>
+        <tbody>
+          {comparisonRows.map((r) => (
+            <tr class={r.us ? 'us' : undefined}>
+              <th scope="row">
+                {r.href
+                  ? <a href={r.href} target="_blank" rel="noopener">{r.name}</a>
+                  : r.name}
+              </th>
+              <td>{r.price}</td>
+              <td>{r.account}</td>
+              <td>{r.telemetry}</td>
+              <td>{r.platforms}</td>
+              <td>{r.licence}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+
+    <p class="compare-note">{runtimeNote}</p>
+
+    <div class="sources">
+      <h3>Sources, claim by claim</h3>
+      <ul>
+        {comparisonSources.map((s) => (
+          <li>
+            <span class="vendor">{s.vendor}</span>
+            <span class="links">
+              {s.links.map((l, i) => (
+                <>
+                  {i > 0 && <span class="sep" aria-hidden="true">·</span>}
+                  <a href={l.url} target="_blank" rel="noopener">{l.label}</a>
+                </>
+              ))}
+            </span>
+          </li>
+        ))}
+        <li>
+          <span class="vendor">{site.name}</span>
+          <span class="links">
+            <a href={site.repo + '/blob/main/LICENSE'} target="_blank" rel="noopener">GPL-3.0</a>
+            <span class="sep" aria-hidden="true">·</span>
+            <span class="own">no analytics dependency and no SDK in the tree, nothing to sign in to,
+            and the only outbound traffic is your git remotes, the update check and forge APIs you
+            configured — <a href={site.repo + '/issues/226'} target="_blank" rel="noopener">kept honest by a guard test</a></span>
+          </span>
+        </li>
+      </ul>
+    </div>
   </section>
 
   <section class="container groups">
@@ -78,6 +150,36 @@ const shotAfterGroup: Record<string, { name: string; alt: string; caption: strin
   .group-list { list-style: none; padding: 0; margin: 0; display: grid; gap: var(--s-4); }
   .group-list li { display: flex; gap: var(--s-4); align-items: baseline; color: var(--fg-1); font-size: 15px; }
   .tick { color: var(--git-added); font-weight: 700; }
+  .compare { margin-top: var(--s-11); }
+  .compare-title { font-size: 24px; margin: 0 0 var(--s-3); }
+  /* A six-column table does not fit a phone; it scrolls inside its own box
+     rather than making the page scroll sideways. */
+  .compare-scroll { margin-top: var(--s-7); overflow-x: auto;
+    border: 1px solid var(--border-0); border-radius: var(--r-5); }
+  .compare-table { width: 100%; min-width: 760px; border-collapse: collapse; font-size: 14px; }
+  .compare-table th, .compare-table td { text-align: left; vertical-align: top;
+    padding: var(--s-5) var(--s-6); border-bottom: 1px solid var(--border-0); }
+  .compare-table thead th { font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em;
+    color: var(--fg-3); font-weight: 600; background: var(--bg-1); white-space: nowrap; }
+  .compare-table tbody th { font-weight: 600; color: var(--fg-0); white-space: nowrap; }
+  .compare-table tbody td { color: var(--fg-2); }
+  .compare-table tbody tr:last-child th, .compare-table tbody tr:last-child td { border-bottom: 0; }
+  .compare-table tbody tr.us { background: var(--bg-1); }
+  .compare-table tbody tr.us th { color: var(--accent); }
+  .compare-table tbody tr.us td { color: var(--fg-1); }
+  .compare-note { margin: var(--s-6) 0 0; color: var(--fg-2); font-size: 14px; max-width: 720px; }
+  .sources { margin-top: var(--s-8); }
+  .sources h3 { font-size: 14px; margin: 0 0 var(--s-5); color: var(--fg-1); }
+  .sources ul { list-style: none; padding: 0; margin: 0; display: grid; gap: var(--s-4); }
+  .sources li { font-size: 13px; color: var(--fg-3); display: flex; gap: var(--s-5);
+    align-items: baseline; flex-wrap: wrap; }
+  .sources .vendor { color: var(--fg-1); min-width: 148px; flex-shrink: 0; }
+  .sources .links { color: var(--fg-3); }
+  .sources .own { color: var(--fg-3); }
+  .sources .sep { padding: 0 var(--s-3); color: var(--fg-4); }
+  .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
+
   .roadmap { margin-top: var(--s-11); }
   .roadmap-title { font-size: 24px; margin: 0 0 var(--s-3); }
   .roadmap-list { list-style: none; padding: 0; margin: var(--s-7) 0 0; display: grid; gap: var(--s-5); max-width: 720px; }
@@ -88,13 +190,15 @@ const shotAfterGroup: Record<string, { name: string; alt: string; caption: strin
     .group { grid-template-columns: 1fr; gap: var(--s-5); }
     .page-head { padding-top: var(--s-11); }
     .page-head h1 { font-size: 30px; }
-    .groups, .roadmap { margin-top: var(--s-10); }
+    .groups, .roadmap, .compare { margin-top: var(--s-10); }
     .opening { margin-top: var(--s-8); }
   }
   @media (max-width: 480px) {
     .page-head h1 { font-size: 26px; }
     .lead { font-size: 15px; }
-    .roadmap-title { font-size: 21px; }
+    .roadmap-title, .compare-title { font-size: 21px; }
+    .sources .vendor { min-width: 0; }
+    .sources li { gap: var(--s-3); }
     .group { padding-bottom: var(--s-8); }
     .group-head h2 { font-size: 18px; }
     .group-list { gap: var(--s-3); }

--- a/test/comparison.test.ts
+++ b/test/comparison.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @vitest-environment node
+ */
+// The comparison table appears twice — as markdown in the README and as a real
+// table on /features (#210) — so it is exactly the shape of thing that drifts:
+// somebody re-checks GitKraken's pricing page, fixes the README, and the site
+// keeps saying last year's price for a year.
+//
+// `site/src/data/comparison.json` is the source of truth. The site renders it
+// through `comparison.ts`, so the site cannot drift. This test makes the README
+// unable to drift either: it parses the README's "How it compares" table and
+// asserts, cell by cell, that it says what the data says, that the checked-on
+// date and the runtime note match, and that every vendor source URL in the data
+// is actually cited in the README.
+//
+// The data is read as JSON rather than imported from `comparison.ts` on
+// purpose: that module lives under `site/`, whose tsconfig extends Astro's, and
+// the root package has no astro to resolve it with — importing it fails the
+// suite before a single assertion runs.
+//
+// What this does NOT check is whether the claims are TRUE — no test can. The
+// date is the claim there: when you re-verify against the vendors' own pages,
+// move `checkedOn`; never move it without re-reading them.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = (rel: string) => resolve(process.cwd(), rel);
+const read = (rel: string) => readFileSync(root(rel), "utf8");
+
+type ComparisonRow = {
+  name: string;
+  price: string;
+  account: string;
+  telemetry: string;
+  platforms: string;
+  licence: string;
+};
+type ComparisonSource = { vendor: string; links: { label: string; url: string }[] };
+
+const data = JSON.parse(read("site/src/data/comparison.json")) as {
+  checkedOn: string;
+  runtimeNote: string;
+  rows: ComparisonRow[];
+  sources: ComparisonSource[];
+};
+const { checkedOn, runtimeNote, rows: comparisonRows, sources: comparisonSources } = data;
+
+const readme = read("README.md");
+
+// The section runs from its heading to the next `## ` heading.
+const section = (() => {
+  const start = readme.indexOf("## How it compares");
+  expect(start, 'README has no "## How it compares" section').toBeGreaterThan(-1);
+  const rest = readme.slice(start + 1);
+  const end = rest.indexOf("\n## ");
+  return end === -1 ? rest : rest.slice(0, end);
+})();
+
+/**
+ * Markdown emphasis and links are presentation, not claim: `**$59.99** once`
+ * and `[Fork](https://fork.dev/)` have to compare equal to the plain strings in
+ * the data. Collapsing whitespace lets the README wrap its prose freely.
+ */
+const plain = (md: string) =>
+  md
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/\*\*/g, "")
+    .replace(/`/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const tableRows = section
+  .split("\n")
+  .filter((line) => line.trimStart().startsWith("|"))
+  // A `|---|---|` separator is layout, not data.
+  .filter((line) => !/^\s*\|[\s|:-]+\|\s*$/.test(line))
+  .map((line) =>
+    line
+      .trim()
+      .replace(/^\|/, "")
+      .replace(/\|$/, "")
+      .split("|")
+      .map(plain),
+  );
+
+describe("README comparison table matches site/src/data/comparison.ts", () => {
+  it("has a header row with the columns the data carries", () => {
+    expect(tableRows.length).toBeGreaterThan(0);
+    expect(tableRows[0]).toEqual([
+      "",
+      "Price",
+      "Account",
+      "Telemetry",
+      "Platforms",
+      "Licence",
+    ]);
+  });
+
+  it("lists the same clients, in the same order", () => {
+    expect(tableRows.slice(1).map((cells) => cells[0])).toEqual(
+      comparisonRows.map((r) => r.name),
+    );
+  });
+
+  it.each(comparisonRows)("says the same things about $name", (row) => {
+    const cells = tableRows.slice(1).find((c) => c[0] === row.name);
+    expect(cells, `no README row for ${row.name}`).toBeDefined();
+    expect(cells!.slice(1)).toEqual([
+      row.price,
+      row.account,
+      row.telemetry,
+      row.platforms,
+      row.licence,
+    ]);
+  });
+
+  it("carries the same checked-on date", () => {
+    expect(plain(section)).toContain(checkedOn);
+  });
+
+  it("carries the runtime note in the same words", () => {
+    expect(plain(section)).toContain(plain(runtimeNote));
+  });
+
+  // Matched against the exact set of link targets, not with `toContain`: a
+  // substring test passes a typo'd or truncated URL whenever the real one is a
+  // prefix of it (`…/privacy` "matches" `…/privacy-oops`), which is precisely
+  // the drift worth catching. The README's own row cites the repository with
+  // relative links (`./LICENSE`), so only the vendor claims are checked here.
+  const cited = new Set(
+    [...section.matchAll(/\]\(([^)\s]+)\)/g)].map((m) => m[1]),
+  );
+
+  it.each(comparisonSources)("cites every source for $vendor", (source) => {
+    for (const link of source.links) {
+      expect(
+        cited,
+        `README does not link ${link.url} — cited: ${[...cited].join(", ")}`,
+      ).toContain(link.url);
+    }
+  });
+});


### PR DESCRIPTION
Closes #210.

A comparison table for the question a "gitkraken alternative" search is
actually asking — what do I get, and what does it cost me — in the README,
mirrored onto `/features`.

|  | Price | Account | Telemetry | Platforms | Licence |
|---|---|---|---|---|---|
| **platypusgit** | Free | None | None | macOS · Windows · Linux | GPL-3.0 |
| GitKraken Desktop | Free for local and public repos — a paid seat for private ones | GitKraken account | Usage analytics plus the folder and file names where you keep your code | macOS · Windows · Linux | Proprietary |
| Fork | $59.99 once, up to 3 machines | None | None — crash reports only | macOS · Windows | Proprietary |
| Sourcetree | Free | Atlassian account required | Anonymous usage data, opt-out | macOS · Windows | Proprietary |
| TortoiseGit | Free | None | Crash dumps, unless disabled at install | Windows only | GPL-2.0 |

## Every cell is sourced

Each claim links to the vendor's own page, and the section is dated
("checked … on 25 August 2026") because pricing pages move. The research
worth knowing:

- **GitKraken** — free tier is local repos and public remotes only; private
  repos need a paid seat. Their privacy policy is the sharpest line in the
  table: they store "usage analytics, the directory, folder and file names on
  your device where you store your code". Electron, per their own blog.
- **Fork** — $59.99 once, one user on up to three machines. Its developer
  states on the public tracker that Fork "doesn't call home and has no
  telemetry" (crash reports only), which is why there is no privacy policy to
  link. No Linux build.
- **Sourcetree** — free, but Atlassian's install guide says outright: "You
  need an Atlassian account to use Sourcetree." Usage data is collected with
  an in-app opt-out.
- **TortoiseGit** — GPLv2, Windows only, and it uploads crash dumps to
  drdump.com unless that is disabled at install.

Two things the issue text asserted turned out to be stale, so they are not in
the table: the `.msi` **does** install `pgit` (`wix/pgit-cli.wxs`) — the real
Windows gap is package-manager install (#187).

## Our own column stays conservative

Verified against the tree, not from memory: GPL-3.0, no analytics dependency
in `package.json` or `src-tauri/Cargo.toml`, no SDK in `src/` or `src-tauri/`,
nothing to sign in to (git's own credential prompts and forge tokens you paste
yourself, kept by your credential helper). The section ends by naming where we
are behind — installers that warn on first launch, manual updates on Windows
and Linux, images shown as "binary" — rather than hiding it.

## One table, not two

`site/src/data/comparison.json` is the source of truth. The site renders it
through `comparison.ts`; `test/comparison.test.ts` parses the README table and
fails the build when a cell, the checked-on date, the runtime note or a source
link disagrees. Both failure modes were verified by breaking the README on
purpose: a changed price fails, and so does a mangled source URL (the URL check
compares against the exact set of cited links — a substring test passes
`…/privacy-oops` when the real URL is a prefix of it).

## Gaps this surfaced, filed separately

- #224 — changed images show as "binary" instead of a preview; the other three
  clients all diff images. Also added to the README's Status list.
- #225 — no user-defined custom actions (Sourcetree has them; TortoiseGit gets
  there via hooks).
- #226 — a guard test to keep the "no telemetry, no account" promise from
  regressing, now that it is advertised.

## Checks

`pnpm test` (216 files, 1866 tests), `pnpm tsc --noEmit`, and `pnpm --dir site
build` all pass. Every one of the 19 source URLs was fetched and returns 200.
No `src/` or `src-tauri/` change, so no e2e run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
