### PR TITLE
fix(git): validate branch names before creating or renaming

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -94,7 +94,9 @@ git/
 │                argv, parse_verify_output. Payload-agnostic: commits and tags
 │                reuse one chain
 ├── tag.rs       Tag signing's pure half (#132): armor detection,
-│                append_signature, validate_tag_name, parse_verify_tag
+│                append_signature, validate_tag_name, parse_verify_tag. Also
+│                the shared ref-name validator (#214): validate_ref_component,
+│                validate_branch_name
 └── signature.rs IDENTITY, not cryptography: default_signature
                  (user.name/email lookup, NoSignature when unset) and
                  apply_signoff (Signed-off-by trailer, idempotent)

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -4024,6 +4024,7 @@ impl GitBackend for Libgit2Backend {
     }
     fn create_branch(&self, repo_id: &RepoId, name: &str, from: Option<&str>) -> AppResult<()> {
         self.with_repo(repo_id, |repo| {
+            crate::git::tag::validate_branch_name(name)?;
             let target_commit = match from {
                 Some(rev) => {
                     let obj = repo
@@ -4075,6 +4076,7 @@ impl GitBackend for Libgit2Backend {
 
     fn rename_branch(&self, repo_id: &RepoId, from: &str, to: &str) -> AppResult<()> {
         self.with_repo(repo_id, |repo| {
+            crate::git::tag::validate_branch_name(to)?;
             let mut branch = repo.find_branch(from, git2::BranchType::Local)?;
             branch.rename(to, false)?;
             Ok(())

--- a/src-tauri/src/git/tag.rs
+++ b/src-tauri/src/git/tag.rs
@@ -60,24 +60,30 @@ pub fn normalize_message(message: &str) -> String {
     format!("{trimmed}\n")
 }
 
-/// Reject a tag name before it reaches an argv or a refname.
+/// Reject a ref component name before it reaches an argv or a refname.
+///
+/// Shared by [`validate_tag_name`] and [`validate_branch_name`]: both a tag and
+/// a branch are a single path component under `refs/{tags,heads}/`, and
+/// `git check-ref-format` applies the same rules to both. `noun` names the
+/// caller in the error message ("tag" / "branch") so a rejected name still reads
+/// like it came from the field the user typed it into.
 ///
 /// Same class as `verify_commit`'s hex check and the D5 review's `git show`
-/// finding: `git verify-tag` would read a leading `-` as an option, and the name
-/// arrives from a text field. The rest mirrors `git check-ref-format`, so a name
-/// we accept is one git can hold.
-pub fn validate_tag_name(name: &str) -> AppResult<()> {
+/// finding: a leading `-` would be read as an option by every git command that
+/// receives the name, and the name arrives from a text field. The rest mirrors
+/// `git check-ref-format`, so a name we accept is one git can hold.
+pub(crate) fn validate_ref_component(name: &str, noun: &str) -> AppResult<()> {
     let bad = |why: &str| Err(AppError::InvalidRef(format!("{name}: {why}")));
 
     if name.is_empty() {
-        return bad("a tag needs a name");
+        return bad(&format!("a {noun} needs a name"));
     }
     // An option, not a ref, to every git command that would receive it.
     if name.starts_with('-') {
-        return bad("a tag name cannot start with '-'");
+        return bad(&format!("a {noun} name cannot start with '-'"));
     }
     if name.starts_with('/') || name.ends_with('/') || name.contains("//") {
-        return bad("a tag name cannot have an empty path component");
+        return bad(&format!("a {noun} name cannot have an empty path component"));
     }
     // A leading '.' is refused for the same reason "/." is: `check_refname_component`
     // rejects a component beginning with a dot, and the leading one is not covered
@@ -87,20 +93,42 @@ pub fn validate_tag_name(name: &str) -> AppResult<()> {
         || name.ends_with(".lock")
         || name.contains("/.")
     {
-        return bad("invalid tag name");
+        return bad(&format!("invalid {noun} name"));
     }
     if name.contains("..") || name.contains("@{") {
-        return bad("invalid tag name");
+        return bad(&format!("invalid {noun} name"));
     }
     for ch in name.chars() {
         if ch.is_whitespace() || ch.is_control() {
-            return bad("a tag name cannot contain whitespace or control characters");
+            return bad(&format!(
+                "a {noun} name cannot contain whitespace or control characters"
+            ));
         }
         if matches!(ch, '~' | '^' | ':' | '?' | '*' | '[' | '\\' | '\x7f') {
-            return bad("a tag name cannot contain ~ ^ : ? * [ or backslash");
+            return bad(&format!(
+                "a {noun} name cannot contain ~ ^ : ? * [ or backslash"
+            ));
         }
     }
     Ok(())
+}
+
+/// Reject a tag name before it reaches an argv or a refname.
+///
+/// See [`validate_ref_component`] for the shared rule set.
+pub fn validate_tag_name(name: &str) -> AppResult<()> {
+    validate_ref_component(name, "tag")
+}
+
+/// Reject a branch name before it reaches an argv or a refname (#214).
+///
+/// Branches got no equivalent of [`validate_tag_name`]: `Libgit2Backend::create_branch`
+/// and `rename_branch` passed the name straight to libgit2 and let the user see
+/// whatever `git2::Error` came back. See [`validate_ref_component`] for the
+/// shared rule set — identical to the tag rules, since both are a single path
+/// component under a `refs/<kind>/` prefix.
+pub fn validate_branch_name(name: &str) -> AppResult<()> {
+    validate_ref_component(name, "branch")
 }
 
 /// GPG status tokens, in the order they are checked.
@@ -365,6 +393,39 @@ mod tests {
                 validate_tag_name(bad).is_err(),
                 "{bad:?} should have been refused"
             );
+        }
+    }
+
+    #[test]
+    fn accepts_ordinary_branch_names() {
+        for ok in ["feature/login", "v2", "release-2026-08", "a/b/c"] {
+            validate_branch_name(ok).unwrap_or_else(|e| panic!("{ok} should be valid: {e:?}"));
+        }
+    }
+
+    #[test]
+    fn refuses_branch_names_git_itself_would_refuse() {
+        // Same table as `refuses_names_git_itself_would_refuse`, using the
+        // examples named in #214 (`foo bar`, `-foo`, `foo..bar`, `foo~1`, `.hidden`).
+        for bad in [
+            "", "foo bar", "-foo", "foo..bar", "foo~1", "foo^", "a:b", "foo?", "foo*", "a[b",
+            "a\\b", "/foo", "foo/", "a//b", "foo.", "foo.lock", "a/.b", "HEAD@{0}", ".hidden",
+        ] {
+            assert!(
+                validate_branch_name(bad).is_err(),
+                "{bad:?} should have been refused"
+            );
+        }
+    }
+
+    #[test]
+    fn branch_error_names_the_offending_field_as_a_branch_not_a_tag() {
+        let err = validate_branch_name("foo bar").expect_err("space is invalid");
+        match err {
+            AppError::InvalidRef(msg) => {
+                assert!(msg.contains("branch"), "message should say 'branch': {msg}");
+            }
+            other => panic!("expected InvalidRef, got {other:?}"),
         }
     }
 

--- a/src-tauri/tests/branches_tags.rs
+++ b/src-tauri/tests/branches_tags.rs
@@ -52,6 +52,53 @@ fn create_branch_from_explicit_ref() {
 }
 
 #[test]
+fn create_branch_rejects_an_invalid_name_before_touching_the_repo() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .create_branch(&handle.id, "foo bar", None)
+        .unwrap_err();
+    assert!(
+        matches!(err, platypusgit_lib::error::AppError::InvalidRef(_)),
+        "got {err:?}"
+    );
+
+    // Rejected before any ref was written.
+    let names: Vec<_> = backend
+        .branches(&handle.id)
+        .unwrap()
+        .into_iter()
+        .map(|b| b.name)
+        .collect();
+    assert!(!names.iter().any(|n| n.contains("foo")));
+}
+
+#[test]
+fn rename_branch_rejects_an_invalid_target_name() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    backend.create_branch(&handle.id, "old", None).unwrap();
+
+    let err = backend
+        .rename_branch(&handle.id, "old", "-bad")
+        .unwrap_err();
+    assert!(
+        matches!(err, platypusgit_lib::error::AppError::InvalidRef(_)),
+        "got {err:?}"
+    );
+
+    // The original branch is untouched.
+    let names: Vec<_> = backend
+        .branches(&handle.id)
+        .unwrap()
+        .into_iter()
+        .map(|b| b.name)
+        .collect();
+    assert!(names.iter().any(|n| n == "old"));
+}
+
+#[test]
 fn delete_branch_removes_ref() {
     let tr = TempRepo::with_initial_commit("hello\n");
     let (backend, handle) = tr.open_with_backend();


### PR DESCRIPTION
Fixes #214.

## What
Tag names are validated before they reach libgit2 (`git/tag.rs`'s
`validate_tag_name`, from #132) so a bad tag name gets a clear message.
Branch names got no such treatment: `Libgit2Backend::create_branch` and
`rename_branch` passed the string straight to `repo.branch(...)` /
`branch.rename(...)` and the user saw whatever libgit2 said.

- Lifted the shared ref-name rules out of `validate_tag_name` into
  `validate_ref_component(name, noun)` (no ASCII control chars, no space,
  no `~ ^ : ? * [ \`, no `..`, no `@{`, no leading/trailing `/` or `.`, no
  `/.`, no trailing `.lock`, no leading `-`). Both `validate_tag_name` and
  a new `validate_branch_name` call it, passing `"tag"` / `"branch"` so
  the error message names the field the user actually typed into.
- Wired `validate_branch_name` into `create_branch` (the new branch's
  name) and `rename_branch` (the `to` name), each returning the existing
  `AppError::InvalidRef` variant instead of a stringified libgit2 error.
- No new `AppError` variant was needed, so the TS `AppError` union in
  `src/lib/errors.ts` is unchanged — `InvalidRef` already exists there
  and already carries a `message: string`.

## UI
Went with **"a clear error on submit"** (the first-step option the issue
calls acceptable), and it needed no frontend changes: `useRepoStore`'s
`createBranch`/`renameBranch` already funnel any thrown error through
`setErrorFor`, and `appErrorMessage` (`src/lib/errors.ts`) already renders
an `AppError`'s `message` text directly in the app's generic error banner
— the same path an invalid tag name already uses. So a bad branch name now
surfaces a clear, specific message the same way a bad tag name does,
through existing infrastructure.

## Tests
- `git/tag.rs`: an acceptance table and a rejection table for
  `validate_branch_name`, mirroring the existing tag tables, plus a test
  that the error message says "branch" (not "tag").
- `tests/branches_tags.rs`: two `TempRepo` integration tests —
  `create_branch` rejects an invalid name before any ref is written, and
  `rename_branch` rejects an invalid `to` name and leaves the original
  branch untouched.

## Checks run
- `cargo check --manifest-path src-tauri/Cargo.toml` — clean.
- `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 163 passed.
- `cargo test --manifest-path src-tauri/Cargo.toml --test branches_tags` —
  27 passed (including the 2 new tests).
- Did not run the frontend/e2e suites — this PR touches no TypeScript.
- `cargo fmt --check` flags pre-existing formatting drift across large
  parts of the repo (including files this PR doesn't touch), which looks
  like a local rustfmt version difference rather than something this PR
  introduced; CI here doesn't run an fmt/clippy gate, so I left it alone
  rather than reformatting unrelated code.

---
Assistant-drafted PR (Claude Code / claude-sonnet-5), reviewed and tested
by me before opening.