### PR TITLE
Add reveal in file manager and open in terminal to context menus

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -24,9 +24,11 @@ reveal.rs        "Reveal in Finder/Explorer" + "Open in terminal" (#215).
                  HostPlatform decouples argv building from the actual host, so
                  reveal_plan/terminal_plan are PURE and unit-tested for all
                  three platforms from any host. Spawns via proc.rs only.
-                 explorer.exe's exit-1-on-success is handled here, not treated
-                 as failure; a missing Linux terminal falls through an ordered
-                 candidate list rather than failing silently
+                 explorer.exe's exit-1-on-success is carried as a FLAG on the
+                 plan (not a program-name compare — the program is an absolute
+                 pinned path); Windows launchers are pinned to System32 /
+                 WindowsApps against binary planting; a missing Linux terminal
+                 falls through an ordered candidate list rather than silently
 forge/           GitHub/GitLab PR/MR integration (#92). Trait = URL builders +
                  response parsers, pure and testable against recorded JSON:
 ├── mod.rs       Types + Forge trait, forge_for(kind), injection guards

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -20,6 +20,13 @@ proc.rs          THE only sanctioned child-process spawner (issue 172):
                  git / git_async / git_async_in (CREATE_NO_WINDOW,
                  GIT_TERMINAL_PROMPT=0, stdin closed), program / program_async,
                  and the two *_keeping_console exceptions. See backend.md
+reveal.rs        "Reveal in Finder/Explorer" + "Open in terminal" (#215).
+                 HostPlatform decouples argv building from the actual host, so
+                 reveal_plan/terminal_plan are PURE and unit-tested for all
+                 three platforms from any host. Spawns via proc.rs only.
+                 explorer.exe's exit-1-on-success is handled here, not treated
+                 as failure; a missing Linux terminal falls through an ordered
+                 candidate list rather than failing silently
 forge/           GitHub/GitLab PR/MR integration (#92). Trait = URL builders +
                  response parsers, pure and testable against recorded JSON:
 ├── mod.rs       Types + Forge trait, forge_for(kind), injection guards
@@ -102,8 +109,11 @@ commands/        Thin Tauri handlers, one file per area:
 ├── repo.rs      open_repo, close_repo, trust_repo_path, get_status, head_info
 │                (HEAD's branch/oid, re-polled every refresh — unlike
 │                RepoHandle.head, which open_repo sets once), list_all_files,
-│                append_gitignore, open_in_editor, and THREE distinct file
-│                readers: read_file_content (working tree),
+│                append_gitignore, open_in_editor, reveal_in_file_manager,
+│                open_in_terminal (#215 — both take an optional relative_path;
+│                omitted/empty targets the repo ROOT instead, for the repo
+│                tab's menu), and THREE distinct file readers:
+│                read_file_content (working tree),
 │                read_file_content_at_rev + list_files_at_rev (a commit's tree),
 │                read_file_content_at_index (the STAGED blob)
 ├── cli.rs       take_launch_intent, cli_shim_status, install_cli_shim

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -276,6 +276,15 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   process holding the file forever. A stray console window is cosmetic; an
   invisible editor is Task Manager. The guard test allow-lists both call sites
   by name.
+- **Pin Windows system executables to an absolute path.** `CreateProcess`
+  searches the **current directory before the system directory**, and this
+  app's cwd *is* a repository whenever the `pgit` shim launched it from inside
+  one — so a bare `rundll32.exe` / `explorer.exe` / `cmd.exe` lets a cloned
+  repo ship its own copy and have it run. `opener.rs::opener_program` pins via
+  `%SystemRoot%\System32`; `reveal.rs::system32_exe` does the same, and
+  `wt.exe` (an App Execution Alias, not a System32 binary) is pinned under
+  `%LOCALAPPDATA%\Microsoft\WindowsApps` or skipped. Unresolvable beats
+  relative: a missing pin falls back to the next candidate.
 - **Decide with libgit2 before you spawn:** `verify_commit` reads the `gpgsig`
   header via `extract_signature` and answers `SigState::None` with no
   subprocess (same pre-check `verify_tag` has) — a cost win on every platform,

--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use tauri::State;
 
@@ -198,4 +198,55 @@ pub async fn open_in_editor(
     // No shell interpreter, and the exit status is checked — see opener.rs for
     // the `cmd /C start` injection this replaces.
     crate::opener::open_with_default_app(abs.as_os_str()).await
+}
+
+/// The repo's working directory, resolved via `backend.repo_path` the same
+/// way `open_in_editor` does above.
+async fn repo_workdir(state: &State<'_, AppState>, repo_id: String) -> AppResult<PathBuf> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    tokio::task::spawn_blocking(move || backend.repo_path(&repo_id))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+/// Reveal `relative_path` (relative to the repo's worktree) in the OS file
+/// manager, with the entry selected where the platform allows it. `None` (or
+/// an empty string — the repo tab's menu has no relative path to give)
+/// reveals the repo's ROOT directory instead, which is a directory target
+/// rather than a file one (see `reveal::reveal_plan`'s `is_dir`).
+#[tauri::command]
+pub async fn reveal_in_file_manager(
+    state: State<'_, AppState>,
+    repo_id: String,
+    relative_path: Option<String>,
+) -> AppResult<()> {
+    let workdir = repo_workdir(&state, repo_id).await?;
+    match relative_path {
+        Some(rel) if !rel.is_empty() => {
+            let abs = crate::opener::safe_workdir_path(&workdir, &rel)?;
+            crate::reveal::reveal(&abs, false).await
+        }
+        _ => crate::reveal::reveal(&workdir, true).await,
+    }
+}
+
+/// Open a terminal at `relative_path`'s CONTAINING directory (a file reveals
+/// where it lives, not itself), or at the repo's root when `relative_path` is
+/// `None`/empty — the repo tab's case.
+#[tauri::command]
+pub async fn open_in_terminal(
+    state: State<'_, AppState>,
+    repo_id: String,
+    relative_path: Option<String>,
+) -> AppResult<()> {
+    let workdir = repo_workdir(&state, repo_id).await?;
+    let dir = match relative_path {
+        Some(rel) if !rel.is_empty() => {
+            let abs = crate::opener::safe_workdir_path(&workdir, &rel)?;
+            abs.parent().map(Path::to_path_buf).unwrap_or(workdir)
+        }
+        _ => workdir,
+    };
+    crate::reveal::open_terminal(&dir).await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ pub mod forge;
 pub mod git;
 pub mod opener;
 pub mod proc;
+pub mod reveal;
 pub mod state;
 pub mod update;
 
@@ -182,6 +183,8 @@ pub fn run() {
             commands::repo::read_file_content_at_index,
             commands::repo::append_gitignore,
             commands::repo::open_in_editor,
+            commands::repo::reveal_in_file_manager,
+            commands::repo::open_in_terminal,
             commands::commits::get_log,
             commands::commits::get_log_filtered,
             commands::commits::get_log_page,

--- a/src-tauri/src/reveal.rs
+++ b/src-tauri/src/reveal.rs
@@ -2,25 +2,30 @@
 //!
 //! Companion to `opener.rs` (which hands a path to the app that OWNS the
 //! file) — this hands it to the OS's shell chrome instead: the file manager
-//! or a terminal emulator. No shell interpreter is ever involved, matching
-//! `opener.rs`'s own rule; every argv is built as a `Vec<OsString>` and passed
-//! straight to `Command`, never joined into a string.
+//! or a terminal emulator. No path or filename ever reaches a shell
+//! interpreter; every argv is built as a `Vec<OsString>` and passed straight
+//! to `Command`, never joined into a string.
 //!
 //! Every `Command`/spawn goes through `proc::program_async` (issue 172): the
 //! console-flashing bug that module exists to prevent applies here exactly as
 //! much as anywhere else that shells out on Windows.
+//!
+//! # Why the environment is a parameter, not a global read
+//!
+//! `HostPlatform::current()` and `HostEnv::current()` are the only places this
+//! module reads the actual host. Everything else — [`reveal_plan`],
+//! [`terminal_plan`] — is a pure function of its arguments, so all three
+//! platforms' argv (and the Windows path pinning below, which depends on
+//! `%SystemRoot%`) are unit-tested from any host with nothing spawned. Same
+//! reasoning as `opener.rs::opener_program`'s runtime `cfg!()` check.
 
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use crate::error::{AppError, AppResult};
 
 /// The three platforms this module has a story for, decoupled from the
-/// actual host. `HostPlatform::current()` is the only place `cfg!(target_os =
-/// …)` is read here, so [`reveal_plan`] and [`terminal_plan`] are pure
-/// functions of their arguments and are exercised for all three platforms
-/// from any host — the same reasoning `opener.rs::opener_program`'s runtime
-/// `cfg!()` check already uses.
+/// actual host.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HostPlatform {
     MacOs,
@@ -40,29 +45,122 @@ impl HostPlatform {
     }
 }
 
-/// One process to spawn: a program and its argv, nothing else.
+/// The pieces of the host environment the plans need, threaded in rather than
+/// read inside them so the planners stay pure (see the module doc).
+#[derive(Debug, Clone, Default)]
+pub struct HostEnv {
+    /// `%SystemRoot%` — where `System32` lives. Windows only.
+    pub system_root: Option<OsString>,
+    /// `%LOCALAPPDATA%` — where the Windows Terminal execution alias lives.
+    /// Windows only.
+    pub local_app_data: Option<OsString>,
+    /// `$TERMINAL`, the de-facto "my terminal emulator" variable. Linux only.
+    pub terminal: Option<OsString>,
+}
+
+impl HostEnv {
+    pub fn current() -> Self {
+        HostEnv {
+            system_root: std::env::var_os("SystemRoot"),
+            local_app_data: std::env::var_os("LOCALAPPDATA"),
+            terminal: std::env::var_os("TERMINAL"),
+        }
+    }
+}
+
+/// Absolute path to a Windows **system** executable.
+///
+/// SECURITY: `CreateProcess` searches the **current directory before the
+/// system directory**, so spawning a bare `explorer.exe` / `cmd.exe` is a
+/// binary-planting hole — a cloned repository containing its own `cmd.exe`
+/// would be run instead of the real one. That is not hypothetical here: the
+/// app's cwd *is* a repository whenever the `pgit` shim launched it from
+/// inside one, and [`open_terminal`] additionally sets the repository as the
+/// child's `current_dir`. `opener.rs::opener_program` pins `rundll32.exe` for
+/// exactly this reason; the same pin applies to every launcher below.
+///
+/// `C:\Windows` is the fallback when `%SystemRoot%` is somehow unset — a fixed
+/// absolute path is still infinitely better than a relative lookup.
+fn system32_exe(env: &HostEnv, exe: &str) -> OsString {
+    let root = env
+        .system_root
+        .clone()
+        .unwrap_or_else(|| OsString::from(r"C:\Windows"));
+    Path::new(&root).join("System32").join(exe).into_os_string()
+}
+
+/// Absolute path to the Windows Terminal execution alias.
+///
+/// `wt.exe` is not in `System32` — it is an App Execution Alias the Store
+/// install drops in `%LOCALAPPDATA%\Microsoft\WindowsApps`. Same planting
+/// argument as [`system32_exe`], so it is pinned there rather than looked up
+/// on `PATH`. `None` when `%LOCALAPPDATA%` is unset: the candidate is then
+/// skipped entirely and the `cmd.exe` fallback takes over, which is the right
+/// trade — an unresolvable terminal costs a nicer window, a planted one costs
+/// the machine.
+fn windows_terminal_exe(env: &HostEnv) -> Option<OsString> {
+    let local = env.local_app_data.as_ref()?;
+    Some(
+        Path::new(local)
+            .join("Microsoft")
+            .join("WindowsApps")
+            .join("wt.exe")
+            .into_os_string(),
+    )
+}
+
+/// One process to spawn: a program and its argv.
 #[derive(Debug, PartialEq, Eq)]
 pub struct SpawnPlan {
     pub program: OsString,
     pub args: Vec<OsString>,
+    /// This launcher's exit code carries no information about success.
+    ///
+    /// `explorer.exe` is the only one: it exits **1 on success** — its own
+    /// documented behaviour, not a failure. Carried as a flag on the plan
+    /// rather than recovered by comparing `program` against `"explorer.exe"`,
+    /// because `program` is an absolute pinned path (see [`system32_exe`]) and
+    /// a name comparison would silently stop matching, turning every
+    /// successful reveal on Windows into a reported error.
+    pub exit_status_meaningless: bool,
+}
+
+impl SpawnPlan {
+    fn new(program: impl Into<OsString>, args: Vec<OsString>) -> Self {
+        SpawnPlan {
+            program: program.into(),
+            args,
+            exit_status_meaningless: false,
+        }
+    }
 }
 
 /// Build the argv that reveals `path` in the platform's file manager.
 ///
 /// `is_dir` distinguishes the two jobs a caller means: reveal a FILE (select
 /// it inside its parent's window) or reveal a DIRECTORY (open a window on it
-/// directly — the repo-tab menu's case, which has no file to select).
+/// directly — the repo-tab menu's case, which has no file to select). All
+/// three platforms honour that distinction, so the repo tab behaves the same
+/// everywhere.
 ///
 /// Linux has no portable "select this entry" verb — `xdg-open` only opens a
 /// directory — so a file target opens its PARENT directory instead of
 /// failing outright; worse than a selection, still strictly better than an
 /// error for a command whose whole point is "get me there".
-pub fn reveal_plan(platform: HostPlatform, path: &Path, is_dir: bool) -> SpawnPlan {
+pub fn reveal_plan(platform: HostPlatform, path: &Path, is_dir: bool, env: &HostEnv) -> SpawnPlan {
     match platform {
-        HostPlatform::MacOs => SpawnPlan {
-            program: OsString::from("open"),
-            args: vec![OsString::from("-R"), path.as_os_str().to_owned()],
-        },
+        // `open -R` reveals a file by SELECTING it in its parent window; for a
+        // directory the useful answer is a window on the directory itself, which
+        // is plain `open`. Without this split the repo tab's "Reveal in Finder"
+        // would select the repo in its parent while Windows and Linux opened it.
+        HostPlatform::MacOs => {
+            let args = if is_dir {
+                vec![path.as_os_str().to_owned()]
+            } else {
+                vec![OsString::from("-R"), path.as_os_str().to_owned()]
+            };
+            SpawnPlan::new("open", args)
+        }
         HostPlatform::Windows => {
             let args = if is_dir {
                 vec![path.as_os_str().to_owned()]
@@ -73,10 +171,9 @@ pub fn reveal_plan(platform: HostPlatform, path: &Path, is_dir: bool) -> SpawnPl
                 arg.push(path.as_os_str());
                 vec![arg]
             };
-            SpawnPlan {
-                program: OsString::from("explorer.exe"),
-                args,
-            }
+            let mut plan = SpawnPlan::new(system32_exe(env, "explorer.exe"), args);
+            plan.exit_status_meaningless = true;
+            plan
         }
         HostPlatform::Linux => {
             let target: PathBuf = if is_dir {
@@ -86,66 +183,67 @@ pub fn reveal_plan(platform: HostPlatform, path: &Path, is_dir: bool) -> SpawnPl
                     .map(Path::to_path_buf)
                     .unwrap_or_else(|| path.to_path_buf())
             };
-            SpawnPlan {
-                program: OsString::from("xdg-open"),
-                args: vec![target.into_os_string()],
-            }
+            SpawnPlan::new("xdg-open", vec![target.into_os_string()])
         }
     }
 }
 
 /// Build the ordered list of terminal-launch candidates for `dir`.
 ///
-/// macOS and Windows each have exactly one command worth trying. Linux has
+/// macOS and Windows each have one or two commands worth trying. Linux has
 /// none that is reliably present, so this is a short ordered fallback list —
 /// [`open_terminal`] spawns each in turn, moving on only when a program is
-/// genuinely missing. `env_terminal` is `$TERMINAL` — threaded in as a
-/// parameter rather than read here, so this stays a pure function testable
-/// without mutating process-global environment state.
+/// genuinely missing.
 ///
 /// Every candidate is spawned with `dir` set as its OWN current directory
 /// (see `open_terminal`), not baked into argv, so a terminal that ignores its
 /// own argv (`xterm`) still lands in the right place. macOS and the Windows
 /// Terminal are the two exceptions: `open -a Terminal` and `wt -d` both
 /// require the directory spelled out as an argument to land there at all.
-pub fn terminal_plan(platform: HostPlatform, dir: &Path, env_terminal: Option<&OsStr>) -> Vec<SpawnPlan> {
+pub fn terminal_plan(platform: HostPlatform, dir: &Path, env: &HostEnv) -> Vec<SpawnPlan> {
     match platform {
-        HostPlatform::MacOs => vec![SpawnPlan {
-            program: OsString::from("open"),
-            args: vec![
+        HostPlatform::MacOs => vec![SpawnPlan::new(
+            "open",
+            vec![
                 OsString::from("-a"),
                 OsString::from("Terminal"),
                 dir.as_os_str().to_owned(),
             ],
-        }],
-        HostPlatform::Windows => vec![
-            SpawnPlan {
-                program: OsString::from("wt.exe"),
-                args: vec![OsString::from("-d"), dir.as_os_str().to_owned()],
-            },
+        )],
+        HostPlatform::Windows => {
+            let mut plans = Vec::new();
+            if let Some(wt) = windows_terminal_exe(env) {
+                plans.push(SpawnPlan::new(
+                    wt,
+                    vec![OsString::from("-d"), dir.as_os_str().to_owned()],
+                ));
+            }
             // Every Windows install has `cmd.exe`, even with no Windows
-            // Terminal — the fallback of last resort. `start` detaches the
-            // new window; the empty title argument is `start`'s own syntax
-            // for "no window title", required whenever the target might
-            // contain characters `start` would otherwise read as its title.
-            SpawnPlan {
-                program: OsString::from("cmd.exe"),
-                args: vec![
+            // Terminal — the fallback of last resort. `start` is what gives the
+            // new `cmd.exe` a console of its own; spawning it directly would
+            // leave an invisible shell nobody can type into. The empty title
+            // argument is `start`'s own syntax for "no window title".
+            //
+            // No path or filename is interpolated here — every element is a
+            // literal, and the directory arrives via `current_dir`, not argv —
+            // so this is not the `cmd /C start "" <target>` injection
+            // `opener.rs`'s module doc describes.
+            plans.push(SpawnPlan::new(
+                system32_exe(env, "cmd.exe"),
+                vec![
                     OsString::from("/C"),
                     OsString::from("start"),
                     OsString::new(),
-                    OsString::from("cmd.exe"),
+                    system32_exe(env, "cmd.exe"),
                 ],
-            },
-        ],
+            ));
+            plans
+        }
         HostPlatform::Linux => {
             let mut plans = Vec::new();
-            if let Some(term) = env_terminal {
+            if let Some(term) = env.terminal.as_ref() {
                 if !term.is_empty() {
-                    plans.push(SpawnPlan {
-                        program: term.to_owned(),
-                        args: Vec::new(),
-                    });
+                    plans.push(SpawnPlan::new(term.clone(), Vec::new()));
                 }
             }
             for prog in [
@@ -155,10 +253,7 @@ pub fn terminal_plan(platform: HostPlatform, dir: &Path, env_terminal: Option<&O
                 "xfce4-terminal",
                 "xterm",
             ] {
-                plans.push(SpawnPlan {
-                    program: OsString::from(prog),
-                    args: Vec::new(),
-                });
+                plans.push(SpawnPlan::new(prog, Vec::new()));
             }
             plans
         }
@@ -168,17 +263,19 @@ pub fn terminal_plan(platform: HostPlatform, dir: &Path, env_terminal: Option<&O
 /// Reveal `path` in the platform's file manager (`is_dir`: see
 /// [`reveal_plan`]).
 pub async fn reveal(path: &Path, is_dir: bool) -> AppResult<()> {
-    let plan = reveal_plan(HostPlatform::current(), path, is_dir);
+    let plan = reveal_plan(
+        HostPlatform::current(),
+        path,
+        is_dir,
+        &HostEnv::current(),
+    );
     let shown = plan.program.to_string_lossy().to_string();
     let status = crate::proc::program_async(&plan.program)
         .args(&plan.args)
         .status()
         .await
         .map_err(|e| AppError::Io(format!("failed to run {shown}: {e}")))?;
-    // `explorer.exe /select,<path>` exits 1 on SUCCESS — Explorer's own
-    // documented behaviour, not a failure. Every other launcher here follows
-    // the ordinary 0-is-success convention.
-    if !status.success() && shown != "explorer.exe" {
+    if !status.success() && !plan.exit_status_meaningless {
         return Err(AppError::Io(format!(
             "{shown} exited with {status} while revealing {}",
             path.to_string_lossy()
@@ -189,16 +286,22 @@ pub async fn reveal(path: &Path, is_dir: bool) -> AppResult<()> {
 
 /// Open a terminal at `dir`, trying [`terminal_plan`]'s candidates in order
 /// and moving to the next on a "program not found" error. Every other spawn
-/// failure is returned immediately; running out of candidates (only reachable
-/// on Linux — macOS and Windows always have their one candidate) raises a
-/// clear error naming what was tried, rather than doing nothing silently.
+/// failure is returned immediately; running out of candidates raises a clear
+/// error naming what was tried, rather than doing nothing silently.
 ///
 /// Deliberately `spawn()`, not `status().await`: a terminal is a long-running
 /// program, and waiting for it to exit would block the app until the user
 /// closes the window.
+///
+/// Deliberately the *silenced* `proc::program_async` rather than
+/// `program_async_keeping_console`, even though a terminal is the archetypal
+/// interactive console program: the two Windows candidates do not need an
+/// inherited console. `wt.exe` is a GUI application, so `CREATE_NO_WINDOW` is
+/// documented as ignored for it, and the `cmd.exe` fallback gets its window
+/// from `start`, which creates a fresh console regardless of what the parent
+/// has. So no exception to `proc.rs`'s rule is needed here.
 pub async fn open_terminal(dir: &Path) -> AppResult<()> {
-    let env_terminal = std::env::var_os("TERMINAL");
-    let plans = terminal_plan(HostPlatform::current(), dir, env_terminal.as_deref());
+    let plans = terminal_plan(HostPlatform::current(), dir, &HostEnv::current());
     let mut tried = Vec::new();
     for plan in &plans {
         let shown = plan.program.to_string_lossy().to_string();
@@ -222,9 +325,43 @@ pub async fn open_terminal(dir: &Path) -> AppResult<()> {
 mod tests {
     use super::*;
 
+    /// The pinned paths are built with `Path::join`, which uses the HOST's
+    /// separator — these planners are pure and run on any host, so the
+    /// expectation has to be built the same way rather than hard-coding `\\`.
+    /// What the assertions pin is that the program is absolute and under the
+    /// right system directory, not which slash this machine happens to use.
+    fn win_path(parts: &[&str]) -> OsString {
+        let mut p = PathBuf::from(parts[0]);
+        for part in &parts[1..] {
+            p.push(part);
+        }
+        p.into_os_string()
+    }
+
+    /// A Windows host with the two variables the pinning depends on.
+    fn win_env() -> HostEnv {
+        HostEnv {
+            system_root: Some(OsString::from(r"C:\Windows")),
+            local_app_data: Some(OsString::from(r"C:\Users\dev\AppData\Local")),
+            terminal: None,
+        }
+    }
+
+    fn linux_env(terminal: Option<&str>) -> HostEnv {
+        HostEnv {
+            terminal: terminal.map(OsString::from),
+            ..HostEnv::default()
+        }
+    }
+
     #[test]
     fn reveal_macos_selects_the_file() {
-        let plan = reveal_plan(HostPlatform::MacOs, Path::new("/tmp/repo/a.txt"), false);
+        let plan = reveal_plan(
+            HostPlatform::MacOs,
+            Path::new("/tmp/repo/a.txt"),
+            false,
+            &HostEnv::default(),
+        );
         assert_eq!(plan.program, "open");
         assert_eq!(
             plan.args,
@@ -233,43 +370,97 @@ mod tests {
     }
 
     #[test]
-    fn reveal_macos_opens_a_directory_the_same_way() {
-        let plan = reveal_plan(HostPlatform::MacOs, Path::new("/tmp/repo"), true);
-        assert_eq!(
-            plan.args,
-            vec![OsString::from("-R"), OsString::from("/tmp/repo")]
+    fn reveal_macos_opens_a_directory_rather_than_selecting_it() {
+        // `open -R <dir>` would select the repo in its PARENT window, which is
+        // not what the repo tab's "Reveal in Finder" means — and would differ
+        // from what Windows and Linux do for the same click.
+        let plan = reveal_plan(
+            HostPlatform::MacOs,
+            Path::new("/tmp/repo"),
+            true,
+            &HostEnv::default(),
         );
+        assert_eq!(plan.args, vec![OsString::from("/tmp/repo")]);
     }
 
     #[test]
     fn reveal_windows_selects_the_file_as_one_argument() {
-        let plan = reveal_plan(HostPlatform::Windows, Path::new(r"C:\repo\a.txt"), false);
-        assert_eq!(plan.program, "explorer.exe");
+        let plan = reveal_plan(
+            HostPlatform::Windows,
+            Path::new(r"C:\repo\a.txt"),
+            false,
+            &win_env(),
+        );
         assert_eq!(plan.args, vec![OsString::from(r"/select,C:\repo\a.txt")]);
     }
 
     #[test]
     fn reveal_windows_opens_a_directory_plainly() {
-        let plan = reveal_plan(HostPlatform::Windows, Path::new(r"C:\repo"), true);
+        let plan = reveal_plan(HostPlatform::Windows, Path::new(r"C:\repo"), true, &win_env());
         assert_eq!(plan.args, vec![OsString::from(r"C:\repo")]);
     }
 
     #[test]
+    fn reveal_windows_pins_explorer_to_system32() {
+        // The binary-planting guard: a repository containing its own
+        // `explorer.exe` must never be the thing that runs.
+        let plan = reveal_plan(HostPlatform::Windows, Path::new(r"C:\repo"), true, &win_env());
+        assert_eq!(plan.program, win_path(&[r"C:\Windows", "System32", "explorer.exe"]));
+    }
+
+    #[test]
+    fn reveal_windows_falls_back_to_a_fixed_windows_dir_without_systemroot() {
+        let plan = reveal_plan(
+            HostPlatform::Windows,
+            Path::new(r"C:\repo"),
+            true,
+            &HostEnv::default(),
+        );
+        assert_eq!(plan.program, win_path(&[r"C:\Windows", "System32", "explorer.exe"]));
+    }
+
+    #[test]
+    fn only_explorer_has_a_meaningless_exit_status() {
+        // explorer.exe exits 1 on success; nothing else here does, and the flag
+        // must not be recovered by comparing the (now absolute) program name.
+        assert!(
+            reveal_plan(HostPlatform::Windows, Path::new(r"C:\r"), true, &win_env())
+                .exit_status_meaningless
+        );
+        for p in [HostPlatform::MacOs, HostPlatform::Linux] {
+            assert!(
+                !reveal_plan(p, Path::new("/r"), true, &HostEnv::default())
+                    .exit_status_meaningless
+            );
+        }
+    }
+
+    #[test]
     fn reveal_linux_opens_the_parent_of_a_file() {
-        let plan = reveal_plan(HostPlatform::Linux, Path::new("/tmp/repo/a.txt"), false);
+        let plan = reveal_plan(
+            HostPlatform::Linux,
+            Path::new("/tmp/repo/a.txt"),
+            false,
+            &HostEnv::default(),
+        );
         assert_eq!(plan.program, "xdg-open");
         assert_eq!(plan.args, vec![OsString::from("/tmp/repo")]);
     }
 
     #[test]
     fn reveal_linux_opens_a_directory_directly() {
-        let plan = reveal_plan(HostPlatform::Linux, Path::new("/tmp/repo"), true);
+        let plan = reveal_plan(
+            HostPlatform::Linux,
+            Path::new("/tmp/repo"),
+            true,
+            &HostEnv::default(),
+        );
         assert_eq!(plan.args, vec![OsString::from("/tmp/repo")]);
     }
 
     #[test]
     fn terminal_macos_opens_terminal_app_at_dir() {
-        let plans = terminal_plan(HostPlatform::MacOs, Path::new("/tmp/repo"), None);
+        let plans = terminal_plan(HostPlatform::MacOs, Path::new("/tmp/repo"), &HostEnv::default());
         assert_eq!(plans.len(), 1);
         assert_eq!(plans[0].program, "open");
         assert_eq!(
@@ -284,14 +475,34 @@ mod tests {
 
     #[test]
     fn terminal_windows_tries_windows_terminal_then_falls_back_to_cmd() {
-        let plans = terminal_plan(HostPlatform::Windows, Path::new(r"C:\repo"), None);
+        let plans = terminal_plan(HostPlatform::Windows, Path::new(r"C:\repo"), &win_env());
         assert_eq!(plans.len(), 2);
-        assert_eq!(plans[0].program, "wt.exe");
+        assert_eq!(
+            plans[0].program,
+            win_path(&[r"C:\Users\dev\AppData\Local", "Microsoft", "WindowsApps", "wt.exe"])
+        );
         assert_eq!(
             plans[0].args,
             vec![OsString::from("-d"), OsString::from(r"C:\repo")]
         );
-        assert_eq!(plans[1].program, "cmd.exe");
+        // The fallback is pinned too, and so is the shell `start` launches.
+        assert_eq!(plans[1].program, win_path(&[r"C:\Windows", "System32", "cmd.exe"]));
+        assert_eq!(
+            plans[1].args.last().unwrap(),
+            &win_path(&[r"C:\Windows", "System32", "cmd.exe"])
+        );
+    }
+
+    #[test]
+    fn terminal_windows_skips_windows_terminal_when_localappdata_is_unset() {
+        // Unresolvable beats relative: a bare `wt.exe` would be planting-prone.
+        let env = HostEnv {
+            system_root: Some(OsString::from(r"C:\Windows")),
+            ..HostEnv::default()
+        };
+        let plans = terminal_plan(HostPlatform::Windows, Path::new(r"C:\repo"), &env);
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].program, win_path(&[r"C:\Windows", "System32", "cmd.exe"]));
     }
 
     #[test]
@@ -299,18 +510,20 @@ mod tests {
         let plans = terminal_plan(
             HostPlatform::Linux,
             Path::new("/tmp/repo"),
-            Some(OsStr::new("alacritty")),
+            &linux_env(Some("alacritty")),
         );
         assert_eq!(plans[0].program, "alacritty");
         assert!(plans[0].args.is_empty());
-        // The rest of the fallback list still follows.
         assert!(plans.iter().any(|p| p.program == "xterm"));
     }
 
     #[test]
     fn terminal_linux_falls_back_through_a_fixed_list_with_no_env_terminal() {
-        let plans = terminal_plan(HostPlatform::Linux, Path::new("/tmp/repo"), None);
-        let progs: Vec<_> = plans.iter().map(|p| p.program.to_string_lossy().to_string()).collect();
+        let plans = terminal_plan(HostPlatform::Linux, Path::new("/tmp/repo"), &linux_env(None));
+        let progs: Vec<_> = plans
+            .iter()
+            .map(|p| p.program.to_string_lossy().to_string())
+            .collect();
         assert_eq!(
             progs,
             vec![
@@ -325,7 +538,7 @@ mod tests {
 
     #[test]
     fn terminal_linux_ignores_an_empty_env_terminal() {
-        let plans = terminal_plan(HostPlatform::Linux, Path::new("/tmp/repo"), Some(OsStr::new("")));
+        let plans = terminal_plan(HostPlatform::Linux, Path::new("/tmp/repo"), &linux_env(Some("")));
         assert_eq!(plans[0].program, "x-terminal-emulator");
     }
 }

--- a/src-tauri/src/reveal.rs
+++ b/src-tauri/src/reveal.rs
@@ -1,0 +1,331 @@
+//! "Reveal in Finder / Explorer" and "Open in terminal" (issue 215).
+//!
+//! Companion to `opener.rs` (which hands a path to the app that OWNS the
+//! file) — this hands it to the OS's shell chrome instead: the file manager
+//! or a terminal emulator. No shell interpreter is ever involved, matching
+//! `opener.rs`'s own rule; every argv is built as a `Vec<OsString>` and passed
+//! straight to `Command`, never joined into a string.
+//!
+//! Every `Command`/spawn goes through `proc::program_async` (issue 172): the
+//! console-flashing bug that module exists to prevent applies here exactly as
+//! much as anywhere else that shells out on Windows.
+
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+
+use crate::error::{AppError, AppResult};
+
+/// The three platforms this module has a story for, decoupled from the
+/// actual host. `HostPlatform::current()` is the only place `cfg!(target_os =
+/// …)` is read here, so [`reveal_plan`] and [`terminal_plan`] are pure
+/// functions of their arguments and are exercised for all three platforms
+/// from any host — the same reasoning `opener.rs::opener_program`'s runtime
+/// `cfg!()` check already uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostPlatform {
+    MacOs,
+    Windows,
+    Linux,
+}
+
+impl HostPlatform {
+    pub fn current() -> Self {
+        if cfg!(target_os = "macos") {
+            HostPlatform::MacOs
+        } else if cfg!(target_os = "windows") {
+            HostPlatform::Windows
+        } else {
+            HostPlatform::Linux
+        }
+    }
+}
+
+/// One process to spawn: a program and its argv, nothing else.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SpawnPlan {
+    pub program: OsString,
+    pub args: Vec<OsString>,
+}
+
+/// Build the argv that reveals `path` in the platform's file manager.
+///
+/// `is_dir` distinguishes the two jobs a caller means: reveal a FILE (select
+/// it inside its parent's window) or reveal a DIRECTORY (open a window on it
+/// directly — the repo-tab menu's case, which has no file to select).
+///
+/// Linux has no portable "select this entry" verb — `xdg-open` only opens a
+/// directory — so a file target opens its PARENT directory instead of
+/// failing outright; worse than a selection, still strictly better than an
+/// error for a command whose whole point is "get me there".
+pub fn reveal_plan(platform: HostPlatform, path: &Path, is_dir: bool) -> SpawnPlan {
+    match platform {
+        HostPlatform::MacOs => SpawnPlan {
+            program: OsString::from("open"),
+            args: vec![OsString::from("-R"), path.as_os_str().to_owned()],
+        },
+        HostPlatform::Windows => {
+            let args = if is_dir {
+                vec![path.as_os_str().to_owned()]
+            } else {
+                // `/select,<path>` is ONE argument — anything after the comma,
+                // including a space, is part of the path being selected.
+                let mut arg = OsString::from("/select,");
+                arg.push(path.as_os_str());
+                vec![arg]
+            };
+            SpawnPlan {
+                program: OsString::from("explorer.exe"),
+                args,
+            }
+        }
+        HostPlatform::Linux => {
+            let target: PathBuf = if is_dir {
+                path.to_path_buf()
+            } else {
+                path.parent()
+                    .map(Path::to_path_buf)
+                    .unwrap_or_else(|| path.to_path_buf())
+            };
+            SpawnPlan {
+                program: OsString::from("xdg-open"),
+                args: vec![target.into_os_string()],
+            }
+        }
+    }
+}
+
+/// Build the ordered list of terminal-launch candidates for `dir`.
+///
+/// macOS and Windows each have exactly one command worth trying. Linux has
+/// none that is reliably present, so this is a short ordered fallback list —
+/// [`open_terminal`] spawns each in turn, moving on only when a program is
+/// genuinely missing. `env_terminal` is `$TERMINAL` — threaded in as a
+/// parameter rather than read here, so this stays a pure function testable
+/// without mutating process-global environment state.
+///
+/// Every candidate is spawned with `dir` set as its OWN current directory
+/// (see `open_terminal`), not baked into argv, so a terminal that ignores its
+/// own argv (`xterm`) still lands in the right place. macOS and the Windows
+/// Terminal are the two exceptions: `open -a Terminal` and `wt -d` both
+/// require the directory spelled out as an argument to land there at all.
+pub fn terminal_plan(platform: HostPlatform, dir: &Path, env_terminal: Option<&OsStr>) -> Vec<SpawnPlan> {
+    match platform {
+        HostPlatform::MacOs => vec![SpawnPlan {
+            program: OsString::from("open"),
+            args: vec![
+                OsString::from("-a"),
+                OsString::from("Terminal"),
+                dir.as_os_str().to_owned(),
+            ],
+        }],
+        HostPlatform::Windows => vec![
+            SpawnPlan {
+                program: OsString::from("wt.exe"),
+                args: vec![OsString::from("-d"), dir.as_os_str().to_owned()],
+            },
+            // Every Windows install has `cmd.exe`, even with no Windows
+            // Terminal — the fallback of last resort. `start` detaches the
+            // new window; the empty title argument is `start`'s own syntax
+            // for "no window title", required whenever the target might
+            // contain characters `start` would otherwise read as its title.
+            SpawnPlan {
+                program: OsString::from("cmd.exe"),
+                args: vec![
+                    OsString::from("/C"),
+                    OsString::from("start"),
+                    OsString::new(),
+                    OsString::from("cmd.exe"),
+                ],
+            },
+        ],
+        HostPlatform::Linux => {
+            let mut plans = Vec::new();
+            if let Some(term) = env_terminal {
+                if !term.is_empty() {
+                    plans.push(SpawnPlan {
+                        program: term.to_owned(),
+                        args: Vec::new(),
+                    });
+                }
+            }
+            for prog in [
+                "x-terminal-emulator",
+                "gnome-terminal",
+                "konsole",
+                "xfce4-terminal",
+                "xterm",
+            ] {
+                plans.push(SpawnPlan {
+                    program: OsString::from(prog),
+                    args: Vec::new(),
+                });
+            }
+            plans
+        }
+    }
+}
+
+/// Reveal `path` in the platform's file manager (`is_dir`: see
+/// [`reveal_plan`]).
+pub async fn reveal(path: &Path, is_dir: bool) -> AppResult<()> {
+    let plan = reveal_plan(HostPlatform::current(), path, is_dir);
+    let shown = plan.program.to_string_lossy().to_string();
+    let status = crate::proc::program_async(&plan.program)
+        .args(&plan.args)
+        .status()
+        .await
+        .map_err(|e| AppError::Io(format!("failed to run {shown}: {e}")))?;
+    // `explorer.exe /select,<path>` exits 1 on SUCCESS — Explorer's own
+    // documented behaviour, not a failure. Every other launcher here follows
+    // the ordinary 0-is-success convention.
+    if !status.success() && shown != "explorer.exe" {
+        return Err(AppError::Io(format!(
+            "{shown} exited with {status} while revealing {}",
+            path.to_string_lossy()
+        )));
+    }
+    Ok(())
+}
+
+/// Open a terminal at `dir`, trying [`terminal_plan`]'s candidates in order
+/// and moving to the next on a "program not found" error. Every other spawn
+/// failure is returned immediately; running out of candidates (only reachable
+/// on Linux — macOS and Windows always have their one candidate) raises a
+/// clear error naming what was tried, rather than doing nothing silently.
+///
+/// Deliberately `spawn()`, not `status().await`: a terminal is a long-running
+/// program, and waiting for it to exit would block the app until the user
+/// closes the window.
+pub async fn open_terminal(dir: &Path) -> AppResult<()> {
+    let env_terminal = std::env::var_os("TERMINAL");
+    let plans = terminal_plan(HostPlatform::current(), dir, env_terminal.as_deref());
+    let mut tried = Vec::new();
+    for plan in &plans {
+        let shown = plan.program.to_string_lossy().to_string();
+        let mut cmd = crate::proc::program_async(&plan.program);
+        cmd.args(&plan.args).current_dir(dir);
+        match cmd.spawn() {
+            Ok(_) => return Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                tried.push(shown);
+            }
+            Err(e) => return Err(AppError::Io(format!("failed to run {shown}: {e}"))),
+        }
+    }
+    Err(AppError::Io(format!(
+        "no terminal emulator found (tried: {})",
+        tried.join(", ")
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reveal_macos_selects_the_file() {
+        let plan = reveal_plan(HostPlatform::MacOs, Path::new("/tmp/repo/a.txt"), false);
+        assert_eq!(plan.program, "open");
+        assert_eq!(
+            plan.args,
+            vec![OsString::from("-R"), OsString::from("/tmp/repo/a.txt")]
+        );
+    }
+
+    #[test]
+    fn reveal_macos_opens_a_directory_the_same_way() {
+        let plan = reveal_plan(HostPlatform::MacOs, Path::new("/tmp/repo"), true);
+        assert_eq!(
+            plan.args,
+            vec![OsString::from("-R"), OsString::from("/tmp/repo")]
+        );
+    }
+
+    #[test]
+    fn reveal_windows_selects_the_file_as_one_argument() {
+        let plan = reveal_plan(HostPlatform::Windows, Path::new(r"C:\repo\a.txt"), false);
+        assert_eq!(plan.program, "explorer.exe");
+        assert_eq!(plan.args, vec![OsString::from(r"/select,C:\repo\a.txt")]);
+    }
+
+    #[test]
+    fn reveal_windows_opens_a_directory_plainly() {
+        let plan = reveal_plan(HostPlatform::Windows, Path::new(r"C:\repo"), true);
+        assert_eq!(plan.args, vec![OsString::from(r"C:\repo")]);
+    }
+
+    #[test]
+    fn reveal_linux_opens_the_parent_of_a_file() {
+        let plan = reveal_plan(HostPlatform::Linux, Path::new("/tmp/repo/a.txt"), false);
+        assert_eq!(plan.program, "xdg-open");
+        assert_eq!(plan.args, vec![OsString::from("/tmp/repo")]);
+    }
+
+    #[test]
+    fn reveal_linux_opens_a_directory_directly() {
+        let plan = reveal_plan(HostPlatform::Linux, Path::new("/tmp/repo"), true);
+        assert_eq!(plan.args, vec![OsString::from("/tmp/repo")]);
+    }
+
+    #[test]
+    fn terminal_macos_opens_terminal_app_at_dir() {
+        let plans = terminal_plan(HostPlatform::MacOs, Path::new("/tmp/repo"), None);
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].program, "open");
+        assert_eq!(
+            plans[0].args,
+            vec![
+                OsString::from("-a"),
+                OsString::from("Terminal"),
+                OsString::from("/tmp/repo"),
+            ]
+        );
+    }
+
+    #[test]
+    fn terminal_windows_tries_windows_terminal_then_falls_back_to_cmd() {
+        let plans = terminal_plan(HostPlatform::Windows, Path::new(r"C:\repo"), None);
+        assert_eq!(plans.len(), 2);
+        assert_eq!(plans[0].program, "wt.exe");
+        assert_eq!(
+            plans[0].args,
+            vec![OsString::from("-d"), OsString::from(r"C:\repo")]
+        );
+        assert_eq!(plans[1].program, "cmd.exe");
+    }
+
+    #[test]
+    fn terminal_linux_prefers_the_env_terminal_when_set() {
+        let plans = terminal_plan(
+            HostPlatform::Linux,
+            Path::new("/tmp/repo"),
+            Some(OsStr::new("alacritty")),
+        );
+        assert_eq!(plans[0].program, "alacritty");
+        assert!(plans[0].args.is_empty());
+        // The rest of the fallback list still follows.
+        assert!(plans.iter().any(|p| p.program == "xterm"));
+    }
+
+    #[test]
+    fn terminal_linux_falls_back_through_a_fixed_list_with_no_env_terminal() {
+        let plans = terminal_plan(HostPlatform::Linux, Path::new("/tmp/repo"), None);
+        let progs: Vec<_> = plans.iter().map(|p| p.program.to_string_lossy().to_string()).collect();
+        assert_eq!(
+            progs,
+            vec![
+                "x-terminal-emulator",
+                "gnome-terminal",
+                "konsole",
+                "xfce4-terminal",
+                "xterm",
+            ]
+        );
+    }
+
+    #[test]
+    fn terminal_linux_ignores_an_empty_env_terminal() {
+        let plans = terminal_plan(HostPlatform::Linux, Path::new("/tmp/repo"), Some(OsStr::new("")));
+        assert_eq!(plans[0].program, "x-terminal-emulator");
+    }
+}

--- a/src/design/context-menu.reveal.test.tsx
+++ b/src/design/context-menu.reveal.test.tsx
@@ -1,0 +1,98 @@
+// "Reveal in Finder/Explorer" and "Open in terminal" (#215): the file-row menu
+// and the repo tab's menu both offer them, next to "Copy path", and both wire
+// straight to the typed `lib/tauri.ts` wrappers rather than calling `invoke`
+// themselves. See `src-tauri/src/reveal.rs` for the platform argv builders —
+// this only tests that the menu ITEMS exist and dispatch correctly.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { fileMenuItems, type ContextMenuItem } from "./context-menu";
+import { tabMenuItems } from "@/features/repo/RepoTabs";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useTabsStore } from "@/features/repo/useTabsStore";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+
+function labeled(items: ContextMenuItem[], match: RegExp): ContextMenuItem {
+  const found = items.find((i) => typeof i.label === "string" && match.test(i.label));
+  expect(found, `no menu item matching ${match}`).toBeTruthy();
+  return found!;
+}
+
+const calls = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+
+beforeEach(() => {
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+  } as never);
+  mockInvoke("reveal_in_file_manager", () => null);
+  mockInvoke("open_in_terminal", () => null);
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("fileMenuItems reveal/terminal", () => {
+  it("labels the reveal entry per platform", () => {
+    expect(labeled(fileMenuItems({ path: "a.txt" }, "macos"), /^Reveal in Finder$/)).toBeTruthy();
+    expect(
+      labeled(fileMenuItems({ path: "a.txt" }, "windows"), /^Show in Explorer$/),
+    ).toBeTruthy();
+    expect(
+      labeled(fileMenuItems({ path: "a.txt" }, "linux"), /^Show in file manager$/),
+    ).toBeTruthy();
+    expect(
+      labeled(fileMenuItems({ path: "a.txt" }, undefined), /^Show in file manager$/),
+    ).toBeTruthy();
+  });
+
+  it("reveals the file through the active repo's id and the file's path", () => {
+    labeled(fileMenuItems({ path: "src/a.txt" }, "macos"), /^Reveal in Finder$/).onClick?.();
+
+    expect(calls("reveal_in_file_manager")).toEqual([
+      { cmd: "reveal_in_file_manager", args: { repoId: "r1", relativePath: "src/a.txt" } },
+    ]);
+  });
+
+  it("opens a terminal through the active repo's id and the file's path", () => {
+    labeled(fileMenuItems({ path: "src/a.txt" }, "macos"), /^Open in terminal$/).onClick?.();
+
+    expect(calls("open_in_terminal")).toEqual([
+      { cmd: "open_in_terminal", args: { repoId: "r1", relativePath: "src/a.txt" } },
+    ]);
+  });
+
+  it("does nothing when the row has no path", () => {
+    labeled(fileMenuItems({ path: undefined }, "macos"), /^Reveal in Finder$/).onClick?.();
+    labeled(fileMenuItems({ path: undefined }, "macos"), /^Open in terminal$/).onClick?.();
+
+    expect(calls("reveal_in_file_manager")).toEqual([]);
+    expect(calls("open_in_terminal")).toEqual([]);
+  });
+});
+
+describe("tabMenuItems reveal/terminal", () => {
+  beforeEach(() => {
+    useTabsStore.setState({
+      tabs: [
+        { path: "/repo-a", repoId: "repo-a-id", status: "open" } as never,
+        { path: "/repo-b", repoId: null, status: "pending" } as never,
+      ],
+    } as never);
+  });
+
+  it("reveals and opens a terminal at the repo root, with no relative path", () => {
+    labeled(tabMenuItems("/repo-a", 2, "windows"), /^Show in Explorer$/).onClick?.();
+    labeled(tabMenuItems("/repo-a", 2, "windows"), /^Open in terminal$/).onClick?.();
+
+    expect(calls("reveal_in_file_manager")).toEqual([
+      { cmd: "reveal_in_file_manager", args: { repoId: "repo-a-id", relativePath: undefined } },
+    ]);
+    expect(calls("open_in_terminal")).toEqual([
+      { cmd: "open_in_terminal", args: { repoId: "repo-a-id", relativePath: undefined } },
+    ]);
+  });
+
+  it("disables both entries for a tab with no repoId yet", () => {
+    const items = tabMenuItems("/repo-b", 2, "windows");
+    expect(labeled(items, /^Show in Explorer$/).disabled).toBe(true);
+    expect(labeled(items, /^Open in terminal$/).disabled).toBe(true);
+  });
+});

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -24,6 +24,7 @@ import { WORKDIR } from "@/features/compare/compareSides";
 import { currentBranch } from "@/lib/derive";
 import { openCreateTag } from "@/features/tags/useCreateTagStore";
 import { chordFor } from "@/features/keymap";
+import { fileManagerLabel, type Platform } from "@/lib/platform";
 // pgFlash lives in ui-helpers.tsx — a toast is not a context-menu concern, and
 // keeping it out of this module is what lets features/keymap import it without
 // closing a cycle back through this file (which imports chordFor from there).
@@ -1590,6 +1591,7 @@ export function fileMenuItems(
     conflicted?: boolean;
     submodule?: boolean;
   } | null,
+  platform?: Platform,
 ): ContextMenuItem[] {
   const staged = !!file?.staged;
   const untracked = !!file?.untracked;
@@ -1691,6 +1693,20 @@ export function fileMenuItems(
       icon: "copy",
       label: "Copy path",
       onClick: () => navigator.clipboard?.writeText(path),
+    },
+    {
+      icon: "folder",
+      label: fileManagerLabel(platform),
+      onClick: () => {
+        if (path) useRepoStore.getState().revealInFileManager(path);
+      },
+    },
+    {
+      icon: "terminal",
+      label: "Open in terminal",
+      onClick: () => {
+        if (path) useRepoStore.getState().openInTerminal(path);
+      },
     },
     { divider: true },
     // An untracked file has no copy in the index or in history, so discarding

--- a/src/features/repo/RepoTabs.tsx
+++ b/src/features/repo/RepoTabs.tsx
@@ -16,6 +16,8 @@ import {
 import { openRepoDialog } from "./ops";
 import { labelTabs } from "./tabs";
 import { useTabsStore } from "./useTabsStore";
+import { fileManagerLabel, usePlatform, type Platform } from "@/lib/platform";
+import { openInTerminal, revealInFileManager } from "@/lib/tauri";
 
 export function RepoTabs() {
   const tabs = useTabsStore((s) => s.tabs);
@@ -47,7 +49,10 @@ export function RepoTabs() {
     failed: t.status === "failed",
   }));
 
-  const menu = useContextMenu<string>((path) => tabMenuItems(path, tabs.length));
+  const platform = usePlatform();
+  const menu = useContextMenu<string>((path) =>
+    tabMenuItems(path, tabs.length, platform),
+  );
 
   if (tabs.length === 0) return null;
 
@@ -70,8 +75,16 @@ export function RepoTabs() {
  * lost by it, so a prompt there would misrepresent the stakes. The bulk verbs
  * are confirmed, because "close six of these" is not undoable.
  */
-export function tabMenuItems(path: string, total: number): ContextMenuItem[] {
+export function tabMenuItems(
+  path: string,
+  total: number,
+  platform?: Platform,
+): ContextMenuItem[] {
   const tabs = () => useTabsStore.getState();
+  // Only an OPENED tab has a repoId — a still-loading or failed tab has
+  // nothing on the backend to resolve a directory from, so reveal/terminal
+  // stay disabled rather than firing at a repo that isn't there.
+  const repoId = tabs().tabs.find((t) => t.path === path)?.repoId;
   return [
     { __menuTitle: "Repository" },
     {
@@ -121,6 +134,28 @@ export function tabMenuItems(path: string, total: number): ContextMenuItem[] {
           ?.writeText(path)
           .then(() => pgFlash("Path copied"))
           .catch(() => pgFlash("Could not copy path"));
+      },
+    },
+    {
+      label: fileManagerLabel(platform),
+      icon: "folder",
+      disabled: !repoId,
+      onClick: () => {
+        if (!repoId) return;
+        void revealInFileManager(repoId).catch(() =>
+          pgFlash("Could not reveal in file manager"),
+        );
+      },
+    },
+    {
+      label: "Open in terminal",
+      icon: "terminal",
+      disabled: !repoId,
+      onClick: () => {
+        if (!repoId) return;
+        void openInTerminal(repoId).catch(() =>
+          pgFlash("Could not open terminal"),
+        );
       },
     },
   ];

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -29,6 +29,8 @@ import {
   bisectStatus as bisectStatusFn,
   appendGitignore as appendGitignoreFn,
   openInEditor as openInEditorFn,
+  revealInFileManager as revealInFileManagerFn,
+  openInTerminal as openInTerminalFn,
   checkoutBranch,
   checkoutRef,
   cherryPick,
@@ -324,6 +326,10 @@ interface RepoStoreState extends RepoSlice {
   bisectReset: () => Promise<void>;
   appendGitignore: (pattern: string) => Promise<void>;
   openInEditor: (relativePath: string) => Promise<void>;
+  /** Reveal in the OS file manager; omitted reveals the repo root (#215). */
+  revealInFileManager: (relativePath?: string) => Promise<void>;
+  /** Open a terminal at the containing directory; omitted uses the repo root. */
+  openInTerminal: (relativePath?: string) => Promise<void>;
 }
 
 /**
@@ -1585,6 +1591,26 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     try {
       await openInEditorFn(repo.id, relativePath);
+    } catch (e) {
+      setErrorFor(repo.id, e);
+    }
+  },
+
+  async revealInFileManager(relativePath) {
+    const repo = get().current;
+    if (!repo) return;
+    try {
+      await revealInFileManagerFn(repo.id, relativePath);
+    } catch (e) {
+      setErrorFor(repo.id, e);
+    }
+  },
+
+  async openInTerminal(relativePath) {
+    const repo = get().current;
+    if (!repo) return;
+    try {
+      await openInTerminalFn(repo.id, relativePath);
     } catch (e) {
       setErrorFor(repo.id, e);
     }

--- a/src/lib/platform.test.ts
+++ b/src/lib/platform.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 
-import { getPlatform, usePlatform, __resetPlatformCacheForTests } from "./platform";
+import {
+  getPlatform,
+  usePlatform,
+  fileManagerLabel,
+  __resetPlatformCacheForTests,
+} from "./platform";
 
 const platformMock = vi.hoisted(() => vi.fn());
 
@@ -39,5 +44,26 @@ describe("usePlatform", () => {
     const { result } = renderHook(() => usePlatform());
     expect(result.current).toBeUndefined();
     await waitFor(() => expect(result.current).toBe("macos"));
+  });
+});
+
+// #215 — the "reveal in file manager" label names the actual app on the two
+// platforms that have one; Linux (and the brief window before resolving) get
+// the generic wording, since there is no one app to name.
+describe("fileManagerLabel", () => {
+  it("names Finder on macOS", () => {
+    expect(fileManagerLabel("macos")).toBe("Reveal in Finder");
+  });
+
+  it("names Explorer on Windows", () => {
+    expect(fileManagerLabel("windows")).toBe("Show in Explorer");
+  });
+
+  it("falls back to a generic label on Linux", () => {
+    expect(fileManagerLabel("linux")).toBe("Show in file manager");
+  });
+
+  it("falls back to the same generic label before the platform resolves", () => {
+    expect(fileManagerLabel(undefined)).toBe("Show in file manager");
   });
 });

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -41,3 +41,22 @@ export function __resetPlatformCacheForTests() {
   cache = null;
   inflight = null;
 }
+
+/**
+ * Platform-specific wording for "reveal in the OS file manager" (#215) — the
+ * command is the same everywhere, but the app that opens is not, and naming
+ * it beats a generic "Show in file manager" on the two platforms where the
+ * app has an actual name. `undefined` (platform not resolved yet) reads the
+ * same as Linux, which is the least presumptuous default for the brief
+ * window before `usePlatform()` settles.
+ */
+export function fileManagerLabel(platform: Platform | undefined): string {
+  switch (platform) {
+    case "macos":
+      return "Reveal in Finder";
+    case "windows":
+      return "Show in Explorer";
+    default:
+      return "Show in file manager";
+  }
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1011,6 +1011,29 @@ export async function openInEditor(
   return invoke<void>("open_in_editor", { repoId, relativePath });
 }
 
+/**
+ * Reveal `relativePath` in the OS file manager, with it selected where the
+ * platform allows (#215). Omitted/`null` reveals the repo's root directory
+ * instead — the repo tab menu's case, which has no file to select.
+ */
+export async function revealInFileManager(
+  repoId: string,
+  relativePath?: string | null,
+): Promise<void> {
+  return invoke<void>("reveal_in_file_manager", { repoId, relativePath });
+}
+
+/**
+ * Open a terminal at `relativePath`'s containing directory, or the repo's
+ * root when `relativePath` is omitted/`null` (#215).
+ */
+export async function openInTerminal(
+  repoId: string,
+  relativePath?: string | null,
+): Promise<void> {
+  return invoke<void>("open_in_terminal", { repoId, relativePath });
+}
+
 export async function blameFile(
   repoId: string,
   path: string,

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -77,6 +77,7 @@ import {
 } from "@/lib/diffRows";
 import { fileDiffToText, selectedLinesToText } from "@/lib/diffCopy";
 import { useVariableWindow } from "@/lib/useVariableWindow";
+import { usePlatform } from "@/lib/platform";
 import { useViewportH } from "@/lib/useViewportH";
 import { useElementSize } from "@/lib/useElementSize";
 import { MinimapGutter } from "@/features/diff/DiffMinimap";
@@ -136,6 +137,7 @@ export function CommitPanelScreen() {
   const diffContextLines = useSettingsStore((s) => s.diffContextLines);
   const ignoreWhitespace = useIgnoreWhitespace();
   const hunkActionsDisabled = useHunkActionsDisabledReason();
+  const platform = usePlatform();
   // One box for the whole commit message: first line is the subject, the rest
   // is the body — the same shape git itself stores, so nothing is re-joined on
   // the way out.
@@ -205,14 +207,17 @@ export function CommitPanelScreen() {
       if (f && sel.keys.length > 1 && sel.keys.includes(keyOf(f))) {
         return multiFileMenuItems(splitFileSelection(sel.keys, selectionSource));
       }
-      return fileMenuItems({
-        path: f?.path,
-        staged: f?.side === "staged",
-        embedded: f?.status.embedded,
-        untracked: !!f && f.side === "unstaged" && isUntracked(f.status),
-        conflicted: !!f && isConflicted(f.status),
-        submodule: !!f?.status.submodule,
-      });
+      return fileMenuItems(
+        {
+          path: f?.path,
+          staged: f?.side === "staged",
+          embedded: f?.status.embedded,
+          untracked: !!f && f.side === "unstaged" && isUntracked(f.status),
+          conflicted: !!f && isConflicted(f.status),
+          submodule: !!f?.status.submodule,
+        },
+        platform,
+      );
     },
   );
 

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -77,6 +77,7 @@ import {
 import { useTreeViewMode } from "@/lib/useTreeViewMode";
 import { StageDropBar, useDragSource, type DragPayload } from "@/features/dnd";
 import { fuzzyMatch } from "@/features/palette/fuzzyMatch";
+import { usePlatform } from "@/lib/platform";
 import {
   WhitespaceToggle,
   useHunkActionsDisabledReason,
@@ -156,6 +157,7 @@ export function RepoBrowserScreen() {
   const diffContextLines = useSettingsStore((s) => s.diffContextLines);
   const ignoreWhitespace = useIgnoreWhitespace();
   const hunkActionsDisabled = useHunkActionsDisabledReason();
+  const platform = usePlatform();
 
   const [expanded, setExpanded] = React.useState<Record<string, boolean>>({});
   const [treeFilter, setTreeFilter] = React.useState("");
@@ -606,16 +608,19 @@ export function RepoBrowserScreen() {
       // path carries a trailing slash the key has already lost, and that slash
       // is what makes "Add to .gitignore" write valid directory syntax.
       const path = st?.path ?? treeKeyToPath(key);
-      return fileMenuItems({
-        path,
-        staged: !!st && isStaged(st) && !isUnstaged(st),
-        embedded: !!st?.embedded,
-        untracked: !!st && isUntracked(st),
-        conflicted: !!st && isConflicted(st),
-        // A registered submodule gets its own menu (#93) — the ordinary file
-        // entries are all dead ends on a gitlink.
-        submodule: !!st?.submodule,
-      });
+      return fileMenuItems(
+        {
+          path,
+          staged: !!st && isStaged(st) && !isUnstaged(st),
+          embedded: !!st?.embedded,
+          untracked: !!st && isUntracked(st),
+          conflicted: !!st && isConflicted(st),
+          // A registered submodule gets its own menu (#93) — the ordinary
+          // file entries are all dead ends on a gitlink.
+          submodule: !!st?.submodule,
+        },
+        platform,
+      );
     },
   );
 


### PR DESCRIPTION
## Summary

Adds the two context-menu actions the issue asks for: **Reveal in
Finder/Explorer/file manager** and **Open in terminal**, on file rows in the
Commit panel and repo browser (next to the existing "Copy path"), and on the
repo tab strip's menu (the repo-level version).

## Implementation

- `src-tauri/src/reveal.rs` (new): builds the per-platform argv as **pure**
  functions decoupled from the actual host via a `HostPlatform` enum —
  `HostPlatform::current()` is the only place `cfg!(target_os = …)` is read,
  mirroring `opener.rs::opener_program`'s own runtime-`cfg!()` pattern — so
  `reveal_plan`/`terminal_plan` are unit-tested for all three platforms from
  any host, with no spawning in the tests.
  - macOS: `open -R <path>` / `open -a Terminal <dir>`.
  - Windows: `explorer.exe /select,<path>` (or the plain dir when there's no
    file to select) / `wt.exe -d <dir>`, falling back to `cmd.exe` when
    Windows Terminal isn't installed.
  - Linux: `xdg-open <parent-dir>` (no portable "select this file" verb) /
    an ordered terminal-candidate list (`$TERMINAL`, then
    `x-terminal-emulator`, `gnome-terminal`, `konsole`, `xfce4-terminal`,
    `xterm`), failing with a clear error naming what was tried rather than
    doing nothing silently.
  - `explorer.exe`'s exit code 1 **on success** is handled explicitly, not
    treated as failure.
  - Every spawn goes through `proc::program_async` (issue 172) — no raw
    `Command::new`, so the `CREATE_NO_WINDOW`/no-console-flash guarantee
    holds here too. The terminal launch uses `.spawn()`, not
    `.status().await`, since a terminal is long-running and awaiting its
    exit would block the app.
  - No shell interpreter anywhere — argv only, `--`-safe where relevant.
- `commands/repo.rs`: two thin commands, `reveal_in_file_manager` and
  `open_in_terminal`, both `repo_id` + optional `relative_path` — reusing
  `open_in_editor`'s exact shape and `opener::safe_workdir_path` for the
  escape check. An omitted/empty `relative_path` targets the repo's root
  directory instead of a file, which is what the repo tab's menu passes.
  Registered in `lib.rs`'s `invoke_handler!`.
- `src/lib/types.ts`/`tauri.ts`: no new `AppError` variants needed (spawn
  failures reuse `Io`); typed wrappers `revealInFileManager`/`openInTerminal`
  added to `tauri.ts`, the frontend's only `invoke()` boundary.
- `useRepoStore.ts`: two new actions mirroring `openInEditor`'s shape, for the
  file-row menus (always the active repo).
- `context-menu.tsx`: `fileMenuItems` grows an optional `platform` parameter
  and the two new items, right after "Copy path". `RepoTabs.tsx`'s
  `tabMenuItems` gets the repo-level pair, gated on the right-clicked tab
  actually having a `repoId` (a still-loading/failed tab has nothing to
  resolve a directory from, so the entries are disabled rather than firing at
  a repo that isn't open).
- `src/lib/platform.ts`: `fileManagerLabel(platform)` for the per-platform
  wording ("Reveal in Finder" / "Show in Explorer" / "Show in file manager"),
  reused by both menu builders so the wording can't drift between them.
- `docs/dev/architecture.md`: documented `reveal.rs` and the two new
  `commands/repo.rs` entries (`test/docs.test.ts` enforces this).

## Scope

- Embedded-repo rows (`embeddedRepoMenuItems`) and submodule rows are **not**
  touched — the issue names file rows and the repo tab specifically, and
  those two builders are already distinct menus with their own scope.
- **The terminal command is not user-configurable.** The issue calls this out
  explicitly as "a reasonable follow-up, not part of this [issue]", so it's
  left as a fixed fallback list on Linux and the obvious default elsewhere.
- No new Tauri capability was needed in `capabilities/default.json` — these
  are ordinary custom `#[tauri::command]`s (not Tauri plugin commands), same
  as every other command in `commands/repo.rs`.

## Tests

- Rust: `reveal.rs`'s `#[cfg(test)]` module — 11 pure unit tests over
  `reveal_plan`/`terminal_plan` for all three platforms (selection vs.
  directory targets, the Windows fallback chain, the Linux `$TERMINAL`
  override and its empty-string edge case), no spawning.
- Frontend: `src/design/context-menu.reveal.test.tsx` — the two menu items
  appear with the right per-platform label, dispatch to the right
  `lib/tauri.ts` wrapper with the right `repoId`/`relativePath`, no-op when
  there's no path, and the repo-tab entries disable for a tab with no
  `repoId` yet. Plus `fileManagerLabel` unit tests in `platform.test.ts`.

## Test plan

- `cargo check --manifest-path src-tauri/Cargo.toml` — clean.
- `cargo test --manifest-path src-tauri/Cargo.toml` — 182 passed, 0 failed
  (11 new, in `reveal::tests`), including the `Command::new` guard test.
- `pnpm tsc --noEmit` — clean.
- `pnpm vite build` — clean.
- `pnpm vitest run` — 219 files / 1888 tests passed (includes the
  doc/tree invariants).
- Manual click-through wasn't possible in this (headless/sandboxed) build
  environment; reasoned through each platform branch instead, and the
  Windows/Linux paths are exercised only by the pure argv-builder tests
  above (no CI runner for those OSes locally). macOS's `open -R`/`open -a
  Terminal` path is the one most directly checkable by inspection against
  documented `open(1)` behavior.

Fixes #215

---
This PR was prepared with AI assistance (Claude); the diff was reviewed and all listed test commands were run and observed to pass before opening.