### PR TITLE
feat(commit): run the commit-side git hooks (#232)

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -98,6 +98,12 @@ git/
 │                a rebase it cannot drive
 ├── auth.rs      PURE: classify_auth_failure (stderr → AuthKind; host-key
 │                failure deliberately not auth), AuthChallenge, scrub_credentials
+├── hooks.rs     The ONE place a git hook is executed (#232). `git hook run`,
+│                so git's own resolution (core.hooksPath, the executable bit,
+│                Windows' sh shim) is not reimplemented — behind a cached,
+│                side-effect-free capability probe, with a Unix-only direct-exec
+│                fallback for a git older than 2.36. NOTE `git hook run` sends
+│                the hook's STDOUT to stderr, so the captured stream is stderr
 ├── signing.rs   CRYPTOGRAPHIC signing, GPG/SSH — not signature.rs. Pure: key
 │                resolution, resolve_key_file (key::… literals refused), signer
 │                argv, parse_verify_output. Payload-agnostic: commits and tags

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -316,3 +316,75 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   note relies on this). `close` is the only removal.
 - Always wrap git2 work in `spawn_blocking` from Tauri commands — don't block
   the async runtime.
+
+## The hook chain
+
+Commit-side hooks run in `Libgit2Backend::commit`, one per name, through
+`git/hooks.rs` — the only place a hook is spawned. The order is load-bearing:
+
+    pre-commit → read index → write tree → prepare-commit-msg → commit-msg
+    → build/sign/move ref → post-commit
+
+- **`pre-commit` runs before the index is read, and outside `with_repo`.** A hook
+  that runs `git add` (lint-staged: reformat, restage) mutates the on-disk index,
+  and only a read that happens afterwards sees it. Running it outside the lock
+  also means a hook shelling out to git cannot deadlock against us.
+- **`index.read(false)` after `repo.index()` is required, not incidental.**
+  `with_repo` hands back a *cached* `git2::Repository`, and libgit2 keeps its
+  index in memory — so reading the index after the hook still returned the
+  pre-hook snapshot, and a reformatting hook's work was silently dropped.
+  `tests/hooks.rs::a_pre_commit_that_restages_is_honoured` found this and pins
+  it; it fails if either the read or the reload moves.
+- **A non-zero `pre-commit`, `prepare-commit-msg` or `commit-msg` creates
+  nothing** — no object, no ref move — the same guarantee the signing chain
+  makes, for the same reason. The index is deliberately **not** rolled back: a
+  hook that restaged did work the user wants, and git does not undo it either.
+- **`post-commit`'s exit code is discarded**, because git discards it. Reporting
+  a commit that exists as failed sends the user hunting for work that landed.
+- **The final message is the hook's, not the user's.** `commit-msg` may rewrite
+  `$GIT_DIR/COMMIT_EDITMSG`, so `commit` returns
+  `CommitResult { oid, message }` and the panel shows what actually landed.
+- **Sign-off is applied before any hook sees the message**, matching
+  `git commit -s` — verified against real git, so a hook validating trailers sees
+  what git would show it.
+- **`prepare-commit-msg` gets source `message` and two arguments, amend
+  included.** The source is `commit` (with the object as `$3`) only when the
+  message is taken *from* a commit, as with `-c`/`-C` or a bare `--amend`; we
+  always supply it as text.
+- **`no_verify` skips all four.** Per-invocation, never persisted — a "skip once"
+  that silently becomes "never run hooks again" is a worse version of the bug
+  that running hooks fixes. `push_args` grows `--no-verify` for `pre-push`.
+- **Support is detected, never inferred from a version string.**
+  `git hook run --ignore-missing <a-hook-name-that-cannot-exist>` exits 0 on a
+  git that has the subcommand and non-zero on one that does not, with no side
+  effects. Probed once, cached.
+- `AppError::HookRejected` carries the hook's name and its output as separate
+  fields, because the output renders *as output* — not as a banner.
+
+### The `PATH` every child gets
+
+`proc.rs` resolves the user's login-shell `PATH` once, caches it, and applies it
+to every child it constructs. Without it a hook calling `node`, or a
+`gpg.program` in `/opt/homebrew/bin`, works or fails depending on whether the app
+was launched from a terminal or from the Dock.
+
+Two things about it that are easy to get wrong:
+
+- **It is a union — login entries first, then the inherited `PATH`.** Measured:
+  `Command::env("PATH", …)` governs where the child *binary itself* is looked up
+  and uses only that value, never the parent's. Assigning the login `PATH`
+  verbatim would break `Command::new("git")` for anyone whose login `PATH` lacks
+  git's directory — a regression caused by the fix.
+- **Children no longer inherit a `PATH` this process changes at runtime.** That
+  is the point, but it means a test that stubs a binary by mutating `PATH` has to
+  starve the probe first; `tests/verify_commit_no_spawn.rs` does, with a comment.
+- **`child_path()` is a non-blocking cache read; `warm_child_path()` is the only
+  resolver**, called once on a background thread from `run()`'s setup. Resolving
+  inside the reader would make the FIRST spawn of the session wait for a login
+  shell to run the user's rc files — a slow `.zshrc` (nvm, a network mount) would
+  then stall their first git operation by up to the probe timeout. The window
+  before the probe lands fails safe: those spawns inherit our environment, which
+  is exactly the pre-feature behaviour. `proc.rs`'s
+  `only_warm_child_path_resolves_the_probe` guards this at the source level,
+  because a timing test in a parallel test binary gets warmed by a sibling and
+  passes vacuously.

--- a/docs/superpowers/plans/2026-08-26-commit-hooks-plan.md
+++ b/docs/superpowers/plans/2026-08-26-commit-hooks-plan.md
@@ -1,0 +1,1994 @@
+# Commit-side git hooks — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run `pre-commit`, `prepare-commit-msg`, `commit-msg` and `post-commit`
+when the app commits; give the user a visible per-invocation `--no-verify` on
+commit and push; and make hooks that call `node`/`python`/`pnpm` work under a
+Dock or `.desktop` launch.
+
+**Architecture:** Keep the libgit2 commit and wrap it in hook calls, so the one
+signing chain in `libgit2.rs::sign_payload` stays the only one. Hooks are
+executed by `git hook run` — git's own hook resolution (`core.hooksPath`,
+executable bit, Windows `sh`) — behind a cached, side-effect-free capability
+probe, with a Unix-only direct-exec fallback for git older than 2.36. The
+environment fix is a cached login-shell `PATH` probe applied by every `proc.rs`
+constructor.
+
+**Tech Stack:** Rust (`git2`, `tokio`, `thiserror`, `serde`), React + TypeScript,
+Zustand, vitest, WebdriverIO.
+
+**Spec:** `docs/superpowers/specs/2026-08-26-commit-hooks-spec.md`
+
+## Global Constraints
+
+- **One signing chain.** Never shell out to `git commit`. All signing stays in
+  `libgit2.rs::sign_payload`. (CLAUDE.md)
+- **Never `Command::new` outside `src-tauri/src/proc.rs`** —
+  `src-tauri/tests/spawn_no_window.rs` fails the build otherwise. All hook
+  spawning goes through a `proc.rs` constructor.
+- **Every IPC-crossing fn returns `AppResult<T>`.** Add `AppError` variants;
+  never stringify. The TS `AppError` union in `src/lib/errors.ts` stays 1:1 with
+  the Rust enum, **updated in the same commit**.
+- `AppError` serializes as `#[serde(tag = "kind", content = "message")]`, so a
+  struct payload arrives as `{ kind, message: {…} }` — follow the existing
+  `Auth(AuthChallenge)` newtype pattern, not named fields.
+- **A new per-repo field must join `RepoSlice` AND `emptySlice`**, or tab
+  switches leak it between repositories. (CLAUDE.md)
+- **`git2::Repository` is `Send` not `Sync`** — all git2 work stays inside
+  `tokio::task::spawn_blocking`.
+- **No native `<select>`/`<option>`**; design system lives in `src/design/`,
+  imported from `@/design`; never hardcode the accent hue.
+- **A non-zero `pre-commit`, `prepare-commit-msg` or `commit-msg` creates no
+  object and moves no reference.** `post-commit`'s exit code is ignored.
+- **`no_verify` is never persisted** — no settings-store key, no default. It is
+  per-invocation only.
+- Register every new command name in `invoke_handler![…]` in
+  `src-tauri/src/lib.rs`, and add it to the matching `commands/<area>.rs` entry
+  in `docs/dev/architecture.md`, or `test/docs.test.ts` fails the build.
+- Toolchain: `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"` before
+  any `pnpm`/`cargo`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `src-tauri/src/proc.rs` (modify) | Cached login-shell `PATH`; every constructor applies it |
+| `src-tauri/src/git/hooks.rs` (create) | The only place a hook is spawned: `git hook run`, capability probe, direct-exec fallback |
+| `src-tauri/src/error.rs` (modify) | `AppError::HookRejected(HookRejection)` |
+| `src-tauri/src/git/types.rs` (modify) | `CommitOptions.no_verify`, `CommitResult` |
+| `src-tauri/src/git/libgit2.rs` (modify) | `commit()` hook sequence; index read moves after `pre-commit` |
+| `src-tauri/src/git/mod.rs` (modify) | `commit` returns `CommitResult` |
+| `src-tauri/src/git/cli.rs` (modify) | `CliBackend` stub kept in shape |
+| `src-tauri/src/commands/commits.rs` (modify) | `commit` takes `no_verify`, returns `CommitResult` |
+| `src-tauri/src/commands/branches.rs` (modify) | `push_args` + `push` take `no_verify` |
+| `src-tauri/tests/hooks.rs` (create) | The contract: real hook scripts against temp repos |
+| `src/lib/errors.ts` (modify) | `HookRejected` union member + prose |
+| `src/lib/types.ts` (modify) | `CommitResult`, `HookRejection` |
+| `src/lib/tauri.ts` (modify) | `commit`/`push` wrappers take `noVerify` |
+| `src/design/hook-output.tsx` (create) | The collapsible monospace output block |
+| `src/features/repo/useRepoStore.ts` (modify) | `hookRejection` per-repo field; actions carry `noVerify` |
+| `src/screens/CommitPanel.tsx` (modify) | Output block, checkbox, retry |
+| `docs/dev/backend.md`, `docs/dev/architecture.md` (modify) | The hook chain; new module + command entries |
+| `e2e/specs/commit.e2e.ts` (modify) | Rejecting `pre-commit` → block visible → retry succeeds |
+
+---
+
+## Task 1: Login-shell `PATH` resolution in `proc.rs`
+
+Independent of every other task; land it first so hooks inherit a working
+environment the moment they exist.
+
+**Files:**
+- Modify: `src-tauri/src/proc.rs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `pub fn login_path() -> Option<&'static str>` (cached);
+  `fn apply_env(cmd: &mut std::process::Command)` /
+  `fn apply_env_async(cmd: &mut tokio::process::Command)`, called by every
+  existing constructor. `pub(crate) fn parse_probe_output(raw: &str) ->
+  Option<String>` exposed for unit tests.
+
+- [ ] **Step 1: Write the failing parser tests**
+
+In `src-tauri/src/proc.rs`, inside `mod tests`:
+
+```rust
+const MARK: &str = "__PGIT_PATH__";
+
+#[test]
+fn parses_path_between_markers_ignoring_rc_noise() {
+    let raw = format!(
+        "Welcome to your shell!\nnvm: loaded\n{MARK}/opt/homebrew/bin:/usr/bin{MARK}\nbye\n"
+    );
+    assert_eq!(
+        parse_probe_output(&raw).as_deref(),
+        Some("/opt/homebrew/bin:/usr/bin")
+    );
+}
+
+#[test]
+fn rejects_output_with_no_markers() {
+    assert_eq!(parse_probe_output("just noise\n"), None);
+}
+
+#[test]
+fn rejects_a_single_unterminated_marker() {
+    // A shell killed by the timeout mid-print must not yield a truncated PATH.
+    assert_eq!(parse_probe_output(&format!("{MARK}/opt/homebrew/bin")), None);
+}
+
+#[test]
+fn rejects_an_empty_path_between_markers() {
+    assert_eq!(parse_probe_output(&format!("{MARK}{MARK}")), None);
+}
+```
+
+- [ ] **Step 2: Run them and confirm they fail**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml proc:: 2>&1 | tail -20
+```
+
+Expected: FAIL — `cannot find function 'parse_probe_output'`.
+
+- [ ] **Step 3: Implement the probe, the parser and the cache**
+
+Add to `src-tauri/src/proc.rs`. Note the doc comment carries the *why*, matching
+the file's existing style.
+
+```rust
+/// Marker wrapped around the probe's payload. An rc file is free to print
+/// banners, version notices and nvm chatter; only what lies between two markers
+/// is ours.
+const PATH_MARK: &str = "__PGIT_PATH__";
+
+/// How long the login shell gets. An rc file can block on a prompt or a slow
+/// network mount, and a GUI app that hangs at startup is worse than one with a
+/// short PATH.
+const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Extract the payload from a probe's stdout, or `None` if it is unusable.
+///
+/// Requires BOTH markers: a shell killed by the timeout mid-print would
+/// otherwise yield a truncated PATH, which is worse than no PATH because it
+/// looks like it worked.
+pub(crate) fn parse_probe_output(raw: &str) -> Option<String> {
+    let start = raw.find(PATH_MARK)? + PATH_MARK.len();
+    let rest = &raw[start..];
+    let end = rest.find(PATH_MARK)?;
+    let path = rest[..end].trim();
+    if path.is_empty() {
+        return None;
+    }
+    Some(path.to_string())
+}
+
+/// The user's login-shell `PATH`, resolved once.
+///
+/// # Why this exists
+///
+/// A GUI launch (Dock, Finder, a `.desktop` file) inherits launchd's or the
+/// session manager's minimal environment, not the login shell's. A launch
+/// through our own `pgit` CLI inherits the terminal's. So a `pre-commit` hook
+/// calling `node`, or a `gpg.program` that lives in `/opt/homebrew/bin`, works
+/// or fails depending on **how the app was started** — which is the worst kind
+/// of bug to debug from a report.
+///
+/// # Why a login shell rather than a list of likely directories
+///
+/// nvm, asdf, pyenv, rbenv and fnm all put their shims in version-specific
+/// directories that cannot be guessed (`~/.nvm/versions/node/v22.3.0/bin`).
+/// Asking the shell is the only way to find them. A static list is the fallback
+/// when the probe fails, not the mechanism.
+///
+/// Returns `None` on Windows (a GUI process there inherits the user and machine
+/// `PATH` from the registry, so there is nothing to fix) and whenever the probe
+/// fails — in which case children inherit our environment exactly as they do
+/// today, so a failure is never worse than the status quo.
+pub fn login_path() -> Option<&'static str> {
+    static CACHE: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+    CACHE.get_or_init(probe_login_path).as_deref()
+}
+
+#[cfg(windows)]
+fn probe_login_path() -> Option<String> {
+    None
+}
+
+#[cfg(not(windows))]
+fn probe_login_path() -> Option<String> {
+    let shell = std::env::var("SHELL").ok().filter(|s| !s.is_empty())?;
+
+    // `-l` so profile files run (that is where the version managers are); `-c`
+    // with `printf` rather than `echo` because `echo` is a builtin whose
+    // escape handling differs between shells.
+    let script = format!("printf '%s%s%s' '{PATH_MARK}' \"$PATH\" '{PATH_MARK}'");
+
+    // Deliberately NOT `program()`: this is the one child that must not inherit
+    // the environment we are trying to replace, and it is never a console
+    // program on Windows because it does not run there at all.
+    let mut cmd = std::process::Command::new(&shell);
+    cmd.arg("-l")
+        .arg("-c")
+        .arg(&script)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+
+    let mut child = cmd.spawn().ok()?;
+
+    // Poll rather than `wait_with_output`, which has no timeout. An rc file that
+    // blocks must not hang the first spawn that needs a PATH.
+    let deadline = std::time::Instant::now() + PROBE_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) if std::time::Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+            Ok(None) => std::thread::sleep(std::time::Duration::from_millis(25)),
+            Err(_) => return None,
+        }
+    }
+
+    use std::io::Read;
+    let mut raw = String::new();
+    child.stdout.as_mut()?.read_to_string(&mut raw).ok()?;
+    parse_probe_output(&raw)
+}
+
+/// Apply the resolved `PATH` to a child. No-op when the probe found nothing.
+fn apply_env(cmd: &mut std::process::Command) {
+    if let Some(p) = login_path() {
+        cmd.env("PATH", p);
+    }
+}
+
+fn apply_env_async(cmd: &mut tokio::process::Command) {
+    if let Some(p) = login_path() {
+        cmd.env("PATH", p);
+    }
+}
+```
+
+- [ ] **Step 4: Call `apply_env` from every constructor**
+
+Add the call to `program`, `program_async`, `git`, `git_async`, `git_async_in`,
+`git_async_keeping_console` and `program_async_keeping_console` — all seven, so
+signing, `$EDITOR`, mergetool and the git-lfs probe are fixed alongside hooks.
+In `program` for example:
+
+```rust
+pub fn program(prog: impl AsRef<OsStr>) -> std::process::Command {
+    let mut cmd = std::process::Command::new(prog);
+    silence(&mut cmd);
+    apply_env(&mut cmd);
+    cmd
+}
+```
+
+- [ ] **Step 5: Warm the cache off the main thread at startup**
+
+In `src-tauri/src/lib.rs`, in the setup hook, before any command can run:
+
+```rust
+// Resolve the login-shell PATH off the main thread: the probe spawns a shell
+// that runs the user's rc files, which is slow enough to be visible at launch.
+// Nothing awaits this — the first spawn that needs a PATH blocks on the same
+// OnceLock and gets the answer.
+std::thread::spawn(|| {
+    let _ = crate::proc::login_path();
+});
+```
+
+- [ ] **Step 6: Run the tests and the guard test**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml proc:: 2>&1 | tail -20
+cargo test --manifest-path src-tauri/Cargo.toml --test spawn_no_window 2>&1 | tail -20
+```
+
+Expected: parser tests PASS. **The guard test may FAIL** on the new
+`Command::new(&shell)` — it is inside `proc.rs`, which is allowed, so if it fails
+read `src-tauri/tests/spawn_no_window.rs` and confirm it scopes to files other
+than `proc.rs`; if it scopes by call *name*, add this site to its allow-list with
+a comment saying why (the probe must not inherit the environment it replaces).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src-tauri/src/proc.rs src-tauri/src/lib.rs
+git commit -m "fix(proc): resolve the login-shell PATH for every spawned child"
+```
+
+---
+
+## Task 2: `git/hooks.rs` — the hook runner
+
+**Files:**
+- Create: `src-tauri/src/git/hooks.rs`
+- Modify: `src-tauri/src/git/mod.rs` (add `pub mod hooks;`)
+
+**Interfaces:**
+- Consumes: `crate::proc::git` (Task 1).
+- Produces:
+  ```rust
+  pub struct HookOutcome { pub ran: bool, pub code: i32, pub output: String }
+  impl HookOutcome { pub fn rejected(&self) -> bool }
+  pub fn run_hook(workdir: &Path, name: &str, args: &[&str]) -> AppResult<HookOutcome>;
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src-tauri/tests/hooks.rs`. The helpers here are reused by Task 4, so
+write them once and well.
+
+```rust
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// A temp repo with one commit, an identity, and a hooks dir.
+pub fn temp_repo() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let p = dir.path();
+    run(p, &["init", "-q", "."]);
+    run(p, &["config", "user.email", "t@example.com"]);
+    run(p, &["config", "user.name", "T"]);
+    fs::write(p.join("seed.txt"), "seed\n").unwrap();
+    run(p, &["add", "seed.txt"]);
+    run(p, &["commit", "-q", "-m", "seed"]);
+    dir
+}
+
+fn run(cwd: &Path, args: &[&str]) {
+    let out = Command::new("git").current_dir(cwd).args(args).output().unwrap();
+    assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+}
+
+/// Write an executable hook. On Unix sets the exec bit, which git requires.
+pub fn write_hook(repo: &Path, name: &str, body: &str) -> PathBuf {
+    let dir = repo.join(".git").join("hooks");
+    fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(name);
+    fs::write(&path, body).unwrap();
+    set_executable(&path);
+    path
+}
+
+pub fn set_executable(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).unwrap();
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+}
+
+#[test]
+fn a_rejecting_hook_reports_its_output_and_code() {
+    let repo = temp_repo();
+    write_hook(
+        repo.path(),
+        "pre-commit",
+        "#!/bin/sh\necho 'lint failed on a.ts'\nexit 3\n",
+    );
+    let out = platypusgit_lib::git::hooks::run_hook(repo.path(), "pre-commit", &[]).unwrap();
+    assert!(out.ran, "the hook exists and is executable, so it ran");
+    assert_eq!(out.code, 3, "exit code propagates verbatim");
+    assert!(out.rejected());
+    assert!(
+        out.output.contains("lint failed on a.ts"),
+        "hook stdout must be captured — git hook run sends it to stderr: {}",
+        out.output
+    );
+}
+
+#[test]
+fn a_passing_hook_is_not_a_rejection_but_its_output_is_still_captured() {
+    let repo = temp_repo();
+    write_hook(repo.path(), "pre-commit", "#!/bin/sh\necho 'reformatted 2 files'\nexit 0\n");
+    let out = platypusgit_lib::git::hooks::run_hook(repo.path(), "pre-commit", &[]).unwrap();
+    assert!(out.ran);
+    assert!(!out.rejected());
+    assert!(out.output.contains("reformatted 2 files"));
+}
+
+#[test]
+fn a_missing_hook_is_not_an_error() {
+    let repo = temp_repo();
+    let out = platypusgit_lib::git::hooks::run_hook(repo.path(), "commit-msg", &[]).unwrap();
+    assert!(!out.ran, "absent hook did not run");
+    assert!(!out.rejected(), "absent is not a rejection");
+}
+
+#[test]
+fn a_non_executable_hook_is_skipped_like_git_skips_it() {
+    let repo = temp_repo();
+    let path = write_hook(repo.path(), "pre-commit", "#!/bin/sh\nexit 1\n");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o644);
+        fs::set_permissions(&path, perms).unwrap();
+    }
+    let out = platypusgit_lib::git::hooks::run_hook(repo.path(), "pre-commit", &[]).unwrap();
+    assert!(!out.rejected(), "a hook git would skip must not reject the commit");
+}
+
+#[test]
+fn core_hooks_path_is_honoured() {
+    let repo = temp_repo();
+    let custom = repo.path().join("myhooks");
+    fs::create_dir_all(&custom).unwrap();
+    let path = custom.join("pre-commit");
+    fs::write(&path, "#!/bin/sh\necho 'from myhooks'\nexit 7\n").unwrap();
+    set_executable(&path);
+    // The hook in the default location must lose.
+    write_hook(repo.path(), "pre-commit", "#!/bin/sh\necho 'from .git/hooks'\nexit 0\n");
+    run(repo.path(), &["config", "core.hooksPath", "myhooks"]);
+
+    let out = platypusgit_lib::git::hooks::run_hook(repo.path(), "pre-commit", &[]).unwrap();
+    assert_eq!(out.code, 7);
+    assert!(out.output.contains("from myhooks"));
+    assert!(!out.output.contains("from .git/hooks"));
+}
+
+#[test]
+fn args_reach_the_hook_and_a_rewrite_of_arg_one_survives() {
+    let repo = temp_repo();
+    write_hook(
+        repo.path(),
+        "prepare-commit-msg",
+        "#!/bin/sh\nprintf 'source=%s\\n' \"$2\"\necho 'appended' >> \"$1\"\n",
+    );
+    let msg = repo.path().join(".git").join("COMMIT_EDITMSG");
+    fs::write(&msg, "original\n").unwrap();
+
+    let out = platypusgit_lib::git::hooks::run_hook(
+        repo.path(),
+        "prepare-commit-msg",
+        &[msg.to_str().unwrap(), "message"],
+    )
+    .unwrap();
+
+    assert!(!out.rejected());
+    assert!(out.output.contains("source=message"));
+    let after = fs::read_to_string(&msg).unwrap();
+    assert!(after.contains("appended"), "the hook's rewrite must persist: {after}");
+}
+```
+
+- [ ] **Step 2: Run and confirm they fail**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test hooks 2>&1 | tail -20
+```
+
+Expected: FAIL to compile — `hooks` module does not exist. If `tempfile` is not
+already a dev-dependency, add it (`cargo add --dev tempfile --manifest-path
+src-tauri/Cargo.toml`); check first, other integration tests likely use it.
+
+- [ ] **Step 3: Implement `hooks.rs`**
+
+```rust
+//! The one place a git hook is executed (issue 232).
+//!
+//! # Why `git hook run` and not the script directly
+//!
+//! Executing `.git/hooks/pre-commit` ourselves means re-implementing git's
+//! contract: resolve `core.hooksPath`, honour the executable bit, and — the one
+//! that silently breaks Windows — run the script through git's bundled `sh`,
+//! because a hook is a shell script and Windows has no shebang. Getting that
+//! last part wrong means hooks quietly do not run on Windows, which is the
+//! exact bug this module exists to fix.
+//!
+//! `git hook run` is git doing all of it. Verified in a scratch repo: it
+//! propagates the hook's exit code, respects `core.hooksPath`, skips a
+//! non-executable hook with git's own advice hint, and passes arguments after
+//! `--`.
+//!
+//! # The one surprise worth knowing
+//!
+//! **`git hook run` redirects the hook's stdout to stderr**, so a hook's output
+//! arrives on stderr whether it succeeded or failed. We capture stderr and
+//! ignore stdout; the reverse captures nothing at all.
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+use crate::error::{AppError, AppResult};
+
+/// What running one hook did.
+#[derive(Debug, Clone)]
+pub struct HookOutcome {
+    /// False when no hook by that name exists, or git skipped it as
+    /// non-executable. Not an error: most repos have no hooks.
+    pub ran: bool,
+    /// The hook's exit status. 0 when it did not run.
+    pub code: i32,
+    /// Everything the hook printed, stdout and stderr interleaved as git
+    /// delivers them.
+    pub output: String,
+}
+
+impl HookOutcome {
+    /// A hook that ran and refused. The only condition that must stop a commit.
+    pub fn rejected(&self) -> bool {
+        self.ran && self.code != 0
+    }
+}
+
+/// A hook name that cannot exist, used to ask git whether it has the
+/// `hook` subcommand at all. Side-effect-free by construction: with
+/// `--ignore-missing` there is nothing to run, so a supporting git exits 0
+/// silently and an older one exits non-zero with
+/// `git: 'hook' is not a git command`.
+const PROBE_HOOK: &str = "pg-capability-probe";
+
+/// Does this git have `git hook run`? Probed once, cached.
+///
+/// Deliberately not `git --version` parsing: comparing version strings is a bug
+/// waiting to happen, and the capability is directly askable. `git hook run`
+/// arrived in git 2.36; Ubuntu 22.04 LTS is supported into 2027 and ships 2.34,
+/// so the fallback is not hypothetical.
+fn has_hook_subcommand(workdir: &Path) -> bool {
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(|| {
+        crate::proc::git(workdir)
+            .args(["hook", "run", "--ignore-missing", PROBE_HOOK])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    })
+}
+
+/// Run hook `name` with `args`, if it exists.
+///
+/// Never returns `Err` for a hook that merely refused — that is
+/// `HookOutcome::rejected`, which the caller turns into
+/// `AppError::HookRejected` with the hook's own output. `Err` here means we
+/// could not run git at all.
+pub fn run_hook(workdir: &Path, name: &str, args: &[&str]) -> AppResult<HookOutcome> {
+    if has_hook_subcommand(workdir) {
+        run_via_git_hook(workdir, name, args)
+    } else {
+        fallback::run_direct(workdir, name, args)
+    }
+}
+
+fn run_via_git_hook(workdir: &Path, name: &str, args: &[&str]) -> AppResult<HookOutcome> {
+    let mut cmd = crate::proc::git(workdir);
+    cmd.args(["hook", "run", "--ignore-missing", name]);
+    if !args.is_empty() {
+        cmd.arg("--");
+        cmd.args(args);
+    }
+    let out = cmd.output().map_err(|e| AppError::Io(e.to_string()))?;
+
+    // Hook output arrives on stderr — including its stdout. See the module note.
+    let output = String::from_utf8_lossy(&out.stderr).trim().to_string();
+    let code = out.status.code().unwrap_or(-1);
+
+    // `--ignore-missing` exits 0 with nothing printed when the hook is absent.
+    // A hook that ran and passed also exits 0, and may or may not print. Both
+    // are `rejected() == false`, so distinguishing them only affects `ran`,
+    // which is reported for logging rather than branched on.
+    Ok(HookOutcome {
+        ran: code != 0 || !output.is_empty(),
+        code,
+        output,
+    })
+}
+
+/// Direct execution, for a git without `git hook run`.
+///
+/// Unix only in practice: Windows always has a current Git for Windows, so this
+/// path never needs git's `sh` shim. A shebang'd executable script runs itself.
+mod fallback {
+    use super::*;
+
+    pub fn run_direct(workdir: &Path, name: &str, args: &[&str]) -> AppResult<HookOutcome> {
+        let Some(path) = resolve(workdir, name) else {
+            return Ok(HookOutcome { ran: false, code: 0, output: String::new() });
+        };
+        if !is_executable(&path) {
+            // Exactly what git does, and why the guard matters: a hook checked
+            // out without its exec bit must not silently block every commit.
+            return Ok(HookOutcome { ran: false, code: 0, output: String::new() });
+        }
+
+        let mut cmd = crate::proc::program(&path);
+        cmd.current_dir(workdir).args(args);
+        let out = cmd.output().map_err(|e| AppError::Io(e.to_string()))?;
+
+        // Direct execution keeps the streams separate, so join them in the
+        // order a terminal would show them.
+        let mut output = String::from_utf8_lossy(&out.stdout).to_string();
+        output.push_str(&String::from_utf8_lossy(&out.stderr));
+
+        Ok(HookOutcome {
+            ran: true,
+            code: out.status.code().unwrap_or(-1),
+            output: output.trim().to_string(),
+        })
+    }
+
+    /// `core.hooksPath` if set (relative resolves against the worktree), else
+    /// `.git/hooks`.
+    fn resolve(workdir: &Path, name: &str) -> Option<std::path::PathBuf> {
+        let configured = crate::proc::git(workdir)
+            .args(["config", "--get", "core.hooksPath"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .filter(|s| !s.is_empty());
+
+        let dir = match configured {
+            Some(c) => {
+                let p = std::path::PathBuf::from(&c);
+                if p.is_absolute() { p } else { workdir.join(p) }
+            }
+            None => workdir.join(".git").join("hooks"),
+        };
+        let path = dir.join(name);
+        path.is_file().then_some(path)
+    }
+
+    fn is_executable(path: &Path) -> bool {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::metadata(path)
+                .map(|m| m.permissions().mode() & 0o111 != 0)
+                .unwrap_or(false)
+        }
+        #[cfg(not(unix))]
+        {
+            path.is_file()
+        }
+    }
+}
+```
+
+Add `pub mod hooks;` to `src-tauri/src/git/mod.rs` beside the other submodules.
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --test hooks 2>&1 | tail -30
+```
+
+Expected: all PASS. If `platypusgit_lib::` is the wrong crate path, check what
+another file in `src-tauri/tests/` uses and match it.
+
+- [ ] **Step 5: Force the fallback path under test**
+
+The fallback ships untested on every machine whose git is modern. Add a test that
+calls it directly:
+
+```rust
+#[test]
+fn the_direct_exec_fallback_matches_git_hook_run_semantics() {
+    // Called directly, because `has_hook_subcommand` short-circuits to
+    // `git hook run` on any modern git — which is every CI machine.
+    let repo = temp_repo();
+    write_hook(repo.path(), "pre-commit", "#!/bin/sh\necho 'fallback ran'\nexit 4\n");
+    let out = platypusgit_lib::git::hooks::run_direct_for_test(repo.path(), "pre-commit", &[]).unwrap();
+    assert_eq!(out.code, 4);
+    assert!(out.output.contains("fallback ran"));
+}
+```
+
+Expose it in `hooks.rs`:
+
+```rust
+/// Test-only door onto the fallback, which `run_hook` reaches only on a git too
+/// old to be on any CI machine.
+#[doc(hidden)]
+pub fn run_direct_for_test(workdir: &Path, name: &str, args: &[&str]) -> AppResult<HookOutcome> {
+    fallback::run_direct(workdir, name, args)
+}
+```
+
+- [ ] **Step 6: Run, then commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --test hooks 2>&1 | tail -30
+git add src-tauri/src/git/hooks.rs src-tauri/src/git/mod.rs src-tauri/tests/hooks.rs
+git commit -m "feat(git): run git hooks through git hook run, with a fallback"
+```
+
+---
+
+## Task 3: `AppError::HookRejected` on both sides of the IPC boundary
+
+**Files:**
+- Modify: `src-tauri/src/error.rs`
+- Modify: `src/lib/errors.ts`
+- Test: `src/lib/errors.test.ts` (extend; create if absent)
+
+**Interfaces:**
+- Produces (Rust): `AppError::HookRejected(HookRejection)` where
+  `pub struct HookRejection { pub hook: String, pub output: String }`, `Serialize`,
+  `#[serde(rename_all = "camelCase")]`.
+- Produces (TS): `{ kind: "HookRejected"; message: HookRejection }` and
+  `export interface HookRejection { hook: string; output: string }`.
+
+- [ ] **Step 1: Add the Rust variant**
+
+In `src-tauri/src/error.rs`, beside the other struct-carrying variant (`Auth`):
+
+```rust
+/// A git hook ran and refused (issue 232). Carries the hook's NAME and its
+/// OUTPUT as separate fields, not a formatted sentence: the output is the whole
+/// point of the feature and needs to render as output — monospace, scrollable,
+/// forty lines of eslint — not as a one-line banner.
+///
+/// Distinct from `Io`, which is a hook we could not launch: that is a broken
+/// environment, not a policy decision by the repository.
+#[error("the {} hook rejected this commit", .0.hook)]
+HookRejected(HookRejection),
+```
+
+And the payload struct, next to the enum:
+
+```rust
+/// A hook's refusal. `output` is whatever the hook printed, verbatim.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HookRejection {
+    pub hook: String,
+    pub output: String,
+}
+```
+
+- [ ] **Step 2: Write the failing TS test**
+
+In `src/lib/errors.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { appErrorMessage, type AppError } from "./errors";
+
+describe("HookRejected", () => {
+  it("names the hook rather than rendering the struct", () => {
+    const e: AppError = {
+      kind: "HookRejected",
+      message: { hook: "pre-commit", output: "eslint: 2 problems" },
+    };
+    const text = appErrorMessage(e);
+    expect(text).toContain("pre-commit");
+    // The struct must never reach a banner as an object.
+    expect(text).not.toContain("[object Object]");
+  });
+
+  it("keeps the output out of the one-line message", () => {
+    // The output belongs in the dedicated block, not the banner: a 40-line
+    // eslint dump inside a toast is the bug this feature is fixing.
+    const e: AppError = {
+      kind: "HookRejected",
+      message: { hook: "commit-msg", output: "line1\nline2\nline3" },
+    };
+    expect(appErrorMessage(e)).not.toContain("line2");
+  });
+});
+```
+
+- [ ] **Step 3: Run it and confirm it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- src/lib/errors.test.ts 2>&1 | tail -20
+```
+
+Expected: FAIL — either a type error on the unknown `kind`, or
+`[object Object]` in the output.
+
+- [ ] **Step 4: Add the TS union member and the prose case**
+
+In `src/lib/errors.ts`, in the union:
+
+```ts
+  /**
+   * A git hook ran and refused (#232). The payload is a STRUCT: the output is
+   * rendered by the dedicated block in the commit panel, never pasted into a
+   * banner, so `appErrorDetail` deliberately drops it here.
+   */
+  | { kind: "HookRejected"; message: HookRejection }
+```
+
+and the interface beside `AuthChallenge`:
+
+```ts
+/** A hook's refusal (#232). `output` is whatever the hook printed, verbatim. */
+export interface HookRejection {
+  hook: string;
+  output: string;
+}
+```
+
+and in `appErrorDetail`, beside the `Auth` case (which is the precedent for a
+struct payload):
+
+```ts
+  // HookRejected's payload is a struct, and its `output` is deliberately NOT
+  // included: it goes to the output block, which can scroll. A banner gets the
+  // sentence that tells the user which hook to look at.
+  if (
+    e.kind === "HookRejected" &&
+    typeof message === "object" &&
+    message !== null &&
+    typeof (message as HookRejection).hook === "string"
+  ) {
+    return `The ${(message as HookRejection).hook} hook rejected this commit.`;
+  }
+```
+
+- [ ] **Step 5: Run the tests and type-check**
+
+```bash
+pnpm test -- src/lib/errors.test.ts 2>&1 | tail -20
+pnpm tsc --noEmit
+cargo check --manifest-path src-tauri/Cargo.toml 2>&1 | tail -20
+```
+
+Expected: PASS, clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/error.rs src/lib/errors.ts src/lib/errors.test.ts
+git commit -m "feat(error): add HookRejected, carrying the hook name and its output"
+```
+
+---
+
+## Task 4: The commit sequence in `libgit2.rs`
+
+The load-bearing task. Everything here is pinned by tests, because the failure
+mode — a half-applied commit — is unrecoverable from the user's side.
+
+**Files:**
+- Modify: `src-tauri/src/git/types.rs`, `src-tauri/src/git/mod.rs`,
+  `src-tauri/src/git/libgit2.rs`, `src-tauri/src/git/cli.rs`
+- Test: `src-tauri/tests/hooks.rs` (extend)
+
+**Interfaces:**
+- Consumes: `git::hooks::run_hook` / `HookOutcome` (Task 2),
+  `AppError::HookRejected` / `HookRejection` (Task 3).
+- Produces: `CommitOptions.no_verify: bool`;
+  `pub struct CommitResult { pub oid: String, pub message: String }`;
+  `GitBackend::commit(&self, &RepoId, CommitOptions) -> AppResult<CommitResult>`.
+
+- [ ] **Step 1: Add the types**
+
+`src-tauri/src/git/types.rs` — on `CommitOptions`:
+
+```rust
+    /// Skip every commit-side hook for this one commit (#232), matching
+    /// `git commit --no-verify`. `#[serde(default)]` so an existing caller that
+    /// omits it keeps hooks on, which is the safe default.
+    ///
+    /// Deliberately not a persisted setting: "skip once" that becomes "never
+    /// run hooks again" is the bug this feature exists to fix.
+    #[serde(default)]
+    pub no_verify: bool,
+```
+
+and the result type:
+
+```rust
+/// What a commit produced (#232).
+///
+/// The message is returned because `commit-msg` may REWRITE it, so what landed
+/// is not necessarily what the user typed — and a panel that keeps showing the
+/// typed version is lying about the repository.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitResult {
+    pub oid: String,
+    pub message: String,
+}
+```
+
+- [ ] **Step 2: Write the failing contract tests**
+
+Append to `src-tauri/tests/hooks.rs`. These call the backend, so build one the
+way the other integration tests in `src-tauri/tests/` do — read a neighbouring
+test file for the exact constructor and `RepoId` registration, then reuse it.
+
+```rust
+/// The four that must create nothing, and the two that must not interfere.
+#[test]
+fn a_rejecting_pre_commit_creates_nothing() {
+    let repo = temp_repo();
+    write_hook(repo.path(), "pre-commit", "#!/bin/sh\necho 'NOPE'\nexit 1\n");
+    fs::write(repo.path().join("a.txt"), "a\n").unwrap();
+    run(repo.path(), &["add", "a.txt"]);
+
+    let before = head_oid(repo.path());
+    let err = commit_via_backend(repo.path(), "subject", Default::default()).unwrap_err();
+
+    match err {
+        AppError::HookRejected(r) => {
+            assert_eq!(r.hook, "pre-commit");
+            assert!(r.output.contains("NOPE"), "the hook's own words reach the user");
+        }
+        other => panic!("expected HookRejected, got {other:?}"),
+    }
+    assert_eq!(head_oid(repo.path()), before, "HEAD must not move");
+    assert_eq!(count_commits(repo.path()), 1, "no object was created");
+}
+
+#[test]
+fn a_rejecting_commit_msg_creates_nothing() {
+    let repo = temp_repo();
+    write_hook(repo.path(), "commit-msg", "#!/bin/sh\necho 'bad subject'\nexit 1\n");
+    fs::write(repo.path().join("a.txt"), "a\n").unwrap();
+    run(repo.path(), &["add", "a.txt"]);
+    let before = head_oid(repo.path());
+
+    let err = commit_via_backend(repo.path(), "nope", Default::default()).unwrap_err();
+    assert!(matches!(err, AppError::HookRejected(ref r) if r.hook == "commit-msg"));
+    assert_eq!(head_oid(repo.path()), before);
+}
+
+#[test]
+fn a_pre_commit_that_restages_is_honoured() {
+    // THE ordering test. `lint-staged`'s shape: reformat a file, `git add` it,
+    // exit 0 — and the commit must contain the reformatted content. It only
+    // works if the index is read AFTER pre-commit; if someone moves the read
+    // back to the top of `commit()`, this fails.
+    let repo = temp_repo();
+    write_hook(
+        repo.path(),
+        "pre-commit",
+        "#!/bin/sh\necho 'fixed' > a.txt\ngit add a.txt\nexit 0\n",
+    );
+    fs::write(repo.path().join("a.txt"), "unfixed\n").unwrap();
+    run(repo.path(), &["add", "a.txt"]);
+
+    let res = commit_via_backend(repo.path(), "subject", Default::default()).unwrap();
+    let blob = show_file_at(repo.path(), &res.oid, "a.txt");
+    assert_eq!(blob.trim(), "fixed", "the hook's restaged content must be what landed");
+}
+
+#[test]
+fn a_rewriting_commit_msg_decides_the_final_message() {
+    let repo = temp_repo();
+    write_hook(
+        repo.path(),
+        "commit-msg",
+        "#!/bin/sh\nprintf 'REWRITTEN\\n' > \"$1\"\n",
+    );
+    fs::write(repo.path().join("a.txt"), "a\n").unwrap();
+    run(repo.path(), &["add", "a.txt"]);
+
+    let res = commit_via_backend(repo.path(), "typed by the user", Default::default()).unwrap();
+    assert_eq!(res.message.trim(), "REWRITTEN", "the returned message is what landed");
+    assert_eq!(
+        message_of(repo.path(), &res.oid).trim(),
+        "REWRITTEN",
+        "and the object agrees"
+    );
+}
+
+#[test]
+fn no_verify_skips_a_rejecting_hook_and_a_rewriting_one() {
+    let repo = temp_repo();
+    write_hook(repo.path(), "pre-commit", "#!/bin/sh\nexit 1\n");
+    write_hook(repo.path(), "commit-msg", "#!/bin/sh\nprintf 'REWRITTEN\\n' > \"$1\"\n");
+    fs::write(repo.path().join("a.txt"), "a\n").unwrap();
+    run(repo.path(), &["add", "a.txt"]);
+
+    let opts = CommitOptions { no_verify: true, ..Default::default() };
+    let res = commit_via_backend(repo.path(), "verbatim subject", opts).unwrap();
+    assert_eq!(res.message.trim(), "verbatim subject", "no hook touched the message");
+}
+
+#[test]
+fn a_failing_post_commit_does_not_fail_the_commit() {
+    // git ignores post-commit's exit code, and so must we: reporting a commit
+    // that EXISTS as failed sends the user looking for work that already landed.
+    let repo = temp_repo();
+    write_hook(repo.path(), "post-commit", "#!/bin/sh\nexit 9\n");
+    fs::write(repo.path().join("a.txt"), "a\n").unwrap();
+    run(repo.path(), &["add", "a.txt"]);
+
+    let res = commit_via_backend(repo.path(), "subject", Default::default()).unwrap();
+    assert_eq!(count_commits(repo.path()), 2);
+    assert!(!res.oid.is_empty());
+}
+
+#[test]
+fn a_repo_with_no_hooks_commits_exactly_as_before() {
+    let repo = temp_repo();
+    fs::write(repo.path().join("a.txt"), "a\n").unwrap();
+    run(repo.path(), &["add", "a.txt"]);
+    let res = commit_via_backend(repo.path(), "plain subject", Default::default()).unwrap();
+    assert_eq!(res.message.trim(), "plain subject");
+    assert_eq!(count_commits(repo.path()), 2);
+}
+```
+
+Helpers to add alongside (all plumbing, no cleverness):
+
+```rust
+fn head_oid(cwd: &Path) -> String { capture(cwd, &["rev-parse", "HEAD"]) }
+fn count_commits(cwd: &Path) -> usize {
+    capture(cwd, &["rev-list", "--count", "HEAD"]).parse().unwrap()
+}
+fn message_of(cwd: &Path, oid: &str) -> String {
+    capture(cwd, &["log", "-1", "--format=%B", oid])
+}
+fn show_file_at(cwd: &Path, oid: &str, path: &str) -> String {
+    capture(cwd, &["show", &format!("{oid}:{path}")])
+}
+fn capture(cwd: &Path, args: &[&str]) -> String {
+    let out = Command::new("git").current_dir(cwd).args(args).output().unwrap();
+    assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+```
+
+`CommitOptions` needs `#[derive(Default)]` for `..Default::default()` — add it
+in Task 4 Step 1 if it is not already there.
+
+- [ ] **Step 3: Run and confirm they fail**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --test hooks 2>&1 | tail -30
+```
+
+Expected: FAIL — `commit` returns `String`, not `CommitResult`; `no_verify`
+unknown; no hooks run.
+
+- [ ] **Step 4: Rewrite `commit()`**
+
+Replace the body of `Libgit2Backend::commit` (`src-tauri/src/git/libgit2.rs`,
+around line 3752). Ordering is the whole point — read the comments before
+changing anything.
+
+```rust
+    fn commit(&self, repo_id: &RepoId, opts: CommitOptions) -> AppResult<CommitResult> {
+        use crate::git::hooks;
+        use crate::git::signature::{apply_signoff, default_signature};
+
+        let repo_path = self.repo_path(repo_id)?;
+
+        // pre-commit runs BEFORE the index is read, and outside `with_repo`.
+        // Both matter: a hook that runs `git add` (the lint-staged shape:
+        // reformat, restage) mutates the on-disk index, and only a read that
+        // happens afterwards sees it. `with_repo` also holds the per-repo mutex,
+        // and a hook shelling out to git must not deadlock against it.
+        if !opts.no_verify {
+            let out = hooks::run_hook(&repo_path, "pre-commit", &[])?;
+            if out.rejected() {
+                return Err(AppError::HookRejected(crate::error::HookRejection {
+                    hook: "pre-commit".into(),
+                    output: out.output,
+                }));
+            }
+        }
+
+        // Sign-off goes on before any hook sees the message, matching
+        // `git commit -s`: verified that git has already appended the trailer by
+        // the time commit-msg reads the file, so a hook validating trailers
+        // must see it here too.
+        //
+        // This takes the per-repo lock a second time, which the stash TOCTOU
+        // rule would normally forbid. It is allowed here because it is a READ of
+        // the config identity, not a verify-then-mutate: the worst a race can do
+        // is trail a `Signed-off-by` for the identity the user had a millisecond
+        // ago. Merging it into the commit's own `with_repo` is impossible —
+        // sign-off must be applied before the hooks run, and the hooks must run
+        // outside the lock.
+        let message_in = if opts.signoff {
+            let committer = self.with_repo(repo_id, |repo| {
+                let c = default_signature(repo)?;
+                Ok((
+                    c.name().unwrap_or("").to_string(),
+                    c.email().unwrap_or("").to_string(),
+                ))
+            })?;
+            apply_signoff(&opts.message, &committer.0, &committer.1)
+        } else {
+            opts.message.clone()
+        };
+
+        // The message file is $GIT_DIR/COMMIT_EDITMSG, where git puts it — so a
+        // hook that ignores $1 and hardcodes the path still works.
+        let message = if opts.no_verify {
+            message_in
+        } else {
+            let msg_path = self.git_dir(repo_id)?.join("COMMIT_EDITMSG");
+            std::fs::write(&msg_path, &message_in).map_err(|e| AppError::Io(e.to_string()))?;
+            let msg_arg = msg_path
+                .to_str()
+                .ok_or_else(|| AppError::InvalidPath(msg_path.display().to_string()))?;
+
+            // Our source is always `message`, with no third argument — amend
+            // included. Verified: the source is `commit` (with the object as $3)
+            // only when the message is taken FROM a commit, as with -c/-C or a
+            // bare --amend. We always supply it as text, so git's equivalent is
+            // `commit --amend -m <msg>`, which reports `message` and passes two.
+            for (hook, args) in [
+                ("prepare-commit-msg", vec![msg_arg, "message"]),
+                ("commit-msg", vec![msg_arg]),
+            ] {
+                let out = hooks::run_hook(&repo_path, hook, &args)?;
+                if out.rejected() {
+                    return Err(AppError::HookRejected(crate::error::HookRejection {
+                        hook: hook.into(),
+                        output: out.output,
+                    }));
+                }
+            }
+
+            // Re-read: either hook may have rewritten the file, and what it left
+            // there is what git would commit.
+            std::fs::read_to_string(&msg_path).map_err(|e| AppError::Io(e.to_string()))?
+        };
+
+        let oid = self.with_repo(repo_id, |repo| {
+            let sig = match &opts.author_override {
+                Some(o) => git2::Signature::now(&o.name, &o.email)?,
+                None => default_signature(repo)?,
+            };
+
+            // Read the index HERE, after pre-commit — see the note above.
+            let mut index = repo.index()?;
+            let tree_oid = index.write_tree()?;
+            let tree = repo.find_tree(tree_oid)?;
+
+            let head = match repo.head() {
+                Ok(h) => Some(h),
+                Err(e) if e.code() == git2::ErrorCode::UnbornBranch => None,
+                Err(e) => return Err(e.into()),
+            };
+
+            // `None` follows commit.gpgsign; `Some` overrides it (#61 D6).
+            let wants_sign = opts
+                .sign
+                .unwrap_or_else(|| crate::git::signing::config_wants_signing(repo));
+
+            if wants_sign {
+                return commit_signed(repo, &sig, &message, &tree, head.as_ref(), opts.amend);
+            }
+
+            if opts.amend {
+                let head_ref = head.ok_or(AppError::Unborn)?;
+                let tip = head_ref.peel_to_commit()?;
+                let new_oid = tip.amend(
+                    Some("HEAD"),
+                    Some(&sig),
+                    Some(&sig),
+                    None,
+                    Some(&message),
+                    Some(&tree),
+                )?;
+                return Ok(new_oid.to_string());
+            }
+
+            let parents: Vec<git2::Commit> = match head {
+                Some(h) => vec![h.peel_to_commit()?],
+                None => Vec::new(),
+            };
+            let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
+
+            let oid = repo.commit(Some("HEAD"), &sig, &sig, &message, &tree, &parent_refs)?;
+            Ok(oid.to_string())
+        })?;
+
+        // post-commit runs after the ref moved, and its exit code is DISCARDED
+        // because git discards it. A failing post-commit must never report a
+        // commit that exists as failed.
+        if !opts.no_verify {
+            let _ = hooks::run_hook(&repo_path, "post-commit", &[]);
+        }
+
+        Ok(CommitResult { oid, message })
+    }
+```
+
+If `Libgit2Backend` has no `git_dir` helper, add one beside `repo_path`:
+
+```rust
+/// `$GIT_DIR` for this repo — not `workdir/.git`, which is wrong for a
+/// worktree, where `.git` is a file pointing elsewhere.
+fn git_dir(&self, repo_id: &RepoId) -> AppResult<std::path::PathBuf> {
+    self.with_repo(repo_id, |repo| Ok(repo.path().to_path_buf()))
+}
+```
+
+- [ ] **Step 5: Update the trait and the CLI stub**
+
+`src-tauri/src/git/mod.rs`:
+
+```rust
+    fn commit(&self, repo_id: &RepoId, opts: CommitOptions) -> AppResult<CommitResult>;
+```
+
+`src-tauri/src/git/cli.rs` — keep the stub in shape:
+
+```rust
+    fn commit(&self, _repo_id: &RepoId, _opts: CommitOptions) -> AppResult<CommitResult> {
+        Err(AppError::NotImplemented)
+    }
+```
+
+- [ ] **Step 6: Run the tests**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --test hooks 2>&1 | tail -40
+cargo test --manifest-path src-tauri/Cargo.toml 2>&1 | tail -20
+```
+
+Expected: the new tests PASS and the existing suite stays green. Existing callers
+of `commit` will not compile until Task 5 — if the whole-suite run fails only on
+those, proceed and re-run at the end of Task 5.
+
+- [ ] **Step 7: Add the signing interaction test**
+
+```rust
+#[test]
+fn a_rejecting_pre_commit_with_signing_on_signs_nothing() {
+    // Both guarantees at once: the hook creates nothing, and the signing chain
+    // is never reached, so there is no signed-but-unreferenced object either.
+    let repo = temp_repo();
+    run(repo.path(), &["config", "commit.gpgsign", "true"]);
+    write_hook(repo.path(), "pre-commit", "#!/bin/sh\nexit 1\n");
+    fs::write(repo.path().join("a.txt"), "a\n").unwrap();
+    run(repo.path(), &["add", "a.txt"]);
+
+    let before = head_oid(repo.path());
+    let err = commit_via_backend(repo.path(), "subject", Default::default()).unwrap_err();
+    assert!(matches!(err, AppError::HookRejected(_)));
+    assert_eq!(head_oid(repo.path()), before);
+    assert_eq!(count_commits(repo.path()), 1);
+}
+```
+
+- [ ] **Step 8: Run and commit**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --test hooks 2>&1 | tail -40
+git add src-tauri/src/git/ src-tauri/tests/hooks.rs
+git commit -m "feat(commit): run the commit-side hooks around the libgit2 commit"
+```
+
+---
+
+## Task 5: Commands — `no_verify` on commit and push
+
+**Files:**
+- Modify: `src-tauri/src/commands/commits.rs`, `src-tauri/src/commands/branches.rs`
+
+**Interfaces:**
+- Consumes: `CommitResult`, `CommitOptions.no_verify` (Task 4).
+- Produces: `commit(..., no_verify: Option<bool>) -> AppResult<CommitResult>`;
+  `push(..., no_verify: Option<bool>)`;
+  `push_args(remote, branch, force, set_upstream, no_verify)`.
+
+- [ ] **Step 1: Write the failing `push_args` tests**
+
+In `src-tauri/src/commands/branches.rs`, in `mod push_args_tests`:
+
+```rust
+    #[test]
+    fn no_verify_is_added_only_when_asked() {
+        assert_eq!(
+            push_args("origin", "main", PushForce::None, false, false),
+            vec!["push", "origin", "main"]
+        );
+        assert_eq!(
+            push_args("origin", "main", PushForce::None, false, true),
+            vec!["push", "origin", "main", "--no-verify"]
+        );
+    }
+
+    #[test]
+    fn no_verify_composes_with_upstream_and_force() {
+        assert_eq!(
+            push_args("origin", "feat/x", PushForce::WithLease, true, true),
+            vec!["push", "-u", "origin", "feat/x", "--force-with-lease", "--no-verify"]
+        );
+    }
+```
+
+The existing tests call `push_args` with four arguments and will not compile —
+add `false` as the fifth to each. That is the point of a required parameter over
+an `Option`: the compiler finds every call site.
+
+- [ ] **Step 2: Run and confirm failure**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml push_args 2>&1 | tail -20
+```
+
+Expected: FAIL — arity mismatch.
+
+- [ ] **Step 3: Implement**
+
+`push_args`:
+
+```rust
+fn push_args(
+    remote: &str,
+    branch: &str,
+    force: PushForce,
+    set_upstream: bool,
+    no_verify: bool,
+) -> Vec<String> {
+    let mut args: Vec<String> = vec!["push".to_string()];
+    if set_upstream {
+        args.push("-u".to_string());
+    }
+    args.push(remote.to_string());
+    args.push(branch.to_string());
+    match force {
+        PushForce::None => {}
+        PushForce::WithLease => args.push("--force-with-lease".to_string()),
+        PushForce::Force => args.push("--force".to_string()),
+    }
+    // Skips pre-push (#232). Last, so the option list reads the way a user
+    // would type it.
+    if no_verify {
+        args.push("--no-verify".to_string());
+    }
+    args
+}
+```
+
+`push` gains `no_verify: Option<bool>` and passes
+`no_verify.unwrap_or(false)`. `commit` gains the same and returns
+`CommitResult`:
+
+```rust
+pub async fn commit(
+    state: State<'_, AppState>,
+    repo_id: String,
+    message: String,
+    amend: bool,
+    signoff: Option<bool>,
+    author_override: Option<AuthorOverride>,
+    sign: Option<bool>,
+    // Skip every commit-side hook for this commit only (#232). Optional so an
+    // existing caller that omits it keeps hooks ON — the safe default.
+    no_verify: Option<bool>,
+) -> AppResult<CommitResult> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    let opts = CommitOptions {
+        message,
+        amend,
+        author_override,
+        signoff: signoff.unwrap_or(false),
+        sign,
+        no_verify: no_verify.unwrap_or(false),
+    };
+    tokio::task::spawn_blocking(move || backend.commit(&repo_id, opts))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+```
+
+- [ ] **Step 4: Fix every other `commit` call site**
+
+```bash
+cargo check --manifest-path src-tauri/Cargo.toml 2>&1 | grep -E "^error" -A 5 | head -40
+```
+
+Work through what it names — `.oid` where a `String` was expected.
+
+- [ ] **Step 5: Run the whole Rust suite**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml 2>&1 | tail -25
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/commands/
+git commit -m "feat(commands): thread no-verify through commit and push"
+```
+
+---
+
+## Task 6: TS types, invoke wrappers, store
+
+**Files:**
+- Modify: `src/lib/types.ts`, `src/lib/tauri.ts`,
+  `src/features/repo/useRepoStore.ts`
+
+**Interfaces:**
+- Consumes: the Rust command signatures from Task 5, `HookRejection` (Task 3).
+- Produces: `CommitResult` in `types.ts`; wrappers
+  `commit(repoId, message, amend, signoff, authorOverride, sign, noVerify) =>
+  Promise<CommitResult>` and `push(repoId, remote, branch, force, credentials,
+  noVerify)`; store `commit(message, amend, signoff, authorOverride, sign,
+  noVerify) => Promise<CommitResult | null>`, `push(remote, branch, force,
+  noVerify)`, and per-repo state `hookRejection: HookRejection | null` with
+  `clearHookRejection()`.
+
+- [ ] **Step 1: Add `CommitResult` to `src/lib/types.ts`**
+
+```ts
+/**
+ * What a commit produced (#232). The message is returned because `commit-msg`
+ * may REWRITE it — what landed is not necessarily what was typed.
+ */
+export interface CommitResult {
+  oid: string;
+  message: string;
+}
+```
+
+- [ ] **Step 2: Update the invoke wrappers in `src/lib/tauri.ts`**
+
+Follow the file's existing style exactly; `noVerify` is last and optional so no
+existing call site changes.
+
+```ts
+export const commit = (
+  repoId: string,
+  message: string,
+  amend: boolean,
+  signoff?: boolean,
+  authorOverride?: AuthorOverride | null,
+  sign?: boolean | null,
+  noVerify?: boolean,
+) =>
+  invoke<CommitResult>("commit", {
+    repoId,
+    message,
+    amend,
+    signoff,
+    authorOverride,
+    sign,
+    noVerify,
+  });
+```
+
+- [ ] **Step 3: Add the per-repo field**
+
+In `useRepoStore.ts`, add to **both** `RepoSlice` and `emptySlice` — a per-repo
+field in only one of them leaks across tab switches (CLAUDE.md):
+
+```ts
+  /**
+   * The hook refusal to display, or null (#232). Per-repo, so switching tabs
+   * does not carry one repository's rejected commit into another's panel.
+   */
+  hookRejection: HookRejection | null;
+```
+
+`emptySlice`: `hookRejection: null,`.
+
+- [ ] **Step 4: Route the rejection into state rather than the error banner**
+
+```ts
+  async commit(
+    message,
+    amend = false,
+    signoff = false,
+    authorOverride = null,
+    sign = null,
+    noVerify = false,
+  ) {
+    const repo = get().current;
+    if (!repo) return null;
+    // Clear the previous refusal first: a stale block above a fresh attempt
+    // reads as though the new attempt failed too.
+    patchRepo(repo.id, { hookRejection: null });
+    try {
+      const result = await commitFn(
+        repo.id, message, amend, signoff, authorOverride, sign, noVerify,
+      );
+      await get().refreshAll();
+      return result;
+    } catch (e) {
+      // A hook refusal is not a banner error: its output needs a surface that
+      // scrolls, and the user is about to act on it in the panel. Everything
+      // else keeps the existing path.
+      if (isAppError(e) && e.kind === "HookRejected") {
+        patchRepo(repo.id, { hookRejection: e.message as HookRejection });
+        // refreshAll anyway: a pre-commit hook may have restaged files before
+        // refusing, so the file lists on screen can already be stale.
+        await get().refreshAll();
+        return null;
+      }
+      setErrorFor(repo.id, e);
+      return null;
+    }
+  },
+
+  clearHookRejection() {
+    const repo = get().current;
+    if (!repo) return;
+    patchRepo(repo.id, { hookRejection: null });
+  },
+```
+
+Use whatever the file's existing per-repo patch helper is called — read how
+`setErrorFor` writes to a specific repo's slice and mirror it exactly rather than
+introducing a second mechanism.
+
+- [ ] **Step 5: Type-check**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: clean. Fix the `commit` return-type change at its call sites — the
+compiler names them.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/types.ts src/lib/tauri.ts src/features/repo/useRepoStore.ts
+git commit -m "feat(store): carry the hook rejection as per-repo state"
+```
+
+---
+
+## Task 7: The hook-output block
+
+**Files:**
+- Create: `src/design/hook-output.tsx`
+- Modify: `src/design/index.ts`
+- Test: `src/design/hook-output.test.tsx`
+
+**Interfaces:**
+- Consumes: `HookRejection` (Task 3).
+- Produces: `HookOutput` with props
+  `{ rejection: HookRejection; onDismiss: () => void; onCommitAnyway: () => void }`,
+  exported from `@/design`.
+
+- [ ] **Step 1: Write the failing component test**
+
+```tsx
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HookOutput } from "./hook-output";
+
+const rejection = {
+  hook: "pre-commit",
+  output: "eslint: src/a.ts:12  no-unused-vars\neslint: src/b.ts:40  eqeqeq\n2 problems",
+};
+
+describe("HookOutput", () => {
+  it("names the hook and shows every line of its output", () => {
+    render(<HookOutput rejection={rejection} onDismiss={() => {}} onCommitAnyway={() => {}} />);
+    expect(screen.getByText(/pre-commit/)).toBeTruthy();
+    // Every line matters: a hook's output is the diagnostic, not a preview.
+    expect(screen.getByTestId("hook-output-body").textContent).toContain("no-unused-vars");
+    expect(screen.getByTestId("hook-output-body").textContent).toContain("2 problems");
+  });
+
+  it("calls onDismiss when dismissed", async () => {
+    const onDismiss = vi.fn();
+    render(<HookOutput rejection={rejection} onDismiss={onDismiss} onCommitAnyway={() => {}} />);
+    await userEvent.click(screen.getByTestId("hook-output-dismiss"));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("offers committing without hooks", async () => {
+    const onCommitAnyway = vi.fn();
+    render(<HookOutput rejection={rejection} onDismiss={() => {}} onCommitAnyway={onCommitAnyway} />);
+    await userEvent.click(screen.getByTestId("hook-output-skip"));
+    expect(onCommitAnyway).toHaveBeenCalledOnce();
+  });
+
+  it("renders an empty output without crashing", () => {
+    // A hook can refuse silently — exit 1, print nothing. The block must still
+    // say which hook, because that is the only clue the user gets.
+    render(
+      <HookOutput
+        rejection={{ hook: "commit-msg", output: "" }}
+        onDismiss={() => {}}
+        onCommitAnyway={() => {}}
+      />,
+    );
+    expect(screen.getByText(/commit-msg/)).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+```bash
+pnpm test -- src/design/hook-output.test.tsx 2>&1 | tail -20
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+Read a neighbouring `src/design/` component first and match its conventions —
+theme tokens (never a hardcoded accent), `PGButton`, icon usage. Then:
+
+```tsx
+/**
+ * A git hook's refusal, rendered as output (#232).
+ *
+ * Inline and persistent rather than a modal or a toast: the user is about to
+ * edit the message or the files the hook objected to, so the complaint has to
+ * stay readable *while* they do it. A modal blocks the panel it is asking them
+ * to fix, and the existing flash auto-dismisses — losing a forty-line eslint
+ * dump before a slow reader clicks anything.
+ */
+export function HookOutput({
+  rejection,
+  onDismiss,
+  onCommitAnyway,
+}: {
+  rejection: HookRejection;
+  onDismiss: () => void;
+  onCommitAnyway: () => void;
+}) {
+  const [collapsed, setCollapsed] = React.useState(false);
+  return (
+    <div
+      data-testid="hook-output"
+      style={{
+        border: "1px solid var(--border-1)",
+        borderRadius: 4,
+        background: "var(--surface-1)",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 6, padding: "6px 8px" }}>
+        <PGIcon name="alert" />
+        <span style={{ flex: 1, fontWeight: 600 }}>
+          The {rejection.hook} hook rejected this commit
+        </span>
+        <PGButton
+          size="sm"
+          variant="ghost"
+          onClick={() => setCollapsed((c) => !c)}
+          data-testid="hook-output-toggle"
+        >
+          {collapsed ? "Show" : "Hide"}
+        </PGButton>
+        <PGButton size="sm" variant="ghost" onClick={onDismiss} data-testid="hook-output-dismiss">
+          Dismiss
+        </PGButton>
+      </div>
+      {!collapsed && (
+        <pre
+          data-testid="hook-output-body"
+          style={{
+            margin: 0,
+            padding: "6px 8px",
+            maxHeight: 200,
+            overflow: "auto",
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.85em",
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+            borderTop: "1px solid var(--border-0)",
+          }}
+        >
+          {rejection.output || "(the hook printed nothing)"}
+        </pre>
+      )}
+      <div style={{ display: "flex", justifyContent: "flex-end", padding: "6px 8px" }}>
+        <PGButton size="sm" onClick={onCommitAnyway} data-testid="hook-output-skip">
+          Commit without hooks
+        </PGButton>
+      </div>
+    </div>
+  );
+}
+```
+
+Export it from `src/design/index.ts`.
+
+- [ ] **Step 4: Run, type-check, commit**
+
+```bash
+pnpm test -- src/design/hook-output.test.tsx 2>&1 | tail -20
+pnpm tsc --noEmit
+git add src/design/hook-output.tsx src/design/hook-output.test.tsx src/design/index.ts
+git commit -m "feat(design): a hook-output block for a hook's refusal"
+```
+
+---
+
+## Task 8: Wire the commit panel
+
+**Files:**
+- Modify: `src/screens/CommitPanel.tsx`
+
+**Interfaces:**
+- Consumes: `HookOutput` (Task 7), store `hookRejection` /
+  `clearHookRejection` / `commit(..., noVerify)` (Task 6).
+- Produces: no new exports.
+
+- [ ] **Step 1: Add the state and the checkbox**
+
+Beside the existing `signOverride` state (around line 152):
+
+```tsx
+  // Skip hooks for this commit only (#232). Never persisted: "skip once" that
+  // silently becomes "never run hooks" is the bug this feature fixes.
+  const [noVerify, setNoVerify] = React.useState(false);
+```
+
+In the toggle block (after the signing checkbox, around line 1607):
+
+```tsx
+            <PGCheckbox
+              checked={noVerify}
+              onChange={setNoVerify}
+              label="Skip hooks for this commit"
+              title="Run no pre-commit, prepare-commit-msg, commit-msg or post-commit hook. Equivalent to `git commit --no-verify`."
+              data-testid="commit-no-verify"
+            />
+```
+
+- [ ] **Step 2: Thread it through `doCommit` and reset it after success**
+
+```tsx
+  const doCommit = async (skipHooks = noVerify): Promise<string | null> => {
+    if (committingRef.current) return null;
+    committingRef.current = true;
+    try {
+      const full = buildMessage(message, coAuthorTrailers(coAuthors));
+      const result = await commitAction(
+        full, amend, signoff, authorIdentity, signForCommit, skipHooks,
+      );
+      if (result) {
+        setMessage("");
+        setAmend(false);
+        draftRef.current = null;
+        setSignOverride(null);
+        // Same reasoning as the signing override: an override must not ride
+        // silently into the next commit.
+        setNoVerify(false);
+      }
+      return result?.oid ?? null;
+    } finally {
+      committingRef.current = false;
+    }
+  };
+```
+
+Add `noVerify` to the `useAction` dependency arrays for `commit.commit` and
+`commit.commitAndPush` alongside `amend` and `signoff`, or a stale closure will
+commit with the previous value.
+
+- [ ] **Step 3: Render the block**
+
+Read `hookRejection` and `clearHookRejection` from the store, and render just
+above the toggle block so it sits between the message box and the checkboxes:
+
+```tsx
+          {hookRejection && (
+            <HookOutput
+              rejection={hookRejection}
+              onDismiss={clearHookRejection}
+              // Retry immediately with hooks off — the in-the-moment half of
+              // the escape hatch. Does not tick the checkbox: this is one
+              // commit, not a new default.
+              onCommitAnyway={() => void doCommit(true)}
+            />
+          )}
+```
+
+- [ ] **Step 4: Handle the empty-panel early return**
+
+`CommitPanel` returns early when there is nothing staged and no amend
+(around line 1125). A `pre-commit` hook that restages can leave the panel in
+that state with a rejection to show, so the rejection must not be hidden by the
+early return — render the block above it too, or add `!hookRejection` to the
+early-return condition. Prefer the latter; it is one condition rather than
+duplicated markup.
+
+- [ ] **Step 5: Type-check and run the unit suite**
+
+```bash
+pnpm tsc --noEmit
+pnpm test 2>&1 | tail -25
+```
+
+Expected: clean, all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/screens/CommitPanel.tsx
+git commit -m "feat(commit): show hook output and offer committing without hooks"
+```
+
+---
+
+## Task 9: Docs — required by `test/docs.test.ts`
+
+**Files:**
+- Modify: `docs/dev/backend.md`, `docs/dev/architecture.md`
+
+- [ ] **Step 1: Confirm what the invariant test wants**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- test/docs.test.ts 2>&1 | tail -30
+```
+
+Expected: FAIL, naming `git/hooks.rs` as undocumented. Let the failure tell you
+the exact required shape rather than guessing.
+
+- [ ] **Step 2: Add `git/hooks.rs` to the backend tree in `docs/dev/architecture.md`**
+
+Match the surrounding entries' format:
+
+```markdown
+- `git/hooks.rs` — the ONE place a git hook is executed (#232). `git hook run`
+  behind a cached capability probe, with a Unix-only direct-exec fallback for a
+  git older than 2.36. Note that `git hook run` sends the hook's **stdout to
+  stderr**, so the captured stream is stderr.
+```
+
+Update the `commands/commits.rs` and `commands/branches.rs` entries to mention
+`no_verify` and the `CommitResult` return.
+
+- [ ] **Step 3: Add the hook chain to `docs/dev/backend.md`**
+
+Place it next to the signing chain and the credential path — it is the same kind
+of rule:
+
+```markdown
+## The hook chain
+
+Commit-side hooks run in `Libgit2Backend::commit`, one per name, through
+`git/hooks.rs` — the only place a hook is spawned. Order is load-bearing:
+
+    pre-commit → read index → write tree → prepare-commit-msg → commit-msg
+    → build/sign/move ref → post-commit
+
+- **`pre-commit` runs before the index is read.** A hook that runs `git add`
+  (lint-staged: reformat, restage) mutates the on-disk index, and only a read
+  that happens afterwards sees it. `tests/hooks.rs::a_pre_commit_that_restages_is_honoured`
+  fails if that read moves back.
+- **`pre-commit` runs outside `with_repo`.** It holds no per-repo mutex, so a
+  hook shelling out to git cannot deadlock against us.
+- **A non-zero `pre-commit`, `prepare-commit-msg` or `commit-msg` creates
+  nothing** — no object, no ref move — the same guarantee the signing chain
+  makes, for the same reason. The index is deliberately NOT rolled back: a hook
+  that restaged did work the user wants, and git does not undo it either.
+- **`post-commit`'s exit code is discarded**, because git discards it. Reporting
+  a commit that exists as failed sends the user hunting for work that landed.
+- **The final message is the hook's, not the user's.** `commit-msg` may rewrite
+  `$GIT_DIR/COMMIT_EDITMSG`; `commit` returns `CommitResult { oid, message }` so
+  the panel can show what actually landed.
+- **`no_verify` skips all four.** Per-invocation, never persisted.
+- `AppError::HookRejected` carries the hook name and its output as separate
+  fields, because the output renders as output — not as a banner.
+```
+
+- [ ] **Step 4: Run the invariant test and commit**
+
+```bash
+pnpm test -- test/docs.test.ts 2>&1 | tail -20
+git add docs/dev/
+git commit -m "docs(dev): document the hook chain and git/hooks.rs"
+```
+
+---
+
+## Task 10: One e2e spec
+
+**Files:**
+- Modify: `e2e/specs/commit.e2e.ts`
+
+- [ ] **Step 1: Read the e2e skill first — this is not optional**
+
+```bash
+cat .claude/skills/e2e-testing/SKILL.md
+```
+
+It carries the selector conventions, the temp-repo fixture helpers and the
+timing traps. Write nothing before reading it.
+
+- [ ] **Step 2: Add the spec**
+
+One case, because the Rust tests carry the matrix and this carries the wiring:
+
+```ts
+it("shows a rejecting pre-commit hook's output and can commit without hooks", async () => {
+  // Fixture: use whatever helper the other specs in this file use to make a
+  // temp repo, then install an executable pre-commit that refuses.
+  // The hook must be chmod +x — git skips a non-executable hook, and the test
+  // would then pass for the wrong reason.
+  await installHook(repoPath, "pre-commit", "#!/bin/sh\necho 'HOOK SAYS NO'\nexit 1\n");
+
+  await stageAFile();
+  await typeCommitMessage("subject");
+  await clickCommit();
+
+  const block = await $('[data-testid="hook-output"]');
+  await expect(block).toBeDisplayed();
+  await expect(await $('[data-testid="hook-output-body"]')).toHaveTextContaining("HOOK SAYS NO");
+
+  await (await $('[data-testid="hook-output-skip"]')).click();
+  // The commit landed: the message box cleared and the block went away.
+  await expect(block).not.toBeDisplayed();
+});
+```
+
+- [ ] **Step 3: Typecheck, rebuild the snapshot, run only this spec**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm exec tsc -p e2e/tsconfig.json --noEmit
+pnpm test:e2e:docker build
+pnpm test:e2e:docker run --spec e2e/specs/commit.e2e.ts
+```
+
+The rebuild is mandatory: `src/` and `src-tauri/` both changed, and a stale
+snapshot tests the old binary. One cold container build at a time across all
+worktrees.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/specs/commit.e2e.ts
+git commit -m "test(e2e): a rejecting pre-commit hook, and committing past it"
+```
+
+---
+
+## Deviations from this plan, as built
+
+- **Push's escape hatch became a palette command** (`action:push-current-no-verify`),
+  not just a backend flag. The plan stopped at `push_args`; the issue asks for the
+  hatch to be visible on push too, and there is no push dialog — force-push is
+  already a `danger: true` palette command behind a confirm, so this follows it.
+  Tested in `commands.test.ts` (the decline path, which needs no mock because
+  `pgConfirm` resolves false with no dialog host) and
+  `commands.noVerifyPush.test.ts` (the accept path, with `@/design` stubbed in
+  its own file so the mock cannot affect other palette tests).
+- **`index.read(false)` was needed** on top of moving the index read. See the
+  spec's correction note; `a_pre_commit_that_restages_is_honoured` caught it.
+- **The output block's child testids do not share its stem** (`hook-body`, not
+  `hook-output-body`) — the e2e attr+text selector trap in
+  `.claude/skills/e2e-testing/SKILL.md`.
+- **`TempRepo.writeHook`** was added to `e2e/support/tempRepo.ts`; `write` alone
+  does not chmod, and git silently skips a non-executable hook.
+- **`tests/verify_commit_no_spawn.rs` needed a change** — it stubs `git` through
+  the process `PATH`, which no longer reaches children.
+
+## Final verification
+
+- [ ] `cargo test --manifest-path src-tauri/Cargo.toml` — all green
+- [ ] `cargo check --manifest-path src-tauri/Cargo.toml` — no warnings introduced
+- [ ] `pnpm tsc --noEmit` — clean
+- [ ] `pnpm test` — unit + component + docs invariants green
+- [ ] `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — clean
+- [ ] `pnpm test:e2e:docker run --spec e2e/specs/commit.e2e.ts` — green
+- [ ] **Manual, and it cannot be skipped:** launch the bundled app from the Dock
+      (not a terminal, not `pnpm tauri dev`) in a repo whose `pre-commit` calls a
+      version-managed `node`, and commit. This is the failure the issue
+      describes, and no automated layer here reproduces it — every test harness
+      already has a terminal's environment. Confirm the hook finds `node`.
+- [ ] Squash to one Conventional Commit against the pinned `origin/main` SHA,
+      open the PR, and let it close #232.

--- a/docs/superpowers/specs/2026-08-26-commit-hooks-spec.md
+++ b/docs/superpowers/specs/2026-08-26-commit-hooks-spec.md
@@ -1,0 +1,361 @@
+# Run the commit-side git hooks (issue 232)
+
+Status: approved for implementation.
+Issue: [232](https://github.com/jonassaa/platypusgit/issues/232).
+
+## Goal
+
+Committing from the app runs the hooks git would run: `pre-commit`,
+`prepare-commit-msg`, `commit-msg`, `post-commit`. Give the user a visible,
+per-invocation way to skip them, on commit and on push. And make a hook that
+calls `node`, `python` or `pnpm` work when the app was launched from the Dock or
+a `.desktop` file, not only when it was launched from a terminal.
+
+The bug today is not that hooks are broken. It is that they are absent on commit
+and present on push, silently: a repo with husky, lefthook, `pre-commit` or
+commitlint is enforced by our `git push` and bypassed by our commit, and nothing
+in the UI says so. That asymmetry is what gets a GUI client banned by a team.
+
+## What is true in the tree, verified by reading it
+
+- `grep -ri hook src-tauri/src` returns nothing but unrelated comments. There has
+  never been hook support.
+- `Libgit2Backend::commit` (`git/libgit2.rs:3752`) builds the commit with
+  `repo.commit(Some("HEAD"), …)`, or `commit_signed` (`libgit2.rs:1134`) when
+  signing is on. **libgit2 runs no hooks, ever.** So the four commit-side hooks
+  never fire.
+- Push is the inconsistency, and it is accidental:
+  `commands::net::run_git_authenticated` shells out to real `git push`
+  (`commands/net.rs:91`), which runs `pre-push` because git does, not because we
+  asked.
+- There is no `--no-verify` anywhere — not on commit, not on push. `push_args`
+  (`commands/branches.rs:223`) builds `push [-u] <remote> <branch> [--force…]`
+  and nothing else.
+- A failed commit surfaces through `pgFlash(appErrorMessage(e))`
+  (`screens/CommitPanel.tsx:1109`) — a transient toast. Nothing in `src/design/`
+  can display multi-line process output. **The output surface is genuinely new.**
+- Every child process is spawned through `proc.rs`, enforced by
+  `tests/spawn_no_window.rs`. `proc.rs` sets `GIT_TERMINAL_PROMPT=0` and closes
+  stdin (`prompt_less`) and touches nothing else about the environment — the
+  child inherits ours.
+
+## The decisions
+
+### 1. Keep the libgit2 commit and run hooks around it — do not shell out to `git commit`
+
+The issue offers either. Shelling out loses on a rule this repo already holds:
+`git commit -S` signs through git's own `gpg.program`, which would stand up a
+**second signing chain** beside `libgit2.rs::sign_payload`. CLAUDE.md's
+one-signing-chain rule exists because two chains drift, and the failure mode is a
+commit the user believes is signed. Shelling out would also hand back raw git
+stderr in place of the classified `AppError` variants the frontend switches on,
+and would need arg translation for amend, author override and sign-off — three
+behaviours already correct in the libgit2 path.
+
+So `commit()` keeps its body and gains hook calls around it.
+
+### 2. Run hooks with `git hook run`, not by executing the scripts ourselves
+
+Executing hook scripts directly means re-implementing git's contract: resolve
+`core.hooksPath`, honour the executable bit, and — the one that silently breaks
+Windows — run the script through git's bundled `sh`, because a hook is a shell
+script and Windows has no shebang. Getting that last part wrong means hooks
+quietly do not run on Windows, which is the exact bug being fixed.
+
+`git hook run` is git doing all of that for us. Probed in a scratch repo rather
+than trusted from the docs:
+
+| Probe | Result |
+| --- | --- |
+| hook exits 3 | `git hook run` exits 3 — exit codes propagate |
+| `core.hooksPath=custom-hooks` | the custom hook ran, `.git/hooks` ignored |
+| hook present but not executable | skipped, exit 0, with git's own `advice.ignoredHook` hint |
+| `--ignore-missing`, hook absent | exit 0 |
+| hook absent, no `--ignore-missing` | exit 1, `error: cannot find a hook named …` |
+| `-- <file> message` | hook saw `$1`/`$2`; appending to `$1` rewrote the file |
+| `pre-commit` running `git add generated.txt` | a later index read saw it staged |
+| `commit --amend -m` | `prepare-commit-msg` got source `message`, argc 2, no `$3` |
+| `commit -s` | `commit-msg` read a file that already had the trailer |
+
+Two findings shape the implementation:
+
+- **Hook stdout is redirected to stderr.** Both a hook's stdout and its stderr
+  arrive on our captured stderr, on success and on failure. So there is one
+  stream to capture and one to display, not two to interleave. Capture stderr;
+  ignore stdout.
+- **An index-modifying `pre-commit` works only if we open the index after it
+  AND reload it.** A hook that runs `git add` (the `lint-staged` shape: reformat,
+  restage) mutates the on-disk index, so `repo.index()` must be called *after*
+  `pre-commit` returns. Ordering alone turned out to be insufficient — see the
+  correction below.
+
+**Support is detected, never inferred from a version number.** `git hook run`
+arrived in git 2.36; Ubuntu 22.04 LTS is supported into 2027 and ships 2.34. But
+parsing `git --version` and comparing is a string-compare bug waiting to happen,
+and it is unnecessary — there is a side-effect-free capability probe:
+
+```
+git hook run --ignore-missing pg-capability-probe
+```
+
+A hook by that name cannot exist, so on a supporting git this runs nothing and
+exits 0 silently (verified). On an older git it exits 1 with
+`git: 'hook' is not a git command`. Probe once, cache the answer, no version
+arithmetic. The probe cannot be confused with a hook rejection, because the hook
+it names never exists.
+
+The fallback for an unsupporting git execs the hook directly, and it is cheap
+because it only has to cover Unix: a shebang'd executable script runs fine, and
+Windows always has a current Git for Windows. The fallback resolves
+`core.hooksPath` and checks the executable bit; it does not attempt Windows `sh`
+shimming, because it never runs there.
+
+**One correction, found by the test rather than by reading.** Reordering the
+index read was *not* enough: the first run of
+`a_pre_commit_that_restages_is_honoured` committed `unfixed`. `with_repo` hands
+back a **cached** `git2::Repository`, and libgit2 keeps that repository's index in
+memory — so a read placed after the hook still returned the pre-hook snapshot,
+and the hook's reformatting was silently discarded. `index.read(false)` after
+`repo.index()` is therefore load-bearing, not hygiene; it reloads only when the
+on-disk index actually changed, so it costs a stat in the common case. Recorded
+in `docs/dev/backend.md`, because a future change to where the index is read has
+to keep both halves.
+
+**A second consequence, found the same way.** `tests/verify_commit_no_spawn.rs`
+stubs `git` by mutating the process `PATH`, which no longer reaches children now
+that `proc.rs` pins one (decision 8). That test starves the probe instead, with a
+comment saying why — and it is a fair warning about the blast radius: pinning
+`PATH` means a runtime `PATH` change no longer affects anything we spawn.
+
+### 3. The commit sequence, and what "creates nothing" means
+
+```
+pre-commit                    → non-zero: stop, create nothing
+open index, write tree        ← after pre-commit, so a restaging hook is honoured
+write COMMIT_EDITMSG
+prepare-commit-msg <file> <source>
+                              → non-zero: stop, create nothing
+commit-msg <file>             → non-zero: stop, create nothing
+re-read COMMIT_EDITMSG        ← the message that lands is the hook's, not the user's
+build + sign + move ref       ← unchanged libgit2 path
+post-commit                   → exit code IGNORED, as git ignores it
+```
+
+A non-zero `pre-commit`, `prepare-commit-msg` or `commit-msg` **creates no object
+and moves no reference**, and leaves the index as the hook left it. This mirrors
+the signing rule (`commit_signed`: a signing failure creates nothing) for the
+same reason — a half-applied commit is worse than a refused one. Note the index
+is deliberately *not* rolled back: a `pre-commit` hook that restaged files did
+work the user wants to keep, and git does not undo it either.
+
+`post-commit` runs after the ref moves. Its exit code is discarded because git
+discards it; a failing `post-commit` must not report a commit that exists as
+failed.
+
+The message file is `$GIT_DIR/COMMIT_EDITMSG`, which is where git puts it and
+therefore where a hook that ignores `$1` and hardcodes the path still works.
+
+`prepare-commit-msg`'s second argument is git's *source*, and ours is always
+`message` with **no third argument — amend included**. Verified rather than
+assumed, because the intuition is wrong: the source is `commit` (with the object
+as `$3`) only when the message is taken *from* a commit, as with `-c`/`-C` or a
+bare `--amend`. We always supply the message as text — the panel prefills HEAD's
+message into the box and sends it back — so git's own equivalent is
+`commit --amend -m <msg>`, which reports `message` and passes two arguments.
+
+**Sign-off is applied before `prepare-commit-msg` sees the message**, matching
+`git commit -s`: verified that the trailer is already in the file by the time
+`commit-msg` reads it, so a hook validating trailers sees what git would show it.
+
+### 4. `AppError::HookRejected { hook, output }` — a typed field, not a stringified banner
+
+Hook output is the whole point of the feature; it cannot arrive as a formatted
+string inside `AppError::Git`. A new variant carries the hook's name and its
+captured output separately, so the frontend renders the output as output — in a
+monospace, scrollable block — rather than pasting a 40-line eslint dump into a
+one-line banner. Per CLAUDE.md the TS `AppError` union is updated in the same
+commit.
+
+Distinct from the missing-hook and cannot-run cases: a hook that does not exist
+is not an error at all (`--ignore-missing`), and a hook we could not *launch*
+(permissions on the hooks dir, no git) is `AppError::Io` — a bug in the
+environment, not a rejection by a hook.
+
+### 5. The commit returns what actually landed
+
+`commit()` today returns the new oid. Because `commit-msg` may rewrite the
+message, the panel's idea of what it committed can now be wrong. The command
+returns the final message alongside the oid so the panel reflects what landed.
+
+### 6. `no_verify` is per-invocation, on `CommitOptions` and on `push_args`
+
+`CommitOptions` gains `no_verify: bool` (`#[serde(default)]`, so an existing
+caller is unchanged). When set, all four hooks are skipped — matching
+`git commit --no-verify`, which skips `pre-commit` and `commit-msg`, and taking
+`prepare-commit-msg` and `post-commit` with it for one reason: a user asking to
+commit without hooks means without hooks, and a `prepare-commit-msg` that
+rewrites the message is exactly the thing a stuck user is trying to get past.
+
+`push_args` gains `--no-verify` to skip `pre-push`.
+
+**On push it is a separate palette command, not a toggle.** There is no push
+dialog to hang a checkbox on — force-push, the other per-invocation push variant,
+is already a distinct `danger: true` palette command behind a confirm, so
+"Push <branch> without hooks" follows that shape exactly. It confirms, and the
+confirm names what will not run, because the hook being skipped is usually the
+test suite. It pushes with `PushForce::None`: skipping hooks must not quietly
+also force.
+
+Not sticky, and not a setting. It is an override; persisting it would turn "skip
+this once" into a repo that silently never runs hooks, which is the bug this
+issue is about, only worse for being our own doing.
+
+### 7. Hook output renders inline in the commit panel
+
+A collapsible, scrollable, monospace block below the message box, persisting
+until dismissed or until the next commit attempt — so the user can read the
+hook's complaint *while editing the message or files it objected to*. A modal
+would block the panel it is asking them to fix; the existing toast auto-dismisses
+and would lose the output before a slow reader clicks anything.
+
+The block carries a `Commit without hooks` action, which is the in-the-moment
+half of decision 6.
+
+### 8. The `$PATH` fix applies to every child spawned through `proc.rs`
+
+A GUI launch (Dock, Finder, `.desktop`) inherits launchd's or the session
+manager's minimal environment, not the login shell's. A launch through our `pgit`
+CLI inherits the terminal's. So a hook calling `node` fails or succeeds depending
+on how the app was started — the worst kind of bug, and the one Fork has an
+upvoted issue about.
+
+**Resolution is a login-shell probe, once, cached:** spawn
+`$SHELL -l -c '<marker>; printf %s "$PATH"; <marker>'`, take what lies between
+the markers, with a timeout. Markers because a noisy rc file prints banners; a
+timeout because an rc file can block on a prompt. This is the only approach that
+finds nvm, asdf and pyenv shims, whose directories are version-specific and
+cannot be guessed. A static list of well-known directories is the fallback when
+the probe fails, not the primary mechanism.
+
+**Scope is every `proc.rs` constructor, not just hooks.** The issue names
+`proc.rs` as where the environment decision belongs, and the identical bug
+silently breaks `gpg`/`ssh-keygen` discovery for signing, `$VISUAL`/`$EDITOR` for
+open-in-editor, `git mergetool`, and the `git-lfs` availability probe. Fixing one
+caller and leaving four is a decision to refix this later.
+
+**The resolved value is a union, not a replacement — and this is load-bearing.**
+Measured, not assumed: Rust's `Command::env("PATH", …)` governs where the child
+*binary itself* is looked up, and it uses **only** that value, not the parent's.
+A probe run against a directory holding one fake binary found the fake and then
+failed to find `sh` with `NotFound`. So assigning the login-shell PATH verbatim
+would break `Command::new("git")` for any user whose login PATH happens not to
+contain git's directory — a regression on flows that work today, caused by the
+fix.
+
+So the applied value is `login_path` first, then the inherited `PATH`, deduped.
+Hooks and program lookup gain the version-manager shims; nothing that resolves
+today stops resolving. Login-first ordering is deliberate: a Dock-launched app
+should prefer the git the user's own terminal uses, which is the point.
+
+The probe is cached and non-fatal: a failure leaves the inherited environment
+exactly as it is now.
+
+**The probe runs off the main thread at startup, and nothing ever waits on it.**
+`child_path()` is a non-blocking cache read; `warm_child_path()` is the only
+resolver. Resolving inside the reader — the obvious shape, and the one this was
+first built as — would make the first spawn of the session wait for a login shell
+to run the user's rc files, so a slow `.zshrc` would stall their first git
+operation by up to the timeout. The window before the probe lands fails safe:
+those spawns inherit our environment, which is exactly the pre-feature
+behaviour.
+
+## Where the code goes
+
+**Backend**
+
+- **`src-tauri/src/git/hooks.rs`** (new) — the only place a hook is spawned.
+  `run_hook(workdir, name, args) -> AppResult<HookOutcome>` where
+  `HookOutcome { ran: bool, code: i32, output: String }`. Owns the
+  `git hook run` invocation, the direct-exec fallback for an older git, and the
+  one-time cached capability probe that chooses between them.
+- **`src-tauri/src/proc.rs`** — the login-shell PATH resolution and its cache;
+  every constructor applies it. Stays the only spawn site, so the guard test is
+  untouched.
+- **`src-tauri/src/git/types.rs`** — `CommitOptions.no_verify`; a `CommitResult
+  { oid, message }` for decision 5.
+- **`src-tauri/src/git/libgit2.rs`** — `commit()` gains the sequence in decision
+  3. Reordered so `repo.index()` follows `pre-commit`.
+- **`src-tauri/src/error.rs`** — `AppError::HookRejected { hook, output }`.
+- **`src-tauri/src/commands/commits.rs`** — `commit` takes `no_verify`, returns
+  `CommitResult`.
+- **`src-tauri/src/commands/branches.rs`** — `push_args` takes `no_verify`;
+  `push` takes it from the frontend.
+- **`src-tauri/src/git/cli.rs`** — `CliBackend` stub stays in shape.
+
+**Frontend**
+
+- **`src/lib/types.ts`** — `AppError` union gains `HookRejected`; `CommitResult`.
+- **`src/lib/tauri.ts`** — `commit`/`push` wrappers take `noVerify`.
+- **`src/design/`** — the output block from decision 7.
+- **`src/screens/CommitPanel.tsx`** — the block, the checkbox beside
+  Amend/Sign-off/Sign, and the `Commit without hooks` retry.
+- **`src/features/repo/`** — `commitAction`/`pushAction` carry `noVerify`; the
+  rejection lands in state rather than a flash.
+
+**Docs** — `docs/dev/backend.md` gets the hook chain (a sibling of the signing
+chain and the credential path); `docs/dev/architecture.md` gets `git/hooks.rs`
+and the changed `commands/` entries, or `test/docs.test.ts` fails the build.
+
+## Out of scope
+
+- **Hooks beyond the four commit-side ones plus `pre-push`.** `post-checkout`,
+  `post-merge`, `post-rewrite` and the rest are real gaps, but they belong to the
+  operations that trigger them, not to this issue.
+- **A hooks manager** — installing, editing or listing hooks. Issue 225 (custom
+  actions) is the neighbour; this issue is git's own contract.
+- **`pre-push` output display.** `pre-push` already runs; surfacing its output as
+  richly as commit's is a follow-up, and pushing it in here doubles the UI work
+  for a path that is not currently broken.
+- **`advice.ignoredHook`.** git already prints the non-executable hint into the
+  output we capture and display. Re-implementing the advice is redundant.
+
+## Testing
+
+**Rust integration, against real temp repos with real hook scripts** — this is
+where the contract lives:
+
+- `pre-commit` exiting non-zero: no new commit object, HEAD unmoved, the hook's
+  output in the error.
+- `pre-commit` that restages a file: the commit contains it (pins the
+  index-after-hook ordering from decision 2; the test fails if the read moves
+  back).
+- `commit-msg` that rewrites the message: the rewritten message is what the
+  commit carries, and what the command returns.
+- `commit-msg` exiting non-zero: nothing created.
+- `core.hooksPath` pointing elsewhere: that hook runs, `.git/hooks` does not.
+- A non-executable hook: skipped, commit succeeds.
+- No hooks at all: commit succeeds, unchanged from today.
+- `no_verify: true` with a rejecting `pre-commit` *and* a rewriting
+  `commit-msg`: commit succeeds and the message is verbatim.
+- `post-commit` exiting non-zero: the commit still succeeds.
+- Signing + a rejecting `pre-commit`: nothing created, and nothing signed.
+
+**Rust unit** — `push_args` with and without `no_verify`, beside the existing
+cases. The login-shell probe's parser against marker-wrapped noisy output. The
+capability probe against both outcomes, and a test that forces the direct-exec
+fallback path so it is exercised on a machine whose git supports `git hook run`
+(otherwise the fallback ships untested everywhere except Ubuntu 22.04).
+
+**Frontend** — a component test for the output block (renders multi-line output,
+collapses, dismisses, fires the retry) and for the checkbox reaching the invoke
+wrapper.
+
+**E2E** — one case in `e2e/specs/commit.e2e.ts`: a temp repo with a rejecting
+`pre-commit`, commit attempted, output block asserted visible with the hook's
+text, then `Commit without hooks` succeeds. One spec, because the Rust tests
+carry the matrix and e2e carries the wiring.
+
+**Manual, and it cannot be skipped** — decision 8 is only real when checked from
+a Dock/Finder launch with a hook that shells out to a version-managed `node`.
+That is the failure the issue describes and no automated layer here reproduces
+it: the test harness always has a terminal's environment.

--- a/e2e/specs/commit.e2e.ts
+++ b/e2e/specs/commit.e2e.ts
@@ -93,4 +93,52 @@ describe("commit", () => {
     // Amend rewrites, never adds — history length is the proof.
     expect(repo.git("rev-list", "--count", "HEAD").trim()).toBe(commitsBefore);
   });
+
+  it("shows a rejecting pre-commit hook's output, and can commit past it", async () => {
+    // Installed inside the test, not before openRepo: unlike dirty files (which
+    // the store reads at open), a hook is only read by git when the commit runs.
+    // `writeHook` chmods — git skips a non-executable hook, and this spec would
+    // then pass because nothing ran.
+    repo.writeHook(
+      "pre-commit",
+      "#!/bin/sh\necho 'HOOK SAYS NO: subject too long'\nexit 1\n",
+    );
+
+    await $("button*=Stage all").click();
+    await browser.waitUntil(
+      async () => !(await $('[data-testid="changes-list"] [data-path]').isExisting()),
+      { timeout: 20_000, timeoutMsg: "changes list should be empty after staging all" },
+    );
+    await $('[data-testid="commit-message"]').setValue("feat: rejected by a hook");
+
+    const headBefore = repo.headSha();
+    await $('[data-testid="commit-button"]').click();
+
+    // UI as the wait condition: the refusal block only mounts once the backend
+    // call has returned, so it is strictly after git finished with the hook.
+    const block = $('[data-testid="hook-output"]');
+    await block.waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "the hook-output block never appeared for a rejecting pre-commit",
+    });
+    // The hook's own words have to reach the user — that is the entire feature.
+    await expect($('[data-testid="hook-body"]')).toHaveText(
+      expect.stringContaining("HOOK SAYS NO"),
+    );
+
+    // Repo truth as acceptance: a refused commit creates NOTHING.
+    expect(repo.headSha()).toBe(headBefore);
+
+    // The escape hatch on the refusal itself.
+    await $('[data-testid="hook-skip"]').click();
+    await $("div*=Working tree clean").waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "committing without hooks did not return the panel to clean",
+    });
+
+    expect(repo.git("log", "-1", "--pretty=%s").trim()).toBe(
+      "feat: rejected by a hook",
+    );
+    expect(repo.headSha()).not.toBe(headBefore);
+  });
 });

--- a/e2e/support/tempRepo.ts
+++ b/e2e/support/tempRepo.ts
@@ -1,5 +1,12 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, readFileSync, mkdirSync, rmSync } from "node:fs";
+import {
+  chmodSync,
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  mkdirSync,
+  rmSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -26,6 +33,21 @@ export class TempRepo {
 
   read(rel: string): string {
     return readFileSync(path.join(this.path, rel), "utf8");
+  }
+
+  /**
+   * Install an executable git hook (#232).
+   *
+   * The chmod is the whole point, and it is why this is a helper rather than a
+   * `write` call in a spec: **git silently skips a non-executable hook.** A spec
+   * that forgot the bit would still go green — the commit succeeds because no
+   * hook ran at all, not because the flow under test works.
+   */
+  writeHook(name: string, body: string): void {
+    const abs = path.join(this.path, ".git", "hooks", name);
+    mkdirSync(path.dirname(abs), { recursive: true });
+    writeFileSync(abs, body);
+    chmodSync(abs, 0o755);
   }
 
   commitFile(rel: string, content: string, msg: string): void {

--- a/src-tauri/src/commands/branches.rs
+++ b/src-tauri/src/commands/branches.rs
@@ -220,7 +220,13 @@ pub async fn pull(
 /// Build `git push` args. `set_upstream` adds `-u`, which the caller passes
 /// only when the branch has no upstream yet — re-sending `-u` on every push
 /// would rewrite tracking the user may have deliberately pointed elsewhere.
-fn push_args(remote: &str, branch: &str, force: PushForce, set_upstream: bool) -> Vec<String> {
+fn push_args(
+    remote: &str,
+    branch: &str,
+    force: PushForce,
+    set_upstream: bool,
+    no_verify: bool,
+) -> Vec<String> {
     let mut args: Vec<String> = vec!["push".to_string()];
     if set_upstream {
         args.push("-u".to_string());
@@ -231,6 +237,11 @@ fn push_args(remote: &str, branch: &str, force: PushForce, set_upstream: bool) -
         PushForce::None => {}
         PushForce::WithLease => args.push("--force-with-lease".to_string()),
         PushForce::Force => args.push("--force".to_string()),
+    }
+    // Skips `pre-push` (#232). Required rather than defaulted, so the compiler
+    // finds every call site instead of one silently keeping hooks on.
+    if no_verify {
+        args.push("--no-verify".to_string());
     }
     args
 }
@@ -243,6 +254,8 @@ pub async fn push(
     branch: String,
     force: PushForce,
     credentials: Option<Credentials>,
+    // Skip `pre-push` for this push only (#232).
+    no_verify: Option<bool>,
 ) -> AppResult<()> {
     let repo_id = RepoId(repo_id);
     let path = get_repo_path(&state, &repo_id).await?;
@@ -265,7 +278,7 @@ pub async fn push(
             .unwrap_or(false)
     };
 
-    let args = push_args(&remote, &branch, force, needs_upstream);
+    let args = push_args(&remote, &branch, force, needs_upstream, no_verify.unwrap_or(false));
     let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     run_git_creds(&path, &arg_refs, credentials.as_ref()).await
 }
@@ -275,13 +288,42 @@ mod push_args_tests {
     use super::*;
 
     #[test]
+    fn no_verify_is_added_only_when_asked() {
+        assert_eq!(
+            push_args("origin", "main", PushForce::None, false, false),
+            vec!["push", "origin", "main"]
+        );
+        assert_eq!(
+            push_args("origin", "main", PushForce::None, false, true),
+            vec!["push", "origin", "main", "--no-verify"]
+        );
+    }
+
+    #[test]
+    fn no_verify_composes_with_upstream_and_force() {
+        assert_eq!(
+            push_args("origin", "feat/x", PushForce::WithLease, true, true),
+            vec![
+                "push",
+                "-u",
+                "origin",
+                "feat/x",
+                "--force-with-lease",
+                "--no-verify"
+            ]
+        );
+    }
+
+    use super::*;
+
+    #[test]
     fn adds_u_only_when_requested() {
         assert_eq!(
-            push_args("origin", "main", PushForce::None, true),
+            push_args("origin", "main", PushForce::None, true, false),
             vec!["push", "-u", "origin", "main"]
         );
         assert_eq!(
-            push_args("origin", "main", PushForce::None, false),
+            push_args("origin", "main", PushForce::None, false, false),
             vec!["push", "origin", "main"]
         );
     }
@@ -289,11 +331,11 @@ mod push_args_tests {
     #[test]
     fn force_flag_comes_last() {
         assert_eq!(
-            push_args("origin", "main", PushForce::WithLease, false),
+            push_args("origin", "main", PushForce::WithLease, false, false),
             vec!["push", "origin", "main", "--force-with-lease"]
         );
         assert_eq!(
-            push_args("origin", "feat/x", PushForce::Force, true),
+            push_args("origin", "feat/x", PushForce::Force, true, false),
             vec!["push", "-u", "origin", "feat/x", "--force"]
         );
     }

--- a/src-tauri/src/commands/commits.rs
+++ b/src-tauri/src/commands/commits.rs
@@ -3,7 +3,7 @@ use tauri::State;
 use crate::{
     error::{AppError, AppResult},
     git::types::{
-        AheadBehind, AuthorOverride, CommitInfo, CommitOptions, LogFilter, LogPage, RepoId,
+        AheadBehind, AuthorOverride, CommitInfo, CommitOptions, CommitResult, LogFilter, LogPage, RepoId,
     },
     state::AppState,
 };
@@ -150,7 +150,10 @@ pub async fn commit(
     author_override: Option<AuthorOverride>,
     // None = follow `commit.gpgsign`; Some overrides it for this commit (#61 D6).
     sign: Option<bool>,
-) -> AppResult<String> {
+    // Skip every commit-side hook for this commit only (#232). Optional so a
+    // caller that omits it keeps hooks ON, which is the safe default.
+    no_verify: Option<bool>,
+) -> AppResult<CommitResult> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
     let opts = CommitOptions {
@@ -159,6 +162,7 @@ pub async fn commit(
         author_override,
         signoff: signoff.unwrap_or(false),
         sign,
+        no_verify: no_verify.unwrap_or(false),
     };
     tokio::task::spawn_blocking(move || backend.commit(&repo_id, opts))
         .await

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -124,6 +124,28 @@ pub enum AppError {
     /// bisect — so the UI refreshes rather than alarms.
     #[error("no bisect in progress")]
     NoBisect,
+
+    /// A git hook ran and refused (#232).
+    ///
+    /// Carries the hook's NAME and its OUTPUT as separate fields rather than one
+    /// formatted sentence: the output is the whole point of the feature and has
+    /// to render *as output* — monospace, scrollable, forty lines of eslint —
+    /// not pasted into a one-line banner.
+    ///
+    /// Distinct from `Io`, which is a hook we could not *launch*: that is a
+    /// broken environment, not a policy decision by the repository. And distinct
+    /// from no error at all, which is what an absent hook produces.
+    #[error("the {} hook rejected this commit", .0.hook)]
+    HookRejected(HookRejection),
+}
+
+/// A hook's refusal (#232). `output` is whatever the hook printed, verbatim —
+/// stdout and stderr both, as git delivers them.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HookRejection {
+    pub hook: String,
+    pub output: String,
 }
 
 impl From<git2::Error> for AppError {

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -4,7 +4,7 @@ use crate::error::{AppError, AppResult};
 
 use super::{
     types::{
-        AheadBehind, BisectMark, BisectStatus, BlameLine, BranchInfo, CommitInfo, CommitOptions, ConflictSides,
+        AheadBehind, BisectMark, BisectStatus, BlameLine, BranchInfo, CommitInfo, CommitOptions, CommitResult, ConflictSides,
         DiffKind, FileContent,
         FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage, RebaseStatus, RebaseStep, ReflogEntry,
         RemoteInfo, RepoHandle, RepoId, RepoState, ResetMode, StashInfo, StashSaveOptions,
@@ -238,7 +238,7 @@ impl GitBackend for CliBackend {
     ) -> AppResult<()> {
         Err(AppError::NotImplemented)
     }
-    fn commit(&self, _repo_id: &RepoId, _opts: CommitOptions) -> AppResult<String> {
+    fn commit(&self, _repo_id: &RepoId, _opts: CommitOptions) -> AppResult<CommitResult> {
         Err(AppError::NotImplemented)
     }
     fn branches(&self, _repo_id: &RepoId) -> AppResult<Vec<BranchInfo>> {

--- a/src-tauri/src/git/hooks.rs
+++ b/src-tauri/src/git/hooks.rs
@@ -1,0 +1,230 @@
+//! The one place a git hook is executed (issue 232).
+//!
+//! # Why hooks are run at all
+//!
+//! libgit2 runs none, ever. So committing through [`crate::git::libgit2`] used
+//! to run no `pre-commit`, `prepare-commit-msg`, `commit-msg` or `post-commit`,
+//! while pushing — which shells out to real `git push` — ran `pre-push` because
+//! git does. A repository with husky, lefthook, `pre-commit` or commitlint was
+//! therefore enforced on push and silently bypassed on commit.
+//!
+//! # Why `git hook run` and not the script directly
+//!
+//! Executing `.git/hooks/pre-commit` ourselves means re-implementing git's
+//! contract: resolve `core.hooksPath`, honour the executable bit, and — the one
+//! that silently breaks Windows — run the script through git's bundled `sh`,
+//! because a hook is a shell script and Windows has no shebang. Getting that
+//! last part wrong means hooks quietly do not run on Windows, which is the exact
+//! bug this module exists to fix.
+//!
+//! `git hook run` is git doing all of it. Verified in a scratch repo rather than
+//! trusted from the docs: it propagates the hook's exit code, respects
+//! `core.hooksPath`, skips a non-executable hook with git's own
+//! `advice.ignoredHook` hint, and passes arguments through after `--`.
+//!
+//! # The one surprise worth knowing
+//!
+//! **`git hook run` redirects the hook's stdout to stderr.** A hook's output
+//! arrives on stderr whether it succeeded or failed, so this module captures
+//! stderr and ignores stdout. Capturing the other way round collects nothing.
+//!
+//! # Why signing is untouched by any of this
+//!
+//! The alternative design was to shell out to `git commit`, which would have run
+//! the hooks for free — and signed through git's own `gpg.program`, standing up a
+//! second signing chain beside `libgit2.rs::sign_payload`. Two chains drift, and
+//! the failure mode is a commit the user believes is signed. So the commit stays
+//! libgit2's and the hooks are wrapped around it.
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+use crate::error::{AppError, AppResult};
+
+/// What running one hook did.
+#[derive(Debug, Clone)]
+pub struct HookOutcome {
+    /// False when no hook by that name exists, or git skipped it as
+    /// non-executable. Not an error: most repositories have no hooks at all.
+    pub ran: bool,
+    /// The hook's exit status, or 0 when it did not run.
+    pub code: i32,
+    /// Everything the hook printed — its stdout and stderr both, as git
+    /// delivers them.
+    pub output: String,
+}
+
+impl HookOutcome {
+    /// A hook that ran and refused. The only condition that stops a commit.
+    ///
+    /// **What actually protects the skip cases is `code`, not `ran`.** A hook
+    /// that is absent or non-executable comes back with `code: 0` — git's own
+    /// choice in the `git hook run` path, and ours in the fallback — so the
+    /// `ran &&` here is belt-and-braces, and a mutation test confirms removing
+    /// it changes no behaviour today.
+    ///
+    /// The invariant that carries real weight is therefore in the constructors:
+    /// **a skipped hook must report `code: 0`.** Reporting non-zero for "I
+    /// didn't run it" would block every commit in a repository whose hooks were
+    /// checked out without their executable bit. `tests/hooks.rs` pins that
+    /// directly rather than pinning this expression.
+    pub fn rejected(&self) -> bool {
+        self.ran && self.code != 0
+    }
+}
+
+/// A hook name that cannot exist, used to ask git whether it has the `hook`
+/// subcommand at all.
+///
+/// Side-effect-free by construction: with `--ignore-missing` there is nothing to
+/// run, so a supporting git exits 0 silently.
+const PROBE_HOOK: &str = "pg-capability-probe";
+
+/// Does this git have `git hook run`? Probed once, cached for the process.
+///
+/// Deliberately **not** `git --version` parsing: comparing version strings is a
+/// bug waiting to happen, and the capability is directly askable. `git hook run`
+/// arrived in git 2.36; Ubuntu 22.04 LTS is supported into 2027 and ships 2.34,
+/// so the fallback below is not hypothetical.
+///
+/// The probe cannot be confused with a hook rejection, because the hook it names
+/// never exists — a supporting git exits 0, an older one exits non-zero with
+/// `git: 'hook' is not a git command`.
+fn has_hook_subcommand(workdir: &Path) -> bool {
+    static CACHE: OnceLock<bool> = OnceLock::new();
+    *CACHE.get_or_init(|| {
+        crate::proc::git(workdir)
+            .args(["hook", "run", "--ignore-missing", PROBE_HOOK])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    })
+}
+
+/// Run hook `name` with `args`, if the repository has one.
+///
+/// `Err` means git itself could not be run — a broken environment. A hook that
+/// ran and *refused* is a successful call returning
+/// [`HookOutcome::rejected`], which the caller turns into
+/// [`AppError::HookRejected`] carrying the hook's own output.
+pub fn run_hook(workdir: &Path, name: &str, args: &[&str]) -> AppResult<HookOutcome> {
+    if has_hook_subcommand(workdir) {
+        run_via_git_hook(workdir, name, args)
+    } else {
+        run_direct(workdir, name, args)
+    }
+}
+
+fn run_via_git_hook(workdir: &Path, name: &str, args: &[&str]) -> AppResult<HookOutcome> {
+    let mut cmd = crate::proc::git(workdir);
+    cmd.args(["hook", "run", "--ignore-missing", name]);
+    if !args.is_empty() {
+        cmd.arg("--");
+        cmd.args(args);
+    }
+    let out = cmd.output().map_err(|e| AppError::Io(e.to_string()))?;
+
+    // Hook output arrives on stderr — including the hook's stdout. See the
+    // module note; capturing stdout here collects nothing.
+    let output = String::from_utf8_lossy(&out.stderr).trim().to_string();
+    let code = out.status.code().unwrap_or(-1);
+
+    // `--ignore-missing` exits 0 and prints nothing for an absent hook, and so
+    // does a hook that ran, passed and said nothing. The two are
+    // indistinguishable from out here — and it does not matter, because both are
+    // `rejected() == false`. `ran` is reported for logging, never branched on
+    // for correctness.
+    Ok(HookOutcome {
+        ran: code != 0 || !output.is_empty(),
+        code,
+        output,
+    })
+}
+
+/// Direct execution, for a git without `git hook run`.
+///
+/// Unix in practice: Windows always has a current Git for Windows, so this path
+/// never needs git's `sh` shim, and a shebang'd executable script runs itself.
+fn run_direct(workdir: &Path, name: &str, args: &[&str]) -> AppResult<HookOutcome> {
+    let skipped = HookOutcome {
+        ran: false,
+        code: 0,
+        output: String::new(),
+    };
+
+    let Some(path) = resolve_hook(workdir, name) else {
+        return Ok(skipped);
+    };
+    if !is_executable(&path) {
+        // Exactly what git does, and why it matters: a hook checked out without
+        // its executable bit must not silently block every commit.
+        return Ok(skipped);
+    }
+
+    let out = crate::proc::program(&path)
+        .current_dir(workdir)
+        .args(args)
+        .output()
+        .map_err(|e| AppError::Io(e.to_string()))?;
+
+    // Direct execution keeps the two streams separate, so join them in the order
+    // a terminal would have shown them.
+    let mut output = String::from_utf8_lossy(&out.stdout).into_owned();
+    output.push_str(&String::from_utf8_lossy(&out.stderr));
+
+    Ok(HookOutcome {
+        ran: true,
+        code: out.status.code().unwrap_or(-1),
+        output: output.trim().to_string(),
+    })
+}
+
+/// `core.hooksPath` if set (a relative value resolves against the worktree),
+/// else `$GIT_DIR/hooks`.
+fn resolve_hook(workdir: &Path, name: &str) -> Option<std::path::PathBuf> {
+    let configured = crate::proc::git(workdir)
+        .args(["config", "--get", "core.hooksPath"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    let dir = match configured {
+        Some(c) => {
+            let p = std::path::PathBuf::from(&c);
+            if p.is_absolute() {
+                p
+            } else {
+                workdir.join(p)
+            }
+        }
+        None => workdir.join(".git").join("hooks"),
+    };
+    let path = dir.join(name);
+    path.is_file().then_some(path)
+}
+
+fn is_executable(path: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(path)
+            .map(|m| m.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+    #[cfg(not(unix))]
+    {
+        path.is_file()
+    }
+}
+
+/// Test-only door onto the direct-exec fallback.
+///
+/// [`run_hook`] reaches it only on a git older than 2.36, which is no CI machine
+/// and no developer machine here — so without this the fallback would ship
+/// exercised on Ubuntu 22.04 and nowhere else.
+#[doc(hidden)]
+pub fn run_direct_for_test(workdir: &Path, name: &str, args: &[&str]) -> AppResult<HookOutcome> {
+    run_direct(workdir, name, args)
+}

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -16,7 +16,8 @@ use crate::opener::safe_workdir_path;
 use super::{
     types::{
         AheadBehind, BisectMark, BisectStatus,
-        BlameLine, BranchInfo, CommitInfo, CommitOptions, ConflictSides, DiffHunk, DiffKind,
+        BlameLine, BranchInfo, CommitInfo, CommitOptions, CommitResult, ConflictSides, DiffHunk,
+        DiffKind,
         DiffLine, DiffLineKind, FileContent, FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage,
         RebaseAction, RebaseStatus, RebaseStep, RebaseSummary, ReflogEntry, ReflogOp, RemoteInfo,
         RepoHandle, RepoId, RepoState, ResetMode, StashInfo, StashSaveOptions, StatusFlag,
@@ -3749,27 +3750,106 @@ impl GitBackend for Libgit2Backend {
         git_apply(&repo_path, &["--reverse"], &patch_text)
     }
 
-    fn commit(&self, repo_id: &RepoId, opts: CommitOptions) -> AppResult<String> {
+    fn commit(&self, repo_id: &RepoId, opts: CommitOptions) -> AppResult<CommitResult> {
+        use crate::git::hooks;
         use crate::git::signature::{apply_signoff, default_signature};
 
-        self.with_repo(repo_id, |repo| {
+        /// Run one hook and turn a refusal into the error the frontend renders.
+        fn gate(workdir: &std::path::Path, name: &str, args: &[&str]) -> AppResult<()> {
+            let out = hooks::run_hook(workdir, name, args)?;
+            if out.rejected() {
+                return Err(AppError::HookRejected(crate::error::HookRejection {
+                    hook: name.to_string(),
+                    output: out.output,
+                }));
+            }
+            Ok(())
+        }
+
+        let repo_path = self.repo_path(repo_id)?;
+
+        // `pre-commit` runs BEFORE the index is read, and OUTSIDE `with_repo`.
+        // Both matter:
+        //
+        //  - A hook that runs `git add` (the lint-staged shape: reformat, then
+        //    restage) mutates the on-disk index, and only a read that happens
+        //    afterwards sees it. `tests/hooks.rs` pins this.
+        //  - `with_repo` holds the per-repo mutex, and a hook shelling out to
+        //    git must not deadlock against us.
+        //
+        // A refusal here returns before anything is created.
+        if !opts.no_verify {
+            gate(&repo_path, "pre-commit", &[])?;
+        }
+
+        // Sign-off goes on before any hook sees the message, matching
+        // `git commit -s` — verified that git has already appended the trailer
+        // by the time `commit-msg` reads the file, so a hook validating trailers
+        // has to see it here too.
+        //
+        // This takes the per-repo lock a second time. The stash TOCTOU rule
+        // would normally forbid that, but this is a READ of the config identity
+        // rather than a verify-then-mutate: the worst a race can do is trail a
+        // `Signed-off-by` for the identity the user had a moment ago. It cannot
+        // be folded into the commit's own `with_repo` either — sign-off must be
+        // applied before the hooks run, and the hooks must run outside the lock.
+        let message_in = if opts.signoff {
+            let (name, email) = self.with_repo(repo_id, |repo| {
+                let c = default_signature(repo)?;
+                Ok((
+                    c.name().unwrap_or("").to_string(),
+                    c.email().unwrap_or("").to_string(),
+                ))
+            })?;
+            apply_signoff(&opts.message, &name, &email)
+        } else {
+            opts.message.clone()
+        };
+
+        // The message hooks negotiate over lives in `$GIT_DIR/COMMIT_EDITMSG`,
+        // where git puts it — so a hook that ignores `$1` and hardcodes the path
+        // still works.
+        let message = if opts.no_verify {
+            message_in
+        } else {
+            let git_dir = self.with_repo(repo_id, |repo| Ok(repo.path().to_path_buf()))?;
+            let msg_path = git_dir.join("COMMIT_EDITMSG");
+            std::fs::write(&msg_path, &message_in).map_err(|e| AppError::Io(e.to_string()))?;
+            let msg_arg = msg_path
+                .to_str()
+                .ok_or_else(|| AppError::InvalidPath(msg_path.display().to_string()))?;
+
+            // Our source is always `message`, with no third argument — amend
+            // INCLUDED. Verified rather than assumed: the source is `commit`
+            // (with the object as `$3`) only when the message is taken FROM a
+            // commit, as with `-c`/`-C` or a bare `--amend`. We always supply it
+            // as text, so git's equivalent is `commit --amend -m <msg>`, which
+            // reports `message` and passes two arguments.
+            gate(&repo_path, "prepare-commit-msg", &[msg_arg, "message"])?;
+            gate(&repo_path, "commit-msg", &[msg_arg])?;
+
+            // Re-read: either hook may have rewritten the file, and what it left
+            // there is what git would commit.
+            std::fs::read_to_string(&msg_path).map_err(|e| AppError::Io(e.to_string()))?
+        };
+
+        let oid = self.with_repo(repo_id, |repo| {
             let sig = match &opts.author_override {
                 Some(o) => git2::Signature::now(&o.name, &o.email)?,
                 None => default_signature(repo)?,
             };
 
-            // Sign-off trailer uses the committer identity (repo config), which
-            // mirrors `git commit -s` even when the author is overridden.
-            let message = if opts.signoff {
-                let committer = default_signature(repo)?;
-                let name = committer.name().unwrap_or("");
-                let email = committer.email().unwrap_or("");
-                apply_signoff(&opts.message, name, email)
-            } else {
-                opts.message.clone()
-            };
-
+            // Read the index HERE, after `pre-commit` — see the note above.
+            //
+            // And `read(false)` is not optional. `with_repo` hands back a CACHED
+            // `git2::Repository`, and libgit2 caches its index in memory, so
+            // `index()` alone returns the snapshot from before the hook ran — a
+            // `pre-commit` that reformats and restages would silently commit the
+            // unformatted content. `read(false)` reloads only if the on-disk
+            // index actually changed, so it costs a stat in the common case.
+            // Pinned by `a_pre_commit_that_restages_is_honoured`.
             let mut index = repo.index()?;
+            index.read(false)?;
             let tree_oid = index.write_tree()?;
             let tree = repo.find_tree(tree_oid)?;
 
@@ -3817,7 +3897,16 @@ impl GitBackend for Libgit2Backend {
                 &parent_refs,
             )?;
             Ok(oid.to_string())
-        })
+        })?;
+
+        // `post-commit` runs after the ref moved, and its exit code is
+        // DISCARDED because git discards it. Reporting a commit that exists as
+        // failed would send the user hunting for work that already landed.
+        if !opts.no_verify {
+            let _ = hooks::run_hook(&repo_path, "post-commit", &[]);
+        }
+
+        Ok(CommitResult { oid, message })
     }
 
     fn branches(&self, repo_id: &RepoId) -> AppResult<Vec<BranchInfo>> {

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod bisect;
 pub mod cli;
+pub mod hooks;
 pub mod libgit2;
 pub mod lfs;
 pub mod ownership;
@@ -19,7 +20,7 @@ use std::path::{Path, PathBuf};
 use crate::error::AppResult;
 use types::{
     AheadBehind,
-    BisectMark, BisectStatus, BlameLine, BranchInfo, CommitInfo, CommitOptions, ConflictSides,
+    BisectMark, BisectStatus, BlameLine, BranchInfo, CommitInfo, CommitOptions, CommitResult, ConflictSides,
     DiffKind, FileContent,
     FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage, RebaseStatus, RebaseStep, ReflogEntry,
     RemoteInfo,
@@ -400,7 +401,7 @@ pub trait GitBackend: Send + Sync {
     ) -> AppResult<()>;
 
     // === commit ===
-    fn commit(&self, repo_id: &RepoId, opts: CommitOptions) -> AppResult<String>;
+    fn commit(&self, repo_id: &RepoId, opts: CommitOptions) -> AppResult<CommitResult>;
 
     // === refs ===
     fn checkout_branch(&self, repo_id: &RepoId, name: &str) -> AppResult<()>;

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -344,7 +344,7 @@ pub struct FileContent {
     pub size: u64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommitOptions {
     pub message: String,
@@ -358,6 +358,26 @@ pub struct CommitOptions {
     /// `commit.gpgsign` from git config; `Some` overrides it for this commit.
     #[serde(default)]
     pub sign: Option<bool>,
+    /// Skip every commit-side hook for this one commit (#232), matching
+    /// `git commit --no-verify`. `#[serde(default)]` so a caller that omits it
+    /// keeps hooks ON, which is the safe default.
+    ///
+    /// Deliberately not a persisted setting: "skip once" that quietly becomes
+    /// "never run hooks again" is a worse version of the bug this fixes.
+    #[serde(default)]
+    pub no_verify: bool,
+}
+
+/// What a commit produced (#232).
+///
+/// The message is returned because `commit-msg` may **rewrite** it, so what
+/// landed is not necessarily what the user typed — and a panel that keeps
+/// showing the typed version is lying about the repository.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitResult {
+    pub oid: String,
+    pub message: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -150,6 +150,22 @@ pub fn run() {
                 "platypusgit starting v{}",
                 env!("CARGO_PKG_VERSION")
             );
+            // Resolve the login-shell PATH off the main thread (issue 232). The
+            // probe spawns a shell that runs the user's rc files, which is slow
+            // enough to be visible at launch.
+            //
+            // This is the ONLY place that resolves it. `child_path()` is a
+            // non-blocking cache read, so a spawn landing before this finishes
+            // inherits our environment exactly as it did before the feature
+            // existed — rather than waiting on someone's `.zshrc`. See
+            // `proc::warm_child_path`.
+            std::thread::spawn(|| {
+                crate::proc::warm_child_path();
+                match crate::proc::child_path() {
+                    Some(p) => log::debug!("resolved child PATH ({} chars)", p.len()),
+                    None => log::debug!("no login-shell PATH; children inherit ours"),
+                }
+            });
             // macOS uses titleBarStyle: Overlay (set in tauri.conf.json) to keep native
             // traffic lights while letting our content extend under them. On Windows /
             // Linux we hide the OS frame entirely and render PGWindowControls ourselves.

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -79,6 +79,7 @@ fn silence_async(_cmd: &mut tokio::process::Command) {}
 pub fn program(prog: impl AsRef<OsStr>) -> std::process::Command {
     let mut cmd = std::process::Command::new(prog);
     silence(&mut cmd);
+    apply_path(&mut cmd, child_path());
     cmd
 }
 
@@ -86,6 +87,7 @@ pub fn program(prog: impl AsRef<OsStr>) -> std::process::Command {
 pub fn program_async(prog: impl AsRef<OsStr>) -> tokio::process::Command {
     let mut cmd = tokio::process::Command::new(prog);
     silence_async(&mut cmd);
+    apply_path_async(&mut cmd, child_path());
     cmd
 }
 
@@ -104,6 +106,172 @@ fn prompt_less(cmd: &mut std::process::Command) {
 
 fn prompt_less_async(cmd: &mut tokio::process::Command) {
     cmd.env("GIT_TERMINAL_PROMPT", "0").stdin(Stdio::null());
+}
+
+/// Marker wrapped around the PATH probe's payload. An rc file is free to print
+/// banners, version notices and nvm chatter; only what lies between two markers
+/// is ours.
+const PATH_MARK: &str = "__PGIT_PATH__";
+
+/// How long the login shell gets before we give up on it. An rc file can block
+/// on a prompt or a slow network mount, and a GUI app that hangs at startup is
+/// worse than one with a short `PATH`.
+const PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Extract the payload from the probe's stdout, or `None` if it is unusable.
+///
+/// Requires BOTH markers. A shell killed by the timeout mid-print would
+/// otherwise yield a truncated `PATH`, which is worse than no `PATH` at all
+/// because it looks like it worked.
+pub(crate) fn parse_probe_output(raw: &str) -> Option<String> {
+    let start = raw.find(PATH_MARK)? + PATH_MARK.len();
+    let rest = &raw[start..];
+    let end = rest.find(PATH_MARK)?;
+    let path = rest[..end].trim();
+    (!path.is_empty()).then(|| path.to_string())
+}
+
+/// `login` first, then whatever we inherited, deduped.
+///
+/// # Why a union and not a replacement
+///
+/// Measured, not assumed: `Command::env("PATH", …)` governs where the child
+/// **binary itself** is looked up, and it uses only that value — never the
+/// parent's. A probe against a directory holding one fake binary found the fake
+/// and then failed to find `sh` at all. So assigning the login shell's `PATH`
+/// verbatim would break `Command::new("git")` for any user whose login `PATH`
+/// happens not to contain git's directory: a regression caused by the fix.
+///
+/// Login entries come first on purpose. A Dock-launched app should prefer the
+/// `git`, `gpg` and `node` the user's own terminal uses; the inherited tail is
+/// there so nothing that resolves today stops resolving.
+pub(crate) fn merge_paths(login: &str, inherited: Option<&str>) -> String {
+    let mut seen = std::collections::HashSet::new();
+    let mut out: Vec<&str> = Vec::new();
+    for entry in login
+        .split(':')
+        .chain(inherited.unwrap_or_default().split(':'))
+    {
+        if !entry.is_empty() && seen.insert(entry) {
+            out.push(entry);
+        }
+    }
+    out.join(":")
+}
+
+/// The `PATH` every child should get, resolved once, or `None` to inherit ours.
+///
+/// # Why this exists
+///
+/// A GUI launch (Dock, Finder, a `.desktop` file) inherits launchd's or the
+/// session manager's minimal environment, not the login shell's. A launch
+/// through our own `pgit` CLI inherits the terminal's. So a `pre-commit` hook
+/// calling `node`, or a `gpg.program` living in `/opt/homebrew/bin`, works or
+/// fails depending on **how the app was started** — the worst kind of bug to
+/// debug from a user's report, and the one issue 232 is fixed around.
+///
+/// # Why a login shell and not a list of likely directories
+///
+/// nvm, asdf, pyenv, rbenv and fnm all put their shims in version-specific
+/// directories that cannot be guessed
+/// (`~/.nvm/versions/node/v22.3.0/bin`). Asking the shell is the only way to
+/// find them.
+///
+/// `None` on Windows — a GUI process there inherits the user and machine `PATH`
+/// from the registry, so there is nothing to fix — and `None` whenever the probe
+/// fails, in which case children inherit our environment exactly as they do
+/// today. A failure is never worse than the status quo.
+pub fn child_path() -> Option<&'static str> {
+    CHILD_PATH.get().and_then(|v| v.as_deref())
+}
+
+static CHILD_PATH: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+
+/// Resolve [`child_path`] if it has not been resolved yet. Blocks.
+///
+/// # Why resolution is separated from reading
+///
+/// [`child_path`] is **non-blocking on purpose**: it reads the cache and answers
+/// `None` if the probe has not finished. Doing the `get_or_init` there instead
+/// would make the FIRST spawn of the process wait for a login shell to run the
+/// user's rc files — up to [`PROBE_TIMEOUT`]. A slow `.zshrc` (nvm, a network
+/// mount) would then stall the first git operation of the session, which is a
+/// bad trade for a `PATH` that is only needed by the time someone commits.
+///
+/// So `run()` warms this on a background thread at startup, and the tiny window
+/// before it lands fails safe: a spawn in that window inherits our environment,
+/// exactly as it did before this existed. In practice the probe resolves in
+/// milliseconds and long before any user action can reach a hook.
+pub fn warm_child_path() {
+    CHILD_PATH.get_or_init(|| {
+        let login = probe_login_path()?;
+        let inherited = std::env::var("PATH").ok();
+        Some(merge_paths(&login, inherited.as_deref()))
+    });
+}
+
+#[cfg(windows)]
+fn probe_login_path() -> Option<String> {
+    None
+}
+
+/// Ask the user's login shell what its `PATH` is.
+#[cfg(not(windows))]
+fn probe_login_path() -> Option<String> {
+    use std::io::Read;
+
+    let shell = std::env::var("SHELL").ok().filter(|s| !s.is_empty())?;
+
+    // `-l` so the profile files run — that is where the version managers put
+    // their shims. `printf` rather than `echo`, whose escape handling differs
+    // between shells.
+    let script = format!("printf '%s%s%s' '{PATH_MARK}' \"$PATH\" '{PATH_MARK}'");
+
+    // Deliberately NOT `program()`: this is the one child that must not be
+    // handed the environment we are trying to replace, and it cannot create a
+    // Windows console because it does not run on Windows at all.
+    let mut child = std::process::Command::new(&shell)
+        .arg("-l")
+        .arg("-c")
+        .arg(&script)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    // Polled rather than `wait_with_output`, which cannot time out. An rc file
+    // that blocks must not hang the first spawn that needs a `PATH`.
+    let deadline = std::time::Instant::now() + PROBE_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) if std::time::Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+            Ok(None) => std::thread::sleep(std::time::Duration::from_millis(25)),
+            Err(_) => return None,
+        }
+    }
+
+    let mut raw = String::new();
+    child.stdout.as_mut()?.read_to_string(&mut raw).ok()?;
+    parse_probe_output(&raw)
+}
+
+/// Hand `path` to a child, if there is one to hand over.
+fn apply_path(cmd: &mut std::process::Command, path: Option<&str>) {
+    if let Some(p) = path {
+        cmd.env("PATH", p);
+    }
+}
+
+fn apply_path_async(cmd: &mut tokio::process::Command, path: Option<&str>) {
+    if let Some(p) = path {
+        cmd.env("PATH", p);
+    }
 }
 
 /// `git -C <workdir>`, with no console window and the prompt-less policy above.
@@ -159,6 +327,9 @@ pub fn git_async_in(dir: &Path) -> tokio::process::Command {
 pub fn git_async_keeping_console(workdir: &Path) -> tokio::process::Command {
     let mut cmd = tokio::process::Command::new("git");
     cmd.arg("-C").arg(workdir);
+    // The PATH fix still applies: a console mergetool the user configured is
+    // exactly the kind of program that lives in a version-managed directory.
+    apply_path_async(&mut cmd, child_path());
     cmd
 }
 
@@ -174,7 +345,10 @@ pub fn git_async_keeping_console(workdir: &Path) -> tokio::process::Command {
 /// since `cmd.exe` is a console application; that is a cosmetic flash traded
 /// against an unrecoverable one, so it loses.
 pub fn program_async_keeping_console(prog: impl AsRef<OsStr>) -> tokio::process::Command {
-    tokio::process::Command::new(prog)
+    let mut cmd = tokio::process::Command::new(prog);
+    // `$EDITOR` is the canonical victim of a Dock launch's minimal PATH.
+    apply_path_async(&mut cmd, child_path());
+    cmd
 }
 
 #[cfg(test)]
@@ -183,8 +357,16 @@ mod tests {
 
     /// `Command`'s getters are the only way to see a builder's decisions without
     /// running it, and they are what makes the policy assertable off Windows.
+    ///
+    /// **`PATH` is filtered out.** Every constructor now applies the cached
+    /// login-shell `PATH` (issue 232), and whether the probe finds anything
+    /// depends on the `$SHELL` of the machine running the test — so asserting on
+    /// it here would make these tests pass or fail by environment. The
+    /// assertions below are about the prompt-less policy; the `PATH` behaviour is
+    /// tested directly in `apply_path_*` and `merge_paths_*`.
     fn envs(cmd: &std::process::Command) -> Vec<(String, Option<String>)> {
         cmd.get_envs()
+            .filter(|(k, _)| k.to_string_lossy() != "PATH")
             .map(|(k, v)| {
                 (
                     k.to_string_lossy().to_string(),
@@ -238,11 +420,173 @@ mod tests {
     }
 
     #[test]
-    fn program_applies_nothing_but_the_flag() {
+    fn program_applies_nothing_but_the_flag_and_the_path() {
         // The signer pipes all three streams itself, so the constructor must not
-        // close stdin under it.
+        // close stdin under it. `envs` filters PATH — see its doc comment.
         let cmd = program("gpg");
         assert_eq!(cmd.get_program(), "gpg");
         assert!(envs(&cmd).is_empty());
     }
+
+    // --- PATH resolution (issue 232) ---
+
+    #[test]
+    fn parses_the_path_between_markers_ignoring_rc_noise() {
+        let raw = format!(
+            "Welcome to your shell!\nnvm: loaded\n\
+             {PATH_MARK}/opt/homebrew/bin:/usr/bin{PATH_MARK}\nbye\n"
+        );
+        assert_eq!(
+            parse_probe_output(&raw).as_deref(),
+            Some("/opt/homebrew/bin:/usr/bin")
+        );
+    }
+
+    #[test]
+    fn rejects_probe_output_with_no_markers() {
+        assert_eq!(parse_probe_output("just noise\n"), None);
+    }
+
+    #[test]
+    fn rejects_a_single_unterminated_marker() {
+        // A shell killed by the timeout mid-print must not yield a truncated
+        // PATH: that looks like success and silently drops directories.
+        assert_eq!(parse_probe_output(&format!("{PATH_MARK}/opt/homebrew/bin")), None);
+    }
+
+    #[test]
+    fn rejects_an_empty_path_between_markers() {
+        assert_eq!(parse_probe_output(&format!("{PATH_MARK}{PATH_MARK}")), None);
+    }
+
+    #[test]
+    fn merge_paths_puts_login_first_and_keeps_the_inherited_tail() {
+        // The inherited tail is what stops this fix breaking `Command::new("git")`
+        // for a user whose login PATH has no git in it.
+        assert_eq!(
+            merge_paths("/opt/homebrew/bin", Some("/usr/bin:/bin")),
+            "/opt/homebrew/bin:/usr/bin:/bin"
+        );
+    }
+
+    #[test]
+    fn merge_paths_dedupes_without_reordering() {
+        assert_eq!(
+            merge_paths("/usr/bin:/opt/homebrew/bin", Some("/usr/bin:/bin")),
+            "/usr/bin:/opt/homebrew/bin:/bin"
+        );
+    }
+
+    #[test]
+    fn merge_paths_drops_empty_entries() {
+        // A trailing colon means "the current directory" to some shells; carrying
+        // it into every child is a footgun we do not need.
+        assert_eq!(merge_paths("/usr/bin:", Some(":/bin")), "/usr/bin:/bin");
+    }
+
+    #[test]
+    fn merge_paths_survives_no_inherited_path() {
+        assert_eq!(merge_paths("/usr/bin", None), "/usr/bin");
+    }
+
+    /// The `PATH` a builder will hand its child, if any.
+    fn path_of(cmd: &std::process::Command) -> Option<String> {
+        cmd.get_envs()
+            .find(|(k, _)| k.to_string_lossy() == "PATH")
+            .and_then(|(_, v)| v.map(|v| v.to_string_lossy().to_string()))
+    }
+
+    /// Asserted against `child_path()` rather than a literal, so the test is
+    /// deterministic on a machine that resolves one AND on a machine that does
+    /// not — including Windows, where the answer is always `None`. A literal
+    /// would make this pass or fail by `$SHELL`.
+    ///
+    /// Deliberately NOT written as `Command::new` + `apply_path`: raw spawns in
+    /// this file are counted by `tests/spawn_no_window.rs`, and a test site
+    /// inflating that count would hide a future production spawn inside the
+    /// allowance. Going through the constructors also tests the thing that
+    /// actually matters — that they apply it at all.
+    #[test]
+    fn the_sync_constructors_hand_over_the_resolved_path() {
+        // Warm first, or `child_path()` is `None` and this compares two Nones.
+        warm_child_path();
+        assert_eq!(path_of(&program("gpg")).as_deref(), child_path());
+        assert_eq!(path_of(&git(Path::new("/tmp/repo"))).as_deref(), child_path());
+    }
+
+    #[test]
+    fn the_async_constructors_hand_over_the_resolved_path() {
+        warm_child_path();
+        assert_eq!(
+            path_of(program_async("gpg").as_std()).as_deref(),
+            child_path()
+        );
+        assert_eq!(
+            path_of(git_async(Path::new("/tmp/repo")).as_std()).as_deref(),
+            child_path()
+        );
+        assert_eq!(
+            path_of(git_async_in(Path::new("/tmp/parent")).as_std()).as_deref(),
+            child_path()
+        );
+    }
+
+    #[test]
+    fn the_console_keeping_constructors_also_get_the_path() {
+        // `$EDITOR` and a console mergetool are exactly the programs a Dock
+        // launch's minimal PATH fails to find, so these two are not exempt.
+        warm_child_path();
+        assert_eq!(
+            path_of(git_async_keeping_console(Path::new("/tmp/repo")).as_std()).as_deref(),
+            child_path()
+        );
+        assert_eq!(
+            path_of(program_async_keeping_console("vim").as_std()).as_deref(),
+            child_path()
+        );
+    }
+    /// The contract that keeps a slow `.zshrc` from stalling the first git
+    /// operation of the session: `child_path()` is a cache READ, and
+    /// `warm_child_path` is the only thing that runs the probe.
+    ///
+    /// Asserted on the SOURCE rather than by timing, for the same reason
+    /// `tests/spawn_no_window.rs` greps: a timing test here would be warmed by
+    /// whichever sibling test ran first in this binary and pass vacuously.
+    #[test]
+    fn only_warm_child_path_resolves_the_probe() {
+        // Everything ABOVE the test module. Scoped that way because this test's
+        // own body names the things it is looking for, and a guard that counts
+        // its own source counts to four.
+        let src = include_str!("proc.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("module source above the tests");
+
+        let body = src
+            .split("pub fn child_path() -> Option<&'static str> {")
+            .nth(1)
+            .and_then(|s| s.split('}').next())
+            .expect("child_path body");
+        assert!(
+            !body.contains("get_or_init"),
+            "child_path() must not resolve the probe itself — warm_child_path \
+             does, off the main thread. Found body: {body}"
+        );
+        // Comment lines are not code — the same filter `tests/spawn_no_window.rs`
+        // needs, and for the same reason: the doc comment above `child_path`
+        // explains this rule by naming it.
+        let code_hits = src
+            .lines()
+            .filter(|l| {
+                let t = l.trim_start();
+                !(t.starts_with("//") || t.starts_with("/*") || t.starts_with('*'))
+            })
+            .filter(|l| l.contains("get_or_init"))
+            .count();
+        assert_eq!(
+            code_hits, 1,
+            "the PATH probe must have exactly one resolution site"
+        );
+    }
+
 }

--- a/src-tauri/tests/branches_tags.rs
+++ b/src-tauri/tests/branches_tags.rs
@@ -191,6 +191,7 @@ fn delete_unmerged_branch_is_refused_without_force() {
                 author_override: None,
                 signoff: false,
                 sign: None,
+                no_verify: false,
             },
         )
         .unwrap();

--- a/src-tauri/tests/cherry_pick_revert.rs
+++ b/src-tauri/tests/cherry_pick_revert.rs
@@ -24,9 +24,11 @@ fn cherry_pick_applies_commit_onto_head() {
                 author_override: None,
                 signoff: false,
                 sign: None,
+                no_verify: false,
             },
         )
-        .unwrap();
+        .unwrap()
+        .oid;
 
     backend.checkout_branch(&handle.id, "main").unwrap();
     assert!(!tr.path().join("NOTES.md").exists());
@@ -53,9 +55,11 @@ fn revert_undoes_commit() {
                 author_override: None,
                 signoff: false,
                 sign: None,
+                no_verify: false,
             },
         )
-        .unwrap();
+        .unwrap()
+        .oid;
 
     backend.revert(&handle.id, &bad_oid).unwrap();
 

--- a/src-tauri/tests/discard_reset.rs
+++ b/src-tauri/tests/discard_reset.rs
@@ -258,6 +258,7 @@ fn reset_hard_moves_head_and_cleans_worktree() {
                     author_override: None,
                     signoff: false,
                     sign: None,
+                    no_verify: false,
                 },
             )
             .unwrap();
@@ -290,6 +291,7 @@ fn reset_soft_keeps_worktree() {
                 author_override: None,
                 signoff: false,
                 sign: None,
+                no_verify: false,
             },
         )
         .unwrap();

--- a/src-tauri/tests/hooks.rs
+++ b/src-tauri/tests/hooks.rs
@@ -1,0 +1,548 @@
+//! Git hook execution (issue 232).
+//!
+//! These run **real hook scripts** against real temp repos, because the whole
+//! feature is a contract with git and a mocked hook would only assert that our
+//! mock works. Every script here is `/bin/sh`, which is what a hook is.
+//!
+//! Unix-only: the scripts have shebangs and the executable-bit semantics under
+//! test do not exist on Windows. The Windows path is `git hook run`'s own `sh`
+//! shim, which is precisely the part we deliberately did not reimplement.
+#![cfg(unix)]
+
+mod support;
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use platypusgit_lib::git::hooks::{run_direct_for_test, run_hook};
+use support::TempRepo;
+
+/// Write an executable hook into `.git/hooks`.
+fn write_hook(repo: &Path, name: &str, body: &str) -> std::path::PathBuf {
+    let dir = repo.join(".git").join("hooks");
+    fs::create_dir_all(&dir).expect("hooks dir");
+    let path = dir.join(name);
+    fs::write(&path, body).expect("write hook");
+    chmod(&path, 0o755);
+    path
+}
+
+fn chmod(path: &Path, mode: u32) {
+    let mut perms = fs::metadata(path).expect("metadata").permissions();
+    perms.set_mode(mode);
+    fs::set_permissions(path, perms).expect("set_permissions");
+}
+
+#[test]
+fn a_rejecting_hook_reports_its_output_and_its_exit_code() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_hook(
+        tr.path(),
+        "pre-commit",
+        "#!/bin/sh\necho 'lint failed on a.ts'\nexit 3\n",
+    );
+
+    let out = run_hook(tr.path(), "pre-commit", &[]).expect("run_hook");
+    assert!(out.ran, "the hook exists and is executable, so it ran");
+    assert_eq!(out.code, 3, "the exit code propagates verbatim");
+    assert!(out.rejected());
+    assert!(
+        out.output.contains("lint failed on a.ts"),
+        "the hook's stdout must be captured — git hook run sends it to stderr; got {:?}",
+        out.output
+    );
+}
+
+#[test]
+fn a_passing_hook_is_not_a_rejection_but_its_output_is_still_captured() {
+    // A formatter that reports what it changed is useful output on success.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_hook(
+        tr.path(),
+        "pre-commit",
+        "#!/bin/sh\necho 'reformatted 2 files'\nexit 0\n",
+    );
+
+    let out = run_hook(tr.path(), "pre-commit", &[]).expect("run_hook");
+    assert!(!out.rejected());
+    assert!(out.output.contains("reformatted 2 files"));
+}
+
+#[test]
+fn a_missing_hook_is_not_an_error_and_not_a_rejection() {
+    // The overwhelmingly common case: no hooks at all.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let out = run_hook(tr.path(), "commit-msg", &[]).expect("run_hook");
+    assert!(!out.ran, "an absent hook did not run");
+    assert!(!out.rejected(), "absent is not a refusal");
+}
+
+#[test]
+fn a_non_executable_hook_is_skipped_the_way_git_skips_it() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let path = write_hook(tr.path(), "pre-commit", "#!/bin/sh\nexit 1\n");
+    chmod(&path, 0o644);
+
+    let out = run_hook(tr.path(), "pre-commit", &[]).expect("run_hook");
+    assert!(
+        !out.rejected(),
+        "a hook git would skip must not reject the commit; got {out:?}"
+    );
+    // THE invariant, pinned where it lives: a skipped hook reports code 0.
+    // Reporting non-zero for "I didn't run it" would block every commit in a
+    // repository whose hooks were checked out without their executable bit.
+    assert_eq!(out.code, 0, "a skipped hook must report success; got {out:?}");
+}
+
+#[test]
+fn core_hooks_path_wins_over_the_default_location() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let custom = tr.path().join("myhooks");
+    fs::create_dir_all(&custom).expect("custom hooks dir");
+    let path = custom.join("pre-commit");
+    fs::write(&path, "#!/bin/sh\necho 'from myhooks'\nexit 7\n").expect("write");
+    chmod(&path, 0o755);
+    // The hook in the default location must lose.
+    write_hook(
+        tr.path(),
+        "pre-commit",
+        "#!/bin/sh\necho 'from .git/hooks'\nexit 0\n",
+    );
+    tr.repo
+        .config()
+        .expect("config")
+        .set_str("core.hooksPath", "myhooks")
+        .expect("set hooksPath");
+
+    let out = run_hook(tr.path(), "pre-commit", &[]).expect("run_hook");
+    assert_eq!(out.code, 7);
+    assert!(out.output.contains("from myhooks"));
+    assert!(!out.output.contains("from .git/hooks"));
+}
+
+#[test]
+fn arguments_reach_the_hook_and_a_rewrite_of_the_first_survives() {
+    // The prepare-commit-msg / commit-msg shape: the hook is handed a file and
+    // may rewrite it in place.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_hook(
+        tr.path(),
+        "prepare-commit-msg",
+        "#!/bin/sh\nprintf 'source=%s\\n' \"$2\"\necho 'appended by hook' >> \"$1\"\n",
+    );
+    let msg = tr.path().join(".git").join("COMMIT_EDITMSG");
+    fs::write(&msg, "original\n").expect("seed message");
+
+    let out = run_hook(
+        tr.path(),
+        "prepare-commit-msg",
+        &[msg.to_str().unwrap(), "message"],
+    )
+    .expect("run_hook");
+
+    assert!(!out.rejected());
+    assert!(
+        out.output.contains("source=message"),
+        "the second argument reached the hook; got {:?}",
+        out.output
+    );
+    let after = fs::read_to_string(&msg).expect("read back");
+    assert!(
+        after.contains("appended by hook"),
+        "the hook's rewrite must persist; got {after:?}"
+    );
+}
+
+#[test]
+fn a_hook_that_refuses_silently_is_still_a_rejection() {
+    // Exit 1, print nothing. The commit must still be refused, and the UI has
+    // only the hook's NAME to show — which is why the error carries it.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_hook(tr.path(), "commit-msg", "#!/bin/sh\nexit 1\n");
+
+    let out = run_hook(tr.path(), "commit-msg", &[]).expect("run_hook");
+    assert!(out.rejected());
+    assert!(out.output.is_empty());
+}
+
+#[test]
+fn the_direct_exec_fallback_matches_git_hook_runs_semantics() {
+    // Called directly: `run_hook` reaches the fallback only on a git older than
+    // 2.36, which is no machine this test ever runs on. Without this the
+    // fallback would be exercised on Ubuntu 22.04 and nowhere else.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_hook(
+        tr.path(),
+        "pre-commit",
+        "#!/bin/sh\necho 'fallback ran'\nexit 4\n",
+    );
+
+    let out = run_direct_for_test(tr.path(), "pre-commit", &[]).expect("fallback");
+    assert_eq!(out.code, 4);
+    assert!(out.rejected());
+    assert!(out.output.contains("fallback ran"));
+}
+
+#[test]
+fn the_fallback_skips_a_missing_hook_and_a_non_executable_one() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let missing = run_direct_for_test(tr.path(), "pre-commit", &[]).expect("fallback");
+    assert!(!missing.ran);
+
+    let path = write_hook(tr.path(), "pre-commit", "#!/bin/sh\nexit 1\n");
+    chmod(&path, 0o644);
+    let not_exec = run_direct_for_test(tr.path(), "pre-commit", &[]).expect("fallback");
+    assert!(!not_exec.ran, "the fallback honours the executable bit too");
+    assert!(!not_exec.rejected());
+    // Same invariant as the `git hook run` path: skipped means code 0.
+    assert_eq!(missing.code, 0, "a missing hook must report success");
+    assert_eq!(not_exec.code, 0, "a non-executable hook must report success");
+}
+
+#[test]
+fn the_fallback_honours_core_hooks_path() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let custom = tr.path().join("elsewhere");
+    fs::create_dir_all(&custom).expect("dir");
+    let path = custom.join("pre-commit");
+    fs::write(&path, "#!/bin/sh\nexit 5\n").expect("write");
+    chmod(&path, 0o755);
+    tr.repo
+        .config()
+        .expect("config")
+        .set_str("core.hooksPath", "elsewhere")
+        .expect("set hooksPath");
+
+    let out = run_direct_for_test(tr.path(), "pre-commit", &[]).expect("fallback");
+    assert_eq!(out.code, 5);
+}
+
+// ---------------------------------------------------------------------------
+// The commit sequence (issue 232).
+//
+// These go through the real backend, because the guarantee under test is about
+// what ends up in the object database — not about which functions got called.
+// ---------------------------------------------------------------------------
+
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::types::{CommitOptions, RepoId};
+use platypusgit_lib::git::GitBackend;
+use std::path::PathBuf;
+
+/// Stage `name` with the given body and return an options struct for it.
+fn stage(backend: &impl GitBackend, id: &RepoId, tr: &TempRepo, name: &str, body: &str) {
+    support::fs::write_file(tr.path(), name, body);
+    backend.stage(id, &[PathBuf::from(name)]).expect("stage");
+}
+
+fn opts(message: &str) -> CommitOptions {
+    CommitOptions {
+        message: message.into(),
+        ..Default::default()
+    }
+}
+
+fn head_oid(tr: &TempRepo) -> Option<String> {
+    let repo = git2::Repository::open(tr.path()).expect("open");
+    repo.head()
+        .ok()
+        .and_then(|h| h.peel_to_commit().ok())
+        .map(|c| c.id().to_string())
+}
+
+fn count_commits(tr: &TempRepo) -> usize {
+    let repo = git2::Repository::open(tr.path()).expect("open");
+    let mut walk = repo.revwalk().expect("revwalk");
+    walk.push_head().expect("push head");
+    walk.count()
+}
+
+fn message_of(tr: &TempRepo, oid: &str) -> String {
+    let repo = git2::Repository::open(tr.path()).expect("open");
+    let id = git2::Oid::from_str(oid).expect("oid");
+    let commit = repo.find_commit(id).expect("find");
+    commit.message().unwrap_or("").to_string()
+}
+
+fn blob_at(tr: &TempRepo, oid: &str, path: &str) -> String {
+    let repo = git2::Repository::open(tr.path()).expect("open");
+    let id = git2::Oid::from_str(oid).expect("oid");
+    // Each step gets its own binding: chaining off `find_commit(..)` borrows a
+    // temporary that drops at the end of the statement.
+    let commit = repo.find_commit(id).expect("find");
+    let tree = commit.tree().expect("tree");
+    let entry = tree.get_path(Path::new(path)).expect("entry");
+    let blob = repo.find_blob(entry.id()).expect("blob");
+    String::from_utf8_lossy(blob.content()).to_string()
+}
+
+#[test]
+fn a_rejecting_pre_commit_creates_nothing() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    write_hook(tr.path(), "pre-commit", "#!/bin/sh\necho 'NOPE: lint'\nexit 1\n");
+    stage(&backend, &handle.id, &tr, "a.txt", "a\n");
+
+    let before = head_oid(&tr);
+    let err = backend
+        .commit(&handle.id, opts("subject"))
+        .expect_err("the hook refused, so the commit must fail");
+
+    match err {
+        AppError::HookRejected(r) => {
+            assert_eq!(r.hook, "pre-commit");
+            assert!(
+                r.output.contains("NOPE: lint"),
+                "the hook's own words must reach the user; got {:?}",
+                r.output
+            );
+        }
+        other => panic!("expected HookRejected, got {other:?}"),
+    }
+    assert_eq!(head_oid(&tr), before, "HEAD must not move");
+    assert_eq!(count_commits(&tr), 1, "no commit object was created");
+}
+
+#[test]
+fn a_rejecting_commit_msg_creates_nothing() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    write_hook(tr.path(), "commit-msg", "#!/bin/sh\necho 'bad subject'\nexit 1\n");
+    stage(&backend, &handle.id, &tr, "a.txt", "a\n");
+
+    let before = head_oid(&tr);
+    let err = backend.commit(&handle.id, opts("nope")).expect_err("refused");
+    assert!(
+        matches!(&err, AppError::HookRejected(r) if r.hook == "commit-msg"),
+        "got {err:?}"
+    );
+    assert_eq!(head_oid(&tr), before);
+    assert_eq!(count_commits(&tr), 1);
+}
+
+#[test]
+fn a_rejecting_prepare_commit_msg_creates_nothing() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    write_hook(
+        tr.path(),
+        "prepare-commit-msg",
+        "#!/bin/sh\necho 'refusing to prepare'\nexit 1\n",
+    );
+    stage(&backend, &handle.id, &tr, "a.txt", "a\n");
+
+    let err = backend.commit(&handle.id, opts("subject")).expect_err("refused");
+    assert!(
+        matches!(&err, AppError::HookRejected(r) if r.hook == "prepare-commit-msg"),
+        "got {err:?}"
+    );
+    assert_eq!(count_commits(&tr), 1);
+}
+
+#[test]
+fn a_pre_commit_that_restages_is_honoured() {
+    // THE ordering test. `lint-staged`'s shape: reformat a file, `git add` it,
+    // exit 0 — and the commit must contain the reformatted content. That only
+    // works if the index is read AFTER pre-commit. Move the read back to the top
+    // of `commit()` and this fails.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    write_hook(
+        tr.path(),
+        "pre-commit",
+        "#!/bin/sh\nprintf 'fixed\\n' > a.txt\ngit add a.txt\nexit 0\n",
+    );
+    stage(&backend, &handle.id, &tr, "a.txt", "unfixed\n");
+
+    let res = backend.commit(&handle.id, opts("subject")).expect("commit");
+    assert_eq!(
+        blob_at(&tr, &res.oid, "a.txt").trim(),
+        "fixed",
+        "the hook's restaged content must be what landed"
+    );
+}
+
+#[test]
+fn a_rewriting_commit_msg_decides_the_final_message() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    write_hook(
+        tr.path(),
+        "commit-msg",
+        "#!/bin/sh\nprintf 'REWRITTEN\\n' > \"$1\"\n",
+    );
+    stage(&backend, &handle.id, &tr, "a.txt", "a\n");
+
+    let res = backend
+        .commit(&handle.id, opts("typed by the user"))
+        .expect("commit");
+    assert_eq!(
+        res.message.trim(),
+        "REWRITTEN",
+        "the RETURNED message is what landed, so the panel can show the truth"
+    );
+    assert_eq!(
+        message_of(&tr, &res.oid).trim(),
+        "REWRITTEN",
+        "and the object itself agrees"
+    );
+}
+
+#[test]
+fn a_rewriting_prepare_commit_msg_also_reaches_the_object() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    write_hook(
+        tr.path(),
+        "prepare-commit-msg",
+        "#!/bin/sh\nprintf '\\nRefs: #232\\n' >> \"$1\"\n",
+    );
+    stage(&backend, &handle.id, &tr, "a.txt", "a\n");
+
+    let res = backend.commit(&handle.id, opts("subject")).expect("commit");
+    assert!(
+        res.message.contains("Refs: #232"),
+        "prepare-commit-msg's addition must survive; got {:?}",
+        res.message
+    );
+    assert!(message_of(&tr, &res.oid).contains("Refs: #232"));
+}
+
+#[test]
+fn commit_msg_sees_the_signoff_trailer_already_applied() {
+    // Matches `git commit -s`, verified against real git: the trailer is in the
+    // file before commit-msg reads it, so a hook validating trailers passes.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    write_hook(
+        tr.path(),
+        "commit-msg",
+        "#!/bin/sh\ngrep -q 'Signed-off-by:' \"$1\" || { echo 'no trailer'; exit 1; }\n",
+    );
+    stage(&backend, &handle.id, &tr, "a.txt", "a\n");
+
+    let res = backend
+        .commit(
+            &handle.id,
+            CommitOptions {
+                signoff: true,
+                ..opts("subject")
+            },
+        )
+        .expect("the trailer must already be there when commit-msg runs");
+    assert!(res.message.contains("Signed-off-by:"));
+}
+
+#[test]
+fn no_verify_skips_a_rejecting_hook_and_a_rewriting_one() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    write_hook(tr.path(), "pre-commit", "#!/bin/sh\nexit 1\n");
+    write_hook(
+        tr.path(),
+        "commit-msg",
+        "#!/bin/sh\nprintf 'REWRITTEN\\n' > \"$1\"\n",
+    );
+    stage(&backend, &handle.id, &tr, "a.txt", "a\n");
+
+    let res = backend
+        .commit(
+            &handle.id,
+            CommitOptions {
+                no_verify: true,
+                ..opts("verbatim subject")
+            },
+        )
+        .expect("no_verify must get past a rejecting hook");
+    assert_eq!(
+        res.message.trim(),
+        "verbatim subject",
+        "no hook touched the message"
+    );
+    assert_eq!(count_commits(&tr), 2);
+}
+
+#[test]
+fn a_failing_post_commit_does_not_fail_the_commit() {
+    // git ignores post-commit's exit code, and so must we: reporting a commit
+    // that EXISTS as failed sends the user hunting for work that already landed.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    write_hook(tr.path(), "post-commit", "#!/bin/sh\necho 'boom'\nexit 9\n");
+    stage(&backend, &handle.id, &tr, "a.txt", "a\n");
+
+    let res = backend
+        .commit(&handle.id, opts("subject"))
+        .expect("post-commit must not be able to fail the commit");
+    assert_eq!(count_commits(&tr), 2);
+    assert_eq!(head_oid(&tr).as_deref(), Some(res.oid.as_str()));
+}
+
+#[test]
+fn a_repo_with_no_hooks_commits_exactly_as_before() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    stage(&backend, &handle.id, &tr, "a.txt", "a\n");
+
+    let res = backend
+        .commit(&handle.id, opts("plain subject"))
+        .expect("commit");
+    assert_eq!(res.message.trim(), "plain subject");
+    assert_eq!(count_commits(&tr), 2);
+}
+
+#[test]
+fn a_rejecting_pre_commit_with_signing_on_signs_nothing() {
+    // Both guarantees at once: the hook creates nothing, and the signing chain
+    // is never reached — so there is no signed-but-unreferenced object either.
+    // Signing is left to fail on purpose (no key configured); the point is that
+    // we never get that far.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    write_hook(tr.path(), "pre-commit", "#!/bin/sh\nexit 1\n");
+    stage(&backend, &handle.id, &tr, "a.txt", "a\n");
+
+    let before = head_oid(&tr);
+    let err = backend
+        .commit(
+            &handle.id,
+            CommitOptions {
+                sign: Some(true),
+                ..opts("subject")
+            },
+        )
+        .expect_err("refused");
+    assert!(
+        matches!(&err, AppError::HookRejected(r) if r.hook == "pre-commit"),
+        "the hook must refuse BEFORE signing is attempted; got {err:?}"
+    );
+    assert_eq!(head_oid(&tr), before);
+    assert_eq!(count_commits(&tr), 1);
+}
+
+#[test]
+fn an_amend_runs_the_hooks_too() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    stage(&backend, &handle.id, &tr, "a.txt", "a\n");
+    backend.commit(&handle.id, opts("original")).expect("commit");
+
+    write_hook(
+        tr.path(),
+        "commit-msg",
+        "#!/bin/sh\nprintf 'AMEND REWRITTEN\\n' > \"$1\"\n",
+    );
+    let res = backend
+        .commit(
+            &handle.id,
+            CommitOptions {
+                amend: true,
+                ..opts("amended by the user")
+            },
+        )
+        .expect("amend");
+
+    assert_eq!(res.message.trim(), "AMEND REWRITTEN");
+    assert_eq!(count_commits(&tr), 2, "an amend replaces, it does not add");
+}

--- a/src-tauri/tests/reflog.rs
+++ b/src-tauri/tests/reflog.rs
@@ -89,6 +89,7 @@ fn read_reflog_classifies_amend_op() {
                 author_override: None,
                 signoff: false,
                 sign: None,
+                no_verify: false,
             },
         )
         .unwrap();

--- a/src-tauri/tests/signing.rs
+++ b/src-tauri/tests/signing.rs
@@ -19,6 +19,7 @@ fn opts(message: &str, sign: Option<bool>) -> CommitOptions {
         author_override: None,
         signoff: false,
         sign,
+        no_verify: false,
     }
 }
 
@@ -104,7 +105,8 @@ fn signed_commit_is_reachable_from_head_and_has_a_gpgsig_header() {
 
     let oid = backend
         .commit(&handle.id, opts("signed", Some(true)))
-        .expect("signed commit");
+        .expect("signed commit")
+        .oid;
 
     // THE trap: commit_signed writes the object but does not move HEAD.
     let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
@@ -171,7 +173,8 @@ fn signed_amend_replaces_head_and_stays_signed() {
                 ..opts("amended", Some(true))
             },
         )
-        .expect("signed amend");
+        .expect("signed amend")
+        .oid;
 
     let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
     assert_eq!(head.id().to_string(), amended, "amend must move HEAD");
@@ -195,7 +198,8 @@ fn unsigned_commit_path_is_unchanged() {
 
     let oid = backend
         .commit(&handle.id, opts("plain", Some(false)))
-        .unwrap();
+        .unwrap()
+        .oid;
 
     let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
     assert_eq!(head.id().to_string(), oid);
@@ -215,7 +219,7 @@ fn sign_none_follows_commit_gpgsign_being_off() {
         .unwrap();
 
     // No commit.gpgsign set → unsigned, and crucially no attempt to run gpg.
-    let oid = backend.commit(&handle.id, opts("plain", None)).unwrap();
+    let oid = backend.commit(&handle.id, opts("plain", None)).unwrap().oid;
     let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
     assert_eq!(head.id().to_string(), oid);
     assert!(head.header_field_bytes("gpgsig").is_err());
@@ -297,7 +301,8 @@ fn verify_commit_grades_our_own_signature_good() {
         .unwrap();
     let oid = backend
         .commit(&handle.id, opts("signed", Some(true)))
-        .expect("signed commit");
+        .expect("signed commit")
+        .oid;
 
     let status = backend.verify_commit(&handle.id, &oid).expect("verify");
     assert_eq!(

--- a/src-tauri/tests/spawn_no_window.rs
+++ b/src-tauri/tests/spawn_no_window.rs
@@ -25,9 +25,13 @@ use std::path::{Path, PathBuf};
 const RAW_SPAWN_ALLOWED: &[(&str, usize, &str)] = &[
     (
         "src/proc.rs",
-        4,
-        "The module that OWNS spawning. Its four constructors are the raw sites: \
-         `program`, `program_async`, and the two `*_keeping_console` exceptions.",
+        5,
+        "The module that OWNS spawning. Four are its constructors: `program`, \
+         `program_async`, and the two `*_keeping_console` exceptions. The fifth \
+         is `probe_login_path`'s login shell (issue 232) — the one child that \
+         must NOT be handed the environment we are trying to replace, which is \
+         why it cannot go through a constructor. It is `#[cfg(not(windows))]`, \
+         so it creates no Windows console either.",
     ),
     (
         "src/detach.rs",

--- a/src-tauri/tests/stage_commit.rs
+++ b/src-tauri/tests/stage_commit.rs
@@ -98,11 +98,12 @@ fn commit_from_staged_changes_advances_head() {
                 author_override: None,
                 signoff: false,
                 sign: None,
+                no_verify: false,
             },
         )
         .expect("commit");
 
-    assert_eq!(oid.len(), 40);
+    assert_eq!(oid.oid.len(), 40);
     let log = backend.log(&handle.id, None, 10).unwrap();
     assert_eq!(log.len(), 2, "should have initial + new commit");
     assert_eq!(log[0].summary, "update readme");
@@ -126,6 +127,7 @@ fn amend_replaces_tip() {
                 author_override: None,
                 signoff: false,
                 sign: None,
+                no_verify: false,
             },
         )
         .unwrap();
@@ -144,6 +146,7 @@ fn amend_replaces_tip() {
                 author_override: None,
                 signoff: false,
                 sign: None,
+                no_verify: false,
             },
         )
         .unwrap();
@@ -171,6 +174,7 @@ fn commit_with_signoff_appends_trailer_from_repo_identity() {
                 author_override: None,
                 signoff: true,
                 sign: None,
+                no_verify: false,
             },
         )
         .expect("commit");
@@ -203,6 +207,7 @@ fn commit_signoff_does_not_duplicate_existing_trailer() {
                 author_override: None,
                 signoff: true,
                 sign: None,
+                no_verify: false,
             },
         )
         .expect("commit");
@@ -230,6 +235,7 @@ fn commit_without_signoff_leaves_message_untouched() {
                 author_override: None,
                 signoff: false,
                 sign: None,
+                no_verify: false,
             },
         )
         .expect("commit");
@@ -256,6 +262,7 @@ fn commit_on_unborn_branch_creates_root() {
                 author_override: None,
                 signoff: false,
                 sign: None,
+                no_verify: false,
             },
         )
         .unwrap();

--- a/src-tauri/tests/support/mod.rs
+++ b/src-tauri/tests/support/mod.rs
@@ -126,6 +126,7 @@ pub fn with_conflicting_merge() -> TempRepo {
                     author_override: None,
                     signoff: false,
                     sign: None,
+                    no_verify: false,
                 },
             )
             .unwrap();
@@ -143,6 +144,7 @@ pub fn with_conflicting_merge() -> TempRepo {
                     author_override: None,
                     signoff: false,
                     sign: None,
+                    no_verify: false,
                 },
             )
             .unwrap();

--- a/src-tauri/tests/verify_commit_no_spawn.rs
+++ b/src-tauri/tests/verify_commit_no_spawn.rs
@@ -87,6 +87,20 @@ fn an_unsigned_commit_is_verified_without_spawning_git() {
             .to_string()
     };
 
+    // A stub on `PATH` only works if children actually inherit this process's
+    // `PATH` — and since issue 232, `proc.rs` PINS a resolved login-shell `PATH`
+    // on every child it constructs, which would send `git` to the real binary
+    // and leave the stub untouched. Pointing `SHELL` at nothing makes the probe
+    // fail, so `child_path()` is `None` and children inherit ours again.
+    //
+    // This must happen BEFORE the first `proc.rs` spawn, because the answer is
+    // cached in a `OnceLock` for the life of the process. That is safe here for
+    // the reason in the module doc: one `#[test]` per binary, so nothing races.
+    //
+    // If a future change gives the probe a static fallback list for when no
+    // shell is available, this stops working and the test needs a real opt-out
+    // rather than a starved probe.
+    std::env::set_var("SHELL", "/nonexistent/pgit-test-shell");
     std::env::set_var("PATH", bindir.path());
 
     // ── the fixture proves itself: a spawn IS observable ─────────────────────

--- a/src/design/hook-output.test.tsx
+++ b/src/design/hook-output.test.tsx
@@ -1,0 +1,114 @@
+// PGHookOutput (#232) — the surface a rejecting hook's output lands on.
+//
+// The contract worth pinning is that EVERY line of a hook's output is reachable.
+// A truncated diagnostic is worse than none: the user acts on what they can see
+// and never learns the third error existed.
+
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { PGHookOutput } from "./hook-output";
+
+const rejection = {
+  hook: "pre-commit",
+  output:
+    "eslint: src/a.ts:12  no-unused-vars\neslint: src/b.ts:40  eqeqeq\n✖ 2 problems",
+};
+
+describe("PGHookOutput", () => {
+  it("names the hook that refused", () => {
+    render(
+      <PGHookOutput
+        rejection={rejection}
+        onDismiss={() => {}}
+        onCommitAnyway={() => {}}
+      />,
+    );
+    expect(screen.getByText(/pre-commit/)).toBeTruthy();
+  });
+
+  it("shows every line of the output, not a preview", () => {
+    render(
+      <PGHookOutput
+        rejection={rejection}
+        onDismiss={() => {}}
+        onCommitAnyway={() => {}}
+      />,
+    );
+    const body = screen.getByTestId("hook-body").textContent ?? "";
+    expect(body).toContain("no-unused-vars");
+    expect(body).toContain("eqeqeq");
+    expect(body).toContain("2 problems");
+  });
+
+  it("collapses and restores the output", async () => {
+    render(
+      <PGHookOutput
+        rejection={rejection}
+        onDismiss={() => {}}
+        onCommitAnyway={() => {}}
+      />,
+    );
+    expect(screen.queryByTestId("hook-body")).toBeTruthy();
+    await userEvent.click(screen.getByTestId("hook-toggle"));
+    expect(screen.queryByTestId("hook-body")).toBeNull();
+    await userEvent.click(screen.getByTestId("hook-toggle"));
+    expect(screen.queryByTestId("hook-body")).toBeTruthy();
+  });
+
+  it("keeps naming the hook while collapsed", async () => {
+    // Collapsing hides the output, not the reason the block is there.
+    render(
+      <PGHookOutput
+        rejection={rejection}
+        onDismiss={() => {}}
+        onCommitAnyway={() => {}}
+      />,
+    );
+    await userEvent.click(screen.getByTestId("hook-toggle"));
+    expect(screen.getByText(/pre-commit/)).toBeTruthy();
+  });
+
+  it("calls onDismiss when dismissed", async () => {
+    const onDismiss = vi.fn();
+    render(
+      <PGHookOutput
+        rejection={rejection}
+        onDismiss={onDismiss}
+        onCommitAnyway={() => {}}
+      />,
+    );
+    await userEvent.click(screen.getByTestId("hook-dismiss"));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("offers committing without hooks", async () => {
+    const onCommitAnyway = vi.fn();
+    render(
+      <PGHookOutput
+        rejection={rejection}
+        onDismiss={() => {}}
+        onCommitAnyway={onCommitAnyway}
+      />,
+    );
+    await userEvent.click(screen.getByTestId("hook-skip"));
+    expect(onCommitAnyway).toHaveBeenCalledOnce();
+  });
+
+  it("says so when the hook printed nothing", () => {
+    // A hook can exit 1 in total silence. An empty box reads as a rendering
+    // bug, so the block states the absence instead.
+    render(
+      <PGHookOutput
+        rejection={{ hook: "commit-msg", output: "" }}
+        onDismiss={() => {}}
+        onCommitAnyway={() => {}}
+      />,
+    );
+    expect(screen.getByText(/commit-msg/)).toBeTruthy();
+    expect(screen.getByTestId("hook-body").textContent).toContain(
+      "printed nothing",
+    );
+  });
+});

--- a/src/design/hook-output.tsx
+++ b/src/design/hook-output.tsx
@@ -1,0 +1,118 @@
+// PGHookOutput (#232) — a git hook's refusal, rendered as output.
+//
+// Why inline and persistent rather than a modal or a toast:
+//
+//   - A modal blocks the very panel it is asking the user to fix. The next
+//     action after "commitlint says your subject is too long" is editing the
+//     subject, which is behind the modal.
+//   - The existing `pgFlash` toast auto-dismisses, so a forty-line eslint dump
+//     would be gone before a slow reader finished it — and it has nowhere to put
+//     forty lines anyway.
+//
+// So the block sits under the message box and stays until dismissed or until
+// the next commit attempt, which is exactly as long as it is useful.
+
+import * as React from "react";
+
+import type { HookRejection } from "@/lib/errors";
+import { PGIcon } from "./icons";
+import { PGButton } from "./primitives";
+
+export function PGHookOutput({
+  rejection,
+  onDismiss,
+  onCommitAnyway,
+}: {
+  rejection: HookRejection;
+  onDismiss: () => void;
+  /**
+   * Retry with hooks off — the in-the-moment half of the escape hatch. Does not
+   * tick the panel's checkbox: this is one commit, not a new default.
+   */
+  onCommitAnyway: () => void;
+}) {
+  const [collapsed, setCollapsed] = React.useState(false);
+  return (
+    <div
+      // The child testids deliberately do NOT start with "hook-output":
+      // WebdriverIO compiles `[data-testid="hook-output"]*=text` to a SUBSTRING
+      // attribute match plus an innermost-only filter, so a child called
+      // `hook-output-body` would satisfy the container's own condition and the
+      // container would silently match nothing. See .claude/skills/e2e-testing.
+      data-testid="hook-output"
+      style={{
+        border: "1px solid var(--border-1)",
+        borderRadius: "var(--r-4)",
+        background: "var(--bg-1)",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "6px 8px",
+        }}
+      >
+        <PGIcon name="warn" />
+        <span style={{ flex: 1, fontSize: "var(--fs-12)", fontWeight: 600 }}>
+          The {rejection.hook} hook rejected this commit
+        </span>
+        <PGButton
+          size="xs"
+          variant="ghost"
+          onClick={() => setCollapsed((c) => !c)}
+          data-testid="hook-toggle"
+        >
+          {collapsed ? "Show" : "Hide"}
+        </PGButton>
+        <PGButton
+          size="xs"
+          variant="ghost"
+          onClick={onDismiss}
+          data-testid="hook-dismiss"
+        >
+          Dismiss
+        </PGButton>
+      </div>
+
+      {!collapsed && (
+        <pre
+          data-testid="hook-body"
+          style={{
+            margin: 0,
+            padding: "6px 8px",
+            maxHeight: 200,
+            overflow: "auto",
+            fontFamily: "var(--font-mono)",
+            fontSize: "var(--fs-11)",
+            // A hook prints preformatted text, but a minified path or a long
+            // rule name must not force the whole panel to scroll sideways.
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+            borderTop: "1px solid var(--border-0)",
+            color: "var(--fg-2)",
+          }}
+        >
+          {/* A hook can refuse in total silence — exit 1, print nothing. Saying
+              so beats an empty box that looks like a rendering bug. */}
+          {rejection.output || "(the hook printed nothing)"}
+        </pre>
+      )}
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          padding: "6px 8px",
+          borderTop: "1px solid var(--border-0)",
+        }}
+      >
+        <PGButton size="xs" onClick={onCommitAnyway} data-testid="hook-skip">
+          Commit without hooks
+        </PGButton>
+      </div>
+    </div>
+  );
+}

--- a/src/design/index.ts
+++ b/src/design/index.ts
@@ -8,6 +8,7 @@ export * from "./context-menu";
 export * from "./dialog";
 export * from "./ui-helpers";
 export * from "./empty-state";
+export * from "./hook-output";
 export * from "./error-boundary";
 export * from "./modal";
 export * from "./use-prevent-browser-context-menu";

--- a/src/features/palette/commands.noVerifyPush.test.ts
+++ b/src/features/palette/commands.noVerifyPush.test.ts
@@ -1,0 +1,76 @@
+// The ACCEPT path of "Push without hooks" (#232), in its own file.
+//
+// `pgConfirm` resolves false with no `<PGDialogHost/>` mounted, so the decline
+// path is free to assert in `commands.test.ts`. Confirming needs the module
+// stubbed — and that stub lives here rather than there so it cannot change the
+// module graph of every other palette test.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/design", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/design")>();
+  return { ...actual, pgConfirm: vi.fn() };
+});
+
+import { pgConfirm } from "@/design";
+import { buildCommands } from "./commands";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import type { BranchInfo } from "@/lib/types";
+
+const mkBranch = (
+  name: string,
+  isHead = false,
+  upstream: string | null = null,
+): BranchInfo => ({
+  name, isHead, isRemote: false, upstream, ahead: 0, behind: 0, tip: "deadbeef",
+  tipTime: 0, isDefault: false,
+});
+
+describe("push without hooks — confirmed", () => {
+  const push = vi.fn();
+
+  beforeEach(() => {
+    push.mockClear();
+    vi.mocked(pgConfirm).mockReset();
+    useRepoStore.setState({
+      current: { id: "r1", path: "/repo", head: "main" },
+      status: [], allFiles: [], branches: [mkBranch("main", true, "origin/main")],
+      tags: [], stashes: [], remotes: [], commits: [],
+      loading: false, error: null, repoState: "Clean",
+      rebaseStatus: { inProgress: false, nextIndex: 0, total: 0, pauseReason: null },
+      activity: {},
+      push,
+    } as never);
+  });
+
+  const item = () =>
+    buildCommands().find((i) => i.id === "action:push-current-no-verify")!;
+
+  it("pushes the UPSTREAM branch with noVerify, and without forcing", async () => {
+    vi.mocked(pgConfirm).mockResolvedValue(true);
+    item().run();
+    // The guard is an async IIFE: let the confirm and the push microtasks land.
+    await vi.waitFor(() => expect(push).toHaveBeenCalled());
+    // "None" matters: skipping hooks must not quietly also force-push.
+    expect(push).toHaveBeenCalledWith("origin", "main", "None", true);
+  });
+
+  it("says in the confirm what will not run", async () => {
+    vi.mocked(pgConfirm).mockResolvedValue(true);
+    item().run();
+    await vi.waitFor(() => expect(pgConfirm).toHaveBeenCalled());
+    const arg = vi.mocked(pgConfirm).mock.calls[0][0] as {
+      body?: string;
+      danger?: boolean;
+    };
+    expect(arg.danger).toBe(true);
+    expect(arg.body).toContain("pre-push");
+  });
+
+  it("pushes nothing when the confirm is declined", async () => {
+    vi.mocked(pgConfirm).mockResolvedValue(false);
+    item().run();
+    await vi.waitFor(() => expect(pgConfirm).toHaveBeenCalled());
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/palette/commands.test.ts
+++ b/src/features/palette/commands.test.ts
@@ -137,6 +137,27 @@ describe("buildCommands", () => {
     expect(push).toHaveBeenCalledWith("origin", "main", "None");
   });
 
+  it("offers a danger-marked push that skips hooks, and refuses without a confirm", () => {
+    // #232: the escape hatch must be per-invocation and VISIBLE. There is no
+    // push dialog to hang a checkbox on, so it is its own command — the shape
+    // force-push already uses.
+    const push = vi.fn();
+    setRepo({ branches: [mkBranch("main", true, "origin/main")] });
+    useRepoStore.setState({ push } as never);
+
+    const item = buildCommands().find(
+      (i) => i.id === "action:push-current-no-verify",
+    );
+    expect(item).toBeTruthy();
+    expect(item!.danger).toBe(true);
+
+    // No <PGDialogHost/> is mounted in this file, so pgConfirm resolves FALSE —
+    // which makes this the decline path, and the safety-critical direction:
+    // an unconfirmed skip must push nothing at all.
+    item!.run();
+    expect(push).not.toHaveBeenCalled();
+  });
+
   it("omits stash-pop when there are no stashes", () => {
     expect(ids()).not.toContain("action:stash-pop-latest");
   });

--- a/src/features/palette/commands.ts
+++ b/src/features/palette/commands.ts
@@ -413,6 +413,38 @@ export function buildCommands(): PaletteItem[] {
             items: remoteItems("push", (r) => guardedForcePush(r, name)),
           })),
     });
+    // Push skipping `pre-push` (#232). A SEPARATE command rather than a toggle,
+    // for the same reason force-push is one: there is no push dialog to hang a
+    // checkbox on, and the escape hatch has to be per-invocation and visible so
+    // nobody skips a team's gate without meaning to. Confirmed, and marked
+    // danger, because the hook it skips is usually the test suite.
+    const guardedNoVerifyPush = (remote: string, branch: string) => {
+      void (async () => {
+        if (
+          !(await pgConfirm({
+            title: `Push ${branch} to ${remote} without hooks?`,
+            body: "Skips this repository's pre-push hook — whatever it checks (tests, lint, protected branches) will not run for this push.",
+            danger: true,
+            confirmLabel: "Push without hooks",
+          }))
+        ) {
+          return;
+        }
+        void repo.push(remote, branch, "None", true);
+      })();
+    };
+    items.push({
+      type: "command", id: "action:push-current-no-verify",
+      search: "Push current branch without hooks no-verify skip pre-push",
+      label: `Push ${name} without hooks`, danger: true,
+      detail: head?.upstream ?? undefined, icon: "push",
+      run: upstream
+        ? direct(() => guardedNoVerifyPush(upstream[0], upstream[1]))
+        : step(() => ({
+            kind: "pick", title: `Push ${name} without hooks to…`,
+            items: remoteItems("push", (r) => guardedNoVerifyPush(r, name)),
+          })),
+    });
   }
 
   // -- branch ops --

--- a/src/features/repo/repoSlice.ts
+++ b/src/features/repo/repoSlice.ts
@@ -37,7 +37,7 @@ import type {
   TagInfo,
 } from "@/lib/types";
 import { LOG_REF_ALL } from "@/lib/types";
-import type { AppError } from "@/lib/errors";
+import type { AppError, HookRejection } from "@/lib/errors";
 import type { RepoActivity } from "./repoActivity";
 
 export const DEFAULT_REBASE_STATUS: RebaseStatus = {
@@ -128,6 +128,15 @@ export interface RepoSlice {
   bisectStatus: BisectStatus;
   /** Active long-running ops keyed by op kind. */
   activity: RepoActivity;
+  /**
+   * The git hook refusal to display, or null (#232).
+   *
+   * Per-repo, and therefore here: a commit rejected by one repository's
+   * `pre-commit` must not show its output in another tab's commit panel. It is
+   * kept out of `error` on purpose — a hook's output needs a surface that
+   * scrolls, and the user is about to act on it rather than dismiss it.
+   */
+  hookRejection: HookRejection | null;
 }
 
 /**
@@ -162,6 +171,7 @@ export function emptySlice(): RepoSlice {
     rebaseStatus: DEFAULT_REBASE_STATUS,
     bisectStatus: DEFAULT_BISECT_STATUS,
     activity: {},
+    hookRejection: null,
   };
 }
 

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import type {
   AuthorOverride,
   BisectMark,
+  CommitResult,
   FileContent,
   FileStatus,
   LogFilter,
@@ -9,9 +10,10 @@ import type {
   RebaseStep,
   RepoHandle,
 } from "@/lib/types";
-import type { AppError } from "@/lib/errors";
+import type { AppError, HookRejection } from "@/lib/errors";
 import {
   dubiousOwnershipPath,
+  isAppError,
   isAuthError,
   isDubiousOwnershipError,
   toAppError,
@@ -243,7 +245,11 @@ interface RepoStoreState extends RepoSlice {
     authorOverride?: AuthorOverride | null,
     /** Sign this commit (#61 D6). null follows commit.gpgsign. */
     sign?: boolean | null,
-  ) => Promise<string | null>;
+    /** Skip every commit-side hook for this commit only (#232). */
+    noVerify?: boolean,
+  ) => Promise<CommitResult | null>;
+  /** Dismiss the hook refusal on display (#232). */
+  clearHookRejection: () => void;
   reset: (target: string, mode: ResetMode) => Promise<void>;
   checkoutBranch: (name: string) => Promise<void>;
   checkoutRef: (reference: string) => Promise<void>;
@@ -293,7 +299,13 @@ interface RepoStoreState extends RepoSlice {
   fetch: (remote: string) => Promise<void>;
   fetchAll: () => Promise<void>;
   pull: (remote: string, branch: string, mode?: PullMode) => Promise<void>;
-  push: (remote: string, branch: string, force?: PushForce) => Promise<void>;
+  push: (
+    remote: string,
+    branch: string,
+    force?: PushForce,
+    /** Skip `pre-push` for this push only (#232). */
+    noVerify?: boolean,
+  ) => Promise<void>;
   // remote management
   addRemote: (name: string, url: string) => Promise<void>;
   removeRemote: (name: string) => Promise<void>;
@@ -871,24 +883,45 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     signoff = false,
     authorOverride = null,
     sign = null,
+    noVerify = false,
   ) {
     const repo = get().current;
     if (!repo) return null;
+    // Clear the previous refusal first: a stale block sitting above a fresh
+    // attempt reads as though the new attempt failed too.
+    setFor(repo.id, { hookRejection: null });
     try {
-      const oid = await commitFn(
+      const result = await commitFn(
         repo.id,
         message,
         amend,
         signoff,
         authorOverride,
         sign,
+        noVerify,
       );
       await get().refreshAll();
-      return oid;
+      return result;
     } catch (e) {
+      // A hook refusal is NOT a banner error. Its output needs a surface that
+      // scrolls, and the user is about to act on it in the panel rather than
+      // dismiss it — so it lands in its own per-repo field.
+      if (isAppError(e) && e.kind === "HookRejected") {
+        // refreshAll regardless: a `pre-commit` hook may have reformatted and
+        // restaged files before refusing, so the lists on screen are stale.
+        await get().refreshAll();
+        setFor(repo.id, { hookRejection: e.message as HookRejection });
+        return null;
+      }
       setErrorFor(repo.id, e);
       return null;
     }
+  },
+
+  clearHookRejection() {
+    const repo = get().current;
+    if (!repo) return;
+    setFor(repo.id, { hookRejection: null });
   },
 
   async checkoutBranch(name) {
@@ -1305,7 +1338,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     );
   },
 
-  async push(remote, branch, force = "None") {
+  async push(remote, branch, force = "None", noVerify = false) {
     const repo = get().current;
     if (!repo) return;
     setActivity("push", `Pushing ${remote}/${branch}…`);
@@ -1313,7 +1346,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await withAuthRetry(
         repo.id,
         async (creds) => {
-          await pushRemote(repo.id, remote, branch, force, creds);
+          await pushRemote(repo.id, remote, branch, force, creds, noVerify);
           await get().refreshAll();
         },
         (e) => setErrorFor(repo.id, e),

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -219,3 +219,46 @@ describe("appErrorMessage", () => {
     expect(appErrorMessage({ code: 7 })).not.toContain(OBJ);
   });
 });
+
+describe("HookRejected (#232)", () => {
+  it("names the hook rather than rendering the struct", () => {
+    const e: AppError = {
+      kind: "HookRejected",
+      message: { hook: "pre-commit", output: "eslint: 2 problems" },
+    };
+    const text = appErrorMessage(e);
+    expect(text).toContain("pre-commit");
+    // The struct must never reach a banner as an object.
+    expect(text).not.toContain("[object Object]");
+  });
+
+  it("keeps the hook's output out of the one-line message", () => {
+    // The output belongs in the dedicated block, not a banner: a forty-line
+    // eslint dump inside a toast is the bug this feature exists to fix.
+    const e: AppError = {
+      kind: "HookRejected",
+      message: { hook: "commit-msg", output: "line1\nline2\nline3" },
+    };
+    expect(appErrorMessage(e)).not.toContain("line2");
+  });
+
+  it("renders safely when the payload has the wrong shape", () => {
+    // A future Rust change that made the payload a plain string must not put
+    // "[object Object]" in front of the user, and must not throw.
+    const e = {
+      kind: "HookRejected",
+      message: "not a struct",
+    } as unknown as AppError;
+    expect(() => appErrorMessage(e)).not.toThrow();
+    expect(appErrorMessage(e)).not.toContain("[object Object]");
+  });
+
+  it("still names the hook when the hook printed nothing", () => {
+    // A hook can exit 1 in silence; the name is then the only clue there is.
+    const e: AppError = {
+      kind: "HookRejected",
+      message: { hook: "pre-commit", output: "" },
+    };
+    expect(appErrorMessage(e)).toContain("pre-commit");
+  });
+});

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -48,7 +48,14 @@ export type AppError =
    */
   | { kind: "LfsUnavailable"; message: string }
   /** An op needed a bisect in progress and found none (#93). */
-  | { kind: "NoBisect"; message?: string };
+  | { kind: "NoBisect"; message?: string }
+  /**
+   * A git hook ran and refused (#232). The payload is a STRUCT, and its
+   * `output` is deliberately NOT rendered into the banner sentence: forty lines
+   * of eslint belong in the dedicated output block, which scrolls. See
+   * `appErrorDetail`.
+   */
+  | { kind: "HookRejected"; message: HookRejection };
 
 /** Which credential the remote is asking for. */
 export type AuthKind = "Https" | "SshPassphrase" | "SshKey";
@@ -57,6 +64,15 @@ export interface AuthChallenge {
   /** Host the credential is for, when git's stderr named one. */
   host: string | null;
   kind: AuthKind;
+}
+
+/**
+ * A hook's refusal (#232). `output` is whatever the hook printed, verbatim —
+ * stdout and stderr both, as git delivers them.
+ */
+export interface HookRejection {
+  hook: string;
+  output: string;
 }
 
 export function isAppError(e: unknown): e is AppError {
@@ -105,6 +121,17 @@ function appErrorDetail(e: AppError): string {
   // prose. Rendered raw, the banner would just read "github.com".
   if (e.kind === "ForgeAuth" && typeof message === "string") {
     return forgeAuthMessage(message);
+  }
+  // HookRejected carries a struct, and its `output` is deliberately dropped
+  // here: the output goes to the block that can scroll, while a banner gets the
+  // sentence naming which hook to go and look at.
+  if (
+    e.kind === "HookRejected" &&
+    typeof message === "object" &&
+    message !== null &&
+    typeof (message as HookRejection).hook === "string"
+  ) {
+    return `The ${(message as HookRejection).hook} hook rejected this commit.`;
   }
   if (e.kind === "BranchExists" && typeof message === "string") {
     return `A local branch named ${message} already exists.`;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -12,6 +12,7 @@ import type {
   ChecksSummary,
   CliShimStatus,
   CommitInfo,
+  CommitResult,
   ConflictSides,
   DiffKind,
   FileContent,
@@ -419,14 +420,20 @@ export async function commit(
    * config; `true`/`false` overrides it for this commit.
    */
   sign: boolean | null = null,
-): Promise<string> {
-  return invoke<string>("commit", {
+  /**
+   * Skip every commit-side hook for this commit only (#232), matching
+   * `git commit --no-verify`. Defaults to running them.
+   */
+  noVerify = false,
+): Promise<CommitResult> {
+  return invoke<CommitResult>("commit", {
     repoId,
     message,
     amend,
     signoff,
     authorOverride,
     sign,
+    noVerify,
   });
 }
 
@@ -856,8 +863,17 @@ export async function push(
   branch: string,
   force: PushForce = "None",
   credentials?: Credentials,
+  /** Skip `pre-push` for this push only (#232). */
+  noVerify = false,
 ): Promise<void> {
-  return invoke<void>("push", { repoId, remote, branch, force, credentials });
+  return invoke<void>("push", {
+    repoId,
+    remote,
+    branch,
+    force,
+    credentials,
+    noVerify,
+  });
 }
 
 // ─── Remote management ───────────────────────────────────────────────────────

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -662,3 +662,15 @@ export interface BisectStatus {
   badCount: number;
   skippedCount: number;
 }
+
+/**
+ * What a commit produced (#232).
+ *
+ * The message comes back because `commit-msg` may **rewrite** it, so what
+ * landed is not necessarily what the user typed — and a panel that keeps showing
+ * the typed version is lying about the repository.
+ */
+export interface CommitResult {
+  oid: string;
+  message: string;
+}

--- a/src/screens/CommitPanel.keyboard.test.tsx
+++ b/src/screens/CommitPanel.keyboard.test.tsx
@@ -142,9 +142,11 @@ describe("CommitPanel keyboard navigation", () => {
           },
         ],
         remotes: [{ name: "origin", url: "/tmp/bare" }],
+        // Returns a CommitResult, not a bare oid (#232): the message comes back
+        // because `commit-msg` may have rewritten it.
         commit: async (m: string, amend?: boolean, signoff?: boolean) => {
           commitCalls.push([m, !!amend, !!signoff]);
-          return "oid123";
+          return { oid: "oid123", message: m };
         },
         push: async (remote: string, branch: string) => {
           pushCalls.push([remote, branch]);

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -18,6 +18,7 @@ import {
   PGTextarea,
   fileMenuItems,
   multiFileMenuItems,
+  PGHookOutput,
   pgConfirm,
   pgFlash,
   pgPrompt,
@@ -129,6 +130,8 @@ export function CommitPanelScreen() {
   const unstage = useRepoStore((s) => s.unstage);
   const commitAction = useRepoStore((s) => s.commit);
   const pushAction = useRepoStore((s) => s.push);
+  const hookRejection = useRepoStore((s) => s.hookRejection);
+  const clearHookRejection = useRepoStore((s) => s.clearHookRejection);
   const activity = useRepoStore((s) => s.activity);
   const commits = useRepoStore((s) => s.commits);
   const setNavIntent = useNavStore((s) => s.setIntent);
@@ -152,6 +155,10 @@ export function CommitPanelScreen() {
   // Signing (#61 D6). null = follow the setting, which itself defaults to
   // following commit.gpgsign; a per-commit toggle overrides just this commit.
   const [signOverride, setSignOverride] = React.useState<boolean | null>(null);
+  // Skip hooks for this commit only (#232). Never persisted: a "skip once" that
+  // quietly becomes "never run hooks again" is a worse version of the bug that
+  // running hooks fixes.
+  const [noVerify, setNoVerify] = React.useState(false);
   const signSetting = useSettingsStore((s) => s.signCommits);
   const signForCommit =
     signOverride ??
@@ -1018,29 +1025,33 @@ export function CommitPanelScreen() {
   // the message/staged state — key auto-repeat (holding ⌘↵) and double-taps
   // both re-dispatch the chord while canCommit is still true.
   const committingRef = React.useRef(false);
-  const doCommit = async (): Promise<string | null> => {
+  const doCommit = async (skipHooks = noVerify): Promise<string | null> => {
     if (committingRef.current) return null;
     committingRef.current = true;
     try {
       const full = buildMessage(message, coAuthorTrailers(coAuthors));
-      const oid = await commitAction(
+      const result = await commitAction(
         full,
         amend,
         signoff,
         authorIdentity,
         signForCommit,
+        skipHooks,
       );
-      if (oid) {
+      if (result) {
         setMessage("");
         setAmend(false);
         draftRef.current = null;
         // Per-commit signing override is not sticky: it is an override, and
         // carrying it silently into the next commit would surprise.
         setSignOverride(null);
+        // Same reasoning for skipping hooks — and more sharply, because a
+        // sticky one would silently disable a team's gates from then on.
+        setNoVerify(false);
         // Attribution is sticky: pairing usually spans several commits, so
         // clearing it after each one would mean retyping every time.
       }
-      return oid;
+      return result?.oid ?? null;
     } finally {
       committingRef.current = false;
     }
@@ -1058,7 +1069,7 @@ export function CommitPanelScreen() {
       void doCommit();
       return true;
     },
-    [canCommit, message, amend, signoff, authorIdentity, coAuthors],
+    [canCommit, message, amend, signoff, authorIdentity, coAuthors, noVerify],
   );
   useAction(
     "commit.commitAndPush",
@@ -1076,6 +1087,8 @@ export function CommitPanelScreen() {
       coAuthors,
       headBranch,
       defaultRemote,
+      // Without this the chord commits with the PREVIOUS value of the toggle.
+      noVerify,
     ],
   );
   // Checking amend pulls HEAD's message into the box (that's the message being
@@ -1127,7 +1140,17 @@ export function CommitPanelScreen() {
 
   // A clean tree still has one thing worth doing: fixing the message of the
   // commit that just landed. Checking amend brings the composer back.
-  if (!loading && staged.length === 0 && unstaged.length === 0 && !amend) {
+  // `!hookRejection` is part of the condition on purpose: a `pre-commit` hook
+  // that reformats and restages can leave the tree clean while its refusal is
+  // still the most important thing on screen. Without this the block would be
+  // unmounted by the very hook that produced it.
+  if (
+    !loading &&
+    staged.length === 0 &&
+    unstaged.length === 0 &&
+    !amend &&
+    !hookRejection
+  ) {
     return (
       <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
         <PGEmpty
@@ -1568,6 +1591,22 @@ export function CommitPanelScreen() {
             />
           </div>
 
+          {/*
+            A hook's refusal (#232), between the message box and the toggles —
+            next to the message it is usually complaining about. Persists until
+            dismissed or until the next attempt clears it, because the user is
+            about to act on it rather than acknowledge it.
+          */}
+          {hookRejection && (
+            <PGHookOutput
+              rejection={hookRejection}
+              onDismiss={clearHookRejection}
+              // Retry with hooks off. Deliberately does NOT tick the checkbox:
+              // this is one commit, not a new default.
+              onCommitAnyway={() => void doCommit(true)}
+            />
+          )}
+
           <div
             style={{
               display: "flex",
@@ -1610,6 +1649,21 @@ export function CommitPanelScreen() {
                     ? "Sign this commit"
                     : "Don't sign this commit"
               }
+            />
+            {/*
+              Skip hooks (#232). Visible rather than hidden away, so a user with
+              a slow hook can opt out on purpose — and so nobody skips hooks
+              without knowing they did. Not sticky: cleared after every commit.
+            */}
+            <PGCheckbox
+              checked={noVerify}
+              onChange={setNoVerify}
+              label={
+                <span title="Run no pre-commit, prepare-commit-msg, commit-msg or post-commit hook. Equivalent to `git commit --no-verify`.">
+                  Skip hooks for this commit
+                </span>
+              }
+              testId="commit-no-verify"
             />
           </div>
 


### PR DESCRIPTION
Closes #232.

Committing ran **no hooks at all** while pushing ran `pre-push` — so a repository with husky, lefthook, `pre-commit` or commitlint was enforced on push and silently bypassed on commit, with nothing in the UI saying so.

## Approach

`pre-commit`, `prepare-commit-msg`, `commit-msg` and `post-commit` now run around the libgit2 commit.

The issue offered shelling out to `git commit` as an alternative. It loses: `git commit -S` signs through git's own `gpg.program`, standing up a **second signing chain** beside `libgit2.rs::sign_payload`, and CLAUDE.md's one-signing-chain rule exists because two chains drift into a commit the user believes is signed. So the commit stays libgit2's and a new `git/hooks.rs` wraps it.

Hooks run via **`git hook run`** rather than executing the scripts ourselves — that avoids reimplementing `core.hooksPath`, the executable bit, and the one that silently breaks Windows: running the script through git's bundled `sh`. Every claim about git's contract here was probed in a scratch repo rather than taken from the docs, which corrected one wrong assumption (an amend passes source `message` with two arguments, not `commit` with a SHA).

Support is **detected, not inferred from a version string**: `git hook run --ignore-missing <a-hook-name-that-cannot-exist>` exits 0 on a git that has the subcommand and non-zero on one that does not, with no side effects. Ubuntu 22.04 LTS still ships git 2.34, so there is a Unix-only direct-exec fallback.

## Three findings only the tests produced

- **`index.read(false)` is load-bearing, not hygiene.** Moving the index read after `pre-commit` was not enough — the first run of `a_pre_commit_that_restages_is_honoured` committed `unfixed`. `with_repo` hands back a *cached* `git2::Repository` whose index libgit2 keeps in memory, so the read still returned the pre-hook snapshot: a lint-staged hook that reformats and restages would have silently committed the unformatted content.
- **The `PATH` fix must be a union, login-shell first.** Measured: `Command::env("PATH", …)` governs where the child *binary itself* is looked up and uses only that value, never the parent's. Assigning the login `PATH` verbatim would have broken `Command::new("git")` for anyone whose login `PATH` lacks git's directory — a regression caused by the fix.
- **Pinning `PATH` for children means a runtime `PATH` change no longer reaches them.** That is the point, but `tests/verify_commit_no_spawn.rs` stubs `git` exactly that way; it now starves the probe instead, with a comment.

A mutation check also showed that what protects the non-executable-hook case is git returning exit 0, not our `ran &&` guard — so the test now pins *that* invariant (a skipped hook reports code 0) rather than an expression that can be removed with no effect.

## Behaviour

- A non-zero `pre-commit`, `prepare-commit-msg` or `commit-msg` **creates no object and moves no reference**, mirroring the signing chain. The index is deliberately not rolled back: a hook that restaged did work the user wants, and git does not undo it either.
- `post-commit`'s exit code is discarded, because git discards it.
- `commit` returns `CommitResult { oid, message }` — `commit-msg` may rewrite the message, and a panel showing the typed version would be lying about the repository.
- Sign-off is applied before any hook sees the message, matching `git commit -s` (verified).

## The escape hatch, in both places the issue asks for

- Commit: a non-sticky checkbox, plus **Commit without hooks** on the refusal itself.
- Push: a confirmed, danger-marked **Push \<branch\> without hooks** palette command, following the shape force-push already uses (there is no push dialog to hang a checkbox on). It pushes with `PushForce::None` — skipping hooks must not quietly also force.

Never persisted: a "skip once" that becomes "never run hooks again" is a worse version of this bug.

## Hook output

Renders inline in the commit panel — not in the flash toast, which auto-dismisses and cannot hold forty lines of eslint, and not in a modal, which would block the panel it is asking the user to fix. `AppError::HookRejected` carries the hook name and its output as separate fields so the output renders as output. It is per-repo state on `RepoSlice`, so switching tabs cannot carry one repository's rejected commit into another's panel.

## Verification

- `cargo test` — **731 passed**, 0 failures, 0 new warnings
- `pnpm test` — **1903 passed** (221 files)
- `pnpm tsc --noEmit` and `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — clean
- `pnpm test:e2e:docker full --spec e2e/specs/commit.e2e.ts` — **3 passing**, including the new rejecting-`pre-commit` case, 0 stalled driver scripts

## Still needs a human

Decision 8's `PATH` fix is only really proven from a **Dock/Finder launch** with a hook shelling out to a version-managed `node`. No automated layer here reproduces it — every test harness already has a terminal's environment. Flagged in the spec and the plan's final checklist.

Spec and plan: `docs/superpowers/specs/2026-08-26-commit-hooks-spec.md`, `docs/superpowers/plans/2026-08-26-commit-hooks-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
