### PR TITLE
fix(net): cancel a running clone, fetch, pull or push

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -16,6 +16,13 @@ opener.rs        URLs/paths → OS default handler. SECURITY-critical: safe_url
 update.rs        Update discovery: semver compare, dev-build (0.0.0) short-circuit
                  before any network call, GitHub release parsing, ureq w/ timeout +
                  https_only. Logic only — handlers live in commands/update.rs
+cancel.rs        Cancelling an in-flight network git subprocess (#234). A
+                 process-wide registry keyed by SCOPE (the clone / one
+                 repository), not by op id — the auto-fetch pile has no id a
+                 user could point at. Registered at the two choke points every
+                 network op already goes through (create::run_clone,
+                 net::run_git_authenticated), so a new network op inherits
+                 cancellation with nothing to remember. See backend.md
 proc.rs          THE only sanctioned child-process spawner (issue 172):
                  git / git_async / git_async_in (CREATE_NO_WINDOW,
                  GIT_TERMINAL_PROMPT=0, stdin closed), program / program_async,
@@ -146,9 +153,10 @@ commands/        Thin Tauri handlers, one file per area:
 │                create/delete/push_tag, verify_tag, merge_branch, rebase_onto,
 │                checkout_ref, push_delete_branch
 ├── net.rs       Shared network plumbing (Credentials, run_git_authenticated,
-│                apply_auth_env, map_git_failure, credential_approve) + ONE
-│                command, remember_credential — stored only after the credential
-│                worked. See backend.md
+│                apply_auth_env, map_git_failure, credential_approve) + TWO
+│                commands: remember_credential — stored only after the
+│                credential worked — and cancel_network_op, which stops a
+│                stalled clone/fetch/pull/push (#234). See backend.md
 ├── update.rs    check_for_update, get_update_capability, open_url — thin
 │                handlers for src-tauri/src/update.rs (same basename, two files)
 ├── history.rs   reset, cherry_pick, revert

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -167,6 +167,44 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   them — the credential protocol is line-based, so a newline injects keys and
   could file a password against another host.
 
+### Cancelling a stalled network op (#234)
+
+- **One cancel path, at the same two choke points as the credential policy.**
+  `cancel.rs` is a process-wide registry; `run_git_authenticated` and
+  `run_clone` each register for as long as they run, so a network op that uses
+  the one runner inherits cancellation with nothing to remember. A second spawn
+  site would be an op nobody can stop, the same way it would be an op nobody can
+  authenticate.
+- **Registered by SCOPE, not by op id** — `Scope::Clone`, or
+  `Scope::Repo(workdir)`. The UI has one of these in flight per scope by
+  construction (`busy`, `activity`), and the auto-fetch timer's stacked fetches
+  are ops the user never started and cannot point at; cancelling a scope reaches
+  the whole pile. `Scope::Repo`'s path comes from `GitBackend::repo_path`, which
+  is where the ops themselves get their `cwd` and where `cancel_network_op`
+  resolves a `repo_id` — **the three must keep agreeing** or Cancel silently
+  matches nothing.
+- **`AppError::Cancelled`, never `Network`.** A SIGKILLed git's dying stderr
+  says "early EOF" / "the remote end hung up unexpectedly"; routed through
+  `Network`, a user who pressed Cancel is told their connection broke. The
+  frontend drops it in `useRepoStore`'s `setErrorFor` (one place, so a network op
+  added later cannot forget) and in `useCreateStore`'s clone catch.
+- **Check `is_cancelled()` after the child exits, not just in the `select!`.**
+  A cancel landing as git dies of its own accord loses the race, and the request
+  is what decides the outcome, not who got there first.
+- **A cancelled clone removes its partial destination**, and puts back an empty
+  directory the user had picked. A SIGKILLed `git clone` cannot run its own
+  cleanup, and the leftovers fail the NEXT attempt's `validate_clone_target`
+  with "already exists and is not empty" — a cancel button whose real effect is
+  to poison the destination. Safe to delete only because `validate_clone_target`
+  already refused anything but "absent" or "empty": kill and **reap** first
+  (`kill_and_reap`), so git is provably not still writing into it.
+- **What it does not kill:** git's own transport helper (`git-remote-https`,
+  `ssh`). It is git's child, not ours, and a SIGKILLed parent cannot take it
+  along; it exits when its pipes close, which for a helper blocked on a network
+  read means when that read times out. Closing that gap means killing the process
+  group — a platform-specific kill path through the one sanctioned spawner —
+  and is deliberately not done. The user-visible hang is gone either way.
+
 ## Signing: one chain for commits and tags (#61 D6, #132)
 
 - **One chain, two callers:** `libgit2.rs::sign_payload` =

--- a/src-tauri/src/cancel.rs
+++ b/src-tauri/src/cancel.rs
@@ -1,0 +1,255 @@
+//! Cancelling an in-flight network git subprocess (#234).
+//!
+//! Before this module a clone, fetch, pull or push that hung could only be
+//! escaped by force-quitting the app — `run_clone` said so in a comment, and
+//! `run_git_authenticated` simply awaited `output()` forever.
+//!
+//! ## The shape
+//!
+//! Cancellation is registered at the two choke points every network op already
+//! goes through — `commands::create::run_clone` and
+//! `commands::net::run_git_authenticated` — rather than per command. That is the
+//! same reason the credential policy lives in one place: a second cancel path
+//! would be a network op nobody can stop. A new network op inherits
+//! cancellation by using `run_git_authenticated`, with nothing to remember.
+//!
+//! ## Scope, not op id
+//!
+//! An op is registered under a [`Scope`] — "the clone", or "this repository" —
+//! not under an id the frontend minted. Two reasons:
+//!
+//! * The UI already has exactly one of these in flight per scope: the Clone
+//!   dialog is `busy`-gated, and the Fetch/Pull/Push buttons carry a `loading`
+//!   spinner keyed on `activity`. There is nothing finer for a user to point at.
+//! * The auto-fetch timer can stack fetches behind a stalled one, and those are
+//!   ops the user never started and has no id for. Cancelling a *scope* reaches
+//!   the whole pile; cancelling an id would leave it.
+//!
+//! So `cancel(Scope::Repo(path))` stops every network op running on that
+//! repository, which is what "Cancel" next to a stuck status line has to mean.
+//!
+//! ## What killing actually kills
+//!
+//! Both call sites spawn with `kill_on_drop(true)` and, for the clone, an
+//! explicit `start_kill()` + reap before the partial directory is removed.
+//! That kills the `git` process we spawned. Git's transport helper
+//! (`git-remote-https`, `ssh`) is git's own child, and a SIGKILL'd parent
+//! cannot take it with it — the helper exits when its pipes close, which for a
+//! helper blocked on a network read means when that read finally times out.
+//! Killing the whole process group would close that gap; it also means a
+//! platform-specific kill path through the one sanctioned spawner, so it is
+//! deliberately not done here. The user-visible hang — an app with no way out —
+//! is gone either way.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use tokio::sync::watch;
+
+/// What a cancellation request addresses.
+///
+/// Deliberately coarse — see the module docs. `Clone` has no repository yet
+/// (that is the whole point of a clone), so it cannot be a `Repo`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Scope {
+    /// The clone the Clone dialog is running. One at a time by construction.
+    Clone,
+    /// Every network op running on the repository at this working-directory
+    /// path. The path comes from `GitBackend::repo_path`, which is also where
+    /// the ops themselves get their `cwd` — the two must keep agreeing, or a
+    /// cancel would silently match nothing.
+    Repo(PathBuf),
+}
+
+impl Scope {
+    /// The scope for a network op running in `cwd`.
+    pub fn repo(cwd: &Path) -> Self {
+        Scope::Repo(cwd.to_path_buf())
+    }
+}
+
+/// The receiving half handed to a running op.
+///
+/// Cloneable and cheap; `cancelled()` resolves once and stays resolved, so an
+/// op may await it in several places (a read loop, then the final `wait`)
+/// without arming anything twice.
+#[derive(Debug, Clone)]
+pub struct CancelToken {
+    rx: watch::Receiver<bool>,
+}
+
+impl CancelToken {
+    /// Resolves when this op has been cancelled, and never otherwise.
+    ///
+    /// A `watch` receiver errors when every sender is gone. That means "nothing
+    /// can ever cancel this op", which must NOT read as "cancelled" — a spurious
+    /// resolve here would kill a healthy clone. The [`Registration`] holds a
+    /// sender for as long as the op runs, so the error branch is unreachable in
+    /// practice; it parks forever rather than trusting that.
+    pub async fn cancelled(&mut self) {
+        if self.rx.wait_for(|v| *v).await.is_err() {
+            std::future::pending::<()>().await;
+        }
+    }
+
+    /// Whether cancellation has already been requested, without awaiting.
+    ///
+    /// The call sites use this after the child has exited: a `select!` can lose
+    /// the race when git dies of its own accord at the same moment, and a
+    /// cancelled op must report `Cancelled` rather than whatever git's dying
+    /// stderr happened to say.
+    pub fn is_cancelled(&self) -> bool {
+        *self.rx.borrow()
+    }
+}
+
+/// A live op's entry in the registry. Removed on drop, so a finished op cannot
+/// be "cancelled" into a later, unrelated one.
+#[derive(Debug)]
+pub struct Registration {
+    id: u64,
+    /// Kept so the sender outlives the op — see [`CancelToken::cancelled`].
+    _tx: Arc<watch::Sender<bool>>,
+}
+
+impl Drop for Registration {
+    fn drop(&mut self) {
+        let mut live = registry().lock().unwrap_or_else(|e| e.into_inner());
+        live.retain(|e| e.id != self.id);
+    }
+}
+
+#[derive(Debug)]
+struct Entry {
+    id: u64,
+    scope: Scope,
+    tx: Arc<watch::Sender<bool>>,
+}
+
+fn registry() -> &'static Mutex<Vec<Entry>> {
+    static REGISTRY: OnceLock<Mutex<Vec<Entry>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Announce a network op as cancellable, until the returned guard is dropped.
+///
+/// A `Vec` and not a map: this holds the ops in flight right now — a handful at
+/// the very worst — and a scope legitimately has several entries (the auto-fetch
+/// pile the module docs describe), which a keyed map would have had to model
+/// anyway.
+pub fn register(scope: Scope) -> (Registration, CancelToken) {
+    static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    let (tx, rx) = watch::channel(false);
+    let tx = Arc::new(tx);
+    registry()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .push(Entry {
+            id,
+            scope,
+            tx: Arc::clone(&tx),
+        });
+    (Registration { id, _tx: tx }, CancelToken { rx })
+}
+
+/// Cancel every op registered under `scope`. Answers how many were signalled,
+/// which is 0 when nothing was running — not an error: the op can simply have
+/// finished between the user reading the status line and clicking Cancel.
+pub fn cancel(scope: &Scope) -> usize {
+    let live = registry().lock().unwrap_or_else(|e| e.into_inner());
+    let mut signalled = 0;
+    for entry in live.iter().filter(|e| &e.scope == scope) {
+        // A send failure means every receiver is gone, i.e. the op is already
+        // unwinding. Still counts as handled from the caller's point of view.
+        let _ = entry.tx.send(true);
+        signalled += 1;
+    }
+    signalled
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The registry is process-wide and `cargo test` runs these in parallel, so
+    /// every test below addresses a scope only it names. `Scope::Clone` is the
+    /// one scope that cannot be made unique — it is a unit variant — so the two
+    /// tests that touch it serialize here instead. Without this, one test's
+    /// `cancel(&Scope::Clone)` reaches the other's token and both are flaky.
+    fn clone_scope_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: Mutex<()> = Mutex::new(());
+        LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[test]
+    fn cancel_signals_a_registered_op() {
+        let scope = Scope::repo(Path::new("/tmp/signal-one"));
+        let (_guard, token) = register(scope.clone());
+        assert!(!token.is_cancelled());
+        assert_eq!(cancel(&scope), 1);
+        assert!(token.is_cancelled());
+    }
+
+    #[test]
+    fn a_clone_is_cancellable_without_a_repository() {
+        let _serialized = clone_scope_lock();
+        let (_guard, token) = register(Scope::Clone);
+        assert_eq!(cancel(&Scope::Clone), 1);
+        assert!(token.is_cancelled());
+    }
+
+    #[test]
+    fn dropping_the_guard_deregisters() {
+        let (guard, _token) = register(Scope::repo(Path::new("/tmp/deregister")));
+        drop(guard);
+        assert_eq!(cancel(&Scope::repo(Path::new("/tmp/deregister"))), 0);
+    }
+
+    #[test]
+    fn scopes_do_not_bleed_into_each_other() {
+        let (_a, token_a) = register(Scope::repo(Path::new("/tmp/a")));
+        let (_b, token_b) = register(Scope::repo(Path::new("/tmp/b")));
+
+        assert_eq!(cancel(&Scope::repo(Path::new("/tmp/b"))), 1);
+
+        assert!(!token_a.is_cancelled(), "/tmp/a must be untouched");
+        assert!(token_b.is_cancelled());
+    }
+
+    /// The auto-fetch pile: several ops share one scope, and Cancel has to
+    /// reach all of them or the stalled one nobody can see stays stalled.
+    #[test]
+    fn one_cancel_reaches_every_op_in_the_scope() {
+        let path = Path::new("/tmp/pile");
+        let (_g1, t1) = register(Scope::repo(path));
+        let (_g2, t2) = register(Scope::repo(path));
+        let (_g3, t3) = register(Scope::repo(path));
+
+        assert_eq!(cancel(&Scope::repo(path)), 3);
+
+        assert!(t1.is_cancelled() && t2.is_cancelled() && t3.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn cancelled_resolves_after_the_signal_and_stays_resolved() {
+        let (_guard, mut token) = register(Scope::repo(Path::new("/tmp/await")));
+        cancel(&Scope::repo(Path::new("/tmp/await")));
+        // Both awaits must return; a second one that parked would hang the
+        // `select!` in `run_clone`'s final `wait`.
+        token.cancelled().await;
+        token.cancelled().await;
+    }
+
+    /// A clone's scope must not be cancelled by a repo op — cancelling a fetch
+    /// on some open repository cannot take the Clone dialog's clone with it.
+    #[test]
+    fn a_repo_cancel_leaves_the_clone_alone() {
+        let _serialized = clone_scope_lock();
+        let (_c, clone_token) = register(Scope::Clone);
+        let (_r, _repo_token) = register(Scope::repo(Path::new("/tmp/other")));
+        cancel(&Scope::repo(Path::new("/tmp/other")));
+        assert!(!clone_token.is_cancelled());
+    }
+}

--- a/src-tauri/src/commands/create.rs
+++ b/src-tauri/src/commands/create.rs
@@ -241,6 +241,11 @@ pub async fn run_clone(
     }
 
     let target = validate_clone_target(parent, name)?;
+    // Whether the destination was the user's own (empty) directory or something
+    // only git is about to create. `validate_clone_target` has just guaranteed
+    // it is one of those two, which is what makes the cancel cleanup below safe
+    // to do at all — see `cancelled_clone`.
+    let target_preexisted = target.is_dir();
     let args = clone_args(url, name, recurse_submodules);
 
     // `git_async_in` and not `git_async`: a clone's working directory is the
@@ -249,24 +254,31 @@ pub async fn run_clone(
     let mut cmd = crate::proc::git_async_in(parent);
     cmd.args(&args)
         // Never let the child read from our stdin. Nothing in this codebase
-        // feeds it anything, so an unexpected read would just block forever
-        // — and a clone has no cancel button, so a hang here is force-quit
-        // territory rather than something the user can dismiss.
+        // feeds it anything, so an unexpected read would just block forever.
+        // There is a cancel button now (#234), so such a hang is escapable —
+        // but a clone that silently waits on input nobody will ever type is
+        // still not a state worth being able to reach.
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
-        // If reading stderr below bails out via `?`, or this future is
-        // dropped (e.g. the window closes mid-clone — there is no cancel
-        // button), `child` is dropped without ever being `.wait()`ed. Without
-        // this, git keeps running to completion in the background and
-        // finishes populating the destination the frontend was told never
-        // got created.
+        // If reading stderr below bails out via `?`, or this future is dropped
+        // (the window closing mid-clone), `child` is dropped without ever being
+        // `.wait()`ed. Without this, git keeps running to completion in the
+        // background and finishes populating the destination the frontend was
+        // told never got created. A user-driven cancel does NOT rely on this —
+        // it kills and reaps explicitly, so the process is provably gone before
+        // the partial directory is removed.
         .kill_on_drop(true);
     // Shared with fetch/pull/push so the env policy cannot drift (#61 D5).
     // With credentials this points askpass at our own executable; without them
     // it is the historical prompt-less policy. Applied after the builder chain
     // so it cannot be silently overridden by one of the calls above.
     crate::commands::net::apply_auth_env(&mut cmd, creds);
+
+    // Registered before the spawn so a cancel arriving in the same tick as the
+    // click cannot slip through the gap and be ignored (#234). The guard
+    // deregisters on every exit path, including the `?`s below.
+    let (_registration, mut cancel) = crate::cancel::register(crate::cancel::Scope::Clone);
 
     let mut child = cmd
         .spawn()
@@ -293,10 +305,25 @@ pub async fn run_clone(
     const MAX_PENDING: usize = 4096;
 
     loop {
-        let read = stderr
-            .read(&mut chunk)
-            .await
-            .map_err(|e| AppError::Io(format!("reading git clone output: {e}")))?;
+        // Where a stalled clone actually sits: git has the connection open and
+        // is saying nothing, so this read never completes. Selecting on the
+        // cancel token here is what turns "force-quit the app" into a button
+        // (#234). `stderr` was `take()`n off the child, so borrowing `child`
+        // mutably in the cancel arm is not a conflict.
+        let read = tokio::select! {
+            // `biased` so a pending cancel always beats a ready read. Without
+            // it `select!` picks at random, and a fast-streaming clone would
+            // keep winning the coin toss for an unbounded number of iterations
+            // after the user had already pressed Cancel.
+            biased;
+            _ = cancel.cancelled() => {
+                kill_and_reap(&mut child).await;
+                return Err(cancelled_clone(&target, target_preexisted).await);
+            }
+            r = stderr.read(&mut chunk) => {
+                r.map_err(|e| AppError::Io(format!("reading git clone output: {e}")))?
+            }
+        };
         if read == 0 {
             break;
         }
@@ -316,10 +343,26 @@ pub async fn run_clone(
         handle_clone_line(&pending, &mut on_progress, &mut tail);
     }
 
-    let status = child
-        .wait()
-        .await
-        .map_err(|e| AppError::Io(format!("waiting for git clone: {e}")))?;
+    // Stderr at EOF means git has closed it, which it only does on the way out —
+    // so this rarely waits. Selected on anyway: "rarely" is not "never", and a
+    // clone that hung between its last progress line and exiting would otherwise
+    // be exactly the unkillable one this issue is about.
+    let status = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            kill_and_reap(&mut child).await;
+            return Err(cancelled_clone(&target, target_preexisted).await);
+        }
+        s = child.wait() => s.map_err(|e| AppError::Io(format!("waiting for git clone: {e}")))?,
+    };
+    // The cancel landed while git was already exiting and lost the `select!`
+    // race. It still cancelled: a clone the user asked us to stop is not one to
+    // hand back and open a tab for, and git's exit status — a success, or the
+    // torn-connection failure our own SIGKILL produced — is not what they should
+    // be told about. `child` is already reaped here, so only the directory goes.
+    if cancel.is_cancelled() {
+        return Err(cancelled_clone(&target, target_preexisted).await);
+    }
     if !status.success() {
         // Routed through the shared classifier so a private repo yields Auth
         // (promptable + retryable) rather than a dead-end Network error, and so
@@ -330,6 +373,51 @@ pub async fn run_clone(
         )));
     }
     Ok(target)
+}
+
+/// Kill a cancelled `git clone` and wait for it to actually be gone (#234).
+///
+/// `kill_on_drop` would eventually do the killing, but "eventually" is the wrong
+/// guarantee here: [`cancelled_clone`] deletes the destination next, and a git
+/// process still writing objects into a directory being deleted is a race with
+/// nothing good on either side of it. Reaping first makes the order provable.
+///
+/// Errors are swallowed on purpose — every one of them means "the process is
+/// already gone", which is the outcome being asked for.
+async fn kill_and_reap(child: &mut tokio::process::Child) {
+    let _ = child.start_kill();
+    let _ = child.wait().await;
+}
+
+/// Remove what a cancelled clone left behind and report the cancellation.
+///
+/// A SIGKILLed `git clone` cannot run its own cleanup, so it leaves a partial
+/// working tree. Left there, the very next attempt fails
+/// `validate_clone_target` with "already exists and is not empty" — a cancel
+/// button whose real effect is to poison the destination.
+///
+/// Safe to delete precisely because `validate_clone_target` ran first and
+/// accepts only two states: nothing there at all, or the user's own EMPTY
+/// directory. Nothing of the user's can be inside it. The empty directory they
+/// picked is put back, because they picked it — only the clone is undone.
+async fn cancelled_clone(target: &Path, target_preexisted: bool) -> AppError {
+    let target = target.to_path_buf();
+    // `spawn_blocking` and not a bare `std::fs` call: a half-finished clone of a
+    // large repository is thousands of unlink syscalls, and doing them on the
+    // async worker would stall every other command in the app behind the cleanup
+    // of the one that was cancelled to unstick it.
+    //
+    // Best-effort throughout: a leftover directory is a worse outcome than a
+    // cancel, but a failure to remove one is not something to report over the
+    // cancel itself — and the retry it breaks says so clearly enough on its own.
+    let _ = tokio::task::spawn_blocking(move || {
+        let _ = std::fs::remove_dir_all(&target);
+        if target_preexisted {
+            let _ = std::fs::create_dir_all(&target);
+        }
+    })
+    .await;
+    AppError::Cancelled
 }
 
 /// Build the `AppError::Network` message for a failed `git clone`. Falls back

--- a/src-tauri/src/commands/net.rs
+++ b/src-tauri/src/commands/net.rs
@@ -88,6 +88,13 @@ pub fn map_git_failure(stderr: &str) -> AppError {
 }
 
 /// Run `git -C cwd <args>`, mapping a non-zero exit through `map_git_failure`.
+///
+/// Cancellable (#234): the op registers under `cancel::Scope::Repo(cwd)` for as
+/// long as it runs, so `cancel_network_op` can stop a fetch, pull or push that
+/// has stalled. Registering HERE and not per command is the same choice the
+/// credential policy makes — a network op that grew its own spawn would be one
+/// nobody can cancel. `cwd` comes from `GitBackend::repo_path`, which is where
+/// `cancel_network_op` resolves its scope from too.
 pub async fn run_git_authenticated(
     cwd: &Path,
     args: &[&str],
@@ -99,15 +106,67 @@ pub async fn run_git_authenticated(
     // pull and push flashed a console, including the ones auto-fetch runs on a
     // timer with no user action at all (issue 172).
     let mut cmd = crate::proc::git_async(cwd);
-    cmd.args(args);
+    cmd.args(args)
+        // `Command::output()` sets these itself; spawning by hand below to keep
+        // the `Child` reachable means setting them here instead.
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        // The kill on cancel: the branch below drops the `wait_with_output`
+        // future, which owns the `Child`, and a dropped `Child` with this set is
+        // a killed process. Also covers the window closing mid-fetch.
+        .kill_on_drop(true);
     apply_auth_env(&mut cmd, creds);
 
-    let output = cmd.output().await.map_err(|e| AppError::Io(e.to_string()))?;
+    let (_registration, mut cancel) = crate::cancel::register(crate::cancel::Scope::repo(cwd));
+
+    let child = cmd.spawn().map_err(|e| AppError::Io(e.to_string()))?;
+    // `wait_with_output` and not two manual pipe reads: it drains stdout and
+    // stderr concurrently, and a fetch whose stderr filled the pipe buffer while
+    // we waited on the exit status would deadlock.
+    let output = tokio::select! {
+        // `biased` so a pending cancel is never lost to a coin toss against a
+        // child that happens to be ready in the same poll.
+        biased;
+        _ = cancel.cancelled() => return Err(AppError::Cancelled),
+        finished = child.wait_with_output() => finished.map_err(|e| AppError::Io(e.to_string()))?,
+    };
 
     if !output.status.success() {
+        // A cancel that lands while git is already dying loses the `select!`
+        // race, and git's last words ("the remote end hung up unexpectedly")
+        // would then be reported as a network failure to a user who pressed
+        // Cancel. The request is what decides, not who got there first.
+        if cancel.is_cancelled() {
+            return Err(AppError::Cancelled);
+        }
         return Err(map_git_failure(&String::from_utf8_lossy(&output.stderr)));
     }
     Ok(())
+}
+
+/// Cancel the network ops running in one scope (#234).
+///
+/// `repo_id` absent means the clone the Clone dialog is running — a clone has no
+/// repository to name yet. Answers how many ops were signalled; zero is a normal
+/// answer, not an error, because the op can finish between the user reading the
+/// status line and clicking Cancel.
+#[tauri::command]
+pub async fn cancel_network_op(
+    state: tauri::State<'_, crate::state::AppState>,
+    repo_id: Option<String>,
+) -> AppResult<usize> {
+    let scope = match repo_id {
+        None => crate::cancel::Scope::Clone,
+        Some(id) => {
+            let backend = state.backend.clone();
+            let id = crate::git::types::RepoId(id);
+            let path = tokio::task::spawn_blocking(move || backend.repo_path(&id))
+                .await
+                .map_err(|e| AppError::Internal(e.to_string()))??;
+            crate::cancel::Scope::Repo(path)
+        }
+    };
+    Ok(crate::cancel::cancel(&scope))
 }
 
 /// Store a credential with the user's own git credential helper (#61 D5).

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -125,6 +125,18 @@ pub enum AppError {
     #[error("no bisect in progress")]
     NoBisect,
 
+    /// The user cancelled a running network op — clone, fetch, pull or push
+    /// (#234). Not a failure: it is the outcome they asked for, so the UI
+    /// clears the spinner and raises no banner.
+    ///
+    /// Distinct from `Network` precisely because of that. A cancelled clone's
+    /// git process is SIGKILLed mid-sentence and its dying stderr says things
+    /// like "early EOF" or "the remote end hung up unexpectedly" — routed
+    /// through `Network` a user who clicked Cancel would be told their
+    /// connection broke.
+    #[error("cancelled")]
+    Cancelled,
+
     /// A git hook ran and refused (#232).
     ///
     /// Carries the hook's NAME and its OUTPUT as separate fields rather than one

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cancel;
 pub mod cli;
 pub mod commands;
 pub mod detach;
@@ -238,6 +239,7 @@ pub fn run() {
             commands::branches::rename_branch,
             commands::branches::set_upstream,
             commands::net::remember_credential,
+            commands::net::cancel_network_op,
             commands::branches::fetch,
             commands::branches::fetch_all,
             commands::branches::pull,

--- a/src-tauri/tests/net_cancel.rs
+++ b/src-tauri/tests/net_cancel.rs
@@ -1,0 +1,226 @@
+//! Cancelling a stalled network op (#234).
+//!
+//! Its own test binary on purpose. The registry in `cancel.rs` is process-wide,
+//! and `Scope::Clone` is a unit variant every clone in the process shares — so a
+//! `cancel(&Scope::Clone)` here, run in parallel with `clone_init.rs`'s clones,
+//! would kill one of those instead and fail a test that has nothing to do with
+//! this feature. Separate binary, separate process, no shared registry.
+//!
+//! The stall is real rather than simulated: a TCP listener that accepts the
+//! connection and then says nothing is exactly the failure the issue names —
+//! "a host that accepts the TCP connection and then stalls" — and it is the one
+//! case a timeout-free `git` will sit in forever. Nothing here touches the
+//! network: the listener is on 127.0.0.1 and answers no HTTP at all.
+
+use std::net::TcpListener;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use platypusgit_lib::cancel::{self, Scope};
+use platypusgit_lib::error::AppError;
+
+/// A listener that accepts connections and then holds them open, silent.
+///
+/// The accepted sockets are parked in a `Vec` rather than dropped: dropping one
+/// closes it, git would see EOF and fail fast, and the test would then be about
+/// a broken connection instead of a stalled one.
+fn stalling_server() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+    let port = listener.local_addr().unwrap().port();
+    std::thread::spawn(move || {
+        let mut held = Vec::new();
+        while let Ok((sock, _)) = listener.accept() {
+            held.push(sock);
+        }
+    });
+    port
+}
+
+/// The two clone tests below serialize here.
+///
+/// Within one binary `cargo test` still runs in parallel, and `Scope::Clone` is
+/// the one scope that cannot be made unique per test — so without this, each
+/// clone test's cancel would reach the other's clone and both would be flaky for
+/// reasons that have nothing to do with the code under test. Repo-scoped tests
+/// need no such thing: each names its own temp path.
+fn clone_scope_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Cancel `scope`, retrying until an op has actually registered under it.
+///
+/// A bare `cancel()` immediately after spawning the op would race its
+/// registration and signal nothing, and the test would then hang on a clone
+/// nobody cancelled — the exact bug it exists to catch, reported as a timeout.
+async fn cancel_when_registered(scope: &Scope) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if cancel::cancel(scope) > 0 {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "no op ever registered under {scope:?} — cancellation is not wired up"
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+#[tokio::test]
+async fn a_stalled_clone_is_cancellable_and_leaves_nothing_behind() {
+    let _serialized = clone_scope_lock();
+    let port = stalling_server();
+    let dest_parent = tempfile::tempdir().unwrap();
+    let parent = dest_parent.path().to_path_buf();
+    let url = format!("http://127.0.0.1:{port}/stalled.git");
+
+    let clone = tokio::spawn(async move {
+        platypusgit_lib::commands::create::run_clone(&url, &parent, "cloned", false, None, |_| {})
+            .await
+    });
+
+    // Long enough for git to have spawned its transport helper and be sitting on
+    // the silent socket, so this cancels a genuinely in-flight clone rather than
+    // one that had not started. `cancel_when_registered` covers the slow machine.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    cancel_when_registered(&Scope::Clone).await;
+
+    let err = tokio::time::timeout(Duration::from_secs(30), clone)
+        .await
+        .expect("the cancelled clone never returned — it is still hanging")
+        .expect("clone task panicked")
+        .expect_err("a cancelled clone must not report success");
+
+    assert!(
+        matches!(err, AppError::Cancelled),
+        "got {err:?}, expected AppError::Cancelled — git's dying stderr must not \
+         be reported to a user who pressed Cancel"
+    );
+    assert!(
+        !dest_parent.path().join("cloned").exists(),
+        "a cancelled clone must not leave a partial destination behind — the next \
+         attempt would fail validate_clone_target with 'already exists and is not empty'"
+    );
+}
+
+/// The destination the user picked is theirs; only the clone is undone.
+#[tokio::test]
+async fn cancelling_puts_back_an_empty_directory_the_user_chose() {
+    let _serialized = clone_scope_lock();
+    let port = stalling_server();
+    let dest_parent = tempfile::tempdir().unwrap();
+    let target = dest_parent.path().join("mine");
+    std::fs::create_dir(&target).unwrap();
+    let parent = dest_parent.path().to_path_buf();
+    let url = format!("http://127.0.0.1:{port}/stalled.git");
+
+    let clone = tokio::spawn(async move {
+        platypusgit_lib::commands::create::run_clone(&url, &parent, "mine", false, None, |_| {})
+            .await
+    });
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    cancel_when_registered(&Scope::Clone).await;
+
+    let err = tokio::time::timeout(Duration::from_secs(30), clone)
+        .await
+        .expect("the cancelled clone never returned")
+        .expect("clone task panicked")
+        .expect_err("a cancelled clone must not report success");
+    assert!(matches!(err, AppError::Cancelled), "got {err:?}");
+
+    assert!(
+        target.is_dir(),
+        "the empty directory the user picked must survive a cancel"
+    );
+    assert_eq!(
+        std::fs::read_dir(&target).unwrap().count(),
+        0,
+        "and it must be empty again, not half a clone"
+    );
+}
+
+#[tokio::test]
+async fn a_stalled_fetch_is_cancellable() {
+    let port = stalling_server();
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().to_path_buf();
+    git(&repo, &["init"]);
+    git(
+        &repo,
+        &["remote", "add", "origin", &format!("http://127.0.0.1:{port}/stalled.git")],
+    );
+
+    let fetching = repo.clone();
+    let fetch = tokio::spawn(async move {
+        platypusgit_lib::commands::net::run_git_authenticated(
+            &fetching,
+            &["fetch", "origin"],
+            None,
+        )
+        .await
+    });
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    // The scope a fetch registers under is its `cwd`, which is what
+    // `cancel_network_op` resolves a repo id to — the two must agree or Cancel
+    // silently matches nothing.
+    cancel_when_registered(&Scope::repo(&repo)).await;
+
+    let err = tokio::time::timeout(Duration::from_secs(30), fetch)
+        .await
+        .expect("the cancelled fetch never returned — it is still hanging")
+        .expect("fetch task panicked")
+        .expect_err("a cancelled fetch must not report success");
+
+    assert!(
+        matches!(err, AppError::Cancelled),
+        "got {err:?}, expected AppError::Cancelled"
+    );
+}
+
+/// Cancelling one repository's fetch must not reach another's.
+#[tokio::test]
+async fn a_cancel_is_scoped_to_the_repository_it_names() {
+    let port = stalling_server();
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().join("mine");
+    std::fs::create_dir(&repo).unwrap();
+    git(&repo, &["init"]);
+    git(
+        &repo,
+        &["remote", "add", "origin", &format!("http://127.0.0.1:{port}/stalled.git")],
+    );
+
+    let fetching = repo.clone();
+    let fetch = tokio::spawn(async move {
+        platypusgit_lib::commands::net::run_git_authenticated(
+            &fetching,
+            &["fetch", "origin"],
+            None,
+        )
+        .await
+    });
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    // A different repository, cancelled while ours is stalled.
+    assert_eq!(cancel::cancel(&Scope::repo(&dir.path().join("someone-else"))), 0);
+    assert!(
+        !fetch.is_finished(),
+        "another repository's cancel stopped this repository's fetch"
+    );
+
+    // Clean up: stop the real one so the test does not leave git hanging.
+    cancel_when_registered(&Scope::repo(&repo)).await;
+    let _ = tokio::time::timeout(Duration::from_secs(30), fetch).await;
+}
+
+fn git(cwd: &Path, args: &[&str]) {
+    let status = std::process::Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .status()
+        .expect("run git");
+    assert!(status.success(), "git {args:?} failed");
+}

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -212,6 +212,12 @@ export function AppShell() {
     if (!repo || !autoFetchEnabled) return;
     const id = window.setInterval(
       () => {
+        // Skip the tick while a fetch is still running (#234). A remote that
+        // stalls outlives the interval, and every tick used to start ANOTHER
+        // `git fetch` against it — a pile of stuck processes the user never
+        // asked for, growing until the app is quit. Nothing is lost by skipping:
+        // the next tick fetches, and a fetch is idempotent.
+        if (useRepoStore.getState().activity.fetch) return;
         useRepoStore.getState().fetchAll();
       },
       Math.max(1, autoFetchMinutes) * 60_000,
@@ -868,7 +874,25 @@ function AppStatusBar() {
           )}
           {loading && !activityLabel && <PGStatusItem icon="sync" label="syncing…" />}
           {activityLabel && (
-            <PGStatusItem icon="sync" label={activityLabel} tone="accent" />
+            <>
+              <PGStatusItem icon="sync" label={activityLabel} tone="accent" />
+              {/*
+                The way out of a stalled fetch, pull or push (#234), and the only
+                one the toolbar's spinning buttons do not offer. It sits beside
+                the label that says what is stuck, because that label is what a
+                user stares at while deciding the app has hung.
+
+                Its own item rather than an onClick on the label: a status line
+                that silently kills the operation when clicked is a trap, and
+                there is nowhere on a bare label to say "Cancel".
+              */}
+              <PGStatusItem
+                icon="x"
+                label="Cancel"
+                tone="danger"
+                onClick={() => void useRepoStore.getState().cancelNetworkOps()}
+              />
+            </>
           )}
         </>
       }

--- a/src/features/create/CloneDialog.test.tsx
+++ b/src/features/create/CloneDialog.test.tsx
@@ -81,6 +81,40 @@ describe("CloneDialog", () => {
     expect(button).not.toBeDisabled();
   });
 
+  // #234 — the Cancel button used to be disabled for exactly as long as the
+  // clone ran, which is the only time a user needs it. A clone against a stalled
+  // host was then escapable only by force-quitting the app.
+  it("offers a live Cancel while the clone runs, and cancels the clone with it", async () => {
+    let cancelled = 0;
+    mockInvoke("cancel_network_op", () => {
+      cancelled += 1;
+      return 1;
+    });
+    useCreateStore.setState({ open: "clone", busy: true, progress: null });
+    render(<CloneDialog />);
+
+    const cancel = screen.getByTestId("clone-cancel");
+    expect(cancel).not.toBeDisabled();
+    // The label carries the difference between the two jobs this button does.
+    expect(cancel).toHaveTextContent("Cancel clone");
+
+    fireEvent.click(cancel);
+
+    await waitFor(() => expect(cancelled).toBe(1));
+    // And it does NOT close the dialog out from under the clone being reaped.
+    expect(useCreateStore.getState().open).toBe("clone");
+  });
+
+  it("closes the dialog with the same button when no clone is running", () => {
+    render(<CloneDialog />);
+
+    const cancel = screen.getByTestId("clone-cancel");
+    expect(cancel).toHaveTextContent("Cancel");
+    fireEvent.click(cancel);
+
+    expect(useCreateStore.getState().open).toBe("none");
+  });
+
   it("renders progress delivered by the clone://progress subscription", async () => {
     useCreateStore.setState({
       open: "clone",

--- a/src/features/create/CloneDialog.tsx
+++ b/src/features/create/CloneDialog.tsx
@@ -16,6 +16,7 @@ export function CloneDialog() {
   const error = useCreateStore((s) => s.error);
   const close = useCreateStore((s) => s.close);
   const runClone = useCreateStore((s) => s.runClone);
+  const cancelClone = useCreateStore((s) => s.cancelClone);
   const setProgress = useCreateStore((s) => s.setProgress);
 
   const [url, setUrl] = React.useState("");
@@ -185,8 +186,22 @@ export function CloneDialog() {
           marginTop: 16,
         }}
       >
-        <PGButton onClick={close} disabled={busy}>
-          Cancel
+        {/*
+          One button, two jobs — and never disabled, which is the point (#234).
+          While a clone runs it stops the clone; otherwise it closes the dialog.
+          Before this it was greyed out for exactly the minutes a user most
+          needs it, and a clone against a stalled host could only be escaped by
+          force-quitting the app.
+
+          Deliberately NOT a second button next to it: a disabled "Cancel" beside
+          a live "Stop" is the arrangement that teaches people the dialog is
+          stuck. The label carries the difference instead.
+        */}
+        <PGButton
+          data-testid="clone-cancel"
+          onClick={() => (busy ? void cancelClone() : close())}
+        >
+          {busy ? "Cancel clone" : "Cancel"}
         </PGButton>
         <PGButton
           variant="primary"

--- a/src/features/create/useCreateStore.cancel.test.ts
+++ b/src/features/create/useCreateStore.cancel.test.ts
@@ -1,0 +1,130 @@
+// Cancelling a running clone (#234).
+//
+// A clone against a host that accepts the connection and then stalls used to be
+// escapable only by force-quitting the app — the Clone dialog's own Cancel
+// button was disabled for exactly as long as the clone ran. These pin the store
+// half of the fix: the cancel is addressed at the clone (not at a repository),
+// the dialog is NOT unlocked until the clone has actually unwound, and a
+// cancelled clone returns to an editable form with no error banner.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useCreateStore } from "./useCreateStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+
+const calls = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+
+beforeEach(() => {
+  resetInvokeMock();
+  useCreateStore.setState({
+    open: "clone",
+    busy: false,
+    progress: null,
+    error: null,
+  });
+});
+
+describe("cancelClone", () => {
+  it("cancels the CLONE, not some repository's ops", async () => {
+    useCreateStore.setState({ busy: true });
+    mockInvoke("cancel_network_op", () => 1);
+
+    await useCreateStore.getState().cancelClone();
+
+    expect(calls("cancel_network_op")).toHaveLength(1);
+    // A clone has no repository yet, and the backend reads a null repoId as
+    // "the clone". Sending an id here would cancel a fetch somewhere instead
+    // and leave the clone running.
+    expect(calls("cancel_network_op")[0].args).toMatchObject({ repoId: null });
+  });
+
+  it("is a no-op when no clone is running", async () => {
+    mockInvoke("cancel_network_op", () => 1);
+
+    await useCreateStore.getState().cancelClone();
+
+    expect(calls("cancel_network_op")).toHaveLength(0);
+  });
+
+  it("leaves the dialog locked until the clone itself unwinds", async () => {
+    useCreateStore.setState({ busy: true });
+    mockInvoke("cancel_network_op", () => 1);
+
+    await useCreateStore.getState().cancelClone();
+
+    // Unlocking here would let a second Clone start into the directory the
+    // first one's cleanup is still deleting. `runClone`'s catch owns this.
+    expect(useCreateStore.getState().busy).toBe(true);
+  });
+
+  it("says so when the cancel could not be signalled", async () => {
+    useCreateStore.setState({ busy: true });
+    mockInvoke("cancel_network_op", () => {
+      throw { kind: "Internal", message: "boom" };
+    });
+
+    await useCreateStore.getState().cancelClone();
+
+    // Staying silent would read as "cancelled" while the user was still stuck
+    // behind an undismissable dialog — the exact dead end being fixed.
+    expect(useCreateStore.getState().error).toBe("boom");
+  });
+});
+
+describe("a cancelled clone", () => {
+  const runCancelledClone = () =>
+    useCreateStore.getState().runClone({
+      url: "https://example.com/repo.git",
+      parentDir: "/tmp",
+      name: "repo",
+      recurseSubmodules: false,
+    });
+
+  beforeEach(() => {
+    mockInvoke("clone_repo", () => {
+      throw { kind: "Cancelled" };
+    });
+  });
+
+  it("returns the dialog to an editable, dismissable state", async () => {
+    await runCancelledClone();
+
+    const s = useCreateStore.getState();
+    expect(s.busy).toBe(false);
+    expect(s.progress).toBeNull();
+    // Still open: the user cancelled the clone, not the dialog. The form keeps
+    // its values so a retry — or a fix to the URL — costs nothing.
+    expect(s.open).toBe("clone");
+  });
+
+  it("raises no error banner", async () => {
+    await runCancelledClone();
+
+    // A cancelled clone's git is SIGKILLed mid-sentence, so its stderr says
+    // things like "early EOF". Reporting that answers the user's own Cancel
+    // click with a failure they did not cause.
+    expect(useCreateStore.getState().error).toBeNull();
+  });
+
+  it("does not open a tab for the clone it threw away", async () => {
+    await runCancelledClone();
+
+    expect(calls("open_repo")).toHaveLength(0);
+  });
+});
+
+it("still reports a clone that genuinely failed", async () => {
+  // The suppression is `kind`-specific, not "clone failures are quiet".
+  mockInvoke("clone_repo", () => {
+    throw { kind: "Network", message: "repository not found" };
+  });
+
+  await useCreateStore.getState().runClone({
+    url: "https://example.com/nope.git",
+    parentDir: "/tmp",
+    name: "nope",
+    recurseSubmodules: false,
+  });
+
+  expect(useCreateStore.getState().error).toBe("repository not found");
+});

--- a/src/features/create/useCreateStore.test.ts
+++ b/src/features/create/useCreateStore.test.ts
@@ -1,9 +1,10 @@
-// Store-logic tests for the busy guard on openClone/openInit: a clone or init
-// in flight has no cancel and its dialog is deliberately non-dismissable, so
-// switching `open` to the other dialog mid-run would unmount the running
-// dialog's view behind a disabled one with a dead backdrop/Escape, and the
-// run's eventual result (including a failure) would land in the wrong
-// dialog's error slot.
+// Store-logic tests for the busy guard on openClone/openInit: a running dialog
+// is deliberately non-dismissable, so switching `open` to the other dialog
+// mid-run would unmount the running dialog's view behind a disabled one with a
+// dead backdrop/Escape, and the run's eventual result (including a failure)
+// would land in the wrong dialog's error slot. A clone can be cancelled now
+// (#234) and the guard matters MORE for it, not less: the cancel button lives
+// in the running dialog, so swapping that dialog away hides the only way out.
 import { describe, it, expect, beforeEach } from "vitest";
 
 import { useCreateStore } from "./useCreateStore";

--- a/src/features/create/useCreateStore.ts
+++ b/src/features/create/useCreateStore.ts
@@ -6,6 +6,7 @@ import { useTabsStore } from "@/features/repo/useTabsStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { useAuthStore } from "@/features/auth/useAuthStore";
 import {
+  cancelNetworkOp,
   cloneRepo,
   closeRepo as closeRepoIpc,
   initRepo,
@@ -18,6 +19,7 @@ import {
   appErrorMessage,
   dubiousOwnershipPath,
   isAuthError,
+  isCancelledError,
   isDubiousOwnershipError,
 } from "@/lib/errors";
 
@@ -32,6 +34,14 @@ interface CreateState {
   openInit: () => void;
   close: () => void;
   setProgress: (p: CloneProgress) => void;
+  /**
+   * Stop the clone in flight (#234). Cheap and idempotent: the running
+   * `runClone` owns the unwind, so this only signals.
+   *
+   * A no-op when nothing is running, so the Cancel button can call it
+   * unconditionally without first re-reading `busy` in the click handler.
+   */
+  cancelClone: () => Promise<void>;
   runClone: (args: {
     url: string;
     parentDir: string;
@@ -51,11 +61,12 @@ export const useCreateStore = create<CreateState>((set, get) => ({
   progress: null,
   error: null,
 
-  // Guarded against `busy`: a clone/init in flight has no cancel, so a chord
-  // or palette command that swaps `open` to the other dialog mid-run would
-  // unmount the running dialog's view behind a disabled, undismissable one —
-  // and once the run finishes, its result (including a failure) would render
-  // into the wrong dialog's error slot.
+  // Guarded against `busy`: a chord or palette command that swaps `open` to the
+  // other dialog mid-run would unmount the running dialog's view behind a
+  // disabled, undismissable one — and once the run finishes, its result
+  // (including a failure) would render into the wrong dialog's error slot. Still
+  // true now that a clone can be cancelled (#234): the cancel affordance is IN
+  // the running dialog, so swapping it away is precisely what hides it.
   openClone: () => {
     if (get().busy) return;
     set({ open: "clone", error: null, progress: null });
@@ -64,13 +75,29 @@ export const useCreateStore = create<CreateState>((set, get) => ({
     if (get().busy) return;
     set({ open: "init", error: null, progress: null });
   },
-  // Never closes mid-run: a clone in flight has no cancel, so dropping the
-  // dialog would leave a git process with no UI attached to it.
+  // Still never closes mid-run, even now that a clone CAN be cancelled (#234):
+  // dropping the dialog while git is being killed and its partial destination
+  // removed would leave that work with no UI attached to it. The dialog closes
+  // itself once `runClone` has unwound — which is a moment later, not never.
   close: () => {
     if (get().busy) return;
     set({ open: "none", error: null, progress: null });
   },
   setProgress: (p) => set({ progress: p }),
+
+  async cancelClone() {
+    if (!get().busy) return;
+    // Nothing is set here: `runClone`'s catch owns the transition back to idle.
+    // Clearing `busy` from here would unlock the dialog while git was still
+    // being reaped, and a second Clone could start into the directory the first
+    // one is in the middle of deleting.
+    await cancelNetworkOp().catch((e) => {
+      // A cancel that could not even be signalled leaves the user stuck with no
+      // way out, which is the whole bug — so it gets said out loud, in the
+      // dialog, where they are looking.
+      set({ error: appErrorMessage(e) });
+    });
+  },
 
   async runClone({ url, parentDir, name, recurseSubmodules }) {
     set({ busy: true, error: null, progress: null });
@@ -92,6 +119,15 @@ export const useCreateStore = create<CreateState>((set, get) => ({
       // clone_repo already takes credentials; without raising the challenge the
       // Clone dialog just printed "Authentication required" with no way to
       // answer it.
+      // A cancel is the outcome the user asked for, so it returns the dialog to
+      // idle with the form intact and NO error — a red banner reading "early
+      // EOF" would answer their own Cancel click with a failure. Everything the
+      // backend does about it (killing git, removing the partial destination)
+      // has already happened by the time this rejects (#234).
+      if (isCancelledError(e)) {
+        set({ busy: false, progress: null, error: null });
+        return;
+      }
       if (!isAuthError(e)) {
         // Error stays in the dialog: the user needs the form still populated to
         // fix a bad URL and retry.
@@ -126,7 +162,11 @@ export const useCreateStore = create<CreateState>((set, get) => ({
             set({
               busy: false,
               progress: null,
-              error: appErrorMessage(retryError),
+              // Same rule as the first attempt: a cancelled retry is not a
+              // failure to report back into the dialog.
+              error: isCancelledError(retryError)
+                ? null
+                : appErrorMessage(retryError),
             });
           }
         },

--- a/src/features/repo/useRepoStore.cancelNetwork.test.ts
+++ b/src/features/repo/useRepoStore.cancelNetwork.test.ts
@@ -1,0 +1,111 @@
+// Cancelling a stalled fetch, pull or push (#234).
+//
+// Before this, a network op that hung had no way out but force-quitting the app.
+// These pin the two halves of the fix that live in the store: the cancel reaches
+// the backend addressed at THIS repository, and a cancelled op unwinds without
+// raising an error banner — a red "early EOF" in answer to the user's own Cancel
+// click is the failure mode worth a test of its own.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { useRepoStore } from "./useRepoStore";
+
+function mockRefreshAll() {
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => null);
+}
+
+const calls = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+const cancelled = () => {
+  throw { kind: "Cancelled" };
+};
+
+beforeEach(() => {
+  resetInvokeMock();
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/tmp/repo-1", head: "main" },
+    error: null,
+    activity: {},
+  });
+  mockRefreshAll();
+  // `pull` auto-stashes first when the setting is on (it is, by default). null
+  // is "the tree was clean", which is the no-op this test wants — the subject
+  // here is the pull's own cancellation, not the stash around it.
+  mockInvoke("stash_save", () => null);
+});
+
+describe("cancelNetworkOps", () => {
+  it("addresses the cancel at the open repository", async () => {
+    mockInvoke("cancel_network_op", () => 1);
+
+    await useRepoStore.getState().cancelNetworkOps();
+
+    expect(calls("cancel_network_op")).toHaveLength(1);
+    // A null repoId means "the clone" on the backend, so sending one here would
+    // cancel the Clone dialog's clone instead of this repository's fetch.
+    expect(calls("cancel_network_op")[0].args).toMatchObject({ repoId: "repo-1" });
+  });
+
+  it("does nothing at all when no repository is open", async () => {
+    useRepoStore.setState({ current: null });
+    mockInvoke("cancel_network_op", () => 1);
+
+    await useRepoStore.getState().cancelNetworkOps();
+
+    expect(calls("cancel_network_op")).toHaveLength(0);
+  });
+
+  it("reports a cancel that could not be signalled", async () => {
+    // Silence here would read as "cancelled" while the user stayed stuck, which
+    // is the whole bug — so this one failure IS worth a banner.
+    mockInvoke("cancel_network_op", () => {
+      throw { kind: "Internal", message: "no such repository" };
+    });
+
+    await useRepoStore.getState().cancelNetworkOps();
+
+    expect(useRepoStore.getState().error).toMatchObject({ kind: "Internal" });
+  });
+});
+
+describe.each([
+  ["fetch", "fetch", () => useRepoStore.getState().fetch("origin")],
+  ["fetchAll", "fetch_all", () => useRepoStore.getState().fetchAll()],
+  ["pull", "pull", () => useRepoStore.getState().pull("origin", "main")],
+  ["push", "push", () => useRepoStore.getState().push("origin", "main")],
+] as const)("a cancelled %s", (_name, cmd, run) => {
+  it("raises no error banner", async () => {
+    mockInvoke(cmd, cancelled);
+
+    await run();
+
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("clears its activity label, so the status line does not stay stuck", async () => {
+    mockInvoke(cmd, cancelled);
+
+    await run();
+
+    expect(useRepoStore.getState().activity).toEqual({});
+  });
+});
+
+it("still reports a genuine network failure", async () => {
+  // The guard above is `kind`-specific, not a blanket "network errors are
+  // quiet": a real failure must still reach the banner.
+  mockInvoke("fetch", () => {
+    throw { kind: "Network", message: "could not resolve host" };
+  });
+
+  await useRepoStore.getState().fetch("origin");
+
+  expect(useRepoStore.getState().error).toMatchObject({ kind: "Network" });
+});

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -15,6 +15,7 @@ import {
   dubiousOwnershipPath,
   isAppError,
   isAuthError,
+  isCancelledError,
   isDubiousOwnershipError,
   toAppError,
 } from "@/lib/errors";
@@ -82,6 +83,7 @@ import {
   repoState as repoStateFn,
   runMergetool as runMergetoolFn,
   restartConflict as restartConflictFn,
+  cancelNetworkOp,
   rememberCredential,
   setRemoteUrl,
   setUpstream as setUpstreamFn,
@@ -306,6 +308,16 @@ interface RepoStoreState extends RepoSlice {
     /** Skip `pre-push` for this push only (#232). */
     noVerify?: boolean,
   ) => Promise<void>;
+  /**
+   * Stop every network op running on this repository (#234) — the way out of a
+   * fetch, pull or push that has stalled, which used to be force-quit.
+   *
+   * Repository-wide and not per op: the auto-fetch timer stacks fetches behind a
+   * stalled one, and those are ops the user never started and cannot point at.
+   * The ops themselves clean up — each returns `Cancelled`, which
+   * `setErrorFor` drops and each `finally` clears the spinner for.
+   */
+  cancelNetworkOps: () => Promise<void>;
   // remote management
   addRemote: (name: string, url: string) => Promise<void>;
   removeRemote: (name: string) => Promise<void>;
@@ -417,9 +429,16 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   };
   /** `setFor` for the error banner: a failure in a repository you have left
    *  must not raise a banner over the one you are in. Keeps the
-   *  refresh-first-error-last ordering — it is still just a guarded set. */
+   *  refresh-first-error-last ordering — it is still just a guarded set.
+   *
+   *  Also the one place a cancellation is dropped (#234). Every network op ends
+   *  in one of these, and a cancel is the outcome the user ASKED for — routing
+   *  it to the banner would answer their Cancel click with a red error. Filtered
+   *  here rather than in each catch arm so a network op added later cannot
+   *  forget: there are seven call sites and they would not stay in step. */
   const setErrorFor = (repoId: string, e: unknown) => {
     if (get().current?.id !== repoId) return;
+    if (isCancelledError(e)) return;
     set({ error: toAppError(e) });
   };
   const setActivity = (key: keyof RepoActivity, label: string | null) => {
@@ -1354,6 +1373,21 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     } finally {
       setActivity("push", null);
     }
+  },
+
+  async cancelNetworkOps() {
+    const repo = get().current;
+    if (!repo) return;
+    // Nothing is set here. The running op owns its own unwind: it returns
+    // `Cancelled`, its `finally` clears the activity label, and `setErrorFor`
+    // drops the error. Clearing `activity` from here would race that and blank
+    // the status line while git was still being reaped.
+    await cancelNetworkOp(repo.id).catch((e) => {
+      // The op finishing first is the common way this "fails", and it is the
+      // outcome the click wanted anyway. A real failure to signal is worth a
+      // banner: the user is still stuck, and silence would read as "cancelled".
+      setErrorFor(repo.id, e);
+    });
   },
 
   async addRemote(name, url) {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -50,6 +50,14 @@ export type AppError =
   /** An op needed a bisect in progress and found none (#93). */
   | { kind: "NoBisect"; message?: string }
   /**
+   * The user cancelled a running network op (#234). The outcome they asked for,
+   * not a failure — every catch arm suppresses the banner for it and just clears
+   * the spinner. Distinct from `Network` because a SIGKILLed git's last words
+   * ("the remote end hung up unexpectedly") would otherwise be reported to
+   * someone who pressed Cancel as a broken connection.
+   */
+  | { kind: "Cancelled"; message?: string }
+  /**
    * A git hook ran and refused (#232). The payload is a STRUCT, and its
    * `output` is deliberately NOT rendered into the banner sentence: forty lines
    * of eslint belong in the dedicated output block, which scrolls. See
@@ -276,6 +284,18 @@ export function isEmbeddedRepoError(e: unknown): boolean {
  */
 export function isDubiousOwnershipError(e: unknown): boolean {
   return isAppError(e) && e.kind === "DubiousOwnership";
+}
+
+/**
+ * The user cancelled this op (#234) — so it is not something to report.
+ *
+ * Every network catch arm asks this before writing an error: a banner reading
+ * "early EOF" after pressing Cancel says the app broke, when what happened is
+ * exactly what was asked for. The op still refreshes on its way out; only the
+ * banner is suppressed.
+ */
+export function isCancelledError(e: unknown): boolean {
+  return isAppError(e) && e.kind === "Cancelled";
 }
 
 /** Narrow to an auth failure, so a caller can prompt and retry (#61 D5). */

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -818,6 +818,22 @@ export async function rememberCredential(
   return invoke<void>("remember_credential", { repoId, host, credentials });
 }
 
+/**
+ * Stop the network ops running in one scope (#234) — a clone, or every fetch,
+ * pull and push on one repository.
+ *
+ * `repoId` omitted means the clone the Clone dialog is running: a clone has no
+ * repository to name yet. Scoped rather than per-op on purpose — the auto-fetch
+ * timer can stack fetches behind a stalled one, and Cancel has to reach the
+ * whole pile, not just the op the user can see.
+ *
+ * Answers how many ops were signalled. Zero is a normal answer, not a failure:
+ * the op can finish between the user reading the status line and clicking.
+ */
+export async function cancelNetworkOp(repoId?: string): Promise<number> {
+  return invoke<number>("cancel_network_op", { repoId: repoId ?? null });
+}
+
 export async function fetch(
   repoId: string,
   remote: string,


### PR DESCRIPTION
Closes #234.

A clone, fetch, pull or push that hung could only be escaped by force-quitting the app. `run_clone` admitted it in a comment — *"a clone has no cancel button, so a hang here is force-quit territory"* — and `run_git_authenticated` simply awaited `output()` forever.

## What a user sees

- **Clone dialog** — the Cancel button stays live while the clone runs and reads "Cancel clone". It used to be greyed out for exactly the minutes you need it. The dialog returns to an editable form with the URL still in it, and no error banner.
- **Status bar** — a red **✕ Cancel** sits beside the "Fetching origin…" / "Pulling origin/main…" label. That label is what you stare at while deciding the app has hung, so that is where the way out belongs.
- **Auto-fetch** no longer stacks. A stalled remote outlives the interval, and every tick used to start *another* `git fetch` against it.

## Design decisions

**Registered by scope, not by op id.** Cancellation lives at the two choke points every network op already goes through — `commands::create::run_clone` and `commands::net::run_git_authenticated` — keyed `Scope::Clone` or `Scope::Repo(workdir)`. Two reasons for a scope: the UI already has exactly one of these in flight per scope (`busy`, `activity`), and the auto-fetch pile is made of ops the user never started and has no id for. A new network op inherits cancellation the same way it inherits the credential policy — by using the one runner, with nothing to remember.

`Scope::Repo`'s path comes from `GitBackend::repo_path`, which is also where the ops get their `cwd` and where `cancel_network_op` resolves a `repo_id`. Those three have to keep agreeing or Cancel silently matches nothing; that is written down next to all of them.

**`AppError::Cancelled`, never `Network`.** A SIGKILLed git's dying stderr says "early EOF" or "the remote end hung up unexpectedly". Routed through `Network`, someone who pressed Cancel is told their connection broke. It is dropped in `useRepoStore`'s `setErrorFor` — one place, so a network op added later cannot forget — and in the clone's own catch.

**A cancelled clone deletes its destination.** A SIGKILLed `git clone` cannot run its own cleanup, and the leftovers fail the *next* attempt's `validate_clone_target` with "already exists and is not empty" — a cancel button whose real effect is to poison the destination. Safe only because that validation already refused anything but "absent" or "the user's own empty directory", and only after an explicit kill **and reap**, so git is provably not still writing into it. An empty directory the user picked is put back; the removal runs on `spawn_blocking` so unlinking a half-cloned kernel tree does not stall every other command.

## Deliberately not included

- **A timeout.** One short enough to rescue a stalled host is short enough to kill a legitimately slow clone of a large repository over a bad link, and the user is the only one who can tell those apart — which is what the button is for. If we ever want one, git's own `http.lowSpeedLimit`/`lowSpeedTime` is the lever, as a setting.
- **Killing the process group.** It would put a platform-specific kill path through the one sanctioned spawner (`proc.rs`). Git's transport helper is git's child, not ours, and exits when its pipes close. The user-visible hang — an app with no way out — is gone either way.

Both are recorded in `docs/dev/backend.md` so the next person does not have to re-derive the trade-off.

## Tests

`src-tauri/tests/net_cancel.rs` drives a **real stall**: a loopback listener that accepts the connection and then says nothing, which is precisely the failure the issue names. Its own test binary, because the registry is process-wide and `Scope::Clone` is shared by every clone in the process.

- a stalled clone comes back `Cancelled` and leaves no partial destination
- an empty directory the user chose survives the cancel, empty
- a stalled fetch comes back `Cancelled`
- one repository's cancel does not reach another's fetch

Plus `cancel.rs` unit tests (signalling, deregistration on drop, scope isolation, one cancel reaching a whole pile), and frontend tests for the store transitions, the suppressed banner, the retained "genuine failure still reports" behaviour, and the dialog's two-job button.

## Verification

| gate | result |
| --- | --- |
| `cargo test` | all suites pass, no failures |
| `pnpm test` | 1925 passed (223 files) |
| `pnpm tsc --noEmit` | clean |
| `pnpm exec tsc -p e2e/tsconfig.json --noEmit` | clean |
| `pnpm test:e2e:docker run --spec e2e/specs/create.e2e.ts` | 2 passing, against a freshly rebuilt snapshot |

No e2e spec was added for the cancel itself: driving it needs a stalled remote inside the container, and the Rust integration tests already exercise the real process against a real stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
