### PR TITLE
Superseded by #260 — cancel-net-ops (op-id design + extras, kept for reference)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,11 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
   exported `withAuthRetry`. Never a second auth path. Secrets travel in env,
   never argv; end option parsing with `--` before user-supplied values.
   (`docs/dev/backend.md`)
+- **One cancel path.** A long-running child is stopped through
+  `cancel::OpRegistry` — the frontend mints the `opId` before the invoke, and
+  cancel kills the child's process group with SIGTERM (never SIGKILL first: git's
+  handlers remove its lock files). A cancelled op returns `AppError::Cancelled`,
+  which no surface may render as an error. (`docs/dev/backend.md`)
 - **Forge tokens are NOT git credentials** — separate storage, separate types
   (`Secret`), no command returns a token. (`docs/dev/backend.md`)
 - **One signing chain** (`libgit2.rs::sign_payload`) for commits AND tags; a

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -18,8 +18,17 @@ update.rs        Update discovery: semver compare, dev-build (0.0.0) short-circu
                  https_only. Logic only — handlers live in commands/update.rs
 proc.rs          THE only sanctioned child-process spawner (issue 172):
                  git / git_async / git_async_in (CREATE_NO_WINDOW,
-                 GIT_TERMINAL_PROMPT=0, stdin closed), program / program_async,
-                 and the two *_keeping_console exceptions. See backend.md
+                 GIT_TERMINAL_PROMPT=0, stdin closed, and — the async git two —
+                 their OWN process group so a cancel can signal the group),
+                 program / program_async, and the two *_keeping_console
+                 exceptions, which get NO process group (SIGTTIN/SIGTTOU would
+                 stop an interactive child). See backend.md
+cancel.rs        Cancelling a running clone/fetch/pull/push (#234): OpRegistry
+                 (id → Op, managed as Arc state), OpGuard (de-registers on Drop),
+                 Op::attach/cancel/is_cancelled, kill_tree (unix: SIGTERM to the
+                 process group, but killpg ONLY when getpgid(pid) == pid;
+                 windows: taskkill /F /T). The op is NOT interrupted — its child
+                 is killed and it notices via is_cancelled. See backend.md
 reveal.rs        "Reveal in Finder/Explorer" + "Open in terminal" (#215).
                  HostPlatform decouples argv building from the actual host, so
                  reveal_plan/terminal_plan are PURE and unit-tested for all
@@ -141,14 +150,18 @@ commands/        Thin Tauri handlers, one file per area:
 │                vs its first parent) and diff_commits (rev↔rev) — check arity
 ├── branches.rs  list_branches/tags/stashes/remotes,
 │                checkout/create/delete/rename_branch, set_upstream,
-│                fetch, fetch_all, pull, push,
+│                fetch, fetch_all, pull, push (all four take an optional op_id
+│                and are cancellable — #234; the rest of this file's network ops
+│                are not, and pass none),
 │                add/remove/rename/prune_remote, set_remote_url,
 │                create/delete/push_tag, verify_tag, merge_branch, rebase_onto,
 │                checkout_ref, push_delete_branch
 ├── net.rs       Shared network plumbing (Credentials, run_git_authenticated,
-│                apply_auth_env, map_git_failure, credential_approve) + ONE
-│                command, remember_credential — stored only after the credential
-│                worked. See backend.md
+│                run_git_cancellable, apply_auth_env, map_git_failure,
+│                credential_approve) + TWO commands: remember_credential —
+│                stored only after the credential worked — and cancel_operation
+│                (#234), which answers false for an id that already finished.
+│                See backend.md
 ├── update.rs    check_for_update, get_update_capability, open_url — thin
 │                handlers for src-tauri/src/update.rs (same basename, two files)
 ├── history.rs   reset, cherry_pick, revert
@@ -169,7 +182,10 @@ commands/        Thin Tauri handlers, one file per area:
 ├── lfs.rs       lfs_status, lfs_checkout (local), lfs_fetch/lfs_pull (credentialed)
 ├── bisect.rs    bisect_status/start/mark/reset
 └── create.rs    init_repo, default_init_branch, clone_repo (streaming
-                 clone://progress events)
+                 clone://progress events, optional op_id). Also
+                 discard_partial_clone (#234): on a cancel, a destination we
+                 created is removed and one that already existed is EMPTIED,
+                 never deleted
 ```
 
 ## Frontend (`src/`)
@@ -177,10 +193,13 @@ commands/        Thin Tauri handlers, one file per area:
 ```
 main.tsx             Entry point (routes ?window=merge)
 App.tsx              Thin wrapper around <AppShell />
-AppShell.tsx         Shell: titlebar (branch chip, remote buttons), tab strip,
-                     activity bar, status bar, error banner, settings. Owns
-                     per-tab screen restore and keys the screen subtree by the
-                     active repository (a switch REMOUNTS it)
+AppShell.tsx         Shell: titlebar (branch chip, remote buttons, and the Stop
+                     button that cancels the running fetch/pull/push — #234),
+                     tab strip, activity bar, status bar, error banner, settings.
+                     Owns per-tab screen restore and keys the screen subtree by
+                     the active repository (a switch REMOUNTS it), plus the
+                     auto-fetch timer: skips while a fetch is in flight and
+                     cancels its own after AUTO_FETCH_DEADLINE_MS
 store.ts             Re-export hub — keep thin
 
 design/              In-house design system (NOT components/ui/), exported via
@@ -209,9 +228,12 @@ screens/             One per activity-bar item + deep views: RepoBrowser,
                      Conflict screen (#108)
 
 features/            Components + Zustand store colocated per feature:
-├── repo/            useRepoStore (ONE repo's live state — the active tab's),
+├── repo/            useRepoStore (ONE repo's live state — the active tab's,
+│                    incl. cancelNetOp / cancelAllNetOps — #234),
 │                    repoSlice (RepoSlice / REPO_SLICE_KEYS / emptySlice),
-│                    repoActivity, tabs.ts (pure tab reducers, labelTabs,
+│                    repoActivity (RepoActivity labels + NetOps: the op ids the
+│                    Stop button cancels, keyed the same way), tabs.ts (pure tab
+│                    reducers, labelTabs,
 │                    pg-open-repos persistence), useTabsStore (open set +
 │                    activate/close/cycle + session restore), RepoTabs,
 │                    useRecentsStore, ops (shared runners), OperationBar
@@ -251,7 +273,10 @@ features/            Components + Zustand store colocated per feature:
 │                    the secret) + CredentialDialog. withAuthRetry LIVES IN
 │                    useRepoStore.ts, exported — never grow a second retry path
 ├── create/          Clone + Init dialogs (PGModal), useCreateStore,
-│                    deriveRepoName. Clone shells out with the prompt-less env
+│                    deriveRepoName. Clone shells out with the prompt-less env;
+│                    while it runs the dialog's Cancel button IS the cancel
+│                    (#234) — cloneOpId / cancelClone, and the dialog closes only
+│                    once the backend confirms it cleaned up
 ├── forge/           useForgeStore (hostKinds+logins under pg-forge-hosts, NEVER
 │                    a token), forgeLabels (prNoun/prNumberLabel/localBranchFor),
 │                    PullRequestRow, CreatePullRequestDialog, ForgeSettings
@@ -302,7 +327,9 @@ lib/                 tauri.ts (typed invoke wrappers — frontend NEVER calls
                      (+ splitFileSelection), tree.ts (buildStatusTree /
                      buildStatusList — SAME row keys), useTreeViewMode.ts,
                      recents.ts (pg-recent-repos; the OPEN set is pg-open-repos
-                     in features/repo/tabs.ts)
+                     in features/repo/tabs.ts), opId.ts (newOpId — the frontend
+                     mints cancellable-op ids BEFORE the invoke, #234; not
+                     crypto.randomUUID, which needs a secure context)
 
 test/ (src/test/)    jsdom component-test harness (root test/ is unrelated —
                      doc invariants, see testing.md): setup.ts (invoke/dialog/

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -130,7 +130,9 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
 - **One runner.** Every network shell-out goes through
   `commands::net::run_git_authenticated` (clone uses its primitives
   `apply_auth_env` + `map_git_failure` for a streamed stderr): fetch, fetch_all,
-  pull, push, push_tag, push_delete_branch, clone_repo,
+  pull, push, push_tag, push_delete_branch, clone_repo (fetch/fetch_all/pull/
+  push go through `run_git_cancellable`, which IS `run_git_authenticated` plus an
+  `Op` — see "Cancelling a network op"),
   forge_checkout_pull_request's fetch (its second git call passes `None` — the
   tip is already local), submodule_update, lfs_fetch/lfs_pull.
   `grep -rn 'run_git_authenticated\|run_git_creds\|apply_auth_env' src-tauri/src/`
@@ -166,6 +168,64 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
 - `credential_approve` refuses values containing a newline rather than escaping
   them — the credential protocol is line-based, so a newline injects keys and
   could file a password against another host.
+
+## Cancelling a network op (#234)
+
+`git clone`, `fetch`, `pull` and `push` can be stopped from the UI. Before this
+the only escape from a stalled transfer was force-quitting the app.
+
+- **The registry never interrupts the op.** `cancel.rs` holds `id → Op`, and a
+  cancel kills the op's **child**; the op then *notices* — its `wait()` returns
+  because git is dead, and it checks `Op::is_cancelled()` before mapping stderr.
+  The two shapes that look more natural both fail: `tokio::select!` over
+  `child.wait()` and a cancel future needs `&mut child` in both arms, and
+  `Arc<Mutex<Child>>` deadlocks because the op holds the lock across the very
+  `wait()` the killer is trying to interrupt.
+- **The frontend mints the id, before the invoke** (`src/lib/opId.ts`). A
+  backend-assigned id emitted back would leave the op unaddressable for exactly
+  as long as it fails to answer, which is the case this feature exists for.
+  `op_id: Option<String>` — omitted means uncancellable, which is what every op
+  outside the four still is (`push_tag`, `push_delete_branch`, LFS, submodule
+  update, forge checkout). Each of those is one argument away from opting in.
+- **The child gets its own process group, and cancel signals the GROUP.**
+  `git` is rarely the process doing the waiting — over https it spawns
+  `git-remote-https`, over ssh it spawns `ssh` — so killing only `git` leaves the
+  transfer's child holding the connection. `proc::git_async`/`git_async_in` set
+  `process_group(0)`; the console-keeping constructors deliberately do NOT (an
+  interactive child outside the terminal's foreground group is stopped by
+  SIGTTIN/SIGTTOU). `kill_tree` still checks `getpgid(pid) == pid` and falls back
+  to a single-process kill: without that check, a future spawn site that skipped
+  the process group would have a cancel signal *our own* group.
+- **SIGTERM, not SIGKILL.** git's own handlers remove its lock files
+  (`lockfile.c`) and, in `clone`, the partial destination
+  (`remove_junk_on_signal`). SIGKILL skips all of it, so a SIGKILLed pull strands
+  `.git/index.lock` and the NEXT pull fails with "Unable to create
+  '…/index.lock': File exists". A cancel that breaks the following operation is
+  worse than no cancel. **A second cancel escalates to SIGKILL** — the user
+  clicking again is the escalation signal, which is why there is no timer here.
+- **Windows is the abrupt case, knowingly.** No SIGTERM, and our children are
+  spawned `CREATE_NO_WINDOW` so they have no console for
+  `GenerateConsoleCtrlEvent` either; cancel is `taskkill /F /T`. git therefore
+  gets no chance to clean up: `discard_partial_clone` covers the clone
+  destination, and a stale `index.lock` after a cancelled pull is the known
+  remaining gap.
+- **A cancelled clone restores the pre-clone state exactly.**
+  `validate_clone_target` accepts only an absent target or an existing EMPTY
+  directory, so `run_clone` records which it saw and `discard_partial_clone`
+  undoes it: a directory *we* created is removed, a directory the **user already
+  had** is emptied and kept. Cancel only — a failed `git clone` removes its own
+  destination, and widening this to every failure would mean deleting a directory
+  on a path we have not just proved is ours.
+- **`AppError::Cancelled` is a state, not a failure.** Checked *before*
+  `map_git_failure` at every site, so a killed git's dying words cannot become a
+  `Network` banner — or, worse, an `Auth` one that pops the credential dialog
+  over a cancel. The frontend's `isCancelledError` then keeps it out of every
+  error surface.
+- **Window close cancels everything** (`lib.rs`'s `on_window_event`, gated on the
+  `main` label so closing the `merge` resolver does not stop a fetch).
+  `kill_on_drop` only fires when a future is dropped, and process exit does not
+  unwind — so without this a clone outlives the app and finishes populating a
+  destination the frontend was told never got created.
 
 ## Signing: one chain for commits and tags (#61 D6, #132)
 

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -349,6 +349,26 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   evict (`mergeWindowHoldsRepo`/`closeMergeWindow`, which waits for the window
   label to disappear — `close()` resolves on delivery, not on gone). An
   unattributable live resolver counts as a match on purpose.
+- **A cancellable network op publishes its id, and clears it in the same
+  `finally` as its activity label** (#234). `activity.fetch` says a fetch is
+  running; `netOps.fetch` says how to stop it — same keys, one per-repo slice
+  field each, both cleared together by `runCancellable`. An id left behind offers
+  a Stop button that would signal a pid the OS has since reissued.
+  - The two are separate fields rather than one richer `RepoActivity` value
+    because `pull` re-labels itself three times (stash → pull → pop), and
+    threading the id through each relabel is how one relabel drops it.
+  - `setNetOp` is deliberately NOT `setFor`-guarded, unlike every other write:
+    it is bookkeeping for a process running right now, and dropping the write
+    because the user switched tabs would leave the id in the slice forever.
+  - **Cancelled is not an error.** Cancellable ops report failures through
+    `reportNetFailure`, which is `setErrorFor` minus `isCancelledError`. Ops with
+    no cancel button keep calling `setErrorFor` directly, so the filter cannot
+    silently swallow something the user did not ask to stop. The `refreshAll()`
+    still happens — a partly-applied pull changed the tree — only the banner is
+    skipped.
+  - The **clone**'s id lives in `useCreateStore` (`cloneOpId`), not the repo
+    slice: there is no repository yet. A fresh id per attempt, because the
+    credential retry is a second `git clone`.
 - **Danger-op error paths refresh first, set error last** (see `mergeBranch`):
   `refreshAll` starts with `set({ error: null })` and React batches same-tick
   sets, so the opposite order wipes the banner. A failed git op must still

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -18,7 +18,10 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   Run one with `pnpm vitest run --project unit`.
 - **E2E** — WebdriverIO specs in `e2e/specs/` (one file per feature area)
   driving the real debug binary via the embedded `@wdio/tauri-service`
-  provider; temp repos from `e2e/support/tempRepo.ts`.
+  provider; temp repos from `e2e/support/tempRepo.ts` — which also holds
+  `stalledGitRemote()`, a `git://` listener that accepts and never answers, for
+  the one thing every other fixture is too fast to test: cancelling an op that
+  cannot finish (#234).
 
 ## E2E rules
 

--- a/docs/superpowers/plans/2026-08-26-cancel-network-ops-plan.md
+++ b/docs/superpowers/plans/2026-08-26-cancel-network-ops-plan.md
@@ -1,0 +1,142 @@
+# Plan — Cancel a running clone, fetch, pull or push (issue 234)
+
+Spec: `docs/superpowers/specs/2026-08-26-cancel-network-ops-spec.md`.
+One PR. Branch `feat/cancel-net-ops`.
+
+## Step 1 — `AppError::Cancelled`
+
+- `src-tauri/src/error.rs`: unit variant `Cancelled`, `#[error("operation cancelled")]`,
+  doc comment saying it is a *state*, not a failure, and must never reach a banner.
+- `src/lib/errors.ts`: `{ kind: "Cancelled"; message?: string }` in the union
+  (same shape as `NoBisect`), plus `isCancelledError(e)`.
+- Test: `src/lib/errors.test.ts` — `isCancelledError` narrows, and
+  `appErrorMessage` still yields the kind rather than an empty banner.
+
+## Step 2 — `src-tauri/src/cancel.rs`
+
+```rust
+pub struct OpRegistry { ops: Mutex<HashMap<String, Arc<Op>>> }
+pub struct Op { id: Option<String>, cancelled: AtomicBool, pid: Mutex<Option<u32>> }
+pub struct OpGuard { registry: Arc<OpRegistry>, op: Arc<Op> }
+```
+
+- `OpRegistry::begin(self: &Arc<Self>, id: Option<&str>) -> OpGuard` — `None`
+  yields a **detached** op (no map entry, never cancellable) so callers never
+  branch on it.
+- `Op::is_cancelled()`, `Op::attach(pid) -> bool` (false = cancel already landed,
+  caller kills its own child and bails), `Op::cancel()`.
+- `OpRegistry::cancel(id) -> bool`, `cancel_all()`, `finish(id)`.
+- `Drop for OpGuard` → `finish`.
+- `kill_tree(pid, hard: bool)`:
+  - unix: `getpgid(pid) == pid` → `killpg`, else `kill`; signal `SIGTERM`, or
+    `SIGKILL` when `hard`.
+  - windows: `taskkill /F /T /PID` through `proc::program` (never a raw
+    `Command::new` — `tests/spawn_no_window.rs` counts those).
+- `Op::cancel()` sets the flag, then kills; `hard` = "the flag was **already**
+  set", i.e. the user clicked Cancel twice.
+- Rust unit tests: a detached op is never cancelled; `attach` after `cancel`
+  returns false; `cancel` on an unknown id is `false`; `Drop` de-registers;
+  `cancel_all` marks every entry. (No live child needed for any of these.)
+
+## Step 3 — `proc.rs`: own process group
+
+- `git_async` and `git_async_in` call a new `cfg(unix)` `own_process_group`
+  (`cmd.process_group(0)`), with the doc comment explaining why the
+  console-keeping constructors are excluded (SIGTTIN/SIGTTOU).
+- Test: `the_console_keeping_constructors_apply_no_policy` gains a line asserting
+  the two console constructors are still the only ones with no policy applied
+  (`process_group` has no getter, so the assertion documents the split rather
+  than reading it back).
+
+## Step 4 — `commands/net.rs`
+
+- `run_git_authenticated(cwd, args, creds)` keeps its signature and delegates to
+  the new `run_git_cancellable(cwd, args, creds, &Op::detached())`.
+- `run_git_cancellable`:
+  1. bail with `Cancelled` if the op is already cancelled (no spawn at all),
+  2. `.stdout(piped()).stderr(piped()).kill_on_drop(true)`, spawn,
+  3. `op.attach(child.id())` — false → `start_kill()` + `Cancelled`,
+  4. `wait_with_output()`, then **check `is_cancelled()` before**
+     `map_git_failure`.
+- `#[tauri::command] cancel_operation(registry, op_id) -> AppResult<bool>`.
+- Register in `lib.rs`'s `invoke_handler!`, `.manage(Arc::new(OpRegistry))`.
+
+## Step 5 — `commands/branches.rs`: thread `opId` through the four ops
+
+- `fetch`, `fetch_all`, `pull`, `push` gain `op_id: Option<String>` and go through
+  `run_git_cancellable` with `registry.begin(op_id.as_deref())`.
+- `run_git`/`run_git_creds` keep delegating with no op — `push_tag`,
+  `push_delete_branch` and the rest are untouched.
+
+## Step 6 — `commands/create.rs`: clone
+
+- `run_clone` gains `op: &Op` and returns `Cancelled` at three points: before the
+  spawn, on a failed `attach`, and after the read loop / `wait()`.
+- Read-error arm checks `is_cancelled()` before mapping to `Io`.
+- `target_existed` recorded after `validate_clone_target`, before the spawn.
+- New `discard_partial_clone(target, existed)` per spec decision 4, with unit
+  tests over a `tempfile` dir for both branches (and for a target that git
+  already removed).
+- `clone_repo` gains `op_id: Option<String>`.
+
+## Step 7 — window close
+
+- `lib.rs`: `.on_window_event(...)`, gated on `window.label() == "main"` — the
+  merge resolver window is labelled `merge` and closing it must not stop a fetch.
+  `CloseRequested` → `registry.cancel_all()`.
+
+## Step 8 — frontend plumbing
+
+- `src/lib/opId.ts`: `newOpId(kind)` → `` `${kind}-${Date.now().toString(36)}-${random}` ``.
+  Not `crypto.randomUUID()`, which needs a secure context we do not control on
+  every platform's custom protocol. Unit test: unique across calls, carries the
+  kind.
+- `src/lib/tauri.ts`: `opId` on `fetch`, `fetchAll`, `pull`, `push`, `cloneRepo`;
+  new `cancelOperation(opId)`.
+- `src/features/repo/repoSlice.ts`: `netOps: NetOps` + `{}` in `emptySlice`.
+- `src/features/repo/useRepoStore.ts`:
+  - the four actions mint an id, set `netOps[kind]`, pass it, clear it in the
+    same `finally` that clears the activity label,
+  - a `Cancelled` catch is **not** an error: `setErrorFor` is skipped (the
+    existing `refreshAll()`-first ordering is kept),
+  - `cancelNetOp(kind)` and `cancelAllNetOps()` actions.
+- `src/features/create/useCreateStore.ts`: `opId` in state, `cancelClone()`,
+  and `runClone`'s catch treats `Cancelled` as "close the dialog, no error".
+
+## Step 9 — frontend surfaces
+
+- `CloneDialog`: Cancel is enabled while busy and calls `cancelClone()`;
+  `data-testid="clone-cancel"`.
+- `AppShell`: a `Stop` button in the titlebar right slot, gated on
+  `netOps.fetch ?? netOps.pull ?? netOps.push`, `data-testid="net-cancel"`.
+- `palette/commands.ts`: `action:cancel-net-op`, gated the same way.
+- `AppShell` auto-fetch effect: skip while `activity.fetch` is set, and arm a
+  120s timer that cancels the fetch it started.
+- Component tests: `CloneDialog` cancel path, the Stop button's appear/disappear
+  and click, the store's `Cancelled` handling (no banner), the palette row's
+  gating, and the auto-fetch skip + deadline.
+
+## Step 10 — docs + verification
+
+- `docs/dev/architecture.md`: `cancel.rs` in the backend tree, `cancel_operation`
+  on the `commands/net.rs` entry, `op_id` noted on the four ops and clone.
+- `docs/dev/backend.md`: a "Cancelling a network op" section — the registry, the
+  signal choice, the process group, the clone cleanup table, and the Windows
+  lock-file caveat.
+- `docs/dev/frontend.md`: `netOps` alongside the `RepoActivity` note, and where
+  the two cancel affordances live.
+- `CLAUDE.md`: one line on the one-cancel-path rule under the conventions list.
+- Gates: `cargo test`, `cargo check`, `pnpm tsc --noEmit`, `pnpm test`, then
+  `pnpm test:e2e:docker build` + the `create.e2e.ts` / `remote.e2e.ts` specs.
+
+## Step 11 — e2e (attempt; drop if it cannot be made deterministic)
+
+A cancellable op needs a remote that **stalls**, and a `file://` clone finishes
+instantly. The spec process is Node, so it can open a TCP listener that accepts
+and never replies, and `git clone git://127.0.0.1:<port>/x` then hangs in
+"Connecting" forever — a deterministic hang with no network access. Assert:
+progress → Cancel → dialog idle, no `clone-error`, destination absent.
+
+Read `.claude/skills/e2e-testing/SKILL.md` first. If the listener cannot be
+reached from the app's container, drop the spec rather than shipping a flaky one,
+and say so in the PR.

--- a/docs/superpowers/specs/2026-08-26-cancel-network-ops-spec.md
+++ b/docs/superpowers/specs/2026-08-26-cancel-network-ops-spec.md
@@ -1,0 +1,208 @@
+# Cancel a running clone, fetch, pull or push (issue 234)
+
+Status: approved for implementation.
+Issue: [234](https://github.com/jonassaa/platypusgit/issues/234).
+
+## Goal
+
+A clone, fetch, pull or push that hangs can be stopped from the UI, and stopping
+it leaves the repository exactly as it was. Today the only escape is force-quit,
+which our own source already admits at `commands/create.rs:253` ("a clone has no
+cancel button, so a hang here is force-quit").
+
+## What already exists, verified in the tree
+
+- **Every network op is a spawned child process**, so cancellation is a signal,
+  not a libgit2 problem: `run_clone` spawns `git clone --progress` via
+  `proc::git_async_in`, and `net::run_git_authenticated` spawns fetch/pull/push
+  via `proc::git_async`. Nothing goes through libgit2's transport.
+- **`kill_on_drop(true)` is already set on the clone child**, so a *dropped
+  future* kills git. That covers nothing the user can trigger — no code path
+  drops those futures — which is why the comment at `create.rs:258` describes the
+  window-close case as a hazard rather than a handled one.
+- **Progress already streams** for clone (`clone://progress`, parsed by
+  `parse_progress`) and fetch/pull/push already render a label through
+  `RepoActivity` + `AppStatusBar`. So "real progress" from the issue's list is
+  half-built: what is missing is a control next to it.
+- **`validate_clone_target`** guarantees the clone destination is either absent
+  or an existing **empty** directory. That is what makes cleanup decidable —
+  see decision 4.
+- `libc` is already a `cfg(unix)` dependency (declared for the `pgit` detach), so
+  a signal needs no new crate.
+
+## What is missing
+
+1. No way to address an in-flight op from the frontend — nothing is keyed, so
+   there is nothing to cancel.
+2. No cancel affordance anywhere: `CloneDialog`'s Cancel button is `disabled={busy}`,
+   and `useCreateStore.close()` refuses to close while busy.
+3. No `AppError` variant for "the user stopped it", so a cancelled op would
+   surface as a red `Network` banner quoting git's death rattle.
+4. Nothing cleans up a partially-written clone directory.
+5. Window close does not stop anything.
+6. The auto-fetch timer can stack: `AppShell`'s `setInterval` calls `fetchAll`
+   unconditionally, so a stalled fetch is joined by another one every N minutes,
+   with nobody watching.
+
+## The decisions
+
+### 1. The frontend mints the op id, and passes it in
+
+Every cancellable command takes an `opId: Option<String>`. The **frontend
+generates it before the invoke**, so the cancel button is live from the first
+frame rather than after a round trip that may never come back — which is the
+whole point, since the op we most need to cancel is the one that never answers.
+
+The alternative (backend assigns an id and emits it) has a window where the op is
+running and uncancellable, and that window is unbounded for exactly the hang this
+issue is about.
+
+`opId` is `Option` on the Rust side so an omitted id means "not cancellable" and
+every existing caller — `push_tag`, `push_delete_branch`, LFS, submodule update,
+forge PR checkout — keeps working untouched. Those ops are short and have no
+progress surface; they can opt in later by passing an id, which is a one-line
+change per call site.
+
+### 2. One registry, keyed by op id, holding a pid and a flag
+
+New module `src-tauri/src/cancel.rs`:
+
+- `OpRegistry` — `Mutex<HashMap<String, Arc<Op>>>`, managed as Tauri state.
+- `Op` — a cancelled flag (`AtomicBool`) and the child's pid once spawned.
+- `begin(id) -> OpGuard` — registers, and de-registers on `Drop` so a `?` return
+  cannot leak an entry.
+- `cancel(id)` / `cancel_all()`.
+
+**No async signalling.** The registry does not tell the op to stop; it kills the
+op's child directly, and the op then *notices*. Its `wait()`/`wait_with_output()`
+returns because the child is dead, and it checks `op.is_cancelled()` before
+mapping stderr to an error. This is what keeps the change small: no
+`tokio::select!` over a `&mut Child` (which does not borrow-check), no
+`Arc<Mutex<Child>>` (whose lock the killer would wait on behind `wait()`).
+
+### 3. SIGTERM to the process group, not SIGKILL to the child
+
+Two things are wrong with `child.kill()`:
+
+- **It is the wrong process.** `git clone` over https spawns `git-remote-https`;
+  over ssh it spawns `ssh`. Killing only `git` leaves the transfer's child holding
+  the connection.
+- **It is the wrong signal.** git installs signal handlers that remove its lock
+  files (`lockfile.c`) and, in `clone`, the partial destination
+  (`remove_junk_on_signal`). SIGKILL skips all of it, so a cancelled pull leaves
+  `.git/index.lock` behind and the *next* pull fails with "Unable to create
+  '.../index.lock': File exists". A cancel that breaks the next operation is
+  worse than no cancel.
+
+So: `proc::git_async`/`git_async_in` put the child in its **own process group**
+(`process_group(0)`, unix only), and cancel sends **SIGTERM to that group**.
+Applied in the constructors rather than at the two cancellable call sites, for the
+same reason `CREATE_NO_WINDOW` is: a call site can forget. The console-keeping
+constructors are deliberately excluded — a console program in a process group
+other than the terminal's foreground group is stopped by SIGTTIN/SIGTTOU the
+moment it touches the tty.
+
+`kill_tree` reads `getpgid(pid)` and only uses `killpg` when the pid **is** the
+group leader, falling back to `kill(pid)` otherwise. Without that check, a future
+spawn site that skipped `process_group` would have us signal our own process
+group — i.e. kill the app.
+
+**A second cancel escalates to SIGKILL.** No timer, no `tokio::time`: the user
+clicking Cancel again is the escalation signal, and the first click has already
+given git its chance to clean up.
+
+On Windows there is no SIGTERM and our children have no console (they are spawned
+`CREATE_NO_WINDOW`, so `GenerateConsoleCtrlEvent` has nothing to signal), so
+cancel runs `taskkill /F /T /PID <pid>` — the whole tree, abruptly. The lock-file
+caveat above therefore stands on Windows; our own cleanup (decision 4) covers the
+clone directory, and a stale `index.lock` is the remaining known gap, recorded in
+`docs/dev/backend.md`.
+
+### 4. A cancelled clone restores the pre-clone state exactly
+
+`validate_clone_target` leaves exactly two possibilities, so `run_clone` records
+which one it saw **before** spawning:
+
+| Before the clone | On cancel |
+| --- | --- |
+| target did not exist | `remove_dir_all(target)` |
+| target existed and was empty | remove its **contents**, keep the directory |
+
+That restores what was there, and never removes a directory the user already had.
+git's own SIGTERM handler usually gets there first (leaving `remove_dir_all` a
+`NotFound` no-op); this is the backstop that makes the guarantee hold on Windows
+and against a git that dies before its handler runs.
+
+Cleanup runs **only on cancel**, not on failure: a failed `git clone` already
+removes its own destination, and widening this to every failure would mean
+deleting a directory on a path we did not just prove was ours.
+
+### 5. `AppError::Cancelled` — a cancelled op is not a failure
+
+New unit variant, 1:1 in the TS union, with `isCancelledError` in `lib/errors.ts`.
+Every catch arm that would raise a banner checks it first: the user knows they
+cancelled, and an error banner saying so is the app arguing with them.
+
+It must also **not raise the credential prompt**. `withAuthRetry` narrows on
+`isAuthError`, and killed git prints nothing that `classify_auth_failure` matches,
+so this holds by construction — but the cancel check comes *before*
+`map_git_failure` anyway, so a remote whose dying words happen to look like an
+auth failure cannot pop a dialog over a cancel.
+
+### 6. Where the cancel button goes
+
+- **Clone:** the dialog's existing Cancel button becomes live while busy — it
+  cancels instead of being disabled. That is the button the user is already
+  reaching for. `close()` keeps refusing to close mid-run; the cancel path drops
+  `busy` itself when the backend confirms.
+- **Fetch/pull/push:** one **Stop** button in the titlebar's right slot, next to
+  Push, rendered only while a cancellable op is in flight, titled with what it
+  will stop. Deliberately not a mode-switch on the Fetch/Pull/Push buttons (a
+  mis-click on a button whose meaning just changed under the pointer) and not the
+  status-bar activity label (a label is not a control).
+- **Keyboard:** a palette row, `Cancel network operation`, listed only while one
+  is running — the same gating `Resolve conflicts…` uses.
+
+### 7. Per-repo op ids live in the slice, next to the activity label
+
+`RepoSlice` gains `netOps: { fetch?: string; pull?: string; push?: string }` — op
+ids keyed the same way `activity` keys its labels, set and cleared in the same
+four actions. It is per-repo state, so it belongs in `RepoSlice`/`emptySlice` or a
+tab switch leaks it (CLAUDE.md).
+
+`RepoActivity`'s values are left as plain label strings on purpose: `pull`
+re-labels itself three times (stash → pull → pop), and threading an id through
+each relabel is how one of them ends up dropping it.
+
+### 8. Auto-fetch: don't stack, and give it a deadline
+
+The timer is the one op with nobody watching, so it gets what a watched op does
+not need:
+
+- **Skip while a fetch is already in flight** — the stacking the issue names.
+- **Cancel after 2 minutes.** An interactive fetch is never cancelled on a timer;
+  the user is right there. A background one that has been stalled for two minutes
+  is not going to finish, and leaving it there is how you accumulate four of them.
+
+## Out of scope, deliberately
+
+- **Cancelling `push_tag`, `push_delete_branch`, LFS, submodule update and forge
+  checkout.** They take an `opId` of `None` and behave exactly as today. Each is
+  one line and one UI affordance away, and none of them is the first-five-minutes
+  hang this issue is about.
+- **A timeout for interactive ops.** A user watching a slow clone of
+  `torvalds/linux` must not have it yanked away at 120s.
+- **Resuming a cancelled clone.** `git clone` has no resume; the offer would be a
+  fresh clone, which the dialog already is.
+
+## Acceptance
+
+- Start a clone of a host that accepts the connection and stalls. The dialog
+  shows progress, Cancel is enabled, clicking it returns the dialog to an idle,
+  dismissable state with no error banner, and the destination directory is gone.
+- Start a fetch against the same host. A Stop button appears next to Push;
+  clicking it clears the status-bar activity with no banner, and the next fetch
+  works (no stale `index.lock`).
+- Close the window mid-clone: no `git` process survives the app.
+- With auto-fetch on and a stalled remote, exactly one fetch is ever in flight,
+  and it stops on its own after two minutes.

--- a/e2e/specs/create.e2e.ts
+++ b/e2e/specs/create.e2e.ts
@@ -4,7 +4,12 @@ import { join } from "node:path";
 import { execFileSync } from "node:child_process";
 
 import { $, expect } from "@wdio/globals";
-import { bareSourceRepo, type BareRepo } from "../support/tempRepo";
+import {
+  bareSourceRepo,
+  stalledGitRemote,
+  type BareRepo,
+  type StalledRemote,
+} from "../support/tempRepo";
 import { resetApp, waitRepoLoaded } from "../support/app";
 
 describe("clone & init", () => {
@@ -13,6 +18,9 @@ describe("clone & init", () => {
   // fixture created by the clone test must not leak when an earlier
   // assertion in that test throws.
   let source: BareRepo | undefined;
+  // Same reason as `source`: a listener left open would keep a git child alive
+  // past the test that started it.
+  let stalled: StalledRemote | undefined;
 
   beforeEach(() => {
     dest = mkdtempSync(join(tmpdir(), "pgit-create-"));
@@ -23,6 +31,8 @@ describe("clone & init", () => {
     rmSync(dest, { recursive: true, force: true });
     source?.dispose();
     source = undefined;
+    stalled?.dispose();
+    stalled = undefined;
   });
 
   it("initializes a new repository and opens it", async () => {
@@ -117,5 +127,54 @@ describe("clone & init", () => {
       encoding: "utf8",
     });
     expect(files.trim().split("\n").sort()).toEqual(["a.txt", "b.txt"]);
+  });
+
+  it("cancels a stalled clone, closing the dialog and leaving nothing behind", async () => {
+    // The case #234 is about: a host that completes the TCP handshake and then
+    // never answers. Before this, the only way out was force-quitting the app —
+    // which left git finishing the transfer into a directory the frontend had
+    // already given up on.
+    stalled = await stalledGitRemote();
+
+    await $('[data-testid="welcome-clone"]').waitForDisplayed({
+      timeout: 30_000,
+      timeoutMsg: "Welcome screen never showed the Clone button",
+    });
+    await $('[data-testid="welcome-clone"]').click();
+
+    const urlInput = $('[data-testid="clone-url"]');
+    await urlInput.waitForDisplayed({
+      timeout: 30_000,
+      timeoutMsg: "Clone dialog never opened",
+    });
+    await urlInput.setValue(stalled.url);
+    await $('[data-testid="clone-parent"]').setValue(dest);
+    await $('[data-testid="clone-name"]').setValue("cancelled");
+    await $('[data-testid="clone-submit"]').click();
+
+    // Running, and unable to finish. This wait is also the proof that the clone
+    // really started — a URL git rejected outright would land in the error slot
+    // instead, and there would be nothing to cancel.
+    await $('[data-testid="clone-progress"]').waitForDisplayed({
+      timeout: 30_000,
+      timeoutMsg: "the clone never started, so there was nothing to cancel",
+    });
+
+    // The one control the user reaches for, which used to be disabled here.
+    const cancel = $('[data-testid="clone-cancel"]');
+    expect(await cancel.isEnabled()).toBe(true);
+    await cancel.click();
+
+    // Back to Welcome: the dialog closed AND no repository was opened. It closes
+    // only on the backend's `Cancelled`, so reaching this state means the
+    // cleanup has already run.
+    await $('[data-testid="welcome-clone"]').waitForDisplayed({
+      timeout: 30_000,
+      timeoutMsg:
+        "the Clone dialog never closed after Cancel — is the cancel reaching the backend?",
+    });
+
+    // repo truth: no half-written destination.
+    expect(existsSync(join(dest, "cancelled"))).toBe(false);
   });
 });

--- a/e2e/specs/remote.e2e.ts
+++ b/e2e/specs/remote.e2e.ts
@@ -1,6 +1,7 @@
 import { browser, $, expect } from "@wdio/globals";
 import {
-  remoteRepo, makeAhead, makeBehind, makeDiverged, type RemotePair,
+  remoteRepo, makeAhead, makeBehind, makeDiverged, stalledGitRemote,
+  type RemotePair, type StalledRemote,
 } from "../support/tempRepo";
 import {
   openRepo, resetApp, switchScreen, stubNativeDialogs,
@@ -9,11 +10,47 @@ import {
 
 describe("remote operations", () => {
   let pair: RemotePair | null = null;
+  let stalled: StalledRemote | undefined;
 
   afterEach(async () => {
     await resetApp();
     pair?.dispose();
     pair = null;
+    // A listener left open keeps a git child alive past its own test.
+    stalled?.dispose();
+    stalled = undefined;
+  });
+
+  it("Stop cancels a stalled fetch, with no error banner", async () => {
+    // The titlebar's Stop button (#234), through the real IPC path: mint an id,
+    // fetch, kill the child's process group, and report `Cancelled` — which no
+    // surface may render as a failure.
+    pair = remoteRepo();
+    stalled = await stalledGitRemote();
+    // Point origin at something that connects and then never answers, so the
+    // fetch cannot finish on its own.
+    pair.repo.git("remote", "set-url", "origin", stalled.url);
+    await openRepo(pair.repo.path);
+
+    await $("button*=Fetch").click(); // titlebar (default screen — unambiguous)
+
+    const stop = $('[data-testid="net-cancel"]');
+    await stop.waitForDisplayed({
+      timeout: 30_000,
+      timeoutMsg: "Stop never appeared while the fetch was in flight",
+    });
+    await stop.click();
+
+    // It disappears when the op clears, which is the UI's own signal that the
+    // fetch is over — and it can only clear once the backend call returned.
+    await stop.waitForExist({
+      reverse: true,
+      timeout: 30_000,
+      timeoutMsg: "the fetch never stopped after Stop was clicked",
+    });
+    // A cancel is not a failure: the user pressed the button, and a banner
+    // saying so looks exactly like the failures that do need attention.
+    expect(await $('div[role="alert"]').isExisting()).toBe(false);
   });
 
   it("lists origin with url; ahead count shows on the ahead fixture", async () => {

--- a/e2e/support/tempRepo.ts
+++ b/e2e/support/tempRepo.ts
@@ -456,3 +456,48 @@ export function bisectRepo(): TempRepo {
   }
   return r;
 }
+
+/**
+ * A remote that accepts the TCP connection and then never answers (#234).
+ *
+ * The only way to test a cancel is to have something that cannot finish, and
+ * every other fixture here is deliberately local and instant. A `file://` clone
+ * is over before a button can be clicked; a bad host fails fast. This is the
+ * third case — the one the issue is actually about, and the one that used to
+ * mean force-quitting the app: `git clone`/`fetch` completes its TCP handshake,
+ * sends its request, and waits for a reply that never comes.
+ *
+ * `git://` rather than https: the git protocol's first move is a plain request
+ * line with no TLS handshake to fail, so a bare `net` listener that reads and
+ * says nothing is enough. No network access, no sleeps, nothing to flake — the
+ * op hangs until something kills it, which is the thing under test.
+ *
+ * The spec process and the app share a network namespace (the e2e container runs
+ * both), so 127.0.0.1 here is 127.0.0.1 there.
+ */
+export interface StalledRemote {
+  /** A URL that will connect and then hang forever. */
+  url: string;
+  dispose: () => void;
+}
+
+export async function stalledGitRemote(): Promise<StalledRemote> {
+  const { createServer } = await import("node:net");
+  const held: import("node:net").Socket[] = [];
+  // Sockets are HELD, not dropped: closing one would let git see EOF and fail
+  // on its own, which would leave nothing to cancel.
+  const server = createServer((socket) => {
+    held.push(socket);
+    socket.on("error", () => {});
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  return {
+    url: `git://127.0.0.1:${port}/stalled.git`,
+    dispose: () => {
+      for (const socket of held) socket.destroy();
+      server.close();
+    },
+  };
+}

--- a/src-tauri/src/cancel.rs
+++ b/src-tauri/src/cancel.rs
@@ -1,0 +1,374 @@
+//! Cancelling a long-running child process (#234).
+//!
+//! # Why a registry and not a channel
+//!
+//! Every network op in this app is a spawned `git` (`proc::git_async`,
+//! `git_async_in`), so cancellation is a signal — the hard part is *addressing*
+//! the child from a second, unrelated IPC call.
+//!
+//! The obvious shape, a `tokio::select!` over `child.wait()` and a cancel
+//! future, does not survive contact with the borrow checker: both arms need
+//! `&mut child`. The next one, `Arc<Mutex<Child>>` shared with a killer task,
+//! deadlocks — the op holds the lock across `wait()`, which is precisely the
+//! await the killer needs to interrupt.
+//!
+//! So the registry does not *ask* the op to stop. It kills the op's child
+//! directly, from the cancelling call's own task, and the op then **notices**:
+//! its `wait()` returns because the child is dead, and it checks
+//! [`Op::is_cancelled`] before mapping stderr to an error. No shared `Child`, no
+//! select, no timers.
+//!
+//! # Why the frontend supplies the id
+//!
+//! The op we most need to cancel is the one that never answers, so an id minted
+//! by the backend and emitted back would leave an unbounded window where the op
+//! is running and unaddressable. The frontend generates the id before the invoke
+//! (`src/lib/opId.ts`), so the cancel button is live from the first frame.
+//!
+//! An op with no id is **detached**: it never enters the map and can never be
+//! cancelled. That is what lets `push_tag`, LFS, submodule update and the forge
+//! PR checkout keep their current behaviour without branching anywhere.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+/// One cancellable operation.
+pub struct Op {
+    /// `None` for a detached op — nothing to look up, nothing to cancel.
+    id: Option<String>,
+    cancelled: AtomicBool,
+    /// The child's pid, once it has been spawned. `None` in the window between
+    /// registration and spawn, which is exactly the window [`Op::attach`]
+    /// closes.
+    pid: Mutex<Option<u32>>,
+}
+
+impl Op {
+    /// An op nobody can cancel. Callers hold one of these instead of an
+    /// `Option<&Op>`, so there is no second code path to keep in step.
+    pub fn detached() -> Self {
+        Self {
+            id: None,
+            cancelled: AtomicBool::new(false),
+            pid: Mutex::new(None),
+        }
+    }
+
+    fn tracked(id: String) -> Self {
+        Self {
+            id: Some(id),
+            cancelled: AtomicBool::new(false),
+            pid: Mutex::new(None),
+        }
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::SeqCst)
+    }
+
+    /// Record the child we just spawned.
+    ///
+    /// Returns `false` when a cancel arrived in the window between registration
+    /// and the spawn — the caller must then kill its own child (it still holds
+    /// `&mut Child`, so `start_kill` is right there) and bail. Without this, a
+    /// cancel clicked in the first milliseconds would set the flag, find no pid,
+    /// and leave a `git` running with nobody left to stop it.
+    pub fn attach(&self, pid: u32) -> bool {
+        *self.pid.lock().expect("op pid mutex") = Some(pid);
+        !self.is_cancelled()
+    }
+
+    /// Cancel: mark, then kill the child's whole process group.
+    ///
+    /// The **second** call escalates to `SIGKILL`. The user clicking Cancel again
+    /// is the escalation signal — a timer would need `tokio::time` and a rule for
+    /// how long to wait, and the first click has already given git its chance to
+    /// clean up after itself.
+    pub fn cancel(&self) {
+        let already = self.cancelled.swap(true, Ordering::SeqCst);
+        let pid = *self.pid.lock().expect("op pid mutex");
+        if let Some(pid) = pid {
+            kill_tree(pid, already);
+        }
+    }
+}
+
+/// Every in-flight cancellable op, by id.
+#[derive(Default)]
+pub struct OpRegistry {
+    ops: Mutex<HashMap<String, Arc<Op>>>,
+}
+
+impl OpRegistry {
+    /// Register an op and hand back a guard that de-registers on drop.
+    ///
+    /// `id: None` yields a detached op, so a caller that was given no id needs no
+    /// special case. A repeat of an id already in the map replaces it: the id is
+    /// minted per invoke, so a collision means the frontend re-used one, and the
+    /// newer op is the one a cancel is meant for.
+    pub fn begin(self: &Arc<Self>, id: Option<&str>) -> OpGuard {
+        let op = match id {
+            None => Arc::new(Op::detached()),
+            Some(id) => {
+                let op = Arc::new(Op::tracked(id.to_string()));
+                self.ops
+                    .lock()
+                    .expect("op registry mutex")
+                    .insert(id.to_string(), op.clone());
+                op
+            }
+        };
+        OpGuard {
+            registry: self.clone(),
+            op,
+        }
+    }
+
+    /// Cancel one op. `false` when no op with that id is in flight — a stale
+    /// cancel (the op finished between the click and the invoke), which is not an
+    /// error the user needs to hear about.
+    pub fn cancel(&self, id: &str) -> bool {
+        let op = self.ops.lock().expect("op registry mutex").get(id).cloned();
+        match op {
+            Some(op) => {
+                op.cancel();
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Cancel everything in flight. The window-close path (`lib.rs`): a `git`
+    /// that outlives the app is a transfer nobody can see and nobody can stop.
+    pub fn cancel_all(&self) -> usize {
+        // Cloned out from under the lock: `Op::cancel` spawns `taskkill` on
+        // Windows, and holding the registry lock across that would block every
+        // op that is trying to finish.
+        let ops: Vec<Arc<Op>> = self
+            .ops
+            .lock()
+            .expect("op registry mutex")
+            .values()
+            .cloned()
+            .collect();
+        for op in &ops {
+            op.cancel();
+        }
+        ops.len()
+    }
+
+    fn finish(&self, id: &str) {
+        self.ops.lock().expect("op registry mutex").remove(id);
+    }
+}
+
+/// Keeps an op in the registry for the lifetime of the operation.
+///
+/// A guard rather than a `finish()` call at the end of each command: every
+/// cancellable op has `?` returns in it, and an entry left behind would make a
+/// later cancel signal a pid that has since been recycled.
+pub struct OpGuard {
+    registry: Arc<OpRegistry>,
+    op: Arc<Op>,
+}
+
+impl OpGuard {
+    pub fn op(&self) -> &Op {
+        &self.op
+    }
+}
+
+impl Drop for OpGuard {
+    fn drop(&mut self) {
+        if let Some(id) = &self.op.id {
+            self.registry.finish(id);
+        }
+    }
+}
+
+/// Kill `pid` and everything it spawned.
+///
+/// # Why the process GROUP
+///
+/// `git clone` over https spawns `git-remote-https`; over ssh it spawns `ssh`.
+/// Killing only `git` leaves that child holding the connection, so the transfer
+/// the user cancelled carries on.
+///
+/// # Why SIGTERM first
+///
+/// git installs signal handlers that remove its lock files (`lockfile.c`) and,
+/// in `clone`, the partially-written destination (`remove_junk_on_signal`).
+/// SIGKILL skips all of it, so a SIGKILLed pull leaves `.git/index.lock` behind
+/// and the *next* pull fails with "Unable to create '…/index.lock': File
+/// exists". A cancel that breaks the following operation is worse than no cancel.
+#[cfg(unix)]
+pub fn kill_tree(pid: u32, hard: bool) {
+    let sig = if hard { libc::SIGKILL } else { libc::SIGTERM };
+    let pid = pid as libc::pid_t;
+    // `getpgid` first, and `killpg` ONLY when the child really is its own group
+    // leader. `proc::git_async*` puts it in one, but a future spawn site that
+    // forgot would otherwise have us signal OUR OWN process group — i.e. kill
+    // the app, from a cancel button. The check makes that unreachable rather
+    // than merely unlikely.
+    let group_leader = unsafe { libc::getpgid(pid) } == pid;
+    unsafe {
+        if group_leader {
+            libc::killpg(pid, sig);
+        } else {
+            libc::kill(pid, sig);
+        }
+    }
+}
+
+/// The Windows tree-kill's argv.
+///
+/// A pure function, compiled and tested on **every** platform even though only
+/// Windows runs it — the same split `reveal.rs` uses for its per-platform argv,
+/// and for the same reason: `#[cfg(windows)]` code is invisible to this repo's
+/// PR CI (only `release.yml` builds Windows), so a mistake here would surface at
+/// release time. Keeping the interesting half platform-independent leaves three
+/// lines of genuinely conditional code.
+///
+/// * `/T` — the whole tree. `git` is rarely the process doing the waiting; this
+///   is Windows' answer to the process group unix gets from `killpg`.
+/// * `/F` — forced. There is no graceful option for a console child spawned with
+///   `CREATE_NO_WINDOW`: it has no console for `GenerateConsoleCtrlEvent` to
+///   signal, and plain `taskkill` sends a `WM_CLOSE` that a console app ignores.
+// Only the `#[cfg(windows)]` sibling below calls it, so off Windows the sole
+// caller is its own test — which `dead_code` does not count.
+#[cfg_attr(not(windows), allow(dead_code))]
+pub(crate) fn taskkill_args(pid: u32) -> [String; 4] {
+    [
+        "/F".to_string(),
+        "/T".to_string(),
+        "/PID".to_string(),
+        pid.to_string(),
+    ]
+}
+
+/// Windows has no SIGTERM, so git gets no chance to remove its lock files —
+/// see [`taskkill_args`]. `discard_partial_clone` covers the clone destination;
+/// a stale `index.lock` after a cancelled pull is the known remaining gap,
+/// recorded in `docs/dev/backend.md`.
+///
+/// Fire-and-forget: `taskkill` is spawned and not awaited, because `cancel()` is
+/// called from a sync window-event handler as well as from a command.
+#[cfg(windows)]
+pub fn kill_tree(pid: u32, _hard: bool) {
+    // Through `proc::program` — `tests/spawn_no_window.rs` fails the build on a
+    // raw `Command::new` anywhere outside proc.rs.
+    let _ = crate::proc::program("taskkill")
+        .args(taskkill_args(pid))
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn registry() -> Arc<OpRegistry> {
+        Arc::new(OpRegistry::default())
+    }
+
+    #[test]
+    fn a_detached_op_is_never_cancelled() {
+        let reg = registry();
+        let guard = reg.begin(None);
+        // Nothing to look up, so the only way to cancel it would be by id.
+        assert!(!reg.cancel("anything"));
+        assert!(!guard.op().is_cancelled());
+    }
+
+    #[test]
+    fn cancelling_a_tracked_op_marks_it() {
+        let reg = registry();
+        let guard = reg.begin(Some("op-1"));
+        assert!(reg.cancel("op-1"));
+        assert!(guard.op().is_cancelled());
+    }
+
+    #[test]
+    fn cancelling_an_unknown_id_is_not_an_error() {
+        // A cancel that lost the race with the op finishing. The user gets
+        // nothing, which is correct: the op they wanted stopped has stopped.
+        assert!(!registry().cancel("op-that-finished"));
+    }
+
+    #[test]
+    fn attach_refuses_after_a_cancel_has_landed() {
+        // The window this exists for: Cancel clicked between `begin` and
+        // `spawn`. `false` tells the caller to kill the child it is holding.
+        let reg = registry();
+        let guard = reg.begin(Some("op-2"));
+        reg.cancel("op-2");
+        assert!(!guard.op().attach(999_999));
+    }
+
+    #[test]
+    fn attach_accepts_while_the_op_is_live() {
+        let reg = registry();
+        let guard = reg.begin(Some("op-3"));
+        assert!(guard.op().attach(999_999));
+    }
+
+    #[test]
+    fn dropping_the_guard_deregisters() {
+        let reg = registry();
+        {
+            let _guard = reg.begin(Some("op-4"));
+            assert!(reg.ops.lock().unwrap().contains_key("op-4"));
+        }
+        // Or a later cancel signals a pid that has since been recycled.
+        assert!(!reg.ops.lock().unwrap().contains_key("op-4"));
+        assert!(!reg.cancel("op-4"));
+    }
+
+    #[test]
+    fn cancel_all_marks_every_op_in_flight() {
+        let reg = registry();
+        let a = reg.begin(Some("op-a"));
+        let b = reg.begin(Some("op-b"));
+        assert_eq!(reg.cancel_all(), 2);
+        assert!(a.op().is_cancelled());
+        assert!(b.op().is_cancelled());
+    }
+
+    #[test]
+    fn cancel_all_with_nothing_in_flight_does_nothing() {
+        assert_eq!(registry().cancel_all(), 0);
+    }
+
+    #[test]
+    fn re_using_an_id_replaces_the_entry_so_cancel_hits_the_newer_op() {
+        let reg = registry();
+        let first = reg.begin(Some("dup"));
+        let second = reg.begin(Some("dup"));
+        assert!(reg.cancel("dup"));
+        assert!(second.op().is_cancelled());
+        assert!(!first.op().is_cancelled());
+    }
+
+    /// Runs everywhere, kills only on Windows. `/T` is the load-bearing flag:
+    /// without it the transport helper (`git-remote-https`, `ssh`) survives the
+    /// cancel and the transfer carries on.
+    #[test]
+    fn the_windows_tree_kill_asks_for_the_whole_tree_by_pid() {
+        assert_eq!(
+            taskkill_args(4321),
+            ["/F".to_string(), "/T".to_string(), "/PID".to_string(), "4321".to_string()]
+        );
+    }
+
+    /// A cancel with no pid recorded must still MARK the op, or the op would
+    /// spawn its child and then run to completion having never noticed.
+    #[test]
+    fn cancelling_before_the_spawn_still_marks() {
+        let reg = registry();
+        let guard = reg.begin(Some("op-5"));
+        reg.cancel("op-5");
+        assert!(guard.op().is_cancelled());
+    }
+}

--- a/src-tauri/src/commands/branches.rs
+++ b/src-tauri/src/commands/branches.rs
@@ -1,6 +1,9 @@
+use std::sync::Arc;
+
 use tauri::State;
 
 use crate::{
+    cancel::OpRegistry,
     commands::net::Credentials,
     error::{AppError, AppResult},
     git::types::{BranchInfo, PullMode, PushForce, RemoteInfo, RepoId, StashInfo, TagInfo, TagTarget},
@@ -150,6 +153,23 @@ async fn run_git_creds(
     crate::commands::net::run_git_authenticated(cwd, args, creds).await
 }
 
+/// [`run_git_creds`], stoppable while `op_id` is in flight (#234).
+///
+/// `op_id: None` means "not cancellable" and behaves exactly like
+/// `run_git_creds` — that is what keeps the option open for `push_tag` and the
+/// rest without changing them now. The guard de-registers on drop, including on
+/// the `?` paths below.
+async fn run_git_cancellable(
+    registry: &Arc<OpRegistry>,
+    op_id: Option<&str>,
+    cwd: &std::path::Path,
+    args: &[&str],
+    creds: Option<&Credentials>,
+) -> AppResult<()> {
+    let guard = registry.begin(op_id);
+    crate::commands::net::run_git_cancellable(cwd, args, creds, guard.op()).await
+}
+
 /// Build the argument list for `git fetch`. `remote = None` means all remotes.
 fn fetch_args(remote: Option<&str>, prune: bool) -> Vec<&str> {
     let mut args = vec!["fetch"];
@@ -166,6 +186,7 @@ fn fetch_args(remote: Option<&str>, prune: bool) -> Vec<&str> {
 #[tauri::command]
 pub async fn fetch(
     state: State<'_, AppState>,
+    registry: State<'_, Arc<OpRegistry>>,
     repo_id: String,
     remote: String,
     prune: bool,
@@ -173,9 +194,15 @@ pub async fn fetch(
     // the first attempt is always prompt-less, and only a retry carries a
     // credential (#61 D5).
     credentials: Option<Credentials>,
+    // The frontend's handle on this op, for `cancel_operation` (#234). Minted
+    // before the invoke so the cancel button is live from the first frame —
+    // omitted means uncancellable, which is what it was before.
+    op_id: Option<String>,
 ) -> AppResult<()> {
     let path = get_repo_path(&state, &RepoId(repo_id)).await?;
-    run_git_creds(
+    run_git_cancellable(
+        &registry,
+        op_id.as_deref(),
         &path,
         &fetch_args(Some(remote.as_str()), prune),
         credentials.as_ref(),
@@ -186,22 +213,33 @@ pub async fn fetch(
 #[tauri::command]
 pub async fn fetch_all(
     state: State<'_, AppState>,
+    registry: State<'_, Arc<OpRegistry>>,
     repo_id: String,
     prune: bool,
     credentials: Option<Credentials>,
+    op_id: Option<String>,
 ) -> AppResult<()> {
     let path = get_repo_path(&state, &RepoId(repo_id)).await?;
-    run_git_creds(&path, &fetch_args(None, prune), credentials.as_ref()).await
+    run_git_cancellable(
+        &registry,
+        op_id.as_deref(),
+        &path,
+        &fetch_args(None, prune),
+        credentials.as_ref(),
+    )
+    .await
 }
 
 #[tauri::command]
 pub async fn pull(
     state: State<'_, AppState>,
+    registry: State<'_, Arc<OpRegistry>>,
     repo_id: String,
     remote: String,
     branch: String,
     mode: PullMode,
     credentials: Option<Credentials>,
+    op_id: Option<String>,
 ) -> AppResult<()> {
     let path = get_repo_path(&state, &RepoId(repo_id)).await?;
     let mode_flag = match mode {
@@ -209,7 +247,9 @@ pub async fn pull(
         PullMode::Merge => "--no-rebase",
         PullMode::Rebase => "--rebase",
     };
-    run_git_creds(
+    run_git_cancellable(
+        &registry,
+        op_id.as_deref(),
         &path,
         &["pull", mode_flag, remote.as_str(), branch.as_str()],
         credentials.as_ref(),
@@ -249,6 +289,7 @@ fn push_args(
 #[tauri::command]
 pub async fn push(
     state: State<'_, AppState>,
+    registry: State<'_, Arc<OpRegistry>>,
     repo_id: String,
     remote: String,
     branch: String,
@@ -256,6 +297,7 @@ pub async fn push(
     credentials: Option<Credentials>,
     // Skip `pre-push` for this push only (#232).
     no_verify: Option<bool>,
+    op_id: Option<String>,
 ) -> AppResult<()> {
     let repo_id = RepoId(repo_id);
     let path = get_repo_path(&state, &repo_id).await?;
@@ -280,7 +322,14 @@ pub async fn push(
 
     let args = push_args(&remote, &branch, force, needs_upstream, no_verify.unwrap_or(false));
     let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-    run_git_creds(&path, &arg_refs, credentials.as_ref()).await
+    run_git_cancellable(
+        &registry,
+        op_id.as_deref(),
+        &path,
+        &arg_refs,
+        credentials.as_ref(),
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/create.rs
+++ b/src-tauri/src/commands/create.rs
@@ -4,6 +4,7 @@ use tauri::{AppHandle, Emitter, State};
 use tokio::io::AsyncReadExt;
 
 use crate::{
+    cancel::{Op, OpRegistry},
     error::{AppError, AppResult},
     git::libgit2::default_branch_name,
     git::types::{CloneProgress, RepoHandle},
@@ -211,12 +212,20 @@ pub fn clone_args(url: &str, name: &str, recurse_submodules: bool) -> Vec<String
 /// Keeps `run_git`'s environment exactly (`commands/branches.rs`): prompts are
 /// hard-disabled, so a private repo works only when the user's credential
 /// helper or SSH agent answers without a TTY. Returns the destination path.
+///
+/// `op` makes it cancellable (#234). Cancel kills the child from another task;
+/// this function notices at three points — before the spawn, when `attach`
+/// refuses, and once the child has died — and every one of them runs
+/// [`discard_partial_clone`] before returning `Cancelled`, so a cancelled clone
+/// leaves the destination as it found it. Pass `&Op::detached()` for a clone
+/// nobody can stop.
 pub async fn run_clone(
     url: &str,
     parent: &Path,
     name: &str,
     recurse_submodules: bool,
     creds: Option<&crate::commands::net::Credentials>,
+    op: &Op,
     mut on_progress: impl FnMut(CloneProgress),
 ) -> AppResult<PathBuf> {
     // Trimmed once, here, and reused for both validation and argv below.
@@ -241,6 +250,11 @@ pub async fn run_clone(
     }
 
     let target = validate_clone_target(parent, name)?;
+    // Recorded BEFORE git touches anything, because it is the only way to know
+    // what "as we found it" means on a cancel. `validate_clone_target` has
+    // already narrowed the possibilities to exactly two: the target is absent,
+    // or it is an existing EMPTY directory. See `discard_partial_clone`.
+    let target_existed = std::fs::symlink_metadata(&target).is_ok();
     let args = clone_args(url, name, recurse_submodules);
 
     // `git_async_in` and not `git_async`: a clone's working directory is the
@@ -268,9 +282,27 @@ pub async fn run_clone(
     // so it cannot be silently overridden by one of the calls above.
     crate::commands::net::apply_auth_env(&mut cmd, creds);
 
+    // Cancelled between the click and here — do not start a transfer nobody is
+    // waiting for.
+    if op.is_cancelled() {
+        discard_partial_clone(&target, target_existed);
+        return Err(AppError::Cancelled);
+    }
+
     let mut child = cmd
         .spawn()
         .map_err(|e| AppError::Io(format!("failed to run git clone: {e}")))?;
+
+    // `id()` answers `None` once the child has been reaped, so read it now.
+    if let Some(pid) = child.id() {
+        if !op.attach(pid) {
+            // Cancel landed between the check above and the spawn. Nothing else
+            // holds this child yet, so kill it here.
+            let _ = child.start_kill();
+            discard_partial_clone(&target, target_existed);
+            return Err(AppError::Cancelled);
+        }
+    }
 
     let mut stderr = child
         .stderr
@@ -293,10 +325,19 @@ pub async fn run_clone(
     const MAX_PENDING: usize = 4096;
 
     loop {
-        let read = stderr
-            .read(&mut chunk)
-            .await
-            .map_err(|e| AppError::Io(format!("reading git clone output: {e}")))?;
+        let read = match stderr.read(&mut chunk).await {
+            Ok(n) => n,
+            // A cancel kills git mid-stream, and what that looks like from here
+            // is a broken pipe. Claim it before it becomes an `Io` error the
+            // dialog would render in red.
+            Err(e) => {
+                if op.is_cancelled() {
+                    discard_partial_clone(&target, target_existed);
+                    return Err(AppError::Cancelled);
+                }
+                return Err(AppError::Io(format!("reading git clone output: {e}")));
+            }
+        };
         if read == 0 {
             break;
         }
@@ -320,6 +361,13 @@ pub async fn run_clone(
         .wait()
         .await
         .map_err(|e| AppError::Io(format!("waiting for git clone: {e}")))?;
+    // BEFORE `map_git_failure`: a killed `git clone`'s last words read like a
+    // network failure, and on a bad day like an auth failure — which would pop
+    // the credential dialog over a cancel.
+    if op.is_cancelled() {
+        discard_partial_clone(&target, target_existed);
+        return Err(AppError::Cancelled);
+    }
     if !status.success() {
         // Routed through the shared classifier so a private repo yields Auth
         // (promptable + retryable) rather than a dead-end Network error, and so
@@ -344,6 +392,56 @@ fn clone_failure_message(tail: &[String], exit_code: Option<i32>) -> String {
     match exit_code {
         Some(code) => format!("git clone failed (exit {code})"),
         None => "git clone failed (terminated by signal)".to_string(),
+    }
+}
+
+/// Put the clone destination back the way we found it, after a cancel (#234).
+///
+/// `validate_clone_target` accepts exactly two starting states, so there are
+/// exactly two things to undo:
+///
+/// | Before the clone | What this does |
+/// | --- | --- |
+/// | the target did not exist | removes the directory git created |
+/// | the target existed and was empty | removes its CONTENTS, keeps the directory |
+///
+/// The split is the point: the second case is a directory **the user already
+/// had**, and deleting it because a clone into it was cancelled would be
+/// destroying something we were never given.
+///
+/// Usually a no-op on unix, and deliberately so: cancel sends SIGTERM, and `git
+/// clone`'s own `remove_junk_on_signal` handler has already removed its
+/// destination by the time we look. This is the backstop for the cases where
+/// that does not happen — Windows, where cancel is a hard `taskkill`, and a git
+/// killed before its handler is installed.
+///
+/// Best-effort by design: every failure here is ignored. A cancel that reports
+/// "could not clean up" on top of itself tells the user nothing they can act on,
+/// and the operation they asked to stop HAS stopped.
+///
+/// Cancel only, never failure: a failed `git clone` removes its own destination,
+/// and widening this to every failure would mean deleting a directory on a path
+/// we have not just proved is ours.
+pub fn discard_partial_clone(target: &Path, existed_before: bool) {
+    if !existed_before {
+        let _ = std::fs::remove_dir_all(target);
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(target) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        // `file_type` reports the LINK for a symlink rather than following it,
+        // so a link git wrote is unlinked instead of being walked into.
+        match entry.file_type() {
+            Ok(t) if t.is_dir() => {
+                let _ = std::fs::remove_dir_all(&path);
+            }
+            _ => {
+                let _ = std::fs::remove_file(&path);
+            }
+        }
     }
 }
 
@@ -374,23 +472,30 @@ fn handle_clone_line(bytes: &[u8], on_progress: &mut impl FnMut(CloneProgress), 
 #[tauri::command]
 pub async fn clone_repo(
     app: AppHandle,
+    registry: State<'_, std::sync::Arc<OpRegistry>>,
     url: String,
     parent_dir: String,
     name: String,
     recurse_submodules: bool,
     credentials: Option<crate::commands::net::Credentials>,
+    // The frontend's handle on this clone, for `cancel_operation` (#234).
+    op_id: Option<String>,
 ) -> AppResult<String> {
     let url = url.trim().to_string();
     if url.is_empty() {
         return Err(AppError::InvalidPath("no repository URL given".into()));
     }
     let parent = PathBuf::from(parent_dir);
+    // Registered before the first await, and de-registered by the guard's Drop
+    // on every path out of here — including the `?` below.
+    let guard = registry.begin(op_id.as_deref());
     let dest = run_clone(
         &url,
         &parent,
         &name,
         recurse_submodules,
         credentials.as_ref(),
+        guard.op(),
         |p| {
             // A dropped event only costs a progress tick, never the clone.
             let _ = app.emit("clone://progress", &p);
@@ -455,6 +560,74 @@ mod tests {
             clone_failure_message(&["fatal: repository not found".to_string()], Some(128)),
             "fatal: repository not found"
         );
+    }
+
+    /// The case that matters most: a directory the user already had, cloned into
+    /// and then cancelled, keeps existing and comes back empty.
+    #[test]
+    fn discarding_keeps_a_directory_that_existed_before_the_clone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("dest");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::create_dir_all(target.join(".git/objects")).unwrap();
+        std::fs::write(target.join(".git/config"), "partial").unwrap();
+        std::fs::write(target.join("README.md"), "half a checkout").unwrap();
+
+        discard_partial_clone(&target, true);
+
+        assert!(target.is_dir(), "the user's own directory must survive");
+        assert_eq!(
+            std::fs::read_dir(&target).unwrap().count(),
+            0,
+            "everything git wrote is gone"
+        );
+    }
+
+    #[test]
+    fn discarding_removes_a_directory_the_clone_created() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("dest");
+        std::fs::create_dir_all(target.join(".git")).unwrap();
+        std::fs::write(target.join(".git/config"), "partial").unwrap();
+
+        discard_partial_clone(&target, false);
+
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn discarding_a_target_git_already_removed_is_a_no_op() {
+        // The common case on unix: SIGTERM, and `git clone`'s own signal handler
+        // removed the destination before we looked. Must not be an error, and
+        // must not touch the parent.
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("gone");
+
+        discard_partial_clone(&target, false);
+        discard_partial_clone(&target, true);
+
+        assert!(tmp.path().is_dir());
+    }
+
+    /// A symlink git wrote into the destination is unlinked, not followed — or a
+    /// cancelled clone of a repository containing `link -> /etc` would take the
+    /// cleanup outside the destination.
+    #[test]
+    fn discarding_unlinks_a_symlink_instead_of_walking_into_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(outside.join("keep.txt"), "not ours to delete").unwrap();
+
+        let target = tmp.path().join("dest");
+        std::fs::create_dir(&target).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&outside, target.join("link")).unwrap();
+
+        discard_partial_clone(&target, true);
+
+        assert!(target.is_dir());
+        assert!(outside.join("keep.txt").exists(), "followed the symlink");
     }
 
     #[test]

--- a/src-tauri/src/commands/net.rs
+++ b/src-tauri/src/commands/net.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use serde::Deserialize;
 
 use crate::{
+    cancel::{Op, OpRegistry},
     cli::{ASKPASS_MODE_ENV, ASKPASS_SECRET_ENV, ASKPASS_USERNAME_ENV},
     error::{AppError, AppResult},
     git::auth::{classify_auth_failure, host_from_stderr, scrub_credentials, AuthChallenge},
@@ -88,26 +89,98 @@ pub fn map_git_failure(stderr: &str) -> AppError {
 }
 
 /// Run `git -C cwd <args>`, mapping a non-zero exit through `map_git_failure`.
+///
+/// Uncancellable, which is right for every op with no progress surface —
+/// `push_tag`, `push_delete_branch`, `git lfs fetch/pull`, `submodule update`,
+/// the forge PR checkout. Fetch, pull and push go through
+/// [`run_git_cancellable`] instead; opting one of these in later is passing an
+/// `Op` instead of a detached one.
 pub async fn run_git_authenticated(
     cwd: &Path,
     args: &[&str],
     creds: Option<&Credentials>,
 ) -> AppResult<()> {
+    run_git_cancellable(cwd, args, creds, &Op::detached()).await
+}
+
+/// [`run_git_authenticated`], stoppable through `op` (#234).
+///
+/// The cancel path does not interrupt this function; it kills the child from
+/// another task and this one **notices** — `wait_with_output` returns because the
+/// child is dead, and the `is_cancelled` check below claims that death before
+/// `map_git_failure` can classify it. See `cancel.rs` for why it is arranged that
+/// way rather than as a `select!`.
+pub async fn run_git_cancellable(
+    cwd: &Path,
+    args: &[&str],
+    creds: Option<&Credentials>,
+    op: &Op,
+) -> AppResult<()> {
     // `proc::git_async` carries GIT_TERMINAL_PROMPT=0 (which `apply_auth_env`
     // sets too), a closed stdin — nothing feeds it, so an unexpected read would
-    // block forever — and, on Windows, CREATE_NO_WINDOW: without it every fetch,
+    // block forever — on Windows CREATE_NO_WINDOW: without it every fetch,
     // pull and push flashed a console, including the ones auto-fetch runs on a
-    // timer with no user action at all (issue 172).
+    // timer with no user action at all (issue 172) — and, on unix, its own
+    // process group, which is what `cancel::kill_tree` signals (issue 234).
     let mut cmd = crate::proc::git_async(cwd);
     cmd.args(args);
     apply_auth_env(&mut cmd, creds);
+    cmd.stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        // A dropped future must not leave git running: it would finish the
+        // fetch, move refs, and report to nobody.
+        .kill_on_drop(true);
 
-    let output = cmd.output().await.map_err(|e| AppError::Io(e.to_string()))?;
+    // Cancelled before we even spawn — the user clicked Cancel while a previous
+    // attempt of the same op was still unwinding. Spawning here would start work
+    // nobody is waiting for.
+    if op.is_cancelled() {
+        return Err(AppError::Cancelled);
+    }
+
+    let mut child = cmd.spawn().map_err(|e| AppError::Io(e.to_string()))?;
+    // `id()` answers `None` once the child has been reaped, so read it now.
+    let pid = child.id();
+    if let Some(pid) = pid {
+        if !op.attach(pid) {
+            // Cancel landed between the check above and the spawn. Nothing else
+            // holds this child, so kill it here.
+            let _ = child.start_kill();
+            return Err(AppError::Cancelled);
+        }
+    }
+
+    let output = child
+        .wait_with_output()
+        .await
+        .map_err(|e| AppError::Io(e.to_string()))?;
+
+    // BEFORE `map_git_failure`: a killed git dies mid-transfer, and its last
+    // stderr line reads like a network failure — or, on a bad day, like an auth
+    // failure, which would pop the credential dialog over a cancel.
+    if op.is_cancelled() {
+        return Err(AppError::Cancelled);
+    }
 
     if !output.status.success() {
         return Err(map_git_failure(&String::from_utf8_lossy(&output.stderr)));
     }
     Ok(())
+}
+
+/// Stop the operation the frontend registered under `op_id` (#234).
+///
+/// `false` means nothing with that id is in flight — the op finished between the
+/// click and this call. Not an error: what the user asked for has happened.
+///
+/// Calling it a second time for the same op escalates SIGTERM to SIGKILL; see
+/// `cancel::Op::cancel`.
+#[tauri::command]
+pub async fn cancel_operation(
+    registry: tauri::State<'_, std::sync::Arc<OpRegistry>>,
+    op_id: String,
+) -> AppResult<bool> {
+    Ok(registry.cancel(&op_id))
 }
 
 /// Store a credential with the user's own git credential helper (#61 D5).

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -137,6 +137,21 @@ pub enum AppError {
     /// from no error at all, which is what an absent hook produces.
     #[error("the {} hook rejected this commit", .0.hook)]
     HookRejected(HookRejection),
+
+    /// The user stopped a long-running operation (#234).
+    ///
+    /// A **state**, not a failure: the user already knows what happened, so no
+    /// surface may raise a banner for it — see `isCancelledError` in
+    /// `src/lib/errors.ts` and the catch arms in `useRepoStore`.
+    ///
+    /// Distinct from `Network` because that is what a killed git would otherwise
+    /// classify as: cancel kills the child, git dies mid-transfer, and its last
+    /// stderr line reads like a broken connection. Every cancellable op
+    /// therefore checks the cancel flag BEFORE `map_git_failure` ever sees that
+    /// line — which also keeps a dying remote from popping the credential dialog
+    /// over a cancel.
+    #[error("operation cancelled")]
+    Cancelled,
 }
 
 /// A hook's refusal (#232). `output` is whatever the hook printed, verbatim —

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cancel;
 pub mod cli;
 pub mod commands;
 pub mod detach;
@@ -144,7 +145,33 @@ pub fn run() {
     #[cfg(feature = "e2e")]
     let builder = builder.plugin(tauri_plugin_wdio_webdriver::init());
 
+    let cancel_registry = std::sync::Arc::new(crate::cancel::OpRegistry::default());
+
     builder
+        // Cancel every in-flight network op when the main window closes (#234).
+        //
+        // `kill_on_drop` on the children only fires if the future is dropped,
+        // and process exit does not unwind — so without this a `git clone`
+        // outlives the app, finishing a transfer nobody can see into a
+        // destination the user was told never got created
+        // (`commands/create.rs`'s comment on the same subject).
+        //
+        // Gated on the MAIN window: the merge resolver is a second window
+        // labelled `merge`, and closing it must not stop a fetch.
+        .on_window_event({
+            let registry = cancel_registry.clone();
+            move |window, event| {
+                if window.label() != "main" {
+                    return;
+                }
+                if matches!(event, tauri::WindowEvent::CloseRequested { .. }) {
+                    let stopped = registry.cancel_all();
+                    if stopped > 0 {
+                        log::info!("window closing — cancelled {stopped} network op(s)");
+                    }
+                }
+            }
+        })
         .setup(|_app| {
             log::info!(
                 "platypusgit starting v{}",
@@ -180,6 +207,11 @@ pub fn run() {
             }
             Ok(())
         })
+        // Cancel a running clone / fetch / pull / push (#234). An Arc rather
+        // than a bare value because `on_window_event` above and every
+        // cancellable command need the same registry, and `begin` hands its
+        // guard a clone.
+        .manage(cancel_registry)
         .manage(AppState::new(backend))
         // Per-host forge API tokens, cached for this process only (#92). NOT the
         // git-transport credential path — see forge/token.rs for why the two
@@ -316,6 +348,7 @@ pub fn run() {
             commands::forge::forge_pull_request_checks,
             commands::forge::forge_create_pull_request,
             commands::forge::forge_checkout_pull_request,
+            commands::net::cancel_operation,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -71,6 +71,36 @@ fn silence_async(cmd: &mut tokio::process::Command) {
 #[cfg(not(windows))]
 fn silence_async(_cmd: &mut tokio::process::Command) {}
 
+/// Put the child in its **own process group**, so cancelling it can signal the
+/// whole group rather than just `git` (#234).
+///
+/// `git` is rarely the process doing the waiting: over https it spawns
+/// `git-remote-https`, over ssh it spawns `ssh`. Signalling only `git` leaves
+/// that child holding the connection, so a cancelled transfer carries on.
+///
+/// Applied **inside the constructors**, for the same reason `CREATE_NO_WINDOW`
+/// is: a call site can forget, and here forgetting is not cosmetic —
+/// `cancel::kill_tree` would find a child that is not a group leader. (It checks
+/// `getpgid` and falls back to a single-process kill precisely so that a miss
+/// degrades instead of signalling our own group, but the constructor is where
+/// the guarantee belongs.)
+///
+/// Deliberately NOT applied by [`git_async_keeping_console`] /
+/// [`program_async_keeping_console`]: those are interactive terminal programs,
+/// and a console process in a group other than the terminal's foreground group
+/// is stopped by SIGTTIN/SIGTTOU the moment it reads or writes the tty. An
+/// invisible stopped `vimdiff` is exactly the failure those two exist to avoid.
+#[cfg(unix)]
+fn own_process_group(cmd: &mut tokio::process::Command) {
+    cmd.process_group(0);
+}
+
+/// No-op off unix. Windows has no process group to signal, and our children have
+/// no console for `GenerateConsoleCtrlEvent` either; cancellation there walks the
+/// tree with `taskkill /T` instead — see `cancel::kill_tree`.
+#[cfg(not(unix))]
+fn own_process_group(_cmd: &mut tokio::process::Command) {}
+
 /// Spawn `prog` with no console window.
 ///
 /// Nothing else is applied: this is for children that are not git and whose
@@ -285,11 +315,12 @@ pub fn git(workdir: &Path) -> std::process::Command {
     cmd
 }
 
-/// [`git`], async.
+/// [`git`], async — plus its own process group, so it can be cancelled (#234).
 pub fn git_async(workdir: &Path) -> tokio::process::Command {
     let mut cmd = program_async("git");
     cmd.arg("-C").arg(workdir);
     prompt_less_async(&mut cmd);
+    own_process_group(&mut cmd);
     cmd
 }
 
@@ -301,6 +332,7 @@ pub fn git_async_in(dir: &Path) -> tokio::process::Command {
     let mut cmd = program_async("git");
     cmd.current_dir(dir);
     prompt_less_async(&mut cmd);
+    own_process_group(&mut cmd);
     cmd
 }
 

--- a/src-tauri/tests/clone_init.rs
+++ b/src-tauri/tests/clone_init.rs
@@ -1,6 +1,7 @@
 mod support;
 
-use platypusgit_lib::commands::create::{clone_args, validate_clone_target};
+use platypusgit_lib::cancel::{Op, OpRegistry};
+use platypusgit_lib::commands::create::{clone_args, discard_partial_clone, validate_clone_target};
 use platypusgit_lib::error::AppError;
 use platypusgit_lib::git::{libgit2::default_branch_name, libgit2::Libgit2Backend, GitBackend};
 
@@ -454,6 +455,7 @@ async fn clone_from_a_local_bare_repo_lands_the_files() {
         "cloned",
         false,
         None,
+        &Op::detached(),
         |_| {},
     )
     .await
@@ -510,6 +512,7 @@ async fn clone_streams_progress_ticks_as_they_arrive() {
         "cloned",
         false,
         None,
+        &Op::detached(),
         move |p| ticks_for_closure.lock().unwrap().push(p),
     )
     .await
@@ -555,6 +558,7 @@ async fn run_clone_trims_whitespace_from_the_name_and_matches_disk() {
         "cloned ", // trailing space, exactly the reviewer's repro
         false,
         None,
+        &Op::detached(),
         |_| {},
     )
     .await
@@ -590,6 +594,7 @@ async fn run_clone_reports_a_missing_parent_directory_by_name() {
         "cloned",
         false,
         None,
+        &Op::detached(),
         |_| {},
     )
     .await
@@ -622,6 +627,7 @@ async fn a_failed_clone_reports_git_stderr_and_leaves_nothing_behind() {
         "cloned",
         false,
         None,
+        &Op::detached(),
         |_| {},
     )
     .await
@@ -639,4 +645,121 @@ async fn a_failed_clone_reports_git_stderr_and_leaves_nothing_behind() {
         !dest_parent.path().join("cloned").exists(),
         "a failed clone must not leave a partial destination"
     );
+}
+
+/// A clone cancelled while it is running reports `Cancelled` — not a `Network`
+/// error quoting git's death rattle — and leaves nothing behind (#234).
+///
+/// The stall is a real TCP listener that accepts and never answers, so
+/// `git clone` blocks in the git-protocol handshake indefinitely. No network
+/// access, and no sleep used as synchronisation: the clone cannot finish on its
+/// own, so the only thing that can end this test is the cancel working.
+#[tokio::test]
+async fn cancelling_a_running_clone_reports_cancelled_and_removes_the_destination() {
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("stall listener");
+    let port = listener.local_addr().unwrap().port();
+    // Accept and HOLD. Dropping the accepted stream would let git see EOF and
+    // fail on its own, which would test nothing.
+    std::thread::spawn(move || {
+        let held: Vec<_> = listener.incoming().take(1).flatten().collect();
+        std::thread::sleep(std::time::Duration::from_secs(60));
+        drop(held);
+    });
+
+    let dest_parent = tempfile::tempdir().unwrap();
+    let target = dest_parent.path().join("cloned");
+    let registry = std::sync::Arc::new(OpRegistry::default());
+    let guard = registry.begin(Some("clone-1"));
+
+    // Cancel once git has actually started. `git clone` creates its destination
+    // before it connects, so the directory appearing is proof that a child is
+    // running — which is the state this test is about, as distinct from the
+    // cancelled-before-spawn path covered below.
+    //
+    // A plain OS thread rather than a tokio task: `tokio::time` is not one of
+    // the features this crate asks for, and a test must not be the thing that
+    // makes it load-bearing.
+    let cancel_side = {
+        let registry = registry.clone();
+        let target = target.clone();
+        std::thread::spawn(move || {
+            for _ in 0..600 {
+                if target.exists() {
+                    return registry.cancel("clone-1");
+                }
+                std::thread::sleep(std::time::Duration::from_millis(25));
+            }
+            false
+        })
+    };
+
+    let err = platypusgit_lib::commands::create::run_clone(
+        &format!("git://127.0.0.1:{port}/stalled.git"),
+        dest_parent.path(),
+        "cloned",
+        false,
+        None,
+        guard.op(),
+        |_| {},
+    )
+    .await
+    .unwrap_err();
+
+    assert!(
+        cancel_side.join().unwrap(),
+        "the cancel never saw the clone start"
+    );
+    assert!(
+        matches!(err, AppError::Cancelled),
+        "a cancelled clone must not surface as a failure: {err:?}"
+    );
+    assert!(
+        !target.exists(),
+        "a cancelled clone left a half-written destination behind"
+    );
+}
+
+/// Cancelling before the child is spawned still reports `Cancelled`, and still
+/// creates nothing — the window between the invoke and the spawn.
+#[tokio::test]
+async fn a_clone_cancelled_before_it_starts_creates_nothing() {
+    let bare = BareTempRepo::new();
+    let dest_parent = tempfile::tempdir().unwrap();
+    let registry = std::sync::Arc::new(OpRegistry::default());
+    let guard = registry.begin(Some("clone-2"));
+    registry.cancel("clone-2");
+
+    let err = platypusgit_lib::commands::create::run_clone(
+        bare.path.to_str().unwrap(),
+        dest_parent.path(),
+        "cloned",
+        false,
+        None,
+        guard.op(),
+        |_| {},
+    )
+    .await
+    .unwrap_err();
+
+    assert!(matches!(err, AppError::Cancelled), "{err:?}");
+    assert!(!dest_parent.path().join("cloned").exists());
+}
+
+/// The other half of the cleanup contract, asserted from outside the module
+/// because getting it wrong deletes a directory the user handed us.
+#[test]
+fn discarding_a_cancelled_clone_never_deletes_a_directory_the_user_supplied() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("mine");
+    std::fs::create_dir(&target).unwrap();
+    std::fs::create_dir_all(target.join(".git")).unwrap();
+
+    discard_partial_clone(&target, true);
+    assert!(target.is_dir(), "emptied, not deleted");
+    assert_eq!(std::fs::read_dir(&target).unwrap().count(), 0);
+
+    discard_partial_clone(&target, false);
+    assert!(!target.exists(), "a directory we created is removed");
 }

--- a/src/AppShell.netcancel.test.tsx
+++ b/src/AppShell.netcancel.test.tsx
@@ -1,0 +1,222 @@
+// The Stop button, and the auto-fetch timer that no longer stacks (#234).
+//
+// Two halves of the same issue: a stalled fetch/pull/push needs a visible way
+// out, and the one op nobody is watching — the auto-fetch timer — needs both a
+// guard against piling up and a deadline of its own.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import App from "./App";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useRecentsStore } from "@/features/repo/useRecentsStore";
+import { useTabsStore } from "@/features/repo/useTabsStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { emptySlice } from "@/features/repo/repoSlice";
+import { newTab } from "@/features/repo/tabs";
+import { useFocusStore } from "@/features/keymap";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import type { RepoHandle } from "@/lib/types";
+
+const API: RepoHandle = { id: "r-api", path: "/dev/api", head: "refs/heads/main" };
+
+function calls(cmd: string) {
+  return getInvokeCalls().filter((c) => c.cmd === cmd);
+}
+
+function wire() {
+  for (const cmd of [
+    "get_status",
+    "list_all_files",
+    "list_branches",
+    "list_tags",
+    "list_stashes",
+    "list_remotes",
+    "get_reflog",
+  ]) {
+    mockInvoke(cmd, () => []);
+  }
+  mockInvoke("open_repo", () => API);
+  mockInvoke("close_repo", () => undefined);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => ({
+    inProgress: false,
+    nextIndex: 0,
+    total: 0,
+    pauseReason: null,
+  }));
+  mockInvoke("take_launch_intent", () => null);
+  mockInvoke("cli_shim_status", () => ({
+    installed: false,
+    shimPath: "",
+    target: "",
+    source: "none",
+    pathState: "offPath",
+  }));
+  mockInvoke("get_diff", () => null);
+  mockInvoke("check_for_update", () => null);
+  mockInvoke("get_update_capability", () => ({ canSelfUpdate: false }));
+  mockInvoke("cancel_operation", () => true);
+  mockInvoke("fetch_all", () => undefined);
+}
+
+function seedOpenRepo(patch: Partial<ReturnType<typeof emptySlice>> = {}) {
+  useRepoStore.setState({ ...emptySlice(), current: API, ...patch } as never);
+  useTabsStore.setState({
+    tabs: [newTab("/dev/api", { status: "open", repoId: "r-api" })],
+    activePath: "/dev/api",
+    activationSeq: 0,
+    activating: null,
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  resetInvokeMock();
+  useSettingsStore.getState().reset();
+  useRecentsStore.setState({ recents: [] });
+  useFocusStore.setState({
+    focused: null,
+    panes: new Map(),
+    order: [],
+    barId: null,
+    primaryId: null,
+    pendingContentFocus: false,
+  });
+  useTabsStore.setState({
+    tabs: [],
+    activePath: null,
+    activationSeq: 0,
+    activating: null,
+  });
+  useRepoStore.setState(emptySlice() as never);
+  wire();
+});
+
+describe("the Stop button", () => {
+  it("is absent while nothing cancellable is running", async () => {
+    seedOpenRepo();
+    render(<App />);
+
+    // Waits for the shell rather than asserting on an empty document.
+    await waitFor(() => expect(screen.getByText("Fetch")).toBeInTheDocument());
+    expect(screen.queryByTestId("net-cancel")).toBeNull();
+  });
+
+  it("appears while a fetch is in flight and stops it by id", async () => {
+    seedOpenRepo({
+      activity: { fetch: "Fetching origin…" },
+      netOps: { fetch: "fetch-7" },
+    });
+    render(<App />);
+
+    const stop = await screen.findByTestId("net-cancel");
+    fireEvent.click(stop);
+
+    await waitFor(() => expect(calls("cancel_operation")).toHaveLength(1));
+    expect(calls("cancel_operation")[0].args.opId).toBe("fetch-7");
+  });
+
+  it("names the op it will stop, so Stop is never ambiguous", async () => {
+    seedOpenRepo({
+      activity: { push: "Pushing origin/main…" },
+      netOps: { push: "push-3" },
+    });
+    render(<App />);
+
+    const stop = await screen.findByTestId("net-cancel");
+    expect(stop.getAttribute("title")).toContain("push");
+  });
+
+  it("addresses the same op the status bar names, when two overlap", async () => {
+    // Both fields use the push → pull → fetch precedence, so the label and the
+    // button can never disagree about which op is "the" running one.
+    seedOpenRepo({
+      activity: { fetch: "Fetching origin…", push: "Pushing origin/main…" },
+      netOps: { fetch: "fetch-1", push: "push-2" },
+    });
+    render(<App />);
+
+    fireEvent.click(await screen.findByTestId("net-cancel"));
+
+    await waitFor(() => expect(calls("cancel_operation")).toHaveLength(1));
+    expect(calls("cancel_operation")[0].args.opId).toBe("push-2");
+  });
+
+  it("disappears once the op clears", async () => {
+    seedOpenRepo({
+      activity: { fetch: "Fetching origin…" },
+      netOps: { fetch: "fetch-7" },
+    });
+    render(<App />);
+    await screen.findByTestId("net-cancel");
+
+    act(() => {
+      useRepoStore.setState({ activity: {}, netOps: {} } as never);
+    });
+
+    await waitFor(() => expect(screen.queryByTestId("net-cancel")).toBeNull());
+  });
+});
+
+describe("the auto-fetch timer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not stack a second fetch on top of a stalled one", async () => {
+    // The failure this prevents: a host that accepts the connection and stalls
+    // used to collect another git process every interval, none of them visible.
+    seedOpenRepo({ activity: { fetch: "Fetching origin…" } });
+    useSettingsStore.setState({ autoFetchEnabled: true, autoFetchMinutes: 1 });
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("Fetch")).toBeInTheDocument());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3 * 60_000);
+    });
+
+    expect(calls("fetch_all")).toHaveLength(0);
+  });
+
+  it("fires when no fetch is running", async () => {
+    seedOpenRepo();
+    useSettingsStore.setState({ autoFetchEnabled: true, autoFetchMinutes: 1 });
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("Fetch")).toBeInTheDocument());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(calls("fetch_all").length).toBeGreaterThan(0);
+  });
+
+  it("cancels its own fetch when it is still running two minutes later", async () => {
+    // ONLY the timer's fetches get a deadline: nobody is watching this one, so a
+    // stall is indistinguishable from a hang. An interactive fetch is never
+    // yanked away — the user is right there.
+    seedOpenRepo();
+    useSettingsStore.setState({ autoFetchEnabled: true, autoFetchMinutes: 1 });
+    // Never resolves: exactly the stall the deadline exists for.
+    mockInvoke("fetch_all", () => new Promise<void>(() => {}));
+    render(<App />);
+    await waitFor(() => expect(screen.getByText("Fetch")).toBeInTheDocument());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(calls("cancel_operation")).toHaveLength(0);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(120_000);
+    });
+
+    await waitFor(() => expect(calls("cancel_operation")).toHaveLength(1));
+    expect(calls("cancel_operation")[0].args.opId).toMatch(/^fetch-/);
+  });
+});

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -33,6 +33,7 @@ import { SubmodulesScreen } from "@/screens/Submodules";
 import { WorktreesScreen } from "@/screens/Worktrees";
 
 import { useRepoStore } from "@/features/repo/useRepoStore";
+import type { CancellableOp } from "@/features/repo/useRepoStore";
 import { useTabsStore } from "@/features/repo/useTabsStore";
 import { RepoTabs } from "@/features/repo/RepoTabs";
 import { headUpstream, openRepoDialog } from "@/features/repo/ops";
@@ -96,6 +97,17 @@ export type ScreenId =
   | "submodules"
   | "worktrees"
   | "settings";
+
+/**
+ * How long a fetch started by the auto-fetch TIMER may run before it is
+ * cancelled (#234).
+ *
+ * Two minutes rather than something tight: a real fetch of a large repository
+ * over a slow link can legitimately take a while, and cancelling those would
+ * make the setting worse than useless. What this catches is the fetch that is
+ * never going to finish — and it only applies to the unwatched ones.
+ */
+const AUTO_FETCH_DEADLINE_MS = 120_000;
 
 // Deep views are reachable ONLY via a nav intent (no activity-bar entry). They
 // carry no valid payload after a reload and have no "you are here" anchor, so
@@ -210,13 +222,34 @@ export function AppShell() {
   const autoFetchMinutes = useSettingsStore((s) => s.autoFetchMinutes);
   React.useEffect(() => {
     if (!repo || !autoFetchEnabled) return;
+    const deadlines = new Set<number>();
     const id = window.setInterval(
       () => {
-        useRepoStore.getState().fetchAll();
+        const store = useRepoStore.getState();
+        // Skip while one is still running (#234). A host that accepts the
+        // connection and then stalls used to collect another fetch every N
+        // minutes, each holding a git process nobody could see or stop.
+        if (store.activity.fetch) return;
+        void store.fetchAll();
+        // And cancel it if it is still going in two minutes. ONLY the timer's
+        // fetches get a deadline: an interactive fetch has the user watching it,
+        // and yanking a slow-but-working one out from under them would be worse
+        // than the stall. This one has nobody, so a stall is indistinguishable
+        // from a hang and costs a process either way.
+        const deadline = window.setTimeout(() => {
+          deadlines.delete(deadline);
+          useRepoStore.getState().cancelNetOp("fetch");
+        }, AUTO_FETCH_DEADLINE_MS);
+        deadlines.add(deadline);
       },
       Math.max(1, autoFetchMinutes) * 60_000,
     );
-    return () => window.clearInterval(id);
+    return () => {
+      window.clearInterval(id);
+      // Or a deadline armed by the outgoing repo would fire on the incoming one
+      // and cancel a fetch the user just started by hand.
+      for (const d of deadlines) window.clearTimeout(d);
+    };
   }, [repo, autoFetchEnabled, autoFetchMinutes]);
 
   // Single global keymap listener — resolves chord → action → handler or
@@ -661,6 +694,7 @@ function AppTitlebar({ onOpenSettings }: { onOpenSettings: () => void }) {
   const branches = useRepoStore((s) => s.branches);
   const status = useRepoStore((s) => s.status);
   const activity = useRepoStore((s) => s.activity);
+  const netOps = useRepoStore((s) => s.netOps);
   const refresh = useRepoStore((s) => s.refreshAll);
   const activePath = useTabsStore((s) => s.activePath);
   const defaultPullMode = useSettingsStore((s) => s.defaultPullMode);
@@ -698,6 +732,17 @@ function AppTitlebar({ onOpenSettings }: { onOpenSettings: () => void }) {
     }
     useRepoStore.getState().pull(upstream[0], upstream[1], defaultPullMode);
   };
+
+  // One op at a time in practice; the order is the same precedence the status
+  // bar's activity label already uses, so the two never disagree about which op
+  // is "the" running one.
+  const cancellableOp: CancellableOp | null = netOps.push
+    ? "push"
+    : netOps.pull
+      ? "pull"
+      : netOps.fetch
+        ? "fetch"
+        : null;
 
   const onPush = () => {
     if (!upstream) {
@@ -761,6 +806,28 @@ function AppTitlebar({ onOpenSettings }: { onOpenSettings: () => void }) {
                 >
                   Push {ahead > 0 && <span style={{ marginLeft: 4 }}>↑{ahead}</span>}
                 </PGButton>
+                {/*
+                  One Stop for all three ops, and only while one is running
+                  (#234). Deliberately NOT a mode switch on Fetch/Pull/Push: a
+                  button whose meaning changes under the pointer is a mis-click
+                  waiting to happen, and the user reaching for Stop is not
+                  necessarily the one who pressed the button that started it.
+                  Also not the status-bar label, which is a label.
+                */}
+                {cancellableOp && (
+                  <PGButton
+                    size="sm"
+                    variant="danger"
+                    icon="x"
+                    data-testid="net-cancel"
+                    onClick={() =>
+                      useRepoStore.getState().cancelNetOp(cancellableOp)
+                    }
+                    title={`Stop the running ${cancellableOp} — click again to force it`}
+                  >
+                    Stop
+                  </PGButton>
+                )}
                 <div
                   style={{
                     width: 1,

--- a/src/features/create/CloneDialog.cancel.test.tsx
+++ b/src/features/create/CloneDialog.cancel.test.tsx
@@ -1,0 +1,103 @@
+// The Cancel button IS the cancel while a clone runs (#234).
+//
+// Before this it was `disabled={busy}`, which is what made a stalled clone a
+// force-quit: the one control the user reaches for was the one that had been
+// switched off.
+import { describe, it, expect, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { CloneDialog } from "./CloneDialog";
+import { useCreateStore } from "./useCreateStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+
+function calls(cmd: string) {
+  return getInvokeCalls().filter((c) => c.cmd === cmd);
+}
+
+describe("CloneDialog cancel", () => {
+  beforeEach(() => {
+    resetInvokeMock();
+    useSettingsStore.getState().reset();
+    mockInvoke("cancel_operation", () => true);
+    useCreateStore.setState({
+      open: "clone",
+      busy: false,
+      progress: null,
+      error: null,
+      cloneOpId: null,
+    });
+  });
+
+  it("is enabled while a clone is running, unlike everything else in the form", () => {
+    useCreateStore.setState({ busy: true, cloneOpId: "clone-1" });
+    render(<CloneDialog />);
+
+    expect(screen.getByTestId("clone-cancel")).not.toBeDisabled();
+    // The rest of the form stays locked — this button is the exception.
+    expect(screen.getByTestId("clone-url")).toBeDisabled();
+    expect(screen.getByTestId("clone-submit")).toBeDisabled();
+  });
+
+  it("cancels the running clone by id", async () => {
+    useCreateStore.setState({ busy: true, cloneOpId: "clone-42" });
+    render(<CloneDialog />);
+
+    fireEvent.click(screen.getByTestId("clone-cancel"));
+
+    await waitFor(() => expect(calls("cancel_operation")).toHaveLength(1));
+    expect(calls("cancel_operation")[0].args.opId).toBe("clone-42");
+  });
+
+  it("says it is stopping, rather than leaving a progress bar creeping along", async () => {
+    useCreateStore.setState({
+      busy: true,
+      cloneOpId: "clone-1",
+      progress: { phase: "Receiving objects", percent: 40 },
+    });
+    render(<CloneDialog />);
+    expect(screen.getByTestId("clone-progress")).toHaveTextContent(
+      "Receiving objects — 40%",
+    );
+
+    fireEvent.click(screen.getByTestId("clone-cancel"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("clone-progress")).toHaveTextContent(
+        "Stopping…",
+      ),
+    );
+  });
+
+  it("stays clickable after the first click, so a second one can force it", async () => {
+    // The backend escalates SIGTERM → SIGKILL on a repeat cancel; disabling the
+    // button after one click would take that escape hatch away.
+    useCreateStore.setState({ busy: true, cloneOpId: "clone-1" });
+    render(<CloneDialog />);
+
+    fireEvent.click(screen.getByTestId("clone-cancel"));
+    await waitFor(() => expect(calls("cancel_operation")).toHaveLength(1));
+    expect(screen.getByTestId("clone-cancel")).not.toBeDisabled();
+
+    fireEvent.click(screen.getByTestId("clone-cancel"));
+    await waitFor(() => expect(calls("cancel_operation")).toHaveLength(2));
+  });
+
+  it("closes the dialog when nothing is running, as it always did", () => {
+    render(<CloneDialog />);
+
+    fireEvent.click(screen.getByTestId("clone-cancel"));
+
+    expect(useCreateStore.getState().open).toBe("none");
+    expect(calls("cancel_operation")).toHaveLength(0);
+  });
+
+  it("is disabled for a clone with no op id — nothing could stop it", () => {
+    // Belt and braces: a clone started without an id (an older frontend, a
+    // dropped id) must not offer a button that does nothing.
+    useCreateStore.setState({ busy: true, cloneOpId: null });
+    render(<CloneDialog />);
+
+    expect(screen.getByTestId("clone-cancel")).toBeDisabled();
+  });
+});

--- a/src/features/create/CloneDialog.tsx
+++ b/src/features/create/CloneDialog.tsx
@@ -17,6 +17,8 @@ export function CloneDialog() {
   const close = useCreateStore((s) => s.close);
   const runClone = useCreateStore((s) => s.runClone);
   const setProgress = useCreateStore((s) => s.setProgress);
+  const cloneOpId = useCreateStore((s) => s.cloneOpId);
+  const cancelClone = useCreateStore((s) => s.cancelClone);
 
   const [url, setUrl] = React.useState("");
   const [parentDir, setParentDir] = React.useState(
@@ -25,6 +27,10 @@ export function CloneDialog() {
   const [name, setName] = React.useState("");
   const [nameEdited, setNameEdited] = React.useState(false);
   const [recurse, setRecurse] = React.useState(true);
+  // Local, not store state: it is about what THIS dialog has been asked to do,
+  // and the store's own `busy`/`cloneOpId` are what actually gate the button.
+  // Cleared on the next open along with the rest of the form.
+  const [cancelling, setCancelling] = React.useState(false);
 
   // Listen before the first clone starts: the first progress tick can land
   // before the invoke promise settles. This dialog stays mounted for the
@@ -53,6 +59,7 @@ export function CloneDialog() {
     setName("");
     setNameEdited(false);
     setRecurse(true);
+    setCancelling(false);
     setParentDir(useSettingsStore.getState().lastCreateDir);
   }, [open]);
 
@@ -142,7 +149,11 @@ export function CloneDialog() {
           data-testid="clone-progress"
           style={{ marginTop: 12, fontSize: "var(--fs-12)" }}
         >
-          {progress ? `${progress.phase} — ${progress.percent}%` : "Cloning…"}
+          {cancelling
+            ? "Stopping…"
+            : progress
+              ? `${progress.phase} — ${progress.percent}%`
+              : "Cloning…"}
           <div
             style={{
               height: 4,
@@ -185,7 +196,36 @@ export function CloneDialog() {
           marginTop: 16,
         }}
       >
-        <PGButton onClick={close} disabled={busy}>
+        {/*
+          One button, two jobs — and deliberately so: while a clone runs, Cancel
+          is the control the user is already reaching for, and a separate Stop
+          next to a disabled Cancel would be two ways to say the same thing.
+          `close()` still refuses to close mid-run; the store closes the dialog
+          once the backend confirms it has cleaned up the partial destination.
+
+          Disabled while busy with no op id: that clone was started without one
+          (an older frontend, or the id was dropped), so nothing can stop it and
+          the button must not pretend otherwise.
+        */}
+        <PGButton
+          data-testid="clone-cancel"
+          onClick={() => {
+            if (!busy) {
+              close();
+              return;
+            }
+            setCancelling(true);
+            cancelClone();
+          }}
+          disabled={busy && !cloneOpId}
+          title={
+            busy
+              ? cancelling
+                ? "Still stopping — click again to force it"
+                : "Stop the clone and remove the partial download"
+              : undefined
+          }
+        >
           Cancel
         </PGButton>
         <PGButton

--- a/src/features/create/useCreateStore.cancel.test.ts
+++ b/src/features/create/useCreateStore.cancel.test.ts
@@ -1,0 +1,162 @@
+// Cancelling a running clone (#234).
+//
+// The clone is the op with the worst failure mode: before this, a stalled clone
+// could only be escaped by force-quitting the app, which left git finishing the
+// transfer into a directory the frontend had already given up on.
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useCreateStore } from "./useCreateStore";
+import { useAuthStore } from "@/features/auth/useAuthStore";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+
+const CANCELLED = { kind: "Cancelled" };
+const AUTH = { kind: "Auth", message: { host: "github.com", kind: "Https" } };
+
+function calls(cmd: string) {
+  return getInvokeCalls().filter((c) => c.cmd === cmd);
+}
+
+const ARGS = {
+  url: "https://github.com/me/slow.git",
+  parentDir: "/dev",
+  name: "slow",
+  recurseSubmodules: false,
+};
+
+beforeEach(() => {
+  resetInvokeMock();
+  mockInvoke("cancel_operation", () => true);
+  useAuthStore.setState({ challenge: null } as never);
+  useRepoStore.setState({ current: null } as never);
+  useCreateStore.setState({
+    open: "clone",
+    busy: false,
+    progress: null,
+    error: null,
+    cloneOpId: null,
+  });
+});
+
+describe("the clone publishes an op id while it runs", () => {
+  it("hands the same id to the backend and to the dialog, then clears it", async () => {
+    let seen: { opId?: string; stored?: string | null } = {};
+    mockInvoke("clone_repo", (args) => {
+      seen = {
+        opId: args.opId as string,
+        stored: useCreateStore.getState().cloneOpId,
+      };
+      throw { kind: "Network", message: "nope" };
+    });
+
+    await useCreateStore.getState().runClone(ARGS);
+
+    expect(seen.opId).toBeTruthy();
+    expect(seen.stored).toBe(seen.opId);
+    // Cleared even though the clone failed, or Cancel points at a dead process.
+    expect(useCreateStore.getState().cloneOpId).toBeNull();
+  });
+
+  it("mints a FRESH id for the credential retry", async () => {
+    // The retry is a second `git clone`. Reusing the first attempt's id would
+    // leave Cancel aimed at a process that has already exited.
+    const ids: unknown[] = [];
+    mockInvoke("clone_repo", (args) => {
+      ids.push(args.opId);
+      throw AUTH;
+    });
+
+    await useCreateStore.getState().runClone(ARGS);
+    await useAuthStore
+      .getState()
+      .challenge!.retry({ username: "ada", secret: "t" }, false);
+
+    expect(ids).toHaveLength(2);
+    expect(ids[0]).not.toBe(ids[1]);
+  });
+});
+
+describe("cancelClone", () => {
+  it("asks the backend to stop the clone that is in flight", async () => {
+    let asked: unknown[] = [];
+    mockInvoke("clone_repo", (args) => {
+      useCreateStore.getState().cancelClone();
+      asked = calls("cancel_operation").map((c) => c.args.opId);
+      expect(asked).toEqual([args.opId]);
+      throw CANCELLED;
+    });
+
+    await useCreateStore.getState().runClone(ARGS);
+
+    expect(asked).toHaveLength(1);
+  });
+
+  it("is a no-op with no clone running", () => {
+    useCreateStore.getState().cancelClone();
+    expect(calls("cancel_operation")).toHaveLength(0);
+  });
+
+  it("does not close the dialog by itself — the backend confirms first", () => {
+    // The dialog must not say "done" before the partial destination is gone.
+    // Only the `Cancelled` rejection proves the backend cleaned up.
+    useCreateStore.setState({ busy: true, cloneOpId: "clone-x" });
+    useCreateStore.getState().cancelClone();
+    expect(useCreateStore.getState().open).toBe("clone");
+    expect(useCreateStore.getState().busy).toBe(true);
+  });
+});
+
+describe("a cancelled clone closes the dialog and says nothing", () => {
+  it("leaves no error and no progress behind", async () => {
+    mockInvoke("clone_repo", () => {
+      throw CANCELLED;
+    });
+
+    await useCreateStore.getState().runClone(ARGS);
+
+    const s = useCreateStore.getState();
+    expect(s.open).toBe("none");
+    expect(s.busy).toBe(false);
+    expect(s.error).toBeNull();
+    expect(s.progress).toBeNull();
+    expect(s.cloneOpId).toBeNull();
+  });
+
+  it("does NOT open a repository — there is nothing there", async () => {
+    mockInvoke("clone_repo", () => {
+      throw CANCELLED;
+    });
+
+    await useCreateStore.getState().runClone(ARGS);
+
+    expect(calls("open_repo")).toHaveLength(0);
+  });
+
+  it("still reports a REAL failure, so the filter is not swallowing everything", async () => {
+    mockInvoke("clone_repo", () => {
+      throw { kind: "Network", message: "repository not found" };
+    });
+
+    await useCreateStore.getState().runClone(ARGS);
+
+    // Error stays IN the dialog: the user needs the form to fix the URL.
+    expect(useCreateStore.getState().open).toBe("clone");
+    expect(useCreateStore.getState().error).toBe("repository not found");
+  });
+
+  it("closes the dialog when the credential RETRY is cancelled too", async () => {
+    let attempt = 0;
+    mockInvoke("clone_repo", () => {
+      attempt += 1;
+      throw attempt === 1 ? AUTH : CANCELLED;
+    });
+
+    await useCreateStore.getState().runClone(ARGS);
+    await useAuthStore
+      .getState()
+      .challenge!.retry({ username: "ada", secret: "t" }, false);
+
+    expect(useCreateStore.getState().open).toBe("none");
+    expect(useCreateStore.getState().error).toBeNull();
+  });
+});

--- a/src/features/create/useCreateStore.ts
+++ b/src/features/create/useCreateStore.ts
@@ -6,6 +6,7 @@ import { useTabsStore } from "@/features/repo/useTabsStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { useAuthStore } from "@/features/auth/useAuthStore";
 import {
+  cancelOperation,
   cloneRepo,
   closeRepo as closeRepoIpc,
   initRepo,
@@ -13,11 +14,13 @@ import {
   trustRepoPath,
   type Credentials,
 } from "@/lib/tauri";
+import { newOpId } from "@/lib/opId";
 import type { CloneProgress, RepoHandle } from "@/lib/types";
 import {
   appErrorMessage,
   dubiousOwnershipPath,
   isAuthError,
+  isCancelledError,
   isDubiousOwnershipError,
 } from "@/lib/errors";
 
@@ -28,9 +31,23 @@ interface CreateState {
   busy: boolean;
   progress: CloneProgress | null;
   error: string | null;
+  /**
+   * The running clone's backend op id, or null (#234).
+   *
+   * Also what the dialog's Cancel button is gated on: a clone with no id is one
+   * the backend cannot be asked to stop, so the button must not offer to.
+   */
+  cloneOpId: string | null;
   openClone: () => void;
   openInit: () => void;
   close: () => void;
+  /**
+   * Stop the running clone (#234). Returns immediately; `runClone`'s own catch
+   * closes the dialog when the backend confirms with `AppError::Cancelled`,
+   * which is also what guarantees the half-written destination has been removed
+   * before the dialog says it is over.
+   */
+  cancelClone: () => void;
   setProgress: (p: CloneProgress) => void;
   runClone: (args: {
     url: string;
@@ -50,12 +67,12 @@ export const useCreateStore = create<CreateState>((set, get) => ({
   busy: false,
   progress: null,
   error: null,
+  cloneOpId: null,
 
-  // Guarded against `busy`: a clone/init in flight has no cancel, so a chord
-  // or palette command that swaps `open` to the other dialog mid-run would
-  // unmount the running dialog's view behind a disabled, undismissable one —
-  // and once the run finishes, its result (including a failure) would render
-  // into the wrong dialog's error slot.
+  // Guarded against `busy`: a chord or palette command that swaps `open` to the
+  // other dialog mid-run would unmount the running dialog's view — taking the
+  // Cancel button for the op with it — and once the run finishes, its result
+  // (including a failure) would render into the wrong dialog's error slot.
   openClone: () => {
     if (get().busy) return;
     set({ open: "clone", error: null, progress: null });
@@ -64,11 +81,23 @@ export const useCreateStore = create<CreateState>((set, get) => ({
     if (get().busy) return;
     set({ open: "init", error: null, progress: null });
   },
-  // Never closes mid-run: a clone in flight has no cancel, so dropping the
-  // dialog would leave a git process with no UI attached to it.
+  // Still never closes mid-run — but the way out is now Cancel, not waiting.
+  // Dropping the dialog while a clone runs would leave a git process with no UI
+  // attached to it AND a half-written destination nobody is going to clean up;
+  // `cancelClone` does both, and this closes once the backend has confirmed.
   close: () => {
     if (get().busy) return;
     set({ open: "none", error: null, progress: null });
+  },
+
+  cancelClone: () => {
+    const opId = get().cloneOpId;
+    if (!opId) return;
+    // Fire and forget: `runClone`'s catch owns the transition out of `busy`,
+    // because only it knows the backend finished cleaning up. A failed cancel
+    // means the clone had already finished — which is the outcome the user wanted
+    // reported by the clone itself, not by an error here.
+    void cancelOperation(opId).catch(() => {});
   },
   setProgress: (p) => set({ progress: p }),
 
@@ -76,17 +105,50 @@ export const useCreateStore = create<CreateState>((set, get) => ({
     set({ busy: true, error: null, progress: null });
 
     const attempt = async (creds?: Credentials) => {
-      const dest = await cloneRepo(url, parentDir, name, recurseSubmodules, creds);
-      useSettingsStore.getState().set("lastCreateDir", parentDir);
-      // busy false BEFORE close(), which refuses to close while busy.
-      set({ busy: false, progress: null });
+      // A fresh id per attempt. The credential retry is a SECOND `git clone`, so
+      // reusing the first attempt's id would leave the Cancel button pointed at
+      // a process that has already exited.
+      const opId = newOpId("clone");
+      set({ cloneOpId: opId });
+      try {
+        const dest = await cloneRepo(
+          url,
+          parentDir,
+          name,
+          recurseSubmodules,
+          creds,
+          opId,
+        );
+        useSettingsStore.getState().set("lastCreateDir", parentDir);
+        // busy false BEFORE close(), which refuses to close while busy.
+        set({ busy: false, progress: null });
+        set({ open: "none" });
+        await useTabsStore.getState().openRepo(dest);
+      } finally {
+        set({ cloneOpId: null });
+      }
+    };
+
+    /**
+     * A cancelled clone closes the dialog and says nothing.
+     *
+     * By the time this rejection arrives the backend has already removed the
+     * half-written destination, so there is nothing left for the user to decide
+     * — and an error banner reading "operation cancelled" over the form they
+     * just dismissed is the app arguing with them.
+     */
+    const settleCancel = () => {
+      set({ busy: false, progress: null, error: null, cloneOpId: null });
       set({ open: "none" });
-      await useTabsStore.getState().openRepo(dest);
     };
 
     try {
       await attempt();
     } catch (e) {
+      if (isCancelledError(e)) {
+        settleCancel();
+        return;
+      }
       // A private remote is exactly what the credential flow exists for. The
       // backend already classifies clone failures as AppError::Auth and
       // clone_repo already takes credentials; without raising the challenge the
@@ -123,6 +185,10 @@ export const useCreateStore = create<CreateState>((set, get) => ({
               }
             }
           } catch (retryError) {
+            if (isCancelledError(retryError)) {
+              settleCancel();
+              return;
+            }
             set({
               busy: false,
               progress: null,

--- a/src/features/palette/commands.cancelNetOp.test.ts
+++ b/src/features/palette/commands.cancelNetOp.test.ts
@@ -1,0 +1,74 @@
+// The palette's route to Stop (#234).
+//
+// The titlebar button is a mouse target; a hung fetch must be stoppable from the
+// keyboard too. Gated on an op actually running, the same way `Resolve
+// conflicts…` is — a row that only ever says "nothing to stop" is noise.
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { buildCommands } from "./commands";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { emptySlice } from "@/features/repo/repoSlice";
+import { paletteInitial, usePaletteStore } from "./usePaletteStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+
+const REPO = { id: "r1", path: "/repo", head: "main" };
+const ROW = "action:cancel-net-op";
+
+function seed(patch: Record<string, unknown> = {}) {
+  useRepoStore.setState({ ...emptySlice(), current: REPO, ...patch } as never);
+}
+
+const row = () => buildCommands().find((i) => i.id === ROW);
+
+beforeEach(() => {
+  resetInvokeMock();
+  mockInvoke("cancel_operation", () => true);
+  seed();
+  usePaletteStore.setState({ ...paletteInitial(), open: true });
+});
+
+describe("the Stop row", () => {
+  it("is absent while nothing cancellable is running", () => {
+    expect(row()).toBeUndefined();
+  });
+
+  it("appears while a fetch is in flight, and names it", () => {
+    seed({ netOps: { fetch: "fetch-1" } });
+    expect(row()?.label).toBe("Stop the running fetch");
+  });
+
+  it("stops the op by id when invoked", async () => {
+    seed({ netOps: { pull: "pull-9" } });
+
+    row()!.run();
+
+    const calls = getInvokeCalls().filter((c) => c.cmd === "cancel_operation");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args.opId).toBe("pull-9");
+  });
+
+  it("closes the palette, like every other direct action", () => {
+    seed({ netOps: { fetch: "fetch-1" } });
+
+    row()!.run();
+
+    expect(usePaletteStore.getState().open).toBe(false);
+  });
+
+  it("addresses the same op the titlebar's Stop does when two overlap", () => {
+    seed({ netOps: { fetch: "fetch-1", push: "push-2" } });
+
+    row()!.run();
+
+    const calls = getInvokeCalls().filter((c) => c.cmd === "cancel_operation");
+    expect(calls[0].args.opId).toBe("push-2");
+  });
+
+  it("is searchable by the words a user would actually type", () => {
+    seed({ netOps: { push: "push-2" } });
+    const search = row()!.search.toLowerCase();
+    for (const term of ["cancel", "stop", "abort", "push"]) {
+      expect(search).toContain(term);
+    }
+  });
+});

--- a/src/features/palette/commands.ts
+++ b/src/features/palette/commands.ts
@@ -19,6 +19,7 @@ import { createBranchInputStep, switchRepoStep } from "./steps";
 import { currentBranch, isConflicted, relativeTime } from "@/lib/derive";
 import { headUpstream, resolveConflictsOp } from "@/features/repo/ops";
 import type { ActionId } from "@/features/keymap";
+import type { CancellableOp } from "@/features/repo/useRepoStore";
 import type { BranchInfo, CommitInfo, FileStatus } from "@/lib/types";
 import type { PaletteItem, PaletteStep } from "./types";
 
@@ -780,6 +781,33 @@ export function buildCommands(): PaletteItem[] {
           })),
         });
       }
+    }
+  }
+
+  // -- stop a running network op (#234) --
+  // Listed only while one is running, the same gating `Resolve conflicts…` uses:
+  // a row that only ever says "nothing to stop" is noise the rest of the time.
+  // This is the KEYBOARD route to the titlebar's Stop button — a hung fetch must
+  // not need a mouse.
+  {
+    const running: CancellableOp | null = repo.netOps.push
+      ? "push"
+      : repo.netOps.pull
+        ? "pull"
+        : repo.netOps.fetch
+          ? "fetch"
+          : null;
+    if (running) {
+      items.push({
+        type: "command",
+        id: "action:cancel-net-op",
+        search: "Cancel stop abort fetch pull push network operation",
+        label: `Stop the running ${running}`,
+        icon: "x",
+        run: direct(() => {
+          repoState().cancelNetOp(running);
+        }),
+      });
     }
   }
 

--- a/src/features/repo/repoActivity.ts
+++ b/src/features/repo/repoActivity.ts
@@ -14,3 +14,22 @@ export interface RepoActivity {
   stash?: string;
   branch?: string;
 }
+
+/**
+ * The network ops that can be stopped from the UI (#234). A subset of
+ * `RepoActivity`'s keys: `stash` and `branch` are local work, done before a
+ * cancel button could be found.
+ */
+export type CancellableOp = "fetch" | "pull" | "push";
+
+/**
+ * Backend op ids for the in-flight cancellable ops, keyed exactly like
+ * [`RepoActivity`]'s labels — `activity.fetch` says a fetch is running,
+ * `netOps.fetch` says how to stop it. Set and cleared by the same four store
+ * actions, in the same `finally`.
+ *
+ * Kept as a separate field rather than folded into `RepoActivity`'s values
+ * because `pull` re-labels itself three times (stash → pull → pop), and
+ * threading an id through each relabel is how one of them ends up dropping it.
+ */
+export type NetOps = Partial<Record<CancellableOp, string>>;

--- a/src/features/repo/repoSlice.ts
+++ b/src/features/repo/repoSlice.ts
@@ -38,7 +38,7 @@ import type {
 } from "@/lib/types";
 import { LOG_REF_ALL } from "@/lib/types";
 import type { AppError, HookRejection } from "@/lib/errors";
-import type { RepoActivity } from "./repoActivity";
+import type { NetOps, RepoActivity } from "./repoActivity";
 
 export const DEFAULT_REBASE_STATUS: RebaseStatus = {
   inProgress: false,
@@ -129,6 +129,14 @@ export interface RepoSlice {
   /** Active long-running ops keyed by op kind. */
   activity: RepoActivity;
   /**
+   * Backend op ids for the cancellable network ops in flight (#234).
+   *
+   * Per-repo, and therefore here: a fetch you started in one tab must not offer
+   * its Stop button over another repository, and switching back must not find a
+   * stale id whose cancel would signal a pid that has since been recycled.
+   */
+  netOps: NetOps;
+  /**
    * The git hook refusal to display, or null (#232).
    *
    * Per-repo, and therefore here: a commit rejected by one repository's
@@ -171,6 +179,7 @@ export function emptySlice(): RepoSlice {
     rebaseStatus: DEFAULT_REBASE_STATUS,
     bisectStatus: DEFAULT_BISECT_STATUS,
     activity: {},
+    netOps: {},
     hookRejection: null,
   };
 }

--- a/src/features/repo/useRepoStore.cancel.test.ts
+++ b/src/features/repo/useRepoStore.cancel.test.ts
@@ -1,0 +1,248 @@
+// Cancelling a running fetch / pull / push (#234).
+//
+// Two invariants, and both are the kind that only a test catches:
+//
+//   1. `netOps[kind]` is published while the op runs and GONE afterwards. An id
+//      left behind offers a Stop button that would signal a pid the OS has since
+//      handed to another process.
+//   2. `AppError::Cancelled` never reaches the error banner. The user pressed
+//      Stop; a red banner saying so is the app arguing with them, and it looks
+//      exactly like the failures that do need attention.
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { emptySlice } from "./repoSlice";
+import { useRepoStore } from "./useRepoStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import type { RepoHandle } from "@/lib/types";
+
+const REPO: RepoHandle = { id: "r-1", path: "/dev/api", head: "refs/heads/main" };
+const CANCELLED = { kind: "Cancelled" };
+
+function calls(cmd: string) {
+  return getInvokeCalls().filter((c) => c.cmd === cmd);
+}
+
+/** Everything `refreshAll` fans out to, so an op can reach its own outcome. */
+function wireRefresh() {
+  for (const cmd of [
+    "get_status",
+    "list_branches",
+    "list_tags",
+    "list_stashes",
+    "list_remotes",
+    "list_all_files",
+  ]) {
+    mockInvoke(cmd, () => []);
+  }
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => null);
+  mockInvoke("head_info", () => null);
+  mockInvoke("bisect_status", () => null);
+  mockInvoke("cancel_operation", () => true);
+}
+
+beforeEach(() => {
+  resetInvokeMock();
+  wireRefresh();
+  useRepoStore.setState({ ...emptySlice(), current: REPO } as never);
+});
+
+describe("a cancellable op publishes its id while it runs", () => {
+  it("hands the same id to the backend and to netOps, then clears it", async () => {
+    let seen: { opId?: string; netOps?: Record<string, string> } = {};
+    mockInvoke("fetch", (args) => {
+      seen = {
+        opId: args.opId as string,
+        // Read INSIDE the op: this is the only moment the Stop button exists.
+        netOps: { ...useRepoStore.getState().netOps },
+      };
+      return undefined;
+    });
+
+    await useRepoStore.getState().fetch("origin");
+
+    expect(seen.opId, "the op id never reached the backend").toBeTruthy();
+    expect(seen.netOps).toEqual({ fetch: seen.opId });
+    // Cleared on the way out, or Stop outlives the op it would stop.
+    expect(useRepoStore.getState().netOps).toEqual({});
+  });
+
+  it("clears the id when the op FAILS, not just when it succeeds", async () => {
+    mockInvoke("fetch", () => {
+      throw { kind: "Network", message: "host unreachable" };
+    });
+
+    await useRepoStore.getState().fetch("origin");
+
+    expect(useRepoStore.getState().netOps).toEqual({});
+    // A real failure still raises a banner — this is what the Cancelled filter
+    // must not swallow.
+    expect(useRepoStore.getState().error).toEqual({
+      kind: "Network",
+      message: "host unreachable",
+    });
+  });
+
+  it("publishes under the right key for each op", async () => {
+    const keys: string[] = [];
+    for (const cmd of ["fetch_all", "pull", "push"]) {
+      mockInvoke(cmd, () => {
+        keys.push(Object.keys(useRepoStore.getState().netOps).join(","));
+        return undefined;
+      });
+    }
+    mockInvoke("stash_save", () => null);
+
+    await useRepoStore.getState().fetchAll();
+    await useRepoStore.getState().pull("origin", "main");
+    await useRepoStore.getState().push("origin", "main");
+
+    expect(keys).toEqual(["fetch", "pull", "push"]);
+    expect(useRepoStore.getState().netOps).toEqual({});
+  });
+});
+
+describe("the credential retry is cancellable too", () => {
+  // `withAuthRetry` resolves as soon as the challenge is RAISED, not when the
+  // retry finishes. So an id minted around it would already be cleared while the
+  // prompt is up, and the retry — a second git process, every bit as able to
+  // stall — would run with no Stop button and a stale id. Caught by reading the
+  // code, not by a failure, which is exactly why it is pinned here.
+  const AUTH = { kind: "Auth", message: { host: "github.com", kind: "Https" } };
+
+  it("gives the retry its own id, published while the retry runs", async () => {
+    const { useAuthStore } = await import("@/features/auth/useAuthStore");
+    useAuthStore.setState({ challenge: null } as never);
+
+    const seen: { opId: unknown; published: unknown }[] = [];
+    let attempt = 0;
+    mockInvoke("fetch", (args) => {
+      attempt += 1;
+      seen.push({
+        opId: args.opId,
+        published: useRepoStore.getState().netOps.fetch,
+      });
+      if (attempt === 1) throw AUTH;
+      return undefined;
+    });
+
+    await useRepoStore.getState().fetch("origin");
+    // Between the two attempts there is nothing to stop.
+    expect(useRepoStore.getState().netOps).toEqual({});
+
+    await useAuthStore
+      .getState()
+      .challenge!.retry({ username: "ada", secret: "t" }, false);
+
+    expect(seen).toHaveLength(2);
+    // Each attempt's id was live in the slice DURING that attempt...
+    expect(seen[0].published).toBe(seen[0].opId);
+    expect(seen[1].published).toBe(seen[1].opId);
+    // ...and they are different processes, so they are different ids.
+    expect(seen[0].opId).not.toBe(seen[1].opId);
+    expect(useRepoStore.getState().netOps).toEqual({});
+  });
+});
+
+describe("cancelNetOp", () => {
+  it("asks the backend to stop the id that is actually in flight", async () => {
+    let cancelledDuring: unknown[] = [];
+    mockInvoke("fetch", async (args) => {
+      // The click happens WHILE the op is running, which is the only time it
+      // can happen at all.
+      useRepoStore.getState().cancelNetOp("fetch");
+      cancelledDuring = calls("cancel_operation").map((c) => c.args.opId);
+      expect(cancelledDuring).toEqual([args.opId]);
+      throw CANCELLED;
+    });
+
+    await useRepoStore.getState().fetch("origin");
+
+    expect(cancelledDuring).toHaveLength(1);
+  });
+
+  it("is a no-op when nothing of that kind is running", () => {
+    useRepoStore.getState().cancelNetOp("push");
+    expect(calls("cancel_operation")).toHaveLength(0);
+  });
+
+  it("survives a rejected cancel — the op had already finished", async () => {
+    mockInvoke("cancel_operation", () => {
+      throw { kind: "Internal", message: "boom" };
+    });
+    mockInvoke("fetch", () => {
+      useRepoStore.getState().cancelNetOp("fetch");
+      return undefined;
+    });
+
+    await useRepoStore.getState().fetch("origin");
+
+    // No banner: a cancel that lost the race is the outcome the user wanted.
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("cancelAllNetOps stops every kind in flight", () => {
+    useRepoStore.setState({
+      netOps: { fetch: "fetch-1", push: "push-2" },
+    } as never);
+
+    useRepoStore.getState().cancelAllNetOps();
+
+    expect(calls("cancel_operation").map((c) => c.args.opId).sort()).toEqual([
+      "fetch-1",
+      "push-2",
+    ]);
+  });
+});
+
+describe("a cancelled op is not a failure", () => {
+  it("raises no banner for fetch", async () => {
+    mockInvoke("fetch", () => {
+      throw CANCELLED;
+    });
+
+    await useRepoStore.getState().fetch("origin");
+
+    expect(useRepoStore.getState().error).toBeNull();
+    expect(useRepoStore.getState().activity.fetch).toBeUndefined();
+  });
+
+  it("raises no banner for push", async () => {
+    mockInvoke("push", () => {
+      throw CANCELLED;
+    });
+
+    await useRepoStore.getState().push("origin", "main");
+
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("still refreshes after a cancelled pull, banner or not", async () => {
+    // A pull killed mid-merge changed the tree. The banner is skipped; the
+    // refresh is not — the UI must reflect disk truth either way.
+    mockInvoke("stash_save", () => null);
+    mockInvoke("pull", () => {
+      throw CANCELLED;
+    });
+
+    await useRepoStore.getState().pull("origin", "main");
+
+    expect(useRepoStore.getState().error).toBeNull();
+    expect(calls("get_status").length).toBeGreaterThan(0);
+  });
+
+  it("does not raise the credential prompt for a cancel", async () => {
+    // The backend claims a cancel before `map_git_failure` runs, so this can
+    // only regress if the frontend starts inventing Auth from something else.
+    const { useAuthStore } = await import("@/features/auth/useAuthStore");
+    useAuthStore.setState({ challenge: null } as never);
+    mockInvoke("fetch", () => {
+      throw CANCELLED;
+    });
+
+    await useRepoStore.getState().fetch("origin");
+
+    expect(useAuthStore.getState().challenge).toBeNull();
+  });
+});

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -10,11 +10,13 @@ import type {
   RebaseStep,
   RepoHandle,
 } from "@/lib/types";
+import { newOpId } from "@/lib/opId";
 import type { AppError, HookRejection } from "@/lib/errors";
 import {
   dubiousOwnershipPath,
   isAppError,
   isAuthError,
+  isCancelledError,
   isDubiousOwnershipError,
   toAppError,
 } from "@/lib/errors";
@@ -35,6 +37,7 @@ import {
   openInTerminal as openInTerminalFn,
   checkoutBranch,
   checkoutRef,
+  cancelOperation,
   cherryPick,
   commit as commitFn,
   continueOperation,
@@ -115,9 +118,9 @@ import {
   sliceOf,
   type RepoSlice,
 } from "./repoSlice";
-import type { RepoActivity } from "./repoActivity";
+import type { CancellableOp, RepoActivity } from "./repoActivity";
 
-export type { RepoActivity } from "./repoActivity";
+export type { CancellableOp, NetOps, RepoActivity } from "./repoActivity";
 
 /**
  * Commits per log page (#68 G11). Was a `500` literal repeated at four call
@@ -306,6 +309,18 @@ interface RepoStoreState extends RepoSlice {
     /** Skip `pre-push` for this push only (#232). */
     noVerify?: boolean,
   ) => Promise<void>;
+  /**
+   * Stop the in-flight fetch / pull / push (#234). No-op when that kind is not
+   * running — the button is gated on `netOps`, but a click can always land after
+   * the op finished.
+   *
+   * The op's own promise reports the outcome (an `AppError::Cancelled` its error
+   * arm then declines to raise a banner for), so this returns immediately rather
+   * than waiting for the child to die.
+   */
+  cancelNetOp: (kind: CancellableOp) => void;
+  /** Stop everything cancellable in this repository. */
+  cancelAllNetOps: () => void;
   // remote management
   addRemote: (name: string, url: string) => Promise<void>;
   removeRemote: (name: string) => Promise<void>;
@@ -402,6 +417,39 @@ export async function withAuthRetry(
   }
 }
 
+/**
+ * Run a cancellable network op: mint an id, publish it so the UI can stop the
+ * op, and clear it however the op ends (#234).
+ *
+ * One place rather than four copies, because the invariant that matters is
+ * pairing — an id left in `netOps` after the op finished offers a Stop button
+ * that signals a pid the OS has since handed to somebody else.
+ *
+ * `run` receives the id and must forward it to the backend command.
+ *
+ * # Called INSIDE the retried closure, never around `withAuthRetry`
+ *
+ * `withAuthRetry` resolves as soon as a credential challenge is RAISED, not when
+ * the retry finishes (see its own doc comment). Wrapping it would therefore clear
+ * the id while the prompt is still up, and the retry — a SECOND git process,
+ * every bit as able to stall as the first — would run with no Stop button and a
+ * stale id. So each attempt mints its own, exactly as the clone path does in
+ * `useCreateStore`.
+ */
+async function runCancellable(
+  kind: CancellableOp,
+  setNetOp: (kind: CancellableOp, opId: string | null) => void,
+  run: (opId: string) => Promise<void>,
+): Promise<void> {
+  const opId = newOpId(kind);
+  setNetOp(kind, opId);
+  try {
+    await run(opId);
+  } finally {
+    setNetOp(kind, null);
+  }
+}
+
 export const useRepoStore = create<RepoStoreState>((set, get) => {
   /**
    * Apply `patch` only while `repoId` is still the open repository (#90).
@@ -421,6 +469,36 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   const setErrorFor = (repoId: string, e: unknown) => {
     if (get().current?.id !== repoId) return;
     set({ error: toAppError(e) });
+  };
+  /**
+   * Publish (or clear) the backend op id for a cancellable network op.
+   *
+   * Deliberately NOT guarded by `setFor`, unlike the error and refresh writers:
+   * this is bookkeeping for a process that is running right now, and dropping
+   * the write because the user switched tabs mid-op would leave the id in the
+   * slice forever — a Stop button for an op that finished. The slice is per-repo,
+   * so the parked tab's copy is what a switch back restores.
+   */
+  const setNetOp = (key: CancellableOp, opId: string | null) => {
+    set((s) => {
+      const next = { ...s.netOps };
+      if (opId === null) delete next[key];
+      else next[key] = opId;
+      return { netOps: next };
+    });
+  };
+  /**
+   * `setErrorFor`, except that a cancel is not a failure (#234).
+   *
+   * The user pressed Stop; a red banner telling them the operation was cancelled
+   * is the app arguing with them, and it looks exactly like the failures that do
+   * need attention. Used by every cancellable op's error arm — the ones that are
+   * not cancellable keep calling `setErrorFor` directly, so this check cannot
+   * silently swallow anything that has no cancel button.
+   */
+  const reportNetFailure = (repoId: string, e: unknown) => {
+    if (isCancelledError(e)) return;
+    setErrorFor(repoId, e);
   };
   const setActivity = (key: keyof RepoActivity, label: string | null) => {
     set((s) => {
@@ -1252,16 +1330,18 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     try {
       await withAuthRetry(
         repo.id,
-        async (creds) => {
-          await fetchRemote(
-            repo.id,
-            remote,
-            useSettingsStore.getState().pruneOnFetch,
-            creds,
-          );
-          await get().refreshAll();
-        },
-        (e) => setErrorFor(repo.id, e),
+        (creds) =>
+          runCancellable("fetch", setNetOp, async (opId) => {
+            await fetchRemote(
+              repo.id,
+              remote,
+              useSettingsStore.getState().pruneOnFetch,
+              creds,
+              opId,
+            );
+            await get().refreshAll();
+          }),
+        (e) => reportNetFailure(repo.id, e),
       );
     } finally {
       setActivity("fetch", null);
@@ -1275,14 +1355,36 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     try {
       await withAuthRetry(
         repo.id,
-        async (creds) => {
-          await fetchAll(repo.id, useSettingsStore.getState().pruneOnFetch, creds);
-          await get().refreshAll();
-        },
-        (e) => setErrorFor(repo.id, e),
+        (creds) =>
+          runCancellable("fetch", setNetOp, async (opId) => {
+            await fetchAll(
+              repo.id,
+              useSettingsStore.getState().pruneOnFetch,
+              creds,
+              opId,
+            );
+            await get().refreshAll();
+          }),
+        (e) => reportNetFailure(repo.id, e),
       );
     } finally {
       setActivity("fetch", null);
+    }
+  },
+
+  cancelNetOp(kind) {
+    const opId = get().netOps[kind];
+    if (!opId) return;
+    // Fire and forget. The op's own promise is what reports the outcome, and a
+    // rejected cancel means the op had already finished — nothing the user needs
+    // to hear about, and nothing to retry.
+    void cancelOperation(opId).catch(() => {});
+  },
+
+  cancelAllNetOps() {
+    const { netOps } = get();
+    for (const kind of Object.keys(netOps) as CancellableOp[]) {
+      get().cancelNetOp(kind);
     }
   },
 
@@ -1297,43 +1399,47 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     let stashed: string | null = null;
     await withAuthRetry(
       repo.id,
-      async (creds) => {
-        // Each attempt owns its own progress indicator: the retry runs long
-        // after the first attempt's `finally` would have cleared it.
-        setActivity("pull", `Pulling ${remote}/${branch}…`);
-        try {
-          // Carry over uncommitted work when the setting is on: stash → pull →
-          // pop, mirroring checkoutBranch's auto-stash. stashSave returns null
-          // when the tree is clean, so this is a no-op in the common case. If
-          // the pull fails, the stash is deliberately NOT popped — the work
-          // stays safe in the stash list rather than colliding with a conflicted
-          // worktree (same policy as checkoutBranch).
-          if (useSettingsStore.getState().autoStashBeforePull && stashed === null) {
-            setActivity("pull", "Stashing changes…");
-            stashed = await stashSave(repo.id, {
-              message: `auto: pull ${remote}/${branch}`,
-              includeUntracked: true,
-              keepIndex: false,
-            });
-            setActivity("pull", `Pulling ${remote}/${branch}…`);
+      (creds) =>
+        runCancellable("pull", setNetOp, async (opId) => {
+          // Each attempt owns its own progress indicator AND its own op id: the
+          // retry runs long after the first attempt's `finally` would have
+          // cleared either.
+          setActivity("pull", `Pulling ${remote}/${branch}…`);
+          try {
+            // Carry over uncommitted work when the setting is on: stash → pull →
+            // pop, mirroring checkoutBranch's auto-stash. stashSave returns null
+            // when the tree is clean, so this is a no-op in the common case. If
+            // the pull fails, the stash is deliberately NOT popped — the work
+            // stays safe in the stash list rather than colliding with a conflicted
+            // worktree (same policy as checkoutBranch).
+            if (useSettingsStore.getState().autoStashBeforePull && stashed === null) {
+              setActivity("pull", "Stashing changes…");
+              stashed = await stashSave(repo.id, {
+                message: `auto: pull ${remote}/${branch}`,
+                includeUntracked: true,
+                keepIndex: false,
+              });
+              setActivity("pull", `Pulling ${remote}/${branch}…`);
+            }
+            await pullRemote(repo.id, remote, branch, mode, creds, opId);
+            if (stashed) {
+              setActivity("pull", "Restoring stashed changes…");
+              await stashPop(repo.id, 0);
+              // Popped — a later attempt must not pop it a second time.
+              stashed = null;
+            }
+            await get().refreshAll();
+          } finally {
+            setActivity("pull", null);
           }
-          await pullRemote(repo.id, remote, branch, mode, creds);
-          if (stashed) {
-            setActivity("pull", "Restoring stashed changes…");
-            await stashPop(repo.id, 0);
-            // Popped — a later attempt must not pop it a second time.
-            stashed = null;
-          }
-          await get().refreshAll();
-        } finally {
-          setActivity("pull", null);
-        }
-      },
+        }),
       async (e) => {
         // See mergeBranch's catch: refresh first, error last, so it isn't
-        // batched away by refreshAll's own `error: null` reset.
+        // batched away by refreshAll's own `error: null` reset. A cancel gets
+        // the refresh too — a partly-applied pull still changed the tree — and
+        // only the banner is skipped.
         await get().refreshAll();
-        setErrorFor(repo.id, e);
+        reportNetFailure(repo.id, e);
       },
     );
   },
@@ -1345,11 +1451,20 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     try {
       await withAuthRetry(
         repo.id,
-        async (creds) => {
-          await pushRemote(repo.id, remote, branch, force, creds, noVerify);
-          await get().refreshAll();
-        },
-        (e) => setErrorFor(repo.id, e),
+        (creds) =>
+          runCancellable("push", setNetOp, async (opId) => {
+            await pushRemote(
+              repo.id,
+              remote,
+              branch,
+              force,
+              creds,
+              noVerify,
+              opId,
+            );
+            await get().refreshAll();
+          }),
+        (e) => reportNetFailure(repo.id, e),
       );
     } finally {
       setActivity("push", null);

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { appErrorMessage, describeError, toAppError, type AppError } from "./errors";
+import {
+  appErrorMessage,
+  describeError,
+  isCancelledError,
+  toAppError,
+  type AppError,
+} from "./errors";
 
 /**
  * #146: every backend failure reached the log file as `[object Object]`, so the
@@ -260,5 +266,36 @@ describe("HookRejected (#232)", () => {
       message: { hook: "pre-commit", output: "" },
     };
     expect(appErrorMessage(e)).toContain("pre-commit");
+  });
+});
+
+describe("isCancelledError (#234)", () => {
+  it("narrows a cancel", () => {
+    expect(isCancelledError({ kind: "Cancelled" })).toBe(true);
+  });
+
+  it("does not narrow anything else", () => {
+    // Especially not `Network`, which is what a killed git would look like if
+    // the backend ever stopped claiming the cancel first.
+    for (const e of [
+      { kind: "Network", message: "connection reset" },
+      { kind: "Auth", message: { host: "github.com", kind: "Https" } },
+      { kind: "Io", message: "broken pipe" },
+      new Error("cancelled"),
+      "Cancelled",
+      null,
+      undefined,
+    ]) {
+      expect(isCancelledError(e)).toBe(false);
+    }
+  });
+
+  it("still renders as SOMETHING if a surface does show it", () => {
+    // The variant carries no message, so this is the no-prose fallback path —
+    // a blank banner would be worse than a terse one.
+    const e: AppError = { kind: "Cancelled" };
+    expect(appErrorMessage(e)).toBe("Cancelled");
+    expect(describeError(e)).toBe("Cancelled");
+    expect(toAppError(e)).toBe(e);
   });
 });

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -55,7 +55,17 @@ export type AppError =
    * of eslint belong in the dedicated output block, which scrolls. See
    * `appErrorDetail`.
    */
-  | { kind: "HookRejected"; message: HookRejection };
+  | { kind: "HookRejected"; message: HookRejection }
+  /**
+   * The user stopped a long-running operation (#234). A STATE, not a failure:
+   * no surface may raise a banner for it — they already know, they clicked the
+   * button. Narrow with `isCancelledError` in every catch arm that reports.
+   *
+   * Distinct from `Network`, which is what a killed git would otherwise be
+   * classified as — see the Rust variant for why the backend claims the death
+   * before the classifier sees it.
+   */
+  | { kind: "Cancelled"; message?: string };
 
 /** Which credential the remote is asking for. */
 export type AuthKind = "Https" | "SshPassphrase" | "SshKey";
@@ -309,6 +319,18 @@ export function forgeAuthHost(e: unknown): string | null {
  */
 export function forgeAuthMessage(host: string): string {
   return `The API token for ${host} is missing or was rejected. Add one in Settings → Integrations.`;
+}
+
+/**
+ * Narrow to "the user cancelled it" (#234).
+ *
+ * Every catch arm that would set an error must check this FIRST. A banner that
+ * says "operation cancelled" after the user pressed Cancel is the app arguing
+ * with them, and — worse — it is indistinguishable at a glance from the failures
+ * that do need attention.
+ */
+export function isCancelledError(e: unknown): boolean {
+  return isAppError(e) && e.kind === "Cancelled";
 }
 
 /** Narrow to "a local branch of that name already exists". */

--- a/src/lib/opId.test.ts
+++ b/src/lib/opId.test.ts
@@ -1,0 +1,40 @@
+// Op ids for cancellable backend operations (#234). Small surface, but a
+// collision means a cancel stops somebody else's operation, and a throw means
+// the click that starts a fetch never starts it.
+import { describe, expect, it } from "vitest";
+
+import { newOpId } from "./opId";
+
+describe("newOpId", () => {
+  it("never repeats, even called in a tight loop", () => {
+    // Two fetches started in the same millisecond must not share an id: the
+    // second cancel would kill the first op's child, which by then may be a pid
+    // the OS has reissued.
+    const ids = new Set(Array.from({ length: 2000 }, () => newOpId("fetch")));
+    expect(ids.size).toBe(2000);
+  });
+
+  it("carries the kind, so a log line or IPC trace is readable", () => {
+    expect(newOpId("clone").startsWith("clone-")).toBe(true);
+    expect(newOpId("push").startsWith("push-")).toBe(true);
+  });
+
+  it("does not depend on crypto.randomUUID", () => {
+    // The whole reason this helper exists: `randomUUID` is only defined in a
+    // secure context, and whether a webview treats the app's custom protocol as
+    // one is a per-platform detail. A throw here would cost the fetch.
+    const original = globalThis.crypto;
+    // Deliberately removed for the duration of the test: `newOpId` must not
+    // reach for it, so its absence must not change the answer.
+    delete (globalThis as { crypto?: unknown }).crypto;
+    try {
+      expect(newOpId("fetch")).toMatch(/^fetch-/);
+    } finally {
+      Object.defineProperty(globalThis, "crypto", {
+        value: original,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+});

--- a/src/lib/opId.ts
+++ b/src/lib/opId.ts
@@ -1,0 +1,29 @@
+/**
+ * Ids for cancellable backend operations (#234).
+ *
+ * # Why the frontend mints them
+ *
+ * The operation we most need to cancel is the one that never answers, so an id
+ * assigned by the backend and emitted back would leave a window — unbounded, for
+ * exactly the hang this exists for — in which the op is running and nothing can
+ * address it. Minting the id before the invoke makes the cancel button live from
+ * the first frame.
+ *
+ * # Why not `crypto.randomUUID()`
+ *
+ * It is only defined in a secure context, and whether a webview treats the app's
+ * custom protocol as one is a per-platform detail we do not control. A missing
+ * `randomUUID` would throw inside the click handler that starts a fetch, so the
+ * feature would cost us the fetch. `Date.now()` + `Math.random()` is not a UUID
+ * and does not need to be: the id only has to be unique among the handful of ops
+ * one app process has in flight, and it is never persisted, compared across
+ * machines, or used as a secret.
+ *
+ * The kind is carried in the id purely so a log line or an IPC trace reads as
+ * `fetch-…` rather than an opaque token.
+ */
+export function newOpId(kind: string): string {
+  return `${kind}-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 10)}`;
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -818,13 +818,26 @@ export async function rememberCredential(
   return invoke<void>("remember_credential", { repoId, host, credentials });
 }
 
+/**
+ * Stop the operation running under `opId` (#234).
+ *
+ * `false` means nothing with that id is in flight — it finished between the
+ * click and this call. Not a failure: what the user asked for has happened.
+ * A second call for the same id escalates SIGTERM to SIGKILL.
+ */
+export async function cancelOperation(opId: string): Promise<boolean> {
+  return invoke<boolean>("cancel_operation", { opId });
+}
+
 export async function fetch(
   repoId: string,
   remote: string,
   prune = true,
   credentials?: Credentials,
+  /** Handle for `cancelOperation`; omitted makes this fetch uncancellable. */
+  opId?: string,
 ): Promise<void> {
-  return invoke<void>("fetch", { repoId, remote, prune, credentials });
+  return invoke<void>("fetch", { repoId, remote, prune, credentials, opId });
 }
 
 /** Fetch all remotes, pruning deleted remote refs. */
@@ -832,8 +845,9 @@ export async function fetchAll(
   repoId: string,
   prune = true,
   credentials?: Credentials,
+  opId?: string,
 ): Promise<void> {
-  return invoke<void>("fetch_all", { repoId, prune, credentials });
+  return invoke<void>("fetch_all", { repoId, prune, credentials, opId });
 }
 
 /**
@@ -848,8 +862,16 @@ export async function pull(
   branch: string,
   mode: PullMode = "Merge",
   credentials?: Credentials,
+  opId?: string,
 ): Promise<void> {
-  return invoke<void>("pull", { repoId, remote, branch, mode, credentials });
+  return invoke<void>("pull", {
+    repoId,
+    remote,
+    branch,
+    mode,
+    credentials,
+    opId,
+  });
 }
 
 /**
@@ -865,6 +887,7 @@ export async function push(
   credentials?: Credentials,
   /** Skip `pre-push` for this push only (#232). */
   noVerify = false,
+  opId?: string,
 ): Promise<void> {
   return invoke<void>("push", {
     repoId,
@@ -873,6 +896,7 @@ export async function push(
     force,
     credentials,
     noVerify,
+    opId,
   });
 }
 
@@ -1103,6 +1127,7 @@ export async function cloneRepo(
   name: string,
   recurseSubmodules: boolean,
   credentials?: Credentials,
+  opId?: string,
 ): Promise<string> {
   return invoke<string>("clone_repo", {
     url,
@@ -1110,6 +1135,7 @@ export async function cloneRepo(
     name,
     recurseSubmodules,
     credentials,
+    opId,
   });
 }
 


### PR DESCRIPTION
> **Superseded by #260**, which landed on `main` first and closed #234. This is a draft kept for
> reference; the pieces with no counterpart in what shipped are tracked in #263. See the comment below.

An independent implementation of #234.

A clone, fetch, pull or push that hangs could only be escaped by force-quitting the app — our own source admitted it at `commands/create.rs:253`. All four are now stoppable, and stopping one leaves the repository exactly as it was.

Spec: `docs/superpowers/specs/2026-08-26-cancel-network-ops-spec.md` · Plan: `docs/superpowers/plans/2026-08-26-cancel-network-ops-plan.md`

## What you get

- **Clone** — while it runs, the dialog's **Cancel** button *is* the cancel (it used to be `disabled={busy}`, which is what made a stall a force-quit). It reports "Stopping…", and the dialog closes only once the backend confirms it cleaned up.
- **Fetch / pull / push** — one **Stop** button in the titlebar next to Push, shown only while a cancellable op is running and titled with what it will stop. Keyboard route: a `Stop the running <op>` palette row, gated the same way.
- **Window close** cancels everything in flight.
- **Auto-fetch** no longer stacks: it skips while a fetch is in flight, and cancels its own after two minutes.

## The decisions worth reviewing

**The registry never interrupts the op.** `cancel.rs` holds `id → Op` and kills the op's *child*; the op then notices — its `wait()` returns because git is dead, and it checks `is_cancelled()` before mapping stderr. The two shapes that read better both fail: `tokio::select!` over `child.wait()` and a cancel future needs `&mut child` in both arms, and `Arc<Mutex<Child>>` deadlocks because the op holds the lock across the very `wait()` the killer must interrupt.

**SIGTERM to the process group, not SIGKILL to the child.** Two things are wrong with `child.kill()`:

- *Wrong process.* `git` spawns `git-remote-https` (https) or `ssh` (ssh), so killing only `git` leaves the transfer's child holding the connection. `proc::git_async`/`git_async_in` now set `process_group(0)`; the `*_keeping_console` constructors deliberately do **not** (an interactive child outside the terminal's foreground group is stopped by SIGTTIN/SIGTTOU).
- *Wrong signal.* git's handlers remove its lock files (`lockfile.c`) and, in `clone`, the partial destination (`remove_junk_on_signal`). SIGKILL skips all of it, so a SIGKILLed pull strands `.git/index.lock` and the **next** pull fails with "Unable to create '…/index.lock': File exists". A cancel that breaks the following operation is worse than no cancel.

`kill_tree` verifies `getpgid(pid) == pid` before using `killpg`, falling back to a single-process kill — without that, a future spawn site that skipped the process group would have a cancel signal *our own* group. A **second** cancel escalates to SIGKILL: the user clicking again is the escalation signal, so there is no timer and no new tokio feature.

**The frontend mints the op id, before the invoke** (`src/lib/opId.ts`). A backend-assigned id emitted back would leave the op unaddressable for exactly as long as it fails to answer, which is the case this exists for. `op_id` is `Option<String>`, so `push_tag`, `push_delete_branch`, LFS, submodule update and the forge PR checkout are untouched and behave exactly as before — each is one argument from opting in.

**A cancelled clone restores the pre-clone state exactly.** `validate_clone_target` accepts only an absent target or an existing **empty** directory, so `run_clone` records which it saw: a directory *we* created is removed, a directory the **user already had** is emptied and kept. Cancel only — a failed `git clone` removes its own destination, and widening this to every failure would mean deleting a directory on a path we have not just proved is ours.

**`AppError::Cancelled` is a state, not a failure.** Checked *before* `map_git_failure` at every site, so a killed git's dying words cannot become a `Network` banner — or an `Auth` one that pops the credential dialog over a cancel. `isCancelledError` then keeps it out of every error surface, while the `refreshAll()` still happens (a partly-applied pull changed the tree).

**Windows is the abrupt case, knowingly.** No SIGTERM, and our children have no console for `GenerateConsoleCtrlEvent`, so cancel is `taskkill /F /T`. git gets no chance to clean up: `discard_partial_clone` covers the clone destination, and a stale `index.lock` after a cancelled pull is the known remaining gap, recorded in `docs/dev/backend.md`. The argv is a pure, unit-tested function so the interesting half is compiled on every platform — PR CI does not build Windows.

## Found while reviewing my own diff

Minting the op id *around* `withAuthRetry` was wrong: it resolves as soon as a credential challenge is **raised**, so the id would be cleared while the prompt was up and the retry — a second git process, every bit as able to stall — would run with no Stop button. Each attempt now mints its own id, as the clone path already did. Pinned by a test.

## Verification

- `cargo test` — 750 passing, including a **real** cancel: a TCP listener that accepts and never answers makes `git clone` hang, the test cancels it, and asserts `Cancelled` plus an absent destination. Plus the cancelled-before-spawn window and the cleanup table.
- `pnpm test` — 1950 passing (227 files), covering both surfaces, the `netOps` publish/clear pairing, the per-attempt retry id, "cancelled is not an error", and the auto-fetch skip + deadline under fake timers.
- `pnpm tsc --noEmit` and `pnpm exec tsc -p e2e/tsconfig.json --noEmit` clean.
- `pnpm test:e2e:docker full --spec create --spec remote --spec palette` — 22 passing, 3 spec files, including two new specs that cancel a genuinely stalled clone and a genuinely stalled fetch through the real IPC path:

```
[WebKitGTK 605.1.15 linux #0-0]    ✓ cancels a stalled clone, closing the dialog and leaving nothing behind
[WebKitGTK 605.1.15 linux #0-1]    ✓ Stop cancels a stalled fetch, with no error banner
Spec Files:	 3 passed, 3 total (100% completed) in 00:00:11
```

## Deliberately out of scope

Cancelling `push_tag` / `push_delete_branch` / LFS / submodule update / forge checkout (no progress surface, not the first-five-minutes hang); a timeout for *interactive* ops (a user watching a slow clone of `torvalds/linux` must not have it yanked away); resuming a cancelled clone (git has no resume — the offer would be a fresh clone, which the dialog already is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
