### PR TITLE
docs(contributing): get a newcomer from clone to a running app (#211)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,7 @@
 - [ ] `pnpm tsc --noEmit` passes
 - [ ] `cargo test --manifest-path src-tauri/Cargo.toml` passes
 - [ ] `pnpm test` passes
+- [ ] If you touched `e2e/`: `pnpm exec tsc -p e2e/tsconfig.json --noEmit` passes (the root typecheck excludes `e2e/`)
 - [ ] Added/updated tests for the change
 - [ ] If a new git op: trait + impl + command + handler registration + TS type/wrapper wired (see CONTRIBUTING.md)
 - [ ] If a new feature: spec + plan added under `docs/superpowers/`

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,17 +51,18 @@ jobs:
           # runs in the unit job — the root tsconfig excludes e2e/, so nothing
           # else typechecks the specs.
           #
-          # The last six entries are the INPUTS the `docs` vitest project
+          # The last seven entries are the INPUTS the `docs` vitest project
           # reads, not frontend sources, and each one was skippable by exactly
           # the change it exists to police: `test/` holds both suites,
           # `docs.test.ts` asserts CLAUDE.md + docs/dev/ match the tree,
           # `shardSpecs.test.ts` asserts e2e.yml's shard matrix covers every
-          # spec, and `comparison.test.ts` asserts README.md's comparison table
-          # matches site/src/data/comparison.json. Without them here, editing
-          # only the docs, only the matrix, or only the table skipped its own
-          # guard and reported green (issue 189, then #210 — a README-only PR
-          # ran no suite at all).
-          if echo "$changed" | grep -qE '^(src/|e2e/|test/|index\.html$|package\.json$|pnpm-lock\.yaml$|vite\.config\.ts$|tsconfig[a-z.]*\.json$|CLAUDE\.md$|README\.md$|docs/dev/|site/src/data/comparison\.json$|\.github/workflows/(tests|e2e)\.yml$)'; then
+          # spec, `comparison.test.ts` asserts README.md's comparison table
+          # matches site/src/data/comparison.json, and `contributing.test.ts`
+          # asserts CONTRIBUTING.md's links and commands still exist (#211).
+          # Without them here, editing only the docs, only the matrix, or only
+          # the table skipped its own guard and reported green (issue 189, then
+          # #210 — a README-only PR ran no suite at all).
+          if echo "$changed" | grep -qE '^(src/|e2e/|test/|index\.html$|package\.json$|pnpm-lock\.yaml$|vite\.config\.ts$|tsconfig[a-z.]*\.json$|CLAUDE\.md$|README\.md$|CONTRIBUTING\.md$|docs/dev/|site/src/data/comparison\.json$|\.github/workflows/(tests|e2e)\.yml$)'; then
             echo "js=true" >> "$GITHUB_OUTPUT"
             echo "-> frontend sources touched, running the unit suite"
           else

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,82 +2,229 @@
 
 Thanks for your interest in contributing! platypusgit is a cross-platform,
 developer-focused git desktop app built with Tauri 2 (Rust) and React +
-TypeScript. This guide covers everything you need to get a change merged.
+TypeScript.
+
+This file owns setup, the test commands and the PR workflow. The
+[README](./README.md) links here rather than repeating them.
 
 By contributing you agree that your contributions are licensed under the
-project's [GPL-3.0 license](./LICENSE).
+project's [GPL-3.0 license](./LICENSE). Please also read the
+[Code of Conduct](./CODE_OF_CONDUCT.md).
 
-## Prerequisites
+## Quick start — clone to a running window
 
-- **Node 22+**
-- **pnpm** — `curl -fsSL https://get.pnpm.io/install.sh | sh -`
+Budget ten minutes, most of it spent watching Rust compile.
+
+### 1. Prerequisites
+
+- **Node 22+** (CI builds on 22)
+- **pnpm 9+** — `curl -fsSL https://get.pnpm.io/install.sh | sh -`. Not npm, not
+  yarn: the lockfile is `pnpm-lock.yaml`.
 - **Rust stable** — via [rustup](https://rustup.rs/)
 - Platform build tools:
-  - **macOS:** Xcode Command Line Tools (`xcode-select --install`)
-  - **Linux:** `libwebkit2gtk-4.1-dev`, `build-essential`, `libssl-dev` (see [Tauri prerequisites](https://tauri.app/start/prerequisites/))
-  - **Windows:** WebView2 (ships with Windows 11), MSVC Build Tools
+  - **macOS:** Xcode Command Line Tools — `xcode-select --install`
+  - **Linux:** the set CI installs, which is the one known to link:
+    ```bash
+    sudo apt-get install libwebkit2gtk-4.1-dev libgtk-3-dev \
+      libayatana-appindicator3-dev librsvg2-dev patchelf build-essential
+    ```
+    (see also [Tauri's prerequisites](https://tauri.app/start/prerequisites/))
+  - **Windows:** MSVC Build Tools, plus WebView2 (already present on Windows 11)
 
-## Getting started
+### 2. Run it
 
 ```bash
-pnpm install        # frontend + tauri-cli deps
-pnpm tauri dev      # run the app (first build ~2-5 min, reruns ~10s)
+pnpm install        # frontend + tauri-cli deps  — ~1 min the first time
+pnpm tauri dev      # builds the Rust tree, then opens the app
 ```
+
+**The first `pnpm tauri dev` compiles the entire Rust dependency tree: 2–5
+minutes with no window and very little output.** It has not hung. Later runs
+reuse the cargo cache and start in ~10s; frontend edits hot-reload without a
+rebuild.
+
+If it fails on Linux with a linker error about `webkit2gtk` or
+`ayatana-appindicator`, a package from the list above is missing.
+
+### 3. Check your toolchain is complete
+
+```bash
+pnpm tsc --noEmit                                   # seconds
+pnpm test                                           # seconds
+cargo test --manifest-path src-tauri/Cargo.toml     # minutes on a cold cache
+```
+
+If those pass, your toolchain is complete. There is a fourth test layer — e2e —
+which runs in Docker rather than on your machine; see [Tests](#tests).
+
+## What to work on
+
+- **[good first issue](https://github.com/jonassaa/platypusgit/labels/good%20first%20issue)**
+  — scoped, self-contained, and written to be picked up cold.
+- **[All open issues](https://github.com/jonassaa/platypusgit/issues)** — bugs
+  and feature requests, most with the relevant files named in the body.
+- **[Discussions](https://github.com/jonassaa/platypusgit/discussions)** — the
+  place for questions, ideas and "is this a bug?" before it is an issue.
+
+Comment on an issue before starting something non-trivial, so two people don't
+build it twice. For anything larger than a small fix, open an issue and agree
+the approach first; net-new features land a spec + plan under
+`docs/superpowers/` before implementation.
 
 ## Project layout
 
-See [`CLAUDE.md`](./CLAUDE.md) for the full architecture tour, conventions, and
-the step-by-step recipe for adding a new git operation. Design specs and
-implementation plans live under `docs/superpowers/`.
+The architecture documentation for humans is [`docs/dev/`](./docs/dev/). **Read
+the one matching your area before making a non-trivial change** — each is an
+annotated tour, not an index:
+
+- [`architecture.md`](./docs/dev/architecture.md) — annotated backend and
+  frontend source trees: every module, command and feature directory, and the
+  traps between them. Start here.
+- [`frontend.md`](./docs/dev/frontend.md) — diff rendering, the paged log,
+  navigation, multi-repo state, the design system, dialogs, drag and drop.
+- [`backend.md`](./docs/dev/backend.md) — errors, forge tokens, the rebase
+  engine, network ops and credentials, signing, stash, process spawning.
+- [`testing.md`](./docs/dev/testing.md) — the four test layers, Docker e2e, the
+  CI workflows and gates.
+- [`distribution.md`](./docs/dev/distribution.md) — the `pgit` CLI, packaging
+  per channel, Tauri permissions.
+
+Approved design specs and implementation plans live under
+[`docs/superpowers/`](./docs/superpowers/).
+[`CLAUDE.md`](./CLAUDE.md) is the short operational brief for AI assistants; it
+points at the same `docs/dev/` files.
 
 High level:
 
-- `src-tauri/` — Rust backend. `GitBackend` trait + `Libgit2Backend` impl, thin
-  Tauri command handlers in `commands/`.
+- `src-tauri/` — Rust backend. A `GitBackend` trait + `Libgit2Backend` impl,
+  behind thin Tauri command handlers in `commands/`.
 - `src/` — React frontend. In-house design system in `src/design/`, per-feature
-  Zustand stores in `src/features/`, screens in `src/screens/`.
+  Zustand stores and components in `src/features/`, screens in `src/screens/`.
 
 ## Tests
 
-Three independent layers — run all before opening a PR:
+**Four independent layers.** Three run on your machine; the fourth runs in
+Docker.
 
 ```bash
-pnpm tsc --noEmit                                   # TypeScript type-check
-cargo test --manifest-path src-tauri/Cargo.toml     # Rust backend integration
-pnpm test                                           # vitest (frontend unit + component)
+cargo test --manifest-path src-tauri/Cargo.toml     # layer 1
+pnpm test                                           # layers 2 and 3 (one vitest run)
+pnpm test:e2e:docker                                # layer 4 — see below
 ```
 
-Add tests alongside the code you change:
+1. **Rust backend integration** — every `GitBackend` op against real temp repos
+   (`TempRepo` fixture in `src-tauri/tests/support/`). No webview, no network.
+2. **Frontend pure logic + component tests** — the vitest `unit` project:
+   `src/**/*.test.{ts,tsx}`, jsdom + React Testing Library, with `invoke` mocked
+   via `src/test/setup.ts` (`mockInvoke(cmd, handler)`).
+3. **Doc and tree invariants** — the vitest `docs` project, `test/*.test.ts`.
+   These read `CLAUDE.md`, `docs/dev/`, `README.md`, `src-tauri/` and `e2e/`,
+   and **will fail your build if you add a command, backend module or feature
+   directory without documenting it**. That is deliberate: a command nobody can
+   find is a command that gets written twice. If `docs.test.ts` fails, the fix
+   is to add your new thing to the tree in `docs/dev/architecture.md`.
+4. **E2E** — WebdriverIO specs in `e2e/specs/` driving the real binary.
 
-- New git op → integration test against a real temp repo (`TempRepo` fixture in
-  `src-tauri/tests/support/`).
-- New pure frontend logic → `*.test.ts`.
-- New component → `*.test.tsx` (jsdom + React Testing Library; mock `invoke` via
-  `mockInvoke` in `src/test/setup.ts`).
+Run one vitest project with `pnpm vitest run --project unit` (or `--project
+docs`).
+
+Two typechecks sit alongside the layers, and CI runs both:
+
+```bash
+pnpm tsc --noEmit                                   # src/ and test/
+pnpm exec tsc -p e2e/tsconfig.json --noEmit         # e2e/ — nothing else covers it
+```
+
+**`pnpm tsc --noEmit` does not cover `e2e/`.** The root tsconfig excludes it, so
+a type error in a spec passes locally and fails CI unless you run the second
+command.
+
+### E2E: always in Docker
+
+```bash
+pnpm test:e2e:docker build                                  # rebuild the binary snapshot
+pnpm test:e2e:docker run --spec e2e/specs/diff-nav.e2e.ts   # one spec, reusing the snapshot
+pnpm test:e2e:docker                                        # build + the whole suite
+```
+
+**Never run e2e natively.** macOS has no headless webview, so a native run pops
+a real window, steals focus, is flaky on multi-window specs and slow — and a
+green native run does not predict the CI gate. The `test:e2e`, `test:e2e:build`
+and `test:e2e:run` scripts are in-container primitives; don't call them on the
+host.
+
+Run e2e when you are *done* developing, and only the spec files covering what
+you touched — CI runs the full suite. After any `src/` or `src-tauri/` change,
+`build` first: `run` against a stale snapshot silently tests the old binary.
+The first Docker run builds the image and compiles Rust from scratch and is
+slow; later runs reuse caches.
+
+Full detail — sharding, the memory limits, spec gotchas — is in
+[`docs/dev/testing.md`](./docs/dev/testing.md).
+
+### Adding tests
+
+Add them alongside the code you change:
+
+- New git op → a Rust integration test against a real temp repo.
+- New pure frontend logic → `*.test.ts` next to it.
+- New component → `*.test.tsx`.
+- New user-facing flow, or a bug that reached the UI → an e2e spec.
+
+## Production bundles
+
+```bash
+pnpm tauri build --no-sign     # .dmg / .msi / .deb / .AppImage under src-tauri/target/release/bundle/
+```
+
+**`--no-sign` is not optional locally.** `src-tauri/tauri.conf.json` carries the
+updater public key and sets `createUpdaterArtifacts`, and a public key with no
+matching private key is a *hard error* on any target that produces an updater
+artifact. Either pass `--no-sign`, or export `TAURI_SIGNING_PRIVATE_KEY` (and
+`TAURI_SIGNING_PRIVATE_KEY_PASSWORD`). CI passes both from repository secrets;
+a plain `pnpm tauri build` will fail for you.
 
 ## Adding a new git operation
 
 1. Add the method to the `GitBackend` trait (`src-tauri/src/git/mod.rs`).
-2. Implement it in `Libgit2Backend` (`libgit2.rs`); stub `NotImplemented` in
-   `CliBackend` (`cli.rs`) to keep the trait shape exercised.
-3. Add a thin Tauri command in the right `commands/<area>.rs`. Wrap git2 calls in
-   `tokio::task::spawn_blocking` (libgit2 is sync).
+2. Implement it in `Libgit2Backend` (`src-tauri/src/git/libgit2.rs`); stub
+   `NotImplemented` in `CliBackend` (`src-tauri/src/git/cli.rs` — *not*
+   `src-tauri/src/cli.rs`, which is the `pgit` launcher) to keep the trait
+   shape exercised.
+3. Add a thin Tauri command in the right `commands/<area>.rs`. Wrap git2 calls
+   in `tokio::task::spawn_blocking` — libgit2 is sync, and `git2::Repository`
+   is `Send` but not `Sync`.
 4. Register the command in `invoke_handler![…]` (`src-tauri/src/lib.rs`).
-5. Add the TS type to `src/lib/types.ts` and a typed wrapper to `src/lib/tauri.ts`
-   (the frontend never calls `invoke()` directly).
+5. Add the TS type to `src/lib/types.ts` and a typed wrapper to
+   `src/lib/tauri.ts` (the frontend never calls `invoke()` directly).
 6. Wire it into the relevant feature's Zustand store.
+7. **Document it** — add the command to its `commands/<area>.rs` entry in the
+   backend tree in `docs/dev/architecture.md`. `test/docs.test.ts` fails the
+   build otherwise.
 
 ## Conventions
 
-- **Errors:** every IPC-crossing Rust fn returns `AppResult<T>`. No `unwrap`/panic
-  in commands — add an `AppError` variant instead of stringifying. Keep the TS
-  `AppError` union (`src/lib/errors.ts`) 1:1 with the Rust enum in the same commit.
-- **State:** Zustand per-feature, not one global store. Cross-screen navigation
-  goes through `useNavStore` intents.
-- **Styling:** Tailwind v4 (CSS-first). Theme tokens in `src/index.css`. No
-  `tailwind.config.js`.
+The rule is here; the reasoning and the traps are in the linked doc.
+
+- **Errors:** every IPC-crossing Rust fn returns `AppResult<T>`. No
+  `unwrap`/panic in commands — add an `AppError` variant instead of
+  stringifying. Keep the TS `AppError` union (`src/lib/errors.ts`) 1:1 with the
+  Rust enum, in the same commit. (`backend.md`)
+- **Process spawning:** never `Command::new` outside `src-tauri/src/proc.rs` —
+  a guard test fails the build. (`backend.md`)
+- **One credential path:** network git ops go through
+  `commands::net::run_git_authenticated`; the frontend retries via
+  `withAuthRetry`. Secrets travel in env, never argv. (`backend.md`)
+- **State:** Zustand per feature, not one global store. `useRepoStore` holds
+  exactly one repository's state, so a new per-repo field must join
+  `RepoSlice`/`emptySlice` or it leaks across tab switches. Cross-screen
+  navigation goes through `useNavStore` intents. (`frontend.md`)
 - **Design system:** import UI primitives from `@/design`. Do not add
-  `src/components/ui/`.
+  `src/components/ui/`. No native `<select>`/`<option>` and no
+  `window.confirm`/`window.prompt` (use `PGSelect`, `pgConfirm`, `pgPrompt`) —
+  guard tests enforce both. Never hardcode the accent hue. (`frontend.md`)
+- **Styling:** Tailwind v4, CSS-first. Theme tokens in `src/index.css`. There is
+  no `tailwind.config.js`.
 - **Path alias:** `@/` → `src/`. Prefer it over deep relative imports.
 
 ## Commit messages
@@ -111,10 +258,13 @@ with no merge commits.
 ## Pull requests
 
 1. Make your change on a feature branch (see above), with tests.
-2. Ensure all three test layers pass (see [Tests](#tests)).
+2. Run the local gates — `pnpm tsc --noEmit`, `pnpm test`,
+   `cargo test --manifest-path src-tauri/Cargo.toml`, plus
+   `pnpm exec tsc -p e2e/tsconfig.json --noEmit` if you touched `e2e/`, and the
+   relevant e2e spec(s) in Docker if you touched `src/` or `src-tauri/`.
 3. Open the PR; fill out the template, describe the change and link any issue.
 4. Keep PRs focused — one logical change per PR.
 
-For larger features beyond a small fix, open an issue first to discuss the
-approach. Net-new features should land a spec + plan under `docs/superpowers/`
-before implementation.
+CI runs the same layers: a `unit` job (typecheck, vitest, e2e typecheck), a
+`rust` job (`cargo test`), and the sharded Linux e2e suite. `e2e-linux` is the
+required check.

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -223,6 +223,21 @@ Rules that keep the gates honest:
   for, so re-read the vendors' pages before moving `checkedOn`. Its inputs
   (`README.md`, `site/src/data/comparison.json`) are in `tests.yml`'s `js`
   filter — without them the guard never runs on the PRs that edit the table.
+- **`test/contributing.test.ts`** keeps `CONTRIBUTING.md` — the only path a
+  newcomer has from `git clone` to a running window (#211) — from going stale
+  in the ways that already happened: it promised "Three independent layers" of
+  tests when there are four, never mentioned e2e at all (so a contributor tried
+  a native run), and pointed humans at `CLAUDE.md` instead of `docs/dev/`. The
+  test resolves every repo-relative link, checks every `pnpm <name>` in a fenced
+  block against `package.json` (plus a small builtin list — `install`, `exec`,
+  `tsc`, `vitest`, `tauri`), requires the four layer commands and all five
+  `docs/dev/` files by name, and asserts the build section still says
+  `--no-sign` for as long as `tauri.conf.json` actually makes a bare
+  `pnpm tauri build` a hard error — read from the config, so the doc and the
+  build fail together rather than drifting apart. It cannot check that the prose
+  WORKS; the acceptance for that is still a human who has never built a Tauri
+  app reaching a window without asking a question. `CONTRIBUTING.md` is in
+  `tests.yml`'s `js` filter, or a CONTRIBUTING-only PR would run no suite at all.
 - **`test/e2eSelectors.test.ts`** guards the `[data-testid="X"]*=text` trap:
   WebdriverIO compiles it to a SUBSTRING attribute test plus an innermost-match
   condition, so any other testid containing `X` makes the outer element match

--- a/test/contributing.test.ts
+++ b/test/contributing.test.ts
@@ -1,0 +1,174 @@
+/**
+ * @vitest-environment node
+ */
+// CONTRIBUTING.md is the newcomer's only path from `git clone` to a running
+// window (#211), and it is the one doc nothing was checking. It had already
+// drifted in the two ways that matter most to somebody reading it cold:
+//
+//   * it promised "Three independent layers" of tests when there are four —
+//     `test/docs.test.ts` will fail your build over an undocumented command,
+//     and e2e was not mentioned at all, so a contributor who tried a native
+//     run got a focus-stealing window and concluded the suite was broken;
+//   * it linked commands and files by name, and nothing noticed when a script
+//     was renamed or a doc moved.
+//
+// So this pins the mechanically checkable half: the links resolve, the
+// commands exist, the layer count matches `docs/dev/testing.md`, and the
+// build instruction still carries `--no-sign` for as long as the Tauri config
+// makes a bare `pnpm tauri build` a hard error. It does NOT check that the
+// prose is any good — passing means "these instructions still refer to things
+// that exist", never "a newcomer can follow them".
+//
+// `CONTRIBUTING.md` is in `tests.yml`'s `js` path filter for this reason: a
+// guard whose input can be edited without running it is decorative (#210).
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = (rel: string) => resolve(process.cwd(), rel);
+const read = (rel: string) => readFileSync(root(rel), "utf8");
+
+const contributing = read("CONTRIBUTING.md");
+
+/** Fenced ``` blocks, contents only. */
+const fencedBlocks = (md: string): string[] =>
+  [...md.matchAll(/```[a-z]*\n([\s\S]*?)```/g)].map((m) => m[1]);
+
+const commandLines = (md: string): string[] =>
+  fencedBlocks(md)
+    .flatMap((block) => block.split("\n"))
+    // Strip trailing `# comment` annotations and line continuations.
+    .map((line) => line.replace(/\s+#.*$/, "").replace(/\s*\\$/, "").trim())
+    .filter(Boolean);
+
+describe("CONTRIBUTING.md links resolve", () => {
+  it("every repo-relative link points at a file that exists", () => {
+    const links = [...contributing.matchAll(/\]\((\.\/[^)#]+)\)/g)].map(
+      (m) => m[1],
+    );
+
+    // Guards the guard: if the link syntax ever changes, an empty match set
+    // would make every assertion below vacuous.
+    expect(links.length).toBeGreaterThan(5);
+
+    for (const link of links) {
+      expect(existsSync(root(link)), `CONTRIBUTING links ${link}`).toBe(true);
+    }
+  });
+
+  it("names every doc in the docs/dev/ set", () => {
+    // A newcomer sent to CLAUDE.md lands in the assistant's brief; docs/dev/
+    // is the tour written for humans, and all five are worth finding.
+    for (const doc of [
+      "architecture.md",
+      "frontend.md",
+      "backend.md",
+      "testing.md",
+      "distribution.md",
+    ]) {
+      expect(contributing, `CONTRIBUTING does not mention ${doc}`).toContain(
+        doc,
+      );
+    }
+  });
+});
+
+describe("CONTRIBUTING.md commands exist", () => {
+  const scripts: Record<string, string> = JSON.parse(
+    read("package.json"),
+  ).scripts;
+
+  it("every `pnpm <name>` refers to a real script or a known passthrough", () => {
+    // `pnpm install`/`exec` are pnpm's own; `tsc`, `vitest` and `tauri` are
+    // binaries pnpm resolves from node_modules rather than package.json.
+    const builtins = new Set(["install", "exec", "tsc", "vitest", "tauri"]);
+
+    const invoked = commandLines(contributing)
+      .filter((line) => line.startsWith("pnpm "))
+      .map((line) => line.split(/\s+/)[1]);
+
+    expect(invoked.length).toBeGreaterThan(5);
+
+    for (const name of invoked) {
+      expect(
+        builtins.has(name) || name in scripts,
+        `CONTRIBUTING runs \`pnpm ${name}\`, which is neither a package.json script nor a known binary`,
+      ).toBe(true);
+    }
+  });
+
+  it("names the command for each of the four test layers", () => {
+    for (const command of [
+      "cargo test --manifest-path src-tauri/Cargo.toml", // Rust integration
+      "pnpm test", // vitest: unit + docs projects
+      "pnpm test:e2e:docker", // e2e
+      "pnpm exec tsc -p e2e/tsconfig.json --noEmit", // the CI-only typecheck
+    ]) {
+      expect(
+        contributing.includes(command),
+        `CONTRIBUTING omits \`${command}\``,
+      ).toBe(true);
+    }
+  });
+
+  it("agrees with docs/dev/testing.md that there are four layers", () => {
+    const lower = contributing.toLowerCase();
+    expect(read("docs/dev/testing.md").toLowerCase()).toContain("four layers");
+    expect(
+      lower.includes("four independent layers"),
+      "CONTRIBUTING does not say there are four independent test layers",
+    ).toBe(true);
+    // The exact wording it drifted to. Cheap, and names the mistake.
+    expect(
+      lower.includes("three independent layers"),
+      "CONTRIBUTING is back to claiming three test layers",
+    ).toBe(false);
+  });
+
+  it("keeps e2e pointed at Docker", () => {
+    // A native run pops a real window, steals focus and does not predict the
+    // CI gate — the single most expensive thing for a newcomer to get wrong.
+    expect(
+      contributing.includes("Never run e2e natively"),
+      "CONTRIBUTING no longer warns against a native e2e run",
+    ).toBe(true);
+    expect(
+      commandLines(contributing).filter((line) => line === "pnpm test:e2e"),
+      "CONTRIBUTING tells contributors to run the in-container e2e primitive on the host",
+    ).toEqual([]);
+  });
+});
+
+describe("CONTRIBUTING.md build instructions match the Tauri config", () => {
+  it("requires --no-sign while the updater pubkey has no local private key", () => {
+    const conf = JSON.parse(read("src-tauri/tauri.conf.json"));
+    const signingIsMandatory =
+      Boolean(conf.bundle?.createUpdaterArtifacts) &&
+      Boolean(conf.plugins?.updater?.pubkey);
+
+    // If the config ever stops forcing it, this test should be revisited
+    // rather than silently keeping a stale warning in the doc.
+    expect(
+      signingIsMandatory,
+      "tauri.conf.json no longer forces updater signing — revisit CONTRIBUTING's build section",
+    ).toBe(true);
+
+    expect(
+      contributing.includes("pnpm tauri build --no-sign"),
+      "CONTRIBUTING no longer shows the --no-sign build",
+    ).toBe(true);
+    expect(
+      contributing.includes("TAURI_SIGNING_PRIVATE_KEY"),
+      "CONTRIBUTING no longer names the signing-key escape hatch",
+    ).toBe(true);
+
+    const bareBuild = commandLines(contributing).filter(
+      (line) => line === "pnpm tauri build",
+    );
+    expect(
+      bareBuild,
+      "CONTRIBUTING tells contributors to run a bare `pnpm tauri build`, which fails hard without the signing key",
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Rewrites `CONTRIBUTING.md` so somebody who has never seen this repo goes from
`git clone` to a running window without asking a question, and adds a guard test
so it cannot drift back. Closes #211.

Every problem the issue named was reproducible from the file as written:

| Was | Now |
| --- | --- |
| Linux prereqs listed `libssl-dev`, omitted `libgtk-3-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev`, `patchelf` — following it gets a linker error | The set CI actually installs, plus the symptom to recognise |
| No timings; a silent 4-minute Rust build reads as a hang | "2–5 minutes with no window and very little output. It has not hung." |
| "Three independent layers" of tests | Four — `test/docs.test.ts` fails your build over an undocumented command, and **e2e was not mentioned at all** |
| E2E absent, so a contributor tries a native run | `pnpm test:e2e:docker`, with why a native run is worse than useless |
| `pnpm test` and the e2e typecheck gate missing | Both present — the root tsc excludes `e2e/`, so a spec type error passes locally and fails CI |
| Build section absent; README's old `pnpm tauri build` is a hard error locally | `pnpm tauri build --no-sign`, with the updater-pubkey reason |
| Humans sent to `CLAUDE.md` | `docs/dev/` — all five files, with what each covers |
| Nothing on what to pick up | good first issue + Discussions |
| Git-op recipe stopped at step 6 | Step 7 (document it in `architecture.md`) — the one that fails the build if skipped |

Also fixed the `CliBackend` path, which the old file wrote as `cli.rs` — there
are two (`git/cli.rs` is the backend, `src-tauri/src/cli.rs` is the `pgit`
launcher), and CLAUDE.md flags the pair as a trap.

## Why?

`test/contributing.test.ts` is the part that keeps this fixed. The file drifted
to "Three independent layers" silently because nothing read it. The guard pins
the mechanically checkable half:

- every repo-relative link resolves;
- every `pnpm <name>` in a fenced block is a real `package.json` script or a
  known binary;
- the four layer commands and all five `docs/dev/` files are named;
- the build section still says `--no-sign` **for as long as `tauri.conf.json`
  actually makes a bare build fail** — read from the config, so the doc and the
  build break together instead of drifting apart.

It deliberately does not check that the prose is any good; the acceptance for
that is still a human reaching a window.

`CONTRIBUTING.md` joins `tests.yml`'s `js` path filter. Without that this very PR
would have run no suite at all — the #210 failure mode, where a guard's input was
outside the filter and a README-only PR reported green having tested nothing.

## Verification

- `pnpm test` — 1939 passed (225 files), including the 7 new assertions
- `pnpm tsc --noEmit` — clean
- `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — clean
- Mutation-tested the guard rather than trusting a green run: reintroducing
  "Three independent layers", a bare `pnpm tauri build`, and a broken
  `docs/dev/` link each failed the expected test. A check that cannot fail is
  worse than no check.
- Exercised the modified filter regex directly — `CONTRIBUTING.md` matches,
  unrelated files (`site/…`, `CODE_OF_CONDUCT.md`) still skip.

No `src/` or `src-tauri/` change, so no e2e run.

## Checklist

- [x] One logical change, focused PR
- [x] Branched off `main`; no merge commits on the branch
- [x] PR title + commit messages follow Conventional Commits
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm test` passes
- [x] Added tests for the change
- [ ] `cargo test` — not run; no `src-tauri/` change, and the `rust` filter skips this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
