### PR TITLE
feat(distribution)!: productName is platypusgit, so the Debian package is too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,6 +390,12 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ (github.event_name == 'release' && github.event.release.prerelease == false) || github.event_name == 'workflow_dispatch' }}
     steps:
+      # Needed for tauri.conf.json — the cask names the .app bundle and the
+      # bundle name is productName, so the rewrite step below cross-checks them.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version.outputs.tag }}
+
       - name: Mint tap token from GitHub App
         id: app-token
         uses: actions/create-github-app-token@v1
@@ -420,6 +426,26 @@ jobs:
           sed -i -E "s/^  sha256 \".*\"/  sha256 \"$sha\"/" "$f"
           echo "--- updated cask ---"
           grep -E '^  (version|sha256|url)' "$f"
+
+          # The cask names the .app bundle, and the bundle name IS productName.
+          # This job only rewrites version + sha256, so a productName change
+          # would otherwise ship a cask pointing at an app that no longer exists
+          # — and `brew install --cask` would fail for every macOS user, only
+          # discovered after the release was published.
+          #
+          # `.app` is stripped rather than matched whole because Homebrew accepts
+          # either casing on a case-insensitive volume; what must not drift is
+          # the NAME.
+          product="$(jq -r .productName src-tauri/tauri.conf.json)"
+          cask_app="$(sed -nE 's/^  app "(.*)\.app"$/\1/p' "$f" | head -n1)"
+          if [ "$cask_app" != "$product" ]; then
+            echo "Cask app stanza is \"$cask_app.app\" but productName is \"$product\"." >&2
+            echo "The .dmg contains \"$product.app\", so this cask would fail to install." >&2
+            echo "Fix jonassaa/homebrew-platypusgit: the app, binary and postflight" >&2
+            echo "stanzas all name the bundle. Then re-run this workflow." >&2
+            exit 1
+          fi
+          echo "cask app stanza matches productName: $product.app"
 
       - name: Commit & push to tap main
         run: |

--- a/docs/dev/distribution.md
+++ b/docs/dev/distribution.md
@@ -227,12 +227,49 @@ one. Two files, two languages, one string. A Rust test pins the constant and the
 smoke gate asserts the path exists after a real install, so a drift fails CI
 rather than silently telling every apt user to go download a file by hand.
 
-### Package naming
+### Package naming, and what `productName` actually controls
 
-The Debian package is **`platypus-git`** — Tauri kebab-cases `productName` and
-`DebConfig` has no override. `provides: ["platypusgit"]` makes the obvious guess
-resolve too, but `platypus-git` is canonical everywhere we print it, because that
-is what `apt search`, `apt remove` and `dpkg -l` use.
+The Debian package is **`platypusgit`**.
+
+**`productName` is lowercase on purpose, and it is load-bearing.** Tauri derives
+the Debian `Package:` field from it — `tauri-bundler/src/bundle/linux/debian.rs`:
+
+```rust
+let package = heck::AsKebabCase(settings.product_name());
+```
+
+`DebConfig` has no name override, so the *only* lever is `productName`. It was
+`"PlatypusGit"`, whose internal capital is a word boundary, so kebab-casing
+produced `platypus-git`. Lowercase maps straight through — and it matches how the
+project brands itself everywhere else (`site/src/data/site.ts` has
+`name: 'platypusgit'`).
+
+`provides` + `replaces` + `conflicts` all name the **old** `platypus-git`, so a
+sideloaded install of an older `.deb` upgrades cleanly instead of hitting a dpkg
+file conflict — both packages own `/usr/bin/platypusgit`. `provides` also keeps an
+older `apt install platypus-git` working. Note a virtual name **installs without
+reporting**: `apt policy platypus-git` shows no candidate, which is why
+`platypusgit` is the name the page and the app print.
+
+**Everything else `productName` renames, and who has to follow:**
+
+| Renamed | Consequence |
+| --- | --- |
+| macOS `platypusgit.app` | The **Homebrew cask must change in the same release** — its `app`, `binary` and `postflight` stanzas all name the bundle, and `bump-cask` only rewrites version + sha256. That job now cross-checks the cask's `app` stanza against `productName` and **fails the release** on a mismatch, because the alternative is discovering it when `brew install` breaks for every macOS user. |
+| `scripts/install-pgit.sh` | Searches BOTH `platypusgit.app` and `PlatypusGit.app`. It exists to serve an already-installed app, so dropping the old name would break the `pgit` one-liner for existing users. |
+| `.desktop` file | `platypusgit.desktop`. No consumer in this repo. |
+| Windows `UpgradeCode` | Derived as `Uuid::new_v5(NAMESPACE_DNS, "<productName>.exe.app.x64")` (`bundle/windows/msi/mod.rs`), so a rename **breaks in-place MSI upgrades** — the new installer lands alongside the old. Harmless this time (no `.msi` installs existed), but before there are real Windows users, pin `bundle.windows.wix.upgradeCode` so `productName` stops being load-bearing for upgrades. `pnpm tauri inspect wix-upgrade-code` prints the current value. |
+
+**Not** renamed, deliberately: the release assets (`PlatypusGit_amd64.deb` and
+friends) are stable names the cask and `latest.json` track, decoupled from the
+bundler's output by a `cp` in `release.yml`; the Windows shim directory
+`%LOCALAPPDATA%\PlatypusGit\bin` (`cli.rs`), because renaming it orphans an
+existing PATH entry; and the in-app display strings (window title, Welcome hero,
+logo label), which are a separate branding decision.
+
+The binary is `platypusgit` either way — it comes from the Cargo package name,
+not `productName`, so `/usr/bin/platypusgit`, `platypusgit.exe` and the e2e
+snapshot are all unaffected.
 
 `depends` in `tauri.conf.json` **appends to** the bundler's auto-detected libs —
 the merge is in `tauri-cli` (`interface/rust.rs`, `depends_deb` is seeded from

--- a/docs/superpowers/specs/2026-08-26-apt-repository-spec.md
+++ b/docs/superpowers/specs/2026-08-26-apt-repository-spec.md
@@ -24,10 +24,13 @@ has to. Linux has neither half.
 Two facts from the shipped artifacts, both of which contradict the issue text and
 change the design:
 
-- **The Debian package is `platypus-git`, not `platypusgit`.** Read from the
+- **The Debian package was `platypus-git`, not `platypusgit`.** Read from the
   v0.0.17 `.deb`'s control file — Tauri kebab-cases `productName`, and
-  `DebConfig` exposes no override. The issue's proposed `sudo apt install
-  platypusgit` would fail as written.
+  `DebConfig` exposes no override, so the issue's proposed `sudo apt install
+  platypusgit` would have failed as written. **Resolved during implementation by
+  renaming `productName` to `platypusgit`** (see §D), which was the right call
+  and had to happen *before* the first apt publish — afterwards every apt user
+  would have needed a `Replaces`/`Conflicts` migration.
 - **`apt.platypusgit.com` does not exist.** DNS is at `datacenter.no`, `www`
   CNAMEs to `jonassaa.github.io`, and there is no wildcard record.
 
@@ -106,11 +109,11 @@ Multi-arch from day one, amd64-only in practice (§J).
 └── pool/
     └── main/
         └── p/
-            └── platypus-git/
-                └── platypus-git_0.0.17_amd64.deb
+            └── platypusgit/
+                └── platypusgit_0.0.18_amd64.deb
 ```
 
-`pool/main/p/platypus-git/` is the Debian pool convention
+`pool/main/p/platypusgit/` is the Debian pool convention
 (`pool/<component>/<first letter>/<source package>/`). The suite name lives in
 the path, so adding a `beta` suite later is a new directory rather than a
 migration — but §E ships **one suite**, gated exactly like `bump-cask`, so a
@@ -176,20 +179,33 @@ something other than the script that installed it.
 
 ### D. `.deb` metadata
 
-Three additive keys in `tauri.conf.json` under `bundle.linux.deb`:
+**`productName` becomes `platypusgit`**, and that is what makes the package name
+`platypusgit`. Tauri derives the Debian `Package:` field from it and nothing else
+(`debian.rs`: `heck::AsKebabCase(settings.product_name())`); `DebConfig` has no
+name override. `"PlatypusGit"` kebab-cased to `platypus-git` because the internal
+capital is a word boundary.
+
+This spec originally **rejected** the rename as cosmetic. That was wrong on two
+counts: lowercase is already how the project brands itself
+(`site/src/data/site.ts`, `name: 'platypusgit'`), so `productName` was the
+outlier; and the rename is only cheap *before the first apt publish* — afterwards
+every apt-managed install needs a migration. `docs/dev/distribution.md` carries
+the table of what else the rename drags along (the Homebrew cask above all) and
+who has to follow.
+
+Keys in `tauri.conf.json` under `bundle.linux.deb`:
 
 | Key | Value | Why |
 | --- | --- | --- |
 | `depends` | `["git"]` | A git GUI without git is not degraded, it is broken. `Depends` is what makes "one command and it works" survive a container or a minimal cloud image. |
-| `provides` | `["platypusgit"]` | apt resolves a single-provider virtual package, so `apt install platypusgit` — the obvious guess — works. |
 | `section` | `"vcs"` | Missing today; `apt-ftparchive` wants it, and generating the index with a hole in it is a needless first impression. |
+| `provides` | `["platypus-git"]` | An older `apt install platypus-git` keeps resolving. |
+| `replaces` + `conflicts` | `["platypus-git"]` | Both packages own `/usr/bin/platypusgit`, so without these a sideloaded older `.deb` upgrades into a hard dpkg file conflict. |
 
-`platypus-git` stays **canonical everywhere the page or the app names it**, so
-`apt search`, `apt remove` and `dpkg -l` all agree with what the user was told.
-`provides` exists to catch the wrong guess, not to replace the right name.
-Renaming `productName` to close the gap is rejected: it would change the `.app`
-bundle name, the binary, the desktop file, and the Homebrew cask for a cosmetic
-win.
+`platypusgit` is **canonical everywhere the page or the app names it**, because a
+virtual name installs without reporting — `apt policy platypus-git` shows no
+candidate. Verified: `apt-get install` by the virtual name succeeds and installs
+the real package.
 
 **`depends` is additive — and this was checked, because getting it wrong ships an
 uninstallable package.** `tauri-bundler`'s `debian.rs` writes `Depends:` from
@@ -209,7 +225,7 @@ The config list is the **seed**; the detected libs are appended. So `["git"]`
 yields `Depends: git, libwebkit2gtk-4.1-0, libgtk-3-0` — consistent with the
 shipped v0.0.17 control file, which carries both libs while its config said
 `[]`. That the fields reach the *built* control file is additionally asserted by
-the publish gate (§H) via `dpkg -s platypus-git`, on a runner that can actually
+the publish gate (§H) via `dpkg -s platypusgit`, on a runner that can actually
 produce a `.deb`.
 
 ### E. The publish job
@@ -278,7 +294,7 @@ from the pool.
    re-signing precisely because §C sets no `Valid-Until`.)
 
 The `.deb` is copied into the pool under a **versioned** name
-(`platypus-git_<version>_amd64.deb`); release assets stay stable-named
+(`platypusgit_<version>_amd64.deb`); release assets stay stable-named
 (`PlatypusGit_amd64.deb`) so the Homebrew cask and `latest.json` keep tracking
 `releases/latest/download`. A copy, never a link.
 
@@ -334,7 +350,7 @@ changes nothing.
 | --- | --- |
 | No `apt-get` on `PATH` | Print the AppImage instructions, exit non-zero. |
 | `dpkg --print-architecture` is not `amd64` | Print "not built for this architecture yet" plus the AppImage route, exit non-zero. |
-| Otherwise | Add the keyring, write the sources file, `apt update`, install `platypus-git`. |
+| Otherwise | Add the keyring, write the sources file, `apt update`, install `platypusgit`. |
 
 Detect-then-refuse, never substitute. Piping a script that installs a *different
 format than the one it advertises* is the kind of surprise that costs trust, and
@@ -362,7 +378,7 @@ Components: main
 Architectures: amd64
 Signed-By: /etc/apt/keyrings/platypusgit.gpg
 EOF
-sudo apt update && sudo apt install platypus-git
+sudo apt update && sudo apt install platypusgit
 ```
 
 **deb822 `.sources`, not a one-line `.list`.** deb822 has been supported since
@@ -399,7 +415,7 @@ The publish job is **hard-gated on a real install**, before the push:
 4. Assert: the client image has no `gnupg` before *or after* (proving the
    dearmored-key claim); `/etc/apt/sources.list.d/platypusgit.sources` exists
    (the §I contract); a scoped `apt-get update` against only our sources file
-   accepts the signature; `dpkg -s platypus-git` reports the expected version,
+   accepts the signature; `dpkg -s platypusgit` reports the expected version,
    with `Depends: git` resolved and `Provides:`/`Section:` present; and
    **`pgit --help` exits 0 and prints usage.**
 5. Only then push.
@@ -462,7 +478,7 @@ That guard is the one place a missed branch would silently render nothing.
 
 | Capability | Platform | Note | Command |
 | --- | --- | --- | --- |
-| `notify-apt` | linux | Updates come from apt on this install. | `sudo apt update && sudo apt upgrade platypus-git` |
+| `notify-apt` | linux | Updates come from apt on this install. | `sudo apt update && sudo apt upgrade platypusgit` |
 | `notify` | linux | This `.deb` was not installed from the platypusgit apt repository. Switch to apt and updates come from your package manager: | `curl -fsSL https://www.platypusgit.com/install-platypusgit.sh \| sh` |
 | `notify` | macos | unchanged | `brew upgrade platypusgit` |
 
@@ -500,7 +516,7 @@ disclosures. The Linux panel becomes:
 
 1. **One-line install** — primary card, `Recommended` pill, the `curl … | sh`.
    Its `<details>`: *Updating and removing* (`sudo apt update && sudo apt upgrade
-   platypus-git`, the macOS card's "Homebrew owns updates" paragraph in apt
+   platypusgit`, the macOS card's "Homebrew owns updates" paragraph in apt
    form), *The same thing, spelled out* (the expanded commands from §G plus the
    key fingerprint), and *Read the installer first, or dry-run it* — retitled so
    it does not collide with the identically-named disclosure the CLI section
@@ -522,7 +538,7 @@ today, and it is the honest answer to a Fedora user who reads the apt one-liner
 and wonders what they get instead. It also sets the `.rpm`/AUR follow-ups up as
 additions rather than corrections.
 
-The `.deb` download button stays. `platypus-git` is named as canonical
+The `.deb` download button stays. `platypusgit` is named as canonical
 throughout.
 
 ### L. State that lives outside the repository
@@ -570,8 +586,14 @@ nothing in CI needs them again.
   the pool.
 - **Key expiry, and `Valid-Until`.** §C — both are scheduled global `apt update`
   outages with no upgrade path.
-- **Renaming `productName` to `platypusgit`.** §D — changes the `.app` bundle
-  name, the binary, the desktop file and the Homebrew cask, for cosmetics.
+- ~~**Renaming `productName` to `platypusgit`.**~~ **Reversed — this was done.**
+  It was rejected here as cosmetic, on the grounds that it changes the `.app`
+  bundle name, the desktop file and the Homebrew cask. Those consequences are
+  real (and the cask now has a release-time guard because of them), but the
+  reasoning was wrong twice over: lowercase is already the project's brand
+  everywhere else, so `productName` was the outlier rather than the fix; and the
+  cost only stays low *before the first apt publish*. It also does not change the
+  binary — that comes from the Cargo package name. See §D.
 - **A one-line `.list` sources file, or `apt-key`.** §G — deb822 is universally
   supported and readable; `apt-key` is deprecated and removed.
 - **A new `is_apt_managed` IPC command.** §I — same information, five

--- a/scripts/apt-repo-publish.sh
+++ b/scripts/apt-repo-publish.sh
@@ -40,11 +40,11 @@ set -eu
 SUITE=stable
 COMPONENT=main
 ARCH=amd64
-PKG=platypus-git
+PKG=platypusgit
 
 ORIGIN=platypusgit
 LABEL=platypusgit
-DESCRIPTION="PlatypusGit APT repository"
+DESCRIPTION="platypusgit APT repository"
 
 # How many .deb files stay in the pool. Every GitHub Pages deploy re-uploads the
 # whole tree, so the pool's size is paid on every publish, not once; and the

--- a/scripts/apt-repo-seed/index.html
+++ b/scripts/apt-repo-seed/index.html
@@ -89,15 +89,15 @@ Components: main
 Architectures: amd64
 Signed-By: /etc/apt/keyrings/platypusgit.gpg
 EOF
-sudo apt update &amp;&amp; sudo apt install platypus-git</pre>
+sudo apt update &amp;&amp; sudo apt install platypusgit</pre>
 
   <h2>Update</h2>
-  <pre>sudo apt update &amp;&amp; sudo apt upgrade platypus-git</pre>
+  <pre>sudo apt update &amp;&amp; sudo apt upgrade platypusgit</pre>
   <p>
-    The package is <code>platypus-git</code> — the name <code>apt search</code>,
-    <code>apt remove</code> and <code>dpkg -l</code> use.
-    <code>apt install platypusgit</code> also resolves, because the package
-    declares that name too.
+    The package is <code>platypusgit</code> — the name <code>apt search</code>,
+    <code>apt remove</code> and <code>dpkg -l</code> use. The former
+    <code>platypus-git</code> still resolves, so an older command line keeps
+    working.
   </p>
 
   <h2>Signing key</h2>
@@ -117,7 +117,7 @@ sudo apt update &amp;&amp; sudo apt install platypus-git</pre>
   <h2>What is in here</h2>
   <pre>dists/stable/InRelease                      signed index
 dists/stable/main/binary-amd64/Packages     the package list
-pool/main/p/platypus-git/                   the .deb files</pre>
+pool/main/p/platypusgit/                   the .deb files</pre>
   <p>
     The pool keeps the ten most recent releases. Older versions stay available
     as

--- a/scripts/apt-repo-smoke.sh
+++ b/scripts/apt-repo-smoke.sh
@@ -31,7 +31,7 @@
 # Spec: docs/superpowers/specs/2026-08-26-apt-repository-spec.md
 set -eu
 
-PKG=platypus-git
+PKG=platypusgit
 SUITE=stable
 PORT=8000
 
@@ -86,7 +86,7 @@ Options:
   --installer PATH   install by running this script (the real one-liner) instead
                      of a hand-written sources file
   --expect-git       also assert Depends: git resolved, and that Section: vcs and
-                     Provides: platypusgit are in the control data. Only true of a
+                     Provides/Replaces/Conflicts are in the control data. Only true of a
                      .deb built after that config change, so it is opt-in.
   --client-image IMG default debian:bookworm
   --serve-image IMG  default python:3-slim
@@ -299,9 +299,16 @@ if [ "$PG_EXPECT_GIT" = yes ]; then
     ok "git was pulled in as a dependency"
     grep -q '^Section: vcs' /tmp/status || fail "Section: vcs missing from the control data"
     ok "Section: vcs present"
-    grep -q '^Provides:.*platypusgit' /tmp/status \
-        || fail "Provides: platypusgit missing from the control data"
-    ok "Provides: platypusgit present"
+    # The migration trio, all naming the OLD package. `productName` became
+    # lowercase (#187) so the package is `platypusgit`; both packages own
+    # /usr/bin/platypusgit, so a sideloaded older .deb would upgrade into a hard
+    # dpkg file conflict without Replaces + Conflicts. Provides keeps an older
+    # `apt install platypus-git` resolving.
+    for field in Provides Replaces Conflicts; do
+        grep -q "^$field:.*platypus-git" /tmp/status \
+            || fail "$field: platypus-git missing from the control data"
+    done
+    ok "Provides/Replaces/Conflicts all name the former platypus-git"
 else
     printf 'SMOKE skip: Depends/Section/Provides assertions (--expect-git not set)\n'
 fi

--- a/scripts/install-pgit.sh
+++ b/scripts/install-pgit.sh
@@ -90,7 +90,15 @@ done
 candidate_apps() {
     case "$UNAME_S" in
         Darwin)
+            # BOTH bundle names, new one first. `productName` became lowercase
+            # (#187), so the bundle is `platypusgit.app` from that release on —
+            # but anyone who installed an earlier build still has
+            # `PlatypusGit.app`, and this script exists precisely to serve an app
+            # that is already installed. Dropping the old name would break the
+            # `pgit` one-liner for every existing macOS user.
             printf '%s\n' \
+                "$SEARCH_ROOT/Applications/platypusgit.app/Contents/MacOS/$BINARY_NAME" \
+                "${HOME:-}/Applications/platypusgit.app/Contents/MacOS/$BINARY_NAME" \
                 "$SEARCH_ROOT/Applications/PlatypusGit.app/Contents/MacOS/$BINARY_NAME" \
                 "${HOME:-}/Applications/PlatypusGit.app/Contents/MacOS/$BINARY_NAME"
             ;;

--- a/scripts/install-platypusgit.sh
+++ b/scripts/install-platypusgit.sh
@@ -23,7 +23,7 @@
 # Spec: docs/superpowers/specs/2026-08-26-apt-repository-spec.md
 set -eu
 
-PKG=platypus-git
+PKG=platypusgit
 APPIMAGE_URL=https://www.platypusgit.com/download/#linux
 DEFAULT_APT_URL=https://apt.platypusgit.com
 
@@ -59,7 +59,7 @@ Usage: install-platypusgit.sh [options]
 Adds the platypusgit APT repository and installs the app. Updates then come
 from your package manager:
 
-  sudo apt update && sudo apt upgrade platypus-git
+  sudo apt update && sudo apt upgrade platypusgit
 
 Options:
   --apt-url URL    repository base URL (default https://apt.platypusgit.com)

--- a/site/src/data/site.ts
+++ b/site/src/data/site.ts
@@ -37,9 +37,10 @@ export const apt = {
   // Kept in sync with scripts/install-platypusgit.sh's DEFAULT_APT_URL and
   // scripts/apt-repo-seed/CNAME.
   url: 'https://apt.platypusgit.com',
-  // The canonical package name. `platypusgit` also resolves, via the .deb's
-  // `Provides:`, but this is the name apt search / apt remove / dpkg -l use.
-  pkg: 'platypus-git',
+  // The Debian package name — derived by Tauri from `productName` via
+  // heck::AsKebabCase, so a lowercase productName maps straight through.
+  // The former `platypus-git` still resolves via the .deb's `Provides:`.
+  pkg: 'platypusgit',
   // Fingerprint of the repository signing key, printed on the download page so
   // it is verifiable against something other than the script that installed it.
   // Empty until the key exists — scripts/apt-repo-wizard.sh prints it and says

--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -216,7 +216,7 @@ const platforms = [
                 <CTAButton href={assets.macosDmg} external>Download .dmg</CTAButton>
                 <p class="filename mono">PlatypusGit_universal.dmg</p>
                 <p class="card-note">
-                  Drag <code>PlatypusGit.app</code> into <code>/Applications</code>. Updates are then
+                  Drag <code>platypusgit.app</code> into <code>/Applications</code>. Updates are then
                   manual — repeat the download for every release — and because a drag-install runs no
                   code, the <a href="#cli"><code>pgit</code></a> command is a separate one-liner.
                 </p>
@@ -226,7 +226,7 @@ const platforms = [
                     The <code>.dmg</code> isn’t notarized, so macOS may say the app is damaged or from an
                     unidentified developer. Clear the quarantine flag — Homebrew installs never hit this:
                   </p>
-                  <CodeBlock code={'xattr -cr /Applications/PlatypusGit.app'} lang="bash" />
+                  <CodeBlock code={'xattr -cr /Applications/platypusgit.app'} lang="bash" />
                   <p class="card-note">
                     Or: <strong>System Settings → Privacy &amp; Security → Open Anyway</strong>.
                   </p>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "PlatypusGit",
+  "productName": "platypusgit",
   "version": "0.0.0",
   "identifier": "io.github.jonassaa.platypusgit",
   "build": {
@@ -71,7 +71,9 @@
     "linux": {
       "deb": {
         "depends": ["git"],
-        "provides": ["platypusgit"],
+        "provides": ["platypus-git"],
+        "replaces": ["platypus-git"],
+        "conflicts": ["platypus-git"],
         "section": "vcs",
         "files": { "/usr/bin/pgit": "deb/pgit" },
         "postInstallScript": "deb/postinst"

--- a/src/features/update/UpdatePanel.test.tsx
+++ b/src/features/update/UpdatePanel.test.tsx
@@ -107,7 +107,7 @@ describe("UpdatePanel — capability + platform arms", () => {
       /view release/i,
     );
     expect(screen.getByTestId("pg-update-pkg-hint")).toHaveTextContent(
-      "sudo apt update && sudo apt upgrade platypus-git",
+      "sudo apt update && sudo apt upgrade platypusgit",
     );
   });
 
@@ -241,7 +241,7 @@ describe("UpdatePanel — the package-manager command is copyable", () => {
     render(<UpdatePanel />);
     await userEvent.click(screen.getByTitle(/copy command/i));
     expect(writeText).toHaveBeenCalledWith(
-      "sudo apt update && sudo apt upgrade platypus-git",
+      "sudo apt update && sudo apt upgrade platypusgit",
     );
   });
 

--- a/src/features/update/packageHint.test.ts
+++ b/src/features/update/packageHint.test.ts
@@ -5,16 +5,20 @@ import { packageHint } from "./packageHint";
 describe("packageHint", () => {
   it("tells an apt-managed install to run apt upgrade", () => {
     const hint = packageHint("notify-apt", "linux");
-    expect(hint?.command).toBe("sudo apt update && sudo apt upgrade platypus-git");
+    expect(hint?.command).toBe("sudo apt update && sudo apt upgrade platypusgit");
     expect(hint?.note).toMatch(/apt/i);
   });
 
-  it("names the canonical package, not the guessable one", () => {
-    // `platypus-git` is the real Package field (Tauri kebab-cases productName).
-    // `platypusgit` only works because the .deb declares Provides:, and telling
-    // people the virtual name would make `apt remove` and `dpkg -l` disagree
-    // with what they were shown.
-    expect(packageHint("notify-apt", "linux")?.command).toContain(
+  it("names the package apt actually reports", () => {
+    // `platypusgit` is the real Package field. Tauri derives it from
+    // `productName` with heck::AsKebabCase, so the lowercase productName maps
+    // straight through with no hyphen inserted.
+    //
+    // The old `platypus-git` still resolves, via the .deb's Provides:, but a
+    // virtual name installs without reporting — `apt policy` shows it as having
+    // no candidate — so the hint must name the real one.
+    expect(packageHint("notify-apt", "linux")?.command).toContain("platypusgit");
+    expect(packageHint("notify-apt", "linux")?.command).not.toContain(
       "platypus-git",
     );
   });
@@ -37,7 +41,7 @@ describe("packageHint", () => {
     // macOS never gets the apt variant, but if the backend ever sent it the
     // command must not become a macOS user's problem.
     expect(packageHint("notify-apt", "macos")?.command).toBe(
-      "sudo apt update && sudo apt upgrade platypus-git",
+      "sudo apt update && sudo apt upgrade platypusgit",
     );
   });
 

--- a/src/features/update/packageHint.ts
+++ b/src/features/update/packageHint.ts
@@ -42,7 +42,7 @@ export function packageHint(
       // Character-for-character the command on the download page. Two places
       // telling one user two different upgrade commands is worse than either.
       note: "Updates come from apt on this install:",
-      command: "sudo apt update && sudo apt upgrade platypus-git",
+      command: "sudo apt update && sudo apt upgrade platypusgit",
     };
   }
   if (capability !== "notify") return null;


### PR DESCRIPTION
Follow-up to #267, which merged while this was being written. Part of #187.

## Why

`productName` was the one place the project spelled itself "PlatypusGit" —
`site/src/data/site.ts` and everything else brand it lowercase. That
inconsistency turned out to be load-bearing, because Tauri derives the Debian
`Package:` field from `productName` and nothing else:

```rust
// tauri-bundler/src/bundle/linux/debian.rs
let package = heck::AsKebabCase(settings.product_name());
```

The internal capital is a word boundary, so the package came out
`platypus-git`. Lowercase maps straight through. `DebConfig` has no name
override, so `productName` is the only lever.

**Timing is why this is urgent.** No release has published to apt yet, so the
repository only ever has to know one name. After the first publish, every
apt-managed install would need a `Replaces`/`Conflicts` migration instead.

`apt install platypusgit` and `apt upgrade platypusgit` are now the real
commands rather than an alias.

## ⚠️ This blocks the next release until the cask is edited — and CI enforces it

`jonassaa/homebrew-platypusgit` names the `.app` bundle in three stanzas
(`app`, `binary`, `postflight`), and `bump-cask` only rewrites version and
sha256. Left alone, the next release would ship a cask pointing at an app that
no longer exists — discovered when `brew install` broke for every macOS user.

`bump-cask` now checks out this repo, compares the cask's `app` stanza against
`productName`, and **fails the release** on a mismatch. Verified against the
live cask: it extracts `PlatypusGit` and would fail today, which is the point.

Edit all three stanzas to `platypusgit.app` when cutting the release — **not
before**, or `brew install` breaks for the current version.

## Migration for existing `.deb` users

The `.deb` keeps the old name as `provides` + `replaces` + `conflicts`. Both
packages own `/usr/bin/platypusgit`, so a sideloaded older `.deb` would
otherwise upgrade into a hard dpkg file conflict.

Tested in a container: install `platypus-git` 0.0.17 → add the repo → upgrade →
`platypusgit` 0.0.18 with the old package replaced cleanly, `pgit --help` still
working, and `apt install platypus-git` still resolving.

## Also followed the rename

- `install-pgit.sh` searches **both** `platypusgit.app` and `PlatypusGit.app`.
  It exists to serve an already-installed app, so dropping the old name would
  break the `pgit` one-liner for existing macOS users.
- The download page's drag and `xattr` instructions.
- The smoke gate's `--expect-git` assertions, which now check the migration trio.

## Deliberately NOT renamed

- The stable release assets (`PlatypusGit_amd64.deb` and friends) — the cask and
  `latest.json` track those, decoupled from the bundler by a `cp` in
  `release.yml`.
- `%LOCALAPPDATA%\PlatypusGit\bin` (`cli.rs`) — renaming orphans a PATH entry.
- In-app display strings (window title, Welcome hero, logo label) — a separate
  branding decision, easy to do later if wanted.

The binary is unaffected either way: it comes from the Cargo package name, not
`productName`.

## One consequence accepted knowingly

The MSI `UpgradeCode` is `Uuid::new_v5(NAMESPACE_DNS, "<productName>.exe.app.x64")`
(`bundle/windows/msi/mod.rs`), so this breaks in-place MSI upgrades. Confirmed
harmless — no `.msi` installs exist. `docs/dev/distribution.md` records that it
should be pinned before there are real Windows users, so `productName` stops
being load-bearing for upgrades.

## Verified

`cargo check` (which is what proves `tauri-build` accepts the config) ·
`pnpm test` 1943 passed, including main's new `test/contributing.test.ts` ·
`pnpm tsc --noEmit` · site build · `actionlint` · a full apt smoke against a
rebuilt 0.0.18 package with `--expect-git` asserting Depends/Section/the
migration trio · and the dpkg migration path above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KM15rxSnbZAR9muKxqbj8T