### PR TITLE
feat(distribution): one-line Scoop install and package-manager updates on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Line-ending policy — deliberately one line long.
+#
+# Only ONE file in the tree needs its endings pinned:
+# `src-tauri/windows/pgit-portable.cmd` ships inside
+# `PlatypusGit_x64_portable.zip`, is executed by cmd.exe, and a Rust test
+# asserts it is CRLF (`cli.rs::PORTABLE_SHIM_CMD` is an `include_str!` of those
+# exact bytes, and `shim_cmd_body` emits CRLF for the same reason). Without this
+# rule, a clone with `core.autocrlf=input` — the common setting on macOS and
+# Linux, and what this repo is developed on — stores and restores it as LF, and
+# that test fails on Linux CI while the file still looks right on Windows.
+#
+# Everything else is left to git's defaults ON PURPOSE. This repo had no
+# .gitattributes at all, so a blanket `* text=auto` would renormalise the whole
+# tree in one commit and bury the change that needed it.
+src-tauri/windows/pgit-portable.cmd text eol=crlf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,7 @@ jobs:
     runs-on: windows-latest
     outputs:
       msi_sig: ${{ steps.sig.outputs.msi_sig }}
+      portable_sha256: ${{ steps.portable.outputs.portable_sha256 }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -234,6 +235,68 @@ jobs:
           msi_dir="src-tauri/target/release/bundle/msi"
           cp "$(ls "$msi_dir"/*.msi | head -n1)" "$msi_dir/PlatypusGit_x64.msi"
 
+      # The PORTABLE payload, which is what the Scoop bucket installs (#187).
+      # Not the .msi: Scoop's msi handling is a deprecated path, and an msiexec
+      # install is per-machine and elevated — which defeats the three properties
+      # Scoop was picked for (per-user, no admin prompt, clean uninstall).
+      # Spec: docs/superpowers/specs/2026-08-27-scoop-bucket-spec.md §A.
+      #
+      # `pgit.cmd` travels INSIDE the zip and is load-bearing, not a courtesy:
+      # cli.rs::shim_status probes `exe_dir/pgit.cmd` before it scans PATH, and
+      # finding it is what makes a Scoop install classify as `Package` — which is
+      # what stops Settings offering to write a second, competing `pgit` that
+      # Scoop neither knows about nor removes. See src-tauri/windows/
+      # pgit-portable.cmd's own header.
+      - name: Build the portable zip
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $stage = 'portable'
+          New-Item -ItemType Directory -Force -Path $stage | Out-Null
+          Copy-Item 'src-tauri/target/release/platypusgit.exe' $stage
+          Copy-Item 'src-tauri/windows/pgit-portable.cmd' (Join-Path $stage 'pgit.cmd')
+          Copy-Item 'LICENSE' $stage
+          # -Path "<stage>/*" so the files land at the ZIP ROOT. Compressing the
+          # directory itself would give Scoop a wrapper folder: the package would
+          # install, find no platypusgit.exe where `bin` says it is, and shim
+          # nothing — an install that looks like it worked.
+          Compress-Archive -Path (Join-Path $stage '*') `
+                           -DestinationPath 'PlatypusGit_x64_portable.zip' -Force
+
+      # THE CHEAP GATE, run on the machine that made the asset. `scoop-verify-live`
+      # is the real one, but it cannot run until the manifest has been pushed —
+      # and a zip with the wrong shape must never get that far.
+      - name: Gate — the portable zip has the shape Scoop needs
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $out = 'portable-check'
+          Expand-Archive -Path 'PlatypusGit_x64_portable.zip' -DestinationPath $out -Force
+          foreach ($f in 'platypusgit.exe', 'pgit.cmd', 'LICENSE') {
+            if (-not (Test-Path -LiteralPath (Join-Path $out $f))) {
+              throw "portable zip has no $f at its root"
+            }
+          }
+          # Relative, and naming the exe: the first keeps it correct across the
+          # `current` junction Scoop re-points on every update, the second is what
+          # cli.rs::references_app matches on.
+          $cmd = Get-Content -Raw (Join-Path $out 'pgit.cmd')
+          if ($cmd -notmatch [regex]::Escape('%~dp0platypusgit.exe')) {
+            throw 'pgit.cmd does not launch platypusgit.exe relative to itself'
+          }
+          Write-Host 'portable zip OK'
+
+      - name: Compute portable zip sha256
+        id: portable
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          # Lowercased because that is how every Scoop manifest in the wild
+          # writes a hash; scoop-manifest.sh accepts either.
+          $sum = (Get-FileHash -Algorithm SHA256 'PlatypusGit_x64_portable.zip').Hash.ToLower()
+          Write-Host "sha256: $sum"
+          "portable_sha256=$sum" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
       # Attach BEFORE reading the signature. Under `set -euo pipefail` a glob
       # miss in the sig step aborts the job, and when that step ran first the
       # release ended up with no installer attached at all.
@@ -241,7 +304,9 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.version.outputs.tag }}
-          files: src-tauri/target/release/bundle/msi/PlatypusGit_x64.msi
+          files: |
+            src-tauri/target/release/bundle/msi/PlatypusGit_x64.msi
+            PlatypusGit_x64_portable.zip
           fail_on_unmatched_files: true
 
       - name: Read updater signature
@@ -460,6 +525,177 @@ jobs:
           git add Casks/platypusgit.rb
           git commit -m "chore: bump platypusgit to ${{ needs.version.outputs.version }}"
           git push
+
+  # Pin the Scoop bucket to this release: rewrite bucket/platypusgit.json in
+  # jonassaa/scoop-platypusgit and commit straight to its main (#187, Windows
+  # half). bump-cask's twin, deliberately — same gate, same App, same guard
+  # shape — so the two read as one pattern rather than two.
+  #
+  # Cheap because it needs NO new secret: the same GitHub App, scoped to one more
+  # repository. Contrast the apt half, which needed a DNS record, a Pages site
+  # and a signing key.
+  #
+  # The manifest is RENDERED by a script in this repo rather than patched in
+  # place, so the artifact users install from is reviewable here and cannot
+  # drift from a second copy nobody reads.
+  bump-scoop:
+    needs: [version, windows]
+    runs-on: ubuntu-latest
+    if: ${{ (github.event_name == 'release' && github.event.release.prerelease == false) || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version.outputs.tag }}
+
+      - name: Mint bucket token from GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.TAP_APP_ID }}
+          private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
+          owner: jonassaa
+          repositories: scoop-platypusgit
+
+      - name: Checkout the bucket
+        uses: actions/checkout@v4
+        with:
+          repository: jonassaa/scoop-platypusgit
+          token: ${{ steps.app-token.outputs.token }}
+          path: bucket-repo
+
+      - name: Render the manifest
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          SHA256: ${{ needs.windows.outputs.portable_sha256 }}
+        run: |
+          set -euo pipefail
+          # Same guard shape as bump-cask's sha256 check. An empty hash renders a
+          # manifest that fails EVERY install with "hash check failed" against a
+          # download that is actually fine — the worst kind of broken, because it
+          # looks like our download is corrupt.
+          if [ -z "$SHA256" ]; then
+            echo "Empty sha256 from the windows job — refusing to publish a manifest" >&2
+            exit 1
+          fi
+          mkdir -p bucket-repo/bucket
+          scripts/scoop-manifest.sh \
+            --version "$VERSION" \
+            --hash "$SHA256" \
+            --out bucket-repo/bucket/platypusgit.json
+          echo "--- rendered manifest ---"
+          cat bucket-repo/bucket/platypusgit.json
+
+      - name: Commit & push to the bucket
+        run: |
+          set -euo pipefail
+          cd bucket-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add bucket/platypusgit.json
+          if git diff --cached --quiet; then
+            echo "Manifest already up to date — nothing to commit"
+            exit 0
+          fi
+          git commit -m "chore: bump platypusgit to ${{ needs.version.outputs.version }}"
+          git push
+
+  # Confirm a real `scoop install` works from what we just pushed — the Windows
+  # counterpart of apt-verify-live, and the only place any of this is proven.
+  # Everything upstream of it was written and reviewed on a machine with no
+  # Windows in sight.
+  #
+  # No `platypusgit --version` here: the Windows binary is GUI-subsystem, so its
+  # stdout is not attached to the runner's console and the check would be a coin
+  # flip rather than a gate. What IS asserted is what the app and the shim
+  # contracts depend on.
+  scoop-verify-live:
+    needs: [version, bump-scoop]
+    runs-on: windows-latest
+    if: ${{ (github.event_name == 'release' && github.event.release.prerelease == false) || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Install Scoop
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          # -RunAsAdmin IS REQUIRED HERE, and only here. GitHub's windows runner
+          # user is in the Administrators group, and Scoop's installer refuses to
+          # run elevated by default ("Running the installer as administrator is
+          # disabled by default") — without the flag this step fails on every
+          # release. It is not advice to pass on to users, who are not elevated.
+          $env:SCOOP = "$env:USERPROFILE\scoop"
+          Invoke-Expression "& {$(Invoke-RestMethod -Uri https://get.scoop.sh)} -RunAsAdmin"
+          # Scoop puts its shims on the USER PATH in the registry; this process's
+          # environment was captured before that, and so is every later step's.
+          # $GITHUB_PATH and $GITHUB_ENV are the only things that carry either
+          # across steps — SCOOP is exported too rather than left to default, so
+          # a later step cannot silently resolve a different root than this one
+          # installed into.
+          "$env:SCOOP\shims" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          "SCOOP=$env:SCOOP" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          & "$env:SCOOP\shims\scoop.cmd" --version
+
+      - name: Install platypusgit from the bucket
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          # Exactly the two lines the download page tells people to run, so the
+          # gate tests the documented route rather than a CI-only variant.
+          #
+          # $LASTEXITCODE is checked explicitly after each: a native command's
+          # non-zero exit is NOT a terminating error in PowerShell, so
+          # $ErrorActionPreference alone would let a failed install fall through
+          # to the assertions below and report a confusing "no platypusgit.exe".
+          scoop bucket add platypusgit https://github.com/jonassaa/scoop-platypusgit
+          if ($LASTEXITCODE -ne 0) { throw "scoop bucket add failed ($LASTEXITCODE)" }
+          scoop install platypusgit
+          if ($LASTEXITCODE -ne 0) { throw "scoop install failed ($LASTEXITCODE)" }
+
+      - name: Gate — the install has everything the app and the shims rely on
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          # Asked of Scoop rather than assumed: `scoop prefix` prints this app's
+          # `current` directory, so nothing here depends on where the root is.
+          $app = (scoop prefix platypusgit | Out-String).Trim()
+          Write-Host "app dir: $app"
+          if (-not $app) { throw 'scoop prefix returned nothing' }
+
+          # The zip's payload, at the root of the version directory.
+          foreach ($f in 'platypusgit.exe', 'pgit.cmd') {
+            if (-not (Test-Path -LiteralPath (Join-Path $app $f))) {
+              throw "installed app directory has no $f"
+            }
+          }
+
+          # THE update.rs CONTRACT. `update::SCOOP_MANIFEST_FILE` is how the app
+          # knows Scoop owns this install and must NOT self-update; if Scoop ever
+          # stops writing it, this fails the release instead of quietly handing
+          # every Scoop user the .msi self-updater and two installs.
+          if (-not (Test-Path -LiteralPath (Join-Path $app 'manifest.json'))) {
+            throw 'no manifest.json beside the exe — update::capability cannot detect this install'
+          }
+
+          # The other half of that probe: update::is_scoop_layout requires the exe
+          # to sit under apps/<CARGO_PKG_NAME>/<version>.
+          if ($app -notmatch [regex]::Escape('\apps\platypusgit\')) {
+            throw "install path is not apps/platypusgit/<version>: $app"
+          }
+
+          # The CLI, which is half of what #187 asked for on Windows.
+          $which = (scoop which pgit | Out-String).Trim()
+          Write-Host "scoop which pgit -> $which"
+          if ($which -notmatch 'pgit') { throw 'scoop did not shim pgit' }
+
+          # And that Scoop installed the version we just published, not a stale
+          # manifest it happened to have cached.
+          $list = (scoop list platypusgit | Out-String)
+          Write-Host $list
+          if ($list -notmatch [regex]::Escape($env:VERSION)) {
+            throw "scoop reports a different version than $env:VERSION"
+          }
+          Write-Host 'scoop install verified'
 
   # Publish the updater manifest so tauri-plugin-updater can verify + install.
   # Points at the stable-named release assets. macOS is intentionally omitted

--- a/README.md
+++ b/README.md
@@ -35,7 +35,22 @@ quarantine flag on install, so it launches with no "unidentified developer"
 prompt. No Homebrew? Take the `.dmg` below — a drag-install needs the quarantine
 flag cleared by hand, and is told about new versions rather than fetching them.
 
-**Windows** — [`PlatypusGit_x64.msi`](https://github.com/jonassaa/platypusgit/releases/latest/download/PlatypusGit_x64.msi). Installs `pgit` and puts it on your PATH. Not code-signed, so SmartScreen will warn on first run. The first install is a manual download ([#187](https://github.com/jonassaa/platypusgit/issues/187)); after that the app updates itself in place.
+**Windows** — [`PlatypusGit_x64.msi`](https://github.com/jonassaa/platypusgit/releases/latest/download/PlatypusGit_x64.msi). Installs `pgit` and puts it on your PATH. Not code-signed, so SmartScreen will warn on first run; after that the app updates itself in place.
+
+Or with [Scoop](https://scoop.sh) — per-user, no admin prompt, and `scoop` owns
+updates from then on.
+
+```powershell
+scoop bucket add platypusgit https://github.com/jonassaa/scoop-platypusgit
+scoop install platypusgit    # install
+scoop update platypusgit     # update
+```
+
+Scoop installs a portable build and shims `pgit` itself, so the in-app updater
+stands down — the two can never disagree about which copy you are running.
+There is still no `winget` package
+([#187](https://github.com/jonassaa/platypusgit/issues/187)): it needs a
+code-signing certificate more than it needs code.
 
 **Linux (Debian · Ubuntu)** — one line to install, and `apt` owns updates from
 then on.
@@ -168,14 +183,14 @@ another instance — it forwards the request to the running window, focuses it,
 and navigates there.
 
 **Most installs already have it.** The Homebrew cask, the `.deb` (via apt or by
-hand) and the `.msi` install `pgit` alongside the app and remove it on
-uninstall. Only the macOS `.dmg` and the Linux AppImage run no install code, so
-those two need
+hand), the `.msi` and Scoop all install `pgit` alongside the app and remove it
+on uninstall. Only the macOS `.dmg` and the Linux AppImage run no install code,
+so those two need
 **Settings → Command line → Install** in the app, or:
 
 ```bash
 curl -fsSL https://www.platypusgit.com/install-pgit.sh | sh    # macOS .dmg / Linux AppImage
-irm https://www.platypusgit.com/install-pgit.ps1 | iex         # Windows, outside the .msi
+irm https://www.platypusgit.com/install-pgit.ps1 | iex         # Windows, outside .msi/Scoop
 ```
 
 Both scripts are meant to be read before they are run — they are a build-time
@@ -189,9 +204,9 @@ edges. Most core git operations work end to end (the feature list above is what
 is implemented, not a roadmap). Known gaps, stated plainly:
 
 - macOS builds are ad-hoc signed and not notarized; the Windows `.msi` is not code-signed.
-- No `winget` or `scoop` yet — both wait on that code signing — so the first Windows install is a manual download ([#187](https://github.com/jonassaa/platypusgit/issues/187)). The app self-updates from then on, as does the Linux AppImage.
+- No `winget` package yet — that one really does wait on the code signing above, which is what separates it from Scoop ([#187](https://github.com/jonassaa/platypusgit/issues/187)). Windows installs from the `.msi` or in one line from Scoop; the `.msi` self-updates from then on, Scoop owns updates on its own installs, and so does the Linux AppImage.
 - No in-app update on macOS: Homebrew owns upgrades there, and a `.dmg` drag-install is told a new version exists rather than fetching it.
-- The APT repository is amd64 only ([#266](https://github.com/jonassaa/platypusgit/issues/266)), and there is no `.rpm` or AUR package, so every other Linux takes the AppImage.
+- The APT repository is amd64 only ([#266](https://github.com/jonassaa/platypusgit/issues/266)), and there is no `.rpm` or AUR package, so every other Linux takes the AppImage. Scoop is x64 only for the same reason.
 - Changed images are reported as binary rather than previewed side by side ([#224](https://github.com/jonassaa/platypusgit/issues/224)).
 - Standalone GUI only: no icon overlays or context menus inside Finder and Explorer themselves, which is a different thing from the app's own reveal-in-file-manager action. Mercurial is out of scope too.
 

--- a/docs/dev/distribution.md
+++ b/docs/dev/distribution.md
@@ -323,3 +323,72 @@ fail, corrupt a byte of `InRelease` and re-run — expect `BADSIG` and exit 100.
 never piped into a shell. `--dry-run` prints the walk and changes nothing. It is
 run **by the user**: it creates a public repository, edits DNS, and installs a
 GitHub App.
+
+## The Scoop bucket — one-line Windows install (#187)
+
+Spec: `docs/superpowers/specs/2026-08-27-scoop-bucket-spec.md`. The apt
+section's Windows twin, and much smaller: **no new secret, no host, no signing
+key, no DNS.** One repository plus the App the Homebrew tap already uses.
+
+- **Where it lives.** `jonassaa/scoop-platypusgit`, holding only
+  `bucket/platypusgit.json` and a README. `scoop bucket add` clones a git repo,
+  so unlike apt there is nothing to serve.
+- **Scoop installs a portable `.zip`, never the `.msi`.** Scoop's msi handling
+  is a deprecated path, and an `msiexec` install is per-machine and elevated —
+  which destroys the three properties Scoop was chosen for (per-user, no admin
+  prompt, clean uninstall). `release.yml`'s `windows` job therefore builds
+  `PlatypusGit_x64_portable.zip` (`platypusgit.exe` + `pgit.cmd` + `LICENSE`, at
+  the zip **root**) and exports its `sha256`.
+- **`scripts/scoop-manifest.sh` renders the manifest**, the way
+  `apt-repo-publish.sh` builds the index: the artifact users install from is
+  reviewable here and runs on a laptop. `bump-scoop` calls it; nothing patches
+  a committed manifest in place.
+- **The manifest URL is the release *tag* URL**, not
+  `releases/latest/download/…` like every other channel. A Scoop `hash` pins one
+  specific build, and the stable path moves on the next release — pointing there
+  would hash-mismatch every install between a release and its bump.
+
+### Three traps, and why each is load-bearing
+
+1. **`pgit.cmd` ships inside the zip and is named in `bin`.** Not a convenience:
+   `cli.rs::shim_status` probes `exe_dir/pgit.cmd` before it scans PATH, and
+   finding it is what classifies a Scoop install as `CliShimSource::Package`.
+   Without it the user gets no `pgit` **and** Settings offers to write a
+   competing shim into `%LOCALAPPDATA%` that Scoop neither knows about nor
+   removes. Its body is **relative** (`%~dp0platypusgit.exe`) where
+   `shim_cmd_body`'s is absolute, because Scoop re-points the `current` junction
+   on every update. `cli.rs::PORTABLE_SHIM_CMD` includes the shipped bytes and a
+   test pins the classification.
+2. **A Scoop install must NOT self-update.** `update::capability` returned
+   `SelfUpdate` for Windows unconditionally; self-updating here runs the
+   per-machine `.msi`, so the box ends up with the new copy in Program Files
+   **and** Scoop's old one still on PATH and still behind the Start Menu
+   shortcut, with `scoop list` wrong forever. Hence `NotifyScoop`, detected by
+   `update::is_scoop_layout` (the exe sits in `apps/<CARGO_PKG_NAME>/<version>`)
+   **plus** one `Path::exists` for Scoop's own `manifest.json` beside it. Never
+   `$env:SCOOP`: it is relocatable, wrong for `SCOOP_GLOBAL`, and set for anyone
+   who uses Scoop *at all* — so an `.msi` install on a Scoop user's machine would
+   be told to `scoop update` a package Scoop does not have.
+3. **`scoop-verify-live` needs `-RunAsAdmin`.** GitHub's `windows-latest` user is
+   in the Administrators group and Scoop's installer refuses to run elevated by
+   default, so without the flag the gate fails on every release. It is a CI-only
+   flag — never advice to pass on to users, who are not elevated. Scoop's PATH
+   edit also has to be re-exported through `$GITHUB_PATH` to reach later steps.
+
+### Verification, honestly
+
+`cargo test`/`pnpm test` cover the pure parts (`is_scoop_layout`, the shim
+classification, the panel's hint). The manifest and the install itself are
+proven only by CI, in two places: the `windows` job expands the zip it just
+built and asserts its shape, and **`scoop-verify-live` does a real
+`scoop install` on a clean Windows runner** — asserting the payload,
+`manifest.json` (the `update.rs` contract), the `pgit` shim, and the version.
+That job is the first thing that has ever run this on Windows.
+
+### The manual setup
+
+`scripts/scoop-bucket-wizard.sh` walks the four steps outside this repo (create,
+seed, App install, verify the first publish). Interactive, `--dry-run`-able, run
+**by the user** — it creates a public repository. The bucket is seeded **empty of
+manifests** on purpose: the first `bump-scoop` writes one, and a hand-seeded
+manifest would carry a hash for an asset that did not exist yet.

--- a/docs/superpowers/plans/2026-08-27-scoop-bucket-plan.md
+++ b/docs/superpowers/plans/2026-08-27-scoop-bucket-plan.md
@@ -33,7 +33,7 @@ New:
 - `scripts/scoop-manifest.sh` — renders `bucket/platypusgit.json`.
 - `scripts/scoop-bucket-wizard.sh` — the one-time human-only steps.
 - `scripts/scoop-bucket-seed/README.md` — the bucket repo's landing text.
-- `scripts/scoop-bucket-seed/bucket/.gitkeep` — so the seed pushes the
+- `scripts/scoop-bucket-seed/bucket/.gitkeep` — so the seed creates the
   directory the first `bump-scoop` writes into.
 - `src-tauri/windows/pgit-portable.cmd` — the relative-path `pgit.cmd` that
   ships inside the zip.
@@ -126,8 +126,10 @@ its own commit; the branch is squashed before merge.
 1. `scripts/scoop-bucket-seed/` — README naming the bucket, the package, and
    the fact that CI owns `bucket/platypusgit.json`; `bucket/.gitkeep`.
 2. `scripts/scoop-bucket-wizard.sh` — idempotent, `--dry-run`, interactive:
-   create the repo, push the seed, install the App on it, verify the App can
-   push, and (last) verify the first `bump-scoop` populated the manifest.
+   create the repo, seed it **through `gh api`** (never a `git push` — the repo
+   has no local clone, so a git remote would fall through to the user's own
+   credential setup), install the App on it, and verify the first `bump-scoop`
+   populated the manifest.
 
 ### Phase 6 — the site and the README
 

--- a/docs/superpowers/plans/2026-08-27-scoop-bucket-plan.md
+++ b/docs/superpowers/plans/2026-08-27-scoop-bucket-plan.md
@@ -1,0 +1,157 @@
+# Scoop bucket + one-line Windows install — implementation plan
+
+Spec: `docs/superpowers/specs/2026-08-27-scoop-bucket-spec.md`
+Issue: [#187](https://github.com/jonassaa/platypusgit/issues/187), Windows half.
+
+## Global Constraints
+
+- **No new secret and no new host.** The bucket push reuses
+  `vars.TAP_APP_ID` / `secrets.TAP_APP_PRIVATE_KEY`, scoped to one more
+  repository. `test/privacy.test.ts`'s `ALLOWED_HOSTS` must not need a new
+  entry: the Scoop upgrade hint is `scoop update platypusgit`, with no URL in
+  it. If a URL ever creeps into `packageHint`, the guard is right and the
+  change is wrong.
+- **`prerelease == false` or `workflow_dispatch`**, same `if:` expression as
+  `bump-cask` and `apt-publish`, character for character. A prerelease must
+  attach assets and touch no channel.
+- **Fail loudly on an empty input.** `bump-scoop` refuses an empty `sha256`
+  exactly as `bump-cask` does; a manifest with an empty `hash` fails every
+  install and must never be pushed.
+- **The Rust IPC rules are unchanged.** No new command, no new `AppError`
+  variant. `UpdateCapability` gains one variant and `src/lib/types.ts` gains
+  the matching union member **in the same commit** (the 1:1 rule).
+- **The detection probe stays one `Path::exists`.** No process spawn, so
+  nothing new goes through `proc.rs` and `get_update_capability` stays
+  synchronous.
+- **Nothing here may make `pgit` fight itself.** A Scoop install must classify
+  as `CliShimSource::Package`, so Settings offers no install (spec §C).
+
+## File Structure
+
+New:
+
+- `scripts/scoop-manifest.sh` — renders `bucket/platypusgit.json`.
+- `scripts/scoop-bucket-wizard.sh` — the one-time human-only steps.
+- `scripts/scoop-bucket-seed/README.md` — the bucket repo's landing text.
+- `scripts/scoop-bucket-seed/bucket/.gitkeep` — so the seed pushes the
+  directory the first `bump-scoop` writes into.
+- `src-tauri/windows/pgit-portable.cmd` — the relative-path `pgit.cmd` that
+  ships inside the zip.
+- `docs/superpowers/specs/2026-08-27-scoop-bucket-spec.md` (this change's spec).
+
+Changed:
+
+- `.github/workflows/release.yml` — `windows` builds + smokes + attaches the
+  zip and outputs its `sha256`; new `bump-scoop` and `scoop-verify-live` jobs.
+- `src-tauri/src/update.rs` — `InstallEnv`, `NotifyScoop`, `is_scoop_layout`,
+  `SCOOP_MANIFEST_FILE`.
+- `src-tauri/src/commands/update.rs` — the Windows probe.
+- `src-tauri/tests/update.rs` — rewrite the `capability` calls onto
+  `InstallEnv`; layout tests.
+- `src-tauri/src/cli.rs` — `PORTABLE_SHIM_CMD` (`include_str!` of the shipped
+  bytes) and, in its inline `mod tests`, that both Scoop shim shapes classify as
+  `Package`.
+- `src/lib/types.ts` — `"notify-scoop"`.
+- `src/features/update/packageHint.ts` (+ tests) — the Scoop arm.
+- `src/features/update/UpdatePanel.test.tsx` — the panel renders it.
+- `site/src/data/site.ts` — `scoop`, `assets.windowsPortableZip`.
+- `site/src/pages/download.astro` — the Windows card, `pgitMatrix`.
+- `README.md` — the Windows install lines and the stale Status bullet.
+- `docs/dev/distribution.md` — the Scoop section.
+
+## Phases
+
+Each phase ends green (`cargo test`, `pnpm test`, `pnpm tsc --noEmit`) and is
+its own commit; the branch is squashed before merge.
+
+### Phase 1 — the manifest generator
+
+1. `scripts/scoop-manifest.sh`: POSIX `sh`, `set -eu`, `jq -n`. Flags
+   `--version`, `--hash`, `--url` (defaulted from the version), `--out`.
+   Rejects an empty version or hash, and a hash that is not 64 hex characters —
+   the one error a reviewer cannot see and Scoop reports as a corrupt download.
+2. Run it locally, read the JSON, and check it against Scoop's documented
+   manifest keys by eye. This is the only verification available off Windows.
+
+### Phase 2 — the portable asset
+
+1. `src-tauri/windows/pgit-portable.cmd` — `@"%~dp0platypusgit.exe" %*`, CRLF,
+   with a header comment saying why it is relative where
+   `cli.rs::shim_cmd_body` is absolute.
+2. `release.yml`'s `windows` job: after the stable-name `cp`, stage
+   `platypusgit.exe`, that `.cmd` and `LICENSE` into a directory and
+   `Compress-Archive` it to `PlatypusGit_x64_portable.zip`.
+3. **Smoke it on the runner**: expand the zip to a temp directory, assert the
+   three entries exist and that the `.cmd` names the exe. Fail the job if not.
+4. `sha256` via `Get-FileHash` → job output `portable_sha256`. Attach the zip
+   in the existing "Attach installer" step, still before the signature read.
+
+### Phase 3 — capability, and what the panel says
+
+1. `update.rs`: `InstallEnv { os, is_appimage, apt_managed, scoop_managed }` +
+   `InstallEnv::new(os)`; `capability(InstallEnv) -> UpdateCapability`;
+   `UpdateCapability::NotifyScoop`; `is_scoop_layout(&Path)`;
+   `SCOOP_MANIFEST_FILE` as the documented contract constant.
+   Windows order: AppImage cannot occur, so `scoop_managed` is the only thing
+   that can turn Windows off `SelfUpdate`.
+2. `commands/update.rs`: `os == "windows" && is_scoop_layout(exe) &&
+   exe_dir.join(SCOOP_MANIFEST_FILE).exists()`, skipped entirely off Windows.
+3. `tests/update.rs`: rewrite existing calls; add — Windows + Scoop is
+   `NotifyScoop`; Windows without it stays `SelfUpdate`; a stray
+   `scoop_managed` off Windows changes nothing; `is_scoop_layout` accepts
+   `…/apps/platypusgit/1.2.3/` and `…/apps/platypusgit/current/`, rejects
+   `…/apps/other/…`, a Program Files path, and a bare filename.
+4. `src/lib/types.ts`: `"self-update" | "notify" | "notify-apt" | "notify-scoop"`.
+5. `packageHint.ts`: a `notify-scoop` arm returning `scoop update platypusgit`,
+   handled with `notify-apt` before the platform switch (the backend already
+   decided; the platform cannot contradict it). Amend the module doc — "Windows
+   is never `notify`" stops being true in spirit — and keep
+   `packageHint("notify", "windows") === null`.
+6. Tests: `packageHint.test.ts` for the new arm and for the unchanged bare
+   `notify` on Windows; `UpdatePanel.test.tsx` renders the hint and no install
+   button under `notify-scoop`.
+
+### Phase 4 — `bump-scoop` and `scoop-verify-live`
+
+1. `bump-scoop`: `needs: [version, windows]`, the shared `if:`, App token for
+   `scoop-platypusgit`, checkout, empty-hash guard, `scripts/scoop-manifest.sh`
+   into `bucket/platypusgit.json`, commit + push with the bump-cask
+   "already up to date" early exit.
+2. `scoop-verify-live`: `needs: [version, bump-scoop]`, `windows-latest`,
+   install Scoop non-interactively, add the bucket **from the pushed repo**,
+   install, then assert the four things in spec §E. No `--version` invocation.
+
+### Phase 5 — the bucket, and the human-only steps
+
+1. `scripts/scoop-bucket-seed/` — README naming the bucket, the package, and
+   the fact that CI owns `bucket/platypusgit.json`; `bucket/.gitkeep`.
+2. `scripts/scoop-bucket-wizard.sh` — idempotent, `--dry-run`, interactive:
+   create the repo, push the seed, install the App on it, verify the App can
+   push, and (last) verify the first `bump-scoop` populated the manifest.
+
+### Phase 6 — the site and the README
+
+1. `site/src/data/site.ts`: `scoop` block + `assets.windowsPortableZip`.
+2. `download.astro`: Windows card leads with `scoop bucket add` +
+   `scoop install`, keeps the `.msi` button, fixes the winget/Chocolatey note,
+   adds the `pgitMatrix` row, updates the Windows `specs`.
+3. `README.md`: the Windows install block gains the Scoop lines; the Status
+   bullet stops claiming there is no scoop/apt repository.
+4. `docs/dev/distribution.md`: the Scoop section — what Scoop installs and why
+   not the `.msi`, the `pgit.cmd`-in-`bin` contract, the layout probe, and the
+   two gates.
+
+## Risks
+
+- **The manifest is unverifiable off Windows.** Mitigated by keeping it to
+  conventional keys, by `scoop-verify-live`, and by seeding the bucket empty so
+  a wrong manifest never becomes the only manifest.
+- **`Compress-Archive` path shape.** It is easy to zip a wrapper directory
+  instead of the files; Scoop would then find no `platypusgit.exe` at the root.
+  The Phase 2 smoke expands the zip and asserts the entries, on the runner.
+- **The Scoop shim classification is a substring match.** `references_app`
+  matches `MAIN_BINARY` inside the shim text, which works because the app
+  directory is named after the package. Pinned by a test with a real shim body,
+  and by requiring the same name in `is_scoop_layout`.
+- **The page promises a bucket that does not exist yet** until the wizard runs.
+  Same accepted window as #267; called out in the PR body, not left implicit.

--- a/docs/superpowers/specs/2026-08-27-scoop-bucket-spec.md
+++ b/docs/superpowers/specs/2026-08-27-scoop-bucket-spec.md
@@ -1,0 +1,359 @@
+# A Scoop bucket: one-line install and package-manager updates on Windows
+
+Issue: [#187](https://github.com/jonassaa/platypusgit/issues/187) — the Windows
+half. The Linux half shipped in #267 (spec:
+`2026-08-26-apt-repository-spec.md`); this is deliberately the same shape on the
+other platform, and reuses its machinery wherever the two are actually the same
+problem.
+
+## Problem
+
+Windows is the last platform where installing and updating are both manual.
+
+- **Install** is a `.msi` button on `site/src/pages/download.astro`. No
+  `winget`, no `scoop`, no `choco` — the download page says so in as many
+  words.
+- **Update** is `update::capability` → `SelfUpdate`, so the in-app updater
+  fetches `PlatypusGit_x64.msi` and runs it. That works, and it is the one
+  platform where it does — but it is also the *only* route, so a Windows user
+  who wants their machine's packages managed in one place cannot have that.
+
+macOS has had both halves via Homebrew since the cask landed; Linux got both in
+#267. #187 ranks the remaining pieces "by value per effort" and puts **Scoop
+first**: per-user, no admin prompt, no third-party moderation queue, and it is
+where the dev-first audience already is. `winget` is second and is *gated on a
+decision this spec does not make* — see Scope.
+
+## Scope
+
+**In:** a Scoop bucket (`jonassaa/scoop-platypusgit`), the portable release
+asset it installs, the release job that bumps its manifest, the in-app update
+advice for a Scoop install, the `pgit` command on that install, and the
+download-page + README copy.
+
+**Out, on purpose:**
+
+- **winget.** #187 gates it on bundle code signing, which is on CLAUDE.md's
+  "deliberately NOT in codebase" list. An unsigned installer means SmartScreen
+  warnings and friction through winget validation, and the fix is a certificate
+  purchase, not code. Nothing here blocks it later: winget consumes the same
+  stable-named `.msi` and the same `sha256` this pipeline already computes.
+- **Chocolatey.** #187 says skip unless asked. Unchanged.
+- **arm64.** Only `x64` is built (arm64 Linux is split out as #266). The
+  manifest is written in Scoop's `architecture` form anyway so a second
+  architecture is an added key, not a rewrite — the lesson #187 recorded for
+  the apt pool applies verbatim here.
+
+## Design
+
+### A. Scoop installs a portable `.zip`, not the `.msi`
+
+**The `.msi` cannot be the thing Scoop installs**, for two independent reasons:
+
+1. Scoop's MSI extraction is a deprecated path (`lessmsi`, or an `msiexec /a`
+   administrative install that mangles the layout). Relying on it makes our
+   install correctness a function of the user's `scoop config`.
+2. Even where it works, an MSI install is per-machine and elevated. That
+   defeats the three properties #187 chose Scoop *for*: per-user, no admin
+   prompt, and a clean `scoop uninstall`. A manifest whose installer writes to
+   `C:\Program Files` and the machine PATH leaves Scoop unable to remove what
+   it installed.
+
+So the `windows` release job gains a second, portable asset:
+
+```
+PlatypusGit_x64_portable.zip
+├── platypusgit.exe    the same binary the .msi wraps
+├── pgit.cmd           the CLI entry point (see §C)
+└── LICENSE            GPL-3.0; we redistribute a binary, so it travels with it
+```
+
+Stable-named like every other asset, `sha256` exported as a job output for the
+manifest bump, and attached to the release before the signature step is read —
+the ordering trap the `windows` job already documents.
+
+**No new updater artifact.** The zip is not a Tauri bundle, gets no `.sig`, and
+gets no key in `latest.json`. That is not an omission: §B switches self-update
+*off* for the installs that come from it, so there is nothing for the updater
+to fetch. Adding a `windows-x86_64-zip` key would create a payload no client
+can legitimately ask for.
+
+**Runtime dependencies are unchanged from the `.msi`.** Both need the WebView2
+runtime (present on Windows 11, and on Windows 10 via Edge) and the MSVC
+runtime; neither bundles them. The zip is not a *worse* install in this
+respect, but it is a *quieter* one — the `.msi`'s WiX webview install mode can
+bootstrap WebView2, and a zip cannot — so the manifest's `notes` say so, which
+is where Scoop prints text after an install.
+
+### B. `update::capability` gains `NotifyScoop`
+
+`capability` returns `SelfUpdate` for `"windows"` unconditionally today. Left
+alone, a Scoop install would:
+
+1. discover a new version,
+2. download `PlatypusGit_x64.msi`,
+3. install it **per-machine into `C:\Program Files`**,
+
+…leaving the machine with two copies: the new MSI one, and Scoop's own under
+`<root>\apps\platypusgit\current`, still on PATH via Scoop's shims and still
+what the Start Menu shortcut points at. `scoop list` would report the old
+version forever, and `scoop update platypusgit` would then "upgrade" the copy
+the user is not running. Silent, and unrecoverable without understanding both
+systems.
+
+This is the same failure the apt work found on Linux, so it gets the same
+answer: a fourth capability variant, and advice naming the package manager that
+actually owns this install.
+
+| capability | when | what the panel says |
+| --- | --- | --- |
+| `self-update` | Windows `.msi`, Linux AppImage | in-app install |
+| `notify-apt` | apt-managed `.deb` | `sudo apt update && sudo apt upgrade platypusgit` |
+| `notify-scoop` | Scoop install | `scoop update platypusgit` |
+| `notify` | everything else | per-platform hint, or nothing |
+
+**Detection: Scoop's own layout, not `$env:SCOOP`.** Scoop lays every install
+out as `<root>\apps\<name>\<version>\…`, with the live version junctioned at
+`<root>\apps\<name>\current`, and writes `manifest.json` + `install.json` into
+the version directory. The root is relocatable (`$env:SCOOP`) and a global
+install uses a different one (`$env:SCOOP_GLOBAL`), so reading an environment
+variable is both fragile and wrong for the global case. Walking up from
+`current_exe()` is neither:
+
+```rust
+// update.rs — pure, so it is testable from macOS and Linux too
+pub fn is_scoop_layout(exe: &Path) -> bool   // .../apps/<CARGO_PKG_NAME>/<version>/exe
+```
+
+The app-directory name must equal `env!("CARGO_PKG_NAME")`, which is what makes
+this a *contract with the bucket*: the manifest is `platypusgit.json`, so Scoop
+names the directory `platypusgit`. `CARGO_PKG_NAME` is read rather than written
+out for the same reason `cli.rs::MAIN_BINARY` is.
+
+The command layer adds one `Path::exists` for Scoop's `manifest.json` beside
+the exe — deliberately the same shape as the apt probe: no process spawn,
+nothing to route through `proc.rs`, nothing to mock, and skipped entirely off
+Windows rather than trusting a path not to exist there. `scoop-verify-live`
+(§E) asserts that file is present after a real install, so the contract fails
+the release gate rather than shipping quietly.
+
+**`capability` takes a struct now.** A fourth positional `bool` next to three
+others (`capability("linux", false, true, false)`) is a foot-gun with no
+compiler help. `InstallEnv { os, is_appimage, apt_managed, scoop_managed }`
+plus `InstallEnv::new(os)` makes every call site name what it is asserting:
+
+```rust
+capability(InstallEnv { scoop_managed: true, ..InstallEnv::new("windows") })
+```
+
+### C. `pgit` on a Scoop install, without a second shim
+
+#187 says "Scoop shims the executable itself" and leaves it there. That is half
+the story, and the missing half breaks an existing invariant.
+
+`cli.rs::shim_status` answers *"is a `pgit` present and does it launch this
+app"*, scanning for a file literally named `SHIM_NAME` — `pgit.cmd` on Windows
+— and classifying what it finds as `App`, `Package` or `Foreign`. `install_shim`
+refuses to write a second copy when a package already ships one (spec
+`2026-08-17-pgit-cli-packaging-spec.md` §A: three parties may own `pgit` and
+they must not fight).
+
+A manifest whose `bin` lists only `platypusgit.exe` would therefore:
+
+- give the user **no `pgit` at all**, the one thing #187's title asks for on
+  Windows, and
+- make Settings → Command line offer an install, writing a **competing**
+  `pgit.cmd` into `%LOCALAPPDATA%\PlatypusGit\bin` and appending that to the
+  user's PATH — a shim Scoop does not know about and will not remove on
+  uninstall.
+
+So the zip ships `pgit.cmd` and the manifest names it:
+
+```json
+"bin": ["platypusgit.exe", "pgit.cmd"]
+```
+
+Scoop shims a `.cmd` target with a generated `.cmd` of its own in
+`<root>\shims`, which is the directory Scoop puts on PATH — so that entry is
+what gives the user `pgit`.
+
+**What makes the app itself classify it correctly is simpler, and does not
+depend on Scoop's shim internals at all.** `shim_status` probes
+`package_shim_paths_for`, whose first entry is `exe_dir/pgit.cmd` — and on a
+Scoop install that is the zip's own `pgit.cmd`, sitting beside the exe. It is
+read as text, `references_app` matches `MAIN_BINARY` in
+`"%~dp0platypusgit.exe" %*`, and its directory is not one of ours, so:
+`Package`. Settings offers no install, writes nothing, and `scoop uninstall`
+removes every trace. Scoop's generated shim would classify the same way if the
+PATH scan reached it, but it never has to.
+
+One consequence worth stating so it is not read as a bug later: that sighting's
+`path_state` is `OffPath`, because `…\apps\platypusgit\current` is genuinely
+not on PATH — Scoop's `shims` directory is. It is not rendered: `Settings.tsx`
+passes `null` to `PathNote` whenever the shim is package-owned, precisely
+because where a package put its file is not the user's problem. No code change
+is needed for this, and none should be made to "fix" the value.
+
+The classification is load-bearing, so it is pinned with a unit test carrying
+the zip's real `pgit.cmd` body and a Scoop-shaped path.
+
+**The zip's `pgit.cmd` is relative, unlike every other one we ship.**
+`cli.rs::shim_cmd_body` writes an absolute path to the exe, which is right for
+a shim the app writes at a known install path. A file inside a zip knows
+neither, and Scoop's `current` junction means an absolute path would be wrong
+after the next `scoop update` anyway. The zip's copy is therefore
+`@"%~dp0platypusgit.exe" %*` — resolved against the `.cmd`'s own directory.
+`shim_installed_at` compares bodies byte-for-byte, but only for shims the *app*
+wrote, so the two forms do not collide.
+
+### D. The manifest, and who writes it
+
+`scripts/scoop-manifest.sh` renders the whole manifest from `--version`,
+`--url` and `--hash`. One generator, in this repository, for the same reason
+`apt-repo-publish.sh` is: the artifact users consume is reviewable here, runs
+locally, and cannot drift from a second copy in the bucket repo.
+
+```json
+{
+  "version": "0.1.0",
+  "homepage": "https://www.platypusgit.com",
+  "license": "GPL-3.0-only",
+  "architecture": { "64bit": { "url": "…/releases/download/v0.1.0/PlatypusGit_x64_portable.zip", "hash": "…" } },
+  "bin": ["platypusgit.exe", "pgit.cmd"],
+  "shortcuts": [["platypusgit.exe", "platypusgit"]],
+  "checkver": { "github": "https://github.com/jonassaa/platypusgit" },
+  "autoupdate": { "architecture": { "64bit": { "url": "…/releases/download/v$version/PlatypusGit_x64_portable.zip" } } }
+}
+```
+
+Four decisions inside it:
+
+- **The URL is the tag URL, not `releases/latest/download`.** Every other
+  channel deliberately uses the stable-named latest path so the Homebrew cask
+  can track it. A Scoop manifest pins a `hash` to a specific build, and
+  `releases/latest/download/…` *moves* on the next release — the manifest would
+  then hash-mismatch every install between a release and the next bump. Tag URL
+  and hash move together, in one commit.
+- **`architecture.64bit`, not top-level `url`/`hash`** — see Scope: arm64
+  becomes a key, not a rewrite.
+- **`shortcuts`** because this is a GUI app; without it a Scoop install has no
+  Start Menu entry and the only launch route is a terminal.
+- **`checkver`/`autoupdate` stay even though CI pushes the bump.** They cost
+  nothing, they are what a bucket is conventionally expected to carry, and they
+  are the fallback if a release ever lands without `bump-scoop` running (the
+  prerelease-promotion gap the release workflow's runbook comment describes is
+  exactly that case).
+
+### E. `bump-scoop`, and a real install as the gate
+
+`bump-scoop` mirrors `bump-cask` step for step — same `if:` prerelease gate,
+the same GitHub App (`vars.TAP_APP_ID` / `secrets.TAP_APP_PRIVATE_KEY`) scoped
+to one more repository, the same fail-loudly-on-an-empty-hash guard, the same
+`github-actions[bot]` attribution. **No new secret**, which is most of why
+Scoop is the cheap piece.
+
+`scoop-verify-live` then does on Windows what `apt-verify-live` does on Linux:
+after the push, a clean `windows-latest` runner installs Scoop, adds the
+bucket, installs the package, and asserts
+
+- the app directory holds `platypusgit.exe` and `pgit.cmd`,
+- `manifest.json` is beside them — the §B detection contract,
+- `scoop which pgit` resolves into the shims directory,
+- `scoop list` reports the version just published.
+
+It deliberately does **not** run `platypusgit --version`: the Windows binary is
+GUI-subsystem, so its stdout is not attached to the runner's console and the
+check would be a coin flip rather than a gate.
+
+A second, cheaper gate lives in the `windows` build job itself: extract the zip
+just built and assert the three files are there and that `pgit.cmd` names the
+exe. It catches a broken asset before it is ever attached, on the machine that
+made it.
+
+### F. State outside this repository
+
+Exactly one new external thing: the bucket repo, `jonassaa/scoop-platypusgit`,
+with the existing GitHub App installed on it. No DNS record, no Pages site, no
+signing key, no second secret — the apt repo needed all four, and that
+asymmetry is the whole "cheapest remaining win" argument.
+
+`scripts/scoop-bucket-wizard.sh` walks it (create, seed, install the App,
+verify a push, verify the first publish), idempotent and `--dry-run`-able, the
+same shape as `apt-repo-wizard.sh`. Until it has been run, the download page's
+`scoop bucket add` line names a repository that 404s — the same window #267
+accepted for `apt.platypusgit.com`, and the reason the wizard exists.
+
+**The bucket starts empty of manifests.** The seed is a README and a `bucket/`
+directory; the first `bump-scoop` writes `bucket/platypusgit.json`. Seeding a
+hand-made manifest would mean publishing a `hash` for an asset that does not
+exist yet — the portable zip first appears in the next release — and a bucket
+whose only manifest fails to install is worse than a bucket with none.
+
+### G. The page and the README
+
+- `site/src/data/site.ts` gains `scoop` (bucket URL, bucket name, package name)
+  and `assets.windowsPortableZip`, so the page, the manifest generator's
+  defaults and the README cannot drift.
+- The Windows card on `download.astro` leads with the two-line Scoop install,
+  keeps the `.msi` button beside it, and its "there is no winget or Chocolatey
+  package today" note becomes true again by naming Scoop as the one that does
+  exist.
+- `pgitMatrix` gains a Scoop row (`ships: true` — §C), and the Windows
+  `specs` list stops implying the `.msi` is the only route.
+- **The README's Windows lines and one Status bullet.** #271 landed a full
+  README pass mid-flight — it had already replaced the stale Linux install
+  section, so this change keeps that text untouched and adds only the Scoop
+  route beside the `.msi`.
+
+  One bullet it wrote does need correcting rather than extending: *"No `winget`
+  or `scoop` yet — **both** wait on that code signing"*. Scoop never waited on
+  code signing, and nothing here required a certificate; only winget does,
+  because only winget's route is an installer that SmartScreen judges. Leaving
+  it would attribute a blocker to the piece that just shipped without one. The
+  `.msi` line's "the first Windows install is a manual download" goes for the
+  same reason: it is now a one-liner too.
+
+## Rejected alternatives
+
+- **A Scoop manifest wrapping the `.msi`** (`installer.script` + `msiexec`) —
+  §A. Elevated, per-machine, and un-uninstallable by Scoop.
+- **Reading `$env:SCOOP` to detect a Scoop install** — §B. Wrong for
+  `SCOOP_GLOBAL`, and set for *any* Scoop user rather than for *this install*,
+  so an MSI install on a machine that also uses Scoop would be told to
+  `scoop update` something Scoop does not have.
+- **Leaving Windows on `SelfUpdate` and letting the updater win** — §B. Two
+  copies, silently.
+- **A `pgit`-only `bin` entry, or no `pgit` at all** — §C. Either no CLI, or a
+  competing shim.
+- **Publishing the portable zip on the download page as its own install
+  route.** It would create a class of user with no package manager *and* no
+  installer, whose self-update lands a second copy in Program Files — the §B
+  failure with none of the §B detection. The asset exists for Scoop; the page
+  offers the `.msi` and Scoop.
+- **winget in this change** — Scope.
+
+## Verification reality
+
+Stated plainly, because it bounds what this change can claim:
+
+- **No Windows machine is in the loop while writing this.** Everything Windows
+  is verified by CI, not locally.
+- **The zip smoke runs on the real `windows-latest` runner** at build time, so
+  a malformed asset fails before it is attached.
+- **`scoop-verify-live` is the real proof, and it first runs on the first
+  release cut after this merges.** A manifest field name that Scoop rejects
+  would surface there, not in review. That is why the manifest is minimal and
+  conventional, and why the bucket is seeded empty (§F) rather than with a
+  guessed manifest.
+- Everything that can be verified without Windows is: the manifest generator
+  runs locally, `is_scoop_layout` is pure and unit-tested on macOS, the shim
+  classification is pinned with a real Scoop shim body, and the panel's Scoop
+  hint is a component test.
+
+## Follow-ups
+
+- **winget** — the remaining #187 item, gated on bundle code signing.
+- **`.rpm` + a dnf repo**, and an AUR `platypusgit-bin` — already recorded as
+  apt follow-ups; unchanged by this.
+- **arm64 Windows** — same shape as #266 for Linux; the manifest is already in
+  the form that accepts it.

--- a/scripts/scoop-bucket-seed/README.md
+++ b/scripts/scoop-bucket-seed/README.md
@@ -1,0 +1,45 @@
+# scoop-platypusgit
+
+A [Scoop](https://scoop.sh) bucket for **[platypusgit](https://github.com/jonassaa/platypusgit)** —
+a dev-first git desktop app. Free and open source, no account, no telemetry.
+
+```powershell
+scoop bucket add platypusgit https://github.com/jonassaa/scoop-platypusgit
+scoop install platypusgit
+```
+
+Updates then come from Scoop:
+
+```powershell
+scoop update platypusgit
+```
+
+The app knows it was installed this way and switches its own updater off, so the
+two can never disagree about which copy you are running.
+
+## What you get
+
+- `platypusgit` — the app, plus a Start Menu shortcut.
+- `pgit` — the CLI, shimmed onto your PATH. `pgit .` opens a repository the way
+  `code .` opens a folder.
+
+It needs the **WebView2 runtime**, which Windows 11 ships and Windows 10 gets
+with Edge — so it is almost certainly already there. Unlike the `.msi`, a
+portable package cannot install it for you: if no window appears, install the
+Evergreen WebView2 Runtime from Microsoft.
+
+Only `x64` is published today.
+
+## This repository is generated
+
+`bucket/platypusgit.json` is written by the **platypusgit release workflow** —
+its `bump-scoop` job renders it with
+[`scripts/scoop-manifest.sh`](https://github.com/jonassaa/platypusgit/blob/main/scripts/scoop-manifest.sh)
+and pushes it here on every non-prerelease release. Nothing else lives here: no
+workflows, no code.
+
+So **do not hand-edit the manifest** — the next release overwrites it. Changes
+belong in the generator, in the app repository, where they are reviewed.
+
+Issues and pull requests: please open them on
+[jonassaa/platypusgit](https://github.com/jonassaa/platypusgit/issues).

--- a/scripts/scoop-bucket-seed/bucket/.gitkeep
+++ b/scripts/scoop-bucket-seed/bucket/.gitkeep
@@ -1,0 +1,7 @@
+Scoop reads manifests from this directory. It is empty on purpose until the
+first release: `release.yml`'s `bump-scoop` job writes `platypusgit.json` here.
+
+Seeding a hand-made manifest would mean publishing a `hash` for a release asset
+that does not exist yet (`PlatypusGit_x64_portable.zip` first appears in the
+release after #187's Windows half landed), and a bucket whose only manifest
+fails to install is worse than a bucket with none.

--- a/scripts/scoop-bucket-wizard.sh
+++ b/scripts/scoop-bucket-wizard.sh
@@ -133,7 +133,7 @@ fi
 
 # ─── 2. the seed ─────────────────────────────────────────────────────────────
 
-step "2/4  Push the seed (README + an empty bucket/)"
+step "2/4  Seed the repository (README + an empty bucket/)"
 
 seeded=no
 if gh api "repos/$OWNER/$REPO/contents/README.md" > /dev/null 2>&1; then
@@ -142,32 +142,51 @@ if gh api "repos/$OWNER/$REPO/contents/README.md" > /dev/null 2>&1; then
 fi
 
 if [ "$seeded" = no ]; then
-    say "Pushes $SEED_DIR as the initial commit:"
+    say "Creates these in $OWNER/$REPO, from $SEED_DIR:"
     say ""
-    (cd "$SEED_DIR" && find . -type f | sed 's|^\./|  |')
+    (cd "$SEED_DIR" && find . -type f ! -name '.DS_Store' | sed 's|^\./|  |')
     say ""
     say "bucket/ ships EMPTY of manifests on purpose. The first bump-scoop run"
     say "writes $MANIFEST; a hand-made manifest here would carry a hash for an"
     say "asset that does not exist yet, and a bucket whose only manifest fails"
     say "to install is worse than a bucket with none."
-    if confirm "Push it?"; then
-        if would "git init + commit + push $SEED_DIR to $OWNER/$REPO"; then
-            tmp="$(mktemp -d)"
-            # A plain copy into a scratch clone, so this never touches the
-            # working tree the wizard is being run from.
-            cp -R "$SEED_DIR/." "$tmp/"
+    if confirm "Create them?"; then
+        if would "create each seed file in $OWNER/$REPO via the GitHub API"; then
+            # UPLOADED WITH `gh api`, NOT `git push`, and that is the fix for a
+            # real failure rather than a preference. `gh` is already
+            # authenticated (the preflight checked) and its token is what every
+            # other step here uses. A `git push` instead goes through git's own
+            # credential system for a repository the user has never cloned — so
+            # the first version of this step, which added an `https://` remote,
+            # prompted for a GitHub *password* that has not been accepted for git
+            # operations for years, and failed. Hardcoding SSH would only move
+            # the assumption; the Contents API needs no remote, no protocol
+            # choice and no credential helper.
+            #
+            # It also handles the empty-repository case for free: the first PUT
+            # creates the default branch, so nothing here has to know or guess
+            # what that branch is called.
+            #
+            # One commit per file. That is fine for a seed, and it keeps this a
+            # loop over the directory rather than a tree-API special case, so
+            # adding a seed file later needs no code change here.
             (
-                cd "$tmp"
-                git init -q -b main
-                git add -A
-                git -c user.name="$(git config user.name || echo platypusgit)" \
-                    -c user.email="$(git config user.email || echo noreply@platypusgit.com)" \
-                    commit -q -m "chore: seed the bucket"
-                git remote add origin "https://github.com/$OWNER/$REPO.git"
-                git push -q -u origin main
+                cd "$SEED_DIR"
+                find . -type f ! -name '.DS_Store' | sed 's|^\./||' | while read -r rel; do
+                    if gh api "repos/$OWNER/$REPO/contents/$rel" > /dev/null 2>&1; then
+                        say "  $rel already there — skipping."
+                        continue
+                    fi
+                    # `tr -d` because base64 line-wraps on some platforms and
+                    # not others, and the API wants one string either way.
+                    content="$(base64 < "$rel" | tr -d '\n')"
+                    gh api --method PUT "repos/$OWNER/$REPO/contents/$rel" \
+                        -f message="chore: seed the bucket ($rel)" \
+                        -f content="$content" > /dev/null
+                    say "  $rel created."
+                done
             )
-            rm -rf "$tmp"
-            say "Pushed."
+            say "Seeded."
         fi
     fi
 fi

--- a/scripts/scoop-bucket-wizard.sh
+++ b/scripts/scoop-bucket-wizard.sh
@@ -1,0 +1,229 @@
+#!/bin/sh
+# One-time setup for the platypusgit Scoop bucket (#187, Windows half).
+#
+# Walks the four steps that live OUTSIDE this git repository and that therefore
+# no code review can see: a second GitHub repo, its seed content, a GitHub App
+# installation, and the first publish. Those are exactly the steps that get
+# half-done and then debugged months later as a mystery release failure, so this
+# script does what it can and verifies each step before moving on.
+#
+#   sh scripts/scoop-bucket-wizard.sh            # walk the steps
+#   sh scripts/scoop-bucket-wizard.sh --dry-run  # print them, change nothing
+#
+# MUCH SHORTER THAN scripts/apt-repo-wizard.sh, and that asymmetry is the whole
+# "cheapest remaining win" argument in #187: no DNS record, no GitHub Pages
+# configuration, no signing key, and no new secret. One repository, and the App
+# the Homebrew tap already uses.
+#
+# INTERACTIVE ON PURPOSE. Unlike scripts/install-platypusgit.sh this is never
+# piped into a shell — it reads stdin, prompts, and waits. Run it from a
+# terminal, and read the step before answering it.
+#
+# It is idempotent: every step detects work already done and skips it, so a run
+# interrupted halfway can simply be re-run.
+#
+# Spec: docs/superpowers/specs/2026-08-27-scoop-bucket-spec.md  (§F)
+set -eu
+
+OWNER=jonassaa
+REPO=scoop-platypusgit
+APP_REPO=platypusgit
+TAP_REPO=homebrew-platypusgit
+MANIFEST=bucket/platypusgit.json
+
+SEED_DIR="$(cd "$(dirname "$0")" && pwd)/scoop-bucket-seed"
+DRY_RUN=no
+
+usage() {
+    cat <<'USAGE'
+Usage: scoop-bucket-wizard.sh [--dry-run]
+
+One-time setup for the platypusgit Scoop bucket. Interactive; run it from a
+terminal.
+
+  --dry-run       print what each step would do and change nothing
+  -h, --help      this text
+USAGE
+}
+
+say() { printf '%s\n' "$*"; }
+warn() { printf '%s\n' "$*" >&2; }
+die() { warn ""; warn "scoop-bucket-wizard: $*"; exit 1; }
+
+step() {
+    say ""
+    say "──────────────────────────────────────────────────────────────"
+    say " $*"
+    say "──────────────────────────────────────────────────────────────"
+}
+
+# Waits for a plain Enter, or `s` to skip. Never proceeds on its own — the whole
+# point of a wizard is that a human looked at the step. Under --dry-run it
+# continues without asking, so the full walk can be reviewed without a terminal;
+# nothing it would reach mutates anything anyway.
+confirm() {
+    if [ "$DRY_RUN" = yes ]; then
+        printf '%s [dry-run: continuing]\n' "$1"
+        return 0
+    fi
+    printf '%s [Enter to continue, s to skip, q to quit] ' "$1"
+    read -r reply || reply=q
+    case "$reply" in
+        s | S) return 1 ;;
+        q | Q) die "stopped at the user's request" ;;
+        *) return 0 ;;
+    esac
+}
+
+would() {
+    if [ "$DRY_RUN" = yes ]; then
+        say "  would run: $*"
+        return 1
+    fi
+    return 0
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) DRY_RUN=yes; shift ;;
+        -h | --help) usage; exit 0 ;;
+        *) die "unknown option: $1 (try --help)" ;;
+    esac
+done
+
+# ─── preflight ───────────────────────────────────────────────────────────────
+
+command -v gh > /dev/null 2>&1 || die "gh is required (https://cli.github.com)"
+command -v git > /dev/null 2>&1 || die "git is required"
+[ -d "$SEED_DIR" ] || die "seed directory not found: $SEED_DIR"
+
+gh auth status > /dev/null 2>&1 || die "gh is not authenticated — run: gh auth login"
+
+say "platypusgit Scoop bucket — one-time setup"
+say ""
+say "  repository   $OWNER/$REPO (public)"
+say "  manifest     $MANIFEST  (written by CI, never by hand)"
+say "  seed         $SEED_DIR"
+say "  secrets      none — reuses the App behind vars.TAP_APP_ID"
+if [ "$DRY_RUN" = yes ]; then
+    say ""
+    say "  DRY RUN — nothing will be created or pushed."
+fi
+
+# ─── 1. the repository ───────────────────────────────────────────────────────
+
+step "1/4  Create $OWNER/$REPO"
+
+if gh repo view "$OWNER/$REPO" > /dev/null 2>&1; then
+    say "Already exists — skipping."
+else
+    say "A Scoop bucket is just a git repository with manifests in bucket/."
+    # Single-quoted: a backtick inside double quotes is command substitution in
+    # sh, so "`scoop bucket add`" would try to RUN scoop.
+    say 'Public, because "scoop bucket add" clones it anonymously.'
+    if confirm "Create it?"; then
+        if would "gh repo create $OWNER/$REPO --public"; then
+            gh repo create "$OWNER/$REPO" --public \
+                --description "Scoop bucket for platypusgit" \
+                --homepage "https://www.platypusgit.com"
+            say "Created."
+        fi
+    fi
+fi
+
+# ─── 2. the seed ─────────────────────────────────────────────────────────────
+
+step "2/4  Push the seed (README + an empty bucket/)"
+
+seeded=no
+if gh api "repos/$OWNER/$REPO/contents/README.md" > /dev/null 2>&1; then
+    say "README.md already present — skipping."
+    seeded=yes
+fi
+
+if [ "$seeded" = no ]; then
+    say "Pushes $SEED_DIR as the initial commit:"
+    say ""
+    (cd "$SEED_DIR" && find . -type f | sed 's|^\./|  |')
+    say ""
+    say "bucket/ ships EMPTY of manifests on purpose. The first bump-scoop run"
+    say "writes $MANIFEST; a hand-made manifest here would carry a hash for an"
+    say "asset that does not exist yet, and a bucket whose only manifest fails"
+    say "to install is worse than a bucket with none."
+    if confirm "Push it?"; then
+        if would "git init + commit + push $SEED_DIR to $OWNER/$REPO"; then
+            tmp="$(mktemp -d)"
+            # A plain copy into a scratch clone, so this never touches the
+            # working tree the wizard is being run from.
+            cp -R "$SEED_DIR/." "$tmp/"
+            (
+                cd "$tmp"
+                git init -q -b main
+                git add -A
+                git -c user.name="$(git config user.name || echo platypusgit)" \
+                    -c user.email="$(git config user.email || echo noreply@platypusgit.com)" \
+                    commit -q -m "chore: seed the bucket"
+                git remote add origin "https://github.com/$OWNER/$REPO.git"
+                git push -q -u origin main
+            )
+            rm -rf "$tmp"
+            say "Pushed."
+        fi
+    fi
+fi
+
+# ─── 3. the GitHub App ───────────────────────────────────────────────────────
+
+step "3/4  Install the existing GitHub App on $REPO"
+
+say "release.yml's bump-scoop job pushes to $OWNER/$REPO with a token minted"
+say "from the SAME App the Homebrew tap and the apt repo already use"
+say "(vars.TAP_APP_ID / secrets.TAP_APP_PRIVATE_KEY). The App has to be"
+say "installed on this repo too, or that step fails with a 404 that reads like"
+say "a missing repository."
+say ""
+say "This is not scriptable — App installations are a UI action. Open:"
+say ""
+say "  https://github.com/settings/installations"
+say ""
+say "then: the App used for $TAP_REPO -> Configure -> Repository access ->"
+say "add '$REPO'. It needs Contents: read and write."
+say ""
+confirm "Done?" || say "Skipped — remember that bump-scoop cannot push until this is done."
+
+# ─── 4. the first publish ────────────────────────────────────────────────────
+
+step "4/4  Verify the first publish"
+
+if gh api "repos/$OWNER/$REPO/contents/$MANIFEST" > /dev/null 2>&1; then
+    version="$(gh api "repos/$OWNER/$REPO/contents/$MANIFEST" \
+        --jq '.content' 2> /dev/null | base64 -d 2> /dev/null \
+        | sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' | head -n1)"
+    say "$MANIFEST is published${version:+ (version $version)}."
+    say ""
+    say "Nothing left to do. Confirm end to end from a Windows box:"
+    say ""
+    say "    scoop bucket add platypusgit https://github.com/$OWNER/$REPO"
+    say "    scoop install platypusgit"
+else
+    say "$MANIFEST is not published yet — expected until the next release."
+    say ""
+    say "It appears when release.yml's bump-scoop job runs, which happens on the"
+    say "next NON-PRERELEASE release. To publish an existing tag instead,"
+    say "dispatch the workflow against it:"
+    say ""
+    say "    gh workflow run release.yml -f tag=vX.Y.Z --repo $OWNER/$APP_REPO"
+    say ""
+    say "...but only a tag built AFTER this change, since older builds attached"
+    say "no PlatypusGit_x64_portable.zip and bump-scoop would have no hash."
+    say ""
+    say "The release run also gates itself: scoop-verify-live does a real"
+    say '"scoop install" on a clean Windows runner and fails the run rather than'
+    say "leaving a broken manifest published."
+fi
+
+say ""
+say "──────────────────────────────────────────────────────────────"
+say " Setup walked."
+say "──────────────────────────────────────────────────────────────"
+say ""

--- a/scripts/scoop-manifest.sh
+++ b/scripts/scoop-manifest.sh
@@ -1,0 +1,130 @@
+#!/bin/sh
+# Render the Scoop manifest for the platypusgit bucket (#187, Windows half).
+#
+#   sh scripts/scoop-manifest.sh --version 0.1.0 --hash <sha256> --out bucket/platypusgit.json
+#   sh scripts/scoop-manifest.sh --version 0.1.0 --hash <sha256>          # to stdout
+#
+# WHY A GENERATOR IN THIS REPOSITORY, and not a manifest committed in the bucket
+# repo and patched in place by CI: the manifest is the artifact users install
+# from, so it should be reviewable here, runnable here, and impossible to drift
+# from a second copy nobody reads. Same argument as scripts/apt-repo-publish.sh,
+# which is why the two look alike.
+#
+# Called by release.yml's `bump-scoop`. Safe to run locally — it writes one file
+# and touches no network.
+#
+# Spec: docs/superpowers/specs/2026-08-27-scoop-bucket-spec.md  (§D)
+set -eu
+
+REPO_URL=https://github.com/jonassaa/platypusgit
+ASSET=PlatypusGit_x64_portable.zip
+HOMEPAGE=https://www.platypusgit.com
+LICENSE_ID=GPL-3.0-only
+
+VERSION=
+HASH=
+URL=
+OUT=
+
+usage() {
+    cat <<'USAGE'
+Usage: scoop-manifest.sh --version X.Y.Z --hash <sha256> [--url URL] [--out FILE]
+
+Renders the Scoop manifest for platypusgit.
+
+  --version X.Y.Z   release version, without a leading v
+  --hash <sha256>   sha256 of PlatypusGit_x64_portable.zip (64 hex chars)
+  --url URL         override the download URL (default: the release tag URL)
+  --out FILE        write here instead of stdout
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --version) VERSION="${2:?--version needs a value}"; shift 2 ;;
+        --hash)    HASH="${2:?--hash needs a value}"; shift 2 ;;
+        --url)     URL="${2:?--url needs a value}"; shift 2 ;;
+        --out)     OUT="${2:?--out needs a value}"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "scoop-manifest.sh: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+if [ -z "$VERSION" ] || [ -z "$HASH" ]; then
+    echo "scoop-manifest.sh: --version and --hash are both required" >&2
+    exit 2
+fi
+
+# Validated rather than trusted, because both failures are invisible in review
+# and only surface as a Scoop error on a stranger's machine: a wrong `version`
+# makes `scoop update` a no-op forever, and a wrong `hash` makes every install
+# fail with "hash check failed" against a download that is actually fine.
+if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$'; then
+    echo "scoop-manifest.sh: --version must be a bare semver (got '$VERSION')" >&2
+    exit 2
+fi
+if ! printf '%s' "$HASH" | grep -Eq '^[0-9a-fA-F]{64}$'; then
+    echo "scoop-manifest.sh: --hash must be 64 hex characters (got '$HASH')" >&2
+    exit 2
+fi
+
+# THE TAG URL, NOT releases/latest/download. Every other channel uses the stable
+# latest-download path on purpose so the Homebrew cask can track it; a Scoop
+# manifest pins a `hash` to one specific build, and the stable path MOVES on the
+# next release — which would hash-mismatch every install in the window between a
+# release and its bump. Tag URL and hash move together, in one commit.
+if [ -z "$URL" ]; then
+    URL="${REPO_URL}/releases/download/v${VERSION}/${ASSET}"
+fi
+
+# `bin` carries pgit.cmd as well as the exe, and that is load-bearing rather
+# than a convenience: cli.rs::shim_status looks for a file named `pgit.cmd` on
+# PATH, so without this entry a Scoop install has no `pgit`, AND Settings would
+# offer to write a competing shim into %LOCALAPPDATA% that Scoop neither knows
+# about nor removes on uninstall. See the spec's §C.
+#
+# `architecture.64bit` rather than a top-level url/hash so arm64 is one more key
+# later, not a rewrite — the lesson #187 recorded for the apt pool.
+#
+# The `$version` in the autoupdate URL is LITERAL and must stay that way: jq
+# interpolates with \(...), so a bare $version inside a string is text, and it is
+# Scoop that substitutes it when checkver finds a new tag. Do not "fix" it into
+# an interpolation — that would freeze autoupdate at the version we happened to
+# publish with.
+manifest=$(jq -n \
+    --arg version "$VERSION" \
+    --arg url "$URL" \
+    --arg hash "$HASH" \
+    --arg homepage "$HOMEPAGE" \
+    --arg license "$LICENSE_ID" \
+    --arg repo "$REPO_URL" \
+    --arg asset "$ASSET" \
+    '{
+      version: $version,
+      description: "A dev-first git desktop app. Cross-platform, no account, no telemetry.",
+      homepage: $homepage,
+      license: $license,
+      architecture: {
+        "64bit": { url: $url, hash: $hash }
+      },
+      bin: ["platypusgit.exe", "pgit.cmd"],
+      shortcuts: [["platypusgit.exe", "platypusgit"]],
+      notes: [
+        "Scoop owns updates for this install: run `scoop update platypusgit`. The in-app updater is switched off here on purpose, so the two can never disagree about which copy you are running.",
+        "`platypusgit` and `pgit` are both on your PATH via Scoop shims.",
+        "Needs the WebView2 runtime. Windows 11 ships it and Windows 10 gets it with Edge, so it is almost certainly already there — but unlike the .msi this package cannot install it for you. If no window appears, install the Evergreen WebView2 Runtime from Microsoft."
+      ],
+      checkver: { github: $repo },
+      autoupdate: {
+        architecture: {
+          "64bit": { url: ($repo + "/releases/download/v$version/" + $asset) }
+        }
+      }
+    }')
+
+if [ -n "$OUT" ]; then
+    printf '%s\n' "$manifest" > "$OUT"
+    echo "scoop-manifest.sh: wrote $OUT (version $VERSION)"
+else
+    printf '%s\n' "$manifest"
+fi

--- a/site/src/data/site.ts
+++ b/site/src/data/site.ts
@@ -16,7 +16,7 @@ export const site = {
 // builds via the release workflow.
 export const downloads = [
   { key: 'macos', label: 'macOS', anchor: '/download/#macos', note: 'Apple Silicon & Intel · .dmg', available: true },
-  { key: 'windows', label: 'Windows', anchor: '/download/#windows', note: 'Windows 10 & 11 · .msi', available: true },
+  { key: 'windows', label: 'Windows', anchor: '/download/#windows', note: 'Windows 10 & 11 · .msi or Scoop', available: true },
   { key: 'linux', label: 'Linux', anchor: '/download/#linux', note: '.deb & AppImage', available: true },
 ] as const;
 
@@ -28,6 +28,24 @@ export const assets = {
   windowsMsi: releaseAsset('PlatypusGit_x64.msi'),
   linuxDeb: releaseAsset('PlatypusGit_amd64.deb'),
   linuxAppImage: releaseAsset('PlatypusGit_amd64.AppImage'),
+};
+
+// The Scoop bucket (#187, Windows half). Its own repo, like the Homebrew tap and
+// the apt repo — but unlike the apt repo it needs no host of its own, because
+// `scoop bucket add` clones a git repository rather than fetching an index.
+//
+// Deliberately NOT offering `assets.windowsPortableZip` here: the zip exists so
+// Scoop has something to install, and advertising it as its own download route
+// would create a class of user with no package manager AND no installer, whose
+// in-app update would land a second copy in Program Files. The page offers the
+// .msi and Scoop.
+export const scoop = {
+  bucket: 'https://github.com/jonassaa/scoop-platypusgit',
+  // The name `scoop bucket add` registers it under, and the manifest's own
+  // basename — which is also the directory Scoop installs into, and therefore
+  // what `update::is_scoop_layout` matches on. Three things, one string.
+  bucketName: 'platypusgit',
+  pkg: 'platypusgit',
 };
 
 // The APT repository (#187). Its own repo + GitHub Pages host, NOT this site:

--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -3,7 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import CTAButton from '../components/CTAButton.astro';
 import CodeBlock from '../components/CodeBlock.astro';
 import OsIcon from '../components/OsIcon.astro';
-import { site, assets, apt } from '../data/site.ts';
+import { site, assets, apt, scoop } from '../data/site.ts';
 import { descriptions, softwareApplicationSchema, ORIGIN } from '../data/seo.ts';
 
 // The two installer URLs. Built from `site` in astro.config.mjs rather than
@@ -39,6 +39,13 @@ const aptAudit = `curl -fsSL ${installAppUrl} -o install-platypusgit.sh
 less install-platypusgit.sh   # read it, then run it
 sh install-platypusgit.sh`;
 
+// Windows' package-manager route (#187). Built from `scoop` in data/site.ts so
+// the page, the manifest generator and release.yml's bump-scoop cannot drift
+// apart on the bucket name.
+const scoopInstall = `scoop bucket add ${scoop.bucketName} ${scoop.bucket}
+scoop install ${scoop.pkg}`;
+const scoopUpgrade = `scoop update ${scoop.pkg}`;
+
 const cliUnix = `curl -fsSL ${installShUrl} | sh`;
 const cliWindows = `irm ${installPs1Url} | iex`;
 const cliUnixAudit = `curl -fsSL ${installShUrl} -o install-pgit.sh
@@ -65,6 +72,7 @@ const pgitMatrix = [
   { os: 'macos', channel: 'Homebrew cask', ships: true, note: 'Removed again on uninstall' },
   { os: 'macos', channel: 'Disk image (.dmg)', ships: false, note: 'A drag-install runs no code' },
   { os: 'windows', channel: 'Installer (.msi)', ships: true, note: 'Added to your PATH' },
+  { os: 'windows', channel: 'Scoop', ships: true, note: 'Scoop shims it for you' },
   { os: 'linux', channel: 'APT repository', ships: true, note: 'Ships /usr/bin/pgit' },
   { os: 'linux', channel: 'Debian package (.deb)', ships: true, note: 'Same package, same shim' },
   { os: 'linux', channel: 'AppImage', ships: false, note: 'Portable, executes no hook' },
@@ -83,7 +91,7 @@ const platforms = [
     key: 'windows',
     label: 'Windows',
     iconSize: 18,
-    blurb: 'Windows 10 and 11, 64-bit.',
+    blurb: 'An installer, or one line with Scoop.',
     specs: ['Windows 10 or 11, x64', 'WebView2 — preinstalled on 11', 'Ships the pgit command'],
   },
   {
@@ -247,7 +255,8 @@ const platforms = [
                 <p class="card-note">
                   Installs the app and the <a href="#cli"><code>pgit</code></a> command together, and puts
                   <code>pgit</code> on your PATH. WebView2 is already present on Windows 11; on Windows 10
-                  the installer pulls it in if it is missing.
+                  the installer pulls it in if it is missing. This is the route that updates itself —
+                  platypusgit offers the new version in-app and installs it for you.
                 </p>
                 <details>
                   <summary>First launch warning</summary>
@@ -258,13 +267,50 @@ const platforms = [
                 </details>
               </article>
 
+              <article class="card card-wide">
+                <h3>Scoop</h3>
+                <p class="card-lead">Already using Scoop? Two lines, no admin prompt, and <code>scoop update</code> for every release after.</p>
+                <CodeBlock code={scoopInstall} lang="powershell" />
+                <p class="card-note">
+                  Installs per-user, so nothing asks for elevation and
+                  <code>scoop uninstall {scoop.pkg}</code> removes every trace. You get the app with a
+                  Start Menu shortcut, and <a href="#cli"><code>pgit</code></a> shimmed onto your PATH by
+                  Scoop itself. Needs <a href="https://scoop.sh" target="_blank" rel="noopener">Scoop</a>
+                  first — if you don’t have it, take the installer above instead.
+                </p>
+                <details>
+                  <summary>Updating and removing</summary>
+                  <p class="card-note">
+                    Scoop owns updates on this install, and the app knows it — the in-app updater is
+                    switched off here, so the two can never disagree about which copy you are running.
+                    Upgrading is:
+                  </p>
+                  <CodeBlock code={scoopUpgrade} lang="powershell" />
+                  <p class="card-note">
+                    Quit platypusgit first so the running app isn’t swapped underneath it.
+                  </p>
+                </details>
+                <details>
+                  <summary>WebView2, and what this package cannot do for you</summary>
+                  <p class="card-note">
+                    Scoop installs a portable build rather than running the <code>.msi</code>, which is
+                    what makes it per-user and cleanly removable — but it also means it cannot install the
+                    WebView2 runtime the way the installer can. Windows 11 ships WebView2 and Windows 10
+                    gets it with Edge, so it is almost certainly already there; if no window appears,
+                    install the Evergreen WebView2 Runtime from Microsoft.
+                  </p>
+                </details>
+              </article>
+
               <article class="card">
                 <h3>Other routes</h3>
-                <p class="card-lead">No packaged alternative yet.</p>
+                <p class="card-lead">No winget or Chocolatey package yet.</p>
                 <p class="card-note">
-                  There is no winget or Chocolatey package today. If you would rather not run the
-                  installer, <a href="#build">build from source</a> — the standard Tauri toolchain
-                  produces the same <code>.msi</code>.
+                  <code>winget</code> is waiting on code signing — an unsigned installer means SmartScreen
+                  warnings and a harder time through winget’s review, so it is a certificate away rather
+                  than a build away. Chocolatey isn’t planned. If you would rather not run the installer
+                  at all, <a href="#build">build from source</a> — the standard Tauri toolchain produces
+                  the same <code>.msi</code>.
                 </p>
               </article>
             </>

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -521,6 +521,21 @@ pub fn shim_cmd_body(exe: &Path) -> String {
     format!("@echo off\r\n\"{}\" %*\r\n", exe.display())
 }
 
+/// The OTHER `pgit.cmd`: the one that ships inside
+/// `PlatypusGit_x64_portable.zip`, which is what the Scoop bucket installs
+/// (#187, Windows half).
+///
+/// Included rather than re-declared so the test that pins "a Scoop install
+/// classifies as `Package`" runs against the bytes we actually ship. That
+/// classification is what stops Settings writing a second `pgit` beside the one
+/// Scoop manages; the file's own header explains why its path is relative where
+/// `shim_cmd_body`'s is absolute.
+///
+/// Not `cfg(windows)`-gated, for the same reason `shim_cmd_body` is not: two of
+/// the three platforms' shim behaviour would otherwise be untestable from the
+/// machine most of this repo is written on.
+pub const PORTABLE_SHIM_CMD: &str = include_str!("../windows/pgit-portable.cmd");
+
 #[cfg(windows)]
 pub fn install_shim_at(dir: &Path, exe: &Path) -> std::io::Result<PathBuf> {
     std::fs::create_dir_all(dir)?;
@@ -1211,6 +1226,70 @@ mod tests {
             ),
             CliShimSource::Package
         );
+    }
+
+    #[test]
+    fn the_scoop_portable_shim_is_package_managed() {
+        // The bytes actually shipped inside PlatypusGit_x64_portable.zip, at the
+        // path Scoop extracts them to (#187).
+        //
+        // This is what stops Settings offering "Install pgit" on a Scoop install
+        // and writing a SECOND shim into %LOCALAPPDATA% — one Scoop does not
+        // know about and will not remove on uninstall. `shim_status` probes
+        // `exe_dir/pgit.cmd` before it scans PATH, so this file is the sighting
+        // that decides it, and its relative `%~dp0` form is still enough for
+        // `references_app` to recognise the binary by name.
+        let app = dirs(&["C:\\Users\\ada\\AppData\\Local\\PlatypusGit\\bin"]);
+        let install = "C:\\Users\\ada\\scoop\\apps\\platypusgit\\current";
+        assert_eq!(
+            classify_sighting(
+                Path::new(&format!("{install}\\pgit.cmd")),
+                &app,
+                None,
+                Some(PORTABLE_SHIM_CMD),
+                Path::new(&format!("{install}\\platypusgit.exe")),
+                "platypusgit"
+            ),
+            CliShimSource::Package
+        );
+    }
+
+    #[test]
+    fn the_scoop_generated_shim_is_package_managed_too() {
+        // Belt and braces: Scoop also writes its own wrapper into <root>\shims,
+        // which is the entry that is really on PATH. `shim_status` reaches
+        // `exe_dir` first so this one normally never decides anything — but if
+        // the app is launched some other way (the Start Menu shortcut resolving
+        // through the junction, say) this is the sighting that classifies, and it
+        // must not come back `Foreign` and offer to install over Scoop.
+        let body = "@rem C:\\Users\\ada\\scoop\\apps\\platypusgit\\current\\pgit.cmd\r\n\
+                    @\"%~dp0..\\apps\\platypusgit\\current\\pgit.cmd\"  %*\r\n";
+        let app = dirs(&["C:\\Users\\ada\\AppData\\Local\\PlatypusGit\\bin"]);
+        assert_eq!(
+            classify_sighting(
+                Path::new("C:\\Users\\ada\\scoop\\shims\\pgit.cmd"),
+                &app,
+                None,
+                Some(body),
+                Path::new("C:\\Users\\ada\\scoop\\apps\\platypusgit\\current\\platypusgit.exe"),
+                "platypusgit"
+            ),
+            CliShimSource::Package
+        );
+    }
+
+    #[test]
+    fn the_portable_shim_names_the_binary_relatively() {
+        // Two properties the zip's shim must keep, both invisible until Windows:
+        // it must name the exe (or `references_app` stops recognising it, and
+        // Settings starts writing a competing shim), and it must stay RELATIVE —
+        // Scoop re-points `current` at a new version directory on every update,
+        // so an absolute path would break at the first `scoop update`.
+        assert!(PORTABLE_SHIM_CMD.contains("platypusgit.exe"));
+        assert!(PORTABLE_SHIM_CMD.contains("%~dp0"));
+        assert!(!PORTABLE_SHIM_CMD.contains("C:\\"));
+        // CRLF, like every other .cmd we emit.
+        assert!(PORTABLE_SHIM_CMD.contains("\r\n"));
     }
 
     #[test]

--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -20,24 +20,38 @@ pub async fn check_for_update() -> AppResult<UpdateInfo> {
 }
 
 /// Whether this install can self-update or should notify + defer to a package
-/// manager. Computed from the build's OS, the `APPIMAGE` env var, and — on Linux
-/// — whether the apt repository from #187 is configured.
+/// manager. Computed from the build's OS, the `APPIMAGE` env var, and — per
+/// platform — whether a package manager owns this install: the apt repository
+/// from #187 on Linux, Scoop on Windows.
 ///
-/// The apt probe is one `Path::exists`, deliberately: no process spawn, so there
+/// Both probes are one `Path::exists`, deliberately: no process spawn, so there
 /// is nothing to route through `proc.rs`, nothing to mock, and no reason for
-/// this command to stop being synchronous. It is skipped entirely off Linux
-/// rather than relying on the path simply not existing there.
+/// this command to stop being synchronous. Each is skipped entirely off its own
+/// platform rather than relying on a path simply not existing there.
+///
+/// The Scoop probe is two cheap checks that must BOTH hold: the exe sits in
+/// Scoop's `apps/<name>/<version>` layout, and Scoop's own `manifest.json` is
+/// beside it. The layout alone would also match a hand-made directory tree that
+/// happened to be shaped like one, and the file alone says nothing about which
+/// app it describes.
 #[tauri::command]
 pub fn get_update_capability() -> AppResult<UpdateCapability> {
     let os = std::env::consts::OS;
-    let apt_managed =
-        os == "linux" && std::path::Path::new(update::APT_SOURCES_PATH).exists();
-    Ok(update::capability(
-        os,
+    let apt_managed = os == "linux" && std::path::Path::new(update::APT_SOURCES_PATH).exists();
+    let scoop_managed = os == "windows"
+        && std::env::current_exe().is_ok_and(|exe| {
+            update::is_scoop_layout(&exe)
+                && exe
+                    .parent()
+                    .is_some_and(|dir| dir.join(update::SCOOP_MANIFEST_FILE).exists())
+        });
+    Ok(update::capability(update::InstallEnv {
         // `APPIMAGE=` (set but empty) is not an AppImage install.
-        std::env::var("APPIMAGE").is_ok_and(|v| !v.is_empty()),
+        is_appimage: std::env::var("APPIMAGE").is_ok_and(|v| !v.is_empty()),
         apt_managed,
-    ))
+        scoop_managed,
+        ..update::InstallEnv::new(os)
+    }))
 }
 
 /// Open an https URL in the user's default browser (notify-path "View release").

--- a/src-tauri/src/update.rs
+++ b/src-tauri/src/update.rs
@@ -3,6 +3,7 @@
 //! fetch and Tauri commands live in `commands/update.rs`.
 
 use std::cmp::Ordering;
+use std::path::Path;
 use std::time::Duration;
 
 use semver::Version;
@@ -35,19 +36,28 @@ pub struct UpdateInfo {
 }
 
 /// Whether this install can swap its own binary or should defer to a package
-/// manager. Serializes to `"self-update"` / `"notify"` / `"notify-apt"`.
+/// manager. Serializes to `"self-update"` / `"notify"` / `"notify-apt"` /
+/// `"notify-scoop"`.
 ///
 /// `NotifyApt` exists because after #187 there are TWO kinds of `.deb` install
 /// and they need different advice. On an apt-managed one, `apt upgrade` is the
 /// answer. On a sideloaded `.deb` the same command reports "already the newest
 /// version" while the panel says a new version exists — a dead end, which is
 /// the exact failure `packageHint` was written to remove.
+///
+/// `NotifyScoop` is the same lesson on Windows, where getting it wrong is worse
+/// than a dead end. Windows was `SelfUpdate` unconditionally, and self-updating
+/// a Scoop install runs the per-machine `.msi`: the machine ends up with the new
+/// copy in `C:\Program Files` AND Scoop's old one still on PATH and still behind
+/// the Start Menu shortcut, with `scoop list` reporting the old version forever.
+/// Silently two installs, from one click.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum UpdateCapability {
     SelfUpdate,
     Notify,
     NotifyApt,
+    NotifyScoop,
 }
 
 /// The deb822 sources file `scripts/install-platypusgit.sh` writes.
@@ -59,6 +69,51 @@ pub enum UpdateCapability {
 /// `scripts/apt-repo-smoke.sh` asserts the path exists after a real install, so
 /// a drift fails the release gate rather than shipping quietly.
 pub const APT_SOURCES_PATH: &str = "/etc/apt/sources.list.d/platypusgit.sources";
+
+/// The metadata file Scoop writes into an installed app's version directory.
+///
+/// The Windows counterpart of `APT_SOURCES_PATH`, and a CONTRACT in the same
+/// sense — except this one is with Scoop's installer rather than with a script
+/// of ours, so we cannot fix it if it moves. It is held up by `release.yml`'s
+/// `scoop-verify-live`, which asserts this file exists beside the exe after a
+/// real `scoop install`: if a future Scoop stops writing it, the
+/// release gate fails instead of quietly handing every Scoop user the `.msi`
+/// self-updater and the two-installs outcome described on `NotifyScoop`.
+pub const SCOOP_MANIFEST_FILE: &str = "manifest.json";
+
+/// Does this executable live inside a Scoop install?
+///
+/// Scoop's layout is `<root>/apps/<name>/<version>/…`, with the live version
+/// junctioned at `<root>/apps/<name>/current`. Both shapes put the exe exactly
+/// three directories below the root, so the whole test is: the third ancestor is
+/// named `apps`, and the directory under it is named after this package.
+///
+/// The app-directory name is `CARGO_PKG_NAME` rather than a literal, which makes
+/// it a contract with the bucket: the manifest is `platypusgit.json`, so Scoop
+/// names the directory `platypusgit`. Read from Cargo for the same reason
+/// `cli.rs::MAIN_BINARY` is — a rename must not silently stop matching.
+///
+/// **Deliberately not `$env:SCOOP`.** That variable is relocatable, is a
+/// different variable for a global install (`SCOOP_GLOBAL`), and above all is
+/// set for anyone who uses Scoop *at all* — so an `.msi` install on a Scoop
+/// user's machine would be told to `scoop update` a package Scoop does not have.
+/// The question is "was THIS install made by Scoop", and the exe's own path is
+/// the only thing that answers it.
+///
+/// Pure and path-only, so it is testable from macOS and Linux. The filesystem
+/// half (the `SCOOP_MANIFEST_FILE` probe) lives in `commands::update`.
+pub fn is_scoop_layout(exe: &Path) -> bool {
+    let named = |dir: Option<&Path>, want: &str| {
+        dir.and_then(Path::file_name)
+            .and_then(|name| name.to_str())
+            // Windows paths are case-insensitive; so is this.
+            .is_some_and(|name| name.eq_ignore_ascii_case(want))
+    };
+    let version_dir = exe.parent();
+    let app_dir = version_dir.and_then(Path::parent);
+    let apps_dir = app_dir.and_then(Path::parent);
+    named(apps_dir, "apps") && named(app_dir, env!("CARGO_PKG_NAME"))
+}
 
 /// Subset of a GitHub release we care about.
 #[derive(Debug, Clone, PartialEq)]
@@ -142,17 +197,58 @@ pub fn discover(
     })
 }
 
+/// How this particular install reached the machine — everything `capability`
+/// decides from.
+///
+/// A struct rather than a fourth positional `bool`. `capability("linux", false,
+/// true, false)` is unreadable at the call site and the compiler cannot catch a
+/// swapped pair; with `InstallEnv::new` supplying the all-false baseline, every
+/// caller and every test names only the thing it is actually asserting:
+///
+/// ```ignore
+/// capability(InstallEnv { scoop_managed: true, ..InstallEnv::new("windows") })
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InstallEnv<'a> {
+    /// `std::env::consts::OS` in production; a literal in tests.
+    pub os: &'a str,
+    /// Running from an AppImage — `APPIMAGE` set and non-empty. Linux only.
+    pub is_appimage: bool,
+    /// The platypusgit apt repository is configured on this machine. Linux only.
+    pub apt_managed: bool,
+    /// This executable lives inside a Scoop install. Windows only.
+    pub scoop_managed: bool,
+}
+
+impl<'a> InstallEnv<'a> {
+    /// The baseline: a plain install on `os`, managed by nothing.
+    pub fn new(os: &'a str) -> Self {
+        Self {
+            os,
+            is_appimage: false,
+            apt_managed: false,
+            scoop_managed: false,
+        }
+    }
+}
+
 /// Per-platform self-update vs notify decision. See the plan's Global Constraints.
 ///
-/// `apt_managed` is only ever true on Linux (the caller does not look for a
-/// sources file anywhere else), and the AppImage arm deliberately wins over it:
-/// an AppImage can replace itself, so it should, even on a machine that also has
-/// the apt repository configured for a different install.
-pub fn capability(os: &str, is_appimage: bool, apt_managed: bool) -> UpdateCapability {
-    match os {
+/// `apt_managed` is only ever true on Linux and `scoop_managed` only ever on
+/// Windows (the caller does not probe for either off its own platform), and the
+/// AppImage arm deliberately wins over apt: an AppImage can replace itself, so
+/// it should, even on a machine that also has the apt repository configured for
+/// a different install.
+///
+/// Scoop is the one package manager that wins over `SelfUpdate` rather than
+/// losing to it, because the Windows self-update path does not *replace* a Scoop
+/// install — it adds a second one alongside. See `UpdateCapability::NotifyScoop`.
+pub fn capability(env: InstallEnv<'_>) -> UpdateCapability {
+    match env.os {
+        "windows" if env.scoop_managed => UpdateCapability::NotifyScoop,
         "windows" => UpdateCapability::SelfUpdate,
-        "linux" if is_appimage => UpdateCapability::SelfUpdate,
-        "linux" if apt_managed => UpdateCapability::NotifyApt,
+        "linux" if env.is_appimage => UpdateCapability::SelfUpdate,
+        "linux" if env.apt_managed => UpdateCapability::NotifyApt,
         _ => UpdateCapability::Notify,
     }
 }

--- a/src-tauri/tests/update.rs
+++ b/src-tauri/tests/update.rs
@@ -2,7 +2,8 @@ use std::cell::Cell;
 
 use platypusgit_lib::error::AppError;
 use platypusgit_lib::update::{
-    capability, compute_available, discover, is_newer, parse_release, ReleaseMeta, UpdateCapability,
+    capability, compute_available, discover, is_newer, is_scoop_layout, parse_release, InstallEnv,
+    ReleaseMeta, UpdateCapability,
 };
 
 #[test]
@@ -120,16 +121,31 @@ fn discover_propagates_fetch_errors() {
 #[test]
 fn capability_matches_platform_rule() {
     assert_eq!(
-        capability("windows", false, false),
+        capability(InstallEnv::new("windows")),
         UpdateCapability::SelfUpdate
     );
     assert_eq!(
-        capability("linux", true, false),
+        capability(InstallEnv {
+            is_appimage: true,
+            ..InstallEnv::new("linux")
+        }),
         UpdateCapability::SelfUpdate
     );
-    assert_eq!(capability("linux", false, false), UpdateCapability::Notify);
-    assert_eq!(capability("macos", false, false), UpdateCapability::Notify);
-    assert_eq!(capability("macos", true, false), UpdateCapability::Notify);
+    assert_eq!(
+        capability(InstallEnv::new("linux")),
+        UpdateCapability::Notify
+    );
+    assert_eq!(
+        capability(InstallEnv::new("macos")),
+        UpdateCapability::Notify
+    );
+    assert_eq!(
+        capability(InstallEnv {
+            is_appimage: true,
+            ..InstallEnv::new("macos")
+        }),
+        UpdateCapability::Notify
+    );
 }
 
 #[test]
@@ -137,10 +153,16 @@ fn capability_reports_apt_managed_linux_separately() {
     // The whole point of the third variant: an apt-managed .deb is told to run
     // `apt upgrade`, a sideloaded one is not.
     assert_eq!(
-        capability("linux", false, true),
+        capability(InstallEnv {
+            apt_managed: true,
+            ..InstallEnv::new("linux")
+        }),
         UpdateCapability::NotifyApt
     );
-    assert_eq!(capability("linux", false, false), UpdateCapability::Notify);
+    assert_eq!(
+        capability(InstallEnv::new("linux")),
+        UpdateCapability::Notify
+    );
 }
 
 #[test]
@@ -148,7 +170,11 @@ fn capability_prefers_appimage_self_update_over_apt() {
     // An AppImage can replace itself, so it should — even on a box that also has
     // the apt repository configured for some other install.
     assert_eq!(
-        capability("linux", true, true),
+        capability(InstallEnv {
+            is_appimage: true,
+            apt_managed: true,
+            ..InstallEnv::new("linux")
+        }),
         UpdateCapability::SelfUpdate
     );
 }
@@ -157,11 +183,139 @@ fn capability_prefers_appimage_self_update_over_apt() {
 fn capability_ignores_apt_off_linux() {
     // The caller never probes for a sources file off Linux; pin that a stray
     // `true` cannot invent an apt install on macOS or Windows.
-    assert_eq!(capability("macos", false, true), UpdateCapability::Notify);
     assert_eq!(
-        capability("windows", false, true),
+        capability(InstallEnv {
+            apt_managed: true,
+            ..InstallEnv::new("macos")
+        }),
+        UpdateCapability::Notify
+    );
+    assert_eq!(
+        capability(InstallEnv {
+            apt_managed: true,
+            ..InstallEnv::new("windows")
+        }),
         UpdateCapability::SelfUpdate
     );
+}
+
+#[test]
+fn capability_takes_scoop_off_the_self_update_path() {
+    // Windows was SelfUpdate unconditionally, and that is exactly wrong for a
+    // Scoop install: the updater runs the per-machine .msi, so the box ends up
+    // with the new copy in Program Files AND Scoop's old one still on PATH.
+    assert_eq!(
+        capability(InstallEnv {
+            scoop_managed: true,
+            ..InstallEnv::new("windows")
+        }),
+        UpdateCapability::NotifyScoop
+    );
+    // ...and the .msi install it is distinguished FROM keeps self-updating.
+    assert_eq!(
+        capability(InstallEnv::new("windows")),
+        UpdateCapability::SelfUpdate
+    );
+}
+
+#[test]
+fn capability_ignores_scoop_off_windows() {
+    // Mirror of the apt case: the caller never probes for Scoop off Windows, so
+    // pin that a stray `true` cannot invent a Scoop install elsewhere — an
+    // AppImage told to run `scoop update` would be actively wrong.
+    assert_eq!(
+        capability(InstallEnv {
+            scoop_managed: true,
+            ..InstallEnv::new("macos")
+        }),
+        UpdateCapability::Notify
+    );
+    assert_eq!(
+        capability(InstallEnv {
+            scoop_managed: true,
+            is_appimage: true,
+            ..InstallEnv::new("linux")
+        }),
+        UpdateCapability::SelfUpdate
+    );
+    assert_eq!(
+        capability(InstallEnv {
+            scoop_managed: true,
+            apt_managed: true,
+            ..InstallEnv::new("linux")
+        }),
+        UpdateCapability::NotifyApt
+    );
+}
+
+// FORWARD SLASHES IN WINDOWS PATHS, ON PURPOSE. `std::path`'s separator set is
+// per-target: on a Unix host a backslash is an ordinary character, so
+// `C:\scoop\apps\…` is ONE path component and every ancestor walk below would
+// vacuously pass. `/` is a separator on both, and Windows accepts it in real
+// paths too, so these cases exercise the same code the shipped Windows build
+// runs — on the machine the suite actually runs on.
+#[test]
+fn scoop_layout_recognises_both_shapes_scoop_installs_into() {
+    use std::path::Path;
+
+    // A version directory, and the `current` junction the shims point through.
+    // Both put the exe three deep under the root, which is the whole test.
+    assert!(is_scoop_layout(Path::new(
+        "C:/Users/dev/scoop/apps/platypusgit/0.1.0/platypusgit.exe"
+    )));
+    assert!(is_scoop_layout(Path::new(
+        "C:/Users/dev/scoop/apps/platypusgit/current/platypusgit.exe"
+    )));
+    // A relocated root ($env:SCOOP) and a global one ($env:SCOOP_GLOBAL) differ
+    // only ABOVE `apps` — which is why the probe reads neither variable.
+    assert!(is_scoop_layout(Path::new(
+        "D:/tools/apps/platypusgit/current/platypusgit.exe"
+    )));
+    assert!(is_scoop_layout(Path::new(
+        "C:/ProgramData/scoop/apps/platypusgit/current/platypusgit.exe"
+    )));
+    // Windows paths are case-insensitive; so is the probe.
+    assert!(is_scoop_layout(Path::new(
+        "C:/Users/dev/scoop/Apps/PlatypusGit/current/platypusgit.exe"
+    )));
+}
+
+#[test]
+fn scoop_layout_rejects_everything_else() {
+    use std::path::Path;
+
+    // The .msi install — the one that MUST keep self-updating.
+    assert!(!is_scoop_layout(Path::new(
+        "C:/Program Files/platypusgit/platypusgit.exe"
+    )));
+    // Another app's Scoop directory. Requiring the app-dir name is what stops a
+    // Scoop user's unrelated install from reading as ours.
+    assert!(!is_scoop_layout(Path::new(
+        "C:/Users/dev/scoop/apps/ripgrep/current/rg.exe"
+    )));
+    // Right name, wrong grandparent: a hand-made tree that only rhymes.
+    assert!(!is_scoop_layout(Path::new(
+        "C:/src/bin/platypusgit/current/platypusgit.exe"
+    )));
+    // Too shallow to have the three ancestors, and a bare filename.
+    assert!(!is_scoop_layout(Path::new(
+        "C:/apps/platypusgit/platypusgit.exe"
+    )));
+    assert!(!is_scoop_layout(Path::new("platypusgit.exe")));
+    // The dev build, which reports version 0.0.0 and never asks anyway.
+    assert!(!is_scoop_layout(Path::new(
+        "/Users/dev/platypusgit/src-tauri/target/debug/platypusgit"
+    )));
+}
+
+#[test]
+fn scoop_manifest_file_is_the_documented_contract() {
+    // Pinned for the same reason APT_SOURCES_PATH is, with one difference that
+    // matters: this contract is with SCOOP's installer, not with a script of
+    // ours. release.yml's scoop-verify-live asserts the file is really there
+    // after a real `scoop install`, so a Scoop change fails the release rather
+    // than silently putting every Scoop user back on the .msi self-updater.
+    assert_eq!(platypusgit_lib::update::SCOOP_MANIFEST_FILE, "manifest.json");
 }
 
 #[test]

--- a/src-tauri/windows/pgit-portable.cmd
+++ b/src-tauri/windows/pgit-portable.cmd
@@ -1,0 +1,22 @@
+@rem The `pgit` entry point that ships INSIDE platypusgit_x64_portable.zip, the
+@rem asset the Scoop bucket installs (#187).
+@rem
+@rem WHY IT IS RELATIVE where cli.rs::shim_cmd_body writes an absolute path: a
+@rem file inside a zip cannot know where it will be extracted, and Scoop keeps
+@rem the live version behind a `current` junction that it re-points on every
+@rem update -- so an absolute path would be wrong the first time the package is
+@rem upgraded, in a way nothing would report. `%~dp0` is this file's own
+@rem directory, trailing backslash included.
+@rem
+@rem WHY IT MUST EXIST AT ALL: cli.rs::shim_status probes `exe_dir/pgit.cmd`
+@rem before it scans PATH, and this file is what makes a Scoop install classify
+@rem as `CliShimSource::Package` -- which is what stops Settings offering to write
+@rem a second, competing shim into %LOCALAPPDATA% that Scoop would neither know
+@rem about nor remove. cli.rs::PORTABLE_SHIM_CMD includes these bytes and a test
+@rem pins that classification, so deleting or renaming this file fails the build
+@rem rather than quietly un-shimming Windows.
+@rem
+@rem The `@rem` prefix keeps these lines out of the console the same way `@echo
+@rem off` does for what follows.
+@echo off
+"%~dp0platypusgit.exe" %*

--- a/src/features/update/UpdatePanel.test.tsx
+++ b/src/features/update/UpdatePanel.test.tsx
@@ -111,7 +111,37 @@ describe("UpdatePanel — capability + platform arms", () => {
     );
   });
 
+  it("notify-scoop on Windows offers 'View release' AND scoop update", () => {
+    // The fourth capability, and the only one that takes a platform OFF the
+    // self-update path: an in-app install here would run the per-machine .msi
+    // and leave the machine with two copies, Scoop's still on PATH. So the
+    // panel must show no Install button, and must name Scoop's command.
+    platformMock.value = "windows";
+    seed({ capability: "notify-scoop" });
+    render(<UpdatePanel />);
+    expect(screen.getByTestId("pg-update-action")).toHaveTextContent(
+      /view release/i,
+    );
+    expect(screen.getByTestId("pg-update-action")).not.toHaveTextContent(
+      /install/i,
+    );
+    expect(screen.getByTestId("pg-update-pkg-hint")).toHaveTextContent(
+      "scoop update platypusgit",
+    );
+  });
+
   it("self-update offers 'Install' and never a package-manager hint", () => {
+    seed({ capability: "self-update" });
+    render(<UpdatePanel />);
+    expect(screen.getByTestId("pg-update-action")).toHaveTextContent(/install/i);
+    expect(screen.queryByTestId("pg-update-pkg-hint")).toBeNull();
+  });
+
+  it("keeps the Windows .msi install self-updating", () => {
+    // The other side of the Scoop case: the .msi is the one Windows install that
+    // SHOULD swap its own binary, so the new variant must not have made every
+    // Windows user click through to a browser.
+    platformMock.value = "windows";
     seed({ capability: "self-update" });
     render(<UpdatePanel />);
     expect(screen.getByTestId("pg-update-action")).toHaveTextContent(/install/i);
@@ -243,6 +273,14 @@ describe("UpdatePanel — the package-manager command is copyable", () => {
     expect(writeText).toHaveBeenCalledWith(
       "sudo apt update && sudo apt upgrade platypusgit",
     );
+  });
+
+  it("copies the scoop update command for a Scoop install", async () => {
+    platformMock.value = "windows";
+    seed({ capability: "notify-scoop" });
+    render(<UpdatePanel />);
+    await userEvent.click(screen.getByTitle(/copy command/i));
+    expect(writeText).toHaveBeenCalledWith("scoop update platypusgit");
   });
 
   it("keeps the command selectable by hand as well", () => {

--- a/src/features/update/packageHint.test.ts
+++ b/src/features/update/packageHint.test.ts
@@ -34,6 +34,27 @@ describe("packageHint", () => {
     expect(hint?.note).toMatch(/apt repository/i);
   });
 
+  it("tells a Scoop install to run scoop update", () => {
+    const hint = packageHint("notify-scoop", "windows");
+    expect(hint?.command).toBe("scoop update platypusgit");
+    expect(hint?.note).toMatch(/scoop/i);
+  });
+
+  it("lets the backend's Scoop answer beat the platform arm", () => {
+    // A Scoop install IS a Windows install, and Windows has no `notify` arm at
+    // all — so if this were matched by platform first, the one install that most
+    // needs a command would render nothing. Pinned because the ordering inside
+    // packageHint is the whole mechanism.
+    expect(packageHint("notify-scoop", "windows")?.command).toBe(
+      "scoop update platypusgit",
+    );
+    // And it survives a platform the backend would never pair it with, rather
+    // than falling through to that platform's advice.
+    expect(packageHint("notify-scoop", undefined)?.command).toBe(
+      "scoop update platypusgit",
+    );
+  });
+
   it("keeps the Homebrew command for macOS", () => {
     expect(packageHint("notify", "macos")?.command).toBe(
       "brew upgrade platypusgit",
@@ -50,6 +71,9 @@ describe("packageHint", () => {
     // telling that user to run apt would be actively wrong.
     expect(packageHint("self-update", "linux")).toBeNull();
     expect(packageHint("self-update", "macos")).toBeNull();
+    // The .msi install, which is the Windows case that DOES self-update. It must
+    // not be told to run `scoop update` for a package Scoop does not have.
+    expect(packageHint("self-update", "windows")).toBeNull();
   });
 
   it("says nothing before capability has loaded", () => {
@@ -60,8 +84,10 @@ describe("packageHint", () => {
 
   it("invents no command for a platform it has no advice for", () => {
     expect(packageHint("notify", undefined)).toBeNull();
-    // Windows is unconditionally `self-update` today; if that ever changes we
-    // fall back to silence rather than guessing an installer command.
+    // BARE `notify` on Windows, which the backend does not produce: Windows is
+    // `self-update`, or `notify-scoop` when Scoop owns the install. So this
+    // combination means "a package manager we could not name", and silence beats
+    // guessing between an .msi, Scoop and a hand-unpacked copy.
     expect(packageHint("notify", "windows")).toBeNull();
   });
 });

--- a/src/features/update/packageHint.ts
+++ b/src/features/update/packageHint.ts
@@ -4,13 +4,14 @@ import type { UpdateCapability } from "@/lib/types";
 /**
  * What to tell a user whose install can't swap its own binary.
  *
- * A `notify` or `notify-apt` capability means the backend decided this install
- * defers to a package manager (see `update::capability` in Rust); `notify-apt`
- * additionally means it knows the platypusgit apt repository is configured, so
- * it can name the command. Without a hint the panel showed a bare "View
- * release" button and nothing else, so a `.deb` user had no way to know *why*
- * the in-app install was unavailable or what to run instead — the panel was a
- * silent dead end.
+ * Any capability other than `self-update` means the backend decided this install
+ * defers to a package manager (see `update::capability` in Rust). The suffixed
+ * ones additionally say WHICH: `notify-apt` that the platypusgit apt repository
+ * is configured, `notify-scoop` that this exe lives in a Scoop install — so the
+ * hint can name the exact command instead of guessing from the platform.
+ * Without a hint the panel showed a bare "View release" button and nothing
+ * else, so a `.deb` user had no way to know *why* the in-app install was
+ * unavailable or what to run instead — the panel was a silent dead end.
  */
 export interface PackageHint {
   /** One line on why in-app install is unavailable here. */
@@ -26,23 +27,37 @@ export interface PackageHint {
  * session) rather than guessing — a hint that flashes the wrong platform's
  * command is worse than no hint.
  *
- * Windows is never `notify` (`capability` returns `SelfUpdate` for it
- * unconditionally), so it has no arm; if that ever changes this yields `null`
- * rather than inventing a command.
+ * Windows reaches the notify path only as `notify-scoop`, handled below by
+ * capability rather than by platform. Bare `notify` on Windows has no arm — that
+ * combination means the backend deferred to a package manager it could not
+ * name, and inventing an installer command for it would be a guess — so it
+ * yields `null`.
  */
 export function packageHint(
   capability: UpdateCapability | null,
   platform: Platform | undefined,
 ): PackageHint | null {
-  // `notify-apt` is a notify path too — the backend already decided this install
-  // defers to a package manager, it just knows WHICH one. Forgetting it here is
-  // the one place a missed branch renders nothing at all.
+  // The suffixed variants are notify paths too — the backend already decided
+  // this install defers to a package manager, it just knows WHICH one. They are
+  // matched BEFORE the platform switch because the backend's answer is the more
+  // specific one: a Scoop install is a Windows install, and the platform arm
+  // must not get a chance to contradict it. Forgetting a variant here is the one
+  // place a missed branch renders nothing at all.
   if (capability === "notify-apt") {
     return {
       // Character-for-character the command on the download page. Two places
       // telling one user two different upgrade commands is worse than either.
       note: "Updates come from apt on this install:",
       command: "sudo apt update && sudo apt upgrade platypusgit",
+    };
+  }
+  if (capability === "notify-scoop") {
+    return {
+      // No URL in this one, deliberately: Scoop already has the bucket, so the
+      // upgrade needs nothing fetched from us. It is also why this arm adds no
+      // entry to test/privacy.test.ts's hostname allowlist.
+      note: "Updates come from Scoop on this install:",
+      command: "scoop update platypusgit",
     };
   }
   if (capability !== "notify") return null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -463,8 +463,17 @@ export interface UpdateInfo {
  * that came from the platypusgit apt repository, so `apt upgrade` is the right
  * advice; plain `notify` on Linux is a sideloaded `.deb`, where that command
  * would report "already the newest version" and dead-end the user.
+ *
+ * `notify-scoop` is a Windows install that came from the Scoop bucket (#187).
+ * Windows is `self-update` everywhere else, and this variant exists because
+ * self-updating a Scoop install would run the per-machine `.msi` and leave the
+ * machine with two copies of the app — see the Rust enum for the full story.
  */
-export type UpdateCapability = "self-update" | "notify" | "notify-apt";
+export type UpdateCapability =
+  | "self-update"
+  | "notify"
+  | "notify-apt"
+  | "notify-scoop";
 
 /**
  * "Commit as" identity. Mirrors Rust `AuthorOverride` (git/types.rs) — it sets


### PR DESCRIPTION
The Windows half of #187, after the Linux half shipped in #267. #187 ranks the
remaining pieces "by value per effort" and puts **Scoop first** — this is that
piece. **winget is deliberately out of scope**, so #187 stays open for it.

Spec: `docs/superpowers/specs/2026-08-27-scoop-bucket-spec.md` ·
Plan: `docs/superpowers/plans/2026-08-27-scoop-bucket-plan.md`

## ⚠️ One thing to do before this is true

`jonassaa/scoop-platypusgit` **does not exist yet.** Run:

```sh
sh scripts/scoop-bucket-wizard.sh --dry-run   # read the walk first
sh scripts/scoop-bucket-wizard.sh
```

Four steps, all outside this repo: create the repo, push the seed, add the repo
to the **existing** GitHub App (`vars.TAP_APP_ID`), and verify the first
publish. **No new secret, no DNS, no Pages, no signing key** — the apt half
needed all four, and that asymmetry is the whole "cheapest win" argument.

Until it is run, the download page's `scoop bucket add` line names a 404. Same
accepted window as #267's host, but worth a decision rather than a surprise:
merging deploys the site.

## Three things this needed beyond publishing a manifest

Each would have failed silently on a user's machine, not in CI.

**1. Scoop cannot install the `.msi`.** Its msi handling is a deprecated path,
and an `msiexec` install is per-machine and elevated — which destroys the three
properties Scoop was picked for (per-user, no admin prompt, clean uninstall). So
the release attaches a portable `PlatypusGit_x64_portable.zip`
(`platypusgit.exe` + `pgit.cmd` + `LICENSE`, at the zip **root**). It gets no
`.sig` and no `latest.json` key — deliberately, see 2.

**2. A Scoop install must not self-update.** `capability` returned `SelfUpdate`
for Windows *unconditionally*, and the Windows updater runs the per-machine
`.msi`. On a Scoop box that does not replace the install — it **adds a second
one**: the new copy in `C:\Program Files`, Scoop's old one still on PATH and
still behind the Start Menu shortcut, and `scoop list` wrong forever. Hence
`UpdateCapability::NotifyScoop` + `scoop update platypusgit` in the panel.

Detected from Scoop's own `apps/<CARGO_PKG_NAME>/<version>` layout **plus** its
`manifest.json` beside the exe. Never `$env:SCOOP`: that is relocatable, wrong
for `SCOOP_GLOBAL`, and set for anyone who uses Scoop *at all* — so an `.msi`
install on a Scoop user's machine would be told to `scoop update` a package
Scoop does not have.

**3. The zip ships `pgit.cmd`, and that is load-bearing.** #187 says "Scoop
shims the executable itself" and stops there. `cli.rs::shim_status` probes
`exe_dir/pgit.cmd` *before* it scans PATH, so shipping that file is what
classifies a Scoop install as `CliShimSource::Package`. Without it the user gets
**no `pgit`** — the thing #187's title asks for on Windows — *and* Settings
offers to write a competing shim into `%LOCALAPPDATA%` that Scoop neither knows
about nor removes. Its body is relative (`%~dp0platypusgit.exe`) because Scoop
re-points `current` on every update; `cli.rs::PORTABLE_SHIM_CMD` includes the
shipped bytes so a test pins the classification.

## Verification, stated honestly

**No Windows machine was in the loop.** That bounds what this can claim:

- ✅ Pure parts unit-tested: `is_scoop_layout` (both install shapes, a relocated
  root, a global root, case-insensitivity, and the `.msi` path it must *not*
  match), both Scoop shim shapes classifying as `Package`, the panel's hint, and
  that the `.msi` keeps self-updating.
- ✅ `scripts/scoop-manifest.sh` runs locally; rejects a leading-`v` version and
  a short hash.
- ✅ `cargo test` (66 binaries), `pnpm test` (1948, was 1943), `tsc`, e2e
  typecheck, `pnpm build` in `site/`.
- ⏳ **The manifest and the install are proven only by CI, first on the next
  release.** The `windows` job expands the zip it just built and asserts its
  shape; `scoop-verify-live` does a real `scoop install` on a clean
  `windows-latest` and asserts the payload, `manifest.json` (the `update.rs`
  contract), the `pgit` shim, and the version. A manifest key Scoop rejects
  would surface there, which is why it stays minimal and why the bucket is
  seeded **empty of manifests** — a hand-seeded one would carry a hash for an
  asset that does not exist yet.

Two CI gotchas found and handled: GitHub's `windows-latest` user is elevated, so
Scoop's installer needs `-RunAsAdmin` (CI-only — users are not elevated), and
Scoop's PATH edit has to be re-exported through `$GITHUB_PATH` to reach later
steps.

## Also in here

- **`capability` takes an `InstallEnv` struct** instead of positional booleans.
  A fourth adjacent `bool` (`capability("linux", false, true, false)`) is a
  foot-gun the compiler cannot help with; call sites now name what they assert.
- **`.gitattributes`, one line.** `pgit-portable.cmd` must stay CRLF and a test
  asserts it; with `core.autocrlf=input` (what this repo is developed on) git
  stored it as LF and that test would have failed on Linux CI while the file
  still looked right on Windows. Verified by deleting and re-checking-out the
  file.
- **One correction to #271**, which landed mid-flight: its Status bullet said
  "No `winget` or `scoop` yet — **both** wait on that code signing". Scoop never
  waited on code signing and none was needed here. Its Linux section is left
  exactly as written; only the Windows lines are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
