### PR TITLE
fix(net): SIGTERM a cancelled op's process group before SIGKILL

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -24,17 +24,21 @@ opener.rs        URLs/paths → OS default handler. SECURITY-critical: safe_url
 update.rs        Update discovery: semver compare, dev-build (0.0.0) short-circuit
                  before any network call, GitHub release parsing, ureq w/ timeout +
                  https_only. Logic only — handlers live in commands/update.rs
-cancel.rs        Cancelling an in-flight network git subprocess (#234). A
+cancel.rs        Cancelling an in-flight network git subprocess (#234, #263). A
                  process-wide registry keyed by SCOPE (the clone / one
                  repository), not by op id — the auto-fetch pile has no id a
                  user could point at. Registered at the two choke points every
                  network op already goes through (create::run_clone,
                  net::run_git_authenticated), so a new network op inherits
-                 cancellation with nothing to remember. See backend.md
+                 cancellation with nothing to remember. cancel() kills the
+                 child directly by pid — SIGTERM to its whole process group
+                 first (kill_tree), escalating to SIGKILL on a second cancel
+                 of the same op. See backend.md
 proc.rs          THE only sanctioned child-process spawner (issue 172):
                  git / git_async / git_async_in (CREATE_NO_WINDOW,
-                 GIT_TERMINAL_PROMPT=0, stdin closed), program / program_async,
-                 and the two *_keeping_console exceptions. See backend.md
+                 GIT_TERMINAL_PROMPT=0, stdin closed, own process group),
+                 program / program_async, and the two *_keeping_console
+                 exceptions. See backend.md
 progress.rs      Reading git's own `--progress` sideband off a child's stderr
                  (#296). parse_progress turns "Receiving objects:  62%
                  (620/1000)" into a CloneProgress; ProgressReader splits a byte
@@ -43,8 +47,9 @@ progress.rs      Reading git's own `--progress` sideband off a child's stderr
                  instead of streaming), bounds an undelimited line, and keeps
                  the non-progress lines as the failure-message tail. Clone had
                  all of this privately; fetch/pull/push use the same code now,
-                 so the two cannot drift. Both callers keep their own select!
-                 loop — the cancel arms differ. See backend.md
+                 so the two cannot drift. Neither caller selects on anything:
+                 the cancel kills the child by pid (#263), and the read loop
+                 just notices the pipe close. See backend.md
 reveal.rs        "Reveal in Finder/Explorer" + "Open in terminal" (#215).
                  HostPlatform decouples argv building from the actual host, so
                  reveal_plan/terminal_plan are PURE and unit-tested for all

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -168,7 +168,7 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   them — the credential protocol is line-based, so a newline injects keys and
   could file a password against another host.
 
-### Cancelling a stalled network op (#234)
+### Cancelling a stalled network op (#234, hardened by #263)
 
 - **One cancel path, at the same two choke points as the credential policy.**
   `cancel.rs` is a process-wide registry; `run_git_authenticated` and
@@ -184,27 +184,45 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   is where the ops themselves get their `cwd` and where `cancel_network_op`
   resolves a `repo_id` — **the three must keep agreeing** or Cancel silently
   matches nothing.
-- **`AppError::Cancelled`, never `Network`.** A SIGKILLed git's dying stderr
-  says "early EOF" / "the remote end hung up unexpectedly"; routed through
+- **`cancel()` kills by pid, from the cancelling call's own task — not through
+  the op's `Child`.** The obvious shape, a `select!` over `child.wait()` and a
+  cancel future, needs `&mut child` in both arms; `Arc<Mutex<Child>>` deadlocks,
+  since the op holds the lock across the very `wait()` the killer needs to
+  interrupt. So `Registration::attach(pid)` records the pid in the registry, and
+  `cancel(scope)` signals it directly via `kill_tree`. The op's task never calls
+  `select!`; it just notices that `wait()`/`wait_with_output()` returned because
+  the child died, and checks `is_cancelled()` before trusting git's exit.
+- **`SIGTERM` to the process group first; `SIGKILL` on a second cancel of the
+  same op.** `SIGKILL` is uncatchable, so a SIGKILLed git never runs
+  `remove_lock_file_on_signal` (`lockfile.c`) — a cancel landing mid-fetch could
+  strand `.git/FETCH_HEAD.lock`, and the NEXT fetch fails with "File exists".
+  `proc::git_async`/`git_async_in` put the child in its own process group
+  (`process_group(0)` on unix); `kill_tree` signals the WHOLE group, which is
+  what actually reaches `git-remote-https`/`ssh` — git's own child for the
+  transfer, invisible to a kill of `git` alone. `kill_tree` checks
+  `getpgid(pid) == pid` before `killpg`, so a future spawn site that forgot
+  `process_group(0)` degrades to a single-process `kill` instead of signalling
+  OUR OWN process group. The second click is the escalation signal — no timer,
+  no rule for how long the first gets. Windows has no `SIGTERM` and a
+  `CREATE_NO_WINDOW` child has no console for `GenerateConsoleCtrlEvent`, so
+  there `kill_tree` is always `taskkill /F /T`; git gets no chance to clean up
+  its lock files on Windows, a known and accepted gap, not one this closes.
+- **`AppError::Cancelled`, never `Network`.** A killed git's dying stderr says
+  "early EOF" / "the remote end hung up unexpectedly"; routed through
   `Network`, a user who pressed Cancel is told their connection broke. The
   frontend drops it in `useRepoStore`'s `setErrorFor` (one place, so a network op
   added later cannot forget) and in `useCreateStore`'s clone catch.
-- **Check `is_cancelled()` after the child exits, not just in the `select!`.**
-  A cancel landing as git dies of its own accord loses the race, and the request
-  is what decides the outcome, not who got there first.
+- **Check `is_cancelled()` after the child exits, always.** A cancel landing as
+  git dies of its own accord must still win: the request is what decides the
+  outcome, not who got there first.
 - **A cancelled clone removes its partial destination**, and puts back an empty
-  directory the user had picked. A SIGKILLed `git clone` cannot run its own
-  cleanup, and the leftovers fail the NEXT attempt's `validate_clone_target`
-  with "already exists and is not empty" — a cancel button whose real effect is
-  to poison the destination. Safe to delete only because `validate_clone_target`
-  already refused anything but "absent" or "empty": kill and **reap** first
-  (`kill_and_reap`), so git is provably not still writing into it.
-- **What it does not kill:** git's own transport helper (`git-remote-https`,
-  `ssh`). It is git's child, not ours, and a SIGKILLed parent cannot take it
-  along; it exits when its pipes close, which for a helper blocked on a network
-  read means when that read times out. Closing that gap means killing the process
-  group — a platform-specific kill path through the one sanctioned spawner —
-  and is deliberately not done. The user-visible hang is gone either way.
+  directory the user had picked. Even with `SIGTERM` giving git a chance to run
+  its own cleanup, the leftovers (a `SIGKILL` escalation, or Windows) fail the
+  NEXT attempt's `validate_clone_target` with "already exists and is not
+  empty" — a cancel button whose real effect is to poison the destination. Safe
+  to delete only because `validate_clone_target` already refused anything but
+  "absent" or "empty": **reap** first (`child.wait()`), so git is provably not
+  still writing into it, before the directory is touched.
 
 ### Reporting progress from a long op (#296)
 

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -203,7 +203,11 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   `getpgid(pid) == pid` before `killpg`, so a future spawn site that forgot
   `process_group(0)` degrades to a single-process `kill` instead of signalling
   OUR OWN process group. The second click is the escalation signal — no timer,
-  no rule for how long the first gets. Windows has no `SIGTERM` and a
+  no rule for how long the first gets. **That puts a requirement on the UI:**
+  the first click has to visibly change something, or an impatient double-click
+  reaches `SIGKILL` in a few hundred milliseconds and strands the lock file
+  this whole path exists to protect. `cancelRequested` and the
+  "Cancelling…"/"Force stop" labels are that half — see `docs/dev/frontend.md`. Windows has no `SIGTERM` and a
   `CREATE_NO_WINDOW` child has no console for `GenerateConsoleCtrlEvent`, so
   there `kill_tree` is always `taskkill /F /T`; git gets no chance to clean up
   its lock files on Windows, a known and accepted gap, not one this closes.

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -667,6 +667,19 @@ cancellable in the backend but unstoppable from the UI for two releases.
   `cancel::Scope::Repo`, so it is the precise set `cancel_network_op` can reach.
   A rebase replay cannot be interrupted at all yet — offering a button that does
   nothing is worse than offering none.
+- **Cancel is a two-click affordance, and the first click MUST be visible**
+  (#263). The backend sends `SIGTERM` on the first cancel of an op and escalates
+  to `SIGKILL` only on a second — and only the `SIGTERM` lets git run its own
+  lock-file cleanup, so an accidental escalation strands `.git/FETCH_HEAD.lock`
+  and breaks the NEXT fetch. That makes the second click load-bearing, which is
+  only safe if the first one changed something on screen: `cancelRequested` (in
+  `RepoSlice`, and its own field on `useCreateStore`) turns the line into
+  "Cancelling…", drops the percentage — a bar still climbing after the click is
+  the clearest way to say "nothing happened" — and relabels the button "Force
+  stop". Neither surface may become disabled: a git that ignores `SIGTERM` is
+  escapable only by clicking again. `cancelRequested` clears when the last
+  `activity` entry goes, so the next stalled op starts from the polite signal.
+  See `docs/dev/backend.md` for the signal half.
 - **`setActivity` is guarded on the repository, like `setFor`.** `activity` is a
   per-repo slice field and an op outlives a tab switch: a fetch on A finishing
   after the user moved to B used to clear B's entry, taking B's spinner and

--- a/src-tauri/src/cancel.rs
+++ b/src-tauri/src/cancel.rs
@@ -494,6 +494,70 @@ mod tests {
         );
     }
 
+    /// The escalation itself, through `cancel()` — not `kill_tree` called with a
+    /// literal.
+    ///
+    /// `kill_tree_soft_sends_sigterm`/`_hard_sends_sigkill` pin what each signal
+    /// does, but neither goes through the registry, so the one line that DECIDES
+    /// which signal to send (`let hard = entry.cancel_requested`) was free to be
+    /// inverted or dropped with the suite still green. This is the test that
+    /// fails when it is.
+    ///
+    /// The child ignores SIGTERM, standing in for a git that does not die on the
+    /// polite ask — so surviving the first `cancel()` is itself the proof that
+    /// the first one was not a SIGKILL, which nothing can ignore.
+    #[cfg(unix)]
+    #[test]
+    fn cancel_asks_politely_first_and_escalates_on_the_second_call() {
+        use std::io::BufRead as _;
+        use std::os::unix::process::{CommandExt as _, ExitStatusExt as _};
+
+        let scope = Scope::repo(Path::new("/tmp/escalation"));
+        let registration = register(scope.clone());
+
+        // `trap '' TERM` in a LOOP, not around a single `sleep 30`: the group
+        // signal kills the inner `sleep` too, and a script whose only command
+        // died would then simply end — exiting for a reason that has nothing to
+        // do with the signal we are measuring.
+        let mut child = crate::proc::program("sh")
+            .arg("-c")
+            .arg("trap '' TERM; echo ready; while :; do sleep 1; done")
+            .process_group(0)
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn the SIGTERM-ignoring child");
+
+        // Wait for the trap to actually be installed. Without this handshake the
+        // first signal races the shell's startup and kills it by the DEFAULT
+        // disposition, which proves nothing about escalation — and does it only
+        // on a loaded machine, i.e. in CI.
+        let mut ready = String::new();
+        std::io::BufReader::new(child.stdout.take().expect("stdout"))
+            .read_line(&mut ready)
+            .expect("read the ready handshake");
+        assert_eq!(ready.trim(), "ready");
+
+        assert!(registration.attach(child.id()));
+
+        // First: SIGTERM, which this child ignores.
+        assert_eq!(cancel(&scope), 1);
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        assert!(
+            child.try_wait().expect("try_wait").is_none(),
+            "the FIRST cancel must be an ignorable SIGTERM — a child that is \
+             gone here was sent SIGKILL, and git never got to run \
+             remove_lock_file_on_signal"
+        );
+
+        // Second: the user telling us the first one did not work.
+        assert_eq!(cancel(&scope), 1);
+        assert_eq!(
+            child.wait().expect("wait").signal(),
+            Some(libc::SIGKILL),
+            "the SECOND cancel must escalate to SIGKILL"
+        );
+    }
+
     /// A future spawn site that forgot `process_group(0)` inherits OUR group —
     /// `kill_tree` must notice the target is not its own group leader and fall
     /// back to a single-process kill, or a cancel button would signal every

--- a/src-tauri/src/cancel.rs
+++ b/src-tauri/src/cancel.rs
@@ -1,4 +1,4 @@
-//! Cancelling an in-flight network git subprocess (#234).
+//! Cancelling an in-flight network git subprocess (#234, hardened by #263).
 //!
 //! Before this module a clone, fetch, pull or push that hung could only be
 //! escaped by force-quitting the app — `run_clone` said so in a comment, and
@@ -28,24 +28,58 @@
 //! So `cancel(Scope::Repo(path))` stops every network op running on that
 //! repository, which is what "Cancel" next to a stuck status line has to mean.
 //!
-//! ## What killing actually kills
+//! ## `cancel()` kills directly, by pid — not through a shared `Child`
 //!
-//! Both call sites spawn with `kill_on_drop(true)` and, for the clone, an
-//! explicit `start_kill()` + reap before the partial directory is removed.
-//! That kills the `git` process we spawned. Git's transport helper
-//! (`git-remote-https`, `ssh`) is git's own child, and a SIGKILL'd parent
-//! cannot take it with it — the helper exits when its pipes close, which for a
-//! helper blocked on a network read means when that read finally times out.
-//! Killing the whole process group would close that gap; it also means a
-//! platform-specific kill path through the one sanctioned spawner, so it is
-//! deliberately not done here. The user-visible hang — an app with no way out —
-//! is gone either way.
+//! The obvious shape, a `tokio::select!` over `child.wait()` and a cancel
+//! future, does not survive contact with the borrow checker: both arms need
+//! `&mut child`. The next one, `Arc<Mutex<Child>>` shared with the cancelling
+//! call, deadlocks — the op holds the lock across `wait()`, which is precisely
+//! the await the killer needs to interrupt.
+//!
+//! So [`Registration::attach`] records the child's pid in the registry, and
+//! [`cancel`] signals that pid **directly, from the cancelling call's own
+//! task** — `cancel_network_op` never touches the op's `Child` at all. The op
+//! then **notices**: its `wait()`/`wait_with_output()` returns because the
+//! child is dead, and it checks [`Registration::is_cancelled`] before mapping
+//! stderr to an error.
+//!
+//! ## SIGTERM first, to the child's own process group; SIGKILL on a second ask
+//!
+//! Two things were wrong with the pre-#263 behaviour (an immediate
+//! `start_kill()` / `kill_on_drop`, i.e. always `SIGKILL`, always just the one
+//! child):
+//!
+//! * **Wrong signal.** Git installs `remove_lock_file_on_signal` (`lockfile.c`)
+//!   for SIGINT / SIGHUP / SIGTERM / SIGQUIT / SIGPIPE — **SIGKILL is
+//!   uncatchable**, so a SIGKILLed git never runs it. A cancel that lands while
+//!   a fetch is writing refs could strand `.git/FETCH_HEAD.lock`, and the next
+//!   fetch fails with "Unable to create '…/FETCH_HEAD.lock': File exists." A
+//!   cancel button whose after-effect is a broken repository is worse than no
+//!   cancel button. [`kill_tree`] sends `SIGTERM` first, giving git the same
+//!   chance to clean up after itself that Ctrl-C would.
+//! * **Wrong process.** `git clone`/`fetch`/`pull`/`push` spawns
+//!   `git-remote-https` (https) or `ssh` (ssh) to do the actual transfer; a
+//!   SIGKILLed **parent** cannot take that child with it, so it survives until
+//!   its own blocked read times out. `proc::git_async`/`git_async_in` now put
+//!   the child in its own process group (`process_group(0)`), and `kill_tree`
+//!   signals the **group**, reaching the transport helper too.
+//!
+//! A **second** cancel of the same op escalates straight to `SIGKILL`: the
+//! user clicking Cancel again is the escalation signal, so there is no timer
+//! and no rule for how long the first click gets to work. [`kill_tree`] checks
+//! `getpgid(pid) == pid` before using `killpg` — a future spawn site that
+//! forgot `process_group(0)` degrades to a single-process kill instead of
+//! signalling our OWN process group, i.e. the app, from a cancel button.
+//!
+//! Windows has no SIGTERM, and a `CREATE_NO_WINDOW` child has no console for
+//! `GenerateConsoleCtrlEvent` to signal — so there, `kill_tree` is always the
+//! forceful `taskkill /F /T`, tree and all, on both the soft and hard call.
+//! Git gets no chance to clean up its lock files on Windows; that gap is
+//! documented, not fixed, here.
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
-
-use tokio::sync::watch;
+use std::sync::{Mutex, OnceLock};
 
 /// What a cancellation request addresses.
 ///
@@ -69,48 +103,74 @@ impl Scope {
     }
 }
 
-/// The receiving half handed to a running op.
-///
-/// Cloneable and cheap; `cancelled()` resolves once and stays resolved, so an
-/// op may await it in several places (a read loop, then the final `wait`)
-/// without arming anything twice.
-#[derive(Debug, Clone)]
-pub struct CancelToken {
-    rx: watch::Receiver<bool>,
-}
-
-impl CancelToken {
-    /// Resolves when this op has been cancelled, and never otherwise.
-    ///
-    /// A `watch` receiver errors when every sender is gone. That means "nothing
-    /// can ever cancel this op", which must NOT read as "cancelled" — a spurious
-    /// resolve here would kill a healthy clone. The [`Registration`] holds a
-    /// sender for as long as the op runs, so the error branch is unreachable in
-    /// practice; it parks forever rather than trusting that.
-    pub async fn cancelled(&mut self) {
-        if self.rx.wait_for(|v| *v).await.is_err() {
-            std::future::pending::<()>().await;
-        }
-    }
-
-    /// Whether cancellation has already been requested, without awaiting.
-    ///
-    /// The call sites use this after the child has exited: a `select!` can lose
-    /// the race when git dies of its own accord at the same moment, and a
-    /// cancelled op must report `Cancelled` rather than whatever git's dying
-    /// stderr happened to say.
-    pub fn is_cancelled(&self) -> bool {
-        *self.rx.borrow()
-    }
-}
-
 /// A live op's entry in the registry. Removed on drop, so a finished op cannot
 /// be "cancelled" into a later, unrelated one.
 #[derive(Debug)]
+struct Entry {
+    id: u64,
+    scope: Scope,
+    /// The child's pid, once [`Registration::attach`] has recorded it. `None`
+    /// in the window between registration and spawn — a `cancel()` landing
+    /// then has nothing to signal yet, so it only marks `cancel_requested`;
+    /// `attach` is what closes that window (see its doc comment).
+    pid: Option<u32>,
+    /// Whether `cancel()` has been called for this entry at least once. The
+    /// FIRST call is a `SIGTERM`; every call after that escalates to
+    /// `SIGKILL` — see the module docs.
+    cancel_requested: bool,
+}
+
+fn registry() -> &'static Mutex<Vec<Entry>> {
+    static REGISTRY: OnceLock<Mutex<Vec<Entry>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// A live op's handle into the registry. Deregisters on drop, so a later
+/// cancel signal cannot reach a pid that has since been recycled by the OS.
+#[derive(Debug)]
 pub struct Registration {
     id: u64,
-    /// Kept so the sender outlives the op — see [`CancelToken::cancelled`].
-    _tx: Arc<watch::Sender<bool>>,
+}
+
+impl Registration {
+    /// Record the pid of the child just spawned under this registration.
+    ///
+    /// Returns `false` when a cancel already landed in the window between
+    /// [`register`] and the spawn — `cancel()` found no pid to signal that
+    /// time, so it could only mark the entry, and nothing has been signalled
+    /// at the OS level yet. The caller must then kill and reap the child
+    /// itself (it still holds `&mut Child` right there) and report
+    /// `AppError::Cancelled`, exactly as if the OS-level kill had already run.
+    pub fn attach(&self, pid: u32) -> bool {
+        let mut live = registry().lock().unwrap_or_else(|e| e.into_inner());
+        match live.iter_mut().find(|e| e.id == self.id) {
+            Some(entry) => {
+                entry.pid = Some(pid);
+                !entry.cancel_requested
+            }
+            // Deregistered already, somehow — treat it the same as "already
+            // cancelled" rather than silently letting the child run.
+            None => false,
+        }
+    }
+
+    /// Whether `cancel()` has been called for this op, without awaiting
+    /// anything.
+    ///
+    /// The call sites use this after the child has exited — including a
+    /// child that died of its own accord at the same moment `cancel()` ran —
+    /// because the request is what decides the outcome, not who got there
+    /// first: git's dying stderr must not be reported as a `Network` failure
+    /// to a user who pressed Cancel.
+    pub fn is_cancelled(&self) -> bool {
+        registry()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .iter()
+            .find(|e| e.id == self.id)
+            .map(|e| e.cancel_requested)
+            .unwrap_or(true)
+    }
 }
 
 impl Drop for Registration {
@@ -120,53 +180,129 @@ impl Drop for Registration {
     }
 }
 
-#[derive(Debug)]
-struct Entry {
-    id: u64,
-    scope: Scope,
-    tx: Arc<watch::Sender<bool>>,
-}
-
-fn registry() -> &'static Mutex<Vec<Entry>> {
-    static REGISTRY: OnceLock<Mutex<Vec<Entry>>> = OnceLock::new();
-    REGISTRY.get_or_init(|| Mutex::new(Vec::new()))
-}
-
 /// Announce a network op as cancellable, until the returned guard is dropped.
 ///
 /// A `Vec` and not a map: this holds the ops in flight right now — a handful at
 /// the very worst — and a scope legitimately has several entries (the auto-fetch
 /// pile the module docs describe), which a keyed map would have had to model
 /// anyway.
-pub fn register(scope: Scope) -> (Registration, CancelToken) {
+pub fn register(scope: Scope) -> Registration {
     static NEXT_ID: AtomicU64 = AtomicU64::new(0);
     let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
-    let (tx, rx) = watch::channel(false);
-    let tx = Arc::new(tx);
     registry()
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .push(Entry {
             id,
             scope,
-            tx: Arc::clone(&tx),
+            pid: None,
+            cancel_requested: false,
         });
-    (Registration { id, _tx: tx }, CancelToken { rx })
+    Registration { id }
 }
 
 /// Cancel every op registered under `scope`. Answers how many were signalled,
 /// which is 0 when nothing was running — not an error: the op can simply have
 /// finished between the user reading the status line and clicking Cancel.
+///
+/// Escalates per-entry: an entry cancelled for the first time gets `SIGTERM`
+/// (to its process group); an entry that was already asked to stop gets
+/// `SIGKILL`, because a second click is the user telling us the first one did
+/// not work.
 pub fn cancel(scope: &Scope) -> usize {
-    let live = registry().lock().unwrap_or_else(|e| e.into_inner());
+    let mut live = registry().lock().unwrap_or_else(|e| e.into_inner());
     let mut signalled = 0;
-    for entry in live.iter().filter(|e| &e.scope == scope) {
-        // A send failure means every receiver is gone, i.e. the op is already
-        // unwinding. Still counts as handled from the caller's point of view.
-        let _ = entry.tx.send(true);
+    for entry in live.iter_mut().filter(|e| &e.scope == scope) {
+        let hard = entry.cancel_requested;
+        entry.cancel_requested = true;
+        if let Some(pid) = entry.pid {
+            kill_tree(pid, hard);
+        }
         signalled += 1;
     }
     signalled
+}
+
+/// Kill `pid` and everything spawned into its process group.
+///
+/// # Why the process group
+///
+/// `git clone` over https spawns `git-remote-https`; over ssh it spawns `ssh`.
+/// Killing only `git` leaves that child holding the connection, so the
+/// transfer the user cancelled carries on. `proc::git_async`/`git_async_in`
+/// put the child in its own group (`process_group(0)`); this signals the
+/// whole group.
+///
+/// # Why SIGTERM first
+///
+/// Git installs signal handlers that remove its lock files (`lockfile.c`) and,
+/// in `clone`, the partially-written destination (`remove_junk_on_signal`).
+/// `SIGKILL` skips all of it, so a SIGKILLed pull can leave `.git/index.lock`
+/// behind, and the *next* pull fails with "Unable to create '…/index.lock':
+/// File exists." — a cancel that breaks the following operation is worse than
+/// no cancel. `hard` is `true` only on the second (or later) cancel of the
+/// same op.
+#[cfg(unix)]
+fn kill_tree(pid: u32, hard: bool) {
+    let sig = if hard { libc::SIGKILL } else { libc::SIGTERM };
+    let pid = pid as libc::pid_t;
+    // `getpgid` first, and `killpg` ONLY when the child really is its own
+    // group leader. `proc::git_async`/`git_async_in` put it in one, but a
+    // future spawn site that forgot would otherwise have this signal OUR OWN
+    // process group — i.e. kill the app, from a cancel button. The check
+    // makes that unreachable rather than merely unlikely.
+    let group_leader = unsafe { libc::getpgid(pid) } == pid;
+    unsafe {
+        if group_leader {
+            libc::killpg(pid, sig);
+        } else {
+            libc::kill(pid, sig);
+        }
+    }
+}
+
+/// The Windows tree-kill's argv.
+///
+/// A pure function, compiled and tested on every platform even though only
+/// Windows runs it — the same split `reveal.rs` uses for its per-platform
+/// argv, and for the same reason: `#[cfg(windows)]` code is invisible to this
+/// repo's PR CI (only `release.yml` builds Windows), so a mistake here would
+/// surface at release time. Keeping the interesting half platform-independent
+/// leaves three lines of genuinely conditional code.
+///
+/// * `/T` — the whole tree. `git` is rarely the process actually blocked on
+///   the network; this is Windows' answer to the process group unix gets from
+///   `killpg`.
+/// * `/F` — forced. There is no graceful option for a console child spawned
+///   with `CREATE_NO_WINDOW`: it has no console for `GenerateConsoleCtrlEvent`
+///   to signal, and a plain `taskkill` sends a `WM_CLOSE` a console app
+///   ignores.
+#[cfg_attr(not(windows), allow(dead_code))]
+pub(crate) fn taskkill_args(pid: u32) -> [String; 4] {
+    [
+        "/F".to_string(),
+        "/T".to_string(),
+        "/PID".to_string(),
+        pid.to_string(),
+    ]
+}
+
+/// Windows has no `SIGTERM`, so git gets no chance to remove its lock files —
+/// see [`taskkill_args`]. The `hard` distinction that matters on unix collapses
+/// to one behaviour here; documented in `docs/dev/backend.md` as a known,
+/// accepted gap rather than something this fixes.
+///
+/// Fire-and-forget: `taskkill` is spawned and not awaited, so a slow-to-die
+/// tree cannot make a click on Cancel itself hang.
+#[cfg(windows)]
+fn kill_tree(pid: u32, _hard: bool) {
+    // Through `proc::program` — `tests/spawn_no_window.rs` fails the build on
+    // a raw `Command::new` anywhere outside `proc.rs`.
+    let _ = crate::proc::program("taskkill")
+        .args(taskkill_args(pid))
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
 }
 
 #[cfg(test)]
@@ -177,7 +313,8 @@ mod tests {
     /// every test below addresses a scope only it names. `Scope::Clone` is the
     /// one scope that cannot be made unique — it is a unit variant — so the two
     /// tests that touch it serialize here instead. Without this, one test's
-    /// `cancel(&Scope::Clone)` reaches the other's token and both are flaky.
+    /// `cancel(&Scope::Clone)` reaches the other's registration and both are
+    /// flaky.
     fn clone_scope_lock() -> std::sync::MutexGuard<'static, ()> {
         static LOCK: Mutex<()> = Mutex::new(());
         LOCK.lock().unwrap_or_else(|e| e.into_inner())
@@ -186,36 +323,36 @@ mod tests {
     #[test]
     fn cancel_signals_a_registered_op() {
         let scope = Scope::repo(Path::new("/tmp/signal-one"));
-        let (_guard, token) = register(scope.clone());
-        assert!(!token.is_cancelled());
+        let registration = register(scope.clone());
+        assert!(!registration.is_cancelled());
         assert_eq!(cancel(&scope), 1);
-        assert!(token.is_cancelled());
+        assert!(registration.is_cancelled());
     }
 
     #[test]
     fn a_clone_is_cancellable_without_a_repository() {
         let _serialized = clone_scope_lock();
-        let (_guard, token) = register(Scope::Clone);
+        let registration = register(Scope::Clone);
         assert_eq!(cancel(&Scope::Clone), 1);
-        assert!(token.is_cancelled());
+        assert!(registration.is_cancelled());
     }
 
     #[test]
     fn dropping_the_guard_deregisters() {
-        let (guard, _token) = register(Scope::repo(Path::new("/tmp/deregister")));
-        drop(guard);
+        let registration = register(Scope::repo(Path::new("/tmp/deregister")));
+        drop(registration);
         assert_eq!(cancel(&Scope::repo(Path::new("/tmp/deregister"))), 0);
     }
 
     #[test]
     fn scopes_do_not_bleed_into_each_other() {
-        let (_a, token_a) = register(Scope::repo(Path::new("/tmp/a")));
-        let (_b, token_b) = register(Scope::repo(Path::new("/tmp/b")));
+        let a = register(Scope::repo(Path::new("/tmp/a")));
+        let b = register(Scope::repo(Path::new("/tmp/b")));
 
         assert_eq!(cancel(&Scope::repo(Path::new("/tmp/b"))), 1);
 
-        assert!(!token_a.is_cancelled(), "/tmp/a must be untouched");
-        assert!(token_b.is_cancelled());
+        assert!(!a.is_cancelled(), "/tmp/a must be untouched");
+        assert!(b.is_cancelled());
     }
 
     /// The auto-fetch pile: several ops share one scope, and Cancel has to
@@ -223,23 +360,13 @@ mod tests {
     #[test]
     fn one_cancel_reaches_every_op_in_the_scope() {
         let path = Path::new("/tmp/pile");
-        let (_g1, t1) = register(Scope::repo(path));
-        let (_g2, t2) = register(Scope::repo(path));
-        let (_g3, t3) = register(Scope::repo(path));
+        let g1 = register(Scope::repo(path));
+        let g2 = register(Scope::repo(path));
+        let g3 = register(Scope::repo(path));
 
         assert_eq!(cancel(&Scope::repo(path)), 3);
 
-        assert!(t1.is_cancelled() && t2.is_cancelled() && t3.is_cancelled());
-    }
-
-    #[tokio::test]
-    async fn cancelled_resolves_after_the_signal_and_stays_resolved() {
-        let (_guard, mut token) = register(Scope::repo(Path::new("/tmp/await")));
-        cancel(&Scope::repo(Path::new("/tmp/await")));
-        // Both awaits must return; a second one that parked would hang the
-        // `select!` in `run_clone`'s final `wait`.
-        token.cancelled().await;
-        token.cancelled().await;
+        assert!(g1.is_cancelled() && g2.is_cancelled() && g3.is_cancelled());
     }
 
     /// A clone's scope must not be cancelled by a repo op — cancelling a fetch
@@ -247,9 +374,154 @@ mod tests {
     #[test]
     fn a_repo_cancel_leaves_the_clone_alone() {
         let _serialized = clone_scope_lock();
-        let (_c, clone_token) = register(Scope::Clone);
-        let (_r, _repo_token) = register(Scope::repo(Path::new("/tmp/other")));
+        let clone_reg = register(Scope::Clone);
+        let _repo_reg = register(Scope::repo(Path::new("/tmp/other")));
         cancel(&Scope::repo(Path::new("/tmp/other")));
-        assert!(!clone_token.is_cancelled());
+        assert!(!clone_reg.is_cancelled());
+    }
+
+    #[test]
+    fn attach_accepts_while_the_op_is_live() {
+        let registration = register(Scope::repo(Path::new("/tmp/attach-live")));
+        assert!(registration.attach(999_999));
+    }
+
+    /// The window `attach` exists for: Cancel clicked between `register` and
+    /// the spawn. No pid is on file yet, so `cancel()` could only mark the
+    /// entry — `attach` must hand that back so the caller kills the child it
+    /// is holding instead of letting it run unnoticed.
+    #[test]
+    fn attach_refuses_after_a_cancel_has_landed_first() {
+        let scope = Scope::repo(Path::new("/tmp/attach-race"));
+        let registration = register(scope.clone());
+        cancel(&scope);
+        assert!(!registration.attach(999_999));
+    }
+
+    #[test]
+    fn cancelling_before_any_op_registers_is_not_an_error() {
+        assert_eq!(cancel(&Scope::repo(Path::new("/tmp/never-registered"))), 0);
+    }
+
+    /// Runs everywhere, kills only on Windows. `/T` is the load-bearing flag:
+    /// without it the transport helper (`git-remote-https`, `ssh`) survives
+    /// the cancel and the transfer carries on.
+    #[test]
+    fn the_windows_tree_kill_asks_for_the_whole_tree_by_pid() {
+        assert_eq!(
+            taskkill_args(4321),
+            [
+                "/F".to_string(),
+                "/T".to_string(),
+                "/PID".to_string(),
+                "4321".to_string()
+            ]
+        );
+    }
+
+    // --- kill_tree (unix): real child processes, real signals ---
+    //
+    // Spawned via `crate::proc::program` rather than a bare `Command::new`, like
+    // every other spawn in this crate (`tests/spawn_no_window.rs` fails the
+    // build on one outside `proc.rs`) — `process_group`/`arg` are still just
+    // `std::process::Command` methods, chained on afterwards.
+
+    #[cfg(unix)]
+    fn spawn_own_group(program: &str, arg: &str) -> std::process::Child {
+        use std::os::unix::process::CommandExt as _;
+        crate::proc::program(program)
+            .arg(arg)
+            .process_group(0)
+            .spawn()
+            .unwrap_or_else(|e| panic!("spawn {program} {arg}: {e}"))
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn kill_tree_soft_sends_sigterm() {
+        let mut child = spawn_own_group("sleep", "30");
+        kill_tree(child.id(), false);
+        let status = child.wait().expect("wait");
+        use std::os::unix::process::ExitStatusExt as _;
+        assert_eq!(
+            status.signal(),
+            Some(libc::SIGTERM),
+            "the first cancel must ask nicely, not SIGKILL"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn kill_tree_hard_sends_sigkill() {
+        let mut child = spawn_own_group("sleep", "30");
+        kill_tree(child.id(), true);
+        let status = child.wait().expect("wait");
+        use std::os::unix::process::ExitStatusExt as _;
+        assert_eq!(
+            status.signal(),
+            Some(libc::SIGKILL),
+            "a second cancel of the same op must escalate"
+        );
+    }
+
+    /// The whole reason for the process group: a sibling spawned into the same
+    /// group (standing in for `git-remote-https`/`ssh`) must die too, or the
+    /// transfer the user cancelled carries on underneath them.
+    #[cfg(unix)]
+    #[test]
+    fn kill_tree_reaches_every_process_in_the_group() {
+        use std::os::unix::process::CommandExt as _;
+        let mut leader = spawn_own_group("sleep", "30");
+        let pgid = leader.id() as i32;
+        let mut sibling = crate::proc::program("sleep")
+            .arg("30")
+            .process_group(pgid) // joins the leader's group, not its own
+            .spawn()
+            .expect("spawn sibling");
+
+        kill_tree(leader.id(), true);
+
+        use std::os::unix::process::ExitStatusExt as _;
+        assert_eq!(
+            leader.wait().expect("wait leader").signal(),
+            Some(libc::SIGKILL)
+        );
+        assert_eq!(
+            sibling.wait().expect("wait sibling").signal(),
+            Some(libc::SIGKILL),
+            "a sibling in the same process group must be reached too — this is \
+             what closes the git-remote-https/ssh helper gap"
+        );
+    }
+
+    /// A future spawn site that forgot `process_group(0)` inherits OUR group —
+    /// `kill_tree` must notice the target is not its own group leader and fall
+    /// back to a single-process kill, or a cancel button would signal every
+    /// process in the app's own group.
+    #[cfg(unix)]
+    #[test]
+    fn kill_tree_falls_back_to_a_single_kill_when_the_pid_is_not_a_group_leader() {
+        let mut unrelated = spawn_own_group("sleep", "30");
+        // No `.process_group(0)`: inherits the TEST PROCESS's group, so this
+        // pid is not its own leader.
+        let mut not_a_leader = crate::proc::program("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn not_a_leader");
+
+        kill_tree(not_a_leader.id(), true);
+
+        use std::os::unix::process::ExitStatusExt as _;
+        assert_eq!(
+            not_a_leader.wait().expect("wait").signal(),
+            Some(libc::SIGKILL),
+            "still killed, just via a single kill() rather than killpg()"
+        );
+        assert!(
+            unrelated.try_wait().expect("try_wait").is_none(),
+            "an unrelated process group must not have been reached"
+        );
+        let _ = unrelated.kill();
+        let _ = unrelated.wait();
     }
 }

--- a/src-tauri/src/commands/create.rs
+++ b/src-tauri/src/commands/create.rs
@@ -199,6 +199,13 @@ pub fn clone_args(url: &str, name: &str, opts: &CloneOptions) -> Vec<String> {
 /// Keeps `run_git`'s environment exactly (`commands/branches.rs`): prompts are
 /// hard-disabled, so a private repo works only when the user's credential
 /// helper or SSH agent answers without a TTY. Returns the destination path.
+///
+/// Cancellable (#234, #263): registers under `cancel::Scope::Clone` for as long
+/// as it runs. `cancel_network_op` kills the child directly, by pid, from its
+/// own task — SIGTERM to the whole process group first, escalating to SIGKILL
+/// on a second cancel (see `cancel.rs`). This function only notices: a read or
+/// `wait` returns because the child died, and every exit path checks
+/// `registration.is_cancelled()` before trusting what git's dying stderr says.
 pub async fn run_clone(
     url: &str,
     parent: &Path,
@@ -265,8 +272,9 @@ pub async fn run_clone(
         // `.wait()`ed. Without this, git keeps running to completion in the
         // background and finishes populating the destination the frontend was
         // told never got created. A user-driven cancel does NOT rely on this —
-        // it kills and reaps explicitly, so the process is provably gone before
-        // the partial directory is removed.
+        // `cancel_network_op` kills the process directly, by pid (#263), and
+        // this function reaps it explicitly before the partial directory is
+        // removed, so the process is provably gone first.
         .kill_on_drop(true);
     // Shared with fetch/pull/push so the env policy cannot drift (#61 D5).
     // With credentials this points askpass at our own executable; without them
@@ -277,11 +285,31 @@ pub async fn run_clone(
     // Registered before the spawn so a cancel arriving in the same tick as the
     // click cannot slip through the gap and be ignored (#234). The guard
     // deregisters on every exit path, including the `?`s below.
-    let (_registration, mut cancel) = crate::cancel::register(crate::cancel::Scope::Clone);
+    let registration = crate::cancel::register(crate::cancel::Scope::Clone);
+
+    // Cancelled between the click and here — do not start a transfer nobody
+    // is waiting for.
+    if registration.is_cancelled() {
+        return Err(cancelled_clone(&target, target_preexisted).await);
+    }
 
     let mut child = cmd
         .spawn()
         .map_err(|e| AppError::Io(format!("failed to run git clone: {e}")))?;
+
+    // `id()` answers `None` once the child has already been reaped, so read it
+    // right away. Recording it is what lets `cancel_network_op` reach this
+    // exact process (#263) — before this, cancelling only ever reached the
+    // `git` we spawned, never its `git-remote-https`/`ssh` transport helper.
+    if let Some(pid) = child.id() {
+        if !registration.attach(pid) {
+            // A cancel landed in the window between the check above and the
+            // spawn. `cancel()` found no pid to signal that time, so nothing
+            // has been killed yet — do it here, now that we hold the child.
+            kill_and_reap(&mut child).await;
+            return Err(cancelled_clone(&target, target_preexisted).await);
+        }
+    }
 
     let mut stderr = child
         .stderr
@@ -296,22 +324,19 @@ pub async fn run_clone(
 
     loop {
         // Where a stalled clone actually sits: git has the connection open and
-        // is saying nothing, so this read never completes. Selecting on the
-        // cancel token here is what turns "force-quit the app" into a button
-        // (#234). `stderr` was `take()`n off the child, so borrowing `child`
-        // mutably in the cancel arm is not a conflict.
-        let read = tokio::select! {
-            // `biased` so a pending cancel always beats a ready read. Without
-            // it `select!` picks at random, and a fast-streaming clone would
-            // keep winning the coin toss for an unbounded number of iterations
-            // after the user had already pressed Cancel.
-            biased;
-            _ = cancel.cancelled() => {
-                kill_and_reap(&mut child).await;
-                return Err(cancelled_clone(&target, target_preexisted).await);
-            }
-            r = stderr.read(&mut chunk) => {
-                r.map_err(|e| AppError::Io(format!("reading git clone output: {e}")))?
+        // is saying nothing, so this read never completes on its own. What
+        // unsticks it is `cancel_network_op` killing the process directly, by
+        // pid, from its own task (#263, see `cancel.rs`) — not anything this
+        // loop does. `read` then returns because the pipe closed underneath
+        // it, either as EOF (the common case) or as an error.
+        let read = match stderr.read(&mut chunk).await {
+            Ok(n) => n,
+            Err(e) => {
+                if registration.is_cancelled() {
+                    let _ = child.wait().await;
+                    return Err(cancelled_clone(&target, target_preexisted).await);
+                }
+                return Err(AppError::Io(format!("reading git clone output: {e}")));
             }
         };
         if read == 0 {
@@ -322,24 +347,16 @@ pub async fn run_clone(
     reader.finish(&mut on_progress);
     let tail = reader.into_tail();
 
-    // Stderr at EOF means git has closed it, which it only does on the way out —
-    // so this rarely waits. Selected on anyway: "rarely" is not "never", and a
-    // clone that hung between its last progress line and exiting would otherwise
-    // be exactly the unkillable one this issue is about.
-    let status = tokio::select! {
-        biased;
-        _ = cancel.cancelled() => {
-            kill_and_reap(&mut child).await;
-            return Err(cancelled_clone(&target, target_preexisted).await);
-        }
-        s = child.wait() => s.map_err(|e| AppError::Io(format!("waiting for git clone: {e}")))?,
-    };
-    // The cancel landed while git was already exiting and lost the `select!`
-    // race. It still cancelled: a clone the user asked us to stop is not one to
-    // hand back and open a tab for, and git's exit status — a success, or the
-    // torn-connection failure our own SIGKILL produced — is not what they should
-    // be told about. `child` is already reaped here, so only the directory goes.
-    if cancel.is_cancelled() {
+    let status = child
+        .wait()
+        .await
+        .map_err(|e| AppError::Io(format!("waiting for git clone: {e}")))?;
+    // BEFORE `map_git_failure`: a cancelled clone's git dies mid-transfer, and
+    // its last stderr line reads like a network failure — or, on a bad day,
+    // like an auth failure, which would pop the credential dialog over a
+    // cancel. `child` is already reaped by the `wait` above, so only the
+    // directory goes.
+    if registration.is_cancelled() {
         return Err(cancelled_clone(&target, target_preexisted).await);
     }
     if !status.success() {
@@ -354,12 +371,19 @@ pub async fn run_clone(
     Ok(target)
 }
 
-/// Kill a cancelled `git clone` and wait for it to actually be gone (#234).
+/// Kill a cancelled `git clone` and wait for it to actually be gone.
 ///
-/// `kill_on_drop` would eventually do the killing, but "eventually" is the wrong
-/// guarantee here: [`cancelled_clone`] deletes the destination next, and a git
-/// process still writing objects into a directory being deleted is a race with
-/// nothing good on either side of it. Reaping first makes the order provable.
+/// The ONE caller left is the narrow race `Registration::attach` documents:
+/// a cancel that landed between registering and spawning, before
+/// `cancel_network_op` had a pid to signal. Every other cancellation is
+/// already killed by the time this function's callers see it — by
+/// `cancel::kill_tree`, from the cancelling call's own task — and only needs
+/// reaping, not a second kill; see `run_clone`.
+///
+/// A hard kill (not the SIGTERM-first escalation `kill_tree` otherwise does):
+/// this window is too small to matter, and there is no second click to wait
+/// for here — the child was never far enough along to leave a lock file, since
+/// it has not sent us so much as one byte of progress yet.
 ///
 /// Errors are swallowed on purpose — every one of them means "the process is
 /// already gone", which is the outcome being asked for.

--- a/src-tauri/src/commands/net.rs
+++ b/src-tauri/src/commands/net.rs
@@ -90,12 +90,18 @@ pub fn map_git_failure(stderr: &str) -> AppError {
 
 /// Run `git -C cwd <args>`, mapping a non-zero exit through `map_git_failure`.
 ///
-/// Cancellable (#234): the op registers under `cancel::Scope::Repo(cwd)` for as
-/// long as it runs, so `cancel_network_op` can stop a fetch, pull or push that
-/// has stalled. Registering HERE and not per command is the same choice the
-/// credential policy makes — a network op that grew its own spawn would be one
-/// nobody can cancel. `cwd` comes from `GitBackend::repo_path`, which is where
-/// `cancel_network_op` resolves its scope from too.
+/// Cancellable (#234, #263): the op registers under `cancel::Scope::Repo(cwd)`
+/// for as long as it runs, so `cancel_network_op` can stop a fetch, pull or
+/// push that has stalled. Registering HERE and not per command is the same
+/// choice the credential policy makes — a network op that grew its own spawn
+/// would be one nobody can cancel. `cwd` comes from `GitBackend::repo_path`,
+/// which is where `cancel_network_op` resolves its scope from too.
+///
+/// `cancel_network_op` kills the child directly, by pid, from its own task —
+/// SIGTERM to the whole process group first, escalating to SIGKILL on a second
+/// cancel (`cancel::kill_tree`). This function does not select on anything; it
+/// just notices that `wait_with_output` returned because the child died, and
+/// checks `is_cancelled()` before trusting what git's dying stderr says.
 pub async fn run_git_authenticated(
     cwd: &Path,
     args: &[&str],
@@ -126,24 +132,46 @@ pub async fn run_git_authenticated_with_progress(
 ) -> AppResult<()> {
     // `proc::git_async` carries GIT_TERMINAL_PROMPT=0 (which `apply_auth_env`
     // sets too), a closed stdin — nothing feeds it, so an unexpected read would
-    // block forever — and, on Windows, CREATE_NO_WINDOW: without it every fetch,
+    // block forever — on Windows CREATE_NO_WINDOW: without it every fetch,
     // pull and push flashed a console, including the ones auto-fetch runs on a
-    // timer with no user action at all (issue 172).
+    // timer with no user action at all (issue 172) — and, on unix, its own
+    // process group, which `cancel::kill_tree` signals (issue 263).
     let mut cmd = crate::proc::git_async(cwd);
     cmd.args(args)
         // Discarded, and always was — this function returns `()`. Nulling it now
         // also keeps a chatty op from filling a pipe nobody drains.
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
-        // The kill on cancel: the branches below return without reaping, which
-        // drops the `Child`, and a dropped `Child` with this set is a killed
-        // process. Also covers the window closing mid-fetch.
+        // Backstop for a dropped future (e.g. the window closing mid-fetch) —
+        // NOT what the ordinary cancel path relies on, which kills this child
+        // by pid instead of dropping it. See `cancel.rs`.
         .kill_on_drop(true);
     apply_auth_env(&mut cmd, creds);
 
-    let (_registration, mut cancel) = crate::cancel::register(crate::cancel::Scope::repo(cwd));
+    let registration = crate::cancel::register(crate::cancel::Scope::repo(cwd));
+
+    // Cancelled between the click and here — do not start a fetch/pull/push
+    // nobody is waiting for.
+    if registration.is_cancelled() {
+        return Err(AppError::Cancelled);
+    }
 
     let mut child = cmd.spawn().map_err(|e| AppError::Io(e.to_string()))?;
+    // `id()` answers `None` once the child has already been reaped, so read it
+    // right away. Recording it is what lets `cancel_network_op` reach this exact
+    // process — and, through its process group, git's `git-remote-https`/`ssh`
+    // transport helper (#263).
+    if let Some(pid) = child.id() {
+        if !registration.attach(pid) {
+            // A cancel landed in the window between the check above and the
+            // spawn. `cancel()` found no pid to signal that time, so nothing has
+            // been killed yet — do it here, now that we hold the child.
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            return Err(AppError::Cancelled);
+        }
+    }
+
     let mut stderr = child
         .stderr
         .take()
@@ -153,17 +181,30 @@ pub async fn run_git_authenticated_with_progress(
     let mut chunk = [0u8; 4096];
     loop {
         // Where a stalled fetch actually sits: the connection is open and the
-        // remote is saying nothing, so this read never completes. Selecting on
-        // the cancel token here is what keeps Cancel working (#234) now that the
-        // wait is spread across many reads instead of one `wait_with_output`.
-        let read = tokio::select! {
-            // `biased` so a pending cancel is never lost to a coin toss against a
-            // child that happens to be ready in the same poll. Without it, a
-            // fast-streaming fetch would keep winning that toss for an unbounded
-            // number of iterations after the user had already pressed Cancel.
-            biased;
-            _ = cancel.cancelled() => return Err(AppError::Cancelled),
-            r = stderr.read(&mut chunk) => r.map_err(|e| AppError::Io(e.to_string()))?,
+        // remote is saying nothing, so this read never completes on its own.
+        // What unsticks it is `cancel_network_op` killing the process directly,
+        // by pid, from its OWN task (#263) — not anything this loop does. The
+        // read then returns because the pipe closed underneath it, as EOF in the
+        // common case or as an error.
+        //
+        // #296 selected on the cancel token here instead, which returned the
+        // instant Cancel was clicked. That is the one thing given up by killing
+        // out-of-band, and deliberately: returning early drops the `Child`, and
+        // `kill_on_drop` is a SIGKILL — the uncatchable signal that skips git's
+        // own `remove_lock_file_on_signal` and strands `.git/FETCH_HEAD.lock`,
+        // which is the whole bug #263 is about. So the op waits for the child it
+        // asked to stop, and the SECOND click is what escalates to SIGKILL for a
+        // git that ignores the first (the status bar says so — see
+        // `docs/dev/frontend.md`).
+        let read = match stderr.read(&mut chunk).await {
+            Ok(n) => n,
+            Err(e) => {
+                if registration.is_cancelled() {
+                    let _ = child.wait().await;
+                    return Err(AppError::Cancelled);
+                }
+                return Err(AppError::Io(e.to_string()));
+            }
         };
         if read == 0 {
             break;
@@ -174,20 +215,26 @@ pub async fn run_git_authenticated_with_progress(
     let tail = reader.into_tail();
 
     // Stderr at EOF means git has closed it, which it only does on the way out,
-    // so this rarely waits — but "rarely" is not "never", and a git that hung
-    // after its last output would otherwise be the one op Cancel could not stop.
-    let status = tokio::select! {
-        biased;
-        _ = cancel.cancelled() => return Err(AppError::Cancelled),
-        s = child.wait() => s.map_err(|e| AppError::Io(e.to_string()))?,
-    };
+    // so this rarely waits.
+    let status = child
+        .wait()
+        .await
+        .map_err(|e| AppError::Io(e.to_string()))?;
 
     if !status.success() {
-        // A cancel that lands while git is already dying loses the `select!`
-        // race, and git's last words ("the remote end hung up unexpectedly")
-        // would then be reported as a network failure to a user who pressed
-        // Cancel. The request is what decides, not who got there first.
-        if cancel.is_cancelled() {
+        // BEFORE `map_git_failure`, and only on the failure path. A cancelled
+        // op's git dies mid-transfer and its last words ("the remote end hung up
+        // unexpectedly") would be reported as a network failure to a user who
+        // pressed Cancel — or, on a bad day, as an auth failure, which pops the
+        // credential dialog over a cancel. The request is what decides, not
+        // whether git happened to be exiting on its own already.
+        //
+        // Kept INSIDE this branch on purpose: an op that actually SUCCEEDED is
+        // reported as the success it was, even if a cancel for the scope landed
+        // in the same breath. Hoisting it would tell the user their completed
+        // fetch was cancelled and skip the `refreshAll` that shows the refs it
+        // just fetched.
+        if registration.is_cancelled() {
             return Err(AppError::Cancelled);
         }
         // The tail, not raw stderr: progress redraws are already filtered out of

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -290,6 +290,7 @@ pub fn git_async(workdir: &Path) -> tokio::process::Command {
     let mut cmd = program_async("git");
     cmd.arg("-C").arg(workdir);
     prompt_less_async(&mut cmd);
+    own_process_group(&mut cmd);
     cmd
 }
 
@@ -301,8 +302,32 @@ pub fn git_async_in(dir: &Path) -> tokio::process::Command {
     let mut cmd = program_async("git");
     cmd.current_dir(dir);
     prompt_less_async(&mut cmd);
+    own_process_group(&mut cmd);
     cmd
 }
+
+/// Put the child in its own process group (issue 263).
+///
+/// `cancel::kill_tree` signals a cancelled network op's WHOLE process group,
+/// which is what reaches `git-remote-https`/`ssh` — git's own child for the
+/// actual transfer, not ours, and invisible to a kill of `git` alone. Without
+/// its own group, that signal would land on OUR process group, i.e. the app.
+///
+/// No-op off unix: `tokio::process::Command::process_group` is unix-only, and
+/// Windows' tree-kill goes through `taskkill /T` instead, which addresses the
+/// process by pid and needs no group.
+///
+/// Applied only to the two ordinary git constructors above, deliberately NOT
+/// to [`git_async_keeping_console`]: that one child is an INTERACTIVE console
+/// mergetool, and moving it out of the terminal's foreground process group is
+/// what gets an unsuspecting process stopped by `SIGTTIN`/`SIGTTOU`.
+#[cfg(unix)]
+fn own_process_group(cmd: &mut tokio::process::Command) {
+    cmd.process_group(0);
+}
+
+#[cfg(not(unix))]
+fn own_process_group(_cmd: &mut tokio::process::Command) {}
 
 /// `git -C <workdir>` **keeping its console**, and inheriting stdio.
 ///
@@ -405,6 +430,53 @@ mod tests {
         let std = cmd.as_std();
         assert_eq!(std.get_current_dir(), Some(Path::new("/tmp/parent")));
         assert_eq!(std.get_args().count(), 0, "no -C for the clone path");
+    }
+
+    /// Issue 263: `cancel::kill_tree` signals a whole process group, which only
+    /// reaches `git-remote-https`/`ssh` if the `git` we spawned actually leads
+    /// one. Asserted against a REAL spawn — `Command`'s builder exposes no
+    /// getter for `process_group`, so the only way to see the decision take
+    /// effect is to look at the child's own `getpgid`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn git_async_and_git_async_in_spawn_their_own_process_group() {
+        for mut cmd in [git_async(Path::new(".")), git_async_in(Path::new("."))] {
+            let child = cmd
+                .arg("--version")
+                .stdout(Stdio::null())
+                .spawn()
+                .expect("spawn git --version");
+            let pid = child.id().expect("pid") as libc::pid_t;
+            assert_eq!(
+                unsafe { libc::getpgid(pid) },
+                pid,
+                "the child must be the leader of its own process group"
+            );
+            let mut child = child;
+            let _ = child.wait().await;
+        }
+    }
+
+    /// The interactive exception: moving `git mergetool`'s child OUT of the
+    /// terminal's foreground process group is what gets it stopped by
+    /// `SIGTTIN`/`SIGTTOU` the moment it tries to read or write the terminal.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn git_async_keeping_console_does_not_get_its_own_process_group() {
+        let mut cmd = git_async_keeping_console(Path::new("."));
+        let child = cmd
+            .arg("--version")
+            .stdout(Stdio::null())
+            .spawn()
+            .expect("spawn git --version");
+        let pid = child.id().expect("pid") as libc::pid_t;
+        assert_eq!(
+            unsafe { libc::getpgid(pid) },
+            unsafe { libc::getpgid(0) },
+            "an interactive child must stay in OUR process group, not get its own"
+        );
+        let mut child = child;
+        let _ = child.wait().await;
     }
 
     #[test]

--- a/src/features/create/CloneDialog.test.tsx
+++ b/src/features/create/CloneDialog.test.tsx
@@ -15,6 +15,7 @@ describe("CloneDialog", () => {
     useCreateStore.setState({
       open: "clone",
       busy: false,
+      cancelRequested: false,
       progress: null,
       error: null,
     });
@@ -105,6 +106,25 @@ describe("CloneDialog", () => {
     await waitFor(() => expect(cancelled).toBe(1));
     // And it does NOT close the dialog out from under the clone being reaped.
     expect(useCreateStore.getState().open).toBe("clone");
+  });
+
+  // #263: the backend escalates SIGTERM to SIGKILL on the second cancel of the
+  // same clone, and only the SIGTERM lets git clean up after itself. So the
+  // first click has to move the label — otherwise the button looks like it did
+  // nothing and the user double-clicks past the signal that matters.
+  it("relabels itself once the cancel has been asked for", async () => {
+    mockInvoke("cancel_network_op", () => 1);
+    useCreateStore.setState({ open: "clone", busy: true, progress: null });
+    render(<CloneDialog />);
+
+    const cancel = screen.getByTestId("clone-cancel");
+    expect(cancel).toHaveTextContent("Cancel clone");
+
+    fireEvent.click(cancel);
+
+    await waitFor(() => expect(cancel).toHaveTextContent("Force stop"));
+    // Still live: the second click is the escalation, so it must stay clickable.
+    expect(cancel).not.toBeDisabled();
   });
 
   it("closes the dialog with the same button when no clone is running", () => {

--- a/src/features/create/CloneDialog.tsx
+++ b/src/features/create/CloneDialog.tsx
@@ -20,6 +20,7 @@ export function CloneDialog() {
   const close = useCreateStore((s) => s.close);
   const runClone = useCreateStore((s) => s.runClone);
   const cancelClone = useCreateStore((s) => s.cancelClone);
+  const cancelRequested = useCreateStore((s) => s.cancelRequested);
   const setProgress = useCreateStore((s) => s.setProgress);
 
   const [url, setUrl] = React.useState("");
@@ -307,13 +308,18 @@ export function CloneDialog() {
 
           Deliberately NOT a second button next to it: a disabled "Cancel" beside
           a live "Stop" is the arrangement that teaches people the dialog is
-          stuck. The label carries the difference instead.
+          stuck. The label carries the difference instead — now for three states
+          rather than two (#263), because the second click on a running clone
+          escalates SIGTERM to SIGKILL and only the SIGTERM lets git clean up
+          its own lock files and partial destination. A button whose label did
+          not move on the first click would read as "nothing happened", and the
+          double-click that follows skips straight past the polite signal.
         */}
         <PGButton
           data-testid="clone-cancel"
           onClick={() => (busy ? void cancelClone() : close())}
         >
-          {busy ? "Cancel clone" : "Cancel"}
+          {busy ? (cancelRequested ? "Force stop" : "Cancel clone") : "Cancel"}
         </PGButton>
         <PGButton
           variant="primary"

--- a/src/features/create/useCreateStore.cancel.test.ts
+++ b/src/features/create/useCreateStore.cancel.test.ts
@@ -29,6 +29,7 @@ beforeEach(() => {
   useCreateStore.setState({
     open: "clone",
     busy: false,
+    cancelRequested: false,
     progress: null,
     error: null,
   });
@@ -137,4 +138,43 @@ it("still reports a clone that genuinely failed", async () => {
   });
 
   expect(useCreateStore.getState().error).toBe("repository not found");
+});
+
+// Same two-click escalation as the status bar (#263): only the first cancel
+// gives git the chance to remove its own lock files and partial destination.
+describe("the cancel is visible after the first click", () => {
+  it("marks the clone as cancelling", async () => {
+    useCreateStore.setState({ busy: true });
+    mockInvoke("cancel_network_op", () => 1);
+
+    await useCreateStore.getState().cancelClone();
+
+    expect(useCreateStore.getState().cancelRequested).toBe(true);
+  });
+
+  it("does not mark it when no clone is running", async () => {
+    mockInvoke("cancel_network_op", () => 1);
+
+    await useCreateStore.getState().cancelClone();
+
+    expect(useCreateStore.getState().cancelRequested).toBe(false);
+  });
+
+  it("starts every run un-cancelled", async () => {
+    // A retry after a cancelled clone must ask politely again rather than
+    // inheriting the previous run's second-click state and going straight to
+    // SIGKILL.
+    useCreateStore.setState({ cancelRequested: true });
+    mockInvoke("clone_repo", () => {
+      expect(useCreateStore.getState().cancelRequested).toBe(false);
+      throw { kind: "Cancelled" };
+    });
+
+    await useCreateStore.getState().runClone({
+      url: "https://example.com/repo.git",
+      parentDir: "/tmp",
+      name: "repo",
+      options: PLAIN,
+    });
+  });
 });

--- a/src/features/create/useCreateStore.ts
+++ b/src/features/create/useCreateStore.ts
@@ -28,6 +28,16 @@ type OpenDialog = "none" | "clone" | "init";
 interface CreateState {
   open: OpenDialog;
   busy: boolean;
+  /**
+   * Whether Cancel has already been clicked on the clone in flight (#263).
+   *
+   * The backend escalates SIGTERM → SIGKILL on the second cancel of the same
+   * op, so the first click has to visibly change something or the user has no
+   * way to tell it landed — and only SIGTERM gives git the chance to remove
+   * its own lock files and partial destination. Meaningful only while `busy`;
+   * every run clears it on the way in.
+   */
+  cancelRequested: boolean;
   progress: CloneProgress | null;
   error: string | null;
   openClone: () => void;
@@ -63,6 +73,7 @@ interface CreateState {
 export const useCreateStore = create<CreateState>((set, get) => ({
   open: "none",
   busy: false,
+  cancelRequested: false,
   progress: null,
   error: null,
 
@@ -92,10 +103,13 @@ export const useCreateStore = create<CreateState>((set, get) => ({
 
   async cancelClone() {
     if (!get().busy) return;
-    // Nothing is set here: `runClone`'s catch owns the transition back to idle.
-    // Clearing `busy` from here would unlock the dialog while git was still
-    // being reaped, and a second Clone could start into the directory the first
-    // one is in the middle of deleting.
+    // `cancelRequested` is the only thing set here, and it is UI intent, not op
+    // state (#263): the second click escalates to SIGKILL, so the first one has
+    // to be visible in the button. `runClone`'s catch still owns the transition
+    // back to idle — clearing `busy` from here would unlock the dialog while git
+    // was still being reaped, and a second Clone could start into the directory
+    // the first one is in the middle of deleting.
+    set({ cancelRequested: true });
     await cancelNetworkOp().catch((e) => {
       // A cancel that could not even be signalled leaves the user stuck with no
       // way out, which is the whole bug — so it gets said out loud, in the
@@ -105,7 +119,7 @@ export const useCreateStore = create<CreateState>((set, get) => ({
   },
 
   async runClone({ url, parentDir, name, options }) {
-    set({ busy: true, error: null, progress: null });
+    set({ busy: true, cancelRequested: false, error: null, progress: null });
 
     const attempt = async (creds?: Credentials) => {
       const dest = await cloneRepo(url, parentDir, name, options, creds);
@@ -148,7 +162,7 @@ export const useCreateStore = create<CreateState>((set, get) => ({
         host,
         kind,
         retry: async (creds, remember) => {
-          set({ busy: true, error: null, progress: null });
+          set({ busy: true, cancelRequested: false, error: null, progress: null });
           try {
             await attempt(creds);
             // Only after it worked, and only for HTTPS — `git credential

--- a/src/features/repo/ActivityStatus.test.tsx
+++ b/src/features/repo/ActivityStatus.test.tsx
@@ -138,3 +138,58 @@ describe("Cancel", () => {
     );
   });
 });
+
+// The escalation is a two-click affordance on the backend (#263): the first
+// cancel SIGTERMs, so git can run `remove_lock_file_on_signal` and not strand
+// `.git/FETCH_HEAD.lock`; a second SIGKILLs, so it cannot. That makes the second
+// click load-bearing, which only works if the first one visibly changed
+// something. Before this the line still read "Fetching origin…" next to a button
+// still reading "Cancel", so the honest reading was "nothing happened" — and the
+// double-click that follows lands on SIGKILL a few hundred milliseconds later.
+describe("once the cancel has been asked for", () => {
+  beforeEach(() => {
+    mockInvoke("cancel_network_op", () => 1);
+  });
+
+  it("says Force stop, so the second click is a decision", () => {
+    show({ fetch: running("Fetching origin…") });
+
+    expect(screen.getByText("Cancel")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(screen.getByText("Force stop")).toBeInTheDocument();
+    expect(screen.queryByText("Cancel")).not.toBeInTheDocument();
+  });
+
+  it("says Cancelling… instead of the op's own label", () => {
+    show({ fetch: running("Fetching origin…") });
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(screen.getByTestId("activity-label")).toHaveTextContent("Cancelling…");
+    expect(screen.queryByText("Fetching origin…")).not.toBeInTheDocument();
+  });
+
+  it("drops the progress bar, which would otherwise keep climbing", () => {
+    show({ fetch: running("Fetching origin…", { percent: 61 }) });
+    expect(screen.getByTestId("activity-percent")).toHaveTextContent("61%");
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    // A bar still moving after the click is the clearest possible way to tell
+    // the user nothing happened.
+    expect(screen.queryByTestId("activity-percent")).not.toBeInTheDocument();
+  });
+
+  it("stays clickable, because the second click IS the escalation", () => {
+    show({ fetch: running("Fetching origin…") });
+
+    fireEvent.click(screen.getByText("Cancel"));
+    fireEvent.click(screen.getByText("Force stop"));
+
+    // A button that disabled itself would leave a git that ignores SIGTERM
+    // unkillable — the dead end #234 existed to remove.
+    expect(getInvokeCalls().filter((c) => c.cmd === "cancel_network_op")).toHaveLength(2);
+  });
+});

--- a/src/features/repo/ActivityStatus.tsx
+++ b/src/features/repo/ActivityStatus.tsx
@@ -82,6 +82,7 @@ function ActivityLine({ state }: { state: ActivityState }) {
 
 export function ActivityStatus() {
   const activity = useRepoStore((s) => s.activity);
+  const cancelRequested = useRepoStore((s) => s.cancelRequested);
   const primary = primaryActivity(activity);
   if (!primary) return null;
 
@@ -95,7 +96,20 @@ export function ActivityStatus() {
       <PGStatusItem
         icon="sync"
         tone="accent"
-        label={<ActivityLine state={primary.state} />}
+        label={
+          <ActivityLine
+            state={
+              // Once Cancel has been clicked the transfer is being torn down,
+              // so the label says that and the bar goes (#263). A percentage
+              // still climbing after the click is the clearest possible way to
+              // tell the user their click did nothing — which is what makes
+              // them click again, and the second click is SIGKILL.
+              cancelRequested
+                ? { ...primary.state, label: "Cancelling…", percent: undefined }
+                : primary.state
+            }
+          />
+        }
       />
       {others > 0 && (
         <PGStatusItem
@@ -117,10 +131,20 @@ export function ActivityStatus() {
           LFS, submodule and forge ops — which were cancellable in the backend
           all along and simply had no button — while a rebase replay, which
           cannot be interrupted, does not get one it could not honour.
+
+          Two labels, because there are two signals (#263). The first click
+          SIGTERMs, which is what lets git remove its own lock files; a second
+          escalates to SIGKILL, which does not. So the first click MUST visibly
+          change something — otherwise the honest reading of a status line that
+          still says "Fetching…" next to a button that still says "Cancel" is
+          "nothing happened", and the user double-clicks their way to the
+          stranded-lock-file bug the SIGTERM was added to avoid. Never
+          disabled, either: a git that ignores SIGTERM is escapable only by
+          clicking again.
         */
         <PGStatusItem
           icon="x"
-          label="Cancel"
+          label={cancelRequested ? "Force stop" : "Cancel"}
           tone="danger"
           onClick={() => void useRepoStore.getState().cancelNetworkOps()}
         />

--- a/src/features/repo/repoSlice.ts
+++ b/src/features/repo/repoSlice.ts
@@ -161,6 +161,19 @@ export interface RepoSlice {
    */
   loadingTasks: LoadingTask[];
   /**
+   * Whether the user has already asked to cancel the network ops in flight
+   * (#263).
+   *
+   * Per-repo, and therefore here: a cancel asked for in one tab must not make
+   * another tab's Cancel read "Force stop". Purely a UI-intent flag — the
+   * authoritative per-op state lives in the backend registry (`cancel.rs`) —
+   * but the status bar has to show it, because the SECOND click is what
+   * escalates SIGTERM to SIGKILL and a button that never changes gives the
+   * user no way to know that. Cleared when `activity` empties, i.e. when the
+   * ops this cancel was aimed at have all unwound.
+   */
+  cancelRequested: boolean;
+  /**
    * The git hook refusal to display, or null (#232).
    *
    * Per-repo, and therefore here: a commit rejected by one repository's
@@ -205,6 +218,7 @@ export function emptySlice(): RepoSlice {
     shallowInfo: DEFAULT_SHALLOW_INFO,
     activity: {},
     loadingTasks: [],
+    cancelRequested: false,
     hookRejection: null,
   };
 }

--- a/src/features/repo/useRepoStore.cancelNetwork.test.ts
+++ b/src/features/repo/useRepoStore.cancelNetwork.test.ts
@@ -23,6 +23,8 @@ function mockRefreshAll() {
 }
 
 const calls = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+/** #299 made every activity entry an object; these tests only care about the label. */
+const act = (label: string) => ({ label, startedAt: Date.now() });
 const cancelled = () => {
   throw { kind: "Cancelled" };
 };
@@ -33,6 +35,7 @@ beforeEach(() => {
     current: { id: "repo-1", path: "/tmp/repo-1", head: "main" },
     error: null,
     activity: {},
+    cancelRequested: false,
   });
   mockRefreshAll();
   // `pull` auto-stashes first when the setting is on (it is, by default). null
@@ -108,4 +111,74 @@ it("still reports a genuine network failure", async () => {
   await useRepoStore.getState().fetch("origin");
 
   expect(useRepoStore.getState().error).toMatchObject({ kind: "Network" });
+});
+
+// The escalation is a two-click affordance on the backend (#263): the first
+// cancel SIGTERMs, so git can remove its own lock files; a second SIGKILLs, so
+// it cannot. The store has to carry that state, because a Cancel button that
+// looks identical after the first click is one an impatient user double-clicks
+// straight past the polite signal — re-creating the stranded `FETCH_HEAD.lock`
+// the SIGTERM was added to prevent.
+describe("the cancel is visible after the first click", () => {
+  it("marks the repository as cancelling", async () => {
+    mockInvoke("cancel_network_op", () => 1);
+    useRepoStore.setState({ activity: { fetch: act("Fetching origin…") } });
+
+    await useRepoStore.getState().cancelNetworkOps();
+
+    expect(useRepoStore.getState().cancelRequested).toBe(true);
+  });
+
+  it("marks it even when the signal reached nothing", async () => {
+    // 0 means the op finished between the user reading the status line and
+    // clicking. The label still has to move: the click DID happen, and any
+    // op still in flight under this scope was still marked on the backend.
+    mockInvoke("cancel_network_op", () => 0);
+    useRepoStore.setState({ activity: { fetch: act("Fetching origin…") } });
+
+    await useRepoStore.getState().cancelNetworkOps();
+
+    expect(useRepoStore.getState().cancelRequested).toBe(true);
+  });
+
+  it("clears once the last op has unwound, so the next click starts over", async () => {
+    mockInvoke("cancel_network_op", () => 1);
+    mockInvoke("fetch", cancelled);
+
+    await useRepoStore.getState().cancelNetworkOps();
+    expect(useRepoStore.getState().cancelRequested).toBe(true);
+
+    await useRepoStore.getState().fetch("origin");
+
+    // Activity is empty again, so the escalation state must be too — otherwise
+    // the FIRST click of the next stalled fetch would read "Force stop" and
+    // send SIGKILL to a git that had never been asked politely.
+    expect(useRepoStore.getState().activity).toEqual({});
+    expect(useRepoStore.getState().cancelRequested).toBe(false);
+  });
+
+  it("stays set while another op in the same scope is still running", async () => {
+    mockInvoke("cancel_network_op", () => 1);
+    useRepoStore.setState({
+      activity: {
+        fetch: act("Fetching origin…"),
+        push: act("Pushing origin/main…"),
+      },
+    });
+
+    await useRepoStore.getState().cancelNetworkOps();
+    // One of the two unwinds; the other is the one still stuck.
+    useRepoStore.setState({ activity: { push: act("Pushing origin/main…") } });
+
+    expect(useRepoStore.getState().cancelRequested).toBe(true);
+  });
+
+  it("does nothing when there is no repository to cancel for", async () => {
+    useRepoStore.setState({ current: null });
+    mockInvoke("cancel_network_op", () => 1);
+
+    await useRepoStore.getState().cancelNetworkOps();
+
+    expect(useRepoStore.getState().cancelRequested).toBe(false);
+  });
 });

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -442,7 +442,15 @@ export function setActivity(repoId: string, key: ActivityKey, label: string | nu
     const next = { ...s.activity };
     if (label === null) delete next[key];
     else next[key] = { label, startedAt: next[key]?.startedAt ?? Date.now() };
-    return { activity: next };
+    // The one place `cancelRequested` is dropped (#263). An op's `finally`
+    // clears its own label and nothing else; when the LAST one goes, the ops
+    // that cancel was aimed at have all unwound, so the next click starts a
+    // fresh SIGTERM-then-SIGKILL escalation rather than inheriting the previous
+    // one's second-click state — which would send SIGKILL to a git that had
+    // never been asked politely.
+    return Object.keys(next).length === 0
+      ? { activity: next, cancelRequested: false }
+      : { activity: next };
   });
 }
 
@@ -1754,10 +1762,20 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   async cancelNetworkOps() {
     const repo = get().current;
     if (!repo) return;
-    // Nothing is set here. The running op owns its own unwind: it returns
-    // `Cancelled`, its `finally` clears the activity label, and `setErrorFor`
-    // drops the error. Clearing `activity` from here would race that and blank
-    // the status line while git was still being reaped.
+    // The ONLY thing set here, and it is UI intent rather than op state (#263):
+    // the backend escalates SIGTERM → SIGKILL on the second cancel of the same
+    // op, so the user has to be able to see that the first click landed and
+    // that clicking again does something different. Without it the label reads
+    // "Cancel" and the status line reads "Fetching…" exactly as before, and an
+    // ordinary impatient double-click reaches SIGKILL in a few hundred
+    // milliseconds — killing git before it can run its own lock-file cleanup,
+    // which is the bug the SIGTERM exists to avoid.
+    //
+    // Everything else the running op still owns: it returns `Cancelled`, its
+    // `finally` clears the activity label, and `setErrorFor` drops the error.
+    // Clearing `activity` from here would race that and blank the status line
+    // while git was still being reaped.
+    set({ cancelRequested: true });
     await cancelNetworkOp(repo.id).catch((e) => {
       // The op finishing first is the common way this "fails", and it is the
       // outcome the click wanted anyway. A real failure to signal is worth a


### PR DESCRIPTION
#263 lists five gaps left after #260 shipped clone/fetch/pull/push cancellation. This PR scopes down to just item 1 — SIGKILL stranding git's own lock files — the same way #220 scoped down #216 for this repo. Items 2-5 (window-close cancelling in-flight ops, e2e coverage for cancel, a command-palette cancel row, and an auto-fetch deadline) are each their own change; happy to follow up on any of them.

## The bug

Cancelling a clone/fetch/pull/push sent `SIGKILL` straight to the `git` process (`cancel.rs`'s `kill_on_drop`/`start_kill`, from #234). Two problems with that:

- **`SIGKILL` is uncatchable.** Git installs `remove_lock_file_on_signal` (`lockfile.c`) for `SIGINT`/`SIGHUP`/`SIGTERM`/`SIGQUIT`/`SIGPIPE`, but not `SIGKILL`. A cancel landing while a fetch is writing refs can strand `.git/FETCH_HEAD.lock`, and the next fetch fails with `Unable to create '…/FETCH_HEAD.lock': File exists.` — a cancel button whose after-effect is a broken repository.
- **Wrong process.** `git clone`/`fetch`/`pull`/`push` spawns `git-remote-https` (https) or `ssh` (ssh) to do the actual transfer. Killing only the `git` we spawned leaves that helper running until its own blocked read times out.

## The fix

- `proc::git_async`/`git_async_in` now spawn `git` in its own process group (`process_group(0)`, unix only — deliberately *not* applied to `git_async_keeping_console`, the interactive mergetool path, since taking that child out of the terminal's foreground group would get it stopped by `SIGTTIN`/`SIGTTOU`).
- `cancel_network_op` now kills by pid, directly, from its own task, via a new `cancel::kill_tree`: `SIGTERM` to the whole process group first (reaching the transport helper too), escalating to `SIGKILL` on a **second** cancel of the same op — the user clicking Cancel again is the escalation signal, so there's no timer. `kill_tree` checks `getpgid(pid) == pid` before `killpg`, so a future spawn site that forgot `process_group(0)` degrades to a single-process kill instead of signalling the app's own process group.
- Windows has no `SIGTERM` and a `CREATE_NO_WINDOW` child has no console for `GenerateConsoleCtrlEvent`, so there `kill_tree` is always a forceful `taskkill /F /T` — now a genuine tree-kill rather than the previous single-process kill, closing the transport-helper gap there too, but still with no chance for git to clean up its own lock files. That's a known, accepted, unchanged gap on Windows, not something this PR fixes.
- Because the OS-level kill now happens out-of-band (by pid, from `cancel_network_op`'s own task) rather than by dropping/killing a shared `Child`, `run_clone`/`run_git_authenticated` no longer need the `tokio::select!` cancellation race — the op's task just notices its child died and checks `is_cancelled()` before trusting git's exit. Simpler, and sidesteps the borrow-checker shape a `select!` over `&mut child` never had a clean answer for (documented in the new `cancel.rs` module docs).

## Test plan

- `cargo check --manifest-path src-tauri/Cargo.toml` — clean.
- `cargo test --manifest-path src-tauri/Cargo.toml` — all green (208 lib tests, including 14 new/updated in `cancel::tests` and 2 new in `proc::tests` that spawn real processes and assert on `getpgid`/exit signal; the existing `tests/net_cancel.rs` stalled-clone/stalled-fetch integration tests pass unchanged).
- `pnpm tsc --noEmit` — clean.
- `pnpm vite build` — clean.
- `pnpm vitest run` — 225 files / 1943 tests passed (includes the doc/tree invariants — `docs/dev/architecture.md` and `docs/dev/backend.md` updated to match).
- No e2e spec currently exercises cancel at all (that's #263 item 3), so none needed rerunning; `pnpm test:e2e:docker` was not run for this backend-only change.
- No manual click-through — headless/sandboxed environment, no GUI available. The new `kill_tree`/process-group tests spawn real `sleep`/`git` processes and assert on real signals (`SIGTERM`/`SIGKILL` via `ExitStatusExt::signal()`) and real `getpgid` results rather than mocking, so the unix behavior is exercised directly rather than by inspection; Windows' `taskkill` argv is covered by a pure, platform-independent unit test (`taskkill_args`), same pattern `reveal.rs` uses, since PR CI doesn't build Windows.

Refs #263 — item 1 only, see the scope note above. Deliberately not a
linking keyword: items 2-5 (window-close cancelling, e2e coverage, the
command-palette row, the auto-fetch deadline) are still open, and #263
must survive this merge.
---
This PR was prepared with AI assistance (Claude); the diff was reviewed and all listed test commands were run and observed to pass before opening.

