### PR TITLE
feat(diagnostics): make the log able to describe a hang, and reachable

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -40,13 +40,19 @@ diagnostics.rs   What the log must say about the machine that wrote it (#274),
                  plus the log-file helpers Settings needs. is_wsl_kernel /
                  describe_wsl / parse_git_version / environment_line /
                  mount_warning / tail_lines are PURE and unit-tested from any
-                 host — read_host_facts (reads /proc, spawns `git --version`
-                 via proc.rs) is the only impure part, cached process-wide by
-                 host_facts(). environment_line writes the one `host os=… wsl=…
-                 git=…` INFO line at startup; before it, a WSL log and a native
-                 Linux log were indistinguishable. mount_warning explains a
-                 /mnt/<drive> repo's slowness in the log rather than leaving a
-                 nine-second launch looking like a broken app. Handlers live in
+                 host — no WSL box needed to test the WSL logic.
+                 TWO fact types, split by COST not topic: WslFacts (two file
+                 reads, no spawn) via wsl_facts(), and HostFacts (adds
+                 `git --version` through proc.rs) via host_facts(); both cached
+                 in a OnceLock. open_repo must use wsl_facts — it is a hot path
+                 and e2e opens a repo while the login-shell PATH probe still
+                 holds the startup thread, so host_facts there would lose the
+                 race and pay for the spawn on every cold open.
+                 environment_line writes the one `host os=… wsl=… git=…` INFO
+                 line at startup; before it, a WSL log and a native Linux log
+                 were indistinguishable. mount_warning explains a /mnt/<drive>
+                 repo's slowness in the log rather than leaving a nine-second
+                 launch looking like a broken app. Handlers live in
                  commands/diagnostics.rs
 forge/           GitHub/GitLab PR/MR integration (#92). Trait = URL builders +
                  response parsers, pure and testable against recorded JSON:

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -36,6 +36,18 @@ reveal.rs        "Reveal in Finder/Explorer" + "Open in terminal" (#215).
                  pinned path); Windows launchers are pinned to System32 /
                  WindowsApps against binary planting; a missing Linux terminal
                  falls through an ordered candidate list rather than silently
+diagnostics.rs   What the log must say about the machine that wrote it (#274),
+                 plus the log-file helpers Settings needs. is_wsl_kernel /
+                 describe_wsl / parse_git_version / environment_line /
+                 mount_warning / tail_lines are PURE and unit-tested from any
+                 host — read_host_facts (reads /proc, spawns `git --version`
+                 via proc.rs) is the only impure part, cached process-wide by
+                 host_facts(). environment_line writes the one `host os=… wsl=…
+                 git=…` INFO line at startup; before it, a WSL log and a native
+                 Linux log were indistinguishable. mount_warning explains a
+                 /mnt/<drive> repo's slowness in the log rather than leaving a
+                 nine-second launch looking like a broken app. Handlers live in
+                 commands/diagnostics.rs
 forge/           GitHub/GitLab PR/MR integration (#92). Trait = URL builders +
                  response parsers, pure and testable against recorded JSON:
 ├── mod.rs       Types + Forge trait, forge_for(kind), injection guards
@@ -134,6 +146,16 @@ commands/        Thin Tauri handlers, one file per area:
 │                read_file_content_at_rev + list_files_at_rev (a commit's tree),
 │                read_file_content_at_index (the STAGED blob)
 ├── cli.rs       take_launch_intent, cli_shim_status, install_cli_shim
+├── diagnostics.rs
+│                Reaching the app's own log from Settings (#274):
+│                diagnostics_report (log path + `host …` line + version),
+│                read_log_tail (last 500 lines, seeking to the last 1 MB — the
+│                file rotates at 5 MB and shipping all of it across IPC is
+│                waste on the machine least able to afford it), and
+│                reveal_log_file (reuses reveal.rs, so it inherits the
+│                explorer.exe / xdg-open exit-code traps). LOG_FILE here must
+│                track the file_name configured in lib.rs — the plugin does not
+│                report what it picked. Thin over src-tauri/src/diagnostics.rs
 ├── commits.rs   get_log, commit, file_history, verify_commit (SELECTED commit
 │                only, never per row). REFSPEC_ALL sentinel = walk all refs, so
 │                the loaded log is NOT HEAD ancestry — rebase input must go

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -421,7 +421,8 @@ differently:
 
 | Log shows | Means |
 | --- | --- |
-| no `open_repo` line at all | never reached the backend — folder picker returned nothing (on WSL usually no `xdg-desktop-portal`), or the frontend never dispatched |
+| `folder picker failed: …` | the native picker itself would not open — on Linux usually no `xdg-desktop-portal`. `open` is plugin-dialog's own IPC call, so it is invisible to the invoke wrapper AND the stall watchdog; `features/repo/ops.ts` catches it explicitly because every caller is a `void openRepoDialog()` whose rejection would otherwise be unhandled and leave no trace at all |
+| no `open_repo` line and no picker line | the user cancelled the picker (a `null` resolve, deliberately not logged), or the frontend never dispatched |
 | `open_repo <path>` and nothing after | libgit2 still working, or wedged. The webview's `still pending after 10000ms` confirms it, and the path says which filesystem |
 | `open_repo <path>` then `open_repo failed for <path>: …` | an ordinary error with a reason — always the easy case |
 

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -382,6 +382,69 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
 - Always wrap git2 work in `spawn_blocking` from Tauri commands — don't block
   the async runtime.
 
+## Reading the log (#274)
+
+Where it is — `tauri_plugin_log`'s `LogDir` target, i.e. Tauri's `app_log_dir`:
+
+| Platform | Path |
+| --- | --- |
+| macOS | `~/Library/Logs/io.github.jonassaa.platypusgit/platypusgit.log` |
+| Linux / WSL | `~/.local/share/io.github.jonassaa.platypusgit/logs/platypusgit.log` (`$XDG_DATA_HOME` if set) |
+| Windows | `%LOCALAPPDATA%\io.github.jonassaa.platypusgit\logs\platypusgit.log` |
+
+**Settings → Diagnostics shows this path and copies the tail** — ask a reporter
+for that rather than reciting a path, which is how a diagnosis once came down to
+comparing `resolved child PATH (N chars)` against a known log to work out which
+machine had written it.
+
+### What the levels mean for you
+
+`lib.rs` pins the file at `Info` and raises only `platypusgit_lib` to `Debug`.
+Webview `debug()` calls — **every successful invoke** — are therefore dropped.
+Consequences worth internalising before reasoning from a log:
+
+- **Absence of an invoke line proves nothing about whether it ran.** A fast,
+  successful call is invisible. Only `slow:` (≥250 ms), `failed:` and
+  `still pending` lines survive.
+- Timestamps are **UTC**. Compare against the file's mtime to find a session.
+- A duration far larger than any plausible operation (`slow: 1052465ms`) is a
+  **suspended machine**, not slow git — the promise resolved after wake.
+- A run of invokes with near-identical durations completing in the same second
+  is **one blocker draining a queue**, not N slow calls: same-repo ops serialize
+  on the inner mutex (see Async / threading). A monotonic ladder
+  (18s → 22s → 30s → …) is the same thing seen as it builds.
+
+### Triaging "it will not open my repository"
+
+`open_repo` logs on the way IN, so three previously identical silences now read
+differently:
+
+| Log shows | Means |
+| --- | --- |
+| no `open_repo` line at all | never reached the backend — folder picker returned nothing (on WSL usually no `xdg-desktop-portal`), or the frontend never dispatched |
+| `open_repo <path>` and nothing after | libgit2 still working, or wedged. The webview's `still pending after 10000ms` confirms it, and the path says which filesystem |
+| `open_repo <path>` then `open_repo failed for <path>: …` | an ordinary error with a reason — always the easy case |
+
+The webview's stall watchdog (`src/lib/tauri.ts`) is what makes the middle row
+readable: it is the only line either side logs **while** a call is outstanding.
+Every other line is written after the fact, which is precisely why a hang used
+to leave no trace at all.
+
+### Environment header
+
+One `host os=… arch=… kernel=… wsl=… git=…` INFO line per launch, from
+`diagnostics::environment_line`. Emitted on the PATH-probe thread *after* the
+probe, so `git=` names the git the app will actually spawn — read earlier, a
+user whose git lives only on the login `PATH` would be told `git=UNAVAILABLE` by
+an app that runs git perfectly well. `git=UNAVAILABLE` is spelled out rather
+than omitted (unlike the other fields) because it pre-explains every git failure
+below it.
+
+A repository under `/mnt/<drive>` on WSL also logs a WARN: it is a Windows
+filesystem over a VM boundary, every libgit2 `stat` crosses it, and a `/mnt/c`
+repo measured 9.8s on the startup fan-out. Not an error — the repo works — but
+an unexplained nine-second launch reads as a broken app.
+
 ## The hook chain
 
 Commit-side hooks run in `Libgit2Backend::commit`, one per name, through

--- a/src-tauri/src/commands/diagnostics.rs
+++ b/src-tauri/src/commands/diagnostics.rs
@@ -1,0 +1,135 @@
+//! Handing the app's own log to the person who needs to read it.
+//!
+//! The log has always been written; it was simply unreachable. Diagnosing a
+//! report meant telling the reporter an undocumented per-platform path
+//! (`~/Library/Logs/<id>/` on macOS, `$XDG_DATA_HOME/<id>/logs/` on Linux,
+//! `%LOCALAPPDATA%\<id>\logs\` on Windows) and hoping they found it — which is
+//! how #274 reached a state where the only available evidence was a log nobody
+//! could place. These commands let Settings show the path, open it, and copy the
+//! tail, so "send me your log" is one click rather than a support conversation.
+
+use tauri::{AppHandle, Manager};
+
+use crate::{
+    diagnostics::{self, TAIL_CAP_BYTES},
+    error::{AppError, AppResult},
+};
+
+/// The log file's name on disk.
+///
+/// `tauri_plugin_log` appends `.log` to the `file_name` configured in `lib.rs`,
+/// so these two must be changed together — the plugin does not tell us what it
+/// picked, and a wrong name here shows the user a path that does not exist.
+const LOG_FILE: &str = "platypusgit.log";
+
+/// How many lines the copy action returns.
+///
+/// Enough to cover several launches and the whole failing session, small enough
+/// to paste into an issue without collapsing it.
+const TAIL_LINES: usize = 500;
+
+/// Where the log is and what the machine looks like, for the Settings panel.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticsReport {
+    /// Absolute path to the current log file, shown verbatim so a user on any
+    /// platform can reach it without being told where to look.
+    pub log_path: String,
+    /// Whether that file exists yet. A fresh install that has not flushed has
+    /// no file, and a panel that offers to open a nonexistent path is worse
+    /// than one that says so.
+    pub log_exists: bool,
+    /// Size in bytes, `None` when the file is absent. Renders as a hint that
+    /// the copy action returns a tail rather than the whole thing.
+    pub log_size_bytes: Option<u64>,
+    /// The same `host …` line that `environment_line` writes at startup, so the
+    /// panel can show it without the user reading the file at all — and so it
+    /// travels with a copied report even if the copy is only the tail.
+    pub environment: String,
+    /// The running version, so a pasted report identifies its build.
+    pub version: String,
+}
+
+/// Resolve the log file's path, wherever this platform puts it.
+fn log_path(app: &AppHandle) -> AppResult<std::path::PathBuf> {
+    app.path()
+        .app_log_dir()
+        .map(|dir| dir.join(LOG_FILE))
+        .map_err(|e| AppError::Io(format!("cannot resolve the log directory: {e}")))
+}
+
+/// The log's location plus the environment facts, for the Settings panel.
+#[tauri::command]
+pub async fn diagnostics_report(app: AppHandle) -> AppResult<DiagnosticsReport> {
+    let path = log_path(&app)?;
+    // `host_facts` may spawn git on the first call, so it does not belong on
+    // the main thread.
+    let environment = tokio::task::spawn_blocking(|| {
+        diagnostics::environment_line(diagnostics::host_facts())
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+    let meta = std::fs::metadata(&path).ok();
+    Ok(DiagnosticsReport {
+        log_path: path.to_string_lossy().into_owned(),
+        log_exists: meta.is_some(),
+        log_size_bytes: meta.as_ref().map(|m| m.len()),
+        environment,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    })
+}
+
+/// The tail of the log, ready to paste into an issue.
+///
+/// Reads at most [`TAIL_CAP_BYTES`] from the END of the file rather than the
+/// whole of it: the file rotates at 5 MB, and shipping five megabytes across IPC
+/// to render a few hundred lines is waste with a latency cost on exactly the
+/// machine most likely to be struggling already.
+#[tauri::command]
+pub async fn read_log_tail(app: AppHandle) -> AppResult<String> {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let path = log_path(&app)?;
+    tokio::task::spawn_blocking(move || {
+        let mut file = std::fs::File::open(&path).map_err(|e| {
+            AppError::Io(format!("cannot read the log at {}: {e}", path.display()))
+        })?;
+        let len = file
+            .metadata()
+            .map_err(|e| AppError::Io(format!("cannot size the log: {e}")))?
+            .len();
+        let truncated = len > TAIL_CAP_BYTES;
+        if truncated {
+            file.seek(SeekFrom::End(-(TAIL_CAP_BYTES as i64)))
+                .map_err(|e| AppError::Io(format!("cannot seek the log: {e}")))?;
+        }
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf)
+            .map_err(|e| AppError::Io(format!("cannot read the log: {e}")))?;
+        // Lossy on purpose: a log is not required to be valid UTF-8 (a hook's
+        // output reaches it verbatim), and refusing to show a log because one
+        // byte is malformed would defeat the only reason this command exists.
+        let text = String::from_utf8_lossy(&buf);
+        Ok(diagnostics::tail_lines(&text, TAIL_LINES, truncated))
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+/// Reveal the log file in the platform's file manager.
+///
+/// Reuses `crate::reveal`, which already knows the per-platform verbs and the
+/// traps in them (`explorer.exe` exiting 1 on success, `xdg-open` exiting 3 with
+/// no handler). `false` because the target is a FILE: the user gets its folder
+/// with the log selected, which is what "show me this" means.
+#[tauri::command]
+pub async fn reveal_log_file(app: AppHandle) -> AppResult<()> {
+    let path = log_path(&app)?;
+    if !path.exists() {
+        return Err(AppError::Io(format!(
+            "no log file at {} yet",
+            path.display()
+        )));
+    }
+    crate::reveal::reveal(&path, false).await
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod cli;
 pub mod commits;
 pub mod conflict;
 pub mod create;
+pub mod diagnostics;
 pub mod diff;
 pub mod forge;
 pub mod history;

--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -37,10 +37,14 @@ pub async fn open_repo(
         // Before the open, not after: the value of this line is that it is
         // written even when the call below never returns.
         log::info!("open_repo {}", path_buf.display());
-        if let Some(warning) = crate::diagnostics::mount_warning(
-            &path_buf,
-            crate::diagnostics::host_facts(),
-        ) {
+        // `wsl_facts`, NOT `host_facts`: this is the repository-open path, and
+        // the WSL question needs no `git --version`. e2e opens a repo about a
+        // second after launch, while the login-shell PATH probe still holds the
+        // startup thread — so a `host_facts` call here would lose that race and
+        // pay for the spawn itself on every cold open.
+        if let Some(warning) =
+            crate::diagnostics::mount_warning(&path_buf, crate::diagnostics::wsl_facts())
+        {
             log::warn!("{warning}");
         }
         let result = backend.open(&path_buf);

--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -8,6 +8,24 @@ use crate::{
     state::AppState,
 };
 
+/// Open a repository at `path`.
+///
+/// # Why this one command logs, when its siblings do not
+///
+/// It is the gate every session goes through, and a failure here leaves the app
+/// with nothing to show — so "it will not load my repository" is the report that
+/// arrives with the least evidence attached. Logging the path on the way IN and
+/// the outcome on the way out turns three indistinguishable silences into three
+/// different logs (#274):
+///
+/// * **No `open_repo` line at all** — the command was never reached. The folder
+///   picker returned nothing (on WSL, typically no `xdg-desktop-portal`), or the
+///   frontend never dispatched. Look for the webview's own stall warning.
+/// * **An `open_repo` line and nothing after it** — libgit2 is still working,
+///   or wedged. Paired with the webview's "still pending" line, that is a hang,
+///   and the path on this line says which filesystem it is hanging on.
+/// * **An `open_repo` line and a failure** — an ordinary error with a reason,
+///   which was always the easy case.
 #[tauri::command]
 pub async fn open_repo(
     state: State<'_, AppState>,
@@ -15,9 +33,28 @@ pub async fn open_repo(
 ) -> AppResult<RepoHandle> {
     let backend = state.backend.clone();
     let path_buf = PathBuf::from(path);
-    tokio::task::spawn_blocking(move || backend.open(&path_buf))
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+    tokio::task::spawn_blocking(move || {
+        // Before the open, not after: the value of this line is that it is
+        // written even when the call below never returns.
+        log::info!("open_repo {}", path_buf.display());
+        if let Some(warning) = crate::diagnostics::mount_warning(
+            &path_buf,
+            crate::diagnostics::host_facts(),
+        ) {
+            log::warn!("{warning}");
+        }
+        let result = backend.open(&path_buf);
+        match &result {
+            Ok(handle) => log::info!("open_repo ok: {}", handle.id.0),
+            // Logged backend-side as well as in the webview's invoke wrapper:
+            // this side survives a webview that has already torn down, and it
+            // is the only side that records the path the failure was about.
+            Err(e) => log::error!("open_repo failed for {}: {e}", path_buf.display()),
+        }
+        result
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
 /// Forget an opened repository (a closed repository tab).

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -1,0 +1,368 @@
+//! What the log needs to say about the machine it was written on, and how the
+//! app hands that log to the person reading it.
+//!
+//! # Why this module exists
+//!
+//! A log that records only what the app did is not enough to diagnose a report
+//! from someone else's machine. A WSL log and a native-Linux log were byte-for
+//! -byte indistinguishable in their headers, so identifying which one a user had
+//! pasted meant comparing an incidental detail — the character count of a
+//! resolved `PATH` — against a known-good log (#274). That is not a diagnostic
+//! procedure, that is a coincidence.
+//!
+//! So [`environment_line`] writes the facts down once, at startup, in a form
+//! that survives being copied into an issue: one `key=value` line, greppable,
+//! naming the platform, the kernel, whether this is WSL, and git's version.
+//!
+//! # Shape
+//!
+//! Everything that can be decided from data is a pure function over
+//! [`HostFacts`] — [`describe_wsl`], [`environment_line`], [`tail_lines`],
+//! [`mount_warning`] — and unit-tested as such. [`read_host_facts`] is the only
+//! part that touches the host, so the interesting logic is testable without a
+//! WSL machine to test it on.
+
+use std::path::Path;
+
+/// Bytes of the log file's tail that [`crate::commands::diagnostics`] will read.
+///
+/// The log rotates at 5 MB (`lib.rs`), and the whole point of the copy action is
+/// that the result gets pasted into an issue — so the cap is about what is
+/// useful to read, not what is possible to read. A megabyte is thousands of
+/// lines, far past the last launch.
+pub const TAIL_CAP_BYTES: u64 = 1024 * 1024;
+
+/// Facts about the machine, as read from the host.
+///
+/// Deliberately all-owned strings rather than borrowed: the values come from
+/// three different places (compile-time constants, `/proc`, a subprocess) with
+/// nothing to borrow from in common.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct HostFacts {
+    /// `std::env::consts::OS` — `"linux"`, `"macos"`, `"windows"`.
+    pub os: String,
+    /// `std::env::consts::ARCH` — `"x86_64"`, `"aarch64"`.
+    pub arch: String,
+    /// Kernel release, Linux only (`/proc/sys/kernel/osrelease`).
+    pub kernel: Option<String>,
+    /// `$WSL_DISTRO_NAME`, when WSL set it.
+    pub wsl_distro: Option<String>,
+    /// `git --version`'s version field, or `None` when git could not be run.
+    ///
+    /// `None` is itself a finding: the `.deb` depends on git, so a missing git
+    /// on a packaged install means something is badly wrong with the
+    /// environment — and every git operation would fail with a message that
+    /// blames the repository rather than the missing binary.
+    pub git_version: Option<String>,
+}
+
+/// Whether a kernel release string is a WSL kernel.
+///
+/// Microsoft's WSL2 kernels are tagged `-microsoft-standard-WSL2`; WSL1 reports
+/// `-Microsoft`. Both markers are checked case-insensitively because the casing
+/// has changed across releases and neither spelling is a promise.
+///
+/// This is the reliable signal, not `$WSL_DISTRO_NAME`: the environment variable
+/// is absent from a process that did not inherit it (a `.desktop` launch through
+/// some session managers), while the kernel is the kernel.
+pub fn is_wsl_kernel(kernel: &str) -> bool {
+    let lower = kernel.to_ascii_lowercase();
+    lower.contains("microsoft") || lower.contains("wsl")
+}
+
+/// How to describe the WSL situation in the header, or `None` when not on WSL.
+///
+/// The distro name is included when known because "WSL" alone does not say
+/// which userland — and a report against Ubuntu 24.04 and one against a
+/// hand-rolled Arch install are not the same report.
+pub fn describe_wsl(facts: &HostFacts) -> Option<String> {
+    let on_wsl = facts.kernel.as_deref().is_some_and(is_wsl_kernel);
+    // The env var alone is enough to conclude WSL: nothing else sets it.
+    let named = facts.wsl_distro.as_deref().filter(|d| !d.is_empty());
+    match (on_wsl, named) {
+        (_, Some(distro)) => Some(distro.to_string()),
+        (true, None) => Some("yes".to_string()),
+        (false, None) => None,
+    }
+}
+
+/// Extract the version from `git --version`'s stdout.
+///
+/// git prints `git version 2.43.0`, and on macOS with the Xcode shim
+/// `git version 2.39.5 (Apple Git-154)`. The whole trailing remainder is kept —
+/// the vendor suffix is a fact worth having — but the fixed `git version`
+/// prefix is dropped so the header does not read `git=git version 2.43.0`.
+pub fn parse_git_version(stdout: &str) -> Option<String> {
+    let line = stdout.lines().next()?.trim();
+    let version = line.strip_prefix("git version ").unwrap_or(line).trim();
+    (!version.is_empty()).then(|| version.to_string())
+}
+
+/// The startup header: one line of `key=value` facts about this machine.
+///
+/// Absent values are OMITTED rather than written as `unknown`. A header that
+/// lists everything it does not know buries the three fields that matter on the
+/// platform in question — `kernel` and `wsl` are meaningless on macOS, and a
+/// reader scanning for them should see their absence, not a column of noise.
+pub fn environment_line(facts: &HostFacts) -> String {
+    let mut parts = vec![
+        format!("os={}", facts.os),
+        format!("arch={}", facts.arch),
+    ];
+    if let Some(kernel) = facts.kernel.as_deref().filter(|k| !k.is_empty()) {
+        parts.push(format!("kernel={kernel}"));
+    }
+    if let Some(wsl) = describe_wsl(facts) {
+        parts.push(format!("wsl={wsl}"));
+    }
+    match facts.git_version.as_deref() {
+        Some(v) => parts.push(format!("git={v}")),
+        // Spelled out, unlike the other absences: this one is a fault, not an
+        // irrelevance, and it explains every git failure that follows it.
+        None => parts.push("git=UNAVAILABLE".to_string()),
+    }
+    format!("host {}", parts.join(" "))
+}
+
+/// A warning about where a repository lives, or `None` when there is nothing to
+/// say.
+///
+/// `/mnt/<drive>` under WSL is a Windows filesystem reached over a VM boundary,
+/// where every `stat` costs orders of magnitude more than on ext4. libgit2 stats
+/// the entire worktree for a status, so the cost lands on the operations the UI
+/// runs on every refresh: a `/mnt/c` repository spent 9.8s on the startup
+/// fan-out that a native path completes in well under a second (#274).
+///
+/// This is logged rather than surfaced as an error because it is not one — the
+/// repository works, it is merely slow, and the user may have no choice about
+/// where it lives. But an unexplained nine-second launch reads as a broken app,
+/// and one line in the log turns it into a known cost with a known cause.
+pub fn mount_warning(path: &Path, facts: &HostFacts) -> Option<String> {
+    if describe_wsl(facts).is_none() {
+        return None;
+    }
+    let text = path.to_string_lossy();
+    // `/mnt/c`, not merely `/mnt`: a user's own bind mount under /mnt is not a
+    // drvfs drive, and warning about it would be wrong. WSL maps drives as a
+    // single letter.
+    let drive = text
+        .strip_prefix("/mnt/")
+        .and_then(|rest| rest.chars().next())
+        .filter(|c| c.is_ascii_alphabetic())
+        .filter(|_| {
+            let rest = &text["/mnt/".len()..];
+            rest.len() == 1 || rest[1..].starts_with('/')
+        })?;
+    Some(format!(
+        "repository is on Windows drive {}: via /mnt — every file operation \
+         crosses the WSL filesystem boundary, so status and diff will be slow. \
+         A repository inside the Linux filesystem (~/) is dramatically faster.",
+        drive.to_ascii_uppercase()
+    ))
+}
+
+/// The last `n` lines of `content`.
+///
+/// `content` may begin mid-line, because the caller seeks to a byte offset
+/// rather than reading a whole multi-megabyte file. A partial first line is
+/// therefore dropped whenever anything was truncated — a half-timestamp at the
+/// top of a pasted log invites the reader to draw a conclusion from a record
+/// that was never written that way.
+pub fn tail_lines(content: &str, n: usize, truncated: bool) -> String {
+    let mut lines: Vec<&str> = content.lines().collect();
+    if truncated && !lines.is_empty() {
+        lines.remove(0);
+    }
+    let start = lines.len().saturating_sub(n);
+    lines[start..].join("\n")
+}
+
+/// The host's facts, read once per process.
+///
+/// [`read_host_facts`] spawns `git --version`, so the callers that want these
+/// facts repeatedly — every `open_repo`, asking whether to warn about a `/mnt`
+/// path — must not each pay for a subprocess. The startup header populates this
+/// on a background thread; a caller that arrives first initialises it itself,
+/// which is why every call site is already inside `spawn_blocking`.
+pub fn host_facts() -> &'static HostFacts {
+    static FACTS: std::sync::OnceLock<HostFacts> = std::sync::OnceLock::new();
+    FACTS.get_or_init(read_host_facts)
+}
+
+/// Read the host's facts. The only function here that is not pure.
+pub fn read_host_facts() -> HostFacts {
+    HostFacts {
+        os: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        kernel: read_kernel(),
+        wsl_distro: std::env::var("WSL_DISTRO_NAME").ok(),
+        git_version: read_git_version(),
+    }
+}
+
+/// Kernel release on Linux; `None` elsewhere, where the file does not exist and
+/// the value would not be the WSL signal anyway.
+fn read_kernel() -> Option<String> {
+    if !cfg!(target_os = "linux") {
+        return None;
+    }
+    std::fs::read_to_string("/proc/sys/kernel/osrelease")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// `git --version`, via [`crate::proc`] like every other spawn in this codebase.
+fn read_git_version() -> Option<String> {
+    let out = crate::proc::program("git").arg("--version").output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    parse_git_version(&String::from_utf8_lossy(&out.stdout))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognises_both_wsl_kernel_spellings() {
+        assert!(is_wsl_kernel("5.15.153.1-microsoft-standard-WSL2"));
+        assert!(is_wsl_kernel("4.4.0-19041-Microsoft"));
+        // A real native kernel must not be mistaken for one.
+        assert!(!is_wsl_kernel("6.8.0-45-generic"));
+        assert!(!is_wsl_kernel("6.6.87.2-hardened"));
+    }
+
+    #[test]
+    fn names_the_distro_when_wsl_exported_it() {
+        let facts = HostFacts {
+            kernel: Some("5.15.153.1-microsoft-standard-WSL2".into()),
+            wsl_distro: Some("Ubuntu-24.04".into()),
+            ..Default::default()
+        };
+        assert_eq!(describe_wsl(&facts).as_deref(), Some("Ubuntu-24.04"));
+    }
+
+    #[test]
+    fn still_reports_wsl_when_the_env_var_did_not_survive_the_launch() {
+        // The case the env var alone would miss: a `.desktop` launch that did
+        // not inherit WSL's environment. The kernel still gives it away, and
+        // this is why `describe_wsl` consults it at all.
+        let facts = HostFacts {
+            kernel: Some("5.15.153.1-microsoft-standard-WSL2".into()),
+            wsl_distro: None,
+            ..Default::default()
+        };
+        assert_eq!(describe_wsl(&facts).as_deref(), Some("yes"));
+    }
+
+    #[test]
+    fn says_nothing_about_wsl_on_a_native_host() {
+        let facts = HostFacts {
+            kernel: Some("6.8.0-45-generic".into()),
+            ..Default::default()
+        };
+        assert_eq!(describe_wsl(&facts), None);
+        assert!(!environment_line(&facts).contains("wsl="));
+    }
+
+    #[test]
+    fn parses_git_version_with_and_without_a_vendor_suffix() {
+        assert_eq!(parse_git_version("git version 2.43.0\n").as_deref(), Some("2.43.0"));
+        assert_eq!(
+            parse_git_version("git version 2.39.5 (Apple Git-154)\n").as_deref(),
+            Some("2.39.5 (Apple Git-154)")
+        );
+        assert_eq!(parse_git_version(""), None);
+        assert_eq!(parse_git_version("   \n"), None);
+    }
+
+    #[test]
+    fn header_reads_as_one_greppable_line() {
+        let facts = HostFacts {
+            os: "linux".into(),
+            arch: "x86_64".into(),
+            kernel: Some("5.15.153.1-microsoft-standard-WSL2".into()),
+            wsl_distro: Some("Ubuntu-24.04".into()),
+            git_version: Some("2.43.0".into()),
+        };
+        assert_eq!(
+            environment_line(&facts),
+            "host os=linux arch=x86_64 kernel=5.15.153.1-microsoft-standard-WSL2 \
+             wsl=Ubuntu-24.04 git=2.43.0"
+        );
+        assert!(!environment_line(&facts).contains('\n'));
+    }
+
+    #[test]
+    fn a_missing_git_is_stated_not_omitted() {
+        // Every other absent field is dropped; this one must not be, because it
+        // pre-explains every git failure in the rest of the log.
+        let facts = HostFacts {
+            os: "linux".into(),
+            arch: "x86_64".into(),
+            git_version: None,
+            ..Default::default()
+        };
+        assert!(environment_line(&facts).contains("git=UNAVAILABLE"));
+    }
+
+    fn wsl_facts() -> HostFacts {
+        HostFacts {
+            kernel: Some("5.15.153.1-microsoft-standard-WSL2".into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn warns_about_a_repository_on_a_windows_drive() {
+        let w = mount_warning(Path::new("/mnt/c/Users/jonas/dev/app"), &wsl_facts());
+        assert!(w.is_some());
+        assert!(w.unwrap().contains("Windows drive C:"));
+    }
+
+    #[test]
+    fn says_nothing_about_a_repository_in_the_linux_filesystem() {
+        assert_eq!(mount_warning(Path::new("/home/jonas/dev/app"), &wsl_facts()), None);
+    }
+
+    #[test]
+    fn does_not_mistake_an_ordinary_mount_for_a_windows_drive() {
+        // A multi-character entry under /mnt is somebody's own mount, not a
+        // drvfs drive letter. Warning about it would be confidently wrong.
+        assert_eq!(mount_warning(Path::new("/mnt/data/repos/app"), &wsl_facts()), None);
+        assert_eq!(mount_warning(Path::new("/mnt/backup"), &wsl_facts()), None);
+        // The bare drive root is still a drive.
+        assert!(mount_warning(Path::new("/mnt/d"), &wsl_facts()).is_some());
+    }
+
+    #[test]
+    fn never_warns_about_a_mount_path_off_wsl() {
+        // `/mnt/c` on a native Linux box is just a directory.
+        let native = HostFacts {
+            kernel: Some("6.8.0-45-generic".into()),
+            ..Default::default()
+        };
+        assert_eq!(mount_warning(Path::new("/mnt/c/repos/app"), &native), None);
+    }
+
+    #[test]
+    fn tail_returns_the_last_lines_in_order() {
+        let content = "a\nb\nc\nd\ne";
+        assert_eq!(tail_lines(content, 2, false), "d\ne");
+        // Asking for more than there is yields everything, not an error.
+        assert_eq!(tail_lines(content, 99, false), content);
+        assert_eq!(tail_lines("", 5, false), "");
+    }
+
+    #[test]
+    fn tail_drops_a_line_the_seek_cut_in_half() {
+        // What a mid-file seek actually produces: the first line is a fragment.
+        // Keeping it would put a half-written timestamp at the top of a log
+        // somebody is about to reason from.
+        assert_eq!(tail_lines("53][INFO] half\nb\nc", 5, true), "b\nc");
+        // Nothing was truncated, so nothing is dropped.
+        assert_eq!(tail_lines("a\nb\nc", 5, false), "a\nb\nc");
+    }
+}

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -17,10 +17,15 @@
 //! # Shape
 //!
 //! Everything that can be decided from data is a pure function over
-//! [`HostFacts`] — [`describe_wsl`], [`environment_line`], [`tail_lines`],
-//! [`mount_warning`] — and unit-tested as such. [`read_host_facts`] is the only
-//! part that touches the host, so the interesting logic is testable without a
-//! WSL machine to test it on.
+//! [`HostFacts`] or [`WslFacts`] — [`describe_wsl`], [`environment_line`],
+//! [`tail_lines`], [`mount_warning`] — and unit-tested as such.
+//! [`read_wsl_facts`] and [`read_host_facts`] are the only parts that touch the
+//! host, so the interesting logic is testable without a WSL machine to test it
+//! on.
+//!
+//! The two fact types are split by COST, not by topic: [`WslFacts`] is two file
+//! reads and is safe on the repository-open path, while [`HostFacts`] spawns
+//! `git --version` and belongs only where a subprocess is already acceptable.
 
 use std::path::Path;
 
@@ -43,17 +48,36 @@ pub struct HostFacts {
     pub os: String,
     /// `std::env::consts::ARCH` — `"x86_64"`, `"aarch64"`.
     pub arch: String,
-    /// Kernel release, Linux only (`/proc/sys/kernel/osrelease`).
-    pub kernel: Option<String>,
-    /// `$WSL_DISTRO_NAME`, when WSL set it.
-    pub wsl_distro: Option<String>,
+    /// The WSL signals, which cost no subprocess. See [`WslFacts`].
+    pub wsl: WslFacts,
     /// `git --version`'s version field, or `None` when git could not be run.
     ///
     /// `None` is itself a finding: the `.deb` depends on git, so a missing git
     /// on a packaged install means something is badly wrong with the
     /// environment — and every git operation would fail with a message that
     /// blames the repository rather than the missing binary.
+    ///
+    /// **This is the one field that costs a process spawn**, which is why it
+    /// lives behind [`host_facts`] and not [`wsl_facts`].
     pub git_version: Option<String>,
+}
+
+/// Just enough to answer "is this WSL, and is that path a Windows drive?".
+///
+/// Split out from [`HostFacts`] because it needs **no subprocess** — two reads,
+/// one of `/proc` and one of the environment. `open_repo` consults it on every
+/// call to decide whether to warn about a `/mnt/<drive>` path, and adding a
+/// `git --version` spawn to the repository-open path would be a real cost paid
+/// for a field that question does not use. It is also the path e2e exercises
+/// within a second of launch, while the login-shell PATH probe still holds the
+/// startup thread — so `open_repo` would lose that race and pay for the spawn
+/// itself rather than inheriting a warm cache.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct WslFacts {
+    /// Kernel release, Linux only (`/proc/sys/kernel/osrelease`).
+    pub kernel: Option<String>,
+    /// `$WSL_DISTRO_NAME`, when WSL set it.
+    pub wsl_distro: Option<String>,
 }
 
 /// Whether a kernel release string is a WSL kernel.
@@ -75,7 +99,7 @@ pub fn is_wsl_kernel(kernel: &str) -> bool {
 /// The distro name is included when known because "WSL" alone does not say
 /// which userland — and a report against Ubuntu 24.04 and one against a
 /// hand-rolled Arch install are not the same report.
-pub fn describe_wsl(facts: &HostFacts) -> Option<String> {
+pub fn describe_wsl(facts: &WslFacts) -> Option<String> {
     let on_wsl = facts.kernel.as_deref().is_some_and(is_wsl_kernel);
     // The env var alone is enough to conclude WSL: nothing else sets it.
     let named = facts.wsl_distro.as_deref().filter(|d| !d.is_empty());
@@ -109,10 +133,10 @@ pub fn environment_line(facts: &HostFacts) -> String {
         format!("os={}", facts.os),
         format!("arch={}", facts.arch),
     ];
-    if let Some(kernel) = facts.kernel.as_deref().filter(|k| !k.is_empty()) {
+    if let Some(kernel) = facts.wsl.kernel.as_deref().filter(|k| !k.is_empty()) {
         parts.push(format!("kernel={kernel}"));
     }
-    if let Some(wsl) = describe_wsl(facts) {
+    if let Some(wsl) = describe_wsl(&facts.wsl) {
         parts.push(format!("wsl={wsl}"));
     }
     match facts.git_version.as_deref() {
@@ -137,7 +161,7 @@ pub fn environment_line(facts: &HostFacts) -> String {
 /// repository works, it is merely slow, and the user may have no choice about
 /// where it lives. But an unexplained nine-second launch reads as a broken app,
 /// and one line in the log turns it into a known cost with a known cause.
-pub fn mount_warning(path: &Path, facts: &HostFacts) -> Option<String> {
+pub fn mount_warning(path: &Path, facts: &WslFacts) -> Option<String> {
     if describe_wsl(facts).is_none() {
         return None;
     }
@@ -177,25 +201,42 @@ pub fn tail_lines(content: &str, n: usize, truncated: bool) -> String {
     lines[start..].join("\n")
 }
 
-/// The host's facts, read once per process.
+/// The WSL signals, read once per process. **Spawns nothing.**
 ///
-/// [`read_host_facts`] spawns `git --version`, so the callers that want these
-/// facts repeatedly — every `open_repo`, asking whether to warn about a `/mnt`
-/// path — must not each pay for a subprocess. The startup header populates this
-/// on a background thread; a caller that arrives first initialises it itself,
-/// which is why every call site is already inside `spawn_blocking`.
+/// This is what `open_repo` calls. Kept deliberately separate from
+/// [`host_facts`] so the repository-open path never waits on a process, and
+/// never blocks behind a [`host_facts`] initialisation that is mid-`git
+/// --version` on another thread.
+pub fn wsl_facts() -> &'static WslFacts {
+    static FACTS: std::sync::OnceLock<WslFacts> = std::sync::OnceLock::new();
+    FACTS.get_or_init(read_wsl_facts)
+}
+
+/// The full facts including git's version, read once per process.
+///
+/// [`read_host_facts`] spawns `git --version`, so this is for the two callers
+/// that actually want it — the startup header and the Settings report — both of
+/// which are already off the main thread and neither of which is on a hot path.
 pub fn host_facts() -> &'static HostFacts {
     static FACTS: std::sync::OnceLock<HostFacts> = std::sync::OnceLock::new();
     FACTS.get_or_init(read_host_facts)
 }
 
-/// Read the host's facts. The only function here that is not pure.
+/// Read the WSL signals: one `/proc` read and one environment read.
+pub fn read_wsl_facts() -> WslFacts {
+    WslFacts {
+        kernel: read_kernel(),
+        wsl_distro: std::env::var("WSL_DISTRO_NAME").ok(),
+    }
+}
+
+/// Read the host's facts. Spawns git; not pure.
 pub fn read_host_facts() -> HostFacts {
     HostFacts {
         os: std::env::consts::OS.to_string(),
         arch: std::env::consts::ARCH.to_string(),
-        kernel: read_kernel(),
-        wsl_distro: std::env::var("WSL_DISTRO_NAME").ok(),
+        // Reuses the cheap cache rather than re-reading /proc.
+        wsl: wsl_facts().clone(),
         git_version: read_git_version(),
     }
 }
@@ -236,10 +277,9 @@ mod tests {
 
     #[test]
     fn names_the_distro_when_wsl_exported_it() {
-        let facts = HostFacts {
+        let facts = WslFacts {
             kernel: Some("5.15.153.1-microsoft-standard-WSL2".into()),
             wsl_distro: Some("Ubuntu-24.04".into()),
-            ..Default::default()
         };
         assert_eq!(describe_wsl(&facts).as_deref(), Some("Ubuntu-24.04"));
     }
@@ -249,21 +289,21 @@ mod tests {
         // The case the env var alone would miss: a `.desktop` launch that did
         // not inherit WSL's environment. The kernel still gives it away, and
         // this is why `describe_wsl` consults it at all.
-        let facts = HostFacts {
+        let facts = WslFacts {
             kernel: Some("5.15.153.1-microsoft-standard-WSL2".into()),
             wsl_distro: None,
-            ..Default::default()
         };
         assert_eq!(describe_wsl(&facts).as_deref(), Some("yes"));
     }
 
     #[test]
     fn says_nothing_about_wsl_on_a_native_host() {
-        let facts = HostFacts {
+        let wsl = WslFacts {
             kernel: Some("6.8.0-45-generic".into()),
-            ..Default::default()
+            wsl_distro: None,
         };
-        assert_eq!(describe_wsl(&facts), None);
+        assert_eq!(describe_wsl(&wsl), None);
+        let facts = HostFacts { wsl, ..Default::default() };
         assert!(!environment_line(&facts).contains("wsl="));
     }
 
@@ -283,8 +323,10 @@ mod tests {
         let facts = HostFacts {
             os: "linux".into(),
             arch: "x86_64".into(),
-            kernel: Some("5.15.153.1-microsoft-standard-WSL2".into()),
-            wsl_distro: Some("Ubuntu-24.04".into()),
+            wsl: WslFacts {
+                kernel: Some("5.15.153.1-microsoft-standard-WSL2".into()),
+                wsl_distro: Some("Ubuntu-24.04".into()),
+            },
             git_version: Some("2.43.0".into()),
         };
         assert_eq!(
@@ -308,41 +350,41 @@ mod tests {
         assert!(environment_line(&facts).contains("git=UNAVAILABLE"));
     }
 
-    fn wsl_facts() -> HostFacts {
-        HostFacts {
+    fn on_wsl() -> WslFacts {
+        WslFacts {
             kernel: Some("5.15.153.1-microsoft-standard-WSL2".into()),
-            ..Default::default()
+            wsl_distro: None,
         }
     }
 
     #[test]
     fn warns_about_a_repository_on_a_windows_drive() {
-        let w = mount_warning(Path::new("/mnt/c/Users/jonas/dev/app"), &wsl_facts());
+        let w = mount_warning(Path::new("/mnt/c/Users/jonas/dev/app"), &on_wsl());
         assert!(w.is_some());
         assert!(w.unwrap().contains("Windows drive C:"));
     }
 
     #[test]
     fn says_nothing_about_a_repository_in_the_linux_filesystem() {
-        assert_eq!(mount_warning(Path::new("/home/jonas/dev/app"), &wsl_facts()), None);
+        assert_eq!(mount_warning(Path::new("/home/jonas/dev/app"), &on_wsl()), None);
     }
 
     #[test]
     fn does_not_mistake_an_ordinary_mount_for_a_windows_drive() {
         // A multi-character entry under /mnt is somebody's own mount, not a
         // drvfs drive letter. Warning about it would be confidently wrong.
-        assert_eq!(mount_warning(Path::new("/mnt/data/repos/app"), &wsl_facts()), None);
-        assert_eq!(mount_warning(Path::new("/mnt/backup"), &wsl_facts()), None);
+        assert_eq!(mount_warning(Path::new("/mnt/data/repos/app"), &on_wsl()), None);
+        assert_eq!(mount_warning(Path::new("/mnt/backup"), &on_wsl()), None);
         // The bare drive root is still a drive.
-        assert!(mount_warning(Path::new("/mnt/d"), &wsl_facts()).is_some());
+        assert!(mount_warning(Path::new("/mnt/d"), &on_wsl()).is_some());
     }
 
     #[test]
     fn never_warns_about_a_mount_path_off_wsl() {
         // `/mnt/c` on a native Linux box is just a directory.
-        let native = HostFacts {
+        let native = WslFacts {
             kernel: Some("6.8.0-45-generic".into()),
-            ..Default::default()
+            wsl_distro: None,
         };
         assert_eq!(mount_warning(Path::new("/mnt/c/repos/app"), &native), None);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ pub mod cancel;
 pub mod cli;
 pub mod commands;
 pub mod detach;
+pub mod diagnostics;
 pub mod error;
 pub mod forge;
 pub mod git;
@@ -166,6 +167,22 @@ pub fn run() {
                     Some(p) => log::debug!("resolved child PATH ({} chars)", p.len()),
                     None => log::debug!("no login-shell PATH; children inherit ours"),
                 }
+                // Which machine wrote this log. Emitted here — on this thread,
+                // AFTER the PATH probe — for two reasons: `read_host_facts`
+                // spawns `git --version`, which has no business on the main
+                // thread; and `git=` has to report the git the app will
+                // actually spawn, which resolves against the child PATH. Read
+                // before the probe, a user whose git lives only on the login
+                // PATH would be told `git=UNAVAILABLE` by an app that then
+                // proceeds to run git perfectly well.
+                //
+                // INFO, not DEBUG: the log file's filter is pinned at `Info`,
+                // and a header nobody receives is the problem this line was
+                // added to solve (#274).
+                log::info!(
+                    "{}",
+                    crate::diagnostics::environment_line(crate::diagnostics::host_facts())
+                );
             });
             // macOS uses titleBarStyle: Overlay (set in tauri.conf.json) to keep native
             // traffic lights while letting our content extend under them. On Windows /
@@ -202,6 +219,9 @@ pub fn run() {
             commands::repo::open_in_editor,
             commands::repo::reveal_in_file_manager,
             commands::repo::open_in_terminal,
+            commands::diagnostics::diagnostics_report,
+            commands::diagnostics::read_log_tail,
+            commands::diagnostics::reveal_log_file,
             commands::commits::get_log,
             commands::commits::get_log_filtered,
             commands::commits::get_log_page,

--- a/src/features/repo/ops.picker.test.ts
+++ b/src/features/repo/ops.picker.test.ts
@@ -1,0 +1,70 @@
+// The folder picker is the one step on the open-a-repository path that the log
+// cannot see: `open` is plugin-dialog's own IPC call, so neither lib/tauri.ts's
+// invoke logging nor its stall watchdog covers it. Combined with every caller
+// using `void openRepoDialog()`, a rejection was an unhandled one — clicking
+// "Open repository" did nothing, forever, and left no trace anywhere (#274).
+//
+// A stock WSL install typically has no xdg-desktop-portal, which is exactly the
+// environment that makes `open` reject.
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { open } from "@tauri-apps/plugin-dialog";
+import { error as logError } from "@tauri-apps/plugin-log";
+
+import { openRepoDialog } from "./ops";
+import { useTabsStore } from "./useTabsStore";
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn() }));
+
+beforeEach(() => {
+  vi.mocked(open).mockReset();
+  vi.mocked(logError).mockClear();
+});
+
+describe("the open-repository folder picker", () => {
+  it("logs and reports a picker that will not open, instead of failing silently", async () => {
+    vi.mocked(open).mockRejectedValue(
+      new Error("Failed to open portal: org.freedesktop.portal.Desktop"),
+    );
+    const openRepo = vi
+      .spyOn(useTabsStore.getState(), "openRepo")
+      .mockResolvedValue(undefined);
+
+    // Must not reject: every call site is `void openRepoDialog()`, so a
+    // rejection here is unhandled and invisible.
+    await expect(openRepoDialog()).resolves.toBeUndefined();
+
+    expect(logError).toHaveBeenCalledTimes(1);
+    const line = String(vi.mocked(logError).mock.calls[0][0]);
+    expect(line).toContain("folder picker failed");
+    // The reason travels, not `[object Object]`.
+    expect(line).toContain("portal");
+    expect(openRepo).not.toHaveBeenCalled();
+  });
+
+  it("says nothing when the user simply cancels", async () => {
+    // `open` resolves to null for a cancel. That is the user getting what they
+    // asked for, and logging it as a failure would train people to ignore the
+    // line that matters.
+    vi.mocked(open).mockResolvedValue(null);
+    const openRepo = vi
+      .spyOn(useTabsStore.getState(), "openRepo")
+      .mockResolvedValue(undefined);
+
+    await openRepoDialog();
+
+    expect(logError).not.toHaveBeenCalled();
+    expect(openRepo).not.toHaveBeenCalled();
+  });
+
+  it("still opens the repository the user picked", async () => {
+    vi.mocked(open).mockResolvedValue("/mnt/c/dev/app");
+    const openRepo = vi
+      .spyOn(useTabsStore.getState(), "openRepo")
+      .mockResolvedValue(undefined);
+
+    await openRepoDialog();
+
+    expect(openRepo).toHaveBeenCalledWith("/mnt/c/dev/app");
+    expect(logError).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/repo/ops.ts
+++ b/src/features/repo/ops.ts
@@ -4,7 +4,9 @@
 // can fall through cleanly.
 
 import { open } from "@tauri-apps/plugin-dialog";
+import { error as logError } from "@tauri-apps/plugin-log";
 import { pgFlash } from "@/design";
+import { describeError } from "@/lib/errors";
 import { useCreateStore } from "@/features/create/useCreateStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { openMergeWindow } from "@/features/merge/openMergeWindow";
@@ -24,14 +26,48 @@ export function headUpstream(
   return [upstream.slice(0, idx), upstream.slice(idx + 1)];
 }
 
-/** Show the native folder picker and open the chosen repository. Shared by the
- *  titlebar/Welcome buttons and the ⌘O keymap action so all three agree. */
+/**
+ * Show the native folder picker and open the chosen repository. Shared by the
+ * titlebar/Welcome buttons and the ⌘O keymap action so all three agree.
+ *
+ * # Why the picker gets its own try/catch
+ *
+ * Every caller invokes this as `void openRepoDialog()` — the keymap runner must
+ * return a boolean synchronously, and the three buttons are click handlers. So a
+ * rejection here is an UNHANDLED one: no flash, no log, no change on screen.
+ * Clicking "Open repository" simply did nothing, forever, leaving no trace
+ * anywhere (#274).
+ *
+ * And the picker is the one step in the whole path that cannot be seen from the
+ * log: `open` is `@tauri-apps/plugin-dialog`'s own IPC call, not one of
+ * `lib/tauri.ts`'s, so neither the invoke logging nor the stall watchdog covers
+ * it. On Linux it reaches the XDG desktop portal, which is genuinely absent on
+ * some systems — a stock WSL install typically has no `xdg-desktop-portal` — and
+ * "the portal is missing" is a diagnosable environment problem the moment
+ * anybody is told about it.
+ *
+ * A cancel is NOT reported: `open` resolves to `null` for it, which is the user
+ * getting what they asked for.
+ */
 export async function openRepoDialog(): Promise<void> {
-  const selected = await open({
-    directory: true,
-    multiple: false,
-    title: "Open repository",
-  });
+  let selected: string | string[] | null;
+  try {
+    selected = await open({
+      directory: true,
+      multiple: false,
+      title: "Open repository",
+    });
+  } catch (e) {
+    logError(`folder picker failed: ${describeError(e)}`);
+    // Names the likely cause rather than echoing a D-Bus error nobody can act
+    // on. If the picker cannot open, the path typed into a terminal still works
+    // — `pgit <path>` does not need a portal.
+    pgFlash(
+      "Could not open the folder picker. On Linux this usually means no " +
+        "desktop portal is installed — try `pgit <path>` from a terminal.",
+    );
+    return;
+  }
   if (typeof selected === "string") {
     await useTabsStore.getState().openRepo(selected);
   }

--- a/src/lib/tauri.stall.test.ts
+++ b/src/lib/tauri.stall.test.ts
@@ -1,0 +1,81 @@
+// The stall watchdog is the only line this module logs while a call is still
+// outstanding, and it exists because of a failure the log could not describe:
+// four WSL launches recorded `check_for_update` and then nothing at all, and
+// nobody could tell an `open_repo` that hung from an `open_repo` that was never
+// issued (#274). Both look like silence.
+//
+// So these tests pin the property that matters — a call that never comes back
+// leaves a line naming itself — and, just as importantly, that a healthy call
+// leaves no such line. A watchdog that cries wolf on every launch gets ignored,
+// and an ignored watchdog is the bug all over again.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { warn as logWarn } from "@tauri-apps/plugin-log";
+
+import { mockInvoke } from "@/test/invokeMock";
+import { getStatus } from "./tauri";
+
+/** Mirrors `STALL_INVOKE_MS` in tauri.ts. */
+const STALL_MS = 10_000;
+
+function stallLines(): string[] {
+  return vi
+    .mocked(logWarn)
+    .mock.calls.map((c) => String(c[0]))
+    .filter((line) => line.includes("still pending"));
+}
+
+describe("the invoke stall watchdog", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("names a call that has not come back", async () => {
+    // A hang, modelled honestly: a promise with no path to settling. This is
+    // what a `git2` call blocked on a stat over WSL's 9p mount looks like from
+    // the webview — indefinitely pending, never rejected.
+    mockInvoke("get_status", () => new Promise<never>(() => {}));
+
+    const pending = getStatus("r1");
+    expect(stallLines()).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(STALL_MS);
+
+    const lines = stallLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("get_status");
+
+    // Leave nothing dangling for the next test; the call itself never settles.
+    void pending.catch(() => {});
+  });
+
+  it("stays quiet for a call that returns in time", async () => {
+    mockInvoke("get_status", () => []);
+
+    await expect(getStatus("r1")).resolves.toEqual([]);
+    // Well past the threshold: the timer must have been cleared, not merely
+    // not-yet-fired. `finally` is what guarantees this.
+    await vi.advanceTimersByTimeAsync(STALL_MS * 3);
+
+    expect(stallLines()).toEqual([]);
+  });
+
+  it("stays quiet for a call that fails fast", async () => {
+    // The `catch` arm returns via `throw`, so only a `finally` clears the timer
+    // here. Without one, every backend error would be followed ten seconds
+    // later by a phantom "still pending" line for a call that had long since
+    // reported its reason — noise that would make the watchdog untrustworthy
+    // exactly where the log is most read.
+    mockInvoke("get_status", () => {
+      throw { kind: "NotARepo", message: "not a git repository" };
+    });
+
+    await expect(getStatus("r1")).rejects.toBeTruthy();
+    await vi.advanceTimersByTimeAsync(STALL_MS * 3);
+
+    expect(stallLines()).toEqual([]);
+  });
+});

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -14,6 +14,7 @@ import type {
   CommitInfo,
   CommitResult,
   ConflictSides,
+  DiagnosticsReport,
   DiffKind,
   FileContent,
   FileDiff,
@@ -52,8 +53,46 @@ import type {
 
 const SLOW_INVOKE_MS = 250;
 
+/**
+ * How long an invoke may stay unsettled before the watchdog reports it.
+ *
+ * Deliberately far above `SLOW_INVOKE_MS`: this is not a "slow" threshold but a
+ * "we may never hear back" one. A real repository on a slow filesystem takes
+ * seconds legitimately — a WSL repo under `/mnt/c` spent 9.8s on the startup
+ * fan-out (#274) — so a low bound here would cry wolf on every launch.
+ */
+const STALL_INVOKE_MS = 10_000;
+
+/**
+ * Report an invoke that has not settled yet.
+ *
+ * Every other line this module writes is a PAST-TENSE record: emitted once the
+ * call returned or threw, carrying its duration. That made a whole failure
+ * class invisible — an invoke that hangs, or one that is never issued at all,
+ * produces no line ever. So a log from a repository that "would not open" was
+ * indistinguishable from a log of a session where nobody tried: the four WSL
+ * launches in #274 showed `check_for_update` and then silence, and the log
+ * could not say which.
+ *
+ * The watchdog logs in the PRESENT tense, from a timer, while the call is still
+ * outstanding. The absence of a matching completion line afterwards then
+ * becomes the evidence rather than the void: the call never came back.
+ *
+ * WARN, not DEBUG: the level has to clear the `Info` filter that
+ * `src-tauri/src/lib.rs` pins the log file to, or the one line worth having
+ * would be the one line dropped.
+ */
+function watchForStall(cmd: string): ReturnType<typeof setTimeout> {
+  return setTimeout(() => {
+    logWarn(`invoke ${cmd} still pending after ${STALL_INVOKE_MS}ms`);
+  }, STALL_INVOKE_MS);
+}
+
 async function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
   const start = performance.now();
+  // Paired with the `clearTimeout` in `finally`. Armed BEFORE the call so a
+  // `rawInvoke` that throws synchronously cannot leave a timer running.
+  const stall = watchForStall(cmd);
   try {
     const result = await rawInvoke<T>(cmd, args);
     const ms = Math.round(performance.now() - start);
@@ -70,6 +109,8 @@ async function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T
     // user-supplied log carried no reason at all (#146).
     logError(`invoke ${cmd} failed after ${ms}ms: ${describeError(err)}`);
     throw err;
+  } finally {
+    clearTimeout(stall);
   }
 }
 
@@ -1083,6 +1124,32 @@ export async function cliShimStatus(): Promise<CliShimStatus> {
 
 export async function installCliShim(): Promise<CliInstallOutcome> {
   return invoke<CliInstallOutcome>("install_cli_shim");
+}
+
+/**
+ * Where the log is, and what machine is writing it (#274).
+ *
+ * The log path is per-platform and was previously undocumented anywhere the
+ * user could see, which made "send me your log" a support conversation instead
+ * of a click.
+ */
+export async function diagnosticsReport(): Promise<DiagnosticsReport> {
+  return invoke<DiagnosticsReport>("diagnostics_report");
+}
+
+/**
+ * The tail of the log file, ready to paste into an issue.
+ *
+ * A TAIL, not the whole file: the log rotates at 5 MB and the backend reads only
+ * the last megabyte of it. Rejects when no log file exists yet.
+ */
+export async function readLogTail(): Promise<string> {
+  return invoke<string>("read_log_tail");
+}
+
+/** Reveal the log file in the platform's file manager. */
+export async function revealLogFile(): Promise<void> {
+  return invoke<void>("reveal_log_file");
 }
 
 export function checkForUpdate(): Promise<UpdateInfo> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -442,6 +442,24 @@ export interface CliShimStatus {
   pathState: CliPathState;
 }
 
+/**
+ * Where the app's log lives and what machine wrote it (#274).
+ *
+ * 1:1 with `DiagnosticsReport` in `src-tauri/src/commands/diagnostics.rs`.
+ */
+export interface DiagnosticsReport {
+  /** Absolute path to the current log file. */
+  logPath: string;
+  /** Whether that file exists yet — a fresh install may not have flushed. */
+  logExists: boolean;
+  /** Size in bytes, `null` when the file is absent. */
+  logSizeBytes: number | null;
+  /** The `host os=… wsl=… git=…` line, so the panel can show it unread. */
+  environment: string;
+  /** The running version, so a pasted report identifies its build. */
+  version: string;
+}
+
 export interface CliInstallOutcome {
   installed: boolean;
   path: string;

--- a/src/screens/Settings.diagnostics.test.tsx
+++ b/src/screens/Settings.diagnostics.test.tsx
@@ -1,0 +1,116 @@
+// The Diagnostics panel exists so that "send me your log" is a click rather
+// than a per-platform path nobody can be told over chat (#274). What these tests
+// pin is therefore not the layout but the two properties that make it work at
+// all: the path is shown verbatim, and what lands on the clipboard identifies
+// the machine it came from.
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { mockInvoke } from "@/test/invokeMock";
+import { SettingsScreen } from "./Settings";
+
+const LOG_PATH = "/home/jonas/.local/share/io.github.jonassaa.platypusgit/logs/platypusgit.log";
+const ENV_LINE =
+  "host os=linux arch=x86_64 kernel=5.15.153.1-microsoft-standard-WSL2 wsl=Ubuntu-24.04 git=2.43.0";
+
+/** The rest of the Settings screen loads too; give it what it asks for. */
+function mockRestOfSettings() {
+  mockInvoke("cli_shim_status", () => ({
+    installed: true,
+    shimPath: "/usr/local/bin/pgit",
+    target: "/usr/bin/platypusgit",
+    source: "package",
+    pathState: "onPath",
+  }));
+}
+
+function mockReport(over: Record<string, unknown> = {}) {
+  mockInvoke("diagnostics_report", () => ({
+    logPath: LOG_PATH,
+    logExists: true,
+    logSizeBytes: 4096,
+    environment: ENV_LINE,
+    version: "0.1.0",
+    ...over,
+  }));
+}
+
+let clipboard: string[];
+
+beforeEach(() => {
+  clipboard = [];
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: vi.fn((t: string) => void clipboard.push(t)) },
+  });
+  mockRestOfSettings();
+});
+
+describe("the Settings diagnostics panel", () => {
+  it("shows the log path and the environment line verbatim", async () => {
+    mockReport();
+    render(<SettingsScreen />);
+
+    // Verbatim and selectable: the user's next move is to copy it or go find
+    // the file, and a path shortened for layout serves neither.
+    expect(await screen.findByText(LOG_PATH)).toBeInTheDocument();
+    expect(screen.getByText(ENV_LINE)).toBeInTheDocument();
+  });
+
+  it("puts the version, environment and path ON the clipboard, above the tail", async () => {
+    mockReport();
+    mockInvoke("read_log_tail", () => "[2026-08-27][12:01:13][INFO] open_repo /mnt/c/dev/app");
+    render(<SettingsScreen />);
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /copy last 500 lines/i }),
+    );
+
+    await waitFor(() => expect(clipboard).toHaveLength(1));
+    const pasted = clipboard[0];
+    // The whole point: a tail alone cannot say which machine wrote it, and a
+    // 500-line window may not reach back to the startup header. #274 was hard
+    // to read for exactly this reason, so provenance travels with the copy.
+    expect(pasted).toContain("0.1.0");
+    expect(pasted).toContain(ENV_LINE);
+    expect(pasted).toContain(LOG_PATH);
+    expect(pasted).toContain("open_repo /mnt/c/dev/app");
+    // Header first, log after — not interleaved.
+    expect(pasted.indexOf(ENV_LINE)).toBeLessThan(pasted.indexOf("open_repo"));
+  });
+
+  it("offers neither action when no log file has been written yet", async () => {
+    mockReport({ logExists: false, logSizeBytes: null });
+    render(<SettingsScreen />);
+
+    // A button that reveals a nonexistent path fails in the file manager, where
+    // the error is the OS's problem to explain and it explains it badly.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /copy last 500 lines/i }),
+      ).toBeDisabled(),
+    );
+    expect(screen.getByRole("button", { name: /show file/i })).toBeDisabled();
+    expect(screen.getByText(/not written yet/i)).toBeInTheDocument();
+  });
+
+  it("reports a failed read instead of copying a lie", async () => {
+    mockReport();
+    mockInvoke("read_log_tail", () => {
+      throw { kind: "Io", message: "cannot read the log: permission denied" };
+    });
+    render(<SettingsScreen />);
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /copy last 500 lines/i }),
+    );
+
+    // Nothing reaches the clipboard: a user who is told "copied" and pastes an
+    // empty buffer into an issue has been actively misled.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /copy last 500 lines/i })).toBeEnabled(),
+    );
+    expect(clipboard).toEqual([]);
+  });
+});

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -23,10 +23,21 @@ import {
 } from "@/features/settings/useSettingsStore";
 import { HeadMarksControl } from "@/features/settings/HeadMarksControl";
 import { ForgeSettings } from "@/features/forge/ForgeSettings";
-import { cliShimStatus, installCliShim, type PullMode } from "@/lib/tauri";
+import {
+  cliShimStatus,
+  diagnosticsReport,
+  installCliShim,
+  readLogTail,
+  revealLogFile,
+  type PullMode,
+} from "@/lib/tauri";
 import { appErrorMessage } from "@/lib/errors";
 import { useUpdateStore } from "@/features/update/useUpdateStore";
-import type { CliPathState, CliShimStatus } from "@/lib/types";
+import type {
+  CliPathState,
+  CliShimStatus,
+  DiagnosticsReport,
+} from "@/lib/types";
 import { BUILTIN_PRESETS, useKeymapStore } from "@/features/keymap";
 
 export function SettingsScreen() {
@@ -272,6 +283,7 @@ export function SettingsScreen() {
         <KeyboardSection />
         <CliSection />
         <UpdatesSection />
+        <DiagnosticsSection />
       </div>
     </div>
   );
@@ -407,6 +419,107 @@ function CliSection() {
               {source === "app" ? "Reinstall pgit" : "Install pgit"}
             </PGButton>
           )
+        }
+      />
+    </Section>
+  );
+}
+
+/**
+ * Reaching the app's own log (#274).
+ *
+ * The log was always written and never reachable: diagnosing a report meant
+ * telling someone an undocumented per-platform path and hoping. That failure
+ * mode had a cost — a WSL repository that would not open produced four logged
+ * sessions nobody could interpret, because the log could neither say which
+ * machine wrote it nor that a call had been issued and never returned.
+ *
+ * So this panel does the three things a bug report needs: says where the log is,
+ * opens it, and copies its tail with the environment header on top.
+ */
+function DiagnosticsSection() {
+  const [report, setReport] = React.useState<DiagnosticsReport | null>(null);
+  const [busy, setBusy] = React.useState(false);
+
+  React.useEffect(() => {
+    diagnosticsReport()
+      .then(setReport)
+      .catch(() => setReport(null));
+  }, []);
+
+  const copy = async () => {
+    setBusy(true);
+    try {
+      const tail = await readLogTail();
+      // The header goes ON the clipboard, not just on screen. A pasted tail may
+      // not reach back far enough to include the startup `host …` line, and a
+      // log whose platform is unknown is what made #274 hard to read in the
+      // first place — so the copy carries its own provenance.
+      const header = report
+        ? `platypusgit ${report.version}\n${report.environment}\n${report.logPath}\n\n`
+        : "";
+      await navigator.clipboard?.writeText(`${header}${tail}`);
+      pgFlash("Log tail copied");
+    } catch (e) {
+      pgFlash(appErrorMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const reveal = async () => {
+    try {
+      await revealLogFile();
+    } catch (e) {
+      pgFlash(appErrorMessage(e));
+    }
+  };
+
+  return (
+    <Section
+      title="Diagnostics"
+      subtitle="The app's log — what to attach to a bug report."
+    >
+      <Row
+        label="Environment"
+        hint={
+          report ? (
+            <Mono selectable>{report.environment}</Mono>
+          ) : (
+            "Reading…"
+          )
+        }
+        control={<span />}
+      />
+      <Row
+        label="Log file"
+        hint={
+          report ? (
+            <>
+              <Mono selectable>{report.logPath}</Mono>
+              {!report.logExists && " — not written yet"}
+            </>
+          ) : (
+            "Reading…"
+          )
+        }
+        control={
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <PGButton
+              size="sm"
+              onClick={copy}
+              disabled={busy || !report?.logExists}
+            >
+              Copy last 500 lines
+            </PGButton>
+            <PGButton
+              size="sm"
+              onClick={reveal}
+              disabled={!report?.logExists}
+            >
+              Show file
+            </PGButton>
+          </div>
         }
       />
     </Section>


### PR DESCRIPTION
Refs #274. **Deliberately does not close it** — this makes the WSL failure
diagnosable and plugs the one hole that hid it, but it does not prove the cause.
#274 stays open until a log from the affected machine says what actually breaks.

## The problem

A WSL repository under `/mnt/c` would not load, and the log could not say why.
Four launches produced only `starting v0.1.0`, the PATH probe, and
`check_for_update slow: 259ms` — then silence. Four gaps, each verified in the
code rather than guessed:

1. **`src/lib/tauri.ts` logged only after a call settled.** An `open_repo` that
   hangs, or one never dispatched, produced no line ever. "Hung" and "never
   tried" were the same log.
2. **`src-tauri/src/lib.rs` pins the file filter at `Info`**, raising only
   `platypusgit_lib` to `Debug`. Every *successful* webview invoke is a
   `debug()` call, so the whole call sequence was dropped — absence of a line
   proves nothing.
3. **No environment header.** A WSL log and a native-Linux log were identical in
   shape. Working out which machine wrote the pasted one came down to comparing
   `resolved child PATH (N chars)` against a known-good log. A coincidence, not
   a procedure.
4. **The folder picker could fail completely silently** — see below. This is the
   likeliest cause of the reported symptom, and it left no trace anywhere.

## What changed

**A stall watchdog** (`src/lib/tauri.ts`) — WARN when an invoke is still
unsettled after 10s. The only line either side writes *while* a call is
outstanding, which is what turns a missing completion line into evidence. The
threshold sits far above `SLOW_INVOKE_MS` on purpose: a `/mnt/c` repo
legitimately spends ~9.8s on the startup fan-out, and a watchdog that cries wolf
every launch gets ignored.

**An environment header** (`src-tauri/src/diagnostics.rs`) — one
`host os=… arch=… kernel=… wsl=… git=…` INFO line per launch. Emitted on the
PATH-probe thread *after* the probe, so `git=` names the git the app will
actually spawn; read earlier, a user whose git lives only on the login PATH gets
told `git=UNAVAILABLE` by an app that runs git perfectly well.
`git=UNAVAILABLE` is spelled out where other absent fields are omitted, because
it pre-explains every git failure below it.

**`open_repo` instrumentation** — logs its path on the way in and its outcome on
the way out, so previously identical silences become different logs (triage table
in `docs/dev/backend.md`). A repo under `/mnt/<drive>` on WSL also logs a WARN:
every libgit2 `stat` crosses the VM boundary there. Not an error, but an
unexplained nine-second launch reads as a broken app.

**The folder picker no longer fails silently** (`src/features/repo/ops.ts`) —
the find that came out of writing the above. `open` is
`@tauri-apps/plugin-dialog`'s own IPC call, so it is invisible to the invoke
logging *and* to the new watchdog. And all four call sites
(`AppShell.tsx:688`, `RepoTabs.tsx:65`, `Welcome.tsx:15`, `openRepoOp`) invoke it
as `void openRepoDialog()` — the keymap runner must return a boolean
synchronously, the rest are click handlers. So a rejection was an *unhandled*
rejection: no flash, no log, no change on screen. Clicking "Open repository" did
nothing, forever, with nothing recording that it had been tried. On Linux `open`
reaches the XDG desktop portal, which a stock WSL install typically lacks — so
the environment most likely to hit this was also the one with no way to find
out. Now logged at ERROR with the reason and flashed with the likely cause plus
a route that needs no portal (`pgit <path>`). A cancel still says nothing: `open`
resolves to `null` for it, and logging that would train people to ignore the line
that matters.

**Settings → Diagnostics** — the log path shown verbatim, "Show file", and
"Copy last 500 lines". The copy puts version, environment line and path *on the
clipboard* above the tail: a 500-line window may not reach back to the startup
header, and a log whose platform is unknown is exactly what made #274 hard to
read. Reuses `reveal.rs` for "Show file", inheriting its
`explorer.exe`-exits-1-on-success and `xdg-open`-exits-3 handling rather than
respawning that logic.

## Also found, not addressed here

The one launch that *did* load the repo shows a second, separate problem. Twelve
startup invokes, all issued together, all completing in the same second,
durations clustered 9303–9820ms. Twelve genuinely-slow calls would stagger;
clustering means they queued behind one ~9.2s blocker and drained together —
same-repo ops serialize on the per-repo mutex (`git/libgit2.rs:60`). The same
signature appears as a ladder while arrowing through history (`diff_commit`
18851 → 22666 → 30473 → 34061 → 39260 → 44775ms, each with a `verify_commit`
alongside). Reducing the read fan-out's serialization would turn a 45s ladder
back into ~5s. Written up in #274; out of scope for a logging change.

## Tests

- `src/lib/tauri.stall.test.ts` — a hang gets named; a healthy call and a
  fast-failing call stay quiet. Verified red without the `finally`: both quiet
  cases fail, catching the phantom-warning noise that would make the watchdog
  untrustworthy exactly where the log is most read.
- `src/features/repo/ops.picker.test.ts` — a rejecting picker resolves (never
  rejects, since callers cannot catch), logs the reason, and does not open a
  repo; a cancel logs nothing; a real pick still opens.
- `src-tauri/src/diagnostics.rs` — 13 unit tests over pure functions, so WSL
  kernel detection and the `/mnt` classifier are testable from macOS. The
  classifier deliberately does not fire on `/mnt/data` (someone's own mount) or
  on `/mnt/c` off WSL.
- `src/screens/Settings.diagnostics.test.tsx` — path shown verbatim, provenance
  on the clipboard, both actions disabled with no log file, and a failed read
  copying nothing rather than telling the user "copied" over an empty buffer.

Full suite: 1953 frontend tests across 228 files, all pass. Rust: 0 failures.
`tsc --noEmit` and the e2e typecheck clean. E2E in Docker after a snapshot
rebuild: `settings` 8 passing, `repo-tabs` 9 passing, `smoke` 3 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
