### PR TITLE
fix(distribution)!: the MSI shipped claiming "github" as its publisher

### DIFF
--- a/docs/dev/distribution.md
+++ b/docs/dev/distribution.md
@@ -166,6 +166,51 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   — `iconutil -c iconset` unpacks the former, the latter is a container of
   PNGs.
 
+## The MSI's registry identity — pinned for winget
+
+Two `bundle` fields in `tauri.conf.json` exist only to control what the `.msi`
+writes into the Windows registry. Both were added because the Windows Package
+Manager reads that registry entry back and refuses to guess.
+
+- **`bundle.publisher: "platypusgit"`.** Unset, the bundler does *not* fall back
+  to the Cargo `authors` — it splits the bundle identifier and takes the second
+  segment (`settings.rs`, `msi/mod.rs`):
+
+  ```rust
+  let manufacturer = settings.publisher()
+    .unwrap_or_else(|| bundle_id.split('.').nth(1).unwrap_or(bundle_id));
+  ```
+
+  `io.github.jonassaa.platypusgit` → **`github`**. Every `.msi` up to and
+  including v0.1.1 therefore shipped with `Publisher: github` in Add/Remove
+  Programs and its shortcut bookkeeping under `HKCU\Software\github\platypusgit`.
+  That is wrong on its own, and it is disqualifying for winget: a manifest's
+  `AppsAndFeaturesEntries.Publisher` must match what the installer actually
+  wrote, so the manifest would have had to claim `github` as the publisher —
+  straight into a trademark/impersonation review.
+
+  Setting it moves the HKCU key to `Software\platypusgit\platypusgit`. That key
+  holds only shortcut flags and a `PrevInstallDir` search, and the default
+  install location is unchanged, so an upgrade over an older MSI still lands in
+  the same place. It does **not** touch the `UpgradeCode`.
+
+- **`bundle.windows.wix.upgradeCode`.** Pinned to
+  `8E03762C-0A45-5879-AB93-77EB9C468C68` — **the value the derivation was
+  already producing**, confirmed with `pnpm tauri inspect wix-upgrade-code`
+  before and after (it prints both the derived default and the override, so the
+  no-op is visible in one line). Pinning is therefore invisible to anyone who
+  already installed v0.1.x, and from here a `productName` change can no longer
+  orphan their install.
+
+**The `ProductCode` is not pinnable and must not be** — Tauri's `main.wxs` uses
+`<Product Id="*">`, so it regenerates on every build. Anything that needs it
+(a winget manifest does) has to read it out of the released `.msi`, never
+predict it.
+
+The MSI is **`InstallScope="perMachine"`**, hardcoded in the bundler's
+`main.wxs` — not configurable. That is why `wix/pgit-cli.wxs` can write the
+machine PATH, and why a winget manifest for this app is `Scope: machine`.
+
 ## The APT repository — one-line Linux install (#187)
 
 Spec: `docs/superpowers/specs/2026-08-26-apt-repository-spec.md`. Read that for
@@ -258,7 +303,7 @@ reporting**: `apt policy platypus-git` shows no candidate, which is why
 | macOS `platypusgit.app` | The **Homebrew cask must change in the same release** — its `app`, `binary` and `postflight` stanzas all name the bundle, and `bump-cask` only rewrites version + sha256. That job now cross-checks the cask's `app` stanza against `productName` and **fails the release** on a mismatch, because the alternative is discovering it when `brew install` breaks for every macOS user. |
 | `scripts/install-pgit.sh` | Searches BOTH `platypusgit.app` and `PlatypusGit.app`. It exists to serve an already-installed app, so dropping the old name would break the `pgit` one-liner for existing users. |
 | `.desktop` file | `platypusgit.desktop`. No consumer in this repo. |
-| Windows `UpgradeCode` | Derived as `Uuid::new_v5(NAMESPACE_DNS, "<productName>.exe.app.x64")` (`bundle/windows/msi/mod.rs`), so a rename **breaks in-place MSI upgrades** — the new installer lands alongside the old. Harmless this time (no `.msi` installs existed), but before there are real Windows users, pin `bundle.windows.wix.upgradeCode` so `productName` stops being load-bearing for upgrades. `pnpm tauri inspect wix-upgrade-code` prints the current value. |
+| Windows `UpgradeCode` | **No longer** — it is now pinned in `tauri.conf.json` (see below), so `productName` has stopped being load-bearing for MSI upgrades. It *was* derived as `Uuid::new_v5(NAMESPACE_DNS, "<productName>.exe.app.x64")` (`bundle/windows/msi/mod.rs`), which meant a rename **broke in-place MSI upgrades** — the new installer landed alongside the old. |
 
 **Not** renamed, deliberately: the release assets (`PlatypusGit_amd64.deb` and
 friends) are stable names the cask and `latest.json` track, decoupled from the

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -41,6 +41,7 @@
     "createUpdaterArtifacts": true,
     "targets": ["msi", "dmg", "deb", "appimage"],
     "category": "DeveloperTool",
+    "publisher": "platypusgit",
     "shortDescription": "A developer-focused git client",
     "longDescription": "PlatypusGit — a cross-platform, developer-focused git client.",
     "copyright": "Copyright (c) 2026 Jonas Aasberg",
@@ -64,6 +65,7 @@
     "windows": {
       "wix": {
         "language": ["en-US"],
+        "upgradeCode": "8E03762C-0A45-5879-AB93-77EB9C468C68",
         "fragmentPaths": ["wix/pgit-cli.wxs"],
         "componentRefs": ["PgitCli"]
       }

--- a/src-tauri/tests/msi_identity.rs
+++ b/src-tauri/tests/msi_identity.rs
@@ -1,0 +1,90 @@
+//! **The Windows `.msi` must keep telling the registry who published it and
+//! which product line it upgrades.** Two `bundle` fields in `tauri.conf.json`
+//! decide that, and both have defaults that are wrong in a way nothing else
+//! notices — the `.msi` builds, installs, and runs exactly the same either way.
+//! The damage shows up in Add/Remove Programs and, downstream of it, in the
+//! Windows Package Manager, which reads that registry entry back and refuses to
+//! guess (`docs/dev/distribution.md`, "The MSI's registry identity").
+//!
+//! Same shape as `no_telemetry.rs` beside it: a test over config text, because
+//! the property is about what the tree *declares*, not what a function returns.
+//! It lives in the Rust half because `tests.yml`'s `js` filter does not match
+//! `src-tauri/` — a vitest guard reading this file would be skipped by exactly
+//! the one-line edit it exists to police.
+//!
+//! Limits, stated honestly: this pins the two values, not their consequences.
+//! It cannot see the registry, and it does not build an `.msi`. It catches the
+//! realistic accident — a field dropped in a config tidy-up, or a `productName`
+//! change made without realising an unpinned `UpgradeCode` followed it.
+
+use std::path::Path;
+
+/// The `UpgradeCode` every shipped `.msi` has carried. It is **not** an
+/// arbitrary GUID: it is the value Tauri's own derivation was already producing
+/// from `productName`, so pinning it changed nothing for anyone who installed
+/// v0.1.x. Confirm with `pnpm tauri inspect wix-upgrade-code`, which prints the
+/// derived default and the override on separate lines.
+///
+/// Changing this orphans every existing Windows install — the next installer
+/// lands *alongside* the old one instead of upgrading it, and winget's
+/// `AppsAndFeaturesEntries.UpgradeCode` stops matching.
+const PINNED_UPGRADE_CODE: &str = "8E03762C-0A45-5879-AB93-77EB9C468C68";
+
+fn conf() -> serde_json::Value {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tauri.conf.json");
+    let text = std::fs::read_to_string(&path).expect("read tauri.conf.json");
+    serde_json::from_str(&text).expect("tauri.conf.json is valid JSON")
+}
+
+#[test]
+fn the_bundle_names_a_publisher() {
+    let conf = conf();
+    let publisher = conf["bundle"]["publisher"].as_str();
+
+    assert!(
+        publisher.is_some_and(|p| !p.trim().is_empty()),
+        "bundle.publisher is gone. Without it the bundler does NOT fall back to \
+         the Cargo `authors` — it takes the SECOND SEGMENT of the bundle \
+         identifier (`bundle_id.split('.').nth(1)`), and ours is \
+         `io.github.jonassaa.platypusgit`, so every `.msi` would ship claiming \
+         `github` as its publisher in Add/Remove Programs. See \
+         `docs/dev/distribution.md`."
+    );
+}
+
+#[test]
+fn the_publisher_is_not_the_identifier_fallback() {
+    let conf = conf();
+    let identifier = conf["identifier"]
+        .as_str()
+        .expect("identifier is a string");
+    let publisher = conf["bundle"]["publisher"]
+        .as_str()
+        .expect("bundle.publisher is a string");
+
+    // Reproduces the bundler's fallback (`msi/mod.rs`) rather than hard-coding
+    // `github`, so this keeps meaning the right thing if the identifier moves.
+    let fallback = identifier.split('.').nth(1).unwrap_or(identifier);
+    assert_ne!(
+        publisher, fallback,
+        "bundle.publisher has been set to `{fallback}` — the exact string the \
+         bundler would have used anyway from the identifier. That is the bug \
+         this field exists to fix, not a fix for it."
+    );
+}
+
+#[test]
+fn the_wix_upgrade_code_is_pinned() {
+    let conf = conf();
+    let code = conf["bundle"]["windows"]["wix"]["upgradeCode"].as_str();
+
+    assert_eq!(
+        code,
+        Some(PINNED_UPGRADE_CODE),
+        "bundle.windows.wix.upgradeCode is missing or changed. Unpinned, it is \
+         derived from `productName` (`Uuid::new_v5(NAMESPACE_DNS, \
+         \"<productName>.exe.app.x64\")`), which quietly makes a rename break \
+         in-place MSI upgrades. Pinned, a rename is safe — but editing the pin \
+         itself orphans every existing Windows install."
+    );
+}


### PR DESCRIPTION
Step 1 of getting the app onto **winget**. Config only — no code paths change,
and the `.msi` builds, installs and runs exactly as before. What changes is what
it writes into the Windows registry.

## The bug

`bundle.publisher` was never set. The bundler's fallback is **not** the Cargo
`authors` — it is the second segment of the bundle identifier
(`tauri-bundler/src/bundle/windows/msi/mod.rs`):

```rust
let manufacturer = settings.publisher()
  .unwrap_or_else(|| bundle_id.split('.').nth(1).unwrap_or(bundle_id));
```

`io.github.jonassaa.platypusgit` → **`github`**. So every `.msi` up to and
including v0.1.1 shipped with `Publisher: github` in Add/Remove Programs, and its
shortcut bookkeeping under `HKCU\Software\github\platypusgit`.

Bad on its own; disqualifying for winget. A manifest's
`AppsAndFeaturesEntries.Publisher` has to match what the installer actually
wrote, so the manifest would have had to claim `github` as the publisher —
straight into a trademark/impersonation review (`Policy-Test-2.2`).

Fix: `"publisher": "platypusgit"`, matching how the project brands itself in
`site/src/data/site.ts`, the apt package name, and the domain.

## The pin that came with it

`docs/dev/distribution.md` already carried a TODO to pin
`bundle.windows.wix.upgradeCode` "before there are real Windows users". winget
upgrades *are* real Windows users, so it is pinned here — to the value the
derivation **was already producing**:

```
Info Default WiX Upgrade Code, derived from platypusgit: 8e03762c-...-9c468c68
Info Application Upgrade Code override:                  8e03762c-...-9c468c68
```

Identical, so this is invisible to anyone already on v0.1.x. From here a
`productName` change can no longer silently orphan their install.

## Blast radius on existing Windows installs

- `UpgradeCode` unchanged → in-place upgrade still works.
- The HKCU key moves to `Software\platypusgit\platypusgit`. It holds only
  shortcut flags and a `PrevInstallDir` search, and the default install location
  is unchanged, so an upgrade lands in the same directory. Shortcut bookkeeping
  resets; nothing user-visible.

Marked `!` because it changes a published installer's registry identity, not
because it breaks an upgrade.

## The guard

`src-tauri/tests/msi_identity.rs` pins both fields. It is in the **Rust** suite
deliberately: `tests.yml`'s `js` filter does not match `src-tauri/`, so a vitest
guard reading this config would be skipped by exactly the one-line edit it
exists to police — the same split `no_telemetry.rs` documents beside it.

Rather than hard-coding `github`, the publisher test *reproduces* the bundler's
fallback from the identifier, so it keeps meaning the right thing if the
identifier ever moves.

Shown to fail on the bad inputs, not just to pass on the good ones:

```
publisher: "github", upgradeCode: 11111111-...
  the_publisher_is_not_the_identifier_fallback ... FAILED
  the_wix_upgrade_code_is_pinned ... FAILED
```

## Verification

- `pnpm test` — 1958 passed (228 files)
- `cargo test --test msi_identity` — 3 passed; negative case confirmed
- `cargo test --test no_telemetry --test update --test spawn_no_window` — 31 passed
- `pnpm tauri inspect wix-upgrade-code` — override == derived default

No e2e: config-only, and nothing here reaches the e2e snapshot.

## Next

2. Cut v0.1.2 (yours — publishing a release).
3. First winget submission against that `.msi` (yours — needs the Microsoft CLA
   and a `winget-pkgs` fork under your account).
4. Add a `winget-publish` job to `release.yml`, gated exactly like `bump-cask`.

Doing 1 before 3 is the point: it keeps `Publisher: github` from ever entering
the public winget catalog, where the `DisplayVersion`-range rules would lock it
in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
