### PR TITLE
fix(distribution): publisher must not equal productName

### DIFF
--- a/docs/dev/distribution.md
+++ b/docs/dev/distribution.md
@@ -172,7 +172,7 @@ Two `bundle` fields in `tauri.conf.json` exist only to control what the `.msi`
 writes into the Windows registry. Both were added because the Windows Package
 Manager reads that registry entry back and refuses to guess.
 
-- **`bundle.publisher: "platypusgit"`.** Unset, the bundler does *not* fall back
+- **`bundle.publisher: "Jonas Aasberg"`.** Unset, the bundler does *not* fall back
   to the Cargo `authors` — it splits the bundle identifier and takes the second
   segment (`settings.rs`, `msi/mod.rs`):
 
@@ -189,10 +189,20 @@ Manager reads that registry entry back and refuses to guess.
   wrote, so the manifest would have had to claim `github` as the publisher —
   straight into a trademark/impersonation review.
 
-  Setting it moves the HKCU key to `Software\platypusgit\platypusgit`. That key
-  holds only shortcut flags and a `PrevInstallDir` search, and the default
+  Setting it moves the HKCU key to `Software\Jonas Aasberg\platypusgit`. That
+  key holds only shortcut flags and a `PrevInstallDir` search, and the default
   install location is unchanged, so an upgrade over an older MSI still lands in
   the same place. It does **not** touch the `UpgradeCode`.
+
+  **It is a person's name, not the brand, and that is the constraint talking.**
+  Tauri's Microsoft Store page states *"Your application publisher name cannot
+  match the application product name"* and points at `bundle.publisher` as the
+  fix. `productName` is `platypusgit`, so `"platypusgit"` — the obvious choice,
+  and the one the winget precedent (`GitButler.GitButler`) suggests — is exactly
+  the pair Tauri documents as invalid. It shipped that way for one commit (#278)
+  before `docs/superpowers/specs/2026-08-27-microsoft-store-research.md` caught
+  it, and the window to change it closes the moment a release carries it into
+  users' registries. `msi_identity.rs` now fails on the collision.
 
 - **`bundle.windows.wix.upgradeCode`.** Pinned to
   `8E03762C-0A45-5879-AB93-77EB9C468C68` — **the value the derivation was

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -41,7 +41,7 @@
     "createUpdaterArtifacts": true,
     "targets": ["msi", "dmg", "deb", "appimage"],
     "category": "DeveloperTool",
-    "publisher": "platypusgit",
+    "publisher": "Jonas Aasberg",
     "shortDescription": "A developer-focused git client",
     "longDescription": "PlatypusGit — a cross-platform, developer-focused git client.",
     "copyright": "Copyright (c) 2026 Jonas Aasberg",

--- a/src-tauri/tests/msi_identity.rs
+++ b/src-tauri/tests/msi_identity.rs
@@ -73,6 +73,38 @@ fn the_publisher_is_not_the_identifier_fallback() {
     );
 }
 
+/// Tauri's own Microsoft Store page: *"Your application publisher name cannot
+/// match the application product name"*, and it names `bundle.publisher` as the
+/// way to resolve the clash. Nothing in the `.msi` path enforces this — a
+/// matching pair builds and installs fine — so the cost lands later, at a Store
+/// submission, by which point the publisher is already written into every
+/// installed machine's registry and into the winget `PackageIdentifier`.
+///
+/// This was not hypothetical: `publisher` first landed as `platypusgit`, which
+/// is exactly `productName`, and the clash was caught by reading
+/// `docs/superpowers/specs/2026-08-27-microsoft-store-research.md` rather than
+/// by any test. Hence this one.
+#[test]
+fn the_publisher_does_not_collide_with_the_product_name() {
+    let conf = conf();
+    let product = conf["productName"].as_str().expect("productName is a string");
+    let publisher = conf["bundle"]["publisher"]
+        .as_str()
+        .expect("bundle.publisher is a string");
+
+    // Case-insensitive: the constraint is about the displayed names being the
+    // same name, not the same bytes.
+    assert_ne!(
+        publisher.to_lowercase(),
+        product.to_lowercase(),
+        "bundle.publisher and productName are both `{product}`. Tauri documents \
+         this pair as invalid for the Microsoft Store — the publisher name may \
+         not match the product name — and fixing it after a release rewrites \
+         the publisher in every installed machine's Add/Remove Programs entry. \
+         See `docs/dev/distribution.md`."
+    );
+}
+
 #[test]
 fn the_wix_upgrade_code_is_pinned() {
     let conf = conf();


### PR DESCRIPTION
Follow-up to #278, which landed an hour ago. Same file, one value changed, plus
the guard that should have caught it.

## The problem

#278 set `bundle.publisher` to `platypusgit`. `productName` is also
`platypusgit`. Tauri's [Microsoft Store page](https://v2.tauri.app/distribute/microsoft-store/)
says:

> Your application publisher name cannot match the application product name

and points at `bundle.publisher` as the way to resolve exactly that clash. So
#278 traded a wrong publisher (`github`) for an invalid one.

`docs/superpowers/specs/2026-08-27-microsoft-store-research.md` (#277) had
already written this down — *"`platypusgit` is not available"* — but #277 and
#278 were in flight at the same time and neither saw the other. #277 even
recommends the value used here.

Nothing shipped with it: `git tag --contains f74b936` is empty. This is the last
cheap moment. After a release the publisher is in every installed machine's
Add/Remove Programs entry and in the winget `PackageIdentifier`, and changing it
then means rewriting both.

## The value

`"Jonas Aasberg"` — matches the Cargo `authors` field and the `copyright` line
already sitting in the same config. Chosen by @jonassaa over the brand-style
alternatives.

Consequences: Add/Remove Programs reads `platypusgit — Jonas Aasberg`; the HKCU
bookkeeping key becomes `Software\Jonas Aasberg\platypusgit`; the winget
identifier will be `JonasAasberg.PlatypusGit`. `UpgradeCode` untouched, so
in-place upgrades are unaffected.

## The guard

`the_publisher_does_not_collide_with_the_product_name`, in the same Rust file
#278 added. **Case-insensitive** on purpose — `PlatypusGit` vs `platypusgit` is
the variant someone reaches for next, and the constraint is about the displayed
names, not the bytes.

Shown to fail on that exact near-miss rather than only to pass on the fix:

```
publisher: "PlatypusGit"  (vs productName "platypusgit")
  the_publisher_does_not_collide_with_the_product_name ... FAILED
```

## Verification

- `cargo test --test msi_identity --test no_telemetry` — 12 passed
- `pnpm test` — 1958 passed (228 files)
- Negative case confirmed, then reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
