### PR TITLE
fix(distribution): the publisher cannot be the product name either

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -41,7 +41,7 @@
     "createUpdaterArtifacts": true,
     "targets": ["msi", "dmg", "deb", "appimage"],
     "category": "DeveloperTool",
-    "publisher": "platypusgit",
+    "publisher": "Jonas Aasberg",
     "shortDescription": "A developer-focused git client",
     "longDescription": "PlatypusGit — a cross-platform, developer-focused git client.",
     "copyright": "Copyright (c) 2026 Jonas Aasberg",

--- a/src-tauri/tests/msi_identity.rs
+++ b/src-tauri/tests/msi_identity.rs
@@ -74,6 +74,32 @@ fn the_publisher_is_not_the_identifier_fallback() {
 }
 
 #[test]
+fn the_publisher_is_not_the_product_name() {
+    let conf = conf();
+    let product = conf["productName"].as_str().expect("productName is a string");
+    let publisher = conf["bundle"]["publisher"]
+        .as_str()
+        .expect("bundle.publisher is a string");
+
+    // A THIRD wrong value for this field, and the only one that looks right.
+    // Tauri's Microsoft Store guidance: "Your application publisher name cannot
+    // match the application product name." `productName` is lowercase and
+    // load-bearing for the Debian package name, so the field that has to move is
+    // this one. See `docs/superpowers/specs/2026-08-27-msix-store-spec.md` §F.
+    //
+    // Not a style preference: it is a submission blocker for the Store channel,
+    // and once winget has published a manifest whose
+    // `AppsAndFeaturesEntries.Publisher` matches what the installer wrote,
+    // changing it means a second registry-identity change for every install.
+    assert_ne!(
+        publisher, product,
+        "bundle.publisher equals productName (`{product}`). The Microsoft Store \
+         rejects that pairing, so this blocks the MSIX channel. Use a person or \
+         entity name — the publisher is who ships it, not what is shipped."
+    );
+}
+
+#[test]
 fn the_wix_upgrade_code_is_pinned() {
     let conf = conf();
     let code = conf["bundle"]["windows"]["wix"]["upgradeCode"].as_str();


### PR DESCRIPTION
`bundle.publisher` had **two** wrong values available. #278 fixed the first (`github`, the identifier fallback). This is the second.

`"platypusgit"` equals `productName`, and Tauri's [Microsoft Store guide](https://v2.tauri.app/distribute/microsoft-store/) states: *"Your application publisher name cannot match the application product name."* It reads correct, which is exactly what makes it worth a guard rather than a comment.

## Why now, specifically

The window is open and closing:

- **No published release carries it.** v0.1.1 predates #278, so today this is one line and nobody's registry moves.
- **After v0.1.2** it becomes a second registry-identity change for everyone who installed.
- **After the first winget submission** it is locked in by `AppsAndFeaturesEntries.Publisher`, which has to match what the installer actually wrote.

`productName` is the field that can't move — the bundler derives the Debian package name from it (#269) — so the publisher is what changes. `"Jonas Aasberg"` is also just the accurate answer: the publisher is who ships it, not what is shipped.

## Why a fourth test

The three existing guards are deliberately value-agnostic — non-empty, and `!=` the identifier fallback — so **all three pass with either value**. Nothing in the suite could see this. Shown failing on the bad input, not just passing on the good one:

```
test the_publisher_is_not_the_product_name ... FAILED
  assertion `left != right` failed: bundle.publisher equals productName
  (`platypusgit`). The Microsoft Store rejects that pairing, so this blocks
  the MSIX channel.
test the_bundle_names_a_publisher ... ok
test the_publisher_is_not_the_identifier_fallback ... ok
test the_wix_upgrade_code_is_pinned ... ok
```

## Blast radius

`UpgradeCode` untouched → in-place upgrade unaffected. The HKCU shortcut-bookkeeping key moves from `Software\platypusgit\platypusgit` to `Software\Jonas Aasberg\platypusgit`; it holds shortcut flags and a `PrevInstallDir` search, the install location is unchanged, so an upgrade lands in the same directory. Not marked `!` because the value it replaces has never shipped.

## Verification

- `cargo test --test msi_identity` → 4 passed; negative case confirmed above.

Config + test only; nothing reaches the e2e snapshot.

Context: `docs/superpowers/specs/2026-08-27-msix-store-spec.md` §F (landing separately on `feat/msix-store`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)