### PR TITLE
feat(settings): opt out of update checks, or check only when asked

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -281,8 +281,11 @@ features/            Components + Zustand store colocated per feature:
 │                    useRepoStore). Applies via save_resolution, emits
 │                    merge://resolved → main refreshes
 ├── update/          useUpdateStore (discovery, semver-aware dismiss,
-│                    self-update), semver.ts (§11 precedence, tested),
-│                    UpdateChip, UpdatePanel (Escape via app.closeOverlay)
+│                    self-update; the updateCheckMode gate + lastCheckedAt live
+│                    HERE, not at the AppShell call site — see
+│                    docs/dev/distribution.md), semver.ts (§11 precedence,
+│                    tested), UpdateChip, UpdatePanel (Escape via
+│                    app.closeOverlay)
 ├── auth/            useAuthStore (ONE pending challenge + retry closure — never
 │                    the secret) + CredentialDialog. withAuthRetry LIVES IN
 │                    useRepoStore.ts, exported — never grow a second retry path

--- a/docs/dev/distribution.md
+++ b/docs/dev/distribution.md
@@ -105,6 +105,42 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   credentialed one — a pure-function test cannot show git still gets its
   answer.
 
+## The update check is opt-out, and the gate is in the store (#237)
+
+`updateCheckMode` (`PersistedState`, default `"auto"`) decides whether the app
+asks GitHub about a newer release: `auto` (startup check, today's behaviour),
+`manual` (nothing automatic; Settings → "Check for updates" still works), or
+`never` (no request from any path — the Settings button renders disabled and the
+titlebar `UpdateChip` is hidden).
+
+Three modes, not a toggle, because `manual` and `never` promise different things:
+`manual` is about controlling the *timing*, `never` is for a locked-down,
+offline, or blocked-endpoint machine where even an accidental click must produce
+no outbound traffic — and for users who read "no telemetry, no account" as
+covering the update endpoint too. Switching out of `never` is one click in the
+same row, so it is not a dead end.
+
+Two things are load-bearing about *where* this lives:
+
+- **The gate is inside `useUpdateStore.check()`, not at the `AppShell` call
+  site.** `check()` already takes `manual`, so it can decide before touching
+  `checkForUpdate()`: an automatic check needs `auto`, a manual one needs
+  anything but `never` (`checkAllowed`, pure and exported). Settings, the command
+  palette and the keymap all reach `check()`; gating only at the startup call
+  site would leave three paths able to spend a request the user switched off.
+  `src/features/update/updateCheckMode.test.ts` asserts `checkForUpdate` is
+  never **called** — a request whose result is discarded still hits the network.
+- **The last-checked timestamp is NOT in `PersistedState`.** It lives beside
+  `dismissedVersion` under the update store's own `pg-update-last-checked` key.
+  `PersistedState` is the portable-preferences bag that #254 exports to a
+  shareable JSON file, and a per-machine "when did this install last look" is
+  state, not a preference. It also only advances on a *completed* check: a
+  timestamp that moved on an offline failure would read as "checked fine just
+  now" on exactly the machine whose updater is stuck.
+
+The per-version snooze (`dismissedVersion` / `shouldNag`) is orthogonal and
+unchanged — that is "not this release", not "not ever".
+
 ## Permissions (Tauri 2)
 
 - Shared permissions in `src-tauri/capabilities/default.json`: `core:default`,

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -243,6 +243,11 @@ export function AppShell() {
 
   // Check for a newer release shortly after launch — non-blocking, and silent
   // on failure (offline, rate-limited). Manual re-check lives in Settings.
+  //
+  // Deliberately NOT gated here: the "check for updates" preference (#237) is
+  // enforced inside check() itself, so this call site, Settings and the command
+  // palette cannot drift apart. `check(false)` says "automatic", which is the
+  // only thing the store needs to decide whether a request is allowed.
   React.useEffect(() => {
     const t = setTimeout(() => {
       void useUpdateStore.getState().check(false);

--- a/src/features/settings/useSettingsStore.test.ts
+++ b/src/features/settings/useSettingsStore.test.ts
@@ -163,6 +163,44 @@ describe("head marks migration", () => {
   });
 });
 
+describe("updateCheckMode (#237)", () => {
+  // The out-of-box behaviour must not change: an app that stops telling people
+  // about security fixes by default is worse than one that asks.
+  it("defaults to auto", async () => {
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().updateCheckMode).toBe("auto");
+  });
+
+  it("honors a persisted mode", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ updateCheckMode: "never" }));
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().updateCheckMode).toBe("never");
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ updateCheckMode: "manual" }));
+    const again = await freshStore();
+    expect(again.useSettingsStore.getState().updateCheckMode).toBe("manual");
+  });
+
+  // Same reasoning as the signCommits tri-state and the diff modes: the store
+  // and the gate branch on these exact strings, so an unknown value has to fall
+  // back rather than resolve to "neither" — which here would mean an app that
+  // silently never checks for updates again.
+  it("falls back to auto for an unknown or wrongly-typed persisted value", async () => {
+    for (const bad of ["weekly", "", true, 0, null] as unknown[]) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ updateCheckMode: bad }));
+      const { useSettingsStore } = await freshStore();
+      expect(useSettingsStore.getState().updateCheckMode, String(bad)).toBe("auto");
+    }
+  });
+
+  it("reset() returns to auto", async () => {
+    const { useSettingsStore } = await freshStore();
+    useSettingsStore.getState().set("updateCheckMode", "never");
+    expect(useSettingsStore.getState().updateCheckMode).toBe("never");
+    useSettingsStore.getState().reset();
+    expect(useSettingsStore.getState().updateCheckMode).toBe("auto");
+  });
+});
+
 describe("logo theme slots", () => {
   const BRAND_PRIMARY = "#3e9b91";
   const BRAND_SECONDARY = "#e6a95a";

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -592,6 +592,35 @@ export function applyZoom(zoom: number): void {
   })();
 }
 
+// ─── Update checks (#237) ────────────────────────────────────────────────────
+
+/**
+ * When the app is allowed to ask GitHub whether a newer release exists.
+ *
+ * Three modes rather than a toggle, because "manual" and "never" are different
+ * promises and conflating them breaks one of them:
+ *
+ * - `auto`   — the startup check runs (today's behaviour, and the default:
+ *              shipping security fixes matters more than the request).
+ * - `manual` — no automatic request, ever; Settings → "Check for updates" still
+ *              works. For people who want to control the TIMING.
+ * - `never`  — no request from any path. The Settings button renders disabled,
+ *              so an accidental click cannot produce outbound traffic either.
+ *              For locked-down, offline or blocked-endpoint machines, and for
+ *              users who chose this app partly for "no telemetry, no account"
+ *              and want that to include the update endpoint.
+ *
+ * Orthogonal to the per-version snooze (`useUpdateStore.dismissedVersion`),
+ * which is about one release rather than about checking at all.
+ */
+export type UpdateCheckMode = "auto" | "manual" | "never";
+
+export const UPDATE_CHECK_MODES: readonly UpdateCheckMode[] = [
+  "auto",
+  "manual",
+  "never",
+];
+
 // ═════════════════════════════════════════════════════════════════════════════
 // STORE
 // ═════════════════════════════════════════════════════════════════════════════
@@ -651,6 +680,18 @@ interface PersistedState {
    */
   diffContextMode: "wholeFile" | "chunks";
   ignoreWhitespaceInDiff: boolean;
+  /**
+   * Whether the app checks for a newer release, and on whose initiative — see
+   * UpdateCheckMode. The gate itself lives in `useUpdateStore.check()`, not at
+   * the call sites, so no path can spend a request the user disabled.
+   *
+   * The last-checked TIMESTAMP deliberately does not live here: `PersistedState`
+   * is the portable-preferences bag (#254 exports it to a shareable file), and a
+   * per-machine "when did this install last look" is not a preference anyone
+   * would want to import. It lives beside `dismissedVersion` in the update
+   * store's own localStorage key.
+   */
+  updateCheckMode: UpdateCheckMode;
   /** Parent directory last used for Clone/Init, prefilled next time. */
   lastCreateDir: string;
 }
@@ -691,6 +732,7 @@ const DEFAULTS: PersistedState = {
   diffViewMode: "inline",
   diffContextMode: "wholeFile",
   ignoreWhitespaceInDiff: false,
+  updateCheckMode: "auto",
   lastCreateDir: "",
 };
 
@@ -739,6 +781,14 @@ function load(): PersistedState {
     }
     if (!["wholeFile", "chunks"].includes(out.diffContextMode as string)) {
       out.diffContextMode = DEFAULTS.diffContextMode;
+    }
+    // Same reasoning for the update-check mode, with a sharper failure: the gate
+    // in useUpdateStore only lets `auto` through automatically, so an unknown
+    // string (hand-edited file, a mode a newer build added) would silently mean
+    // "this install never checks for updates again" — the one outcome nobody
+    // asked for. Anything not one of the three modes falls back to "auto".
+    if (!UPDATE_CHECK_MODES.includes(out.updateCheckMode as UpdateCheckMode)) {
+      out.updateCheckMode = DEFAULTS.updateCheckMode;
     }
     // Backfill logo colors for custom themes saved before the slots existed,
     // so the theme editor and CSS vars always have a value.
@@ -791,6 +841,7 @@ function snapshot(s: SettingsState): PersistedState {
     diffViewMode: s.diffViewMode,
     diffContextMode: s.diffContextMode,
     ignoreWhitespaceInDiff: s.ignoreWhitespaceInDiff,
+    updateCheckMode: s.updateCheckMode,
     lastCreateDir: s.lastCreateDir,
   };
 }

--- a/src/features/update/UpdateChip.tsx
+++ b/src/features/update/UpdateChip.tsx
@@ -1,4 +1,5 @@
 import { PGIcon } from "@/design";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { useUpdateStore } from "./useUpdateStore";
 
 /** Titlebar chip shown whenever an update is available (even if dismissed). */
@@ -6,7 +7,14 @@ export function UpdateChip() {
   const available = useUpdateStore((s) => s.info?.available ?? false);
   const latest = useUpdateStore((s) => s.info?.latestVersion);
   const openPanel = useUpdateStore((s) => s.openPanel);
+  const mode = useSettingsStore((s) => s.updateCheckMode);
 
+  // "Never" is not only "make no request" (#237). A session that checked before
+  // the user switched checks off still holds the result, and a chip whose only
+  // action is a panel offering to update is the interruption they opted out of.
+  // `manual` deliberately still shows it: that mode gates the REQUEST, not the
+  // answer to a check the user asked for.
+  if (mode === "never") return null;
   if (!available) return null;
 
   return (

--- a/src/features/update/UpdatePanel.test.tsx
+++ b/src/features/update/UpdatePanel.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { useUpdateStore } from "./useUpdateStore";
 import { UpdatePanel } from "./UpdatePanel";
 import { UpdateChip } from "./UpdateChip";
@@ -42,9 +43,10 @@ function seed(partial: Partial<ReturnType<typeof useUpdateStore.getState>>) {
 }
 
 describe("UpdateChip", () => {
-  beforeEach(() =>
-    useUpdateStore.setState({ info: null, status: "idle", panelOpen: false }),
-  );
+  beforeEach(() => {
+    useSettingsStore.getState().set("updateCheckMode", "auto");
+    useUpdateStore.setState({ info: null, status: "idle", panelOpen: false });
+  });
 
   it("is hidden when no update is available", () => {
     render(<UpdateChip />);
@@ -58,6 +60,25 @@ describe("UpdateChip", () => {
     expect(chip).toHaveTextContent("0.1.0");
     await userEvent.click(chip);
     expect(useUpdateStore.getState().panelOpen).toBe(true);
+  });
+
+  // "Never" is not only "make no request": a chip nagging about a version found
+  // before the user turned checks off is the same interruption they opted out
+  // of, and its only action is a panel offering to update (#237).
+  it("is hidden when update checks are turned off", () => {
+    seed({ panelOpen: false });
+    useSettingsStore.getState().set("updateCheckMode", "never");
+    render(<UpdateChip />);
+    expect(screen.queryByTestId("pg-update-chip")).toBeNull();
+  });
+
+  it("still shows under 'only when I ask'", () => {
+    // manual gates the REQUEST, not the result: a check the user asked for that
+    // found something must still be visible outside Settings.
+    seed({ panelOpen: false });
+    useSettingsStore.getState().set("updateCheckMode", "manual");
+    render(<UpdateChip />);
+    expect(screen.getByTestId("pg-update-chip")).toHaveTextContent("0.1.0");
   });
 });
 

--- a/src/features/update/updateCheckMode.test.ts
+++ b/src/features/update/updateCheckMode.test.ts
@@ -1,0 +1,163 @@
+// The update-check preference (#237) — the gate, not the label.
+//
+// The point of this file is a NEGATIVE assertion: when the preference forbids a
+// check, `checkForUpdate` must not be CALLED. "A request whose result is
+// ignored" would satisfy a status-only test and still put a packet on the wire,
+// which is exactly what "Never" promises not to do — so `@/lib/tauri` is mocked
+// here and the assertion is on the call count.
+//
+// Mocking the wrapper module rather than `invoke` is deliberate: it pins the
+// boundary the store is allowed to reach, so a future second discovery path
+// (a bare `invoke`, a fetch) would show up as an unmocked call rather than
+// slipping past a satisfied assertion.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { UpdateInfo } from "@/lib/types";
+
+const tauri = vi.hoisted(() => ({
+  checkForUpdate: vi.fn(),
+  getUpdateCapability: vi.fn(),
+  openUrl: vi.fn(),
+}));
+vi.mock("@/lib/tauri", () => tauri);
+
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { checkAllowed, useUpdateStore } from "./useUpdateStore";
+
+const AVAILABLE: UpdateInfo = {
+  available: true,
+  currentVersion: "0.0.5",
+  latestVersion: "0.1.0",
+  notes: "rebase fixes",
+  releaseUrl: "https://github.com/jonassaa/platypusgit/releases/tag/v0.1.0",
+  publishedAt: "2026-07-08T10:00:00Z",
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  tauri.checkForUpdate.mockReset().mockResolvedValue(AVAILABLE);
+  tauri.getUpdateCapability.mockReset().mockResolvedValue("notify");
+  tauri.openUrl.mockReset().mockResolvedValue(undefined);
+  useSettingsStore.getState().set("updateCheckMode", "auto");
+  useUpdateStore.setState({
+    status: "idle",
+    info: null,
+    capability: null,
+    dismissedVersion: null,
+    currentVersion: null,
+    lastCheckedAt: null,
+    installing: false,
+    progress: null,
+    error: null,
+    message: null,
+    panelOpen: false,
+  });
+});
+
+describe("updateCheckMode gate — no request the user disabled", () => {
+  it("automatic check makes NO request when the mode is 'manual'", async () => {
+    useSettingsStore.getState().set("updateCheckMode", "manual");
+    await useUpdateStore.getState().check(false);
+    expect(tauri.checkForUpdate).not.toHaveBeenCalled();
+    expect(tauri.getUpdateCapability).not.toHaveBeenCalled();
+    // Silent: a startup check the user turned off is not an error state.
+    expect(useUpdateStore.getState().status).toBe("idle");
+    expect(useUpdateStore.getState().error).toBeNull();
+  });
+
+  it("automatic check makes NO request when the mode is 'never'", async () => {
+    useSettingsStore.getState().set("updateCheckMode", "never");
+    await useUpdateStore.getState().check(false);
+    expect(tauri.checkForUpdate).not.toHaveBeenCalled();
+    expect(tauri.getUpdateCapability).not.toHaveBeenCalled();
+    expect(useUpdateStore.getState().status).toBe("idle");
+  });
+
+  it("MANUAL check makes NO request when the mode is 'never'", async () => {
+    // The whole reason the gate lives in the store: Settings, the command
+    // palette and the keymap all reach check(true), and "Never" has to hold on
+    // every one of them — including a click on a button that somehow rendered
+    // enabled.
+    useSettingsStore.getState().set("updateCheckMode", "never");
+    await useUpdateStore.getState().check(true);
+    expect(tauri.checkForUpdate).not.toHaveBeenCalled();
+    expect(tauri.getUpdateCapability).not.toHaveBeenCalled();
+    expect(useUpdateStore.getState().status).toBe("idle");
+  });
+
+  it("manual check DOES request when the mode is 'manual'", async () => {
+    useSettingsStore.getState().set("updateCheckMode", "manual");
+    await useUpdateStore.getState().check(true);
+    expect(tauri.checkForUpdate).toHaveBeenCalledTimes(1);
+    expect(useUpdateStore.getState().status).toBe("available");
+  });
+
+  it("automatic check DOES request when the mode is 'auto'", async () => {
+    await useUpdateStore.getState().check(false);
+    expect(tauri.checkForUpdate).toHaveBeenCalledTimes(1);
+    expect(useUpdateStore.getState().status).toBe("available");
+  });
+
+  it("leaves an already-known update on screen when switched to 'never'", async () => {
+    // Turning checks off must not make a check that already happened vanish
+    // mid-session; it stops future requests. What the chip does with it is
+    // UpdateChip's business (see UpdatePanel.test.tsx).
+    await useUpdateStore.getState().check(false);
+    useSettingsStore.getState().set("updateCheckMode", "never");
+    expect(useUpdateStore.getState().info).toEqual(AVAILABLE);
+  });
+
+  it("still honours the per-version snooze, which is orthogonal", async () => {
+    useUpdateStore.setState({ dismissedVersion: "0.1.0" });
+    await useUpdateStore.getState().check(false);
+    const s = useUpdateStore.getState();
+    expect(s.status).toBe("available");
+    expect(s.panelOpen).toBe(false);
+  });
+});
+
+describe("lastCheckedAt", () => {
+  it("is recorded and persisted after a completed check", async () => {
+    expect(useUpdateStore.getState().lastCheckedAt).toBeNull();
+    const before = Date.now();
+    await useUpdateStore.getState().check(true);
+    const at = useUpdateStore.getState().lastCheckedAt;
+    expect(at).not.toBeNull();
+    expect(at!).toBeGreaterThanOrEqual(before);
+    expect(localStorage.getItem("pg-update-last-checked")).toBe(String(at));
+  });
+
+  it("does NOT advance on a failed check", async () => {
+    // A timestamp that moves on an offline failure reads as "checked fine just
+    // now" on precisely the machine whose updater is stuck.
+    tauri.checkForUpdate.mockRejectedValue({ kind: "Network", message: "offline" });
+    await useUpdateStore.getState().check(true);
+    expect(useUpdateStore.getState().lastCheckedAt).toBeNull();
+    expect(localStorage.getItem("pg-update-last-checked")).toBeNull();
+  });
+
+  it("does NOT advance for a blocked check", async () => {
+    useSettingsStore.getState().set("updateCheckMode", "never");
+    await useUpdateStore.getState().check(true);
+    expect(useUpdateStore.getState().lastCheckedAt).toBeNull();
+  });
+
+  it("stays OUT of the portable settings payload (#254 exports it)", async () => {
+    // Per-machine state, not a preference: a last-checked time must not travel
+    // in someone's exported settings file.
+    await useUpdateStore.getState().check(true);
+    const raw = JSON.parse(localStorage.getItem("pg-settings-v2") ?? "{}");
+    expect("lastCheckedAt" in raw).toBe(false);
+  });
+});
+
+describe("checkAllowed — the rule, as a table", () => {
+  it("lets automatic through only on auto, and manual through unless never", () => {
+    expect(checkAllowed("auto", false)).toBe(true);
+    expect(checkAllowed("auto", true)).toBe(true);
+    expect(checkAllowed("manual", false)).toBe(false);
+    expect(checkAllowed("manual", true)).toBe(true);
+    expect(checkAllowed("never", false)).toBe(false);
+    expect(checkAllowed("never", true)).toBe(false);
+  });
+});

--- a/src/features/update/useUpdateStore.test.ts
+++ b/src/features/update/useUpdateStore.test.ts
@@ -31,6 +31,7 @@ function reset() {
     capability: null,
     dismissedVersion: null,
     currentVersion: null,
+    lastCheckedAt: null,
     installing: false,
     progress: null,
     error: null,

--- a/src/features/update/useUpdateStore.ts
+++ b/src/features/update/useUpdateStore.ts
@@ -1,11 +1,24 @@
 import { create } from "zustand";
 
+import {
+  useSettingsStore,
+  type UpdateCheckMode,
+} from "@/features/settings/useSettingsStore";
 import { appErrorMessage } from "@/lib/errors";
 import { checkForUpdate, getUpdateCapability, openUrl } from "@/lib/tauri";
 import type { UpdateCapability, UpdateInfo } from "@/lib/types";
 import { compareSemver } from "./semver";
 
 const DISMISS_KEY = "pg-update-dismissed";
+/**
+ * When this install last completed an update check.
+ *
+ * Stored here rather than in the settings store's `PersistedState` on purpose:
+ * that bag is the portable preferences payload (#254 exports it to a file people
+ * share), and a per-machine timestamp is state, not a preference — it must not
+ * travel in someone else's settings.
+ */
+const LAST_CHECKED_KEY = "pg-update-last-checked";
 
 export type UpdateStatus =
   | "idle"
@@ -21,6 +34,14 @@ export interface UpdateState {
   dismissedVersion: string | null;
   /** The running app's version — one source for every version readout. */
   currentVersion: string | null;
+  /**
+   * Epoch ms of the last COMPLETED check, or null if this install has never
+   * finished one. Only advanced on success: a timestamp that moved on an
+   * offline failure would read as "checked fine just now" on exactly the
+   * machine whose updater is stuck, which is what people open this panel to
+   * find out.
+   */
+  lastCheckedAt: number | null;
   /**
    * A self-update is downloading/installing. Deliberately NOT a `status` value:
    * `status` is owned by `check()`, so overloading it let any check (e.g.
@@ -50,6 +71,27 @@ function loadDismissed(): string | null {
   }
 }
 
+function loadLastChecked(): number | null {
+  try {
+    const raw = localStorage.getItem(LAST_CHECKED_KEY);
+    if (!raw) return null;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether a check with this initiative is allowed to hit the network at all.
+ *
+ * PURE and exported so the rule can be read (and tested) without a store: an
+ * automatic check needs `auto`, a manual one needs anything but `never`.
+ */
+export function checkAllowed(mode: UpdateCheckMode, manual: boolean): boolean {
+  return manual ? mode !== "never" : mode === "auto";
+}
+
 /**
  * An update exists that the user hasn't already dismissed.
  *
@@ -73,6 +115,7 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
   capability: null,
   dismissedVersion: loadDismissed(),
   currentVersion: null,
+  lastCheckedAt: loadLastChecked(),
   installing: false,
   progress: null,
   error: null,
@@ -82,6 +125,17 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
   async check(manual) {
     // Never yank the Install button out from under an in-flight install.
     if (get().installing) return;
+    // The update-check preference is enforced HERE, before anything reaches the
+    // network — not only at the AppShell startup call site. check() is reachable
+    // from the startup timer and from Settings today, and from any palette or
+    // keymap entry someone adds tomorrow; a call-site-only gate would need
+    // remembering at each one, and the one that forgets spends a request the
+    // user switched off. Silent rather than an error: a check the user disabled
+    // is not a failure, and the Settings panel already says checks are off.
+    if (!checkAllowed(useSettingsStore.getState().updateCheckMode, manual)) {
+      set({ status: "idle" });
+      return;
+    }
     set({ status: "checking", error: null, message: null });
     try {
       // Capability is stable per install; fetch once.
@@ -90,7 +144,18 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
         capability = await getUpdateCapability();
       }
       const info = await checkForUpdate();
-      set({ info, capability, currentVersion: info.currentVersion });
+      const lastCheckedAt = Date.now();
+      try {
+        localStorage.setItem(LAST_CHECKED_KEY, String(lastCheckedAt));
+      } catch {
+        // non-fatal — the in-memory value still serves this session
+      }
+      set({
+        info,
+        capability,
+        currentVersion: info.currentVersion,
+        lastCheckedAt,
+      });
       if (info.available) {
         set({ status: "available" });
         // Auto-open the panel only for a version the user hasn't dismissed.

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -20,6 +20,7 @@ import {
   useSettingsStore,
   type ThemeColors,
   type ThemeDef,
+  type UpdateCheckMode,
 } from "@/features/settings/useSettingsStore";
 import { HeadMarksControl } from "@/features/settings/HeadMarksControl";
 import { ForgeSettings } from "@/features/forge/ForgeSettings";
@@ -31,6 +32,7 @@ import {
   revealLogFile,
   type PullMode,
 } from "@/lib/tauri";
+import { relativeTime } from "@/lib/derive";
 import { appErrorMessage } from "@/lib/errors";
 import { useUpdateStore } from "@/features/update/useUpdateStore";
 import type {
@@ -576,6 +578,7 @@ function PathNote({
 }
 
 function UpdatesSection() {
+  const settings = useSettingsStore();
   const status = useUpdateStore((s) => s.status);
   const info = useUpdateStore((s) => s.info);
   const error = useUpdateStore((s) => s.error);
@@ -584,7 +587,9 @@ function UpdatesSection() {
   // Single source: the store owns the running version (seeded from getVersion,
   // and confirmed by check() from the backend's env!("CARGO_PKG_VERSION")).
   const currentVersion = useUpdateStore((s) => s.currentVersion);
+  const lastCheckedAt = useUpdateStore((s) => s.lastCheckedAt);
   const loadCurrentVersion = useUpdateStore((s) => s.loadCurrentVersion);
+  const off = settings.updateCheckMode === "never";
 
   React.useEffect(() => {
     void loadCurrentVersion();
@@ -624,6 +629,31 @@ function UpdatesSection() {
         subtitle="Check whether a newer PlatypusGit release is available."
       >
         <Row
+          label="Check for updates"
+          hint={
+            <>
+              <strong>Automatically</strong> asks GitHub shortly after launch.{" "}
+              <strong>Only when I ask</strong> never checks on its own — the
+              button below still works. <strong>Never</strong> makes no request
+              at all, from any part of the app.
+            </>
+          }
+          control={
+            <PGSelect
+              data-testid="update-check-mode"
+              value={settings.updateCheckMode}
+              onChange={(v) =>
+                settings.set("updateCheckMode", v as UpdateCheckMode)
+              }
+              options={[
+                { value: "auto", label: "Automatically" },
+                { value: "manual", label: "Only when I ask" },
+                { value: "never", label: "Never" },
+              ]}
+            />
+          }
+        />
+        <Row
           label="Current version"
           hint={
             <>
@@ -631,6 +661,21 @@ function UpdatesSection() {
                 {currentVersion || "…"}
               </code>
               {statusNode && <> — {statusNode}</>}
+              <div data-testid="update-last-checked" style={{ marginTop: 3 }}>
+                {off ? (
+                  // Not a dead end: the reason the button is disabled names the
+                  // setting one row up, which is one click from "Only when I
+                  // ask".
+                  <>Update checks are turned off.</>
+                ) : (
+                  <>
+                    Last checked:{" "}
+                    {lastCheckedAt
+                      ? relativeTime(Math.floor(lastCheckedAt / 1000))
+                      : "never"}
+                  </>
+                )}
+              </div>
             </>
           }
           control={
@@ -638,6 +683,10 @@ function UpdatesSection() {
               size="sm"
               onClick={() => check(true)}
               loading={status === "checking"}
+              disabled={off}
+              title={
+                off ? "Update checks are turned off in Settings" : undefined
+              }
             >
               Check for updates
             </PGButton>

--- a/src/screens/Settings.updates.test.tsx
+++ b/src/screens/Settings.updates.test.tsx
@@ -1,0 +1,138 @@
+// The Updates panel's half of #237: the three-way preference is reachable, and
+// "Never" is visibly off rather than a button that quietly does nothing.
+//
+// The gate itself is pinned in features/update/updateCheckMode.test.ts — this
+// file only asserts the UI cannot lead someone into it.
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { mockInvoke } from "@/test/invokeMock";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { useUpdateStore } from "@/features/update/useUpdateStore";
+import { SettingsScreen } from "./Settings";
+
+/** The rest of the Settings screen loads too; give it what it asks for. */
+function mockRestOfSettings() {
+  mockInvoke("cli_shim_status", () => ({
+    installed: true,
+    shimPath: "/usr/local/bin/pgit",
+    target: "/usr/bin/platypusgit",
+    source: "package",
+    pathState: "onPath",
+  }));
+  mockInvoke("diagnostics_report", () => ({
+    logPath: "/tmp/platypusgit.log",
+    logExists: false,
+    logSizeBytes: 0,
+    environment: "host os=macos arch=aarch64 git=2.43.0",
+    version: "0.1.0",
+  }));
+}
+
+let checked: boolean[];
+
+beforeEach(() => {
+  checked = [];
+  localStorage.clear();
+  mockRestOfSettings();
+  useSettingsStore.getState().set("updateCheckMode", "auto");
+  useUpdateStore.setState({
+    status: "idle",
+    info: null,
+    capability: null,
+    dismissedVersion: null,
+    currentVersion: "0.1.0",
+    lastCheckedAt: null,
+    installing: false,
+    progress: null,
+    error: null,
+    message: null,
+    panelOpen: false,
+    check: vi.fn(async (manual: boolean) => void checked.push(manual)),
+  });
+});
+
+const modeSelect = () => screen.getByTestId("update-check-mode");
+const checkButton = () =>
+  screen.getByRole("button", { name: /check for updates/i });
+
+/** PGSelect is an in-page listbox, not a native <select> — its rows are the
+ *  only place the labels appear once (the trigger renders a hidden sizing copy
+ *  of the current one, which is why a bare getByText finds two). */
+const openModeOptions = async (): Promise<HTMLElement[]> => {
+  await userEvent.click(modeSelect());
+  return [...document.querySelectorAll<HTMLElement>("[data-pg-option]")];
+};
+
+const pickMode = async (label: string) => {
+  const rows = await openModeOptions();
+  const row = rows.find((r) => r.textContent === label);
+  if (!row) throw new Error(`no option labelled "${label}"`);
+  await userEvent.click(row);
+};
+
+describe("Settings → Updates: the check preference", () => {
+  it("offers the three modes through PGSelect and persists the choice", async () => {
+    render(<SettingsScreen />);
+    // The labels are the promise the user reads; assert them, not the values.
+    const rows = await openModeOptions();
+    expect(rows.map((r) => r.textContent)).toEqual([
+      "Automatically",
+      "Only when I ask",
+      "Never",
+    ]);
+    // And no native control got there by the back door (guard-tested globally,
+    // asserted here because this is the row that introduced one).
+    expect(document.querySelector("select")).toBeNull();
+    expect(document.querySelector("option")).toBeNull();
+
+    await userEvent.click(rows[1]);
+    expect(useSettingsStore.getState().updateCheckMode).toBe("manual");
+    const raw = JSON.parse(localStorage.getItem("pg-settings-v2") ?? "{}");
+    expect(raw.updateCheckMode).toBe("manual");
+  });
+
+  it("keeps the manual button live under 'only when I ask'", async () => {
+    useSettingsStore.getState().set("updateCheckMode", "manual");
+    render(<SettingsScreen />);
+    expect(checkButton()).not.toBeDisabled();
+    await userEvent.click(checkButton());
+    expect(checked).toEqual([true]);
+  });
+
+  it("disables the button and explains itself under 'never'", async () => {
+    useSettingsStore.getState().set("updateCheckMode", "never");
+    render(<SettingsScreen />);
+    expect(checkButton()).toBeDisabled();
+    expect(
+      screen.getByText(/update checks are turned off/i),
+    ).toBeInTheDocument();
+    // Disabled means disabled: even a forced click reaches nothing.
+    await userEvent.click(checkButton(), { pointerEventsCheck: 0 });
+    expect(checked).toEqual([]);
+  });
+
+  it("is one click back out of 'never' — not a dead end", async () => {
+    useSettingsStore.getState().set("updateCheckMode", "never");
+    render(<SettingsScreen />);
+    await pickMode("Only when I ask");
+    expect(useSettingsStore.getState().updateCheckMode).toBe("manual");
+    await waitFor(() => expect(checkButton()).not.toBeDisabled());
+  });
+});
+
+describe("Settings → Updates: last checked", () => {
+  it("says never when nothing has been checked yet", () => {
+    render(<SettingsScreen />);
+    expect(screen.getByTestId("update-last-checked")).toHaveTextContent(
+      /never/i,
+    );
+  });
+
+  it("shows a relative time once a check has run", () => {
+    useUpdateStore.setState({ lastCheckedAt: Date.now() - 2 * 3600 * 1000 });
+    render(<SettingsScreen />);
+    expect(screen.getByTestId("update-last-checked")).toHaveTextContent("2h ago");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds real update preferences, so update checking is something the user controls rather than something that just happens.

- **`updateCheckMode`** — `auto` / `manual` / `never`, default `auto` — joins `PersistedState` in `useSettingsStore`, validated in `load()` like the other enums.
- **The gate is inside `useUpdateStore.check()`**, via an exported pure `checkAllowed(mode, manual)`.
- **Last-checked time** in the Updates section, persisted beside `dismissedVersion`.
- The existing "Check for updates" button and current-version readout are **extended, not rebuilt** — they already shipped.

Part of #237. The **stable/prerelease channel picker is deliberately not here** — it reaches into the updater engine and the release/prerelease behaviour, and lands separately. Issue stays open for it.

## Why?

**The issue's three modes were self-contradictory as written.** It asks for three modes, insists "never must genuinely make no request", and also wants a manual button "so never is not a dead end". All three cannot hold: a "never" that still permits a manual request is indistinguishable from "only when I ask".

Resolved as:

| Mode | Startup check | Settings button |
|---|---|---|
| **Automatically** (default) | runs, as today | works |
| **Only when I ask** | never fires | works |
| **Never** | never fires | **disabled**, and says why |

Under **Never** the `UpdateChip` is hidden too, so nothing in the UI advertises updates and no path can produce outbound traffic. Not a dead end: the picker that undoes it is the row directly above the disabled button.

**Why the gate is in the store, not the call site.** `check(manual)` already knows whether it was user-initiated, and is reachable from the startup timer, from Settings, and from any palette/keymap entry added later. A call-site gate would need remembering at each one, and the one that forgets spends a request the user switched off — the same reasoning as the repo's "never a second auth path" rule. `AppShell` gets a comment pointing at the store instead of a duplicate gate.

**Why the timestamp is not in `PersistedState`.** That bag is the portable-preferences payload #254 is about to export to a shareable JSON file. A per-machine "when did this install last look" is state, not a preference, and must not travel in someone else's settings. There is a test pinning it out of the payload.

**Why `lastCheckedAt` only advances on a completed check.** A timestamp that moved on an offline failure would read as "checked fine just now" on exactly the machine whose updater is stuck — which is what people open this panel to find out.

This also strengthens #226: "you can switch off the only outbound request we make" is now literally true.

## Notable for review

- **Existing installs land on `auto`** — the key is absent from their persisted payload, so `load()` fills the default. Behaviour does not change for anyone who does nothing.
- An unknown persisted value (hand-edited file, a mode a newer build adds) falls back to `auto`, not to "never check again".
- `UpdatePanel` itself is not gated — under `never` the chip is gone and no check runs, so `panelOpen` has no path to `true`. Say the word if you want it belt-and-braces.

## Checklist

- [x] One logical change, focused PR
- [x] Branched off `main`; rebased onto `3f15cb7`, no merge commits, single squashed commit
- [x] PR title + commit message follow Conventional Commits
- [x] `pnpm tsc --noEmit` passes — exit 0
- [ ] `cargo test` — **not run locally: no Rust in this diff.** CI's rust job covers it
- [x] `pnpm test` passes — 230 files, 1982 tests, includes the `docs` and `privacy` projects
- [x] `e2e/` untouched
- [x] Added tests — including three that assert `checkForUpdate` and `getUpdateCapability` are **never called** when the mode forbids it
- [x] Not a new git op
- [x] Not a new feature area — extends an existing settings surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
