### PR TITLE
feat(ui): "Copy relative path", and one meaning for "Copy path"

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -334,7 +334,8 @@ lib/                 tauri.ts (typed invoke wrappers — frontend NEVER calls
                      ResizeObserver), useWindowedList.ts, useVariableWindow.ts
                      (incl. scrollTo — every programmatic diff scroll),
                      useDiffRowHeight.ts (--diff-row-h → px, jsdom fallback),
-                     platform.ts, fileIcon.ts, selection.ts
+                     platform.ts, fileIcon.ts, paths.ts (workdir-relative ⇄
+                     absolute, pure — no node:path in a webview), selection.ts
                      (+ splitFileSelection), tree.ts (buildStatusTree /
                      buildStatusList — SAME row keys), useTreeViewMode.ts,
                      recents.ts (pg-recent-repos; the OPEN set is pg-open-repos

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -500,6 +500,33 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   `submoduleMenuItems` (the file menu is dead ends on a gitlink); staging stays
   legal — an updated pointer is an ordinary commit.
 
+### Paths on the clipboard, and the file manager (#245)
+
+- **The label is the contract**: `copyPathItems(paths)` in
+  `design/context-menu.tsx` emits the "Copy path" (absolute) / "Copy relative
+  path" (workdir-relative) pair, plural above one path, and is the ONLY place a
+  file surface should spell either out. Before it, "Copy path" copied a
+  *relative* path on the file row, the embedded-repo row, the multi-select and
+  the diff pane's ⋯ menu, and an absolute one on the worktree menu and the repo
+  tab — one label, two meanings.
+- The arithmetic is pure and separate: `lib/paths.ts`
+  (`relativeToWorkdir` / `absoluteInWorkdir` / `normalizeSeparators` /
+  `isAbsolutePath`). No `node:path` in the webview, so the separator is inferred
+  from the value — a Windows or UNC workdir gets its own style back on the way
+  out, and comparison is case-insensitive only there. Out-of-workdir answers
+  `null`; it never emits `../..`.
+- Two surfaces deliberately have NO relative entry: `worktreeMenuItems` and
+  `RepoTabs.tsx`'s `tabMenuItems`. Their target is a repository root, whose path
+  relative to itself is `""`.
+- **"Open containing folder" is the reveal entry** — there is no second menu
+  item, on any platform. `reveal_in_file_manager` passes `is_dir: false` for a
+  relative path, and `reveal.rs` then runs `open -R` / `explorer /select,` (the
+  parent window, file selected) or xdg-opens the parent on Linux. The only
+  variant that would differ is a folder window with no selection, which needs
+  `reveal(parent, is_dir: true)` — a backend change, not a frontend one.
+  `context-menu.copyPath.test.tsx` pins the single entry so the synonym does not
+  get added.
+
 ## Drag and drop
 
 - **Pointer events, never HTML5 drag-and-drop** — WebDriver can't synthesize an

--- a/src/design/context-menu.copyPath.test.tsx
+++ b/src/design/context-menu.copyPath.test.tsx
@@ -1,0 +1,212 @@
+// "Copy path" / "Copy relative path" on every surface that has a file (#245).
+//
+// The pair is one helper (`copyPathItems`) reused by the four file-bearing
+// menus, so what this pins is: the two entries always sit together, each copies
+// what its LABEL says (absolute for "Copy path", workdir-relative for "Copy
+// relative path"), and the surfaces where a relative path is meaningless — the
+// worktree menu and the repo tab, whose path relative to itself is "" — never
+// grow one.
+//
+// The path arithmetic itself is unit-tested in `src/lib/paths.test.ts`; this is
+// about which entry appears where and what it dispatches.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import {
+  copyPathItems,
+  fileMenuItems,
+  multiFileMenuItems,
+  worktreeMenuItems,
+  type ContextMenuItem,
+} from "./context-menu";
+import { tabMenuItems } from "@/features/repo/RepoTabs";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useTabsStore } from "@/features/repo/useTabsStore";
+
+const copied: string[] = [];
+
+const labels = (items: ContextMenuItem[]) =>
+  items.filter((i) => !i.divider && !i.__menuTitle).map((i) => String(i.label));
+
+function item(items: ContextMenuItem[], label: string): ContextMenuItem {
+  const found = items.find((i) => String(i.label) === label);
+  expect(found, `no menu item labelled ${label}`).toBeDefined();
+  return found!;
+}
+
+const click = async (items: ContextMenuItem[], label: string) => {
+  await item(items, label).onClick?.();
+};
+
+function openRepoAt(path: string | null) {
+  useRepoStore.setState({
+    current: path ? { id: "r1", path, head: "main" } : null,
+  } as never);
+}
+
+beforeEach(() => {
+  copied.length = 0;
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: {
+      writeText: vi.fn((t: string) => {
+        copied.push(t);
+        return Promise.resolve();
+      }),
+    },
+  });
+  openRepoAt("/repo");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.innerHTML = "";
+});
+
+describe("copyPathItems", () => {
+  it("offers the singular pair for one path", () => {
+    expect(labels(copyPathItems(["src/a.txt"]))).toEqual([
+      "Copy path",
+      "Copy relative path",
+    ]);
+  });
+
+  it("offers the plural pair for a multi-path selection", () => {
+    expect(labels(copyPathItems(["a.txt", "b.txt"]))).toEqual([
+      "Copy paths",
+      "Copy relative paths",
+    ]);
+  });
+
+  it("copies the absolute path for 'Copy path'", async () => {
+    await click(copyPathItems(["src/a.txt"]), "Copy path");
+    expect(copied).toEqual(["/repo/src/a.txt"]);
+  });
+
+  it("copies the workdir-relative path for 'Copy relative path'", async () => {
+    await click(copyPathItems(["src/a.txt"]), "Copy relative path");
+    expect(copied).toEqual(["src/a.txt"]);
+  });
+
+  it("uses the workdir's own separator style for the absolute form", async () => {
+    openRepoAt("C:\\Users\\me\\repo");
+    await click(copyPathItems(["src/a.txt"]), "Copy path");
+    expect(copied).toEqual(["C:\\Users\\me\\repo\\src\\a.txt"]);
+  });
+
+  it("joins a multi-path copy with newlines, on both entries", async () => {
+    const items = copyPathItems(["src/a.txt", "b.txt"]);
+    await click(items, "Copy paths");
+    await click(items, "Copy relative paths");
+    expect(copied).toEqual(["/repo/src/a.txt\n/repo/b.txt", "src/a.txt\nb.txt"]);
+  });
+
+  it("disables the absolute entry with no repository open, keeping the relative one", async () => {
+    openRepoAt(null);
+    const items = copyPathItems(["src/a.txt"]);
+    expect(item(items, "Copy path").disabled).toBe(true);
+    expect(item(items, "Copy relative path").disabled).toBeFalsy();
+
+    await click(items, "Copy path");
+    expect(copied).toEqual([]);
+    await click(items, "Copy relative path");
+    expect(copied).toEqual(["src/a.txt"]);
+  });
+
+  it("disables both entries when there is no path", () => {
+    const items = copyPathItems([]);
+    expect(item(items, "Copy path").disabled).toBe(true);
+    expect(item(items, "Copy relative path").disabled).toBe(true);
+  });
+
+  it("copies nothing at all when the path list is empty", async () => {
+    const items = copyPathItems([""]);
+    await click(items, "Copy path");
+    await click(items, "Copy relative path");
+    expect(copied).toEqual([]);
+  });
+});
+
+describe("the file row menu", () => {
+  it("offers both entries next to each other", () => {
+    const items = fileMenuItems({ path: "src/a.txt" }, "macos");
+    const l = labels(items);
+    expect(l.indexOf("Copy relative path")).toBe(l.indexOf("Copy path") + 1);
+  });
+
+  it("copies absolute and relative from the same row", async () => {
+    const items = fileMenuItems({ path: "src/a.txt" }, "macos");
+    await click(items, "Copy path");
+    await click(items, "Copy relative path");
+    expect(copied).toEqual(["/repo/src/a.txt", "src/a.txt"]);
+  });
+
+  it("offers both entries on an embedded-repository row", async () => {
+    const items = fileMenuItems({ path: "vendor/lib/", embedded: true }, "macos");
+    expect(labels(items)).toContain("Copy relative path");
+    await click(items, "Copy path");
+    await click(items, "Copy relative path");
+    // libgit2 reports an embedded repo with a trailing slash (it is gitignore
+    // syntax there); neither clipboard form should carry it.
+    expect(copied).toEqual(["/repo/vendor/lib", "vendor/lib"]);
+  });
+
+  it("has exactly one file-manager entry, addressing the file itself", () => {
+    // Reveal (#231) already opens the CONTAINING folder on all three platforms
+    // — `open -R` / `explorer /select,` open the parent with the file selected,
+    // and Linux xdg-opens the parent. A second "Open containing folder" entry
+    // would be a synonym, so there is deliberately only one.
+    const items = fileMenuItems({ path: "src/a.txt" }, "linux");
+    expect(labels(items).filter((l) => /folder|file manager|Finder|Explorer/i.test(l))).toEqual([
+      "Show in file manager",
+    ]);
+  });
+});
+
+describe("the multi-file selection menu", () => {
+  it("offers both plural entries", () => {
+    const items = multiFileMenuItems({
+      stagedPaths: [],
+      unstagedPaths: ["src/a.txt", "b.txt"],
+    });
+    const l = labels(items);
+    expect(l.indexOf("Copy relative paths")).toBe(l.indexOf("Copy paths") + 1);
+  });
+
+  it("copies every selected path, absolute or relative", async () => {
+    const items = multiFileMenuItems({
+      stagedPaths: ["staged.txt"],
+      unstagedPaths: ["src/a.txt"],
+      paths: ["staged.txt", "src/a.txt", "untouched.txt"],
+    });
+    await click(items, "Copy paths");
+    await click(items, "Copy relative paths");
+    expect(copied).toEqual([
+      "/repo/staged.txt\n/repo/src/a.txt\n/repo/untouched.txt",
+      "staged.txt\nsrc/a.txt\nuntouched.txt",
+    ]);
+  });
+});
+
+describe("surfaces with no meaningful relative path", () => {
+  it("leaves the worktree menu with only an absolute Copy path", async () => {
+    const items = worktreeMenuItems({ name: "wt", path: "/elsewhere/wt" });
+    expect(labels(items)).toContain("Copy path");
+    expect(labels(items)).not.toContain("Copy relative path");
+
+    await click(items, "Copy path");
+    expect(copied).toEqual(["/elsewhere/wt"]);
+  });
+
+  it("leaves the repo tab menu with only an absolute Copy path", async () => {
+    useTabsStore.setState({
+      tabs: [{ path: "/repo-a", repoId: "repo-a-id", status: "open" } as never],
+    } as never);
+    const items = tabMenuItems("/repo-a", 1, "macos");
+    expect(labels(items)).toContain("Copy path");
+    expect(labels(items)).not.toContain("Copy relative path");
+
+    await click(items, "Copy path");
+    expect(copied).toEqual(["/repo-a"]);
+  });
+});

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -25,6 +25,7 @@ import { currentBranch } from "@/lib/derive";
 import { openCreateTag } from "@/features/tags/useCreateTagStore";
 import { chordFor } from "@/features/keymap";
 import { fileManagerLabel, type Platform } from "@/lib/platform";
+import { absoluteInWorkdir, relativeToWorkdir } from "@/lib/paths";
 // pgFlash lives in ui-helpers.tsx — a toast is not a context-menu concern, and
 // keeping it out of this module is what lets features/keymap import it without
 // closing a cycle back through this file (which imports chordFor from there).
@@ -885,6 +886,59 @@ export function submoduleMenuItems(
   ];
 }
 
+/**
+ * The "Copy path" / "Copy relative path" pair, for one path or a whole
+ * selection (#245).
+ *
+ * One helper rather than four hand-written pairs because the two entries only
+ * make sense together: before this, "Copy path" copied a *relative* path on
+ * every file surface (the file row, the embedded-repo row, the multi-select and
+ * the diff pane's ⋯ menu) and an absolute one on the worktree menu and the repo
+ * tab, so the same label meant two different things depending on where you
+ * right-clicked. Now the label is the contract — "Copy path" is always
+ * absolute, "Copy relative path" always workdir-relative.
+ *
+ * `paths` are repository-relative (what git reports and every file list holds);
+ * an absolute one is passed through unharmed. Empty strings are dropped, so a
+ * row with no path yields two disabled entries instead of copying the workdir.
+ * The absolute entry is disabled — not silently downgraded — when no repository
+ * is open, since a path is either the real one or not worth pasting.
+ *
+ * Two surfaces deliberately do NOT call this: the worktree menu and the repo
+ * tab menu, whose target IS a repository root. Its path relative to itself is
+ * the empty string, so the pair would be one real entry and one that copies
+ * nothing.
+ */
+export function copyPathItems(paths: string[]): ContextMenuItem[] {
+  const workdir = useRepoStore.getState().current?.path ?? null;
+  const targets = paths.filter((p) => !!p && !!p.trim());
+  const plural = targets.length > 1;
+  const keep = (v: string | null): v is string => !!v;
+  const absolute = targets.map((p) => absoluteInWorkdir(workdir, p)).filter(keep);
+  const relative = targets.map((p) => relativeToWorkdir(workdir, p)).filter(keep);
+
+  const copy = (values: string[], what: string) => () => {
+    if (!values.length) return;
+    navigator.clipboard?.writeText(values.join("\n"));
+    pgFlash(`copied ${what}`);
+  };
+
+  return [
+    {
+      icon: "copy",
+      label: plural ? "Copy paths" : "Copy path",
+      disabled: !absolute.length,
+      onClick: copy(absolute, plural ? "paths" : "path"),
+    },
+    {
+      icon: "copy",
+      label: plural ? "Copy relative paths" : "Copy relative path",
+      disabled: !relative.length,
+      onClick: copy(relative, plural ? "relative paths" : "relative path"),
+    },
+  ];
+}
+
 export function worktreeMenuItems(
   worktree: {
     name?: string;
@@ -1574,11 +1628,7 @@ function embeddedRepoMenuItems(path: string): ContextMenuItem[] {
         if (path) useRepoStore.getState().openInEditor(path);
       },
     },
-    {
-      icon: "copy",
-      label: "Copy path",
-      onClick: () => navigator.clipboard?.writeText(path),
-    },
+    ...copyPathItems([path]),
   ];
 }
 
@@ -1689,11 +1739,14 @@ export function fileMenuItems(
       },
     },
     { divider: true },
-    {
-      icon: "copy",
-      label: "Copy path",
-      onClick: () => navigator.clipboard?.writeText(path),
-    },
+    ...copyPathItems([path]),
+    // This IS "open containing folder", on all three platforms: `open -R` and
+    // `explorer /select,` open the parent window with the file selected, and
+    // Linux xdg-opens the parent (there is no portable "select this file"
+    // verb). A separate "Open containing folder" entry would be a synonym — the
+    // only variant that differs is a folder window with NO selection, which
+    // needs `reveal(parent, is_dir: true)` and so a backend change. See
+    // docs/dev/frontend.md.
     {
       icon: "folder",
       label: fileManagerLabel(platform),
@@ -1909,17 +1962,7 @@ export function multiFileMenuItems(
         }),
     });
   }
-  items.push(
-    { divider: true },
-    {
-      icon: "copy",
-      label: "Copy paths",
-      onClick: () => {
-        navigator.clipboard?.writeText(all.join("\n"));
-        pgFlash("copied paths");
-      },
-    },
-  );
+  items.push({ divider: true }, ...copyPathItems(all));
   if (unstagedPaths.length) {
     items.push(
       { divider: true },

--- a/src/lib/paths.test.ts
+++ b/src/lib/paths.test.ts
@@ -1,0 +1,143 @@
+// Path arithmetic for "Copy path" / "Copy relative path" (#245). Pure, so every
+// platform's separator and every degenerate input is testable from any host.
+import { describe, expect, it } from "vitest";
+
+import {
+  absoluteInWorkdir,
+  isAbsolutePath,
+  normalizeSeparators,
+  relativeToWorkdir,
+} from "./paths";
+
+describe("normalizeSeparators", () => {
+  it("turns backslashes into forward slashes", () => {
+    expect(normalizeSeparators("src\\lib\\paths.ts")).toBe("src/lib/paths.ts");
+    expect(normalizeSeparators("C:\\repo\\a.txt")).toBe("C:/repo/a.txt");
+  });
+
+  it("collapses repeated separators and drops trailing ones", () => {
+    expect(normalizeSeparators("src//lib/")).toBe("src/lib");
+    expect(normalizeSeparators("src\\lib\\\\")).toBe("src/lib");
+    expect(normalizeSeparators("/repo/")).toBe("/repo");
+  });
+
+  it("keeps a lone root", () => {
+    expect(normalizeSeparators("/")).toBe("/");
+    expect(normalizeSeparators("\\")).toBe("/");
+  });
+
+  it("passes the empty string through", () => {
+    expect(normalizeSeparators("")).toBe("");
+  });
+});
+
+describe("isAbsolutePath", () => {
+  it("recognises posix, drive-letter and UNC roots", () => {
+    expect(isAbsolutePath("/repo/a.txt")).toBe(true);
+    expect(isAbsolutePath("C:\\repo\\a.txt")).toBe(true);
+    expect(isAbsolutePath("c:/repo/a.txt")).toBe(true);
+    expect(isAbsolutePath("\\\\server\\share\\a.txt")).toBe(true);
+  });
+
+  it("rejects relative paths", () => {
+    expect(isAbsolutePath("src/a.txt")).toBe(false);
+    expect(isAbsolutePath("src\\a.txt")).toBe(false);
+    expect(isAbsolutePath("./a.txt")).toBe(false);
+    expect(isAbsolutePath("../a.txt")).toBe(false);
+    expect(isAbsolutePath("")).toBe(false);
+  });
+});
+
+describe("relativeToWorkdir", () => {
+  it("strips the workdir prefix from an absolute path", () => {
+    expect(relativeToWorkdir("/repo", "/repo/src/a.txt")).toBe("src/a.txt");
+  });
+
+  it("tolerates trailing separators on either side", () => {
+    expect(relativeToWorkdir("/repo/", "/repo/src/a.txt")).toBe("src/a.txt");
+    expect(relativeToWorkdir("/repo", "/repo/src/")).toBe("src");
+  });
+
+  it("normalises Windows separators on both sides", () => {
+    expect(relativeToWorkdir("C:\\repo", "C:\\repo\\src\\a.txt")).toBe(
+      "src/a.txt",
+    );
+    expect(relativeToWorkdir("C:\\repo\\", "C:/repo/src/a.txt")).toBe(
+      "src/a.txt",
+    );
+  });
+
+  it("compares Windows paths case-insensitively, posix paths exactly", () => {
+    expect(relativeToWorkdir("C:\\Repo", "c:\\repo\\a.txt")).toBe("a.txt");
+    // Case matters on a posix workdir — /Repo and /repo are two directories.
+    expect(relativeToWorkdir("/Repo", "/repo/a.txt")).toBeNull();
+  });
+
+  it("returns a path that is already relative unchanged (normalised)", () => {
+    expect(relativeToWorkdir("/repo", "src/a.txt")).toBe("src/a.txt");
+    expect(relativeToWorkdir("/repo", "src\\a.txt")).toBe("src/a.txt");
+    expect(relativeToWorkdir("/repo", "./src/a.txt")).toBe("src/a.txt");
+  });
+
+  it("returns null for an absolute path outside the workdir", () => {
+    expect(relativeToWorkdir("/repo", "/etc/passwd")).toBeNull();
+    expect(relativeToWorkdir("/repo", "/repo-other/a.txt")).toBeNull();
+    // The sibling-prefix trap: /repository must not become "sitory/a.txt".
+    expect(relativeToWorkdir("/repo", "/repository/a.txt")).toBeNull();
+  });
+
+  it("returns the empty string for the workdir itself", () => {
+    expect(relativeToWorkdir("/repo", "/repo")).toBe("");
+    expect(relativeToWorkdir("/repo", "/repo/")).toBe("");
+  });
+
+  it("returns null when there is no workdir to measure against", () => {
+    expect(relativeToWorkdir(undefined, "/repo/a.txt")).toBeNull();
+    expect(relativeToWorkdir(null, "/repo/a.txt")).toBeNull();
+    expect(relativeToWorkdir("", "/repo/a.txt")).toBeNull();
+  });
+
+  it("returns null for an empty path", () => {
+    expect(relativeToWorkdir("/repo", "")).toBeNull();
+  });
+});
+
+describe("absoluteInWorkdir", () => {
+  it("joins a relative path onto a posix workdir", () => {
+    expect(absoluteInWorkdir("/repo", "src/a.txt")).toBe("/repo/src/a.txt");
+    expect(absoluteInWorkdir("/repo/", "src/a.txt")).toBe("/repo/src/a.txt");
+  });
+
+  it("joins with backslashes when the workdir is a Windows path", () => {
+    expect(absoluteInWorkdir("C:\\repo", "src/a.txt")).toBe(
+      "C:\\repo\\src\\a.txt",
+    );
+    expect(absoluteInWorkdir("C:/repo", "src\\a.txt")).toBe(
+      "C:\\repo\\src\\a.txt",
+    );
+    expect(absoluteInWorkdir("\\\\server\\share", "a.txt")).toBe(
+      "\\\\server\\share\\a.txt",
+    );
+  });
+
+  it("drops trailing separators on the input path", () => {
+    expect(absoluteInWorkdir("/repo", "src/")).toBe("/repo/src");
+  });
+
+  it("returns an already-absolute path unchanged", () => {
+    expect(absoluteInWorkdir("/repo", "/elsewhere/a.txt")).toBe(
+      "/elsewhere/a.txt",
+    );
+    expect(absoluteInWorkdir("/repo", "C:\\x\\a.txt")).toBe("C:\\x\\a.txt");
+  });
+
+  it("returns the workdir itself for an empty relative path", () => {
+    expect(absoluteInWorkdir("/repo", "")).toBe("/repo");
+    expect(absoluteInWorkdir("/repo/", "")).toBe("/repo");
+  });
+
+  it("returns null when there is no workdir and the path is relative", () => {
+    expect(absoluteInWorkdir(undefined, "src/a.txt")).toBeNull();
+    expect(absoluteInWorkdir("", "src/a.txt")).toBeNull();
+  });
+});

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -1,0 +1,116 @@
+// Workdir-relative ⇄ absolute path arithmetic for the "Copy path" / "Copy
+// relative path" menu entries (#245).
+//
+// Pure string work, deliberately not `node:path` — this runs in the webview,
+// where there is no `path` module and no way to ask the host which separator
+// it uses. The separator is inferred from the value instead: a repository
+// opened on Windows hands the frontend `C:\Users\me\repo`, a UNC share hands
+// it `\\server\share\repo`, and everywhere else it is posix. Git itself always
+// reports file paths with forward slashes, so the two sides of a join can and
+// do disagree — every function normalises first and only re-applies the
+// workdir's own style on the way out.
+//
+// The whole module is total: no throw, and no `../..` walking. A path that is
+// not inside the workdir has no meaningful repository-relative form, so
+// `relativeToWorkdir` answers `null` rather than emitting a traversal string a
+// user would paste into a bug report.
+
+/** A drive-letter root: `C:` or `C:/…`. */
+const DRIVE = /^[A-Za-z]:(?:\/|$)/;
+
+/**
+ * One canonical form: forward slashes, no repeated separators, no trailing
+ * separator. A lone root stays `/`, and the leading pair of a UNC path
+ * (`\\server\share`) is part of its root and survives.
+ */
+export function normalizeSeparators(path: string): string {
+  if (!path) return "";
+  const slashed = path.replace(/\\/g, "/");
+  const unc = slashed.startsWith("//");
+  const collapsed = slashed.replace(/\/{2,}/g, "/");
+  const joined = unc ? `/${collapsed}` : collapsed;
+  return joined.replace(/\/+$/, "") || "/";
+}
+
+/** `true` for a posix root, a drive letter, or a UNC share. */
+export function isAbsolutePath(path: string): boolean {
+  const s = normalizeSeparators(path);
+  return s.startsWith("/") || DRIVE.test(s);
+}
+
+/**
+ * Does this value look like a Windows path? Drive letter or UNC root settle
+ * it; failing that, a backslash anywhere can only be a separator, since git
+ * never emits one and a literal backslash in a filename is not addressable on
+ * the platform we would be guessing wrong for.
+ */
+function isWindowsStyle(path: string): boolean {
+  const s = normalizeSeparators(path);
+  return DRIVE.test(s) || s.startsWith("//") || path.includes("\\");
+}
+
+/** `./a/b` → `a/b`. Git never emits the prefix; hand-typed paths carry it. */
+function stripDotSlash(path: string): string {
+  return path.replace(/^(?:\.\/)+/, "");
+}
+
+/** Re-apply the platform's separator to a normalized path. */
+function denormalize(path: string, windows: boolean): string {
+  return windows ? path.replace(/\//g, "\\") : path;
+}
+
+/**
+ * `path` expressed relative to the repository workdir, with forward slashes.
+ *
+ * - A path that is already relative comes back normalized, untouched — the
+ *   file lists hand out git-relative paths and asking for their relative form
+ *   must be a no-op, not a second prefix strip.
+ * - `""` when `path` *is* the workdir (a repository relative to itself), which
+ *   callers treat the same as `null`: nothing worth putting on a clipboard.
+ * - `null` when there is no workdir, `path` is empty, or `path` is absolute
+ *   and outside the workdir. Comparison is per segment, so `/repository` is
+ *   never read as a child of `/repo`; it is case-insensitive only for
+ *   Windows-style paths, where `/Repo` and `/repo` are one directory.
+ */
+export function relativeToWorkdir(
+  workdir: string | null | undefined,
+  path: string,
+): string | null {
+  const p = normalizeSeparators(path ?? "");
+  if (!p) return null;
+  if (!isAbsolutePath(p)) return stripDotSlash(p);
+
+  const root = normalizeSeparators(workdir ?? "");
+  if (!root) return null;
+
+  const windows = isWindowsStyle(root) || isWindowsStyle(path);
+  const fold = (s: string) => (windows ? s.toLowerCase() : s);
+  if (fold(p) === fold(root)) return "";
+
+  const prefix = root.endsWith("/") ? root : `${root}/`;
+  if (!fold(p).startsWith(fold(prefix))) return null;
+  return p.slice(prefix.length);
+}
+
+/**
+ * `path` as an absolute path, using the workdir's own separator style.
+ *
+ * An already-absolute `path` comes back as-is (normalized), so this is safe to
+ * apply to a value whose provenance is mixed. `""` resolves to the workdir
+ * itself. `null` only when a relative path has no workdir to hang from — the
+ * "no repository open" case, where callers disable the entry rather than
+ * copying a half-answer.
+ */
+export function absoluteInWorkdir(
+  workdir: string | null | undefined,
+  path: string,
+): string | null {
+  const p = stripDotSlash(normalizeSeparators(path ?? ""));
+  if (isAbsolutePath(p)) return denormalize(p, isWindowsStyle(path ?? ""));
+
+  const root = normalizeSeparators(workdir ?? "");
+  if (!root) return null;
+
+  const joined = !p ? root : root === "/" ? `/${p}` : `${root}/${p}`;
+  return denormalize(joined, isWindowsStyle(workdir ?? ""));
+}

--- a/src/screens/CommitPanel.copyPath.test.tsx
+++ b/src/screens/CommitPanel.copyPath.test.tsx
@@ -1,0 +1,103 @@
+// The diff pane's ⋯ ("File actions") menu offers the same "Copy path" / "Copy
+// relative path" pair as the file row (#245).
+//
+// The pair itself is unit-tested in `src/design/context-menu.copyPath.test.tsx`
+// and the arithmetic in `src/lib/paths.test.ts` — what this covers is the
+// wiring: the ⋯ menu is built inline in this screen rather than by
+// `fileMenuItems`, so it is the one surface that could silently keep copying a
+// relative path under the "Copy path" label.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { CommitPanelScreen } from "./CommitPanel";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { settleDiff } from "@/test/settle";
+import { WithDialogs } from "@/test/dialog";
+import type { FileStatus } from "@/lib/types";
+
+const PATH = "src/deep/a.ts";
+
+const unstaged = (path: string): FileStatus => ({
+  path,
+  worktree: { kind: "Modified" },
+  index: { kind: "Unmodified" },
+  additions: 1,
+  deletions: 0,
+  embedded: false,
+});
+
+const diff = (path: string) => ({
+  path,
+  oldPath: null,
+  binary: false,
+  additions: 1,
+  deletions: 0,
+  hunks: [
+    {
+      header: "@@ -1,1 +1,2 @@",
+      oldStart: 1,
+      oldLines: 1,
+      newStart: 1,
+      newLines: 2,
+      lines: [
+        { kind: { kind: "Context" }, oldLineno: 1, newLineno: 1, content: "base\n" },
+        { kind: { kind: "Addition" }, oldLineno: null, newLineno: 2, content: "add\n" },
+      ],
+    },
+  ],
+});
+
+const copied: string[] = [];
+
+/** Open the ⋯ menu over the selected file and click `label`. */
+function clickInMoreMenu(label: string) {
+  fireEvent.click(screen.getByTitle("File actions"));
+  fireEvent.click(screen.getByText(label));
+}
+
+beforeEach(async () => {
+  resetInvokeMock();
+  copied.length = 0;
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: {
+      writeText: vi.fn((t: string) => {
+        copied.push(t);
+        return Promise.resolve();
+      }),
+    },
+  });
+  useSettingsStore.setState({ ignoreWhitespaceInDiff: false });
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
+    status: [unstaged(PATH)],
+    branches: [],
+    remotes: [],
+    commits: [],
+    loading: false,
+  } as never);
+  mockInvoke("get_diff", (args) => diff(args.path as string));
+  mockInvoke("get_status", () => [unstaged(PATH)]);
+  render(
+    <WithDialogs>
+      <CommitPanelScreen />
+    </WithDialogs>,
+  );
+  await screen.findAllByTestId("diff-line-changed");
+  await settleDiff();
+});
+
+describe("the diff pane's ⋯ menu", () => {
+  it("copies the absolute path for 'Copy path'", () => {
+    clickInMoreMenu("Copy path");
+    expect(copied).toEqual(["/repo/src/deep/a.ts"]);
+  });
+
+  it("copies the workdir-relative path for 'Copy relative path'", () => {
+    clickInMoreMenu("Copy relative path");
+    expect(copied).toEqual([PATH]);
+  });
+});

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -16,6 +16,7 @@ import {
   PGStatusMark,
   PGResizeHandle,
   PGTextarea,
+  copyPathItems,
   fileMenuItems,
   multiFileMenuItems,
   PGHookOutput,
@@ -231,15 +232,7 @@ export function CommitPanelScreen() {
   const moreMenu = useContextMenu<{ path: string; diff: FileDiff | null }>(
     (p) => [
       { __menuTitle: p?.path || "file" },
-      {
-        icon: "copy",
-        label: "Copy path",
-        onClick: () => {
-          if (!p?.path) return;
-          navigator.clipboard?.writeText(p.path);
-          pgFlash("copied path");
-        },
-      },
+      ...copyPathItems(p?.path ? [p.path] : []),
       {
         icon: "copy",
         label: "Copy diff as text",


### PR DESCRIPTION
## What does this PR do?

Adds **"Copy relative path"** beside every absolute "Copy path" (and "Copy relative paths" for a multi-selection), and — necessarily — makes "Copy path" mean one thing everywhere.

New pure module `src/lib/paths.ts`: `normalizeSeparators`, `isAbsolutePath`, `relativeToWorkdir`, `absoluteInWorkdir`. One shared `copyPathItems(paths)` in `design/context-menu.tsx` replaces four hand-written entries.

Part of #245. The **delete-untracked-file** half lands as a separate PR — it is the destructive one, needs a new backend command with workdir containment, and should not be reviewed alongside a clipboard feature.

## ⚠️ Behaviour change — the thing to actually review

The premise in the issue ("only absolute Copy path exists") turned out to be **wrong in four of six places**. The audit:

| Site | Copied before | Copies now |
|---|---|---|
| `context-menu.tsx:924` worktree menu | absolute | **unchanged** — skipped |
| `context-menu.tsx:1579` embedded-repo row | **relative**, labelled "Copy path" | pair: absolute + relative |
| `context-menu.tsx:1694` file row | **relative**, labelled "Copy path" | pair: absolute + relative |
| `context-menu.tsx:1916` multi-select | **relative** | pair; labels now singular for 1 file |
| `RepoTabs.tsx:130` repo tab | absolute | **unchanged** — skipped |
| `CommitPanel.tsx:236` diff-pane ⋯ menu | **relative**, labelled "Copy path" | pair: absolute + relative |

So **four shipped actions now copy an absolute path where they previously copied a relative one.** Anyone with muscle memory for "Copy path" in a file list gets a different string; the old value is one entry below.

This is the deliberate choice, because the alternative — adding "Copy relative path" next to four entries that *already* copied a relative path — ships four menus with two identically-behaving items under different labels. But it is a user-visible change to existing behaviour and it is reversible in one commit if you would rather "Copy path" stayed relative on file surfaces.

## Why?

**Two surfaces get no relative entry on purpose:** the worktree menu and the repo tab. Their target *is* a repository root, whose path relative to itself is `""` — the pair would be one real entry and one that copies nothing.

**No "Open containing folder" entry.** Reveal already is that action on all three platforms: `open -R` (macOS) and `explorer /select,` (Windows) open the containing folder with the file selected, and Linux `xdg-open`s the parent, there being no portable "select this file" verb. A second entry would be a pure synonym. Note the obvious-looking implementation is wrong: `reveal_in_file_manager` hardcodes `is_dir: false`, so applying it to the *parent* would open the **grandparent** with the parent selected. The only genuinely different variant — a folder window with no selection — needs `reveal(parent, is_dir: true)`, i.e. a backend change, so it rides along with the delete-file PR. Pinned by a test asserting exactly one file-manager entry on a file row.

**`paths.ts` is pure and total** — no `node:path` (a webview has none), no `../..` walking (outside the workdir answers `null` rather than emitting a traversal string someone pastes into a bug report), separator inferred from the workdir so drive letters and UNC shares round-trip. It handles the `/repo` vs `/repository` sibling-prefix trap, already-relative input, `./` prefixes, and repeated/trailing separators.

## Known limitations

- A Linux filename containing a **literal backslash** (`/repo/a\b.txt`) is mangled into a separator, since the separator has to be inferred from the string. Legal but pathological; cosmetic-only (a wrong clipboard string, no disk access).
- **Directory rows still cannot be revealed** — folder rows go through `multiFileMenuItems`, which has no file-manager entry at all. They *do* now get the copy-path pair. Pre-existing gap, worth its own small PR; the issue asked for it.
- On WSL, "Copy path" yields the `/mnt/c/...` posix path, not `C:\...` — correct for the process that opened the repo, but not what you would paste into a Windows program.

## Checklist

- [x] One logical change, focused PR
- [x] Branched off `main`; rebased onto `3f15cb7`, no merge commits, single squashed commit
- [x] PR title + commit message follow Conventional Commits
- [x] `pnpm tsc --noEmit` passes — exit 0
- [ ] `cargo test` — **not run locally: no Rust in this diff.** CI's rust job covers it
- [x] `pnpm test` passes — 231 files, 1998 tests, includes the `docs` project
- [x] `e2e/` untouched (`e2e` typecheck also clean)
- [x] Added tests — 21 in `paths.test.ts`, 17 in `context-menu.copyPath.test.tsx`, 2 in `CommitPanel.copyPath.test.tsx`
- [x] Not a new git op — no Rust touched
- [x] Not a new feature area — extends existing context menus

🤖 Generated with [Claude Code](https://claude.com/claude-code)
