### PR TITLE
feat(settings): export and import all settings, not just themes

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -354,6 +354,64 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   sets, so the opposite order wipes the banner. A failed git op must still
   refresh — the UI reflects disk truth even on error.
 
+### Settings: one validator, two untrusted sources (#254)
+
+`useSettingsStore` reads a payload it does not control from two places — the
+`pg-settings-v2` localStorage key on startup, and a settings file someone
+imports — and both go through ONE function, `coerceSettings(parsed, base)`.
+Its rules: a key absent from the payload keeps `base`'s value, a valid one is
+applied, an unusable one falls back to the DEFAULT (not to `base`) because the
+payload asked for a change and the documented safe value is the honest answer to
+garbage. `load()` calls it with `base = DEFAULTS`; `importSettings` calls it with
+the current state, so an older export cannot silently reset a preference it
+predates — an export written before `updateCheckMode` existed must not switch
+update checks back on for someone who turned them off.
+
+- **The export derives its key set from the schema minus a deny-list**
+  (`NON_PORTABLE_KEYS`, today just `lastCreateDir`), never a hand-written
+  allow-list, so a preference added tomorrow travels by default. #283 added
+  `updateCheckMode` days before the export landed and an allow-list would have
+  dropped it silently. **Import keeps the opposite asymmetry** — only keys still
+  in `DEFAULTS` are accepted, so an old or hostile file cannot poison the store.
+  `useSettingsStore.export.test.ts` snapshots the exported key list: adding a
+  `PersistedState` field fails that test until someone decides which side it
+  belongs on. **The deny-list holds in both directions** — `importSettings`
+  strips those keys from the payload and reports them, because "never in an
+  export" is only half a promise if a hand-edited file can still set
+  `lastCreateDir` on someone else's machine.
+- **Nothing secret is in `PersistedState`,** which is what makes the deny-list
+  safe: forge tokens and git credentials live in their own `Secret`-typed
+  storage and no command returns them. The same test asserts no
+  credential-shaped key or token-shaped value appears in a serialised export.
+  Any new persisted field has to keep that true.
+- **The payload's `version` is not `STORAGE_KEY`'s "-v2".** One versions the
+  interchange format, the other the localStorage slot this install reads. A
+  file from a newer build is accepted key by key and flagged
+  (`report.fromNewerVersion`) rather than rejected — rejecting would strand
+  anyone moving a machine back onto an older release, which is a case the export
+  exists for.
+- **The keymap crosses as a parameter, not an import.** `useKeymapStore`
+  persists the active preset under its own key, and `keymap/actions.ts` imports
+  the settings store — so the settings store cannot read it back without a
+  cycle. `screens/Settings.tsx` owns both stores and bridges them: it hands the
+  preset to `exportSettings({ keymapPresetId })` and applies the one
+  `importSettings` reports, ignoring an id no `BUILTIN_PRESETS` entry has
+  (`presetById` would silently resolve it to the default while the picker showed
+  the unknown name).
+- **One theme format.** `themePayload()` is the per-theme serialiser behind both
+  `exportTheme` and the settings bundle; the bundle adds only `id`, because
+  `activeThemeId` has to stay resolvable. `normalizeCustomThemes` is lenient in
+  the direction `validateTheme` already chose for the logo slots — a missing
+  colour is filled from the default theme rather than costing the user the
+  theme, one unusable entry costs only itself, every colour goes through
+  `sanitizeHex`, and `builtin` is never carried over (a custom theme claiming to
+  be built in renders read-only and cannot be deleted).
+- **Both file-import paths read `file.text()`,** which jsdom's Blob does not
+  implement; `Settings.export.test.tsx` bridges it to `FileReader` at the top of
+  the file. The hidden `<input type="file">` is also `display: none`, so
+  `userEvent.upload` (which clicks first) does not reach it — dispatch
+  `fireEvent.change` with `target: { files: [file] }` instead.
+
 ## Styling
 
 - Tailwind v4, CSS-first (no `tailwind.config.js`, no `@theme` block). Tokens

--- a/src/features/settings/useSettingsStore.export.test.ts
+++ b/src/features/settings/useSettingsStore.export.test.ts
@@ -1,0 +1,588 @@
+// Settings export / import (#254). Themes could already leave the machine one
+// at a time; everything else was trapped in one localStorage key.
+//
+// The load-bearing tests here are the two guards, not the happy path:
+//
+//   * the KEY-SET SNAPSHOT — the export derives its keys from the schema minus
+//     a deny-list, so a new preference travels by default. The snapshot is what
+//     turns "someone added a setting" into a deliberate decision (export it, or
+//     deny it) instead of a silent omission. #283 added `updateCheckMode` days
+//     before this feature landed, and a hand-written allow-list would have
+//     missed it.
+//   * NO SECRET-SHAPED KEYS — forge tokens and git credentials live in
+//     Secret-typed storage and no command returns them. A settings export is
+//     exactly the change that could accidentally undo that, so the assertion
+//     reads the serialised payload rather than trusting the key list.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const STORAGE_KEY = "pg-settings-v2";
+
+async function freshStore() {
+  vi.resetModules();
+  return await import("./useSettingsStore");
+}
+
+type Store = Awaited<ReturnType<typeof freshStore>>;
+
+interface Payload {
+  kind: string;
+  version: number;
+  exportedAt: string;
+  settings: Record<string, unknown>;
+  keymap?: { presetId: string };
+}
+
+/** The payload as an object, without re-parsing at every call site. */
+function exported(store: Store, opts?: { keymapPresetId?: string | null }): Payload {
+  return JSON.parse(store.useSettingsStore.getState().exportSettings(opts)) as Payload;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// THE KEY SET
+// ═════════════════════════════════════════════════════════════════════════════
+
+// Every key in PersistedState, minus the deny-list. Adding a setting changes
+// this list — which is the point. Export it (add it here) or deny it (add it to
+// NON_PORTABLE_KEYS and to EXCLUDED below), but decide.
+const PORTABLE = [
+  "activeThemeId",
+  "addSignoff",
+  "autoFetchEnabled",
+  "autoFetchMinutes",
+  "autoStashBeforePull",
+  "confirmForcePush",
+  "customThemes",
+  "defaultPullMode",
+  "diffContextLines",
+  "diffContextMode",
+  "diffViewMode",
+  "headMarks",
+  "headWeight",
+  "ignoreWhitespaceInDiff",
+  "pruneOnFetch",
+  "signCommits",
+  "uiDensity",
+  "uiZoom",
+  "updateCheckMode",
+];
+
+/** Machine-specific, so deliberately absent from an export. */
+const EXCLUDED = ["lastCreateDir"];
+
+describe("the exported key set", () => {
+  it("is exactly the schema minus the deny-list", async () => {
+    const store = await freshStore();
+    expect(Object.keys(exported(store).settings).sort()).toEqual([...PORTABLE].sort());
+    expect([...store.NON_PORTABLE_KEYS].sort()).toEqual([...EXCLUDED].sort());
+  });
+
+  it("accounts for every key the store persists", async () => {
+    const store = await freshStore();
+    // No key may fall between the two lists: their union has to be the whole
+    // schema, or a preference exists that nobody decided about.
+    store.useSettingsStore.getState().set("pruneOnFetch", false);
+    const written = Object.keys(
+      JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}") as object,
+    );
+    expect(written.sort()).toEqual([...PORTABLE, ...EXCLUDED].sort());
+  });
+
+  it("carries updateCheckMode, the setting added days before this export existed", async () => {
+    const store = await freshStore();
+    store.useSettingsStore.getState().set("updateCheckMode", "never");
+    expect(exported(store).settings.updateCheckMode).toBe("never");
+  });
+
+  it("leaves lastCreateDir behind — it names a directory on ONE machine", async () => {
+    const store = await freshStore();
+    store.useSettingsStore.getState().set("lastCreateDir", "/Users/someone/dev");
+    const json = store.useSettingsStore.getState().exportSettings();
+    expect(JSON.parse(json).settings).not.toHaveProperty("lastCreateDir");
+    // …and the path itself is nowhere in the file, under any key.
+    expect(json).not.toContain("/Users/someone/dev");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// SECRETS
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("an export carries no secrets", () => {
+  // "key" is deliberately not in this list — keymap, activeThemeId and the
+  // theme colour slots all use it innocently. These are the words that only
+  // ever mean a credential.
+  const FORBIDDEN = [
+    "token",
+    "secret",
+    "password",
+    "passphrase",
+    "credential",
+    "apikey",
+    "api_key",
+    "signingkey",
+    "accesstoken",
+  ];
+
+  function keysDeep(value: unknown, out: string[] = []): string[] {
+    if (Array.isArray(value)) {
+      for (const v of value) keysDeep(v, out);
+    } else if (value && typeof value === "object") {
+      for (const [k, v] of Object.entries(value)) {
+        out.push(k);
+        keysDeep(v, out);
+      }
+    }
+    return out;
+  }
+
+  it("has no credential-shaped key anywhere in the payload", async () => {
+    const store = await freshStore();
+    // Fill the payload out as far as a user can: a custom theme too.
+    store.useSettingsStore.getState().saveAsNewTheme("Mine");
+    const json = store.useSettingsStore
+      .getState()
+      .exportSettings({ keymapPresetId: "rider" });
+    const offenders = keysDeep(JSON.parse(json)).filter((k) =>
+      FORBIDDEN.some((bad) => k.toLowerCase().includes(bad)),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("has no forge-token-shaped VALUE either", async () => {
+    const store = await freshStore();
+    const json = store.useSettingsStore.getState().exportSettings();
+    // The prefixes GitHub and GitLab put on their tokens. If a token ever
+    // reaches PersistedState this catches it even under an innocent key name.
+    for (const shape of ["ghp_", "gho_", "ghu_", "github_pat_", "glpat-"]) {
+      expect(json).not.toContain(shape);
+    }
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// ROUND TRIP
+// ═════════════════════════════════════════════════════════════════════════════
+
+/** Every portable setting moved off its default, so a round trip proves it. */
+function moveEverything(store: Store) {
+  store.useSettingsStore.getState().saveAsNewTheme("House style");
+  const set = store.useSettingsStore.getState().set;
+  set("uiDensity", "comfortable");
+  set("uiZoom", 1.2);
+  set("headMarks", ["badge"]);
+  set("headWeight", "subtle");
+  set("defaultPullMode", "Merge");
+  set("autoFetchEnabled", true);
+  set("autoFetchMinutes", 17);
+  set("pruneOnFetch", false);
+  set("confirmForcePush", false);
+  set("autoStashBeforePull", false);
+  set("addSignoff", true);
+  set("signCommits", "always");
+  set("diffContextLines", 9);
+  set("diffViewMode", "split");
+  set("diffContextMode", "chunks");
+  set("ignoreWhitespaceInDiff", true);
+  set("updateCheckMode", "manual");
+}
+
+function portableSnapshot(state: Record<string, unknown>) {
+  const out: Record<string, unknown> = {};
+  for (const k of PORTABLE) out[k] = state[k];
+  return out;
+}
+
+const stateOf = (store: Store) =>
+  store.useSettingsStore.getState() as unknown as Record<string, unknown>;
+
+describe("round trip", () => {
+  it("export → reset → import restores every portable setting", async () => {
+    const store = await freshStore();
+    moveEverything(store);
+    const before = portableSnapshot(stateOf(store));
+    const json = store.useSettingsStore.getState().exportSettings();
+
+    store.useSettingsStore.getState().reset();
+    // Sanity: reset really did undo it, so the comparison below means something.
+    expect(store.useSettingsStore.getState().diffViewMode).toBe("inline");
+
+    store.useSettingsStore.getState().importSettings(json);
+    expect(portableSnapshot(stateOf(store))).toEqual(before);
+  });
+
+  it("survives the trip through localStorage, not just through store state", async () => {
+    const store = await freshStore();
+    moveEverything(store);
+    const json = store.useSettingsStore.getState().exportSettings();
+    store.useSettingsStore.getState().reset();
+    store.useSettingsStore.getState().importSettings(json);
+
+    // A fresh module instance reads what import persisted.
+    const reloaded = await freshStore();
+    expect(reloaded.useSettingsStore.getState().diffViewMode).toBe("split");
+    expect(reloaded.useSettingsStore.getState().uiZoom).toBe(1.2);
+    expect(reloaded.useSettingsStore.getState().customThemes).toHaveLength(1);
+  });
+
+  it("keeps a custom theme, and keeps activeThemeId pointing at it", async () => {
+    const store = await freshStore();
+    const created = store.useSettingsStore.getState().saveAsNewTheme("House style");
+    store.useSettingsStore.getState().updateActiveColors({ accent: "#abcdef" });
+    const json = store.useSettingsStore.getState().exportSettings();
+
+    store.useSettingsStore.getState().reset();
+    expect(store.useSettingsStore.getState().customThemes).toEqual([]);
+
+    store.useSettingsStore.getState().importSettings(json);
+    const s = store.useSettingsStore.getState();
+    expect(s.customThemes).toHaveLength(1);
+    expect(s.customThemes[0].name).toBe("House style");
+    expect(s.customThemes[0].colors.accent).toBe("#abcdef");
+    // The id has to survive or activeThemeId dangles and the app silently
+    // falls back to the default theme — the one thing a theme export is for.
+    expect(s.customThemes[0].id).toBe(created.id);
+    expect(s.activeThemeId).toBe(created.id);
+    expect(s.getActiveTheme().name).toBe("House style");
+  });
+
+  it("uses the same per-theme shape as a single-theme export", async () => {
+    const store = await freshStore();
+    const created = store.useSettingsStore.getState().saveAsNewTheme("House style");
+    const one = JSON.parse(
+      store.useSettingsStore.getState().exportTheme(created.id),
+    ) as Record<string, unknown>;
+    const inBundle = (
+      exported(store).settings.customThemes as Record<string, unknown>[]
+    )[0];
+    // Same serialiser, so the same fields carry the same values — only the id
+    // is added, because a bundle has to keep activeThemeId resolvable.
+    expect(inBundle.name).toEqual(one.name);
+    expect(inBundle.mode).toEqual(one.mode);
+    expect(inBundle.colors).toEqual(one.colors);
+    expect(Object.keys(inBundle).sort()).toEqual(["colors", "id", "mode", "name"]);
+  });
+
+  it("carries the keymap preset beside the settings, and reports it back", async () => {
+    const store = await freshStore();
+    const json = store.useSettingsStore
+      .getState()
+      .exportSettings({ keymapPresetId: "platypusgit" });
+    expect(JSON.parse(json).keymap).toEqual({ presetId: "platypusgit" });
+    const report = store.useSettingsStore.getState().importSettings(json);
+    expect(report.keymapPresetId).toBe("platypusgit");
+  });
+
+  it("omits the keymap block when the caller has no preset to offer", async () => {
+    const store = await freshStore();
+    const payload = exported(store);
+    expect(payload).not.toHaveProperty("keymap");
+    const report = store.useSettingsStore
+      .getState()
+      .importSettings(JSON.stringify(payload));
+    expect(report.keymapPresetId).toBeNull();
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// IMPORT: THE DEFENSIVE POSTURE
+// ═════════════════════════════════════════════════════════════════════════════
+
+/** A minimal well-formed payload carrying just the given settings. */
+function payloadOf(
+  settings: Record<string, unknown>,
+  extra: Record<string, unknown> = {},
+) {
+  return JSON.stringify({
+    kind: "platypusgit-settings",
+    version: 1,
+    settings,
+    ...extra,
+  });
+}
+
+describe("import validates like load() does", () => {
+  it("ignores a key the schema no longer has, and says so", async () => {
+    const store = await freshStore();
+    const report = store.useSettingsStore
+      .getState()
+      .importSettings(payloadOf({ showWhitespaceInDiff: true, pruneOnFetch: false }));
+    expect(report.ignored).toEqual(["showWhitespaceInDiff"]);
+    expect(report.changed).toEqual(["pruneOnFetch"]);
+    expect("showWhitespaceInDiff" in store.useSettingsStore.getState()).toBe(false);
+    expect(store.useSettingsStore.getState().pruneOnFetch).toBe(false);
+  });
+
+  it("clamps an out-of-range uiZoom instead of leaving the UI unzoomable", async () => {
+    const store = await freshStore();
+    store.useSettingsStore.getState().importSettings(payloadOf({ uiZoom: 99 }));
+    expect(store.useSettingsStore.getState().uiZoom).toBe(store.ZOOM_MAX);
+
+    store.useSettingsStore.getState().importSettings(payloadOf({ uiZoom: -4 }));
+    expect(store.useSettingsStore.getState().uiZoom).toBe(store.ZOOM_MIN);
+  });
+
+  it("falls back to the safe default for a bad signCommits", async () => {
+    const store = await freshStore();
+    for (const bad of [true, "sometimes", 3, null]) {
+      store.useSettingsStore.getState().set("signCommits", "always");
+      store.useSettingsStore.getState().importSettings(payloadOf({ signCommits: bad }));
+      // "config" defers to the repository rather than forcing signing on.
+      expect(store.useSettingsStore.getState().signCommits, String(bad)).toBe("config");
+    }
+  });
+
+  it("falls back to auto for a bad updateCheckMode", async () => {
+    const store = await freshStore();
+    for (const bad of ["weekly", "", true, 0]) {
+      store.useSettingsStore.getState().set("updateCheckMode", "manual");
+      store.useSettingsStore
+        .getState()
+        .importSettings(payloadOf({ updateCheckMode: bad }));
+      expect(store.useSettingsStore.getState().updateCheckMode, String(bad)).toBe("auto");
+    }
+  });
+
+  it("degrades unknown diff modes, density and pull mode", async () => {
+    const store = await freshStore();
+    store.useSettingsStore.getState().importSettings(
+      payloadOf({
+        diffViewMode: "sideways",
+        diffContextMode: "everything",
+        uiDensity: "cozy",
+        defaultPullMode: "Yolo",
+      }),
+    );
+    const s = store.useSettingsStore.getState();
+    expect(s.diffViewMode).toBe("inline");
+    expect(s.diffContextMode).toBe("wholeFile");
+    expect(s.uiDensity).toBe("compact");
+    expect(s.defaultPullMode).toBe("Rebase");
+  });
+
+  it("refuses a string where a toggle expects a boolean", async () => {
+    const store = await freshStore();
+    // `checked={"no"}` is a toggle stuck ON — the value reads truthy, so the
+    // user sees the opposite of what the file said.
+    store.useSettingsStore
+      .getState()
+      .importSettings(payloadOf({ pruneOnFetch: "no", addSignoff: 1 }));
+    const s = store.useSettingsStore.getState();
+    expect(s.pruneOnFetch).toBe(true);
+    expect(s.addSignoff).toBe(false);
+  });
+
+  it("clamps the two numeric ranges the UI already clamps", async () => {
+    const store = await freshStore();
+    store.useSettingsStore
+      .getState()
+      .importSettings(payloadOf({ diffContextLines: 5000, autoFetchMinutes: 0 }));
+    const s = store.useSettingsStore.getState();
+    expect(s.diffContextLines).toBe(20);
+    expect(s.autoFetchMinutes).toBe(1);
+  });
+
+  it("drops an unusable custom theme without losing the other settings", async () => {
+    const store = await freshStore();
+    const report = store.useSettingsStore.getState().importSettings(
+      payloadOf({
+        customThemes: ["not a theme", { name: "No colors" }],
+        diffViewMode: "split",
+      }),
+    );
+    expect(store.useSettingsStore.getState().customThemes).toEqual([]);
+    expect(store.useSettingsStore.getState().diffViewMode).toBe("split");
+    expect(report.changed).toContain("diffViewMode");
+  });
+
+  it("never lets an imported theme claim to be built in", async () => {
+    const store = await freshStore();
+    const base = store.BUILTIN_THEMES[0];
+    store.useSettingsStore.getState().importSettings(
+      payloadOf({
+        customThemes: [
+          {
+            id: "sneaky",
+            name: "Sneaky",
+            mode: "dark",
+            colors: base.colors,
+            builtin: true,
+          },
+        ],
+      }),
+    );
+    // A `builtin` flag makes the theme editor read-only — an imported theme
+    // must stay editable and deletable.
+    expect(store.useSettingsStore.getState().customThemes[0].builtin).toBeUndefined();
+  });
+
+  it("refuses a non-portable key even when a file carries one", async () => {
+    const store = await freshStore();
+    store.useSettingsStore.getState().set("lastCreateDir", "/Users/me/dev");
+    const report = store.useSettingsStore
+      .getState()
+      .importSettings(payloadOf({ lastCreateDir: "/Users/someone-else/dev" }));
+    // The deny-list has to hold in both directions, or "never in an export" is
+    // only half a promise: a hand-edited file could still retarget the Clone
+    // dialog on someone else's machine.
+    expect(store.useSettingsStore.getState().lastCreateDir).toBe("/Users/me/dev");
+    expect(report.changed).toEqual([]);
+    expect(report.ignored).toEqual(["lastCreateDir"]);
+  });
+
+  it("leaves a setting the payload never mentions alone", async () => {
+    const store = await freshStore();
+    store.useSettingsStore.getState().set("updateCheckMode", "never");
+    store.useSettingsStore.getState().set("lastCreateDir", "/Users/someone/dev");
+    store.useSettingsStore.getState().importSettings(payloadOf({ diffViewMode: "split" }));
+    const s = store.useSettingsStore.getState();
+    // An older export that predates a setting must not silently re-enable the
+    // update check for someone who turned it off.
+    expect(s.updateCheckMode).toBe("never");
+    // And the machine-specific key an export can never carry stays put.
+    expect(s.lastCreateDir).toBe("/Users/someone/dev");
+    expect(s.diffViewMode).toBe("split");
+  });
+});
+
+describe("import reports rather than applying silently", () => {
+  it("lists only the settings that actually changed", async () => {
+    const store = await freshStore();
+    const report = store.useSettingsStore.getState().importSettings(
+      payloadOf({
+        // Already the default, so importing it changes nothing.
+        pruneOnFetch: true,
+        diffViewMode: "split",
+        addSignoff: true,
+      }),
+    );
+    expect([...report.changed].sort()).toEqual(["addSignoff", "diffViewMode"]);
+    expect(report.ignored).toEqual([]);
+  });
+
+  it("reports an empty change list for a file that matches the machine", async () => {
+    const store = await freshStore();
+    const json = store.useSettingsStore.getState().exportSettings();
+    expect(store.useSettingsStore.getState().importSettings(json).changed).toEqual([]);
+  });
+});
+
+describe("import refuses what it cannot read", () => {
+  it("fails cleanly on a file that isn't JSON", async () => {
+    const store = await freshStore();
+    expect(() =>
+      store.useSettingsStore.getState().importSettings("<html>not json</html>"),
+    ).toThrow(/valid JSON/i);
+    // …and leaves the store untouched.
+    expect(store.useSettingsStore.getState().diffViewMode).toBe("inline");
+  });
+
+  it("fails cleanly on JSON that isn't a settings export", async () => {
+    const store = await freshStore();
+    for (const bad of ["[1,2,3]", "null", '"a string"', '{"version":1}']) {
+      expect(() => store.useSettingsStore.getState().importSettings(bad), bad).toThrow(
+        /settings export/i,
+      );
+    }
+  });
+
+  it("points a single-theme file at the right button", async () => {
+    const store = await freshStore();
+    const themeJson = store.useSettingsStore
+      .getState()
+      .exportTheme(store.BUILTIN_THEMES[0].id);
+    expect(() => store.useSettingsStore.getState().importSettings(themeJson)).toThrow(
+      /theme/i,
+    );
+  });
+
+  it("rejects a payload whose kind is something else entirely", async () => {
+    const store = await freshStore();
+    expect(() =>
+      store.useSettingsStore
+        .getState()
+        .importSettings(
+          JSON.stringify({ kind: "some-other-app", version: 1, settings: {} }),
+        ),
+    ).toThrow(/settings export/i);
+  });
+});
+
+describe("schema version", () => {
+  it("stamps the current version on an export", async () => {
+    const store = await freshStore();
+    const payload = exported(store);
+    expect(payload.version).toBe(store.SETTINGS_EXPORT_VERSION);
+    expect(payload.kind).toBe("platypusgit-settings");
+  });
+
+  it("accepts a payload from a newer build key by key, and flags it", async () => {
+    const store = await freshStore();
+    const newer = store.SETTINGS_EXPORT_VERSION + 7;
+    const report = store.useSettingsStore
+      .getState()
+      .importSettings(
+        payloadOf({ diffViewMode: "split", warpDriveEnabled: true }, { version: newer }),
+      );
+    expect(report.fromNewerVersion).toBe(true);
+    expect(report.version).toBe(newer);
+    // Every field is validated on its own, so the settings this build DOES
+    // know about still land — that is the whole reason not to reject.
+    expect(store.useSettingsStore.getState().diffViewMode).toBe("split");
+    expect(report.ignored).toEqual(["warpDriveEnabled"]);
+  });
+
+  it("does not flag a payload at or below the current version", async () => {
+    const store = await freshStore();
+    const report = store.useSettingsStore
+      .getState()
+      .importSettings(payloadOf({}, { version: 1 }));
+    expect(report.fromNewerVersion).toBe(false);
+    expect(report.version).toBe(1);
+  });
+
+  it("is a different notion from the localStorage key's version", async () => {
+    // STORAGE_KEY is "pg-settings-v2" and has its own history; the payload
+    // version describes the FILE format. Conflating them would mean a
+    // localStorage migration silently invalidating everyone's saved exports.
+    const store = await freshStore();
+    expect(store.SETTINGS_EXPORT_VERSION).toBe(1);
+    expect(STORAGE_KEY).toBe("pg-settings-v2");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// DOWNLOAD
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("downloadSettings", () => {
+  it("names the file it wrote, so the UI can say where it went", async () => {
+    const store = await freshStore();
+    const hrefs: string[] = [];
+    const names: string[] = [];
+    const origCreate = URL.createObjectURL;
+    const origRevoke = URL.revokeObjectURL;
+    const origClick = HTMLAnchorElement.prototype.click;
+    URL.createObjectURL = vi.fn(() => "blob:settings") as typeof URL.createObjectURL;
+    URL.revokeObjectURL = vi.fn() as typeof URL.revokeObjectURL;
+    HTMLAnchorElement.prototype.click = function (this: HTMLAnchorElement) {
+      names.push(this.download);
+      hrefs.push(this.href);
+    };
+    try {
+      const name = store.useSettingsStore.getState().downloadSettings();
+      expect(name).toMatch(/^platypusgit-settings-\d{4}-\d{2}-\d{2}\.json$/);
+      expect(names).toEqual([name]);
+      expect(hrefs).toEqual(["blob:settings"]);
+      // No anchor left behind in the document.
+      expect(document.querySelectorAll("a")).toHaveLength(0);
+    } finally {
+      HTMLAnchorElement.prototype.click = origClick;
+      URL.createObjectURL = origCreate;
+      URL.revokeObjectURL = origRevoke;
+    }
+  });
+});

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -707,6 +707,23 @@ export interface SettingsState extends PersistedState {
   exportTheme: (id: string) => string;
   downloadTheme: (id: string) => void;
   importThemeJson: (json: string) => ThemeDef;
+  /**
+   * Serialise every portable setting to one versioned JSON string (#254).
+   * Custom themes travel in it, in the same per-theme shape `exportTheme`
+   * writes; machine-specific keys (`NON_PORTABLE_KEYS`) do not.
+   */
+  exportSettings: (opts?: SettingsExportOptions) => string;
+  /**
+   * `exportSettings` plus the download. Returns the filename, because "your
+   * settings were exported" is useless without saying to what.
+   */
+  downloadSettings: (opts?: SettingsExportOptions) => string;
+  /**
+   * Apply a settings file and report what it changed — an import that replaces
+   * every preference silently is indistinguishable from one that did nothing.
+   * Throws an `Error` with a user-facing message when the file cannot be read.
+   */
+  importSettings: (json: string) => SettingsImportReport;
   set: <K extends keyof PersistedState>(key: K, value: PersistedState[K]) => void;
   /** Nudge the zoom by whole steps; clamped at both ends. */
   stepZoom: (steps: number) => void;
@@ -736,78 +753,327 @@ const DEFAULTS: PersistedState = {
   lastCreateDir: "",
 };
 
+// ═════════════════════════════════════════════════════════════════════════════
+// PORTABLE SETTINGS — export / import the whole bag (#254)
+// ═════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Schema version of an exported settings FILE.
+ *
+ * A different notion from `STORAGE_KEY`'s "-v2": that versions the localStorage
+ * slot THIS install reads, and bumping it is a local migration. This versions
+ * the interchange format, and bumping it changes what other builds can read.
+ * Conflating them would let a localStorage migration silently invalidate every
+ * export anyone had already saved.
+ */
+export const SETTINGS_EXPORT_VERSION = 1;
+
+/** Marks a file as ours — a `.pgtheme.json` or a stray JSON is refused. */
+export const SETTINGS_EXPORT_KIND = "platypusgit-settings";
+
+// An identifier, not a fetch: nothing in the app dereferences it. Same
+// reasoning as the theme export's, and the same allow-list entry in
+// test/privacy.test.ts.
+const SETTINGS_SCHEMA_URL = "https://platypusgit.dev/settings.schema.json";
+
+/**
+ * Settings that describe THIS MACHINE and must not travel.
+ *
+ * A deny-list rather than an allow-list, and the asymmetry is the point: the
+ * export walks `DEFAULTS` and skips these, so a preference added tomorrow is
+ * exported by default instead of waiting for someone to remember a second
+ * list. #283 added `updateCheckMode` days before this export existed — a
+ * hand-written allow-list would have missed it and quietly dropped a real
+ * preference from every file people had already saved.
+ *
+ * Nothing secret needs denying, because nothing secret is in `PersistedState`:
+ * forge tokens and git credentials live in their own `Secret`-typed storage and
+ * no command returns them. `useSettingsStore.export.test.ts` asserts that
+ * against the serialised payload rather than leaving it to memory.
+ */
+export const NON_PORTABLE_KEYS: readonly (keyof PersistedState)[] = [
+  "lastCreateDir",
+];
+
+/** `DEFAULTS`' keys minus the deny-list — exactly what an export carries. */
+export const PORTABLE_KEYS: readonly (keyof PersistedState)[] = (
+  Object.keys(DEFAULTS) as (keyof PersistedState)[]
+).filter((k) => !NON_PORTABLE_KEYS.includes(k));
+
+export interface SettingsExportOptions {
+  /**
+   * The active keymap preset id, when the caller wants it in the file. The
+   * keymap is the setting people are most attached to, but it is persisted by
+   * `useKeymapStore` under its own localStorage key — and `keymap/actions.ts`
+   * imports THIS module, so reading it from here would be an import cycle.
+   * `screens/Settings.tsx` already owns both stores and bridges them.
+   */
+  keymapPresetId?: string | null;
+}
+
+export interface SettingsImportReport {
+  /** Settings whose value the file actually changed. */
+  changed: (keyof PersistedState)[];
+  /**
+   * Keys in the file this build has no setting for — removed since, or added by
+   * a newer build. Reported rather than swallowed so "why did my X not come
+   * across" has an answer on screen.
+   */
+  ignored: string[];
+  /** The preset the file asks for, for the caller to hand to the keymap store. */
+  keymapPresetId: string | null;
+  /** The file's declared schema version, or null when it declared none. */
+  version: number | null;
+  /** True when the file was written by a build newer than this one. */
+  fromNewerVersion: boolean;
+}
+
+// The three values the backend's PullMode accepts. A fourth string would reach
+// git as a mode nobody implements.
+const PULL_MODES: readonly PullMode[] = ["Rebase", "Merge", "FastForward"];
+
+const NOT_AN_EXPORT = "That file isn't a platypusgit settings export.";
+
+/**
+ * Read the envelope of a settings file, or throw a message a user can act on.
+ *
+ * Deliberately strict about the WRAPPER and lenient about the contents: the
+ * wrapper is how we know this file was meant for us at all, while every setting
+ * inside is validated one at a time by `coerceSettings`.
+ */
+function parseSettingsExport(json: string): {
+  settings: Record<string, unknown>;
+  keymapPresetId: string | null;
+  version: number | null;
+} {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    // The failure people hit by accident (wrong file, truncated download), so
+    // it names which half went wrong instead of surfacing a parser message.
+    throw new Error("That file isn't valid JSON.");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(NOT_AN_EXPORT);
+  }
+  const o = parsed as Record<string, unknown>;
+  if (o.kind !== undefined && o.kind !== SETTINGS_EXPORT_KIND) {
+    throw new Error(NOT_AN_EXPORT);
+  }
+  const settings = o.settings;
+  if (!settings || typeof settings !== "object" || Array.isArray(settings)) {
+    // A single-theme file is the near miss worth naming: it is the other file
+    // this app writes, and it has its own button three rows up.
+    if (o.colors && typeof o.colors === "object") {
+      throw new Error(
+        "That looks like a single theme file — import it under Appearance.",
+      );
+    }
+    throw new Error(NOT_AN_EXPORT);
+  }
+  const keymap = o.keymap as Record<string, unknown> | undefined;
+  const presetId =
+    keymap && typeof keymap === "object" && typeof keymap.presetId === "string"
+      ? keymap.presetId.trim()
+      : "";
+  return {
+    settings: settings as Record<string, unknown>,
+    keymapPresetId: presetId || null,
+    version:
+      typeof o.version === "number" && Number.isFinite(o.version) ? o.version : null,
+  };
+}
+
+/** Structural equality, enough for the two array-valued settings. */
+function sameValue(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if ((a !== null && typeof a === "object") || (b !== null && typeof b === "object")) {
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+  return false;
+}
+
+/**
+ * Coerce a persisted or imported theme list into usable `ThemeDef`s.
+ *
+ * Lenient in the direction `validateTheme` already chose for the logo slots: a
+ * missing colour is filled from the default theme rather than costing the user
+ * the whole theme, and one unusable entry costs only itself. Every colour goes
+ * through `sanitizeHex`, so neither a hand-edited localStorage payload nor a
+ * shared file can put an arbitrary string into a CSS var. `builtin` is never
+ * carried over — a custom theme that claims to be built in renders read-only in
+ * the editor and cannot be deleted.
+ */
+function normalizeCustomThemes(value: unknown, fallback: ThemeDef[]): ThemeDef[] {
+  if (!Array.isArray(value)) return fallback;
+  const out: ThemeDef[] = [];
+  const seen = new Set<string>();
+  for (const raw of value) {
+    if (!raw || typeof raw !== "object") continue;
+    const o = raw as Record<string, unknown>;
+    if (!o.colors || typeof o.colors !== "object") continue;
+    const src = o.colors as Record<string, unknown>;
+    const colors = {} as ThemeColors;
+    for (const f of THEME_COLOR_FIELDS) {
+      const v = src[f.key];
+      colors[f.key] =
+        typeof v === "string" ? sanitizeHex(v) : BUILTIN_THEMES[0].colors[f.key];
+    }
+    // The id has to survive, or `activeThemeId` dangles and the app silently
+    // falls back to the default theme.
+    const wanted =
+      typeof o.id === "string" && o.id.trim() ? o.id.trim() : uniqueId(out);
+    const id = seen.has(wanted) ? `${wanted}-${out.length}` : wanted;
+    seen.add(id);
+    out.push({
+      id,
+      name: typeof o.name === "string" && o.name.trim() ? o.name.trim() : "Imported theme",
+      mode: o.mode === "light" ? "light" : "dark",
+      colors,
+    });
+  }
+  return out;
+}
+
+interface CoercedSettings {
+  state: PersistedState;
+  /** Keys whose value ended up different from `base`. */
+  changed: (keyof PersistedState)[];
+  /** Keys in the payload this build has no setting for. */
+  ignored: string[];
+}
+
+/**
+ * Fold an arbitrary object into a complete, valid `PersistedState`.
+ *
+ * ONE validator for both untrusted sources — the localStorage payload `load()`
+ * reads on startup, and the file `importSettings` reads. They face the same
+ * problems (a hand-edited value, a setting this build removed, a value from a
+ * newer build), and a second copy of these guards would be a second copy to
+ * forget to update.
+ *
+ * The rules, in order:
+ *   absent from `parsed`  → keep `base`'s value. For `load()` that is DEFAULTS;
+ *                           for an import it means an older file cannot silently
+ *                           reset a preference it predates (an export without
+ *                           `updateCheckMode` must not switch update checks back
+ *                           on for someone who turned them off).
+ *   present and valid     → apply it.
+ *   present and unusable  → the DEFAULT, not `base`: the payload asked for a
+ *                           change, and the documented safe value is the honest
+ *                           answer to garbage.
+ */
+function coerceSettings(
+  parsed: Record<string, unknown>,
+  base: PersistedState,
+): CoercedSettings {
+  const known = new Set<string>(Object.keys(DEFAULTS));
+  const ignored = Object.keys(parsed).filter(
+    // `headIndicator` left the schema but the migration below still reads it,
+    // so it is honoured rather than ignored.
+    (k) => !known.has(k) && k !== "headIndicator",
+  );
+
+  // Only pick keys that still exist in the schema, so settings removed in
+  // newer versions (e.g. showWhitespaceInDiff) don't leak stale properties
+  // into the store state.
+  const out: PersistedState = { ...base };
+  for (const key of Object.keys(DEFAULTS) as (keyof PersistedState)[]) {
+    if (key in parsed) {
+      (out as unknown as Record<string, unknown>)[key] = parsed[key];
+    }
+  }
+
+  // Type-guard every scalar against the type of its default. A payload can hold
+  // a string where a toggle expects a boolean, and `checked={"no"}` is a toggle
+  // stuck ON — the user sees the opposite of what the file said. Deriving the
+  // expected type from DEFAULTS means a new scalar preference is guarded the day
+  // it is added, for the same reason the export derives its key set. The two
+  // object-valued settings (customThemes, headMarks) have their own normalizers
+  // below.
+  for (const key of Object.keys(DEFAULTS) as (keyof PersistedState)[]) {
+    const want = typeof DEFAULTS[key];
+    if (want !== "object" && typeof out[key] !== want) {
+      (out as unknown as Record<string, unknown>)[key] = DEFAULTS[key];
+    }
+  }
+
+  // `signCommits` was once a boolean no-op setting and is now a tri-state
+  // (#61 D6), so an old payload can carry `true`/`false` where a mode is
+  // expected. Anything that is not one of the three modes falls back to
+  // "config", which defers to the repository rather than forcing signing on.
+  if (!["config", "always", "never"].includes(out.signCommits as string)) {
+    out.signCommits = DEFAULTS.signCommits;
+  }
+  // A hand-edited or newer-build zoom must not survive as-is: an out-of-range
+  // factor is rejected by the webview and would leave the UI unzoomable.
+  out.uiZoom = normalizeZoom(Number(out.uiZoom));
+  // An unrecognized density would emit `--row-step: undefinedpx`, and an
+  // invalid substitution makes every `calc(Npx + var(--row-step))` compute to
+  // `auto` — collapsing the height of every row in the app at once.
+  out.uiDensity = normalizeDensity(out.uiDensity);
+  // HEAD marks: prefer a stored list, else carry over the pre-#118 single
+  // `headIndicator` enum, else — if the payload spoke about marks at all but
+  // said something unusable — the default, and otherwise whatever `base` had.
+  // Migration reads `parsed`, not `out`: the old key is gone from the schema, so
+  // the copy loop above never picked it up. Landing an upgraded install on
+  // "strong" is deliberate: the same choice as before, at roughly twice the
+  // visibility.
+  const storedMarks =
+    normalizeHeadMarks(parsed.headMarks) ?? migrateHeadIndicator(parsed.headIndicator);
+  const mentionsMarks = "headMarks" in parsed || "headIndicator" in parsed;
+  out.headMarks = storedMarks ?? (mentionsMarks ? DEFAULTS.headMarks : base.headMarks);
+  // Same reasoning as the zoom clamp: an unknown weight would resolve every
+  // mark to NaN and silently draw nothing.
+  if (!HEAD_WEIGHTS.includes(out.headWeight as HeadWeight)) {
+    out.headWeight = DEFAULTS.headWeight;
+  }
+  // Same reasoning again for the two diff modes: the renderers branch on these
+  // exact strings, so an unknown value means "neither branch" — a blank pane.
+  if (!["inline", "split"].includes(out.diffViewMode as string)) {
+    out.diffViewMode = DEFAULTS.diffViewMode;
+  }
+  if (!["wholeFile", "chunks"].includes(out.diffContextMode as string)) {
+    out.diffContextMode = DEFAULTS.diffContextMode;
+  }
+  // Same reasoning for the update-check mode, with a sharper failure: the gate
+  // in useUpdateStore only lets `auto` through automatically, so an unknown
+  // string (hand-edited file, a mode a newer build added) would silently mean
+  // "this install never checks for updates again" — the one outcome nobody
+  // asked for. Anything not one of the three modes falls back to "auto".
+  if (!UPDATE_CHECK_MODES.includes(out.updateCheckMode as UpdateCheckMode)) {
+    out.updateCheckMode = DEFAULTS.updateCheckMode;
+  }
+  // A pull mode the backend has no arm for would fail every pull.
+  if (!PULL_MODES.includes(out.defaultPullMode)) {
+    out.defaultPullMode = DEFAULTS.defaultPullMode;
+  }
+  // The same bounds the Settings inputs enforce, applied to values that did not
+  // come through those inputs.
+  out.diffContextLines = clampInt(out.diffContextLines, 0, 20, DEFAULTS.diffContextLines);
+  out.autoFetchMinutes = clampInt(out.autoFetchMinutes, 1, 60, DEFAULTS.autoFetchMinutes);
+  // Backfill logo colors for custom themes saved before the slots existed, drop
+  // anything unusable, and keep the ids so `activeThemeId` still resolves.
+  out.customThemes = normalizeCustomThemes(out.customThemes, base.customThemes);
+
+  const changed = (Object.keys(DEFAULTS) as (keyof PersistedState)[]).filter(
+    (key) => !sameValue(out[key], base[key]),
+  );
+  return { state: out, changed, ignored };
+}
+
+function clampInt(value: number, min: number, max: number, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, Math.round(value)));
+}
+
 function load(): PersistedState {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return { ...DEFAULTS };
     const parsed = JSON.parse(raw) as Record<string, unknown>;
-    // Only pick keys that still exist in the schema, so settings removed in
-    // newer versions (e.g. showWhitespaceInDiff) don't leak stale properties
-    // into the store state.
-    const out = { ...DEFAULTS };
-    for (const key of Object.keys(DEFAULTS) as (keyof PersistedState)[]) {
-      if (key in parsed) {
-        (out as Record<string, unknown>)[key] = parsed[key];
-      }
-    }
-    // `signCommits` was once a boolean no-op setting and is now a tri-state
-    // (#61 D6), so an old payload can carry `true`/`false` where a mode is
-    // expected. Anything that is not one of the three modes falls back to
-    // "config", which defers to the repository rather than forcing signing on.
-    if (!["config", "always", "never"].includes(out.signCommits as string)) {
-      out.signCommits = DEFAULTS.signCommits;
-    }
-    // A hand-edited or newer-build zoom must not survive as-is: an out-of-range
-    // factor is rejected by the webview and would leave the UI unzoomable.
-    out.uiZoom = normalizeZoom(Number(out.uiZoom));
-    // HEAD marks: prefer a stored list, else carry over the pre-#118 single
-    // `headIndicator` enum, else the default. Migration reads `parsed`, not
-    // `out` — the old key is gone from the schema, so the copy loop above never
-    // picked it up. Landing an upgraded install on "strong" is deliberate: the
-    // same choice as before, just at roughly twice the visibility.
-    out.headMarks =
-      normalizeHeadMarks(parsed.headMarks) ??
-      migrateHeadIndicator(parsed.headIndicator) ??
-      DEFAULTS.headMarks;
-    // Same reasoning as the zoom clamp: an unknown weight would resolve every
-    // mark to NaN and silently draw nothing.
-    if (!HEAD_WEIGHTS.includes(out.headWeight as HeadWeight)) {
-      out.headWeight = DEFAULTS.headWeight;
-    }
-    // Same reasoning again for the two diff modes: the renderers branch on these
-    // exact strings, so an unknown value means "neither branch" — a blank pane.
-    if (!["inline", "split"].includes(out.diffViewMode as string)) {
-      out.diffViewMode = DEFAULTS.diffViewMode;
-    }
-    if (!["wholeFile", "chunks"].includes(out.diffContextMode as string)) {
-      out.diffContextMode = DEFAULTS.diffContextMode;
-    }
-    // Same reasoning for the update-check mode, with a sharper failure: the gate
-    // in useUpdateStore only lets `auto` through automatically, so an unknown
-    // string (hand-edited file, a mode a newer build added) would silently mean
-    // "this install never checks for updates again" — the one outcome nobody
-    // asked for. Anything not one of the three modes falls back to "auto".
-    if (!UPDATE_CHECK_MODES.includes(out.updateCheckMode as UpdateCheckMode)) {
-      out.updateCheckMode = DEFAULTS.updateCheckMode;
-    }
-    // Backfill logo colors for custom themes saved before the slots existed,
-    // so the theme editor and CSS vars always have a value.
-    out.customThemes = out.customThemes.map((t) => {
-      if (!t.colors) return t;
-      const needs =
-        t.colors.logo === undefined || t.colors.logo2 === undefined;
-      return needs
-        ? {
-            ...t,
-            colors: {
-              ...t.colors,
-              logo: t.colors.logo ?? LOGO_PRIMARY,
-              logo2: t.colors.logo2 ?? LOGO_SECONDARY,
-            },
-          }
-        : t;
-    });
-    return out;
+    return coerceSettings(parsed, DEFAULTS).state;
   } catch {
     return { ...DEFAULTS };
   }
@@ -821,29 +1087,19 @@ function persist(state: PersistedState) {
   }
 }
 
+/**
+ * The persisted slice of the store.
+ *
+ * Derived from `DEFAULTS` rather than hand-listed: the key set already lives in
+ * one place, and a third copy is a third thing to forget when a preference is
+ * added — which is the same reason the export derives its keys.
+ */
 function snapshot(s: SettingsState): PersistedState {
-  return {
-    activeThemeId: s.activeThemeId,
-    customThemes: s.customThemes,
-    uiDensity: s.uiDensity,
-    uiZoom: s.uiZoom,
-    headMarks: s.headMarks,
-    headWeight: s.headWeight,
-    defaultPullMode: s.defaultPullMode,
-    autoFetchEnabled: s.autoFetchEnabled,
-    autoFetchMinutes: s.autoFetchMinutes,
-    pruneOnFetch: s.pruneOnFetch,
-    confirmForcePush: s.confirmForcePush,
-    autoStashBeforePull: s.autoStashBeforePull,
-    addSignoff: s.addSignoff,
-    signCommits: s.signCommits,
-    diffContextLines: s.diffContextLines,
-    diffViewMode: s.diffViewMode,
-    diffContextMode: s.diffContextMode,
-    ignoreWhitespaceInDiff: s.ignoreWhitespaceInDiff,
-    updateCheckMode: s.updateCheckMode,
-    lastCreateDir: s.lastCreateDir,
-  };
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(DEFAULTS)) {
+    out[key] = (s as unknown as Record<string, unknown>)[key];
+  }
+  return out as unknown as PersistedState;
 }
 
 function findTheme(
@@ -876,6 +1132,15 @@ function sanitizeHex(value: string): string {
   if (body.length === 6) return `#${body}`;
   if (body.length === 8) return `#${body.slice(0, 6)}`;
   return "#000000";
+}
+
+/**
+ * The wire shape of ONE theme. Shared by the single-theme export and the
+ * settings bundle, so there is one theme format rather than two — a bundle adds
+ * `id` on top, because it has to keep `activeThemeId` resolvable.
+ */
+function themePayload(t: ThemeDef): Pick<ThemeDef, "name" | "mode" | "colors"> {
+  return { name: t.name, mode: t.mode, colors: t.colors };
 }
 
 function validateTheme(obj: unknown): ThemeDef {
@@ -1030,9 +1295,7 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     const payload = {
       $schema: "https://platypusgit.dev/theme.schema.json",
       version: 1,
-      name: t.name,
-      mode: t.mode,
-      colors: t.colors,
+      ...themePayload(t),
     };
     return JSON.stringify(payload, null, 2);
   },
@@ -1068,6 +1331,91 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     persist(snapshot(get()));
     applyTheme(theme);
     return theme;
+  },
+
+  exportSettings(opts) {
+    const s = get();
+    const settings: Record<string, unknown> = {};
+    for (const key of PORTABLE_KEYS) {
+      settings[key] =
+        key === "customThemes"
+          ? s.customThemes.map((t) => ({ id: t.id, ...themePayload(t) }))
+          : s[key];
+    }
+    const presetId = opts?.keymapPresetId?.trim();
+    return JSON.stringify(
+      {
+        $schema: SETTINGS_SCHEMA_URL,
+        kind: SETTINGS_EXPORT_KIND,
+        version: SETTINGS_EXPORT_VERSION,
+        // File metadata, not a preference: the import path never reads it. It
+        // is here because "attach your settings export" is a support story, and
+        // the first question is always how old the file is.
+        exportedAt: new Date().toISOString(),
+        settings,
+        ...(presetId ? { keymap: { presetId } } : {}),
+      },
+      null,
+      2,
+    );
+  },
+
+  downloadSettings(opts) {
+    const json = get().exportSettings(opts);
+    // Date, not timestamp: this is a file people keep and re-read, so a name
+    // they can recognise beats a name that is unique.
+    const filename = `platypusgit-settings-${new Date()
+      .toISOString()
+      .slice(0, 10)}.json`;
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    return filename;
+  },
+
+  importSettings(json) {
+    const file = parseSettingsExport(json);
+    // The deny-list works in BOTH directions. Export skipping a key is only
+    // half the promise: a hand-edited file, or one from a build that shortened
+    // its own deny-list, must not be able to set a preference that describes
+    // another machine either. Reported, not swallowed.
+    const portable: Record<string, unknown> = {};
+    const denied: string[] = [];
+    for (const [key, value] of Object.entries(file.settings)) {
+      if (NON_PORTABLE_KEYS.includes(key as keyof PersistedState)) {
+        denied.push(key);
+      } else {
+        portable[key] = value;
+      }
+    }
+    // Merge onto the CURRENT state, not onto DEFAULTS — see coerceSettings.
+    const { state, changed, ignored } = coerceSettings(portable, snapshot(get()));
+    set(state);
+    persist(state);
+    // Everything with an effect outside the store has to be re-applied, or the
+    // import lands in state and not on screen.
+    applyTheme(findTheme(state, state.activeThemeId) ?? BUILTIN_THEMES[0]);
+    applyDensity(state.uiDensity);
+    applyZoom(state.uiZoom);
+    return {
+      changed,
+      ignored: [...ignored, ...denied],
+      keymapPresetId: file.keymapPresetId,
+      version: file.version,
+      // Accepted, not rejected: every field is validated on its own and unknown
+      // keys are reported, so a file from a newer build degrades to "the
+      // settings this build understands". Rejecting it would strand anyone
+      // moving a machine back onto an older release — one of the cases the
+      // export exists for.
+      fromNewerVersion:
+        file.version !== null && file.version > SETTINGS_EXPORT_VERSION,
+    };
   },
 
   set(key, value) {

--- a/src/screens/Settings.export.test.tsx
+++ b/src/screens/Settings.export.test.tsx
@@ -1,0 +1,283 @@
+// The Settings → "Settings file" panel (#254). The store's half is pinned in
+// features/settings/useSettingsStore.export.test.ts; this file asserts the two
+// promises the UI itself makes:
+//
+//   * export SAYS WHERE THE FILE WENT — "settings exported" with no filename is
+//     not an answer.
+//   * import ASKS FIRST and then REPORTS what changed, rather than replacing
+//     every preference silently.
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+import { mockInvoke } from "@/test/invokeMock";
+import { WithDialogs, acceptDialog, dismissDialog, resetDialogs } from "@/test/dialog";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { useKeymapStore } from "@/features/keymap";
+import { SettingsScreen } from "./Settings";
+
+// jsdom's Blob has no `text()`, and both file-import paths in Settings read the
+// picked file with `file.text()` (the real WKWebView/WebKitGTK/WebView2 all have
+// it). FileReader IS implemented, so bridge the two.
+if (typeof Blob.prototype.text !== "function") {
+  Blob.prototype.text = function (this: Blob) {
+    return new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(String(reader.result));
+      reader.onerror = () => reject(reader.error);
+      reader.readAsText(this);
+    });
+  };
+}
+
+/** The rest of the Settings screen loads too; give it what it asks for. */
+function mockRestOfSettings() {
+  mockInvoke("cli_shim_status", () => ({
+    installed: true,
+    shimPath: "/usr/local/bin/pgit",
+    target: "/usr/bin/platypusgit",
+    source: "package",
+    pathState: "onPath",
+  }));
+  mockInvoke("diagnostics_report", () => ({
+    logPath: "/tmp/platypusgit.log",
+    logExists: false,
+    logSizeBytes: 0,
+    environment: "host os=macos arch=aarch64 git=2.43.0",
+    version: "0.1.0",
+  }));
+}
+
+let downloads: string[];
+let origClick: () => void;
+let origCreate: typeof URL.createObjectURL;
+let origRevoke: typeof URL.revokeObjectURL;
+
+beforeEach(() => {
+  localStorage.clear();
+  resetDialogs();
+  mockRestOfSettings();
+  useSettingsStore.getState().reset();
+  downloads = [];
+  origClick = HTMLAnchorElement.prototype.click;
+  origCreate = URL.createObjectURL;
+  origRevoke = URL.revokeObjectURL;
+  // jsdom has no blob-URL plumbing and no downloads; record what the anchor was
+  // told to save instead.
+  URL.createObjectURL = vi.fn(
+    () => "blob:settings",
+  ) as unknown as typeof URL.createObjectURL;
+  URL.revokeObjectURL = vi.fn() as unknown as typeof URL.revokeObjectURL;
+  HTMLAnchorElement.prototype.click = function (this: HTMLAnchorElement) {
+    downloads.push(this.download);
+  };
+});
+
+afterEach(() => {
+  HTMLAnchorElement.prototype.click = origClick;
+  URL.createObjectURL = origCreate;
+  URL.revokeObjectURL = origRevoke;
+  resetDialogs();
+});
+
+// Deliberately distinct from Appearance's theme "Export" / "Import…" pair —
+// two buttons called Import… on one screen is ambiguous for a user and
+// ambiguous for a query.
+const exportButton = () =>
+  screen.getByRole("button", { name: /^export settings$/i });
+const importButton = () =>
+  screen.getByRole("button", { name: /^import settings…$/i });
+const importInput = () =>
+  screen.getByTestId("settings-import-input") as HTMLInputElement;
+
+/**
+ * Feed the hidden file input. `userEvent.upload` clicks the element first, and
+ * this input is `display: none` (the visible control is the Import… button), so
+ * the change event is dispatched directly.
+ */
+async function pickFile(json: string, name = "platypusgit-settings.json") {
+  const file = new File([json], name, { type: "application/json" });
+  await act(async () => {
+    fireEvent.change(importInput(), { target: { files: [file] } });
+  });
+}
+
+describe("Settings → Settings file: export", () => {
+  it("offers both halves as buttons, with the file picker behind Import…", async () => {
+    render(
+      <WithDialogs>
+        <SettingsScreen />
+      </WithDialogs>,
+    );
+    expect(exportButton()).toBeTruthy();
+    // The visible control is a button; the <input type="file"> is hidden behind
+    // it, so the section reads like the rest of Settings.
+    expect(importButton()).toBeTruthy();
+    expect(importInput().style.display).toBe("none");
+    await userEvent.click(importButton());
+  });
+
+  it("names the file it wrote", async () => {
+    render(
+      <WithDialogs>
+        <SettingsScreen />
+      </WithDialogs>,
+    );
+    await userEvent.click(exportButton());
+    const said = await screen.findByTestId("settings-export-result");
+    expect(downloads).toHaveLength(1);
+    // The filename on screen is the filename the browser was given — a message
+    // that says "exported" without saying to what is not an answer.
+    expect(said.textContent).toContain(downloads[0]);
+    expect(downloads[0]).toMatch(/^platypusgit-settings-\d{4}-\d{2}-\d{2}\.json$/);
+  });
+
+  it("puts the active keymap preset in the file", async () => {
+    useKeymapStore.getState().setPreset("platypusgit");
+    render(
+      <WithDialogs>
+        <SettingsScreen />
+      </WithDialogs>,
+    );
+    await userEvent.click(exportButton());
+    // The screen is what bridges the two stores, so this is the only level at
+    // which the keymap actually reaches the file.
+    const json = useSettingsStore
+      .getState()
+      .exportSettings({ keymapPresetId: useKeymapStore.getState().activePresetId });
+    expect(JSON.parse(json).keymap).toEqual({ presetId: "platypusgit" });
+  });
+});
+
+describe("Settings → Settings file: import", () => {
+  /** A payload as the app itself writes it. */
+  function fileWith(patch: Record<string, unknown>, extra: Record<string, unknown> = {}) {
+    const base = JSON.parse(useSettingsStore.getState().exportSettings()) as {
+      settings: Record<string, unknown>;
+    };
+    return JSON.stringify({ ...base, ...extra, settings: { ...base.settings, ...patch } });
+  }
+
+  it("asks before replacing anything, and does nothing if declined", async () => {
+    render(
+      <WithDialogs>
+        <SettingsScreen />
+      </WithDialogs>,
+    );
+    await pickFile(fileWith({ diffViewMode: "split" }));
+    // The dialog names the file, which is the only thing the user can still
+    // recognise at this point.
+    await screen.findByTestId("dialog-confirm");
+    expect(screen.getByTestId("dialog-title").textContent).toMatch(/replace/i);
+    await dismissDialog();
+    expect(useSettingsStore.getState().diffViewMode).toBe("inline");
+    expect(screen.queryByTestId("settings-import-report")).toBeNull();
+  });
+
+  it("applies on confirm and reports the settings that changed", async () => {
+    render(
+      <WithDialogs>
+        <SettingsScreen />
+      </WithDialogs>,
+    );
+    await pickFile(fileWith({ diffViewMode: "split", addSignoff: true }));
+    await screen.findByTestId("dialog-confirm");
+    await acceptDialog();
+
+    expect(useSettingsStore.getState().diffViewMode).toBe("split");
+    const report = await screen.findByTestId("settings-import-report");
+    expect(report.textContent).toContain("diffViewMode");
+    expect(report.textContent).toContain("addSignoff");
+    // Settings the file matched are NOT listed — the report is what changed,
+    // not what the file contained.
+    expect(report.textContent).not.toContain("pruneOnFetch");
+  });
+
+  it("says so when the file matches the machine already", async () => {
+    render(
+      <WithDialogs>
+        <SettingsScreen />
+      </WithDialogs>,
+    );
+    await pickFile(fileWith({}));
+    await screen.findByTestId("dialog-confirm");
+    await acceptDialog();
+    const report = await screen.findByTestId("settings-import-report");
+    expect(report.textContent).toMatch(/nothing changed/i);
+  });
+
+  it("applies the keymap preset and counts it as a change", async () => {
+    useKeymapStore.getState().setPreset("rider");
+    render(
+      <WithDialogs>
+        <SettingsScreen />
+      </WithDialogs>,
+    );
+    await pickFile(fileWith({}, { keymap: { presetId: "platypusgit" } }));
+    await screen.findByTestId("dialog-confirm");
+    await acceptDialog();
+    expect(useKeymapStore.getState().activePresetId).toBe("platypusgit");
+    const report = await screen.findByTestId("settings-import-report");
+    expect(report.textContent).toContain("keymap");
+  });
+
+  it("reports an unknown keymap preset instead of applying it", async () => {
+    useKeymapStore.getState().setPreset("rider");
+    render(
+      <WithDialogs>
+        <SettingsScreen />
+      </WithDialogs>,
+    );
+    await pickFile(fileWith({}, { keymap: { presetId: "emacs-someday" } }));
+    await screen.findByTestId("dialog-confirm");
+    await acceptDialog();
+    // presetById would silently resolve an unknown id to the default while the
+    // picker showed the unknown name, so it is reported, not applied.
+    expect(useKeymapStore.getState().activePresetId).toBe("rider");
+    const report = await screen.findByTestId("settings-import-report");
+    expect(report.textContent).toContain("emacs-someday");
+  });
+
+  it("shows a readable message for a file that isn't a settings export", async () => {
+    render(
+      <WithDialogs>
+        <SettingsScreen />
+      </WithDialogs>,
+    );
+    await pickFile("<html>nope</html>", "notes.json");
+    await screen.findByTestId("dialog-confirm");
+    await acceptDialog();
+    const err = await screen.findByTestId("settings-import-error");
+    expect(err.textContent).toMatch(/valid JSON/i);
+    // Nothing applied, and no report claiming otherwise.
+    expect(screen.queryByTestId("settings-import-report")).toBeNull();
+    expect(useSettingsStore.getState().diffViewMode).toBe("inline");
+  });
+
+  it("points a single-theme file at the Appearance button", async () => {
+    render(
+      <WithDialogs>
+        <SettingsScreen />
+      </WithDialogs>,
+    );
+    const themeJson = useSettingsStore.getState().exportTheme("dark-cool");
+    await pickFile(themeJson, "midnight.pgtheme.json");
+    await screen.findByTestId("dialog-confirm");
+    await acceptDialog();
+    const err = await screen.findByTestId("settings-import-error");
+    expect(err.textContent).toMatch(/theme/i);
+  });
+
+  it("names the keys it ignored", async () => {
+    render(
+      <WithDialogs>
+        <SettingsScreen />
+      </WithDialogs>,
+    );
+    await pickFile(fileWith({ warpDriveEnabled: true }));
+    await screen.findByTestId("dialog-confirm");
+    await acceptDialog();
+    const report = await screen.findByTestId("settings-import-report");
+    await waitFor(() => expect(report.textContent).toContain("warpDriveEnabled"));
+  });
+});

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -18,6 +18,7 @@ import {
   ZOOM_MIN,
   applyTheme,
   useSettingsStore,
+  type SettingsImportReport,
   type ThemeColors,
   type ThemeDef,
   type UpdateCheckMode,
@@ -285,6 +286,7 @@ export function SettingsScreen() {
         <KeyboardSection />
         <CliSection />
         <UpdatesSection />
+        <BackupSection />
         <DiagnosticsSection />
       </div>
     </div>
@@ -694,6 +696,204 @@ function UpdatesSection() {
         />
       </Section>
     </div>
+  );
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// BACKUP SECTION — export / import every setting as one file (#254)
+// ═════════════════════════════════════════════════════════════════════════════
+
+/**
+ * The keymap lives in `useKeymapStore` under its own localStorage key, so this
+ * screen is what bridges the two stores: it hands the active preset to the
+ * export and applies the one an import reports. The settings store cannot read
+ * it directly — `keymap/actions.ts` imports the settings store, so the reverse
+ * import would be a cycle.
+ */
+function BackupSection() {
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+  const [exportedTo, setExportedTo] = React.useState<string | null>(null);
+  const [report, setReport] = React.useState<
+    (SettingsImportReport & { keymapApplied: string | null }) | null
+  >(null);
+  const [failure, setFailure] = React.useState<string | null>(null);
+
+  const onExport = () => {
+    setReport(null);
+    setFailure(null);
+    const name = useSettingsStore.getState().downloadSettings({
+      keymapPresetId: useKeymapStore.getState().activePresetId,
+    });
+    setExportedTo(name);
+    pgFlash(`Exported ${name}`);
+  };
+
+  const onImportFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+    setExportedTo(null);
+    setReport(null);
+    setFailure(null);
+    let text: string;
+    try {
+      text = await file.text();
+    } catch (err) {
+      setFailure(appErrorMessage(err));
+      return;
+    }
+    // Asked before applying, not after: an import replaces every preference at
+    // once, and the file is the one thing the user can still recognise here.
+    if (
+      !(await pgConfirm({
+        title: "Replace your settings with this file?",
+        body: (
+          <>
+            Every preference in <Mono>{file.name}</Mono> is applied to this
+            machine. Nothing in your repositories changes, and what changed is
+            listed afterwards.
+          </>
+        ),
+        confirmLabel: "Import settings",
+      }))
+    )
+      return;
+
+    let result: SettingsImportReport;
+    try {
+      result = useSettingsStore.getState().importSettings(text);
+    } catch (err) {
+      setFailure(appErrorMessage(err));
+      return;
+    }
+
+    // The keymap half. An id this build has no preset for is reported as
+    // ignored rather than applied — `presetById` would silently resolve it to
+    // the default while the picker showed the unknown name.
+    const keymap = useKeymapStore.getState();
+    let keymapApplied: string | null = null;
+    const ignored = [...result.ignored];
+    if (result.keymapPresetId) {
+      const known = BUILTIN_PRESETS.some((p) => p.id === result.keymapPresetId);
+      if (!known) {
+        ignored.push(`keymap: ${result.keymapPresetId}`);
+      } else if (result.keymapPresetId !== keymap.activePresetId) {
+        keymap.setPreset(result.keymapPresetId);
+        keymapApplied = result.keymapPresetId;
+      }
+    }
+    setReport({ ...result, ignored, keymapApplied });
+    // The toast is the immediate answer; the report row below is the detail,
+    // because a list of key names outlives a 1.7s toast.
+    const count = result.changed.length + (keymapApplied ? 1 : 0);
+    pgFlash(
+      count === 0
+        ? "Settings already match this file"
+        : `Imported ${count} ${count === 1 ? "setting" : "settings"}`,
+    );
+  };
+
+  return (
+    <Section
+      title="Settings file"
+      subtitle="Move every preference to another machine, or share a house style with your team."
+    >
+      <Row
+        label="Export settings"
+        hint={
+          exportedTo ? (
+            <span data-testid="settings-export-result">
+              Saved <Mono>{exportedTo}</Mono> to your downloads folder.
+            </span>
+          ) : (
+            <>
+              One JSON file with every preference and every custom theme.
+              Forge tokens and git credentials are never in it, and neither is
+              anything specific to this machine.
+            </>
+          )
+        }
+        control={
+          <PGButton size="sm" icon="download" onClick={onExport}>
+            Export settings
+          </PGButton>
+        }
+      />
+      <Row
+        label="Import settings"
+        hint={
+          failure ? (
+            <span
+              data-testid="settings-import-error"
+              style={{ color: "var(--git-removed)" }}
+            >
+              {failure}
+            </span>
+          ) : report ? (
+            <ImportReport report={report} />
+          ) : (
+            <>
+              Reads a file exported here. Settings it does not mention are left
+              as they are, and you will see exactly what changed.
+            </>
+          )
+        }
+        control={
+          <PGButton
+            size="sm"
+            icon="upload"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            Import settings…
+          </PGButton>
+        }
+      />
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="application/json,.json"
+        onChange={onImportFile}
+        data-testid="settings-import-input"
+        style={{ display: "none" }}
+      />
+    </Section>
+  );
+}
+
+/** What the import changed. Key names, not prose labels: this is a developer
+ *  tool, the names are what the file contains, and a second table of friendly
+ *  labels would be a second thing to keep in step with the schema. */
+function ImportReport({
+  report,
+}: {
+  report: SettingsImportReport & { keymapApplied: string | null };
+}) {
+  const changed = [
+    ...report.changed,
+    ...(report.keymapApplied ? [`keymap → ${report.keymapApplied}`] : []),
+  ];
+  return (
+    <span data-testid="settings-import-report">
+      {changed.length === 0 ? (
+        <>Nothing changed — this machine already matches the file.</>
+      ) : (
+        <>
+          Changed {changed.length}{" "}
+          {changed.length === 1 ? "setting" : "settings"}:{" "}
+          <Mono>{changed.join(", ")}</Mono>.
+        </>
+      )}
+      {report.ignored.length > 0 && (
+        <>
+          {" "}
+          Ignored (not a portable setting in this version):{" "}
+          <Mono>{report.ignored.join(", ")}</Mono>.
+        </>
+      )}
+      {report.fromNewerVersion && (
+        <> The file was written by a newer version of platypusgit.</>
+      )}
+    </span>
   );
 }
 

--- a/test/privacy.test.ts
+++ b/test/privacy.test.ts
@@ -149,11 +149,14 @@ const ALLOWED_HOSTS: Array<[string, string]> = [
   ],
   [
     "platypusgit.dev",
-    "The `$schema` identifier written into an exported theme file " +
-      "(`features/settings/useSettingsStore.ts`, `screens/Settings.tsx`). A " +
+    "The `$schema` identifier written into an exported theme file and into an " +
+      "exported settings file (#254, both in " +
+      "`features/settings/useSettingsStore.ts`; `screens/Settings.tsx`). A " +
       "JSON Schema `$schema` is an identifier, not a fetch — nothing in the " +
       "app dereferences it, and no editor does either unless the USER opens " +
-      "the file in one.",
+      "the file in one. Both exports are local file downloads: the JSON is " +
+      "built in the renderer, handed to a blob URL and saved by the webview, " +
+      "with no request anywhere.",
   ],
   [
     "www.platypusgit.com",


### PR DESCRIPTION
## What does this PR do?

Exports every setting to one versioned JSON file, and imports it back with validation. Previously settings could leave the machine one way only: a theme at a time.

- **Export** — `Object.keys(DEFAULTS)` minus a `NON_PORTABLE_KEYS` deny-list. 19 keys, plus `$schema`, `kind`, `version`, `exportedAt`, and `keymap: { presetId }`.
- **Import** — a `pgConfirm` naming the file, then a report row listing changed keys, ignored keys, and a newer-version note.
- **One validator.** `load()` and `importSettings` now share `coerceSettings` instead of two copies of the rules.
- **Custom themes travel**, using `exportTheme`'s existing serialisation (plus `id`, so `activeThemeId` stays resolvable) rather than a second format.
- **Keymap included** — `useKeymapStore` persists only `activePresetId`, so it crosses as one string.

Closes #254.

## Why?

**The exported key set is derived, not hand-written.** This was the sharp lesson from the PR merged immediately before this one: #283 added `updateCheckMode` to `PersistedState` while this work was queued, and a hand-written allow-list would have silently omitted a real preference. Deriving from the schema means a new setting is exported by default — and a **snapshot test pins the key set**, so the next added preference forces a deliberate choice (export it, or deny-list it) instead of a silent wrong answer either way.

**The safety asymmetry is intentional:** deny-list on export (new preferences travel by default), allow-list on import (only keys still in the schema are accepted, so an old or hostile file cannot poison the store). That is safe for secrets *specifically* because no secret lives in `PersistedState` at all — forge tokens and git credentials are `Secret`-typed, in separate storage, and no command returns them. There is a test asserting no token/credential-shaped key or value appears in an export, so this stays true rather than being assumed.

**Import merges rather than replaces.** A key absent from the payload keeps its current value. Replace-all would let an old export silently flip `updateCheckMode` from `never` back to `auto` — i.e. **start making network requests someone deliberately turned off**. `reset()` remains the clean-slate path.

**Excluded, with reasons:** `lastCreateDir` (names a directory on one machine — the only entry in the deny-list); the update store's `lastCheckedAt` / `dismissedVersion` (per-machine state, deliberately kept out of `PersistedState` by #283 for exactly this reason). The deny-list holds in **both** directions — import strips those keys too, since skipping them only on export would still let a hand-edited file retarget another machine's Clone dialog.

## Refactor note — the part to review hardest

`load()` was rewritten to call the shared `coerceSettings(parsed, base)`. It differs from the old code only in its `base`: `load()` passes `DEFAULTS`, which is the previous behaviour exactly; import passes the current state. Every existing repair is preserved and now generalized — scalars are type-guarded against `typeof DEFAULTS[key]`, so a new scalar preference is guarded the day it is added.

**The pre-existing `useSettingsStore.test.ts` is untouched and still passes**, which is the main evidence that the refactor preserved behaviour. Two clamps are genuinely new on the `load()` path (`diffContextLines` 0–20, `autoFetchMinutes` 1–60), matching the bounds the Settings inputs already enforce — a hand-edited out-of-range value is now repaired on load.

## Privacy gate

`test/privacy.test.ts` is touched, but **no hostname is added** — the `platypusgit.dev` entry already existed for the `$schema` identifier written into exported *theme* files, and the reason text now covers the settings export too. Both exports are local blob downloads: the JSON is built in the renderer and saved by the webview, with no request anywhere. Nothing dereferences a `$schema`.

## Notable / follow-ups

- **`Blob.prototype.text` is polyfilled inside `Settings.export.test.tsx`** (jsdom's Blob lacks it, and both file-import paths use `file.text()`). It may belong in shared `src/test/setup.ts` so the existing theme-import path becomes testable too — left local to avoid touching shared setup in this PR.
- **"your downloads folder"** is the honest limit of a blob download; naming an absolute path needs `plugin-fs` or a backend write command.
- **Settings-on-disk instead of `localStorage`** — the issue flagged this as worth considering but not required. Not done here; noted on the issue thread as the issue asked. This export makes settings *portable* but not *durable*: clearing site data still loses everything silently, and `coerceSettings` is now exactly the migration seam a file-backed store would need.

## Checklist

- [x] One logical change, focused PR
- [x] Branched off `main` @ `76f0fbd`; no merge commits, single squashed commit
- [x] PR title + commit message follow Conventional Commits
- [x] `pnpm tsc --noEmit` passes — exit 0
- [ ] `cargo test` — **not run locally: no Rust in this diff.** CI's rust job covers it
- [x] `pnpm test` passes — 235 files, 2067 tests (45 new), includes the `docs` and `privacy` projects
- [x] `e2e/` untouched — no e2e run, per the issue's explicit request
- [x] Added tests — 34 in `useSettingsStore.export.test.ts` (incl. the key-set snapshot and no-secrets assertions), 11 in `Settings.export.test.tsx`
- [x] Not a new git op
- [x] Not a new feature area — extends an existing settings surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)
