### PR TITLE
feat(files): delete an untracked file, and reveal directory rows

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -12,7 +12,15 @@ error.rs         AppError enum (thiserror + serde-tagged) — ONLY error type cr
 state.rs         AppState { backend: Arc<dyn GitBackend> }
 opener.rs        URLs/paths → OS default handler. SECURITY-critical: safe_url
                  (https-only, rejects quotes/control chars), safe_workdir_path
-                 (no absolute/`..` escape), never spawns via a shell, child exit checked
+                 (no absolute/`..` escape), never spawns via a shell, child exit checked.
+                 THE home for "is this path inside the workdir", in two
+                 strengths: safe_workdir_path is LEXICAL (enough to hand a path
+                 to an app) and resolved_workdir_path CANONICALIZES both sides
+                 and re-checks with the pure contained_in — which is what
+                 anything that UNLINKS must use, because the lexical check
+                 cannot see a symlink or a path reached through one (#245).
+                 contained_in compares components, not string prefixes:
+                 /repository is not inside /repo
 update.rs        Update discovery: semver compare, dev-build (0.0.0) short-circuit
                  before any network call, GitHub release parsing, ureq w/ timeout +
                  https_only. Logic only — handlers live in commands/update.rs
@@ -31,6 +39,12 @@ reveal.rs        "Reveal in Finder/Explorer" + "Open in terminal" (#215).
                  HostPlatform decouples argv building from the actual host, so
                  reveal_plan/terminal_plan are PURE and unit-tested for all
                  three platforms from any host. Spawns via proc.rs only.
+                 reveal_target/terminal_target answer WHAT to open for a
+                 repo-relative path, reading is-it-a-directory off the
+                 filesystem rather than from a parameter — the filesystem is the
+                 only authority, and that is what makes a directory row open a
+                 window on the folder instead of selecting it in its parent
+                 (#245).
                  explorer.exe's exit-1-on-success is carried as a FLAG on the
                  plan (not a program-name compare — the program is an absolute
                  pinned path); Windows launchers are pinned to System32 /
@@ -147,7 +161,12 @@ commands/        Thin Tauri handlers, one file per area:
 │                append_gitignore, open_in_editor, reveal_in_file_manager,
 │                open_in_terminal (#215 — both take an optional relative_path;
 │                omitted/empty targets the repo ROOT instead, for the repo
-│                tab's menu), and THREE distinct file readers:
+│                tab's menu, and both ask reveal.rs whether the path is a
+│                directory rather than assuming a file),
+│                delete_untracked_files (#245 — the ONLY destructive worktree op
+│                here; thin over GitBackend::delete_untracked, which validates
+│                the whole batch before unlinking anything and then reports
+│                per-path failures), and THREE distinct file readers:
 │                read_file_content (working tree),
 │                read_file_content_at_rev + list_files_at_rev (a commit's tree),
 │                read_file_content_at_index (the STAGED blob)

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -318,6 +318,45 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   other copy anywhere. Crash-safety needs a journal and its own spec; do not
   stub an affordance meanwhile.
 
+## Deleting an untracked file (#245)
+
+`GitBackend::delete_untracked` is on the trait despite being an unlink rather
+than a git call, because every check it depends on is a git question — does the
+index know this path (at ANY stage: a conflicted file lives at 1/2/3), is the
+entry an embedded repository — and the verify has to happen under the SAME lock
+acquisition as the mutation. Only an implementation holding the per-repo lock can
+do that; a command reading `status()` and then unlinking is the stash TOCTOU
+again. `commands/repo.rs::delete_untracked_files` is therefore thin.
+
+- **It is not `discard` with a nicer name.** Discard RESTORES a tracked path from
+  the index and only deletes an untracked one. Delete refuses a tracked path
+  outright, because a menu entry labelled "Delete file…" that reverted a file
+  instead is the worst surprise available on a destructive action.
+- **Containment is proven against the filesystem, not the string.**
+  `opener::resolved_workdir_path` canonicalizes BOTH sides (the workdir too — on
+  macOS a tempdir lives under `/var`, itself a symlink) and re-checks with the
+  pure component-wise `contained_in`. The lexical `safe_workdir_path` cannot see
+  a symlink: `repo/out -> /etc` makes `out/passwd` an innocent-looking relative
+  path with no `..` in it. Only the PARENT is canonicalized and the last
+  component re-joined, so a file that is already gone still resolves — its
+  absence is the caller's to report. A symlink whose target leaves the worktree
+  is refused, and so is one that cannot be resolved at all.
+- **Containment runs BEFORE the index is touched**, and not only for tidiness:
+  `git2::Index::get_path` PANICS on a path that is absolute or starts with `..`
+  (it unwraps its own `path_to_repo_path`). `discard` orders itself the same way.
+- **Two phases.** Everything decidable without touching the disk (tracked,
+  escape, embedded repo, directory) is validated for the WHOLE batch first and
+  fails all of it — a refusal must never leave a half-deleted selection, or a
+  crafted path becomes discoverable by noticing the three files before it are
+  gone. Then the unlinks run BEST-EFFORT, one `DeleteFailure` per path the OS
+  refused: three read-only files in a ten-file selection must not decide the fate
+  of the other seven.
+- **Files, not trees.** A real directory is refused; a recursive delete is a
+  different and far more dangerous op, and libgit2 recurses untracked directories
+  in `status()` anyway, so every untracked row the UI shows is a file. Symlinks
+  are unlinked as links (with a `remove_dir` fallback for the Windows
+  directory-symlink case), never followed.
+
 ## Spawning processes (issue 172)
 
 - **Never write `Command::new` outside `src-tauri/src/proc.rs`** —

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -577,13 +577,46 @@ update checks back on for someone who turned them off.
   `RepoTabs.tsx`'s `tabMenuItems`. Their target is a repository root, whose path
   relative to itself is `""`.
 - **"Open containing folder" is the reveal entry** — there is no second menu
-  item, on any platform. `reveal_in_file_manager` passes `is_dir: false` for a
-  relative path, and `reveal.rs` then runs `open -R` / `explorer /select,` (the
-  parent window, file selected) or xdg-opens the parent on Linux. The only
-  variant that would differ is a folder window with no selection, which needs
-  `reveal(parent, is_dir: true)` — a backend change, not a frontend one.
-  `context-menu.copyPath.test.tsx` pins the single entry so the synonym does not
-  get added.
+  item, on any platform, and this is settled rather than pending. On a FILE row
+  `open -R` / `explorer /select,` open the containing folder with the file
+  selected, and Linux xdg-opens the parent, so the existing entry already *is*
+  "open containing folder" everywhere. The only variant that differs is a folder
+  window with NO selection: identical to reveal on Linux, and the same window
+  minus the selection on macOS/Windows — strictly less information for a second
+  entry that looks like a different action. `context-menu.copyPath.test.tsx` and
+  `context-menu.deleteUntracked.test.tsx` each pin the single entry, on the file
+  row and the folder row, so the synonym does not get added.
+- **Directory rows reveal too, and it took a backend change** (#245).
+  `reveal_in_file_manager` used to pass a hard-coded `is_dir: false`, which for a
+  folder means "select it in its parent" — so `reveal.rs::reveal_target` now
+  reads is-it-a-directory off the FILESYSTEM instead. No parameter: a
+  caller-supplied flag is a second source of truth that can disagree (libgit2
+  spells an embedded repo with a trailing slash; a folder row has no status entry
+  at all), and every existing call site got directory rows right the moment it
+  landed. `terminal_target` is the same fix for "Open in terminal", which would
+  otherwise open a folder's PARENT.
+- **The folder row's menu is `multiFileMenuItems`** — both trees hand a folder
+  key straight to `splitFileSelection`, which expands it to the files BENEATH it.
+  So the menu never knew which folder it was on; `MultiFileMenuSelection.directoryPath`
+  is that missing piece, set only for a single folder row (`sidedFolderPath`
+  recovers it from the commit panel's `side:dir:path` key). Entries that address
+  ONE location — reveal, terminal — appear only when it is set: for a multi-row
+  selection the honest answer would be five windows.
+- **Delete an untracked file** (#245) is `deleteUntracked` in `useRepoStore`, over
+  `delete_untracked_files` — NOT `discard`. Discard restores a tracked path from
+  the index and only deletes an untracked one; an entry labelled "Delete file…"
+  that restored a file instead (because the path became tracked between the
+  right-click and the confirm) is the worst surprise available on a destructive
+  action, so the backend refuses a tracked path outright. Behind `pgConfirm`,
+  with the #67 wording ("there is no copy in the index or in history"). In the
+  multi-select menu, Delete acts on the untracked subset and **Discard steps
+  aside when the whole unstaged selection is untracked** — the same swap
+  `fileMenuItems` makes on a single row, because "discard changes" is then a lie
+  about what happens. Mixed selections keep both, and they differ there: Discard
+  restores the tracked ones, Delete touches only the untracked ones. The delete
+  is best-effort once it starts unlinking, so a RESOLVED call can still carry
+  `DeleteFailure[]`; the store refreshes the file list before it reports them,
+  and `refreshAll()` first / error last in the catch arm.
 
 ## Drag and drop
 

--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -1,10 +1,10 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use tauri::State;
 
 use crate::{
     error::{AppError, AppResult},
-    git::types::{FileContent, FileStatus, HeadInfo, RepoHandle, RepoId},
+    git::types::{DeleteFailure, FileContent, FileStatus, HeadInfo, RepoHandle, RepoId},
     state::AppState,
 };
 
@@ -193,6 +193,31 @@ pub async fn append_gitignore(
         .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
+/// Delete untracked files from the working tree (#245).
+///
+/// Thin, like every handler here: every rule — untracked-only, inside the
+/// worktree, no directories, no embedded repositories — is enforced by
+/// `GitBackend::delete_untracked` under the per-repo lock, because each of them
+/// is a question only the repository can answer and a check taken in a
+/// different lock acquisition than the unlink is a TOCTOU.
+///
+/// Returns one entry per path the OS refused to remove; an empty vector means
+/// the whole selection is gone. A refusal on validation grounds is an `Err` and
+/// deletes NOTHING — see the trait doc for why the two are split.
+#[tauri::command]
+pub async fn delete_untracked_files(
+    state: State<'_, AppState>,
+    repo_id: String,
+    paths: Vec<String>,
+) -> AppResult<Vec<DeleteFailure>> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    let paths: Vec<PathBuf> = paths.into_iter().map(PathBuf::from).collect();
+    tokio::task::spawn_blocking(move || backend.delete_untracked(&repo_id, &paths))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
 /// Open `relative_path` (relative to the repo's worktree) in the user's editor.
 /// Resolution order: $VISUAL, $EDITOR, then the platform default opener.
 #[tauri::command]
@@ -254,8 +279,17 @@ async fn repo_workdir(state: &State<'_, AppState>, repo_id: String) -> AppResult
 /// Reveal `relative_path` (relative to the repo's worktree) in the OS file
 /// manager, with the entry selected where the platform allows it. `None` (or
 /// an empty string — the repo tab's menu has no relative path to give)
-/// reveals the repo's ROOT directory instead, which is a directory target
-/// rather than a file one (see `reveal::reveal_plan`'s `is_dir`).
+/// reveals the repo's ROOT directory instead.
+///
+/// Which of `reveal_plan`'s two jobs this is — select a FILE in its parent, or
+/// open a window ON a directory — is decided by `reveal::reveal_target` from
+/// the filesystem, not by a parameter. That is what makes a directory row
+/// reveal the folder rather than selecting it in its parent (#245).
+///
+/// Note there is deliberately no separate "open containing folder" command:
+/// on all three platforms revealing a FILE already opens its containing folder
+/// (`open -R`, `explorer /select,`, and xdg-open on the parent). See
+/// `docs/dev/frontend.md`.
 #[tauri::command]
 pub async fn reveal_in_file_manager(
     state: State<'_, AppState>,
@@ -263,18 +297,14 @@ pub async fn reveal_in_file_manager(
     relative_path: Option<String>,
 ) -> AppResult<()> {
     let workdir = repo_workdir(&state, repo_id).await?;
-    match relative_path {
-        Some(rel) if !rel.is_empty() => {
-            let abs = crate::opener::safe_workdir_path(&workdir, &rel)?;
-            crate::reveal::reveal(&abs, false).await
-        }
-        _ => crate::reveal::reveal(&workdir, true).await,
-    }
+    let (target, is_dir) = crate::reveal::reveal_target(&workdir, relative_path.as_deref())?;
+    crate::reveal::reveal(&target, is_dir).await
 }
 
 /// Open a terminal at `relative_path`'s CONTAINING directory (a file reveals
-/// where it lives, not itself), or at the repo's root when `relative_path` is
-/// `None`/empty — the repo tab's case.
+/// where it lives, not itself) — or IN it when `relative_path` is itself a
+/// directory, or at the repo's root when it is `None`/empty (the repo tab's
+/// case). See `reveal::terminal_target`.
 #[tauri::command]
 pub async fn open_in_terminal(
     state: State<'_, AppState>,
@@ -282,12 +312,6 @@ pub async fn open_in_terminal(
     relative_path: Option<String>,
 ) -> AppResult<()> {
     let workdir = repo_workdir(&state, repo_id).await?;
-    let dir = match relative_path {
-        Some(rel) if !rel.is_empty() => {
-            let abs = crate::opener::safe_workdir_path(&workdir, &rel)?;
-            abs.parent().map(Path::to_path_buf).unwrap_or(workdir)
-        }
-        _ => workdir,
-    };
+    let dir = crate::reveal::terminal_target(&workdir, relative_path.as_deref())?;
     crate::reveal::open_terminal(&dir).await
 }

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -5,7 +5,7 @@ use crate::error::{AppError, AppResult};
 use super::{
     types::{
         AheadBehind, BisectMark, BisectStatus, BlameLine, BranchInfo, CommitInfo, CommitOptions, CommitResult, ConflictSides,
-        DiffKind, FileContent,
+        DeleteFailure, DiffKind, FileContent,
         FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage, RebaseStatus, RebaseStep, ReflogEntry,
         RemoteInfo, RepoHandle, RepoId, RepoState, ResetMode, StashInfo, StashSaveOptions,
         SubmoduleInfo, TagInfo,
@@ -179,6 +179,13 @@ impl GitBackend for CliBackend {
         Err(AppError::NotImplemented)
     }
     fn discard(&self, _repo_id: &RepoId, _paths: &[PathBuf]) -> AppResult<()> {
+        Err(AppError::NotImplemented)
+    }
+    fn delete_untracked(
+        &self,
+        _repo_id: &RepoId,
+        _paths: &[PathBuf],
+    ) -> AppResult<Vec<DeleteFailure>> {
         Err(AppError::NotImplemented)
     }
     fn stage_hunk(

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -11,12 +11,13 @@ use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
 use crate::git::ownership;
-use crate::opener::safe_workdir_path;
+use crate::opener::{resolved_workdir_path, safe_workdir_path};
 
 use super::{
     types::{
         AheadBehind, BisectMark, BisectStatus,
-        BlameLine, BranchInfo, CommitInfo, CommitOptions, CommitResult, ConflictSides, DiffHunk,
+        BlameLine, BranchInfo, CommitInfo, CommitOptions, CommitResult, ConflictSides,
+        DeleteFailure, DiffHunk,
         DiffKind,
         DiffLine, DiffLineKind, FileContent, FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage,
         RebaseAction, RebaseStatus, RebaseStep, RebaseSummary, ReflogEntry, ReflogOp, RemoteInfo,
@@ -3550,6 +3551,98 @@ impl GitBackend for Libgit2Backend {
                 repo.checkout_index(None, Some(&mut opts))?;
             }
             Ok(())
+        })
+    }
+
+    fn delete_untracked(
+        &self,
+        repo_id: &RepoId,
+        paths: &[PathBuf],
+    ) -> AppResult<Vec<DeleteFailure>> {
+        self.with_repo(repo_id, |repo| {
+            let workdir = repo
+                .workdir()
+                .ok_or_else(|| AppError::InvalidPath("bare repository has no workdir".into()))?
+                .to_path_buf();
+            let index = repo.index()?;
+
+            // ── Phase 1: validate everything, delete nothing ─────────────────
+            //
+            // All four refusals below are decidable without touching the disk,
+            // so a batch containing one leaves the worktree exactly as it was.
+            // That is the point: a crafted path, or a tracked file that slipped
+            // into the selection, must not be discoverable by noticing that the
+            // three files before it are already gone.
+            let mut targets: Vec<(String, PathBuf)> = Vec::with_capacity(paths.len());
+            for p in paths {
+                let rel = p.to_string_lossy().to_string();
+                // The security boundary, and it comes FIRST for two reasons.
+                //
+                // It is the check that must not be reachable around, and — less
+                // obviously — `git2::Index::get_path` PANICS on a path that is
+                // absolute or starts with `..` (it unwraps its own
+                // `path_to_repo_path`). So the tracked check below is only safe
+                // to run on a path already proven relative and contained;
+                // `discard` orders itself the same way for the same reason.
+                //
+                // `resolved_workdir_path` canonicalizes, so unlike the lexical
+                // `safe_workdir_path` this also refuses a symlink out of the
+                // tree and a path reached THROUGH one.
+                let abs = resolved_workdir_path(&workdir, &rel)?;
+                // An embedded repository is untracked, and removing one destroys
+                // commits git cannot recover. Same refusal `stage`/`discard`
+                // make, and it precedes both checks below so the message names
+                // the real reason rather than "is a directory".
+                reject_embedded_repo(repo, p)?;
+                // Any index stage counts as tracked, not just stage 0: a
+                // conflicted path lives at 1/2/3, and reading it as untracked
+                // would delete a merge in progress. An entry BENEATH the path
+                // counts too, so `src` is not "untracked" merely because `src`
+                // itself is not an index entry.
+                if index_tracks_path(&index, p) || index_has_entry_under(&index, p) {
+                    return Err(AppError::InvalidPath(format!(
+                        "{rel} is tracked by git — delete only removes untracked files, \
+                         and discarding it would restore it from the index instead"
+                    )));
+                }
+                // A real directory is refused: this is the file list's action for
+                // untracked FILES, and a recursive directory delete is a
+                // different and far more dangerous operation. libgit2 recurses
+                // untracked directories in `status()` anyway, so every untracked
+                // row the UI shows is a file. Symlinks are NOT caught here —
+                // `symlink_metadata` does not follow — and are unlinked as links
+                // below, which is what removing a link means.
+                if std::fs::symlink_metadata(&abs).is_ok_and(|m| m.is_dir()) {
+                    return Err(AppError::InvalidPath(format!(
+                        "{rel} is a directory — delete removes files, not directory trees"
+                    )));
+                }
+                targets.push((rel, abs));
+            }
+
+            // ── Phase 2: delete, best-effort ─────────────────────────────────
+            let mut failed = Vec::new();
+            for (rel, abs) in targets {
+                let is_link = std::fs::symlink_metadata(&abs).is_ok_and(|m| m.is_symlink());
+                let mut result = std::fs::remove_file(&abs);
+                // A Windows symlink to a DIRECTORY (or a junction) is a
+                // directory entry as far as the OS is concerned, so `unlink`
+                // refuses it and `remove_dir` is the call that removes the link
+                // without touching its target. Only ever attempted for something
+                // we already know is a link — phase 1 refused real directories.
+                if result.is_err() && is_link {
+                    result = std::fs::remove_dir(&abs);
+                }
+                if let Err(e) = result {
+                    failed.push(DeleteFailure {
+                        // The path the CALLER spelled, not the canonicalized
+                        // absolute one: the file list has no row for the latter.
+                        path: rel,
+                        reason: e.to_string(),
+                    });
+                }
+            }
+            Ok(failed)
         })
     }
 

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -21,7 +21,7 @@ use crate::error::AppResult;
 use types::{
     AheadBehind,
     BisectMark, BisectStatus, BlameLine, BranchInfo, CommitInfo, CommitOptions, CommitResult, ConflictSides,
-    DiffKind, FileContent,
+    DeleteFailure, DiffKind, FileContent,
     FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage, RebaseStatus, RebaseStep, ReflogEntry,
     RemoteInfo,
     RepoHandle,
@@ -327,6 +327,42 @@ pub trait GitBackend: Send + Sync {
     fn stage(&self, repo_id: &RepoId, paths: &[PathBuf]) -> AppResult<()>;
     fn unstage(&self, repo_id: &RepoId, paths: &[PathBuf]) -> AppResult<()>;
     fn discard(&self, repo_id: &RepoId, paths: &[PathBuf]) -> AppResult<()>;
+
+    // === worktree writes that are not index writes ===
+    /// Delete UNTRACKED files from the working tree (#245).
+    ///
+    /// Not the same op as [`GitBackend::discard`], which restores a tracked path
+    /// from the index and deletes an untracked one — this only ever deletes, and
+    /// REFUSES a tracked path outright rather than quietly restoring it. "Delete"
+    /// has to mean delete, and a menu entry that sometimes reverted a file
+    /// instead would be the worst possible surprise on a destructive action.
+    ///
+    /// On the trait, despite being an unlink rather than a git call, because
+    /// every check it depends on is a git question: whether the index knows the
+    /// path (at ANY stage — a conflicted file lives at 1/2/3), and whether the
+    /// entry is an embedded repository. CLAUDE.md's rule is that a verify and
+    /// the mutation it guards happen under ONE lock acquisition, and only an
+    /// implementation holding the per-repo lock can do that; a command reading
+    /// `status()` and then unlinking is the TOCTOU the stash ops were fixed to
+    /// avoid.
+    ///
+    /// Two phases, deliberately:
+    ///
+    /// 1. **Validate every path, delete nothing.** A tracked path, a path that
+    ///    escapes the worktree, an embedded repository or a directory fails the
+    ///    WHOLE batch — a refusal must never leave a half-deleted selection, and
+    ///    all four are decidable without touching the disk.
+    /// 2. **Delete, best-effort**, collecting one [`DeleteFailure`] per path the
+    ///    OS refused. Three read-only files in a ten-file selection must not
+    ///    decide the fate of the other seven.
+    ///
+    /// `Ok(vec![])` therefore means every path is gone; `Ok(failures)` means the
+    /// rest are.
+    fn delete_untracked(
+        &self,
+        repo_id: &RepoId,
+        paths: &[PathBuf],
+    ) -> AppResult<Vec<DeleteFailure>>;
 
     // === hunk-level staging ===
     // Hunk indices are positions in the diff produced with `context_lines`.

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -130,6 +130,25 @@ pub struct AheadBehind {
     pub merge_base: Option<String>,
 }
 
+/// One path a delete could not remove (#245).
+///
+/// `delete_untracked` is BEST-EFFORT once it starts unlinking: three read-only
+/// files in a ten-file selection must not decide the fate of the other seven,
+/// and stopping at the first failure would delete an arbitrary prefix and then
+/// name only one of the causes. So every refusal that can be decided WITHOUT
+/// touching the disk (a tracked path, an escape, an embedded repo) is raised as
+/// an `AppError` before anything is deleted, and only genuine I/O failures land
+/// here, one per path, with the OS's own reason.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteFailure {
+    /// The repo-relative path, exactly as the caller spelled it — never the
+    /// canonicalized absolute one, which is not what the file list shows.
+    pub path: String,
+    /// The OS's message. Never a path, so it stays readable next to `path`.
+    pub reason: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommitInfo {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -216,6 +216,7 @@ pub fn run() {
             commands::repo::read_file_content_at_rev,
             commands::repo::read_file_content_at_index,
             commands::repo::append_gitignore,
+            commands::repo::delete_untracked_files,
             commands::repo::open_in_editor,
             commands::repo::reveal_in_file_manager,
             commands::repo::open_in_terminal,

--- a/src-tauri/src/opener.rs
+++ b/src-tauri/src/opener.rs
@@ -80,6 +80,101 @@ pub fn safe_workdir_path(workdir: &Path, relative: &str) -> AppResult<PathBuf> {
     Ok(workdir.join(rel))
 }
 
+/// Is `candidate` strictly inside `root`?
+///
+/// PURE — no filesystem access; both sides are compared as already-resolved
+/// paths. Component-wise, because a string `starts_with` reads `/repository` as
+/// a child of `/repo` and `/repo-backup` as a child of `/repo` too. "Strictly"
+/// means the root itself is NOT contained: a caller asking about "the workdir,
+/// relative to the workdir" is asking about the repository, not about something
+/// inside it, and a destructive caller must never resolve to it.
+///
+/// Case is compared exactly. Both sides reach here from `fs::canonicalize`,
+/// which returns the on-disk spelling, so a case-insensitive filesystem hands
+/// us matching prefixes anyway — folding here would instead make `/Repo` and
+/// `/repo` interchangeable on a case-SENSITIVE filesystem, where they are two
+/// different directories.
+pub fn contained_in(root: &Path, candidate: &Path) -> bool {
+    match candidate.strip_prefix(root) {
+        Ok(rest) => rest.components().next().is_some(),
+        Err(_) => false,
+    }
+}
+
+/// Resolve a repo-relative path against `workdir` and PROVE, against the real
+/// filesystem, that it lands inside it (#245).
+///
+/// [`safe_workdir_path`] is a LEXICAL check: it refuses `..`, absolute paths and
+/// Windows prefixes, which is enough for "hand this string to an application".
+/// It is not enough for a caller that will unlink the result, because it cannot
+/// see symlinks — `repo/out -> /etc` makes `out/passwd` an innocent-looking
+/// relative path with no `..` anywhere in it.
+///
+/// So this canonicalizes both sides and re-checks containment with
+/// [`contained_in`]:
+///
+/// - The **workdir** is canonicalized too, not just the candidate. On macOS a
+///   tempdir lives under `/var`, which is itself a symlink to `/private/var`,
+///   so comparing a raw workdir against a canonicalized candidate would refuse
+///   everything.
+/// - The candidate's **parent** is canonicalized and the final component
+///   re-joined, rather than canonicalizing the whole path: that resolves every
+///   intermediate symlink while leaving the entry itself unfollowed, so a
+///   missing file still resolves — its absence is the caller's business to
+///   report, and a delete that reported "escapes the worktree" for a file
+///   somebody else already removed would be a lie.
+/// - A **symlink** as the final component is refused unless its own target
+///   canonicalizes inside the workdir. Unlinking a symlink does not touch what
+///   it points at, so this is stricter than it has to be, and deliberately: a
+///   link is not the file the user is looking at in the list, and "refuse and
+///   say so" beats reasoning about link semantics per platform on a
+///   destructive path. A link we cannot resolve at all (a broken one) is
+///   refused for the same reason.
+pub fn resolved_workdir_path(workdir: &Path, relative: &str) -> AppResult<PathBuf> {
+    let joined = safe_workdir_path(workdir, relative)?;
+    let root = workdir.canonicalize().map_err(|e| {
+        AppError::InvalidPath(format!(
+            "cannot resolve the repository worktree {}: {e}",
+            workdir.display()
+        ))
+    })?;
+    let (parent, name) = match (joined.parent(), joined.file_name()) {
+        (Some(parent), Some(name)) => (parent, name),
+        // `safe_workdir_path` already refused the empty string and every root /
+        // prefix component, and a trailing `..` with it — so this is
+        // unreachable in practice. Still an error rather than a panic.
+        _ => {
+            return Err(AppError::InvalidPath(format!(
+                "path names no entry: {relative}"
+            )))
+        }
+    };
+    let parent = parent.canonicalize().map_err(|e| {
+        AppError::InvalidPath(format!(
+            "cannot resolve the directory holding {relative}: {e}"
+        ))
+    })?;
+    let resolved = parent.join(name);
+    if !contained_in(&root, &resolved) {
+        return Err(AppError::InvalidPath(format!(
+            "path escapes the repository worktree: {relative}"
+        )));
+    }
+    if std::fs::symlink_metadata(&resolved).is_ok_and(|m| m.is_symlink()) {
+        let target = resolved.canonicalize().map_err(|e| {
+            AppError::InvalidPath(format!(
+                "refusing to act on a symbolic link whose target cannot be resolved ({e}): {relative}"
+            ))
+        })?;
+        if !contained_in(&root, &target) {
+            return Err(AppError::InvalidPath(format!(
+                "refusing to act on a symbolic link that leaves the repository worktree: {relative}"
+            )));
+        }
+    }
+    Ok(resolved)
+}
+
 /// The launcher executable to spawn.
 ///
 /// SECURITY (Windows): `CreateProcess` searches the **current directory before

--- a/src-tauri/src/reveal.rs
+++ b/src-tauri/src/reveal.rs
@@ -260,6 +260,49 @@ pub fn terminal_plan(platform: HostPlatform, dir: &Path, env: &HostEnv) -> Vec<S
     }
 }
 
+/// What a reveal of `relative` inside `workdir` should actually target:
+/// `(path, is_dir)` for [`reveal_plan`].
+///
+/// `None` or `""` means the repository itself — the repo tab's menu, which has
+/// no entry to select.
+///
+/// **`is_dir` is read from the filesystem, not passed in.** A directory row and
+/// a file row want the two different jobs `reveal_plan` describes, and the
+/// filesystem is the only authority on which one a path is: a caller-supplied
+/// flag is a second source of truth that can disagree (libgit2 spells an
+/// embedded repository with a trailing slash, a folder row in the tree carries
+/// no status entry at all), and being wrong means selecting a directory in its
+/// parent instead of opening it. Reading it here also means every existing call
+/// site got directory rows right the moment this landed, with no signature
+/// change (#245).
+pub fn reveal_target(workdir: &Path, relative: Option<&str>) -> AppResult<(PathBuf, bool)> {
+    match relative {
+        Some(rel) if !rel.is_empty() => {
+            let abs = crate::opener::safe_workdir_path(workdir, rel)?;
+            let is_dir = abs.is_dir();
+            Ok((abs, is_dir))
+        }
+        _ => Ok((workdir.to_path_buf(), true)),
+    }
+}
+
+/// Which directory a terminal for `relative` should open in.
+///
+/// A FILE reveals where it lives, so its containing directory is the answer; a
+/// DIRECTORY is already the answer and must not be replaced by its parent —
+/// same filesystem-is-the-authority reasoning as [`reveal_target`], and the same
+/// bug if it is skipped (a terminal for `src/` landing in the repo root).
+pub fn terminal_target(workdir: &Path, relative: Option<&str>) -> AppResult<PathBuf> {
+    let (abs, is_dir) = reveal_target(workdir, relative)?;
+    if is_dir {
+        return Ok(abs);
+    }
+    Ok(abs
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| workdir.to_path_buf()))
+}
+
 /// Reveal `path` in the platform's file manager (`is_dir`: see
 /// [`reveal_plan`]).
 pub async fn reveal(path: &Path, is_dir: bool) -> AppResult<()> {
@@ -540,5 +583,90 @@ mod tests {
     fn terminal_linux_ignores_an_empty_env_terminal() {
         let plans = terminal_plan(HostPlatform::Linux, Path::new("/tmp/repo"), &linux_env(Some("")));
         assert_eq!(plans[0].program, "x-terminal-emulator");
+    }
+
+    // ── reveal_target / terminal_target (#245) ───────────────────────────────
+    //
+    // These DO touch the filesystem (that is the whole point — the filesystem
+    // decides whether a path is a directory), so they run against a tempdir
+    // rather than being pure like the planners above.
+
+    fn tree() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/a.txt"), "a").unwrap();
+        std::fs::write(dir.path().join("top.txt"), "t").unwrap();
+        dir
+    }
+
+    #[test]
+    fn reveal_target_treats_a_file_as_a_file() {
+        let dir = tree();
+        let (path, is_dir) = reveal_target(dir.path(), Some("src/a.txt")).unwrap();
+        assert_eq!(path, dir.path().join("src/a.txt"));
+        assert!(!is_dir, "a file must be SELECTED in its parent, not opened");
+    }
+
+    #[test]
+    fn reveal_target_treats_a_directory_as_a_directory() {
+        // The bug this fixes: the command hard-coded `is_dir: false`, so a
+        // folder row ran `open -R src` and selected the folder in the repo root
+        // instead of opening a window on it.
+        let dir = tree();
+        let (path, is_dir) = reveal_target(dir.path(), Some("src")).unwrap();
+        assert_eq!(path, dir.path().join("src"));
+        assert!(is_dir);
+    }
+
+    #[test]
+    fn reveal_target_falls_back_to_the_repo_root() {
+        let dir = tree();
+        for rel in [None, Some("")] {
+            let (path, is_dir) = reveal_target(dir.path(), rel).unwrap();
+            assert_eq!(path, dir.path());
+            assert!(is_dir, "the repo root is a directory target");
+        }
+    }
+
+    #[test]
+    fn reveal_target_treats_a_path_that_does_not_exist_as_a_file() {
+        // `is_dir()` answers false for a missing path, which is the right guess:
+        // a file target degrades to "open the parent" on Linux and to a failed
+        // selection elsewhere, where a directory target would open a window on
+        // nothing.
+        let dir = tree();
+        let (_, is_dir) = reveal_target(dir.path(), Some("gone.txt")).unwrap();
+        assert!(!is_dir);
+    }
+
+    #[test]
+    fn reveal_target_refuses_a_path_outside_the_worktree() {
+        let dir = tree();
+        assert!(reveal_target(dir.path(), Some("../../etc/passwd")).is_err());
+        assert!(reveal_target(dir.path(), Some("/etc/passwd")).is_err());
+    }
+
+    #[test]
+    fn terminal_target_opens_a_files_parent_but_a_directory_itself() {
+        let dir = tree();
+        assert_eq!(
+            terminal_target(dir.path(), Some("src/a.txt")).unwrap(),
+            dir.path().join("src")
+        );
+        // Not the parent: a terminal asked for `src/` must land in `src/`.
+        assert_eq!(
+            terminal_target(dir.path(), Some("src")).unwrap(),
+            dir.path().join("src")
+        );
+        assert_eq!(terminal_target(dir.path(), None).unwrap(), dir.path());
+    }
+
+    #[test]
+    fn terminal_target_for_a_top_level_file_is_the_repo_root() {
+        let dir = tree();
+        assert_eq!(
+            terminal_target(dir.path(), Some("top.txt")).unwrap(),
+            dir.path()
+        );
     }
 }

--- a/src-tauri/tests/delete_untracked.rs
+++ b/src-tauri/tests/delete_untracked.rs
@@ -1,0 +1,357 @@
+//! Deleting untracked files from the working tree (#245).
+//!
+//! `discard` and `delete_untracked` both remove an untracked file, and that is
+//! where the resemblance stops: discard RESTORES a tracked path from the index,
+//! and delete must refuse one. These pin that split, the containment boundary
+//! (`opener::resolved_workdir_path` — its own path arithmetic is unit-tested in
+//! `tests/opener.rs`), and the two-phase batch: validation refusals delete
+//! nothing at all, I/O failures are reported per path while their neighbours
+//! still go.
+
+mod support;
+
+use std::path::PathBuf;
+
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::GitBackend;
+use support::{fs::write_file, with_conflicting_merge, TempRepo};
+
+fn rel(paths: &[&str]) -> Vec<PathBuf> {
+    paths.iter().map(PathBuf::from).collect()
+}
+
+// ─── The happy path ─────────────────────────────────────────────────────────
+
+#[test]
+fn deletes_an_untracked_file() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "loose.txt", "scratch\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let failed = backend
+        .delete_untracked(&handle.id, &rel(&["loose.txt"]))
+        .expect("delete an untracked file");
+
+    assert!(failed.is_empty(), "unexpected failures: {failed:?}");
+    assert!(!tr.path().join("loose.txt").exists(), "file survived");
+}
+
+#[test]
+fn deletes_a_whole_batch_of_untracked_files() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "a.tmp", "a");
+    write_file(tr.path(), "nested/b.tmp", "b");
+    write_file(tr.path(), "nested/deep/c.tmp", "c");
+    let (backend, handle) = tr.open_with_backend();
+
+    let failed = backend
+        .delete_untracked(&handle.id, &rel(&["a.tmp", "nested/b.tmp", "nested/deep/c.tmp"]))
+        .expect("delete a batch");
+
+    assert!(failed.is_empty(), "unexpected failures: {failed:?}");
+    assert!(!tr.path().join("a.tmp").exists());
+    assert!(!tr.path().join("nested/b.tmp").exists());
+    assert!(!tr.path().join("nested/deep/c.tmp").exists());
+    // Directories are git's business, not ours: it does not track them, so an
+    // emptied one is left where it is rather than silently pruned.
+    assert!(tr.path().join("nested/deep").is_dir());
+}
+
+#[test]
+fn an_empty_batch_does_nothing() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    assert!(backend
+        .delete_untracked(&handle.id, &[])
+        .expect("empty batch")
+        .is_empty());
+}
+
+// ─── Untracked ONLY ─────────────────────────────────────────────────────────
+
+#[test]
+fn refuses_a_tracked_file() {
+    // The point of the whole command: "Delete" must never quietly become
+    // "restore from the index", which is what discard does for a tracked path.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .delete_untracked(&handle.id, &rel(&["README.md"]))
+        .expect_err("a tracked file must be refused");
+
+    assert!(matches!(err, AppError::InvalidPath(_)), "wrong error: {err:?}");
+    assert!(format!("{err}").contains("tracked"), "unhelpful message: {err}");
+    assert!(tr.path().join("README.md").exists(), "tracked file deleted");
+}
+
+#[test]
+fn refuses_a_tracked_file_with_local_modifications() {
+    // The row a user is most likely to right-click: modified, unstaged, and
+    // still recoverable from the index.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "README.md", "edited\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    assert!(backend
+        .delete_untracked(&handle.id, &rel(&["README.md"]))
+        .is_err());
+    assert!(tr.path().join("README.md").exists());
+}
+
+#[test]
+fn refuses_a_staged_new_file() {
+    // Staged-but-never-committed: no copy in HISTORY, but the index has one, so
+    // it is tracked and delete is the wrong verb for it.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "fresh.txt", "new\n");
+    let (backend, handle) = tr.open_with_backend();
+    backend.stage(&handle.id, &rel(&["fresh.txt"])).unwrap();
+
+    assert!(backend
+        .delete_untracked(&handle.id, &rel(&["fresh.txt"]))
+        .is_err());
+    assert!(tr.path().join("fresh.txt").exists());
+}
+
+#[test]
+fn refuses_a_conflicted_file() {
+    // A conflicted path has index entries at stages 1/2/3 and NONE at stage 0,
+    // so a stage-0-only tracked check reads it as untracked — and deleting it
+    // would destroy a merge in progress.
+    let tr = with_conflicting_merge();
+    let (backend, handle) = tr.open_with_backend();
+
+    assert!(backend
+        .delete_untracked(&handle.id, &rel(&["README.md"]))
+        .is_err());
+    assert!(tr.path().join("README.md").exists());
+}
+
+#[test]
+fn refuses_a_directory_that_holds_tracked_files() {
+    // `src` is never its own index entry, so "absent from the index" must not be
+    // read as "untracked" for a directory — that reading would delete every
+    // tracked file beneath it.
+    let tr = TempRepo::fresh();
+    write_file(tr.path(), "src/main.rs", "fn main() {}\n");
+    tr.commit_all("add src");
+    let (backend, handle) = tr.open_with_backend();
+
+    assert!(backend.delete_untracked(&handle.id, &rel(&["src"])).is_err());
+    assert!(tr.path().join("src/main.rs").exists());
+}
+
+#[test]
+fn refuses_a_directory_of_untracked_files() {
+    // Nothing in the index at all, so the tracked check passes — the directory
+    // refusal is what stops this. Delete removes files; a recursive tree delete
+    // is a different and far more dangerous operation, and libgit2 reports
+    // untracked directories as their individual files anyway.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "scratch/a.txt", "a");
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .delete_untracked(&handle.id, &rel(&["scratch"]))
+        .expect_err("a directory must be refused");
+
+    assert!(format!("{err}").contains("directory"), "unhelpful: {err}");
+    assert!(tr.path().join("scratch/a.txt").exists());
+}
+
+#[test]
+fn refuses_an_embedded_repository() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let nested = tr.path().join("vendor/lib");
+    std::fs::create_dir_all(&nested).unwrap();
+    git2::Repository::init(&nested).unwrap();
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .delete_untracked(&handle.id, &rel(&["vendor/lib"]))
+        .expect_err("an embedded repo must be refused");
+
+    assert!(
+        matches!(err, AppError::EmbeddedRepo(_)),
+        "wrong error: {err:?}"
+    );
+    assert!(nested.join(".git").exists(), "embedded repo destroyed");
+}
+
+// ─── Containment ────────────────────────────────────────────────────────────
+
+#[test]
+fn refuses_a_parent_dir_escape() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    // A sibling of the repo, so `..` genuinely reaches it.
+    let outside = tr.path().parent().unwrap().join("pg-outside-target.txt");
+    std::fs::write(&outside, "secret").unwrap();
+    let (backend, handle) = tr.open_with_backend();
+
+    let escape = format!("../{}", outside.file_name().unwrap().to_string_lossy());
+    let err = backend
+        .delete_untracked(&handle.id, &rel(&[&escape]))
+        .expect_err("../ must be refused");
+
+    assert!(matches!(err, AppError::InvalidPath(_)), "wrong error: {err:?}");
+    assert!(outside.exists(), "deleted a file outside the repository");
+    let _ = std::fs::remove_file(&outside);
+}
+
+#[test]
+fn refuses_an_absolute_path_outside_the_workdir() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let outside = tempfile::tempdir().unwrap();
+    let target = outside.path().join("secret.txt");
+    std::fs::write(&target, "secret").unwrap();
+    let (backend, handle) = tr.open_with_backend();
+
+    let abs = target.to_string_lossy().to_string();
+    assert!(backend.delete_untracked(&handle.id, &rel(&[&abs])).is_err());
+    assert!(target.exists(), "deleted a file outside the repository");
+}
+
+#[cfg(unix)]
+#[test]
+fn refuses_a_symlink_that_points_out_of_the_tree() {
+    // No `..`, not absolute: the lexical check cannot see this one, which is why
+    // the resolution canonicalizes.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let outside = tempfile::tempdir().unwrap();
+    let target = outside.path().join("secret.txt");
+    std::fs::write(&target, "secret").unwrap();
+    std::os::unix::fs::symlink(&target, tr.path().join("escape")).unwrap();
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .delete_untracked(&handle.id, &rel(&["escape"]))
+        .expect_err("an escaping symlink must be refused");
+
+    assert!(matches!(err, AppError::InvalidPath(_)), "wrong error: {err:?}");
+    assert!(target.exists(), "the symlink's target was deleted");
+    assert!(
+        tr.path().join("escape").symlink_metadata().is_ok(),
+        "the link itself was deleted"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn refuses_a_path_reached_through_a_symlinked_directory() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let outside = tempfile::tempdir().unwrap();
+    let target = outside.path().join("secret.txt");
+    std::fs::write(&target, "secret").unwrap();
+    std::os::unix::fs::symlink(outside.path(), tr.path().join("out")).unwrap();
+    let (backend, handle) = tr.open_with_backend();
+
+    assert!(backend
+        .delete_untracked(&handle.id, &rel(&["out/secret.txt"]))
+        .is_err());
+    assert!(target.exists(), "deleted through a symlinked directory");
+}
+
+#[cfg(unix)]
+#[test]
+fn deletes_a_symlink_that_stays_inside_the_tree() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "real.txt", "r");
+    std::os::unix::fs::symlink(tr.path().join("real.txt"), tr.path().join("alias")).unwrap();
+    let (backend, handle) = tr.open_with_backend();
+
+    let failed = backend
+        .delete_untracked(&handle.id, &rel(&["alias"]))
+        .expect("a contained link is deletable");
+
+    assert!(failed.is_empty(), "unexpected failures: {failed:?}");
+    assert!(tr.path().join("alias").symlink_metadata().is_err(), "link survived");
+    // Unlinking a link never touches what it points at.
+    assert!(tr.path().join("real.txt").exists(), "target deleted with the link");
+}
+
+// ─── The two phases ─────────────────────────────────────────────────────────
+
+#[test]
+fn a_validation_refusal_deletes_nothing_from_the_batch() {
+    // The reason validation is a separate pass. A crafted or mistaken path must
+    // not be discoverable by noticing that the files listed before it are gone.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "first.tmp", "1");
+    write_file(tr.path(), "second.tmp", "2");
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .delete_untracked(
+            &handle.id,
+            &rel(&["first.tmp", "README.md", "second.tmp"]),
+        )
+        .expect_err("a tracked path in the batch must refuse the batch");
+
+    assert!(matches!(err, AppError::InvalidPath(_)), "wrong error: {err:?}");
+    assert!(tr.path().join("first.tmp").exists(), "deleted a prefix of the batch");
+    assert!(tr.path().join("second.tmp").exists());
+    assert!(tr.path().join("README.md").exists());
+}
+
+#[test]
+fn reports_a_missing_file_and_still_deletes_its_neighbours() {
+    // Best-effort once unlinking starts: a stale selection (something a build
+    // script already removed) must not cost the user the files that ARE there.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "here.tmp", "h");
+    let (backend, handle) = tr.open_with_backend();
+
+    let failed = backend
+        .delete_untracked(&handle.id, &rel(&["here.tmp", "gone.tmp"]))
+        .expect("best-effort deletes what it can");
+
+    assert_eq!(failed.len(), 1, "expected one failure: {failed:?}");
+    // The path the CALLER spelled — the file list has no row for a canonicalized
+    // absolute path.
+    assert_eq!(failed[0].path, "gone.tmp");
+    assert!(!failed[0].reason.is_empty(), "no reason given");
+    assert!(!tr.path().join("here.tmp").exists(), "neighbour not deleted");
+}
+
+#[test]
+fn a_missing_file_on_its_own_is_reported_not_silently_ok() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let failed = backend
+        .delete_untracked(&handle.id, &rel(&["never-existed.tmp"]))
+        .expect("resolution succeeds; the unlink is what fails");
+
+    assert_eq!(failed.len(), 1, "a missing file must be reported: {failed:?}");
+    assert_eq!(failed[0].path, "never-existed.tmp");
+}
+
+#[cfg(unix)]
+#[test]
+fn reports_a_file_the_os_refuses_and_still_deletes_the_rest() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // A read-ONLY file is still deletable on unix (the directory's write bit is
+    // what governs), so the way to make one genuinely unremovable is to take the
+    // write bit off its DIRECTORY.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "locked/inside.tmp", "x");
+    write_file(tr.path(), "free.tmp", "y");
+    let locked = tr.path().join("locked");
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o500)).unwrap();
+    let (backend, handle) = tr.open_with_backend();
+
+    let failed = backend
+        .delete_untracked(&handle.id, &rel(&["locked/inside.tmp", "free.tmp"]));
+
+    // Restore the bit before asserting, or the TempDir cannot clean itself up.
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o700)).unwrap();
+    let failed = failed.expect("best-effort deletes what it can");
+
+    assert_eq!(failed.len(), 1, "expected one failure: {failed:?}");
+    assert_eq!(failed[0].path, "locked/inside.tmp");
+    assert!(!tr.path().join("free.tmp").exists(), "neighbour not deleted");
+    assert!(locked.join("inside.tmp").exists(), "the locked file went anyway");
+}

--- a/src-tauri/tests/opener.rs
+++ b/src-tauri/tests/opener.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 
-use platypusgit_lib::opener::{safe_url, safe_workdir_path};
+use platypusgit_lib::opener::{
+    contained_in, resolved_workdir_path, safe_url, safe_workdir_path,
+};
 
 #[test]
 fn safe_url_accepts_a_normal_github_release_url() {
@@ -74,4 +76,127 @@ fn safe_workdir_path_refuses_to_escape_the_worktree() {
     assert!(safe_workdir_path(wd, "../../etc/passwd").is_err());
     assert!(safe_workdir_path(wd, "src/../../etc/passwd").is_err());
     assert!(safe_workdir_path(wd, "").is_err());
+}
+
+// ─── Containment against the real filesystem (#245) ──────────────────────────
+//
+// `safe_workdir_path` above is lexical and cannot see symlinks. Anything that
+// UNLINKS the result goes through `resolved_workdir_path`, which canonicalizes
+// both sides. These are the inputs it has to refuse.
+
+#[test]
+fn contained_in_is_component_wise_not_a_string_prefix() {
+    let root = Path::new("/repo");
+    assert!(contained_in(root, Path::new("/repo/a.txt")));
+    assert!(contained_in(root, Path::new("/repo/src/a.txt")));
+    // The three ways a string `starts_with` gets this wrong.
+    assert!(!contained_in(root, Path::new("/repository/a.txt")));
+    assert!(!contained_in(root, Path::new("/repo-backup/a.txt")));
+    assert!(!contained_in(root, Path::new("/repoX")));
+    // Strictly inside: the root itself is the repository, not a thing in it.
+    assert!(!contained_in(root, Path::new("/repo")));
+    assert!(!contained_in(root, Path::new("/")));
+    assert!(!contained_in(root, Path::new("/elsewhere/a.txt")));
+}
+
+/// A repo dir plus a sibling directory outside it, both canonicalized-able.
+fn two_trees() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = dir.path().join("repo");
+    let outside = dir.path().join("outside");
+    std::fs::create_dir_all(&repo).unwrap();
+    std::fs::create_dir_all(&outside).unwrap();
+    std::fs::write(outside.join("secret.txt"), "s").unwrap();
+    (dir, repo, outside)
+}
+
+#[test]
+fn resolved_workdir_path_resolves_a_file_inside_the_worktree() {
+    let (_dir, repo, _outside) = two_trees();
+    std::fs::create_dir_all(repo.join("src")).unwrap();
+    std::fs::write(repo.join("src/a.txt"), "a").unwrap();
+
+    let resolved = resolved_workdir_path(&repo, "src/a.txt").expect("inside the worktree");
+
+    // Canonicalized on BOTH sides: on macOS the tempdir sits under /var, which
+    // is a symlink to /private/var, so a raw-workdir comparison refuses
+    // everything.
+    assert_eq!(resolved, repo.canonicalize().unwrap().join("src").join("a.txt"));
+}
+
+#[test]
+fn resolved_workdir_path_resolves_a_file_that_does_not_exist() {
+    // Only the PARENT is canonicalized, so a path whose entry is already gone
+    // still resolves — reporting its absence belongs to the caller, and a
+    // delete that answered "escapes the worktree" for a file somebody else
+    // removed would be a lie.
+    let (_dir, repo, _outside) = two_trees();
+    let resolved = resolved_workdir_path(&repo, "vanished.txt").expect("missing but contained");
+    assert_eq!(resolved, repo.canonicalize().unwrap().join("vanished.txt"));
+}
+
+#[test]
+fn resolved_workdir_path_refuses_a_parent_dir_escape() {
+    let (_dir, repo, _outside) = two_trees();
+    assert!(resolved_workdir_path(&repo, "../outside/secret.txt").is_err());
+    assert!(resolved_workdir_path(&repo, "../../../etc/passwd").is_err());
+    assert!(resolved_workdir_path(&repo, "src/../../outside/secret.txt").is_err());
+}
+
+#[test]
+fn resolved_workdir_path_refuses_an_absolute_path_outside_the_worktree() {
+    let (_dir, repo, outside) = two_trees();
+    let abs = outside.join("secret.txt").to_string_lossy().to_string();
+    assert!(resolved_workdir_path(&repo, &abs).is_err());
+    assert!(resolved_workdir_path(&repo, "/etc/passwd").is_err());
+    assert!(resolved_workdir_path(&repo, "").is_err());
+}
+
+#[cfg(unix)]
+#[test]
+fn resolved_workdir_path_refuses_a_symlink_that_leaves_the_worktree() {
+    // The case the lexical check cannot see: no `..`, not absolute, and it
+    // still names a file outside the repository.
+    let (_dir, repo, outside) = two_trees();
+    std::os::unix::fs::symlink(outside.join("secret.txt"), repo.join("escape")).unwrap();
+
+    let err = resolved_workdir_path(&repo, "escape").expect_err("symlink out of the tree");
+
+    assert!(
+        format!("{err}").contains("symbolic link"),
+        "unexpected error: {err}"
+    );
+    assert!(repo.join("escape").symlink_metadata().is_ok(), "link removed");
+}
+
+#[cfg(unix)]
+#[test]
+fn resolved_workdir_path_refuses_a_path_through_a_symlinked_directory() {
+    // `out/secret.txt` has no `..` in it at all — the escape is one level up.
+    let (_dir, repo, outside) = two_trees();
+    std::os::unix::fs::symlink(&outside, repo.join("out")).unwrap();
+
+    assert!(resolved_workdir_path(&repo, "out/secret.txt").is_err());
+}
+
+#[cfg(unix)]
+#[test]
+fn resolved_workdir_path_refuses_a_broken_symlink() {
+    let (_dir, repo, _outside) = two_trees();
+    std::os::unix::fs::symlink(repo.join("nothing-here"), repo.join("dangling")).unwrap();
+
+    assert!(resolved_workdir_path(&repo, "dangling").is_err());
+}
+
+#[cfg(unix)]
+#[test]
+fn resolved_workdir_path_allows_a_symlink_that_stays_inside_the_worktree() {
+    let (_dir, repo, _outside) = two_trees();
+    std::fs::write(repo.join("real.txt"), "r").unwrap();
+    std::os::unix::fs::symlink(repo.join("real.txt"), repo.join("alias")).unwrap();
+
+    assert_eq!(
+        resolved_workdir_path(&repo, "alias").expect("contained link"),
+        repo.canonicalize().unwrap().join("alias")
+    );
 }

--- a/src/design/context-menu.deleteUntracked.test.tsx
+++ b/src/design/context-menu.deleteUntracked.test.tsx
@@ -1,0 +1,288 @@
+// "Delete file…" for untracked files, single and multi-select (#245).
+//
+// Three things are pinned here, and each has already been got wrong somewhere:
+//
+//  1. **It is `delete_untracked_files`, never `discard_paths`.** Discard restores
+//     a tracked path from the index; an entry labelled "Delete file…" that
+//     restored a file instead would be the worst surprise available on a
+//     destructive action.
+//  2. **`pgConfirm`, and the confirm decides.** A guard test bans
+//     `window.confirm` outright; what this asserts is the FLOW — declining
+//     dispatches nothing, and the body says the file is untracked and has no
+//     copy in the index or in history (the #67 wording).
+//  3. **Discard steps aside** when every unstaged path in a multi-selection is
+//     untracked, because "discard changes" is then a lie about what happens.
+//     A mixed selection keeps both entries.
+//
+// The backend rules (untracked-only, inside the worktree, no directories) are
+// NOT frontend concerns and are tested in `src-tauri/tests/delete_untracked.rs`.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+
+import {
+  fileMenuItems,
+  multiFileMenuItems,
+  type ContextMenuItem,
+} from "./context-menu";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import {
+  WithDialogs,
+  acceptDialog,
+  dialogBody,
+  dialogTitle,
+  dismissDialog,
+  resetDialogs,
+} from "@/test/dialog";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+
+const labels = (items: ContextMenuItem[]) =>
+  items.filter((i) => !i.divider && !i.__menuTitle).map((i) => String(i.label));
+
+function labeled(items: ContextMenuItem[], match: RegExp): ContextMenuItem {
+  const found = items.find((i) => typeof i.label === "string" && match.test(i.label));
+  expect(found, `no menu item matching ${match}`).toBeTruthy();
+  return found!;
+}
+
+const calls = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+
+/** Open the confirm, answer it, and let the dispatched op settle. */
+async function clickAndAnswer(item: ContextMenuItem, accept: boolean) {
+  void item.onClick?.();
+  await waitFor(() => expect(dialogTitle()).not.toBeNull());
+  if (accept) await acceptDialog();
+  else await dismissDialog();
+}
+
+beforeEach(() => {
+  resetDialogs();
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    status: [],
+    commits: [],
+    branches: [],
+    stashes: [],
+    loading: false,
+  } as never);
+  mockInvoke("delete_untracked_files", () => []);
+  mockInvoke("discard_paths", () => null);
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("head_info", () => ({ branch: "main", oid: null, detached: false }));
+  mockInvoke("rebase_status", () => ({
+    inProgress: false,
+    nextIndex: 0,
+    total: 0,
+    pauseReason: null,
+  }));
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("the single untracked file row", () => {
+  it("offers Delete instead of Discard changes", () => {
+    const l = labels(fileMenuItems({ path: "loose.txt", untracked: true }, "macos"));
+    expect(l).toContain("Delete file…");
+    expect(l).not.toContain("Discard changes");
+  });
+
+  it("dispatches delete_untracked_files, never discard_paths", async () => {
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
+    const items = fileMenuItems({ path: "src/loose.txt", untracked: true }, "macos");
+
+    await clickAndAnswer(labeled(items, /^Delete file…$/), true);
+
+    await waitFor(() => expect(calls("delete_untracked_files").length).toBe(1));
+    expect(calls("delete_untracked_files")[0].args).toEqual({
+      repoId: "r1",
+      paths: ["src/loose.txt"],
+    });
+    expect(calls("discard_paths")).toEqual([]);
+  });
+
+  it("says the file is untracked and has no copy anywhere git can reach", async () => {
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
+    const items = fileMenuItems({ path: "loose.txt", untracked: true }, "macos");
+
+    void labeled(items, /^Delete file…$/).onClick?.();
+
+    await waitFor(() => expect(dialogTitle()).toBe("Delete loose.txt?"));
+    // The #67 wording — the reason this confirm exists at all.
+    expect(dialogBody()).toContain("untracked");
+    expect(dialogBody()).toContain("no copy in the index or in history");
+    await dismissDialog();
+  });
+
+  it("deletes nothing when the confirm is declined", async () => {
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
+    const items = fileMenuItems({ path: "loose.txt", untracked: true }, "macos");
+
+    await clickAndAnswer(labeled(items, /^Delete file…$/), false);
+
+    expect(calls("delete_untracked_files")).toEqual([]);
+  });
+
+  it("keeps Discard changes, and no Delete, for a tracked row", () => {
+    const l = labels(fileMenuItems({ path: "a.txt" }, "macos"));
+    expect(l).toContain("Discard changes");
+    expect(l).not.toContain("Delete file…");
+  });
+});
+
+describe("the multi-file selection menu", () => {
+  it("replaces Discard with Delete when every unstaged path is untracked", () => {
+    const l = labels(
+      multiFileMenuItems({
+        stagedPaths: [],
+        unstagedPaths: ["a.tmp", "b.tmp", "c.tmp"],
+        untrackedPaths: ["a.tmp", "b.tmp", "c.tmp"],
+      }),
+    );
+    expect(l).toContain("Delete 3 files…");
+    expect(l.filter((x) => x.startsWith("Discard"))).toEqual([]);
+  });
+
+  it("offers both when the selection is mixed, each acting on its own bucket", async () => {
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
+    const sel = {
+      stagedPaths: [],
+      unstagedPaths: ["tracked.txt", "loose.tmp"],
+      untrackedPaths: ["loose.tmp"],
+    };
+    const l = labels(multiFileMenuItems(sel));
+    // Discard still counts every unstaged path — it restores the tracked one and
+    // deletes the untracked one, which is a different op from Delete.
+    expect(l).toContain("Discard changes in 2 files…");
+    expect(l).toContain("Delete 1 file…");
+
+    await clickAndAnswer(labeled(multiFileMenuItems(sel), /^Delete 1 file…$/), true);
+
+    await waitFor(() => expect(calls("delete_untracked_files").length).toBe(1));
+    expect(calls("delete_untracked_files")[0].args).toEqual({
+      repoId: "r1",
+      paths: ["loose.tmp"],
+    });
+  });
+
+  it("offers no Delete at all with nothing untracked selected", () => {
+    const l = labels(
+      multiFileMenuItems({
+        stagedPaths: ["s.txt"],
+        unstagedPaths: ["a.txt"],
+      }),
+    );
+    expect(l).toContain("Discard changes in 1 file…");
+    expect(l.filter((x) => x.startsWith("Delete"))).toEqual([]);
+  });
+
+  it("ignores untracked paths that are not in the selection", () => {
+    // Same filtering `promptStashPaths` does: the caller's bucket can be wider
+    // than what is actually selected, and a Delete counting phantom rows would
+    // put the wrong number in a destructive confirm.
+    const l = labels(
+      multiFileMenuItems({
+        stagedPaths: [],
+        unstagedPaths: ["a.tmp"],
+        untrackedPaths: ["a.tmp", "not-selected.tmp"],
+      }),
+    );
+    expect(l).toContain("Delete 1 file…");
+  });
+
+  it("says the files are untracked, in the plural", async () => {
+    render(
+      <WithDialogs>
+        <div />
+      </WithDialogs>,
+    );
+    void labeled(
+      multiFileMenuItems({
+        stagedPaths: [],
+        unstagedPaths: ["a.tmp", "b.tmp"],
+        untrackedPaths: ["a.tmp", "b.tmp"],
+      }),
+      /^Delete 2 files…$/,
+    ).onClick?.();
+
+    await waitFor(() => expect(dialogTitle()).toBe("Delete 2 files?"));
+    expect(dialogBody()).toContain("They are untracked");
+    expect(dialogBody()).toContain("no copy in the index or in history");
+    await dismissDialog();
+    expect(calls("delete_untracked_files")).toEqual([]);
+  });
+});
+
+describe("the folder row's file-manager entries", () => {
+  const FOLDER = {
+    stagedPaths: [],
+    unstagedPaths: ["src/a.txt"],
+    paths: ["src/a.txt"],
+    directoryPath: "src",
+  };
+
+  it("reveals and opens a terminal on the FOLDER, not on the files beneath it", () => {
+    mockInvoke("reveal_in_file_manager", () => null);
+    mockInvoke("open_in_terminal", () => null);
+    const items = multiFileMenuItems(FOLDER, "macos");
+
+    labeled(items, /^Reveal in Finder$/).onClick?.();
+    labeled(items, /^Open in terminal$/).onClick?.();
+
+    expect(calls("reveal_in_file_manager")).toEqual([
+      { cmd: "reveal_in_file_manager", args: { repoId: "r1", relativePath: "src" } },
+    ]);
+    expect(calls("open_in_terminal")).toEqual([
+      { cmd: "open_in_terminal", args: { repoId: "r1", relativePath: "src" } },
+    ]);
+  });
+
+  it("labels the reveal entry per platform, like the file row does", () => {
+    expect(labeled(multiFileMenuItems(FOLDER, "windows"), /^Show in Explorer$/)).toBeTruthy();
+    expect(
+      labeled(multiFileMenuItems(FOLDER, "linux"), /^Show in file manager$/),
+    ).toBeTruthy();
+  });
+
+  it("has exactly one file-manager entry — no 'Open containing folder' synonym", () => {
+    // Same reasoning as the file row (see context-menu.copyPath.test.tsx):
+    // revealing a directory opens a window on it, and the only variant that
+    // differs is its PARENT, which is not what "reveal this folder" means.
+    const l = labels(multiFileMenuItems(FOLDER, "linux"));
+    expect(l.filter((x) => /folder|file manager|Finder|Explorer/i.test(x))).toEqual([
+      "Show in file manager",
+    ]);
+  });
+
+  it("offers neither for a multi-row selection, which has no single target", () => {
+    const l = labels(
+      multiFileMenuItems(
+        { stagedPaths: [], unstagedPaths: ["a.txt", "b.txt"] },
+        "macos",
+      ),
+    );
+    expect(l).not.toContain("Reveal in Finder");
+    expect(l).not.toContain("Open in terminal");
+  });
+});

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -1762,9 +1762,15 @@ export function fileMenuItems(
       },
     },
     { divider: true },
-    // An untracked file has no copy in the index or in history, so discarding
-    // it deletes it for good — say so, and never do it on a single click the
-    // way a recoverable "restore from index" can be.
+    // An untracked file has no copy in the index or in history, so deleting it
+    // is for good — say so, and never do it on a single click the way a
+    // recoverable "restore from index" can be.
+    //
+    // Wired to `deleteUntracked`, not `discard` (#245): discard would RESTORE
+    // this path the moment it became tracked between the right-click and the
+    // confirm, and an entry labelled "Delete file…" that reverted a file
+    // instead is the worst surprise available on a destructive action. The
+    // backend refuses a tracked path outright.
     untracked
       ? {
           icon: "trash",
@@ -1780,7 +1786,7 @@ export function fileMenuItems(
                 confirmLabel: "Delete file",
               })
             ) {
-              useRepoStore.getState().discard([path]);
+              useRepoStore.getState().deleteUntracked([path]);
             }
           },
         }
@@ -1823,9 +1829,22 @@ export interface MultiFileMenuSelection {
   /**
    * Subset of `unstagedPaths` that is untracked. Discarding those deletes them
    * outright — git has no copy — so the confirm has to name that separately
-   * from the recoverable "restore from index" case.
+   * from the recoverable "restore from index" case. Also the set "Delete N
+   * files…" acts on (#245).
    */
   untrackedPaths?: string[];
+  /**
+   * The DIRECTORY this menu was opened on, when it was opened on exactly one
+   * (#245).
+   *
+   * Both trees hand a folder key straight to `splitFileSelection`, which
+   * expands it to the files beneath — so this menu is also the folder row's
+   * menu, and until this field existed it had no idea which folder that was.
+   * Set only for a single folder row: entries that address one location (reveal,
+   * terminal) are meaningless for a multi-row selection, where the honest answer
+   * would be five windows.
+   */
+  directoryPath?: string;
 }
 
 /**
@@ -1903,6 +1922,7 @@ export async function promptStashPaths(
 
 export function multiFileMenuItems(
   sel: MultiFileMenuSelection | null,
+  platform?: Platform,
 ): ContextMenuItem[] {
   const stagedPaths = sel?.stagedPaths ?? [];
   const unstagedPaths = sel?.unstagedPaths ?? [];
@@ -1963,33 +1983,95 @@ export function multiFileMenuItems(
     });
   }
   items.push({ divider: true }, ...copyPathItems(all));
-  if (unstagedPaths.length) {
+  // The folder row's file-manager entries (#245). `reveal_in_file_manager` reads
+  // is-it-a-directory off the filesystem, so this opens a WINDOW on the folder
+  // rather than selecting it in its parent — and "Open containing folder" is
+  // what the file row's own entry has always been, on every platform, so there
+  // is deliberately no such synonym here either.
+  const directoryPath = sel?.directoryPath;
+  if (directoryPath) {
     items.push(
       { divider: true },
       {
-        icon: "undo",
-        label: `Discard changes in ${files(unstagedPaths.length)}…`,
-        danger: true,
-        onClick: async () => {
-          const untracked = sel?.untrackedPaths ?? [];
-          const deleted = untracked.length
-            ? ` ${files(untracked.length)} ${
-                untracked.length === 1 ? "is" : "are"
-              } untracked and will be deleted permanently.`
-            : "";
-          if (
-            await pgConfirm({
-              title: `Discard changes in ${files(unstagedPaths.length)}?`,
-              body: `The changes will be lost.${deleted}`,
-              danger: true,
-              confirmLabel: "Discard",
-            })
-          ) {
-            useRepoStore.getState().discard(unstagedPaths);
-          }
+        icon: "folder",
+        label: fileManagerLabel(platform),
+        onClick: () => {
+          useRepoStore.getState().revealInFileManager(directoryPath);
+        },
+      },
+      {
+        icon: "terminal",
+        label: "Open in terminal",
+        onClick: () => {
+          useRepoStore.getState().openInTerminal(directoryPath);
         },
       },
     );
+  }
+
+  // The untracked half of the selection, which is what Delete acts on. Filtered
+  // against the selection for the same reason `promptStashPaths` filters: the
+  // caller's bucket can be wider than what is actually selected.
+  const untracked = (sel?.untrackedPaths ?? []).filter((p) =>
+    unstagedPaths.includes(p),
+  );
+  // Discard RESTORES from the index; where every unstaged path is untracked
+  // there is nothing to restore and the op is a delete, so the Discard entry
+  // steps aside for the Delete one — exactly the swap `fileMenuItems` makes on a
+  // single untracked row (#67). A MIXED selection keeps both, because they
+  // genuinely differ there: Discard restores the tracked ones and deletes the
+  // untracked ones, Delete touches only the untracked ones.
+  const restorable = unstagedPaths.filter((p) => !untracked.includes(p));
+  if (restorable.length || untracked.length) items.push({ divider: true });
+  if (restorable.length) {
+    items.push({
+      icon: "undo",
+      label: `Discard changes in ${files(unstagedPaths.length)}…`,
+      danger: true,
+      onClick: async () => {
+        const deleted = untracked.length
+          ? ` ${files(untracked.length)} ${
+              untracked.length === 1 ? "is" : "are"
+            } untracked and will be deleted permanently.`
+          : "";
+        if (
+          await pgConfirm({
+            title: `Discard changes in ${files(unstagedPaths.length)}?`,
+            body: `The changes will be lost.${deleted}`,
+            danger: true,
+            confirmLabel: "Discard",
+          })
+        ) {
+          useRepoStore.getState().discard(unstagedPaths);
+        }
+      },
+    });
+  }
+  if (untracked.length) {
+    const n = untracked.length;
+    items.push({
+      icon: "trash",
+      label: `Delete ${files(n)}…`,
+      danger: true,
+      onClick: async () => {
+        if (
+          await pgConfirm({
+            title: `Delete ${files(n)}?`,
+            // The #67 wording, in the plural: an untracked file has no copy
+            // anywhere git can reach, and that is the whole reason this confirm
+            // exists.
+            body:
+              n === 1
+                ? "It is untracked — there is no copy in the index or in history, so this cannot be undone."
+                : "They are untracked — there is no copy in the index or in history, so this cannot be undone.",
+            danger: true,
+            confirmLabel: n === 1 ? "Delete file" : "Delete files",
+          })
+        ) {
+          useRepoStore.getState().deleteUntracked(untracked);
+        }
+      },
+    });
   }
   return items;
 }

--- a/src/features/repo/useRepoStore.deleteUntracked.test.ts
+++ b/src/features/repo/useRepoStore.deleteUntracked.test.ts
@@ -1,0 +1,152 @@
+// `deleteUntracked` — the store half of #245.
+//
+// A destructive op, so the ordering is the contract (CLAUDE.md): the file list
+// is refreshed BEFORE anything is reported, on both paths. A partially completed
+// multi-file delete otherwise leaves the UI listing files that are already gone,
+// under a banner explaining the ones that are not.
+//
+// The delete is also best-effort by design — the backend validates the whole
+// batch before unlinking anything, then reports per-path I/O failures — so a
+// RESOLVED call can still carry bad news, and the store has to surface it rather
+// than treating "no exception" as "all done".
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { useRepoStore } from "./useRepoStore";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+
+/** The order in which the store touched refresh vs. the error banner. */
+const trace: string[] = [];
+
+function armRepo() {
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    status: [],
+    error: null,
+    refreshStatus: async () => {
+      trace.push("refreshStatus");
+    },
+    refreshAll: async () => {
+      trace.push("refreshAll");
+    },
+  } as never);
+}
+
+beforeEach(() => {
+  trace.length = 0;
+  armRepo();
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("deleteUntracked", () => {
+  it("sends the selection and refreshes the file list on success", async () => {
+    mockInvoke("delete_untracked_files", () => []);
+
+    await useRepoStore.getState().deleteUntracked(["a.tmp", "b.tmp"]);
+
+    expect(getInvokeCalls().filter((c) => c.cmd === "delete_untracked_files")).toEqual([
+      {
+        cmd: "delete_untracked_files",
+        args: { repoId: "r1", paths: ["a.tmp", "b.tmp"] },
+      },
+    ]);
+    expect(trace).toEqual(["refreshStatus"]);
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("does nothing at all with no repository open", async () => {
+    useRepoStore.setState({ current: null } as never);
+    mockInvoke("delete_untracked_files", () => []);
+
+    await useRepoStore.getState().deleteUntracked(["a.tmp"]);
+
+    expect(getInvokeCalls()).toEqual([]);
+  });
+
+  it("does not dispatch an empty selection", async () => {
+    mockInvoke("delete_untracked_files", () => []);
+
+    await useRepoStore.getState().deleteUntracked([]);
+
+    expect(getInvokeCalls()).toEqual([]);
+    expect(trace).toEqual([]);
+  });
+
+  it("reports the paths the OS refused, naming each and its reason", async () => {
+    mockInvoke("delete_untracked_files", () => [
+      { path: "locked/a.tmp", reason: "Permission denied (os error 13)" },
+      { path: "gone.tmp", reason: "No such file or directory (os error 2)" },
+    ]);
+
+    await useRepoStore
+      .getState()
+      .deleteUntracked(["locked/a.tmp", "gone.tmp", "fine.tmp"]);
+
+    const error = useRepoStore.getState().error;
+    expect(error?.kind).toBe("Io");
+    expect(String(error?.message)).toContain("could not delete 2 files");
+    expect(String(error?.message)).toContain("locked/a.tmp");
+    expect(String(error?.message)).toContain("Permission denied");
+    expect(String(error?.message)).toContain("gone.tmp");
+  });
+
+  it("refreshes BEFORE reporting a partial failure", async () => {
+    // The files that DID go are gone; the list must say so before the banner
+    // starts talking about the ones that did not.
+    mockInvoke("delete_untracked_files", () => [
+      { path: "gone.tmp", reason: "No such file or directory" },
+    ]);
+    useRepoStore.setState({
+      refreshStatus: async () => {
+        trace.push("refreshStatus");
+        // The banner is still clear at refresh time.
+        trace.push(`error=${String(useRepoStore.getState().error)}`);
+      },
+    } as never);
+
+    await useRepoStore.getState().deleteUntracked(["gone.tmp"]);
+
+    expect(trace).toEqual(["refreshStatus", "error=null"]);
+    expect(useRepoStore.getState().error).not.toBeNull();
+  });
+
+  it("uses the singular for one failure", async () => {
+    mockInvoke("delete_untracked_files", () => [
+      { path: "gone.tmp", reason: "No such file or directory" },
+    ]);
+
+    await useRepoStore.getState().deleteUntracked(["gone.tmp"]);
+
+    expect(String(useRepoStore.getState().error?.message)).toContain(
+      "could not delete 1 file:",
+    );
+  });
+
+  it("refreshes everything FIRST and sets the error LAST when the call rejects", async () => {
+    mockInvoke("delete_untracked_files", () => {
+      throw { kind: "InvalidPath", message: "loose.txt is tracked by git" };
+    });
+
+    await useRepoStore.getState().deleteUntracked(["loose.txt"]);
+
+    // The CLAUDE.md rule for a danger op's catch arm, in order.
+    expect(trace).toEqual(["refreshAll"]);
+    expect(useRepoStore.getState().error).toEqual({
+      kind: "InvalidPath",
+      message: "loose.txt is tracked by git",
+    });
+  });
+
+  it("never raises a banner for a repository the user has left", async () => {
+    mockInvoke("delete_untracked_files", () => {
+      // Tab switch lands while the delete is in flight.
+      useRepoStore.setState({ current: { id: "r2", path: "/other", head: "main" } } as never);
+      throw { kind: "Io", message: "boom" };
+    });
+
+    await useRepoStore.getState().deleteUntracked(["loose.txt"]);
+
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+});

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -46,6 +46,7 @@ import {
   discardHunk,
   discardLines as discardLinesFn,
   discardPaths,
+  deleteUntrackedFiles as deleteUntrackedFilesFn,
   fetch as fetchRemote,
   fetchAll,
   getLogFilteredPage,
@@ -229,6 +230,15 @@ interface RepoStoreState extends RepoSlice {
   stage: (paths: string[]) => Promise<void>;
   unstage: (paths: string[]) => Promise<void>;
   discard: (paths: string[]) => Promise<void>;
+  /**
+   * Delete untracked files outright (#245).
+   *
+   * A different op from `discard`, not a nicer name for it: discard restores a
+   * tracked path from the index, and this refuses one. Callers must therefore
+   * confirm first (`pgConfirm`) — the store does not, because it is also the
+   * layer a keyboard shortcut would reach.
+   */
+  deleteUntracked: (paths: string[]) => Promise<void>;
   stageHunk: (path: string, hunkIndex: number) => Promise<void>;
   unstageHunk: (path: string, hunkIndex: number) => Promise<void>;
   discardHunk: (path: string, hunkIndex: number) => Promise<void>;
@@ -795,6 +805,35 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await discardPaths(repo.id, paths);
       await get().refreshStatus();
     } catch (e) {
+      setErrorFor(repo.id, e);
+    }
+  },
+
+  async deleteUntracked(paths) {
+    const repo = get().current;
+    if (!repo || !paths.length) return;
+    try {
+      const failed = await deleteUntrackedFilesFn(repo.id, paths);
+      // Refresh BEFORE reporting, on the success path as much as in the catch
+      // arm: the delete is best-effort, so "some of these are gone" is a
+      // partial outcome and the list has to show which ones before the banner
+      // talks about the rest.
+      await get().refreshStatus();
+      if (failed.length) {
+        const detail = failed.map((f) => `${f.path} (${f.reason})`).join("; ");
+        setErrorFor(repo.id, {
+          kind: "Io",
+          message: `could not delete ${failed.length} file${
+            failed.length === 1 ? "" : "s"
+          }: ${detail}`,
+        });
+      }
+    } catch (e) {
+      // A danger op: refreshAll() FIRST, the error LAST. The backend refuses a
+      // batch before deleting anything, but a rejection can also come from a
+      // dropped IPC call mid-flight — the UI must show what is actually on disk
+      // before it explains itself.
+      await get().refreshAll();
       setErrorFor(repo.id, e);
     }
   },

--- a/src/lib/selection.test.ts
+++ b/src/lib/selection.test.ts
@@ -6,6 +6,7 @@ import {
   pruneSelection,
   sidedFileKey,
   sidedFolderKey,
+  sidedFolderPath,
   sidedSelectionSource,
   splitFileSelection,
   treeSelectionSource,
@@ -322,5 +323,31 @@ describe("splitFileSelection over the sided key space", () => {
 
   it("yields nothing for a key outside the space", () => {
     expect(splitFileSelection(["/src/a.ts"], source).paths).toEqual([]);
+  });
+});
+
+describe("sidedFolderPath", () => {
+  it("recovers the directory a folder key stands for", () => {
+    // What the folder row's context menu needs: `splitFileSelection` answers
+    // with the files BENEATH a folder key, so revealing the folder itself (#245)
+    // has to read the path back out of the key.
+    expect(sidedFolderPath(sidedFolderKey("unstaged", "src/features"))).toBe(
+      "src/features",
+    );
+    expect(sidedFolderPath(sidedFolderKey("staged", "src"))).toBe("src");
+  });
+
+  it("answers null for a file key, so nothing mistakes one for a folder", () => {
+    expect(sidedFolderPath(sidedFileKey("unstaged", "src/a.txt"))).toBeNull();
+    // A file whose own path starts with `dir:` is still a file — the `side:`
+    // prefix is what the marker sits behind.
+    expect(sidedFolderPath("unstaged:dir-ish/a.txt")).toBeNull();
+    expect(sidedFolderPath("")).toBeNull();
+  });
+
+  it("round-trips a directory whose name contains a colon", () => {
+    expect(sidedFolderPath(sidedFolderKey("unstaged", "odd:name/sub"))).toBe(
+      "odd:name/sub",
+    );
   });
 });

--- a/src/lib/selection.ts
+++ b/src/lib/selection.ts
@@ -217,6 +217,18 @@ export function sidedFolderKey(side: FileSide, dirPath: string): string {
 }
 
 /**
+ * The directory path inside a `side:dir:path` key, or `null` for a file key.
+ *
+ * The inverse of {@link sidedFolderKey}, and the reason it exists: a folder
+ * row's context menu needs the folder ITSELF (to reveal it, #245), while
+ * `splitFileSelection` deliberately answers only with the files beneath it.
+ */
+export function sidedFolderPath(key: string): string | null {
+  const m = SIDED_FOLDER_KEY.exec(key);
+  return m ? m[2] : null;
+}
+
+/**
  * Source for the `side:path` / `side:dir:path` key space — two pre-split row
  * lists, one per section. A folder key only ever expands within its own
  * section, so staging a folder in CHANGES cannot reach the STAGED rows below.

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -10,6 +10,7 @@ import type {
   BranchInfo,
   CliInstallOutcome,
   ChecksSummary,
+  DeleteFailure,
   CliShimStatus,
   CommitInfo,
   CommitResult,
@@ -494,6 +495,25 @@ export async function verifyCommit(
 
 export async function discardPaths(repoId: string, paths: string[]): Promise<void> {
   return invoke<void>("discard_paths", { repoId, paths });
+}
+
+/**
+ * Delete UNTRACKED files from the working tree (#245).
+ *
+ * Not `discardPaths`: that restores a tracked path from the index and only
+ * deletes an untracked one, while this refuses a tracked path outright — the
+ * backend enforces untracked-only, inside-the-worktree, no directories and no
+ * embedded repositories, and none of those are the frontend's to decide.
+ *
+ * Rejects without deleting anything when a path fails one of those rules.
+ * Resolves with one entry per path the OS refused to unlink (an empty array
+ * means the whole selection is gone) — the delete is best-effort once it starts.
+ */
+export async function deleteUntrackedFiles(
+  repoId: string,
+  paths: string[],
+): Promise<DeleteFailure[]> {
+  return invoke<DeleteFailure[]>("delete_untracked_files", { repoId, paths });
 }
 
 // Hunk indices refer to the diff computed with `contextLines` — always pass

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -13,6 +13,23 @@ export interface RepoHandle {
   head: string | null;
 }
 
+/**
+ * One path `deleteUntrackedFiles` could not remove (#245). 1:1 with
+ * `DeleteFailure` in `src-tauri/src/git/types.rs`.
+ *
+ * The delete is best-effort once it starts unlinking — three read-only files in
+ * a ten-file selection must not decide the fate of the other seven — so a
+ * resolved call can still carry failures. Refusals decidable *before* anything
+ * is deleted (a tracked path, an escape, an embedded repo, a directory) arrive
+ * as a thrown `AppError` instead, and nothing was deleted.
+ */
+export interface DeleteFailure {
+  /** The repo-relative path, as the caller spelled it — a row in the file list. */
+  path: string;
+  /** The OS's own message. */
+  reason: string;
+}
+
 export type StatusFlag =
   | { kind: "Unmodified" }
   | { kind: "Modified" }

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -64,6 +64,7 @@ import {
   pruneSelection,
   sidedFileKey,
   sidedFolderKey,
+  sidedFolderPath,
   sidedSelectionSource,
   splitFileSelection,
   type Selection,
@@ -206,14 +207,24 @@ export function CommitPanelScreen() {
   const { onContextMenu: onFolderCtx, menu: folderMenu } = useContextMenu<string>(
     (navKey) =>
       multiFileMenuItems(
-        splitFileSelection(navKey ? [navKey] : [], selectionSource),
+        {
+          ...splitFileSelection(navKey ? [navKey] : [], selectionSource),
+          // The folder itself. `splitFileSelection` answers with the files
+          // BENEATH a folder key, so the path has to come back out of the key
+          // for the file-manager entry to have a target (#245).
+          directoryPath: (navKey && sidedFolderPath(navKey)) || undefined,
+        },
+        platform,
       ),
   );
 
   const { onContextMenu: onFileCtx, menu: fileMenu } = useContextMenu<FileSlot>(
     (f) => {
       if (f && sel.keys.length > 1 && sel.keys.includes(keyOf(f))) {
-        return multiFileMenuItems(splitFileSelection(sel.keys, selectionSource));
+        return multiFileMenuItems(
+          splitFileSelection(sel.keys, selectionSource),
+          platform,
+        );
       }
       return fileMenuItems(
         {

--- a/src/screens/RepoBrowser.test.tsx
+++ b/src/screens/RepoBrowser.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, fireEvent, within } from "@testing-library/rea
 
 import { RepoBrowserScreen } from "./RepoBrowser";
 import { useRepoStore } from "@/features/repo/useRepoStore";
-import { mockInvoke } from "@/test/invokeMock";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
 import {
   WithDialogs,
   acceptDialog,
@@ -234,12 +234,16 @@ describe("RepoBrowser embedded git repositories", () => {
 });
 
 /**
- * Discarding an untracked file DELETES it — git holds no copy to restore from,
- * so unlike "restore this modified file from the index" there is no way back.
- * The menu says so and never fires on a single click.
+ * Deleting an untracked file is final — git holds no copy to restore from, so
+ * unlike "restore this modified file from the index" there is no way back. The
+ * menu says so, never fires on a single click, and goes to `deleteUntracked`
+ * rather than `discard` (#245): discard would RESTORE the path if it had become
+ * tracked since the right-click, which is the last thing an entry labelled
+ * "Delete file…" may do.
  */
 describe("RepoBrowser discarding untracked files", () => {
   const discardCalls: string[][] = [];
+  const deleteCalls: string[][] = [];
 
   function untracked(path: string): FileStatus {
     return {
@@ -254,11 +258,15 @@ describe("RepoBrowser discarding untracked files", () => {
 
   beforeEach(() => {
     discardCalls.length = 0;
+    deleteCalls.length = 0;
     resetDialogs();
     resetStore({
       status: [modified("a.txt"), untracked("loose.txt")],
       discard: async (paths: string[]) => {
         discardCalls.push(paths);
+      },
+      deleteUntracked: async (paths: string[]) => {
+        deleteCalls.push(paths);
       },
     } as never);
     wireMocks();
@@ -295,14 +303,16 @@ describe("RepoBrowser discarding untracked files", () => {
       "cannot be undone",
     );
     await dismissDialog();
-    expect(discardCalls).toEqual([]);
+    expect(deleteCalls).toEqual([]);
 
     fireEvent.contextMenu(treeRow("loose.txt"));
     fireEvent.click(within(await waitFor(contextMenu)).getByText("Delete file…"));
     await waitFor(() => expect(dialogTitle()).toBe("Delete loose.txt?"));
     await acceptDialog();
 
-    await waitFor(() => expect(discardCalls).toEqual([["loose.txt"]]));
+    await waitFor(() => expect(deleteCalls).toEqual([["loose.txt"]]));
+    // Never the restoring op, whatever the row's state turned out to be.
+    expect(discardCalls).toEqual([]);
   });
 
   it("keeps Discard changes for a tracked modification", async () => {
@@ -382,5 +392,57 @@ describe("RepoBrowser conflicted files", () => {
     expect(within(menu).getByText("Accept ours")).toBeInTheDocument();
     expect(within(menu).getByText("Accept theirs")).toBeInTheDocument();
     expect(within(menu).queryByText("Stage")).toBeNull();
+  });
+});
+
+/**
+ * A DIRECTORY row (#245). The issue asked for reveal "on a file row, a directory
+ * row, and the repository itself", and the folder row was the one that had no
+ * file-manager entry at all: it goes to `multiFileMenuItems`, which is handed
+ * the files BENEATH the folder and, until `directoryPath`, had no idea which
+ * folder it was looking at.
+ */
+describe("RepoBrowser folder rows", () => {
+  beforeEach(() => {
+    resetStore({ status: [modified("src/nested/a.txt")] });
+    wireMocks();
+    mockInvoke("reveal_in_file_manager", () => null);
+    mockInvoke("open_in_terminal", () => null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reveals the FOLDER itself, not the files inside it", async () => {
+    render(<RepoBrowserScreen />);
+    const row = await waitFor(() => treeRow("src/nested"));
+
+    fireEvent.contextMenu(row);
+    const menu = await waitFor(contextMenu);
+    // The label is platform-dependent (`fileManagerLabel`); the entry is not.
+    fireEvent.click(within(menu).getByText(/Finder|Explorer|file manager/));
+
+    await waitFor(() => {
+      const call = getInvokeCalls().find((c) => c.cmd === "reveal_in_file_manager");
+      expect(call).toBeDefined();
+      // The backend reads is-it-a-directory off the filesystem, so this opens a
+      // window ON the folder rather than selecting it in its parent.
+      expect(call!.args).toEqual({ repoId: "repo-1", relativePath: "src/nested" });
+    });
+  });
+
+  it("opens a terminal in the folder", async () => {
+    render(<RepoBrowserScreen />);
+    const row = await waitFor(() => treeRow("src/nested"));
+
+    fireEvent.contextMenu(row);
+    fireEvent.click(within(await waitFor(contextMenu)).getByText("Open in terminal"));
+
+    await waitFor(() => {
+      const call = getInvokeCalls().find((c) => c.cmd === "open_in_terminal");
+      expect(call).toBeDefined();
+      expect(call!.args).toEqual({ repoId: "repo-1", relativePath: "src/nested" });
+    });
   });
 });

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -598,11 +598,17 @@ export function RepoBrowserScreen() {
   const fileCtx = useContextMenu<{ key: string; node: PGFileTreeNode }>(
     ({ key, node }) => {
       if (sel.keys.length > 1 && sel.keys.includes(key)) {
-        return multiFileMenuItems(splitSelection(sel.keys));
+        return multiFileMenuItems(splitSelection(sel.keys), platform);
       }
       // Folder: act on every file beneath it — stage / unstage / discard all,
-      // the same batch menu a multi-row selection gets.
-      if (node.children?.length) return multiFileMenuItems(splitSelection([key]));
+      // the same batch menu a multi-row selection gets. `directoryPath` is the
+      // folder itself, which the split deliberately does not carry (it answers
+      // with the files beneath) and which the file-manager entry needs (#245).
+      if (node.children?.length)
+        return multiFileMenuItems(
+          { ...splitSelection([key]), directoryPath: treeKeyToPath(key) },
+          platform,
+        );
       const st = findStatusByTreeKey(key, status);
       // Act on the status entry's own path, not the key: an embedded repo's
       // path carries a trailing slash the key has already lost, and that slash


### PR DESCRIPTION
## What does this PR do?

Completes #245 — the destructive half, plus the two reveal gaps.

1. **Delete untracked file(s)** — `Delete file…` on untracked rows, behind `pgConfirm`, single and multi-select. New `GitBackend::delete_untracked` + `delete_untracked_files` command.
2. **Reveal on directory rows** — folder rows had *no* file-manager entry at all, though the issue asked for one.
3. **"Open containing folder"** — deliberately **not** a separate entry, and now settled rather than deferred. See below.

Closes #245.

## The containment check — the part to review hardest

`resolved_workdir_path` in `src-tauri/src/opener.rs`, beside the existing `safe_workdir_path`, so there is one home for "is this inside the workdir" in two strengths.

`safe_workdir_path` is **lexical**: it refuses `..`, absolute paths and Windows prefixes. That is enough to hand a string to an application, and **not** enough to unlink the result — `repo/out -> /etc` makes `out/passwd` an innocent-looking relative path with **no `..` anywhere in it**. So:

- Canonicalizes **both** the workdir and the candidate's **parent**, re-joins the final component, and re-checks with a pure, component-wise `contained_in`.
- **The workdir must be canonicalized too**, not just the candidate: a macOS tempdir sits under `/var`, itself a symlink to `/private/var`, so comparing a raw workdir against a canonicalized candidate would refuse everything.
- **Only the parent** is canonicalized, not the whole path, so a file somebody else already deleted still resolves — its absence is reported as absence, not as "escapes the worktree", which would be a lie.
- `contained_in` is component-wise because a string `starts_with` reads `/repository` and `/repo-backup` as children of `/repo`. Strictly inside: the root itself is not contained.
- A **final-component symlink** is refused unless its target canonicalizes inside the workdir; a broken link is refused too. Stricter than strictly necessary (unlinking a link never touches its target) and deliberately so.

**Proven refusals** (`tests/opener.rs` +8, `tests/delete_untracked.rs` 19): `../outside/secret.txt`, `../../../etc/passwd`, `src/../../outside/secret.txt`, an absolute path to a sibling tempdir, `/etc/passwd`, `""`, a symlink to a file outside, **`out/secret.txt` reached *through* a symlinked directory (no `..` in it)**, and a dangling link. Accepted: `src/a.txt`, a missing file, and a symlink staying inside (whose target survives).

## Atomic or best-effort? Both, split by kind of failure

**Validation refusals abort the whole batch. Unlinks are best-effort.**

Everything decidable without touching the disk — tracked, escape, embedded repo, directory — is validated for every path first, and one failure fails all of it. A security refusal must never leave a half-deleted selection, or **a crafted path becomes discoverable by noticing the three files before it are already gone.**

The unlinks then report one `DeleteFailure { path, reason }` per path the OS refused. With 3 of 10 read-only, stopping at the first deletes an arbitrary prefix and names one cause; best-effort deletes the 7 it can and names the 3 it cannot. `path` is the caller's spelling, never the canonicalized absolute — the file list has no row for that.

## Why the delete is on the `GitBackend` trait

Every rule it enforces is a question only the repository can answer: is this path an index entry at **any** stage (a conflicted file lives at 1/2/3, and reading it as untracked would delete a merge in progress), and is the entry an embedded repository whose commits git cannot recover. CLAUDE.md requires a verify and the mutation it guards to share **one** lock acquisition — a handler that reads `status()` and then unlinks is the stash TOCTOU again. `CliBackend` stubbed `NotImplemented`.

## Two traps found on the way

- **`git2::Index::get_path` PANICS** on a path that is absolute or starts with `..` (it unwraps its own `path_to_repo_path`). So containment must run *before* the index is touched. `discard` already ordered itself that way; the reason is now written down in `docs/dev/backend.md`, because `discard` and `delete_untracked` both silently depend on it.
- **`remove_dir_all`/`is_dir` follow symlinks**, so the delete uses `symlink_metadata` throughout and only ever `remove_file` — plus a `remove_dir` fallback for a Windows directory symlink, which `unlink` refuses.

## The reveal fix, and why "Open containing folder" is not an entry

`reveal_in_file_manager` hard-coded `is_dir: false` on its relative-path branch, so aiming it at a folder ran `open -R src` — **selecting** the folder in its parent rather than opening it. `reveal_target` now reads is-it-a-directory off the filesystem, which is the only authority (libgit2 spells an embedded repo with a trailing slash; a folder row has no status entry at all). **File rows and the repo tab are unaffected** — the repo-root branch already passed `true`. `terminal_target` is the same fix for "Open in terminal", which would otherwise open a folder's *parent*.

On **no separate "Open containing folder" entry**: revealing a file already opens its containing folder on all three platforms — `open -R` (macOS) and `explorer /select,` (Windows) open the parent with the file selected, and Linux `xdg-open`s the parent since there is no portable select verb. The `reveal(parent, is_dir: true)` variant is the same window minus the selection on two platforms and byte-identical on the third: strictly less information behind an entry that looks like a different action. That is the synonym `docs/dev/frontend.md` was updated to prevent one PR ago; this promotes it from "deferred, needs a backend change" to settled, and pins one file-manager entry on the folder row too.

## Also

Discard steps aside in the multi-select menu when the whole unstaged selection is untracked — the same swap `fileMenuItems` already makes on a single row (#67), because "discard changes" is a lie there. Mixed selections keep both.

## Checklist

- [x] One logical change, focused PR
- [x] Branched off `main`; rebased onto `59ac32c`, no merge commits, single squashed commit
- [x] PR title + commit message follow Conventional Commits
- [x] `pnpm tsc --noEmit` passes — exit 0
- [x] `cargo test` passes — **816 tests, 0 failed** (incl. 19 new `delete_untracked`, 16 `opener`)
- [x] `pnpm test` passes — 237 files, 2094 tests
- [x] `pnpm exec tsc -p e2e/tsconfig.json --noEmit` passes
- [x] **e2e run** — `pnpm test:e2e:docker full --spec e2e/specs/status-stage.e2e.ts`: **7 passing**, including "deletes an untracked file via context menu", which now exercises `delete_untracked_files` instead of `discard_paths` through the real binary. Ran because a shipped spec moved under this change
- [x] New git op: trait + impl + `CliBackend` stub + command + `invoke_handler!` registration + TS type/wrapper wired
- [x] `docs/dev/architecture.md`, `backend.md`, `frontend.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
