### PR TITLE
feat(settings): follow the system light/dark appearance

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -283,7 +283,8 @@ features/            Components + Zustand store colocated per feature:
 │                    dragController.ts, resolveDrop.ts (pure drop tables),
 │                    useRowReorder, StageDropBar. See frontend.md
 ├── reflog/          useReflogStore, DirtyTreeDialog, ReflogActionDialog
-├── settings/        useSettingsStore (autoFetch, defaultPullMode, …), headMarks
+├── settings/        useSettingsStore (autoFetch, defaultPullMode, …), headMarks,
+│                   systemAppearance (OS light/dark → themePreference)
 │                    + HeadMarksControl
 ├── palette/         usePaletteStore (step stack + chips), commands catalog,
 │                    frecency, CommandPalette (⌘P; rows show live keymap chords)

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -398,6 +398,14 @@ update checks back on for someone who turned them off.
   `importSettings` reports, ignoring an id no `BUILTIN_PRESETS` entry has
   (`presetById` would silently resolve it to the default while the picker showed
   the unknown name).
+- **`themePreference` travels; the appearance it resolved against does not.**
+  The pairing is a preference like any other, so the export carries it. The
+  observed OS appearance is not in `PersistedState` at all, so `snapshot()` and
+  `PORTABLE_KEYS` — both derived from `DEFAULTS` — exclude it by construction
+  (the call #283 made for `lastCheckedAt`). On import, `coerceSettings` repairs
+  a half naming a theme this machine lacks and **re-derives** `activeThemeId`
+  from this machine's own appearance: the exported id only records which half
+  was on screen where the file was written.
 - **One theme format.** `themePayload()` is the per-theme serialiser behind both
   `exportTheme` and the settings bundle; the bundle adds only `id`, because
   `activeThemeId` has to stay resolvable. `normalizeCustomThemes` is lenient in
@@ -425,6 +433,37 @@ update checks back on for someone who turned them off.
   theme MODE and `SELECTION_TOKENS` derived from `--accent`. Light themes need
   their own calibration (#61 B4). The dark column stays byte-identical to
   `index.css` — edit both or they drift.
+- **Following the system appearance is a PAIRING, not a theme** (#236). A
+  `ThemeDef` is intrinsically one mode, so "system" cannot be one:
+  `themePreference: { mode: "system" | "fixed", lightId, darkId }` says which
+  light theme and which dark theme to pair, and `activeThemeId` stays the single
+  answer to "what is on screen" — DERIVED from the pairing while following, the
+  user's own choice while fixed. Keeping it derived is what makes the feature
+  invisible downstream: `getActiveTheme`, the theme editor and `DiffMinimap`'s
+  `activeThemeId` repaint subscription all work unchanged, and the minimap
+  repaints on an OS switch for free.
+  - `features/settings/systemAppearance.ts` reads the OS, from **two** sources
+    with different jobs: `prefers-color-scheme` is synchronous (so module load
+    can paint the right half with no flash, and it is the only source in a
+    browser tab or the unit suite), and `getCurrentWindow().theme()` +
+    `tauri://theme-changed` is authoritative and is what actually fires at
+    sunset. It asks BOTH media queries, never only the dark one — a webview
+    without the feature answers `false` to both, and reading that as "light"
+    flips the app on exactly the platforms that cannot correct it. Nothing here
+    is persisted or exported: the observed appearance is state about the
+    machine, so it lives on `SettingsState` and **not** in `PersistedState`.
+  - `main.tsx` calls `startSystemAppearanceWatch()` **before** the
+    `window=merge` branch, so the merge resolver — a second Tauri window on the
+    same bundle — subscribes for itself. A window still in last night's theme is
+    the bug the feature exists to fix. No Rust and no extra capability:
+    `core:window:allow-theme` is already inside `core:window:default`.
+  - Every path that used to assign `activeThemeId` (pick, fork, duplicate,
+    import) goes through `activationPatch`, which in system mode writes the id
+    into the half matching the theme's OWN mode. Without it a fork made while
+    following the system is thrown away by the next re-resolve. `pairedThemeId`
+    re-validates both halves on every read, because the theme editor can flip a
+    custom theme dark ↔ light behind the pairing's back — a pairing whose halves
+    share a mode never switches, which is the original bug wearing a disguise.
 - Never hardcode the accent hue: `var(--accent)` or
   `oklch(from var(--accent) l c h / <alpha>)`.
 - Fonts are vendored (`@fontsource-variable/*`). Inline `style={{…}}` with CSS

--- a/src/features/settings/systemAppearance.test.ts
+++ b/src/features/settings/systemAppearance.test.ts
@@ -1,0 +1,133 @@
+// The OS appearance source (#236).
+//
+// Two sources with different jobs, so both are pinned here: `prefers-color-
+// scheme` answers synchronously (no flash of the wrong theme at first paint,
+// and the only source in a plain browser tab), while Tauri's window theme +
+// `tauri://theme-changed` is authoritative and is what makes a switch at
+// sunset land mid-session.
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+import { installMatchMedia, uninstallMatchMedia } from "@/test/matchMediaStub";
+
+async function fresh() {
+  vi.resetModules();
+  return await import("./systemAppearance");
+}
+
+/** The mocked window from src/test/setup.ts, typed enough to steer. */
+function tauriWindow() {
+  return getCurrentWindow() as unknown as {
+    theme: ReturnType<typeof vi.fn>;
+    onThemeChanged: ReturnType<typeof vi.fn>;
+  };
+}
+
+beforeEach(() => {
+  uninstallMatchMedia();
+  tauriWindow().theme.mockResolvedValue(null);
+  tauriWindow().onThemeChanged.mockResolvedValue(() => {});
+});
+
+afterEach(() => {
+  uninstallMatchMedia();
+});
+
+describe("reading the OS appearance", () => {
+  it("reads prefers-color-scheme synchronously", async () => {
+    installMatchMedia("light");
+    const m = await fresh();
+    expect(m.getSystemAppearance()).toBe("light");
+  });
+
+  it("falls back to dark when nothing can answer", async () => {
+    // jsdom has no matchMedia at all, and a webview with no
+    // prefers-color-scheme support answers `false` to both queries. Neither is
+    // "light" — the app's historic appearance is the honest answer.
+    const m = await fresh();
+    expect(m.getSystemAppearance()).toBe("dark");
+  });
+
+  it("does not read 'not dark' as 'light'", async () => {
+    installMatchMedia(null); // both queries answer false
+    const m = await fresh();
+    expect(m.getSystemAppearance()).toBe("dark");
+    expect(m.readMediaQuery()).toBeNull();
+  });
+});
+
+describe("watching the OS appearance", () => {
+  it("delivers the Tauri window theme, which outranks the media query", async () => {
+    installMatchMedia("dark");
+    tauriWindow().theme.mockResolvedValue("light");
+    const m = await fresh();
+    const seen: string[] = [];
+    m.watchSystemAppearance((a) => seen.push(a));
+    await vi.waitFor(() => expect(seen).toEqual(["light"]));
+    expect(m.getSystemAppearance()).toBe("light");
+  });
+
+  it("re-resolves on tauri://theme-changed", async () => {
+    installMatchMedia("dark");
+    let fire: ((e: { payload: string }) => void) | null = null;
+    tauriWindow().onThemeChanged.mockImplementation(
+      async (handler: (e: { payload: string }) => void) => {
+        fire = handler;
+        return () => {};
+      },
+    );
+    const m = await fresh();
+    const seen: string[] = [];
+    m.watchSystemAppearance((a) => seen.push(a));
+    await vi.waitFor(() => expect(fire).not.toBeNull());
+    fire!({ payload: "light" });
+    expect(seen).toEqual(["light"]);
+    expect(m.getSystemAppearance()).toBe("light");
+  });
+
+  it("re-resolves on a prefers-color-scheme change", async () => {
+    const mq = installMatchMedia("dark");
+    const m = await fresh();
+    const seen: string[] = [];
+    m.watchSystemAppearance((a) => seen.push(a));
+    mq.set("light");
+    expect(seen).toEqual(["light"]);
+  });
+
+  it("reports a change once, not once per source", async () => {
+    const mq = installMatchMedia("dark");
+    tauriWindow().theme.mockResolvedValue("dark");
+    const m = await fresh();
+    const seen: string[] = [];
+    m.watchSystemAppearance((a) => seen.push(a));
+    await vi.waitFor(() => expect(tauriWindow().theme).toHaveBeenCalled());
+    // The window theme agreed with the media query — nothing changed, so
+    // nothing is reported and the theme is not re-applied for no reason.
+    expect(seen).toEqual([]);
+    mq.set("light");
+    expect(seen).toEqual(["light"]);
+  });
+
+  it("stops delivering after the returned unsubscribe", async () => {
+    const mq = installMatchMedia("dark");
+    const m = await fresh();
+    const seen: string[] = [];
+    const stop = m.watchSystemAppearance((a) => seen.push(a));
+    await vi.waitFor(() => expect(tauriWindow().onThemeChanged).toHaveBeenCalled());
+    stop();
+    mq.set("light");
+    expect(seen).toEqual([]);
+  });
+
+  it("survives a webview with no Tauri window API", async () => {
+    installMatchMedia("light");
+    tauriWindow().theme.mockRejectedValue(new Error("not running under Tauri"));
+    const m = await fresh();
+    const seen: string[] = [];
+    expect(() => m.watchSystemAppearance((a) => seen.push(a))).not.toThrow();
+    // The media query already answered at import; nothing is reported because
+    // nothing changed, and no unhandled rejection escapes.
+    await vi.waitFor(() => expect(tauriWindow().theme).toHaveBeenCalled());
+    expect(m.getSystemAppearance()).toBe("light");
+  });
+});

--- a/src/features/settings/systemAppearance.ts
+++ b/src/features/settings/systemAppearance.ts
@@ -1,0 +1,136 @@
+// The OS light/dark appearance, as THIS window observes it (#236).
+//
+// Deliberately not a setting. Nothing here is persisted or exported: it is a
+// fact about the machine at this moment, not something a person chose, and
+// importing "it was dark where this file was written" would be meaningless.
+// The same call `useUpdateStore.lastCheckedAt` got in #283.
+//
+// TWO SOURCES, because neither covers every platform or every moment:
+//
+//   `prefers-color-scheme` — synchronous, so it can answer during module load
+//     and the first paint is already the right theme instead of a flash of the
+//     other one. It is also the ONLY source outside Tauri (a plain `pnpm dev`
+//     browser tab, and the unit suite).
+//   `getCurrentWindow().theme()` + `tauri://theme-changed` — authoritative,
+//     and the one that actually fires when the OS switches at sunset. Async,
+//     so it refines the first answer rather than providing it.
+//
+// Both are per-window, which is what makes the merge resolver follow on its
+// own: it is a second Tauri window running the same bundle, and it subscribes
+// for itself rather than depending on the main window being open.
+
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+export type Appearance = "dark" | "light";
+
+/**
+ * The answer when no source can tell us.
+ *
+ * Dark, because that is the appearance this app has always had — a machine
+ * that cannot report its preference must not be handed a change.
+ */
+export const FALLBACK_APPEARANCE: Appearance = "dark";
+
+const DARK_QUERY = "(prefers-color-scheme: dark)";
+const LIGHT_QUERY = "(prefers-color-scheme: light)";
+
+function queryMatches(query: string): boolean {
+  try {
+    // jsdom implements no matchMedia at all; some embedded webviews implement
+    // it without the color-scheme feature.
+    return window.matchMedia?.(query)?.matches === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * What `prefers-color-scheme` says, or null when it cannot say.
+ *
+ * BOTH queries are asked, never only the dark one. A webview with no support
+ * for the feature answers `false` to both — indistinguishable from "light" if
+ * you only ask about dark, and reading that as light would flip the app's
+ * appearance on exactly the platforms that cannot correct it.
+ */
+export function readMediaQuery(): Appearance | null {
+  if (queryMatches(DARK_QUERY)) return "dark";
+  if (queryMatches(LIGHT_QUERY)) return "light";
+  return null;
+}
+
+let observed: Appearance = readMediaQuery() ?? FALLBACK_APPEARANCE;
+
+/** The last observed appearance. Available synchronously, from module load. */
+export function getSystemAppearance(): Appearance {
+  return observed;
+}
+
+/**
+ * Record an observation. Returns true only when it actually changed, so the
+ * two sources agreeing costs nothing — no re-resolve, no re-apply, no write.
+ */
+export function setSystemAppearance(next: Appearance): boolean {
+  if (next === observed) return false;
+  observed = next;
+  return true;
+}
+
+/**
+ * Subscribe this window to the OS appearance for as long as it lives.
+ *
+ * `onChange` fires only on a real change (see `setSystemAppearance`), never
+ * with the value already in hand — the caller has `getSystemAppearance()` for
+ * that and has already used it.
+ */
+export function watchSystemAppearance(
+  onChange: (appearance: Appearance) => void,
+): () => void {
+  let live = true;
+  const cleanups: Array<() => void> = [];
+
+  const deliver = (next: Appearance | null) => {
+    if (!live || !next) return;
+    if (setSystemAppearance(next)) onChange(next);
+  };
+
+  // Source 1 — the media query.
+  try {
+    const mq = window.matchMedia?.(DARK_QUERY);
+    if (mq?.addEventListener) {
+      const handler = (e: MediaQueryListEvent) =>
+        deliver(e.matches ? "dark" : "light");
+      mq.addEventListener("change", handler);
+      cleanups.push(() => mq.removeEventListener("change", handler));
+    }
+  } catch {
+    // No matchMedia: source 2 is the whole answer here.
+  }
+
+  // Source 2 — the Tauri window theme. Async, and absent entirely outside
+  // Tauri, so every step is guarded: a browser tab must degrade to source 1
+  // rather than throwing an unhandled rejection out of module load.
+  void (async () => {
+    try {
+      const win = getCurrentWindow();
+      const now = await win.theme?.();
+      deliver(now === "dark" || now === "light" ? now : null);
+      const unlisten = await win.onThemeChanged?.(({ payload }) => {
+        deliver(payload === "dark" || payload === "light" ? payload : null);
+      });
+      if (!unlisten) return;
+      // The caller may have unsubscribed while we were awaiting.
+      if (!live) {
+        unlisten();
+        return;
+      }
+      cleanups.push(unlisten);
+    } catch {
+      // Not running under Tauri, or the window API is unavailable.
+    }
+  })();
+
+  return () => {
+    live = false;
+    for (const off of cleanups.splice(0)) off();
+  };
+}

--- a/src/features/settings/themePreference.test.ts
+++ b/src/features/settings/themePreference.test.ts
@@ -1,0 +1,379 @@
+// "Follow the system appearance" (#236).
+//
+// The load-bearing tests are the two that protect people who did nothing:
+//
+//   * THE MIGRATION — every install that predates this feature holds an
+//     `activeThemeId` and no `themePreference`. It must land on "fixed" with
+//     the same theme on screen. Nobody's app changes appearance because they
+//     updated.
+//   * THE FALLBACKS — an unknown mode, a half of the pair naming a theme this
+//     machine does not have, a custom theme flipped from dark to light behind
+//     the pairing's back. Each has to leave a real theme applied; "themeless"
+//     is not an outcome the app can render.
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+import { installMatchMedia, uninstallMatchMedia } from "@/test/matchMediaStub";
+
+const STORAGE_KEY = "pg-settings-v2";
+
+/** The store applies the theme at module load, so every test re-imports. */
+async function freshStore() {
+  vi.resetModules();
+  return await import("./useSettingsStore");
+}
+
+const appliedThemeId = () => document.documentElement.dataset.theme;
+const appliedMode = () => document.documentElement.dataset.themeMode;
+
+/** A minimal but complete custom theme, so a pairing can name a non-builtin. */
+function customTheme(id: string, mode: "dark" | "light") {
+  return {
+    id,
+    name: id,
+    mode,
+    colors: {
+      bg0: "#111111", bg1: "#161616", bg2: "#1c1c1c", bg3: "#222222",
+      bg4: "#2a2a2a", titlebar: "#141414", fg0: "#eeeeee", fg1: "#cccccc",
+      fg2: "#999999", fg3: "#777777", fg4: "#555555", border0: "#2a2a2a",
+      border1: "#333333", border2: "#444444", accent: "#ff6600",
+      accentInk: "#111111", logo: "#3e9b91", logo2: "#e6a95a",
+    },
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  uninstallMatchMedia();
+});
+
+afterEach(() => {
+  uninstallMatchMedia();
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// THE MIGRATION
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("an install from before themePreference existed", () => {
+  it("lands on fixed with its theme untouched, whatever the OS is doing", async () => {
+    installMatchMedia("light"); // the OS is light; the app must not care
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ activeThemeId: "nord" }));
+    const { useSettingsStore } = await freshStore();
+    const s = useSettingsStore.getState();
+    expect(s.themePreference.mode).toBe("fixed");
+    expect(s.activeThemeId).toBe("nord");
+    expect(appliedThemeId()).toBe("nord");
+    expect(appliedMode()).toBe("dark");
+  });
+
+  it("seeds the matching half of the pair from the theme it was already on", async () => {
+    // So the day they DO switch to "Follow system", the half they were already
+    // in is the one they kept — not the built-in pairing.
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ activeThemeId: "gruvbox-dark" }));
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().themePreference.darkId).toBe("gruvbox-dark");
+    expect(useSettingsStore.getState().themePreference.lightId).toBe("light");
+  });
+
+  it("seeds from a custom theme too", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        activeThemeId: "mine",
+        customThemes: [customTheme("mine", "light")],
+      }),
+    );
+    const { useSettingsStore } = await freshStore();
+    const pref = useSettingsStore.getState().themePreference;
+    expect(pref.lightId).toBe("mine");
+    expect(pref.darkId).toBe("dark-cool");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// FRESH INSTALLS
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("a fresh install", () => {
+  it("is fixed on dark-cool, exactly as before this feature", async () => {
+    installMatchMedia("light");
+    const { useSettingsStore } = await freshStore();
+    const s = useSettingsStore.getState();
+    expect(s.themePreference).toEqual({
+      mode: "fixed",
+      lightId: "light",
+      darkId: "dark-cool",
+    });
+    expect(appliedThemeId()).toBe("dark-cool");
+  });
+
+  it("follows the system the moment the mode is switched, with no other setup", async () => {
+    installMatchMedia("light");
+    const { useSettingsStore } = await freshStore();
+    useSettingsStore.getState().setThemeFollowMode("system");
+    expect(useSettingsStore.getState().activeThemeId).toBe("light");
+    expect(appliedThemeId()).toBe("light");
+    expect(appliedMode()).toBe("light");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// RESOLUTION
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("system mode", () => {
+  it("resolves to the dark half when the OS reports dark", async () => {
+    installMatchMedia("dark");
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        activeThemeId: "light",
+        themePreference: { mode: "system", lightId: "github-light", darkId: "nord" },
+      }),
+    );
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().activeThemeId).toBe("nord");
+    expect(appliedThemeId()).toBe("nord");
+    expect(appliedMode()).toBe("dark");
+  });
+
+  it("resolves to the light half when the OS reports light", async () => {
+    installMatchMedia("light");
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        activeThemeId: "nord",
+        themePreference: { mode: "system", lightId: "github-light", darkId: "nord" },
+      }),
+    );
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().activeThemeId).toBe("github-light");
+    expect(appliedThemeId()).toBe("github-light");
+    expect(appliedMode()).toBe("light");
+  });
+
+  it("re-resolves and re-applies when the OS switches mid-session", async () => {
+    installMatchMedia("dark");
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        themePreference: { mode: "system", lightId: "github-light", darkId: "nord" },
+      }),
+    );
+    const { useSettingsStore, BUILTIN_THEMES } = await freshStore();
+    expect(appliedThemeId()).toBe("nord");
+
+    useSettingsStore.getState().syncSystemAppearance("light");
+    expect(useSettingsStore.getState().systemAppearance).toBe("light");
+    expect(useSettingsStore.getState().activeThemeId).toBe("github-light");
+    expect(appliedThemeId()).toBe("github-light");
+    // On Windows/Linux the titlebar is OURS, painted from --bg-titlebar — so
+    // "the titlebar follows too" is exactly applyTheme having re-run.
+    const target = BUILTIN_THEMES.find((t) => t.id === "github-light")!;
+    expect(document.documentElement.style.getPropertyValue("--bg-titlebar")).toBe(
+      target.colors.titlebar,
+    );
+  });
+
+  it("leaves a fixed install alone when the OS switches", async () => {
+    installMatchMedia("dark");
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ activeThemeId: "dracula" }));
+    const { useSettingsStore } = await freshStore();
+    useSettingsStore.getState().syncSystemAppearance("light");
+    // Observed, and recorded — but nothing on screen moves.
+    expect(useSettingsStore.getState().systemAppearance).toBe("light");
+    expect(useSettingsStore.getState().activeThemeId).toBe("dracula");
+    expect(appliedThemeId()).toBe("dracula");
+  });
+
+  it("switching back to fixed keeps whatever is on screen", async () => {
+    installMatchMedia("light");
+    const { useSettingsStore } = await freshStore();
+    useSettingsStore.getState().setThemeFollowMode("system");
+    expect(useSettingsStore.getState().activeThemeId).toBe("light");
+    useSettingsStore.getState().setThemeFollowMode("fixed");
+    expect(useSettingsStore.getState().activeThemeId).toBe("light");
+    useSettingsStore.getState().syncSystemAppearance("dark");
+    expect(useSettingsStore.getState().activeThemeId).toBe("light");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// VALIDATION — a hand-edited or foreign payload must not poison the store
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("a payload the app did not write", () => {
+  it("reads an unknown mode as fixed, so activeThemeId still answers", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        activeThemeId: "dracula",
+        themePreference: { mode: "auto", lightId: "light", darkId: "nord" },
+      }),
+    );
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().themePreference.mode).toBe("fixed");
+    expect(appliedThemeId()).toBe("dracula");
+  });
+
+  it("repairs a half that names a theme this machine does not have", async () => {
+    installMatchMedia("light");
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        themePreference: { mode: "system", lightId: "someone-elses-theme", darkId: "nord" },
+      }),
+    );
+    const { useSettingsStore } = await freshStore();
+    const s = useSettingsStore.getState();
+    // Repaired in state, not merely resolved around — the Settings picker has
+    // to show what the app will actually use.
+    expect(s.themePreference.lightId).toBe("light");
+    expect(s.themePreference.darkId).toBe("nord");
+    expect(appliedThemeId()).toBe("light");
+  });
+
+  it("repairs a half that names a theme of the wrong mode", async () => {
+    // Otherwise "follow the system" resolves to the same half twice and the
+    // app never switches — the exact bug the feature exists to fix.
+    installMatchMedia("dark");
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        themePreference: { mode: "system", lightId: "light", darkId: "github-light" },
+      }),
+    );
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().themePreference.darkId).toBe("dark-cool");
+    expect(appliedMode()).toBe("dark");
+  });
+
+  it("survives a missing half, a wrong type and a non-object", async () => {
+    for (const themePreference of [
+      { mode: "system" },
+      { mode: "system", lightId: 7, darkId: null },
+      "system",
+      [],
+      null,
+    ]) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ themePreference }));
+      const { useSettingsStore } = await freshStore();
+      const pref = useSettingsStore.getState().themePreference;
+      expect(typeof pref.lightId).toBe("string");
+      expect(typeof pref.darkId).toBe("string");
+      expect(["system", "fixed"]).toContain(pref.mode);
+      // Whatever the payload said, a real theme is on screen.
+      expect(useSettingsStore.getState().getActiveTheme().colors.bg0).toBeTruthy();
+      expect(appliedThemeId()).toBeTruthy();
+    }
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// LIVING WITH THE PAIRING
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("editing themes while following the system", () => {
+  it("picking a theme writes the half matching its OWN mode", async () => {
+    installMatchMedia("dark");
+    const { useSettingsStore } = await freshStore();
+    const s = () => useSettingsStore.getState();
+    s().setThemeFollowMode("system");
+    // A light theme picked while the OS is dark is the light half of the pair.
+    // It does not win the screen — that would break the promise of the mode.
+    s().setActiveThemeId("github-light");
+    expect(s().themePreference.lightId).toBe("github-light");
+    expect(s().activeThemeId).toBe("dark-cool");
+    // A dark one does take effect immediately.
+    s().setActiveThemeId("dracula");
+    expect(s().themePreference.darkId).toBe("dracula");
+    expect(s().activeThemeId).toBe("dracula");
+  });
+
+  it("a fork of the active theme survives the next re-resolve", async () => {
+    installMatchMedia("dark");
+    const { useSettingsStore } = await freshStore();
+    const s = () => useSettingsStore.getState();
+    s().setThemeFollowMode("system");
+    // Editing a builtin auto-duplicates it; in system mode the duplicate has
+    // to become the dark half, or the next OS flip throws the fork away.
+    s().updateActiveColors({ accent: "#ff0000" });
+    const forkId = s().activeThemeId;
+    expect(forkId).not.toBe("dark-cool");
+    s().syncSystemAppearance("light");
+    s().syncSystemAppearance("dark");
+    expect(s().activeThemeId).toBe(forkId);
+  });
+
+  it("deleting a paired theme repairs the pair instead of leaving it dangling", async () => {
+    installMatchMedia("dark");
+    const { useSettingsStore } = await freshStore();
+    const s = () => useSettingsStore.getState();
+    s().setThemeFollowMode("system");
+    const fork = s().saveAsNewTheme("Mine");
+    expect(s().themePreference.darkId).toBe(fork.id);
+    s().deleteTheme(fork.id);
+    expect(s().themePreference.darkId).toBe("dark-cool");
+    expect(s().activeThemeId).toBe("dark-cool");
+    expect(appliedThemeId()).toBe("dark-cool");
+  });
+
+  it("setPairedThemeId refuses a theme of the wrong mode", async () => {
+    const { useSettingsStore } = await freshStore();
+    const s = () => useSettingsStore.getState();
+    s().setPairedThemeId("light", "nord");
+    expect(s().themePreference.lightId).toBe("light");
+    s().setPairedThemeId("light", "github-light");
+    expect(s().themePreference.lightId).toBe("github-light");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// PERSISTENCE
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("what reaches localStorage", () => {
+  it("persists the preference and never the observed appearance", async () => {
+    installMatchMedia("light");
+    const { useSettingsStore } = await freshStore();
+    useSettingsStore.getState().setThemeFollowMode("system");
+    const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}");
+    expect(raw.themePreference).toEqual({
+      mode: "system",
+      lightId: "light",
+      darkId: "dark-cool",
+    });
+    // Observed state about THIS machine at THIS moment — not a setting.
+    expect(raw).not.toHaveProperty("systemAppearance");
+  });
+
+  it("re-resolves when the preference goes through the generic setter", async () => {
+    // `set(key, value)` is public API and must not be a back door around the
+    // resolve — a preference set without re-deriving activeThemeId leaves
+    // "follow the system" on with the wrong half on screen.
+    installMatchMedia("light");
+    const { useSettingsStore } = await freshStore();
+    useSettingsStore.getState().set("themePreference", {
+      mode: "system",
+      lightId: "github-light",
+      darkId: "nord",
+    });
+    expect(useSettingsStore.getState().activeThemeId).toBe("github-light");
+    expect(appliedThemeId()).toBe("github-light");
+  });
+
+  it("re-resolves at load from the OS, not from the persisted active id", async () => {
+    // The persisted `activeThemeId` is a cache of the last resolution. Booting
+    // on the other appearance must not honour it.
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        activeThemeId: "nord",
+        themePreference: { mode: "system", lightId: "github-light", darkId: "nord" },
+      }),
+    );
+    installMatchMedia("light");
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().activeThemeId).toBe("github-light");
+  });
+});

--- a/src/features/settings/useSettingsStore.export.test.ts
+++ b/src/features/settings/useSettingsStore.export.test.ts
@@ -65,6 +65,12 @@ const PORTABLE = [
   "ignoreWhitespaceInDiff",
   "pruneOnFetch",
   "signCommits",
+  // A pairing of a light and a dark theme plus which one to follow (#236). A
+  // preference like any other — it says what the person likes, not what the
+  // machine is — so it travels. The OS appearance it RESOLVES against does
+  // not: that is observed state, it is not in PersistedState at all, and the
+  // "no systemAppearance" assertions below pin that.
+  "themePreference",
   "uiDensity",
   "uiZoom",
   "updateCheckMode",
@@ -95,6 +101,48 @@ describe("the exported key set", () => {
     const store = await freshStore();
     store.useSettingsStore.getState().set("updateCheckMode", "never");
     expect(exported(store).settings.updateCheckMode).toBe("never");
+  });
+
+  it("carries themePreference, and never the appearance it resolved against", async () => {
+    const store = await freshStore();
+    store.useSettingsStore.getState().setThemeFollowMode("system");
+    const json = store.useSettingsStore.getState().exportSettings();
+    const payload = JSON.parse(json) as Payload;
+    expect(payload.settings.themePreference).toEqual({
+      mode: "system",
+      lightId: "light",
+      darkId: "dark-cool",
+    });
+    // "It was dark on the machine that wrote this file" is not a preference —
+    // it is a fact about that machine at that moment, and importing it would
+    // be meaningless. Same call #283 made for the update store's lastCheckedAt.
+    expect(payload.settings).not.toHaveProperty("systemAppearance");
+    expect(json).not.toContain("systemAppearance");
+  });
+
+  it("repairs an imported pairing that names a theme this machine lacks", async () => {
+    const store = await freshStore();
+    const report = store.useSettingsStore.getState().importSettings(
+      JSON.stringify({
+        kind: "platypusgit-settings",
+        version: 1,
+        settings: {
+          themePreference: {
+            mode: "system",
+            lightId: "their-custom-light",
+            darkId: "their-custom-dark",
+          },
+        },
+      }),
+    );
+    const s = store.useSettingsStore.getState();
+    expect(s.themePreference).toEqual({
+      mode: "system",
+      lightId: "light",
+      darkId: "dark-cool",
+    });
+    expect(s.getActiveTheme().id).toBe("dark-cool");
+    expect(report.changed).toContain("themePreference");
   });
 
   it("leaves lastCreateDir behind — it names a directory on ONE machine", async () => {
@@ -188,6 +236,8 @@ function moveEverything(store: Store) {
   set("diffContextMode", "chunks");
   set("ignoreWhitespaceInDiff", true);
   set("updateCheckMode", "manual");
+  store.useSettingsStore.getState().setPairedThemeId("light", "github-light");
+  store.useSettingsStore.getState().setThemeFollowMode("system");
 }
 
 function portableSnapshot(state: Record<string, unknown>) {

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -8,6 +8,11 @@ import {
   type HeadMark,
   type HeadWeight,
 } from "./headMarks";
+import {
+  getSystemAppearance,
+  watchSystemAppearance,
+  type Appearance,
+} from "./systemAppearance";
 
 const STORAGE_KEY = "pg-settings-v2";
 
@@ -508,6 +513,121 @@ export function applyTheme(theme: ThemeDef) {
   root.dataset.themeMode = theme.mode;
 }
 
+// ═════════════════════════════════════════════════════════════════════════════
+// THEME PREFERENCE — following the system appearance (#236)
+// ═════════════════════════════════════════════════════════════════════════════
+
+export type ThemeFollowMode = "system" | "fixed";
+
+export const THEME_FOLLOW_MODES: readonly ThemeFollowMode[] = ["fixed", "system"];
+
+/**
+ * Which theme to apply, and on whose say-so.
+ *
+ * A PAIR plus a mode, rather than a third magic value in `activeThemeId`. A
+ * theme is intrinsically one mode (`ThemeDef.mode`), so "follow the system"
+ * cannot be a theme — it is a rule for choosing between two of them, and the
+ * person gets to say WHICH light and WHICH dark, not just "the light one".
+ *
+ * `activeThemeId` stays the single answer to "what is on screen":
+ *
+ *   fixed  — `activeThemeId` is the user's choice and nothing moves it.
+ *   system — `activeThemeId` is DERIVED from this pair and the observed OS
+ *            appearance, and is rewritten every time the OS switches.
+ *
+ * Keeping it derived rather than adding a second "resolved id" field is what
+ * makes the feature invisible downstream: `getActiveTheme`, the theme editor
+ * and `DiffMinimap`'s repaint subscription all keep working unchanged, and the
+ * minimap repaints on an OS switch for free.
+ */
+export interface ThemePreference {
+  mode: ThemeFollowMode;
+  /** Theme id used while the OS is light. Must name a `mode: "light"` theme. */
+  lightId: string;
+  /** Theme id used while the OS is dark. Must name a `mode: "dark"` theme. */
+  darkId: string;
+}
+
+/**
+ * The built-in pairing, so "Follow system" works the instant it is chosen with
+ * nothing else configured.
+ *
+ * The default MODE is `fixed`, not `system`: every install before #236 was
+ * effectively fixed, and a fresh install that suddenly renders light on a light
+ * Mac is a different product decision from the one this feature asked for.
+ * Following the system is one click away and needs no further setup.
+ */
+export const DEFAULT_THEME_PREFERENCE: ThemePreference = {
+  mode: "fixed",
+  lightId: "light",
+  darkId: "dark-cool",
+};
+
+/**
+ * The id one half of the pairing names, validated.
+ *
+ * Validated on every read rather than only at load, because the pairing can be
+ * broken from behind: the theme editor lets a custom theme be flipped from dark
+ * to light (and writes `customThemes` directly), which would otherwise leave
+ * `darkId` naming a light theme and the app resolving to the same half twice —
+ * i.e. not switching at all, the exact bug this feature exists to fix.
+ */
+function pairedThemeId(
+  pref: ThemePreference,
+  appearance: Appearance,
+  customThemes: ThemeDef[],
+): string {
+  const wanted = appearance === "light" ? pref.lightId : pref.darkId;
+  const found = findTheme({ customThemes }, wanted);
+  if (found && found.mode === appearance) return wanted;
+  return appearance === "light"
+    ? DEFAULT_THEME_PREFERENCE.lightId
+    : DEFAULT_THEME_PREFERENCE.darkId;
+}
+
+/** What `activeThemeId` should be, for a given state and OS appearance. */
+function resolveActiveThemeId(
+  s: Pick<PersistedState, "themePreference" | "customThemes" | "activeThemeId">,
+  appearance: Appearance,
+): string {
+  return s.themePreference.mode === "system"
+    ? pairedThemeId(s.themePreference, appearance, s.customThemes)
+    : s.activeThemeId;
+}
+
+/**
+ * The `{ activeThemeId, themePreference }` patch that makes `theme` the user's
+ * choice.
+ *
+ * In system mode "which theme is active" is not a free choice, so every path
+ * that used to just assign `activeThemeId` (pick, fork, duplicate, import)
+ * routes through here instead: the id goes into the half matching the theme's
+ * OWN mode, and what ends up on screen is still whatever the OS asked for.
+ * Without this, a fork made while following the system is thrown away by the
+ * next re-resolve.
+ *
+ * `customThemes` is a parameter because three callers create the theme in the
+ * same breath — it is not in the store's list yet.
+ */
+function activationPatch(
+  s: Pick<PersistedState, "themePreference">,
+  theme: ThemeDef,
+  appearance: Appearance,
+  customThemes: ThemeDef[],
+): Pick<PersistedState, "activeThemeId" | "themePreference"> {
+  if (s.themePreference.mode !== "system") {
+    return { activeThemeId: theme.id, themePreference: s.themePreference };
+  }
+  const themePreference: ThemePreference = {
+    ...s.themePreference,
+    ...(theme.mode === "light" ? { lightId: theme.id } : { darkId: theme.id }),
+  };
+  return {
+    themePreference,
+    activeThemeId: pairedThemeId(themePreference, appearance, customThemes),
+  };
+}
+
 /**
  * Extra vertical pixels each row-ish surface adds for a given density.
  *
@@ -638,7 +758,15 @@ export const UPDATE_CHECK_MODES: readonly UpdateCheckMode[] = [
 // flag reaches the diff READ paths only, and every surface disables its
 // hunk-level stage/discard while it is on.
 interface PersistedState {
+  /**
+   * The theme on screen. In `themePreference.mode === "system"` this is
+   * DERIVED — recomputed from the pairing every time the OS appearance
+   * changes — and it is still persisted, as the cache that lets the next
+   * launch paint before the async window-theme query answers.
+   */
   activeThemeId: string;
+  /** Which theme to apply and on whose say-so (#236). See ThemePreference. */
+  themePreference: ThemePreference;
   customThemes: ThemeDef[];
   uiDensity: "compact" | "comfortable";
   /** Webview zoom factor — 1 is 100%. See applyZoom. */
@@ -697,8 +825,34 @@ interface PersistedState {
 }
 
 export interface SettingsState extends PersistedState {
+  /**
+   * The OS appearance this window last observed.
+   *
+   * NOT in `PersistedState`, and that is the whole point: it is observed state
+   * about this machine right now, so it is neither written to localStorage nor
+   * carried by a settings export. `snapshot()` and `PORTABLE_KEYS` both derive
+   * from `DEFAULTS`, so staying out of the schema keeps it out of both by
+   * construction. Same call #283 made for `useUpdateStore.lastCheckedAt`.
+   *
+   * It lives on the store rather than only in the `systemAppearance` module so
+   * the Settings screen re-renders when it flips.
+   */
+  systemAppearance: Appearance;
   getActiveTheme: () => ThemeDef;
   setActiveThemeId: (id: string) => void;
+  /** Switch between following the OS and one fixed theme. */
+  setThemeFollowMode: (mode: ThemeFollowMode) => void;
+  /**
+   * Choose the theme for one half of the pairing. A theme whose own mode is
+   * not `appearance` is refused — the pairing would resolve to the same half
+   * twice and stop switching.
+   */
+  setPairedThemeId: (appearance: Appearance, id: string) => void;
+  /**
+   * Record a new OS appearance and re-resolve. Called by the watcher started
+   * in `main.tsx`; exported so a test can flip the OS without one.
+   */
+  syncSystemAppearance: (appearance: Appearance) => void;
   updateActiveColors: (patch: Partial<ThemeColors>) => void;
   saveAsNewTheme: (name: string) => ThemeDef;
   renameTheme: (id: string, name: string) => void;
@@ -732,6 +886,7 @@ export interface SettingsState extends PersistedState {
 
 const DEFAULTS: PersistedState = {
   activeThemeId: "dark-cool",
+  themePreference: { ...DEFAULT_THEME_PREFERENCE },
   customThemes: [],
   uiDensity: "compact",
   uiZoom: 1,
@@ -936,6 +1091,55 @@ function normalizeCustomThemes(value: unknown, fallback: ThemeDef[]): ThemeDef[]
   return out;
 }
 
+/**
+ * Coerce a persisted or imported value into a usable `ThemePreference`.
+ *
+ * Its own normalizer for the same reason `customThemes` and `headMarks` have
+ * one: the scalar type-guard in `coerceSettings` compares against
+ * `typeof DEFAULTS[key]`, and every object-valued setting is `"object"` — so a
+ * hand-edited `{ mode: "auto" }`, a `lightId` of `7`, or a bare string would
+ * all sail through it.
+ *
+ * An unknown mode reads as `fixed`, never `system`: fixed falls back on
+ * `activeThemeId`, which always resolves (`getActiveTheme` ends at
+ * `BUILTIN_THEMES[0]`), so the worst case is the theme the person already had
+ * rather than an app with no theme at all.
+ */
+function normalizeThemePreference(value: unknown): ThemePreference {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { ...DEFAULT_THEME_PREFERENCE };
+  }
+  const o = value as Record<string, unknown>;
+  const id = (raw: unknown, fallback: string) =>
+    typeof raw === "string" && raw.trim() ? raw.trim() : fallback;
+  return {
+    mode: o.mode === "system" ? "system" : "fixed",
+    lightId: id(o.lightId, DEFAULT_THEME_PREFERENCE.lightId),
+    darkId: id(o.darkId, DEFAULT_THEME_PREFERENCE.darkId),
+  };
+}
+
+/**
+ * Point the half matching `activeThemeId`'s own mode at it.
+ *
+ * The migration for every install that predates #236: they hold an
+ * `activeThemeId` and no `themePreference`, and they land on `fixed` — so
+ * nothing changes appearance on upgrade. But the day they DO switch to
+ * "Follow system", handing them the built-in pairing would take away the theme
+ * they had been using for years. Seeding costs one lookup and keeps it.
+ */
+function seedPairingFrom(
+  pref: ThemePreference,
+  activeThemeId: string,
+  customThemes: ThemeDef[],
+): ThemePreference {
+  const active = findTheme({ customThemes }, activeThemeId);
+  if (!active) return pref;
+  return active.mode === "light"
+    ? { ...pref, lightId: active.id }
+    : { ...pref, darkId: active.id };
+}
+
 interface CoercedSettings {
   state: PersistedState;
   /** Keys whose value ended up different from `base`. */
@@ -1057,6 +1261,44 @@ function coerceSettings(
   // anything unusable, and keep the ids so `activeThemeId` still resolves.
   out.customThemes = normalizeCustomThemes(out.customThemes, base.customThemes);
 
+  // THEME PREFERENCE (#236). Runs after `customThemes` so both the repair and
+  // the seed can see the theme list this payload actually brings.
+  //
+  // Absent means an install from before the feature existed: it keeps `base`'s
+  // preference — DEFAULTS for `load()`, so `fixed`, so nothing on screen moves
+  // on upgrade — and the half matching the theme they were already on is
+  // seeded from it. Seeded only when the preference is still untouched, or an
+  // import of an OLD file would silently overwrite a pairing this install has
+  // since configured.
+  if ("themePreference" in parsed) {
+    out.themePreference = normalizeThemePreference(parsed.themePreference);
+  } else if (sameValue(base.themePreference, DEFAULTS.themePreference)) {
+    out.themePreference = seedPairingFrom(
+      base.themePreference,
+      out.activeThemeId,
+      out.customThemes,
+    );
+  }
+  // Repair a half naming a theme this machine does not have, or one whose mode
+  // no longer matches. Written BACK rather than only resolved around, so the
+  // Settings pickers show the theme the app will actually use.
+  out.themePreference = {
+    ...out.themePreference,
+    lightId: pairedThemeId(out.themePreference, "light", out.customThemes),
+    darkId: pairedThemeId(out.themePreference, "dark", out.customThemes),
+  };
+  // In system mode `activeThemeId` is derived, so it is re-derived here rather
+  // than trusted: the persisted value is only a cache of the last resolution,
+  // and an imported one records whichever half was on screen on someone else's
+  // machine. This machine's own appearance is the only correct answer.
+  if (out.themePreference.mode === "system") {
+    out.activeThemeId = pairedThemeId(
+      out.themePreference,
+      getSystemAppearance(),
+      out.customThemes,
+    );
+  }
+
   const changed = (Object.keys(DEFAULTS) as (keyof PersistedState)[]).filter(
     (key) => !sameValue(out[key], base[key]),
   );
@@ -1110,6 +1352,11 @@ function findTheme(
     BUILTIN_THEMES.find((t) => t.id === id) ??
     state.customThemes.find((t) => t.id === id)
   );
+}
+
+/** Re-apply whatever the state now resolves to. */
+function applyResolved(s: SettingsState): void {
+  applyTheme(findTheme(s, s.activeThemeId) ?? BUILTIN_THEMES[0]);
 }
 
 function uniqueId(existing: ThemeDef[]): string {
@@ -1175,6 +1422,10 @@ const initial = load();
 
 export const useSettingsStore = create<SettingsState>((set, get) => ({
   ...initial,
+  // Read synchronously from `prefers-color-scheme` at module load; the Tauri
+  // window theme refines it a tick later (see startSystemAppearanceWatch), so
+  // the first paint is already right instead of flashing the other half.
+  systemAppearance: getSystemAppearance(),
 
   getActiveTheme() {
     const s = get();
@@ -1188,9 +1439,54 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     const s = get();
     const theme = findTheme(s, id);
     if (!theme) return;
-    set({ activeThemeId: id });
+    set(activationPatch(s, theme, s.systemAppearance, s.customThemes));
     persist(snapshot(get()));
-    applyTheme(theme);
+    applyResolved(get());
+  },
+
+  setThemeFollowMode(mode) {
+    const s = get();
+    if (s.themePreference.mode === mode) return;
+    const themePreference: ThemePreference = { ...s.themePreference, mode };
+    // Going system → fixed keeps whatever is on screen: `activeThemeId` is
+    // already the resolved half, so "fixed" means "stop here", which is the
+    // only reading that does not surprise the person who just clicked it.
+    set({
+      themePreference,
+      activeThemeId: resolveActiveThemeId({ ...s, themePreference }, s.systemAppearance),
+    });
+    persist(snapshot(get()));
+    applyResolved(get());
+  },
+
+  setPairedThemeId(appearance, id) {
+    const s = get();
+    const theme = findTheme(s, id);
+    if (!theme || theme.mode !== appearance) return;
+    const themePreference: ThemePreference = {
+      ...s.themePreference,
+      ...(appearance === "light" ? { lightId: id } : { darkId: id }),
+    };
+    set({
+      themePreference,
+      activeThemeId: resolveActiveThemeId({ ...s, themePreference }, s.systemAppearance),
+    });
+    persist(snapshot(get()));
+    applyResolved(get());
+  },
+
+  syncSystemAppearance(appearance) {
+    const s = get();
+    if (s.systemAppearance === appearance) return;
+    set({ systemAppearance: appearance });
+    // A fixed install records the observation (Settings shows it) and stops
+    // there — nothing on screen moves, and nothing is written.
+    if (s.themePreference.mode !== "system") return;
+    const activeThemeId = resolveActiveThemeId(s, appearance);
+    if (activeThemeId === s.activeThemeId) return;
+    set({ activeThemeId });
+    persist(snapshot(get()));
+    applyResolved(get());
   },
 
   updateActiveColors(patch) {
@@ -1206,12 +1502,13 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
         mode: active.mode,
         colors: { ...active.colors, ...patch },
       };
+      const customThemes = [...s.customThemes, dup];
       set({
-        customThemes: [...s.customThemes, dup],
-        activeThemeId: dup.id,
+        customThemes,
+        ...activationPatch(s, dup, s.systemAppearance, customThemes),
       });
       persist(snapshot(get()));
-      applyTheme(dup);
+      applyResolved(get());
       return;
     }
 
@@ -1235,12 +1532,13 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       mode: active.mode,
       colors: { ...active.colors },
     };
+    const customThemes = [...s.customThemes, dup];
     set({
-      customThemes: [...s.customThemes, dup],
-      activeThemeId: dup.id,
+      customThemes,
+      ...activationPatch(s, dup, s.systemAppearance, customThemes),
     });
     persist(snapshot(get()));
-    applyTheme(dup);
+    applyResolved(get());
     return dup;
   },
 
@@ -1254,12 +1552,13 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
       mode: src.mode,
       colors: { ...src.colors },
     };
+    const customThemes = [...s.customThemes, dup];
     set({
-      customThemes: [...s.customThemes, dup],
-      activeThemeId: dup.id,
+      customThemes,
+      ...activationPatch(s, dup, s.systemAppearance, customThemes),
     });
     persist(snapshot(get()));
-    applyTheme(dup);
+    applyResolved(get());
     return dup;
   },
 
@@ -1279,13 +1578,24 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     const s = get();
     if (!s.customThemes.some((t) => t.id === id)) return;
     const next = s.customThemes.filter((t) => t.id !== id);
-    const nextActive =
-      s.activeThemeId === id ? "dark-cool" : s.activeThemeId;
-    set({ customThemes: next, activeThemeId: nextActive });
+    // The pairing can name the theme being deleted, in either half. Repair
+    // both against the surviving list rather than only the active one: a
+    // dangling `lightId` is invisible until sunrise, which is the worst time
+    // to discover it.
+    const themePreference: ThemePreference = {
+      ...s.themePreference,
+      lightId: pairedThemeId(s.themePreference, "light", next),
+      darkId: pairedThemeId(s.themePreference, "dark", next),
+    };
+    const activeThemeId =
+      themePreference.mode === "system"
+        ? pairedThemeId(themePreference, s.systemAppearance, next)
+        : s.activeThemeId === id
+          ? DEFAULT_THEME_PREFERENCE.darkId
+          : s.activeThemeId;
+    set({ customThemes: next, themePreference, activeThemeId });
     persist(snapshot(get()));
-    if (s.activeThemeId === id) {
-      applyTheme(BUILTIN_THEMES[0]);
-    }
+    if (activeThemeId !== s.activeThemeId) applyResolved(get());
   },
 
   exportTheme(id) {
@@ -1324,12 +1634,13 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
     const s = get();
     // Ensure id is unique among customs.
     theme.id = uniqueId(s.customThemes);
+    const customThemes = [...s.customThemes, theme];
     set({
-      customThemes: [...s.customThemes, theme],
-      activeThemeId: theme.id,
+      customThemes,
+      ...activationPatch(s, theme, s.systemAppearance, customThemes),
     });
     persist(snapshot(get()));
-    applyTheme(theme);
+    applyResolved(get());
     return theme;
   },
 
@@ -1420,6 +1731,14 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
 
   set(key, value) {
     set({ [key]: value } as Partial<SettingsState>);
+    if (key === "themePreference") {
+      // The generic setter is public API, so it must not be a back door around
+      // the resolve: assigning a preference without re-deriving `activeThemeId`
+      // would leave "follow the system" set and the wrong half on screen.
+      const s = get();
+      set({ activeThemeId: resolveActiveThemeId(s, s.systemAppearance) });
+      applyResolved(get());
+    }
     persist(snapshot(get()));
     if (key === "uiDensity") {
       applyDensity(get().uiDensity);
@@ -1451,6 +1770,27 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   applyDensity(s.uiDensity);
   applyZoom(s.uiZoom);
 }
+
+/**
+ * Follow the OS light/dark appearance for as long as this window lives (#236).
+ *
+ * Called from `main.tsx` — which BOTH windows run, before it branches on the
+ * `window=merge` query param, so the merge resolver subscribes for itself.
+ * A resolver left in last night's theme while the main window switched is
+ * exactly the bug this feature exists to fix, and the two windows do not
+ * depend on each other being open.
+ *
+ * Not a module-load side effect: an async subscription firing in every test
+ * that so much as imports a setting is noise, and the caller is the one that
+ * knows the window's lifetime.
+ */
+export function startSystemAppearanceWatch(): () => void {
+  return watchSystemAppearance((appearance) => {
+    useSettingsStore.getState().syncSystemAppearance(appearance);
+  });
+}
+
+export type { Appearance } from "./systemAppearance";
 
 /**
  * The active density's pixel step, for surfaces that need the NUMBER rather

--- a/src/main.appearance.test.tsx
+++ b/src/main.appearance.test.tsx
@@ -1,0 +1,75 @@
+// Both windows follow the OS appearance (#236).
+//
+// The merge resolver is a second Tauri window running THIS bundle, selected by
+// a query param — so the one place that can wire the appearance watch for both
+// is `main.tsx`, before it branches on which window it is. A resolver left in
+// last night's theme while the main window switched is precisely the bug the
+// issue is about, and it is invisible in every test that renders a component
+// directly.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+// React never has to actually mount for this: the question is what main.tsx
+// wires up on the way there.
+vi.mock("react-dom/client", () => ({
+  default: { createRoot: () => ({ render: () => {} }) },
+  createRoot: () => ({ render: () => {} }),
+}));
+
+function tauriWindow() {
+  return getCurrentWindow() as unknown as {
+    theme: ReturnType<typeof vi.fn>;
+    onThemeChanged: ReturnType<typeof vi.fn>;
+  };
+}
+
+async function bootAs(search: string) {
+  vi.resetModules();
+  window.history.replaceState(null, "", search ? `/?${search}` : "/");
+  document.body.innerHTML = '<div id="root"></div>';
+  await import("./main");
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  tauriWindow().theme.mockResolvedValue(null);
+  tauriWindow().onThemeChanged.mockResolvedValue(() => {});
+});
+
+describe("main.tsx", () => {
+  it("subscribes the MAIN window to tauri://theme-changed", async () => {
+    await bootAs("");
+    await vi.waitFor(() =>
+      expect(tauriWindow().onThemeChanged).toHaveBeenCalledTimes(1),
+    );
+  });
+
+  it("subscribes the MERGE resolver window too", async () => {
+    await bootAs("window=merge&repoId=r1");
+    await vi.waitFor(() =>
+      expect(tauriWindow().onThemeChanged).toHaveBeenCalledTimes(1),
+    );
+  });
+
+  it("re-themes the resolver window when its OS appearance flips", async () => {
+    let fire: ((e: { payload: string }) => void) | null = null;
+    tauriWindow().onThemeChanged.mockImplementation(
+      async (handler: (e: { payload: string }) => void) => {
+        fire = handler;
+        return () => {};
+      },
+    );
+    localStorage.setItem(
+      "pg-settings-v2",
+      JSON.stringify({
+        themePreference: { mode: "system", lightId: "github-light", darkId: "nord" },
+      }),
+    );
+    await bootAs("window=merge&repoId=r1");
+    await vi.waitFor(() => expect(fire).not.toBeNull());
+    expect(document.documentElement.dataset.theme).toBe("nord");
+    fire!({ payload: "light" });
+    expect(document.documentElement.dataset.theme).toBe("github-light");
+    expect(document.documentElement.dataset.themeMode).toBe("light");
+  });
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { attachConsole } from "@tauri-apps/plugin-log";
 import App from "./App";
 import { PGErrorBoundary } from "./design/error-boundary";
 import { MergeWindow } from "./features/merge/MergeWindow";
+import { startSystemAppearanceWatch } from "./features/settings/useSettingsStore";
 import "./index.css";
 
 if (import.meta.env.DEV) {
@@ -11,6 +12,14 @@ if (import.meta.env.DEV) {
     console.warn("attachConsole failed", err);
   });
 }
+
+// Follow the OS light/dark appearance (#236). Deliberately BEFORE the
+// which-window branch: the merge resolver is a second Tauri window running
+// this same bundle, and one window still in last night's theme is the bug the
+// feature exists to fix. Each window subscribes to its own
+// `tauri://theme-changed`, so neither depends on the other being open. Never
+// unsubscribed — the subscription's lifetime is the window's.
+startSystemAppearanceWatch();
 
 // The merge resolver runs as a second Tauri window on the same bundle,
 // selected by query param (see features/merge/openMergeWindow.ts).

--- a/src/screens/Settings.appearance.test.tsx
+++ b/src/screens/Settings.appearance.test.tsx
@@ -1,0 +1,108 @@
+// Settings → Appearance, the "follow the system" half (#236). The store's side
+// is pinned in features/settings/themePreference.test.ts; this file asserts the
+// one thing only the UI can get wrong — offering a pairing that cannot switch.
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { mockInvoke } from "@/test/invokeMock";
+import { WithDialogs, resetDialogs } from "@/test/dialog";
+import { pgPickOption, pgSelectTrigger, pgSelectValues } from "@/test/select";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { SettingsScreen } from "./Settings";
+
+function mockRestOfSettings() {
+  mockInvoke("cli_shim_status", () => ({
+    installed: true,
+    shimPath: "/usr/local/bin/pgit",
+    target: "/usr/bin/platypusgit",
+    source: "package",
+    pathState: "onPath",
+  }));
+  mockInvoke("diagnostics_report", () => ({
+    logPath: "/tmp/platypusgit.log",
+    logExists: false,
+    logSizeBytes: 0,
+    environment: "host os=macos arch=aarch64 git=2.43.0",
+    version: "0.1.0",
+  }));
+}
+
+/**
+ * The Row whose label is `label`, so a control can be found by what it is FOR
+ * rather than by position.
+ *
+ * `Row` wraps label + hint in a `flex: 1` div and puts the control beside it,
+ * so the row is the label node's grandparent — and that wrapper is also what
+ * distinguishes a row label from the Section header of the same name
+ * ("Appearance" is both, deliberately: it is the word the OS uses).
+ */
+function row(label: string): HTMLElement {
+  const wrapper = screen
+    .getAllByText(label)
+    .map((el) => el.parentElement)
+    .find((el) => el?.style.flex);
+  if (!wrapper?.parentElement) throw new Error(`no settings row labelled "${label}"`);
+  return wrapper.parentElement;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  resetDialogs();
+  mockRestOfSettings();
+  useSettingsStore.getState().reset();
+  useSettingsStore.getState().syncSystemAppearance("dark");
+});
+
+function renderSettings() {
+  render(
+    <WithDialogs>
+      <SettingsScreen />
+    </WithDialogs>,
+  );
+}
+
+describe("the Appearance control", () => {
+  it("shows one theme picker while fixed, and the pair while following", () => {
+    renderSettings();
+    expect(screen.getByText("Theme")).toBeInTheDocument();
+    expect(screen.queryByText("Light theme")).not.toBeInTheDocument();
+
+    fireEvent.click(within(row("Appearance")).getByText("Follow system"));
+
+    expect(screen.getByText("Light theme")).toBeInTheDocument();
+    expect(screen.getByText("Dark theme")).toBeInTheDocument();
+    expect(screen.queryByText("Theme")).not.toBeInTheDocument();
+  });
+
+  it("offers only light themes as the light half, and only dark as the dark", () => {
+    useSettingsStore.getState().setThemeFollowMode("system");
+    renderSettings();
+    const light = pgSelectValues(pgSelectTrigger(row("Light theme")));
+    const dark = pgSelectValues(pgSelectTrigger(row("Dark theme")));
+    // A pairing whose halves are the same mode never switches — the control
+    // must make that unrepresentable rather than validating it after the fact.
+    expect(light).toEqual(["light", "github-light"]);
+    expect(dark).toContain("dark-cool");
+    expect(dark).not.toContain("light");
+    expect(light).not.toContain("nord");
+  });
+
+  it("applies the pick that matches the current OS appearance", () => {
+    useSettingsStore.getState().setThemeFollowMode("system");
+    renderSettings();
+    pgPickOption(pgSelectTrigger(row("Dark theme")), "dracula");
+    expect(useSettingsStore.getState().themePreference.darkId).toBe("dracula");
+    expect(document.documentElement.dataset.theme).toBe("dracula");
+
+    // …and stores the other half without touching the screen.
+    pgPickOption(pgSelectTrigger(row("Light theme")), "github-light");
+    expect(useSettingsStore.getState().themePreference.lightId).toBe("github-light");
+    expect(document.documentElement.dataset.theme).toBe("dracula");
+  });
+
+  it("says which appearance it is currently following", () => {
+    useSettingsStore.getState().setThemeFollowMode("system");
+    renderSettings();
+    expect(screen.getByText(/Follows the OS — currently dark/)).toBeInTheDocument();
+  });
+});

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -21,6 +21,7 @@ import {
   type SettingsImportReport,
   type ThemeColors,
   type ThemeDef,
+  type ThemeFollowMode,
   type UpdateCheckMode,
 } from "@/features/settings/useSettingsStore";
 import { HeadMarksControl } from "@/features/settings/HeadMarksControl";
@@ -922,6 +923,24 @@ function AppearanceSection({ active }: { active: ThemeDef }) {
     return [...builtins, ...customs];
   }, [s.customThemes]);
 
+  // Each half of the pairing may only name a theme of its own mode — offering
+  // a dark theme as "the light one" would let the user build a pairing that
+  // never switches.
+  const pairOptions = React.useMemo(() => {
+    const of = (mode: "dark" | "light") => [
+      ...BUILTIN_THEMES.filter((t) => t.mode === mode).map((t) => ({
+        value: t.id,
+        label: t.name,
+      })),
+      ...s.customThemes
+        .filter((t) => t.mode === mode)
+        .map((t) => ({ value: t.id, label: `★ ${t.name}` })),
+    ];
+    return { light: of("light"), dark: of("dark") };
+  }, [s.customThemes]);
+
+  const following = s.themePreference.mode === "system";
+
   const onImportClick = () => fileInputRef.current?.click();
 
   const onImportFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -956,22 +975,75 @@ function AppearanceSection({ active }: { active: ThemeDef }) {
       subtitle="Pick a theme, or customize every color and export it as a sharable file."
     >
       <Row
-        label="Theme"
+        label="Appearance"
         hint={
-          isBuiltin
-            ? "Built-in themes are read-only. Click “New custom theme” to fork and edit."
-            : "Custom theme. Click “Edit custom theme” to change its colors."
+          following
+            ? `Follows the OS — currently ${
+                s.systemAppearance === "light" ? "light" : "dark"
+              }. Pick the theme each half uses below.`
+            : "One theme, always. Switch to “Follow system” to pair a light theme with a dark one."
         }
         control={
-          <PGSelect
-            value={active.id}
-            onChange={(v) => s.setActiveThemeId(v)}
-            options={themeOptions}
+          <PGButtonGroup
             size="sm"
-            style={{ minWidth: 200 }}
+            value={s.themePreference.mode}
+            onChange={(v) => s.setThemeFollowMode(v as ThemeFollowMode)}
+            options={[
+              { value: "fixed", label: "Fixed" },
+              { value: "system", label: "Follow system" },
+            ]}
           />
         }
       />
+
+      {following ? (
+        <>
+          <Row
+            label="Light theme"
+            hint="Applied while the OS is in light appearance."
+            control={
+              <PGSelect
+                value={s.themePreference.lightId}
+                onChange={(v) => s.setPairedThemeId("light", v)}
+                options={pairOptions.light}
+                size="sm"
+                style={{ minWidth: 200 }}
+              />
+            }
+          />
+          <Row
+            label="Dark theme"
+            hint="Applied while the OS is in dark appearance."
+            control={
+              <PGSelect
+                value={s.themePreference.darkId}
+                onChange={(v) => s.setPairedThemeId("dark", v)}
+                options={pairOptions.dark}
+                size="sm"
+                style={{ minWidth: 200 }}
+              />
+            }
+          />
+        </>
+      ) : (
+        <Row
+          label="Theme"
+          hint={
+            isBuiltin
+              ? "Built-in themes are read-only. Click “New custom theme” to fork and edit."
+              : "Custom theme. Click “Edit custom theme” to change its colors."
+          }
+          control={
+            <PGSelect
+              value={active.id}
+              onChange={(v) => s.setActiveThemeId(v)}
+              options={themeOptions}
+              size="sm"
+              style={{ minWidth: 200 }}
+            />
+          }
+        />
+      )}
 
       <div
         style={{
@@ -1194,6 +1266,10 @@ function ThemeEditorDialog({
             : t,
         ),
       }));
+      // Through the store, not just `setState`: the draft's dark/light toggle
+      // may have flipped the mode the duplicate inherited, and in "follow the
+      // system" mode that decides WHICH half of the pairing this theme is.
+      useSettingsStore.getState().setActiveThemeId(created.id);
       // Re-apply so the saved version is what's showing.
       applyTheme({
         ...created,

--- a/src/test/matchMediaStub.ts
+++ b/src/test/matchMediaStub.ts
@@ -1,0 +1,66 @@
+// jsdom implements no `matchMedia` at all, so `prefers-color-scheme` — one of
+// the two sources behind "follow the system appearance" (#236) — has nothing
+// to read in the unit suite. This installs a controllable one.
+//
+// Deliberately NOT installed globally in `setup.ts`: with no matchMedia the
+// app falls back to dark, which is exactly what every pre-existing test
+// expects, and a global stub would quietly make that fallback untested.
+
+export type StubAppearance = "dark" | "light";
+
+interface Listener {
+  query: string;
+  fn: (e: MediaQueryListEvent) => void;
+}
+
+export interface MatchMediaStub {
+  /** Flip the OS appearance and notify every subscriber. */
+  set(next: StubAppearance): void;
+}
+
+const DARK = "(prefers-color-scheme: dark)";
+
+/**
+ * @param initial `null` models a webview with no prefers-color-scheme support:
+ *   BOTH queries answer false, which must not be read as "light".
+ */
+export function installMatchMedia(initial: StubAppearance | null): MatchMediaStub {
+  let current = initial;
+  const listeners = new Set<Listener>();
+  const matchesFor = (query: string, value: StubAppearance | null) =>
+    value === null ? false : query === DARK ? value === "dark" : value === "light";
+
+  const matchMedia = (query: string): MediaQueryList =>
+    ({
+      media: query,
+      get matches() {
+        return matchesFor(query, current);
+      },
+      addEventListener: (_type: string, fn: (e: MediaQueryListEvent) => void) => {
+        listeners.add({ query, fn });
+      },
+      removeEventListener: (_type: string, fn: (e: MediaQueryListEvent) => void) => {
+        for (const l of [...listeners]) if (l.fn === fn) listeners.delete(l);
+      },
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+      onchange: null,
+    }) as unknown as MediaQueryList;
+
+  (window as unknown as { matchMedia?: unknown }).matchMedia = matchMedia;
+
+  return {
+    set(next) {
+      current = next;
+      for (const l of [...listeners]) {
+        l.fn({ matches: matchesFor(l.query, next) } as MediaQueryListEvent);
+      }
+    },
+  };
+}
+
+/** Back to jsdom's default — no matchMedia at all. */
+export function uninstallMatchMedia(): void {
+  delete (window as unknown as { matchMedia?: unknown }).matchMedia;
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -42,6 +42,11 @@ vi.mock("@tauri-apps/api/window", () => {
     isMaximized: vi.fn().mockResolvedValue(false),
     onResized: vi.fn().mockResolvedValue(() => {}),
     setTitle: vi.fn().mockResolvedValue(undefined),
+    // The OS appearance source (#236). `null` is the honest default here:
+    // nothing under test runs against a real window, and "the window cannot
+    // tell us" is the branch that has to keep working.
+    theme: vi.fn().mockResolvedValue(null),
+    onThemeChanged: vi.fn().mockResolvedValue(() => {}),
   };
   return { getCurrentWindow: () => win };
 });


### PR DESCRIPTION
## What does this PR do?

Adds a **"Follow system"** appearance mode, pairing a chosen light theme with a chosen dark one.

```ts
themePreference: { mode: "system" | "fixed"; lightId: string; darkId: string }
```

`activeThemeId` stays the single answer to "what is on screen" — the user's own choice while `fixed`, **derived** from the pairing while `system`, and still persisted as the cache that lets the next launch paint before the async window-theme query answers. Everything downstream (`getActiveTheme`, the theme editor, `DiffMinimap`'s repaint subscription) keeps working untouched.

Closes #236.

## ⚠️ One product call I'd like you to confirm

**The default mode is `fixed`, not `system`.** A fresh install behaves exactly as today (`dark-cool`), and the built-in pairing means "Follow system" needs zero configuration when the user chooses it.

The issue asks to *"default the built-in pairing … so system works without the user configuring anything"* — the **pairing**, not the mode — so this matches what was asked. But defaulting to `system` is arguably the modern expectation, and it would silently put every new user on a light theme on a light Mac. That felt like a bigger product decision than #236 asked for, so I left it. **One-line change if you want the opposite.**

## Why two appearance sources

Neither covers every platform or every moment, so both are wired as peers:

- **`prefers-color-scheme`** — synchronous, so it answers during module load and the first paint is already the right half instead of a flash of the other. It is also the *only* source outside Tauri (a plain `pnpm dev` browser tab, and the unit suite).
- **`getCurrentWindow().theme()` + `tauri://theme-changed`** — authoritative, and the one that actually fires when the OS switches at sunset. Async, so it refines the first answer.

**Both media queries are asked, never only the dark one.** A webview with no support for the feature answers `false` to both — indistinguishable from "light" if you only ask about dark, and reading that as light would flip the app on exactly the platforms that cannot correct it. `null` means "this source doesn't know"; `FALLBACK_APPEARANCE` is `dark`, the appearance this app has always had.

## Existing installs do not change appearance

A payload with no `themePreference` keeps its `activeThemeId` and lands on `{ mode: "fixed", … }`. It additionally **seeds the half matching the theme they were already on** (a `gruvbox-dark` install gets `darkId: "gruvbox-dark"`), so the day they flip to "Follow system" they keep the theme they had. Seeding fires only while the preference is untouched — otherwise importing an older file would overwrite a pairing this install has since configured. The migration sits in `coerceSettings` beside the `headIndicator` → `headMarks` one.

## The two windows, and the titlebar

`startSystemAppearanceWatch()` is called in `main.tsx` **before** the `window=merge` branch, so the merge resolver — a second Tauri window running the same bundle — subscribes for itself rather than depending on the main window being open. Both sources are per-window, which is what makes that work. `src/main.appearance.test.tsx` boots `main.tsx` as `?window=merge`, fires `tauri://theme-changed`, and asserts `data-theme` moves.

The Windows/Linux titlebar is ours, painted from `--bg-titlebar`, so it follows because the re-resolve goes back through the existing `applyTheme` — pinned by an assertion on `--bg-titlebar` after a mid-session flip.

## Settings export interaction (#254)

The key-set snapshot test added by #285 failed, **as designed** — that test exists so a new `PersistedState` key forces a deliberate decision. Resolved:

- `themePreference` → **`PORTABLE`**. It is a preference (which themes you like, and whether the OS should choose), not machine state. Two tests pin the consequences: the pairing round-trips, and `coerceSettings` repairs an imported pairing naming themes this machine lacks.
- The **resolved appearance** is not in `PersistedState` at all — it lives on `SettingsState` only, so `snapshot()` and `PORTABLE_KEYS` (both derived from `Object.keys(DEFAULTS)`) exclude it from localStorage *and* the export by construction. Asserted both ways.

Same call `useUpdateStore.lastCheckedAt` got in #283.

## No Rust, no new capability

`core:window:allow-theme` is inside `core:window:default`, and `onThemeChanged` routes through `listen` (`core:event:allow-listen`) — both already in `core:default`, which `capabilities/default.json` grants to both windows. Verified against the Tauri 2.10.3 permission reference rather than assumed.

## Known limits

- **Linux/WebKitGTK** is where I'd want a real run: tao's GTK backend may not emit `tauri://theme-changed`, which is exactly why the media-query source is a peer rather than a last resort. It should follow the GTK dark preference, but a unit test cannot prove it.
- **macOS traffic lights** in `fixed` mode still follow the OS, not our theme (pre-existing). Fixing it needs `window.setTheme()`, which would make `theme()` return our forced value instead of the OS's — breaking the detection this feature depends on. Deliberately not done.
- **Cross-window preference changes** don't propagate: changing the pairing in Settings won't reach an already-open merge resolver until it reopens. Only the *OS* appearance propagates. Pre-existing limitation of the two-window design.

## Checklist

- [x] One logical change, focused PR
- [x] Branched off `main` @ `d82664e`; no merge commits, single squashed commit
- [x] PR title + commit message follow Conventional Commits
- [x] `pnpm tsc --noEmit` passes — exit 0
- [ ] `cargo test` — **not run: `src-tauri/` is untouched.** CI covers it
- [x] `pnpm test` passes — 241 files, 2133 tests, includes `docs` + `privacy`
- [x] `e2e/` untouched — no e2e run
- [x] Added tests — 9 `systemAppearance`, 21 `themePreference`, 4 `Settings.appearance`, 3 `main.appearance`, 2 export
- [x] Not a new git op
- [x] `docs/dev/frontend.md` + `architecture.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
