### PR TITLE
feat(diff): find in diff (⌘F), searching the row model

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -318,7 +318,9 @@ features/            Components + Zustand store colocated per feature:
 │                    CompareSidePicker
 ├── diff/            CommitDiffPanel (shared commit-diff view), DiffMinimap,
 │                    useDiffGaps (+ useExpandedGaps, diffOpenReady),
-│                    WhitespaceToggle (+ useHunkActionsDisabledReason)
+│                    WhitespaceToggle (+ useHunkActionsDisabledReason),
+│                    useDiffFind + DiffFindBar (find in diff — ONE hook for all
+│                    four surfaces; searches the row model, scrolls by offset)
 ├── submodules/      useSubmodulesStore (persisted recursive toggle; update goes
 │                    through withAuthRetry)
 ├── worktrees/       useWorktreesStore + WorktreeAddDialog (store owns the
@@ -350,7 +352,9 @@ lib/                 tauri.ts (typed invoke wrappers — frontend NEVER calls
                      canvas can't take CSS vars), wordDiff.ts,
                      pairChangedLines.ts (which rem pairs with which add — one
                      definition, three surfaces), lineSpans.ts (syntax ×
-                     word-diff tiling), codeLines.ts (display-line split;
+                     word-diff tiling, plus find marks), diffFind.ts (find in
+                     diff, PURE: match/count/wrap over DiffRow[], never the
+                     rendered window), codeLines.ts (display-line split;
                      text.split("\n") gets two cases wrong), useViewportH.ts,
                      useElementSize.ts (both: measure WITHOUT depending on
                      ResizeObserver), useWindowedList.ts, useVariableWindow.ts

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -92,6 +92,56 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
     which walks the tree the way an engine serialises a copy) and, because the
     granting rule lives in a stylesheet and gutter exclusion is an engine
     behaviour, by `e2e/specs/diff-selection.e2e.ts` in the real webview.
+- **Find in diff searches the ROW MODEL** (#241) — `lib/diffFind.ts` (pure) +
+  `features/diff/useDiffFind.ts` (state, chords, scrolling) +
+  `features/diff/DiffFindBar.tsx` (the bar). All four surfaces mount it;
+  `test/diffFindSurfaces.test.ts` fails the build for a fifth that forgets to,
+  exactly as `diffCopyMenu.test.ts` does for the copy menu. Same reason
+  `diffCopy.ts` exists: the surfaces are windowed, so the webview's own find
+  would search the mounted screenful and answer "no results" for a match two
+  thousand lines down — a wrong answer, not a degraded one. Six rules:
+  - **`Mod+F` is `diff.find`, pane-scoped and `suppressInInput`.** That flag IS
+    the answer to "the find key must not be stolen from an input that wants it":
+    the dispatcher never resolves a suppressed action inside a text field, so the
+    commit-message box, the file filter and the bar's OWN input keep it. Escape
+    is `diff.closeFind` — pane-scoped, `allowInInput` (the bar autofocuses its
+    input), bound BEFORE the global `app.closeOverlay` in `presets.ts` and
+    DECLINING when the bar is shut. Same ordering asymmetry as
+    `diff.viewCombined` vs `nav.diff`, pinned in `presets.test.ts`. Enter /
+    ⇧Enter are handled on the input itself: the caret is in it, bare-key chords
+    are suppressed there anyway, and "Enter submits the box you are typing in" is
+    the one chord a form owns rather than the app.
+  - **Jumping to a match is `scrollTopForRow`** written through
+    `useVariableWindow.scrollTo` — never `scrollIntoView` (the row is unmounted;
+    #68 G10) and never `scrollTopForHunk`'s CENTRING, which would yank the pane
+    on every Enter. Reveal semantics, the line cursor's, for the same reason.
+  - **Highlighting is a THIRD range set in `buildLineSpans`**, not markup wrapped
+    around matched text afterwards. The tiling keeps syntax classes and word-diff
+    spans intact through a match, and the code cell's `.pg-selectable` split is
+    untouched because the marks are spans INSIDE that cell — pinned by
+    `src/design/diffFindHighlight.test.tsx`, which re-runs the selection walk.
+    Paint derives from `--accent` rather than a new semantic token (those are
+    duplicated per theme mode in `SEMANTIC_TOKENS` and drift); the CURRENT match
+    flips the foreground to `--accent-ink`, the only thing that stays legible on
+    an already-tinted add/rem line.
+  - **A row with no match gets `undefined`, not `[]`** — `findMarksByRow` returns
+    a Map for exactly that. `PGDiffRow` is memoized and the whole window
+    re-renders per keystroke in the find box, so a fresh empty array per row
+    would defeat the memo for the entire slice.
+  - **Gated on `isTextualDiff`**, and additionally OFF in split mode (a different
+    renderer, `PGSideBySideDiff`) and in the DiffViewer's WRAP mode — heights
+    describe nothing there, and a wrap caller drops windowing, the minimap and
+    offset scrolling together, so an offset-scrolling consumer drops with them
+    (turning Wrap on closes an open bar rather than leaving one that scrolls
+    wrong). The merge window is out of scope on purpose: CodeMirror, no `DiffRow`.
+  - The match count is capped at `MAX_FIND_MATCHES` and reported as a floor
+    ("5000+"). Scanning a whole-file diff per keystroke is cheap; allocating
+    half a million match objects is not.
+- **The DiffViewer's old "Find in diff" was a line FILTER**, not a find: it
+  rewrote the hunks down to matching lines, which forced whole-file mode off,
+  made "copy the file" mean "copy the matches", and could not say WHERE in the
+  file a match was. #241 replaced it with the shared bar above. Don't bring it
+  back as a second control on that screen.
 - **Tokenization runs in a module worker** (Shiki's `codeToTokens` is sync CPU);
   tokens return as transferable `Int32Array`s. `vite.config.ts` sets
   `worker: { format: "es" }` — the grammars are dynamic imports and the default

--- a/src/design/PGWindowedDiff.tsx
+++ b/src/design/PGWindowedDiff.tsx
@@ -13,6 +13,7 @@
 // Stage/Discard cluster is pinned to that same row.
 import React from "react";
 import type { DiffRow } from "@/lib/diffRows";
+import type { FindMark } from "@/lib/diffFind";
 import type { WindowRange } from "@/lib/useWindowedList";
 import { PGDiffRow, PGFoldSeparator, PGHunkActions } from "./git-components";
 
@@ -46,6 +47,17 @@ export interface PGWindowedDiffProps {
    */
   focusedRow?: number | null;
   /**
+   * Find-in-diff hits for a row, by ABSOLUTE row index — the flat model's index
+   * space, not the window's.
+   *
+   * A lookup rather than an array prop because find searches the whole row model
+   * (`lib/diffFind.ts`) while this renders a screenful: passing every row's marks
+   * would mean building an array as long as the file on every keystroke. Callers
+   * hand over `findMarksByRow(...).get`, which returns `undefined` for a row with
+   * no match — the value `PGDiffRow`'s memo needs it to return.
+   */
+  findMarks?: (rowIndex: number) => readonly FindMark[] | undefined;
+  /**
    * Soft-wrap long code lines. Forwarded to every `PGDiffRow`, which then renders
    * an ELASTIC row — so a caller passing this must also omit `window` and switch
    * off every other heights consumer it owns (minimap, hunk scroll), because
@@ -64,6 +76,7 @@ export function PGWindowedDiff({
   onLineClick,
   onExpandGap,
   focusedRow,
+  findMarks,
   wrap,
 }: PGWindowedDiffProps) {
   const start = win?.start ?? 0;
@@ -100,7 +113,17 @@ export function PGWindowedDiff({
         // no hunk, so it gets no selection and no click target — there is no hunk
         // index it could stage.
         if (row.kind === "fill") {
-          return <PGDiffRow key={`f${start + i}`} line={row.line} wrap={wrap} />;
+          return (
+            <PGDiffRow
+              key={`f${start + i}`}
+              line={row.line}
+              wrap={wrap}
+              // Whole-file filler is ordinary file text and the most likely place
+              // for a match to hide, so it is searched and highlighted like any
+              // other row — it simply has no hunk to stage.
+              marks={findMarks?.(start + i)}
+            />
+          );
         }
         if (row.kind === "fold") {
           return (
@@ -129,6 +152,7 @@ export function PGWindowedDiff({
             }
             focused={focusedRow === start + i}
             wrap={wrap}
+            marks={findMarks?.(start + i)}
             onLineClick={
               onLineClick && !disabled ? clickHandlerFor(row.hunkIndex) : undefined
             }

--- a/src/design/diffFindHighlight.test.tsx
+++ b/src/design/diffFindHighlight.test.tsx
@@ -1,0 +1,70 @@
+// Find-in-diff highlighting, at the two renderers that draw diff rows.
+//
+// The marks come from `lib/diffFind.ts` (the ROW model) and are reconciled with
+// syntax and word-diff spans by `buildLineSpans`, so what is left to pin here is
+// what reaches the DOM: every match visible, the current one distinct, and the
+// selection split still intact — highlighting is the one feature that adds
+// elements INSIDE the code cell, which is exactly where `.pg-selectable` lives.
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { PGWindowedDiff } from "./PGWindowedDiff";
+import { selectionText } from "@/test/selectionText";
+import { flattenDiffRows } from "@/lib/diffRows";
+import type { FindMark } from "@/lib/diffFind";
+import type { FileDiff } from "@/lib/types";
+
+type Line = FileDiff["hunks"][number]["lines"][number];
+
+const lines: Line[] = [
+  { kind: { kind: "Context" }, oldLineno: 1, newLineno: 1, content: "one needle here" },
+  { kind: { kind: "Deletion" }, oldLineno: 2, newLineno: null, content: "no hit" },
+  { kind: { kind: "Addition" }, oldLineno: null, newLineno: 2, content: "two needle rows" },
+];
+
+const rows = flattenDiffRows(
+  [{ header: "@@ -1,2 +1,2 @@", oldStart: 1, oldLines: 2, newStart: 1, newLines: 2, lines }],
+  { foldH: 22, rowH: 19 },
+);
+
+/** Marks for "needle": row 0 at 4..10, row 2 at 4..10; row 2's is the active one. */
+const marks = new Map<number, FindMark[]>([
+  [0, [{ start: 4, end: 10 }]],
+  [2, [{ start: 4, end: 10, active: true }]],
+]);
+const findMarks = (i: number) => marks.get(i);
+
+describe("find highlighting in PGWindowedDiff", () => {
+  it("marks every match in view", () => {
+    const { container } = render(<PGWindowedDiff rows={rows} findMarks={findMarks} />);
+    const hits = container.querySelectorAll('[data-testid="diff-find-match"]');
+    expect([...hits].map((el) => el.textContent)).toEqual(["needle", "needle"]);
+  });
+
+  it("makes the CURRENT match distinct from the rest", () => {
+    const { container } = render(<PGWindowedDiff rows={rows} findMarks={findMarks} />);
+    const active = container.querySelectorAll("[data-find-active]");
+    expect(active).toHaveLength(1);
+    expect(active[0].textContent).toBe("needle");
+    // ...and it is the one on row 2, not merely "some match".
+    expect(active[0].closest(".pg-selectable")?.textContent).toBe("two needle rows");
+  });
+
+  it("leaves rows with no match untouched", () => {
+    const { container } = render(<PGWindowedDiff rows={rows} findMarks={findMarks} />);
+    expect(container.textContent).toContain("no hit");
+    expect(container.querySelectorAll('[data-testid="diff-find-match"]')).toHaveLength(2);
+  });
+
+  it("renders nothing extra when there is no query", () => {
+    const { container } = render(<PGWindowedDiff rows={rows} />);
+    expect(container.querySelectorAll('[data-testid="diff-find-match"]')).toHaveLength(0);
+  });
+
+  it("keeps the selection split: code selectable, gutters and marker not", () => {
+    const { container } = render(<PGWindowedDiff rows={rows} findMarks={findMarks} />);
+    expect([...container.querySelectorAll(".pg-selectable")].map((e) => e.textContent))
+      .toEqual(["one needle here", "no hit", "two needle rows"]);
+    // No line number, no +/- marker — the highlight spans did not open a hole.
+    expect(selectionText(container)).toBe("one needle hereno hittwo needle rows");
+  });
+});

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -1,6 +1,7 @@
 import React, { type CSSProperties, type MouseEvent, type ReactNode } from "react";
 import type { WordSpan } from "@/lib/wordDiff";
 import { buildLineSpans } from "@/lib/lineSpans";
+import type { FindMark } from "@/lib/diffFind";
 import type { SyntaxToken } from "@/lib/syntax";
 import { PGIcon, type IconName } from "./icons";
 import {
@@ -665,20 +666,28 @@ function DiffText({
   spans,
   syntax,
   kind,
+  marks,
 }: {
   text: string;
   spans?: WordSpan[];
   syntax?: SyntaxToken[];
   kind: DiffLineKind;
+  /** Find-in-diff hits on this line (`lib/diffFind.ts`). */
+  marks?: readonly FindMark[];
 }) {
   const rendered = React.useMemo(
-    () => buildLineSpans(text, syntax ?? null, spans),
-    [text, syntax, spans],
+    () => buildLineSpans(text, syntax ?? null, spans, marks),
+    [text, syntax, spans, marks],
   );
   // Nothing to mark: emit the bare string so the DOM stays as light as it was
   // before highlighting existed.
   if (rendered.length === 0) return <>{text}</>;
-  if (rendered.length === 1 && !rendered[0].cls && !rendered[0].changed) {
+  if (
+    rendered.length === 1 &&
+    !rendered[0].cls &&
+    !rendered[0].changed &&
+    !rendered[0].mark
+  ) {
     return <>{text}</>;
   }
   const tint =
@@ -689,14 +698,50 @@ function DiffText({
         <span
           key={i}
           className={s.cls}
-          data-testid={s.changed ? "word-change" : undefined}
-          style={s.changed ? { background: tint, borderRadius: 2 } : undefined}
+          data-testid={
+            s.mark ? "diff-find-match" : s.changed ? "word-change" : undefined
+          }
+          data-find-active={s.mark === "active" ? "" : undefined}
+          style={
+            findMarkStyle(s.mark) ??
+            (s.changed ? { background: tint, borderRadius: 2 } : undefined)
+          }
         >
           {text.slice(s.start, s.end)}
         </span>
       ))}
     </>
   );
+}
+
+/**
+ * Paint for a find hit — derived from `--accent` rather than a new semantic
+ * token, so it themes with everything else and hardcodes no hue.
+ *
+ * The ACTIVE match is a filled accent chip rather than a stronger tint of the
+ * same wash: "which one is Enter on" has to survive a line that is already
+ * tinted green or red and already carries a word-diff highlight, and only a
+ * change of foreground does that reliably. `--accent-ink` is the token for text
+ * sitting ON the accent, so this stays readable in every theme.
+ *
+ * It deliberately WINS over the word-diff tint on the same span: while find is
+ * open, the reader is looking for the query, not for the intra-line change.
+ */
+function findMarkStyle(
+  mark: "match" | "active" | undefined,
+): React.CSSProperties | undefined {
+  if (!mark) return undefined;
+  if (mark === "active") {
+    return {
+      background: "var(--accent)",
+      color: "var(--accent-ink)",
+      borderRadius: 2,
+    };
+  }
+  return {
+    background: "oklch(from var(--accent) l c h / 0.3)",
+    borderRadius: 2,
+  };
 }
 
 /**
@@ -741,10 +786,21 @@ export const PGDiffRow = React.memo(function PGDiffRow({
   selected,
   focused,
   wrap,
+  marks,
   onLineClick,
 }: {
   line: DiffLineData;
   selected?: boolean;
+  /**
+   * Find-in-diff hits on this row, or undefined for a row with none.
+   *
+   * UNDEFINED, not an empty array, for a row that does not match: this component
+   * is `React.memo`'d and a windowed diff re-renders its whole slice on every
+   * keystroke in the find box, so a fresh `[]` per row per render would defeat
+   * the memo for the entire window. `findMarksByRow` returns a Map for exactly
+   * that reason.
+   */
+  marks?: readonly FindMark[];
   /**
    * The keyboard line cursor sits here (#61 D7 step 5). Distinct from
    * `selected`: selection is a set the hunk's Stage button acts on, focus is the
@@ -901,6 +957,7 @@ export const PGDiffRow = React.memo(function PGDiffRow({
               spans={ln.spans}
               syntax={ln.syntax}
               kind={kind}
+              marks={marks}
             />
           </span>
         </div>

--- a/src/features/diff/CommitDiffPanel.find.test.tsx
+++ b/src/features/diff/CommitDiffPanel.find.test.tsx
@@ -1,0 +1,109 @@
+// Find in diff on the ONE surface with its own row markup (#241).
+//
+// The other three go through `PGDiffRow`, whose highlighting is pinned by
+// `src/design/diffFindHighlight.test.tsx`. This panel renders its own spans, so
+// the same two claims have to be made again here: the marks reach the DOM, and
+// adding elements INSIDE the code cell did not break the selection split that
+// `CommitDiffPanel.selection.test.tsx` guards.
+import { beforeEach, describe, expect, it } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { resetInvokeMock } from "@/test/invokeMock";
+import { selectionText } from "@/test/selectionText";
+import { useFocusStore, useKeymapStore } from "@/features/keymap";
+import { CommitDiffPanel } from "./CommitDiffPanel";
+import type { FileDiff } from "@/lib/types";
+
+const diffs: FileDiff[] = [
+  {
+    path: "a.ts",
+    oldPath: null,
+    binary: false,
+    additions: 1,
+    deletions: 1,
+    hunks: [
+      {
+        header: "@@ -1,3 +1,3 @@",
+        oldStart: 1,
+        oldLines: 3,
+        newStart: 1,
+        newLines: 3,
+        lines: [
+          { kind: { kind: "Context" }, oldLineno: 1, newLineno: 1, content: "ctx needle one" },
+          { kind: { kind: "Deletion" }, oldLineno: 2, newLineno: null, content: "removed line" },
+          { kind: { kind: "Addition" }, oldLineno: null, newLineno: 2, content: "added needle two" },
+        ],
+      },
+    ],
+  },
+];
+
+const PREFIX = "find-panel";
+
+const findChord = () => {
+  let handled = false;
+  act(() => {
+    handled = useKeymapStore.getState().dispatch({
+      key: "f",
+      code: "KeyF",
+      metaKey: true,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: false,
+      preventDefault() {},
+      target: document.body,
+    } as unknown as KeyboardEvent);
+  });
+  return handled;
+};
+
+beforeEach(async () => {
+  resetInvokeMock();
+  useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+  useKeymapStore.getState().setPreset("rider");
+  useFocusStore.setState({
+    focused: null,
+    panes: new Map(),
+    order: [],
+    barId: null,
+    pendingContentFocus: false,
+  } as never);
+  render(
+    <CommitDiffPanel
+      diffs={diffs}
+      loading={false}
+      error={null}
+      header="x to y"
+      paneIdPrefix={PREFIX}
+    />,
+  );
+  await waitFor(() =>
+    expect(document.querySelectorAll("[data-hunk-index]").length).toBe(1),
+  );
+  act(() => {
+    useFocusStore.setState({ focused: `${PREFIX}.view` } as never);
+  });
+  expect(findChord()).toBe(true);
+  fireEvent.change(screen.getByTestId("diff-find-input"), {
+    target: { value: "needle" },
+  });
+});
+
+describe("CommitDiffPanel find", () => {
+  it("marks every match and makes the current one distinct", () => {
+    const hits = document.querySelectorAll('[data-testid="diff-find-match"]');
+    expect([...hits].map((el) => el.textContent)).toEqual(["needle", "needle"]);
+    expect(document.querySelectorAll("[data-find-active]")).toHaveLength(1);
+    expect(screen.getByTestId("diff-find-count").textContent).toBe("1 of 2");
+  });
+
+  it("keeps the selection split — highlights live inside the code cell", () => {
+    const container = document.body;
+    expect(
+      [...container.querySelectorAll(".pg-selectable")].map((el) => el.textContent),
+    ).toEqual(["ctx needle one", "removed line", "added needle two"]);
+    const copied = selectionText(container);
+    expect(copied).toContain("ctx needle one");
+    expect(copied).not.toContain("+added");
+    expect(copied).not.toContain("-removed");
+  });
+});

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -26,6 +26,9 @@ import { useVariableWindow } from "@/lib/useVariableWindow";
 import { useViewportH } from "@/lib/useViewportH";
 import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
 import { buildLineSpans } from "@/lib/lineSpans";
+import type { FindMark } from "@/lib/diffFind";
+import { DiffFindBar } from "./DiffFindBar";
+import { useDiffFind } from "./useDiffFind";
 import type { FileDiff } from "@/lib/types";
 import { isTextualDiff } from "@/lib/derive";
 import { LfsDiffNotice } from "@/features/lfs/LfsDiffNotice";
@@ -40,33 +43,62 @@ import { LfsDiffNotice } from "@/features/lfs/LfsDiffNotice";
  */
 const CommitDiffRowText = React.memo(function CommitDiffRowText({
   line,
+  marks,
 }: {
   line: DiffLineData;
+  /**
+   * Find-in-diff hits on this row, or undefined for a row with none (#241).
+   *
+   * Undefined rather than an empty array, for the same reason `PGDiffRow` takes
+   * it that way: this component is memoized and the panel re-renders its whole
+   * window on every keystroke in the find box.
+   */
+  marks?: readonly FindMark[];
 }) {
   const text = line.text ?? "";
   // Memoized (and the component memo'd on the row's stable identity): this
   // panel renders a window of rows per frame and the span tiling is the only
   // non-trivial work per row.
   const rendered = React.useMemo(
-    () => buildLineSpans(text, line.syntax ?? null, line.spans),
-    [text, line.syntax, line.spans],
+    () => buildLineSpans(text, line.syntax ?? null, line.spans, marks),
+    [text, line.syntax, line.spans, marks],
   );
   if (rendered.length === 0) return <>{text}</>;
-  if (rendered.length === 1 && !rendered[0].cls && !rendered[0].changed) {
+  if (
+    rendered.length === 1 &&
+    !rendered[0].cls &&
+    !rendered[0].changed &&
+    !rendered[0].mark
+  ) {
     return <>{text}</>;
   }
   const tint =
     line.kind === "rem"
       ? "oklch(from var(--git-removed) l c h / 0.28)"
       : "oklch(from var(--git-added) l c h / 0.28)";
+  // Find paint, derived from --accent so it themes and hardcodes no hue. The
+  // ACTIVE match flips the foreground too: "which one is Enter on" has to survive
+  // a line that is already tinted red or green.
+  const markStyle = (mark: "match" | "active" | undefined) =>
+    mark === "active"
+      ? { background: "var(--accent)", color: "var(--accent-ink)", borderRadius: 2 }
+      : mark
+        ? { background: "oklch(from var(--accent) l c h / 0.3)", borderRadius: 2 }
+        : undefined;
   return (
     <>
       {rendered.map((s, k) => (
         <span
           key={k}
           className={s.cls}
-          data-testid={s.changed ? "word-change" : undefined}
-          style={s.changed ? { background: tint, borderRadius: 2 } : undefined}
+          data-testid={
+            s.mark ? "diff-find-match" : s.changed ? "word-change" : undefined
+          }
+          data-find-active={s.mark === "active" ? "" : undefined}
+          style={
+            markStyle(s.mark) ??
+            (s.changed ? { background: tint, borderRadius: 2 } : undefined)
+          }
         >
           {text.slice(s.start, s.end)}
         </span>
@@ -238,6 +270,20 @@ export function CommitDiffPanel({
     heights,
     viewportH,
     scrollRef,
+  });
+
+  // Find in diff (#241) — the same hook the windowed-diff surfaces use, over the
+  // same row model. This panel keeps its own lighter markup, so the MARKS are
+  // rendered by hand above; everything about matching, counting, wrapping and the
+  // by-offset scroll is shared.
+  const find = useDiffFind({
+    paneIds: [filesPaneId, viewPaneId],
+    rows,
+    heights,
+    scrollRef,
+    scrollTo: scrollDiffTo,
+    enabled: isTextualDiff(current) && !!current,
+    resetKey: selected,
   });
 
   // F7/⇧F7. The cursor lands on each hunk's ANCHOR row — its first changed line —
@@ -448,6 +494,7 @@ export function CommitDiffPanel({
         id={viewPaneId}
         style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column" }}
       >
+        <DiffFindBar find={find} />
         <div
           ref={diffBox.ref}
           style={{ flex: 1, minWidth: 0, minHeight: 0, display: "flex" }}
@@ -537,7 +584,10 @@ export function CommitDiffPanel({
                   {kind === "add" ? "+" : kind === "rem" ? "-" : " "}
                 </span>
                 <span className="pg-selectable">
-                  <CommitDiffRowText line={row.line} />
+                  <CommitDiffRowText
+                    line={row.line}
+                    marks={find.marksFor(win.start + k)}
+                  />
                 </span>
               </div>
             );

--- a/src/features/diff/DiffFindBar.tsx
+++ b/src/features/diff/DiffFindBar.tsx
@@ -1,0 +1,97 @@
+// The find bar every diff surface mounts, driven by `useDiffFind`.
+//
+// It renders INSIDE the diff pane on purpose. Focusing the input then puts the
+// focus store on that pane (PGPane's onFocusCapture), which is what keeps the
+// pane-scoped Escape binding (`diff.closeFind`) alive while the caret sits in the
+// box — a bar mounted outside the pane would close only after clicking away.
+import { PGButton, PGIconButton, PGInput } from "@/design";
+import type { DiffFind } from "./useDiffFind";
+
+/**
+ * "3 of 128", "No results", or nothing at all before anything is typed.
+ *
+ * The count is over the WHOLE row model, which is the point of the feature: a
+ * count of what is rendered would say "1" for a file with two hundred hits.
+ */
+function countLabel(find: DiffFind): string {
+  if (find.query.length === 0) return "";
+  if (find.matchCount === 0) return "No results";
+  const total = find.truncated ? `${find.matchCount}+` : `${find.matchCount}`;
+  return `${find.current + 1} of ${total}`;
+}
+
+export function DiffFindBar({ find }: { find: DiffFind }) {
+  if (!find.open) return null;
+  return (
+    <div
+      data-testid="diff-find-bar"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 6,
+        padding: "5px 10px",
+        background: "var(--bg-1)",
+        borderBottom: "1px solid var(--border-0)",
+        flexShrink: 0,
+      }}
+    >
+      <PGInput
+        icon="search"
+        size="sm"
+        mono
+        value={find.query}
+        onChange={find.setQuery}
+        inputRef={find.inputRef}
+        placeholder="Find in diff"
+        aria-label="Find in diff"
+        data-testid="diff-find-input"
+        style={{ width: 240 }}
+        // Enter / Shift+Enter step the matches. Handled on the input rather than
+        // through the keymap because the caret is IN it: the dispatcher suppresses
+        // bare-key chords inside a text field (so `list.activate` never sees this
+        // Enter), and "Enter submits the box you are typing in" is the one chord a
+        // form owns rather than the app.
+        onKeyDown={(e) => {
+          if (e.key !== "Enter") return;
+          e.preventDefault();
+          if (e.shiftKey) find.prev();
+          else find.next();
+        }}
+      />
+      <span
+        data-testid="diff-find-count"
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "var(--fs-11)",
+          color: "var(--fg-2)",
+          minWidth: 74,
+        }}
+      >
+        {countLabel(find)}
+      </span>
+      <PGButton
+        size="xs"
+        variant={find.caseSensitive ? "primary" : "ghost"}
+        aria-pressed={find.caseSensitive}
+        title="Match case"
+        data-testid="diff-find-case"
+        onClick={() => find.setCaseSensitive(!find.caseSensitive)}
+      >
+        Aa
+      </PGButton>
+      <PGIconButton
+        icon="chevronUp"
+        size="sm"
+        title="Previous match (Shift+Enter)"
+        onClick={find.prev}
+      />
+      <PGIconButton
+        icon="chevronDown"
+        size="sm"
+        title="Next match (Enter)"
+        onClick={find.next}
+      />
+      <PGIconButton icon="x" size="sm" title="Close (Escape)" onClick={find.close} />
+    </div>
+  );
+}

--- a/src/features/diff/useDiffFind.test.tsx
+++ b/src/features/diff/useDiffFind.test.tsx
@@ -1,0 +1,257 @@
+// The find bar's behaviour, driven through the shared hook.
+//
+// The claims worth pinning are the ones the windowing makes non-obvious:
+//
+//  - a match FAR outside the rendered window is found and counted;
+//  - reaching it is a scrollTop write computed from the row heights, and NEVER a
+//    `scrollIntoView` on a DOM node (which under windowing addresses whatever
+//    happens to be mounted - the #68 G10 trap);
+//  - the chord that opens it declines inside a text input, so the commit message
+//    box and the file filter keep their own find key.
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { useDiffFind } from "./useDiffFind";
+import { DiffFindBar } from "./DiffFindBar";
+import { useFocusStore, useKeymapStore } from "@/features/keymap";
+import { flattenDiffRows } from "@/lib/diffRows";
+import type { FileDiff } from "@/lib/types";
+
+const ROW_H = 19;
+const VIEWPORT_H = 190; // ten rows
+
+/** 300 context lines; `hit(i)` decides which of them carry the needle. */
+function bigDiff(hit: (i: number) => string): FileDiff["hunks"] {
+  const n = 300;
+  return [
+    {
+      header: `@@ -1,${n} +1,${n} @@`,
+      oldStart: 1,
+      oldLines: n,
+      newStart: 1,
+      newLines: n,
+      lines: Array.from({ length: n }, (_, i) => ({
+        kind: { kind: "Context" as const },
+        oldLineno: i + 1,
+        newLineno: i + 1,
+        content: `${hit(i)}\n`,
+      })),
+    },
+  ];
+}
+
+const PANE = "test.diff";
+
+let scrolls: number[] = [];
+let intoView: ReturnType<typeof vi.fn>;
+const realIntoView = Element.prototype.scrollIntoView;
+
+function Harness({ hunks, enabled = true }: { hunks: FileDiff["hunks"]; enabled?: boolean }) {
+  const rows = React.useMemo(
+    () => flattenDiffRows(hunks, { foldH: 22, rowH: ROW_H }),
+    [hunks],
+  );
+  const heights = React.useMemo(() => rows.map((r) => r.h), [rows]);
+  const scrollRef = React.useRef<HTMLDivElement>(null);
+  // jsdom lays nothing out, so the scroll box has to be faked: a real viewport
+  // height (or `scrollTopForRow` no-ops on `viewportH <= 0`) and a scrollTop that
+  // actually stores what is written to it.
+  const attach = React.useCallback((el: HTMLDivElement | null) => {
+    scrollRef.current = el;
+    if (el && !Object.getOwnPropertyDescriptor(el, "clientHeight")) {
+      Object.defineProperty(el, "clientHeight", { value: VIEWPORT_H, configurable: true });
+      Object.defineProperty(el, "scrollTop", { value: 0, writable: true, configurable: true });
+    }
+  }, []);
+  const find = useDiffFind({
+    paneIds: PANE,
+    rows,
+    heights,
+    scrollRef,
+    scrollTo: (top) => {
+      scrolls.push(top);
+      if (scrollRef.current) scrollRef.current.scrollTop = top;
+    },
+    enabled,
+  });
+  return (
+    <div>
+      <div ref={attach} data-testid="scroller" />
+      <DiffFindBar find={find} />
+      <div data-testid="count">{find.matchCount}</div>
+      <div data-testid="current">{find.current}</div>
+      {/* A row's marks, by absolute index — proof the lookup reaches past the window. */}
+      <div data-testid="marks-250">{JSON.stringify(find.marksFor(250) ?? null)}</div>
+    </div>
+  );
+}
+
+/** Dispatch a chord straight at the store, the way AppShell's listener does. */
+function press(o: {
+  key: string;
+  code?: string;
+  meta?: boolean;
+  shift?: boolean;
+  target?: EventTarget;
+}): boolean {
+  let handled = false;
+  act(() => {
+    handled = useKeymapStore.getState().dispatch({
+      key: o.key,
+      code: o.code ?? "",
+      metaKey: o.meta ?? false,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: o.shift ?? false,
+      preventDefault() {},
+      target: o.target ?? document.body,
+    } as unknown as KeyboardEvent);
+  });
+  return handled;
+}
+
+const findChord = (target?: EventTarget) =>
+  press({ key: "f", code: "KeyF", meta: true, target });
+const escape = () => press({ key: "Escape" });
+
+const input = () => screen.getByTestId("diff-find-input") as HTMLInputElement;
+const type = (q: string) => fireEvent.change(input(), { target: { value: q } });
+const count = () => Number(screen.getByTestId("count").textContent);
+const current = () => Number(screen.getByTestId("current").textContent);
+
+beforeEach(() => {
+  scrolls = [];
+  intoView = vi.fn();
+  // The DOM route this feature must never take: a spy here is what turns "we
+  // scrolled by offset" from a claim into an assertion.
+  Element.prototype.scrollIntoView = intoView as unknown as Element["scrollIntoView"];
+  useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+  useKeymapStore.getState().setPreset("rider");
+  useFocusStore.setState({
+    focused: PANE,
+    panes: new Map(),
+    order: [],
+    barId: null,
+    pendingContentFocus: false,
+  } as never);
+});
+
+afterEach(() => {
+  Element.prototype.scrollIntoView = realIntoView;
+  useFocusStore.setState({ focused: null } as never);
+});
+
+describe("find in diff", () => {
+  it("opens on the find chord while a diff pane holds focus", () => {
+    render(<Harness hunks={bigDiff((i) => `line ${i}`)} />);
+    expect(screen.queryByTestId("diff-find-bar")).not.toBeInTheDocument();
+    expect(findChord()).toBe(true);
+    expect(screen.getByTestId("diff-find-bar")).toBeInTheDocument();
+  });
+
+  it("finds and counts a match far OUTSIDE the rendered window", () => {
+    // Row 250 of 300. A window is a screenful — ten rows here — so this row is
+    // nowhere in the document, which is exactly what the webview's own find
+    // cannot see and this feature exists for.
+    render(<Harness hunks={bigDiff((i) => (i === 250 ? "the needle" : `line ${i}`))} />);
+    findChord();
+    type("needle");
+    expect(count()).toBe(1);
+    expect(current()).toBe(0);
+    // ...and the row is genuinely not mounted: nothing rendered its text.
+    expect(screen.queryByText("the needle")).not.toBeInTheDocument();
+    // ...while the model still hands that row its highlight.
+    expect(screen.getByTestId("marks-250").textContent).toBe(
+      JSON.stringify([{ start: 4, end: 10, active: true }]),
+    );
+  });
+
+  it("reaches the match BY OFFSET, never by scrollIntoView", () => {
+    render(<Harness hunks={bigDiff((i) => (i === 250 ? "the needle" : `line ${i}`))} />);
+    findChord();
+    type("needle");
+    // `scrollTopForRow` reveal semantics: the row's BOTTOM edge flush with the
+    // viewport's. 251 rows above it, minus the ten-row viewport.
+    expect(scrolls.at(-1)).toBe(251 * ROW_H - VIEWPORT_H);
+    expect(intoView).not.toHaveBeenCalled();
+  });
+
+  it("counts every match and steps next/previous with wrap-around", () => {
+    render(<Harness hunks={bigDiff((i) => (i % 100 === 0 ? "needle" : `line ${i}`))} />);
+    findChord();
+    type("needle");
+    expect(count()).toBe(3); // rows 0, 100, 200
+    expect(current()).toBe(0);
+    fireEvent.keyDown(input(), { key: "Enter" });
+    expect(current()).toBe(1);
+    fireEvent.keyDown(input(), { key: "Enter" });
+    expect(current()).toBe(2);
+    // Off the end, back to the first.
+    fireEvent.keyDown(input(), { key: "Enter" });
+    expect(current()).toBe(0);
+    // ...and off the start, back to the last.
+    fireEvent.keyDown(input(), { key: "Enter", shiftKey: true });
+    expect(current()).toBe(2);
+  });
+
+  it("matches case-insensitively until the toggle says otherwise", () => {
+    render(
+      <Harness hunks={bigDiff((i) => (i < 2 ? (i === 0 ? "Needle" : "needle") : `x${i}`))} />,
+    );
+    findChord();
+    type("needle");
+    expect(count()).toBe(2);
+    fireEvent.click(screen.getByTestId("diff-find-case"));
+    expect(count()).toBe(1);
+    fireEvent.click(screen.getByTestId("diff-find-case"));
+    expect(count()).toBe(2);
+  });
+
+  it("reports no results without pretending to have a cursor", () => {
+    render(<Harness hunks={bigDiff((i) => `line ${i}`)} />);
+    findChord();
+    type("nothing here");
+    expect(count()).toBe(0);
+    expect(current()).toBe(-1);
+    expect(screen.getByTestId("diff-find-count").textContent).toBe("No results");
+  });
+
+  it("closes on Escape", () => {
+    render(<Harness hunks={bigDiff((i) => `line ${i}`)} />);
+    findChord();
+    expect(screen.getByTestId("diff-find-bar")).toBeInTheDocument();
+    expect(escape()).toBe(true);
+    expect(screen.queryByTestId("diff-find-bar")).not.toBeInTheDocument();
+    // ...and once it is shut the chord falls through, so Escape still reaches
+    // whatever overlay is behind it.
+    expect(escape()).toBe(false);
+  });
+
+  it("does not open over a diff with nothing to search (binary, LFS)", () => {
+    render(<Harness hunks={bigDiff((i) => `line ${i}`)} enabled={false} />);
+    expect(findChord()).toBe(false);
+    expect(screen.queryByTestId("diff-find-bar")).not.toBeInTheDocument();
+  });
+
+  it("does not steal the find key from a text input", () => {
+    render(<Harness hunks={bigDiff((i) => `line ${i}`)} />);
+    const box = document.createElement("input");
+    document.body.appendChild(box);
+    expect(findChord(box)).toBe(false);
+    expect(screen.queryByTestId("diff-find-bar")).not.toBeInTheDocument();
+    // ...including a TEXTAREA, which is what the commit message box is.
+    const area = document.createElement("textarea");
+    document.body.appendChild(area);
+    expect(findChord(area)).toBe(false);
+    box.remove();
+    area.remove();
+  });
+
+  it("is not offered while another pane holds focus", () => {
+    render(<Harness hunks={bigDiff((i) => `line ${i}`)} />);
+    act(() => {
+      useFocusStore.setState({ focused: "somewhere.else" } as never);
+    });
+    expect(findChord()).toBe(false);
+  });
+});

--- a/src/features/diff/useDiffFind.ts
+++ b/src/features/diff/useDiffFind.ts
@@ -1,0 +1,236 @@
+// useDiffFind — the find bar's state, keys and scrolling, once for every diff
+// surface that renders the flat row model.
+//
+// Three rules from `docs/dev/frontend.md` meet here, and all three are the reason
+// this is a hook rather than four copies:
+//
+// 1. **Search the ROW MODEL, never the rendered window.** The surfaces are
+//    windowed, so the webview's own find would search a screenful and report "no
+//    results" for a match two thousand lines down. `lib/diffFind.ts` scans
+//    `DiffRow[]`, which is the whole file. (Same reason `lib/diffCopy.ts` exists.)
+// 2. **Scroll BY OFFSET, never `scrollIntoView`.** The row a match sits on is
+//    almost always unmounted, so a `querySelector` finds nothing and the DOM route
+//    silently does nothing — the #68 G10 trap. `scrollTopForRow` needs no DOM at
+//    all, and the write goes through `useVariableWindow.scrollTo` so the rendered
+//    range actually follows (issue 188).
+// 3. **The find chord must not steal the key from an input that already wants it.**
+//    That is `diff.find`'s `suppressInInput` in `features/keymap/actions.ts`, not
+//    anything here: the dispatcher never resolves the action while focus sits in a
+//    text field, so the commit-message box, the file filter and this bar's own
+//    input all keep Mod+F.
+import React from "react";
+import { useAction } from "@/features/keymap";
+import { scrollTopForRow } from "@/lib/diffRows";
+import type { DiffRow } from "@/lib/diffRows";
+import {
+  findDiffMatches,
+  findMarksByRow,
+  firstMatchFrom,
+  rowAtOffset,
+  stepMatch,
+  type FindMark,
+} from "@/lib/diffFind";
+
+export interface DiffFind {
+  open: boolean;
+  /**
+   * Find is possible on what is showing (the `enabled` input).
+   *
+   * Exposed so a surface can HIDE its find affordance instead of offering a
+   * button that quietly does nothing — a control that declines invisibly is worse
+   * than no control.
+   */
+  available: boolean;
+  query: string;
+  caseSensitive: boolean;
+  /** Number of matches in the whole row model — not in the window. */
+  matchCount: number;
+  /** True when the count is a floor (`MAX_FIND_MATCHES`). */
+  truncated: boolean;
+  /** 0-based index of the current match, `-1` when there is none. */
+  current: number;
+  setQuery: (q: string) => void;
+  setCaseSensitive: (v: boolean) => void;
+  next: () => void;
+  prev: () => void;
+  /** Open the bar and focus its input — the toolbar button's half of the chord. */
+  openBar: () => void;
+  close: () => void;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  /** Marks for one ABSOLUTE row index — the prop `PGWindowedDiff` wants. */
+  marksFor: (rowIndex: number) => readonly FindMark[] | undefined;
+}
+
+export function useDiffFind(o: {
+  /** Panes the find chords answer from — the diff pane, or it and its file list. */
+  paneIds: string | readonly string[];
+  rows: DiffRow[];
+  heights: number[];
+  scrollRef: React.RefObject<HTMLElement | null>;
+  /** `useVariableWindow`'s setter. A bare `scrollTop =` leaves the window behind. */
+  scrollTo: (top: number) => void;
+  /**
+   * There is something searchable on screen. Gate this on `isTextualDiff` — a
+   * binary or LFS diff renders a notice, not rows, and a find bar over it would
+   * be a control that can never match anything.
+   */
+  enabled: boolean;
+  /** The viewed file. The cursor restarts when it changes; the query survives. */
+  resetKey?: unknown;
+}): DiffFind {
+  const { paneIds, rows, heights, scrollRef, scrollTo, enabled, resetKey } = o;
+
+  const [open, setOpen] = React.useState(false);
+  const [query, setQuery] = React.useState("");
+  const [caseSensitive, setCaseSensitive] = React.useState(false);
+  const [current, setCurrent] = React.useState(-1);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  // Closed, or nothing to search: no scan at all. `enabled` going false must also
+  // drop the matches, or a binary file would keep the previous file's count.
+  const { matches, truncated } = React.useMemo(
+    () =>
+      open && enabled
+        ? findDiffMatches(rows, query, { caseSensitive })
+        : { matches: [], truncated: false },
+    [open, enabled, rows, query, caseSensitive],
+  );
+
+  /**
+   * Put a row on screen BY OFFSET.
+   *
+   * `scrollTopForRow` REVEALS — the smallest move that brings the row into view,
+   * and a no-op when it is already visible. That is the right semantics for a
+   * find: stepping through neighbouring matches should scroll a line at a time,
+   * exactly as the line cursor does, rather than yanking the pane on every Enter
+   * the way `scrollTopForHunk`'s centring deliberately does for F7.
+   */
+  const revealRow = React.useCallback(
+    (rowIndex: number) => {
+      const el = scrollRef.current;
+      if (!el) return;
+      scrollTo(
+        scrollTopForRow(heights, rowIndex, {
+          scrollTop: el.scrollTop,
+          viewportH: el.clientHeight,
+        }),
+      );
+    },
+    [heights, scrollRef, scrollTo],
+  );
+
+  /**
+   * The reader's current row, from the scroll offset by prefix sum.
+   *
+   * From the model, not the DOM: the heights say exactly which row sits at the top
+   * of the viewport, and the rows around it are the only ones a DOM query could
+   * see anyway.
+   */
+  const readerRow = React.useCallback(
+    () => rowAtOffset(heights, scrollRef.current?.scrollTop ?? 0),
+    [heights, scrollRef],
+  );
+
+  // A new query (or a new file) restarts the cursor at the first match from where
+  // the reader IS, so opening find deep in a file does not throw them back to the
+  // top of it. `-1` when nothing matches — `stepMatch` reads that as "no cursor".
+  const matchKey = matches.length === 0 ? "" : `${caseSensitive} ${query}`;
+  React.useEffect(() => {
+    setCurrent(matches.length === 0 ? -1 : firstMatchFrom(matches, readerRow()));
+    // `matches` is a fresh array per scan, so keying on it would re-enter on every
+    // unrelated render of the owning screen; the query+mode pair is what actually
+    // changes the answer. `resetKey` is in here for the file change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [matchKey, resetKey]);
+
+  // Reveal whatever the cursor lands on, wherever it came from — typing, Enter,
+  // the chevrons. One effect, so every path scrolls the same way.
+  React.useEffect(() => {
+    const m = matches[current];
+    if (open && m) revealRow(m.rowIndex);
+    // Same reason as above: keyed on the position, not on the array identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [current, matchKey, open]);
+
+  const step = React.useCallback(
+    (delta: 1 | -1) => setCurrent((c) => stepMatch(matches.length, c, delta)),
+    [matches.length],
+  );
+  const next = React.useCallback(() => step(1), [step]);
+  const prev = React.useCallback(() => step(-1), [step]);
+
+  const close = React.useCallback(() => {
+    setOpen(false);
+    setCurrent(-1);
+  }, []);
+
+  // The bar's input takes focus on open — and on a second find chord while it is
+  // already open, which re-selects the query so typing replaces it. That second
+  // press only ever arrives from OUTSIDE a text field (see `suppressInInput`),
+  // which is precisely the case where the reader has clicked back into the diff.
+  const openFind = React.useCallback(() => {
+    setOpen(true);
+    // On a frame boundary: on the first open the input does not exist yet.
+    const focus = () => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    };
+    if (typeof requestAnimationFrame === "function") requestAnimationFrame(focus);
+    else focus();
+  }, []);
+
+  useAction(
+    "diff.find",
+    () => {
+      // Nothing searchable (binary, LFS, no diff): decline rather than offer a
+      // control that can never match. The chord then falls through unhandled.
+      if (!enabled) return false;
+      openFind();
+      return true;
+    },
+    [enabled, openFind],
+    { paneId: paneIds },
+  );
+
+  useAction(
+    "diff.closeFind",
+    () => {
+      // Declining is what keeps Escape reaching app.closeOverlay from a diff pane
+      // when there is no find bar to close — see the ordering note in presets.ts.
+      if (!open) return false;
+      close();
+      return true;
+    },
+    [open, close],
+    { paneId: paneIds },
+  );
+
+  const marks = React.useMemo(
+    () => (open ? findMarksByRow(matches, current) : new Map<number, FindMark[]>()),
+    [open, matches, current],
+  );
+  const marksFor = React.useCallback(
+    (rowIndex: number) => marks.get(rowIndex),
+    [marks],
+  );
+
+  return {
+    // `enabled` also HIDES the bar, so switching to a binary file does not leave a
+    // find box floating over "Binary file — no textual diff."
+    open: open && enabled,
+    available: enabled,
+    query,
+    caseSensitive,
+    matchCount: matches.length,
+    truncated,
+    current,
+    setQuery,
+    setCaseSensitive,
+    next,
+    prev,
+    openBar: openFind,
+    close,
+    inputRef,
+    marksFor,
+  };
+}

--- a/src/features/keymap/actions.ts
+++ b/src/features/keymap/actions.ts
@@ -93,6 +93,8 @@ export type ActionId =
   | "diff.stageHunk"
   | "diff.discardHunk"
   | "diff.copy"
+  | "diff.find"
+  | "diff.closeFind"
   | "commit.commit"
   | "commit.commitAndPush"
   | "commit.toggleAmend"
@@ -353,6 +355,28 @@ export const ACTIONS: Record<ActionId, ActionDef> = {
   // ever offered while a diff pane holds focus; `suppressInInput` keeps it away
   // from the commit-message textarea, where Mod+C is the caret's.
   "diff.copy": { id: "diff.copy", title: "Copy selected diff lines", category: "Diff", scope: "pane", suppressInInput: true },
+  // Find in diff (#241). The webview's own ⌘F is useless here: the diff surfaces
+  // are windowed, so native find would search the screenful that happens to be
+  // mounted and answer "no results" for a match two thousand lines down. This
+  // action opens a find bar that searches the ROW MODEL instead — the same reason
+  // `diff.copy` exists one entry up.
+  //
+  // suppressInInput, and that is the whole answer to "⌘F must not steal the key
+  // from an input that already wants it": the dispatcher never resolves a
+  // suppressed action while focus sits in an INPUT/TEXTAREA/contentEditable, so
+  // the commit-message box, the file filter and the find bar's OWN input all keep
+  // whatever ⌘F means to them. Pane-scoped on top of that, so it is only ever
+  // offered while a diff pane holds focus.
+  "diff.find": { id: "diff.find", title: "Find in diff", category: "Diff", scope: "pane", suppressInInput: true },
+  // Escape closes the find bar. Pane-scoped, which is what makes sharing Escape
+  // with the GLOBAL app.closeOverlay legal (the same asymmetry as
+  // diff.viewCombined vs nav.diff) — and the handler DECLINES when the bar is
+  // shut, so Escape still reaches the overlay from a diff pane.
+  //
+  // allowInInput because the bar autofocuses its own input: a bare-key chord is
+  // suppressed inside a text field unless the action opts in, and an Escape that
+  // only worked after clicking away from the box would not close anything.
+  "diff.closeFind": { id: "diff.closeFind", title: "Close the diff find bar", category: "Diff", scope: "pane", allowInInput: true },
 
   "repo.open": { id: "repo.open", title: "Open repository…", category: "Repository", scope: "global", run: openRepoOp },
   "repo.clone": { id: "repo.clone", title: "Clone repository…", category: "Repository", scope: "global", run: cloneRepoOp },

--- a/src/features/keymap/presets.test.ts
+++ b/src/features/keymap/presets.test.ts
@@ -192,6 +192,31 @@ describe("Mod+D is shared between a pane action and a global one (#158)", () => 
   });
 });
 
+// Same asymmetry on Escape (#241): the diff find bar's close is pane-scoped and
+// DECLINES when the bar is shut, so app.closeOverlay — global, with a default
+// runner that never declines — must be offered second or it would swallow every
+// Escape in the app.
+describe("Escape is shared between the find bar and the overlay closer (#241)", () => {
+  for (const preset of BUILTIN_PRESETS) {
+    it(`${preset.id}: offers diff.closeFind before app.closeOverlay`, () => {
+      const ids = buildReverseMap(preset).get("Escape") ?? [];
+      expect(ids).toEqual(["diff.closeFind", "app.closeOverlay"]);
+      expect(ACTIONS["diff.closeFind"].scope).toBe("pane");
+      // A bare key inside the find bar's own input only dispatches for an action
+      // that opted in — and the bar autofocuses that input.
+      expect(ACTIONS["diff.closeFind"].allowInInput).toBe(true);
+    });
+
+    it(`${preset.id}: binds find-in-diff to the unshifted find key`, () => {
+      // ⌘⇧F stays the Files tree's filter — a different question, a different pane.
+      expect(preset.bindings["diff.find"]).toEqual(["Mod+F"]);
+      expect(preset.bindings["tree.find"]).toEqual(["Mod+Shift+F"]);
+      // The one rule that keeps ⌘F out of a text field that wants it.
+      expect(ACTIONS["diff.find"].suppressInInput).toBe(true);
+    });
+  }
+});
+
 describe("repository tabs (#90)", () => {
   // Every preset binds them (the catalog-coverage test above enforces that);
   // these pin the SHAPE of the chords, which is what makes them work on every

--- a/src/features/keymap/presets.ts
+++ b/src/features/keymap/presets.ts
@@ -42,6 +42,11 @@ const COMMON = {
   // NOT Mod+Alt+N — AltGr on Windows (see the no-new-Mod+Alt+letter rule in
   // presets.test.ts and the two specs it cites).
   "repo.init": ["Mod+Shift+N"],
+  // ORDER IS LOAD-BEARING, the same way diff.viewCombined sits before nav.diff
+  // below: buildReverseMap walks Object.entries, so the PANE action must be
+  // offered before the global one, or app.closeOverlay (which is global with a
+  // default runner) would answer Escape first everywhere. #241.
+  "diff.closeFind": ["Escape"],
   "app.closeOverlay": ["Escape"],
   // Editor-style zoom. Two chords each: "Mod+=" is the unshifted key, "Mod++"
   // is what Shift+= (and the numpad plus) produce — eventToChord bakes the
@@ -83,6 +88,11 @@ const COMMON = {
   // which leaves the chord unhandled and the webview's native copy in charge, so
   // this binding never takes Mod+C away from anything.
   "diff.copy": ["Mod+C"],
+  // The find key every editor has, unshifted — ⌘⇧F is already tree.find (the
+  // Files tree's filter), and the two are different questions asked of different
+  // panes. Free in both presets. Pane-scoped and suppressInInput (see actions.ts),
+  // so it never reaches a text field that wants ⌘F for itself. #241.
+  "diff.find": ["Mod+F"],
   // The History selection's diff, on the same Mod+D as nav.diff (#158). Legal
   // because this one is pane-scoped: the dispatcher tries each id bound to a
   // chord in turn, and the pane handler declines unless the commit list has focus

--- a/src/lib/diffFind.test.ts
+++ b/src/lib/diffFind.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_FIND_MATCHES,
+  findDiffMatches,
+  findMarksByRow,
+  firstMatchFrom,
+  rowAtOffset,
+  rowFindText,
+  stepMatch,
+} from "./diffFind";
+import { flattenDiffRows } from "./diffRows";
+import type { DiffRow } from "./diffRows";
+import type { FileDiff } from "./types";
+
+/** A context-only hunk of `n` lines whose text is `line <i>`. */
+function ctxHunk(n: number, text: (i: number) => string): FileDiff["hunks"] {
+  return [
+    {
+      header: `@@ -1,${n} +1,${n} @@`,
+      oldStart: 1,
+      oldLines: n,
+      newStart: 1,
+      newLines: n,
+      lines: Array.from({ length: n }, (_, i) => ({
+        kind: { kind: "Context" as const },
+        oldLineno: i + 1,
+        newLineno: i + 1,
+        content: `${text(i)}\n`,
+      })),
+    },
+  ];
+}
+
+const rowsOf = (hunks: FileDiff["hunks"]): DiffRow[] =>
+  flattenDiffRows(hunks, { foldH: 22, rowH: 19 });
+
+describe("rowFindText", () => {
+  it("drops the trailing newline git puts on every line", () => {
+    const rows = rowsOf(ctxHunk(1, () => "needle"));
+    expect(rows[0].kind).toBe("line");
+    expect(rowFindText(rows[0])).toBe("needle");
+  });
+
+  it("has no text for a fold separator — the lines it hides are not on screen", () => {
+    const fold: DiffRow = {
+      kind: "fold",
+      gapIndex: 0,
+      hiddenLines: 12,
+      fromL: 1,
+      fromR: 1,
+      h: 22,
+    };
+    expect(rowFindText(fold)).toBeNull();
+  });
+});
+
+describe("findDiffMatches", () => {
+  it("finds a match FAR OUTSIDE any rendered window", () => {
+    // The whole point of the feature: a window is a screenful, so a match 2000
+    // rows down is not in the document at all. The model has it anyway.
+    const rows = rowsOf(ctxHunk(2000, (i) => (i === 1873 ? "the needle" : `line ${i}`)));
+    const { matches } = findDiffMatches(rows, "needle");
+    expect(matches).toEqual([{ rowIndex: 1873, start: 4, end: 10 }]);
+  });
+
+  it("counts every occurrence, including several on one line", () => {
+    const rows = rowsOf(ctxHunk(3, (i) => (i === 1 ? "aa bb aa" : "cc")));
+    expect(findDiffMatches(rows, "aa").matches).toEqual([
+      { rowIndex: 1, start: 0, end: 2 },
+      { rowIndex: 1, start: 6, end: 8 },
+    ]);
+  });
+
+  it("does not overlap matches with themselves", () => {
+    const rows = rowsOf(ctxHunk(1, () => "aaaa"));
+    expect(findDiffMatches(rows, "aa").matches).toHaveLength(2);
+  });
+
+  it("is case-insensitive by default and exact with the toggle on", () => {
+    const rows = rowsOf(ctxHunk(2, (i) => (i === 0 ? "Needle" : "needle")));
+    expect(findDiffMatches(rows, "needle").matches).toHaveLength(2);
+    expect(
+      findDiffMatches(rows, "needle", { caseSensitive: true }).matches,
+    ).toEqual([{ rowIndex: 1, start: 0, end: 6 }]);
+    expect(
+      findDiffMatches(rows, "Needle", { caseSensitive: true }).matches,
+    ).toEqual([{ rowIndex: 0, start: 0, end: 6 }]);
+  });
+
+  it("treats an empty query as no search, not as a match per row", () => {
+    const rows = rowsOf(ctxHunk(5, (i) => `line ${i}`));
+    expect(findDiffMatches(rows, "")).toEqual({ matches: [], truncated: false });
+  });
+
+  it("stops at the ceiling and says the count is a floor", () => {
+    const rows = rowsOf(ctxHunk(MAX_FIND_MATCHES + 10, () => "x"));
+    const res = findDiffMatches(rows, "x");
+    expect(res.matches).toHaveLength(MAX_FIND_MATCHES);
+    expect(res.truncated).toBe(true);
+  });
+
+  it("never matches the trailing newline", () => {
+    const rows = rowsOf(ctxHunk(3, (i) => `line ${i}`));
+    expect(findDiffMatches(rows, "\n").matches).toEqual([]);
+  });
+});
+
+describe("stepMatch", () => {
+  it("wraps forward off the end and backward off the start", () => {
+    expect(stepMatch(3, 2, 1)).toBe(0);
+    expect(stepMatch(3, 0, -1)).toBe(2);
+    expect(stepMatch(3, 0, 1)).toBe(1);
+    expect(stepMatch(3, 2, -1)).toBe(1);
+  });
+
+  it("enters at the first match forward and the last one backward", () => {
+    expect(stepMatch(3, -1, 1)).toBe(0);
+    expect(stepMatch(3, -1, -1)).toBe(2);
+  });
+
+  it("has no cursor with nothing to step through", () => {
+    expect(stepMatch(0, -1, 1)).toBe(-1);
+    expect(stepMatch(0, 4, -1)).toBe(-1);
+  });
+});
+
+describe("firstMatchFrom", () => {
+  it("starts at the first match at or after the reader's row", () => {
+    const matches = [
+      { rowIndex: 2, start: 0, end: 1 },
+      { rowIndex: 40, start: 0, end: 1 },
+      { rowIndex: 90, start: 0, end: 1 },
+    ];
+    expect(firstMatchFrom(matches, 0)).toBe(0);
+    expect(firstMatchFrom(matches, 3)).toBe(1);
+    expect(firstMatchFrom(matches, 90)).toBe(2);
+  });
+
+  it("wraps to the top when nothing follows, and has no answer with no matches", () => {
+    expect(firstMatchFrom([{ rowIndex: 2, start: 0, end: 1 }], 500)).toBe(0);
+    expect(firstMatchFrom([], 0)).toBe(-1);
+  });
+});
+
+describe("findMarksByRow", () => {
+  it("groups by row and flags exactly the active match", () => {
+    const matches = [
+      { rowIndex: 4, start: 0, end: 2 },
+      { rowIndex: 4, start: 6, end: 8 },
+      { rowIndex: 9, start: 1, end: 3 },
+    ];
+    const map = findMarksByRow(matches, 1);
+    expect(map.get(4)).toEqual([
+      { start: 0, end: 2 },
+      { start: 6, end: 8, active: true },
+    ]);
+    expect(map.get(9)).toEqual([{ start: 1, end: 3 }]);
+  });
+
+  it("leaves a row with no matches undefined, so a memoized row keeps its prop", () => {
+    const map = findMarksByRow([{ rowIndex: 4, start: 0, end: 2 }], 0);
+    expect(map.get(5)).toBeUndefined();
+  });
+});
+
+describe("rowAtOffset", () => {
+  it("finds the row at a scroll position by prefix sum, never by the DOM", () => {
+    const heights = [19, 19, 22, 19, 19];
+    expect(rowAtOffset(heights, 0)).toBe(0);
+    expect(rowAtOffset(heights, 18)).toBe(0);
+    expect(rowAtOffset(heights, 19)).toBe(1);
+    expect(rowAtOffset(heights, 40)).toBe(2);
+    expect(rowAtOffset(heights, 10_000)).toBe(4);
+  });
+});

--- a/src/lib/diffFind.ts
+++ b/src/lib/diffFind.ts
@@ -1,0 +1,177 @@
+// Find-in-diff, over the ROW MODEL rather than the rendered window.
+//
+// Why this exists at all is the same reason `lib/diffCopy.ts` does: every diff
+// surface is windowed, so only about a screenful of rows is in the document at
+// any moment. The webview's own find would therefore search a few dozen rows and
+// report "no results" for a match two thousand lines down — not a degraded
+// answer, a wrong one. These helpers scan `DiffRow[]`, which is the whole file,
+// and hand back positions the surfaces reach BY OFFSET (`scrollTopForRow`).
+//
+// Pure and DOM-free on purpose: the hook that drives it (`features/diff/
+// useDiffFind.ts`) owns the React state and the scrolling, and everything worth
+// pinning about matching, counting and wrapping is pinned here.
+import type { DiffRow } from "./diffRows";
+
+/** One match, addressed in the flat row model's index space. */
+export interface DiffFindMatch {
+  /**
+   * Index into the flat `DiffRow[]` — NOT into the rendered window, and not a
+   * `changedIndex`. This is what `scrollTopForRow` addresses.
+   */
+  rowIndex: number;
+  /** Character offsets into the row's `line.text`. */
+  start: number;
+  end: number;
+}
+
+/**
+ * A highlight range handed to a renderer. `active` marks the ONE match the
+ * cursor sits on, which every surface must draw differently — a find that
+ * highlights ten matches identically cannot tell you which one Enter just moved
+ * you to.
+ */
+export interface FindMark {
+  start: number;
+  end: number;
+  active?: boolean;
+}
+
+export interface DiffFindResult {
+  matches: DiffFindMatch[];
+  /** True when the scan stopped at `MAX_FIND_MATCHES` and the count is a floor. */
+  truncated: boolean;
+}
+
+/**
+ * Ceiling on collected matches.
+ *
+ * A one-character query over a whole-file diff of `MAX_WHOLE_FILE_LINES` rows can
+ * match hundreds of thousands of times, and the scan re-runs on every keystroke.
+ * Scanning that much text is cheap; ALLOCATING that many match objects is not, so
+ * the collection stops and the count is reported as a floor ("5000+"). Nobody
+ * navigates match 6000 of 400000 — they type another character.
+ */
+export const MAX_FIND_MATCHES = 5000;
+
+/**
+ * The text of a row as the reader sees it, or null for a row that has none.
+ *
+ * `fold` rows are chrome (a separator naming a hidden run), so they are not
+ * searchable — the lines they hide are not on screen to be found. A trailing
+ * newline is dropped: `DiffLine.content` is git's raw line, so it usually carries
+ * one, and it is not something the reader can see or would mean to search for.
+ * Dropping it from the END cannot shift any earlier offset, so match positions
+ * still index straight into `line.text`.
+ */
+export function rowFindText(row: DiffRow): string | null {
+  if (row.kind === "fold") return null;
+  const text = row.line.text;
+  if (text == null) return null;
+  return text.replace(/\r?\n$/, "");
+}
+
+/**
+ * Every match of `query` in the row model, in reading order.
+ *
+ * Matches are non-overlapping and left-to-right, the way every editor's find
+ * counts them: a search for "aa" in "aaaa" is two matches, not three.
+ *
+ * An empty query is not a search — it returns nothing rather than one zero-width
+ * match per row, which is what an unguarded `indexOf("")` loop produces.
+ */
+export function findDiffMatches(
+  rows: readonly DiffRow[],
+  query: string,
+  o?: { caseSensitive?: boolean },
+): DiffFindResult {
+  const matches: DiffFindMatch[] = [];
+  if (query.length === 0) return { matches, truncated: false };
+  const caseSensitive = o?.caseSensitive ?? false;
+  const needle = caseSensitive ? query : query.toLowerCase();
+
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+    const raw = rowFindText(rows[rowIndex]);
+    if (raw == null || raw.length === 0) continue;
+    const hay = caseSensitive ? raw : raw.toLowerCase();
+    let from = 0;
+    for (;;) {
+      const at = hay.indexOf(needle, from);
+      if (at < 0) break;
+      matches.push({ rowIndex, start: at, end: at + needle.length });
+      if (matches.length >= MAX_FIND_MATCHES) return { matches, truncated: true };
+      from = at + needle.length;
+    }
+  }
+  return { matches, truncated: false };
+}
+
+/**
+ * The next/previous match index, WRAPPING at both ends.
+ *
+ * `current` is `-1` for "no cursor yet" — the state right after a query is typed
+ * and before anything has been stepped. From there forward means the first match
+ * and backward means the last, so ⇧Enter as the first keypress lands at the end
+ * of the file rather than doing nothing.
+ */
+export function stepMatch(count: number, current: number, delta: number): number {
+  if (count <= 0) return -1;
+  const base = current < 0 ? (delta > 0 ? -1 : 0) : current;
+  return (((base + delta) % count) + count) % count;
+}
+
+/**
+ * Index of the first match at or after `rowIndex`, else 0.
+ *
+ * Opening the find bar deep inside a file should not yank the reader back to the
+ * top of it, so the cursor starts at the first match from where they are reading.
+ * Wrapping to 0 when nothing follows is the same wrap `stepMatch` does.
+ */
+export function firstMatchFrom(
+  matches: readonly DiffFindMatch[],
+  rowIndex: number,
+): number {
+  if (matches.length === 0) return -1;
+  const at = matches.findIndex((m) => m.rowIndex >= rowIndex);
+  return at < 0 ? 0 : at;
+}
+
+/**
+ * Matches grouped by row, with the active one flagged — the shape a renderer
+ * wants.
+ *
+ * A `Map` rather than an array per row: only rows that MATCH get an entry, so a
+ * row with no matches looks up `undefined`, and `undefined` is a stable prop that
+ * does not defeat `PGDiffRow`'s `React.memo` for the (usually vast) majority of
+ * the window.
+ */
+export function findMarksByRow(
+  matches: readonly DiffFindMatch[],
+  activeIndex: number,
+): Map<number, FindMark[]> {
+  const out = new Map<number, FindMark[]>();
+  matches.forEach((m, i) => {
+    const arr = out.get(m.rowIndex);
+    const mark: FindMark = { start: m.start, end: m.end };
+    if (i === activeIndex) mark.active = true;
+    if (arr) arr.push(mark);
+    else out.set(m.rowIndex, [mark]);
+  });
+  return out;
+}
+
+/**
+ * The row occupying scroll offset `y`, by prefix sum over the known heights.
+ *
+ * Same arithmetic `windowVariable` opens with, and the reason find never reads
+ * the DOM to answer "where is the reader": the rows around `y` are frequently
+ * unmounted.
+ */
+export function rowAtOffset(heights: readonly number[], y: number): number {
+  if (y <= 0) return 0;
+  let acc = 0;
+  for (let i = 0; i < heights.length; i++) {
+    acc += heights[i];
+    if (acc > y) return i;
+  }
+  return Math.max(0, heights.length - 1);
+}

--- a/src/lib/lineSpans.test.ts
+++ b/src/lib/lineSpans.test.ts
@@ -79,3 +79,46 @@ describe("buildLineSpans", () => {
     expect(tiles("abc", out)).toBe("abc");
   });
 });
+
+describe("buildLineSpans — find marks", () => {
+  const mark = (start: number, end: number, active?: boolean) => ({ start, end, active });
+
+  it("cuts a match out of the line and labels it", () => {
+    const out = buildLineSpans("a needle b", null, undefined, [mark(2, 8)]);
+    expect(out).toEqual([
+      { start: 0, end: 2, cls: undefined, changed: false },
+      { start: 2, end: 8, cls: undefined, changed: false, mark: "match" },
+      { start: 8, end: 10, cls: undefined, changed: false },
+    ]);
+    expect(tiles("a needle b", out)).toBe("a needle b");
+  });
+
+  it("labels the ACTIVE match differently — Enter has to be visible", () => {
+    const out = buildLineSpans("aa bb", null, undefined, [
+      mark(0, 2),
+      mark(3, 5, true),
+    ]);
+    expect(out.map((s) => s.mark)).toEqual(["match", undefined, "active"]);
+  });
+
+  it("keeps syntax and word-diff spans through a match", () => {
+    // A match lands on a keyword that is also part of a changed word: the tiling
+    // must carry all three, or highlighting find would erase the diff's own.
+    const out = buildLineSpans("let x", [syn(0, 3, "syn-keyword")], [word(0, 5, true)], [
+      mark(1, 2),
+    ]);
+    expect(out).toEqual([
+      { start: 0, end: 1, cls: "syn-keyword", changed: true },
+      { start: 1, end: 2, cls: "syn-keyword", changed: true, mark: "match" },
+      { start: 2, end: 3, cls: "syn-keyword", changed: true },
+      { start: 3, end: 5, cls: undefined, changed: true },
+    ]);
+    expect(tiles("let x", out)).toBe("let x");
+  });
+
+  it("is inert when no marks are passed", () => {
+    expect(buildLineSpans("abc", null, undefined, [])).toEqual([
+      { start: 0, end: 3, cls: undefined, changed: false },
+    ]);
+  });
+});

--- a/src/lib/lineSpans.ts
+++ b/src/lib/lineSpans.ts
@@ -7,6 +7,7 @@
 // it once syntax joins in.
 import type { SyntaxToken } from "./syntax";
 import type { WordSpan } from "./wordDiff";
+import type { FindMark } from "./diffFind";
 
 export interface RenderSpan {
   start: number;
@@ -15,6 +16,16 @@ export interface RenderSpan {
   cls?: string;
   /** True when the word diff marked this range as changed. */
   changed: boolean;
+  /**
+   * Set when find-in-diff matched this range: `"active"` for the ONE match the
+   * find cursor sits on, `"match"` for the rest.
+   *
+   * A third independent range set over the same line, reconciled here for the
+   * same reason the other two are — a renderer that wrapped matches in its own
+   * elements after the fact would have to reason about overlaps with syntax and
+   * word spans, and would break the tiling contract this module exists to keep.
+   */
+  mark?: "match" | "active";
 }
 
 interface Range {
@@ -54,6 +65,8 @@ export function buildLineSpans(
   text: string,
   syntax: SyntaxToken[] | null,
   words: WordSpan[] | undefined,
+  /** Find-in-diff hits on this line, sorted and non-overlapping (`diffFind.ts`). */
+  marks?: readonly FindMark[],
 ): RenderSpan[] {
   const len = text.length;
   if (len === 0) return [];
@@ -64,6 +77,7 @@ export function buildLineSpans(
   // this is a public helper and a `.find` scan per segment was the alternative.
   const syn = normalized(syntax, len);
   const wrd = normalized(words, len);
+  const mks = normalized(marks, len);
 
   // Boundaries: line ends plus every edge of either input.
   const cuts = new Set<number>([0, len]);
@@ -75,11 +89,16 @@ export function buildLineSpans(
     cuts.add(w.start);
     cuts.add(w.end);
   }
+  for (const m of mks) {
+    cuts.add(m.start);
+    cuts.add(m.end);
+  }
   const edges = [...cuts].sort((a, b) => a - b);
 
   const out: RenderSpan[] = [];
   let si = 0;
   let wi = 0;
+  let mi = 0;
   for (let i = 0; i + 1 < edges.length; i++) {
     const start = edges[i];
     const end = edges[i + 1];
@@ -89,9 +108,19 @@ export function buildLineSpans(
     const mid = (start + end) / 2;
     while (si < syn.length && syn[si].end <= mid) si++;
     while (wi < wrd.length && wrd[wi].end <= mid) wi++;
+    while (mi < mks.length && mks[mi].end <= mid) mi++;
     const tok = si < syn.length && syn[si].start <= mid ? syn[si] : undefined;
     const w = wi < wrd.length && wrd[wi].start <= mid ? wrd[wi] : undefined;
-    out.push({ start, end, cls: tok?.cls, changed: w?.changed ?? false });
+    const m = mi < mks.length && mks[mi].start <= mid ? mks[mi] : undefined;
+    out.push({
+      start,
+      end,
+      cls: tok?.cls,
+      changed: w?.changed ?? false,
+      // Only when there IS one: an always-present `mark: undefined` would be a
+      // fourth key on every span of every row in every window.
+      ...(m ? { mark: m.active ? ("active" as const) : ("match" as const) } : {}),
+    });
   }
   return out;
 }

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -84,6 +84,8 @@ import { usePlatform } from "@/lib/platform";
 import { useViewportH } from "@/lib/useViewportH";
 import { useElementSize } from "@/lib/useElementSize";
 import { MinimapGutter } from "@/features/diff/DiffMinimap";
+import { DiffFindBar } from "@/features/diff/DiffFindBar";
+import { useDiffFind } from "@/features/diff/useDiffFind";
 import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
 import {
   WhitespaceToggle,
@@ -762,6 +764,19 @@ export function CommitPanelScreen() {
     [heights, rowH, scrollDiffTo],
   );
 
+  // Find in diff (#241) — over the ROW MODEL, so a match below the rendered
+  // window is found and reached by offset. Unified only: split mode renders
+  // `PGSideBySideDiff`, which is a different renderer with no marks to give.
+  const find = useDiffFind({
+    paneIds: "commit.diff",
+    rows,
+    heights,
+    scrollRef: diffScrollRef,
+    scrollTo: scrollDiffTo,
+    enabled: diffMode === "unified" && isTextualDiff(diff) && !!diff,
+    resetKey: diff,
+  });
+
   /**
    * Space on the focused line, staging on the unstaged side and unstaging on the
    * staged side — the same direction rule the hunk header's button uses.
@@ -1410,6 +1425,7 @@ export function CommitPanelScreen() {
             }}
           />
         </div>
+        <DiffFindBar find={find} />
         <div
           ref={diffBox.ref}
           style={{ flex: 1, minWidth: 0, minHeight: 0, display: "flex" }}
@@ -1469,6 +1485,7 @@ export function CommitPanelScreen() {
                 selectedLines={(i) => lineSel[i] ?? []}
                 onLineClick={onLineClick}
                 focusedRow={lineFocus.focused?.rowIndex ?? null}
+                findMarks={find.marksFor}
                 hunkActions={(i) => ({
                   staged: selected?.side === "staged",
                   actionsDisabledReason: hunkActionsDisabled,

--- a/src/screens/DiffViewer.find.test.tsx
+++ b/src/screens/DiffViewer.find.test.tsx
@@ -1,0 +1,159 @@
+// Find in diff on a real surface (#241).
+//
+// `useDiffFind.test.tsx` pins the hook against a harness; this pins that the
+// DiffViewer actually wires it — the chord reaches the pane, the count is over
+// the whole file rather than the mounted rows, and the highlight lands in the
+// markup the screen renders.
+//
+// jsdom lays nothing out, so the viewport measures 0 and `windowVariable` falls
+// back to a screenful: a 400-line diff mounts a few dozen rows, which is what
+// makes the "counted but not mounted" assertion meaningful here.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { DiffViewerScreen } from "./DiffViewer";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { useFocusStore, useKeymapStore } from "@/features/keymap";
+import { mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { WithDialogs } from "@/test/dialog";
+import type { FileStatus } from "@/lib/types";
+
+vi.mock("@/lib/syntax/tokenize", async (orig) => ({
+  ...(await orig<typeof import("@/lib/syntax/tokenize")>()),
+  tokenizeFile: async () => null, // plain rows; this suite is about find
+}));
+
+const LINES = 400;
+const NEAR = 2; // inside the first window
+const FAR = 380; // far outside it
+
+const unstaged = (path: string): FileStatus => ({
+  path,
+  worktree: { kind: "Modified" },
+  index: { kind: "Unmodified" },
+  additions: 0,
+  deletions: 0,
+  embedded: false,
+});
+
+const diff = (path: string) => ({
+  path,
+  oldPath: null,
+  binary: false,
+  additions: 0,
+  deletions: 0,
+  hunks: [
+    {
+      header: `@@ -1,${LINES} +1,${LINES} @@`,
+      oldStart: 1,
+      oldLines: LINES,
+      newStart: 1,
+      newLines: LINES,
+      lines: Array.from({ length: LINES }, (_, i) => ({
+        kind: { kind: "Context" as const },
+        oldLineno: i + 1,
+        newLineno: i + 1,
+        content: i === NEAR || i === FAR ? `carries a needle ${i}` : `line ${i}`,
+      })),
+    },
+  ],
+});
+
+const findChord = (target?: EventTarget) => {
+  let handled = false;
+  act(() => {
+    handled = useKeymapStore.getState().dispatch({
+      key: "f",
+      code: "KeyF",
+      metaKey: true,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: false,
+      preventDefault() {},
+      target: target ?? document.body,
+    } as unknown as KeyboardEvent);
+  });
+  return handled;
+};
+
+beforeEach(async () => {
+  resetInvokeMock();
+  useSettingsStore.setState({ ignoreWhitespaceInDiff: false });
+  useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+  useKeymapStore.getState().setPreset("rider");
+  useFocusStore.setState({
+    focused: null,
+    panes: new Map(),
+    order: [],
+    barId: null,
+    pendingContentFocus: false,
+  } as never);
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
+    status: [unstaged("a.ts")],
+    branches: [],
+    remotes: [],
+    commits: [],
+    loading: false,
+  } as never);
+  mockInvoke("get_status", () => [unstaged("a.ts")]);
+  mockInvoke("get_diff", (args) => diff(args.path as string));
+  mockInvoke("read_file_content", () => ({
+    path: "a.ts", binary: false, text: "x", fromHead: false, size: 1,
+  }));
+  mockInvoke("read_file_content_at_rev", () => ({
+    path: "a.ts", binary: false, text: "x", fromHead: true, size: 1,
+  }));
+  render(
+    <WithDialogs>
+      <DiffViewerScreen />
+    </WithDialogs>,
+  );
+  await waitFor(() => expect(screen.getByText("line 0")).toBeInTheDocument());
+  act(() => {
+    useFocusStore.setState({ focused: "diff.view" } as never);
+  });
+});
+
+describe("DiffViewer find in diff", () => {
+  it("counts matches the rendered window cannot see", async () => {
+    expect(findChord()).toBe(true);
+    fireEvent.change(screen.getByTestId("diff-find-input"), {
+      target: { value: "needle" },
+    });
+    // The far match is genuinely not in the document...
+    expect(screen.queryByText(`carries a needle ${FAR}`)).not.toBeInTheDocument();
+    // ...and is counted anyway. Two of two, from the row model.
+    expect(screen.getByTestId("diff-find-count").textContent).toBe("1 of 2");
+  });
+
+  it("highlights the match that IS on screen, marking the current one", () => {
+    findChord();
+    fireEvent.change(screen.getByTestId("diff-find-input"), {
+      target: { value: "needle" },
+    });
+    const hits = document.querySelectorAll('[data-testid="diff-find-match"]');
+    expect([...hits].map((el) => el.textContent)).toEqual(["needle"]);
+    expect(hits[0].hasAttribute("data-find-active")).toBe(true);
+  });
+
+  it("keeps the whole file on screen — this is a find, not a filter", () => {
+    // The old "Find in diff" on this screen rewrote the hunks down to matching
+    // lines, so typing a query deleted the file around it. Non-matching rows must
+    // survive.
+    findChord();
+    fireEvent.change(screen.getByTestId("diff-find-input"), {
+      target: { value: "needle" },
+    });
+    expect(screen.getByText("line 0")).toBeInTheDocument();
+    expect(screen.getByText("line 1")).toBeInTheDocument();
+  });
+
+  it("declines the chord while the caret is in the file filter", () => {
+    // The screen's own filter box: Mod+F there belongs to the input.
+    const filter = document.querySelector("input") as HTMLInputElement;
+    expect(filter).toBeTruthy();
+    expect(findChord(filter)).toBe(false);
+    expect(screen.queryByTestId("diff-find-bar")).not.toBeInTheDocument();
+  });
+});

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -44,10 +44,18 @@ import { useVariableWindow } from "@/lib/useVariableWindow";
 import { useViewportH } from "@/lib/useViewportH";
 import { useElementSize } from "@/lib/useElementSize";
 import { MinimapGutter } from "@/features/diff/DiffMinimap";
+import { DiffFindBar } from "@/features/diff/DiffFindBar";
+import { useDiffFind } from "@/features/diff/useDiffFind";
 import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
 import { useDensityStep } from "@/features/settings/useSettingsStore";
 import { pairChangedLines } from "@/lib/pairChangedLines";
-import { PGPane, FocusableScroll, usePaneList, useHunkNav } from "@/features/keymap";
+import {
+  PGPane,
+  FocusableScroll,
+  chordFor,
+  usePaneList,
+  useHunkNav,
+} from "@/features/keymap";
 import type { FileDiff } from "@/lib/types";
 
 export function DiffViewerScreen() {
@@ -67,12 +75,6 @@ export function DiffViewerScreen() {
   );
   const [wrap, setWrap] = React.useState(false);
   const [filter, setFilter] = React.useState("");
-  const [findQuery, setFindQuery] = React.useState("");
-  const [findOpen, setFindOpen] = React.useState(false);
-  const findInputRef = React.useRef<HTMLInputElement>(null);
-  React.useEffect(() => {
-    if (findOpen) findInputRef.current?.focus();
-  }, [findOpen]);
   const [selectedPath, setSelectedPath] = React.useState<string | null>(null);
   const [diff, setDiff] = React.useState<FileDiff | null>(null);
   const [diffLoading, setDiffLoading] = React.useState(false);
@@ -156,27 +158,12 @@ export function DiffViewerScreen() {
     new: { kind: "worktree" },
   });
 
-  const findFiltered = React.useMemo<FileDiff | null>(() => {
-    if (!diff || !findQuery.trim()) return diff;
-    const q = findQuery.toLowerCase();
-    const hunks = diff.hunks
-      .map((h) => ({
-        ...h,
-        lines: h.lines.filter((ln) => ln.content.toLowerCase().includes(q)),
-      }))
-      .filter((h) => h.lines.length > 0);
-    return { ...diff, hunks };
-  }, [diff, findQuery]);
-
   // Right-click to copy. A read-only surface, so there is no line selection to
   // offer — just the dragged text and the whole file, which is the part a
-  // windowed selection cannot reach. Built off `findFiltered` so Find narrowing
-  // the diff narrows what "copy the file" means, matching what is on screen.
-  const diffCopyMenu = useContextMenu<void>(() =>
-    diffCopyMenuItems({ diff: findFiltered }),
-  );
+  // windowed selection cannot reach.
+  const diffCopyMenu = useContextMenu<void>(() => diffCopyMenuItems({ diff }));
 
-  const split = React.useMemo(() => diffToSplit(findFiltered), [findFiltered]);
+  const split = React.useMemo(() => diffToSplit(diff), [diff]);
 
   // Same side rule as the unified path: the left column is the old file, the
   // right the new one, and a row resolves its tokens by its own line number.
@@ -216,15 +203,10 @@ export function DiffViewerScreen() {
   const foldH = 22 + useDensityStep();
   const { expanded: expandedGaps, expand: expandGap } = useExpandedGaps(selectedPath);
 
-  // A find query rewrites the hunks down to matching lines only, so the pane
-  // becomes a list of matches rather than a file. Filler rows are never matches,
-  // so whole-file mode is suppressed while a query is active.
-  const { gaps, text: diffText } = useDiffGaps(syntax, {
-    disabled: !!findQuery.trim(),
-  });
+  const { gaps, text: diffText } = useDiffGaps(syntax);
   const rows = React.useMemo(
     () =>
-      flattenDiffRows(findFiltered?.hunks ?? [], {
+      flattenDiffRows(isTextualDiff(diff) && diff ? diff.hunks : [], {
         foldH,
         rowH,
         syntax,
@@ -232,7 +214,7 @@ export function DiffViewerScreen() {
         gaps,
         expandedGaps,
       }),
-    [findFiltered, foldH, rowH, syntax, diffText, gaps, expandedGaps],
+    [diff, foldH, rowH, syntax, diffText, gaps, expandedGaps],
   );
   const heights = React.useMemo(() => rows.map((r) => r.h), [rows]);
 
@@ -264,6 +246,29 @@ export function DiffViewerScreen() {
   // breath — the window here, the minimap and `scrollToHunk` further down — so one
   // heights array stays the single source of truth for whoever is still reading it.
   const win = wrap ? undefined : varWin;
+
+  // Find in diff (#241) — over the ROW MODEL, not the rendered window, and
+  // reached by offset. It replaces the line FILTER this screen used to call
+  // "Find in diff": that rewrote the hunks down to matching lines, which meant
+  // whole-file mode had to be switched off, "copy the file" meant "copy the
+  // matches", and the one thing a reader actually wants - where in the file the
+  // match is - was the one thing it could not say.
+  //
+  // Not offered in split mode (a different renderer, `PGSideBySideDiff`) nor in
+  // WRAP mode: wrap makes `DiffRow.h` describe nothing, and a wrap caller drops
+  // windowing, the minimap and offset scrolling together. Find is an
+  // offset-scrolling consumer, so it drops with them — and `open && enabled`
+  // means turning Wrap on closes an open bar rather than leaving one that
+  // scrolls to the wrong line.
+  const find = useDiffFind({
+    paneIds: ["diff.files", "diff.view"],
+    rows,
+    heights,
+    scrollRef,
+    scrollTo: scrollDiffTo,
+    enabled: mode === "unified" && !wrap && isTextualDiff(diff) && !!diff,
+    resetKey: selectedPath,
+  });
 
   // F7/⇧F7 walk the viewed file's hunks from either pane. Scroll to the hunk's
   // ANCHOR row BY OFFSET (#157): a querySelector would find nothing whenever that
@@ -340,7 +345,7 @@ export function DiffViewerScreen() {
   );
   const hunkCursor = useHunkNav({
     paneIds: ["diff.files", "diff.view"],
-    count: findFiltered?.hunks.length ?? 0,
+    count: diff?.hunks.length ?? 0,
     resetKey: selectedPath,
     // Wrap mode measures the mounted rows instead of trusting `heights` — same
     // centring rule, different ruler.
@@ -439,52 +444,21 @@ export function DiffViewerScreen() {
               label="Wrap"
               testId="diff-wrap-toggle"
             />
-            <PGIconButton
-              icon="search"
-              size="md"
-              title="Find in diff"
-              active={findOpen}
-              onClick={() => {
-                setFindOpen((v) => {
-                  if (v) setFindQuery("");
-                  return !v;
-                });
-              }}
-            />
+            {/* Hidden rather than disabled when find cannot run (split, wrap,
+                binary): the chord declines there too, and a button that quietly
+                does nothing is worse than no button. */}
+            {find.available && (
+              <PGIconButton
+                icon="search"
+                size="md"
+                title={`Find in diff (${chordFor("diff.find")})`}
+                active={find.open}
+                onClick={() => (find.open ? find.close() : find.openBar())}
+              />
+            )}
           </>
         }
       />
-      {findOpen && (
-        <div
-          style={{
-            padding: "6px 10px",
-            borderBottom: "1px solid var(--border-0)",
-            background: "var(--bg-1)",
-            display: "flex",
-            alignItems: "center",
-            gap: 8,
-          }}
-        >
-          <PGSearchInput
-            value={findQuery}
-            onChange={setFindQuery}
-            placeholder="Find in diff…"
-            inputRef={findInputRef}
-            style={{ width: 320 }}
-          />
-          <span
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "var(--fs-11)",
-              color: "var(--fg-2)",
-            }}
-          >
-            {findQuery.trim()
-              ? `${findFiltered?.hunks.reduce((n, h) => n + h.lines.length, 0) ?? 0} matches`
-              : ""}
-          </span>
-        </div>
-      )}
       <div
         ref={layout.ref}
         style={{
@@ -588,7 +562,9 @@ export function DiffViewerScreen() {
               (#93). `isTextualDiff` is the shared gate; the notice is the shared
               replacement. */}
           {!diffLoading && diff?.lfs && <LfsDiffNotice diff={diff} />}
-          {!diffLoading && isTextualDiff(findFiltered) && findFiltered && mode === "unified" && (
+          {!diffLoading && isTextualDiff(diff) && diff && mode === "unified" && (
+            <>
+            <DiffFindBar find={find} />
             <div
               ref={diffBox.ref}
               style={{ flex: 1, minWidth: 0, display: "flex", minHeight: 0 }}
@@ -603,15 +579,13 @@ export function DiffViewerScreen() {
                 }}
                 onContextMenu={(e) => diffCopyMenu.onContextMenu(e, undefined)}
               >
-                {findFiltered.hunks.length === 0 && findQuery.trim() && (
-                  <PGEmpty icon="search" title="No matches" />
-                )}
                 <PGWindowedDiff
                   rows={rows}
                   window={win}
                   wrap={wrap}
                   activeHunk={hunkCursor >= 0 ? hunkCursor : undefined}
                   onExpandGap={expandGap}
+                  findMarks={find.marksFor}
                 />
               </FocusableScroll>
               {/* Wrap makes row heights genuinely unknown — the same reason
@@ -629,8 +603,9 @@ export function DiffViewerScreen() {
                 />
               )}
             </div>
+            </>
           )}
-          {!diffLoading && isTextualDiff(findFiltered) && findFiltered && mode === "split" && (
+          {!diffLoading && isTextualDiff(diff) && diff && mode === "split" && (
             <PGSideBySideDiff
               left={splitWithSyntax.left}
               right={splitWithSyntax.right}

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -64,6 +64,8 @@ import { useVariableWindow } from "@/lib/useVariableWindow";
 import { useViewportH } from "@/lib/useViewportH";
 import { useElementSize } from "@/lib/useElementSize";
 import { MinimapGutter } from "@/features/diff/DiffMinimap";
+import { DiffFindBar } from "@/features/diff/DiffFindBar";
+import { useDiffFind } from "@/features/diff/useDiffFind";
 import { useDiffRowHeight } from "@/lib/useDiffRowHeight";
 import { buildLineSpans } from "@/lib/lineSpans";
 import { splitCodeLines } from "@/lib/codeLines";
@@ -705,6 +707,19 @@ export function RepoBrowserScreen() {
     viewportH: diffViewportH,
     scrollRef: diffScrollRef,
   });
+  // Find in diff (#241) — over the ROW MODEL, not the rendered window. Answers
+  // from both panes, the way F7 does here: the reader arrows through the tree on
+  // the left while reading the diff on the right.
+  const find = useDiffFind({
+    paneIds: ["repo.tree", "repo.preview"],
+    rows: diffRows,
+    heights: diffHeights,
+    scrollRef: diffScrollRef,
+    scrollTo: scrollDiffTo,
+    enabled: isTextualDiff(diff) && !!diff,
+    resetKey: selectedFile?.path ?? null,
+  });
+
   // ── Hunk cursor + hunk-level chords (#157) ───────────────────────────────
   // This pane had no F7 either; the `@@` banner's Stage/Discard was mouse-only.
   // Scroll BY OFFSET — the anchor row is usually unmounted under windowing.
@@ -1144,6 +1159,7 @@ export function RepoBrowserScreen() {
               Blame
             </PGButton>
           </div>
+          <DiffFindBar find={find} />
           <div
             ref={diffBox.ref}
             style={{ flex: 1, minWidth: 0, minHeight: 0, display: "flex" }}
@@ -1195,6 +1211,7 @@ export function RepoBrowserScreen() {
                 window={diffWin}
                 activeHunk={hunkCursor >= 0 ? hunkCursor : undefined}
                 onExpandGap={expandGap}
+                findMarks={find.marksFor}
                 hunkActions={(i) => ({
                   staged: false,
                   actionsDisabledReason: hunkActionsDisabled,

--- a/test/diffFindSurfaces.test.ts
+++ b/test/diffFindSurfaces.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment node
+ */
+// "Every diff surface offers find-in-diff." (#241)
+//
+// Same shape, and the same reasoning, as `diffCopyMenu.test.ts` next door: the
+// diff surfaces are WINDOWED, so the webview's own find would search the
+// screenful that happens to be mounted and answer "no results" for a match two
+// thousand lines down. `useDiffFind` searches the row model instead — and a
+// surface that forgets to mount it is a surface where the find key does nothing
+// at all, which looks like nothing, not like a bug, until someone tries.
+//
+// What no rendering test can catch is a FIFTH diff surface arriving without it,
+// which is exactly the mistake this file fails the build for. The behaviour is
+// pinned by `src/features/diff/useDiffFind.test.tsx` and the highlighting by
+// `src/design/diffFindHighlight.test.tsx`.
+//
+// The merge window is deliberately NOT in this list: it renders conflicts through
+// CodeMirror (`features/merge/`), not through the flat DiffRow model, so it shares
+// none of this and has none of the windowing problem that motivates it.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/** Every file that renders diff rows — the same four as the copy menu's list. */
+const DIFF_SURFACES = [
+  "src/screens/CommitPanel.tsx",
+  "src/screens/DiffViewer.tsx",
+  "src/screens/RepoBrowser.tsx",
+  "src/features/diff/CommitDiffPanel.tsx",
+];
+
+const read = (p: string) => readFileSync(resolve(process.cwd(), p), "utf8");
+
+describe("find in diff reaches every diff surface", () => {
+  it.each(DIFF_SURFACES)("%s drives the shared hook", (file) => {
+    expect(read(file)).toContain("useDiffFind(");
+  });
+
+  it.each(DIFF_SURFACES)("%s mounts the bar", (file) => {
+    expect(read(file)).toContain("<DiffFindBar");
+  });
+
+  // A bar with no highlighting is a match counter, not a find: the reader still
+  // cannot see WHICH text matched. Each surface hands its renderer the marks —
+  // three through `PGWindowedDiff`'s `findMarks`, and `CommitDiffPanel` through
+  // its own markup, which is why this greps for the shared accessor rather than
+  // for one prop name.
+  it.each(DIFF_SURFACES)("%s hands its renderer the marks", (file) => {
+    expect(read(file)).toContain("find.marksFor");
+  });
+
+  // The four surfaces are the SAME four the copy menu names, and for the same
+  // reason. Keeping the lists in step is what stops a new surface being added to
+  // one and forgotten by the other.
+  it("names the same surfaces the copy-menu guard does", () => {
+    const other = read("test/diffCopyMenu.test.ts");
+    for (const file of DIFF_SURFACES) expect(other).toContain(file);
+  });
+
+  // The merge window renders no DiffRow, so it must not be quietly half-wired.
+  it("leaves the merge window out, and out of the row model entirely", () => {
+    const merge = read("src/features/merge/MergeBody.tsx");
+    expect(merge).not.toContain("useDiffFind");
+    expect(merge).not.toContain("flattenDiffRows");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

⌘F / Ctrl+F opens a find bar on the diff pane, searching the **full row model** rather than the rendered window. Match count, Enter / Shift+Enter for next / previous, Escape to close, case-sensitivity toggle, all matches highlighted with the current one distinct.

The browser's own find is useless here: the diff is windowed, so `PGWindowedDiff` only has visible rows in the DOM and native find would search a few dozen rows and miss the file.

Closes #241.

## ⚠️ This deletes an existing control — please confirm

The issue says *"Today: Nothing"*, but DiffViewer **did** ship a "Find in diff" button. It was a **line filter**, not a find:

```ts
// removed
const findFiltered = diff.hunks
  .map(h => ({ ...h, lines: h.lines.filter(ln => ln.content.toLowerCase().includes(q)) }))
  .filter(h => h.lines.length > 0);
```

Consequences it had, all visible in the removed code: whole-file mode was **suppressed** while a query was active (filler rows are never matches), `diffCopyMenu` was built off the filtered diff so **"copy the file" meant "copy the matches"**, and it could never say *where* a match was — the actual question you open a find bar to answer.

Keeping both would put two controls named "Find in diff" on one screen. Nothing pinned the old behaviour in tests; it dated to the initial release, which is presumably why the issue reads it as absent.

**If you want the line filter kept, it needs a different name and its own control — say so and I'll restore it as e.g. "Filter lines".**

## Where the find bar is, and is not

**Has it — all four diff surfaces:**
- `CommitPanel.tsx` — working copy / staging
- `DiffViewer.tsx` — the Changes screen
- `RepoBrowser.tsx` — Files preview
- `CommitDiffPanel.tsx` — **commit, compare, history-inline and stash** (its own markup; one wiring covers four screens)

**Deliberately not:**
- **Merge window** — CodeMirror, no `DiffRow`, none of the windowing problem that motivates this. `test/diffFindSurfaces.test.ts` asserts it stays **out** rather than half-wired.
- **Split mode** — a different renderer (`PGSideBySideDiff`).
- **Wrap mode** — wrap makes `DiffRow.h` describe nothing, and the documented rule is that a wrap caller drops windowing, the minimap and offset scrolling together. Turning Wrap on **closes** an open bar rather than leaving one that scrolls to the wrong line, and the button hides so nothing declines invisibly.

## The two rules the issue called out

**Searches beyond the rendered window** — proven, not asserted in prose:
- `useDiffFind.test.tsx` → *"finds and counts a match far OUTSIDE the rendered window"*: 300 rows, needle on row 250, ten-row viewport; asserts `count() === 1`, asserts the text is **not** in the document, and asserts the highlight still resolves for row 250.
- `DiffViewer.find.test.tsx` → 400-line diff, needles at rows 2 and 380; row 380 absent from the DOM, count still reads `1 of 2`.
- `diffFind.test.ts` → 2000 rows, needle at 1873.

**Scrolls by offset, never `scrollIntoView`** — `scrollTopForRow(...)` written through the caller's `useVariableWindow.scrollTo`, one implementation so no surface can get it wrong. The test asserts the exact value (`251 * 19 - 190 = 4579`) *and* spies `Element.prototype.scrollIntoView` for zero calls. Reveal semantics rather than centring, so stepping between neighbouring matches scrolls a line instead of yanking the pane.

## The selection split, and the chord

Highlighting is a **third range set inside `buildLineSpans`**, not markup wrapped around matched text. That keeps the tiling contract, keeps syntax and word-diff spans intact through a match, and leaves the marks as spans *inside* `.pg-selectable` — so line numbers and the `+`/`−` marker stay unselectable and the code cell stays selectable.

⌘F is a catalog action with `scope: "pane"` and **`suppressInInput`** — the pre-existing keymap mechanism, not a hand-rolled listener — so the commit-message box, the file filter and the find bar's own input all keep the chord. Escape is bound *before* the global `app.closeOverlay` and declines when the bar is shut, so Escape still reaches overlays; `presets.test.ts` pins that ordering in both presets.

## Notable

- Match count capped at 5000, displayed "5000+" — scanning per keystroke is cheap, allocating 500k match objects is not.
- No regex; the issue lists it as a nice-to-have and it was not nearly free.
- Highlight paint derives from `var(--accent)` inline (`oklch(from …)`, the pattern `PGDiffRow` already uses) rather than a new semantic token — those are duplicated per theme mode in `SEMANTIC_TOKENS` and drift.
- `data-testid="diff-find-match"` shadows `word-change` where a span is both; deliberate precedence while the bar is open, no current test or spec hits the combination.
- An open bar shrinks the diff viewport by ~34px; `useViewportH` re-measures, but worth one look in the real app.

## Checklist

- [x] One logical change, focused PR
- [x] Branched off `main` @ `d82664e`; no merge commits, single squashed commit
- [x] PR title + commit message follow Conventional Commits
- [x] `pnpm tsc --noEmit` passes — exit 0
- [ ] `cargo test` — **not run: no Rust in this diff.** CI covers it
- [x] `pnpm test` passes — 243 files, 2154 tests (+30 cases)
- [x] `pnpm exec tsc -p e2e/tsconfig.json --noEmit` passes; `e2e/` specs untouched
- [x] Added tests — incl. the outside-the-window proofs and the no-`scrollIntoView` spy
- [x] Not a new git op
- [x] `docs/dev/frontend.md` + `architecture.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
