### PR TITLE
feat(branches): fast-forward a branch without checking it out

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -196,6 +196,11 @@ commands/        Thin Tauri handlers, one file per area:
 ├── branches.rs  list_branches/tags/stashes/remotes,
 │                checkout/create/delete/rename_branch, set_upstream,
 │                fetch, fetch_all, pull, push,
+│                fast_forward_branch — fetch the branch's remote, then advance
+│                a NOT-checked-out branch to its upstream if that is a
+│                fast-forward (#246); fast_forward_all_branches does the sweep
+│                on one fetch. Both are thin: the ancestry check and the ref
+│                move are one backend call under one lock (see backend.md),
 │                add/remove/rename/prune_remote, set_remote_url,
 │                create/delete/push_tag, verify_tag, merge_branch, rebase_onto,
 │                checkout_ref, push_delete_branch

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -130,7 +130,8 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
 - **One runner.** Every network shell-out goes through
   `commands::net::run_git_authenticated` (clone uses its primitives
   `apply_auth_env` + `map_git_failure` for a streamed stderr): fetch, fetch_all,
-  pull, push, push_tag, push_delete_branch, clone_repo,
+  pull, push, push_tag, push_delete_branch, fast_forward_branch,
+  fast_forward_all_branches, clone_repo,
   forge_checkout_pull_request's fetch (its second git call passes `None` — the
   tip is already local), submodule_update, lfs_fetch/lfs_pull.
   `grep -rn 'run_git_authenticated\|run_git_creds\|apply_auth_env' src-tauri/src/`
@@ -317,6 +318,49 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   interruption silently reduces the index to the selection — staged work has no
   other copy anywhere. Crash-safety needs a journal and its own spec; do not
   stub an affordance meanwhile.
+
+## Fast-forwarding a branch you are not on (#246)
+
+`pull <remote> <branch>` never could do this: the branch argument is a
+*refspec*, so `git pull origin main` while HEAD is `feat/x` merges `origin/main`
+into `feat/x`. `GitBackend::fast_forward_branch` moves the branch's REF instead,
+and `fast_forward_all` sweeps every local branch that can.
+
+- **The network half and the ref half sit on opposite sides of the command
+  boundary, on purpose.** The fetch is a credentialed subprocess, so it stays in
+  `commands/branches.rs` on the one runner (`run_git_authenticated`). The
+  ancestry check and the ref move are libgit2 work that must not be split, so
+  they are ONE backend call. `fast_forward_remote` runs FIRST and refuses a
+  checked-out or untracked branch, so a call that cannot succeed never spends a
+  fetch.
+- **Verify and mutate under ONE lock acquisition** — the stash TOCTOU again, with
+  a ref instead of a reflog slot. `fast_forward_branch` is a single `with_repo`
+  closure, and `fast_forward_all` is a single closure for the WHOLE sweep
+  (listing included). `plan_fast_forward` hands the caller the `Reference` it
+  read, so the object that was checked is the object that moves — one ref lookup,
+  not two.
+- **A branch any working tree is standing on is refused**, HEAD here or a linked
+  worktree's HEAD: moving the ref without touching the index and worktree leaves
+  that checkout rendering every incoming change as a deletion. The frontend
+  routes HEAD to `pull` with the user's `defaultPullMode` instead. git2-rs 0.20
+  does not bind `git_branch_is_checked_out`, so `worktree::linked_worktree_heads`
+  walks the linked worktrees — one repository open each, which is why only
+  ref-moving ops pay it and a bulk sweep walks once.
+- **Already-current and strictly-ahead are `moved: false`, not errors**; only
+  real divergence is, as `NotFastForward` naming both refs. `NoUpstream` is its
+  own variant because the remedy is specific. A bulk run COLLECTS those refusals
+  into `diverged` / `checked_out` rather than aborting — one diverged branch must
+  not decide the fate of the other five.
+- **The remote comes from `branch.<name>.remote`, never `upstream.split('/')[0]`**
+  — a remote name may contain a slash, and `team/fork/main` would otherwise be
+  fetched from a remote called `team`. The frontend has the same rule in
+  `features/branches/fastForward.ts::remoteOfUpstream`, resolved against the
+  repository's own remote list.
+- **`fetch_args` ends option parsing before the remote name** (`git fetch
+  --prune -- origin`). Same finding class as `push_tag_args`: the remote is
+  user-supplied and `--upload-pack=<program>` names a program git runs for the
+  transport. Verified against git 2.50 — the fetch works normally, and a
+  dash-leading value is refused as a strange pathname instead of honoured.
 
 ## Deleting an untracked file (#245)
 

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -403,6 +403,21 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   `refreshAll` starts with `set({ error: null })` and React batches same-tick
   sets, so the opposite order wipes the banner. A failed git op must still
   refresh — the UI reflects disk truth even on error.
+- **`fastForwardBranch` routes HEAD to `pull`, and only HEAD** (#246). The
+  backend op moves a REF, which is wrong for the branch the working tree is
+  standing on — so the store checks `isHead` from `s.branches` and delegates to
+  its own `pull` with `useSettingsStore`'s `defaultPullMode`, keeping the
+  auto-stash and the user's chosen mode. Never `--ff-only` behind their back.
+  The bulk action (`fastForwardAllBranches`) does NOT route: it reports the
+  checked-out branch and leaves it, because a "fast-forward all" button must not
+  rewrite the working tree. Both return their outcome so the caller can flash a
+  summary (`features/branches/fastForward.ts`); the store never imports
+  `@/design`.
+- **The remote a branch tracks is not `upstream.split("/")[0]`** — a remote name
+  may contain a slash. `remoteOfUpstream(upstream, s.remotes)` resolves it
+  against the repository's own remote list, longest match first. The older
+  `branchMenuItems` Pull/Push entries still use the split; they predate the
+  helper and were left alone rather than changed under this feature's tests.
 
 ### Settings: one validator, two untrusted sources (#254)
 

--- a/src-tauri/src/commands/branches.rs
+++ b/src-tauri/src/commands/branches.rs
@@ -3,7 +3,10 @@ use tauri::State;
 use crate::{
     commands::net::Credentials,
     error::{AppError, AppResult},
-    git::types::{BranchInfo, PullMode, PushForce, RemoteInfo, RepoId, StashInfo, TagInfo, TagTarget},
+    git::types::{
+        BranchInfo, BulkFastForward, FastForward, PullMode, PushForce, RemoteInfo, RepoId,
+        StashInfo, TagInfo, TagTarget,
+    },
     state::AppState,
 };
 
@@ -151,14 +154,26 @@ async fn run_git_creds(
 }
 
 /// Build the argument list for `git fetch`. `remote = None` means all remotes.
+///
+/// The remote name lands strictly after `--`, for the reason spelled out on
+/// `push_tag_args` below: it is user-supplied (typed into the add-remote prompt,
+/// picked from the remote list) and `git fetch` has options that name a program
+/// to run for the transport (`--upload-pack=<program>`). `--all` is ours, so it
+/// stays where it is — there is no user value on that branch to separate.
+/// Verified against git 2.50: `git fetch --prune -- origin` fetches normally,
+/// and `-- --upload-pack=/bin/false` is refused as a strange pathname instead of
+/// being honoured as an option.
 fn fetch_args(remote: Option<&str>, prune: bool) -> Vec<&str> {
     let mut args = vec!["fetch"];
-    match remote {
-        Some(r) => args.push(r),
-        None => args.push("--all"),
+    if remote.is_none() {
+        args.push("--all");
     }
     if prune {
         args.push("--prune");
+    }
+    if let Some(r) = remote {
+        args.push("--");
+        args.push(r);
     }
     args
 }
@@ -215,6 +230,83 @@ pub async fn pull(
         credentials.as_ref(),
     )
     .await
+}
+
+/// Fetch a branch's remote, then advance the branch to its upstream (#246).
+///
+/// The op `pull` cannot be: `git pull <remote> <branch>` merges the fetched head
+/// into whatever HEAD is, so naming `main` while standing on `feat/x` merged
+/// `origin/main` into `feat/x`. This moves `main`'s ref and leaves HEAD alone.
+///
+/// **The network half and the ref half sit on opposite sides of the boundary on
+/// purpose.** A fetch is a subprocess with credentials, so it belongs here,
+/// where `run_git_authenticated` is the one credential path. The ancestry check
+/// and the ref move are libgit2 work that must not be split, so they are ONE
+/// backend call holding ONE lock — see `GitBackend::fast_forward_branch`. The
+/// remote lookup comes first and refuses a checked-out or untracked branch up
+/// front, so a call that could not have succeeded never spends a fetch.
+///
+/// A branch that IS `HEAD` is refused rather than silently fast-forwarded: it
+/// needs a working-tree update, and the user's `defaultPullMode` decides how.
+/// The frontend routes those to `pull` before calling this.
+#[tauri::command]
+pub async fn fast_forward_branch(
+    state: State<'_, AppState>,
+    repo_id: String,
+    branch: String,
+    prune: bool,
+    // Optional so the first attempt is always prompt-less and only a retry
+    // carries a credential (#61 D5), exactly as fetch/pull/push do.
+    credentials: Option<Credentials>,
+) -> AppResult<FastForward> {
+    let repo_id = RepoId(repo_id);
+    let path = get_repo_path(&state, &repo_id).await?;
+
+    let remote = {
+        let backend = state.backend.clone();
+        let id = repo_id.clone();
+        let name = branch.clone();
+        tokio::task::spawn_blocking(move || backend.fast_forward_remote(&id, &name))
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))??
+    };
+
+    run_git_creds(
+        &path,
+        &fetch_args(Some(remote.as_str()), prune),
+        credentials.as_ref(),
+    )
+    .await?;
+
+    let backend = state.backend.clone();
+    tokio::task::spawn_blocking(move || backend.fast_forward_branch(&repo_id, &branch))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+/// Fetch every remote, then fast-forward every local branch that can be (#246).
+///
+/// One fetch for the whole sweep — the reason this is a command of its own
+/// rather than the frontend looping the single-branch one, which would spend a
+/// network round trip per branch.
+///
+/// The per-branch refusals come back as a report, not an error: one diverged
+/// branch must not decide the fate of the other five.
+#[tauri::command]
+pub async fn fast_forward_all_branches(
+    state: State<'_, AppState>,
+    repo_id: String,
+    prune: bool,
+    credentials: Option<Credentials>,
+) -> AppResult<BulkFastForward> {
+    let repo_id = RepoId(repo_id);
+    let path = get_repo_path(&state, &repo_id).await?;
+    run_git_creds(&path, &fetch_args(None, prune), credentials.as_ref()).await?;
+
+    let backend = state.backend.clone();
+    tokio::task::spawn_blocking(move || backend.fast_forward_all(&repo_id))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
 /// Build `git push` args. `set_upstream` adds `-u`, which the caller passes
@@ -548,14 +640,38 @@ mod tests {
 
     #[test]
     fn fetch_args_with_prune() {
-        assert_eq!(fetch_args(Some("origin"), true), ["fetch", "origin", "--prune"]);
+        assert_eq!(
+            fetch_args(Some("origin"), true),
+            ["fetch", "--prune", "--", "origin"]
+        );
         assert_eq!(fetch_args(None, true), ["fetch", "--all", "--prune"]);
     }
 
     #[test]
     fn fetch_args_without_prune() {
-        assert_eq!(fetch_args(Some("origin"), false), ["fetch", "origin"]);
+        assert_eq!(fetch_args(Some("origin"), false), ["fetch", "--", "origin"]);
         assert_eq!(fetch_args(None, false), ["fetch", "--all"]);
+    }
+
+    #[test]
+    fn fetch_args_keep_the_remote_name_after_the_separator() {
+        // `--upload-pack=<program>` names a program git runs for the transport,
+        // so a remote name read as an option is argument injection, not just a
+        // confusing error. Same class of finding as push_tag_args guards.
+        for args in [
+            fetch_args(Some("--upload-pack=/bin/false"), true),
+            fetch_args(Some("--upload-pack=/bin/false"), false),
+        ] {
+            let sep = args
+                .iter()
+                .position(|a| *a == "--")
+                .expect("named-remote fetch must emit an end-of-options separator");
+            let hostile = args
+                .iter()
+                .position(|a| a.starts_with("--upload-pack"))
+                .expect("test value present");
+            assert!(hostile > sep, "{args:?}");
+        }
     }
 
     #[test]

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -39,6 +39,23 @@ pub enum AppError {
     #[error("branch not fully merged: {0}")]
     NotMerged(String),
 
+    /// A local branch has no upstream, so there is nothing to fast-forward it
+    /// to (#246). Distinct from `InvalidRef` — the branch is perfectly valid,
+    /// it just tracks nothing — and distinct from `Git` because the remedy is
+    /// specific and one click away: set an upstream.
+    #[error("no upstream: {0}")]
+    NoUpstream(String),
+
+    /// The branch's tip is not an ancestor of its upstream's tip, so the ref
+    /// cannot be advanced without a merge or a rebase (#246).
+    ///
+    /// Its own variant rather than `Git` or `NotMerged`: it is the ONE refusal
+    /// the fast-forward op exists to make, the message names both refs, and a
+    /// bulk run collects these instead of aborting on the first one. `NotMerged`
+    /// means the opposite question — "would deleting this lose commits?".
+    #[error("not a fast-forward: {0}")]
+    NotFastForward(String),
+
     #[error("operation produced conflicts: {0}")]
     ConflictsDetected(String),
 

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -5,7 +5,7 @@ use crate::error::{AppError, AppResult};
 use super::{
     types::{
         AheadBehind, BisectMark, BisectStatus, BlameLine, BranchInfo, CommitInfo, CommitOptions, CommitResult, ConflictSides,
-        DeleteFailure, DiffKind, FileContent,
+        BulkFastForward, DeleteFailure, DiffKind, FastForward, FileContent,
         FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage, RebaseStatus, RebaseStep, ReflogEntry,
         RemoteInfo, RepoHandle, RepoId, RepoState, ResetMode, StashInfo, StashSaveOptions,
         SubmoduleInfo, TagInfo,
@@ -278,6 +278,15 @@ impl GitBackend for CliBackend {
         _branch: &str,
         _upstream: Option<&str>,
     ) -> AppResult<()> {
+        Err(AppError::NotImplemented)
+    }
+    fn fast_forward_remote(&self, _repo_id: &RepoId, _branch: &str) -> AppResult<String> {
+        Err(AppError::NotImplemented)
+    }
+    fn fast_forward_branch(&self, _repo_id: &RepoId, _branch: &str) -> AppResult<FastForward> {
+        Err(AppError::NotImplemented)
+    }
+    fn fast_forward_all(&self, _repo_id: &RepoId) -> AppResult<BulkFastForward> {
         Err(AppError::NotImplemented)
     }
     fn create_tag(&self, _repo_id: &RepoId, _name: &str, _target: TagTarget) -> AppResult<()> {

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -17,9 +17,10 @@ use super::{
     types::{
         AheadBehind, BisectMark, BisectStatus,
         BlameLine, BranchInfo, CommitInfo, CommitOptions, CommitResult, ConflictSides,
-        DeleteFailure, DiffHunk,
+        BulkFastForward, DeleteFailure, DiffHunk,
         DiffKind,
-        DiffLine, DiffLineKind, FileContent, FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage,
+        DiffLine, DiffLineKind, FastForward, FileContent, FileDiff, FileStatus, HeadInfo, LfsStatus,
+        LogFilter, LogPage,
         RebaseAction, RebaseStatus, RebaseStep, RebaseSummary, ReflogEntry, ReflogOp, RemoteInfo,
         RepoHandle, RepoId, RepoState, ResetMode, StashInfo, StashSaveOptions, StatusFlag,
         SubmoduleInfo, TagInfo, TagTarget, WorkdirDiff, WorktreeBranch, WorktreeInfo, REFSPEC_ALL,
@@ -2262,6 +2263,156 @@ fn is_default_branch_name(name: &str, is_remote: bool, default: Option<&str>) ->
     }
 }
 
+// ─── Fast-forwarding a branch that is not checked out (#246) ─────────────────
+//
+// Every function here takes an ALREADY-BORROWED `&Repository`, exactly like the
+// `stash_pairs`/`stash_entry_at` pair above and for the same reason: the
+// ancestry check and the ref move have to happen under ONE acquisition of the
+// per-repo mutex, and std's `Mutex` is not reentrant, so a helper that took a
+// `&RepoId` and re-entered `with_repo` would deadlock — or, if it took the lock
+// separately, would be the stash TOCTOU with a different ref.
+
+/// What advancing one branch to its upstream would do.
+enum FastForwardKind {
+    /// The ref already points at the upstream tip, or past it. Nothing to do —
+    /// a state, not a failure, and what `git pull --ff-only` calls "Already up
+    /// to date" in both cases.
+    UpToDate,
+    /// The local tip is an ancestor of the upstream tip: move the ref here.
+    Advance(git2::Oid),
+    /// Both sides have commits the other lacks — or the histories are unrelated,
+    /// which is divergence in every sense that matters to a ref move.
+    Diverged,
+}
+
+/// The graph question and the reference to act on, from ONE ref lookup.
+///
+/// Holding the `Reference` rather than re-finding the branch to move it is what
+/// keeps "check" and "mutate" reading the same object; the lock makes that
+/// atomic against other commands, and one lookup makes it atomic against a
+/// `git` CLI writing the ref from outside in the same instant.
+struct FastForwardPlan<'r> {
+    /// Upstream shorthand, e.g. `origin/main`.
+    upstream: String,
+    from: git2::Oid,
+    kind: FastForwardKind,
+    reference: git2::Reference<'r>,
+}
+
+fn plan_fast_forward<'r>(repo: &'r Repository, branch: &str) -> AppResult<FastForwardPlan<'r>> {
+    let local = repo
+        .find_branch(branch, BranchType::Local)
+        .map_err(|_| AppError::InvalidRef(branch.to_string()))?;
+    let no_upstream =
+        || AppError::NoUpstream(format!("{branch} tracks no remote branch — set an upstream first"));
+    let upstream = local.upstream().map_err(|_| no_upstream())?;
+    let up_name = upstream
+        .name()
+        .ok()
+        .flatten()
+        .map(String::from)
+        .ok_or_else(no_upstream)?;
+    let up_oid = upstream
+        .get()
+        .target()
+        .ok_or_else(|| AppError::InvalidRef(up_name.clone()))?;
+
+    let reference = local.into_reference();
+    // A symbolic or unborn branch ref has no oid to compare, so there is no
+    // ancestry question to answer.
+    let from = reference.target().ok_or(AppError::Unborn)?;
+
+    let kind = if from == up_oid {
+        FastForwardKind::UpToDate
+    } else {
+        match repo.merge_base(from, up_oid) {
+            Ok(base) if base == from => FastForwardKind::Advance(up_oid),
+            // Strictly ahead: there is nothing to fast-forward TO.
+            Ok(base) if base == up_oid => FastForwardKind::UpToDate,
+            _ => FastForwardKind::Diverged,
+        }
+    };
+
+    Ok(FastForwardPlan {
+        upstream: up_name,
+        from,
+        kind,
+        reference,
+    })
+}
+
+/// Carry out a plan. `Diverged` is refused HERE, so no caller can move a ref by
+/// forgetting to look at the kind.
+fn apply_fast_forward(branch: &str, mut plan: FastForwardPlan<'_>) -> AppResult<FastForward> {
+    let done = |to: git2::Oid, moved: bool| FastForward {
+        branch: branch.to_string(),
+        upstream: plan.upstream.clone(),
+        from: plan.from.to_string(),
+        to: to.to_string(),
+        moved,
+    };
+    match plan.kind {
+        FastForwardKind::UpToDate => Ok(done(plan.from, false)),
+        FastForwardKind::Diverged => Err(AppError::NotFastForward(format!(
+            "{branch} has diverged from {} — check it out to merge or rebase",
+            plan.upstream
+        ))),
+        FastForwardKind::Advance(to) => {
+            // The reflog message is the undo: a ref that moved without one
+            // is a ref the user cannot walk back. It names the upstream, the way
+            // git's own ff messages do ("merge origin/main: Fast-forward"), so
+            // `git reflog main` reads as a history rather than a mystery.
+            let msg = format!("fast-forward: moved to {}", plan.upstream);
+            plan.reference.set_target(to, &msg)?;
+            Ok(done(to, true))
+        }
+    }
+}
+
+/// Where `branch` is checked out, if anywhere — this repository's HEAD or a
+/// linked worktree's.
+///
+/// `head` is `repo.head()`'s shorthand, passed in so a bulk sweep reads it once;
+/// `linked` is `worktree::linked_worktree_heads`, for the same reason.
+fn checked_out_at(branch: &str, head: Option<&str>, linked: &[(String, String)]) -> Option<String> {
+    if head == Some(branch) {
+        return Some("this worktree".to_string());
+    }
+    linked
+        .iter()
+        .find(|(_, on)| on == branch)
+        .map(|(wt, _)| format!("worktree {wt}"))
+}
+
+/// The refusal a checked-out branch gets: moving its ref without touching the
+/// index or the working tree would leave that checkout showing every incoming
+/// change as a deletion. The caller pulls instead, with the user's pull mode.
+fn reject_checked_out(repo: &Repository, branch: &str) -> AppResult<()> {
+    let head = repo
+        .head()
+        .ok()
+        .and_then(|h| h.shorthand().map(String::from));
+    let linked = crate::git::worktree::linked_worktree_heads(repo);
+    match checked_out_at(branch, head.as_deref(), &linked) {
+        None => Ok(()),
+        Some(where_) => Err(AppError::InvalidArgument(format!(
+            "{branch} is checked out in {where_} — pull it there instead of moving its ref"
+        ))),
+    }
+}
+
+/// Local branch names, in listing order.
+fn local_branch_names(repo: &Repository) -> AppResult<Vec<String>> {
+    let mut names = Vec::new();
+    for entry in repo.branches(Some(BranchType::Local))? {
+        let (branch, _) = entry?;
+        if let Ok(Some(name)) = branch.name() {
+            names.push(name.to_string());
+        }
+    }
+    Ok(names)
+}
+
 impl GitBackend for Libgit2Backend {
     fn open(&self, path: &Path) -> AppResult<RepoHandle> {
         if !path.exists() {
@@ -4282,6 +4433,95 @@ impl GitBackend for Libgit2Backend {
                 .map_err(|_| AppError::InvalidRef(branch.to_string()))?;
             local.set_upstream(upstream)?;
             Ok(())
+        })
+    }
+
+    fn fast_forward_remote(&self, repo_id: &RepoId, branch: &str) -> AppResult<String> {
+        self.with_repo(repo_id, |repo| {
+            // Both refusals happen before the caller spends a fetch. The
+            // upstream one goes FIRST: for a checked-out branch that also tracks
+            // nothing, "set an upstream" is the useful sentence and "pull it
+            // instead" is advice the user cannot act on.
+            let full = format!("refs/heads/{branch}");
+            // `branch.<name>.remote`, not `upstream.split('/')[0]`: a remote name
+            // may itself contain a slash, and `team/fork/main` would otherwise be
+            // fetched from a remote called `team`.
+            let remote = repo.branch_upstream_remote(&full).map_err(|_| {
+                // Either the branch does not exist or it tracks nothing. Tell
+                // those apart so a typo is not reported as a missing upstream.
+                match repo.find_branch(branch, BranchType::Local) {
+                    Ok(_) => AppError::NoUpstream(format!(
+                        "{branch} tracks no remote branch — set an upstream first"
+                    )),
+                    Err(_) => AppError::InvalidRef(branch.to_string()),
+                }
+            })?;
+            let name = remote.as_str().unwrap_or_default().to_string();
+            if name.is_empty() {
+                return Err(AppError::NoUpstream(format!(
+                    "{branch} tracks no remote branch — set an upstream first"
+                )));
+            }
+            reject_checked_out(repo, branch)?;
+            Ok(name)
+        })
+    }
+
+    fn fast_forward_branch(&self, repo_id: &RepoId, branch: &str) -> AppResult<FastForward> {
+        // ONE `with_repo`: the ancestry check and the ref move share a single
+        // acquisition of the per-repo mutex. See the trait doc.
+        self.with_repo(repo_id, |repo| {
+            // Plan first so an unknown branch or a missing upstream is reported
+            // as itself; `reject_checked_out` then stops the move. Nothing has
+            // been written at either point.
+            let plan = plan_fast_forward(repo, branch)?;
+            reject_checked_out(repo, branch)?;
+            apply_fast_forward(branch, plan)
+        })
+    }
+
+    fn fast_forward_all(&self, repo_id: &RepoId) -> AppResult<BulkFastForward> {
+        // ONE `with_repo` for the WHOLE sweep — the branch listing and every ref
+        // move it leads to are one atomic step as far as other commands go.
+        self.with_repo(repo_id, |repo| {
+            let head = repo
+                .head()
+                .ok()
+                .and_then(|h| h.shorthand().map(String::from));
+            // Walked once, not once per branch: each entry costs a repository
+            // open.
+            let linked = crate::git::worktree::linked_worktree_heads(repo);
+
+            let mut out = BulkFastForward {
+                advanced: Vec::new(),
+                diverged: Vec::new(),
+                checked_out: Vec::new(),
+            };
+            for name in local_branch_names(repo)? {
+                let plan = match plan_fast_forward(repo, &name) {
+                    Ok(p) => p,
+                    // Nothing to answer for, and nothing the user has to act on.
+                    Err(AppError::NoUpstream(_)) | Err(AppError::Unborn) => continue,
+                    Err(e) => return Err(e),
+                };
+                match plan.kind {
+                    FastForwardKind::UpToDate => {}
+                    // Diverged wins over checked-out: the remedy is a merge or a
+                    // rebase either way, and "pull it" would be wrong advice.
+                    FastForwardKind::Diverged => out.diverged.push(name),
+                    FastForwardKind::Advance(_) => {
+                        // Classified only for a branch that WOULD have moved, so
+                        // the branch you are standing on is named just when
+                        // there is actually something to pull.
+                        if checked_out_at(&name, head.as_deref(), &linked).is_some() {
+                            out.checked_out.push(name);
+                        } else {
+                            out.advanced.push(apply_fast_forward(&name, plan)?);
+                        }
+                    }
+                }
+            }
+            Ok(out)
         })
     }
     fn create_tag(&self, repo_id: &RepoId, name: &str, target: TagTarget) -> AppResult<()> {

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -21,7 +21,7 @@ use crate::error::AppResult;
 use types::{
     AheadBehind,
     BisectMark, BisectStatus, BlameLine, BranchInfo, CommitInfo, CommitOptions, CommitResult, ConflictSides,
-    DeleteFailure, DiffKind, FileContent,
+    BulkFastForward, DeleteFailure, DiffKind, FastForward, FileContent,
     FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage, RebaseStatus, RebaseStep, ReflogEntry,
     RemoteInfo,
     RepoHandle,
@@ -457,6 +457,49 @@ pub trait GitBackend: Send + Sync {
         branch: &str,
         upstream: Option<&str>,
     ) -> AppResult<()>;
+    /// The remote that has to be fetched before `fast_forward_branch(branch)`
+    /// can decide anything (#246).
+    ///
+    /// Read from the branch's own `branch.<name>.remote`, NOT by splitting the
+    /// upstream shorthand on `/` — a remote name may itself contain a slash, and
+    /// `team/fork/main` would then be fetched from a remote called `team`.
+    ///
+    /// Refuses up front — `NoUpstream`, or `InvalidArgument` for a branch that
+    /// is checked out — so the network is never spent on a call that could not
+    /// have succeeded afterwards. Answering here rather than inside the
+    /// fast-forward is what lets the fetch sit BETWEEN the two: a network op
+    /// belongs in the command layer, where `run_git_authenticated` is.
+    fn fast_forward_remote(&self, repo_id: &RepoId, branch: &str) -> AppResult<String>;
+    /// Advance one local branch to its upstream, if and only if that is a
+    /// fast-forward (#246).
+    ///
+    /// The op `pull` cannot be: `git pull <remote> <branch>` merges the fetched
+    /// head into whatever HEAD is, so it never advanced the branch it named.
+    /// This moves the REF, which is why it refuses a branch that any working
+    /// tree is standing on — HEAD here, or a linked worktree's HEAD — rather
+    /// than leaving that checkout with a phantom reverse diff. The caller pulls
+    /// instead, with the user's own pull mode.
+    ///
+    /// **The ancestry check and the ref move happen under ONE lock
+    /// acquisition**, inside a single `with_repo` closure. Two hops would be the
+    /// stash TOCTOU again: the per-repo mutex serialises every backend op, so a
+    /// concurrent command is parked to run at exactly that boundary and the ref
+    /// verified as fast-forwardable is not the ref that gets moved.
+    ///
+    /// A branch that is already at (or ahead of) its upstream answers
+    /// `moved: false` — a state, not a failure. Divergence is `NotFastForward`
+    /// and moves nothing.
+    fn fast_forward_branch(&self, repo_id: &RepoId, branch: &str) -> AppResult<FastForward>;
+    /// `fast_forward_branch` for every local branch that has an upstream (#246).
+    ///
+    /// One `with_repo` closure for the WHOLE sweep, so no other command can
+    /// interleave between the branch listing and the last ref move. The
+    /// per-branch refusals become the report's `diverged` / `checked_out` lists
+    /// instead of an error: one diverged branch must not decide the fate of the
+    /// other five, which is the entire point of the bulk action.
+    ///
+    /// Assumes the caller has already fetched. It performs no network I/O.
+    fn fast_forward_all(&self, repo_id: &RepoId) -> AppResult<BulkFastForward>;
     /// Create a tag. `target.annotation` picks lightweight vs annotated and
     /// `target.sign` picks signed vs not, defaulting to `tag.gpgsign` (#132).
     ///

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -226,6 +226,45 @@ pub struct BranchInfo {
     pub is_default: bool,
 }
 
+/// What advancing one local branch to its upstream did (#246).
+///
+/// `moved` is FALSE for the two harmless outcomes — the ref already pointed at
+/// the upstream tip, or it is strictly ahead of it — so a caller can say
+/// "already up to date" without re-deriving it from the oids. Anything that
+/// would NOT be a fast-forward is an error, never a `moved: false`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FastForward {
+    pub branch: String,
+    /// Shorthand of the upstream that was used, e.g. `origin/main`.
+    pub upstream: String,
+    /// FULL oids, the same spelling `BranchInfo.tip` uses — consumers compare
+    /// them against `CommitInfo.oid`, which a 7-char prefix silently never
+    /// matches.
+    pub from: String,
+    pub to: String,
+    pub moved: bool,
+}
+
+/// The outcome of fast-forwarding every eligible local branch at once (#246).
+///
+/// Three lists rather than a count, because the two that did NOT move are the
+/// half a user has to act on: a diverged branch needs a merge or a rebase, and a
+/// checked-out one needs a pull (which is a working-tree operation, so this op
+/// refuses it rather than moving a ref out from under it).
+///
+/// Branches that are already current, and branches with no upstream, are simply
+/// absent: neither is something the user has to do anything about.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BulkFastForward {
+    pub advanced: Vec<FastForward>,
+    /// Behind, but the local tip is not an ancestor of the upstream tip.
+    pub diverged: Vec<String>,
+    /// Behind, but checked out — in this worktree or a linked one.
+    pub checked_out: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TagInfo {

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -72,6 +72,45 @@ pub fn info(repo: &Repository, name: &str, current: Option<&Path>) -> AppResult<
     })
 }
 
+/// Every LINKED worktree that is standing on a branch, as `(worktree, branch)`
+/// (#246).
+///
+/// Only linked worktrees: `git_worktree_list` never reports the main one, whose
+/// HEAD the caller already has from `repo.head()`.
+///
+/// libgit2 has `git_branch_is_checked_out`, but git2-rs 0.20 does not bind it —
+/// hence the walk. It costs one `Repository::open_from_worktree` per linked
+/// worktree, so only ref-MOVING ops pay it, never a listing; a bulk op walks
+/// once and looks branches up in the result.
+///
+/// A worktree whose directory has been deleted behind git's back cannot be
+/// opened. It is not standing on anything, so it is skipped rather than failing
+/// the caller — this project is developed through `.claude/worktrees/`, where a
+/// removed-but-unpruned entry is routine.
+pub fn linked_worktree_heads(repo: &Repository) -> Vec<(String, String)> {
+    let Ok(names) = repo.worktrees() else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for name in names.iter().flatten() {
+        let Ok(wt) = repo.find_worktree(name) else {
+            continue;
+        };
+        let Ok(wrepo) = Repository::open_from_worktree(&wt) else {
+            continue;
+        };
+        let on = wrepo
+            .head()
+            .ok()
+            .filter(|h| h.is_branch())
+            .and_then(|h| h.shorthand().map(str::to_string));
+        if let Some(branch) = on {
+            out.push((name.to_string(), branch));
+        }
+    }
+    out
+}
+
 /// Path equality that survives the symlink indirection macOS puts on `/tmp`.
 ///
 /// git records the worktree path as given, while the app's open-repo path has been

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -264,6 +264,8 @@ pub fn run() {
             commands::branches::fetch,
             commands::branches::fetch_all,
             commands::branches::pull,
+            commands::branches::fast_forward_branch,
+            commands::branches::fast_forward_all_branches,
             commands::branches::push,
             commands::branches::add_remote,
             commands::branches::remove_remote,

--- a/src-tauri/tests/fast_forward.rs
+++ b/src-tauri/tests/fast_forward.rs
@@ -1,0 +1,337 @@
+//! Fast-forwarding a branch that is NOT checked out (#246).
+//!
+//! `pull <remote> <branch>` merges the fetched head into whatever HEAD is, so it
+//! could never advance `main` while you stood on `feat/x`. These pin the op that
+//! can: the ancestry check and the ref move, decided on the commit graph.
+//!
+//! The remote is a local bare repo, so the suite stays offline. The FETCH half
+//! lives in `commands::branches` (it needs `run_git_authenticated` and a Tauri
+//! `State`); everything below is the half that decides and moves the ref.
+
+mod support;
+
+use platypusgit_lib::{error::AppError, git::GitBackend};
+use support::{git_in, BareTempRepo, TempRepo};
+
+/// A work repo whose `origin` is a bare repo, with `main` pushed and tracking.
+fn tracked_pair() -> (TempRepo, BareTempRepo) {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let bare = BareTempRepo::new();
+    git_in(
+        tr.path(),
+        &["remote", "add", "origin", bare.path.to_str().unwrap()],
+    );
+    git_in(tr.path(), &["push", "-u", "origin", "main"]);
+    (tr, bare)
+}
+
+/// Push a commit and rewind the local branch, leaving it one BEHIND its
+/// upstream. The remote-tracking ref keeps the pushed tip, so the state is the
+/// one a fetch would have produced.
+fn make_behind(tr: &TempRepo) {
+    tr.add_commit("remote.txt", "remote\n", "remote-only commit");
+    git_in(tr.path(), &["push", "origin", "main"]);
+    git_in(tr.path(), &["reset", "--hard", "HEAD~1"]);
+}
+
+/// One commit on each side of the merge base: behind AND ahead.
+fn make_diverged(tr: &TempRepo) {
+    make_behind(tr);
+    tr.add_commit("local.txt", "local\n", "local-only commit");
+}
+
+/// Step off `main` so it is no longer HEAD — the whole point of the op.
+fn step_off_main(tr: &TempRepo) {
+    git_in(tr.path(), &["checkout", "-b", "feat/x"]);
+}
+
+fn oid_of(tr: &TempRepo, refname: &str) -> String {
+    git_in(tr.path(), &["rev-parse", refname]).trim().to_string()
+}
+
+#[test]
+fn a_behind_branch_is_advanced_to_its_upstream() {
+    let (tr, _bare) = tracked_pair();
+    make_behind(&tr);
+    step_off_main(&tr);
+    let upstream = oid_of(&tr, "refs/remotes/origin/main");
+    let before = oid_of(&tr, "refs/heads/main");
+    assert_ne!(before, upstream, "fixture must leave main behind");
+
+    let (backend, handle) = tr.open_with_backend();
+    let ff = backend
+        .fast_forward_branch(&handle.id, "main")
+        .expect("fast-forward");
+
+    assert!(ff.moved, "the ref should have moved");
+    assert_eq!(ff.from, before);
+    assert_eq!(ff.to, upstream);
+    assert_eq!(ff.upstream, "origin/main");
+    assert_eq!(oid_of(&tr, "refs/heads/main"), upstream);
+}
+
+#[test]
+fn the_move_leaves_a_reflog_entry() {
+    // A ref that moved with no reflog entry is a ref the user cannot walk back.
+    let (tr, _bare) = tracked_pair();
+    make_behind(&tr);
+    step_off_main(&tr);
+    let before = oid_of(&tr, "refs/heads/main");
+
+    let (backend, handle) = tr.open_with_backend();
+    backend.fast_forward_branch(&handle.id, "main").expect("ff");
+
+    let reflog = git_in(tr.path(), &["reflog", "show", "main"]);
+    assert!(
+        reflog.contains(&before[..7]),
+        "reflog should still reach the old tip: {reflog}"
+    );
+}
+
+#[test]
+fn a_diverged_branch_is_refused_and_its_ref_does_not_move() {
+    let (tr, _bare) = tracked_pair();
+    make_diverged(&tr);
+    step_off_main(&tr);
+    let before = oid_of(&tr, "refs/heads/main");
+
+    let (backend, handle) = tr.open_with_backend();
+    let err = backend
+        .fast_forward_branch(&handle.id, "main")
+        .expect_err("diverged must be refused");
+
+    match &err {
+        AppError::NotFastForward(msg) => {
+            assert!(msg.contains("main"), "message names the branch: {msg}");
+            assert!(
+                msg.contains("origin/main"),
+                "message names the upstream: {msg}"
+            );
+        }
+        other => panic!("expected NotFastForward, got {other:?}"),
+    }
+    assert_eq!(
+        oid_of(&tr, "refs/heads/main"),
+        before,
+        "a refused fast-forward moves nothing"
+    );
+}
+
+#[test]
+fn an_up_to_date_branch_is_a_clean_no_op() {
+    let (tr, _bare) = tracked_pair();
+    step_off_main(&tr);
+    let before = oid_of(&tr, "refs/heads/main");
+
+    let (backend, handle) = tr.open_with_backend();
+    let ff = backend
+        .fast_forward_branch(&handle.id, "main")
+        .expect("up to date is not a failure");
+
+    assert!(!ff.moved);
+    assert_eq!(ff.from, before);
+    assert_eq!(ff.to, before);
+    assert_eq!(oid_of(&tr, "refs/heads/main"), before);
+}
+
+#[test]
+fn a_branch_that_is_ahead_of_its_upstream_is_a_no_op_too() {
+    // Strictly ahead is not divergence: there is nothing to fast-forward TO,
+    // which `git pull --ff-only` also reports as "Already up to date".
+    let (tr, _bare) = tracked_pair();
+    tr.add_commit("local.txt", "local\n", "local-only commit");
+    step_off_main(&tr);
+    let before = oid_of(&tr, "refs/heads/main");
+
+    let (backend, handle) = tr.open_with_backend();
+    let ff = backend.fast_forward_branch(&handle.id, "main").expect("ahead");
+
+    assert!(!ff.moved);
+    assert_eq!(oid_of(&tr, "refs/heads/main"), before);
+}
+
+#[test]
+fn a_branch_with_no_upstream_says_so() {
+    let (tr, _bare) = tracked_pair();
+    git_in(tr.path(), &["branch", "orphan"]);
+
+    let (backend, handle) = tr.open_with_backend();
+    let err = backend
+        .fast_forward_branch(&handle.id, "orphan")
+        .expect_err("no upstream");
+    assert!(
+        matches!(&err, AppError::NoUpstream(msg) if msg.contains("orphan")),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn an_unknown_branch_is_an_invalid_ref() {
+    let (tr, _bare) = tracked_pair();
+    let (backend, handle) = tr.open_with_backend();
+    let err = backend
+        .fast_forward_branch(&handle.id, "nope")
+        .expect_err("unknown branch");
+    assert!(matches!(err, AppError::InvalidRef(_)), "got {err:?}");
+}
+
+#[test]
+fn the_checked_out_branch_is_refused_so_the_caller_pulls_instead() {
+    // Moving HEAD's ref without touching the index or worktree would leave the
+    // working tree looking like every incoming change had been reverted.
+    let (tr, _bare) = tracked_pair();
+    make_behind(&tr);
+    let before = oid_of(&tr, "refs/heads/main");
+
+    let (backend, handle) = tr.open_with_backend();
+    let err = backend
+        .fast_forward_branch(&handle.id, "main")
+        .expect_err("HEAD must be refused");
+    assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+    assert_eq!(oid_of(&tr, "refs/heads/main"), before);
+}
+
+#[test]
+fn a_branch_checked_out_in_a_linked_worktree_is_refused() {
+    // This project is developed through `.claude/worktrees/`: moving a ref out
+    // from under a linked worktree gives that checkout a phantom reverse diff.
+    let (tr, _bare) = tracked_pair();
+    make_behind(&tr);
+    step_off_main(&tr);
+    let (_dir, wt_path) = support::worktree_target("wt-main");
+    git_in(
+        tr.path(),
+        &["worktree", "add", wt_path.to_str().unwrap(), "main"],
+    );
+    let before = oid_of(&tr, "refs/heads/main");
+
+    let (backend, handle) = tr.open_with_backend();
+    let err = backend
+        .fast_forward_branch(&handle.id, "main")
+        .expect_err("checked out elsewhere");
+    assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+    assert_eq!(oid_of(&tr, "refs/heads/main"), before);
+}
+
+#[test]
+fn the_remote_to_fetch_comes_from_the_branchs_own_config() {
+    // Not `upstream.split('/')[0]`: a remote name may itself contain a slash.
+    let (tr, _bare) = tracked_pair();
+    git_in(tr.path(), &["remote", "rename", "origin", "team/fork"]);
+    step_off_main(&tr);
+
+    let (backend, handle) = tr.open_with_backend();
+    assert_eq!(
+        backend.fast_forward_remote(&handle.id, "main").expect("remote"),
+        "team/fork"
+    );
+}
+
+#[test]
+fn the_remote_lookup_refuses_head_before_any_network_happens() {
+    let (tr, _bare) = tracked_pair();
+    let (backend, handle) = tr.open_with_backend();
+    let err = backend
+        .fast_forward_remote(&handle.id, "main")
+        .expect_err("HEAD must be refused up front");
+    assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+}
+
+#[test]
+fn the_remote_lookup_refuses_a_branch_with_no_upstream() {
+    let (tr, _bare) = tracked_pair();
+    git_in(tr.path(), &["branch", "orphan"]);
+    let (backend, handle) = tr.open_with_backend();
+    let err = backend
+        .fast_forward_remote(&handle.id, "orphan")
+        .expect_err("no upstream");
+    assert!(matches!(err, AppError::NoUpstream(_)), "got {err:?}");
+}
+
+#[test]
+fn bulk_advances_every_behind_branch_and_reports_the_rest() {
+    let (tr, _bare) = tracked_pair();
+
+    // `main`: behind by one, a clean fast-forward.
+    make_behind(&tr);
+    // `topic`: pushed, then rewound AND given a local commit — diverged.
+    git_in(tr.path(), &["checkout", "-b", "topic"]);
+    tr.add_commit("topic.txt", "topic\n", "topic base");
+    git_in(tr.path(), &["push", "-u", "origin", "topic"]);
+    tr.add_commit("topic2.txt", "topic2\n", "remote-only on topic");
+    git_in(tr.path(), &["push", "origin", "topic"]);
+    git_in(tr.path(), &["reset", "--hard", "HEAD~1"]);
+    tr.add_commit("topic-local.txt", "l\n", "local-only on topic");
+    // `orphan`: no upstream at all.
+    git_in(tr.path(), &["branch", "orphan"]);
+    // Stand somewhere that is neither.
+    git_in(tr.path(), &["checkout", "-b", "feat/x"]);
+
+    let main_upstream = oid_of(&tr, "refs/remotes/origin/main");
+    let topic_before = oid_of(&tr, "refs/heads/topic");
+
+    let (backend, handle) = tr.open_with_backend();
+    let report = backend.fast_forward_all(&handle.id).expect("bulk");
+
+    let advanced: Vec<_> = report.advanced.iter().map(|f| f.branch.as_str()).collect();
+    assert_eq!(advanced, ["main"], "only main could fast-forward");
+    assert_eq!(oid_of(&tr, "refs/heads/main"), main_upstream);
+
+    assert_eq!(report.diverged, ["topic"]);
+    assert_eq!(
+        oid_of(&tr, "refs/heads/topic"),
+        topic_before,
+        "a diverged branch is left exactly where it was"
+    );
+
+    assert!(
+        report.checked_out.is_empty(),
+        "feat/x has no upstream, so it is not reportable"
+    );
+    // A branch with no upstream is simply not part of the answer.
+    assert!(!report.diverged.iter().any(|b| b == "orphan"));
+}
+
+#[test]
+fn bulk_leaves_the_checked_out_branch_for_pull_and_names_it() {
+    let (tr, _bare) = tracked_pair();
+    make_behind(&tr);
+    let before = oid_of(&tr, "refs/heads/main");
+
+    let (backend, handle) = tr.open_with_backend();
+    let report = backend.fast_forward_all(&handle.id).expect("bulk");
+
+    assert!(report.advanced.is_empty());
+    assert_eq!(report.checked_out, ["main"]);
+    assert_eq!(
+        oid_of(&tr, "refs/heads/main"),
+        before,
+        "HEAD's branch is never moved from under the working tree"
+    );
+}
+
+#[test]
+fn bulk_on_an_already_current_repo_reports_nothing() {
+    let (tr, _bare) = tracked_pair();
+    step_off_main(&tr);
+    let (backend, handle) = tr.open_with_backend();
+    let report = backend.fast_forward_all(&handle.id).expect("bulk");
+    assert!(report.advanced.is_empty());
+    assert!(report.diverged.is_empty());
+    assert!(report.checked_out.is_empty());
+}
+
+#[test]
+fn a_checked_out_branch_with_no_upstream_is_told_about_the_upstream() {
+    // Both refusals apply; the one the user can act on wins. "Pull it instead"
+    // is useless advice for a branch that tracks nothing.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    for err in [
+        backend.fast_forward_branch(&handle.id, "main").unwrap_err(),
+        backend.fast_forward_remote(&handle.id, "main").unwrap_err(),
+    ] {
+        assert!(matches!(err, AppError::NoUpstream(_)), "got {err:?}");
+    }
+}

--- a/src/design/context-menu.fastForward.test.tsx
+++ b/src/design/context-menu.fastForward.test.tsx
@@ -1,0 +1,76 @@
+// The "Fast-forward to upstream" entry on a branch's context menu (#246).
+//
+// The two things worth pinning are the ones a reviewer would get wrong: it is
+// offered on branches that are NOT checked out (the whole point), and it is not
+// gated on `behind`, which is only as fresh as the last fetch — and this op
+// fetches, so gating would hide the action exactly when it is needed.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { branchMenuItems, type ContextMenuItem } from "./context-menu";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+
+const LABEL = "Fast-forward to upstream";
+
+const entry = (items: ContextMenuItem[]) =>
+  items.find((i) => typeof i.label === "string" && i.label === LABEL);
+
+beforeEach(() => {
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "feat/x" },
+    branches: [],
+  } as never);
+});
+
+describe("branchMenuItems fast-forward entry", () => {
+  it("is offered on a branch that is not checked out", () => {
+    const item = entry(
+      branchMenuItems({ name: "main", current: false, upstream: "origin/main" }),
+    );
+    expect(item).toBeDefined();
+    expect(item?.disabled).toBeFalsy();
+  });
+
+  it("is offered on the checked-out branch too — the store routes it to pull", () => {
+    const item = entry(
+      branchMenuItems({ name: "main", current: true, upstream: "origin/main" }),
+    );
+    expect(item?.disabled).toBeFalsy();
+  });
+
+  it("is disabled without an upstream, which is the only thing it needs", () => {
+    const item = entry(
+      branchMenuItems({ name: "orphan", current: false, upstream: null }),
+    );
+    expect(item?.disabled).toBe(true);
+  });
+
+  it("calls the store action with the branch it was opened on", async () => {
+    const fastForwardBranch = vi.fn().mockResolvedValue(null);
+    useRepoStore.setState({ fastForwardBranch } as never);
+
+    await entry(
+      branchMenuItems({ name: "main", current: false, upstream: "origin/main" }),
+    )?.onClick?.();
+
+    expect(fastForwardBranch).toHaveBeenCalledWith("main");
+  });
+
+  it("flashes the outcome, including 'nothing changed'", async () => {
+    const fastForwardBranch = vi.fn().mockResolvedValue({
+      branch: "main",
+      upstream: "origin/main",
+      from: "a".repeat(40),
+      to: "a".repeat(40),
+      moved: false,
+    });
+    useRepoStore.setState({ fastForwardBranch } as never);
+
+    await entry(
+      branchMenuItems({ name: "main", current: false, upstream: "origin/main" }),
+    )?.onClick?.();
+
+    const flash = document.querySelector("[data-pg-flash]");
+    expect(flash?.textContent).toBe("main is already up to date");
+  });
+});

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -30,6 +30,7 @@ import { absoluteInWorkdir, relativeToWorkdir } from "@/lib/paths";
 // keeping it out of this module is what lets features/keymap import it without
 // closing a cycle back through this file (which imports chordFor from there).
 import { pgFlash } from "./ui-helpers";
+import { describeFastForward } from "@/features/branches/fastForward";
 
 export interface ContextMenuItem {
   label?: ReactNode;
@@ -1231,6 +1232,23 @@ export function branchMenuItems(
       shortcut: chordFor("repo.pull"),
       disabled: !isCurrent || !upstream,
       onClick: () => useRepoStore.getState().pull(remote, name),
+    },
+    {
+      icon: "pull",
+      // Enabled for ANY tracking branch, current included — the row you are on
+      // routes to a real pull inside the store, and every other row has its ref
+      // moved without a checkout. Deliberately NOT gated on `behind`: that count
+      // is only as fresh as the last fetch, and this op fetches, so gating would
+      // hide the action exactly when it is most needed.
+      label: "Fast-forward to upstream",
+      disabled: !name || !upstream,
+      onClick: async () => {
+        if (!name) return;
+        const out = await useRepoStore.getState().fastForwardBranch(name);
+        // `null` means it routed to pull (which reports itself) or failed (the
+        // banner already says why) — nothing to flash either way.
+        if (out) pgFlash(describeFastForward(out));
+      },
     },
     {
       icon: "push",

--- a/src/features/branches/fastForward.test.ts
+++ b/src/features/branches/fastForward.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import type { BulkFastForward, FastForward } from "@/lib/types";
+import {
+  describeFastForward,
+  remoteOfUpstream,
+  summarizeFastForward,
+} from "./fastForward";
+
+const remotes = (...names: string[]) => names.map((name) => ({ name }));
+
+describe("remoteOfUpstream", () => {
+  it("names the remote an upstream lives on", () => {
+    expect(remoteOfUpstream("origin/main", remotes("origin"))).toBe("origin");
+  });
+
+  it("keeps a remote name that contains a slash whole", () => {
+    // The `upstream.split('/')[0]` shorthand answers "team" here, and a fetch
+    // from a remote called "team" fails or, worse, fetches the wrong repo.
+    expect(remoteOfUpstream("team/fork/main", remotes("team/fork"))).toBe(
+      "team/fork",
+    );
+  });
+
+  it("prefers the longest matching remote name", () => {
+    expect(
+      remoteOfUpstream("team/fork/main", remotes("team", "team/fork")),
+    ).toBe("team/fork");
+  });
+
+  it("does not match a remote that is merely a name prefix", () => {
+    // "orig" is not "origin": the boundary has to be a whole segment.
+    expect(remoteOfUpstream("origin/main", remotes("orig"))).toBeNull();
+  });
+
+  it("answers null for a branch that tracks nothing", () => {
+    expect(remoteOfUpstream(null, remotes("origin"))).toBeNull();
+  });
+
+  it("answers null when no configured remote matches", () => {
+    expect(remoteOfUpstream("upstream/main", remotes("origin"))).toBeNull();
+  });
+});
+
+const advanced = (branch: string): FastForward => ({
+  branch,
+  upstream: `origin/${branch}`,
+  from: "a".repeat(40),
+  to: "b".repeat(40),
+  moved: true,
+});
+
+const report = (r: Partial<BulkFastForward>): BulkFastForward => ({
+  advanced: [],
+  diverged: [],
+  checkedOut: [],
+  ...r,
+});
+
+describe("summarizeFastForward", () => {
+  it("says so when there was nothing to do", () => {
+    expect(summarizeFastForward(report({}))).toBe("All branches are up to date");
+  });
+
+  it("names a single advanced branch", () => {
+    expect(summarizeFastForward(report({ advanced: [advanced("main")] }))).toBe(
+      "Fast-forwarded main",
+    );
+  });
+
+  it("counts several advanced branches", () => {
+    expect(
+      summarizeFastForward(
+        report({ advanced: [advanced("main"), advanced("dev")] }),
+      ),
+    ).toBe("Fast-forwarded 2 branches");
+  });
+
+  it("reports the diverged ones, which are the actionable half", () => {
+    expect(
+      summarizeFastForward(
+        report({ advanced: [advanced("main")], diverged: ["feat/x"] }),
+      ),
+    ).toBe("Fast-forwarded main · feat/x has diverged");
+  });
+
+  it("counts several diverged branches rather than listing them all", () => {
+    expect(summarizeFastForward(report({ diverged: ["a", "b", "c"] }))).toBe(
+      "3 branches have diverged",
+    );
+  });
+
+  it("tells the user to pull the branch they are standing on", () => {
+    expect(summarizeFastForward(report({ checkedOut: ["main"] }))).toBe(
+      "main is checked out — pull it",
+    );
+  });
+
+  it("combines all three", () => {
+    expect(
+      summarizeFastForward(
+        report({
+          advanced: [advanced("dev")],
+          diverged: ["feat/x"],
+          checkedOut: ["main"],
+        }),
+      ),
+    ).toBe("Fast-forwarded dev · feat/x has diverged · main is checked out — pull it");
+  });
+});
+
+describe("describeFastForward", () => {
+  it("names the branch and where it landed", () => {
+    expect(describeFastForward(advanced("main"))).toBe(
+      "Fast-forwarded main to origin/main",
+    );
+  });
+
+  it("says nothing happened rather than staying silent", () => {
+    // The action fetched first, so "no change" is information the row cannot
+    // give the user by itself.
+    expect(describeFastForward({ ...advanced("main"), moved: false })).toBe(
+      "main is already up to date",
+    );
+  });
+});

--- a/src/features/branches/fastForward.ts
+++ b/src/features/branches/fastForward.ts
@@ -1,0 +1,73 @@
+import type { BulkFastForward, FastForward } from "@/lib/types";
+
+/**
+ * The remote a branch's upstream lives on (#246).
+ *
+ * NOT `upstream.split("/")[0]`. A git remote name may itself contain a slash —
+ * `git remote add team/fork …` is legal — and splitting on the first one turns
+ * `team/fork/main` into a remote called `team`, which either does not exist or,
+ * worse, is a different repository. Resolved against the repository's OWN remote
+ * list instead, longest name first so `team/fork` beats a sibling `team`.
+ *
+ * The match must end on a segment boundary: `orig` is not a prefix of
+ * `origin/main` in any sense that matters.
+ *
+ * The backend answers this question properly for the fast-forward path itself
+ * (`GitBackend::fast_forward_remote` reads `branch.<name>.remote`); this is the
+ * frontend's answer for the call that has to name a remote up front — the pull
+ * a checked-out branch is routed to.
+ */
+export function remoteOfUpstream(
+  upstream: string | null | undefined,
+  remotes: readonly { name: string }[],
+): string | null {
+  if (!upstream) return null;
+  const matches = remotes
+    .filter((r) => upstream.startsWith(`${r.name}/`))
+    .map((r) => r.name)
+    .sort((a, b) => b.length - a.length);
+  return matches[0] ?? null;
+}
+
+/**
+ * One line describing what a bulk fast-forward did (#246).
+ *
+ * The branches that did NOT move lead the interesting half, so they are never
+ * dropped: a diverged branch needs a merge or a rebase, and the branch you are
+ * standing on needs a pull. One name is named; several are counted, because a
+ * toast is one line and eight branch names is not.
+ */
+export function summarizeFastForward(report: BulkFastForward): string {
+  const parts: string[] = [];
+  const names = (list: readonly string[], verb: string) =>
+    list.length === 1
+      ? `${list[0]} ${verb}`
+      : `${list.length} branches ${verb.replace(/^has /, "have ")}`;
+
+  if (report.advanced.length === 1) {
+    parts.push(`Fast-forwarded ${report.advanced[0].branch}`);
+  } else if (report.advanced.length > 1) {
+    parts.push(`Fast-forwarded ${report.advanced.length} branches`);
+  }
+  if (report.diverged.length) parts.push(names(report.diverged, "has diverged"));
+  if (report.checkedOut.length) {
+    parts.push(
+      report.checkedOut.length === 1
+        ? `${report.checkedOut[0]} is checked out — pull it`
+        : `${report.checkedOut.length} branches are checked out — pull them`,
+    );
+  }
+  return parts.length ? parts.join(" · ") : "All branches are up to date";
+}
+
+/**
+ * One line describing what a single fast-forward did (#246).
+ *
+ * "Already up to date" is a real outcome, not silence: the action fetched
+ * first, so the user cannot tell from the row whether anything happened.
+ */
+export function describeFastForward(ff: FastForward): string {
+  return ff.moved
+    ? `Fast-forwarded ${ff.branch} to ${ff.upstream}`
+    : `${ff.branch} is already up to date`;
+}

--- a/src/features/palette/commands.ts
+++ b/src/features/palette/commands.ts
@@ -1,5 +1,5 @@
 // src/features/palette/commands.ts
-import { pgConfirm } from "@/design";
+import { pgConfirm, pgFlash } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useCreateStore } from "@/features/create/useCreateStore";
 import { useLfsStore } from "@/features/lfs/useLfsStore";
@@ -13,6 +13,7 @@ import { useTabsStore } from "@/features/repo/useTabsStore";
 import { openCompare } from "@/features/compare/useCompareStore";
 import { WORKDIR } from "@/features/compare/compareSides";
 import { orderBranchesGrouped } from "@/features/branches/orderBranches";
+import { summarizeFastForward } from "@/features/branches/fastForward";
 import { openCreateTag } from "@/features/tags/useCreateTagStore";
 import { usePaletteStore } from "./usePaletteStore";
 import { createBranchInputStep, switchRepoStep } from "./steps";
@@ -286,6 +287,20 @@ export function buildCommands(): PaletteItem[] {
       type: "command", id: "action:fetch-all", search: "Fetch all remotes",
       label: "Fetch all remotes", icon: "fetch", actionId: "repo.fetch",
       run: direct(() => void repo.fetchAll()),
+    },
+    {
+      // The Monday-morning command: every stale local branch caught up in one
+      // fetch, without a single checkout. The branch you are ON is reported,
+      // not pulled — see `fastForwardAllBranches` (#246).
+      type: "command", id: "action:fast-forward-all",
+      search: "Fast-forward all branches behind upstream pull",
+      label: "Fast-forward all branches", icon: "pull",
+      run: direct(() => {
+        void (async () => {
+          const report = await repo.fastForwardAllBranches();
+          if (report) pgFlash(summarizeFastForward(report));
+        })();
+      }),
     },
     {
       type: "command", id: "action:refresh", search: "Refresh repository",

--- a/src/features/repo/useRepoStore.fastForward.test.ts
+++ b/src/features/repo/useRepoStore.fastForward.test.ts
@@ -1,0 +1,200 @@
+// Fast-forwarding a branch that is not checked out (#246).
+//
+// The routing is the part worth pinning: the op moves a REF, so the branch that
+// is HEAD must go to `pull` with the user's own mode instead — a user who set
+// Rebase gets Rebase, never a silent --ff-only, and never a ref moved out from
+// under their working tree.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { useAuthStore } from "@/features/auth/useAuthStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import type { BranchInfo } from "@/lib/types";
+import { useRepoStore } from "./useRepoStore";
+
+const branch = (b: Partial<BranchInfo> & { name: string }): BranchInfo => ({
+  isHead: false,
+  isRemote: false,
+  upstream: `origin/${b.name}`,
+  ahead: 0,
+  behind: 1,
+  tip: "a".repeat(40),
+  tipTime: 0,
+  isDefault: false,
+  ...b,
+});
+
+const ff = (b: string) => ({
+  branch: b,
+  upstream: `origin/${b}`,
+  from: "a".repeat(40),
+  to: "b".repeat(40),
+  moved: true,
+});
+
+function mockRefreshAll() {
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => null);
+}
+
+const calls = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+
+beforeEach(() => {
+  resetInvokeMock();
+  useAuthStore.setState({ challenge: null });
+  useSettingsStore.getState().reset();
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/tmp/repo-1", head: "feat/x" },
+    branches: [
+      branch({ name: "main" }),
+      branch({ name: "feat/x", isHead: true, upstream: null, behind: 0 }),
+    ],
+    remotes: [{ name: "origin", url: "git@example.com:me/repo.git" }],
+    error: null,
+  });
+  mockRefreshAll();
+});
+
+describe("fastForwardBranch", () => {
+  it("advances a branch that is not checked out", async () => {
+    mockInvoke("fast_forward_branch", () => ff("main"));
+
+    const out = await useRepoStore.getState().fastForwardBranch("main");
+
+    expect(calls("fast_forward_branch")).toHaveLength(1);
+    expect(calls("fast_forward_branch")[0].args.branch).toBe("main");
+    expect(out?.moved).toBe(true);
+    expect(useRepoStore.getState().error).toBeNull();
+    // Refs and log both change when a ref moves.
+    expect(calls("list_branches").length).toBeGreaterThan(0);
+  });
+
+  it("passes the prune setting through to the fetch it does first", async () => {
+    useSettingsStore.getState().set("pruneOnFetch", false);
+    mockInvoke("fast_forward_branch", () => ff("main"));
+
+    await useRepoStore.getState().fastForwardBranch("main");
+
+    expect(calls("fast_forward_branch")[0].args.prune).toBe(false);
+  });
+
+  it("routes the checked-out branch to pull with the user's own mode", async () => {
+    // The whole point of the routing: --ff-only would quietly override a user
+    // who chose Rebase, and moving HEAD's ref would strand the working tree.
+    useSettingsStore.getState().set("defaultPullMode", "Rebase");
+    useRepoStore.setState({
+      current: { id: "repo-1", path: "/tmp/repo-1", head: "main" },
+      branches: [branch({ name: "main", isHead: true })],
+    });
+    mockInvoke("pull", () => null);
+    mockInvoke("stash_save", () => null);
+
+    await useRepoStore.getState().fastForwardBranch("main");
+
+    expect(calls("fast_forward_branch")).toHaveLength(0);
+    expect(calls("pull")).toHaveLength(1);
+    expect(calls("pull")[0].args).toMatchObject({
+      remote: "origin",
+      branch: "main",
+      mode: "Rebase",
+    });
+  });
+
+  it("keeps a slash-bearing remote name whole when it routes to pull", async () => {
+    useRepoStore.setState({
+      current: { id: "repo-1", path: "/tmp/repo-1", head: "main" },
+      branches: [
+        branch({ name: "main", isHead: true, upstream: "team/fork/main" }),
+      ],
+      remotes: [{ name: "team/fork", url: "git@example.com:team/fork.git" }],
+    });
+    mockInvoke("pull", () => null);
+    mockInvoke("stash_save", () => null);
+
+    await useRepoStore.getState().fastForwardBranch("main");
+
+    expect(calls("pull")[0].args.remote).toBe("team/fork");
+  });
+
+  it("raises a credential challenge and retries the same op", async () => {
+    let attempts = 0;
+    mockInvoke("fast_forward_branch", () => {
+      attempts += 1;
+      if (attempts === 1)
+        throw { kind: "Auth", message: { host: "github.com", kind: "Https" } };
+      return ff("main");
+    });
+
+    await useRepoStore.getState().fastForwardBranch("main");
+    expect(useRepoStore.getState().error).toBeNull();
+    await useAuthStore
+      .getState()
+      .challenge!.retry({ username: "ada", secret: "t" }, false);
+
+    expect(attempts).toBe(2);
+    expect(calls("fast_forward_branch")[1].args.credentials).toEqual({
+      username: "ada",
+      secret: "t",
+    });
+  });
+
+  it("refreshes before it reports a refusal, so the banner survives", async () => {
+    mockInvoke("fast_forward_branch", () => {
+      throw { kind: "NotFastForward", message: "main has diverged" };
+    });
+
+    await useRepoStore.getState().fastForwardBranch("main");
+
+    // refreshAll clears `error` as its first act, so the order matters.
+    expect(useRepoStore.getState().error).toEqual({
+      kind: "NotFastForward",
+      message: "main has diverged",
+    });
+    expect(calls("list_branches").length).toBeGreaterThan(0);
+  });
+
+  it("does nothing for a branch it has never heard of", async () => {
+    await useRepoStore.getState().fastForwardBranch("ghost");
+    // Not routed to pull, and not sent to the backend as a guess.
+    expect(calls("pull")).toHaveLength(0);
+    expect(calls("fast_forward_branch")).toHaveLength(1);
+  });
+});
+
+describe("fastForwardAllBranches", () => {
+  it("asks the backend once and hands back the report", async () => {
+    const report = {
+      advanced: [ff("main")],
+      diverged: ["feat/y"],
+      checkedOut: [],
+    };
+    mockInvoke("fast_forward_all_branches", () => report);
+
+    const out = await useRepoStore.getState().fastForwardAllBranches();
+
+    expect(calls("fast_forward_all_branches")).toHaveLength(1);
+    expect(out).toEqual(report);
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("reports a failure through the banner, after refreshing", async () => {
+    mockInvoke("fast_forward_all_branches", () => {
+      throw { kind: "Network", message: "no route to host" };
+    });
+
+    const out = await useRepoStore.getState().fastForwardAllBranches();
+
+    expect(out).toBeNull();
+    expect(useRepoStore.getState().error).toEqual({
+      kind: "Network",
+      message: "no route to host",
+    });
+  });
+});

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -2,7 +2,9 @@ import { create } from "zustand";
 import type {
   AuthorOverride,
   BisectMark,
+  BulkFastForward,
   CommitResult,
+  FastForward,
   FileContent,
   FileStatus,
   LogFilter,
@@ -47,6 +49,8 @@ import {
   discardLines as discardLinesFn,
   discardPaths,
   deleteUntrackedFiles as deleteUntrackedFilesFn,
+  fastForwardAllBranches as fastForwardAllBranchesFn,
+  fastForwardBranch as fastForwardBranchFn,
   fetch as fetchRemote,
   fetchAll,
   getLogFilteredPage,
@@ -109,6 +113,7 @@ import {
   type TagTarget,
 } from "@/lib/tauri";
 import { isFilterEmpty } from "@/features/commits/logFilter";
+import { remoteOfUpstream } from "@/features/branches/fastForward";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { useRecentsStore } from "./useRecentsStore";
 import {
@@ -311,6 +316,31 @@ interface RepoStoreState extends RepoSlice {
   fetch: (remote: string) => Promise<void>;
   fetchAll: () => Promise<void>;
   pull: (remote: string, branch: string, mode?: PullMode) => Promise<void>;
+  /**
+   * Fetch a branch's remote and advance the branch to its upstream (#246).
+   *
+   * The op `pull` cannot be: `git pull <remote> <branch>` merges the fetched
+   * head into whatever HEAD is, so it never advanced the branch it named.
+   *
+   * **The branch that IS HEAD is routed to `pull` with the user's own
+   * `defaultPullMode`** — it needs a working-tree update, and a user who chose
+   * Rebase must not be quietly given `--ff-only`. Every other branch has its ref
+   * moved, and a divergence comes back as a `NotFastForward` banner rather than
+   * a surprise merge.
+   *
+   * Answers the outcome so a caller can say what happened (the ref moved, or it
+   * was already current); `null` when it routed to pull or failed.
+   */
+  fastForwardBranch: (name: string) => Promise<FastForward | null>;
+  /**
+   * `fastForwardBranch` for every local branch that can be, on one fetch (#246).
+   *
+   * Answers the report — advanced, diverged, checked-out — so the caller can
+   * summarize it; `null` when it failed (the banner already says why). The
+   * checked-out branch is REPORTED, never pulled: a bulk button must not rewrite
+   * the working tree.
+   */
+  fastForwardAllBranches: () => Promise<BulkFastForward | null>;
   push: (
     remote: string,
     branch: string,
@@ -1394,6 +1424,82 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         setErrorFor(repo.id, e);
       },
     );
+  },
+
+  async fastForwardBranch(name) {
+    const repo = get().current;
+    if (!repo) return null;
+
+    // HEAD's ref cannot just be moved: the index and worktree would still be at
+    // the old tip, so every incoming change would render as a deletion. Route to
+    // the real pull — which carries the auto-stash and the user's own mode.
+    const branch = get().branches.find((b) => !b.isRemote && b.name === name);
+    if (branch?.isHead) {
+      const remote = remoteOfUpstream(branch.upstream, get().remotes);
+      // No resolvable remote means no upstream to pull from; let the backend
+      // say so rather than guessing "origin".
+      if (remote) {
+        await get().pull(
+          remote,
+          name,
+          useSettingsStore.getState().defaultPullMode,
+        );
+        return null;
+      }
+    }
+
+    let out: FastForward | null = null;
+    setActivity("fetch", `Fast-forwarding ${name}…`);
+    try {
+      await withAuthRetry(
+        repo.id,
+        async (creds) => {
+          out = await fastForwardBranchFn(
+            repo.id,
+            name,
+            useSettingsStore.getState().pruneOnFetch,
+            creds,
+          );
+          await get().refreshAll();
+        },
+        async (e) => {
+          // Refresh first, error last — refreshAll clears `error` as its first
+          // act, so the other order loses the banner (see mergeBranch).
+          await get().refreshAll();
+          setErrorFor(repo.id, e);
+        },
+      );
+    } finally {
+      setActivity("fetch", null);
+    }
+    return out;
+  },
+
+  async fastForwardAllBranches() {
+    const repo = get().current;
+    if (!repo) return null;
+    let out: BulkFastForward | null = null;
+    setActivity("fetch", "Fast-forwarding branches…");
+    try {
+      await withAuthRetry(
+        repo.id,
+        async (creds) => {
+          out = await fastForwardAllBranchesFn(
+            repo.id,
+            useSettingsStore.getState().pruneOnFetch,
+            creds,
+          );
+          await get().refreshAll();
+        },
+        async (e) => {
+          await get().refreshAll();
+          setErrorFor(repo.id, e);
+        },
+      );
+    } finally {
+      setActivity("fetch", null);
+    }
+    return out;
   },
 
   async push(remote, branch, force = "None", noVerify = false) {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -11,6 +11,18 @@ export type AppError =
   | { kind: "InvalidArgument"; message: string }
   | { kind: "DirtyWorktree"; message: string }
   | { kind: "NotMerged"; message: string }
+  /**
+   * A local branch tracks nothing, so there is no upstream to fast-forward it
+   * to (#246). Distinct from `InvalidRef` — the branch is fine, it just has no
+   * upstream — and the remedy is one menu item away: set one.
+   */
+  | { kind: "NoUpstream"; message: string }
+  /**
+   * The branch tip is not an ancestor of its upstream tip, so its ref cannot be
+   * advanced without a merge or a rebase (#246). The one refusal the
+   * fast-forward op exists to make; the message names both refs.
+   */
+  | { kind: "NotFastForward"; message: string }
   | { kind: "ConflictsDetected"; message: string }
   | { kind: "NoSignature"; message?: string }
   | { kind: "Internal"; message: string }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -8,6 +8,7 @@ import type {
   BisectStatus,
   BlameLine,
   BranchInfo,
+  BulkFastForward,
   CliInstallOutcome,
   ChecksSummary,
   DeleteFailure,
@@ -17,6 +18,7 @@ import type {
   ConflictSides,
   DiagnosticsReport,
   DiffKind,
+  FastForward,
   FileContent,
   FileDiff,
   FileStatus,
@@ -927,6 +929,51 @@ export async function pull(
   credentials?: Credentials,
 ): Promise<void> {
   return invoke<void>("pull", { repoId, remote, branch, mode, credentials });
+}
+
+/**
+ * Fetch a branch's remote, then advance the branch to its upstream (#246).
+ *
+ * The op `pull` cannot be: `git pull <remote> <branch>` merges the fetched head
+ * into whatever HEAD is, so it never advanced the branch it named. This moves
+ * that branch's REF and leaves HEAD alone — and therefore REFUSES a branch that
+ * is checked out here or in a linked worktree. Route those to `pull` with the
+ * user's own `defaultPullMode`; `useRepoStore.fastForwardBranch` does.
+ *
+ * Rejects with `NotFastForward` when the branch has diverged. Never merges,
+ * never rebases, never silently does nothing.
+ */
+export async function fastForwardBranch(
+  repoId: string,
+  branch: string,
+  prune = true,
+  credentials?: Credentials,
+): Promise<FastForward> {
+  return invoke<FastForward>("fast_forward_branch", {
+    repoId,
+    branch,
+    prune,
+    credentials,
+  });
+}
+
+/**
+ * Fetch every remote, then fast-forward every local branch that can be (#246).
+ *
+ * One fetch for the whole sweep, which is why it is a command rather than a
+ * loop over `fastForwardBranch` — that would cost a network round trip per
+ * branch. Per-branch refusals come back in the report, not as a rejection.
+ */
+export async function fastForwardAllBranches(
+  repoId: string,
+  prune = true,
+  credentials?: Credentials,
+): Promise<BulkFastForward> {
+  return invoke<BulkFastForward>("fast_forward_all_branches", {
+    repoId,
+    prune,
+    credentials,
+  });
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -204,6 +204,38 @@ export interface BranchInfo {
   isDefault: boolean;
 }
 
+/**
+ * What advancing one local branch to its upstream did (#246).
+ *
+ * `moved` is false for the two harmless outcomes — already at the upstream tip,
+ * or strictly ahead of it — so a caller can say "already up to date" without
+ * re-deriving it. Anything that would NOT be a fast-forward comes back as a
+ * `NotFastForward` error instead, never as `moved: false`.
+ */
+export interface FastForward {
+  branch: string;
+  /** Upstream shorthand, e.g. `origin/main`. */
+  upstream: string;
+  /** FULL oids, like `BranchInfo.tip` — shorten at the display site. */
+  from: string;
+  to: string;
+  moved: boolean;
+}
+
+/**
+ * The outcome of fast-forwarding every eligible local branch at once (#246).
+ *
+ * The two lists that did NOT move are the half the user has to act on: a
+ * diverged branch needs a merge or a rebase, a checked-out one needs a pull.
+ * Branches that were already current, and branches with no upstream, are absent
+ * — neither is something to do anything about.
+ */
+export interface BulkFastForward {
+  advanced: FastForward[];
+  diverged: string[];
+  checkedOut: string[];
+}
+
 export interface TagInfo {
   name: string;
   shortOid: string;

--- a/src/screens/Branches.fastForward.test.tsx
+++ b/src/screens/Branches.fastForward.test.tsx
@@ -1,0 +1,99 @@
+// The bulk "Fast-forward all" action on the Branches toolbar (#246).
+//
+// One fetch, then every local branch that can fast-forward moves — the Monday
+// morning action. What is pinned here is the summary: the branches that did NOT
+// move are the half the user has to act on, so they must survive into the toast.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { BranchesScreen } from "./Branches";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { resetInvokeMock } from "@/test/invokeMock";
+import { WithDialogs } from "@/test/dialog";
+import type { BranchInfo, BulkFastForward } from "@/lib/types";
+
+const branch = (over: Partial<BranchInfo> & { name: string }): BranchInfo => ({
+  isHead: false,
+  isRemote: false,
+  upstream: `origin/${over.name}`,
+  ahead: 0,
+  behind: 1,
+  tip: "a".repeat(40),
+  tipTime: 0,
+  isDefault: false,
+  ...over,
+});
+
+function setup(report: BulkFastForward | null) {
+  const fastForwardAllBranches = vi.fn().mockResolvedValue(report);
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/feat/x" },
+    status: [],
+    branches: [branch({ name: "main" }), branch({ name: "feat/x", isHead: true })],
+    remotes: [{ name: "origin", url: "git@example.com:me/repo.git" }],
+    tags: [],
+    stashes: [],
+    commits: [],
+    loading: false,
+    activity: {},
+    fastForwardAllBranches,
+  } as never);
+  render(
+    <WithDialogs>
+      <BranchesScreen />
+    </WithDialogs>,
+  );
+  return fastForwardAllBranches;
+}
+
+beforeEach(() => {
+  resetInvokeMock();
+  document.querySelector("[data-pg-flash]")?.remove();
+});
+
+describe("Fast-forward all", () => {
+  it("is on the toolbar and runs the bulk op", async () => {
+    const run = setup({ advanced: [], diverged: [], checkedOut: [] });
+
+    fireEvent.click(screen.getByText("Fast-forward all"));
+
+    await waitFor(() => expect(run).toHaveBeenCalledTimes(1));
+  });
+
+  it("summarizes the run, keeping the branches that did not move", async () => {
+    setup({
+      advanced: [
+        {
+          branch: "main",
+          upstream: "origin/main",
+          from: "a".repeat(40),
+          to: "b".repeat(40),
+          moved: true,
+        },
+      ],
+      diverged: ["feat/y"],
+      checkedOut: ["feat/x"],
+    });
+
+    fireEvent.click(screen.getByText("Fast-forward all"));
+
+    await waitFor(() =>
+      expect(document.querySelector("[data-pg-flash]")?.textContent).toBe(
+        "Fast-forwarded main · feat/y has diverged · feat/x is checked out — pull it",
+      ),
+    );
+  });
+
+  it("says nothing when the op failed — the banner already did", async () => {
+    const run = setup(null);
+
+    fireEvent.click(screen.getByText("Fast-forward all"));
+
+    // Wait for the op to have actually resolved before concluding "no toast",
+    // otherwise the assertion passes before anything could have appeared.
+    await waitFor(() => expect(run).toHaveBeenCalledTimes(1));
+    await run.mock.results[0].value;
+    expect(document.querySelector("[data-pg-flash]")).toBeNull();
+  });
+});

--- a/src/screens/Branches.tsx
+++ b/src/screens/Branches.tsx
@@ -12,6 +12,7 @@ import {
   KV,
   branchMenuItems,
   pgConfirm,
+  pgFlash,
   pgPrompt,
   remoteBranchMenuItems,
   stashMenuItems,
@@ -26,6 +27,7 @@ import {
 import { useElementSize } from "@/lib/useElementSize";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { orderBranches } from "@/features/branches/orderBranches";
+import { summarizeFastForward } from "@/features/branches/fastForward";
 import { TagSignatureBadge } from "@/features/signing/TagSignatureBadge";
 import { PGPane, FocusableScroll, usePaneList } from "@/features/keymap";
 import type { BranchInfo, StashInfo, TagInfo } from "@/lib/types";
@@ -52,12 +54,21 @@ export function BranchesScreen() {
   const stashes = useRepoStore((s) => s.stashes);
   const activity = useRepoStore((s) => s.activity);
   const fetchAllOp = useRepoStore((s) => s.fetchAll);
+  const fastForwardAll = useRepoStore((s) => s.fastForwardAllBranches);
   const createAndSwitchBranch = useRepoStore((s) => s.createAndSwitchBranch);
   const [selection, setSelection] = React.useState<Selection | null>(null);
   const [filter, setFilter] = React.useState("");
   const [view, setView] = React.useState<
     "all" | "local" | "remote" | "tags" | "stashes"
   >("all");
+
+  // No confirm: a fast-forward only ever moves a ref forward, and every move
+  // leaves a reflog entry. The branch you are STANDING on is reported, never
+  // pulled — a bulk button must not rewrite the working tree (#246).
+  const startFastForwardAll = async () => {
+    const report = await fastForwardAll();
+    if (report) pgFlash(summarizeFastForward(report));
+  };
 
   const startCreate = async () => {
     const raw = await pgPrompt({
@@ -251,6 +262,7 @@ export function BranchesScreen() {
           onView={setView}
           onNew={startCreate}
           onFetchAll={fetchAllOp}
+          onFastForwardAll={startFastForwardAll}
           fetching={!!activity.fetch}
         />
         <PGEmpty icon="branch" title="No branches, tags, or stashes">
@@ -269,6 +281,7 @@ export function BranchesScreen() {
         onView={setView}
         onNew={startCreate}
         onFetchAll={fetchAllOp}
+        onFastForwardAll={startFastForwardAll}
         fetching={!!activity.fetch}
       />
       <div ref={layout.ref} style={{ flex: 1, minHeight: 0, display: "flex" }}>
@@ -701,6 +714,7 @@ function BranchesToolbar({
   onView,
   onNew,
   onFetchAll,
+  onFastForwardAll,
   fetching,
 }: {
   filter: string;
@@ -709,6 +723,7 @@ function BranchesToolbar({
   onView: (v: "all" | "local" | "remote" | "tags" | "stashes") => void;
   onNew: () => void;
   onFetchAll: () => void;
+  onFastForwardAll: () => void;
   fetching: boolean;
 }) {
   return (
@@ -744,6 +759,16 @@ function BranchesToolbar({
             onClick={onFetchAll}
           >
             Fetch all
+          </PGButton>
+          <PGButton
+            size="sm"
+            variant="outline"
+            icon="pull"
+            loading={fetching}
+            title="Fetch, then advance every local branch that can fast-forward"
+            onClick={onFastForwardAll}
+          >
+            Fast-forward all
           </PGButton>
           <PGButton
             size="sm"


### PR DESCRIPTION
## What does this PR do?

Adds **"Fast-forward to upstream"** on any local branch row, a **"Fast-forward all"** toolbar button on Branches, and a command-palette entry. The workflow it removes: `main` is behind, you are on `feat/x`, and getting `main` current cost checkout → pull → checkout — three operations, two working-copy rewrites, and a stash if you were dirty.

Closes #246.

## Why this needs a new op rather than reusing `pull`

`commands::branches::pull` shells `git pull <mode> <remote> <branch>`, and that branch argument is a **refspec** — git merges the fetched head into **whatever HEAD currently is**, regardless of which branch was named. So `pull("origin", "main")` from `feat/x` does not update `main`; it merges `origin/main` into `feat/x`. There was no way to advance a non-checked-out branch.

## The lock, which is the whole risk

Both `fast_forward_branch` and `fast_forward_all` do everything inside a **single `with_repo` closure**, so the ancestry check and the ref move share one acquisition of the per-repo mutex. Two details make it tighter than the minimum:

- `plan_fast_forward` returns the `git2::Reference` **it read**, and `apply_fast_forward` calls `set_target` on *that object* — one ref lookup, not two. The ref that was checked is the ref that moves, even against a `git` CLI writing it from outside in the same instant.
- `fast_forward_all` is one closure for the **whole sweep, listing included**, so nothing can interleave between branch enumeration and the last ref move.

All helpers take an already-borrowed `&Repository`, the same shape as `stash_pairs`/`stash_entry_at`, because std's `Mutex` is not reentrant.

## Refusals are states, not surprises

| Situation | Answer |
|---|---|
| Genuine fast-forward | ref moves, reflog entry written |
| Diverged | `NotFastForward` naming both refs; **ref does not move** (test asserts the oid is unchanged) |
| Already current / strictly ahead | `moved: false` — a state, not an error, matching `git pull --ff-only`'s "Already up to date"; still flashes, so never a silent no-op |
| No upstream | `NoUpstream`; the menu entry is disabled |
| Is HEAD | routes in the store to the existing `pull` with the user's `defaultPullMode` |
| Checked out in a **linked worktree** | refused |

**HEAD routes in the frontend store, not the command** — routing inside the command would bypass `useRepoStore.pull`'s auto-stash → pull → pop and the user's chosen mode (someone who set Rebase gets Rebase). The backend refuses HEAD independently as a safety net. The bulk action deliberately does **not** route HEAD: it reports it in `checkedOut` and leaves it, because a "fast-forward all" button must not rewrite your working tree.

**The linked-worktree refusal matters concretely here.** This project is developed through `.claude/worktrees/`, so moving a ref out from under a sibling checkout is a real hazard, not a theoretical one — that checkout would render every incoming change as a deletion. git2-rs 0.20 does not bind `git_branch_is_checked_out`, so it walks `worktree::linked_worktree_heads`; only ref-moving ops pay the walk, and the bulk sweep walks once.

## One credential path

The fetch goes through `commands::net::run_git_authenticated` (via a one-line `run_git_creds` wrapper); the frontend retries through the exported `withAuthRetry`. No private retry, no second auth path — verified against the authoritative grep in `docs/dev/backend.md` and pinned by a store test that raises an `Auth` challenge and asserts the retry carries the credential into the *same* command.

## ⚠️ One change to an existing code path

`fetch_args` now ends option parsing before the remote name: **`git fetch --prune -- origin`** (was `git fetch origin --prune`). Same hardening the file already documents for `push_tag_args` — the remote is user-supplied and `--upload-pack=<program>` names a program git runs for the transport.

This changes the **existing** `fetch` and `pull` argv, so it got an e2e run rather than reasoning:

- `pnpm test:e2e:docker full --spec e2e/specs/remote.e2e.ts` → **10 passing**, including `fetch surfaces behind count`, `pull brings the remote-only commit into the worktree` and `prunes stale remote-tracking refs`.
- The `--all` form is **byte-identical** before and after (`["fetch", "--all", "--prune"]`), so `fetch-all` paths are untouched.
- A unit test pins that `--upload-pack=/bin/false` as a remote name lands after the separator.

## Notable / follow-ups

- Existing `branchMenuItems` "Pull"/"Push" still use `upstream.split("/")[0]` (remote names can contain slashes) and "Pull" uses the default `Merge` rather than `defaultPullMode`. Pre-existing inconsistencies, deliberately not changed under this feature's tests; `remoteOfUpstream` is now available if you want them fixed.
- "Fast-forward all" shares `loading={!!activity.fetch}` with "Fetch all", so clicking either spins both — consistent with the existing fetch button.
- `fast_forward_all_branches` runs `git fetch --all`; fetching only remotes backing a behind branch would be a follow-up.

## Checklist

- [x] One logical change, focused PR
- [x] Branched off `main`; rebased onto `27f6335`, no merge commits, single squashed commit
- [x] PR title + commit message follow Conventional Commits
- [x] `pnpm tsc --noEmit` passes — exit 0
- [x] `cargo test` passes — **832 tests, 0 failed** (16 new in `tests/fast_forward.rs` + a `fetch_args` injection guard)
- [x] `pnpm test` passes — 251 files, 2225 tests (32 new)
- [x] `pnpm exec tsc -p e2e/tsconfig.json --noEmit` passes
- [x] **e2e run** — `remote.e2e.ts`, 10 passing, because `fetch_args` changed a shipped path
- [x] New git op: trait + impl + `CliBackend` stub + commands + `invoke_handler!` + TS type/wrapper wired
- [x] `docs/dev/architecture.md`, `backend.md`, `frontend.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
