### PR TITLE
feat(history): show git notes, and honour blame.ignoreRevsFile

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -121,6 +121,19 @@ git/
 ├── stash.rs     Repo-less stash helpers (#133): push/store argv builders
 │                (`--` placement, GIT_LITERAL_PATHSPECS), validate_message,
 │                rename_store_landed. Unit-tested with no temp repo
+├── blame.rs     `blame.ignoreRevsFile` — the PURE half (#253): read_settings,
+│                resolve_ignore_revs_path, blame_args, parse_porcelain. libgit2
+│                has NO ignore-revs support at all, so a repo that configures a
+│                file gets `git blame --line-porcelain`; a repo that does not
+│                keeps the in-process libgit2 blame. The configured path never
+│                enters argv — git reads its own config, and the un-ignored view
+│                passes the fixed literal `--ignore-revs-file=` (git's "clear
+│                the list"). See backend.md
+├── notes.rs     Reading `refs/notes/*` (#253), read-only: label_for,
+│                is_notes_ref, sort_refs (all PURE) + read(). EVERY notes ref is
+│                shown, labelled — `core.notesRef`/`notes.displayRef` are
+│                deliberately not consulted. Absence is a state at three levels.
+│                See backend.md
 ├── bisect.rs    Reads git's own BISECT_* + refs/bisect/* — deliberately NO
 │                parallel state file (see backend.md); progress via
 │                `git rev-list --bisect-vars`
@@ -182,7 +195,10 @@ commands/        Thin Tauri handlers, one file per area:
 │                track the file_name configured in lib.rs — the plugin does not
 │                report what it picked. Thin over src-tauri/src/diagnostics.rs
 ├── commits.rs   get_log, commit, file_history, verify_commit (SELECTED commit
-│                only, never per row). REFSPEC_ALL sentinel = walk all refs, so
+│                only, never per row) and commit_notes, which is lazy for the
+│                same reason (#253 — the log walk is the hot path, so notes are
+│                read for the selected commit and cost the page nothing).
+│                REFSPEC_ALL sentinel = walk all refs, so
 │                the loaded log is NOT HEAD ancestry — rebase input must go
 │                through headAncestryOf. Paged (see frontend.md): get_log_page /
 │                get_log_filtered_page / get_log_filtered. Also commits_since
@@ -190,7 +206,8 @@ commands/        Thin Tauri handlers, one file per area:
 │                (base..tip, no ancestry requirement) and ahead_behind (counts
 │                a→b + merge base; unrelated histories → mergeBase: null)
 ├── diff.rs      get_diff, stage/unstage/discard_paths, stage/unstage/discard_hunk,
-│                stage/unstage/discard_lines, diff_ref_to_workdir, blame_file,
+│                stage/unstage/discard_lines, diff_ref_to_workdir, blame_file
+│                (takes ignoreRevs — the Blame screen's toggle; see git/blame.rs),
 │                and two commit diffs ONE character apart: diff_commit (one oid
 │                vs its first parent) and diff_commits (rev↔rev) — check arity
 ├── branches.rs  list_branches/tags/stashes/remotes,
@@ -283,6 +300,8 @@ features/            Components + Zustand store colocated per feature:
 │                    graphAncestry, rowIdentity, buildRebasePlan /
 │                    buildPreservePlan / withPlanBase / runRebasePlan /
 │                    planCommitSelection / squashMessage, headAncestry, logFilter
+│                    — plus CommitNotes, the one component here: `git notes` for
+│                    the SELECTED commit, debounced like SignatureBadge (#253)
 ├── rebase/          RebaseBasePicker + useRebaseMergeMode (flatten ⇄ preserve)
 ├── dnd/             ALL drag-and-drop (#91): useDragSource / useDropZone over
 │                    dragController.ts, resolveDrop.ts (pure drop tables),

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -401,6 +401,77 @@ again. `commands/repo.rs::delete_untracked_files` is therefore thin.
   are unlinked as links (with a `remove_dir` fallback for the Windows
   directory-symlink case), never followed.
 
+## `blame.ignoreRevsFile` — where libgit2 cannot follow (#253)
+
+- **libgit2's blame has no ignore-revs support of any kind.**
+  `git_blame_options` carries whitespace, first-parent and range flags and
+  nothing that takes a list of revisions to pass through, so there is no
+  in-process answer to give. `.git-blame-ignore-revs` is committed in a great
+  many repositories, and blame that names whoever ran the formatter is worse
+  than no blame — it looks authoritative and is wrong. So blame joins
+  `merge_branch`, `rebase_onto` and `worktree remove` in shelling out.
+- **The shell-out is opt-in by the repository, not global.** No
+  `blame.ignoreRevsFile` → the in-process libgit2 blame, exactly as before: no
+  subprocess, no parsing, no behaviour change for the common case. A repo that
+  configured one gets `git blame` for **both** toggle states — comparing a
+  libgit2 blame against a git blame would let unrelated engine differences
+  masquerade as the effect of the toggle.
+- **The configured path never reaches argv.** `git blame` reads
+  `blame.ignoreRevsFile` from the repository's own config, so the ignore-revs
+  view passes no `--ignore-revs-file=<path>` at all: the user-supplied path is
+  never assembled into a command line and can never be read as an option. The
+  un-ignored view passes the fixed literal `--ignore-revs-file=`, whose empty
+  value is git's documented "clear the list of revs from previously processed
+  files" — including the entries the config contributed. The only user-supplied
+  argv value left is the blamed path, and it goes after `--`. The resolved path
+  is used for one thing only: deciding whether the file is there.
+- **`HEAD` is passed explicitly**, so both engines answer the same question:
+  the file as of HEAD, not the working tree. Without it git would blame the
+  worktree and attribute uncommitted lines to the all-zero oid, and the line
+  COUNT would change depending on whether the repository happens to have an
+  ignore-revs file — the toggle would appear to add and remove lines.
+- **A configured file that cannot be used degrades, it does not fail.** git
+  DIES on a missing one (`fatal: could not open object name list`) and on a
+  malformed one (an oid it cannot peel to a commit), and a missing file is an
+  ordinary state — a config that arrived through an include, a template, or a
+  branch where the file does not exist yet. Both cases fall back to the libgit2
+  blame with `BlameResult.ignore_revs_error` set; the screen shows a warning
+  beside a working blame. `--ignore-revs-file=` cannot rescue it, because git
+  processes the config entries first and dies before reaching the clear.
+- **`--line-porcelain`, not the default format.** The default packs author,
+  date and line number into a column-aligned parenthesised field around content
+  that may contain any of those characters. Porcelain is the stable documented
+  form — and it carries the `ignored` / `unblamable` keys, so
+  `blame.markIgnoredLines` needs no second run to observe. Those keys are
+  **gated on the config** (measured, git 2.50.1): git only marks when asked, and
+  so do we. Parsing keys on the TAB prefix is what makes blaming a file that
+  itself contains blame output unambiguous.
+
+## `git notes` — read-only, and lazy on purpose (#253)
+
+- **Per SELECTED commit, never per log row.** `commit_notes` has the same shape
+  as `verify_commit` beside it, for the same reason: the paged log walk is the
+  hot path, and a note lookup is a fanout-tree descent per notes ref. Batching
+  the page would still put that work on every page fetch, for a feature most
+  repositories never use — so the log page's cost is **zero**, and the read
+  happens once the selection settles (`CommitNotes`, debounced 100 ms, so
+  arrowing through the log reads nothing for the rows passed over).
+- **Absence is a state at THREE levels** and none of them may error: no
+  `refs/notes/*` in the repository, no note for this commit on a ref that has
+  others, and a note whose message is blank. All three are `Ok(vec![])`, and the
+  component renders `null` — a "no notes" placeholder would be permanent
+  furniture in a panel most commits never fill. An unresolvable OID is still an
+  error: that is a caller bug, and reporting it as "no notes" hides it forever.
+- **Every `refs/notes/*` ref is shown, labelled with the ref**, and
+  `core.notesRef` / `notes.displayRef` are deliberately NOT consulted. The
+  asymmetry decides it: showing a note the display config would have hidden
+  costs one labelled block, and the ref name is on screen so nothing is
+  ambiguous; hiding a note somebody deliberately attached, in a GUI with no
+  "show all notes" affordance, is a fact the user cannot discover at all. The
+  default ref sorts first.
+- **Read-only.** Writing needs a ref to pick, a merge strategy for the notes
+  tree, and a push story; it is a separate feature, not a missing button.
+
 ## Spawning processes (issue 172)
 
 - **Never write `Command::new` outside `src-tauri/src/proc.rs`** —

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -286,6 +286,37 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   `MAX_BARREN_PAGES`, or it walks the whole repository. New client-side log
   filters inherit that trap.
 
+## `git notes` in the commit detail panel (#253)
+
+- **Notes hang off the SELECTED commit, never the log page.** `CommitNotes`
+  lives inside the message scroll region (a long note scrolls with the body
+  rather than pushing the action row out of the panel) and reads debounced, like
+  `SignatureBadge` — the log walk is the hot path, and rows arrowed past cost
+  nothing.
+- **No note renders `null`, and so does a failed read.** Most commits in most
+  repositories have no notes, so an "empty" affordance would be permanent
+  furniture; a banner beside a perfectly viewable commit is noise.
+- Each note is badged with its ref, because a note on `refs/notes/review` and
+  one on `refs/notes/commits` are different claims about the commit.
+
+## Blame and `blame.ignoreRevsFile` (#253)
+
+- **The ignore-revs toggle exists only where an ignore-revs file does.**
+  `BlameResult.ignoreRevsFile === null` means the repository configured none, so
+  there is no control to show — the backend's answer, not a guess from the
+  frontend. `PGToggle`, not a native control.
+- **The toggle is NOT persisted, deliberately.** git's own behaviour (honour the
+  config) is the right default every time a file is opened; a remembered "off"
+  would silently contradict the repository's `.git-blame-ignore-revs` in some
+  later session with nothing on screen explaining why the formatter owns every
+  line. It is view state in the screen, so it also stays out of
+  `PersistedState` and out of the settings export key set.
+- **git's `?` / `*` marks are rendered only when the repo asked for them**
+  (`blame.markIgnoredLines` / `blame.markUnblamableLines`). git only marks when
+  asked; a mark nobody configured reads as a defect in the line.
+- An unusable ignore-revs file is a WARNING strip above a working blame, never
+  an error screen — the backend already degraded to a plain blame.
+
 ## Navigation model
 
 - Activity bar = primary switcher, History first. **Launch always lands on

--- a/src-tauri/src/commands/commits.rs
+++ b/src-tauri/src/commands/commits.rs
@@ -3,7 +3,8 @@ use tauri::State;
 use crate::{
     error::{AppError, AppResult},
     git::types::{
-        AheadBehind, AuthorOverride, CommitInfo, CommitOptions, CommitResult, LogFilter, LogPage, RepoId,
+        AheadBehind, AuthorOverride, CommitInfo, CommitNote, CommitOptions, CommitResult, LogFilter,
+        LogPage, RepoId,
     },
     state::AppState,
 };
@@ -180,6 +181,24 @@ pub async fn verify_commit(
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
     tokio::task::spawn_blocking(move || backend.verify_commit(&repo_id, &oid))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+/// Every `refs/notes/*` note on ONE commit (#253).
+///
+/// Read-only, and lazy for the SELECTED commit — the same shape (and the same
+/// reason) as `verify_commit` beside it: the paged log walk is the hot path,
+/// and a per-row notes lookup would put a fanout-tree descent on every page.
+#[tauri::command]
+pub async fn commit_notes(
+    state: State<'_, AppState>,
+    repo_id: String,
+    oid: String,
+) -> AppResult<Vec<CommitNote>> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    tokio::task::spawn_blocking(move || backend.commit_notes(&repo_id, &oid))
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
 }

--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -4,7 +4,7 @@ use tauri::State;
 
 use crate::{
     error::{AppError, AppResult},
-    git::types::{BlameLine, DiffKind, FileDiff, RepoId, WorkdirDiff},
+    git::types::{BlameResult, DiffKind, FileDiff, RepoId, WorkdirDiff},
     state::AppState,
 };
 
@@ -243,16 +243,23 @@ pub async fn diff_ref_to_workdir(
     .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
+/// Blame one file as of HEAD (#253).
+///
+/// `ignore_revs` defaults to TRUE — git's own behaviour when the repository
+/// configures `blame.ignoreRevsFile`. The Blame screen passes `false` for the
+/// un-ignored view behind its toggle.
 #[tauri::command]
 pub async fn blame_file(
     state: State<'_, AppState>,
     repo_id: String,
     path: String,
-) -> AppResult<Vec<BlameLine>> {
+    ignore_revs: Option<bool>,
+) -> AppResult<BlameResult> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
     let path = PathBuf::from(path);
-    tokio::task::spawn_blocking(move || backend.blame_file(&repo_id, &path))
+    let ignore_revs = ignore_revs.unwrap_or(true);
+    tokio::task::spawn_blocking(move || backend.blame_file(&repo_id, &path, ignore_revs))
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
 }

--- a/src-tauri/src/git/blame.rs
+++ b/src-tauri/src/git/blame.rs
@@ -1,0 +1,380 @@
+//! `blame.ignoreRevsFile` support — the pure half (#253).
+//!
+//! # Why blame leaves libgit2 at all
+//!
+//! `.git-blame-ignore-revs` is how a repository says "the reformat commit is
+//! not the author of these lines", and it is committed in a great many
+//! repositories. **libgit2 has no equivalent**: `git_blame_options` carries
+//! whitespace, first-parent and range flags and nothing that takes a list of
+//! revisions to pass through, so there is no in-process way to answer the
+//! question at all. Where libgit2 falls short, this codebase shells out to real
+//! git — the same trade `merge_branch`, `rebase_onto` and `worktree remove`
+//! already make.
+//!
+//! # The shell-out is opt-in by the repository, not global
+//!
+//! A repo with no `blame.ignoreRevsFile` still gets the in-process libgit2
+//! blame, exactly as before: no subprocess, no parsing, no behaviour change.
+//! Only a repo that configured one pays for git, and only then are BOTH toggle
+//! states served by git — comparing a libgit2 blame against a git blame would
+//! let unrelated engine differences masquerade as the effect of the toggle.
+//!
+//! # The configured path never reaches argv
+//!
+//! `git blame` reads `blame.ignoreRevsFile` from the repository's own config,
+//! so the ignore-revs view needs no `--ignore-revs-file=<path>` at all — the
+//! user-supplied path is never assembled into a command line, never has to be
+//! quoted, and can never be read as an option because it is not an argument.
+//! The un-ignored view passes the fixed literal `--ignore-revs-file=`, whose
+//! empty value is git's documented "clear the list" (including entries the
+//! config contributed). The only user-supplied argv value left is the path
+//! being blamed, and it goes after `--`.
+//!
+//! # `--line-porcelain`, not the default format
+//!
+//! The default output packs author, date and line number into a
+//! column-aligned parenthesised field around content that may contain any of
+//! those characters. `--line-porcelain` is the stable, documented,
+//! machine-readable form: one header line, `key value` lines, then the content
+//! prefixed with a TAB. It also carries the `ignored` / `unblamable` keys, so
+//! `blame.markIgnoredLines` needs no second run to observe.
+
+use std::path::{Path, PathBuf};
+
+use git2::Repository;
+
+use crate::git::types::BlameLine;
+
+/// The three `blame.*` settings this feature reads.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BlameSettings {
+    /// `blame.ignoreRevsFile`, verbatim. `None` when unset or empty — git
+    /// treats an empty value as "reset the list", which for a single-valued
+    /// read is indistinguishable from unset.
+    pub ignore_revs_file: Option<String>,
+    pub mark_ignored_lines: bool,
+    pub mark_unblamable_lines: bool,
+}
+
+/// Read the `blame.*` settings from the repository's effective config
+/// (system + global + local, exactly as git resolves them).
+pub fn read_settings(repo: &Repository) -> BlameSettings {
+    let cfg = match repo.config() {
+        Ok(c) => c,
+        // No readable config is the same answer as no settings.
+        Err(_) => return BlameSettings::default(),
+    };
+    BlameSettings {
+        ignore_revs_file: cfg
+            .get_string("blame.ignoreRevsFile")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty()),
+        mark_ignored_lines: cfg.get_bool("blame.markIgnoredLines").unwrap_or(false),
+        mark_unblamable_lines: cfg.get_bool("blame.markUnblamableLines").unwrap_or(false),
+    }
+}
+
+/// Where a configured `blame.ignoreRevsFile` actually lives. PURE.
+///
+/// Mirrors git: `~` is expanded (git runs the value through
+/// `git_config_pathname`), and a relative path resolves against the top of the
+/// working tree — which is where git itself is standing, because `proc::git`
+/// runs it as `git -C <workdir>`.
+///
+/// Used ONLY to decide whether the file is there. The resolved path is never
+/// handed to git; see the module docs.
+pub fn resolve_ignore_revs_path(workdir: &Path, home: Option<&Path>, raw: &str) -> PathBuf {
+    if let Some(rest) = raw.strip_prefix("~/").or_else(|| {
+        // A bare `~` is the home directory itself.
+        (raw == "~").then_some("")
+    }) {
+        if let Some(home) = home {
+            return home.join(rest);
+        }
+    }
+    let p = Path::new(raw);
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        workdir.join(p)
+    }
+}
+
+/// `$HOME` for [`resolve_ignore_revs_path`], the same way `cli.rs` finds it.
+pub fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+/// argv for `git -C <workdir> …`, everything except the path. PURE.
+///
+/// `HEAD` is explicit so this asks the SAME question libgit2's blame does —
+/// the file as of HEAD, not the working tree. Without it git would blame the
+/// worktree and attribute uncommitted lines to the all-zero oid, so the line
+/// COUNT would change depending on whether the repository happens to have an
+/// ignore-revs file. `--` ends option parsing before the caller appends the
+/// path.
+pub fn blame_args(ignore_revs: bool) -> Vec<&'static str> {
+    let mut args = vec!["blame", "--line-porcelain"];
+    if !ignore_revs {
+        // git's documented "clear the list of revs from previously processed
+        // files", which includes the ones `blame.ignoreRevsFile` contributed.
+        args.push("--ignore-revs-file=");
+    }
+    args.push("HEAD");
+    args.push("--");
+    args
+}
+
+/// A partly-read porcelain entry.
+#[derive(Default)]
+struct Partial {
+    oid: String,
+    line_no: u32,
+    author: String,
+    email: String,
+    timestamp: i64,
+    summary: String,
+    ignored: bool,
+    unblamable: bool,
+}
+
+/// Is this a porcelain header line (`<sha> <orig-lno> <final-lno> [<count>]`)?
+///
+/// Distinguishable from a `key value` line because the first token of a header
+/// is all hex and at least a full oid long, and no porcelain key is.
+fn parse_header(line: &str) -> Option<Partial> {
+    let mut it = line.split(' ');
+    let sha = it.next()?;
+    if sha.len() < 40 || !sha.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let _orig_lno: u32 = it.next()?.parse().ok()?;
+    let line_no: u32 = it.next()?.parse().ok()?;
+    Some(Partial {
+        oid: sha.to_string(),
+        line_no,
+        ..Default::default()
+    })
+}
+
+impl Partial {
+    fn key(&mut self, line: &str) {
+        let (key, value) = match line.split_once(' ') {
+            Some((k, v)) => (k, v),
+            None => (line, ""),
+        };
+        match key {
+            "author" => self.author = value.to_string(),
+            // Porcelain wraps the address in angle brackets; the rest of the
+            // app stores bare addresses.
+            "author-mail" => {
+                self.email = value
+                    .trim()
+                    .trim_start_matches('<')
+                    .trim_end_matches('>')
+                    .to_string()
+            }
+            "author-time" => self.timestamp = value.trim().parse().unwrap_or(0),
+            "summary" => self.summary = value.to_string(),
+            "ignored" => self.ignored = true,
+            "unblamable" => self.unblamable = true,
+            _ => {}
+        }
+    }
+
+    fn finish(self, content: &str) -> BlameLine {
+        let short_oid = self.oid.chars().take(7).collect();
+        BlameLine {
+            line_no: self.line_no,
+            short_oid,
+            oid: self.oid,
+            author: self.author,
+            email: self.email,
+            timestamp: self.timestamp,
+            summary: self.summary,
+            content: content.to_string(),
+            ignored: self.ignored,
+            unblamable: self.unblamable,
+        }
+    }
+}
+
+/// Parse `git blame --line-porcelain` output into one [`BlameLine`] per line
+/// of the file. PURE.
+///
+/// Content lines are the ones prefixed with a TAB, which is what makes this
+/// unambiguous: no header and no key can start with one, and a line of the
+/// file that happens to look like a porcelain header is still preceded by its
+/// TAB. A trailing `\r` is stripped so a CRLF file matches what the libgit2
+/// path produces (`str::lines` drops it there).
+pub fn parse_porcelain(stdout: &str) -> Vec<BlameLine> {
+    let mut out = Vec::new();
+    let mut cur: Option<Partial> = None;
+    for raw in stdout.split('\n') {
+        if let Some(content) = raw.strip_prefix('\t') {
+            if let Some(partial) = cur.take() {
+                out.push(partial.finish(content.strip_suffix('\r').unwrap_or(content)));
+            }
+            continue;
+        }
+        if let Some(header) = parse_header(raw) {
+            cur = Some(header);
+            continue;
+        }
+        if let Some(partial) = cur.as_mut() {
+            partial.key(raw);
+        }
+    }
+    out.sort_by_key(|l| l.line_no);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TWO_LINES: &str = "\
+1111111111111111111111111111111111111111 1 1 1
+author Ada Lovelace
+author-mail <ada@example.com>
+author-time 1700000000
+author-tz +0000
+committer Ada Lovelace
+committer-mail <ada@example.com>
+committer-time 1700000000
+committer-tz +0000
+summary write the lines
+boundary
+filename src.txt
+ignored
+\t    alpha
+2222222222222222222222222222222222222222 2 2 1
+author Grace Hopper
+author-mail <grace@example.com>
+author-time 1700000100
+author-tz +0000
+committer Grace Hopper
+committer-mail <grace@example.com>
+committer-time 1700000100
+committer-tz +0000
+summary add a line
+previous 1111111111111111111111111111111111111111 src.txt
+filename src.txt
+unblamable
+\tbrand new
+";
+
+    #[test]
+    fn parses_one_line_per_file_line_with_its_attribution() {
+        let lines = parse_porcelain(TWO_LINES);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].line_no, 1);
+        assert_eq!(lines[0].oid, "1".repeat(40));
+        assert_eq!(lines[0].short_oid, "1111111");
+        assert_eq!(lines[0].author, "Ada Lovelace");
+        assert_eq!(lines[0].email, "ada@example.com");
+        assert_eq!(lines[0].timestamp, 1_700_000_000);
+        assert_eq!(lines[0].summary, "write the lines");
+        assert_eq!(lines[0].content, "    alpha");
+        assert_eq!(lines[1].author, "Grace Hopper");
+        assert_eq!(lines[1].content, "brand new");
+    }
+
+    #[test]
+    fn carries_gits_ignored_and_unblamable_marks_separately() {
+        let lines = parse_porcelain(TWO_LINES);
+        assert!(lines[0].ignored && !lines[0].unblamable);
+        assert!(lines[1].unblamable && !lines[1].ignored);
+    }
+
+    #[test]
+    fn a_file_line_that_looks_like_a_porcelain_header_is_still_content() {
+        // The failure this guards: blaming a file that CONTAINS blame output.
+        // The TAB is what disambiguates, so the parser must key on it.
+        let out = format!(
+            "{sha} 1 1 1\nauthor A\nauthor-mail <a@b>\nauthor-time 1\nsummary s\nfilename f\n\t{sha} 9 9 9\n",
+            sha = "3".repeat(40)
+        );
+        let lines = parse_porcelain(&out);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].content, format!("{} 9 9 9", "3".repeat(40)));
+    }
+
+    #[test]
+    fn an_empty_file_line_survives_and_crlf_is_normalised() {
+        let sha = "4".repeat(40);
+        let out = format!(
+            "{sha} 1 1 2\nauthor A\nauthor-time 1\nfilename f\n\t\n{sha} 2 2\nauthor A\nauthor-time 1\nfilename f\n\ttext\r\n"
+        );
+        let lines = parse_porcelain(&out);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].content, "");
+        assert_eq!(lines[1].content, "text");
+    }
+
+    #[test]
+    fn empty_output_is_an_empty_blame_not_a_panic() {
+        assert!(parse_porcelain("").is_empty());
+    }
+
+    #[test]
+    fn the_ignore_revs_view_passes_no_path_and_the_other_clears_the_list() {
+        // The security property in one assertion: neither form carries a
+        // user-supplied path, and both end option parsing before the caller
+        // appends one.
+        assert_eq!(
+            blame_args(true),
+            vec!["blame", "--line-porcelain", "HEAD", "--"]
+        );
+        assert_eq!(
+            blame_args(false),
+            vec![
+                "blame",
+                "--line-porcelain",
+                "--ignore-revs-file=",
+                "HEAD",
+                "--"
+            ]
+        );
+        for on in [true, false] {
+            assert_eq!(*blame_args(on).last().unwrap(), "--");
+        }
+    }
+
+    #[test]
+    fn a_relative_ignore_revs_path_resolves_against_the_worktree_root() {
+        assert_eq!(
+            resolve_ignore_revs_path(
+                Path::new("/repo"),
+                Some(Path::new("/home/ada")),
+                ".git-blame-ignore-revs"
+            ),
+            PathBuf::from("/repo/.git-blame-ignore-revs")
+        );
+    }
+
+    #[test]
+    fn absolute_and_tilde_ignore_revs_paths_are_left_where_they_point() {
+        assert_eq!(
+            resolve_ignore_revs_path(Path::new("/repo"), Some(Path::new("/home/ada")), "/etc/revs"),
+            PathBuf::from("/etc/revs")
+        );
+        assert_eq!(
+            resolve_ignore_revs_path(
+                Path::new("/repo"),
+                Some(Path::new("/home/ada")),
+                "~/shared-revs"
+            ),
+            PathBuf::from("/home/ada/shared-revs")
+        );
+        // No home to expand against: better a path that fails to stat than a
+        // literal "~" directory created inside somebody's repository.
+        assert_eq!(
+            resolve_ignore_revs_path(Path::new("/repo"), None, "~/shared-revs"),
+            PathBuf::from("/repo/~/shared-revs")
+        );
+    }
+}

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -4,8 +4,9 @@ use crate::error::{AppError, AppResult};
 
 use super::{
     types::{
-        AheadBehind, BisectMark, BisectStatus, BlameLine, BranchInfo, CommitInfo, CommitOptions, CommitResult, ConflictSides,
-        BulkFastForward, DeleteFailure, DiffKind, FastForward, FileContent,
+        AheadBehind, BisectMark, BisectStatus, BlameResult, BranchInfo, CommitInfo, CommitNote, CommitOptions, CommitResult, ConflictSides,
+        DeleteFailure, DiffKind, FileContent,
+        BulkFastForward, FastForward,
         FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage, RebaseStatus, RebaseStep, ReflogEntry,
         RemoteInfo, RepoHandle, RepoId, RepoState, ResetMode, StashInfo, StashSaveOptions,
         SubmoduleInfo, TagInfo,
@@ -429,7 +430,15 @@ impl GitBackend for CliBackend {
     fn append_gitignore(&self, _repo_id: &RepoId, _pattern: &str) -> AppResult<()> {
         Err(AppError::NotImplemented)
     }
-    fn blame_file(&self, _repo_id: &RepoId, _path: &Path) -> AppResult<Vec<BlameLine>> {
+    fn blame_file(
+        &self,
+        _repo_id: &RepoId,
+        _path: &Path,
+        _ignore_revs: bool,
+    ) -> AppResult<BlameResult> {
+        Err(AppError::NotImplemented)
+    }
+    fn commit_notes(&self, _repo_id: &RepoId, _oid: &str) -> AppResult<Vec<CommitNote>> {
         Err(AppError::NotImplemented)
     }
 

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -16,8 +16,10 @@ use crate::opener::{resolved_workdir_path, safe_workdir_path};
 use super::{
     types::{
         AheadBehind, BisectMark, BisectStatus,
-        BlameLine, BranchInfo, CommitInfo, CommitOptions, CommitResult, ConflictSides,
-        BulkFastForward, DeleteFailure, DiffHunk,
+        BlameLine, BlameResult, BranchInfo, CommitInfo, CommitNote, CommitOptions, CommitResult,
+        ConflictSides,
+        DeleteFailure, DiffHunk,
+        BulkFastForward,
         DiffKind,
         DiffLine, DiffLineKind, FastForward, FileContent, FileDiff, FileStatus, HeadInfo, LfsStatus,
         LogFilter, LogPage,
@@ -116,6 +118,73 @@ impl Libgit2Backend {
             .lock()
             .map_err(|e| AppError::Internal(e.to_string()))?;
         f(&mut repo)
+    }
+
+    /// The in-process blame: libgit2, HEAD, no subprocess.
+    ///
+    /// This is what a repository with no `blame.ignoreRevsFile` gets, and what
+    /// a repository whose ignore-revs file is broken falls back to — so a
+    /// misconfigured file costs a warning, never the screen. libgit2 has no
+    /// ignore-revs support of any kind, which is the whole reason
+    /// `git/blame.rs` exists.
+    fn blame_with_libgit2(&self, repo_id: &RepoId, path: &Path) -> AppResult<Vec<BlameLine>> {
+        self.with_repo(repo_id, |repo| {
+            let mut opts = git2::BlameOptions::new();
+            let blame = repo.blame_file(path, Some(&mut opts))?;
+
+            let workdir = repo
+                .workdir()
+                .ok_or_else(|| AppError::Git("bare repo has no worktree".into()))?;
+            let content = std::fs::read_to_string(workdir.join(path))?;
+            let content_lines: Vec<&str> = content.lines().collect();
+
+            let mut out = Vec::new();
+            for hunk in blame.iter() {
+                let oid = hunk.final_commit_id();
+                let commit = repo.find_commit(oid).ok();
+                let author = commit
+                    .as_ref()
+                    .map(|c| c.author().name().unwrap_or("").to_string())
+                    .unwrap_or_default();
+                let email = commit
+                    .as_ref()
+                    .map(|c| c.author().email().unwrap_or("").to_string())
+                    .unwrap_or_default();
+                let timestamp = commit
+                    .as_ref()
+                    .map(|c| c.time().seconds())
+                    .unwrap_or(0);
+                let summary = commit
+                    .as_ref()
+                    .and_then(|c| c.summary().map(String::from))
+                    .unwrap_or_default();
+                let short = oid.to_string()[..7].to_string();
+                let start = hunk.final_start_line();
+                for i in 0..hunk.lines_in_hunk() {
+                    let line_no = (start + i) as u32;
+                    let content_str = content_lines
+                        .get((line_no - 1) as usize)
+                        .copied()
+                        .unwrap_or("")
+                        .to_string();
+                    out.push(BlameLine {
+                        line_no,
+                        oid: oid.to_string(),
+                        short_oid: short.clone(),
+                        author: author.clone(),
+                        email: email.clone(),
+                        timestamp,
+                        summary: summary.clone(),
+                        content: content_str,
+                        // libgit2 ignores nothing, so it can mark nothing.
+                        ignored: false,
+                        unblamable: false,
+                    });
+                }
+            }
+            out.sort_by_key(|l| l.line_no);
+            Ok(out)
+        })
     }
 
     /// Drop the entry at `index`, but only if it is still the one the caller
@@ -5696,63 +5765,89 @@ impl GitBackend for Libgit2Backend {
         })
     }
 
-    fn blame_file(&self, repo_id: &RepoId, path: &Path) -> AppResult<Vec<BlameLine>> {
-        self.with_repo(repo_id, |repo| {
+    /// See the trait docs and `git/blame.rs`: libgit2 in the common case, real
+    /// git the moment the repository configures an ignore-revs file.
+    fn blame_file(
+        &self,
+        repo_id: &RepoId,
+        path: &Path,
+        ignore_revs: bool,
+    ) -> AppResult<BlameResult> {
+        let settings = self.with_repo(repo_id, |repo| {
             // Without this libgit2 answers with a cryptic
             // "path 'vendor' does not exist in the given tree".
             reject_embedded_repo(repo, path)?;
-            let mut opts = git2::BlameOptions::new();
-            let blame = repo.blame_file(path, Some(&mut opts))?;
+            Ok(crate::git::blame::read_settings(repo))
+        })?;
 
-            let workdir = repo
-                .workdir()
-                .ok_or_else(|| AppError::Git("bare repo has no worktree".into()))?;
-            let content = std::fs::read_to_string(workdir.join(path))?;
-            let content_lines: Vec<&str> = content.lines().collect();
+        let mut result = BlameResult {
+            lines: Vec::new(),
+            ignore_revs_file: settings.ignore_revs_file.clone(),
+            ignore_revs_applied: false,
+            mark_ignored_lines: settings.mark_ignored_lines,
+            mark_unblamable_lines: settings.mark_unblamable_lines,
+            ignore_revs_error: None,
+        };
 
-            let mut out = Vec::new();
-            for hunk in blame.iter() {
-                let oid = hunk.final_commit_id();
-                let commit = repo.find_commit(oid).ok();
-                let author = commit
-                    .as_ref()
-                    .map(|c| c.author().name().unwrap_or("").to_string())
-                    .unwrap_or_default();
-                let email = commit
-                    .as_ref()
-                    .map(|c| c.author().email().unwrap_or("").to_string())
-                    .unwrap_or_default();
-                let timestamp = commit
-                    .as_ref()
-                    .map(|c| c.time().seconds())
-                    .unwrap_or(0);
-                let summary = commit
-                    .as_ref()
-                    .and_then(|c| c.summary().map(String::from))
-                    .unwrap_or_default();
-                let short = oid.to_string()[..7].to_string();
-                let start = hunk.final_start_line();
-                for i in 0..hunk.lines_in_hunk() {
-                    let line_no = (start + i) as u32;
-                    let content_str = content_lines
-                        .get((line_no - 1) as usize)
-                        .copied()
-                        .unwrap_or("")
-                        .to_string();
-                    out.push(BlameLine {
-                        line_no,
-                        oid: oid.to_string(),
-                        short_oid: short.clone(),
-                        author: author.clone(),
-                        email: email.clone(),
-                        timestamp,
-                        summary: summary.clone(),
-                        content: content_str,
-                    });
-                }
+        // No ignore-revs file: nothing to ignore, nothing to shell out for.
+        // This is the overwhelmingly common case and it must stay in-process.
+        let Some(raw) = settings.ignore_revs_file.as_deref() else {
+            result.lines = self.blame_with_libgit2(repo_id, path)?;
+            return Ok(result);
+        };
+
+        let workdir = self.repo_path(repo_id)?;
+        let resolved = crate::git::blame::resolve_ignore_revs_path(
+            &workdir,
+            crate::git::blame::home_dir().as_deref(),
+            raw,
+        );
+        if !resolved.is_file() {
+            // `git blame` DIES here ("could not open object name list"), and a
+            // missing file is an ordinary state — a config that arrived through
+            // an include, a template, or a branch where the file does not exist
+            // yet. Losing the whole Blame screen over it would be absurd, so
+            // this degrades to the plain blame with the reason attached.
+            result.ignore_revs_error = Some(format!(
+                "blame.ignoreRevsFile points at {raw}, which is not a readable file —                  ignoring it and blaming normally"
+            ));
+            result.lines = self.blame_with_libgit2(repo_id, path)?;
+            return Ok(result);
+        }
+
+        let mut args: Vec<String> = crate::git::blame::blame_args(ignore_revs)
+            .into_iter()
+            .map(String::from)
+            .collect();
+        // The one user-supplied value in this argv, and it goes after `--`.
+        args.push(path.to_string_lossy().to_string());
+
+        match run_git_capture(&workdir, &args) {
+            Ok(stdout) => {
+                result.lines = crate::git::blame::parse_porcelain(&stdout);
+                result.ignore_revs_applied = ignore_revs;
+                Ok(result)
             }
-            out.sort_by_key(|l| l.line_no);
-            Ok(out)
+            Err(detail) => {
+                // git refuses the whole run for a malformed ignore list or an
+                // object name it cannot peel to a commit. Same contract as the
+                // missing file: a warning beside a working blame.
+                result.ignore_revs_error = Some(detail);
+                result.lines = self.blame_with_libgit2(repo_id, path)?;
+                Ok(result)
+            }
+        }
+    }
+
+    fn commit_notes(&self, repo_id: &RepoId, oid: &str) -> AppResult<Vec<CommitNote>> {
+        self.with_repo(repo_id, |repo| {
+            let id = repo
+                .revparse_single(oid)
+                .map_err(|_| AppError::InvalidRef(oid.to_string()))?
+                .peel_to_commit()
+                .map_err(|_| AppError::InvalidRef(oid.to_string()))?
+                .id();
+            crate::git::notes::read(repo, id)
         })
     }
 

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -1,9 +1,11 @@
 pub mod auth;
 pub mod bisect;
+pub mod blame;
 pub mod cli;
 pub mod hooks;
 pub mod libgit2;
 pub mod lfs;
+pub mod notes;
 pub mod ownership;
 pub mod rebase_plan;
 pub mod rebase_state;
@@ -20,8 +22,9 @@ use std::path::{Path, PathBuf};
 use crate::error::AppResult;
 use types::{
     AheadBehind,
-    BisectMark, BisectStatus, BlameLine, BranchInfo, CommitInfo, CommitOptions, CommitResult, ConflictSides,
-    BulkFastForward, DeleteFailure, DiffKind, FastForward, FileContent,
+    BisectMark, BisectStatus, BlameResult, BranchInfo, CommitInfo, CommitNote, CommitOptions, CommitResult, ConflictSides,
+    DeleteFailure, DiffKind, FileContent,
+    BulkFastForward, FastForward,
     FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage, RebaseStatus, RebaseStep, ReflogEntry,
     RemoteInfo,
     RepoHandle,
@@ -172,7 +175,31 @@ pub trait GitBackend: Send + Sync {
         path: &Path,
         limit: usize,
     ) -> AppResult<Vec<CommitInfo>>;
-    fn blame_file(&self, repo_id: &RepoId, path: &Path) -> AppResult<Vec<BlameLine>>;
+    /// Blame `path` as of HEAD (#253).
+    ///
+    /// `ignore_revs` selects between the two views a repository with a
+    /// `blame.ignoreRevsFile` has: git's own behaviour (`true` — the listed
+    /// revisions are passed through to whoever last really touched the line)
+    /// and the un-ignored truth (`false`). It is meaningless, and ignored,
+    /// when no ignore-revs file is configured; `BlameResult::ignore_revs_file`
+    /// is what tells a caller whether the toggle is worth offering.
+    ///
+    /// A configured file that cannot be used is a WARNING carried on the
+    /// result, never an error: the blame beside it is still correct.
+    fn blame_file(
+        &self,
+        repo_id: &RepoId,
+        path: &Path,
+        ignore_revs: bool,
+    ) -> AppResult<BlameResult>;
+    /// Every `refs/notes/*` note attached to ONE commit (#253). Read-only.
+    ///
+    /// Deliberately per-commit and called lazily for the SELECTED commit, the
+    /// same shape `verify_commit` has and for the same reason: the log walk is
+    /// the hot path, and a notes lookup per walked row would put a fanout-tree
+    /// descent on every page fetch for a feature most repositories never use.
+    /// No note is `Ok(vec![])`, at every level of absence.
+    fn commit_notes(&self, repo_id: &RepoId, oid: &str) -> AppResult<Vec<CommitNote>>;
     fn read_reflog(&self, repo_id: &RepoId) -> AppResult<Vec<ReflogEntry>>;
     /// Signature status of ONE commit (#61 D6).
     ///

--- a/src-tauri/src/git/notes.rs
+++ b/src-tauri/src/git/notes.rs
@@ -1,0 +1,138 @@
+//! Reading `refs/notes/*` — the commit metadata the history never showed (#253).
+//!
+//! # Read-only, on purpose
+//!
+//! Writing a note is a different feature: it needs a ref to pick, a merge
+//! strategy for the notes tree, and a push story of its own. Nothing here
+//! mutates.
+//!
+//! # Which refs are shown, and why not `notes.displayRef`
+//!
+//! git decides what `git log` displays from `core.notesRef` plus the
+//! (multi-valued, glob-capable) `notes.displayRef`. We deliberately do not
+//! consult either: **every** `refs/notes/*` ref is read, and each note is
+//! labelled with the ref it came from.
+//!
+//! The asymmetry decides it. Showing a note the display config would have
+//! hidden costs a labelled extra block in a panel — the ref name is on screen,
+//! so nothing is ambiguous. Hiding a note somebody deliberately attached, in a
+//! GUI with no "show all notes" affordance, is a fact the user cannot discover
+//! at all. A read-only viewer should err towards showing.
+//!
+//! # Cost
+//!
+//! Every function here is called for ONE commit — the one selected in the
+//! detail panel — never during the log walk. See `GitBackend::commit_notes`.
+
+use git2::{Oid, Repository};
+
+use crate::error::AppResult;
+use crate::git::types::CommitNote;
+
+/// git's own default notes ref, and the one that sorts first.
+pub const DEFAULT_NOTES_REF: &str = "refs/notes/commits";
+
+const PREFIX: &str = "refs/notes/";
+
+/// The part of a notes ref worth putting on a badge: `refs/notes/ci/results`
+/// → `ci/results`. PURE.
+pub fn label_for(ref_name: &str) -> &str {
+    ref_name.strip_prefix(PREFIX).unwrap_or(ref_name)
+}
+
+/// Is this a notes ref with something after the prefix? PURE.
+///
+/// `refs/notes` itself is not one — a ref of that exact name would produce an
+/// empty label and a note nobody can name.
+pub fn is_notes_ref(ref_name: &str) -> bool {
+    ref_name.len() > PREFIX.len() && ref_name.starts_with(PREFIX)
+}
+
+/// Default ref first, everything else alphabetical. PURE.
+pub fn sort_refs(refs: &mut [String]) {
+    refs.sort_by(|a, b| {
+        (a != DEFAULT_NOTES_REF, a.as_str()).cmp(&(b != DEFAULT_NOTES_REF, b.as_str()))
+    });
+}
+
+/// Every `refs/notes/*` in the repository, sorted by [`sort_refs`].
+///
+/// Broken individual refs are skipped rather than failing the walk: one
+/// unreadable ref must not cost the user the notes on all the others.
+pub fn notes_refs(repo: &Repository) -> AppResult<Vec<String>> {
+    let mut out: Vec<String> = repo
+        .references()?
+        .flatten()
+        .filter_map(|r| r.name().map(str::to_string))
+        .filter(|name| is_notes_ref(name))
+        .collect();
+    sort_refs(&mut out);
+    Ok(out)
+}
+
+/// Every note attached to `oid`, one per notes ref that has one.
+///
+/// **Absence is a state, not an error**, at all three levels: no notes ref in
+/// the repository, no note for this commit on a ref that exists, and a note
+/// whose message is blank. All three answer with an empty vec, because a
+/// commit detail panel that raised a banner for "this commit has no notes"
+/// would raise one for nearly every commit in nearly every repository.
+pub fn read(repo: &Repository, oid: Oid) -> AppResult<Vec<CommitNote>> {
+    let mut out = Vec::new();
+    for ref_name in notes_refs(repo)? {
+        // `find_note` answers NotFound for a commit this ref has no note for,
+        // which is the overwhelmingly common case — not a failure.
+        let Ok(note) = repo.find_note(Some(&ref_name), oid) else {
+            continue;
+        };
+        let message = note.message().unwrap_or_default().trim_end().to_string();
+        if message.is_empty() {
+            continue;
+        }
+        out.push(CommitNote {
+            label: label_for(&ref_name).to_string(),
+            ref_name,
+            message,
+        });
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn labels_strip_the_ref_prefix_and_keep_the_rest_of_the_path() {
+        assert_eq!(label_for("refs/notes/commits"), "commits");
+        assert_eq!(label_for("refs/notes/ci/results"), "ci/results");
+        // Nothing else should ever reach here, but a label is better than a panic.
+        assert_eq!(label_for("refs/heads/main"), "refs/heads/main");
+    }
+
+    #[test]
+    fn only_refs_with_something_after_the_prefix_count() {
+        assert!(is_notes_ref("refs/notes/commits"));
+        assert!(!is_notes_ref("refs/notes/"));
+        assert!(!is_notes_ref("refs/notesy/x"));
+        assert!(!is_notes_ref("refs/heads/notes"));
+    }
+
+    #[test]
+    fn the_default_ref_sorts_first_and_the_rest_alphabetically() {
+        let mut refs = vec![
+            "refs/notes/review".to_string(),
+            "refs/notes/commits".to_string(),
+            "refs/notes/ci/results".to_string(),
+        ];
+        sort_refs(&mut refs);
+        assert_eq!(
+            refs,
+            vec![
+                "refs/notes/commits",
+                "refs/notes/ci/results",
+                "refs/notes/review"
+            ]
+        );
+    }
+}

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -520,6 +520,53 @@ pub struct BlameLine {
     pub timestamp: i64,
     pub summary: String,
     pub content: String,
+    /// git's `?` mark: the line was changed by an ignored revision and git
+    /// could only guess which earlier commit to hand it to (#253). Only ever
+    /// true when `blame.markIgnoredLines` is on — git gates the porcelain key
+    /// on the config, and so, faithfully, do we.
+    pub ignored: bool,
+    /// git's `*` mark: the ignored revision ADDED this line, so there is no
+    /// earlier commit to fall back to. Gated on `blame.markUnblamableLines`.
+    pub unblamable: bool,
+}
+
+/// One blame run's lines plus everything the UI needs to explain them (#253).
+///
+/// The three ignore-revs fields are what let the Blame screen offer a toggle
+/// only where one is meaningful, say which view is on screen, and report a
+/// broken configuration WITHOUT losing the blame itself — a repo whose
+/// `blame.ignoreRevsFile` points at a file that is not there still gets its
+/// lines, with a warning beside them.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlameResult {
+    pub lines: Vec<BlameLine>,
+    /// `blame.ignoreRevsFile` verbatim, or `None` when unset. `None` is what
+    /// tells the UI there is no toggle worth showing.
+    pub ignore_revs_file: Option<String>,
+    /// Whether THIS result actually had the ignore list applied. False when
+    /// the caller asked for the un-ignored view, and false when the file could
+    /// not be used — the two are told apart by `ignore_revs_error`.
+    pub ignore_revs_applied: bool,
+    /// `blame.markIgnoredLines` — see `BlameLine::ignored`.
+    pub mark_ignored_lines: bool,
+    /// `blame.markUnblamableLines` — see `BlameLine::unblamable`.
+    pub mark_unblamable_lines: bool,
+    /// Why a configured ignore-revs file was not applied. A STATE, not an
+    /// `AppError`: the blame beside it is perfectly good, and a repository
+    /// whose ignore-revs file is missing must not lose the whole screen.
+    pub ignore_revs_error: Option<String>,
+}
+
+/// One `git notes` entry attached to a commit (#253). Read-only.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitNote {
+    /// Full ref the note lives on, e.g. `refs/notes/commits`.
+    pub ref_name: String,
+    /// `ref_name` with `refs/notes/` stripped — what goes on the badge.
+    pub label: String,
+    pub message: String,
 }
 
 /// Content of the three index stages for a conflicted file.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -233,6 +233,7 @@ pub fn run() {
             commands::commits::commit,
             commands::commits::file_history,
             commands::commits::verify_commit,
+            commands::commits::commit_notes,
             commands::create::init_repo,
             commands::create::default_init_branch,
             commands::create::clone_repo,

--- a/src-tauri/tests/blame.rs
+++ b/src-tauri/tests/blame.rs
@@ -1,8 +1,51 @@
 mod support;
 
+use std::path::Path;
+
+use git2::Signature;
 use platypusgit_lib::git::GitBackend;
 use support::fs::write_file;
 use support::TempRepo;
+
+/// Commit everything in the worktree as `who`, so a test can tell "the person
+/// who wrote the line" apart from "the person who ran the formatter".
+fn commit_as(tr: &TempRepo, who: &str, msg: &str) -> git2::Oid {
+    let repo = git2::Repository::open(tr.path()).unwrap();
+    let mut index = repo.index().unwrap();
+    index
+        .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+        .unwrap();
+    index.write().unwrap();
+    let tree_oid = index.write_tree().unwrap();
+    let tree = repo.find_tree(tree_oid).unwrap();
+    let sig = Signature::now(who, &format!("{who}@example.com")).unwrap();
+    let head = repo
+        .head()
+        .ok()
+        .and_then(|h| h.target())
+        .map(|o| repo.find_commit(o).unwrap());
+    let parents: Vec<&git2::Commit> = head.as_ref().map(|c| vec![c]).unwrap_or_default();
+    repo.commit(Some("HEAD"), &sig, &sig, msg, &tree, &parents)
+        .unwrap()
+}
+
+fn set_config(tr: &TempRepo, key: &str, value: &str) {
+    let repo = git2::Repository::open(tr.path()).unwrap();
+    repo.config().unwrap().set_str(key, value).unwrap();
+}
+
+/// A repo where `Formatter` reindented every line that `Author` wrote, with the
+/// formatting commit listed in `.git-blame-ignore-revs` (not yet configured).
+fn reformatted_repo() -> TempRepo {
+    let tr = TempRepo::fresh();
+    write_file(tr.path(), "src.txt", "alpha\nbeta\n");
+    commit_as(&tr, "Author", "write the lines");
+    write_file(tr.path(), "src.txt", "    alpha\n    beta\n");
+    let fmt = commit_as(&tr, "Formatter", "reindent everything");
+    write_file(tr.path(), ".git-blame-ignore-revs", &format!("{fmt}\n"));
+    commit_as(&tr, "Author", "record the formatting commit");
+    tr
+}
 
 #[test]
 fn blame_attributes_each_line_to_the_commit_that_last_changed_it() {
@@ -14,9 +57,10 @@ fn blame_attributes_each_line_to_the_commit_that_last_changed_it() {
     let commit2 = tr.commit_all("edit line 2");
     let initial = backend.log(&handle.id, None, 10).unwrap().last().unwrap().oid.clone();
 
-    let lines = backend
-        .blame_file(&handle.id, std::path::Path::new("README.md"))
+    let result = backend
+        .blame_file(&handle.id, Path::new("README.md"), true)
         .unwrap();
+    let lines = result.lines;
 
     assert_eq!(lines.len(), 2);
     assert_eq!(lines[0].line_no, 1);
@@ -24,4 +68,176 @@ fn blame_attributes_each_line_to_the_commit_that_last_changed_it() {
     assert_eq!(lines[1].line_no, 2);
     assert_eq!(lines[1].oid, commit2.to_string());
     assert_eq!(lines[1].content, "line-b-edited");
+
+    // No `blame.ignoreRevsFile` anywhere: nothing to ignore, nothing to offer.
+    assert_eq!(result.ignore_revs_file, None);
+    assert!(!result.ignore_revs_applied);
+    assert_eq!(result.ignore_revs_error, None);
+    assert!(lines.iter().all(|l| !l.ignored && !l.unblamable));
+}
+
+#[test]
+fn an_ignore_revs_file_attributes_the_line_to_the_original_author() {
+    let tr = reformatted_repo();
+    set_config(&tr, "blame.ignoreRevsFile", ".git-blame-ignore-revs");
+    let (backend, handle) = tr.open_with_backend();
+
+    let result = backend
+        .blame_file(&handle.id, Path::new("src.txt"), true)
+        .unwrap();
+
+    assert_eq!(
+        result.ignore_revs_file.as_deref(),
+        Some(".git-blame-ignore-revs")
+    );
+    assert!(result.ignore_revs_applied, "{result:?}");
+    assert_eq!(result.ignore_revs_error, None);
+    let authors: Vec<&str> = result.lines.iter().map(|l| l.author.as_str()).collect();
+    assert_eq!(
+        authors,
+        vec!["Author", "Author"],
+        "the formatter must not own the lines it only reindented"
+    );
+    // The content still comes from the blamed revision, not the pre-format one.
+    assert_eq!(result.lines[0].content, "    alpha");
+}
+
+#[test]
+fn the_un_ignored_view_gives_the_lines_back_to_the_formatting_commit() {
+    // The toggle's whole job: the same file, same engine, ignore-revs off.
+    let tr = reformatted_repo();
+    set_config(&tr, "blame.ignoreRevsFile", ".git-blame-ignore-revs");
+    let (backend, handle) = tr.open_with_backend();
+
+    let result = backend
+        .blame_file(&handle.id, Path::new("src.txt"), false)
+        .unwrap();
+
+    assert_eq!(
+        result.ignore_revs_file.as_deref(),
+        Some(".git-blame-ignore-revs"),
+        "the toggle must still know the file exists, or it cannot be turned back on"
+    );
+    assert!(!result.ignore_revs_applied);
+    let authors: Vec<&str> = result.lines.iter().map(|l| l.author.as_str()).collect();
+    assert_eq!(authors, vec!["Formatter", "Formatter"]);
+}
+
+#[test]
+fn a_configured_ignore_revs_file_that_does_not_exist_degrades_to_a_plain_blame() {
+    // `git blame` itself dies with "could not open object name list" here, and
+    // a missing file is the normal state of a fresh clone whose config came
+    // from an include or a shared template. Blame must still render.
+    let tr = reformatted_repo();
+    set_config(&tr, "blame.ignoreRevsFile", ".no-such-file");
+    let (backend, handle) = tr.open_with_backend();
+
+    let result = backend
+        .blame_file(&handle.id, Path::new("src.txt"), true)
+        .unwrap();
+
+    assert!(!result.lines.is_empty(), "blame still rendered");
+    assert!(!result.ignore_revs_applied);
+    let err = result.ignore_revs_error.expect("a reason was reported");
+    assert!(err.contains(".no-such-file"), "{err}");
+}
+
+#[test]
+fn an_unreadable_ignore_revs_file_degrades_rather_than_failing_blame() {
+    // Same contract one level down: the file exists, so we hand the run to git,
+    // and git refuses it (an object name that is not a commit). The result is a
+    // warning beside a working blame, never an error screen.
+    let tr = reformatted_repo();
+    write_file(tr.path(), ".git-blame-ignore-revs", "not-a-sha\n");
+    commit_as(&tr, "Author", "corrupt the ignore list");
+    set_config(&tr, "blame.ignoreRevsFile", ".git-blame-ignore-revs");
+    let (backend, handle) = tr.open_with_backend();
+
+    let result = backend
+        .blame_file(&handle.id, Path::new("src.txt"), true)
+        .unwrap();
+
+    assert!(!result.lines.is_empty(), "blame still rendered");
+    assert!(!result.ignore_revs_applied);
+    assert!(result.ignore_revs_error.is_some());
+}
+
+#[test]
+fn mark_ignored_lines_is_reflected_on_the_lines_it_marks() {
+    let tr = reformatted_repo();
+    set_config(&tr, "blame.ignoreRevsFile", ".git-blame-ignore-revs");
+    let (backend, handle) = tr.open_with_backend();
+
+    let unmarked = backend
+        .blame_file(&handle.id, Path::new("src.txt"), true)
+        .unwrap();
+    assert!(!unmarked.mark_ignored_lines);
+    assert!(
+        unmarked.lines.iter().all(|l| !l.ignored),
+        "git only marks when asked, and so do we"
+    );
+
+    set_config(&tr, "blame.markIgnoredLines", "true");
+    let marked = backend
+        .blame_file(&handle.id, Path::new("src.txt"), true)
+        .unwrap();
+
+    assert!(marked.mark_ignored_lines);
+    assert!(
+        marked.lines.iter().any(|l| l.ignored),
+        "a line re-attributed past an ignored commit carries git's `?`: {:?}",
+        marked.lines
+    );
+}
+
+#[test]
+fn mark_unblamable_lines_is_reflected_too() {
+    // A line the ignored commit ADDED has no earlier commit to fall back to —
+    // git's `*`, a different verdict from `?` and worth keeping distinct.
+    let tr = TempRepo::fresh();
+    write_file(tr.path(), "src.txt", "alpha\n");
+    commit_as(&tr, "Author", "one line");
+    write_file(tr.path(), "src.txt", "alpha\nbrand new\n");
+    let fmt = commit_as(&tr, "Formatter", "add a line");
+    write_file(tr.path(), ".git-blame-ignore-revs", &format!("{fmt}\n"));
+    commit_as(&tr, "Author", "record it");
+    set_config(&tr, "blame.ignoreRevsFile", ".git-blame-ignore-revs");
+    set_config(&tr, "blame.markUnblamableLines", "true");
+
+    let (backend, handle) = tr.open_with_backend();
+    let result = backend
+        .blame_file(&handle.id, Path::new("src.txt"), true)
+        .unwrap();
+
+    assert!(result.mark_unblamable_lines);
+    assert!(
+        result.lines.iter().any(|l| l.unblamable),
+        "{:?}",
+        result.lines
+    );
+}
+
+#[test]
+fn the_shelled_out_blame_answers_the_same_question_as_the_libgit2_one() {
+    // Two engines, so they must be asked the same thing: the file as of HEAD,
+    // not the working tree. Otherwise a user with an uncommitted edit sees a
+    // different line COUNT depending on whether their repo has an ignore-revs
+    // file — and the toggle would appear to add and remove lines.
+    let tr = reformatted_repo();
+    let (backend, handle) = tr.open_with_backend();
+    let without_config = backend
+        .blame_file(&handle.id, Path::new("src.txt"), true)
+        .unwrap();
+
+    write_file(tr.path(), "src.txt", "    alpha\n    beta\n    uncommitted\n");
+    set_config(&tr, "blame.ignoreRevsFile", ".git-blame-ignore-revs");
+    let with_config = backend
+        .blame_file(&handle.id, Path::new("src.txt"), false)
+        .unwrap();
+
+    assert_eq!(
+        with_config.lines.len(),
+        without_config.lines.len(),
+        "both engines blame HEAD, so an uncommitted line is in neither"
+    );
 }

--- a/src-tauri/tests/embedded_repo.rs
+++ b/src-tauri/tests/embedded_repo.rs
@@ -235,7 +235,7 @@ fn blame_rejects_the_embedded_repo() {
     make_embedded_repo(&tr);
 
     for path in ["vendor/lib/", "vendor/lib"] {
-        let err = backend.blame_file(&handle.id, &PathBuf::from(path)).unwrap_err();
+        let err = backend.blame_file(&handle.id, &PathBuf::from(path), true).unwrap_err();
         assert!(matches!(err, AppError::EmbeddedRepo(p) if p == path));
     }
 }
@@ -265,7 +265,7 @@ fn guards_leave_ordinary_paths_alone() {
     assert!(backend
         .diff(&handle.id, &readme, DiffKind::WorktreeToHead, 3, false)
         .is_ok());
-    assert!(backend.blame_file(&handle.id, &readme).is_ok());
+    assert!(backend.blame_file(&handle.id, &readme, true).is_ok());
     assert_eq!(
         backend.file_history(&handle.id, &readme, 50).unwrap().len(),
         1

--- a/src-tauri/tests/notes.rs
+++ b/src-tauri/tests/notes.rs
@@ -1,0 +1,113 @@
+//! `git notes` are read-only history metadata the log never showed (#253).
+//!
+//! The behaviours pinned here are the ones a naive implementation gets wrong:
+//! absence is a STATE (empty vec) at three different levels — no notes ref in
+//! the repository at all, a notes ref with no note for this commit, and an
+//! empty note — and none of the three may surface as an error, because the
+//! commit detail panel would then show a banner for every commit in every repo
+//! that has never used notes (which is most of them).
+
+mod support;
+
+use git2::Signature;
+use platypusgit_lib::git::GitBackend;
+use support::TempRepo;
+
+/// Attach a note through git2 so the test does not depend on a `git` binary.
+fn attach_note(tr: &TempRepo, notes_ref: &str, oid: git2::Oid, message: &str) {
+    let repo = git2::Repository::open(tr.path()).unwrap();
+    let sig = Signature::now("Noter", "noter@example.com").unwrap();
+    repo.note(&sig, &sig, Some(notes_ref), oid, message, false)
+        .unwrap();
+}
+
+fn head_oid(tr: &TempRepo) -> git2::Oid {
+    git2::Repository::open(tr.path())
+        .unwrap()
+        .head()
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .id()
+}
+
+#[test]
+fn a_commit_with_a_note_returns_it() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let oid = head_oid(&tr);
+    attach_note(&tr, "refs/notes/commits", oid, "reviewed-by: ada\n");
+
+    let (backend, handle) = tr.open_with_backend();
+    let notes = backend.commit_notes(&handle.id, &oid.to_string()).unwrap();
+
+    assert_eq!(notes.len(), 1, "{notes:?}");
+    assert_eq!(notes[0].ref_name, "refs/notes/commits");
+    assert_eq!(notes[0].label, "commits");
+    assert_eq!(notes[0].message, "reviewed-by: ada");
+}
+
+#[test]
+fn a_commit_without_a_note_returns_nothing() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let noted = head_oid(&tr);
+    attach_note(&tr, "refs/notes/commits", noted, "on the first one only\n");
+    tr.add_commit("b.txt", "b\n", "second");
+    let unnoted = head_oid(&tr);
+
+    let (backend, handle) = tr.open_with_backend();
+    let notes = backend
+        .commit_notes(&handle.id, &unnoted.to_string())
+        .unwrap();
+
+    // The notes ref exists and has an entry — just not for this commit.
+    assert!(notes.is_empty(), "{notes:?}");
+}
+
+#[test]
+fn a_repo_with_no_notes_ref_at_all_is_not_an_error() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let oid = head_oid(&tr);
+
+    let (backend, handle) = tr.open_with_backend();
+    let notes = backend.commit_notes(&handle.id, &oid.to_string()).unwrap();
+
+    assert!(notes.is_empty(), "{notes:?}");
+}
+
+#[test]
+fn several_notes_refs_are_all_returned_with_the_default_first() {
+    // `refs/notes/commits` is git's default, but `notes.displayRef` and
+    // per-tool refs are real (`refs/notes/review`, CI results); showing only
+    // the default would hide them with no way to discover they exist.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let oid = head_oid(&tr);
+    attach_note(&tr, "refs/notes/review", oid, "looks good\n");
+    attach_note(&tr, "refs/notes/commits", oid, "the default ref\n");
+    attach_note(&tr, "refs/notes/ci/results", oid, "green\n");
+
+    let (backend, handle) = tr.open_with_backend();
+    let notes = backend.commit_notes(&handle.id, &oid.to_string()).unwrap();
+
+    let refs: Vec<&str> = notes.iter().map(|n| n.ref_name.as_str()).collect();
+    assert_eq!(
+        refs,
+        vec![
+            "refs/notes/commits",
+            "refs/notes/ci/results",
+            "refs/notes/review"
+        ],
+        "default ref first, then alphabetical"
+    );
+    let labels: Vec<&str> = notes.iter().map(|n| n.label.as_str()).collect();
+    assert_eq!(labels, vec!["commits", "ci/results", "review"]);
+}
+
+#[test]
+fn an_unresolvable_oid_is_an_error_not_an_empty_list() {
+    // Absence of a NOTE is a state; absence of the COMMIT is a bug in the
+    // caller, and reporting it as "no notes" would hide it forever.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    assert!(backend.commit_notes(&handle.id, "nonsense").is_err());
+}

--- a/src/features/commits/CommitNotes.test.tsx
+++ b/src/features/commits/CommitNotes.test.tsx
@@ -1,0 +1,90 @@
+// `git notes` in the commit detail panel (#253).
+//
+// The two behaviours that matter are opposites: a note must be visible with its
+// ref labelled (a note on `refs/notes/review` and one on `refs/notes/commits`
+// mean different things), and a commit with NO note must render nothing at all
+// — no heading, no empty box. Most commits in most repositories have no notes,
+// so an "empty notes" affordance would be permanent furniture.
+//
+// The third is a cost contract: notes are read for the SELECTED commit only,
+// and arrowing through the log must not fire one read per row passed over.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { CommitNotes } from "./CommitNotes";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import type { CommitNote } from "@/lib/types";
+
+const noteCalls = () => getInvokeCalls().filter((c) => c.cmd === "commit_notes");
+
+const NOTE: CommitNote = {
+  refName: "refs/notes/commits",
+  label: "commits",
+  message: "Reviewed-by: Ada\nCI: green",
+};
+
+beforeEach(() => {
+  resetInvokeMock();
+  vi.useRealTimers();
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "main" },
+  } as never);
+  mockInvoke("commit_notes", () => [NOTE]);
+});
+
+describe("CommitNotes", () => {
+  it("renders the note and the ref it came from", async () => {
+    render(<CommitNotes oid={"a".repeat(40)} />);
+
+    await waitFor(() => expect(screen.getByTestId("commit-notes")).toBeTruthy());
+    expect(screen.getByTestId("commit-notes").textContent).toContain(
+      "Reviewed-by: Ada",
+    );
+    expect(screen.getByTestId("commit-notes").textContent).toContain("commits");
+  });
+
+  it("labels each note with its own ref when several exist", async () => {
+    mockInvoke("commit_notes", () => [
+      NOTE,
+      { refName: "refs/notes/review", label: "review", message: "LGTM" },
+    ]);
+    render(<CommitNotes oid={"a".repeat(40)} />);
+
+    await waitFor(() => expect(screen.getByTestId("commit-notes")).toBeTruthy());
+    const text = screen.getByTestId("commit-notes").textContent ?? "";
+    expect(text).toContain("commits");
+    expect(text).toContain("review");
+    expect(text).toContain("LGTM");
+  });
+
+  it("renders nothing for a commit with no notes", async () => {
+    mockInvoke("commit_notes", () => []);
+    render(<CommitNotes oid={"b".repeat(40)} />);
+
+    await waitFor(() => expect(noteCalls()).toHaveLength(1));
+    expect(screen.queryByTestId("commit-notes")).toBeNull();
+  });
+
+  it("renders nothing when the read fails", async () => {
+    // A repository the backend refused to read notes from is still a
+    // perfectly viewable commit; a banner here would be noise.
+    mockInvoke("commit_notes", () => {
+      throw new Error("boom");
+    });
+    render(<CommitNotes oid={"c".repeat(40)} />);
+
+    await waitFor(() => expect(noteCalls()).toHaveLength(1));
+    expect(screen.queryByTestId("commit-notes")).toBeNull();
+  });
+
+  it("does not read notes for a commit that was only arrowed past", async () => {
+    const { rerender } = render(<CommitNotes oid={"1".repeat(40)} />);
+    rerender(<CommitNotes oid={"2".repeat(40)} />);
+    rerender(<CommitNotes oid={"3".repeat(40)} />);
+
+    await waitFor(() => expect(noteCalls()).toHaveLength(1));
+    expect(noteCalls()[0].args.oid).toBe("3".repeat(40));
+  });
+});

--- a/src/features/commits/CommitNotes.tsx
+++ b/src/features/commits/CommitNotes.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+
+import { PGBadge } from "@/design";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { commitNotes } from "@/lib/tauri";
+import type { CommitNote } from "@/lib/types";
+
+/**
+ * Settle time before reading notes, matching `SignatureBadge`'s.
+ *
+ * A notes read is a fanout-tree descent per notes ref, and arrowing through
+ * the log otherwise queues one per row passed over — all still behind
+ * `spawn_blocking` after the user has stopped moving.
+ */
+export const NOTES_DEBOUNCE_MS = 100;
+
+/**
+ * `git notes` attached to ONE commit (#253). Read-only.
+ *
+ * # Why this is not part of the log page
+ *
+ * The log is paged and its walk is the hot path: a notes lookup per walked
+ * commit would put a tree descent on every page fetch, for a feature most
+ * repositories never use. So notes are read lazily for the SELECTED commit
+ * only — the same shape `SignatureBadge` has, and for the same reason. The
+ * cost to the log page is exactly zero.
+ *
+ * # Absence renders nothing
+ *
+ * Most commits in most repositories have no notes. An "no notes" placeholder
+ * would be permanent furniture in the panel, so the component collapses to
+ * `null` — as it does when the read fails, which is not worth a banner beside
+ * a perfectly viewable commit.
+ */
+export function CommitNotes({ oid }: { oid: string }) {
+  const repoId = useRepoStore((s) => s.current?.id ?? null);
+  const [notes, setNotes] = React.useState<CommitNote[]>([]);
+
+  React.useEffect(() => {
+    if (!repoId || !oid) {
+      setNotes([]);
+      return;
+    }
+    let cancelled = false;
+    setNotes([]);
+    const handle = window.setTimeout(() => {
+      commitNotes(repoId, oid)
+        .then((n) => {
+          if (!cancelled) setNotes(n);
+        })
+        .catch(() => {
+          if (!cancelled) setNotes([]);
+        });
+    }, NOTES_DEBOUNCE_MS);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, [repoId, oid]);
+
+  if (notes.length === 0) return null;
+
+  return (
+    <div
+      data-testid="commit-notes"
+      style={{ marginBottom: 10, display: "flex", flexDirection: "column", gap: 6 }}
+    >
+      {notes.map((note) => (
+        <div
+          key={note.refName}
+          data-testid="commit-note"
+          data-note-ref={note.refName}
+          style={{
+            border: "1px solid var(--border-1)",
+            borderLeft: "2px solid var(--accent)",
+            borderRadius: "var(--r-2)",
+            background: "var(--bg-1)",
+            padding: "6px 8px",
+          }}
+        >
+          <div style={{ marginBottom: 4 }} title={note.refName}>
+            {/* The ref is load-bearing: a note on refs/notes/review and one on
+                refs/notes/commits are different claims about the commit. */}
+            <PGBadge tone="muted" icon="fileDoc">
+              {note.label}
+            </PGBadge>
+          </div>
+          <div
+            style={{
+              color: "var(--fg-1)",
+              fontSize: "var(--fs-12)",
+              fontFamily: "var(--font-mono)",
+              whiteSpace: "pre-wrap",
+              overflowWrap: "anywhere",
+              lineHeight: 1.5,
+            }}
+          >
+            {note.message}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -6,7 +6,7 @@ import type {
   AuthorOverride,
   BisectMark,
   BisectStatus,
-  BlameLine,
+  BlameResult,
   BranchInfo,
   BulkFastForward,
   CliInstallOutcome,
@@ -14,6 +14,7 @@ import type {
   DeleteFailure,
   CliShimStatus,
   CommitInfo,
+  CommitNote,
   CommitResult,
   ConflictSides,
   DiagnosticsReport,
@@ -1174,11 +1175,32 @@ export async function openInTerminal(
   return invoke<void>("open_in_terminal", { repoId, relativePath });
 }
 
+/**
+ * Blame one file as of HEAD (#253).
+ *
+ * `ignoreRevs` defaults to git's own behaviour — a configured
+ * `blame.ignoreRevsFile` is honoured. Pass `false` for the un-ignored truth
+ * behind the Blame screen's toggle.
+ */
 export async function blameFile(
   repoId: string,
   path: string,
-): Promise<BlameLine[]> {
-  return invoke<BlameLine[]>("blame_file", { repoId, path });
+  ignoreRevs = true,
+): Promise<BlameResult> {
+  return invoke<BlameResult>("blame_file", { repoId, path, ignoreRevs });
+}
+
+/**
+ * Every `refs/notes/*` note on ONE commit (#253).
+ *
+ * Called lazily for the SELECTED commit only — never per log row. No note is
+ * an empty array, at every level of absence.
+ */
+export async function commitNotes(
+  repoId: string,
+  oid: string,
+): Promise<CommitNote[]> {
+  return invoke<CommitNote[]>("commit_notes", { repoId, oid });
 }
 
 export async function takeLaunchIntent(): Promise<LaunchIntent | null> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -459,6 +459,41 @@ export interface BlameLine {
   timestamp: number;
   summary: string;
   content: string;
+  /**
+   * git's `?` mark — the line was changed by an ignored revision and git could
+   * only guess which earlier commit to hand it to (#253). Only ever true when
+   * `blame.markIgnoredLines` is on, because git gates the porcelain key on it.
+   */
+  ignored: boolean;
+  /** git's `*` mark — the ignored revision ADDED the line, so nothing earlier
+   * can own it. Gated on `blame.markUnblamableLines`. */
+  unblamable: boolean;
+}
+
+/**
+ * One blame run plus what the screen needs to explain it (#253).
+ *
+ * `ignoreRevsFile === null` means the repository configured none, which is
+ * what tells the Blame screen there is no toggle worth showing.
+ * `ignoreRevsError` is a WARNING, never a failure: the lines beside it are
+ * still a correct blame.
+ */
+export interface BlameResult {
+  lines: BlameLine[];
+  ignoreRevsFile: string | null;
+  ignoreRevsApplied: boolean;
+  markIgnoredLines: boolean;
+  markUnblamableLines: boolean;
+  ignoreRevsError: string | null;
+}
+
+/** One `git notes` entry attached to a commit (#253). Read-only. */
+export interface CommitNote {
+  /** Full ref the note lives on, e.g. `refs/notes/commits`. */
+  refName: string;
+  /** `refName` with `refs/notes/` stripped — what goes on the badge. */
+  label: string;
+  message: string;
 }
 
 /** CLI launch request (pgit [subcommand] [path]) — mirrors Rust cli::LaunchIntent. */

--- a/src/screens/Blame.ignoreRevs.test.tsx
+++ b/src/screens/Blame.ignoreRevs.test.tsx
@@ -1,0 +1,160 @@
+// `blame.ignoreRevsFile` on the Blame screen (#253).
+//
+// Blame that names whoever ran the formatter is worse than no blame: the answer
+// looks authoritative and is wrong. `.git-blame-ignore-revs` is git's fix, so
+// the screen honours it by default — and offers a toggle, because "who really
+// touched this line" and "which commit rewrote this line" are both real
+// questions and only the repository knows which one you are asking.
+//
+// The toggle only exists where an ignore-revs file does, so a repository
+// without one gains no chrome it cannot use.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { BlameScreen } from "./Blame";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import type { BlameLine, BlameResult } from "@/lib/types";
+
+const line = (over: Partial<BlameLine>): BlameLine => ({
+  lineNo: 1,
+  oid: "1".repeat(40),
+  shortOid: "1111111",
+  author: "Author",
+  email: "author@example.com",
+  timestamp: 1_700_000_000,
+  summary: "write the lines",
+  content: "    alpha",
+  ignored: false,
+  unblamable: false,
+  ...over,
+});
+
+const result = (over: Partial<BlameResult>): BlameResult => ({
+  lines: [line({})],
+  ignoreRevsFile: null,
+  ignoreRevsApplied: false,
+  markIgnoredLines: false,
+  markUnblamableLines: false,
+  ignoreRevsError: null,
+  ...over,
+});
+
+const IGNORED = result({
+  lines: [line({ author: "Author" })],
+  ignoreRevsFile: ".git-blame-ignore-revs",
+  ignoreRevsApplied: true,
+});
+
+const UNIGNORED = result({
+  lines: [
+    line({
+      author: "Formatter",
+      oid: "2".repeat(40),
+      shortOid: "2222222",
+      summary: "reindent everything",
+    }),
+  ],
+  ignoreRevsFile: ".git-blame-ignore-revs",
+  ignoreRevsApplied: false,
+});
+
+const blameCalls = () => getInvokeCalls().filter((c) => c.cmd === "blame_file");
+
+beforeEach(() => {
+  resetInvokeMock();
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+  } as never);
+  useNavStore.setState({ intent: { kind: "blame", path: "src.txt" } });
+});
+
+describe("Blame with an ignore-revs file", () => {
+  it("asks for the ignored view first and shows the original author", async () => {
+    mockInvoke("blame_file", () => IGNORED);
+    render(<BlameScreen />);
+
+    await waitFor(() => expect(blameCalls()).toHaveLength(1));
+    expect(blameCalls()[0].args.ignoreRevs).toBe(true);
+    await waitFor(() =>
+      expect(screen.getByTestId("blame-content").textContent).toContain("Author"),
+    );
+  });
+
+  it("switches to the un-ignored view and back", async () => {
+    mockInvoke("blame_file", (args) =>
+      args.ignoreRevs === false ? UNIGNORED : IGNORED,
+    );
+    render(<BlameScreen />);
+
+    const toggle = await screen.findByTestId("blame-ignore-revs-toggle");
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(blameCalls()).toHaveLength(2));
+    expect(blameCalls()[1].args.ignoreRevs).toBe(false);
+    await waitFor(() =>
+      expect(screen.getByTestId("blame-content").textContent).toContain(
+        "Formatter",
+      ),
+    );
+
+    fireEvent.click(screen.getByTestId("blame-ignore-revs-toggle"));
+    await waitFor(() => expect(blameCalls()).toHaveLength(3));
+    expect(blameCalls()[2].args.ignoreRevs).toBe(true);
+    await waitFor(() =>
+      expect(screen.getByTestId("blame-content").textContent).toContain("Author"),
+    );
+  });
+
+  it("offers no toggle when the repository configures no ignore-revs file", async () => {
+    mockInvoke("blame_file", () => result({}));
+    render(<BlameScreen />);
+
+    await waitFor(() => expect(blameCalls()).toHaveLength(1));
+    expect(screen.queryByTestId("blame-ignore-revs-toggle")).toBeNull();
+  });
+
+  it("marks the lines git marked, only when markIgnoredLines is on", async () => {
+    mockInvoke("blame_file", () =>
+      result({
+        lines: [line({ ignored: true }), line({ lineNo: 2, unblamable: true })],
+        ignoreRevsFile: ".git-blame-ignore-revs",
+        ignoreRevsApplied: true,
+        markIgnoredLines: true,
+        markUnblamableLines: true,
+      }),
+    );
+    render(<BlameScreen />);
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId("blame-line").length).toBe(2),
+    );
+    const rows = screen.getAllByTestId("blame-line");
+    expect(rows[0].textContent).toContain("?");
+    expect(rows[1].textContent).toContain("*");
+  });
+
+  it("warns about an unusable ignore-revs file without losing the blame", async () => {
+    // The backend degraded to a plain blame and said why. Losing the screen
+    // over a config line would be absurd, so the lines must still be there.
+    mockInvoke("blame_file", () =>
+      result({
+        ignoreRevsFile: ".no-such-file",
+        ignoreRevsApplied: false,
+        ignoreRevsError:
+          "blame.ignoreRevsFile points at .no-such-file, which is not a readable file",
+      }),
+    );
+    render(<BlameScreen />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("blame-ignore-revs-warning")).toBeTruthy(),
+    );
+    expect(screen.getByTestId("blame-ignore-revs-warning").textContent).toContain(
+      ".no-such-file",
+    );
+    expect(screen.getAllByTestId("blame-line").length).toBe(1);
+  });
+});

--- a/src/screens/Blame.tsx
+++ b/src/screens/Blame.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { PGEmpty, PGSpinner } from "@/design";
+import { PGEmpty, PGSpinner, PGToggle } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { blameFile } from "@/lib/tauri";
@@ -8,7 +8,7 @@ import { DeepViewHeader } from "@/features/nav/DeepViewHeader";
 import { PGPane, FocusableScroll } from "@/features/keymap";
 import { useSyntax, type SyntaxToken } from "@/lib/syntax";
 import { buildLineSpans } from "@/lib/lineSpans";
-import type { BlameLine } from "@/lib/types";
+import type { BlameLine, BlameResult } from "@/lib/types";
 
 /**
  * One blame line's text, highlighted when tokens for it have arrived. Bare
@@ -27,15 +27,38 @@ function BlameText({ text, syntax }: { text: string; syntax?: SyntaxToken[] }) {
   );
 }
 
+/**
+ * git's own marks for a line an ignored revision touched: `?` when the
+ * attribution beside it is a guess, `*` when nothing earlier can own the line
+ * at all. Empty unless the repository asked for them
+ * (`blame.markIgnoredLines` / `blame.markUnblamableLines`) — git only marks
+ * when asked, and a mark nobody configured would read as a defect in the line.
+ */
+function markFor(l: BlameLine): string {
+  if (l.unblamable) return "*";
+  if (l.ignored) return "?";
+  return " ";
+}
+
 export function BlameScreen() {
   const repo = useRepoStore((s) => s.current);
   const intent = useNavStore((s) => s.intent);
   const clearIntent = useNavStore((s) => s.clearIntent);
 
   const [path, setPath] = React.useState<string | null>(null);
-  const [lines, setLines] = React.useState<BlameLine[]>([]);
+  const [result, setResult] = React.useState<BlameResult | null>(null);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+  /**
+   * Honour `blame.ignoreRevsFile` — git's own default — until the user says
+   * otherwise.
+   *
+   * Deliberately NOT a persisted setting. The right default is git's behaviour
+   * every time you open a file; a remembered "off" would silently contradict
+   * the repository's own `.git-blame-ignore-revs` in some later session, with
+   * nothing on screen explaining why the formatter owns every line.
+   */
+  const [ignoreRevs, setIgnoreRevs] = React.useState(true);
 
   React.useEffect(() => {
     if (intent?.kind === "blame") {
@@ -49,12 +72,14 @@ export function BlameScreen() {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    blameFile(repo.id, path)
-      .then((l) => { if (!cancelled) setLines(l); })
+    blameFile(repo.id, path, ignoreRevs)
+      .then((r) => { if (!cancelled) setResult(r); })
       .catch((e) => { if (!cancelled) setError(appErrorMessage(e)); })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, [repo?.id, path]);
+  }, [repo?.id, path, ignoreRevs]);
+
+  const lines = result?.lines ?? [];
 
   // Blame already holds the whole file, so the tokens come from joining it back
   // up rather than a second read. Memoized: a new string identity on every
@@ -76,22 +101,78 @@ export function BlameScreen() {
     );
   }
 
+  const marked = result?.markIgnoredLines || result?.markUnblamableLines;
+
   return (
     <PGPane id="blame.content" style={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
       <DeepViewHeader crumbs={[`Blame — ${path}`]} />
+      {/* The toggle exists only where an ignore-revs file does: a repository
+          without one would gain a control that changes nothing. */}
+      {result?.ignoreRevsFile && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            padding: "6px 12px",
+            borderBottom: "1px solid var(--border-0)",
+            flexShrink: 0,
+          }}
+        >
+          <PGToggle
+            testId="blame-ignore-revs-toggle"
+            checked={ignoreRevs}
+            onChange={setIgnoreRevs}
+            label={`Ignore revisions in ${result.ignoreRevsFile}`}
+          />
+          <span style={{ color: "var(--fg-3)", fontSize: "var(--fs-11)" }}>
+            {ignoreRevs
+              ? "lines a listed revision only reformatted are blamed on whoever wrote them"
+              : "showing the raw blame — listed revisions own their lines"}
+          </span>
+        </div>
+      )}
+      {result?.ignoreRevsError && (
+        <div
+          data-testid="blame-ignore-revs-warning"
+          style={{
+            padding: "6px 12px",
+            color: "var(--git-modified)",
+            fontSize: "var(--fs-11)",
+            borderBottom: "1px solid var(--border-0)",
+            flexShrink: 0,
+          }}
+        >
+          {result.ignoreRevsError}
+        </div>
+      )}
       {loading && <div style={{ padding: 12 }}><PGSpinner /></div>}
       {error && <div style={{ padding: 12, color: "var(--git-removed)" }}>{error}</div>}
-      <FocusableScroll style={{
+      <FocusableScroll testId="blame-content" style={{
         flex: 1,
         fontFamily: "var(--font-mono)", fontSize: "var(--fs-12)",
       }}>
         {lines.map((l, i) => (
-          <div key={l.lineNo} style={{
+          <div key={l.lineNo} data-testid="blame-line" style={{
             display: "flex",
             gap: 12,
             padding: "0 12px",
             whiteSpace: "pre",
           }}>
+            {marked && (
+              <span
+                title={
+                  l.unblamable
+                    ? "Added by an ignored revision — no earlier commit can own this line"
+                    : l.ignored
+                      ? "Changed by an ignored revision — this attribution is git's best guess"
+                      : undefined
+                }
+                style={{ width: 8, color: "var(--git-modified)" }}
+              >
+                {markFor(l)}
+              </span>
+            )}
             <span style={{ width: 56, color: "var(--fg-3)" }}>{l.shortOid}</span>
             <span style={{ width: 120, color: "var(--fg-3)", overflow: "hidden", textOverflow: "ellipsis" }}>
               {l.author}

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -36,6 +36,7 @@ import { headAncestryOf } from "@/features/commits/headAncestry";
 import { buildRebasePlan } from "@/features/commits/buildRebasePlan";
 import { combinedSquashMessage } from "@/features/commits/squashMessage";
 import { runRebasePlanNow } from "@/features/commits/runRebasePlan";
+import { CommitNotes } from "@/features/commits/CommitNotes";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { openCreateTag } from "@/features/tags/useCreateTagStore";
 import { useNavStore } from "@/features/nav/useNavStore";
@@ -897,6 +898,13 @@ export function HistoryScreen() {
           date={relativeTime(current.timestamp)}
           parents={current.parents.map(shortSha)}
         />
+        {/* Notes hang off the commit, not off the log page: read lazily for
+            THIS commit, so the paged walk costs nothing (#253). Inside the
+            message scroll region, so a long note scrolls with the body rather
+            than pushing the action row out of the panel. */}
+        <div style={{ padding: "0 12px 12px" }}>
+          <CommitNotes oid={current.oid} />
+        </div>
       </FocusableScroll>
       <CommitActionRow commit={current} />
     </>


### PR DESCRIPTION
## What does this PR do?

Two of the three gaps in #253, both "render what git already knows":

1. **`git notes`** in the commit detail panel (read-only).
2. **`blame.ignoreRevsFile`** + `blame.markIgnoredLines`, with a toggle.

**Part of #253** — markdown commit bodies (item 3) are deliberately **not** here: they need a new markdown dependency whose bundle size and sanitisation are a separate decision. The issue stays open for it.

## Notes: lazy per commit — the log page pays nothing

Read **lazily per selected commit**, debounced 100 ms — the same shape and rationale as the existing `verify_commit` / `SignatureBadge` pair.

Batching them onto the log page was the alternative and is worse: a note lookup is a fanout-tree descent **per notes ref**, and batching puts that work on **every** page fetch of the paged log, for a feature most repositories never use. Lazily, the log page pays nothing, and rows arrowed past cost nothing either.

Every `refs/notes/*` is shown, badged with its ref (default `refs/notes/commits` sorts first). `core.notesRef` / `notes.displayRef` are deliberately **not** consulted: showing a note the display config would hide costs one labelled block on screen; *hiding* one somebody attached is undiscoverable in a GUI with no "show all" affordance.

## Blame: shelled out, scoped so the blast radius is opt-in

libgit2 has **no** ignore-revs support — `git_blame_options` carries whitespace, first-parent and range flags and nothing that takes a revision list — so there is no in-process answer. The shell-out is scoped so it costs nothing where it isn't wanted:

- **No `blame.ignoreRevsFile` configured → the in-process libgit2 blame runs, byte-identical to before.** No subprocess, no parsing, no behaviour change for the common case. Blame is also a user-initiated deep view, never a hot path.
- Where a file **is** configured, **both** toggle states go through git — so the toggle compares like with like, instead of letting engine differences look like the toggle's effect.
- Parsing is `--line-porcelain`, the stable documented machine format, whose content lines are TAB-prefixed. That stays unambiguous even when blaming a file that itself contains blame output (there is a test for exactly that). The column-aligned default format is never parsed.
- The porcelain already carries `ignored` / `unblamable`, so `markIgnoredLines` needs no second run.

### The ignore-revs path never reaches argv

git reads `blame.ignoreRevsFile` from the repository's own config, so the **ignored** view passes no path at all. The **un-ignored** view passes the fixed literal `--ignore-revs-file=` — git's documented "clear the list", which also clears config-supplied entries.

```
git -C <workdir> blame --line-porcelain [--ignore-revs-file=] HEAD -- <path>
```

The only user-supplied value is the blamed path, after `--`. The resolved config path is used for exactly one thing: `is_file()`, to decide whether to hand the run to git. Spawned via `proc::git`; `tests/spawn_no_window.rs` passes.

**`HEAD` is passed explicitly** so both engines blame the committed file rather than the worktree — otherwise the line *count* would change with the presence of an ignore-revs file, and the toggle would appear to add or remove lines. Pinned by a test.

## Two smaller calls

- **A missing or malformed ignore-revs file degrades** to the libgit2 blame plus a warning strip, rather than erroring — git *dies* in both cases and `--ignore-revs-file=` cannot rescue it (config entries are parsed first). It's a state on `BlameResult`, not a new `AppError`, so the Rust↔TS union is untouched.
- **The toggle is view state, not a persisted setting.** git's own behaviour is the right default every time; a remembered "off" would silently contradict the repo's `.git-blame-ignore-revs` later with nothing explaining why. `PersistedState` and the export key-set snapshot are therefore untouched.

## Verification

Rebased onto `f3da08f`; the rebase conflicted with #291 (both added trait methods and import lists in `git/mod.rs`, `cli.rs`, `libgit2.rs`) and was resolved as a union, keeping #291's `FastForward`/`BulkFastForward` and this branch's `CommitNote`/`BlameResult` — with `BlameLine` correctly dropped where the trait signature changed to `BlameResult`.

- `pnpm tsc --noEmit` — exit 0
- `pnpm test` — **253 files, 2235 tests**
- `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — exit 0
- `cargo test` — **855 tests, 0 failed**
- **e2e** — `history-diff.e2e.ts` + `resizable-panes.e2e.ts`, **11 passing**. Run because `[data-testid="history-detail"]` now contains `CommitNotes` and both specs assert on it; it renders `null` where there are no notes, and this confirms it.

## Worth a look

- **The shell-out is the judgement call.** If you'd rather blame never spawn, the alternative is dropping ignore-revs support entirely — there is no in-process middle ground.
- **Engine split**: a repo *with* a configured file gets git blame in both states; one *without* gets libgit2. Subtle differences are possible across repos, never within one.
- Relative `blame.ignoreRevsFile` paths resolve from the worktree root (verified: git chdirs to the toplevel), `~` expanded, used only for the existence check.
- Notes badge uses `PGBadge tone="muted" icon="fileDoc"` — there is no note-shaped icon and I chose not to add one.

## Checklist

- [x] One logical change, focused PR
- [x] Rebased onto `main`, no merge commits, single squashed commit
- [x] Conventional Commits
- [x] `pnpm tsc --noEmit`, `pnpm test`, `cargo check`, `cargo test` all pass
- [x] e2e typecheck passes; **targeted e2e run green**
- [x] New git ops: trait + impl + `CliBackend` stubs + commands + `invoke_handler!` + TS types/wrappers
- [x] `docs/dev/architecture.md`, `backend.md`, `frontend.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
