### PR TITLE
feat(diff): preview changed images instead of a dead end

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -104,7 +104,9 @@ git/
 │                RebaseStep, RepoState, ConflictSides, CommitOptions,
 │                StashSaveOptions, TagTarget, ResetMode, SubmoduleInfo/State,
 │                WorktreeInfo/WorktreeBranch, LfsStatus/LfsFile/LfsPointer/
-│                LfsDiff, BisectStatus/BisectMark, etc.
+│                LfsDiff, BisectStatus/BisectMark, BlobSource/ImagePreview
+│                (#224 — which SIDE a preview reads, and the four answers:
+│                image / tooLarge / unsupported / lfsMissing), etc.
 ├── libgit2.rs   Libgit2Backend — active impl. merge_branch and rebase_onto
 │                shell out to real git, so a conflicted rebase is git's on-disk
 │                state; continue/abort_operation detect that
@@ -118,6 +120,13 @@ git/
 ├── lfs.rs       Pointer parsing + lfs_diff_of are PURE (a pointer fits in the
 │                diff's own lines). "Repo uses LFS" answered from .gitattributes
 │                via the INDEX — must work with the lfs binary missing
+├── image.rs     Image-preview sniffing (#224). PURE, table-tested: magic bytes
+│                → media type for PNG/JPEG/GIF/WebP/BMP/ICO, the size ceiling
+│                (MAX_PREVIEW_BYTES), and git-lfs's objects/aa/bb/<oid> fan-out.
+│                The EXTENSION never decides — a repository is untrusted input.
+│                SVG is recognised and REFUSED by name (script + remote refs,
+│                and the app ships no CSP behind the <img>); the module doc
+│                argues it
 ├── stash.rs     Repo-less stash helpers (#133): push/store argv builders
 │                (`--` placement, GIT_LITERAL_PATHSPECS), validate_message,
 │                rename_store_landed. Unit-tested with no temp repo
@@ -182,7 +191,12 @@ commands/        Thin Tauri handlers, one file per area:
 │                per-path failures), and THREE distinct file readers:
 │                read_file_content (working tree),
 │                read_file_content_at_rev + list_files_at_rev (a commit's tree),
-│                read_file_content_at_index (the STAGED blob)
+│                read_file_content_at_index (the STAGED blob) — plus a FOURTH
+│                reader that answers with BYTES, read_image_preview (#224:
+│                worktree / index / rev / conflict stage → base64 + the sniffed
+│                media type, so an <img> can be fed without guessing from the
+│                extension; the other three carry text, which is None for a
+│                binary blob by contract)
 ├── cli.rs       take_launch_intent, cli_shim_status, install_cli_shim
 ├── diagnostics.rs
 │                Reaching the app's own log from Settings (#274):
@@ -345,7 +359,11 @@ features/            Components + Zustand store colocated per feature:
 │                    useDiffGaps (+ useExpandedGaps, diffOpenReady),
 │                    WhitespaceToggle (+ useHunkActionsDisabledReason),
 │                    useDiffFind + DiffFindBar (find in diff — ONE hook for all
-│                    four surfaces; searches the row model, scrolls by offset)
+│                    four surfaces; searches the row model, scrolls by offset),
+│                    useImagePreviews + ImageDiffView (image previews — the same
+│                    ONE-component rule, for the complement of isTextualDiff:
+│                    old beside new with dimensions, bytes and both deltas, and
+│                    the honest empty state for everything that is not an image)
 ├── submodules/      useSubmodulesStore (persisted recursive toggle; update goes
 │                    through withAuthRetry)
 ├── worktrees/       useWorktreesStore + WorktreeAddDialog (store owns the

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -233,6 +233,55 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   does not match `README.md`, so one test over both trees would be skipped by
   exactly the change it polices. See `docs/dev/testing.md`.
 
+## Image previews: the only reader that returns BYTES (#224)
+
+- **`read_image_preview` is the fourth file reader**, and the only one that can
+  feed an `<img>`: `FileContent.text` is `None` for a binary blob *by contract*,
+  so `read_file_content`, `_at_rev` and `_at_index` structurally cannot. It
+  takes a `BlobSource` (`worktree` / `index` / `rev` / conflict `stage`) rather
+  than a nullable revspec — a sentinel meaning three things is how call sites
+  get it wrong — and answers `AppResult<Option<ImagePreview>>`.
+- **Bytes cross IPC as base64, in the ordinary JSON payload.** Tauri serialises
+  a `Vec<u8>` as a JSON array of decimal numbers, ~5 bytes on the wire per byte
+  of image, so raw bytes were never the cheap option. The alternatives were a
+  raw `tauri::ipc::Response` (cannot also carry the sniffed media type, and
+  steps outside the `AppResult<T>` contract) and a custom URI scheme (a protocol
+  registration, a scope and a CSP, for a payload the ceiling already bounds).
+  Base64 costs ~1.33x and lands as the exact string a `data:` URL wants, so the
+  frontend concatenates it into an `src` with no decode and no second copy.
+- **The extension never decides.** `git/image.rs::sniff` reads magic bytes only,
+  and every rule checks enough of the header to be a real answer — a truncated
+  `\x89PNG` is `NotAnImage`, `BM` needs its reserved field zero, an ICONDIR
+  needs a non-zero image count. A repository is untrusted input, and a broken
+  `<img>` is worse than a sentence.
+- **SVG is recognised and REFUSED**, as its own `UnsupportedReason::Svg` so the
+  UI can say so rather than looking broken. It is the one format on the list
+  that is not inert (script, `<foreignObject>`, external `href`/`url()`,
+  `@import`), and `tauri.conf.json` ships `"csp": null` — so there is nothing
+  behind whatever the engine's `<img>` secure-static-mode does, and one engine
+  bug or one refactor to inline SVG is script execution against unrestricted
+  IPC. Sanitizing XML with a text scan is not a boundary worth pretending to
+  have. The argument lives in `git/image.rs`'s module doc; change it there.
+- **The ceiling is applied to the DECLARED size** — `metadata().len()` for the
+  worktree, `Blob::size()` for a blob — so an oversized asset is never read,
+  never encoded and never crosses IPC. It comes back as `TooLarge` carrying the
+  size and the limit. Sniffing first and measuring after would defeat the point.
+- **The worktree source does NOT fall back to HEAD**, unlike `read_file_content`.
+  A preview *pair* asks for each side by name; the fallback would paint the old
+  image into the "new" slot and claim a delete changed nothing.
+- **An LFS pointer resolves to its object by PATH**, not by shelling out:
+  `image::lfs_object_path` builds git-lfs's own `objects/aa/bb/<oid>` fan-out
+  under `lfs.storage` (default `.git/lfs`). Asking the `git lfs` binary would
+  refuse a perfectly readable object on a machine where git-lfs is not
+  installed, and it would put a spawn on a preview path. The oid comes from a
+  pointer file in an untrusted repository, so the builder refuses anything that
+  is not plain lowercase hex. An object that is not there answers `LfsMissing`
+  — never the pointer's own three lines.
+- Absence stays a **state** on every source (`Ok(None)`), the #146 rule: an
+  added file has no old side. A bad revspec or an unknown repository still
+  errors. Pinned by `tests/image_preview.rs`; the sniffing table is unit-tested
+  in `git/image.rs` with no repository at all, the `reveal.rs` model.
+
 ## Signing: one chain for commits and tags (#61 D6, #132)
 
 - **One chain, two callers:** `libgit2.rs::sign_payload` =

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -54,6 +54,33 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   type back — silent truncation is worse than the overflow.
 - **Gate text rendering on `isTextualDiff(diff)`, not `!diff.binary`** (#93) —
   an LFS pointer is honestly text; the surfaces render `LfsDiffNotice` instead.
+- **The complement of `isTextualDiff` is not automatically a dead end** (#224).
+  When the binary is an IMAGE, all five diff surfaces render the shared
+  `ImageDiffView` (`features/diff/`) — old beside new, each with pixel
+  dimensions and byte size, plus the delta of both; an added or deleted file
+  shows the one side that exists; the merge resolver's binary chooser gets the
+  same pair above its two buttons, which is where it is worth the most.
+  * **One component, and it owns the empty state too.** `fallback` is a PROP,
+    because "is there anything to preview" is the question the component
+    answers. A PDF, a font, an archive — every binary #224 left out of scope —
+    keeps the exact sentence its surface printed before. A too-large blob, an
+    unfetched LFS object and an SVG say something more specific instead: a
+    silent nothing reads as a bug.
+  * **Sides come from `diffImageSides`**, built from the same `SideSource` pair
+    the surface already computes for `useDiffSyntax`, so the preview and the
+    coloured text can never disagree about which revision they show. A fifth
+    surface gets previews by passing the sides it already had. The merge chooser
+    is the exception and names index STAGES 2/3 — neither side is in any tree
+    while the merge is unresolved.
+  * **Nothing is fetched speculatively.** `useImagePreviews` is inert without a
+    path, and every surface mounts it only for the selected file. That is what
+    lets the backend's ceiling be as generous as it is.
+  * **Bytes arrive as base64 and go straight into a `data:` URL** — no decode on
+    this side, and a preview makes no request of any kind (#226). Dimensions
+    come from the `<img>`'s `naturalWidth/Height` on load, not from a decoder:
+    the webview already knows, and until it fires there simply are no
+    dimensions (never `0 × 0`). The backdrop is a checkerboard built from
+    `--bg-1`/`--bg-2` so transparency reads in both themes (#236).
 - **Diff CODE is selectable; diff CHROME is not.** `body` is `user-select: none`
   (native desktop feel), so each row's code cell opts back in with
   `.pg-selectable` (`index.css`) while the line-number cells and the `+`/`−`

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3221,6 +3221,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 name = "platypusgit"
 version = "0.0.0"
 dependencies = [
+ "base64 0.22.1",
  "git2",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,6 +49,11 @@ url = "2"
 semver = "1"
 # Content log search (#61 D10) compiles the user's pattern once per walk.
 regex = "1"
+# Image-preview blobs cross IPC as base64 inside the ordinary JSON payload
+# (#224) — a `Vec<u8>` serialises as a JSON array of numbers, which is ~5x
+# the bytes. Already in the tree transitively, so this declares it rather
+# than adding it.
+base64 = "0.22"
 
 # `setsid()` between fork and exec, for the detached `pgit` launch (#163) —
 # nothing in std reaches it (`Command::process_group` only makes a new process

--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -4,7 +4,10 @@ use tauri::State;
 
 use crate::{
     error::{AppError, AppResult},
-    git::types::{DeleteFailure, FileContent, FileStatus, HeadInfo, RepoHandle, RepoId},
+    git::types::{
+        BlobSource, DeleteFailure, FileContent, FileStatus, HeadInfo, ImagePreview, RepoHandle,
+        RepoId,
+    },
     state::AppState,
 };
 
@@ -176,6 +179,42 @@ pub async fn read_file_content_at_index(
     let repo_id = RepoId(repo_id);
     let path_buf = PathBuf::from(path);
     tokio::task::spawn_blocking(move || backend.read_file_content_at_index(&repo_id, &path_buf))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+/// Bytes of an image at `path` on one side, for the preview surfaces (#224).
+///
+/// The fourth file reader, and the only one that can answer with BYTES — the
+/// other three carry `FileContent.text`, which is `None` for a binary blob by
+/// contract, so none of them can feed an `<img>`.
+///
+/// **Why base64 in the ordinary JSON payload.** Tauri's IPC serialises a
+/// `Vec<u8>` as a JSON array of decimal numbers — roughly five bytes on the wire
+/// per byte of image — so raw bytes were never the cheap option they look like.
+/// The two alternatives were a raw `tauri::ipc::Response`, which cannot also
+/// carry the sniffed media type and steps outside the `AppResult<T>` contract
+/// every other command keeps, and a custom URI scheme, which would need a
+/// protocol registration, a scope and a CSP the app deliberately does not have —
+/// for bytes that are capped at a few MB anyway. Base64 costs ~1.33x, keeps the
+/// one error type crossing IPC, and lands as the exact string a `data:` URL
+/// wants, so the frontend concatenates it into an `src` with no decode.
+///
+/// The cap (`git::image::MAX_PREVIEW_BYTES`) is applied to the blob's DECLARED
+/// size inside the backend, so an oversized asset is never read, never encoded
+/// and never crosses IPC — it comes back as `TooLarge` instead. And nothing here
+/// runs speculatively: the frontend asks only for the file the user selected.
+#[tauri::command]
+pub async fn read_image_preview(
+    state: State<'_, AppState>,
+    repo_id: String,
+    source: BlobSource,
+    path: String,
+) -> AppResult<Option<ImagePreview>> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    let path_buf = PathBuf::from(path);
+    tokio::task::spawn_blocking(move || backend.read_image_preview(&repo_id, &source, &path_buf))
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
 }

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -8,6 +8,7 @@ use super::{
         DeleteFailure, DiffKind, FileContent,
         BulkFastForward, FastForward,
         FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage, RebaseStatus, RebaseStep, ReflogEntry,
+        BlobSource, ImagePreview,
         RemoteInfo, RepoHandle, RepoId, RepoState, ResetMode, StashInfo, StashSaveOptions,
         SubmoduleInfo, TagInfo,
         TagTarget, WorkdirDiff, WorktreeBranch, WorktreeInfo,
@@ -142,6 +143,14 @@ impl GitBackend for CliBackend {
         _repo_id: &RepoId,
         _path: &Path,
     ) -> AppResult<Option<FileContent>> {
+        Err(AppError::NotImplemented)
+    }
+    fn read_image_preview(
+        &self,
+        _repo_id: &RepoId,
+        _source: &BlobSource,
+        _path: &Path,
+    ) -> AppResult<Option<ImagePreview>> {
         Err(AppError::NotImplemented)
     }
     fn diff_commits(

--- a/src-tauri/src/git/image.rs
+++ b/src-tauri/src/git/image.rs
@@ -1,0 +1,390 @@
+//! Image previews for the diff surfaces (#224).
+//!
+//! Everything here is PURE — magic-byte sniffing and LFS object-path building,
+//! no repository, no filesystem, no spawn. Same reasoning as `reveal.rs`'s argv
+//! planners: the interesting decisions are table-testable, and the only impure
+//! part (reading a blob) stays in `libgit2.rs` where the per-repo lock lives.
+//!
+//! # Detect, don't assume
+//!
+//! The format is decided by the BYTES, never by the extension. A repository is
+//! untrusted input: `logo.png` holding a PDF must reach the same honest empty
+//! state as `notes.txt`, because a broken `<img>` is worse than a sentence. That
+//! also makes the reverse work — an image committed with no extension at all
+//! still previews.
+//!
+//! # SVG is deliberately NOT previewed
+//!
+//! SVG is the one entry on the "formats a webview can display" list that is not
+//! inert. It carries `<script>`, `<foreignObject>` HTML, external `href` /
+//! `xlink:href` / CSS `url()` references and `@import` — i.e. both script
+//! execution and outbound requests, from a file that arrived in a `git clone`.
+//!
+//! Rendering it through `<img src="data:image/svg+xml,…">` is *supposed* to be
+//! safe (the SVG-in-image "secure static mode" forbids scripting and external
+//! resource loads), and that is what a browser relies on. This app does not take
+//! that bet, for two reasons specific to it:
+//!
+//! * `tauri.conf.json` ships `"csp": null`, so there is no second line of
+//!   defense behind the engine's behaviour. One engine bug, or one future
+//!   refactor from `<img>` to inline SVG, is script execution inside a webview
+//!   with unrestricted Tauri IPC — every git op, the forge tokens, the
+//!   filesystem.
+//! * Buying the guarantee back by "sanitizing" the XML here is not a boundary
+//!   worth standing behind: entities, encodings, CDATA and namespace tricks all
+//!   defeat a text scan, and a scan that *looks* like a boundary is worse than
+//!   none.
+//!
+//! So SVG is recognised and refused *by name* — [`UnsupportedReason::Svg`] —
+//! rather than silently falling through to "not an image". The surfaces say
+//! "SVG previews are disabled", which is a decision; rendering nothing and
+//! saying nothing would read as a bug.
+
+use std::path::{Path, PathBuf};
+
+/// Largest blob we will hand to a preview, per side.
+///
+/// A few MB, in the issue's words. It covers every image a repository has any
+/// business holding — icons, screenshots, design exports, test fixtures — and
+/// bounds ONE selection at two sides × 4 MiB ≈ 11 MB of base64, the same order
+/// as the whole-file text `read_file_content` already ships over IPC.
+///
+/// Enforced before the bytes are read (worktree: `metadata().len()`; a blob:
+/// `Blob::size()`), so an oversized file is never loaded, never encoded and
+/// never crosses IPC — it becomes `ImagePreview::TooLarge`.
+pub const MAX_PREVIEW_BYTES: u64 = 4 * 1024 * 1024;
+
+/// A pointer file is three short lines; nothing larger is worth parsing as one.
+/// Mirrors `lfs::MAX_POINTER_LINES`'s reasoning, in bytes, so the LFS probe on
+/// the byte reader costs a length comparison for every real image.
+pub const MAX_POINTER_BYTES: u64 = 1024;
+
+/// What a webview can display, and therefore what we will preview.
+///
+/// The media type is what reaches the `data:` URL, so it has to be the type the
+/// bytes actually are.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Sniffed {
+    /// Displayable. Carries the media type for the `data:` URL.
+    Image(&'static str),
+    /// Recognised as SVG and refused on purpose — see the module doc.
+    Svg,
+    /// Not an image format we render.
+    NotAnImage,
+}
+
+/// Longest prefix any rule below inspects. Callers may sniff a HEAD slice.
+pub const SNIFF_PREFIX_BYTES: usize = 512;
+
+/// Decide what `bytes` are, from the bytes alone.
+///
+/// Every rule checks enough of the header to be a real answer: a two-byte `BM`
+/// or a bare `\xFF\xD8` matches far too much, so BMP additionally requires its
+/// reserved field to be zero and a plausible pixel-array offset, and ICO
+/// requires a non-zero image count. A TRUNCATED file — the first four bytes of
+/// a PNG signature and nothing else — is not an image, and must answer
+/// `NotAnImage` rather than producing an `<img>` that renders as a broken icon.
+pub fn sniff(bytes: &[u8]) -> Sniffed {
+    if is_png(bytes) {
+        return Sniffed::Image("image/png");
+    }
+    if is_jpeg(bytes) {
+        return Sniffed::Image("image/jpeg");
+    }
+    if is_gif(bytes) {
+        return Sniffed::Image("image/gif");
+    }
+    if is_webp(bytes) {
+        return Sniffed::Image("image/webp");
+    }
+    if is_bmp(bytes) {
+        return Sniffed::Image("image/bmp");
+    }
+    if is_ico(bytes) {
+        return Sniffed::Image("image/x-icon");
+    }
+    if is_svg(bytes) {
+        return Sniffed::Svg;
+    }
+    Sniffed::NotAnImage
+}
+
+/// `\x89PNG\r\n\x1a\n`, then the mandatory `IHDR` chunk. The signature alone is
+/// eight bytes a truncated download also has.
+fn is_png(b: &[u8]) -> bool {
+    b.len() >= 16 && b.starts_with(b"\x89PNG\r\n\x1a\n") && &b[12..16] == b"IHDR"
+}
+
+/// SOI + the first marker byte. Every JPEG starts `FF D8 FF`, and the fourth
+/// byte is a marker id (never `FF 00`, which is a stuffed byte inside a scan).
+fn is_jpeg(b: &[u8]) -> bool {
+    b.len() >= 4 && b[0] == 0xFF && b[1] == 0xD8 && b[2] == 0xFF && b[3] != 0x00
+}
+
+fn is_gif(b: &[u8]) -> bool {
+    // Header + the 7-byte logical screen descriptor that always follows it.
+    b.len() >= 13 && (b.starts_with(b"GIF87a") || b.starts_with(b"GIF89a"))
+}
+
+/// RIFF container whose form type is `WEBP`, plus one of the three real chunk
+/// ids — a bare `RIFF….WEBP` with no chunk is not something to hand an `<img>`.
+fn is_webp(b: &[u8]) -> bool {
+    b.len() >= 16
+        && b.starts_with(b"RIFF")
+        && &b[8..12] == b"WEBP"
+        && matches!(&b[12..16], b"VP8 " | b"VP8L" | b"VP8X")
+}
+
+/// `BM` is two bytes of ASCII that any text file could open with, so the header
+/// has to corroborate: bytes 6..10 are reserved and zero in every real BMP, and
+/// the pixel-array offset must clear the 14-byte file header.
+fn is_bmp(b: &[u8]) -> bool {
+    if b.len() < 26 || !b.starts_with(b"BM") {
+        return false;
+    }
+    let reserved = u32::from_le_bytes([b[6], b[7], b[8], b[9]]);
+    let pixel_offset = u32::from_le_bytes([b[10], b[11], b[12], b[13]]);
+    reserved == 0 && pixel_offset >= 26
+}
+
+/// ICONDIR: reserved 0, type 1 (icon; type 2 is a cursor, which `<img>` does
+/// not display), then a non-zero image count.
+fn is_ico(b: &[u8]) -> bool {
+    b.len() >= 22 && b[0] == 0 && b[1] == 0 && b[2] == 1 && b[3] == 0 && {
+        let count = u16::from_le_bytes([b[4], b[5]]);
+        count > 0
+    }
+}
+
+/// SVG, recognised so it can be refused by name (see the module doc).
+///
+/// Text, so it is sniffed as text: UTF-8, then the first tag after any BOM,
+/// whitespace, XML declaration, comment or DOCTYPE must be `<svg`. That last
+/// part matters — an HTML page mentioning `<svg>` halfway down is not an SVG
+/// file, and calling it one would replace a repository's `index.html` preview
+/// with a refusal notice.
+fn is_svg(b: &[u8]) -> bool {
+    let head = &b[..b.len().min(SNIFF_PREFIX_BYTES)];
+    let Ok(text) = std::str::from_utf8(head) else {
+        // A prefix cut mid-codepoint is still worth reading up to the cut.
+        let cut = head
+            .iter()
+            .rposition(|c| c.is_ascii())
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        return std::str::from_utf8(&head[..cut]).is_ok_and(svg_root);
+    };
+    svg_root(text)
+}
+
+/// True when the first element of this XML text is `<svg`.
+fn svg_root(text: &str) -> bool {
+    let mut rest = text.trim_start_matches('\u{feff}').trim_start();
+    loop {
+        // `<?xml …?>`, `<!-- … -->`, `<!DOCTYPE …>` — the only things allowed to
+        // precede the root element. Anything else decides the answer.
+        let skipped = if let Some(after) = rest.strip_prefix("<?") {
+            after.find("?>").map(|i| &after[i + 2..])
+        } else if let Some(after) = rest.strip_prefix("<!--") {
+            after.find("-->").map(|i| &after[i + 3..])
+        } else if rest.len() >= 9 && rest[..9].eq_ignore_ascii_case("<!doctype") {
+            rest[9..].find('>').map(|i| &rest[9 + i + 1..])
+        } else {
+            None
+        };
+        match skipped {
+            Some(next) => rest = next.trim_start(),
+            None => break,
+        }
+    }
+    let Some(after) = rest.strip_prefix("<svg") else {
+        return false;
+    };
+    // `<svg>`, `<svg …>`, `<svg/>` — but not `<svgfoo>`.
+    after.is_empty() || after.starts_with(|c: char| c.is_whitespace() || c == '>' || c == '/')
+}
+
+/// Where git-lfs stores object `oid` under a storage directory.
+///
+/// `<storage>/objects/aa/bb/<oid>` — git-lfs's own fan-out, two levels of two
+/// hex characters. Built here, PURE, rather than asked of the `git lfs` binary:
+/// the whole point of the LFS branch is to preview an object that IS present,
+/// and requiring the binary would refuse that on a machine where git-lfs is not
+/// installed but the object happens to be in `.git/lfs`. It also keeps this
+/// reader off `proc.rs` entirely.
+///
+/// `None` for an oid that is not plain lowercase hex of sane length — an oid
+/// reaches this from a pointer FILE in the repository, so it is attacker-
+/// controlled text and must never be able to build `…/objects/../../..`.
+pub fn lfs_object_path(storage: &Path, oid: &str) -> Option<PathBuf> {
+    if oid.len() < 4
+        || oid.len() > 128
+        || !oid.bytes().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+    {
+        return None;
+    }
+    Some(storage.join("objects").join(&oid[0..2]).join(&oid[2..4]).join(oid))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal-but-real headers. Each is the shortest byte string the matching
+    /// rule accepts, so a rule that got looser would stop being pinned by it.
+    fn png() -> Vec<u8> {
+        let mut v = b"\x89PNG\r\n\x1a\n".to_vec();
+        v.extend_from_slice(&[0, 0, 0, 13]);
+        v.extend_from_slice(b"IHDR");
+        v.extend_from_slice(&[0u8; 13]);
+        v
+    }
+    fn jpeg() -> Vec<u8> {
+        let mut v = vec![0xFF, 0xD8, 0xFF, 0xE0];
+        v.extend_from_slice(b"\x00\x10JFIF\0");
+        v
+    }
+    fn gif() -> Vec<u8> {
+        let mut v = b"GIF89a".to_vec();
+        v.extend_from_slice(&[1, 0, 1, 0, 0, 0, 0]);
+        v
+    }
+    fn webp() -> Vec<u8> {
+        let mut v = b"RIFF".to_vec();
+        v.extend_from_slice(&24u32.to_le_bytes());
+        v.extend_from_slice(b"WEBPVP8 ");
+        v.extend_from_slice(&[0u8; 8]);
+        v
+    }
+    fn bmp() -> Vec<u8> {
+        let mut v = b"BM".to_vec();
+        v.extend_from_slice(&70u32.to_le_bytes()); // file size
+        v.extend_from_slice(&0u32.to_le_bytes()); // reserved
+        v.extend_from_slice(&54u32.to_le_bytes()); // pixel offset
+        v.extend_from_slice(&[0u8; 12]);
+        v
+    }
+    fn ico() -> Vec<u8> {
+        let mut v = vec![0, 0, 1, 0, 1, 0];
+        v.extend_from_slice(&[0u8; 16]);
+        v
+    }
+
+    #[test]
+    fn recognises_every_displayable_format() {
+        assert_eq!(sniff(&png()), Sniffed::Image("image/png"));
+        assert_eq!(sniff(&jpeg()), Sniffed::Image("image/jpeg"));
+        assert_eq!(sniff(&gif()), Sniffed::Image("image/gif"));
+        assert_eq!(sniff(&webp()), Sniffed::Image("image/webp"));
+        assert_eq!(sniff(&bmp()), Sniffed::Image("image/bmp"));
+        assert_eq!(sniff(&ico()), Sniffed::Image("image/x-icon"));
+    }
+
+    #[test]
+    fn gif87a_is_a_gif_too() {
+        let mut v = b"GIF87a".to_vec();
+        v.extend_from_slice(&[1, 0, 1, 0, 0, 0, 0]);
+        assert_eq!(sniff(&v), Sniffed::Image("image/gif"));
+    }
+
+    #[test]
+    fn every_webp_chunk_id_counts() {
+        for chunk in [b"VP8 ", b"VP8L", b"VP8X"] {
+            let mut v = b"RIFF".to_vec();
+            v.extend_from_slice(&24u32.to_le_bytes());
+            v.extend_from_slice(b"WEBP");
+            v.extend_from_slice(chunk);
+            v.extend_from_slice(&[0u8; 8]);
+            assert_eq!(sniff(&v), Sniffed::Image("image/webp"), "{chunk:?}");
+        }
+    }
+
+    #[test]
+    fn a_truncated_header_is_not_an_image() {
+        // The exact failure the sniff exists to prevent: enough bytes to LOOK
+        // like a PNG, not enough to be one. An `<img>` renders these broken.
+        assert_eq!(sniff(b"\x89PNG"), Sniffed::NotAnImage);
+        assert_eq!(sniff(b"\x89PNG\r\n\x1a\n"), Sniffed::NotAnImage);
+        assert_eq!(sniff(&[0xFF, 0xD8]), Sniffed::NotAnImage);
+        assert_eq!(sniff(b"GIF89a"), Sniffed::NotAnImage);
+        assert_eq!(sniff(b"RIFF\x18\x00\x00\x00WEBP"), Sniffed::NotAnImage);
+        assert_eq!(sniff(b""), Sniffed::NotAnImage);
+    }
+
+    #[test]
+    fn plain_text_that_starts_with_bm_is_not_a_bitmap() {
+        // "BM" is two ASCII letters; a lyric sheet must not preview as an image.
+        assert_eq!(sniff(b"BMW ownership notes\n\nThe car is fine.\n"), Sniffed::NotAnImage);
+    }
+
+    #[test]
+    fn a_cursor_is_not_an_icon() {
+        // ICONDIR type 2 is `.cur`, which `<img>` does not display.
+        let mut v = vec![0, 0, 2, 0, 1, 0];
+        v.extend_from_slice(&[0u8; 16]);
+        assert_eq!(sniff(&v), Sniffed::NotAnImage);
+        // ...and an icon claiming zero images is not one either.
+        let mut empty = vec![0, 0, 1, 0, 0, 0];
+        empty.extend_from_slice(&[0u8; 16]);
+        assert_eq!(sniff(&empty), Sniffed::NotAnImage);
+    }
+
+    #[test]
+    fn other_binaries_keep_the_empty_state() {
+        // Explicitly out of scope (#224): PDFs, fonts, archives, executables.
+        assert_eq!(sniff(b"%PDF-1.7\n%\xE2\xE3\xCF\xD3\n"), Sniffed::NotAnImage);
+        assert_eq!(sniff(b"\x00\x01\x00\x00\x00\x0ftrue"), Sniffed::NotAnImage);
+        assert_eq!(sniff(b"PK\x03\x04\x14\x00\x00\x00"), Sniffed::NotAnImage);
+        assert_eq!(sniff(b"\x7fELF\x02\x01\x01\x00"), Sniffed::NotAnImage);
+    }
+
+    #[test]
+    fn a_file_whose_extension_lies_is_judged_by_its_bytes() {
+        // `sniff` never sees a name — this pins that the CONTENT decides, which
+        // is what makes `logo.png` holding a PDF reach the honest empty state.
+        assert_eq!(sniff(b"%PDF-1.4\ntrust me I am a png\n"), Sniffed::NotAnImage);
+    }
+
+    #[test]
+    fn svg_is_recognised_and_refused_by_name() {
+        // The `xmlns` value is spelled with a placeholder on purpose: the real
+        // SVG namespace is a w3.org URI, and `tests/no_telemetry.rs` allow-lists
+        // every hostname baked into this tree. A fixture is not worth an entry —
+        // and the sniff never looks at the attribute anyway.
+        assert_eq!(sniff(b"<svg xmlns=\"ns\"/>"), Sniffed::Svg);
+        assert_eq!(sniff(b"<svg>"), Sniffed::Svg);
+        assert_eq!(
+            sniff(b"<?xml version=\"1.0\"?>\n<!-- made by hand -->\n<svg width=\"1\"/>"),
+            Sniffed::Svg,
+        );
+        assert_eq!(
+            sniff("\u{feff}<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"x.dtd\">\n<svg />".as_bytes()),
+            Sniffed::Svg,
+        );
+    }
+
+    #[test]
+    fn html_that_merely_contains_an_svg_tag_is_not_an_svg_file() {
+        // Otherwise every `index.html` in every repository would render the
+        // "SVG previews are disabled" notice instead of its own preview.
+        assert_eq!(sniff(b"<!DOCTYPE html>\n<html><body><svg/></body></html>"), Sniffed::NotAnImage);
+        assert_eq!(sniff(b"<svgfoo/>"), Sniffed::NotAnImage);
+        assert_eq!(sniff(b"const s = \"<svg/>\";\n"), Sniffed::NotAnImage);
+    }
+
+    #[test]
+    fn lfs_object_paths_fan_out_the_way_git_lfs_does() {
+        let p = lfs_object_path(Path::new("/r/.git/lfs"), "abcdef0123").unwrap();
+        assert_eq!(p, Path::new("/r/.git/lfs/objects/ab/cd/abcdef0123"));
+    }
+
+    #[test]
+    fn an_oid_that_is_not_hex_can_never_build_a_path() {
+        // The oid comes from a pointer FILE in an untrusted repository.
+        assert!(lfs_object_path(Path::new("/r/.git/lfs"), "../../../etc/passwd").is_none());
+        assert!(lfs_object_path(Path::new("/r/.git/lfs"), "ab/cd").is_none());
+        assert!(lfs_object_path(Path::new("/r/.git/lfs"), "ABCDEF01").is_none());
+        assert!(lfs_object_path(Path::new("/r/.git/lfs"), "ab").is_none());
+        assert!(lfs_object_path(Path::new("/r/.git/lfs"), "").is_none());
+    }
+}

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -10,7 +10,10 @@ use git2::{
 use uuid::Uuid;
 
 use crate::error::{AppError, AppResult};
+use crate::git::image;
 use crate::git::ownership;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use crate::opener::{resolved_workdir_path, safe_workdir_path};
 
 use super::{
@@ -20,12 +23,15 @@ use super::{
         ConflictSides,
         DeleteFailure, DiffHunk,
         BulkFastForward,
+        BlobSource,
         DiffKind,
-        DiffLine, DiffLineKind, FastForward, FileContent, FileDiff, FileStatus, HeadInfo, LfsStatus,
+        DiffLine, DiffLineKind, FastForward, FileContent, FileDiff, FileStatus, HeadInfo, ImagePreview,
+        LfsStatus,
         LogFilter, LogPage,
         RebaseAction, RebaseStatus, RebaseStep, RebaseSummary, ReflogEntry, ReflogOp, RemoteInfo,
         RepoHandle, RepoId, RepoState, ResetMode, StashInfo, StashSaveOptions, StatusFlag,
-        SubmoduleInfo, TagInfo, TagTarget, WorkdirDiff, WorktreeBranch, WorktreeInfo, REFSPEC_ALL,
+        SubmoduleInfo, TagInfo, TagTarget, UnsupportedReason, WorkdirDiff, WorktreeBranch, WorktreeInfo,
+        REFSPEC_ALL,
     },
     GitBackend,
 };
@@ -1885,6 +1891,121 @@ fn stash_entry_at(repo: &mut Repository, index: usize) -> AppResult<(String, Str
 /// Resolve a revspec (branch, tag, short/full oid, `HEAD~2`, `tag^{}`, …) to
 /// its tree, mapping any resolution failure to `InvalidRef` so the UI gets a
 /// clean "unknown revision" error rather than a stringified internal one.
+/// One side of an image preview, before it has been sniffed (#224).
+///
+/// `TooLarge` exists as its own arm so the ceiling is applied to the DECLARED
+/// size — `metadata().len()` for the worktree, `Blob::size()` for a blob —
+/// before any bytes are copied. Reading first and measuring after would defeat
+/// the point of having a ceiling.
+enum BlobSide {
+    /// No blob at this path on this side. An added file's old side.
+    Absent,
+    TooLarge(u64),
+    Bytes(Vec<u8>),
+}
+
+/// The worktree copy, with NO fallback to HEAD.
+///
+/// `read_file_content`'s fallback is right for a single-file view and wrong
+/// here: a preview PAIR asks for each side by name, so recovering the HEAD blob
+/// would paint the deleted image into the "new" slot and claim nothing changed.
+fn read_worktree_side(abs: &Path) -> AppResult<BlobSide> {
+    let meta = match std::fs::metadata(abs) {
+        Ok(m) => m,
+        // Absent, or unreachable through a broken symlink — a state every diff
+        // surface already renders as "one side only", not a failure (#146).
+        Err(_) => return Ok(BlobSide::Absent),
+    };
+    if !meta.is_file() {
+        return Ok(BlobSide::Absent);
+    }
+    if meta.len() > image::MAX_PREVIEW_BYTES {
+        return Ok(BlobSide::TooLarge(meta.len()));
+    }
+    Ok(BlobSide::Bytes(std::fs::read(abs)?))
+}
+
+/// A blob from the object database, measured before it is copied.
+fn read_blob_side(repo: &Repository, oid: git2::Oid) -> AppResult<BlobSide> {
+    let Ok(blob) = repo.find_blob(oid) else {
+        return Ok(BlobSide::Absent);
+    };
+    if blob.size() as u64 > image::MAX_PREVIEW_BYTES {
+        return Ok(BlobSide::TooLarge(blob.size() as u64));
+    }
+    Ok(BlobSide::Bytes(blob.content().to_vec()))
+}
+
+/// Sniff bytes we already hold and turn them into the answer.
+fn describe_bytes(path: String, bytes: &[u8]) -> ImagePreview {
+    let size = bytes.len() as u64;
+    match image::sniff(bytes) {
+        image::Sniffed::Image(media_type) => ImagePreview::Image {
+            path,
+            media_type: media_type.to_string(),
+            size,
+            // Base64 HERE rather than in the frontend: it is what a `data:` URL
+            // takes, so the string crosses IPC once and is concatenated into an
+            // `src` with no decode and no second copy on the other side.
+            data: BASE64.encode(bytes),
+        },
+        image::Sniffed::Svg => ImagePreview::Unsupported {
+            path,
+            size,
+            reason: UnsupportedReason::Svg,
+        },
+        image::Sniffed::NotAnImage => ImagePreview::Unsupported {
+            path,
+            size,
+            reason: UnsupportedReason::NotAnImage,
+        },
+    }
+}
+
+/// Preview the OBJECT an LFS pointer names, when it is present locally (#224).
+///
+/// Reads `.git/lfs/objects/aa/bb/<oid>` directly instead of asking the `git lfs`
+/// binary: the answer we want is "is this object on this disk", and shelling out
+/// would refuse a perfectly readable object on a machine where git-lfs is not
+/// installed. It also keeps this reader off `proc.rs` entirely, so a preview
+/// never spawns anything.
+///
+/// `lfs.storage` is honoured because git-lfs honours it; a relative value is
+/// relative to the `.git` directory, as git-lfs resolves it.
+fn resolve_lfs_object(
+    repo: &Repository,
+    path: String,
+    pointer: &crate::git::types::LfsPointer,
+) -> AppResult<ImagePreview> {
+    let git_dir = repo.path().to_path_buf();
+    let storage = repo
+        .config()
+        .ok()
+        .and_then(|c| c.get_path("lfs.storage").ok())
+        .map(|p| if p.is_absolute() { p } else { git_dir.join(p) })
+        .unwrap_or_else(|| git_dir.join("lfs"));
+
+    let missing = || ImagePreview::LfsMissing {
+        path: path.clone(),
+        oid: pointer.oid.clone(),
+        size: pointer.size,
+    };
+    // `lfs_object_path` refuses an oid that is not plain lowercase hex — it came
+    // from a pointer file in an untrusted repository.
+    let Some(object) = image::lfs_object_path(&storage, &pointer.oid) else {
+        return Ok(missing());
+    };
+    match read_worktree_side(&object)? {
+        BlobSide::Absent => Ok(missing()),
+        BlobSide::TooLarge(size) => Ok(ImagePreview::TooLarge {
+            path,
+            size,
+            limit: image::MAX_PREVIEW_BYTES,
+        }),
+        BlobSide::Bytes(bytes) => Ok(describe_bytes(path, &bytes)),
+    }
+}
+
 fn resolve_tree<'a>(repo: &'a Repository, revspec: &str) -> AppResult<git2::Tree<'a>> {
     repo.revparse_single(revspec)
         .and_then(|obj| obj.peel_to_tree())
@@ -3496,6 +3617,86 @@ impl GitBackend for Libgit2Backend {
                     size,
                 },
             }))
+        })
+    }
+
+    fn read_image_preview(
+        &self,
+        repo_id: &RepoId,
+        source: &BlobSource,
+        path: &Path,
+    ) -> AppResult<Option<ImagePreview>> {
+        let rel = path.to_path_buf();
+        let path_str = rel.to_string_lossy().into_owned();
+        // ONE lock acquisition for the whole answer, including the LFS hop:
+        // resolving a pointer needs `repo.path()` and `lfs.storage`, and taking
+        // a second acquisition to get them would let the worktree move between
+        // the blob we sniffed and the object we opened.
+        self.with_repo(repo_id, |repo| {
+            let side = match source {
+                BlobSource::Worktree => {
+                    let workdir = repo.workdir().ok_or_else(|| {
+                        AppError::InvalidPath("bare repository has no workdir".into())
+                    })?;
+                    read_worktree_side(&workdir.join(&rel))?
+                }
+                BlobSource::Index => {
+                    let index = repo.index()?;
+                    match index.get_path(&rel, 0) {
+                        // A `160000` gitlink HAS a stage-0 entry and its oid is
+                        // a commit in the submodule's object database, so
+                        // `find_blob` would error — the same guard the other
+                        // three readers carry, for the same reason (#151).
+                        Some(e) if e.mode != u32::from(git2::FileMode::Commit) => {
+                            read_blob_side(repo, e.id)?
+                        }
+                        _ => BlobSide::Absent,
+                    }
+                }
+                BlobSource::Stage { stage } => {
+                    let index = repo.index()?;
+                    match index.get_path(&rel, i32::from(*stage)) {
+                        Some(e) if e.mode != u32::from(git2::FileMode::Commit) => {
+                            read_blob_side(repo, e.id)?
+                        }
+                        _ => BlobSide::Absent,
+                    }
+                }
+                BlobSource::Rev { revspec } => {
+                    let tree = resolve_tree(repo, revspec)?;
+                    match tree.get_path(&rel) {
+                        // KIND before lookup: a gitlink's oid names a commit
+                        // this repository does not hold.
+                        Ok(entry) if entry.kind() == Some(git2::ObjectType::Blob) => {
+                            read_blob_side(repo, entry.id())?
+                        }
+                        _ => BlobSide::Absent,
+                    }
+                }
+            };
+
+            let bytes = match side {
+                BlobSide::Absent => return Ok(None),
+                BlobSide::TooLarge(size) => {
+                    return Ok(Some(ImagePreview::TooLarge {
+                        path: path_str,
+                        size,
+                        limit: image::MAX_PREVIEW_BYTES,
+                    }))
+                }
+                BlobSide::Bytes(b) => b,
+            };
+
+            // An LFS pointer is a ≤3-line text file, so this costs one length
+            // comparison for every real image (#93's reasoning, in bytes).
+            if bytes.len() as u64 <= image::MAX_POINTER_BYTES {
+                if let Some(pointer) =
+                    std::str::from_utf8(&bytes).ok().and_then(crate::git::lfs::parse_pointer)
+                {
+                    return Ok(Some(resolve_lfs_object(repo, path_str, &pointer)?));
+                }
+            }
+            Ok(Some(describe_bytes(path_str, &bytes)))
         })
     }
 

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -3,6 +3,7 @@ pub mod bisect;
 pub mod blame;
 pub mod cli;
 pub mod hooks;
+pub mod image;
 pub mod libgit2;
 pub mod lfs;
 pub mod notes;
@@ -26,6 +27,7 @@ use types::{
     DeleteFailure, DiffKind, FileContent,
     BulkFastForward, FastForward,
     FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage, RebaseStatus, RebaseStep, ReflogEntry,
+    BlobSource, ImagePreview,
     RemoteInfo,
     RepoHandle,
     RepoId, RepoState, ResetMode, StashInfo, StashSaveOptions, SubmoduleInfo, TagInfo, TagTarget,
@@ -289,6 +291,36 @@ pub trait GitBackend: Send + Sync {
         repo_id: &RepoId,
         path: &Path,
     ) -> AppResult<Option<FileContent>>;
+    /// The raw BYTES of `path` at `source`, sniffed, for the image preview
+    /// surfaces (#224).
+    ///
+    /// The fourth file reader, and the only one that can answer with bytes:
+    /// `FileContent.text` is `None` for a binary blob by contract, so none of
+    /// the other three can feed an `<img>`.
+    ///
+    /// The FORMAT is decided by the bytes, never by the extension — a
+    /// repository is untrusted input, and `logo.png` holding a PDF has to reach
+    /// the same honest empty state as any other binary. The size ceiling is
+    /// applied to the DECLARED size before anything is read, so an oversized
+    /// blob is never loaded and never encoded.
+    ///
+    /// An LFS pointer resolves to its object in `.git/lfs` when that object is
+    /// present locally, and answers `LfsMissing` when it is not — matching the
+    /// pointer-aware treatment every other surface already gives one, and never
+    /// rendering the pointer text as if it were the asset.
+    ///
+    /// `Ok(None)` — NOT an error — when there is no blob at that path on that
+    /// side. Same contract as the other three readers (#146): every caller is a
+    /// preview asking for one side of a file it is already rendering, so an
+    /// added file having no old side is the expected answer, and a directory or
+    /// a `160000` gitlink answers the same way. A genuine failure — unknown
+    /// repository, unresolvable revspec, an unreadable file — still errors.
+    fn read_image_preview(
+        &self,
+        repo_id: &RepoId,
+        source: &BlobSource,
+        path: &Path,
+    ) -> AppResult<Option<ImagePreview>>;
     fn diff_commits(
         &self,
         repo_id: &RepoId,

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -402,6 +402,81 @@ pub struct FileContent {
     pub size: u64,
 }
 
+/// Which copy of a path an image preview should read (#224).
+///
+/// Spelled out rather than passing a nullable revspec: "the worktree", "the
+/// index" and "the third conflict stage" are not revisions, and a sentinel that
+/// means three things is how call sites get it wrong. Mirrors the frontend's
+/// `ImageSource`, and deliberately NOT `syntax`'s `SideSource` — that one feeds
+/// a text tokenizer, where a conflict stage has nothing to say.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum BlobSource {
+    /// The file on disk. NO fallback to HEAD, unlike `read_file_content`: a
+    /// preview PAIR needs each side to be exactly that side, and the fallback
+    /// would paint the old image into the "new" slot for a deleted file.
+    Worktree,
+    /// The staged blob — stage 0 of the index.
+    Index,
+    /// A committed tree.
+    Rev { revspec: String },
+    /// A conflict stage: 1 base, 2 ours, 3 theirs. The merge resolver's binary
+    /// chooser has no other way to name its two sides — neither is in any tree.
+    Stage { stage: u16 },
+}
+
+/// Why a blob that exists is not being previewed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum UnsupportedReason {
+    /// The bytes are not any image format a webview displays. Includes every
+    /// binary explicitly out of scope for #224 — PDF, fonts, archives.
+    NotAnImage,
+    /// Recognised as SVG and refused on purpose. See `git/image.rs`.
+    Svg,
+}
+
+/// One side of an image preview (#224).
+///
+/// A tagged union rather than a struct of nullable fields, because the four
+/// outcomes are genuinely different things to render and the UI must not have to
+/// infer which one it got from which fields happen to be set. `Ok(None)` from
+/// the reader is a FIFTH state and means something else again: there is no blob
+/// at that path on that side — an added file's old side, a deleted file's new
+/// one — which every diff surface already renders as "one side only".
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum ImagePreview {
+    /// Displayable. `data` is standard base64 of the whole blob, ready to be
+    /// concatenated into a `data:` URL — see the command's doc for why base64.
+    Image {
+        path: String,
+        #[serde(rename = "mediaType")]
+        media_type: String,
+        /// Bytes of the image itself, not of the base64.
+        size: u64,
+        data: String,
+    },
+    /// Over `image::MAX_PREVIEW_BYTES`. The bytes were never read: this is
+    /// decided from the blob's declared size, so an enormous asset costs a
+    /// length comparison rather than a copy through IPC.
+    TooLarge { path: String, size: u64, limit: u64 },
+    Unsupported {
+        path: String,
+        size: u64,
+        reason: UnsupportedReason,
+    },
+    /// An LFS pointer whose object has not been fetched into `.git/lfs`.
+    /// Rendering the pointer would show three lines of text where an image
+    /// belongs, so the surfaces say the object is missing instead (#93, #224).
+    LfsMissing {
+        path: String,
+        oid: String,
+        /// The real object's size, from the pointer.
+        size: u64,
+    },
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommitOptions {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -215,6 +215,7 @@ pub fn run() {
             commands::repo::list_files_at_rev,
             commands::repo::read_file_content_at_rev,
             commands::repo::read_file_content_at_index,
+            commands::repo::read_image_preview,
             commands::repo::append_gitignore,
             commands::repo::delete_untracked_files,
             commands::repo::open_in_editor,

--- a/src-tauri/tests/image_preview.rs
+++ b/src-tauri/tests/image_preview.rs
@@ -1,0 +1,469 @@
+//! The fourth file reader: BYTES, sniffed, for the image preview surfaces (#224).
+//!
+//! `git/image.rs` unit-tests the sniffing table with no repository at all; this
+//! file pins the half that needs one — which side each `BlobSource` reads, that
+//! the ceiling refuses a blob without loading it, that absence stays a state
+//! rather than an error, and that an LFS pointer previews its OBJECT when the
+//! object is on this disk and says so when it is not.
+//!
+//! Fixtures are written as real bytes, never as "a file called `.png`": the
+//! whole promise of the feature is that the CONTENT decides, so a fixture that
+//! relied on its own extension would test nothing.
+
+mod support;
+
+use std::path::{Path, PathBuf};
+
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::image::MAX_PREVIEW_BYTES;
+use platypusgit_lib::git::{
+    libgit2::Libgit2Backend,
+    types::{BlobSource, ImagePreview, RepoId, UnsupportedReason},
+    GitBackend,
+};
+
+use support::TempRepo;
+
+/// A real 1×1 PNG, header through IEND. Small enough to inline, complete enough
+/// that a browser would render it.
+fn png_bytes() -> Vec<u8> {
+    let mut v = b"\x89PNG\r\n\x1a\n".to_vec();
+    // IHDR: 1x1, 8-bit RGBA
+    v.extend_from_slice(&13u32.to_be_bytes());
+    v.extend_from_slice(b"IHDR");
+    v.extend_from_slice(&1u32.to_be_bytes());
+    v.extend_from_slice(&1u32.to_be_bytes());
+    v.extend_from_slice(&[8, 6, 0, 0, 0]);
+    v.extend_from_slice(&[0x1F, 0x15, 0xC4, 0x89]);
+    // IDAT (a valid zlib stream for one transparent pixel)
+    let idat: [u8; 13] = [
+        0x78, 0x9C, 0x63, 0x60, 0x60, 0x60, 0x00, 0x00, 0x00, 0x04, 0x00, 0x01, 0x0D,
+    ];
+    v.extend_from_slice(&(idat.len() as u32).to_be_bytes());
+    v.extend_from_slice(b"IDAT");
+    v.extend_from_slice(&idat);
+    v.extend_from_slice(&[0x0A, 0x2D, 0xB4, 0x00]);
+    v.extend_from_slice(&0u32.to_be_bytes());
+    v.extend_from_slice(b"IEND");
+    v.extend_from_slice(&[0xAE, 0x42, 0x60, 0x82]);
+    v
+}
+
+fn write_bytes(root: &Path, rel: &str, bytes: &[u8]) {
+    let p = root.join(rel);
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent).expect("parent dirs");
+    }
+    std::fs::write(&p, bytes).expect("write bytes");
+}
+
+fn worktree() -> BlobSource {
+    BlobSource::Worktree
+}
+fn at(rev: &str) -> BlobSource {
+    BlobSource::Rev {
+        revspec: rev.to_string(),
+    }
+}
+
+/// Assert an `Image` answer and hand back its media type + base64.
+#[track_caller]
+fn expect_image(p: Option<ImagePreview>) -> (String, String, u64) {
+    match p {
+        Some(ImagePreview::Image {
+            media_type,
+            data,
+            size,
+            ..
+        }) => (media_type, data, size),
+        other => panic!("expected an image, got {other:?}"),
+    }
+}
+
+// ── Which side each source reads ────────────────────────────────────────────
+
+#[test]
+fn reads_the_worktree_copy() {
+    let tr = TempRepo::with_initial_commit("v1\n");
+    write_bytes(tr.path(), "logo.png", &png_bytes());
+    let (backend, handle) = tr.open_with_backend();
+
+    let out = backend
+        .read_image_preview(&handle.id, &worktree(), Path::new("logo.png"))
+        .expect("preview");
+    let (media, data, size) = expect_image(out);
+    assert_eq!(media, "image/png");
+    assert_eq!(size, png_bytes().len() as u64);
+    // Base64 of the real bytes, ready to be concatenated into a `data:` URL —
+    // nothing on the frontend decodes it, so a wrong encoding is invisible until
+    // an image silently fails to render.
+    assert!(data.starts_with("iVBORw0KGgo"), "not base64 PNG: {data}");
+}
+
+#[test]
+fn reads_the_staged_blob() {
+    let tr = TempRepo::with_initial_commit("v1\n");
+    write_bytes(tr.path(), "logo.png", &png_bytes());
+    let (backend, handle) = tr.open_with_backend();
+    backend
+        .stage(&handle.id, &[PathBuf::from("logo.png")])
+        .expect("stage");
+    // Change the worktree AFTER staging: if the index reader were secretly
+    // reading the worktree this would come back as "not an image".
+    write_bytes(tr.path(), "logo.png", b"scribbled over\n");
+
+    let out = backend
+        .read_image_preview(&handle.id, &BlobSource::Index, Path::new("logo.png"))
+        .expect("preview");
+    let (media, _, _) = expect_image(out);
+    assert_eq!(media, "image/png");
+}
+
+#[test]
+fn reads_a_committed_tree() {
+    let tr = TempRepo::with_initial_commit("v1\n");
+    write_bytes(tr.path(), "logo.png", &png_bytes());
+    tr.commit_all("add logo");
+    // Replace it in the worktree with something that is not an image.
+    write_bytes(tr.path(), "logo.png", b"deleted the art\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let (media, _, _) = expect_image(
+        backend
+            .read_image_preview(&handle.id, &at("HEAD"), Path::new("logo.png"))
+            .expect("preview"),
+    );
+    assert_eq!(media, "image/png");
+
+    // ...and the worktree side of the same path is the OTHER answer, which is
+    // the whole reason a preview asks for each side by name.
+    match backend
+        .read_image_preview(&handle.id, &worktree(), Path::new("logo.png"))
+        .expect("preview")
+    {
+        Some(ImagePreview::Unsupported {
+            reason: UnsupportedReason::NotAnImage,
+            ..
+        }) => {}
+        other => panic!("expected NotAnImage, got {other:?}"),
+    }
+}
+
+#[test]
+fn reads_a_conflict_stage() {
+    // The merge resolver's binary chooser has no other way to name its sides:
+    // neither "ours" nor "theirs" is in any tree while the merge is unresolved.
+    let tr = support::with_conflicting_merge();
+    let (backend, handle) = tr.open_with_backend();
+
+    for stage in [2u16, 3u16] {
+        let out = backend
+            .read_image_preview(
+                &handle.id,
+                &BlobSource::Stage { stage },
+                Path::new("README.md"),
+            )
+            .expect("preview");
+        match out {
+            Some(ImagePreview::Unsupported {
+                reason: UnsupportedReason::NotAnImage,
+                ..
+            }) => {}
+            other => panic!("stage {stage}: expected NotAnImage, got {other:?}"),
+        }
+    }
+}
+
+// ── The worktree reader does NOT fall back to HEAD ──────────────────────────
+
+#[test]
+fn a_deleted_file_has_no_new_side() {
+    // `read_file_content` recovers the HEAD blob here, and that is right for a
+    // single-file view and wrong for a PAIR: falling back would paint the old
+    // image into the "new" slot and claim the delete changed nothing.
+    let tr = TempRepo::with_initial_commit("v1\n");
+    write_bytes(tr.path(), "logo.png", &png_bytes());
+    tr.commit_all("add logo");
+    std::fs::remove_file(tr.path().join("logo.png")).expect("rm");
+    let (backend, handle) = tr.open_with_backend();
+
+    assert!(
+        backend
+            .read_image_preview(&handle.id, &worktree(), Path::new("logo.png"))
+            .expect("absence is a state, not a failure")
+            .is_none(),
+        "the worktree side of a deleted file must be None, not HEAD's blob",
+    );
+    // The old side still exists, so the surface renders one panel.
+    expect_image(
+        backend
+            .read_image_preview(&handle.id, &at("HEAD"), Path::new("logo.png"))
+            .expect("preview"),
+    );
+}
+
+// ── Absence, and genuine failure ────────────────────────────────────────────
+
+#[test]
+fn a_missing_path_is_a_state_on_every_source() {
+    let tr = TempRepo::with_initial_commit("v1\n");
+    let (backend, handle) = tr.open_with_backend();
+    let nope = Path::new("assets/nope.png");
+
+    for source in [worktree(), BlobSource::Index, at("HEAD"), BlobSource::Stage { stage: 2 }] {
+        let out = backend
+            .read_image_preview(&handle.id, &source, nope)
+            .unwrap_or_else(|e| panic!("{source:?} must not error: {e:?}"));
+        assert!(out.is_none(), "{source:?}: expected None, got {out:?}");
+    }
+}
+
+#[test]
+fn a_directory_is_a_state_not_an_image() {
+    let tr = TempRepo::with_initial_commit("v1\n");
+    write_bytes(tr.path(), "assets/logo.png", &png_bytes());
+    tr.commit_all("add logo");
+    let (backend, handle) = tr.open_with_backend();
+
+    for source in [worktree(), at("HEAD")] {
+        let out = backend
+            .read_image_preview(&handle.id, &source, Path::new("assets"))
+            .unwrap_or_else(|e| panic!("{source:?} must not error: {e:?}"));
+        assert!(out.is_none(), "{source:?}: expected None, got {out:?}");
+    }
+}
+
+#[test]
+fn an_unresolvable_revspec_still_errors() {
+    // Absence is a state; a revspec that names nothing is a real failure, and
+    // must stay one — the surface has asked a question with no answer.
+    let tr = TempRepo::with_initial_commit("v1\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    match backend.read_image_preview(&handle.id, &at("no-such-ref"), Path::new("README.md")) {
+        Err(AppError::InvalidRef(spec)) => assert_eq!(spec, "no-such-ref"),
+        other => panic!("expected InvalidRef, got {other:?}"),
+    }
+}
+
+#[test]
+fn an_unknown_repository_still_errors() {
+    let backend = Libgit2Backend::new();
+    match backend.read_image_preview(
+        &RepoId("not-a-repo-id".into()),
+        &worktree(),
+        Path::new("logo.png"),
+    ) {
+        Err(AppError::UnknownRepo(_)) => {}
+        other => panic!("expected UnknownRepo, got {other:?}"),
+    }
+}
+
+// ── The ceiling ─────────────────────────────────────────────────────────────
+
+#[test]
+fn a_blob_over_the_ceiling_is_refused_without_being_read() {
+    let tr = TempRepo::with_initial_commit("v1\n");
+    // A real PNG header followed by enough padding to clear the cap: the answer
+    // must be TooLarge, NOT "a 5 MB image" — sniffing first and measuring after
+    // would defeat the point of having a cap at all.
+    let mut huge = png_bytes();
+    huge.resize((MAX_PREVIEW_BYTES + 1024) as usize, 0u8);
+    write_bytes(tr.path(), "huge.png", &huge);
+    tr.commit_all("add a huge png");
+    let (backend, handle) = tr.open_with_backend();
+
+    for source in [worktree(), at("HEAD")] {
+        match backend
+            .read_image_preview(&handle.id, &source, Path::new("huge.png"))
+            .expect("preview")
+        {
+            Some(ImagePreview::TooLarge { size, limit, .. }) => {
+                assert_eq!(size, huge.len() as u64);
+                assert_eq!(limit, MAX_PREVIEW_BYTES);
+            }
+            other => panic!("{source:?}: expected TooLarge, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn a_blob_at_exactly_the_ceiling_is_still_previewed() {
+    // Off-by-one on a limit is how "4 MB" quietly becomes "3.999 MB".
+    let tr = TempRepo::with_initial_commit("v1\n");
+    let mut exact = png_bytes();
+    exact.resize(MAX_PREVIEW_BYTES as usize, 0u8);
+    write_bytes(tr.path(), "exact.png", &exact);
+    let (backend, handle) = tr.open_with_backend();
+
+    let (_, _, size) = expect_image(
+        backend
+            .read_image_preview(&handle.id, &worktree(), Path::new("exact.png"))
+            .expect("preview"),
+    );
+    assert_eq!(size, MAX_PREVIEW_BYTES);
+}
+
+// ── Detect, don't assume ────────────────────────────────────────────────────
+
+#[test]
+fn an_extension_that_lies_reaches_the_empty_state() {
+    let tr = TempRepo::with_initial_commit("v1\n");
+    write_bytes(tr.path(), "logo.png", b"%PDF-1.7\ntrust me\n");
+    write_bytes(tr.path(), "half.jpg", b"\xFF\xD8"); // truncated: looks like a JPEG
+    let (backend, handle) = tr.open_with_backend();
+
+    for name in ["logo.png", "half.jpg"] {
+        match backend
+            .read_image_preview(&handle.id, &worktree(), Path::new(name))
+            .expect("preview")
+        {
+            Some(ImagePreview::Unsupported {
+                reason: UnsupportedReason::NotAnImage,
+                ..
+            }) => {}
+            other => panic!("{name}: expected NotAnImage, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn an_image_with_no_extension_still_previews() {
+    // The other direction of the same rule: the bytes decide.
+    let tr = TempRepo::with_initial_commit("v1\n");
+    write_bytes(tr.path(), "fixture", &png_bytes());
+    let (backend, handle) = tr.open_with_backend();
+
+    let (media, _, _) = expect_image(
+        backend
+            .read_image_preview(&handle.id, &worktree(), Path::new("fixture"))
+            .expect("preview"),
+    );
+    assert_eq!(media, "image/png");
+}
+
+#[test]
+fn svg_is_refused_by_name_not_silently() {
+    // Deliberate (see git/image.rs): SVG carries script and remote references,
+    // and this app ships no CSP behind the `<img>` element. The surfaces have to
+    // be able to SAY that, so the refusal is its own reason, not "not an image".
+    let tr = TempRepo::with_initial_commit("v1\n");
+    write_bytes(
+        tr.path(),
+        "icon.svg",
+        b"<?xml version=\"1.0\"?>\n<svg xmlns=\"http://www.w3.org/2000/svg\"><rect/></svg>\n",
+    );
+    let (backend, handle) = tr.open_with_backend();
+
+    match backend
+        .read_image_preview(&handle.id, &worktree(), Path::new("icon.svg"))
+        .expect("preview")
+    {
+        Some(ImagePreview::Unsupported {
+            reason: UnsupportedReason::Svg,
+            size,
+            ..
+        }) => assert!(size > 0),
+        other => panic!("expected Svg, got {other:?}"),
+    }
+}
+
+// ── git-LFS ─────────────────────────────────────────────────────────────────
+
+/// The pointer file for `oid`/`size`, byte-for-byte as git-lfs writes it.
+fn pointer(oid: &str, size: u64) -> String {
+    format!("version https://git-lfs.github.com/spec/v1\noid sha256:{oid}\nsize {size}\n")
+}
+
+const OID: &str = "1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f809";
+
+#[test]
+fn an_lfs_pointer_previews_the_object_when_it_is_present_locally() {
+    let tr = TempRepo::with_initial_commit("v1\n");
+    let png = png_bytes();
+    write_bytes(tr.path(), "art.png", pointer(OID, png.len() as u64).as_bytes());
+    // git-lfs's own fan-out under `.git/lfs`. Written directly rather than via
+    // the binary: the question is "is the object on this disk", and a machine
+    // without git-lfs installed can still answer it.
+    write_bytes(
+        tr.path(),
+        &format!(".git/lfs/objects/{}/{}/{OID}", &OID[0..2], &OID[2..4]),
+        &png,
+    );
+    let (backend, handle) = tr.open_with_backend();
+
+    let (media, _, size) = expect_image(
+        backend
+            .read_image_preview(&handle.id, &worktree(), Path::new("art.png"))
+            .expect("preview"),
+    );
+    assert_eq!(media, "image/png");
+    // The OBJECT's size, not the pointer's — otherwise the panel would report a
+    // 130-byte image.
+    assert_eq!(size, png.len() as u64);
+}
+
+#[test]
+fn an_unfetched_lfs_object_says_so_instead_of_rendering_the_pointer() {
+    let tr = TempRepo::with_initial_commit("v1\n");
+    write_bytes(tr.path(), "art.png", pointer(OID, 4_096).as_bytes());
+    let (backend, handle) = tr.open_with_backend();
+
+    match backend
+        .read_image_preview(&handle.id, &worktree(), Path::new("art.png"))
+        .expect("preview")
+    {
+        Some(ImagePreview::LfsMissing { oid, size, .. }) => {
+            assert_eq!(oid, OID);
+            // From the pointer: the surface can say how big the missing thing is.
+            assert_eq!(size, 4_096);
+        }
+        other => panic!("expected LfsMissing, got {other:?}"),
+    }
+}
+
+#[test]
+fn an_lfs_pointer_committed_to_a_tree_resolves_the_same_way() {
+    // The pointer is what git stores, so every source can hand one back — the
+    // resolution has to live below the source choice, not in the worktree arm.
+    let tr = TempRepo::with_initial_commit("v1\n");
+    let png = png_bytes();
+    write_bytes(tr.path(), "art.png", pointer(OID, png.len() as u64).as_bytes());
+    tr.commit_all("add pointer");
+    write_bytes(
+        tr.path(),
+        &format!(".git/lfs/objects/{}/{}/{OID}", &OID[0..2], &OID[2..4]),
+        &png,
+    );
+    let (backend, handle) = tr.open_with_backend();
+
+    let (media, _, _) = expect_image(
+        backend
+            .read_image_preview(&handle.id, &at("HEAD"), Path::new("art.png"))
+            .expect("preview"),
+    );
+    assert_eq!(media, "image/png");
+}
+
+#[test]
+fn a_pointer_naming_a_non_image_object_keeps_the_empty_state() {
+    let tr = TempRepo::with_initial_commit("v1\n");
+    write_bytes(tr.path(), "asset.psd", pointer(OID, 8).as_bytes());
+    write_bytes(
+        tr.path(),
+        &format!(".git/lfs/objects/{}/{}/{OID}", &OID[0..2], &OID[2..4]),
+        b"8PSD....",
+    );
+    let (backend, handle) = tr.open_with_backend();
+
+    match backend
+        .read_image_preview(&handle.id, &worktree(), Path::new("asset.psd"))
+        .expect("preview")
+    {
+        Some(ImagePreview::Unsupported {
+            reason: UnsupportedReason::NotAnImage,
+            ..
+        }) => {}
+        other => panic!("expected NotAnImage, got {other:?}"),
+    }
+}

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -32,6 +32,8 @@ import { useDiffFind } from "./useDiffFind";
 import type { FileDiff } from "@/lib/types";
 import { isTextualDiff } from "@/lib/derive";
 import { LfsDiffNotice } from "@/features/lfs/LfsDiffNotice";
+import { ImageDiffView } from "./ImageDiffView";
+import { diffImageSides } from "./useImagePreviews";
 
 /**
  * One diff row's text: syntax classes plus intra-line change marks, through the
@@ -519,12 +521,36 @@ export function CommitDiffPanel({
               <PGSkeleton count={14} height={10} gap={5} />
             </div>
           )}
-          {current?.binary && (
-            <div style={{ color: "var(--fg-3)", fontSize: "var(--fs-12)" }}>
-              Binary file — no textual diff.
-            </div>
+          {/* The complement of `isTextualDiff`: everything the row model cannot
+              render. An IMAGE gets previewed here rather than dead-ending
+              (#224); the sentence stays as the fallback for everything else. */}
+          {current && !isTextualDiff(current) && (
+            <>
+              {current.lfs && <LfsDiffNotice diff={current} />}
+              <ImageDiffView
+                repoId={syntaxSides?.repoId ?? null}
+                path={current.path}
+                sides={
+                  syntaxSides
+                    ? diffImageSides({
+                        old: syntaxSides.old,
+                        new: syntaxSides.new,
+                        oldPath: current.oldPath,
+                      })
+                    : []
+                }
+                fallback={
+                  // The LFS notice above already said why there is no text, so
+                  // adding "Binary file" under it would say it twice.
+                  current.lfs ? null : (
+                    <div style={{ color: "var(--fg-3)", fontSize: "var(--fs-12)" }}>
+                      Binary file — no textual diff.
+                    </div>
+                  )
+                }
+              />
+            </>
           )}
-          {current?.lfs && <LfsDiffNotice diff={current} />}
           {win.topPad > 0 && (
             <div data-pg-spacer="top" style={{ height: `${win.topPad}px` }} />
           )}

--- a/src/features/diff/ImageDiffView.test.tsx
+++ b/src/features/diff/ImageDiffView.test.tsx
@@ -1,0 +1,292 @@
+// The shared image preview (#224).
+//
+// Four diff surfaces render this, so the rules it encodes are asserted once
+// here rather than four times over four screens: what previews, what keeps the
+// old empty state, and what says something more specific instead.
+
+import { describe, expect, it } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+import type { ImagePreview } from "@/lib/types";
+import { ImageDiffOrEmpty, ImageDiffView, type ImageSide } from "./ImageDiffView";
+
+const OLD: ImageSide = {
+  key: "old",
+  label: "Old",
+  tone: "removed",
+  source: { kind: "rev", revspec: "HEAD" },
+};
+const NEW: ImageSide = {
+  key: "new",
+  label: "New",
+  tone: "added",
+  source: { kind: "worktree" },
+};
+
+const png = (over: Partial<Extract<ImagePreview, { kind: "image" }>> = {}): ImagePreview => ({
+  kind: "image",
+  path: "logo.png",
+  mediaType: "image/png",
+  size: 1024,
+  data: "AAAA",
+  ...over,
+});
+
+/** Answer `read_image_preview` per source kind. */
+function mockPreviews(by: Partial<Record<string, ImagePreview | null>>) {
+  mockInvoke("read_image_preview", (args) => {
+    const kind = (args.source as { kind: string }).kind;
+    return by[kind] ?? null;
+  });
+}
+
+function renderPair(fallback?: React.ReactNode) {
+  return render(
+    <ImageDiffView repoId="r1" path="logo.png" sides={[OLD, NEW]} fallback={fallback} />,
+  );
+}
+
+/** jsdom never decodes an image, so the dimensions arrive the way a real one's do. */
+function decode(testId: string, w: number, h: number) {
+  const img = screen.getByTestId(testId) as HTMLImageElement;
+  Object.defineProperty(img, "naturalWidth", { value: w, configurable: true });
+  Object.defineProperty(img, "naturalHeight", { value: h, configurable: true });
+  fireEvent.load(img);
+}
+
+describe("an image diff", () => {
+  it("renders both sides as local data: URLs", async () => {
+    mockPreviews({
+      rev: png({ size: 1024, data: "T0xE" }),
+      worktree: png({ size: 4096, data: "TkVX" }),
+    });
+    renderPair();
+
+    const oldImg = (await screen.findByTestId("image-preview-old")) as HTMLImageElement;
+    const newImg = screen.getByTestId("image-preview-new") as HTMLImageElement;
+    expect(oldImg.getAttribute("src")).toBe("data:image/png;base64,T0xE");
+    expect(newImg.getAttribute("src")).toBe("data:image/png;base64,TkVX");
+    // The promise the privacy guard exists to keep: bytes reach the <img>
+    // without a request. Nothing here may ever become an http(s) URL.
+    for (const img of [oldImg, newImg]) {
+      expect(img.getAttribute("src")?.startsWith("data:")).toBe(true);
+    }
+  });
+
+  it("captions each side with its byte size, and its pixels once decoded", async () => {
+    mockPreviews({ rev: png({ size: 1024 }), worktree: png({ size: 4096 }) });
+    renderPair();
+
+    await screen.findByTestId("image-preview-old");
+    // Before the image decodes there are no dimensions to report — and "0 × 0"
+    // would be a lie, not a placeholder.
+    expect(screen.getByTestId("image-caption-old").textContent).toBe("1.0 KB");
+
+    decode("image-preview-old", 16, 16);
+    decode("image-preview-new", 32, 32);
+    expect(screen.getByTestId("image-caption-old").textContent).toBe("16 × 16 · 1.0 KB");
+    expect(screen.getByTestId("image-caption-new").textContent).toBe("32 × 32 · 4.0 KB");
+  });
+
+  it("reports the delta of both currencies under the pair", async () => {
+    mockPreviews({ rev: png({ size: 1024 }), worktree: png({ size: 4096 }) });
+    renderPair();
+    await screen.findByTestId("image-preview-old");
+    decode("image-preview-old", 16, 16);
+    decode("image-preview-new", 32, 32);
+
+    expect(screen.getByTestId("image-diff-delta").textContent).toBe(
+      "16 × 16 → 32 × 32 · 1.0 KB → 4.0 KB (+3.0 KB)",
+    );
+  });
+
+  it("asks for each side by name, and asks only for the selected path", async () => {
+    mockPreviews({ rev: png(), worktree: png() });
+    renderPair();
+    await screen.findByTestId("image-preview-old");
+
+    const reads = getInvokeCalls().filter((c) => c.cmd === "read_image_preview");
+    expect(reads.map((c) => c.args.source)).toEqual([
+      { kind: "rev", revspec: "HEAD" },
+      { kind: "worktree" },
+    ]);
+    expect(new Set(reads.map((c) => c.args.path))).toEqual(new Set(["logo.png"]));
+  });
+
+  it("never reads bytes for a file that has not been selected", () => {
+    mockPreviews({ rev: png(), worktree: png() });
+    render(<ImageDiffView repoId="r1" path={null} sides={[OLD, NEW]} />);
+    expect(getInvokeCalls().filter((c) => c.cmd === "read_image_preview")).toEqual([]);
+  });
+});
+
+describe("one side only", () => {
+  it("shows the side that exists and names the add", async () => {
+    // An added file has no old side — the backend answers null, which is a
+    // state, not a failure.
+    mockPreviews({ rev: null, worktree: png({ size: 2048 }) });
+    renderPair();
+
+    await screen.findByTestId("image-preview-new");
+    expect(screen.queryByTestId("image-preview-old")).toBeNull();
+    expect(screen.getByTestId("image-absent-old")).toBeInTheDocument();
+    expect(screen.getByTestId("image-diff-onesided").textContent).toBe(
+      "Added — no previous version",
+    );
+    // A delta needs two numbers; half a pair must not print one.
+    expect(screen.queryByTestId("image-diff-delta")).toBeNull();
+  });
+
+  it("names the delete when the new side is the missing one", async () => {
+    mockPreviews({ rev: png(), worktree: null });
+    renderPair();
+    await screen.findByTestId("image-preview-old");
+    expect(screen.getByTestId("image-diff-onesided").textContent).toBe(
+      "Removed — no new version",
+    );
+  });
+});
+
+describe("everything that is not a previewable image", () => {
+  it("keeps the surface's existing empty state for another binary", async () => {
+    // PDFs, fonts and archives are explicitly out of scope (#224): they must
+    // reach the same sentence they reached before this feature existed.
+    const unsupported: ImagePreview = {
+      kind: "unsupported",
+      path: "doc.pdf",
+      size: 900,
+      reason: "notAnImage",
+    };
+    mockPreviews({ rev: unsupported, worktree: unsupported });
+    render(
+      <ImageDiffOrEmpty
+        repoId="r1"
+        path="doc.pdf"
+        sides={[OLD, NEW]}
+        title="Binary file"
+      >
+        Binary diffs aren&apos;t shown.
+      </ImageDiffOrEmpty>,
+    );
+
+    expect(await screen.findByText("Binary file")).toBeInTheDocument();
+    expect(screen.getByText("Binary diffs aren't shown.")).toBeInTheDocument();
+    expect(screen.queryByTestId("image-diff")).toBeNull();
+  });
+
+  it("says an image is too large rather than loading it", async () => {
+    mockPreviews({
+      rev: png({ size: 1024 }),
+      worktree: {
+        kind: "tooLarge",
+        path: "huge.png",
+        size: 9 * 1024 * 1024,
+        limit: 4 * 1024 * 1024,
+      },
+    });
+    renderPair();
+
+    const note = await screen.findByTestId("image-note-new");
+    expect(note.textContent).toBe(
+      "Too large to preview — 9.0 MB (limit 4.0 MB)",
+    );
+    // The other side still previews: one oversized version does not blind the
+    // whole comparison.
+    expect(screen.getByTestId("image-preview-old")).toBeInTheDocument();
+  });
+
+  it("says an LFS object has not been fetched instead of rendering the pointer", async () => {
+    mockPreviews({
+      rev: null,
+      worktree: {
+        kind: "lfsMissing",
+        path: "art.png",
+        oid: "1a2b3c",
+        size: 5 * 1024 * 1024,
+      },
+    });
+    renderPair();
+
+    const note = await screen.findByTestId("image-note-new");
+    expect(note.textContent).toContain("LFS object not fetched");
+    // The size comes from the pointer, so the panel can say how big the thing
+    // it cannot show is.
+    expect(note.textContent).toContain("5.0 MB");
+  });
+
+  it("says SVG previews are off, because refusing them is a decision", async () => {
+    const svg: ImagePreview = {
+      kind: "unsupported",
+      path: "icon.svg",
+      size: 400,
+      reason: "svg",
+    };
+    mockPreviews({ rev: svg, worktree: svg });
+    render(
+      <ImageDiffOrEmpty repoId="r1" path="icon.svg" sides={[OLD, NEW]} title="Binary file">
+        Binary diffs aren&apos;t shown.
+      </ImageDiffOrEmpty>,
+    );
+
+    const note = await screen.findByTestId("image-note-new");
+    expect(note.textContent).toContain("SVG previews are disabled");
+    // ...and it must NOT fall through to the generic empty state, which would
+    // look like the feature simply failed.
+    expect(screen.queryByText("Binary diffs aren't shown.")).toBeNull();
+  });
+
+  it("falls back to the empty state when the read fails outright", async () => {
+    mockInvoke("read_image_preview", () => {
+      throw { kind: "Git", message: "object not found" };
+    });
+    render(
+      <ImageDiffOrEmpty repoId="r1" path="logo.png" sides={[OLD, NEW]} title="Binary file">
+        Binary diffs aren&apos;t shown.
+      </ImageDiffOrEmpty>,
+    );
+    // A rejection must not take the pane down with it.
+    expect(await screen.findByText("Binary file")).toBeInTheDocument();
+  });
+});
+
+describe("a single side", () => {
+  it("renders one panel with no add/delete caption", async () => {
+    // Browsing a committed tree is not an "add" — there is one version because
+    // one version was asked for.
+    mockPreviews({ rev: png({ size: 2048 }) });
+    render(
+      <ImageDiffView
+        repoId="r1"
+        path="logo.png"
+        sides={[{ key: "file", label: "File", tone: "neutral", source: { kind: "rev", revspec: "v1.0" } }]}
+      />,
+    );
+
+    await screen.findByTestId("image-preview-file");
+    expect(screen.queryByTestId("image-diff-onesided")).toBeNull();
+    expect(screen.queryByTestId("image-diff-delta")).toBeNull();
+  });
+});
+
+describe("re-selection", () => {
+  it("re-reads when the path changes and drops the previous dimensions", async () => {
+    mockPreviews({ worktree: png({ size: 1024 }) });
+    const one: ImageSide[] = [NEW];
+    const { rerender } = render(
+      <ImageDiffView repoId="r1" path="a.png" sides={one} />,
+    );
+    await screen.findByTestId("image-preview-new");
+    decode("image-preview-new", 64, 64);
+    expect(screen.getByTestId("image-caption-new").textContent).toBe("64 × 64 · 1.0 KB");
+
+    rerender(<ImageDiffView repoId="r1" path="b.png" sides={one} />);
+    // A stale caption would report the previous file's pixels next to the new
+    // file's bytes.
+    await waitFor(() =>
+      expect(screen.getByTestId("image-caption-new").textContent).toBe("1.0 KB"),
+    );
+    expect(
+      getInvokeCalls().filter((c) => c.cmd === "read_image_preview").map((c) => c.args.path),
+    ).toEqual(["a.png", "b.png"]);
+  });
+});

--- a/src/features/diff/ImageDiffView.tsx
+++ b/src/features/diff/ImageDiffView.tsx
@@ -1,0 +1,334 @@
+// What a diff surface shows INSTEAD of "Binary file" when the binary is an
+// image (#224).
+//
+// ONE component for every diff surface — the CommitDiffPanel, the DiffViewer,
+// the RepoBrowser, the CommitPanel and the merge resolver's binary chooser — so
+// the next diff surface inherits it and the same file cannot read differently
+// depending on which pane you opened it in. Same rule as `LfsDiffNotice` (#93)
+// and `useDiffFind` (#241).
+//
+// # It renders the empty state too
+//
+// The fallback is a PROP rather than something each caller wraps this in,
+// because "is there anything to preview" is exactly the question this component
+// answers. A PDF, a font, an archive — every binary #224 left out of scope —
+// keeps the sentence the surface printed before, and each surface keeps its own
+// wording by passing it in.
+//
+// # No measurement, no windowing
+//
+// Two images in a grid: `auto-fit` collapses to one column when the pane is
+// narrow, and `object-fit: contain` inside a fixed max height does the rest. No
+// `ResizeObserver` (WebKitGTK has none) and nothing to scroll by offset.
+
+import React from "react";
+import { PGEmpty, PGIcon, PGSkeleton } from "@/design";
+import { formatBytes } from "@/lib/bytes";
+import {
+  describeDelta,
+  describeSide,
+  hasImage,
+  isNotablePreview,
+  previewDataUrl,
+  type ImageDims,
+} from "@/lib/imagePreview";
+import type { ImagePreview } from "@/lib/types";
+import { useImagePreviews, type ImageSide } from "./useImagePreviews";
+
+export type { ImageSide } from "./useImagePreviews";
+
+/**
+ * Transparency has to be visible in BOTH themes, and an icon exported on a white
+ * artboard has to be distinguishable from one with an alpha channel. A
+ * checkerboard built from the surface tokens does that and inherits the theme —
+ * light themes became reachable at runtime in #236, and a hardcoded grey would
+ * be a hole in one of them. No accent hue anywhere near this.
+ */
+const CHECKERBOARD: React.CSSProperties = {
+  backgroundColor: "var(--bg-1)",
+  backgroundImage:
+    "conic-gradient(var(--bg-2) 0 25%, transparent 0 50%, var(--bg-2) 0 75%, transparent 0)",
+  backgroundSize: "16px 16px",
+  backgroundPosition: "0 0",
+};
+
+const toneColor = (tone: ImageSide["tone"]) =>
+  tone === "removed"
+    ? "var(--git-removed)"
+    : tone === "added"
+      ? "var(--git-added)"
+      : "var(--fg-2)";
+
+/** The sentence a non-image side gets inside a panel. */
+function noteFor(p: ImagePreview | null): { icon: string; text: string } | null {
+  if (!p) return null;
+  switch (p.kind) {
+    case "image":
+      return null;
+    case "tooLarge":
+      return {
+        icon: "warn",
+        text: `Too large to preview — ${formatBytes(p.size)} (limit ${formatBytes(p.limit)})`,
+      };
+    case "lfsMissing":
+      return {
+        icon: "lfs",
+        // The point of the LFS branch: git holds a three-line pointer, and
+        // rendering THAT would put text where an image belongs.
+        text: `LFS object not fetched — ${formatBytes(p.size)}. Run “LFS fetch” to preview it.`,
+      };
+    case "unsupported":
+      return p.reason === "svg"
+        ? {
+            icon: "warn",
+            // Refusing SVG is a decision, not a gap — see git/image.rs. Saying
+            // nothing here would read as a bug.
+            text: "SVG previews are disabled — an SVG can carry script and remote references.",
+          }
+        : { icon: "file", text: "Not an image we can preview." };
+  }
+}
+
+function ImagePanel({
+  side,
+  preview,
+  dims,
+  onDims,
+}: {
+  side: ImageSide;
+  preview: ImagePreview | null;
+  dims: ImageDims | null;
+  onDims: (key: string, d: ImageDims) => void;
+}) {
+  const note = noteFor(preview);
+  return (
+    <div
+      data-testid={`image-panel-${side.key}`}
+      style={{
+        minWidth: 0,
+        display: "flex",
+        flexDirection: "column",
+        gap: 6,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          gap: 8,
+          fontSize: "var(--fs-11)",
+          minWidth: 0,
+        }}
+      >
+        <span style={{ fontWeight: 600, color: toneColor(side.tone) }}>{side.label}</span>
+        <span
+          data-testid={`image-caption-${side.key}`}
+          style={{
+            color: "var(--fg-2)",
+            fontFamily: "var(--font-mono)",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {preview ? describeSide(preview.size, dims) : "—"}
+        </span>
+      </div>
+      <div
+        style={{
+          ...CHECKERBOARD,
+          border: "1px solid var(--border-0)",
+          borderRadius: "var(--r-3)",
+          minHeight: 72,
+          padding: 8,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        {preview?.kind === "image" ? (
+          <img
+            data-testid={`image-preview-${side.key}`}
+            // A `data:` URL over bytes the backend already read. Local, always:
+            // a preview issues no request of any kind (#226).
+            src={previewDataUrl(preview)}
+            alt={`${side.label} version of ${preview.path}`}
+            onLoad={(e) =>
+              onDims(side.key, {
+                w: e.currentTarget.naturalWidth,
+                h: e.currentTarget.naturalHeight,
+              })
+            }
+            // The box only ever SHRINKS an image (`max-*`, never a width), so
+            // a 16×16 favicon renders at 16×16 and a screenshot is scaled down.
+            // Deliberately no `image-rendering: pixelated`: it would only ever
+            // apply to the downscale, where it aliases.
+            style={{
+              maxWidth: "100%",
+              maxHeight: "min(48vh, 420px)",
+              objectFit: "contain",
+            }}
+          />
+        ) : note ? (
+          <div
+            data-testid={`image-note-${side.key}`}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              color: "var(--fg-2)",
+              fontSize: "var(--fs-11)",
+              textAlign: "center",
+            }}
+          >
+            <PGIcon name={note.icon} size={13} />
+            <span>{note.text}</span>
+          </div>
+        ) : (
+          <span
+            data-testid={`image-absent-${side.key}`}
+            style={{ color: "var(--fg-3)", fontSize: "var(--fs-11)" }}
+          >
+            No version on this side
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export interface ImageDiffViewProps {
+  repoId: string | null;
+  /** The path being previewed — a side may override it (renames). */
+  path: string | null;
+  /** One or two sides. Two renders a comparison; one renders a single preview. */
+  sides: readonly ImageSide[];
+  /**
+   * What to render when nothing here is previewable — the surface's own
+   * "Binary file" copy. `null` for a surface that already said it another way
+   * (an LFS notice above, the merge chooser below).
+   */
+  fallback?: React.ReactNode;
+}
+
+/**
+ * Old beside new, each with its pixel dimensions and byte size, and the delta of
+ * both. An added or deleted file shows the one side that exists.
+ */
+export function ImageDiffView({ repoId, path, sides, fallback = null }: ImageDiffViewProps) {
+  // The gate that keeps the promise "never load bytes for a file the user has
+  // not selected": no path, no read.
+  const enabled = !!repoId && !!path;
+  const { previews, loading } = useImagePreviews({ repoId, path, sides, enabled });
+  const [dims, setDims] = React.useState<Record<string, ImageDims>>({});
+  const onDims = React.useCallback(
+    (key: string, d: ImageDims) =>
+      setDims((prev) =>
+        prev[key]?.w === d.w && prev[key]?.h === d.h ? prev : { ...prev, [key]: d },
+      ),
+    [],
+  );
+  // Measured dimensions belong to the blobs currently loaded; a new selection
+  // must not caption its image with the previous one's size.
+  const previewKey = previews.map((p) => (p?.kind === "image" ? p.data.length : 0)).join(",");
+  React.useEffect(() => setDims({}), [path, previewKey]);
+
+  if (loading) {
+    return (
+      <div data-testid="image-diff-loading" style={{ padding: 12 }} aria-busy="true">
+        <PGSkeleton count={4} height={12} gap={6} />
+      </div>
+    );
+  }
+  if (!previews.some(isNotablePreview)) return <>{fallback}</>;
+
+  const delta = describeDelta(
+    previews[0]?.kind === "image"
+      ? { size: previews[0].size, dims: dims[sides[0].key] }
+      : null,
+    previews[1]?.kind === "image"
+      ? { size: previews[1].size, dims: dims[sides[1].key] }
+      : null,
+  );
+  // "Added" / "Removed" only when there genuinely are two sides and one of them
+  // holds nothing — a one-sided view (browsing a tree) is not an add.
+  const oneSided =
+    sides.length === 2 && hasImage(previews) && previews.some((p) => p == null)
+      ? previews[0] == null
+        ? "Added — no previous version"
+        : "Removed — no new version"
+      : null;
+
+  return (
+    <div
+      data-testid="image-diff"
+      style={{ margin: 12, display: "flex", flexDirection: "column", gap: 10 }}
+    >
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: `repeat(auto-fit, minmax(180px, 1fr))`,
+          gap: 12,
+        }}
+      >
+        {sides.map((side, i) => (
+          <ImagePanel
+            key={side.key}
+            side={side}
+            preview={previews[i] ?? null}
+            dims={dims[side.key] ?? null}
+            onDims={onDims}
+          />
+        ))}
+      </div>
+      {oneSided && (
+        <div
+          data-testid="image-diff-onesided"
+          style={{ fontSize: "var(--fs-11)", color: "var(--fg-2)" }}
+        >
+          {oneSided}
+        </div>
+      )}
+      {delta && (
+        <div
+          data-testid="image-diff-delta"
+          style={{
+            fontSize: "var(--fs-11)",
+            color: "var(--fg-2)",
+            fontFamily: "var(--font-mono)",
+          }}
+        >
+          {delta}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The whole-pane version, for surfaces whose binary state IS a `PGEmpty`.
+ *
+ * Keeps each surface's existing title and copy — the empty state was never the
+ * bug, only the fact that an image never got past it.
+ */
+export function ImageDiffOrEmpty({
+  title,
+  icon = "file",
+  children,
+  ...props
+}: ImageDiffViewProps & {
+  title: React.ReactNode;
+  icon?: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <ImageDiffView
+      {...props}
+      fallback={
+        <PGEmpty icon={icon} title={title}>
+          {children}
+        </PGEmpty>
+      }
+    />
+  );
+}

--- a/src/features/diff/useImagePreviews.ts
+++ b/src/features/diff/useImagePreviews.ts
@@ -1,0 +1,126 @@
+// Fetching the bytes behind an image preview (#224).
+//
+// ONE hook for every diff surface, for the same reason `useDiffFind` is one hook
+// (#241) and `LfsDiffNotice` is one component (#93): the same file must not read
+// differently depending on which pane you opened it in.
+
+import React from "react";
+import { readImagePreview } from "@/lib/tauri";
+import { imageSourceFromSide } from "@/lib/imagePreview";
+import type { SideSource } from "@/lib/syntax";
+import type { ImagePreview, ImageSource } from "@/lib/types";
+
+/** One panel's worth of "where do these bytes come from, and what to call it". */
+export interface ImageSide {
+  /** Stable identity across renders. Also the panel's test id suffix. */
+  key: string;
+  /** Panel heading — "Old"/"New", "Ours"/"Theirs", "File". */
+  label: string;
+  /** Diff tone for the heading. `neutral` for a chooser or a single file. */
+  tone?: "removed" | "added" | "neutral";
+  source: ImageSource;
+  /**
+   * Path on THIS side. A rename has a different old path, and reading the new
+   * one against the old tree would come back empty — the same trap
+   * `useDiffSyntax` documents for its `rev` source.
+   */
+  path?: string | null;
+}
+
+export interface ImagePreviews {
+  /** One entry per side, in the order given. `null` = no blob on that side. */
+  previews: (ImagePreview | null)[];
+  loading: boolean;
+}
+
+const NONE: ImagePreviews = { previews: [], loading: false };
+
+/**
+ * Read every side's bytes, once per selection.
+ *
+ * **Nothing is fetched speculatively.** The hook is inert unless `enabled`, and
+ * every surface enables it only for the file the user has actually selected —
+ * which is the whole reason the ceiling can be as generous as it is.
+ *
+ * The effect depends on a serialized key rather than on `sides`: callers build
+ * that array inline every render, so depending on its identity would re-read
+ * both blobs on every keystroke in a filter box.
+ */
+export function useImagePreviews(o: {
+  repoId: string | null;
+  path: string | null;
+  sides: readonly ImageSide[];
+  enabled: boolean;
+}): ImagePreviews {
+  const { repoId, path, sides, enabled } = o;
+  const key = JSON.stringify(
+    enabled && repoId && path
+      ? [repoId, path, sides.map((s) => [s.key, s.source, s.path ?? null])]
+      : null,
+  );
+  const [state, setState] = React.useState<ImagePreviews>(NONE);
+
+  React.useEffect(() => {
+    const spec = JSON.parse(key) as
+      | [string, string, [string, ImageSource, string | null][]]
+      | null;
+    if (!spec) {
+      setState(NONE);
+      return;
+    }
+    const [rid, p, wanted] = spec;
+    let cancelled = false;
+    setState({ previews: wanted.map(() => null), loading: true });
+    Promise.all(
+      wanted.map(([, source, sidePath]) =>
+        // A rejection here is a real failure (unknown repository, bad revspec)
+        // and it must not take the surface down with it — the pane falls back to
+        // the empty state it had before this feature existed.
+        readImagePreview(rid, source, sidePath ?? p).catch(() => null),
+      ),
+    ).then((previews) => {
+      if (!cancelled) setState({ previews, loading: false });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [key]);
+
+  return state;
+}
+
+/**
+ * The two panels of an ordinary old-vs-new diff.
+ *
+ * Built from the `SideSource` pair the surface ALREADY computed for syntax
+ * highlighting, so the preview and the coloured text can never disagree about
+ * which revision they are showing — and a fifth diff surface gets its previews
+ * by passing the sides it already had.
+ *
+ * A side the surface calls `none` is dropped, because there is nothing to read;
+ * a side that simply holds no blob is NOT dropped here — the backend answers
+ * `null` for that, and the panel says "Added" / "Removed" from the pair.
+ */
+export function diffImageSides(o: {
+  old: SideSource;
+  new: SideSource;
+  /** The old side's path, when a rename moved it. */
+  oldPath?: string | null;
+}): ImageSide[] {
+  const sides: ImageSide[] = [];
+  const oldSource = imageSourceFromSide(o.old);
+  if (oldSource) {
+    sides.push({
+      key: "old",
+      label: "Old",
+      tone: "removed",
+      source: oldSource,
+      path: o.oldPath ?? null,
+    });
+  }
+  const newSource = imageSourceFromSide(o.new);
+  if (newSource) {
+    sides.push({ key: "new", label: "New", tone: "added", source: newSource });
+  }
+  return sides;
+}

--- a/src/features/lfs/LfsDiffNotice.tsx
+++ b/src/features/lfs/LfsDiffNotice.tsx
@@ -6,7 +6,7 @@
 
 import { PGBadge, PGIcon } from "@/design";
 import type { FileDiff } from "@/lib/types";
-import { formatBytes } from "./useLfsStore";
+import { formatBytes } from "@/lib/bytes";
 
 /** "1.4 MB → 2.1 MB", or the one side that exists for an add/delete. */
 export function lfsSizeSummary(diff: FileDiff): string {

--- a/src/features/lfs/lfsPointer.test.ts
+++ b/src/features/lfs/lfsPointer.test.ts
@@ -5,7 +5,8 @@
 // wrong or unreadable number there is the only content the panel has.
 
 import { describe, it, expect } from "vitest";
-import { formatBytes, lfsCounts, lfsDisabledReason } from "./useLfsStore";
+import { formatBytes } from "@/lib/bytes";
+import { lfsCounts, lfsDisabledReason } from "./useLfsStore";
 import { lfsSizeSummary } from "./LfsDiffNotice";
 import type { FileDiff, LfsStatus } from "@/lib/types";
 

--- a/src/features/lfs/useLfsStore.ts
+++ b/src/features/lfs/useLfsStore.ts
@@ -11,21 +11,6 @@ import type { LfsStatus } from "@/lib/types";
 import { lfsCheckout, lfsFetch, lfsPull, lfsStatus } from "@/lib/tauri";
 import { useRepoStore, withAuthRetry } from "@/features/repo/useRepoStore";
 
-/** Human-readable byte size for a pointer's payload. */
-export function formatBytes(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes < 0) return "—";
-  if (bytes < 1024) return `${bytes} B`;
-  const units = ["KB", "MB", "GB", "TB"];
-  let value = bytes / 1024;
-  let unit = 0;
-  while (value >= 1024 && unit < units.length - 1) {
-    value /= 1024;
-    unit += 1;
-  }
-  // One decimal below 10, none above — "1.4 MB", "512 MB".
-  return `${value < 10 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`;
-}
-
 /** Materialized vs pointer counts, for the panel's summary line. */
 export function lfsCounts(status: LfsStatus | null): {
   total: number;

--- a/src/features/merge/MergeWindow.imagepreview.test.tsx
+++ b/src/features/merge/MergeWindow.imagepreview.test.tsx
@@ -1,0 +1,109 @@
+// The binary chooser's image previews (#224).
+//
+// The issue calls this the surface where a preview is worth the most, and it is
+// right: everywhere else "Binary file" costs you a look at a picture, but here
+// it costs you the ability to answer the question the two buttons are asking.
+// "Take ours" and "Take theirs" over two unnamed blobs is a coin flip.
+
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MergeWindow } from "./MergeWindow";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+import type { FileStatus } from "@/lib/types";
+
+function conflictedStatus(paths: string[]): FileStatus[] {
+  return paths.map((path) => ({
+    path,
+    index: { kind: "Conflicted" },
+    worktree: { kind: "Conflicted" },
+  })) as unknown as FileStatus[];
+}
+
+function setSearch(params: string) {
+  window.history.replaceState(null, "", `/?${params}`);
+}
+
+/** libgit2 reports every side as null for a binary conflict — hence the stages. */
+function binarySides(path: string) {
+  return { path, base: null, ours: null, theirs: null, binary: true };
+}
+
+describe("a conflicted image", () => {
+  it("previews both stages above the chooser, and keeps the buttons", async () => {
+    setSearch("window=merge&repoId=r1&path=logo.png");
+    mockInvoke("get_status", () => conflictedStatus(["logo.png"]));
+    mockInvoke("conflict_sides", () => binarySides("logo.png"));
+    mockInvoke("read_image_preview", (args) => ({
+      kind: "image",
+      path: "logo.png",
+      mediaType: "image/png",
+      size: (args.source as { stage: number }).stage === 2 ? 1024 : 2048,
+      data: (args.source as { stage: number }).stage === 2 ? "T1VSUw" : "VEhFSVJT",
+    }));
+    render(<MergeWindow />);
+
+    const ours = (await screen.findByTestId("image-preview-ours")) as HTMLImageElement;
+    const theirs = screen.getByTestId("image-preview-theirs") as HTMLImageElement;
+    expect(ours.getAttribute("src")).toBe("data:image/png;base64,T1VSUw");
+    expect(theirs.getAttribute("src")).toBe("data:image/png;base64,VEhFSVJT");
+    // The previews are an ADDITION to the chooser, not a replacement: these two
+    // buttons remain the only way to resolve a binary conflict.
+    expect(screen.getByTestId("chooser-take-ours")).toBeInTheDocument();
+    expect(screen.getByTestId("chooser-take-theirs")).toBeInTheDocument();
+    expect(screen.getByTestId("merge-chooser").textContent).toContain(
+      "Binary file — pick a side",
+    );
+  });
+
+  it("reads the two conflict STAGES, which is the only way to name the sides", async () => {
+    // Neither "ours" nor "theirs" is in any tree while the merge is unresolved.
+    setSearch("window=merge&repoId=r1&path=logo.png");
+    mockInvoke("get_status", () => conflictedStatus(["logo.png"]));
+    mockInvoke("conflict_sides", () => binarySides("logo.png"));
+    mockInvoke("read_image_preview", () => null);
+    render(<MergeWindow />);
+    await screen.findByTestId("merge-chooser");
+
+    await new Promise((r) => setTimeout(r, 0));
+    const reads = getInvokeCalls().filter((c) => c.cmd === "read_image_preview");
+    expect(reads.map((c) => c.args.source)).toEqual([
+      { kind: "stage", stage: 2 },
+      { kind: "stage", stage: 3 },
+    ]);
+  });
+
+  it("leaves a non-image binary conflict exactly as it was", async () => {
+    setSearch("window=merge&repoId=r1&path=blob.bin");
+    mockInvoke("get_status", () => conflictedStatus(["blob.bin"]));
+    mockInvoke("conflict_sides", () => binarySides("blob.bin"));
+    mockInvoke("read_image_preview", () => ({
+      kind: "unsupported",
+      path: "blob.bin",
+      size: 12,
+      reason: "notAnImage",
+    }));
+    render(<MergeWindow />);
+
+    const chooser = await screen.findByTestId("merge-chooser");
+    expect(screen.queryByTestId("image-diff")).toBeNull();
+    expect(chooser.textContent).toContain("Binary file — pick a side");
+  });
+
+  it("reads nothing at all for a deleted-side conflict", async () => {
+    // The chooser also handles "deleted on one side", which is a TEXT conflict —
+    // no bytes to preview and none should be asked for.
+    setSearch("window=merge&repoId=r1&path=gone.txt");
+    mockInvoke("get_status", () => conflictedStatus(["gone.txt"]));
+    mockInvoke("conflict_sides", () => ({
+      path: "gone.txt",
+      base: "b\n",
+      ours: null,
+      theirs: "t\n",
+      binary: false,
+    }));
+    render(<MergeWindow />);
+    await screen.findByTestId("merge-chooser");
+
+    expect(getInvokeCalls().filter((c) => c.cmd === "read_image_preview")).toEqual([]);
+  });
+});

--- a/src/features/merge/MergeWindow.tsx
+++ b/src/features/merge/MergeWindow.tsx
@@ -31,6 +31,7 @@ import type { ConflictSides, FileStatus } from "@/lib/types";
 import { isConflicted } from "@/lib/derive";
 import { appErrorMessage } from "@/lib/errors";
 import { eventToChord, formatChord } from "@/features/keymap/chord";
+import { ImageDiffView } from "@/features/diff/ImageDiffView";
 import { buildMergeModel } from "./mergeModel";
 import { MergeBody, type MergeBodyHandle } from "./MergeBody";
 import type { RegionState } from "./resultEditor";
@@ -605,6 +606,10 @@ function ChooserPanel({
       data-testid="merge-chooser"
       style={{
         flex: 1,
+        minHeight: 0,
+        // The previews below can be taller than the pane; the buttons must stay
+        // reachable rather than being pushed off the bottom.
+        overflow: "auto",
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
@@ -613,7 +618,36 @@ function ChooserPanel({
         color: "var(--fg-2)",
       }}
     >
-      <PGIcon name="file" size={32} />
+      {/* Where a preview is worth the most (#224): the chooser is otherwise two
+          buttons and no way to tell which side is which. `ours` and `theirs` are
+          index stages 2 and 3 — neither is in any tree while the merge is
+          unresolved, so nothing else can name them. Falls back to the icon this
+          panel always showed when the conflict is not over an image. */}
+      <div style={{ alignSelf: "stretch", minWidth: 0, maxWidth: 900, margin: "0 auto" }}>
+        <ImageDiffView
+          repoId={repoId}
+          path={sides.binary ? path : null}
+          sides={[
+            {
+              key: "ours",
+              label: "Ours (current)",
+              tone: "neutral",
+              source: { kind: "stage", stage: 2 },
+            },
+            {
+              key: "theirs",
+              label: "Theirs (incoming)",
+              tone: "neutral",
+              source: { kind: "stage", stage: 3 },
+            },
+          ]}
+          fallback={
+            <div style={{ display: "flex", justifyContent: "center" }}>
+              <PGIcon name="file" size={32} />
+            </div>
+          }
+        />
+      </div>
       <div style={{ fontFamily: "var(--font-mono)", fontSize: "var(--fs-13)" }}>
         {sides.binary
           ? "Binary file — pick a side"

--- a/src/lib/bytes.ts
+++ b/src/lib/bytes.ts
@@ -1,0 +1,20 @@
+/**
+ * Human-readable byte size.
+ *
+ * Lives in `lib/` rather than in the LFS store because three unrelated surfaces
+ * now report a size — an LFS pointer's payload (#93), and both sides of an image
+ * preview (#224) — and two spellings of "1.4 MB" in one window reads as a bug.
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  // One decimal below 10, none above — "1.4 MB", "512 MB".
+  return `${value < 10 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`;
+}

--- a/src/lib/imagePreview.test.ts
+++ b/src/lib/imagePreview.test.ts
@@ -1,0 +1,138 @@
+// The pure rules behind the image preview panels (#224).
+
+import { describe, expect, it } from "vitest";
+import {
+  describeByteDelta,
+  describeDelta,
+  describeSide,
+  formatDims,
+  hasImage,
+  imageSourceFromSide,
+  isNotablePreview,
+  previewDataUrl,
+} from "./imagePreview";
+import type { ImagePreview } from "./types";
+
+type ImageOk = Extract<ImagePreview, { kind: "image" }>;
+
+const image = (over: Partial<ImageOk> = {}): ImageOk => ({
+  kind: "image",
+  path: "logo.png",
+  mediaType: "image/png",
+  size: 1024,
+  data: "AAAA",
+  ...over,
+});
+
+describe("previewDataUrl", () => {
+  it("builds a data: URL from the media type the BYTES were sniffed as", () => {
+    // Not the extension: `logo.png` holding a JPEG must be served as a JPEG.
+    expect(previewDataUrl(image({ mediaType: "image/jpeg" }))).toBe(
+      "data:image/jpeg;base64,AAAA",
+    );
+  });
+
+  it("stays local — a preview never names a host", () => {
+    // The privacy guard scans for hostnames; this pins the intent behind it.
+    expect(previewDataUrl(image()).startsWith("data:")).toBe(true);
+  });
+});
+
+describe("isNotablePreview", () => {
+  it("shows a panel for an image, a too-large blob and a missing LFS object", () => {
+    expect(isNotablePreview(image())).toBe(true);
+    expect(
+      isNotablePreview({ kind: "tooLarge", path: "a.png", size: 9e6, limit: 4e6 }),
+    ).toBe(true);
+    expect(
+      isNotablePreview({ kind: "lfsMissing", path: "a.png", oid: "ab", size: 9e6 }),
+    ).toBe(true);
+  });
+
+  it("keeps the old empty state for a binary that is not an image", () => {
+    // PDFs, fonts and archives are explicitly out of scope for #224.
+    expect(
+      isNotablePreview({
+        kind: "unsupported",
+        path: "a.pdf",
+        size: 10,
+        reason: "notAnImage",
+      }),
+    ).toBe(false);
+    expect(isNotablePreview(null)).toBe(false);
+  });
+
+  it("DOES speak up about an SVG, because refusing it is a decision", () => {
+    expect(
+      isNotablePreview({ kind: "unsupported", path: "i.svg", size: 10, reason: "svg" }),
+    ).toBe(true);
+  });
+});
+
+describe("hasImage", () => {
+  it("is true when either side decoded", () => {
+    expect(hasImage([null, image()])).toBe(true);
+    expect(hasImage([null, null])).toBe(false);
+  });
+});
+
+describe("captions", () => {
+  it("omits dimensions until the image has actually decoded", () => {
+    // naturalWidth is 0 before load; printing "0 × 0" would be a lie.
+    expect(formatDims(null)).toBe(null);
+    expect(formatDims({ w: 0, h: 0 })).toBe(null);
+    expect(formatDims({ w: 512, h: 384 })).toBe("512 × 384");
+    expect(describeSide(2048, null)).toBe("2.0 KB");
+    expect(describeSide(2048, { w: 16, h: 16 })).toBe("16 × 16 · 2.0 KB");
+  });
+});
+
+describe("describeByteDelta", () => {
+  it("signs the change and uses a real minus", () => {
+    expect(describeByteDelta(1024, 3072)).toBe("+2.0 KB");
+    expect(describeByteDelta(3072, 1024)).toBe("−2.0 KB");
+    expect(describeByteDelta(10, 10)).toBe("no size change");
+  });
+});
+
+describe("describeDelta", () => {
+  it("reports both currencies when both sides decoded", () => {
+    expect(
+      describeDelta(
+        { size: 1024, dims: { w: 16, h: 16 } },
+        { size: 4096, dims: { w: 32, h: 32 } },
+      ),
+    ).toBe("16 × 16 → 32 × 32 · 1.0 KB → 4.0 KB (+3.0 KB)");
+  });
+
+  it("does not repeat an unchanged dimension or size", () => {
+    expect(
+      describeDelta(
+        { size: 4096, dims: { w: 32, h: 32 } },
+        { size: 4096, dims: { w: 32, h: 32 } },
+      ),
+    ).toBe("32 × 32 · 4.0 KB");
+  });
+
+  it("is null for an added or deleted file", () => {
+    // A delta needs two numbers. Half a pair is how "+100%" gets printed for a
+    // file that never had a previous version.
+    expect(describeDelta(null, { size: 10 })).toBe(null);
+    expect(describeDelta({ size: 10 }, null)).toBe(null);
+  });
+});
+
+describe("imageSourceFromSide", () => {
+  it("reuses the side each surface already computed for syntax", () => {
+    expect(imageSourceFromSide({ kind: "worktree" })).toEqual({ kind: "worktree" });
+    expect(imageSourceFromSide({ kind: "index" })).toEqual({ kind: "index" });
+    expect(imageSourceFromSide({ kind: "rev", rev: "HEAD" })).toEqual({
+      kind: "rev",
+      revspec: "HEAD",
+    });
+  });
+
+  it("maps `none` to no side at all", () => {
+    expect(imageSourceFromSide({ kind: "none" })).toBe(null);
+  });
+});

--- a/src/lib/imagePreview.ts
+++ b/src/lib/imagePreview.ts
@@ -1,0 +1,116 @@
+// The pure half of image previews (#224).
+//
+// Everything a preview panel decides that is not React lives here, for the same
+// reason `lib/derive.ts` exists: four diff surfaces render the same thing, and a
+// rule they each re-implement is a rule they eventually disagree about.
+
+import { formatBytes } from "@/lib/bytes";
+import type { ImagePreview, ImageSource } from "@/lib/types";
+import type { SideSource } from "@/lib/syntax";
+
+/** Pixel dimensions, as the webview reported them once the image decoded. */
+export interface ImageDims {
+  w: number;
+  h: number;
+}
+
+/**
+ * The `src` for a preview.
+ *
+ * A `data:` URL, built from base64 the backend already produced — the bytes
+ * never leave this machine, and a preview makes no request of any kind (#226).
+ * There is no decode on this side: the base64 goes into the `src` verbatim.
+ */
+export function previewDataUrl(p: Extract<ImagePreview, { kind: "image" }>): string {
+  return `data:${p.mediaType};base64,${p.data}`;
+}
+
+/**
+ * Is this side worth showing a preview panel for?
+ *
+ * `unsupported / notAnImage` is NOT — that is a PDF, a font, an archive, an
+ * executable, every binary #224 explicitly left out of scope — and neither is an
+ * absent side on its own. Those keep the surface's existing empty state, which
+ * is the honest answer: a broken `<img>` is worse than a sentence.
+ *
+ * An SVG refusal IS notable, because it is a decision rather than a gap and has
+ * to be able to say so; rendering nothing would read as a bug.
+ */
+export function isNotablePreview(p: ImagePreview | null | undefined): boolean {
+  if (!p) return false;
+  if (p.kind === "unsupported") return p.reason === "svg";
+  return true;
+}
+
+/** Any side that actually decoded into an image. */
+export function hasImage(previews: readonly (ImagePreview | null)[]): boolean {
+  return previews.some((p) => p?.kind === "image");
+}
+
+/** "512 × 512", or null while the image has not decoded yet. */
+export function formatDims(d: ImageDims | null | undefined): string | null {
+  if (!d || !d.w || !d.h) return null;
+  return `${d.w} × ${d.h}`;
+}
+
+/** "512 × 512 · 24.1 KB" — one panel's caption. */
+export function describeSide(size: number, dims: ImageDims | null | undefined): string {
+  const px = formatDims(dims);
+  return px ? `${px} · ${formatBytes(size)}` : formatBytes(size);
+}
+
+/** A signed byte delta: "+64.2 KB", "−1.5 MB", or "no size change". */
+export function describeByteDelta(oldSize: number, newSize: number): string {
+  const d = newSize - oldSize;
+  if (d === 0) return "no size change";
+  // U+2212 MINUS, matching the diff gutter's `−`, not a hyphen.
+  return `${d > 0 ? "+" : "−"}${formatBytes(Math.abs(d))}`;
+}
+
+/**
+ * The line under a two-sided preview: what changed, in both currencies.
+ *
+ * `null` unless BOTH sides decoded — a delta needs two numbers, and inventing
+ * one from an added file's missing side is how "+100%" gets printed for a file
+ * that never had a previous version.
+ */
+export function describeDelta(
+  oldSide: { size: number; dims?: ImageDims | null } | null,
+  newSide: { size: number; dims?: ImageDims | null } | null,
+): string | null {
+  if (!oldSide || !newSide) return null;
+  const parts: string[] = [];
+  const a = formatDims(oldSide.dims);
+  const b = formatDims(newSide.dims);
+  if (a && b) parts.push(a === b ? a : `${a} → ${b}`);
+  parts.push(
+    oldSide.size === newSide.size
+      ? formatBytes(newSide.size)
+      : `${formatBytes(oldSide.size)} → ${formatBytes(newSide.size)} (${describeByteDelta(
+          oldSide.size,
+          newSide.size,
+        )})`,
+  );
+  return parts.join(" · ");
+}
+
+/**
+ * The same side a diff surface already told the syntax highlighter about.
+ *
+ * Every surface computes a `SideSource` for `useDiffSyntax`; deriving the image
+ * source from it means the preview and the highlighted text can never disagree
+ * about which revision they are showing. `none` maps to `null` — that side does
+ * not exist.
+ */
+export function imageSourceFromSide(side: SideSource): ImageSource | null {
+  switch (side.kind) {
+    case "none":
+      return null;
+    case "worktree":
+      return { kind: "worktree" };
+    case "index":
+      return { kind: "index" };
+    case "rev":
+      return { kind: "rev", revspec: side.rev };
+  }
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -30,6 +30,8 @@ import type {
   ForgeRepo,
   ForgeTokenStatus,
   HeadInfo,
+  ImagePreview,
+  ImageSource,
   LaunchIntent,
   LfsStatus,
   LogFilter,
@@ -224,6 +226,34 @@ export async function readFileContentAtRev(
   return invoke<FileContent | null>("read_file_content_at_rev", {
     repoId,
     revspec,
+    path,
+  });
+}
+
+/**
+ * The BYTES of an image at `path` on one side, sniffed (#224).
+ *
+ * The only reader that can feed an `<img>`: the other three carry
+ * `FileContent.text`, which is `null` for a binary blob by contract.
+ *
+ * Resolves to `null` — it does NOT reject — when there is no blob at all on that
+ * side, which is routine for a preview pair (an added file has no old side).
+ * Everything else is a state ON the payload: `tooLarge`, `unsupported`,
+ * `lfsMissing`. A genuine failure (unknown repository, unresolvable revspec)
+ * still rejects.
+ *
+ * `data` is base64 of the whole blob, ready to be concatenated into a `data:`
+ * URL — nothing decodes it on this side. **Image bytes reach the `<img>`
+ * locally and only locally**; a preview never makes a request (#226).
+ */
+export async function readImagePreview(
+  repoId: string,
+  source: ImageSource,
+  path: string,
+): Promise<ImagePreview | null> {
+  return invoke<ImagePreview | null>("read_image_preview", {
+    repoId,
+    source,
     path,
   });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -341,6 +341,51 @@ export interface FileContent {
   size: number;
 }
 
+/**
+ * Which copy of a path an image preview reads (#224).
+ *
+ * Mirrors Rust's `BlobSource`. Deliberately NOT `syntax`'s `SideSource`: that
+ * one feeds a text tokenizer, where a conflict stage has nothing to say, and
+ * overloading it would add a kind to `useDiffSyntax`'s read path that can never
+ * produce text.
+ */
+export type ImageSource =
+  | { kind: "worktree" }
+  | { kind: "index" }
+  | { kind: "rev"; revspec: string }
+  /** A conflict stage: 1 base, 2 ours, 3 theirs. */
+  | { kind: "stage"; stage: number };
+
+/**
+ * One side of an image preview (#224). Mirrors Rust's `ImagePreview`.
+ *
+ * `null` from `readImagePreview` is a FIFTH state and means something else
+ * again: there is no blob at all on that side — an added file's old side, a
+ * deleted file's new one — which the surfaces render as "one side only".
+ */
+export type ImagePreview =
+  | {
+      kind: "image";
+      path: string;
+      /** Sniffed from the bytes, never from the extension. */
+      mediaType: string;
+      /** Bytes of the image, not of the base64. */
+      size: number;
+      /** Standard base64, ready to concatenate into a `data:` URL. */
+      data: string;
+    }
+  /** Over the backend's ceiling. The bytes were never read. */
+  | { kind: "tooLarge"; path: string; size: number; limit: number }
+  | {
+      kind: "unsupported";
+      path: string;
+      size: number;
+      /** `svg` is a deliberate refusal, not a gap — see `git/image.rs`. */
+      reason: "notAnImage" | "svg";
+    }
+  /** An LFS pointer whose object has not been fetched into `.git/lfs`. */
+  | { kind: "lfsMissing"; path: string; oid: string; size: number };
+
 export type RepoState =
   | "Clean"
   | "Merge"

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -71,6 +71,8 @@ import {
 } from "@/lib/selection";
 import { getDiff, getLogPage } from "@/lib/tauri";
 import { useDiffSyntax } from "@/lib/syntax";
+import { ImageDiffOrEmpty, ImageDiffView } from "@/features/diff/ImageDiffView";
+import { diffImageSides } from "@/features/diff/useImagePreviews";
 import {
   flattenDiffRows,
   hunkExtentRows,
@@ -587,6 +589,15 @@ export function CommitPanelScreen() {
         ? { kind: "rev", rev: "HEAD", path: diff?.oldPath }
         : { kind: "index" },
     new: selected?.side === "staged" ? { kind: "index" } : { kind: "worktree" },
+  });
+
+  // The same pair, for the image preview: one derivation, so the preview and the
+  // tokens can never describe different revisions of the same file.
+  const commitPanelImageSides = diffImageSides({
+    old:
+      selected?.side === "staged" ? { kind: "rev", rev: "HEAD" } : { kind: "index" },
+    new: selected?.side === "staged" ? { kind: "index" } : { kind: "worktree" },
+    oldPath: diff?.oldPath,
   });
 
   // ── Windowed diff rows ───────────────────────────────────────────────────
@@ -1463,12 +1474,29 @@ export function CommitPanelScreen() {
               {diffError}
             </div>
           )}
+          {/* The two sides the diff was computed from — IndexToHead for a
+              staged row, WorktreeToIndex otherwise — so an image previews the
+              same pair the hunks describe (#224). */}
           {!diffLoading && !diffError && diff && diff.binary && (
-            <PGEmpty icon="file" title="Binary file">
+            <ImageDiffOrEmpty
+              repoId={repo?.id ?? null}
+              path={diff.path}
+              sides={commitPanelImageSides}
+              title="Binary file"
+            >
               Binary diffs aren&apos;t shown.
-            </PGEmpty>
+            </ImageDiffOrEmpty>
           )}
-          {!diffLoading && !diffError && diff?.lfs && <LfsDiffNotice diff={diff} />}
+          {!diffLoading && !diffError && diff?.lfs && (
+            <>
+              <LfsDiffNotice diff={diff} />
+              <ImageDiffView
+                repoId={repo?.id ?? null}
+                path={diff.path}
+                sides={commitPanelImageSides}
+              />
+            </>
+          )}
           {!diffLoading && !diffError && isTextualDiff(diff) && diff &&
             diff.hunks.length === 0 && (
               <PGEmpty icon="file" title="No diff">

--- a/src/screens/DiffViewer.imagepreview.test.tsx
+++ b/src/screens/DiffViewer.imagepreview.test.tsx
@@ -1,0 +1,119 @@
+// A changed image is no longer a dead end in the DiffViewer (#224).
+//
+// The per-surface WIRING, not the preview's own rules — those are asserted once
+// in `features/diff/ImageDiffView.test.tsx`. What this pins is that this screen
+// hands the shared component the same two sides its syntax hook reads (HEAD vs
+// the worktree), and that a binary which is NOT an image still gets the empty
+// state it always had.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { DiffViewerScreen } from "./DiffViewer";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { WithDialogs } from "@/test/dialog";
+import type { FileStatus } from "@/lib/types";
+
+const modified = (path: string): FileStatus =>
+  ({
+    path,
+    worktree: { kind: "Modified" },
+    index: { kind: "Unmodified" },
+    additions: 0,
+    deletions: 0,
+    embedded: false,
+  }) as unknown as FileStatus;
+
+const binaryDiff = (path: string) => ({
+  path,
+  oldPath: null,
+  binary: true,
+  additions: 0,
+  deletions: 0,
+  hunks: [],
+  lfs: null,
+});
+
+function setup(path: string) {
+  resetInvokeMock();
+  useSettingsStore.setState({ ignoreWhitespaceInDiff: false });
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
+    status: [modified(path)],
+    branches: [],
+    remotes: [],
+    commits: [],
+    loading: false,
+  } as never);
+  mockInvoke("get_status", () => [modified(path)]);
+  mockInvoke("get_diff", () => binaryDiff(path));
+  // The syntax hook fires for every selection; a binary blob has no text.
+  mockInvoke("read_file_content", () => null);
+  mockInvoke("read_file_content_at_rev", () => null);
+}
+
+describe("DiffViewer, binary file", () => {
+  beforeEach(() => resetInvokeMock());
+
+  it("previews a changed image instead of the empty state", async () => {
+    setup("logo.png");
+    mockInvoke("read_image_preview", (args) => ({
+      kind: "image",
+      path: "logo.png",
+      mediaType: "image/png",
+      size: (args.source as { kind: string }).kind === "rev" ? 1024 : 4096,
+      data: "AAAA",
+    }));
+    render(
+      <WithDialogs>
+        <DiffViewerScreen />
+      </WithDialogs>,
+    );
+
+    await screen.findByTestId("image-preview-old");
+    expect(screen.getByTestId("image-preview-new")).toBeInTheDocument();
+    // The sentence this feature exists to replace must be gone.
+    expect(screen.queryByText("Binary file")).toBeNull();
+  });
+
+  it("asks for the same two sides the syntax hook reads — HEAD and the worktree", async () => {
+    setup("logo.png");
+    mockInvoke("read_image_preview", () => null);
+    render(
+      <WithDialogs>
+        <DiffViewerScreen />
+      </WithDialogs>,
+    );
+
+    await waitFor(() =>
+      expect(
+        getInvokeCalls().filter((c) => c.cmd === "read_image_preview").length,
+      ).toBe(2),
+    );
+    expect(
+      getInvokeCalls()
+        .filter((c) => c.cmd === "read_image_preview")
+        .map((c) => c.args.source),
+    ).toEqual([{ kind: "rev", revspec: "HEAD" }, { kind: "worktree" }]);
+  });
+
+  it("keeps the empty state for a binary that is not an image", async () => {
+    // PDFs, fonts and archives are explicitly out of scope (#224).
+    setup("doc.pdf");
+    mockInvoke("read_image_preview", () => ({
+      kind: "unsupported",
+      path: "doc.pdf",
+      size: 900,
+      reason: "notAnImage",
+    }));
+    render(
+      <WithDialogs>
+        <DiffViewerScreen />
+      </WithDialogs>,
+    );
+
+    expect(await screen.findByText("Binary file")).toBeInTheDocument();
+    expect(screen.queryByTestId("image-diff")).toBeNull();
+  });
+});

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -31,6 +31,8 @@ import {
 } from "@/features/diff/useDiffGaps";
 import { isTextualDiff, statusMark } from "@/lib/derive";
 import { LfsDiffNotice } from "@/features/lfs/LfsDiffNotice";
+import { ImageDiffOrEmpty, ImageDiffView } from "@/features/diff/ImageDiffView";
+import { diffImageSides } from "@/features/diff/useImagePreviews";
 import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
 import { getDiff } from "@/lib/tauri";
 import { useDiffSyntax } from "@/lib/syntax";
@@ -554,14 +556,40 @@ export function DiffViewerScreen() {
               <span data-testid="diff-error">{diffError}</span>
             </PGEmpty>
           )}
+          {/* An image previews here instead of dead-ending (#224); everything
+              else keeps the empty state. Same sides the syntax hook reads. */}
           {!diffLoading && diff?.binary && (
-            <PGEmpty icon="file" title="Binary file" />
+            <ImageDiffOrEmpty
+              repoId={repo?.id ?? null}
+              path={diff.path}
+              sides={diffImageSides({
+                old: { kind: "rev", rev: "HEAD" },
+                new: { kind: "worktree" },
+                oldPath: diff.oldPath,
+              })}
+              title="Binary file"
+            />
           )}
           {/* An LFS pointer is TEXT, so `binary` is honestly false — without this
               the pane would render "2 lines changed" for a multi-megabyte asset
               (#93). `isTextualDiff` is the shared gate; the notice is the shared
               replacement. */}
-          {!diffLoading && diff?.lfs && <LfsDiffNotice diff={diff} />}
+          {!diffLoading && diff?.lfs && (
+            <>
+              <LfsDiffNotice diff={diff} />
+              {/* A pointer to an IMAGE previews the object when it is present
+                  locally, and says so when it is not (#224). */}
+              <ImageDiffView
+                repoId={repo?.id ?? null}
+                path={diff.path}
+                sides={diffImageSides({
+                  old: { kind: "rev", rev: "HEAD" },
+                  new: { kind: "worktree" },
+                  oldPath: diff.oldPath,
+                })}
+              />
+            </>
+          )}
           {!diffLoading && isTextualDiff(diff) && diff && mode === "unified" && (
             <>
             <DiffFindBar find={find} />

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -43,6 +43,8 @@ import {
   statusMark,
 } from "@/lib/derive";
 import { LfsDiffNotice } from "@/features/lfs/LfsDiffNotice";
+import { ImageDiffOrEmpty, ImageDiffView } from "@/features/diff/ImageDiffView";
+import { diffImageSides } from "@/features/diff/useImagePreviews";
 import {
   clickSelection,
   emptySelection,
@@ -1220,18 +1222,66 @@ export function RepoBrowserScreen() {
                 })}
               />
             )}
+            {/* This pane compares WorktreeToHead, the same two sides its syntax
+                hook reads — so an image previews here instead of dead-ending
+                (#224). */}
             {selectedFile && !diffLoading && diff?.binary && (
-              <PGEmpty icon="file" title="Binary file">
+              <ImageDiffOrEmpty
+                repoId={repo?.id ?? null}
+                path={diff.path}
+                sides={diffImageSides({
+                  old: { kind: "rev", rev: "HEAD" },
+                  new: { kind: "worktree" },
+                  oldPath: diff.oldPath,
+                })}
+                title="Binary file"
+              >
                 Binary diffs aren&apos;t shown.
-              </PGEmpty>
+              </ImageDiffOrEmpty>
             )}
             {selectedFile && !diffLoading && diff?.lfs && (
-              <LfsDiffNotice diff={diff} />
+              <>
+                <LfsDiffNotice diff={diff} />
+                <ImageDiffView
+                  repoId={repo?.id ?? null}
+                  path={diff.path}
+                  sides={diffImageSides({
+                    old: { kind: "rev", rev: "HEAD" },
+                    new: { kind: "worktree" },
+                    oldPath: diff.oldPath,
+                  })}
+                />
+              </>
             )}
+            {/* CONTENT, not a diff: an unmodified file, or one browsed at a
+                revision. One panel, and no "Old"/"New" — there is one version
+                because one version was asked for. */}
             {selectedFile && !diffLoading && fileContent?.binary && (
-              <PGEmpty icon="file" title="Binary file">
+              <ImageDiffOrEmpty
+                repoId={repo?.id ?? null}
+                path={fileContent.path}
+                sides={[
+                  {
+                    key: "file",
+                    // Just "File": the toolbar above already says which
+                    // revision is being browsed, and a 40-character oid would
+                    // not fit a panel heading.
+                    label: "File",
+                    tone: "neutral",
+                    // The same side the content came from, so the preview and
+                    // the byte count below it describe one blob.
+                    source:
+                      browsingRev && rev
+                        ? { kind: "rev", revspec: rev }
+                        : fileContent.fromHead
+                          ? { kind: "rev", revspec: "HEAD" }
+                          : { kind: "worktree" },
+                  },
+                ]}
+                title="Binary file"
+              >
                 Binary contents aren&apos;t shown.
-              </PGEmpty>
+              </ImageDiffOrEmpty>
             )}
             {selectedFile && !diffLoading && fileContent && !fileContent.binary &&
               fileContent.text !== null && (


### PR DESCRIPTION
## What does this PR do?

Previews changed images instead of printing "Binary file — no textual diff." Old beside new, each with **pixel dimensions and byte size**, and the delta of both; added/deleted files show the one side that exists.

One shared component, wired into **five** surfaces — the four the issue lists (`CommitDiffPanel`, `DiffViewer`, `RepoBrowser`, `MergeWindow`) plus `CommitPanel`, which has a fifth binary empty state the issue missed. Leaving it would make the same file read differently depending on the pane.

Closes #224.

## The blocker, and how bytes cross IPC

No command could return bytes: `FileContent` carries `text: Option<String>`, documented `None` when `binary` is true. `read_image_preview` is a new op down the full standard path, returning the blob **plus the sniffed media type** so the frontend never guesses from the extension.

**Base64 in the ordinary JSON payload**, consumed verbatim as a `data:` URL. Tauri serialises `Vec<u8>` as a JSON array of decimal numbers — roughly **5 bytes on the wire per byte of image** — so raw bytes were never the cheap option they look like. The alternatives:

- a raw `tauri::ipc::Response` — cannot also carry the sniffed media type, and steps outside the `AppResult<T>` contract every other command keeps;
- a custom URI scheme — needs a protocol registration, a scope and a CSP the app deliberately does not have, for a payload the ceiling already bounds.

Base64 costs ~1.33×, keeps one error type crossing IPC, and lands as exactly the string a `data:` URL wants — zero frontend decoding, one copy held.

## ⚠️ SVG is refused, and that is a product call

**Recognised and refused by name** ("SVG previews are disabled — an SVG can carry script and remote references"), not silently dropped into "not an image", because refusing is a decision and silence reads as a bug.

SVG is the only format on the list that is **not inert**: script, `<foreignObject>`, external `href`/`xlink:href`/`url()`, `@import`. Rendering it via `<img src="data:…">` is *supposed* to be safe — the SVG-in-image secure static mode forbids scripting and external loads — but **`tauri.conf.json` ships `"csp": null`**, so there is nothing behind that engine behaviour. One engine bug, or one future refactor from `<img>` to inline SVG, is script execution inside a webview with unrestricted IPC to every git op and the forge tokens. And "sanitizing" the XML here is not a boundary worth pretending to have: entities, encodings, CDATA and namespace tricks all defeat a text scan.

Cost of refusing: one sentence instead of a picture, for one format. **If you'd rather ship SVG previews, it is one arm in `git/image.rs::sniff` — but I'd want a CSP first, and `csp: null` deserves its own issue regardless.**

The SVG *detector* is careful: `<svg` must be the first element after BOM / whitespace / XML declaration / comment / DOCTYPE, so an `index.html` containing `<svg>` halfway down is not mislabelled.

## Cap, and LFS

**4 MiB per side**, applied to the **declared** size — `metadata().len()` for the worktree, `Blob::size()` for a blob — so an oversized asset is **never read, never encoded and never crosses IPC**. Above it: "Too large to preview — 9.0 MB (limit 4.0 MB)", and the other side still previews. A blob at exactly the limit still previews (pinned by a test).

**LFS objects are resolved by path**, never by spawning `git lfs`: the question is "is the object on this disk", and shelling out would refuse a readable object on a machine without git-lfs installed *and* put a spawn on a preview path. The path builder refuses any oid that is not lowercase hex, since it comes from an untrusted pointer file. An object that hasn't been fetched says so rather than rendering the pointer.

## Two details worth noting

- **The worktree source has no HEAD fallback**, unlike `read_file_content` — a preview pair needs each side to be exactly that side, or a delete paints the old image into the "new" slot.
- **Pixel dimensions come from the `<img>`'s `naturalWidth/Height` on load**, not a Rust decoder — no new dependency, and it is the size the webview actually renders. Until load fires there are simply no dimensions, never `0 × 0`.

## The privacy gate caught a real thing

`tests/no_telemetry.rs` allow-lists every hostname baked into `src-tauri/src/`, and a realistic `xmlns="http://www.w3.org/2000/svg"` in the sniff fixture tripped it. Fixed by using a **placeholder** rather than adding an allow-list entry — the sniff never reads the attribute, and a test fixture is not worth widening the gate.

## Verification

- `pnpm tsc --noEmit` — exit 0
- `pnpm test` — **255 files, 2259 tests**
- `cargo test` — **862 tests, 0 failed** (18 integration in `tests/image_preview.rs` + 12 unit in `git/image.rs`)
- `cargo test --test no_telemetry` — 8 passed
- **No e2e run**: `grep -rn "[Bb]inary" e2e/` returns only unrelated hits about the app *binary*. Nothing drives a binary empty state.

## Worth an eyeball in the real app

- **The merge chooser now has `overflow: auto`** and a preview block above the icon — a visual change to a pane that previously just centred an icon and two buttons.
- `ImageDiffView` uses `min(48vh, 420px)` as per-image max height; in the merge sub-window `vh` is that window's height, which is what you want, but it wasn't seen rendered.
- **CommitPanel is a fifth surface** the issue didn't list — say the word if you'd rather it stayed as-is.

## Checklist

- [x] One logical change, focused PR
- [x] Rebased onto `main`, no merge commits, single squashed commit
- [x] Conventional Commits
- [x] `pnpm tsc --noEmit`, `pnpm test`, `cargo check`, `cargo test` all pass
- [x] New git op: trait + impl + `CliBackend` stub + command + `invoke_handler!` + TS type/wrapper wired
- [x] `docs/dev/architecture.md`, `backend.md`, `frontend.md` updated
- [x] `base64` declared in `Cargo.toml` (already in the tree transitively); `pnpm-lock.yaml` untouched, `Cargo.lock` +1 line

🤖 Generated with [Claude Code](https://claude.com/claude-code)
