### PR TITLE
feat(commit): commit.template, ticket prefix and message help

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,14 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
   `user-select: none`. A selection cannot leave the rendered window, so copying a
   long range goes through `lib/diffCopy.ts` (`diff.copy` / the right-click menu),
   and `Mod+C` must keep declining to the native copy. (`docs/dev/frontend.md`)
+- **One commit-message composition surface** — `features/commits/message/`
+  (`useCommitComposer` + `CommitMessageBar`). A new way to compose message text
+  joins it; it never grows a second surface beside it. The box stays plain text
+  (the picker parses it back out), git's cleanup decides what is sent AND
+  whether Commit is enabled, and nothing overwrites what the user typed.
+  Comment stripping is SCOPED the way git scopes it: the box is `git commit -m`
+  (a typed `#123 fix` commits as written) until `commit.template` seeds it.
+  (`docs/dev/frontend.md`)
 - **The log is paged** — `s.commits` is a prefix of history, never the answer
   to "does X exist / is X an ancestor"; ask the backend.
   (`docs/dev/frontend.md`)

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -173,6 +173,20 @@ git/
 │                append_signature, validate_tag_name, parse_verify_tag. Also
 │                the shared ref-name validator (#214): validate_ref_component,
 │                validate_branch_name
+├── commit_template.rs
+│                `commit.template` + `core.commentChar` + `commit.cleanup`
+│                (#252). Resolves the
+│                template PATH (worktree-relative — `git commit` runs after
+│                setup_git_directory() chdir'd to the top — absolute, or `~`
+│                expanded) and the comment prefix, `auto` resolved git's way.
+│                `CleanupMode::Default` is deliberately NOT resolved here — it
+│                means "strip if the message is to be EDITED, whitespace
+│                otherwise", and only the composer knows which its box is. The
+│                STRIPPING is not here either: it lives in the composer
+│                (features/commits/message/cleanup.ts) so the box can show what
+│                it removes before Commit. Path + prefix resolution are pure fns
+│                unit-tested without a repo; tests/commit_template.rs covers the
+│                repo side
 └── signature.rs IDENTITY, not cryptography: default_signature
                  (user.name/email lookup, NoSignature when unset) and
                  apply_signoff (Signed-off-by trailer, idempotent)
@@ -209,9 +223,13 @@ commands/        Thin Tauri handlers, one file per area:
 │                track the file_name configured in lib.rs — the plugin does not
 │                report what it picked. Thin over src-tauri/src/diagnostics.rs
 ├── commits.rs   get_log, commit, file_history, verify_commit (SELECTED commit
-│                only, never per row) and commit_notes, which is lazy for the
+│                only, never per row), commit_notes, which is lazy for the
 │                same reason (#253 — the log walk is the hot path, so notes are
-│                read for the selected commit and cost the page nothing).
+│                read for the selected commit and cost the page nothing), and
+│                get_commit_template (#252 — the repo's commit.template +
+│                comment prefix; a configured template that cannot be read
+│                comes back FLAGGED, never as an error, so a stale config line
+│                cannot stop the commit screen opening).
 │                REFSPEC_ALL sentinel = walk all refs, so
 │                the loaded log is NOT HEAD ancestry — rebase input must go
 │                through headAncestryOf. Paged (see frontend.md): get_log_page /
@@ -314,8 +332,14 @@ features/            Components + Zustand store colocated per feature:
 │                    graphAncestry, rowIdentity, buildRebasePlan /
 │                    buildPreservePlan / withPlanBase / runRebasePlan /
 │                    planCommitSelection / squashMessage, headAncestry, logFilter
-│                    — plus CommitNotes, the one component here: `git notes` for
-│                    the SELECTED commit, debounced like SignatureBadge (#253)
+│                    — plus CommitNotes: `git notes` for the SELECTED commit,
+│                    debounced like SignatureBadge (#253)
+│   └── message/     THE commit-message composition surface (#252):
+│                    useCommitComposer (template pre-fill, cleanup, ticket,
+│                    type picker) + CommitMessageBar, over pure cleanup.ts /
+│                    ticket.ts / subject.ts. A new way to compose commit-message
+│                    text joins THIS hook and THIS bar's `extra` slot — see
+│                    frontend.md
 ├── rebase/          RebaseBasePicker + useRebaseMergeMode (flatten ⇄ preserve)
 ├── dnd/             ALL drag-and-drop (#91): useDragSource / useDropZone over
 │                    dragController.ts, resolveDrop.ts (pure drop tables),

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -295,6 +295,64 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   `useHunkActionsDisabledReason` — the keyboard must never reach what the mouse
   cannot (#61 D2).
 
+## The commit-message composer (#252)
+
+`src/features/commits/message/` is **THE** commit-message composition surface —
+one hook plus one bar, used by `screens/CommitPanel.tsx`:
+
+```
+const composer = useCommitComposer({ repoId, branch, ticketPattern, message, setMessage, amend });
+<CommitMessageBar composer={composer} extra={…} />
+```
+
+- **A new way to compose commit-message text joins this surface** — a field on
+  `CommitComposer` and an affordance in the bar's `extra` slot — rather than
+  becoming a fifth widget in `CommitPanel.tsx` or a parallel surface beside it.
+  #250 (assisted drafts) is the one queued behind #252, and the two must not
+  grow side by side.
+- **The textarea is the single source of truth.** The type picker PARSES the
+  subject on every render and rewrites it on change; nothing keeps a structured
+  draft on the side. Typing `feat: x` by hand selects `feat` in the picker,
+  clearing the picker hands the typed text back. Free typing has to keep
+  working — the issue is explicit that a mandatory form would be worse than
+  nothing, so there is deliberately no subject/body split, no `BREAKING CHANGE`
+  toggle and no modal.
+- **Nothing overwrites text the user typed.** `commit.template` pre-fills only
+  an EMPTY box, and never while amending (amend's prefill from HEAD wins). The
+  template goes back in after a commit, because `git commit` re-applies it every
+  time — `reseed()`, which the screen calls having just cleared the box.
+- **`cleanupCommitMessage` is git's `strbuf_stripspace` — in the mode git would
+  use** (`cleanup.ts`). git's `default` cleanup is context-sensitive: `strip` if
+  the message is to be EDITED, `whitespace` otherwise. `git commit -m "#123 fix
+  the thing"` commits `#123 fix the thing`, and **so must we** — that is an
+  ordinary subject and a forge renders it as an issue link.
+  - **`fromTemplate` is the stand-in for "is the message to be edited".** It is
+    true only once `commit.template` has seeded the box, which is the one way
+    `#` lines arrive without the user typing them. It drives both halves of
+    git's context-sensitivity: what `default` means, and whether `scissors`
+    cuts (verified: `--cleanup=scissors -m …` does not cut).
+  - The **whitespace half is unconditional** (every mode but `verbatim`):
+    trailing whitespace, blank-run collapsing, leading/trailing blanks.
+  - An explicit **`commit.cleanup`** (`verbatim`/`whitespace`/`strip`/
+    `scissors`/`default`) overrides the context in both directions. Unknown
+    values degrade to `default`.
+  - A comment is a line whose FIRST character begins the prefix — `  # indented`
+    is committed, and so is `refs #12`. The prefix comes from the backend
+    (`core.commentChar`, `auto` resolved), never assumed to be `#`.
+  - It decides what is sent AND whether Commit is enabled: a **template** whose
+    comment lines are all that survive is an EMPTY commit message. A hand-typed
+    `#123 fix` is not, and stays committable.
+  - The one deviation from git: no trailing newline, in any mode, because the
+    backend stores the message verbatim and `buildMessage` trims the end
+    regardless.
+  - Pinned by 134 differential cases against real `git commit` (all five modes,
+    `-m` and a scripted editor) — re-run that comparison before changing
+    anything here rather than reasoning from the docs.
+- **The length readout is advisory and stays advisory** — amber past 50, red
+  past 72, `canCommit` untouched.
+- Composes with what was already there: sign-off, co-author / author-override
+  and recent-message recall all still read and write the same box.
+
 ## The log is paged (#68 G11)
 
 - **`s.commits` is a PREFIX of history** (`PAGE_SIZE = 500`, appended;

--- a/src-tauri/src/commands/commits.rs
+++ b/src-tauri/src/commands/commits.rs
@@ -170,6 +170,24 @@ pub async fn commit(
         .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
+/// The repository's `commit.template` + comment prefix (#252).
+///
+/// Called once per commit-screen visit. A configured template that cannot be
+/// read comes back FLAGGED, not as an error: a stale `commit.template` line
+/// must not stop the commit screen from opening, and the composer names the
+/// path on screen instead of failing silently.
+#[tauri::command]
+pub async fn get_commit_template(
+    state: State<'_, AppState>,
+    repo_id: String,
+) -> AppResult<crate::git::commit_template::CommitTemplate> {
+    let backend = state.backend.clone();
+    let repo_id = RepoId(repo_id);
+    tokio::task::spawn_blocking(move || backend.commit_template(&repo_id))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
 /// Signature status of one commit (#61 D6). Called lazily for the selected
 /// commit, never per log row.
 #[tauri::command]

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -258,6 +258,13 @@ impl GitBackend for CliBackend {
     fn commit(&self, _repo_id: &RepoId, _opts: CommitOptions) -> AppResult<CommitResult> {
         Err(AppError::NotImplemented)
     }
+
+    fn commit_template(
+        &self,
+        _repo_id: &RepoId,
+    ) -> AppResult<super::commit_template::CommitTemplate> {
+        Err(AppError::NotImplemented)
+    }
     fn branches(&self, _repo_id: &RepoId) -> AppResult<Vec<BranchInfo>> {
         Err(AppError::NotImplemented)
     }

--- a/src-tauri/src/git/commit_template.rs
+++ b/src-tauri/src/git/commit_template.rs
@@ -1,0 +1,372 @@
+//! `commit.template` and `core.commentChar` (#252).
+//!
+//! git's own mechanism for seeding a commit message: a repository sets
+//! `commit.template`, the CLI opens the editor on that file, and every line
+//! starting with the comment character is stripped back out before the commit
+//! object is written. We honoured neither half until this issue, so a
+//! repository that ships a template got a blank box.
+//!
+//! Both halves are read together on purpose. A template without its comment
+//! prefix is a commit message with the repository's instructions still inside
+//! it — which is exactly the bug the issue names.
+//!
+//! `commit.cleanup` rides along for the same reason. It is what decides whether
+//! the comment prefix is USED at all, and reading the template without it would
+//! leave the frontend guessing at the one config value that governs the answer.
+//!
+//! What is NOT here is the stripping. That lives in the composer
+//! (`src/features/commits/message/cleanup.ts`) so the box can show the user
+//! what will be removed *before* they press Commit, and so one implementation
+//! serves both the display and the commit. This module answers only "what text,
+//! and which prefix".
+//!
+//! Path and comment-character resolution are free functions over plain values —
+//! no repository, no home directory — for the same reason `signing.rs` keeps its
+//! decisions pure: they are the part with the edge cases, and they are the part
+//! worth testing exhaustively.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::AppResult;
+
+/// git's default comment character, used when `core.commentChar` is unset.
+pub const DEFAULT_COMMENT_PREFIX: &str = "#";
+
+/// What `core.commentChar = auto` chooses from, in git's order
+/// (`builtin/commit.c::adjust_comment_line_char`).
+const AUTO_CANDIDATES: &str = "#;@!$%^&|:";
+
+/// `commit.cleanup`, git's five modes.
+///
+/// Serialised in git's OWN spelling rather than this codebase's usual bare
+/// PascalCase (`ResetMode`): these are config values a user types into
+/// `.gitconfig`, so round-tripping them unchanged means the TypeScript union is
+/// literally the documented set and neither side has a translation table to get
+/// wrong.
+///
+/// `Default` is deliberately kept as a value rather than resolved here. It means
+/// "`strip` if the message is to be EDITED, `whitespace` otherwise", and only
+/// the composer knows which of those the box it is holding is — see
+/// `features/commits/message/cleanup.ts`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CleanupMode {
+    Default,
+    Verbatim,
+    Whitespace,
+    Strip,
+    Scissors,
+}
+
+/// A repository's commit-message template plus the two config values that
+/// govern how the text in the box is cleaned up on the way to a commit.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitTemplate {
+    /// Where `commit.template` resolved to, when it is set at all. Reported
+    /// even when the file could not be read, so the UI can name the path
+    /// instead of saying "something went wrong".
+    pub path: Option<String>,
+    /// The template's contents, comments and all — exactly what git would put
+    /// in the editor. `None` when no template is configured, or when the
+    /// configured one could not be read.
+    pub body: Option<String>,
+    /// `commit.template` is set but the file behind it could not be read —
+    /// missing, unreadable, or not UTF-8.
+    ///
+    /// git *dies* here. Refusing to open the commit screen over a stale config
+    /// line would be worse than useless, so this comes back as a fact the
+    /// composer puts on screen rather than as an error. Deliberately a flag and
+    /// not a stringified `io::Error`: the command still succeeded, and `AppError`
+    /// exists so nobody invents a second error channel.
+    pub unreadable: bool,
+    /// The comment prefix for THIS repository: `core.commentChar`, defaulting to
+    /// `#`, with `auto` resolved the way git resolves it. Never empty.
+    pub comment_prefix: String,
+    /// `commit.cleanup`. `Default` when unset — or when set to something git
+    /// would reject, since a hand-typed `commit.cleanup = strp` must not decide
+    /// on its own that nothing gets cleaned up.
+    pub cleanup: CleanupMode,
+}
+
+impl CommitTemplate {
+    /// No template configured, comments governed by `prefix`.
+    fn none(prefix: String, cleanup: CleanupMode) -> Self {
+        CommitTemplate {
+            path: None,
+            body: None,
+            unreadable: false,
+            comment_prefix: prefix,
+            cleanup,
+        }
+    }
+}
+
+/// Read `commit.template` (resolving and loading the file) and `core.commentChar`.
+///
+/// Never fails over the template itself — only over a config read that libgit2
+/// refuses outright.
+pub fn read(repo: &git2::Repository) -> AppResult<CommitTemplate> {
+    let cfg = repo.config()?;
+    let get = |k: &str| cfg.get_string(k).ok().filter(|s| !s.trim().is_empty());
+    let comment_char = get("core.commentChar");
+    let cleanup = resolve_cleanup(get("commit.cleanup").as_deref());
+
+    let Some(configured) = get("commit.template") else {
+        // `auto` with nothing to inspect is `#`, which is also what git lands
+        // on for an empty editor buffer.
+        return Ok(CommitTemplate::none(
+            resolve_comment_prefix(comment_char.as_deref(), ""),
+            cleanup,
+        ));
+    };
+
+    let resolved = resolve_template_path(&configured, repo.workdir(), home_dir().as_deref());
+    let body = resolved
+        .as_deref()
+        .and_then(|p| std::fs::read_to_string(p).ok());
+
+    Ok(CommitTemplate {
+        path: resolved.map(|p| p.to_string_lossy().into_owned()),
+        comment_prefix: resolve_comment_prefix(comment_char.as_deref(), body.as_deref().unwrap_or("")),
+        unreadable: body.is_none(),
+        body,
+        cleanup,
+    })
+}
+
+/// `commit.cleanup`, in git's spelling. Anything unrecognised is `Default`.
+///
+/// git errors on an unknown value; degrading to the default is the safer answer
+/// here, because the alternative readings all silently change what gets
+/// committed and the commit screen has to open either way.
+pub fn resolve_cleanup(configured: Option<&str>) -> CleanupMode {
+    match configured.map(str::trim) {
+        Some("verbatim") => CleanupMode::Verbatim,
+        Some("whitespace") => CleanupMode::Whitespace,
+        Some("strip") => CleanupMode::Strip,
+        Some("scissors") => CleanupMode::Scissors,
+        _ => CleanupMode::Default,
+    }
+}
+
+/// Where a configured `commit.template` points.
+///
+/// - `~` / `~/…` expand against `home` — git does this itself
+///   (`expand_user_path`). `~otheruser/…` is left literal: resolving another
+///   account's home needs a platform password-database lookup for a case that
+///   does not occur in practice, and an unexpanded path is then *reported* as
+///   unreadable rather than silently ignored.
+/// - An absolute path is taken as given.
+/// - A relative path resolves from the WORKTREE ROOT. `git commit` runs after
+///   `setup_git_directory()` has chdir'd to the top of the worktree, so that is
+///   where the CLI looks — not wherever the user happened to be standing.
+pub fn resolve_template_path(
+    configured: &str,
+    workdir: Option<&Path>,
+    home: Option<&Path>,
+) -> Option<PathBuf> {
+    let raw = configured.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    if raw == "~" {
+        return home.map(Path::to_path_buf);
+    }
+    if let Some(rest) = raw.strip_prefix("~/").or_else(|| raw.strip_prefix("~\\")) {
+        return home.map(|h| h.join(rest));
+    }
+    let p = Path::new(raw);
+    if p.is_absolute() {
+        return Some(p.to_path_buf());
+    }
+    workdir.map(|w| w.join(p))
+}
+
+/// `core.commentChar`, with git's defaulting and its `auto` rule.
+///
+/// git 2.45 widened this from a character to a string, so it is carried as one.
+pub fn resolve_comment_prefix(configured: Option<&str>, body: &str) -> String {
+    match configured {
+        Some("auto") => auto_comment_prefix(body),
+        Some(v) if !v.is_empty() => v.to_string(),
+        _ => DEFAULT_COMMENT_PREFIX.to_string(),
+    }
+}
+
+/// git's `auto` rule, verbatim (`adjust_comment_line_char`): if `#` appears
+/// nowhere in the buffer it stays; otherwise every candidate that starts a line
+/// is struck out and the first survivor wins.
+fn auto_comment_prefix(body: &str) -> String {
+    if !body.contains('#') {
+        return DEFAULT_COMMENT_PREFIX.to_string();
+    }
+    let mut available: Vec<char> = AUTO_CANDIDATES.chars().collect();
+    for line in body.split('\n') {
+        if let Some(first) = line.chars().next() {
+            available.retain(|c| *c != first);
+        }
+    }
+    // git dies when nothing survives ("unable to select a comment character").
+    // Falling back to `#` keeps the commit screen usable, and the composer shows
+    // which lines a prefix would remove before anything is committed.
+    available
+        .first()
+        .map(char::to_string)
+        .unwrap_or_else(|| DEFAULT_COMMENT_PREFIX.to_string())
+}
+
+/// The home directory `~` expands against — `$HOME`, as git uses, with
+/// `%USERPROFILE%` behind it for a Windows shell that sets no `HOME`.
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const WORKDIR: &str = if cfg!(windows) { r"C:\repo" } else { "/repo" };
+    const HOME: &str = if cfg!(windows) { r"C:\Users\ada" } else { "/home/ada" };
+
+    fn resolve(configured: &str) -> Option<PathBuf> {
+        resolve_template_path(configured, Some(Path::new(WORKDIR)), Some(Path::new(HOME)))
+    }
+
+    #[test]
+    fn a_relative_path_hangs_off_the_worktree_root() {
+        assert_eq!(resolve(".gitmessage"), Some(Path::new(WORKDIR).join(".gitmessage")));
+        assert_eq!(
+            resolve(".config/commit.txt"),
+            Some(Path::new(WORKDIR).join(".config/commit.txt"))
+        );
+    }
+
+    #[test]
+    fn an_absolute_path_is_left_alone() {
+        let abs = Path::new(HOME).join("house-style.txt");
+        assert_eq!(resolve(abs.to_str().unwrap()), Some(abs));
+    }
+
+    #[test]
+    fn a_tilde_path_expands_against_home() {
+        assert_eq!(resolve("~/.gitmessage"), Some(Path::new(HOME).join(".gitmessage")));
+        assert_eq!(resolve("~"), Some(PathBuf::from(HOME)));
+    }
+
+    #[test]
+    fn surrounding_whitespace_does_not_defeat_the_lookup() {
+        assert_eq!(resolve("  .gitmessage  "), Some(Path::new(WORKDIR).join(".gitmessage")));
+    }
+
+    #[test]
+    fn an_empty_setting_resolves_to_nothing() {
+        assert_eq!(resolve(""), None);
+        assert_eq!(resolve("   "), None);
+    }
+
+    #[test]
+    fn another_users_home_is_not_guessed_at() {
+        // Left literal, so it lands as a (missing) worktree-relative path and is
+        // REPORTED — rather than quietly resolving to the wrong person's file.
+        assert_eq!(
+            resolve("~bob/.gitmessage"),
+            Some(Path::new(WORKDIR).join("~bob/.gitmessage"))
+        );
+    }
+
+    #[test]
+    fn a_relative_path_in_a_bare_repo_resolves_to_nothing() {
+        assert_eq!(
+            resolve_template_path(".gitmessage", None, Some(Path::new(HOME))),
+            None
+        );
+    }
+
+    #[test]
+    fn a_tilde_path_with_no_home_resolves_to_nothing() {
+        assert_eq!(
+            resolve_template_path("~/.gitmessage", Some(Path::new(WORKDIR)), None),
+            None
+        );
+    }
+
+    #[test]
+    fn cleanup_reads_gits_own_spellings() {
+        assert_eq!(resolve_cleanup(Some("verbatim")), CleanupMode::Verbatim);
+        assert_eq!(resolve_cleanup(Some("whitespace")), CleanupMode::Whitespace);
+        assert_eq!(resolve_cleanup(Some("strip")), CleanupMode::Strip);
+        assert_eq!(resolve_cleanup(Some("scissors")), CleanupMode::Scissors);
+        assert_eq!(resolve_cleanup(Some("default")), CleanupMode::Default);
+    }
+
+    #[test]
+    fn cleanup_defaults_when_absent_or_unreadable() {
+        assert_eq!(resolve_cleanup(None), CleanupMode::Default);
+        // git errors on this; we degrade, because every other reading silently
+        // changes what gets committed.
+        assert_eq!(resolve_cleanup(Some("strp")), CleanupMode::Default);
+        assert_eq!(resolve_cleanup(Some("")), CleanupMode::Default);
+        // Case-sensitive, as git's own parser is.
+        assert_eq!(resolve_cleanup(Some("Strip")), CleanupMode::Default);
+    }
+
+    #[test]
+    fn cleanup_serialises_in_gits_spelling() {
+        // The TypeScript union is literally the documented set, so a rename on
+        // either side has to be deliberate.
+        assert_eq!(
+            serde_json::to_string(&CleanupMode::Whitespace).unwrap(),
+            "\"whitespace\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CleanupMode::Default).unwrap(),
+            "\"default\""
+        );
+    }
+
+    #[test]
+    fn the_comment_prefix_defaults_to_hash() {
+        assert_eq!(resolve_comment_prefix(None, ""), "#");
+        assert_eq!(resolve_comment_prefix(Some(""), ""), "#");
+    }
+
+    #[test]
+    fn a_configured_comment_char_wins() {
+        assert_eq!(resolve_comment_prefix(Some(";"), "# not a comment here"), ";");
+        // git 2.45 widened this from one character to a string.
+        assert_eq!(resolve_comment_prefix(Some("//"), ""), "//");
+    }
+
+    #[test]
+    fn auto_keeps_hash_when_the_body_has_none() {
+        assert_eq!(resolve_comment_prefix(Some("auto"), "subject\n\nbody\n"), "#");
+        assert_eq!(resolve_comment_prefix(Some("auto"), ""), "#");
+    }
+
+    #[test]
+    fn auto_steps_aside_when_a_line_starts_with_hash() {
+        assert_eq!(resolve_comment_prefix(Some("auto"), "#123 an issue ref\n"), ";");
+    }
+
+    #[test]
+    fn auto_steps_aside_again_when_the_next_candidate_is_taken_too() {
+        assert_eq!(
+            resolve_comment_prefix(Some("auto"), "#123 an issue\n; a note\n"),
+            "@"
+        );
+    }
+
+    #[test]
+    fn auto_only_looks_at_the_first_character_of_a_line() {
+        // A `#` in the MIDDLE of a line makes git leave `#` alone only if it is
+        // nowhere at all — it is somewhere here, so the elimination pass runs,
+        // and no line STARTS with a candidate, so `#` survives it.
+        assert_eq!(resolve_comment_prefix(Some("auto"), "fixes issue #7\n"), "#");
+    }
+}

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -4423,6 +4423,16 @@ impl GitBackend for Libgit2Backend {
         Ok(CommitResult { oid, message })
     }
 
+    fn commit_template(
+        &self,
+        repo_id: &RepoId,
+    ) -> AppResult<crate::git::commit_template::CommitTemplate> {
+        // Read every time rather than cached: a template the user has just
+        // edited must not keep coming back stale, and this is one small file
+        // read per visit to the commit screen.
+        self.with_repo(repo_id, crate::git::commit_template::read)
+    }
+
     fn branches(&self, repo_id: &RepoId) -> AppResult<Vec<BranchInfo>> {
         self.with_repo(repo_id, |repo| {
             let head_ref = repo.head().ok();

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod bisect;
 pub mod blame;
 pub mod cli;
+pub mod commit_template;
 pub mod hooks;
 pub mod image;
 pub mod libgit2;
@@ -497,6 +498,14 @@ pub trait GitBackend: Send + Sync {
 
     // === commit ===
     fn commit(&self, repo_id: &RepoId, opts: CommitOptions) -> AppResult<CommitResult>;
+
+    /// The repository's `commit.template` and comment prefix (#252).
+    ///
+    /// A read, not a commit step: the composer asks once per repository and
+    /// pre-fills an EMPTY message box with it. A configured template that could
+    /// not be read comes back flagged rather than as an error — see
+    /// `git/commit_template.rs`.
+    fn commit_template(&self, repo_id: &RepoId) -> AppResult<commit_template::CommitTemplate>;
 
     // === refs ===
     fn checkout_branch(&self, repo_id: &RepoId, name: &str) -> AppResult<()>;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -235,6 +235,7 @@ pub fn run() {
             commands::commits::file_history,
             commands::commits::verify_commit,
             commands::commits::commit_notes,
+            commands::commits::get_commit_template,
             commands::create::init_repo,
             commands::create::default_init_branch,
             commands::create::clone_repo,

--- a/src-tauri/tests/commit_template.rs
+++ b/src-tauri/tests/commit_template.rs
@@ -1,0 +1,177 @@
+// `commit.template` + `core.commentChar` (#252).
+//
+// git's own way for a repository to seed a commit message. We ignored it
+// entirely until this issue: the CLI honours it, so a repo that ships a
+// template got a blank box in the app.
+//
+// What is pinned here is the RESOLUTION — where the file is looked for, and
+// which comment prefix governs stripping it. The stripping itself is the
+// composer's job (src/features/commits/message/cleanup.ts) so the user can see
+// what will be removed before committing; these tests only assert that the
+// backend hands over the two facts that decide it.
+
+mod support;
+
+use platypusgit_lib::git::{commit_template::CleanupMode, GitBackend};
+use support::TempRepo;
+
+/// Write a file under the repo and point `commit.template` at `value`.
+fn with_template(tr: &TempRepo, value: &str) {
+    let mut cfg = tr.repo.config().expect("config");
+    cfg.set_str("commit.template", value).unwrap();
+}
+
+#[test]
+fn no_configured_template_is_not_an_error() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let t = backend.commit_template(&handle.id).expect("commit_template");
+    assert_eq!(t.path, None);
+    assert_eq!(t.body, None);
+    assert!(!t.unreadable);
+    // Even with no template the comment prefix is answered: the composer strips
+    // comments from a hand-typed message too, exactly as git's editor does.
+    assert_eq!(t.comment_prefix, "#");
+    // `Default` reaches the frontend unresolved on purpose: it means "strip if
+    // the message is to be EDITED, whitespace otherwise", and only the composer
+    // knows which of those the box it holds is.
+    assert_eq!(t.cleanup, CleanupMode::Default);
+}
+
+#[test]
+fn commit_cleanup_is_read_and_reported() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    for (value, want) in [
+        ("verbatim", CleanupMode::Verbatim),
+        ("whitespace", CleanupMode::Whitespace),
+        ("strip", CleanupMode::Strip),
+        ("scissors", CleanupMode::Scissors),
+        ("default", CleanupMode::Default),
+        // git errors on an unknown value; we degrade rather than refuse to open
+        // the commit screen.
+        ("nonsense", CleanupMode::Default),
+    ] {
+        tr.repo.config().unwrap().set_str("commit.cleanup", value).unwrap();
+        let t = backend.commit_template(&handle.id).expect("commit_template");
+        assert_eq!(t.cleanup, want, "commit.cleanup = {value}");
+    }
+}
+
+#[test]
+fn a_repo_relative_path_resolves_from_the_worktree_root() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    support::fs::write_file(tr.path(), ".gitmessage", "subject\n\n# a hint\n");
+    with_template(&tr, ".gitmessage");
+
+    let (backend, handle) = tr.open_with_backend();
+    let t = backend.commit_template(&handle.id).expect("commit_template");
+    assert_eq!(t.body.as_deref(), Some("subject\n\n# a hint\n"));
+    assert!(!t.unreadable);
+    assert!(
+        t.path.as_deref().unwrap().ends_with(".gitmessage"),
+        "path was {:?}",
+        t.path
+    );
+}
+
+#[test]
+fn a_nested_repo_relative_path_resolves_from_the_worktree_root_too() {
+    // `git commit` runs after setup_git_directory() has chdir'd to the top of
+    // the worktree, so a relative template is worktree-relative — not relative
+    // to wherever the user happened to be standing.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    std::fs::create_dir_all(tr.path().join(".config")).unwrap();
+    support::fs::write_file(tr.path(), ".config/msg.txt", "from a subdirectory\n");
+    with_template(&tr, ".config/msg.txt");
+
+    let (backend, handle) = tr.open_with_backend();
+    let t = backend.commit_template(&handle.id).expect("commit_template");
+    assert_eq!(t.body.as_deref(), Some("from a subdirectory\n"));
+}
+
+#[test]
+fn an_absolute_path_is_read_as_given() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let outside = tempfile::tempdir().unwrap();
+    let file = outside.path().join("house-style.txt");
+    std::fs::write(&file, "house style\n").unwrap();
+    with_template(&tr, file.to_str().unwrap());
+
+    let (backend, handle) = tr.open_with_backend();
+    let t = backend.commit_template(&handle.id).expect("commit_template");
+    assert_eq!(t.body.as_deref(), Some("house style\n"));
+    assert_eq!(t.path.as_deref(), file.to_str());
+}
+
+#[test]
+fn a_configured_template_that_does_not_exist_is_reported_not_fatal() {
+    // Refusing nothing silently: git dies here. The commit screen must still
+    // open, so this comes back as a flag the composer can put on screen.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    with_template(&tr, "nope/not-here.txt");
+
+    let (backend, handle) = tr.open_with_backend();
+    let t = backend.commit_template(&handle.id).expect("commit_template");
+    assert!(t.unreadable, "a missing template must be reported");
+    assert_eq!(t.body, None);
+    assert!(t.path.is_some(), "the path is reported so the UI can name it");
+}
+
+#[test]
+fn core_comment_char_is_honoured() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    support::fs::write_file(tr.path(), ".gitmessage", "subject\n; a hint\n");
+    with_template(&tr, ".gitmessage");
+    tr.repo.config().unwrap().set_str("core.commentChar", ";").unwrap();
+
+    let (backend, handle) = tr.open_with_backend();
+    let t = backend.commit_template(&handle.id).expect("commit_template");
+    assert_eq!(t.comment_prefix, ";");
+}
+
+#[test]
+fn comment_char_auto_avoids_a_character_the_template_already_uses() {
+    // git resolves `auto` against the buffer it is about to hand the editor —
+    // the template — and strikes out every candidate that starts a line.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    support::fs::write_file(tr.path(), ".gitmessage", "#123 refs an issue\nbody\n");
+    with_template(&tr, ".gitmessage");
+    tr.repo.config().unwrap().set_str("core.commentChar", "auto").unwrap();
+
+    let (backend, handle) = tr.open_with_backend();
+    let t = backend.commit_template(&handle.id).expect("commit_template");
+    assert_eq!(t.comment_prefix, ";");
+}
+
+#[test]
+fn comment_char_auto_stays_hash_when_the_template_never_uses_one() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    support::fs::write_file(tr.path(), ".gitmessage", "subject\n\nbody\n");
+    with_template(&tr, ".gitmessage");
+    tr.repo.config().unwrap().set_str("core.commentChar", "auto").unwrap();
+
+    let (backend, handle) = tr.open_with_backend();
+    let t = backend.commit_template(&handle.id).expect("commit_template");
+    assert_eq!(t.comment_prefix, "#");
+}
+
+#[test]
+fn a_template_is_read_fresh_on_every_call() {
+    // The composer asks per repository visit; a cached first read would keep
+    // showing a template the user has since edited.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    support::fs::write_file(tr.path(), ".gitmessage", "first\n");
+    with_template(&tr, ".gitmessage");
+
+    let (backend, handle) = tr.open_with_backend();
+    assert_eq!(
+        backend.commit_template(&handle.id).unwrap().body.as_deref(),
+        Some("first\n")
+    );
+    support::fs::write_file(tr.path(), ".gitmessage", "second\n");
+    assert_eq!(
+        backend.commit_template(&handle.id).unwrap().body.as_deref(),
+        Some("second\n")
+    );
+}

--- a/src/features/commits/message/CommitMessageBar.tsx
+++ b/src/features/commits/message/CommitMessageBar.tsx
@@ -1,0 +1,143 @@
+// The commit composer's ONE affordance row (#252).
+//
+// Everything that helps write the message lives here, immediately under the box
+// it writes into: the conventional-commit type picker, its scope, the ticket
+// chip derived from the branch name, and the two advisories the composer owes
+// the user (a template that could not be read, and comment lines a commit will
+// silently drop).
+//
+// Nothing in this bar is required and nothing in it is modal. Every control
+// composes plain text into the ordinary textarea and can be undone by editing
+// that text — which is the whole design constraint the issue names: "it must
+// stay possible to just type freely; a mandatory form here would be worse than
+// nothing".
+//
+// `extra` is where the NEXT message-composition feature hangs its affordance
+// (#250's assisted draft is the one queued behind this). One bar, not two.
+
+import React from "react";
+
+import { PGButton, PGInput, PGSelect } from "@/design";
+
+import type { CommitComposer } from "./useCommitComposer";
+
+export interface CommitMessageBarProps {
+  composer: CommitComposer;
+  /** Additional affordances for this same message box. See the note above. */
+  extra?: React.ReactNode;
+}
+
+export function CommitMessageBar({ composer, extra }: CommitMessageBarProps) {
+  const {
+    type,
+    scope,
+    typeOptions,
+    setType,
+    setScope,
+    ticket,
+    ticketPresent,
+    insertTicket,
+    droppedComments,
+    commentPrefix,
+    strippingComments,
+    templatePath,
+    templateUnreadable,
+  } = composer;
+
+  return (
+    <div
+      data-testid="commit-message-bar"
+      style={{ display: "flex", flexDirection: "column", gap: 4, marginTop: 6 }}
+    >
+      <div style={{ display: "flex", gap: 4, alignItems: "center", flexWrap: "wrap" }}>
+        <PGSelect
+          value={type}
+          onChange={setType}
+          options={typeOptions}
+          size="sm"
+          title="Conventional-commit type. Composes `type(scope): ` onto the subject line; clearing it takes the prefix back off."
+          data-testid="commit-type"
+        />
+        <PGInput
+          value={scope}
+          onChange={setScope}
+          // A scope with no type cannot be written down — `(ui): thing` is not
+          // a conventional commit — so the field waits for one.
+          disabled={!type}
+          placeholder="scope"
+          size="sm"
+          mono
+          title="Optional conventional-commit scope."
+          style={{ width: 96 }}
+          data-testid="commit-scope"
+        />
+        {ticket && (
+          <PGButton
+            size="xs"
+            variant="outline"
+            icon="tag"
+            disabled={ticketPresent}
+            title={
+              ticketPresent
+                ? `${ticket} is already in the subject`
+                : `Insert ${ticket} — from the branch name`
+            }
+            onClick={insertTicket}
+            data-testid="commit-ticket"
+          >
+            {ticket}
+          </PGButton>
+        )}
+        {extra}
+      </div>
+
+      {templateUnreadable && (
+        <Advisory testId="commit-template-missing" tone="warn">
+          commit.template points at {templatePath ?? "a file"}, which could not
+          be read.
+        </Advisory>
+      )}
+      {/*
+        Only where stripping actually applies — which is the template path. A
+        message the user typed is `git commit -m`: `#123 fix the thing` is an
+        ordinary subject, it commits as written, and telling the user otherwise
+        would be worse than saying nothing.
+      */}
+      {strippingComments && droppedComments > 0 && (
+        <Advisory testId="commit-comment-notice">
+          {droppedComments} line{droppedComments !== 1 ? "s" : ""} starting with
+          {" "}
+          <code>{commentPrefix}</code> will be stripped, as git does from a
+          template.
+        </Advisory>
+      )}
+    </div>
+  );
+}
+
+/**
+ * A one-line note under the bar. Advisory in the strict sense: it never
+ * disables Commit, it only says what is about to happen.
+ */
+function Advisory({
+  children,
+  testId,
+  tone,
+}: {
+  children: React.ReactNode;
+  testId: string;
+  tone?: "warn";
+}) {
+  return (
+    <div
+      data-testid={testId}
+      style={{
+        fontSize: "var(--fs-10)",
+        fontFamily: "var(--font-mono)",
+        color: tone === "warn" ? "var(--git-modified)" : "var(--fg-3)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/features/commits/message/cleanup.test.ts
+++ b/src/features/commits/message/cleanup.test.ts
@@ -1,0 +1,212 @@
+// git's message cleanup, ported — and, more importantly, WHICH cleanup.
+//
+// Every expectation here was checked against real `git commit` (2.50) across
+// all five `--cleanup` modes, both `-m` and a scripted editor. That is the only
+// way to be sure, because the rules are not the obvious ones:
+//
+//   * `default` is context-sensitive. `git commit -m "#123 fix"` commits
+//     `#123 fix`; comments are stripped only when the message went through the
+//     editor. Our stand-in for "went through the editor" is `fromTemplate`.
+//   * a comment line is one whose FIRST character is the comment prefix.
+//     `  # indented` is NOT a comment and git commits it.
+//   * a `#` in the middle of a line is ordinary text.
+//   * the whitespace half applies in every mode but `verbatim`, `-m` included:
+//     trailing whitespace goes, runs of blank lines collapse to one, and
+//     leading/trailing blank lines vanish.
+//   * a comment line does not itself count as a blank line, so removing one
+//     from between two paragraphs does not open a gap.
+//   * scissors cuts in the EDITOR path only.
+import { describe, it, expect } from "vitest";
+import {
+  cleanupCommitMessage,
+  commentLineCount,
+  stripsComments,
+} from "./cleanup";
+
+/** The editor-path context: the box was seeded from `commit.template`. */
+const SEEDED = { fromTemplate: true } as const;
+
+describe("which cleanup applies", () => {
+  it("keeps comments for a message the user typed — this is `git commit -m`", () => {
+    // The whole point of scoping this. `#123` is an ordinary subject and a
+    // forge renders it as an issue link; stripping it would silently delete
+    // the user's words.
+    expect(cleanupCommitMessage("#123 fix the thing")).toBe("#123 fix the thing");
+    expect(stripsComments({})).toBe(false);
+  });
+
+  it("strips comments once the box came from commit.template", () => {
+    expect(cleanupCommitMessage("subject\n# a hint\n", SEEDED)).toBe("subject");
+    expect(stripsComments(SEEDED)).toBe(true);
+  });
+
+  it("honours an explicit commit.cleanup over the context either way", () => {
+    expect(cleanupCommitMessage("subject\n# a hint\n", { mode: "strip" })).toBe(
+      "subject",
+    );
+    expect(
+      cleanupCommitMessage("subject\n# a hint\n", { ...SEEDED, mode: "whitespace" }),
+    ).toBe("subject\n# a hint");
+    expect(stripsComments({ mode: "strip" })).toBe(true);
+    expect(stripsComments({ ...SEEDED, mode: "whitespace" })).toBe(false);
+  });
+
+  it("keeps comments, blank runs and trailing spaces in verbatim", () => {
+    const msg = "subject   \n\n\n\n# a comment\n\n\n";
+    // Only the terminating newline goes, which is this module's one deviation
+    // from git and applies in every mode — `buildMessage` trims the end on the
+    // way out anyway, so nothing observable changes.
+    const kept = "subject   \n\n\n\n# a comment";
+    expect(cleanupCommitMessage(msg, { mode: "verbatim" })).toBe(kept);
+    expect(cleanupCommitMessage(msg, { ...SEEDED, mode: "verbatim" })).toBe(kept);
+  });
+});
+
+describe("the comment rule, where it applies", () => {
+  it("drops a line that starts with the comment prefix", () => {
+    expect(
+      cleanupCommitMessage("feat: thing\n\n# please explain why\n", SEEDED),
+    ).toBe("feat: thing");
+  });
+
+  it("keeps a # that is not the first character of the line", () => {
+    // Stripping too much is as wrong as stripping too little.
+    expect(
+      cleanupCommitMessage("fix: crash\n\nCloses the #123 report\n", SEEDED),
+    ).toBe("fix: crash\n\nCloses the #123 report");
+  });
+
+  it("keeps an INDENTED comment line, exactly as git does", () => {
+    expect(cleanupCommitMessage("subject\n\n  # indented hash\n", SEEDED)).toBe(
+      "subject\n\n  # indented hash",
+    );
+  });
+
+  it("drops a subject that IS a comment — which is how git empties a message", () => {
+    expect(cleanupCommitMessage("#123 this is a comment line\n", SEEDED)).toBe("");
+  });
+
+  it("honours a different comment prefix", () => {
+    expect(
+      cleanupCommitMessage("subject\n; a hint\n#123 kept\n", {
+        ...SEEDED,
+        commentPrefix: ";",
+      }),
+    ).toBe("subject\n#123 kept");
+  });
+
+  it("honours a multi-character prefix (git 2.45 widened commentChar)", () => {
+    expect(
+      cleanupCommitMessage("subject\n// a hint\n", {
+        ...SEEDED,
+        commentPrefix: "//",
+      }),
+    ).toBe("subject");
+  });
+
+  it("falls back to # for an empty prefix rather than stripping everything", () => {
+    expect(
+      cleanupCommitMessage("subject\n# hint\n", { ...SEEDED, commentPrefix: "" }),
+    ).toBe("subject");
+  });
+
+  it("does not open a gap where a comment line used to be", () => {
+    // git's stripspace `continue`s past a comment WITHOUT counting it as an
+    // empty line, so two adjacent paragraphs stay adjacent.
+    expect(cleanupCommitMessage("line one\n# a note\nline two", SEEDED)).toBe(
+      "line one\nline two",
+    );
+  });
+
+  it("reduces an all-comment message to nothing", () => {
+    expect(cleanupCommitMessage("# one\n# two\n\n# three\n", SEEDED)).toBe("");
+  });
+});
+
+describe("the whitespace rules — every mode but verbatim, -m included", () => {
+  it("trims trailing whitespace from every line", () => {
+    expect(cleanupCommitMessage("subject   \n\nbody\t\n")).toBe("subject\n\nbody");
+  });
+
+  it("collapses a run of blank lines to one", () => {
+    expect(cleanupCommitMessage("subject\n\n\n\nbody\n")).toBe("subject\n\nbody");
+  });
+
+  it("drops leading and trailing blank lines", () => {
+    expect(cleanupCommitMessage("\n\n\nsubject\n\n\n")).toBe("subject");
+  });
+
+  it("treats a whitespace-only line as blank", () => {
+    expect(cleanupCommitMessage("subject\n   \n   \nbody")).toBe("subject\n\nbody");
+  });
+
+  it("leaves an already-clean message byte-for-byte alone", () => {
+    const msg = "feat: thing\n\nWhy: because.\nAlso: this.";
+    expect(cleanupCommitMessage(msg)).toBe(msg);
+    expect(cleanupCommitMessage(msg, SEEDED)).toBe(msg);
+  });
+
+  it("still applies when comments are being kept", () => {
+    expect(cleanupCommitMessage("#123 subject   \n\n\n\nbody\n")).toBe(
+      "#123 subject\n\nbody",
+    );
+  });
+});
+
+describe("scissors", () => {
+  const MSG =
+    "subject\n# a comment\nbody\n\n# ------------------------ >8 ------------------------\ncut me\n";
+
+  it("cuts at the scissors line in the editor path", () => {
+    expect(cleanupCommitMessage(MSG, { ...SEEDED, mode: "scissors" })).toBe(
+      "subject\n# a comment\nbody",
+    );
+  });
+
+  it("does NOT cut for a message the user typed — matching `-m`", () => {
+    // Verified: `git commit --cleanup=scissors -m …` leaves the line alone.
+    expect(cleanupCommitMessage(MSG, { mode: "scissors" })).toBe(
+      "subject\n# a comment\nbody\n\n# ------------------------ >8 ------------------------\ncut me",
+    );
+  });
+
+  it("empties a message that opens with the scissors line", () => {
+    expect(
+      cleanupCommitMessage(
+        "# ------------------------ >8 ------------------------\nall of it\n",
+        { ...SEEDED, mode: "scissors" },
+      ),
+    ).toBe("");
+  });
+
+  it("needs the marker to end a line, as git does", () => {
+    const noNewline =
+      "subject\n# ------------------------ >8 ------------------------";
+    expect(cleanupCommitMessage(noNewline, { ...SEEDED, mode: "scissors" })).toBe(
+      noNewline,
+    );
+  });
+
+  it("uses the repository's comment prefix for the marker", () => {
+    expect(
+      cleanupCommitMessage(
+        "subject\n; ------------------------ >8 ------------------------\ncut\n",
+        { ...SEEDED, mode: "scissors", commentPrefix: ";" },
+      ),
+    ).toBe("subject");
+  });
+});
+
+describe("commentLineCount", () => {
+  it("counts what a strip cleanup would silently drop", () => {
+    expect(commentLineCount("subject\n# a\n# b\nbody\n")).toBe(2);
+  });
+
+  it("counts nothing when nothing would be dropped", () => {
+    expect(commentLineCount("subject\n\nrefs #12\n")).toBe(0);
+  });
+
+  it("uses the repository's own prefix", () => {
+    expect(commentLineCount("subject\n; a\n# b\n", ";")).toBe(1);
+  });
+});

--- a/src/features/commits/message/cleanup.ts
+++ b/src/features/commits/message/cleanup.ts
@@ -1,0 +1,161 @@
+// git's own commit-message cleanup, ported (#252) — including WHICH cleanup.
+//
+// git has five cleanup modes and the default one is context-sensitive:
+//
+//   verbatim    nothing is touched.
+//   whitespace  trailing whitespace goes, blank runs collapse, leading and
+//               trailing blanks go. Comment lines are KEPT.
+//   strip       whitespace, plus every comment line removed.
+//   scissors    whitespace, plus — in the editor path only — everything from
+//               the scissors line down is cut.
+//   default     `strip` if the message is to be EDITED, `whitespace` otherwise.
+//
+// That last line is the whole subtlety. `git commit -m "#123 fix the thing"`
+// commits `#123 fix the thing`: comments are stripped only when the message
+// passed through the editor, which is the only context where git (or a
+// template) put `#` lines into the buffer unasked.
+//
+// Our textarea is much closer to `-m` than to the editor — we never append
+// status comments — EXCEPT when `commit.template` has just seeded it. That is
+// exactly the editor's situation, and those comments must go. So one flag,
+// `fromTemplate`, stands in for git's "is the message to be edited", and it
+// drives both halves: what `default` means, and whether `scissors` cuts.
+//
+// This is the frontend's copy on purpose: the composer shows what will be
+// removed BEFORE anyone presses Commit, and gates the Commit button on the
+// CLEANED text, so a message that is nothing but comments cannot become an
+// empty commit message. One implementation serves the preview and the send.
+//
+// Every rule below was checked against real `git commit` (2.50) — all five
+// modes, `-m` and a scripted editor — rather than read off the documentation.
+
+// ONE definition of the mode set, at the IPC boundary where it mirrors the Rust
+// enum — re-exported rather than restated, so the two cannot drift apart.
+import type { CleanupMode } from "@/lib/types";
+
+export type { CleanupMode };
+
+/** git's default, and what `core.commentChar` falls back to. */
+export const DEFAULT_COMMENT_PREFIX = "#";
+
+/** The line `--cleanup=scissors` cuts at, after the comment prefix and a space. */
+const SCISSORS = "------------------------ >8 ------------------------";
+
+/**
+ * Every character C's `isspace()` treats as whitespace, which is what git's
+ * per-line trim uses. Deliberately NOT `\s`: JavaScript's `\s` also matches
+ * NBSP and the Unicode spaces, and trimming those would remove bytes git keeps.
+ */
+const TRAILING_WS = /[ \t\r\f\v]+$/;
+
+export interface CleanupSpec {
+  /** `commit.cleanup`. Defaults to git's own default. */
+  mode?: CleanupMode;
+  /** `core.commentChar`, already resolved (`auto` included). */
+  commentPrefix?: string;
+  /**
+   * Whether the text in the box came from `commit.template`.
+   *
+   * This is our stand-in for git's "the message is to be edited": it is true in
+   * exactly the case where comment lines arrived in the buffer without the user
+   * putting them there. A message the user typed themselves is treated like
+   * `git commit -m`, so a `#123 fix the thing` subject survives.
+   */
+  fromTemplate?: boolean;
+}
+
+/** `default` resolved against the context; every other mode passes through. */
+function resolveMode(spec: CleanupSpec): Exclude<CleanupMode, "default"> {
+  const mode = spec.mode ?? "default";
+  if (mode !== "default") return mode;
+  return spec.fromTemplate ? "strip" : "whitespace";
+}
+
+/**
+ * Whether this cleanup will remove comment lines — what the composer's advisory
+ * and its empty-message check both key on.
+ */
+export function stripsComments(spec: CleanupSpec = {}): boolean {
+  return resolveMode(spec) === "strip";
+}
+
+/**
+ * The message git would actually store, given this text and this context.
+ *
+ * The whitespace half is faithful to `strbuf_stripspace()`:
+ *   - each surviving line loses its trailing whitespace;
+ *   - runs of blank lines collapse to one; leading and trailing blanks go.
+ *
+ * The comment half (mode `strip` only):
+ *   - a line whose FIRST character begins `commentPrefix` is removed entirely.
+ *     Leading whitespace disqualifies it — git commits `  # indented`, and so
+ *     do we — and a `#` anywhere but position 0 is ordinary text;
+ *   - a removed comment line is not counted as a blank line, so deleting one
+ *     from between two paragraphs does not open a gap.
+ *
+ * The one deviation from git: git terminates a non-empty result with a newline.
+ * We do not, because the backend stores the message verbatim and every other
+ * producer in the composer (`buildMessage`'s `trimEnd`, the trailer block)
+ * already works in unterminated text — adding one here would change the bytes
+ * of every commit the app writes without changing what anybody reads.
+ */
+export function cleanupCommitMessage(text: string, spec: CleanupSpec = {}): string {
+  const prefix = spec.commentPrefix || DEFAULT_COMMENT_PREFIX;
+  const mode = resolveMode(spec);
+  // Verbatim keeps every comment, every blank run and every trailing space —
+  // only the terminating newline goes, so the "no trailing newline" deviation
+  // below holds in EVERY mode rather than in four of five. Costs nothing:
+  // `buildMessage` trims the end of the message on the way out regardless.
+  if (mode === "verbatim") return text.replace(/\n+$/, "");
+  // Scissors cuts in the EDITOR path only — verified: `git commit --cleanup=
+  // scissors -m …` leaves a scissors line in the message untouched. Our
+  // editor-path equivalent is a buffer that came from the template.
+  const body =
+    mode === "scissors" && spec.fromTemplate ? truncateAtScissors(text, prefix) : text;
+  return stripspace(body, mode === "strip" ? prefix : null);
+}
+
+/** How many lines a `strip` cleanup would drop as comments. */
+export function commentLineCount(
+  text: string,
+  commentPrefix: string = DEFAULT_COMMENT_PREFIX,
+): number {
+  const prefix = commentPrefix || DEFAULT_COMMENT_PREFIX;
+  let n = 0;
+  for (const line of text.split("\n")) if (line.startsWith(prefix)) n += 1;
+  return n;
+}
+
+/** `strbuf_stripspace()`. A null `commentPrefix` keeps comment lines. */
+function stripspace(text: string, commentPrefix: string | null): string {
+  const out: string[] = [];
+  let pendingBlank = false;
+  for (const raw of text.split("\n")) {
+    if (commentPrefix !== null && raw.startsWith(commentPrefix)) continue;
+    const line = raw.replace(TRAILING_WS, "");
+    if (line === "") {
+      // Blank lines before anything has been emitted are dropped outright;
+      // otherwise one blank is held back and flushed if more text follows.
+      pendingBlank = out.length > 0;
+      continue;
+    }
+    if (pendingBlank) out.push("");
+    pendingBlank = false;
+    out.push(line);
+  }
+  return out.join("\n");
+}
+
+/**
+ * `wt_status_locate_end()`: cut at the first `<prefix> ---…--- >8 ---…---`
+ * line, keeping everything above it.
+ *
+ * The marker has to be followed by a newline — a scissors line at the very end
+ * with nothing after it is not one, which is git's rule and not an oversight.
+ */
+function truncateAtScissors(text: string, prefix: string): string {
+  const marker = `${prefix} ${SCISSORS}\n`;
+  if (text.startsWith(marker)) return "";
+  const at = text.indexOf(`\n${marker}`);
+  return at === -1 ? text : text.slice(0, at + 1);
+}

--- a/src/features/commits/message/index.ts
+++ b/src/features/commits/message/index.ts
@@ -1,0 +1,27 @@
+// The commit-message composition surface (#252). See useCommitComposer.ts for
+// what belongs here and why it is one surface rather than four widgets.
+export { CommitMessageBar } from "./CommitMessageBar";
+export type { CommitMessageBarProps } from "./CommitMessageBar";
+export {
+  SUBJECT_LIMIT,
+  SUBJECT_SOFT_LIMIT,
+  useCommitComposer,
+} from "./useCommitComposer";
+export type { CommitComposer, UseCommitComposerOptions } from "./useCommitComposer";
+export {
+  cleanupCommitMessage,
+  commentLineCount,
+  stripsComments,
+  DEFAULT_COMMENT_PREFIX,
+} from "./cleanup";
+export type { CleanupMode, CleanupSpec } from "./cleanup";
+export { DEFAULT_TICKET_PATTERN, extractTicket, isValidTicketPattern } from "./ticket";
+export {
+  CONVENTIONAL_TYPES,
+  insertTicket,
+  parseConventionalPrefix,
+  subjectNamesTicket,
+  subjectOf,
+  withConventionalPrefix,
+} from "./subject";
+export type { ConventionalPrefix } from "./subject";

--- a/src/features/commits/message/subject.test.ts
+++ b/src/features/commits/message/subject.test.ts
@@ -1,0 +1,163 @@
+// The subject line, and the two things that get composed onto it (#252): a
+// conventional-commit `type(scope):` prefix and a ticket key.
+//
+// Everything here is a rewrite of PLAIN TEXT in the one message box. There is
+// no structured draft behind the textarea and no second storage format — the
+// picker reads the subject back out on every render, so typing `feat: x` by
+// hand selects "feat" in the picker, and clearing the picker gives the typed
+// text back rather than a form's idea of it.
+import { describe, it, expect } from "vitest";
+import {
+  CONVENTIONAL_TYPES,
+  insertTicket,
+  parseConventionalPrefix,
+  subjectOf,
+  withConventionalPrefix,
+} from "./subject";
+
+describe("subjectOf", () => {
+  it("is the first line, body or no body", () => {
+    expect(subjectOf("feat: thing")).toBe("feat: thing");
+    expect(subjectOf("feat: thing\n\nbody\nmore")).toBe("feat: thing");
+    expect(subjectOf("")).toBe("");
+  });
+});
+
+describe("parseConventionalPrefix", () => {
+  it("reads a bare type", () => {
+    expect(parseConventionalPrefix("feat: add a thing")).toEqual({
+      type: "feat",
+      scope: "",
+      breaking: false,
+      rest: "add a thing",
+    });
+  });
+
+  it("reads a scope", () => {
+    expect(parseConventionalPrefix("fix(commit): stop the crash")).toEqual({
+      type: "fix",
+      scope: "commit",
+      breaking: false,
+      rest: "stop the crash",
+    });
+  });
+
+  it("reads the breaking-change marker without offering to set it", () => {
+    // Parsed so a picker change PRESERVES it. The `!` toggle itself is out of
+    // scope for this change — see the issue: a mandatory form here would be
+    // worse than nothing.
+    expect(parseConventionalPrefix("feat(api)!: drop v1")).toEqual({
+      type: "feat",
+      scope: "api",
+      breaking: true,
+      rest: "drop v1",
+    });
+  });
+
+  it("reads a type nobody standardised", () => {
+    expect(parseConventionalPrefix("wip: halfway")?.type).toBe("wip");
+  });
+
+  it("returns null for prose that merely contains a colon", () => {
+    expect(parseConventionalPrefix("Merge branch 'x': tidy up")).toBeNull();
+    expect(parseConventionalPrefix("See also: the README")).toBeNull();
+    expect(parseConventionalPrefix("just a subject")).toBeNull();
+  });
+
+  it("returns null for a nested-paren scope it cannot round-trip", () => {
+    expect(parseConventionalPrefix("feat(a(b)): thing")).toBeNull();
+  });
+
+  it("reads a half-typed prefix, so the picker is right while you type", () => {
+    expect(parseConventionalPrefix("feat:")).toEqual({
+      type: "feat",
+      scope: "",
+      breaking: false,
+      rest: "",
+    });
+  });
+
+  it("ships the conventional set the picker offers", () => {
+    expect(CONVENTIONAL_TYPES).toContain("feat");
+    expect(CONVENTIONAL_TYPES).toContain("fix");
+    expect(CONVENTIONAL_TYPES).toContain("chore");
+  });
+});
+
+describe("withConventionalPrefix", () => {
+  it("prefixes a plain subject", () => {
+    expect(withConventionalPrefix("add a thing", "feat", "")).toBe(
+      "feat: add a thing",
+    );
+  });
+
+  it("adds a scope", () => {
+    expect(withConventionalPrefix("add a thing", "feat", "commit")).toBe(
+      "feat(commit): add a thing",
+    );
+  });
+
+  it("replaces an existing prefix instead of stacking one", () => {
+    expect(withConventionalPrefix("feat(a): thing", "fix", "b")).toBe(
+      "fix(b): thing",
+    );
+  });
+
+  it("keeps the breaking marker across a type change", () => {
+    expect(withConventionalPrefix("feat(api)!: drop v1", "fix", "api")).toBe(
+      "fix(api)!: drop v1",
+    );
+  });
+
+  it("removes the prefix when the type is cleared", () => {
+    expect(withConventionalPrefix("feat(a): thing", "", "")).toBe("thing");
+  });
+
+  it("leaves the body untouched", () => {
+    expect(
+      withConventionalPrefix("add a thing\n\nWhy: because.", "feat", ""),
+    ).toBe("feat: add a thing\n\nWhy: because.");
+  });
+
+  it("composes onto an empty box, ready to type into", () => {
+    expect(withConventionalPrefix("", "feat", "")).toBe("feat: ");
+    expect(withConventionalPrefix("", "feat", "ui")).toBe("feat(ui): ");
+  });
+
+  it("does not touch prose that looked like a prefix but is not", () => {
+    expect(withConventionalPrefix("See also: the README", "docs", "")).toBe(
+      "docs: See also: the README",
+    );
+  });
+});
+
+describe("insertTicket", () => {
+  it("puts the ticket at the front of a plain subject", () => {
+    expect(insertTicket("do the thing", "PROJ-1")).toBe("PROJ-1 do the thing");
+  });
+
+  it("goes AFTER a conventional prefix, not in front of it", () => {
+    // `PROJ-1 feat: thing` is not a conventional commit; `feat: PROJ-1 thing`
+    // is, and it is what commitlint accepts.
+    expect(insertTicket("feat(ui): thing", "PROJ-1")).toBe(
+      "feat(ui): PROJ-1 thing",
+    );
+  });
+
+  it("is a no-op when the subject already names the ticket", () => {
+    expect(insertTicket("feat: PROJ-1 thing", "PROJ-1")).toBe(
+      "feat: PROJ-1 thing",
+    );
+    expect(insertTicket("PROJ-1 thing", "PROJ-1")).toBe("PROJ-1 thing");
+  });
+
+  it("seeds an empty box", () => {
+    expect(insertTicket("", "PROJ-1")).toBe("PROJ-1 ");
+  });
+
+  it("leaves the body alone, and does not match a ticket found only there", () => {
+    expect(insertTicket("thing\n\nRefs PROJ-1", "PROJ-1")).toBe(
+      "PROJ-1 thing\n\nRefs PROJ-1",
+    );
+  });
+});

--- a/src/features/commits/message/subject.ts
+++ b/src/features/commits/message/subject.ts
@@ -1,0 +1,119 @@
+// The subject line, and the two things composed onto it (#252): a
+// conventional-commit `type(scope):` prefix and a ticket key.
+//
+// The message box holds plain text and nothing else. There is no structured
+// draft behind it: the type picker PARSES the subject on every render and
+// rewrites it on change, so typing `feat: x` by hand selects "feat" in the
+// picker, clearing the picker hands the typed text back, and free typing keeps
+// working exactly as it did. The issue is explicit that it must — "a mandatory
+// form here would be worse than nothing".
+
+/** The types conventionalcommits.org names, plus the two the Angular set adds. */
+export const CONVENTIONAL_TYPES = [
+  "feat",
+  "fix",
+  "docs",
+  "style",
+  "refactor",
+  "perf",
+  "test",
+  "build",
+  "ci",
+  "chore",
+  "revert",
+] as const;
+
+export interface ConventionalPrefix {
+  type: string;
+  /** The `(scope)`, without parentheses. Empty when there is none. */
+  scope: string;
+  /** The `!` breaking-change marker. Parsed so a type change PRESERVES it. */
+  breaking: boolean;
+  /** The subject with the prefix removed. */
+  rest: string;
+}
+
+/**
+ * `type(scope)!: rest`, or `null` when the subject is not one.
+ *
+ * The type is a single word — deliberately no space allowed — which is what
+ * keeps prose out: `Merge branch 'x': tidy` and `See also: the README` both
+ * have a space before the colon and are left alone. A scope containing
+ * parentheses is refused too, because it could not be written back out
+ * unambiguously.
+ */
+export function parseConventionalPrefix(subject: string): ConventionalPrefix | null {
+  const m = /^([A-Za-z][A-Za-z0-9]*)(?:\(([^()]*)\))?(!?):(?: (.*))?$/.exec(subject);
+  if (!m) return null;
+  return {
+    type: m[1],
+    scope: m[2] ?? "",
+    breaking: m[3] === "!",
+    rest: m[4] ?? "",
+  };
+}
+
+/** The first line of a message. */
+export function subjectOf(message: string): string {
+  return message.split("\n", 1)[0];
+}
+
+/** A message with its first line replaced, body untouched. */
+function withSubject(message: string, subject: string): string {
+  const nl = message.indexOf("\n");
+  return nl === -1 ? subject : subject + message.slice(nl);
+}
+
+/**
+ * Rewrite the subject's conventional prefix.
+ *
+ * An empty `type` REMOVES the prefix and gives back what was after it, which is
+ * why the picker having a blank option is safe: it can always be undone by
+ * re-picking. An existing `!` survives a type or scope change — this feature
+ * does not offer that toggle, and silently dropping a marker the user typed
+ * would be the worst of both.
+ */
+export function withConventionalPrefix(
+  message: string,
+  type: string,
+  scope: string,
+): string {
+  const subject = subjectOf(message);
+  const parsed = parseConventionalPrefix(subject);
+  const base = parsed ? parsed.rest : subject;
+  if (!type) return withSubject(message, base);
+  const bang = parsed?.breaking ? "!" : "";
+  const scoped = scope ? `(${scope})` : "";
+  return withSubject(message, `${type}${scoped}${bang}: ${base}`);
+}
+
+/**
+ * Put `ticket` at the front of the subject — after any conventional prefix.
+ *
+ * `PROJ-1 feat: thing` is not a conventional commit and commitlint rejects it;
+ * `feat: PROJ-1 thing` is one and it does not. A subject that already names the
+ * ticket is returned unchanged, so the affordance is idempotent; the BODY is
+ * not searched, because a `Refs PROJ-1` trailer is not the same claim as a
+ * subject prefix.
+ */
+export function insertTicket(message: string, ticket: string): string {
+  const subject = subjectOf(message);
+  if (subjectNamesTicket(subject, ticket)) return message;
+  const parsed = parseConventionalPrefix(subject);
+  if (!parsed) return withSubject(message, joinTicket(ticket, subject));
+  const scoped = parsed.scope ? `(${parsed.scope})` : "";
+  const bang = parsed.breaking ? "!" : "";
+  return withSubject(
+    message,
+    `${parsed.type}${scoped}${bang}: ${joinTicket(ticket, parsed.rest)}`,
+  );
+}
+
+/** Whether the subject already carries this ticket — the chip's disable rule. */
+export function subjectNamesTicket(subject: string, ticket: string): boolean {
+  return subject.includes(ticket);
+}
+
+function joinTicket(ticket: string, rest: string): string {
+  return rest ? `${ticket} ${rest}` : `${ticket} `;
+}

--- a/src/features/commits/message/ticket.test.ts
+++ b/src/features/commits/message/ticket.test.ts
@@ -1,0 +1,81 @@
+// Ticket / issue prefix derived from the branch name (#252).
+//
+// The default pattern is deliberately UPPERCASE-only. A permissive
+// `[A-Za-z][A-Za-z0-9]+-\d+` matches `fix-404` in `feature/fix-404-page` and
+// `add-2` in `feat/add-2fa-login`, and a one-click insert that offers garbage
+// is worse than one that offers nothing. Teams whose branches carry lowercase
+// keys change the pattern; the cost of being wrong runs the other way.
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_TICKET_PATTERN,
+  extractTicket,
+  isValidTicketPattern,
+} from "./ticket";
+
+describe("extractTicket with the default pattern", () => {
+  it.each([
+    ["feat/PROJ-123-thing", "PROJ-123"],
+    ["PROJ-123", "PROJ-123"],
+    ["bugfix/ABC-7", "ABC-7"],
+    ["users/ada/DEV-1042-retry-logic", "DEV-1042"],
+    ["release/PLAT-99/hotfix", "PLAT-99"],
+    ["feat/AB1-23-mixed-key", "AB1-23"],
+  ])("finds a ticket in %s", (branch, ticket) => {
+    expect(extractTicket(branch)).toBe(ticket);
+  });
+
+  it.each([
+    ["feat/add-commit-help"],
+    ["main"],
+    ["feature/fix-404-page"],
+    ["feat/add-2fa-login"],
+    ["chore/bump-deps-2026"],
+  ])("finds nothing in %s", (branch) => {
+    expect(extractTicket(branch)).toBeNull();
+  });
+
+  it("has nothing to offer on a detached HEAD", () => {
+    expect(extractTicket(null)).toBeNull();
+    expect(extractTicket(undefined)).toBeNull();
+    expect(extractTicket("")).toBeNull();
+  });
+
+  it("takes the first match when a branch names two tickets", () => {
+    expect(extractTicket("feat/PROJ-1-and-PROJ-2")).toBe("PROJ-1");
+  });
+});
+
+describe("extractTicket with a custom pattern", () => {
+  it("uses capture group 1 when the pattern has one", () => {
+    // Lets a team match around the ticket without inserting the surroundings.
+    expect(extractTicket("issue-42-do-the-thing", "issue-(\\d+)")).toBe("42");
+  });
+
+  it("uses the whole match when the pattern has no group", () => {
+    expect(extractTicket("gh-777-fix", "gh-\\d+")).toBe("gh-777");
+  });
+
+  it("survives a pattern that is not a valid regex", () => {
+    // A half-typed pattern in Settings must not take the commit screen down.
+    expect(extractTicket("feat/PROJ-1", "([unclosed")).toBeNull();
+  });
+
+  it("treats an empty pattern as no pattern", () => {
+    expect(extractTicket("feat/PROJ-1", "")).toBeNull();
+    expect(extractTicket("feat/PROJ-1", "   ")).toBeNull();
+  });
+});
+
+describe("isValidTicketPattern", () => {
+  it("accepts the default", () => {
+    expect(isValidTicketPattern(DEFAULT_TICKET_PATTERN)).toBe(true);
+  });
+
+  it("rejects a pattern that will not compile", () => {
+    expect(isValidTicketPattern("([unclosed")).toBe(false);
+  });
+
+  it("accepts an empty pattern — that is 'off', not 'broken'", () => {
+    expect(isValidTicketPattern("")).toBe(true);
+  });
+});

--- a/src/features/commits/message/ticket.ts
+++ b/src/features/commits/message/ticket.ts
@@ -1,0 +1,52 @@
+// Ticket / issue key derived from the branch name (#252).
+//
+// Offered as a one-click insert, never applied automatically: a branch name is
+// a guess about intent, and a guess does not get to write in the message box.
+
+/**
+ * Jira / Linear / YouTrack shape: an uppercase project key, a hyphen, a number.
+ *
+ * UPPERCASE deliberately. The permissive `[A-Za-z][A-Za-z0-9]+-\d+` also matches
+ * `fix-404` in `feature/fix-404-page` and `add-2` in `feat/add-2fa-login`, and a
+ * chip offering `add-2` as your ticket is worse than no chip at all. A team whose
+ * branches carry lowercase keys edits the pattern; a team using words with
+ * numbers in them cannot edit their way out of a false positive.
+ */
+export const DEFAULT_TICKET_PATTERN = "[A-Z][A-Z0-9]+-\\d+";
+
+/** Whether a pattern compiles. An empty pattern is "off", not "broken". */
+export function isValidTicketPattern(pattern: string): boolean {
+  if (pattern.trim() === "") return true;
+  try {
+    new RegExp(pattern);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The ticket a branch name carries, or `null`.
+ *
+ * Capture group 1 wins when the pattern has one, so `issue-(\d+)` can match
+ * around the ticket and still insert only the ticket. A pattern that does not
+ * compile — a half-typed one in Settings — yields `null` rather than throwing:
+ * this runs on every keystroke in the commit box.
+ */
+export function extractTicket(
+  branch: string | null | undefined,
+  pattern: string = DEFAULT_TICKET_PATTERN,
+): string | null {
+  if (!branch) return null;
+  if (pattern.trim() === "") return null;
+  let re: RegExp;
+  try {
+    re = new RegExp(pattern);
+  } catch {
+    return null;
+  }
+  const m = re.exec(branch);
+  if (!m) return null;
+  const found = m[1] ?? m[0];
+  return found ? found : null;
+}

--- a/src/features/commits/message/useCommitComposer.ts
+++ b/src/features/commits/message/useCommitComposer.ts
@@ -1,0 +1,274 @@
+// THE commit-message composition surface (#252).
+//
+// One hook and one bar, not four widgets sprinkled through CommitPanel. The
+// four things this feature added — `commit.template` pre-fill, comment
+// stripping, a ticket chip, a conventional-commit type picker — all read and
+// rewrite the SAME plain-text box, so they share one place to live and one
+// contract with the screen:
+//
+//     const composer = useCommitComposer({ repoId, branch, message, setMessage, amend });
+//     <CommitMessageBar composer={composer} extra={…} />
+//
+// The next feature to compose commit-message text (#250, AI-assisted drafts)
+// belongs HERE — a field on `CommitComposer` and an affordance in the bar's
+// `extra` slot — rather than as a second surface growing beside this one. The
+// issue's own comment is explicit that whichever landed first should own it.
+//
+// Two invariants everything here obeys:
+//   * the textarea is the single source of truth. The picker parses the subject
+//     back out on every render; nothing keeps a structured draft on the side.
+//   * nothing overwrites text the user has already typed.
+
+import React from "react";
+
+import { getCommitTemplate } from "@/lib/tauri";
+import type { CommitTemplate } from "@/lib/types";
+import type { PGSelectOption } from "@/design";
+
+import {
+  cleanupCommitMessage,
+  commentLineCount,
+  stripsComments,
+  DEFAULT_COMMENT_PREFIX,
+  type CleanupSpec,
+} from "./cleanup";
+import { extractTicket } from "./ticket";
+import {
+  CONVENTIONAL_TYPES,
+  insertTicket as insertTicketInto,
+  parseConventionalPrefix,
+  subjectNamesTicket,
+  subjectOf,
+  withConventionalPrefix,
+} from "./subject";
+
+/** The hard convention. Advisory — nothing in the app enforces it. */
+export const SUBJECT_LIMIT = 72;
+/** The softer one everybody also quotes, used only to warn earlier. */
+export const SUBJECT_SOFT_LIMIT = 50;
+
+export interface CommitComposer {
+  /** Where `commit.template` pointed, when it is set. For naming it on screen. */
+  templatePath: string | null;
+  /** `commit.template` is set but its file could not be read. */
+  templateUnreadable: boolean;
+  /**
+   * Put the template back in the box. Called by the screen immediately after a
+   * commit has cleared it — `git commit` re-applies the template on every
+   * commit, and a template that appears once is a template that does not work.
+   *
+   * Unlike the load-time seed this does NOT check whether the box is empty: the
+   * caller has just emptied it, and React has not re-rendered yet, so the
+   * hook's own view of the message is a render behind. The contract is in the
+   * name — only call it having just cleared the box.
+   */
+  reseed: () => void;
+
+  /** `core.commentChar` for this repo, `auto` already resolved. */
+  commentPrefix: string;
+  /** What a commit would actually store: git's cleanup applied to the box. */
+  cleaned: string;
+  /**
+   * Whether this cleanup removes comment lines at all.
+   *
+   * False for a message the user typed — that is `git commit -m`, where `#123
+   * fix the thing` is an ordinary subject and a forge renders it as an issue
+   * link. True once `commit.template` has seeded the box, which is git's
+   * editor path and the only place `#` lines arrive unasked.
+   */
+  strippingComments: boolean;
+  /**
+   * How many comment lines the cleanup drops — 0 whenever it drops none,
+   * including when it is not stripping at all. Shown, never hidden.
+   */
+  droppedComments: number;
+
+  /** The ticket the branch name carries, or null. */
+  ticket: string | null;
+  /** The subject already names it, so the chip has nothing left to do. */
+  ticketPresent: boolean;
+  insertTicket: () => void;
+
+  /** The subject's current conventional type — PARSED, not stored. */
+  type: string;
+  scope: string;
+  /** The conventional set, plus whatever type the subject already carries. */
+  typeOptions: PGSelectOption[];
+  setType: (t: string) => void;
+  setScope: (s: string) => void;
+
+  subjectLength: number;
+}
+
+export interface UseCommitComposerOptions {
+  repoId: string | null;
+  /** HEAD's branch name, for the ticket. Null on a detached HEAD. */
+  branch: string | null;
+  /** The regex that finds a ticket in the branch name. */
+  ticketPattern: string;
+  message: string;
+  setMessage: (m: string) => void;
+  /**
+   * Amend prefills the box from HEAD. The template must never race that — the
+   * message being rewritten is the one that already exists.
+   */
+  amend: boolean;
+}
+
+/**
+ * The template body worth seeding with, or null. A whitespace-only template
+ * would look like a no-op that ate the box.
+ */
+function seedBody(t: CommitTemplate | null): string | null {
+  const body = t?.body;
+  return body && body.trim() !== "" ? body : null;
+}
+
+export function useCommitComposer({
+  repoId,
+  branch,
+  ticketPattern,
+  message,
+  setMessage,
+  amend,
+}: UseCommitComposerOptions): CommitComposer {
+  const [template, setTemplate] = React.useState<CommitTemplate | null>(null);
+  // Our stand-in for git's "is the message to be edited": true once the box's
+  // text came from `commit.template`, which is the only way `#` lines get into
+  // it without the user typing them. Deliberately NOT cleared when the user
+  // edits or even wipes the box — git resolves this once, for the whole editor
+  // session, and a template session that silently changes mode halfway would be
+  // the harder behaviour to reason about.
+  const [fromTemplate, setFromTemplate] = React.useState(false);
+
+  // Read through refs inside the seed so the seeding effect depends on the
+  // REPOSITORY, not on every keystroke: an effect that re-ran on `message`
+  // would re-seed the moment someone cleared the box under their own cursor.
+  const messageRef = React.useRef(message);
+  messageRef.current = message;
+  const amendRef = React.useRef(amend);
+  amendRef.current = amend;
+  const setMessageRef = React.useRef(setMessage);
+  setMessageRef.current = setMessage;
+  const templateRef = React.useRef<CommitTemplate | null>(null);
+
+  const seed = React.useCallback((t: CommitTemplate | null) => {
+    const body = seedBody(t);
+    if (!body) return;
+    // Never over an existing draft, and never while amending — the message
+    // being amended is the one that already exists.
+    if (amendRef.current) return;
+    if (messageRef.current.trim() !== "") return;
+    setMessageRef.current(body);
+    setFromTemplate(true);
+  }, []);
+
+  React.useEffect(() => {
+    // A different repository is a different template and a different answer to
+    // "did this text come from one".
+    setFromTemplate(false);
+    if (!repoId) {
+      templateRef.current = null;
+      setTemplate(null);
+      return;
+    }
+    let alive = true;
+    void getCommitTemplate(repoId)
+      .then((t) => {
+        if (!alive) return;
+        templateRef.current = t;
+        setTemplate(t);
+        seed(t);
+      })
+      .catch(() => {
+        // A repository whose template cannot even be ASKED about still gets a
+        // working commit screen. `unreadable` covers the case worth reporting
+        // (a configured template that is not there); a failed command is a
+        // backend problem the rest of the screen will already be shouting about.
+        if (!alive) return;
+        templateRef.current = null;
+        setTemplate(null);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [repoId, seed]);
+
+  const reseed = React.useCallback(() => {
+    const body = seedBody(templateRef.current);
+    if (!body) return;
+    setMessageRef.current(body);
+    setFromTemplate(true);
+  }, []);
+
+  const commentPrefix = template?.commentPrefix || DEFAULT_COMMENT_PREFIX;
+  const spec = React.useMemo<CleanupSpec>(
+    () => ({ mode: template?.cleanup ?? "default", commentPrefix, fromTemplate }),
+    [template?.cleanup, commentPrefix, fromTemplate],
+  );
+  const cleaned = React.useMemo(
+    () => cleanupCommitMessage(message, spec),
+    [message, spec],
+  );
+  const strippingComments = stripsComments(spec);
+  const droppedComments = React.useMemo(
+    () => (strippingComments ? commentLineCount(message, commentPrefix) : 0),
+    [strippingComments, message, commentPrefix],
+  );
+
+  const subject = subjectOf(message);
+  const parsed = React.useMemo(() => parseConventionalPrefix(subject), [subject]);
+  const type = parsed?.type ?? "";
+  const scope = parsed?.scope ?? "";
+
+  const typeOptions = React.useMemo<PGSelectOption[]>(() => {
+    const base: PGSelectOption[] = CONVENTIONAL_TYPES.map((t) => ({
+      value: t,
+      label: t,
+    }));
+    // A subject already reading `wip: …` must not make the picker claim there
+    // is no type — the control would then be lying about the text it edits.
+    if (type && !CONVENTIONAL_TYPES.includes(type as (typeof CONVENTIONAL_TYPES)[number])) {
+      base.push({ value: type, label: type });
+    }
+    return [{ value: "", label: "type…" }, ...base];
+  }, [type]);
+
+  const setType = React.useCallback(
+    (t: string) => setMessage(withConventionalPrefix(message, t, scope)),
+    [message, scope, setMessage],
+  );
+  const setScope = React.useCallback(
+    (s: string) => setMessage(withConventionalPrefix(message, type, s)),
+    [message, type, setMessage],
+  );
+
+  const ticket = React.useMemo(
+    () => extractTicket(branch, ticketPattern),
+    [branch, ticketPattern],
+  );
+  const ticketPresent = !!ticket && subjectNamesTicket(subject, ticket);
+  const insertTicket = React.useCallback(() => {
+    if (!ticket) return;
+    setMessage(insertTicketInto(message, ticket));
+  }, [message, setMessage, ticket]);
+
+  return {
+    templatePath: template?.path ?? null,
+    templateUnreadable: !!template?.unreadable,
+    reseed,
+    commentPrefix,
+    cleaned,
+    strippingComments,
+    droppedComments,
+    ticket,
+    ticketPresent,
+    insertTicket,
+    type,
+    scope,
+    typeOptions,
+    setType,
+    setScope,
+    subjectLength: subject.length,
+  };
+}

--- a/src/features/settings/useSettingsStore.export.test.ts
+++ b/src/features/settings/useSettingsStore.export.test.ts
@@ -54,6 +54,10 @@ const PORTABLE = [
   "autoFetchEnabled",
   "autoFetchMinutes",
   "autoStashBeforePull",
+  // The branch-name → ticket regex (#252). Portable: it describes a TEAM's
+  // ticket convention, which is exactly the kind of thing a settings file is
+  // carried between machines to keep in step.
+  "commitTicketPattern",
   "confirmForcePush",
   "customThemes",
   "defaultPullMode",
@@ -231,6 +235,7 @@ function moveEverything(store: Store) {
   set("autoStashBeforePull", false);
   set("addSignoff", true);
   set("signCommits", "always");
+  set("commitTicketPattern", "issue-(\\d+)");
   set("diffContextLines", 9);
   set("diffViewMode", "split");
   set("diffContextMode", "chunks");
@@ -383,6 +388,22 @@ describe("import validates like load() does", () => {
       // "config" defers to the repository rather than forcing signing on.
       expect(store.useSettingsStore.getState().signCommits, String(bad)).toBe("config");
     }
+  });
+
+  it("falls back to the default for a ticket pattern that will not compile", async () => {
+    const store = await freshStore();
+    store.useSettingsStore.getState().importSettings(payloadOf({ commitTicketPattern: "([" }));
+    // Not left as-is: the chip would silently never appear, with nothing on
+    // screen saying the pattern is the reason.
+    expect(store.useSettingsStore.getState().commitTicketPattern).toBe(
+      "[A-Z][A-Z0-9]+-\\d+",
+    );
+  });
+
+  it("keeps an empty ticket pattern — that is 'no chip', deliberately", async () => {
+    const store = await freshStore();
+    store.useSettingsStore.getState().importSettings(payloadOf({ commitTicketPattern: "" }));
+    expect(store.useSettingsStore.getState().commitTicketPattern).toBe("");
   });
 
   it("falls back to auto for a bad updateCheckMode", async () => {

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -9,6 +9,10 @@ import {
   type HeadWeight,
 } from "./headMarks";
 import {
+  DEFAULT_TICKET_PATTERN,
+  isValidTicketPattern,
+} from "@/features/commits/message/ticket";
+import {
   getSystemAppearance,
   watchSystemAppearance,
   type Appearance,
@@ -791,6 +795,17 @@ interface PersistedState {
    * repository that has already made this decision.
    */
   signCommits: "config" | "always" | "never";
+  /**
+   * Regex the commit composer runs over the BRANCH NAME to find a ticket key
+   * to offer (#252). Its own setting rather than a hard-coded shape because
+   * ticket conventions are per-team and there is no majority: Jira keys,
+   * `issue-NNN`, bare `#NNN`. Capture group 1 wins when the pattern has one.
+   *
+   * A pattern that does not compile is replaced with the default on load —
+   * `extractTicket` also refuses to throw, so a half-typed one in Settings only
+   * means "no chip", never a broken commit screen.
+   */
+  commitTicketPattern: string;
   diffContextLines: number;
   /**
    * Inline (unified) or side-by-side. Persisted so it is a preference rather
@@ -900,6 +915,7 @@ const DEFAULTS: PersistedState = {
   autoStashBeforePull: true,
   addSignoff: false,
   signCommits: "config",
+  commitTicketPattern: DEFAULT_TICKET_PATTERN,
   diffContextLines: 3,
   diffViewMode: "inline",
   diffContextMode: "wholeFile",
@@ -1209,6 +1225,13 @@ function coerceSettings(
   // "config", which defers to the repository rather than forcing signing on.
   if (!["config", "always", "never"].includes(out.signCommits as string)) {
     out.signCommits = DEFAULTS.signCommits;
+  }
+  // A pattern that does not compile would make the ticket chip permanently
+  // absent with nothing on screen saying why. `extractTicket` refuses to throw
+  // either way, so this is about the user getting their feature back, not about
+  // safety.
+  if (!isValidTicketPattern(String(out.commitTicketPattern))) {
+    out.commitTicketPattern = DEFAULTS.commitTicketPattern;
   }
   // A hand-edited or newer-build zoom must not survive as-is: an out-of-range
   // factor is rejected by the webview and would leave the UI unzoomable.

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -16,6 +16,7 @@ import type {
   CommitInfo,
   CommitNote,
   CommitResult,
+  CommitTemplate,
   ConflictSides,
   DiagnosticsReport,
   DiffKind,
@@ -524,6 +525,17 @@ export async function verifyCommit(
   oid: string,
 ): Promise<SignatureStatus> {
   return invoke<SignatureStatus>("verify_commit", { repoId, oid });
+}
+
+/**
+ * The repository's `commit.template` and comment prefix (#252).
+ *
+ * Resolves even when `commit.template` names a file that is not there: the
+ * result carries `unreadable`, and the composer says so on screen. A stale
+ * config line must not stop the commit screen from opening.
+ */
+export async function getCommitTemplate(repoId: string): Promise<CommitTemplate> {
+  return invoke<CommitTemplate>("get_commit_template", { repoId });
 }
 
 export async function discardPaths(repoId: string, paths: string[]): Promise<void> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -841,3 +841,36 @@ export interface CommitResult {
   oid: string;
   message: string;
 }
+
+/**
+ * `commit.cleanup`, in git's own spelling. Mirrors Rust
+ * `git/commit_template.rs::CleanupMode`.
+ *
+ * `default` stays unresolved across IPC on purpose: it means "strip if the
+ * message is to be EDITED, whitespace otherwise", and only the composer knows
+ * which of those the box it is holding is.
+ */
+export type CleanupMode =
+  | "default"
+  | "verbatim"
+  | "whitespace"
+  | "strip"
+  | "scissors";
+
+/**
+ * A repository's `commit.template` plus the two config values that govern how
+ * the text in the box is cleaned up on the way to a commit (#252). Mirrors Rust
+ * `git/commit_template.rs::CommitTemplate`.
+ */
+export interface CommitTemplate {
+  /** Where `commit.template` resolved to; reported even when unreadable. */
+  path: string | null;
+  /** The template's text, comments and all — what git would put in the editor. */
+  body: string | null;
+  /** `commit.template` is set but the file behind it could not be read. */
+  unreadable: boolean;
+  /** `core.commentChar` for this repo, `auto` already resolved. Never empty. */
+  commentPrefix: string;
+  /** `commit.cleanup`; `"default"` when unset or unrecognised. */
+  cleanup: CleanupMode;
+}

--- a/src/screens/CommitPanel.compose.test.tsx
+++ b/src/screens/CommitPanel.compose.test.tsx
@@ -1,0 +1,481 @@
+// The commit-message composition surface (#252), at the screen.
+//
+// The pure halves are tested next to their modules
+// (features/commits/message/*.test.ts). What is pinned HERE is the wiring that
+// only exists once the screen is real: that a template pre-fills but never
+// overwrites, that the message actually SENT is the cleaned one, that the
+// affordances compose into the same ordinary textarea, and that none of it
+// broke sign-off, recall or attribution.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { CommitPanelScreen } from "./CommitPanel";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { pgPickOption, pgSelectValues } from "@/test/select";
+import type { BranchInfo, CommitInfo, CommitTemplate, FileStatus } from "@/lib/types";
+
+const staged = (path: string): FileStatus => ({
+  path,
+  worktree: { kind: "Unmodified" },
+  index: { kind: "Modified" },
+  additions: 1,
+  deletions: 0,
+  embedded: false,
+});
+
+const branch = (name: string): BranchInfo => ({
+  name,
+  isHead: true,
+  isRemote: false,
+  upstream: null,
+  ahead: 0,
+  behind: 0,
+  tip: "abc1234",
+  tipTime: 0,
+  isDefault: false,
+});
+
+const commit = (summary: string, body: string | null = null): CommitInfo => ({
+  oid: "aaa1111",
+  shortOid: "aaa1111",
+  summary,
+  body,
+  author: "Ada",
+  email: "ada@example.com",
+  timestamp: 0,
+  parents: ["parent"],
+  refs: [],
+});
+
+const NO_TEMPLATE: CommitTemplate = {
+  path: null,
+  body: null,
+  unreadable: false,
+  commentPrefix: "#",
+  cleanup: "default",
+};
+
+const template = (over: Partial<CommitTemplate>): CommitTemplate => ({
+  ...NO_TEMPLATE,
+  ...over,
+});
+
+interface SetupOpts {
+  template?: CommitTemplate;
+  branchName?: string;
+  commits?: CommitInfo[];
+}
+
+function setup(opts: SetupOpts = {}) {
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
+    status: [staged("a.ts")],
+    branches: [branch(opts.branchName ?? "main")],
+    remotes: [],
+    commits: opts.commits ?? [],
+    logRef: null,
+    loading: false,
+  } as never);
+  mockInvoke("get_diff", () => ({
+    path: "a.ts",
+    oldPath: null,
+    binary: false,
+    additions: 0,
+    deletions: 0,
+    hunks: [],
+  }));
+  mockInvoke("get_status", () => [staged("a.ts")]);
+  mockInvoke("commit", () => ({ oid: "oid123", message: "" }));
+  mockInvoke("get_commit_template", () => opts.template ?? NO_TEMPLATE);
+  return render(<CommitPanelScreen />);
+}
+
+const messageField = () => screen.getByTestId<HTMLTextAreaElement>("commit-message");
+const commitCall = () => getInvokeCalls().find((c) => c.cmd === "commit");
+const type = (value: string) =>
+  fireEvent.change(messageField(), { target: { value } });
+const typePicker = () => screen.getByTestId("commit-type");
+
+beforeEach(() => {
+  resetInvokeMock();
+  useSettingsStore.getState().reset();
+});
+
+afterEach(() => {
+  useSettingsStore.getState().reset();
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// commit.template
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("commit.template", () => {
+  it("pre-fills an empty box, comments and all — as git's editor does", async () => {
+    setup({ template: template({ path: "/repo/.gitmessage", body: "subject\n\n# why?\n" }) });
+    await waitFor(() => expect(messageField().value).toBe("subject\n\n# why?\n"));
+  });
+
+  it("never overwrites a draft the user already typed", async () => {
+    setup({ template: template({ path: "/repo/.gitmessage", body: "TEMPLATE\n" }) });
+    // Types before the template read resolves — the race the guard is for.
+    type("my own words");
+    await waitFor(() =>
+      expect(getInvokeCalls().some((c) => c.cmd === "get_commit_template")).toBe(true),
+    );
+    expect(messageField().value).toBe("my own words");
+  });
+
+  it("leaves the box alone when no template is configured", async () => {
+    setup();
+    await waitFor(() =>
+      expect(getInvokeCalls().some((c) => c.cmd === "get_commit_template")).toBe(true),
+    );
+    expect(messageField().value).toBe("");
+  });
+
+  it("says so when commit.template names a file that is not there", async () => {
+    setup({ template: template({ path: "/repo/gone.txt", unreadable: true }) });
+    const notice = await screen.findByTestId("commit-template-missing");
+    // Named, not swallowed: the whole point is that the user can go fix it.
+    expect(notice.textContent).toContain("/repo/gone.txt");
+    // …and the screen still works.
+    type("feat: thing");
+    expect(screen.getByTestId<HTMLButtonElement>("commit-button").disabled).toBe(false);
+  });
+
+  it("survives a backend that cannot answer at all", async () => {
+    useRepoStore.setState({
+      current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
+      status: [staged("a.ts")],
+      branches: [branch("main")],
+      remotes: [],
+      commits: [],
+      logRef: null,
+      loading: false,
+    } as never);
+    mockInvoke("get_diff", () => ({
+      path: "a.ts", oldPath: null, binary: false, additions: 0, deletions: 0, hunks: [],
+    }));
+    mockInvoke("get_status", () => [staged("a.ts")]);
+    mockInvoke("commit", () => ({ oid: "oid123", message: "" }));
+    // get_commit_template deliberately unmocked → the invoke mock rejects.
+    render(<CommitPanelScreen />);
+    await waitFor(() =>
+      expect(getInvokeCalls().some((c) => c.cmd === "get_commit_template")).toBe(true),
+    );
+    type("feat: thing");
+    expect(messageField().value).toBe("feat: thing");
+  });
+
+  it("comes back after a commit, because git re-applies it every time", async () => {
+    setup({ template: template({ path: "/repo/.gitmessage", body: "# describe the change\n" }) });
+    await waitFor(() => expect(messageField().value).toBe("# describe the change\n"));
+    type("feat: thing");
+    fireEvent.click(screen.getByTestId("commit-button"));
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    await waitFor(() => expect(messageField().value).toBe("# describe the change\n"));
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// COMMENT STRIPPING — the bug the issue names
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("comment stripping on commit", () => {
+  it("strips the template's comment lines instead of committing them", async () => {
+    setup({ template: template({ path: "/repo/.gitmessage", body: "\n# Why is this change needed?\n" }) });
+    await waitFor(() => expect(messageField().value).toContain("# Why"));
+    type("feat: thing\n\n# Why is this change needed?\nBecause.\n");
+    fireEvent.click(screen.getByTestId("commit-button"));
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    expect(commitCall()!.args.message).toBe("feat: thing\n\nBecause.");
+  });
+
+  it("keeps a # that is not the first character of its line", async () => {
+    setup({ template: template({ path: "/repo/.gitmessage", body: "seed\n" }) });
+    await waitFor(() => expect(messageField().value).toBe("seed\n"));
+    type("fix: crash\n\nCloses the #123 report");
+    fireEvent.click(screen.getByTestId("commit-button"));
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    expect(commitCall()!.args.message).toBe("fix: crash\n\nCloses the #123 report");
+  });
+
+  it("honours core.commentChar rather than assuming #", async () => {
+    setup({ template: template({ path: "/repo/.gitmessage", body: "x", commentPrefix: ";" }) });
+    await waitFor(() =>
+      expect(getInvokeCalls().some((c) => c.cmd === "get_commit_template")).toBe(true),
+    );
+    type("feat: thing\n; a hint\n#123 kept");
+    fireEvent.click(screen.getByTestId("commit-button"));
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    expect(commitCall()!.args.message).toBe("feat: thing\n#123 kept");
+  });
+
+  it("shows how many lines it is about to drop", async () => {
+    setup({ template: template({ path: "/repo/.gitmessage", body: "seed\n" }) });
+    await waitFor(() => expect(messageField().value).toBe("seed\n"));
+    type("feat: thing\n# one\n# two\n");
+    const notice = await screen.findByTestId("commit-comment-notice");
+    expect(notice.textContent).toMatch(/2 lines/);
+  });
+
+  it("refuses to commit a template message that is nothing but comments", async () => {
+    setup({ template: template({ path: "/repo/.gitmessage", body: "seed\n" }) });
+    await waitFor(() => expect(messageField().value).toBe("seed\n"));
+    type("# just a comment\n# and another\n");
+    // git calls this an empty commit message and aborts. Committing it would
+    // create a commit whose message is the instructions.
+    expect(screen.getByTestId<HTMLButtonElement>("commit-button").disabled).toBe(true);
+    expect(screen.queryByTestId("commit-comment-notice")).not.toBeNull();
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// …AND WHERE IT MUST NOT APPLY
+// ═════════════════════════════════════════════════════════════════════════════
+
+// git's `default` cleanup strips comments only when the message went through
+// the EDITOR. `git commit -m "#123 fix the thing"` commits `#123 fix the
+// thing`, and our box is `-m` until a template puts comments in it. Getting
+// this wrong deletes the user's own words.
+describe("a message the user typed is `git commit -m`", () => {
+  it("commits a #123 subject as written, and keeps Commit enabled", async () => {
+    setup();
+    await screen.findByTestId("commit-type");
+    type("#123 fix the thing");
+    expect(screen.getByTestId<HTMLButtonElement>("commit-button").disabled).toBe(false);
+    fireEvent.click(screen.getByTestId("commit-button"));
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    expect(commitCall()!.args.message).toBe("#123 fix the thing");
+  });
+
+  it("keeps a whole comment-shaped body, and says nothing about stripping", async () => {
+    setup();
+    await screen.findByTestId("commit-type");
+    type("#123 fix\n\n# a heading, not a comment\nbody\n");
+    expect(screen.queryByTestId("commit-comment-notice")).toBeNull();
+    fireEvent.click(screen.getByTestId("commit-button"));
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    expect(commitCall()!.args.message).toBe(
+      "#123 fix\n\n# a heading, not a comment\nbody",
+    );
+  });
+
+  it("still applies the whitespace half, which git does in both modes", async () => {
+    setup();
+    await screen.findByTestId("commit-type");
+    type("#123 fix   \n\n\n\nbody\n\n\n");
+    fireEvent.click(screen.getByTestId("commit-button"));
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    expect(commitCall()!.args.message).toBe("#123 fix\n\nbody");
+  });
+
+  it("strips once the repository's template has seeded the box", async () => {
+    // Same keystrokes, different context — the one distinction git makes.
+    setup({ template: template({ path: "/repo/.gitmessage", body: "seed\n" }) });
+    await waitFor(() => expect(messageField().value).toBe("seed\n"));
+    type("#123 fix the thing");
+    expect(screen.getByTestId<HTMLButtonElement>("commit-button").disabled).toBe(true);
+  });
+
+  it("obeys an explicit commit.cleanup=strip even with no template", async () => {
+    setup({ template: template({ cleanup: "strip" }) });
+    await waitFor(() =>
+      expect(getInvokeCalls().some((c) => c.cmd === "get_commit_template")).toBe(true),
+    );
+    type("feat: thing\n# a note\n");
+    fireEvent.click(screen.getByTestId("commit-button"));
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    expect(commitCall()!.args.message).toBe("feat: thing");
+  });
+
+  it("obeys an explicit commit.cleanup=whitespace even from a template", async () => {
+    setup({
+      template: template({
+        path: "/repo/.gitmessage",
+        body: "seed\n",
+        cleanup: "whitespace",
+      }),
+    });
+    await waitFor(() => expect(messageField().value).toBe("seed\n"));
+    type("feat: thing\n# kept on purpose\n");
+    fireEvent.click(screen.getByTestId("commit-button"));
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    expect(commitCall()!.args.message).toBe("feat: thing\n# kept on purpose");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// TICKET PREFIX
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("the ticket chip", () => {
+  it("offers the ticket the branch name carries, and inserts it on click", async () => {
+    setup({ branchName: "feat/PROJ-123-commit-help" });
+    const chip = await screen.findByTestId("commit-ticket");
+    expect(chip.textContent).toContain("PROJ-123");
+    type("do the thing");
+    fireEvent.click(screen.getByTestId("commit-ticket"));
+    expect(messageField().value).toBe("PROJ-123 do the thing");
+  });
+
+  it("goes after a conventional prefix, not in front of it", async () => {
+    setup({ branchName: "feat/PROJ-123-commit-help" });
+    await screen.findByTestId("commit-ticket");
+    type("feat(ui): do the thing");
+    fireEvent.click(screen.getByTestId("commit-ticket"));
+    expect(messageField().value).toBe("feat(ui): PROJ-123 do the thing");
+  });
+
+  it("goes quiet once the subject already names the ticket", async () => {
+    setup({ branchName: "feat/PROJ-123-commit-help" });
+    await screen.findByTestId("commit-ticket");
+    type("PROJ-123 already here");
+    expect(screen.getByTestId<HTMLButtonElement>("commit-ticket").disabled).toBe(true);
+  });
+
+  it("offers nothing for a branch with no ticket in it", async () => {
+    setup({ branchName: "feat/add-commit-help" });
+    await waitFor(() =>
+      expect(getInvokeCalls().some((c) => c.cmd === "get_commit_template")).toBe(true),
+    );
+    expect(screen.queryByTestId("commit-ticket")).toBeNull();
+  });
+
+  it("follows the configured pattern", async () => {
+    useSettingsStore.getState().set("commitTicketPattern", "issue-(\\d+)");
+    setup({ branchName: "fix/issue-42-crash" });
+    const chip = await screen.findByTestId("commit-ticket");
+    expect(chip.textContent).toContain("42");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// CONVENTIONAL TYPE PICKER
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("the conventional-commit picker", () => {
+  it("composes `type: ` onto the plain-text subject", async () => {
+    setup();
+    await screen.findByTestId("commit-type");
+    type("add a thing");
+    pgPickOption(typePicker(), "feat");
+    expect(messageField().value).toBe("feat: add a thing");
+  });
+
+  it("maps no native <select>, open or closed", async () => {
+    setup();
+    await screen.findByTestId("commit-type");
+    expect(document.querySelector("select")).toBeNull();
+    // Opening it is where a native control would show up.
+    expect(pgSelectValues(typePicker())).toContain("feat");
+    expect(document.querySelector("select")).toBeNull();
+    expect(document.querySelector("option")).toBeNull();
+  });
+
+  it("reads a prefix the user typed by hand, rather than ignoring it", async () => {
+    setup();
+    await screen.findByTestId("commit-type");
+    type("fix(commit): stop the crash");
+    // The picker parses the box; it does not keep its own draft.
+    expect(screen.getByTestId<HTMLInputElement>("commit-type").value).toBe("fix");
+    expect(screen.getByTestId<HTMLInputElement>("commit-scope").value).toBe("commit");
+  });
+
+  it("adds the scope to the subject once a type is there", async () => {
+    setup();
+    await screen.findByTestId("commit-type");
+    type("feat: do the thing");
+    fireEvent.change(screen.getByTestId("commit-scope"), { target: { value: "ui" } });
+    expect(messageField().value).toBe("feat(ui): do the thing");
+  });
+
+  it("waits for a type before it will take a scope", async () => {
+    setup();
+    await screen.findByTestId("commit-type");
+    type("do the thing");
+    expect(screen.getByTestId<HTMLInputElement>("commit-scope").disabled).toBe(true);
+  });
+
+  it("leaves the body alone", async () => {
+    setup();
+    await screen.findByTestId("commit-type");
+    type("add a thing\n\nWhy: because.");
+    pgPickOption(typePicker(), "feat");
+    expect(messageField().value).toBe("feat: add a thing\n\nWhy: because.");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// SUBJECT LENGTH — advisory, and only advisory
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("the subject-length readout", () => {
+  it("counts against 72 and never blocks the commit", async () => {
+    setup();
+    await screen.findByTestId("commit-type");
+    const long = "feat: " + "x".repeat(120);
+    type(long);
+    expect(screen.getByTestId("commit-subject-count").textContent).toBe(
+      `${long.length}/72`,
+    );
+    expect(screen.getByTestId<HTMLButtonElement>("commit-button").disabled).toBe(false);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// WHAT WAS ALREADY THERE
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("the composer's existing affordances still work", () => {
+  it("still sends the sign-off flag", async () => {
+    setup();
+    await screen.findByTestId("commit-type");
+    type("feat: thing");
+    fireEvent.click(screen.getByLabelText("Add Signed-off-by trailer"));
+    fireEvent.click(screen.getByTestId("commit-button"));
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    expect(commitCall()!.args.signoff).toBe(true);
+  });
+
+  it("still appends co-author trailers after the cleaned message", async () => {
+    setup();
+    await screen.findByTestId("commit-type");
+    // Trailing blank lines are cleaned in BOTH modes, so the trailer block
+    // still joins on exactly one blank line — while the `#` line, typed by
+    // hand and not seeded, stays where the user put it.
+    type("feat: thing\n# a comment\n\n\n");
+    fireEvent.change(screen.getByTestId("commit-coauthors"), {
+      target: { value: "Ada <ada@x.com>" },
+    });
+    fireEvent.click(screen.getByTestId("commit-button"));
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    expect(commitCall()!.args.message).toBe(
+      "feat: thing\n# a comment\n\nCo-Authored-By: Ada <ada@x.com>",
+    );
+  });
+
+  it("appends them after the STRIPPED message when a template seeded the box", async () => {
+    setup({ template: template({ path: "/repo/.gitmessage", body: "seed\n" }) });
+    await waitFor(() => expect(messageField().value).toBe("seed\n"));
+    type("feat: thing\n# a comment\n\n\n");
+    fireEvent.change(screen.getByTestId("commit-coauthors"), {
+      target: { value: "Ada <ada@x.com>" },
+    });
+    fireEvent.click(screen.getByTestId("commit-button"));
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    expect(commitCall()!.args.message).toBe(
+      "feat: thing\n\nCo-Authored-By: Ada <ada@x.com>",
+    );
+  });
+
+  it("still recalls a recent message into the box", async () => {
+    setup({ commits: [commit("feat: an earlier one", "With a body.")] });
+    await screen.findByTestId("commit-type");
+    fireEvent.click(screen.getByText("Recent"));
+    fireEvent.click(await screen.findByText("feat: an earlier one"));
+    expect(messageField().value).toBe("feat: an earlier one\n\nWith a body.");
+  });
+});

--- a/src/screens/CommitPanel.message.test.tsx
+++ b/src/screens/CommitPanel.message.test.tsx
@@ -63,14 +63,16 @@ describe("CommitPanel message composer", () => {
     );
   });
 
-  it("counts only the subject line against the 50-char budget", () => {
+  it("counts only the subject line against the subject budget", () => {
     fireEvent.change(messageField(), {
       target: {
         value: "feat: short\n\nA body line that is comfortably past fifty characters long.",
       },
     });
 
-    expect(screen.getByTestId("commit-subject-count").textContent).toBe("11/50");
+    // 72 since #252 — the number the convention actually names, and the one
+    // `git log --oneline` and the forges truncate at. Advisory either way.
+    expect(screen.getByTestId("commit-subject-count").textContent).toBe("11/72");
   });
 
   it("trims trailing blank lines so a trailer block joins cleanly", async () => {

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -31,6 +31,12 @@ import {
   type PGStageState,
   type SideLine,
 } from "@/design";
+import {
+  CommitMessageBar,
+  SUBJECT_LIMIT,
+  SUBJECT_SOFT_LIMIT,
+  useCommitComposer,
+} from "@/features/commits/message";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useDensityStep, useSettingsStore } from "@/features/settings/useSettingsStore";
@@ -142,6 +148,7 @@ export function CommitPanelScreen() {
   const commits = useRepoStore((s) => s.commits);
   const setNavIntent = useNavStore((s) => s.setIntent);
   const addSignoff = useSettingsStore((s) => s.addSignoff);
+  const ticketPattern = useSettingsStore((s) => s.commitTicketPattern);
   const setSetting = useSettingsStore((s) => s.set);
   const diffContextLines = useSettingsStore((s) => s.diffContextLines);
   const ignoreWhitespace = useIgnoreWhitespace();
@@ -1045,11 +1052,27 @@ export function CommitPanelScreen() {
     () => coAuthorTrailers(coAuthors).length,
     [coAuthors],
   );
-  // Only the first line counts against the 50-char subject budget; everything
-  // below it is body text nobody truncates.
-  const subjectLength = message.split("\n", 1)[0].length;
+  // THE commit-message composition surface (#252): `commit.template` pre-fill,
+  // git's comment stripping, the branch's ticket, the conventional-commit type
+  // picker. One hook and one bar rather than four widgets in this file — see
+  // features/commits/message/useCommitComposer.ts.
+  const composer = useCommitComposer({
+    repoId: repo?.id ?? null,
+    branch: headBranch?.name ?? null,
+    ticketPattern,
+    message,
+    setMessage,
+    amend,
+  });
+  // Only the first line counts against the subject budget; everything below it
+  // is body text nobody truncates.
+  const subjectLength = composer.subjectLength;
+  // The CLEANED message decides, not the raw box: a template whose comment lines
+  // are all that is left is what git calls an empty commit message, and Commit
+  // has to be disabled for it rather than writing one. A hand-typed `#123 fix`
+  // is NOT that — nothing is stripped there, so it stays committable.
   const canCommit =
-    (amend || staged.length > 0) && !!message.trim() && !authorInvalid;
+    (amend || staged.length > 0) && !!composer.cleaned && !authorInvalid;
   const canCommitAndPush = canCommit && !!headBranch && !!defaultRemote;
   // Guards against a second commit firing before the first resolves and clears
   // the message/staged state — key auto-repeat (holding ⌘↵) and double-taps
@@ -1059,7 +1082,12 @@ export function CommitPanelScreen() {
     if (committingRef.current) return null;
     committingRef.current = true;
     try {
-      const full = buildMessage(message, coAuthorTrailers(coAuthors));
+      // git's own cleanup, in the mode git would use: whitespace only for a
+      // message the user typed (this box is `git commit -m`, where `#123 fix`
+      // is an ordinary subject), plus comment stripping once commit.template
+      // has seeded it. Applied here rather than in the backend so the box can
+      // show what it removes before anyone presses Commit.
+      const full = buildMessage(composer.cleaned, coAuthorTrailers(coAuthors));
       const result = await commitAction(
         full,
         amend,
@@ -1070,6 +1098,10 @@ export function CommitPanelScreen() {
       );
       if (result) {
         setMessage("");
+        // `git commit` re-applies commit.template on EVERY commit, so the next
+        // message starts from it too. Safe to call unconditionally: the box was
+        // just cleared, and with no template it does nothing.
+        composer.reseed();
         setAmend(false);
         draftRef.current = null;
         // Per-commit signing override is not sticky: it is an override, and
@@ -1612,18 +1644,28 @@ export function CommitPanelScreen() {
                     color: "var(--fg-3)",
                   }}
                 >
+                  {/*
+                    Advisory, never a limit (#252). git enforces no subject
+                    length and neither does this: the number turns amber past
+                    the 50-char convention and red past 72, where `git log
+                    --oneline` and most forges start truncating — and Commit
+                    stays enabled either way.
+                  */}
                   <span
                     data-testid="commit-subject-count"
+                    title={`Subject length. ${SUBJECT_SOFT_LIMIT} is the conventional target, ${SUBJECT_LIMIT} is where tools truncate. Neither is enforced.`}
                     style={{
                       color:
-                        subjectLength > 50
-                          ? "var(--git-modified)"
-                          : "var(--fg-3)",
+                        subjectLength > SUBJECT_LIMIT
+                          ? "var(--git-removed)"
+                          : subjectLength > SUBJECT_SOFT_LIMIT
+                            ? "var(--git-modified)"
+                            : "var(--fg-3)",
                     }}
                   >
-                    {subjectLength}/50
+                    {subjectLength}/{SUBJECT_LIMIT}
                   </span>
-                  <span>wrap at 72</span>
+                  <span>wrap body at 72</span>
                 </span>
               }
             />
@@ -1638,6 +1680,13 @@ export function CommitPanelScreen() {
               className="focusable"
               style={{ flex: 1 }}
             />
+            {/*
+              THE affordance row for this box (#252) — type picker, scope,
+              ticket chip, and the advisories the composer owes the user. A
+              later message-composition feature adds to this bar rather than
+              growing a second one beside it.
+            */}
+            <CommitMessageBar composer={composer} />
           </div>
 
           {/*

--- a/src/screens/Settings.commit.test.tsx
+++ b/src/screens/Settings.commit.test.tsx
@@ -1,0 +1,70 @@
+// Settings → Commit → Ticket pattern (#252).
+//
+// The pattern's SEMANTICS are pinned next to `extractTicket` and its coercion
+// next to the store. What only the screen can get wrong is the one thing tested
+// here: a pattern that will not compile means the composer's ticket chip simply
+// never appears, so the field has to say so while it is being typed rather than
+// accepting it in silence.
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { mockInvoke } from "@/test/invokeMock";
+import { WithDialogs, resetDialogs } from "@/test/dialog";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { SettingsScreen } from "./Settings";
+
+function mockRestOfSettings() {
+  mockInvoke("cli_shim_status", () => ({
+    installed: true,
+    shimPath: "/usr/local/bin/pgit",
+    target: "/usr/bin/platypusgit",
+    source: "package",
+    pathState: "onPath",
+  }));
+  mockInvoke("diagnostics_report", () => ({
+    logPath: "/tmp/platypusgit.log",
+    logExists: false,
+    logSizeBytes: 0,
+    environment: "host os=macos arch=aarch64 git=2.43.0",
+    version: "0.1.0",
+  }));
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  resetDialogs();
+  mockRestOfSettings();
+  useSettingsStore.getState().reset();
+});
+
+function renderSettings() {
+  render(
+    <WithDialogs>
+      <SettingsScreen />
+    </WithDialogs>,
+  );
+}
+
+const field = () => screen.getByTestId<HTMLInputElement>("settings-ticket-pattern");
+
+describe("the ticket pattern field", () => {
+  it("shows the stored pattern and writes edits straight through", () => {
+    renderSettings();
+    expect(field().value).toBe("[A-Z][A-Z0-9]+-\\d+");
+    fireEvent.change(field(), { target: { value: "issue-(\\d+)" } });
+    expect(useSettingsStore.getState().commitTicketPattern).toBe("issue-(\\d+)");
+    expect(field().getAttribute("aria-invalid")).not.toBe("true");
+  });
+
+  it("flags a pattern that will not compile", () => {
+    renderSettings();
+    fireEvent.change(field(), { target: { value: "([unclosed" } });
+    expect(field().getAttribute("aria-invalid")).toBe("true");
+  });
+
+  it("treats an empty pattern as off, not as broken", () => {
+    renderSettings();
+    fireEvent.change(field(), { target: { value: "" } });
+    expect(field().getAttribute("aria-invalid")).not.toBe("true");
+  });
+});

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -24,6 +24,10 @@ import {
   type ThemeFollowMode,
   type UpdateCheckMode,
 } from "@/features/settings/useSettingsStore";
+import {
+  DEFAULT_TICKET_PATTERN,
+  isValidTicketPattern,
+} from "@/features/commits/message";
 import { HeadMarksControl } from "@/features/settings/HeadMarksControl";
 import { ForgeSettings } from "@/features/forge/ForgeSettings";
 import {
@@ -203,6 +207,37 @@ export function SettingsScreen() {
               <PGToggle
                 checked={s.addSignoff}
                 onChange={(v) => s.set("addSignoff", v)}
+              />
+            }
+          />
+          <Row
+            label="Ticket pattern"
+            hint={
+              <>
+                Regular expression run over the BRANCH NAME to find a ticket key
+                the commit composer offers as a one-click insert (#252). Capture
+                group 1 wins when the pattern has one, so{" "}
+                <code>issue-(\d+)</code> inserts just the number. Leave it empty
+                for no chip. Nothing is inserted automatically.
+              </>
+            }
+            control={
+              <PGInput
+                value={s.commitTicketPattern}
+                onChange={(v) => s.set("commitTicketPattern", v)}
+                // A pattern that will not compile means no chip and no
+                // explanation, so the field says so while it is being typed.
+                // `aria-invalid` alongside `error` because PGInput's `error` is
+                // a border colour and nothing more — adding the attribute to the
+                // shared primitive would restate the semantics of every input in
+                // the app in a change that is not about that.
+                error={!isValidTicketPattern(s.commitTicketPattern)}
+                aria-invalid={!isValidTicketPattern(s.commitTicketPattern)}
+                mono
+                size="sm"
+                placeholder={DEFAULT_TICKET_PATTERN}
+                style={{ width: 220 }}
+                data-testid="settings-ticket-pattern"
               />
             }
           />


### PR DESCRIPTION
## What does this PR do?

The most-used text field in the app helped in exactly one way — recalling recent messages — and ignored every convention a repository tries to establish. This adds:

- **`commit.template`** — read, path-resolved (repo-relative, absolute, `~`), pre-filling an **empty** box; never overwriting what you typed.
- **Ticket prefix** from the branch name (`feat/PROJ-123-thing` → `PROJ-123`), one-click insert, configurable pattern.
- **Conventional-commit type/scope picker** that composes `type(scope): ` into the ordinary textarea.
- **72-char subject guidance**, advisory only.

All behind **one composition surface**: `src/features/commits/message/` (`useCommitComposer` + `CommitMessageBar`). The issue's own thread says whichever of #252/#250 lands first should own that surface — so #250's AI-assisted half joins **this** hook and **this** bar's documented `extra` slot rather than growing a second surface beside it. `CommitPanel.tsx` grew ~40 net lines, not four widgets.

**Part of #252** — the full structured form (separate subject/body fields, a `BREAKING CHANGE` toggle) is deliberately **not** here: the issue warns that "a mandatory form here would be worse than nothing". The `!` marker *is* parsed and preserved across type/scope edits, just never offered.

## The part I sent back once, and why

The first pass stripped `#` comments from **every** commit. That is not git's behaviour, and it would have broken an ordinary habit.

git's default cleanup is *"same as `whitespace`, except that `#` commentary is removed **if the message is to be edited**"* — so `git commit -m "#123 fix"` commits `#123 fix`. A GUI textarea is much closer to `-m` than to the editor, **except** right after `commit.template` has seeded it, which is the only way `#` lines arrive unasked (we never append a status block).

So a `fromTemplate` flag stands in for git's "is it to be edited":

| | hand-typed | template-seeded |
|---|---|---|
| `#123 fix the thing` | **commits as written, Commit enabled** | stripped |
| whitespace cleanup | applied | applied |

Both cases are pinned side by side in `cleanup.test.ts`.

## `commit.cleanup`, honoured in full

It turned out to be one more config read beside the two already there, so all five modes are supported. The behaviour table was **derived by driving real git 2.50**, not read off the docs:

| mode | comments | scissors cut | whitespace |
|---|---|---|---|
| `verbatim` | kept | no | no |
| `whitespace` | kept | no | yes |
| `strip` | removed | no | yes |
| `scissors` | kept | **editor path only** | yes |
| `default` | editor→strip, else whitespace | no | yes |

`git commit --cleanup=scissors -m …` does **not** cut — which is why the same flag gates both the `default` resolution and scissors, rather than just the former. An unknown value degrades to `default` rather than erroring, because every other reading silently changes what gets committed and the commit screen has to open regardless.

**`core.commentChar` is honoured including `auto`**, replicating `adjust_comment_line_char`: if `#` appears nowhere keep `#`; otherwise strike every candidate from `#;@!$%^&|:` that starts a line and take the first survivor — resolved against the template body, which is the buffer git resolves against. Confirmed against real git: `commentChar=auto` with a template containing both `#…` and `;…` lines makes git pick `@`, and so do we.

The cleanup is a port of `strbuf_stripspace`, pinned by a **134-case differential** across all five modes (`-m` and a scripted editor with a real template). The harness is **not committed** — it needs a `git` binary and pins one git's exact output — so its results are baked into `cleanup.test.ts` as literals.

## Smaller calls

- A configured template that **cannot be read** comes back `unreadable: true`, not an error — a stale `commit.template` must never block the commit screen. Not an error string either, which would be a second error channel beside `AppError`.
- The template **re-seeds after a commit** (git re-applies it every time) but **not** whenever the box goes empty — text reappearing under your cursor mid-edit is hostile.
- **Picker and scope are derived from the subject**, not separate state, so the box stays the single source of truth. A type outside the conventional set (`wip`) is added as an option so the control never misreports the text.
- Default ticket pattern is uppercase-only `[A-Z][A-Z0-9]+-\d+` — the permissive version matches `fix-404` in `feature/fix-404-page`, and a chip offering garbage is worse than no chip.
- `commitTicketPattern` joins the **exported** settings key set (it describes a team convention), with the #254 snapshot updated consciously plus two coercion cases.
- Subject counter moved 50 → 72, the number the issue names; amber past 50, red past 72; `canCommit` untouched.

## Verification

Rebased onto `ad00f37`; conflicts were a `generate_handler!` entry and two doc-tree entries landing beside #253's, resolved by keeping both.

- `pnpm tsc --noEmit` — exit 0
- `pnpm test` — **262 files, 2380 tests**
- `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — exit 0
- `cargo test` — **926 tests, 0 failed**
- **e2e** — `commit.e2e.ts` + `settings.e2e.ts`, **11 passing**. Run because the commit screen gained a `get_commit_template` invoke on mount and a bar under the textarea, and Settings gained a row. Includes `Signed-off-by trailer is appended`, confirming sign-off still composes with the new surface.

## Worth your eye

- **Comment stripping is the behaviour change**, now correctly scoped — but if a repo *does* set `commit.template`, `#123` typed into that seeded box still strips. That is exactly git's behaviour, and the `commit-comment-notice` advisory says so, but it's the sharpest edge left.
- A user-supplied ticket regex is compiled per keystroke against the branch name — a pathological pattern is a self-inflicted stall on a ~50-char string, the same posture as the backend's user-supplied log-content regex.
- `CLAUDE.md` gains one conventions bullet pointing at `docs/dev/frontend.md`, matching that file's stated pattern.

## Checklist

- [x] One logical change, focused PR
- [x] Rebased onto `main`, no merge commits, single squashed commit
- [x] Conventional Commits
- [x] `pnpm tsc --noEmit`, `pnpm test`, `cargo check`, `cargo test` all pass
- [x] e2e typecheck passes; **targeted e2e run green**
- [x] New command: trait + impl + `CliBackend` stub + command + `invoke_handler!` + TS type/wrapper wired
- [x] `docs/dev/architecture.md`, `frontend.md`, `CLAUDE.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
