### PR TITLE
test(diff): fix a CI-only flake in the image-preview empty state

### DIFF
--- a/src/screens/DiffViewer.imagepreview.test.tsx
+++ b/src/screens/DiffViewer.imagepreview.test.tsx
@@ -113,7 +113,18 @@ describe("DiffViewer, binary file", () => {
       </WithDialogs>,
     );
 
-    expect(await screen.findByText("Binary file")).toBeInTheDocument();
+    // Both reads must LAND before this is meaningful, and the node must be
+    // queried fresh afterwards. `expect(await findByText(...))` was neither: the
+    // resolving preview re-renders this pane, so the node findByText returned
+    // was detached by the time the assertion read it — "element could not be
+    // found in the document", CI-only, once in ~4 runs of the full suite.
+    // Same wait the HEAD-and-worktree test above uses.
+    await waitFor(() =>
+      expect(
+        getInvokeCalls().filter((c) => c.cmd === "read_image_preview").length,
+      ).toBe(2),
+    );
+    expect(screen.getByText("Binary file")).toBeInTheDocument();
     expect(screen.queryByTestId("image-diff")).toBeNull();
   });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes a CI-only flake I introduced in #293 (issue #224).

`DiffViewer.imagepreview.test.tsx > keeps the empty state for a binary that is not an image` **failed on `main`** at `ad00f37` — the #224 merge commit — with:

```
Error: expect(element).toBeInTheDocument()
element could not be found in the document
 ❯ src/screens/DiffViewer.imagepreview.test.tsx:116:52
```

1 failed / 2272 passed. It passed on #293's own PR run, and 8/8 locally in isolation, so it only shows under a loaded runner.

## Why it failed

```ts
expect(await screen.findByText("Binary file")).toBeInTheDocument();
```

This holds a node **across a re-render**. `read_image_preview` resolves *after* the empty state first paints; React replaces the node; the handle `findByText` returned is detached by the time the assertion reads it.

**Not a timeout** — `findByText` succeeded. The element it handed back stopped being in the document, which is exactly what jest-dom's "element could not be found in the document" means (as opposed to `findBy`'s own "Unable to find an element…" rejection).

## The fix

The `unsupported` branch renders the **same** "Binary file" fallback on this surface, so there is no post-resolve DOM signal to wait on. So it waits for both reads to land — the same `getInvokeCalls()` wait the HEAD-and-worktree test two blocks above already uses — and then queries fresh:

```ts
await waitFor(() =>
  expect(
    getInvokeCalls().filter((c) => c.cmd === "read_image_preview").length,
  ).toBe(2),
);
expect(screen.getByText("Binary file")).toBeInTheDocument();
expect(screen.queryByTestId("image-diff")).toBeNull();
```

No handle is held across a render, so the failure mode is gone by construction rather than by timing.

**It also makes the test stronger.** The old form could pass on the *first* paint, before the preview resolved — so it never actually pinned the post-resolve state it exists to check. Now it cannot pass until both reads have landed.

## Scope

Only this test. The same `expect(await screen.findBy…).toBeInTheDocument()` shape appears **15 times** across `src/`, but the others are on renders with no async re-render behind them and none has been observed flaking — worth knowing as a pattern, not worth a blanket refactor in a flake fix.

## Verification

- `pnpm tsc --noEmit` — exit 0
- `pnpm test` — **262 files, 2380 tests**, exit 0
- The spec alone, repeatedly: green

No production code changes — test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
