### PR TITLE
feat(diff): F7 carries a visible caret, and puts its hint where the caret is

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -191,6 +191,32 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   carries BOTH `rowIndex` (flat-row space: focus ring, `scrollTopForRow`) and
   `changedIndex` (the ONLY value `stage/unstage/discard_lines` accept). Never
   derive one from the other; read `changedIndex` off the row.
+- **Two cursors, ONE position (#297).** They are separate index spaces, not
+  separate places the reader is. Every landing `useHunkNav` makes is reported
+  through `onLand`, and the surface answers it with
+  `lineFocus.focusRow(extents[h].first)` — the anchor row, which always carries a
+  `changedIndex`, so `Space` is live on arrival. `follows` closes the loop the
+  other way, so F7 means "the next change after where I am" rather than "after
+  where I last pressed F7". Three rules hold this together and each one was a bug
+  first:
+  - `follows` is an **edge, not a level** — it reacts to the caret MOVING. Read
+    as a level, any render where the caret has not caught up undoes the jump (F7
+    sets 3, the effect sees a caret still on 2), and where the caret cannot move
+    at all — ignore-whitespace leaves no targets — it pins F7 to one hunk forever.
+  - `onLand` fires **after** the reveal. F7 CENTRES and the caret REVEALS, and a
+    reveal is the intended no-op only once the centring has put the row on screen.
+  - A clamped press reports **nothing**. Landing on a cursor that did not move
+    would drag the caret back to the anchor of the hunk the reader is inside.
+  - All four surfaces mount the caret and both couplings; `test/diffCaretSurfaces.test.ts`
+    fails the build for a fifth that does not. Read-only surfaces (`DiffViewer`,
+    `CommitDiffPanel`, `RepoBrowser`) pass no `onToggle`, so `Space` stays
+    unclaimed there.
+- **Code is selectable wherever it is SHOWN, not just in a diff.** The app is
+  `user-select: none` (`index.css`) and each code cell opts back in with
+  `.pg-selectable` — the code, never the gutters. Blame rendered its source bare
+  and so could not be selected or copied at all, invisibly, because the three
+  rendering guards enumerate diff surfaces only. `test/codeSelectable.test.ts` is
+  the list that includes it.
 - **Scroll diff rows BY OFFSET** (`scrollTopForRow`), never
   `querySelector` + `scrollIntoView` — the row is usually unmounted under
   windowing and the DOM route silently does nothing (the #68 G10 trap). F7
@@ -267,6 +293,15 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   - The hint names its chord via `chordFor("diff.nextChange")` (bindings are
     rebindable); the arming expires with `PG_FLASH_MS`; `pgFlash` is
     single-instance.
+  - **The hint appears at the caret, and dies with the crossing (#297).**
+    `pgFlash` takes an optional anchor; `useHunkNav` passes the caret's row
+    (`[data-focused]`, then `[data-hunk-active]`, then null → the centred toast,
+    because a hint is worth more mispositioned than missing). The press that
+    crosses calls `pgFlashClear()`: the hint is a question, and left up it spends
+    its remaining 1.4s under the file it moved TO, announcing "no more changes"
+    from on top of that file's first one. It is deliberately NOT dismissed on
+    scroll — the arming expires on a timer, so an early dismissal would leave a
+    live arming with nothing on screen to explain it.
 - **A programmatic `scrollTop` write is not a scroll event** — the windowed
   range does not update by itself (measured: seconds of `start: 0` on WebKitGTK
   while the DOM sat scrolled, masked usually by token arrival — a token-cache

--- a/e2e/specs/diff-nav.e2e.ts
+++ b/e2e/specs/diff-nav.e2e.ts
@@ -32,6 +32,22 @@ const selectedRow = `${filesPane} [data-pg-row][data-selected]`;
 // FocusableScroll's ariaLabel — the diff pane's own scroll container.
 const diffScroll = '[aria-label="Diff"]';
 const activeHunk = (i: number) => `[data-hunk-index="${i}"][data-hunk-active]`;
+/** The line caret — one row at most, inside the diff pane (#297). */
+const caret = '[data-pg-pane="diff.view"] [data-focused]';
+
+/** Read-only probes, so bare `execute` rather than `executeOnce`. */
+const caretText = () =>
+  browser.execute(
+    (sel: string) => document.querySelector(sel)?.textContent ?? null,
+    caret,
+  );
+const caretCount = () =>
+  browser.execute((sel: string) => document.querySelectorAll(sel).length, caret);
+const flashHere = () =>
+  browser.execute(() => ({
+    up: !!document.querySelector("[data-pg-flash]"),
+    anchored: !!document.querySelector("[data-pg-flash][data-pg-flash-at]"),
+  }));
 
 const FILES = ["one.txt", "two.txt"] as const;
 const LINES = 260;
@@ -103,6 +119,19 @@ describe("diff navigation (issue 188)", () => {
       diffScroll,
     );
     expect(scrollTop).toBeGreaterThan(0);
+
+    // ...and the caret is ON that change (#297). A diff that opens at its first
+    // change while the text cursor stays unplaced contradicts itself: the mark
+    // says "you are here" and the first arrow key says "you are at line 1".
+    await waitForSelector(caret, "the diff opened with no caret on the change");
+    expect(await caretCount()).toBe(1);
+    // `extent.first` is the hunk's first CHANGED row, and the fixture MODIFIES
+    // line 100 — which diffs as a deletion followed by an addition. So the caret
+    // lands on the `−` row carrying the OLD text, not on the `+` row that
+    // replaced it. Asserting the absence of "CHANGED" is what pins that.
+    const opened = await caretText();
+    expect(opened).toContain("line 100");
+    expect(opened).not.toContain("CHANGED");
   });
 
   it("F7 carries into the next file at its first change, and stops at the last", async () => {
@@ -119,8 +148,19 @@ describe("diff navigation (issue 188)", () => {
 
     // Inside the file first: the cursor opened on change 1, so one F7 reaches the
     // last change rather than the second.
+    await waitForSelector(caret, "the diff opened with no caret");
+    expect(await caretText()).toContain("line 100");
     await jsChord("F7");
     await waitForSelector(activeHunk(1), "F7 did not advance to the second change");
+    // The caret went WITH it, and there is still only one of it.
+    await browser.waitUntil(
+      async () => (await caretText())?.includes("line 200") ?? false,
+      {
+        timeout: 10_000,
+        timeoutMsg: "the caret stayed behind when F7 moved to the second change",
+      },
+    );
+    expect(await caretCount()).toBe(1);
 
     // At the last change, F7 announces the crossing WITHOUT performing it. Before
     // issue 188 this press was a silent no-op that still claimed the chord.
@@ -128,9 +168,17 @@ describe("diff navigation (issue 188)", () => {
     expect(await $(selectedRow).getText()).toContain(first);
     const hint = await flashLog();
     expect(hint[hint.length - 1]).toContain("again for the next file");
+    // Beside the caret, not at the bottom of the window (#297). Only a real
+    // webview can show this: the placement reads `getBoundingClientRect`, which
+    // is all zeros without layout.
+    expect(await flashHere()).toEqual({ up: true, anchored: true });
 
     // The next press opens the next file, moving the FILE LIST selection too.
     await jsChord("F7");
+    // Checked HERE, before any wait: the dismissal is synchronous inside the
+    // keydown handler, and the toast would have expired on its own within ~1.7s
+    // — so asserting it after the waits below would pass either way.
+    expect((await flashHere()).up).toBe(false);
     await browser.waitUntil(
       async () => (await $(selectedRow).getText()).includes(second),
       {
@@ -141,6 +189,14 @@ describe("diff navigation (issue 188)", () => {
     await waitForSelector(
       activeHunk(0),
       "the next file did not open at its first change",
+    );
+    // The caret came across with it, onto the new file's first change.
+    await browser.waitUntil(
+      async () => (await caretText())?.includes("line 100") ?? false,
+      {
+        timeout: 10_000,
+        timeoutMsg: "the caret did not follow F7 into the next file",
+      },
     );
 
     // ...and the end of the LIST stops, rather than cycling back to the first file.

--- a/src/design/ui-helpers.tsx
+++ b/src/design/ui-helpers.tsx
@@ -46,8 +46,65 @@ const FLASH_VISIBLE_MS = 1400;
 const FLASH_FADE_MS = 200;
 export const PG_FLASH_MS = 1700; // visible, then the fade, then a little slack
 
+/** Breathing room between an anchored toast and the row it belongs to, in px. */
+const FLASH_GAP = 8;
+
 /**
- * Tiny bottom toast.
+ * Put the toast at the bottom of the window, or beside the row a caller named.
+ *
+ * The element is reused across calls, so every positioning property one branch
+ * sets must be cleared by the other — a leftover `bottom` under a fresh `top`
+ * stretches one toast down the screen.
+ */
+function placeFlash(el: HTMLDivElement, anchor: Element | null) {
+  if (!anchor) {
+    el.removeAttribute("data-pg-flash-at");
+    el.style.top = "auto";
+    el.style.bottom = "24px";
+    el.style.left = "50%";
+    el.style.transform = "translateX(-50%)";
+    return;
+  }
+  const r = anchor.getBoundingClientRect();
+  el.setAttribute("data-pg-flash-at", "");
+  el.style.bottom = "auto";
+  el.style.transform = "none";
+  // Measured after the text is in, so this is the box that will actually be
+  // drawn. jsdom reports zeros throughout and the clamps degrade to the top-left
+  // corner, which is the honest answer for a layout that does not exist.
+  const box = el.getBoundingClientRect();
+  const clamp = (v: number, max: number) =>
+    Math.max(FLASH_GAP, Math.min(v, Math.max(FLASH_GAP, max)));
+  // Below the row by preference, above it when there is no room. Either side of
+  // the row is a shorter trip for the eye than the bottom of the window.
+  const below = r.bottom + FLASH_GAP;
+  const wantTop =
+    below + box.height + FLASH_GAP > window.innerHeight
+      ? r.top - box.height - FLASH_GAP
+      : below;
+  // Left-aligned with the row, which is the left edge of the diff pane: a change
+  // starts there, so that is where the reading is happening.
+  el.style.top = `${clamp(wantTop, window.innerHeight - box.height - FLASH_GAP)}px`;
+  el.style.left = `${clamp(r.left, window.innerWidth - box.width - FLASH_GAP)}px`;
+}
+
+/**
+ * Tiny toast — at the bottom of the window, or beside `anchor` when the message
+ * is about where the reader is standing (#297).
+ *
+ * The bottom-centre position is right for messages with no location ("copied",
+ * "no upstream configured"). It is wrong for F7's "press F7 again for the next
+ * file", which appears at the far bottom edge of the app — a sidebar and a file
+ * list away from the change the same keypress just centred — and is easy to miss
+ * entirely. Missing it matters: it is the only thing that says a second press
+ * leaves the file, and the arming it announces expires with it.
+ *
+ * A null anchor degrades to the centred toast, so a caller that cannot find the
+ * reader's row needs no branch of its own.
+ *
+ * Deliberately NOT dismissed when the pane scrolls: the arming expires on a
+ * TIMER (`PG_FLASH_MS`), so taking the hint down early would leave a live arming
+ * with nothing on screen to explain it.
  *
  * ONE element, reused. It used to append a fresh node per call with no dedup, so
  * two calls in quick succession stacked two toasts at the same fixed position,
@@ -57,7 +114,7 @@ export const PG_FLASH_MS = 1700; // visible, then the fade, then a little slack
 let flashEl: HTMLDivElement | null = null;
 let flashTimers: ReturnType<typeof setTimeout>[] = [];
 
-export function pgFlash(msg: string) {
+export function pgFlash(msg: string, anchor: Element | null = null) {
   for (const t of flashTimers) clearTimeout(t);
   flashTimers = [];
   // `isConnected` covers the window a test (or a React root swap) cleared the
@@ -66,7 +123,7 @@ export function pgFlash(msg: string) {
     flashEl = document.createElement("div");
     flashEl.setAttribute("data-pg-flash", "");
     flashEl.style.cssText = `
-      position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
+      position: fixed;
       background: var(--bg-3); color: var(--fg-0);
       border: 1px solid var(--border-1); border-radius: var(--r-3);
       padding: 6px 12px; font-size: var(--fs-12);
@@ -83,6 +140,9 @@ export function pgFlash(msg: string) {
   el.textContent = msg;
   el.style.transition = "";
   el.style.opacity = "1";
+  // After the text, so an anchored toast is placed by the size it will be drawn
+  // at rather than by the previous message's.
+  placeFlash(el, anchor);
   flashTimers.push(
     setTimeout(() => {
       el.style.transition = `opacity ${FLASH_FADE_MS}ms`;
@@ -95,4 +155,25 @@ export function pgFlash(msg: string) {
       if (flashEl === el) flashEl = null;
     }, PG_FLASH_MS),
   );
+}
+
+/**
+ * Take the toast down NOW, timers and all.
+ *
+ * A flash is a statement about where the reader is, and some of them stop being
+ * true before they expire. `useHunkNav`'s "press F7 again for the next file" is
+ * the case this exists for: it is a QUESTION, and the very next press answers
+ * it — after which it sits under the file it just left for the rest of its 1.4s,
+ * reading as "no more changes" while the reader stands on the first change of a
+ * file full of them.
+ *
+ * Dropping the timers is not tidiness. The remove-timer closes over `el` and the
+ * module handle, so leaving it pending is a scheduled removal aimed at whatever
+ * toast happens to be up when it fires.
+ */
+export function pgFlashClear() {
+  for (const t of flashTimers) clearTimeout(t);
+  flashTimers = [];
+  flashEl?.remove();
+  flashEl = null;
 }

--- a/src/features/diff/CommitDiffPanel.caret.test.tsx
+++ b/src/features/diff/CommitDiffPanel.caret.test.tsx
@@ -1,0 +1,118 @@
+// The line caret in the commit-diff panel (#297).
+//
+// This panel is the one diff surface with its own row markup — the other three
+// render through `PGDiffRow`, which has drawn the focus ring since #61 D7. So
+// the ring here is a second implementation of the same two CSS lines, and the
+// source-level guard in `test/diffCaretSurfaces.test.ts` can only prove the
+// attribute is written somewhere in the file. This proves it reaches the DOM,
+// lands on the right row, and does not change the row's height — which the
+// window's variable-height arithmetic depends on (`outline`, never `border`).
+import { beforeEach, describe, expect, it } from "vitest";
+import { act, render, waitFor } from "@testing-library/react";
+import { resetInvokeMock } from "@/test/invokeMock";
+import { useKeymapStore, useFocusStore } from "@/features/keymap";
+import { CommitDiffPanel } from "./CommitDiffPanel";
+import type { FileDiff } from "@/lib/types";
+
+const diffs: FileDiff[] = [
+  {
+    path: "a.ts",
+    oldPath: null,
+    binary: false,
+    additions: 1,
+    deletions: 1,
+    hunks: [
+      {
+        header: "@@ -1,3 +1,3 @@",
+        oldStart: 1,
+        oldLines: 3,
+        newStart: 1,
+        newLines: 3,
+        lines: [
+          { kind: { kind: "Context" }, oldLineno: 1, newLineno: 1, content: "ctx line" },
+          { kind: { kind: "Deletion" }, oldLineno: 2, newLineno: null, content: "removed line" },
+          { kind: { kind: "Addition" }, oldLineno: null, newLineno: 2, content: "added line" },
+        ],
+      },
+    ],
+  },
+];
+
+const pressF7 = (shift = false) =>
+  act(() => {
+    useKeymapStore.getState().dispatch({
+      key: "F7",
+      code: "",
+      metaKey: false,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: shift,
+      preventDefault() {},
+      target: document.body,
+    } as unknown as KeyboardEvent);
+  });
+
+beforeEach(() => {
+  resetInvokeMock();
+  useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+  useKeymapStore.getState().setPreset("rider");
+  useFocusStore.setState({
+    focused: null,
+    panes: new Map(),
+    order: [],
+    barId: null,
+    pendingContentFocus: false,
+  });
+});
+
+async function renderPanel(paneIdPrefix: string) {
+  const r = render(
+    <CommitDiffPanel
+      diffs={diffs}
+      loading={false}
+      error={null}
+      header="x → y"
+      paneIdPrefix={paneIdPrefix}
+    />,
+  );
+  await waitFor(() =>
+    expect(r.container.querySelectorAll("[data-hunk-index]").length).toBe(1),
+  );
+  useFocusStore.setState({ focused: `${paneIdPrefix}.view` });
+  return r;
+}
+
+describe("CommitDiffPanel caret", () => {
+  it("paints no ring before the reader has asked for one", async () => {
+    const { container } = await renderPanel("caret1");
+    expect(container.querySelector("[data-focused]")).toBeNull();
+  });
+
+  it("F7 puts the caret on the hunk's first CHANGED row", async () => {
+    const { container } = await renderPanel("caret2");
+    pressF7();
+    const focused = container.querySelector("[data-focused]");
+    // Not the context line above it: the caret's index space is changed lines
+    // only, and the anchor F7 addresses this hunk by is its first changed row.
+    expect(focused?.textContent).toContain("removed line");
+    expect(focused?.textContent).not.toContain("ctx line");
+  });
+
+  it("rings exactly one row", async () => {
+    const { container } = await renderPanel("caret3");
+    pressF7();
+    expect(container.querySelectorAll("[data-focused]").length).toBe(1);
+  });
+
+  it("rings with an inset outline, so the row's height is unchanged", async () => {
+    const { container } = await renderPanel("caret4");
+    pressF7();
+    const focused = container.querySelector<HTMLElement>("[data-focused]");
+    // A border or extra padding here would grow the row past the window's pitch
+    // and put the variable-height arithmetic out of step with what is rendered —
+    // the same reason `PGDiffRow` draws its ring this way.
+    expect(focused!.style.outline).toContain("var(--accent)");
+    expect(focused!.style.outlineOffset).toBe("-1px");
+    expect(focused!.style.borderLeftWidth || "").not.toBe("1px");
+  });
+});

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -11,7 +11,13 @@ import {
 } from "@/design";
 import { useElementSize } from "@/lib/useElementSize";
 import { MinimapGutter } from "./DiffMinimap";
-import { PGPane, FocusableScroll, usePaneList, useHunkNav } from "@/features/keymap";
+import {
+  PGPane,
+  FocusableScroll,
+  usePaneList,
+  useHunkNav,
+  useDiffLineFocus,
+} from "@/features/keymap";
 import { fileIconSpec } from "@/lib/fileIcon";
 import { WhitespaceToggle } from "./WhitespaceToggle";
 import { diffOpenReady, useDiffGaps, useExpandedGaps } from "./useDiffGaps";
@@ -21,6 +27,7 @@ import {
   flattenDiffRows,
   hunkExtentRows,
   scrollTopForHunk,
+  scrollTopForRow,
 } from "@/lib/diffRows";
 import { useVariableWindow } from "@/lib/useVariableWindow";
 import { useViewportH } from "@/lib/useViewportH";
@@ -288,6 +295,33 @@ export function CommitDiffPanel({
     resetKey: selected,
   });
 
+  // The line caret (#297). Read-only surface, so no `onToggle`: Space stays
+  // unclaimed here and falls through to whatever else wants it. The caret is for
+  // reading — knowing where F7 put you, and having somewhere for the next arrow
+  // key to start from.
+  //
+  // REVEAL semantics, unlike F7's centring below: a cursor stepping one row
+  // should scroll one row. Both go by offset — the row is usually unmounted.
+  const scrollRowIntoView = React.useCallback(
+    (rowIndex: number): boolean => {
+      const el = scrollRef.current;
+      if (!el) return false;
+      const want = scrollTopForRow(heights, rowIndex, {
+        scrollTop: el.scrollTop,
+        viewportH: el.clientHeight,
+      });
+      scrollDiffTo(want);
+      return Math.abs(el.scrollTop - want) <= 1;
+    },
+    [heights, scrollDiffTo],
+  );
+  const lineFocus = useDiffLineFocus({
+    paneId: viewPaneId,
+    rows,
+    resetKey: selected,
+    scrollToRow: scrollRowIntoView,
+  });
+
   // F7/⇧F7. The cursor lands on each hunk's ANCHOR row — its first changed line —
   // and scrolling goes BY OFFSET, because that row is usually unmounted (#157).
   const extents = React.useMemo(() => hunkExtentRows(rows), [rows]);
@@ -316,6 +350,11 @@ export function CommitDiffPanel({
     count: current?.hunks.length ?? 0,
     resetKey: selected,
     scrollToHunk,
+    // The caret rides along, and the cursor follows it back (#297).
+    onLand: (h) => {
+      lineFocus.focusRow(extents[h]?.first);
+    },
+    follows: lineFocus.focused?.hunkIndex ?? null,
     ready: diffOpenReady({
       // `current` falls back to `diffs[0]` while `selected` is still the previous
       // commit's file, so these disagree for exactly the renders where the row
@@ -569,9 +608,11 @@ export function CommitDiffPanel({
               );
             }
             const kind = row.line.kind;
+            const focused = lineFocus.focused?.rowIndex === win.start + k;
             const line = (
               <div
                 key={`l${win.start + k}`}
+                data-focused={focused || undefined}
                 style={{
                   height: `var(--diff-row-h)`,
                   fontFamily: "var(--font-mono)",
@@ -594,6 +635,13 @@ export function CommitDiffPanel({
                         : "2px solid transparent",
                   paddingLeft: 2,
                   boxSizing: "border-box",
+                  // outline, not a border: this row's height is the window's
+                  // pitch, and anything that grows it puts the variable-height
+                  // arithmetic out of step with what is rendered. The offset
+                  // pulls the ring inside so neighbours do not clip it. Same
+                  // rule, and same two lines, as `PGDiffRow`.
+                  outline: focused ? "1px solid var(--accent)" : undefined,
+                  outlineOffset: focused ? "-1px" : undefined,
                   color:
                     kind === "add"
                       ? "var(--git-added)"

--- a/src/features/keymap/useDiffLineFocus.test.tsx
+++ b/src/features/keymap/useDiffLineFocus.test.tsx
@@ -72,7 +72,11 @@ function Harness(props: {
   onToggle?: (t: DiffLineTarget) => void;
   scrollToRow?: (i: number) => void;
   disabled?: boolean;
-  seen: { focus: DiffLineTarget | null };
+  seen: {
+    focus: DiffLineTarget | null;
+    focusRow?: (r: number | null) => boolean;
+    focusLine?: (h: number, c: number) => boolean;
+  };
 }) {
   const f = useDiffLineFocus({
     paneId: "d.diff",
@@ -83,6 +87,8 @@ function Harness(props: {
     disabled: props.disabled,
   });
   props.seen.focus = f.focused;
+  props.seen.focusRow = f.focusRow;
+  props.seen.focusLine = f.focusLine;
   return null;
 }
 
@@ -263,6 +269,127 @@ describe("useDiffLineFocus", () => {
 
     const one = rowsFor([hunkWithContext("@@ -1,3 +1,4 @@")]);
     act(() => rerender(<Harness rows={one} seen={seen} />));
+    expect(seen.focus).toBeNull();
+  });
+});
+
+// ── focusRow: putting the caret where the reader was SENT (#297) ───────────
+//
+// The arrow keys are not the only thing that moves a reader through a diff. F7
+// jumps to the next change, the auto-open jumps to the first one, and a click
+// picks a line — and every one of those used to leave the caret behind, so the
+// text cursor and the place the reader was actually looking at were different
+// rows. This is the entry point all three come in through.
+describe("focusRow", () => {
+  beforeEach(reset);
+
+  const rows = rowsFor([hunkWithContext("@@ -1,3 +1,4 @@")]);
+
+  it("puts the caret on the changed line at a row index", () => {
+    const seen: { focus: DiffLineTarget | null; focusRow?: (r: number | null) => boolean } = {
+      focus: null,
+    };
+    render(<Harness rows={rows} seen={seen} />);
+    expect(seen.focus).toBeNull();
+
+    // Row 3 is the `rem` line — changedIndex 1, two rows below the first change.
+    act(() => {
+      expect(seen.focusRow!(3)).toBe(true);
+    });
+    expect(seen.focus).toEqual({ rowIndex: 3, hunkIndex: 0, changedIndex: 1 });
+  });
+
+  it("declines a row that carries no changed line, leaving the caret alone", () => {
+    const seen: { focus: DiffLineTarget | null; focusRow?: (r: number | null) => boolean } = {
+      focus: null,
+    };
+    render(<Harness rows={rows} seen={seen} />);
+    act(() => {
+      seen.focusRow!(1);
+    });
+    expect(seen.focus?.rowIndex).toBe(1);
+
+    // Row 0 is context: unstageable, so it is not in the cursor's index space at
+    // all. Moving the caret there would put it somewhere Space cannot act, and
+    // silently break the changedIndex mapping the backend's line ops speak.
+    act(() => {
+      expect(seen.focusRow!(0)).toBe(false);
+    });
+    expect(seen.focus?.rowIndex).toBe(1);
+  });
+
+  it("declines null, so a caller with no row to offer says so in one place", () => {
+    const seen: { focus: DiffLineTarget | null; focusRow?: (r: number | null) => boolean } = {
+      focus: null,
+    };
+    render(<Harness rows={rows} seen={seen} />);
+    act(() => {
+      expect(seen.focusRow!(null)).toBe(false);
+    });
+    expect(seen.focus).toBeNull();
+  });
+
+  it("declines while ignore-whitespace has the cursor disabled", () => {
+    const seen: { focus: DiffLineTarget | null; focusRow?: (r: number | null) => boolean } = {
+      focus: null,
+    };
+    render(<Harness rows={rows} seen={seen} disabled />);
+    // Same gate the arrows and the mouse sit behind (#61 D2): hunk indices do not
+    // address what git would apply, so nothing may put a cursor on them — F7
+    // included. It degrades to the caret-less behaviour, not to a wrong caret.
+    act(() => {
+      expect(seen.focusRow!(3)).toBe(false);
+    });
+    expect(seen.focus).toBeNull();
+  });
+
+  it("keeps a stable identity across renders", () => {
+    const seen: { focus: DiffLineTarget | null; focusRow?: (r: number | null) => boolean } = {
+      focus: null,
+    };
+    const { rerender } = render(<Harness rows={rows} seen={seen} />);
+    const first = seen.focusRow;
+    rerender(<Harness rows={rows} seen={seen} />);
+    // Surfaces hand this to `useHunkNav` as `onLand`, which stores it in a ref
+    // precisely because a new function every render would re-register both F7
+    // actions on every render of the screen.
+    expect(seen.focusRow).toBe(first);
+  });
+});
+
+describe("focusLine", () => {
+  beforeEach(reset);
+
+  it("moves the caret to a (hunk, changedIndex) pair — what a click carries", () => {
+    const rows = rowsFor([
+      hunkWithContext("@@ -1,3 +1,4 @@"),
+      hunkWithContext("@@ -20,3 +20,4 @@", 20),
+    ]);
+    const seen: {
+      focus: DiffLineTarget | null;
+      focusLine?: (h: number, c: number) => boolean;
+    } = { focus: null };
+    render(<Harness rows={rows} seen={seen} />);
+
+    act(() => {
+      expect(seen.focusLine!(1, 2)).toBe(true);
+    });
+    // Addressed in the backend's index space and resolved to the renderer's: the
+    // second hunk's third changed line, whose flat row index is neither 2 nor 5.
+    expect(seen.focus).toMatchObject({ hunkIndex: 1, changedIndex: 2 });
+    expect(seen.focus!.rowIndex).toBeGreaterThan(5);
+  });
+
+  it("declines a pair no row carries", () => {
+    const seen: {
+      focus: DiffLineTarget | null;
+      focusLine?: (h: number, c: number) => boolean;
+    } = { focus: null };
+    render(<Harness rows={rowsFor([hunkWithContext("@@ -1,3 +1,4 @@")])} seen={seen} />);
+    act(() => {
+      expect(seen.focusLine!(0, 99)).toBe(false);
+      expect(seen.focusLine!(7, 0)).toBe(false);
+    });
     expect(seen.focus).toBeNull();
   });
 });

--- a/src/features/keymap/useDiffLineFocus.ts
+++ b/src/features/keymap/useDiffLineFocus.ts
@@ -15,6 +15,13 @@
 // Independent of useHunkNav on purpose. F7/⇧F7 bind different actions and move a
 // different cursor, so neither claims the other's chord; the two coexist as
 // "jump to the next change block" and "step through changed lines".
+//
+// Independent is not the same as unaware, though (#297). The arrows are not the
+// only thing that moves a reader through a diff: F7 jumps to the next change, the
+// auto-open jumps to the first one, and a click picks a line. Each of those used
+// to leave the caret where it was, so the text cursor and the row the reader was
+// actually looking at were different places — and the next arrow key went back to
+// the wrong one. `focusRow` is the entry point all three come in through.
 
 import React from "react";
 import type { DiffRow } from "@/lib/diffRows";
@@ -58,6 +65,33 @@ export interface DiffLineFocus {
   /** -1 while the pane has no cursor yet. */
   index: number;
   focused: DiffLineTarget | null;
+  /**
+   * Put the caret on the changed line at a FLAT ROW index, for a reader who was
+   * moved by something other than the arrow keys — F7's landing, the auto-open's,
+   * a click.
+   *
+   * Returns whether it found one, and declines rather than approximating: a row
+   * with no `changedIndex` (context, whole-file fill, a fold separator) is not in
+   * this cursor's index space, and putting the caret there would both park it
+   * where Space cannot act and break the one mapping the backend's line ops
+   * speak. `null` is accepted and declined, so a caller with no row to offer —
+   * an empty hunk, a diff still loading — needs no guard of its own.
+   *
+   * Identity is stable across renders: surfaces hand this to `useHunkNav` as
+   * `onLand`, and a new function per render would re-register the F7 actions on
+   * every render of the screen.
+   */
+  focusRow: (rowIndex: number | null | undefined) => boolean;
+  /**
+   * The same move addressed in the BACKEND's index space — the pair a click
+   * already carries (`onLineClick`), rather than the flat row index only the
+   * renderer knows.
+   *
+   * Clicking a line without this leaves the caret where it was, which is the
+   * arrow-key bug in mouse form: click line 40 to stage it, press the down arrow,
+   * and the cursor resumes from line 12 where you last left it.
+   */
+  focusLine: (hunkIndex: number, changedIndex: number) => boolean;
 }
 
 export function useDiffLineFocus(opts: {
@@ -112,6 +146,32 @@ export function useDiffLineFocus(opts: {
     [targets, scrollToRow],
   );
 
+  // Read through a ref so `focusRow` can keep one identity for the life of the
+  // pane while still seeing the current targets — `targets` changes with every
+  // refetch, and this is called from another hook's effects.
+  const targetsRef = React.useRef(targets);
+  targetsRef.current = targets;
+  const focusRow = React.useCallback(
+    (rowIndex: number | null | undefined): boolean => {
+      if (rowIndex == null) return false;
+      const i = targetsRef.current.findIndex((t) => t.rowIndex === rowIndex);
+      if (i < 0) return false;
+      setIndex(i);
+      return true;
+    },
+    [],
+  );
+
+  const focusLine = React.useCallback(
+    (hunkIndex: number, changedIndex: number): boolean => {
+      const t = targetsRef.current.find(
+        (x) => x.hunkIndex === hunkIndex && x.changedIndex === changedIndex,
+      );
+      return focusRow(t?.rowIndex);
+    },
+    [focusRow],
+  );
+
   usePaneList({
     paneId,
     count: targets.length,
@@ -137,5 +197,5 @@ export function useDiffLineFocus(opts: {
     { paneId },
   );
 
-  return { targets, index: cursor, focused };
+  return { targets, index: cursor, focused, focusRow, focusLine };
 }

--- a/src/features/keymap/useHunkNav.test.tsx
+++ b/src/features/keymap/useHunkNav.test.tsx
@@ -10,7 +10,7 @@ import { act, render } from "@testing-library/react";
 import { useHunkNav } from "./useHunkNav";
 import { useKeymapStore } from "./useKeymapStore";
 import { useFocusStore } from "./useFocusStore";
-import { PG_FLASH_MS } from "@/design/ui-helpers";
+import { pgFlash, pgFlashClear, PG_FLASH_MS } from "@/design/ui-helpers";
 
 function Harness({
   count,
@@ -19,6 +19,8 @@ function Harness({
   paneIds = ["d.files", "d.view"],
   ready,
   scrollToHunk,
+  onLand,
+  follows,
 }: {
   count: number;
   resetKey: string;
@@ -26,8 +28,18 @@ function Harness({
   paneIds?: string[];
   ready?: boolean;
   scrollToHunk?: (i: number) => void;
+  onLand?: (i: number) => void;
+  follows?: number | null;
 }) {
-  const cursor = useHunkNav({ paneIds, count, resetKey, ready, scrollToHunk });
+  const cursor = useHunkNav({
+    paneIds,
+    count,
+    resetKey,
+    ready,
+    scrollToHunk,
+    onLand,
+    follows,
+  });
   onCursor(cursor);
   return null;
 }
@@ -46,6 +58,7 @@ function FileHarness({
   onSelect,
   scrollToHunk,
   startIndex = 0,
+  follows,
 }: {
   hunksPerFile: number[];
   ready?: boolean;
@@ -53,6 +66,7 @@ function FileHarness({
   onSelect?: (i: number) => void;
   scrollToHunk?: (i: number) => void;
   startIndex?: number;
+  follows?: number | null;
 }) {
   const [index, setIndex] = React.useState(startIndex);
   const cursor = useHunkNav({
@@ -65,6 +79,7 @@ function FileHarness({
     // harness renders no rows, so the auto-open would never land. A surface that
     // scrolls and reports nothing is the shape being modelled here.
     scrollToHunk: scrollToHunk ?? (() => {}),
+    follows,
     files: {
       count: hunksPerFile.length,
       index,
@@ -441,6 +456,39 @@ describe("useHunkNav", () => {
     expect(scrollToHunk).toHaveBeenCalledWith(0);
   });
 
+  it("takes the hint down the moment it crosses, not a second later", () => {
+    render(<FileHarness hunksPerFile={[2, 3]} onCursor={onCursor} />);
+    useFocusStore.setState({ focused: "d.view" });
+    press("F7"); // → hunk 1 (last)
+    press("F7"); // arms + flashes
+    expect(flashText()).not.toBeNull();
+
+    press("F7"); // crosses
+    // The hint was a question ("press F7 again?") and the press just answered it.
+    // Leaving it up parks "No more changes" under the file it moved TO, standing
+    // on the first of that file's changes — a statement that is false where it is
+    // now drawn, for the rest of its 1.4s.
+    expect(flashText()).toBeNull();
+    expect(flashCount()).toBe(0);
+  });
+
+  it("dismissing is idempotent, and survives a toast that is already gone", () => {
+    // `useHunkNav` calls it on every crossing, including ones where nothing was
+    // ever flashed (the arming can outlive its own toast by a frame). A dismissal
+    // that threw there would break navigation, not just the hint.
+    expect(() => pgFlashClear()).not.toThrow();
+    pgFlash("up");
+    expect(flashText()).toBe("up");
+    pgFlashClear();
+    pgFlashClear();
+    expect(flashCount()).toBe(0);
+    // And the module handle really was released — the next flash mounts a fresh
+    // element rather than writing into the detached one.
+    pgFlash("again");
+    expect(flashText()).toBe("again");
+    expect(flashCount()).toBe(1);
+  });
+
   it("forgets the arming once the hint has expired", () => {
     vi.useFakeTimers();
     try {
@@ -550,5 +598,201 @@ describe("useHunkNav", () => {
     const handlers = useKeymapStore.getState().handlers;
     expect(handlers.get("diff.nextChange")?.length).toBe(1);
     expect(handlers.get("diff.prevChange")?.length).toBe(1);
+  });
+
+  // ── The caret rides along (#297) ─────────────────────────────────────────
+  // F7 used to move a hunk highlight and a scroll position and nothing else, so
+  // "go to the next change" left no cursor in the text it went to: the next
+  // arrow started over at the file's first changed line and Space had nothing to
+  // act on. `onLand` is the hook's half of the fix — the surface puts its line
+  // caret on the hunk's first changed row.
+
+  it("reports every landing it makes, the auto-open's included", () => {
+    const onLand = vi.fn();
+    render(
+      <Harness
+        count={3}
+        resetKey="a"
+        onCursor={onCursor}
+        ready
+        scrollToHunk={() => {}}
+        onLand={onLand}
+      />,
+    );
+    // The auto-open is a landing like any other: a diff that opens AT its first
+    // change must open with the caret there too, or the pane contradicts itself.
+    expect(onLand).toHaveBeenCalledWith(0);
+
+    useFocusStore.setState({ focused: "d.view" });
+    onLand.mockClear();
+    press("F7");
+    expect(onLand).toHaveBeenCalledWith(1);
+    press("F7", true);
+    expect(onLand).toHaveBeenLastCalledWith(0);
+  });
+
+  it("does not report a landing it did not make", () => {
+    const onLand = vi.fn();
+    render(
+      <Harness
+        count={1}
+        resetKey="a"
+        onCursor={onCursor}
+        ready
+        scrollToHunk={() => {}}
+        onLand={onLand}
+      />,
+    );
+    useFocusStore.setState({ focused: "d.view" });
+    onLand.mockClear();
+    press("F7"); // clamped at the only hunk — the cursor did not move
+    expect(onLand).not.toHaveBeenCalled();
+  });
+
+  it("reports the landing AFTER the scroll, so the caret's reveal is a no-op", () => {
+    const order: string[] = [];
+    render(
+      <Harness
+        count={3}
+        resetKey="a"
+        onCursor={onCursor}
+        ready
+        scrollToHunk={() => {
+          order.push("scroll");
+        }}
+        onLand={() => order.push("land")}
+      />,
+    );
+    useFocusStore.setState({ focused: "d.view" });
+    order.length = 0;
+    press("F7");
+    // Order is load-bearing. F7 CENTRES the hunk; the caret that follows it
+    // scrolls with REVEAL semantics, which is a no-op only while the row is
+    // already on screen. Landing first would reveal against the OLD scroll
+    // position and drag the pane somewhere F7 never asked for.
+    expect(order).toEqual(["scroll", "land"]);
+  });
+
+  it("tracks the caret, so F7 continues from where the READER is", () => {
+    const { rerender } = render(
+      <Harness count={4} resetKey="a" onCursor={onCursor} ready scrollToHunk={() => {}} />,
+    );
+    useFocusStore.setState({ focused: "d.view" });
+    expect(cursor).toBe(0);
+
+    // The reader arrows down through the lines and ends up inside hunk 2.
+    rerender(
+      <Harness
+        count={4}
+        resetKey="a"
+        onCursor={onCursor}
+        ready
+        scrollToHunk={() => {}}
+        follows={2}
+      />,
+    );
+    expect(cursor).toBe(2);
+    // ...so "next change" is 3, not 1. Without this, F7 walks back over ground
+    // the reader has already covered, one press per hunk they arrowed past.
+    press("F7");
+    expect(cursor).toBe(3);
+  });
+
+  it("a tracked caret at the last hunk still arms the crossing", () => {
+    const select = vi.fn();
+    render(
+      <FileHarness
+        hunksPerFile={[3, 2]}
+        onCursor={onCursor}
+        onSelect={select}
+        follows={2}
+      />,
+    );
+    useFocusStore.setState({ focused: "d.view" });
+    expect(cursor).toBe(2);
+    press("F7");
+    expect(flashText()).toBe("No more changes — press F7 again for the next file");
+    expect(select).not.toHaveBeenCalled();
+    press("F7");
+    expect(select).toHaveBeenCalledWith(1);
+  });
+
+  // ── The hint appears where the reader is (#297) ──────────────────────────
+  // The bottom-centre toast is a sidebar and a file list away from the change
+  // the same keypress just centred, and it is the ONLY thing that says a second
+  // press leaves the file.
+
+  it("anchors the hint to the caret's row", () => {
+    const pane = document.createElement("div");
+    pane.setAttribute("data-pg-pane", "d.view");
+    const row = document.createElement("div");
+    row.setAttribute("data-focused", "");
+    pane.appendChild(row);
+    document.body.appendChild(pane);
+
+    render(<FileHarness hunksPerFile={[2, 2]} onCursor={onCursor} />);
+    useFocusStore.setState({ focused: "d.view" });
+    press("F7");
+    press("F7"); // the hint
+
+    const toast = document.querySelector<HTMLElement>("[data-pg-flash]")!;
+    expect(toast.hasAttribute("data-pg-flash-at")).toBe(true);
+    // The bottom-centre positioning must be actively undone, not just overridden:
+    // one element is reused for every toast, so a leftover `bottom` under a fresh
+    // `top` stretches it down the screen.
+    expect(toast.style.bottom).toBe("auto");
+    expect(toast.style.transform).toBe("none");
+    expect(toast.style.top).not.toBe("");
+  });
+
+  it("falls back to the hunk cursor's row when no caret has been placed", () => {
+    const pane = document.createElement("div");
+    pane.setAttribute("data-pg-pane", "d.view");
+    const row = document.createElement("div");
+    // Ignore-whitespace turns the line cursor off entirely, so some surfaces
+    // reach the hint with a hunk highlight and no caret at all.
+    row.setAttribute("data-hunk-active", "");
+    pane.appendChild(row);
+    document.body.appendChild(pane);
+
+    render(<FileHarness hunksPerFile={[2, 2]} onCursor={onCursor} />);
+    useFocusStore.setState({ focused: "d.view" });
+    press("F7");
+    press("F7");
+    expect(
+      document.querySelector("[data-pg-flash]")!.hasAttribute("data-pg-flash-at"),
+    ).toBe(true);
+  });
+
+  it("degrades to the centred toast rather than dropping the hint", () => {
+    // No pane mounted, so there is nothing to anchor to. The message is worth
+    // more mispositioned than missing — it is what announces the arming.
+    render(<FileHarness hunksPerFile={[2, 2]} onCursor={onCursor} />);
+    useFocusStore.setState({ focused: "d.view" });
+    press("F7");
+    press("F7");
+    const toast = document.querySelector<HTMLElement>("[data-pg-flash]")!;
+    expect(toast.textContent).toBe(
+      "No more changes — press F7 again for the next file",
+    );
+    expect(toast.hasAttribute("data-pg-flash-at")).toBe(false);
+    expect(toast.style.bottom).toBe("24px");
+  });
+
+  it("anchors the end-of-list message too", () => {
+    const pane = document.createElement("div");
+    pane.setAttribute("data-pg-pane", "d.view");
+    const row = document.createElement("div");
+    row.setAttribute("data-focused", "");
+    pane.appendChild(row);
+    document.body.appendChild(pane);
+
+    render(<FileHarness hunksPerFile={[2]} onCursor={onCursor} />);
+    useFocusStore.setState({ focused: "d.view" });
+    press("F7");
+    press("F7"); // the only file, so: "Last file — no more changes"
+    const toast = document.querySelector<HTMLElement>("[data-pg-flash]")!;
+    expect(toast.textContent).toBe("Last file — no more changes");
+    expect(toast.hasAttribute("data-pg-flash-at")).toBe(true);
   });
 });

--- a/src/features/keymap/useHunkNav.ts
+++ b/src/features/keymap/useHunkNav.ts
@@ -25,6 +25,12 @@
 //     supplies no `files` keeps the old clamp.
 //  3. STOP AT THE ENDS. The last file's last hunk flashes and stays put; there is
 //     no wrap-around. Silently re-showing a file already reviewed is worse.
+//  4. THE CARET RIDES ALONG (#297). Every landing is reported through `onLand`,
+//     and the surface puts its LINE caret (`useDiffLineFocus`) on the hunk's
+//     first changed row. Before it, "go to the next change" moved a highlight and
+//     a scroll position and left no cursor in the text it had gone to: the next
+//     arrow key started over at the file's first changed line, and Space had
+//     nothing to act on. `follows` closes the loop in the other direction.
 //
 // Scrolling goes through the caller's `scrollToHunk` when it supplies one, and it
 // must: under windowing the anchor row is usually unmounted, so the DOM route
@@ -35,7 +41,7 @@
 import React from "react";
 import { useAction } from "./useAction";
 import { chordFor } from "./chordFor";
-import { pgFlash, PG_FLASH_MS } from "@/design/ui-helpers";
+import { pgFlash, pgFlashClear, PG_FLASH_MS } from "@/design/ui-helpers";
 
 /**
  * The caller's own file list, and the only thing that makes F7 cross files.
@@ -94,8 +100,46 @@ export function useHunkNav(opts: {
   ready?: boolean;
   /** Supply to let F7 carry into the next file. Omit to keep the old clamp. */
   files?: HunkNavFiles;
+  /**
+   * The cursor landed on this hunk — the auto-open's landing, F7's and shift-F7's
+   * alike. Surfaces put their line caret on the hunk's first changed row, which
+   * is what turns "next change" into a place in the text rather than a scroll
+   * position (#297).
+   *
+   * Called AFTER the reveal, deliberately: F7 CENTRES a hunk while the caret
+   * scrolls with REVEAL semantics, and a reveal is only the intended no-op once
+   * the centring has already put the row on screen. Landing first would scroll
+   * the pane against the old position.
+   *
+   * Not called when the cursor did not move — a clamped press at either end
+   * reports nothing, so the caret stays where the reader put it.
+   */
+  onLand?: (hunkIndex: number) => void;
+  /**
+   * The hunk the reader's caret is in, or null while they have not placed one.
+   * The cursor TRACKS it, without scrolling.
+   *
+   * This is the other half of the coupling, and it is what keeps `F7` meaning
+   * "the next change after where I am". Arrow down through a hunk or two and the
+   * cursor would otherwise still sit where the last `F7` left it, so the next
+   * press walks back over ground already read — one wasted press per hunk
+   * arrowed past.
+   *
+   * Read as a MOVE, not as a state — see the effect below for why the difference
+   * is load-bearing rather than stylistic.
+   */
+  follows?: number | null;
 }): number {
-  const { paneIds, count, resetKey, scrollToHunk, ready = false, files } = opts;
+  const {
+    paneIds,
+    count,
+    resetKey,
+    scrollToHunk,
+    ready = false,
+    files,
+    onLand,
+    follows = null,
+  } = opts;
   const [cursor, setCursor] = React.useState(-1);
 
   // Read by the key handlers, which run long after any render, so a ref keeps a
@@ -103,6 +147,14 @@ export function useHunkNav(opts: {
   const filesRef = React.useRef(files);
   React.useEffect(() => {
     filesRef.current = files;
+  });
+
+  // Same reason as `filesRef`: the surfaces build this closure over their caret's
+  // targets, so it is a new function every render and would re-register both
+  // actions each time if the handlers read it directly.
+  const onLandRef = React.useRef(onLand);
+  React.useEffect(() => {
+    onLandRef.current = onLand;
   });
 
   // Which end of the NEXT file to land on, and the request that sets it. Two refs
@@ -117,16 +169,43 @@ export function useHunkNav(opts: {
   const opened = React.useRef(false);
   /** The reader has moved the cursor in this file — from here on it is theirs. */
   const readerActed = React.useRef(false);
+  /** Last caret position seen, so `follows` can be read as a move and not a state. */
+  const lastFollows = React.useRef<number | null>(null);
 
   React.useEffect(() => {
     setCursor(-1);
     armed.current = null;
     opened.current = false;
     readerActed.current = false;
+    lastFollows.current = null;
     landing.current = pending.current ?? "first";
     pending.current = null;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resetKey]);
+
+  /**
+   * The row the reader is standing on, for a hint that should appear THERE and
+   * not at the bottom of the window (#297).
+   *
+   * The caret first, since that is literally where they are looking; the hunk
+   * cursor's anchor row as a fallback, for a surface whose caret is off
+   * (ignore-whitespace) or has not been placed yet. Panes are tried in the
+   * caller's order, and a file list carries neither attribute, so a screen whose
+   * scope spans both panes still finds the diff row.
+   *
+   * Null degrades to the centred toast rather than suppressing the hint: the
+   * message is worth more mispositioned than missing.
+   */
+  const caretAnchor = (): HTMLElement | null => {
+    for (const paneId of paneIds) {
+      const scope = `[data-pg-pane="${paneId}"]`;
+      const el =
+        document.querySelector<HTMLElement>(`${scope} [data-focused]`) ??
+        document.querySelector<HTMLElement>(`${scope} [data-hunk-active]`);
+      if (el) return el;
+    }
+    return null;
+  };
 
   /** Did the hunk actually get addressed? See `scrollToHunk`. */
   const reveal = (hunkIndex: number): boolean => {
@@ -179,8 +258,31 @@ export function useHunkNav(opts: {
     landing.current = "first";
     opened.current = true;
     setCursor(target);
+    // The auto-open is a landing like any other. A diff that opens AT its first
+    // change and leaves the caret unplaced contradicts itself: the highlight says
+    // "you are here", the first arrow key says "you are at the top of the file".
+    onLandRef.current?.(target);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ready, count, resetKey, scrollToHunk]);
+
+  // The reader's caret wins: the cursor follows it wherever they put it, by arrow
+  // key or by click. No scroll — the caret's own movement already did that, with
+  // the reveal semantics a one-row step should have.
+  //
+  // An EDGE, not a level: this reacts to the caret MOVING, and never to it merely
+  // sitting somewhere. Comparing `follows` against the cursor on every render
+  // instead makes the caret continuously authoritative, and then any render where
+  // it has not caught up drags the cursor back — F7 sets the cursor to 3, this
+  // effect reads a caret still on 2 and undoes it. That window is real (`onLand`
+  // is what moves the caret, one setState later) and it is unbounded when the
+  // caret cannot move at all: with the line cursor disabled by ignore-whitespace
+  // there are no targets to land on, `follows` never changes, and a level-based
+  // rule would pin F7 to one hunk forever.
+  React.useEffect(() => {
+    const moved = follows != null && follows !== lastFollows.current;
+    lastFollows.current = follows;
+    if (moved) setCursor(follows);
+  }, [follows]);
 
   const go = (delta: 1 | -1) => (): boolean => {
     if (count === 0) return false;
@@ -203,6 +305,10 @@ export function useHunkNav(opts: {
         now - armed.current.at <= PG_FLASH_MS;
       if (isArmed && crossable) {
         armed.current = null;
+        // The hint asked a question and this press answered it. Left up, it would
+        // spend the rest of its lifetime under the file it moved TO, announcing
+        // "no more changes" from on top of that file's first one.
+        pgFlashClear();
         // Coming from below, land on the previous file's LAST change.
         pending.current = delta === 1 ? "first" : "last";
         list.select(to);
@@ -216,6 +322,7 @@ export function useHunkNav(opts: {
           delta === 1
             ? "Last file — no more changes"
             : "First file — no earlier changes",
+          caretAnchor(),
         );
         return true;
       }
@@ -225,13 +332,20 @@ export function useHunkNav(opts: {
         `No more changes — press ${chord} again for the ${
           delta === 1 ? "next" : "previous"
         } file`,
+        caretAnchor(),
       );
       return true;
     }
     armed.current = null;
     const next = Math.max(0, Math.min(count - 1, cursor + delta));
     setCursor(next);
+    // Still re-centres on a clamped press, as it always has — that nudge is how a
+    // dead end announces itself on a surface with no file list to carry into.
     reveal(next);
+    // But it reports no LANDING, because nothing landed: the caret would be
+    // dragged back to the anchor row of the hunk the reader is already inside,
+    // undoing the arrow keys that got them further down it.
+    if (next !== cursor) onLandRef.current?.(next);
     return true;
   };
 

--- a/src/screens/Blame.selection.test.tsx
+++ b/src/screens/Blame.selection.test.tsx
@@ -1,0 +1,83 @@
+// Selecting a blamed line (#297).
+//
+// The app is `user-select: none` everywhere (`index.css`), and surfaces that
+// show code opt back in per cell with `.pg-selectable` — the code, never the
+// gutters, so a copied block pastes as source rather than as a column of
+// metadata. All four diff surfaces have done this since #61.
+//
+// Blame never did, and nothing caught it: the screen looks completely normal,
+// and "I cannot select this text" is not a thing anyone reports until they try
+// to copy a line out. That is the whole failure mode this file exists for.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { BlameScreen } from "./Blame";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useNavStore } from "@/features/nav/useNavStore";
+import { mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import type { BlameLine, BlameResult } from "@/lib/types";
+
+const line = (over: Partial<BlameLine>): BlameLine => ({
+  lineNo: 1,
+  oid: "1".repeat(40),
+  shortOid: "1111111",
+  author: "Author",
+  email: "author@example.com",
+  timestamp: 1_700_000_000,
+  summary: "write the lines",
+  content: "    alpha",
+  ignored: false,
+  unblamable: false,
+  ...over,
+});
+
+const RESULT: BlameResult = {
+  lines: [
+    line({ lineNo: 1, content: "const alpha = 1" }),
+    line({ lineNo: 2, content: "const beta = 2", shortOid: "2222222", author: "Other" }),
+  ],
+  ignoreRevsFile: null,
+  ignoreRevsApplied: false,
+  markIgnoredLines: false,
+  markUnblamableLines: false,
+  ignoreRevsError: null,
+};
+
+beforeEach(() => {
+  resetInvokeMock();
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+  } as never);
+  useNavStore.setState({ intent: { kind: "blame", path: "src.txt" } });
+});
+
+async function renderBlame() {
+  mockInvoke("blame_file", () => RESULT);
+  const r = render(<BlameScreen />);
+  await waitFor(() => expect(screen.getAllByTestId("blame-line")).toHaveLength(2));
+  return r;
+}
+
+describe("Blame selection", () => {
+  it("makes each line's source selectable", async () => {
+    const { container } = await renderBlame();
+    // jsdom applies no stylesheet, so the CLASS is the assertion — the rule it
+    // keys on is pinned by `src/design/diffSelection.test.tsx`.
+    expect(
+      [...container.querySelectorAll(".pg-selectable")].map((el) => el.textContent),
+    ).toEqual(["const alpha = 1", "const beta = 2"]);
+  });
+
+  it("leaves the oid, author and line number out of it", async () => {
+    const { container } = await renderBlame();
+    const selectable = [...container.querySelectorAll(".pg-selectable")]
+      .map((el) => el.textContent)
+      .join("");
+    // Otherwise copying three lines of a file hands you three lines of file with
+    // a commit hash and a name wedged into each one.
+    expect(selectable).not.toContain("1111111");
+    expect(selectable).not.toContain("Author");
+    expect(selectable).not.toContain("Other");
+  });
+});

--- a/src/screens/Blame.tsx
+++ b/src/screens/Blame.tsx
@@ -178,7 +178,13 @@ export function BlameScreen() {
               {l.author}
             </span>
             <span style={{ width: 40, color: "var(--fg-3)", textAlign: "right" }}>{l.lineNo}</span>
-            <span style={{ flex: 1 }}>
+            {/* The one selectable cell in the row: the source, without the
+                oid / author / line-number gutters beside it, so a copied block
+                pastes as code. `.pg-selectable` (index.css) opts back in from
+                the app-wide `user-select: none` — without it a blamed line could
+                not be selected or copied AT ALL, which is the same contract the
+                four diff surfaces have kept since #61 (#297). */}
+            <span className="pg-selectable" style={{ flex: 1 }}>
               <BlameText text={l.content} syntax={syntax?.[i]} />
             </span>
           </div>

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -834,6 +834,17 @@ export function CommitPanelScreen() {
     onToggle: toggleFocusedLine,
   });
 
+  // A click is a navigation too. Selecting a line for staging without moving the
+  // caret leaves the reader's two positions in different places, so the next
+  // arrow key resumes from wherever they last used the keyboard (#297).
+  const onLineClickFocusing = React.useCallback(
+    (hunkIndex: number, changedIndex: number, range: boolean) => {
+      lineFocus.focusLine(hunkIndex, changedIndex);
+      onLineClick(hunkIndex, changedIndex, range);
+    },
+    [lineFocus, onLineClick],
+  );
+
   // ONE list across both sections, staged first — the rendered order. Declared
   // here because both `usePaneList` (arrows) and `useHunkNav` (F7 carrying into
   // the next file, issue 188) address the same list: two orderings for two
@@ -861,6 +872,16 @@ export function CommitPanelScreen() {
     count: isTextualDiff(diff) && diff ? diff.hunks.length : 0,
     resetKey: selKey,
     scrollToHunk,
+    // The caret rides along (#297): every landing F7, shift-F7 and the auto-open
+    // make puts the line cursor on that hunk's first changed row — `extent.first`
+    // IS the anchor row, and it always carries a changedIndex, so Space is live
+    // the moment the reader arrives rather than after an arrow key to wake it.
+    onLand: (h) => {
+      lineFocus.focusRow(extents[h]?.first);
+    },
+    // ...and the cursor follows the caret back, so F7 means "the next change
+    // after where I am" rather than "after where I last pressed F7".
+    follows: lineFocus.focused?.hunkIndex ?? null,
     // Split mode renders no unified scroll container, and `useViewportH` keeps the
     // last height it read rather than resetting to 0 when that element goes away.
     ready:
@@ -1543,7 +1564,7 @@ export function CommitPanelScreen() {
                 activeHunk={hunkCursor >= 0 ? hunkCursor : undefined}
                 onExpandGap={expandGap}
                 selectedLines={(i) => lineSel[i] ?? []}
-                onLineClick={onLineClick}
+                onLineClick={onLineClickFocusing}
                 focusedRow={lineFocus.focused?.rowIndex ?? null}
                 findMarks={find.marksFor}
                 hunkActions={(i) => ({

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -41,6 +41,7 @@ import {
   HUNK_LEAD_ROWS,
   hunkExtentRows,
   scrollTopForHunk,
+  scrollTopForRow,
 } from "@/lib/diffRows";
 import { useVariableWindow } from "@/lib/useVariableWindow";
 import { useViewportH } from "@/lib/useViewportH";
@@ -57,6 +58,7 @@ import {
   chordFor,
   usePaneList,
   useHunkNav,
+  useDiffLineFocus,
 } from "@/features/keymap";
 import type { FileDiff } from "@/lib/types";
 
@@ -345,6 +347,42 @@ export function DiffViewerScreen() {
     },
     [rowH, scrollDiffTo],
   );
+  // The line caret (#297). Read-only surface, so no `onToggle`: Space stays
+  // unclaimed here and falls through to whatever else wants it. The caret is for
+  // reading — knowing where F7 put you, and having somewhere for the next arrow
+  // key to start from.
+  //
+  // Wrap mode is the one case that cannot go by offset: `heights` stops
+  // describing the rendered rows there, which is the same reason windowing is
+  // off — and because it IS off, every row is mounted and the DOM can be asked
+  // directly. That is the one situation where a querySelector cannot silently
+  // no-op (the #68 G10 trap), so it is safe here and nowhere else.
+  const scrollRowIntoView = React.useCallback(
+    (rowIndex: number): boolean => {
+      const el = scrollRef.current;
+      if (!el) return false;
+      if (wrap) {
+        const row = el.querySelector<HTMLElement>("[data-focused]");
+        row?.scrollIntoView?.({ block: "nearest" });
+        return !!row;
+      }
+      const want = scrollTopForRow(heights, rowIndex, {
+        scrollTop: el.scrollTop,
+        viewportH: el.clientHeight,
+      });
+      scrollDiffTo(want);
+      return Math.abs(el.scrollTop - want) <= 1;
+    },
+    [heights, scrollDiffTo, wrap],
+  );
+  const lineFocus = useDiffLineFocus({
+    paneId: "diff.view",
+    rows,
+    // A refetched diff renumbers, so the caret cannot outlive one.
+    resetKey: diff,
+    scrollToRow: scrollRowIntoView,
+  });
+
   const hunkCursor = useHunkNav({
     paneIds: ["diff.files", "diff.view"],
     count: diff?.hunks.length ?? 0,
@@ -352,6 +390,11 @@ export function DiffViewerScreen() {
     // Wrap mode measures the mounted rows instead of trusting `heights` — same
     // centring rule, different ruler.
     scrollToHunk: wrap ? scrollToHunkInWrap : scrollToHunk,
+    // The caret rides along, and the cursor follows it back (#297).
+    onLand: (h) => {
+      lineFocus.focusRow(extents[h]?.first);
+    },
+    follows: lineFocus.focused?.hunkIndex ?? null,
     // Split mode has no unified scroll container, and `useViewportH` keeps the
     // last height it managed to read rather than resetting to 0 when the element
     // goes away — so the mode is part of the question, not just the measurement.
@@ -611,6 +654,7 @@ export function DiffViewerScreen() {
                   rows={rows}
                   window={win}
                   wrap={wrap}
+                  focusedRow={lineFocus.focused?.rowIndex ?? null}
                   activeHunk={hunkCursor >= 0 ? hunkCursor : undefined}
                   onExpandGap={expandGap}
                   findMarks={find.marksFor}

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -61,6 +61,7 @@ import {
   flattenDiffRows,
   hunkExtentRows,
   scrollTopForHunk,
+  scrollTopForRow,
 } from "@/lib/diffRows";
 import { useVariableWindow } from "@/lib/useVariableWindow";
 import { useViewportH } from "@/lib/useViewportH";
@@ -98,6 +99,7 @@ import {
   useAction,
   useHunkNav,
   usePaneList,
+  useDiffLineFocus,
 } from "@/features/keymap";
 import type {
   BranchInfo,
@@ -746,11 +748,43 @@ export function RepoBrowserScreen() {
     },
     [diffExtents, diffHeights, diffRowH, scrollDiffTo],
   );
+  // The line caret (#297). Read-only surface, so no `onToggle`: Space stays
+  // unclaimed here and falls through to whatever else wants it. The caret is for
+  // reading — knowing where F7 put you, and having somewhere for the next arrow
+  // key to start from.
+  const scrollDiffRowIntoView = React.useCallback(
+    (rowIndex: number): boolean => {
+      const el = diffScrollRef.current;
+      if (!el) return false;
+      const want = scrollTopForRow(diffHeights, rowIndex, {
+        scrollTop: el.scrollTop,
+        viewportH: el.clientHeight,
+      });
+      scrollDiffTo(want);
+      return Math.abs(el.scrollTop - want) <= 1;
+    },
+    [diffHeights, scrollDiffTo],
+  );
+  const lineFocus = useDiffLineFocus({
+    paneId: "repo.preview",
+    rows: diffRows,
+    resetKey: diff,
+    scrollToRow: scrollDiffRowIntoView,
+    // Ignore-whitespace makes hunk indices unusable, and the caret's index space
+    // is derived from them — the same gate the hunk buttons sit behind (#61 D2).
+    disabled: !!hunkActionsDisabled,
+  });
+
   const hunkCursor = useHunkNav({
     paneIds: ["repo.tree", "repo.preview"],
     count: isTextualDiff(diff) && diff ? diff.hunks.length : 0,
     resetKey: selectedFile?.path ?? null,
     scrollToHunk,
+    // The caret rides along, and the cursor follows it back (#297).
+    onLand: (h) => {
+      lineFocus.focusRow(diffExtents[h]?.first);
+    },
+    follows: lineFocus.focused?.hunkIndex ?? null,
     ready: diffOpenReady({
       // The fetch is async, so this pane renders once with the outgoing file's
       // rows while the selection already names the new one.
@@ -1211,6 +1245,7 @@ export function RepoBrowserScreen() {
               <PGWindowedDiff
                 rows={diffRows}
                 window={diffWin}
+                focusedRow={lineFocus.focused?.rowIndex ?? null}
                 activeHunk={hunkCursor >= 0 ? hunkCursor : undefined}
                 onExpandGap={expandGap}
                 findMarks={find.marksFor}

--- a/test/codeSelectable.test.ts
+++ b/test/codeSelectable.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment node
+ */
+// "Every surface that shows code lets you select it." (#297)
+//
+// The app is `user-select: none` everywhere (`index.css`, so a drag across the
+// UI does not smear a selection over the chrome), and each surface that renders
+// CODE opts one cell back in with `.pg-selectable` — the code, never the gutters
+// beside it, so a copied block pastes as source rather than as a column of line
+// numbers and commit hashes.
+//
+// That contract is invisible until it is broken, and then it is invisible in the
+// other direction: an unselectable pane looks completely normal, and nobody
+// reports it until they try to copy a line out. Blame shipped that way and the
+// three rendering guards next door could not see it, because none of them knew
+// Blame existed. This is the list they were missing.
+//
+// The per-surface rendering proof lives in `src/design/diffSelection.test.tsx`,
+// `src/features/diff/CommitDiffPanel.selection.test.tsx` and
+// `src/screens/Blame.selection.test.tsx`; the end-to-end proof against a real
+// WebKit is `e2e/specs/diff-selection.e2e.ts`. What none of them can catch is a
+// SIXTH surface arriving without any of it, which is what this file fails the
+// build for.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Every file that renders lines of source for reading.
+ *
+ * The four diff surfaces reach it through shared renderers (`PGDiffRow`,
+ * `PGDiffLine`, `PGSideBySideDiff`) or their own markup; Blame renders its own.
+ * The merge window is out: CodeMirror manages its own selection and is not built
+ * on the DiffRow model.
+ */
+const CODE_SURFACES = [
+  "src/design/git-components.tsx",
+  "src/features/diff/CommitDiffPanel.tsx",
+  "src/screens/Blame.tsx",
+];
+
+const read = (p: string) => readFileSync(resolve(process.cwd(), p), "utf8");
+
+describe("code is selectable wherever it is shown", () => {
+  it.each(CODE_SURFACES)("%s opts its code cell back in", (file) => {
+    expect(read(file)).toContain("pg-selectable");
+  });
+
+  // The class only means something while the rule that grants selection exists.
+  it("the class still grants selection, prefixed and not", () => {
+    const css = read("src/index.css");
+    const rule = css.slice(css.indexOf(".pg-selectable"));
+    expect(rule).toMatch(/user-select:\s*text/);
+    expect(rule).toMatch(/-webkit-user-select:\s*text/);
+  });
+
+  // The three diff surfaces that render through `PGWindowedDiff` inherit their
+  // cell from `git-components.tsx`, so they carry no class of their own — which
+  // is why they are absent above and asserted here instead. A surface that stops
+  // using the shared renderer would fail this, and belong in the list.
+  it.each([
+    "src/screens/CommitPanel.tsx",
+    "src/screens/DiffViewer.tsx",
+    "src/screens/RepoBrowser.tsx",
+  ])("%s renders through the shared row", (file) => {
+    expect(read(file)).toContain("PGWindowedDiff");
+  });
+});

--- a/test/diffCaretSurfaces.test.ts
+++ b/test/diffCaretSurfaces.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @vitest-environment node
+ */
+// "Every diff surface has a caret, and F7 moves it." (#297)
+//
+// Same shape, and the same reasoning, as `diffFindSurfaces.test.ts` and
+// `diffCopyMenu.test.ts` next door. The line caret shipped in ONE of the four
+// surfaces and stayed there: `focusedRow` was passed by CommitPanel alone, so
+// history, compare and browse rendered rows that could draw the ring
+// (`PGDiffRow` has always known how) and never lit one. Nothing failed — a
+// missing cursor looks like a design choice, not a bug, until someone presses
+// the down arrow and watches nothing happen.
+//
+// The other half is the coupling. A caret that F7 does not move is worse than no
+// caret: the highlight says "you are here" and the text cursor says otherwise,
+// and the reader's next arrow key believes the wrong one. So each surface must
+// both MOUNT the hook and hand it to `useHunkNav` — `onLand` (F7 moves the
+// caret) and `follows` (the caret moves F7).
+//
+// The merge window is deliberately NOT in this list, for the same reason it is
+// out of the find guard's: it renders conflicts through CodeMirror, which brings
+// its own cursor, and shares none of the DiffRow model this is built on.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/** Every file that renders diff rows — the same four as the find and copy guards. */
+const DIFF_SURFACES = [
+  "src/screens/CommitPanel.tsx",
+  "src/screens/DiffViewer.tsx",
+  "src/screens/RepoBrowser.tsx",
+  "src/features/diff/CommitDiffPanel.tsx",
+];
+
+const read = (p: string) => readFileSync(resolve(process.cwd(), p), "utf8");
+
+describe("the diff caret reaches every diff surface", () => {
+  it.each(DIFF_SURFACES)("%s mounts the shared cursor", (file) => {
+    expect(read(file)).toContain("useDiffLineFocus(");
+  });
+
+  // Three surfaces render through `PGWindowedDiff` and pass `focusedRow`;
+  // `CommitDiffPanel` keeps its own lighter markup and draws the ring by hand.
+  // Both routes end at the same attribute, which is what this greps for rather
+  // than a prop name only three of them have.
+  it.each(DIFF_SURFACES)("%s draws the ring", (file) => {
+    const src = read(file);
+    expect(src.includes("focusedRow=") || src.includes("data-focused=")).toBe(true);
+  });
+
+  it.each(DIFF_SURFACES)("%s lets F7 move the caret", (file) => {
+    expect(read(file)).toContain("onLand:");
+  });
+
+  // Without this the hunk cursor stays where the last F7 left it, so arrowing
+  // down through two hunks and pressing F7 walks back over ground already read.
+  it.each(DIFF_SURFACES)("%s lets the caret move F7", (file) => {
+    expect(read(file)).toContain("follows:");
+  });
+
+  // The four surfaces are the SAME four the find and copy-menu guards name.
+  // Keeping the lists in step is what stops a fifth surface being added to one
+  // and forgotten by the others.
+  it("names the same surfaces the find and copy-menu guards do", () => {
+    const find = read("test/diffFindSurfaces.test.ts");
+    const copy = read("test/diffCopyMenu.test.ts");
+    for (const file of DIFF_SURFACES) {
+      expect(find).toContain(file);
+      expect(copy).toContain(file);
+    }
+  });
+
+  it("leaves the merge window out, and out of the row model entirely", () => {
+    const merge = read("src/features/merge/MergeBody.tsx");
+    expect(merge).not.toContain("useDiffLineFocus");
+    expect(merge).not.toContain("flattenDiffRows");
+  });
+});


### PR DESCRIPTION
Closes #297.

`F7` moved a hunk highlight and a scroll position and nothing else, so "go to the next change" left no cursor in the text it went to — and the message about that keypress appeared at the bottom edge of the window, a sidebar and a file list away from where the reader was looking.

## What changed

**1. F7 carries the caret.** `useHunkNav` reports every landing it makes through `onLand` — the auto-open's included, since a diff that opens AT its first change and leaves the caret unplaced contradicts itself. Each surface answers by putting its line caret on the hunk's first changed row (`extent.first`, which always carries a `changedIndex`, so `Space` is live on arrival rather than after an arrow key to wake it).

**2. The caret carries F7 back.** `follows` keeps `F7` meaning "the next change after where I am" rather than "after where I last pressed F7" — without it, arrowing down two hunks and pressing F7 walks back over ground already read, one wasted press per hunk.

**3. A caret in all four diff surfaces.** `focusedRow` was passed by `CommitPanel` alone, so history, compare and browse rendered rows that could draw the ring and never lit one. `test/diffCaretSurfaces.test.ts` fails the build for a fifth surface that forgets.

**4. The hint appears at the caret**, and **dies with the crossing**. `pgFlash` takes an optional anchor; `pgFlashClear()` is new (there was no dismiss API at all).

**5. Blame's source is selectable.** It rendered its code column bare, so under the app-wide `user-select: none` a blamed line could not be selected or copied at all — invisibly, because the existing guards enumerate diff surfaces only.

## The three open questions in the issue, settled

1. **The caret drives F7, not just follows it** — both directions, for the reason in (2).
2. **A click moves the caret** — same bug in mouse form: click line 40 to stage it, press `↓`, and the cursor resumes from line 12.
3. **The auto-open paints a caret on arrival** — that is the ask, and it is a deliberate change to the "no ring until the reader asks" rule, which still holds for merely entering a pane.

## Two things worth a second opinion

- **Arrows and Home/End in the three read-only diff panes now move the caret instead of scrolling 40px.** `FocusableScroll` already defers when the dispatcher claims a key, and `CommitPanel` has behaved this way since #61 D7 — so this makes the other three consistent rather than inventing anything. But it is user-visible: `End` in whole-file mode now goes to the last *changed* line, not the bottom of the file. `PageUp`/`PageDown` still scroll.
- **`follows` is an edge, not a level** — it reacts to the caret *moving*. Read as a level, any render where the caret has not caught up undoes the jump (F7 sets 3, the effect sees a caret still on 2), and where the caret cannot move at all (ignore-whitespace leaves no targets) it would pin F7 to one hunk forever. This was a real failure caught by a unit test, not a hypothetical.

## Verification

- `pnpm test` — 2429 passing, including new coverage for `focusRow`/`focusLine`, `onLand`/`follows`, the anchored hint, `CommitDiffPanel`'s hand-drawn ring (its markup is a second implementation of the ring, so the source guard alone could not prove it reaches the DOM), and Blame selection (confirmed failing without the fix).
- `pnpm tsc --noEmit` + `pnpm exec tsc -p e2e/tsconfig.json --noEmit` clean.
- E2E in Docker against a binary rebuilt after the last source change: `diff-nav`, `diff-selection`, `keymap`, `history-diff`, `commit`, `status-stage`.

Docs: `docs/dev/frontend.md` — the "Two cursors, two index spaces" rule this couples, and the auto-open/carry section, both updated in the same commit.
