### PR TITLE
feat(ui): say how far along a network op or rebase is, not just that one is running

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,12 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
   `set({ error })` last. (`docs/dev/frontend.md`)
 - **A new `NavIntent` kind must be routed in `AppShell`** — compile-enforced
   (`assertNever`) + `AppShell.navroutes.test.tsx`. (`docs/dev/frontend.md`)
+- **A new long-running op joins `RepoActivity`**, and one that can raise a
+  credential challenge lets `withAuthRetry` own its label (pass `{ key, label }`,
+  never a `finally` at the call site — that clears while the password dialog is
+  still open). `RepoActivity` is what produces the status line, the progress bar
+  and the Cancel button; a private `busy` field only says which row is busy.
+  (`docs/dev/frontend.md`)
 - **Diff surfaces:** one row model (`flattenDiffRows`); gate text rendering on
   `isTextualDiff`, scroll by offset (never `scrollIntoView` under windowing),
   measure viewports with `lib/useViewportH`/`useElementSize` (read first,

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -35,6 +35,16 @@ proc.rs          THE only sanctioned child-process spawner (issue 172):
                  git / git_async / git_async_in (CREATE_NO_WINDOW,
                  GIT_TERMINAL_PROMPT=0, stdin closed), program / program_async,
                  and the two *_keeping_console exceptions. See backend.md
+progress.rs      Reading git's own `--progress` sideband off a child's stderr
+                 (#296). parse_progress turns "Receiving objects:  62%
+                 (620/1000)" into a CloneProgress; ProgressReader splits a byte
+                 stream on `\r` AS WELL AS `\n` (git redraws with a bare `\r`,
+                 so reading by line buffers a whole phase and the bar jumps
+                 instead of streaming), bounds an undelimited line, and keeps
+                 the non-progress lines as the failure-message tail. Clone had
+                 all of this privately; fetch/pull/push use the same code now,
+                 so the two cannot drift. Both callers keep their own select!
+                 loop — the cancel arms differ. See backend.md
 reveal.rs        "Reveal in Finder/Explorer" + "Open in terminal" (#215).
                  HostPlatform decouples argv building from the actual host, so
                  reveal_plan/terminal_plan are PURE and unit-tested for all

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -206,6 +206,43 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   group — a platform-specific kill path through the one sanctioned spawner —
   and is deliberately not done. The user-visible hang is gone either way.
 
+### Reporting progress from a long op (#296)
+
+- **`--progress` or there is nothing to report.** Git writes its sideband
+  progress only when stderr is a tty, and it never is here. `fetch_args` and
+  `push_args` carry the flag unconditionally; a caller with no sink just
+  discards the ticks. Forgetting the flag is the silent failure mode — the code
+  looks wired up and no tick ever arrives.
+- **One parser and one byte-splitter, in `progress.rs`.** Clone had both
+  privately first. The splitter breaks on `\r` **as well as** `\n`: git redraws
+  a progress line with a bare `\r`, so `read_until(b'\n')` buffers a whole phase
+  and releases it in one burst — the bar freezes, then jumps. It also bounds an
+  undelimited line and keeps the non-progress lines as the failure tail.
+- **The failure message comes from that tail, not from raw stderr.** Progress
+  redraws are filtered out of it, so `classify_auth_failure` and
+  `host_from_stderr` see git's actual words instead of five hundred copies of
+  "Receiving objects". Every non-progress line is kept, which is what those two
+  need; the cap keeps the NEWEST lines, because git puts its `fatal:` last.
+- **`run_git_authenticated` drains stderr by hand, so stdout goes to
+  `/dev/null`.** It always discarded stdout; `wait_with_output` was there to
+  drain both concurrently and avoid a deadlock. With one pipe to read, nulling
+  the other removes the hazard rather than managing it.
+- **Cancellation still works because the `select!` is inside the read loop.**
+  The wait used to be one `wait_with_output`; it is now many reads, and each one
+  races the cancel token `biased`-first. A stalled fetch sits in exactly that
+  read.
+- **Rebase reports through a sink on the trait, not an `AppHandle` on the
+  backend.** `rebase_start_with_progress` / `rebase_continue_with_progress` take
+  a `RebaseProgressSink`; the old names remain as default methods delegating
+  with a no-op. That keeps 66 existing call sites untouched, keeps
+  `GitBackend` object-safe (`AppState` holds an `Arc<dyn GitBackend>`), and
+  keeps the ticks assertable from a plain `cargo test` — see
+  `tests/rebase_progress.rs`.
+- **A tick fires BEFORE its step is applied**, and `next_index` is the count of
+  steps already done — the same value `RebaseStatus.next_index` carries, so one
+  `+ 1` renders both. Drops tick too: they are part of `total`, and skipping
+  them would freeze the counter on a plan that is in fact advancing.
+
 ## "No telemetry, no account" is a build gate (#226)
 
 - The README advertises three promises as the reason to choose this app: no

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -535,6 +535,53 @@ const composer = useCommitComposer({ repoId, branch, ticketPattern, message, set
   `branchMenuItems` Pull/Push entries still use the split; they predate the
   helper and were left alone rather than changed under this feature's tests.
 
+### Progress and loading state (#296)
+
+`RepoActivity` is the app's ONE answer to "is something running, what is it, how
+far along, and can I stop it". A long op that keeps its busy state privately gets
+none of that surface — which is how LFS fetch and submodule update ended up
+cancellable in the backend but unstoppable from the UI for two releases.
+
+- **`withAuthRetry` owns the indicator, not its callers.** It resolves the moment
+  it RAISES a credential challenge; it does not await the retry, which runs later
+  from the dialog's callback. So a caller that set a label before calling and
+  cleared it in a `finally` cleared it while the user was still typing their
+  password, and the retried op — the slower attempt, by definition — ran with no
+  spinner, no status line and no Cancel. Pass `{ key, label }` and every attempt
+  gets its own. Pinned by `useRepoStore.activity.test.ts`; the six sites do not
+  stay in step by hand.
+- **A new long-running op joins `RepoActivity`.** A private `busy` field is only
+  for saying WHICH row is busy (`useLfsStore`, `useSubmodulesStore` and
+  `useForgeStore` keep theirs for exactly that, and set an activity entry too).
+- **Only ops that go through `run_git_authenticated` get a Cancel button**
+  (`isCancellable` in `repoActivity.ts`). It is the registration point for
+  `cancel::Scope::Repo`, so it is the precise set `cancel_network_op` can reach.
+  A rebase replay cannot be interrupted at all yet — offering a button that does
+  nothing is worse than offering none.
+- **`setActivity` is guarded on the repository, like `setFor`.** `activity` is a
+  per-repo slice field and an op outlives a tab switch: a fetch on A finishing
+  after the user moved to B used to clear B's entry, taking B's spinner and
+  Cancel with it. `frozenSlice` clears `activity` for the matching reason — with
+  writes scoped to the current repo, nothing would ever clear a parked tab's
+  entry, and returning to it would show a live status line for an op long over.
+  (The cost: a background tab's running op has no indicator until you come back
+  to it and `refreshAll` re-reads the world. Same trade `loading` already makes.)
+- **Ticks are guarded twice** (`applyNetProgress`): the event is app-global, so it
+  must name the open repository, AND an entry must already exist. Ticks are still
+  in flight when the process exits, and one landing after the op finished would
+  light a status line — with a Cancel button — over nothing.
+- **A label change keeps `startedAt` but drops `phase`/`percent`.** Pull's
+  stash → pull → pop is three labels but one wait, so restarting the elapsed
+  clock three times would make it useless; carrying a 90%-complete bar into the
+  stash pop would be a lie.
+- **Say when you stop doing the thing you said you were doing.** Every network op
+  sets `Refreshing…` before its `refreshAll`, which on a large repository is a
+  real share of the wall clock spent under a label that says "Fetching".
+- **Elapsed time appears only after `ELAPSED_AFTER_MS`.** It exists to answer "is
+  this stuck?", and a number that flashes up on every 200 ms fetch is noise. It
+  also keeps the 1 Hz re-render off the common case — and that re-render is why
+  `ActivityStatus` is a leaf component rather than markup in `AppStatusBar`.
+
 ### Settings: one validator, two untrusted sources (#254)
 
 `useSettingsStore` reads a payload it does not control from two places — the

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -582,6 +582,38 @@ cancellable in the backend but unstoppable from the UI for two releases.
   also keeps the 1 Hz re-render off the common case — and that re-render is why
   `ActivityStatus` is a leaf component rather than markup in `AppStatusBar`.
 
+#### `loadingTasks` — the detail behind `loading` (gap 8)
+
+`refreshAll` is TEN backend reads behind one `Promise.all` with one boolean to
+describe them. That is fine until a refresh is slow, and then "syncing…" is
+exactly no help: a `/mnt/c` repository under WSL (#274) spends its nine seconds
+in one or two of the ten and nothing said which.
+
+- **Each read registers a named task while it runs**, via `trackLoad(repoId, id,
+  label, promise)`. It returns the promise unchanged, so it drops into the
+  existing `Promise.all` — a read added later that skips it is simply missing
+  from the popover rather than breaking it. `useRepoStore.loading.test.ts`
+  asserts the full set of ten ids, so an unwrapped read shows up as a diff.
+- **`trackLoad` is NOT `async`.** Registration has to happen before the first
+  suspension point, or ten reads fired together would register one microtask
+  apart and "longest-running" would mean "whichever scheduled first".
+- **`LoadingTask` is deliberately not `RepoActivity`.** An activity entry is an
+  operation the *user* started and earns a Cancel button; a loading task is the
+  app reading its own state, cannot be cancelled, and is usually over in under a
+  tenth of a second. Merging them would put a Cancel button on `listing tags`.
+- **`SHOW_AFTER_MS` is what makes this liveable.** A refresh runs on every tab
+  switch, every commit and after every network op. With no delay the corner of
+  the screen strobes all day; what survives 400 ms is the refresh worth reading
+  about. Same idea as `ELAPSED_AFTER_MS`, different threshold and purpose.
+- **The collapsed label names the longest-running read** (`primaryTask`), so as
+  the fast ones drop off it settles onto the one holding the refresh up. Reads
+  that started in the same millisecond are genuinely tied; the id breaks it so
+  the label cannot flap between two of them on every render.
+- The popover expands **upward** — the status bar is the last row on screen —
+  and sits at `zIndex: 40`: above content (1–5), below pickers and modals (100),
+  which must cover it. The shell root's `overflow: hidden` does not clip it,
+  because it grows into the content area rather than out of the window.
+
 ### Settings: one validator, two untrusted sources (#254)
 
 `useSettingsStore` reads a payload it does not control from two places — the

--- a/src-tauri/src/commands/branches.rs
+++ b/src-tauri/src/commands/branches.rs
@@ -1,11 +1,11 @@
-use tauri::State;
+use tauri::{AppHandle, Emitter, State};
 
 use crate::{
     commands::net::Credentials,
     error::{AppError, AppResult},
     git::types::{
-        BranchInfo, BulkFastForward, FastForward, PullMode, PushForce, RemoteInfo, RepoId,
-        StashInfo, TagInfo, TagTarget,
+        BranchInfo, BulkFastForward, FastForward, NetOp, NetProgress, PullMode, PushForce,
+        RemoteInfo, RepoId, StashInfo, TagInfo, TagTarget,
     },
     state::AppState,
 };
@@ -153,6 +153,40 @@ async fn run_git_creds(
     crate::commands::net::run_git_authenticated(cwd, args, creds).await
 }
 
+/// `run_git_creds`, forwarding git's own progress to the frontend (#296).
+///
+/// The four ops a user watches — fetch, fetch-all, pull, push — go through this
+/// one; everything else that talks to a remote (fast-forward's fetch, tag push,
+/// remote-branch delete) keeps the quiet path, because its transfer is a handful
+/// of objects and a bar that fills instantly is noise.
+///
+/// `repo_id` rides along on every tick because the event is app-global while the
+/// indicator is per-repository: a background tab's fetch must not drive the
+/// active tab's bar.
+async fn run_git_progress(
+    app: &AppHandle,
+    cwd: &std::path::Path,
+    repo_id: &RepoId,
+    op: NetOp,
+    args: &[&str],
+    creds: Option<&Credentials>,
+) -> AppResult<()> {
+    let repo_id = repo_id.0.clone();
+    crate::commands::net::run_git_authenticated_with_progress(cwd, args, creds, &mut |p| {
+        // A dropped event costs one progress tick, never the operation.
+        let _ = app.emit(
+            "net://progress",
+            &NetProgress {
+                repo_id: repo_id.clone(),
+                op,
+                phase: p.phase,
+                percent: p.percent,
+            },
+        );
+    })
+    .await
+}
+
 /// Build the argument list for `git fetch`. `remote = None` means all remotes.
 ///
 /// The remote name lands strictly after `--`, for the reason spelled out on
@@ -163,8 +197,13 @@ async fn run_git_creds(
 /// Verified against git 2.50: `git fetch --prune -- origin` fetches normally,
 /// and `-- --upload-pack=/bin/false` is refused as a strange pathname instead of
 /// being honoured as an option.
+///
+/// `--progress` is unconditional: git writes no sideband progress unless stderr
+/// is a tty, which it never is here, so without the flag there is nothing for
+/// `run_git_progress` to report (#296). Harmless on the quiet callers — a sink
+/// that never fires just discards the ticks.
 fn fetch_args(remote: Option<&str>, prune: bool) -> Vec<&str> {
-    let mut args = vec!["fetch"];
+    let mut args = vec!["fetch", "--progress"];
     if remote.is_none() {
         args.push("--all");
     }
@@ -180,6 +219,7 @@ fn fetch_args(remote: Option<&str>, prune: bool) -> Vec<&str> {
 
 #[tauri::command]
 pub async fn fetch(
+    app: AppHandle,
     state: State<'_, AppState>,
     repo_id: String,
     remote: String,
@@ -189,9 +229,13 @@ pub async fn fetch(
     // credential (#61 D5).
     credentials: Option<Credentials>,
 ) -> AppResult<()> {
-    let path = get_repo_path(&state, &RepoId(repo_id)).await?;
-    run_git_creds(
+    let repo_id = RepoId(repo_id);
+    let path = get_repo_path(&state, &repo_id).await?;
+    run_git_progress(
+        &app,
         &path,
+        &repo_id,
+        NetOp::Fetch,
         &fetch_args(Some(remote.as_str()), prune),
         credentials.as_ref(),
     )
@@ -200,17 +244,28 @@ pub async fn fetch(
 
 #[tauri::command]
 pub async fn fetch_all(
+    app: AppHandle,
     state: State<'_, AppState>,
     repo_id: String,
     prune: bool,
     credentials: Option<Credentials>,
 ) -> AppResult<()> {
-    let path = get_repo_path(&state, &RepoId(repo_id)).await?;
-    run_git_creds(&path, &fetch_args(None, prune), credentials.as_ref()).await
+    let repo_id = RepoId(repo_id);
+    let path = get_repo_path(&state, &repo_id).await?;
+    run_git_progress(
+        &app,
+        &path,
+        &repo_id,
+        NetOp::Fetch,
+        &fetch_args(None, prune),
+        credentials.as_ref(),
+    )
+    .await
 }
 
 #[tauri::command]
 pub async fn pull(
+    app: AppHandle,
     state: State<'_, AppState>,
     repo_id: String,
     remote: String,
@@ -218,15 +273,21 @@ pub async fn pull(
     mode: PullMode,
     credentials: Option<Credentials>,
 ) -> AppResult<()> {
-    let path = get_repo_path(&state, &RepoId(repo_id)).await?;
+    let repo_id = RepoId(repo_id);
+    let path = get_repo_path(&state, &repo_id).await?;
     let mode_flag = match mode {
         PullMode::FastForward => "--ff-only",
         PullMode::Merge => "--no-rebase",
         PullMode::Rebase => "--rebase",
     };
-    run_git_creds(
+    run_git_progress(
+        &app,
         &path,
-        &["pull", mode_flag, remote.as_str(), branch.as_str()],
+        &repo_id,
+        NetOp::Pull,
+        // `--progress` for the same reason `fetch_args` carries it: a pull is a
+        // fetch, and the fetch half is the part that takes the time.
+        &["pull", "--progress", mode_flag, remote.as_str(), branch.as_str()],
         credentials.as_ref(),
     )
     .await
@@ -319,7 +380,9 @@ fn push_args(
     set_upstream: bool,
     no_verify: bool,
 ) -> Vec<String> {
-    let mut args: Vec<String> = vec!["push".to_string()];
+    // `--progress` for the same reason `fetch_args` carries it (#296): without
+    // it git stays silent on a non-tty stderr and there is no bar to draw.
+    let mut args: Vec<String> = vec!["push".to_string(), "--progress".to_string()];
     if set_upstream {
         args.push("-u".to_string());
     }
@@ -340,6 +403,7 @@ fn push_args(
 
 #[tauri::command]
 pub async fn push(
+    app: AppHandle,
     state: State<'_, AppState>,
     repo_id: String,
     remote: String,
@@ -372,7 +436,15 @@ pub async fn push(
 
     let args = push_args(&remote, &branch, force, needs_upstream, no_verify.unwrap_or(false));
     let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-    run_git_creds(&path, &arg_refs, credentials.as_ref()).await
+    run_git_progress(
+        &app,
+        &path,
+        &repo_id,
+        NetOp::Push,
+        &arg_refs,
+        credentials.as_ref(),
+    )
+    .await
 }
 
 #[cfg(test)]
@@ -383,11 +455,11 @@ mod push_args_tests {
     fn no_verify_is_added_only_when_asked() {
         assert_eq!(
             push_args("origin", "main", PushForce::None, false, false),
-            vec!["push", "origin", "main"]
+            vec!["push", "--progress", "origin", "main"]
         );
         assert_eq!(
             push_args("origin", "main", PushForce::None, false, true),
-            vec!["push", "origin", "main", "--no-verify"]
+            vec!["push", "--progress", "origin", "main", "--no-verify"]
         );
     }
 
@@ -397,6 +469,7 @@ mod push_args_tests {
             push_args("origin", "feat/x", PushForce::WithLease, true, true),
             vec![
                 "push",
+                "--progress",
                 "-u",
                 "origin",
                 "feat/x",
@@ -412,11 +485,11 @@ mod push_args_tests {
     fn adds_u_only_when_requested() {
         assert_eq!(
             push_args("origin", "main", PushForce::None, true, false),
-            vec!["push", "-u", "origin", "main"]
+            vec!["push", "--progress", "-u", "origin", "main"]
         );
         assert_eq!(
             push_args("origin", "main", PushForce::None, false, false),
-            vec!["push", "origin", "main"]
+            vec!["push", "--progress", "origin", "main"]
         );
     }
 
@@ -424,11 +497,11 @@ mod push_args_tests {
     fn force_flag_comes_last() {
         assert_eq!(
             push_args("origin", "main", PushForce::WithLease, false, false),
-            vec!["push", "origin", "main", "--force-with-lease"]
+            vec!["push", "--progress", "origin", "main", "--force-with-lease"]
         );
         assert_eq!(
             push_args("origin", "feat/x", PushForce::Force, true, false),
-            vec!["push", "-u", "origin", "feat/x", "--force"]
+            vec!["push", "--progress", "-u", "origin", "feat/x", "--force"]
         );
     }
 }
@@ -642,15 +715,15 @@ mod tests {
     fn fetch_args_with_prune() {
         assert_eq!(
             fetch_args(Some("origin"), true),
-            ["fetch", "--prune", "--", "origin"]
+            ["fetch", "--progress", "--prune", "--", "origin"]
         );
-        assert_eq!(fetch_args(None, true), ["fetch", "--all", "--prune"]);
+        assert_eq!(fetch_args(None, true), ["fetch", "--progress", "--all", "--prune"]);
     }
 
     #[test]
     fn fetch_args_without_prune() {
-        assert_eq!(fetch_args(Some("origin"), false), ["fetch", "--", "origin"]);
-        assert_eq!(fetch_args(None, false), ["fetch", "--all"]);
+        assert_eq!(fetch_args(Some("origin"), false), ["fetch", "--progress", "--", "origin"]);
+        assert_eq!(fetch_args(None, false), ["fetch", "--progress", "--all"]);
     }
 
     #[test]

--- a/src-tauri/src/commands/create.rs
+++ b/src-tauri/src/commands/create.rs
@@ -7,44 +7,9 @@ use crate::{
     error::{AppError, AppResult},
     git::libgit2::default_branch_name,
     git::types::{CloneProgress, RepoHandle},
+    progress::{ProgressReader, DEFAULT_TAIL_LINES},
     state::AppState,
 };
-
-/// Parse one stderr line from `git clone --progress`.
-///
-/// Git writes progress as `Receiving objects:  62% (620/1000)`, separated by
-/// carriage returns rather than newlines, and interleaves non-progress chatter
-/// ("Cloning into 'foo'...", "remote: Enumerating objects: 1000, done.").
-/// Unrecognized lines return `None` — a guess here would render a bogus bar.
-pub fn parse_progress(line: &str) -> Option<CloneProgress> {
-    let line = line.trim();
-    let (phase, rest) = line.split_once(':')?;
-    let phase = phase.trim();
-    if phase.is_empty() {
-        return None;
-    }
-    // Strip "remote:" prefix and parse the actual phase underneath.
-    if phase == "remote" {
-        return parse_progress(rest.trim());
-    }
-    // Reject non-progress lines that happen to have a colon.
-    if phase == "fatal" || phase == "warning" {
-        return None;
-    }
-    // Require an actual '%' character — split always yields at least one item,
-    // but we need to verify the delimiter was found.
-    let mut parts = rest.trim().splitn(2, '%');
-    let percent_token = parts.next()?.trim();
-    parts.next()?; // only Some when a '%' was actually present
-    let percent: u8 = percent_token.parse().ok()?;
-    if percent > 100 {
-        return None;
-    }
-    Some(CloneProgress {
-        phase: phase.to_string(),
-        percent,
-    })
-}
 
 /// The branch name the Init dialog should prefill.
 #[tauri::command]
@@ -289,20 +254,11 @@ pub async fn run_clone(
         .take()
         .ok_or_else(|| AppError::Internal("git clone produced no stderr pipe".into()))?;
 
-    // Git redraws each progress line with a bare `\r`; `\n` only shows up
-    // once, at the end of a phase ("...done."). Reading by `\n` alone (as
-    // `BufReader::read_until` did) buffers an entire phase — e.g. all of
-    // "Receiving objects" — and only releases it as one burst right before
-    // the next phase starts, which is not streaming: the bar freezes, then
-    // jumps. Read raw bytes as they arrive off the pipe and split on both
-    // `\r` and `\n`, carrying any trailing partial line across reads.
-    let mut tail: Vec<String> = Vec::new();
-    let mut pending: Vec<u8> = Vec::new();
+    // Splitting on `\r` as well as `\n`, the bounded `pending` buffer, and the
+    // progress/failure-tail classification all live in `progress.rs` now: fetch,
+    // pull and push read git's progress exactly the same way (#296).
+    let mut reader = ProgressReader::new(DEFAULT_TAIL_LINES);
     let mut chunk = [0u8; 4096];
-    // Bounds `pending` against a line that never gets a delimiter (a
-    // malformed or adversarial sideband stream) — `read_until` had no such
-    // bound and would have grown forever.
-    const MAX_PENDING: usize = 4096;
 
     loop {
         // Where a stalled clone actually sits: git has the connection open and
@@ -327,21 +283,10 @@ pub async fn run_clone(
         if read == 0 {
             break;
         }
-        pending.extend_from_slice(&chunk[..read]);
-        while let Some(idx) = pending.iter().position(|&b| b == b'\r' || b == b'\n') {
-            let line: Vec<u8> = pending.drain(..=idx).collect();
-            handle_clone_line(&line[..line.len() - 1], &mut on_progress, &mut tail);
-        }
-        if pending.len() > MAX_PENDING {
-            let overflow = std::mem::take(&mut pending);
-            handle_clone_line(&overflow, &mut on_progress, &mut tail);
-        }
+        reader.push(&chunk[..read], &mut on_progress);
     }
-    // EOF can leave one final undelimited line (e.g. git's last error
-    // message doesn't always end in a newline) — flush it too, or it's lost.
-    if !pending.is_empty() {
-        handle_clone_line(&pending, &mut on_progress, &mut tail);
-    }
+    reader.finish(&mut on_progress);
+    let tail = reader.into_tail();
 
     // Stderr at EOF means git has closed it, which it only does on the way out —
     // so this rarely waits. Selected on anyway: "rarely" is not "never", and a
@@ -435,29 +380,6 @@ fn clone_failure_message(tail: &[String], exit_code: Option<i32>) -> String {
     }
 }
 
-/// Classify one stderr segment (already split on `\r`/`\n`): feed progress
-/// lines to `on_progress`, keep everything else as context for a failure
-/// message. `parse_progress`'s contract is a single trimmed line — it must
-/// not see the delimiter itself.
-fn handle_clone_line(bytes: &[u8], on_progress: &mut impl FnMut(CloneProgress), tail: &mut Vec<String>) {
-    let line = String::from_utf8_lossy(bytes);
-    let line = line.trim();
-    if line.is_empty() {
-        return;
-    }
-    match parse_progress(line) {
-        Some(p) => on_progress(p),
-        // Keep non-progress lines: git's failure message is in here, and the
-        // exit status alone would say nothing useful.
-        None => {
-            tail.push(line.to_string());
-            if tail.len() > 20 {
-                tail.remove(0);
-            }
-        }
-    }
-}
-
 /// Clone `url` into `parent_dir/name`, emitting `clone://progress` as it goes.
 #[tauri::command]
 pub async fn clone_repo(
@@ -491,51 +413,6 @@ pub async fn clone_repo(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn parses_a_receiving_objects_line() {
-        assert_eq!(
-            parse_progress("Receiving objects:  62% (620/1000)"),
-            Some(CloneProgress { phase: "Receiving objects".into(), percent: 62 })
-        );
-    }
-
-    #[test]
-    fn parses_every_phase_git_reports() {
-        for (line, phase, pct) in [
-            ("Counting objects: 100% (10/10), done.", "Counting objects", 100),
-            ("Compressing objects:   5% (1/20)", "Compressing objects", 5),
-            ("Resolving deltas: 100% (3/3), done.", "Resolving deltas", 100),
-            ("remote: Compressing objects:  45% (9/20)", "Compressing objects", 45),
-        ] {
-            assert_eq!(
-                parse_progress(line),
-                Some(CloneProgress { phase: phase.into(), percent: pct }),
-                "failed on {line}"
-            );
-        }
-    }
-
-    #[test]
-    fn ignores_lines_that_are_not_progress() {
-        for line in [
-            "Cloning into 'foo'...",
-            "remote: Enumerating objects: 1000, done.",
-            "",
-            "warning: redirecting to https://example.com/repo.git/",
-            "fatal: repository 'https://example.com/nope.git/' not found",
-        ] {
-            assert_eq!(parse_progress(line), None, "should ignore {line}");
-        }
-    }
-
-    #[test]
-    fn rejects_a_percentless_number_instead_of_guessing() {
-        // `split('%')` yields the whole string when the delimiter is absent, so
-        // this used to parse as a confident 6%. Git delimits progress with \r,
-        // so a truncated read really can hand us this.
-        assert_eq!(parse_progress("Receiving objects: 6"), None);
-    }
 
     #[test]
     fn clone_failure_message_uses_the_tail_when_present() {

--- a/src-tauri/src/commands/net.rs
+++ b/src-tauri/src/commands/net.rs
@@ -6,6 +6,7 @@
 use std::path::Path;
 
 use serde::Deserialize;
+use tokio::io::AsyncReadExt;
 
 use crate::{
     cli::{ASKPASS_MODE_ENV, ASKPASS_SECRET_ENV, ASKPASS_USERNAME_ENV},
@@ -100,6 +101,29 @@ pub async fn run_git_authenticated(
     args: &[&str],
     creds: Option<&Credentials>,
 ) -> AppResult<()> {
+    run_git_authenticated_with_progress(cwd, args, creds, &mut |_| {}).await
+}
+
+/// [`run_git_authenticated`], reporting git's own progress as it arrives (#296).
+///
+/// The op must be run with `--progress` for there to be anything to report — git
+/// writes no sideband progress when stderr is not a tty, which it never is here.
+/// `fetch_args`/`push_args` add the flag; a caller that does not is simply one
+/// whose sink never fires, which is why the plain wrapper above can share this
+/// body rather than keeping a second spawn path alive.
+///
+/// Streaming stderr instead of `wait_with_output()`-ing it is the whole
+/// difference between "a spinner" and "62% of 1000 objects" — the same reason
+/// the clone path grew this first, and the splitter is literally the same one
+/// (`progress::ProgressReader`). `stdout` goes to `/dev/null`: nothing has ever
+/// read it, and having exactly one pipe to drain by hand is what removes the
+/// deadlock `wait_with_output` was here to avoid.
+pub async fn run_git_authenticated_with_progress(
+    cwd: &Path,
+    args: &[&str],
+    creds: Option<&Credentials>,
+    on_progress: &mut (dyn FnMut(crate::git::types::CloneProgress) + Send),
+) -> AppResult<()> {
     // `proc::git_async` carries GIT_TERMINAL_PROMPT=0 (which `apply_auth_env`
     // sets too), a closed stdin — nothing feeds it, so an unexpected read would
     // block forever — and, on Windows, CREATE_NO_WINDOW: without it every fetch,
@@ -107,31 +131,58 @@ pub async fn run_git_authenticated(
     // timer with no user action at all (issue 172).
     let mut cmd = crate::proc::git_async(cwd);
     cmd.args(args)
-        // `Command::output()` sets these itself; spawning by hand below to keep
-        // the `Child` reachable means setting them here instead.
-        .stdout(std::process::Stdio::piped())
+        // Discarded, and always was — this function returns `()`. Nulling it now
+        // also keeps a chatty op from filling a pipe nobody drains.
+        .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
-        // The kill on cancel: the branch below drops the `wait_with_output`
-        // future, which owns the `Child`, and a dropped `Child` with this set is
-        // a killed process. Also covers the window closing mid-fetch.
+        // The kill on cancel: the branches below return without reaping, which
+        // drops the `Child`, and a dropped `Child` with this set is a killed
+        // process. Also covers the window closing mid-fetch.
         .kill_on_drop(true);
     apply_auth_env(&mut cmd, creds);
 
     let (_registration, mut cancel) = crate::cancel::register(crate::cancel::Scope::repo(cwd));
 
-    let child = cmd.spawn().map_err(|e| AppError::Io(e.to_string()))?;
-    // `wait_with_output` and not two manual pipe reads: it drains stdout and
-    // stderr concurrently, and a fetch whose stderr filled the pipe buffer while
-    // we waited on the exit status would deadlock.
-    let output = tokio::select! {
-        // `biased` so a pending cancel is never lost to a coin toss against a
-        // child that happens to be ready in the same poll.
+    let mut child = cmd.spawn().map_err(|e| AppError::Io(e.to_string()))?;
+    let mut stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| AppError::Internal("git produced no stderr pipe".into()))?;
+
+    let mut reader = crate::progress::ProgressReader::new(crate::progress::DEFAULT_TAIL_LINES);
+    let mut chunk = [0u8; 4096];
+    loop {
+        // Where a stalled fetch actually sits: the connection is open and the
+        // remote is saying nothing, so this read never completes. Selecting on
+        // the cancel token here is what keeps Cancel working (#234) now that the
+        // wait is spread across many reads instead of one `wait_with_output`.
+        let read = tokio::select! {
+            // `biased` so a pending cancel is never lost to a coin toss against a
+            // child that happens to be ready in the same poll. Without it, a
+            // fast-streaming fetch would keep winning that toss for an unbounded
+            // number of iterations after the user had already pressed Cancel.
+            biased;
+            _ = cancel.cancelled() => return Err(AppError::Cancelled),
+            r = stderr.read(&mut chunk) => r.map_err(|e| AppError::Io(e.to_string()))?,
+        };
+        if read == 0 {
+            break;
+        }
+        reader.push(&chunk[..read], on_progress);
+    }
+    reader.finish(on_progress);
+    let tail = reader.into_tail();
+
+    // Stderr at EOF means git has closed it, which it only does on the way out,
+    // so this rarely waits — but "rarely" is not "never", and a git that hung
+    // after its last output would otherwise be the one op Cancel could not stop.
+    let status = tokio::select! {
         biased;
         _ = cancel.cancelled() => return Err(AppError::Cancelled),
-        finished = child.wait_with_output() => finished.map_err(|e| AppError::Io(e.to_string()))?,
+        s = child.wait() => s.map_err(|e| AppError::Io(e.to_string()))?,
     };
 
-    if !output.status.success() {
+    if !status.success() {
         // A cancel that lands while git is already dying loses the `select!`
         // race, and git's last words ("the remote end hung up unexpectedly")
         // would then be reported as a network failure to a user who pressed
@@ -139,7 +190,12 @@ pub async fn run_git_authenticated(
         if cancel.is_cancelled() {
             return Err(AppError::Cancelled);
         }
-        return Err(map_git_failure(&String::from_utf8_lossy(&output.stderr)));
+        // The tail, not raw stderr: progress redraws are already filtered out of
+        // it, so the classifier and the message the user reads see git's actual
+        // words rather than five hundred copies of "Receiving objects". Every
+        // non-progress line is kept, which is what `classify_auth_failure` and
+        // `host_from_stderr` need.
+        return Err(map_git_failure(&tail.join("\n")));
     }
     Ok(())
 }

--- a/src-tauri/src/commands/rebase.rs
+++ b/src-tauri/src/commands/rebase.rs
@@ -1,4 +1,4 @@
-use tauri::State;
+use tauri::{AppHandle, Emitter, State};
 
 use crate::{
     error::{AppError, AppResult},
@@ -6,29 +6,47 @@ use crate::{
     state::AppState,
 };
 
+/// Publish one replay step to `rebase://progress` (#296).
+///
+/// A dropped event costs one tick of the counter, never the rebase — the same
+/// policy `clone://progress` and `net://progress` take.
+fn emit_progress(app: &AppHandle) -> impl Fn(crate::git::types::RebaseProgress) + Send + Sync + '_ {
+    move |p| {
+        let _ = app.emit("rebase://progress", &p);
+    }
+}
+
 #[tauri::command]
 pub async fn rebase_start(
+    app: AppHandle,
     state: State<'_, AppState>,
     repo_id: String,
     plan: Vec<RebaseStep>,
 ) -> AppResult<RebaseStatus> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
-    tokio::task::spawn_blocking(move || backend.rebase_start(&repo_id, plan))
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+    // The whole plan replays inside this one blocking call, so without the sink
+    // the frontend learns nothing until it is over (#296).
+    tokio::task::spawn_blocking(move || {
+        backend.rebase_start_with_progress(&repo_id, plan, &emit_progress(&app))
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
 #[tauri::command]
 pub async fn rebase_continue(
+    app: AppHandle,
     state: State<'_, AppState>,
     repo_id: String,
 ) -> AppResult<RebaseStatus> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
-    tokio::task::spawn_blocking(move || backend.rebase_continue(&repo_id))
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+    tokio::task::spawn_blocking(move || {
+        backend.rebase_continue_with_progress(&repo_id, &emit_progress(&app))
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
 #[tauri::command]

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -7,7 +7,7 @@ use super::{
         AheadBehind, BisectMark, BisectStatus, BlameResult, BranchInfo, CommitInfo, CommitNote, CommitOptions, CommitResult, ConflictSides,
         DeleteFailure, DiffKind, FileContent,
         BulkFastForward, FastForward,
-        FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage, RebaseStatus, RebaseStep, ReflogEntry,
+        FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage, RebaseProgressSink, RebaseStatus, RebaseStep, ReflogEntry,
         BlobSource, ImagePreview,
         RemoteInfo, RepoHandle, RepoId, RepoState, ResetMode, StashInfo, StashSaveOptions,
         SubmoduleInfo, TagInfo,
@@ -418,10 +418,19 @@ impl GitBackend for CliBackend {
     fn continue_operation(&self, _repo_id: &RepoId) -> AppResult<String> {
         Err(AppError::NotImplemented)
     }
-    fn rebase_start(&self, _repo_id: &RepoId, _plan: Vec<RebaseStep>) -> AppResult<RebaseStatus> {
+    fn rebase_start_with_progress(
+        &self,
+        _repo_id: &RepoId,
+        _plan: Vec<RebaseStep>,
+        _on_progress: RebaseProgressSink<'_>,
+    ) -> AppResult<RebaseStatus> {
         Err(AppError::NotImplemented)
     }
-    fn rebase_continue(&self, _repo_id: &RepoId) -> AppResult<RebaseStatus> {
+    fn rebase_continue_with_progress(
+        &self,
+        _repo_id: &RepoId,
+        _on_progress: RebaseProgressSink<'_>,
+    ) -> AppResult<RebaseStatus> {
         Err(AppError::NotImplemented)
     }
     fn rebase_abort(&self, _repo_id: &RepoId) -> AppResult<()> {

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -28,7 +28,8 @@ use super::{
         DiffLine, DiffLineKind, FastForward, FileContent, FileDiff, FileStatus, HeadInfo, ImagePreview,
         LfsStatus,
         LogFilter, LogPage,
-        RebaseAction, RebaseStatus, RebaseStep, RebaseSummary, ReflogEntry, ReflogOp, RemoteInfo,
+        RebaseAction, RebaseProgress, RebaseProgressSink, RebaseStatus, RebaseStep, RebaseSummary,
+        ReflogEntry, ReflogOp, RemoteInfo,
         RepoHandle, RepoId, RepoState, ResetMode, StashInfo, StashSaveOptions, StatusFlag,
         SubmoduleInfo, TagInfo, TagTarget, UnsupportedReason, WorkdirDiff, WorktreeBranch, WorktreeInfo,
         REFSPEC_ALL,
@@ -662,10 +663,34 @@ impl Libgit2Backend {
         self.rebase_status(repo_id)
     }
 
+    /// The subject line of `oid`, for a progress tick. Best-effort: a step whose
+    /// commit cannot be read still replays, and an empty subject just means the
+    /// status line shows the oid alone (#296).
+    fn step_subject(&self, repo_id: &RepoId, oid: &str) -> String {
+        self.with_repo(repo_id, |repo| {
+            Ok(repo
+                .revparse_single(oid)
+                .ok()
+                .and_then(|o| o.peel_to_commit().ok())
+                .and_then(|c| c.summary().map(str::to_string))
+                .unwrap_or_default())
+        })
+        .unwrap_or_default()
+    }
+
     /// The main execution loop: pops steps off the front of the plan and
     /// applies them until either (a) the plan is exhausted, or (b) a step
     /// pauses execution (conflict / edit).
-    fn advance_rebase(&self, repo_id: &RepoId) -> AppResult<RebaseStatus> {
+    ///
+    /// `on_progress` fires once per step, BEFORE it is applied (#296). The
+    /// whole plan runs inside this one call, so a tick here is the only way the
+    /// frontend learns anything before the run ends — `rebase_status` is
+    /// accurate throughout, but nothing polls it mid-replay.
+    fn advance_rebase(
+        &self,
+        repo_id: &RepoId,
+        on_progress: RebaseProgressSink<'_>,
+    ) -> AppResult<RebaseStatus> {
         loop {
             // Resume a conflict step first (its cherry-pick already ran and the
             // user has resolved + staged the tree), else take the next planned
@@ -726,6 +751,32 @@ impl Libgit2Backend {
                 status.last_completed = Some(summary);
                 return Ok(status);
             };
+
+            // Announce the step before doing any of its work: the tick is what
+            // the status line and the operation bar render while this iteration
+            // runs, and one published after the fact would always be one step
+            // behind. Drops are announced too — they are part of the plan's
+            // total, so skipping them would make the counter appear to stall.
+            {
+                let (next_index, total) = {
+                    let rebases = self
+                        .rebases
+                        .lock()
+                        .map_err(|e| AppError::Internal(e.to_string()))?;
+                    match rebases.get(repo_id) {
+                        Some(s) => (s.completed, s.total),
+                        None => (0, 0),
+                    }
+                };
+                on_progress(RebaseProgress {
+                    repo_id: repo_id.0.clone(),
+                    next_index,
+                    total,
+                    action: step.action,
+                    short_oid: crate::git::rebase_plan::short(&step.oid).to_string(),
+                    subject: self.step_subject(repo_id, &step.oid),
+                });
+            }
 
             // Drop is never cherry-picked, so it is never a resume step. It
             // still maps into `rewritten` — as the HEAD it left behind — so a
@@ -5249,7 +5300,12 @@ impl GitBackend for Libgit2Backend {
         Ok(())
     }
 
-    fn rebase_start(&self, repo_id: &RepoId, plan: Vec<RebaseStep>) -> AppResult<RebaseStatus> {
+    fn rebase_start_with_progress(
+        &self,
+        repo_id: &RepoId,
+        plan: Vec<RebaseStep>,
+        on_progress: RebaseProgressSink<'_>,
+    ) -> AppResult<RebaseStatus> {
         // Validate BEFORE touching anything. An unexecutable step used to be
         // discovered mid-replay, with earlier picks already committed and the
         // branch tip already moved.
@@ -5355,10 +5411,14 @@ impl GitBackend for Libgit2Backend {
         // the first commit must still be recoverable.
         self.persist_rebase(repo_id)?;
 
-        self.advance_rebase(repo_id)
+        self.advance_rebase(repo_id, on_progress)
     }
 
-    fn rebase_continue(&self, repo_id: &RepoId) -> AppResult<RebaseStatus> {
+    fn rebase_continue_with_progress(
+        &self,
+        repo_id: &RepoId,
+        on_progress: RebaseProgressSink<'_>,
+    ) -> AppResult<RebaseStatus> {
         // A rebase started by an earlier session has no in-memory entry; its
         // plan, progress, and rewritten map are all on disk.
         let known = {
@@ -5382,7 +5442,7 @@ impl GitBackend for Libgit2Backend {
             }
             Ok(())
         })?;
-        self.advance_rebase(repo_id)
+        self.advance_rebase(repo_id, on_progress)
     }
 
     fn rebase_abort(&self, repo_id: &RepoId) -> AppResult<()> {

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -27,7 +27,7 @@ use types::{
     BisectMark, BisectStatus, BlameResult, BranchInfo, CommitInfo, CommitNote, CommitOptions, CommitResult, ConflictSides,
     DeleteFailure, DiffKind, FileContent,
     BulkFastForward, FastForward,
-    FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage, RebaseStatus, RebaseStep, ReflogEntry,
+    FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage, RebaseProgressSink, RebaseStatus, RebaseStep, ReflogEntry,
     BlobSource, ImagePreview,
     RemoteInfo,
     RepoHandle,
@@ -679,8 +679,30 @@ pub trait GitBackend: Send + Sync {
     fn continue_operation(&self, repo_id: &RepoId) -> AppResult<String>;
 
     // === interactive rebase ===
-    fn rebase_start(&self, repo_id: &RepoId, plan: Vec<RebaseStep>) -> AppResult<RebaseStatus>;
-    fn rebase_continue(&self, repo_id: &RepoId) -> AppResult<RebaseStatus>;
+    /// Replay `plan`, reporting each step boundary to `on_progress` (#296).
+    ///
+    /// The whole plan runs inside this ONE call — it returns only when the plan
+    /// is exhausted or a step pauses — so without a sink there is no way to
+    /// render progress for the part of a long rebase that actually takes time.
+    fn rebase_start_with_progress(
+        &self,
+        repo_id: &RepoId,
+        plan: Vec<RebaseStep>,
+        on_progress: RebaseProgressSink<'_>,
+    ) -> AppResult<RebaseStatus>;
+    /// [`Self::rebase_start_with_progress`] for a caller that has nowhere to put
+    /// the ticks — every test, and `resolve_and_continue`'s internal resume.
+    fn rebase_start(&self, repo_id: &RepoId, plan: Vec<RebaseStep>) -> AppResult<RebaseStatus> {
+        self.rebase_start_with_progress(repo_id, plan, &|_| {})
+    }
+    fn rebase_continue_with_progress(
+        &self,
+        repo_id: &RepoId,
+        on_progress: RebaseProgressSink<'_>,
+    ) -> AppResult<RebaseStatus>;
+    fn rebase_continue(&self, repo_id: &RepoId) -> AppResult<RebaseStatus> {
+        self.rebase_continue_with_progress(repo_id, &|_| {})
+    }
     fn rebase_abort(&self, repo_id: &RepoId) -> AppResult<()>;
     fn rebase_status(&self, repo_id: &RepoId) -> AppResult<RebaseStatus>;
     /// Drop the retained `RebaseStatus.last_completed` summary. Called once the

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -737,6 +737,38 @@ pub struct RebaseStatus {
     pub last_completed: Option<RebaseSummary>,
 }
 
+/// One step boundary during a rebase replay, as emitted on `rebase://progress`
+/// (#296).
+///
+/// `rebase_start` returns a [`RebaseStatus`] only when the plan finishes or
+/// pauses, so `OperationBar`'s "step N of M" could never render during the part
+/// that actually takes time. This is the same counter, published as it moves.
+///
+/// Emitted BEFORE the step is applied, so `next_index` is the number of steps
+/// already done and the step being announced is `next_index + 1` — exactly the
+/// arithmetic `RebaseStatus.next_index` already gets.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RebaseProgress {
+    pub repo_id: String,
+    pub next_index: usize,
+    pub total: usize,
+    pub action: RebaseAction,
+    /// Abbreviated pre-rebase oid of the commit being replayed.
+    pub short_oid: String,
+    /// The commit's subject line; empty when it could not be read, which is not
+    /// worth failing a rebase over.
+    pub subject: String,
+}
+
+/// Where [`RebaseProgress`] ticks go.
+///
+/// `&dyn` rather than a generic parameter because `GitBackend` must stay
+/// object-safe — `AppState` holds an `Arc<dyn GitBackend>`. `Send + Sync`
+/// because the sink closes over a Tauri `AppHandle` and runs inside
+/// `spawn_blocking`.
+pub type RebaseProgressSink<'a> = &'a (dyn Fn(RebaseProgress) + Send + Sync);
+
 /// How to integrate fetched changes during a pull.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PullMode {
@@ -789,6 +821,35 @@ pub struct ReflogEntry {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CloneProgress {
+    pub phase: String,
+    pub percent: u8,
+}
+
+/// Which network op a `net://progress` tick belongs to (#296).
+///
+/// One variant per `RepoActivity` key that can report a percentage, so the
+/// frontend can route a tick to the indicator already on screen rather than
+/// inventing a second one. LFS and submodule ops are deliberately absent: they
+/// are `git lfs`/`git submodule` wrappers whose stderr is not git's own
+/// `--progress` sideband, so they get a label and a Cancel button but no bar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum NetOp {
+    Fetch,
+    Pull,
+    Push,
+}
+
+/// One progress tick from a fetch, pull or push, as emitted on `net://progress`.
+///
+/// Carries `repo_id` because the event is app-global while the indicator is
+/// per-repository: a tick from a background tab's fetch must not drive the
+/// active tab's bar. Same `phase`/`percent` shape as [`CloneProgress`], because
+/// it is parsed out of the same sideband by the same parser.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NetProgress {
+    pub repo_id: String,
+    pub op: NetOp,
     pub phase: String,
     pub percent: u8,
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ pub mod forge;
 pub mod git;
 pub mod opener;
 pub mod proc;
+pub mod progress;
 pub mod reveal;
 pub mod state;
 pub mod update;

--- a/src-tauri/src/progress.rs
+++ b/src-tauri/src/progress.rs
@@ -1,0 +1,275 @@
+//! Reading git's own progress reporting off a child's stderr (#296).
+//!
+//! Clone had this first and kept it private; fetch, pull and push now need the
+//! identical thing, so the parser and the byte-splitter live here rather than
+//! being copied. Both callers keep their own `tokio::select!` loop — the cancel
+//! arms differ (a cancelled clone deletes its destination, a cancelled fetch
+//! does not), and that difference is not worth a callback to abstract over.
+//!
+//! What is shared is everything below the read: how a chunk of bytes becomes
+//! lines, which lines are progress, and what is kept for the failure message.
+
+use crate::git::types::CloneProgress;
+
+/// How many non-progress stderr lines a reader keeps by default.
+///
+/// The tail is what a failed op reports, and git puts its `fatal:` last, so
+/// keeping the END of the stream is what matters — not the start. Twenty covers
+/// git's own multi-line advice blocks (`! [rejected]` + the hint paragraph)
+/// without letting a chatty `remote:` banner become the error message.
+pub const DEFAULT_TAIL_LINES: usize = 20;
+
+/// Parse one stderr line from a git command run with `--progress`.
+///
+/// Git writes progress as `Receiving objects:  62% (620/1000)`, separated by
+/// carriage returns rather than newlines, and interleaves non-progress chatter
+/// ("Cloning into 'foo'...", "remote: Enumerating objects: 1000, done.").
+/// Unrecognized lines return `None` — a guess here would render a bogus bar.
+pub fn parse_progress(line: &str) -> Option<CloneProgress> {
+    let line = line.trim();
+    let (phase, rest) = line.split_once(':')?;
+    let phase = phase.trim();
+    if phase.is_empty() {
+        return None;
+    }
+    // Strip "remote:" prefix and parse the actual phase underneath.
+    if phase == "remote" {
+        return parse_progress(rest.trim());
+    }
+    // Reject non-progress lines that happen to have a colon.
+    if phase == "fatal" || phase == "warning" || phase == "error" || phase == "hint" {
+        return None;
+    }
+    // Require an actual '%' character — split always yields at least one item,
+    // but we need to verify the delimiter was found.
+    let mut parts = rest.trim().splitn(2, '%');
+    let percent_token = parts.next()?.trim();
+    parts.next()?; // only Some when a '%' was actually present
+    let percent: u8 = percent_token.parse().ok()?;
+    if percent > 100 {
+        return None;
+    }
+    Some(CloneProgress {
+        phase: phase.to_string(),
+        percent,
+    })
+}
+
+/// Turns raw stderr chunks into progress ticks plus a failure-message tail.
+///
+/// Git redraws each progress line with a bare `\r`; `\n` only shows up once, at
+/// the end of a phase ("...done."). Reading by `\n` alone (as
+/// `BufReader::read_until` did) buffers an entire phase — e.g. all of
+/// "Receiving objects" — and only releases it as one burst right before the
+/// next phase starts, which is not streaming: the bar freezes, then jumps. So
+/// callers read raw bytes as they arrive off the pipe and hand them here, and
+/// this splits on both `\r` and `\n`, carrying any trailing partial line across
+/// reads.
+pub struct ProgressReader {
+    pending: Vec<u8>,
+    tail: Vec<String>,
+    max_tail: usize,
+}
+
+/// Bounds `pending` against a line that never gets a delimiter (a malformed or
+/// adversarial sideband stream) — `read_until` had no such bound and would have
+/// grown forever.
+const MAX_PENDING: usize = 4096;
+
+impl ProgressReader {
+    pub fn new(max_tail: usize) -> Self {
+        Self {
+            pending: Vec::new(),
+            tail: Vec::new(),
+            max_tail,
+        }
+    }
+
+    /// Feed the bytes of one read. Complete lines are classified immediately;
+    /// an unterminated remainder waits for the next chunk.
+    pub fn push(&mut self, bytes: &[u8], on_progress: &mut (impl FnMut(CloneProgress) + ?Sized)) {
+        self.pending.extend_from_slice(bytes);
+        while let Some(idx) = self.pending.iter().position(|&b| b == b'\r' || b == b'\n') {
+            let line: Vec<u8> = self.pending.drain(..=idx).collect();
+            self.classify(&line[..line.len() - 1], on_progress);
+        }
+        if self.pending.len() > MAX_PENDING {
+            let overflow = std::mem::take(&mut self.pending);
+            self.classify(&overflow, on_progress);
+        }
+    }
+
+    /// Flush the final undelimited line at EOF — git's last error message does
+    /// not always end in a newline, and it would otherwise be lost.
+    pub fn finish(&mut self, on_progress: &mut (impl FnMut(CloneProgress) + ?Sized)) {
+        if !self.pending.is_empty() {
+            let pending = std::mem::take(&mut self.pending);
+            self.classify(&pending, on_progress);
+        }
+    }
+
+    /// Everything that was not a progress tick, newest last.
+    pub fn into_tail(self) -> Vec<String> {
+        self.tail
+    }
+
+    /// Classify one stderr segment (already split on `\r`/`\n`): feed progress
+    /// lines to `on_progress`, keep everything else as context for a failure
+    /// message. `parse_progress`'s contract is a single trimmed line — it must
+    /// not see the delimiter itself.
+    fn classify(&mut self, bytes: &[u8], on_progress: &mut (impl FnMut(CloneProgress) + ?Sized)) {
+        let line = String::from_utf8_lossy(bytes);
+        let line = line.trim();
+        if line.is_empty() {
+            return;
+        }
+        match parse_progress(line) {
+            Some(p) => on_progress(p),
+            // Keep non-progress lines: git's failure message is in here, and the
+            // exit status alone would say nothing useful.
+            None => {
+                self.tail.push(line.to_string());
+                if self.tail.len() > self.max_tail {
+                    self.tail.remove(0);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn drain(chunks: &[&[u8]]) -> (Vec<CloneProgress>, Vec<String>) {
+        let mut reader = ProgressReader::new(DEFAULT_TAIL_LINES);
+        let mut seen = Vec::new();
+        for chunk in chunks {
+            reader.push(chunk, &mut |p| seen.push(p));
+        }
+        reader.finish(&mut |p| seen.push(p));
+        (seen, reader.into_tail())
+    }
+
+    #[test]
+    fn parses_a_receiving_objects_line() {
+        assert_eq!(
+            parse_progress("Receiving objects:  62% (620/1000)"),
+            Some(CloneProgress {
+                phase: "Receiving objects".into(),
+                percent: 62
+            })
+        );
+    }
+
+    #[test]
+    fn parses_every_phase_git_reports() {
+        for (line, phase, pct) in [
+            ("Counting objects: 100% (10/10), done.", "Counting objects", 100),
+            ("Compressing objects:   5% (1/20)", "Compressing objects", 5),
+            ("Resolving deltas: 100% (3/3), done.", "Resolving deltas", 100),
+            ("remote: Compressing objects:  45% (9/20)", "Compressing objects", 45),
+            // Push-side phases, which clone never sees.
+            ("Writing objects:  33% (1/3)", "Writing objects", 33),
+            ("Enumerating objects:  10% (1/10)", "Enumerating objects", 10),
+        ] {
+            assert_eq!(
+                parse_progress(line),
+                Some(CloneProgress {
+                    phase: phase.into(),
+                    percent: pct
+                }),
+                "failed on {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn ignores_lines_that_are_not_progress() {
+        for line in [
+            "Cloning into 'foo'...",
+            "remote: Enumerating objects: 1000, done.",
+            "",
+            "warning: redirecting to https://example.com/repo.git/",
+            "fatal: repository 'https://example.com/nope.git/' not found",
+            // Push's rejection advice is a colon-bearing multi-line block that
+            // must reach the failure message rather than be eaten as progress.
+            "hint: Updates were rejected because the tip of your current branch is behind",
+            "error: failed to push some refs to 'origin'",
+        ] {
+            assert_eq!(parse_progress(line), None, "should ignore {line}");
+        }
+    }
+
+    #[test]
+    fn rejects_a_percentless_number_instead_of_guessing() {
+        // `split('%')` yields the whole string when the delimiter is absent, so
+        // this used to parse as a confident 6%. Git delimits progress with \r,
+        // so a truncated read really can hand us this.
+        assert_eq!(parse_progress("Receiving objects: 6"), None);
+    }
+
+    #[test]
+    fn splits_on_carriage_returns_so_a_phase_streams() {
+        // The whole point: one read carrying four redraws must yield four ticks,
+        // not one burst at the end of the phase.
+        let (seen, tail) = drain(&[
+            b"Receiving objects:  10% (1/10)\rReceiving objects:  50% (5/10)\r",
+            b"Receiving objects: 100% (10/10), done.\n",
+        ]);
+        assert_eq!(
+            seen.iter().map(|p| p.percent).collect::<Vec<_>>(),
+            [10, 50, 100]
+        );
+        assert!(tail.is_empty());
+    }
+
+    #[test]
+    fn carries_a_partial_line_across_reads() {
+        // A pipe read splits wherever it likes, including mid-percentage.
+        let (seen, _) = drain(&[b"Receiving objec", b"ts:  62% (620/1000)\r"]);
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].percent, 62);
+    }
+
+    #[test]
+    fn keeps_non_progress_lines_for_the_failure_message() {
+        let (seen, tail) = drain(&[
+            b"Receiving objects: 100% (10/10)\r",
+            b"fatal: could not read Username for 'https://example.com'\n",
+        ]);
+        assert_eq!(seen.len(), 1);
+        assert_eq!(
+            tail,
+            ["fatal: could not read Username for 'https://example.com'"]
+        );
+    }
+
+    #[test]
+    fn a_final_line_without_a_newline_is_not_lost() {
+        // Git's last error message does not always end in a delimiter, and it is
+        // the one line the user most needs to see.
+        let (_, tail) = drain(&[b"fatal: repository not found"]);
+        assert_eq!(tail, ["fatal: repository not found"]);
+    }
+
+    #[test]
+    fn the_tail_keeps_the_newest_lines_not_the_oldest() {
+        // The fatal is last. A cap that dropped from the end would throw away
+        // the only line worth reporting.
+        let mut reader = ProgressReader::new(2);
+        for line in ["remote: one\n", "remote: two\n", "fatal: three\n"] {
+            reader.push(line.as_bytes(), &mut |_| {});
+        }
+        assert_eq!(reader.into_tail(), ["remote: two", "fatal: three"]);
+    }
+
+    #[test]
+    fn an_undelimited_flood_is_bounded_rather_than_buffered_forever() {
+        let mut reader = ProgressReader::new(DEFAULT_TAIL_LINES);
+        let flood = vec![b'x'; MAX_PENDING * 3];
+        reader.push(&flood, &mut |_| {});
+        // Forced out in MAX_PENDING-sized pieces rather than held in `pending`.
+        assert!(!reader.into_tail().is_empty());
+    }
+}

--- a/src-tauri/tests/net_progress.rs
+++ b/src-tauri/tests/net_progress.rs
@@ -1,0 +1,181 @@
+//! Progress and failure reporting from the shared network runner (#296).
+//!
+//! `run_git_authenticated` used to `wait_with_output()` its child: one buffered
+//! read at the end, no `--progress`, and therefore no way to tell a 300 MB fetch
+//! from a stalled one. It streams now, which changes two things worth pinning
+//! against a real `git`:
+//!
+//! 1. **Ticks actually arrive.** The parser is unit-tested in `progress.rs`
+//!    against captured lines; this tests the whole path — flag, spawn, pipe,
+//!    splitter, sink — with git as the author of the bytes. A `file://` remote
+//!    is enough: git runs a real pack transfer over it and reports progress,
+//!    while a plain path clone hardlinks and reports nothing.
+//! 2. **A failure still says what git said.** `map_git_failure` is now fed the
+//!    reader's tail rather than raw stderr. If the filtering ever swallowed the
+//!    `fatal:` line, every network error in the app would degrade to a bare exit
+//!    code — and no unit test of the parser would notice.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use platypusgit_lib::commands::net::{run_git_authenticated, run_git_authenticated_with_progress};
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::types::CloneProgress;
+
+fn git(cwd: &Path, args: &[&str]) {
+    let status = std::process::Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@example.invalid")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@example.invalid")
+        .status()
+        .expect("run git");
+    assert!(status.success(), "git {args:?} failed");
+}
+
+fn commit_files(repo: &Path, prefix: &str, count: usize) {
+    for i in 0..count {
+        std::fs::write(repo.join(format!("{prefix}{i}.txt")), format!("{prefix} {i}\n")).unwrap();
+    }
+    git(repo, &["add", "-A"]);
+    git(repo, &["commit", "-qm", prefix]);
+}
+
+/// A bare origin, and a clone of it that is one commit behind.
+///
+/// Returned as `(clone_dir, _tempdir)` — the `TempDir` guard has to outlive the
+/// test or the whole fixture is deleted before git is done with it.
+fn behind_clone() -> (PathBuf, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let origin = dir.path().join("origin.git");
+    let seed = dir.path().join("seed");
+    let clone = dir.path().join("clone");
+    std::fs::create_dir_all(&seed).unwrap();
+
+    git(dir.path(), &["init", "-q", "--bare", "origin.git"]);
+    git(&seed, &["init", "-q", "-b", "main"]);
+    commit_files(&seed, "first", 40);
+    let url = format!("file://{}", origin.display());
+    git(&seed, &["remote", "add", "origin", &url]);
+    git(&seed, &["push", "-q", "origin", "main"]);
+
+    git(dir.path(), &["clone", "-q", &url, "clone"]);
+
+    // Move origin ahead, so the clone's fetch has a real pack to transfer.
+    commit_files(&seed, "second", 60);
+    git(&seed, &["push", "-q", "origin", "main"]);
+
+    (clone, dir)
+}
+
+#[tokio::test]
+async fn a_fetch_reports_gits_own_progress() {
+    let (clone, _guard) = behind_clone();
+    let seen: Mutex<Vec<CloneProgress>> = Mutex::new(Vec::new());
+
+    // The same argv `fetch_args` builds — `--progress` included, which is the
+    // whole reason there is anything on stderr to read.
+    run_git_authenticated_with_progress(
+        &clone,
+        &["fetch", "--progress", "--", "origin"],
+        None,
+        &mut |p| seen.lock().unwrap().push(p),
+    )
+    .await
+    .expect("the fetch itself must succeed");
+
+    let seen = seen.into_inner().unwrap();
+    assert!(
+        !seen.is_empty(),
+        "no progress ticks — git was not run with --progress, or the reader is not \
+         splitting on the carriage returns git redraws with"
+    );
+    assert!(
+        seen.iter().all(|p| p.percent <= 100 && !p.phase.is_empty()),
+        "every tick must carry a usable phase and percentage: {seen:?}"
+    );
+    // Git counts up within a phase. Anything else means the splitter is handing
+    // whole buffers to the parser instead of one redraw at a time.
+    assert!(
+        seen.iter().any(|p| p.percent == 100),
+        "a completed phase must reach 100%: {seen:?}"
+    );
+}
+
+#[tokio::test]
+async fn the_quiet_wrapper_runs_the_same_op_without_a_sink() {
+    // `run_git_authenticated` delegates to the streaming body with a no-op sink.
+    // If that delegation ever broke, every op in the app that does not want
+    // progress would break with it.
+    let (clone, _guard) = behind_clone();
+
+    run_git_authenticated(&clone, &["fetch", "--progress", "--", "origin"], None)
+        .await
+        .expect("a sinkless fetch must still fetch");
+}
+
+#[tokio::test]
+async fn a_failure_still_carries_gits_own_words() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().to_path_buf();
+    git(&repo, &["init", "-q"]);
+
+    let err = run_git_authenticated(&repo, &["fetch", "--progress", "--", "nope"], None)
+        .await
+        .expect_err("fetching an undefined remote must fail");
+
+    // Not `AppError::Auth` — there is no credential to ask for here — and not an
+    // empty message: the tail must reach the classifier intact.
+    match err {
+        AppError::Network(msg) => {
+            assert!(
+                msg.contains("nope"),
+                "the error must name what git complained about, got: {msg:?}"
+            );
+        }
+        other => panic!("expected AppError::Network, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn progress_lines_are_kept_out_of_the_failure_message() {
+    // A push that transfers a pack and THEN gets rejected: the message the user
+    // reads must be git's rejection, not the five hundred redraws in front of it.
+    let dir = tempfile::tempdir().unwrap();
+    let origin = dir.path().join("origin.git");
+    let work = dir.path().join("work");
+    std::fs::create_dir_all(&work).unwrap();
+
+    git(dir.path(), &["init", "-q", "--bare", "origin.git"]);
+    git(&work, &["init", "-q", "-b", "main"]);
+    commit_files(&work, "base", 40);
+    let url = format!("file://{}", origin.display());
+    git(&work, &["remote", "add", "origin", &url]);
+    git(&work, &["push", "-q", "origin", "main"]);
+
+    // Refuse the update: origin moves on, and the local side rewinds so its push
+    // is a non-fast-forward.
+    let other = dir.path().join("other");
+    git(dir.path(), &["clone", "-q", &url, "other"]);
+    commit_files(&other, "theirs", 5);
+    git(&other, &["push", "-q", "origin", "main"]);
+    commit_files(&work, "mine", 40);
+
+    let err = run_git_authenticated(&work, &["push", "--progress", "origin", "main"], None)
+        .await
+        .expect_err("a non-fast-forward push must fail");
+
+    let AppError::Network(msg) = err else {
+        panic!("expected AppError::Network");
+    };
+    assert!(
+        msg.contains("rejected") || msg.contains("fetch first") || msg.contains("non-fast-forward"),
+        "the rejection must survive: {msg:?}"
+    );
+    assert!(
+        !msg.contains('%'),
+        "progress redraws must not be part of what the user reads: {msg:?}"
+    );
+}

--- a/src-tauri/tests/rebase_progress.rs
+++ b/src-tauri/tests/rebase_progress.rs
@@ -1,0 +1,213 @@
+//! Live progress from a rebase replay (#296).
+//!
+//! `rebase_start` runs the entire plan inside one call and returns a
+//! `RebaseStatus` only when it finishes or pauses, so the operation bar's
+//! "step N of M" could only ever render at a pause — never during the replay,
+//! which is the part that takes the time on a long plan. These tests pin the
+//! sink that fixes that:
+//!
+//! - one tick per step, in plan order, before the step is applied;
+//! - `next_index` counts steps ALREADY done, matching `RebaseStatus.next_index`,
+//!   so the same `+ 1` arithmetic renders both;
+//! - drops tick too — they are part of `total`, and skipping them would make the
+//!   counter appear to stall;
+//! - a pause stops the ticks where the replay stopped, and `rebase_continue`
+//!   resumes them rather than restarting from zero;
+//! - the plain `rebase_start` still works, because every test and internal
+//!   resume in the codebase calls it.
+
+mod support;
+
+use std::sync::Mutex;
+
+use platypusgit_lib::git::{
+    types::{RebaseAction, RebaseProgress, RebaseStep, RepoId},
+    GitBackend,
+};
+
+use support::{linear_history, TempRepo};
+
+fn step(oid: &str, action: RebaseAction) -> RebaseStep {
+    RebaseStep {
+        oid: oid.to_string(),
+        action,
+        message: None,
+        onto: None,
+        merge_parents: Vec::new(),
+    }
+}
+
+fn pick_all(oids: &[String]) -> Vec<RebaseStep> {
+    oids.iter().map(|o| step(o, RebaseAction::Pick)).collect()
+}
+
+/// Collects every tick a replay publishes. A `Mutex` because the sink is
+/// `Fn + Send + Sync` — it has to be, since it runs inside `spawn_blocking` in
+/// the real command.
+#[derive(Default)]
+struct Ticks(Mutex<Vec<RebaseProgress>>);
+
+impl Ticks {
+    fn sink(&self) -> impl Fn(RebaseProgress) + Send + Sync + '_ {
+        move |p| self.0.lock().unwrap().push(p)
+    }
+    fn taken(&self) -> Vec<RebaseProgress> {
+        self.0.lock().unwrap().clone()
+    }
+}
+
+#[test]
+fn every_step_ticks_once_in_plan_order_before_it_is_applied() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 3);
+    let (backend, handle) = tr.open_with_backend();
+
+    let ticks = Ticks::default();
+    let done = backend
+        .rebase_start_with_progress(&handle.id, pick_all(&oids), &ticks.sink())
+        .unwrap();
+    assert!(!done.in_progress, "a plain pick plan runs to completion");
+
+    let seen = ticks.taken();
+    assert_eq!(seen.len(), 3, "one tick per step, no more");
+
+    // `next_index` is how many steps are DONE, so the first step reports 0 —
+    // the same value `RebaseStatus.next_index` carries, which is what lets the
+    // operation bar render both with one `+ 1`.
+    assert_eq!(
+        seen.iter().map(|p| p.next_index).collect::<Vec<_>>(),
+        [0, 1, 2],
+        "the counter advances one step at a time, starting at zero"
+    );
+    assert!(
+        seen.iter().all(|p| p.total == 3),
+        "every tick knows the size of the whole plan"
+    );
+    assert!(
+        seen.iter().all(|p| p.repo_id == handle.id.0),
+        "every tick names its repository — the event is app-global, the bar is not"
+    );
+
+    // Plan order, and the oid is the PRE-rebase one the plan named: the frontend
+    // built the plan from those oids and has nothing else to match against.
+    for (tick, oid) in seen.iter().zip(oids.iter()) {
+        assert_eq!(tick.short_oid, oid[..7], "tick names the commit it replays");
+        assert_eq!(tick.action, RebaseAction::Pick);
+        assert!(
+            !tick.subject.is_empty(),
+            "the subject is what makes the status line readable, not the oid"
+        );
+    }
+}
+
+#[test]
+fn a_dropped_step_still_ticks() {
+    // A Drop never reaches a cherry-pick, but it IS one of `total`'s steps.
+    // Skipping its tick would freeze the counter at N-1 of N for the rest of a
+    // plan that is in fact progressing.
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 3);
+    let (backend, handle) = tr.open_with_backend();
+
+    let plan = vec![
+        step(&oids[0], RebaseAction::Pick),
+        step(&oids[1], RebaseAction::Drop),
+        step(&oids[2], RebaseAction::Pick),
+    ];
+    let ticks = Ticks::default();
+    backend
+        .rebase_start_with_progress(&handle.id, plan, &ticks.sink())
+        .unwrap();
+
+    let seen = ticks.taken();
+    assert_eq!(
+        seen.iter()
+            .map(|p| (p.next_index, p.action))
+            .collect::<Vec<_>>(),
+        [
+            (0, RebaseAction::Pick),
+            (1, RebaseAction::Drop),
+            (2, RebaseAction::Pick)
+        ],
+    );
+}
+
+#[test]
+fn a_pause_stops_the_ticks_and_continue_resumes_them() {
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 3);
+    let (backend, handle) = tr.open_with_backend();
+
+    // Edit on the second step: the replay applies step 1, announces step 2, and
+    // parks there.
+    let plan = vec![
+        step(&oids[0], RebaseAction::Pick),
+        step(&oids[1], RebaseAction::Edit),
+        step(&oids[2], RebaseAction::Pick),
+    ];
+    let start = Ticks::default();
+    let paused = backend
+        .rebase_start_with_progress(&handle.id, plan, &start.sink())
+        .unwrap();
+    assert!(paused.in_progress, "an Edit step pauses the replay");
+
+    let before = start.taken();
+    assert_eq!(
+        before.iter().map(|p| p.next_index).collect::<Vec<_>>(),
+        [0, 1],
+        "the third step is never announced, because it never started"
+    );
+
+    // Resuming picks the counter up where it stopped rather than restarting it —
+    // the status line must not jump back to "step 1 of 3" halfway through.
+    //
+    // Only the third step is announced: an `Edit` pause happens AFTER its commit
+    // is made and counted, so there is nothing to re-announce. (A conflict pause
+    // parks its step in `conflict_step` instead and does re-announce it at the
+    // same index on resume — which is also right: the counter holds rather than
+    // going backwards.)
+    let resume = Ticks::default();
+    let done = backend
+        .rebase_continue_with_progress(&handle.id, &resume.sink())
+        .unwrap();
+    assert!(!done.in_progress, "the rest of the plan runs to completion");
+    assert_eq!(
+        resume
+            .taken()
+            .iter()
+            .map(|p| p.next_index)
+            .collect::<Vec<_>>(),
+        [2],
+        "the resume continues the count instead of restarting it"
+    );
+}
+
+#[test]
+fn the_sinkless_entry_points_still_replay() {
+    // Every existing caller — all the other rebase tests, and the conflict
+    // resolver's internal `rebase_continue` — goes through the default methods.
+    // They must stay a plain delegation, not a second engine.
+    let tr = TempRepo::with_initial_commit("root\n");
+    let oids = linear_history(&tr, 2);
+    let (backend, handle) = tr.open_with_backend();
+
+    let done = backend.rebase_start(&handle.id, pick_all(&oids)).unwrap();
+    assert!(!done.in_progress);
+    assert_eq!(done.total, 2);
+}
+
+#[test]
+fn an_unknown_repository_reports_no_ticks() {
+    // The sink must not be called on a failure path — a tick for a rebase that
+    // never began would leave the status line lit with nothing behind it.
+    let tr = TempRepo::with_initial_commit("root\n");
+    let (backend, _handle) = tr.open_with_backend();
+
+    let ticks = Ticks::default();
+    let err = backend.rebase_continue_with_progress(
+        &RepoId("nope".to_string()),
+        &ticks.sink(),
+    );
+    assert!(err.is_err());
+    assert!(ticks.taken().is_empty());
+}

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -32,7 +32,14 @@ import { PullsScreen } from "@/screens/Pulls";
 import { SubmodulesScreen } from "@/screens/Submodules";
 import { WorktreesScreen } from "@/screens/Worktrees";
 
-import { useRepoStore } from "@/features/repo/useRepoStore";
+import {
+  applyNetProgress,
+  applyRebaseProgress,
+  useRepoStore,
+} from "@/features/repo/useRepoStore";
+import { ActivityStatus } from "@/features/repo/ActivityStatus";
+import { primaryActivity } from "@/features/repo/repoActivity";
+import type { NetProgress, RebaseProgress } from "@/lib/types";
 import { useTabsStore } from "@/features/repo/useTabsStore";
 import { RepoTabs } from "@/features/repo/RepoTabs";
 import { headUpstream, openRepoDialog } from "@/features/repo/ops";
@@ -205,6 +212,22 @@ export function AppShell() {
     void useSubmodulesStore.getState().refresh();
     void useWorktreesStore.getState().refresh();
   }, [repo]);
+
+  // Progress ticks from the backend's long operations (#296).
+  //
+  // Subscribed once for the app's lifetime, not per repository: the events are
+  // app-global and carry their own `repoId`, and `applyNetProgress` /
+  // `applyRebaseProgress` drop anything that is not for the open one. Resubscribing
+  // on every tab switch would open a window where ticks are silently lost.
+  React.useEffect(() => {
+    const subs = [
+      listen<NetProgress>("net://progress", (e) => applyNetProgress(e.payload)),
+      listen<RebaseProgress>("rebase://progress", (e) => applyRebaseProgress(e.payload)),
+    ];
+    return () => {
+      for (const sub of subs) void sub.then((un) => un()).catch(() => {});
+    };
+  }, []);
 
   const autoFetchEnabled = useSettingsStore((s) => s.autoFetchEnabled);
   const autoFetchMinutes = useSettingsStore((s) => s.autoFetchMinutes);
@@ -671,7 +694,12 @@ function AppTitlebar({ onOpenSettings }: { onOpenSettings: () => void }) {
   const repo = useRepoStore((s) => s.current);
   const branches = useRepoStore((s) => s.branches);
   const status = useRepoStore((s) => s.status);
-  const activity = useRepoStore((s) => s.activity);
+  // Booleans, not the `activity` object: a fetch publishes a progress tick many
+  // times a second, and selecting the object would re-render the whole toolbar
+  // on each one. These flip twice per operation (#296).
+  const fetching = useRepoStore((s) => !!s.activity.fetch);
+  const pulling = useRepoStore((s) => !!s.activity.pull);
+  const pushing = useRepoStore((s) => !!s.activity.push);
   const refresh = useRepoStore((s) => s.refreshAll);
   const activePath = useTabsStore((s) => s.activePath);
   const defaultPullMode = useSettingsStore((s) => s.defaultPullMode);
@@ -743,7 +771,7 @@ function AppTitlebar({ onOpenSettings }: { onOpenSettings: () => void }) {
                   variant="default"
                   icon="fetch"
                   onClick={onFetch}
-                  loading={!!activity.fetch}
+                  loading={fetching}
                 >
                   Fetch
                 </PGButton>
@@ -752,7 +780,7 @@ function AppTitlebar({ onOpenSettings }: { onOpenSettings: () => void }) {
                   variant="default"
                   icon="pull"
                   onClick={onPull}
-                  loading={!!activity.pull}
+                  loading={pulling}
                 >
                   Pull{" "}
                   {behind > 0 && (
@@ -768,7 +796,7 @@ function AppTitlebar({ onOpenSettings }: { onOpenSettings: () => void }) {
                   variant="primary"
                   icon="push"
                   onClick={onPush}
-                  loading={!!activity.push}
+                  loading={pushing}
                 >
                   Push {ahead > 0 && <span style={{ marginLeft: 4 }}>↑{ahead}</span>}
                 </PGButton>
@@ -824,10 +852,11 @@ function AppStatusBar() {
   const branches = useRepoStore((s) => s.branches);
   const status = useRepoStore((s) => s.status);
   const loading = useRepoStore((s) => s.loading);
-  const activity = useRepoStore((s) => s.activity);
-  // First non-empty activity entry wins — expected to be one at a time.
-  const activityLabel =
-    activity.push ?? activity.pull ?? activity.fetch ?? activity.stash ?? activity.branch ?? null;
+  // A boolean, so the status bar does not re-render on every progress tick —
+  // `ActivityStatus` is the leaf that subscribes to the ticks themselves. Which
+  // entry wins, the bar, the elapsed clock and the Cancel button all live there
+  // now (#296); this only needs to know whether to fall back to "syncing…".
+  const busy = useRepoStore((s) => primaryActivity(s.activity) !== null);
 
   if (!repo) {
     return (
@@ -877,28 +906,8 @@ function AppStatusBar() {
               onClick={() => void openMergeWindow(repo.id)}
             />
           )}
-          {loading && !activityLabel && <PGStatusItem icon="sync" label="syncing…" />}
-          {activityLabel && (
-            <>
-              <PGStatusItem icon="sync" label={activityLabel} tone="accent" />
-              {/*
-                The way out of a stalled fetch, pull or push (#234), and the only
-                one the toolbar's spinning buttons do not offer. It sits beside
-                the label that says what is stuck, because that label is what a
-                user stares at while deciding the app has hung.
-
-                Its own item rather than an onClick on the label: a status line
-                that silently kills the operation when clicked is a trap, and
-                there is nowhere on a bare label to say "Cancel".
-              */}
-              <PGStatusItem
-                icon="x"
-                label="Cancel"
-                tone="danger"
-                onClick={() => void useRepoStore.getState().cancelNetworkOps()}
-              />
-            </>
-          )}
+          {loading && !busy && <PGStatusItem icon="sync" label="syncing…" />}
+          <ActivityStatus />
         </>
       }
       right={<PGStatusItem label={repo.path} />}

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -38,6 +38,7 @@ import {
   useRepoStore,
 } from "@/features/repo/useRepoStore";
 import { ActivityStatus } from "@/features/repo/ActivityStatus";
+import { LoadingStatus } from "@/features/repo/LoadingStatus";
 import { primaryActivity } from "@/features/repo/repoActivity";
 import type { NetProgress, RebaseProgress } from "@/lib/types";
 import { useTabsStore } from "@/features/repo/useTabsStore";
@@ -851,7 +852,6 @@ function AppStatusBar() {
   const repo = useRepoStore((s) => s.current);
   const branches = useRepoStore((s) => s.branches);
   const status = useRepoStore((s) => s.status);
-  const loading = useRepoStore((s) => s.loading);
   // A boolean, so the status bar does not re-render on every progress tick —
   // `ActivityStatus` is the leaf that subscribes to the ticks themselves. Which
   // entry wins, the bar, the elapsed clock and the Cancel button all live there
@@ -906,7 +906,7 @@ function AppStatusBar() {
               onClick={() => void openMergeWindow(repo.id)}
             />
           )}
-          {loading && !busy && <PGStatusItem icon="sync" label="syncing…" />}
+          {!busy && <LoadingStatus />}
           <ActivityStatus />
         </>
       }

--- a/src/features/forge/useForgeStore.ts
+++ b/src/features/forge/useForgeStore.ts
@@ -295,6 +295,10 @@ export const useForgeStore = create<ForgeState>((set, get) => ({
         outcome = "error";
         set({ error: appErrorMessage(e) });
       },
+      // `checkingOut` drives this panel's own button; the `activity` entry is
+      // what reaches the status bar and the Cancel button (#296). Fetching a
+      // pull request's head ref is an ordinary transfer and can stall like one.
+      { key: "forge", label: `Checking out #${pr.number}…` },
     );
     set({ checkingOut: false });
     return outcome;

--- a/src/features/lfs/useLfsStore.ts
+++ b/src/features/lfs/useLfsStore.ts
@@ -115,6 +115,13 @@ async function runNetworkOp(
 ): Promise<void> {
   const repo = useRepoStore.getState().current;
   if (!repo) return;
+  // TWO pieces of busy state, and they are not redundant (#296). `busy` says
+  // WHICH LFS op this panel is running, so its own buttons can spin the right
+  // one. The `activity` entry is the app-wide one: it is what puts a line in the
+  // status bar and — because the Cancel button is gated on exactly that — what
+  // makes a stalled `git lfs pull` stoppable at all. It goes through
+  // `run_git_authenticated`, so the backend could always cancel it; there was
+  // simply no button.
   set({ busy: op, error: null });
   try {
     await withAuthRetry(
@@ -129,6 +136,7 @@ async function runNetworkOp(
         await get().refresh();
         set({ error: toAppError(e) });
       },
+      { key: "lfs", label: op === "fetch" ? "Fetching LFS objects…" : "Pulling LFS objects…" },
     );
   } finally {
     set({ busy: null });

--- a/src/features/repo/ActivityStatus.test.tsx
+++ b/src/features/repo/ActivityStatus.test.tsx
@@ -12,7 +12,8 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 
-import { ActivityStatus, ELAPSED_AFTER_MS, formatElapsed } from "./ActivityStatus";
+import { ActivityStatus, ELAPSED_AFTER_MS } from "./ActivityStatus";
+import { formatElapsed } from "./elapsed";
 import { useRepoStore } from "./useRepoStore";
 import { emptySlice } from "./repoSlice";
 import type { RepoActivity } from "./repoActivity";

--- a/src/features/repo/ActivityStatus.test.tsx
+++ b/src/features/repo/ActivityStatus.test.tsx
@@ -1,0 +1,139 @@
+// The status bar's answer to "what is running, how far along, how long, and can
+// I stop it" (#296).
+//
+// The Cancel gating is the load-bearing part. The button calls
+// `cancel_network_op`, which reaches exactly the ops that run as a git
+// subprocess through `run_git_authenticated`. Offering it for a rebase replay —
+// which cannot be interrupted at all yet — would be a button that does nothing,
+// which is worse than no button. Offering it for LFS and submodule updates,
+// which the backend could always cancel, is the whole point of them joining
+// `activity` in the first place.
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+
+import { ActivityStatus, ELAPSED_AFTER_MS, formatElapsed } from "./ActivityStatus";
+import { useRepoStore } from "./useRepoStore";
+import { emptySlice } from "./repoSlice";
+import type { RepoActivity } from "./repoActivity";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+
+const NOW = 1_700_000_000_000;
+
+function show(activity: RepoActivity) {
+  useRepoStore.setState({
+    ...emptySlice(),
+    current: { id: "repo-1", path: "/tmp/repo-1", head: "main" },
+    activity,
+  });
+  return render(<ActivityStatus />);
+}
+
+const running = (label: string, extra: Partial<RepoActivity["fetch"]> = {}) => ({
+  label,
+  startedAt: NOW,
+  ...extra,
+});
+
+beforeEach(() => {
+  resetInvokeMock();
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("what it shows", () => {
+  it("shows nothing at all when nothing is running", () => {
+    const { container } = show({});
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the label with no bar until git reports a percentage", () => {
+    // Most ops never report one — a bar stuck at 0% would read as "wedged".
+    show({ fetch: running("Fetching origin…") });
+    expect(screen.getByTestId("activity-label")).toHaveTextContent("Fetching origin…");
+    expect(screen.queryByTestId("activity-bar")).toBeNull();
+  });
+
+  it("shows a determinate bar once a tick has landed", () => {
+    show({ fetch: running("Fetching origin…", { phase: "Receiving objects", percent: 62 }) });
+    expect(screen.getByTestId("activity-bar")).toHaveAttribute("data-percent", "62");
+    expect(screen.getByTestId("activity-percent")).toHaveTextContent("62%");
+  });
+
+  it("picks the op the user is most likely waiting on, and counts the rest", () => {
+    show({
+      push: running("Pushing origin/main…"),
+      submodule: running("Updating submodules…"),
+      lfs: running("Fetching LFS objects…"),
+    });
+    expect(screen.getByTestId("activity-label")).toHaveTextContent("Pushing origin/main…");
+    // Silently hiding the other two would misreport what the app is doing.
+    expect(screen.getByText("+2 more")).toBeInTheDocument();
+  });
+});
+
+describe("the elapsed clock", () => {
+  it("stays hidden for a fast operation", () => {
+    // The reason to show elapsed time is "this is taking longer than expected".
+    // A number that flashes up on every 200 ms fetch is noise.
+    show({ fetch: running("Fetching origin…") });
+    expect(screen.queryByTestId("activity-elapsed")).toBeNull();
+  });
+
+  it("appears once the operation has run long enough", () => {
+    show({ fetch: running("Fetching origin…") });
+    // `act` because the readout advances from the component's own 1 Hz interval,
+    // not from a store write.
+    act(() => {
+      vi.advanceTimersByTime(ELAPSED_AFTER_MS + 1000);
+    });
+    expect(screen.getByTestId("activity-elapsed")).toHaveTextContent("4s");
+  });
+
+  it("formats past a minute", () => {
+    expect(formatElapsed(42_000)).toBe("42s");
+    expect(formatElapsed(80_000)).toBe("1m 20s");
+    expect(formatElapsed(120_000)).toBe("2m 0s");
+  });
+});
+
+describe("Cancel", () => {
+  it.each([
+    ["fetch", "Fetching origin…"],
+    ["pull", "Pulling origin/main…"],
+    ["push", "Pushing origin/main…"],
+    // The three that were cancellable in the backend all along and had no button.
+    ["lfs", "Fetching LFS objects…"],
+    ["submodule", "Updating submodules…"],
+    ["forge", "Checking out #42…"],
+  ] as const)("is offered for %s", (key, label) => {
+    show({ [key]: running(label) });
+    expect(screen.getByText("Cancel")).toBeInTheDocument();
+  });
+
+  it.each([
+    // A rebase replay runs inside one blocking libgit2 call with nothing to
+    // signal — see #296 gap 6. The others are over before a click could land.
+    ["rebase", "Rebasing 12 of 200: fix a thing"],
+    ["stash", "Stashing changes…"],
+    ["branch", "Switching to main…"],
+  ] as const)("is NOT offered for %s", (key, label) => {
+    show({ [key]: running(label) });
+    expect(screen.getByTestId("activity-label")).toHaveTextContent(label);
+    expect(screen.queryByText("Cancel")).toBeNull();
+  });
+
+  it("cancels the repository's network ops when clicked", async () => {
+    mockInvoke("cancel_network_op", () => 1);
+    show({ fetch: running("Fetching origin…") });
+
+    fireEvent.click(screen.getByText("Cancel"));
+    await vi.waitFor(() =>
+      expect(getInvokeCalls().filter((c) => c.cmd === "cancel_network_op")).toHaveLength(1),
+    );
+  });
+});

--- a/src/features/repo/ActivityStatus.tsx
+++ b/src/features/repo/ActivityStatus.tsx
@@ -8,9 +8,8 @@
 // Its own file also keeps the 1 Hz elapsed-time re-render inside a leaf: the
 // whole status bar would otherwise re-render every second while any op is live.
 
-import React from "react";
-
 import { PGStatusItem } from "@/design";
+import { formatElapsed, useElapsed } from "./elapsed";
 import {
   activityCount,
   isCancellable,
@@ -28,28 +27,6 @@ import { useRepoStore } from "./useRepoStore";
  * common case, where the op is over before the first tick.
  */
 export const ELAPSED_AFTER_MS = 3000;
-
-/** `42s`, `1m 20s`. Seconds resolution — this is a "should I worry?" readout. */
-export function formatElapsed(ms: number): string {
-  const total = Math.floor(ms / 1000);
-  if (total < 60) return `${total}s`;
-  return `${Math.floor(total / 60)}m ${total % 60}s`;
-}
-
-/** Milliseconds since `startedAt`, re-read once a second. Null when idle. */
-function useElapsed(startedAt: number | null): number | null {
-  const [now, setNow] = React.useState(() => Date.now());
-  React.useEffect(() => {
-    if (startedAt === null) return;
-    // Re-read immediately as well as on the interval: mounting mid-operation
-    // (a tab switch back) would otherwise show a stale `now` for up to a second.
-    setNow(Date.now());
-    const id = window.setInterval(() => setNow(Date.now()), 1000);
-    return () => window.clearInterval(id);
-  }, [startedAt]);
-  if (startedAt === null) return null;
-  return Math.max(0, now - startedAt);
-}
 
 /** The determinate bar, shown only once git has reported a real percentage. */
 function ProgressBar({ percent }: { percent: number }) {

--- a/src/features/repo/ActivityStatus.tsx
+++ b/src/features/repo/ActivityStatus.tsx
@@ -1,0 +1,153 @@
+// The status bar's "something is running" line (#296).
+//
+// One component rather than markup inlined in `AppStatusBar`, because it is the
+// only place in the app that answers all four of the questions a waiting user
+// has — what is running, how far along, how long it has been, and can I stop it
+// — and those answers should not drift apart across surfaces.
+//
+// Its own file also keeps the 1 Hz elapsed-time re-render inside a leaf: the
+// whole status bar would otherwise re-render every second while any op is live.
+
+import React from "react";
+
+import { PGStatusItem } from "@/design";
+import {
+  activityCount,
+  isCancellable,
+  primaryActivity,
+  type ActivityState,
+} from "./repoActivity";
+import { useRepoStore } from "./useRepoStore";
+
+/**
+ * How long an operation must run before its elapsed time appears.
+ *
+ * Every fetch shows a number for a moment otherwise, which is noise: the reason
+ * to show elapsed time at all is "this is taking longer than I expected", and
+ * nothing under a few seconds is. It also keeps the 1 Hz re-render off the
+ * common case, where the op is over before the first tick.
+ */
+export const ELAPSED_AFTER_MS = 3000;
+
+/** `42s`, `1m 20s`. Seconds resolution — this is a "should I worry?" readout. */
+export function formatElapsed(ms: number): string {
+  const total = Math.floor(ms / 1000);
+  if (total < 60) return `${total}s`;
+  return `${Math.floor(total / 60)}m ${total % 60}s`;
+}
+
+/** Milliseconds since `startedAt`, re-read once a second. Null when idle. */
+function useElapsed(startedAt: number | null): number | null {
+  const [now, setNow] = React.useState(() => Date.now());
+  React.useEffect(() => {
+    if (startedAt === null) return;
+    // Re-read immediately as well as on the interval: mounting mid-operation
+    // (a tab switch back) would otherwise show a stale `now` for up to a second.
+    setNow(Date.now());
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [startedAt]);
+  if (startedAt === null) return null;
+  return Math.max(0, now - startedAt);
+}
+
+/** The determinate bar, shown only once git has reported a real percentage. */
+function ProgressBar({ percent }: { percent: number }) {
+  return (
+    <span
+      data-testid="activity-bar"
+      data-percent={percent}
+      aria-hidden
+      style={{
+        display: "inline-block",
+        width: 52,
+        height: 4,
+        marginLeft: 2,
+        background: "var(--bg-2)",
+        borderRadius: 2,
+        overflow: "hidden",
+        verticalAlign: "middle",
+      }}
+    >
+      <span
+        style={{
+          display: "block",
+          height: "100%",
+          // Clamped: a malformed tick must not paint outside the track.
+          width: `${Math.max(0, Math.min(100, percent))}%`,
+          background: "var(--accent)",
+        }}
+      />
+    </span>
+  );
+}
+
+function ActivityLine({ state }: { state: ActivityState }) {
+  const elapsed = useElapsed(state.startedAt);
+  const showElapsed = elapsed !== null && elapsed >= ELAPSED_AFTER_MS;
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+      <span data-testid="activity-label">{state.label}</span>
+      {state.percent !== undefined && (
+        <>
+          <ProgressBar percent={state.percent} />
+          <span data-testid="activity-percent">{state.percent}%</span>
+        </>
+      )}
+      {showElapsed && (
+        <span data-testid="activity-elapsed" style={{ color: "var(--fg-3)" }}>
+          {formatElapsed(elapsed)}
+        </span>
+      )}
+    </span>
+  );
+}
+
+export function ActivityStatus() {
+  const activity = useRepoStore((s) => s.activity);
+  const primary = primaryActivity(activity);
+  if (!primary) return null;
+
+  // More than one op at a time stopped being hypothetical once LFS, submodule
+  // and forge checkouts joined `activity` (#296). Naming the count beats
+  // silently hiding the others behind whichever one sorts first.
+  const others = activityCount(activity) - 1;
+
+  return (
+    <>
+      <PGStatusItem
+        icon="sync"
+        tone="accent"
+        label={<ActivityLine state={primary.state} />}
+      />
+      {others > 0 && (
+        <PGStatusItem
+          label={`+${others} more`}
+        />
+      )}
+      {isCancellable(primary.key) && (
+        /*
+          The way out of a stalled fetch, pull or push (#234), and the only one
+          the toolbar's spinning buttons do not offer. It sits beside the label
+          that says what is stuck, because that label is what a user stares at
+          while deciding the app has hung.
+
+          Its own item rather than an onClick on the label: a status line that
+          silently kills the operation when clicked is a trap, and there is
+          nowhere on a bare label to say "Cancel".
+
+          Gated on the op actually being cancellable (#296): it now also covers
+          LFS, submodule and forge ops — which were cancellable in the backend
+          all along and simply had no button — while a rebase replay, which
+          cannot be interrupted, does not get one it could not honour.
+        */
+        <PGStatusItem
+          icon="x"
+          label="Cancel"
+          tone="danger"
+          onClick={() => void useRepoStore.getState().cancelNetworkOps()}
+        />
+      )}
+    </>
+  );
+}

--- a/src/features/repo/LoadingStatus.test.tsx
+++ b/src/features/repo/LoadingStatus.test.tsx
@@ -1,0 +1,193 @@
+// The Rider-style loading indicator: a summary line that opens upward (#296
+// gap 8).
+//
+// Two things carry most of the value and are easy to regress. The **delay** is
+// what makes a status-bar indicator tolerable at all — a refresh runs on every
+// tab switch and usually finishes in under 100 ms, so without it the corner of
+// the screen strobes. And the **collapsed summary** is the whole feature for
+// anyone who never clicks: it has to name one read and count the rest.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+
+import { LoadingStatus, SHOW_AFTER_MS } from "./LoadingStatus";
+import { useRepoStore } from "./useRepoStore";
+import { emptySlice } from "./repoSlice";
+import type { LoadingTask } from "./loadingTasks";
+import { resetInvokeMock } from "@/test/invokeMock";
+
+const NOW = 1_700_000_000_000;
+
+const task = (id: string, label: string, ageMs = 0): LoadingTask => ({
+  id,
+  label,
+  startedAt: NOW - ageMs,
+});
+
+function show(tasks: LoadingTask[], loading = false) {
+  useRepoStore.setState({
+    ...emptySlice(),
+    current: { id: "repo-1", path: "/tmp/repo-1", head: "main" },
+    loadingTasks: tasks,
+    loading,
+  });
+  return render(<LoadingStatus />);
+}
+
+/** Push past the flicker floor so the indicator is actually on screen. */
+function settle() {
+  act(() => {
+    vi.advanceTimersByTime(SHOW_AFTER_MS + 50);
+  });
+}
+
+beforeEach(() => {
+  resetInvokeMock();
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("the flicker floor", () => {
+  it("shows nothing at all when nothing is loading", () => {
+    const { container } = show([]);
+    settle();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("stays hidden for a refresh that finishes quickly", () => {
+    // The common case, many times a minute. If this ever renders, the status
+    // bar flashes on every tab switch and every commit.
+    show([task("status", "reading status")]);
+    act(() => {
+      vi.advanceTimersByTime(SHOW_AFTER_MS - 50);
+    });
+    expect(screen.queryByTestId("loading-status")).toBeNull();
+  });
+
+  it("appears once a refresh has been running long enough", () => {
+    show([task("status", "reading status")]);
+    settle();
+    expect(screen.getByTestId("loading-summary")).toHaveTextContent(
+      "Loading: reading status",
+    );
+  });
+});
+
+describe("the collapsed summary", () => {
+  it("names the longest-running read and counts the rest", () => {
+    show([
+      task("remotes", "fetching remotes", 5000),
+      task("status", "reading status", 200),
+      task("tags", "listing tags", 100),
+    ]);
+    settle();
+    expect(screen.getByTestId("loading-summary")).toHaveTextContent(
+      "Loading: fetching remotes + 2 others",
+    );
+  });
+
+  it("falls back to a bare label when the flag is up with no named reads", () => {
+    // Opening a repository sets `loading` before there is a repository to
+    // attribute reads to. Reporting nothing there would be a regression on the
+    // old "syncing…".
+    show([], true);
+    settle();
+    expect(screen.getByTestId("loading-summary")).toHaveTextContent("Loading…");
+    // Nothing to expand into, so no affordance offering an empty box.
+    expect(screen.queryByRole("group", { name: "Loading" })).toBeNull();
+    fireEvent.click(screen.getByTestId("loading-summary"));
+    expect(screen.queryByTestId("loading-panel")).toBeNull();
+  });
+});
+
+describe("expanding", () => {
+  const three = () => [
+    task("remotes", "fetching remotes", 5000),
+    task("status", "reading status", 1200),
+    task("tags", "listing tags", 300),
+  ];
+
+  it("lists every read, longest-running first, with its own clock", () => {
+    show(three());
+    settle();
+    fireEvent.click(screen.getByTestId("loading-summary"));
+
+    const rows = screen.getAllByTestId("loading-task");
+    expect(rows.map((r) => r.getAttribute("data-task-id"))).toEqual([
+      "remotes",
+      "status",
+      "tags",
+    ]);
+    // The elapsed column is the point: it says which read is the slow one even
+    // when the summary has already named it.
+    expect(rows[0]).toHaveTextContent("fetching remotes");
+    expect(rows[0]).toHaveTextContent("5s");
+    expect(rows[2]).toHaveTextContent("0s");
+  });
+
+  it("opens from the keyboard", () => {
+    // The status bar has no other tab stop, so without a real button this
+    // panel would be mouse-only — the app's own rule for drag targets.
+    show(three());
+    settle();
+    const trigger = screen.getByRole("button", { expanded: false });
+    fireEvent.keyDown(trigger, { key: "Enter" });
+    expect(screen.getByTestId("loading-panel")).toBeInTheDocument();
+    expect(screen.getByRole("button", { expanded: true })).toBeInTheDocument();
+  });
+
+  it("toggles shut on a second click", () => {
+    show(three());
+    settle();
+    fireEvent.click(screen.getByTestId("loading-summary"));
+    expect(screen.getByTestId("loading-panel")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("loading-summary"));
+    expect(screen.queryByTestId("loading-panel")).toBeNull();
+  });
+
+  it("closes on Escape", () => {
+    show(three());
+    settle();
+    fireEvent.click(screen.getByTestId("loading-summary"));
+    act(() => {
+      fireEvent.keyDown(window, { key: "Escape" });
+    });
+    expect(screen.queryByTestId("loading-panel")).toBeNull();
+  });
+
+  it("closes when the pointer goes down outside it", () => {
+    show(three());
+    settle();
+    fireEvent.click(screen.getByTestId("loading-summary"));
+    act(() => {
+      fireEvent.mouseDown(document.body);
+    });
+    expect(screen.queryByTestId("loading-panel")).toBeNull();
+  });
+
+  it("does not come back already-open on the next slow refresh", () => {
+    // The panel would otherwise reappear expanded over a completely different
+    // set of reads than the one the user opened it for.
+    const { rerender } = show(three());
+    settle();
+    fireEvent.click(screen.getByTestId("loading-summary"));
+    expect(screen.getByTestId("loading-panel")).toBeInTheDocument();
+
+    act(() => {
+      useRepoStore.setState({ loadingTasks: [], loading: false });
+    });
+    rerender(<LoadingStatus />);
+    expect(screen.queryByTestId("loading-status")).toBeNull();
+
+    act(() => {
+      useRepoStore.setState({ loadingTasks: three() });
+    });
+    settle();
+    expect(screen.getByTestId("loading-summary")).toBeInTheDocument();
+    expect(screen.queryByTestId("loading-panel")).toBeNull();
+  });
+});

--- a/src/features/repo/LoadingStatus.tsx
+++ b/src/features/repo/LoadingStatus.tsx
@@ -1,0 +1,184 @@
+// "Loading: fetching remotes + 5 others", and what the 5 others are (#296 gap 8).
+//
+// A refresh is ten backend reads behind one `Promise.all`. The status bar used
+// to describe all of them as "syncing…", which is exactly no help on the setups
+// where a refresh is slow enough to notice — a `/mnt/c` repository under WSL
+// (#274) spends its nine seconds in one or two of the ten, and nothing said
+// which. Collapsed, this names the one running longest; expanded, it lists them
+// all with their own clocks, so the answer is readable rather than inferred.
+//
+// Modelled on Rider's background-task indicator: a quiet line in the corner
+// that opens upward into the detail, and is absent entirely when there is
+// nothing slow to report.
+
+import React from "react";
+
+import { PGIcon, PGStatusItem } from "@/design";
+import { formatElapsed, useDelayedFlag, useElapsed } from "./elapsed";
+import { byAge, loadingSummary, type LoadingTask } from "./loadingTasks";
+import { useRepoStore } from "./useRepoStore";
+
+/**
+ * How long a refresh must run before it is worth mentioning.
+ *
+ * The flicker floor, and the reason this is tolerable in a status bar at all: a
+ * refresh runs on every tab switch, every commit and after every network op,
+ * and almost always finishes inside 100 ms. Without the delay the corner of the
+ * screen would strobe all day. What survives the delay is the refresh that did
+ * not finish quickly — the only one anybody wants to read about.
+ */
+export const SHOW_AFTER_MS = 400;
+
+/** One row of the expanded panel: what it is, and how long it has been. */
+function TaskRow({ task }: { task: LoadingTask }) {
+  const elapsed = useElapsed(task.startedAt);
+  return (
+    <div
+      data-testid="loading-task"
+      data-task-id={task.id}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 16,
+        padding: "3px 10px",
+        whiteSpace: "nowrap",
+      }}
+    >
+      <span style={{ color: "var(--fg-1)" }}>{task.label}</span>
+      <span
+        style={{
+          color: "var(--fg-3)",
+          fontFamily: "var(--font-mono)",
+          fontSize: "var(--fs-11)",
+        }}
+      >
+        {formatElapsed(elapsed ?? 0)}
+      </span>
+    </div>
+  );
+}
+
+export function LoadingStatus() {
+  const tasks = useRepoStore((s) => s.loadingTasks);
+  const loading = useRepoStore((s) => s.loading);
+  const [open, setOpen] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  // `loading` as well as the task list: opening a repository sets the flag
+  // before there is a repository to attribute reads to, so it has no named
+  // tasks and would otherwise report nothing at all.
+  const active = tasks.length > 0 || loading;
+  const visible = useDelayedFlag(active, SHOW_AFTER_MS);
+
+  // Collapse when the thing being described stops existing. Without this the
+  // panel would reappear already-open on the next slow refresh, over a
+  // completely different set of reads.
+  React.useEffect(() => {
+    if (!visible) setOpen(false);
+  }, [visible]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    const onDown = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    // `mousedown`, not `click`: a click that starts outside and ends inside
+    // should still close, and this fires before the toggle's own handler.
+    window.addEventListener("mousedown", onDown);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("mousedown", onDown);
+    };
+  }, [open]);
+
+  if (!visible) return null;
+
+  // No named tasks means there is nothing to expand INTO — say what is happening
+  // and leave it at that rather than offering an affordance that opens an empty
+  // box.
+  const summary = loadingSummary(tasks) ?? "Loading…";
+  const expandable = tasks.length > 0;
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="loading-status"
+      style={{ position: "relative", display: "flex", alignItems: "center" }}
+    >
+      {open && (
+        <div
+          data-testid="loading-panel"
+          role="group"
+          aria-label="Loading"
+          style={{
+            position: "absolute",
+            // Upward: the status bar is the last row on screen, so there is
+            // nowhere below it to put this.
+            bottom: "100%",
+            left: 0,
+            marginBottom: 6,
+            minWidth: 240,
+            padding: "5px 0",
+            background: "var(--bg-1)",
+            border: "1px solid var(--border-1)",
+            borderRadius: 4,
+            boxShadow: "0 6px 20px oklch(0 0 0 / 0.35)",
+            fontSize: "var(--fs-12)",
+            // Above screen content (1–5), deliberately BELOW the pickers and
+            // modals (100): a branch picker or a dialog opening over this must
+            // cover it, not sit behind a status popover the user has forgotten
+            // is open. The shell root's `overflow: hidden` does not clip it —
+            // the panel expands up into the content area, not out of the window.
+            zIndex: 40,
+          }}
+        >
+          {byAge(tasks).map((t) => (
+            <TaskRow key={t.id} task={t} />
+          ))}
+        </div>
+      )}
+      {/*
+        The wrapper owns every interaction, and `PGStatusItem` stays purely
+        visual, so there is ONE focusable thing with the right role rather than
+        a div-with-onClick that a keyboard cannot reach. The status bar has no
+        other tab stop, so this costs nothing to tab past when it is absent —
+        and it is absent almost always.
+      */}
+      <span
+        {...(expandable
+          ? {
+              role: "button" as const,
+              tabIndex: 0,
+              "aria-expanded": open,
+              "aria-label": summary,
+              onClick: () => setOpen((o) => !o),
+              onKeyDown: (e: React.KeyboardEvent) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  setOpen((o) => !o);
+                }
+              },
+              style: { cursor: "pointer", display: "inline-flex" },
+            }
+          : { style: { display: "inline-flex" } })}
+      >
+        <PGStatusItem
+          icon="sync"
+          label={
+            <span style={{ display: "inline-flex", alignItems: "center", gap: 5 }}>
+              <span data-testid="loading-summary">{summary}</span>
+              {expandable && (
+                <PGIcon name={open ? "chevronDown" : "chevronUp"} size={10} />
+              )}
+            </span>
+          }
+        />
+      </span>
+    </div>
+  );
+}

--- a/src/features/repo/elapsed.ts
+++ b/src/features/repo/elapsed.ts
@@ -1,0 +1,58 @@
+// "How long has this been going?" — shared by the two status-bar indicators
+// (#296).
+//
+// Both the activity line (a fetch, a rebase) and the loading popover (the
+// backend reads behind a refresh) answer the same question the same way, and a
+// second copy of the formatting would drift.
+
+import React from "react";
+
+/** `42s`, `1m 20s`. Seconds resolution — this is a "should I worry?" readout. */
+export function formatElapsed(ms: number): string {
+  const total = Math.floor(ms / 1000);
+  if (total < 60) return `${total}s`;
+  return `${Math.floor(total / 60)}m ${total % 60}s`;
+}
+
+/**
+ * Milliseconds since `startedAt`, re-read once a second. Null when idle.
+ *
+ * The 1 Hz re-render is why every caller is a leaf component: subscribing to
+ * this from a status bar that also renders branch, ahead/behind and file counts
+ * would re-render all of it every second for the duration of an operation.
+ */
+export function useElapsed(startedAt: number | null): number | null {
+  const [now, setNow] = React.useState(() => Date.now());
+  React.useEffect(() => {
+    if (startedAt === null) return;
+    // Re-read immediately as well as on the interval: mounting mid-operation
+    // (a tab switch back) would otherwise show a stale `now` for up to a second.
+    setNow(Date.now());
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [startedAt]);
+  if (startedAt === null) return null;
+  return Math.max(0, now - startedAt);
+}
+
+/**
+ * `active`, but only after it has been continuously true for `delayMs`.
+ *
+ * The flicker floor. A refresh is ten backend reads that usually finish inside
+ * 100 ms, and it runs on every tab switch, every commit and after every network
+ * op — an indicator with no delay would strobe in the corner of the screen all
+ * day and say nothing. What is worth showing is the refresh that did NOT finish
+ * quickly, which is exactly what survives the delay.
+ */
+export function useDelayedFlag(active: boolean, delayMs: number): boolean {
+  const [shown, setShown] = React.useState(false);
+  React.useEffect(() => {
+    if (!active) {
+      setShown(false);
+      return;
+    }
+    const id = window.setTimeout(() => setShown(true), delayMs);
+    return () => window.clearTimeout(id);
+  }, [active, delayMs]);
+  return shown;
+}

--- a/src/features/repo/loadingTasks.test.ts
+++ b/src/features/repo/loadingTasks.test.ts
@@ -1,0 +1,78 @@
+// How the collapsed loading indicator reads (#296 gap 8).
+//
+// The summary line is the whole feature for anyone who never clicks it, so its
+// wording and — more importantly — WHICH task it names are pinned here rather
+// than left to the component test.
+
+import { describe, expect, it } from "vitest";
+
+import { byAge, loadingSummary, primaryTask, type LoadingTask } from "./loadingTasks";
+
+const task = (id: string, startedAt: number, label = id): LoadingTask => ({
+  id,
+  label,
+  startedAt,
+});
+
+describe("which task gets named", () => {
+  it("names nothing when nothing is running", () => {
+    expect(primaryTask([])).toBeNull();
+    expect(loadingSummary([])).toBeNull();
+  });
+
+  it("names the longest-running one, not the first or last registered", () => {
+    // This is the point of the feature. As the nine fast reads drop off, the
+    // label settles onto the one actually holding the refresh up — which is the
+    // question a user staring at a nine-second launch is asking.
+    const tasks = [
+      task("status", 1_000),
+      task("remotes", 500),
+      task("tags", 1_200),
+    ];
+    expect(primaryTask(tasks)?.id).toBe("remotes");
+  });
+
+  it("breaks a tie on id so the label cannot flap", () => {
+    // Ten reads fired from one `Promise.all` can share a millisecond. Without a
+    // stable tiebreak the named task would change on every re-render.
+    const a = [task("branches", 900), task("almanac", 900)];
+    const b = [task("almanac", 900), task("branches", 900)];
+    expect(primaryTask(a)?.id).toBe("almanac");
+    expect(primaryTask(b)?.id).toBe("almanac");
+  });
+});
+
+describe("the summary line", () => {
+  it("names the task alone when it is the only one", () => {
+    expect(loadingSummary([task("remotes", 1, "fetching remotes")])).toBe(
+      "Loading: fetching remotes",
+    );
+  });
+
+  it("counts the rest when there are more", () => {
+    const tasks = [
+      task("remotes", 1, "fetching remotes"),
+      ...Array.from({ length: 5 }, (_, i) => task(`t${i}`, 2 + i)),
+    ];
+    expect(loadingSummary(tasks)).toBe("Loading: fetching remotes + 5 others");
+  });
+
+  it("says 'other' for exactly one", () => {
+    expect(
+      loadingSummary([task("remotes", 1, "fetching remotes"), task("tags", 2)]),
+    ).toBe("Loading: fetching remotes + 1 other");
+  });
+});
+
+describe("the expanded order", () => {
+  it("puts the longest-running first", () => {
+    const ordered = byAge([task("c", 300), task("a", 100), task("b", 200)]);
+    expect(ordered.map((t) => t.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("does not mutate its input", () => {
+    const tasks = [task("c", 300), task("a", 100)];
+    byAge(tasks);
+    expect(tasks.map((t) => t.id)).toEqual(["c", "a"]);
+  });
+});

--- a/src/features/repo/loadingTasks.ts
+++ b/src/features/repo/loadingTasks.ts
@@ -1,0 +1,70 @@
+/**
+ * What the app is reading from the repository right now (#296 gap 8).
+ *
+ * `refreshAll` is TEN backend reads behind one `Promise.all`, and it had one
+ * boolean to describe all of them. On a fast local repository that is fine and
+ * nobody ever sees it; on the setups where it is not — a `/mnt/c` repository
+ * under WSL (#274), a repository with tens of thousands of refs — "syncing…"
+ * told the user nothing about which of the ten was the slow one, which is the
+ * single most useful fact when a launch takes nine seconds.
+ *
+ * So each read registers a task while it is in flight. The status bar names the
+ * longest-running one and counts the rest; expanding it lists them all with
+ * their own clocks.
+ *
+ * **This is deliberately NOT `RepoActivity`.** An activity entry is an operation
+ * the USER started, and it earns a Cancel button. A loading task is the app
+ * reading its own state, cannot be cancelled, and is usually over in under a
+ * tenth of a second. Merging them would put a Cancel button on `listing tags`.
+ */
+
+/** One backend read in flight. */
+export interface LoadingTask {
+  /**
+   * Stable key for the read, unique within a repository. Two reads with the
+   * same id are the same read — a refresh that starts while another is still
+   * running replaces rather than duplicates, which is what keeps the count
+   * honest when refreshes overlap.
+   */
+  id: string;
+  /**
+   * Lowercase gerund, as it reads inside "Loading: …" — "fetching remotes",
+   * not "Fetch remotes" or "Remotes".
+   */
+  label: string;
+  startedAt: number;
+}
+
+/**
+ * The task to name when the indicator is collapsed: the one running longest.
+ *
+ * Not the first registered, and not the most recent. As the fast reads drop
+ * off, the name settles onto the one actually holding the refresh up — which is
+ * the whole question this feature exists to answer. Ties break on `id` so the
+ * label cannot flap between two reads that started in the same millisecond.
+ */
+export function primaryTask(tasks: LoadingTask[]): LoadingTask | null {
+  if (tasks.length === 0) return null;
+  return tasks.reduce((oldest, t) =>
+    t.startedAt < oldest.startedAt ||
+    (t.startedAt === oldest.startedAt && t.id < oldest.id)
+      ? t
+      : oldest,
+  );
+}
+
+/** `Loading: fetching remotes + 5 others`, or null when nothing is in flight. */
+export function loadingSummary(tasks: LoadingTask[]): string | null {
+  const primary = primaryTask(tasks);
+  if (!primary) return null;
+  const others = tasks.length - 1;
+  if (others <= 0) return `Loading: ${primary.label}`;
+  return `Loading: ${primary.label} + ${others} other${others === 1 ? "" : "s"}`;
+}
+
+/** Longest-running first — the order the expanded list reads best in. */
+export function byAge(tasks: LoadingTask[]): LoadingTask[] {
+  return [...tasks].sort(
+    (a, b) => a.startedAt - b.startedAt || a.id.localeCompare(b.id),
+  );
+}

--- a/src/features/repo/repoActivity.ts
+++ b/src/features/repo/repoActivity.ts
@@ -1,16 +1,123 @@
 /**
- * Active long-running operations, keyed by operation kind. Value is the
- * user-visible label (e.g. "Fetching origin…"). Consumers can flip button
- * spinners with `!!activity.fetch` and render a status-bar line from the
- * first truthy entry.
+ * Active long-running operations, keyed by operation kind (#296).
  *
  * Its own module so `repoSlice.ts` can name it without importing
  * `useRepoStore` — which imports `repoSlice`.
+ *
+ * This is the app's ONE answer to "is something running, what is it, how far
+ * along, and can I stop it": the toolbar spins a button off `!!activity.fetch`,
+ * the status bar renders the first live entry as a line with a bar and a Cancel
+ * button beside it. A long-running op that keeps its busy state privately gets
+ * none of that — which is exactly how LFS and submodule updates ended up
+ * cancellable in the backend but unstoppable from the UI. New long ops join
+ * here; a private `busy` field is only for saying WHICH row is busy.
+ */
+
+/** What one running operation is doing right now. */
+export interface ActivityState {
+  /** The user-visible line: "Fetching origin…". */
+  label: string;
+  /**
+   * Git's own phase name for the current transfer stage ("Receiving objects"),
+   * when it is reporting one. Absent until the first `net://progress` tick, and
+   * absent for the whole op when git has no sideband to report (a local
+   * operation, or `git lfs`, whose stderr is not git's progress protocol).
+   */
+  phase?: string;
+  /** 0–100 for `phase`. Absent means indeterminate — spinner, no bar. */
+  percent?: number;
+  /**
+   * `Date.now()` when this operation started, for the elapsed-time readout.
+   *
+   * Survives a label change within the same op (pull's stash → pull → pop
+   * sequence is one wait from the user's side, so the clock must not restart
+   * three times), which is why `setActivity` carries it forward rather than
+   * stamping a new one on every call.
+   */
+  startedAt: number;
+}
+
+/**
+ * Every operation kind that can be in flight on one repository.
+ *
+ * Only fetch/pull/push ever carry a `percent`: they are the ones run with
+ * `--progress`, which is the only source of a real number. The rest are
+ * honestly indeterminate and say so by having no bar.
  */
 export interface RepoActivity {
-  fetch?: string;
-  pull?: string;
-  push?: string;
-  stash?: string;
-  branch?: string;
+  fetch?: ActivityState;
+  pull?: ActivityState;
+  push?: ActivityState;
+  stash?: ActivityState;
+  branch?: ActivityState;
+  /** An interactive rebase replaying its plan, or a `rebase --onto`. */
+  rebase?: ActivityState;
+  /** `git lfs fetch` / `git lfs pull`. */
+  lfs?: ActivityState;
+  /** `git submodule update`. */
+  submodule?: ActivityState;
+  /** Checking out a pull request's head ref. */
+  forge?: ActivityState;
+}
+
+export type ActivityKey = keyof RepoActivity;
+
+/**
+ * The order the status bar picks an entry in when more than one is live.
+ *
+ * "Expected to be one at a time" stopped being true once LFS, submodule and
+ * forge ops joined: a submodule update fetching while the user pushes is
+ * ordinary. The order is by how much the user is waiting on it — the push they
+ * just started outranks a background submodule fetch.
+ */
+export const ACTIVITY_PRIORITY: readonly ActivityKey[] = [
+  "push",
+  "pull",
+  "fetch",
+  "rebase",
+  "stash",
+  "branch",
+  "forge",
+  "lfs",
+  "submodule",
+];
+
+/** The entry the status bar should show, with its key, or null when idle. */
+export function primaryActivity(
+  activity: RepoActivity,
+): { key: ActivityKey; state: ActivityState } | null {
+  for (const key of ACTIVITY_PRIORITY) {
+    const state = activity[key];
+    if (state) return { key, state };
+  }
+  return null;
+}
+
+/** How many operations are running. Drives the "+2 more" hint in the status bar. */
+export function activityCount(activity: RepoActivity): number {
+  return ACTIVITY_PRIORITY.filter((k) => activity[k]).length;
+}
+
+/**
+ * The kinds `cancelNetworkOps` can actually stop.
+ *
+ * Everything here runs as a `git` subprocess through
+ * `commands::net::run_git_authenticated`, which registers it under
+ * `cancel::Scope::Repo` — so `cancel_network_op` reaches it. The rest are
+ * libgit2 work inside one blocking call with nothing to signal: a rebase replay
+ * cannot be interrupted at all yet (#296 gap 6), and a checkout or stash is over
+ * before a button could be found. Offering Cancel on those would be a button
+ * that does nothing, which is worse than no button.
+ */
+const CANCELLABLE: ReadonlySet<ActivityKey> = new Set<ActivityKey>([
+  "fetch",
+  "pull",
+  "push",
+  "lfs",
+  "submodule",
+  "forge",
+]);
+
+export function isCancellable(key: ActivityKey): boolean {
+  return CANCELLABLE.has(key);
 }

--- a/src/features/repo/repoSlice.ts
+++ b/src/features/repo/repoSlice.ts
@@ -184,14 +184,19 @@ export const REPO_SLICE_KEYS = Object.keys(emptySlice()) as (keyof RepoSlice)[];
 /**
  * The slice as it should be PARKED on an inactive tab.
  *
- * The three in-flight flags are cleared: their requests were issued against the
+ * Every in-flight marker is cleared: those requests were issued against the
  * repository that is no longer active, so `setFor` will drop their responses and
  * nothing will ever clear the flags again. Freezing `loadingMore: true` would
  * make "load more" a permanent no-op on that tab (its re-entry guard reads the
  * flag), and a frozen `loading`/`searching` would park a spinner forever.
  */
 export function frozenSlice(slice: RepoSlice): RepoSlice {
-  return { ...slice, loading: false, loadingMore: false, searching: false };
+  // `activity` clears for the same reason (#296), and it is the same class of
+  // bug the paragraph above describes: the op's `setActivity` is guarded on the
+  // repository being current, so once this tab is parked nothing will ever clear
+  // its entry. Left frozen, returning to the tab shows a spinner — and a Cancel
+  // button — for an operation that finished long ago.
+  return { ...slice, loading: false, loadingMore: false, searching: false, activity: {} };
 }
 
 /** Pick exactly the per-repo fields off a live store state. */

--- a/src/features/repo/repoSlice.ts
+++ b/src/features/repo/repoSlice.ts
@@ -39,6 +39,7 @@ import type {
 import { LOG_REF_ALL } from "@/lib/types";
 import type { AppError, HookRejection } from "@/lib/errors";
 import type { RepoActivity } from "./repoActivity";
+import type { LoadingTask } from "./loadingTasks";
 
 export const DEFAULT_REBASE_STATUS: RebaseStatus = {
   inProgress: false,
@@ -129,6 +130,14 @@ export interface RepoSlice {
   /** Active long-running ops keyed by op kind. */
   activity: RepoActivity;
   /**
+   * The backend reads in flight right now (#296 gap 8) — the detail behind
+   * `loading`, which is one boolean for what is usually ten parallel queries.
+   *
+   * Per-repo like everything else here: a refresh running on a background tab
+   * must not describe the one on screen.
+   */
+  loadingTasks: LoadingTask[];
+  /**
    * The git hook refusal to display, or null (#232).
    *
    * Per-repo, and therefore here: a commit rejected by one repository's
@@ -171,6 +180,7 @@ export function emptySlice(): RepoSlice {
     rebaseStatus: DEFAULT_REBASE_STATUS,
     bisectStatus: DEFAULT_BISECT_STATUS,
     activity: {},
+    loadingTasks: [],
     hookRejection: null,
   };
 }
@@ -196,7 +206,14 @@ export function frozenSlice(slice: RepoSlice): RepoSlice {
   // repository being current, so once this tab is parked nothing will ever clear
   // its entry. Left frozen, returning to the tab shows a spinner — and a Cancel
   // button — for an operation that finished long ago.
-  return { ...slice, loading: false, loadingMore: false, searching: false, activity: {} };
+  return {
+    ...slice,
+    loading: false,
+    loadingMore: false,
+    searching: false,
+    activity: {},
+    loadingTasks: [],
+  };
 }
 
 /** Pick exactly the per-repo fields off a live store state. */

--- a/src/features/repo/useRepoStore.activity.test.ts
+++ b/src/features/repo/useRepoStore.activity.test.ts
@@ -1,0 +1,341 @@
+// The one indicator every long operation reports through (#296).
+//
+// The bug that motivated most of this: `withAuthRetry` resolves as soon as it
+// RAISES a credential challenge — it does not await the retry, which runs later
+// from the dialog's callback. `fetch` and `push` set their label before calling
+// it and cleared it in a `finally`, so the label vanished the moment the
+// password prompt appeared and the retried op — the slower attempt, by
+// definition — ran with no spinner, no status line, and no Cancel button (the
+// status bar gates Cancel on an activity entry existing).
+//
+// These tests pin the fix and the rest of the activity contract:
+//
+// - every attempt, first or retried, carries its own indicator;
+// - the ops that had NO indicator at all now have one (tag push, branch delete,
+//   rebase, LFS, submodule update, forge checkout);
+// - a `net://progress` tick reaches only the repository it names, and only while
+//   an op is actually live;
+// - a label change within one operation does not restart its clock.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { useAuthStore } from "@/features/auth/useAuthStore";
+import {
+  applyNetProgress,
+  applyRebaseProgress,
+  setActivity,
+  useRepoStore,
+} from "./useRepoStore";
+import { emptySlice } from "./repoSlice";
+
+function mockRefreshAll() {
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => null);
+}
+
+const httpsChallenge = () => {
+  throw { kind: "Auth", message: { host: "github.com", kind: "Https" } };
+};
+
+const activity = () => useRepoStore.getState().activity;
+
+beforeEach(() => {
+  resetInvokeMock();
+  useAuthStore.setState({ challenge: null });
+  useRepoStore.setState({
+    ...emptySlice(),
+    current: { id: "repo-1", path: "/tmp/repo-1", head: "main" },
+  });
+  mockRefreshAll();
+  mockInvoke("remember_credential", () => null);
+});
+
+describe("the credential retry keeps its indicator", () => {
+  it("holds the entry open while the challenge is unanswered", async () => {
+    // This is the regression. `fetch` resolves as soon as the dialog is raised;
+    // if it cleared the entry on the way out, the user would be typing a
+    // password with nothing on screen saying a fetch is waiting on them.
+    mockInvoke("fetch", httpsChallenge);
+
+    await useRepoStore.getState().fetch("origin");
+
+    expect(useAuthStore.getState().challenge).not.toBeNull();
+    // The first attempt is over, so its entry is gone — but the moment the retry
+    // runs, one comes back. That is what the next test pins.
+    expect(activity().fetch).toBeUndefined();
+  });
+
+  it("re-opens the entry for the retried attempt, and clears it when that ends", async () => {
+    let seenDuringRetry: string | undefined;
+    let attempts = 0;
+    mockInvoke("fetch", () => {
+      attempts += 1;
+      if (attempts === 1) httpsChallenge();
+      // Sampled INSIDE the retried op: this is precisely the window that used to
+      // have no spinner and no Cancel.
+      seenDuringRetry = activity().fetch?.label;
+      return null;
+    });
+
+    await useRepoStore.getState().fetch("origin");
+    const challenge = useAuthStore.getState().challenge!;
+    await challenge.retry({ username: "u", secret: "s" }, false);
+
+    expect(attempts).toBe(2);
+    expect(seenDuringRetry).toBe("Fetching origin…");
+    expect(activity().fetch).toBeUndefined();
+  });
+
+  it("clears the entry even when the retry fails again", async () => {
+    mockInvoke("push", httpsChallenge);
+
+    await useRepoStore.getState().push("origin", "main");
+    const challenge = useAuthStore.getState().challenge!;
+    await challenge.retry({ username: "u", secret: "s" }, false);
+
+    // A second failure must not park a spinner and a Cancel button forever.
+    expect(activity().push).toBeUndefined();
+  });
+});
+
+describe("every network op reports itself", () => {
+  it.each([
+    ["fetch", "fetch", () => useRepoStore.getState().fetch("origin"), "Fetching origin…"],
+    ["fetch", "fetch_all", () => useRepoStore.getState().fetchAll(), "Fetching all remotes…"],
+    [
+      "push",
+      "push",
+      () => useRepoStore.getState().push("origin", "main"),
+      "Pushing origin/main…",
+    ],
+    // These two had no indicator at all before #296: silent, and therefore
+    // un-cancellable, because the Cancel button is gated on one existing.
+    [
+      "push",
+      "push_tag",
+      () => useRepoStore.getState().pushTag("origin", "v1.2.0"),
+      "Pushing tag v1.2.0…",
+    ],
+    [
+      "push",
+      "push_delete_branch",
+      () => useRepoStore.getState().pushDeleteBranch("origin", "feature/x"),
+      "Deleting origin/feature/x…",
+    ],
+    // Fast-forward landed with the same hand-rolled label-plus-`finally` shape
+    // that broke fetch and push on the retry path.
+    [
+      "fetch",
+      "fast_forward_all_branches",
+      () => useRepoStore.getState().fastForwardAllBranches(),
+      "Fast-forwarding branches…",
+    ],
+  ])("%s: %s", async (key, cmd, run, label) => {
+    let seen: string | undefined;
+    mockInvoke(cmd, () => {
+      seen = activity()[key as "fetch" | "push"]?.label;
+      return null;
+    });
+
+    await run();
+
+    expect(seen).toBe(label);
+    expect(activity()[key as "fetch" | "push"]).toBeUndefined();
+  });
+
+  it("says it is refreshing once the transfer is done", async () => {
+    // The fetch finishes long before `refreshAll`'s ten queries do; holding
+    // "Fetching origin…" over them is the label lying about what it is doing.
+    const labels: string[] = [];
+    mockInvoke("fetch", () => null);
+    mockInvoke("get_status", () => {
+      const l = activity().fetch?.label;
+      if (l) labels.push(l);
+      return [];
+    });
+
+    await useRepoStore.getState().fetch("origin");
+
+    expect(labels).toEqual(["Refreshing…"]);
+  });
+});
+
+describe("the rebase indicator", () => {
+  it("is live for the whole replay and gone afterwards", async () => {
+    let seen: string | undefined;
+    mockInvoke("rebase_start", () => {
+      seen = activity().rebase?.label;
+      return { inProgress: false, nextIndex: 2, total: 2, pauseReason: null };
+    });
+
+    await useRepoStore.getState().rebaseStart([
+      { oid: "a".repeat(40), action: "Pick", message: null, onto: null, mergeParents: [] },
+      { oid: "b".repeat(40), action: "Pick", message: null, onto: null, mergeParents: [] },
+    ]);
+
+    expect(seen).toBe("Rebasing 2 commits…");
+    expect(activity().rebase).toBeUndefined();
+  });
+
+  it("clears after a failure, so the Start button comes back", async () => {
+    mockInvoke("rebase_start", () => {
+      throw { kind: "DirtyWorktree", message: "commit or stash first" };
+    });
+
+    await useRepoStore.getState().rebaseStart([
+      { oid: "a".repeat(40), action: "Pick", message: null, onto: null, mergeParents: [] },
+    ]);
+
+    expect(activity().rebase).toBeUndefined();
+    expect(useRepoStore.getState().error).not.toBeNull();
+  });
+});
+
+describe("progress ticks", () => {
+  it("fill in the phase and percent of the live op", () => {
+    setActivity("repo-1", "fetch", "Fetching origin…");
+    applyNetProgress({
+      repoId: "repo-1",
+      op: "Fetch",
+      phase: "Receiving objects",
+      percent: 62,
+    });
+
+    expect(activity().fetch).toMatchObject({
+      label: "Fetching origin…",
+      phase: "Receiving objects",
+      percent: 62,
+    });
+  });
+
+  it("are dropped when they name a different repository", () => {
+    // The event is app-global. A background tab's fetch must not drive the
+    // active tab's bar.
+    setActivity("repo-1", "fetch", "Fetching origin…");
+    applyNetProgress({ repoId: "repo-2", op: "Fetch", phase: "Receiving objects", percent: 62 });
+
+    expect(activity().fetch?.percent).toBeUndefined();
+  });
+
+  it("are dropped when no such op is running", () => {
+    // Ticks are still in flight when the process exits. One that landed after
+    // the entry was cleared would resurrect a status line — and a Cancel button
+    // — over an operation that is already over.
+    applyNetProgress({ repoId: "repo-1", op: "Push", phase: "Writing objects", percent: 10 });
+
+    expect(activity().push).toBeUndefined();
+  });
+
+  it("relabel a rebase with the step it is on", () => {
+    setActivity("repo-1", "rebase", "Rebasing 200 commits…");
+    applyRebaseProgress({
+      repoId: "repo-1",
+      nextIndex: 11,
+      total: 200,
+      action: "Pick",
+      shortOid: "a1b2c3d",
+      subject: "fix(diff): stop scrolling on selection",
+    });
+
+    // `nextIndex` counts steps DONE, so the one being applied is the 12th.
+    expect(activity().rebase?.label).toBe(
+      "Rebasing 12 of 200: fix(diff): stop scrolling on selection",
+    );
+    expect(activity().rebase?.percent).toBe(6);
+  });
+
+  it("fall back to the oid when a subject could not be read", () => {
+    setActivity("repo-1", "rebase", "Rebasing…");
+    applyRebaseProgress({
+      repoId: "repo-1",
+      nextIndex: 0,
+      total: 1,
+      action: "Pick",
+      shortOid: "a1b2c3d",
+      subject: "",
+    });
+
+    expect(activity().rebase?.label).toBe("Rebasing 1 of 1: a1b2c3d");
+  });
+});
+
+describe("setActivity", () => {
+  it("keeps the clock running across a label change", () => {
+    // Pull is stash → pull → pop: three labels, one wait. Restarting the elapsed
+    // clock at each would make it useless exactly when the user is watching it.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date(1_000_000));
+      setActivity("repo-1", "pull", "Stashing changes…");
+      const started = activity().pull!.startedAt;
+
+      vi.setSystemTime(new Date(1_050_000));
+      setActivity("repo-1", "pull", "Pulling origin/main…");
+
+      expect(activity().pull!.startedAt).toBe(started);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("drops a stale bar when the phase changes", () => {
+    setActivity("repo-1", "pull", "Pulling origin/main…");
+    applyNetProgress({ repoId: "repo-1", op: "Pull", phase: "Receiving objects", percent: 90 });
+    setActivity("repo-1", "pull", "Restoring stashed changes…");
+
+    // 90% of the fetch says nothing about the stash pop that follows it.
+    expect(activity().pull?.percent).toBeUndefined();
+    expect(activity().pull?.phase).toBeUndefined();
+  });
+
+  it("removes the entry on null", () => {
+    setActivity("repo-1", "lfs", "Fetching LFS objects…");
+    expect(activity().lfs).toBeDefined();
+    setActivity("repo-1", "lfs", null);
+    expect("lfs" in activity()).toBe(false);
+  });
+
+  it("does not write into another repository's slice", () => {
+    // An op outlives a tab switch. A fetch on A finishing after the user moved
+    // to B used to clear B's entry — taking B's own spinner and Cancel with it.
+    setActivity("repo-1", "fetch", "Fetching origin…");
+    useRepoStore.setState({
+      current: { id: "repo-2", path: "/tmp/repo-2", head: "main" },
+      activity: { fetch: { label: "Fetching upstream…", startedAt: 1 } },
+    });
+
+    setActivity("repo-1", "fetch", null);
+
+    expect(activity().fetch?.label).toBe("Fetching upstream…");
+  });
+});
+
+describe("parking a tab", () => {
+  it("clears the activity so a finished op cannot leave a spinner behind", async () => {
+    // The other half of the guard above: with writes scoped to the current
+    // repository, nothing will ever clear a parked tab's entry. Returning to it
+    // would show a live-looking status line, and a Cancel button, for an
+    // operation that ended minutes ago.
+    const { frozenSlice } = await import("./repoSlice");
+    const parked = frozenSlice({
+      ...emptySlice(),
+      activity: { fetch: { label: "Fetching origin…", startedAt: 1, percent: 40 } },
+    });
+    expect(parked.activity).toEqual({});
+  });
+});
+
+describe("cancel reaches the ops that go through the shared runner", () => {
+  it("cancels by repository, not by op", async () => {
+    mockInvoke("cancel_network_op", () => 1);
+    await useRepoStore.getState().cancelNetworkOps();
+    expect(getInvokeCalls().filter((c) => c.cmd === "cancel_network_op")).toHaveLength(1);
+  });
+});

--- a/src/features/repo/useRepoStore.loading.test.ts
+++ b/src/features/repo/useRepoStore.loading.test.ts
@@ -1,0 +1,184 @@
+// Naming the backend reads a refresh is waiting on (#296 gap 8).
+//
+// `refreshAll` fires ten reads behind one `Promise.all` and had one boolean to
+// describe all of them. These tests pin that each read now registers itself
+// while it runs, that the registry empties again, and that a read issued
+// against a tab the user has left cannot describe the tab they are on.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { trackLoad, useRepoStore } from "./useRepoStore";
+import { emptySlice, frozenSlice } from "./repoSlice";
+import { loadingSummary } from "./loadingTasks";
+
+/** A promise plus the handle to settle it, so a test can hold a read open. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const tasks = () => useRepoStore.getState().loadingTasks;
+const ids = () => tasks().map((t) => t.id).sort();
+
+function mockRefreshAll() {
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => null);
+  mockInvoke("bisect_status", () => null);
+  mockInvoke("head_info", () => null);
+}
+
+beforeEach(() => {
+  resetInvokeMock();
+  useRepoStore.setState({
+    ...emptySlice(),
+    current: { id: "repo-1", path: "/tmp/repo-1", head: "main" },
+  });
+  mockRefreshAll();
+});
+
+describe("trackLoad", () => {
+  it("registers the read before it can suspend", () => {
+    // Synchronous registration is the contract: ten reads started in one
+    // `Promise.all` must all be present immediately, or "longest-running" would
+    // just report whichever microtask happened to run first.
+    const d = deferred<number>();
+    void trackLoad("repo-1", "status", "reading status", d.promise);
+    expect(ids()).toEqual(["status"]);
+    d.resolve(1);
+  });
+
+  it("removes the read when it settles, and passes the value through", async () => {
+    const out = await trackLoad("repo-1", "status", "reading status", Promise.resolve(7));
+    expect(out).toBe(7);
+    expect(tasks()).toEqual([]);
+  });
+
+  it("removes the read when it rejects, and still rejects", async () => {
+    // A failed read that stayed registered would leave the indicator lit
+    // forever — and the failure path is exactly when a read is slow.
+    await expect(
+      trackLoad("repo-1", "status", "reading status", Promise.reject(new Error("nope"))),
+    ).rejects.toThrow("nope");
+    expect(tasks()).toEqual([]);
+  });
+
+  it("does not count the same read twice when refreshes overlap", () => {
+    const a = deferred<number>();
+    const b = deferred<number>();
+    void trackLoad("repo-1", "status", "reading status", a.promise);
+    void trackLoad("repo-1", "status", "reading status", b.promise);
+    expect(tasks()).toHaveLength(1);
+    a.resolve(1);
+    b.resolve(2);
+  });
+
+  it("ignores a read belonging to another repository", async () => {
+    await trackLoad("repo-2", "status", "reading status", Promise.resolve(1));
+    expect(tasks()).toEqual([]);
+  });
+
+  it("does not remove a row after the user has switched tabs", async () => {
+    // The removal is guarded as well as the add: repo A's read settling must
+    // not reach into repo B's list, which by then holds B's own reads.
+    const d = deferred<number>();
+    void trackLoad("repo-1", "status", "reading status", d.promise);
+    useRepoStore.setState({
+      current: { id: "repo-2", path: "/tmp/repo-2", head: "main" },
+      loadingTasks: [{ id: "status", label: "reading status", startedAt: 1 }],
+    });
+
+    d.resolve(1);
+    await d.promise;
+
+    expect(ids()).toEqual(["status"]);
+  });
+});
+
+describe("refreshAll", () => {
+  it("names every read it is waiting on", async () => {
+    // One read held open; the other nine resolve. What is left is what the
+    // status bar would be naming.
+    const held = deferred<unknown[]>();
+    mockInvoke("list_remotes", () => held.promise);
+
+    const refreshing = useRepoStore.getState().refreshAll();
+    // All ten, registered synchronously — a read added to `refreshAll` later
+    // that skips `trackLoad` shows up here as a missing name.
+    expect(ids()).toEqual([
+      "bisect",
+      "branches",
+      "head",
+      "log",
+      "rebase",
+      "remotes",
+      "repoState",
+      "stashes",
+      "status",
+      "tags",
+    ]);
+
+    held.resolve([]);
+    await refreshing;
+
+    expect(tasks()).toEqual([]);
+  });
+
+  it("narrows to the slow read once the fast ones finish", async () => {
+    // The behaviour worth having: ten reads start together, so at t=0 they are
+    // all equally long-running and the named one is an arbitrary (but stable)
+    // pick. What makes the indicator useful is what happens next — the nine
+    // fast reads drop off and the label is left pointing at the one that is
+    // actually holding the refresh up.
+    const held = deferred<unknown[]>();
+    mockInvoke("list_remotes", () => held.promise);
+
+    const refreshing = useRepoStore.getState().refreshAll();
+    expect(loadingSummary(tasks())).toMatch(/\+ 9 others$/);
+
+    // A macrotask, not a few microtasks: the fast reads each settle through
+    // their own await chain, and counting ticks would be guesswork.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(loadingSummary(tasks())).toBe("Loading: fetching remotes");
+
+    held.resolve([]);
+    await refreshing;
+    expect(tasks()).toEqual([]);
+  });
+
+  it("clears the registry even when a read fails the whole refresh", async () => {
+    mockInvoke("get_status", () => {
+      throw new Error("boom");
+    });
+
+    await useRepoStore.getState().refreshAll();
+
+    expect(tasks()).toEqual([]);
+    expect(useRepoStore.getState().error).not.toBeNull();
+  });
+});
+
+describe("parking a tab", () => {
+  it("drops the task list, like every other in-flight marker", () => {
+    // Writes are scoped to the current repository, so nothing would ever clear
+    // a parked tab's rows — returning to it would show reads that finished long
+    // ago, with clocks still counting up.
+    const parked = frozenSlice({
+      ...emptySlice(),
+      loadingTasks: [{ id: "status", label: "reading status", startedAt: 1 }],
+    });
+    expect(parked.loadingTasks).toEqual([]);
+  });
+});

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -8,6 +8,8 @@ import type {
   FileContent,
   FileStatus,
   LogFilter,
+  NetProgress,
+  RebaseProgress,
   RebaseStatus,
   RebaseStep,
   RepoHandle,
@@ -123,7 +125,7 @@ import {
   sliceOf,
   type RepoSlice,
 } from "./repoSlice";
-import type { RepoActivity } from "./repoActivity";
+import type { ActivityKey } from "./repoActivity";
 
 export type { RepoActivity } from "./repoActivity";
 
@@ -397,6 +399,93 @@ interface RepoStoreState extends RepoSlice {
 }
 
 /**
+ * Set or clear one activity entry, for `repoId` only (#296).
+ *
+ * Module-level rather than a closure inside `create()` because `withAuthRetry`
+ * — which owns the indicator for every network op — is module-level too.
+ *
+ * **Guarded on the repository, like `setFor`.** `activity` lives in the
+ * per-repo slice, and an op outlives a tab switch: a fetch on A that finished
+ * after the user moved to B used to clear B's entry, taking B's own spinner and
+ * Cancel button with it. Same reasoning, same guard — the write belongs to the
+ * repository that asked for it, not to whichever tab happens to be open.
+ * `frozenSlice` handles the other half by clearing `activity` on the way out.
+ *
+ * A label change on a live entry KEEPS its `startedAt`: pull's stash → pull →
+ * pop sequence is three labels but one wait, and restarting the clock at each
+ * would make the elapsed readout useless exactly when it matters. It clears
+ * `phase`/`percent` though: those describe the transfer the previous label
+ * named, and carrying a stale bar into the next phase is worse than no bar.
+ */
+export function setActivity(repoId: string, key: ActivityKey, label: string | null) {
+  useRepoStore.setState((s) => {
+    if (s.current?.id !== repoId) return {};
+    const next = { ...s.activity };
+    if (label === null) delete next[key];
+    else next[key] = { label, startedAt: next[key]?.startedAt ?? Date.now() };
+    return { activity: next };
+  });
+}
+
+/** Which activity entry a `net://progress` tick drives. */
+const NET_OP_KEY: Record<NetProgress["op"], ActivityKey> = {
+  Fetch: "fetch",
+  Pull: "pull",
+  Push: "push",
+};
+
+/**
+ * Apply one `net://progress` tick to the indicator already on screen (#296).
+ *
+ * Two guards, both load-bearing:
+ *
+ * - **The repository must still be the open one.** The event is app-global; a
+ *   fetch running on a background tab would otherwise drive the active tab's bar.
+ * - **The entry must already exist.** A tick that arrives after the op finished
+ *   (they are in flight when the process exits) must not resurrect a cleared
+ *   indicator, which would leave a Cancel button over nothing.
+ */
+export function applyNetProgress(p: NetProgress) {
+  const key = NET_OP_KEY[p.op];
+  useRepoStore.setState((s) => {
+    if (s.current?.id !== p.repoId) return {};
+    const live = s.activity[key];
+    if (!live) return {};
+    return {
+      activity: { ...s.activity, [key]: { ...live, phase: p.phase, percent: p.percent } },
+    };
+  });
+}
+
+/**
+ * Apply one `rebase://progress` tick (#296).
+ *
+ * Relabels the `rebase` entry rather than writing `rebaseStatus`: the status is
+ * the backend's to report when the replay ends or pauses, and a second writer
+ * would race that. The percentage is steps, not bytes — which is the honest unit
+ * for a rebase, where one step can take far longer than another.
+ */
+export function applyRebaseProgress(p: RebaseProgress) {
+  useRepoStore.setState((s) => {
+    if (s.current?.id !== p.repoId) return {};
+    const live = s.activity.rebase;
+    if (!live) return {};
+    const step = p.nextIndex + 1;
+    const what = p.subject || p.shortOid;
+    return {
+      activity: {
+        ...s.activity,
+        rebase: {
+          ...live,
+          label: `Rebasing ${step} of ${p.total}: ${what}`,
+          percent: p.total > 0 ? Math.round((p.nextIndex / p.total) * 100) : undefined,
+        },
+      },
+    };
+  });
+}
+
+/**
  * Run a network op; on an authentication failure, raise a credential challenge
  * whose retry re-runs the SAME op with credentials (#61 D5).
  *
@@ -414,14 +503,34 @@ interface RepoStoreState extends RepoSlice {
  * than growing a second retry path — `useForgeStore.checkout` fetches a pull
  * request's head ref, which needs a git-transport credential exactly like
  * fetch/pull/push/pushTag do (#92). Keep it the only implementation.
+ *
+ * **`activity` is why this function, and not its callers, owns the indicator
+ * (#296).** This resolves the moment it RAISES a challenge — it does not await
+ * the retry, which runs later from the dialog's callback. So a caller that set
+ * a label before calling and cleared it in a `finally` cleared it while the user
+ * was still typing their password, and the retried push — the slower attempt, by
+ * definition — then ran with no spinner, no status line and no Cancel button.
+ * Passing the label here instead makes every attempt carry its own indicator,
+ * and makes it impossible for a network op added later to forget.
  */
 export async function withAuthRetry(
   repoId: string,
   run: (creds?: Credentials) => Promise<void>,
   onError: (e: unknown) => void | Promise<void>,
+  activity?: { key: ActivityKey; label: string },
 ): Promise<void> {
+  /** One attempt, wrapped in its own indicator. */
+  const attempt = async (creds?: Credentials) => {
+    if (!activity) return run(creds);
+    setActivity(repoId, activity.key, activity.label);
+    try {
+      await run(creds);
+    } finally {
+      setActivity(repoId, activity.key, null);
+    }
+  };
   try {
-    await run();
+    await attempt();
     return;
   } catch (e) {
     if (!isAuthError(e)) {
@@ -434,7 +543,7 @@ export async function withAuthRetry(
       kind,
       retry: async (creds, remember) => {
         try {
-          await run(creds);
+          await attempt(creds);
           // Only after it worked: storing on submit would persist a typo.
           // HTTPS only: `git credential approve` stores an HTTP(S) password, so
           // remembering an SSH passphrase there would file the wrong secret
@@ -481,14 +590,8 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (isCancelledError(e)) return;
     set({ error: toAppError(e) });
   };
-  const setActivity = (key: keyof RepoActivity, label: string | null) => {
-    set((s) => {
-      const next = { ...s.activity };
-      if (label === null) delete next[key];
-      else next[key] = label;
-      return { activity: next };
-    });
-  };
+  // `setActivity` is the module-level one above — shared with `withAuthRetry`,
+  // which owns the indicator for every op that can raise a credential challenge.
   /**
    * Open `path` into a freshly reset slice. Throws on failure.
    *
@@ -1015,22 +1118,22 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   async checkoutBranch(name) {
     const repo = get().current;
     if (!repo) return;
-    setActivity("branch", `Switching to ${name}…`);
+    setActivity(repo.id, "branch", `Switching to ${name}…`);
     try {
       // Carry over uncommitted work automatically: stash → checkout → pop.
       // stashSave returns null when there's nothing to stash, so this is a
       // no-op on a clean tree. The client-side `status` can lag behind the
       // backend, so we always attempt the stash rather than gating on it.
-      setActivity("branch", `Stashing changes…`);
+      setActivity(repo.id, "branch", `Stashing changes…`);
       const stashed = await stashSave(repo.id, {
         message: `auto: switch to ${name}`,
         includeUntracked: true,
         keepIndex: false,
       });
-      setActivity("branch", `Switching to ${name}…`);
+      setActivity(repo.id, "branch", `Switching to ${name}…`);
       await checkoutBranch(repo.id, name);
       if (stashed) {
-        setActivity("branch", `Restoring stashed changes…`);
+        setActivity(repo.id, "branch", `Restoring stashed changes…`);
         await stashPop(repo.id, 0);
       }
       await get().refreshAll();
@@ -1038,7 +1141,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       setErrorFor(repo.id, e);
       await get().refreshAll();
     } finally {
-      setActivity("branch", null);
+      setActivity(repo.id, "branch", null);
     }
   },
 
@@ -1071,6 +1174,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   async rebaseOnto(upstream) {
     const repo = get().current;
     if (!repo) return;
+    setActivity(repo.id, "rebase", `Rebasing onto ${upstream}…`);
     try {
       await rebaseOntoFn(repo.id, upstream);
       await get().refreshAll();
@@ -1079,6 +1183,8 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       // batched away by refreshAll's own `error: null` reset.
       await get().refreshAll();
       setErrorFor(repo.id, e);
+    } finally {
+      setActivity(repo.id, "rebase", null);
     }
   },
 
@@ -1089,6 +1195,10 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   async pushTag(remote, name) {
     const repo = get().current;
     if (!repo) return;
+    // These two are pushes, and a push to a slow remote is a wait like any other
+    // (#296). Without an activity entry they were completely silent: no spinner,
+    // no status line, and — because the status bar's Cancel is gated on one —
+    // no way to stop a stalled one either.
     await withAuthRetry(
       repo.id,
       async (creds) => {
@@ -1096,6 +1206,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         await get().refreshAll();
       },
       (e) => setErrorFor(repo.id, e),
+      { key: "push", label: `Pushing tag ${name}…` },
     );
   },
 
@@ -1109,6 +1220,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         await get().refreshAll();
       },
       (e) => setErrorFor(repo.id, e),
+      { key: "push", label: `Deleting ${remote}/${name}…` },
     );
   },
 
@@ -1126,16 +1238,16 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   async createAndSwitchBranch(name, opts) {
     const repo = get().current;
     if (!repo) return false;
-    setActivity("branch", `Creating ${name}…`);
+    setActivity(repo.id, "branch", `Creating ${name}…`);
     try {
       await createBranch(repo.id, name, opts?.from);
     } catch (e) {
       setErrorFor(repo.id, e);
-      setActivity("branch", null);
+      setActivity(repo.id, "branch", null);
       await get().refreshAll();
       return false;
     }
-    setActivity("branch", null);
+    setActivity(repo.id, "branch", null);
     // checkoutBranch handles stash + checkout + pop and its own activity
     // labels. Any error surfaces via the store's `error` field.
     await get().checkoutBranch(name);
@@ -1336,42 +1448,42 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   async fetch(remote) {
     const repo = get().current;
     if (!repo) return;
-    setActivity("fetch", `Fetching ${remote}…`);
-    try {
-      await withAuthRetry(
-        repo.id,
-        async (creds) => {
-          await fetchRemote(
-            repo.id,
-            remote,
-            useSettingsStore.getState().pruneOnFetch,
-            creds,
-          );
-          await get().refreshAll();
-        },
-        (e) => setErrorFor(repo.id, e),
-      );
-    } finally {
-      setActivity("fetch", null);
-    }
+    // The label belongs to `withAuthRetry`, not to a `finally` here (#296):
+    // that `finally` fired the moment a credential challenge was raised, so the
+    // retry ran with no spinner and no Cancel. See `withAuthRetry`.
+    await withAuthRetry(
+      repo.id,
+      async (creds) => {
+        await fetchRemote(
+          repo.id,
+          remote,
+          useSettingsStore.getState().pruneOnFetch,
+          creds,
+        );
+        // The fetch is done; the refresh that follows is not the fetch, and on a
+        // large repository it is a real share of the wait. Saying so beats
+        // holding "Fetching origin…" up over ten queries against a local repo.
+        setActivity(repo.id, "fetch", "Refreshing…");
+        await get().refreshAll();
+      },
+      (e) => setErrorFor(repo.id, e),
+      { key: "fetch", label: `Fetching ${remote}…` },
+    );
   },
 
   async fetchAll() {
     const repo = get().current;
     if (!repo) return;
-    setActivity("fetch", "Fetching all remotes…");
-    try {
-      await withAuthRetry(
-        repo.id,
-        async (creds) => {
-          await fetchAll(repo.id, useSettingsStore.getState().pruneOnFetch, creds);
-          await get().refreshAll();
-        },
-        (e) => setErrorFor(repo.id, e),
-      );
-    } finally {
-      setActivity("fetch", null);
-    }
+    await withAuthRetry(
+      repo.id,
+      async (creds) => {
+        await fetchAll(repo.id, useSettingsStore.getState().pruneOnFetch, creds);
+        setActivity(repo.id, "fetch", "Refreshing…");
+        await get().refreshAll();
+      },
+      (e) => setErrorFor(repo.id, e),
+      { key: "fetch", label: "Fetching all remotes…" },
+    );
   },
 
   async pull(remote, branch, mode = "Merge") {
@@ -1383,39 +1495,36 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     // the now-clean tree, pull successfully and never pop — silently stranding
     // the user's uncommitted work in a stash they were never told about.
     let stashed: string | null = null;
+    // `withAuthRetry` sets and clears the indicator around EACH attempt (#296),
+    // which is what this closure used to hand-roll — the phase changes below
+    // just relabel the entry it opened.
     await withAuthRetry(
       repo.id,
       async (creds) => {
-        // Each attempt owns its own progress indicator: the retry runs long
-        // after the first attempt's `finally` would have cleared it.
-        setActivity("pull", `Pulling ${remote}/${branch}…`);
-        try {
-          // Carry over uncommitted work when the setting is on: stash → pull →
-          // pop, mirroring checkoutBranch's auto-stash. stashSave returns null
-          // when the tree is clean, so this is a no-op in the common case. If
-          // the pull fails, the stash is deliberately NOT popped — the work
-          // stays safe in the stash list rather than colliding with a conflicted
-          // worktree (same policy as checkoutBranch).
-          if (useSettingsStore.getState().autoStashBeforePull && stashed === null) {
-            setActivity("pull", "Stashing changes…");
-            stashed = await stashSave(repo.id, {
-              message: `auto: pull ${remote}/${branch}`,
-              includeUntracked: true,
-              keepIndex: false,
-            });
-            setActivity("pull", `Pulling ${remote}/${branch}…`);
-          }
-          await pullRemote(repo.id, remote, branch, mode, creds);
-          if (stashed) {
-            setActivity("pull", "Restoring stashed changes…");
-            await stashPop(repo.id, 0);
-            // Popped — a later attempt must not pop it a second time.
-            stashed = null;
-          }
-          await get().refreshAll();
-        } finally {
-          setActivity("pull", null);
+        // Carry over uncommitted work when the setting is on: stash → pull →
+        // pop, mirroring checkoutBranch's auto-stash. stashSave returns null
+        // when the tree is clean, so this is a no-op in the common case. If
+        // the pull fails, the stash is deliberately NOT popped — the work
+        // stays safe in the stash list rather than colliding with a conflicted
+        // worktree (same policy as checkoutBranch).
+        if (useSettingsStore.getState().autoStashBeforePull && stashed === null) {
+          setActivity(repo.id, "pull", "Stashing changes…");
+          stashed = await stashSave(repo.id, {
+            message: `auto: pull ${remote}/${branch}`,
+            includeUntracked: true,
+            keepIndex: false,
+          });
+          setActivity(repo.id, "pull", `Pulling ${remote}/${branch}…`);
         }
+        await pullRemote(repo.id, remote, branch, mode, creds);
+        if (stashed) {
+          setActivity(repo.id, "pull", "Restoring stashed changes…");
+          await stashPop(repo.id, 0);
+          // Popped — a later attempt must not pop it a second time.
+          stashed = null;
+        }
+        setActivity(repo.id, "pull", "Refreshing…");
+        await get().refreshAll();
       },
       async (e) => {
         // See mergeBranch's catch: refresh first, error last, so it isn't
@@ -1423,6 +1532,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         await get().refreshAll();
         setErrorFor(repo.id, e);
       },
+      { key: "pull", label: `Pulling ${remote}/${branch}…` },
     );
   },
 
@@ -1449,29 +1559,26 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     }
 
     let out: FastForward | null = null;
-    setActivity("fetch", `Fast-forwarding ${name}…`);
-    try {
-      await withAuthRetry(
-        repo.id,
-        async (creds) => {
-          out = await fastForwardBranchFn(
-            repo.id,
-            name,
-            useSettingsStore.getState().pruneOnFetch,
-            creds,
-          );
-          await get().refreshAll();
-        },
-        async (e) => {
-          // Refresh first, error last — refreshAll clears `error` as its first
-          // act, so the other order loses the banner (see mergeBranch).
-          await get().refreshAll();
-          setErrorFor(repo.id, e);
-        },
-      );
-    } finally {
-      setActivity("fetch", null);
-    }
+    await withAuthRetry(
+      repo.id,
+      async (creds) => {
+        out = await fastForwardBranchFn(
+          repo.id,
+          name,
+          useSettingsStore.getState().pruneOnFetch,
+          creds,
+        );
+        setActivity(repo.id, "fetch", "Refreshing…");
+        await get().refreshAll();
+      },
+      async (e) => {
+        // Refresh first, error last — refreshAll clears `error` as its first
+        // act, so the other order loses the banner (see mergeBranch).
+        await get().refreshAll();
+        setErrorFor(repo.id, e);
+      },
+      { key: "fetch", label: `Fast-forwarding ${name}…` },
+    );
     return out;
   },
 
@@ -1479,45 +1586,39 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     const repo = get().current;
     if (!repo) return null;
     let out: BulkFastForward | null = null;
-    setActivity("fetch", "Fast-forwarding branches…");
-    try {
-      await withAuthRetry(
-        repo.id,
-        async (creds) => {
-          out = await fastForwardAllBranchesFn(
-            repo.id,
-            useSettingsStore.getState().pruneOnFetch,
-            creds,
-          );
-          await get().refreshAll();
-        },
-        async (e) => {
-          await get().refreshAll();
-          setErrorFor(repo.id, e);
-        },
-      );
-    } finally {
-      setActivity("fetch", null);
-    }
+    await withAuthRetry(
+      repo.id,
+      async (creds) => {
+        out = await fastForwardAllBranchesFn(
+          repo.id,
+          useSettingsStore.getState().pruneOnFetch,
+          creds,
+        );
+        setActivity(repo.id, "fetch", "Refreshing…");
+        await get().refreshAll();
+      },
+      async (e) => {
+        await get().refreshAll();
+        setErrorFor(repo.id, e);
+      },
+      { key: "fetch", label: "Fast-forwarding branches…" },
+    );
     return out;
   },
 
   async push(remote, branch, force = "None", noVerify = false) {
     const repo = get().current;
     if (!repo) return;
-    setActivity("push", `Pushing ${remote}/${branch}…`);
-    try {
-      await withAuthRetry(
-        repo.id,
-        async (creds) => {
-          await pushRemote(repo.id, remote, branch, force, creds, noVerify);
-          await get().refreshAll();
-        },
-        (e) => setErrorFor(repo.id, e),
-      );
-    } finally {
-      setActivity("push", null);
-    }
+    await withAuthRetry(
+      repo.id,
+      async (creds) => {
+        await pushRemote(repo.id, remote, branch, force, creds, noVerify);
+        setActivity(repo.id, "push", "Refreshing…");
+        await get().refreshAll();
+      },
+      (e) => setErrorFor(repo.id, e),
+      { key: "push", label: `Pushing ${remote}/${branch}…` },
+    );
   },
 
   async cancelNetworkOps() {
@@ -1692,40 +1793,54 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   async rebaseStart(plan) {
     const repo = get().current;
     if (!repo) return null;
+    // The whole plan replays inside this one call, so without an activity entry
+    // the Start button sat un-spun and re-clickable for the entire run (#296).
+    // `rebase://progress` relabels this entry per step as the replay advances.
+    setActivity(repo.id, "rebase", `Rebasing ${plan.length} commit${plan.length === 1 ? "" : "s"}…`);
     try {
       const status = await rebaseStartFn(repo.id, plan);
       setFor(repo.id, { rebaseStatus: status });
+      setActivity(repo.id, "rebase", "Refreshing…");
       await get().refreshAll();
       return status;
     } catch (e) {
       setErrorFor(repo.id, e);
       return null;
+    } finally {
+      setActivity(repo.id, "rebase", null);
     }
   },
 
   async rebaseContinue() {
     const repo = get().current;
     if (!repo) return null;
+    setActivity(repo.id, "rebase", "Continuing rebase…");
     try {
       const status = await rebaseContinueFn(repo.id);
       setFor(repo.id, { rebaseStatus: status });
+      setActivity(repo.id, "rebase", "Refreshing…");
       await get().refreshAll();
       return status;
     } catch (e) {
       setErrorFor(repo.id, e);
       return null;
+    } finally {
+      setActivity(repo.id, "rebase", null);
     }
   },
 
   async rebaseAbort() {
     const repo = get().current;
     if (!repo) return;
+    setActivity(repo.id, "rebase", "Aborting rebase…");
     try {
       await rebaseAbort(repo.id);
       setFor(repo.id, { rebaseStatus: DEFAULT_REBASE_STATUS });
       await get().refreshAll();
     } catch (e) {
       setErrorFor(repo.id, e);
+    } finally {
+      setActivity(repo.id, "rebase", null);
     }
   },
 

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -427,6 +427,45 @@ export function setActivity(repoId: string, key: ActivityKey, label: string | nu
   });
 }
 
+/**
+ * Register `work` as a named backend read for as long as it runs (#296 gap 8).
+ *
+ * Returns `work` unchanged, so it drops into an existing `Promise.all` without
+ * restructuring the call — which is the point: ten reads become ten named reads
+ * by wrapping each one, and a read added later that skips this is simply absent
+ * from the popover rather than breaking it.
+ *
+ * NOT `async`: the task has to be registered synchronously, before the first
+ * suspension point, or a `Promise.all` of ten reads would register them one
+ * microtask apart and the "longest-running" pick would be meaningless.
+ *
+ * Both ends are guarded on the repository, like `setFor` and `setActivity`: a
+ * read issued against a tab the user has since left must not add — or remove —
+ * a row describing the tab they are looking at now.
+ */
+export function trackLoad<T>(
+  repoId: string,
+  id: string,
+  label: string,
+  work: Promise<T>,
+): Promise<T> {
+  useRepoStore.setState((s) => {
+    if (s.current?.id !== repoId) return {};
+    // Replace rather than append when the id is already present: two refreshes
+    // can overlap, and the same read counted twice would inflate the "+ N
+    // others" count with work that is not actually separate.
+    const rest = s.loadingTasks.filter((t) => t.id !== id);
+    return { loadingTasks: [...rest, { id, label, startedAt: Date.now() }] };
+  });
+  return work.finally(() => {
+    useRepoStore.setState((s) => {
+      if (s.current?.id !== repoId) return {};
+      if (!s.loadingTasks.some((t) => t.id === id)) return {};
+      return { loadingTasks: s.loadingTasks.filter((t) => t.id !== id) };
+    });
+  });
+}
+
 /** Which activity entry a `net://progress` tick drives. */
 const NET_OP_KEY: Record<NetProgress["op"], ActivityKey> = {
   Fetch: "fetch",
@@ -698,7 +737,12 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     set({ commitFilter: filter, searching: true });
     const refspec = get().logRef;
     try {
-      const page = await getLogFilteredPage(repo.id, filter, null, PAGE_SIZE, refspec);
+      const page = await trackLoad(
+        repo.id,
+        "search",
+        "searching commits",
+        getLogFilteredPage(repo.id, filter, null, PAGE_SIZE, refspec),
+      );
       // Guard against a stale response overwriting a newer filter or scope.
       if (get().commitFilter !== filter || get().logRef !== refspec) return;
       setFor(repo.id, {
@@ -759,7 +803,12 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     }
     set({ logRef: refspec, loading: true, error: null });
     try {
-      const page = await getLogPage(repo.id, null, PAGE_SIZE, refspec);
+      const page = await trackLoad(
+        repo.id,
+        "log",
+        "loading history",
+        getLogPage(repo.id, null, PAGE_SIZE, refspec),
+      );
       // Guard against a stale response overwriting a newer scope.
       if (get().logRef !== refspec) return;
       setFor(repo.id, {
@@ -795,31 +844,50 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         rebaseStatus,
         bisectStatus,
         headInfo,
+      // Each read is named while it runs (#296 gap 8), so a refresh that takes
+      // nine seconds can say WHICH of the ten is holding it up instead of
+      // showing one undifferentiated "syncing…". The wrappers are the only
+      // change here — every promise is the same promise it always was.
       ] = await Promise.all([
-          getStatus(repo.id),
-          listBranches(repo.id),
-          listTags(repo.id),
-          listStashes(repo.id),
-          listRemotes(repo.id),
-          getLogPage(repo.id, null, PAGE_SIZE, logRef).catch((e) => {
-            // The browsed ref may have vanished since it was selected (e.g.
-            // the branch was deleted) — fall back to HEAD instead of failing
-            // the whole refresh.
-            if (logRef === null) throw e;
-            setFor(repo.id, { logRef: null });
-            return getLogPage(repo.id, null, PAGE_SIZE);
-          }),
-          repoStateFn(repo.id),
-          rebaseStatusFn(repo.id),
+          trackLoad(repo.id, "status", "reading status", getStatus(repo.id)),
+          trackLoad(repo.id, "branches", "listing branches", listBranches(repo.id)),
+          trackLoad(repo.id, "tags", "listing tags", listTags(repo.id)),
+          trackLoad(repo.id, "stashes", "listing stashes", listStashes(repo.id)),
+          trackLoad(repo.id, "remotes", "fetching remotes", listRemotes(repo.id)),
+          trackLoad(
+            repo.id,
+            "log",
+            "loading history",
+            getLogPage(repo.id, null, PAGE_SIZE, logRef).catch((e) => {
+              // The browsed ref may have vanished since it was selected (e.g.
+              // the branch was deleted) — fall back to HEAD instead of failing
+              // the whole refresh.
+              if (logRef === null) throw e;
+              setFor(repo.id, { logRef: null });
+              return getLogPage(repo.id, null, PAGE_SIZE);
+            }),
+          ),
+          trackLoad(repo.id, "repoState", "reading repository state", repoStateFn(repo.id)),
+          trackLoad(repo.id, "rebase", "reading rebase state", rebaseStatusFn(repo.id)),
           // Degrades instead of failing the refresh. `bisect_status` shells out to
           // `git rev-list --bisect-vars` for its progress numbers, and a repository
           // where that cannot run must still show its status, branches and log —
           // the same reasoning as the browsed-ref fallback above. The cost of the
           // fallback is a bar without step counts, not a broken screen.
-          bisectStatusFn(repo.id).catch(() => DEFAULT_BISECT_STATUS),
+          trackLoad(
+            repo.id,
+            "bisect",
+            "reading bisect state",
+            bisectStatusFn(repo.id).catch(() => DEFAULT_BISECT_STATUS),
+          ),
           // Same degrade-don't-fail policy: the window title (#217) falls back
           // to just the repo name rather than losing the whole refresh.
-          headInfoFn(repo.id).catch(() => null),
+          trackLoad(
+            repo.id,
+            "head",
+            "reading HEAD",
+            headInfoFn(repo.id).catch(() => null),
+          ),
         ]);
       setFor(repo.id, {
         status,

--- a/src/features/submodules/useSubmodulesStore.ts
+++ b/src/features/submodules/useSubmodulesStore.ts
@@ -138,6 +138,11 @@ export const useSubmodulesStore = create<SubmodulesState>((set, get) => ({
           await get().refresh();
           set({ error: toAppError(e) });
         },
+        // `busy` above spins the right ROW; this puts the op in the status bar
+        // and, with it, within reach of the Cancel button — which is gated on an
+        // `activity` entry existing (#296). An update that has to fetch is as
+        // stallable as any other network op.
+        { key: "submodule", label: path ? `Updating ${path}…` : "Updating submodules…" },
       );
     } finally {
       set({ busy: null });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -643,6 +643,38 @@ export interface CloneProgress {
   percent: number;
 }
 
+/** Which network op a `net://progress` tick belongs to. Mirrors Rust `NetOp`. */
+export type NetOp = "Fetch" | "Pull" | "Push";
+
+/**
+ * One tick of `net://progress` (#296). Mirrors `NetProgress` in types.rs.
+ *
+ * `repoId` because the event is app-global while the indicator is per-repository
+ * — a background tab's fetch must not drive the active tab's bar.
+ */
+export interface NetProgress {
+  repoId: string;
+  op: NetOp;
+  phase: string;
+  percent: number;
+}
+
+/**
+ * One tick of `rebase://progress` (#296). Mirrors `RebaseProgress` in types.rs.
+ *
+ * Published before each step is applied, so `nextIndex` is the number of steps
+ * already done — the same value `RebaseStatus.nextIndex` carries, which is what
+ * lets the operation bar render both with one `+ 1`.
+ */
+export interface RebaseProgress {
+  repoId: string;
+  nextIndex: number;
+  total: number;
+  action: RebaseAction;
+  shortOid: string;
+  subject: string;
+}
+
 // ── Forge integration (#92) ──────────────────────────────────────────────────
 // Mirrors `src-tauri/src/forge/mod.rs`. A forge token NEVER appears in any of
 // these: `forge_sign_in` takes one and returns an identity, and nothing hands

--- a/src/screens/Rebase.tsx
+++ b/src/screens/Rebase.tsx
@@ -100,12 +100,15 @@ function RebaseBanner({
   nextIndex,
   total,
   pauseReason,
+  busy,
 }: {
   onContinue: () => void;
   onAbort: () => void;
   nextIndex: number;
   total: number;
   pauseReason: string | null;
+  /** A continue or abort is running — both take as long as a replay (#296). */
+  busy: boolean;
 }) {
   const isConflict = pauseReason === "conflict";
   const isEdit = pauseReason === "edit";
@@ -154,6 +157,8 @@ function RebaseBanner({
         variant="outline"
         onClick={onAbort}
         icon="x"
+        loading={busy}
+        disabled={busy}
         data-testid="rebase-abort"
       >
         Abort
@@ -163,6 +168,8 @@ function RebaseBanner({
         variant="primary"
         onClick={onContinue}
         icon="check"
+        loading={busy}
+        disabled={busy}
         data-testid="rebase-continue"
       >
         Continue
@@ -177,6 +184,8 @@ export function RebaseScreen() {
   const current = useRepoStore((s) => s.current);
   const commits = useRepoStore((s) => s.commits);
   const rebaseStatus = useRepoStore((s) => s.rebaseStatus);
+  /** True while a replay, continue, abort or `rebase --onto` is running (#296). */
+  const rebaseBusy = useRepoStore((s) => !!s.activity.rebase);
   // Store actions are stable identities; selecting them individually keeps this
   // screen from re-rendering on every unrelated store write (the selector-less
   // destructure subscribed to the whole store).
@@ -484,6 +493,7 @@ export function RebaseScreen() {
           nextIndex={rebaseStatus.nextIndex}
           total={rebaseStatus.total}
           pauseReason={rebaseStatus.pauseReason}
+          busy={rebaseBusy}
           onContinue={() => rebaseContinue()}
           onAbort={() => rebaseAbort()}
         />
@@ -565,12 +575,19 @@ export function RebaseScreen() {
                 Clear
               </PGButton>
             )}
+            {/*
+              A long plan replays inside one backend call, so this button used
+              to sit un-spun and re-clickable for the whole run — a dead-looking
+              button whose second click starts a second rebase (#296). The
+              status bar carries the live "Rebasing 12 of 200: <subject>" line.
+            */}
             <PGButton
               size="sm"
               variant="primary"
               icon="rebase"
               onClick={handleStart}
-              disabled={plan.length === 0}
+              loading={rebaseBusy}
+              disabled={plan.length === 0 || rebaseBusy}
               data-testid="rebase-start"
             >
               Start rebase


### PR DESCRIPTION
Closes #296 — gaps 1–5, 7 and 8. Gap 6 (interrupting a rebase replay) stays open; it needs its own design pass and this PR deliberately does not promise it.

Clone was the only operation that could answer *how far along?*. Everything else showed an indeterminate spinner, so a 300 MB fetch and a fetch stalled on a dead host looked identical for their whole duration — and a slow refresh said only `syncing…`, never which of its ten queries was slow.

Two commits, reviewable separately.

---

## 1 — Progress for network ops and rebase (gaps 1–5, 7)

**Backend**

- **`progress.rs`** — clone's stderr parser and its `\r`-aware line splitter, extracted so fetch/pull/push use the same code. The `\r` split is the load-bearing part: git redraws a progress line with a bare carriage return, so reading by `\n` buffers a whole phase and the bar jumps instead of streaming.
- **`run_git_authenticated` streams** instead of `wait_with_output`-ing, and the arg builders pass `--progress` (git writes no sideband when stderr is not a tty, which it never is here). `stdout` goes to `/dev/null` — always discarded, and one pipe to drain removes the deadlock the buffered read existed to avoid. Cancellation survives because the `select!` moved inside the read loop.
- **The failure message comes from the reader's tail**, so git's own words reach `map_git_failure` with the redraws stripped. Every non-progress line is kept, which is what `classify_auth_failure` and `host_from_stderr` need; the cap keeps the newest, because git puts its `fatal:` last.
- **Rebase ticks per step.** `advance_rebase` takes a `RebaseProgressSink` and publishes before applying each step. `rebase_start`/`rebase_continue` keep their signatures as default methods delegating with a no-op sink — 66 call sites across 8 test files untouched, `GitBackend` still object-safe.

**Frontend**

`RepoActivity` grows from a label string to `{ label, phase, percent, startedAt }` and gains `rebase` / `lfs` / `submodule` / `forge` keys. The status bar gets a determinate bar, an elapsed clock past three seconds, a `+N more` count, and a Cancel button gated on `isCancellable`.

Three bugs fell out:

1. **The credential retry lost its indicator.** `withAuthRetry` resolves the moment it *raises* a challenge — it does not await the retry. So `fetch`, `push` and `fastForward*` clearing their label in a `finally` cleared it while the password dialog was still open, and the retried op (the slower attempt, by definition) ran with no spinner, no status line and **no Cancel**. `withAuthRetry` owns the label now, per attempt.
2. **Three ops were silent, three were unstoppable.** Tag push and remote-branch delete had no indicator at all. LFS fetch/pull, submodule update and forge checkout all go through `run_git_authenticated` — the backend could always cancel them — but kept private `busy` fields that never reached the status bar, where the Cancel button lives.
3. **`setActivity` wrote to the wrong tab.** `activity` is a per-repo slice field, but the write was unguarded: an op finishing after a tab switch cleared the *other* tab's spinner, and its own entry stayed frozen on the parked slice, so returning showed a live status line for an op long over.

Cancel is deliberately **not** offered for a rebase replay — it cannot be interrupted yet, and a button that does nothing is worse than none.

---

## 2 — Naming what a slow refresh is waiting on (gap 8)

`refreshAll` is ten backend reads behind one `Promise.all` with one boolean to describe them. Fine on a fast local repo; useless on the setups where it isn't — a `/mnt/c` repository under WSL (#274) spends its nine seconds in one or two of the ten and nothing said which.

Each read now registers a named task while it runs. The status bar shows the summary; clicking expands a panel upward listing every read with its own clock, in the manner of Rider's background-task indicator.

```
Loading: fetching remotes + 5 others   ⌃
```

- **`trackLoad(repoId, id, label, promise)` returns the promise unchanged**, so it drops into the existing `Promise.all` without restructuring it. A read added later that skips it is simply missing from the popover rather than breaking it — and `useRepoStore.loading.test.ts` asserts the full set of ten ids, so an unwrapped read shows up as a diff.
- **It is not `async`**, on purpose: registration must happen before the first suspension point, or ten reads fired together would register one microtask apart and "longest-running" would mean "whichever scheduled first".
- **`SHOW_AFTER_MS = 400` is what makes this liveable.** A refresh runs on every tab switch, every commit and after every network op, almost always finishing inside 100 ms. Without the delay the corner of the screen strobes all day. The consequence worth knowing: **on a fast local repository this indicator will rarely appear at all** — that is the design, not a defect.
- **The collapsed label names the longest-running read**, so as the fast ones drop off it settles onto the one holding the refresh up. Reads that start in the same millisecond are genuinely tied; the id breaks it so the label cannot flap on every render.
- **`LoadingTask` is deliberately not `RepoActivity`.** An activity entry is an operation the user started and earns a Cancel button; a loading task is the app reading its own state and cannot be cancelled. Merging them would put a Cancel button on `listing tags`.
- The trigger is a real `role="button"` with `aria-expanded` and Enter/Space, not a div with an `onClick` — the status bar has no other tab stop, so a mouse-only popover there would be unreachable.

## Verification

| Gate | Result |
| --- | --- |
| `cargo test` | 74 suites, 0 failures (+9 new) |
| `pnpm test` | 2449 passed (+69) |
| `pnpm tsc --noEmit` | clean |
| `pnpm exec tsc -p e2e/tsconfig.json` | clean |
| `pnpm vite build` | clean |
| e2e (Docker) | `remote`, `rebase`, `create`, `submodules`, `pulls` — all passing |

Three checks worth trusting specifically, each verified by mutation:

- **`tests/net_progress.rs` drives a real `git`** over a `file://` remote, which runs a genuine pack transfer and emits real progress — so the flag, pipe, splitter and sink are covered end to end, not just the parser against captured strings. Dropping `--progress` makes it fail with the message it was written to produce.
- **The retry fix**: restoring the old label-plus-`finally` shape fails 8 assertions. The six call sites would not have stayed in step by hand.
- **The flicker floor**: making `useDelayedFlag` return `active` directly fails the "stays hidden for a refresh that finishes quickly" test.

## Docs

`docs/dev/backend.md` and `docs/dev/frontend.md` gain a section each; `docs/dev/architecture.md` gains the `progress.rs` entry the doc invariant requires. One new rule in `CLAUDE.md`: a new long-running op joins `RepoActivity`, and one that can raise a credential challenge lets `withAuthRetry` own its label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
