### PR TITLE
feat(diff): open any diff in the user's own diff tool

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -213,6 +213,16 @@ git/
 │                append_signature, validate_tag_name, parse_verify_tag. Also
 │                the shared ref-name validator (#214): validate_ref_component,
 │                validate_branch_name
+├── difftool.rs  `git difftool` — handing any diff to the user's own tool (#235).
+│                Decides WHICH TWO SIDES and builds the argv; which PROGRAM runs
+│                stays git's (diff.guitool / diff.tool / merge.tool /
+│                difftool.<tool>.cmd), which is what makes it zero-config.
+│                difftool_args + normalize_tool are PURE; spec_for is the one
+│                impure fn and exists for a single case — a commit's own diff
+│                resolves its first parent HERE, because `<oid>^` fails at a
+│                root commit and `<oid>^!` silently degrades to a diff against
+│                the WORKING TREE. `--gui` and `--tool` are never passed
+│                together: git refuses the pair
 ├── commit_template.rs
 │                `commit.template` + `core.commentChar` + `commit.cleanup`
 │                (#252). Resolves the
@@ -283,8 +293,13 @@ commands/        Thin Tauri handlers, one file per area:
 ├── diff.rs      get_diff, stage/unstage/discard_paths, stage/unstage/discard_hunk,
 │                stage/unstage/discard_lines, diff_ref_to_workdir, blame_file
 │                (takes ignoreRevs — the Blame screen's toggle; see git/blame.rs),
-│                and two commit diffs ONE character apart: diff_commit (one oid
-│                vs its first parent) and diff_commits (rev↔rev) — check arity
+│                two commit diffs ONE character apart: diff_commit (one oid
+│                vs its first parent) and diff_commits (rev↔rev) — check arity —
+│                and open_in_difftool (#235), the only command here that does
+│                not return a diff: it hands one to `git difftool`. Thin over
+│                GitBackend::difftool_plan; the spawn is the SECOND deliberate
+│                console-keeping exception (see backend.md) and pipes stderr, so
+│                git's own "diff.tool is not configured" reaches the banner
 ├── branches.rs  list_branches/tags/stashes/remotes,
 │                checkout/create/delete/rename_branch, set_upstream,
 │                fetch, fetch_all, pull, push,

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -636,13 +636,15 @@ again. `commands/repo.rs::delete_untracked_files` is therefore thin.
   `GIT_TERMINAL_PROMPT=0` and a closed stdin; `git_async_in` is the clone shape
   (cwd instead of `-C`); `program`/`program_async` apply the flag only. Later
   builder calls win, so a caller piping stdin just overrides the null.
-- **The two console-KEEPING exceptions are deliberate:**
-  `git_async_keeping_console` (`git mergetool`) and
-  `program_async_keeping_console` (`$VISUAL`/`$EDITOR`) — a console mergetool
-  or `EDITOR=vim` IS a terminal program; silencing it leaves an invisible
-  process holding the file forever. A stray console window is cosmetic; an
-  invisible editor is Task Manager. The guard test allow-lists both call sites
-  by name.
+- **The console-KEEPING exceptions are deliberate**, and there are three call
+  sites across two constructors: `git_async_keeping_console` for `git mergetool`
+  and for `git difftool` (#235), `program_async_keeping_console` for
+  `$VISUAL`/`$EDITOR`. A console mergetool, a console difftool (`vimdiff`,
+  `nvimdiff`) or `EDITOR=vim` IS a terminal program; silencing it leaves an
+  invisible process holding the file forever. A stray console window is
+  cosmetic; an invisible editor is Task Manager. The guard test allow-lists
+  every call site by name with its reason, so a fourth is an argued change with
+  a test to update.
 - **Pin Windows system executables to an absolute path.** `CreateProcess`
   searches the **current directory before the system directory**, and this
   app's cwd *is* a repository whenever the `pgit` shim launched it from inside
@@ -703,6 +705,60 @@ one of those has to hold for an option-bearing clone too.
   the reader's actual question ("why does history stop") goes unanswered; a widen
   rewrites the user's own config with a per-remote choice to make. Both are their
   own change — see the spec.
+
+## `git difftool` — what we decide, and what git does (#235)
+
+The feature is "open this diff in Beyond Compare / Kaleidoscope / Meld /
+`nvimdiff`", and almost all of it is git's. `git/difftool.rs` decides which two
+sides and builds the argv; `commands/diff.rs::open_in_difftool` spawns it.
+
+- **Shell out, never materialise the sides ourselves.** For a commit or an index
+  diff neither side is a file — they are blobs — and `git difftool` already
+  extracts both, honours `diff.guitool` / `diff.tool` / `merge.tool` /
+  `difftool.<tool>.cmd` / `difftool.<tool>.path`, and cleans up. Our own copy
+  would be worse and would drift the first time git adds a tool. That is also
+  what makes this zero-config for anyone already set up: with no Settings
+  override we pass no tool at all.
+- **`--gui` and `--tool` are mutually exclusive.** git refuses the pair —
+  `fatal: options '--gui' and '--tool' cannot be used together` — because they
+  answer the same question. No override → `--gui` (which puts `diff.guitool`
+  first and falls back to `diff.tool`); an override → `--tool=<name>` alone.
+  Found by the end-to-end test, pinned by a unit test.
+- **A commit's own diff resolves its parent in RUST.** Both shorthands are wrong
+  at a root commit: `<oid>^` fails to resolve, and `<oid>^!` — git's own
+  documented "changes on this commit" form — silently degrades to
+  `git diff <oid>`, a diff against the **working tree**. So `spec_for` asks git2
+  for the first parent and falls back to `treebuilder(None).write()`, the
+  repository's own empty tree (hash-algorithm-correct, where a hard-coded
+  `4b825dc…` is SHA-1 only). `tests/difftool.rs` pins the wrong answer as much as
+  the right one: an uncommitted edit in the worktree must never reach a commit's
+  diff.
+- **A tool NAME is not a command line.** `normalize_tool` refuses whitespace and
+  control characters with `InvalidArgument`, because `diff.tool=meld` selects
+  `difftool.meld.cmd` — the command line belongs in that key, where git reads it.
+- **No `NoDiffTool` variant.** When nothing resolves, git says
+  `This message is displayed because 'diff.tool' is not configured` in the user's
+  own locale. The command pipes **stderr** (stdin and stdout stay inherited, so a
+  console tool still owns the terminal) and puts its tail in `AppError::Git`.
+  Minting a variant would mean pattern-matching English against a resolution
+  order we do not own.
+- **No caller-supplied string reaches argv.** Revisions are RESOLVED to hex oids
+  (`resolve_commit`), not validated: `git difftool` needs its revisions **ahead
+  of `--`**, so the separator that protects the pathspecs cannot protect them,
+  and a `--output=…` in a revision slot would be read as an option. Resolving
+  makes that unrepresentable rather than merely refused, and it is the better
+  error besides — a bad ref fails as `InvalidRef` with git's own message instead
+  of after the spawn. `every_revision_reaching_argv_is_a_hex_oid` asserts it as a
+  property over every target shape, so a new variant that passed a string through
+  fails without anyone remembering this paragraph.
+- **`GIT_LITERAL_PATHSPECS` is the second user of `git/stash.rs`'s constant.**
+  This is the app's other pathspec-passing shell-out; without it a file named
+  `a[b].c` is a glob and the row the user right-clicked is not the file git
+  opens. Tested with a decoy that the glob would have matched.
+- Paths are a LIST so a rename passes `[oldPath, newPath]` — scoped to the new
+  path alone git reports a renamed file as wholly added, which is the dead end
+  the feature exists to remove. Every path goes through
+  `opener::safe_workdir_path`, and one bad path refuses the whole batch.
 
 ## Bisect: git's state is the only state of record (#93)
 

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -329,6 +329,30 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   boundaries): both click path and keyboard cursor are disabled by
   `useHunkActionsDisabledReason` — the keyboard must never reach what the mouse
   cannot (#61 D2).
+- **The way OUT of our diff is one helper** (#235):
+  `design/context-menu.tsx::externalDiffItem(target, paths)`, in `fileMenuItems`
+  (Commit panel, repo browser) and on `CommitDiffPanel`'s file rows (commit
+  diff, History inline, Compare, both stash diffs). One definition because the
+  entry has to say the same thing everywhere — a user who finds it on a
+  working-tree row and not on a commit's file has found a bug, not a
+  distinction. Three things about it:
+  - **`CommitDiffPanel` takes an explicit `difftoolTarget`, never one derived
+    from `syntaxSides`.** The two describe the same comparison, but `syntaxSides`
+    is allowed to be approximate — History passes `{ rev: "<oid>^" }`, which
+    fails harmlessly on a root commit — and `<oid>^` handed to `git difftool`
+    either errors or, in its `^!` spelling, diffs against the WORKING TREE. A
+    surface showing one commit passes `{ kind: "commit" }` and the backend
+    resolves the parent.
+  - **A rename passes BOTH paths.** `[oldPath, newPath]`, so git pairs them
+    instead of reporting the file as wholly added.
+  - **Not in the multi-file menu**, and **disabled on a purely untracked row.**
+    Forty files is forty windows; and an untracked path is in neither side of
+    any diff git computes, so the click would do nothing at all. Staging it makes
+    it work via the `staged` target — hence `untracked && !staged`.
+  The store action (`useRepoStore.openInDifftool`) holds a `difftool`
+  `RepoActivity` entry for the whole time the tool is open — it resolves when the
+  TOOL exits, which is minutes — and `refreshAll()`s afterwards, because a
+  working-tree side is handed to the tool as the REAL file, not a copy.
 
 ## The commit-message composer (#252)
 

--- a/docs/superpowers/plans/2026-08-30-external-difftool-plan.md
+++ b/docs/superpowers/plans/2026-08-30-external-difftool-plan.md
@@ -1,0 +1,110 @@
+# Plan — external diff tool (#235)
+
+Spec: `docs/superpowers/specs/2026-08-30-external-difftool-spec.md`.
+One PR, one squashed commit on `feat/external-difftool`.
+
+## 1. Backend — the value
+
+**`src-tauri/src/git/types.rs`**
+- `DiffToolTarget` — `#[serde(tag = "kind", rename_all = "camelCase")]`,
+  `Deserialize` only (it only travels frontend → backend). Variants:
+  `Worktree`, `Staged`, `Commit { oid }`, `Range { from, to }`,
+  `RevToWorktree { rev }`.
+
+**`src-tauri/src/git/difftool.rs`** (new)
+- `pub struct DiffSpec { cached: bool, revs: Vec<String> }` — what git needs,
+  after the target has been resolved against the repository.
+- `pub fn spec_for(repo: &git2::Repository, target: &DiffToolTarget) -> AppResult<DiffSpec>`
+  — the only impure part: `Commit` looks up the first parent, falling back to
+  `repo.treebuilder(None)?.write()?` for a root commit.
+- `pub fn difftool_args(spec, tool: Option<&str>, paths: &[String]) -> Vec<String>`
+  — PURE. `difftool --no-prompt --gui [--cached] [--tool=T] <revs…> -- <paths…>`.
+- `pub fn normalize_tool(raw: Option<&str>) -> AppResult<Option<String>>` — PURE.
+- `pub struct DiffToolPlan { workdir, args, tool }`.
+
+**`src-tauri/src/git/mod.rs`** — `pub mod difftool;` + trait method:
+```rust
+fn difftool_plan(
+    &self,
+    repo_id: &RepoId,
+    target: &DiffToolTarget,
+    paths: &[String],
+    tool: Option<&str>,
+) -> AppResult<DiffToolPlan>;
+```
+
+**`src-tauri/src/git/libgit2.rs`** — implement: `with_repo` → workdir,
+`safe_workdir_path` every path, `normalize_tool`, `spec_for`, `difftool_args`.
+
+**`src-tauri/src/git/cli.rs`** — `NotImplemented` stub.
+
+## 2. Backend — the spawn
+
+**`src-tauri/src/commands/diff.rs`** — `open_in_difftool(repo_id, target, paths, tool)`:
+`spawn_blocking` for the plan, then `proc::git_async_keeping_console(workdir)`
+with `GIT_LITERAL_PATHSPECS=1` and `stderr(piped())`; non-zero exit →
+`AppError::Git` carrying the stderr tail.
+
+**`src-tauri/src/lib.rs`** — register `commands::diff::open_in_difftool`.
+
+**`src-tauri/tests/spawn_no_window.rs`** — add
+`src/commands/diff.rs` to `CONSOLE_KEEPING_CALLERS` with the reason.
+
+**`src-tauri/src/git/stash.rs`** — its `LITERAL_PATHSPECS` doc says it is the
+only pathspec-passing shell-out. It now has a second caller; fix the comment
+rather than defining the constant twice.
+
+## 3. Tests — Rust
+
+**`src-tauri/tests/difftool.rs`** (new)
+- argv table: every kind, with and without `--tool`, one path and two.
+- `normalize_tool` accepts/trims/rejects.
+- plan against a real repo: commit-vs-parent, root commit → empty tree,
+  `../escape` → `InvalidPath`, unknown repo id.
+- END-TO-END: temp repo, `diff.tool=pgfake`,
+  `difftool.pgfake.cmd` writes `$LOCAL`/`$REMOTE` to a marker; run the plan's
+  argv through `proc::git`; assert the marker holds two readable files with the
+  expected contents. Second test sets `diff.tool` to a tool that would fail and
+  passes `--tool=pgfake` to prove the override wins. Skip with an `eprintln!`
+  when `git difftool` is unavailable.
+
+## 4. Frontend
+
+- `src/lib/types.ts` — `DiffToolTarget` mirror.
+- `src/lib/tauri.ts` — `openInDifftool(repoId, target, paths, tool)`.
+- `src/features/repo/repoActivity.ts` — `difftool` key + priority entry (not
+  cancellable).
+- `src/features/repo/useRepoStore.ts` — `openInDifftool(target, paths)`: reads
+  `useSettingsStore.getState().externalDiffTool`, sets the activity entry,
+  awaits, `refreshAll()`, `setErrorFor` on failure (refresh first, error last).
+- `src/design/context-menu.tsx` — `externalDiffItem(target, paths)` helper +
+  entry in `fileMenuItems` (after "Open in editor").
+- `src/features/diff/CommitDiffPanel.tsx` — optional `difftoolTarget` prop, a
+  `useContextMenu` over the file rows.
+- `src/screens/CommitDiff.tsx`, `Compare.tsx`, `History.tsx` — pass the target.
+- `src/features/settings/useSettingsStore.ts` — `externalDiffTool: ""`.
+- `src/screens/Settings.tsx` — the field, in the Diff section.
+
+## 5. Tests — frontend
+
+- `src/design/contextMenu.difftool.test.ts` — the entry exists on both sides and
+  dispatches the right target.
+- `src/features/diff/CommitDiffPanel.difftool.test.tsx` — right-click a file row.
+- `src/features/repo/useRepoStore.difftool.test.ts` — settings override reaches
+  the invoke, activity entry set and cleared, refresh on success.
+- `src/features/settings/useSettingsStore.export.test.ts` — add to `PORTABLE`.
+- `src/screens/Settings.diff.test.tsx` — the field writes the setting.
+
+## 6. Docs
+
+- `docs/dev/architecture.md` — `git/difftool.rs` in the backend tree,
+  `open_in_difftool` in the `commands/diff.rs` entry.
+- `docs/dev/backend.md` — the two-shorthands-are-wrong note under a difftool
+  heading; the `CONSOLE_KEEPING_CALLERS` bullet gains its second entry.
+- `docs/dev/frontend.md` — one line in the diff-surfaces section.
+- CLAUDE.md — untouched (it is a pointer file).
+
+## Gates
+
+`pnpm tsc --noEmit`, `pnpm test`, `cargo test`. No e2e spec, so no
+`e2e/tsconfig.json` typecheck; CI runs the e2e suite unchanged.

--- a/docs/superpowers/specs/2026-08-30-external-difftool-spec.md
+++ b/docs/superpowers/specs/2026-08-30-external-difftool-spec.md
@@ -1,0 +1,178 @@
+# Open any diff in an external diff tool (#235)
+
+## The problem
+
+We can hand a *conflict* to the user's configured merge tool
+(`run_mergetool`, `commands/conflict.rs`), but every other diff in the app is a
+closed room. There is no way to open a working-tree change, a commit's diff or a
+branch-compare file in Beyond Compare, Kaleidoscope, Meld or `nvimdiff`.
+
+Two independent trackers carry the same ask (Sublime Merge #58, GitHub Desktop
+#9609), and the people asking have already bought a diff tool and have opinions
+about it. Our own diff is good and most users will stay in it — this is about not
+being a dead end for the ones who will not, and about the diffs our renderer
+genuinely cannot show (binaries).
+
+Not #224 (rendering binaries *in* our diff) and not #225 (generic custom
+actions).
+
+## The shape of the answer
+
+**Shell out to `git difftool`. Do not materialise temp files ourselves.**
+
+For a commit or an index diff, an external tool needs two real files on disk.
+`git difftool` already extracts both sides, honours `diff.tool`,
+`diff.guitool`, `merge.tool`, `difftool.<tool>.cmd`, `difftool.<tool>.path` and
+`difftool.prompt`, and cleans up after itself. Re-implementing any of that would
+be a second, worse copy of a thing git ships.
+
+So the whole feature is: build the right argv, spawn it, and put the entry point
+where the user is already right-clicking.
+
+### What we resolve, and what git resolves
+
+| Decision | Who makes it |
+| --- | --- |
+| Which tool to run | **git** — `diff.guitool` → `diff.tool` → `merge.*` → autodetect. Zero-config for anyone already set up. |
+| An explicit override | **us** — the optional Settings field becomes `--tool=<name>`, which git treats as the top of that list. |
+| Prompting | **us** — always `--no-prompt`. A GUI app has no terminal for git's `Launch 'vimdiff' [Y/n]?`. |
+| GUI preference | **us** — `--gui` when no override is set, so a user who split `diff.guitool` (Kaleidoscope) from `diff.tool` (vimdiff) gets the graphical one from a graphical app. It falls back to `diff.tool` when no guitool is set, so it costs nothing for everyone else. Never *both* `--gui` and `--tool`: git refuses the pair (`fatal: options '--gui' and '--tool' cannot be used together`) because they answer the same question — found by the end-to-end test, pinned by a unit test. |
+| Which two sides | **us** — a `DiffToolTarget`, resolved to revs before it reaches git. |
+
+**No `NoDiffTool` error variant.** When nothing resolves, git's own stderr
+already says `This message is displayed because 'diff.tool' is not configured` —
+which is a better sentence than anything we would write, in the user's own
+locale, and it cannot drift out of step with git's resolution order. We surface
+that stderr through `AppError::Git` rather than pattern-matching English to mint
+a variant. (This is why the command pipes stderr while inheriting stdin/stdout:
+without it the banner would read `git difftool exited with exit status: 1`.)
+
+### `DiffToolTarget`
+
+The two sides, named rather than inferred:
+
+| Kind | argv | Surface |
+| --- | --- | --- |
+| `worktree` | `difftool … -- <paths>` | an unstaged row |
+| `staged` | `difftool … --cached -- <paths>` | a staged row |
+| `commit { oid }` | `difftool … <parent> <oid> -- <paths>` | a commit's diff, a stash's own diff |
+| `range { from, to }` | `difftool … <from> <to> -- <paths>` | branch compare, commit↔commit |
+| `revToWorktree { rev }` | `difftool … <rev> -- <paths>` | compare-against-workdir, stash-vs-worktree |
+
+**`commit` resolves the parent in Rust, and that is load-bearing.** The two
+obvious shorthands are both wrong on a root commit:
+
+- `<oid>^` — `git rev-parse` fails, so the whole invocation fails.
+- `<oid>^!` — git's documented "changes on this commit" form silently degrades
+  to `git diff <oid>`, which diffs the commit against the **working tree**.
+  Verified against git 2.50: on a root commit `git diff <root>^!` printed the
+  worktree delta, not the commit. A wrong diff is worse than an error.
+
+So `spec_for` asks git2 for the first parent and falls back to the repository's
+empty tree (`treebuilder(None).write()`, which is hash-algorithm-correct where a
+hard-coded `4b825dc…` is not) — the same pair `git show` uses for a root commit.
+
+### Revisions are resolved, not trusted
+
+Every rev in a `DiffToolTarget` goes through `revparse_single` + `peel_to_commit`
+and reaches argv as a **hex oid**. `git difftool` requires its revisions ahead of
+`--`, so the separator that protects the pathspecs cannot protect these: a
+`--output=…` arriving over IPC in a revision slot would sit in an option
+position. Resolving rather than validating makes the shape unrepresentable, which
+is the same standard the app already holds elsewhere (`git/tag.rs`,
+`forge/mod.rs`, `ssh.rs` all refuse a leading `-`) and a stronger one — a string
+cannot pass by merely looking safe. It also produces the better error: a bad ref
+fails as `InvalidRef` carrying git's own message rather than after the spawn.
+
+### Paths, not a path
+
+The command takes `paths: Vec<String>` so a rename can pass `[oldPath, newPath]`.
+Scoped to the new path alone, `git difftool` would show a renamed file as a whole
+file added — the same dead end this feature exists to remove. Both go through
+`opener::safe_workdir_path` (rejects empty, absolute and `..`) and after `--`,
+with `GIT_LITERAL_PATHSPECS=1` so a file honestly named `:(exclude)x` or `a[b].c`
+selects itself.
+
+### The console exception
+
+`git difftool` inherits `run_mergetool`'s window handling verbatim: it is spawned
+through `proc::git_async_keeping_console`, so a console difftool (`vimdiff`,
+`nvimdiff`) gets the console it needs. The asymmetry `proc.rs:141` argues for
+mergetool holds identically here — silencing a console tool leaves an invisible
+process the user can only reach through Task Manager, while not silencing a GUI
+tool costs a cosmetic window (and `CREATE_NO_WINDOW` is ignored for it anyway).
+This is the second and last entry in `spawn_no_window.rs`'s
+`CONSOLE_KEEPING_CALLERS`, added with its reason.
+
+## Where it appears
+
+Exactly the three surfaces the issue names, which are two code sites:
+
+1. **`fileMenuItems`** — the file row in the Commit panel and the repo browser.
+   Target is `staged` for a staged row, `worktree` otherwise.
+2. **`CommitDiffPanel`'s file list** — one component behind the commit diff
+   screen, the History inline panel, Compare and the two stash diffs, so all
+   four inherit it from one new context menu. The target arrives as an explicit
+   `difftoolTarget` prop rather than being derived from `syntaxSides`: History
+   passes `{ rev: "<oid>^" }` for highlighting, where failing is harmless, and
+   reusing it here would reintroduce the root-commit trap above.
+
+Deliberately **not** in the multi-file menu: "open 40 files in Beyond Compare" is
+40 windows, and git difftool would open them one at a time behind a prompt we
+have turned off.
+
+**Disabled on a purely untracked row.** The file is in neither side of any diff
+git computes, so `git difftool` runs no tool at all and the click does nothing
+whatsoever — the exact dead end the feature exists to remove, reintroduced. Stage
+it and the `staged` target shows it, so the gate is `untracked && !staged`.
+
+## Settings
+
+One optional field, `externalDiffTool`, under Diff. Empty (the default) means
+"let git decide", which is the case the feature is designed around; a value is
+passed as `--tool=<name>`. Validated in Rust (`normalize_tool`): trimmed, empty →
+`None`, anything with whitespace or a control character → `InvalidArgument`,
+because a git tool name is a config-key segment and never a command line — the
+command line lives in `difftool.<tool>.cmd`, where git wants it.
+
+Portable in the settings export: a tool name describes a preference, not a
+machine path, and a name that is not installed elsewhere fails visibly with
+git's own message rather than silently.
+
+## What the user sees while the tool is open
+
+A `difftool` entry in `RepoActivity` for as long as `git difftool` runs. A
+graphical diff tool can sit open for minutes, and the documented rule
+(`docs/dev/frontend.md`) is that a long op joins the one indicator; without it
+the app looks like it swallowed the click. Not cancellable — it does not go
+through `run_git_authenticated`, so `cancel_network_op` cannot reach it, and a
+Cancel button that does nothing is worse than none.
+
+On exit the store runs `refreshAll()`: when the right-hand side is the working
+tree, `git difftool` hands the tool the **real file**, so edits made in it land
+in the worktree.
+
+## Verification
+
+- Pure argv tests for every `DiffToolTarget` × tool-override × multi-path
+  combination.
+- Real-repo tests for the plan: parent resolution, root-commit empty tree,
+  pathspec refusal.
+- **Two end-to-end tests that run real `git difftool`** against a temp repo with
+  `diff.tool` pointed at a fake tool that writes `$LOCAL`/`$REMOTE` to a marker
+  file. One proves the config is honoured (which is the whole "respect
+  `diff.tool`/`difftool.*`" requirement, proven rather than asserted); the other
+  proves `--tool=` overrides it. They skip with a message where `git difftool` is
+  unavailable, the same way the gpg and git-lfs tests do.
+- Component tests for both menu surfaces and the Settings field.
+
+## Deliberately out of scope
+
+- Naming the resolved tool in the menu label ("Open in Kaleidoscope"). It needs a
+  second command and a per-repo store field to answer a question the user already
+  knows the answer to.
+- A directory diff (`git difftool -d`) for a whole commit. Real, but a different
+  interaction: it has no file row to hang off and its own "the tool owns the
+  window now" story.
+- `difftool.writeToTemp`, `--trust-exit-code`. Left at git's defaults, which is
+  what makes closing the tool with a non-zero status not raise a banner.

--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -4,7 +4,7 @@ use tauri::State;
 
 use crate::{
     error::{AppError, AppResult},
-    git::types::{BlameResult, DiffKind, FileDiff, RepoId, WorkdirDiff},
+    git::types::{BlameResult, DiffKind, DiffToolTarget, FileDiff, RepoId, WorkdirDiff},
     state::AppState,
 };
 
@@ -262,4 +262,139 @@ pub async fn blame_file(
     tokio::task::spawn_blocking(move || backend.blame_file(&repo_id, &path, ignore_revs))
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+/// Hand one file's diff to the user's own diff tool (#235).
+///
+/// Thin over `GitBackend::difftool_plan`, which decides the argv under one
+/// repository lock; everything here is the spawn.
+///
+/// # Two deliberate departures from the other git shell-outs
+///
+/// **The console is kept.** `crate::proc::git_async_keeping_console` is used for
+/// the same reason `run_mergetool` uses it: `git difftool` launches the tool the
+/// USER configured, and a console difftool (`vimdiff`, `nvimdiff`) *is* a
+/// terminal program. Silencing it on Windows would leave an invisible process
+/// holding the file with `status().await` never returning and no cancel button
+/// in the UI, while a GUI tool is unaffected either way — `CREATE_NO_WINDOW`
+/// does not apply to a non-console application. `tests/spawn_no_window.rs`
+/// allow-lists this call site by name so it cannot be "fixed" into consistency.
+///
+/// **stderr is piped.** The failure this command has to report well is "no diff
+/// tool resolved", and git's own stderr says it better than we could — in the
+/// user's locale, and without us pattern-matching English to decide. Without the
+/// pipe the banner would read `git difftool exited with exit status: 1`, which
+/// sends the reader nowhere. stdin and stdout stay inherited so a console tool
+/// still owns the terminal.
+///
+/// The exit code is git difftool's own: `difftool.trustExitCode` is left at its
+/// default (off), so closing Beyond Compare with a non-zero status is not a
+/// failure, and only git failing to run a tool at all is.
+#[tauri::command]
+pub async fn open_in_difftool(
+    state: State<'_, AppState>,
+    repo_id: String,
+    target: DiffToolTarget,
+    paths: Vec<String>,
+    tool: Option<String>,
+) -> AppResult<()> {
+    let backend = state.backend.clone();
+    let repo = RepoId(repo_id);
+    let plan = tokio::task::spawn_blocking(move || {
+        backend.difftool_plan(&repo, &target, &paths, tool.as_deref())
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))??;
+
+    log::info!(
+        "difftool: {} arg(s), tool={}",
+        plan.args.len(),
+        plan.tool.as_deref().unwrap_or("<git decides>")
+    );
+
+    let mut cmd = crate::proc::git_async_keeping_console(&plan.workdir);
+    cmd.args(&plan.args);
+    // The pathspec-shaped sibling of the `--` the argv builder already put in:
+    // a file honestly named `:(exclude)x` must select itself rather than be read
+    // as pathspec magic. Same reasoning, and the same one constant, as the other
+    // shell-out in the app that passes a pathspec.
+    let (key, value) = crate::git::stash::LITERAL_PATHSPECS;
+    cmd.env(key, value);
+    cmd.stderr(std::process::Stdio::piped());
+
+    let out = cmd
+        .spawn()
+        .map_err(|e| AppError::Io(e.to_string()))?
+        .wait_with_output()
+        .await
+        .map_err(|e| AppError::Io(e.to_string()))?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        return Err(AppError::Git(difftool_failure(&stderr, out.status)));
+    }
+    Ok(())
+}
+
+/// What a failed `git difftool` should say.
+///
+/// git's own words, tail-first and bounded, because the useful sentence
+/// ("This message is displayed because 'diff.tool' is not configured") is the
+/// LAST thing it prints, after a block of instructions. A silent failure falls
+/// back to the exit status, which is at least a fact.
+fn difftool_failure(stderr: &str, status: std::process::ExitStatus) -> String {
+    const MAX_LINES: usize = 6;
+    let lines: Vec<&str> = stderr
+        .lines()
+        .map(str::trim_end)
+        .filter(|l| !l.is_empty())
+        .collect();
+    if lines.is_empty() {
+        return format!("git difftool exited with {status}");
+    }
+    let tail = &lines[lines.len().saturating_sub(MAX_LINES)..];
+    tail.join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::difftool_failure;
+
+    /// The exact failure the zero-config user hits, and the one line of it worth
+    /// putting in a banner.
+    #[test]
+    fn the_tail_of_gits_own_complaint_is_what_reaches_the_banner() {
+        let stderr = "\nThis message is displayed because 'diff.tool' is not configured.\n\
+                      See 'git difftool --tool-help' or 'git help config' for more details.\n";
+        let text = difftool_failure(stderr, exit_status());
+        assert!(text.contains("'diff.tool' is not configured"), "{text}");
+        assert!(!text.starts_with('\n'), "{text}");
+    }
+
+    #[test]
+    fn a_silent_failure_still_says_something() {
+        let text = difftool_failure("   \n\n", exit_status());
+        assert!(text.starts_with("git difftool exited with"), "{text}");
+    }
+
+    #[test]
+    fn a_long_complaint_is_bounded() {
+        let stderr = (0..40)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let text = difftool_failure(&stderr, exit_status());
+        assert!(text.contains("line 39"), "the tail is the useful end: {text}");
+        assert!(!text.contains("line 0"), "unbounded: {text}");
+    }
+
+    /// A real `ExitStatus` with no platform-specific constructor in reach: run
+    /// the shortest possible failing child through the sanctioned spawner.
+    fn exit_status() -> std::process::ExitStatus {
+        crate::proc::program("git")
+            .arg("--this-flag-does-not-exist")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("git is on PATH for the test suite")
+    }
 }

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -5,7 +5,7 @@ use crate::error::{AppError, AppResult};
 use super::{
     types::{
         AheadBehind, BisectMark, BisectStatus, BlameResult, BranchInfo, CommitInfo, CommitNote, CommitOptions, CommitResult, ConflictSides,
-        DeleteFailure, DiffKind, FileContent,
+        DeleteFailure, DiffKind, DiffToolTarget, FileContent,
         BulkFastForward, FastForward,
         FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage, RebaseProgressSink, RebaseStatus, RebaseStep, ReflogEntry,
         BlobSource, ImagePreview,
@@ -378,6 +378,15 @@ impl GitBackend for CliBackend {
         Err(AppError::NotImplemented)
     }
     fn shallow_info(&self, _repo_id: &RepoId) -> AppResult<ShallowInfo> {
+        Err(AppError::NotImplemented)
+    }
+    fn difftool_plan(
+        &self,
+        _repo_id: &RepoId,
+        _target: &DiffToolTarget,
+        _paths: &[String],
+        _tool: Option<&str>,
+    ) -> AppResult<crate::git::difftool::DiffToolPlan> {
         Err(AppError::NotImplemented)
     }
     fn add_remote(&self, _repo_id: &RepoId, _name: &str, _url: &str) -> AppResult<()> {

--- a/src-tauri/src/git/difftool.rs
+++ b/src-tauri/src/git/difftool.rs
@@ -1,0 +1,366 @@
+//! `git difftool` — handing any diff to the user's own tool (#235).
+//!
+//! # Why we shell out rather than materialise the sides ourselves
+//!
+//! An external tool wants two real files on disk. For a commit or an index diff
+//! neither side is a file: they are blobs in the object database. `git difftool`
+//! already extracts both, names the temp files, honours `diff.guitool` /
+//! `diff.tool` / `merge.tool` / `difftool.<tool>.cmd` / `difftool.<tool>.path`,
+//! and cleans up afterwards. Writing our own copy of that would be a second,
+//! worse version of something git ships — and it would drift the first time git
+//! adds a tool.
+//!
+//! So this module is deliberately small: it decides WHICH TWO SIDES, and builds
+//! the argv. Everything about which program runs stays git's.
+//!
+//! # What we do decide
+//!
+//! * `--no-prompt`, always. A GUI process has no terminal for git's
+//!   `Launch 'vimdiff' [Y/n]?`, so the prompt is a hang with no window.
+//! * `--gui` OR `--tool=<name>`, never both — git refuses the pair (`fatal:
+//!   options '--gui' and '--tool' cannot be used together`), because they answer
+//!   the same question. With no Settings override we pass `--gui`, which puts
+//!   `diff.guitool` at the top of git's list and falls back to `diff.tool` when
+//!   there is no guitool: a user who split the two (Kaleidoscope for graphical
+//!   contexts, `vimdiff` in a terminal) gets the graphical one from a graphical
+//!   app, and nobody else notices. With an override we pass `--tool=<name>`,
+//!   which has already made that choice.
+//!
+//! Nothing here decides what to do when no tool resolves: git's own stderr
+//! already says `This message is displayed because 'diff.tool' is not
+//! configured`, in the user's locale, and pattern-matching that sentence to mint
+//! an error variant would only be able to go out of date.
+//!
+//! # Nothing a caller typed reaches argv
+//!
+//! Two kinds of caller-supplied text arrive here, and each is neutralised by
+//! construction rather than by inspection:
+//!
+//! * **Revisions** are RESOLVED to hex oids ([`resolve_commit`]). They have to
+//!   sit ahead of `--`, where the separator cannot protect them, so a
+//!   `--output=…` in a revision slot would be read as an option — resolving
+//!   makes that unrepresentable.
+//! * **Pathspecs** go after `--`, are checked against the worktree by the caller
+//!   (`opener::safe_workdir_path`), and are paired with
+//!   `GIT_LITERAL_PATHSPECS=1`.
+//!
+//! The tool name is the third, and [`normalize_tool`] refuses anything that is
+//! not one; it is emitted as a single `--tool=<name>` token besides.
+
+use std::path::PathBuf;
+
+use git2::Repository;
+
+use crate::error::{AppError, AppResult};
+use crate::git::types::DiffToolTarget;
+
+/// What `git difftool` needs once the target has been resolved against the
+/// repository: whether to look at the index, and the revisions to pass through
+/// to `git diff`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffSpec {
+    /// `--cached` — compare the index rather than the working tree.
+    pub cached: bool,
+    /// Zero, one or two revisions, in git's order: old, then new.
+    pub revs: Vec<String>,
+}
+
+/// Everything the command needs to spawn, decided under one repository lock.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffToolPlan {
+    /// The worktree `git -C` runs in — also what the pathspecs are relative to.
+    pub workdir: PathBuf,
+    /// Full argv after `git`, including `difftool` itself.
+    pub args: Vec<String>,
+    /// The override that was applied, or `None` when git decides. Logged, so a
+    /// report says which of the two paths was taken.
+    pub tool: Option<String>,
+}
+
+/// The app-settings override, cleaned up, or `None` for "let git decide".
+///
+/// PURE. A git tool NAME is a config-key segment — `diff.tool=meld` selects
+/// `difftool.meld.cmd` — so it can never legitimately contain whitespace or a
+/// control character. The command line belongs in `difftool.<tool>.cmd`, where
+/// git wants it, and a field that silently accepted one would look like it
+/// worked and then fail inside git with a message about a tool nobody named.
+///
+/// Empty (the default) is not an error: it is the zero-config case.
+pub fn normalize_tool(raw: Option<&str>) -> AppResult<Option<String>> {
+    let Some(trimmed) = raw.map(str::trim).filter(|t| !t.is_empty()) else {
+        return Ok(None);
+    };
+    if trimmed
+        .chars()
+        .any(|c| c.is_whitespace() || c.is_control())
+    {
+        return Err(AppError::InvalidArgument(format!(
+            "not a diff tool name: {trimmed:?}. Name a tool git knows \
+             (`meld`, `bc`, `vimdiff`) or one you defined with \
+             difftool.<tool>.cmd — the command line belongs in that config key, \
+             not here."
+        )));
+    }
+    Ok(Some(trimmed.to_string()))
+}
+
+/// The empty tree, as this repository spells it.
+///
+/// Written rather than hard-coded: `4b825dc642cb6eb9a060e54bf8d69288fbee4904` is
+/// the SHA-1 answer only, and a SHA-256 repository has a different one. The
+/// object itself is a zero-byte tree — git writes it on any commit of an empty
+/// directory — so this is idempotent and costs nothing.
+fn empty_tree(repo: &Repository) -> AppResult<String> {
+    Ok(repo.treebuilder(None)?.write()?.to_string())
+}
+
+/// One revision, as a commit this repository actually has.
+///
+/// **Every** revision that reaches argv goes through here, and that is the whole
+/// point of it existing rather than each arm calling `revparse_single` itself.
+///
+/// A revspec crosses IPC as a caller-supplied string, and `git difftool` needs
+/// its revisions **before** `--` — so the separator that protects the pathspecs
+/// cannot protect these. A value like `--output=/tmp/x` would sit in an option
+/// position and be read as one. Resolving rather than validating means what
+/// lands in argv is a **hex oid by construction**, which is the same guarantee
+/// the app makes everywhere else user text meets git's argv
+/// (`git/tag.rs::validate_ref_component`, `forge/mod.rs::validate_ref_name`,
+/// `ssh.rs`) — and a stronger one, because it cannot be satisfied by a string
+/// that merely looks safe.
+///
+/// It is also the better error. A ref that does not exist fails HERE as
+/// `InvalidRef` carrying git's own message, instead of after the spawn as
+/// whatever `git difftool` chooses to print.
+///
+/// Peeled to a commit, matching what "diff these two revisions" means
+/// everywhere else in the app; an annotated tag peels through, and a revspec
+/// naming a tree or a blob is refused rather than silently diffing something
+/// else.
+fn resolve_commit<'r>(repo: &'r Repository, rev: &str) -> AppResult<git2::Commit<'r>> {
+    let object = repo
+        .revparse_single(rev)
+        .map_err(|e| AppError::InvalidRef(format!("{rev}: {}", e.message())))?;
+    object
+        .peel_to_commit()
+        .map_err(|e| AppError::InvalidRef(format!("{rev}: {}", e.message())))
+}
+
+/// Resolve a target against the repository.
+///
+/// The only impure function here, and it does two jobs: it turns every revision
+/// into a real oid (see [`resolve_commit`] — nothing a caller typed reaches
+/// argv), and it resolves a commit's PARENT, because neither `<oid>^` nor
+/// `<oid>^!` can be used for that. See [`DiffToolTarget`].
+pub fn spec_for(repo: &Repository, target: &DiffToolTarget) -> AppResult<DiffSpec> {
+    match target {
+        DiffToolTarget::Worktree => Ok(DiffSpec {
+            cached: false,
+            revs: Vec::new(),
+        }),
+        DiffToolTarget::Staged => Ok(DiffSpec {
+            cached: true,
+            revs: Vec::new(),
+        }),
+        DiffToolTarget::Commit { oid } => {
+            let commit = resolve_commit(repo, oid)?;
+            let old = match commit.parent_id(0) {
+                Ok(parent) => parent.to_string(),
+                // A root commit. Its "old side" is the empty tree, which is the
+                // pair `git show` uses and the only one that does not quietly
+                // become a diff against the working tree.
+                Err(_) => empty_tree(repo)?,
+            };
+            Ok(DiffSpec {
+                cached: false,
+                revs: vec![old, commit.id().to_string()],
+            })
+        }
+        DiffToolTarget::Range { from, to } => Ok(DiffSpec {
+            cached: false,
+            revs: vec![
+                resolve_commit(repo, from)?.id().to_string(),
+                resolve_commit(repo, to)?.id().to_string(),
+            ],
+        }),
+        DiffToolTarget::RevToWorktree { rev } => Ok(DiffSpec {
+            cached: false,
+            revs: vec![resolve_commit(repo, rev)?.id().to_string()],
+        }),
+    }
+}
+
+/// The argv after `git`. PURE.
+///
+/// Order is not stylistic: `git difftool` parses its own options first and hands
+/// the rest to `git diff`, so options precede revisions and `--` precedes the
+/// pathspecs. The separator is mandatory for the same reason it is in
+/// `stash.rs` — a file honestly named `-f` must not be read as a flag — and the
+/// caller pairs it with `GIT_LITERAL_PATHSPECS=1` so a file named `a[b].c`
+/// selects itself.
+///
+/// `paths` is a LIST because a rename has two of them: scoped to the new path
+/// alone, git would report a renamed file as a whole file added, which is the
+/// same dead end this feature exists to remove.
+pub fn difftool_args(spec: &DiffSpec, tool: Option<&str>, paths: &[String]) -> Vec<String> {
+    let mut args = vec!["difftool".to_string(), "--no-prompt".to_string()];
+    if spec.cached {
+        args.push("--cached".to_string());
+    }
+    match tool {
+        // One argv token, so a name that begins with `-` cannot be read as an
+        // option even before `normalize_tool` has refused it.
+        //
+        // And NO `--gui` beside it: git refuses the pair outright — `fatal:
+        // options '--gui' and '--tool' cannot be used together`. That is not a
+        // limitation to work around, it is git saying the two answer the same
+        // question. `--gui` means "pick from the guitool list"; naming a tool
+        // has already picked.
+        Some(tool) => args.push(format!("--tool={tool}")),
+        None => args.push("--gui".to_string()),
+    }
+    args.extend(spec.revs.iter().cloned());
+    args.push("--".to_string());
+    args.extend(paths.iter().cloned());
+    args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(cached: bool, revs: &[&str]) -> DiffSpec {
+        DiffSpec {
+            cached,
+            revs: revs.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn paths(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn the_worktree_form_passes_no_revisions() {
+        assert_eq!(
+            difftool_args(&spec(false, &[]), None, &paths(&["src/a.rs"])),
+            vec!["difftool", "--no-prompt", "--gui", "--", "src/a.rs"]
+        );
+    }
+
+    #[test]
+    fn the_staged_form_is_cached_and_still_revisionless() {
+        assert_eq!(
+            difftool_args(&spec(true, &[]), None, &paths(&["src/a.rs"])),
+            vec!["difftool", "--no-prompt", "--cached", "--gui", "--", "src/a.rs"]
+        );
+    }
+
+    #[test]
+    fn a_range_keeps_gits_own_old_then_new_order() {
+        assert_eq!(
+            difftool_args(&spec(false, &["main", "feature"]), None, &paths(&["a"])),
+            vec!["difftool", "--no-prompt", "--gui", "main", "feature", "--", "a"]
+        );
+    }
+
+    #[test]
+    fn the_tool_override_lands_before_the_revisions() {
+        // git difftool parses its own options first; a `--tool` after a revision
+        // is a pathspec-looking argument to `git diff`.
+        assert_eq!(
+            difftool_args(&spec(false, &["a1", "b2"]), Some("meld"), &paths(&["x"])),
+            vec!["difftool", "--no-prompt", "--tool=meld", "a1", "b2", "--", "x"]
+        );
+    }
+
+    #[test]
+    fn gui_and_tool_are_never_passed_together() {
+        // git REFUSES the pair — `fatal: options '--gui' and '--tool' cannot be
+        // used together` — so this is the difference between the feature working
+        // and every override failing. Found by the end-to-end test, pinned here.
+        for spec in [spec(false, &[]), spec(true, &[]), spec(false, &["a", "b"])] {
+            let with_tool = difftool_args(&spec, Some("bc"), &paths(&["p"]));
+            assert!(
+                !with_tool.contains(&"--gui".to_string()),
+                "{with_tool:?}"
+            );
+            let without = difftool_args(&spec, None, &paths(&["p"]));
+            assert!(without.contains(&"--gui".to_string()), "{without:?}");
+            assert!(
+                !without.iter().any(|a| a.starts_with("--tool")),
+                "{without:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_rename_passes_both_paths() {
+        let args = difftool_args(&spec(false, &["a1", "b2"]), None, &paths(&["old", "new"]));
+        let sep = args.iter().position(|a| a == "--").expect("separator");
+        assert_eq!(&args[sep + 1..], ["old", "new"]);
+    }
+
+    #[test]
+    fn every_path_lands_after_the_separator() {
+        // The one property that must hold for every shape: a file named `-f` is
+        // a file. Asserted over the whole matrix rather than per case, because a
+        // new variant would otherwise be the one that forgot.
+        for spec in [
+            spec(false, &[]),
+            spec(true, &[]),
+            spec(false, &["r"]),
+            spec(false, &["a", "b"]),
+        ] {
+            for tool in [None, Some("bc")] {
+                let args = difftool_args(&spec, tool, &paths(&["-f", "--cached"]));
+                let sep = args.iter().position(|a| a == "--").expect("separator");
+                assert_eq!(
+                    &args[sep + 1..],
+                    ["-f", "--cached"],
+                    "spec {spec:?} tool {tool:?}"
+                );
+                assert!(
+                    !args[..sep].contains(&"-f".to_string()),
+                    "a pathspec leaked into the option run: {args:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_prompt_is_off_in_every_shape() {
+        // git's prompt is a hang with no window in a GUI process, so this is not
+        // a preference — it is the flag that makes the feature work at all.
+        for spec in [spec(false, &[]), spec(true, &[]), spec(false, &["a", "b"])] {
+            let args = difftool_args(&spec, None, &paths(&["p"]));
+            assert!(args.contains(&"--no-prompt".to_string()), "{args:?}");
+        }
+    }
+
+    #[test]
+    fn an_absent_or_blank_override_means_git_decides() {
+        assert_eq!(normalize_tool(None).unwrap(), None);
+        assert_eq!(normalize_tool(Some("")).unwrap(), None);
+        assert_eq!(normalize_tool(Some("   ")).unwrap(), None);
+    }
+
+    #[test]
+    fn a_tool_name_is_trimmed_not_rejected_for_stray_spacing() {
+        assert_eq!(normalize_tool(Some("  meld  ")).unwrap().as_deref(), Some("meld"));
+    }
+
+    #[test]
+    fn a_command_line_is_refused_rather_than_passed_as_a_tool_name() {
+        // The trap this exists for: someone types `bcompare "$LOCAL" "$REMOTE"`
+        // into the Settings field. git would look for a tool by that whole name
+        // and fail with a message naming a tool nobody configured.
+        let err = normalize_tool(Some("bcompare $LOCAL $REMOTE")).unwrap_err();
+        assert!(matches!(err, AppError::InvalidArgument(_)), "{err:?}");
+    }
+
+    #[test]
+    fn a_control_character_is_refused() {
+        assert!(normalize_tool(Some("meld\nrm -rf")).is_err());
+    }
+}

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -26,6 +26,7 @@ use super::{
         BulkFastForward,
         BlobSource,
         DiffKind,
+        DiffToolTarget,
         DiffLine, DiffLineKind, FastForward, FileContent, FileDiff, FileStatus, HeadInfo, ImagePreview,
         LfsStatus,
         LogFilter, LogPage,
@@ -5300,6 +5301,42 @@ impl GitBackend for Libgit2Backend {
                 shallow,
                 boundary_count,
                 single_branch: shallow_mod::single_branch_from_refspecs(&per_remote),
+            })
+        })
+    }
+
+    fn difftool_plan(
+        &self,
+        repo_id: &RepoId,
+        target: &DiffToolTarget,
+        paths: &[String],
+        tool: Option<&str>,
+    ) -> AppResult<super::difftool::DiffToolPlan> {
+        // Validated before the repository is touched: an unusable request must
+        // not depend on which lock was free.
+        let tool = super::difftool::normalize_tool(tool)?;
+        if paths.is_empty() {
+            return Err(AppError::InvalidArgument(
+                "no path to open in a diff tool".into(),
+            ));
+        }
+        self.with_repo(repo_id, |repo| {
+            let workdir = repo
+                .workdir()
+                .map(PathBuf::from)
+                .ok_or_else(|| AppError::InvalidPath("bare repository has no workdir".into()))?;
+            // The pathspecs are relative to the worktree root (`git -C`), so the
+            // lexical check is the right strength — nothing here unlinks. It
+            // rejects the three shapes that would address a file outside the
+            // repository: empty, absolute, and one containing `..`.
+            for path in paths {
+                safe_workdir_path(&workdir, path)?;
+            }
+            let spec = super::difftool::spec_for(repo, target)?;
+            Ok(super::difftool::DiffToolPlan {
+                workdir,
+                args: super::difftool::difftool_args(&spec, tool.as_deref(), paths),
+                tool,
             })
         })
     }

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -3,6 +3,7 @@ pub mod bisect;
 pub mod blame;
 pub mod cli;
 pub mod commit_template;
+pub mod difftool;
 pub mod hooks;
 pub mod image;
 pub mod libgit2;
@@ -26,7 +27,7 @@ use crate::error::AppResult;
 use types::{
     AheadBehind,
     BisectMark, BisectStatus, BlameResult, BranchInfo, CommitInfo, CommitNote, CommitOptions, CommitResult, ConflictSides,
-    DeleteFailure, DiffKind, FileContent,
+    DeleteFailure, DiffKind, DiffToolTarget, FileContent,
     BulkFastForward, FastForward,
     FileDiff, FileStatus, HeadInfo, LfsStatus, LogFilter, LogPage, RebaseProgressSink, RebaseStatus, RebaseStep, ReflogEntry,
     BlobSource, ImagePreview,
@@ -392,6 +393,22 @@ pub trait GitBackend: Send + Sync {
     /// `remote.<name>.fetch` are git's, and a second record could only
     /// disagree. See `git/shallow.rs` for the parsing half.
     fn shallow_info(&self, repo_id: &RepoId) -> AppResult<ShallowInfo>;
+    /// Everything `git difftool` needs for one file, decided under one lock
+    /// (#235) — see `git/difftool.rs`.
+    ///
+    /// A PLAN rather than the spawn itself: the spawn is async and deliberately
+    /// keeps its console (a console difftool is a terminal program), so it lives
+    /// in `commands/diff.rs` next to the one other exception, where
+    /// `tests/spawn_no_window.rs` can allow-list it by name. Everything that
+    /// needs the repository — the workdir, a commit's parent, the pathspec
+    /// check — happens here instead of being re-derived at the call site.
+    fn difftool_plan(
+        &self,
+        repo_id: &RepoId,
+        target: &DiffToolTarget,
+        paths: &[String],
+        tool: Option<&str>,
+    ) -> AppResult<difftool::DiffToolPlan>;
 
     // === index writes ===
     fn stage(&self, repo_id: &RepoId, paths: &[PathBuf]) -> AppResult<()>;

--- a/src-tauri/src/git/stash.rs
+++ b/src-tauri/src/git/stash.rs
@@ -19,8 +19,11 @@ use crate::git::types::StashSaveOptions;
 /// A path reaching us is data from `git status`, but git reads a leading `:`
 /// as pathspec MAGIC — a file honestly named `:(exclude)x` would otherwise
 /// select a different set than the row the user right-clicked. This is the
-/// pathspec-shaped member of the same family as the `--` rule, and it is set
-/// only here because no other shell-out in the app passes a pathspec.
+/// pathspec-shaped member of the same family as the `--` rule.
+///
+/// Defined here and reused: `commands::diff::open_in_difftool` (#235) is the
+/// second shell-out in the app that passes a pathspec, and it needs exactly
+/// this. A second copy of the pair would be a second one to forget.
 pub const LITERAL_PATHSPECS: (&str, &str) = ("GIT_LITERAL_PATHSPECS", "1");
 
 /// `git stash push …` for a pathspec-scoped stash.

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -425,6 +425,33 @@ pub enum BlobSource {
     Stage { stage: u16 },
 }
 
+/// Which two sides `git difftool` should be pointed at (#235).
+///
+/// Named rather than passed as a revspec pair, for the reason `BlobSource`
+/// above is: "the working tree" and "the index" are not revisions, and a
+/// nullable rev that means either of them is how call sites get it wrong.
+///
+/// `Commit` is a kind of its own instead of a `Range` the frontend builds with
+/// `^`, because both shorthands for "this commit against its parent" are wrong
+/// on a ROOT commit: `<oid>^` fails to resolve, and `<oid>^!` — git's own
+/// documented form — silently degrades to `git diff <oid>`, which diffs the
+/// commit against the WORKING TREE. `git/difftool.rs::spec_for` resolves the
+/// parent instead. Deserialize only: it never travels back.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum DiffToolTarget {
+    /// Unstaged changes — the working tree against the index.
+    Worktree,
+    /// Staged changes — the index against HEAD.
+    Staged,
+    /// One commit against its first parent (or the empty tree, at a root).
+    Commit { oid: String },
+    /// Any two revisions, in git's own order: old, then new.
+    Range { from: String, to: String },
+    /// A revision against the working tree.
+    RevToWorktree { rev: String },
+}
+
 /// Why a blob that exists is not being previewed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -256,6 +256,7 @@ pub fn run() {
             commands::diff::diff_commit,
             commands::diff::diff_ref_to_workdir,
             commands::diff::blame_file,
+            commands::diff::open_in_difftool,
             commands::branches::list_branches,
             commands::branches::list_tags,
             commands::branches::list_stashes,

--- a/src-tauri/tests/difftool.rs
+++ b/src-tauri/tests/difftool.rs
@@ -1,0 +1,934 @@
+//! `git difftool` — the plan, and a real run (#235).
+//!
+//! Two halves, and the second is the one that matters.
+//!
+//! The plan tests pin what we decide: which revisions a target resolves to, that
+//! a root commit gets the empty tree rather than a diff against the working
+//! tree, that a pathspec cannot leave the worktree. They can be asserted from
+//! the values alone.
+//!
+//! The end-to-end tests pin what we DON'T decide. The feature's central promise
+//! is "respect `diff.tool` / `difftool.*` from git config", and that promise is
+//! kept by shelling out rather than by any code of ours — so the only honest
+//! proof is a real repository, a real `diff.tool`, and a real tool that leaves
+//! evidence. They also prove the three flags the argv builder cannot:
+//! `--no-prompt` really does suppress the prompt, `--` really does scope the
+//! run to one file, and `--tool=` really does outrank `diff.tool`.
+
+mod support;
+
+use std::path::{Path, PathBuf};
+
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::difftool::{difftool_args, normalize_tool, DiffSpec};
+use platypusgit_lib::git::types::{DiffToolTarget, RepoId};
+use platypusgit_lib::git::GitBackend;
+use support::TempRepo;
+
+fn paths(list: &[&str]) -> Vec<String> {
+    list.iter().map(|s| s.to_string()).collect()
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE PLAN
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn a_worktree_target_passes_no_revisions_and_scopes_to_the_path() {
+    let tr = TempRepo::with_initial_commit("one\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let plan = backend
+        .difftool_plan(
+            &handle.id,
+            &DiffToolTarget::Worktree,
+            &paths(&["README.md"]),
+            None,
+        )
+        .expect("plan");
+
+    assert_eq!(plan.tool, None, "nothing configured means git decides");
+    assert_eq!(
+        plan.args,
+        vec!["difftool", "--no-prompt", "--gui", "--", "README.md"]
+    );
+    assert_eq!(
+        plan.workdir.canonicalize().unwrap(),
+        tr.path().canonicalize().unwrap()
+    );
+}
+
+#[test]
+fn a_staged_target_is_the_index_side() {
+    let tr = TempRepo::with_initial_commit("one\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let plan = backend
+        .difftool_plan(
+            &handle.id,
+            &DiffToolTarget::Staged,
+            &paths(&["README.md"]),
+            None,
+        )
+        .expect("plan");
+
+    assert!(plan.args.contains(&"--cached".to_string()), "{:?}", plan.args);
+}
+
+#[test]
+fn a_commit_target_resolves_its_first_parent() {
+    let tr = TempRepo::with_initial_commit("one\n");
+    tr.add_commit("README.md", "two\n", "second");
+    let (backend, handle) = tr.open_with_backend();
+
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    let parent = head.parent(0).unwrap();
+
+    let plan = backend
+        .difftool_plan(
+            &handle.id,
+            &DiffToolTarget::Commit {
+                oid: head.id().to_string(),
+            },
+            &paths(&["README.md"]),
+            None,
+        )
+        .expect("plan");
+
+    let sep = plan.args.iter().position(|a| a == "--").unwrap();
+    assert_eq!(
+        &plan.args[sep - 2..sep],
+        [parent.id().to_string(), head.id().to_string()],
+        "old then new, both resolved: {:?}",
+        plan.args
+    );
+}
+
+/// The trap this whole `Commit` variant exists for.
+///
+/// `<oid>^` fails to resolve at a root commit, and `<oid>^!` — git's own
+/// documented "changes on this commit" shorthand — silently degrades to
+/// `git diff <oid>`, which diffs the commit against the WORKING TREE. Verified
+/// against git 2.50 before this variant was written. The empty tree is the pair
+/// `git show` uses, and it is the only one that is neither an error nor a lie.
+#[test]
+fn a_root_commit_diffs_against_the_empty_tree_not_the_working_tree() {
+    let tr = TempRepo::with_initial_commit("one\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let root = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    assert_eq!(root.parent_count(), 0, "fixture must be a root commit");
+
+    let plan = backend
+        .difftool_plan(
+            &handle.id,
+            &DiffToolTarget::Commit {
+                oid: root.id().to_string(),
+            },
+            &paths(&["README.md"]),
+            None,
+        )
+        .expect("plan");
+
+    let sep = plan.args.iter().position(|a| a == "--").unwrap();
+    let old = &plan.args[sep - 2];
+    let new = &plan.args[sep - 1];
+    assert_eq!(new, &root.id().to_string());
+    assert_ne!(old, &root.id().to_string(), "two sides, not one");
+    // It is a tree, it is empty, and it exists — so git can read it.
+    let oid = git2::Oid::from_str(old).expect("an oid");
+    let tree = tr.repo.find_tree(oid).expect("the empty tree is written");
+    assert_eq!(tree.len(), 0);
+}
+
+#[test]
+fn a_range_target_resolves_both_revisions_to_oids() {
+    let tr = TempRepo::with_initial_commit("one\n");
+    tr.add_commit("README.md", "two\n", "second");
+    let (backend, handle) = tr.open_with_backend();
+
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+    let parent = head.parent(0).unwrap();
+
+    let plan = backend
+        .difftool_plan(
+            &handle.id,
+            &DiffToolTarget::Range {
+                from: parent.id().to_string(),
+                to: "HEAD".into(),
+            },
+            &paths(&["README.md"]),
+            None,
+        )
+        .expect("plan");
+
+    // Still the same two commits, in git's own old-then-new order — the
+    // resolution changes the SPELLING, never the pair.
+    let sep = plan.args.iter().position(|a| a == "--").unwrap();
+    assert_eq!(
+        &plan.args[sep - 2..sep],
+        [parent.id().to_string(), head.id().to_string()]
+    );
+}
+
+/// A branch name resolves to the commit it points at, so the argv never carries
+/// the name — which is what makes the option-injection shape unrepresentable
+/// rather than merely unlikely.
+#[test]
+fn a_range_named_by_refs_still_resolves_to_the_same_two_commits() {
+    let tr = TempRepo::with_initial_commit("one\n");
+    tr.add_commit("README.md", "two\n", "second");
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+
+    let plan = backend
+        .difftool_plan(
+            &handle.id,
+            &DiffToolTarget::Range {
+                from: "main".into(),
+                to: "HEAD".into(),
+            },
+            &paths(&["README.md"]),
+            None,
+        )
+        .expect("plan");
+
+    let sep = plan.args.iter().position(|a| a == "--").unwrap();
+    assert_eq!(
+        &plan.args[sep - 2..sep],
+        [head.id().to_string(), head.id().to_string()],
+        "both name the same commit here; neither reaches argv as a name"
+    );
+    assert!(
+        !plan.args.contains(&"main".to_string()),
+        "a ref NAME must not survive into argv: {:?}",
+        plan.args
+    );
+}
+
+#[test]
+fn a_rev_to_worktree_target_resolves_its_one_revision() {
+    let tr = TempRepo::with_initial_commit("one\n");
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap();
+
+    let plan = backend
+        .difftool_plan(
+            &handle.id,
+            &DiffToolTarget::RevToWorktree { rev: "HEAD".into() },
+            &paths(&["README.md"]),
+            None,
+        )
+        .expect("plan");
+
+    let sep = plan.args.iter().position(|a| a == "--").unwrap();
+    assert_eq!(&plan.args[sep - 1..sep], [head.id().to_string()]);
+}
+
+/// **A revision that looks like an option is refused, never passed through.**
+///
+/// `git difftool` requires its revisions AHEAD of `--`, so the separator that
+/// protects the pathspecs cannot protect these: a `--output=/tmp/x` in a
+/// revision slot sits in an option position. Every rev therefore goes through
+/// `revparse_single`, and a string that is not a revision fails there — the same
+/// refusal `git/tag.rs`, `forge/mod.rs` and `ssh.rs` make for their own argv.
+#[test]
+fn a_revision_that_looks_like_an_option_is_refused() {
+    let tr = TempRepo::with_initial_commit("one\n");
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string();
+
+    let hostile = ["--output=/tmp/pgpwn", "-c", "--exit-code", "-"];
+    let mut targets: Vec<DiffToolTarget> = Vec::new();
+    for bad in hostile {
+        targets.push(DiffToolTarget::Range {
+            from: bad.into(),
+            to: head.clone(),
+        });
+        // The SECOND slot too: a guard on the first only would leave half the
+        // shape open.
+        targets.push(DiffToolTarget::Range {
+            from: head.clone(),
+            to: bad.into(),
+        });
+        targets.push(DiffToolTarget::RevToWorktree { rev: bad.into() });
+        targets.push(DiffToolTarget::Commit { oid: bad.into() });
+    }
+
+    for target in targets {
+        let err = backend
+            .difftool_plan(&handle.id, &target, &paths(&["README.md"]), None)
+            .expect_err(&format!("must refuse {target:?}"));
+        assert!(
+            matches!(err, AppError::InvalidRef(_)),
+            "{target:?} gave {err:?}"
+        );
+    }
+}
+
+/// The invariant behind all of the above, asserted over every target shape at
+/// once: **nothing between the options and `--` is anything but a hex oid.**
+///
+/// Written as a property rather than as another example because a new
+/// `DiffToolTarget` variant is exactly the change that would reintroduce a
+/// pass-through, and this fails for it without anyone remembering to come back
+/// here.
+#[test]
+fn every_revision_reaching_argv_is_a_hex_oid() {
+    let tr = TempRepo::with_initial_commit("one\n");
+    tr.add_commit("README.md", "two\n", "second");
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap().id().to_string();
+
+    let targets = [
+        DiffToolTarget::Worktree,
+        DiffToolTarget::Staged,
+        DiffToolTarget::Commit { oid: head.clone() },
+        DiffToolTarget::Range {
+            from: "main".into(),
+            to: "HEAD".into(),
+        },
+        DiffToolTarget::RevToWorktree { rev: "HEAD".into() },
+    ];
+
+    // Every flag the builder is allowed to emit. Anything else ahead of `--`
+    // came from a caller.
+    let ours = ["difftool", "--no-prompt", "--gui", "--cached"];
+
+    for target in targets {
+        for tool in [None, Some("meld")] {
+            let plan = backend
+                .difftool_plan(&handle.id, &target, &paths(&["README.md"]), tool)
+                .expect("plan");
+            let sep = plan.args.iter().position(|a| a == "--").expect("separator");
+            for arg in &plan.args[..sep] {
+                if ours.contains(&arg.as_str()) || arg.starts_with("--tool=") {
+                    continue;
+                }
+                assert!(
+                    arg.len() == 40 && arg.chars().all(|c| c.is_ascii_hexdigit()),
+                    "{target:?}: {arg:?} is not a hex oid and is not one of our \
+                     own flags — a caller-supplied string reached an option \
+                     position. Full argv: {:?}",
+                    plan.args
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn a_path_outside_the_worktree_is_refused() {
+    let tr = TempRepo::with_initial_commit("one\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    for bad in ["../escape", "/etc/passwd", ""] {
+        let err = backend
+            .difftool_plan(
+                &handle.id,
+                &DiffToolTarget::Worktree,
+                &paths(&[bad]),
+                None,
+            )
+            .expect_err("must refuse {bad}");
+        assert!(matches!(err, AppError::InvalidPath(_)), "{bad}: {err:?}");
+    }
+}
+
+#[test]
+fn a_batch_is_refused_whole_when_one_path_escapes() {
+    // The same all-or-nothing rule `delete_untracked` makes (#245): validate the
+    // batch, then act. Half an argv is not a smaller version of the request.
+    let tr = TempRepo::with_initial_commit("one\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .difftool_plan(
+            &handle.id,
+            &DiffToolTarget::Worktree,
+            &paths(&["README.md", "../escape"]),
+            None,
+        )
+        .expect_err("must refuse");
+    assert!(matches!(err, AppError::InvalidPath(_)), "{err:?}");
+}
+
+#[test]
+fn an_empty_path_list_is_refused() {
+    let tr = TempRepo::with_initial_commit("one\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .difftool_plan(&handle.id, &DiffToolTarget::Worktree, &[], None)
+        .expect_err("must refuse");
+    assert!(matches!(err, AppError::InvalidArgument(_)), "{err:?}");
+}
+
+#[test]
+fn a_bad_tool_name_is_refused_before_the_repository_is_touched() {
+    // Asserted against an id no repository was ever opened under: reaching
+    // `UnknownRepo` would mean the name was validated too late.
+    let backend = platypusgit_lib::git::libgit2::Libgit2Backend::new();
+    let err = backend
+        .difftool_plan(
+            &RepoId("never-opened".into()),
+            &DiffToolTarget::Worktree,
+            &paths(&["a"]),
+            Some("bcompare $LOCAL $REMOTE"),
+        )
+        .expect_err("must refuse");
+    assert!(matches!(err, AppError::InvalidArgument(_)), "{err:?}");
+}
+
+#[test]
+fn an_unresolvable_commit_is_an_invalid_ref_not_a_bare_git_error() {
+    let tr = TempRepo::with_initial_commit("one\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .difftool_plan(
+            &handle.id,
+            &DiffToolTarget::Commit {
+                oid: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".into(),
+            },
+            &paths(&["README.md"]),
+            None,
+        )
+        .expect_err("must refuse");
+    assert!(matches!(err, AppError::InvalidRef(_)), "{err:?}");
+}
+
+#[test]
+fn the_settings_override_reaches_the_argv() {
+    let tr = TempRepo::with_initial_commit("one\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let plan = backend
+        .difftool_plan(
+            &handle.id,
+            &DiffToolTarget::Worktree,
+            &paths(&["README.md"]),
+            Some("  meld  "),
+        )
+        .expect("plan");
+
+    assert_eq!(plan.tool.as_deref(), Some("meld"));
+    assert!(plan.args.contains(&"--tool=meld".to_string()), "{:?}", plan.args);
+    // git refuses `--gui` beside `--tool`; the builder must never emit both.
+    assert!(!plan.args.contains(&"--gui".to_string()), "{:?}", plan.args);
+}
+
+#[test]
+fn normalize_tool_is_the_one_gate_on_the_settings_field() {
+    assert_eq!(normalize_tool(Some("")).unwrap(), None);
+    assert_eq!(normalize_tool(Some("kdiff3")).unwrap().as_deref(), Some("kdiff3"));
+    assert!(normalize_tool(Some("a b")).is_err());
+}
+
+#[test]
+fn the_argv_builder_is_reachable_and_pure() {
+    // The module's own unit tests cover the matrix; this only pins that the
+    // builder is part of the crate's public surface, which is what lets the
+    // end-to-end tests below run a plan without a Tauri command.
+    let spec = DiffSpec {
+        cached: false,
+        revs: vec!["a".into()],
+    };
+    assert_eq!(
+        difftool_args(&spec, None, &paths(&["p"])),
+        vec!["difftool", "--no-prompt", "--gui", "a", "--", "p"]
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// A REAL RUN
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Is `git difftool` usable here?
+///
+/// It ships with git, but it is a separate script and a stripped-down
+/// installation can lack it. Skipped rather than failed for the same reason the
+/// gpg and git-lfs suites skip: a missing optional binary is an environment
+/// fact, not a regression.
+fn difftool_available() -> bool {
+    platypusgit_lib::proc::git(Path::new("."))
+        .arg("difftool")
+        .arg("--tool-help")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Point `diff.tool` at a tool that leaves evidence instead of a window.
+///
+/// `difftool.<tool>.cmd` is run by git through a shell with `$LOCAL` and
+/// `$REMOTE` set to the two sides, which is exactly the contract a real tool is
+/// invoked under — so a tool that copies them into a marker file proves the
+/// whole chain: config read, sides extracted, tool launched.
+fn configure_fake_tool(root: &Path, name: &str, marker: &str) {
+    let repo = git2::Repository::open(root).unwrap();
+    let mut cfg = repo.config().unwrap();
+    cfg.set_str(
+        &format!("difftool.{name}.cmd"),
+        // Appends, so a run over two files is visible as two records.
+        &format!("cat \"$LOCAL\" >> {marker}; echo '---' >> {marker}; cat \"$REMOTE\" >> {marker}"),
+    )
+    .unwrap();
+}
+
+/// Run a plan the way the Tauri command does, minus the console handling — the
+/// spawner differs only in the Windows console flag, which no assertion here is
+/// about.
+fn run(plan: &platypusgit_lib::git::difftool::DiffToolPlan) -> std::process::Output {
+    let (key, value) = platypusgit_lib::git::stash::LITERAL_PATHSPECS;
+    platypusgit_lib::proc::git(&plan.workdir)
+        .args(&plan.args)
+        .env(key, value)
+        .output()
+        .expect("spawn git difftool")
+}
+
+fn marker_body(root: &Path, marker: &str) -> String {
+    std::fs::read_to_string(root.join(marker)).unwrap_or_default()
+}
+
+#[test]
+fn diff_tool_from_git_config_is_what_actually_runs() {
+    if !difftool_available() {
+        eprintln!("skipping: `git difftool` is not available here");
+        return;
+    }
+    let tr = TempRepo::with_initial_commit("committed\n");
+    configure_fake_tool(tr.path(), "pgfake", "marker.txt");
+    {
+        let repo = git2::Repository::open(tr.path()).unwrap();
+        repo.config().unwrap().set_str("diff.tool", "pgfake").unwrap();
+    }
+    // An unstaged change, so there is something for the tool to be given.
+    support::fs::write_file(tr.path(), "README.md", "edited\n");
+    // A second changed file the run must NOT touch — that is what `--` buys.
+    support::fs::write_file(tr.path(), "other.md", "untracked\n");
+    tr.add_commit("other.md", "other v1\n", "add other");
+    support::fs::write_file(tr.path(), "other.md", "other v2\n");
+
+    let (backend, handle) = tr.open_with_backend();
+    let plan = backend
+        .difftool_plan(
+            &handle.id,
+            &DiffToolTarget::Worktree,
+            &paths(&["README.md"]),
+            None,
+        )
+        .expect("plan");
+
+    let out = run(&plan);
+    assert!(
+        out.status.success(),
+        "git difftool failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let body = marker_body(tr.path(), "marker.txt");
+    assert!(
+        body.contains("committed") && body.contains("edited"),
+        "the configured tool saw both sides: {body:?}"
+    );
+    assert!(
+        !body.contains("other v"),
+        "`--` must scope the run to the one path: {body:?}"
+    );
+}
+
+#[test]
+fn the_tool_override_outranks_diff_tool() {
+    if !difftool_available() {
+        eprintln!("skipping: `git difftool` is not available here");
+        return;
+    }
+    let tr = TempRepo::with_initial_commit("committed\n");
+    configure_fake_tool(tr.path(), "chosen", "chosen.txt");
+    configure_fake_tool(tr.path(), "configured", "configured.txt");
+    {
+        let repo = git2::Repository::open(tr.path()).unwrap();
+        repo.config()
+            .unwrap()
+            .set_str("diff.tool", "configured")
+            .unwrap();
+    }
+    support::fs::write_file(tr.path(), "README.md", "edited\n");
+
+    let (backend, handle) = tr.open_with_backend();
+    let plan = backend
+        .difftool_plan(
+            &handle.id,
+            &DiffToolTarget::Worktree,
+            &paths(&["README.md"]),
+            Some("chosen"),
+        )
+        .expect("plan");
+
+    let out = run(&plan);
+    assert!(
+        out.status.success(),
+        "git difftool failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !marker_body(tr.path(), "chosen.txt").is_empty(),
+        "the override should have run"
+    );
+    assert!(
+        marker_body(tr.path(), "configured.txt").is_empty(),
+        "diff.tool should have been overridden, not merged"
+    );
+}
+
+#[test]
+fn a_commits_own_diff_reaches_the_tool_with_both_sides() {
+    if !difftool_available() {
+        eprintln!("skipping: `git difftool` is not available here");
+        return;
+    }
+    let tr = TempRepo::with_initial_commit("v1\n");
+    tr.add_commit("README.md", "v2\n", "second");
+    configure_fake_tool(tr.path(), "pgfake", "marker.txt");
+    {
+        let repo = git2::Repository::open(tr.path()).unwrap();
+        repo.config().unwrap().set_str("diff.tool", "pgfake").unwrap();
+    }
+
+    let (backend, handle) = tr.open_with_backend();
+    let head = tr.repo.head().unwrap().peel_to_commit().unwrap().id();
+    let plan = backend
+        .difftool_plan(
+            &handle.id,
+            &DiffToolTarget::Commit {
+                oid: head.to_string(),
+            },
+            &paths(&["README.md"]),
+            None,
+        )
+        .expect("plan");
+
+    let out = run(&plan);
+    assert!(
+        out.status.success(),
+        "git difftool failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Both sides are blobs in the ODB, not files — this is the case the whole
+    // "shell out rather than materialise" decision was made for.
+    let body = marker_body(tr.path(), "marker.txt");
+    assert!(body.contains("v1") && body.contains("v2"), "{body:?}");
+}
+
+/// The `--cached` shape, run for real.
+///
+/// It is the one target whose argv puts an extra option ahead of the
+/// `--gui`/`--tool` slot, and the only way to know git is happy with that
+/// ordering is to run it. The tell is deliberate: the worktree copy differs from
+/// BOTH the index and HEAD, so a run that reached the working tree by mistake
+/// would show `worktree only` and this would catch it.
+#[test]
+fn a_staged_target_reaches_the_tool_as_the_index_against_head() {
+    if !difftool_available() {
+        eprintln!("skipping: `git difftool` is not available here");
+        return;
+    }
+    let tr = TempRepo::with_initial_commit("committed\n");
+    support::fs::write_file(tr.path(), "README.md", "staged\n");
+    {
+        let (backend, handle) = tr.open_with_backend();
+        backend
+            .stage(&handle.id, &[PathBuf::from("README.md")])
+            .expect("stage");
+    }
+    support::fs::write_file(tr.path(), "README.md", "worktree only\n");
+
+    configure_fake_tool(tr.path(), "pgfake", "marker.txt");
+    {
+        let repo = git2::Repository::open(tr.path()).unwrap();
+        repo.config().unwrap().set_str("diff.tool", "pgfake").unwrap();
+    }
+
+    let (backend, handle) = tr.open_with_backend();
+    let plan = backend
+        .difftool_plan(
+            &handle.id,
+            &DiffToolTarget::Staged,
+            &paths(&["README.md"]),
+            None,
+        )
+        .expect("plan");
+
+    let out = run(&plan);
+    assert!(
+        out.status.success(),
+        "git difftool failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let body = marker_body(tr.path(), "marker.txt");
+    assert!(
+        body.contains("committed") && body.contains("staged"),
+        "the index against HEAD: {body:?}"
+    );
+    assert!(
+        !body.contains("worktree only"),
+        "`--cached` must not reach the working tree: {body:?}"
+    );
+}
+
+#[test]
+fn a_root_commits_diff_shows_the_file_as_added_not_as_the_worktree() {
+    if !difftool_available() {
+        eprintln!("skipping: `git difftool` is not available here");
+        return;
+    }
+    let tr = TempRepo::with_initial_commit("original\n");
+    configure_fake_tool(tr.path(), "pgfake", "marker.txt");
+    {
+        let repo = git2::Repository::open(tr.path()).unwrap();
+        repo.config().unwrap().set_str("diff.tool", "pgfake").unwrap();
+    }
+    // The tell: an uncommitted edit sitting in the worktree. `<root>^!` would
+    // put THIS on the right-hand side; the empty-tree pair must not.
+    support::fs::write_file(tr.path(), "README.md", "uncommitted\n");
+
+    let (backend, handle) = tr.open_with_backend();
+    let root = tr.repo.head().unwrap().peel_to_commit().unwrap().id();
+    let plan = backend
+        .difftool_plan(
+            &handle.id,
+            &DiffToolTarget::Commit {
+                oid: root.to_string(),
+            },
+            &paths(&["README.md"]),
+            None,
+        )
+        .expect("plan");
+
+    let out = run(&plan);
+    assert!(
+        out.status.success(),
+        "git difftool failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let body = marker_body(tr.path(), "marker.txt");
+    assert!(body.contains("original"), "the commit's content: {body:?}");
+    assert!(
+        !body.contains("uncommitted"),
+        "the working tree leaked into a commit's diff — the `^!` bug: {body:?}"
+    );
+}
+
+/// The range shape, run for real, named by REFS.
+///
+/// The point is the resolution added for the argv fix: `main`/`HEAD` never reach
+/// git, only the oids they resolved to — and the tool must still be handed the
+/// same two file versions it was before. A test on the argv alone could not tell
+/// a correct resolution from one that silently picked the wrong commits.
+#[test]
+fn a_range_named_by_refs_reaches_the_tool_with_the_right_two_versions() {
+    if !difftool_available() {
+        eprintln!("skipping: `git difftool` is not available here");
+        return;
+    }
+    let tr = TempRepo::with_initial_commit("v1\n");
+    tr.add_commit("README.md", "v2\n", "second");
+    configure_fake_tool(tr.path(), "pgfake", "marker.txt");
+    {
+        let repo = git2::Repository::open(tr.path()).unwrap();
+        repo.config().unwrap().set_str("diff.tool", "pgfake").unwrap();
+    }
+    // A worktree edit that belongs to NEITHER side, so a range that leaked into
+    // a worktree comparison would show up here.
+    support::fs::write_file(tr.path(), "README.md", "uncommitted\n");
+
+    let (backend, handle) = tr.open_with_backend();
+    let root = tr
+        .repo
+        .head()
+        .unwrap()
+        .peel_to_commit()
+        .unwrap()
+        .parent(0)
+        .unwrap()
+        .id()
+        .to_string();
+    let plan = backend
+        .difftool_plan(
+            &handle.id,
+            &DiffToolTarget::Range {
+                from: root,
+                to: "HEAD".into(),
+            },
+            &paths(&["README.md"]),
+            None,
+        )
+        .expect("plan");
+
+    let out = run(&plan);
+    assert!(
+        out.status.success(),
+        "git difftool failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let body = marker_body(tr.path(), "marker.txt");
+    assert!(body.contains("v1") && body.contains("v2"), "{body:?}");
+    assert!(
+        !body.contains("uncommitted"),
+        "a range must not reach the working tree: {body:?}"
+    );
+}
+
+#[test]
+fn a_pathspec_shaped_filename_selects_itself() {
+    if !difftool_available() {
+        eprintln!("skipping: `git difftool` is not available here");
+        return;
+    }
+    // `GIT_LITERAL_PATHSPECS`, tested rather than trusted: git reads `[ab]` as a
+    // glob, so without it the row the user right-clicked and the file git opens
+    // are different files.
+    let tr = TempRepo::with_initial_commit("readme\n");
+    let literal = "a[bc].txt";
+    support::fs::write_file(tr.path(), literal, "literal v1\n");
+    support::fs::write_file(tr.path(), "ab.txt", "decoy v1\n");
+    tr.commit_all("add both");
+    support::fs::write_file(tr.path(), literal, "literal v2\n");
+    support::fs::write_file(tr.path(), "ab.txt", "decoy v2\n");
+
+    configure_fake_tool(tr.path(), "pgfake", "marker.txt");
+    {
+        let repo = git2::Repository::open(tr.path()).unwrap();
+        repo.config().unwrap().set_str("diff.tool", "pgfake").unwrap();
+    }
+
+    let (backend, handle) = tr.open_with_backend();
+    let plan = backend
+        .difftool_plan(
+            &handle.id,
+            &DiffToolTarget::Worktree,
+            &paths(&[literal]),
+            None,
+        )
+        .expect("plan");
+
+    let out = run(&plan);
+    assert!(
+        out.status.success(),
+        "git difftool failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let body = marker_body(tr.path(), "marker.txt");
+    assert!(body.contains("literal v2"), "{body:?}");
+    assert!(!body.contains("decoy"), "the glob matched a decoy: {body:?}");
+}
+
+#[test]
+fn a_repository_with_no_tool_at_all_fails_with_gits_own_words() {
+    if !difftool_available() {
+        eprintln!("skipping: `git difftool` is not available here");
+        return;
+    }
+    // `--tool` names something no config defines, which is the shape of "nothing
+    // resolved" we can produce deterministically — autodetect would find
+    // whatever the test machine has installed. The point is the same: git
+    // explains itself, so `commands::diff` has something worth putting in a
+    // banner and no reason to mint an error variant.
+    let tr = TempRepo::with_initial_commit("committed\n");
+    support::fs::write_file(tr.path(), "README.md", "edited\n");
+    let (backend, handle) = tr.open_with_backend();
+    let plan = backend
+        .difftool_plan(
+            &handle.id,
+            &DiffToolTarget::Worktree,
+            &paths(&["README.md"]),
+            Some("pg-no-such-tool"),
+        )
+        .expect("plan");
+
+    let out = run(&plan);
+    assert!(!out.status.success(), "an unknown tool must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr).to_lowercase();
+    assert!(
+        stderr.contains("pg-no-such-tool"),
+        "git should name the tool it could not find: {stderr:?}"
+    );
+}
+
+/// A plan is a value, so the workdir it carries has to be the repository's — the
+/// command runs `git -C` with it and every pathspec is relative to it.
+#[test]
+fn the_plan_names_the_repository_the_id_belongs_to() {
+    let a = TempRepo::with_initial_commit("a\n");
+    let b = TempRepo::with_initial_commit("b\n");
+    let backend = platypusgit_lib::git::libgit2::Libgit2Backend::new();
+    let ha = backend.open(a.path()).unwrap();
+    let hb = backend.open(b.path()).unwrap();
+
+    let plan_a = backend
+        .difftool_plan(&ha.id, &DiffToolTarget::Worktree, &paths(&["README.md"]), None)
+        .unwrap();
+    let plan_b = backend
+        .difftool_plan(&hb.id, &DiffToolTarget::Worktree, &paths(&["README.md"]), None)
+        .unwrap();
+
+    assert_eq!(
+        PathBuf::from(&plan_a.workdir).canonicalize().unwrap(),
+        a.path().canonicalize().unwrap()
+    );
+    assert_eq!(
+        PathBuf::from(&plan_b.workdir).canonicalize().unwrap(),
+        b.path().canonicalize().unwrap()
+    );
+}
+
+/// The command's own spawn shape, since the command itself needs a Tauri
+/// `State` no test can build: console kept, **stderr piped, stdout inherited**.
+///
+/// That combination is the one thing in `open_in_difftool` that could silently
+/// stop working — `wait_with_output` on a child whose stdout was never piped is
+/// exactly the shape people get wrong — and its failure mode is the banner going
+/// back to `git difftool exited with exit status: 1`, which tells the reader
+/// nothing. stdout stays inherited so a console difftool still owns the
+/// terminal.
+#[tokio::test]
+async fn the_spawn_shape_captures_stderr_without_taking_stdout() {
+    if !difftool_available() {
+        eprintln!("skipping: `git difftool` is not available here");
+        return;
+    }
+    let tr = TempRepo::with_initial_commit("committed\n");
+    support::fs::write_file(tr.path(), "README.md", "edited\n");
+    let (backend, handle) = tr.open_with_backend();
+    let plan = backend
+        .difftool_plan(
+            &handle.id,
+            &DiffToolTarget::Worktree,
+            &paths(&["README.md"]),
+            Some("pg-no-such-tool"),
+        )
+        .expect("plan");
+
+    let (key, value) = platypusgit_lib::git::stash::LITERAL_PATHSPECS;
+    let mut cmd = platypusgit_lib::proc::git_async_keeping_console(&plan.workdir);
+    cmd.args(&plan.args)
+        .env(key, value)
+        .stderr(std::process::Stdio::piped());
+    let out = cmd
+        .spawn()
+        .expect("spawn")
+        .wait_with_output()
+        .await
+        .expect("wait");
+
+    assert!(!out.status.success());
+    assert!(
+        !out.stderr.is_empty(),
+        "stderr must reach the caller — it is the only useful thing git says here"
+    );
+    assert!(out.stdout.is_empty(), "stdout was never piped");
+}

--- a/src-tauri/tests/spawn_no_window.rs
+++ b/src-tauri/tests/spawn_no_window.rs
@@ -59,6 +59,17 @@ const CONSOLE_KEEPING_CALLERS: &[(&str, &str, &str)] = &[
          unaffected either way — the flag does not apply to non-console apps.",
     ),
     (
+        "src/commands/diff.rs",
+        "crate::proc::git_async_keeping_console(",
+        "`git difftool` (#235), for the identical reason to `git mergetool` \
+         directly above: it launches the tool the USER configured, and a console \
+         difftool (`vimdiff`, `nvimdiff`) is a terminal program that needs the \
+         console it is given. The asymmetry is the same one — silencing costs a \
+         GUI tool nothing (the flag does not apply to it) and costs a console \
+         tool the window it renders in, leaving an invisible process holding \
+         the file with no way to stop it.",
+    ),
+    (
         "src/commands/repo.rs",
         "crate::proc::program_async_keeping_console(",
         "`$VISUAL`/`$EDITOR`. `EDITOR=vim` names a console program, and hiding \

--- a/src/design/context-menu.difftool.test.tsx
+++ b/src/design/context-menu.difftool.test.tsx
@@ -1,0 +1,133 @@
+// "Open in external diff tool" on a file row (#235).
+//
+// The argv, the tool resolution and the console handling are the backend's, and
+// `src-tauri/tests/difftool.rs` pins them against a real repository. What only
+// this layer can get wrong is WHICH TWO SIDES a row names — and the failure is
+// silent: a staged row sent as `worktree` opens the file against the index
+// instead of against HEAD, which is a real diff of the wrong thing.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { fileMenuItems, type ContextMenuItem } from "./context-menu";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+
+function labeled(items: ContextMenuItem[], match: RegExp): ContextMenuItem {
+  const found = items.find((i) => typeof i.label === "string" && match.test(i.label));
+  expect(found, `no menu item matching ${match}`).toBeTruthy();
+  return found!;
+}
+
+const ENTRY = /^Open in external diff tool$/;
+
+const difftoolCalls = () =>
+  getInvokeCalls().filter((c) => c.cmd === "open_in_difftool");
+
+function mockRefreshAll() {
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => null);
+}
+
+beforeEach(() => {
+  resetInvokeMock();
+  localStorage.clear();
+  useSettingsStore.getState().reset();
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+  } as never);
+  mockRefreshAll();
+  mockInvoke("open_in_difftool", () => null);
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("the external-diff entry on a file row", () => {
+  it("sends an unstaged row as the working tree against the index", async () => {
+    await labeled(fileMenuItems({ path: "src/a.rs" }), ENTRY).onClick?.();
+
+    expect(difftoolCalls()).toEqual([
+      {
+        cmd: "open_in_difftool",
+        args: {
+          repoId: "r1",
+          target: { kind: "worktree" },
+          paths: ["src/a.rs"],
+          tool: null,
+        },
+      },
+    ]);
+  });
+
+  it("sends a staged row as the index against HEAD", async () => {
+    // The distinction that matters: a staged row's diff is `--cached`. Sent as
+    // `worktree` it would open a real diff of the wrong pair, with nothing on
+    // screen to say so.
+    await labeled(fileMenuItems({ path: "src/a.rs", staged: true }), ENTRY).onClick?.();
+
+    expect(difftoolCalls()[0]?.args).toMatchObject({
+      target: { kind: "staged" },
+      paths: ["src/a.rs"],
+    });
+  });
+
+  it("passes the Settings override, trimmed, and nothing when it is blank", async () => {
+    useSettingsStore.getState().set("externalDiffTool", "  meld  ");
+    await labeled(fileMenuItems({ path: "a" }), ENTRY).onClick?.();
+    expect(difftoolCalls()[0]?.args).toMatchObject({ tool: "meld" });
+
+    resetInvokeMock();
+    mockRefreshAll();
+    mockInvoke("open_in_difftool", () => null);
+    // Empty is not an empty `--tool=` — it is "let git decide", which is the
+    // case the whole feature is built around.
+    useSettingsStore.getState().set("externalDiffTool", "   ");
+    await labeled(fileMenuItems({ path: "a" }), ENTRY).onClick?.();
+    expect(difftoolCalls()[0]?.args).toMatchObject({ tool: null });
+  });
+
+  it("is disabled on an untracked row — git has no diff to hand over", async () => {
+    // `git difftool` would run no tool at all for a path in neither side of any
+    // diff, so the click would do literally nothing. Disabled says so.
+    const item = labeled(fileMenuItems({ path: "new.rs", untracked: true }), ENTRY);
+    expect(item.disabled).toBe(true);
+    await item.onClick?.();
+    expect(difftoolCalls()).toEqual([]);
+  });
+
+  it("is enabled once that untracked file is staged", async () => {
+    // Then it IS in a diff — the index against HEAD — and `--cached` shows it.
+    const item = labeled(
+      fileMenuItems({ path: "new.rs", untracked: true, staged: true }),
+      ENTRY,
+    );
+    expect(item.disabled).toBeFalsy();
+    await item.onClick?.();
+    expect(difftoolCalls()[0]?.args).toMatchObject({ target: { kind: "staged" } });
+  });
+
+  it("is disabled, and dispatches nothing, on a row with no path", async () => {
+    const item = labeled(fileMenuItems({ path: undefined }), ENTRY);
+    expect(item.disabled).toBe(true);
+    await item.onClick?.();
+    expect(difftoolCalls()).toEqual([]);
+  });
+
+  it("is absent from the menus that replace the file menu entirely", () => {
+    // A conflicted row gets the conflict menu (its escape hatch is the 3-way
+    // merge tool, not a 2-way diff), and a submodule row gets the submodule
+    // menu — it has no diff to open at all.
+    const conflicted = fileMenuItems({ path: "a", conflicted: true });
+    const submodule = fileMenuItems({ path: "vendor/lib", submodule: true });
+    for (const items of [conflicted, submodule]) {
+      expect(
+        items.some((i) => typeof i.label === "string" && ENTRY.test(i.label)),
+      ).toBe(false);
+    }
+  });
+});

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -11,7 +11,12 @@ import { planCommitSelection } from "@/features/commits/planCommitSelection";
 import { headAncestryOf } from "@/features/commits/headAncestry";
 import { runRebasePlanNow } from "@/features/commits/runRebasePlan";
 import { combinedSquashMessage } from "@/features/commits/squashMessage";
-import type { BranchInfo, CommitInfo, FileDiff } from "@/lib/types";
+import type {
+  BranchInfo,
+  CommitInfo,
+  DiffToolTarget,
+  FileDiff,
+} from "@/lib/types";
 import { fileDiffToText, selectedLinesToText } from "@/lib/diffCopy";
 import { orderBranchesGrouped } from "@/features/branches/orderBranches";
 import { openMergeWindow } from "@/features/merge/openMergeWindow";
@@ -940,6 +945,40 @@ export function copyPathItems(paths: string[]): ContextMenuItem[] {
   ];
 }
 
+/**
+ * "Open in external diff tool" — the one definition, for every surface (#235).
+ *
+ * A helper rather than a copied literal because the entry has to say the same
+ * thing everywhere: this is the escape hatch out of our diff, and a user who
+ * finds it on a working-tree row and not on a commit's file has found a bug, not
+ * a distinction.
+ *
+ * `paths` is a list so a rename can pass `[oldPath, newPath]`: scoped to the new
+ * path alone git reports a renamed file as a whole file added, which is exactly
+ * the dead end this exists to remove.
+ *
+ * Which tool runs is not decided here and not named in the label — git resolves
+ * it from `diff.guitool` / `diff.tool` / `merge.tool`, and a label claiming
+ * "Open in Meld" would be a guess printed as a fact.
+ */
+export function externalDiffItem(
+  target: DiffToolTarget,
+  paths: string[],
+  opts: { disabled?: boolean } = {},
+): ContextMenuItem {
+  const usable = paths.filter((p) => !!p && !!p.trim());
+  const disabled = opts.disabled || usable.length === 0;
+  return {
+    icon: "external",
+    label: "Open in external diff tool",
+    disabled,
+    onClick: () => {
+      if (disabled) return;
+      void useRepoStore.getState().openInDifftool(target, usable);
+    },
+  };
+}
+
 export function worktreeMenuItems(
   worktree: {
     name?: string;
@@ -1742,6 +1781,18 @@ export function fileMenuItems(
         useRepoStore.getState().openInEditor(path);
       },
     },
+    // The escape hatch out of our own diff (#235). A staged row's two sides are
+    // the index and HEAD; every other row's are the working tree and the index —
+    // the same split "Unstage"/"Stage" above is already making.
+    //
+    // Disabled for a purely untracked row, and that is not fussiness: the file is
+    // in NEITHER side of any diff git computes, so `git difftool` would run no
+    // tool at all and the click would do nothing whatsoever. A dead entry that
+    // looks dead beats one that looks alive. Staging it first makes it work, via
+    // the `staged` target — which is why the gate is `untracked && !staged`.
+    externalDiffItem({ kind: staged ? "staged" : "worktree" }, [path], {
+      disabled: untracked && !staged,
+    }),
     // Partial stash of one file (#133). Here as well as in the multi-selection
     // menu because one row IS the common selection — reaching it only by
     // selecting two files first would be a shortcut nobody finds.

--- a/src/features/diff/CommitDiffPanel.difftool.test.tsx
+++ b/src/features/diff/CommitDiffPanel.difftool.test.tsx
@@ -1,0 +1,155 @@
+// The file rows' context menu on the read-only diff surfaces (#235).
+//
+// This panel is behind the commit diff screen, History's inline panel, Compare
+// and both stash diffs, so one menu here is the entry point on four surfaces.
+// Before it, right-clicking a file row in any of them did nothing at all.
+//
+// The two things only this layer can get wrong:
+//   - a rename must pass BOTH paths, or git reports the file as wholly added —
+//     the same dead end the feature exists to remove;
+//   - a panel with no target must not offer a broken entry (the combined
+//     multi-commit diff has no "the" comparison to hand over).
+import { beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { emptySlice } from "@/features/repo/repoSlice";
+import { CommitDiffPanel } from "./CommitDiffPanel";
+import type { DiffToolTarget, FileDiff } from "@/lib/types";
+
+function fileDiff(path: string, oldPath: string | null = null): FileDiff {
+  return {
+    path,
+    oldPath,
+    binary: false,
+    additions: 1,
+    deletions: 0,
+    hunks: [
+      {
+        header: "@@ -1 +1,2 @@",
+        oldStart: 1,
+        oldLines: 1,
+        newStart: 1,
+        newLines: 2,
+        lines: [
+          { kind: { kind: "Context" }, oldLineno: 1, newLineno: 1, content: "ctx" },
+          { kind: { kind: "Addition" }, oldLineno: null, newLineno: 2, content: "add" },
+        ],
+      },
+    ],
+  };
+}
+
+function mockRefreshAll() {
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => null);
+}
+
+beforeEach(() => {
+  resetInvokeMock();
+  localStorage.clear();
+  useSettingsStore.getState().reset();
+  useRepoStore.setState({
+    ...emptySlice(),
+    current: { id: "r1", path: "/repo", head: "main" },
+  });
+  mockRefreshAll();
+  mockInvoke("open_in_difftool", () => null);
+});
+
+function renderPanel(
+  diffs: FileDiff[],
+  difftoolTarget: DiffToolTarget | undefined,
+  paneIdPrefix: string,
+) {
+  return render(
+    <CommitDiffPanel
+      diffs={diffs}
+      loading={false}
+      error={null}
+      header="a → b"
+      paneIdPrefix={paneIdPrefix}
+      difftoolTarget={difftoolTarget}
+    />,
+  );
+}
+
+function rightClickRow(container: HTMLElement, path: string) {
+  const row = container.querySelector(`[data-path="${path}"]`);
+  expect(row, `no file row for ${path}`).toBeTruthy();
+  fireEvent.contextMenu(row!, { clientX: 10, clientY: 10 });
+}
+
+const difftoolArgs = () =>
+  getInvokeCalls().find((c) => c.cmd === "open_in_difftool")?.args;
+
+describe("the file-row menu on a read-only diff", () => {
+  it("hands the panel's target and the row's path to the diff tool", async () => {
+    const { container } = renderPanel(
+      [fileDiff("src/a.rs")],
+      { kind: "commit", oid: "abc123" },
+      "dt1",
+    );
+    rightClickRow(container, "src/a.rs");
+
+    fireEvent.click(await screen.findByText("Open in external diff tool"));
+
+    await waitFor(() =>
+      expect(difftoolArgs()).toMatchObject({
+        repoId: "r1",
+        target: { kind: "commit", oid: "abc123" },
+        paths: ["src/a.rs"],
+      }),
+    );
+  });
+
+  it("passes both sides of a rename, old first", async () => {
+    const { container } = renderPanel(
+      [fileDiff("src/new.rs", "src/old.rs")],
+      { kind: "commit", oid: "abc123" },
+      "dt2",
+    );
+    rightClickRow(container, "src/new.rs");
+
+    fireEvent.click(await screen.findByText("Open in external diff tool"));
+
+    await waitFor(() =>
+      expect(difftoolArgs()).toMatchObject({
+        paths: ["src/old.rs", "src/new.rs"],
+      }),
+    );
+  });
+
+  it("offers copy-path but no diff-tool entry when the panel has no target", async () => {
+    const { container } = renderPanel([fileDiff("src/a.rs")], undefined, "dt3");
+    rightClickRow(container, "src/a.rs");
+
+    // The menu still opens — it is the only per-file menu these surfaces have.
+    expect(await screen.findByText("Copy path")).toBeTruthy();
+    expect(screen.queryByText("Open in external diff tool")).toBeNull();
+  });
+
+  it("selects the row it was opened on", async () => {
+    // Otherwise the menu acts on a file the user is not looking at — the same
+    // surprise a right-click on an unselected row makes anywhere else.
+    const { container } = renderPanel(
+      [fileDiff("a.rs"), fileDiff("b.rs")],
+      { kind: "worktree" },
+      "dt4",
+    );
+    rightClickRow(container, "b.rs");
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-path="b.rs"]')?.hasAttribute("data-selected"),
+      ).toBe(true),
+    );
+  });
+});

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -4,7 +4,9 @@ import {
   PGIcon,
   PGResizeHandle,
   PGSkeleton,
+  copyPathItems,
   diffCopyMenuItems,
+  externalDiffItem,
   useContextMenu,
   usePaneSize,
   type DiffLineData,
@@ -36,7 +38,7 @@ import { buildLineSpans } from "@/lib/lineSpans";
 import type { FindMark } from "@/lib/diffFind";
 import { DiffFindBar } from "./DiffFindBar";
 import { useDiffFind } from "./useDiffFind";
-import type { FileDiff } from "@/lib/types";
+import type { DiffToolTarget, FileDiff } from "@/lib/types";
 import { isTextualDiff } from "@/lib/derive";
 import { LfsDiffNotice } from "@/features/lfs/LfsDiffNotice";
 import { ImageDiffView } from "./ImageDiffView";
@@ -149,6 +151,21 @@ export interface CommitDiffPanelProps {
    * filled in by the panel itself, which knows the selected file.
    */
   syntaxSides?: { repoId: string; old: SideSource; new: SideSource };
+  /**
+   * The two sides to hand an external diff tool, for the file-row menu (#235).
+   *
+   * An explicit target rather than something derived from `syntaxSides`, even
+   * though the two describe the same comparison. `syntaxSides` is allowed to be
+   * approximate — History passes `{ rev: "<oid>^" }`, which simply fails and
+   * renders plain on a root commit — whereas `<oid>^` handed to `git difftool`
+   * either errors or, in its `^!` spelling, silently diffs against the WORKING
+   * TREE. A surface showing one commit passes `{ kind: "commit" }` and lets the
+   * backend resolve the parent.
+   *
+   * Omitted where the comparison has no external equivalent (a combined
+   * multi-commit diff), and the menu entry is then absent rather than broken.
+   */
+  difftoolTarget?: DiffToolTarget;
 }
 
 /**
@@ -166,6 +183,7 @@ export function CommitDiffPanel({
   emptyLabel = "No changes in this commit.",
   verifyOid,
   syntaxSides,
+  difftoolTarget,
 }: CommitDiffPanelProps) {
   const filesPaneId = `${paneIdPrefix}.files`;
   const viewPaneId = `${paneIdPrefix}.view`;
@@ -214,6 +232,27 @@ export function CommitDiffPanel({
   const diffCopyMenu = useContextMenu<void>(() =>
     diffCopyMenuItems({ diff: current }),
   );
+
+  // The file ROWS get their own menu (#235). Until this existed the read-only
+  // diff surfaces had no per-file menu at all — right-clicking a row did
+  // nothing — so this is the whole entry point for "open this one in my own
+  // tool" on a commit, a compare and a stash.
+  //
+  // A rename passes BOTH paths, so git can pair them instead of reporting the
+  // file as wholly added.
+  const fileMenu = useContextMenu<FileDiff>((d) => [
+    { __menuTitle: d?.path || "file" },
+    ...copyPathItems(d?.path ? [d.path] : []),
+    ...(difftoolTarget && d
+      ? [
+          { divider: true },
+          externalDiffItem(
+            difftoolTarget,
+            d.oldPath && d.oldPath !== d.path ? [d.oldPath, d.path] : [d.path],
+          ),
+        ]
+      : []),
+  ]);
 
   const syntax = useDiffSyntax({
     repoId: syntaxSides?.repoId ?? null,
@@ -458,6 +497,13 @@ export function CommitDiffPanel({
             <div
               key={d.path}
               onClick={() => setSelected(d.path)}
+              onContextMenu={(e) => {
+                // Select first: a menu acting on a row the user is not looking
+                // at is the same surprise a right-click on an unselected file
+                // row makes anywhere else.
+                setSelected(d.path);
+                fileMenu.onContextMenu(e, d);
+              }}
               data-pg-row=""
               data-selected={d.path === selected ? "" : undefined}
               data-path={d.path}
@@ -524,6 +570,7 @@ export function CommitDiffPanel({
             );
           })}
         </FocusableScroll>
+        {fileMenu.menu}
       </PGPane>
       <PGResizeHandle
         side="right"

--- a/src/features/repo/repoActivity.ts
+++ b/src/features/repo/repoActivity.ts
@@ -58,6 +58,16 @@ export interface RepoActivity {
   submodule?: ActivityState;
   /** Checking out a pull request's head ref. */
   forge?: ActivityState;
+  /**
+   * `git difftool` — the user's own diff tool, open on one file (#235).
+   *
+   * The longest-lived entry in here by a wide margin: git waits for the tool,
+   * and a person reading a diff in Beyond Compare takes minutes. That is exactly
+   * why it is an entry at all — without one, clicking "Open in external diff
+   * tool" and then alt-tabbing back to a window that says nothing looks like the
+   * click was swallowed.
+   */
+  difftool?: ActivityState;
 }
 
 export type ActivityKey = keyof RepoActivity;
@@ -68,7 +78,10 @@ export type ActivityKey = keyof RepoActivity;
  * "Expected to be one at a time" stopped being true once LFS, submodule and
  * forge ops joined: a submodule update fetching while the user pushes is
  * ordinary. The order is by how much the user is waiting on it — the push they
- * just started outranks a background submodule fetch.
+ * just started outranks a background submodule fetch. `difftool` sits low for
+ * the same reason it is the longest-lived: the app is not busy, the user is
+ * reading, and any real git op running underneath is the more urgent thing to
+ * say.
  */
 export const ACTIVITY_PRIORITY: readonly ActivityKey[] = [
   "push",
@@ -78,6 +91,7 @@ export const ACTIVITY_PRIORITY: readonly ActivityKey[] = [
   "stash",
   "branch",
   "forge",
+  "difftool",
   "lfs",
   "submodule",
 ];

--- a/src/features/repo/useRepoStore.difftool.test.ts
+++ b/src/features/repo/useRepoStore.difftool.test.ts
@@ -1,0 +1,116 @@
+// `useRepoStore.openInDifftool` (#235).
+//
+// The action is short, and every line of it is there for a reason that is easy
+// to delete by accident:
+//
+// - the activity entry, because `git difftool` resolves when the TOOL exits and
+//   a person reading a diff in Beyond Compare takes minutes — without it, the
+//   click looks swallowed;
+// - the `finally` that clears it, because a failed tool must not leave a status
+//   line up forever;
+// - the refresh, because a working-tree side is handed to the tool as the REAL
+//   file, so edits land in the worktree;
+// - refresh BEFORE the error, because `refreshAll` clears `error` as its first
+//   act and React batches same-tick sets.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { useRepoStore } from "./useRepoStore";
+import { emptySlice } from "./repoSlice";
+
+function mockRefreshAll() {
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => null);
+}
+
+const statusReads = () =>
+  getInvokeCalls().filter((c) => c.cmd === "get_status").length;
+
+beforeEach(() => {
+  resetInvokeMock();
+  localStorage.clear();
+  useSettingsStore.getState().reset();
+  useRepoStore.setState({
+    ...emptySlice(),
+    current: { id: "r1", path: "/repo", head: "main" },
+  });
+  mockRefreshAll();
+});
+
+describe("openInDifftool", () => {
+  it("holds a difftool activity entry until the tool exits", async () => {
+    let seen: string | undefined;
+    let release: (() => void) | null = null;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    mockInvoke("open_in_difftool", async () => {
+      seen = useRepoStore.getState().activity.difftool?.label;
+      await gate;
+      return null;
+    });
+
+    const running = useRepoStore
+      .getState()
+      .openInDifftool({ kind: "worktree" }, ["src/a.rs"]);
+    // Still open — this is the whole point of the entry.
+    await Promise.resolve();
+    expect(useRepoStore.getState().activity.difftool).toBeTruthy();
+    release!();
+    await running;
+
+    expect(seen).toContain("src/a.rs");
+    expect(useRepoStore.getState().activity.difftool).toBeUndefined();
+  });
+
+  it("clears the entry when the tool fails, and reports the failure", async () => {
+    mockInvoke("open_in_difftool", () => {
+      throw { kind: "Git", message: "no known diff tool is available" };
+    });
+
+    await useRepoStore.getState().openInDifftool({ kind: "worktree" }, ["a"]);
+
+    expect(useRepoStore.getState().activity.difftool).toBeUndefined();
+    // Refresh-then-error: the opposite order wipes the banner, because
+    // `refreshAll` starts with `set({ error: null })`.
+    expect(useRepoStore.getState().error).toMatchObject({ kind: "Git" });
+    expect(statusReads()).toBe(1);
+  });
+
+  it("refreshes afterwards — the tool may have written the working-tree side", async () => {
+    mockInvoke("open_in_difftool", () => null);
+    await useRepoStore.getState().openInDifftool({ kind: "worktree" }, ["a"]);
+    expect(statusReads()).toBe(1);
+  });
+
+  it("passes the target and paths through untouched", async () => {
+    mockInvoke("open_in_difftool", () => null);
+    await useRepoStore
+      .getState()
+      .openInDifftool({ kind: "commit", oid: "abc123" }, ["old.rs", "new.rs"]);
+
+    expect(getInvokeCalls().find((c) => c.cmd === "open_in_difftool")?.args).toEqual({
+      repoId: "r1",
+      target: { kind: "commit", oid: "abc123" },
+      paths: ["old.rs", "new.rs"],
+      tool: null,
+    });
+  });
+
+  it("does nothing without a repository or without a path", async () => {
+    mockInvoke("open_in_difftool", () => null);
+    await useRepoStore.getState().openInDifftool({ kind: "worktree" }, []);
+    useRepoStore.setState({ current: null });
+    await useRepoStore.getState().openInDifftool({ kind: "worktree" }, ["a"]);
+
+    expect(getInvokeCalls().filter((c) => c.cmd === "open_in_difftool")).toEqual([]);
+  });
+});

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -4,6 +4,7 @@ import type {
   BisectMark,
   BulkFastForward,
   CommitResult,
+  DiffToolTarget,
   FastForward,
   FileContent,
   FileStatus,
@@ -35,6 +36,7 @@ import {
   bisectStart as bisectStartFn,
   bisectStatus as bisectStatusFn,
   appendGitignore as appendGitignoreFn,
+  openInDifftool as openInDifftoolFn,
   openInEditor as openInEditorFn,
   revealInFileManager as revealInFileManagerFn,
   openInTerminal as openInTerminalFn,
@@ -400,6 +402,15 @@ interface RepoStoreState extends RepoSlice {
   bisectReset: () => Promise<void>;
   appendGitignore: (pattern: string) => Promise<void>;
   openInEditor: (relativePath: string) => Promise<void>;
+  /**
+   * Open `paths` in the user's own diff tool (#235).
+   *
+   * `paths` is a list because a rename has two of them — pass
+   * `[oldPath, newPath]` so git can pair them; one path is the ordinary case.
+   * Resolves when the TOOL exits, which can be minutes, so this holds a
+   * `difftool` activity entry for the whole time.
+   */
+  openInDifftool: (target: DiffToolTarget, paths: string[]) => Promise<void>;
   /** Reveal in the OS file manager; omitted reveals the repo root (#215). */
   revealInFileManager: (relativePath?: string) => Promise<void>;
   /** Open a terminal at the containing directory; omitted uses the repo root. */
@@ -2039,6 +2050,34 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       await openInEditorFn(repo.id, relativePath);
     } catch (e) {
       setErrorFor(repo.id, e);
+    }
+  },
+
+  async openInDifftool(target, paths) {
+    const repo = get().current;
+    if (!repo || paths.length === 0) return;
+    // The label names the FILE, not the tool: we deliberately do not resolve
+    // which tool git will pick (see git/difftool.rs), so claiming one here
+    // would be a guess printed as a fact.
+    const label = `Diffing ${paths[paths.length - 1]} externally…`;
+    setActivity(repo.id, "difftool", label);
+    try {
+      // Empty means "let git decide", which is the zero-config case the whole
+      // feature is built around — so it is passed through as null rather than
+      // as an empty `--tool=`.
+      const tool = useSettingsStore.getState().externalDiffTool.trim();
+      await openInDifftoolFn(repo.id, target, paths, tool === "" ? null : tool);
+      // The tool may have EDITED the file: when the right-hand side is the
+      // working tree, git difftool hands it the real one rather than a copy.
+      await get().refreshAll();
+    } catch (e) {
+      // Refresh first, error last — refreshAll clears `error` as its first act
+      // and React batches same-tick sets. Same order every danger-op catch arm
+      // uses; a tool that half-wrote a file must not leave the UI stale either.
+      await get().refreshAll();
+      setErrorFor(repo.id, e);
+    } finally {
+      setActivity(repo.id, "difftool", null);
     }
   },
 

--- a/src/features/settings/useSettingsStore.export.test.ts
+++ b/src/features/settings/useSettingsStore.export.test.ts
@@ -64,6 +64,11 @@ const PORTABLE = [
   "diffContextLines",
   "diffContextMode",
   "diffViewMode",
+  // The external diff tool's NAME (#235). Portable on purpose: it says which
+  // tool this person prefers, not where anything lives on this machine, and a
+  // name that is not installed on the next machine fails visibly with git's own
+  // message rather than silently doing the wrong thing.
+  "externalDiffTool",
   "headMarks",
   "headWeight",
   "ignoreWhitespaceInDiff",
@@ -404,6 +409,25 @@ describe("import validates like load() does", () => {
     const store = await freshStore();
     store.useSettingsStore.getState().importSettings(payloadOf({ commitTicketPattern: "" }));
     expect(store.useSettingsStore.getState().commitTicketPattern).toBe("");
+  });
+
+  it("falls back to 'git decides' for a diff tool name git cannot use", async () => {
+    const store = await freshStore();
+    store.useSettingsStore.getState().set("externalDiffTool", "meld");
+    store.useSettingsStore
+      .getState()
+      .importSettings(payloadOf({ externalDiffTool: 'bcompare "$LOCAL"' }));
+    // Empty is the documented safe value: it hands the choice back to git,
+    // rather than failing every difftool click with a banner about a tool
+    // nobody configured.
+    expect(store.useSettingsStore.getState().externalDiffTool).toBe("");
+  });
+
+  it("keeps an empty diff tool name — that IS the default", async () => {
+    const store = await freshStore();
+    store.useSettingsStore.getState().set("externalDiffTool", "meld");
+    store.useSettingsStore.getState().importSettings(payloadOf({ externalDiffTool: "" }));
+    expect(store.useSettingsStore.getState().externalDiffTool).toBe("");
   });
 
   it("falls back to auto for a bad updateCheckMode", async () => {

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -662,6 +662,26 @@ function normalizeDensity(density: UiDensity): UiDensity {
 }
 
 /**
+ * Is this a git diff-tool NAME (#235)?
+ *
+ * The one mistake worth catching in the field: pasting a command line
+ * (`bcompare "$LOCAL" "$REMOTE"`). git would look for a tool by that whole
+ * name and fail with a message about a tool nobody configured — the command
+ * line belongs in `difftool.<tool>.cmd`, which is where git reads it from.
+ *
+ * Empty is VALID, and it is the default: it means "let git decide", the
+ * zero-config case the feature is designed around. The authority is
+ * `git/difftool.rs::normalize_tool`, which refuses the same shapes on the way
+ * in; this is the half that can colour the border while it is being typed.
+ */
+export function isValidDiffToolName(name: string): boolean {
+  const trimmed = name.trim();
+  if (trimmed === "") return true;
+  // eslint-disable-next-line no-control-regex
+  return !/[\s\u0000-\u001f\u007f]/.test(trimmed);
+}
+
+/**
  * Apply UI density by writing the row-step slot to CSS vars on :root.
  *
  * `data-density` is also set — a reserved hook for any future density rule
@@ -824,6 +844,21 @@ interface PersistedState {
   diffContextMode: "wholeFile" | "chunks";
   ignoreWhitespaceInDiff: boolean;
   /**
+   * Which external diff tool to hand a diff to, overriding git config (#235).
+   *
+   * Empty — the default — means "let git decide", and that is the case the
+   * feature is built around: `git difftool` already resolves `diff.guitool`,
+   * `diff.tool`, `merge.tool` and `difftool.<tool>.cmd` on its own, so anyone
+   * who has already set one up needs nothing here. A value is passed as
+   * `--tool=<name>`, which git treats as the top of that list.
+   *
+   * A tool NAME, not a command line: `meld`, `bc`, `vimdiff`, or a name the
+   * user defined with `difftool.<tool>.cmd`. The backend refuses anything with
+   * whitespace in it rather than letting git fail with a message about a tool
+   * nobody configured — see `git/difftool.rs::normalize_tool`.
+   */
+  externalDiffTool: string;
+  /**
    * Whether the app checks for a newer release, and on whose initiative — see
    * UpdateCheckMode. The gate itself lives in `useUpdateStore.check()`, not at
    * the call sites, so no path can spend a request the user disabled.
@@ -920,6 +955,7 @@ const DEFAULTS: PersistedState = {
   diffViewMode: "inline",
   diffContextMode: "wholeFile",
   ignoreWhitespaceInDiff: false,
+  externalDiffTool: "",
   updateCheckMode: "auto",
   lastCreateDir: "",
 };
@@ -1232,6 +1268,12 @@ function coerceSettings(
   // safety.
   if (!isValidTicketPattern(String(out.commitTicketPattern))) {
     out.commitTicketPattern = DEFAULTS.commitTicketPattern;
+  }
+  // Same reasoning one setting over: a stored tool name that git cannot use
+  // would fail every "open in external diff tool" click with nothing on screen
+  // explaining it. Empty — git decides — is the documented safe value.
+  if (!isValidDiffToolName(String(out.externalDiffTool))) {
+    out.externalDiffTool = DEFAULTS.externalDiffTool;
   }
   // A hand-edited or newer-build zoom must not survive as-is: an out-of-range
   // factor is rejected by the webview and would leave the UI unzoomable.

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -21,6 +21,7 @@ import type {
   ConflictSides,
   DiagnosticsReport,
   DiffKind,
+  DiffToolTarget,
   FastForward,
   FileContent,
   FileDiff,
@@ -1223,6 +1224,29 @@ export async function openInEditor(
   relativePath: string,
 ): Promise<void> {
   return invoke<void>("open_in_editor", { repoId, relativePath });
+}
+
+/**
+ * Hand one file's diff to the user's own diff tool (#235).
+ *
+ * `paths` is a LIST so a rename can pass `[oldPath, newPath]`: scoped to the new
+ * path alone, `git difftool` reports a renamed file as a whole file added, which
+ * is the dead end this feature exists to remove.
+ *
+ * `tool` is the app's optional Settings override. Omit it — the normal case —
+ * and git resolves the tool itself from `diff.guitool` / `diff.tool` /
+ * `merge.tool`, which is what makes this zero-config for anyone already set up.
+ *
+ * Resolves when the tool EXITS: `git difftool` waits for it, so this promise is
+ * open for as long as the window is. Callers show an activity entry.
+ */
+export async function openInDifftool(
+  repoId: string,
+  target: DiffToolTarget,
+  paths: string[],
+  tool?: string | null,
+): Promise<void> {
+  return invoke<void>("open_in_difftool", { repoId, target, paths, tool });
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -357,6 +357,29 @@ export type ImageSource =
   | { kind: "stage"; stage: number };
 
 /**
+ * Which two sides `git difftool` should be pointed at (#235). Mirrors Rust's
+ * `DiffToolTarget`.
+ *
+ * `commit` is a kind of its own rather than a `range` built here with `^`,
+ * because both shorthands for "this commit against its parent" are wrong at a
+ * ROOT commit: `<oid>^` fails to resolve, and `<oid>^!` silently degrades to a
+ * diff against the WORKING TREE. The backend resolves the parent instead — see
+ * `git/difftool.rs`. So a surface that knows it is showing one commit passes
+ * `commit`, never a range it composed.
+ */
+export type DiffToolTarget =
+  /** Unstaged changes — the working tree against the index. */
+  | { kind: "worktree" }
+  /** Staged changes — the index against HEAD. */
+  | { kind: "staged" }
+  /** One commit against its first parent (or the empty tree, at a root). */
+  | { kind: "commit"; oid: string }
+  /** Any two revisions, in git's own order: old, then new. */
+  | { kind: "range"; from: string; to: string }
+  /** A revision against the working tree. */
+  | { kind: "revToWorktree"; rev: string };
+
+/**
  * One side of an image preview (#224). Mirrors Rust's `ImagePreview`.
  *
  * `null` from `readImagePreview` is a FIFTH state and means something else

--- a/src/screens/CommitDiff.tsx
+++ b/src/screens/CommitDiff.tsx
@@ -8,7 +8,7 @@ import { useIgnoreWhitespace } from "@/features/diff/WhitespaceToggle";
 import { DeepViewHeader } from "@/features/nav/DeepViewHeader";
 import { diffCommit, diffCommits, diffRefToWorkdir, stashDiff } from "@/lib/tauri";
 import { appErrorMessage } from "@/lib/errors";
-import type { FileDiff } from "@/lib/types";
+import type { DiffToolTarget, FileDiff } from "@/lib/types";
 import type { SideSource } from "@/lib/syntax/useDiffSyntax";
 
 /**
@@ -81,6 +81,39 @@ function syntaxSidesFor(
         old: { kind: "rev", rev: target.oid },
         new: { kind: "rev", rev: "HEAD" },
       };
+  }
+}
+
+/**
+ * The same two sides again, for `git difftool` (#235).
+ *
+ * A separate function from `syntaxSidesFor` rather than a translation of it,
+ * and the reason is `commit-self`: `syntaxSidesFor` says `<oid>^`, which is
+ * allowed to fail — a root commit simply renders plain. `git difftool` cannot
+ * be given that. `<oid>^` errors, and `<oid>^!` silently diffs the commit
+ * against the WORKING TREE. So the commit targets pass `commit` and let the
+ * backend resolve the parent (or the empty tree at a root).
+ *
+ * `stash-diff` is the same shape — a stash IS a commit, and its first parent is
+ * the base it was taken from, which is the pair `git stash show` uses. Its
+ * untracked payload lives on a third parent that `git difftool` will not reach,
+ * so an untracked file in the stash opens empty; the screen already says the
+ * untracked files are included, and the alternative is no entry at all on a
+ * surface where most rows work.
+ */
+function difftoolTargetFor(target: Target): DiffToolTarget {
+  switch (target.kind) {
+    case "commit-self":
+    case "stash-diff":
+      return { kind: "commit", oid: target.oid };
+    case "stash-vs-wt":
+      return { kind: "revToWorktree", rev: target.oid };
+    case "commit-vs-commit":
+      return { kind: "range", from: target.from, to: target.to };
+    case "commit-vs-wt":
+      // Not `revToWorktree`: this target diffs the commit against HEAD, which
+      // is what the fetch above does too. The header says so.
+      return { kind: "range", from: target.oid, to: "HEAD" };
   }
 }
 
@@ -217,6 +250,7 @@ export function CommitDiffScreen() {
         // comparison does not (#61 D6).
         verifyOid={target.kind === "commit-self" ? target.oid : undefined}
         syntaxSides={repo ? syntaxSidesFor(target, repo.id) : undefined}
+        difftoolTarget={difftoolTargetFor(target)}
       />
     </div>
   );

--- a/src/screens/Compare.tsx
+++ b/src/screens/Compare.tsx
@@ -424,6 +424,21 @@ export function CompareScreen() {
                 ? { kind: "worktree" }
                 : { kind: "rev", rev: right.rev },
           }}
+          // The same two sides again, in git's own vocabulary (#235). The
+          // working-tree right-hand side is a one-revision diff, not a range —
+          // `git diff <rev> -- <path>` already means "against the working tree".
+          difftoolTarget={
+            right.kind === "workdir"
+              ? {
+                  kind: "revToWorktree",
+                  rev: left.kind === "rev" ? left.rev : "HEAD",
+                }
+              : {
+                  kind: "range",
+                  from: left.kind === "rev" ? left.rev : "HEAD",
+                  to: right.rev,
+                }
+          }
         />
       </div>
     </div>

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -932,6 +932,11 @@ export function HistoryScreen() {
             }
           : undefined
       }
+      // The commit itself, NOT the `^` pair above (#235): `^` is fine for
+      // highlighting, where failing on a root commit just renders plain, and
+      // wrong for difftool, where it either errors or diffs against the working
+      // tree. The backend resolves the parent.
+      difftoolTarget={current ? { kind: "commit", oid: current.oid } : undefined}
     />
   );
 

--- a/src/screens/Settings.difftool.test.tsx
+++ b/src/screens/Settings.difftool.test.tsx
@@ -1,0 +1,79 @@
+// Settings → Diff → External diff tool (#235).
+//
+// The field's whole job is to stay OUT of the way: git resolves the tool from
+// `diff.guitool` / `diff.tool` / `merge.tool` on its own, so empty is both the
+// default and the answer for most people. What only the screen can get wrong is
+// the one mistake the field invites — pasting a command line
+// (`bcompare "$LOCAL" "$REMOTE"`) where git wants a tool NAME. The backend
+// refuses it; without a marker here the user would only find out by clicking
+// and reading a banner.
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { mockInvoke } from "@/test/invokeMock";
+import { WithDialogs, resetDialogs } from "@/test/dialog";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { SettingsScreen } from "./Settings";
+
+function mockRestOfSettings() {
+  mockInvoke("cli_shim_status", () => ({
+    installed: true,
+    shimPath: "/usr/local/bin/pgit",
+    target: "/usr/bin/platypusgit",
+    source: "package",
+    pathState: "onPath",
+  }));
+  mockInvoke("diagnostics_report", () => ({
+    logPath: "/tmp/platypusgit.log",
+    logExists: false,
+    logSizeBytes: 0,
+    environment: "host os=macos arch=aarch64 git=2.43.0",
+    version: "0.1.0",
+  }));
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  resetDialogs();
+  mockRestOfSettings();
+  useSettingsStore.getState().reset();
+});
+
+function renderSettings() {
+  render(
+    <WithDialogs>
+      <SettingsScreen />
+    </WithDialogs>,
+  );
+}
+
+const field = () =>
+  screen.getByTestId<HTMLInputElement>("settings-external-diff-tool");
+
+describe("the external diff tool field", () => {
+  it("starts empty — git decides — and writes edits straight through", () => {
+    renderSettings();
+    expect(field().value).toBe("");
+    expect(field().getAttribute("aria-invalid")).not.toBe("true");
+
+    fireEvent.change(field(), { target: { value: "meld" } });
+    expect(useSettingsStore.getState().externalDiffTool).toBe("meld");
+    expect(field().getAttribute("aria-invalid")).not.toBe("true");
+  });
+
+  it("flags a command line, which git cannot use as a tool name", () => {
+    renderSettings();
+    fireEvent.change(field(), {
+      target: { value: 'bcompare "$LOCAL" "$REMOTE"' },
+    });
+    expect(field().getAttribute("aria-invalid")).toBe("true");
+  });
+
+  it("does not flag an empty field — that is the default and it is valid", () => {
+    renderSettings();
+    fireEvent.change(field(), { target: { value: "kdiff3" } });
+    fireEvent.change(field(), { target: { value: "" } });
+    expect(field().getAttribute("aria-invalid")).not.toBe("true");
+    expect(useSettingsStore.getState().externalDiffTool).toBe("");
+  });
+});

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -17,6 +17,7 @@ import {
   ZOOM_MAX,
   ZOOM_MIN,
   applyTheme,
+  isValidDiffToolName,
   useSettingsStore,
   type SettingsImportReport,
   type ThemeColors,
@@ -313,6 +314,36 @@ export function SettingsScreen() {
               <PGToggle
                 checked={s.ignoreWhitespaceInDiff}
                 onChange={(v) => s.set("ignoreWhitespaceInDiff", v)}
+              />
+            }
+          />
+          <Row
+            label="External diff tool"
+            hint={
+              <>
+                Which tool &quot;Open in external diff tool&quot; hands a file
+                to. Leave it empty and git decides, from{" "}
+                <code>diff.guitool</code>, <code>diff.tool</code> or{" "}
+                <code>merge.tool</code> — so anyone who has already configured
+                one needs nothing here. A tool NAME, not a command line
+                (<code>meld</code>, <code>bc</code>, <code>vimdiff</code>, or one
+                you defined with <code>difftool.&lt;tool&gt;.cmd</code>).
+              </>
+            }
+            control={
+              <PGInput
+                value={s.externalDiffTool}
+                onChange={(v) => s.set("externalDiffTool", v)}
+                // A command line here would fail inside git with a message
+                // about a tool nobody configured, so the field says so while it
+                // is being typed — same treatment as the ticket pattern above.
+                error={!isValidDiffToolName(s.externalDiffTool)}
+                aria-invalid={!isValidDiffToolName(s.externalDiffTool)}
+                mono
+                size="sm"
+                placeholder="git decides"
+                style={{ width: 220 }}
+                data-testid="settings-external-diff-tool"
               />
             }
           />


### PR DESCRIPTION
Closes #235

We could hand a *conflict* to the user's configured merge tool (`run_mergetool`) and nothing else, so every ordinary diff in the app was a closed room. This adds **"Open in external diff tool"** to the file rows the issue names, on top of a real `git difftool` shell-out.

## What changed

**It shells out to `git difftool` rather than materialising the two sides.** For a commit or an index diff neither side is a file — they are blobs — and git already extracts both, resolves the tool from `diff.guitool` / `diff.tool` / `merge.tool` / `difftool.<tool>.cmd`, and cleans up. So it is **zero-config for anyone already set up**: with no override we pass no tool at all.

**Where it appears** — the three surfaces the issue lists, which are two code sites:

- `fileMenuItems` — the file row in the **Commit panel** and the **repo browser**. `staged` for a staged row, `worktree` otherwise.
- `CommitDiffPanel`'s file rows — one component behind the **commit diff screen**, **History's inline panel**, **branch compare** and both stash diffs, so all of them inherit it. These rows had no per-file menu at all before; they now get one (copy path + open externally).

Not in the multi-file menu (40 files is 40 windows), and disabled on a purely untracked row — that path is in neither side of any diff git computes, so the click would do literally nothing.

**Settings → Diff → External diff tool** is optional and empty by default. A value becomes `--tool=<name>`; a tool NAME, not a command line, and the field flags a pasted command line while it is being typed (the command line belongs in `difftool.<tool>.cmd`, where git reads it).

**Console handling is `run_mergetool`'s, verbatim** — `proc::git_async_keeping_console`, so a console difftool (`vimdiff`, `nvimdiff`) gets the console it renders in. This is the second entry in `spawn_no_window.rs`'s `CONSOLE_KEEPING_CALLERS`, added with its reason.

## Two traps found while building it, both now pinned by tests

- **`<oid>^!` is not safe for a commit's own diff.** Verified against git 2.50: on a **root** commit, git's own documented "changes on this commit" form silently degrades to `git diff <oid>` — a diff against the **working tree**. `<oid>^` merely fails. So `DiffToolTarget::Commit` resolves the first parent in Rust, falling back to the repository's own empty tree (`treebuilder(None).write()`, hash-algorithm-correct where a hard-coded `4b825dc…` is SHA-1 only). `tests/difftool.rs` pins the wrong answer as hard as the right one: an uncommitted edit must never reach a commit's diff.
- **`--gui` and `--tool` cannot be used together** — git refuses the pair outright. Found by the end-to-end test, which went red on it; the builder now emits one or the other.

## Notes on the design

- **No new `AppError` variant.** When no tool resolves, git already says `This message is displayed because 'diff.tool' is not configured` — in the user's locale, and in step with a resolution order we do not own. The command pipes **stderr** (stdin/stdout stay inherited so a console tool keeps the terminal) and puts its tail in `AppError::Git`. Minting a variant would mean pattern-matching English.
- **No caller-supplied string reaches argv.** Revisions are **resolved** to hex oids (`revparse_single` + peel), not validated — `git difftool` needs them *ahead of* `--`, so the separator that guards the pathspecs cannot guard these, and a `--output=…` arriving over IPC in a revision slot would sit in an option position. Resolving makes that unrepresentable rather than merely refused, matches the standard `git/tag.rs` / `forge/mod.rs` / `ssh.rs` already hold, and gives the better error (`InvalidRef` with git's own message, before the spawn). `every_revision_reaching_argv_is_a_hex_oid` pins it as a property across every target shape, so a future variant that passed a string through fails without anyone remembering.
- **A rename passes both paths** (`[oldPath, newPath]`), or git reports the file as wholly added — the same dead end this is meant to remove. Every path goes through `opener::safe_workdir_path`, after `--`, with `GIT_LITERAL_PATHSPECS=1` (the second user of `git/stash.rs`'s constant).
- **A `difftool` `RepoActivity` entry** is held for as long as the tool is open — `git difftool` waits for it, and a person reading in Beyond Compare takes minutes. Not cancellable: it does not go through `run_git_authenticated`, so `cancel_network_op` cannot reach it.

Spec and plan: `docs/superpowers/specs/2026-08-30-external-difftool-spec.md`, `docs/superpowers/plans/2026-08-30-external-difftool-plan.md`.

## Verification

All run from the worktree, all green:

| Command | Result |
| --- | --- |
| `pnpm tsc --noEmit` | clean |
| `pnpm test` | **2573 passed** (280 files) |
| `cargo test --manifest-path src-tauri/Cargo.toml` | **1041 passed, 0 failed** |

(Counts are post-rebase onto `main` @ `f068e57`; the branch was rebased over #300 and #301, which conflicted in `git/mod.rs`, `git/cli.rs`, `git/libgit2.rs` and `docs/dev/backend.md` — all "both sides added a neighbouring method/section", resolved by keeping both. All three gates were re-run after the rebase.)

New tests: `src-tauri/tests/difftool.rs` (27), `src/design/context-menu.difftool.test.tsx` (7), `src/features/repo/useRepoStore.difftool.test.ts` (5), `src/features/diff/CommitDiffPanel.difftool.test.tsx` (4), `src/screens/Settings.difftool.test.tsx` (3), plus two coercion cases in the settings export suite.

Eight of the Rust tests **run real `git difftool`** against a temp repo with `diff.tool` pointed at a fake tool that copies `$LOCAL`/`$REMOTE` into a marker file — which is the only honest proof that "respect `diff.tool` / `difftool.*`" holds, since it is kept by shelling out rather than by any code of ours. They also prove `--` really scopes the run to one file, `GIT_LITERAL_PATHSPECS` really stops `a[b].c` matching a decoy, and `--tool=` really outranks `diff.tool`. They skip with a message where `git difftool` is unavailable, the same way the gpg and git-lfs suites do.

No e2e spec added, so no `e2e/tsconfig.json` typecheck; CI runs the e2e suite unchanged.

## For the reviewer

- `git difftool` **ships with git but is a separate script**; the end-to-end tests skip if it is missing rather than fail. On `ubuntu-latest` it is present, so they should really run in CI — worth a glance at the log to confirm they did rather than skipped.
- The command **awaits the tool's exit**. That matches `run_mergetool`, and it is what makes the activity entry meaningful, but it does mean a tool that never exits holds an entry until the app closes.
- `CommitDiffPanel` now calls `useRepoStore` for the action. The panel is documented as never learning the repo; it already mounts `SignatureBadge`, which reads the store, so this does not open a new dependency — but it is worth agreeing with.
- **`--gui` when no override is set** is a judgement call: it prefers `diff.guitool` over `diff.tool` for someone who has split the two. It falls back to `diff.tool` when there is no guitool, so it should be invisible to everyone else.
- `externalDiffTool` is **portable** in the settings export (a tool name is a preference, not a machine path; a missing tool fails visibly with git's own message). The opposite call is defensible.
- An **unmodified** file in the repo browser still offers the entry and the tool opens on nothing — same shape as "View diff" there today, so it was left alone rather than given a third gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
