### PR TITLE
feat(branches): group the branch list into folders on `/`

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -397,7 +397,13 @@ features/            Components + Zustand store colocated per feature:
 │                    (repoState-driven bar), ownership (safe.directory confirm)
 ├── nav/             useNavStore — cross-screen intents + DeepViewHeader
 ├── branches/        BranchChip, BranchPicker, orderBranches (PURE, #135 — THE
-│                    one branch ordering; every branch list goes through it)
+│                    one branch ordering; every branch list goes through it),
+│                    branchTree (PURE, #244 — grouping on `/` AFTER ordering:
+│                    compressed folder rows + flat depth-carrying rows,
+│                    parentFolderPath, branchesInFolder), useBranchFolders
+│                    (per-repo collapsed set in localStorage), deleteMerged
+│                    (candidates + `ahead_behind` merge check + summary),
+│                    fastForward (#246)
 ├── commits/         Pure log logic, all tested: graphLayout, laneColors,
 │                    graphAncestry, rowIdentity, buildRebasePlan /
 │                    buildPreservePlan / withPlanBase / runRebasePlan /

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -511,6 +511,51 @@ that is only partly here — which is the whole reason the notice exists.
   included, resets on a closed→open transition — a `--depth 1` chosen for one
   enormous repository must not quietly truncate the next.
 
+## Branch folders (#244)
+
+- **Filter, then order, then group — in that order.** `orderBranches` (#135) is
+  still THE branch ordering; `features/branches/branchTree.ts` only moves the
+  ordered rows into folders, so the pinned default branch stays the first row on
+  the screen and the newest-first order holds inside every folder. A folder
+  ranks where its first (freshest) branch was. Grouping never sorts.
+- **A prefix that groups nothing is not a folder.** Single-child chains compress
+  (`feat/foo/bar` alone is ONE row reading `feat/foo/bar`, not three), the same
+  rule `lib/tree.ts::compactNode` applies to file paths. So a folder row always
+  holds at least two things, and `branchFolderPaths` names the compressed paths
+  — the ones "collapse all" must write, not one per segment.
+- **The output is FLAT: rows carrying their own `depth`.** The Branches screen
+  keeps its grid, its `usePaneList` index and its selection model unchanged; a
+  nested render would have needed all three rewritten. Indentation lives in the
+  NAME cell only, so TIP / UPSTREAM / STATUS stay on the grid at any depth.
+- **A leaf row's `path` is always the branch's full name** — selection, context
+  menus and the inspector key off it. That is why a name with an empty segment
+  (`a//b`, which git rejects anyway) is left whole rather than split.
+- **A filter flattens the tree to its matches, showing full names.** Hiding a
+  hit behind a folded folder is the one thing a search box must never do, and a
+  bare `bar` with no `feat/foo` above it names nothing.
+- **Fold state is the EXCEPTIONS, per repository, outside the store.**
+  `useBranchFolders` persists the set of COLLAPSED paths in localStorage keyed by
+  repository path (`pg-branch-folders-v1`), pruning a repository's entry once it
+  is empty. Not in `useRepoStore`: that holds one repository's live git state and
+  every field must join `RepoSlice`, whereas this has to outlive the tab. It is
+  re-read on every repository change, or one tab's folds would be written back
+  under another tab's path.
+- **Folding the folder the selection sits in moves the selection onto it.**
+  Otherwise `flatIndex` goes to -1 and the next ArrowDown restarts at the top.
+  ← on a folder folds it and on anything else climbs to `parentFolderPath`.
+- **"Delete merged branches in this folder" means `git branch --merged`** —
+  contained in HEAD — and the confirm says so. Never a remote (that would be a
+  push), never HEAD, never the default branch even when it lives in a folder.
+  The merge check is one `ahead_behind` per candidate, run on demand and
+  sequentially (the backend serializes per-repository work), never per render; a
+  branch it cannot ask about is reported unmerged, the safe direction. The
+  confirm names every branch in a scrolling list — "8 branches" is not something
+  anyone can check before clicking Delete.
+- **Drag and drop is deliberately NOT wired to folder rows yet.** When it is, a
+  branch dragged onto or out of a folder resolves through `resolveDrop.ts` like
+  every other drop, with a keyboard equivalent — see the drag-and-drop rules
+  below.
+
 ## Navigation model
 
 - Activity bar = primary switcher, History first. **Launch always lands on

--- a/src/features/branches/branchTree.test.ts
+++ b/src/features/branches/branchTree.test.ts
@@ -1,0 +1,306 @@
+// Grouping branches on "/" (#244). Pure, so the whole table is testable
+// without a DOM, a store or a repository — the Branches screen only renders
+// what comes out of here.
+
+import { describe, it, expect } from "vitest";
+import {
+  branchTreeRows,
+  branchFolderPaths,
+  branchesInFolder,
+  parentFolderPath,
+  type BranchTreeRow,
+} from "./branchTree";
+
+const b = (name: string) => ({ name });
+const none = new Set<string>();
+
+/** `depth:kind:label` per row — the shape assertions read off. */
+const shape = (rows: readonly BranchTreeRow<{ name: string }>[]) =>
+  rows.map((r) => `${r.depth}:${r.kind === "folder" ? "d" : "-"}:${r.label}`);
+
+describe("branchTreeRows", () => {
+  it("leaves a slashless list exactly as it found it", () => {
+    const rows = branchTreeRows([b("main"), b("wip"), b("gh-pages")], none);
+
+    expect(shape(rows)).toEqual(["0:-:main", "0:-:wip", "0:-:gh-pages"]);
+  });
+
+  it("groups branches that share a first segment into a folder", () => {
+    const rows = branchTreeRows([b("main"), b("feat/a"), b("feat/b")], none);
+
+    expect(shape(rows)).toEqual(["0:-:main", "0:d:feat", "1:-:a", "1:-:b"]);
+  });
+
+  // The point of the compression: a prefix that groups nothing is not a folder,
+  // it is part of the name. `feat/foo/bar` alone is ONE row, not three.
+  it("renders a lone deep branch as one row, not a chain of folders", () => {
+    const rows = branchTreeRows([b("feat/foo/bar")], none);
+
+    expect(shape(rows)).toEqual(["0:-:feat/foo/bar"]);
+    expect(rows[0].path).toBe("feat/foo/bar");
+  });
+
+  it("compresses only the part of the chain that branches nothing", () => {
+    const rows = branchTreeRows(
+      [b("feat/foo/bar"), b("feat/foo/baz"), b("other")],
+      none,
+    );
+
+    // `feat` holds one thing, so it merges with `foo`, which holds two.
+    expect(shape(rows)).toEqual([
+      "0:d:feat/foo",
+      "1:-:bar",
+      "1:-:baz",
+      "0:-:other",
+    ]);
+    expect(rows[0].path).toBe("feat/foo");
+  });
+
+  it("nests arbitrarily deep", () => {
+    const rows = branchTreeRows(
+      [b("a/b/one"), b("a/b/two"), b("a/c/three"), b("a/c/four")],
+      none,
+    );
+
+    expect(shape(rows)).toEqual([
+      "0:d:a",
+      "1:d:b",
+      "2:-:one",
+      "2:-:two",
+      "1:d:c",
+      "2:-:three",
+      "2:-:four",
+    ]);
+  });
+
+  // Ordering is `orderBranches`' job (#135) and stays its job: the tree groups
+  // what it is handed and never re-sorts, or the pinned default and the
+  // recency order would both be silently undone.
+  it("keeps the order it was given inside a folder", () => {
+    const rows = branchTreeRows(
+      [b("feat/zeta"), b("feat/alpha"), b("feat/mid")],
+      none,
+    );
+
+    expect(shape(rows)).toEqual([
+      "0:d:feat",
+      "1:-:zeta",
+      "1:-:alpha",
+      "1:-:mid",
+    ]);
+  });
+
+  // A folder is only as recent as its freshest branch, and the input is already
+  // newest-first — so first touch wins, and a folder full of stale branches
+  // sinks below a fresh loose one.
+  it("ranks a folder where its first branch was", () => {
+    const rows = branchTreeRows(
+      [b("chore/old"), b("hotfix"), b("chore/older")],
+      none,
+    );
+
+    expect(shape(rows)).toEqual([
+      "0:d:chore",
+      "1:-:old",
+      "1:-:older",
+      "0:-:hotfix",
+    ]);
+  });
+
+  it("counts every branch beneath a folder, however deep", () => {
+    const rows = branchTreeRows(
+      [b("a/b/one"), b("a/b/two"), b("a/three")],
+      none,
+    );
+
+    const folders = rows.filter((r) => r.kind === "folder");
+    expect(folders.map((f) => [f.path, f.kind === "folder" && f.count])).toEqual(
+      [
+        ["a", 3],
+        ["a/b", 2],
+      ],
+    );
+  });
+
+  it("hides a collapsed folder's subtree but still counts it", () => {
+    const rows = branchTreeRows(
+      [b("main"), b("feat/a"), b("feat/b")],
+      new Set(["feat"]),
+    );
+
+    expect(shape(rows)).toEqual(["0:-:main", "0:d:feat"]);
+    const folder = rows[1];
+    expect(folder.kind === "folder" && folder.count).toBe(2);
+    expect(folder.kind === "folder" && folder.collapsed).toBe(true);
+  });
+
+  it("hides folders nested inside a collapsed folder", () => {
+    const rows = branchTreeRows(
+      [b("a/b/one"), b("a/b/two"), b("a/three")],
+      new Set(["a"]),
+    );
+
+    expect(shape(rows)).toEqual(["0:d:a"]);
+  });
+
+  it("collapsing an inner folder leaves its parent's other rows alone", () => {
+    const rows = branchTreeRows(
+      [b("a/b/one"), b("a/b/two"), b("a/three")],
+      new Set(["a/b"]),
+    );
+
+    expect(shape(rows)).toEqual(["0:d:a", "1:d:b", "1:-:three"]);
+  });
+
+  // Every branch row has to be able to say which branch it is: the screen keys
+  // selection, context menus and the inspector off the full name.
+  it("carries the full branch name and the row's own branch object", () => {
+    const rows = branchTreeRows([b("feat/foo/bar"), b("feat/foo/baz")], none);
+
+    const leaves = rows.filter((r) => r.kind === "branch");
+    expect(leaves.map((l) => l.path)).toEqual(["feat/foo/bar", "feat/foo/baz"]);
+    expect(leaves[0].kind === "branch" && leaves[0].branch.name).toBe(
+      "feat/foo/bar",
+    );
+  });
+
+  it("shows every branch exactly once when nothing is collapsed", () => {
+    const input = [
+      b("main"),
+      b("feat/a"),
+      b("feat/deep/b"),
+      b("feat/deep/c"),
+      b("origin/main"),
+      b("origin/feat/a"),
+    ];
+
+    const leaves = branchTreeRows(input, none)
+      .filter((r) => r.kind === "branch")
+      .map((r) => r.path);
+
+    expect(leaves.slice().sort()).toEqual(input.map((r) => r.name).sort());
+  });
+
+  // Remote names are `origin/<branch>`, so the remote IS the first segment and
+  // grouping labels the remote block for free — the flat list never did.
+  it("groups remote branches under their remote", () => {
+    const rows = branchTreeRows(
+      [b("origin/main"), b("origin/feat/a"), b("origin/feat/b")],
+      none,
+    );
+
+    expect(shape(rows)).toEqual([
+      "0:d:origin",
+      "1:-:main",
+      "1:d:feat",
+      "2:-:a",
+      "2:-:b",
+    ]);
+  });
+
+  // Git refuses a branch called `feat` next to `feat/x` ("cannot lock ref"), so
+  // this shape cannot come from a repository — but a row that vanished because
+  // the tree assumed it away would be a silent wrong answer, so both render.
+  it("still renders a branch whose name is also a folder prefix", () => {
+    const rows = branchTreeRows([b("feat"), b("feat/a")], none);
+
+    expect(shape(rows)).toEqual(["0:-:feat", "0:d:feat", "1:-:a"]);
+  });
+
+  // `refs/heads/a//b` is not a legal ref either. Splitting it would produce a
+  // leaf whose path is no longer the branch's name, which every call site keys
+  // off — so such a name is left whole instead.
+  it("does not split a name with an empty segment", () => {
+    const rows = branchTreeRows([b("a//b")], none);
+
+    expect(shape(rows)).toEqual(["0:-:a//b"]);
+    expect(rows[0].path).toBe("a//b");
+  });
+
+  it("does not mutate its input", () => {
+    const input = [b("feat/b"), b("feat/a")];
+    const before = input.map((r) => r.name);
+
+    branchTreeRows(input, none);
+
+    expect(input.map((r) => r.name)).toEqual(before);
+  });
+
+  it("is empty for an empty list", () => {
+    expect(branchTreeRows([], none)).toEqual([]);
+  });
+});
+
+describe("branchFolderPaths", () => {
+  // "Collapse all" writes this set, so it must name exactly the folder rows the
+  // tree renders — a compressed chain is ONE path, not one per segment.
+  it("names every folder the tree renders, and nothing else", () => {
+    expect(
+      branchFolderPaths([
+        b("main"),
+        b("feat/foo/bar"),
+        b("feat/foo/baz"),
+        b("release/1/x"),
+        b("a/b/one"),
+        b("a/b/two"),
+        b("a/three"),
+      ]),
+    ).toEqual(["feat/foo", "a", "a/b"]);
+  });
+
+  it("has no folders when no name has a slash", () => {
+    expect(branchFolderPaths([b("main"), b("wip")])).toEqual([]);
+  });
+});
+
+describe("parentFolderPath", () => {
+  const rows = branchTreeRows(
+    [b("main"), b("a/b/one"), b("a/b/two"), b("a/three")],
+    none,
+  );
+  // 0 main · 1 folder a · 2 folder a/b · 3 one · 4 two · 5 three
+
+  it("is null for a top-level row", () => {
+    expect(parentFolderPath(rows, 0)).toBeNull();
+    expect(parentFolderPath(rows, 1)).toBeNull();
+  });
+
+  it("climbs from a branch to the folder it sits in", () => {
+    expect(parentFolderPath(rows, 3)).toBe("a/b");
+    expect(parentFolderPath(rows, 5)).toBe("a");
+  });
+
+  it("climbs from a folder to the folder above it", () => {
+    expect(parentFolderPath(rows, 2)).toBe("a");
+  });
+
+  // The keyboard list also holds tags and stashes, whose indices run past the
+  // end of the tree — those must climb nowhere rather than throw.
+  it("is null past the end of the rows", () => {
+    expect(parentFolderPath(rows, 99)).toBeNull();
+  });
+});
+
+describe("branchesInFolder", () => {
+  it("returns the branches beneath a folder, in the order given", () => {
+    const input = [b("feat/b"), b("feat/a"), b("feat/deep/c"), b("main")];
+
+    expect(branchesInFolder(input, "feat").map((r) => r.name)).toEqual([
+      "feat/b",
+      "feat/a",
+      "feat/deep/c",
+    ]);
+  });
+
+  it("matches on a segment boundary, never a bare prefix", () => {
+    const input = [b("feature/x"), b("feat/y")];
+
+    expect(branchesInFolder(input, "feat").map((r) => r.name)).toEqual([
+      "feat/y",
+    ]);
+  });
+
+  it("is empty for a folder nothing lives in", () => {
+    expect(branchesInFolder([b("main")], "feat")).toEqual([]);
+  });
+});

--- a/src/features/branches/branchTree.ts
+++ b/src/features/branches/branchTree.ts
@@ -1,0 +1,211 @@
+// Grouping branches on "/" (#244). Pure — see branchTree.test.ts.
+//
+// Every team names branches `feat/…`, `fix/…`, `release/…`, so a forty-branch
+// repository renders as forty rows with nothing to collapse. This turns that
+// flat list into a tree WITHOUT touching the order it arrives in: the caller
+// filters, then orders with `orderBranches` (#135), then groups here. Grouping
+// is the last step for a reason — it only ever moves rows into folders, so the
+// pinned default branch and the newest-first order both survive it.
+//
+// The output is FLAT: one array of rows carrying their own `depth`. The
+// Branches screen keeps its grid, its keyboard list and its selection index
+// exactly as they were — a nested render would have needed all three rewritten.
+
+/** A folder row: a name prefix that groups two or more things. */
+export interface BranchTreeFolder {
+  kind: "folder";
+  /** Full prefix — `feat/foo`. The identity a collapse state keys on. */
+  path: string;
+  /** What the row shows: the segments this row owns after compression. */
+  label: string;
+  depth: number;
+  /** Branches beneath it, recursively — shown even while collapsed. */
+  count: number;
+  collapsed: boolean;
+}
+
+/** A branch row. `path` is always the branch's full name. */
+export interface BranchTreeLeaf<T> {
+  kind: "branch";
+  path: string;
+  label: string;
+  depth: number;
+  branch: T;
+}
+
+export type BranchTreeRow<T> = BranchTreeFolder | BranchTreeLeaf<T>;
+
+interface Node<T> {
+  /** The one segment this node was created for. */
+  label: string;
+  /** Full path from the root. */
+  path: string;
+  branch?: T;
+  /** Insertion-ordered on purpose — that IS the within-folder order. */
+  children: Map<string, Node<T>>;
+}
+
+/**
+ * The segments a name groups on.
+ *
+ * A ref name cannot contain an empty segment (`git check-ref-format` rejects
+ * `a//b`, a leading `/` and a trailing one), and splitting one anyway would
+ * produce a leaf whose `path` is no longer the branch's name — which selection,
+ * context menus and the inspector all key off. So such a name stays whole.
+ */
+function segmentsOf(name: string): string[] {
+  const parts = name.split("/");
+  return parts.some((p) => p === "") ? [name] : parts;
+}
+
+function build<T extends { name: string }>(branches: readonly T[]): Node<T> {
+  const root: Node<T> = { label: "", path: "", children: new Map() };
+  for (const branch of branches) {
+    let cursor = root;
+    for (const seg of segmentsOf(branch.name)) {
+      let next = cursor.children.get(seg);
+      if (!next) {
+        next = {
+          label: seg,
+          path: cursor.path ? `${cursor.path}/${seg}` : seg,
+          children: new Map(),
+        };
+        cursor.children.set(seg, next);
+      }
+      cursor = next;
+    }
+    cursor.branch = branch;
+  }
+  return root;
+}
+
+/**
+ * Merge a single-child chain into one row (Fork / IntelliJ style, and the same
+ * rule `lib/tree.ts::compactNode` applies to file paths).
+ *
+ * A prefix that groups nothing is not a folder, it is part of the name: a lone
+ * `feat/foo/bar` is ONE row reading `feat/foo/bar`, not three nested ones. The
+ * merge walks through the final leaf too, which is what makes that one row a
+ * BRANCH row rather than a folder holding a single child.
+ */
+function compress<T>(node: Node<T>): Node<T> {
+  let n = node;
+  let label = node.label;
+  while (!n.branch && n.children.size === 1) {
+    const only = n.children.values().next().value as Node<T>;
+    label = `${label}/${only.label}`;
+    n = only;
+  }
+  return { ...n, label };
+}
+
+function countBranches<T>(node: Node<T>): number {
+  let n = node.branch ? 1 : 0;
+  for (const child of node.children.values()) n += countBranches(child);
+  return n;
+}
+
+function countBelow<T>(node: Node<T>): number {
+  let n = 0;
+  for (const child of node.children.values()) n += countBranches(child);
+  return n;
+}
+
+function emit<T>(
+  parent: Node<T>,
+  depth: number,
+  collapsed: ReadonlySet<string>,
+  out: BranchTreeRow<T>[],
+): void {
+  for (const raw of parent.children.values()) {
+    const node = compress(raw);
+    // A node can hold a branch AND children only if a repository contains both
+    // `feat` and `feat/a`, which git refuses to create. Rendering both anyway
+    // costs one row; assuming it away would silently drop a real branch.
+    if (node.branch) {
+      out.push({
+        kind: "branch",
+        path: node.path,
+        label: node.label,
+        depth,
+        branch: node.branch,
+      });
+    }
+    if (node.children.size > 0) {
+      const isCollapsed = collapsed.has(node.path);
+      out.push({
+        kind: "folder",
+        path: node.path,
+        label: node.label,
+        depth,
+        count: countBelow(node),
+        collapsed: isCollapsed,
+      });
+      if (!isCollapsed) emit(node, depth + 1, collapsed, out);
+    }
+  }
+}
+
+/**
+ * Group an ALREADY filtered and ordered branch list into display rows.
+ *
+ * `collapsed` holds folder paths, so the persisted state is the exceptions:
+ * a folder that appears after a fetch is visible without anyone having said so.
+ */
+export function branchTreeRows<T extends { name: string }>(
+  branches: readonly T[],
+  collapsed: ReadonlySet<string>,
+): BranchTreeRow<T>[] {
+  const out: BranchTreeRow<T>[] = [];
+  emit(build(branches), 0, collapsed, out);
+  return out;
+}
+
+/**
+ * Every folder path the tree would render, expanded or not — what "collapse
+ * all" writes. A compressed chain is ONE path (`feat/foo`), never one per
+ * segment, or collapsing all would leave rows keyed on folders that don't exist.
+ */
+export function branchFolderPaths<T extends { name: string }>(
+  branches: readonly T[],
+): string[] {
+  return branchTreeRows(branches, new Set())
+    .filter((r) => r.kind === "folder")
+    .map((r) => r.path);
+}
+
+/**
+ * The folder a row sits in: the nearest row above it that is a folder at a
+ * shallower depth. Null at the top level, or past the end of the tree.
+ *
+ * This is ←'s answer for a row that is not itself an expanded folder — the
+ * "climb out" half of tree navigation. Read off the RENDERED rows rather than
+ * off the path: chain compression means the folder holding `feat/foo/bar` may
+ * be `feat/foo` or `feat`, depending on what else the repository contains.
+ */
+export function parentFolderPath<T>(
+  rows: readonly BranchTreeRow<T>[],
+  index: number,
+): string | null {
+  const row = rows[index];
+  if (!row) return null;
+  for (let i = index - 1; i >= 0; i--) {
+    const candidate = rows[i];
+    if (candidate.kind === "folder" && candidate.depth < row.depth)
+      return candidate.path;
+  }
+  return null;
+}
+
+/**
+ * The branches beneath a folder, in the order given.
+ *
+ * Prefix match on a SEGMENT boundary: `feat` does not contain `feature/x`.
+ */
+export function branchesInFolder<T extends { name: string }>(
+  branches: readonly T[],
+  folderPath: string,
+): T[] {
+  const prefix = `${folderPath}/`;
+  return branches.filter((b) => b.name.startsWith(prefix));
+}

--- a/src/features/branches/deleteMerged.test.ts
+++ b/src/features/branches/deleteMerged.test.ts
@@ -1,0 +1,176 @@
+// "Delete merged branches in this folder" (#244) — the operation the flat list
+// made tedious, and the one destructive thing a folder row can do.
+
+import { describe, it, expect } from "vitest";
+import { mockInvoke, getInvokeCalls } from "@/test/invokeMock";
+import {
+  deleteMergedCandidates,
+  findMergedBranches,
+  summarizeDeleteMerged,
+} from "./deleteMerged";
+import type { BranchInfo } from "@/lib/types";
+
+const b = (over: Partial<BranchInfo> & { name: string }): BranchInfo => ({
+  isHead: false,
+  isRemote: false,
+  upstream: null,
+  ahead: 0,
+  behind: 0,
+  tip: "a".repeat(40),
+  tipTime: 0,
+  isDefault: false,
+  ...over,
+});
+
+const names = (rows: readonly BranchInfo[]) => rows.map((r) => r.name);
+
+describe("deleteMergedCandidates", () => {
+  it("takes the local branches inside the folder", () => {
+    const rows = deleteMergedCandidates(
+      [b({ name: "feat/a" }), b({ name: "feat/deep/c" }), b({ name: "main" })],
+      "feat",
+    );
+
+    expect(names(rows)).toEqual(["feat/a", "feat/deep/c"]);
+  });
+
+  // Deleting a remote branch is a push, not a local ref delete — a bulk action
+  // must not reach across the network on one menu click.
+  it("never offers a remote branch", () => {
+    const rows = deleteMergedCandidates(
+      [b({ name: "origin/feat/a", isRemote: true }), b({ name: "feat/a" })],
+      "feat",
+    );
+
+    expect(names(rows)).toEqual(["feat/a"]);
+  });
+
+  it("never offers the branch you are standing on", () => {
+    const rows = deleteMergedCandidates(
+      [b({ name: "feat/a", isHead: true }), b({ name: "feat/b" })],
+      "feat",
+    );
+
+    expect(names(rows)).toEqual(["feat/b"]);
+  });
+
+  // A repository whose default branch lives in a folder (`trunk/main`) must not
+  // lose it to a bulk delete — it is merged into HEAD by definition half the time.
+  it("never offers the default branch", () => {
+    const rows = deleteMergedCandidates(
+      [b({ name: "trunk/main", isDefault: true }), b({ name: "trunk/old" })],
+      "trunk",
+    );
+
+    expect(names(rows)).toEqual(["trunk/old"]);
+  });
+
+  it("skips a branch whose tip could not be resolved", () => {
+    const rows = deleteMergedCandidates(
+      [b({ name: "feat/broken", tip: null }), b({ name: "feat/ok" })],
+      "feat",
+    );
+
+    expect(names(rows)).toEqual(["feat/ok"]);
+  });
+
+  it("matches the folder on a segment boundary", () => {
+    const rows = deleteMergedCandidates(
+      [b({ name: "feature/x" }), b({ name: "feat/y" })],
+      "feat",
+    );
+
+    expect(names(rows)).toEqual(["feat/y"]);
+  });
+});
+
+describe("findMergedBranches", () => {
+  it("keeps only branches with nothing the base does not have", async () => {
+    mockInvoke("ahead_behind", ({ b: branch }) => ({
+      ahead: branch === "feat/done" ? 0 : 3,
+      behind: 0,
+      mergeBase: "c".repeat(40),
+    }));
+
+    const merged = await findMergedBranches("repo-1", "HEAD", [
+      b({ name: "feat/done" }),
+      b({ name: "feat/wip" }),
+    ]);
+
+    expect(names(merged)).toEqual(["feat/done"]);
+  });
+
+  it("asks about each branch against the base, in order", async () => {
+    mockInvoke("ahead_behind", () => ({
+      ahead: 0,
+      behind: 0,
+      mergeBase: null,
+    }));
+
+    await findMergedBranches("repo-1", "HEAD", [
+      b({ name: "feat/one" }),
+      b({ name: "feat/two" }),
+    ]);
+
+    expect(
+      getInvokeCalls()
+        .filter((c) => c.cmd === "ahead_behind")
+        .map((c) => [c.args.a, c.args.b]),
+    ).toEqual([
+      ["HEAD", "feat/one"],
+      ["HEAD", "feat/two"],
+    ]);
+  });
+
+  // The safe direction: a branch we could not ask about is NOT offered for
+  // deletion, and one unreadable ref does not abandon the whole operation.
+  it("treats a branch it cannot ask about as unmerged", async () => {
+    mockInvoke("ahead_behind", ({ b: branch }) => {
+      if (branch === "feat/broken") throw new Error("InvalidRef");
+      return { ahead: 0, behind: 0, mergeBase: null };
+    });
+
+    const merged = await findMergedBranches("repo-1", "HEAD", [
+      b({ name: "feat/broken" }),
+      b({ name: "feat/fine" }),
+    ]);
+
+    expect(names(merged)).toEqual(["feat/fine"]);
+  });
+
+  it("asks nothing when there are no candidates", async () => {
+    const merged = await findMergedBranches("repo-1", "HEAD", []);
+
+    expect(merged).toEqual([]);
+    expect(getInvokeCalls()).toEqual([]);
+  });
+});
+
+describe("summarizeDeleteMerged", () => {
+  it("names the one branch it deleted", () => {
+    expect(summarizeDeleteMerged(["feat/a"], [])).toBe("Deleted feat/a");
+  });
+
+  it("counts several", () => {
+    expect(summarizeDeleteMerged(["feat/a", "feat/b"], [])).toBe(
+      "Deleted 2 branches",
+    );
+  });
+
+  // A partial delete is the interesting outcome and must never read as success.
+  it("reports what it could not delete alongside what it did", () => {
+    expect(summarizeDeleteMerged(["feat/a"], ["feat/b"])).toBe(
+      "Deleted feat/a · feat/b could not be deleted",
+    );
+  });
+
+  it("counts several failures", () => {
+    expect(summarizeDeleteMerged([], ["feat/a", "feat/b"])).toBe(
+      "2 branches could not be deleted",
+    );
+  });
+
+  it("says so when nothing happened", () => {
+    expect(summarizeDeleteMerged([], [])).toBe("No branches were deleted");
+  });
+});

--- a/src/features/branches/deleteMerged.ts
+++ b/src/features/branches/deleteMerged.ts
@@ -1,0 +1,79 @@
+// "Delete merged branches in this folder" (#244).
+//
+// A folder row's one destructive action, and the operation a flat list of forty
+// branches makes tedious enough that nobody does it. Split the way
+// `fastForward.ts` is: the decisions are pure and tested here, the screen owns
+// the confirm and the store owns the deletes.
+//
+// "Merged" means git's own definition — `git branch --merged`, i.e. contained
+// in HEAD — rather than "merged into its upstream" or "merged into the default
+// branch". It is the definition the CLI would give the same answer for, and the
+// one the confirm can state in a single line.
+
+import { aheadBehind } from "@/lib/tauri";
+import type { BranchInfo } from "@/lib/types";
+import { branchesInFolder } from "./branchTree";
+
+/**
+ * The branches in `folderPath` a bulk delete may even CONSIDER, before anything
+ * has been asked about merge state. Pure.
+ *
+ * Remotes are out: deleting one is a push, and a menu click must not reach
+ * across the network. HEAD is out: git refuses, and offering it is a lie. The
+ * default branch is out even when it sits in a folder — it is contained in HEAD
+ * for half of a repository's life, so "merged" would happily delete `main`.
+ */
+export function deleteMergedCandidates(
+  branches: readonly BranchInfo[],
+  folderPath: string,
+): BranchInfo[] {
+  return branchesInFolder(branches, folderPath).filter(
+    (b) => !b.isRemote && !b.isHead && !b.isDefault && b.tip !== null,
+  );
+}
+
+/**
+ * Which candidates are fully contained in `base` — `ahead` counts what the
+ * branch has and the base does not, so zero is "merged".
+ *
+ * Sequential on purpose: the backend serializes per-repository work behind one
+ * mutex, so firing forty of these at once only queues them while making a
+ * cancel meaningless. A branch we cannot ask about is reported UNMERGED — the
+ * safe direction, and one unreadable ref does not abandon the other thirty-nine.
+ */
+export async function findMergedBranches(
+  repoId: string,
+  base: string,
+  candidates: readonly BranchInfo[],
+): Promise<BranchInfo[]> {
+  const merged: BranchInfo[] = [];
+  for (const branch of candidates) {
+    try {
+      const rel = await aheadBehind(repoId, base, branch.name);
+      if (rel.ahead === 0) merged.push(branch);
+    } catch {
+      // Unreadable ref → not offered for deletion.
+    }
+  }
+  return merged;
+}
+
+/**
+ * One line describing what a bulk delete did.
+ *
+ * The failures lead the interesting half and are never dropped: a partial
+ * delete must not read as success. One name is named, several are counted —
+ * a toast is one line and eight branch names is not.
+ */
+export function summarizeDeleteMerged(
+  deleted: readonly string[],
+  failed: readonly string[],
+): string {
+  const parts: string[] = [];
+  if (deleted.length === 1) parts.push(`Deleted ${deleted[0]}`);
+  else if (deleted.length > 1) parts.push(`Deleted ${deleted.length} branches`);
+  if (failed.length === 1) parts.push(`${failed[0]} could not be deleted`);
+  else if (failed.length > 1)
+    parts.push(`${failed.length} branches could not be deleted`);
+  return parts.length ? parts.join(" · ") : "No branches were deleted";
+}

--- a/src/features/branches/useBranchFolders.test.ts
+++ b/src/features/branches/useBranchFolders.test.ts
@@ -1,0 +1,97 @@
+// Which branch folders a repository has collapsed (#244), persisted like the
+// other per-surface view preferences: localStorage, best-effort, never fatal.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  readCollapsedFolders,
+  writeCollapsedFolders,
+  BRANCH_FOLDERS_KEY,
+} from "./useBranchFolders";
+
+const raw = () => localStorage.getItem(BRANCH_FOLDERS_KEY);
+
+describe("collapsed branch folders", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("is empty for a repository nobody has collapsed anything in", () => {
+    expect(readCollapsedFolders("/repos/a")).toEqual(new Set());
+  });
+
+  it("round-trips a set for one repository", () => {
+    writeCollapsedFolders("/repos/a", new Set(["feat", "release/1"]));
+
+    expect(readCollapsedFolders("/repos/a")).toEqual(
+      new Set(["feat", "release/1"]),
+    );
+  });
+
+  // One key holds every repository's state, so two open tabs must not read
+  // each other's folders — the same anti-leak rule the repo slice enforces.
+  it("keeps repositories apart", () => {
+    writeCollapsedFolders("/repos/a", new Set(["feat"]));
+    writeCollapsedFolders("/repos/b", new Set(["fix"]));
+
+    expect(readCollapsedFolders("/repos/a")).toEqual(new Set(["feat"]));
+    expect(readCollapsedFolders("/repos/b")).toEqual(new Set(["fix"]));
+  });
+
+  // Collapsing is the exception, not the default — so a repository the user
+  // expanded again leaves nothing behind, and the key self-prunes instead of
+  // growing one entry per repository ever opened.
+  it("drops a repository's entry once nothing is collapsed", () => {
+    writeCollapsedFolders("/repos/a", new Set(["feat"]));
+    writeCollapsedFolders("/repos/b", new Set(["fix"]));
+
+    writeCollapsedFolders("/repos/a", new Set());
+
+    expect(JSON.parse(raw() ?? "{}")).toEqual({ "/repos/b": ["fix"] });
+  });
+
+  it("writes nothing at all when the last repository is emptied", () => {
+    writeCollapsedFolders("/repos/a", new Set(["feat"]));
+
+    writeCollapsedFolders("/repos/a", new Set());
+
+    expect(raw()).toBeNull();
+  });
+
+  it("has nowhere to store state for a repository that is not open", () => {
+    writeCollapsedFolders(null, new Set(["feat"]));
+
+    expect(raw()).toBeNull();
+    expect(readCollapsedFolders(null)).toEqual(new Set());
+  });
+
+  // A hand-edited or half-written payload must degrade to "nothing collapsed",
+  // never to a screen that throws on mount.
+  it("survives a corrupt payload", () => {
+    localStorage.setItem(BRANCH_FOLDERS_KEY, "{not json");
+
+    expect(readCollapsedFolders("/repos/a")).toEqual(new Set());
+  });
+
+  it("ignores entries that are not a list of strings", () => {
+    localStorage.setItem(
+      BRANCH_FOLDERS_KEY,
+      JSON.stringify({ "/repos/a": ["feat", 7, null, "fix"], "/repos/b": 3 }),
+    );
+
+    expect(readCollapsedFolders("/repos/a")).toEqual(new Set(["feat", "fix"]));
+    expect(readCollapsedFolders("/repos/b")).toEqual(new Set());
+  });
+
+  it("survives a payload that is not an object", () => {
+    localStorage.setItem(BRANCH_FOLDERS_KEY, JSON.stringify(["feat"]));
+
+    expect(readCollapsedFolders("/repos/a")).toEqual(new Set());
+  });
+
+  it("leaves other repositories intact when one is rewritten", () => {
+    writeCollapsedFolders("/repos/a", new Set(["feat"]));
+    writeCollapsedFolders("/repos/b", new Set(["fix"]));
+
+    writeCollapsedFolders("/repos/a", new Set(["feat", "chore"]));
+
+    expect(readCollapsedFolders("/repos/b")).toEqual(new Set(["fix"]));
+  });
+});

--- a/src/features/branches/useBranchFolders.ts
+++ b/src/features/branches/useBranchFolders.ts
@@ -1,0 +1,122 @@
+// Which branch folders a repository has collapsed (#244), persisted like the
+// other per-surface view preferences (`useRebaseMergeMode`): localStorage,
+// best-effort, never fatal.
+//
+// NOT in `useRepoStore`. That store holds exactly one repository's live git
+// state and every field of it has to join `RepoSlice`; this is a view
+// preference that must OUTLIVE the tab, so it is keyed by repository path
+// here and re-read whenever the active repository changes.
+//
+// The stored value is the set of COLLAPSED folders, so the default is expanded:
+// a folder that appears after a fetch shows up without anyone having asked, and
+// a repository the user expanded again leaves no entry behind.
+
+import React from "react";
+
+/** One key for every repository's state — see `useForgeStore`'s host map. */
+export const BRANCH_FOLDERS_KEY = "pg-branch-folders-v1";
+
+type Store = Record<string, string[]>;
+
+function readStore(): Store {
+  try {
+    const raw = localStorage.getItem(BRANCH_FOLDERS_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return parsed as Store;
+  } catch {
+    return {};
+  }
+}
+
+/** The folders `repoPath` has collapsed. Empty for an unknown or absent repo. */
+export function readCollapsedFolders(repoPath: string | null): Set<string> {
+  if (!repoPath) return new Set();
+  const entry = readStore()[repoPath];
+  if (!Array.isArray(entry)) return new Set();
+  return new Set(entry.filter((p): p is string => typeof p === "string"));
+}
+
+/** Persist `collapsed` for `repoPath`, pruning the entry when it is empty. */
+export function writeCollapsedFolders(
+  repoPath: string | null,
+  collapsed: ReadonlySet<string>,
+): void {
+  if (!repoPath) return;
+  try {
+    const store = readStore();
+    if (collapsed.size === 0) delete store[repoPath];
+    else store[repoPath] = [...collapsed];
+    if (Object.keys(store).length === 0) {
+      localStorage.removeItem(BRANCH_FOLDERS_KEY);
+      return;
+    }
+    localStorage.setItem(BRANCH_FOLDERS_KEY, JSON.stringify(store));
+  } catch {
+    // non-fatal — the session just won't remember the folds
+  }
+}
+
+export interface BranchFolders {
+  collapsed: ReadonlySet<string>;
+  toggle: (path: string) => void;
+  /** Collapse exactly these folders, leaving the rest alone. */
+  collapse: (paths: readonly string[]) => void;
+  /** Expand exactly these folders, leaving the rest alone. */
+  expand: (paths: readonly string[]) => void;
+}
+
+export function useBranchFolders(repoPath: string | null): BranchFolders {
+  const [collapsed, setCollapsed] = React.useState<ReadonlySet<string>>(() =>
+    readCollapsedFolders(repoPath),
+  );
+
+  // Re-read on every tab switch. Without this the outgoing repository's folds
+  // would be applied to the incoming one — and then written back under ITS
+  // path on the next click.
+  React.useEffect(() => {
+    setCollapsed(readCollapsedFolders(repoPath));
+  }, [repoPath]);
+
+  // Side effects stay OUT of the state updater: these are single user
+  // gestures, so deriving the next set from the rendered one is safe, and a
+  // localStorage write inside an updater would run twice under StrictMode.
+  const apply = React.useCallback(
+    (next: Set<string>) => {
+      setCollapsed(next);
+      writeCollapsedFolders(repoPath, next);
+    },
+    [repoPath],
+  );
+
+  const toggle = React.useCallback(
+    (path: string) => {
+      const next = new Set(collapsed);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      apply(next);
+    },
+    [collapsed, apply],
+  );
+
+  const collapse = React.useCallback(
+    (paths: readonly string[]) => {
+      const next = new Set(collapsed);
+      for (const p of paths) next.add(p);
+      apply(next);
+    },
+    [collapsed, apply],
+  );
+
+  const expand = React.useCallback(
+    (paths: readonly string[]) => {
+      const next = new Set(collapsed);
+      for (const p of paths) next.delete(p);
+      apply(next);
+    },
+    [collapsed, apply],
+  );
+
+  return { collapsed, toggle, collapse, expand };
+}

--- a/src/features/repo/useRepoStore.deleteBranches.test.ts
+++ b/src/features/repo/useRepoStore.deleteBranches.test.ts
@@ -1,0 +1,104 @@
+// `deleteBranches` — the store half of "delete merged branches in this
+// folder" (#244).
+//
+// A destructive bulk op, so the same two contracts as `deleteUntracked` apply:
+// the branch list is refreshed BEFORE anything is reported (a banner must not
+// point at a list that still shows deleted refs), and the delete is
+// best-effort — two refs that refuse do not decide the fate of the other six.
+//
+// It also refreshes ONCE. Looping `deleteBranch` would have run a full
+// refreshAll — status, branches, tags, stashes, remotes, log — per branch.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { useRepoStore } from "./useRepoStore";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+
+/** The order in which the store touched refresh vs. the error banner. */
+const trace: string[] = [];
+
+function armRepo() {
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    branches: [],
+    error: null,
+    refreshAll: async () => {
+      trace.push("refreshAll");
+    },
+  } as never);
+}
+
+const deleteCalls = () =>
+  getInvokeCalls()
+    .filter((c) => c.cmd === "delete_branch")
+    .map((c) => c.args.name);
+
+beforeEach(() => {
+  trace.length = 0;
+  armRepo();
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("deleteBranches", () => {
+  it("deletes each branch and refreshes exactly once", async () => {
+    mockInvoke("delete_branch", () => null);
+
+    const report = await useRepoStore
+      .getState()
+      .deleteBranches(["feat/a", "feat/b"]);
+
+    expect(deleteCalls()).toEqual(["feat/a", "feat/b"]);
+    expect(report).toEqual({ deleted: ["feat/a", "feat/b"], failed: [] });
+    expect(trace).toEqual(["refreshAll"]);
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("keeps going past a ref that refuses, and reports both halves", async () => {
+    mockInvoke("delete_branch", ({ name }) => {
+      if (name === "feat/b") throw { kind: "Git", message: "cannot lock ref" };
+      return null;
+    });
+
+    const report = await useRepoStore
+      .getState()
+      .deleteBranches(["feat/a", "feat/b", "feat/c"]);
+
+    expect(deleteCalls()).toEqual(["feat/a", "feat/b", "feat/c"]);
+    expect(report).toEqual({ deleted: ["feat/a", "feat/c"], failed: ["feat/b"] });
+  });
+
+  it("refreshes before it reports the failure", async () => {
+    mockInvoke("delete_branch", () => {
+      throw { kind: "Git", message: "nope" };
+    });
+    const unsubscribe = useRepoStore.subscribe((s) => {
+      if (s.error) trace.push("error");
+    });
+
+    await useRepoStore.getState().deleteBranches(["feat/a"]);
+    unsubscribe();
+
+    expect(trace).toEqual(["refreshAll", "error"]);
+    expect(useRepoStore.getState().error).not.toBeNull();
+  });
+
+  it("does nothing at all with no repository open", async () => {
+    useRepoStore.setState({ current: null } as never);
+    mockInvoke("delete_branch", () => null);
+
+    const report = await useRepoStore.getState().deleteBranches(["feat/a"]);
+
+    expect(report).toEqual({ deleted: [], failed: [] });
+    expect(deleteCalls()).toEqual([]);
+    expect(trace).toEqual([]);
+  });
+
+  it("still refreshes when handed an empty list", async () => {
+    const report = await useRepoStore.getState().deleteBranches([]);
+
+    expect(report).toEqual({ deleted: [], failed: [] });
+    expect(deleteCalls()).toEqual([]);
+    expect(trace).toEqual(["refreshAll"]);
+  });
+});

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -288,6 +288,14 @@ interface RepoStoreState extends RepoSlice {
     opts?: { from?: string; autoStash?: boolean },
   ) => Promise<boolean>;
   deleteBranch: (name: string, force?: boolean) => Promise<void>;
+  /**
+   * Delete several local branches, refreshing ONCE (#244). Best-effort: two
+   * refs that refuse do not decide the fate of the other six, so the report
+   * names both halves — see `summarizeDeleteMerged`.
+   */
+  deleteBranches: (
+    names: readonly string[],
+  ) => Promise<{ deleted: string[]; failed: string[] }>;
   renameBranch: (from: string, to: string) => Promise<void>;
   /** Set (`"origin/main"`) or clear (`null`) a local branch's upstream. */
   setUpstream: (branch: string, upstream: string | null) => Promise<void>;
@@ -1367,6 +1375,28 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
       return;
     }
     await get().refreshAll();
+  },
+
+  async deleteBranches(names) {
+    const repo = get().current;
+    if (!repo) return { deleted: [], failed: [] };
+    const deleted: string[] = [];
+    const failed: string[] = [];
+    let firstError: unknown = null;
+    for (const name of names) {
+      try {
+        await deleteBranch(repo.id, name);
+        deleted.push(name);
+      } catch (e) {
+        failed.push(name);
+        firstError ??= e;
+      }
+    }
+    // Refresh FIRST, then report — the branch list must already match reality
+    // by the time an error banner points at it.
+    await get().refreshAll();
+    if (firstError) setErrorFor(repo.id, firstError);
+    return { deleted, failed };
   },
 
   async renameBranch(from, to) {

--- a/src/screens/Branches.folders.test.tsx
+++ b/src/screens/Branches.folders.test.tsx
@@ -1,0 +1,269 @@
+// The Branches screen's folder tree (#244).
+//
+// The pure grouping lives in `features/branches/branchTree.ts` and is tested
+// there; this covers the wiring the tree cannot see — what a click folds, what
+// survives a filter, and that the keyboard list still walks every rendered row.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { BranchesScreen } from "./Branches";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useKeymapStore, useFocusStore } from "@/features/keymap";
+import { mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { WithDialogs, resetDialogs } from "@/test/dialog";
+import { BRANCH_FOLDERS_KEY } from "@/features/branches/useBranchFolders";
+import type { BranchInfo } from "@/lib/types";
+
+const mkBranch = (over: Partial<BranchInfo> & { name: string }): BranchInfo => ({
+  isHead: false,
+  isRemote: false,
+  upstream: null,
+  ahead: 0,
+  behind: 0,
+  tip: "0".repeat(40),
+  tipTime: 0,
+  isDefault: false,
+  ...over,
+});
+
+const BRANCHES = [
+  mkBranch({ name: "main", tipTime: 10, isDefault: true }),
+  mkBranch({ name: "feat/alpha", tipTime: 900 }),
+  mkBranch({ name: "feat/beta", tipTime: 800 }),
+  mkBranch({ name: "release/1.0/rc", tipTime: 700 }),
+  mkBranch({ name: "chore/deps", tipTime: 600, isHead: true }),
+  mkBranch({ name: "chore/lint", tipTime: 500 }),
+];
+
+const key = (k: string) =>
+  ({
+    key: k,
+    code: "",
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    preventDefault() {},
+    target: document.body,
+  }) as unknown as KeyboardEvent;
+
+function press(k: string): void {
+  act(() => {
+    useKeymapStore.getState().dispatch(key(k));
+  });
+}
+
+const branchNames = () =>
+  Array.from(document.querySelectorAll('[data-testid="branch-row"]')).map(
+    (el) => el.querySelector("[data-branch-label]")?.textContent ?? "",
+  );
+
+const folderPaths = () =>
+  Array.from(
+    document.querySelectorAll('[data-testid="branch-folder-row"]'),
+  ).map((el) => el.getAttribute("data-folder") ?? "");
+
+const folderRow = (path: string) =>
+  document.querySelector(`[data-folder="${path}"]`) as HTMLElement;
+
+function setup(branches = BRANCHES) {
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/chore/deps" },
+    status: [],
+    branches,
+    remotes: [],
+    tags: [],
+    stashes: [],
+    commits: [],
+    loading: false,
+    checkoutBranch: async () => {},
+  } as never);
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => branches);
+  render(
+    <WithDialogs>
+      <BranchesScreen />
+    </WithDialogs>,
+  );
+  useFocusStore.setState({ focused: "branches.list" });
+}
+
+describe("Branches folder tree", () => {
+  beforeEach(() => {
+    resetInvokeMock();
+    resetDialogs();
+    localStorage.clear();
+    useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+    useKeymapStore.getState().setPreset("rider");
+    useFocusStore.setState({
+      focused: null,
+      panes: new Map(),
+      order: [],
+      barId: null,
+      pendingContentFocus: false,
+    });
+  });
+
+  it("groups branches that share a prefix and leaves lone ones whole", () => {
+    setup();
+
+    expect(folderPaths()).toEqual(["feat", "chore"]);
+    // `release/1.0/rc` groups nothing, so it keeps its full name and no folder.
+    expect(branchNames()).toEqual([
+      "main",
+      "alpha",
+      "beta",
+      "release/1.0/rc",
+      "deps",
+      "lint",
+    ]);
+  });
+
+  // Grouping runs AFTER `orderBranches`, so #135's pin still holds: the
+  // default branch is the first row on the screen, not the first row inside
+  // some folder.
+  it("keeps the default branch pinned above every folder", () => {
+    setup();
+
+    const rows = Array.from(document.querySelectorAll("[data-pg-row]"));
+    expect(rows[0].getAttribute("data-testid")).toBe("branch-row");
+    expect(rows[0].querySelector("[data-branch-label]")?.textContent).toBe(
+      "main",
+    );
+  });
+
+  it("folds a folder away when its row is clicked, and back", () => {
+    setup();
+
+    fireEvent.click(folderRow("feat"));
+    expect(branchNames()).not.toContain("alpha");
+    expect(folderPaths()).toEqual(["feat", "chore"]);
+
+    fireEvent.click(folderRow("feat"));
+    expect(branchNames()).toContain("alpha");
+  });
+
+  it("remembers the fold across a remount, per repository", () => {
+    setup();
+    fireEvent.click(folderRow("feat"));
+
+    expect(JSON.parse(localStorage.getItem(BRANCH_FOLDERS_KEY) ?? "{}")).toEqual(
+      { "/repo": ["feat"] },
+    );
+
+    cleanupAndRemount();
+    expect(branchNames()).not.toContain("alpha");
+  });
+
+  // A search box that hides a hit behind a folded folder is broken, so a filter
+  // flattens the tree — and the rows then carry their full names, because a
+  // bare `alpha` with no `feat` above it names nothing.
+  it("flattens to full names while a filter is typed", () => {
+    setup();
+    fireEvent.click(folderRow("feat"));
+
+    fireEvent.change(screen.getByPlaceholderText("Filter by name…"), {
+      target: { value: "a" },
+    });
+
+    expect(folderPaths()).toEqual([]);
+    expect(branchNames()).toContain("feat/alpha");
+    expect(branchNames()).toContain("feat/beta");
+  });
+
+  it("restores the tree, folds and all, when the filter is cleared", () => {
+    setup();
+    fireEvent.click(folderRow("feat"));
+    const input = screen.getByPlaceholderText("Filter by name…");
+
+    fireEvent.change(input, { target: { value: "a" } });
+    fireEvent.change(input, { target: { value: "" } });
+
+    expect(folderPaths()).toEqual(["feat", "chore"]);
+    expect(branchNames()).not.toContain("alpha");
+  });
+
+  it("walks folder rows with the rest of the list", () => {
+    setup();
+
+    press("ArrowDown"); // main
+    press("ArrowDown"); // feat/ folder
+
+    expect(folderRow("feat").getAttribute("data-selected")).toBe("");
+  });
+
+  it("collapses and expands the selected folder with ← and →", () => {
+    setup();
+
+    press("ArrowDown");
+    press("ArrowDown");
+    press("ArrowLeft");
+
+    expect(branchNames()).not.toContain("alpha");
+
+    press("ArrowRight");
+    expect(branchNames()).toContain("alpha");
+  });
+
+  // Folding the folder the selection sits inside would otherwise leave the
+  // keyboard list pointing at a row that is no longer rendered.
+  it("moves the selection up to the folder it folded away", () => {
+    setup();
+
+    press("ArrowDown"); // main
+    press("ArrowDown"); // feat/
+    press("ArrowDown"); // alpha
+    press("ArrowLeft"); // climb out to feat/
+    press("ArrowLeft"); // fold it
+
+    expect(branchNames()).not.toContain("alpha");
+    expect(folderRow("feat").getAttribute("data-selected")).toBe("");
+  });
+
+  it("folds every folder at once from the toolbar, and unfolds them", () => {
+    setup();
+
+    fireEvent.click(screen.getByTitle(/Collapse all branch folders/));
+    expect(branchNames()).toEqual(["main", "release/1.0/rc"]);
+
+    fireEvent.click(screen.getByTitle(/Expand all branch folders/));
+    expect(branchNames()).toContain("alpha");
+  });
+
+  it("offers no fold-all control in a repository with no folders", () => {
+    setup([mkBranch({ name: "main", isDefault: true }), mkBranch({ name: "wip" })]);
+
+    expect(screen.queryByTitle(/branch folders/)).toBeNull();
+  });
+
+  // Folding a folder must not hide where you are standing.
+  it("marks a folded folder that holds the current branch", () => {
+    setup();
+
+    expect(folderRow("chore").querySelector("[data-holds-head]")).toBeNull();
+
+    fireEvent.click(folderRow("chore"));
+
+    expect(folderRow("chore").querySelector("[data-holds-head]")).not.toBeNull();
+    expect(folderRow("feat").querySelector("[data-holds-head]")).toBeNull();
+  });
+
+  it("describes the selected folder in the inspector", () => {
+    setup();
+
+    fireEvent.click(folderRow("feat"));
+
+    expect(screen.getByText("feat/")).toBeTruthy();
+    expect(screen.getByText("Delete merged branches…")).toBeTruthy();
+  });
+});
+
+/** Re-render the screen from scratch, as a tab switch or restart would. */
+function cleanupAndRemount(): void {
+  document.body.innerHTML = "";
+  render(
+    <WithDialogs>
+      <BranchesScreen />
+    </WithDialogs>,
+  );
+}

--- a/src/screens/Branches.tsx
+++ b/src/screens/Branches.tsx
@@ -27,6 +27,19 @@ import {
 import { useElementSize } from "@/lib/useElementSize";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { orderBranches } from "@/features/branches/orderBranches";
+import {
+  branchFolderPaths,
+  branchTreeRows,
+  branchesInFolder,
+  parentFolderPath,
+  type BranchTreeRow,
+} from "@/features/branches/branchTree";
+import { useBranchFolders } from "@/features/branches/useBranchFolders";
+import {
+  deleteMergedCandidates,
+  findMergedBranches,
+  summarizeDeleteMerged,
+} from "@/features/branches/deleteMerged";
 import { summarizeFastForward } from "@/features/branches/fastForward";
 import { TagSignatureBadge } from "@/features/signing/TagSignatureBadge";
 import { PGPane, FocusableScroll, usePaneList } from "@/features/keymap";
@@ -36,8 +49,23 @@ import { shortSha } from "@/lib/derive";
 
 type Selection =
   | { kind: "branch"; name: string }
+  | { kind: "folder"; path: string }
   | { kind: "tag"; name: string }
   | { kind: "stash"; index: number };
+
+/** Two selections pointing at the same row. */
+function sameRef(a: Selection, b: Selection): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "stash") return b.kind === "stash" && a.index === b.index;
+  if (a.kind === "folder") return b.kind === "folder" && a.path === b.path;
+  return b.kind !== "stash" && b.kind !== "folder" && a.name === b.name;
+}
+
+/** Row = one branch, carrying which list it came from. */
+type BranchRow = BranchInfo & { kind: "local" | "remote" };
+
+/** Pixels a nesting level indents the NAME cell by. */
+const INDENT = 14;
 
 const COLS = [
   { key: "icon", label: "", initial: 20, min: 20, resizable: false },
@@ -50,6 +78,7 @@ const COLS = [
 
 export function BranchesScreen() {
   const branches = useRepoStore((s) => s.branches);
+  const repoPath = useRepoStore((s) => s.current?.path ?? null);
   const tags = useRepoStore((s) => s.tags);
   const stashes = useRepoStore((s) => s.stashes);
   const activity = useRepoStore((s) => s.activity);
@@ -58,6 +87,7 @@ export function BranchesScreen() {
   const createAndSwitchBranch = useRepoStore((s) => s.createAndSwitchBranch);
   const [selection, setSelection] = React.useState<Selection | null>(null);
   const [filter, setFilter] = React.useState("");
+  const folders = useBranchFolders(repoPath);
   const [view, setView] = React.useState<
     "all" | "local" | "remote" | "tags" | "stashes"
   >("all");
@@ -89,6 +119,64 @@ export function BranchesScreen() {
     setSelection(null);
   }, [view]);
 
+  /**
+   * The bulk delete the flat list made tedious (#244). "Merged" is git's own
+   * definition — contained in HEAD, like `git branch --merged` — and the
+   * confirm says so, because it is the one thing that decides what goes.
+   *
+   * The merge check runs on demand, never per render: it is one `ahead_behind`
+   * per candidate, and the list of forty branches this exists for would pay
+   * for it on every refresh.
+   */
+  const deleteMergedInFolder = async (path: string) => {
+    const repo = useRepoStore.getState().current;
+    if (!repo) return;
+    const candidates = deleteMergedCandidates(branches, path);
+    if (candidates.length === 0) {
+      pgFlash(`No deletable local branches in ${path}/`);
+      return;
+    }
+    const merged = await findMergedBranches(repo.id, "HEAD", candidates);
+    if (merged.length === 0) {
+      pgFlash(`Nothing in ${path}/ is merged into HEAD`);
+      return;
+    }
+    const names = merged.map((b) => b.name);
+    const ok = await pgConfirm({
+      title:
+        names.length === 1
+          ? `Delete ${names[0]}?`
+          : `Delete ${names.length} merged branches in ${path}/?`,
+      // Named in full and scrolled, never counted: this deletes refs, and
+      // "8 branches" is not something anyone can check before clicking Delete.
+      body: (
+        <>
+          <div>
+            Every commit on {names.length === 1 ? "it is" : "them is"} already
+            contained in HEAD.
+          </div>
+          <div
+            className="mono"
+            style={{
+              marginTop: 8,
+              maxHeight: 180,
+              overflow: "auto",
+              whiteSpace: "pre",
+              fontSize: "var(--fs-12)",
+            }}
+          >
+            {names.join("\n")}
+          </div>
+        </>
+      ),
+      confirmLabel: "Delete",
+      danger: true,
+    });
+    if (!ok) return;
+    const report = await useRepoStore.getState().deleteBranches(names);
+    pgFlash(summarizeDeleteMerged(report.deleted, report.failed));
+  };
+
   const { onContextMenu: onBranchCtx, menu: branchMenu } = useContextMenu<
     BranchInfo & { kind: "local" | "remote" }
   >((b) =>
@@ -100,6 +188,48 @@ export function BranchesScreen() {
           upstream: b?.upstream,
         }),
   );
+  // Built here rather than in `design/context-menu.tsx` like the ref menus: the
+  // useful folder actions are fold state and a bulk delete scoped to the rows
+  // ON SCREEN, none of which exist outside this screen.
+  const { onContextMenu: onFolderCtx, menu: folderMenu } = useContextMenu<{
+    path: string;
+    count: number;
+  }>((f) => {
+    const path = f?.path ?? "";
+    // The folder itself comes back from the walk — drop it, so "Expand all"
+    // can tell "nothing nested here" from "there is more to open".
+    const inside = branchFolderPaths(branchesInFolder(rows, path)).filter(
+      (p) => p !== path,
+    );
+    return [
+      { __menuTitle: `${path}/` },
+      {
+        icon: "chevronDown",
+        label: "Expand all",
+        disabled: !inside.length && !folders.collapsed.has(path),
+        onClick: () => folders.expand([path, ...inside]),
+      },
+      {
+        icon: "chevronRight",
+        label: "Collapse all",
+        onClick: () => {
+          folders.collapse([path, ...inside]);
+          if (
+            selection?.kind === "branch" &&
+            selection.name.startsWith(`${path}/`)
+          )
+            setSelection({ kind: "folder", path });
+        },
+      },
+      { divider: true },
+      {
+        icon: "trash",
+        label: "Delete merged branches…",
+        danger: true,
+        onClick: () => deleteMergedInFolder(path),
+      },
+    ];
+  });
   const { onContextMenu: onTagCtx, menu: tagMenu } = useContextMenu<TagInfo>(
     (t) => tagMenuItems({ name: t?.name, sha: t?.shortOid, oid: t?.oid }),
   );
@@ -146,9 +276,9 @@ export function BranchesScreen() {
     document.body.style.userSelect = "none";
   };
 
-  const rows = React.useMemo(() => {
+  const rows = React.useMemo<BranchRow[]>(() => {
     if (view === "tags" || view === "stashes") return [];
-    const list = branches.map((b) => ({
+    const list: BranchRow[] = branches.map((b) => ({
       ...b,
       kind: b.isRemote ? ("remote" as const) : ("local" as const),
     }));
@@ -163,6 +293,27 @@ export function BranchesScreen() {
     if (view === "remote") return remotes;
     return [...locals, ...remotes];
   }, [branches, filter, view]);
+
+  // Grouping is the LAST step (#244): filter, order (#135), then group. It only
+  // moves rows into folders, so the pinned default and the newest-first order
+  // both survive — and a filtered-out branch cannot reappear inside a folder.
+  //
+  // A filter flattens the tree to its matches, as filters should: hiding a hit
+  // behind a folded folder is the one thing a search box must never do. Rows
+  // then show their FULL names, because a bare `bar` with no `feat/foo` above
+  // it names nothing.
+  const filtering = filter.length > 0;
+  const displayRows = React.useMemo<BranchTreeRow<BranchRow>[]>(() => {
+    if (filtering)
+      return rows.map((b) => ({
+        kind: "branch" as const,
+        path: b.name,
+        label: b.name,
+        depth: 0,
+        branch: b,
+      }));
+    return branchTreeRows(rows, folders.collapsed);
+  }, [rows, filtering, folders.collapsed]);
 
   const visibleTags = React.useMemo(() => {
     if (view === "stashes") return [];
@@ -184,11 +335,15 @@ export function BranchesScreen() {
   // stashes). Enter checks out the selected local branch.
   const flatRefs = React.useMemo<Selection[]>(
     () => [
-      ...rows.map((b) => ({ kind: "branch" as const, name: b.name })),
+      ...displayRows.map((r) =>
+        r.kind === "folder"
+          ? ({ kind: "folder", path: r.path } as const)
+          : ({ kind: "branch", name: r.path } as const),
+      ),
       ...visibleTags.map((t) => ({ kind: "tag" as const, name: t.name })),
       ...visibleStashes.map((s) => ({ kind: "stash" as const, index: s.index })),
     ],
-    [rows, visibleTags, visibleStashes],
+    [displayRows, visibleTags, visibleStashes],
   );
   // -1 when nothing is selected, and it must STAY -1: this used to clamp to 0,
   // so `list.activate` checked out row 0 while no row had ever appeared
@@ -197,14 +352,21 @@ export function BranchesScreen() {
   // whatever sorted first, which since #135 is the pinned default branch.
   // `usePaneList` handles -1: arrowing either way lands on row 0, and
   // `onActivate(-1)` reads past the end of `flatRefs` and no-ops.
-  const flatIndex = flatRefs.findIndex(
-    (r) =>
-      selection &&
-      r.kind === selection.kind &&
-      (r.kind === "stash"
-        ? selection.kind === "stash" && r.index === selection.index
-        : selection.kind !== "stash" && r.name === selection.name),
-  );
+  const flatIndex = flatRefs.findIndex((r) => selection && sameRef(r, selection));
+
+  // Collapsing a folder can hide the selected branch. Moving the selection onto
+  // the folder keeps `flatIndex` pointing at a rendered row — otherwise it goes
+  // to -1 and the next ArrowDown restarts at the top of the list.
+  const collapseFolder = (path: string) => {
+    folders.collapse([path]);
+    if (selection?.kind === "branch" && selection.name.startsWith(`${path}/`))
+      setSelection({ kind: "folder", path });
+  };
+  const toggleFolder = (path: string) => {
+    if (folders.collapsed.has(path)) folders.expand([path]);
+    else collapseFolder(path);
+  };
+
   usePaneList({
     paneId: "branches.list",
     count: flatRefs.length,
@@ -215,16 +377,36 @@ export function BranchesScreen() {
     },
     onActivate: (i) => {
       const r = flatRefs[i];
+      if (r?.kind === "folder") {
+        toggleFolder(r.path);
+        return;
+      }
       if (r?.kind !== "branch") return;
       const b = branches.find((x) => x.name === r.name);
       if (b && !b.isHead && !b.isRemote) {
         void useRepoStore.getState().checkoutBranch(b.name);
       }
     },
+    onExpand: (i) => {
+      const r = flatRefs[i];
+      if (r?.kind === "folder") folders.expand([r.path]);
+    },
+    // ← on an open folder folds it; on anything else it climbs to the folder
+    // the row sits in, which is what every other tree does.
+    onCollapse: (i) => {
+      const r = flatRefs[i];
+      if (r?.kind === "folder" && !folders.collapsed.has(r.path)) {
+        collapseFolder(r.path);
+        return;
+      }
+      const parent = parentFolderPath(displayRows, i);
+      if (parent) setSelection({ kind: "folder", path: parent });
+    },
     searchText: (i) => {
       const r = flatRefs[i];
       if (!r) return "";
-      return r.kind === "stash" ? `stash@{${r.index}}` : r.name;
+      if (r.kind === "stash") return `stash@{${r.index}}`;
+      return r.kind === "folder" ? r.path : r.name;
     },
   });
 
@@ -240,6 +422,29 @@ export function BranchesScreen() {
     selection?.kind === "stash"
       ? stashes.find((s) => s.index === selection.index) ?? null
       : null;
+  const selectedFolder = selection?.kind === "folder" ? selection.path : null;
+
+  // One click for the whole tree: forty rows become five folders, which is the
+  // point of grouping them at all. Hidden while a filter is flattening the
+  // tree, where there is nothing to fold.
+  const allFolders = React.useMemo(() => branchFolderPaths(rows), [rows]);
+  const allCollapsed =
+    allFolders.length > 0 && allFolders.every((p) => folders.collapsed.has(p));
+  const toggleAllFolders = () => {
+    if (allCollapsed) {
+      folders.expand(allFolders);
+      return;
+    }
+    folders.collapse(allFolders);
+    // The selected branch is about to be hidden — move up to the outermost
+    // folder holding it, which is the row that stays on screen.
+    if (selection?.kind === "branch") {
+      const holding = allFolders
+        .filter((p) => selection.name.startsWith(`${p}/`))
+        .sort((a, b) => a.length - b.length)[0];
+      setSelection(holding ? { kind: "folder", path: holding } : selection);
+    }
+  };
 
   const cellStyle: CSSProperties = {
     minWidth: 0,
@@ -264,6 +469,9 @@ export function BranchesScreen() {
           onFetchAll={fetchAllOp}
           onFastForwardAll={startFastForwardAll}
           fetching={!!activity.fetch}
+          folderCount={0}
+          allFoldersCollapsed={false}
+          onToggleAllFolders={toggleAllFolders}
         />
         <PGEmpty icon="branch" title="No branches, tags, or stashes">
           This repository doesn&apos;t have any branches, tags, or stashes yet.
@@ -283,6 +491,9 @@ export function BranchesScreen() {
         onFetchAll={fetchAllOp}
         onFastForwardAll={startFastForwardAll}
         fetching={!!activity.fetch}
+        folderCount={filtering ? 0 : allFolders.length}
+        allFoldersCollapsed={allCollapsed}
+        onToggleAllFolders={toggleAllFolders}
       />
       <div ref={layout.ref} style={{ flex: 1, minHeight: 0, display: "flex" }}>
         <PGPane
@@ -347,7 +558,142 @@ export function BranchesScreen() {
                 </div>
               ))}
             </div>
-            {rows.map((b, i) => (
+            {displayRows.map((row, i) => {
+              if (row.kind === "folder") {
+                const selected =
+                  selection?.kind === "folder" && selection.path === row.path;
+                // Folding a folder must not hide WHERE YOU ARE. Marked only
+                // while collapsed: open, the HEAD row carries its own accent
+                // bar, and a second marker above it would just be noise.
+                const holdsHead =
+                  row.collapsed &&
+                  branchesInFolder(rows, row.path).some(
+                    (b) => b.isHead && !b.isRemote,
+                  );
+                const openFolderMenu = (e: React.MouseEvent) => {
+                  setSelection({ kind: "folder", path: row.path });
+                  onFolderCtx(e, { path: row.path, count: row.count });
+                };
+                return (
+                  <div
+                    key={`folder:${row.path}`}
+                    // The whole row folds, not just the chevron — unlike
+                    // `PGFileTreeRow`, where a folder row is a thing you select
+                    // and act on. A branch folder is not a git object; folding
+                    // is the only reason it is on screen, so it gets the
+                    // easiest target. Right-click and ⋯ select without folding.
+                    onClick={() => {
+                      setSelection({ kind: "folder", path: row.path });
+                      toggleFolder(row.path);
+                    }}
+                    onContextMenu={openFolderMenu}
+                    data-pg-row=""
+                    data-testid="branch-folder-row"
+                    data-folder={row.path}
+                    data-collapsed={row.collapsed ? "" : undefined}
+                    data-selected={selected ? "" : undefined}
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: gridTemplate,
+                      alignItems: "center",
+                      height: "calc(28px + var(--row-step))",
+                      background: selected
+                        ? undefined
+                        : i % 2
+                          ? "var(--bg-1)"
+                          : "transparent",
+                      borderBottom: "1px solid oklch(0.22 0.008 260 / 0.3)",
+                      cursor: "pointer",
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "var(--fs-12)",
+                      // A folder row is a control, not text: a stray drag
+                      // across it must not select "feat (12)".
+                      userSelect: "none",
+                      position: "relative",
+                    }}
+                  >
+                    {holdsHead && (
+                      <span
+                        data-holds-head=""
+                        style={{
+                          position: "absolute",
+                          left: 0,
+                          top: 0,
+                          bottom: 0,
+                          width: 2,
+                          background: "var(--accent)",
+                          zIndex: 1,
+                        }}
+                      />
+                    )}
+                    <div
+                      style={{
+                        ...cellStyle,
+                        justifyContent: "center",
+                        padding: 0,
+                      }}
+                    >
+                      <PGIcon
+                        name={row.collapsed ? "folder" : "folderOpen"}
+                        size={12}
+                        style={{
+                          color: holdsHead ? "var(--accent)" : "var(--fg-2)",
+                        }}
+                      />
+                    </div>
+                    <div
+                      style={{
+                        ...cellStyle,
+                        paddingLeft: 8 + row.depth * INDENT,
+                      }}
+                      title={
+                        holdsHead
+                          ? `${row.path}/ — holds the current branch`
+                          : `${row.path}/`
+                      }
+                    >
+                      <PGIcon
+                        name={row.collapsed ? "chevronRight" : "chevronDown"}
+                        size={10}
+                        style={{ color: "var(--fg-3)", flexShrink: 0 }}
+                      />
+                      <span
+                        style={{
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {row.label}
+                      </span>
+                      <span style={{ color: "var(--fg-3)" }}>({row.count})</span>
+                    </div>
+                    <div style={cellStyle} />
+                    <div style={cellStyle} />
+                    <div style={cellStyle} />
+                    <div
+                      style={{
+                        ...cellStyle,
+                        justifyContent: "center",
+                        padding: 0,
+                      }}
+                    >
+                      <PGIconButton
+                        icon="more"
+                        size="sm"
+                        title="Folder actions"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          openFolderMenu(e);
+                        }}
+                      />
+                    </div>
+                  </div>
+                );
+              }
+
+              const b = row.branch;
+              return (
               <div
                 key={`${b.kind}:${b.name}`}
                 onClick={() => setSelection({ kind: "branch", name: b.name })}
@@ -404,18 +750,25 @@ export function BranchesScreen() {
                 <div
                   style={{
                     ...cellStyle,
+                    // Indented in the NAME cell, never on the row: tip,
+                    // upstream and status stay on the grid at any depth. The
+                    // extra 10px is the width of the chevron a folder row
+                    // spends there, so nested labels line up under it.
+                    paddingLeft:
+                      8 + row.depth * INDENT + (row.depth > 0 ? 10 : 0),
                     color: b.isHead ? "var(--accent)" : "var(--fg-0)",
                   }}
                   title={b.name}
                 >
                   <span
+                    data-branch-label=""
                     style={{
                       overflow: "hidden",
                       textOverflow: "ellipsis",
                       whiteSpace: "nowrap",
                     }}
                   >
-                    {b.name}
+                    {row.label}
                   </span>
                   {b.isHead && <PGBadge tone="accent">HEAD</PGBadge>}
                   {b.kind === "remote" && <PGBadge tone="muted">remote</PGBadge>}
@@ -471,7 +824,8 @@ export function BranchesScreen() {
                   />
                 </div>
               </div>
-            ))}
+              );
+            })}
 
             {visibleTags.length > 0 && (
               <div
@@ -685,6 +1039,12 @@ export function BranchesScreen() {
               {selection?.kind?.toUpperCase() ?? "REF"}
             </div>
             {selectedBranch && <BranchInspector branch={selectedBranch} />}
+            {selectedFolder !== null && (
+              <FolderInspector
+                path={selectedFolder}
+                branches={branchesInFolder(rows, selectedFolder)}
+              />
+            )}
             {selectedTag && <TagInspector tag={selectedTag} />}
             {selectedStash && <StashInspector stash={selectedStash} />}
             {!selection && (
@@ -695,12 +1055,21 @@ export function BranchesScreen() {
           </div>
           <div style={{ padding: 12, display: "flex", flexDirection: "column", gap: 6 }}>
             {selectedBranch && <BranchActions branch={selectedBranch} />}
+            {selectedFolder !== null && (
+              <FolderActions
+                path={selectedFolder}
+                collapsed={folders.collapsed.has(selectedFolder)}
+                onToggle={() => toggleFolder(selectedFolder)}
+                onDeleteMerged={() => void deleteMergedInFolder(selectedFolder)}
+              />
+            )}
             {selectedTag && <TagActions tag={selectedTag} />}
             {selectedStash && <StashActions stash={selectedStash} />}
           </div>
         </PGPane>
       </div>
       {branchMenu}
+      {folderMenu}
       {tagMenu}
       {stashMenu}
     </>
@@ -716,6 +1085,9 @@ function BranchesToolbar({
   onFetchAll,
   onFastForwardAll,
   fetching,
+  folderCount,
+  allFoldersCollapsed,
+  onToggleAllFolders,
 }: {
   filter: string;
   onFilter: (v: string) => void;
@@ -725,6 +1097,9 @@ function BranchesToolbar({
   onFetchAll: () => void;
   onFastForwardAll: () => void;
   fetching: boolean;
+  folderCount: number;
+  allFoldersCollapsed: boolean;
+  onToggleAllFolders: () => void;
 }) {
   return (
     <PGToolbar
@@ -747,6 +1122,17 @@ function BranchesToolbar({
               { value: "stashes", label: "Stashes" },
             ]}
           />
+          {folderCount > 0 && (
+            <PGIconButton
+              icon={allFoldersCollapsed ? "chevronDown" : "chevronRight"}
+              title={
+                allFoldersCollapsed
+                  ? "Expand all branch folders"
+                  : "Collapse all branch folders"
+              }
+              onClick={onToggleAllFolders}
+            />
+          )}
         </>
       }
       right={
@@ -946,6 +1332,88 @@ export async function promptUpstream(branch: BranchInfo) {
   await useRepoStore
     .getState()
     .setUpstream(branch.name, trimmed === "" ? null : trimmed);
+}
+
+/**
+ * A folder is a name prefix, not a git object — so the inspector says what the
+ * prefix holds rather than pretending there is an object to describe.
+ */
+function FolderInspector({
+  path,
+  branches,
+}: {
+  path: string;
+  branches: readonly BranchRow[];
+}) {
+  const local = branches.filter((b) => b.kind === "local").length;
+  return (
+    <>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          marginBottom: 8,
+          minWidth: 0,
+        }}
+      >
+        <PGIcon
+          name="folderOpen"
+          size={14}
+          style={{ color: "var(--fg-2)", flexShrink: 0 }}
+        />
+        <span
+          title={`${path}/`}
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "var(--fs-14)",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {path}/
+        </span>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        <KV k="Branches" v={String(branches.length)} />
+        <KV k="Local" v={String(local)} />
+        <KV k="Remote" v={String(branches.length - local)} />
+      </div>
+    </>
+  );
+}
+
+function FolderActions({
+  path,
+  collapsed,
+  onToggle,
+  onDeleteMerged,
+}: {
+  path: string;
+  collapsed: boolean;
+  onToggle: () => void;
+  onDeleteMerged: () => void;
+}) {
+  return (
+    <>
+      <PGButton
+        variant="outline"
+        icon={collapsed ? "chevronDown" : "chevronRight"}
+        onClick={onToggle}
+      >
+        {collapsed ? "Expand" : "Collapse"}
+      </PGButton>
+      <PGButton
+        variant="outline"
+        icon="trash"
+        title={`Delete every local branch under ${path}/ already contained in HEAD`}
+        onClick={onDeleteMerged}
+      >
+        Delete merged branches…
+      </PGButton>
+    </>
+  );
 }
 
 function TagInspector({ tag }: { tag: TagInfo }) {


### PR DESCRIPTION
## What does this PR do?

Every team names branches `feat/…`, `fix/…`, `release/…`, `jonas/…`, so a
forty-branch repository rendered as forty flat rows with nothing to collapse.
The Branches screen now groups them into a collapsible tree.

- **Folders on `/`, arbitrarily deep**, with single-child chains compressed.
- **Fold state persists per repository**, and the whole tree folds from one
  toolbar button.
- **A filter flattens the tree to its matches**, showing full names.
- **Keyboard**: folder rows join the list; Enter toggles, → expands, ← folds an
  open folder or climbs out of the row's folder.
- **Folder context menu + inspector**, including the operation the flat list
  made tedious: **Delete merged branches…**

## Grouping is the LAST step, and that is the whole safety argument

Filter → order (`orderBranches`, #135) → group. `branchTree.ts` **only moves
ordered rows into folders; it never sorts.** So the pinned default branch is
still the first row on the screen rather than the first row inside some folder,
and the newest-first order holds inside every folder. `orderBranches.test.ts` is
untouched and still passes, which is the point.

A folder ranks where its **first** (freshest) branch was — first touch of an
insertion-ordered map — so a folder of stale branches sinks below a fresh loose
one, exactly as a flat recency list would have put them.

## A prefix that groups nothing is not a folder

A lone `feat/foo/bar` is **one row reading `feat/foo/bar`**, not three nested
ones — the same compression `lib/tree.ts::compactNode` already applies to file
paths, and the reason `branchFolderPaths` names compressed paths (`feat/foo`)
rather than one per segment: "collapse all" would otherwise write folder keys
that no row uses.

The other end of that rule: git refuses to create both `feat` and `feat/a`, so a
node holding a branch *and* children cannot come from a repository — but it
renders both rows anyway. Costing one extra row beats silently dropping a branch
that does exist.

## The tree output is FLAT

Rows carry their own `depth`. The screen keeps its grid, its `usePaneList`
index and its selection model; a nested render would have needed all three
rewritten. Indentation lives in the **NAME cell only**, so TIP / UPSTREAM /
STATUS stay on the grid at any depth, and folder rows use
`calc(28px + var(--row-step))` like every other row surface.

## Fold state: the exceptions, per repository, outside the store

`pg-branch-folders-v1` holds the set of **COLLAPSED** paths per repository path.
Storing the exceptions means a folder that appears after a fetch is visible
without anyone having said so, and a repository the user expanded again leaves
no entry behind — the key self-prunes.

Deliberately **not** in `useRepoStore`: that holds exactly one repository's live
git state and every field of it has to join `RepoSlice`, whereas this has to
*outlive* the tab. It is re-read on every repository change, or one tab's folds
would be written back under another tab's path.

## Two things the fold could have hidden, and doesn't

- **Where you are standing.** A folded folder containing HEAD is marked with the
  accent bar. Only while folded — open, the HEAD row carries its own.
- **A search hit.** A filter flattens the tree rather than folding matches away.
  Rows then show full names, because a bare `bar` with no `feat/foo` above it
  names nothing.

Folding the folder the selection sits in also **moves the selection onto that
folder**, so `flatIndex` never points at an unrendered row (it would go to -1,
and the next ArrowDown would restart at the top of the list).

## Delete merged branches: git's own definition, stated in the confirm

"Merged" means **contained in HEAD** — `git branch --merged` — and the dialog
says so, because that is the one thing deciding what goes. Never a remote
(deleting one is a *push*, and a menu click must not reach across the network),
never HEAD, and never the default branch **even when it lives in a folder**: it
is contained in HEAD for half a repository's life, so "merged" would happily
delete `trunk/main`.

The check is one `ahead_behind` per candidate, run **on demand and
sequentially** — the backend serializes per-repository work behind one mutex, so
firing forty at once only queues them — and never per render. A branch it cannot
ask about is reported **unmerged**, the safe direction; one unreadable ref does
not abandon the other thirty-nine.

The confirm **names every branch** in a scrolling list rather than counting
them: "8 branches" is not something anyone can check before clicking Delete.
`useRepoStore.deleteBranches` then deletes the batch with **one** refresh
(looping `deleteBranch` would have run a full `refreshAll` per branch),
best-effort, refreshing before it reports — the branch list must already match
reality by the time a banner points at it.

## Deliberately not here

- **The titlebar `BranchPicker`.** It is a type-to-filter switcher whose
  documented cursor-resting rules and Enter path assume every row is
  checkout-able; folder rows put non-checkout-able rows in that path, and typing
  flattens the list anyway. The forty-row problem is on the Branches screen.
- **Drag and drop onto folder rows.** There is no branch drag today at all. When
  there is, it resolves through `resolveDrop.ts` with a keyboard equivalent like
  every other drop — noted in `docs/dev/frontend.md`.

**Part of #244** — the issue stays open for those two.

## Tests

- `branchTree.test.ts` (27) — compression, depth, ordering preservation, folder
  ranking, counts, collapse, the git-impossible shapes, `parentFolderPath`,
  `branchesInFolder` segment-boundary matching.
- `useBranchFolders.test.ts` (10) — round-trip, per-repository isolation,
  pruning, corrupt/hand-edited payloads.
- `deleteMerged.test.ts` (15) — candidate rules, the `ahead_behind` calls, the
  unreadable-ref direction, summaries.
- `useRepoStore.deleteBranches.test.ts` (5) — one refresh, best-effort, refresh
  before report.
- `Branches.folders.test.tsx` (13) — grouping, the #135 pin, click-to-fold,
  persistence across remount, filter flatten/restore, keyboard traversal and
  ←/→, selection rescue, fold-all, the HEAD marker, the folder inspector.

`pnpm test` 2568 passing / 276 files · `pnpm tsc --noEmit` clean · e2e typecheck
clean · `branches.e2e.ts` (3) and `settings.e2e.ts` (8, it measures branch-row
height for the UI-density gate) pass in Docker.

Closes nothing else; no backend change, so no `cargo test` delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
