### PR TITLE
fix(distribution): the release would have built an unsubmittable MSIX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,10 +390,26 @@ jobs:
       - name: Build arm64
         run: pnpm tauri build --no-bundle --target aarch64-pc-windows-msvc --config src-tauri/tauri.msstore.conf.json
 
+      # The Store identity comes from REPOSITORY VARIABLES, not from the script's
+      # defaults. msix-pack.sh falls back to a development identity
+      # (`platypusgit.dev` / `CN=platypusgit-development`) so a local build works
+      # without Partner Center — but a RELEASE stamped with that identity is
+      # rejected on upload, and nothing before the upload would say so. Both are
+      # public values (they ship inside every installed package), hence `vars`
+      # rather than `secrets`; set them from Partner Center > Product identity:
+      #   gh variable set MSIX_IDENTITY_NAME --body '<Publisher>.<name>'
+      #   gh variable set MSIX_PUBLISHER     --body 'CN=<guid>'
       - name: Stage and pack both architectures
         shell: bash
+        env:
+          MSIX_IDENTITY_NAME: ${{ vars.MSIX_IDENTITY_NAME }}
+          MSIX_PUBLISHER: ${{ vars.MSIX_PUBLISHER }}
         run: |
           set -euo pipefail
+          # Fail the job rather than attach an unsubmittable bundle to a public
+          # release. `${VAR:?msg}` under `set -u` aborts with the message.
+          : "${MSIX_IDENTITY_NAME:?repository variable is unset — copy it from Partner Center > Product identity}"
+          : "${MSIX_PUBLISHER:?repository variable is unset — the whole CN=... string from Partner Center}"
           v="${{ needs.version.outputs.version }}"
           sh scripts/msix-pack.sh --version "$v" --arch x64 \
             --exe src-tauri/target/x86_64-pc-windows-msvc/release/platypusgit.exe \
@@ -439,6 +455,13 @@ jobs:
               $manifest = Get-Content (Join-Path $inner 'AppxManifest.xml') -Raw
               if ($manifest -match '__MSIX_') {
                   throw "$arch manifest carries an unsubstituted token"
+              }
+              # Second line of defence behind the `:?` guards on the pack step.
+              # A dev-identity bundle is the one defect that passes every other
+              # check here, installs fine locally, and is only rejected by
+              # Partner Center days later.
+              if ($manifest -match 'platypusgit\.dev' -or $manifest -match 'CN=platypusgit-development') {
+                  throw "$arch package carries the DEVELOPMENT identity — set the MSIX_IDENTITY_NAME and MSIX_PUBLISHER repository variables"
               }
               if ($manifest -notmatch 'Alias="pgit\.exe"') {
                   throw "$arch manifest lost the pgit alias, so the package would ship no CLI"

--- a/docs/dev/distribution.md
+++ b/docs/dev/distribution.md
@@ -671,20 +671,43 @@ it at the first upload and fix the script and spec §E together if it disagrees.
 ### The manual setup
 
 `scripts/msstore-wizard.sh` walks the eight steps outside this repo.
-Interactive, `--dry-run`-able, run **by the user** — step 1 is a government ID
-check. It automates almost nothing by design; what it carries is the traps:
+Interactive, `--dry-run`-able, run **by the user** — a first account needs a
+government ID check. It automates almost nothing by design; what it carries is
+the traps:
 
-- **The fee-free account flow exists ONLY from `storedeveloper.microsoft.com`.**
-  Reaching Partner Center any other way serves the legacy flow, which still
-  charges $19.
+- **A first account must be created from `storedeveloper.microsoft.com`** — that
+  page states it is the only supported entry point for the fee-free flow, and
+  other paths "will show the legacy flow". The $19 registration fee is waived in
+  the new flow; Microsoft does not document what the legacy flow costs, so do not
+  assert that it charges. **An existing developer account skips this entirely** —
+  the same FAQ says the flow is "only for new individual developers creating
+  their account for the first time" — and goes straight to
+  `https://aka.ms/submitwindowsapp`.
 - `runFullTrust` is a **restricted** capability: Partner Center requires a
   written justification.
 - Policy **10.2.4** means the `git` dependency must be the **first line** of the
   Store description, not a footnote.
 - Policy **10.5.1** requires a privacy policy URL for a Win32/Desktop Bridge
   product regardless of what it collects — hence `site/src/pages/privacy.astro`,
-  served at `https://www.platypusgit.com/privacy`.
+  served at `https://www.platypusgit.com/privacy/` (the site 301s the unslashed
+  form; paste the canonical one).
 
-The one thing it does automate is the step where a typo is silent: it turns the
-assigned identity values into the exact `msix-pack.sh` invocation. Those values
-are never written to disk.
+### The Store identity lives in repository variables
+
+Partner Center assigns `Identity/Name` and `Identity/Publisher`, and the manifest
+carries them only as `__MSIX_…__` tokens. The release job reads them from
+**repository variables** `MSIX_IDENTITY_NAME` and `MSIX_PUBLISHER` — `vars`, not
+`secrets`, because both ship inside every installed package and neither is
+sensitive.
+
+```bash
+gh variable set MSIX_IDENTITY_NAME --body 'JonasAasberg.platypusgit'
+gh variable set MSIX_PUBLISHER     --body 'CN=<guid>'
+```
+
+**The `msix` job fails if either is unset**, and the shape gate additionally
+rejects a bundle carrying the development identity. Both guards exist because
+`msix-pack.sh` deliberately falls back to `platypusgit.dev` /
+`CN=platypusgit-development` so a local pack works without Partner Center — and
+that fallback is exactly what would otherwise be attached to a public release,
+install fine everywhere, and be rejected only at upload.

--- a/scripts/msstore-wizard.sh
+++ b/scripts/msstore-wizard.sh
@@ -24,9 +24,12 @@ set -eu
 OWNER=jonassaa
 REPO=platypusgit
 PRODUCT=platypusgit
-PRIVACY_URL=https://www.platypusgit.com/privacy
+# Trailing slash: the site serves /privacy/ and 301s the unslashed form. This is
+# the value that gets pasted into Partner Center, so it is the canonical one.
+PRIVACY_URL=https://www.platypusgit.com/privacy/
 STORE_SIGNUP=https://storedeveloper.microsoft.com
 PARTNER_CENTER=https://partner.microsoft.com/dashboard
+PARTNER_APPS=https://aka.ms/submitwindowsapp
 
 root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 MANIFEST="$root/src-tauri/windows/Package.appxmanifest"
@@ -120,14 +123,23 @@ fi
 
 # ─── 1. the account ──────────────────────────────────────────────────────────
 
-step "1/8  Create the developer account — START AT THE RIGHT URL"
+step "1/8  The developer account"
 
-say "Open: $STORE_SIGNUP"
+say "ALREADY HAVE A MICROSOFT DEVELOPER ACCOUNT? Skip this step entirely."
+say "Microsoft's own FAQ: 'this flow is only for new individual developers"
+say "creating their account for the first time.' Go straight to:"
 say ""
-say "THIS IS THE TRAP, and it costs money to get wrong. That page states it is"
-say "the ONLY supported entry point for the fee-free flow. Reaching Partner"
-say "Center any other way — a direct dashboard link, Xbox, Visual Studio —"
-say "serves the LEGACY flow, which still charges the \$19 registration fee."
+say "  $PARTNER_APPS"
+say ""
+say "FIRST ACCOUNT? Then the entry point matters — open:"
+say ""
+say "  $STORE_SIGNUP"
+say ""
+say "That page states it is the ONLY supported entry point for the fee-free"
+say "flow: 'Other paths (e.g. direct via Partner Center, Xbox, or Visual"
+say "Studio) will show the legacy flow.' The \$19 registration fee is waived in"
+say "the new flow. Microsoft does not document what the legacy flow costs, so"
+say "the safe move is simply to start at the URL above."
 say ""
 say "Choose 'Get started for free', then 'Individual developer'."
 say "Store policy 10.14 reserves Company accounts for organisations and for"
@@ -136,7 +148,7 @@ say "project is an Individual account."
 say ""
 say "Verification is a government-issued ID plus a selfie, on a phone, in good"
 say "light. Nobody can do this step for you."
-confirm "Account created and verified?" || say "Skipped."
+confirm "Account ready (existing or newly verified)?" || say "Skipped."
 
 # ─── 2. the name ─────────────────────────────────────────────────────────────
 
@@ -178,12 +190,17 @@ if confirm "Enter them now, and I will print the exact pack command?"; then
     esac
 
     say ""
-    say "Export these before packing, and msix-pack.sh will pick them up:"
+    say "THE RELEASE READS THESE FROM REPOSITORY VARIABLES. Set them once:"
     say ""
-    say "  export MSIX_IDENTITY_NAME='$identity_name'"
-    say "  export MSIX_PUBLISHER='$publisher'"
+    say "  gh variable set MSIX_IDENTITY_NAME --body '$identity_name'"
+    say "  gh variable set MSIX_PUBLISHER     --body '$publisher'"
     say ""
-    say "Or pass them directly:"
+    say "They are public values — they ship inside every installed package — so"
+    say "they are variables, not secrets. release.yml FAILS the msix job if"
+    say "either is unset, rather than attaching a bundle stamped with the"
+    say "development identity that Partner Center would reject."
+    say ""
+    say "For a one-off local pack, pass them directly instead:"
     say ""
     say "  sh scripts/msix-pack.sh --version <X.Y.Z> --arch x64 \\"
     say "      --exe src-tauri/target/x86_64-pc-windows-msvc/release/platypusgit.exe \\"
@@ -191,8 +208,7 @@ if confirm "Enter them now, and I will print the exact pack command?"; then
     say "      --identity-name '$identity_name' \\"
     say "      --publisher '$publisher'"
     say ""
-    say "Nothing was written to disk: these belong in the release environment,"
-    say "not in the repository."
+    say "Nothing was written to disk by this wizard."
 else
     say "Skipped — you can re-run this step alone later."
 fi
@@ -288,8 +304,8 @@ step "Done — what you should have now"
 say "  1. An Individual developer account, created via $STORE_SIGNUP"
 say "     (fee-free — any other entry point charges)."
 say "  2. The name '$PRODUCT' reserved."
-say "  3. Identity Name + Publisher copied out, passed to msix-pack.sh as flags"
-say "     or exported as MSIX_IDENTITY_NAME / MSIX_PUBLISHER. Never committed."
+say "  3. Identity Name + Publisher stored as the MSIX_IDENTITY_NAME and"
+say "     MSIX_PUBLISHER repository variables. Never committed to the tree."
 say "  4. Age ratings completed."
 say "  5. runFullTrust justified."
 say "  6. A description whose FIRST line names the git dependency."


### PR DESCRIPTION
Follow-up to #288, fixing a defect in it plus two claims I couldn't source.

## The defect

The `msix` job called `msix-pack.sh` with no identity flags and set no `MSIX_*` env, so the bundle carried the script's **development** fallback — `platypusgit.dev` / `CN=platypusgit-development`.

That value passes everything: `makeappx` accepts it, the package installs, the shape gate is happy, the token check finds no leftover `__MSIX_`. Partner Center rejects it. The only symptom would have been a failed submission days after a release went out.

It couldn't be wired before now — Partner Center assigns the values, and they didn't exist until the product was registered. They're now set as **repository variables** (`vars`, not `secrets`: both ship inside every installed package, neither is sensitive).

## Two guards, because the failure is silent

1. The pack step **fails the job** via `${VAR:?…}` when either variable is unset, instead of attaching a junk bundle to a public release.
2. The shape gate **rejects a bundle carrying the development identity**, so a regression in the env wiring can't slip past the one check everything else passes.

Both verified rather than assumed:

```
$ env -u MSIX_IDENTITY_NAME bash guardcheck.sh
MSIX_IDENTITY_NAME: repository variable is unset — copy it from Partner Center > Product identity
exit=1

$ MSIX_IDENTITY_NAME=… MSIX_PUBLISHER=… sh scripts/msix-pack.sh … --stage-only
    Name="JonasAasberg.platypusgit"
    Publisher="CN=0886DDC7-…"
```

## Two corrections to claims I couldn't source

- **The wizard asserted the legacy signup flow "still charges the $19 registration fee".** Microsoft's page says only that the fee *"is waived in the new flow"*, and that other entry points *"will show the legacy flow"* — it never says what the legacy flow costs. Reworded to match the source while keeping the actionable part: start at `storedeveloper.microsoft.com`.
- **Step 1 assumed a first-time account.** The same FAQ: the flow is *"only for new individual developers creating their account for the first time."* An existing developer account skips it entirely and goes to `aka.ms/submitwindowsapp`. The wizard now branches, instead of sending an existing developer through an ID check they don't need.

Plus the privacy URL's trailing slash — the site 301s the unslashed form, and this is the string pasted into Partner Center.

## Verification

`release.yml` parses (13 msix steps, still **no** `TAURI_SIGNING` reference — the job needs no signing key); `sh -n` clean on the wizard; `--dry-run </dev/null` exits 0 and never reads stdin; docs invariants 112 passed.

Unchanged: the six Windows behaviours from #288 are still unverified, `GIT_ASKPASS` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)