### PR TITLE
fix(release): makeappx is on the runner but not on PATH

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,6 +390,36 @@ jobs:
       - name: Build arm64
         run: pnpm tauri build --no-bundle --target aarch64-pc-windows-msvc --config src-tauri/tauri.msstore.conf.json
 
+      # `makeappx.exe` ships with the Windows 10 SDK, and the SDK IS on the
+      # runner — but its `bin\<version>\x64` directory is NOT on PATH, so the
+      # command does not resolve. Learned the hard way: the v0.2.0 release
+      # staged both payloads successfully and then failed with "makeappx.exe is
+      # not on PATH", attaching no bundle.
+      #
+      # `$GITHUB_PATH` is the only thing that carries a PATH addition to later
+      # steps — the same reason `scoop-verify-live` below uses it. The highest
+      # SDK version present is chosen rather than a pinned one, so a runner
+      # image bump does not silently break this; the name filter is required
+      # because that `bin` directory also holds non-version `x64`/`x86`/`arm64`
+      # directories, and `[version]` would throw on those.
+      - name: Put the Windows SDK's makeappx on PATH
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $root = 'C:\Program Files (x86)\Windows Kits\10\bin'
+          if (-not (Test-Path $root)) { throw "no Windows 10 SDK at $root" }
+          $sdk = Get-ChildItem $root -Directory |
+              Where-Object {
+                  $_.Name -match '^\d+\.\d+\.\d+\.\d+$' -and
+                  (Test-Path (Join-Path $_.FullName 'x64\makeappx.exe'))
+              } |
+              Sort-Object { [version]$_.Name } -Descending |
+              Select-Object -First 1
+          if (-not $sdk) { throw "no x64\makeappx.exe under any SDK version in $root" }
+          $bin = Join-Path $sdk.FullName 'x64'
+          Write-Host "makeappx found in: $bin"
+          $bin | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+
       # The Store identity comes from REPOSITORY VARIABLES, not from the script's
       # defaults. msix-pack.sh falls back to a development identity
       # (`platypusgit.dev` / `CN=platypusgit-development`) so a local build works

--- a/scripts/msix-pack.sh
+++ b/scripts/msix-pack.sh
@@ -150,8 +150,18 @@ if [ "$STAGE_ONLY" -eq 1 ]; then
 fi
 
 if ! command -v makeappx.exe >/dev/null 2>&1; then
-    echo "makeappx.exe is not on PATH — it ships with the Windows SDK." >&2
-    echo "On a non-Windows host, use --stage-only." >&2
+    echo "makeappx.exe is not on PATH." >&2
+    echo >&2
+    echo "It ships with the Windows 10 SDK, but the SDK's bin directory is NOT" >&2
+    echo "on PATH by default — including on GitHub's windows runners, which is" >&2
+    echo "how the v0.2.0 release failed here. Add it:" >&2
+    echo >&2
+    # printf, not echo: POSIX `echo` interprets backslash escapes, so this path
+    # printed as `10in\<version>d` — `\b` became a backspace and `\x64` became
+    # the character 0x64. A Windows path is nothing but backslashes.
+    printf '  "C:\\Program Files (x86)\\Windows Kits\\10\\bin\\<version>\\x64"\n' >&2
+    echo >&2
+    echo "On a non-Windows host, use --stage-only instead." >&2
     exit 1
 fi
 


### PR DESCRIPTION
The v0.2.0 `msix` job failed, so **no bundle was attached to the release**. This fixes it.

## What actually happened

The job got further than it looked. From the log:

```
MSIX_IDENTITY_NAME: JonasAasberg.platypusgit
MSIX_PUBLISHER: CN=0886DDC7-…
staged x64 payload in msix-x64 (version 0.2.0.0)
makeappx.exe is not on PATH — it ships with the Windows SDK.
```

So #304 worked exactly as intended — the real Store identity reached the manifest. The failure is one step later, and it's mine: I wrote that makeappx *"ships with the Windows SDK, which is already on the runner"* as though that settled it. The SDK **is** on the runner; its `bin\<version>\x64` directory is **not on PATH**, so the command doesn't resolve.

This is precisely the assumption I'd flagged as unverifiable from macOS. It was, and it was wrong.

## The fix

A step locates the SDK and prepends its bin directory via `$GITHUB_PATH` — the only mechanism that carries a PATH addition to later steps, which is the same reason `scoop-verify-live` uses it and documents why.

Two details that aren't incidental:

- **Highest SDK version present**, not a pinned one, so a runner image bump can't silently break this.
- **The directory name is filtered to a version pattern**, because `Windows Kits\10\bin` also contains non-version `x64`/`x86`/`arm64` directories — `[version]` would throw on those.

## Two smaller things, both found by running rather than reading

The script's error message told a Windows runner to use `--stage-only`, which is advice for a Mac. It now names the directory to add.

And that message **printed the path wrong**: POSIX `echo` interprets backslash escapes, so `10\bin\<version>\x64` came out as `10in\<version>d` — `\b` became a backspace and `\x64` became the character `0x64`. A Windows path is nothing but backslashes. It's `printf` now.

```
before:  "C:\Program Files (x86)\Windows Kits\10in\<version>d"
after:   "C:\Program Files (x86)\Windows Kits\10\bin\<version>\x64"
```

## After this merges

Re-run the release against the existing tag — the workflow takes a `tag` input for exactly this:

```
gh workflow run release.yml -f tag=v0.2.0
```

That also re-runs `apt-verify-live`, which failed on the same run for an unrelated and transient reason: it checked before GitHub Pages had served the new index and correctly refused, reporting `installed version is '0.1.2', expected '0.2.0'`. The live repo now serves 0.2.0 (index, `InRelease` and the `.deb` all verified directly), so that gate should pass on the re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)