### PR TITLE
fix(release): Git Bash rewrote makeappx's flags, and add a gate that catches it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -452,14 +452,23 @@ jobs:
       # which is a lower version than anything already in the Store and is
       # rejected as a downgrade. The inner packages carry the real version from
       # msix-pack.sh; the bundle needs telling separately.
+      #
+      # pwsh, NOT bash, and that is the fix rather than a preference: `shell:
+      # bash` on a Windows runner is Git Bash, whose MSYS runtime rewrites
+      # arguments that look like POSIX absolute paths before a native binary sees
+      # them — `/d` arrives as `D:/`. makeappx takes DOS-style switches, so every
+      # flag is affected. PowerShell does no such conversion, so there is nothing
+      # to suppress. (msix-pack.sh cannot take this route — it is POSIX sh by
+      # design and runs on a Mac too — so it sets MSYS_NO_PATHCONV instead.)
       - name: Bundle x64 + arm64
-        shell: bash
+        shell: pwsh
         run: |
-          set -euo pipefail
-          v="${{ needs.version.outputs.version }}"
-          mkdir -p msix-bundle
-          cp msix-x64.msix msix-arm64.msix msix-bundle/
-          makeappx.exe bundle /d msix-bundle /bv "$v.0" /p PlatypusGit.msixbundle /o
+          $ErrorActionPreference = 'Stop'
+          $v = '${{ needs.version.outputs.version }}'
+          New-Item -ItemType Directory -Force -Path msix-bundle | Out-Null
+          Copy-Item msix-x64.msix, msix-arm64.msix msix-bundle/
+          & makeappx.exe bundle /d msix-bundle /bv "$v.0" /p PlatypusGit.msixbundle /o
+          if ($LASTEXITCODE -ne 0) { throw "makeappx bundle failed ($LASTEXITCODE)" }
 
       # The .msi needs no equivalent gate because the bundler owns its shape.
       # This one does: the payload is assembled by a script of ours, and a bundle

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,7 @@ jobs:
     outputs:
       js: ${{ steps.filter.outputs.js || 'true' }}
       rust: ${{ steps.filter.outputs.rust || 'true' }}
+      msix: ${{ steps.filter.outputs.msix || 'true' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -76,6 +77,19 @@ jobs:
           else
             echo "rust=false" >> "$GITHUB_OUTPUT"
             echo "-> no backend sources touched, skipping the Rust suite"
+          fi
+
+          # The Store packaging inputs. This gate exists because TWO bugs in it
+          # reached a published release and could only be found on a Windows
+          # runner: makeappx not being on PATH, then Git Bash rewriting `/d`
+          # into `D:/`. Neither is reachable from a Mac or from the unit suites,
+          # so nothing before the release job could see them.
+          if echo "$changed" | grep -qE '^(src-tauri/windows/Package\.appxmanifest$|src-tauri/tauri\.msstore\.conf\.json$|scripts/msix-pack\.sh$|\.github/workflows/(release|tests)\.yml$)'; then
+            echo "msix=true" >> "$GITHUB_OUTPUT"
+            echo "-> Store packaging touched, running the msix pack gate"
+          else
+            echo "msix=false" >> "$GITHUB_OUTPUT"
+            echo "-> Store packaging untouched, skipping the msix pack gate"
           fi
 
   # Frontend: both typechecks plus the vitest unit + component tests. Pure
@@ -217,3 +231,81 @@ jobs:
               ;;
             *) echo "Rust suite did not pass."; exit 1 ;;
           esac
+
+  # Prove the Store package can actually be BUILT, on a PR rather than on a
+  # release.
+  #
+  # Why this exists: two bugs in this path reached a published release, and
+  # neither was reachable from a Mac or from any other suite here — makeappx was
+  # not on PATH, and then Git Bash rewrote `/d` into `D:/` so every flag arrived
+  # corrupted. Both are Windows-runner-only, and both cost a 20-minute release
+  # cycle to discover.
+  #
+  # Why it does NOT build the app: the bugs are in the PACKAGING, not the binary,
+  # so any valid PE proves the same thing. Copying a system executable makes this
+  # a one-minute job instead of a Rust release build, which is what keeps it
+  # affordable on every PR that touches these three files. It deliberately does
+  # not sign, submit, or upload anything.
+  msix-pack:
+    needs: changes
+    if: ${{ needs.changes.outputs.msix == 'true' }}
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Put the Windows SDK's makeappx on PATH
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $root = 'C:\Program Files (x86)\Windows Kits\10\bin'
+          if (-not (Test-Path $root)) { throw "no Windows 10 SDK at $root" }
+          $sdk = Get-ChildItem $root -Directory |
+              Where-Object {
+                  $_.Name -match '^\d+\.\d+\.\d+\.\d+$' -and
+                  (Test-Path (Join-Path $_.FullName 'x64\makeappx.exe'))
+              } |
+              Sort-Object { [version]$_.Name } -Descending |
+              Select-Object -First 1
+          if (-not $sdk) { throw "no x64\makeappx.exe under any SDK version in $root" }
+          $bin = Join-Path $sdk.FullName 'x64'
+          Write-Host "makeappx found in: $bin"
+          $bin | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+
+      # A real PE, because makeappx validates the Executable it is pointed at.
+      # `where.exe` is tiny and always present; nothing here runs it.
+      - name: Stand in a real executable
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          New-Item -ItemType Directory -Force -Path stand-in | Out-Null
+          Copy-Item C:\Windows\System32\where.exe stand-in\platypusgit.exe
+
+      # Deliberately runs under `shell: bash` — Git Bash — because that is the
+      # shell the release uses and the one whose argument rewriting broke it.
+      # Running this under pwsh would pass while the release still failed.
+      - name: Pack, the same way the release does
+        shell: bash
+        env:
+          MSIX_IDENTITY_NAME: GateCheck.platypusgit
+          MSIX_PUBLISHER: CN=00000000-0000-0000-0000-000000000000
+        run: |
+          set -euo pipefail
+          sh scripts/msix-pack.sh --version 9.9.9 --arch x64 \
+            --exe stand-in/platypusgit.exe --out msix-gate
+
+      - name: Gate — a package exists and carries what it must
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (-not (Test-Path 'msix-gate.msix')) { throw 'no .msix was produced' }
+          Expand-Archive -Path 'msix-gate.msix' -DestinationPath 'msix-gate-check' -Force
+          foreach ($f in 'platypusgit.exe', 'pgit.cmd', 'AppxManifest.xml') {
+              if (-not (Test-Path (Join-Path 'msix-gate-check' $f))) {
+                  throw "packed .msix has no $f at its root"
+              }
+          }
+          $manifest = Get-Content 'msix-gate-check\AppxManifest.xml' -Raw
+          if ($manifest -match '__MSIX_') { throw 'packed manifest carries an unsubstituted token' }
+          if ($manifest -notmatch 'Alias="pgit\.exe"') { throw 'packed manifest lost the pgit alias' }
+          if ($manifest -notmatch 'Version="9\.9\.9\.0"') { throw 'packed manifest has the wrong version' }
+          Write-Host 'msix pack gate OK'

--- a/scripts/msix-pack.sh
+++ b/scripts/msix-pack.sh
@@ -33,7 +33,11 @@ set -eu
 # src-tauri/tests/msix_identity.rs asserts the manifest references nothing that
 # is missing from icons/, so a regeneration that drops a size fails the build
 # rather than producing a package with blank tiles.
-LOGOS="Square44x44Logo Square71x71Logo Square150x150Logo Square310x310Logo StoreLogo"
+# Square310x310Logo is deliberately ABSENT: the manifest cannot name it without
+# also naming a Wide310x150Logo we do not render (see Package.appxmanifest), so
+# copying it would put an unreferenced file in the package. If the large tile is
+# ever added, it comes back here together with the wide asset.
+LOGOS="Square44x44Logo Square71x71Logo Square150x150Logo StoreLogo"
 
 VERSION=
 ARCH=

--- a/scripts/msix-pack.sh
+++ b/scripts/msix-pack.sh
@@ -168,5 +168,23 @@ fi
 # No signing here, deliberately: the Microsoft Store re-signs the package, which
 # is the entire economics of this channel (spec §Problem). Signing locally is for
 # the winapp debug loop, not for submission.
+# MSYS_NO_PATHCONV / MSYS2_ARG_CONV_EXCL ARE LOAD-BEARING, not belt-and-braces.
+# Under Git Bash — which is what `shell: bash` is on a Windows runner — the MSYS
+# runtime rewrites arguments that look like POSIX absolute paths before a native
+# Windows binary sees them. `/d` becomes `D:/`, and `/p` and `/o` become paths
+# under the Git installation. The v0.2.0 re-run failed exactly here:
+#
+#   MakeAppx : error: Unknown command line option: "D:/"
+#
+# makeappx takes DOS-style switches, so every flag it has is affected. Both
+# variables are set because the name differs between Git for Windows
+# (MSYS_NO_PATHCONV) and MSYS2 proper (MSYS2_ARG_CONV_EXCL); on a non-MSYS host
+# they are simply ignored.
+# Exported rather than prefixed onto the command: the conversion is done by the
+# MSYS runtime of the SPAWNING shell, so putting it in this shell's own
+# environment leaves no doubt about which process reads it.
+export MSYS_NO_PATHCONV=1
+export MSYS2_ARG_CONV_EXCL='*'
+
 makeappx.exe pack /d "$OUT" /p "$OUT.msix" /o
 echo "packed $OUT.msix"

--- a/src-tauri/windows/Package.appxmanifest
+++ b/src-tauri/windows/Package.appxmanifest
@@ -73,10 +73,24 @@
                  uap10:RuntimeBehavior="packagedClassicApp"
                  uap10:TrustLevel="mediumIL">
       <!--
-        No Wide310x150Logo: src-tauri/icons/ holds only square renders (the set
-        `tauri icon` generates from app-icon.svg, #206), and the slot is
-        optional. Pointing it at a square image would letterbox or be rejected,
-        which is worse than omitting a tile size the Store does not require.
+        NO Square310x310Logo, AND NO Wide310x150Logo, and the two facts are one
+        decision: makeappx refuses a manifest that names the large square tile
+        without also naming the wide one —
+
+          error 80080204: The DefaultTile element must specify the
+          Wide310x150Logo attribute if the Square310x310Logo attribute is
+          specified.
+
+        `src-tauri/icons/` holds only SQUARE renders — it is the set `tauri icon`
+        generates from app-icon.svg (#206), and that directory is generated
+        output with exactly two hand-authored files in it. Producing a wide
+        310x150 asset means a new render step and a new hand-authored source, so
+        the cheaper correct answer is to name neither tile. Windows falls back to
+        the 150x150.
+
+        If the large tile is ever wanted, BOTH attributes have to arrive
+        together, along with the asset and its entry in msix-pack.sh's LOGOS
+        list. Re-adding just the square one puts the release back where it was.
       -->
       <uap:VisualElements
         DisplayName="platypusgit"
@@ -84,8 +98,7 @@
         BackgroundColor="transparent"
         Square150x150Logo="Assets\Square150x150Logo.png"
         Square44x44Logo="Assets\Square44x44Logo.png">
-        <uap:DefaultTile Square71x71Logo="Assets\Square71x71Logo.png"
-                         Square310x310Logo="Assets\Square310x310Logo.png" />
+        <uap:DefaultTile Square71x71Logo="Assets\Square71x71Logo.png" />
       </uap:VisualElements>
       <Extensions>
         <!--


### PR DESCRIPTION
The v0.2.0 re-run got **past** the PATH fix — makeappx was found and ran — then failed on its arguments:

```
MakeAppx : error: Unknown command line option: "D:/"
```

`shell: bash` on a Windows runner is Git Bash, whose MSYS runtime rewrites arguments that look like POSIX absolute paths before a native binary sees them. `/d` arrives as `D:/`; `/p` and `/o` become paths under the Git installation. makeappx takes DOS-style switches, so **every flag it has** is affected.

## Two call sites, two different fixes

The constraints differ, so the fixes do:

- **`msix-pack.sh`** exports `MSYS_NO_PATHCONV` and `MSYS2_ARG_CONV_EXCL` — the variable name differs between Git for Windows and MSYS2 proper, and both are ignored on a non-MSYS host. It can't switch shells: it's POSIX `sh` by design and runs on a Mac too.
- **The Bundle step becomes `pwsh`**, which does no conversion at all, so there's nothing to suppress. It also now checks `$LASTEXITCODE` — a native command's non-zero exit isn't a terminating error in PowerShell even under `$ErrorActionPreference = 'Stop'`, the same trap `scoop-verify-live` already documents.

## And a gate, because this is the second one to reach a release

Both bugs in this path were Windows-runner-only and invisible to every existing suite, so the release job was the first thing that could see them — at 20 minutes per discovery. That's not a sustainable way to find them.

`msix-pack` in `tests.yml` packs a real `.msix` on `windows-latest` and asserts its shape, on any PR touching the three packaging inputs.

Two deliberate choices keep it cheap and honest:

- **It does not build the app.** The bugs are in the packaging, not the binary, so standing in a system executable (`where.exe` — a real PE, which makeappx validates) proves the same thing in about a minute rather than a Rust release build.
- **Its pack step runs under `shell: bash`.** Under pwsh it would pass while the release still failed. It has to reproduce the shell that broke.

It signs nothing, uploads nothing and submits nothing.

**This PR's own gate is what verifies the Windows half of this fix** — which is the point of adding it, and why I'd rather land it here than after a third red release.

## Verification

Locally: `sh -n` clean, `--stage-only` unaffected, both workflows parse, `pnpm test` 2656 passed (285 files). The Windows behaviour is verified by the new gate on this PR.

If you'd rather not carry the gate, it's one job and one filter branch to drop — say so and I'll split it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)