### PR TITLE
fix(release): the apt gate waited for a reachable index, not a current one

### DIFF
--- a/scripts/apt-repo-smoke.sh
+++ b/scripts/apt-repo-smoke.sh
@@ -208,6 +208,29 @@ until curl -fsS "$PG_BASE_URL/dists/stable/InRelease" > /dev/null 2>&1; do
 done
 ok "repository reachable at $PG_BASE_URL (after ${i}s)"
 
+# REACHABLE IS NOT THE SAME AS CURRENT, and against the live host that
+# distinction is the difference between a real failure and a false one.
+#
+# GitHub Pages does not publish atomically. On the v0.2.0 release this loop
+# above answered "reachable (after 0s)" against an index that still described
+# the PREVIOUS version, so the run installed it and reported
+# `installed version is '0.1.2', expected '0.2.0'` — a broken repository, said
+# of a repository that was merely mid-deploy and was serving the right thing
+# minutes later. A second run hit the neighbouring window where the index and
+# its signature disagreed and apt exited 100. Two red releases, no defect.
+#
+# So wait for the expected version to actually be LISTED. In local mode the pool
+# was just built, so this returns on the first try and costs nothing.
+i=0
+until curl -fsS "$PG_BASE_URL/dists/stable/main/binary-amd64/Packages" 2> /dev/null \
+    | grep -qx "Version: $PG_EXPECT_VERSION"; do
+    i=$((i + 1))
+    [ "$i" -lt "$PG_WAIT_SECS" ] \
+        || fail "index at $PG_BASE_URL never listed version $PG_EXPECT_VERSION after ${PG_WAIT_SECS}s"
+    sleep 1
+done
+ok "index lists version $PG_EXPECT_VERSION (after ${i}s)"
+
 # --- install ---------------------------------------------------------------
 
 if [ "$PG_MODE" = installer ]; then


### PR DESCRIPTION
`apt-verify-live` failed on **two of the three** v0.2.0 release runs, both times against a repository that was serving the right thing minutes later. No defect either time — the gate was wrong.

## The bug

The wait loop only asked whether `InRelease` could be *fetched*, and GitHub Pages doesn't publish atomically:

| Run | Symptom | What was actually true |
|---|---|---|
| 1 | `installed version is '0.1.2', expected '0.2.0'` | got `reachable (after 0s)` from an index still describing the previous version, and installed it |
| 3 | `client exited 100` | hit the neighbouring window where the index and its signature disagreed |

Both read as a broken repository to anyone looking at a red release. That's the real cost: a gate that cries wolf on most releases is one people learn to skip — and this one guards the signed index every existing apt user pulls from.

## The fix

Wait for the expected version to actually be **listed**, not merely for the server to answer. In local mode the pool was just built, so it returns on the first try and costs nothing.

Shown working in both directions against the live host:

```
--version 0.2.0 -> ok  "index lists version 0.2.0 (after 0s)"  ... SMOKE PASS
--version 9.9.9 -> ok  "repository reachable at … (after 0s)"
                   FAIL "index never listed version 9.9.9 after 5s"
```

The second case is the point. Previously that run would have installed whatever the index *did* list and then blamed the package for a version mismatch — which is exactly what happened on run 1.

Independent of this, I verified the live repo directly and with a full local smoke run: index lists 0.2.0, `InRelease` 200, `.deb` 200 at 12.4 MB, `dpkg reports version 0.2.0`, both binaries executable, `git` pulled in as a dependency. **Linux users were never affected.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)