### PR TITLE
fix(commit): a fresh machine could not commit, and the error said "NoSignature"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,9 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
 
 - **Errors:** every IPC-crossing fn returns `AppResult<T>`; add `AppError`
   variants, never stringify. TS `AppError` union stays 1:1 with the Rust enum,
-  updated in the same commit. (`docs/dev/backend.md`)
+  updated in the same commit — and a UNIT variant needs prose in
+  `appErrorDetail`, or a banner shows the enum's own spelling.
+  `test/appErrors.test.ts` fails the build for both. (`docs/dev/backend.md`)
 - **Never `Command::new` outside `src-tauri/src/proc.rs`** — a guard test
   fails the build. Use the `proc::git*`/`proc::program*` constructors.
   (`docs/dev/backend.md`)
@@ -180,6 +182,12 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
   whether Commit is enabled, and nothing overwrites what the user typed.
   Comment stripping is SCOPED the way git scopes it: the box is `git commit -m`
   (a typed `#123 fix` commits as written) until `commit.template` seeds it.
+  (`docs/dev/frontend.md`)
+- **One committer-identity surface** — `features/commits/identity/`, rendered by
+  Settings and by the commit panel. `NoSignature` is a FORM, not a banner: it
+  lands in `useRepoStore`'s per-repo `noSignature`, and saving retries the
+  commit. The write is global and the form names the file; per-repo identities
+  (#233) add a scope control there, never a second form.
   (`docs/dev/frontend.md`)
 - **The log is paged** — `s.commits` is a prefix of history, never the answer
   to "does X exist / is X an ancestor"; ask the backend.

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -243,8 +243,16 @@ git/
 │                unit-tested without a repo; tests/commit_template.rs covers the
 │                repo side
 └── signature.rs IDENTITY, not cryptography: default_signature
-                 (user.name/email lookup, NoSignature when unset) and
-                 apply_signoff (Signed-off-by trailer, idempotent)
+                 (user.name/email lookup, NoSignature when there is no
+                 identity git accepts — asked of the CONFIG, not of libgit2's
+                 error code, because a MISSING user.name is NotFound while a
+                 BLANK one is a generic error whose only mark is the prose
+                 "failed to parse signature"), read_identity / global_config_
+                 path / validate_identity / set_global_identity (#212 — the
+                 write side, GLOBAL only; validate_identity is the ONE rule
+                 both the writer and default_signature use, so "what we save"
+                 and "what we call missing" cannot drift), and apply_signoff
+                 (Signed-off-by trailer, idempotent)
 commands/        Thin Tauri handlers, one file per area:
 ├── repo.rs      open_repo, close_repo, trust_repo_path, get_status, head_info
 │                (HEAD's branch/oid, re-polled every refresh — unlike
@@ -288,6 +296,15 @@ commands/        Thin Tauri handlers, one file per area:
 │                comment prefix; a configured template that cannot be read
 │                comes back FLAGGED, never as an error, so a stale config line
 │                cannot stop the commit screen opening).
+│                get_identity / set_identity (#212 — the committer identity.
+│                get_identity's repoId is OPTIONAL, because Settings is
+│                reachable before a repo is open and the global chain is the
+│                real answer there; it reports each half's SCOPE so the UI can
+│                say why a global save changed nothing in a repo that overrides
+│                it. set_identity is the only write in the app that touches the
+│                user's own global git config, and it validates before opening
+│                anything, so a refused value creates no file. See
+│                git/signature.rs)
 │                REFSPEC_ALL sentinel = walk all refs, so
 │                the loaded log is NOT HEAD ancestry — rebase input must go
 │                through headAncestryOf. Paged (see frontend.md): get_log_page /

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -354,6 +354,40 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   TOOL exits, which is minutes — and `refreshAll()`s afterwards, because a
   working-tree side is handed to the tool as the REAL file, not a copy.
 
+## The committer identity (#212)
+
+`src/features/commits/identity/` is **THE** identity surface: `IdentityForm`
+(the fields plus the save) and `NoSignaturePrompt` (the same form, framed as an
+answer to a refused commit). `screens/Settings.tsx`'s `IdentitySection` and
+`screens/CommitPanel.tsx` both render it; a third place to type a name and an
+email joins this one rather than growing beside it.
+
+- **`NoSignature` is a form, not a banner.** It lands in `useRepoStore`'s
+  per-repo `noSignature` field, exactly the split `hookRejection` makes, and for
+  the same reason: an error is something you acknowledge, and this is something
+  you answer. Saving RETRIES the commit — the user already typed a message and
+  pressed Commit, and making them press it again is a second failure with extra
+  steps.
+- **It is the first thing a brand-new user hits**, because git refuses to record
+  a commit until `user.name` and `user.email` are set — and before #212 that
+  refusal reached them as a banner reading the literal string `NoSignature`,
+  with nowhere in the app to set an identity. `test/appErrors.test.ts` now fails
+  the build for any unit variant that could do the same thing again.
+- **The write is GLOBAL, and the form says so on screen** (`identity-target`
+  names the file). `set_identity` is the only place the app writes the user's own
+  git config, so it is deliberately explicit rather than something a commit does
+  for you. Per-repository identities and multiple accounts are #233 — that lands
+  as a scope control on this form, not a second one.
+- **A repo-local override is called out** (`identity-scope-note`). Saving writes
+  the global config, so a repository that sets its own `user.email` would
+  otherwise leave the user watching a successful save change nothing.
+- **The fields seed from `get_identity` ONCE per mount.** Re-seeding on every
+  read would wipe what is being typed the moment anything refreshed.
+- **Blankness is checked in the UI; every other rule is the backend's.**
+  `validate_identity` (Rust) is the single authority on what git accepts, and its
+  refusal names the offending character — so the button gates on "both fields
+  non-empty" and nothing more.
+
 ## The commit-message composer (#252)
 
 `src/features/commits/message/` is **THE** commit-message composition surface —

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -210,6 +210,21 @@ Rules that keep the gates honest:
   `js` does not match `src-tauri/` and `rust` does not match `README.md`.
   Both files self-test their matchers — a guard that cannot fail reads like
   coverage.
+- **`test/appErrors.test.ts`** makes the error enum's two written promises
+  mechanical (#212). It parses `pub enum AppError` out of
+  `src-tauri/src/error.rs` and asserts (a) every variant has a `kind: "Name"`
+  case in `src/lib/errors.ts` — the 1:1 rule CLAUDE.md states as prose and
+  nothing checked — and (b) no UNIT variant renders as its own enum spelling
+  through `appErrorMessage`. (b) is the one that had already been broken: a unit
+  variant carries no payload, so it fell through the `|| e.kind` fallback, and
+  `NoSignature` — the ONE error every brand-new user hits, because git will not
+  record a commit without `user.name`/`user.email` — put the literal string
+  "NoSignature" on screen in the commit panel, and in merge, cherry-pick,
+  revert, rebase, tag and stash besides. `NEVER_RENDERED` is the escape hatch:
+  an allow-list of unit variants no user can see, each with a written reason, in
+  the shape `privacy.test.ts` uses for hostnames — so adding one is a decision
+  somebody made rather than an assertion quietly weakened. Node env, because it
+  reads `src-tauri/`.
 - **`test/comparison.test.ts`** keeps the competitor comparison (#210) from
   existing twice. `site/src/data/comparison.json` is the source of truth; the
   site renders it through `comparison.ts`, and the test parses the README's

--- a/src-tauri/src/commands/commits.rs
+++ b/src-tauri/src/commands/commits.rs
@@ -188,6 +188,40 @@ pub async fn get_commit_template(
         .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
+/// The committer identity a commit would use, and where each half is
+/// configured (#212).
+///
+/// `repo_id` is optional so Settings can answer before a repository is open —
+/// the global + system chain is the effective identity there.
+#[tauri::command]
+pub async fn get_identity(
+    state: State<'_, AppState>,
+    repo_id: Option<String>,
+) -> AppResult<crate::git::signature::GitIdentity> {
+    let backend = state.backend.clone();
+    let repo_id = repo_id.map(RepoId);
+    tokio::task::spawn_blocking(move || backend.identity(repo_id.as_ref()))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+/// Write `user.name` / `user.email` to the global git config (#212).
+///
+/// The remedy for `NoSignature`, and the only write in the app that touches the
+/// user's global git config — which is why it is deliberately explicit rather
+/// than something a commit does for you behind your back.
+#[tauri::command]
+pub async fn set_identity(
+    state: State<'_, AppState>,
+    name: String,
+    email: String,
+) -> AppResult<()> {
+    let backend = state.backend.clone();
+    tokio::task::spawn_blocking(move || backend.set_global_identity(&name, &email))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
 /// Signature status of one commit (#61 D6). Called lazily for the selected
 /// commit, never per log row.
 #[tauri::command]

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -266,6 +266,14 @@ impl GitBackend for CliBackend {
     ) -> AppResult<super::commit_template::CommitTemplate> {
         Err(AppError::NotImplemented)
     }
+
+    fn identity(&self, _repo_id: Option<&RepoId>) -> AppResult<super::signature::GitIdentity> {
+        Err(AppError::NotImplemented)
+    }
+
+    fn set_global_identity(&self, _name: &str, _email: &str) -> AppResult<()> {
+        Err(AppError::NotImplemented)
+    }
     fn branches(&self, _repo_id: &RepoId) -> AppResult<Vec<BranchInfo>> {
         Err(AppError::NotImplemented)
     }

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -4487,6 +4487,21 @@ impl GitBackend for Libgit2Backend {
         self.with_repo(repo_id, crate::git::commit_template::read)
     }
 
+    fn identity(&self, repo_id: Option<&RepoId>) -> AppResult<crate::git::signature::GitIdentity> {
+        match repo_id {
+            Some(repo_id) => {
+                self.with_repo(repo_id, |repo| crate::git::signature::read_identity(Some(repo)))
+            }
+            // No repository, no per-repo mutex to take: the global + system
+            // chain is the whole answer.
+            None => crate::git::signature::read_identity(None),
+        }
+    }
+
+    fn set_global_identity(&self, name: &str, email: &str) -> AppResult<()> {
+        crate::git::signature::set_global_identity(name, email)
+    }
+
     fn branches(&self, repo_id: &RepoId) -> AppResult<Vec<BranchInfo>> {
         self.with_repo(repo_id, |repo| {
             let head_ref = repo.head().ok();

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -534,6 +534,23 @@ pub trait GitBackend: Send + Sync {
     /// `git/commit_template.rs`.
     fn commit_template(&self, repo_id: &RepoId) -> AppResult<commit_template::CommitTemplate>;
 
+    // === identity ===
+    /// The committer identity a commit would use, and which config file each
+    /// half came from (#212).
+    ///
+    /// `repo_id` is optional because Settings is reachable with no repository
+    /// open, and the answer is still meaningful there: without a repository the
+    /// global + system chain IS the effective identity.
+    fn identity(&self, repo_id: Option<&RepoId>) -> AppResult<signature::GitIdentity>;
+
+    /// Write `user.name` / `user.email` to the global git config, creating the
+    /// file when there is none (#212).
+    ///
+    /// Takes no `repo_id`: the state this exists to fix is a machine with no
+    /// identity at all, so the fix has to outlive the repository the user
+    /// happened to be in. Per-repository identities are #233.
+    fn set_global_identity(&self, name: &str, email: &str) -> AppResult<()>;
+
     // === refs ===
     fn checkout_branch(&self, repo_id: &RepoId, name: &str) -> AppResult<()>;
     fn create_branch(&self, repo_id: &RepoId, name: &str, from: Option<&str>) -> AppResult<()>;

--- a/src-tauri/src/git/signature.rs
+++ b/src-tauri/src/git/signature.rs
@@ -1,19 +1,245 @@
+use std::path::PathBuf;
+
 use git2::{Repository, Signature};
+use serde::{Deserialize, Serialize};
 
 use crate::error::{AppError, AppResult};
+
+/// Which config file a `user.name` / `user.email` came from (#212).
+///
+/// Coarser than libgit2's `ConfigLevel` on purpose: what a user can act on is
+/// "this repository", "your account" or "this machine", and collapsing
+/// `Local`/`Worktree` and `Global`/`XDG` spares the UI having to explain the
+/// difference between `~/.gitconfig` and `~/.config/git/config`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum IdentityScope {
+    /// `.git/config` or a worktree-specific config — this repository only.
+    Repository,
+    /// `~/.gitconfig` or the XDG file — every repository for this user.
+    Global,
+    /// `/etc/gitconfig` (or Windows' ProgramData) — every user on this machine.
+    System,
+}
+
+/// One configured value plus where it came from.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfiguredValue {
+    /// Verbatim, INCLUDING a blank one — a `user.email =` line git refuses is a
+    /// state the user has to see to fix, and reporting it as absent would send
+    /// them looking for a line that is already there.
+    pub value: String,
+    pub scope: IdentityScope,
+}
+
+/// The committer identity a commit would use, and where each half comes from
+/// (#212).
+///
+/// Both halves are optional because the state this type exists to describe is a
+/// fresh machine, where neither is set. `usable()` is the question callers
+/// actually ask; a present-but-blank value is not usable, which is why
+/// `ConfiguredValue` keeps the raw string instead of being dropped.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitIdentity {
+    pub name: Option<ConfiguredValue>,
+    pub email: Option<ConfiguredValue>,
+    /// The file [`set_global_identity`] would write to, so the UI can name it
+    /// before anything changes. `None` only when no home directory resolves.
+    pub global_config_path: Option<String>,
+}
+
+impl GitIdentity {
+    /// Whether git could build a committer signature from this.
+    ///
+    /// Mirrors libgit2's own rule — both halves present and non-blank — so a UI
+    /// that gates on this agrees with what the commit will actually do.
+    pub fn usable(&self) -> bool {
+        let ok =
+            |v: &Option<ConfiguredValue>| v.as_ref().is_some_and(|c| !c.value.trim().is_empty());
+        ok(&self.name) && ok(&self.email)
+    }
+}
+
+fn scope_of(level: git2::ConfigLevel) -> IdentityScope {
+    use git2::ConfigLevel::*;
+    match level {
+        // `App` and `Highest` are libgit2's in-memory layers, above every file.
+        // Nothing here writes them; if one ever answers, it is closer to this
+        // repository than to the machine.
+        Local | Worktree | App | Highest => IdentityScope::Repository,
+        Global | XDG => IdentityScope::Global,
+        System | ProgramData => IdentityScope::System,
+    }
+}
+
+fn configured(cfg: &git2::Config, key: &str) -> Option<ConfiguredValue> {
+    // `get_entry` answers with the WINNING entry across every level — the one a
+    // commit would use, and the only one whose scope is worth reporting.
+    let entry = cfg.get_entry(key).ok()?;
+    Some(ConfiguredValue {
+        value: entry.value()?.to_string(),
+        scope: scope_of(entry.level()),
+    })
+}
+
+/// The identity a commit in `repo` would use. `None` reads the config chain
+/// with no repository open — the Settings screen before one is opened.
+pub fn read_identity(repo: Option<&Repository>) -> AppResult<GitIdentity> {
+    let mut cfg = match repo {
+        Some(repo) => repo.config()?,
+        None => git2::Config::open_default()?,
+    };
+    // A snapshot, so both reads see the same files even if something rewrites
+    // one between them.
+    let cfg = cfg.snapshot()?;
+    Ok(GitIdentity {
+        name: configured(&cfg, "user.name"),
+        email: configured(&cfg, "user.email"),
+        global_config_path: global_config_path()
+            .ok()
+            .map(|p| p.to_string_lossy().to_string()),
+    })
+}
+
+/// The file `git config --global` would write to.
+///
+/// Resolved the way git resolves it: `~/.gitconfig` when it exists, otherwise
+/// an existing XDG `git/config`, otherwise `~/.gitconfig` — the file git
+/// creates when neither is there. Naming a file that does not exist yet is the
+/// point; this runs on a fresh machine.
+pub fn global_config_path() -> AppResult<PathBuf> {
+    if let Ok(p) = git2::Config::find_global() {
+        return Ok(p);
+    }
+    if let Ok(p) = git2::Config::find_xdg() {
+        return Ok(p);
+    }
+    crate::git::blame::home_dir()
+        .map(|h| h.join(".gitconfig"))
+        .ok_or_else(|| {
+            AppError::Io("no home directory to write a global git config into".to_string())
+        })
+}
+
+/// A `user.name` / `user.email` a user typed, trimmed — or the reason git would
+/// refuse them.
+///
+/// git2 is the authority on that second question rather than a regex of our
+/// own: whatever it cannot build a `Signature` from is exactly what would fail
+/// at commit time, which is the failure this path exists to prevent. The
+/// explicit checks above it exist only to say WHICH rule was broken — git2's
+/// own "failed to parse signature" names none of them.
+pub fn validate_identity(name: &str, email: &str) -> AppResult<(String, String)> {
+    let name = name.trim();
+    let email = email.trim();
+    if name.is_empty() {
+        return Err(AppError::InvalidArgument("a name is required".to_string()));
+    }
+    if email.is_empty() {
+        return Err(AppError::InvalidArgument(
+            "an email address is required".to_string(),
+        ));
+    }
+    for (label, value) in [("name", name), ("email", email)] {
+        if let Some(c) = value.chars().find(|c| matches!(c, '<' | '>' | '\n' | '\r')) {
+            let what = if c == '\n' || c == '\r' {
+                "a line break".to_string()
+            } else {
+                format!("'{}'", c)
+            };
+            return Err(AppError::InvalidArgument(format!(
+                "a {} cannot contain {}",
+                label, what
+            )));
+        }
+    }
+    Signature::now(name, email).map_err(|e| {
+        AppError::InvalidArgument(format!("git will not accept this identity: {}", e.message()))
+    })?;
+    Ok((name.to_string(), email.to_string()))
+}
+
+/// Write `user.name` / `user.email` to the global git config, creating the file
+/// when there is none yet (#212).
+///
+/// Global rather than per-repository because the state this fixes is a machine
+/// with no identity at all, where per-repository would mean answering the same
+/// question again in every repository the user opens. Per-repository identities
+/// and multiple accounts are #233.
+///
+/// Validated BEFORE anything is opened, so a refused value leaves no file
+/// behind on a machine that had none — the same "a failure creates nothing"
+/// rule the signing chain follows.
+pub fn set_global_identity(name: &str, email: &str) -> AppResult<()> {
+    let (name, email) = validate_identity(name, email)?;
+    let path = global_config_path()?;
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    // libgit2 will open a config file that is not there, but it is not
+    // documented to create one — and an XDG path's directory may not exist
+    // either. Creating it first makes both cases the same case.
+    if !path.exists() {
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)?;
+    }
+    let mut cfg = git2::Config::open(&path)?;
+    cfg.set_str("user.name", &name)?;
+    cfg.set_str("user.email", &email)?;
+    Ok(())
+}
+
+/// Whether the configured `user.name` / `user.email` are an identity git would
+/// accept — asked of the CONFIG, not of an error message.
+///
+/// This is what separates `NoSignature` from a genuine git failure, and it has
+/// to read the config because libgit2's error codes do not distinguish the two
+/// cases that matter: a MISSING `user.name` comes back as `NotFound`, while a
+/// BLANK or malformed one comes back as a generic error whose only
+/// distinguishing mark is prose ("failed to parse signature - Signature cannot
+/// have an empty name or email"). Matching on that string would be a parser for
+/// another project's wording.
+///
+/// [`validate_identity`] is deliberately the same rule the writer enforces, so
+/// "what this app will save" and "what this app calls a missing identity" can
+/// never drift apart.
+fn configured_identity_is_valid(repo: &Repository) -> bool {
+    let Ok(mut cfg) = repo.config() else {
+        return false;
+    };
+    let Ok(cfg) = cfg.snapshot() else {
+        return false;
+    };
+    let (Ok(name), Ok(email)) = (cfg.get_string("user.name"), cfg.get_string("user.email")) else {
+        return false;
+    };
+    validate_identity(&name, &email).is_ok()
+}
 
 /// Resolve a `Signature` from the repository's config.
 ///
 /// Priority: repo-local config → global → system. Fails with
-/// `AppError::NoSignature` when `user.name` or `user.email` is missing.
+/// `AppError::NoSignature` when there is no identity git will accept —
+/// missing, blank, or malformed, because all three have the same remedy and
+/// the identity prompt shows the offending value back to the user.
+///
+/// Before #212 only the MISSING case was `NoSignature`; a blank `user.email`
+/// reached the user as the raw libgit2 string "failed to parse signature",
+/// which names neither the key nor the fix.
 pub fn default_signature<'a>(repo: &'a Repository) -> AppResult<Signature<'a>> {
     match repo.signature() {
         Ok(sig) => Ok(sig),
         Err(e) => {
-            if e.code() == git2::ErrorCode::NotFound {
-                Err(AppError::NoSignature)
-            } else {
+            if configured_identity_is_valid(repo) {
                 Err(e.into())
+            } else {
+                Err(AppError::NoSignature)
             }
         }
     }
@@ -72,6 +298,80 @@ fn is_trailer_line(line: &str) -> bool {
             !key.is_empty() && key.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
         }
         None => false,
+    }
+}
+
+#[cfg(test)]
+mod identity_tests {
+    use super::{validate_identity, ConfiguredValue, GitIdentity, IdentityScope};
+    use crate::error::AppError;
+
+    fn refusal(name: &str, email: &str) -> String {
+        match validate_identity(name, email) {
+            Err(AppError::InvalidArgument(m)) => m,
+            other => panic!("expected InvalidArgument for ({name:?}, {email:?}), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn trims_what_it_accepts() {
+        let (name, email) = validate_identity("  Ada Lovelace \t", " ada@example.com ").unwrap();
+        assert_eq!(name, "Ada Lovelace");
+        assert_eq!(email, "ada@example.com");
+    }
+
+    #[test]
+    fn names_which_half_is_missing() {
+        assert!(refusal("", "ada@example.com").contains("name"));
+        assert!(refusal("   ", "ada@example.com").contains("name"));
+        assert!(refusal("Ada", "").contains("email"));
+        assert!(refusal("Ada", "  \t ").contains("email"));
+    }
+
+    #[test]
+    fn names_the_character_git_would_choke_on() {
+        // `<` and `>` delimit the email in a commit's author line, so git
+        // refuses them anywhere in either half. The message has to say which
+        // character, because "failed to parse signature" does not.
+        assert!(refusal("Ada <Lovelace>", "ada@example.com").contains("'<'"));
+        assert!(refusal("Ada", "ada<@example.com").contains("'<'"));
+        assert!(refusal("Ada", "ada@example.com>").contains("'>'"));
+        assert!(refusal("Ada\nLovelace", "ada@example.com").contains("line break"));
+        assert!(refusal("Ada", "ada\r@example.com").contains("line break"));
+        // A line break at either END is whitespace and is trimmed, not
+        // refused — a pasted value with a stray newline still saves.
+        assert!(validate_identity("Ada\n", "ada@example.com\r\n").is_ok());
+    }
+
+    #[test]
+    fn a_plain_identity_is_accepted() {
+        assert!(validate_identity("Ada Lovelace", "ada@example.com").is_ok());
+        // Unicode, and the `+` and `.` forms real addresses use.
+        assert!(validate_identity("Ada Løvelace 김", "ada.b+git@example.co.uk").is_ok());
+    }
+
+    fn value(v: &str) -> Option<ConfiguredValue> {
+        Some(ConfiguredValue {
+            value: v.to_string(),
+            scope: IdentityScope::Global,
+        })
+    }
+
+    #[test]
+    fn usable_needs_both_halves_non_blank() {
+        let id = |name, email| GitIdentity {
+            name,
+            email,
+            global_config_path: None,
+        };
+        assert!(id(value("Ada"), value("ada@example.com")).usable());
+        assert!(!id(None, value("ada@example.com")).usable());
+        assert!(!id(value("Ada"), None).usable());
+        assert!(!id(None, None).usable());
+        // Present but blank is the case that used to reach the user as raw
+        // libgit2 text — it is NOT usable.
+        assert!(!id(value("Ada"), value("   ")).usable());
+        assert!(!id(value(""), value("ada@example.com")).usable());
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -239,6 +239,8 @@ pub fn run() {
             commands::commits::verify_commit,
             commands::commits::commit_notes,
             commands::commits::get_commit_template,
+            commands::commits::get_identity,
+            commands::commits::set_identity,
             commands::create::init_repo,
             commands::create::default_init_branch,
             commands::create::clone_repo,

--- a/src-tauri/tests/identity.rs
+++ b/src-tauri/tests/identity.rs
@@ -1,0 +1,251 @@
+//! The committer identity on a machine that has none (#212).
+//!
+//! Every other test in this suite gets a repo-local `user.name` / `user.email`
+//! from `support::TempRepo::fresh` — deliberately, "so commit() works without
+//! global config leaking in". That is why the fresh-machine path went
+//! unexercised: the state a brand-new user is actually in was the one state no
+//! test could reach.
+//!
+//! **One test function on purpose.** libgit2's config search paths and `HOME`
+//! are process-global, and this file redirects both at a tempdir so it can
+//! create and rewrite a *global* git config without touching the developer's
+//! own. Splitting the story across `#[test]` functions would run them
+//! concurrently against that one shared file.
+
+mod support;
+
+use std::path::PathBuf;
+
+use git2::ConfigLevel;
+use platypusgit_lib::{
+    error::AppError,
+    git::{
+        signature::{IdentityScope, GitIdentity},
+        types::CommitOptions,
+        GitBackend,
+    },
+};
+use support::TempRepo;
+
+/// Point libgit2's global, XDG and system config lookups — and `HOME`, which
+/// `signature::global_config_path` falls back to — at throwaway directories.
+///
+/// Without the XDG and system redirects this test would find the developer's
+/// real `~/.config/git/config` or `/etc/gitconfig`, and `set_global_identity`
+/// would then WRITE to it.
+fn isolate_config(home: &std::path::Path) {
+    let xdg = home.join("xdg");
+    let system = home.join("system");
+    std::fs::create_dir_all(&xdg).unwrap();
+    std::fs::create_dir_all(&system).unwrap();
+    unsafe {
+        git2::opts::set_search_path(ConfigLevel::Global, home.to_str().unwrap()).unwrap();
+        git2::opts::set_search_path(ConfigLevel::XDG, xdg.to_str().unwrap()).unwrap();
+        git2::opts::set_search_path(ConfigLevel::System, system.to_str().unwrap()).unwrap();
+    }
+    std::env::set_var("HOME", home);
+    std::env::set_var("USERPROFILE", home);
+    std::env::set_var("XDG_CONFIG_HOME", &xdg);
+}
+
+/// Strip the repo-local identity `TempRepo` installs, so the repository is in
+/// the state a real clone on a fresh machine is in.
+fn strip_local_identity(repo_path: &std::path::Path) {
+    let mut cfg = git2::Config::open(&repo_path.join(".git").join("config")).unwrap();
+    cfg.remove("user.name").unwrap();
+    cfg.remove("user.email").unwrap();
+}
+
+fn value_of(v: &Option<platypusgit_lib::git::signature::ConfiguredValue>) -> Option<&str> {
+    v.as_ref().map(|c| c.value.as_str())
+}
+
+fn scope_of(v: &Option<platypusgit_lib::git::signature::ConfiguredValue>) -> Option<IdentityScope> {
+    v.as_ref().map(|c| c.scope)
+}
+
+#[test]
+fn a_machine_with_no_identity_can_be_told_who_it_is() {
+    let home = tempfile::tempdir().expect("fake home");
+    isolate_config(home.path());
+
+    let tr = TempRepo::fresh();
+    strip_local_identity(tr.path());
+    let (backend, handle) = tr.open_with_backend();
+    support::fs::write_file(tr.path(), "README.md", "hello\n");
+    backend
+        .stage(&handle.id, &[PathBuf::from("README.md")])
+        .expect("stage");
+
+    // --- 1. Nothing configured anywhere: the identity reads as absent, and the
+    // path a fix would be written to is named even though no such file exists.
+    let identity: GitIdentity = backend.identity(Some(&handle.id)).expect("identity");
+    assert_eq!(value_of(&identity.name), None);
+    assert_eq!(value_of(&identity.email), None);
+    assert!(!identity.usable());
+    let global_path = PathBuf::from(
+        identity
+            .global_config_path
+            .as_deref()
+            .expect("a global config path to write to"),
+    );
+    assert!(
+        !global_path.exists(),
+        "the fresh machine must not already have a global config: {}",
+        global_path.display()
+    );
+
+    // --- 2. Committing raises NoSignature, NOT a stringified libgit2 error —
+    // and creates nothing, so HEAD is still unborn afterwards.
+    let err = backend
+        .commit(
+            &handle.id,
+            CommitOptions {
+                message: "initial".to_string(),
+                amend: false,
+                author_override: None,
+                signoff: false,
+                sign: None,
+                no_verify: false,
+            },
+        )
+        .expect_err("a commit with no identity must fail");
+    assert!(
+        matches!(err, AppError::NoSignature),
+        "expected NoSignature, got {:?}",
+        err
+    );
+    assert!(
+        git2::Repository::open(tr.path()).unwrap().head().is_err(),
+        "the refused commit must have created nothing"
+    );
+
+    // --- 3. Refusals validate before touching the filesystem: a rejected
+    // identity leaves the machine exactly as it was, with no config file.
+    for (name, email) in [
+        ("", "ada@example.com"),
+        ("   ", "ada@example.com"),
+        ("Ada Lovelace", ""),
+        ("Ada <Lovelace>", "ada@example.com"),
+        ("Ada Lovelace", "ada@exa<mple.com"),
+        ("Ada\nLovelace", "ada@example.com"),
+    ] {
+        let err = backend
+            .set_global_identity(name, email)
+            .expect_err("expected a refusal");
+        assert!(
+            matches!(err, AppError::InvalidArgument(_)),
+            "expected InvalidArgument for ({name:?}, {email:?}), got {err:?}"
+        );
+    }
+    assert!(
+        !global_path.exists(),
+        "a refused identity must not have created a config file"
+    );
+
+    // --- 4. Setting it creates the global config and the commit goes through,
+    // attributed to what was typed. Surrounding whitespace is trimmed, the way
+    // git trims it.
+    backend
+        .set_global_identity("  Ada Lovelace  ", " ada@example.com ")
+        .expect("set identity");
+    assert!(
+        global_path.exists(),
+        "the global config should have been created at {}",
+        global_path.display()
+    );
+
+    let identity = backend.identity(Some(&handle.id)).expect("identity");
+    assert_eq!(value_of(&identity.name), Some("Ada Lovelace"));
+    assert_eq!(value_of(&identity.email), Some("ada@example.com"));
+    assert_eq!(scope_of(&identity.name), Some(IdentityScope::Global));
+    assert!(identity.usable());
+
+    let result = backend
+        .commit(
+            &handle.id,
+            CommitOptions {
+                message: "initial".to_string(),
+                amend: false,
+                author_override: None,
+                signoff: false,
+                sign: None,
+                no_verify: false,
+            },
+        )
+        .expect("commit after the identity is set");
+    let repo = git2::Repository::open(tr.path()).unwrap();
+    let commit = repo
+        .find_commit(git2::Oid::from_str(&result.oid).unwrap())
+        .unwrap();
+    assert_eq!(commit.author().name(), Some("Ada Lovelace"));
+    assert_eq!(commit.author().email(), Some("ada@example.com"));
+
+    // --- 5. Rewriting it overwrites rather than appending a second pair — a
+    // duplicated key in a git config is legal and the LAST one wins, so an
+    // append-only writer would look correct here and diverge the moment
+    // anything read the file with `--get`.
+    backend
+        .set_global_identity("Grace Hopper", "grace@example.com")
+        .expect("rewrite identity");
+    let text = std::fs::read_to_string(&global_path).unwrap();
+    assert_eq!(
+        text.matches("email").count(),
+        1,
+        "user.email should appear once, not once per save:\n{text}"
+    );
+    let identity = backend.identity(Some(&handle.id)).expect("identity");
+    assert_eq!(value_of(&identity.email), Some("grace@example.com"));
+
+    // --- 6. A repo-local identity wins, and says so, so the UI can explain why
+    // changing the global one changed nothing.
+    {
+        let mut cfg = git2::Config::open(&tr.path().join(".git").join("config")).unwrap();
+        cfg.set_str("user.name", "Repo Local").unwrap();
+        cfg.set_str("user.email", "local@example.com").unwrap();
+    }
+    let identity = backend.identity(Some(&handle.id)).expect("identity");
+    assert_eq!(value_of(&identity.name), Some("Repo Local"));
+    assert_eq!(scope_of(&identity.name), Some(IdentityScope::Repository));
+    assert_eq!(scope_of(&identity.email), Some(IdentityScope::Repository));
+
+    // --- 7. With no repository open at all, the global chain is still the
+    // answer — this is what Settings reads before a repo is opened.
+    let identity = backend.identity(None).expect("identity with no repo");
+    assert_eq!(value_of(&identity.name), Some("Grace Hopper"));
+    assert_eq!(scope_of(&identity.name), Some(IdentityScope::Global));
+
+    // --- 8. A configured-but-BLANK identity is `NoSignature` too, not a raw
+    // "failed to parse signature" from libgit2: the remedy is identical, and
+    // the value is reported back verbatim so the user can see the empty line
+    // rather than hunt for a missing one.
+    {
+        let mut cfg = git2::Config::open(&tr.path().join(".git").join("config")).unwrap();
+        cfg.set_str("user.email", "   ").unwrap();
+    }
+    support::fs::write_file(tr.path(), "second.md", "more\n");
+    backend
+        .stage(&handle.id, &[PathBuf::from("second.md")])
+        .expect("stage");
+    let err = backend
+        .commit(
+            &handle.id,
+            CommitOptions {
+                message: "second".to_string(),
+                amend: false,
+                author_override: None,
+                signoff: false,
+                sign: None,
+                no_verify: false,
+            },
+        )
+        .expect_err("a blank email must fail");
+    assert!(
+        matches!(err, AppError::NoSignature),
+        "expected NoSignature for a blank email, got {:?}",
+        err
+    );
+    let identity = backend.identity(Some(&handle.id)).expect("identity");
+    assert_eq!(value_of(&identity.email), Some("   "));
+    assert!(!identity.usable(), "a blank email is not a usable identity");
+}

--- a/src/features/commits/identity/IdentityForm.tsx
+++ b/src/features/commits/identity/IdentityForm.tsx
@@ -1,0 +1,280 @@
+// The committer identity (#212) — one form, two places.
+//
+// Why this exists at all: `user.name` / `user.email` are the ONLY thing a brand
+// new user must configure before the app can do the thing it is for, and until
+// #212 there was nowhere in the app to set them. A fresh machine's first commit
+// failed with a banner reading "NoSignature" and the app offered nothing to
+// click.
+//
+// Why ONE component for both surfaces: the commit panel's prompt and the
+// Settings section ask the identical question, and two forms would drift — one
+// would learn that a blank email is refused and the other would not. The
+// difference between them is framing, not behaviour, so it is a prop.
+//
+// Global, not per-repository, deliberately: the state being fixed is a machine
+// with no identity at all, and per-repository would ask the same question again
+// in every repository the user opens. Per-repository identities and multiple
+// accounts are #233; when that lands, this form grows a scope control rather
+// than a sibling.
+
+import * as React from "react";
+
+import { PGButton, PGIcon, PGInput } from "@/design";
+import { appErrorMessage } from "@/lib/errors";
+import { getIdentity, setIdentity } from "@/lib/tauri";
+import type { GitIdentity, IdentityScope } from "@/lib/types";
+
+/** Where a value came from, as a user reads it. */
+function scopeLabel(scope: IdentityScope): string {
+  switch (scope) {
+    case "repository":
+      return "this repository";
+    case "system":
+      return "this machine";
+    default:
+      return "your global git config";
+  }
+}
+
+/**
+ * The identity's current state as one line of prose, or null when there is
+ * nothing worth saying.
+ *
+ * A repo-local value is the one worth naming: saving here writes the GLOBAL
+ * config, so a user whose repository overrides it would otherwise save, see no
+ * change, and conclude the app is broken.
+ */
+function currentStateNote(identity: GitIdentity | null): string | null {
+  if (!identity) return null;
+  const overrides = [
+    identity.name?.scope === "repository" ? "name" : null,
+    identity.email?.scope === "repository" ? "email" : null,
+  ].filter(Boolean) as string[];
+  if (overrides.length === 0) return null;
+  // No issue number in prose a user reads — "#233" means nothing to them, and
+  // the sentence has to end with something they can act on instead.
+  return `This repository sets its own ${overrides.join(" and ")} in its .git/config, which wins over anything saved here. Saving will not change what this repository's commits are recorded as.`;
+}
+
+/**
+ * Where the values in the fields came from, as one line — naming BOTH halves
+ * when they disagree.
+ *
+ * They can: `user.name` from `/etc/gitconfig` and `user.email` from
+ * `~/.gitconfig` is an ordinary state on a managed machine, and reporting only
+ * the first would be a confident wrong answer about the second.
+ */
+function sourceNote(identity: GitIdentity): string | null {
+  const { name, email } = identity;
+  if (!name && !email) return null;
+  if (name && email) {
+    return name.scope === email.scope
+      ? `Currently read from ${scopeLabel(name.scope)}.`
+      : `Name read from ${scopeLabel(name.scope)}, email from ${scopeLabel(email.scope)}.`;
+  }
+  const half = name ? "Name" : "Email";
+  const only = (name ?? email)!;
+  // One half set and the other not is exactly the state git refuses on, so say
+  // which one is still missing rather than only where the other came from.
+  return `${half} read from ${scopeLabel(only.scope)}; the other is not set.`;
+}
+
+export interface IdentityFormProps {
+  /** Read the effective identity for this repository; omit for global only. */
+  repoId?: string | null;
+  /**
+   * Called after a successful save. The commit panel retries the commit here;
+   * Settings just re-reads.
+   */
+  onSaved?: () => void;
+  /** Label for the confirm button — the one thing the two surfaces differ on. */
+  saveLabel?: string;
+  autoFocus?: boolean;
+}
+
+export function IdentityForm({
+  repoId,
+  onSaved,
+  saveLabel = "Save",
+  autoFocus,
+}: IdentityFormProps) {
+  const [identity, setLoaded] = React.useState<GitIdentity | null>(null);
+  const [name, setName] = React.useState("");
+  const [email, setEmail] = React.useState("");
+  const [saving, setSaving] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [saved, setSaved] = React.useState(false);
+
+  // One load per mount. The fields are seeded from it ONCE: re-seeding on every
+  // read would wipe what the user is typing the moment anything refreshed.
+  React.useEffect(() => {
+    let alive = true;
+    void (async () => {
+      try {
+        const next = await getIdentity(repoId ?? null);
+        if (!alive) return;
+        setLoaded(next);
+        setName(next.name?.value ?? "");
+        setEmail(next.email?.value ?? "");
+      } catch (e) {
+        if (!alive) return;
+        // Reading the config failed, which is not the same as having no
+        // identity — say so rather than presenting empty fields as the truth.
+        setError(appErrorMessage(e));
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [repoId]);
+
+  // Mirrors the backend's own precondition, so the button is not offering to do
+  // something that will be refused. Everything BEYOND blankness (a `<`, a line
+  // break) is left to the backend on purpose — one rule, in one place, and the
+  // refusal it returns names the character.
+  const canSave = name.trim() !== "" && email.trim() !== "" && !saving;
+
+  async function save() {
+    if (!canSave) return;
+    setSaving(true);
+    setError(null);
+    setSaved(false);
+    try {
+      await setIdentity(name, email);
+      setSaved(true);
+      // Re-read rather than assume: this is what proves the write landed where
+      // the form said it would, and it picks up a repo-local override that is
+      // still winning.
+      try {
+        setLoaded(await getIdentity(repoId ?? null));
+      } catch {
+        // The write succeeded; a failed re-read is not worth an error banner
+        // over the top of it.
+      }
+      onSaved?.();
+    } catch (e) {
+      setError(appErrorMessage(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const note = currentStateNote(identity);
+  const target = identity?.globalConfigPath;
+
+  return (
+    <div
+      data-testid="identity-form"
+      style={{ display: "flex", flexDirection: "column", gap: 8 }}
+    >
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <label style={{ flex: "1 1 160px", minWidth: 0 }}>
+          <div style={fieldLabel}>Name</div>
+          <PGInput
+            value={name}
+            onChange={setName}
+            placeholder="Ada Lovelace"
+            autoFocus={autoFocus}
+            data-testid="identity-name"
+            aria-label="Name"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void save();
+            }}
+          />
+        </label>
+        <label style={{ flex: "1 1 200px", minWidth: 0 }}>
+          <div style={fieldLabel}>Email</div>
+          <PGInput
+            value={email}
+            onChange={setEmail}
+            placeholder="ada@example.com"
+            data-testid="identity-email"
+            aria-label="Email"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void save();
+            }}
+          />
+        </label>
+      </div>
+
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <PGButton
+          size="sm"
+          variant="primary"
+          disabled={!canSave}
+          onClick={() => void save()}
+          data-testid="identity-save"
+        >
+          {saving ? "Saving…" : saveLabel}
+        </PGButton>
+        {/* Naming the file is the honest version of "Save": this is a write to
+            the user's own git config, outside the app's own settings. */}
+        {target && (
+          <span
+            style={{ fontSize: "var(--fs-11)", color: "var(--fg-3)" }}
+            data-testid="identity-target"
+          >
+            Writes user.name and user.email to {target}
+          </span>
+        )}
+      </div>
+
+      {saved && !error && (
+        <div
+          data-testid="identity-saved"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            fontSize: "var(--fs-11)",
+            color: "var(--fg-2)",
+          }}
+        >
+          <PGIcon name="check" size={11} />
+          Saved.
+        </div>
+      )}
+
+      {error && (
+        <div
+          data-testid="identity-error"
+          style={{ fontSize: "var(--fs-11)", color: "var(--git-removed)" }}
+        >
+          {error}
+        </div>
+      )}
+
+      {note && (
+        <div
+          data-testid="identity-scope-note"
+          style={{
+            fontSize: "var(--fs-11)",
+            color: "var(--fg-3)",
+            lineHeight: 1.5,
+          }}
+        >
+          {note}
+        </div>
+      )}
+
+      {/* Where the values in the fields came from, when they came from
+          somewhere. Silent on a fresh machine, where there is nothing to
+          report and a "not configured" line would just be noise beside two
+          empty inputs. */}
+      {identity && !note && sourceNote(identity) && (
+        <div
+          data-testid="identity-source"
+          style={{ fontSize: "var(--fs-11)", color: "var(--fg-3)" }}
+        >
+          {sourceNote(identity)}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const fieldLabel: React.CSSProperties = {
+  fontSize: "var(--fs-11)",
+  color: "var(--fg-3)",
+  marginBottom: 3,
+};

--- a/src/features/commits/identity/NoSignaturePrompt.tsx
+++ b/src/features/commits/identity/NoSignaturePrompt.tsx
@@ -1,0 +1,99 @@
+// "git does not know who you are" (#212), as a thing you can fix in place.
+//
+// Shaped after `PGHookOutput`, for the same reasons and one more:
+//
+//   - Inline, not a modal: a modal over the commit panel would cover the
+//     staged files and the message the user is one click from committing.
+//   - Not the error banner: a banner is something you acknowledge, and this is
+//     something you answer. Before #212 it WAS the banner, and it read
+//     "NoSignature".
+//   - Persistent until answered or dismissed, because the very next thing the
+//     user does is type into it.
+//
+// It sits beside the hook block rather than replacing it: they are different
+// refusals with different remedies, and a repository can produce both.
+
+import { PGButton, PGIcon } from "@/design";
+import { NO_SIGNATURE_HELP, NO_SIGNATURE_MESSAGE } from "@/lib/errors";
+
+import { IdentityForm } from "./IdentityForm";
+
+export function NoSignaturePrompt({
+  repoId,
+  onSaved,
+  onDismiss,
+}: {
+  repoId: string;
+  /**
+   * The identity is set — retry the commit. Retrying rather than just closing
+   * is the point: the user already typed a message and pressed Commit, and
+   * making them press it again is a second failure with extra steps.
+   */
+  onSaved: () => void;
+  onDismiss: () => void;
+}) {
+  return (
+    <div
+      // Child testids deliberately do NOT share this prefix — WebdriverIO
+      // compiles `[data-testid="x"]*=text` to a substring attribute match, so a
+      // child called `no-signature-body` would satisfy the container's own
+      // condition and the container would match nothing. See the e2e-testing
+      // skill.
+      data-testid="no-signature"
+      style={{
+        border: "1px solid var(--border-1)",
+        borderRadius: "var(--r-4)",
+        background: "var(--bg-1)",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "6px 8px",
+        }}
+      >
+        <PGIcon name="user" />
+        <span style={{ flex: 1, fontSize: "var(--fs-12)", fontWeight: 600 }}>
+          {NO_SIGNATURE_MESSAGE}
+        </span>
+        <PGButton
+          size="xs"
+          variant="ghost"
+          onClick={onDismiss}
+          data-testid="identity-dismiss"
+        >
+          Dismiss
+        </PGButton>
+      </div>
+
+      <div
+        style={{
+          padding: "8px",
+          borderTop: "1px solid var(--border-0)",
+          display: "flex",
+          flexDirection: "column",
+          gap: 8,
+        }}
+      >
+        <div
+          style={{
+            fontSize: "var(--fs-11)",
+            color: "var(--fg-3)",
+            lineHeight: 1.5,
+          }}
+        >
+          {NO_SIGNATURE_HELP}
+        </div>
+        <IdentityForm
+          repoId={repoId}
+          onSaved={onSaved}
+          saveLabel="Save and commit"
+          autoFocus
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/repo/repoSlice.ts
+++ b/src/features/repo/repoSlice.ts
@@ -182,6 +182,16 @@ export interface RepoSlice {
    * scrolls, and the user is about to act on it rather than dismiss it.
    */
   hookRejection: HookRejection | null;
+  /**
+   * A commit that was refused because git has no committer identity it will
+   * accept (#212).
+   *
+   * Per-repo for the same reason `hookRejection` is, and kept out of `error`
+   * for the same reason too: the remedy is a form, not an acknowledgement. A
+   * fresh machine hits this on its very first commit, and before #212 it got a
+   * banner reading "NoSignature" and no way to fix it from inside the app.
+   */
+  noSignature: boolean;
 }
 
 /**
@@ -220,6 +230,7 @@ export function emptySlice(): RepoSlice {
     loadingTasks: [],
     cancelRequested: false,
     hookRejection: null,
+    noSignature: false,
   };
 }
 

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -22,6 +22,7 @@ import {
   isAuthError,
   isCancelledError,
   isDubiousOwnershipError,
+  isNoSignatureError,
   toAppError,
 } from "@/lib/errors";
 import { useAuthStore } from "@/features/auth/useAuthStore";
@@ -274,6 +275,11 @@ interface RepoStoreState extends RepoSlice {
   ) => Promise<CommitResult | null>;
   /** Dismiss the hook refusal on display (#232). */
   clearHookRejection: () => void;
+  /**
+   * Dismiss the "no committer identity" prompt (#212). Called after the
+   * identity is saved, and by the prompt's own Dismiss.
+   */
+  clearNoSignature: () => void;
   reset: (target: string, mode: ResetMode) => Promise<void>;
   checkoutBranch: (name: string) => Promise<void>;
   checkoutRef: (reference: string) => Promise<void>;
@@ -1199,7 +1205,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return null;
     // Clear the previous refusal first: a stale block sitting above a fresh
     // attempt reads as though the new attempt failed too.
-    setFor(repo.id, { hookRejection: null });
+    setFor(repo.id, { hookRejection: null, noSignature: false });
     try {
       const result = await commitFn(
         repo.id,
@@ -1223,6 +1229,14 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         setFor(repo.id, { hookRejection: e.message as HookRejection });
         return null;
       }
+      // Nor is a missing identity (#212). It is not a failure to report but a
+      // question to answer, and the panel can answer it in place — so it gets
+      // its own field rather than a banner, the same split the hook refusal
+      // above makes. Nothing was created, so nothing needs refreshing.
+      if (isNoSignatureError(e)) {
+        setFor(repo.id, { noSignature: true });
+        return null;
+      }
       setErrorFor(repo.id, e);
       return null;
     }
@@ -1232,6 +1246,12 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     const repo = get().current;
     if (!repo) return;
     setFor(repo.id, { hookRejection: null });
+  },
+
+  clearNoSignature() {
+    const repo = get().current;
+    if (!repo) return;
+    setFor(repo.id, { noSignature: false });
   },
 
   async checkoutBranch(name) {

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -24,9 +24,27 @@ describe("describeError", () => {
   });
 
   it("renders a kind whose message is absent as just the kind", () => {
-    expect(describeError({ kind: "Unborn" })).toBe("Unborn");
+    // The two examples here have to be variants that carry no prose AND are
+    // never shown to a user — i.e. members of `NEVER_RENDERED` in
+    // `test/appErrors.test.ts`, which is the list that keeps the two in step.
+    // This case used to use `Unborn`, until #212 gave it prose: a user who ran
+    // an op on a freshly-initialised repository was being shown git's internal
+    // word for "a branch with no commits on it".
+    expect(describeError({ kind: "NoBisect" })).toBe("NoBisect");
     expect(describeError({ kind: "NotImplemented", message: undefined })).toBe(
       "NotImplemented",
+    );
+  });
+
+  it("leads a payload-less variant that HAS prose with its kind (#212)", () => {
+    // A log line keeps the discriminant — it is the greppable half — so prose
+    // for a unit variant adds to the line rather than replacing it. A banner,
+    // by contrast, gets the prose alone (`appErrorMessage`).
+    expect(describeError({ kind: "Unborn" })).toMatch(
+      /^Unborn: This repository has no commits yet/,
+    );
+    expect(describeError({ kind: "NoSignature" })).toMatch(
+      /^NoSignature: git needs a name and an email/,
     );
   });
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -168,6 +168,21 @@ function appErrorDetail(e: AppError): string {
   if (e.kind === "BranchExists" && typeof message === "string") {
     return `A local branch named ${message} already exists.`;
   }
+  // NoSignature carries NO payload — a unit variant in Rust. Without a case
+  // here `appErrorMessage` fell through to its `|| e.kind` fallback and a
+  // fresh machine's first commit put the literal string "NoSignature" on
+  // screen (#212). It is the ONE error every brand-new user hits, so it is the
+  // last one that should have read like an enum.
+  if (e.kind === "NoSignature") {
+    return NO_SIGNATURE_MESSAGE;
+  }
+  // Unborn is a unit variant too, and had the same problem: an op run on a
+  // freshly-initialised repository put the word "Unborn" on screen, which is
+  // git's internal vocabulary for a branch with no commits on it (#212's
+  // empty-repository box).
+  if (e.kind === "Unborn") {
+    return "This repository has no commits yet, so there is nothing to show here. Make the first commit and this fills in.";
+  }
   // SshKeyExists carries a PATH. Rendered raw the banner would be a file name
   // with no hint that the app refused on purpose rather than failed.
   if (e.kind === "SshKeyExists" && typeof message === "string") {
@@ -398,6 +413,32 @@ export function isLfsUnavailableError(e: unknown): boolean {
 
 export const LFS_UNAVAILABLE_HELP =
   "Install git-lfs and run `git lfs install` once, then reopen the repository. Large files stay as pointer text until their objects are fetched.";
+
+/**
+ * What a banner says when git has no committer identity it will accept (#212).
+ *
+ * Names the two config keys, because that is what every git answer on the
+ * internet names — a user who has seen `git config --global user.email` before
+ * recognises this instantly, and one who has not is told the app can do it.
+ */
+export const NO_SIGNATURE_MESSAGE =
+  "git needs a name and an email address before it can record a commit (user.name and user.email are not set).";
+
+/**
+ * Narrow to "there is no committer identity" (#212), so a surface can offer to
+ * SET one instead of reporting a failure.
+ *
+ * The shape `isLfsUnavailableError` and `isSshKeygenUnavailableError` already
+ * use: a state with a specific remedy, not an error to acknowledge. Raised for
+ * a missing identity, a blank one, and one git refuses to parse — all three
+ * have the same fix, and the prompt shows the offending value back.
+ */
+export function isNoSignatureError(e: unknown): boolean {
+  return isAppError(e) && e.kind === "NoSignature";
+}
+
+export const NO_SIGNATURE_HELP =
+  "Every commit records who made it. git reads that from user.name and user.email in your git config, and refuses to commit without them — this machine has none set yet. Saving here writes them to your global git config, so every repository on this machine gets them.";
 
 /** Narrow to "there is already a key at that path" (#248). */
 export function isSshKeyExistsError(e: unknown): boolean {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -28,6 +28,7 @@ import type {
   FileStatus,
   ForgeCheckoutRequest,
   ForgeDetection,
+  GitIdentity,
   ForgeIdentity,
   ForgeKind,
   ForgeRepo,
@@ -542,6 +543,28 @@ export async function verifyCommit(
  */
 export async function getCommitTemplate(repoId: string): Promise<CommitTemplate> {
   return invoke<CommitTemplate>("get_commit_template", { repoId });
+}
+
+/**
+ * The committer identity a commit would use, and where each half is configured
+ * (#212).
+ *
+ * `repoId` is optional because Settings is reachable before a repository is
+ * open, and the global + system chain is the effective identity there.
+ */
+export async function getIdentity(repoId?: string | null): Promise<GitIdentity> {
+  return invoke<GitIdentity>("get_identity", { repoId: repoId ?? null });
+}
+
+/**
+ * Write `user.name` / `user.email` to the global git config (#212) — the remedy
+ * for `NoSignature`.
+ *
+ * Rejects with `InvalidArgument` for anything git would refuse, and writes
+ * nothing in that case.
+ */
+export async function setIdentity(name: string, email: string): Promise<void> {
+  return invoke<void>("set_identity", { name, email });
 }
 
 export async function discardPaths(repoId: string, paths: string[]): Promise<void> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -977,6 +977,47 @@ export interface CommitTemplate {
 }
 
 /**
+ * Which config file a `user.name` / `user.email` came from (#212). Mirrors Rust
+ * `git/signature.rs::IdentityScope`.
+ */
+export type IdentityScope = "repository" | "global" | "system";
+
+/** One configured value plus where it came from. */
+export interface ConfiguredValue {
+  /**
+   * Verbatim, INCLUDING a blank one — a `user.email =` line git refuses is a
+   * state the user has to see to fix.
+   */
+  value: string;
+  scope: IdentityScope;
+}
+
+/**
+ * The committer identity a commit would use (#212). Mirrors Rust
+ * `git/signature.rs::GitIdentity`.
+ *
+ * Both halves are optional because the state this describes is a fresh
+ * machine, where neither is set — the case that used to end in a banner
+ * reading "NoSignature" with nothing to click.
+ */
+export interface GitIdentity {
+  name: ConfiguredValue | null;
+  email: ConfiguredValue | null;
+  /** The file a save would write to, so the UI can name it beforehand. */
+  globalConfigPath: string | null;
+}
+
+/**
+ * Whether git could build a committer signature from this — both halves
+ * present and non-blank, the same rule `GitIdentity::usable` applies in Rust.
+ */
+export function identityIsUsable(identity: GitIdentity | null): boolean {
+  if (!identity) return false;
+  const ok = (v: ConfiguredValue | null) => !!v && v.value.trim() !== "";
+  return ok(identity.name) && ok(identity.email);
+}
+
+/**
  * One SSH key pair found on this machine (#248). Mirrors Rust
  * `ssh.rs::SshKeyInfo`.
  *

--- a/src/screens/CommitPanel.identity.test.tsx
+++ b/src/screens/CommitPanel.identity.test.tsx
@@ -1,0 +1,265 @@
+// A fresh machine's first commit (#212).
+//
+// git refuses to record a commit until `user.name` and `user.email` are set, so
+// this is the first thing a brand-new user hits — and before #212 it was an
+// error banner reading the literal string "NoSignature", with nothing anywhere
+// in the app that could set an identity. These tests pin the two halves of the
+// fix: the refusal becomes a form, and answering it makes the commit the user
+// already asked for.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { CommitPanelScreen } from "./CommitPanel";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { appErrorMessage } from "@/lib/errors";
+import type { FileStatus, GitIdentity } from "@/lib/types";
+
+const staged = (path: string): FileStatus => ({
+  path,
+  worktree: { kind: "Unmodified" },
+  index: { kind: "Modified" },
+  additions: 1,
+  deletions: 0,
+  embedded: false,
+});
+
+const NO_IDENTITY: GitIdentity = {
+  name: null,
+  email: null,
+  globalConfigPath: "/home/ada/.gitconfig",
+};
+
+/** How many times `commit` has been attempted. */
+const commitCalls = () => getInvokeCalls().filter((c) => c.cmd === "commit");
+const setIdentityCalls = () =>
+  getInvokeCalls().filter((c) => c.cmd === "set_identity");
+
+function setup({
+  identity = NO_IDENTITY,
+  onSetIdentity,
+}: {
+  identity?: GitIdentity;
+  onSetIdentity?: () => void;
+} = {}) {
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
+    status: [staged("a.ts")],
+    branches: [],
+    remotes: [],
+    commits: [],
+    logRef: null,
+    loading: false,
+    error: null,
+    noSignature: false,
+  } as never);
+  mockInvoke("get_diff", () => ({
+    path: "a.ts",
+    oldPath: null,
+    binary: false,
+    additions: 0,
+    deletions: 0,
+    hunks: [],
+  }));
+  mockInvoke("get_status", () => [staged("a.ts")]);
+  mockInvoke("get_identity", () => identity);
+  // The identity is missing until `set_identity` succeeds; after that the
+  // commit goes through. One pair of handlers models the whole story — and the
+  // backend refuses anything git would refuse, writing nothing.
+  let hasIdentity = false;
+  mockInvoke("set_identity", (args) => {
+    onSetIdentity?.();
+    if (String(args.name).includes("<")) {
+      throw { kind: "InvalidArgument", message: "a name cannot contain '<'" };
+    }
+    hasIdentity = true;
+    return null;
+  });
+  mockInvoke("commit", () => {
+    if (!hasIdentity) throw { kind: "NoSignature" };
+    return { oid: "oid123", message: "feat: thing" };
+  });
+  render(<CommitPanelScreen />);
+}
+
+const typeMessage = (text: string) =>
+  fireEvent.change(screen.getByTestId("commit-message"), {
+    target: { value: text },
+  });
+
+async function commitAndGetRefused() {
+  typeMessage("feat: thing");
+  fireEvent.click(screen.getByTestId("commit-button"));
+  await waitFor(() => expect(screen.getByTestId("no-signature")).toBeTruthy());
+}
+
+describe("CommitPanel — no committer identity (#212)", () => {
+  beforeEach(() => {
+    resetInvokeMock();
+  });
+
+  it("turns the refusal into a form instead of an error banner", async () => {
+    setup();
+    await commitAndGetRefused();
+
+    // The refusal is NOT in `error`: an error is something you acknowledge,
+    // and this is something you answer.
+    expect(useRepoStore.getState().error).toBeNull();
+    expect(useRepoStore.getState().noSignature).toBe(true);
+    // And the enum's spelling must never reach the screen.
+    expect(document.body.textContent).not.toContain("NoSignature");
+    expect(screen.getByTestId("identity-name")).toBeTruthy();
+    expect(screen.getByTestId("identity-email")).toBeTruthy();
+  });
+
+  it("names the file it is about to write", async () => {
+    setup();
+    await commitAndGetRefused();
+    expect(screen.getByTestId("identity-target").textContent).toContain(
+      "/home/ada/.gitconfig",
+    );
+  });
+
+  it("will not offer to save until both halves are filled in", async () => {
+    setup();
+    await commitAndGetRefused();
+    const save = screen.getByTestId<HTMLButtonElement>("identity-save");
+    expect(save.disabled).toBe(true);
+
+    fireEvent.change(screen.getByTestId("identity-name"), {
+      target: { value: "Ada Lovelace" },
+    });
+    expect(save.disabled).toBe(true);
+
+    fireEvent.change(screen.getByTestId("identity-email"), {
+      target: { value: "ada@example.com" },
+    });
+    expect(save.disabled).toBe(false);
+
+    // Whitespace is not an answer.
+    fireEvent.change(screen.getByTestId("identity-email"), {
+      target: { value: "   " },
+    });
+    expect(save.disabled).toBe(true);
+  });
+
+  it("saves the identity and then makes the commit the user already asked for", async () => {
+    setup();
+    await commitAndGetRefused();
+    expect(commitCalls()).toHaveLength(1);
+
+    fireEvent.change(screen.getByTestId("identity-name"), {
+      target: { value: "Ada Lovelace" },
+    });
+    fireEvent.change(screen.getByTestId("identity-email"), {
+      target: { value: "ada@example.com" },
+    });
+    fireEvent.click(screen.getByTestId("identity-save"));
+
+    await waitFor(() => expect(setIdentityCalls()).toHaveLength(1));
+    expect(setIdentityCalls()[0].args).toMatchObject({
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+    });
+
+    // The retry is the point: the user typed a message and pressed Commit, and
+    // making them press it again is a second failure with extra steps.
+    await waitFor(() => expect(commitCalls()).toHaveLength(2));
+    expect(commitCalls()[1].args.message).toBe("feat: thing");
+    await waitFor(() =>
+      expect(useRepoStore.getState().noSignature).toBe(false),
+    );
+  });
+
+  it("keeps the prompt up and commits nothing when the backend refuses the identity", async () => {
+    setup();
+    await commitAndGetRefused();
+
+    fireEvent.change(screen.getByTestId("identity-name"), {
+      target: { value: "Ada <Lovelace>" },
+    });
+    fireEvent.change(screen.getByTestId("identity-email"), {
+      target: { value: "ada@example.com" },
+    });
+    fireEvent.click(screen.getByTestId("identity-save"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("identity-error").textContent).toContain(
+        "cannot contain",
+      ),
+    );
+    // No second commit attempt — a refused save has not fixed anything.
+    expect(commitCalls()).toHaveLength(1);
+    expect(screen.getByTestId("no-signature")).toBeTruthy();
+  });
+
+  it("can be dismissed, and a fresh attempt clears the stale prompt", async () => {
+    setup();
+    await commitAndGetRefused();
+
+    fireEvent.click(screen.getByTestId("identity-dismiss"));
+    await waitFor(() =>
+      expect(screen.queryByTestId("no-signature")).toBeNull(),
+    );
+    expect(useRepoStore.getState().noSignature).toBe(false);
+  });
+
+  it("says which repository is overriding the identity, so a global save is not a mystery", async () => {
+    setup({
+      identity: {
+        name: { value: "Repo Local", scope: "repository" },
+        email: { value: "local@example.com", scope: "repository" },
+        globalConfigPath: "/home/ada/.gitconfig",
+      },
+    });
+    await commitAndGetRefused();
+    const note = screen.getByTestId("identity-scope-note").textContent ?? "";
+    expect(note).toContain("This repository sets its own");
+    // No issue numbers in prose a user reads.
+    expect(note).not.toMatch(/#\d+/);
+  });
+
+  it("names both halves' sources when they disagree", async () => {
+    // `user.name` from /etc/gitconfig and `user.email` from ~/.gitconfig is an
+    // ordinary state on a managed machine; reporting only the first would be a
+    // confident wrong answer about the second.
+    setup({
+      identity: {
+        name: { value: "Managed Name", scope: "system" },
+        email: { value: "ada@example.com", scope: "global" },
+        globalConfigPath: "/home/ada/.gitconfig",
+      },
+    });
+    await commitAndGetRefused();
+    const source = screen.getByTestId("identity-source").textContent ?? "";
+    expect(source).toContain("this machine");
+    expect(source).toContain("your global git config");
+  });
+
+  it("says which half is still missing when only one is set", async () => {
+    setup({
+      identity: {
+        name: { value: "Ada Lovelace", scope: "global" },
+        email: null,
+        globalConfigPath: "/home/ada/.gitconfig",
+      },
+    });
+    await commitAndGetRefused();
+    expect(screen.getByTestId("identity-source").textContent).toContain(
+      "the other is not set",
+    );
+  });
+});
+
+describe("appErrorMessage — NoSignature (#212)", () => {
+  it("never renders the enum's own spelling", () => {
+    // The regression this whole issue turned on: `NoSignature` is a UNIT
+    // variant, so it carries no message, and `appErrorMessage`'s `|| e.kind`
+    // fallback put "NoSignature" on screen wherever it was raised — merge,
+    // cherry-pick, revert, rebase, tag, stash, not only commit.
+    const msg = appErrorMessage({ kind: "NoSignature" });
+    expect(msg).not.toBe("NoSignature");
+    expect(msg).toContain("user.name");
+    expect(msg).toContain("user.email");
+  });
+});

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -62,6 +62,7 @@ import {
   statusMark,
 } from "@/lib/derive";
 import { LfsDiffNotice } from "@/features/lfs/LfsDiffNotice";
+import { NoSignaturePrompt } from "@/features/commits/identity/NoSignaturePrompt";
 import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
 import {
   clickSelection,
@@ -144,6 +145,8 @@ export function CommitPanelScreen() {
   const pushAction = useRepoStore((s) => s.push);
   const hookRejection = useRepoStore((s) => s.hookRejection);
   const clearHookRejection = useRepoStore((s) => s.clearHookRejection);
+  const noSignature = useRepoStore((s) => s.noSignature);
+  const clearNoSignature = useRepoStore((s) => s.clearNoSignature);
   const activity = useRepoStore((s) => s.activity);
   const commits = useRepoStore((s) => s.commits);
   const setNavIntent = useNavStore((s) => s.setIntent);
@@ -1227,12 +1230,18 @@ export function CommitPanelScreen() {
   // that reformats and restages can leave the tree clean while its refusal is
   // still the most important thing on screen. Without this the block would be
   // unmounted by the very hook that produced it.
+  //
+  // `!noSignature` for the same reason (#212): a refused commit leaves the tree
+  // exactly as it was, so this cannot fire on the attempt itself — but an
+  // external change that empties the tree while the identity form is open must
+  // not swallow the form the user is typing into.
   if (
     !loading &&
     staged.length === 0 &&
     unstaged.length === 0 &&
     !amend &&
-    !hookRejection
+    !hookRejection &&
+    !noSignature
   ) {
     return (
       <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
@@ -1723,6 +1732,23 @@ export function CommitPanelScreen() {
               // Retry with hooks off. Deliberately does NOT tick the checkbox:
               // this is one commit, not a new default.
               onCommitAnyway={() => void doCommit(true)}
+            />
+          )}
+
+          {/*
+            git has no committer identity (#212) — the one refusal a brand-new
+            user is guaranteed to hit, in the same place and the same shape as
+            the hook block. Saving retries the commit, so the message the user
+            already typed still becomes the commit they asked for.
+          */}
+          {noSignature && repo && (
+            <NoSignaturePrompt
+              repoId={repo.id}
+              onSaved={() => {
+                clearNoSignature();
+                void doCommit();
+              }}
+              onDismiss={clearNoSignature}
             />
           )}
 

--- a/src/screens/Settings.identity.test.tsx
+++ b/src/screens/Settings.identity.test.tsx
@@ -1,0 +1,147 @@
+// Settings → Identity (#212).
+//
+// The commit panel's prompt is the same form, and its behaviour is pinned in
+// `CommitPanel.identity.test.tsx`. What only this screen can get wrong is
+// reachability: the identity has to be settable BEFORE a commit fails, and with
+// no repository open at all — a user who lands here from Welcome is exactly the
+// user who has no identity yet.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { WithDialogs, resetDialogs } from "@/test/dialog";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { SettingsScreen } from "./Settings";
+import type { GitIdentity } from "@/lib/types";
+
+function mockRestOfSettings() {
+  mockInvoke("cli_shim_status", () => ({
+    installed: true,
+    shimPath: "/usr/local/bin/pgit",
+    target: "/usr/bin/platypusgit",
+    source: "package",
+    pathState: "onPath",
+  }));
+  mockInvoke("diagnostics_report", () => ({
+    logPath: "/tmp/platypusgit.log",
+    logExists: false,
+    logSizeBytes: 0,
+    environment: "host os=macos arch=aarch64 git=2.43.0",
+    version: "0.1.0",
+  }));
+}
+
+const GLOBAL_IDENTITY: GitIdentity = {
+  name: { value: "Ada Lovelace", scope: "global" },
+  email: { value: "ada@example.com", scope: "global" },
+  globalConfigPath: "/home/ada/.gitconfig",
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  resetInvokeMock();
+  resetDialogs();
+  mockRestOfSettings();
+  useSettingsStore.getState().reset();
+  useRepoStore.setState({ current: null } as never);
+});
+
+function renderSettings() {
+  render(
+    <WithDialogs>
+      <SettingsScreen />
+    </WithDialogs>,
+  );
+}
+
+const identityCall = () => getInvokeCalls().find((c) => c.cmd === "get_identity");
+
+describe("Settings → Identity (#212)", () => {
+  it("shows the configured identity, and where it comes from", async () => {
+    mockInvoke("get_identity", () => GLOBAL_IDENTITY);
+    renderSettings();
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId<HTMLInputElement>("identity-name").value,
+      ).toBe("Ada Lovelace"),
+    );
+    expect(screen.getByTestId<HTMLInputElement>("identity-email").value).toBe(
+      "ada@example.com",
+    );
+    expect(screen.getByTestId("identity-source").textContent).toContain(
+      "your global git config",
+    );
+  });
+
+  it("asks for the global chain when no repository is open", async () => {
+    mockInvoke("get_identity", () => GLOBAL_IDENTITY);
+    renderSettings();
+
+    // `repoId: null` is what makes this answerable from Welcome — with a
+    // required repoId the screen could not have shown a true answer here.
+    await waitFor(() => expect(identityCall()).toBeDefined());
+    expect(identityCall()!.args.repoId).toBeNull();
+  });
+
+  it("asks for the open repository's effective identity when there is one", async () => {
+    useRepoStore.setState({
+      current: { id: "repo-7", path: "/repo", head: "refs/heads/main" },
+    } as never);
+    mockInvoke("get_identity", () => GLOBAL_IDENTITY);
+    renderSettings();
+
+    await waitFor(() => expect(identityCall()).toBeDefined());
+    expect(identityCall()!.args.repoId).toBe("repo-7");
+  });
+
+  it("saves what was typed and confirms it landed", async () => {
+    let stored: GitIdentity = {
+      name: null,
+      email: null,
+      globalConfigPath: "/home/ada/.gitconfig",
+    };
+    mockInvoke("get_identity", () => stored);
+    mockInvoke("set_identity", (args) => {
+      stored = {
+        name: { value: String(args.name), scope: "global" },
+        email: { value: String(args.email), scope: "global" },
+        globalConfigPath: "/home/ada/.gitconfig",
+      };
+      return null;
+    });
+    renderSettings();
+
+    await waitFor(() => expect(screen.getByTestId("identity-form")).toBeTruthy());
+    fireEvent.change(screen.getByTestId("identity-name"), {
+      target: { value: "Grace Hopper" },
+    });
+    fireEvent.change(screen.getByTestId("identity-email"), {
+      target: { value: "grace@example.com" },
+    });
+    fireEvent.click(screen.getByTestId("identity-save"));
+
+    await waitFor(() => expect(screen.getByTestId("identity-saved")).toBeTruthy());
+    const saves = getInvokeCalls().filter((c) => c.cmd === "set_identity");
+    expect(saves).toHaveLength(1);
+    expect(saves[0].args).toMatchObject({
+      name: "Grace Hopper",
+      email: "grace@example.com",
+    });
+  });
+
+  it("reports a config it could not read instead of showing empty fields as the truth", async () => {
+    mockInvoke("get_identity", () => {
+      throw { kind: "Io", message: "permission denied" };
+    });
+    renderSettings();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("identity-error").textContent).toContain(
+        "permission denied",
+      ),
+    );
+  });
+});

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -29,6 +29,8 @@ import {
   DEFAULT_TICKET_PATTERN,
   isValidTicketPattern,
 } from "@/features/commits/message";
+import { IdentityForm } from "@/features/commits/identity/IdentityForm";
+import { useRepoStore } from "@/features/repo/useRepoStore";
 import { HeadMarksControl } from "@/features/settings/HeadMarksControl";
 import { ForgeSettings } from "@/features/forge/ForgeSettings";
 import {
@@ -103,6 +105,8 @@ export function SettingsScreen() {
         >
           Preferences are saved locally and apply to every repository.
         </p>
+
+        <IdentitySection />
 
         <AppearanceSection active={active} />
 
@@ -363,6 +367,37 @@ export function SettingsScreen() {
 // ═════════════════════════════════════════════════════════════════════════════
 // KEYBOARD SECTION — keymap preset picker
 // ═════════════════════════════════════════════════════════════════════════════
+
+/**
+ * `user.name` / `user.email` (#212) — the one thing on this screen that is NOT
+ * a platypusgit preference.
+ *
+ * It is here anyway, and first, because it is the only setting the app cannot
+ * work without: git refuses to record a commit until both are set, and until
+ * #212 there was nowhere in the app to set them. The subtitle says out loud
+ * that this writes git's own config, since the page's own header promises
+ * "preferences are saved locally".
+ *
+ * Reachable with no repository open, which is why `repoId` is optional all the
+ * way down: a user who lands in Settings before opening anything still gets a
+ * true answer, from the global + system chain.
+ */
+function IdentitySection() {
+  const repo = useRepoStore((s) => s.current);
+  return (
+    <Section
+      title="Identity"
+      subtitle="Who your commits are recorded as. Unlike everything else here, this is written to your git config — the same user.name and user.email git itself reads."
+    >
+      <Row
+        label="Commit author"
+        hint="git refuses to record a commit without both. Saving writes them to your global git config, so every repository on this machine gets them."
+        stacked
+        control={<IdentityForm repoId={repo?.id ?? null} />}
+      />
+    </Section>
+  );
+}
 
 function KeyboardSection() {
   const activePresetId = useKeymapStore((k) => k.activePresetId);

--- a/test/appErrors.test.ts
+++ b/test/appErrors.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @vitest-environment node
+ */
+// The error enum's two written promises, made mechanical (#212).
+//
+// CLAUDE.md states both as prose: "TS `AppError` union stays 1:1 with the Rust
+// enum, updated in the same commit", and #212's acceptance criterion "every
+// error a user can trigger says what happened and what to do next — no bare
+// 'failed', no raw libgit2 text, no `[object Object]`". Neither was checked by
+// anything, and both had already been broken by the same variant.
+//
+// `NoSignature` is what prompted this file. It is a UNIT variant — it carries
+// no message — so `appErrorMessage` fell through to its `|| e.kind` fallback
+// and rendered the literal string "NoSignature" wherever it was raised: the
+// commit panel, but also merge, cherry-pick, revert, rebase, tag and stash,
+// every one of which resolves a committer signature. It is also the ONE error a
+// brand-new user is guaranteed to hit, because git refuses to record a commit
+// until `user.name` and `user.email` are set.
+//
+// So this reads the Rust enum and asserts, per variant, that the TS union knows
+// about it and that a banner would never show the enum's own spelling. What it
+// does NOT check is whether the prose is any good — only that somebody wrote
+// some.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { appErrorMessage } from "../src/lib/errors";
+
+const read = (rel: string) => readFileSync(resolve(process.cwd(), rel), "utf8");
+
+/**
+ * Every variant of Rust's `AppError`, and whether it carries a payload.
+ *
+ * Text-parsed for the same reason `docs.test.ts` parses `invoke_handler!`: the
+ * enum declaration is the single place a variant comes into existence, and
+ * reading it needs no cargo run.
+ */
+function rustVariants(): { name: string; unit: boolean }[] {
+  const src = read("src-tauri/src/error.rs");
+  const start = src.indexOf("pub enum AppError {");
+  expect(start, "pub enum AppError not found in error.rs").toBeGreaterThan(-1);
+  const block = src.slice(start, src.indexOf("\n}", start));
+  const variants = [...block.matchAll(/^ {4}([A-Z][A-Za-z0-9]*)(\(|,)/gm)].map(
+    (m) => ({ name: m[1], unit: m[2] === "," }),
+  );
+  expect(variants.length, "parsed no AppError variants").toBeGreaterThan(20);
+  return variants;
+}
+
+/**
+ * Unit variants whose kind name may reach `appErrorMessage`'s fallback, each
+ * with the reason no user ever reads it.
+ *
+ * An allow-list with written reasons rather than a softer assertion, in the
+ * shape `test/privacy.test.ts` already uses for hard-coded hostnames: adding an
+ * entry has to be a decision somebody made on purpose.
+ */
+const NEVER_RENDERED: Record<string, string> = {
+  // Only `CliBackend`'s stubs raise it, and no shipped surface calls that
+  // backend — it exists to keep the trait shape exercised. Reaching a user
+  // would be a programming error, not a state to explain.
+  NotImplemented:
+    "raised only by CliBackend stubs, which no shipped surface calls",
+  // The outcome the user asked for, not a failure. Every network catch arm
+  // suppresses it via `isCancelledError` before anything is rendered — and
+  // giving it prose would invite somebody to show it.
+  Cancelled: "suppressed by isCancelledError; a banner here is the bug",
+  // Benign: the usual cause is another process resetting the bisect, so the UI
+  // refreshes rather than alarms.
+  NoBisect: "the UI refreshes on it rather than reporting it",
+};
+
+describe("AppError stays 1:1 with the frontend union", () => {
+  const variants = rustVariants();
+
+  it("names every Rust variant in src/lib/errors.ts", () => {
+    const ts = read("src/lib/errors.ts");
+    const missing = variants
+      .map((v) => v.name)
+      .filter((name) => !ts.includes(`kind: "${name}"`));
+    expect(
+      missing,
+      "Rust AppError variants with no case in the TS union. Add each as " +
+        '`| { kind: "Name"; message: … }` — the union has to be updated in the ' +
+        "same commit as the enum, or `isAppError` narrowing silently stops " +
+        "compiling against reality.",
+    ).toEqual([]);
+  });
+
+  it("never renders a variant as its own enum spelling", () => {
+    const leaked = variants
+      .filter((v) => v.unit && !(v.name in NEVER_RENDERED))
+      // A unit variant carries no payload, which is exactly how it reaches the
+      // fallback. Payload variants render their message and cannot.
+      .filter((v) => appErrorMessage({ kind: v.name }) === v.name);
+    expect(
+      leaked,
+      "Unit AppError variants whose kind name would land in a banner. Add a " +
+        "case to `appErrorDetail` saying what happened and what to do next, or " +
+        "— if no user can ever see it — an entry in NEVER_RENDERED with the " +
+        "reason why.",
+    ).toEqual([]);
+  });
+
+  it("renders something for every variant, payload or not", () => {
+    // The `[object Object]` half of the promise: `isAppError` only requires a
+    // string `kind`, so a variant carrying a STRUCT with no case in
+    // `appErrorDetail` used to render as "[object Object]" in a banner and take
+    // the screen down in React (#146).
+    for (const { name } of variants) {
+      const struct = appErrorMessage({
+        kind: name,
+        message: { some: "struct", nested: { deep: true } },
+      });
+      expect(struct, `${name} with a struct payload`).not.toContain(
+        "[object Object]",
+      );
+      expect(struct.length, `${name} with a struct payload`).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
Walks #212's **stage / commit** adverse paths and fixes the one every brand-new
user hits first, before they have done anything else with the app.

## What was broken

A fresh machine has no `user.name` / `user.email`. git refuses to record a
commit without them. So the very first commit a new user attempts failed — and
the banner read, literally:

> NoSignature

There was also **nowhere in the app to set an identity**. The only way out was a
terminal and `git config --global`, which is a hard stop for the GUI-first
audience this app is for.

Two distinct defects, both found by writing the test first rather than by
reading the code:

1. **`NoSignature` had no prose at all.** It is a UNIT variant in Rust, so it
   crosses IPC as `{ kind: "NoSignature" }` with no `message`, and
   `appErrorMessage` fell through to its `|| e.kind` fallback. Not just the
   commit panel: **merge, cherry-pick, revert, rebase, tag and stash** all
   resolve a committer signature through `default_signature`, so all of them
   could show the enum's spelling. `Unborn` had the same problem
   (#212's empty-repository box).
2. **A blank `user.email` was not `NoSignature` at all.** libgit2 reports a
   *missing* `user.name` as `NotFound`, but a *blank* one as a generic error
   whose only distinguishing mark is prose — so `user.email =` in a config
   reached the user as the raw libgit2 string `failed to parse signature -
   Signature cannot have an empty name or email`. That is exactly the "no raw
   libgit2 text" acceptance criterion.

Neither was reachable by any existing test, and for a findable reason:
`support::TempRepo::fresh` sets a repo-local identity on every temp repo,
deliberately — *"so commit() works without global config leaking in"*. The state
a brand-new user is actually in was the one state no test could reach.

## The fix

**The refusal becomes a form.** `src/features/commits/identity/` is one surface
with two framings:

- **`NoSignaturePrompt`** in the commit panel — same place and same shape as the
  `pre-commit` hook block, for the same reasons (a modal would cover the staged
  files and the message being asked about; a toast cannot hold a form). Saving
  **retries the commit**: the user already typed a message and pressed Commit,
  and making them press it again is a second failure with extra steps.
- **Settings → Identity**, so it is reachable *before* a commit fails — and with
  no repository open at all, which is where a user who has not opened anything
  yet actually is. Hence `get_identity`'s `repoId` is optional.

`NoSignature` lands in `useRepoStore`'s per-repo `noSignature` field rather than
`error`, the same split `hookRejection` makes: an error is something you
acknowledge, this is something you answer.

### Decisions worth checking

- **The write is GLOBAL**, and the form names the file it is about to touch
  (`Writes user.name and user.email to /home/…/.gitconfig`). This is the only
  place the app writes the user's own git config, so it is deliberately explicit
  rather than something a commit does for you.
- **Per-repository identities and multiple accounts stay #233.** When that
  lands it adds a scope control to *this* form, not a second one. Meanwhile a
  repo-local override is called out on screen, so a global save that changes
  nothing is not a mystery.
- **`validate_identity` is the single authority** on what git accepts, used by
  both the writer and `default_signature`, so "what we save" and "what we call a
  missing identity" cannot drift. Its refusal names the offending character —
  git's own message names none of them. The UI checks only blankness.
- **`default_signature` asks the config, not the error code.** Matching on
  "failed to parse signature" would be a parser for another project's wording.
- **The global config path is resolved the way git resolves it**: `~/.gitconfig`
  when it exists, else an existing XDG `git/config`, else `~/.gitconfig` — the
  file git creates when neither is there.

### A new guard, so this cannot happen again

`test/appErrors.test.ts` parses `pub enum AppError` out of `error.rs` and fails
the build when

- a variant has no case in the TS union — the 1:1 rule CLAUDE.md stated as prose
  and **nothing checked**; or
- a **unit** variant would render as its own enum spelling.

`NEVER_RENDERED` allow-lists the three variants no user can see
(`NotImplemented`, `Cancelled`, `NoBisect`), each with a written reason, in the
shape `test/privacy.test.ts` uses for hostnames — so weakening it is a decision
somebody made rather than an assertion quietly loosened. The guard was verified
to actually fail by removing the `Unborn` case and watching it go red.

## Verification

- `src-tauri/tests/identity.rs` — one test function, on purpose (libgit2's config
  search paths and `HOME` are process-global, and this file redirects all of them
  at a tempdir so it can create and rewrite a *global* git config without
  touching the developer's own). It drives the whole story: the refused commit
  creates nothing and leaves HEAD unborn; six refused identities create no config
  file; a save creates `~/.gitconfig` and the commit then lands attributed to
  what was typed; a rewrite **overwrites** rather than appending a second
  `user.email` (a duplicated key is legal in a git config and the last one wins,
  so an append-only writer would look correct here and diverge the moment
  anything read it with `--get`); a repo-local override wins and says so; a blank
  email is `NoSignature`, reported back verbatim.
- `cargo test` — 326 unit + the full integration suite, green.
- `pnpm test` — 2669 tests green, including 8 new commit-panel and 5 new Settings
  tests.
- `pnpm tsc --noEmit` clean.
- Docker e2e for `commit`, `status-stage` and `settings` (the three surfaces
  touched).

## Not in scope

The rest of #212 stays open — this is one slice of it (the stage/commit
adverse-path sweep, and only the parts verifiable headlessly). The clone,
push/pull and diff walkthroughs, and the three-platform manual pass, still need
doing.

Refs #212
