### PR TITLE
fix(worktrees): the action column moved on every locked row

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -922,6 +922,28 @@ update checks back on for someone who turned them off.
   does NOT (forwards `title` only). Row components need explicit prop threading
   for new attributes.
 
+### A row's trailing action buttons get FIXED slots
+
+`PGWorktreeRow` is the worked example (`git-components.worktreeRow.test.tsx`
+pins it). A list row whose trailing buttons are auto-sized has an action column
+that moves *down the list*, because one of the labels is state-dependent —
+Lock/Unlock differ by 30px, so Open and Remove sat at a different x on exactly
+the locked rows. Put the actions in a grid of identical fixed tracks
+(`84px 84px 84px`, `flexShrink: 0`), make each button `fullWidth`, and
+`justifyContent: "flex-start"` inside the slot — centring re-centres the label
+when the state flips and the icon column jitters instead.
+
+The other half of the same fix: **one fact per line, every line clipped.** The
+worktree list is a dozen near-identical absolute paths, so name / branch+sha /
+path / lock reason each get their own line, each `overflow: hidden` +
+`textOverflow: ellipsis` + `whiteSpace: nowrap` + `minWidth: 0`, each with a
+`title` so the clipped tail survives on hover. A long value must never reach a
+`PGBadge` — the badge is a fixed-height uppercase pill and a 79-character lock
+reason wrapped inside it, giving every locked row its own height. Badges stay
+one word (`locked`) with the variable text as a sibling span, `flexShrink: 0`
+on the badge. Screens that are all-path (`Worktrees`) skip the centred
+`maxWidth: 1100` column — the cap ate exactly the width the paths needed.
+
 ## No native `<select>` (issue 146)
 
 - **`PGSelect`** renders a `role="combobox"` trigger + a portalled

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -2379,6 +2379,13 @@ export interface PGWorktreeRowProps {
   busy?: boolean;
 }
 
+/**
+ * Width of one action slot. The three actions live in a fixed 3-column grid so
+ * they line up DOWN the list: Lock/Unlock are different lengths, and letting the
+ * buttons size to their labels slid Open and Remove sideways on every locked row.
+ */
+const WORKTREE_ACTION_W = 84;
+
 export function PGWorktreeRow({
   worktree,
   onContextMenu,
@@ -2387,6 +2394,28 @@ export function PGWorktreeRow({
   onToggleLock,
   busy,
 }: PGWorktreeRowProps) {
+  // One fact per line, each clipped rather than wrapped. This list's whole job
+  // is telling near-identical paths apart, and a name + branch + lock reason
+  // crammed onto one line wrapped into a different row height per worktree.
+  const line: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    minWidth: 0,
+    maxWidth: "100%",
+  };
+  const clip: React.CSSProperties = {
+    minWidth: 0,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  };
+  const meta: React.CSSProperties = {
+    fontFamily: "var(--font-mono)",
+    fontSize: "var(--fs-11)",
+    color: "var(--fg-2)",
+  };
+
   return (
     <div
       data-testid="worktree-row"
@@ -2403,7 +2432,9 @@ export function PGWorktreeRow({
           : "1px solid var(--border-0)",
         borderRadius: "var(--r-3)",
         display: "flex",
-        alignItems: "center",
+        // Top, not center: the info column grows a line when a worktree is
+        // locked, and the buttons stay on the name's line either way.
+        alignItems: "flex-start",
         gap: 10,
         marginBottom: 6,
       }}
@@ -2411,49 +2442,95 @@ export function PGWorktreeRow({
       <PGIcon
         name="worktree"
         size={14}
-        style={{ color: worktree.isCurrent ? "var(--accent)" : "var(--fg-2)" }}
+        style={{
+          color: worktree.isCurrent ? "var(--accent)" : "var(--fg-2)",
+          flexShrink: 0,
+          marginTop: 3,
+        }}
       />
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          <span style={{ fontWeight: 600, fontSize: "var(--fs-13)" }}>
+      <div
+        style={{
+          flex: 1,
+          minWidth: 0,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-start",
+          gap: 3,
+        }}
+      >
+        <div style={line}>
+          <span
+            title={worktree.name}
+            style={{ ...clip, fontWeight: 600, fontSize: "var(--fs-13)" }}
+          >
             {worktree.name}
           </span>
-          {worktree.branch ? (
-            <PGBranchPill name={worktree.branch} tone="accent" />
-          ) : (
-            <PGBadge tone="muted">detached</PGBadge>
-          )}
-          {worktree.isCurrent && <PGBadge tone="accent">this window</PGBadge>}
-          {worktree.locked && (
-            <PGBadge tone="warn" icon="lock">
-              {worktree.lockReason ? `locked · ${worktree.lockReason}` : "locked"}
+          {worktree.isCurrent && (
+            <PGBadge tone="accent" style={{ flexShrink: 0 }}>
+              this window
             </PGBadge>
           )}
           {worktree.prunable && (
-            <PGBadge tone="danger" icon="warn">
+            <PGBadge tone="danger" icon="warn" style={{ flexShrink: 0 }}>
               directory missing
             </PGBadge>
           )}
         </div>
-        <div
-          style={{
-            fontFamily: "var(--font-mono)",
-            fontSize: "var(--fs-11)",
-            color: "var(--fg-2)",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-          }}
-        >
-          {worktree.path}
-          {worktree.headOid ? ` · ${worktree.headOid.slice(0, 7)}` : ""}
+        <div style={line}>
+          {worktree.branch ? (
+            <PGBranchPill name={worktree.branch} tone="accent" />
+          ) : (
+            <PGBadge tone="muted" style={{ flexShrink: 0 }}>
+              detached
+            </PGBadge>
+          )}
+          {worktree.headOid && (
+            <span style={{ ...meta, flexShrink: 0 }}>
+              {worktree.headOid.slice(0, 7)}
+            </span>
+          )}
         </div>
+        <div title={worktree.path} style={{ ...clip, ...meta, maxWidth: "100%" }}>
+          {worktree.path}
+        </div>
+        {worktree.locked && (
+          <div style={line}>
+            <PGBadge tone="warn" icon="lock" style={{ flexShrink: 0 }}>
+              locked
+            </PGBadge>
+            {worktree.lockReason && (
+              <span
+                title={worktree.lockReason}
+                style={{
+                  ...clip,
+                  fontSize: "var(--fs-11)",
+                  color: "var(--git-modified)",
+                }}
+              >
+                {worktree.lockReason}
+              </span>
+            )}
+          </div>
+        )}
       </div>
-      <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+      <div
+        style={{
+          display: "grid",
+          // Spelled out rather than repeat(): three identical tracks is the
+          // property that keeps the column still, and this way a test can read it.
+          gridTemplateColumns: `${WORKTREE_ACTION_W}px ${WORKTREE_ACTION_W}px ${WORKTREE_ACTION_W}px`,
+          gap: 6,
+          flexShrink: 0,
+        }}
+      >
         <PGButton
           size="sm"
           variant="outline"
           icon="folder"
+          fullWidth
+          // Left, not centred: in a fixed slot, centring re-centres the label
+          // when Lock becomes Unlock, and the icon column jitters row to row.
+          style={{ justifyContent: "flex-start" }}
           data-testid="worktree-open"
           onClick={onOpen}
           // Nothing to open once the directory is gone.
@@ -2465,6 +2542,10 @@ export function PGWorktreeRow({
           size="sm"
           variant="ghost"
           icon="lock"
+          fullWidth
+          // Left, not centred: in a fixed slot, centring re-centres the label
+          // when Lock becomes Unlock, and the icon column jitters row to row.
+          style={{ justifyContent: "flex-start" }}
           data-testid="worktree-lock"
           onClick={onToggleLock}
         >
@@ -2475,6 +2556,10 @@ export function PGWorktreeRow({
           variant="ghost"
           tone="danger"
           icon="trash"
+          fullWidth
+          // Left, not centred: in a fixed slot, centring re-centres the label
+          // when Lock becomes Unlock, and the icon column jitters row to row.
+          style={{ justifyContent: "flex-start" }}
           data-testid="worktree-remove"
           onClick={onRemove}
           loading={busy}

--- a/src/design/git-components.worktreeRow.test.tsx
+++ b/src/design/git-components.worktreeRow.test.tsx
@@ -1,0 +1,130 @@
+// PGWorktreeRow's layout, pinned.
+//
+// The list is a dozen rows whose paths differ only in the last segment, so it
+// only works if it is scannable: one fact per line, every line clipped instead
+// of wrapped, and an action column that does not move. Both halves regressed at
+// once before this — a lock reason wrapped to a second line inside its badge
+// (giving every locked row a different height), and because Lock/Unlock are
+// different lengths, the auto-sized buttons slid Open and Remove sideways on
+// exactly those rows. jsdom cannot measure pixels, so these assert the
+// mechanism: fixed equal grid tracks, and clip styles on every text line.
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+
+import { PGWorktreeRow } from "./git-components";
+import type { WorktreeInfo } from "@/lib/types";
+
+const LONG_REASON =
+  "claude session commit-flow-hardening (PID 19292 start Mon Aug 31 14:10:57 2026)";
+
+function wt(over: Partial<WorktreeInfo> = {}): WorktreeInfo {
+  return {
+    name: "commit-flow-hardening",
+    path: "/Users/jonas/dev/fun/platypusgit/.claude/worktrees/commit-flow-hardening",
+    branch: "fix/commit-flow-hardening",
+    headOid: "177ddb1c0ffee0ffee0ffee0ffee0ffee0ffee000",
+    locked: false,
+    lockReason: null,
+    prunable: false,
+    isCurrent: false,
+    ...over,
+  };
+}
+
+function renderRow(over: Partial<WorktreeInfo> = {}) {
+  const { container } = render(<PGWorktreeRow worktree={wt(over)} />);
+  const row = container.querySelector<HTMLElement>('[data-testid="worktree-row"]')!;
+  const buttons = ["open", "lock", "remove"].map(
+    (k) => container.querySelector<HTMLElement>(`[data-testid="worktree-${k}"]`)!,
+  );
+  return { container, row, buttons };
+}
+
+const clipped = (el: HTMLElement) => ({
+  overflow: el.style.overflow,
+  textOverflow: el.style.textOverflow,
+  whiteSpace: el.style.whiteSpace,
+  minWidth: el.style.minWidth,
+});
+const CLIPPED = {
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  minWidth: "0",
+};
+
+describe("PGWorktreeRow layout", () => {
+  it("puts the three actions in equal fixed-width slots", () => {
+    const { buttons } = renderRow();
+    const grid = buttons[0].parentElement!;
+    // Same parent, so they cannot drift apart independently.
+    for (const b of buttons) expect(b.parentElement).toBe(grid);
+    expect(grid.style.display).toBe("grid");
+
+    const tracks = grid.style.gridTemplateColumns.split(/\s+/).filter(Boolean);
+    expect(tracks).toHaveLength(3);
+    expect(new Set(tracks).size).toBe(1); // three IDENTICAL tracks
+    // The column never gives ground to a long branch name or path.
+    expect(grid.style.flexShrink).toBe("0");
+    // Each button fills its slot and left-aligns inside it: centring would
+    // re-centre the label when Lock becomes Unlock, jittering the icon column.
+    for (const b of buttons) {
+      expect(b.style.width).toBe("100%");
+      expect(b.style.justifyContent).toBe("flex-start");
+    }
+  });
+
+  it("keeps Lock and Unlock in the same slot", () => {
+    const locked = renderRow({ locked: true });
+    expect(locked.buttons[1].textContent).toContain("Unlock");
+    const unlocked = renderRow();
+    expect(unlocked.buttons[1].textContent).toContain("Lock");
+    // Identical slot geometry in both states — the label length is the row's
+    // business, not the column's.
+    expect(locked.buttons[1].parentElement!.style.gridTemplateColumns).toBe(
+      unlocked.buttons[1].parentElement!.style.gridTemplateColumns,
+    );
+  });
+
+  it("pins the buttons to the top so a lock line cannot push them down", () => {
+    const { row } = renderRow({ locked: true, lockReason: LONG_REASON });
+    expect(row.style.alignItems).toBe("flex-start");
+  });
+
+  it("gives each fact its own line", () => {
+    const { container } = renderRow({ locked: true, lockReason: LONG_REASON });
+    const column = container.querySelector<HTMLElement>(
+      '[data-testid="worktree-row"] > div',
+    )!;
+    expect(column.style.flexDirection).toBe("column");
+    // name / branch+sha / path / lock — four separate lines.
+    expect(column.children).toHaveLength(4);
+  });
+
+  it("clips the name, the path and the lock reason rather than wrapping", () => {
+    const w = wt({ locked: true, lockReason: LONG_REASON });
+    const { container } = render(<PGWorktreeRow worktree={w} />);
+    for (const full of [w.name, w.path, w.lockReason!]) {
+      const el = container.querySelector<HTMLElement>(`[title="${full}"]`);
+      // A title, so the clipped text is still recoverable on hover.
+      expect(el, `no titled element for ${full}`).not.toBeNull();
+      expect(clipped(el!)).toEqual(CLIPPED);
+    }
+  });
+
+  it("shows the lock reason beside a short badge, not inside one", () => {
+    const w = wt({ locked: true, lockReason: LONG_REASON });
+    const { container } = render(<PGWorktreeRow worktree={w} />);
+    const reason = container.querySelector<HTMLElement>(`[title="${w.lockReason}"]`)!;
+    // The badge is uppercase and fixed-height; a 79-character reason inside it
+    // is what wrapped. It stays a one-word badge with the reason as text.
+    const badge = reason.previousElementSibling as HTMLElement;
+    expect(badge.textContent).toBe("locked");
+    expect(badge.style.flexShrink).toBe("0");
+  });
+
+  it("still shows a lock with no reason", () => {
+    const { container } = render(<PGWorktreeRow worktree={wt({ locked: true })} />);
+    expect(container.textContent).toContain("locked");
+  });
+});

--- a/src/screens/Worktrees.tsx
+++ b/src/screens/Worktrees.tsx
@@ -70,7 +70,11 @@ export function WorktreesScreen() {
           testId="worktrees-list"
           style={{ flex: 1, minHeight: 0, padding: 16 }}
         >
-          <div style={{ maxWidth: 1100, margin: "0 auto" }}>
+          {/*
+            Full width, no centred 1100px column: every row is a long absolute
+            path, and the width capped off exactly the space the paths needed.
+          */}
+          <div>
             <PGSectionHeader
               actions={
                 <div style={{ display: "flex", gap: 6, alignItems: "center" }}>


### PR DESCRIPTION
Visual cleanup of the linked-worktrees list, from a screenshot of the real 13-worktree list.

### What was wrong

1. **The action column moved down the list.** `Lock` and `Unlock` differ by ~30px, and the buttons were sized to their labels — so `Open` and `Remove` sat at a different x on exactly the locked rows.
2. **Locked rows were a different height.** A 79-character lock reason went *inside* a `PGBadge`, which is a fixed-height uppercase pill; the text wrapped to a second line and shoved the row open.
3. **Everything was on one line.** Name + branch pill + lock badge shared a line and collided; path + sha shared the next.
4. **A centred `maxWidth: 1100` column** capped off exactly the width the absolute paths needed, so paths clipped that didn't have to.

### What it does now

- **One fact per line** — name / branch + sha / path / lock — each `overflow: hidden` + `textOverflow: ellipsis` + `whiteSpace: nowrap`, each with a `title` so the clipped tail is still readable on hover.
- **The lock badge stays one word** (`locked`) with the reason as a sibling span, so nothing variable-length ever enters a fixed-height pill.
- **The three actions sit in a grid of three identical fixed tracks**, `fullWidth`, left-aligned inside their slot — centring re-centres the label when `Lock` becomes `Unlock`, which jitters the icon column instead. `alignItems: flex-start` on the row keeps the buttons on the name's line when a lock line appears below.
- **The screen goes full width.**

### Verification

`pnpm tsc --noEmit` clean; full `pnpm test` green (286 files / 2663 tests), including a new `git-components.worktreeRow.test.tsx` that pins the fixed slots, the left-aligned labels, one line per fact, and the clip styles.

Because jsdom can't measure pixels, the layout was also checked for real: the component rendered under the real design CSS and screenshotted in headless Chrome at **1174px** and **560px**. Both show the three action columns lining up down the whole list (`Unlock` rows included) and the name, branch, path and lock reason each clipping with an ellipsis rather than wrapping.

`e2e/specs/worktrees.e2e.ts` selectors are unaffected — its `span*=removable drive` still matches, since the reason is now its own span.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
