### PR TITLE
feat(branches): pin branches to the top of the list

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -545,13 +545,38 @@ that is only partly here — which is the whole reason the notice exists.
   included, resets on a closed→open transition — a `--depth 1` chosen for one
   enormous repository must not quietly truncate the next.
 
+## Branch pins (#238)
+
+- **A pin is a TIER in `orderBranches`, and it outranks the default branch.**
+  #135's default-branch pin is the app guessing what belongs on top; a user pin
+  is an instruction, and an instruction that loses to a guess is not a pin. With
+  no pins the order is exactly #135's, which is why its tests are untouched.
+- **Pins are HOISTED OUT of the folder tree, not sorted to the front of it.**
+  Grouping runs after ordering and only moves rows into folders, so a pinned
+  `feat/foo` would otherwise be the first row INSIDE `feat` — invisible whenever
+  that folder is collapsed, which is the case pinning exists for. Hoisted rows
+  render at depth 0 under their FULL names and are removed from the tree rather
+  than duplicated into it. This is also why the tier has to outrank the default:
+  otherwise the comparator and this screen would disagree about one list.
+- **The pin set is a STORE, not the folds' React hook** (`useBranchPins`,
+  `pg-branch-pins-v1`, keyed by repository path, entry pruned when empty). Two
+  of the four surfaces that order branches are not components —
+  `design/context-menu.tsx` and `features/palette/commands.ts` reach state
+  through `getState()` — and a hook cannot serve them. `usePinSet` is the React
+  side; it subscribes to the stored ARRAY so the memoized `Set` is rebuilt only
+  when a pin actually changes.
+- **A pin matches the branch name exactly.** Pinning `feat/foo` does not pin
+  `origin/feat/foo`: two rows, two sections, and the user pinned one of them.
+
 ## Branch folders (#244)
 
 - **Filter, then order, then group — in that order.** `orderBranches` (#135) is
   still THE branch ordering; `features/branches/branchTree.ts` only moves the
   ordered rows into folders, so the pinned default branch stays the first row on
   the screen and the newest-first order holds inside every folder. A folder
-  ranks where its first (freshest) branch was. Grouping never sorts.
+  ranks where its first (freshest) branch was. Grouping never sorts. Since #238
+  the hoisted pins sit above that whole tree, and are the one thing removed from
+  it before grouping runs.
 - **A prefix that groups nothing is not a folder.** Single-child chains compress
   (`feat/foo/bar` alone is ONE row reading `feat/foo/bar`, not three), the same
   rule `lib/tree.ts::compactNode` applies to file paths. So a folder row always

--- a/e2e/specs/branches.e2e.ts
+++ b/e2e/specs/branches.e2e.ts
@@ -1,6 +1,12 @@
 import { browser, $, $$, expect } from "@wdio/globals";
 import { basicRepo, manyRefsRepo, TempRepo } from "../support/tempRepo";
-import { openRepo, resetApp, switchScreen } from "../support/app";
+import {
+  jsClickMenuItem,
+  jsContextMenu,
+  openRepo,
+  resetApp,
+  switchScreen,
+} from "../support/app";
 
 describe("branches", () => {
   let repo: TempRepo;
@@ -54,6 +60,49 @@ describe("branches", () => {
       { timeout: 20_000, timeoutMsg: "chip did not update back to main" },
     );
     expect(repo.git("branch", "--show-current").trim()).toBe("main");
+  });
+  // #238: a user pin outranks the recency order AND is hoisted out of its
+  // folder, so it is the first row on the Branches screen even when the folder
+  // it belongs to is collapsed.
+  it("pins a branch to the top of the Branches screen", async () => {
+    repo.git("branch", "feat/alpha");
+    repo.git("branch", "feat/beta");
+    await openRepo(repo.path);
+    await switchScreen("branches");
+
+    await browser.waitUntil(
+      async () => [...(await $$('[data-testid="branch-row"]'))].length > 1,
+      { timeout: 20_000, timeoutMsg: "branch rows never appeared" },
+    );
+
+    const labels = () =>
+      browser.execute(() =>
+        Array.from(document.querySelectorAll('[data-testid="branch-row"]')).map(
+          (r) => r.querySelector("[data-branch-label]")?.textContent ?? "",
+        ),
+      );
+
+    // `feat/beta` sits inside the `feat` folder, labelled by its segment.
+    expect(await labels()).not.toContain("feat/beta");
+
+    await jsContextMenu('[data-testid="branch-row"]', { text: "beta" });
+    await jsClickMenuItem("Pin to top");
+
+    await browser.waitUntil(async () => (await labels())[0] === "feat/beta", {
+      timeout: 20_000,
+      timeoutMsg: "the pinned branch never reached the top row",
+    });
+
+    // Hoisted under its FULL name, and exactly once — not duplicated into the
+    // folder it came from.
+    const rows = await labels();
+    expect(rows.filter((l) => l === "feat/beta")).toHaveLength(1);
+
+    // Persisted per repository, so a reload keeps it on top.
+    const stored = await browser.execute(() =>
+      localStorage.getItem("pg-branch-pins-v1"),
+    );
+    expect(stored).toContain("feat/beta");
   });
 });
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5059,6 +5059,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -19,6 +19,7 @@ import type {
 } from "@/lib/types";
 import { fileDiffToText, selectedLinesToText } from "@/lib/diffCopy";
 import { orderBranchesGrouped } from "@/features/branches/orderBranches";
+import { activePins, pinItem } from "@/features/branches/pins";
 import { openMergeWindow } from "@/features/merge/openMergeWindow";
 import {
   markedRefFor,
@@ -723,7 +724,7 @@ function branchesAtCommit(oid: string | null | undefined): BranchInfo[] {
   const at = useRepoStore.getState().branches.filter((b) => !!b.tip && b.tip === oid);
   // Locals ahead of remotes, each group in the ONE branch ordering (#135).
   // This renders as an undivided list, so the grouping has to happen here.
-  const ordered = orderBranchesGrouped(at);
+  const ordered = orderBranchesGrouped(at, activePins());
   // A remote ref whose local counterpart is at this very commit adds nothing:
   // the local branch is already offered and checking it out lands on the same
   // tree, while the remote entry would only prompt for a name already taken.
@@ -1339,6 +1340,7 @@ export function branchMenuItems(
           .setUpstream(name, trimmed === "" ? null : trimmed);
       },
     },
+    pinItem(name),
     {
       icon: "copy",
       label: "Copy name",
@@ -1469,6 +1471,7 @@ export function remoteBranchMenuItems(branch: { name?: string } | null): Context
       },
     },
     { divider: true },
+    pinItem(name),
     {
       icon: "fetch",
       label: "Fetch remote",

--- a/src/design/icons.tsx
+++ b/src/design/icons.tsx
@@ -13,7 +13,7 @@ export type IconName =
   | "dot" | "circle" | "warn" | "error" | "info" | "clock"
   | "user" | "eye" | "terminal" | "history" | "kbd"
   | "download" | "upload" | "link" | "lock"
-  | "play" | "pause" | "star" | "copy" | "external"
+  | "play" | "pause" | "star" | "copy" | "external" | "pin"
   | "edit" | "trash" | "conflict" | "squash" | "drag" | "bell"
   | "diff" | "undo" | "fix" | "expandAll" | "collapseAll"
   | "viewTree" | "viewList"
@@ -219,6 +219,10 @@ const ICONS: Record<IconName, ReactNode> = {
     <rect x="9" y="3" width="3" height="10" />
   </>,
   star: <path d="M8 1l2 5 5 .5-4 3.5 1 5-4-2.5-4 2.5 1-5-4-3.5 5-.5z" />,
+  pin: <>
+    <path d="M6 2h4l-.5 4 2 2.5H4.5L6.5 6z" />
+    <path d="M8 8.5V14" />
+  </>,
   copy: <>
     <rect x="4" y="4" width="10" height="10" />
     <path d="M2 10V2h8v2" />

--- a/src/features/branches/BranchPicker.tsx
+++ b/src/features/branches/BranchPicker.tsx
@@ -11,6 +11,7 @@ import {
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import type { BranchInfo } from "@/lib/types";
 import { orderBranches } from "./orderBranches";
+import { usePinSet } from "./usePinSet";
 
 interface BranchPickerProps {
   anchor: HTMLElement | null;
@@ -25,6 +26,7 @@ const MAX_HEIGHT = 480;
 
 export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
   const branches = useRepoStore((s) => s.branches);
+  const pins = usePinSet();
   const checkoutBranch = useRepoStore((s) => s.checkoutBranch);
   const createAndSwitchBranch = useRepoStore((s) => s.createAndSwitchBranch);
   const [query, setQuery] = React.useState("");
@@ -45,16 +47,18 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
       remoteBranchMenuItems({ name: b?.name }),
     );
 
-  // Filter FIRST, order SECOND (#135). `orderBranches` only permutes, so the
-  // pinned default can never come back once the query has excluded it.
+  // Filter FIRST, order SECOND (#135). `orderBranches` only permutes, so
+  // neither the pinned default nor a user pin (#238) can come back once the
+  // query has excluded it.
   const local: Row[] = React.useMemo(
     () =>
       orderBranches(
         branches
           .filter((b) => !b.isRemote && b.name.includes(query))
           .map((b) => ({ ...b, kind: "local" as const })),
+        pins,
       ),
-    [branches, query],
+    [branches, query, pins],
   );
   const remote: Row[] = React.useMemo(
     () =>
@@ -62,8 +66,9 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
         branches
           .filter((b) => b.isRemote && b.name.includes(query))
           .map((b) => ({ ...b, kind: "remote" as const })),
+        pins,
       ),
-    [branches, query],
+    [branches, query, pins],
   );
 
   const flat = React.useMemo(() => [...local, ...remote], [local, remote]);

--- a/src/features/branches/orderBranches.test.ts
+++ b/src/features/branches/orderBranches.test.ts
@@ -143,3 +143,113 @@ describe("compareBranches", () => {
     expect(compareBranches(head, other)).toBeGreaterThan(0);
   });
 });
+
+describe("user pins (#238)", () => {
+  const pins = (...names: string[]) => new Set(names);
+
+  it("lifts a pinned branch above the recency block", () => {
+    const rows = orderBranches(
+      [
+        b({ name: "fresh", tipTime: 9000 }),
+        b({ name: "feat/foo", tipTime: 1 }),
+        b({ name: "stale", tipTime: 2 }),
+      ],
+      pins("feat/foo"),
+    );
+    expect(names(rows)).toEqual(["feat/foo", "fresh", "stale"]);
+  });
+
+  it("lifts a pin above the default branch", () => {
+    // #135's pin is a DEFAULT — the app guessing. A user pin is an instruction,
+    // and an instruction that loses to a guess is not a pin. It also has to
+    // rank first for the comparator and the Branches screen (which hoists pins
+    // out of the folder tree, above it) to agree about one list.
+    const rows = orderBranches(
+      [
+        b({ name: "feat/foo", tipTime: 1 }),
+        b({ name: "main", tipTime: 0, isDefault: true }),
+        b({ name: "fresh", tipTime: 9000 }),
+      ],
+      pins("feat/foo"),
+    );
+    expect(names(rows)).toEqual(["feat/foo", "main", "fresh"]);
+  });
+
+  it("keeps the default branch above everything unpinned", () => {
+    const rows = orderBranches(
+      [
+        b({ name: "feat/foo", tipTime: 1 }),
+        b({ name: "main", tipTime: 0, isDefault: true }),
+        b({ name: "fresh", tipTime: 9000 }),
+      ],
+      pins("feat/foo"),
+    );
+    expect(names(rows).slice(1)).toEqual(["main", "fresh"]);
+  });
+
+  it("pinning the default branch changes nothing", () => {
+    const rows = orderBranches(
+      [b({ name: "fresh", tipTime: 9000 }), b({ name: "main", isDefault: true })],
+      pins("main"),
+    );
+    expect(names(rows)).toEqual(["main", "fresh"]);
+  });
+
+  it("orders several pins among themselves by the ordinary rules", () => {
+    const rows = orderBranches(
+      [
+        b({ name: "a", tipTime: 1 }),
+        b({ name: "b", tipTime: 500 }),
+        b({ name: "loose", tipTime: 9000 }),
+      ],
+      pins("a", "b"),
+    );
+    // Newest pin first — pinning is a tier, not a hand-ordered list.
+    expect(names(rows)).toEqual(["b", "a", "loose"]);
+  });
+
+  it("matches a pin by exact name, so a remote copy is not pinned with it", () => {
+    const rows = orderBranches(
+      [
+        b({ name: "origin/feat/foo", isRemote: true, tipTime: 1 }),
+        b({ name: "origin/zzz", isRemote: true, tipTime: 9000 }),
+      ],
+      pins("feat/foo"),
+    );
+    expect(names(rows)).toEqual(["origin/zzz", "origin/feat/foo"]);
+  });
+
+  it("is still only a permutation — a pin cannot resurrect a filtered-out row", () => {
+    const input = [b({ name: "x", tipTime: 3 }), b({ name: "y", tipTime: 4 })];
+    const rows = orderBranches(input, pins("gone"));
+    expect(names(rows).sort()).toEqual(["x", "y"]);
+    expect(rows).toHaveLength(2);
+  });
+
+  it("with no pins orders exactly as it did before", () => {
+    const input = [
+      b({ name: "old", tipTime: 1 }),
+      b({ name: "new", tipTime: 9 }),
+    ];
+    expect(names(orderBranches(input, pins()))).toEqual(names(orderBranches(input)));
+  });
+
+  it("carries pins through the grouped ordering", () => {
+    const rows = orderBranchesGrouped(
+      [
+        b({ name: "origin/pinned", isRemote: true, tipTime: 1 }),
+        b({ name: "origin/fresh", isRemote: true, tipTime: 9000 }),
+        b({ name: "local", tipTime: 5 }),
+      ],
+      pins("origin/pinned"),
+    );
+    expect(names(rows)).toEqual(["local", "origin/pinned", "origin/fresh"]);
+  });
+
+  it("compareBranches reads the pin set it is given", () => {
+    const a = b({ name: "a", tipTime: 1 });
+    const z = b({ name: "z", tipTime: 9000 });
+    expect(compareBranches(a, z, pins("a"))).toBeLessThan(0);
+    expect(compareBranches(a, z)).toBeGreaterThan(0);
+  });
+});

--- a/src/features/branches/orderBranches.ts
+++ b/src/features/branches/orderBranches.ts
@@ -6,14 +6,42 @@
 
 import type { BranchInfo } from "@/lib/types";
 
+/** Shared empty set, so the no-pins path allocates nothing. */
+const NO_PINS: ReadonlySet<string> = new Set();
+
 /**
- * Default branch first, then newest tip first, then name ascending.
+ * USER PINS first, then the default branch, then newest tip first, then name
+ * ascending.
  *
  * `isHead` is deliberately NOT read: the current branch is already accent-
  * coloured and badged, it is the one branch the picker exists to leave, and
  * pinning it would push the actual default down for no navigational gain.
+ *
+ * Pins rank ABOVE the default branch (#238). Two reasons, and the second is the
+ * load-bearing one:
+ *
+ *  - #135's pin is a DEFAULT — the app guessing what you want on top. A user
+ *    pin is an instruction. An instruction that loses to a guess is not a pin,
+ *    and the default branch is the one row nobody has trouble finding anyway.
+ *  - The Branches screen hoists pinned branches OUT of the folder tree, above
+ *    it. Ranking pins second here would put the comparator (default first) and
+ *    that screen (pins first) in permanent disagreement about the same list.
+ *
+ * With nothing pinned this is exactly #135's order, which is why its tests are
+ * untouched — and pinning the default branch alone still changes nothing.
+ *
+ * A pin matches `name` exactly, so pinning `feat/foo` does not also pin
+ * `origin/feat/foo` — they are two rows in two sections, and the user pinned
+ * one of them.
  */
-export function compareBranches(a: BranchInfo, b: BranchInfo): number {
+export function compareBranches(
+  a: BranchInfo,
+  b: BranchInfo,
+  pins: ReadonlySet<string> = NO_PINS,
+): number {
+  const aPinned = pins.has(a.name);
+  const bPinned = pins.has(b.name);
+  if (aPinned !== bPinned) return aPinned ? -1 : 1;
   if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
   if (a.tipTime !== b.tipTime) return b.tipTime - a.tipTime;
   // Plain comparison, not localeCompare: branches cut from one commit all share
@@ -32,8 +60,11 @@ export function compareBranches(a: BranchInfo, b: BranchInfo): number {
  * filter first and order second, so a query that excludes the default branch
  * keeps excluding it.
  */
-export function orderBranches<T extends BranchInfo>(rows: readonly T[]): T[] {
-  return [...rows].sort(compareBranches);
+export function orderBranches<T extends BranchInfo>(
+  rows: readonly T[],
+  pins: ReadonlySet<string> = NO_PINS,
+): T[] {
+  return [...rows].sort((a, b) => compareBranches(a, b, pins));
 }
 
 /**
@@ -48,9 +79,10 @@ export function orderBranches<T extends BranchInfo>(rows: readonly T[]): T[] {
  */
 export function orderBranchesGrouped<T extends BranchInfo>(
   rows: readonly T[],
+  pins: ReadonlySet<string> = NO_PINS,
 ): T[] {
   return [
-    ...orderBranches(rows.filter((r) => !r.isRemote)),
-    ...orderBranches(rows.filter((r) => r.isRemote)),
+    ...orderBranches(rows.filter((r) => !r.isRemote), pins),
+    ...orderBranches(rows.filter((r) => r.isRemote), pins),
   ];
 }

--- a/src/features/branches/pins.ts
+++ b/src/features/branches/pins.ts
@@ -1,0 +1,34 @@
+// Branch pins as the ACTIVE repository sees them (#238).
+//
+// Split from `useBranchPins` so that the storage module stays pure key/value
+// and only this one knows which repository is open. Both consumers here are
+// non-React — `design/context-menu.tsx` builds menu items and
+// `features/palette/commands.ts` builds palette rows — which is the whole
+// reason the pins live in a store rather than in the folds' React hook.
+
+import type { ContextMenuItem } from "@/design/context-menu";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { pinnedIn, useBranchPins } from "./useBranchPins";
+
+function activeRepoPath(): string | null {
+  return useRepoStore.getState().current?.path ?? null;
+}
+
+/** The open repository's pins, as a set for the comparator. */
+export function activePins(): ReadonlySet<string> {
+  return new Set(pinnedIn(activeRepoPath()));
+}
+
+/** The Pin/Unpin entry shared by the local and the remote branch menus. */
+export function pinItem(name: string): ContextMenuItem {
+  const repoPath = activeRepoPath();
+  const pinned = !!repoPath && pinnedIn(repoPath).includes(name);
+  return {
+    icon: "pin",
+    label: pinned ? "Unpin" : "Pin to top",
+    // No repository open means no per-repository set to write to. Shown
+    // disabled rather than hidden, so the menu keeps a stable shape.
+    disabled: !repoPath || !name,
+    onClick: () => useBranchPins.getState().toggle(repoPath, name),
+  };
+}

--- a/src/features/branches/useBranchPins.test.ts
+++ b/src/features/branches/useBranchPins.test.ts
@@ -1,0 +1,94 @@
+// Per-repository branch pins (#238), stored the way the folds are: one
+// localStorage key holding every repository's set, best-effort, never fatal.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  BRANCH_PINS_KEY,
+  pinnedIn,
+  useBranchPins,
+} from "./useBranchPins";
+
+const raw = () =>
+  JSON.parse(localStorage.getItem(BRANCH_PINS_KEY) ?? "null") as Record<
+    string,
+    string[]
+  > | null;
+
+/** Re-read localStorage into the store, as a fresh app start would. */
+const reload = () => useBranchPins.getState().reload();
+
+beforeEach(() => {
+  localStorage.clear();
+  useBranchPins.setState({ byRepo: {} });
+});
+
+describe("useBranchPins", () => {
+  it("pins a branch and reads it back for that repository", () => {
+    useBranchPins.getState().toggle("/a", "feat/foo");
+    expect(pinnedIn("/a")).toEqual(["feat/foo"]);
+    expect(raw()).toEqual({ "/a": ["feat/foo"] });
+  });
+
+  it("unpins on a second toggle", () => {
+    useBranchPins.getState().toggle("/a", "feat/foo");
+    useBranchPins.getState().toggle("/a", "feat/foo");
+    expect(pinnedIn("/a")).toEqual([]);
+    // The entry is pruned rather than left as an empty array, so a repository
+    // with no pins leaves nothing behind.
+    expect(raw()).toBeNull();
+  });
+
+  it("keeps repositories apart", () => {
+    useBranchPins.getState().toggle("/a", "main");
+    useBranchPins.getState().toggle("/b", "trunk");
+    expect(pinnedIn("/a")).toEqual(["main"]);
+    expect(pinnedIn("/b")).toEqual(["trunk"]);
+  });
+
+  it("leaves other repositories intact when one empties", () => {
+    useBranchPins.getState().toggle("/a", "main");
+    useBranchPins.getState().toggle("/b", "trunk");
+    useBranchPins.getState().toggle("/b", "trunk");
+    expect(raw()).toEqual({ "/a": ["main"] });
+  });
+
+  it("survives a restart", () => {
+    useBranchPins.getState().toggle("/a", "feat/foo");
+    useBranchPins.setState({ byRepo: {} });
+    reload();
+    expect(pinnedIn("/a")).toEqual(["feat/foo"]);
+  });
+
+  it("returns nothing for an unknown repository or none at all", () => {
+    expect(pinnedIn("/nope")).toEqual([]);
+    expect(pinnedIn(null)).toEqual([]);
+  });
+
+  it("keeps the array reference stable while the pins do not change", () => {
+    useBranchPins.getState().toggle("/a", "main");
+    const first = pinnedIn("/a");
+    useBranchPins.getState().toggle("/b", "other");
+    // Branches.tsx memoizes a Set on this reference; a fresh array per read
+    // would rebuild the ordering on every unrelated store write.
+    expect(pinnedIn("/a")).toBe(first);
+  });
+
+  it("survives a corrupt payload", () => {
+    localStorage.setItem(BRANCH_PINS_KEY, "{not json");
+    reload();
+    expect(pinnedIn("/a")).toEqual([]);
+  });
+
+  it("survives a payload that is not an object", () => {
+    localStorage.setItem(BRANCH_PINS_KEY, '["nope"]');
+    reload();
+    expect(pinnedIn("/a")).toEqual([]);
+  });
+
+  it("ignores non-string entries in a stored set", () => {
+    localStorage.setItem(BRANCH_PINS_KEY, JSON.stringify({ "/a": ["ok", 3, null] }));
+    reload();
+    expect(pinnedIn("/a")).toEqual(["ok"]);
+  });
+});

--- a/src/features/branches/useBranchPins.ts
+++ b/src/features/branches/useBranchPins.ts
@@ -1,0 +1,97 @@
+// Which branches a repository has pinned (#238), stored beside the folds
+// (`useBranchFolders`): one localStorage key holding every repository's set,
+// best-effort, never fatal.
+//
+// NOT in `useRepoStore`, for the reason the folds are not: that store holds one
+// repository's live git state and every field of it has to join `RepoSlice`,
+// while a pin is a view preference that must OUTLIVE the tab.
+//
+// A zustand STORE rather than the folds' React hook, because two of the four
+// surfaces that order branches are not components — `design/context-menu.tsx`
+// builds the menu items and `features/palette/commands.ts` builds the palette
+// rows, and both reach state through `getState()`. Keying by repository path
+// rather than tracking a "current" repository is what keeps a tab switch from
+// showing one repository's pins against another's branches.
+
+import { create } from "zustand";
+
+/** One key for every repository's pins — see `useBranchFolders`'s fold map. */
+export const BRANCH_PINS_KEY = "pg-branch-pins-v1";
+
+type PinMap = Record<string, string[]>;
+
+const EMPTY: string[] = [];
+
+function readStore(): PinMap {
+  try {
+    const raw = localStorage.getItem(BRANCH_PINS_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const out: PinMap = {};
+    for (const [repo, names] of Object.entries(parsed as Record<string, unknown>)) {
+      if (!Array.isArray(names)) continue;
+      const clean = names.filter((n): n is string => typeof n === "string");
+      if (clean.length > 0) out[repo] = clean;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function persist(byRepo: PinMap): void {
+  try {
+    if (Object.keys(byRepo).length === 0) {
+      localStorage.removeItem(BRANCH_PINS_KEY);
+      return;
+    }
+    localStorage.setItem(BRANCH_PINS_KEY, JSON.stringify(byRepo));
+  } catch {
+    // non-fatal — the session just won't remember the pins
+  }
+}
+
+interface BranchPinsState {
+  /** Every repository's pinned branch names, keyed by workdir path. */
+  byRepo: PinMap;
+  /** Pin `name` in `repoPath`, or unpin it if it is already pinned. */
+  toggle: (repoPath: string | null, name: string) => void;
+  /** Re-read localStorage. Only a fresh app start needs this; tests use it. */
+  reload: () => void;
+}
+
+export const useBranchPins = create<BranchPinsState>((set, get) => ({
+  byRepo: readStore(),
+
+  toggle(repoPath, name) {
+    if (!repoPath || !name) return;
+    const byRepo = { ...get().byRepo };
+    const current = byRepo[repoPath] ?? EMPTY;
+    const next = current.includes(name)
+      ? current.filter((n) => n !== name)
+      : [...current, name];
+    // Prune rather than store an empty array, so a repository whose pins were
+    // all removed leaves no entry behind.
+    if (next.length === 0) delete byRepo[repoPath];
+    else byRepo[repoPath] = next;
+    set({ byRepo });
+    persist(byRepo);
+  },
+
+  reload() {
+    set({ byRepo: readStore() });
+  },
+}));
+
+/**
+ * The branch names pinned in `repoPath`, newest pin last.
+ *
+ * Returns the stored array itself, so the reference is stable while the pins
+ * are — `Branches.tsx` memoizes a `Set` on it, and a fresh array per read would
+ * rebuild the ordering on every unrelated store write.
+ */
+export function pinnedIn(repoPath: string | null): string[] {
+  if (!repoPath) return EMPTY;
+  return useBranchPins.getState().byRepo[repoPath] ?? EMPTY;
+}

--- a/src/features/branches/usePinSet.ts
+++ b/src/features/branches/usePinSet.ts
@@ -1,0 +1,18 @@
+// The open repository's pins, as a memoized Set (#238) — the React side of
+// `useBranchPins`, for the two surfaces that ARE components.
+//
+// Subscribes to the stored ARRAY, not to a derived Set: the store hands back
+// the same array reference while the pins are unchanged, so the Set is rebuilt
+// only when a pin is actually toggled. Selecting a fresh `new Set(...)` would
+// fail zustand's identity check and re-render the picker on every store write.
+
+import React from "react";
+
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useBranchPins } from "./useBranchPins";
+
+export function usePinSet(): ReadonlySet<string> {
+  const repoPath = useRepoStore((s) => s.current?.path ?? null);
+  const names = useBranchPins((s) => (repoPath ? s.byRepo[repoPath] : undefined));
+  return React.useMemo(() => new Set(names ?? []), [names]);
+}

--- a/src/features/palette/commands.ts
+++ b/src/features/palette/commands.ts
@@ -13,6 +13,7 @@ import { useTabsStore } from "@/features/repo/useTabsStore";
 import { openCompare } from "@/features/compare/useCompareStore";
 import { WORKDIR } from "@/features/compare/compareSides";
 import { orderBranchesGrouped } from "@/features/branches/orderBranches";
+import { activePins } from "@/features/branches/pins";
 import { summarizeFastForward } from "@/features/branches/fastForward";
 import { openCreateTag } from "@/features/tags/useCreateTagStore";
 import { usePaletteStore } from "./usePaletteStore";
@@ -85,7 +86,10 @@ export function branchItems({
   // outranks the pinned default there. The pin is honoured in the picker, the
   // Branches screen and the pick steps; the root step is a relevance ranking
   // and deliberately stays one.
-  return orderBranchesGrouped(filter ? rows.filter(filter) : rows).map((b) => ({
+  return orderBranchesGrouped(
+    filter ? rows.filter(filter) : rows,
+    activePins(),
+  ).map((b) => ({
     type: "branch" as const,
     id: `${idPrefix}:${b.isRemote ? "r" : "l"}:${b.name}`,
     search: b.name,

--- a/src/screens/Branches.pins.test.tsx
+++ b/src/screens/Branches.pins.test.tsx
@@ -1,0 +1,183 @@
+// Pinned branches on the Branches screen (#238).
+//
+// The comparator's pin tier is tested in `orderBranches.test.ts`; this covers
+// the part it cannot see — that a pin is HOISTED OUT of the folder tree rather
+// than merely sorted to the front of the folder it lives in, which is the whole
+// point when that folder is collapsed.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { BranchesScreen } from "./Branches";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useKeymapStore, useFocusStore } from "@/features/keymap";
+import { mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { WithDialogs, resetDialogs } from "@/test/dialog";
+import { BRANCH_FOLDERS_KEY } from "@/features/branches/useBranchFolders";
+import { useBranchPins } from "@/features/branches/useBranchPins";
+import type { BranchInfo } from "@/lib/types";
+
+const mkBranch = (over: Partial<BranchInfo> & { name: string }): BranchInfo => ({
+  isHead: false,
+  isRemote: false,
+  upstream: null,
+  ahead: 0,
+  behind: 0,
+  tip: "0".repeat(40),
+  tipTime: 0,
+  isDefault: false,
+  ...over,
+});
+
+// `feat` and `rel` hold more than one branch each, so both are real folders.
+// `chore/deps` is alone and therefore ONE row reading `chore/deps` — a prefix
+// that groups nothing is not a folder (#244), which is exactly the compression
+// a hoist has to respect when it empties a folder out.
+const BRANCHES = [
+  mkBranch({ name: "main", tipTime: 10, isDefault: true }),
+  mkBranch({ name: "feat/alpha", tipTime: 900 }),
+  mkBranch({ name: "feat/beta", tipTime: 800 }),
+  mkBranch({ name: "feat/gamma", tipTime: 700 }),
+  mkBranch({ name: "rel/x", tipTime: 600 }),
+  mkBranch({ name: "rel/y", tipTime: 500 }),
+  mkBranch({ name: "chore/deps", tipTime: 400, isHead: true }),
+];
+
+const branchNames = () =>
+  Array.from(document.querySelectorAll('[data-testid="branch-row"]')).map(
+    (el) => el.querySelector("[data-branch-label]")?.textContent ?? "",
+  );
+
+const folderPaths = () =>
+  Array.from(
+    document.querySelectorAll('[data-testid="branch-folder-row"]'),
+  ).map((el) => el.getAttribute("data-folder") ?? "");
+
+function setup(branches = BRANCHES) {
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/chore/deps" },
+    status: [],
+    branches,
+    remotes: [],
+    tags: [],
+    stashes: [],
+    commits: [],
+    loading: false,
+    checkoutBranch: async () => {},
+  } as never);
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => branches);
+  render(
+    <WithDialogs>
+      <BranchesScreen />
+    </WithDialogs>,
+  );
+  useFocusStore.setState({ focused: "branches.list" });
+}
+
+beforeEach(() => {
+  resetInvokeMock();
+  resetDialogs();
+  localStorage.clear();
+  useBranchPins.setState({ byRepo: {} });
+  useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+  useKeymapStore.getState().setPreset("rider");
+  useFocusStore.setState({
+    focused: null,
+    panes: new Map(),
+    order: [],
+    barId: null,
+    pendingContentFocus: false,
+  });
+});
+
+describe("pinned branches on the Branches screen", () => {
+  it("hoists a pinned branch out of its folder, under its full name", () => {
+    useBranchPins.setState({ byRepo: { "/repo": ["feat/beta"] } });
+    setup();
+
+    // First row, above the default branch and above every folder.
+    expect(branchNames()[0]).toBe("feat/beta");
+    // And gone from the tree — hoisted, not duplicated.
+    expect(branchNames().filter((n) => n === "feat/beta")).toHaveLength(1);
+  });
+
+  it("keeps a pin visible while its folder is collapsed", () => {
+    // The case pinning exists for: without the hoist the row would be the first
+    // one INSIDE `feat`, and a collapsed `feat` would hide it entirely.
+    localStorage.setItem(BRANCH_FOLDERS_KEY, JSON.stringify({ "/repo": ["feat"] }));
+    useBranchPins.setState({ byRepo: { "/repo": ["feat/beta"] } });
+    setup();
+
+    expect(folderPaths()).toContain("feat");
+    expect(branchNames()).toContain("feat/beta");
+    expect(branchNames()).not.toContain("feat/alpha");
+  });
+
+  it("leaves the folder behind when it still holds other branches", () => {
+    useBranchPins.setState({ byRepo: { "/repo": ["feat/beta"] } });
+    setup();
+    expect(folderPaths()).toContain("feat");
+  });
+
+  it("drops a folder the pins emptied out", () => {
+    useBranchPins.setState({ byRepo: { "/repo": ["rel/x", "rel/y"] } });
+    setup();
+    // Hoisting every branch out of `rel` leaves no folder to draw — and no
+    // empty one either.
+    expect(folderPaths()).not.toContain("rel");
+    expect(branchNames().slice(0, 2)).toEqual(["rel/x", "rel/y"]);
+  });
+
+  it("orders several pins among themselves by the ordinary rules", () => {
+    useBranchPins.setState({ byRepo: { "/repo": ["feat/beta", "chore/deps"] } });
+    setup();
+    // feat/beta tipTime 800 > chore/deps 400 — newest first, as everywhere.
+    expect(branchNames().slice(0, 2)).toEqual(["feat/beta", "chore/deps"]);
+  });
+
+  it("changes nothing when the repository has no pins", () => {
+    setup();
+    expect(branchNames()[0]).toBe("main");
+    expect(folderPaths()).toEqual(["feat", "rel"]);
+  });
+
+  it("keeps another repository's pins out of this one", () => {
+    useBranchPins.setState({ byRepo: { "/elsewhere": ["feat/beta"] } });
+    setup();
+    expect(branchNames()[0]).toBe("main");
+  });
+});
+
+describe("the branch menu's pin verb", () => {
+  const rowFor = (label: string) =>
+    Array.from(
+      document.querySelectorAll('[data-testid="branch-row"]'),
+    ).find(
+      (el) => el.querySelector("[data-branch-label]")?.textContent === label,
+    ) as HTMLElement;
+
+  it("pins from the context menu and persists it for this repository", async () => {
+    setup();
+    // Unpinned it lives inside the expanded `feat` folder, where the row is
+    // labelled by its SEGMENT; only a hoisted row carries the full name.
+    fireEvent.contextMenu(rowFor("beta"));
+    await act(async () => {
+      fireEvent.click(screen.getByText("Pin to top"));
+    });
+
+    expect(useBranchPins.getState().byRepo["/repo"]).toEqual(["feat/beta"]);
+    expect(branchNames()[0]).toBe("feat/beta");
+  });
+
+  it("offers Unpin for a branch already pinned, and unpins it", async () => {
+    useBranchPins.setState({ byRepo: { "/repo": ["feat/beta"] } });
+    setup();
+    fireEvent.contextMenu(rowFor("feat/beta"));
+    await act(async () => {
+      fireEvent.click(screen.getByText("Unpin"));
+    });
+
+    expect(useBranchPins.getState().byRepo["/repo"]).toBeUndefined();
+    expect(branchNames()[0]).toBe("main");
+  });
+});

--- a/src/screens/Branches.tsx
+++ b/src/screens/Branches.tsx
@@ -35,6 +35,7 @@ import {
   type BranchTreeRow,
 } from "@/features/branches/branchTree";
 import { useBranchFolders } from "@/features/branches/useBranchFolders";
+import { usePinSet } from "@/features/branches/usePinSet";
 import {
   deleteMergedCandidates,
   findMergedBranches,
@@ -88,6 +89,7 @@ export function BranchesScreen() {
   const [selection, setSelection] = React.useState<Selection | null>(null);
   const [filter, setFilter] = React.useState("");
   const folders = useBranchFolders(repoPath);
+  const pins = usePinSet();
   const [view, setView] = React.useState<
     "all" | "local" | "remote" | "tags" | "stashes"
   >("all");
@@ -287,12 +289,12 @@ export function BranchesScreen() {
     // is ordered WITHIN its group so the `all` view still lists locals before
     // remotes rather than interleaving them by tip time.
     const filtered = list.filter((b) => b.name.includes(filter));
-    const locals = orderBranches(filtered.filter((b) => b.kind === "local"));
-    const remotes = orderBranches(filtered.filter((b) => b.kind === "remote"));
+    const locals = orderBranches(filtered.filter((b) => b.kind === "local"), pins);
+    const remotes = orderBranches(filtered.filter((b) => b.kind === "remote"), pins);
     if (view === "local") return locals;
     if (view === "remote") return remotes;
     return [...locals, ...remotes];
-  }, [branches, filter, view]);
+  }, [branches, filter, view, pins]);
 
   // Grouping is the LAST step (#244): filter, order (#135), then group. It only
   // moves rows into folders, so the pinned default and the newest-first order
@@ -304,16 +306,29 @@ export function BranchesScreen() {
   // it names nothing.
   const filtering = filter.length > 0;
   const displayRows = React.useMemo<BranchTreeRow<BranchRow>[]>(() => {
-    if (filtering)
-      return rows.map((b) => ({
-        kind: "branch" as const,
-        path: b.name,
-        label: b.name,
-        depth: 0,
-        branch: b,
-      }));
-    return branchTreeRows(rows, folders.collapsed);
-  }, [rows, filtering, folders.collapsed]);
+    const flat = (b: BranchRow) => ({
+      kind: "branch" as const,
+      path: b.name,
+      label: b.name,
+      depth: 0,
+      branch: b,
+    });
+    if (filtering) return rows.map(flat);
+    // Pinned branches are HOISTED OUT of the tree (#238), not just sorted to
+    // the front of it. Grouping only moves ordered rows into folders, so a
+    // pinned `feat/foo` would otherwise be the first row INSIDE `feat` — and
+    // invisible whenever that folder is collapsed, which is the case pinning
+    // exists for. The default branch escapes this today only because `main`
+    // has no `/` and is therefore already a root-level leaf.
+    //
+    // They render at depth 0 under their FULL names (a bare `foo` with no
+    // `feat/` above it names nothing) and are REMOVED from the tree rather
+    // than duplicated into it. `rows` is already ordered pins-first, so the
+    // hoisted block and the tree below it are in one continuous order.
+    const pinned = rows.filter((b) => pins.has(b.name));
+    const rest = rows.filter((b) => !pins.has(b.name));
+    return [...pinned.map(flat), ...branchTreeRows(rest, folders.collapsed)];
+  }, [rows, filtering, folders.collapsed, pins]);
 
   const visibleTags = React.useMemo(() => {
     if (view === "stashes") return [];
@@ -760,6 +775,16 @@ export function BranchesScreen() {
                   }}
                   title={b.name}
                 >
+                  {pins.has(b.name) && (
+                    // Says WHY this row is at the top, and where the verb that
+                    // put it there lives. Without it a hoisted branch is just a
+                    // row in a surprising place.
+                    <PGIcon
+                      name="pin"
+                      size={10}
+                      style={{ color: "var(--fg-2)", flexShrink: 0 }}
+                    />
+                  )}
                   <span
                     data-branch-label=""
                     style={{


### PR DESCRIPTION
## What does this PR do?

A fifty-branch repository ordered by recency gives you no way to say "keep
`feat/foo` on top". Branches now **pin**, from the context menu, per repository
— and a pinned branch is the first row wherever branches are listed.

Closes #238 — this is its second half; the first, drag-to-reorder repository
tabs, landed in #332.

Two things the issue floated are deliberately **not** here, and neither is
needed to call it done:

- **Making the pin-vs-default order configurable.** One rule that reads the
  same on every surface beats a setting nobody will find; if the ordering turns
  out to be wrong, changing it is a one-line move in the comparator.
- **Per-branch colour**, which the issue lists as "optional and cheap once
  pinning exists". It is a separate feature with its own surface (a colour
  picker, a swatch in every branch row, a palette that has to survive both
  themes) and belongs in its own issue rather than smuggled in here.

## Pins outrank the default branch

#135 pins the default branch to the top. That pin is the app **guessing** what
belongs on top; a user pin is an **instruction**, and an instruction that loses
to a guess is not a pin. The default branch is also the one row nobody has
trouble finding.

With nothing pinned the order is exactly #135's, which is why its tests are
untouched — and pinning the default branch on its own still changes nothing.

I first implemented this the other way round (default above pins) and had to
flip it, for the reason in the next section.

## Hoisting is the real work, not the comparator tier

Grouping (#244) runs **after** ordering and only moves ordered rows into
folders. So a pinned `feat/foo` would be the first row *inside* `feat` — and
invisible whenever that folder is collapsed, which is precisely the case
pinning exists for. The default branch escapes this today only because `main`
has no `/` and is therefore already a root-level leaf.

Pinned branches are therefore **lifted out of the tree**: rendered at depth 0
under their FULL names (a bare `foo` with no `feat/` above it names nothing),
and **removed** from the tree rather than duplicated into it. A folder the pins
emptied out stops being drawn, and one that still holds two branches stays.

That is also the second reason the tier has to outrank the default: with pins
ranked second, the comparator (default first) and this screen (pins first)
would disagree permanently about one list.

## A store, not the folds' React hook

`useBranchPins` is zustand, keyed by repository path, persisted to
`pg-branch-pins-v1` and pruned when a repository's set empties — the same shape
and best-effort error handling as `useBranchFolders`.

Where it departs from the folds is that it is a **store**: two of the four
surfaces that order branches are not components. `design/context-menu.tsx`
builds the menu items and `features/palette/commands.ts` builds the palette
rows, and both reach state through `getState()`. A hook cannot serve them.
`usePinSet` is the React side, and it subscribes to the stored **array** so the
memoized `Set` is rebuilt only when a pin actually changes rather than on every
unrelated store write.

Not in `useRepoStore`, for the reason the folds are not: that holds one
repository's live git state and every field must join `RepoSlice`, whereas a
pin has to outlive the tab.

## Details worth a look

- **A pin matches the branch name exactly.** Pinning `feat/foo` does not also
  pin `origin/feat/foo` — two rows, two sections, and the user pinned one.
- **One `pinItem`** shared by the local and remote branch menus, so the verb
  cannot drift between them. It reads the active repository through
  `getState()`, like every other verb in those menus.
- **A new `pin` glyph** marks hoisted rows. Without it a pinned branch is just
  a row in a surprising place, with nothing saying why or where the verb that
  put it there lives.

## Testing

- `useBranchPins.test.ts` — round-trip, repositories kept apart, entry pruned
  when empty, the array reference staying stable, and three corrupt-payload
  cases.
- `orderBranches.test.ts` — the new tier, pins above the default, pinning the
  default as a no-op, exact-name matching, and that ordering is still only a
  permutation so a pin cannot resurrect a filtered-out row.
- `Branches.pins.test.tsx` — the hoist: out of its folder under the full name,
  exactly once; still visible while its folder is collapsed; the folder left
  behind when it holds others and dropped when the pins emptied it; and one
  repository's pins staying out of another's.
- `branches.e2e.ts` — pinning through the real context menu in WebKitGTK,
  asserted against the rendered rows and `pg-branch-pins-v1`.

```
pnpm tsc --noEmit                            clean
pnpm exec tsc -p e2e/tsconfig.json --noEmit  clean
pnpm test                                    291 files, 2730 tests passing
pnpm test:e2e:docker --spec e2e/specs/branches.e2e.ts   4 passing
```

The e2e run above was against this branch's own snapshot before the rebase onto
#332; the two changes do not touch the same code, and CI runs the full suite on
the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
