### PR TITLE
feat(update): a release channel, so prereleases are opt-in (#237)

### DIFF
--- a/docs/dev/distribution.md
+++ b/docs/dev/distribution.md
@@ -141,6 +141,46 @@ Two things are load-bearing about *where* this lives:
 The per-version snooze (`dismissedVersion` / `shouldNag`) is orthogonal and
 unchanged — that is "not this release", not "not ever".
 
+### The channel is two endpoints, not one endpoint plus a filter
+
+`updateChannel` (`PersistedState`, default `"stable"`) selects which releases a
+check considers, and the two channels hit **different GitHub endpoints**
+(`update.rs::fetch_for_channel`):
+
+- `stable` → `GET /releases/latest`. This is GitHub's own answer to "what is the
+  current release": it excludes prereleases and drafts server-side and honours
+  `make_latest`. Re-deriving that by filtering the full list would mean
+  re-implementing a rule GitHub already applies — and getting it wrong in
+  exactly the place the release process already has traps (see the prerelease
+  promote notes: clearing `prerelease` does **not** move `releases/latest`).
+- `prerelease` → `GET /releases?per_page=30`, then `pick_newest`, which takes the
+  **semver-highest** entry rather than the first. GitHub orders that list by
+  creation date, so list order is the wrong answer whenever a patch on an older
+  line is published after a newer candidate. Precedence is also what makes
+  `0.3.0` correctly beat its own `0.3.0-rc.2`.
+
+`prerelease` means "offer me prereleases **as well**", never "only prereleases" —
+so someone on that channel still gets a stable release when it is the newest
+thing published. One page is enough because the list is newest-first by date, so
+the newest release under any ordering is on it.
+
+Two consequences worth knowing before changing this:
+
+- **Switching back to `stable` does not downgrade.** The stable release is older
+  than the running prerelease, `compute_available` says no, and the panel says
+  up to date. That is honest — the app cannot un-install a version, and offering
+  a "downgrade" would produce a prompt whose install fails.
+- **`UpdateInfo.prerelease` is GitHub's flag, not a re-parse of the tag.** The
+  two disagree in both directions: a `-rc.1` tag can be published as a full
+  release, and a plain `v0.3.0` tag can be flagged prerelease. The panel's
+  badge reads the flag, so the label cannot contradict the channel that found
+  the release.
+
+The channel is portable (it travels in a #254 settings export): "this team
+tracks the prereleases" is a team decision, not a fact about one machine — the
+same call `updateCheckMode` made. The check-mode gate still outranks it: `never`
+makes no request whatever the channel is set to.
+
 ## Permissions (Tauri 2)
 
 - Shared permissions in `src-tauri/capabilities/default.json`: `core:default`,

--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -3,20 +3,32 @@ use std::ffi::OsStr;
 use crate::{
     error::{AppError, AppResult},
     opener,
-    update::{self, UpdateCapability, UpdateInfo},
+    update::{self, UpdateCapability, UpdateChannel, UpdateInfo},
 };
 
-/// Query GitHub for the latest release and compare to the running version.
-/// Drives the update prompt only — never installs anything.
+/// Query GitHub for the newest release on `channel` and compare to the running
+/// version. Drives the update prompt only — never installs anything.
 ///
 /// `update::discover` short-circuits dev/e2e builds (`0.0.0`) BEFORE the fetch,
 /// so no network request leaves a `pnpm tauri dev` or e2e process.
+///
+/// The channel is a PARAMETER rather than something the backend reads for
+/// itself: the preference lives in the frontend's persisted settings, which is
+/// also where the "should this check happen at all" gate lives
+/// (`useUpdateStore.check`). Keeping both on the same side of the IPC boundary
+/// means there is one place to read to know what any given check will do.
 #[tauri::command]
-pub async fn check_for_update() -> AppResult<UpdateInfo> {
+pub async fn check_for_update(channel: Option<UpdateChannel>) -> AppResult<UpdateInfo> {
     let current = env!("CARGO_PKG_VERSION").to_string();
-    tokio::task::spawn_blocking(move || update::discover(&current, update::fetch_latest_release))
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+    // Absent means stable. The frontend always sends one; the default is here so
+    // that a caller which does not — an older webview against a newer binary, or
+    // a hand-issued invoke — gets the conservative channel rather than an error.
+    let channel = channel.unwrap_or_default();
+    tokio::task::spawn_blocking(move || {
+        update::discover(&current, || update::fetch_for_channel(channel))
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
 /// Whether this install can self-update or should notify + defer to a package

--- a/src-tauri/src/update.rs
+++ b/src-tauri/src/update.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use semver::Version;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::error::{AppError, AppResult};
 
@@ -23,6 +23,26 @@ pub const DEV_VERSION: &str = "0.0.0";
 /// becomes a permanently disabled spinner with no cancel.
 const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Which releases this install is willing to be offered (#237).
+///
+/// `Stable` is the default and is not merely "filter out prereleases" — it is a
+/// DIFFERENT endpoint. `GET /releases/latest` is GitHub's own answer to "what is
+/// the current release", which excludes prereleases and drafts server-side and
+/// respects `make_latest`; reproducing that by filtering the list would mean
+/// re-deriving a rule GitHub already applies.
+///
+/// `Prerelease` means "offer me prereleases *as well*", never "only
+/// prereleases": it takes the semver-highest of every published release, so a
+/// user on the prerelease channel still gets a stable release when that is the
+/// newest thing there is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum UpdateChannel {
+    #[default]
+    Stable,
+    Prerelease,
+}
+
 /// Discovery result handed to the frontend.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -33,6 +53,14 @@ pub struct UpdateInfo {
     pub notes: String,
     pub release_url: String,
     pub published_at: String,
+    /// Whether the release being offered is marked prerelease on GitHub.
+    ///
+    /// Reported rather than inferred from the version string: GitHub's flag is
+    /// what decides which channel a release belongs to, and the two can
+    /// disagree in both directions — a `-rc.1` tag published as a full release,
+    /// or a plain `v0.3.0` tag flagged prerelease. The flag is what the panel
+    /// labels, so the label cannot contradict the channel that found it.
+    pub prerelease: bool,
 }
 
 /// Whether this install can swap its own binary or should defer to a package
@@ -131,6 +159,8 @@ pub struct ReleaseMeta {
     pub notes: String,
     pub url: String,
     pub published_at: String,
+    /// GitHub's `prerelease` flag. See `UpdateInfo::prerelease`.
+    pub prerelease: bool,
 }
 
 /// Parse a release tag or crate version into a semver `Version`.
@@ -192,6 +222,7 @@ pub fn discover(
             notes: String::new(),
             release_url: String::new(),
             published_at: String::new(),
+            prerelease: false,
         });
     }
     let rel = fetch()?;
@@ -202,6 +233,7 @@ pub fn discover(
         notes: rel.notes,
         release_url: rel.url,
         published_at: rel.published_at,
+        prerelease: rel.prerelease,
     })
 }
 
@@ -309,10 +341,16 @@ pub fn capability(env: InstallEnv<'_>) -> UpdateCapability {
     }
 }
 
-/// Parse the JSON body of `GET /repos/:slug/releases/latest`.
-pub fn parse_release(json: &str) -> AppResult<ReleaseMeta> {
-    let v: serde_json::Value = serde_json::from_str(json)
-        .map_err(|e| AppError::Network(format!("parse release json: {e}")))?;
+/// How many releases the prerelease channel considers.
+///
+/// GitHub returns `/releases` newest-first by creation date, so the newest
+/// release by *any* ordering is in the first page. One page is therefore enough
+/// to answer "what is the newest thing published", and asking for more would
+/// spend bandwidth to re-rank releases that are already known to be older.
+const RELEASES_PER_PAGE: u32 = 30;
+
+/// Map one release object from either endpoint.
+fn release_from_value(v: &serde_json::Value) -> AppResult<ReleaseMeta> {
     let tag = v["tag_name"]
         .as_str()
         .ok_or_else(|| AppError::Network("release json missing tag_name".into()))?
@@ -324,14 +362,63 @@ pub fn parse_release(json: &str) -> AppResult<ReleaseMeta> {
         notes: v["body"].as_str().unwrap_or("").to_string(),
         url: v["html_url"].as_str().unwrap_or("").to_string(),
         published_at: v["published_at"].as_str().unwrap_or("").to_string(),
+        // Absent means false: `/releases/latest` never returns a prerelease, so
+        // a missing flag there is the truth rather than a gap.
+        prerelease: v["prerelease"].as_bool().unwrap_or(false),
     })
 }
 
-/// Blocking GET of the latest published release from GitHub. Call inside
-/// `spawn_blocking`. Unauthenticated (60 req/hr/IP is ample for our cadence —
-/// and dev/e2e builds never get here, see `discover`).
-pub fn fetch_latest_release() -> AppResult<ReleaseMeta> {
-    let url = format!("https://api.github.com/repos/{REPO_SLUG}/releases/latest");
+/// Parse the JSON body of `GET /repos/:slug/releases/latest`.
+pub fn parse_release(json: &str) -> AppResult<ReleaseMeta> {
+    let v: serde_json::Value = serde_json::from_str(json)
+        .map_err(|e| AppError::Network(format!("parse release json: {e}")))?;
+    release_from_value(&v)
+}
+
+/// Parse the JSON body of `GET /repos/:slug/releases` — the prerelease channel.
+///
+/// Drafts are dropped here rather than relied on being absent. An
+/// unauthenticated request does not see them, which is what we make, but this
+/// function is also the one place a future authenticated request would flow
+/// through, and offering a draft would point every user at a release page that
+/// 404s for them.
+///
+/// A single malformed entry does not fail the whole check — it is skipped. The
+/// alternative is that one release published with an odd payload turns the
+/// updater off for everyone on the channel until it is fixed.
+pub fn parse_releases(json: &str) -> AppResult<Vec<ReleaseMeta>> {
+    let v: serde_json::Value = serde_json::from_str(json)
+        .map_err(|e| AppError::Network(format!("parse releases json: {e}")))?;
+    let arr = v
+        .as_array()
+        .ok_or_else(|| AppError::Network("releases json is not an array".into()))?;
+    Ok(arr
+        .iter()
+        .filter(|r| !r["draft"].as_bool().unwrap_or(false))
+        .filter_map(|r| release_from_value(r).ok())
+        .collect())
+}
+
+/// The semver-highest release in the list, or `None` if none has a usable tag.
+///
+/// By PRECEDENCE, not by list order, and that is the whole point of the
+/// prerelease channel. GitHub orders `/releases` by creation date, so a patch
+/// cut on an old line after a newer prerelease would otherwise win — and the
+/// same ordering is what makes `1.0.0` correctly beat a stale `1.1.0-rc.1`
+/// only when precedence, not dates, decides. Unparseable tags are skipped for
+/// the reason `is_newer` refuses them: no comparison is better than a wrong one.
+pub fn pick_newest(releases: &[ReleaseMeta]) -> Option<&ReleaseMeta> {
+    releases
+        .iter()
+        .filter_map(|r| parse_version(&r.version).map(|v| (v, r)))
+        .max_by(|(a, _), (b, _)| a.cmp_precedence(b))
+        .map(|(_, r)| r)
+}
+
+/// Blocking GET returning the response body. Call inside `spawn_blocking`.
+/// Unauthenticated (60 req/hr/IP is ample for our cadence — and dev/e2e builds
+/// never get here, see `discover`).
+fn get_body(url: &str) -> AppResult<String> {
     // `https_only` matters because the agent follows up to 5 redirects by
     // default — without it a redirect could downgrade us to plaintext http.
     let agent = ureq::AgentBuilder::new()
@@ -339,13 +426,37 @@ pub fn fetch_latest_release() -> AppResult<ReleaseMeta> {
         .https_only(true)
         .build();
     let resp = agent
-        .get(&url)
+        .get(url)
         .set("User-Agent", "platypusgit-updater")
         .set("Accept", "application/vnd.github+json")
         .call()
         .map_err(|e| AppError::Network(e.to_string()))?;
-    let body = resp
-        .into_string()
-        .map_err(|e| AppError::Network(e.to_string()))?;
-    parse_release(&body)
+    resp.into_string()
+        .map_err(|e| AppError::Network(e.to_string()))
+}
+
+/// Blocking GET of the latest published release from GitHub (stable channel).
+pub fn fetch_latest_release() -> AppResult<ReleaseMeta> {
+    let url = format!("https://api.github.com/repos/{REPO_SLUG}/releases/latest");
+    parse_release(&get_body(&url)?)
+}
+
+/// Blocking GET of the newest release including prereleases.
+pub fn fetch_newest_release() -> AppResult<ReleaseMeta> {
+    let url = format!(
+        "https://api.github.com/repos/{REPO_SLUG}/releases?per_page={RELEASES_PER_PAGE}"
+    );
+    let releases = parse_releases(&get_body(&url)?)?;
+    pick_newest(&releases)
+        .cloned()
+        .ok_or_else(|| AppError::Network("no published releases".into()))
+}
+
+/// The fetch for a channel. The one place the two endpoints are chosen between,
+/// so no caller can pair a channel with the wrong URL.
+pub fn fetch_for_channel(channel: UpdateChannel) -> AppResult<ReleaseMeta> {
+    match channel {
+        UpdateChannel::Stable => fetch_latest_release(),
+        UpdateChannel::Prerelease => fetch_newest_release(),
+    }
 }

--- a/src-tauri/tests/update.rs
+++ b/src-tauri/tests/update.rs
@@ -3,7 +3,8 @@ use std::cell::Cell;
 use platypusgit_lib::error::AppError;
 use platypusgit_lib::update::{
     capability, compute_available, discover, is_msix_packaged, is_newer, is_scoop_layout,
-    parse_release, InstallEnv, ReleaseMeta, UpdateCapability,
+    parse_release, parse_releases, pick_newest, InstallEnv, ReleaseMeta, UpdateCapability,
+    UpdateChannel,
 };
 
 #[test]
@@ -75,6 +76,7 @@ fn meta(version: &str) -> ReleaseMeta {
         notes: "notes".into(),
         url: "https://example.com/r".into(),
         published_at: "2026-07-08T10:00:00Z".into(),
+        prerelease: false,
     }
 }
 
@@ -419,5 +421,171 @@ fn capability_ignores_msix_off_windows() {
             ..InstallEnv::new("linux")
         }),
         UpdateCapability::SelfUpdate
+    );
+}
+
+
+// ---------------------------------------------------------------------------
+// Update channel (#237)
+// ---------------------------------------------------------------------------
+
+/// A `/releases` list page, newest-by-date first — the order GitHub returns.
+const RELEASES_JSON: &str = r#"[
+    {
+        "tag_name": "v0.3.0-rc.2",
+        "body": "second candidate",
+        "html_url": "https://example.com/rc2",
+        "published_at": "2026-08-30T10:00:00Z",
+        "prerelease": true,
+        "draft": false
+    },
+    {
+        "tag_name": "v0.2.1",
+        "body": "patch",
+        "html_url": "https://example.com/021",
+        "published_at": "2026-08-20T10:00:00Z",
+        "prerelease": false,
+        "draft": false
+    },
+    {
+        "tag_name": "v0.3.0-rc.1",
+        "body": "first candidate",
+        "html_url": "https://example.com/rc1",
+        "published_at": "2026-08-10T10:00:00Z",
+        "prerelease": true,
+        "draft": false
+    }
+]"#;
+
+#[test]
+fn parse_releases_maps_a_list_page() {
+    let rels = parse_releases(RELEASES_JSON).unwrap();
+    assert_eq!(rels.len(), 3);
+    assert_eq!(rels[0].version, "0.3.0-rc.2");
+    assert!(rels[0].prerelease);
+    assert_eq!(rels[1].version, "0.2.1");
+    assert!(!rels[1].prerelease, "a full release is not flagged");
+    assert_eq!(rels[0].notes, "second candidate");
+    assert_eq!(rels[0].url, "https://example.com/rc2");
+}
+
+#[test]
+fn parse_releases_drops_drafts() {
+    // A draft's release page 404s for anyone but its author, so offering one
+    // would be a dead link. Unauthenticated requests don't see drafts, but this
+    // is the one place an authenticated one would flow through.
+    let json = r#"[
+        {"tag_name":"v0.4.0","draft":true,"prerelease":false},
+        {"tag_name":"v0.3.0","draft":false,"prerelease":false}
+    ]"#;
+    let rels = parse_releases(json).unwrap();
+    assert_eq!(rels.len(), 1);
+    assert_eq!(rels[0].version, "0.3.0");
+}
+
+#[test]
+fn parse_releases_skips_a_malformed_entry_rather_than_failing() {
+    // One odd payload must not turn the updater off for the whole channel.
+    let json = r#"[
+        {"name":"no tag here","draft":false},
+        {"tag_name":"v0.3.0","draft":false}
+    ]"#;
+    let rels = parse_releases(json).unwrap();
+    assert_eq!(rels.len(), 1);
+    assert_eq!(rels[0].version, "0.3.0");
+}
+
+#[test]
+fn parse_releases_rejects_a_non_array_body() {
+    // The shape GitHub returns on error — an object, not a list.
+    assert!(parse_releases(r#"{"message":"Not Found"}"#).is_err());
+    assert!(parse_releases("not json at all").is_err());
+}
+
+#[test]
+fn pick_newest_uses_precedence_not_list_order() {
+    let rels = parse_releases(RELEASES_JSON).unwrap();
+    let newest = pick_newest(&rels).unwrap();
+    assert_eq!(newest.version, "0.3.0-rc.2");
+}
+
+#[test]
+fn pick_newest_prefers_a_release_over_a_stale_prerelease_of_it() {
+    // The case that makes date order wrong: 0.3.0 ships, then a hotfix branch
+    // publishes nothing newer — 0.3.0 must still win over its own candidates,
+    // which sort BELOW it under semver precedence.
+    let rels = vec![meta("0.3.0-rc.1"), meta("0.3.0"), meta("0.3.0-rc.2")];
+    assert_eq!(pick_newest(&rels).unwrap().version, "0.3.0");
+}
+
+#[test]
+fn pick_newest_can_return_a_stable_release_on_the_prerelease_channel() {
+    // "Prerelease" means "offer me prereleases as well", never "only
+    // prereleases": the newest thing published wins whatever it is flagged.
+    let rels = vec![meta("0.3.0-rc.1"), meta("0.4.0")];
+    let newest = pick_newest(&rels).unwrap();
+    assert_eq!(newest.version, "0.4.0");
+    assert!(!newest.prerelease);
+}
+
+#[test]
+fn pick_newest_skips_unparseable_tags() {
+    let rels = vec![meta("nightly"), meta("0.2.0"), meta("v")];
+    assert_eq!(pick_newest(&rels).unwrap().version, "0.2.0");
+}
+
+#[test]
+fn pick_newest_is_none_when_nothing_is_comparable() {
+    assert!(pick_newest(&[]).is_none());
+    assert!(pick_newest(&[meta("nightly")]).is_none());
+}
+
+#[test]
+fn parse_release_reads_the_prerelease_flag() {
+    // A release flagged prerelease can still carry a plain tag; the flag is
+    // what the panel labels, so it must survive parsing rather than being
+    // re-derived from the version string.
+    let json = r#"{"tag_name":"v0.3.0","prerelease":true,"draft":false}"#;
+    assert!(parse_release(json).unwrap().prerelease);
+    // Absent means false — /releases/latest omits nothing, but be explicit.
+    let json = r#"{"tag_name":"v0.3.0"}"#;
+    assert!(!parse_release(json).unwrap().prerelease);
+}
+
+#[test]
+fn discover_carries_the_prerelease_flag_to_the_frontend() {
+    let mut rc = meta("0.3.0-rc.1");
+    rc.prerelease = true;
+    let info = discover("0.2.0", || Ok(rc)).unwrap();
+    assert!(info.available);
+    assert!(info.prerelease, "the panel needs to be able to say so");
+
+    // ...and a dev build reports the flag false rather than leaving it stale.
+    let info = discover("0.0.0", || unreachable!()).unwrap();
+    assert!(!info.prerelease);
+}
+
+#[test]
+fn the_default_channel_is_stable() {
+    // The conservative default matters: it is what an absent `channel` argument
+    // resolves to in `check_for_update`, so a caller that forgets cannot
+    // silently put a user on prereleases.
+    assert_eq!(UpdateChannel::default(), UpdateChannel::Stable);
+}
+
+#[test]
+fn the_channel_serialises_as_the_frontend_spells_it() {
+    // 1:1 with the TS `UpdateChannel` union in src/lib/types.ts.
+    assert_eq!(
+        serde_json::to_string(&UpdateChannel::Stable).unwrap(),
+        "\"stable\""
+    );
+    assert_eq!(
+        serde_json::to_string(&UpdateChannel::Prerelease).unwrap(),
+        "\"prerelease\""
+    );
+    assert_eq!(
+        serde_json::from_str::<UpdateChannel>("\"prerelease\"").unwrap(),
+        UpdateChannel::Prerelease
     );
 }

--- a/src/features/settings/useSettingsStore.export.test.ts
+++ b/src/features/settings/useSettingsStore.export.test.ts
@@ -82,6 +82,10 @@ const PORTABLE = [
   "themePreference",
   "uiDensity",
   "uiZoom",
+  // The release channel (#237). Portable: "we track the prereleases" is a
+  // team decision, not a fact about one machine — the same call
+  // `updateCheckMode` beside it made.
+  "updateChannel",
   "updateCheckMode",
 ];
 

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import type { PullMode } from "@/lib/tauri";
+import type { UpdateChannel } from "@/lib/types";
 import {
   DEFAULT_HEAD_WEIGHT,
   HEAD_WEIGHTS,
@@ -765,6 +766,15 @@ export const UPDATE_CHECK_MODES: readonly UpdateCheckMode[] = [
   "never",
 ];
 
+/**
+ * Re-exported so the Settings screen imports its preference types from one
+ * place; the definition lives in `@/lib/types` with the other Rust mirrors,
+ * because the backend is what has to agree with it.
+ */
+export type { UpdateChannel };
+
+export const UPDATE_CHANNELS: readonly UpdateChannel[] = ["stable", "prerelease"];
+
 // ═════════════════════════════════════════════════════════════════════════════
 // STORE
 // ═════════════════════════════════════════════════════════════════════════════
@@ -870,6 +880,19 @@ interface PersistedState {
    * store's own localStorage key.
    */
   updateCheckMode: UpdateCheckMode;
+  /**
+   * Which releases update checks consider — see UpdateChannel.
+   *
+   * A preference rather than machine state, so it belongs in the portable bag
+   * and travels with an export: "this team tests the prereleases" is exactly
+   * the kind of thing a shared settings file should carry.
+   *
+   * Switching back to `"stable"` while running a prerelease does NOT offer a
+   * downgrade. The stable release is older, `compute_available` says no, and
+   * the panel says up to date — which is honest: the app cannot un-install a
+   * version, and pretending otherwise would produce a prompt that fails.
+   */
+  updateChannel: UpdateChannel;
   /** Parent directory last used for Clone/Init, prefilled next time. */
   lastCreateDir: string;
 }
@@ -957,6 +980,7 @@ const DEFAULTS: PersistedState = {
   ignoreWhitespaceInDiff: false,
   externalDiffTool: "",
   updateCheckMode: "auto",
+  updateChannel: "stable",
   lastCreateDir: "",
 };
 

--- a/src/features/update/UpdatePanel.test.tsx
+++ b/src/features/update/UpdatePanel.test.tsx
@@ -24,6 +24,7 @@ const INFO: UpdateInfo = {
   notes: "rebase fixes",
   releaseUrl: "https://github.com/jonassaa/platypusgit/releases/tag/v0.1.0",
   publishedAt: "2026-07-08T10:00:00Z",
+  prerelease: false,
 };
 
 function seed(partial: Partial<ReturnType<typeof useUpdateStore.getState>>) {

--- a/src/features/update/UpdatePanel.tsx
+++ b/src/features/update/UpdatePanel.tsx
@@ -74,6 +74,26 @@ export function UpdatePanel() {
       >
         <span style={{ fontWeight: 600, color: "var(--fg-0)" }}>
           Update available — {info.latestVersion}
+          {/*
+            Only reachable from the prerelease channel, and worth saying out
+            loud there: the whole reason to name it is that the user opted into
+            being offered something not yet shipped to everyone, and the
+            version string alone does not always show it (a release flagged
+            prerelease can carry a plain tag).
+          */}
+          {info.prerelease && (
+            <span
+              data-testid="update-prerelease-badge"
+              style={{
+                marginLeft: 6,
+                fontWeight: 500,
+                fontSize: "var(--fs-10)",
+                color: "var(--fg-2)",
+              }}
+            >
+              prerelease
+            </span>
+          )}
         </span>
         <PGIconButton
           icon="x"

--- a/src/features/update/updateChannel.test.ts
+++ b/src/features/update/updateChannel.test.ts
@@ -1,0 +1,129 @@
+// The release-channel preference (#237).
+//
+// The gate in `updateCheckMode.test.ts` asserts a check does not HAPPEN; this
+// file asserts what a check that does happen ASKS FOR. Those are different
+// failures with the same symptom on screen ("no update offered"), so they get
+// separate files rather than one that would pass while the store quietly asked
+// the wrong endpoint.
+//
+// `@/lib/tauri` is mocked for the same reason it is there: the assertion is on
+// the ARGUMENT handed across the IPC boundary, which is the only place the
+// channel is expressed. A store that read the preference and then dropped it
+// would satisfy any status-only assertion.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { UpdateInfo } from "@/lib/types";
+
+const tauri = vi.hoisted(() => ({
+  checkForUpdate: vi.fn(),
+  getUpdateCapability: vi.fn(),
+  openUrl: vi.fn(),
+}));
+vi.mock("@/lib/tauri", () => tauri);
+
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { useUpdateStore } from "./useUpdateStore";
+
+const AVAILABLE: UpdateInfo = {
+  available: true,
+  currentVersion: "0.2.0",
+  latestVersion: "0.3.0",
+  notes: "notes",
+  releaseUrl: "https://github.com/jonassaa/platypusgit/releases/tag/v0.3.0",
+  publishedAt: "2026-08-30T10:00:00Z",
+  prerelease: false,
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  tauri.checkForUpdate.mockReset().mockResolvedValue(AVAILABLE);
+  tauri.getUpdateCapability.mockReset().mockResolvedValue("notify");
+  tauri.openUrl.mockReset().mockResolvedValue(undefined);
+  useSettingsStore.getState().set("updateCheckMode", "auto");
+  useSettingsStore.getState().set("updateChannel", "stable");
+  useUpdateStore.setState({
+    status: "idle",
+    info: null,
+    capability: null,
+    dismissedVersion: null,
+    currentVersion: null,
+    lastCheckedAt: null,
+    installing: false,
+    progress: null,
+    error: null,
+    message: null,
+    panelOpen: false,
+  });
+});
+
+describe("the channel preference reaches the backend", () => {
+  it("defaults to stable", () => {
+    // The conservative default is load-bearing: nobody is put on prereleases by
+    // upgrading into a build that has this feature.
+    expect(useSettingsStore.getState().updateChannel).toBe("stable");
+  });
+
+  it("sends 'stable' on a stable-channel check", async () => {
+    await useUpdateStore.getState().check(true);
+    expect(tauri.checkForUpdate).toHaveBeenCalledWith("stable");
+  });
+
+  it("sends 'prerelease' once the preference is switched", async () => {
+    useSettingsStore.getState().set("updateChannel", "prerelease");
+    await useUpdateStore.getState().check(true);
+    expect(tauri.checkForUpdate).toHaveBeenCalledWith("prerelease");
+  });
+
+  it("sends the channel on an automatic check too, not just a manual one", async () => {
+    // Both initiatives read the same preference. A manual-only wiring would
+    // leave the startup check silently on stable for a prerelease user, which
+    // is the check that actually runs for most people most of the time.
+    useSettingsStore.getState().set("updateChannel", "prerelease");
+    await useUpdateStore.getState().check(false);
+    expect(tauri.checkForUpdate).toHaveBeenCalledWith("prerelease");
+  });
+
+  it("persists the choice", () => {
+    useSettingsStore.getState().set("updateChannel", "prerelease");
+    const raw = JSON.parse(
+      localStorage.getItem(
+        Object.keys(localStorage).find((k) => k.startsWith("pg-settings")) ?? "",
+      ) ?? "{}",
+    );
+    expect(raw.updateChannel).toBe("prerelease");
+  });
+
+  it("makes no request at all when checks are off, whatever the channel", async () => {
+    // The channel must not become a second way in. `never` outranks it.
+    useSettingsStore.getState().set("updateChannel", "prerelease");
+    useSettingsStore.getState().set("updateCheckMode", "never");
+    await useUpdateStore.getState().check(true);
+    expect(tauri.checkForUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("what the panel is told about a prerelease", () => {
+  it("carries the backend's prerelease flag into store state", async () => {
+    tauri.checkForUpdate.mockResolvedValue({
+      ...AVAILABLE,
+      latestVersion: "0.4.0-rc.1",
+      prerelease: true,
+    });
+    useSettingsStore.getState().set("updateChannel", "prerelease");
+    await useUpdateStore.getState().check(true);
+    expect(useUpdateStore.getState().info?.prerelease).toBe(true);
+  });
+
+  it("does not infer 'prerelease' from the version string", async () => {
+    // A release flagged prerelease on GitHub can carry a plain tag, and a
+    // `-rc` tag can be published as a full release. The flag is the answer;
+    // deriving it here would let the label contradict the backend.
+    tauri.checkForUpdate.mockResolvedValue({
+      ...AVAILABLE,
+      latestVersion: "0.4.0-rc.1",
+      prerelease: false,
+    });
+    await useUpdateStore.getState().check(true);
+    expect(useUpdateStore.getState().info?.prerelease).toBe(false);
+  });
+});

--- a/src/features/update/updateCheckMode.test.ts
+++ b/src/features/update/updateCheckMode.test.ts
@@ -31,6 +31,7 @@ const AVAILABLE: UpdateInfo = {
   notes: "rebase fixes",
   releaseUrl: "https://github.com/jonassaa/platypusgit/releases/tag/v0.1.0",
   publishedAt: "2026-07-08T10:00:00Z",
+  prerelease: false,
 };
 
 beforeEach(() => {

--- a/src/features/update/useUpdateStore.test.ts
+++ b/src/features/update/useUpdateStore.test.ts
@@ -18,6 +18,7 @@ const AVAILABLE: UpdateInfo = {
   notes: "rebase fixes",
   releaseUrl: "https://github.com/jonassaa/platypusgit/releases/tag/v0.1.0",
   publishedAt: "2026-07-08T10:00:00Z",
+  prerelease: false,
 };
 
 function reset() {

--- a/src/features/update/useUpdateStore.ts
+++ b/src/features/update/useUpdateStore.ts
@@ -132,7 +132,8 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
     // remembering at each one, and the one that forgets spends a request the
     // user switched off. Silent rather than an error: a check the user disabled
     // is not a failure, and the Settings panel already says checks are off.
-    if (!checkAllowed(useSettingsStore.getState().updateCheckMode, manual)) {
+    const settings = useSettingsStore.getState();
+    if (!checkAllowed(settings.updateCheckMode, manual)) {
       set({ status: "idle" });
       return;
     }
@@ -143,7 +144,9 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
       if (!capability) {
         capability = await getUpdateCapability();
       }
-      const info = await checkForUpdate();
+      // Read from the same snapshot the gate used, so a channel switch
+      // mid-check cannot produce a result attributed to the other channel.
+      const info = await checkForUpdate(settings.updateChannel);
       const lastCheckedAt = Date.now();
       try {
         localStorage.setItem(LAST_CHECKED_KEY, String(lastCheckedAt));

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -59,6 +59,7 @@ import type {
   SubmoduleInfo,
   TagInfo,
   UpdateCapability,
+  UpdateChannel,
   UpdateInfo,
   WorkdirDiff,
   WorktreeBranch,
@@ -1361,8 +1362,8 @@ export async function revealLogFile(): Promise<void> {
   return invoke<void>("reveal_log_file");
 }
 
-export function checkForUpdate(): Promise<UpdateInfo> {
-  return invoke<UpdateInfo>("check_for_update");
+export function checkForUpdate(channel: UpdateChannel): Promise<UpdateInfo> {
+  return invoke<UpdateInfo>("check_for_update", { channel });
 }
 
 export function getUpdateCapability(): Promise<UpdateCapability> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -619,6 +619,19 @@ export interface CliInstallOutcome {
   pathState: CliPathState;
 }
 
+/**
+ * Which releases update checks consider (#237). Mirrors Rust `UpdateChannel`
+ * (update.rs) 1:1.
+ *
+ * `"prerelease"` means "offer me prereleases AS WELL", not "only prereleases":
+ * the backend takes the semver-highest of everything published, so someone on
+ * this channel still gets a stable release when that is the newest thing there
+ * is. The two channels are different ENDPOINTS, not one endpoint plus a filter —
+ * `/releases/latest` is GitHub's own answer to "what is current", and
+ * re-deriving it by filtering the list would mean re-implementing `make_latest`.
+ */
+export type UpdateChannel = "stable" | "prerelease";
+
 export interface UpdateInfo {
   available: boolean;
   currentVersion: string;
@@ -626,6 +639,14 @@ export interface UpdateInfo {
   notes: string;
   releaseUrl: string;
   publishedAt: string;
+  /**
+   * Whether the offered release is flagged prerelease on GitHub (#237).
+   *
+   * GitHub's flag, not something derived from `latestVersion`: the two can
+   * disagree in both directions, and the label has to agree with the channel
+   * that found the release rather than with the shape of its tag.
+   */
+  prerelease: boolean;
 }
 
 /**

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -23,6 +23,7 @@ import {
   type ThemeColors,
   type ThemeDef,
   type ThemeFollowMode,
+  type UpdateChannel,
   type UpdateCheckMode,
 } from "@/features/settings/useSettingsStore";
 import {
@@ -753,6 +754,37 @@ function UpdatesSection() {
                 { value: "auto", label: "Automatically" },
                 { value: "manual", label: "Only when I ask" },
                 { value: "never", label: "Never" },
+              ]}
+            />
+          }
+        />
+        <Row
+          label="Release channel"
+          hint={
+            <>
+              <strong>Stable</strong> offers published releases only.{" "}
+              <strong>Include prereleases</strong> also offers release
+              candidates — newer, and not yet shipped to everyone. It adds
+              prereleases to what you are offered rather than restricting you to
+              them, so a stable release still wins whenever it is the newest
+              thing published. Switching back to Stable does not downgrade an
+              install; it just stops offering the next candidate.
+              {/*
+                Left enabled when checks are off. The preference is still real —
+                it persists and travels in a settings export — and a control
+                that appeared and disappeared as the row above changed would be
+                worse than one that is simply not consulted right now.
+              */}
+            </>
+          }
+          control={
+            <PGSelect
+              data-testid="update-channel"
+              value={settings.updateChannel}
+              onChange={(v) => settings.set("updateChannel", v as UpdateChannel)}
+              options={[
+                { value: "stable", label: "Stable" },
+                { value: "prerelease", label: "Include prereleases" },
               ]}
             />
           }


### PR DESCRIPTION
Closes #237.

The rest of #237 shipped in #283 — check mode (automatically / only when I ask / never), the manual check button, the current-version and last-checked readout. The one bullet left was the channel, and without it there was no way to be offered a release candidate at all: discovery only ever asked `GET /releases/latest`, which by definition never returns a prerelease.

## What this adds

`updateChannel` in `PersistedState`, default `"stable"`, sent with every check — automatic and manual alike. Settings gets a **Release channel** row next to the check mode; the update panel badges an offered prerelease.

## Two endpoints, not one endpoint plus a filter

This is the design decision worth reviewing:

- **`stable` → `GET /releases/latest`** (unchanged). It is GitHub's own answer to "what is the current release": prereleases and drafts are excluded server-side and `make_latest` is honoured. Re-deriving that by filtering the full list would mean re-implementing a rule GitHub already applies, in exactly the area where the release process already has traps — clearing `prerelease` does *not* move `releases/latest`.
- **`prerelease` → `GET /releases?per_page=30`, then `pick_newest`**, which takes the **semver-highest** entry rather than the first. GitHub orders that list by creation date, so list order is wrong whenever a patch on an older line is published after a newer candidate. Precedence is also what makes `0.3.0` correctly beat its own `0.3.0-rc.2`. One page suffices because the list is newest-first by date.

`prerelease` means *offer me prereleases as well*, never *only prereleases*: a stable release still wins whenever it is the newest thing published, and there is a test for exactly that.

## Behaviour worth knowing

- **Switching back to `stable` does not downgrade.** The stable release is older than the running prerelease, `compute_available` says no, the panel says up to date. Honest — the app cannot un-install a version, and a downgrade prompt would fail at install.
- **`UpdateInfo.prerelease` is GitHub's flag, not a re-parse of the tag.** The two disagree in both directions: a `-rc.1` tag can be published as a full release, and a plain `v0.3.0` tag can be flagged prerelease. The badge reads the flag, so it cannot contradict the channel that found the release.
- **The check-mode gate still outranks the channel.** `never` makes no request whatever the channel says; pinned by a test, because the channel must not become a second way onto the network.
- **The channel is portable** and travels in a #254 settings export — "this team tracks the prereleases" is a team decision, not a machine fact. Same call `updateCheckMode` made.
- Drafts are dropped in `parse_releases` rather than relied on being absent, and a single malformed release entry is skipped rather than failing the whole check — one odd payload must not turn the updater off for everyone on the channel.

## Privacy

No new host: `api.github.com` was already on the allow-list, so `test/privacy.test.ts` and `no_telemetry.rs` are untouched. Dev/e2e builds (`0.0.0`) still short-circuit before the fetch, so no request leaves `pnpm tauri dev` or an e2e run on either channel.

## Tests

- `src-tauri/tests/update.rs` — 14 new: list parsing, draft dropping, malformed-entry skipping, non-array bodies, precedence vs list order, stable-wins-on-prerelease-channel, unparseable tags, flag round-tripping, the serde spelling matching the TS union.
- `src/features/update/updateChannel.test.ts` — new: the channel actually reaches the IPC boundary on both initiatives, `never` still makes no call, the flag is not inferred from the version string.
- Full suites green: `cargo test` and `pnpm test` (2745 passed), `pnpm tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
