### PR TITLE
feat(commit): per-repository identity, and say who you are committing as (#233)

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -248,10 +248,18 @@ git/
                  error code, because a MISSING user.name is NotFound while a
                  BLANK one is a generic error whose only mark is the prose
                  "failed to parse signature"), read_identity / global_config_
-                 path / validate_identity / set_global_identity (#212 — the
-                 write side, GLOBAL only; validate_identity is the ONE rule
-                 both the writer and default_signature use, so "what we save"
-                 and "what we call missing" cannot drift), and apply_signoff
+                 path / local_config_path / validate_identity /
+                 set_global_identity / set_local_identity (#212, #233 — the
+                 write side, at BOTH scopes. IdentityWriteScope is deliberately
+                 not IdentityScope: the latter has a System member because a
+                 value can be READ from /etc/gitconfig, but writing there needs
+                 root and would change every user on the machine, so two enums
+                 keep that unreachable rather than merely unhandled.
+                 local_config_path uses commondir(), not path(): they differ in
+                 a linked worktree, where --local writes the SHARED config.
+                 validate_identity is the ONE rule both writers and
+                 default_signature use, so "what we save" and "what we call
+                 missing" cannot drift), and apply_signoff
                  (Signed-off-by trailer, idempotent)
 commands/        Thin Tauri handlers, one file per area:
 ├── repo.rs      open_repo, close_repo, trust_repo_path, get_status, head_info
@@ -296,15 +304,18 @@ commands/        Thin Tauri handlers, one file per area:
 │                comment prefix; a configured template that cannot be read
 │                comes back FLAGGED, never as an error, so a stale config line
 │                cannot stop the commit screen opening).
-│                get_identity / set_identity (#212 — the committer identity.
-│                get_identity's repoId is OPTIONAL, because Settings is
-│                reachable before a repo is open and the global chain is the
-│                real answer there; it reports each half's SCOPE so the UI can
-│                say why a global save changed nothing in a repo that overrides
-│                it. set_identity is the only write in the app that touches the
-│                user's own global git config, and it validates before opening
-│                anything, so a refused value creates no file. See
-│                git/signature.rs)
+│                get_identity / set_identity (#212, #233 — the committer
+│                identity. get_identity's repoId is OPTIONAL, because Settings
+│                is reachable before a repo is open and the global chain is the
+│                real answer there; it reports each half's SCOPE, and both
+│                config paths, so the UI can name the file a save will write.
+│                set_identity is the only write in the app that touches the
+│                user's own git config; its `scope` is REQUIRED with no default
+│                — "which config did that change?" is the question #233 exists
+│                to stop people asking — and `repository` without a repoId is
+│                REFUSED rather than falling back to global. It validates
+│                before opening anything, so a refused value creates no file.
+│                See git/signature.rs)
 │                REFSPEC_ALL sentinel = walk all refs, so
 │                the loaded log is NOT HEAD ancestry — rebase input must go
 │                through headAncestryOf. Paged (see frontend.md): get_log_page /

--- a/src-tauri/src/commands/commits.rs
+++ b/src-tauri/src/commands/commits.rs
@@ -205,21 +205,29 @@ pub async fn get_identity(
         .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
-/// Write `user.name` / `user.email` to the global git config (#212).
+/// Write `user.name` / `user.email` at `scope` — this repository or global
+/// (#212, #233).
 ///
 /// The remedy for `NoSignature`, and the only write in the app that touches the
-/// user's global git config — which is why it is deliberately explicit rather
-/// than something a commit does for you behind your back.
+/// user's git config — which is why it is deliberately explicit rather than
+/// something a commit does for you behind your back, and why the SCOPE is a
+/// required argument rather than a default. "Which config did that change?" is
+/// the question this whole feature exists to stop people having to ask.
 #[tauri::command]
 pub async fn set_identity(
     state: State<'_, AppState>,
+    repo_id: Option<String>,
+    scope: crate::git::signature::IdentityWriteScope,
     name: String,
     email: String,
 ) -> AppResult<()> {
     let backend = state.backend.clone();
-    tokio::task::spawn_blocking(move || backend.set_global_identity(&name, &email))
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+    let repo_id = repo_id.map(RepoId);
+    tokio::task::spawn_blocking(move || {
+        backend.set_identity(repo_id.as_ref(), scope, &name, &email)
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
 /// Signature status of one commit (#61 D6). Called lazily for the selected

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -271,7 +271,13 @@ impl GitBackend for CliBackend {
         Err(AppError::NotImplemented)
     }
 
-    fn set_global_identity(&self, _name: &str, _email: &str) -> AppResult<()> {
+    fn set_identity(
+        &self,
+        _repo_id: Option<&RepoId>,
+        _scope: super::signature::IdentityWriteScope,
+        _name: &str,
+        _email: &str,
+    ) -> AppResult<()> {
         Err(AppError::NotImplemented)
     }
     fn branches(&self, _repo_id: &RepoId) -> AppResult<Vec<BranchInfo>> {

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -4501,8 +4501,27 @@ impl GitBackend for Libgit2Backend {
         }
     }
 
-    fn set_global_identity(&self, name: &str, email: &str) -> AppResult<()> {
-        crate::git::signature::set_global_identity(name, email)
+    fn set_identity(
+        &self,
+        repo_id: Option<&RepoId>,
+        scope: crate::git::signature::IdentityWriteScope,
+        name: &str,
+        email: &str,
+    ) -> AppResult<()> {
+        use crate::git::signature::IdentityWriteScope;
+        match scope {
+            IdentityWriteScope::Global => crate::git::signature::set_global_identity(name, email),
+            IdentityWriteScope::Repository => {
+                let repo_id = repo_id.ok_or_else(|| {
+                    AppError::InvalidArgument(
+                        "saving to this repository needs a repository to be open".to_string(),
+                    )
+                })?;
+                self.with_repo(repo_id, |repo| {
+                    crate::git::signature::set_local_identity(repo, name, email)
+                })
+            }
+        }
     }
 
     fn branches(&self, repo_id: &RepoId) -> AppResult<Vec<BranchInfo>> {

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -543,13 +543,21 @@ pub trait GitBackend: Send + Sync {
     /// global + system chain IS the effective identity.
     fn identity(&self, repo_id: Option<&RepoId>) -> AppResult<signature::GitIdentity>;
 
-    /// Write `user.name` / `user.email` to the global git config, creating the
-    /// file when there is none (#212).
+    /// Write `user.name` / `user.email` at `scope` (#212, #233).
     ///
-    /// Takes no `repo_id`: the state this exists to fix is a machine with no
-    /// identity at all, so the fix has to outlive the repository the user
-    /// happened to be in. Per-repository identities are #233.
-    fn set_global_identity(&self, name: &str, email: &str) -> AppResult<()>;
+    /// `Global` creates the file when there is none — the state #212 exists to
+    /// fix is a machine with no identity at all, so that fix has to outlive the
+    /// repository the user happens to have open. `Repository` needs a
+    /// `repo_id`, and is refused without one rather than silently falling back
+    /// to global: a save the user scoped to one repository must never quietly
+    /// change every other one.
+    fn set_identity(
+        &self,
+        repo_id: Option<&RepoId>,
+        scope: signature::IdentityWriteScope,
+        name: &str,
+        email: &str,
+    ) -> AppResult<()>;
 
     // === refs ===
     fn checkout_branch(&self, repo_id: &RepoId, name: &str) -> AppResult<()>;

--- a/src-tauri/src/git/signature.rs
+++ b/src-tauri/src/git/signature.rs
@@ -22,6 +22,23 @@ pub enum IdentityScope {
     System,
 }
 
+/// Where a write goes (#233).
+///
+/// Deliberately NOT `IdentityScope`. That type has a `System` variant, because
+/// a value can be READ from `/etc/gitconfig` — but writing there needs root and
+/// would change the identity of every user on the machine, which is never what
+/// someone fixing their own commits is asking for. Keeping the two enums apart
+/// makes "you cannot save to system" a fact the type system enforces rather
+/// than a runtime check someone can forget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum IdentityWriteScope {
+    /// This repository's `.git/config` — `git config --local`.
+    Repository,
+    /// `~/.gitconfig` — `git config --global`.
+    Global,
+}
+
 /// One configured value plus where it came from.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -48,6 +65,14 @@ pub struct GitIdentity {
     /// The file [`set_global_identity`] would write to, so the UI can name it
     /// before anything changes. `None` only when no home directory resolves.
     pub global_config_path: Option<String>,
+    /// The file [`set_local_identity`] would write to (#233). `None` when the
+    /// identity was read without a repository — the Settings screen with
+    /// nothing open, where "this repository" is not an option to offer.
+    ///
+    /// Named for the same reason the global one is: a save that writes to the
+    /// user's own git config, outside the app's settings, should say which file
+    /// it is about to touch.
+    pub local_config_path: Option<String>,
 }
 
 impl GitIdentity {
@@ -100,6 +125,7 @@ pub fn read_identity(repo: Option<&Repository>) -> AppResult<GitIdentity> {
         global_config_path: global_config_path()
             .ok()
             .map(|p| p.to_string_lossy().to_string()),
+        local_config_path: repo.map(|r| local_config_path(r).to_string_lossy().to_string()),
     })
 }
 
@@ -121,6 +147,41 @@ pub fn global_config_path() -> AppResult<PathBuf> {
         .ok_or_else(|| {
             AppError::Io("no home directory to write a global git config into".to_string())
         })
+}
+
+/// The file `git config --local` would write to.
+///
+/// `commondir()`, not `path()`. They differ in a linked worktree: `path()` is
+/// that worktree's own gitdir (`.git/worktrees/<name>`), while `--local` writes
+/// to the SHARED config in the common directory — so `path()` would name a file
+/// git never writes and the UI would promise the wrong thing. In an ordinary
+/// repository the two are the same directory, which is why the difference is
+/// easy to miss.
+pub fn local_config_path(repo: &Repository) -> PathBuf {
+    repo.commondir().join("config")
+}
+
+/// Write `user.name` / `user.email` to this repository's own config (#233).
+///
+/// The counterpart to [`set_global_identity`], and the reason #233 exists: a
+/// work identity and a personal one on the same machine differ per repository,
+/// and the cost of getting it wrong — a corporate address on a public commit —
+/// is not fixable after the push.
+///
+/// Validated BEFORE the config is opened, the same rule the global writer
+/// follows: a refused value must leave nothing behind.
+pub fn set_local_identity(repo: &Repository, name: &str, email: &str) -> AppResult<()> {
+    let (name, email) = validate_identity(name, email)?;
+    // `repo.config()` is the whole chain, and `set_str` on it writes to the
+    // highest-priority writable level — which IS local today. Opening the level
+    // explicitly says so at the call site instead of relying on that, so a
+    // future libgit2 that resolves it differently fails loudly here rather than
+    // quietly writing the user's global config from a button labelled "this
+    // repository".
+    let mut cfg = repo.config()?.open_level(git2::ConfigLevel::Local)?;
+    cfg.set_str("user.name", &name)?;
+    cfg.set_str("user.email", &email)?;
+    Ok(())
 }
 
 /// A `user.name` / `user.email` a user typed, trimmed — or the reason git would
@@ -363,6 +424,7 @@ mod identity_tests {
             name,
             email,
             global_config_path: None,
+            local_config_path: None,
         };
         assert!(id(value("Ada"), value("ada@example.com")).usable());
         assert!(!id(None, value("ada@example.com")).usable());

--- a/src-tauri/tests/identity.rs
+++ b/src-tauri/tests/identity.rs
@@ -1,4 +1,5 @@
-//! The committer identity on a machine that has none (#212).
+//! The committer identity: a machine that has none (#212), and choosing
+//! which config a fix is written to (#233).
 //!
 //! Every other test in this suite gets a repo-local `user.name` / `user.email`
 //! from `support::TempRepo::fresh` — deliberately, "so commit() works without
@@ -20,7 +21,7 @@ use git2::ConfigLevel;
 use platypusgit_lib::{
     error::AppError,
     git::{
-        signature::{IdentityScope, GitIdentity},
+        signature::{local_config_path, GitIdentity, IdentityScope, IdentityWriteScope},
         types::CommitOptions,
         GitBackend,
     },
@@ -131,7 +132,7 @@ fn a_machine_with_no_identity_can_be_told_who_it_is() {
         ("Ada\nLovelace", "ada@example.com"),
     ] {
         let err = backend
-            .set_global_identity(name, email)
+            .set_identity(None, IdentityWriteScope::Global, name, email)
             .expect_err("expected a refusal");
         assert!(
             matches!(err, AppError::InvalidArgument(_)),
@@ -147,7 +148,12 @@ fn a_machine_with_no_identity_can_be_told_who_it_is() {
     // attributed to what was typed. Surrounding whitespace is trimmed, the way
     // git trims it.
     backend
-        .set_global_identity("  Ada Lovelace  ", " ada@example.com ")
+        .set_identity(
+            None,
+            IdentityWriteScope::Global,
+            "  Ada Lovelace  ",
+            " ada@example.com ",
+        )
         .expect("set identity");
     assert!(
         global_path.exists(),
@@ -186,7 +192,12 @@ fn a_machine_with_no_identity_can_be_told_who_it_is() {
     // append-only writer would look correct here and diverge the moment
     // anything read the file with `--get`.
     backend
-        .set_global_identity("Grace Hopper", "grace@example.com")
+        .set_identity(
+            None,
+            IdentityWriteScope::Global,
+            "Grace Hopper",
+            "grace@example.com",
+        )
         .expect("rewrite identity");
     let text = std::fs::read_to_string(&global_path).unwrap();
     assert_eq!(
@@ -248,4 +259,137 @@ fn a_machine_with_no_identity_can_be_told_who_it_is() {
     let identity = backend.identity(Some(&handle.id)).expect("identity");
     assert_eq!(value_of(&identity.email), Some("   "));
     assert!(!identity.usable(), "a blank email is not a usable identity");
+
+    // ════════════════════════════════════════════════════════════════════════
+    // Per-repository identity (#233)
+    // ════════════════════════════════════════════════════════════════════════
+
+    // --- 9. The repository's own config is named, so the UI can say which file
+    // "this repository" means before anything is written.
+    let repo = git2::Repository::open(tr.path()).unwrap();
+    let local_path = local_config_path(&repo);
+    assert_eq!(
+        identity.local_config_path.as_deref(),
+        Some(local_path.to_string_lossy().as_ref()),
+    );
+    assert!(local_path.exists(), "an open repository has a .git/config");
+
+    // ...and it is absent when there is no repository, because "this
+    // repository" is not a scope the UI may offer there.
+    let no_repo = backend.identity(None).expect("identity with no repo");
+    assert_eq!(no_repo.local_config_path, None);
+
+    // --- 10. Saving at Repository scope writes the repository's config, wins
+    // over the global one, and leaves the global one alone. This is the whole
+    // feature: a work address on this repo, the personal one everywhere else.
+    let global_before = std::fs::read_to_string(&global_path).unwrap();
+    backend
+        .set_identity(
+            Some(&handle.id),
+            IdentityWriteScope::Repository,
+            "  Work Person  ",
+            " work@corp.example ",
+        )
+        .expect("set a repo-local identity");
+
+    let identity = backend.identity(Some(&handle.id)).expect("identity");
+    assert_eq!(value_of(&identity.name), Some("Work Person"));
+    assert_eq!(value_of(&identity.email), Some("work@corp.example"));
+    assert_eq!(scope_of(&identity.name), Some(IdentityScope::Repository));
+    assert_eq!(scope_of(&identity.email), Some(IdentityScope::Repository));
+    assert!(identity.usable(), "the blank email from step 8 is fixed");
+    assert_eq!(
+        std::fs::read_to_string(&global_path).unwrap(),
+        global_before,
+        "a repository-scoped save must not touch the global config"
+    );
+    // The global identity is still what a DIFFERENT repository would get.
+    let global_identity = backend.identity(None).expect("global identity");
+    assert_eq!(value_of(&global_identity.name), Some("Grace Hopper"));
+
+    // --- 11. A repo-local rewrite overwrites rather than appending, the same
+    // property step 5 pins for the global writer. A duplicated key is legal in
+    // a git config and the LAST one wins, so an append-only writer reads
+    // correct here and diverges the moment anything uses `--get`.
+    backend
+        .set_identity(
+            Some(&handle.id),
+            IdentityWriteScope::Repository,
+            "Work Person",
+            "second@corp.example",
+        )
+        .expect("rewrite the repo-local identity");
+    let text = std::fs::read_to_string(&local_path).unwrap();
+    assert_eq!(
+        text.matches("email").count(),
+        1,
+        "user.email should appear once in .git/config, not once per save:\n{text}"
+    );
+
+    // --- 12. The commit is attributed to the repository's identity, not the
+    // global one — the assertion the whole feature is for.
+    support::fs::write_file(tr.path(), "third.md", "more\n");
+    backend
+        .stage(&handle.id, &[PathBuf::from("third.md")])
+        .expect("stage");
+    let result = backend
+        .commit(
+            &handle.id,
+            CommitOptions {
+                message: "third".to_string(),
+                amend: false,
+                author_override: None,
+                signoff: false,
+                sign: None,
+                no_verify: false,
+            },
+        )
+        .expect("commit with a repo-local identity");
+    let repo = git2::Repository::open(tr.path()).unwrap();
+    let commit = repo
+        .find_commit(git2::Oid::from_str(&result.oid).unwrap())
+        .unwrap();
+    assert_eq!(commit.author().email().ok(), Some("second@corp.example"));
+    // The COMMITTER too, not just the author. `author_override` (#61 D1) only
+    // moves the author, which is exactly why it is not an identity feature.
+    assert_eq!(commit.committer().email().ok(), Some("second@corp.example"));
+
+    // --- 13. Repository scope with no repository is refused, not silently
+    // downgraded to global. Writing every repository's identity from a control
+    // labelled "this repository" is the one failure this feature must not have.
+    let err = backend
+        .set_identity(
+            None,
+            IdentityWriteScope::Repository,
+            "Nobody",
+            "nobody@example.com",
+        )
+        .expect_err("repository scope with no repository must be refused");
+    assert!(
+        matches!(err, AppError::InvalidArgument(_)),
+        "expected InvalidArgument, got {err:?}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&global_path).unwrap(),
+        global_before,
+        "the refused save must not have fallen back to the global config"
+    );
+
+    // --- 14. Validation runs before the repository config is opened, the same
+    // rule the global writer follows — a refused value changes nothing.
+    let before = std::fs::read_to_string(&local_path).unwrap();
+    let err = backend
+        .set_identity(
+            Some(&handle.id),
+            IdentityWriteScope::Repository,
+            "Ada <Lovelace>",
+            "ada@example.com",
+        )
+        .expect_err("an invalid identity must be refused at repository scope too");
+    assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+    assert_eq!(
+        std::fs::read_to_string(&local_path).unwrap(),
+        before,
+        "a refused identity must leave the repository config untouched"
+    );
 }

--- a/src/features/commits/identity/IdentityForm.scope.test.tsx
+++ b/src/features/commits/identity/IdentityForm.scope.test.tsx
@@ -1,0 +1,204 @@
+// The identity's SCOPE control (#233).
+//
+// #212 could only write the global config, which is the right fix for a fresh
+// machine and the wrong one for the case this file is about: a work identity
+// and a personal identity on the same machine. Getting that wrong puts a
+// corporate address on a public commit, and no amount of later editing takes it
+// back — so the tests here are mostly about the app never picking a config file
+// on the user's behalf.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { pgPickOption } from "@/test/select";
+import type { GitIdentity } from "@/lib/types";
+
+import { IdentityForm } from "./IdentityForm";
+
+const GLOBAL_PATH = "/home/ada/.gitconfig";
+const LOCAL_PATH = "/repo/.git/config";
+
+/** A repository is open: both scopes are real. */
+const withRepo = (over?: Partial<GitIdentity>): GitIdentity => ({
+  name: { value: "Ada Lovelace", scope: "global" },
+  email: { value: "ada@example.com", scope: "global" },
+  globalConfigPath: GLOBAL_PATH,
+  localConfigPath: LOCAL_PATH,
+  ...over,
+});
+
+/** Settings with nothing open: only global exists. */
+const noRepo = (): GitIdentity => ({
+  name: { value: "Ada Lovelace", scope: "global" },
+  email: { value: "ada@example.com", scope: "global" },
+  globalConfigPath: GLOBAL_PATH,
+  localConfigPath: null,
+});
+
+const saves = () => getInvokeCalls().filter((c) => c.cmd === "set_identity");
+
+/** PGSelect is an in-page listbox, not a native `<select>` — see @/test/select. */
+const pickScope = (value: string) =>
+  pgPickOption(screen.getByTestId("identity-scope"), value);
+
+function renderForm(identity: GitIdentity, repoId: string | null = "repo-1") {
+  mockInvoke("get_identity", () => identity);
+  mockInvoke("set_identity", () => null);
+  render(<IdentityForm repoId={repoId} />);
+  return waitFor(() => expect(screen.getByTestId("identity-form")).toBeTruthy());
+}
+
+beforeEach(() => {
+  resetInvokeMock();
+});
+
+describe("which scopes are offered", () => {
+  it("offers both when a repository is open", async () => {
+    await renderForm(withRepo());
+    await waitFor(() => expect(screen.getByTestId("identity-scope")).toBeTruthy());
+  });
+
+  it("offers no choice at all with no repository open", async () => {
+    // The backend refuses repository scope without a repo, so offering it here
+    // would be an option that cannot work. Settings before a repo is opened is
+    // exactly where a new user lands from Welcome.
+    await renderForm(noRepo(), null);
+    expect(screen.queryByTestId("identity-scope")).toBeNull();
+    await waitFor(() =>
+      expect(screen.getByTestId("identity-target").textContent).toContain(
+        GLOBAL_PATH,
+      ),
+    );
+  });
+});
+
+describe("the scope it opens on", () => {
+  it("defaults to global when the repository has no override", async () => {
+    // The overwhelmingly common case, and #212's fresh-machine case too.
+    await renderForm(withRepo());
+    await waitFor(() =>
+      expect(screen.getByTestId("identity-target").textContent).toContain(
+        GLOBAL_PATH,
+      ),
+    );
+  });
+
+  it("defaults to this repository when the repository already overrides", async () => {
+    // Someone with a repo-local identity is managing that repository's
+    // identity. Opening on "global" would invite them to edit the value that
+    // is being overridden — a save that appears to do nothing.
+    await renderForm(
+      withRepo({
+        name: { value: "Work Person", scope: "repository" },
+        email: { value: "work@corp.example", scope: "repository" },
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("identity-target").textContent).toContain(
+        LOCAL_PATH,
+      ),
+    );
+  });
+
+  it("defaults to this repository when only ONE half is overridden", async () => {
+    // A repo that sets only `user.email` is the common shape of exactly this
+    // feature's use case — the name is the same at work and at home.
+    await renderForm(
+      withRepo({ email: { value: "work@corp.example", scope: "repository" } }),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("identity-target").textContent).toContain(
+        LOCAL_PATH,
+      ),
+    );
+  });
+});
+
+describe("what a save sends", () => {
+  it("sends the repository scope and the repo id", async () => {
+    await renderForm(withRepo());
+    pickScope("repository");
+    fireEvent.change(screen.getByTestId("identity-name"), {
+      target: { value: "Work Person" },
+    });
+    fireEvent.change(screen.getByTestId("identity-email"), {
+      target: { value: "work@corp.example" },
+    });
+    fireEvent.click(screen.getByTestId("identity-save"));
+
+    await waitFor(() => expect(saves()).toHaveLength(1));
+    expect(saves()[0].args).toMatchObject({
+      scope: "repository",
+      repoId: "repo-1",
+      name: "Work Person",
+      email: "work@corp.example",
+    });
+  });
+
+  it("sends the global scope when that is what is selected", async () => {
+    await renderForm(withRepo());
+    fireEvent.click(screen.getByTestId("identity-save"));
+    await waitFor(() => expect(saves()).toHaveLength(1));
+    expect(saves()[0].args).toMatchObject({ scope: "global" });
+  });
+
+  it("always sends a scope — never leaves the backend to guess", async () => {
+    // The one property this whole feature rests on. A save with no scope would
+    // be the backend's default, decided somewhere the user cannot see.
+    await renderForm(noRepo(), null);
+    fireEvent.click(screen.getByTestId("identity-save"));
+    await waitFor(() => expect(saves()).toHaveLength(1));
+    expect(saves()[0].args.scope).toBe("global");
+  });
+});
+
+describe("the target file named beside the button", () => {
+  it("follows the scope, so the two can never disagree", async () => {
+    await renderForm(withRepo());
+    await waitFor(() =>
+      expect(screen.getByTestId("identity-target").textContent).toContain(
+        GLOBAL_PATH,
+      ),
+    );
+    pickScope("repository");
+    await waitFor(() =>
+      expect(screen.getByTestId("identity-target").textContent).toContain(
+        LOCAL_PATH,
+      ),
+    );
+  });
+});
+
+describe("the override warning", () => {
+  const overridden = () =>
+    withRepo({
+      name: { value: "Work Person", scope: "repository" },
+      email: { value: "work@corp.example", scope: "repository" },
+    });
+
+  it("is silent at repository scope, where there is nothing to warn about", async () => {
+    // Saving here writes exactly the value that wins. Warning anyway would
+    // train people to ignore the warning that matters.
+    await renderForm(overridden());
+    await waitFor(() =>
+      expect(screen.getByTestId("identity-target").textContent).toContain(
+        LOCAL_PATH,
+      ),
+    );
+    expect(screen.queryByTestId("identity-scope-note")).toBeNull();
+  });
+
+  it("appears on switching to global, and points at the other scope", async () => {
+    await renderForm(overridden());
+    pickScope("global");
+    await waitFor(() =>
+      expect(screen.getByTestId("identity-scope-note")).toBeTruthy(),
+    );
+    const note = screen.getByTestId("identity-scope-note").textContent ?? "";
+    expect(note).toContain("This repository sets its own");
+    expect(note).toContain("save to this repository instead");
+    // No issue numbers in prose a user reads.
+    expect(note).not.toMatch(/#\d+/);
+  });
+});

--- a/src/features/commits/identity/IdentityForm.tsx
+++ b/src/features/commits/identity/IdentityForm.tsx
@@ -11,18 +11,28 @@
 // would learn that a blank email is refused and the other would not. The
 // difference between them is framing, not behaviour, so it is a prop.
 //
-// Global, not per-repository, deliberately: the state being fixed is a machine
-// with no identity at all, and per-repository would ask the same question again
-// in every repository the user opens. Per-repository identities and multiple
-// accounts are #233; when that lands, this form grows a scope control rather
-// than a sibling.
+// It started global-only: the state #212 fixed is a machine with no identity at
+// all, where per-repository would ask the same question again in every
+// repository the user opens. #233 added the SCOPE control this file's earlier
+// note promised — a control, not a sibling form, so there is still exactly one
+// place that knows what git will accept.
+//
+// The scope is shown even when there is only one to pick, and named in the
+// button's own line, because "which config did that change?" is the question
+// the whole feature exists to stop people having to ask. A work identity
+// committed under a personal address — or worse, the reverse on a public
+// repository — is not fixable after the push.
 
 import * as React from "react";
 
-import { PGButton, PGIcon, PGInput } from "@/design";
+import { PGButton, PGIcon, PGInput, PGSelect } from "@/design";
 import { appErrorMessage } from "@/lib/errors";
 import { getIdentity, setIdentity } from "@/lib/tauri";
-import type { GitIdentity, IdentityScope } from "@/lib/types";
+import type {
+  GitIdentity,
+  IdentityScope,
+  IdentityWriteScope,
+} from "@/lib/types";
 
 /** Where a value came from, as a user reads it. */
 function scopeLabel(scope: IdentityScope): string {
@@ -37,23 +47,27 @@ function scopeLabel(scope: IdentityScope): string {
 }
 
 /**
- * The identity's current state as one line of prose, or null when there is
- * nothing worth saying.
+ * The warning that a global save will not do what the user expects, or null.
  *
- * A repo-local value is the one worth naming: saving here writes the GLOBAL
- * config, so a user whose repository overrides it would otherwise save, see no
- * change, and conclude the app is broken.
+ * Only for a GLOBAL save: a repository that overrides `user.email` wins, so a
+ * user who saves globally would otherwise see no change here and conclude the
+ * app is broken. Saving at repository scope writes exactly the value that
+ * wins, so there is nothing to warn about — and showing the warning there
+ * anyway would train people to ignore it.
  */
-function currentStateNote(identity: GitIdentity | null): string | null {
-  if (!identity) return null;
+function currentStateNote(
+  identity: GitIdentity | null,
+  scope: IdentityWriteScope,
+): string | null {
+  if (!identity || scope !== "global") return null;
   const overrides = [
     identity.name?.scope === "repository" ? "name" : null,
     identity.email?.scope === "repository" ? "email" : null,
   ].filter(Boolean) as string[];
   if (overrides.length === 0) return null;
-  // No issue number in prose a user reads — "#233" means nothing to them, and
-  // the sentence has to end with something they can act on instead.
-  return `This repository sets its own ${overrides.join(" and ")} in its .git/config, which wins over anything saved here. Saving will not change what this repository's commits are recorded as.`;
+  // No issue number in prose a user reads, and the sentence has to end with
+  // something they can act on — here, the scope control directly above it.
+  return `This repository sets its own ${overrides.join(" and ")} in its .git/config, which wins over anything saved globally. To change what this repository's commits are recorded as, save to this repository instead.`;
 }
 
 /**
@@ -79,6 +93,26 @@ function sourceNote(identity: GitIdentity): string | null {
   return `${half} read from ${scopeLabel(only.scope)}; the other is not set.`;
 }
 
+/**
+ * Which scope the form opens on.
+ *
+ * `"repository"` when this repository ALREADY overrides either half — someone
+ * who has a repo-local identity is managing that repository's identity, and
+ * opening on "global" would invite them to edit the value that is being
+ * overridden. Otherwise `"global"`, which is both #212's fresh-machine case and
+ * the right default for the great majority of repositories.
+ *
+ * A default, not a lock: the control is right there, and the button names the
+ * file either way.
+ */
+function defaultScope(identity: GitIdentity): IdentityWriteScope {
+  if (!identity.localConfigPath) return "global";
+  const overridden =
+    identity.name?.scope === "repository" ||
+    identity.email?.scope === "repository";
+  return overridden ? "repository" : "global";
+}
+
 export interface IdentityFormProps {
   /** Read the effective identity for this repository; omit for global only. */
   repoId?: string | null;
@@ -101,6 +135,7 @@ export function IdentityForm({
   const [identity, setLoaded] = React.useState<GitIdentity | null>(null);
   const [name, setName] = React.useState("");
   const [email, setEmail] = React.useState("");
+  const [scope, setScope] = React.useState<IdentityWriteScope>("global");
   const [saving, setSaving] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const [saved, setSaved] = React.useState(false);
@@ -116,6 +151,7 @@ export function IdentityForm({
         setLoaded(next);
         setName(next.name?.value ?? "");
         setEmail(next.email?.value ?? "");
+        setScope(defaultScope(next));
       } catch (e) {
         if (!alive) return;
         // Reading the config failed, which is not the same as having no
@@ -140,7 +176,7 @@ export function IdentityForm({
     setError(null);
     setSaved(false);
     try {
-      await setIdentity(name, email);
+      await setIdentity(name, email, scope, repoId ?? null);
       setSaved(true);
       // Re-read rather than assume: this is what proves the write landed where
       // the form said it would, and it picks up a repo-local override that is
@@ -159,8 +195,18 @@ export function IdentityForm({
     }
   }
 
-  const note = currentStateNote(identity);
-  const target = identity?.globalConfigPath;
+  const note = currentStateNote(identity, scope);
+  // Where THIS save lands, not where a save lands in general. Naming the file
+  // is the honest version of "Save": it is a write to the user's own git
+  // config, outside the app's settings.
+  const target =
+    scope === "repository"
+      ? identity?.localConfigPath
+      : identity?.globalConfigPath;
+  // "This repository" is offered only when there is one. Without a repo open
+  // the backend refuses the scope outright, so showing it would be an option
+  // that cannot work.
+  const canScopeToRepo = !!identity?.localConfigPath;
 
   return (
     <div
@@ -197,6 +243,28 @@ export function IdentityForm({
         </label>
       </div>
 
+      {/*
+        The scope, rendered whenever a repository is open — including when the
+        answer looks obvious. A save that silently picks a config file is the
+        failure this control exists to prevent, and the cost of showing it is
+        one row.
+      */}
+      {canScopeToRepo && (
+        <label style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ ...fieldLabel, marginBottom: 0 }}>Save to</span>
+          <PGSelect
+            value={scope}
+            onChange={(v) => setScope(v as IdentityWriteScope)}
+            size="sm"
+            data-testid="identity-scope"
+            options={[
+              { value: "repository", label: "This repository" },
+              { value: "global", label: "All repositories (global)" },
+            ]}
+          />
+        </label>
+      )}
+
       <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
         <PGButton
           size="sm"
@@ -208,7 +276,9 @@ export function IdentityForm({
           {saving ? "Saving…" : saveLabel}
         </PGButton>
         {/* Naming the file is the honest version of "Save": this is a write to
-            the user's own git config, outside the app's own settings. */}
+            the user's own git config, outside the app's own settings — and with
+            two scopes to choose between, the filename is what distinguishes
+            them concretely. */}
         {target && (
           <span
             style={{ fontSize: "var(--fs-11)", color: "var(--fg-3)" }}

--- a/src/features/commits/identity/useIdentity.test.ts
+++ b/src/features/commits/identity/useIdentity.test.ts
@@ -1,0 +1,92 @@
+// The byline's two pure helpers (#233).
+//
+// They exist to answer "who will this commit be attributed to, and which config
+// said so" — the question a user with a work address and a personal one cannot
+// answer by looking at the app, and gets wrong at a cost that survives the push.
+
+import { describe, expect, it } from "vitest";
+
+import type { GitIdentity } from "@/lib/types";
+import { identityLine, identityOrigin } from "./useIdentity";
+
+const identity = (
+  name: GitIdentity["name"],
+  email: GitIdentity["email"],
+): GitIdentity => ({
+  name,
+  email,
+  globalConfigPath: "/home/ada/.gitconfig",
+  localConfigPath: "/repo/.git/config",
+});
+
+const at = (value: string, scope: "repository" | "global" | "system") => ({
+  value,
+  scope,
+});
+
+describe("identityLine", () => {
+  it("renders the identity the way a commit records it", () => {
+    expect(
+      identityLine(
+        identity(at("Ada Lovelace", "global"), at("ada@example.com", "global")),
+      ),
+    ).toBe("Ada Lovelace <ada@example.com>");
+  });
+
+  it("is null when either half is missing", () => {
+    expect(identityLine(null)).toBeNull();
+    expect(
+      identityLine(identity(at("Ada", "global"), null)),
+    ).toBeNull();
+    expect(
+      identityLine(identity(null, at("ada@example.com", "global"))),
+    ).toBeNull();
+  });
+
+  it("treats a present-but-blank half as missing", () => {
+    // The state git refuses on. Rendering `Ada <>` would present a commit that
+    // is about to fail as one that is fine — the exact failure #212 removed
+    // from the error path, which must not come back on the display path.
+    expect(
+      identityLine(identity(at("Ada", "global"), at("   ", "global"))),
+    ).toBeNull();
+    expect(
+      identityLine(identity(at("", "global"), at("ada@example.com", "global"))),
+    ).toBeNull();
+  });
+
+  it("trims, so a config with a stray space reads cleanly", () => {
+    expect(
+      identityLine(
+        identity(at("  Ada  ", "global"), at(" ada@example.com ", "global")),
+      ),
+    ).toBe("Ada <ada@example.com>");
+  });
+});
+
+describe("identityOrigin", () => {
+  it("names the scope in the words the form's control uses", () => {
+    const origin = (scope: "repository" | "global" | "system") =>
+      identityOrigin(identity(at("Ada", scope), at("ada@example.com", scope)));
+    expect(origin("repository")).toBe("this repository");
+    expect(origin("global")).toBe("global");
+    expect(origin("system")).toBe("this machine");
+  });
+
+  it("says nothing when the two halves come from different files", () => {
+    // `user.name` from /etc/gitconfig and `user.email` from ~/.gitconfig is an
+    // ordinary managed-machine state. Naming only the first would be a
+    // confident wrong answer about the second, so the byline stays quiet and
+    // the form tells the full story when opened.
+    expect(
+      identityOrigin(
+        identity(at("Managed", "system"), at("ada@example.com", "global")),
+      ),
+    ).toBeNull();
+  });
+
+  it("is null when there is no identity to describe", () => {
+    expect(identityOrigin(null)).toBeNull();
+    expect(identityOrigin(identity(at("Ada", "global"), null))).toBeNull();
+  });
+});

--- a/src/features/commits/identity/useIdentity.ts
+++ b/src/features/commits/identity/useIdentity.ts
@@ -1,0 +1,89 @@
+// The committer identity, loaded for display (#233).
+//
+// Separate from `IdentityForm`'s own load on purpose. That one seeds editable
+// fields ONCE per mount and must not re-seed, or it would wipe what the user is
+// typing; this one is read-only and wants the opposite — it re-reads whenever
+// something might have changed it, because a stale "committing as" line is
+// worse than none. Two needs, two loads, no shared state to get wrong.
+//
+// Not in `useRepoStore`: the identity is not per-repository state the app
+// mutates and coordinates, it is a fact about git config that two surfaces
+// read. Putting it in `RepoSlice` would mean an `emptySlice` entry, a tab-switch
+// invalidation and a refresh path, all to cache a config read that takes
+// microseconds.
+
+import * as React from "react";
+
+import { getIdentity } from "@/lib/tauri";
+import type { GitIdentity } from "@/lib/types";
+
+export interface UseIdentity {
+  /** `null` until the first read lands, or if it failed. */
+  identity: GitIdentity | null;
+  /** Re-read — call after anything that may have written git config. */
+  reload: () => void;
+}
+
+export function useIdentity(repoId: string | null | undefined): UseIdentity {
+  const [identity, setIdentity] = React.useState<GitIdentity | null>(null);
+  const [nonce, setNonce] = React.useState(0);
+
+  React.useEffect(() => {
+    let alive = true;
+    void (async () => {
+      try {
+        const next = await getIdentity(repoId ?? null);
+        if (alive) setIdentity(next);
+      } catch {
+        // Silent. This drives an informational line, and a repository whose
+        // config cannot be read has a louder problem than a missing byline —
+        // the commit itself will fail, with `NoSignature` and a form to fix it.
+        if (alive) setIdentity(null);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [repoId, nonce]);
+
+  const reload = React.useCallback(() => setNonce((n) => n + 1), []);
+  return { identity, reload };
+}
+
+/**
+ * `Name <email>` as the commit will record it, or `null` when git has no
+ * identity it would accept.
+ *
+ * Blank-but-present counts as absent, matching `GitIdentity::usable` in Rust —
+ * a `user.email =` line is exactly the state that fails at commit time, and
+ * rendering `Ada <>` would present it as fine.
+ */
+export function identityLine(identity: GitIdentity | null): string | null {
+  const name = identity?.name?.value.trim();
+  const email = identity?.email?.value.trim();
+  if (!name || !email) return null;
+  return `${name} <${email}>`;
+}
+
+/**
+ * Where the identity comes from, in the words the scope control uses — so the
+ * byline and the form cannot describe the same state differently.
+ *
+ * `null` when the two halves disagree about scope. That is a real state on a
+ * managed machine (`user.name` from `/etc/gitconfig`, `user.email` from
+ * `~/.gitconfig`), and naming only the first would be a confident wrong answer
+ * about the second; the form says the full story when the user opens it.
+ */
+export function identityOrigin(identity: GitIdentity | null): string | null {
+  const a = identity?.name?.scope;
+  const b = identity?.email?.scope;
+  if (!a || !b || a !== b) return null;
+  switch (a) {
+    case "repository":
+      return "this repository";
+    case "system":
+      return "this machine";
+    default:
+      return "global";
+  }
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -29,6 +29,7 @@ import type {
   ForgeCheckoutRequest,
   ForgeDetection,
   GitIdentity,
+  IdentityWriteScope,
   ForgeIdentity,
   ForgeKind,
   ForgeRepo,
@@ -557,14 +558,31 @@ export async function getIdentity(repoId?: string | null): Promise<GitIdentity> 
 }
 
 /**
- * Write `user.name` / `user.email` to the global git config (#212) — the remedy
- * for `NoSignature`.
+ * Write `user.name` / `user.email` at `scope` (#212, #233) — the remedy for
+ * `NoSignature`, and the way a repository gets its own identity.
+ *
+ * `scope` is REQUIRED, with no default: "which config did that change?" is the
+ * question this feature exists to stop people having to ask, and a default here
+ * would answer it silently at the one call site that forgot to.
+ *
+ * `"repository"` needs `repoId`; the backend refuses it without one rather than
+ * falling back to global.
  *
  * Rejects with `InvalidArgument` for anything git would refuse, and writes
  * nothing in that case.
  */
-export async function setIdentity(name: string, email: string): Promise<void> {
-  return invoke<void>("set_identity", { name, email });
+export async function setIdentity(
+  name: string,
+  email: string,
+  scope: IdentityWriteScope,
+  repoId?: string | null,
+): Promise<void> {
+  return invoke<void>("set_identity", {
+    name,
+    email,
+    scope,
+    repoId: repoId ?? null,
+  });
 }
 
 export async function discardPaths(repoId: string, paths: string[]): Promise<void> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1003,9 +1003,28 @@ export interface ConfiguredValue {
 export interface GitIdentity {
   name: ConfiguredValue | null;
   email: ConfiguredValue | null;
-  /** The file a save would write to, so the UI can name it beforehand. */
+  /** The file a global save would write to, so the UI can name it beforehand. */
   globalConfigPath: string | null;
+  /**
+   * The file a repository-scoped save would write to (#233) — this
+   * repository's `.git/config`.
+   *
+   * `null` when the identity was read without a repository, which is also the
+   * UI's signal that "this repository" is not a scope it may offer.
+   */
+  localConfigPath: string | null;
 }
+
+/**
+ * Where an identity save is written (#233). Mirrors Rust
+ * `git/signature.rs::IdentityWriteScope`.
+ *
+ * Deliberately NOT `IdentityScope`, which has a `system` member: a value can be
+ * READ from `/etc/gitconfig`, but writing there needs root and would change
+ * every user on the machine. Two types keep "you cannot save to system" out of
+ * reach rather than merely unhandled.
+ */
+export type IdentityWriteScope = "repository" | "global";
 
 /**
  * Whether git could build a committer signature from this — both halves

--- a/src/screens/CommitPanel.identity.test.tsx
+++ b/src/screens/CommitPanel.identity.test.tsx
@@ -12,6 +12,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { CommitPanelScreen } from "./CommitPanel";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { pgPickOption } from "@/test/select";
 import { appErrorMessage } from "@/lib/errors";
 import type { FileStatus, GitIdentity } from "@/lib/types";
 
@@ -28,6 +29,7 @@ const NO_IDENTITY: GitIdentity = {
   name: null,
   email: null,
   globalConfigPath: "/home/ada/.gitconfig",
+  localConfigPath: null,
 };
 
 /** How many times `commit` has been attempted. */
@@ -205,14 +207,25 @@ describe("CommitPanel — no committer identity (#212)", () => {
   });
 
   it("says which repository is overriding the identity, so a global save is not a mystery", async () => {
+    // A repository-scoped value implies an open repository, so the fixture
+    // names its config file — and with one, the form opens on repository scope
+    // (#233), where the warning correctly does not apply. It is the switch TO
+    // global that needs explaining.
     setup({
       identity: {
         name: { value: "Repo Local", scope: "repository" },
         email: { value: "local@example.com", scope: "repository" },
         globalConfigPath: "/home/ada/.gitconfig",
+        localConfigPath: "/repo/.git/config",
       },
     });
     await commitAndGetRefused();
+    expect(screen.queryByTestId("identity-scope-note")).toBeNull();
+
+    pgPickOption(screen.getByTestId("identity-scope"), "global");
+    await waitFor(() =>
+      expect(screen.getByTestId("identity-scope-note")).toBeTruthy(),
+    );
     const note = screen.getByTestId("identity-scope-note").textContent ?? "";
     expect(note).toContain("This repository sets its own");
     // No issue numbers in prose a user reads.
@@ -228,6 +241,7 @@ describe("CommitPanel — no committer identity (#212)", () => {
         name: { value: "Managed Name", scope: "system" },
         email: { value: "ada@example.com", scope: "global" },
         globalConfigPath: "/home/ada/.gitconfig",
+        localConfigPath: null,
       },
     });
     await commitAndGetRefused();
@@ -242,6 +256,7 @@ describe("CommitPanel — no committer identity (#212)", () => {
         name: { value: "Ada Lovelace", scope: "global" },
         email: null,
         globalConfigPath: "/home/ada/.gitconfig",
+        localConfigPath: null,
       },
     });
     await commitAndGetRefused();
@@ -261,5 +276,88 @@ describe("appErrorMessage — NoSignature (#212)", () => {
     expect(msg).not.toBe("NoSignature");
     expect(msg).toContain("user.name");
     expect(msg).toContain("user.email");
+  });
+});
+
+describe("CommitPanel — who the commit will be attributed to (#233)", () => {
+  beforeEach(() => {
+    resetInvokeMock();
+  });
+
+  const IDENTITY: GitIdentity = {
+    name: { value: "Ada Lovelace", scope: "global" },
+    email: { value: "ada@example.com", scope: "global" },
+    globalConfigPath: "/home/ada/.gitconfig",
+    localConfigPath: "/repo/.git/config",
+  };
+
+  it("names the identity rather than the fact that one exists", async () => {
+    // It used to read "(signature will come from git config)" — true, and
+    // useless to the person who has two addresses and needs to know which one
+    // this repository is about to use.
+    setup({ identity: IDENTITY });
+    await waitFor(() =>
+      expect(screen.getByTestId("commit-attribution").textContent).toContain(
+        "Ada Lovelace <ada@example.com>",
+      ),
+    );
+  });
+
+  it("says which config it came from", async () => {
+    setup({
+      identity: {
+        ...IDENTITY,
+        name: { value: "Work Person", scope: "repository" },
+        email: { value: "work@corp.example", scope: "repository" },
+      },
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("commit-identity-origin").textContent,
+      ).toContain("this repository"),
+    );
+  });
+
+  it("stays quiet about the source when the two halves disagree", async () => {
+    // `user.name` from /etc/gitconfig and `user.email` from ~/.gitconfig.
+    // Naming one would be a confident wrong answer about the other.
+    setup({
+      identity: {
+        ...IDENTITY,
+        name: { value: "Managed", scope: "system" },
+        email: { value: "ada@example.com", scope: "global" },
+      },
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("commit-attribution").textContent).toContain(
+        "Managed <ada@example.com>",
+      ),
+    );
+    expect(screen.queryByTestId("commit-identity-origin")).toBeNull();
+  });
+
+  it("says git has none, rather than showing an empty byline", async () => {
+    setup({ identity: NO_IDENTITY });
+    await waitFor(() =>
+      expect(screen.getByTestId("commit-attribution").textContent).toContain(
+        "git has no identity configured",
+      ),
+    );
+  });
+
+  it("an author override still wins, and still says the committer is you", async () => {
+    // `author_override` (#61 D1) moves the AUTHOR only — a different claim from
+    // the identity, and the byline must not conflate them.
+    setup({ identity: IDENTITY });
+    await waitFor(() => expect(screen.getByTestId("commit-author")).toBeTruthy());
+    fireEvent.change(screen.getByTestId("commit-author"), {
+      target: { value: "Grace Hopper <grace@example.com>" },
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("commit-attribution").textContent).toContain(
+        "you stay the committer",
+      ),
+    );
+    expect(screen.queryByTestId("commit-identity-origin")).toBeNull();
   });
 });

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -63,6 +63,11 @@ import {
 } from "@/lib/derive";
 import { LfsDiffNotice } from "@/features/lfs/LfsDiffNotice";
 import { NoSignaturePrompt } from "@/features/commits/identity/NoSignaturePrompt";
+import {
+  identityLine,
+  identityOrigin,
+  useIdentity,
+} from "@/features/commits/identity/useIdentity";
 import { EMBEDDED_REPO_HELP, appErrorMessage } from "@/lib/errors";
 import {
   clickSelection,
@@ -146,6 +151,12 @@ export function CommitPanelScreen() {
   const hookRejection = useRepoStore((s) => s.hookRejection);
   const clearHookRejection = useRepoStore((s) => s.clearHookRejection);
   const noSignature = useRepoStore((s) => s.noSignature);
+  // Who the commit will be attributed to (#233), for the byline below the
+  // attribution fields. Reloaded after the NoSignaturePrompt saves, which is
+  // the one thing in this screen that can change it.
+  const { identity: committerIdentity, reload: reloadIdentity } = useIdentity(
+    repo?.id ?? null,
+  );
   const clearNoSignature = useRepoStore((s) => s.clearNoSignature);
   const activity = useRepoStore((s) => s.activity);
   const commits = useRepoStore((s) => s.commits);
@@ -1098,6 +1109,8 @@ export function CommitPanelScreen() {
   const canCommit =
     (amend || staged.length > 0) && !!composer.cleaned && !authorInvalid;
   const canCommitAndPush = canCommit && !!headBranch && !!defaultRemote;
+  const committerLine = identityLine(committerIdentity);
+  const committerFrom = identityOrigin(committerIdentity);
   // Guards against a second commit firing before the first resolves and clears
   // the message/staged state — key auto-repeat (holding ⌘↵) and double-taps
   // both re-dispatch the chord while canCommit is still true.
@@ -1746,6 +1759,7 @@ export function CommitPanelScreen() {
               repoId={repo.id}
               onSaved={() => {
                 clearNoSignature();
+                reloadIdentity();
                 void doCommit();
               }}
               onDismiss={clearNoSignature}
@@ -1848,12 +1862,35 @@ export function CommitPanelScreen() {
             }}
             data-testid="commit-attribution"
           >
-            <PGAvatar name={authorIdentity?.name ?? "you"} size={14} />
+            <PGAvatar
+              name={
+                authorIdentity?.name ??
+                committerIdentity?.name?.value ??
+                "you"
+              }
+              size={14}
+            />
+            {/*
+              With no author override this names the ACTUAL identity rather
+              than the fact that one exists somewhere. "(signature will come
+              from git config)" was true and useless: the whole point of #233
+              is that a user with a work and a personal address cannot tell
+              which one this repository is about to use, and the cost of
+              guessing wrong is a corporate address on a public commit that no
+              amount of later editing takes back.
+            */}
             {authorInvalid
               ? "Author must look like: Name <email@example.com>"
               : authorIdentity
                 ? `${authorIdentity.name} <${authorIdentity.email}> — you stay the committer`
-                : "(signature will come from git config)"}
+                : (committerLine ??
+                  "git has no identity configured — Commit will offer to set one")}
+            {!authorInvalid && !authorIdentity && committerLine && committerFrom && (
+              <span style={{ color: "var(--fg-3)" }} data-testid="commit-identity-origin">
+                {" "}
+                — from {committerFrom}
+              </span>
+            )}
             {coAuthorCount > 0 && !authorInvalid && (
               <span style={{ color: "var(--fg-3)" }}>
                 {" "}

--- a/src/screens/Settings.identity.test.tsx
+++ b/src/screens/Settings.identity.test.tsx
@@ -37,6 +37,7 @@ const GLOBAL_IDENTITY: GitIdentity = {
   name: { value: "Ada Lovelace", scope: "global" },
   email: { value: "ada@example.com", scope: "global" },
   globalConfigPath: "/home/ada/.gitconfig",
+  localConfigPath: null,
 };
 
 beforeEach(() => {
@@ -102,6 +103,7 @@ describe("Settings → Identity (#212)", () => {
       name: null,
       email: null,
       globalConfigPath: "/home/ada/.gitconfig",
+      localConfigPath: null,
     };
     mockInvoke("get_identity", () => stored);
     mockInvoke("set_identity", (args) => {
@@ -109,6 +111,7 @@ describe("Settings → Identity (#212)", () => {
         name: { value: String(args.name), scope: "global" },
         email: { value: String(args.email), scope: "global" },
         globalConfigPath: "/home/ada/.gitconfig",
+        localConfigPath: null,
       };
       return null;
     });


### PR DESCRIPTION
Part of #233 — the two bullets that prevent the actual damage. Deliberately leaves #233 open; see *What this does not do* below.

The cost of getting this wrong is a corporate address on a public commit, which is not fixable after the push. That framing drove every decision here.

## Show the identity

The commit panel's attribution line read **"(signature will come from git config)"** — true, and useless to exactly the person who needs it: someone with a work address and a personal one, who cannot tell which this repository is about to use. It now names the identity and which config it came from:

> Ada Lovelace `<ada@example.com>` — from global

When the two halves come from *different* files — `user.name` from `/etc/gitconfig` and `user.email` from `~/.gitconfig` is ordinary on a managed machine — it names neither. Naming one would be a confident wrong answer about the other; the form tells the full story when opened.

A present-but-blank half counts as absent, matching `GitIdentity::usable` in Rust. Rendering `Ada <>` would present a commit that is about to fail as one that is fine.

## Set it, at an explicit scope

`set_identity` gains a **required** `scope`, with no default. *"Which config did that change?"* is the question this feature exists to stop people asking, and a default would answer it silently at the one call site that forgot.

Two decisions worth reviewing:

- **`IdentityWriteScope` is deliberately not `IdentityScope`.** The latter has a `System` member because a value can be *read* from `/etc/gitconfig` — but writing there needs root and would change every user on the machine. Two enums make "you cannot save to system" a fact the type system enforces rather than a runtime check someone can forget.
- **`repository` without a repo id is refused, never downgraded to global.** A save the user scoped to one repository must not quietly change every other one. There is a test asserting the global config is byte-identical after that refusal.

`IdentityForm` grows the **scope control its own header comment promised** back in #212 (*"when that lands, this form grows a scope control rather than a sibling"*) — so there is still exactly one place that knows what git will accept. It opens on `repository` when the repo already overrides either half (someone with a repo-local identity is managing that repository's identity; opening on global would invite them to edit the value being overridden), and on `global` otherwise. The filename beside the button follows the scope, so the two can never disagree.

The **"this repository overrides you"** warning now appears only for a *global* save, where it is true. At repository scope you are writing exactly the value that wins — warning anyway would train people to ignore the warning that matters.

## The worktree trap

`local_config_path` uses `commondir()`, **not** `path()`. They differ in a linked worktree: `path()` is that worktree's own gitdir (`.git/worktrees/<name>`), while `--local` writes to the shared config in the common directory. Using `path()` would have named a file git never writes, and the UI would have promised the wrong thing. In an ordinary repository the two are the same directory, which is why it is easy to miss.

## What this does not do

Left for a follow-up, and why #233 stays open:

- **Named identities** — a saved set of (label, name, email, signing key) with a per-repository choice. That is a real design (where they persist, how they interact with `signCommits`, what happens when one is deleted) and wants its own spec rather than being tacked on here.
- **Per-repository default editor**, the adjacent "per-repo override" shape the issue mentions.

## Tests

- `src-tauri/tests/identity.rs` — six new sections on the existing single-test story (the file is deliberately one `#[test]`: libgit2's config search paths are process-global). Covers: the local config path is named and is `commondir`-based; a repository save wins and leaves the global config byte-identical; a rewrite overwrites rather than appending (a duplicated key is legal and the *last* wins, so an append-only writer reads correct and diverges under `--get`); the commit's **author and committer** both carry the repo-local address; repository scope with no repo is refused and writes nothing; validation still runs before the config is opened.
- `src/features/commits/identity/IdentityForm.scope.test.tsx` — new, 12 cases on which scopes are offered, which one it opens on, what a save sends, and when the override warning appears.
- `src/features/commits/identity/useIdentity.test.ts` — new, the byline's two pure helpers.
- `src/screens/CommitPanel.identity.test.tsx` — five new byline cases; one existing fixture made realistic (a repository-scoped value implies an open repository, so it now names a config file).
- Green: `pnpm test` (2760 passed), full `cargo test`, `pnpm tsc --noEmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
