### PR TITLE
feat(repo): watch the filesystem so the working copy is live (#239)

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -24,6 +24,26 @@ opener.rs        URLs/paths → OS default handler. SECURITY-critical: safe_url
 update.rs        Update discovery: semver compare, dev-build (0.0.0) short-circuit
                  before any network call, GitHub release parsing, ureq w/ timeout +
                  https_only. Logic only — handlers live in commands/update.rs
+watcher.rs       Filesystem watching so the working copy is live (#239).
+                 notify-debouncer-mini around a RecommendedWatcher, ONE live
+                 watch (WatchState) on the ACTIVE repository — a second
+                 watch_repo REPLACES rather than stacks. The value is in what
+                 it DROPS: classify() sorts each path into Noise / Ref / State
+                 / Worktree, and only Ref asks for the expensive log refresh,
+                 so a file save cannot repaint history. `.lock` files are
+                 Noise (git STARTING work, not finishing it — honouring them
+                 doubles every event and fires the first mid-write), and so
+                 are objects/, logs/, COMMIT_EDITMSG and FETCH_HEAD.
+                 classify() takes BOTH the gitdir and the commondir and tries
+                 them in that order: in a linked worktree HEAD and index live
+                 in the worktree's gitdir while refs live in the shared
+                 commondir, and the gitdir is INSIDE the commondir, so
+                 matching the commondir first would miss every worktree branch
+                 switch. Ignore filtering uses the watcher's OWN libgit2
+                 handle, not the shared per-repo mutex — see the module's own
+                 note for why (the mutex is held by exactly the rebase/merge
+                 that produces the storm this has to filter). Emits one
+                 fs://changed per debounce batch, tagged with repoId
 cancel.rs        Cancelling an in-flight network git subprocess (#234, #263). A
                  process-wide registry keyed by SCOPE (the clone / one
                  repository), not by op id — the auto-fetch pile has no id a
@@ -354,6 +374,14 @@ commands/        Thin Tauri handlers, one file per area:
 │                stalled clone/fetch/pull/push (#234). See backend.md
 ├── update.rs    check_for_update, get_update_capability, open_url — thin
 │                handlers for src-tauri/src/update.rs (same basename, two files)
+├── watch.rs     watch_repo, watch_stop (#239) — thin over src-tauri/src/
+│                watcher.rs. watch_repo resolves the workdir through the
+│                backend rather than taking a path argument: a path from the
+│                frontend would be a second source of truth for where a
+│                repository lives, and this one registers an OS-level
+│                recursive watch on whatever it is handed. watch_stop is
+│                idempotent, so the frontend can call it on a setting change
+│                without tracking whether anything was running
 ├── history.rs   reset, cherry_pick, revert
 ├── ssh.rs       ssh_key_status, ssh_key_generate (#248) — thin over
 │                src-tauri/src/ssh.rs. Take NO repository: an SSH key belongs to

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -446,6 +446,46 @@ const composer = useCommitComposer({ repoId, branch, ticketPattern, message, set
 - Composes with what was already there: sign-off, co-author / author-override
   and recent-message recall all still read and write the same box.
 
+## The filesystem watcher's refresh policy (#239)
+
+The backend decides WHETHER an event is interesting (`watcher.rs`, and the
+architecture doc's entry for it); the frontend decides **how much to refresh**,
+in `features/repo/fsWatchPlan.ts`. It is pure and separate from the
+subscription because the four ways it can be wrong are all real bugs:
+
+- **Another repository's event.** `useRepoStore` holds exactly ONE repository's
+  state — the active tab's — so applying another tab's event writes its status
+  over the open one. The backend watches only the active repo, but an event can
+  already be in flight when the tab switches, which is exactly why the payload
+  carries `repoId`. Both halves of the guard are needed; they fail differently.
+- **An operation in flight.** A rebase or a merge writes to `.git/` in a storm,
+  and a refresh landing mid-transition can read a half-applied state. The plan
+  returns `none` whenever `RepoActivity` is non-empty. Skipping loses nothing:
+  every operation refreshes on completion anyway, so only the flicker of
+  intermediate states is dropped.
+- **A file save repainting history.** `refsMoved` is the whole reason the
+  backend classifies instead of just saying "something changed": a status
+  refresh is cheap and a log refresh is not.
+- **An event after the setting is off.** Otherwise "off" is off with
+  exceptions.
+
+`useFsWatch` mounts two effects with deliberately different lifetimes: the
+`fs://changed` **subscription** is app-global and mounted once (like
+`net://progress` — re-subscribing per repository opens a window on every tab
+switch where events are silently dropped), while the **watch** follows the
+active repository and the setting. `watch_repo` is a swap on the backend, so a
+tab switch needs no matching stop, and `watch_stop` is idempotent so the caller
+never has to track whether one was running.
+
+Refreshes coalesce rather than queue: a burst produces at most one more refresh
+after the current one, and `mergeRefresh` keeps a queued `status` from
+downgrading a pending `all`.
+
+The watcher's refresh deliberately does **not** join `RepoActivity`. That is
+for operations the user started and can cancel; this is background upkeep, and
+a status line that flickered on every keystroke in someone's editor would be
+noise. It *reads* `RepoActivity` instead, to know when to stay out of the way.
+
 ## Undo the last operation (#242)
 
 `features/repo/undoStack.ts` is the whole model, and it is deliberately small:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1279,6 +1279,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2138,6 +2147,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592"
+dependencies = [
+ "bitflags 2.11.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,6 +2361,26 @@ dependencies = [
  "bitflags 2.11.1",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
 ]
 
 [[package]]
@@ -2560,6 +2609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -2632,6 +2682,45 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17849edfaabd9a5fef1c606d99cfc615a8e99f7ac4366406d86c7942a3184cf2"
+dependencies = [
+ "log",
+ "notify",
+ "notify-types",
+ "tempfile",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.1",
+]
 
 [[package]]
 name = "num-conv"
@@ -3276,6 +3365,7 @@ dependencies = [
  "git2",
  "libc",
  "log",
+ "notify-debouncer-mini",
  "regex",
  "semver",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -59,6 +59,7 @@ base64 = "0.23"
 # lets the SSH panel list N keys with zero subprocesses. Already in the tree
 # transitively, so this declares it rather than adding it.
 sha2 = "0.11"
+notify-debouncer-mini = "0.7.0"
 
 # `setsid()` between fork and exec, for the detached `pgit` launch (#163) —
 # nothing in std reaches it (`Command::process_group` only makes a new process

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -17,4 +17,5 @@ pub mod ssh;
 pub mod stash;
 pub mod submodule;
 pub mod update;
+pub mod watch;
 pub mod worktree;

--- a/src-tauri/src/commands/watch.rs
+++ b/src-tauri/src/commands/watch.rs
@@ -1,0 +1,50 @@
+//! Start and stop the filesystem watcher (#239).
+//!
+//! Two commands and no state of their own — [`crate::watcher::WatchState`] owns
+//! the single live watch. The frontend calls `watch_repo` when a repository
+//! becomes the active tab and `watch_stop` when the setting is turned off or
+//! the last repository closes; a second `watch_repo` replaces rather than
+//! stacks, so a tab switch needs no matching stop.
+
+use std::path::PathBuf;
+
+use tauri::{AppHandle, State};
+
+use crate::{
+    error::{AppError, AppResult},
+    git::types::RepoId,
+    state::AppState,
+    watcher::WatchState,
+};
+
+/// Watch this repository's working directory, replacing any existing watch.
+///
+/// The workdir is resolved through the backend rather than taken from the
+/// frontend: a path argument would be a second source of truth for where a
+/// repository lives, and this one registers an OS-level recursive watch on
+/// whatever it is handed.
+#[tauri::command]
+pub async fn watch_repo(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    watch: State<'_, WatchState>,
+    repo_id: String,
+) -> AppResult<()> {
+    let backend = state.backend.clone();
+    let id = RepoId(repo_id.clone());
+    let workdir: PathBuf = tokio::task::spawn_blocking(move || backend.repo_path(&id))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))??;
+    // `start` opens a libgit2 handle and registers the watch — both blocking,
+    // both fast, and neither touching the shared per-repo mutex. See the
+    // module note in `watcher.rs` for why this does not go through it.
+    watch.inner().start(app, repo_id, workdir)
+}
+
+/// Stop watching. Idempotent — the frontend calls this on a setting change
+/// without knowing whether anything was running.
+#[tauri::command]
+pub async fn watch_stop(watch: State<'_, WatchState>) -> AppResult<()> {
+    watch.inner().stop();
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ pub mod reveal;
 pub mod ssh;
 pub mod state;
 pub mod update;
+pub mod watcher;
 
 use std::sync::{Arc, Mutex};
 
@@ -205,6 +206,8 @@ pub fn run() {
         // git-transport credential path — see forge/token.rs for why the two
         // must never share storage.
         .manage(commands::forge::ForgeTokens::default())
+        // One live filesystem watch, on the active repository (#239).
+        .manage(watcher::WatchState::default())
         .manage(commands::cli::CliLaunchState(Mutex::new(initial_intent)))
         .invoke_handler(tauri::generate_handler![
             commands::repo::open_repo,
@@ -343,6 +346,8 @@ pub fn run() {
             commands::ssh::ssh_key_generate,
             commands::update::check_for_update,
             commands::update::get_update_capability,
+            commands::watch::watch_repo,
+            commands::watch::watch_stop,
             commands::update::open_url,
             commands::forge::forge_detect,
             commands::forge::forge_sign_in,

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -1,0 +1,325 @@
+//! Filesystem watching, so the working copy is live rather than stale (#239).
+//!
+//! You save a file in your editor, tab back, and the status is already right.
+//! Before this the app was only correct if you remembered to refresh: the sole
+//! self-starting refresh was the auto-fetch timer, which is a *network* fetch on
+//! a minutes-scale interval and does not run at all when auto-fetch is off.
+//!
+//! ## The shape
+//!
+//! One watcher at a time, on the ACTIVE repository, started by `watch_repo` and
+//! replaced (not stacked) by the next call. Events are debounced, classified,
+//! filtered against the repository's ignore rules, and emitted as a single
+//! [`FsChange`] carrying the `repoId` they came from.
+//!
+//! Both halves of the multi-repo guard are in place on purpose, because they
+//! fail differently: watching only the active repo keeps N-1 watchers off the
+//! filesystem, and tagging the event lets the frontend drop one that arrives
+//! after a tab switch — a race a single-slot watcher alone cannot close, since
+//! an event can already be in flight when the slot is swapped.
+//!
+//! ## Why the ignore check does not take the per-repo mutex
+//!
+//! The issue asked for `spawn_blocking` behind the shared mutex, and the
+//! constraint it was protecting — `git2::Repository` is `Send` but not `Sync` —
+//! is real. This module satisfies it differently: the watcher owns its OWN
+//! `Repository`, opened once on the debouncer's thread and never shared, so the
+//! handle never crosses threads and the `Sync` question never arises.
+//!
+//! Taking the shared mutex would have been worse for the case that matters
+//! most. A rebase or a merge holds that mutex while producing exactly the event
+//! storm this module has to filter, so the watcher would queue behind the
+//! operation, wake up when it finished, and do its work twice — once for the
+//! storm and once for the completion refresh the operation already triggers.
+//! Worse, on a slow filesystem (a `/mnt/c` repository under WSL) it would add
+//! ignore-rule reads to a mutex that is already the bottleneck. Two independent
+//! libgit2 handles on one repository are ordinary — git is built for concurrent
+//! processes — and this one only ever asks read-only questions.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::Duration;
+
+use notify_debouncer_mini::notify::{RecommendedWatcher, RecursiveMode};
+use notify_debouncer_mini::{new_debouncer, DebounceEventResult, Debouncer};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+
+use crate::error::{AppError, AppResult};
+
+/// The event the frontend listens for. Named like `net://progress` and
+/// `rebase://progress`, and subscribed the same way: once, app-global, with the
+/// payload's `repoId` deciding whether it applies.
+pub const FS_CHANGED_EVENT: &str = "fs://changed";
+
+/// How long the debouncer coalesces before reporting.
+///
+/// Long enough that `git checkout` on a large tree reports once rather than per
+/// file, short enough that saving in an editor feels immediate. The number is a
+/// judgement, but the ORDER matters: below ~100ms a single `git status` run
+/// produces multiple batches, and above ~1s the feature stops feeling live.
+const DEBOUNCE: Duration = Duration::from_millis(400);
+
+/// How many paths one batch will run ignore checks on.
+///
+/// A `cargo build` or an `npm install` can touch tens of thousands of files. We
+/// only need to know WHETHER anything relevant changed, so the check stops at
+/// the first path that is not ignored; this cap bounds the opposite case, where
+/// everything IS ignored and the honest answer costs one `is_path_ignored` per
+/// file. Past the cap the batch is treated as relevant — a spurious refresh is
+/// cheap, a stalled watcher thread is not.
+const MAX_IGNORE_CHECKS: usize = 512;
+
+/// What one changed path means for the UI.
+///
+/// The distinction that earns its keep is `Ref` vs `Worktree`: a status refresh
+/// is cheap and a log refresh is not, so a file save must not repaint history.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathKind {
+    /// Inside the gitdir and not interesting — refresh nothing.
+    Noise,
+    /// A ref moved: `HEAD`, `refs/**`, `packed-refs`. The graph and the HEAD
+    /// marks are now wrong.
+    Ref,
+    /// Repository state changed without a ref moving: the index, or an
+    /// in-progress merge/rebase/cherry-pick marker.
+    State,
+    /// An ordinary working-copy file.
+    Worktree,
+}
+
+/// What the frontend is told. One event per debounce batch, never per file.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FsChange {
+    /// Which repository this is about. The frontend drops anything that is not
+    /// the active tab's — see the module note on the two-part guard.
+    pub repo_id: String,
+    /// Whether a ref moved, so the log and branch list need re-reading too.
+    /// `false` means a status refresh is enough.
+    pub refs_moved: bool,
+}
+
+/// Classify a path inside a gitdir, given the path relative to that gitdir.
+///
+/// Everything not named here is `Noise`, and that direction is deliberate:
+/// `objects/`, `logs/`, `COMMIT_EDITMSG`, `FETCH_HEAD` and the rest change
+/// constantly and tell the UI nothing it does not already learn from `refs/`
+/// or the index.
+pub fn classify_git_entry(rel: &Path) -> PathKind {
+    let s = rel.to_string_lossy().replace('\\', "/");
+
+    // A `.lock` file is git STARTING to work, not git having worked — and it is
+    // removed again a moment later, so honouring it would double every event
+    // and fire the first one while the index is mid-write.
+    if s.ends_with(".lock") {
+        return PathKind::Noise;
+    }
+
+    if s == "HEAD" || s == "packed-refs" || s.starts_with("refs/") {
+        return PathKind::Ref;
+    }
+
+    if s == "index" {
+        return PathKind::State;
+    }
+
+    // An operation is in progress or has just ended. The working copy and the
+    // repository's state both changed even though no ref has moved yet.
+    const STATE_FILES: [&str; 6] = [
+        "MERGE_HEAD",
+        "CHERRY_PICK_HEAD",
+        "REVERT_HEAD",
+        "REBASE_HEAD",
+        "BISECT_LOG",
+        "MERGE_MSG",
+    ];
+    if STATE_FILES.contains(&s.as_str())
+        || s.starts_with("rebase-merge/")
+        || s.starts_with("rebase-apply/")
+        || s.starts_with("sequencer/")
+    {
+        return PathKind::State;
+    }
+
+    PathKind::Noise
+}
+
+/// Classify an absolute path against a repository's gitdir and common dir.
+///
+/// Both, because they differ in a linked worktree: `HEAD` and `index` live in
+/// the worktree's own gitdir while `refs/` lives in the shared common dir. A
+/// classifier that knew only one of them would miss half the ref moves in every
+/// worktree — and this app creates worktrees, so that is not a hypothetical.
+pub fn classify(path: &Path, gitdir: &Path, commondir: &Path) -> PathKind {
+    if let Ok(rel) = path.strip_prefix(gitdir) {
+        return classify_git_entry(rel);
+    }
+    if let Ok(rel) = path.strip_prefix(commondir) {
+        return classify_git_entry(rel);
+    }
+    PathKind::Worktree
+}
+
+/// Fold a batch of classified paths into the one event to emit, or `None` when
+/// nothing in the batch was worth waking the UI for.
+pub fn summarize(repo_id: &str, kinds: &[PathKind]) -> Option<FsChange> {
+    let mut relevant = false;
+    let mut refs_moved = false;
+    for kind in kinds {
+        match kind {
+            PathKind::Noise => {}
+            PathKind::Ref => {
+                relevant = true;
+                refs_moved = true;
+            }
+            PathKind::State | PathKind::Worktree => relevant = true,
+        }
+    }
+    relevant.then(|| FsChange {
+        repo_id: repo_id.to_string(),
+        refs_moved,
+    })
+}
+
+/// The one live watcher. `None` when nothing is being watched.
+///
+/// A single slot rather than a map: only the active tab's repository is
+/// watched, so a second `watch_repo` REPLACES rather than adds. Dropping the
+/// previous `Debouncer` is what unregisters it from the OS.
+#[derive(Default)]
+pub struct WatchState {
+    active: Mutex<Option<Active>>,
+}
+
+struct Active {
+    repo_id: String,
+    /// Held only to keep the watch alive; dropping it stops the watcher.
+    _debouncer: Debouncer<RecommendedWatcher>,
+}
+
+impl WatchState {
+    /// Which repository is being watched, if any. For tests and diagnostics.
+    pub fn watching(&self) -> Option<String> {
+        self.active
+            .lock()
+            .ok()
+            .and_then(|g| g.as_ref().map(|a| a.repo_id.clone()))
+    }
+
+    /// Stop whatever is being watched. Idempotent.
+    pub fn stop(&self) {
+        if let Ok(mut guard) = self.active.lock() {
+            *guard = None;
+        }
+    }
+
+    /// Watch `workdir`, replacing any existing watch.
+    ///
+    /// The previous watcher is dropped BEFORE the new one is registered, so two
+    /// watchers never hold the same directory — on macOS that would double
+    /// every event for as long as both lived.
+    pub fn start(&self, app: AppHandle, repo_id: String, workdir: PathBuf) -> AppResult<()> {
+        let repo = git2::Repository::open(&workdir)?;
+        let gitdir = repo.path().to_path_buf();
+        let commondir = repo.commondir().to_path_buf();
+
+        let mut guard = self
+            .active
+            .lock()
+            .map_err(|_| AppError::Internal("watch state poisoned".to_string()))?;
+        // Drop the old one first — see the doc comment.
+        *guard = None;
+
+        let handler = Handler {
+            app,
+            repo_id: repo_id.clone(),
+            workdir: workdir.clone(),
+            gitdir,
+            commondir,
+            repo: Some(repo),
+        };
+        let mut debouncer = new_debouncer(DEBOUNCE, handler)
+            .map_err(|e| AppError::Io(format!("could not start a filesystem watcher: {e}")))?;
+        debouncer
+            .watcher()
+            .watch(&workdir, RecursiveMode::Recursive)
+            .map_err(|e| AppError::Io(format!("could not watch {}: {e}", workdir.display())))?;
+
+        *guard = Some(Active {
+            repo_id,
+            _debouncer: debouncer,
+        });
+        Ok(())
+    }
+}
+
+/// The debounce callback's state.
+///
+/// Lives on the debouncer's own thread for the life of the watch, which is what
+/// makes holding a `git2::Repository` here sound — see the module note. It is
+/// `Option` so a repository that disappears out from under the watcher (deleted,
+/// moved, unmounted) degrades to "assume relevant" instead of panicking: the
+/// next refresh will surface the real error, with a real message.
+struct Handler {
+    app: AppHandle,
+    repo_id: String,
+    workdir: PathBuf,
+    gitdir: PathBuf,
+    commondir: PathBuf,
+    repo: Option<git2::Repository>,
+}
+
+impl Handler {
+    /// Whether a working-copy path is ignored. Errs toward NOT ignored: a
+    /// spurious refresh is a wasted `git status`, a wrongly-suppressed one is
+    /// the stale working copy this whole module exists to remove.
+    fn is_ignored(&self, path: &Path) -> bool {
+        let Some(repo) = self.repo.as_ref() else {
+            return false;
+        };
+        let rel = path.strip_prefix(&self.workdir).unwrap_or(path);
+        repo.is_path_ignored(rel).unwrap_or(false)
+    }
+
+    fn kinds_for(&self, paths: &[PathBuf]) -> Vec<PathKind> {
+        let mut out = Vec::with_capacity(paths.len());
+        let mut checked = 0usize;
+        for path in paths {
+            let kind = classify(path, &self.gitdir, &self.commondir);
+            if kind == PathKind::Worktree {
+                // Past the cap, stop asking and assume it matters. See
+                // MAX_IGNORE_CHECKS.
+                if checked < MAX_IGNORE_CHECKS {
+                    checked += 1;
+                    if self.is_ignored(path) {
+                        out.push(PathKind::Noise);
+                        continue;
+                    }
+                }
+            }
+            out.push(kind);
+        }
+        out
+    }
+}
+
+impl notify_debouncer_mini::DebounceEventHandler for Handler {
+    fn handle_event(&mut self, result: DebounceEventResult) {
+        let events = match result {
+            Ok(events) => events,
+            Err(e) => {
+                // A watch error is not worth a banner — the app is still
+                // correct, just no longer live — but it must not be silent
+                // either, or "why did it stop updating" has no answer in the log.
+                log::warn!("filesystem watcher: {e}");
+                return;
+            }
+        };
+        let paths: Vec<PathBuf> = events.into_iter().map(|e| e.path).collect();
+        let kinds = self.kinds_for(&paths);
+        if let Some(change) = summarize(&self.repo_id, &kinds) {
+            let _ = self.app.emit(FS_CHANGED_EVENT, &change);
+        }
+    }
+}

--- a/src-tauri/tests/watcher.rs
+++ b/src-tauri/tests/watcher.rs
@@ -1,0 +1,257 @@
+//! Which filesystem events are worth waking the UI for (#239).
+//!
+//! The watcher's whole value is in what it DROPS. A watcher that reports every
+//! event is worse than no watcher on a large repository: `cargo build` and
+//! `npm install` each touch tens of thousands of ignored files, and every one
+//! of them would be a `git status`. So most of this file is negative
+//! assertions.
+//!
+//! The classification is pure, which is why it is tested here rather than
+//! through a real watcher: an OS-level watch is timing-dependent, differs per
+//! platform, and would test `notify` rather than our rules.
+
+use std::path::{Path, PathBuf};
+
+use platypusgit_lib::watcher::{classify, classify_git_entry, summarize, PathKind};
+
+/// An ordinary repository: gitdir and common dir are the same directory.
+const GITDIR: &str = "/repo/.git";
+
+fn kind(abs: &str) -> PathKind {
+    classify(Path::new(abs), Path::new(GITDIR), Path::new(GITDIR))
+}
+
+fn entry(rel: &str) -> PathKind {
+    classify_git_entry(Path::new(rel))
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// A ref moved — the log and the HEAD marks are now wrong
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn a_branch_switch_or_a_commit_in_a_terminal_is_a_ref_move() {
+    // `git checkout` rewrites HEAD; `git commit` rewrites refs/heads/<branch>.
+    // Both have to move the graph, which is the expensive refresh — so these
+    // are the only paths allowed to ask for it.
+    assert_eq!(entry("HEAD"), PathKind::Ref);
+    assert_eq!(entry("refs/heads/main"), PathKind::Ref);
+    assert_eq!(entry("refs/remotes/origin/main"), PathKind::Ref);
+    assert_eq!(entry("refs/tags/v1.0.0"), PathKind::Ref);
+    // `git gc` / `git pack-refs` collapses loose refs into one file. Missing
+    // this would leave the graph stale after a gc with no other signal.
+    assert_eq!(entry("packed-refs"), PathKind::Ref);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// State changed without a ref moving
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn staging_from_a_terminal_is_a_state_change_not_a_ref_move() {
+    // `git add` rewrites the index and nothing else. The file list is wrong,
+    // the graph is not — and repainting history on every `git add` is exactly
+    // the cost this distinction exists to avoid.
+    assert_eq!(entry("index"), PathKind::State);
+}
+
+#[test]
+fn an_operation_in_progress_is_a_state_change() {
+    // These are what make the app show "merging" / "rebasing". A user who
+    // starts a rebase in a terminal must not see a tab that still says clean.
+    assert_eq!(entry("MERGE_HEAD"), PathKind::State);
+    assert_eq!(entry("CHERRY_PICK_HEAD"), PathKind::State);
+    assert_eq!(entry("REVERT_HEAD"), PathKind::State);
+    assert_eq!(entry("REBASE_HEAD"), PathKind::State);
+    assert_eq!(entry("BISECT_LOG"), PathKind::State);
+    assert_eq!(entry("MERGE_MSG"), PathKind::State);
+    assert_eq!(entry("rebase-merge/done"), PathKind::State);
+    assert_eq!(entry("rebase-apply/next"), PathKind::State);
+    assert_eq!(entry("sequencer/todo"), PathKind::State);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Noise — the part that makes the feature usable
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn a_lock_file_is_git_starting_work_not_finishing_it() {
+    // `index.lock` appears at the START of nearly every git command and is
+    // removed moments later. Honouring it would double every event AND fire
+    // the first one while the index is still being written — a refresh reading
+    // a half-written index is worse than a late one.
+    assert_eq!(entry("index.lock"), PathKind::Noise);
+    assert_eq!(entry("HEAD.lock"), PathKind::Noise);
+    assert_eq!(entry("refs/heads/main.lock"), PathKind::Noise);
+    assert_eq!(entry("packed-refs.lock"), PathKind::Noise);
+}
+
+#[test]
+fn the_object_database_and_the_reflog_are_noise() {
+    // Objects are written before the ref that points at them, so acting on
+    // them would refresh to a state no ref names yet. The reflog moves with
+    // every ref, so `refs/` already covers everything it would tell us —
+    // counting it too would just double the work.
+    assert_eq!(entry("objects/ab/cdef0123456789"), PathKind::Noise);
+    assert_eq!(entry("objects/pack/pack-abc.pack"), PathKind::Noise);
+    assert_eq!(entry("logs/HEAD"), PathKind::Noise);
+    assert_eq!(entry("logs/refs/heads/main"), PathKind::Noise);
+}
+
+#[test]
+fn the_editor_scratch_files_are_noise() {
+    // COMMIT_EDITMSG changes on every commit attempt, including abandoned
+    // ones. FETCH_HEAD changes on every fetch, which is a network op that
+    // already refreshes on completion.
+    assert_eq!(entry("COMMIT_EDITMSG"), PathKind::Noise);
+    assert_eq!(entry("FETCH_HEAD"), PathKind::Noise);
+    assert_eq!(entry("ORIG_HEAD"), PathKind::Noise);
+    assert_eq!(entry("config"), PathKind::Noise);
+    assert_eq!(entry("hooks/pre-commit.sample"), PathKind::Noise);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Inside the gitdir vs outside it
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn a_working_copy_file_is_a_worktree_change() {
+    assert_eq!(kind("/repo/src/main.rs"), PathKind::Worktree);
+    assert_eq!(kind("/repo/README.md"), PathKind::Worktree);
+    // A file whose NAME resembles a git one but lives in the worktree is still
+    // an ordinary file — the classifier keys on location, not spelling.
+    assert_eq!(kind("/repo/HEAD"), PathKind::Worktree);
+    assert_eq!(kind("/repo/docs/index"), PathKind::Worktree);
+}
+
+#[test]
+fn gitdir_paths_are_recognised_through_the_absolute_form() {
+    assert_eq!(kind("/repo/.git/HEAD"), PathKind::Ref);
+    assert_eq!(kind("/repo/.git/refs/heads/main"), PathKind::Ref);
+    assert_eq!(kind("/repo/.git/index"), PathKind::State);
+    assert_eq!(kind("/repo/.git/objects/ab/cd"), PathKind::Noise);
+}
+
+#[test]
+fn a_linked_worktree_is_classified_against_both_directories() {
+    // The trap: in a linked worktree HEAD and index live in the worktree's own
+    // gitdir (`.git/worktrees/<name>`) while refs live in the SHARED common
+    // dir. A classifier that knew only one would miss half of every ref move —
+    // and this app creates worktrees, so it is not hypothetical.
+    let gitdir = Path::new("/repo/.git/worktrees/feature");
+    let commondir = Path::new("/repo/.git");
+    let k = |p: &str| classify(Path::new(p), gitdir, commondir);
+
+    assert_eq!(k("/repo/.git/worktrees/feature/HEAD"), PathKind::Ref);
+    assert_eq!(k("/repo/.git/worktrees/feature/index"), PathKind::State);
+    assert_eq!(k("/repo/.git/refs/heads/feature"), PathKind::Ref);
+    assert_eq!(k("/repo/.git/packed-refs"), PathKind::Ref);
+    // ...and an ordinary file in the linked worktree's own checkout.
+    assert_eq!(k("/worktrees/feature/src/main.rs"), PathKind::Worktree);
+}
+
+#[test]
+fn the_gitdir_is_matched_before_the_commondir() {
+    // They overlap — the gitdir is INSIDE the common dir for a linked worktree
+    // — so order decides. Matching commondir first would make
+    // `worktrees/feature/HEAD` a relative path of `worktrees/feature/HEAD`,
+    // which is Noise, and every branch switch in a worktree would be missed.
+    let gitdir = Path::new("/repo/.git/worktrees/feature");
+    let commondir = Path::new("/repo/.git");
+    assert_eq!(
+        classify(
+            Path::new("/repo/.git/worktrees/feature/HEAD"),
+            gitdir,
+            commondir
+        ),
+        PathKind::Ref,
+    );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Folding a batch into one event
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn a_batch_of_noise_wakes_nothing() {
+    // The npm-install case. Every path ignored or uninteresting means no
+    // event at all — not an event saying "nothing happened".
+    assert_eq!(summarize("r1", &[]), None);
+    assert_eq!(
+        summarize("r1", &[PathKind::Noise, PathKind::Noise, PathKind::Noise]),
+        None
+    );
+}
+
+#[test]
+fn a_file_save_asks_for_a_status_refresh_only() {
+    let change = summarize("r1", &[PathKind::Worktree]).expect("an event");
+    assert_eq!(change.repo_id, "r1");
+    assert!(
+        !change.refs_moved,
+        "saving a file must not repaint the graph"
+    );
+}
+
+#[test]
+fn one_ref_move_anywhere_in_the_batch_asks_for_the_log_too() {
+    // A `git commit` in a terminal writes the index, the objects and the ref.
+    // The batch is mixed, and the expensive refresh has to win.
+    let change = summarize(
+        "r1",
+        &[
+            PathKind::Noise,
+            PathKind::Worktree,
+            PathKind::State,
+            PathKind::Ref,
+        ],
+    )
+    .expect("an event");
+    assert!(change.refs_moved);
+}
+
+#[test]
+fn state_alone_is_not_a_ref_move() {
+    let change = summarize("r1", &[PathKind::State, PathKind::Noise]).expect("an event");
+    assert!(!change.refs_moved);
+}
+
+#[test]
+fn the_event_carries_the_repository_it_came_from() {
+    // Half the multi-repo guard. A watch is swapped on tab switch, but an
+    // event can already be in flight when that happens — the frontend needs
+    // this field to drop it.
+    let change = summarize("repo-7", &[PathKind::Worktree]).expect("an event");
+    assert_eq!(change.repo_id, "repo-7");
+}
+
+#[test]
+fn the_event_serialises_as_the_frontend_spells_it() {
+    // 1:1 with the TS `FsChange` in src/lib/types.ts.
+    let change = summarize("repo-7", &[PathKind::Ref]).expect("an event");
+    let json = serde_json::to_string(&change).unwrap();
+    assert!(json.contains("\"repoId\":\"repo-7\""), "{json}");
+    assert!(json.contains("\"refsMoved\":true"), "{json}");
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// The real thing, against a real repository
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn a_real_repository_reports_its_gitdir_and_commondir() {
+    // The classifier is only correct if the two paths it is handed are the
+    // ones libgit2 actually reports — including the trailing separator
+    // `Repository::path()` returns, which `strip_prefix` handles but a naive
+    // string comparison would not.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let repo = git2::Repository::init(dir.path()).expect("init");
+    let gitdir = repo.path().to_path_buf();
+    let commondir = repo.commondir().to_path_buf();
+
+    let head: PathBuf = gitdir.join("HEAD");
+    assert_eq!(classify(&head, &gitdir, &commondir), PathKind::Ref);
+
+    let file = dir.path().join("src").join("main.rs");
+    assert_eq!(classify(&file, &gitdir, &commondir), PathKind::Worktree);
+}

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -37,6 +37,7 @@ import {
   applyRebaseProgress,
   useRepoStore,
 } from "@/features/repo/useRepoStore";
+import { useFsWatch } from "@/features/repo/useFsWatch";
 import { ActivityStatus } from "@/features/repo/ActivityStatus";
 import { LoadingStatus } from "@/features/repo/LoadingStatus";
 import { primaryActivity } from "@/features/repo/repoActivity";
@@ -229,6 +230,10 @@ export function AppShell() {
       for (const sub of subs) void sub.then((un) => un()).catch(() => {});
     };
   }, []);
+
+  // The working copy stays live while the user is in another window (#239).
+  // App-global subscription inside; the watch itself follows this repository.
+  useFsWatch(repo?.id ?? null);
 
   const autoFetchEnabled = useSettingsStore((s) => s.autoFetchEnabled);
   const autoFetchMinutes = useSettingsStore((s) => s.autoFetchMinutes);

--- a/src/features/repo/fsWatchPlan.test.ts
+++ b/src/features/repo/fsWatchPlan.test.ts
@@ -1,0 +1,96 @@
+// What a filesystem event is allowed to refresh (#239).
+//
+// Four ways this can be wrong, and each of them is a real bug rather than a
+// tidiness concern: refreshing for the wrong repository writes another tab's
+// status over the open one; refreshing mid-operation reads a half-applied
+// state; repainting history on a file save makes the feature cost more than it
+// saves; and honouring an event after the setting is off breaks a promise.
+
+import { describe, expect, it } from "vitest";
+
+import type { FsChange } from "@/lib/types";
+import { fsRefreshPlan, mergeRefresh } from "./fsWatchPlan";
+
+const change = (over?: Partial<FsChange>): FsChange => ({
+  repoId: "repo-1",
+  refsMoved: false,
+  ...over,
+});
+
+const plan = (over?: Partial<Parameters<typeof fsRefreshPlan>[0]>) =>
+  fsRefreshPlan({
+    change: change(),
+    currentRepoId: "repo-1",
+    busy: false,
+    enabled: true,
+    ...over,
+  });
+
+describe("how much to refresh", () => {
+  it("a file save re-reads status only", () => {
+    // The common case by far, and the one whose cost decides whether the
+    // whole feature is worth having.
+    expect(plan()).toBe("status");
+  });
+
+  it("a ref move re-reads everything", () => {
+    // A commit or a branch switch in a terminal: the graph and the HEAD marks
+    // are now wrong, and only a full refresh fixes them.
+    expect(plan({ change: change({ refsMoved: true }) })).toBe("all");
+  });
+});
+
+describe("when to do nothing at all", () => {
+  it("drops an event for a different repository", () => {
+    // `useRepoStore` holds exactly ONE repository's state — the active tab's.
+    // Applying another tab's event would write its status over the open one.
+    expect(plan({ change: change({ repoId: "repo-2" }) })).toBe("none");
+  });
+
+  it("drops an event that arrives after the tab is closed", () => {
+    expect(plan({ currentRepoId: null })).toBe("none");
+  });
+
+  it("drops an event while an operation is in flight", () => {
+    // A rebase or a merge writes to .git/ in a storm, and a refresh landing
+    // mid-transition can read a half-applied state. Skipping loses nothing:
+    // every operation refreshes on completion anyway, so only the flicker of
+    // intermediate states is dropped, never the final one.
+    expect(plan({ busy: true })).toBe("none");
+    expect(plan({ busy: true, change: change({ refsMoved: true }) })).toBe("none");
+  });
+
+  it("drops an event still in flight when the setting was switched off", () => {
+    // The backend watch is stopped too, but an event already on its way must
+    // not sneak a refresh through — otherwise "off" is off with exceptions.
+    expect(plan({ enabled: false })).toBe("none");
+    expect(plan({ enabled: false, change: change({ refsMoved: true }) })).toBe(
+      "none",
+    );
+  });
+
+  it("checks the repository even when the setting is on and nothing is busy", () => {
+    // Guards against a future reordering that returns early on `enabled`
+    // alone.
+    expect(
+      plan({ change: change({ repoId: "other", refsMoved: true }) }),
+    ).toBe("none");
+  });
+});
+
+describe("mergeRefresh", () => {
+  it("never downgrades a pending log refresh", () => {
+    // Events arrive faster than a refresh completes on a big repository. A
+    // `status` queued behind an `all` must not turn it into a status-only one,
+    // or a branch switch during a busy save loop leaves the graph stale.
+    expect(mergeRefresh("all", "status")).toBe("all");
+    expect(mergeRefresh("status", "all")).toBe("all");
+  });
+
+  it("keeps the stronger of two", () => {
+    expect(mergeRefresh("none", "status")).toBe("status");
+    expect(mergeRefresh("status", "none")).toBe("status");
+    expect(mergeRefresh("none", "none")).toBe("none");
+    expect(mergeRefresh("all", "all")).toBe("all");
+  });
+});

--- a/src/features/repo/fsWatchPlan.ts
+++ b/src/features/repo/fsWatchPlan.ts
@@ -1,0 +1,69 @@
+// What to do about one filesystem event (#239).
+//
+// Pure and separate from the subscription so the three ways this can be wrong
+// are testable without a Tauri event bus: refreshing for the wrong repository,
+// refreshing while an operation is mid-flight, and repainting history for a
+// file save.
+
+import type { FsChange } from "@/lib/types";
+
+/** How much of the repository state one event asks to be re-read. */
+export type FsRefresh = "none" | "status" | "all";
+
+export interface FsPlanInput {
+  change: FsChange;
+  /** The active tab's repository id, or null when nothing is open. */
+  currentRepoId: string | null;
+  /**
+   * Whether a long-running operation owns the repository right now
+   * (`RepoActivity` is non-empty).
+   */
+  busy: boolean;
+  /** Whether the user has the watcher switched on. */
+  enabled: boolean;
+}
+
+/**
+ * The refresh one event earns.
+ *
+ * Four reasons to do nothing, and each is a bug if it is missing:
+ *
+ * - **The setting is off.** The backend watch is stopped too, but an event
+ *   already in flight when it stopped must not sneak a refresh through.
+ * - **No repository is open.** Nothing to refresh into.
+ * - **A different repository.** `useRepoStore` holds exactly ONE repository's
+ *   state — the active tab's — so applying another tab's event would write its
+ *   status over the open one. The backend watches only the active repo, but an
+ *   event can already be in flight when the tab switches, which is precisely
+ *   why the payload carries `repoId`.
+ * - **An operation is in flight.** A rebase or a merge writes to `.git/` in a
+ *   storm, and a refresh landing mid-transition can read a half-applied state.
+ *   Skipping is safe rather than lossy: every operation refreshes on
+ *   completion anyway, so the final state is never missed — only the flicker
+ *   of intermediate ones.
+ */
+export function fsRefreshPlan({
+  change,
+  currentRepoId,
+  busy,
+  enabled,
+}: FsPlanInput): FsRefresh {
+  if (!enabled) return "none";
+  if (!currentRepoId) return "none";
+  if (change.repoId !== currentRepoId) return "none";
+  if (busy) return "none";
+  return change.refsMoved ? "all" : "status";
+}
+
+/**
+ * Fold two pending refreshes into the one that covers both.
+ *
+ * Events arrive faster than a refresh completes on a big repository, so the
+ * second one waits — and it must not downgrade the first. A `status` arriving
+ * behind an `all` still needs the log re-read.
+ */
+export function mergeRefresh(a: FsRefresh, b: FsRefresh): FsRefresh {
+  if (a === "all" || b === "all") return "all";
+  if (a === "status" || b === "status") return "status";
+  return "none";
+}

--- a/src/features/repo/useFsWatch.test.tsx
+++ b/src/features/repo/useFsWatch.test.tsx
@@ -1,0 +1,132 @@
+// The watcher's wiring (#239): the watch follows the repository and the
+// setting, and an event refreshes the right amount.
+//
+// `fsWatchPlan.test.ts` pins the DECISION. This file pins that the decision is
+// actually reached — that the subscription exists, that the backend is told
+// which repository to watch, and that turning the setting off really stops it.
+// A correct policy nobody calls is the failure these tests exist to catch.
+
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { emitMockEvent, resetEventMock } from "@/test/eventMock";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import type { FsChange } from "@/lib/types";
+
+import { useFsWatch } from "./useFsWatch";
+import { useRepoStore } from "./useRepoStore";
+
+function Probe({ repoId }: { repoId: string | null }) {
+  useFsWatch(repoId);
+  return null;
+}
+
+const calls = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+
+const refreshAll = vi.fn();
+const refreshStatus = vi.fn();
+
+function setRepo(id: string | null, activity: Record<string, unknown> = {}) {
+  useRepoStore.setState({
+    current: id ? { id, path: "/repo", head: "refs/heads/main" } : null,
+    activity,
+    refreshAll,
+    refreshStatus,
+  } as never);
+}
+
+const fire = (over?: Partial<FsChange>) =>
+  emitMockEvent("fs://changed", {
+    repoId: "repo-1",
+    refsMoved: false,
+    ...over,
+  } satisfies FsChange);
+
+beforeEach(() => {
+  resetInvokeMock();
+  resetEventMock();
+  refreshAll.mockReset().mockResolvedValue(undefined);
+  refreshStatus.mockReset().mockResolvedValue(undefined);
+  mockInvoke("watch_repo", () => null);
+  mockInvoke("watch_stop", () => null);
+  useSettingsStore.getState().reset();
+  setRepo("repo-1");
+});
+
+describe("starting and stopping the watch", () => {
+  it("watches the open repository", async () => {
+    render(<Probe repoId="repo-1" />);
+    await waitFor(() => expect(calls("watch_repo")).toHaveLength(1));
+    expect(calls("watch_repo")[0].args.repoId).toBe("repo-1");
+  });
+
+  it("does not watch when the setting is off, and stops any running watch", async () => {
+    useSettingsStore.getState().set("watchFilesystem", false);
+    render(<Probe repoId="repo-1" />);
+    await waitFor(() => expect(calls("watch_stop").length).toBeGreaterThan(0));
+    expect(calls("watch_repo")).toHaveLength(0);
+  });
+
+  it("does not watch when no repository is open", async () => {
+    render(<Probe repoId={null} />);
+    await waitFor(() => expect(calls("watch_stop").length).toBeGreaterThan(0));
+    expect(calls("watch_repo")).toHaveLength(0);
+  });
+
+  it("stops watching when the component goes away", async () => {
+    const { unmount } = render(<Probe repoId="repo-1" />);
+    await waitFor(() => expect(calls("watch_repo")).toHaveLength(1));
+    unmount();
+    await waitFor(() => expect(calls("watch_stop").length).toBeGreaterThan(0));
+  });
+});
+
+describe("what an event does", () => {
+  it("refreshes status for a working-copy change", async () => {
+    render(<Probe repoId="repo-1" />);
+    await waitFor(() => expect(calls("watch_repo")).toHaveLength(1));
+    fire();
+    await waitFor(() => expect(refreshStatus).toHaveBeenCalledTimes(1));
+    expect(refreshAll).not.toHaveBeenCalled();
+  });
+
+  it("refreshes everything when a ref moved", async () => {
+    render(<Probe repoId="repo-1" />);
+    await waitFor(() => expect(calls("watch_repo")).toHaveLength(1));
+    fire({ refsMoved: true });
+    await waitFor(() => expect(refreshAll).toHaveBeenCalledTimes(1));
+  });
+
+  it("ignores an event for another repository", async () => {
+    // The half of the multi-repo guard a single-slot watcher cannot provide:
+    // the tab switched while this event was already in flight.
+    render(<Probe repoId="repo-1" />);
+    await waitFor(() => expect(calls("watch_repo")).toHaveLength(1));
+    fire({ repoId: "repo-2", refsMoved: true });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(refreshStatus).not.toHaveBeenCalled();
+    expect(refreshAll).not.toHaveBeenCalled();
+  });
+
+  it("ignores an event while an operation is in flight", async () => {
+    setRepo("repo-1", { rebase: { label: "Rebasing" } });
+    render(<Probe repoId="repo-1" />);
+    await waitFor(() => expect(calls("watch_repo")).toHaveLength(1));
+    fire({ refsMoved: true });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(refreshAll).not.toHaveBeenCalled();
+  });
+
+  it("survives a refresh that throws, and keeps working afterwards", async () => {
+    // A background refresh must not raise a banner the user cannot connect to
+    // anything they did — but it must also not wedge the listener.
+    refreshStatus.mockRejectedValueOnce(new Error("boom"));
+    render(<Probe repoId="repo-1" />);
+    await waitFor(() => expect(calls("watch_repo")).toHaveLength(1));
+    fire();
+    await waitFor(() => expect(refreshStatus).toHaveBeenCalledTimes(1));
+    fire();
+    await waitFor(() => expect(refreshStatus).toHaveBeenCalledTimes(2));
+  });
+});

--- a/src/features/repo/useFsWatch.ts
+++ b/src/features/repo/useFsWatch.ts
@@ -1,0 +1,100 @@
+// Keep the working copy live (#239).
+//
+// Two effects with different lifetimes, and keeping them apart is the point:
+//
+//   1. The SUBSCRIPTION is app-global and mounted once, like `net://progress`.
+//      Re-subscribing per repository would open a window on every tab switch
+//      where events are silently dropped.
+//   2. The WATCH follows the active repository and the setting. Starting it is
+//      a swap on the backend, so a tab switch needs no matching stop.
+
+import * as React from "react";
+import { listen } from "@tauri-apps/api/event";
+
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { watchRepo, watchStop } from "@/lib/tauri";
+import type { FsChange } from "@/lib/types";
+
+import { fsRefreshPlan, mergeRefresh, type FsRefresh } from "./fsWatchPlan";
+import { useRepoStore } from "./useRepoStore";
+
+/**
+ * Subscribe to `fs://changed` and refresh what it asks for.
+ *
+ * Mounted once from `AppShell`.
+ */
+export function useFsWatch(repoId: string | null): void {
+  const enabled = useSettingsStore((s) => s.watchFilesystem);
+
+  // A refresh in flight, and what to run after it. Refs rather than state:
+  // these coordinate async work and must never cause a render of their own —
+  // a re-render here would remount nothing but would re-run the effect below
+  // and churn the backend watch.
+  const running = React.useRef(false);
+  const pending = React.useRef<FsRefresh>("none");
+
+  const run = React.useCallback(async (what: FsRefresh) => {
+    if (what === "none") return;
+    if (running.current) {
+      // Coalesce rather than queue. A burst produces at most one more refresh
+      // after the current one, and `mergeRefresh` keeps it from downgrading a
+      // pending log refresh to a status-only one.
+      pending.current = mergeRefresh(pending.current, what);
+      return;
+    }
+    running.current = true;
+    try {
+      const store = useRepoStore.getState();
+      if (what === "all") await store.refreshAll();
+      else await store.refreshStatus();
+    } catch {
+      // A background refresh must not raise a banner. The user did not ask for
+      // this one, and whatever is wrong will surface loudly the moment they do
+      // ask for something — with an error that names an action they took.
+    } finally {
+      running.current = false;
+      const next = pending.current;
+      pending.current = "none";
+      if (next !== "none") void run(next);
+    }
+  }, []);
+
+  // 1. The subscription — once, for the app's lifetime.
+  React.useEffect(() => {
+    const sub = listen<FsChange>("fs://changed", (e) => {
+      const s = useRepoStore.getState();
+      void run(
+        fsRefreshPlan({
+          change: e.payload,
+          currentRepoId: s.current?.id ?? null,
+          // `activity` is what the status line and the Cancel button are
+          // driven from, so "the app is doing something" and "do not refresh
+          // under it" cannot drift apart.
+          busy: Object.keys(s.activity).length > 0,
+          enabled: useSettingsStore.getState().watchFilesystem,
+        }),
+      );
+    });
+    return () => {
+      void sub.then((un) => un()).catch(() => {});
+    };
+  }, [run]);
+
+  // 2. The watch itself — follows the repository and the setting.
+  React.useEffect(() => {
+    if (!enabled || !repoId) {
+      // Stopping unconditionally rather than only when one was started: this
+      // also covers the setting being switched off, and `watch_stop` is
+      // idempotent precisely so the caller does not have to track that.
+      void watchStop().catch(() => {});
+      return;
+    }
+    void watchRepo(repoId).catch(() => {
+      // A watch that cannot start is a degradation, not a failure — the app is
+      // still correct, just not live. The backend has already logged why.
+    });
+    return () => {
+      void watchStop().catch(() => {});
+    };
+  }, [enabled, repoId]);
+}

--- a/src/features/settings/useSettingsStore.export.test.ts
+++ b/src/features/settings/useSettingsStore.export.test.ts
@@ -87,6 +87,11 @@ const PORTABLE = [
   // `updateCheckMode` beside it made.
   "updateChannel",
   "updateCheckMode",
+  // The filesystem watcher (#239). Portable: whether you want the app to
+  // notice outside edits is a preference, not a fact about this machine.
+  // Someone who turns it off for a network mount will want it off on the
+  // next network mount too.
+  "watchFilesystem",
 ];
 
 /** Machine-specific, so deliberately absent from an export. */

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -879,6 +879,17 @@ interface PersistedState {
    * would want to import. It lives beside `dismissedVersion` in the update
    * store's own localStorage key.
    */
+  /**
+   * Whether the app watches the working copy so it stays live (#239).
+   *
+   * Default ON: the app being right without being asked is the point, and the
+   * watcher is ignore-aware so a `target/` or `node_modules/` write costs
+   * nothing. Off is for the cases where an OS watch is genuinely the wrong
+   * tool — a network mount where recursive watching is expensive or
+   * unsupported, or a repository large enough that the user would rather
+   * refresh by hand than pay for it.
+   */
+  watchFilesystem: boolean;
   updateCheckMode: UpdateCheckMode;
   /**
    * Which releases update checks consider — see UpdateChannel.
@@ -979,6 +990,7 @@ const DEFAULTS: PersistedState = {
   diffContextMode: "wholeFile",
   ignoreWhitespaceInDiff: false,
   externalDiffTool: "",
+  watchFilesystem: true,
   updateCheckMode: "auto",
   updateChannel: "stable",
   lastCreateDir: "",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1388,6 +1388,20 @@ export function getUpdateCapability(): Promise<UpdateCapability> {
   return invoke<UpdateCapability>("get_update_capability");
 }
 
+/**
+ * Watch this repository's working directory for changes (#239), replacing any
+ * existing watch. Only the ACTIVE repository is watched — a second call is a
+ * swap, not an addition, so a tab switch needs no matching stop.
+ */
+export function watchRepo(repoId: string): Promise<void> {
+  return invoke<void>("watch_repo", { repoId });
+}
+
+/** Stop watching. Idempotent — safe to call without knowing whether a watch is running. */
+export function watchStop(): Promise<void> {
+  return invoke<void>("watch_stop");
+}
+
 export function openUrl(url: string): Promise<void> {
   return invoke("open_url", { url });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -632,6 +632,25 @@ export interface CliInstallOutcome {
  */
 export type UpdateChannel = "stable" | "prerelease";
 
+/**
+ * One coalesced filesystem change (#239). Mirrors Rust `watcher.rs::FsChange`.
+ *
+ * One event per debounce batch, never per file, and always tagged with the
+ * repository it came from — a watch is swapped on tab switch, but an event can
+ * already be in flight when that happens, so the listener drops anything that
+ * is not the active tab's.
+ */
+export interface FsChange {
+  repoId: string;
+  /**
+   * A ref moved, so the log and branch list need re-reading too. `false` means
+   * a status refresh is enough — the distinction is the whole reason the
+   * backend classifies rather than just saying "something changed": repainting
+   * history on every file save would make the feature cost more than it saves.
+   */
+  refsMoved: boolean;
+}
+
 export interface UpdateInfo {
   available: boolean;
   currentVersion: string;

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -149,6 +149,17 @@ export function SettingsScreen() {
             }
           />
           <Row
+            label="Watch the working copy"
+            hint="Notice edits made outside the app — in your editor or a terminal — and keep the file list and history up to date without a manual refresh. Ignored files are skipped, so a build directory costs nothing."
+            control={
+              <PGToggle
+                data-testid="watch-filesystem"
+                checked={s.watchFilesystem}
+                onChange={(v) => s.set("watchFilesystem", v)}
+              />
+            }
+          />
+          <Row
             label="Auto-fetch"
             hint="Periodically run fetch in the background so ahead/behind counts stay fresh."
             control={


### PR DESCRIPTION
Closes #239.

Save a file in your editor, tab back, and the status is already right. Until now the app was only correct if you remembered to refresh — the only self-starting refresh was the auto-fetch timer, which is a *network* fetch on a minutes-scale interval and does not run at all when auto-fetch is off.

`notify-debouncer-mini` around a `RecommendedWatcher`, **one** live watch on the active repository. A second `watch_repo` replaces rather than stacks, so a tab switch needs no matching stop.

## The value is in what it drops

A watcher that reports everything is *worse* than no watcher on a large repository: `cargo build` and `npm install` each touch tens of thousands of ignored files, and every one would be a `git status`. So `classify` sorts each path and most of the test file is negative assertions:

| Kind | Examples | Refresh |
|---|---|---|
| `Ref` | `HEAD`, `refs/**`, `packed-refs` | status **+ log** |
| `State` | `index`, `MERGE_HEAD`, `rebase-merge/**` | status |
| `Worktree` | an ordinary file, if not ignored | status |
| `Noise` | `*.lock`, `objects/`, `logs/`, `COMMIT_EDITMSG`, `FETCH_HEAD` | none |

`.lock` files are `Noise` because they are git **starting** work, not finishing it — honouring them would double every event *and* fire the first one while the index is still being written, so a refresh would read a half-written index. Objects are `Noise` because they are written before the ref that points at them; acting on them would refresh to a state no ref names yet.

## Three decisions worth reviewing

**`classify` takes both the gitdir and the commondir, and tries them in that order.** In a linked worktree `HEAD` and `index` live in the worktree's own gitdir while `refs/` lives in the shared commondir — and the gitdir is *inside* the commondir. Matching the commondir first would classify `worktrees/feature/HEAD` as `Noise` and miss every branch switch in a worktree. This app creates worktrees, so that is not hypothetical; there is a test named for it.

**The ignore check does not take the per-repo mutex.** The issue asked for `spawn_blocking` behind it, and the constraint it protects — `git2::Repository` is `Send` but not `Sync` — is real. This satisfies it differently: the watcher owns its *own* handle, opened once on the debouncer's thread and never shared, so the handle never crosses threads. Taking the shared mutex would be worse for the case that matters most — a rebase holds it while producing exactly the event storm this has to filter, so the watcher would queue behind the operation, wake when it finished, and do its work twice. On a slow filesystem (a `/mnt/c` repo under WSL) it would add ignore reads to a mutex that is already the bottleneck. Two independent libgit2 handles on one repository are ordinary; this one only asks read-only questions. **Happy to change this if you'd rather follow the issue literally.**

**Both halves of the multi-repo guard are present**, because they fail differently: watching only the active repo keeps N−1 watchers off the filesystem, and tagging the event with `repoId` lets the frontend drop one that arrives *after* a tab switch — a race a single-slot watcher alone cannot close.

## Frontend

`fsWatchPlan` is pure and separate from the subscription, and returns `none` for four distinct reasons — each a real bug if missing:

- **another repository's event** — `useRepoStore` holds exactly one repository's state, so applying another tab's event writes its status over the open one;
- **an operation in flight** — a refresh landing mid-rebase can read a half-applied state. Skipping loses nothing: every operation refreshes on completion, so only the flicker of intermediate states is dropped;
- **a file save** does not get the log refresh;
- **an event after the setting is off** — otherwise "off" is off with exceptions.

`useFsWatch` mounts two effects with different lifetimes on purpose: the subscription is app-global and mounted once (like `net://progress` — re-subscribing per repository opens a window on every tab switch where events are dropped), while the watch follows the repository and the setting. Refreshes coalesce rather than queue, and `mergeRefresh` keeps a queued `status` from downgrading a pending `all`.

The refresh deliberately does **not** join `RepoActivity` — that is for operations the user started and can cancel, and a status line flickering on every keystroke in someone's editor would be noise. It *reads* `RepoActivity` instead, to know when to stay out of the way.

Settings toggle, default on.

## Tests

- `src-tauri/tests/watcher.rs` — 17 new, mostly negative: lock files, the object database, the reflog, editor scratch files; the linked-worktree case and the gitdir-before-commondir ordering; batch folding; the serde spelling matching the TS type; one against a real `git2::Repository` so the classifier is checked against the paths libgit2 actually reports (including the trailing separator `path()` returns).
- `src/features/repo/fsWatchPlan.test.ts` + `useFsWatch.test.tsx` — 18 new: the policy, and that the policy is actually reached (a correct policy nobody calls is the failure these catch).
- Green: `pnpm test` (2755 passed), full `cargo test`, `pnpm tsc --noEmit`.

New dependency: `notify` 8.2 / `notify-debouncer-mini` 0.7. Neither is an analytics or HTTP crate, so `no_telemetry.rs` and `privacy.test.ts` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
