### PR TITLE
feat(repo): undo the last operation with Mod+Z (#242)

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -446,6 +446,54 @@ const composer = useCommitComposer({ repoId, branch, ticketPattern, message, set
 - Composes with what was already there: sign-off, co-author / author-override
   and recent-message recall all still read and write the same box.
 
+## Undo the last operation (#242)
+
+`features/repo/undoStack.ts` is the whole model, and it is deliberately small:
+an entry is a **before/after pair of HEAD snapshots** plus what produced them.
+Undo moves HEAD from `after` back to `before`; redo moves it forward. It does
+not replay operations backwards, it moves a ref — git keeps the old commits
+reachable through the reflog, so undoing a commit costs and loses nothing.
+
+`undoStack` + `undoCursor` live in `RepoSlice`, so the stack is per repository
+and a tab switch cannot carry it. Session-scoped rather than persisted on
+purpose: an entry is only meaningful while the recorded HEAD is still where the
+operation left it, so a stack restored from disk would mostly be entries that
+refuse. The reflog is the durable answer, and the refusals say so.
+
+**What pushes an entry:** the operations that move HEAD — commit (including
+amend), checkout, merge, cherry-pick, revert, reset. `noteUndo` is called after
+the op's own `refreshAll()`, and is guarded on the repository the way
+`setErrorFor` is, so an op resolving after a tab switch writes nothing.
+`pushUndo` drops an entry whose before and after are identical, so a checkout
+of the branch you are already on records nothing rather than an entry ⌘Z would
+appear to apply and then not.
+
+**What does not, and why the absence is the safe failure:** a push (the remote
+has it, and rewriting someone else's history is not an undo), a dropped stash,
+branch create/delete/rename (they move a ref that is not HEAD and need their own
+inverse), and rebase (its own engine, its own retained summary; folding it in
+without thinking through an interrupted plan would be an undo that lies).
+Anything absent simply records nothing, so ⌘Z undoes the last thing that *is*
+undoable.
+
+**Preconditions are re-read from the backend at undo time**, never from cached
+state: `head_info` plus a fresh status. The paged log can never answer "is HEAD
+still where I left it". On a mismatch it refuses and changes nothing, with a
+message that names the operation and points at the reflog.
+
+A refusal is **not** an `AppError`. Nothing was attempted, the TS union stays
+1:1 with the Rust enum, and there is no variant for a frontend-only condition —
+so it is a `pgFlash`, the way `ops.ts` already refuses "no upstream".
+
+**The confirmation lives in `ops.ts`, not the store**, matching
+`deleteUntracked`: the store is also the layer a keyboard shortcut reaches, so
+it performs and does not ask. The store then re-checks preconditions *after*
+the dialog is answered, because the world can move while it is open.
+
+`undoOp`/`redoOp` answer **synchronously** and return `false` when the stack is
+empty — that is what keeps `Mod+Z` from being stolen from every text field in
+the app; the chord falls through and still undoes typing.
+
 ## The log is paged (#68 G11)
 
 - **`s.commits` is a PREFIX of history** (`PAGE_SIZE = 500`, appended;

--- a/src/features/keymap/actions.ts
+++ b/src/features/keymap/actions.ts
@@ -21,9 +21,11 @@ import {
   openRepoOp,
   pullCurrentOp,
   pushCurrentOp,
+  redoOp,
   refreshOp,
   resolveConflictsOp,
   stageAllOp,
+  undoOp,
   unstageAllOp,
 } from "@/features/repo/ops";
 import { useRepoStore } from "@/features/repo/useRepoStore";
@@ -82,6 +84,8 @@ export type ActionId =
   | "repo.fetch"
   | "repo.pull"
   | "repo.push"
+  | "repo.undo"
+  | "repo.redo"
   | "repo.refresh"
   | "repo.stageAll"
   | "repo.unstageAll"
@@ -402,6 +406,13 @@ export const ACTIONS: Record<ActionId, ActionDef> = {
   "repo.fetch": { id: "repo.fetch", title: "Fetch all remotes", category: "Repository", scope: "global", run: fetchAllOp },
   "repo.pull": { id: "repo.pull", title: "Pull (update project)", category: "Repository", scope: "global", run: pullCurrentOp },
   "repo.push": { id: "repo.push", title: "Push", category: "Repository", scope: "global", run: pushCurrentOp },
+  // Undo/redo name the operation at DISPATCH time (the ops read the stack), so
+  // the palette row here carries the generic title and the confirmation says
+  // "Undo merge of feat/x?". Both runners return false when there is nothing to
+  // undo, which lets Mod+Z fall through to the browser and still undo typing in
+  // a text field — the behaviour anyone would expect from that chord.
+  "repo.undo": { id: "repo.undo", title: "Undo last operation", category: "Repository", scope: "global", run: undoOp },
+  "repo.redo": { id: "repo.redo", title: "Redo last undone operation", category: "Repository", scope: "global", run: redoOp },
   "repo.refresh": { id: "repo.refresh", title: "Refresh repository", category: "Repository", scope: "global", run: refreshOp },
   "repo.stageAll": { id: "repo.stageAll", title: "Stage all changes", category: "Repository", scope: "global", run: stageAllOp },
   "repo.unstageAll": { id: "repo.unstageAll", title: "Unstage all changes", category: "Repository", scope: "global", run: unstageAllOp },

--- a/src/features/keymap/presets.ts
+++ b/src/features/keymap/presets.ts
@@ -28,6 +28,11 @@ const POWER_SHORTCUTS = {
   "commit.commit": ["Mod+Enter"],
   "commit.commitAndPush": ["Mod+Shift+Enter"],
   "commit.toggleAmend": ["Mod+Shift+M"],
+  // The chord everyone already reaches for when they have just done the wrong
+  // thing. Both runners decline when the stack is empty, so this does not steal
+  // Mod+Z from text fields.
+  "repo.undo": ["Mod+Z"],
+  "repo.redo": ["Mod+Shift+Z"],
   "repo.stageAll": ["Mod+Shift+S"],
   "repo.unstageAll": ["Mod+Shift+U"],
   "branch.createNew": ["Mod+N"],

--- a/src/features/repo/ops.ts
+++ b/src/features/repo/ops.ts
@@ -5,7 +5,7 @@
 
 import { open } from "@tauri-apps/plugin-dialog";
 import { error as logError } from "@tauri-apps/plugin-log";
-import { pgFlash } from "@/design";
+import { pgConfirm, pgFlash } from "@/design";
 import { describeError } from "@/lib/errors";
 import { useCreateStore } from "@/features/create/useCreateStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
@@ -13,6 +13,14 @@ import { openMergeWindow } from "@/features/merge/openMergeWindow";
 import { currentBranch, isConflicted, isStaged, isUnstaged } from "@/lib/derive";
 import type { FileStatus } from "@/lib/types";
 import { useRepoStore } from "./useRepoStore";
+import {
+  describeUndo,
+  needsConfirm,
+  redoable,
+  shortOid,
+  undoable,
+  type UndoDirection,
+} from "./undoStack";
 import { useTabsStore } from "./useTabsStore";
 
 /** Derive the [remote, branch] pair from the HEAD branch's upstream tracking ref. */
@@ -182,5 +190,64 @@ export function resolveConflictsOp(): boolean {
     return true;
   }
   void openMergeWindow(repo.current.id);
+  return true;
+}
+
+/**
+ * Undo (or redo) the last recorded operation (#242).
+ *
+ * The confirmation lives HERE rather than in the store, matching
+ * `deleteUntracked`: the store is also the layer a keyboard shortcut reaches,
+ * so it performs and does not ask. The store re-checks preconditions after
+ * this dialog is answered, because the world can move while it is open.
+ *
+ * The dialog names the operation — "Undo merge of feat/x?", never a bare
+ * "Undo". Knowing what is about to happen is the entire point of the feature:
+ * an undo you cannot predict is another way to lose work.
+ */
+async function applyUndoOp(direction: UndoDirection): Promise<void> {
+  const s = useRepoStore.getState();
+  const entry = direction === "undo" ? undoable(s) : redoable(s);
+  // The synchronous runners above already established there is one; this
+  // re-read is what makes the function safe to call on its own.
+  if (!s.current || !entry) return;
+
+  if (needsConfirm(entry)) {
+    const verb = direction === "undo" ? "Undo" : "Redo";
+    const target = direction === "undo" ? entry.before : entry.after;
+    const ok = await pgConfirm({
+      title: `${describeUndo(entry, direction)}?`,
+      body:
+        `This moves the branch to ${shortOid(target.oid)} and resets the working ` +
+        `copy to match. Nothing is deleted — the commits stay reachable through ` +
+        `the reflog.`,
+      confirmLabel: verb,
+      danger: true,
+    });
+    if (!ok) return;
+  }
+
+  await useRepoStore.getState().applyUndo(direction);
+}
+
+/**
+ * Both runners answer SYNCHRONOUSLY, like every other op here: the dispatcher
+ * needs to know immediately whether the action was claimed.
+ *
+ * Declining when the stack is empty is what keeps `Mod+Z` from being stolen
+ * from text fields — the chord falls through to the browser and still undoes
+ * typing, which is the behaviour anyone pressing it in a message box expects.
+ */
+export function undoOp(): boolean {
+  const s = useRepoStore.getState();
+  if (!s.current || !undoable(s)) return false;
+  void applyUndoOp("undo");
+  return true;
+}
+
+export function redoOp(): boolean {
+  const s = useRepoStore.getState();
+  if (!s.current || !redoable(s)) return false;
+  void applyUndoOp("redo");
   return true;
 }

--- a/src/features/repo/ops.undo.test.tsx
+++ b/src/features/repo/ops.undo.test.tsx
@@ -1,0 +1,157 @@
+// The undo/redo op runners (#242).
+//
+// Two things only this layer can get wrong: whether ⌘Z is CLAIMED (a runner
+// that always returns true steals the chord from every text field in the app),
+// and whether the hard kinds are confirmed before anything moves.
+
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  WithDialogs,
+  acceptDialog,
+  dialogIsOpen,
+  dialogTitle,
+  dismissDialog,
+  resetDialogs,
+} from "@/test/dialog";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+
+import { redoOp, undoOp } from "./ops";
+import { emptyUndo, type UndoEntry } from "./undoStack";
+import { useRepoStore } from "./useRepoStore";
+
+const HEAD = { branch: "refs/heads/main", headOid: "bbbb2222" };
+
+function mockRefresh() {
+  for (const cmd of [
+    "get_status",
+    "list_branches",
+    "list_tags",
+    "list_stashes",
+    "list_remotes",
+  ]) {
+    mockInvoke(cmd, () => []);
+  }
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("head_info", () => HEAD);
+  mockInvoke("rebase_status", () => ({
+    inProgress: false,
+    nextIndex: 0,
+    total: 0,
+    pauseReason: null,
+  }));
+  mockInvoke("shallow_info", () => ({
+    shallow: false,
+    boundaryCount: 0,
+    singleBranch: false,
+  }));
+  mockInvoke("reset", () => undefined);
+  mockInvoke("checkout_ref", () => undefined);
+}
+
+const entry = (over: Partial<UndoEntry> = {}): UndoEntry => ({
+  id: "e1",
+  kind: "merge",
+  label: "merge of feat/x",
+  before: { ref: "refs/heads/main", oid: "aaaa1111" },
+  after: { ref: "refs/heads/main", oid: "bbbb2222" },
+  ...over,
+});
+
+function seed(stack: UndoEntry[], cursor = stack.length) {
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    error: null,
+    status: [],
+    headInfo: HEAD,
+    undoStack: stack,
+    undoCursor: cursor,
+  } as never);
+}
+
+const cmds = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+
+beforeEach(() => {
+  resetInvokeMock();
+  resetDialogs();
+  mockRefresh();
+  useRepoStore.setState({ current: null, ...emptyUndo() } as never);
+});
+
+describe("claiming the chord", () => {
+  it("declines with nothing to undo, so Mod+Z still undoes typing", () => {
+    // The whole reason this returns a boolean. A runner that always claimed
+    // the chord would break text editing everywhere in the app.
+    seed([]);
+    expect(undoOp()).toBe(false);
+    expect(redoOp()).toBe(false);
+  });
+
+  it("declines with no repository open", () => {
+    useRepoStore.setState({ current: null, ...emptyUndo() } as never);
+    expect(undoOp()).toBe(false);
+  });
+
+  it("claims the chord when there is something to undo", () => {
+    seed([entry()]);
+    expect(undoOp()).toBe(true);
+  });
+
+  it("redo declines until something has been undone", () => {
+    seed([entry()]);
+    expect(redoOp()).toBe(false);
+    seed([entry()], 0);
+    expect(redoOp()).toBe(true);
+  });
+});
+
+describe("confirming the destructive kinds", () => {
+  it("names the operation in the dialog, never a bare Undo", async () => {
+    render(<WithDialogs>{null}</WithDialogs>);
+    seed([entry()]);
+    undoOp();
+    await waitFor(() => expect(dialogIsOpen()).toBe(true));
+    expect(dialogTitle()).toBe("Undo merge of feat/x?");
+  });
+
+  it("does nothing when the confirmation is dismissed", async () => {
+    render(<WithDialogs>{null}</WithDialogs>);
+    seed([entry()]);
+    undoOp();
+    await waitFor(() => expect(dialogIsOpen()).toBe(true));
+    await dismissDialog();
+    expect(cmds("reset")).toHaveLength(0);
+    expect(useRepoStore.getState().undoCursor).toBe(1);
+  });
+
+  it("proceeds when it is accepted", async () => {
+    render(<WithDialogs>{null}</WithDialogs>);
+    seed([entry()]);
+    undoOp();
+    await waitFor(() => expect(dialogIsOpen()).toBe(true));
+    await acceptDialog();
+    await waitFor(() => expect(cmds("reset")).toHaveLength(1));
+    expect(cmds("reset")[0].args.target).toBe("aaaa1111");
+  });
+
+  it("does NOT confirm a checkout — it discards nothing", async () => {
+    render(<WithDialogs>{null}</WithDialogs>);
+    seed([entry({ kind: "checkout", label: "switch to feat/x" })]);
+    undoOp();
+    await waitFor(() => expect(cmds("checkout_ref")).toHaveLength(1));
+    expect(dialogIsOpen()).toBe(false);
+  });
+
+  it("says the commits are not lost", async () => {
+    // The confirmation exists because a commit is about to stop being on a
+    // branch — not because anything is deleted. Saying so is what keeps the
+    // dialog from reading scarier than the operation is.
+    render(<WithDialogs>{null}</WithDialogs>);
+    seed([entry()]);
+    undoOp();
+    await waitFor(() => expect(dialogIsOpen()).toBe(true));
+    expect(document.body.textContent).toContain("reflog");
+  });
+});

--- a/src/features/repo/repoSlice.ts
+++ b/src/features/repo/repoSlice.ts
@@ -41,6 +41,7 @@ import { LOG_REF_ALL } from "@/lib/types";
 import type { AppError, HookRejection } from "@/lib/errors";
 import type { RepoActivity } from "./repoActivity";
 import type { LoadingTask } from "./loadingTasks";
+import { emptyUndo, type UndoEntry } from "./undoStack";
 
 export const DEFAULT_REBASE_STATUS: RebaseStatus = {
   inProgress: false,
@@ -192,6 +193,22 @@ export interface RepoSlice {
    * banner reading "NoSignature" and no way to fix it from inside the app.
    */
   noSignature: boolean;
+  /**
+   * Operations that can be undone in this repository (#242), oldest first.
+   *
+   * Per-repo, and therefore here: ⌘Z in one tab must never undo something that
+   * happened in another. Session-scoped by design rather than persisted — an
+   * entry is only meaningful while the recorded HEAD is still where the
+   * operation left it, and a stack restored from disk would mostly be entries
+   * that refuse. The reflog is the durable answer, and the refusals point at
+   * it.
+   */
+  undoStack: UndoEntry[];
+  /**
+   * How many entries are still "done" — the index of the next one to undo.
+   * Equal to `undoStack.length` when nothing has been undone. See undoStack.ts.
+   */
+  undoCursor: number;
 }
 
 /**
@@ -231,6 +248,7 @@ export function emptySlice(): RepoSlice {
     cancelRequested: false,
     hookRejection: null,
     noSignature: false,
+    ...emptyUndo(),
   };
 }
 

--- a/src/features/repo/undoStack.test.ts
+++ b/src/features/repo/undoStack.test.ts
@@ -1,0 +1,267 @@
+// The undo model (#242).
+//
+// An undo that silently does the wrong thing is worse than no undo, so most of
+// this file is about REFUSING: the world moved, the tree is dirty, there is
+// nothing to undo. The happy path is one line; the honesty is the feature.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  HARD_KINDS,
+  UNDO_LIMIT,
+  checkUndo,
+  describeUndo,
+  emptyUndo,
+  expectedOf,
+  needsConfirm,
+  pushUndo,
+  quoteSubject,
+  redoable,
+  shortOid,
+  targetOf,
+  undoable,
+  type UndoEntry,
+  type UndoKind,
+  type UndoState,
+} from "./undoStack";
+
+let seq = 0;
+const entry = (over: Partial<UndoEntry> = {}): UndoEntry => ({
+  id: `e${++seq}`,
+  kind: "commit",
+  label: 'commit "fix: thing"',
+  before: { ref: "refs/heads/main", oid: "aaaa1111" },
+  after: { ref: "refs/heads/main", oid: "bbbb2222" },
+  ...over,
+});
+
+const stateWith = (...entries: UndoEntry[]): UndoState =>
+  entries.reduce((s, e) => pushUndo(s, e), emptyUndo());
+
+describe("recording operations", () => {
+  it("starts empty", () => {
+    const s = emptyUndo();
+    expect(undoable(s)).toBeNull();
+    expect(redoable(s)).toBeNull();
+  });
+
+  it("makes the newest operation the one to undo", () => {
+    const a = entry({ label: "merge of feat/x" });
+    const b = entry({
+      label: "commit “second”",
+      before: a.after,
+      after: { ref: "refs/heads/main", oid: "cccc3333" },
+    });
+    const s = stateWith(a, b);
+    expect(undoable(s)?.label).toBe("commit “second”");
+  });
+
+  it("records nothing when HEAD did not actually move", () => {
+    // Checking out the branch you are already on. An entry here would make ⌘Z
+    // appear to do something and then do nothing — the behaviour that makes
+    // people stop trusting undo.
+    const s = pushUndo(
+      emptyUndo(),
+      entry({
+        kind: "checkout",
+        before: { ref: "refs/heads/main", oid: "aaaa1111" },
+        after: { ref: "refs/heads/main", oid: "aaaa1111" },
+      }),
+    );
+    expect(s.undoStack).toHaveLength(0);
+  });
+
+  it("records a detach even though the commit is the same", () => {
+    // Same oid, different ref: `main` vs detached at main's tip is a real
+    // state change, and undoing it has to put you back ON the branch.
+    const s = pushUndo(
+      emptyUndo(),
+      entry({
+        kind: "checkout",
+        before: { ref: "refs/heads/main", oid: "aaaa1111" },
+        after: { ref: null, oid: "aaaa1111" },
+      }),
+    );
+    expect(s.undoStack).toHaveLength(1);
+  });
+
+  it("is bounded, dropping the OLDEST", () => {
+    let s = emptyUndo();
+    for (let i = 0; i < UNDO_LIMIT + 5; i++) {
+      s = pushUndo(
+        s,
+        entry({ label: `op ${i}`, after: { ref: "refs/heads/main", oid: `oid${i}` } }),
+      );
+    }
+    expect(s.undoStack).toHaveLength(UNDO_LIMIT);
+    expect(s.undoStack[0]?.label).toBe("op 5");
+    expect(undoable(s)?.label).toBe(`op ${UNDO_LIMIT + 4}`);
+    // The cursor stays meaningful after trimming — trimming from the old end
+    // is what makes that true.
+    expect(s.undoCursor).toBe(UNDO_LIMIT);
+  });
+});
+
+describe("the cursor", () => {
+  it("moves back and forth without losing entries", () => {
+    const a = entry({ label: "first" });
+    const b = entry({ label: "second", before: a.after, after: { ref: "refs/heads/main", oid: "cccc3333" } });
+    let s = stateWith(a, b);
+
+    expect(undoable(s)?.label).toBe("second");
+    s = { ...s, undoCursor: s.undoCursor - 1 };
+    expect(undoable(s)?.label).toBe("first");
+    expect(redoable(s)?.label).toBe("second");
+
+    s = { ...s, undoCursor: 0 };
+    expect(undoable(s)).toBeNull();
+    expect(redoable(s)?.label).toBe("first");
+  });
+
+  it("a new operation discards what was undone", () => {
+    // Once you undo a merge and then commit something else, the merge is no
+    // longer ahead of you on the timeline — every undo stack works this way.
+    const a = entry({ label: "first" });
+    const b = entry({ label: "second", after: { ref: "refs/heads/main", oid: "cccc3333" } });
+    let s = stateWith(a, b);
+    s = { ...s, undoCursor: 1 }; // "second" undone
+    s = pushUndo(s, entry({ label: "third", after: { ref: "refs/heads/main", oid: "dddd4444" } }));
+
+    expect(s.undoStack.map((e) => e.label)).toEqual(["first", "third"]);
+    expect(redoable(s)).toBeNull();
+  });
+});
+
+describe("which end of the entry is used", () => {
+  it("undo goes back to before and expects to still be at after", () => {
+    const e = entry();
+    expect(targetOf(e, "undo")).toEqual(e.before);
+    expect(expectedOf(e, "undo")).toEqual(e.after);
+  });
+
+  it("redo goes forward to after and expects to still be at before", () => {
+    const e = entry();
+    expect(targetOf(e, "redo")).toEqual(e.after);
+    expect(expectedOf(e, "redo")).toEqual(e.before);
+  });
+});
+
+describe("preconditions", () => {
+  const clean = { headOid: "bbbb2222", dirty: false };
+
+  it("allows an undo when the world has not moved", () => {
+    const check = checkUndo(entry(), "undo", clean);
+    expect(check.ok).toBe(true);
+    if (check.ok) expect(check.target.oid).toBe("aaaa1111");
+  });
+
+  it("refuses when HEAD has moved since the operation", () => {
+    // The recorded `before` is no longer the state this operation started
+    // from, so resetting to it would discard whatever happened since — under
+    // a keystroke the user reads as "put it back".
+    const check = checkUndo(entry(), "undo", { headOid: "9999", dirty: false });
+    expect(check.ok).toBe(false);
+    if (!check.ok) {
+      expect(check.reason).toContain("HEAD has moved");
+      // Names the operation, and points at the tool that CAN go back.
+      expect(check.reason).toContain('commit "fix: thing"');
+      expect(check.reason).toContain("reflog");
+    }
+  });
+
+  it("refuses a hard undo when the working copy is dirty", () => {
+    const check = checkUndo(entry(), "undo", { headOid: "bbbb2222", dirty: true });
+    expect(check.ok).toBe(false);
+    if (!check.ok) {
+      expect(check.reason).toContain("working copy has changed");
+      expect(check.reason).toContain("stash");
+    }
+  });
+
+  it("allows a dirty undo of a CHECKOUT", () => {
+    // Switching back to where you were keeps your changes, exactly the way
+    // switching away did. Refusing here would be a rule with no reason.
+    const check = checkUndo(
+      entry({ kind: "checkout", label: "switch to feat/x" }),
+      "undo",
+      { headOid: "bbbb2222", dirty: true },
+    );
+    expect(check.ok).toBe(true);
+  });
+
+  it("refuses when there is no entry", () => {
+    const check = checkUndo(null, "undo", clean);
+    expect(check.ok).toBe(false);
+  });
+
+  it("checks redo against the OTHER end", () => {
+    const e = entry();
+    // Sitting at `before` (the undone state) is what makes a redo valid...
+    expect(checkUndo(e, "redo", { headOid: "aaaa1111", dirty: false }).ok).toBe(true);
+    // ...and sitting at `after` is what makes it invalid.
+    expect(checkUndo(e, "redo", { headOid: "bbbb2222", dirty: false }).ok).toBe(false);
+  });
+
+  it("refuses an unborn HEAD rather than treating it as a match", () => {
+    expect(checkUndo(entry(), "undo", { headOid: null, dirty: false }).ok).toBe(false);
+  });
+});
+
+describe("what needs a confirmation", () => {
+  it("every hard kind does", () => {
+    for (const kind of HARD_KINDS) {
+      expect(needsConfirm(entry({ kind }))).toBe(true);
+    }
+  });
+
+  it("a checkout does not — it discards nothing", () => {
+    expect(needsConfirm(entry({ kind: "checkout" }))).toBe(false);
+  });
+
+  it("every kind is either hard or checkout, with nothing unclassified", () => {
+    // Guards a future kind being added to the union and quietly inheriting
+    // "no confirmation needed".
+    const all: UndoKind[] = [
+      "commit",
+      "checkout",
+      "merge",
+      "cherryPick",
+      "revert",
+      "reset",
+    ];
+    for (const kind of all) {
+      expect(needsConfirm(entry({ kind }))).toBe(kind !== "checkout");
+    }
+  });
+});
+
+describe("labels", () => {
+  it("never renders a bare Undo when there is something to undo", () => {
+    expect(describeUndo(entry({ label: "merge of feat/x" }), "undo")).toBe(
+      "Undo merge of feat/x",
+    );
+    expect(describeUndo(entry({ label: "merge of feat/x" }), "redo")).toBe(
+      "Redo merge of feat/x",
+    );
+  });
+
+  it("shortens an oid the way the UI shows one", () => {
+    expect(shortOid("0123456789abcdef")).toBe("01234567");
+    expect(shortOid("abc")).toBe("abc");
+  });
+
+  it("quotes a commit subject and drops the body", () => {
+    expect(quoteSubject("fix: thing\n\nlonger body")).toBe("“fix: thing”");
+  });
+
+  it("truncates a long subject so the verb stays visible in a menu row", () => {
+    const out = quoteSubject("x".repeat(80));
+    expect(out.length).toBeLessThanOrEqual(42);
+    expect(out).toContain("…");
+  });
+
+  it("is empty for an empty message rather than a pair of empty quotes", () => {
+    expect(quoteSubject("")).toBe("");
+    expect(quoteSubject("   \n  ")).toBe("");
+  });
+});

--- a/src/features/repo/undoStack.ts
+++ b/src/features/repo/undoStack.ts
@@ -1,0 +1,244 @@
+// Undo the last operation (#242).
+//
+// The reason people fear a git GUI is that a misclick is unrecoverable unless
+// you already know the reflog well enough not to need the GUI. This is the
+// one-keystroke answer — and the design is deliberately honest about what it
+// cannot do, because an undo that silently does the wrong thing is worse than
+// no undo at all.
+//
+// ## What an entry is
+//
+// A before/after pair of HEAD snapshots plus what produced them. Undo moves
+// HEAD from `after` back to `before`; redo moves it forward again. That is the
+// whole model: it does not replay operations backwards, it moves a ref. git
+// keeps the old commits reachable through the reflog until it garbage-collects,
+// so "undo a commit" costs nothing and loses nothing.
+//
+// ## What it deliberately does NOT cover
+//
+// Only operations that move HEAD, and only where moving it back is the honest
+// inverse. A push is not undoable (the remote has it, and rewriting someone
+// else's history is not an undo). A dropped stash is not undoable. Branch
+// create/delete/rename move a ref that is not HEAD and need their own inverse,
+// so they are not here yet. Rebase has its own engine and its own retained
+// summary; folding it in without thinking through an interrupted plan would be
+// the kind of undo that lies.
+//
+// Anything absent simply pushes no entry, which is the safe failure: ⌘Z then
+// undoes the last thing that IS undoable, rather than appearing to undo
+// something it cannot.
+
+/** The operations that push an entry. */
+export type UndoKind =
+  | "commit"
+  | "checkout"
+  | "merge"
+  | "cherryPick"
+  | "revert"
+  | "reset";
+
+/**
+ * The kinds whose undo is a hard reset, and therefore discards uncommitted
+ * work if there is any.
+ *
+ * These get the clean-tree precondition and a confirmation. `checkout` is the
+ * one that does not: switching back to where you were keeps your changes, the
+ * same way switching away did.
+ */
+export const HARD_KINDS: ReadonlySet<UndoKind> = new Set<UndoKind>([
+  "commit",
+  "merge",
+  "cherryPick",
+  "revert",
+  "reset",
+]);
+
+/** Where HEAD was. */
+export interface HeadSnapshot {
+  /** The branch HEAD pointed at, or null when detached. */
+  ref: string | null;
+  oid: string;
+}
+
+export interface UndoEntry {
+  /** Stable across renders; the palette and the tests key on it. */
+  id: string;
+  kind: UndoKind;
+  /**
+   * What the operation was, in the words the user saw — "merge of `feat/x`",
+   * not "merge". The issue is explicit that ⌘Z must never appear as a bare
+   * "Undo": the whole point is knowing what is about to happen.
+   */
+  label: string;
+  before: HeadSnapshot;
+  after: HeadSnapshot;
+}
+
+/**
+ * How many entries are kept.
+ *
+ * Bounded because the stack is per-repository and lives for the session, and
+ * because an undo of something you did two hundred operations ago is not an
+ * undo — it is a reset to an old commit, which the reflog view already does
+ * better and with more context.
+ */
+export const UNDO_LIMIT = 50;
+
+/** The stack and where in it we are. Both live in `RepoSlice`. */
+export interface UndoState {
+  /** Oldest first. */
+  undoStack: UndoEntry[];
+  /**
+   * How many entries are still "done" — the index of the next entry to undo.
+   * Equal to `undoStack.length` when nothing has been undone.
+   */
+  undoCursor: number;
+}
+
+export const emptyUndo = (): UndoState => ({ undoStack: [], undoCursor: 0 });
+
+/** The entry ⌘Z would undo, or null. */
+export function undoable(s: UndoState): UndoEntry | null {
+  return s.undoCursor > 0 ? (s.undoStack[s.undoCursor - 1] ?? null) : null;
+}
+
+/** The entry ⌘⇧Z would redo, or null. */
+export function redoable(s: UndoState): UndoEntry | null {
+  return s.undoCursor < s.undoStack.length
+    ? (s.undoStack[s.undoCursor] ?? null)
+    : null;
+}
+
+/**
+ * Record a new operation.
+ *
+ * Truncates anything that was undone, which is what every undo stack does and
+ * what users expect: once you undo a merge and then commit something else, the
+ * merge is no longer ahead of you on the timeline. Trimming is from the OLD
+ * end, so the cursor stays meaningful.
+ *
+ * An operation that did not actually move HEAD pushes nothing. That is not an
+ * optimisation — a no-op entry would make ⌘Z appear to do something and then
+ * do nothing, which is exactly the behaviour that makes people distrust undo.
+ */
+export function pushUndo(
+  s: UndoState,
+  entry: UndoEntry,
+  limit = UNDO_LIMIT,
+): UndoState {
+  if (entry.before.oid === entry.after.oid && entry.before.ref === entry.after.ref) {
+    return s;
+  }
+  const kept = s.undoStack.slice(0, s.undoCursor);
+  kept.push(entry);
+  const overflow = Math.max(0, kept.length - limit);
+  const undoStack = overflow > 0 ? kept.slice(overflow) : kept;
+  return { undoStack, undoCursor: undoStack.length };
+}
+
+/** Which way an entry is being applied. */
+export type UndoDirection = "undo" | "redo";
+
+/** Where an entry sends HEAD when applied in `direction`. */
+export function targetOf(entry: UndoEntry, direction: UndoDirection): HeadSnapshot {
+  return direction === "undo" ? entry.before : entry.after;
+}
+
+/** Where HEAD must still be for an entry to be applicable in `direction`. */
+export function expectedOf(
+  entry: UndoEntry,
+  direction: UndoDirection,
+): HeadSnapshot {
+  return direction === "undo" ? entry.after : entry.before;
+}
+
+/** The state of the world an undo is checked against. */
+export interface UndoWorld {
+  /** HEAD's oid right now, straight from the backend. Never from the log. */
+  headOid: string | null;
+  /** Whether the working copy has changes — also straight from the backend. */
+  dirty: boolean;
+}
+
+export type UndoCheck =
+  | { ok: true; entry: UndoEntry; direction: UndoDirection; target: HeadSnapshot }
+  | { ok: false; reason: string };
+
+/**
+ * Whether an entry can still be applied, and why not when it cannot.
+ *
+ * **Refuses rather than guesses.** If the world moved, the recorded `before`
+ * is no longer the state this operation started from, and resetting to it
+ * would throw away whatever happened since — under a keystroke the user reads
+ * as "put it back".
+ *
+ * The refusals name the operation, because "cannot undo" with no subject is
+ * the same dead end as a bare "Undo".
+ */
+export function checkUndo(
+  entry: UndoEntry | null,
+  direction: UndoDirection,
+  world: UndoWorld,
+): UndoCheck {
+  if (!entry) {
+    return { ok: false, reason: "There is nothing to undo." };
+  }
+  const expected = expectedOf(entry, direction);
+  if (world.headOid !== expected.oid) {
+    return {
+      ok: false,
+      reason: `HEAD has moved since that ${entry.label} — ${
+        direction === "undo" ? "undoing" : "redoing"
+      } it would discard what happened after it. Use the reflog to go back deliberately.`,
+    };
+  }
+  if (HARD_KINDS.has(entry.kind) && world.dirty) {
+    return {
+      ok: false,
+      reason: `The working copy has changed since that ${entry.label}. Undoing it resets the working copy, which would discard those changes — commit or stash them first.`,
+    };
+  }
+  return { ok: true, entry, direction, target: targetOf(entry, direction) };
+}
+
+/**
+ * The menu/palette label. Names the operation, never a bare "Undo".
+ */
+export function describeUndo(
+  entry: UndoEntry | null,
+  direction: UndoDirection,
+): string {
+  const verb = direction === "undo" ? "Undo" : "Redo";
+  return entry ? `${verb} ${entry.label}` : `${verb}`;
+}
+
+/**
+ * Whether applying this entry needs a confirmation.
+ *
+ * A hard reset can only discard uncommitted work when there is some — and
+ * `checkUndo` already refuses that case outright. What the confirmation is
+ * really for is the commit that is about to stop being on a branch: it stays
+ * in the reflog, but "your commit is now only reachable from the reflog" is
+ * not something to do to someone silently.
+ */
+export function needsConfirm(entry: UndoEntry): boolean {
+  return HARD_KINDS.has(entry.kind);
+}
+
+/** An oid as the UI shows it. Undo labels name commits, and a full sha is noise. */
+export function shortOid(oid: string): string {
+  return oid.length > 8 ? oid.slice(0, 8) : oid;
+}
+
+/**
+ * A commit's subject, quoted for a label, truncated.
+ *
+ * The label ends up inside a sentence ("Undo commit “fix: thing”?"), so a long
+ * message would push the actual verb off the end of a menu row.
+ */
+export function quoteSubject(message: string, max = 40): string {
+  const subject = message.split("\n", 1)[0]?.trim() ?? "";
+  if (!subject) return "";
+  const cut = subject.length > max ? `${subject.slice(0, max - 1)}…` : subject;
+  return `\u201c${cut}\u201d`;
+}

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { pgFlash } from "@/design";
 import type {
   AuthorOverride,
   BisectMark,
@@ -132,6 +133,20 @@ import {
   type RepoSlice,
 } from "./repoSlice";
 import type { ActivityKey } from "./repoActivity";
+import {
+  checkUndo,
+  pushUndo,
+  quoteSubject,
+  redoable,
+  shortOid,
+  undoable,
+  type HeadSnapshot,
+  type UndoDirection,
+  type UndoKind,
+} from "./undoStack";
+
+/** Ids for undo entries. Module-level so they are unique across repositories. */
+let undoSeq = 0;
 
 export type { RepoActivity } from "./repoActivity";
 
@@ -219,6 +234,21 @@ interface RepoStoreState extends RepoSlice {
    * `refreshAll` does but that these ops can't change.
    */
   refreshStatus: () => Promise<void>;
+  /**
+   * Undo (or redo) the last recorded operation (#242).
+   *
+   * Re-checks preconditions against the BACKEND first — `head_info` and a
+   * fresh status, never `s.commits`, which is only a prefix of history. On a
+   * mismatch it refuses with a message naming the operation, and changes
+   * nothing.
+   *
+   * Does NOT confirm, for the same reason `deleteUntracked` does not: this is
+   * the layer a keyboard shortcut reaches. `undoOp`/`redoOp` in ops.ts own the
+   * `pgConfirm` for the hard kinds — and the preconditions are re-checked
+   * HERE, after that dialog has been answered, because the world can move
+   * while it is open.
+   */
+  applyUndo: (direction: UndoDirection) => Promise<void>;
   refreshAllFiles: () => Promise<void>;
   /**
    * List every file in the tree at `revspec` (commit/branch/tag/revspec).
@@ -671,6 +701,42 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (get().current?.id !== repoId) return;
     if (isCancelledError(e)) return;
     set({ error: toAppError(e) });
+  };
+
+  /** Where HEAD is according to the last refresh, or null if it is unborn. */
+  const headSnapshot = (): HeadSnapshot | null => {
+    const h = get().headInfo;
+    return h?.headOid ? { ref: h.branch, oid: h.headOid } : null;
+  };
+
+  /**
+   * Record an operation that moved HEAD (#242).
+   *
+   * Called AFTER the op's `refreshAll()`, so `headInfo` is the new position —
+   * and guarded on the repository the way `setErrorFor` is, because an op that
+   * resolves after a tab switch must not push an entry onto the wrong stack.
+   *
+   * `pushUndo` drops an entry whose before and after are identical, so a
+   * checkout of the branch you are already on records nothing rather than an
+   * entry ⌘Z would appear to apply and then not.
+   */
+  const noteUndo = (
+    repoId: string,
+    kind: UndoKind,
+    label: string,
+    before: HeadSnapshot | null,
+  ) => {
+    if (!before) return;
+    if (get().current?.id !== repoId) return;
+    const after = headSnapshot();
+    if (!after) return;
+    undoSeq += 1;
+    set(
+      pushUndo(
+        { undoStack: get().undoStack, undoCursor: get().undoCursor },
+        { id: `undo-${undoSeq}`, kind, label, before, after },
+      ),
+    );
   };
   // `setActivity` is the module-level one above — shared with `withAuthRetry`,
   // which owns the indicator for every op that can raise a credential challenge.
@@ -1185,9 +1251,11 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   async reset(target, mode) {
     const repo = get().current;
     if (!repo) return;
+    const before = headSnapshot();
     try {
       await resetFn(repo.id, target, mode);
       await get().refreshAll();
+      noteUndo(repo.id, "reset", `${mode.toLowerCase()} reset to ${shortOid(target)}`, before);
     } catch (e) {
       setErrorFor(repo.id, e);
     }
@@ -1206,6 +1274,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     // Clear the previous refusal first: a stale block sitting above a fresh
     // attempt reads as though the new attempt failed too.
     setFor(repo.id, { hookRejection: null, noSignature: false });
+    const before = headSnapshot();
     try {
       const result = await commitFn(
         repo.id,
@@ -1217,6 +1286,15 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         noVerify,
       );
       await get().refreshAll();
+      // An AMEND replaces the tip rather than adding one, so undoing it puts
+      // the ORIGINAL commit back — which is exactly what before/after already
+      // describes, with no special case needed.
+      noteUndo(
+        repo.id,
+        "commit",
+        amend ? "amend" : `commit ${quoteSubject(message)}`,
+        before,
+      );
       return result;
     } catch (e) {
       // A hook refusal is NOT a banner error. Its output needs a surface that
@@ -1242,6 +1320,62 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     }
   },
 
+  async applyUndo(direction) {
+    const repo = get().current;
+    if (!repo) return;
+    const entry = direction === "undo" ? undoable(get()) : redoable(get());
+    if (!entry) {
+      pgFlash(direction === "undo" ? "Nothing to undo" : "Nothing to redo");
+      return;
+    }
+
+    // Ask the BACKEND where HEAD is, rather than trusting the last refresh.
+    // Something may have moved it since — a terminal, another window — and
+    // this whole check exists to notice exactly that. `s.commits` is a prefix
+    // of history and can never answer it.
+    let headOid: string | null;
+    try {
+      headOid = (await headInfoFn(repo.id)).headOid;
+      await get().refreshStatus();
+    } catch (e) {
+      setErrorFor(repo.id, e);
+      return;
+    }
+    if (get().current?.id !== repo.id) return;
+
+    const check = checkUndo(entry, direction, {
+      headOid,
+      dirty: get().status.length > 0,
+    });
+    if (!check.ok) {
+      // A precondition refusal is not a backend error — nothing was attempted.
+      // It must not become an `AppError`, whose union stays 1:1 with the Rust
+      // enum; a frontend-only condition has no variant there and inventing one
+      // would claim git refused something it was never asked.
+      pgFlash(check.reason);
+      return;
+    }
+
+    try {
+      if (entry.kind === "checkout") {
+        // Put HEAD back the way it was, on the branch it was on — not
+        // detached at the same commit, which would look identical in the log
+        // and be a different repository state.
+        await checkoutRef(repo.id, check.target.ref ?? check.target.oid);
+      } else {
+        await resetFn(repo.id, check.target.oid, "Hard");
+      }
+      await get().refreshAll();
+      set({
+        undoCursor:
+          direction === "undo" ? get().undoCursor - 1 : get().undoCursor + 1,
+      });
+    } catch (e) {
+      await get().refreshAll();
+      setErrorFor(repo.id, e);
+    }
+  },
+
   clearHookRejection() {
     const repo = get().current;
     if (!repo) return;
@@ -1257,6 +1391,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   async checkoutBranch(name) {
     const repo = get().current;
     if (!repo) return;
+    const before = headSnapshot();
     setActivity(repo.id, "branch", `Switching to ${name}…`);
     try {
       // Carry over uncommitted work automatically: stash → checkout → pop.
@@ -1276,6 +1411,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         await stashPop(repo.id, 0);
       }
       await get().refreshAll();
+      noteUndo(repo.id, "checkout", `switch to ${name}`, before);
     } catch (e) {
       setErrorFor(repo.id, e);
       await get().refreshAll();
@@ -1287,9 +1423,11 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   async checkoutRef(reference) {
     const repo = get().current;
     if (!repo) return;
+    const before = headSnapshot();
     try {
       await checkoutRef(repo.id, reference);
       await get().refreshAll();
+      noteUndo(repo.id, "checkout", `checkout of ${reference}`, before);
     } catch (e) {
       setErrorFor(repo.id, e);
     }
@@ -1298,9 +1436,11 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   async mergeBranch(name) {
     const repo = get().current;
     if (!repo) return;
+    const before = headSnapshot();
     try {
       await mergeBranchFn(repo.id, name);
       await get().refreshAll();
+      noteUndo(repo.id, "merge", `merge of ${name}`, before);
     } catch (e) {
       // refreshAll clears `error` as its first act, so refresh before
       // recording the error — otherwise the two synchronous `set()` calls
@@ -1474,9 +1614,11 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   async cherryPick(oid) {
     const repo = get().current;
     if (!repo) return;
+    const before = headSnapshot();
     try {
       await cherryPick(repo.id, oid);
       await get().refreshAll();
+      noteUndo(repo.id, "cherryPick", `cherry-pick of ${shortOid(oid)}`, before);
     } catch (e) {
       // See mergeBranch's catch: refresh first, error last, so it isn't
       // batched away by refreshAll's own `error: null` reset.
@@ -1488,6 +1630,7 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   async cherryPickMany(oids) {
     const repo = get().current;
     if (!repo) return;
+    const before = headSnapshot();
     try {
       // Apply oldest→newest (the caller orders them). Each clean pick
       // auto-commits and moves HEAD; the next applies on top. A conflicting
@@ -1498,6 +1641,14 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         await cherryPick(repo.id, oid);
       }
       await get().refreshAll();
+      noteUndo(
+        repo.id,
+        "cherryPick",
+        oids.length === 1
+          ? `cherry-pick of ${shortOid(oids[0] ?? "")}`
+          : `cherry-pick of ${oids.length} commits`,
+        before,
+      );
     } catch (e) {
       // See mergeBranch's catch: refresh first, error last, so it isn't
       // batched away by refreshAll's own `error: null` reset.
@@ -1509,9 +1660,11 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
   async revert(oid) {
     const repo = get().current;
     if (!repo) return;
+    const before = headSnapshot();
     try {
       await revertFn(repo.id, oid);
       await get().refreshAll();
+      noteUndo(repo.id, "revert", `revert of ${shortOid(oid)}`, before);
     } catch (e) {
       // See mergeBranch's catch: refresh first, error last, so it isn't
       // batched away by refreshAll's own `error: null` reset.

--- a/src/features/repo/useRepoStore.undo.test.ts
+++ b/src/features/repo/useRepoStore.undo.test.ts
@@ -1,0 +1,308 @@
+// Undo, end to end through the store (#242).
+//
+// `undoStack.test.ts` pins the model. This file pins that the model is
+// actually fed and actually acted on: that operations record entries, that
+// preconditions are re-read from the BACKEND rather than from cached state,
+// and that a refusal changes nothing.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { pgFlashClear } from "@/design";
+
+import { emptyUndo, undoable } from "./undoStack";
+import { useRepoStore } from "./useRepoStore";
+
+/** Where HEAD is, as the backend reports it. Moved by tests. */
+let head: { branch: string | null; headOid: string } = {
+  branch: "refs/heads/main",
+  headOid: "aaaa1111",
+};
+/** Whether the working copy is dirty, as the backend reports it. */
+let dirty = false;
+
+function mockRefresh() {
+  mockInvoke("get_status", () =>
+    dirty
+      ? [
+          {
+            path: "a.ts",
+            worktree: { kind: "Modified" },
+            index: { kind: "Unmodified" },
+            additions: 1,
+            deletions: 0,
+            embedded: false,
+          },
+        ]
+      : [],
+  );
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("head_info", () => head);
+  mockInvoke("rebase_status", () => ({
+    inProgress: false,
+    nextIndex: 0,
+    total: 0,
+    pauseReason: null,
+  }));
+  mockInvoke("shallow_info", () => ({
+    shallow: false,
+    boundaryCount: 0,
+    singleBranch: false,
+  }));
+  mockInvoke("bisect_status", () => ({
+    inProgress: false,
+    startRef: null,
+    badTerm: "bad",
+    goodTerm: "good",
+    currentOid: null,
+    remaining: null,
+    steps: null,
+    firstBadOid: null,
+    goodCount: 0,
+    badCount: 0,
+    skippedCount: 0,
+  }));
+}
+
+const cmds = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+
+/** Run `op`, with HEAD moving to `to` as a result. */
+async function withHeadMovingTo(
+  to: { branch: string | null; headOid: string },
+  op: () => Promise<unknown>,
+) {
+  const done = op();
+  head = to;
+  await done;
+}
+
+beforeEach(async () => {
+  resetInvokeMock();
+  pgFlashClear();
+  head = { branch: "refs/heads/main", headOid: "aaaa1111" };
+  dirty = false;
+  mockRefresh();
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    error: null,
+    status: [],
+    headInfo: head,
+    ...emptyUndo(),
+  } as never);
+});
+
+describe("operations record what they did", () => {
+  it("a commit records an entry naming its subject", async () => {
+    mockInvoke("commit", () => ({ oid: "bbbb2222", message: "fix: thing" }));
+    await withHeadMovingTo(
+      { branch: "refs/heads/main", headOid: "bbbb2222" },
+      () => useRepoStore.getState().commit("fix: thing\n\nbody"),
+    );
+
+    const entry = undoable(useRepoStore.getState());
+    expect(entry?.kind).toBe("commit");
+    // Never a bare "Undo" — the label carries the subject.
+    expect(entry?.label).toContain("fix: thing");
+    expect(entry?.before.oid).toBe("aaaa1111");
+    expect(entry?.after.oid).toBe("bbbb2222");
+  });
+
+  it("a merge records the branch it merged", async () => {
+    mockInvoke("merge_branch", () => undefined);
+    await withHeadMovingTo(
+      { branch: "refs/heads/main", headOid: "bbbb2222" },
+      () => useRepoStore.getState().mergeBranch("feat/x"),
+    );
+    expect(undoable(useRepoStore.getState())?.label).toBe("merge of feat/x");
+  });
+
+  it("a revert records the commit it reverted", async () => {
+    mockInvoke("revert", () => undefined);
+    await withHeadMovingTo(
+      { branch: "refs/heads/main", headOid: "bbbb2222" },
+      () => useRepoStore.getState().revert("0123456789abcdef"),
+    );
+    expect(undoable(useRepoStore.getState())?.label).toBe(
+      "revert of 01234567",
+    );
+  });
+
+  it("an operation that FAILED records nothing", async () => {
+    mockInvoke("merge_branch", () => {
+      throw { kind: "ConflictsDetected", message: "conflicts" };
+    });
+    await useRepoStore.getState().mergeBranch("feat/x");
+    expect(undoable(useRepoStore.getState())).toBeNull();
+  });
+
+  it("an operation that did not move HEAD records nothing", async () => {
+    // Checking out the branch you are already on. An entry here would make ⌘Z
+    // appear to act and then do nothing.
+    mockInvoke("checkout_ref", () => undefined);
+    mockInvoke("stash_save", () => null);
+    await useRepoStore.getState().checkoutRef("main");
+    expect(undoable(useRepoStore.getState())).toBeNull();
+  });
+});
+
+describe("applying an undo", () => {
+  async function recordACommit() {
+    mockInvoke("commit", () => ({ oid: "bbbb2222", message: "fix: thing" }));
+    await withHeadMovingTo(
+      { branch: "refs/heads/main", headOid: "bbbb2222" },
+      () => useRepoStore.getState().commit("fix: thing"),
+    );
+  }
+
+  it("hard-resets back to where the operation started", async () => {
+    await recordACommit();
+    mockInvoke("reset", () => undefined);
+    await withHeadMovingTo(
+      { branch: "refs/heads/main", headOid: "aaaa1111" },
+      () => useRepoStore.getState().applyUndo("undo"),
+    );
+
+    const reset = cmds("reset");
+    expect(reset).toHaveLength(1);
+    expect(reset[0].args).toMatchObject({ target: "aaaa1111", mode: "Hard" });
+    // The entry is not discarded — it moves behind the cursor, ready to redo.
+    expect(useRepoStore.getState().undoStack).toHaveLength(1);
+    expect(useRepoStore.getState().undoCursor).toBe(0);
+  });
+
+  it("puts a checkout back ON the branch, not detached at the same commit", async () => {
+    // Same oid, different ref is a real state difference, and `checkout_ref`
+    // with an oid would leave HEAD detached — identical in the log, and not
+    // what the user had.
+    mockInvoke("checkout_ref", () => undefined);
+    await withHeadMovingTo({ branch: null, headOid: "bbbb2222" }, () =>
+      useRepoStore.getState().checkoutRef("bbbb2222"),
+    );
+    resetInvokeMock();
+    mockRefresh();
+    mockInvoke("checkout_ref", () => undefined);
+
+    await withHeadMovingTo(
+      { branch: "refs/heads/main", headOid: "aaaa1111" },
+      () => useRepoStore.getState().applyUndo("undo"),
+    );
+    expect(cmds("checkout_ref")[0].args.reference).toBe("refs/heads/main");
+    expect(cmds("reset")).toHaveLength(0);
+  });
+
+  it("redo moves forward again", async () => {
+    await recordACommit();
+    mockInvoke("reset", () => undefined);
+    await withHeadMovingTo(
+      { branch: "refs/heads/main", headOid: "aaaa1111" },
+      () => useRepoStore.getState().applyUndo("undo"),
+    );
+    await withHeadMovingTo(
+      { branch: "refs/heads/main", headOid: "bbbb2222" },
+      () => useRepoStore.getState().applyUndo("redo"),
+    );
+
+    expect(cmds("reset")).toHaveLength(2);
+    expect(cmds("reset")[1].args.target).toBe("bbbb2222");
+    expect(useRepoStore.getState().undoCursor).toBe(1);
+  });
+});
+
+describe("refusals change nothing", () => {
+  async function recordACommit() {
+    mockInvoke("commit", () => ({ oid: "bbbb2222", message: "fix: thing" }));
+    await withHeadMovingTo(
+      { branch: "refs/heads/main", headOid: "bbbb2222" },
+      () => useRepoStore.getState().commit("fix: thing"),
+    );
+  }
+
+  it("refuses when HEAD moved, asking the BACKEND not the cached value", async () => {
+    await recordACommit();
+    // The store still believes HEAD is at bbbb2222; only the backend knows a
+    // terminal moved it. Reading the cached `headInfo` would let this through.
+    head = { branch: "refs/heads/main", headOid: "9999ffff" };
+    mockInvoke("reset", () => undefined);
+
+    await useRepoStore.getState().applyUndo("undo");
+
+    expect(cmds("head_info").length).toBeGreaterThan(0);
+    expect(cmds("reset")).toHaveLength(0);
+    expect(useRepoStore.getState().undoCursor).toBe(1);
+  });
+
+  it("refuses a hard undo when the working copy is dirty", async () => {
+    await recordACommit();
+    dirty = true;
+    mockInvoke("reset", () => undefined);
+
+    await useRepoStore.getState().applyUndo("undo");
+
+    expect(cmds("reset")).toHaveLength(0);
+    expect(useRepoStore.getState().undoCursor).toBe(1);
+  });
+
+  it("does not become an AppError — the union stays 1:1 with Rust", async () => {
+    // A precondition refusal is not something git refused; nothing was even
+    // attempted. Synthesising an AppError would claim otherwise, and there is
+    // no Rust variant for a frontend-only condition.
+    await recordACommit();
+    head = { branch: "refs/heads/main", headOid: "9999ffff" };
+    await useRepoStore.getState().applyUndo("undo");
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("does nothing at all with an empty stack", async () => {
+    await useRepoStore.getState().applyUndo("undo");
+    expect(cmds("reset")).toHaveLength(0);
+    expect(cmds("checkout_ref")).toHaveLength(0);
+  });
+});
+
+describe("the stack is per repository", () => {
+  it("does not survive a tab switch", async () => {
+    // `useRepoStore` holds exactly one repository's state, and `emptySlice()`
+    // is a TOTAL write. An undo stack that leaked would offer to reset the
+    // wrong repository.
+    mockInvoke("commit", () => ({ oid: "bbbb2222", message: "fix: thing" }));
+    await withHeadMovingTo(
+      { branch: "refs/heads/main", headOid: "bbbb2222" },
+      () => useRepoStore.getState().commit("fix: thing"),
+    );
+    expect(useRepoStore.getState().undoStack).toHaveLength(1);
+
+    useRepoStore.getState().closeRepo();
+    expect(useRepoStore.getState().undoStack).toHaveLength(0);
+    expect(useRepoStore.getState().undoCursor).toBe(0);
+  });
+});
+
+describe("the stack is guarded against a late resolution", () => {
+  it("does not record onto another repository's stack", async () => {
+    // The `setErrorFor` rule, applied to undo: an op that resolves after the
+    // user has moved to another repository must write nothing.
+    let release: (() => void) | null = null;
+    mockInvoke("merge_branch", async () => {
+      await new Promise<void>((r) => {
+        release = r;
+      });
+    });
+    const pending = useRepoStore.getState().mergeBranch("feat/x");
+    await vi.waitFor(() => expect(release).not.toBeNull());
+
+    useRepoStore.setState({
+      current: { id: "r2", path: "/other", head: "main" },
+      ...emptyUndo(),
+    } as never);
+    head = { branch: "refs/heads/main", headOid: "bbbb2222" };
+    release!();
+    await pending;
+
+    expect(useRepoStore.getState().undoStack).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #242.

The reason people fear a git GUI is that a misclick is unrecoverable unless you already know the reflog well enough not to need the GUI. This is the one-keystroke answer — and it is deliberately honest about what it cannot do, because an undo that silently does the wrong thing is worse than no undo at all.

## The model

An entry is a **before/after pair of HEAD snapshots** plus what produced them. Undo moves HEAD from `after` back to `before`; redo moves it forward. It does not replay operations backwards, it **moves a ref** — git keeps the old commits reachable through the reflog, so undoing a commit costs and loses nothing.

`undoStack` + `undoCursor` join `RepoSlice`, so a tab switch cannot carry the stack. Session-scoped rather than persisted on purpose: an entry is only meaningful while the recorded HEAD is still where the operation left it, so a stack restored from disk would mostly be entries that refuse.

## What it records — and what it deliberately does not

**Recorded:** commit (including amend — an amend replaces the tip, which before/after already describes with no special case), checkout, merge, cherry-pick, revert, reset.

**Not recorded**, and the absence is the safe failure rather than a gap:

- **a push** — the remote has it, and rewriting someone else's history is not an undo;
- **a dropped stash** — nothing to move HEAD back to;
- **branch create/delete/rename** — they move a ref that is *not* HEAD and need their own inverse;
- **rebase** — its own engine and its own retained summary; folding it in without thinking through an interrupted plan would be exactly the kind of undo that lies.

Anything absent simply pushes no entry, so ⌘Z undoes the last thing that *is* undoable rather than appearing to undo something it cannot.

## Refusing rather than guessing

**Preconditions are re-read from the backend at undo time** — `head_info` plus a fresh status, never cached state and never `s.commits`, which is a prefix of history and cannot answer "is HEAD still where I left it". There is a test that moves HEAD only on the backend and asserts the undo is refused; reading the cached `headInfo` would let it through.

On a mismatch it changes nothing and says why, naming the operation and pointing at the reflog: *"HEAD has moved since that merge of feat/x — undoing it would discard what happened after it."* Hard kinds also require a clean tree; a **checkout** does not, because switching back to where you were keeps your changes exactly the way switching away did.

**A refusal is not an `AppError`.** Nothing was attempted, the TS union stays 1:1 with the Rust enum, and there is no variant for a frontend-only condition — so it is a `pgFlash`, the way `ops.ts` already refuses "no upstream". There is a test asserting `error` stays null.

## Two placement decisions

**The confirmation lives in `ops.ts`, not the store** — the same call `deleteUntracked` made, and for the reason its comment gives: the store is also the layer a keyboard shortcut reaches, so it performs and does not ask. The store then re-checks preconditions *after* the dialog is answered, because the world can move while it is open.

**`undoOp`/`redoOp` answer synchronously and return `false` when the stack is empty.** That is what keeps `Mod+Z` from being stolen from every text field in the app — the chord falls through to the browser and still undoes typing, which is what anyone pressing it in a commit message box expects. There is a test for it.

The dialog and the palette name the operation — *"Undo merge of feat/x?"*, never a bare "Undo". Knowing what is about to happen is the whole feature; an undo you cannot predict is another way to lose work. And undoing a checkout puts HEAD back **on the branch**, not detached at the same commit — identical in the log, a different repository state.

## Tests

- `undoStack.test.ts` — 24, mostly refusals: HEAD moved, dirty tree, nothing to undo, redo checked against the other end, an unborn HEAD not treated as a match; bounding and cursor mechanics; a guard that every kind is classified so a future one cannot quietly inherit "no confirmation needed".
- `useRepoStore.undo.test.ts` — 14: operations record (and failed ones do not, and no-op ones do not); the hard-reset and checkout undo paths; redo; the backend-not-cache precondition; the stack clearing on close; a late-resolving op not writing onto another repository's stack.
- `ops.undo.test.tsx` — 9: chord claiming, and the confirmation's content and both outcomes.
- Green after rebasing onto current main: `pnpm test` (2815 passed), full `cargo test`, `pnpm tsc --noEmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
