### PR TITLE
test(commit): wait for the identity to load, not just the form to mount

### DIFF
--- a/src/features/commits/identity/IdentityForm.scope.test.tsx
+++ b/src/features/commits/identity/IdentityForm.scope.test.tsx
@@ -42,11 +42,28 @@ const saves = () => getInvokeCalls().filter((c) => c.cmd === "set_identity");
 const pickScope = (value: string) =>
   pgPickOption(screen.getByTestId("identity-scope"), value);
 
+/**
+ * Render and wait until the identity has actually LOADED — not merely until
+ * the form has mounted.
+ *
+ * The form renders immediately and seeds its fields from an async
+ * `get_identity`. Waiting only for `identity-form` therefore returns while
+ * Name and Email are still empty, which leaves Save disabled — so a test that
+ * clicks it straight away silently does nothing and asserts on zero calls.
+ * That raced: it passed locally and failed on CI, which is the worst version
+ * of the bug.
+ *
+ * `identity-target` is the right thing to wait on: it renders from the loaded
+ * `identity`, so its presence means the seeding has happened.
+ */
 function renderForm(identity: GitIdentity, repoId: string | null = "repo-1") {
   mockInvoke("get_identity", () => identity);
   mockInvoke("set_identity", () => null);
   render(<IdentityForm repoId={repoId} />);
-  return waitFor(() => expect(screen.getByTestId("identity-form")).toBeTruthy());
+  return waitFor(() => {
+    expect(screen.getByTestId("identity-form")).toBeTruthy();
+    expect(screen.getByTestId("identity-target")).toBeTruthy();
+  });
 }
 
 beforeEach(() => {


### PR DESCRIPTION
A test I added in #335 (for #233) is flaky on `main`, and it fails whichever PR happens to be running rather than the one that introduced it — it took down #336's `unit` job while that branch changes nothing near it.

## The race

`IdentityForm.scope.test.tsx`'s `renderForm` waited for `identity-form`. That element exists on the **first render**, before the async `get_identity` has resolved and seeded Name and Email. `canSave` requires both non-blank, so Save is still disabled at that point — and the two cases that click Save *without typing anything first* were racing the load:

- "sends the global scope when that is what is selected"
- "always sends a scope — never leaves the backend to guess"

When the click loses the race, `save()` returns early, nothing is invoked, and the assertion fails with `expected [] to have a length of 1`. Which is exactly what CI reported.

The cases that type into the fields first were never affected — `fireEvent.change` enables Save regardless of the load — which is why only two of the twelve ever failed.

## The fix

Wait on `identity-target` as well. That element renders from the loaded `identity` (`identity?.globalConfigPath` / `localConfigPath`), not from mount, so its presence is proof the seeding has happened. One helper, so every case in the file gets it.

Both fixtures in the file set `globalConfigPath`, so the wait always has something to resolve on; the helper's comment says why it is the right element to key on, so a future fixture without one fails with a clear reason rather than a mystery timeout.

## Verification

`pnpm test` — 2815 passed, `pnpm tsc --noEmit` clean.

Worth being explicit about what this does *not* prove: the suite passed locally before this change too, because the race is a microtask-ordering one. The argument for the fix is structural rather than empirical — `identity-form` is present at mount and `identity-target` is not, so the wait now genuinely spans the async load instead of terminating before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
