### PR TITLE
feat(history): render commit bodies as restrained markdown (#253)

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -534,6 +534,52 @@ the dialog is answered, because the world can move while it is open.
 empty — that is what keeps `Mod+Z` from being stolen from every text field in
 the app; the chord falls through and still undoes typing.
 
+## Markdown in commit bodies (#253)
+
+`features/commits/body/` renders the commit **body** — never the subject, which
+is one line and is not markdown — as a restrained subset, with a raw/rendered
+toggle (`commitBodyMarkdown`, a persisted preference).
+
+**Why a parser of our own rather than a dependency.** The issue's two hard
+constraints are *no remote content of any kind* and *a raw toggle*, and it asks
+for a bundle-size and sanitisation review of any markdown dependency. That
+review does not end well for the general-purpose libraries: they exist to render
+arbitrary documents, which means HTML passthrough, images, and a sanitiser you
+must keep configured correctly forever. `markdown.ts` parses the subset into a
+**typed AST**, and `CommitBody.tsx` turns AST nodes into React elements — so
+there is no HTML string anywhere in the path, and the whole
+`dangerouslySetInnerHTML` class of bug is gone by construction rather than by
+vigilance.
+
+**Deliberately not in the subset:**
+
+- **Headings.** `#` at the start of a line in a commit body is far more likely
+  to be an issue reference than an ATX heading.
+- **Images.** Nothing may fetch. `![alt](url)` parses to a LINK labelled with
+  its alt text — the useful non-fetching reading — and there is no image node in
+  the AST for a renderer to grow one from.
+- **Raw HTML**, tables, footnotes.
+
+**Links** are restricted to `http`, `https` and `mailto` by an allow-list
+(`isSafeHref`); anything else keeps its words and loses its destination. They
+open through `openUrl`, never by navigating — a plain navigation in a webview
+replaces the app.
+
+**`#123` is a styled token, not a link.** Linking it means guessing which forge
+and which repository the number belongs to, and there is no helper in the tree
+that resolves a remote to a web URL. A link to the wrong issue is worse than no
+link; building that resolver is the follow-up that unlocks it.
+
+Paragraphs are **joined across hard-wrapped lines** (commit bodies wrap at 72
+columns, and one visual line per physical line is the "reads badly" the issue is
+about), with markdown's two-trailing-spaces hard break honoured. The raw view is
+the original text, not a re-serialisation of the parse — that is the one
+guarantee it exists to give.
+
+`PGCommitDetail` stays presentational: it gained a `bodyContent` slot rather than
+importing the renderer, because the renderer reads a setting and opens URLs and
+therefore belongs in `features/`, not `design/`.
+
 ## The log is paged (#68 G11)
 
 - **`s.commits` is a PREFIX of history** (`PAGE_SIZE = 500`, appended;

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -1787,6 +1787,15 @@ export interface PGCommitDetailProps {
   fullSha?: string;
   subject: string;
   body?: string;
+  /**
+   * Replaces the plain-text `body` block when given (#253).
+   *
+   * The markdown renderer is FEATURE code (`features/commits/body`), not design
+   * code — it reads a setting and opens URLs — so it is injected rather than
+   * imported here. This component stays presentational, and callers that just
+   * want the text keep passing `body`.
+   */
+  bodyContent?: ReactNode;
   author: string;
   email?: string;
   date: string;
@@ -1800,6 +1809,7 @@ export function PGCommitDetail({
   fullSha,
   subject,
   body,
+  bodyContent,
   author,
   email,
   date,
@@ -1865,7 +1875,8 @@ export function PGCommitDetail({
       >
         {subject}
       </div>
-      {body && (
+      {bodyContent}
+      {!bodyContent && body && (
         <div
           style={{
             color: "var(--fg-1)",

--- a/src/design/primitives.tsx
+++ b/src/design/primitives.tsx
@@ -145,6 +145,14 @@ export interface PGIconButtonProps {
   active?: boolean;
   tone?: string;
   style?: CSSProperties;
+  /**
+   * Threaded onto the button, matching `PGSelect` and `PGInput`.
+   *
+   * Without it the only handle a test has on an icon button is its `title`,
+   * which is user-facing prose — so rewording a tooltip silently breaks tests
+   * that have nothing to do with the wording.
+   */
+  "data-testid"?: string;
 }
 
 export function PGIconButton({
@@ -155,6 +163,7 @@ export function PGIconButton({
   active,
   tone,
   style,
+  "data-testid": testId,
 }: PGIconButtonProps) {
   const sizes = { sm: 20, md: 24, lg: 28 } as const;
   const sz = sizes[size];
@@ -163,6 +172,7 @@ export function PGIconButton({
     <button
       onClick={onClick}
       title={title}
+      data-testid={testId}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       className="focusable"

--- a/src/features/commits/body/CommitBody.test.tsx
+++ b/src/features/commits/body/CommitBody.test.tsx
@@ -1,0 +1,117 @@
+// The commit body's rendered/raw toggle (#253).
+//
+// The raw view is the constraint that makes the rendered one safe to ship: a
+// commit message is a git object, and there has to be a way to see it
+// byte-for-byte. So the assertions here are mostly about the raw side being
+// genuinely raw, and about nothing in the rendered side reaching the network.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { getInvokeCalls, resetInvokeMock, mockInvoke } from "@/test/invokeMock";
+
+import { CommitBody } from "./CommitBody";
+
+const BODY = [
+  "Rework the thing so it *reads* better.",
+  "",
+  "- one bullet",
+  "- another with `code`",
+  "",
+  "```sh",
+  "git rebase -i main",
+  "```",
+  "",
+  "See https://example.com/docs for more. Fixes #123.",
+  "",
+  "Co-Authored-By: Ada <ada@example.com>",
+].join("\n");
+
+beforeEach(() => {
+  resetInvokeMock();
+  mockInvoke("open_url", () => null);
+  useSettingsStore.getState().reset();
+});
+
+describe("the toggle", () => {
+  it("renders markdown by default", () => {
+    render(<CommitBody text={BODY} />);
+    expect(screen.getByTestId("commit-body-rendered")).toBeTruthy();
+    expect(screen.queryByTestId("commit-body-raw")).toBeNull();
+  });
+
+  it("switches to the raw message and back", () => {
+    render(<CommitBody text={BODY} />);
+    fireEvent.click(screen.getByTestId("commit-body-toggle"));
+    expect(screen.getByTestId("commit-body-raw")).toBeTruthy();
+    expect(screen.queryByTestId("commit-body-rendered")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("commit-body-toggle"));
+    expect(screen.getByTestId("commit-body-rendered")).toBeTruthy();
+  });
+
+  it("shows the message byte for byte in raw mode", () => {
+    // Not a re-serialisation of the parse — the original text. If this ever
+    // became "render the AST back to markdown", the one guarantee the raw view
+    // exists to give would be gone.
+    render(<CommitBody text={BODY} />);
+    fireEvent.click(screen.getByTestId("commit-body-toggle"));
+    expect(screen.getByTestId("commit-body-raw").textContent).toBe(BODY);
+  });
+
+  it("remembers the choice as a preference", () => {
+    render(<CommitBody text={BODY} />);
+    fireEvent.click(screen.getByTestId("commit-body-toggle"));
+    expect(useSettingsStore.getState().commitBodyMarkdown).toBe(false);
+  });
+});
+
+describe("what the rendered view contains", () => {
+  it("renders the structure rather than the syntax", () => {
+    render(<CommitBody text={BODY} />);
+    const el = screen.getByTestId("commit-body-rendered");
+    expect(el.querySelectorAll("li")).toHaveLength(2);
+    expect(el.querySelector("em")?.textContent).toBe("reads");
+    expect(screen.getByTestId("commit-body-code").textContent).toBe(
+      "git rebase -i main",
+    );
+    expect(screen.getByTestId("commit-body-trailers").textContent).toContain(
+      "Co-Authored-By",
+    );
+  });
+
+  it("shows an issue reference as a token, not a link", () => {
+    // Linking it means guessing which forge and which repository the number
+    // belongs to, and a link to the wrong issue is worse than no link.
+    render(<CommitBody text={BODY} />);
+    expect(screen.getByTestId("commit-body-issue").textContent).toBe("#123");
+    const links = screen.getAllByTestId("commit-body-link");
+    expect(links.every((a) => a.textContent !== "#123")).toBe(true);
+  });
+
+  it("never emits an img, and never fetches", () => {
+    // The hard constraint: no remote content of any kind.
+    render(<CommitBody text={"![pic](https://example.com/x.png)"} />);
+    const el = screen.getByTestId("commit-body-rendered");
+    expect(el.querySelectorAll("img")).toHaveLength(0);
+    expect(el.querySelectorAll("script,iframe,object,embed,link")).toHaveLength(0);
+    // It survives as a link, which opens only on a click, through the opener.
+    expect(screen.getByTestId("commit-body-link").textContent).toBe("pic");
+  });
+
+  it("opens a link through the opener instead of navigating the webview", () => {
+    // A plain navigation in a webview replaces the APP.
+    render(<CommitBody text={"see https://example.com/docs"} />);
+    fireEvent.click(screen.getByTestId("commit-body-link"));
+    const calls = getInvokeCalls().filter((c) => c.cmd === "open_url");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args.url).toBe("https://example.com/docs");
+  });
+
+  it("does not turn a javascript: link into anything clickable", () => {
+    render(<CommitBody text={"[x](javascript:alert)"} />);
+    expect(screen.queryByTestId("commit-body-link")).toBeNull();
+    expect(screen.getByTestId("commit-body-rendered").textContent).toContain("x");
+  });
+});

--- a/src/features/commits/body/CommitBody.tsx
+++ b/src/features/commits/body/CommitBody.tsx
@@ -1,0 +1,230 @@
+// The commit body, rendered (#253).
+//
+// Two things this component owes the user, and they pull in opposite
+// directions: a long body with lists and code fences should READ well, and a
+// commit message is a git object that sometimes has to be seen byte-for-byte.
+// Hence the toggle — and hence the raw view being the plain `<pre>`-equivalent
+// the panel has always shown, not a re-serialisation of the parse.
+//
+// Nothing here fetches. The AST has no image node, links are limited to
+// http/https/mailto, and every node becomes a React element rather than an HTML
+// string — so there is no sanitiser to get wrong and no
+// `dangerouslySetInnerHTML` anywhere in the path.
+
+import * as React from "react";
+
+import { PGIconButton } from "@/design";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { openUrl } from "@/lib/tauri";
+
+import { parseCommitBody, type Block, type Inline } from "./markdown";
+
+export interface CommitBodyProps {
+  text: string;
+}
+
+export function CommitBody({ text }: CommitBodyProps) {
+  const rendered = useSettingsStore((s) => s.commitBodyMarkdown);
+  const setSetting = useSettingsStore((s) => s.set);
+
+  // Parsing is cheap, but it runs on every selection change in a list people
+  // hold a key down to scroll, so it is worth not re-doing per render.
+  const blocks = React.useMemo(
+    () => (rendered ? parseCommitBody(text) : []),
+    [rendered, text],
+  );
+
+  return (
+    <div style={{ marginBottom: 10 }} data-testid="commit-body">
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          // Pulled up into the body's own top margin: the toggle is a control
+          // for the block below it, not a row of its own.
+          marginBottom: -4,
+        }}
+      >
+        <PGIconButton
+          icon={rendered ? "fileCode" : "fileDoc"}
+          title={
+            rendered
+              ? "Show the raw commit message, byte for byte"
+              : "Render the body as markdown"
+          }
+          data-testid="commit-body-toggle"
+          onClick={() => setSetting("commitBodyMarkdown", !rendered)}
+        />
+      </div>
+      {rendered ? (
+        <div
+          data-testid="commit-body-rendered"
+          style={{
+            color: "var(--fg-1)",
+            fontSize: "var(--fs-12)",
+            overflowWrap: "anywhere",
+            lineHeight: 1.5,
+          }}
+        >
+          {blocks.map((b, i) => (
+            <BlockView key={i} block={b} />
+          ))}
+        </div>
+      ) : (
+        <div
+          data-testid="commit-body-raw"
+          style={{
+            color: "var(--fg-1)",
+            fontSize: "var(--fs-12)",
+            whiteSpace: "pre-wrap",
+            overflowWrap: "anywhere",
+            fontFamily: "var(--font-mono)",
+            lineHeight: 1.5,
+          }}
+        >
+          {text}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BlockView({ block }: { block: Block }) {
+  switch (block.kind) {
+    case "paragraph":
+      return (
+        <p style={{ margin: "0 0 8px" }}>
+          <InlineView nodes={block.children} />
+        </p>
+      );
+
+    case "code":
+      return (
+        <pre
+          data-testid="commit-body-code"
+          style={{
+            margin: "0 0 8px",
+            padding: 8,
+            background: "var(--bg-2)",
+            border: "1px solid var(--border-0)",
+            borderRadius: "var(--r-3)",
+            fontFamily: "var(--font-mono)",
+            fontSize: "var(--fs-11)",
+            // A fenced block is the one place a horizontal scrollbar is right:
+            // wrapping code changes what it says.
+            overflowX: "auto",
+            whiteSpace: "pre",
+          }}
+        >
+          {block.text}
+        </pre>
+      );
+
+    case "list": {
+      const Tag = block.ordered ? "ol" : "ul";
+      return (
+        <Tag style={{ margin: "0 0 8px", paddingLeft: 20 }}>
+          {block.items.map((item, i) => (
+            <li key={i} style={{ marginBottom: 2 }}>
+              <InlineView nodes={item} />
+            </li>
+          ))}
+        </Tag>
+      );
+    }
+
+    case "trailers":
+      return (
+        <div
+          data-testid="commit-body-trailers"
+          style={{
+            margin: "0 0 8px",
+            fontFamily: "var(--font-mono)",
+            fontSize: "var(--fs-11)",
+          }}
+        >
+          {block.entries.map((t, i) => (
+            <div key={i}>
+              <span style={{ color: "var(--fg-3)" }}>{t.key}: </span>
+              <InlineView nodes={t.value} />
+            </div>
+          ))}
+        </div>
+      );
+  }
+}
+
+function InlineView({ nodes }: { nodes: Inline[] }) {
+  return (
+    <>
+      {nodes.map((n, i) => (
+        <InlineNode key={i} node={n} />
+      ))}
+    </>
+  );
+}
+
+function InlineNode({ node }: { node: Inline }) {
+  switch (node.kind) {
+    case "text":
+      return <>{node.text}</>;
+
+    case "code":
+      return (
+        <code
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.92em",
+            background: "var(--bg-2)",
+            padding: "0 3px",
+            borderRadius: "var(--r-2)",
+          }}
+        >
+          {node.text}
+        </code>
+      );
+
+    case "em":
+      return (
+        <em>
+          <InlineView nodes={node.children} />
+        </em>
+      );
+
+    case "strong":
+      return (
+        <strong>
+          <InlineView nodes={node.children} />
+        </strong>
+      );
+
+    case "link":
+      return (
+        <a
+          href={node.href}
+          data-testid="commit-body-link"
+          style={{ color: "var(--accent)", cursor: "pointer" }}
+          onClick={(e) => {
+            // The webview is not a browser tab: a plain navigation would
+            // replace the APP. Every outbound link goes through the opener,
+            // which validates the URL and hands it to the OS.
+            e.preventDefault();
+            void openUrl(node.href).catch(() => {});
+          }}
+        >
+          <InlineView nodes={node.children} />
+        </a>
+      );
+
+    case "issue":
+      // Styled, not linked — see the `issue` node's comment in markdown.ts.
+      return (
+        <span
+          data-testid="commit-body-issue"
+          style={{ fontFamily: "var(--font-mono)", color: "var(--fg-2)" }}
+        >
+          {node.text}
+        </span>
+      );
+  }
+}

--- a/src/features/commits/body/index.ts
+++ b/src/features/commits/body/index.ts
@@ -1,0 +1,10 @@
+export { CommitBody } from "./CommitBody";
+export {
+  isSafeHref,
+  isTrailerLine,
+  parseCommitBody,
+  parseInline,
+  type Block,
+  type Inline,
+  type Trailer,
+} from "./markdown";

--- a/src/features/commits/body/markdown.test.ts
+++ b/src/features/commits/body/markdown.test.ts
@@ -1,0 +1,305 @@
+// The restrained markdown subset for commit bodies (#253).
+//
+// Two kinds of assertion here, and the second matters more: what the subset
+// RENDERS, and what it refuses to. A commit body is untrusted text that
+// arrives from anyone who has ever pushed to the repository, so the refusals
+// (no images, no javascript: links, no HTML passthrough) are the security
+// surface — and the "leave it alone" cases are what stop a body that talks
+// about syntax from being mangled by it.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  isSafeHref,
+  isTrailerLine,
+  parseCommitBody,
+  parseInline,
+  type Block,
+  type Inline,
+} from "./markdown";
+
+/** The text of every inline node, concatenated — for shape-agnostic checks. */
+function flatten(nodes: Inline[]): string {
+  return nodes
+    .map((n) => {
+      switch (n.kind) {
+        case "text":
+        case "code":
+        case "issue":
+          return n.text;
+        default:
+          return flatten(n.children);
+      }
+    })
+    .join("");
+}
+
+const kinds = (blocks: Block[]) => blocks.map((b) => b.kind);
+
+describe("block structure", () => {
+  it("renders a plain paragraph", () => {
+    const blocks = parseCommitBody("Just some prose.");
+    expect(kinds(blocks)).toEqual(["paragraph"]);
+  });
+
+  it("joins a hard-wrapped paragraph into one run", () => {
+    // Commit bodies wrap at 72 columns. Rendering each physical line as its own
+    // visual line is exactly the "reads badly" this feature is about.
+    const blocks = parseCommitBody("one two\nthree four\n\nsecond para");
+    expect(kinds(blocks)).toEqual(["paragraph", "paragraph"]);
+    const first = blocks[0];
+    if (first?.kind !== "paragraph") throw new Error("expected a paragraph");
+    expect(flatten(first.children)).toBe("one two three four");
+  });
+
+  it("honours markdown's two-space hard break", () => {
+    const blocks = parseCommitBody("one  \ntwo");
+    const b = blocks[0];
+    if (b?.kind !== "paragraph") throw new Error("expected a paragraph");
+    expect(flatten(b.children)).toBe("one\ntwo");
+  });
+
+  it("reads a fenced code block, with its language", () => {
+    const blocks = parseCommitBody("before\n\n```rust\nfn main() {}\n```\n\nafter");
+    expect(kinds(blocks)).toEqual(["paragraph", "code", "paragraph"]);
+    const code = blocks[1];
+    if (code?.kind !== "code") throw new Error("expected code");
+    expect(code.lang).toBe("rust");
+    expect(code.text).toBe("fn main() {}");
+  });
+
+  it("keeps blank lines and markdown syntax INSIDE a fence literal", () => {
+    // The whole point of a fence: a body pasting a diff or a config must come
+    // out byte-for-byte, not re-parsed as lists and emphasis.
+    const blocks = parseCommitBody("```\n- not a list\n\n*not emphasis*\n```");
+    const code = blocks[0];
+    if (code?.kind !== "code") throw new Error("expected code");
+    expect(code.text).toBe("- not a list\n\n*not emphasis*");
+  });
+
+  it("still renders an unterminated fence as code", () => {
+    // Commit bodies get truncated and hand-edited. Refusing to render one
+    // because the closing fence is missing fails exactly when the content is
+    // most unusual.
+    const blocks = parseCommitBody("```\nsomething");
+    expect(kinds(blocks)).toEqual(["code"]);
+  });
+
+  it("reads unordered and ordered lists", () => {
+    const ul = parseCommitBody("- one\n- two\n* three");
+    const list = ul[0];
+    if (list?.kind !== "list") throw new Error("expected a list");
+    expect(list.ordered).toBe(false);
+    expect(list.items.map(flatten)).toEqual(["one", "two", "three"]);
+
+    const ol = parseCommitBody("1. first\n2. second");
+    const olist = ol[0];
+    if (olist?.kind !== "list") throw new Error("expected a list");
+    expect(olist.ordered).toBe(true);
+    expect(olist.items.map(flatten)).toEqual(["first", "second"]);
+  });
+
+  it("folds a wrapped bullet back into its item", () => {
+    // At 72 columns a wrapped bullet is the normal case, not an edge one.
+    const blocks = parseCommitBody("- a long bullet that\n  wrapped\n- second");
+    const list = blocks[0];
+    if (list?.kind !== "list") throw new Error("expected a list");
+    expect(list.items.map(flatten)).toEqual(["a long bullet that wrapped", "second"]);
+  });
+
+  it("recognises a trailer block", () => {
+    const blocks = parseCommitBody(
+      "Do the thing.\n\nCo-Authored-By: Ada <ada@example.com>\nSigned-off-by: Bo <bo@example.com>",
+    );
+    expect(kinds(blocks)).toEqual(["paragraph", "trailers"]);
+    const t = blocks[1];
+    if (t?.kind !== "trailers") throw new Error("expected trailers");
+    expect(t.entries.map((e) => e.key)).toEqual(["Co-Authored-By", "Signed-off-by"]);
+  });
+
+  it("does not mistake prose with a colon for a trailer", () => {
+    // git's own rule: the key may not contain a space. `See also: the README`
+    // is prose, and styling it as metadata would be a confident wrong answer.
+    expect(isTrailerLine("See also: the README")).toBe(false);
+    expect(isTrailerLine("Fixes:#123")).toBe(true);
+    expect(isTrailerLine("Co-Authored-By: Ada")).toBe(true);
+    const blocks = parseCommitBody("Some body.\n\nSee also: the README");
+    expect(kinds(blocks)).toEqual(["paragraph", "paragraph"]);
+  });
+
+  it("has no heading block at all", () => {
+    // Deliberate: `#` at the start of a line in a commit body is far more
+    // likely to be an issue reference than an ATX heading.
+    const blocks = parseCommitBody("# 123 is not a heading");
+    expect(kinds(blocks)).toEqual(["paragraph"]);
+  });
+
+  it("is empty for an empty body", () => {
+    expect(parseCommitBody("")).toEqual([]);
+    expect(parseCommitBody("\n\n  \n")).toEqual([]);
+  });
+});
+
+describe("inline: what it renders", () => {
+  it("emphasis and strong", () => {
+    const nodes = parseInline("plain *em* and **strong** here");
+    expect(nodes.map((n) => n.kind)).toEqual([
+      "text",
+      "em",
+      "text",
+      "strong",
+      "text",
+    ]);
+  });
+
+  it("underscore forms too", () => {
+    expect(parseInline("_em_").map((n) => n.kind)).toEqual(["em"]);
+    expect(parseInline("__strong__").map((n) => n.kind)).toEqual(["strong"]);
+  });
+
+  it("inline code", () => {
+    const nodes = parseInline("run `git rebase -i` first");
+    expect(nodes[1]).toEqual({ kind: "code", text: "git rebase -i" });
+  });
+
+  it("code spans win over emphasis", () => {
+    // The single most common way a naive renderer mangles a body that is
+    // talking ABOUT syntax.
+    const nodes = parseInline("`a*b*c`");
+    expect(nodes).toEqual([{ kind: "code", text: "a*b*c" }]);
+  });
+
+  it("an unclosed backtick stays literal", () => {
+    expect(flatten(parseInline("a ` b"))).toBe("a ` b");
+  });
+
+  it("markdown links", () => {
+    const nodes = parseInline("see [the docs](https://example.com/x)");
+    const link = nodes[1];
+    if (link?.kind !== "link") throw new Error("expected a link");
+    expect(link.href).toBe("https://example.com/x");
+    expect(flatten(link.children)).toBe("the docs");
+  });
+
+  it("bare URLs", () => {
+    const nodes = parseInline("see https://example.com/a?b=1 for more");
+    const link = nodes[1];
+    if (link?.kind !== "link") throw new Error("expected a link");
+    expect(link.href).toBe("https://example.com/a?b=1");
+  });
+
+  it("does not swallow trailing punctuation into a bare URL", () => {
+    const nodes = parseInline("see https://example.com.");
+    const link = nodes[1];
+    if (link?.kind !== "link") throw new Error("expected a link");
+    expect(link.href).toBe("https://example.com");
+    expect(flatten(nodes)).toBe("see https://example.com.");
+  });
+
+  it("issue references, as a token rather than a guess at a URL", () => {
+    const nodes = parseInline("fixes #123 and (#456)");
+    const issues = nodes.filter((n) => n.kind === "issue");
+    expect(issues.map((n) => (n.kind === "issue" ? n.text : ""))).toEqual([
+      "#123",
+      "#456",
+    ]);
+  });
+
+  it("leaves a # that is not an issue reference alone", () => {
+    // A hex colour and a fragment in the middle of a word are both common.
+    expect(parseInline("#fff").every((n) => n.kind === "text")).toBe(true);
+    expect(parseInline("abc#1").every((n) => n.kind === "text")).toBe(true);
+  });
+});
+
+describe("inline: what it refuses", () => {
+  it("never produces an image node — there is no image node", () => {
+    // "No remote content of any kind" is the constraint. `![alt](url)` parses
+    // as a LINK labelled by its alt text, which is the useful non-fetching
+    // reading, and nothing in the AST can cause a request.
+    const nodes = parseInline("![a picture](https://example.com/x.png)");
+    const link = nodes[0];
+    if (link?.kind !== "link") throw new Error("expected a link");
+    expect(link.href).toBe("https://example.com/x.png");
+    expect(flatten(link.children)).toBe("a picture");
+    expect(JSON.stringify(nodes)).not.toContain("image");
+  });
+
+  it("drops a javascript: destination but keeps the words", () => {
+    // The two properties that matter: no link node reaches the renderer, and
+    // the label survives as text. A destination containing parentheses leaves
+    // the unmatched `)` as literal text, which is cosmetic and strictly safer
+    // than trying to balance parens inside a URL we have already rejected.
+    const nodes = parseInline("[click me](javascript:alert(1))");
+    expect(nodes.some((n) => n.kind === "link")).toBe(false);
+    expect(flatten(nodes)).toContain("click me");
+    expect(flatten(nodes)).not.toContain("javascript:");
+
+    // The ordinary shape, with no parens in the destination, is exact.
+    const plain = parseInline("[click me](javascript:alert)");
+    expect(plain.some((n) => n.kind === "link")).toBe(false);
+    expect(flatten(plain)).toBe("click me");
+  });
+
+  it("drops a data: destination too", () => {
+    const nodes = parseInline("[x](data:text/html;base64,AAA)");
+    expect(nodes.some((n) => n.kind === "link")).toBe(false);
+  });
+
+  it("allows exactly http, https and mailto", () => {
+    expect(isSafeHref("https://example.com")).toBe(true);
+    expect(isSafeHref("http://example.com")).toBe(true);
+    expect(isSafeHref("mailto:ada@example.com")).toBe(true);
+    expect(isSafeHref("javascript:alert(1)")).toBe(false);
+    expect(isSafeHref("JavaScript:alert(1)")).toBe(false);
+    expect(isSafeHref("data:text/html,x")).toBe(false);
+    expect(isSafeHref("file:///etc/passwd")).toBe(false);
+    expect(isSafeHref("vbscript:x")).toBe(false);
+    expect(isSafeHref("//example.com")).toBe(false);
+  });
+
+  it("leaves raw HTML as literal text", () => {
+    // Not parsed, not passed through. The renderer builds React elements from
+    // this AST, so there is no HTML string anywhere in the path — but the AST
+    // must not carry markup either.
+    const nodes = parseInline("<script>alert(1)</script>");
+    expect(nodes.every((n) => n.kind === "text")).toBe(true);
+    expect(flatten(nodes)).toBe("<script>alert(1)</script>");
+  });
+
+  it("survives adversarial nesting without throwing", () => {
+    for (const input of [
+      "*".repeat(200),
+      "`".repeat(200),
+      "[".repeat(200),
+      "![".repeat(100) + "]".repeat(100),
+      "**a*b**c*",
+      "[a](b",
+      "```".repeat(50),
+    ]) {
+      expect(() => parseCommitBody(input)).not.toThrow();
+    }
+  });
+});
+
+describe("round-tripping the text", () => {
+  it("keeps every character of a plain paragraph", () => {
+    // Nothing may be silently dropped: the rendered view is the default, and a
+    // renderer that eats content would hide part of a commit message.
+    const text = "Do the thing, then the other thing (see below).";
+    const blocks = parseCommitBody(text);
+    const p = blocks[0];
+    if (p?.kind !== "paragraph") throw new Error("expected a paragraph");
+    expect(flatten(p.children)).toBe(text);
+  });
+
+  it("keeps the words of a body full of syntax", () => {
+    const text = "Use `--force-with-lease`, not **--force**, when [rewriting](https://example.com).";
+    const blocks = parseCommitBody(text);
+    const p = blocks[0];
+    if (p?.kind !== "paragraph") throw new Error("expected a paragraph");
+    expect(flatten(p.children)).toBe(
+      "Use --force-with-lease, not --force, when rewriting.",
+    );
+  });
+});

--- a/src/features/commits/body/markdown.ts
+++ b/src/features/commits/body/markdown.ts
@@ -1,0 +1,325 @@
+// A restrained markdown subset for commit message BODIES (#253).
+//
+// ## Why a parser of our own rather than a dependency
+//
+// The issue asks for "restrained markdown" under two hard constraints: no
+// remote content of any kind, and a raw/rendered toggle. It also says any
+// markdown dependency needs a look at bundle size and sanitisation first — and
+// that look does not end well for the general-purpose libraries. They exist to
+// render arbitrary documents, which means HTML passthrough, images, and a
+// sanitiser you have to configure correctly forever. The subset a commit body
+// actually uses is small enough to parse in a few hundred lines, and parsing it
+// into a TYPED AST that the renderer turns into React elements removes the
+// whole `dangerouslySetInnerHTML` class of bug by construction: there is no
+// HTML string anywhere in this path.
+//
+// ## What is deliberately NOT in the subset
+//
+// - **Headings.** `#` at the start of a line is far more likely to be an issue
+//   reference in a commit body than an ATX heading, and getting that wrong on
+//   the first line of someone's message is worse than not supporting headings.
+// - **Images.** Nothing here may fetch. `![alt](url)` is parsed, but it renders
+//   as a LINK labelled with its alt text — the useful non-fetching reading —
+//   never as an `<img>`.
+// - **Raw HTML.** Not parsed, not passed through; it stays literal text.
+// - **Tables, footnotes, definition lists.** Not what commit bodies contain.
+//
+// The raw toggle is what makes all of this safe to be wrong about: a commit
+// message is a git object, and the user can always see it byte-for-byte.
+
+/** A run of inline content. */
+export type Inline =
+  | { kind: "text"; text: string }
+  | { kind: "code"; text: string }
+  | { kind: "em"; children: Inline[] }
+  | { kind: "strong"; children: Inline[] }
+  | { kind: "link"; href: string; children: Inline[] }
+  /**
+   * An issue reference like `#123`.
+   *
+   * Deliberately NOT a link. Turning it into one means guessing which forge and
+   * which repository the number belongs to, and there is no helper in the tree
+   * that resolves a remote to a web URL. A link to the wrong issue is worse
+   * than no link — so this is a styled token, and linking it is a follow-up
+   * that starts by building that resolver.
+   */
+  | { kind: "issue"; text: string };
+
+/** One trailer line, e.g. `Co-Authored-By: Ada <ada@example.com>`. */
+export interface Trailer {
+  key: string;
+  value: Inline[];
+}
+
+export type Block =
+  | { kind: "paragraph"; children: Inline[] }
+  | { kind: "code"; lang: string | null; text: string }
+  | { kind: "list"; ordered: boolean; items: Inline[][] }
+  | { kind: "trailers"; entries: Trailer[] };
+
+/**
+ * Schemes a link may use.
+ *
+ * An allow-list, not a deny-list: `javascript:` is the one everybody remembers
+ * and `data:` is the one they forget. Anything not named here is not a link at
+ * all — the text stays, the href is dropped.
+ */
+const SAFE_SCHEMES = ["http://", "https://", "mailto:"];
+
+export function isSafeHref(href: string): boolean {
+  const h = href.trim().toLowerCase();
+  return SAFE_SCHEMES.some((s) => h.startsWith(s));
+}
+
+/**
+ * git's own trailer rule: a key of `[A-Za-z0-9-]+` immediately followed by `:`.
+ *
+ * The same rule `signature.rs::is_trailer_line` applies in Rust, and for the
+ * same reason: it rejects prose that merely contains ": " (`See also: the
+ * README` — the key would contain a space) while accepting `Fixes:#123`.
+ */
+const TRAILER_RE = /^([A-Za-z0-9-]+):[ \t]?(.*)$/;
+
+export function isTrailerLine(line: string): boolean {
+  return TRAILER_RE.test(line.trimEnd());
+}
+
+const FENCE_RE = /^\s*```+\s*(\S*)\s*$/;
+const UL_RE = /^[ \t]*[-*+][ \t]+(.*)$/;
+const OL_RE = /^[ \t]*\d+[.)][ \t]+(.*)$/;
+
+/**
+ * Parse a commit body into blocks.
+ *
+ * The SUBJECT is never passed here. It is one line, it is not markdown, and
+ * rendering `*` in it as emphasis would change what the commit appears to say.
+ */
+export function parseCommitBody(text: string): Block[] {
+  const lines = text.replace(/\r\n?/g, "\n").split("\n");
+  const blocks: Block[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i] ?? "";
+
+    if (line.trim() === "") {
+      i += 1;
+      continue;
+    }
+
+    // ── fenced code ──────────────────────────────────────────────────────
+    const fence = FENCE_RE.exec(line);
+    if (fence) {
+      const lang = fence[1] ? fence[1] : null;
+      const body: string[] = [];
+      i += 1;
+      while (i < lines.length && !FENCE_RE.test(lines[i] ?? "")) {
+        body.push(lines[i] ?? "");
+        i += 1;
+      }
+      // An unterminated fence still produces a code block. Commit bodies get
+      // truncated and hand-edited; refusing to render one because its closing
+      // fence is missing would fail exactly when the content is most unusual.
+      if (i < lines.length) i += 1;
+      blocks.push({ kind: "code", lang, text: body.join("\n") });
+      continue;
+    }
+
+    // ── lists ────────────────────────────────────────────────────────────
+    const isUl = UL_RE.test(line);
+    const isOl = !isUl && OL_RE.test(line);
+    if (isUl || isOl) {
+      const re = isUl ? UL_RE : OL_RE;
+      const items: Inline[][] = [];
+      let current: string[] = [];
+      while (i < lines.length) {
+        const l = lines[i] ?? "";
+        const m = re.exec(l);
+        if (m) {
+          if (current.length > 0) items.push(parseInline(current.join(" ")));
+          current = [m[1] ?? ""];
+          i += 1;
+          continue;
+        }
+        // A continuation line: indented, non-blank, and not the start of the
+        // other kind of list. Commit bodies wrap at 72 columns, so a wrapped
+        // bullet is the normal case rather than an edge one.
+        if (l.trim() !== "" && /^[ \t]+/.test(l) && !UL_RE.test(l) && !OL_RE.test(l)) {
+          current.push(l.trim());
+          i += 1;
+          continue;
+        }
+        break;
+      }
+      if (current.length > 0) items.push(parseInline(current.join(" ")));
+      blocks.push({ kind: "list", ordered: isOl, items });
+      continue;
+    }
+
+    // ── paragraph (or trailer block) ─────────────────────────────────────
+    const para: string[] = [];
+    while (i < lines.length) {
+      const l = lines[i] ?? "";
+      if (l.trim() === "" || FENCE_RE.test(l) || UL_RE.test(l) || OL_RE.test(l)) break;
+      para.push(l);
+      i += 1;
+    }
+
+    // A block whose every line is a trailer is a trailer block, wherever it
+    // sits. git only recognises them at the end, but a body with a trailer
+    // block followed by a postscript is common enough, and styling them is
+    // useful in both positions.
+    if (para.length > 0 && para.every((l) => isTrailerLine(l))) {
+      blocks.push({
+        kind: "trailers",
+        entries: para.map((l) => {
+          const m = TRAILER_RE.exec(l.trimEnd());
+          return {
+            key: m?.[1] ?? "",
+            value: parseInline(m?.[2] ?? ""),
+          };
+        }),
+      });
+      continue;
+    }
+
+    blocks.push({ kind: "paragraph", children: parseInline(joinWrapped(para)) });
+  }
+
+  return blocks;
+}
+
+/**
+ * Join a hard-wrapped paragraph into one run.
+ *
+ * Commit bodies are wrapped at 72 columns by convention, and rendering each
+ * physical line as its own visual line is exactly the "reads badly" the issue
+ * is about. Markdown's own rule applies: a line ending in two spaces is a hard
+ * break and survives.
+ */
+function joinWrapped(lines: string[]): string {
+  let out = "";
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    out += line.replace(/[ \t]+$/, "");
+    if (i === lines.length - 1) break;
+    out += /[ ]{2,}$/.test(line) ? "\n" : " ";
+  }
+  return out;
+}
+
+// ── inline ──────────────────────────────────────────────────────────────────
+
+const BARE_URL_RE = /^(https?:\/\/[^\s<>()[\]]+[^\s<>()[\].,;:!?'"])/;
+
+/**
+ * Parse inline content.
+ *
+ * Code spans win over everything, which is what makes `` `a*b*c` `` render
+ * literally — the single most common way a naive renderer mangles a commit
+ * body that is talking ABOUT syntax.
+ */
+export function parseInline(text: string): Inline[] {
+  const out: Inline[] = [];
+  let buf = "";
+  let i = 0;
+
+  const flush = () => {
+    if (buf) {
+      out.push({ kind: "text", text: buf });
+      buf = "";
+    }
+  };
+
+  while (i < text.length) {
+    const rest = text.slice(i);
+
+    // `code`
+    if (text[i] === "`") {
+      const close = text.indexOf("`", i + 1);
+      if (close > i) {
+        flush();
+        out.push({ kind: "code", text: text.slice(i + 1, close) });
+        i = close + 1;
+        continue;
+      }
+    }
+
+    // ![alt](url) — a link, never an image. Checked before `[` so the `!` is
+    // consumed rather than left dangling in front of the link.
+    const img = /^!\[([^\]]*)\]\(([^)\s]+)\)/.exec(rest);
+    if (img) {
+      const href = img[2] ?? "";
+      const label = img[1] || href;
+      flush();
+      if (isSafeHref(href)) {
+        out.push({ kind: "link", href, children: [{ kind: "text", text: label }] });
+      } else {
+        out.push({ kind: "text", text: label });
+      }
+      i += img[0].length;
+      continue;
+    }
+
+    // [text](url)
+    const link = /^\[([^\]]*)\]\(([^)\s]+)\)/.exec(rest);
+    if (link) {
+      const href = link[2] ?? "";
+      const label = link[1] || href;
+      flush();
+      if (isSafeHref(href)) {
+        out.push({ kind: "link", href, children: parseInline(label) });
+      } else {
+        // Not a scheme we will open. Keep the words, drop the destination —
+        // silently rendering it as plain text is better than a link that does
+        // something the user did not ask for.
+        out.push(...parseInline(label));
+      }
+      i += link[0].length;
+      continue;
+    }
+
+    // bare URL
+    const bare = BARE_URL_RE.exec(rest);
+    if (bare) {
+      const href = bare[1] ?? "";
+      flush();
+      out.push({ kind: "link", href, children: [{ kind: "text", text: href }] });
+      i += href.length;
+      continue;
+    }
+
+    // **strong** / __strong__
+    const strong = /^(\*\*|__)(?=\S)([\s\S]*?\S)\1/.exec(rest);
+    if (strong) {
+      flush();
+      out.push({ kind: "strong", children: parseInline(strong[2] ?? "") });
+      i += strong[0].length;
+      continue;
+    }
+
+    // *em* / _em_
+    const em = /^(\*|_)(?=\S)([\s\S]*?\S)\1/.exec(rest);
+    if (em) {
+      flush();
+      out.push({ kind: "em", children: parseInline(em[2] ?? "") });
+      i += em[0].length;
+      continue;
+    }
+
+    // #123 — only at a word boundary, so `abc#1` and a hex colour are left be.
+    const issue = /^#(\d+)\b/.exec(rest);
+    if (issue && (i === 0 || /[\s([{]/.test(text[i - 1] ?? " "))) {
+      flush();
+      out.push({ kind: "issue", text: `#${issue[1]}` });
+      i += issue[0].length;
+      continue;
+    }
+
+    buf += text[i];
+    i += 1;
+  }
+
+  flush();
+  return out;
+}

--- a/src/features/settings/useSettingsStore.export.test.ts
+++ b/src/features/settings/useSettingsStore.export.test.ts
@@ -57,6 +57,9 @@ const PORTABLE = [
   // The branch-name → ticket regex (#252). Portable: it describes a TEAM's
   // ticket convention, which is exactly the kind of thing a settings file is
   // carried between machines to keep in step.
+  // Whether commit bodies render as markdown (#253). Portable: it is a
+  // reading preference, not a fact about this machine.
+  "commitBodyMarkdown",
   "commitTicketPattern",
   "confirmForcePush",
   "customThemes",

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -890,6 +890,15 @@ interface PersistedState {
    * refresh by hand than pay for it.
    */
   watchFilesystem: boolean;
+  /**
+   * Whether the commit BODY is rendered as restrained markdown (#253).
+   *
+   * A preference rather than a per-visit toggle, for the reason `diffViewMode`
+   * is: people who want the raw object want it every time, and people who want
+   * it readable want that every time. Never applies to the subject — that is
+   * one line and is not markdown.
+   */
+  commitBodyMarkdown: boolean;
   updateCheckMode: UpdateCheckMode;
   /**
    * Which releases update checks consider — see UpdateChannel.
@@ -991,6 +1000,7 @@ const DEFAULTS: PersistedState = {
   ignoreWhitespaceInDiff: false,
   externalDiffTool: "",
   watchFilesystem: true,
+  commitBodyMarkdown: true,
   updateCheckMode: "auto",
   updateChannel: "stable",
   lastCreateDir: "",

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -36,6 +36,7 @@ import { headAncestryOf } from "@/features/commits/headAncestry";
 import { buildRebasePlan } from "@/features/commits/buildRebasePlan";
 import { combinedSquashMessage } from "@/features/commits/squashMessage";
 import { runRebasePlanNow } from "@/features/commits/runRebasePlan";
+import { CommitBody } from "@/features/commits/body";
 import { CommitNotes } from "@/features/commits/CommitNotes";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { ShallowNotice } from "@/features/repo/ShallowNotice";
@@ -893,7 +894,9 @@ export function HistoryScreen() {
           sha={current.shortOid}
           fullSha={current.oid}
           subject={current.summary}
-          body={current.body ?? undefined}
+          bodyContent={
+            current.body ? <CommitBody text={current.body} /> : undefined
+          }
           author={current.author || "unknown"}
           email={current.email}
           date={relativeTime(current.timestamp)}


### PR DESCRIPTION
Closes #253 — this is the third and last part. Parts 1 (`git notes`, `CommitNotes.tsx`) and 2 (`blame.ignoreRevsFile`, `Blame.ignoreRevs.test.tsx`) already shipped.

Commit bodies were rendered as plain monospace text. Long bodies with lists, links and code fences read badly, and every squashed PR body is one.

## Why a parser of our own rather than a dependency

The issue sets two hard constraints — **no remote content of any kind**, and **a raw/rendered toggle** — and asks for a bundle-size and sanitisation review of any markdown dependency before adopting one. That review does not end well for the general-purpose libraries: they exist to render arbitrary documents, which means HTML passthrough, images, and a sanitiser that has to stay correctly configured forever.

So `markdown.ts` parses the subset into a **typed AST**, and `CommitBody.tsx` turns AST nodes into React elements. There is no HTML string anywhere in the path, which removes the whole `dangerouslySetInnerHTML` class of bug by construction rather than by vigilance. No new dependency; `privacy.test.ts` and `no_telemetry.rs` are untouched.

## What is deliberately *not* in the subset

- **Headings.** A leading `#` in a commit body is far more likely to be an issue reference than an ATX heading, and getting that wrong on someone's first line is worse than not supporting headings.
- **Images.** There is no image node in the AST for a renderer to grow one from. `![alt](url)` parses as a **link** labelled with its alt text — the useful non-fetching reading. A test asserts zero `<img>` (and zero `script`/`iframe`/`object`/`embed`/`link`) elements.
- **Raw HTML**, tables, footnotes.

## The safety surface

- Links are **allow-listed** to `http`, `https`, `mailto` (`isSafeHref`). Anything else keeps its words and loses its destination — `javascript:` and `data:` both have tests.
- Links open through `openUrl`, never by navigating: a plain navigation in a webview replaces the app.
- A fuzz-ish case throws 200-character runs of `*`, backticks, `[`, and unbalanced `![` at the parser and asserts it does not throw.

## One bullet I did not do, and why

The issue says "Linkify issue references (`#123`) and trailers while we are in there." Trailers are styled (key dimmed, monospace). **`#123` is a styled token, not a link** — linking it means guessing which forge and which repository the number belongs to, and there is no helper anywhere in the tree that resolves a remote URL to a forge web URL. A link to the wrong issue is worse than no link. Building that resolver is a clean follow-up, and the AST already has a dedicated `issue` node waiting for it. Happy to do it here instead if you'd rather.

## Details worth a look

- **Paragraphs are joined across hard-wrapped lines.** Bodies wrap at 72 columns, and one visual line per physical line *is* the "reads badly" the issue describes. Markdown's two-trailing-spaces hard break is honoured, and the raw toggle covers byte-fidelity.
- **The raw view is the original text**, not a re-serialisation of the parse — the one guarantee it exists to give, with a test pinning it.
- **Code spans win over emphasis**, so a body talking *about* syntax (`` `a*b*c` ``) is not mangled — the most common way a naive renderer ruins a commit message.
- `PGCommitDetail` gained a `bodyContent` slot rather than importing the renderer: the renderer reads a setting and opens URLs, so it belongs in `features/`, not `design/`. Callers that just want text keep passing `body`.
- `PGIconButton` gained `data-testid`, matching `PGSelect`/`PGInput`. Without it the only handle a test has on an icon button is its user-facing `title`, so rewording a tooltip silently breaks unrelated tests.

## Tests

39 new across `markdown.test.ts` (block structure, inline, and a whole `what it refuses` section) and `CommitBody.test.tsx` (the toggle, byte-for-byte raw, no-img, opener routing).

Green: `pnpm test` (2872 passed), `pnpm tsc --noEmit`, full `cargo test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
