### PR TITLE
feat(commit): named identities to switch a repository between (#233)

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -388,6 +388,44 @@ email joins this one rather than growing beside it.
   refusal names the offending character — so the button gates on "both fields
   non-empty" and nothing more.
 
+## Named identities (#233)
+
+`features/commits/identity/identityList.ts` + `SavedIdentities.tsx`: a small set
+of saved `{label, name, email}` entries, and a one-click "Use here" that applies
+one to the open repository.
+
+**There is deliberately no `repoId → identityId` map.** git already stores which
+identity a repository uses — `user.name`/`user.email` in that repository's own
+config, where the CLI, every hook and every other git tool read it. A second
+store of the same fact drifts the moment anyone runs `git config` in a terminal,
+and then the app confidently names an identity the next commit will not use.
+
+So the saved list is a **palette, not an assignment**. Applying an entry writes
+the repository's local config (through the same scoped `setIdentity` from #233's
+first half), and "which one is active here" is answered by reading git config
+back and matching on the name/email pair — never on the label, so a repository
+configured by hand still lights up the entry it corresponds to. The email
+compares case-insensitively, because addresses are.
+
+The consequence worth knowing, and the UI says it: **editing or removing an entry
+does not change any repository already using it.** Deleting a bookmark does not
+move the page.
+
+Applying always writes the REPOSITORY scope, never global — that is the feature
+(work address on work repositories), and it is the safe direction: a mis-click
+changes one repository rather than every repository on the machine. The global
+identity stays `IdentityForm`'s job, where the scope control makes it explicit.
+
+`identities` is in `NON_PORTABLE_KEYS`. A settings export is a file people share,
+and every other key in the bag describes how the app should behave; this one is a
+list of someone's email addresses, and it is useless on the receiving machine
+anyway.
+
+**Signing keys are not attached yet.** #233 lists one as optional and it is the
+right shape, but `signCommits` is a global tri-state (#61 D6) and the signing
+chain resolves its key from git config — a field nothing reads would be dead
+weight that later needs migrating.
+
 ## The commit-message composer (#252)
 
 `src/features/commits/message/` is **THE** commit-message composition surface —

--- a/src/features/commits/identity/SavedIdentities.test.tsx
+++ b/src/features/commits/identity/SavedIdentities.test.tsx
@@ -1,0 +1,220 @@
+// The saved-identity list, end to end (#233).
+//
+// The property worth guarding: applying an entry writes THIS REPOSITORY's
+// config, never the global one. Getting that backwards would change every
+// repository on the machine from a button labelled "Use here".
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import type { GitIdentity } from "@/lib/types";
+
+import { SavedIdentities } from "./SavedIdentities";
+import type { SavedIdentity } from "./identityList";
+
+const WORK: SavedIdentity = {
+  id: "a",
+  label: "Work",
+  name: "Ada Lovelace",
+  email: "ada@corp.example",
+};
+const PERSONAL: SavedIdentity = {
+  id: "b",
+  label: "Personal",
+  name: "Ada Lovelace",
+  email: "ada@home.example",
+};
+
+/** What git currently resolves to. Moved by tests. */
+let resolved: GitIdentity = {
+  name: { value: "Ada Lovelace", scope: "global" },
+  email: { value: "ada@home.example", scope: "global" },
+  globalConfigPath: "/home/ada/.gitconfig",
+  localConfigPath: "/repo/.git/config",
+};
+
+const saves = () => getInvokeCalls().filter((c) => c.cmd === "set_identity");
+
+function renderList(repoId: string | null = "repo-1") {
+  mockInvoke("get_identity", () => resolved);
+  mockInvoke("set_identity", () => null);
+  render(<SavedIdentities repoId={repoId} />);
+  return waitFor(() => expect(screen.getByTestId("saved-identities")).toBeTruthy());
+}
+
+beforeEach(() => {
+  resetInvokeMock();
+  useSettingsStore.getState().reset();
+  resolved = {
+    name: { value: "Ada Lovelace", scope: "global" },
+    email: { value: "ada@home.example", scope: "global" },
+    globalConfigPath: "/home/ada/.gitconfig",
+    localConfigPath: "/repo/.git/config",
+  };
+});
+
+describe("applying an identity", () => {
+  it("writes THIS repository's config, never the global one", async () => {
+    // The whole feature, in one assertion. A mis-scoped write here changes
+    // every repository on the machine.
+    useSettingsStore.getState().set("identities", [WORK, PERSONAL]);
+    await renderList();
+
+    const applyButtons = screen.getAllByTestId("saved-identity-apply");
+    fireEvent.click(applyButtons[0]!);
+
+    await waitFor(() => expect(saves()).toHaveLength(1));
+    expect(saves()[0].args).toMatchObject({
+      scope: "repository",
+      repoId: "repo-1",
+      name: "Ada Lovelace",
+      email: "ada@corp.example",
+    });
+  });
+
+  it("cannot be applied with no repository open", async () => {
+    // The backend refuses repository scope without a repo id, so an enabled
+    // button would be an offer that cannot be kept.
+    useSettingsStore.getState().set("identities", [WORK]);
+    await renderList(null);
+    const btn = screen.getByTestId<HTMLButtonElement>("saved-identity-apply");
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("re-reads git afterwards rather than assuming the write landed", async () => {
+    useSettingsStore.getState().set("identities", [WORK, PERSONAL]);
+    await renderList();
+    const before = getInvokeCalls().filter((c) => c.cmd === "get_identity").length;
+
+    fireEvent.click(screen.getAllByTestId("saved-identity-apply")[0]!);
+    await waitFor(() =>
+      expect(
+        getInvokeCalls().filter((c) => c.cmd === "get_identity").length,
+      ).toBeGreaterThan(before),
+    );
+  });
+
+  it("surfaces a refusal from the backend", async () => {
+    useSettingsStore.getState().set("identities", [WORK]);
+    mockInvoke("get_identity", () => resolved);
+    mockInvoke("set_identity", () => {
+      throw { kind: "InvalidArgument", message: "a name cannot contain '<'" };
+    });
+    render(<SavedIdentities repoId="repo-1" />);
+    await waitFor(() => expect(screen.getByTestId("saved-identity-apply")).toBeTruthy());
+    fireEvent.click(screen.getByTestId("saved-identity-apply"));
+    await waitFor(() =>
+      expect(screen.getByTestId("saved-identity-error").textContent).toContain(
+        "cannot contain",
+      ),
+    );
+  });
+});
+
+describe("which one is in use", () => {
+  it("marks the entry git actually resolves to", async () => {
+    useSettingsStore.getState().set("identities", [WORK, PERSONAL]);
+    await renderList();
+    // `resolved` is the personal address.
+    await waitFor(() =>
+      expect(screen.getByTestId("saved-identity-active")).toBeTruthy(),
+    );
+    const rows = screen.getAllByTestId("saved-identity-row");
+    expect(rows[1]?.textContent).toContain("in use here");
+    expect(rows[0]?.textContent).not.toContain("in use here");
+  });
+
+  it("marks nothing when git resolves to an unsaved identity", async () => {
+    resolved = {
+      ...resolved,
+      name: { value: "Grace Hopper", scope: "global" },
+      email: { value: "grace@example.com", scope: "global" },
+    };
+    useSettingsStore.getState().set("identities", [WORK, PERSONAL]);
+    await renderList();
+    await waitFor(() => expect(screen.getAllByTestId("saved-identity-row")).toHaveLength(2));
+    expect(screen.queryByTestId("saved-identity-active")).toBeNull();
+  });
+
+  it("does not offer to apply the one already in use", async () => {
+    useSettingsStore.getState().set("identities", [PERSONAL]);
+    await renderList();
+    await waitFor(() => expect(screen.getByTestId("saved-identity-active")).toBeTruthy());
+    expect(
+      screen.getByTestId<HTMLButtonElement>("saved-identity-apply").disabled,
+    ).toBe(true);
+  });
+});
+
+describe("managing the list", () => {
+  it("adds an identity", async () => {
+    await renderList();
+    fireEvent.click(screen.getByTestId("saved-identity-add"));
+    fireEvent.change(screen.getByTestId("saved-identity-label-input"), {
+      target: { value: "Work" },
+    });
+    fireEvent.change(screen.getByTestId("saved-identity-name-input"), {
+      target: { value: "Ada Lovelace" },
+    });
+    fireEvent.change(screen.getByTestId("saved-identity-email-input"), {
+      target: { value: "ada@corp.example" },
+    });
+    fireEvent.click(screen.getByTestId("saved-identity-save"));
+
+    const stored = useSettingsStore.getState().identities;
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({
+      label: "Work",
+      name: "Ada Lovelace",
+      email: "ada@corp.example",
+    });
+  });
+
+  it("will not save a half-filled row", async () => {
+    await renderList();
+    fireEvent.click(screen.getByTestId("saved-identity-add"));
+    fireEvent.change(screen.getByTestId("saved-identity-label-input"), {
+      target: { value: "Work" },
+    });
+    expect(
+      screen.getByTestId<HTMLButtonElement>("saved-identity-save").disabled,
+    ).toBe(true);
+  });
+
+  it("removes an identity without touching any repository", async () => {
+    // Deleting a bookmark does not move the page: a repository already using
+    // this identity keeps it, because the identity lives in git config.
+    useSettingsStore.getState().set("identities", [WORK, PERSONAL]);
+    await renderList();
+    fireEvent.click(screen.getAllByTestId("saved-identity-remove")[0]!);
+    expect(useSettingsStore.getState().identities.map((e) => e.id)).toEqual(["b"]);
+    expect(saves()).toHaveLength(0);
+  });
+
+  it("edits an identity in place", async () => {
+    useSettingsStore.getState().set("identities", [WORK]);
+    await renderList();
+    fireEvent.click(screen.getByTestId("saved-identity-edit"));
+    fireEvent.change(screen.getByTestId("saved-identity-label-input"), {
+      target: { value: "Day job" },
+    });
+    fireEvent.click(screen.getByTestId("saved-identity-save"));
+    const stored = useSettingsStore.getState().identities;
+    expect(stored).toHaveLength(1);
+    expect(stored[0]?.label).toBe("Day job");
+    expect(stored[0]?.id).toBe("a");
+  });
+});
+
+describe("privacy", () => {
+  it("saved identities are not carried by a settings export", async () => {
+    // An export is a file people SHARE. Every other preference describes how
+    // the app behaves; this one is a list of someone's email addresses.
+    useSettingsStore.getState().set("identities", [WORK, PERSONAL]);
+    const json = useSettingsStore.getState().exportSettings();
+    expect(json).not.toContain("ada@corp.example");
+    expect(json).not.toContain("identities");
+  });
+});

--- a/src/features/commits/identity/SavedIdentities.tsx
+++ b/src/features/commits/identity/SavedIdentities.tsx
@@ -1,0 +1,278 @@
+// The saved-identity list (#233).
+//
+// Sits under `IdentityForm` in Settings, and does one thing the form cannot:
+// let you keep more than one identity around and switch a repository between
+// them in a click.
+//
+// Applying an entry writes the REPOSITORY's config, never the global one. That
+// is the whole point of the feature — a work address on the work repositories
+// and a personal one everywhere else — and it is also the safe direction: a
+// mis-click changes one repository, not every repository on the machine. The
+// global identity stays `IdentityForm`'s job, where the scope control makes it
+// an explicit choice.
+
+import * as React from "react";
+
+import { PGButton, PGIcon, PGInput } from "@/design";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { appErrorMessage } from "@/lib/errors";
+import { setIdentity } from "@/lib/tauri";
+
+import { useIdentity } from "./useIdentity";
+import {
+  activeIdentity,
+  isSavableIdentity,
+  newIdentityId,
+  normalizeIdentity,
+  removeIdentity,
+  upsertIdentity,
+  type SavedIdentity,
+} from "./identityList";
+
+export interface SavedIdentitiesProps {
+  /** The open repository, or null in Settings with nothing open. */
+  repoId?: string | null;
+}
+
+const blank = (): SavedIdentity => ({
+  id: newIdentityId(),
+  label: "",
+  name: "",
+  email: "",
+});
+
+export function SavedIdentities({ repoId }: SavedIdentitiesProps) {
+  const identities = useSettingsStore((s) => s.identities);
+  const setSetting = useSettingsStore((s) => s.set);
+  const { identity, reload } = useIdentity(repoId ?? null);
+
+  const [draft, setDraft] = React.useState<SavedIdentity | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [applying, setApplying] = React.useState<string | null>(null);
+
+  const active = activeIdentity(identities, {
+    name: identity?.name?.value,
+    email: identity?.email?.value,
+  });
+
+  async function apply(entry: SavedIdentity) {
+    if (!repoId) return;
+    setApplying(entry.id);
+    setError(null);
+    try {
+      await setIdentity(entry.name, entry.email, "repository", repoId);
+      // Re-read rather than assume: this is what proves the write landed, and
+      // it is what lights up the "in use here" mark.
+      reload();
+    } catch (e) {
+      setError(appErrorMessage(e));
+    } finally {
+      setApplying(null);
+    }
+  }
+
+  function save() {
+    if (!draft || !isSavableIdentity(draft)) return;
+    setSetting("identities", upsertIdentity(identities, normalizeIdentity(draft)));
+    setDraft(null);
+  }
+
+  return (
+    <div
+      data-testid="saved-identities"
+      style={{ display: "flex", flexDirection: "column", gap: 8 }}
+    >
+      {identities.length === 0 && !draft && (
+        <div style={{ fontSize: "var(--fs-11)", color: "var(--fg-3)" }}>
+          No saved identities yet. Save the ones you switch between — a work
+          address and a personal one — and applying one writes it to the open
+          repository&rsquo;s own config.
+        </div>
+      )}
+
+      {identities.map((entry) =>
+        draft?.id === entry.id ? (
+          <IdentityEditor
+            key={entry.id}
+            draft={draft}
+            onChange={setDraft}
+            onSave={save}
+            onCancel={() => setDraft(null)}
+          />
+        ) : (
+          <div
+            key={entry.id}
+            data-testid="saved-identity-row"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              flexWrap: "wrap",
+            }}
+          >
+            <div style={{ flex: "1 1 200px", minWidth: 0 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                <span style={{ fontWeight: 600 }}>{entry.label}</span>
+                {active?.id === entry.id && (
+                  <span
+                    data-testid="saved-identity-active"
+                    title="This repository's commits are recorded as this identity"
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 3,
+                      fontSize: "var(--fs-10)",
+                      color: "var(--fg-2)",
+                    }}
+                  >
+                    <PGIcon name="check" size={10} />
+                    in use here
+                  </span>
+                )}
+              </div>
+              <div
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "var(--fs-11)",
+                  color: "var(--fg-3)",
+                  overflowWrap: "anywhere",
+                }}
+              >
+                {entry.name} &lt;{entry.email}&gt;
+              </div>
+            </div>
+            <PGButton
+              size="xs"
+              variant="outline"
+              // Only meaningful with a repository open: the backend refuses
+              // repository scope without one, so an enabled button here would
+              // be an offer that cannot be kept.
+              disabled={!repoId || applying !== null || active?.id === entry.id}
+              title={
+                !repoId
+                  ? "Open a repository to apply an identity to it"
+                  : active?.id === entry.id
+                    ? "Already in use in this repository"
+                    : `Write ${entry.name} <${entry.email}> to this repository's config`
+              }
+              onClick={() => void apply(entry)}
+              data-testid="saved-identity-apply"
+            >
+              {applying === entry.id ? "Applying…" : "Use here"}
+            </PGButton>
+            <PGButton
+              size="xs"
+              variant="ghost"
+              icon="edit"
+              title="Edit"
+              onClick={() => setDraft(entry)}
+              data-testid="saved-identity-edit"
+            />
+            <PGButton
+              size="xs"
+              variant="ghost"
+              icon="trash"
+              title="Remove from the list. Repositories already using it are not changed."
+              onClick={() => setSetting("identities", removeIdentity(identities, entry.id))}
+              data-testid="saved-identity-remove"
+            />
+          </div>
+        ),
+      )}
+
+      {draft && !identities.some((e) => e.id === draft.id) && (
+        <IdentityEditor
+          draft={draft}
+          onChange={setDraft}
+          onSave={save}
+          onCancel={() => setDraft(null)}
+        />
+      )}
+
+      {!draft && (
+        <div>
+          <PGButton
+            size="xs"
+            variant="outline"
+            icon="plus"
+            onClick={() => setDraft(blank())}
+            data-testid="saved-identity-add"
+          >
+            Add identity
+          </PGButton>
+        </div>
+      )}
+
+      {error && (
+        <div
+          data-testid="saved-identity-error"
+          style={{ fontSize: "var(--fs-11)", color: "var(--git-removed)" }}
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function IdentityEditor({
+  draft,
+  onChange,
+  onSave,
+  onCancel,
+}: {
+  draft: SavedIdentity;
+  onChange: (d: SavedIdentity) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div
+      data-testid="saved-identity-editor"
+      style={{ display: "flex", gap: 6, flexWrap: "wrap", alignItems: "center" }}
+    >
+      <PGInput
+        value={draft.label}
+        onChange={(v) => onChange({ ...draft, label: v })}
+        placeholder="Work"
+        size="sm"
+        aria-label="Label"
+        data-testid="saved-identity-label-input"
+        style={{ width: 96 }}
+      />
+      <PGInput
+        value={draft.name}
+        onChange={(v) => onChange({ ...draft, name: v })}
+        placeholder="Ada Lovelace"
+        size="sm"
+        aria-label="Name"
+        data-testid="saved-identity-name-input"
+        style={{ flex: "1 1 140px", minWidth: 0 }}
+      />
+      <PGInput
+        value={draft.email}
+        onChange={(v) => onChange({ ...draft, email: v })}
+        placeholder="ada@example.com"
+        size="sm"
+        mono
+        aria-label="Email"
+        data-testid="saved-identity-email-input"
+        style={{ flex: "1 1 180px", minWidth: 0 }}
+      />
+      <PGButton
+        size="xs"
+        variant="primary"
+        // Blankness only — everything git refuses beyond that is the backend's
+        // rule, and it names the offending character when a save is attempted.
+        disabled={!isSavableIdentity(draft)}
+        onClick={onSave}
+        data-testid="saved-identity-save"
+      >
+        Save
+      </PGButton>
+      <PGButton size="xs" variant="ghost" onClick={onCancel}>
+        Cancel
+      </PGButton>
+    </div>
+  );
+}

--- a/src/features/commits/identity/identityList.test.ts
+++ b/src/features/commits/identity/identityList.test.ts
@@ -1,0 +1,170 @@
+// The saved-identity list model (#233).
+//
+// The load-bearing function here is `activeIdentity`. It answers "which of my
+// saved identities is this repository actually using" by comparing against what
+// git resolved — never against a remembered assignment — which is what keeps
+// the app from confidently naming an identity the next commit will not use.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  activeIdentity,
+  isSavableIdentity,
+  newIdentityId,
+  normalizeIdentity,
+  removeIdentity,
+  upsertIdentity,
+  type SavedIdentity,
+} from "./identityList";
+
+const work: SavedIdentity = {
+  id: "a",
+  label: "Work",
+  name: "Ada Lovelace",
+  email: "ada@corp.example",
+};
+const personal: SavedIdentity = {
+  id: "b",
+  label: "Personal",
+  name: "Ada Lovelace",
+  email: "ada@home.example",
+};
+
+describe("activeIdentity", () => {
+  it("matches on the name and email pair, not the label", () => {
+    // The label is ours; the pair is git's. A repository configured by hand or
+    // by another tool must still light up the entry it corresponds to.
+    expect(
+      activeIdentity([work, personal], {
+        name: "Ada Lovelace",
+        email: "ada@home.example",
+      })?.id,
+    ).toBe("b");
+  });
+
+  it("distinguishes two identities that share a name", () => {
+    // The overwhelmingly common shape of this feature: same person, two
+    // addresses. Matching on name alone would pick whichever came first.
+    expect(
+      activeIdentity([work, personal], {
+        name: "Ada Lovelace",
+        email: "ada@corp.example",
+      })?.id,
+    ).toBe("a");
+  });
+
+  it("is case-insensitive about the email", () => {
+    // Addresses are. `Ada@Corp.Example` and `ada@corp.example` are the same
+    // person, not an unmatched identity.
+    expect(
+      activeIdentity([work], { name: "Ada Lovelace", email: "Ada@Corp.Example" })
+        ?.id,
+    ).toBe("a");
+  });
+
+  it("tolerates surrounding whitespace on either side", () => {
+    expect(
+      activeIdentity([work], {
+        name: "  Ada Lovelace ",
+        email: " ada@corp.example  ",
+      })?.id,
+    ).toBe("a");
+  });
+
+  it("is null when git resolves to something not on the list", () => {
+    // The honest answer, and the common one: most repositories use the global
+    // identity, which may not be saved here at all.
+    expect(
+      activeIdentity([work, personal], {
+        name: "Grace Hopper",
+        email: "grace@example.com",
+      }),
+    ).toBeNull();
+  });
+
+  it("is null when git has no identity at all", () => {
+    expect(activeIdentity([work], { name: null, email: null })).toBeNull();
+    expect(activeIdentity([work], { name: "Ada Lovelace", email: "" })).toBeNull();
+    expect(activeIdentity([work], { name: undefined, email: undefined })).toBeNull();
+  });
+
+  it("does not match a blank identity against a blank saved entry", () => {
+    // A present-but-blank `user.email` is the state git refuses on. It must not
+    // quietly "match" anything.
+    const empty: SavedIdentity = { id: "c", label: "x", name: "", email: "" };
+    expect(activeIdentity([empty], { name: "  ", email: "  " })).toBeNull();
+  });
+});
+
+describe("editing the list", () => {
+  it("adds a new entry at the end", () => {
+    expect(upsertIdentity([work], personal).map((e) => e.id)).toEqual(["a", "b"]);
+  });
+
+  it("replaces by id, in place", () => {
+    const renamed = { ...work, label: "Day job" };
+    const next = upsertIdentity([work, personal], renamed);
+    expect(next.map((e) => e.id)).toEqual(["a", "b"]);
+    expect(next[0]?.label).toBe("Day job");
+  });
+
+  it("trims what it stores", () => {
+    const next = upsertIdentity([], {
+      id: "x",
+      label: "  Work  ",
+      name: " Ada ",
+      email: " ada@example.com ",
+    });
+    expect(next[0]).toEqual({
+      id: "x",
+      label: "Work",
+      name: "Ada",
+      email: "ada@example.com",
+    });
+  });
+
+  it("removes by id and leaves the rest alone", () => {
+    expect(removeIdentity([work, personal], "a").map((e) => e.id)).toEqual(["b"]);
+    expect(removeIdentity([work], "nope").map((e) => e.id)).toEqual(["a"]);
+  });
+
+  it("never mutates the input", () => {
+    const list = [work];
+    upsertIdentity(list, personal);
+    removeIdentity(list, "a");
+    expect(list).toEqual([work]);
+  });
+});
+
+describe("what is savable", () => {
+  it("requires all three fields, non-blank", () => {
+    expect(isSavableIdentity(work)).toBe(true);
+    expect(isSavableIdentity({ ...work, label: "" })).toBe(false);
+    expect(isSavableIdentity({ ...work, name: "   " })).toBe(false);
+    expect(isSavableIdentity({ ...work, email: "" })).toBe(false);
+  });
+
+  it("does not re-implement what git will accept", () => {
+    // Blankness only. `Ada <Lovelace>` is refused by the BACKEND, whose message
+    // names the offending character — duplicating that rule here would create a
+    // second place for it to drift.
+    expect(isSavableIdentity({ ...work, name: "Ada <Lovelace>" })).toBe(true);
+  });
+
+  it("normalizeIdentity is what upsert stores", () => {
+    const messy = { id: "x", label: " a ", name: " b ", email: " c " };
+    expect(normalizeIdentity(messy)).toEqual({
+      id: "x",
+      label: "a",
+      name: "b",
+      email: "c",
+    });
+  });
+});
+
+describe("ids", () => {
+  it("are unique within a session", () => {
+    const ids = new Set(Array.from({ length: 50 }, () => newIdentityId()));
+    expect(ids.size).toBe(50);
+  });
+});

--- a/src/features/commits/identity/identityList.ts
+++ b/src/features/commits/identity/identityList.ts
@@ -1,0 +1,116 @@
+// Named identities (#233) — a work address and a personal one, kept somewhere
+// you can pick between them.
+//
+// ## Why there is no repo → identity map
+//
+// The obvious design is a table of `repoId → identityId`, and it is wrong. git
+// already stores which identity a repository uses: it is `user.name` /
+// `user.email` in that repository's own config, and the CLI, every hook, and
+// every other git tool read it. A second store of the same fact drifts the
+// moment anyone runs `git config user.email` in a terminal, and then the app
+// confidently shows an identity the next commit will not use.
+//
+// So the saved list is a PALETTE, not an assignment. Applying an entry writes
+// the repository's local config — which is what the issue asks for ("with the
+// chosen one written to the repo's local config so the CLI agrees with us") —
+// and "which one is active here" is answered by reading git config back and
+// matching, never by remembering. The consequence worth knowing: an identity
+// edited or deleted here does not change any repository that already uses it.
+// That is correct — deleting a bookmark does not move the page — and the UI
+// says so.
+
+/** One saved identity. */
+export interface SavedIdentity {
+  /** Stable across renames; what the UI keys on. */
+  id: string;
+  /** What the user calls it: "Work", "Personal", "OSS". */
+  label: string;
+  name: string;
+  email: string;
+}
+
+/**
+ * Signing keys are deliberately not here yet.
+ *
+ * The issue lists one as optional, and hanging a key off an identity is the
+ * right shape — but `signCommits` is a global tri-state today (#61 D6) and the
+ * signing chain resolves its key from git config. Adding a field nothing reads
+ * would be dead weight that later has to be migrated; wiring it properly is its
+ * own change.
+ */
+export const SIGNING_KEY_IS_A_FOLLOW_UP = true;
+
+let seq = 0;
+
+/** A fresh id. Time-based so two entries added in one session cannot collide. */
+export function newIdentityId(): string {
+  seq += 1;
+  return `id-${Date.now().toString(36)}-${seq}`;
+}
+
+/** Trim, and answer whether this is worth saving at all. */
+export function normalizeIdentity(entry: SavedIdentity): SavedIdentity {
+  return {
+    ...entry,
+    label: entry.label.trim(),
+    name: entry.name.trim(),
+    email: entry.email.trim(),
+  };
+}
+
+/**
+ * Whether an entry can be saved.
+ *
+ * Blankness only. Everything beyond it — a `<`, a line break — is the
+ * BACKEND's rule (`validate_identity`), and duplicating it here would create a
+ * second place for "what git accepts" to drift. The refusal from an actual save
+ * names the offending character; this just stops an obviously empty row.
+ */
+export function isSavableIdentity(entry: SavedIdentity): boolean {
+  const e = normalizeIdentity(entry);
+  return e.label !== "" && e.name !== "" && e.email !== "";
+}
+
+/**
+ * The saved entry that matches what git currently resolves to, or null.
+ *
+ * Matched on name AND email, not on the label: the label is ours, the pair is
+ * git's, and a repository configured by hand or by another tool should still
+ * light up the entry it corresponds to. Comparison is trimmed, and the email is
+ * case-insensitive — addresses are, and `Ada@Example.com` in one place and
+ * `ada@example.com` in the other is the same person, not an unmatched identity.
+ */
+export function activeIdentity(
+  saved: readonly SavedIdentity[],
+  current: { name: string | null | undefined; email: string | null | undefined },
+): SavedIdentity | null {
+  const name = (current.name ?? "").trim();
+  const email = (current.email ?? "").trim().toLowerCase();
+  if (!name || !email) return null;
+  return (
+    saved.find(
+      (s) =>
+        s.name.trim() === name && s.email.trim().toLowerCase() === email,
+    ) ?? null
+  );
+}
+
+/** Add or replace by id, preserving order. */
+export function upsertIdentity(
+  list: readonly SavedIdentity[],
+  entry: SavedIdentity,
+): SavedIdentity[] {
+  const next = normalizeIdentity(entry);
+  const i = list.findIndex((s) => s.id === next.id);
+  if (i === -1) return [...list, next];
+  const copy = [...list];
+  copy[i] = next;
+  return copy;
+}
+
+export function removeIdentity(
+  list: readonly SavedIdentity[],
+  id: string,
+): SavedIdentity[] {
+  return list.filter((s) => s.id !== id);
+}

--- a/src/features/settings/useSettingsStore.export.test.ts
+++ b/src/features/settings/useSettingsStore.export.test.ts
@@ -98,7 +98,11 @@ const PORTABLE = [
 ];
 
 /** Machine-specific, so deliberately absent from an export. */
-const EXCLUDED = ["lastCreateDir"];
+// Saved commit identities (#233) are DENIED, not exported. An export is a file
+// people share, and every other key in the bag says how the app should behave —
+// this one is a list of someone's name and email addresses. It is also useless
+// on the receiving machine, since identities are per-person by definition.
+const EXCLUDED = ["lastCreateDir", "identities"];
 
 describe("the exported key set", () => {
   it("is exactly the schema minus the deny-list", async () => {

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import type { PullMode } from "@/lib/tauri";
 import type { UpdateChannel } from "@/lib/types";
+import type { SavedIdentity } from "@/features/commits/identity/identityList";
 import {
   DEFAULT_HEAD_WEIGHT,
   HEAD_WEIGHTS,
@@ -899,6 +900,20 @@ interface PersistedState {
    * one line and is not markdown.
    */
   commitBodyMarkdown: boolean;
+  /**
+   * Saved commit identities to pick between (#233) — a work address and a
+   * personal one.
+   *
+   * A PALETTE, not an assignment: which identity a repository uses is
+   * `user.name`/`user.email` in that repository's own config, where git, the
+   * CLI and every hook already read it. Storing that mapping here as well
+   * would drift the moment someone ran `git config` in a terminal. Applying an
+   * entry WRITES the local config; "which one is active" is answered by
+   * reading it back and matching.
+   *
+   * NOT portable — see NON_PORTABLE_KEYS.
+   */
+  identities: SavedIdentity[];
   updateCheckMode: UpdateCheckMode;
   /**
    * Which releases update checks consider — see UpdateChannel.
@@ -1001,6 +1016,7 @@ const DEFAULTS: PersistedState = {
   externalDiffTool: "",
   watchFilesystem: true,
   commitBodyMarkdown: true,
+  identities: [],
   updateCheckMode: "auto",
   updateChannel: "stable",
   lastCreateDir: "",
@@ -1046,6 +1062,15 @@ const SETTINGS_SCHEMA_URL = "https://platypusgit.dev/settings.schema.json";
  */
 export const NON_PORTABLE_KEYS: readonly (keyof PersistedState)[] = [
   "lastCreateDir",
+  /**
+   * Saved identities (#233). Denied because an export is a file people SHARE:
+   * every other preference in the bag describes how the app should behave, and
+   * this one is a list of someone's name and email addresses. Carrying it into
+   * a colleague's install would leak personal data through a feature nobody
+   * expects to carry any — and the receiving machine has no use for it anyway,
+   * since identities are per-person by definition.
+   */
+  "identities",
 ];
 
 /** `DEFAULTS`' keys minus the deny-list — exactly what an export carries. */

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -31,6 +31,7 @@ import {
   isValidTicketPattern,
 } from "@/features/commits/message";
 import { IdentityForm } from "@/features/commits/identity/IdentityForm";
+import { SavedIdentities } from "@/features/commits/identity/SavedIdentities";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { HeadMarksControl } from "@/features/settings/HeadMarksControl";
 import { ForgeSettings } from "@/features/forge/ForgeSettings";
@@ -403,9 +404,15 @@ function IdentitySection() {
     >
       <Row
         label="Commit author"
-        hint="git refuses to record a commit without both. Saving writes them to your global git config, so every repository on this machine gets them."
+        hint="git refuses to record a commit without both. The scope control decides whether saving writes this repository's own config or your global one."
         stacked
         control={<IdentityForm repoId={repo?.id ?? null} />}
+      />
+      <Row
+        label="Saved identities"
+        hint="Keep the identities you switch between — a work address and a personal one. Applying one writes it to the OPEN repository's config, so git and every hook agree with what you see here. Editing or removing an entry does not change repositories that already use it."
+        stacked
+        control={<SavedIdentities repoId={repo?.id ?? null} />}
       />
     </Section>
   );


### PR DESCRIPTION
Part of #233 — the **named identities** bullet, deferred from #335. Two bullets still remain, listed at the bottom, so this deliberately does not close the issue.

Save the identities you switch between — a work address and a personal one — and apply one to the open repository in a click.

## The design decision worth reviewing: no `repoId → identityId` map

The obvious implementation is a table mapping repositories to identities, and I think it is wrong. **git already stores which identity a repository uses**: `user.name`/`user.email` in that repository's own config, where the CLI, every hook, and every other git tool read it. A second store of the same fact drifts the moment anyone runs `git config user.email` in a terminal — and then the app confidently shows an identity the next commit will not use, which is precisely the failure this whole issue exists to prevent.

So the saved list is a **palette, not an assignment**:

- Applying an entry **writes the repository's local config**, through the scoped `setIdentity` from #233's first half. This is what the issue asked for — *"with the chosen one written to the repo's local config so the CLI agrees with us"*.
- **"Which one is active here"** is computed by reading git config back and matching on the name/email **pair** — never the label, so a repository configured by hand or by another tool still lights up the entry it corresponds to. Email compares case-insensitively, because addresses are.

The consequence, which the UI states in the remove button's tooltip and the section hint: **editing or removing an entry does not change a repository already using it.** Deleting a bookmark does not move the page. I think that is the correct and least surprising behaviour, but it is a real design choice and worth a second opinion.

## Safety

- **Applying always writes the `repository` scope, never global.** That is the feature (work address on the work repositories), and it is the safe direction — a mis-click changes one repository rather than every repository on the machine. Global stays `IdentityForm`'s job, where the scope control makes it an explicit choice. There is a test asserting the scope and repo id that reach the IPC boundary.
- The "Use here" button is **disabled with no repository open**, because the backend refuses `repository` scope without a repo id and an enabled button would be an offer that cannot be kept.
- Validation here is **blankness only**. Everything git refuses beyond that (`<`, a line break) stays the backend's `validate_identity`, so there is no second place for "what git accepts" to drift; a refused save surfaces the backend's message, which names the offending character.

## Privacy

`identities` joins `NON_PORTABLE_KEYS`. A settings export is a file people *share*, and every other key in that bag describes how the app should behave — this one is a list of someone's name and email addresses, and it is useless on the receiving machine anyway since identities are per-person. A test asserts an export contains neither the key nor the addresses.

## Still open on #233

- **Tie in signing.** The issue notes a signing key belongs to an identity. Not done: `signCommits` is a global tri-state (#61 D6) and the signing chain resolves its key from git config, so a field nothing reads would be dead weight that later needs migrating. Wiring it properly is its own change.
- **Per-repository default editor**, the adjacent "per-repo override" shape the issue mentions as cheap once identities exist.

Happy to split those into their own issue if you'd rather see #233 closed.

## Tests

- `identityList.test.ts` — 20: matching (two identities sharing a name, case-insensitive email, whitespace, unsaved identity, blank identity), list editing, savability, input immutability.
- `SavedIdentities.test.tsx` — 13: the scope/repo id that reach the backend, disabled with no repo, re-read after apply, backend refusal surfaced, the "in use here" mark, add/edit/remove, and the export-privacy assertion.

Green: `pnpm test` (2861 passed), `pnpm tsc --noEmit`, full `cargo test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
