### PR TITLE
feat(actions): user-defined commands in the command palette (#225)

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -226,6 +226,21 @@ git/
 │                what the branch contains and deleting it would destroy a ref
 │                nobody asked us to touch. config_enabled reads
 │                rebase.updateRefs, and the default is git's own `false`
+custom_action.rs SECURITY-critical, and pure (#225). A user-supplied command
+                 string is NOT a shell line: parse_command splits it into argv
+                 (quotes group; `| > ; && $ *` are ORDINARY CHARACTERS because
+                 nothing interprets them), then `substitute` expands
+                 $REPO/$FILE/$FILES/$SHA/$BRANCH INTO INDIVIDUAL ARGV ENTRIES.
+                 So a value can never introduce a new argument — a branch named
+                 `main; rm -rf ~` stays one argument, and branch names come from
+                 anyone who ever pushed. Two traps the tests pin: substitution
+                 is ONE left-to-right pass, because chained str::replace
+                 re-scans text it just wrote (a file named `$SHA` would pull in
+                 the sha — values are DATA, not templates); and placeholders are
+                 tried LONGEST NAME FIRST, because `$FILE` is a prefix of
+                 `$FILES`. Spawned through proc::program_async only, with no
+                 token, credential or askpass — a custom action is a USER
+                 program, not a trusted one
 ├── auth.rs      PURE: classify_auth_failure (stderr → AuthKind; host-key
 │                failure deliberately not auth), AuthChallenge, scrub_credentials
 ├── hooks.rs     The ONE place a git hook is executed (#232). `git hook run`,
@@ -385,6 +400,14 @@ commands/        Thin Tauri handlers, one file per area:
 │                commands: remember_credential — stored only after the
 │                credential worked — and cancel_network_op, which stops a
 │                stalled clone/fetch/pull/push (#234). See backend.md
+├── custom_action.rs run_custom_action (#225) — thin over
+│                src-tauri/src/custom_action.rs, which decides WHAT runs. The
+│                workdir is resolved through the backend, never taken from the
+│                frontend: it is about to become a child process's cwd, and a
+│                path argument would be a second source of truth for where a
+│                repository lives. Output is captured and truncated with a
+│                marker, so a command that prints a gigabyte cannot become a
+│                gigabyte-sized IPC message
 ├── update.rs    check_for_update, get_update_capability, open_url — thin
 │                handlers for src-tauri/src/update.rs (same basename, two files)
 ├── watch.rs     watch_repo, watch_stop (#239) — thin over src-tauri/src/
@@ -475,6 +498,15 @@ features/            Components + Zustand store colocated per feature:
 │                    activate/close/cycle + session restore), RepoTabs,
 │                    useRecentsStore, ops (shared runners), OperationBar
 │                    (repoState-driven bar), ownership (safe.directory confirm)
+├── actions/         User-defined commands (#225): customActions (the list, its
+│                    validation, and how a result is reported — a FAILURE is
+│                    always shown whatever the setting says, because an action
+│                    that exits non-zero silently is indistinguishable from one
+│                    that never ran), runAction (spawn → report → refresh, with
+│                    a RepoActivity entry so a slow user program is visible),
+│                    CustomActionsSettings. Deliberately does NOT re-implement
+│                    the command parser — that lives beside the spawn in Rust,
+│                    and a second one would be a second place to drift
 ├── nav/             useNavStore — cross-screen intents + DeepViewHeader
 ├── branches/        BranchChip, BranchPicker, orderBranches (PURE, #135 — THE
 │                    one branch ordering; every branch list goes through it),

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -979,3 +979,43 @@ unless set. Turning it on for someone who did not ask is the same class of
 surprise as leaving their stack behind, just in the other direction. The
 frontend still confirms first and names every ref (`features/commits/stackedRefs.ts`),
 because the flag alone is a silent behaviour change.
+## A user-supplied command string is not a shell line (#225)
+
+Custom actions let a user run their own program from the UI. The tempting
+implementation is `sh -c "<the string>"`, and it is wrong in a way that stays
+invisible until it bites: under a shell, a branch named `main; rm -rf ~` or a
+path containing `$(...)` stops being **data** and becomes **code**. Branch names
+and paths come from the repository, which means they can come from anyone who
+has ever pushed to it.
+
+`custom_action.rs` is therefore pure, and the whole design is three steps:
+
+1. **`parse_command`** splits the string into argv once. Quotes group; a
+   backslash escapes (except inside single quotes, so a Windows path survives).
+   `|`, `>`, `;`, `&&`, `$`, `*`, `~` are ordinary characters, because that is
+   all they can be when nothing interprets them.
+2. **`substitute`** expands `$REPO` / `$FILE` / `$FILES` / `$SHA` / `$BRANCH`
+   **into individual argv entries**, after splitting. A value can therefore
+   never introduce a new argument, however it is spelled.
+3. **`proc::program_async`** spawns it — the only sanctioned constructor (a
+   guard test fails the build on a bare `Command::new`), which also carries the
+   `CREATE_NO_WINDOW` treatment from #172 so an action never flashes a console.
+
+Two traps worth knowing before editing `substitute`, both pinned by tests:
+
+- **It is ONE left-to-right pass.** Chained `str::replace` calls re-scan text an
+  earlier call just substituted, so a file literally named `$SHA` would pull in
+  the commit sha. Values are data, not templates; emitting each expansion
+  straight into the output and never looking at it again makes that structural.
+- **Placeholders are tried LONGEST NAME FIRST**, because `$FILE` is a prefix of
+  `$FILES`. Anything else matches `$FILE` inside `$FILES` and leaves a stray
+  `S`.
+
+`$FILES` is the one placeholder that changes the *number* of arguments, and only
+when it is the whole entry — as whole entries, never by splitting a joined
+string. Inside a larger argument (`--files=$FILES`) it joins, because "become N
+arguments" cannot be expressed as a substring replacement.
+
+**No secrets, ever.** A custom action is a user program, not a trusted one:
+nothing from the auth path goes near it — no forge token, no git credential, no
+askpass wiring. It gets the ordinary child environment `proc.rs` builds.

--- a/src-tauri/src/commands/custom_action.rs
+++ b/src-tauri/src/commands/custom_action.rs
@@ -1,0 +1,73 @@
+//! Run a user-defined command (#225).
+//!
+//! Thin: everything that decides WHAT runs is in `custom_action.rs`, which is
+//! pure and heavily tested, because that is where the security properties live.
+//! This file only spawns what that module produced.
+
+use std::process::Stdio;
+
+use tauri::State;
+
+use crate::{
+    custom_action::{build_argv, truncate_output, ActionContext, ActionOutput},
+    error::{AppError, AppResult},
+    git::types::RepoId,
+    state::AppState,
+};
+
+/// Run `command` with the placeholders in `context` substituted.
+///
+/// The working directory is the repository's, resolved through the backend
+/// rather than taken from the frontend — a path argument would be a second
+/// source of truth for where a repository lives, and this one is about to
+/// become a child process's cwd.
+///
+/// **Nothing from the auth path goes near this.** A custom action is a user
+/// program, not a trusted one: no forge token, no git credential, no askpass.
+/// It gets the ordinary child environment `proc.rs` builds and nothing else.
+#[tauri::command]
+pub async fn run_custom_action(
+    state: State<'_, AppState>,
+    repo_id: String,
+    command: String,
+    context: ActionContext,
+) -> AppResult<ActionOutput> {
+    let backend = state.backend.clone();
+    let id = RepoId(repo_id);
+    let workdir = tokio::task::spawn_blocking(move || backend.repo_path(&id))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))??;
+
+    // The repo path the child actually gets, so `$REPO` and the cwd cannot
+    // disagree — the frontend never supplies it.
+    let ctx = ActionContext {
+        repo: workdir.to_string_lossy().to_string(),
+        ..context
+    };
+    let argv = build_argv(&command, &ctx)?;
+    let (program, args) = argv.split_first().expect("build_argv rejects empty argv");
+
+    // `proc::program_async` is the ONLY sanctioned constructor (a guard test
+    // fails the build on a bare `Command::new`), and it carries the
+    // CREATE_NO_WINDOW treatment from #172 so this never flashes a console.
+    let mut cmd = crate::proc::program_async(program);
+    cmd.args(args)
+        .current_dir(&workdir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let out = cmd.output().await.map_err(|e| {
+        // The overwhelmingly common failure, and the one worth naming: the
+        // program is not on PATH. The raw io::Error says "No such file or
+        // directory" without saying which file.
+        AppError::Io(format!("could not run `{program}`: {e}"))
+    })?;
+
+    Ok(ActionOutput {
+        code: out.status.code(),
+        stdout: truncate_output(String::from_utf8_lossy(&out.stdout).to_string()),
+        stderr: truncate_output(String::from_utf8_lossy(&out.stderr).to_string()),
+        argv: argv.clone(),
+    })
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod cli;
 pub mod commits;
 pub mod conflict;
 pub mod create;
+pub mod custom_action;
 pub mod diagnostics;
 pub mod diff;
 pub mod forge;

--- a/src-tauri/src/custom_action.rs
+++ b/src-tauri/src/custom_action.rs
@@ -1,0 +1,262 @@
+//! User-defined external commands (#225).
+//!
+//! The feature that lets a GUI absorb the one git-adjacent command a team runs
+//! fifty times a day, without that command having to be something we shipped.
+//!
+//! ## A user-supplied command string is NOT a shell line
+//!
+//! This is the whole security design, and it is worth being explicit about
+//! because the tempting implementation — hand the string to `sh -c` — is wrong
+//! in a way that is invisible until it bites. Under a shell, a branch named
+//! `main; rm -rf ~` or a path containing `$(...)` stops being *data* and becomes
+//! *code*. Branch names and paths come from the repository, which means they can
+//! come from anyone who has ever pushed to it.
+//!
+//! So:
+//!
+//! 1. The command string is parsed ONCE, here, into a program plus an argv
+//!    vector — quotes group, nothing else is special. No globbing, no variable
+//!    expansion, no operators: `|`, `>`, `;`, `&&` are ordinary characters in an
+//!    argument, because that is all they can be when nothing interprets them.
+//! 2. Placeholders are substituted INTO INDIVIDUAL ARGV ENTRIES, after parsing.
+//!    A value can never introduce a new argument, however it is spelled — a path
+//!    with a space stays one argument, and a branch name with a `;` stays a
+//!    branch name.
+//! 3. The result is spawned directly through `proc::program_async`, which is the
+//!    only place in this codebase allowed to construct a `Command` (a guard test
+//!    fails the build otherwise) and which carries the `CREATE_NO_WINDOW`
+//!    treatment from #172, so a custom action never flashes a console on Windows.
+//!
+//! The one placeholder that legitimately expands to several arguments is
+//! `$FILES`, and it does so as whole entries — never by splitting a string.
+//!
+//! ## No secrets, ever
+//!
+//! A custom action is a USER program, not a trusted one. Nothing from the auth
+//! path goes near it: no forge token, no git credential, no askpass wiring. It
+//! inherits the ordinary child environment `proc.rs` builds and nothing else.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{AppError, AppResult};
+
+/// The values a placeholder can take for one invocation.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActionContext {
+    /// The repository's working directory. Always present.
+    pub repo: String,
+    /// Selected files, repo-relative. Empty when the action was not invoked on
+    /// a file.
+    #[serde(default)]
+    pub files: Vec<String>,
+    /// The selected commit, if any.
+    #[serde(default)]
+    pub sha: Option<String>,
+    /// The current branch, if HEAD is on one.
+    #[serde(default)]
+    pub branch: Option<String>,
+}
+
+/// What a finished action reports back.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ActionOutput {
+    /// Exit status, or `None` when the process was killed by a signal.
+    pub code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    /// The argv actually spawned, for the output panel — so "what did it run"
+    /// is answerable without guessing at how the string was parsed.
+    pub argv: Vec<String>,
+}
+
+/// How much output is kept.
+///
+/// A command that prints a gigabyte must not become a gigabyte-sized IPC
+/// message and a frozen UI. Truncated with a marker rather than silently, so
+/// the panel never implies it showed everything.
+pub const MAX_OUTPUT_BYTES: usize = 256 * 1024;
+
+pub fn truncate_output(mut s: String) -> String {
+    if s.len() <= MAX_OUTPUT_BYTES {
+        return s;
+    }
+    s.truncate(MAX_OUTPUT_BYTES);
+    s.push_str("\n… output truncated");
+    s
+}
+
+/// Split a command string into program + arguments.
+///
+/// **Not a shell.** Quotes (single and double) group; a backslash escapes the
+/// next character inside double quotes and outside them. Everything else —
+/// including `|`, `>`, `;`, `&&`, `$`, `*` — is a literal character in whatever
+/// argument it lands in.
+///
+/// Refuses an empty command rather than spawning something ambiguous.
+pub fn parse_command(line: &str) -> AppResult<Vec<String>> {
+    let mut argv: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    let mut has_cur = false;
+    let mut chars = line.chars().peekable();
+    let mut quote: Option<char> = None;
+
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => {
+                // An escape is literal inside single quotes, the way a shell
+                // treats it — otherwise a Windows path in single quotes would
+                // lose its separators.
+                if quote == Some('\'') {
+                    cur.push(c);
+                    has_cur = true;
+                } else if let Some(next) = chars.next() {
+                    cur.push(next);
+                    has_cur = true;
+                } else {
+                    return Err(AppError::InvalidArgument(
+                        "the command ends with a trailing backslash".to_string(),
+                    ));
+                }
+            }
+            '\'' | '"' => match quote {
+                Some(q) if q == c => {
+                    quote = None;
+                    // An empty quoted string IS an argument: `foo ""` is two.
+                    has_cur = true;
+                }
+                Some(_) => {
+                    cur.push(c);
+                    has_cur = true;
+                }
+                None => {
+                    quote = Some(c);
+                    has_cur = true;
+                }
+            },
+            c if c.is_whitespace() && quote.is_none() => {
+                if has_cur {
+                    argv.push(std::mem::take(&mut cur));
+                    has_cur = false;
+                }
+            }
+            c => {
+                cur.push(c);
+                has_cur = true;
+            }
+        }
+    }
+
+    if quote.is_some() {
+        return Err(AppError::InvalidArgument(
+            "the command has an unclosed quote".to_string(),
+        ));
+    }
+    if has_cur {
+        argv.push(cur);
+    }
+    if argv.is_empty() {
+        return Err(AppError::InvalidArgument(
+            "the command is empty".to_string(),
+        ));
+    }
+    Ok(argv)
+}
+
+/// The placeholders and their values, LONGEST NAME FIRST.
+///
+/// The order is load-bearing: `$FILE` is a prefix of `$FILES`, so a scan that
+/// tried them in any other order would match `$FILE` inside `$FILES` and leave
+/// a stray `S` behind. Sorting by descending length makes that structural
+/// rather than something the next placeholder has to remember.
+fn placeholders(ctx: &ActionContext) -> Vec<(&'static str, String)> {
+    let mut v: Vec<(&'static str, String)> = vec![
+        ("$REPO", ctx.repo.clone()),
+        // Every selected file, space-joined. Only reached when `$FILES` appears
+        // INSIDE a larger argument — a bare `$FILES` entry expands to one
+        // argument per file, which a string substitution cannot express.
+        ("$FILES", ctx.files.join(" ")),
+        // The FIRST selected file, which is what `$FILE` means on a
+        // single-select surface. Empty rather than absent when nothing is
+        // selected: an action invoked without a file should get an empty
+        // argument, not the four literal characters `$FILE`, which look like a
+        // real argument and fail somewhere further away.
+        ("$FILE", ctx.files.first().cloned().unwrap_or_default()),
+        ("$SHA", ctx.sha.clone().unwrap_or_default()),
+        ("$BRANCH", ctx.branch.clone().unwrap_or_default()),
+    ];
+    v.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+    v
+}
+
+/// Expand placeholders in ONE pass, left to right.
+///
+/// A single pass is the point. Chained `str::replace` calls re-scan text that
+/// an earlier call just substituted, so a file literally named `$SHA` would
+/// pull in the commit sha — the substituted value would be treated as another
+/// template. Values are DATA. Emitting each expansion straight into the output
+/// and never looking at it again is what makes that true by construction.
+fn expand(entry: &str, vars: &[(&'static str, String)]) -> String {
+    let mut out = String::new();
+    let mut rest = entry;
+    'outer: while !rest.is_empty() {
+        if rest.starts_with('$') {
+            for (name, value) in vars {
+                if let Some(tail) = rest.strip_prefix(name) {
+                    out.push_str(value);
+                    rest = tail;
+                    continue 'outer;
+                }
+            }
+        }
+        // Not a placeholder — copy one character and move on. Char-wise rather
+        // than byte-wise so a multi-byte character is never split.
+        let c = rest.chars().next().expect("rest is non-empty");
+        out.push(c);
+        rest = &rest[c.len_utf8()..];
+    }
+    out
+}
+
+/// Substitute placeholders into already-parsed argv entries.
+///
+/// The security property: a substituted value can never introduce a new
+/// argument. `$BRANCH` holding `main; rm -rf ~` produces ONE argument
+/// containing that text, because splitting already happened in `parse_command`
+/// and nothing re-splits afterwards.
+///
+/// An entry that is exactly `$FILES` expands to one argument per selected file
+/// — as whole entries, never by splitting a joined string. An entry that merely
+/// CONTAINS `$FILES` gets the files space-joined, because there is no sensible
+/// way to expand `--files=$FILES` into several arguments and joining is the
+/// least surprising reading.
+pub fn substitute(argv: &[String], ctx: &ActionContext) -> Vec<String> {
+    let vars = placeholders(ctx);
+    let mut out: Vec<String> = Vec::new();
+    for entry in argv {
+        // The one placeholder that changes the NUMBER of arguments, and it only
+        // does so when it is the whole entry. Handled before `expand` because a
+        // string substitution cannot express "become N arguments".
+        if entry == "$FILES" {
+            out.extend(ctx.files.iter().cloned());
+            continue;
+        }
+        out.push(expand(entry, &vars));
+    }
+    out
+}
+
+/// Parse and substitute in one step — the whole argv pipeline.
+pub fn build_argv(command: &str, ctx: &ActionContext) -> AppResult<Vec<String>> {
+    let parsed = parse_command(command)?;
+    let argv = substitute(&parsed, ctx);
+    // Substitution can empty the program name (`$FILE` as the program with no
+    // file selected). Spawning "" is a confusing OS error; this is a clear one.
+    if argv.first().map(String::is_empty).unwrap_or(true) {
+        return Err(AppError::InvalidArgument(
+            "the command's program name is empty after substitution".to_string(),
+        ));
+    }
+    Ok(argv)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cancel;
 pub mod cli;
+pub mod custom_action;
 pub mod commands;
 pub mod detach;
 pub mod diagnostics;
@@ -347,6 +348,7 @@ pub fn run() {
             commands::ssh::ssh_key_generate,
             commands::update::check_for_update,
             commands::update::get_update_capability,
+            commands::custom_action::run_custom_action,
             commands::watch::watch_repo,
             commands::watch::watch_stop,
             commands::update::open_url,

--- a/src-tauri/tests/custom_action.rs
+++ b/src-tauri/tests/custom_action.rs
@@ -1,0 +1,271 @@
+//! User-defined commands (#225) — mostly about what a user's data CANNOT do.
+//!
+//! The tempting implementation of this feature is `sh -c "<the string>"`, and it
+//! is wrong in a way that stays invisible until it bites: under a shell, a
+//! branch named `main; rm -rf ~` or a path containing `$(...)` stops being data
+//! and becomes code. Branch names and paths come from the repository, which
+//! means they can come from anyone who has ever pushed to it.
+//!
+//! So the load-bearing property, asserted from several directions below, is:
+//! **a substituted value can never introduce a new argument.**
+
+use platypusgit_lib::custom_action::{
+    build_argv, parse_command, substitute, truncate_output, ActionContext, MAX_OUTPUT_BYTES,
+};
+use platypusgit_lib::error::AppError;
+
+fn ctx() -> ActionContext {
+    ActionContext {
+        repo: "/repo".to_string(),
+        files: vec!["src/a.rs".to_string()],
+        sha: Some("abc123".to_string()),
+        branch: Some("main".to_string()),
+    }
+}
+
+fn parse(line: &str) -> Vec<String> {
+    parse_command(line).expect("should parse")
+}
+
+fn refusal(line: &str) -> String {
+    match parse_command(line) {
+        Err(AppError::InvalidArgument(m)) => m,
+        other => panic!("expected InvalidArgument for {line:?}, got {other:?}"),
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Parsing: quotes group, nothing else is special
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn splits_on_whitespace() {
+    assert_eq!(parse("code -g file"), vec!["code", "-g", "file"]);
+    assert_eq!(parse("  code   -g  "), vec!["code", "-g"]);
+    assert_eq!(parse("code\t-g\nfile"), vec!["code", "-g", "file"]);
+}
+
+#[test]
+fn quotes_group_arguments() {
+    assert_eq!(
+        parse(r#"code "my file.txt""#),
+        vec!["code", "my file.txt"]
+    );
+    assert_eq!(parse("code 'my file.txt'"), vec!["code", "my file.txt"]);
+    // Adjacent quoting concatenates, the way a shell does.
+    assert_eq!(parse(r#"a "b"c"#), vec!["a", "bc"]);
+    // An empty quoted string IS an argument.
+    assert_eq!(parse(r#"foo "" bar"#), vec!["foo", "", "bar"]);
+}
+
+#[test]
+fn backslash_escapes_outside_single_quotes() {
+    assert_eq!(parse(r"code my\ file"), vec!["code", "my file"]);
+    assert_eq!(parse(r#"code "a\"b""#), vec!["code", r#"a"b"#]);
+    // Inside single quotes a backslash is literal, so a Windows path survives.
+    assert_eq!(parse(r"code 'C:\Users\me'"), vec!["code", r"C:\Users\me"]);
+}
+
+#[test]
+fn shell_operators_are_ORDINARY_CHARACTERS() {
+    // Nothing interprets them, so they can only ever be text in an argument.
+    // This is the property that makes the whole feature safe.
+    assert_eq!(
+        parse("echo a;rm -rf /"),
+        vec!["echo", "a;rm", "-rf", "/"],
+        "a semicolon does not start a second command",
+    );
+    assert_eq!(parse("echo a|b"), vec!["echo", "a|b"]);
+    assert_eq!(parse("echo a>b"), vec!["echo", "a>b"]);
+    assert_eq!(parse("echo a&&b"), vec!["echo", "a&&b"]);
+    assert_eq!(parse("echo $(whoami)"), vec!["echo", "$(whoami)"]);
+    assert_eq!(parse("echo `whoami`"), vec!["echo", "`whoami`"]);
+    assert_eq!(parse("echo *"), vec!["echo", "*"], "no globbing");
+    assert_eq!(parse("echo ~"), vec!["echo", "~"], "no tilde expansion");
+    assert_eq!(parse("echo $HOME"), vec!["echo", "$HOME"], "no env expansion");
+}
+
+#[test]
+fn refuses_what_it_cannot_parse() {
+    assert!(refusal(r#"code "unclosed"#).contains("unclosed quote"));
+    assert!(refusal("code 'unclosed").contains("unclosed quote"));
+    assert!(refusal(r"code trailing\").contains("trailing backslash"));
+    assert!(refusal("").contains("empty"));
+    assert!(refusal("   ").contains("empty"));
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Substitution: into individual entries, never creating new ones
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn substitutes_the_documented_placeholders() {
+    let argv = substitute(
+        &parse("tool $REPO $FILE $SHA $BRANCH"),
+        &ctx(),
+    );
+    assert_eq!(argv, vec!["tool", "/repo", "src/a.rs", "abc123", "main"]);
+}
+
+#[test]
+fn substitutes_inside_a_larger_argument() {
+    let argv = substitute(&parse("tool --repo=$REPO/sub"), &ctx());
+    assert_eq!(argv, vec!["tool", "--repo=/repo/sub"]);
+}
+
+#[test]
+fn a_value_containing_a_space_stays_ONE_argument() {
+    // The property the whole design exists for. Splitting already happened in
+    // `parse_command`; nothing re-splits afterwards.
+    let mut c = ctx();
+    c.files = vec!["my file.txt".to_string()];
+    let argv = substitute(&parse("tool $FILE"), &c);
+    assert_eq!(argv, vec!["tool", "my file.txt"]);
+    assert_eq!(argv.len(), 2, "still two arguments, not three");
+}
+
+#[test]
+fn a_branch_name_with_shell_metacharacters_is_inert() {
+    // Branch names come from the repository, which means from anyone who has
+    // ever pushed to it. Under `sh -c` this would be a second command.
+    let mut c = ctx();
+    c.branch = Some("main; rm -rf ~".to_string());
+    let argv = substitute(&parse("tool $BRANCH"), &c);
+    assert_eq!(argv, vec!["tool", "main; rm -rf ~"]);
+    assert_eq!(argv.len(), 2);
+}
+
+#[test]
+fn command_substitution_in_a_value_is_inert() {
+    let mut c = ctx();
+    c.branch = Some("$(whoami)".to_string());
+    c.files = vec!["`id`".to_string()];
+    let argv = substitute(&parse("tool $BRANCH $FILE"), &c);
+    assert_eq!(argv, vec!["tool", "$(whoami)", "`id`"]);
+}
+
+#[test]
+fn a_substituted_value_is_not_itself_re_scanned_for_placeholders() {
+    // A file literally named `$SHA` must not pull in the sha. Values are data.
+    let mut c = ctx();
+    c.files = vec!["$SHA".to_string()];
+    let argv = substitute(&parse("tool $FILE"), &c);
+    assert_eq!(
+        argv,
+        vec!["tool", "$SHA"],
+        "the substituted text is final, not another template",
+    );
+}
+
+#[test]
+fn an_absent_value_becomes_an_empty_argument_not_a_literal_placeholder() {
+    // Handing a program the four characters `$SHA` would be worse: it looks
+    // like a real argument and fails somewhere further away.
+    let c = ActionContext {
+        repo: "/repo".to_string(),
+        files: vec![],
+        sha: None,
+        branch: None,
+    };
+    let argv = substitute(&parse("tool $SHA $BRANCH $FILE"), &c);
+    assert_eq!(argv, vec!["tool", "", "", ""]);
+}
+
+#[test]
+fn files_expands_to_one_argument_per_file() {
+    let mut c = ctx();
+    c.files = vec![
+        "a.rs".to_string(),
+        "my file.txt".to_string(),
+        "c;d.rs".to_string(),
+    ];
+    let argv = substitute(&parse("tool $FILES"), &c);
+    assert_eq!(argv, vec!["tool", "a.rs", "my file.txt", "c;d.rs"]);
+    assert_eq!(argv.len(), 4, "whole entries, never a split string");
+}
+
+#[test]
+fn files_with_no_selection_expands_to_nothing() {
+    let mut c = ctx();
+    c.files = vec![];
+    assert_eq!(substitute(&parse("tool $FILES"), &c), vec!["tool"]);
+}
+
+#[test]
+fn files_inside_a_larger_argument_joins_rather_than_splitting() {
+    // `--files=$FILES` cannot become several arguments, so joining is the
+    // least surprising reading — and it is still ONE argument.
+    let mut c = ctx();
+    c.files = vec!["a.rs".to_string(), "b.rs".to_string()];
+    let argv = substitute(&parse("tool --files=$FILES"), &c);
+    assert_eq!(argv, vec!["tool", "--files=a.rs b.rs"]);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// build_argv
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn file_is_a_prefix_of_files_and_the_longer_one_wins() {
+    // The bug this pins: matching `$FILE` inside `$FILES` leaves a stray `S`.
+    // `placeholders()` sorts by descending name length so the ordering is
+    // structural rather than something the next placeholder has to remember.
+    let mut c = ctx();
+    c.files = vec!["a.rs".to_string(), "b.rs".to_string()];
+    assert_eq!(
+        substitute(&parse("tool x$FILESy"), &c),
+        vec!["tool", "xa.rs b.rsy"],
+        "`$FILES` must not be read as `$FILE` followed by an S",
+    );
+}
+
+#[test]
+fn build_argv_runs_the_whole_pipeline() {
+    let argv = build_argv("code -g $FILE", &ctx()).unwrap();
+    assert_eq!(argv, vec!["code", "-g", "src/a.rs"]);
+}
+
+#[test]
+fn build_argv_refuses_an_empty_program_after_substitution() {
+    // `$FILE` as the program with nothing selected. Spawning "" is a confusing
+    // OS error; this is a clear one.
+    let c = ActionContext {
+        repo: "/repo".to_string(),
+        files: vec![],
+        sha: None,
+        branch: None,
+    };
+    let err = build_argv("$FILE --flag", &c).unwrap_err();
+    assert!(
+        matches!(&err, AppError::InvalidArgument(m) if m.contains("program name")),
+        "got {err:?}",
+    );
+}
+
+#[test]
+fn build_argv_propagates_a_parse_refusal() {
+    assert!(matches!(
+        build_argv(r#"code "unclosed"#, &ctx()),
+        Err(AppError::InvalidArgument(_))
+    ));
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Output
+// ───────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn output_is_truncated_with_a_marker_rather_than_silently() {
+    let big = "x".repeat(MAX_OUTPUT_BYTES + 1000);
+    let out = truncate_output(big);
+    assert!(out.len() < MAX_OUTPUT_BYTES + 100);
+    assert!(
+        out.ends_with("output truncated"),
+        "the panel must never imply it showed everything",
+    );
+}
+
+#[test]
+fn short_output_is_untouched() {
+    assert_eq!(truncate_output("hello".to_string()), "hello");
+}

--- a/src/design/dialog.tsx
+++ b/src/design/dialog.tsx
@@ -33,6 +33,14 @@ export interface PGConfirmOptions {
   /** Red primary button + warning glyph. */
   danger?: boolean;
   /**
+   * Hide the Cancel button — an acknowledgement rather than a question.
+   *
+   * Escape and the backdrop still dismiss, so there is always a way out; what
+   * goes away is the second button, which on a "here is the output" dialog
+   * offers a choice that does not exist. See `pgAlert`.
+   */
+  hideCancel?: boolean;
+  /**
    * Require typing this exact string before the primary button enables —
    * for the genuinely unrecoverable operations (GitKraken-style).
    */
@@ -102,6 +110,22 @@ export function pgConfirm(opts: PGConfirmOptions | string): Promise<boolean> {
 }
 
 /**
+ * Show something and wait for it to be acknowledged.
+ *
+ * `pgConfirm` with one button. It exists because the alternative at every call
+ * site is `window.alert`, which this codebase bans for the same reasons it bans
+ * `window.confirm`: unstyled, blocks the whole webview, and cannot show
+ * anything but a short string.
+ *
+ * Resolves when dismissed, however it was dismissed — there is no answer to
+ * report, so callers do not have one to handle.
+ */
+export async function pgAlert(opts: PGConfirmOptions | string): Promise<void> {
+  const o = typeof opts === "string" ? { title: opts } : opts;
+  await pgConfirm({ confirmLabel: "Close", ...o, hideCancel: true });
+}
+
+/**
  * Ask for a line of text. Resolves the string, or null if dismissed — same
  * contract as `window.prompt`, including "empty string" being a real answer
  * distinct from null (unless `requireValue`).
@@ -138,6 +162,8 @@ export function PGDialogHost() {
 function DialogView({ req }: { req: Request }) {
   const isConfirm = req.kind === "confirm";
   const danger = isConfirm && !!(req.opts as PGConfirmOptions).danger;
+  // An acknowledgement, not a question — see `pgAlert`.
+  const hideCancel = isConfirm && !!(req.opts as PGConfirmOptions).hideCancel;
   const requireText = isConfirm
     ? (req.opts as PGConfirmOptions).requireText
     : undefined;
@@ -315,9 +341,11 @@ function DialogView({ req }: { req: Request }) {
         )}
 
         <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
-          <PGButton size="sm" variant="ghost" onClick={cancel} data-testid="dialog-cancel">
-            {cancelLabel}
-          </PGButton>
+          {!hideCancel && (
+            <PGButton size="sm" variant="ghost" onClick={cancel} data-testid="dialog-cancel">
+              {cancelLabel}
+            </PGButton>
+          )}
           <PGButton
             size="sm"
             variant={danger ? "danger" : "primary"}

--- a/src/features/actions/CustomActionsSettings.tsx
+++ b/src/features/actions/CustomActionsSettings.tsx
@@ -1,0 +1,214 @@
+// Managing user-defined commands (#225).
+//
+// The hint text carries real weight here: this is the one Settings surface that
+// spawns a process, and the two things people get wrong about it are (a)
+// expecting shell syntax and (b) not knowing the placeholders. Both are said
+// plainly rather than left to be discovered by a command that silently does
+// nothing useful.
+
+import * as React from "react";
+
+import { PGButton, PGInput, PGToggle } from "@/design";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+
+import {
+  PLACEHOLDERS,
+  blankAction,
+  isSavableAction,
+  normalizeAction,
+  removeAction,
+  upsertAction,
+  type CustomAction,
+} from "./customActions";
+
+export function CustomActionsSettings() {
+  const actions = useSettingsStore((s) => s.customActions);
+  const setSetting = useSettingsStore((s) => s.set);
+  const [draft, setDraft] = React.useState<CustomAction | null>(null);
+
+  function save() {
+    if (!draft || !isSavableAction(draft)) return;
+    setSetting("customActions", upsertAction(actions, normalizeAction(draft)));
+    setDraft(null);
+  }
+
+  return (
+    <div
+      data-testid="custom-actions"
+      style={{ display: "flex", flexDirection: "column", gap: 8 }}
+    >
+      <div
+        style={{
+          fontSize: "var(--fs-11)",
+          color: "var(--fg-3)",
+          lineHeight: 1.5,
+        }}
+      >
+        Your own commands, in the command palette. The command is a program and
+        its arguments —{" "}
+        <strong>not a shell line</strong>: quotes group arguments, and{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>| &gt; ; &amp;&amp;</code>{" "}
+        are ordinary characters, so a branch name or a path can never turn into
+        a second command. Placeholders:{" "}
+        <code style={{ fontFamily: "var(--font-mono)" }}>
+          {PLACEHOLDERS.join(" ")}
+        </code>
+        . They run in the repository&rsquo;s directory and are never given a
+        token or credential.
+      </div>
+
+      {actions.length === 0 && !draft && (
+        <div style={{ fontSize: "var(--fs-11)", color: "var(--fg-3)" }}>
+          No custom actions yet.
+        </div>
+      )}
+
+      {actions.map((a) =>
+        draft?.id === a.id ? (
+          <ActionEditor
+            key={a.id}
+            draft={draft}
+            onChange={setDraft}
+            onSave={save}
+            onCancel={() => setDraft(null)}
+          />
+        ) : (
+          <div
+            key={a.id}
+            data-testid="custom-action-row"
+            style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}
+          >
+            <div style={{ flex: "1 1 220px", minWidth: 0 }}>
+              <div style={{ fontWeight: 600 }}>{a.name}</div>
+              <div
+                style={{
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "var(--fs-11)",
+                  color: "var(--fg-3)",
+                  overflowWrap: "anywhere",
+                }}
+              >
+                {a.command}
+              </div>
+            </div>
+            <PGButton
+              size="xs"
+              variant="ghost"
+              icon="edit"
+              title="Edit"
+              onClick={() => setDraft(a)}
+              data-testid="custom-action-edit"
+            />
+            <PGButton
+              size="xs"
+              variant="ghost"
+              icon="trash"
+              title="Remove"
+              onClick={() => setSetting("customActions", removeAction(actions, a.id))}
+              data-testid="custom-action-remove"
+            />
+          </div>
+        ),
+      )}
+
+      {draft && !actions.some((a) => a.id === draft.id) && (
+        <ActionEditor
+          draft={draft}
+          onChange={setDraft}
+          onSave={save}
+          onCancel={() => setDraft(null)}
+        />
+      )}
+
+      {!draft && (
+        <div>
+          <PGButton
+            size="xs"
+            variant="outline"
+            icon="plus"
+            onClick={() => setDraft(blankAction())}
+            data-testid="custom-action-add"
+          >
+            Add action
+          </PGButton>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ActionEditor({
+  draft,
+  onChange,
+  onSave,
+  onCancel,
+}: {
+  draft: CustomAction;
+  onChange: (a: CustomAction) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div
+      data-testid="custom-action-editor"
+      style={{ display: "flex", flexDirection: "column", gap: 6 }}
+    >
+      <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+        <PGInput
+          value={draft.name}
+          onChange={(v) => onChange({ ...draft, name: v })}
+          placeholder="Open in editor"
+          size="sm"
+          aria-label="Name"
+          data-testid="custom-action-name-input"
+          style={{ flex: "1 1 140px", minWidth: 0 }}
+        />
+        <PGInput
+          value={draft.command}
+          onChange={(v) => onChange({ ...draft, command: v })}
+          placeholder="code -g $FILE"
+          size="sm"
+          mono
+          aria-label="Command"
+          data-testid="custom-action-command-input"
+          style={{ flex: "2 1 240px", minWidth: 0 }}
+        />
+      </div>
+      <div style={{ display: "flex", gap: 16, alignItems: "center", flexWrap: "wrap" }}>
+        <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
+          <PGToggle
+            checked={draft.showOutput}
+            onChange={(v) => onChange({ ...draft, showOutput: v })}
+            data-testid="custom-action-show-output"
+          />
+          <span style={{ fontSize: "var(--fs-11)" }}>
+            Show output (a failure is always shown)
+          </span>
+        </label>
+        <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
+          <PGToggle
+            checked={draft.refreshAfter}
+            onChange={(v) => onChange({ ...draft, refreshAfter: v })}
+            data-testid="custom-action-refresh-after"
+          />
+          <span style={{ fontSize: "var(--fs-11)" }}>Refresh when it exits</span>
+        </label>
+        <PGButton
+          size="xs"
+          variant="primary"
+          // Name and command non-blank, and nothing more: whether the command
+          // PARSES is the backend's question, and its refusal names what is
+          // wrong. A second parser here would be a second place to drift.
+          disabled={!isSavableAction(draft)}
+          onClick={onSave}
+          data-testid="custom-action-save"
+        >
+          Save
+        </PGButton>
+        <PGButton size="xs" variant="ghost" onClick={onCancel}>
+          Cancel
+        </PGButton>
+      </div>
+    </div>
+  );
+}

--- a/src/features/actions/customActions.test.ts
+++ b/src/features/actions/customActions.test.ts
@@ -1,0 +1,120 @@
+// The custom-action list and how results are reported (#225).
+//
+// The parsing and substitution — the security-critical half — live in Rust and
+// are tested in `src-tauri/tests/custom_action.rs`. Deliberately not duplicated
+// here: a second parser would be a second place for "what actually runs" to
+// drift from the one next to the spawn.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  blankAction,
+  describeResult,
+  isSavableAction,
+  newActionId,
+  normalizeAction,
+  removeAction,
+  repoContext,
+  shouldShowOutput,
+  upsertAction,
+  type CustomAction,
+} from "./customActions";
+
+const action = (over: Partial<CustomAction> = {}): CustomAction => ({
+  id: "a",
+  name: "Open in editor",
+  command: "code -g $FILE",
+  showOutput: false,
+  refreshAfter: true,
+  ...over,
+});
+
+describe("what is savable", () => {
+  it("needs a name and a command", () => {
+    expect(isSavableAction(action())).toBe(true);
+    expect(isSavableAction(action({ name: "  " }))).toBe(false);
+    expect(isSavableAction(action({ command: "" }))).toBe(false);
+  });
+
+  it("does not re-implement the backend's parser", () => {
+    // Whether a command PARSES is the backend's question — it owns the parser
+    // and its refusal names what is wrong ("unclosed quote"). A second check
+    // here would be a second place to drift.
+    expect(isSavableAction(action({ command: 'code "unclosed' }))).toBe(true);
+  });
+
+  it("trims what it stores", () => {
+    expect(normalizeAction(action({ name: " x ", command: " y " }))).toMatchObject(
+      { name: "x", command: "y" },
+    );
+  });
+});
+
+describe("editing the list", () => {
+  it("adds, replaces in place, and removes", () => {
+    const b = action({ id: "b", name: "Second" });
+    expect(upsertAction([action()], b).map((a) => a.id)).toEqual(["a", "b"]);
+
+    const renamed = action({ name: "Renamed" });
+    const next = upsertAction([action(), b], renamed);
+    expect(next.map((a) => a.id)).toEqual(["a", "b"]);
+    expect(next[0]?.name).toBe("Renamed");
+
+    expect(removeAction([action(), b], "a").map((a) => a.id)).toEqual(["b"]);
+  });
+
+  it("never mutates the input", () => {
+    const list = [action()];
+    upsertAction(list, action({ id: "b" }));
+    removeAction(list, "a");
+    expect(list).toHaveLength(1);
+  });
+
+  it("mints unique ids", () => {
+    const ids = new Set(Array.from({ length: 50 }, () => newActionId()));
+    expect(ids.size).toBe(50);
+  });
+
+  it("a blank action is not savable but is a valid draft", () => {
+    const b = blankAction();
+    expect(isSavableAction(b)).toBe(false);
+    expect(b.showOutput).toBe(true);
+    expect(b.refreshAfter).toBe(true);
+  });
+});
+
+describe("reporting the result", () => {
+  it("always shows a failure, whatever the setting says", () => {
+    // An action that exits non-zero and says nothing is indistinguishable from
+    // one that never ran, and that is the state people file bugs about.
+    expect(shouldShowOutput(action({ showOutput: false }), 1)).toBe(true);
+    expect(shouldShowOutput(action({ showOutput: false }), null)).toBe(true);
+  });
+
+  it("respects the setting on success", () => {
+    expect(shouldShowOutput(action({ showOutput: false }), 0)).toBe(false);
+    expect(shouldShowOutput(action({ showOutput: true }), 0)).toBe(true);
+  });
+
+  it("names the exit code, because 'it failed' is not actionable", () => {
+    expect(describeResult(action(), 0)).toBe("Open in editor finished.");
+    expect(describeResult(action(), 2)).toBe("Open in editor exited with code 2.");
+    expect(describeResult(action(), null)).toBe("Open in editor was terminated.");
+  });
+});
+
+describe("the context sent for a repo-level invocation", () => {
+  it("sends an EMPTY repo path — the backend fills it in", () => {
+    // The security property: a custom action's working directory can never be
+    // chosen by the caller. The backend resolves it from the repository.
+    const ctx = repoContext("main");
+    expect(ctx.repo).toBe("");
+    expect(ctx.branch).toBe("main");
+    expect(ctx.files).toEqual([]);
+    expect(ctx.sha).toBeNull();
+  });
+
+  it("tolerates a detached HEAD", () => {
+    expect(repoContext(null).branch).toBeNull();
+  });
+});

--- a/src/features/actions/customActions.ts
+++ b/src/features/actions/customActions.ts
@@ -1,0 +1,110 @@
+// User-defined commands (#225) — the frontend model.
+//
+// The security-critical half lives in Rust (`custom_action.rs`): parsing the
+// command string into argv and substituting placeholders into individual
+// entries. Deliberately NOT duplicated here — a second parser would be a second
+// place for "what actually runs" to drift, and the one that matters is the one
+// next to the spawn.
+//
+// This file is the list, its validation, and what the palette shows.
+
+import type { ActionContext } from "@/lib/types";
+
+/** One user-defined command. */
+export interface CustomAction {
+  id: string;
+  /** What appears in the palette. */
+  name: string;
+  /** Program + arguments, with placeholders. Parsed by the backend, not here. */
+  command: string;
+  /** Show the output afterwards even when it succeeds. */
+  showOutput: boolean;
+  /** Refresh the repository when it exits — for actions that change the tree. */
+  refreshAfter: boolean;
+}
+
+/** The placeholders the backend substitutes, for the Settings hint. */
+export const PLACEHOLDERS = ["$REPO", "$FILE", "$FILES", "$SHA", "$BRANCH"] as const;
+
+let seq = 0;
+
+export function newActionId(): string {
+  seq += 1;
+  return `act-${Date.now().toString(36)}-${seq}`;
+}
+
+export function blankAction(): CustomAction {
+  return {
+    id: newActionId(),
+    name: "",
+    command: "",
+    showOutput: true,
+    refreshAfter: true,
+  };
+}
+
+export function normalizeAction(a: CustomAction): CustomAction {
+  return { ...a, name: a.name.trim(), command: a.command.trim() };
+}
+
+/**
+ * Whether an action is worth saving.
+ *
+ * Name and command non-blank, and nothing else. Whether the command PARSES is
+ * the backend's question — it owns the parser, and its refusal names what is
+ * wrong ("unclosed quote", "trailing backslash"). Re-implementing that check
+ * here would create exactly the drift this file's header warns about.
+ */
+export function isSavableAction(a: CustomAction): boolean {
+  const n = normalizeAction(a);
+  return n.name !== "" && n.command !== "";
+}
+
+export function upsertAction(
+  list: readonly CustomAction[],
+  a: CustomAction,
+): CustomAction[] {
+  const next = normalizeAction(a);
+  const i = list.findIndex((x) => x.id === next.id);
+  if (i === -1) return [...list, next];
+  const copy = [...list];
+  copy[i] = next;
+  return copy;
+}
+
+export function removeAction(
+  list: readonly CustomAction[],
+  id: string,
+): CustomAction[] {
+  return list.filter((a) => a.id !== id);
+}
+
+/**
+ * How an action's result should be reported.
+ *
+ * A failure is always shown, whatever `showOutput` says: an action that exits
+ * non-zero and says nothing is indistinguishable from one that did not run, and
+ * that is the state people file bugs about.
+ */
+export function shouldShowOutput(action: CustomAction, code: number | null): boolean {
+  return action.showOutput || code !== 0;
+}
+
+/**
+ * The one-line result summary.
+ *
+ * Names the exit code because "it failed" is not actionable and `exit 2` often
+ * is — many tools document their codes.
+ */
+export function describeResult(action: CustomAction, code: number | null): string {
+  if (code === 0) return `${action.name} finished.`;
+  if (code === null) return `${action.name} was terminated.`;
+  return `${action.name} exited with code ${code}.`;
+}
+
+/** The context an action gets when invoked with nothing selected. */
+export function repoContext(branch: string | null): ActionContext {
+  // `repo` is filled in by the BACKEND from the repository it resolves, so the
+  // frontend cannot point a child process at a directory of its choosing.
+  return { repo: "", files: [], sha: null, branch };
+}

--- a/src/features/actions/runAction.ts
+++ b/src/features/actions/runAction.ts
@@ -1,0 +1,87 @@
+// Running a user-defined command (#225).
+//
+// Separate from the palette entry and from Settings so "what happens when an
+// action runs" is one place: spawn, report, refresh.
+
+import { pgAlert, pgFlash } from "@/design";
+import { setActivity, useRepoStore } from "@/features/repo/useRepoStore";
+import { appErrorMessage } from "@/lib/errors";
+import { runCustomAction } from "@/lib/tauri";
+import type { ActionContext, ActionOutput } from "@/lib/types";
+
+import {
+  describeResult,
+  repoContext,
+  shouldShowOutput,
+  type CustomAction,
+} from "./customActions";
+
+/**
+ * What the output panel shows.
+ *
+ * The argv comes first because "what did it actually run" is the question a
+ * surprising result raises, and it cannot be answered by re-reading the command
+ * string — that string is a template, and the argv is the result.
+ */
+export function formatOutput(action: CustomAction, out: ActionOutput): string {
+  const parts = [
+    out.argv.join(" "),
+    "",
+    describeResult(action, out.code),
+  ];
+  if (out.stdout.trim()) parts.push("", out.stdout.trimEnd());
+  if (out.stderr.trim()) parts.push("", out.stderr.trimEnd());
+  return parts.join("\n");
+}
+
+/**
+ * Run `action` against the open repository.
+ *
+ * Returns false when there was nothing to run against, so a keymap runner can
+ * decline cleanly.
+ *
+ * The action is announced while it runs through `RepoActivity`, per the rule
+ * that a new long-running op joins it: a user command can take as long as it
+ * likes, and one that silently pins nothing visible is indistinguishable from
+ * one that never started.
+ */
+export async function runAction(
+  action: CustomAction,
+  context?: Partial<ActionContext>,
+): Promise<boolean> {
+  const store = useRepoStore.getState();
+  const repo = store.current;
+  if (!repo) return false;
+
+  const ctx: ActionContext = {
+    ...repoContext(store.headInfo?.branch ?? null),
+    ...context,
+  };
+
+  setActivity(repo.id, "action", `Running ${action.name}…`);
+  try {
+    const out = await runCustomAction(repo.id, action.command, ctx);
+    if (shouldShowOutput(action, out.code)) {
+      await pgAlert({
+        title: describeResult(action, out.code),
+        body: formatOutput(action, out),
+      });
+    } else {
+      pgFlash(describeResult(action, out.code));
+    }
+    // After the dialog, not before: an action that changed the tree should
+    // leave the app showing the new state once the user is done reading.
+    if (action.refreshAfter) await useRepoStore.getState().refreshAll();
+  } catch (e) {
+    // A refusal from the backend — an unparseable command, a program that is
+    // not on PATH. It names the problem, so show it rather than a toast that
+    // scrolls away.
+    await pgAlert({
+      title: `${action.name} could not run`,
+      body: appErrorMessage(e),
+    });
+  } finally {
+    setActivity(repo.id, "action", null);
+  }
+  return true;
+}

--- a/src/features/palette/commands.ts
+++ b/src/features/palette/commands.ts
@@ -16,6 +16,7 @@ import { orderBranchesGrouped } from "@/features/branches/orderBranches";
 import { activePins } from "@/features/branches/pins";
 import { summarizeFastForward } from "@/features/branches/fastForward";
 import { openCreateTag } from "@/features/tags/useCreateTagStore";
+import { runAction } from "@/features/actions/runAction";
 import { usePaletteStore } from "./usePaletteStore";
 import { createBranchInputStep, switchRepoStep } from "./steps";
 import { currentBranch, isConflicted, relativeTime } from "@/lib/derive";
@@ -283,6 +284,25 @@ export function buildCommands(): PaletteItem[] {
       actionId,
       run: direct(() => nav.setIntent({ kind: "switch-screen", screen: id })),
     });
+  }
+
+  // -- user-defined commands (#225) --
+  //
+  // In the palette like everything else, which is the point: an action the
+  // team runs fifty times a day should be reachable the same way `Fetch all
+  // remotes` is, not buried in a menu. Only with a repository open — every
+  // placeholder is about one.
+  if (repo.current) {
+    for (const action of useSettingsStore.getState().customActions) {
+      items.push({
+        type: "command",
+        id: `custom-action:${action.id}`,
+        search: `${action.name} custom action ${action.command}`,
+        label: action.name,
+        icon: "terminal",
+        run: direct(() => void runAction(action)),
+      });
+    }
   }
 
   // -- direct actions --

--- a/src/features/repo/repoActivity.ts
+++ b/src/features/repo/repoActivity.ts
@@ -68,6 +68,14 @@ export interface RepoActivity {
    * click was swallowed.
    */
   difftool?: ActivityState;
+  /**
+   * A user-defined custom action (#225).
+   *
+   * It is here for the same reason `difftool` is: a user's own program can take
+   * as long as it likes, and one that pins nothing visible is indistinguishable
+   * from one that never started.
+   */
+  action?: ActivityState;
 }
 
 export type ActivityKey = keyof RepoActivity;
@@ -92,6 +100,9 @@ export const ACTIVITY_PRIORITY: readonly ActivityKey[] = [
   "branch",
   "forge",
   "difftool",
+  // Below difftool: like it, the app is not busy — someone else's program is —
+  // and any real git op running underneath is the more urgent thing to say.
+  "action",
   "lfs",
   "submodule",
 ];

--- a/src/features/settings/useSettingsStore.export.test.ts
+++ b/src/features/settings/useSettingsStore.export.test.ts
@@ -62,6 +62,10 @@ const PORTABLE = [
   "commitBodyMarkdown",
   "commitTicketPattern",
   "confirmForcePush",
+  // User-defined commands (#225). Portable: "the command our team runs
+  // fifty times a day" is what a shared settings file is for, and an action
+  // is plain data with no secrets in it.
+  "customActions",
   "customThemes",
   "defaultPullMode",
   "diffContextLines",

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import type { PullMode } from "@/lib/tauri";
 import type { UpdateChannel, UpdateRefsMode } from "@/lib/types";
 import type { SavedIdentity } from "@/features/commits/identity/identityList";
+import type { CustomAction } from "@/features/actions/customActions";
 import {
   DEFAULT_HEAD_WEIGHT,
   HEAD_WEIGHTS,
@@ -925,6 +926,15 @@ interface PersistedState {
    * already decided.
    */
   rebaseUpdateRefs: UpdateRefsMode;
+  /**
+   * User-defined commands (#225), shown in the command palette.
+   *
+   * Portable: "the command our team runs fifty times a day" is exactly the
+   * kind of thing a shared settings file should carry. It is also plain data —
+   * a name and a command string — with no secrets in it, because a custom
+   * action never receives any.
+   */
+  customActions: CustomAction[];
   updateCheckMode: UpdateCheckMode;
   /**
    * Which releases update checks consider — see UpdateChannel.
@@ -1029,6 +1039,7 @@ const DEFAULTS: PersistedState = {
   commitBodyMarkdown: true,
   identities: [],
   rebaseUpdateRefs: "config",
+  customActions: [],
   updateCheckMode: "auto",
   updateChannel: "stable",
   lastCreateDir: "",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -2,6 +2,8 @@ import { invoke as rawInvoke } from "@tauri-apps/api/core";
 import { debug as logDebug, warn as logWarn, error as logError } from "@tauri-apps/plugin-log";
 import { describeError } from "./errors";
 import type {
+  ActionContext,
+  ActionOutput,
   AheadBehind,
   AuthorOverride,
   BisectMark,
@@ -1400,6 +1402,20 @@ export async function revealLogFile(): Promise<void> {
 
 export function checkForUpdate(channel: UpdateChannel): Promise<UpdateInfo> {
   return invoke<UpdateInfo>("check_for_update", { channel });
+}
+
+/**
+ * Run a user-defined command (#225).
+ *
+ * The command string is parsed into argv and the placeholders substituted BY
+ * THE BACKEND — never here, and never by a shell. See `custom_action.rs`.
+ */
+export function runCustomAction(
+  repoId: string,
+  command: string,
+  context: ActionContext,
+): Promise<ActionOutput> {
+  return invoke<ActionOutput>("run_custom_action", { repoId, command, context });
 }
 
 export function getUpdateCapability(): Promise<UpdateCapability> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -685,6 +685,34 @@ export interface FsChange {
   refsMoved: boolean;
 }
 
+/**
+ * The values a custom action's placeholders take (#225). Mirrors Rust
+ * `custom_action.rs::ActionContext`.
+ *
+ * `repo` is filled in by the BACKEND from the repository it resolves — the
+ * frontend sends an empty string — so a custom action's working directory can
+ * never be chosen by the caller.
+ */
+export interface ActionContext {
+  repo: string;
+  files: string[];
+  sha: string | null;
+  branch: string | null;
+}
+
+/** What a finished custom action reports (#225). Mirrors Rust `ActionOutput`. */
+export interface ActionOutput {
+  /** Exit status, or null when the process was killed by a signal. */
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  /**
+   * The argv actually spawned. Shown in the output panel so "what did it run"
+   * is answerable without guessing how the command string was parsed.
+   */
+  argv: string[];
+}
+
 export interface UpdateInfo {
   available: boolean;
   currentVersion: string;

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -32,6 +32,7 @@ import {
   isValidTicketPattern,
 } from "@/features/commits/message";
 import type { UpdateRefsMode } from "@/lib/types";
+import { CustomActionsSettings } from "@/features/actions/CustomActionsSettings";
 import { IdentityForm } from "@/features/commits/identity/IdentityForm";
 import { SavedIdentities } from "@/features/commits/identity/SavedIdentities";
 import { useRepoStore } from "@/features/repo/useRepoStore";
@@ -111,6 +112,7 @@ export function SettingsScreen() {
         </p>
 
         <IdentitySection />
+        <CustomActionsSection />
 
         <AppearanceSection active={active} />
 
@@ -413,6 +415,24 @@ export function SettingsScreen() {
  * way down: a user who lands in Settings before opening anything still gets a
  * true answer, from the global + system chain.
  */
+/**
+ * User-defined commands (#225).
+ *
+ * Its own section rather than a row under something else: it is the one
+ * Settings surface that spawns a process, and burying it would make the
+ * "not a shell line" explanation easy to miss.
+ */
+function CustomActionsSection() {
+  return (
+    <Section
+      title="Custom actions"
+      subtitle="Your own commands, available from the command palette."
+    >
+      <Row label="Actions" stacked control={<CustomActionsSettings />} />
+    </Section>
+  );
+}
+
 function IdentitySection() {
   const repo = useRepoStore((s) => s.current);
   return (


### PR DESCRIPTION
Part of #225 — repo-level actions in the command palette. File/commit context menus and per-action keybindings are left for a follow-up (see the bottom), so this deliberately does not close the issue.

The feature that lets a GUI absorb the one git-adjacent command a team runs fifty times a day, without that command having to be something we shipped.

## The security design, which is most of the work

**A user-supplied command string is NOT a shell line.** The tempting implementation is `sh -c "<the string>"`, and it is wrong in a way that stays invisible until it bites: under a shell, a branch named `main; rm -rf ~` or a path containing `$(...)` stops being *data* and becomes *code*. Branch names and paths come from the repository, which means they can come from anyone who has ever pushed to it.

`custom_action.rs` is pure and does three things:

1. **`parse_command`** splits the string into argv **once**. Quotes group; a backslash escapes (except inside single quotes, so a Windows path survives). `|`, `>`, `;`, `&&`, `$`, `*`, `~` are ordinary characters, because that is all they can be when nothing interprets them.
2. **`substitute`** expands `$REPO` / `$FILE` / `$FILES` / `$SHA` / `$BRANCH` **into individual argv entries**, after splitting. A value can therefore never introduce a new argument, however it is spelled.
3. **`proc::program_async`** spawns it — the only sanctioned constructor (a guard test fails the build on a bare `Command::new`), which also carries #172's `CREATE_NO_WINDOW`, so an action never flashes a console on Windows.

## Two bugs my own tests caught, both now pinned

- **Substitution has to be ONE left-to-right pass.** My first version chained `str::replace`, which re-scans text an earlier call just wrote — so a file literally named `$SHA` pulled in the commit sha. Values are *data*, not templates. Emitting each expansion straight into the output and never looking at it again makes that structural.
- **Placeholders are tried longest-name-first.** `$FILE` is a prefix of `$FILES` — my first comment claimed no placeholder was a prefix of another, which was simply wrong. Anything but longest-first matches `$FILE` inside `$FILES` and leaves a stray `S`.

## Other constraints from the issue

- **No secrets, ever.** No forge token, no git credential, no askpass. A custom action is a *user* program, not a trusted one.
- **The workdir is resolved by the backend**, never taken from the frontend — it is about to become a child process's cwd, and a path argument would be a second source of truth for where a repository lives. The frontend sends `repo: ""` and there is a test asserting that.
- **A running action is visible and not silent**: it takes a `RepoActivity` entry, per the rule that a new long-running op joins it.
- **Output is truncated with a marker**, so a command printing a gigabyte cannot become a gigabyte-sized IPC message — and the panel never implies it showed everything.
- The frontend **does not re-implement the parser**. Whether a command parses is the backend's question; its refusal names what is wrong ("unclosed quote"). A second parser would be a second place for "what actually runs" to drift.

A **failure is always shown**, whatever "show output" says: an action that exits non-zero and says nothing is indistinguishable from one that never ran.

## One design-system addition

`pgAlert` — `pgConfirm` with one button — plus a `hideCancel` option. The alternative at every call site is `window.alert`, which this codebase bans for the same reasons it bans `window.confirm`: unstyled, blocks the whole webview, cannot show more than a short string. Escape and the backdrop still dismiss.

## Not in this PR

- **File and commit context-menu placement.** The issue asks for it; the model and the backend already carry `$FILE`/`$FILES`/`$SHA` and the context type, so wiring the menus is additive.
- **Per-action keybindings.**
- The issue's open questions (per-repository vs global actions; stderr in a dialog vs a toast) — this takes the global + always-show-failures answer, which is the conservative one, and I'd rather you decide the other before it is baked in.

## Tests

- `src-tauri/tests/custom_action.rs` — 21, mostly about what a user's data *cannot* do: shell operators inert, a branch name with `;` staying one argument, command substitution inert, a value not re-scanned as a template, the `$FILE`/`$FILES` prefix case, `$FILES` expanding as whole entries, parse refusals, output truncation.
- `src/features/actions/customActions.test.ts` — 12: list editing, savability (and that it does *not* re-implement the parser), result reporting, and the empty-`repo` context.

Green: full `cargo test` (including the `Command::new` guard and the no-telemetry tests), `pnpm test` (2884 passed), `pnpm tsc --noEmit`. Rebased onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
