### PR TITLE
fix(repo): a background refresh must not clear the error banner (#239)

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -481,6 +481,16 @@ Refreshes coalesce rather than queue: a burst produces at most one more refresh
 after the current one, and `mergeRefresh` keeps a queued `status` from
 downgrading a pending `all`.
 
+A background refresh passes **`preserveError`**, and that is load-bearing. A
+failed `--ff-only` pull sets `error` — but the *fetch* half of that same pull
+already moved `refs/remotes/…`, so the watcher's debounced event lands a few
+hundred milliseconds later, **after** the operation cleared `activity` and
+therefore past the busy guard. `refreshAll` opens with `set({ error: null })`,
+so without `preserveError` it wipes the banner and the user sees a pull that
+silently did nothing — the worst possible reading of a failure. `settings.e2e.ts`
+caught this on CI. A refresh nobody asked for must not clear a message nobody
+has read.
+
 The watcher's refresh deliberately does **not** join `RepoActivity`. That is
 for operations the user started and can cancel; this is background upkeep, and
 a status line that flickered on every keystroke in someone's editor would be

--- a/src/features/repo/refreshPreserveError.test.ts
+++ b/src/features/repo/refreshPreserveError.test.ts
@@ -1,0 +1,101 @@
+// A background refresh must not clear an error the user has not read (#239).
+//
+// `useFsWatch.test.tsx` asserts the watcher PASSES `preserveError`. This file
+// asserts the store HONOURS it — the two together are the fix, and either alone
+// would pass while the bug remained.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+
+import { useRepoStore } from "./useRepoStore";
+
+function mockReads() {
+  for (const cmd of [
+    "get_status",
+    "list_branches",
+    "list_tags",
+    "list_stashes",
+    "list_remotes",
+  ]) {
+    mockInvoke(cmd, () => []);
+  }
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("head_info", () => ({ branch: "refs/heads/main", headOid: "a1" }));
+  mockInvoke("rebase_status", () => ({
+    inProgress: false,
+    nextIndex: 0,
+    total: 0,
+    pauseReason: null,
+  }));
+  mockInvoke("shallow_info", () => ({
+    shallow: false,
+    boundaryCount: 0,
+    singleBranch: false,
+  }));
+  mockInvoke("bisect_status", () => ({
+    inProgress: false,
+    startRef: null,
+    badTerm: "bad",
+    goodTerm: "good",
+    currentOid: null,
+    remaining: null,
+    steps: null,
+    firstBadOid: null,
+    goodCount: 0,
+    badCount: 0,
+    skippedCount: 0,
+  }));
+}
+
+const BANNER = { kind: "Git", message: "not possible to fast-forward" } as const;
+
+beforeEach(() => {
+  resetInvokeMock();
+  mockReads();
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    error: null,
+  } as never);
+});
+
+describe("refreshAll", () => {
+  it("clears the error by default — a refresh the user asked for", async () => {
+    useRepoStore.setState({ error: BANNER } as never);
+    await useRepoStore.getState().refreshAll();
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("keeps the error with preserveError", async () => {
+    // The failed `--ff-only` pull's banner, and the watcher event that used to
+    // wipe it a few hundred milliseconds later.
+    useRepoStore.setState({ error: BANNER } as never);
+    await useRepoStore.getState().refreshAll({ preserveError: true });
+    expect(useRepoStore.getState().error).toEqual(BANNER);
+  });
+
+  it("still refreshes when preserving — it is not a no-op", async () => {
+    useRepoStore.setState({ error: BANNER, headInfo: null } as never);
+    await useRepoStore.getState().refreshAll({ preserveError: true });
+    expect(useRepoStore.getState().headInfo).toEqual({
+      branch: "refs/heads/main",
+      headOid: "a1",
+    });
+    expect(useRepoStore.getState().error).toEqual(BANNER);
+  });
+});
+
+describe("refreshStatus", () => {
+  it("clears the error by default", async () => {
+    useRepoStore.setState({ error: BANNER } as never);
+    await useRepoStore.getState().refreshStatus();
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("keeps the error with preserveError", async () => {
+    useRepoStore.setState({ error: BANNER } as never);
+    await useRepoStore.getState().refreshStatus({ preserveError: true });
+    expect(useRepoStore.getState().error).toEqual(BANNER);
+  });
+});

--- a/src/features/repo/useFsWatch.test.tsx
+++ b/src/features/repo/useFsWatch.test.tsx
@@ -118,6 +118,37 @@ describe("what an event does", () => {
     expect(refreshAll).not.toHaveBeenCalled();
   });
 
+  it("does NOT clear an error banner the user has not read", async () => {
+    // The regression this fixes, and the sequence that produced it:
+    //
+    //   1. an `--ff-only` pull on a diverged branch fails and sets `error`;
+    //   2. the FETCH half of that same pull already moved `refs/remotes/…`;
+    //   3. the watcher's DEBOUNCED event lands a few hundred ms later — after
+    //      the operation cleared `activity`, so the busy guard no longer
+    //      suppresses it;
+    //   4. `refreshAll` opens with `set({ error: null })` and wipes the banner.
+    //
+    // The user sees a pull that silently did nothing, which is the worst
+    // possible reading of a failure. `settings.e2e.ts` caught it on CI.
+    render(<Probe repoId="repo-1" />);
+    await waitFor(() => expect(calls("watch_repo")).toHaveLength(1));
+
+    fire({ refsMoved: true });
+    await waitFor(() => expect(refreshAll).toHaveBeenCalledTimes(1));
+    expect(refreshAll).toHaveBeenCalledWith({ preserveError: true });
+  });
+
+  it("preserves the error on a status-only refresh too", async () => {
+    // Both refresh paths clear `error`, so both need it — a working-copy write
+    // arriving after a failed operation is the same story.
+    render(<Probe repoId="repo-1" />);
+    await waitFor(() => expect(calls("watch_repo")).toHaveLength(1));
+
+    fire();
+    await waitFor(() => expect(refreshStatus).toHaveBeenCalledTimes(1));
+    expect(refreshStatus).toHaveBeenCalledWith({ preserveError: true });
+  });
+
   it("survives a refresh that throws, and keeps working afterwards", async () => {
     // A background refresh must not raise a banner the user cannot connect to
     // anything they did — but it must also not wedge the listener.

--- a/src/features/repo/useFsWatch.ts
+++ b/src/features/repo/useFsWatch.ts
@@ -45,8 +45,14 @@ export function useFsWatch(repoId: string | null): void {
     running.current = true;
     try {
       const store = useRepoStore.getState();
-      if (what === "all") await store.refreshAll();
-      else await store.refreshStatus();
+      // `preserveError` because this refresh is not one the user asked for.
+      // Without it, the debounced event from a failed operation's own writes
+      // arrives just after that operation clears `activity` — past the busy
+      // guard — and wipes the error banner it just set. A pull that failed
+      // then looks like a pull that silently did nothing.
+      const opts = { preserveError: true };
+      if (what === "all") await store.refreshAll(opts);
+      else await store.refreshStatus(opts);
     } catch {
       // A background refresh must not raise a banner. The user did not ask for
       // this one, and whatever is wrong will surface loudly the moment they do

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -169,6 +169,25 @@ const PAGE_SIZE = 500;
  *   - every fetch/error write goes through `setFor`/`setErrorFor`, which drop a
  *     response that resolved after the user moved to another repository.
  */
+/**
+ * Options for the two refreshes.
+ *
+ * `preserveError` exists for exactly one caller: the filesystem watcher (#239).
+ * A refresh nobody asked for must not clear a banner the user has not read.
+ *
+ * The bug it fixes: a failed `--ff-only` pull sets `error`, but the fetch half
+ * of that same pull moved `refs/remotes/…`, so the watcher's DEBOUNCED event
+ * lands a few hundred milliseconds later — after the operation has cleared
+ * `activity`, so `fsRefreshPlan`'s busy guard no longer suppresses it — and
+ * `refreshAll`'s opening `set({ error: null })` wipes the message. The user
+ * sees a pull that silently did nothing, which is the worst possible reading of
+ * a failure.
+ */
+export interface RefreshOptions {
+  /** Leave `error` alone. For refreshes the user did not ask for. */
+  preserveError?: boolean;
+}
+
 interface RepoStoreState extends RepoSlice {
   /**
    * Open `path` into the ACTIVE slice and refresh it, returning the handle (or
@@ -226,14 +245,22 @@ interface RepoStoreState extends RepoSlice {
    * the store; the previous list is kept.
    */
   setLogRef: (refspec: string | null) => Promise<void>;
-  refreshAll: () => Promise<void>;
+  /**
+   * Re-read everything about the repository.
+   *
+   * Clears `error` first, because a refresh the USER asked for means "show me
+   * where things stand now" and a stale banner from a previous action is not
+   * that. A BACKGROUND refresh must pass `preserveError` — see
+   * `RefreshOptions`.
+   */
+  refreshAll: (opts?: RefreshOptions) => Promise<void>;
   /**
    * Lightweight refresh for index-only mutations (stage/unstage/discard and
    * the hunk ops): re-fetches just `status` + `repoState`, skipping the full
    * branch/tag/stash/remote enumeration and the ≤500-commit log walk that
    * `refreshAll` does but that these ops can't change.
    */
-  refreshStatus: () => Promise<void>;
+  refreshStatus: (opts?: RefreshOptions) => Promise<void>;
   /**
    * Undo (or redo) the last recorded operation (#242).
    *
@@ -936,10 +963,10 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     }
   },
 
-  async refreshAll() {
+  async refreshAll(opts) {
     const repo = get().current;
     if (!repo) return;
-    set({ loading: true, error: null });
+    set({ loading: true, ...(opts?.preserveError ? {} : { error: null }) });
     const logRef = get().logRef;
     try {
       const [
@@ -1037,10 +1064,10 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     }
   },
 
-  async refreshStatus() {
+  async refreshStatus(opts) {
     const repo = get().current;
     if (!repo) return;
-    set({ error: null });
+    if (!opts?.preserveError) set({ error: null });
     try {
       // `bisect_status` joins the pair here because the operation bar's bisect
       // actions must stay live after an index op too. The backend short-circuits


### PR DESCRIPTION
**`main` is red.** `settings.e2e.ts` → "FF-only pull on diverged branch showed no error", failing on two consecutive attempts of the same commit, so not a flake.

The pull *did* fail. The banner was being wiped a moment later.

## The sequence

1. The `--ff-only` pull on a diverged branch fails and sets `error`.
2. The **fetch half of that same pull** already moved `refs/remotes/…`.
3. The filesystem watcher's **debounced** event (400 ms) lands after that — by which point the operation has cleared `activity`, so `fsRefreshPlan`'s busy guard no longer suppresses it.
4. `refreshAll` opens with `set({ error: null })` and wipes the message.

The user sees a pull that silently did nothing, which is the worst possible reading of a failure.

## The fix

`refreshAll` and `refreshStatus` take `RefreshOptions`; the watcher passes `preserveError: true`.

The default is deliberately unchanged. A refresh the **user** asked for still clears the banner — "show me where things stand now" is not compatible with a stale error from a previous action. A refresh **nobody** asked for must not clear a message nobody has read.

## Provenance

Mine, from #336 (#239). The race was there from the moment the watcher landed; the busy guard covers events *during* an operation, and this is the event that arrives just *after* one. #336's own e2e run and the next merge both passed, so the timing only recently started landing consistently on the wrong side — which is exactly the kind of bug that gets blamed on whichever PR is unlucky enough to be running when it turns.

## Tests

Two levels, because either alone would pass while the bug remained:

- `useFsWatch.test.tsx` — the watcher **passes** `preserveError`, on both the log and status-only paths.
- `refreshPreserveError.test.ts` (new) — the store **honours** it, and still refreshes when it does (not a no-op), with the default-clears behaviour pinned in both directions.

`pnpm test` — 2879 passed, `pnpm tsc --noEmit` clean.

I have not run the e2e suite locally against this; the CI run on this PR is the real check, since the failing spec is what motivated it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
