### PR TITLE
feat(cli): pgit --debug launches attached and streams the log (#344)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ pgit commit             # open the cwd repo, land on the Commit panel
 pgit log src/           # open the repo containing src/, land on History
 pgit --help             # print usage, no window
 pgit --version          # print version, no window
+pgit --debug .          # open it, but stay attached and stream the log here
 ```
 
 | subcommand | screen |
@@ -181,6 +182,15 @@ A bare path with no recognized subcommand opens that repository and keeps the
 current screen. If the app is already running, a second `pgit …` doesn't spawn
 another instance — it forwards the request to the running window, focuses it,
 and navigates there.
+
+**`--debug` when something goes wrong at startup.** It is the one flag that
+keeps the app in the foreground instead of handing the prompt back, and it
+raises the log level, so the app's log — including every call the window makes
+to the backend — streams into the terminal you launched it from. Ctrl+C quits
+the app. Because a second `pgit` forwards to the running window rather than
+starting anything, quit the app first if you want to trace a fresh launch.
+Unix only: the Windows binary has no console to print to, though `--debug` still
+raises the level of the log file it writes.
 
 **Most installs already have it.** The Homebrew cask, the `.deb` (via apt or by
 hand), the `.msi` and Scoop all install `pgit` alongside the app and remove it

--- a/docs/dev/distribution.md
+++ b/docs/dev/distribution.md
@@ -100,6 +100,46 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   proxy: the same flag chooses `devUrl` over the embedded assets. `cargo run`
   stays in the foreground for the same reason; the e2e build sets
   `tauri/custom-protocol` and is unchanged (its stdio is a pipe anyway).
+## `pgit --debug` opts out of the detach to stream the log (#344)
+
+`--debug` is the escape hatch from the section above: the app stays attached to
+the invoking terminal and its log streams there at `debug` level. It is what you
+reach for when something fails at startup and the rotating log file cannot say
+why (#274) — or will not, because at the default `Info` every *successful*
+webview invoke is dropped.
+
+- **It is `Parsed::DebugLaunch`, a separate variant — not a `debug` field on
+  `Parsed::Launch`.** `should_detach` is spelled
+  `matches!(parsed, Parsed::Launch(_))`, so a new variant is refused **by
+  construction** and that function needed no edit at all. A field would have
+  left the pattern matching, detached the launch, and sent the log to the
+  child's `/dev/null` — the exact failure the flag exists to prevent, in the one
+  function whose wrong answer is invisible until somebody's push stops
+  authenticating. This is the extension shape `detach.rs`'s "Room left for
+  `--wait`" note describes; `--wait` should follow it too.
+- **`--debug` is stripped before the positional walk** in `parse_args`.
+  `screen_for` only consults index 0, so leaving the flag in place would make
+  `pgit --debug log` open a *path* named `log`.
+- **`--help` and `--version` still win**, and the askpass short-circuit in
+  `lib.rs::run` is still ahead of all of it — git's prompt is arbitrary text
+  arriving as argv[1] and is never scanned for our flags. Both are pinned by pty
+  tests in `tests/cli_detach.rs`: a prompt that literally reads `--debug` must
+  still be answered as a credential, not launched as a GUI.
+- **The level is raised globally, not just for `platypusgit_lib`**
+  (`cli::log_filter`). The lines that matter for a startup failure come from the
+  `webview:…` target, which the crate-specific `level_for` does not reach.
+- **The notice on stderr is unconditional, and says what silence means.** A
+  second `pgit --debug` against a running app is forwarded and exits *inside*
+  `Builder::run()` (tauri-plugin-single-instance), which is past the point where
+  this process could detect it — so rather than returning a silent, log-free 0,
+  the launch always prints that no following log lines means an instance was
+  already running. Quit it and retry to trace a fresh launch. stderr, because
+  stdout is where the log itself goes.
+- **Unix only, in practice.** The Windows binary is GUI-subsystem, so it has no
+  console to print to — `pgit --help` prints nothing there today for the same
+  reason. `--debug` still raises the file log's level on Windows; streaming it
+  to cmd/PowerShell needs `AttachConsole` and is not done.
+
 - `tests/cli_detach.rs` drives the real binary through a **pty** for the
   must-stay-synchronous paths and `git credential fill` (offline) for the
   credentialed one — a pure-function test cannot show git still gets its

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -21,6 +21,16 @@ pub enum Parsed {
     Askpass(String),
     /// `None` = plain app launch (no CLI args at all).
     Launch(Option<LaunchIntent>),
+    /// `--debug`: the same launch, but staying in the foreground with the log
+    /// filter raised so the app's log streams to the invoking terminal (#344).
+    ///
+    /// This is a **separate variant and not a `debug` field on `Launch`** on
+    /// purpose. `detach::should_detach` is spelled
+    /// `matches!(parsed, Parsed::Launch(_))`, so a new variant is refused by
+    /// construction; a field would have left that pattern matching and detached
+    /// the very launch whose whole point is to keep the terminal — with the log
+    /// going to the child's `/dev/null` and nothing to say why.
+    DebugLaunch(Option<LaunchIntent>),
 }
 
 /// Env vars the parent process sets so the askpass shim can answer without any
@@ -79,6 +89,10 @@ pub fn askpass_answer(
     }
 }
 
+/// `--debug`. One spelling, no short form: `-d` is worth keeping free, and a
+/// flag that changes how the process is launched should be typed out.
+const DEBUG_FLAG: &str = "--debug";
+
 pub const USAGE: &str = "\
 PlatypusGit
 
@@ -100,6 +114,8 @@ Subcommands:
 Options:
   -h, --help         print this help and exit
   -V, --version      print the version and exit
+      --debug        keep the app in the foreground and stream its log, at
+                     debug level, to this terminal. Ctrl+C quits the app.
 
 With a path and no subcommand, opens the repo containing that path.
 With a subcommand and no path, uses the current directory.
@@ -156,9 +172,18 @@ pub fn parse_args(args: &[String], cwd: &Path) -> Parsed {
     if args.iter().any(|a| a == "--version" || a == "-V") {
         return Parsed::Version;
     }
+    // Stripped BEFORE the positional walk below, which only consults
+    // `screen_for` at index 0: left in place, `pgit --debug log` would put
+    // `log` at index 1 and open it as a *path* named "log".
+    let debug = args.iter().any(|a| a == DEBUG_FLAG);
+    let positional: Vec<&str> = args
+        .iter()
+        .map(String::as_str)
+        .filter(|a| *a != DEBUG_FLAG)
+        .collect();
     let mut screen: Option<String> = None;
     let mut path: Option<PathBuf> = None;
-    for (i, arg) in args.iter().enumerate() {
+    for (i, arg) in positional.iter().enumerate() {
         if i == 0 {
             if let Some(s) = screen_for(arg) {
                 screen = Some(s.to_string());
@@ -172,9 +197,29 @@ pub fn parse_args(args: &[String], cwd: &Path) -> Parsed {
     if screen.is_some() && path.is_none() {
         path = Some(cwd.to_path_buf());
     }
-    match (path, &screen) {
-        (None, None) => Parsed::Launch(None),
-        (path, _) => Parsed::Launch(Some(LaunchIntent { path, screen })),
+    let intent = match (path, screen) {
+        (None, None) => None,
+        (path, screen) => Some(LaunchIntent { path, screen }),
+    };
+    if debug {
+        Parsed::DebugLaunch(intent)
+    } else {
+        Parsed::Launch(intent)
+    }
+}
+
+/// The global log-level filter a launch installs.
+///
+/// The default is `Info`, which drops every *successful* webview invoke —
+/// `src/lib/tauri.ts` logs those at `debug()`. That is the exact silence #274
+/// ran into: at `Info` a call that hung and a call that was never dispatched
+/// produce the same (empty) log. `--debug` raises the floor so that sequence
+/// reaches the terminal.
+pub fn log_filter(debug: bool) -> log::LevelFilter {
+    if debug {
+        log::LevelFilter::Debug
+    } else {
+        log::LevelFilter::Info
     }
 }
 
@@ -768,6 +813,69 @@ mod tests {
     #[test]
     fn bare_launch_has_no_intent() {
         assert_eq!(parse_args(&[], Path::new("/w")), Parsed::Launch(None));
+    }
+
+    #[test]
+    fn the_debug_flag_marks_the_launch_and_is_not_read_as_a_path() {
+        assert_eq!(
+            parse_args(&s(&["--debug"]), Path::new("/w")),
+            Parsed::DebugLaunch(None)
+        );
+    }
+
+    #[test]
+    fn the_debug_flag_leaves_the_screen_and_path_intact() {
+        // Stripped BEFORE the positional walk, or `log` lands at index 1 and
+        // `screen_for` (index 0 only) reads it as a path instead of a screen.
+        assert_eq!(
+            parse_args(&s(&["--debug", "log", "sub/dir"]), Path::new("/w")),
+            Parsed::DebugLaunch(Some(LaunchIntent {
+                path: Some(PathBuf::from("/w/sub/dir")),
+                screen: Some("history".to_string()),
+            }))
+        );
+    }
+
+    #[test]
+    fn the_debug_flag_is_accepted_after_the_subcommand_too() {
+        assert_eq!(
+            parse_args(&s(&["commit", "--debug"]), Path::new("/w")),
+            Parsed::DebugLaunch(Some(LaunchIntent {
+                path: Some(PathBuf::from("/w")),
+                screen: Some("commit".to_string()),
+            }))
+        );
+    }
+
+    #[test]
+    fn help_still_wins_over_the_debug_flag() {
+        // `--debug` must not turn `pgit --debug --help` into a GUI launch.
+        assert_eq!(
+            parse_args(&s(&["--debug", "--help"]), Path::new("/w")),
+            Parsed::Help
+        );
+        assert_eq!(
+            parse_args(&s(&["--debug", "-V"]), Path::new("/w")),
+            Parsed::Version
+        );
+    }
+
+    #[test]
+    fn a_git_prompt_is_never_scanned_for_the_debug_flag() {
+        // Same contract as -h: the askpass prompt is arbitrary text from git and
+        // is returned verbatim, never parsed as one of our own flags.
+        assert_eq!(
+            parse_args(&s(&["--askpass", "--debug"]), Path::new("/w")),
+            Parsed::Askpass("--debug".to_string())
+        );
+    }
+
+    #[test]
+    fn debug_raises_the_global_log_filter() {
+        // Info drops every successful webview invoke (all `debug!()`), which is
+        // exactly the sequence a debug launch exists to show.
+        assert_eq!(log_filter(false), log::LevelFilter::Info);
+        assert_eq!(log_filter(true), log::LevelFilter::Debug);
     }
 
     #[test]

--- a/src-tauri/src/detach.rs
+++ b/src-tauri/src/detach.rs
@@ -254,6 +254,24 @@ mod tests {
     }
 
     #[test]
+    fn a_debug_launch_never_detaches() {
+        // The whole point of `--debug`: the log has to reach the terminal that
+        // asked for it, and a detached child's stdout is /dev/null.
+        //
+        // Note this needs no change to `should_detach` — it names
+        // `Parsed::Launch` and nothing else, so a new variant is refused by
+        // construction. That is deliberate: a `debug` *field* on `Launch` would
+        // have kept `matches!(parsed, Parsed::Launch { .. })` true and detached
+        // anyway.
+        let d = Parsed::DebugLaunch(Some(LaunchIntent {
+            path: Some(PathBuf::from("/repo")),
+            screen: None,
+        }));
+        assert!(!should_detach(&d, env(true)));
+        assert!(!should_detach(&Parsed::DebugLaunch(None), env(true)));
+    }
+
+    #[test]
     fn help_never_detaches() {
         // USAGE must reach the terminal that asked for it.
         assert!(!should_detach(&Parsed::Help, env(true)));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -81,6 +81,27 @@ pub fn run() {
         return;
     }
 
+    // `--debug` (#344). `should_detach` above named `Parsed::Launch` and nothing
+    // else, so this variant already stayed in the foreground; what is left is to
+    // raise the log filter and say what is happening.
+    //
+    // The notice is printed unconditionally for a debug launch, and names the
+    // already-running case, because that case cannot be detected from here: the
+    // single-instance plugin forwards this invocation's intent and exits inside
+    // `Builder::run()` below, so a `pgit --debug` against a running app would
+    // otherwise return an immediate, silent, log-free 0. stderr, not stdout —
+    // stdout is where the log itself is about to go.
+    let debug_launch = matches!(parsed, cli::Parsed::DebugLaunch(_));
+    if debug_launch {
+        eprintln!(
+            "platypusgit: debug launch — log level raised to debug, streaming to this terminal."
+        );
+        eprintln!(
+            "platypusgit: Ctrl+C quits the app. If no log lines follow, an instance was already \
+             running and was focused instead — quit it and retry."
+        );
+    }
+
     let initial_intent = match parsed {
         cli::Parsed::Help => {
             print!("{}", cli::USAGE);
@@ -92,7 +113,9 @@ pub fn run() {
         }
         // Already handled above; unreachable in practice.
         cli::Parsed::Askpass(_) => return,
-        cli::Parsed::Launch(intent) => intent.map(cli::resolve_repo_root),
+        cli::Parsed::Launch(intent) | cli::Parsed::DebugLaunch(intent) => {
+            intent.map(cli::resolve_repo_root)
+        }
     };
 
     let backend = Arc::new(Libgit2Backend::new());
@@ -108,7 +131,7 @@ pub fn run() {
         builder = builder.plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
             use tauri::{Emitter, Manager};
             let args: Vec<String> = argv.into_iter().skip(1).collect();
-            if let cli::Parsed::Launch(Some(intent)) =
+            if let cli::Parsed::Launch(Some(intent)) | cli::Parsed::DebugLaunch(Some(intent)) =
                 cli::parse_args(&args, std::path::Path::new(&cwd))
             {
                 let intent = cli::resolve_repo_root(intent);
@@ -126,7 +149,7 @@ pub fn run() {
     let builder = builder
         .plugin(
             tauri_plugin_log::Builder::new()
-                .level(log::LevelFilter::Info)
+                .level(cli::log_filter(debug_launch))
                 .level_for("platypusgit_lib", log::LevelFilter::Debug)
                 .targets([
                     tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),

--- a/src-tauri/tests/cli_detach.rs
+++ b/src-tauri/tests/cli_detach.rs
@@ -185,6 +185,39 @@ fn help_prints_usage_and_exits_even_with_a_terminal_attached() {
     );
 }
 
+#[test]
+fn the_debug_flag_does_not_stop_help_reaching_the_terminal() {
+    // `--debug` is the one flag that makes a launch stay in the foreground, so
+    // a reordering that let it win over `--help` would open a window instead of
+    // printing USAGE — and the pty here is the condition that would hide it.
+    let mut cmd = Command::new(EXE);
+    clean_env(&mut cmd);
+    cmd.args(["--debug", "--help"]);
+
+    let run = run_in_pty(cmd);
+
+    assert_eq!(run.code, Some(0));
+    assert_eq!(run.output, USAGE);
+}
+
+#[test]
+fn askpass_answers_a_prompt_that_looks_like_the_debug_flag() {
+    // git's prompt is arbitrary text arriving as argv[1]. If it were ever
+    // scanned for `--debug`, this invocation would build a Tauri app and open a
+    // window instead of printing the credential — with git blocked on a read
+    // that never completes.
+    let mut cmd = Command::new(EXE);
+    clean_env(&mut cmd);
+    cmd.arg("Password for '--debug': ")
+        .env(ASKPASS_MODE_ENV, "1")
+        .env(ASKPASS_SECRET_ENV, "s3cr3t-despite-the-flag");
+
+    let run = run_in_pty(cmd);
+
+    assert_eq!(run.code, Some(0), "askpass output was: {:?}", run.output);
+    assert_eq!(run.output.trim_end(), "s3cr3t-despite-the-flag");
+}
+
 // ─────────────────────────────────────────────────────────────
 // The credentialed regression test: real git → the real binary
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #344.

`pgit .` hands the prompt back by re-execing detached, with the child's stdout
on `/dev/null` — so the one launch shape that *has* a terminal is exactly the
one that throws the log away. The level filter is separately pinned at `Info`,
which drops every successful webview invoke (all `debug!()`). Between them there
was no way to launch the app and watch it log.

`pgit --debug [subcommand] [path]` stays in the foreground and raises the global
filter to `Debug`, so the whole invoke sequence streams to the invoking terminal.

## The load-bearing decision

**`Parsed::DebugLaunch` is a separate variant, not a `debug` field on
`Parsed::Launch`.** `should_detach` is spelled
`matches!(parsed, Parsed::Launch(_))`, so a new variant is **refused by
construction** — that function needed no edit at all. A field would have left
that pattern matching and detached the very launch whose whole point is to keep
the terminal, sending the log to `/dev/null` with nothing to say why. It is also
the extension shape `detach.rs`'s "Room left for `--wait`" note already
describes, so `--wait` should follow it.

Two other ordering constraints, both pinned by pty tests:

- `--help`/`--version` still win over `--debug`.
- The askpass short-circuit in `lib.rs::run` stays ahead of all of it. A git
  prompt that literally reads `--debug` must be answered as a credential, not
  launched as a GUI — otherwise git blocks on a read that never completes.

## Resolving the issue's open questions

1. **Spelling** — `--debug`, one spelling, no short form (`-d` stays free).
2. **Single-instance** — the notice on stderr is unconditional and names the
   already-running case. That case cannot be detected from `run()`:
   tauri-plugin-single-instance forwards the intent and exits *inside*
   `Builder::run()`, so `pgit --debug` against a running app would otherwise
   return a silent, log-free `0`. Forwarding itself now also accepts a debug
   launch, or `pgit --debug <path>` would focus the window without opening the
   repo.
3. **Askpass** — unchanged and pinned, as above.
4. **Windows** — scoped out, as the issue allowed. The GUI-subsystem binary has
   no console (`pgit --help` prints nothing there today for the same reason);
   `--debug` still raises the file log's level.

## Verification

Unit + integration tests are green (`cargo test`: 333 lib + all integration
suites; `pnpm test`: 2929 tests / 307 files, doc invariants included), and the
two new pty tests in `tests/cli_detach.rs` cover the help and askpass orderings.

Because no unit test can show a GUI launch actually streaming, this was also
driven end-to-end against a real `tauri/custom-protocol` build through a pty:

- `platypusgit .` — parent returned immediately, zero output (detach unchanged).
- `platypusgit --debug .` — parent stayed attached, banner on stderr, then:

  ```
  [platypusgit_lib][INFO] platypusgit starting v0.0.0
  [platypusgit_lib::commands::repo][INFO] open_repo /…/pgit-debug-flag
  [webview:…][DEBUG] invoke open_repo 6ms
  [webview:…][DEBUG] invoke get_status 36ms
  [webview:…][DEBUG] invoke list_branches 120ms
  …
  ```

  Those `webview:…[DEBUG]` lines are the ones the `Info` floor was dropping.

- `platypusgit --debug --help` — prints USAGE and exits.

E2E was not run locally: the harness drives the binary over pipes with no
`--debug`, where both the detach gate and the log filter are bit-for-bit
unchanged. CI's full suite gates it.

## Relationship to #274

That issue is about *what* the log contains and reaching it from Settings; this
is about *seeing* it live. They compose — a debug launch is how you would use
the extra lines — and this PR leaves its checklist alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
