### PR TITLE
chore(ci): least-privilege permissions in tests.yml and e2e.yml

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Least privilege for every job below (#345). Nothing in this file touches
+# GITHUB_TOKEN or `gh`: the change filter diffs locally after a full-depth
+# checkout, and upload/download-artifact authenticate with the Actions runtime
+# token, not this one. Declared explicitly so the scope is documented here
+# rather than inherited from a repository setting that can change under it.
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
@@ -271,6 +279,8 @@ jobs:
     needs: [changes, build, e2e]
     if: always()
     runs-on: ubuntu-latest
+    # No checkout and no token use: this gate only reads `needs.*.result`.
+    permissions: {}
     steps:
       - name: Gate on the E2E result
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Least privilege for every job below (#345). Nothing in this file touches
+# GITHUB_TOKEN or `gh`: the change filter diffs locally after a full-depth
+# checkout, and upload/download-artifact authenticate with the Actions runtime
+# token, not this one. Declared explicitly so the scope is documented here
+# rather than inherited from a repository setting that can change under it.
+permissions:
+  contents: read
+
 concurrency:
   group: tests-${{ github.ref }}
   cancel-in-progress: true
@@ -175,6 +183,8 @@ jobs:
     needs: [changes, unit]
     if: always()
     runs-on: ubuntu-latest
+    # No checkout and no token use: this gate only reads `needs.*.result`.
+    permissions: {}
     steps:
       - name: Gate on the unit result
         env:
@@ -207,6 +217,8 @@ jobs:
     needs: [changes, rust]
     if: always()
     runs-on: ubuntu-latest
+    # No checkout and no token use: this gate only reads `needs.*.result`.
+    permissions: {}
     steps:
       - name: Gate on the Rust result
         env:


### PR DESCRIPTION
Closes #345 — all ten open `actions/missing-workflow-permissions` CodeQL alerts.

Neither `tests.yml` nor `e2e.yml` declared a `permissions` block, at the root
or on any job, so all ten jobs inherited the repository default.

The repository default is already `read`, so nothing was exposed. This is
worth doing anyway because that default is a repository *setting* — invisible
in the tree, reversible in one click, and not carried along when a workflow is
copied elsewhere — and because ten permanently-open alerts bury the next real
one. `release.yml` and `site.yml` already declare root-level permissions; these
two just never got one.

## The change

Root of both files:

```yaml
permissions:
  contents: read
```

and `permissions: {}` on the three gate jobs — `unit-tests`, `rust-tests`,
`e2e-linux`.

## Why those are the right scopes

- Neither workflow references `GITHUB_TOKEN`, and neither runs `gh`.
- Both `changes` jobs compute their filter with a plain
  `git diff --name-only "$BASE_SHA"...HEAD` after a `fetch-depth: 0` checkout —
  not `dorny/paths-filter`, so no `pull-requests: read` is needed.
- `actions/upload-artifact` / `download-artifact` authenticate with the Actions
  runtime token, not `GITHUB_TOKEN`.
- The three gate jobs have no checkout at all; they only read `needs.*.result`
  and `echo`/`exit`. CodeQL's own suggested minimum for those three is the
  empty set.

## Verification

- `pnpm test` — **307 files / 2929 tests passed**, including the guards that
  read `.github/`: `test/shardSpecs.test.ts`, `test/privacy.test.ts`,
  `test/docs.test.ts`.
- Parsed both files with `yaml` and asserted the resolved permissions per job:
  root `{contents: read}` on both, `{}` on the three gates, and the seven
  checkout jobs still inheriting the root (no accidental empty block on a job
  that needs to clone). Also re-checked that the single-line
  `shard: [ ... ]` matrix `shardSpecs.test.ts` parses is untouched.
- This PR gates itself: `tests.yml` trips the `js`, `rust` and `msix` filters
  and `e2e.yml` trips `js` and `app`, so CI runs the full unit + rust + msix +
  e2e suite against the reduced tokens. That run is the real proof they are
  still sufficient.

After merge, CodeQL re-runs on `main` and should close all ten:

```
gh api repos/jonassaa/platypusgit/code-scanning/alerts -q '.[] | [.number, .state] | @tsv'
```

## Not included

The optional follow-up noted in #345 — narrowing `release.yml`'s root
`contents: write` (granted to all 12 jobs) and `site.yml`'s `pages: write` /
`id-token: write` (granted to `build` as well as `deploy`). Neither is
CodeQL-reported and neither is needed to clear the alert list, so they stay out
of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
