### PR TITLE
test: guard the pnpm.overrides security block against a silent drop (#346)

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -243,6 +243,22 @@ proven by `pnpm test`. It needs a real Docker e2e run.
 - **`test/nativeSelect.test.ts`** is a SOURCE invariant: no `<select>`/`<option>`
   in shipped `src/` (issue 146) — the failure is invisible on macOS/Windows.
   Comments stripped first; test files out of scope.
+- **`test/depOverrides.test.ts`** guards the `pnpm.overrides` security block
+  (#346) against the one thing that routinely kills it: a Dependabot npm PR
+  regenerates the lockfile, drops the whole block, and 20 advisories come back
+  with nothing in the diff that looks like a security change. It asserts both
+  halves, because the block surviving is not the fix surviving — every security
+  override key is still in `package.json`, AND no version resolved in
+  `pnpm-lock.yaml` sits below its advisory floor, which is what catches a block
+  that was kept while the lockfile was never regenerated. It asserts a FLOOR,
+  never a ceiling, so ordinary bumps stay green; an unguarded new major is
+  allowed through on purpose (the advisory ranges are major-scoped, so
+  `undici` 8.x is a new question, not a regression of this one). Two traps if
+  you edit it: the lockfile records our own `undici@6` selector keys at the
+  same indentation as real packages, so the version pattern must demand a full
+  `major.minor.patch` or it reads a selector as a version; and `it.each`'s
+  `$major` renders as `undefined`, which is why the floor cases are a plain
+  loop.
 - **`test/privacy.test.ts`** pins the promise the README advertises (#226): no
   analytics package in `package.json` or anywhere in `pnpm-lock.yaml`
   (transitive is the arrival nobody reviews), no network call or analytics

--- a/test/depOverrides.test.ts
+++ b/test/depOverrides.test.ts
@@ -1,0 +1,188 @@
+/**
+ * @vitest-environment node
+ */
+// The standing half of issue 346: **the `pnpm.overrides` security block is the
+// only thing fixing 20 advisories, and the routine way it dies is a merge.**
+//
+// Every npm Dependabot alert this repo gets against the root project is
+// `development` scope and transitive-only. Dependabot cannot fix any of them:
+// its security updater bumps manifest entries and never writes
+// `pnpm.overrides`. So the fix is hand-written in `package.json` — and a
+// Dependabot npm PR regenerates the lockfile and **drops the whole block**.
+// Merge one of those without restoring it and 20 advisories come back silently,
+// with no test failing and nothing in the diff that looks like a security
+// change. That is the exact failure this file exists to make loud.
+//
+// It guards two things, because the block surviving is not the same as the fix
+// surviving:
+//
+//   1. every security override key is still present in `package.json`, and
+//   2. no version actually resolved in `pnpm-lock.yaml` is below the advisory's
+//      first patched version — which also catches a block that was kept but a
+//      lockfile that was never regenerated against it.
+//
+// If this test fails, do NOT delete the entry to make it pass. Restore the
+// block (`git show origin/main:package.json`), re-run `pnpm install`, and check
+// the lockfile diff. The reasoning behind each entry, and the two advisories
+// deliberately left open (`esbuild`, `extract-zip`), are in
+// `docs/dev/testing.md`; the one shipped advisory we cannot fix (`glib`) is in
+// `docs/dev/distribution.md`.
+//
+// **Deliberately NOT a version-drift test.** It asserts a floor, never a
+// ceiling, so an ordinary bump past the floor keeps it green. And an unguarded
+// MAJOR is allowed through on purpose: the advisory ranges below are
+// major-scoped, so a future `ws` 9.x or `undici` 8.x is a new question rather
+// than a regression of this one. Widen the table when that happens.
+//
+// Its inputs (`package.json`, `pnpm-lock.yaml`, `test/`) are all already in
+// `tests.yml`'s `js` change-filter — the #210 failure mode is a guard whose
+// inputs the filter does not match, which gets skipped by exactly the change it
+// polices. Keep it that way.
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = join(__dirname, "..");
+const read = (p: string) => readFileSync(join(root, p), "utf8");
+
+/** The advisory floor for each guarded package, keyed by major.
+ *
+ *  `min` is the advisory's `first_patched_version`, not the version currently
+ *  resolved — the point is the floor, so a routine bump does not fail this. */
+const FLOORS: Array<{
+  name: string;
+  major: number;
+  min: string;
+  why: string;
+}> = [
+  { name: "@babel/core", major: 7, min: "7.29.6", why: "GHSA-4x5r-pxfx-6jf8 — arbitrary file read via sourceMappingURL" },
+  { name: "brace-expansion", major: 1, min: "1.1.16", why: "GHSA-3jxr-9vmj-r5cp — exponential-time expansion DoS" },
+  { name: "brace-expansion", major: 2, min: "2.1.2", why: "GHSA-3jxr-9vmj-r5cp — exponential-time expansion DoS" },
+  { name: "fast-xml-parser", major: 5, min: "5.10.1", why: "GHSA-8r6m-32jq-jx6q — DOCTYPE resets entity expansion limits" },
+  { name: "form-data", major: 4, min: "4.0.6", why: "GHSA-hmw2-7cc7-3qxx — CRLF injection in multipart field names" },
+  { name: "ip-address", major: 10, min: "10.3.1", why: "GHSA-mwp4-54f8-5fhr — leading-zero octets decoded as decimal, SSRF bypass" },
+  { name: "js-yaml", major: 4, min: "4.3.1", why: "GHSA-5p4m-2wfm-xmqj — quadratic CPU in !!omap resolution" },
+  { name: "serialize-javascript", major: 7, min: "7.0.5", why: "GHSA-5c6j-r48x-rmvq + GHSA-qj8w-gfj5-8c6v — RCE and CPU-exhaustion DoS" },
+  { name: "undici", major: 6, min: "6.28.0", why: "GHSA-8xcm-r25x-g524 + GHSA-v3r7-h72x-cjcm + GHSA-m8rv-5g2x-5cg5" },
+  { name: "undici", major: 7, min: "7.29.0", why: "GHSA-4cwx-7wf7-3272 + GHSA-jr45-8vmc-qm54 and three more" },
+  { name: "ws", major: 8, min: "8.21.0", why: "GHSA-96hv-2xvq-fx4p — memory-exhaustion DoS from tiny fragments" },
+];
+
+/** The override keys that must exist in `package.json`.
+ *
+ *  Two majors of one package coexist for `undici` and `brace-expansion`, so
+ *  those MUST use the `pkg@major` selector form. A bare `"undici": "^7"` would
+ *  drag `webdriver`, which wants 6.x, across a major and break the e2e runner
+ *  — so the selector is not cosmetic and the key shape is part of the fix. */
+const REQUIRED_KEYS = [
+  "@babel/core",
+  "brace-expansion@1",
+  "brace-expansion@2",
+  "fast-xml-parser",
+  "form-data",
+  "ip-address",
+  "js-yaml",
+  "serialize-javascript",
+  "undici@6",
+  "undici@7",
+  "ws",
+];
+
+/** Numeric compare of two dotted versions. Prerelease tags are cut off first:
+ *  nothing here is pinned to one, and a prerelease below the floor should fail
+ *  rather than parse as NaN and slip through. */
+function lte(a: string, b: string): boolean {
+  const parse = (v: string) =>
+    v
+      .split("-")[0]
+      .split(".")
+      .map((n) => Number.parseInt(n, 10) || 0);
+  const [x, y] = [parse(a), parse(b)];
+  for (let i = 0; i < Math.max(x.length, y.length); i++) {
+    const d = (x[i] ?? 0) - (y[i] ?? 0);
+    if (d !== 0) return d < 0;
+  }
+  return true;
+}
+
+describe("the pnpm.overrides security block survives (#346)", () => {
+  const pkg = JSON.parse(read("package.json")) as {
+    pnpm?: { overrides?: Record<string, string> };
+  };
+  const overrides = pkg.pnpm?.overrides ?? {};
+
+  it("still pins the broken @wdio/tauri-service dep", () => {
+    // Not a security entry — it pins a BROKEN dep, and predates #346. It lives
+    // in the same block, so a dropped block takes it out too and the e2e runner
+    // stops working. See docs/dev/testing.md.
+    expect(overrides["@wdio/native-utils"]).toBe("2.5.0");
+  });
+
+  it.each(REQUIRED_KEYS)("still overrides %s", (key) => {
+    expect(
+      overrides[key],
+      `pnpm.overrides["${key}"] is gone. A Dependabot npm PR regenerates the ` +
+        `lockfile and drops the whole overrides block — restore it from ` +
+        `origin/main and re-run pnpm install before merging. See ` +
+        `docs/dev/testing.md.`,
+    ).toBeTruthy();
+  });
+
+  it("uses the pkg@major selector form where two majors coexist", () => {
+    // A bare key here would force every major onto one range. That is the
+    // difference between fixing an advisory and breaking the e2e runner.
+    for (const name of ["undici", "brace-expansion"]) {
+      expect(
+        overrides[name],
+        `pnpm.overrides["${name}"] is a bare key. Two majors of ${name} ` +
+          `coexist in this tree; use the ${name}@<major> selector form.`,
+      ).toBeUndefined();
+    }
+  });
+});
+
+describe("no resolved version sits below its advisory floor (#346)", () => {
+  const lock = read("pnpm-lock.yaml");
+
+  /** Every version of `name` that the lockfile actually resolves. Reads the
+   *  `packages:`/`snapshots:` keys, which are the resolved versions — not the
+   *  requested ranges, which is what makes this an assertion about what gets
+   *  installed rather than about what someone asked for.
+   *
+   *  The full `major.minor.patch` shape is required, not a bare leading digit:
+   *  the lockfile also records the override table itself, where our own
+   *  `undici@6` / `brace-expansion@1` SELECTOR keys sit at the same
+   *  indentation. A looser pattern reads those selectors as versions and the
+   *  floor check then fails against "6". */
+  function resolved(name: string): string[] {
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const re = new RegExp(`^ {2}'?${escaped}@(\\d+\\.\\d+\\.\\d+[^:'(]*)`, "gm");
+    return [...lock.matchAll(re)].map((m) => m[1].trim());
+  }
+
+  it("finds the lockfile it is meant to be reading", () => {
+    // Cheap canary: if the lockfile format changes shape, `resolved()` starts
+    // returning [] for everything and every assertion below passes vacuously.
+    expect(resolved("undici").length).toBeGreaterThan(0);
+    expect(resolved("ws").length).toBeGreaterThan(0);
+  });
+
+  // A plain loop rather than `it.each`: the `$major` placeholder renders as
+  // `undefined` in the test name, which makes a real failure read as
+  // "'undici' undefined is at or above '7.29.0'".
+  for (const { name, major, min, why } of FLOORS) {
+    it(`${name} ${major}.x is at or above ${min}`, () => {
+      const offenders = resolved(name)
+        .filter((v) => Number.parseInt(v.split(".")[0], 10) === major)
+        .filter((v) => !lte(min, v));
+
+      expect(
+        offenders,
+        `${name}@${offenders.join(", ")} is below ${min} (${why}). The ` +
+          `override may still be in package.json while the lockfile was never ` +
+          `regenerated against it — re-run pnpm install.`,
+      ).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
Follow-up to #349, closing out the Group D concern in #346 — but not the way that
issue sketched it. See below.

## The failure this catches

The `pnpm.overrides` block from #349 is the only thing fixing 20 advisories, and
it has a routine way to die: **a Dependabot npm PR regenerates the lockfile and
drops the whole block.** Merge one without restoring it and every advisory comes
back — nothing in the diff looks like a security change, no test fails, and no
alert re-opens until the next scan. That is a bad shape for a fix to have.

This adds `test/depOverrides.test.ts`, which asserts both halves, because the
block surviving is not the same as the fix surviving:

1. every security override key is still present in `package.json`, and
2. no version resolved in `pnpm-lock.yaml` sits below its advisory floor — which
   also catches a block that was *kept* while the lockfile was never regenerated
   against it.

## Why not the scheduled `pnpm audit` job #346 proposed

Because it would be **red forever, and therefore ignored.** `extract-zip` has no
patched version at all and `glib` cannot be fixed without an upstream gtk move,
so a job that fails on any advisory is permanently failing — and a permanently
failing scheduled workflow stops being read within a week. Meanwhile the failure
actually worth catching (a merge quietly reverting the fix) is something
`pnpm test` catches for free, in the idiom this repo already uses for
load-bearing promises: `privacy.test.ts`, `nativeSelect.test.ts`,
`shardSpecs.test.ts`.

If a periodic report is still wanted later, it should be report-only and separate
from this. I did not build it, on the grounds above.

## Floor, not ceiling

The test asserts a **floor**, never a ceiling, so an ordinary bump past the floor
stays green rather than turning this into a version-drift chore. An unguarded new
major passes on purpose too: the advisory ranges are major-scoped, so `undici`
8.x is a new question, not a regression of this one. The table is the place to
widen when that happens.

## Verified by breaking it

A guard that has never failed is not evidence of anything, so both modes were
checked against a deliberately broken tree:

- dropped the `js-yaml` key from `package.json` → fails with *"pnpm.overrides
  ["js-yaml"] is gone. A Dependabot npm PR regenerates the lockfile and drops the
  whole overrides block — restore it from origin/main…"*
- rewrote a resolved `undici@7.29.0` back to `7.28.0` in the lockfile → fails
  with *"undici@7.28.0 is below 7.29.0 (GHSA-4cwx-7wf7-3272 …). The override may
  still be in package.json while the lockfile was never regenerated against
  it."*

Both trees were then restored (`git status` clean apart from the new file).

## Two traps found writing it

Both now recorded in `docs/dev/testing.md` so the next person does not rediscover
them:

- the lockfile stores our own `undici@6` / `brace-expansion@1` **selector** keys
  at the same indentation as real packages, so the version pattern must demand a
  full `major.minor.patch` — a looser one reads a selector as a version and the
  floor check fails against "6".
- `it.each`'s `$major` placeholder renders as `undefined`, which made a genuine
  failure read as `'undici' undefined is at or above '7.29.0'`. The floor cases
  are a plain loop for that reason.

## Verification

- `pnpm tsc --noEmit` — clean
- `pnpm test` — 308 files, 2954 tests passed (+1 file, +25 tests, all from this
  file)

No `src/` or `src-tauri/` change, so no e2e rebuild is implicated.

#346 stays open for the remaining item there: the `@puppeteer/browsers` pruning
experiment, which would take `extract-zip` and `ip-address` out of the tree
entirely, and the `glib` upstream watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
