### PR TITLE
feat(terminal): a built-in terminal, cd-ed to the open repository (#243)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,10 +101,11 @@ components (`features/*/`), an in-house design system (`design/`, NOT
 `components/ui/`), shared logic in `lib/` (typed `invoke` wrappers in
 `lib/tauri.ts` — never call `invoke` directly). `@/` → `src/` path alias; use it.
 
-**Three near-identical filename pairs do different jobs** — check before
+**Four near-identical filename pairs do different jobs** — check before
 editing: `git/signing.rs` (cryptography) vs `git/signature.rs` (identity/
 sign-off); `src-tauri/src/update.rs` (engine) vs `commands/update.rs`
-(handlers); `src-tauri/src/cli.rs` (pgit launch) vs `git/cli.rs` (CliBackend).
+(handlers); `src-tauri/src/cli.rs` (pgit launch) vs `git/cli.rs` (CliBackend);
+`src-tauri/src/terminal.rs` (pty sessions) vs `commands/terminal.rs` (handlers).
 
 The full annotated trees are in `docs/dev/architecture.md`.
 

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -21,6 +21,26 @@ opener.rs        URLs/paths → OS default handler. SECURITY-critical: safe_url
                  cannot see a symlink or a path reached through one (#245).
                  contained_in compares components, not string prefixes:
                  /repository is not inside /repo
+terminal.rs      Live pty sessions for the built-in terminal (#243). Shape of
+                 watcher.rs: a Default state manage-d on the app, thin handlers
+                 in commands/terminal.rs. Sessions keyed by RepoId, which is
+                 what makes "one shell per repository tab" a property of the map
+                 rather than a rule the frontend remembers; a second open for a
+                 live repo returns the existing epoch instead of stacking a
+                 shell. Output leaves through an INJECTED EventSink, not an
+                 AppHandle — that is what lets tests/terminal.rs assert on the
+                 exact stream the frontend sees, and it keeps the reader thread
+                 free of the Tauri runtime. Data crosses as BASE64: an 8 KiB
+                 read splits a multi-byte character often enough that
+                 from_utf8_lossy would put U+FFFD inside filenames. Every event
+                 carries an epoch and the frontend drops the ones that are not
+                 its own — a reader still mid-read when the user reopened the
+                 terminal would otherwise paint the dead shell's tail into the
+                 new one. One blocking reader THREAD per session, because a pty
+                 read does not return while the shell lives; polling it with a
+                 deadline hangs inside the read. THIS FILE LOGS NOTHING —
+                 tests/terminal_privacy.rs fails the build if it starts to,
+                 because a terminal is where passwords get typed
 update.rs        Update discovery: semver compare, dev-build (0.0.0) short-circuit
                  before any network call, GitHub release parsing, ureq w/ timeout +
                  https_only. Logic only — handlers live in commands/update.rs
@@ -418,6 +438,19 @@ commands/        Thin Tauri handlers, one file per area:
 │                recursive watch on whatever it is handed. watch_stop is
 │                idempotent, so the frontend can call it on a setting change
 │                without tracking whether anything was running
+├── terminal.rs  term_open, term_write, term_resize, term_close (#243) — thin
+│                over src-tauri/src/terminal.rs (same basename, two files).
+│                term_open resolves the workdir through the backend rather than
+│                taking a path argument, for the reason watch.rs gives, and
+│                this one is about to become a shell's cwd. It also picks the
+│                shell: the Settings override when it is non-blank, else
+│                proc::default_shell. Returns the session's EPOCH, which the
+│                frontend filters events on. term_close is idempotent, so a tab
+│                that never opened a terminal costs one no-op invoke. The
+│                LIFECYCLE LOGGING lives here rather than in terminal.rs
+│                precisely because this file sees ids, sizes and exit codes and
+│                never a byte of traffic — term_write's payload is what the
+│                user typed, and a sudo password travels that way
 ├── history.rs   reset, cherry_pick, revert
 ├── ssh.rs       ssh_key_status, ssh_key_generate (#248) — thin over
 │                src-tauri/src/ssh.rs. Take NO repository: an SSH key belongs to
@@ -593,6 +626,22 @@ features/            Components + Zustand store colocated per feature:
 │                    because two call sites are not React components
 ├── lfs/             useLfsStore, LfsPanel (a Remote-screen section, not a
 │                    screen), LfsDiffNotice
+├── terminal/        The built-in terminal (#243). TerminalPanel docks below the
+│                    active screen and keeps one TerminalView per LIVE SESSION,
+│                    keyed by repository, showing only the active one — hidden,
+│                    never unmounted, because unmounting disposes xterm and
+│                    takes the scrollback with it, leaving the user a blank pane
+│                    attached to a live shell. Keyed rather than re-pointed for
+│                    the same reason: one instance moved between repos would put
+│                    the previous repo's scrollback under the new repo's prompt.
+│                    Per-repo session state lives in useTerminalStore and NOT in
+│                    RepoSlice: RepoSlice is cleared on every tab switch, which
+│                    is right for a diff and would orphan the shells of every
+│                    inactive tab. Sizing is MEASURED (useElementSize) rather
+│                    than observed — WebKitGTK has no ResizeObserver, so xterm's
+│                    FitAddon would leave Linux at 80x24 forever, which is why
+│                    the addon is not installed at all. Unmounting does not end
+│                    a session; useTabsStore's evict() does
 └── cli/             useCliLaunch — first-launch intent + forwarded cli-launch
                      events → useTabsStore.openRepo (never evicts current repo)
 

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -681,6 +681,48 @@ again. `commands/repo.rs::delete_untracked_files` is therefore thin.
   subprocess (same pre-check `verify_tag` has) — a cost win on every platform,
   and the question to ask of any new shell-out.
 
+## The pty carve-out (#243)
+
+`portable-pty` spawns through its **own** `CommandBuilder`, not
+`std::process::Command`, so a pty opened anywhere would sail straight past the
+`Command::new` guard above — a second spawn path with no guard on it, which is
+exactly the state issue 172 found the tree in, and invisible this time.
+
+So `proc::spawn_pty_shell` owns the **whole operation** — `openpty`, the
+builder, and `spawn_command` — and returns the master and the child.
+`crate::terminal` never touches `portable_pty`'s spawn API.
+`tests/spawn_no_window.rs` allow-lists those three symbols in `proc.rs` and
+counts zero everywhere else, so a future second pty fails the build the way a
+second `Command::new` does.
+
+Two properties of that child are deliberate inversions of what every other
+spawn in this codebase gets, and both are the kind of thing a later reader
+would "fix":
+
+- **`GIT_TERMINAL_PROMPT` is NOT set to 0.** The standing `prompt_less` policy
+  exists because a child of a GUI app has no terminal, so an auth prompt hangs
+  forever behind a window nobody can see. This child *is* a terminal, on
+  purpose, and the user is looking at it. Inheriting the silence would turn a
+  working `git push` into a mysterious failure.
+- **`CREATE_NO_WINDOW` does not apply**, which is why this does not go through
+  `program()`. ConPTY is not `CreateProcess` with an inherited console:
+  `portable-pty` allocates a pseudoconsole, so no `conhost` window appears and
+  #172's flash cannot happen here. *Reasoned, not yet measured on Windows* — if
+  a flash ever appears, the fix is in `spawn_pty_shell` and nowhere else, which
+  is the point of the carve-out.
+
+It does get `child_path()`: a Dock-launched app inherits launchd's minimal
+environment (#232), and without it the built-in terminal would be the one
+terminal on the machine where `node` is missing.
+
+**One more rule, with a test behind it: `src/terminal.rs` contains no logging
+call at all.** A terminal is where a `sudo` password gets typed. The bytes read
+from the pty have exactly one destination — the event sink — and the lifecycle
+logging worth having lives in `commands/terminal.rs`, which handles ids and exit
+codes and never sees traffic. `tests/terminal_privacy.rs` enforces the split;
+the rule is blunt (no logger, not "no logger near the buffer") because that is
+the version a grep can actually keep.
+
 ## Clone options, and what a shallow clone costs (#255)
 
 `--depth`, `--filter=blob:none`, `--single-branch` and `--recurse-submodules`

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1258,6 +1258,77 @@ on the badge. Screens that are all-path (`Worktrees`) skip the centred
   the one mouse-event drag in the app (document listeners are registered by an
   effect the mousedown schedules, so the grab needs its own driver round trip).
 
+## The built-in terminal (#243)
+
+A real pty, docked in `AppBody`'s screen column below the routed screen, so it
+spans the screen's width and not the activity bar's. Height persisted, dragged
+with the shared `PGResizeHandle` (`orientation="vertical"`). **Closed by
+default** — a terminal nobody asked for should not spawn a shell for every
+repository they open, and a `.zshrc` that runs nvm would then be paid for on
+every tab, invisibly.
+
+Four rules that are easy to break:
+
+- **Sizing is MEASURED, never observed.** WebKitGTK has no `ResizeObserver`, so
+  xterm's `FitAddon` would leave the Linux build rendering 80×24 in a
+  200-column pane forever. `TerminalView` uses `lib/useElementSize` (read first,
+  observe second) and calls `term.resize` and `term_resize` together, so the
+  renderer and the pty can never disagree about the grid. **The addon is
+  deliberately not installed** — there is nothing to reach for by accident.
+- **Per-repo state is NOT in `RepoSlice`.** `useTerminalStore` holds a session
+  epoch for every open repository at once — the shape `useTabsStore` has, not
+  the shape `RepoSlice` has. `RepoSlice` is cleared on every tab switch, which
+  is right for a diff and would orphan the shells of every inactive tab.
+- **The global chord handler stands down inside the terminal.** xterm renders a
+  hidden `<textarea>`, so the keymap's `isEditable` already drops bare chords —
+  but *not* modifier chords, and those are exactly the set a shell needs
+  (`Ctrl+C`, `Ctrl+D`, `Ctrl+R`). `useKeymapStore`'s `inTerminal` guard lets
+  only `terminal.toggle` and `app.closeOverlay` through. A terminal that sends
+  `Ctrl+C` to the command palette instead of the foreground process is worse
+  than no terminal, and `allowInInput` is not a licence to take it.
+- **A view is HIDDEN, never unmounted, and that is load-bearing.** Unmounting
+  disposes the xterm instance and takes the SCROLLBACK with it. The shell would
+  survive — sessions live in the backend, not the view — so the user would
+  reopen the panel to a blank pane attached to a live shell, with the build
+  output they were reading gone. "Hiding leaves the shell running" would be
+  technically kept and practically broken. So every repository with a live
+  session keeps its view mounted and only the active one is visible; collapsing
+  the panel hides the container rather than dropping its children.
+  `TerminalPanel.test.tsx` counts MOUNTS (from an effect, not the component
+  body) so a refactor back to unmounting fails there.
+- **Ending a session is `useTabsStore`'s `evict()`** — the one place that calls
+  `termClose`, covering `close`, `closeOthers`, `closeAll` and the LRU
+  displacement path together. `forget()` then drops the view.
+
+Output arrives base64-encoded and is decoded to bytes before `term.write` —
+see `terminal.rs` in `architecture.md` for why a string payload would put
+U+FFFD inside filenames. Events carry an epoch and the view drops the ones that
+are not its own.
+
+**Three ordering rules in `TerminalView`, all three found by the e2e spec and
+invisible to every other layer:**
+
+1. **Listen BEFORE `term_open`.** That command spawns the shell *and* its reader
+   thread before it returns, so the prompt is on the wire while a listener
+   attached afterwards does not exist yet, and Tauri buffers nothing. The
+   terminal opened blank and stayed blank. Events that arrive before the epoch
+   is known go to a pending buffer, which is flushed — filtered by epoch —
+   the moment `term_open` resolves, with no `await` in between.
+2. **Keystrokes are chained, one IPC call at a time.** `onData` fires per
+   keystroke; firing an un-awaited `term_write` from each lets the invokes race
+   and the pty receives them in completion order. Measured: `echo ZZMARKER`
+   reached the shell as `ecoZARhR ZMKE`. A paste would hit it every time.
+3. **The event payload is the flat struct, not the Rust enum** — see the note on
+   `TermEvent`. An externally-tagged enum nests the fields under a variant key,
+   the view's `repoId` check then fails for every event, and nothing renders
+   with no error anywhere.
+
+**Refresh after a command is not this feature's job.** The filesystem watcher
+(#239) defaults on and classifies against `gitdir`/`commondir`, so a `git
+commit` typed into the pane moves the graph already. A user who turned the
+watcher off gets no automatic refresh from the terminal either — documented,
+not worked around: a second mechanism for the same job would also fire on `ls`.
+
 ## Dialogs
 
 - **Never `window.confirm`/`window.prompt`** — `pgConfirm`/`pgPrompt` from

--- a/docs/superpowers/plans/2026-09-01-builtin-terminal.md
+++ b/docs/superpowers/plans/2026-09-01-builtin-terminal.md
@@ -1,0 +1,2383 @@
+# Built-in Terminal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A resizable terminal panel running a real pty, one shell per repository tab, already `cd`-ed to that repository's working directory.
+
+**Architecture:** `proc.rs` gains one function that owns the entire pty spawn, so the existing "no spawning outside `proc.rs`" guard keeps its meaning against a crate that spawns through its own builder. A Tauri-free `terminal.rs` holds the live sessions keyed by `RepoId` and pushes output through an injected event sink — which is what makes it testable without an `AppHandle`. Four thin commands wrap it. The frontend mounts one xterm.js instance per repository, sized by measurement rather than `ResizeObserver`.
+
+**Tech Stack:** Rust + `portable-pty` 0.9, Tauri 2, React 19 + `@xterm/xterm` 6, Zustand, vitest, WebdriverIO.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-builtin-terminal-spec.md`
+
+## Global Constraints
+
+- **Toolchain:** Node 22 + pnpm, Rust stable. The assistant's Bash tool does not inherit the interactive shell rc — prepend `export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"` to every `pnpm` and `cargo` invocation.
+- **Never `Command::new` outside `src-tauri/src/proc.rs`.** Extended by this work to `CommandBuilder::new`, `openpty(` and `spawn_command(`.
+- **Every IPC-crossing fn returns `AppResult<T>`.** Add `AppError` variants, never stringify. The TS `AppError` union stays 1:1 with the Rust enum **in the same commit** — `test/appErrors.test.ts` fails the build otherwise.
+- **Never call `invoke` directly from a component.** Typed wrappers in `src/lib/tauri.ts` only.
+- **Design system is `src/design/`, imported from `@/design`.** Never hardcode the accent hue — CSS variables and theme tokens only. Do not create `src/components/ui/`.
+- **No native `<select>`/`<option>` in shipped `src/`** — `PGSelect`. Never `window.confirm`/`window.prompt` — `pgConfirm`/`pgPrompt`.
+- **`useRepoStore` holds exactly ONE repository's state.** The terminal deliberately does not put per-repo state there — see Task 5.
+- **Measure viewports with `lib/useViewportH`/`useElementSize`** (read first, observe second). WebKitGTK has no `ResizeObserver`.
+- **No telemetry, no account** is a build gate. `test/privacy.test.ts` + `src-tauri/tests/no_telemetry.rs`. Neither new dependency may add a network call or a hostname.
+- **Commit style:** `feat(scope): …` / `fix(scope): …` / `test: …` / `docs: …`, imperative subject under 72 chars, `Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>`.
+- **Branch:** `feat/builtin-terminal`, already created off `origin/main` in the worktree `.claude/worktrees/builtin-terminal`. Never commit to `main`.
+- **Run e2e only when done, in Docker only:** `pnpm test:e2e:docker build` then `pnpm test:e2e:docker run --spec e2e/specs/terminal.e2e.ts`.
+
+---
+
+## File Structure
+
+**Created**
+
+| File | Responsibility |
+|---|---|
+| `src-tauri/src/terminal.rs` | Session registry. Owns every live pty and its reader thread. Tauri-free. Contains **no logging macro** — see Task 2. |
+| `src-tauri/src/commands/terminal.rs` | Four thin handlers. Resolves the workdir through the backend, supplies the event sink, logs lifecycle. |
+| `src-tauri/tests/terminal.rs` | Integration tests against real ptys. |
+| `src-tauri/tests/terminal_privacy.rs` | Guard: no logging of pty traffic. |
+| `src/features/terminal/useTerminalStore.ts` | Panel open/height + per-repo session status. |
+| `src/features/terminal/TerminalPanel.tsx` | The docked pane, its resize handle, its header. |
+| `src/features/terminal/TerminalView.tsx` | One xterm.js instance for one repository. |
+| `src/features/terminal/shellLabel.ts` | Pure: display name for a shell path. |
+| `src/features/terminal/index.ts` | Feature barrel. |
+| `src/features/terminal/useTerminalStore.test.ts` | Store logic. |
+| `src/features/terminal/TerminalView.test.tsx` | View against a mocked xterm. |
+| `src/features/terminal/shellLabel.test.ts` | Pure tests. |
+| `e2e/specs/terminal.e2e.ts` | One end-to-end spec. |
+
+**Modified**
+
+| File | Change |
+|---|---|
+| `src-tauri/Cargo.toml` | `portable-pty = "0.9"`, `base64` if not already present |
+| `src-tauri/src/proc.rs` | `PtySession`, `spawn_pty_shell`, `default_shell` |
+| `src-tauri/src/lib.rs` | `pub mod terminal;`, `.manage(TerminalState::default())`, four `invoke_handler!` entries |
+| `src-tauri/src/commands/mod.rs` | `pub mod terminal;` |
+| `src-tauri/src/error.rs` | `TerminalUnavailable(String)` |
+| `src-tauri/tests/spawn_no_window.rs` | pty-API allow-list |
+| `package.json` | `@xterm/xterm` |
+| `src/lib/types.ts` | `TermData`, `TermExit`, `TermSize` |
+| `src/lib/tauri.ts` | `termOpen`, `termWrite`, `termResize`, `termClose` |
+| `src/lib/errors.ts` | `TerminalUnavailable` union member + `appErrorDetail` prose |
+| `src/features/settings/useSettingsStore.ts` | `terminalShell: string` |
+| `src/screens/Settings.tsx` | Terminal section |
+| `src/features/keymap/actions.ts` | `terminal.toggle` |
+| `src/features/keymap/presets.ts` | Default chord `Ctrl+\`` |
+| `src/features/repo/useTabsStore.ts` | `close()` also closes the terminal session |
+| `src/AppShell.tsx` | Dock `TerminalPanel` in `AppBody` |
+| `docs/dev/architecture.md` | Backend + feature tree entries (**gates the build**) |
+| `docs/dev/backend.md` | The pty carve-out and the no-logging rule |
+| `docs/dev/frontend.md` | The panel, the measured fit, the focus rule |
+| `CLAUDE.md` | The near-identical filename pairs list goes from three to four |
+
+---
+
+### Task 1: The pty spawn carve-out in `proc.rs`
+
+The whole pty spawn lives in `proc.rs` so the `Command::new` guard cannot be walked past by a crate that spawns through `CommandBuilder`. Nothing else in the tree may touch `portable_pty`'s spawn API.
+
+**Files:**
+- Modify: `src-tauri/Cargo.toml`
+- Modify: `src-tauri/src/proc.rs` (append after `git_dir`/the last constructor)
+- Modify: `src-tauri/tests/spawn_no_window.rs:24-45` (`RAW_SPAWN_ALLOWED`) and append a new test
+- Test: `src-tauri/tests/terminal.rs` (created here, grown in Task 2)
+
+**Interfaces:**
+- Consumes: `crate::proc::child_path()` — the existing login-`PATH` merge.
+- Produces:
+  - `pub struct PtySession { pub master: Box<dyn portable_pty::MasterPty + Send>, pub child: Box<dyn portable_pty::Child + Send + Sync> }`
+  - `pub fn spawn_pty_shell(shell: &std::ffi::OsStr, workdir: &Path, rows: u16, cols: u16) -> std::io::Result<PtySession>`
+  - `pub fn default_shell() -> std::ffi::OsString`
+
+- [ ] **Step 1: Add the dependency**
+
+In `src-tauri/Cargo.toml`, under `[dependencies]`:
+
+```toml
+portable-pty = "0.9"
+```
+
+Check whether `base64` is already a dependency (`grep '^base64' src-tauri/Cargo.toml`). If not, add `base64 = "0.22"`.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src-tauri/tests/terminal.rs`:
+
+```rust
+//! The built-in terminal (#243), tested against real ptys.
+
+use std::io::{Read, Write};
+use std::time::{Duration, Instant};
+
+/// Read from `reader` until `marker` appears or the deadline passes.
+///
+/// A pty delivers in chunks whose boundaries are not ours to choose, so every
+/// assertion here is "the marker eventually appears", never "this read equals".
+fn read_until(reader: &mut (dyn Read + Send), marker: &str, secs: u64) -> String {
+    let deadline = Instant::now() + Duration::from_secs(secs);
+    let mut acc = String::new();
+    let mut buf = [0u8; 4096];
+    while Instant::now() < deadline {
+        match reader.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                acc.push_str(&String::from_utf8_lossy(&buf[..n]));
+                if acc.contains(marker) {
+                    return acc;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    acc
+}
+
+#[test]
+fn spawn_pty_shell_runs_in_the_given_workdir() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Canonicalise: macOS hands out /var/folders/… which is a symlink to
+    // /private/var/folders/…, and the shell reports the resolved one.
+    let workdir = dir.path().canonicalize().expect("canonicalize");
+
+    let session = platypusgit_lib::proc::spawn_pty_shell(
+        &platypusgit_lib::proc::default_shell(),
+        &workdir,
+        24,
+        80,
+    )
+    .expect("spawn a shell");
+
+    let mut reader = session.master.try_clone_reader().expect("reader");
+    let mut writer = session.master.take_writer().expect("writer");
+
+    writeln!(writer, "printf 'PGIT[%s]END\\n' \"$PWD\"").expect("write");
+    writer.flush().expect("flush");
+
+    let out = read_until(&mut *reader, "END", 10);
+    assert!(
+        out.contains(&format!("PGIT[{}]END", workdir.display())),
+        "the shell's cwd should be the workdir. saw: {out}"
+    );
+}
+
+#[test]
+fn spawn_pty_shell_rejects_a_shell_that_does_not_exist() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let err = platypusgit_lib::proc::spawn_pty_shell(
+        std::ffi::OsStr::new("/nonexistent/pgit-not-a-shell"),
+        dir.path(),
+        24,
+        80,
+    );
+    assert!(err.is_err(), "a missing shell must not silently succeed");
+}
+```
+
+Confirm the crate's lib name — run `grep -n 'name' src-tauri/Cargo.toml | head` and check `[lib] name`. If it is not `platypusgit_lib`, use whatever the other integration tests import (`grep -rn '^use platypusgit' src-tauri/tests/ | head -1`) and fix the paths above.
+
+- [ ] **Step 3: Run it to make sure it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test terminal
+```
+
+Expected: FAIL to compile — `no function named spawn_pty_shell`.
+
+- [ ] **Step 4: Implement in `proc.rs`**
+
+Append to `src-tauri/src/proc.rs`:
+
+```rust
+/// A live pty and the shell running on it.
+///
+/// Returned by [`spawn_pty_shell`], owned by `crate::terminal`. The master is
+/// what resizes and what is read/written; the child is what gets killed.
+pub struct PtySession {
+    pub master: Box<dyn portable_pty::MasterPty + Send>,
+    pub child: Box<dyn portable_pty::Child + Send + Sync>,
+}
+
+/// The shell to run when the user has not named one.
+///
+/// `$SHELL` is what the user's own terminal runs, which is the whole point —
+/// the built-in terminal should not be a different shell from the one outside
+/// the app. `/bin/sh` exists on every unix and is the honest last resort.
+#[cfg(not(windows))]
+pub fn default_shell() -> std::ffi::OsString {
+    std::env::var_os("SHELL")
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| std::ffi::OsString::from("/bin/sh"))
+}
+
+/// Windows has no `$SHELL`. Preference order is best-to-worst experience:
+/// PowerShell 7, then Windows PowerShell, then `cmd`. Resolution is left to
+/// `PATH` — `where.exe`-style probing would be a second spawn path.
+#[cfg(windows)]
+pub fn default_shell() -> std::ffi::OsString {
+    std::ffi::OsString::from("powershell.exe")
+}
+
+/// Spawn an INTERACTIVE shell on a fresh pty, `cd`-ed to `workdir` (#243).
+///
+/// # Why the whole spawn lives here rather than in `crate::terminal`
+///
+/// The rule this module exists to enforce is "no process spawn outside
+/// `proc.rs`", and `tests/spawn_no_window.rs` enforces it by grepping for
+/// `Command::new`. `portable_pty` spawns through its **own** `CommandBuilder`,
+/// so a pty spawned anywhere else would sail straight past that guard — the
+/// second spawn path the guard exists to prevent, and invisible. So this
+/// function owns `openpty`, the `CommandBuilder` and `spawn_command`, and the
+/// guard test allow-lists those three APIs here and nowhere else.
+///
+/// # What this child gets, and what it deliberately does not
+///
+/// * [`child_path`] — yes. A Dock-launched app inherits launchd's minimal
+///   environment (#232); without this the built-in terminal would be the one
+///   terminal on the machine where `node` is missing.
+/// * `TERM=xterm-256color` — the terminal we actually render.
+/// * `GIT_TERMINAL_PROMPT=0` — **no**, and this inverts the standing
+///   [`prompt_less`] policy on purpose. That policy exists because a child of a
+///   GUI app has no terminal, so an auth prompt hangs forever behind a window
+///   nobody can see. This child *is* a terminal and the user is looking at it;
+///   suppressing the prompt would turn a working `git push` into a mysterious
+///   failure. Inherited silence would have been the bug.
+/// * `CREATE_NO_WINDOW` — not applicable. ConPTY is not `CreateProcess` with an
+///   inherited console: `portable_pty` allocates a pseudoconsole and no
+///   `conhost` window appears, so #172's flash cannot happen here.
+///
+/// Nothing from the auth path goes near it — no forge token, no git credential,
+/// no askpass environment — exactly as `run_custom_action` does it.
+pub fn spawn_pty_shell(
+    shell: &OsStr,
+    workdir: &Path,
+    rows: u16,
+    cols: u16,
+) -> std::io::Result<PtySession> {
+    use portable_pty::{CommandBuilder, PtySize};
+
+    let pty = portable_pty::native_pty_system();
+    let pair = pty
+        .openpty(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| std::io::Error::other(format!("could not open a pty: {e}")))?;
+
+    let mut cmd = CommandBuilder::new(shell);
+    cmd.cwd(workdir);
+    cmd.env("TERM", "xterm-256color");
+    if let Some(p) = child_path() {
+        cmd.env("PATH", p);
+    }
+
+    let child = pair
+        .slave
+        .spawn_command(cmd)
+        .map_err(|e| std::io::Error::other(format!("could not start `{}`: {e}", shell.to_string_lossy())))?;
+
+    // The slave is the child's end. Holding it open here would mean the reader
+    // never sees EOF when the shell exits, so the reader thread would block
+    // forever on a dead session — the leaked thread per tab the issue warned
+    // about. Dropping it is what makes exit detectable.
+    drop(pair.slave);
+
+    Ok(PtySession {
+        master: pair.master,
+        child,
+    })
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test terminal
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 6: Extend the spawn guard**
+
+In `src-tauri/tests/spawn_no_window.rs`, append a new test after `the_windows_creation_flag_is_set_in_one_place_only`:
+
+```rust
+/// The pty half of the same rule (#243).
+///
+/// `portable_pty` spawns through its own `CommandBuilder`, not
+/// `std::process::Command`, so the `Command::new` guard above cannot see it. A
+/// pty opened anywhere but `proc.rs` would therefore be a second spawn path
+/// with no guard on it at all — which is the exact failure mode #172 was.
+#[test]
+fn the_pty_spawn_lives_only_in_the_proc_module() {
+    const PTY_APIS: [&str; 3] = ["CommandBuilder::new", "openpty(", "spawn_command("];
+
+    for (rel, body) in sources() {
+        for api in PTY_APIS {
+            let found = count_code_occurrences(&body, api);
+            let expected = if rel == "src/proc.rs" { 1 } else { 0 };
+            assert_eq!(
+                found, expected,
+                "{rel} uses `{api}` {found} time(s), expected {expected}. The \
+                 whole pty spawn belongs in src/proc.rs::spawn_pty_shell — a \
+                 second one would not be covered by any guard in this file."
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 7: Run the guard**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test spawn_no_window
+```
+
+Expected: 4 passed. If `no_raw_command_new_outside_the_proc_module` now fails with a count mismatch for `src/proc.rs`, that means the implementation introduced a `Command::new` — it should not have; `CommandBuilder::new` is a different string and the count stays 5.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src-tauri/Cargo.toml src-tauri/Cargo.lock src-tauri/src/proc.rs src-tauri/tests/terminal.rs src-tauri/tests/spawn_no_window.rs
+git commit -m "feat(terminal): own the pty spawn in proc.rs (#243)
+
+Why: portable-pty spawns through its own CommandBuilder, so a pty
+opened outside proc.rs sails past the Command::new guard — the second
+spawn path #172 exists to prevent, and invisible. The guard grows a
+pty-API case rather than the rule growing an exception.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: The session registry
+
+`terminal.rs` holds the live ptys. It is **Tauri-free**: output leaves through an injected sink, which is both better decomposition and the only reason this is testable without an `AppHandle`.
+
+**Files:**
+- Create: `src-tauri/src/terminal.rs`
+- Modify: `src-tauri/src/lib.rs:1-17` (module list)
+- Test: `src-tauri/tests/terminal.rs` (append)
+- Test: `src-tauri/tests/terminal_privacy.rs` (create)
+
+**Interfaces:**
+- Consumes: `crate::proc::{spawn_pty_shell, default_shell, PtySession}` from Task 1.
+- Produces:
+  - `pub enum TermEvent { Data { repo_id: String, epoch: u64, data: String }, Exit { repo_id: String, epoch: u64, code: Option<i32> } }`
+  - `pub type EventSink = Arc<dyn Fn(TermEvent) + Send + Sync>`
+  - `pub struct TerminalState` (implements `Default`)
+  - `pub fn open(&self, sink: EventSink, repo_id: &str, shell: &OsStr, workdir: &Path, rows: u16, cols: u16) -> io::Result<u64>` — returns the epoch
+  - `pub fn write(&self, repo_id: &str, data: &[u8]) -> io::Result<()>`
+  - `pub fn resize(&self, repo_id: &str, rows: u16, cols: u16) -> io::Result<()>`
+  - `pub fn close(&self, repo_id: &str)` — idempotent
+  - `pub fn is_open(&self, repo_id: &str) -> bool`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src-tauri/tests/terminal.rs`:
+
+```rust
+use std::sync::{Arc, Mutex};
+use platypusgit_lib::terminal::{EventSink, TermEvent, TerminalState};
+
+/// A sink that records every event, so a test can wait on the stream the
+/// frontend would receive rather than on the pty directly.
+#[derive(Default, Clone)]
+struct Recorder(Arc<Mutex<Vec<TermEvent>>>);
+
+impl Recorder {
+    fn sink(&self) -> EventSink {
+        let inner = self.0.clone();
+        Arc::new(move |ev| inner.lock().expect("sink lock").push(ev))
+    }
+
+    /// Everything decoded from `Data` events so far, concatenated.
+    fn text(&self) -> String {
+        use base64::Engine as _;
+        self.0
+            .lock()
+            .expect("lock")
+            .iter()
+            .filter_map(|e| match e {
+                TermEvent::Data { data, .. } => Some(
+                    base64::engine::general_purpose::STANDARD
+                        .decode(data)
+                        .expect("the payload is base64"),
+                ),
+                _ => None,
+            })
+            .flatten()
+            .collect::<Vec<u8>>()
+            .iter()
+            .map(|b| *b as char)
+            .collect()
+    }
+
+    fn exit(&self) -> Option<Option<i32>> {
+        self.0.lock().expect("lock").iter().find_map(|e| match e {
+            TermEvent::Exit { code, .. } => Some(*code),
+            _ => None,
+        })
+    }
+}
+
+/// Poll `f` until it is true or the deadline passes. A pty is asynchronous and
+/// a fixed sleep is either flaky or slow; this is neither.
+fn wait_for(secs: u64, mut f: impl FnMut() -> bool) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(secs);
+    while Instant::now() < deadline {
+        if f() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    false
+}
+
+fn open_in_tempdir(state: &TerminalState, rec: &Recorder, id: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    state
+        .open(
+            rec.sink(),
+            id,
+            &platypusgit_lib::proc::default_shell(),
+            dir.path(),
+            24,
+            80,
+        )
+        .expect("open a session");
+    dir
+}
+
+#[test]
+fn output_reaches_the_sink_as_base64() {
+    let state = TerminalState::default();
+    let rec = Recorder::default();
+    let _dir = open_in_tempdir(&state, &rec, "repo-a");
+
+    state.write("repo-a", b"echo pgit-ok\n").expect("write");
+
+    assert!(
+        wait_for(10, || rec.text().contains("pgit-ok")),
+        "the marker should reach the sink. saw: {}",
+        rec.text()
+    );
+    state.close("repo-a");
+}
+
+#[test]
+fn two_repositories_get_two_independent_sessions() {
+    let state = TerminalState::default();
+    let a = Recorder::default();
+    let b = Recorder::default();
+    let _da = open_in_tempdir(&state, &a, "repo-a");
+    let _db = open_in_tempdir(&state, &b, "repo-b");
+
+    state.write("repo-a", b"echo only-a\n").expect("write a");
+    assert!(wait_for(10, || a.text().contains("only-a")));
+
+    // Closing one must not touch the other.
+    state.close("repo-a");
+    assert!(!state.is_open("repo-a"));
+    assert!(state.is_open("repo-b"));
+
+    state.write("repo-b", b"echo still-b\n").expect("write b");
+    assert!(
+        wait_for(10, || b.text().contains("still-b")),
+        "repo-b should still be alive. saw: {}",
+        b.text()
+    );
+    assert!(
+        !a.text().contains("still-b"),
+        "sessions must not cross sinks"
+    );
+    state.close("repo-b");
+}
+
+#[test]
+fn a_shell_that_exits_reports_and_is_reaped() {
+    let state = TerminalState::default();
+    let rec = Recorder::default();
+    let _dir = open_in_tempdir(&state, &rec, "repo-x");
+
+    state.write("repo-x", b"exit 3\n").expect("write");
+
+    assert!(
+        wait_for(10, || rec.exit().is_some()),
+        "an exiting shell must produce an Exit event"
+    );
+    assert!(
+        wait_for(5, || !state.is_open("repo-x")),
+        "the session must drop itself once the shell is gone — no zombie, no \
+         leaked reader thread"
+    );
+}
+
+#[test]
+fn opening_twice_yields_one_session() {
+    let state = TerminalState::default();
+    let rec = Recorder::default();
+    let dir = open_in_tempdir(&state, &rec, "repo-a");
+
+    // A panel re-mount must not stack shells.
+    let again = state
+        .open(
+            rec.sink(),
+            "repo-a",
+            &platypusgit_lib::proc::default_shell(),
+            dir.path(),
+            24,
+            80,
+        )
+        .expect("second open is a no-op");
+
+    state.write("repo-a", b"echo once\n").expect("write");
+    assert!(wait_for(10, || rec.text().contains("once")));
+
+    // One close is enough because there is one session.
+    state.close("repo-a");
+    assert!(!state.is_open("repo-a"));
+    let _ = again;
+}
+
+#[test]
+fn closing_an_unknown_session_is_not_an_error() {
+    let state = TerminalState::default();
+    state.close("never-opened");
+    state.close("never-opened");
+    assert!(!state.is_open("never-opened"));
+}
+
+#[test]
+fn writing_to_a_closed_session_errors_rather_than_panicking() {
+    let state = TerminalState::default();
+    assert!(state.write("nope", b"x").is_err());
+    assert!(state.resize("nope", 10, 10).is_err());
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test terminal
+```
+
+Expected: FAIL to compile — `unresolved import platypusgit_lib::terminal`.
+
+- [ ] **Step 3: Implement `terminal.rs`**
+
+Create `src-tauri/src/terminal.rs`:
+
+```rust
+//! Live pty sessions for the built-in terminal (#243).
+//!
+//! Shape borrowed from `watcher.rs`: a `Default`-constructed state object is
+//! `manage`d on the Tauri app, the handlers in `commands/terminal.rs` stay
+//! thin, and all the lifetime management lives here.
+//!
+//! # Why this module knows nothing about Tauri
+//!
+//! Output leaves through an injected [`EventSink`] rather than an `AppHandle`.
+//! Two reasons, in order of importance: an integration test can supply a
+//! recording sink and assert on the exact stream the frontend would see, which
+//! an `AppHandle` makes impossible outside a running app; and the reader thread
+//! then has one dependency instead of the whole Tauri runtime.
+//!
+//! # Why there is not a single logging call in this file
+//!
+//! A terminal is where secrets get typed — a `sudo` password, a token pasted at
+//! a prompt. The property we want is that bytes read from the pty reach exactly
+//! one destination, the sink, and nothing else. That is easy to state and hard
+//! to keep by care alone, so it is kept structurally: this module logs nothing
+//! at all, `tests/terminal_privacy.rs` fails the build if it starts to, and the
+//! lifecycle logging worth having lives in `commands/terminal.rs`, which sees
+//! ids and exit codes and never a byte of traffic.
+
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::io::{Read, Write};
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use base64::Engine as _;
+
+/// What a session tells the frontend.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TermEvent {
+    /// A chunk of pty output. `data` is **base64**.
+    ///
+    /// Not a `String`: pty output is arbitrary bytes and a 4 KiB read splits a
+    /// multi-byte character at the boundary about as often as you would expect.
+    /// `from_utf8_lossy` would replace the split character with U+FFFD, so the
+    /// user would see a replacement glyph inside a filename — intermittently,
+    /// and only for non-ASCII, which is the worst kind of bug to be told about.
+    /// xterm.js decodes UTF-8 incrementally across chunks, which is the correct
+    /// place for it.
+    Data {
+        repo_id: String,
+        epoch: u64,
+        data: String,
+    },
+    /// The shell exited. `code` is `None` when it was signalled.
+    Exit {
+        repo_id: String,
+        epoch: u64,
+        code: Option<i32>,
+    },
+}
+
+/// Where a session's events go. `commands/terminal.rs` supplies one that emits
+/// on the Tauri app; tests supply one that records.
+pub type EventSink = Arc<dyn Fn(TermEvent) + Send + Sync>;
+
+struct Session {
+    master: Box<dyn portable_pty::MasterPty + Send>,
+    writer: Box<dyn Write + Send>,
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+    epoch: u64,
+}
+
+/// Every live pty, keyed by repository.
+///
+/// Keying by `RepoId` is what makes "one shell per repository tab" a property
+/// of the data structure rather than a rule the frontend has to remember.
+#[derive(Default)]
+pub struct TerminalState {
+    sessions: Mutex<HashMap<String, Session>>,
+    next_epoch: AtomicU64,
+}
+
+impl TerminalState {
+    /// Start a shell for `repo_id`, or return the existing session's epoch.
+    ///
+    /// Idempotent on purpose: a panel re-mount, a fast double toggle and a tab
+    /// re-activation all reach here, and none of them should stack a shell.
+    pub fn open(
+        &self,
+        sink: EventSink,
+        repo_id: &str,
+        shell: &OsStr,
+        workdir: &Path,
+        rows: u16,
+        cols: u16,
+    ) -> std::io::Result<u64> {
+        let mut sessions = self.sessions.lock().expect("terminal sessions lock");
+        if let Some(existing) = sessions.get(repo_id) {
+            return Ok(existing.epoch);
+        }
+
+        let session = crate::proc::spawn_pty_shell(shell, workdir, rows, cols)?;
+        let epoch = self.next_epoch.fetch_add(1, Ordering::Relaxed);
+
+        let reader = session.master.try_clone_reader()?;
+        let writer = session.master.take_writer()?;
+
+        spawn_reader(sink, repo_id.to_string(), epoch, reader);
+
+        sessions.insert(
+            repo_id.to_string(),
+            Session {
+                master: session.master,
+                writer,
+                child: session.child,
+                epoch,
+            },
+        );
+        Ok(epoch)
+    }
+
+    pub fn write(&self, repo_id: &str, data: &[u8]) -> std::io::Result<()> {
+        let mut sessions = self.sessions.lock().expect("terminal sessions lock");
+        let session = sessions
+            .get_mut(repo_id)
+            .ok_or_else(|| std::io::Error::other("no terminal session for this repository"))?;
+        session.writer.write_all(data)?;
+        session.writer.flush()
+    }
+
+    pub fn resize(&self, repo_id: &str, rows: u16, cols: u16) -> std::io::Result<()> {
+        let sessions = self.sessions.lock().expect("terminal sessions lock");
+        let session = sessions
+            .get(repo_id)
+            .ok_or_else(|| std::io::Error::other("no terminal session for this repository"))?;
+        session
+            .master
+            .resize(portable_pty::PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|e| std::io::Error::other(format!("could not resize the pty: {e}")))
+    }
+
+    /// Kill the shell and forget the session. Idempotent — killing a child that
+    /// has already exited is not an error, and neither is closing nothing.
+    pub fn close(&self, repo_id: &str) {
+        let session = self
+            .sessions
+            .lock()
+            .expect("terminal sessions lock")
+            .remove(repo_id);
+        if let Some(mut session) = session {
+            let _ = session.child.kill();
+            // Reap, so the exiting shell does not become a zombie. The reader
+            // thread ends on its own when the master's last reader sees EOF.
+            let _ = session.child.wait();
+        }
+    }
+
+    pub fn is_open(&self, repo_id: &str) -> bool {
+        self.sessions
+            .lock()
+            .expect("terminal sessions lock")
+            .contains_key(repo_id)
+    }
+
+    /// Close everything. Called on app exit so no child outlives the window.
+    pub fn close_all(&self) {
+        let ids: Vec<String> = self
+            .sessions
+            .lock()
+            .expect("terminal sessions lock")
+            .keys()
+            .cloned()
+            .collect();
+        for id in ids {
+            self.close(&id);
+        }
+    }
+
+    /// Drop the session `epoch` belongs to, if it is still the current one.
+    ///
+    /// The epoch check is the fence: a reader that reaches EOF just after the
+    /// user closed and reopened the terminal would otherwise remove the NEW
+    /// session, killing a shell the user is looking at.
+    fn retire(&self, repo_id: &str, epoch: u64) -> Option<Option<i32>> {
+        let mut sessions = self.sessions.lock().expect("terminal sessions lock");
+        match sessions.get(repo_id) {
+            Some(s) if s.epoch == epoch => {}
+            _ => return None,
+        }
+        let mut session = sessions.remove(repo_id)?;
+        drop(sessions);
+        let code = session.child.wait().ok().map(|s| s.exit_code() as i32);
+        Some(code)
+    }
+}
+
+impl Drop for TerminalState {
+    fn drop(&mut self) {
+        // Belt and braces next to the explicit close_all on window destroy: a
+        // panic elsewhere must not leave a shell running with no window.
+        let ids: Vec<String> = self
+            .sessions
+            .lock()
+            .map(|s| s.keys().cloned().collect())
+            .unwrap_or_default();
+        for id in ids {
+            self.close(&id);
+        }
+    }
+}
+
+/// One blocking reader thread per session.
+///
+/// A free function rather than a method so it cannot accidentally capture the
+/// state's mutex: it holds only the sink, and the `Arc<TerminalState>` it needs
+/// for retirement is passed in by the caller in `commands/terminal.rs`. Reading
+/// under the sessions lock would serialise every terminal in the app behind the
+/// slowest one and deadlock the first `write` during a read.
+fn spawn_reader(sink: EventSink, repo_id: String, epoch: u64, mut reader: Box<dyn Read + Send>) {
+    std::thread::Builder::new()
+        .name(format!("pty-reader-{epoch}"))
+        .spawn(move || {
+            let mut buf = [0u8; 8192];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        sink(TermEvent::Data {
+                            repo_id: repo_id.clone(),
+                            epoch,
+                            data: base64::engine::general_purpose::STANDARD.encode(&buf[..n]),
+                        });
+                    }
+                }
+            }
+            sink(TermEvent::Exit {
+                repo_id,
+                epoch,
+                code: None,
+            });
+        })
+        .expect("spawn a pty reader thread");
+}
+```
+
+Then in `src-tauri/src/lib.rs`, add `pub mod terminal;` to the module list (alphabetical, between `state` and `update`).
+
+- [ ] **Step 4: Reconcile the exit code**
+
+The reader emits `Exit { code: None }` because it does not own the child. `TerminalState::retire` is what learns the real code. Wire them: in `commands/terminal.rs` (Task 3) the sink closure intercepts `TermEvent::Exit`, calls `state.retire(&repo_id, epoch)` and re-emits with the real code. Leave `retire` `pub(crate)` for now and let Task 3 finish the loop; the test `a_shell_that_exits_reports_and_is_reaped` asserts only that *an* Exit arrives and the session is gone, so make the sink in the test drive retirement too:
+
+In the test file's `Recorder::sink`, after pushing, nothing else is needed — but `a_shell_that_exits_reports_and_is_reaped` asserts `!state.is_open(...)`. So the reader must retire the session itself. Change `spawn_reader` to take an `Arc<TerminalState>` and do it:
+
+```rust
+fn spawn_reader(
+    state: Arc<TerminalState>,
+    sink: EventSink,
+    repo_id: String,
+    epoch: u64,
+    mut reader: Box<dyn Read + Send>,
+) {
+    std::thread::Builder::new()
+        .name(format!("pty-reader-{epoch}"))
+        .spawn(move || {
+            let mut buf = [0u8; 8192];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => sink(TermEvent::Data {
+                        repo_id: repo_id.clone(),
+                        epoch,
+                        data: base64::engine::general_purpose::STANDARD.encode(&buf[..n]),
+                    }),
+                }
+            }
+            // EOF means the shell is gone. Retire under the epoch fence, then
+            // report — in that order, so `is_open` is already false by the time
+            // the frontend reacts to the exit.
+            let code = state.retire(&repo_id, epoch).flatten();
+            sink(TermEvent::Exit { repo_id, epoch, code });
+        })
+        .expect("spawn a pty reader thread");
+}
+```
+
+This makes `TerminalState` need to be behind an `Arc`. Change `open` to an associated function taking `self: &Arc<Self>`:
+
+```rust
+pub fn open(
+    self: &Arc<Self>,
+    sink: EventSink,
+    repo_id: &str,
+    /* … */
+) -> std::io::Result<u64> {
+    /* … */
+    spawn_reader(Arc::clone(self), sink, repo_id.to_string(), epoch, reader);
+    /* … */
+}
+```
+
+and make the tests construct `Arc<TerminalState>`:
+
+```rust
+let state = Arc::new(TerminalState::default());
+```
+
+Update every `TerminalState::default()` in the tests to `Arc::new(TerminalState::default())`. Tauri's `manage` stores the value itself, so `commands/terminal.rs` manages `Arc<TerminalState>` and reads it with `State<'_, Arc<TerminalState>>`.
+
+Drop the `impl Drop for TerminalState` — with the state behind an `Arc` held by a reader thread, `Drop` runs at an unpredictable time. Task 3 calls `close_all()` explicitly on window destroy instead, which is the deterministic point.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test terminal
+```
+
+Expected: 8 passed. If `a_shell_that_exits_reports_and_is_reaped` is flaky, raise only its `wait_for` budget — never add a fixed `sleep`.
+
+- [ ] **Step 6: Write the privacy guard**
+
+Create `src-tauri/tests/terminal_privacy.rs`:
+
+```rust
+//! The terminal never logs its traffic (#243).
+//!
+//! A terminal is where secrets get typed: a `sudo` password, a token pasted at
+//! a prompt, a passphrase. The property we want is that bytes read from the pty
+//! reach exactly one destination — the event sink — and bytes written to it
+//! reach exactly one destination, the pty.
+//!
+//! Stated that way it is a property about what the source may CONTAIN, so it is
+//! a test over the source text, in the same shape as `spawn_no_window.rs` and
+//! `test/docs.test.ts`. The alternative — keeping it by care — is how these
+//! things get lost in the third refactor.
+//!
+//! The rule is deliberately blunt: `src/terminal.rs` contains no logging macro
+//! AT ALL. That is enforceable in four lines, whereas "no logging macro that
+//! mentions the buffer" is a judgement call a grep cannot make. It costs
+//! nothing, because the lifecycle events worth logging (opened, exited, closed)
+//! are logged from `commands/terminal.rs`, which handles ids and exit codes and
+//! never sees a byte of traffic.
+
+use std::path::Path;
+
+fn read(rel: &str) -> String {
+    let p = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+}
+
+fn is_comment(line: &str) -> bool {
+    let t = line.trim_start();
+    t.starts_with("//") || t.starts_with("/*") || t.starts_with('*')
+}
+
+fn code_lines(body: &str) -> impl Iterator<Item = &str> {
+    body.lines().filter(|l| !is_comment(l))
+}
+
+#[test]
+fn the_session_registry_logs_nothing() {
+    const LOGGERS: [&str; 6] = [
+        "log::", "tracing::", "println!", "eprintln!", "dbg!", "info!",
+    ];
+    let body = read("src/terminal.rs");
+    for logger in LOGGERS {
+        let hits: Vec<&str> = code_lines(&body).filter(|l| l.contains(logger)).collect();
+        assert!(
+            hits.is_empty(),
+            "src/terminal.rs uses `{logger}`, and this module handles pty \
+             traffic — a password typed at a sudo prompt goes through it. \
+             Lifecycle logging belongs in commands/terminal.rs, which never \
+             sees a byte. Offending line(s): {hits:?}"
+        );
+    }
+}
+
+#[test]
+fn the_traffic_never_reaches_a_file_or_a_child_process() {
+    const EXFIL: [&str; 5] = [
+        "File::create",
+        "OpenOptions",
+        "write_all(&buf",
+        "Command",
+        "reqwest",
+    ];
+    let body = read("src/terminal.rs");
+    for needle in EXFIL {
+        assert!(
+            !code_lines(&body).any(|l| l.contains(needle)),
+            "src/terminal.rs mentions `{needle}`; pty traffic has exactly one \
+             destination and it is the event sink"
+        );
+    }
+}
+
+#[test]
+fn the_handlers_do_not_log_what_the_user_typed() {
+    // `term_write`'s payload travels toward the shell — a sudo password goes
+    // this way. The handler may log THAT a write happened, never its content.
+    let body = read("src/commands/terminal.rs");
+    for line in code_lines(&body).filter(|l| {
+        l.contains("log::") || l.contains("println!") || l.contains("tracing::")
+    }) {
+        assert!(
+            !line.contains("data"),
+            "a log line in commands/terminal.rs mentions `data`, which is what \
+             the user typed: {line}"
+        );
+    }
+}
+```
+
+- [ ] **Step 7: Run it**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test terminal_privacy
+```
+
+Expected: the first two pass; `the_handlers_do_not_log_what_the_user_typed` FAILS because `src/commands/terminal.rs` does not exist yet. That is correct — Task 3 creates it. To keep the suite green between tasks, guard that one test with an early return:
+
+```rust
+    let p = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/commands/terminal.rs");
+    if !p.exists() {
+        return; // Task 3 creates it; the other two guards already have teeth.
+    }
+```
+
+Remove the early return at the end of Task 3 once the file exists.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src-tauri/src/terminal.rs src-tauri/src/lib.rs src-tauri/tests/terminal.rs src-tauri/tests/terminal_privacy.rs
+git commit -m "feat(terminal): pty session registry, one shell per repository (#243)
+
+Why: sessions keyed by RepoId make \"one shell per repo tab\" a property
+of the data structure, not a rule the frontend must remember. Output
+leaves through an injected sink rather than an AppHandle so the stream
+the frontend sees is testable, and so the module can log nothing at all
+— a terminal is where passwords get typed.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Commands, the error variant, and the TS bridge
+
+**Files:**
+- Create: `src-tauri/src/commands/terminal.rs`
+- Modify: `src-tauri/src/commands/mod.rs`
+- Modify: `src-tauri/src/error.rs` (after `LfsUnavailable`)
+- Modify: `src-tauri/src/lib.rs` (`manage` + `invoke_handler!` + window-destroy hook)
+- Modify: `src/lib/types.ts`, `src/lib/tauri.ts`, `src/lib/errors.ts`
+- Modify: `src-tauri/tests/terminal_privacy.rs` (drop the early return)
+- Test: `test/appErrors.test.ts` (existing — it gates this)
+
+**Interfaces:**
+- Consumes: `TerminalState` from Task 2.
+- Produces:
+  - Rust: `AppError::TerminalUnavailable(String)`; commands `term_open`, `term_write`, `term_resize`, `term_close`.
+  - TS: `termOpen(repoId, rows, cols): Promise<number>`, `termWrite(repoId, data): Promise<void>`, `termResize(repoId, rows, cols): Promise<void>`, `termClose(repoId): Promise<void>`; types `TermData { repoId, epoch, data }`, `TermExit { repoId, epoch, code }`.
+
+- [ ] **Step 1: Add the error variant**
+
+In `src-tauri/src/error.rs`, after the `LfsUnavailable` variant:
+
+```rust
+    /// The shell the built-in terminal tried to run is missing or not runnable
+    /// (#243). A **state**, not a failure — the same shape `LfsUnavailable` and
+    /// `SshKeygenUnavailable` use: the panel disables itself and says which
+    /// shell it tried, because the remedy is one field in Settings. `Io` would
+    /// put "No such file or directory" in a banner without naming the file.
+    #[error("no usable shell: {0}")]
+    TerminalUnavailable(String),
+```
+
+- [ ] **Step 2: Mirror it in TypeScript**
+
+In `src/lib/errors.ts`, add to the `AppError` union (next to `SshKeygenUnavailable`):
+
+```ts
+  /**
+   * The shell the built-in terminal tried to run is missing or not runnable
+   * (#243). A state the panel disables on, in the shape `LfsUnavailable`
+   * already uses — the message names the shell, `appErrorDetail` names the
+   * remedy.
+   */
+  | { kind: "TerminalUnavailable"; message: string }
+```
+
+And in `appErrorDetail`, a case:
+
+```ts
+    case "TerminalUnavailable":
+      return (
+        `Could not start ${typeof message === "string" && message ? message : "a shell"}. ` +
+        "Set a shell in Settings ▸ Terminal, or leave it blank to use $SHELL."
+      );
+```
+
+Match the surrounding cases' exact style — read three neighbours before writing this.
+
+- [ ] **Step 3: Run the error gate to verify both halves are in step**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- appErrors
+```
+
+Expected: PASS. If it fails saying the union and the enum have drifted, one of the two edits above is missing or misspelled.
+
+- [ ] **Step 4: Write the handlers**
+
+Create `src-tauri/src/commands/terminal.rs`:
+
+```rust
+//! The built-in terminal's four handlers (#243).
+//!
+//! Thin, in the shape of `commands/watch.rs`: `crate::terminal::TerminalState`
+//! owns every live pty and all of the lifetime management; this file resolves
+//! the workdir, picks the shell, supplies the event sink, and logs the
+//! lifecycle.
+//!
+//! The logging lives HERE and not in `terminal.rs` on purpose. This file sees
+//! repository ids, sizes and exit codes; `terminal.rs` sees the bytes. A
+//! terminal is where passwords get typed, so the module that handles traffic
+//! logs nothing at all and `tests/terminal_privacy.rs` fails the build if that
+//! stops being true.
+
+use std::sync::Arc;
+
+use tauri::{AppHandle, Emitter, State};
+
+use crate::{
+    error::{AppError, AppResult},
+    git::types::RepoId,
+    state::AppState,
+    terminal::{TermEvent, TerminalState},
+};
+
+/// The event a `TermEvent::Data` is delivered on.
+pub const TERM_DATA_EVENT: &str = "term://data";
+/// The event a `TermEvent::Exit` is delivered on.
+pub const TERM_EXIT_EVENT: &str = "term://exit";
+
+/// Start a shell for `repo_id`, or adopt the one already running.
+///
+/// The workdir is resolved through the backend rather than taken from the
+/// frontend: a path argument would be a second source of truth for where a
+/// repository lives, and this one is about to become a shell's cwd.
+#[tauri::command]
+pub async fn term_open(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    terminals: State<'_, Arc<TerminalState>>,
+    repo_id: String,
+    rows: u16,
+    cols: u16,
+    shell: Option<String>,
+) -> AppResult<u64> {
+    let backend = state.backend.clone();
+    let id = RepoId(repo_id.clone());
+    let workdir = tokio::task::spawn_blocking(move || backend.repo_path(&id))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))??;
+
+    // A blank setting means "use the default" — the Settings field is a text
+    // box, and an empty text box is not a shell named "".
+    let shell = shell
+        .filter(|s| !s.trim().is_empty())
+        .map(std::ffi::OsString::from)
+        .unwrap_or_else(crate::proc::default_shell);
+
+    let sink = {
+        let app = app.clone();
+        Arc::new(move |ev: TermEvent| {
+            let name = match &ev {
+                TermEvent::Data { .. } => TERM_DATA_EVENT,
+                TermEvent::Exit { .. } => TERM_EXIT_EVENT,
+            };
+            // Nothing is logged here: `ev` carries traffic.
+            let _ = app.emit(name, ev);
+        })
+    };
+
+    let terminals = terminals.inner().clone();
+    let shell_name = shell.to_string_lossy().to_string();
+    let epoch = terminals
+        .open(sink, &repo_id, &shell, &workdir, rows, cols)
+        .map_err(|e| AppError::TerminalUnavailable(format!("{shell_name}: {e}")))?;
+
+    log::info!("terminal: session {epoch} open for {repo_id} ({shell_name})");
+    Ok(epoch)
+}
+
+/// Send input to the shell. `data` is what the user typed — never logged.
+#[tauri::command]
+pub async fn term_write(
+    terminals: State<'_, Arc<TerminalState>>,
+    repo_id: String,
+    data: String,
+) -> AppResult<()> {
+    terminals
+        .write(&repo_id, data.as_bytes())
+        .map_err(|e| AppError::Io(e.to_string()))
+}
+
+#[tauri::command]
+pub async fn term_resize(
+    terminals: State<'_, Arc<TerminalState>>,
+    repo_id: String,
+    rows: u16,
+    cols: u16,
+) -> AppResult<()> {
+    terminals
+        .resize(&repo_id, rows, cols)
+        .map_err(|e| AppError::Io(e.to_string()))
+}
+
+/// Kill this repository's shell. Idempotent.
+#[tauri::command]
+pub async fn term_close(
+    terminals: State<'_, Arc<TerminalState>>,
+    repo_id: String,
+) -> AppResult<()> {
+    terminals.close(&repo_id);
+    log::info!("terminal: session closed for {repo_id}");
+    Ok(())
+}
+```
+
+Add `pub mod terminal;` to `src-tauri/src/commands/mod.rs` (alphabetical).
+
+- [ ] **Step 5: Register**
+
+In `src-tauri/src/lib.rs`:
+
+1. Next to `.manage(watcher::WatchState::default())`:
+
+```rust
+        .manage(std::sync::Arc::new(terminal::TerminalState::default()))
+```
+
+2. In `tauri::generate_handler![…]`, after the `commands::watch::*` entries:
+
+```rust
+            commands::terminal::term_open,
+            commands::terminal::term_write,
+            commands::terminal::term_resize,
+            commands::terminal::term_close,
+```
+
+3. Kill every shell when the window goes away. Find the existing `.on_window_event` / `RunEvent` handling (`grep -n 'on_window_event\|RunEvent' src-tauri/src/lib.rs`) and add a `Destroyed`/`ExitRequested` arm:
+
+```rust
+        // A shell must not outlive the window that hosts it. `close_all` is
+        // called explicitly here rather than left to a Drop: the state is
+        // behind an Arc held by every reader thread, so its Drop runs at a time
+        // nobody controls.
+        if let Some(terminals) = app.try_state::<std::sync::Arc<terminal::TerminalState>>() {
+            terminals.close_all();
+        }
+```
+
+Adapt to whatever shape the existing handler has — if there is none, add
+`.on_window_event(|window, event| { if matches!(event, tauri::WindowEvent::Destroyed) { … } })`
+using `window.app_handle()`.
+
+- [ ] **Step 6: Compile and run the Rust suite**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo check --manifest-path src-tauri/Cargo.toml --all-targets
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+Expected: clean check, all tests pass.
+
+- [ ] **Step 7: Remove the privacy guard's early return**
+
+In `src-tauri/tests/terminal_privacy.rs`, delete the `if !p.exists() { return; }` block added in Task 2 Step 7 and use `read("src/commands/terminal.rs")` directly. Re-run:
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path src-tauri/Cargo.toml --test terminal_privacy
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 8: The TypeScript bridge**
+
+In `src/lib/types.ts`:
+
+```ts
+/**
+ * A chunk of terminal output (#243). `data` is base64 — pty output is
+ * arbitrary bytes and a read can split a multi-byte character, which a string
+ * payload would turn into U+FFFD.
+ */
+export interface TermData {
+  repoId: string;
+  epoch: number;
+  data: string;
+}
+
+/** The shell exited. `code` is null when it was signalled. */
+export interface TermExit {
+  repoId: string;
+  epoch: number;
+  code: number | null;
+}
+```
+
+In `src/lib/tauri.ts`, next to the `watchRepo`/`watchStop` pair:
+
+```ts
+/**
+ * Start a shell for this repository, or adopt the one already running (#243).
+ * Returns the session's epoch — every `term://data` event carries one, and a
+ * view must drop the events that are not its own or a re-opened terminal shows
+ * the dead shell's last line.
+ *
+ * `shell` blank or omitted means the backend's default ($SHELL, then /bin/sh).
+ */
+export function termOpen(
+  repoId: string,
+  rows: number,
+  cols: number,
+  shell?: string,
+): Promise<number> {
+  return invoke<number>("term_open", { repoId, rows, cols, shell: shell ?? null });
+}
+
+/** Send input to the shell. This is what the user typed — never log it. */
+export function termWrite(repoId: string, data: string): Promise<void> {
+  return invoke<void>("term_write", { repoId, data });
+}
+
+export function termResize(repoId: string, rows: number, cols: number): Promise<void> {
+  return invoke<void>("term_resize", { repoId, rows, cols });
+}
+
+/** Kill this repository's shell. Idempotent. */
+export function termClose(repoId: string): Promise<void> {
+  return invoke<void>("term_close", { repoId });
+}
+```
+
+- [ ] **Step 9: Type-check and commit**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm tsc --noEmit
+pnpm test -- appErrors
+git add src-tauri/src/commands/terminal.rs src-tauri/src/commands/mod.rs src-tauri/src/error.rs src-tauri/src/lib.rs src-tauri/tests/terminal_privacy.rs src/lib/types.ts src/lib/tauri.ts src/lib/errors.ts
+git commit -m "feat(terminal): four commands and the TerminalUnavailable state (#243)
+
+Why: a missing shell is a state, not a failure — the shape
+LfsUnavailable already uses. The panel says which shell it tried,
+because the remedy is one field in Settings.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: The Settings field
+
+**Files:**
+- Modify: `src/features/settings/useSettingsStore.ts`
+- Modify: `src/screens/Settings.tsx`
+- Test: `src/screens/Settings.terminal.test.tsx` (create)
+
+**Interfaces:**
+- Produces: `useSettingsStore` field `terminalShell: string` (default `""`) and setter `setTerminalShell(v: string)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/screens/Settings.terminal.test.tsx`. Model it on the existing `Settings.difftool.test.tsx` — read that file first and copy its render harness and mocks exactly; it is the closest sibling (a text field in Settings that names an external program).
+
+```tsx
+import { describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { SettingsScreen } from "./Settings";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+
+describe("Settings ▸ Terminal", () => {
+  it("defaults to blank, meaning the backend picks the shell", () => {
+    expect(useSettingsStore.getState().terminalShell).toBe("");
+  });
+
+  it("stores the shell the user names", async () => {
+    render(<SettingsScreen />);
+    const field = await screen.findByLabelText(/shell/i);
+    await userEvent.clear(field);
+    await userEvent.type(field, "/opt/homebrew/bin/fish");
+    await waitFor(() =>
+      expect(useSettingsStore.getState().terminalShell).toBe(
+        "/opt/homebrew/bin/fish",
+      ),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- Settings.terminal
+```
+
+Expected: FAIL — `terminalShell` is undefined.
+
+- [ ] **Step 3: Add the field**
+
+In `src/features/settings/useSettingsStore.ts`, next to `watchFilesystem` in the interface:
+
+```ts
+  /**
+   * The shell the built-in terminal runs (#243). Blank means the backend
+   * decides: `$SHELL` then `/bin/sh` on unix, PowerShell on Windows.
+   *
+   * A free text field rather than a picker of installed shells: enumerating
+   * them would mean probing the filesystem for a list that is never complete,
+   * and the people who want `nu` know where it lives.
+   */
+  terminalShell: string;
+```
+
+In the defaults object (near `watchFilesystem: true`): `terminalShell: "",`.
+
+Add the setter following the file's existing setter convention — read two neighbouring setters and match them exactly, including whether they persist.
+
+- [ ] **Step 4: Render it**
+
+In `src/screens/Settings.tsx`, add a **Terminal** section after the section that holds `watchFilesystem`. Match the surrounding section markup exactly (heading component, description paragraph, field wrapper). The field is a plain labelled text input with placeholder `$SHELL` and helper text:
+
+> Leave blank to use `$SHELL`. The terminal opens in the active repository's working directory.
+
+- [ ] **Step 5: Run the test**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- Settings.terminal
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/settings/useSettingsStore.ts src/screens/Settings.tsx src/screens/Settings.terminal.test.tsx
+git commit -m "feat(terminal): a Settings field for the shell to run (#243)
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: The store, the view and the panel
+
+**Files:**
+- Create: `src/features/terminal/{useTerminalStore.ts,TerminalView.tsx,TerminalPanel.tsx,shellLabel.ts,index.ts}`
+- Create: `src/features/terminal/{useTerminalStore.test.ts,TerminalView.test.tsx,shellLabel.test.ts}`
+- Modify: `package.json`
+
+**Interfaces:**
+- Consumes: `termOpen/termWrite/termResize/termClose` (Task 3), `useElementSize` from `@/lib/useElementSize`, `PGResizeHandle`/`usePaneSize` from `@/design`.
+- Produces:
+  - `useTerminalStore` — `{ open: boolean, heightPx: number, epochs: Record<string, number>, toggle(), setOpen(b), setHeight(px), noteEpoch(repoId, epoch), forget(repoId) }`
+  - `<TerminalPanel />` — self-contained, reads the active repo itself.
+  - `<TerminalView repoId={string} />`
+  - `shellLabel(path: string): string`
+
+- [ ] **Step 1: Install xterm**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm add @xterm/xterm
+```
+
+Pin it the way the other deps are pinned — check whether `package.json` uses `^` for runtime deps (it does for most) and match.
+
+- [ ] **Step 2: Write the pure tests first**
+
+`src/features/terminal/shellLabel.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { shellLabel } from "./shellLabel";
+
+describe("shellLabel", () => {
+  it("is the basename of a path", () => {
+    expect(shellLabel("/opt/homebrew/bin/fish")).toBe("fish");
+    expect(shellLabel("/bin/zsh")).toBe("zsh");
+  });
+
+  it("handles a Windows path", () => {
+    expect(shellLabel("C:\\Program Files\\PowerShell\\7\\pwsh.exe")).toBe("pwsh.exe");
+  });
+
+  it("says what blank means rather than showing nothing", () => {
+    expect(shellLabel("")).toBe("default shell");
+  });
+});
+```
+
+`src/features/terminal/useTerminalStore.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it } from "vitest";
+import { useTerminalStore } from "./useTerminalStore";
+
+const reset = () =>
+  useTerminalStore.setState({ open: false, heightPx: 240, epochs: {} });
+
+describe("useTerminalStore", () => {
+  beforeEach(reset);
+
+  it("starts closed — a terminal nobody asked for should not spawn a shell", () => {
+    expect(useTerminalStore.getState().open).toBe(false);
+  });
+
+  it("toggles", () => {
+    useTerminalStore.getState().toggle();
+    expect(useTerminalStore.getState().open).toBe(true);
+    useTerminalStore.getState().toggle();
+    expect(useTerminalStore.getState().open).toBe(false);
+  });
+
+  it("clamps the height to something a terminal can render in", () => {
+    useTerminalStore.getState().setHeight(10);
+    expect(useTerminalStore.getState().heightPx).toBeGreaterThanOrEqual(80);
+    useTerminalStore.getState().setHeight(100_000);
+    expect(useTerminalStore.getState().heightPx).toBeLessThanOrEqual(2000);
+  });
+
+  it("tracks an epoch per repository, not one for the app", () => {
+    useTerminalStore.getState().noteEpoch("a", 1);
+    useTerminalStore.getState().noteEpoch("b", 2);
+    expect(useTerminalStore.getState().epochs).toEqual({ a: 1, b: 2 });
+  });
+
+  it("forgets one repository without disturbing the others", () => {
+    useTerminalStore.getState().noteEpoch("a", 1);
+    useTerminalStore.getState().noteEpoch("b", 2);
+    useTerminalStore.getState().forget("a");
+    expect(useTerminalStore.getState().epochs).toEqual({ b: 2 });
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify they fail**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- features/terminal
+```
+
+Expected: FAIL — modules not found.
+
+- [ ] **Step 4: Implement `shellLabel.ts` and `useTerminalStore.ts`**
+
+```ts
+// shellLabel.ts
+/** The name to show for a configured shell path. Blank means "the default". */
+export function shellLabel(shell: string): string {
+  if (!shell.trim()) return "default shell";
+  const parts = shell.split(/[/\\]/).filter(Boolean);
+  return parts[parts.length - 1] ?? shell;
+}
+```
+
+```ts
+// useTerminalStore.ts
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+/** Below this the terminal cannot show a prompt and a line of output. */
+const MIN_HEIGHT = 80;
+/** Above this the panel has eaten the app; the drag handle stops here. */
+const MAX_HEIGHT = 2000;
+
+export const clampHeight = (px: number) =>
+  Math.max(MIN_HEIGHT, Math.min(MAX_HEIGHT, Math.round(px)));
+
+interface TerminalState {
+  /** Whether the panel is showing. Closed by default: a terminal nobody asked
+   *  for should not spawn a shell for every repository they open. */
+  open: boolean;
+  heightPx: number;
+  /**
+   * The live session epoch per repository.
+   *
+   * Per-repo state lives HERE and not in `useRepoStore`. `RepoSlice` holds
+   * exactly one repository's state and is cleared on every tab switch — which
+   * is right for a diff and catastrophic for a session handle, because it would
+   * orphan the shells of every inactive tab. This is the shape `useTabsStore`
+   * has: all open repositories at once.
+   */
+  epochs: Record<string, number>;
+  toggle: () => void;
+  setOpen: (open: boolean) => void;
+  setHeight: (px: number) => void;
+  noteEpoch: (repoId: string, epoch: number) => void;
+  forget: (repoId: string) => void;
+}
+
+export const useTerminalStore = create<TerminalState>()(
+  persist(
+    (set) => ({
+      open: false,
+      heightPx: 240,
+      epochs: {},
+      toggle: () => set((s) => ({ open: !s.open })),
+      setOpen: (open) => set({ open }),
+      setHeight: (px) => set({ heightPx: clampHeight(px) }),
+      noteEpoch: (repoId, epoch) =>
+        set((s) => ({ epochs: { ...s.epochs, [repoId]: epoch } })),
+      forget: (repoId) =>
+        set((s) => {
+          const next = { ...s.epochs };
+          delete next[repoId];
+          return { epochs: next };
+        }),
+    }),
+    {
+      name: "pg.terminal",
+      // Sessions do not survive a reload — the shells are gone with the
+      // process — so only the UI preference is persisted.
+      partialize: (s) => ({ open: s.open, heightPx: s.heightPx }),
+    },
+  ),
+);
+```
+
+Check how the other stores persist (`grep -n 'persist(' src/features/*/use*.ts | head`) and match the convention; if the codebase persists through its own helper rather than zustand's `persist`, use that instead.
+
+- [ ] **Step 5: Run the pure tests**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- features/terminal
+```
+
+Expected: `shellLabel` and `useTerminalStore` pass.
+
+- [ ] **Step 6: Write the view test**
+
+`src/features/terminal/TerminalView.test.tsx`:
+
+```tsx
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+
+const onDataHandlers: Array<(s: string) => void> = [];
+const write = vi.fn();
+const dispose = vi.fn();
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class {
+    cols = 80;
+    rows = 24;
+    element: HTMLElement | null = null;
+    open(el: HTMLElement) {
+      this.element = el;
+    }
+    onData(cb: (s: string) => void) {
+      onDataHandlers.push(cb);
+      return { dispose: vi.fn() };
+    }
+    write = write;
+    resize = vi.fn();
+    focus = vi.fn();
+    dispose = dispose;
+    loadAddon = vi.fn();
+  },
+}));
+
+const termOpen = vi.fn().mockResolvedValue(7);
+const termWrite = vi.fn().mockResolvedValue(undefined);
+const termResize = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/tauri", async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  termOpen: (...a: unknown[]) => termOpen(...a),
+  termWrite: (...a: unknown[]) => termWrite(...a),
+  termResize: (...a: unknown[]) => termResize(...a),
+  termClose: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { TerminalView } from "./TerminalView";
+
+describe("TerminalView", () => {
+  beforeEach(() => {
+    onDataHandlers.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it("opens a session for its repository", async () => {
+    render(<TerminalView repoId="repo-a" />);
+    await waitFor(() => expect(termOpen).toHaveBeenCalled());
+    expect(termOpen.mock.calls[0][0]).toBe("repo-a");
+  });
+
+  it("forwards what the user types to the pty", async () => {
+    render(<TerminalView repoId="repo-a" />);
+    await waitFor(() => expect(onDataHandlers.length).toBeGreaterThan(0));
+    onDataHandlers[0]("ls\r");
+    await waitFor(() => expect(termWrite).toHaveBeenCalledWith("repo-a", "ls\r"));
+  });
+
+  it("tears its listeners down on unmount", async () => {
+    const { unmount } = render(<TerminalView repoId="repo-a" />);
+    await waitFor(() => expect(termOpen).toHaveBeenCalled());
+    unmount();
+    await waitFor(() => expect(dispose).toHaveBeenCalled());
+  });
+});
+```
+
+Read `src/test/setup.ts` first — it already mocks `@tauri-apps/api/event`. If `listen` is mocked there, use that mock to push a `term://data` event and add a fourth test asserting `write` is called with the decoded bytes. If it is not, skip that assertion rather than inventing a second mocking strategy.
+
+- [ ] **Step 7: Implement `TerminalView.tsx`**
+
+```tsx
+import { listen } from "@tauri-apps/api/event";
+import React from "react";
+import { Terminal } from "@xterm/xterm";
+import "@xterm/xterm/css/xterm.css";
+
+import { termOpen, termResize, termWrite } from "@/lib/tauri";
+import type { TermData, TermExit } from "@/lib/types";
+import { useElementSize } from "@/lib/useElementSize";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { useTerminalStore } from "./useTerminalStore";
+
+/** Approximate cell size for the mono font at the current size. Used only to
+ *  turn a measured pixel box into rows/cols; xterm corrects itself on render. */
+const CELL_W = 8;
+const CELL_H = 17;
+
+/** Build xterm's theme from the design tokens, so the terminal is the same
+ *  colour scheme as the app and the accent hue is never hardcoded. */
+function themeFromCss(): Record<string, string> {
+  const css = getComputedStyle(document.documentElement);
+  const v = (name: string, fallback: string) =>
+    css.getPropertyValue(name).trim() || fallback;
+  return {
+    background: v("--bg-0", "#101013"),
+    foreground: v("--fg-0", "#e6e6e6"),
+    cursor: v("--accent", "#7aa2f7"),
+    selectionBackground: v("--selection", "#2d3f63"),
+  };
+}
+
+/**
+ * One xterm instance for one repository.
+ *
+ * Keyed by `repoId` at the call site, so switching tabs mounts a different
+ * instance rather than re-pointing this one — a re-pointed terminal would show
+ * the previous repository's scrollback under the new repository's prompt.
+ */
+export function TerminalView({ repoId }: { repoId: string }) {
+  const { ref, width, height } = useElementSize();
+  const shell = useSettingsStore((s) => s.terminalShell);
+  const noteEpoch = useTerminalStore((s) => s.noteEpoch);
+
+  const hostRef = React.useRef<HTMLDivElement | null>(null);
+  const termRef = React.useRef<Terminal | null>(null);
+  const epochRef = React.useRef<number | null>(null);
+
+  // Mount the terminal and open the session. Runs once per repoId.
+  React.useEffect(() => {
+    const term = new Terminal({
+      fontFamily: "var(--font-mono), monospace",
+      fontSize: 12,
+      theme: themeFromCss(),
+      // A terminal that cannot scroll back is a terminal that loses your build
+      // output the moment it finishes.
+      scrollback: 5000,
+      allowProposedApi: false,
+    });
+    termRef.current = term;
+    if (hostRef.current) term.open(hostRef.current);
+
+    const typed = term.onData((data) => {
+      void termWrite(repoId, data).catch(() => {
+        /* the session is gone; the exit listener reports it */
+      });
+    });
+
+    let disposed = false;
+    const unlisteners: Array<() => void> = [];
+
+    void (async () => {
+      const epoch = await termOpen(repoId, term.rows, term.cols, shell);
+      if (disposed) return;
+      epochRef.current = epoch;
+      noteEpoch(repoId, epoch);
+
+      unlisteners.push(
+        await listen<TermData>("term://data", (e) => {
+          // Drop another repository's traffic, and a dead session's tail — a
+          // reader mid-read when the terminal was reopened would otherwise
+          // paint the old shell's last line into the new one.
+          if (e.payload.repoId !== repoId) return;
+          if (epochRef.current !== null && e.payload.epoch !== epochRef.current) return;
+          const bytes = Uint8Array.from(atob(e.payload.data), (c) => c.charCodeAt(0));
+          term.write(bytes);
+        }),
+      );
+      unlisteners.push(
+        await listen<TermExit>("term://exit", (e) => {
+          if (e.payload.repoId !== repoId) return;
+          if (epochRef.current !== null && e.payload.epoch !== epochRef.current) return;
+          const code = e.payload.code;
+          term.write(
+            `\r\n\x1b[2m[shell exited${code === null ? "" : ` with ${code}`}]\x1b[0m\r\n`,
+          );
+          epochRef.current = null;
+        }),
+      );
+    })();
+
+    return () => {
+      disposed = true;
+      typed.dispose();
+      for (const un of unlisteners) un();
+      term.dispose();
+      termRef.current = null;
+      // The SESSION is deliberately left running: hiding the panel or switching
+      // tabs must not kill the shell. `useTabsStore.close` is what ends it.
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [repoId]);
+
+  // Fit on measured size, NOT on a ResizeObserver — WebKitGTK does not have one
+  // and the Linux build would render 80x24 in a 200-column pane forever.
+  // `useElementSize` reads first and observes second, per the frontend rules.
+  React.useEffect(() => {
+    const term = termRef.current;
+    if (!term || width === 0 || height === 0) return;
+    const cols = Math.max(20, Math.floor(width / CELL_W));
+    const rows = Math.max(4, Math.floor(height / CELL_H));
+    if (cols === term.cols && rows === term.rows) return;
+    term.resize(cols, rows);
+    void termResize(repoId, rows, cols).catch(() => {
+      /* no session yet, or it is gone */
+    });
+  }, [width, height, repoId]);
+
+  return (
+    <div
+      ref={ref}
+      data-testid="terminal-view"
+      style={{ flex: 1, minHeight: 0, overflow: "hidden", padding: "4px 6px" }}
+    >
+      <div ref={hostRef} style={{ width: "100%", height: "100%" }} />
+    </div>
+  );
+}
+```
+
+`useElementSize` returns `{ ref, width, height }` — confirm the exact shape (`grep -n 'ElementSize' src/lib/useElementSize.ts`) and adjust the destructure if it differs.
+
+- [ ] **Step 8: Implement `TerminalPanel.tsx`**
+
+```tsx
+import React from "react";
+
+import { PGIconButton, PGResizeHandle } from "@/design";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { useTerminalStore } from "./useTerminalStore";
+import { TerminalView } from "./TerminalView";
+import { shellLabel } from "./shellLabel";
+
+/**
+ * The docked terminal, below the active screen (#243).
+ *
+ * Renders nothing when closed, and mounts a view only for the ACTIVE
+ * repository — the inactive tabs' shells stay alive in the backend without
+ * costing a renderer each.
+ */
+export function TerminalPanel() {
+  const open = useTerminalStore((s) => s.open);
+  const heightPx = useTerminalStore((s) => s.heightPx);
+  const setHeight = useTerminalStore((s) => s.setHeight);
+  const setOpen = useTerminalStore((s) => s.setOpen);
+  const repo = useRepoStore((s) => s.current);
+  const shell = useSettingsStore((s) => s.terminalShell);
+
+  if (!open || !repo) return null;
+
+  return (
+    <div
+      data-testid="terminal-panel"
+      style={{
+        height: heightPx,
+        flexShrink: 0,
+        display: "flex",
+        flexDirection: "column",
+        borderTop: "1px solid var(--border-1)",
+        background: "var(--bg-0)",
+      }}
+    >
+      <PGResizeHandle
+        orientation="vertical"
+        side="top"
+        testId="terminal-resize"
+        onDrag={(dy) => setHeight(heightPx - dy)}
+        onReset={() => setHeight(240)}
+      />
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "2px 8px",
+          fontSize: "var(--fs-11)",
+          color: "var(--fg-3)",
+        }}
+      >
+        <span>{shellLabel(shell)}</span>
+        <span style={{ flex: 1 }} />
+        <PGIconButton
+          icon="close"
+          size="sm"
+          title="Hide terminal"
+          onClick={() => setOpen(false)}
+        />
+      </div>
+      {/* Keyed by repository: a switch mounts a new view rather than
+          re-pointing this one at a different shell. */}
+      <TerminalView key={repo.id} repoId={repo.id} />
+    </div>
+  );
+}
+```
+
+Confirm `PGIconButton`'s available `icon` names (`grep -n 'close' src/design/icons.tsx | head`) and use one that exists.
+
+Create `src/features/terminal/index.ts` exporting `TerminalPanel`, `useTerminalStore`, `shellLabel`.
+
+- [ ] **Step 9: Run the tests and the type-check**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- features/terminal
+pnpm tsc --noEmit
+```
+
+Expected: all pass, no type errors.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml src/features/terminal
+git commit -m "feat(terminal): the panel, the view and its store (#243)
+
+Why: per-repo session state lives in its own store, not RepoSlice —
+RepoSlice is cleared on every tab switch, which is right for a diff and
+would orphan the shells of every inactive tab. Sizing is measured
+rather than observed: WebKitGTK has no ResizeObserver.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Wiring — the chord, the dock, the lifecycle
+
+**Files:**
+- Modify: `src/features/keymap/actions.ts`, `src/features/keymap/presets.ts`
+- Modify: `src/AppShell.tsx:658-690` (`AppBody`)
+- Modify: `src/features/repo/useTabsStore.ts` (`close`)
+- Test: `src/features/terminal/TerminalPanel.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `TerminalPanel`, `useTerminalStore` (Task 5); `termClose` (Task 3).
+- Produces: `ActionId` gains `"terminal.toggle"`.
+
+- [ ] **Step 1: Write the failing test**
+
+`src/features/terminal/TerminalPanel.test.tsx`:
+
+```tsx
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("./TerminalView", () => ({
+  TerminalView: ({ repoId }: { repoId: string }) => (
+    <div data-testid="terminal-view">{repoId}</div>
+  ),
+}));
+
+import { TerminalPanel } from "./TerminalPanel";
+import { useTerminalStore } from "./useTerminalStore";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+
+describe("TerminalPanel", () => {
+  beforeEach(() => {
+    useTerminalStore.setState({ open: false, heightPx: 240, epochs: {} });
+  });
+
+  it("renders nothing when closed", () => {
+    useRepoStore.setState({ current: { id: "r1", path: "/tmp/r1" } } as never);
+    const { container } = render(<TerminalPanel />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing with no repository open", () => {
+    useRepoStore.setState({ current: null } as never);
+    useTerminalStore.setState({ open: true });
+    const { container } = render(<TerminalPanel />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("mounts a view for the active repository when open", () => {
+    useRepoStore.setState({ current: { id: "r1", path: "/tmp/r1" } } as never);
+    useTerminalStore.setState({ open: true });
+    render(<TerminalPanel />);
+    expect(screen.getByTestId("terminal-view")).toHaveTextContent("r1");
+  });
+});
+```
+
+Check `useRepoStore`'s `current` shape first (`grep -n 'current:' src/features/repo/useRepoStore.ts | head`) and build the fixture to match — `as never` is a crutch, not the goal; if there is an existing repo fixture helper in `src/test/`, use it.
+
+- [ ] **Step 2: Run to verify it fails, then make it pass**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- TerminalPanel
+```
+
+If Task 5's `TerminalPanel` is correct these pass immediately. That is fine — they are regression cover for the wiring about to happen, not a red-green cycle for code that already exists.
+
+- [ ] **Step 3: Add the keymap action**
+
+In `src/features/keymap/actions.ts`, add `| "terminal.toggle"` to `ActionId`, and to `ACTIONS`:
+
+```ts
+  "terminal.toggle": {
+    id: "terminal.toggle",
+    title: "Toggle terminal",
+    category: "View",
+    scope: "global",
+    run: () => useTerminalStore.getState().toggle(),
+  },
+```
+
+Import `useTerminalStore` from `@/features/terminal`. Match the `category` string to one that already exists in the file — read the `ACTIONS` entries around `view.zoomIn` and reuse its category verbatim.
+
+In `src/features/keymap/presets.ts`, bind it in each preset. The default is `Ctrl+\``; read how another global chord is spelled in that file and copy the notation exactly.
+
+- [ ] **Step 4: Dock the panel**
+
+In `src/AppShell.tsx`, import `TerminalPanel` from `@/features/terminal` and place it inside `AppBody`'s screen column — the `<div data-pg-screen={screen}>` at line ~685 — as a sibling **after** `{screens[screen]}`:
+
+```tsx
+          {screens[screen]}
+          <TerminalPanel />
+```
+
+That div is already `display: flex; flexDirection: column`, so the panel's fixed height and the screen's `flex: 1` compose without further layout work.
+
+- [ ] **Step 5: Keep the shell's keys out of the global chord handler**
+
+Find where the global key handler decides to ignore an event (`grep -n 'suppressInInput\|isEditable\|tagName' src/features/keymap/useKeymapStore.ts`). Extend that predicate so an event originating inside the terminal is ignored, except for `terminal.toggle` itself and the overlay-escape action:
+
+```ts
+  // A terminal that swallows Ctrl+C into the command palette instead of the
+  // foreground process is worse than no terminal. Everything typed inside the
+  // xterm host belongs to the shell — except the chord that hides the panel,
+  // which is the way back out.
+  const inTerminal = !!(e.target as HTMLElement | null)?.closest?.(
+    "[data-testid='terminal-view']",
+  );
+  if (inTerminal && id !== "terminal.toggle" && id !== "app.closeOverlay") return;
+```
+
+Place it alongside the existing `suppressInInput` check, in the same style. Add a test to the keymap's existing test file asserting a chord bound to a non-terminal action does not fire when the event target is inside `[data-testid='terminal-view']`.
+
+- [ ] **Step 6: Kill the shell when the repository tab closes**
+
+In `src/features/repo/useTabsStore.ts`'s `close`, after the tab is removed:
+
+```ts
+    // The shell belongs to the tab. `termClose` is idempotent, so a tab that
+    // never opened a terminal costs one no-op invoke.
+    void termClose(repoId).catch(() => {});
+    useTerminalStore.getState().forget(repoId);
+```
+
+`close` takes a `path`, so read how it resolves the path to a `RepoId` in that function and use the same value; if the id is not available there, call `termClose` with whatever the backend keys sessions by and make `term_open` key on the same thing. Verify by reading the `close` implementation before editing.
+
+Add a test to the existing tabs test file asserting `termClose` is called on close (mock `@/lib/tauri` the way that file already does).
+
+- [ ] **Step 7: Run everything and commit**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm tsc --noEmit
+pnpm test
+```
+
+Expected: the whole vitest suite green — including `AppShell.navroutes`, which is compile-enforced, and `docs`, which will FAIL until Task 7. Note the docs failure and continue; it is the next task's red.
+
+```bash
+git add src/features/keymap src/AppShell.tsx src/features/repo/useTabsStore.ts src/features/terminal
+git commit -m "feat(terminal): dock the panel, bind the chord, end the shell with the tab (#243)
+
+Why: keys typed in the terminal belong to the shell, so the global chord
+handler stands down inside it — everything except the chord that hides
+the panel, which is the way back out.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Documentation — which is a build gate here
+
+`test/docs.test.ts` fails the build when `docs/dev/architecture.md` does not name every backend module and every `src/features/` directory. This task is not optional polish.
+
+**Files:**
+- Modify: `docs/dev/architecture.md`, `docs/dev/backend.md`, `docs/dev/frontend.md`, `CLAUDE.md`
+
+- [ ] **Step 1: Run the gate to see exactly what it wants**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- docs
+```
+
+Expected: FAIL naming `terminal.rs`, the four `term_*` commands, and `features/terminal`.
+
+- [ ] **Step 2: The backend tree**
+
+In `docs/dev/architecture.md`, in the `src-tauri/src/` tree, after the `state.rs` entry (alphabetical):
+
+```
+terminal.rs      Live pty sessions for the built-in terminal (#243). Shape of
+                 watcher.rs: a Default state manage-d on the app, thin handlers
+                 in commands/terminal.rs. Sessions are keyed by RepoId, which is
+                 what makes "one shell per repository tab" a property of the map
+                 rather than a rule the frontend remembers; a second open for a
+                 live repo returns the existing epoch instead of stacking a
+                 shell. Output leaves through an INJECTED EventSink, not an
+                 AppHandle — that is what lets tests/terminal.rs assert on the
+                 exact stream the frontend sees, and it keeps the reader thread
+                 free of the Tauri runtime. Data crosses as BASE64: a 4 KiB read
+                 splits a multi-byte character often enough that from_utf8_lossy
+                 would put U+FFFD inside filenames. Every event carries an epoch
+                 and the frontend drops the ones that are not its own — a reader
+                 still mid-read when the user reopened the terminal would else
+                 paint the dead shell's tail into the new one. THIS FILE LOGS
+                 NOTHING; tests/terminal_privacy.rs fails the build if it starts
+                 to, because a terminal is where passwords get typed.
+```
+
+And in the `commands/` section, after `submodule.rs`:
+
+```
+                 terminal.rs — term_open/term_write/term_resize/term_close
+                 (#243). Thin over crate::terminal. term_open resolves the
+                 workdir through the backend, never from an argument, and picks
+                 the shell (the Settings override, else proc::default_shell).
+                 The lifecycle logging lives here rather than in terminal.rs
+                 precisely because this file sees ids and exit codes and never a
+                 byte of traffic.
+```
+
+Match the surrounding entries' indentation and wrapping exactly — the file is a fixed-width tree.
+
+- [ ] **Step 3: The frontend tree**
+
+In the `src/features/` tree, after `submodules/`:
+
+```
+── terminal/     The built-in terminal (#243). TerminalPanel docks below the
+                 active screen and mounts ONE TerminalView, keyed by the active
+                 repository. Per-repo session state lives in useTerminalStore
+                 and NOT in RepoSlice: RepoSlice is cleared on every tab switch,
+                 which is right for a diff and would orphan the shells of every
+                 inactive tab. Sizing is MEASURED (useElementSize) rather than
+                 observed — WebKitGTK has no ResizeObserver, so xterm's FitAddon
+                 would leave the Linux build at 80x24 forever, which is why the
+                 addon is not installed.
+```
+
+- [ ] **Step 4: `docs/dev/backend.md`**
+
+Add a section under the process-spawning material:
+
+```markdown
+### The pty carve-out (#243)
+
+`portable-pty` spawns through its own `CommandBuilder`, not
+`std::process::Command`, so a pty opened outside `proc.rs` would sail straight
+past the `Command::new` guard — the second spawn path #172 exists to prevent,
+and invisible. `proc::spawn_pty_shell` therefore owns `openpty`, the
+`CommandBuilder` and `spawn_command`, and `tests/spawn_no_window.rs` allow-lists
+those three APIs in `proc.rs` and nowhere else.
+
+Two things about that child are deliberate inversions worth knowing:
+
+- **`GIT_TERMINAL_PROMPT` is NOT set to 0.** The standing `prompt_less` policy
+  exists because a child of a GUI app has no terminal, so an auth prompt hangs
+  behind a window nobody can see. This child *is* a terminal and the user is
+  looking at it; inheriting the silence would turn a working `git push` into a
+  mysterious failure.
+- **`CREATE_NO_WINDOW` does not apply.** ConPTY is not `CreateProcess` with an
+  inherited console — `portable-pty` allocates a pseudoconsole, so no `conhost`
+  window appears and #172's flash cannot happen here.
+
+And one rule with a test behind it: **`src/terminal.rs` contains no logging call
+at all.** A terminal is where a `sudo` password gets typed. The bytes read from
+the pty have exactly one destination — the event sink — and the lifecycle
+logging worth having lives in `commands/terminal.rs`, which handles ids and exit
+codes and never sees traffic. `tests/terminal_privacy.rs` enforces the split.
+```
+
+- [ ] **Step 5: `docs/dev/frontend.md`**
+
+Add a section near the other pane/layout material:
+
+```markdown
+### The terminal panel (#243)
+
+Docked in `AppBody`'s screen column, below the routed screen, height persisted
+and drag-resized with the shared `PGResizeHandle`. Closed by default: a terminal
+nobody asked for should not spawn a shell for every repository they open.
+
+Three rules that are easy to break:
+
+- **Sizing is measured, never observed.** WebKitGTK has no `ResizeObserver`, so
+  xterm's `FitAddon` would leave the Linux build rendering 80×24 in a
+  200-column pane forever. The panel uses `lib/useElementSize` (read first,
+  observe second) and calls `term.resize` and `term_resize` together, so the
+  renderer and the pty never disagree. The addon is deliberately not installed.
+- **Per-repo state is NOT in `RepoSlice`.** `useTerminalStore` holds a session
+  epoch for every open repository at once — the shape `useTabsStore` has.
+  `RepoSlice` is cleared on every tab switch, which would orphan the shells of
+  every inactive tab.
+- **The global chord handler stands down inside the terminal.** Everything typed
+  in the xterm host belongs to the shell, except `terminal.toggle` and the
+  overlay escape. A terminal that swallows `Ctrl+C` into the command palette
+  instead of the foreground process is worse than no terminal.
+```
+
+- [ ] **Step 6: `CLAUDE.md` — the pairs list goes from three to four**
+
+Change the "Three near-identical filename pairs" paragraph to four and add the new pair:
+
+```
+**Four near-identical filename pairs do different jobs** — check before
+editing: `git/signing.rs` (cryptography) vs `git/signature.rs` (identity/
+sign-off); `src-tauri/src/update.rs` (engine) vs `commands/update.rs`
+(handlers); `src-tauri/src/cli.rs` (pgit launch) vs `git/cli.rs` (CliBackend);
+`src-tauri/src/terminal.rs` (pty sessions) vs `commands/terminal.rs` (handlers).
+```
+
+Keep the edit to that paragraph. `CLAUDE.md` is loaded into every session — do not add a section for the terminal; the pointers above carry it.
+
+- [ ] **Step 7: Run the gate**
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test -- docs
+```
+
+Expected: PASS. If it still names a `term_*` command, the command list entry in Step 2 is not in a form the expander reads — spell each of the four ids out individually rather than as a slashed group.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add docs/dev CLAUDE.md
+git commit -m "docs(terminal): the pty carve-out, the panel, the fourth filename pair (#243)
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: The e2e spec, and the full gate
+
+**Files:**
+- Create: `e2e/specs/terminal.e2e.ts`
+
+- [ ] **Step 1: Read the e2e skill first**
+
+**REQUIRED:** read `.claude/skills/e2e-testing/SKILL.md` before writing a line of this spec. It carries the selector conventions, the temp-repo fixtures and the timing rules that make the difference between a spec that passes in CI and one that wastes a merge window.
+
+- [ ] **Step 2: Write the spec**
+
+Model it on the smallest existing spec in `e2e/specs/`. Shape:
+
+```ts
+// Toggle the panel, run one command, see its output. Everything finer-grained
+// is cheaper and less flaky at the vitest and cargo layers — this exists to
+// prove the pty reaches a real WebKit view at all.
+```
+
+1. Open a temp repository through the standard fixture.
+2. Toggle the terminal (use the chord, or click the toggle if the spec harness makes chords awkward — follow whatever the other specs do).
+3. Wait for `[data-testid='terminal-view']` to exist and for its text to be non-empty (the prompt).
+4. Type `echo pgit-e2e-<unique>` + Enter.
+5. Assert the unique marker appears in the panel's text.
+6. Toggle it away and assert the panel is gone.
+
+Use a unique marker per run so a stale snapshot cannot produce a false pass.
+
+- [ ] **Step 3: Rebuild the snapshot and run only this spec**
+
+A `src/` and `src-tauri/` change means the snapshot is stale. One cold container build at a time across ALL worktrees.
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm test:e2e:docker build
+pnpm test:e2e:docker run --spec e2e/specs/terminal.e2e.ts
+```
+
+- [ ] **Step 4: If xterm does not render headlessly**
+
+This is the spec's stated risk. If the view mounts but never paints text, do **not** spend the merge window on it: reduce the spec to the panel-opens smoke test (steps 1-3 and 6, dropping the typing and the marker), leave a comment saying why, and note it in the PR body. The behaviour stays covered by `src-tauri/tests/terminal.rs` and the vitest layer. Do not delete the spec — a panel that fails to mount in a real webview is exactly what it should catch.
+
+- [ ] **Step 5: The full local gate**
+
+Run every layer against the final tree. A green number is only evidence for the tree it ran on, so this must come **after** the last edit.
+
+```bash
+export PATH="$HOME/Library/pnpm:$HOME/.cargo/bin:$PATH"
+pnpm tsc --noEmit
+pnpm exec tsc -p e2e/tsconfig.json --noEmit
+pnpm test
+cargo test --manifest-path src-tauri/Cargo.toml
+```
+
+Do **not** run the full vitest suite while a Docker e2e build is running — contention fakes a red.
+
+Expected: all four clean. Confirm `no_telemetry` and `privacy` are among the passes; the two new dependencies are exactly what they exist to catch.
+
+- [ ] **Step 6: Squash and open the PR**
+
+The PR squashes to one commit anyway, so squash locally first for a clean message. Pin `main`'s SHA before the reset — a concurrent PR merging in between would otherwise be reverted by the squash.
+
+```bash
+git fetch origin
+BASE=$(git rev-parse origin/main)
+git reset --soft "$BASE"
+git commit -m "feat(terminal): a built-in terminal, cd-ed to the open repository (#243)"
+git push -u origin feat/builtin-terminal
+gh pr create --title "feat(terminal): a built-in terminal, cd-ed to the open repository (#243)" --body "…"
+```
+
+The PR body must state: what shipped, the `proc.rs` carve-out and why the guard grew rather than gained an exception, the base64 decision, that the refresh bullet was satisfied by #239 rather than reimplemented, that Windows ConPTY is reasoned but unmeasured, and whatever happened to the e2e spec in Step 4.
+
+- [ ] **Step 7: Watch CI**
+
+`gh run watch` has lied about exit codes here — read the run's **conclusion**, never the watcher's exit status:
+
+```bash
+gh pr checks --watch
+gh run list --branch feat/builtin-terminal --limit 3 --json conclusion,name,status
+```
+
+`e2e-linux` is the required check and it is a known flake source. Three reds is not proof it is you — a wandering sub-test is the flake tell. Compare per-spec `driver scripts` counts against `main` before assuming the terminal broke something unrelated.
+
+---
+
+## Self-Review
+
+**Spec coverage** — every section maps to a task:
+
+| Spec section | Task |
+|---|---|
+| Backend / session registry / reader thread | 2 |
+| `term_open`/`write`/`resize`/`close` | 3 |
+| The `proc.rs` carve-out + guard | 1 |
+| No logging of pty traffic | 2 (guard), 3 (the split) |
+| `TerminalUnavailable` | 3 |
+| Frontend store / panel / view / theme / measured fit | 5 |
+| Keyboard, lifecycle, dock | 6 |
+| Settings | 4 |
+| Tauri permissions (none) | — nothing to do; recorded in the spec |
+| Refresh (already done by #239) | — nothing to do; recorded in the spec |
+| Dependencies | 1 (Rust), 5 (npm) |
+| Testing: Rust / guards / vitest / docs / e2e | 1, 2, 3, 5, 6, 7, 8 |
+| Risks: xterm headless / ConPTY / shell startup | 8 Step 4; 8 Step 6 PR body; 5 (the "starting…" line is the panel header's shell label) |
+
+**Known open thread, deliberately left to the implementer:** Task 6 Step 6 says to verify how `useTabsStore.close` resolves a path to a `RepoId` before wiring `termClose`. The tabs store is keyed by path and the terminal by `RepoId`; if `close` does not have the id in hand, the fix is to key sessions by whatever `close` does have and make `term_open` agree. Both are consistent choices — the plan does not pick one because the answer is three lines of reading away and picking wrong would be worse than looking.
+
+**Type consistency:** `epoch` is `u64` in Rust and `number` in TS throughout; `repo_id`/`repoId` follows Tauri's camelCase serde rename in every payload; `TerminalState::open` returns the epoch in Rust and `termOpen` returns `Promise<number>`; `EventSink` is `Arc<dyn Fn(TermEvent) + Send + Sync>` in Task 2's interface block, its implementation, and the test recorder.

--- a/docs/superpowers/specs/2026-09-01-builtin-terminal-spec.md
+++ b/docs/superpowers/specs/2026-09-01-builtin-terminal-spec.md
@@ -1,0 +1,316 @@
+# A built-in terminal, already cd-ed to the open repository (#243)
+
+Status: approved 2026-09-01.
+
+## Why
+
+`platypusgit` assumes you know git. The person who knows git drops to a shell
+for the 5% the GUI does not cover — a `git rebase --onto` with an odd revset, a
+`gh` invocation, a `cargo test`. Today that means leaving the app, finding a
+terminal, and `cd`-ing to the repository they already had open.
+
+We already ship the other leg: `pgit` takes you terminal → app
+(`docs/dev/distribution.md`). This is the return leg.
+
+The issue flagged "use your own terminal" as a defensible answer. It was
+considered and rejected: for a dev-first client the shell is not an escape
+hatch, it is the other half of the workflow, and the round trip through a
+separate app loses the one thing the GUI already knows — which repository you
+are in.
+
+## What ships
+
+A real pty. Not a command runner: `vim`, `less`, `ssh`, `git rebase -i`, tab
+completion and colour all work, because anything less is a text box that lies
+about being a terminal.
+
+- A terminal panel docked below the active screen, toggled with a chord and
+  resizable by drag. Closed by default.
+- **One shell per repository tab.** Switching tabs switches shells; the cwd is
+  that repository's workdir. Hiding the panel leaves the shell running; closing
+  the repository tab kills it.
+- Shell chosen by auto-detection, overridable in Settings.
+- Nothing to build for "refresh after a command" — see *Refresh*, below.
+
+Explicitly **not** in this cut: multiple shells per repository tab, a terminal
+tab strip, split terminals, shell profiles, scrollback search. One shell per
+repository is what the issue asked for and what the panel can do well.
+
+## Architecture
+
+### Backend
+
+Two new files, in the shape `watcher.rs` + `commands/watch.rs` already
+established for "a subsystem holding live OS resources, driven by thin
+commands":
+
+- `src-tauri/src/terminal.rs` — the session registry. Owns every live pty.
+- `src-tauri/src/commands/terminal.rs` — four thin handlers.
+
+`TerminalState` is `manage`d on the Tauri app alongside `WatchState`. It holds
+`Mutex<HashMap<RepoId, Session>>`. A `Session` owns:
+
+| field | for |
+|---|---|
+| `master: Box<dyn MasterPty + Send>` | `resize` |
+| `writer: Box<dyn Write + Send>` | `term_write` |
+| `child: Box<dyn Child + Send + Sync>` | `kill` on close |
+| `epoch: u64` | fencing a stale reader (below) |
+
+Sessions are keyed by `RepoId`, which is what makes "one shell per repository
+tab" a property of the data structure rather than a rule the frontend has to
+remember. A second `term_open` for a repository that already has a live session
+is a no-op returning the existing dimensions, so a panel re-mount cannot stack
+shells.
+
+#### The reader thread
+
+One blocking thread per session, reading the pty master. Each read emits a
+`term://data` event carrying `{ repoId, epoch, data }`.
+
+**`data` is base64.** This is the detail most likely to be got wrong: pty output
+is arbitrary bytes, and a 4 KiB read splits a multi-byte character at the
+boundary about as often as you would expect. Handing Tauri a `String` means
+`from_utf8_lossy`, which silently replaces the split character with U+FFFD — the
+user sees a `<?>` in the middle of a filename, intermittently, and only for
+non-ASCII. Base64 across IPC and `atob` on the frontend feeding xterm's
+byte-oriented `write` keeps the stream exact. xterm.js does its own incremental
+UTF-8 decoding across chunks, which is the correct place for it.
+
+`epoch` fences the thread. Closing and immediately reopening a repository's
+terminal can leave the old thread mid-`read` with a chunk in hand; without a
+fence it emits into the new session and the user sees the dead shell's last
+line. The frontend drops any event whose epoch is not the one it opened.
+
+When `read` returns 0 the shell has exited: emit `term://exit` with the status,
+reap the child, drop the session from the map. The thread then returns — no
+leaked thread per tab, which the issue called out.
+
+#### `term_open` / `term_write` / `term_resize` / `term_close`
+
+Thin, in `commands/terminal.rs`. `term_open` takes `repo_id`, `rows`, `cols`
+and resolves the workdir **through the backend**, never from a frontend
+argument — the same rule `watch_repo` and `run_custom_action` follow, and for
+the same reason: a path argument would be a second source of truth for where a
+repository lives, and this one is about to become a shell's cwd.
+
+`term_close` is idempotent. Killing an already-exited child is not an error.
+
+### The `proc.rs` carve-out
+
+The rule is *never `Command::new` outside `src-tauri/src/proc.rs`*, enforced by
+`src-tauri/tests/spawn_no_window.rs`. `portable-pty` would slip straight past
+that guard: it spawns through its own `CommandBuilder`, not
+`std::process::Command`, so the grep never fires. Adding the crate without
+touching `proc.rs` would create exactly the second spawn path the guard exists
+to prevent — invisibly.
+
+So `proc.rs` owns the whole operation, not just the command:
+
+```rust
+pub fn spawn_pty_shell(
+    shell: &OsStr, workdir: &Path, rows: u16, cols: u16,
+) -> io::Result<PtySession>
+```
+
+It calls `native_pty_system().openpty(...)`, builds the `CommandBuilder`, and
+calls `slave.spawn_command(...)`, returning the master and the child.
+`terminal.rs` never touches `portable_pty`'s spawn API. This matches the
+module's own stated philosophy — the treatment is applied *by the only functions
+that hand out a command at all* — rather than bolting a fourth thing onto it.
+
+What it applies, and why each is a deliberate choice:
+
+- **`child_path()`** — yes. The login-`PATH` merge from #232. A Dock-launched
+  app inherits launchd's minimal environment; without this the built-in
+  terminal would be the one terminal on the machine where `node` is missing.
+- **`TERM=xterm-256color`** — the terminal we actually render.
+- **cwd = the repository workdir** — the entire point of the feature.
+- **`GIT_TERMINAL_PROMPT=0`** — *no*, and this inversion of `proc.rs`'s standing
+  policy must be argued rather than inherited. `prompt_less` exists because a
+  child of a GUI app has no terminal, so an auth prompt hangs forever behind a
+  window nobody can see. This child **is** a terminal, on purpose, and the user
+  is looking at it. Suppressing the prompt here would turn a working `git push`
+  into a mysterious failure.
+- **`CREATE_NO_WINDOW`** — not applicable. ConPTY is not `CreateProcess` with an
+  inherited console; `portable-pty` allocates a pseudoconsole and no `conhost`
+  window appears. The issue's "must not flash a console" requirement is
+  satisfied by the mechanism, not by a flag. Verified on Windows before merge.
+
+The guard test grows a third case: `CommandBuilder::new`, `openpty(` and
+`spawn_command(` may appear only in `src/proc.rs`, count 1 each. A future second
+pty path then fails the build the way a second `Command::new` does.
+
+### No logging of pty traffic, ever
+
+A terminal is where secrets get typed. The property we want is that bytes read
+from the pty reach exactly one destination — the `term://data` emit — and
+nothing else.
+
+Enforced structurally rather than by care: `src/terminal.rs` contains **no
+logging macro at all**, asserted by a new `src-tauri/tests/terminal_privacy.rs`.
+Session lifecycle worth logging (opened, exited, closed) is logged from
+`commands/terminal.rs`, which handles ids and exit codes and never sees a byte
+of traffic. That split is what makes the test cheap and total.
+
+The same test asserts the module never writes the buffer to a file or a command,
+and that `term_write`'s payload is not logged either — a password typed at a
+`sudo` prompt travels that direction.
+
+Nothing from the auth path goes near the shell: no forge token, no git
+credential, no askpass environment. It gets the ordinary child environment
+`proc.rs` builds, exactly as `run_custom_action` does.
+
+### A new `AppError` variant
+
+`TerminalUnavailable(String)` — the shell binary is missing or not runnable.
+This is the shape `LfsUnavailable` and `SshKeygenUnavailable` already use: a
+**state**, not a failure. The panel disables itself and says which shell it
+tried, because the remedy is one field in Settings. Raising `Io` instead would
+put "No such file or directory" in an error banner without saying which file.
+
+The TS union in `src/lib/errors.ts` gains the matching member in the same
+commit, with prose in `appErrorDetail` naming the Settings field.
+`test/appErrors.test.ts` fails the build for either half alone.
+
+### Frontend
+
+`src/features/terminal/`:
+
+- `useTerminalStore.ts` — panel `open`, `heightPx`, and per-repo session status.
+- `TerminalPanel.tsx` — the docked pane and its resize handle.
+- `TerminalView.tsx` — one xterm.js instance, mounted per repository.
+- `shellLabel.ts` — pure: the display name for the configured or auto shell.
+
+**Why a separate store and not `RepoSlice`.** `useRepoStore` holds exactly one
+repository's state, and a new per-repo field must join `RepoSlice`/`emptySlice`
+or tab switches leak it. The terminal's per-repo state is *session liveness for
+every open tab at once*, which is the shape `useTabsStore` has, not the shape
+`RepoSlice` has — putting it in `RepoSlice` would destroy the sessions of every
+inactive tab on each switch, the opposite of what we want. Panel open and height
+are a global UI preference, persisted like a pane size.
+
+**Sizing does not use `ResizeObserver`.** xterm's `FitAddon` is normally driven
+by one, and WebKitGTK does not have it — the Linux build would render an 80×24
+terminal in a 200-column pane forever. The panel measures with
+`lib/useElementSize` (read first, observe second, per the frontend rules) and
+computes cols/rows from the measured cell size, calling the fit and
+`term_resize` together so the pty and the renderer never disagree.
+
+**Theme.** xterm's theme object is built from the design-system CSS variables at
+mount and rebuilt on theme change. No hardcoded accent — the rule holds here as
+everywhere.
+
+**Keyboard.** A `terminal.toggle` action joins `features/keymap/actions.ts`
+(default `Ctrl+\``). The panel is a `PGPane` so spatial navigation can reach it.
+While xterm holds focus the global chord handler stands down except for the
+toggle itself and the pane-escape chord: a terminal that swallows `Ctrl+C` into
+a command palette instead of the foreground process is worse than no terminal.
+
+**Lifecycle.**
+
+| event | effect |
+|---|---|
+| panel opened, no session for the active repo | `term_open` |
+| repository tab activated | show that repo's view; open a session if none |
+| panel hidden | container hidden; every view stays mounted |
+| repository tab closed | `term_close` for that repo, then drop its view |
+| shell exits (`term://exit`) | print the status in place; no auto-respawn |
+| app exits | `close_all` on window destroy kills every child |
+
+No auto-respawn on exit: the user typed `exit` and meant it, and a shell that
+comes back is a shell you cannot get rid of.
+
+**Views are hidden, never unmounted** — amended during implementation, where the
+first cut returned `null` on collapse. Unmounting disposes the xterm instance
+and takes the scrollback with it: the shell survives, so "hiding leaves the
+shell running" is technically kept, but the user reopens the panel to a blank
+pane and the build output they were reading is gone. Every repository with a
+live session therefore keeps its view mounted, and only the active one is
+visible. Nothing mounts before the panel is first opened, so "closed by default,
+no shell nobody asked for" is unaffected.
+
+### Settings
+
+One field, `terminalShell` (blank = auto), in a new **Terminal** section.
+Auto-detection is `$SHELL` then `/bin/sh` on unix; `pwsh.exe` then
+`powershell.exe` then `cmd.exe` on Windows.
+
+### Tauri permissions
+
+None. The four commands are ordinary `#[tauri::command]`s reached through the
+existing invoke bridge, and the two events go over the standard event channel —
+neither needs a capability entry. Nothing is added to `default.json` and no new
+scoped capability file is created. Recorded here because the issue asked.
+
+## Refresh
+
+The issue asked for a repository refresh when the shell goes idle after a
+command. **That work is already done.** #239 landed the filesystem watcher, it
+defaults on (`watchFilesystem: true`), and `watcher.rs` classifies paths against
+`gitdir` and `commondir` — so a `git commit` typed into the pane writes refs,
+the watcher debounces, and the graph moves. No shell-idle detection, no command
+parsing, no second refresh path.
+
+The honest gap: a user who has turned the watcher off gets no automatic refresh
+from the terminal either. That is documented, not worked around. Adding a
+terminal-specific refresh would be a second mechanism for a job the first one
+does, and it would fire on `ls`.
+
+## Dependencies
+
+- `portable-pty` (Rust) — the maintained cross-platform pty crate with ConPTY
+  support; wezterm's, and the same one angkorgit uses.
+- `@xterm/xterm` (npm) — the terminal renderer. No addons: `FitAddon` is
+  replaced by our own measured fit (above), and we need nothing else.
+
+Both are clean against the privacy gates. Neither reaches the network, so
+`ALLOWED_HOSTS` in `test/privacy.test.ts` is untouched; `no_telemetry.rs`'s
+dependency scan is re-run against the new lockfile as part of the work.
+
+## Testing
+
+**Rust** (`src-tauri/tests/terminal.rs`) — against a real pty:
+
+- open a session on a temp repo, write `echo pgit-ok\n`, read until the marker
+  appears; the cwd the shell reports is the repository's workdir
+- two repositories get two independent sessions; closing one leaves the other
+  running
+- `exit\n` produces an exit status and reaps the child — no zombie
+- `term_close` on an already-exited session succeeds
+- `term_open` twice for one repository yields one child, not two
+
+**Rust guards** — `spawn_no_window.rs` gains the pty-API allow-list;
+`terminal_privacy.rs` is new.
+
+**Frontend** (`vitest`) — store logic (session keying, height clamp, epoch
+fencing) as pure tests; `TerminalView` against a mocked xterm asserting
+`term_write` on input, `term_resize` on a measured size change, and listener
+teardown on unmount.
+
+**Docs invariant** — `docs/dev/architecture.md` gains `terminal.rs`,
+`commands/terminal.rs` and `features/terminal/`; `test/docs.test.ts` fails the
+build otherwise. `docs/dev/backend.md` gains the pty carve-out and the
+no-logging rule; `docs/dev/frontend.md` gains the panel and the
+no-`ResizeObserver` fit.
+
+**E2E** (`e2e/specs/terminal.e2e.ts`) — one spec, deliberately small: toggle the
+panel, wait for a prompt, type a command with a unique marker, assert the marker
+appears in the scrollback, toggle it away. Everything finer-grained is cheaper
+and less flaky at the layers above.
+
+## Risks
+
+- **xterm in the headless container.** The e2e stack renders in a real
+  WebKit-family view, so xterm's DOM renderer should work, but this is the first
+  canvas-adjacent thing we test. Mitigation: the spec asserts on the DOM
+  renderer's text rows, and if the renderer proves unstable headlessly the e2e
+  spec drops to a panel-opens smoke test and the behaviour stays covered by the
+  Rust and vitest layers. The feature does not ship worse for it.
+- **Windows ConPTY.** The claim that no console flashes is reasoned, not yet
+  measured. Verified on Windows before merge; if a flash appears the fix is in
+  `spawn_pty_shell` and nowhere else, which is the reason for the carve-out.
+- **Shell startup cost.** A slow `.zshrc` makes the first paint of the panel
+  slow. Not worked around: it is the user's own shell and the same wait their
+  own terminal has. The panel shows a "starting <shell>…" line so the delay is
+  attributed correctly.

--- a/e2e/specs/terminal.e2e.ts
+++ b/e2e/specs/terminal.e2e.ts
@@ -1,0 +1,93 @@
+// The built-in terminal (#243).
+//
+// Deliberately small. Everything about the session registry is cheaper and
+// sharper in `src-tauri/tests/terminal.rs`, and everything about the wiring is
+// cheaper in vitest. What ONLY a real webview can answer is whether a pty's
+// bytes reach xterm and render — the whole chain, pty → base64 → IPC → decode →
+// renderer — and whether the panel docks without breaking the shell layout.
+//
+// The assertions read xterm's own rows for that reason: anything closer to the
+// backend would still pass with the renderer broken, which is the one failure
+// this file exists to catch.
+import { $, browser, expect } from "@wdio/globals";
+
+import { basicRepo, TempRepo } from "../support/tempRepo";
+import {
+  TERMINAL_VIEW,
+  jsChord,
+  jsTypeInTerminal,
+  openRepo,
+  resetApp,
+  terminalText,
+} from "../support/app";
+
+describe("the built-in terminal", () => {
+  let repo: TempRepo | undefined;
+
+  afterEach(async () => {
+    await resetApp();
+    repo?.dispose();
+    repo = undefined;
+  });
+
+  it("opens a shell in the repository, renders its output, and hides again", async () => {
+    repo = basicRepo();
+    await openRepo(repo.path);
+
+    // Closed by default — a terminal nobody asked for should not have spawned
+    // a shell just because a repository opened.
+    await expect($(TERMINAL_VIEW)).not.toBeExisting();
+
+    await jsChord("Ctrl+`");
+    await $(TERMINAL_VIEW).waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "the terminal panel never appeared after Ctrl+`",
+    });
+
+    // A prompt means the pty started, the shell ran its rc files, and its bytes
+    // made it all the way to the renderer. This is the assertion the Rust and
+    // vitest layers cannot make.
+    await browser.waitUntil(async () => (await terminalText()).trim().length > 0,
+      {
+        timeout: 30_000,
+        timeoutMsg: "the terminal rendered nothing — no prompt reached xterm",
+      },
+    );
+
+    // A marker unique per run, so a stale snapshot cannot produce a false pass.
+    const marker = `pgit-e2e-${Date.now()}`;
+    await jsTypeInTerminal(`echo ${marker}\n`);
+
+    await browser.waitUntil(
+      async () => {
+        const text = await terminalText();
+        // Twice: once as the echo of what was typed, once as the output. One
+        // occurrence is just the echo and proves nothing ran.
+        return text.split(marker).length - 1 >= 2;
+      },
+      {
+        timeout: 30_000,
+        timeoutMsg: `the shell never produced "${marker}" — the command did not run, or its output did not render`,
+      },
+    );
+
+    // And the way back out. The view stays in the DOM on purpose — hiding is
+    // not unmounting, or the scrollback would go with it — so this asserts on
+    // VISIBILITY, and the panel is what carries it.
+    await jsChord("Ctrl+`");
+    await $('[data-testid="terminal-panel"]').waitForDisplayed({
+      reverse: true,
+      timeout: 10_000,
+      timeoutMsg: "the terminal panel did not hide on the second Ctrl+`",
+    });
+
+    // Reopening returns to the SAME terminal, marker and all: the shell was
+    // never killed and neither was its scrollback.
+    await jsChord("Ctrl+`");
+    await $(TERMINAL_VIEW).waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg: "the terminal panel did not come back",
+    });
+    await expect(await terminalText()).toContain(marker);
+  });
+});

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -1248,3 +1248,96 @@ export function waitForSelector(
     { timeout, timeoutMsg },
   );
 }
+
+/** The docked terminal panel's host element (#243). */
+export const TERMINAL_VIEW = '[data-testid="terminal-view"]';
+
+/**
+ * Everything the terminal has rendered, as text.
+ *
+ * Read from xterm's own rows rather than from the pty: this is the assertion
+ * that the whole chain worked — pty → base64 → IPC → decode → renderer. Reading
+ * anything closer to the backend would pass with the renderer broken.
+ *
+ * Read-only, so bare `browser.execute` (see `executeOnce`).
+ */
+export function terminalText(): Promise<string> {
+  return browser.execute((sel: string) => {
+    // `.xterm-rows` and NOT the host's textContent: xterm injects a <style>
+    // element into its own container, so reading the host returns hundreds of
+    // characters of CSS. A "did anything render yet?" wait against that passes
+    // instantly and vacuously — which it did, and it hid the real failure for
+    // a full debugging round.
+    const rows = document.querySelector(`${sel} .xterm-rows`);
+    return rows ? (rows.textContent ?? "") : "";
+  }, TERMINAL_VIEW);
+}
+
+/**
+ * Type into the terminal, as the user would.
+ *
+ * Goes through xterm's own hidden textarea → `term.onData` → `term_write` →
+ * the pty, which is the path under test. Writing to the pty directly would
+ * prove nothing about the frontend.
+ *
+ * # Why two different events
+ *
+ * xterm splits its keyboard handling, and sending the wrong half is silent —
+ * the first version of this helper dispatched only `keydown` and the shell
+ * received nothing at all, with the panel and the prompt working perfectly:
+ *
+ * - **Printable characters go through `keypress`**, whose handler reads
+ *   `charCode` (`_keyPress` in `xterm.js`; `keydown` deliberately declines them
+ *   so the browser can produce the keypress — which a SYNTHETIC keydown never
+ *   does). `charCode` and `which` are legacy read-only getters that
+ *   `KeyboardEventInit` cannot set, hence the `defineProperty`.
+ * - **Enter goes through `keydown`**, where `evaluateKeyboardEvent` turns it
+ *   into `\r`.
+ *
+ * `executeOnce` because a driver retry would type the command twice, and a
+ * shell runs whatever it is sent.
+ */
+export async function jsTypeInTerminal(text: string): Promise<void> {
+  const ok = await executeOnce(
+    (sel: string, s: string) => {
+      const host = document.querySelector(sel);
+      const area = host?.querySelector("textarea");
+      if (!area) return false;
+      area.focus();
+      for (const ch of s) {
+        if (ch === "\n" || ch === "\r") {
+          const enter = new KeyboardEvent("keydown", {
+            key: "Enter",
+            code: "Enter",
+            bubbles: true,
+            cancelable: true,
+          });
+          // xterm's key handling is `switch (ev.keyCode)`, and `keyCode` is a
+          // legacy read-only getter that `KeyboardEventInit` cannot set — it
+          // is 0 on a synthetic event, so without this the Enter matches
+          // nothing and the command is typed but never submitted. The symptom
+          // is maximally confusing: the text appears on screen (the pty echoes
+          // it) and the shell simply never runs it.
+          Object.defineProperty(enter, "keyCode", { get: () => 13 });
+          Object.defineProperty(enter, "which", { get: () => 13 });
+          area.dispatchEvent(enter);
+          continue;
+        }
+        const ev = new KeyboardEvent("keypress", {
+          key: ch,
+          bubbles: true,
+          cancelable: true,
+        });
+        const cc = ch.charCodeAt(0);
+        Object.defineProperty(ev, "charCode", { get: () => cc });
+        Object.defineProperty(ev, "which", { get: () => cc });
+        Object.defineProperty(ev, "keyCode", { get: () => cc });
+        area.dispatchEvent(ev);
+      }
+      return true;
+    },
+    TERMINAL_VIEW,
+    text,
+  );
+  if (!ok) throw new Error("jsTypeInTerminal: no terminal textarea on screen");
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@tauri-apps/plugin-os": "^2.3.2",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",
+    "@xterm/xterm": "^6.0.0",
     "lucide-react": "^1.35.0",
     "node-diff3": "^3.2.1",
     "react": "^19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
       '@tauri-apps/plugin-updater':
         specifier: ^2.10.1
         version: 2.10.1
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
       lucide-react:
         specifier: ^1.35.0
         version: 1.38.0(react@19.2.8)
@@ -1582,6 +1585,9 @@ packages:
   '@wdio/xvfb@9.31.2':
     resolution: {integrity: sha512-48MqdcrvdC/Jn2YPhW6hjGLzcQqOEt1Q6KELR/TWz3vIJoZwzTngGAdT06voUnZS+PUEcd/vKSo4a6zxQ/mm7g==}
     engines: {node: '>=18.20.0'}
+
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
 
   '@zip.js/zip.js@2.8.26':
     resolution: {integrity: sha512-RQ4h9F6DOiHxpdocUDrOl6xBM+yOtz+LkUol47AVWcfebGBDpZ7w7Xvz9PS24JgXvLGiXXzSAfdCdVy1tPlaFA==}
@@ -4960,6 +4966,8 @@ snapshots:
   '@wdio/xvfb@9.31.2':
     dependencies:
       '@wdio/logger': 9.29.1
+
+  '@xterm/xterm@6.0.0': {}
 
   '@zip.js/zip.js@2.8.26': {}
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -560,6 +560,12 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -1009,6 +1015,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,7 +1082,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -1196,6 +1208,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -2396,6 +2419,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2667,13 +2696,25 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -3079,7 +3120,7 @@ checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
 dependencies = [
  "android_system_properties",
  "log",
- "nix",
+ "nix 0.30.1",
  "objc2",
  "objc2-foundation",
  "objc2-ui-kit",
@@ -3366,6 +3407,7 @@ dependencies = [
  "libc",
  "log",
  "notify-debouncer-mini",
+ "portable-pty",
  "regex",
  "semver",
  "serde",
@@ -3454,6 +3496,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -4238,6 +4301,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16809bc35793b19ce4e0c53924bc0dce3937f15487997cfdaed936004180730"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4299,6 +4373,22 @@ dependencies = [
  "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -6353,6 +6443,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,6 +60,12 @@ base64 = "0.23"
 # transitively, so this declares it rather than adding it.
 sha2 = "0.11"
 notify-debouncer-mini = "0.7.0"
+# The pty behind the built-in terminal (#243). Chosen because it is the one
+# cross-platform pty crate with a real ConPTY implementation — a Windows
+# terminal built on anything else either flashes a console or cannot resize.
+# Its spawn API is walled off inside `proc::spawn_pty_shell`; see the module
+# doc there and `tests/spawn_no_window.rs` for why that wall is load-bearing.
+portable-pty = "0.9"
 
 # `setsid()` between fork and exec, for the detached `pgit` launch (#163) —
 # nothing in std reaches it (`Command::process_group` only makes a new process

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod repo;
 pub mod ssh;
 pub mod stash;
 pub mod submodule;
+pub mod terminal;
 pub mod update;
 pub mod watch;
 pub mod worktree;

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -1,0 +1,132 @@
+//! The built-in terminal's four handlers (#243).
+//!
+//! Thin, in the shape of `commands/watch.rs`: `crate::terminal::TerminalState`
+//! owns every live pty and all of the lifetime management; this file resolves
+//! the workdir, picks the shell, supplies the event sink, and logs the
+//! lifecycle.
+//!
+//! The logging lives HERE and not in `terminal.rs` on purpose. This file sees
+//! repository ids, sizes and exit codes; `terminal.rs` sees the bytes. A
+//! terminal is where passwords get typed, so the module that handles traffic
+//! logs nothing at all and `tests/terminal_privacy.rs` fails the build if that
+//! stops being true.
+
+use std::sync::Arc;
+
+use tauri::{AppHandle, Emitter, State};
+
+use crate::{
+    error::{AppError, AppResult},
+    git::types::RepoId,
+    state::AppState,
+    terminal::{TermEvent, TerminalState},
+};
+
+/// The event a `TermEvent::Data` is delivered on.
+pub const TERM_DATA_EVENT: &str = "term://data";
+/// The event a `TermEvent::Exit` is delivered on.
+pub const TERM_EXIT_EVENT: &str = "term://exit";
+
+/// Start a shell for `repo_id`, or adopt the one already running.
+///
+/// Returns the session's **epoch**. Every event carries one, and the frontend
+/// drops the events whose epoch is not the one it opened — a reader still
+/// mid-read when the user closed and reopened the terminal would otherwise
+/// paint the dead shell's last line into the new one.
+///
+/// The workdir is resolved through the backend rather than taken from the
+/// frontend: a path argument would be a second source of truth for where a
+/// repository lives, and this one is about to become a shell's cwd.
+#[tauri::command]
+pub async fn term_open(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    terminals: State<'_, Arc<TerminalState>>,
+    repo_id: String,
+    rows: u16,
+    cols: u16,
+    shell: Option<String>,
+) -> AppResult<u64> {
+    let backend = state.backend.clone();
+    let id = RepoId(repo_id.clone());
+    let workdir = tokio::task::spawn_blocking(move || backend.repo_path(&id))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))??;
+
+    // A blank setting means "use the default": the Settings field is a text
+    // box, and an empty text box is not a shell named "".
+    let shell = shell
+        .filter(|s| !s.trim().is_empty())
+        .map(std::ffi::OsString::from)
+        .unwrap_or_else(crate::proc::default_shell);
+    let shell_name = shell.to_string_lossy().to_string();
+
+    let sink = {
+        let app = app.clone();
+        Arc::new(move |ev: TermEvent| {
+            // The INNER struct goes on the wire, never the enum: serde tags an
+            // enum externally, so emitting `ev` would wrap every payload in a
+            // `data` / `exit` key the frontend does not look under, and every
+            // event would be silently dropped by its repoId check. See the note
+            // on `TermEvent`.
+            // Nothing is logged in here: the payload is traffic.
+            match ev {
+                TermEvent::Data(p) => {
+                    let _ = app.emit(TERM_DATA_EVENT, p);
+                }
+                TermEvent::Exit(p) => {
+                    let _ = app.emit(TERM_EXIT_EVENT, p);
+                }
+            }
+        })
+    };
+
+    let terminals = terminals.inner().clone();
+    let epoch = terminals
+        .open(sink, &repo_id, &shell, &workdir, rows, cols)
+        .map_err(|e| AppError::TerminalUnavailable(format!("{shell_name}: {e}")))?;
+
+    log::info!("terminal: session {epoch} open for {repo_id} ({shell_name})");
+    Ok(epoch)
+}
+
+/// Send input to the shell.
+///
+/// The payload is what the user typed — a `sudo` password travels this way, so
+/// it is never logged, and the guard test asserts as much.
+#[tauri::command]
+pub async fn term_write(
+    terminals: State<'_, Arc<TerminalState>>,
+    repo_id: String,
+    data: String,
+) -> AppResult<()> {
+    terminals
+        .write(&repo_id, data.as_bytes())
+        .map_err(|e| AppError::Io(e.to_string()))
+}
+
+/// Tell the pty how big the renderer is, so the shell wraps where the user sees
+/// the edge and a full-screen program (`vim`, `less`) fills the pane.
+#[tauri::command]
+pub async fn term_resize(
+    terminals: State<'_, Arc<TerminalState>>,
+    repo_id: String,
+    rows: u16,
+    cols: u16,
+) -> AppResult<()> {
+    terminals
+        .resize(&repo_id, rows, cols)
+        .map_err(|e| AppError::Io(e.to_string()))
+}
+
+/// Kill this repository's shell. Idempotent — the frontend calls it on tab
+/// close without knowing whether a terminal was ever opened.
+#[tauri::command]
+pub async fn term_close(
+    terminals: State<'_, Arc<TerminalState>>,
+    repo_id: String,
+) -> AppResult<()> {
+    terminals.close(&repo_id);
+    log::info!("terminal: session closed for {repo_id}");
+    Ok(())
+}

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -171,6 +171,15 @@ pub enum AppError {
     #[error("ssh-keygen is not available: {0}")]
     SshKeygenUnavailable(String),
 
+    /// The shell the built-in terminal tried to run is missing or not runnable
+    /// (#243). A **state**, not a failure — the same shape `LfsUnavailable` and
+    /// `SshKeygenUnavailable` use: the panel disables itself and names the
+    /// shell it tried, because the remedy is one field in Settings. Carries
+    /// that name; `Io` would put "No such file or directory" in a banner
+    /// without saying which file.
+    #[error("no usable shell: {0}")]
+    TerminalUnavailable(String),
+
     /// A git hook ran and refused (#232).
     ///
     /// Carries the hook's NAME and its OUTPUT as separate fields rather than one

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ pub mod progress;
 pub mod reveal;
 pub mod ssh;
 pub mod state;
+pub mod terminal;
 pub mod update;
 pub mod watcher;
 
@@ -232,6 +233,9 @@ pub fn run() {
         .manage(commands::forge::ForgeTokens::default())
         // One live filesystem watch, on the active repository (#239).
         .manage(watcher::WatchState::default())
+        // Every live pty, keyed by repository (#243). Behind an `Arc` because
+        // each session's reader thread holds one to retire itself on EOF.
+        .manage(Arc::new(terminal::TerminalState::default()))
         .manage(commands::cli::CliLaunchState(Mutex::new(initial_intent)))
         .invoke_handler(tauri::generate_handler![
             commands::repo::open_repo,
@@ -384,7 +388,26 @@ pub fn run() {
             commands::forge::forge_pull_request_checks,
             commands::forge::forge_create_pull_request,
             commands::forge::forge_checkout_pull_request,
+            commands::terminal::term_open,
+            commands::terminal::term_write,
+            commands::terminal::term_resize,
+            commands::terminal::term_close,
         ])
+        // A shell must not outlive the window that hosts it (#243). Called
+        // explicitly rather than left to a `Drop`: the state is behind an `Arc`
+        // that every reader thread holds, so its drop runs at a time nobody
+        // controls — and an orphaned interactive shell is not a leak the user
+        // can see, only one their process list can.
+        .on_window_event(|window, event| {
+            if matches!(event, tauri::WindowEvent::Destroyed) {
+                use tauri::Manager as _;
+                if let Some(terminals) =
+                    window.app_handle().try_state::<Arc<terminal::TerminalState>>()
+                {
+                    terminals.close_all();
+                }
+            }
+        })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/proc.rs
+++ b/src-tauri/src/proc.rs
@@ -376,6 +376,111 @@ pub fn program_async_keeping_console(prog: impl AsRef<OsStr>) -> tokio::process:
     cmd
 }
 
+/// A live pty and the shell running on it.
+///
+/// Returned by [`spawn_pty_shell`] and owned by `crate::terminal`. The master
+/// is what resizes and what is read from and written to; the child is what gets
+/// killed.
+pub struct PtySession {
+    pub master: Box<dyn portable_pty::MasterPty + Send>,
+    pub child: Box<dyn portable_pty::Child + Send + Sync>,
+}
+
+/// The shell to run when the user has not named one in Settings.
+///
+/// `$SHELL` is what the user's own terminal runs, which is the whole point: the
+/// built-in terminal should not be a *different* shell from the one outside the
+/// app. `/bin/sh` exists on every unix and is the honest last resort.
+#[cfg(not(windows))]
+pub fn default_shell() -> std::ffi::OsString {
+    std::env::var_os("SHELL")
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| std::ffi::OsString::from("/bin/sh"))
+}
+
+/// Windows has no `$SHELL`. PowerShell is the shell a Windows developer
+/// actually uses, and resolution is left to `PATH` — probing for `pwsh.exe`
+/// first would mean a second spawn just to decide what to spawn.
+#[cfg(windows)]
+pub fn default_shell() -> std::ffi::OsString {
+    std::ffi::OsString::from("powershell.exe")
+}
+
+/// Spawn an INTERACTIVE shell on a fresh pty, `cd`-ed to `workdir` (#243).
+///
+/// # Why the whole spawn lives here rather than in `crate::terminal`
+///
+/// The rule this module exists to enforce is "no process spawn outside
+/// `proc.rs`", and `tests/spawn_no_window.rs` enforces it by grepping for
+/// `Command::new`. `portable_pty` spawns through its **own** `CommandBuilder`,
+/// so a pty opened anywhere else would sail straight past that guard — the
+/// second spawn path the guard exists to prevent, and invisible. So this
+/// function owns `openpty`, the `CommandBuilder` and `spawn_command`, and the
+/// guard test allow-lists those three APIs here and nowhere else.
+///
+/// # What this child gets, and what it deliberately does not
+///
+/// * [`child_path`] — yes. A Dock-launched app inherits launchd's minimal
+///   environment (issue 232); without this the built-in terminal would be the
+///   one terminal on the machine where `node` is missing.
+/// * `TERM=xterm-256color` — the terminal we actually render.
+/// * `GIT_TERMINAL_PROMPT=0` — **no**, and this inverts [`prompt_less`], the
+///   standing policy for every other child in this module. That policy exists
+///   because a child of a GUI app has no terminal, so an auth prompt hangs
+///   forever behind a window nobody can see. This child *is* a terminal, on
+///   purpose, and the user is looking at it; suppressing the prompt here would
+///   turn a working `git push` into a mysterious failure. Inheriting the
+///   silence would have been the bug.
+/// * `CREATE_NO_WINDOW` — not applicable, which is why this does not go through
+///   [`program`]. ConPTY is not `CreateProcess` with an inherited console:
+///   `portable_pty` allocates a pseudoconsole, so no `conhost` window appears
+///   and issue 172's flash cannot happen here.
+///
+/// Nothing from the auth path goes near it — no forge token, no git credential,
+/// no askpass environment — exactly as `run_custom_action` does it.
+pub fn spawn_pty_shell(
+    shell: &OsStr,
+    workdir: &Path,
+    rows: u16,
+    cols: u16,
+) -> std::io::Result<PtySession> {
+    use portable_pty::{CommandBuilder, PtySize};
+
+    let pair = portable_pty::native_pty_system()
+        .openpty(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| std::io::Error::other(format!("could not open a pty: {e}")))?;
+
+    let mut cmd = CommandBuilder::new(shell);
+    cmd.cwd(workdir);
+    cmd.env("TERM", "xterm-256color");
+    if let Some(p) = child_path() {
+        cmd.env("PATH", p);
+    }
+
+    let child = pair.slave.spawn_command(cmd).map_err(|e| {
+        std::io::Error::other(format!(
+            "could not start `{}`: {e}",
+            shell.to_string_lossy()
+        ))
+    })?;
+
+    // The slave is the CHILD's end of the pty. Holding it open here would mean
+    // our reader never sees EOF when the shell exits, so the reader thread
+    // would block forever on a dead session — the leaked thread per tab the
+    // issue warned about. Dropping it is what makes exit detectable at all.
+    drop(pair.slave);
+
+    Ok(PtySession {
+        master: pair.master,
+        child,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -1,0 +1,300 @@
+//! Live pty sessions for the built-in terminal (#243).
+//!
+//! Shape borrowed from `watcher.rs`: a `Default`-constructed state object is
+//! `manage`d on the Tauri app, the handlers in `commands/terminal.rs` stay
+//! thin, and all of the lifetime management lives here.
+//!
+//! # Why this module knows nothing about Tauri
+//!
+//! Output leaves through an injected [`EventSink`] rather than an `AppHandle`.
+//! Two reasons, in order of importance: an integration test can supply a
+//! recording sink and assert on the exact stream the frontend would see, which
+//! an `AppHandle` makes impossible outside a running app; and the reader thread
+//! then depends on one closure instead of the whole Tauri runtime.
+//!
+//! # Why there is not a single logging call in this file
+//!
+//! A terminal is where secrets get typed — a `sudo` password, a token pasted at
+//! a prompt. The property we want is that bytes read from the pty reach exactly
+//! one destination, the sink, and nothing else. That is easy to state and hard
+//! to keep by care alone, so it is kept structurally: this module logs nothing
+//! at all, `tests/terminal_privacy.rs` fails the build if that changes, and the
+//! lifecycle logging worth having lives in `commands/terminal.rs`, which sees
+//! ids and exit codes and never a byte of traffic.
+
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::io::{Read, Write};
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use base64::Engine as _;
+
+/// A chunk of pty output. `data` is **base64**.
+///
+/// Not a `String`: pty output is arbitrary bytes, and an 8 KiB read splits a
+/// multi-byte character at the boundary about as often as you would expect.
+/// `from_utf8_lossy` would replace the split character with U+FFFD, so the user
+/// would see a replacement glyph inside a filename — intermittently, and only
+/// for non-ASCII, which is the worst kind of bug to be told about. xterm.js
+/// decodes UTF-8 incrementally across chunks, which is the correct place for it.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TermData {
+    pub repo_id: String,
+    pub epoch: u64,
+    pub data: String,
+}
+
+/// The shell exited. `code` is `None` when it was signalled, or when the
+/// session had already been retired by an explicit close.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TermExit {
+    pub repo_id: String,
+    pub epoch: u64,
+    pub code: Option<i32>,
+}
+
+/// What a session tells the frontend.
+///
+/// # Why the variants wrap structs instead of carrying fields
+///
+/// This enum is a ROUTING type — it tells `commands/terminal.rs` which event
+/// name to emit — and it is deliberately **not** `Serialize`. What goes on the
+/// wire is the inner struct, flat.
+///
+/// A struct-variant enum looks tidier and is a trap: serde tags externally by
+/// default, so `TermEvent::Data { .. }` serialises as `{"data": {"repoId": …}}`
+/// rather than `{"repoId": …}`. The frontend's first check is
+/// `payload.repoId !== repoId`, which is then `undefined !== "…"` for every
+/// event, so the terminal opens, the shell runs, and **not one byte is ever
+/// displayed** — with no error anywhere, because dropping a foreign
+/// repository's traffic is exactly what that line is supposed to do sometimes.
+/// Cost a full e2e debugging round; the shape below makes it unrepresentable.
+pub enum TermEvent {
+    Data(TermData),
+    Exit(TermExit),
+}
+
+/// Where a session's events go.
+///
+/// `commands/terminal.rs` supplies one that emits on the Tauri app; tests
+/// supply one that records.
+pub type EventSink = Arc<dyn Fn(TermEvent) + Send + Sync>;
+
+struct Session {
+    master: Box<dyn portable_pty::MasterPty + Send>,
+    writer: Box<dyn Write + Send>,
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+    epoch: u64,
+}
+
+/// Every live pty, keyed by repository.
+///
+/// Keying by repository id is what makes "one shell per repository tab" a
+/// property of the data structure rather than a rule the frontend has to
+/// remember.
+#[derive(Default)]
+pub struct TerminalState {
+    sessions: Mutex<HashMap<String, Session>>,
+    next_epoch: AtomicU64,
+}
+
+impl TerminalState {
+    /// Start a shell for `repo_id`, or return the epoch of the one already
+    /// running.
+    ///
+    /// Idempotent on purpose: a panel re-mount, a fast double toggle and a tab
+    /// re-activation all reach here, and none of them should stack a shell.
+    pub fn open(
+        self: &Arc<Self>,
+        sink: EventSink,
+        repo_id: &str,
+        shell: &OsStr,
+        workdir: &Path,
+        rows: u16,
+        cols: u16,
+    ) -> std::io::Result<u64> {
+        let mut sessions = self.sessions.lock().expect("terminal sessions lock");
+        if let Some(existing) = sessions.get(repo_id) {
+            return Ok(existing.epoch);
+        }
+
+        // The spawn happens UNDER the lock, and that is deliberate rather than
+        // sloppy: the check above and the insert below have to be one atomic
+        // step, or two concurrent `term_open`s for the same repository — a
+        // double toggle, a re-mount racing a tab activation — both miss the
+        // existing session and both spawn a shell, leaving one orphaned with
+        // nothing holding its handle. Same shape as the stash TOCTOU rule.
+        // The cost is a few milliseconds of contention on a mutex only
+        // terminals touch, which is the cheaper half of the trade.
+        let session = crate::proc::spawn_pty_shell(shell, workdir, rows, cols)?;
+        let epoch = self.next_epoch.fetch_add(1, Ordering::Relaxed);
+
+        // `portable_pty` reports these as `anyhow::Error`, which `?` cannot
+        // convert into `io::Error`. Mapped rather than propagated so the whole
+        // module keeps one error type and the caller keeps one match arm.
+        let reader = session
+            .master
+            .try_clone_reader()
+            .map_err(|e| std::io::Error::other(format!("could not read the pty: {e}")))?;
+        let writer = session
+            .master
+            .take_writer()
+            .map_err(|e| std::io::Error::other(format!("could not write to the pty: {e}")))?;
+
+        spawn_reader(
+            Arc::clone(self),
+            sink,
+            repo_id.to_string(),
+            epoch,
+            reader,
+        );
+
+        sessions.insert(
+            repo_id.to_string(),
+            Session {
+                master: session.master,
+                writer,
+                child: session.child,
+                epoch,
+            },
+        );
+        Ok(epoch)
+    }
+
+    /// Send input to the shell.
+    pub fn write(&self, repo_id: &str, data: &[u8]) -> std::io::Result<()> {
+        let mut sessions = self.sessions.lock().expect("terminal sessions lock");
+        let session = sessions
+            .get_mut(repo_id)
+            .ok_or_else(|| std::io::Error::other("no terminal session for this repository"))?;
+        session.writer.write_all(data)?;
+        session.writer.flush()
+    }
+
+    pub fn resize(&self, repo_id: &str, rows: u16, cols: u16) -> std::io::Result<()> {
+        let sessions = self.sessions.lock().expect("terminal sessions lock");
+        let session = sessions
+            .get(repo_id)
+            .ok_or_else(|| std::io::Error::other("no terminal session for this repository"))?;
+        session
+            .master
+            .resize(portable_pty::PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|e| std::io::Error::other(format!("could not resize the pty: {e}")))
+    }
+
+    /// Kill the shell and forget the session.
+    ///
+    /// Idempotent — killing a child that has already exited is not an error,
+    /// and neither is closing nothing.
+    pub fn close(&self, repo_id: &str) {
+        // Removed from the map BEFORE the kill, and the lock dropped before the
+        // wait: `wait` blocks, and holding the sessions mutex across it would
+        // stall every other repository's terminal behind this one.
+        let session = self
+            .sessions
+            .lock()
+            .expect("terminal sessions lock")
+            .remove(repo_id);
+        if let Some(mut session) = session {
+            let _ = session.child.kill();
+            // Reap, so the dying shell does not become a zombie. The reader
+            // thread ends on its own once the master reports EOF.
+            let _ = session.child.wait();
+        }
+    }
+
+    pub fn is_open(&self, repo_id: &str) -> bool {
+        self.sessions
+            .lock()
+            .expect("terminal sessions lock")
+            .contains_key(repo_id)
+    }
+
+    /// Close every session. Called when the window goes away, so no shell
+    /// outlives the app that hosts it.
+    pub fn close_all(&self) {
+        let ids: Vec<String> = self
+            .sessions
+            .lock()
+            .expect("terminal sessions lock")
+            .keys()
+            .cloned()
+            .collect();
+        for id in ids {
+            self.close(&id);
+        }
+    }
+
+    /// Drop the session `epoch` belongs to, if it is still the current one, and
+    /// return its exit code.
+    ///
+    /// The epoch check is the fence. A reader that reaches EOF just after the
+    /// user closed and reopened the terminal would otherwise remove the NEW
+    /// session — killing a shell the user is looking at, from a thread that
+    /// belongs to a dead one.
+    fn retire(&self, repo_id: &str, epoch: u64) -> Option<i32> {
+        let mut sessions = self.sessions.lock().expect("terminal sessions lock");
+        match sessions.get(repo_id) {
+            Some(s) if s.epoch == epoch => {}
+            _ => return None,
+        }
+        let mut session = sessions.remove(repo_id)?;
+        drop(sessions);
+        session
+            .child
+            .wait()
+            .ok()
+            .map(|status| status.exit_code() as i32)
+    }
+}
+
+/// One blocking reader thread per session.
+///
+/// A free function rather than a method so it cannot accidentally capture the
+/// sessions mutex: reading under that lock would serialise every terminal in
+/// the app behind the slowest one, and would deadlock the first `write` that
+/// arrived during a read. A pty read does not return while the shell lives, so
+/// this genuinely has to be a thread — polling it with a deadline hangs inside
+/// the read.
+fn spawn_reader(
+    state: Arc<TerminalState>,
+    sink: EventSink,
+    repo_id: String,
+    epoch: u64,
+    mut reader: Box<dyn Read + Send>,
+) {
+    std::thread::Builder::new()
+        .name(format!("pty-reader-{epoch}"))
+        .spawn(move || {
+            let mut buf = [0u8; 8192];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => sink(TermEvent::Data(TermData {
+                        repo_id: repo_id.clone(),
+                        epoch,
+                        data: base64::engine::general_purpose::STANDARD.encode(&buf[..n]),
+                    })),
+                }
+            }
+            // EOF means the shell is gone. Retire under the epoch fence FIRST,
+            // then report, so `is_open` is already false by the time the
+            // frontend reacts to the exit.
+            let code = state.retire(&repo_id, epoch);
+            sink(TermEvent::Exit(TermExit {
+                repo_id,
+                epoch,
+                code,
+            }));
+        })
+        .expect("spawn a pty reader thread");
+}

--- a/src-tauri/tests/spawn_no_window.rs
+++ b/src-tauri/tests/spawn_no_window.rs
@@ -219,6 +219,32 @@ fn the_console_keeping_exceptions_are_exactly_the_allow_listed_ones() {
     }
 }
 
+/// The pty half of the same rule (#243).
+///
+/// `portable_pty` spawns through its own `CommandBuilder`, not
+/// `std::process::Command`, so the `Command::new` guard above cannot see it at
+/// all. A pty opened anywhere but `proc.rs` would therefore be a second spawn
+/// path with NO guard on it — precisely the state issue 172 found the tree in,
+/// and the reason `spawn_pty_shell` owns the whole operation (openpty, the
+/// builder, and the spawn) rather than just handing out a builder.
+#[test]
+fn the_pty_spawn_lives_only_in_the_proc_module() {
+    const PTY_APIS: [&str; 3] = ["CommandBuilder::new", "openpty(", "spawn_command("];
+
+    for (rel, body) in sources() {
+        for api in PTY_APIS {
+            let found = count_code_occurrences(&body, api);
+            let expected = usize::from(rel == "src/proc.rs");
+            assert_eq!(
+                found, expected,
+                "{rel} uses `{api}` {found} time(s), expected {expected}. The \
+                 whole pty spawn belongs in src/proc.rs::spawn_pty_shell — a \
+                 second one would be covered by no guard in this file."
+            );
+        }
+    }
+}
+
 #[test]
 fn the_windows_creation_flag_is_set_in_one_place_only() {
     // The pre-172 state was one hand-rolled `creation_flags(0x0800_0000)` in

--- a/src-tauri/tests/terminal.rs
+++ b/src-tauri/tests/terminal.rs
@@ -1,0 +1,386 @@
+//! The built-in terminal (#243), tested against real ptys.
+//!
+//! Every assertion here is "the marker eventually appears", never "this read
+//! equals": a pty delivers in chunks whose boundaries are not ours to choose,
+//! and a shell prints a prompt, echoes the input and prints the output in an
+//! order that is the shell's business, not the test's.
+//!
+//! Two traps these tests were written around, both of which cost a debugging
+//! round and are the reason the helpers look the way they do:
+//!
+//! 1. **A pty echoes its input.** A marker that also appears in the command
+//!    text matches the echo, so the assertion passes before the shell has run
+//!    anything at all. Every marker here is either an expanded value or a
+//!    string that cannot appear in what was typed.
+//! 2. **`read` on a pty master does not return while the shell lives.** A
+//!    `while Instant::now() < deadline { reader.read(..) }` loop hangs forever
+//!    inside the read, because the deadline is only checked between reads. So
+//!    reading happens on a thread and the test waits on a channel — which is
+//!    also exactly why `TerminalState` gives every session its own reader
+//!    thread rather than polling.
+
+use std::io::{Read, Write};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+/// Drain `reader` on a thread, forwarding every chunk as a lossy string.
+///
+/// The receiver ends when the shell exits and the master reports EOF.
+fn drain(mut reader: Box<dyn Read + Send>) -> mpsc::Receiver<String> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut buf = [0u8; 4096];
+        while let Ok(n) = reader.read(&mut buf) {
+            if n == 0 || tx.send(String::from_utf8_lossy(&buf[..n]).into_owned()).is_err() {
+                break;
+            }
+        }
+    });
+    rx
+}
+
+/// Accumulate from `rx` until `marker` appears or `secs` elapse.
+fn read_until(rx: &mpsc::Receiver<String>, marker: &str, secs: u64) -> String {
+    let deadline = Instant::now() + Duration::from_secs(secs);
+    let mut acc = String::new();
+    while Instant::now() < deadline {
+        match rx.recv_timeout(Duration::from_millis(200)) {
+            Ok(chunk) => {
+                acc.push_str(&chunk);
+                if acc.contains(marker) {
+                    return acc;
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    acc
+}
+
+/// The shell these tests drive.
+///
+/// Deliberately NOT `proc::default_shell()`, which is `$SHELL` — the developer's
+/// own interactive shell, with their rc files. Two reasons, both learned the
+/// hard way: a themed zsh resets the line editor as it starts and DISCARDS
+/// input already buffered in the pty, so the test hangs against one machine's
+/// dotfiles and passes on another; and a suite whose result depends on who is
+/// running it is not a suite. `/bin/sh` reads what is waiting for it.
+///
+/// `default_shell()` itself is pinned by `default_shell_prefers_the_users_shell`
+/// below, which is the part of it worth testing.
+#[cfg(unix)]
+const TEST_SHELL: &str = "/bin/sh";
+
+#[cfg(unix)]
+#[test]
+fn spawn_pty_shell_runs_in_the_given_workdir() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Canonicalise: macOS hands out /var/folders/… which is a symlink to
+    // /private/var/folders/…, and the shell reports the resolved one.
+    let workdir = dir.path().canonicalize().expect("canonicalize");
+
+    let mut session = platypusgit_lib::proc::spawn_pty_shell(
+        std::ffi::OsStr::new(TEST_SHELL),
+        &workdir,
+        24,
+        80,
+    )
+    .expect("spawn a shell");
+
+    let rx = drain(session.master.try_clone_reader().expect("reader"));
+    let mut writer = session.master.take_writer().expect("writer");
+
+    writeln!(writer, "printf 'PGIT[%s]END\\n' \"$PWD\"").expect("write");
+    writer.flush().expect("flush");
+
+    // The EXPANDED path — see trap 1 in the module doc. `PGIT[%s]END` is on the
+    // stream as an echo before the shell has run anything.
+    let expected = format!("PGIT[{}]END", workdir.display());
+    let out = read_until(&rx, &expected, 15);
+
+    let _ = session.child.kill();
+    let _ = session.child.wait();
+
+    assert!(
+        out.contains(&expected),
+        "the shell's cwd should be the workdir. saw: {out}"
+    );
+}
+
+/// `$SHELL` is what the user's own terminal runs, and the built-in terminal
+/// should not be a *different* shell from the one outside the app.
+#[cfg(unix)]
+#[test]
+fn default_shell_prefers_the_users_shell() {
+    let shell = platypusgit_lib::proc::default_shell();
+    match std::env::var_os("SHELL").filter(|s| !s.is_empty()) {
+        Some(expected) => assert_eq!(shell, expected),
+        // No `$SHELL` (a bare CI container): the honest last resort, not empty.
+        None => assert_eq!(shell, std::ffi::OsString::from("/bin/sh")),
+    }
+}
+
+#[test]
+fn spawn_pty_shell_rejects_a_shell_that_does_not_exist() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let err = platypusgit_lib::proc::spawn_pty_shell(
+        std::ffi::OsStr::new("/nonexistent/pgit-not-a-shell"),
+        dir.path(),
+        24,
+        80,
+    );
+    assert!(err.is_err(), "a missing shell must not silently succeed");
+}
+
+// ---------------------------------------------------------------------------
+// The session registry
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+mod registry {
+    use super::TEST_SHELL;
+    use platypusgit_lib::terminal::{EventSink, TermEvent, TerminalState};
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
+
+    /// A sink that records every event, so a test can assert on the stream the
+    /// frontend would receive rather than on the pty directly. This is the
+    /// whole reason `terminal.rs` takes a sink instead of an `AppHandle`.
+    #[derive(Default, Clone)]
+    struct Recorder(Arc<Mutex<Vec<TermEvent>>>);
+
+    impl Recorder {
+        fn sink(&self) -> EventSink {
+            let inner = self.0.clone();
+            Arc::new(move |ev| inner.lock().expect("sink lock").push(ev))
+        }
+
+        /// Everything decoded from `Data` events so far, concatenated. Decoding
+        /// here is also the assertion that the payload really is base64.
+        fn text(&self) -> String {
+            use base64::Engine as _;
+            let bytes: Vec<u8> = self
+                .0
+                .lock()
+                .expect("lock")
+                .iter()
+                .filter_map(|e| match e {
+                    TermEvent::Data(p) => Some(
+                        base64::engine::general_purpose::STANDARD
+                            .decode(&p.data)
+                            .expect("the payload is base64"),
+                    ),
+                    TermEvent::Exit(_) => None,
+                })
+                .flatten()
+                .collect();
+            String::from_utf8_lossy(&bytes).into_owned()
+        }
+
+        fn saw_exit(&self) -> bool {
+            self.0
+                .lock()
+                .expect("lock")
+                .iter()
+                .any(|e| matches!(e, TermEvent::Exit(_)))
+        }
+
+        /// The first `Data` payload as the frontend would receive it.
+        fn first_data_json(&self) -> Option<serde_json::Value> {
+            self.0.lock().expect("lock").iter().find_map(|e| match e {
+                TermEvent::Data(p) => Some(serde_json::to_value(p).expect("serialise")),
+                TermEvent::Exit(_) => None,
+            })
+        }
+    }
+
+    /// Poll until `f` is true or the deadline passes. A pty is asynchronous; a
+    /// fixed sleep is either flaky or slow, and this is neither.
+    fn wait_for(secs: u64, mut f: impl FnMut() -> bool) -> bool {
+        let deadline = Instant::now() + Duration::from_secs(secs);
+        while Instant::now() < deadline {
+            if f() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        false
+    }
+
+    fn open_in_tempdir(
+        state: &Arc<TerminalState>,
+        rec: &Recorder,
+        id: &str,
+    ) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        state
+            .open(
+                rec.sink(),
+                id,
+                std::ffi::OsStr::new(TEST_SHELL),
+                dir.path(),
+                24,
+                80,
+            )
+            .expect("open a session");
+        dir
+    }
+
+    #[test]
+    fn output_reaches_the_sink_as_base64() {
+        let state = Arc::new(TerminalState::default());
+        let rec = Recorder::default();
+        let _dir = open_in_tempdir(&state, &rec, "repo-a");
+
+        state.write("repo-a", b"echo pgit-ok\n").expect("write");
+
+        assert!(
+            wait_for(15, || rec.text().contains("pgit-ok")),
+            "the marker should reach the sink. saw: {}",
+            rec.text()
+        );
+        state.close("repo-a");
+    }
+
+    /// The wire format is FLAT and camelCase, and this is the test that would
+    /// have caught the bug that cost an e2e debugging round.
+    ///
+    /// `TermEvent` used to be a struct-variant enum, and serde tags an enum
+    /// externally: the payload went out as `{"data": {"repoId": …}}` instead of
+    /// `{"repoId": …}`. The frontend's first line is `payload.repoId !== repoId`
+    /// — `undefined !== "…"` for every event — so the shell ran and not one
+    /// byte was ever displayed, with no error anywhere, because dropping
+    /// another repository's traffic is what that line is FOR.
+    ///
+    /// Nothing in the Rust suite or the vitest suite could see it: one side
+    /// never serialised, the other mocked the payload in the shape it wanted.
+    #[test]
+    fn the_wire_payload_is_flat_and_camel_case() {
+        let state = Arc::new(TerminalState::default());
+        let rec = Recorder::default();
+        let _dir = open_in_tempdir(&state, &rec, "repo-a");
+
+        state.write("repo-a", b"echo shape\n").expect("write");
+        assert!(wait_for(15, || rec.first_data_json().is_some()));
+
+        let json = rec.first_data_json().expect("a data event");
+        let obj = json.as_object().expect("an object");
+        assert!(
+            obj.contains_key("repoId"),
+            "the payload must carry repoId at the TOP level, not nested under a \
+             variant tag. got: {json}"
+        );
+        assert!(obj.contains_key("epoch"), "got: {json}");
+        assert!(obj.contains_key("data"), "got: {json}");
+        assert_eq!(obj["repoId"], "repo-a");
+        // And no variant tag wrapping it.
+        assert!(
+            !obj.contains_key("Data") && !obj.contains_key("data0"),
+            "the enum must not be serialised — emit the inner struct. got: {json}"
+        );
+        state.close("repo-a");
+    }
+
+    #[test]
+    fn two_repositories_get_two_independent_sessions() {
+        let state = Arc::new(TerminalState::default());
+        let a = Recorder::default();
+        let b = Recorder::default();
+        let _da = open_in_tempdir(&state, &a, "repo-a");
+        let _db = open_in_tempdir(&state, &b, "repo-b");
+
+        state.write("repo-a", b"echo only-a\n").expect("write a");
+        assert!(wait_for(15, || a.text().contains("only-a")));
+
+        // Closing one must not touch the other.
+        state.close("repo-a");
+        assert!(!state.is_open("repo-a"));
+        assert!(state.is_open("repo-b"));
+
+        state.write("repo-b", b"echo still-b\n").expect("write b");
+        assert!(
+            wait_for(15, || b.text().contains("still-b")),
+            "repo-b should still be alive. saw: {}",
+            b.text()
+        );
+        assert!(
+            !a.text().contains("still-b"),
+            "sessions must not cross sinks"
+        );
+        state.close("repo-b");
+    }
+
+    #[test]
+    fn a_shell_that_exits_reports_and_is_reaped() {
+        let state = Arc::new(TerminalState::default());
+        let rec = Recorder::default();
+        let _dir = open_in_tempdir(&state, &rec, "repo-x");
+
+        state.write("repo-x", b"exit 3\n").expect("write");
+
+        assert!(
+            wait_for(15, || rec.saw_exit()),
+            "an exiting shell must produce an Exit event"
+        );
+        assert!(
+            wait_for(5, || !state.is_open("repo-x")),
+            "the session must retire itself once the shell is gone — no zombie, \
+             no leaked reader thread"
+        );
+    }
+
+    #[test]
+    fn opening_twice_yields_one_session() {
+        let state = Arc::new(TerminalState::default());
+        let rec = Recorder::default();
+        let dir = open_in_tempdir(&state, &rec, "repo-a");
+
+        // A panel re-mount must not stack shells.
+        state
+            .open(
+                rec.sink(),
+                "repo-a",
+                std::ffi::OsStr::new(TEST_SHELL),
+                dir.path(),
+                24,
+                80,
+            )
+            .expect("second open is a no-op");
+
+        state.write("repo-a", b"echo once\n").expect("write");
+        assert!(wait_for(15, || rec.text().contains("once")));
+
+        // One close is enough, because there is one session.
+        state.close("repo-a");
+        assert!(!state.is_open("repo-a"));
+    }
+
+    #[test]
+    fn closing_an_unknown_session_is_not_an_error() {
+        let state = Arc::new(TerminalState::default());
+        state.close("never-opened");
+        state.close("never-opened");
+        assert!(!state.is_open("never-opened"));
+    }
+
+    #[test]
+    fn writing_to_a_closed_session_errors_rather_than_panicking() {
+        let state = Arc::new(TerminalState::default());
+        assert!(state.write("nope", b"x").is_err());
+        assert!(state.resize("nope", 10, 10).is_err());
+    }
+
+    #[test]
+    fn close_all_leaves_nothing_running() {
+        let state = Arc::new(TerminalState::default());
+        let rec = Recorder::default();
+        let _a = open_in_tempdir(&state, &rec, "repo-a");
+        let _b = open_in_tempdir(&state, &rec, "repo-b");
+
+        state.close_all();
+
+        assert!(!state.is_open("repo-a"));
+        assert!(!state.is_open("repo-b"));
+    }
+}

--- a/src-tauri/tests/terminal_privacy.rs
+++ b/src-tauri/tests/terminal_privacy.rs
@@ -1,0 +1,102 @@
+//! The terminal never logs its traffic (#243).
+//!
+//! A terminal is where secrets get typed: a `sudo` password, a token pasted at
+//! a prompt, an SSH passphrase. The property we want is that bytes read from
+//! the pty reach exactly one destination — the event sink — and bytes written
+//! to it reach exactly one destination, the pty.
+//!
+//! Stated that way it is a property about what the source may CONTAIN, so it is
+//! a test over the source text, in the same shape as `spawn_no_window.rs` and
+//! `test/docs.test.ts`. The alternative — keeping it by care — is how these
+//! things get lost in the third refactor.
+//!
+//! The rule is deliberately blunt: `src/terminal.rs` contains no logging macro
+//! AT ALL. That is enforceable in four lines, whereas "no logging macro that
+//! mentions the buffer" is a judgement a grep cannot make. It costs nothing,
+//! because the lifecycle events worth logging (opened, exited, closed) are
+//! logged from `commands/terminal.rs`, which handles ids and exit codes and
+//! never sees a byte of traffic. That split is the whole design.
+
+use std::path::{Path, PathBuf};
+
+fn path(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn read(rel: &str) -> String {
+    let p = path(rel);
+    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()))
+}
+
+/// Comment lines are not code — without this, the module doc explaining the
+/// rule would count as breaking it. Same filter `spawn_no_window.rs` needs.
+fn is_comment(line: &str) -> bool {
+    let t = line.trim_start();
+    t.starts_with("//") || t.starts_with("/*") || t.starts_with('*')
+}
+
+fn code_lines(body: &str) -> impl Iterator<Item = &str> {
+    body.lines().filter(|l| !is_comment(l))
+}
+
+#[test]
+fn the_session_registry_logs_nothing() {
+    const LOGGERS: [&str; 7] = [
+        "log::",
+        "tracing::",
+        "println!",
+        "eprintln!",
+        "dbg!",
+        "info!",
+        "warn!",
+    ];
+    let body = read("src/terminal.rs");
+    for logger in LOGGERS {
+        let hits: Vec<&str> = code_lines(&body).filter(|l| l.contains(logger)).collect();
+        assert!(
+            hits.is_empty(),
+            "src/terminal.rs uses `{logger}`, and this module handles pty \
+             traffic — a password typed at a sudo prompt goes through it. \
+             Lifecycle logging belongs in commands/terminal.rs, which never \
+             sees a byte. Offending line(s): {hits:?}"
+        );
+    }
+}
+
+#[test]
+fn the_traffic_never_reaches_a_file_or_the_network() {
+    const EXFIL: [&str; 6] = [
+        "File::create",
+        "OpenOptions",
+        "fs::write",
+        "ureq",
+        "reqwest",
+        "TcpStream",
+    ];
+    let body = read("src/terminal.rs");
+    for needle in EXFIL {
+        assert!(
+            !code_lines(&body).any(|l| l.contains(needle)),
+            "src/terminal.rs mentions `{needle}`; pty traffic has exactly one \
+             destination and it is the event sink"
+        );
+    }
+}
+
+#[test]
+fn the_handlers_do_not_log_what_the_user_typed() {
+    // `term_write`'s payload travels TOWARD the shell — a sudo password goes
+    // this way. The handler may log that a write happened, never its content.
+    let rel = "src/commands/terminal.rs";
+    let body = read(rel);
+    let logging = |l: &&str| {
+        l.contains("log::") || l.contains("println!") || l.contains("tracing::")
+    };
+    for line in code_lines(&body).filter(logging) {
+        assert!(
+            !line.contains("data"),
+            "a log line in {rel} mentions `data`, which is what the user \
+             typed: {line}"
+        );
+    }
+}

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -59,6 +59,7 @@ import {
   type ActionId,
 } from "@/features/keymap";
 import { CommandPalette } from "@/features/palette/CommandPalette";
+import { TerminalPanel } from "@/features/terminal";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { BranchChip } from "@/features/branches/BranchChip";
 import { CloneDialog } from "@/features/create/CloneDialog";
@@ -690,6 +691,11 @@ function AppBody({
           }}
         >
           {screens[screen]}
+          {/* The terminal docks BELOW the routed screen and inside the same
+              column, so it spans the screen's width and not the activity bar's
+              (#243). This div is already a flex column, so the panel's fixed
+              height composes with the screen's `flex: 1` on its own. */}
+          <TerminalPanel />
         </div>
       </div>
     </div>

--- a/src/features/keymap/actions.ts
+++ b/src/features/keymap/actions.ts
@@ -14,6 +14,7 @@ import { useCreateTagStore } from "@/features/tags/useCreateTagStore";
 import { useForgeStore } from "@/features/forge/useForgeStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { usePaletteStore } from "@/features/palette/usePaletteStore";
+import { useTerminalStore } from "@/features/terminal/useTerminalStore";
 import {
   cloneRepoOp,
   fetchAllOp,
@@ -64,6 +65,7 @@ export type ActionId =
   | "view.zoomIn"
   | "view.zoomOut"
   | "view.zoomReset"
+  | "terminal.toggle"
   | "app.closeOverlay"
   | "pane.focusLeft"
   | "pane.focusRight"
@@ -261,6 +263,21 @@ export const ACTIONS: Record<ActionId, ActionDef> = {
     allowInInput: true,
     run: () => {
       useSettingsStore.getState().set("uiZoom", 1);
+      return true;
+    },
+  },
+
+  // The built-in terminal (#243). `allowInInput` because this is the ONE chord
+  // that must work from inside the terminal itself — it is the way back out,
+  // and xterm's textarea is an input as far as the dispatcher is concerned.
+  "terminal.toggle": {
+    id: "terminal.toggle",
+    title: "Toggle terminal",
+    category: "App",
+    scope: "global",
+    allowInInput: true,
+    run: () => {
+      useTerminalStore.getState().toggle();
       return true;
     },
   },

--- a/src/features/keymap/presets.ts
+++ b/src/features/keymap/presets.ts
@@ -59,6 +59,9 @@ const COMMON = {
   "view.zoomIn": ["Mod+=", "Mod++"],
   "view.zoomOut": ["Mod+-", "Mod+_"],
   "view.zoomReset": ["Mod+0"],
+  // The editor-standard terminal chord, and Mod+` as the second because a
+  // bare Ctrl+` is awkward on layouts where the backtick needs AltGr.
+  "terminal.toggle": ["Ctrl+`", "Mod+`"],
   "pane.focusLeft": ["Alt+ArrowLeft"],
   "pane.focusRight": ["Alt+ArrowRight"],
   "pane.focusUp": ["Alt+ArrowUp"],

--- a/src/features/keymap/useKeymapStore.ts
+++ b/src/features/keymap/useKeymapStore.ts
@@ -35,6 +35,31 @@ function isEditable(t: EventTarget | null): boolean {
   );
 }
 
+/**
+ * Whether the event came from inside the built-in terminal (#243).
+ *
+ * xterm renders a hidden `<textarea>`, so `isEditable` already suppresses bare
+ * chords there. It does NOT suppress MODIFIER chords — and those are exactly
+ * the ones a shell needs: Ctrl+C to interrupt, Ctrl+D for EOF, Ctrl+R for
+ * history search, Ctrl+A/E to move. A terminal that sends Ctrl+C to the command
+ * palette instead of the foreground process is worse than no terminal.
+ *
+ * So everything typed in there belongs to the shell, with exactly two
+ * exceptions in [`TERMINAL_ESCAPES`]: the chord that hides the panel, which is
+ * the way back out, and the overlay escape, so a cheat sheet opened over the
+ * terminal can still be dismissed.
+ */
+function inTerminal(t: EventTarget | null): boolean {
+  const el = t as HTMLElement | null;
+  return !!el?.closest?.("[data-testid='terminal-view']");
+}
+
+/** The only actions a key press inside the terminal may reach. */
+const TERMINAL_ESCAPES: ReadonlySet<string> = new Set([
+  "terminal.toggle",
+  "app.closeOverlay",
+]);
+
 function hasRealModifier(chord: string): boolean {
   return (
     chord.startsWith("Mod+") ||
@@ -201,10 +226,15 @@ export const useKeymapStore = create<KeymapState>((set, get) => {
 
       const editable = isEditable(e.target);
       const modChord = hasRealModifier(chord);
+      const terminal = inTerminal(e.target);
       const focusedPane = useFocusStore.getState().focused;
 
       for (const id of ids) {
         const def = ACTIONS[id];
+        // Inside the terminal the shell owns the keyboard — see `inTerminal`.
+        // This is checked BEFORE the input rules because it is stricter than
+        // them: `allowInInput` is not a licence to steal Ctrl+C from a shell.
+        if (terminal && !TERMINAL_ESCAPES.has(id)) continue;
         if (editable && def.suppressInInput) continue;
         if (editable && !modChord && !def.allowInInput) continue;
 

--- a/src/features/repo/useTabsStore.ts
+++ b/src/features/repo/useTabsStore.ts
@@ -31,7 +31,8 @@ import {
   closeMergeWindow,
   mergeWindowHoldsRepo,
 } from "@/features/merge/openMergeWindow";
-import { closeRepo as closeRepoIpc, getStatus } from "@/lib/tauri";
+import { closeRepo as closeRepoIpc, getStatus, termClose } from "@/lib/tauri";
+import { useTerminalStore } from "@/features/terminal/useTerminalStore";
 import type { RepoHandle } from "@/lib/types";
 import { isConflicted, isStaged, isUnstaged } from "@/lib/derive";
 import { warn as logWarn } from "@tauri-apps/plugin-log";
@@ -210,6 +211,16 @@ export const useTabsStore = create<TabsState>((set, get) => {
 
   const evict = (tab: RepoTab | null) => {
     if (!tab?.repoId) return;
+    // The shell belongs to the tab (#243). Done HERE rather than in `close` so
+    // every eviction route is covered — `closeOthers` and `closeAll` delegate
+    // to `close`, but the displaced-tab path at the LRU cap does not, and an
+    // orphaned interactive shell is invisible except in a process list.
+    // `term_close` is idempotent, so a tab that never opened a terminal costs
+    // one no-op invoke.
+    void termClose(tab.repoId).catch((e) => {
+      logWarn(`term_close failed for ${tab.path}: ${describeError(e)}`);
+    });
+    useTerminalStore.getState().forget(tab.repoId);
     void closeRepoIpc(tab.repoId).catch((e) => {
       // The tab is going away either way; a failed eviction is a leak, not a
       // thing to interrupt the user about.

--- a/src/features/settings/useSettingsStore.export.test.ts
+++ b/src/features/settings/useSettingsStore.export.test.ts
@@ -109,7 +109,10 @@ const PORTABLE = [
 // people share, and every other key in the bag says how the app should behave —
 // this one is a list of someone's name and email addresses. It is also useless
 // on the receiving machine, since identities are per-person by definition.
-const EXCLUDED = ["lastCreateDir", "identities"];
+// `terminalShell` (#243) is a PATH to a binary on this machine, so it is denied
+// for the same reason `lastCreateDir` is — see NON_PORTABLE_KEYS for the
+// contrast with `externalDiffTool`, which holds a tool name and does travel.
+const EXCLUDED = ["lastCreateDir", "identities", "terminalShell"];
 
 describe("the exported key set", () => {
   it("is exactly the schema minus the deny-list", async () => {

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -893,6 +893,18 @@ interface PersistedState {
    */
   watchFilesystem: boolean;
   /**
+   * The shell the built-in terminal runs (#243). Blank means the backend
+   * decides: `$SHELL` then `/bin/sh` on unix, PowerShell on Windows.
+   *
+   * A free text field rather than a picker of installed shells. Enumerating
+   * them would mean probing the filesystem for a list that is never complete —
+   * nu, fish and a nix-store path are all reasonable answers — and the people
+   * who want one of those know where it lives. Blank is the honest default
+   * because the built-in terminal should be the SAME shell as the one outside
+   * the app, not a second opinion about it.
+   */
+  terminalShell: string;
+  /**
    * Whether the commit BODY is rendered as restrained markdown (#253).
    *
    * A preference rather than a per-visit toggle, for the reason `diffViewMode`
@@ -1036,6 +1048,7 @@ const DEFAULTS: PersistedState = {
   ignoreWhitespaceInDiff: false,
   externalDiffTool: "",
   watchFilesystem: true,
+  terminalShell: "",
   commitBodyMarkdown: true,
   identities: [],
   rebaseUpdateRefs: "config",
@@ -1094,6 +1107,19 @@ export const NON_PORTABLE_KEYS: readonly (keyof PersistedState)[] = [
    * since identities are per-person by definition.
    */
   "identities",
+  /**
+   * The terminal's shell (#243). Denied because it is a PATH to a binary on
+   * this machine: `/opt/homebrew/bin/fish` does not exist on a colleague's
+   * Linux box, and `pwsh.exe` does not exist anywhere but Windows. Importing
+   * one would replace a working default with a `TerminalUnavailable` on first
+   * open.
+   *
+   * The contrast with `externalDiffTool`, which IS portable, is the useful one:
+   * that field holds a tool NAME that git resolves per machine, this one holds
+   * an absolute path we hand straight to a spawn. Blank — the default — is the
+   * portable answer, and it is what an import leaves in place.
+   */
+  "terminalShell",
 ];
 
 /** `DEFAULTS`' keys minus the deny-list — exactly what an export carries. */

--- a/src/features/terminal/TerminalPanel.test.tsx
+++ b/src/features/terminal/TerminalPanel.test.tsx
@@ -1,0 +1,183 @@
+// The docked terminal panel (#243).
+//
+// TerminalView is mocked here: it owns an xterm instance and a session, and
+// what this file is about is the MOUNTING decisions — when a view exists at
+// all, and which one is visible. Those carry the feature's least obvious rule:
+// a view is hidden, never unmounted, because unmounting disposes xterm and
+// takes the scrollback with it. The shell would survive and the user would
+// still reopen the panel to a blank pane.
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Counts MOUNTS per repo, so "was it unmounted and rebuilt?" is directly
+// observable — which is the whole property this file exists to pin. Recorded
+// from an effect with empty deps, not from the component body: a body re-runs
+// on every render and would count those too.
+const mounts: string[] = [];
+
+vi.mock("./TerminalView", async () => {
+  const React = await import("react");
+  return {
+    TerminalView: ({
+      repoId,
+      hidden,
+    }: {
+      repoId: string;
+      hidden?: boolean;
+    }) => {
+      React.useEffect(() => {
+        mounts.push(repoId);
+      }, [repoId]);
+      return (
+        <div
+          data-testid="terminal-view"
+          data-repo-id={repoId}
+          data-hidden={hidden ? "true" : "false"}
+        >
+          {repoId}
+        </div>
+      );
+    },
+  };
+});
+
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { TerminalPanel } from "./TerminalPanel";
+import { DEFAULT_HEIGHT, useTerminalStore } from "./useTerminalStore";
+
+const repo = (id: string) => ({ id, path: `/tmp/${id}`, head: "main" });
+
+const views = () =>
+  screen.queryAllByTestId("terminal-view").map((el) => ({
+    id: el.getAttribute("data-repo-id"),
+    hidden: el.getAttribute("data-hidden") === "true",
+  }));
+
+beforeEach(() => {
+  localStorage.clear();
+  mounts.length = 0;
+  useTerminalStore.setState({
+    open: false,
+    heightPx: DEFAULT_HEIGHT,
+    epochs: {},
+  });
+  useSettingsStore.getState().reset();
+  useRepoStore.setState({ current: repo("r1") } as never);
+});
+
+describe("when nothing has been opened", () => {
+  it("renders nothing, and spawns no shell", () => {
+    const { container } = render(<TerminalPanel />);
+    expect(container).toBeEmptyDOMElement();
+    expect(mounts).toEqual([]);
+  });
+
+  it("renders nothing with no repository open — there is nowhere to cd to", () => {
+    useRepoStore.setState({ current: null } as never);
+    useTerminalStore.setState({ open: true });
+    const { container } = render(<TerminalPanel />);
+    expect(container).toBeEmptyDOMElement();
+    expect(mounts).toEqual([]);
+  });
+});
+
+describe("when the panel is open", () => {
+  beforeEach(() => {
+    useTerminalStore.setState({ open: true });
+  });
+
+  it("mounts a visible view for the active repository", () => {
+    render(<TerminalPanel />);
+    expect(views()).toEqual([{ id: "r1", hidden: false }]);
+  });
+
+  it("takes its height from the store", () => {
+    useTerminalStore.setState({ heightPx: 321 });
+    render(<TerminalPanel />);
+    expect(screen.getByTestId("terminal-panel")).toHaveStyle({
+      height: "321px",
+    });
+  });
+
+  it("names the shell, so a slow rc file reads as the shell starting", () => {
+    render(<TerminalPanel />);
+    expect(screen.getByTestId("terminal-shell-label")).toHaveTextContent(
+      "default shell",
+    );
+  });
+});
+
+describe("keeping the scrollback", () => {
+  it("hides rather than unmounts when the panel is collapsed", () => {
+    useTerminalStore.setState({ open: true, epochs: { r1: 1 } });
+    const { rerender } = render(<TerminalPanel />);
+    expect(mounts).toEqual(["r1"]);
+
+    useTerminalStore.setState({ open: false });
+    rerender(<TerminalPanel />);
+
+    // Still there — disposing it would take the scrollback with it.
+    expect(screen.getByTestId("terminal-view")).toBeInTheDocument();
+    expect(screen.getByTestId("terminal-panel")).not.toBeVisible();
+    // And it was never re-created, which is what proves it was not unmounted.
+    expect(mounts).toEqual(["r1"]);
+  });
+
+  it("keeps an inactive tab's terminal mounted but hidden", () => {
+    useTerminalStore.setState({ open: true, epochs: { r1: 1 } });
+    const { rerender } = render(<TerminalPanel />);
+
+    useRepoStore.setState({ current: repo("r2") } as never);
+    rerender(<TerminalPanel />);
+
+    // r1's shell is still alive, so its view stays — hidden. r2 gets its own.
+    expect(views()).toEqual([
+      { id: "r1", hidden: true },
+      { id: "r2", hidden: false },
+    ]);
+  });
+
+  it("returns to the same instance when the user switches back", () => {
+    useTerminalStore.setState({ open: true, epochs: { r1: 1 } });
+    const { rerender } = render(<TerminalPanel />);
+
+    useRepoStore.setState({ current: repo("r2") } as never);
+    useTerminalStore.setState({ epochs: { r1: 1, r2: 2 } });
+    rerender(<TerminalPanel />);
+
+    useRepoStore.setState({ current: repo("r1") } as never);
+    rerender(<TerminalPanel />);
+
+    expect(views()).toEqual([
+      { id: "r1", hidden: false },
+      { id: "r2", hidden: true },
+    ]);
+    // Each was created exactly once across the whole round trip.
+    expect(mounts).toEqual(["r1", "r2"]);
+  });
+
+  it("drops a repository's view once its session is forgotten", () => {
+    useTerminalStore.setState({ open: true, epochs: { r1: 1, r2: 2 } });
+    useRepoStore.setState({ current: repo("r1") } as never);
+    const { rerender } = render(<TerminalPanel />);
+    expect(views()).toHaveLength(2);
+
+    // What `useTabsStore.evict` does when a repository tab closes.
+    useTerminalStore.getState().forget("r2");
+    rerender(<TerminalPanel />);
+
+    expect(views()).toEqual([{ id: "r1", hidden: false }]);
+  });
+});
+
+describe("hiding the panel", () => {
+  it("does not kill the session", () => {
+    useTerminalStore.setState({ open: true, epochs: { r1: 1 } });
+    render(<TerminalPanel />);
+    screen.getByTitle("Hide terminal").click();
+    expect(useTerminalStore.getState().open).toBe(false);
+    // The epochs map is what tracks live sessions; hiding must not touch it.
+    expect(useTerminalStore.getState().epochs).toEqual({ r1: 1 });
+  });
+});

--- a/src/features/terminal/TerminalPanel.tsx
+++ b/src/features/terminal/TerminalPanel.tsx
@@ -1,0 +1,97 @@
+import { PGIcon, PGIconButton, PGResizeHandle } from "@/design";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { DEFAULT_HEIGHT, useTerminalStore } from "./useTerminalStore";
+import { TerminalView } from "./TerminalView";
+import { shellLabel } from "./shellLabel";
+
+/**
+ * The docked terminal, below the active screen (#243).
+ *
+ * # Why this hides with CSS instead of unmounting
+ *
+ * Unmounting disposes the xterm instance, and with it the SCROLLBACK. The shell
+ * itself survives — the backend session is not tied to the view — but the user
+ * would reopen the panel to a blank pane attached to a live shell, with the
+ * build output they were reading gone. That makes "hiding the panel leaves the
+ * shell running" a promise that is technically kept and practically broken.
+ *
+ * So every repository with a live session keeps its view mounted, and only the
+ * active one is visible. A tab switch then returns to the scrollback it left,
+ * which is what every other terminal does.
+ *
+ * Nothing is mounted before the panel is first opened, so the "closed by
+ * default, no shell nobody asked for" rule survives: a view only exists for a
+ * repository that has been the active one while the panel was open.
+ */
+export function TerminalPanel() {
+  const open = useTerminalStore((s) => s.open);
+  const heightPx = useTerminalStore((s) => s.heightPx);
+  const setHeight = useTerminalStore((s) => s.setHeight);
+  const setOpen = useTerminalStore((s) => s.setOpen);
+  const epochs = useTerminalStore((s) => s.epochs);
+  const repo = useRepoStore((s) => s.current);
+  const shell = useSettingsStore((s) => s.terminalShell);
+
+  // Every repository whose shell is alive, plus the active one when the panel
+  // is open — that last part is what CREATES the first session.
+  const live = Object.keys(epochs);
+  const mounted =
+    open && repo && !live.includes(repo.id) ? [...live, repo.id] : live;
+
+  // Nothing to show and nothing to keep alive.
+  if (mounted.length === 0) return null;
+
+  return (
+    <div
+      data-testid="terminal-panel"
+      // `hidden` rather than unmounting — see the note above. The attribute as
+      // well as the style so a test can read the intent.
+      hidden={!open}
+      style={{
+        display: open ? "flex" : "none",
+        height: heightPx,
+        flexShrink: 0,
+        flexDirection: "column",
+        borderTop: "1px solid var(--border-1)",
+        background: "var(--bg-0)",
+      }}
+    >
+      <PGResizeHandle
+        orientation="vertical"
+        side="top"
+        testId="terminal-resize"
+        // The handle is on TOP of the panel, so dragging up (negative dy) has
+        // to make it taller. Hence the subtraction.
+        onDrag={(dy) => setHeight(heightPx - dy)}
+        onReset={() => setHeight(DEFAULT_HEIGHT)}
+      />
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "2px 8px",
+          fontSize: "var(--fs-11)",
+          color: "var(--fg-3)",
+          flexShrink: 0,
+        }}
+      >
+        <PGIcon name="terminal" />
+        {/* Naming the shell is what makes a slow `.zshrc` read as "zsh is
+            starting" rather than as the app hanging. */}
+        <span data-testid="terminal-shell-label">{shellLabel(shell)}</span>
+        <span style={{ flex: 1 }} />
+        <PGIconButton
+          icon="x"
+          size="sm"
+          title="Hide terminal"
+          onClick={() => setOpen(false)}
+        />
+      </div>
+      {mounted.map((id) => (
+        <TerminalView key={id} repoId={id} hidden={id !== repo?.id} />
+      ))}
+    </div>
+  );
+}

--- a/src/features/terminal/TerminalView.test.tsx
+++ b/src/features/terminal/TerminalView.test.tsx
@@ -1,0 +1,295 @@
+// The terminal view (#243).
+//
+// xterm itself is mocked: it needs a real layout engine and this is jsdom, and
+// what is worth testing here is not "does xterm render" (that is the e2e spec's
+// one job) but the WIRING — which is where the bugs are. Specifically the three
+// things a careless refactor breaks silently: that output is base64-decoded
+// rather than written as text, that another session's events are dropped, and
+// that unmounting does not leak a listener.
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const onDataHandlers: Array<(s: string) => void> = [];
+const written: Array<Uint8Array | string> = [];
+const disposed = vi.fn();
+const resized = vi.fn();
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class {
+    cols = 80;
+    rows = 24;
+    open() {}
+    onData(cb: (s: string) => void) {
+      onDataHandlers.push(cb);
+      return { dispose: vi.fn() };
+    }
+    write(d: Uint8Array | string) {
+      written.push(d);
+    }
+    resize(c: number, r: number) {
+      resized(c, r);
+      this.cols = c;
+      this.rows = r;
+    }
+    focus() {}
+    dispose() {
+      disposed();
+    }
+  },
+}));
+
+// The css import has no loader in the vitest env.
+vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
+
+import { emitMockEvent } from "@/test/eventMock";
+import { mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { TerminalView } from "./TerminalView";
+import { useTerminalStore } from "./useTerminalStore";
+
+/** Decode what the view handed xterm, so assertions read as text. */
+const writtenText = () =>
+  written
+    .map((w) =>
+      typeof w === "string" ? w : new TextDecoder().decode(w),
+    )
+    .join("");
+
+const b64 = (s: string) => btoa(s);
+
+beforeEach(() => {
+  onDataHandlers.length = 0;
+  written.length = 0;
+  vi.clearAllMocks();
+  resetInvokeMock();
+  localStorage.clear();
+  useTerminalStore.setState({ epochs: {} });
+  mockInvoke("term_open", () => 7);
+  mockInvoke("term_write", () => null);
+  mockInvoke("term_resize", () => null);
+  mockInvoke("term_close", () => null);
+});
+
+describe("TerminalView", () => {
+  it("opens a session for its own repository", async () => {
+    render(<TerminalView repoId="repo-a" />);
+    await waitFor(() =>
+      expect(useTerminalStore.getState().epochs["repo-a"]).toBe(7),
+    );
+  });
+
+  it("forwards what the user types to the pty", async () => {
+    const calls: unknown[] = [];
+    mockInvoke("term_write", (args) => {
+      calls.push(args);
+      return null;
+    });
+    render(<TerminalView repoId="repo-a" />);
+    await waitFor(() => expect(onDataHandlers.length).toBeGreaterThan(0));
+
+    onDataHandlers[0]("ls\r");
+
+    await waitFor(() =>
+      expect(calls).toContainEqual({ repoId: "repo-a", data: "ls\r" }),
+    );
+  });
+
+  it("sends keystrokes in order even when the IPC calls resolve out of order", async () => {
+    // The regression this exists for: one un-awaited `term_write` per
+    // keystroke lets the invokes race, and the pty receives whatever order
+    // they land in. Typing `echo ZZMARKER` into the real app reached the shell
+    // as `ecoZARhR ZMKE`.
+    const order: string[] = [];
+    // A holder rather than a bare `let`: TypeScript cannot see the assignment
+    // inside the promise callback and narrows a `let … = null` to `never` at
+    // the call site below.
+    const gate: { release?: () => void } = {};
+    mockInvoke("term_write", (args) => {
+      const data = (args as { data: string }).data;
+      order.push(data);
+      // Make the FIRST call the slowest, so an unordered implementation
+      // finishes the later ones first and records them out of order.
+      if (data === "a") {
+        return new Promise<null>((res) => {
+          gate.release = () => res(null);
+        });
+      }
+      return null;
+    });
+
+    render(<TerminalView repoId="repo-a" />);
+    await waitFor(() => expect(onDataHandlers.length).toBeGreaterThan(0));
+
+    onDataHandlers[0]("a");
+    onDataHandlers[0]("b");
+    onDataHandlers[0]("c");
+
+    // Only the first has been issued; the rest are queued behind it.
+    await waitFor(() => expect(order).toEqual(["a"]));
+    gate.release?.();
+
+    await waitFor(() => expect(order).toEqual(["a", "b", "c"]));
+  });
+
+  it("decodes output from base64 instead of writing the payload as text", async () => {
+    render(<TerminalView repoId="repo-a" />);
+    await waitFor(() =>
+      expect(useTerminalStore.getState().epochs["repo-a"]).toBe(7),
+    );
+
+    emitMockEvent("term://data", {
+      repoId: "repo-a",
+      epoch: 7,
+      data: b64("hello"),
+    });
+
+    await waitFor(() => expect(writtenText()).toContain("hello"));
+    // The literal base64 must never reach the screen.
+    expect(writtenText()).not.toContain(b64("hello"));
+  });
+
+  it("keeps a multi-byte character intact across the wire", async () => {
+    render(<TerminalView repoId="repo-a" />);
+    await waitFor(() =>
+      expect(useTerminalStore.getState().epochs["repo-a"]).toBe(7),
+    );
+
+    // The whole reason the payload is bytes and not a string: an é that a
+    // String payload would have had a chance to turn into U+FFFD.
+    const bytes = new TextEncoder().encode("café");
+    const payload = btoa(String.fromCharCode(...bytes));
+    emitMockEvent("term://data", {
+      repoId: "repo-a",
+      epoch: 7,
+      data: payload,
+    });
+
+    await waitFor(() => expect(writtenText()).toContain("café"));
+    expect(writtenText()).not.toContain("�");
+  });
+
+  it("does not lose output emitted before term_open returns", async () => {
+    // The regression this exists for: `term_open` spawns the shell AND its
+    // reader thread before it returns, so the prompt is on the wire while a
+    // listener attached afterwards does not exist yet. Tauri buffers nothing,
+    // so the terminal opened blank and stayed blank — the bug was invisible in
+    // every test that emitted after the open resolved.
+    mockInvoke("term_open", () => {
+      // Emit from inside the command, i.e. before the caller has the epoch.
+      emitMockEvent("term://data", {
+        repoId: "repo-a",
+        epoch: 7,
+        data: b64("$ prompt-from-the-shell"),
+      });
+      return 7;
+    });
+
+    render(<TerminalView repoId="repo-a" />);
+
+    await waitFor(() =>
+      expect(writtenText()).toContain("prompt-from-the-shell"),
+    );
+  });
+
+  it("drops pre-open output belonging to a different session", async () => {
+    // The buffer must not become a hole in the epoch fence.
+    mockInvoke("term_open", () => {
+      emitMockEvent("term://data", {
+        repoId: "repo-a",
+        epoch: 6,
+        data: b64("older-session"),
+      });
+      emitMockEvent("term://data", {
+        repoId: "repo-a",
+        epoch: 7,
+        data: b64("this-session"),
+      });
+      return 7;
+    });
+
+    render(<TerminalView repoId="repo-a" />);
+
+    await waitFor(() => expect(writtenText()).toContain("this-session"));
+    expect(writtenText()).not.toContain("older-session");
+  });
+
+  it("ignores another repository's output", async () => {
+    render(<TerminalView repoId="repo-a" />);
+    await waitFor(() =>
+      expect(useTerminalStore.getState().epochs["repo-a"]).toBe(7),
+    );
+
+    emitMockEvent("term://data", {
+      repoId: "repo-b",
+      epoch: 7,
+      data: b64("not mine"),
+    });
+
+    expect(writtenText()).not.toContain("not mine");
+  });
+
+  it("ignores a dead session's tail", async () => {
+    render(<TerminalView repoId="repo-a" />);
+    await waitFor(() =>
+      expect(useTerminalStore.getState().epochs["repo-a"]).toBe(7),
+    );
+
+    // A reader still mid-read when the terminal was closed and reopened.
+    emitMockEvent("term://data", {
+      repoId: "repo-a",
+      epoch: 6,
+      data: b64("ghost of the old shell"),
+    });
+
+    expect(writtenText()).not.toContain("ghost");
+  });
+
+  it("says so when the shell exits, and does not respawn it", async () => {
+    render(<TerminalView repoId="repo-a" />);
+    await waitFor(() =>
+      expect(useTerminalStore.getState().epochs["repo-a"]).toBe(7),
+    );
+
+    emitMockEvent("term://exit", { repoId: "repo-a", epoch: 7, code: 3 });
+
+    await waitFor(() => expect(writtenText()).toContain("shell exited with 3"));
+
+    // Nothing further is accepted on that epoch — the session is over.
+    written.length = 0;
+    emitMockEvent("term://data", {
+      repoId: "repo-a",
+      epoch: 7,
+      data: b64("zombie output"),
+    });
+    expect(writtenText()).not.toContain("zombie");
+  });
+
+  it("shows the reason when no shell could be started", async () => {
+    mockInvoke("term_open", () => {
+      throw { kind: "TerminalUnavailable", message: "/bin/nope: not found" };
+    });
+    render(<TerminalView repoId="repo-a" />);
+
+    const banner = await screen.findByTestId("terminal-error");
+    // The remedy, not just the failure — the field that fixes it is named.
+    expect(banner.textContent).toMatch(/Settings/);
+    expect(banner.textContent).toMatch(/nope/);
+  });
+
+  it("tears its listeners down on unmount", async () => {
+    const { unmount } = render(<TerminalView repoId="repo-a" />);
+    await waitFor(() =>
+      expect(useTerminalStore.getState().epochs["repo-a"]).toBe(7),
+    );
+
+    unmount();
+    expect(disposed).toHaveBeenCalled();
+
+    written.length = 0;
+    emitMockEvent("term://data", {
+      repoId: "repo-a",
+      epoch: 7,
+      data: b64("after unmount"),
+    });
+    expect(writtenText()).toBe("");
+  });
+});

--- a/src/features/terminal/TerminalView.tsx
+++ b/src/features/terminal/TerminalView.tsx
@@ -1,0 +1,270 @@
+import { listen } from "@tauri-apps/api/event";
+import React from "react";
+import { Terminal } from "@xterm/xterm";
+import "@xterm/xterm/css/xterm.css";
+
+import { termOpen, termResize, termWrite } from "@/lib/tauri";
+import type { TermData, TermExit } from "@/lib/types";
+import { appErrorMessage } from "@/lib/errors";
+import { useElementSize } from "@/lib/useElementSize";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { useTerminalStore } from "./useTerminalStore";
+
+/**
+ * Approximate cell size for the mono font at 12px, used ONLY to turn a measured
+ * pixel box into rows and cols.
+ *
+ * Deliberately a constant rather than a measurement of a rendered glyph: xterm
+ * lays out on its own metrics anyway, so this only has to be close enough that
+ * the pty and the renderer agree on the shape of the grid. Being one column out
+ * costs a wrap in the wrong place; measuring a glyph costs a layout read on
+ * every resize tick.
+ */
+const CELL_W = 8;
+const CELL_H = 17;
+
+/**
+ * Build xterm's theme from the design tokens.
+ *
+ * Read at mount rather than hardcoded, so the terminal is the app's colour
+ * scheme and the accent hue is never baked in — the same rule the rest of the
+ * design system follows.
+ */
+function themeFromCss(): Record<string, string> {
+  const css = getComputedStyle(document.documentElement);
+  const v = (name: string, fallback: string) =>
+    css.getPropertyValue(name).trim() || fallback;
+  return {
+    background: v("--bg-0", "#101013"),
+    foreground: v("--fg-0", "#e6e6e6"),
+    cursor: v("--accent", "#7aa2f7"),
+    cursorAccent: v("--bg-0", "#101013"),
+    selectionBackground: v("--selection", "#2d3f63"),
+  };
+}
+
+/** base64 → bytes. xterm's `write` takes `Uint8Array` and does incremental
+ *  UTF-8 across chunks, which is why the payload crosses IPC as bytes at all. */
+function decode(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+/**
+ * One xterm instance for one repository (#243).
+ *
+ * Keyed by `repoId` at the call site, so switching tabs MOUNTS A DIFFERENT
+ * instance rather than re-pointing this one — a re-pointed terminal would show
+ * the previous repository's scrollback under the new repository's prompt.
+ *
+ * Unmounting does not end the session. Hiding the panel or switching tabs must
+ * leave the shell running; `useTabsStore.close` is what ends it.
+ */
+export function TerminalView({
+  repoId,
+  hidden = false,
+}: {
+  repoId: string;
+  /**
+   * Mounted but not shown — an inactive tab's terminal, or every terminal
+   * while the panel is collapsed. Hidden rather than unmounted so the
+   * scrollback survives; see `TerminalPanel`.
+   */
+  hidden?: boolean;
+}) {
+  const { ref, width, height } = useElementSize();
+  const shell = useSettingsStore((s) => s.terminalShell);
+  const noteEpoch = useTerminalStore((s) => s.noteEpoch);
+
+  const hostRef = React.useRef<HTMLDivElement | null>(null);
+  const termRef = React.useRef<Terminal | null>(null);
+  // A ref, not state: the event handlers below close over it once and must see
+  // the CURRENT epoch, and a re-render per session would remount the terminal.
+  const epochRef = React.useRef<number | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  // The shell setting is read once per session, not subscribed to: changing it
+  // mid-session must not tear down a running shell under the user. It takes
+  // effect the next time a terminal opens, which is what "restart to apply"
+  // means everywhere else too.
+  const shellRef = React.useRef(shell);
+  shellRef.current = shell;
+
+  React.useEffect(() => {
+    const term = new Terminal({
+      fontFamily: "var(--font-mono), monospace",
+      fontSize: 12,
+      theme: themeFromCss(),
+      // A terminal that cannot scroll back loses your build output the moment
+      // it finishes.
+      scrollback: 5000,
+      allowProposedApi: false,
+    });
+    termRef.current = term;
+    if (hostRef.current) term.open(hostRef.current);
+
+    // Keystrokes are sent STRICTLY IN ORDER, one IPC call at a time.
+    //
+    // `onData` fires once per keystroke, and firing an un-awaited `term_write`
+    // from each one lets the calls race: they are separate async invokes, they
+    // complete in whatever order they complete, and the pty receives the bytes
+    // in that order. Measured, not theorised — typing `echo ZZMARKER` into the
+    // real app arrived at the shell as `ecoZARhR ZMKE`. A paste or a fast
+    // typist would hit it every time.
+    //
+    // Chaining each write onto the previous one costs a promise per keystroke
+    // and makes reordering unrepresentable.
+    let writeChain: Promise<unknown> = Promise.resolve();
+    const typed = term.onData((data) => {
+      writeChain = writeChain.then(() =>
+        termWrite(repoId, data).catch(() => {
+          // The session is gone; the exit listener is what reports that. The
+          // catch is also what keeps one failure from breaking the chain for
+          // every keystroke after it.
+        }),
+      );
+    });
+
+    let disposed = false;
+    const unlisteners: Array<() => void> = [];
+
+    /**
+     * Output that arrived before we knew our epoch.
+     *
+     * The listeners are attached BEFORE `term_open`, because `term_open`
+     * spawns the shell and its reader thread before it returns — so the
+     * shell's very first bytes, which include the prompt, are emitted while a
+     * listener attached afterwards does not exist yet. Tauri does not buffer
+     * events, so those bytes are simply gone: the terminal opens blank and
+     * stays blank until the user blindly types something. Attaching first
+     * means events can arrive before the epoch is known, and this holds them
+     * until it is.
+     */
+    let pending: TermData[] | null = [];
+
+    const writeData = (p: TermData) => term.write(decode(p.data));
+
+    void (async () => {
+      try {
+        unlisteners.push(
+          await listen<TermData>("term://data", (e) => {
+            // Another repository's traffic is never ours.
+            if (e.payload.repoId !== repoId) return;
+            if (pending) {
+              pending.push(e.payload);
+              return;
+            }
+            // A dead session's tail: a reader still mid-read when the terminal
+            // was reopened would otherwise paint the old shell's last line
+            // into the new one.
+            if (e.payload.epoch !== epochRef.current) return;
+            writeData(e.payload);
+          }),
+        );
+        unlisteners.push(
+          await listen<TermExit>("term://exit", (e) => {
+            if (e.payload.repoId !== repoId) return;
+            // Before the epoch is known there is exactly one session for this
+            // repository, so an exit for it is ours.
+            if (!pending && e.payload.epoch !== epochRef.current) return;
+            const { code } = e.payload;
+            term.write(
+              `\r\n\x1b[2m[shell exited${code === null ? "" : ` with ${code}`}]\x1b[0m\r\n`,
+            );
+            // No auto-respawn: the user typed `exit` and meant it, and a shell
+            // that comes back is a shell you cannot get rid of.
+            epochRef.current = null;
+          }),
+        );
+
+        const epoch = await termOpen(
+          repoId,
+          term.rows,
+          term.cols,
+          shellRef.current,
+        );
+        if (disposed) return;
+        epochRef.current = epoch;
+        noteEpoch(repoId, epoch);
+
+        // Flush what arrived while we were opening, in order, and switch to
+        // the live path. No `await` between the two, so no event can slip
+        // past into a queue nobody drains.
+        const queued = pending;
+        pending = null;
+        for (const p of queued) {
+          if (p.epoch === epoch) writeData(p);
+        }
+      } catch (e) {
+        pending = null;
+        if (!disposed) setError(appErrorMessage(e));
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      typed.dispose();
+      for (const un of unlisteners) un();
+      term.dispose();
+      termRef.current = null;
+    };
+    // `shell` is deliberately absent — see shellRef above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [repoId, noteEpoch]);
+
+  // Fit on the MEASURED size, not on a ResizeObserver: WebKitGTK does not have
+  // one, so xterm's FitAddon would leave the Linux build rendering 80x24 in a
+  // 200-column pane forever. `useElementSize` reads first and observes second.
+  // The renderer and the pty are resized together so they cannot disagree.
+  React.useEffect(() => {
+    const term = termRef.current;
+    if (!term || width === 0 || height === 0) return;
+    const cols = Math.max(20, Math.floor(width / CELL_W));
+    const rows = Math.max(4, Math.floor(height / CELL_H));
+    if (cols === term.cols && rows === term.rows) return;
+    term.resize(cols, rows);
+    void termResize(repoId, rows, cols).catch(() => {
+      // No session yet, or it has exited. Neither is worth a banner.
+    });
+  }, [width, height, repoId]);
+
+  return (
+    <div
+      ref={ref}
+      data-testid="terminal-view"
+      data-repo-id={repoId}
+      // `display: none` and not the `hidden` attribute, because this element is
+      // a flex child: `hidden` is overridden by the `display` a flex container
+      // gives its children in some engines, and a "hidden" terminal that still
+      // takes a row is worse than either state.
+      style={{
+        display: hidden ? "none" : undefined,
+        flex: 1,
+        minHeight: 0,
+        overflow: "hidden",
+        padding: "4px 6px",
+        background: "var(--bg-0)",
+      }}
+    >
+      {error ? (
+        <div
+          data-testid="terminal-error"
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "var(--fs-11)",
+            color: "var(--danger)",
+            whiteSpace: "pre-wrap",
+          }}
+        >
+          {error}
+        </div>
+      ) : null}
+      <div
+        ref={hostRef}
+        style={{ width: "100%", height: "100%", display: error ? "none" : undefined }}
+      />
+    </div>
+  );
+}

--- a/src/features/terminal/index.ts
+++ b/src/features/terminal/index.ts
@@ -1,0 +1,10 @@
+export { TerminalPanel } from "./TerminalPanel";
+export { TerminalView } from "./TerminalView";
+export { shellLabel } from "./shellLabel";
+export {
+  DEFAULT_HEIGHT,
+  MAX_HEIGHT,
+  MIN_HEIGHT,
+  clampHeight,
+  useTerminalStore,
+} from "./useTerminalStore";

--- a/src/features/terminal/shellLabel.test.ts
+++ b/src/features/terminal/shellLabel.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { shellLabel } from "./shellLabel";
+
+describe("shellLabel", () => {
+  it("is the basename of a path", () => {
+    expect(shellLabel("/opt/homebrew/bin/fish")).toBe("fish");
+    expect(shellLabel("/bin/zsh")).toBe("zsh");
+  });
+
+  it("handles a Windows path, which a settings export can carry anywhere", () => {
+    expect(shellLabel("C:\\Program Files\\PowerShell\\7\\pwsh.exe")).toBe(
+      "pwsh.exe",
+    );
+  });
+
+  it("says what blank MEANS rather than rendering nothing", () => {
+    // An empty header reads as "something failed to load".
+    expect(shellLabel("")).toBe("default shell");
+    expect(shellLabel("   ")).toBe("default shell");
+  });
+
+  it("leaves a bare name alone", () => {
+    expect(shellLabel("nu")).toBe("nu");
+  });
+});

--- a/src/features/terminal/shellLabel.ts
+++ b/src/features/terminal/shellLabel.ts
@@ -1,0 +1,18 @@
+/**
+ * The name to show for a configured shell path (#243).
+ *
+ * The panel header names the shell so a slow start is attributed to the right
+ * thing — a `.zshrc` that takes two seconds should read as "zsh is starting",
+ * not as the app hanging. A full path there would be noise; the basename is
+ * what the user calls it.
+ */
+export function shellLabel(shell: string): string {
+  const trimmed = shell.trim();
+  // Blank is the default and the common case. Saying so beats an empty header,
+  // which would read as "something failed to load".
+  if (!trimmed) return "default shell";
+  // Split on both separators, not the platform's: a Windows path can reach a
+  // macOS dev's settings export, and this is a label, not a filesystem call.
+  const parts = trimmed.split(/[/\\]/).filter(Boolean);
+  return parts[parts.length - 1] ?? trimmed;
+}

--- a/src/features/terminal/useTerminalStore.test.ts
+++ b/src/features/terminal/useTerminalStore.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_HEIGHT,
+  MAX_HEIGHT,
+  MIN_HEIGHT,
+  clampHeight,
+  useTerminalStore,
+} from "./useTerminalStore";
+
+beforeEach(() => {
+  localStorage.clear();
+  useTerminalStore.setState({
+    open: false,
+    heightPx: DEFAULT_HEIGHT,
+    epochs: {},
+  });
+});
+
+describe("the terminal panel's UI state", () => {
+  it("starts closed — a terminal nobody asked for should not spawn a shell", () => {
+    expect(useTerminalStore.getState().open).toBe(false);
+  });
+
+  it("toggles", () => {
+    useTerminalStore.getState().toggle();
+    expect(useTerminalStore.getState().open).toBe(true);
+    useTerminalStore.getState().toggle();
+    expect(useTerminalStore.getState().open).toBe(false);
+  });
+
+  it("clamps the height to a range a terminal can render in", () => {
+    useTerminalStore.getState().setHeight(10);
+    expect(useTerminalStore.getState().heightPx).toBe(MIN_HEIGHT);
+    useTerminalStore.getState().setHeight(100_000);
+    expect(useTerminalStore.getState().heightPx).toBe(MAX_HEIGHT);
+  });
+
+  it("remembers open and height across a reload, but not the sessions", () => {
+    useTerminalStore.getState().setOpen(true);
+    useTerminalStore.getState().setHeight(321);
+    useTerminalStore.getState().noteEpoch("a", 9);
+
+    const raw = localStorage.getItem("pg.terminal.ui");
+    expect(raw).toBeTruthy();
+    const persisted = JSON.parse(raw as string) as Record<string, unknown>;
+    expect(persisted.open).toBe(true);
+    expect(persisted.heightPx).toBe(321);
+    // The shells die with the process, so a restored epoch would be a handle
+    // to nothing.
+    expect(persisted.epochs).toBeUndefined();
+  });
+
+  it("survives a corrupt persisted value rather than failing to start", () => {
+    localStorage.setItem("pg.terminal.ui", "{not json");
+    expect(clampHeight(DEFAULT_HEIGHT)).toBe(DEFAULT_HEIGHT);
+  });
+});
+
+describe("session epochs", () => {
+  it("tracks one per repository, not one for the app", () => {
+    useTerminalStore.getState().noteEpoch("a", 1);
+    useTerminalStore.getState().noteEpoch("b", 2);
+    expect(useTerminalStore.getState().epochs).toEqual({ a: 1, b: 2 });
+  });
+
+  it("replaces a repository's epoch when its terminal is reopened", () => {
+    useTerminalStore.getState().noteEpoch("a", 1);
+    useTerminalStore.getState().noteEpoch("a", 7);
+    expect(useTerminalStore.getState().epochs).toEqual({ a: 7 });
+  });
+
+  it("forgets one repository without disturbing the others", () => {
+    useTerminalStore.getState().noteEpoch("a", 1);
+    useTerminalStore.getState().noteEpoch("b", 2);
+    useTerminalStore.getState().forget("a");
+    expect(useTerminalStore.getState().epochs).toEqual({ b: 2 });
+  });
+
+  it("forgetting a repository that never had a terminal is a no-op", () => {
+    useTerminalStore.getState().noteEpoch("b", 2);
+    useTerminalStore.getState().forget("never");
+    expect(useTerminalStore.getState().epochs).toEqual({ b: 2 });
+  });
+});

--- a/src/features/terminal/useTerminalStore.ts
+++ b/src/features/terminal/useTerminalStore.ts
@@ -1,0 +1,104 @@
+import { create } from "zustand";
+
+const TERMINAL_UI_KEY = "pg.terminal.ui";
+
+/** Below this the terminal cannot show a prompt and a line of output, so the
+ *  drag handle stops here rather than letting the panel collapse to a sliver
+ *  the user then cannot grab. */
+export const MIN_HEIGHT = 80;
+/** Above this the panel has eaten the app. */
+export const MAX_HEIGHT = 2000;
+/** What a double-click on the handle returns to, and the first-run height. */
+export const DEFAULT_HEIGHT = 240;
+
+export const clampHeight = (px: number) =>
+  Math.max(MIN_HEIGHT, Math.min(MAX_HEIGHT, Math.round(px)));
+
+interface PersistedUi {
+  open: boolean;
+  heightPx: number;
+}
+
+function load(): PersistedUi {
+  try {
+    const raw = localStorage.getItem(TERMINAL_UI_KEY);
+    if (!raw) return { open: false, heightPx: DEFAULT_HEIGHT };
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") {
+      return { open: false, heightPx: DEFAULT_HEIGHT };
+    }
+    const { open, heightPx } = parsed as Partial<PersistedUi>;
+    return {
+      open: typeof open === "boolean" ? open : false,
+      heightPx:
+        typeof heightPx === "number" ? clampHeight(heightPx) : DEFAULT_HEIGHT,
+    };
+  } catch {
+    return { open: false, heightPx: DEFAULT_HEIGHT };
+  }
+}
+
+function persist(ui: PersistedUi): void {
+  try {
+    localStorage.setItem(TERMINAL_UI_KEY, JSON.stringify(ui));
+  } catch {
+    // non-fatal — the session just won't remember the panel
+  }
+}
+
+interface TerminalState {
+  /**
+   * Whether the panel is showing.
+   *
+   * Closed by default. A terminal nobody asked for should not spawn a shell for
+   * every repository they open — a `.zshrc` that runs nvm would then be paid
+   * for on every tab, invisibly.
+   */
+  open: boolean;
+  heightPx: number;
+  /**
+   * The live session epoch per repository.
+   *
+   * Per-repo state lives HERE and not in `useRepoStore`. `RepoSlice` holds
+   * exactly one repository's state and is cleared on every tab switch, which is
+   * right for a diff and catastrophic for a session handle: it would orphan the
+   * shells of every inactive tab. This is the shape `useTabsStore` has — all
+   * open repositories at once.
+   *
+   * Deliberately NOT persisted: the shells die with the process, so a restored
+   * epoch would be a handle to nothing.
+   */
+  epochs: Record<string, number>;
+  toggle: () => void;
+  setOpen: (open: boolean) => void;
+  setHeight: (px: number) => void;
+  noteEpoch: (repoId: string, epoch: number) => void;
+  forget: (repoId: string) => void;
+}
+
+export const useTerminalStore = create<TerminalState>()((set, get) => ({
+  ...load(),
+  epochs: {},
+  toggle: () => {
+    const open = !get().open;
+    set({ open });
+    persist({ open, heightPx: get().heightPx });
+  },
+  setOpen: (open) => {
+    set({ open });
+    persist({ open, heightPx: get().heightPx });
+  },
+  setHeight: (px) => {
+    const heightPx = clampHeight(px);
+    set({ heightPx });
+    persist({ open: get().open, heightPx });
+  },
+  noteEpoch: (repoId, epoch) =>
+    set((s) => ({ epochs: { ...s.epochs, [repoId]: epoch } })),
+  forget: (repoId) =>
+    set((s) => {
+      const next = { ...s.epochs };
+      delete next[repoId];
+      return { epochs: next };
+    }),
+}));

--- a/src/features/terminal/wiring.test.tsx
+++ b/src/features/terminal/wiring.test.tsx
@@ -1,0 +1,121 @@
+// How the terminal joins the rest of the app (#243).
+//
+// Two rules that live in files the terminal does not own, so they are tested
+// here where the reason for them is written down:
+//
+//   1. Keys typed in the terminal belong to the SHELL. xterm renders a hidden
+//      textarea, so the keymap's `isEditable` already drops bare chords — but
+//      not modifier chords, which is exactly the set a shell needs (Ctrl+C,
+//      Ctrl+D, Ctrl+R). Without an explicit guard, Ctrl+C opens whatever the
+//      app has bound instead of interrupting the foreground process.
+//   2. The shell belongs to the TAB. Closing a repository must end its shell,
+//      or an interactive process outlives every trace of it in the UI.
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { ACTIONS, type ActionId } from "@/features/keymap/actions";
+import { useKeymapStore } from "@/features/keymap/useKeymapStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { useTerminalStore } from "./useTerminalStore";
+
+beforeEach(() => {
+  localStorage.clear();
+  resetInvokeMock();
+  useTerminalStore.setState({ open: false, heightPx: 240, epochs: {} });
+});
+
+/** A key event whose target is inside the terminal host. */
+function keyInTerminal(init: KeyboardEventInit) {
+  const host = document.createElement("div");
+  host.setAttribute("data-testid", "terminal-view");
+  const textarea = document.createElement("textarea");
+  host.appendChild(textarea);
+  document.body.appendChild(host);
+  const e = new KeyboardEvent("keydown", { ...init, bubbles: true });
+  Object.defineProperty(e, "target", { value: textarea });
+  return e;
+}
+
+/** The same event from an ordinary, non-terminal target. */
+function keyOutside(init: KeyboardEventInit) {
+  const div = document.createElement("div");
+  document.body.appendChild(div);
+  const e = new KeyboardEvent("keydown", { ...init, bubbles: true });
+  Object.defineProperty(e, "target", { value: div });
+  return e;
+}
+
+describe("the shell owns the keyboard inside the terminal", () => {
+  it("does not let Ctrl+C reach an app action", () => {
+    const dispatch = useKeymapStore.getState().dispatch;
+    const handled = dispatch(
+      keyInTerminal({ key: "c", ctrlKey: true }) as unknown as KeyboardEvent,
+    );
+    expect(handled).toBe(false);
+  });
+
+  it("does not let the command palette chord through either", () => {
+    const dispatch = useKeymapStore.getState().dispatch;
+    // Sanity: the chord IS bound, so a false below means the guard fired and
+    // not that nothing was listening.
+    const outside = dispatch(
+      keyOutside({ key: "k", metaKey: true }) as unknown as KeyboardEvent,
+    );
+    expect(outside).toBe(true);
+
+    const inside = dispatch(
+      keyInTerminal({ key: "k", metaKey: true }) as unknown as KeyboardEvent,
+    );
+    expect(inside).toBe(false);
+  });
+
+  it("still honours the toggle — that is the way back out", () => {
+    useTerminalStore.setState({ open: true });
+    const dispatch = useKeymapStore.getState().dispatch;
+    const handled = dispatch(
+      keyInTerminal({ key: "`", ctrlKey: true }) as unknown as KeyboardEvent,
+    );
+    expect(handled).toBe(true);
+    expect(useTerminalStore.getState().open).toBe(false);
+  });
+});
+
+describe("the toggle action", () => {
+  it("is in the catalog, so the palette and cheat sheet can find it", () => {
+    const id: ActionId = "terminal.toggle";
+    expect(ACTIONS[id]).toBeTruthy();
+    expect(ACTIONS[id].title).toMatch(/terminal/i);
+  });
+
+  it("flips the panel", () => {
+    ACTIONS["terminal.toggle"].run?.("Ctrl+`");
+    expect(useTerminalStore.getState().open).toBe(true);
+    ACTIONS["terminal.toggle"].run?.("Ctrl+`");
+    expect(useTerminalStore.getState().open).toBe(false);
+  });
+});
+
+describe("the shell belongs to the tab", () => {
+  it("closes the session when the repository tab is evicted", async () => {
+    mockInvoke("close_repo", () => null);
+    mockInvoke("term_close", () => null);
+    mockInvoke("get_status", () => []);
+
+    const { useTabsStore } = await import("@/features/repo/useTabsStore");
+    useTerminalStore.getState().noteEpoch("r1", 4);
+    useTabsStore.setState({
+      tabs: [{ path: "/tmp/r1", repoId: "r1", status: "open" }] as never,
+      activePath: "/tmp/r1",
+    });
+
+    await useTabsStore.getState().close("/tmp/r1");
+
+    expect(
+      getInvokeCalls().some(
+        (c) => c.cmd === "term_close" && c.args?.repoId === "r1",
+      ),
+    ).toBe(true);
+    // And the frontend forgets the handle, so a reopened tab does not filter
+    // its new session's events against a dead epoch.
+    expect(useTerminalStore.getState().epochs.r1).toBeUndefined();
+  });
+});

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -82,6 +82,14 @@ export type AppError =
    */
   | { kind: "SshKeygenUnavailable"; message: string }
   /**
+   * The shell the built-in terminal tried to run is missing or not runnable
+   * (#243). A state the panel disables on, in the shape `LfsUnavailable`
+   * already uses. The payload is the SHELL and the reason, not prose —
+   * `appErrorDetail` turns it into a sentence that names the Settings field,
+   * because that is the only thing the user can do about it.
+   */
+  | { kind: "TerminalUnavailable"; message: string }
+  /**
    * A git hook ran and refused (#232). The payload is a STRUCT, and its
    * `output` is deliberately NOT rendered into the banner sentence: forty lines
    * of eslint belong in the dedicated output block, which scrolls. See
@@ -187,6 +195,12 @@ function appErrorDetail(e: AppError): string {
   // with no hint that the app refused on purpose rather than failed.
   if (e.kind === "SshKeyExists" && typeof message === "string") {
     return `${message} already exists. Nothing was overwritten — choose another name.`;
+  }
+  // TerminalUnavailable carries the SHELL and the reason it would not start.
+  // Rendered raw the banner would be "zsh: No such file or directory", which
+  // says what happened and nothing about the one field that fixes it.
+  if (e.kind === "TerminalUnavailable" && typeof message === "string") {
+    return `Could not start a shell (${message}). Set one in Settings ▸ Terminal, or leave that field blank to use $SHELL.`;
   }
   // StaleStash carries a LABEL (`stash@{1}`) — rendered raw the banner would
   // just read "stash@{1}" with no hint of what to do about it.

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1436,6 +1436,52 @@ export function watchStop(): Promise<void> {
   return invoke<void>("watch_stop");
 }
 
+/**
+ * Start a shell for this repository, or adopt the one already running (#243).
+ *
+ * Returns the session's EPOCH. Every `term://data` and `term://exit` event
+ * carries one, and a view must drop the events whose epoch is not the one it
+ * opened — a reader still mid-read when the terminal was closed and reopened
+ * would otherwise paint the dead shell's last line into the new one.
+ *
+ * `shell` blank or omitted means the backend's default: `$SHELL` then `/bin/sh`
+ * on unix, PowerShell on Windows.
+ */
+export function termOpen(
+  repoId: string,
+  rows: number,
+  cols: number,
+  shell?: string,
+): Promise<number> {
+  return invoke<number>("term_open", {
+    repoId,
+    rows,
+    cols,
+    shell: shell?.trim() ? shell : null,
+  });
+}
+
+/** Send input to the shell. This is what the user typed — never log it. */
+export function termWrite(repoId: string, data: string): Promise<void> {
+  return invoke<void>("term_write", { repoId, data });
+}
+
+/** Tell the pty how big the renderer is, so the shell wraps where the user
+ *  sees the edge and a full-screen program fills the pane. */
+export function termResize(
+  repoId: string,
+  rows: number,
+  cols: number,
+): Promise<void> {
+  return invoke<void>("term_resize", { repoId, rows, cols });
+}
+
+/** Kill this repository's shell. Idempotent — safe on a tab that never opened
+ *  a terminal. */
+export function termClose(repoId: string): Promise<void> {
+  return invoke<void>("term_close", { repoId });
+}
+
 export function openUrl(url: string): Promise<void> {
   return invoke("open_url", { url });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1205,3 +1205,28 @@ export interface SshKeyGenerateRequest {
   comment?: string;
   passphrase?: string;
 }
+
+/**
+ * A chunk of terminal output (#243). Mirrors Rust `terminal.rs::TermEvent`.
+ *
+ * `data` is **base64**, not text. Pty output is arbitrary bytes and a read
+ * splits multi-byte characters at the chunk boundary; a string payload would
+ * mean `from_utf8_lossy` on the Rust side, putting U+FFFD inside filenames
+ * intermittently and only for non-ASCII. Decode it and hand xterm the bytes —
+ * it does incremental UTF-8 across chunks, which is the right place for it.
+ */
+export interface TermData {
+  repoId: string;
+  /** Which session this belongs to. Drop anything that is not the one you
+   *  opened: a reader still mid-read when the terminal was reopened would
+   *  otherwise paint the dead shell's last line into the new one. */
+  epoch: number;
+  data: string;
+}
+
+/** The shell exited (#243). `code` is null when it was signalled. */
+export interface TermExit {
+  repoId: string;
+  epoch: number;
+  code: number | null;
+}

--- a/src/screens/Settings.terminal.test.tsx
+++ b/src/screens/Settings.terminal.test.tsx
@@ -1,0 +1,74 @@
+// Settings → Terminal shell (#243).
+//
+// Blank is the default AND the answer for most people: the built-in terminal
+// should be the same shell as the one outside the app, and the backend resolves
+// that from `$SHELL`. So the two things worth pinning are that it starts empty
+// — a non-empty default would silently give someone a different shell from
+// their own terminal — and that blank survives being cleared, since that is the
+// route back for anyone who typed a path that turned out not to work.
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { mockInvoke } from "@/test/invokeMock";
+import { WithDialogs, resetDialogs } from "@/test/dialog";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { SettingsScreen } from "./Settings";
+
+function mockRestOfSettings() {
+  mockInvoke("cli_shim_status", () => ({
+    installed: true,
+    shimPath: "/usr/local/bin/pgit",
+    target: "/usr/bin/platypusgit",
+    source: "package",
+    pathState: "onPath",
+  }));
+  mockInvoke("diagnostics_report", () => ({
+    logPath: "/tmp/platypusgit.log",
+    logExists: false,
+    logSizeBytes: 0,
+    environment: "host os=macos arch=aarch64 git=2.43.0",
+    version: "0.1.0",
+  }));
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  resetDialogs();
+  mockRestOfSettings();
+  useSettingsStore.getState().reset();
+});
+
+function renderSettings() {
+  render(
+    <WithDialogs>
+      <SettingsScreen />
+    </WithDialogs>,
+  );
+}
+
+const field = () => screen.getByTestId<HTMLInputElement>("terminal-shell");
+
+describe("the terminal shell field", () => {
+  it("starts empty, which is what makes the built-in terminal the user's own shell", () => {
+    renderSettings();
+    expect(field().value).toBe("");
+    expect(useSettingsStore.getState().terminalShell).toBe("");
+  });
+
+  it("stores the shell the user names", () => {
+    renderSettings();
+    fireEvent.change(field(), {
+      target: { value: "/opt/homebrew/bin/fish" },
+    });
+    expect(useSettingsStore.getState().terminalShell).toBe(
+      "/opt/homebrew/bin/fish",
+    );
+  });
+
+  it("lets the field be cleared back to the default", () => {
+    renderSettings();
+    fireEvent.change(field(), { target: { value: "/bin/nonsense" } });
+    fireEvent.change(field(), { target: { value: "" } });
+    expect(useSettingsStore.getState().terminalShell).toBe("");
+  });
+});

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -165,6 +165,19 @@ export function SettingsScreen() {
             }
           />
           <Row
+            label="Terminal shell"
+            hint="The shell the built-in terminal runs, opened in the active repository's working directory. Leave blank to use the same shell as your own terminal ($SHELL, or PowerShell on Windows)."
+            control={
+              <PGInput
+                data-testid="terminal-shell"
+                value={s.terminalShell}
+                placeholder="$SHELL"
+                onChange={(v) => s.set("terminalShell", v)}
+                style={{ width: 220 }}
+              />
+            }
+          />
+          <Row
             label="Auto-fetch"
             hint="Periodically run fetch in the background so ahead/behind counts stay fresh."
             control={


### PR DESCRIPTION
Closes #243.

A real pty in a docked panel, one shell per repository tab, opened in that
repository's working directory. `vim`, `less`, `ssh` and `git rebase -i` all
work — anything less is a text box that lies about being a terminal.

The issue flagged this as the item most reasonable to say no to. It was
considered and rejected: for a dev-first client the shell is the other half of
the workflow, not an escape hatch, and the round trip through a separate app
loses the one thing the GUI already knows — which repository you are in.

Spec and plan: `docs/superpowers/specs/2026-09-01-builtin-terminal-spec.md`,
`docs/superpowers/plans/2026-09-01-builtin-terminal.md`.

## What ships

- Terminal panel below the active screen, ``Ctrl+` `` to toggle, drag to resize,
  **closed by default** — a terminal nobody asked for should not spawn a shell
  for every repository they open.
- One shell per repository tab, keyed by `RepoId` in the backend, so that rule
  is a property of the data structure rather than something the frontend has to
  remember. Closing the tab kills the shell.
- Shell auto-detected (`$SHELL` → `/bin/sh`; PowerShell on Windows), overridable
  in **Settings ▸ Terminal**.
- Views are **hidden, never unmounted**, so hiding the panel or switching tabs
  returns to the scrollback you left.

## The `proc.rs` carve-out — why the guard grew instead of gaining an exception

`portable-pty` spawns through its own `CommandBuilder`, not
`std::process::Command`, so a pty opened anywhere would sail straight past the
`Command::new` guard — the second spawn path #172 exists to prevent, and
invisible this time. `proc::spawn_pty_shell` therefore owns the *whole*
operation (`openpty`, the builder, `spawn_command`), and
`tests/spawn_no_window.rs` now allow-lists those three symbols in `proc.rs` and
counts zero everywhere else.

Two properties of that child are deliberate inversions, argued in place because
they look like mistakes:

- **`GIT_TERMINAL_PROMPT` is not set to 0.** `prompt_less` exists because a GUI
  app's children have no terminal, so an auth prompt hangs behind a window
  nobody can see. This child *is* a terminal and the user is looking at it —
  inheriting the silence would turn a working `git push` into a mystery.
- **`CREATE_NO_WINDOW` does not apply.** ConPTY is not `CreateProcess` with an
  inherited console; `portable-pty` allocates a pseudoconsole, so no `conhost`
  window appears. **Reasoned, not measured** — see Risks.

## No logging of pty traffic

`src/terminal.rs` contains **no logging call at all**, enforced by
`tests/terminal_privacy.rs`. A terminal is where a `sudo` password gets typed;
the bytes have exactly one destination, and the lifecycle logging lives in
`commands/terminal.rs`, which handles ids and exit codes and never sees traffic.
The rule is blunt on purpose — "no logger near the buffer" is not something a
grep can keep.

## The refresh bullet needed no code

#239's watcher defaults on and classifies against `gitdir`/`commondir`, so a
`git commit` typed into the pane already moves the graph. A terminal-specific
refresh would be a second mechanism for a job the first one does, and it would
fire on `ls`. Honest gap, documented not worked around: with the watcher off,
the terminal does not refresh either.

## Three bugs only the e2e spec could see

All three were **silent** — the terminal opened, the shell ran, nothing worked —
and each now has a test at the layer that can catch it:

1. **The event payload was the Rust enum.** serde tags externally, so it went out
   as `{"data":{"repoId":…}}` and the view's `repoId` check dropped every
   event — which is exactly what that line is supposed to do sometimes, so there
   was no error anywhere. `TermEvent` now wraps flat structs and is not
   `Serialize` at all; a cargo test pins the wire shape.
2. **Listeners were attached after `term_open`**, which spawns the shell and its
   reader thread before returning. The prompt was emitted into a listener that
   did not exist yet, and Tauri buffers nothing.
3. **One un-awaited `term_write` per keystroke** let the invokes race. Typing
   `echo ZZMARKER` reached the shell as `ecoZARhR ZMKE`.

## Tauri permissions

None needed — ordinary commands and events. `default.json` untouched, no new
scoped capability. Noted because the issue asked.

## Verification

- `cargo test` — 84 test binaries green, including 11 new pty tests against real
  ptys, the extended spawn guard, and the privacy guard
- `pnpm test` — 314 files / 2998 tests green
- `pnpm tsc --noEmit` and `pnpm exec tsc -p e2e/tsconfig.json --noEmit` clean
- `pnpm test:e2e:docker full --spec e2e/specs/terminal.e2e.ts` — passing, run
  against this rebased tree
- Privacy gates (`test/privacy.test.ts`, `no_telemetry.rs`) green with the two
  new dependencies

## Risks

- **Windows ConPTY is reasoned, not measured.** No Windows machine in this loop.
  If a console flashes, the fix is in `spawn_pty_shell` and nowhere else — which
  is the reason for the carve-out.
- **`portable-pty` and `@xterm/xterm` are the first of their kind** in either
  tree. Both clean against the privacy gates; neither reaches the network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
