### PR TITLE
fix(git): refuse checkout of a branch a linked worktree holds

### DIFF
--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -512,7 +512,7 @@ and `fast_forward_all` sweeps every local branch that can.
 - **A branch any working tree is standing on is refused**, HEAD here or a linked
   worktree's HEAD: moving the ref without touching the index and worktree leaves
   that checkout rendering every incoming change as a deletion. The frontend
-  routes HEAD to `pull` with the user's `defaultPullMode` instead. git2-rs 0.20
+  routes HEAD to `pull` with the user's `defaultPullMode` instead. git2-rs 0.21
   does not bind `git_branch_is_checked_out`, so `worktree::linked_worktree_heads`
   walks the linked worktrees — one repository open each, which is why only
   ref-moving ops pay it and a bulk sweep walks once.
@@ -531,6 +531,42 @@ and `fast_forward_all` sweeps every local branch that can.
   user-supplied and `--upload-pack=<program>` names a program git runs for the
   transport. Verified against git 2.50 — the fetch works normally, and a
   dash-leading value is refused as a strange pathname instead of honoured.
+
+## Checking out a branch another worktree holds (#356)
+
+`checkout_branch` used to be two statements — `checkout_tree` then `set_head` —
+and libgit2 refuses the second one when a linked worktree is standing on the
+target: *"cannot set HEAD to reference 'refs/heads/x' as it is the current HEAD
+of a linked repository"*. The refusal was correct and arrived too late. By then
+`checkout_tree` had rewritten the index and the working tree to the target's
+tree, so the user was left on an unmoved HEAD with **the entire difference
+between the two branches staged**, files from their own branch deleted off disk.
+A refusal had presented as data loss.
+
+- **Validate before you write, the way git does.** git dies with `'x' is already
+  used by worktree at '…'` before it touches anything;
+  `reject_held_by_linked_worktree` is that check, and it runs first in the
+  closure — ahead of the dirty check too, because "stash first" is the wrong
+  instruction for a branch that is checked out somewhere else and stashing will
+  not make the second attempt succeed.
+- **Only LINKED worktrees block a checkout.** It reuses `checked_out_at` from
+  #246 with `head: None`, which skips that helper's "this worktree" case on
+  purpose: re-checking-out the branch you are already on is `git checkout
+  <current>`, a no-op rather than an error. Passing `repo.head()` here — the
+  obvious reuse of `reject_checked_out` — would refuse an everyday operation.
+- **The tree write still rolls back if the ref move fails anyway.** `set_head`
+  is no longer expected to fail, but it is the one step that runs after the
+  worktree has been rewritten, so its error arm resets hard to the commit
+  captured before `checkout_tree`. The dirty check above it means that reset
+  restores the state we started from rather than discarding anybody's work.
+  Every other head-moving path in `libgit2.rs` (`checkout_detached`,
+  `stash_branch`, rebase finish and abort) already moves the ref *before* it
+  touches the tree; `checkout_branch` was the only inverted one.
+- **`checkout_tree` first is still the right order for checkout itself** — it is
+  git's order, and it is what lets libgit2's SAFE strategy refuse a checkout that
+  would overwrite untracked files while HEAD is still where the user left it.
+  Moving `set_head` up would just relocate the same class of bug to the conflict
+  path.
 
 ## Deleting an untracked file (#245)
 

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -2690,6 +2690,31 @@ fn reject_checked_out(repo: &Repository, branch: &str) -> AppResult<()> {
     }
 }
 
+/// The refusal a CHECKOUT gets when a linked worktree is standing on the target
+/// branch — git's own `'x' is already used by worktree at '…'`.
+///
+/// libgit2 refuses this too, but it refuses from `set_head`, which runs *after*
+/// `checkout_tree` has already rewritten the index and the working tree. That
+/// ordering is what turned this into a data bug rather than an error message:
+/// the tree became the target's, HEAD stayed put, and the entire difference
+/// between the two branches showed up staged. So the check happens here, before
+/// anything is written.
+///
+/// `checked_out_at`'s `head` argument is deliberately `None`, which skips its
+/// "this worktree" case: only LINKED worktrees block a checkout. The branch this
+/// repository is already on is a legal target — `git checkout <current>` is a
+/// no-op, not an error — so `reject_checked_out`, the obvious reuse, is the
+/// wrong helper here.
+fn reject_held_by_linked_worktree(repo: &Repository, branch: &str) -> AppResult<()> {
+    let linked = crate::git::worktree::linked_worktree_heads(repo);
+    match checked_out_at(branch, None, &linked) {
+        None => Ok(()),
+        Some(where_) => Err(AppError::InvalidArgument(format!(
+            "{branch} is checked out in {where_} — switch to it there, or remove that worktree first"
+        ))),
+    }
+}
+
 /// Local branch names, in listing order.
 fn local_branch_names(repo: &Repository) -> AppResult<Vec<String>> {
     let mut names = Vec::new();
@@ -4736,6 +4761,10 @@ impl GitBackend for Libgit2Backend {
 
     fn checkout_branch(&self, repo_id: &RepoId, name: &str) -> AppResult<()> {
         self.with_repo(repo_id, |repo| {
+            // Before ANY of the checks that can write: a branch another worktree
+            // is standing on cannot be checked out here, and finding that out
+            // from `set_head` would be too late (see the helper).
+            reject_held_by_linked_worktree(repo, name)?;
             // Refuse only when tracked paths have pending modifications or staged
             // changes; untracked files are fine unless they would be overwritten by
             // the target tree (that's checked by checkout_tree's conflict detection).
@@ -4761,13 +4790,27 @@ impl GitBackend for Libgit2Backend {
             let obj = repo
                 .revparse_single(&refname)
                 .map_err(|_| AppError::InvalidRef(name.to_string()))?;
+            // Captured before the tree write, so a failed `set_head` can put the
+            // checkout back where it started. Unborn HEAD has nothing to restore.
+            let previous = repo.head().and_then(|h| h.peel(git2::ObjectType::Commit));
             repo.checkout_tree(&obj, None).map_err(|e| match e.code() {
                 git2::ErrorCode::Conflict => AppError::DirtyWorktree(
                     "untracked files would be overwritten by checkout".into(),
                 ),
                 _ => AppError::from(e),
             })?;
-            repo.set_head(&refname)?;
+            // `checkout_tree` has now rewritten the index and the working tree,
+            // and only the ref move is left. A failure here used to be left
+            // exactly as it fell — the target's tree under an unmoved HEAD, which
+            // reads as "the whole branch diff is staged". The worktree was
+            // verified clean above, so the reset restores where we started rather
+            // than discarding anyone's work.
+            if let Err(e) = repo.set_head(&refname) {
+                if let Ok(previous) = previous {
+                    let _ = repo.reset(&previous, git2::ResetType::Hard, None);
+                }
+                return Err(AppError::from(e));
+            }
             Ok(())
         })
     }

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -78,7 +78,7 @@ pub fn info(repo: &Repository, name: &str, current: Option<&Path>) -> AppResult<
 /// Only linked worktrees: `git_worktree_list` never reports the main one, whose
 /// HEAD the caller already has from `repo.head()`.
 ///
-/// libgit2 has `git_branch_is_checked_out`, but git2-rs 0.20 does not bind it —
+/// libgit2 has `git_branch_is_checked_out`, but git2-rs 0.21 does not bind it —
 /// hence the walk. It costs one `Repository::open_from_worktree` per linked
 /// worktree, so only ref-MOVING ops pay it, never a listing; a bulk op walks
 /// once and looks branches up in the result.

--- a/src-tauri/tests/worktrees.rs
+++ b/src-tauri/tests/worktrees.rs
@@ -233,3 +233,83 @@ fn an_unknown_worktree_name_is_an_argument_error_not_a_panic() {
         assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
     }
 }
+
+/// Checking out a branch that a LINKED worktree is standing on (#356).
+///
+/// libgit2's `set_head` refuses this — "cannot set HEAD to reference '…' as it
+/// is the current HEAD of a linked repository" — but `checkout_branch` used to
+/// run `checkout_tree` FIRST, so the refusal arrived after the index and the
+/// working tree had already been rewritten to the target's tree. HEAD never
+/// moved, which left every difference between the two branches sitting in the
+/// index as staged changes. git validates this before it touches anything, and
+/// so must we.
+#[test]
+fn checkout_refuses_a_branch_held_by_a_linked_worktree_and_touches_nothing() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    // `held` is the OLDER branch: forked at the initial commit, while the main
+    // worktree moves on. That gap is what showed up staged in the bug report.
+    backend
+        .create_branch(&handle.id, "held", None)
+        .expect("create_branch");
+    tr.add_commit(
+        "only-on-main.txt",
+        "main moved on\n",
+        "feat: a commit only main has",
+    );
+
+    let (_hold, path) = worktree_target("held-elsewhere");
+    backend
+        .worktree_add(
+            &handle.id,
+            &path,
+            WorktreeBranch::Existing("held".to_string()),
+        )
+        .expect("worktree_add");
+
+    let head_before = git_in(tr.path(), &["rev-parse", "HEAD"]);
+
+    let err = backend
+        .checkout_branch(&handle.id, "held")
+        .expect_err("a branch held by a linked worktree cannot be checked out here");
+    match &err {
+        AppError::InvalidArgument(m) => assert!(
+            m.contains("held") && m.contains("worktree"),
+            "the refusal should name the branch and where it is checked out: {m}"
+        ),
+        other => panic!("expected InvalidArgument, got {other:?}"),
+    }
+
+    // The whole point: a refused checkout is a no-op.
+    assert_eq!(
+        head_before,
+        git_in(tr.path(), &["rev-parse", "HEAD"]),
+        "HEAD must not move"
+    );
+    let status = git_in(tr.path(), &["status", "--porcelain"]);
+    assert!(
+        status.trim().is_empty(),
+        "a refused checkout must leave the index and working tree untouched:\n{status}"
+    );
+    assert!(
+        tr.path().join("only-on-main.txt").exists(),
+        "main's own file must still be in the working tree"
+    );
+}
+
+/// The guard is about LINKED worktrees only. Re-checking-out the branch this
+/// repository is already on is what `git checkout <current>` does every day, and
+/// `checked_out_at` would otherwise report "this worktree" and refuse it.
+#[test]
+fn checkout_still_accepts_the_branch_this_worktree_is_already_on() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let current = git_in(tr.path(), &["rev-parse", "--abbrev-ref", "HEAD"])
+        .trim()
+        .to_string();
+
+    backend
+        .checkout_branch(&handle.id, &current)
+        .expect("checking out the current branch is a no-op, not an error");
+}


### PR DESCRIPTION
## The bug

Checking out a branch that a **linked worktree** is standing on did not just
fail — it left the repository mangled. Reported from the field:

> I tried checking out a branch from the menu on top and from the log view. Both
> times it only staged the changes between `main`, which I was on, and this
> branch, which was older.

```
[ERROR] invoke checkout_branch failed after 14ms: Git: cannot set HEAD to
reference 'refs/heads/FIM-122-Adjust-422-error-details' as it is the current
HEAD of a linked repository.
```

## Root cause

`Libgit2Backend::checkout_branch` was two statements in the wrong order:

```rust
repo.checkout_tree(&obj, None)?;   // rewrites the index AND the working tree
repo.set_head(&refname)?;          // ← libgit2 refuses here
```

libgit2 refuses `set_head` onto a branch another worktree holds. The refusal is
correct; it just arrived **after** the destructive half had already run. HEAD
stayed on `main` while the index and worktree became the target's tree, so
`git status` showed the entire `main`→target diff as staged, with `main`'s own
files deleted from disk. A refusal presented as data loss.

Reproduced in a temp repo before fixing — the failed checkout left exactly
`D  only-on-main.txt` staged and the file gone, on an unmoved HEAD.

## The fix

1. **Validate before writing, the way git does.** git dies with `'x' is already
   used by worktree at '…'` before touching anything.
   `reject_held_by_linked_worktree` runs first in the closure — ahead of the
   dirty check too, since "stash first" is the wrong instruction for a branch
   checked out elsewhere and stashing would not make the retry succeed.
   It reuses #246's `checked_out_at` with `head: None`, which skips that
   helper's "this worktree" case on purpose: re-checking-out the branch you are
   already on is a no-op, not an error.
2. **A rollback arm on `set_head`.** It is the one step that runs after the
   worktree has been rewritten, so its error path now resets hard to the commit
   captured before `checkout_tree`. The dirty check above means that restores
   where we started rather than discarding anyone's work. Every other
   head-moving path in `libgit2.rs` (`checkout_detached`, `stash_branch`, rebase
   finish/abort) already moves the ref *before* touching the tree —
   `checkout_branch` was the only inverted one.

`checkout_tree`-first is still right for checkout itself: it is git's order, and
it is what lets libgit2's SAFE strategy refuse an untracked-file conflict while
HEAD is still where the user left it.

No new `AppError` variant — this reuses `InvalidArgument`, which already carries
prose to the UI, matching the precedent #246 set for the same class of refusal.

## Tests

- `checkout_refuses_a_branch_held_by_a_linked_worktree_and_touches_nothing` —
  the regression: refusal names the branch and where it is, HEAD does not move,
  `git status --porcelain` is empty, and the current branch's file survives.
- `checkout_still_accepts_the_branch_this_worktree_is_already_on` — pins the
  distinction that makes `reject_checked_out` the wrong helper here.

## Verification

- `cargo test` — 84 suites, all green.
- `pnpm test` — 314 files / 2998 tests green (doc invariants included).
- `pnpm tsc --noEmit` — clean.
- Local Docker e2e could not run (daemon not up on the dev machine). No e2e spec
  checks out a branch held by a linked worktree, so the new guard is inert for
  every path they exercise; the required `e2e-linux` check covers it here.

Lesson written up in `docs/dev/backend.md`, next to the #246 section it builds
on. Also corrects a stale `git2-rs 0.20` reference in that section and in
`worktree.rs` — the crate is on 0.21, which still does not bind
`git_branch_is_checked_out`, so the worktree walk stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
