### PR TITLE
feat(git): offer to move a held branch into this worktree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,8 +148,9 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
   promises; do that deliberately, in the same commit. (`docs/dev/backend.md`)
 - **One signing chain** (`libgit2.rs::sign_payload`) for commits AND tags; a
   signing failure creates nothing. (`docs/dev/backend.md`)
-- **Never `window.confirm`/`window.prompt`** — `pgConfirm`/`pgPrompt` from
-  `@/design`. (`docs/dev/frontend.md`)
+- **Never `window.confirm`/`window.prompt`** — `pgConfirm`/`pgPrompt`/`pgChoose`
+  from `@/design`; every one of them reads a dismissal as "no answer", never as a
+  choice. (`docs/dev/frontend.md`)
 - **No native `<select>`/`<option>` in shipped `src/`** — `PGSelect`; a guard
   test enforces it. (`docs/dev/frontend.md`)
 - **Design system lives in `src/design/`**, imported from `@/design`. Do NOT

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -568,6 +568,49 @@ A refusal had presented as data loss.
   Moving `set_head` up would just relocate the same class of bug to the conflict
   path.
 
+### Taking a held branch (#358)
+
+The refusal above tells the user where the branch is; `checkout_branch`'s `take`
+flag is how they get it *here*, which is what they actually wanted.
+
+- **A worktree can RELEASE a branch without being removed.** It is already
+  standing on the branch's tip, so releasing is `set_head_detached` to the oid it
+  is already at: a rewrite of that worktree's HEAD file and nothing else — no
+  checkout, no index write, its working tree never opened. That is the whole
+  reason this is safe to offer, and it is why uncommitted work over there
+  survives. `taking_a_held_branch_leaves_the_holders_uncommitted_work_alone`
+  pins it.
+- **One flag on the existing command, not a second command.** `take: false`
+  refuses and describes; `take: true` releases and proceeds. Same shape as
+  `delete_branch(.., force)` and `BranchExists`, and it keeps the resolve →
+  validate → release → checkout sequence inside ONE `with_repo` closure, so
+  nothing can move between the check and the write.
+- **The blockers are the two kinds of state a detached HEAD would abandon**, not
+  dirtiness: a **locked** worktree (an explicit "leave me alone" that operations
+  honour) and one **mid-operation** — rebase, merge, cherry-pick, revert, am or
+  bisect, read off `Repository::state()`. git tracks those against HEAD, so
+  moving HEAD out from under one leaves a half-finished operation nobody can
+  explain. Dirtiness is reported, never refused.
+- **`release_blocker` computes `dirty` BEFORE it returns any refusal.** Returning
+  early from the lock check reported every locked worktree as clean, and the
+  confirmation's wording depends on it — the bug the
+  `the_refusal_reports_a_blocked_holder…` test was written to catch.
+- **The refusal re-validates at take time** rather than trusting the `blocked` it
+  reported: the user saw that a dialog ago, and a lock or a rebase can have
+  started since.
+- **A checkout that fails after the release puts the holder back on its branch.**
+  Leaving it detached would have cost it its branch for a checkout that never
+  happened — the same half-applied state this whole guard exists to prevent, one
+  worktree over.
+
+The frontend half is one catch arm in `useRepoStore.checkoutBranch`: it turns
+`BranchHeldByWorktree` into a `pgChoose`, retries with `take: true` on "move it
+here", and **pops the auto-stash back on every path that does not complete the
+checkout** — decline, "open that one", and a take the backend refuses on
+re-validation. That action stashes BEFORE it calls the backend, so any of those
+returning early would leave the user's work in a stash they never made. Only the
+refused take also raises a banner; a decline is a choice, not a failure.
+
 ## Deleting an untracked file (#245)
 
 `GitBackend::delete_untracked` is on the trait despite being an unlink rather

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1334,6 +1334,13 @@ not worked around: a second mechanism for the same job would also fire on `ls`.
 - **Never `window.confirm`/`window.prompt`** — `pgConfirm`/`pgPrompt` from
   `@/design`, promise-shaped, matching the native contract (dismissal →
   `false`/`null`; Escape + backdrop dismiss; empty prompt string ≠ `null`).
+- **`pgChoose` is the third one, for a refusal with two remedies** (#358).
+  Resolves the chosen option's `id`; Cancel, Escape, the backdrop and a missing
+  host ALL resolve `null`, so dismissal can never be read as an answer. Reach
+  for it instead of chaining two `pgConfirm`s — dialogs queue rather than stack,
+  so the second would appear after the first was answered rather than over it.
+  Mark at most one choice `primary`; Enter is left to the focused button, which
+  is why the Enter handler returns early for this kind.
 - `PGConfirmOptions` carries `body`, `danger`, `requireText` (type-the-name) —
   use them for destructive ops. `PGPromptOptions.multiline: <rows>` renders a
   textarea (Enter inserts a newline, ⌘/Ctrl+Enter submits; e2e's stub picks the

--- a/src-tauri/src/commands/branches.rs
+++ b/src-tauri/src/commands/branches.rs
@@ -55,15 +55,21 @@ pub async fn list_remotes(
         .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
+/// Switch to a local branch.
+///
+/// `take` releases the branch from a linked worktree that holds it instead of
+/// refusing (#358). The frontend passes it only after the user has answered the
+/// choice `BranchHeldByWorktree` raised — never on a first attempt.
 #[tauri::command]
 pub async fn checkout_branch(
     state: State<'_, AppState>,
     repo_id: String,
     name: String,
+    take: bool,
 ) -> AppResult<()> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
-    tokio::task::spawn_blocking(move || backend.checkout_branch(&repo_id, &name))
+    tokio::task::spawn_blocking(move || backend.checkout_branch(&repo_id, &name, take))
         .await
         .map_err(|e| AppError::Internal(e.to_string()))?
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -192,6 +192,17 @@ pub enum AppError {
     /// from no error at all, which is what an absent hook produces.
     #[error("the {} hook rejected this commit", .0.hook)]
     HookRejected(HookRejection),
+
+    /// A linked worktree is standing on the branch a checkout asked for (#358).
+    ///
+    /// Its own variant, carrying a STRUCT, because the remedy is a choice and
+    /// the UI has to render it: the branch can be taken from that worktree
+    /// (`checkout_branch`'s `take`), or the user can go and work there instead —
+    /// and naming which worktree, at which path, is the whole difference between
+    /// an actionable refusal and libgit2's "current HEAD of a linked
+    /// repository". Prose in a `Git` string could not be offered as buttons.
+    #[error("{} is checked out in worktree {}", .0.branch, .0.worktree)]
+    BranchHeldByWorktree(BranchHeld),
 }
 
 /// A hook's refusal (#232). `output` is whatever the hook printed, verbatim —
@@ -201,6 +212,26 @@ pub enum AppError {
 pub struct HookRejection {
     pub hook: String,
     pub output: String,
+}
+
+/// Which worktree holds a branch, and whether it can be made to let go (#358).
+///
+/// `blocked` is the load-bearing field: `None` means a take would succeed, so
+/// the UI can offer it. `Some(reason)` means it would not, so the UI must say
+/// why instead of offering a button that is going to fail. `dirty` only changes
+/// the wording — a dirty holder is still releasable, because releasing rewrites
+/// its HEAD and never its working tree.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BranchHeld {
+    pub branch: String,
+    /// git's worktree name — the basename of its directory.
+    pub worktree: String,
+    /// Absolute path, which is what tells two same-named checkouts apart and
+    /// what "open that one instead" opens.
+    pub path: String,
+    pub blocked: Option<String>,
+    pub dirty: bool,
 }
 
 impl From<git2::Error> for AppError {

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -292,7 +292,7 @@ impl GitBackend for CliBackend {
     fn remotes(&self, _repo_id: &RepoId) -> AppResult<Vec<RemoteInfo>> {
         Err(AppError::NotImplemented)
     }
-    fn checkout_branch(&self, _repo_id: &RepoId, _name: &str) -> AppResult<()> {
+    fn checkout_branch(&self, _repo_id: &RepoId, _name: &str, _take: bool) -> AppResult<()> {
         Err(AppError::NotImplemented)
     }
     fn create_branch(&self, _repo_id: &RepoId, _name: &str, _from: Option<&str>) -> AppResult<()> {

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -2700,19 +2700,97 @@ fn reject_checked_out(repo: &Repository, branch: &str) -> AppResult<()> {
 /// between the two branches showed up staged. So the check happens here, before
 /// anything is written.
 ///
-/// `checked_out_at`'s `head` argument is deliberately `None`, which skips its
-/// "this worktree" case: only LINKED worktrees block a checkout. The branch this
-/// repository is already on is a legal target — `git checkout <current>` is a
-/// no-op, not an error — so `reject_checked_out`, the obvious reuse, is the
-/// wrong helper here.
-fn reject_held_by_linked_worktree(repo: &Repository, branch: &str) -> AppResult<()> {
-    let linked = crate::git::worktree::linked_worktree_heads(repo);
-    match checked_out_at(branch, None, &linked) {
-        None => Ok(()),
-        Some(where_) => Err(AppError::InvalidArgument(format!(
-            "{branch} is checked out in {where_} — switch to it there, or remove that worktree first"
-        ))),
+/// Only LINKED worktrees are looked at: the branch this repository is already on
+/// is a legal target — `git checkout <current>` is a no-op, not an error — so
+/// `reject_checked_out`, the obvious reuse, is the wrong helper here.
+///
+/// Returns the holding worktree's name, or `None` when the branch is free.
+fn held_by_linked_worktree(repo: &Repository, branch: &str) -> Option<String> {
+    crate::git::worktree::linked_worktree_heads(repo)
+        .into_iter()
+        .find(|(_, on)| on == branch)
+        .map(|(wt, _)| wt)
+}
+
+/// Why `worktree` cannot release its branch right now, or `None` when it can.
+///
+/// Two refusals, both about state that a detached HEAD would abandon rather than
+/// preserve:
+///
+/// - **Locked** is an explicit "leave me alone" that a user or another tool set,
+///   and the whole point of the lock is that operations honour it.
+/// - **Mid-operation** — a rebase, merge, cherry-pick, revert or bisect in
+///   progress. git tracks those against HEAD, so moving HEAD out from under one
+///   leaves a half-finished operation that neither git nor the user can explain.
+///
+/// Dirtiness is deliberately NOT a blocker: releasing rewrites HEAD and never
+/// the working tree, so uncommitted work is untouched. It is reported separately
+/// so the confirmation can mention it.
+fn release_blocker(repo: &Repository, worktree: &str) -> (Option<String>, bool) {
+    let Ok(wt) = repo.find_worktree(worktree) else {
+        return (Some("its worktree cannot be read".to_string()), false);
+    };
+    let Ok(wrepo) = Repository::open_from_worktree(&wt) else {
+        return (Some("its worktree cannot be opened".to_string()), false);
+    };
+    // Computed BEFORE any refusal returns: `dirty` describes the holder for the
+    // confirmation's wording, and a blocked holder still has to be described —
+    // returning early from the lock check reported every locked worktree as
+    // clean.
+    let dirty = wrepo
+        .statuses(None)
+        .map(|s| s.iter().any(|e| e.status() != git2::Status::CURRENT))
+        .unwrap_or(false);
+    if let Ok(git2::WorktreeLockStatus::Locked(reason)) = wt.is_locked() {
+        let why = reason
+            .as_deref()
+            .map(|r| r.trim())
+            .filter(|r| !r.is_empty())
+            .map(|r| format!("it is locked: {r}"))
+            .unwrap_or_else(|| "it is locked".to_string());
+        return (Some(why), dirty);
     }
+    let busy = match wrepo.state() {
+        git2::RepositoryState::Clean => None,
+        git2::RepositoryState::Merge => Some("a merge"),
+        git2::RepositoryState::Revert | git2::RepositoryState::RevertSequence => Some("a revert"),
+        git2::RepositoryState::CherryPick | git2::RepositoryState::CherryPickSequence => {
+            Some("a cherry-pick")
+        }
+        git2::RepositoryState::Bisect => Some("a bisect"),
+        git2::RepositoryState::Rebase
+        | git2::RepositoryState::RebaseInteractive
+        | git2::RepositoryState::RebaseMerge => Some("a rebase"),
+        git2::RepositoryState::ApplyMailbox | git2::RepositoryState::ApplyMailboxOrRebase => {
+            Some("an am")
+        }
+    };
+    (busy.map(|op| format!("{op} is in progress there")), dirty)
+}
+
+/// The refusal a CHECKOUT gets when a linked worktree is standing on the target
+/// branch — git's own `'x' is already used by worktree at '…'`.
+///
+/// libgit2 refuses this too, but it refuses from `set_head`, which runs *after*
+/// `checkout_tree` has already rewritten the index and the working tree. That
+/// ordering is what turned this into a data bug rather than an error message:
+/// the tree became the target's, HEAD stayed put, and the entire difference
+/// between the two branches showed up staged. So the check happens before
+/// anything is written, and it describes the holder well enough for the UI to
+/// offer the take (#358).
+fn describe_holder(repo: &Repository, branch: &str, worktree: &str) -> AppError {
+    let (blocked, dirty) = release_blocker(repo, worktree);
+    let path = repo
+        .find_worktree(worktree)
+        .map(|wt| wt.path().to_string_lossy().to_string())
+        .unwrap_or_default();
+    AppError::BranchHeldByWorktree(crate::error::BranchHeld {
+        branch: branch.to_string(),
+        worktree: worktree.to_string(),
+        path,
+        blocked,
+        dirty,
+    })
 }
 
 /// Local branch names, in listing order.
@@ -4759,12 +4837,29 @@ impl GitBackend for Libgit2Backend {
         })
     }
 
-    fn checkout_branch(&self, repo_id: &RepoId, name: &str) -> AppResult<()> {
+    fn checkout_branch(&self, repo_id: &RepoId, name: &str, take: bool) -> AppResult<()> {
         self.with_repo(repo_id, |repo| {
             // Before ANY of the checks that can write: a branch another worktree
             // is standing on cannot be checked out here, and finding that out
-            // from `set_head` would be too late (see the helper).
-            reject_held_by_linked_worktree(repo, name)?;
+            // from `set_head` would be too late (see `describe_holder`).
+            //
+            // The holder is resolved, validated and — if `take` — released inside
+            // this ONE `with_repo` closure, so nothing can move in between. Same
+            // rule as the stash ops: verify and mutate under one acquisition.
+            let holder = held_by_linked_worktree(repo, name);
+            if let Some(worktree) = holder.as_deref() {
+                if !take {
+                    return Err(describe_holder(repo, name, worktree));
+                }
+                // Re-checked here rather than trusting the `blocked` the refusal
+                // reported: the user saw that a dialog ago, and a lock or a
+                // rebase can have started since.
+                if let (Some(why), _) = release_blocker(repo, worktree) {
+                    return Err(AppError::InvalidArgument(format!(
+                        "{name} cannot be taken from worktree {worktree} — {why}"
+                    )));
+                }
+            }
             // Refuse only when tracked paths have pending modifications or staged
             // changes; untracked files are fine unless they would be overwritten by
             // the target tree (that's checked by checkout_tree's conflict detection).
@@ -4793,25 +4888,56 @@ impl GitBackend for Libgit2Backend {
             // Captured before the tree write, so a failed `set_head` can put the
             // checkout back where it started. Unborn HEAD has nothing to restore.
             let previous = repo.head().and_then(|h| h.peel(git2::ObjectType::Commit));
-            repo.checkout_tree(&obj, None).map_err(|e| match e.code() {
-                git2::ErrorCode::Conflict => AppError::DirtyWorktree(
-                    "untracked files would be overwritten by checkout".into(),
-                ),
-                _ => AppError::from(e),
-            })?;
-            // `checkout_tree` has now rewritten the index and the working tree,
-            // and only the ref move is left. A failure here used to be left
-            // exactly as it fell — the target's tree under an unmoved HEAD, which
-            // reads as "the whole branch diff is staged". The worktree was
+
+            // Release the branch from its holder — the FIRST mutation this op
+            // makes. `set_head_detached` to the commit that worktree is already
+            // standing on rewrites its HEAD file and NOTHING else: no checkout,
+            // no index write. That is the whole reason a take is safe to offer —
+            // uncommitted work over there is not even looked at.
+            let released = match holder.as_deref() {
+                None => None,
+                Some(worktree) => {
+                    let wt = repo.find_worktree(worktree)?;
+                    let wrepo = Repository::open_from_worktree(&wt)?;
+                    let at = wrepo.head()?.peel_to_commit()?.id();
+                    wrepo.set_head_detached(at)?;
+                    Some(wrepo)
+                }
+            };
+
+            // `checkout_tree` rewrites the index and the working tree, and only
+            // the ref move is left after it. A failure at either point used to be
+            // left exactly as it fell — the target's tree under an unmoved HEAD,
+            // which reads as "the whole branch diff is staged". This worktree was
             // verified clean above, so the reset restores where we started rather
             // than discarding anyone's work.
-            if let Err(e) = repo.set_head(&refname) {
-                if let Ok(previous) = previous {
-                    let _ = repo.reset(&previous, git2::ResetType::Hard, None);
+            let outcome = repo
+                .checkout_tree(&obj, None)
+                .map_err(|e| match e.code() {
+                    git2::ErrorCode::Conflict => AppError::DirtyWorktree(
+                        "untracked files would be overwritten by checkout".into(),
+                    ),
+                    _ => AppError::from(e),
+                })
+                .and_then(|()| {
+                    repo.set_head(&refname).map_err(|e| {
+                        if let Ok(previous) = &previous {
+                            let _ = repo.reset(previous, git2::ResetType::Hard, None);
+                        }
+                        AppError::from(e)
+                    })
+                });
+
+            if outcome.is_err() {
+                // Undo the release. Leaving that worktree detached would have
+                // cost it its branch for a checkout that never happened — the
+                // same class of half-applied state this whole guard exists to
+                // prevent, just one worktree over.
+                if let Some(wrepo) = &released {
+                    let _ = wrepo.set_head(&refname);
                 }
-                return Err(AppError::from(e));
             }
-            Ok(())
+            outcome
         })
     }
     fn create_branch(&self, repo_id: &RepoId, name: &str, from: Option<&str>) -> AppResult<()> {

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -561,7 +561,22 @@ pub trait GitBackend: Send + Sync {
     ) -> AppResult<()>;
 
     // === refs ===
-    fn checkout_branch(&self, repo_id: &RepoId, name: &str) -> AppResult<()>;
+    /// Switch this worktree to a local branch.
+    ///
+    /// `take` decides what happens when a LINKED worktree is already standing on
+    /// `name`, which git forbids two worktrees from doing at once:
+    ///
+    /// - `false` — refuse with `BranchHeldByWorktree`, naming the holder so the
+    ///   caller can offer a choice. Nothing is written.
+    /// - `true` — release the branch from that worktree first, by detaching its
+    ///   HEAD to the commit it is already on. Its working tree is never written
+    ///   to, so uncommitted work there survives; a holder that is locked or
+    ///   mid-operation is refused instead.
+    ///
+    /// Validation and both ref moves happen under ONE lock acquisition, and a
+    /// checkout that fails after the release puts the holder back on its branch
+    /// — see the implementation.
+    fn checkout_branch(&self, repo_id: &RepoId, name: &str, take: bool) -> AppResult<()>;
     fn create_branch(&self, repo_id: &RepoId, name: &str, from: Option<&str>) -> AppResult<()>;
     fn delete_branch(&self, repo_id: &RepoId, name: &str, force: bool) -> AppResult<()>;
     fn rename_branch(&self, repo_id: &RepoId, from: &str, to: &str) -> AppResult<()>;

--- a/src-tauri/tests/branches_tags.rs
+++ b/src-tauri/tests/branches_tags.rs
@@ -12,7 +12,7 @@ fn checkout_moves_head_to_existing_branch() {
     tr.repo.branch("feature", &head_commit, false).unwrap();
 
     backend
-        .checkout_branch(&handle.id, "feature")
+        .checkout_branch(&handle.id, "feature", false)
         .expect("checkout");
 
     let head = tr.repo.head().unwrap();
@@ -154,7 +154,7 @@ fn checkout_is_ok_with_untracked_files_that_dont_conflict() {
     support::fs::write_file(tr.path(), "scratch.txt", "junk\n");
 
     backend
-        .checkout_branch(&handle.id, "feature")
+        .checkout_branch(&handle.id, "feature", false)
         .expect("untracked file should not block checkout");
 }
 
@@ -168,7 +168,7 @@ fn checkout_refuses_with_modified_tracked_file() {
     support::fs::write_file(tr.path(), "README.md", "modified\n");
 
     let err = backend
-        .checkout_branch(&handle.id, "feature")
+        .checkout_branch(&handle.id, "feature", false)
         .unwrap_err();
     assert!(matches!(err, platypusgit_lib::error::AppError::DirtyWorktree(_)));
 }
@@ -179,7 +179,7 @@ fn delete_unmerged_branch_is_refused_without_force() {
     let (backend, handle) = tr.open_with_backend();
     // Create a branch, check it out, commit a change on it, go back to main.
     backend.create_branch(&handle.id, "feature", None).unwrap();
-    backend.checkout_branch(&handle.id, "feature").unwrap();
+    backend.checkout_branch(&handle.id, "feature", false).unwrap();
     support::fs::write_file(tr.path(), "NOTES.md", "notes\n");
     backend.stage(&handle.id, &[std::path::PathBuf::from("NOTES.md")]).unwrap();
     backend
@@ -195,7 +195,7 @@ fn delete_unmerged_branch_is_refused_without_force() {
             },
         )
         .unwrap();
-    backend.checkout_branch(&handle.id, "main").unwrap();
+    backend.checkout_branch(&handle.id, "main", false).unwrap();
 
     let err = backend.delete_branch(&handle.id, "feature", false).unwrap_err();
     assert!(matches!(err, platypusgit_lib::error::AppError::NotMerged(_)));
@@ -433,7 +433,7 @@ fn without_main(tr: &TempRepo, keep: &str) {
     let (backend, handle) = tr.open_with_backend();
     let tip = tr.repo.head().unwrap().peel_to_commit().unwrap();
     tr.repo.branch(keep, &tip, false).unwrap();
-    backend.checkout_branch(&handle.id, keep).unwrap();
+    backend.checkout_branch(&handle.id, keep, false).unwrap();
     backend.delete_branch(&handle.id, "main", false).unwrap();
 }
 

--- a/src-tauri/tests/browse_tree_at_rev.rs
+++ b/src-tauri/tests/browse_tree_at_rev.rs
@@ -72,7 +72,7 @@ fn resolves_branch_revspec() {
     let tr = TempRepo::with_initial_commit("main content\n");
     let (backend, handle) = tr.open_with_backend();
     backend.create_branch(&handle.id, "feature", None).unwrap();
-    backend.checkout_branch(&handle.id, "feature").unwrap();
+    backend.checkout_branch(&handle.id, "feature", false).unwrap();
     write_file(tr.path(), "feature.txt", "on feature\n");
     tr.commit_all("feature commit");
 

--- a/src-tauri/tests/cherry_pick_revert.rs
+++ b/src-tauri/tests/cherry_pick_revert.rs
@@ -12,7 +12,7 @@ fn cherry_pick_applies_commit_onto_head() {
 
     // Create branch `feature`, commit a change there, go back to main.
     backend.create_branch(&handle.id, "feature", None).unwrap();
-    backend.checkout_branch(&handle.id, "feature").unwrap();
+    backend.checkout_branch(&handle.id, "feature", false).unwrap();
     write_file(tr.path(), "NOTES.md", "hello notes\n");
     backend.stage(&handle.id, &[PathBuf::from("NOTES.md")]).unwrap();
     let feature_oid = backend
@@ -30,7 +30,7 @@ fn cherry_pick_applies_commit_onto_head() {
         .unwrap()
         .oid;
 
-    backend.checkout_branch(&handle.id, "main").unwrap();
+    backend.checkout_branch(&handle.id, "main", false).unwrap();
     assert!(!tr.path().join("NOTES.md").exists());
 
     backend.cherry_pick(&handle.id, &feature_oid).unwrap();

--- a/src-tauri/tests/diff_commit.rs
+++ b/src-tauri/tests/diff_commit.rs
@@ -51,7 +51,7 @@ fn diff_commit_merge_uses_first_parent() {
 
     // feature branch off the initial commit, adds feat.txt.
     backend.create_branch(&handle.id, "feature", None).unwrap();
-    backend.checkout_branch(&handle.id, "feature").unwrap();
+    backend.checkout_branch(&handle.id, "feature", false).unwrap();
     // The backend's checkout wrote a fresh index to disk; tr.repo caches its
     // own index in memory, so force it to re-read before committing through it
     // (else the previous branch's staged files leak into this commit's tree).
@@ -59,7 +59,7 @@ fn diff_commit_merge_uses_first_parent() {
     tr.add_commit("feat.txt", "feature\n", "feature work");
 
     // main diverges, adds main.txt.
-    backend.checkout_branch(&handle.id, "main").unwrap();
+    backend.checkout_branch(&handle.id, "main", false).unwrap();
     tr.repo.index().unwrap().read(true).unwrap();
     tr.add_commit("main.txt", "main\n", "main work");
 

--- a/src-tauri/tests/ref_compare.rs
+++ b/src-tauri/tests/ref_compare.rs
@@ -30,12 +30,12 @@ fn diverged() -> TempRepo {
         }
 
         // 3 commits on feature.
-        backend.checkout_branch(&handle.id, "feature").unwrap();
+        backend.checkout_branch(&handle.id, "feature", false).unwrap();
         for i in 0..3 {
             write_file(tr.path(), "feature.txt", &format!("feature {i}\n"));
             tr.commit_all(&format!("feature {i}"));
         }
-        backend.checkout_branch(&handle.id, "main").unwrap();
+        backend.checkout_branch(&handle.id, "main", false).unwrap();
     }
     tr
 }

--- a/src-tauri/tests/support/mod.rs
+++ b/src-tauri/tests/support/mod.rs
@@ -114,7 +114,7 @@ pub fn with_conflicting_merge() -> TempRepo {
         let (backend, handle) = tr.open_with_backend();
         // feature branch: change README.
         backend.create_branch(&handle.id, "feature", None).unwrap();
-        backend.checkout_branch(&handle.id, "feature").unwrap();
+        backend.checkout_branch(&handle.id, "feature", false).unwrap();
         write_file(tr.path(), "README.md", "feature branch content\n");
         backend.stage(&handle.id, &[PathBuf::from("README.md")]).unwrap();
         backend
@@ -132,7 +132,7 @@ pub fn with_conflicting_merge() -> TempRepo {
             .unwrap();
 
         // main: change README differently.
-        backend.checkout_branch(&handle.id, "main").unwrap();
+        backend.checkout_branch(&handle.id, "main", false).unwrap();
         write_file(tr.path(), "README.md", "main branch content\n");
         backend.stage(&handle.id, &[PathBuf::from("README.md")]).unwrap();
         backend

--- a/src-tauri/tests/worktrees.rs
+++ b/src-tauri/tests/worktrees.rs
@@ -7,8 +7,13 @@
 
 mod support;
 
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+
 use platypusgit_lib::error::AppError;
-use platypusgit_lib::git::types::WorktreeBranch;
+use platypusgit_lib::git::libgit2::Libgit2Backend;
+use platypusgit_lib::git::types::{RepoId, WorktreeBranch};
 use platypusgit_lib::git::GitBackend;
 use support::{git_in, worktree_target, TempRepo};
 
@@ -271,14 +276,14 @@ fn checkout_refuses_a_branch_held_by_a_linked_worktree_and_touches_nothing() {
     let head_before = git_in(tr.path(), &["rev-parse", "HEAD"]);
 
     let err = backend
-        .checkout_branch(&handle.id, "held")
+        .checkout_branch(&handle.id, "held", false)
         .expect_err("a branch held by a linked worktree cannot be checked out here");
     match &err {
-        AppError::InvalidArgument(m) => assert!(
-            m.contains("held") && m.contains("worktree"),
-            "the refusal should name the branch and where it is checked out: {m}"
-        ),
-        other => panic!("expected InvalidArgument, got {other:?}"),
+        AppError::BranchHeldByWorktree(held) => {
+            assert_eq!(held.branch, "held");
+            assert_eq!(held.worktree, "held-elsewhere");
+        }
+        other => panic!("expected BranchHeldByWorktree, got {other:?}"),
     }
 
     // The whole point: a refused checkout is a no-op.
@@ -310,6 +315,252 @@ fn checkout_still_accepts_the_branch_this_worktree_is_already_on() {
         .to_string();
 
     backend
-        .checkout_branch(&handle.id, &current)
+        .checkout_branch(&handle.id, &current, false)
         .expect("checking out the current branch is a no-op, not an error");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Taking a held branch (#358)
+//
+// The refusal above tells the user where the branch is, but the answer they
+// usually want is "bring it here". A worktree can RELEASE a branch without
+// being removed: it is already standing on the branch's tip, so releasing is a
+// rewrite of its HEAD to the same oid — `set_head_detached`, no checkout, no
+// index write. That is why its uncommitted work survives, and these tests are
+// what pin that.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build the shape every test below needs: `held` forked at the initial commit
+/// and checked out in a linked worktree, `main` one commit ahead. Returns the
+/// holder's path.
+fn with_holder(tr: &TempRepo, backend: &Libgit2Backend, id: &RepoId) -> (TempDir, PathBuf) {
+    backend.create_branch(id, "held", None).expect("create_branch");
+    tr.add_commit(
+        "only-on-main.txt",
+        "main moved on\n",
+        "feat: a commit only main has",
+    );
+    let (hold, path) = worktree_target("holder");
+    backend
+        .worktree_add(id, &path, WorktreeBranch::Existing("held".to_string()))
+        .expect("worktree_add");
+    (hold, path)
+}
+
+#[test]
+fn taking_a_held_branch_checks_it_out_here_and_leaves_the_holder_detached() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let (_hold, holder) = with_holder(&tr, &backend, &handle.id);
+
+    let tip = git_in(&holder, &["rev-parse", "HEAD"]).trim().to_string();
+
+    backend
+        .checkout_branch(&handle.id, "held", true)
+        .expect("taking the branch should succeed");
+
+    // Here: actually on the branch.
+    assert_eq!(
+        git_in(tr.path(), &["rev-parse", "--abbrev-ref", "HEAD"]).trim(),
+        "held"
+    );
+    // There: same commit, no longer on the branch, directory still a worktree.
+    assert_eq!(
+        git_in(&holder, &["rev-parse", "--abbrev-ref", "HEAD"]).trim(),
+        "HEAD",
+        "the holder should be detached"
+    );
+    assert_eq!(
+        git_in(&holder, &["rev-parse", "HEAD"]).trim(),
+        tip,
+        "the holder must not move off the commit it was on"
+    );
+    assert!(
+        holder.join("README.md").exists(),
+        "releasing a branch must not touch the holder's files"
+    );
+}
+
+#[test]
+fn taking_a_held_branch_leaves_the_holders_uncommitted_work_alone() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let (_hold, holder) = with_holder(&tr, &backend, &handle.id);
+
+    // Someone is mid-thought in that worktree.
+    std::fs::write(holder.join("README.md"), "half-finished edit\n").expect("write");
+    std::fs::write(holder.join("scratch.txt"), "untracked notes\n").expect("write");
+
+    backend
+        .checkout_branch(&handle.id, "held", true)
+        .expect("a dirty holder is still releasable — its files are never written");
+
+    let status = git_in(&holder, &["status", "--porcelain"]);
+    assert!(
+        status.contains("README.md"),
+        "the holder's modification must survive:\n{status}"
+    );
+    assert!(
+        status.contains("scratch.txt"),
+        "the holder's untracked file must survive:\n{status}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(holder.join("README.md")).expect("read"),
+        "half-finished edit\n",
+        "the holder's working tree is never written to"
+    );
+}
+
+#[test]
+fn taking_is_refused_while_the_holder_is_locked() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let (_hold, holder) = with_holder(&tr, &backend, &handle.id);
+
+    backend
+        .worktree_lock(&handle.id, "holder", Some("do not touch"))
+        .expect("worktree_lock");
+
+    let err = backend
+        .checkout_branch(&handle.id, "held", true)
+        .expect_err("a lock is an explicit 'leave me alone'");
+    match &err {
+        AppError::InvalidArgument(m) => {
+            assert!(m.contains("locked"), "the refusal should say it is locked: {m}")
+        }
+        other => panic!("expected InvalidArgument, got {other:?}"),
+    }
+    assert_eq!(
+        git_in(&holder, &["rev-parse", "--abbrev-ref", "HEAD"]).trim(),
+        "held",
+        "a refused take must leave the holder on its branch"
+    );
+}
+
+#[test]
+fn taking_is_refused_while_the_holder_is_mid_operation() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let (_hold, holder) = with_holder(&tr, &backend, &handle.id);
+
+    // A merge left half-done in the holder. Detaching HEAD under an in-progress
+    // operation abandons it in a state neither git nor the user can explain.
+    backend
+        .create_branch(&handle.id, "other", None)
+        .expect("create_branch");
+    git_in(&holder, &["merge", "--no-commit", "--no-ff", "main"]);
+    assert!(
+        holder.join(".git").exists(),
+        "sanity: the holder is a linked worktree"
+    );
+
+    let err = backend
+        .checkout_branch(&handle.id, "held", true)
+        .expect_err("a half-finished operation must block the take");
+    match &err {
+        AppError::InvalidArgument(m) => assert!(
+            m.contains("in progress"),
+            "the refusal should name the unfinished operation: {m}"
+        ),
+        other => panic!("expected InvalidArgument, got {other:?}"),
+    }
+    assert_eq!(
+        git_in(&holder, &["rev-parse", "--abbrev-ref", "HEAD"]).trim(),
+        "held",
+        "a refused take must leave the holder on its branch"
+    );
+}
+
+#[test]
+fn a_take_whose_checkout_fails_puts_the_holder_back_on_its_branch() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let (_hold, holder) = with_holder(&tr, &backend, &handle.id);
+
+    // Give `held` a file main does not have...
+    std::fs::write(holder.join("f.txt"), "from held\n").expect("write");
+    git_in(&holder, &["add", "f.txt"]);
+    git_in(&holder, &["commit", "-m", "add f"]);
+    // ...and put an untracked one of the same name here, so the checkout that
+    // follows the release is refused rather than overwriting it.
+    support::fs::write_file(tr.path(), "f.txt", "mine, untracked\n");
+
+    let err = backend
+        .checkout_branch(&handle.id, "held", true)
+        .expect_err("an untracked file in the way must still refuse the checkout");
+    assert!(
+        matches!(err, AppError::DirtyWorktree(_)),
+        "expected DirtyWorktree, got {err:?}"
+    );
+
+    // The release must be undone: leaving the holder detached would have cost it
+    // its branch for a checkout that never happened.
+    assert_eq!(
+        git_in(&holder, &["rev-parse", "--abbrev-ref", "HEAD"]).trim(),
+        "held",
+        "the holder must be back on its branch"
+    );
+    assert_eq!(
+        std::fs::read_to_string(tr.path().join("f.txt")).expect("read"),
+        "mine, untracked\n",
+        "and our untracked file must be untouched"
+    );
+}
+
+#[test]
+fn the_refusal_names_the_branch_the_worktree_and_its_path() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let (_hold, _holder) = with_holder(&tr, &backend, &handle.id);
+
+    let err = backend
+        .checkout_branch(&handle.id, "held", false)
+        .expect_err("without `take`, a held branch is still refused");
+    match &err {
+        AppError::BranchHeldByWorktree(held) => {
+            assert_eq!(held.branch, "held");
+            assert_eq!(held.worktree, "holder");
+            // The PATH is what the dialog needs: it is the only thing that tells
+            // two identically-named checkouts apart, and it is what "Open that
+            // one" opens.
+            assert!(
+                held.path.contains("holder"),
+                "the payload should carry the holder's path: {}",
+                held.path
+            );
+            assert!(
+                held.blocked.is_none(),
+                "a clean, unlocked holder is takeable: {:?}",
+                held.blocked
+            );
+            assert!(!held.dirty, "this holder has no uncommitted work");
+        }
+        other => panic!("expected BranchHeldByWorktree, got {other:?}"),
+    }
+}
+
+#[test]
+fn the_refusal_reports_a_blocked_holder_so_the_ui_can_hide_the_offer() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let (_hold, holder) = with_holder(&tr, &backend, &handle.id);
+    std::fs::write(holder.join("README.md"), "edited\n").expect("write");
+    backend
+        .worktree_lock(&handle.id, "holder", Some("do not touch"))
+        .expect("worktree_lock");
+
+    let err = backend
+        .checkout_branch(&handle.id, "held", false)
+        .expect_err("still refused");
+    match &err {
+        AppError::BranchHeldByWorktree(held) => {
+            assert!(
+                held.blocked.as_deref().is_some_and(|b| b.contains("locked")),
+                "a locked holder must be reported as blocked: {:?}",
+                held.blocked
+            );
+            assert!(held.dirty, "and its uncommitted work must be reported");
+        }
+        other => panic!("expected BranchHeldByWorktree, got {other:?}"),
+    }
 }

--- a/src/design/dialog.choose.test.tsx
+++ b/src/design/dialog.choose.test.tsx
@@ -1,0 +1,108 @@
+// The three-way choice primitive (#356 follow-up).
+//
+// `pgConfirm` answers yes/no, and a refusal that offers two different remedies
+// ("take the branch from that worktree" vs "go work in that worktree") is not a
+// yes/no question. This pins the contract that makes it safe to reach for:
+// dismissal is NEVER one of the answers, so a call site can only act on a
+// choice the user actually made.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { PGDialogHost, pgChoose, __resetDialogs } from "./dialog";
+
+beforeEach(() => __resetDialogs());
+afterEach(() => __resetDialogs());
+
+const CHOICES = [
+  { id: "open", label: "Open that one" },
+  { id: "take", label: "Move it here", primary: true },
+];
+
+describe("pgChoose", () => {
+  it("resolves the id of the choice that was clicked", async () => {
+    render(<PGDialogHost />);
+
+    const picked = pgChoose({ title: "Move it here?", choices: CHOICES });
+    await screen.findByTestId("dialog-choice-take");
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("dialog-choice-take"));
+    });
+
+    expect(await picked).toBe("take");
+  });
+
+  it("resolves the other choice's id, not just the primary one", async () => {
+    render(<PGDialogHost />);
+
+    const picked = pgChoose({ title: "Move it here?", choices: CHOICES });
+    await screen.findByTestId("dialog-choice-open");
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("dialog-choice-open"));
+    });
+
+    expect(await picked).toBe("open");
+  });
+
+  it("resolves null on Cancel, on Escape and on a backdrop click", async () => {
+    render(<PGDialogHost />);
+
+    const viaCancel = pgChoose({ title: "Move it here?", choices: CHOICES });
+    await screen.findByTestId("dialog-cancel");
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("dialog-cancel"));
+    });
+    expect(await viaCancel).toBeNull();
+
+    const viaEscape = pgChoose({ title: "Move it here?", choices: CHOICES });
+    const dialog = await screen.findByRole("dialog");
+    await act(async () => {
+      fireEvent.keyDown(dialog, { key: "Escape" });
+    });
+    expect(await viaEscape).toBeNull();
+
+    const viaBackdrop = pgChoose({ title: "Move it here?", choices: CHOICES });
+    const backdrop = await screen.findByRole("dialog");
+    await act(async () => {
+      fireEvent.mouseDown(backdrop);
+    });
+    expect(await viaBackdrop).toBeNull();
+  });
+
+  it("renders the title, the body and every choice's label", async () => {
+    render(<PGDialogHost />);
+
+    void pgChoose({
+      title: "Move it here?",
+      body: "It is checked out in worktree 'api-fixes'.",
+      choices: CHOICES,
+    });
+
+    expect(await screen.findByTestId("dialog-title")).toHaveTextContent(
+      "Move it here?",
+    );
+    expect(screen.getByText(/worktree 'api-fixes'/)).toBeTruthy();
+    expect(screen.getByTestId("dialog-choice-open")).toHaveTextContent(
+      "Open that one",
+    );
+    expect(screen.getByTestId("dialog-choice-take")).toHaveTextContent(
+      "Move it here",
+    );
+  });
+
+  it("shows no text input — a choice is not a prompt", async () => {
+    render(<PGDialogHost />);
+
+    void pgChoose({ title: "Move it here?", choices: CHOICES });
+    await screen.findByTestId("dialog-choice-take");
+
+    expect(screen.queryByTestId("dialog-input")).toBeNull();
+    expect(document.querySelector("[data-pg-dialog-kind]")).toHaveAttribute(
+      "data-pg-dialog-kind",
+      "choose",
+    );
+  });
+
+  it("resolves null rather than hanging when no host is mounted", async () => {
+    expect(await pgChoose({ title: "Move it here?", choices: CHOICES })).toBeNull();
+  });
+});

--- a/src/design/dialog.tsx
+++ b/src/design/dialog.tsx
@@ -66,9 +66,34 @@ export interface PGPromptOptions {
   multiline?: number;
 }
 
+/** One answer offered by `pgChoose`. */
+export interface PGChooseOption {
+  /** What `pgChoose` resolves to when this one is picked. */
+  id: string;
+  label: string;
+  /** Filled primary button — the recommended answer. At most one. */
+  primary?: boolean;
+  /** Red button — the destructive answer, if there is one. */
+  danger?: boolean;
+}
+
+export interface PGChooseOptions {
+  /** Headline. Keep it a question. */
+  title: string;
+  /** Optional detail under the title. */
+  body?: ReactNode;
+  /**
+   * The answers, left to right. Dismissal is never one of them — see
+   * `pgChoose`.
+   */
+  choices: PGChooseOption[];
+  cancelLabel?: string;
+}
+
 type Request =
   | { id: number; kind: "confirm"; opts: PGConfirmOptions; resolve: (v: boolean) => void }
-  | { id: number; kind: "prompt"; opts: PGPromptOptions; resolve: (v: string | null) => void };
+  | { id: number; kind: "prompt"; opts: PGPromptOptions; resolve: (v: string | null) => void }
+  | { id: number; kind: "choose"; opts: PGChooseOptions; resolve: (v: string | null) => void };
 
 let nextId = 1;
 let queue: Request[] = [];
@@ -138,6 +163,24 @@ export function pgPrompt(opts: PGPromptOptions | string): Promise<string | null>
   });
 }
 
+/**
+ * Ask the user to pick one of several named answers. Resolves the chosen
+ * option's `id`.
+ *
+ * **Dismissal is never a choice.** Escape, the backdrop, Cancel and a missing
+ * host all resolve `null`, so a call site can only act on an answer the user
+ * actually gave — the same reason `pgConfirm` resolves false rather than
+ * throwing. Reach for this instead of chaining two `pgConfirm`s when a refusal
+ * has two genuinely different remedies; a second modal over the first cannot be
+ * dismissed predictably (see the queue note at the top of this file).
+ */
+export function pgChoose(opts: PGChooseOptions): Promise<string | null> {
+  if (listeners.size === 0) return Promise.resolve(null);
+  return new Promise<string | null>((resolve) => {
+    push({ id: nextId++, kind: "choose", opts, resolve });
+  });
+}
+
 function useQueueHead(): Request | undefined {
   const [, force] = React.useReducer((n: number) => n + 1, 0);
   React.useEffect(() => {
@@ -161,6 +204,10 @@ export function PGDialogHost() {
 
 function DialogView({ req }: { req: Request }) {
   const isConfirm = req.kind === "confirm";
+  // A choice is neither a question nor a field: it renders no input, and it has
+  // no single "accept" for Enter to mean.
+  const isPrompt = req.kind === "prompt";
+  const isChoose = req.kind === "choose";
   const danger = isConfirm && !!(req.opts as PGConfirmOptions).danger;
   // An acknowledgement, not a question — see `pgAlert`.
   const hideCancel = isConfirm && !!(req.opts as PGConfirmOptions).hideCancel;
@@ -205,6 +252,10 @@ function DialogView({ req }: { req: Request }) {
       e.preventDefault();
       cancel();
     } else if (e.key === "Enter" && !e.shiftKey) {
+      // A choice dialog has no single answer to submit: Enter belongs to
+      // whichever choice button has focus, and calling preventDefault here
+      // would swallow the browser's own activation of it.
+      if (isChoose) return;
       // In a multi-line prompt Enter belongs to the text; submitting is a chord.
       if (!isConfirm && promptOpts.multiline && !(e.metaKey || e.ctrlKey)) return;
       e.stopPropagation();
@@ -295,7 +346,7 @@ function DialogView({ req }: { req: Request }) {
           </div>
         </div>
 
-        {!isConfirm &&
+        {isPrompt &&
           (promptOpts.multiline ? (
             <textarea
               ref={areaRef}
@@ -340,21 +391,46 @@ function DialogView({ req }: { req: Request }) {
           />
         )}
 
-        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
-          {!hideCancel && (
-            <PGButton size="sm" variant="ghost" onClick={cancel} data-testid="dialog-cancel">
-              {cancelLabel}
-            </PGButton>
-          )}
-          <PGButton
-            size="sm"
-            variant={danger ? "danger" : "primary"}
-            disabled={!canSubmit}
-            onClick={accept}
-            data-testid="dialog-confirm"
-          >
-            {confirmLabel}
-          </PGButton>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "flex-end",
+            gap: 8,
+            // Three answers plus Cancel do not always fit 440px, and a choice
+            // the user cannot see is a choice they cannot make.
+            flexWrap: "wrap",
+          }}
+        >
+          <>
+            {!hideCancel && (
+              <PGButton size="sm" variant="ghost" onClick={cancel} data-testid="dialog-cancel">
+                {cancelLabel}
+              </PGButton>
+            )}
+            {isChoose ? (
+              (req.opts as PGChooseOptions).choices.map((c) => (
+                <PGButton
+                  key={c.id}
+                  size="sm"
+                  variant={c.danger ? "danger" : c.primary ? "primary" : "default"}
+                  onClick={() => settle(req.id, c.id)}
+                  data-testid={`dialog-choice-${c.id}`}
+                >
+                  {c.label}
+                </PGButton>
+              ))
+            ) : (
+              <PGButton
+                size="sm"
+                variant={danger ? "danger" : "primary"}
+                disabled={!canSubmit}
+                onClick={accept}
+                data-testid="dialog-confirm"
+              >
+                {confirmLabel}
+              </PGButton>
+            )}
+          </>
         </div>
       </div>
     </div>,

--- a/src/features/repo/useRepoStore.checkoutHeld.test.tsx
+++ b/src/features/repo/useRepoStore.checkoutHeld.test.tsx
@@ -1,0 +1,187 @@
+// `checkoutBranch` when a linked worktree holds the branch (#358).
+//
+// The backend refuses with `BranchHeldByWorktree` rather than mangling the
+// index, and the store turns that refusal into the choice the user actually
+// wants: take the branch from that worktree, or go and work in it.
+//
+// The trap this file exists for is the AUTO-STASH. `checkoutBranch` stashes
+// uncommitted work BEFORE it calls the backend, and pops it after a successful
+// checkout. Every path that declines the checkout therefore has to pop it back,
+// or the user's work is left sitting in a stash they never made — a refusal
+// that quietly hides their changes is the same bug class as the one that
+// started all this, just with a different symptom.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+
+import { useRepoStore } from "./useRepoStore";
+import { useTabsStore } from "./useTabsStore";
+import { WithDialogs, resetDialogs } from "@/test/dialog";
+import { getInvokeCalls, mockInvoke } from "@/test/invokeMock";
+import type { BranchHeld } from "@/lib/errors";
+
+const HELD: BranchHeld = {
+  branch: "FIM-122",
+  worktree: "api-fixes",
+  path: "/dev/proj/.worktrees/api-fixes",
+  blocked: null,
+  dirty: true,
+};
+
+/** Every `checkout_branch` invoke, as the `take` flag it was given. */
+const checkoutTakes = () =>
+  getInvokeCalls()
+    .filter((c) => c.cmd === "checkout_branch")
+    .map((c) => c.args.take);
+
+const invoked = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+
+let opened: string[] = [];
+
+function armRepo() {
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    error: null,
+    refreshAll: async () => {},
+  } as never);
+  useTabsStore.setState({
+    openRepo: async (p: string) => {
+      opened.push(p);
+    },
+  } as never);
+}
+
+/**
+ * Refuse the first attempt the way the backend does, accept a `take`.
+ * `held` lets a case vary what the holder looks like.
+ */
+function armBackend(held: BranchHeld = HELD) {
+  // A dirty tree, so the auto-stash actually produces a stash to strand.
+  mockInvoke("stash_save", () => "stash@{0}");
+  mockInvoke("stash_pop", () => null);
+  mockInvoke("checkout_branch", ({ take }) => {
+    if (!take) throw { kind: "BranchHeldByWorktree", message: held };
+    return null;
+  });
+}
+
+const pick = async (id: string) => {
+  const btn = await screen.findByTestId(`dialog-choice-${id}`);
+  await act(async () => {
+    btn.click();
+  });
+};
+
+beforeEach(() => {
+  opened = [];
+  resetDialogs();
+  armRepo();
+});
+afterEach(() => {
+  resetDialogs();
+  vi.restoreAllMocks();
+});
+
+describe("checkoutBranch against a held branch", () => {
+  it("offers the choice and retries with take when the user says move it here", async () => {
+    armBackend();
+    render(<WithDialogs>{null}</WithDialogs>);
+
+    const done = useRepoStore.getState().checkoutBranch("FIM-122");
+    await pick("take");
+    await done;
+
+    expect(checkoutTakes()).toEqual([false, true]);
+    expect(useRepoStore.getState().error).toBeNull();
+    // The stash is restored by the SUCCESS path, exactly once.
+    expect(invoked("stash_pop")).toHaveLength(1);
+  });
+
+  it("opens the holding worktree instead, without touching the branch", async () => {
+    armBackend();
+    render(<WithDialogs>{null}</WithDialogs>);
+
+    const done = useRepoStore.getState().checkoutBranch("FIM-122");
+    await pick("open");
+    await done;
+
+    expect(opened).toEqual(["/dev/proj/.worktrees/api-fixes"]);
+    expect(checkoutTakes()).toEqual([false]);
+    // Declining still has to give the user their work back.
+    expect(invoked("stash_pop")).toHaveLength(1);
+  });
+
+  it("restores the auto-stash and sets no banner when the user cancels", async () => {
+    armBackend();
+    render(<WithDialogs>{null}</WithDialogs>);
+
+    const done = useRepoStore.getState().checkoutBranch("FIM-122");
+    const cancel = await screen.findByTestId("dialog-cancel");
+    await act(async () => {
+      cancel.click();
+    });
+    await done;
+
+    expect(checkoutTakes()).toEqual([false]);
+    expect(invoked("stash_pop")).toHaveLength(1);
+    // A choice the user declined is not an error to report at them.
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
+  it("does not offer the take when the holder is blocked", async () => {
+    armBackend({ ...HELD, blocked: "a rebase is in progress there" });
+    render(<WithDialogs>{null}</WithDialogs>);
+
+    const done = useRepoStore.getState().checkoutBranch("FIM-122");
+    await screen.findByTestId("dialog-choice-open");
+
+    // Offering a button that is going to fail is worse than not offering it.
+    expect(screen.queryByTestId("dialog-choice-take")).toBeNull();
+    expect(screen.getByTestId("dialog-title").textContent).toContain("FIM-122");
+
+    await pick("open");
+    await done;
+    expect(checkoutTakes()).toEqual([false]);
+  });
+
+  it("reports any other refusal as a banner rather than a choice", async () => {
+    mockInvoke("stash_save", () => null);
+    mockInvoke("checkout_branch", () => {
+      throw { kind: "DirtyWorktree", message: "commit or stash first" };
+    });
+    render(<WithDialogs>{null}</WithDialogs>);
+
+    await useRepoStore.getState().checkoutBranch("FIM-122");
+
+    expect(useRepoStore.getState().error).toEqual({
+      kind: "DirtyWorktree",
+      message: "commit or stash first",
+    });
+  });
+
+  it("gives the work back and reports the failure when the take itself is refused", async () => {
+    // The holder acquired a lock (or started a rebase) between the refusal and
+    // the answer — the backend re-validates, so the take can still fail.
+    mockInvoke("stash_save", () => "stash@{0}");
+    mockInvoke("stash_pop", () => null);
+    mockInvoke("checkout_branch", ({ take }) => {
+      if (!take) throw { kind: "BranchHeldByWorktree", message: HELD };
+      throw { kind: "InvalidArgument", message: "it is locked: do not touch" };
+    });
+    render(<WithDialogs>{null}</WithDialogs>);
+
+    const done = useRepoStore.getState().checkoutBranch("FIM-122");
+    await pick("take");
+    await done;
+
+    expect(checkoutTakes()).toEqual([false, true]);
+    // Unlike a cancel, this one IS worth a banner — the user asked for it and
+    // it did not happen.
+    expect(useRepoStore.getState().error).toEqual({
+      kind: "InvalidArgument",
+      message: "it is locked: do not touch",
+    });
+    // And their uncommitted work must not be left in a stash they never made.
+    expect(invoked("stash_pop")).toHaveLength(1);
+  });
+});

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { pgFlash } from "@/design";
+import { pgChoose, pgFlash } from "@/design";
 import type {
   AuthorOverride,
   BisectMark,
@@ -16,7 +16,7 @@ import type {
   RebaseStep,
   RepoHandle,
 } from "@/lib/types";
-import type { AppError, HookRejection } from "@/lib/errors";
+import type { AppError, BranchHeld, HookRejection } from "@/lib/errors";
 import {
   dubiousOwnershipPath,
   isAppError,
@@ -145,6 +145,46 @@ import {
   type UndoDirection,
   type UndoKind,
 } from "./undoStack";
+
+/**
+ * The holder, when a checkout was refused because a linked worktree is standing
+ * on the branch (#358) — otherwise null, and the caller rethrows.
+ *
+ * Shape-checked rather than trusted: `message` is only a struct for the handful
+ * of variants that carry one, and a payload of the wrong type must fall through
+ * to the ordinary banner instead of rendering a dialog with `undefined` in it.
+ */
+function heldByWorktree(e: unknown): BranchHeld | null {
+  if (!isAppError(e) || e.kind !== "BranchHeldByWorktree") return null;
+  const held = e.message as BranchHeld;
+  return held && typeof held.branch === "string" && typeof held.path === "string"
+    ? held
+    : null;
+}
+
+/**
+ * Ask what to do about a branch another worktree holds.
+ *
+ * The take is offered ONLY when the backend said the holder can let go
+ * (`blocked === null`) — a button that is going to be refused is worse than no
+ * button. Cancel, Escape and the backdrop all come back as null, so declining
+ * can never be mistaken for a choice.
+ */
+async function askAboutHeldBranch(held: BranchHeld): Promise<string | null> {
+  const where = `worktree ${held.worktree} (${held.path})`;
+  const body = held.blocked
+    ? `It is checked out in ${where}, and ${held.blocked}. Finish or unlock that first, or go and work there instead.`
+    : `It is checked out in ${where}${held.dirty ? ", which has uncommitted changes" : ""}. ` +
+      `Moving it here leaves that worktree on a detached HEAD at the same commit — its files are not touched.`;
+  return pgChoose({
+    title: `Move ${held.branch} here?`,
+    body,
+    choices: [
+      { id: "open", label: "Open that one" },
+      ...(held.blocked ? [] : [{ id: "take", label: "Move it here", primary: true }]),
+    ],
+  });
+}
 
 /** Ids for undo entries. Module-level so they are unique across repositories. */
 let undoSeq = 0;
@@ -1433,7 +1473,47 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         keepIndex: false,
       });
       setActivity(repo.id, "branch", `Switching to ${name}…`);
-      await checkoutBranch(repo.id, name);
+      try {
+        await checkoutBranch(repo.id, name);
+      } catch (e) {
+        // A branch another worktree is standing on is not a failure to report —
+        // it is a question with two answers (#358). Anything else still is.
+        const held = heldByWorktree(e);
+        if (!held) throw e;
+        const answer = await askAboutHeldBranch(held);
+        if (answer !== "take") {
+          // Declined. Give the auto-stash back BEFORE going anywhere, or the
+          // user's uncommitted work is left in a stash they never made.
+          if (stashed) {
+            setActivity(repo.id, "branch", `Restoring stashed changes…`);
+            await stashPop(repo.id, 0);
+          }
+          if (answer === "open") {
+            // Imported here, not at the top: `useTabsStore` imports THIS module,
+            // and a static edge back would close the cycle at module-eval time.
+            const { useTabsStore } = await import("./useTabsStore");
+            await useTabsStore.getState().openRepo(held.path);
+          }
+          // No banner: the user chose this, and refreshAll puts the UI back in
+          // step with a repository nothing happened to.
+          await get().refreshAll();
+          return;
+        }
+        setActivity(repo.id, "branch", `Taking ${name} from ${held.worktree}…`);
+        try {
+          await checkoutBranch(repo.id, name, true);
+        } catch (takeError) {
+          // The backend re-validates, so the take can still be refused — a lock
+          // or a rebase may have started over there since the dialog opened.
+          // Hand the work back before reporting it, exactly as declining does;
+          // unlike a decline this one DOES deserve a banner, so it rethrows.
+          if (stashed) {
+            setActivity(repo.id, "branch", `Restoring stashed changes…`);
+            await stashPop(repo.id, 0);
+          }
+          throw takeError;
+        }
+      }
       if (stashed) {
         setActivity(repo.id, "branch", `Restoring stashed changes…`);
         await stashPop(repo.id, 0);

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -95,7 +95,15 @@ export type AppError =
    * of eslint belong in the dedicated output block, which scrolls. See
    * `appErrorDetail`.
    */
-  | { kind: "HookRejected"; message: HookRejection };
+  | { kind: "HookRejected"; message: HookRejection }
+  /**
+   * A linked worktree is standing on the branch a checkout asked for (#358).
+   * The payload is a STRUCT because the remedy is a CHOICE the UI renders:
+   * `blocked` says whether the branch can be taken from that worktree at all,
+   * and `path` is what "open that one instead" opens. See
+   * `useRepoStore.checkoutBranch`.
+   */
+  | { kind: "BranchHeldByWorktree"; message: BranchHeld };
 
 /** Which credential the remote is asking for. */
 export type AuthKind = "Https" | "SshPassphrase" | "SshKey";
@@ -113,6 +121,25 @@ export interface AuthChallenge {
 export interface HookRejection {
   hook: string;
   output: string;
+}
+
+/**
+ * Which worktree holds a branch, and whether it can be made to let go (#358).
+ *
+ * `blocked` is the load-bearing field: `null` means taking the branch would
+ * succeed, so the UI may offer it; a string says why it would not, so the UI
+ * says that instead of offering a button destined to fail. `dirty` only changes
+ * the wording — a dirty holder is still releasable, because releasing rewrites
+ * its HEAD and never its working tree.
+ */
+export interface BranchHeld {
+  branch: string;
+  /** git's worktree name — the basename of its directory. */
+  worktree: string;
+  /** Absolute path: what tells two same-named checkouts apart, and what opens. */
+  path: string;
+  blocked: string | null;
+  dirty: boolean;
 }
 
 export function isAppError(e: unknown): e is AppError {
@@ -175,6 +202,21 @@ function appErrorDetail(e: AppError): string {
   }
   if (e.kind === "BranchExists" && typeof message === "string") {
     return `A local branch named ${message} already exists.`;
+  }
+  // BranchHeldByWorktree carries a struct. The banner is the fallback surface
+  // here — `checkoutBranch` normally intercepts this kind and asks the user what
+  // to do instead — so the sentence has to stand alone for the paths that do
+  // not, and it names the worktree because that is the only thing that makes the
+  // refusal actionable.
+  if (
+    e.kind === "BranchHeldByWorktree" &&
+    typeof message === "object" &&
+    message !== null &&
+    typeof (message as BranchHeld).branch === "string"
+  ) {
+    const held = message as BranchHeld;
+    const why = held.blocked ? `, and ${held.blocked}` : "";
+    return `${held.branch} is checked out in the worktree at ${held.path}${why}. git allows one worktree per branch.`;
   }
   // NoSignature carries NO payload — a unit variant in Rust. Without a case
   // here `appErrorMessage` fell through to its `|| e.kind` fallback and a

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -715,8 +715,19 @@ export async function revert(repoId: string, oid: string): Promise<void> {
   return invoke<void>("revert", { repoId, oid });
 }
 
-export async function checkoutBranch(repoId: string, name: string): Promise<void> {
-  return invoke<void>("checkout_branch", { repoId, name });
+/**
+ * Switch to a local branch.
+ *
+ * `take` releases the branch from a linked worktree that holds it instead of
+ * rejecting with `BranchHeldByWorktree` (#358). Pass it only after the user has
+ * answered that refusal — `useRepoStore.checkoutBranch` owns that conversation.
+ */
+export async function checkoutBranch(
+  repoId: string,
+  name: string,
+  take = false,
+): Promise<void> {
+  return invoke<void>("checkout_branch", { repoId, name, take });
 }
 
 export async function createBranch(


### PR DESCRIPTION
Follow-up to #356. That PR stopped a checkout from mangling the index when a linked worktree held the branch, but the refusal left the user nowhere to go — the only remedies were to open that worktree or remove it. The actual ask was "I want it in *this* folder."

## The insight

**A worktree can release a branch without being removed.** It is already standing on the branch's tip, so releasing it is `set_head_detached` to the oid it is already at — a rewrite of that worktree's HEAD file and *nothing else*. No checkout, no index write, its working tree never opened.

Probed before designing anything:

```
fatal: 'held' is already used by worktree at '…/other'
$ git -C ../other checkout --detach     → HEAD is now at 2284ce9
  holder's dirty state after:  M a.txt   ?? dirty.txt     ← survived
$ git checkout held                     → Switched to branch 'held'
```

That is why this is safe to offer: uncommitted work in the holder is not even looked at.

## Backend

`checkout_branch` takes a `take` flag — `false` refuses and describes the holder, `true` releases it and proceeds. One flag on the existing command rather than a second command, matching `delete_branch(.., force)` and the `BranchExists` → retry-with-force precedent. It keeps resolve → validate → release → checkout inside ONE `with_repo` closure, so nothing can move between the check and the write.

**Refusals** are the two kinds of state a detached HEAD would abandon rather than preserve:

- a **locked** worktree — an explicit "leave me alone" that operations honour;
- one **mid-operation** — rebase, merge, cherry-pick, revert, am or bisect, read off `Repository::state()`. git tracks those against HEAD, so moving HEAD out from under one leaves a half-finished operation nobody can explain.

Dirtiness is reported, never refused. The take **re-validates** rather than trusting what the refusal reported — the user saw that a dialog ago. And a checkout that fails after the release **puts the holder back on its branch**: leaving it detached would cost it its branch for a checkout that never happened, which is the same half-applied state #356 existed to prevent, one worktree over.

## Error contract

`BranchHeldByWorktree` carries a struct — branch, worktree, path, `blocked`, `dirty` — following the `Auth` / `HookRejected` precedent, because the remedy is a *choice* the UI renders and prose in a `Git` string cannot become buttons. `blocked` is load-bearing: the take is offered only when it is null, since a button destined to fail is worse than no button.

## Frontend

`pgChoose` joins `pgConfirm`/`pgPrompt` in the design system for the three-way answer. Dismissal — Cancel, Escape, backdrop, or no host mounted — resolves `null` for it as for the others, so declining can never be read as a choice. Enter is left to the focused button rather than intercepted.

`useRepoStore.checkoutBranch` turns the refusal into that choice and retries with `take: true`. Every UI entry point already funnels through this one action, so the top menu, the log view, the branch chip and the palette all get it from one catch arm.

**It also closes an auto-stash trap found on the way in.** `checkoutBranch` stashes uncommitted work *before* calling the backend and pops it only after a successful checkout — so the old catch arm left the user's work in a stash they never made. Every path that does not complete the checkout now pops it back: decline, "open that one", and a take refused on re-validation. Only the refused take also raises a banner; a decline is a choice, not a failure.

## Tests (TDD throughout — each watched fail first)

Backend (`worktrees.rs`, 19 total): the take moves the branch and leaves the holder detached at the same commit; the holder's modified *and* untracked files survive; refusals for a locked holder and a mid-merge holder; a failed checkout re-attaches the holder; the payload names branch/worktree/path and reports a blocked holder.

The `dirty`-on-a-locked-holder test caught a real defect during the loop — an early return from the lock check reported every locked worktree as clean.

Frontend: `pgChoose` (6 cases, including "dismissal is never an answer" and "no text input"); the store's choice flow (6 cases, including the two stash-restore paths and "does not offer the take when blocked").

## Verification

- `cargo test` — 84 suites, all green.
- `pnpm test` — 316 files / 3010 tests green, error-contract and doc invariants included.
- `pnpm tsc --noEmit` — clean.
- All re-run after the last edit.
- Local Docker e2e could not run (daemon not up on the dev machine). `checkout_branch`'s only invoker is the typed wrapper, and no e2e spec checks out a branch held by a worktree, so the new path is inert for the specs; the required `e2e-linux` check covers it here.

Written up in `docs/dev/backend.md` (next to #356 and the #246 section both build on) and `docs/dev/frontend.md`; `CLAUDE.md`'s dialog rule now names `pgChoose`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
