### PR TITLE
fix(update): a Store install has no update surface at all

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,8 +333,9 @@ jobs:
   # (x64 + arm64), it needs NO signing key at all — the Store re-signs, which is
   # the whole economics of this channel — and it must not be able to break the
   # .msi or the portable zip if makeappx or the manifest is wrong. Nothing here
-  # feeds latest.json either: a Store install never self-updates
-  # (update::capability returns NotifyStore), so there is no signature to read.
+  # feeds latest.json either: a Store install never self-updates, and since #360
+  # never even CHECKS (update::capability returns StoreManaged — policy 10.2.5),
+  # so there is no signature to read and no manifest to point at.
   #
   # Spec: docs/superpowers/specs/2026-08-27-msix-store-spec.md §B
   msix:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,12 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
   with a written reason — `test/privacy.test.ts` +
   `src-tauri/tests/no_telemetry.rs`. Tripping one means changing what the README
   promises; do that deliberately, in the same commit. (`docs/dev/backend.md`)
+- **A Microsoft Store install has NO update surface** — no check, no chip, no
+  panel, no release link, no Settings control. `StoreManaged` gates the CHECK,
+  not just the install: Store policy 10.2.5 makes *notifying* the violation, and
+  v0.4.0 failed certification on it. Anything new that reads `UpdateCapability`
+  gates on `may_check_for_updates` / `updatesManagedExternally`.
+  (`docs/dev/distribution.md`)
 - **One signing chain** (`libgit2.rs::sign_payload`) for commits AND tags; a
   signing failure creates nothing. (`docs/dev/backend.md`)
 - **Never `window.confirm`/`window.prompt`** — `pgConfirm`/`pgPrompt`/`pgChoose`

--- a/docs/dev/distribution.md
+++ b/docs/dev/distribution.md
@@ -632,9 +632,9 @@ upgrade, which is exactly the axis `update::capability` expresses:
 | `.msi` direct download | per-machine installer | `SelfUpdate` |
 | Scoop bucket | portable zip in Scoop's tree | `NotifyScoop` |
 | winget | the same `.msi` | `SelfUpdate` |
-| **Store MSIX** | **read-only package** | **`NotifyStore`** |
+| **Store MSIX** | **read-only package** | **`StoreManaged`** |
 
-**`NotifyStore` is matched FIRST among the Windows arms, and that order is
+**`StoreManaged` is matched FIRST among the Windows arms, and that order is
 load-bearing.** Unlike every other notify variant it is not about giving better
 advice: an MSIX is read-only after deployment and Windows *refuses to launch a
 package whose files were tampered with*, so a self-update here does not fail —
@@ -648,6 +648,62 @@ twelve lines of `extern "system"`, no new crate. **Deliberately not** a
 packages install to other PackageVolumes and other paths. Same trap as
 `$env:SCOOP`, rejected for the same reason — the question is *"was this install
 packaged"*, and there is an API that answers exactly that.
+
+### A Store install has NO update surface — policy 10.2.5 (#360)
+
+**This is a certification gate, not a preference.** The v0.4.0 submission was
+rejected under policy **10.2.5 Security — Installing and Updating Store Apps**:
+
+> The product updates outside the Store. Please ensure that the product and
+> in-app products are updated only through the Store and resubmit.
+> **Location where update is found: In App, soon after launch**
+
+The app installed nothing. `StoreManaged` already kept it off the self-update
+path, so no "Install & restart" button was ever offered. What failed was the
+**notification**: the 2-second startup check in `AppShell` asked GitHub for the
+newest release, found one, and auto-opened `UpdatePanel` with a **"View
+release"** button onto the GitHub release page — where a user downloads the
+`.msi` and updates outside the Store. **Learning about the update inside the app
+is the violation**; you do not have to ship the bits.
+
+So `StoreManaged` (was `NotifyStore`, renamed because "notify" is now exactly
+what it must not do) means: *no request, no chip, no panel, no release link, no
+Settings control.*
+
+**Four gates, and each one is meant to be redundant:**
+
+| Where | What it does |
+| --- | --- |
+| `update::may_check_for_updates` | the rule, as one pure function |
+| `commands::update::check_for_update` | refuses with `AppError::UpdatesManagedExternally` **before** the fetch |
+| `useUpdateStore.check()` | returns early after the capability probe — this is what stops the request being made |
+| `UpdateChip` / `Settings → Updates` | render nothing to click |
+
+- **The frontend gate is the one that matters operationally** (nothing reaches
+  the network), the **backend one is the backstop** (a new call site that
+  forgets it fails closed instead of failing certification). `install()` refuses
+  too — unreachable through the UI, but it is the one action that would write to
+  the package.
+- **Settings shows the version and one sentence, not disabled controls.** A
+  greyed-out "Check for updates" beside "Automatically asks GitHub" is still
+  three statements about updating from outside the Store. Removing the section
+  entirely would leave someone looking for their version with nothing. The
+  sentence lives once, in `packageHint.ts::STORE_MANAGED_NOTE`, and names **who
+  updates this install and nothing else** — no command, no download, no release
+  page.
+- **`updateCheckMode` and `updateChannel` keep their persisted values.** They
+  are portable preferences (#254 exports them to a shareable file); this install
+  simply does not consult them. Same call the channel row already makes when
+  checks are off.
+- **The notify variants are untouched.** They still check and then defer the
+  *install* to a package manager — telling a `.deb` user that `apt upgrade` has
+  something for them is the whole point of #187. A gate that swept them up would
+  delete that feature while looking like a Store fix; `every_other_install_still_checks`
+  in `src-tauri/tests/update.rs` is what says so.
+- **`check_for_update_asks_the_gate_before_it_fetches`** pins the ORDER in the
+  source text, because `is_msix_packaged` is a compile-time `false` everywhere a
+  test can run: a gate moved below the fetch still compiles, still passes every
+  other test, and still fails certification.
 
 ### `makeappx` builds it; `winapp` is only for the local loop
 

--- a/docs/superpowers/specs/2026-08-27-msix-store-spec.md
+++ b/docs/superpowers/specs/2026-08-27-msix-store-spec.md
@@ -110,6 +110,13 @@ would write its own `Assets/`; do not let it.
 
 ### C. `update::capability` gains `NotifyStore`
 
+> **Superseded in part — read "Certification round 1" below before this
+> section.** The variant shipped as designed here and then *failed
+> certification*: it is now `StoreManaged` / `"store-managed"`, and it gates the
+> update **check**, not only the install. The design reasoning below is still
+> why the arm exists and why it wins over `SelfUpdate`; the names and the reach
+> are the amendment's.
+
 A fourth `UpdateCapability` variant, `notify-store` over IPC, plus
 `msix_packaged: bool` on `InstallEnv`, plus the mirrored member in the TS union
 (`src/lib/types.ts`). `capability` stays pure and stays fully testable on a Mac;
@@ -357,6 +364,49 @@ and launches the app *with* package identity, which is enough to answer 1–5
 without ever producing an `.msix`. `winapp unregister` afterwards, or the real
 package reports "already installed". Prerequisite: Windows 11 and
 `winget install microsoft.winappcli`.
+
+## Certification round 1 — what actually failed (2026-09-02, #360)
+
+The first submission (v0.4.0) was **rejected**, on one finding:
+
+> **10.2.5 Security - Installing and Updating Store Apps** — The product updates
+> outside the Store. Please ensure that the product and in-app products are
+> updated only through the Store and resubmit.
+> **Location where update is found: In App, soon after launch**
+
+**§C was necessary and not sufficient.** `NotifyStore` correctly kept a packaged
+install off the self-update path, so the app never *installed* anything outside
+the Store — and this spec treated that as the whole of the problem. It is not.
+10.2.5 is about the product being **updated only through the Store**, and the
+certification tester counted the *notification* as the update path: two seconds
+after launch, `AppShell`'s startup check asked GitHub for the newest release,
+`shouldNag` auto-opened `UpdatePanel`, and its primary button read **"View
+release"** — a link to the page where you download the `.msi`.
+
+The lesson worth carrying: **for a Store build, "we only notify" is not a
+mitigation, it is the finding.** Any surface that tells a Store user a newer
+version exists elsewhere is in scope, whoever installs it.
+
+The fix is described operationally in `docs/dev/distribution.md` ("A Store
+install has NO update surface"). In spec terms it amends §C:
+
+- `UpdateCapability::NotifyStore` → **`StoreManaged`** (`"store-managed"` over
+  IPC). The rename is the point: `notify` is precisely what this install must
+  not do, and a variant named for the behaviour it forbids is one refactor away
+  from being treated like its siblings.
+- The variant now gates the **check**, not just the install:
+  `update::may_check_for_updates` is the single pure statement of the rule, read
+  by `commands::update::check_for_update` (which refuses with
+  `AppError::UpdatesManagedExternally` before the fetch) and by
+  `useUpdateStore.check()` (which is what keeps the request from being made).
+- `UpdateChip` and `Settings → Updates` render nothing to click. Settings shows
+  the version and one sentence naming the Store — **not** disabled controls,
+  which would still be three statements about updating from outside it.
+
+**10.2.5 was the report's only finding** — the package itself, the manifest, the
+identity and the listing metadata drew no note, so §A, §B and §D stand as
+written and §E's open question is unchanged. Nothing about the *package* changes
+for the resubmission; the change is entirely in the app's behaviour.
 
 ## Follow-ups
 

--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -17,8 +17,20 @@ use crate::{
 /// also where the "should this check happen at all" gate lives
 /// (`useUpdateStore.check`). Keeping both on the same side of the IPC boundary
 /// means there is one place to read to know what any given check will do.
+///
+/// **The one thing this command decides for itself is the Store install** (#360).
+/// A packaged install refuses here, ahead of the channel and ahead of the fetch,
+/// because Store policy 10.2.5 makes "did we notify?" the failing condition —
+/// not "did we install?" — and a preference the user can flip is the wrong place
+/// to keep a rule certification enforces. The frontend gate stays (it is what
+/// keeps the UI from rendering a check button at all); this is the backstop that
+/// makes forgetting it harmless rather than a submission blocker. See
+/// `update::may_check_for_updates`.
 #[tauri::command]
 pub async fn check_for_update(channel: Option<UpdateChannel>) -> AppResult<UpdateInfo> {
+    if !update::may_check_for_updates(install_capability()) {
+        return Err(AppError::UpdatesManagedExternally);
+    }
     let current = env!("CARGO_PKG_VERSION").to_string();
     // Absent means stable. The frontend always sends one; the default is here so
     // that a caller which does not — an older webview against a newer binary, or
@@ -55,6 +67,21 @@ pub async fn check_for_update(channel: Option<UpdateChannel>) -> AppResult<Updat
 /// the answer is meaningless elsewhere.
 #[tauri::command]
 pub fn get_update_capability() -> AppResult<UpdateCapability> {
+    Ok(install_capability())
+}
+
+/// The probes behind `get_update_capability`, callable from Rust.
+///
+/// Extracted so `check_for_update` can ask the same question without going back
+/// out through IPC (#360). Two callers reading ONE function is the point: a
+/// second copy of the probe order is how a Store install ends up refusing in one
+/// command and checking in the other.
+///
+/// Not cached. Every probe is a `Path::exists` or one kernel32 call, and an
+/// install's identity cannot change under a running process — but a `OnceLock`
+/// here would buy nothing measurable and would have to be reasoned about in
+/// every test that touches it.
+fn install_capability() -> UpdateCapability {
     let os = std::env::consts::OS;
     let apt_managed = os == "linux" && std::path::Path::new(update::APT_SOURCES_PATH).exists();
     let scoop_managed = os == "windows"
@@ -65,14 +92,14 @@ pub fn get_update_capability() -> AppResult<UpdateCapability> {
                     .is_some_and(|dir| dir.join(update::SCOOP_MANIFEST_FILE).exists())
         });
     let msix_packaged = os == "windows" && update::is_msix_packaged();
-    Ok(update::capability(update::InstallEnv {
+    update::capability(update::InstallEnv {
         // `APPIMAGE=` (set but empty) is not an AppImage install.
         is_appimage: std::env::var("APPIMAGE").is_ok_and(|v| !v.is_empty()),
         apt_managed,
         scoop_managed,
         msix_packaged,
         ..update::InstallEnv::new(os)
-    }))
+    })
 }
 
 /// Open an https URL in the user's default browser (notify-path "View release").

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -142,6 +142,24 @@ pub enum AppError {
     #[error("no bisect in progress")]
     NoBisect,
 
+    /// This install does not check for updates, because something else owns
+    /// them: a Microsoft Store (MSIX) package (#360).
+    ///
+    /// A **refusal**, not a failure. `check_for_update` returns it *before* it
+    /// would reach the network, so the request never leaves the machine — Store
+    /// policy 10.2.5 requires that a Store install neither updates nor
+    /// advertises updates outside the Store, and the v0.4.0 certification run
+    /// failed on the notification alone.
+    ///
+    /// A variant rather than a silent `available: false`, which is the tempting
+    /// one-liner and is a lie: "you are up to date" is a claim about the
+    /// release, and this install does not know. It exists as a BACKSTOP — every
+    /// shipped surface is gated ahead of it (`useUpdateStore.check`, and the
+    /// Settings section renders no button at all on such an install), so a user
+    /// reaching it means a new call site forgot the gate.
+    #[error("this install is updated by the Microsoft Store, not by the app")]
+    UpdatesManagedExternally,
+
     /// The user cancelled a running network op — clone, fetch, pull or push
     /// (#234). Not a failure: it is the outcome they asked for, so the UI
     /// clears the spinner and raises no banner.

--- a/src-tauri/src/update.rs
+++ b/src-tauri/src/update.rs
@@ -63,9 +63,10 @@ pub struct UpdateInfo {
     pub prerelease: bool,
 }
 
-/// Whether this install can swap its own binary or should defer to a package
-/// manager. Serializes to `"self-update"` / `"notify"` / `"notify-apt"` /
-/// `"notify-scoop"`.
+/// Whether this install can swap its own binary, should defer to a package
+/// manager, or must not talk about updates at all. Serializes to
+/// `"self-update"` / `"notify"` / `"notify-apt"` / `"notify-scoop"` /
+/// `"store-managed"`.
 ///
 /// `NotifyApt` exists because after #187 there are TWO kinds of `.deb` install
 /// and they need different advice. On an apt-managed one, `apt upgrade` is the
@@ -80,12 +81,28 @@ pub struct UpdateInfo {
 /// the Start Menu shortcut, with `scoop list` reporting the old version forever.
 /// Silently two installs, from one click.
 ///
-/// `NotifyStore` is a Microsoft Store (MSIX) install, and it is the one variant
-/// whose reason is not "better advice". An MSIX is read-only after deployment and
-/// Windows refuses to launch a package whose files were tampered with, so a
-/// self-update here does not fail — it leaves an app that will not start. The
-/// Store owns the upgrade; the panel says so and offers nothing to click, which
-/// is why it is also the only variant with no command to copy.
+/// `StoreManaged` is a Microsoft Store (MSIX) install, and it is the one variant
+/// that is not about advice at all: it means this install has NO update surface.
+/// No check, no chip, no panel, no release link.
+///
+/// Two independent reasons, and either alone would be enough:
+///
+/// 1. **Store policy 10.2.5** — "the product and in-app products are updated
+///    only through the Store". The v0.4.0 submission failed certification on
+///    exactly this: the startup check found a newer GitHub release and the panel
+///    auto-opened with a "View release" button onto an `.msi` download. The
+///    report's own words were *"The product updates outside the Store … Location
+///    where update is found: In App, soon after launch"*. Notifying is enough to
+///    fail it — the app does not have to install anything.
+/// 2. **Technically it could not work anyway.** An MSIX is read-only after
+///    deployment and Windows refuses to launch a package whose files were
+///    tampered with, so a self-update here does not fail — it leaves an app that
+///    will not start.
+///
+/// So this variant is checked at the top of `check_for_update` (via
+/// `may_check_for_updates`) and again in the frontend store, and it is the only
+/// variant with no command to copy: there is nothing for the user to run,
+/// because the Store upgrades the package by itself.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum UpdateCapability {
@@ -93,7 +110,7 @@ pub enum UpdateCapability {
     Notify,
     NotifyApt,
     NotifyScoop,
-    NotifyStore,
+    StoreManaged,
 }
 
 /// The deb822 sources file `scripts/install-platypusgit.sh` writes.
@@ -332,13 +349,34 @@ pub fn is_msix_packaged() -> bool {
 /// toward `scoop update` on an install Scoop does not own.
 pub fn capability(env: InstallEnv<'_>) -> UpdateCapability {
     match env.os {
-        "windows" if env.msix_packaged => UpdateCapability::NotifyStore,
+        "windows" if env.msix_packaged => UpdateCapability::StoreManaged,
         "windows" if env.scoop_managed => UpdateCapability::NotifyScoop,
         "windows" => UpdateCapability::SelfUpdate,
         "linux" if env.is_appimage => UpdateCapability::SelfUpdate,
         "linux" if env.apt_managed => UpdateCapability::NotifyApt,
         _ => UpdateCapability::Notify,
     }
+}
+
+/// Is this install allowed to ask GitHub what the newest release is?
+///
+/// One pure function, so "may this install check" has a single answer that both
+/// `commands::update::check_for_update` and `src/features/update/useUpdateStore`
+/// are written against — and one that a test can exercise without a registered
+/// MSIX package (`is_msix_packaged` is a constant `false` everywhere a test can
+/// run).
+///
+/// A predicate rather than an inline `matches!` at the call site because the
+/// call site is a *refusal*, and Store policy 10.2.5 is the reason for it: the
+/// rule needs somewhere to be stated once and pinned by name. See
+/// `UpdateCapability::StoreManaged`.
+///
+/// Every other variant answers `true`. `Notify*` installs still check — they
+/// just hand the install off to a package manager afterwards, and telling a
+/// `.deb` user that `apt upgrade` has something for them is the whole point of
+/// #187.
+pub fn may_check_for_updates(capability: UpdateCapability) -> bool {
+    !matches!(capability, UpdateCapability::StoreManaged)
 }
 
 /// How many releases the prerelease channel considers.

--- a/src-tauri/tests/update.rs
+++ b/src-tauri/tests/update.rs
@@ -3,8 +3,8 @@ use std::cell::Cell;
 use platypusgit_lib::error::AppError;
 use platypusgit_lib::update::{
     capability, compute_available, discover, is_msix_packaged, is_newer, is_scoop_layout,
-    parse_release, parse_releases, pick_newest, InstallEnv, ReleaseMeta, UpdateCapability,
-    UpdateChannel,
+    may_check_for_updates, parse_release, parse_releases, pick_newest, InstallEnv, ReleaseMeta,
+    UpdateCapability, UpdateChannel,
 };
 
 #[test]
@@ -368,12 +368,69 @@ fn capability_takes_a_packaged_install_off_the_self_update_path() {
             msix_packaged: true,
             ..InstallEnv::new("windows")
         }),
-        UpdateCapability::NotifyStore
+        UpdateCapability::StoreManaged
     );
     // ...and the .msi install it is distinguished FROM keeps self-updating.
     assert_eq!(
         capability(InstallEnv::new("windows")),
         UpdateCapability::SelfUpdate
+    );
+}
+
+#[test]
+fn a_store_install_is_not_allowed_to_check_at_all() {
+    // Store policy 10.2.5, and the reason the v0.4.0 submission failed
+    // certification (#360): "The product updates outside the Store … Location
+    // where update is found: In App, soon after launch". The app installed
+    // nothing — the startup check found a newer GitHub release and the panel
+    // auto-opened offering the release page. NOTIFYING is the failing condition,
+    // so the request itself has to stop.
+    assert!(!may_check_for_updates(capability(InstallEnv {
+        msix_packaged: true,
+        ..InstallEnv::new("windows")
+    })));
+}
+
+#[test]
+fn every_other_install_still_checks() {
+    // The notify variants are NOT swept up by the Store rule: they check, and
+    // then hand the install off to a package manager. Telling a `.deb` user that
+    // `apt upgrade` has something for them is the entire point of #187, and a
+    // predicate that answered "no" to all of them would delete that feature
+    // while looking like a Store fix.
+    for cap in [
+        UpdateCapability::SelfUpdate,
+        UpdateCapability::Notify,
+        UpdateCapability::NotifyApt,
+        UpdateCapability::NotifyScoop,
+    ] {
+        assert!(may_check_for_updates(cap), "{cap:?} must still check");
+    }
+}
+
+#[test]
+fn check_for_update_asks_the_gate_before_it_fetches() {
+    // `may_check_for_updates` is only worth anything if the command consults it
+    // FIRST. The real call cannot be exercised from here — `is_msix_packaged` is
+    // a compile-time `false` on every platform a test runs on — so this pins the
+    // ORDER in the source, which is the part a refactor breaks silently: a gate
+    // moved below the fetch still compiles, still passes every other test, and
+    // still fails certification.
+    let src = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/commands/update.rs"),
+    )
+    .expect("read commands/update.rs");
+    // The trailing `(` matters: the doc comment above the command names the
+    // function in prose, and a comment is not a gate.
+    let gate = src
+        .find("may_check_for_updates(")
+        .expect("check_for_update must CALL update::may_check_for_updates");
+    let fetch = src
+        .find("fetch_for_channel")
+        .expect("check_for_update still fetches");
+    assert!(
+        gate < fetch,
+        "the Store gate must come before the fetch in commands/update.rs"
     );
 }
 
@@ -389,7 +446,7 @@ fn capability_prefers_the_store_over_scoop_when_both_look_true() {
             scoop_managed: true,
             ..InstallEnv::new("windows")
         }),
-        UpdateCapability::NotifyStore
+        UpdateCapability::StoreManaged
     );
 }
 

--- a/src/features/update/UpdateChip.tsx
+++ b/src/features/update/UpdateChip.tsx
@@ -1,13 +1,21 @@
 import { PGIcon } from "@/design";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
-import { useUpdateStore } from "./useUpdateStore";
+import { updatesManagedExternally, useUpdateStore } from "./useUpdateStore";
 
 /** Titlebar chip shown whenever an update is available (even if dismissed). */
 export function UpdateChip() {
   const available = useUpdateStore((s) => s.info?.available ?? false);
   const latest = useUpdateStore((s) => s.info?.latestVersion);
   const openPanel = useUpdateStore((s) => s.openPanel);
+  const capability = useUpdateStore((s) => s.capability);
   const mode = useSettingsStore((s) => s.updateCheckMode);
+
+  // A Microsoft Store install has no update surface, and the chip is the most
+  // visible piece of it (#360): a version number in the titlebar, one click from
+  // a panel pointing at a download. `check()` already refuses to produce `info`
+  // there, so this is belt-and-braces — but it is cheap, and the alternative is
+  // a titlebar element whose absence depends on a promise made two files away.
+  if (updatesManagedExternally(capability)) return null;
 
   // "Never" is not only "make no request" (#237). A session that checked before
   // the user switched checks off still holds the result, and a chip whose only

--- a/src/features/update/UpdatePanel.test.tsx
+++ b/src/features/update/UpdatePanel.test.tsx
@@ -73,6 +73,17 @@ describe("UpdateChip", () => {
     expect(screen.queryByTestId("pg-update-chip")).toBeNull();
   });
 
+  // A Store install should never HAVE an `info` to nag with — `check()` refuses
+  // before the request (#360) — but the chip is the most visible piece of the
+  // surface that failed certification: a version number in the titlebar, one
+  // click from a panel pointing at a download. It gates on the capability too,
+  // rather than trusting a promise made two files away.
+  it("is hidden on a Microsoft Store install", () => {
+    seed({ panelOpen: false, capability: "store-managed" });
+    render(<UpdateChip />);
+    expect(screen.queryByTestId("pg-update-chip")).toBeNull();
+  });
+
   it("still shows under 'only when I ask'", () => {
     // manual gates the REQUEST, not the result: a check the user asked for that
     // found something must still be visible outside Settings.
@@ -133,13 +144,13 @@ describe("UpdatePanel — capability + platform arms", () => {
     );
   });
 
-  it("notify-store on Windows shows the note and NO command box", () => {
+  it("store-managed on Windows shows the note and NO command box", () => {
     // The fifth capability, and the only one with nothing to copy: the Store
     // updates the package itself. An empty code box with a copy button that
     // copies "" is worse than no box, so the command half must not render —
     // while the note, which is the whole hint here, must.
     platformMock.value = "windows";
-    seed({ capability: "notify-store" });
+    seed({ capability: "store-managed" });
     render(<UpdatePanel />);
     expect(screen.getByTestId("pg-update-action")).toHaveTextContent(
       /view release/i,

--- a/src/features/update/packageHint.test.ts
+++ b/src/features/update/packageHint.test.ts
@@ -83,7 +83,7 @@ describe("packageHint", () => {
   });
 
   it("names the Store for a packaged install", () => {
-    const hint = packageHint("notify-store", "windows");
+    const hint = packageHint("store-managed", "windows");
     expect(hint).not.toBeNull();
     expect(hint?.note).toContain("Microsoft Store");
   });
@@ -92,13 +92,13 @@ describe("packageHint", () => {
     // Every other notify variant hands over a command. This one must not: an
     // MSIX is read-only, there is nothing to type, and `winget upgrade` would be
     // advice for a channel this install did not come from.
-    expect(packageHint("notify-store", "windows")?.command).toBe("");
+    expect(packageHint("store-managed", "windows")?.command).toBe("");
   });
 
   it("trusts the backend's Store answer over the platform", () => {
     // Same rule the Scoop arm is pinned by: the capability is the more specific
     // answer and the platform switch must not get a chance to contradict it.
-    expect(packageHint("notify-store", undefined)?.note).toContain(
+    expect(packageHint("store-managed", undefined)?.note).toContain(
       "Microsoft Store",
     );
   });

--- a/src/features/update/packageHint.ts
+++ b/src/features/update/packageHint.ts
@@ -13,12 +13,27 @@ import type { UpdateCapability } from "@/lib/types";
  * else, so a `.deb` user had no way to know *why* the in-app install was
  * unavailable or what to run instead — the panel was a silent dead end.
  */
+/**
+ * What a Microsoft Store install is told about updates, in the one place both
+ * readers take it from (#360).
+ *
+ * Deliberately says who does the updating and stops there. It names no command,
+ * no download and no release page: Store policy 10.2.5 is about the product not
+ * updating — or pointing at an update — outside the Store, and "here's where to
+ * get the new one" is the sentence that failed certification.
+ *
+ * No trailing colon, unlike the other hints' notes: those introduce a command
+ * box and this one introduces nothing.
+ */
+export const STORE_MANAGED_NOTE =
+  "This install came from the Microsoft Store, which keeps it up to date.";
+
 export interface PackageHint {
   /** One line on why in-app install is unavailable here. */
   note: string;
   /**
    * Copy-pasteable upgrade command, or `""` when there is genuinely nothing to
-   * run — `notify-store`, where the Store upgrades the package itself.
+   * run — `store-managed`, where the Store upgrades the package itself.
    * `UpdatePanel` renders the command box only when this is non-empty.
    */
   command: string;
@@ -64,17 +79,23 @@ export function packageHint(
       command: "scoop update platypusgit",
     };
   }
-  if (capability === "notify-store") {
+  if (capability === "store-managed") {
     return {
       // The one hint with an EMPTY command, and the reason is in the Rust enum:
       // the Store updates this install by itself. Naming `winget upgrade` here
       // would send a Store user to a channel they are not on; naming a download
-      // would send them to a file they cannot install over the package.
+      // would send them to a file they cannot install over the package — and
+      // after #360 that download is also what failed certification.
       //
       // UpdatePanel renders the command box only for a non-empty command, so
       // this arm shows its note alone. Returning `null` instead would be wrong:
       // that is "nothing useful to say", and there IS something to say.
-      note: "This install came from the Microsoft Store, which keeps it up to date:",
+      //
+      // Since #360 the PANEL can no longer reach this arm — a Store install
+      // never gets an `info` to open a panel with — so its live reader is
+      // Settings, via STORE_MANAGED_NOTE. It stays here so that the sentence
+      // has one home and so the panel degrades correctly if it ever does open.
+      note: STORE_MANAGED_NOTE,
       command: "",
     };
   }

--- a/src/features/update/storeManaged.test.ts
+++ b/src/features/update/storeManaged.test.ts
@@ -1,0 +1,185 @@
+// A Microsoft Store install has NO update surface (#360).
+//
+// This file exists because of a certification failure, not a bug report. The
+// v0.4.0 MSIX submission was rejected under Store policy 10.2.5 — "the product
+// and in-app products are updated only through the Store" — with the finding
+// spelled out as:
+//
+//   The product updates outside the Store. […]
+//   Location where update is found: In App, soon after launch
+//
+// The app installed nothing. `capability` already took a packaged install off
+// the self-update path, so the "Install & restart" button was never offered.
+// What failed was the NOTIFICATION: the startup check asked GitHub for the
+// newest release, found one, and auto-opened a panel whose primary button
+// opened the release page — where the user downloads an `.msi` and updates
+// outside the Store. Finding out about the update in the app is the violation.
+//
+// So the assertions here are negative, in the shape `updateCheckMode.test.ts`
+// already uses: `checkForUpdate` must not be CALLED. A request whose result is
+// discarded would satisfy a status-only test and still be a GitHub round-trip
+// on every launch of a Store install — and a discarded result is one `set()`
+// away from being rendered again.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { UpdateInfo } from "@/lib/types";
+
+const tauri = vi.hoisted(() => ({
+  checkForUpdate: vi.fn(),
+  getUpdateCapability: vi.fn(),
+  openUrl: vi.fn(),
+}));
+vi.mock("@/lib/tauri", () => tauri);
+
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { updatesManagedExternally, useUpdateStore } from "./useUpdateStore";
+
+const AVAILABLE: UpdateInfo = {
+  available: true,
+  currentVersion: "0.4.0",
+  latestVersion: "0.5.0",
+  notes: "rebase fixes",
+  releaseUrl: "https://github.com/jonassaa/platypusgit/releases/tag/v0.5.0",
+  publishedAt: "2026-09-02T10:00:00Z",
+  prerelease: false,
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  tauri.checkForUpdate.mockReset().mockResolvedValue(AVAILABLE);
+  tauri.getUpdateCapability.mockReset().mockResolvedValue("store-managed");
+  tauri.openUrl.mockReset().mockResolvedValue(undefined);
+  useSettingsStore.getState().set("updateCheckMode", "auto");
+  useUpdateStore.setState({
+    status: "idle",
+    info: null,
+    capability: null,
+    dismissedVersion: null,
+    currentVersion: null,
+    lastCheckedAt: null,
+    installing: false,
+    progress: null,
+    error: null,
+    message: null,
+    panelOpen: false,
+  });
+});
+
+describe("updatesManagedExternally", () => {
+  it("is true for a Store install and false for every other capability", () => {
+    expect(updatesManagedExternally("store-managed")).toBe(true);
+    for (const cap of [
+      "self-update",
+      "notify",
+      "notify-apt",
+      "notify-scoop",
+    ] as const) {
+      // The notify variants still check — they defer the INSTALL to a package
+      // manager, and telling a `.deb` user that `apt upgrade` has something for
+      // them is the whole point of #187. A predicate that swept them up would
+      // delete that feature while looking like a Store fix.
+      expect(updatesManagedExternally(cap)).toBe(false);
+    }
+  });
+
+  it("is false while the capability is still unknown", () => {
+    // `check()` loads the capability before it can reach the network, so the
+    // unknown window belongs to nothing that could leak. Answering true here
+    // would blank the update UI for a frame on every ordinary install.
+    expect(updatesManagedExternally(null)).toBe(false);
+  });
+});
+
+describe("the Store gate — no check, no notification", () => {
+  it("makes NO GitHub request on the startup check", async () => {
+    await useUpdateStore.getState().check(false);
+    expect(tauri.checkForUpdate).not.toHaveBeenCalled();
+    // The capability probe itself IS allowed and required: it is a local IPC
+    // call, and it is what produced the refusal.
+    expect(tauri.getUpdateCapability).toHaveBeenCalled();
+  });
+
+  it("makes NO GitHub request on a MANUAL check either", async () => {
+    // The Settings button is not rendered on such an install, but the gate has
+    // to hold for the command palette, the keymap, and any call site added
+    // later. This is not a preference — no setting turns it off — which is why
+    // it is checked separately from `updateCheckMode`.
+    await useUpdateStore.getState().check(true);
+    expect(tauri.checkForUpdate).not.toHaveBeenCalled();
+  });
+
+  it("leaves no info, no panel and no error behind", async () => {
+    await useUpdateStore.getState().check(true);
+    const s = useUpdateStore.getState();
+    // `info: null` is the load-bearing one. `UpdateChip` renders on
+    // `info.available` and `UpdatePanel` returns null without an `info`, so an
+    // empty result is what makes the whole surface absent rather than merely
+    // closed.
+    expect(s.info).toBeNull();
+    expect(s.panelOpen).toBe(false);
+    // Silent, like a check the user turned off: a refusal the user cannot
+    // change is not a failure to report, and an error banner about updates is
+    // still an in-app statement about updates.
+    expect(s.status).toBe("idle");
+    expect(s.error).toBeNull();
+    // ...and the capability is retained, so Settings and the chip can gate on
+    // it without probing again.
+    expect(s.capability).toBe("store-managed");
+  });
+
+  it("records no last-checked time", async () => {
+    // The panel and Settings read this to say when the install last looked. A
+    // Store install never looks, and a timestamp would claim otherwise.
+    await useUpdateStore.getState().check(true);
+    expect(useUpdateStore.getState().lastCheckedAt).toBeNull();
+  });
+
+  it("refuses to self-install even if something calls install()", async () => {
+    // Unreachable through the UI, but this is the one action that writes to the
+    // package. A self-update over an MSIX does not fail cleanly: Windows
+    // refuses to launch a package whose files were tampered with, so the
+    // outcome is an app that will not start.
+    useUpdateStore.setState({ capability: "store-managed", info: AVAILABLE });
+    await useUpdateStore.getState().install();
+    const s = useUpdateStore.getState();
+    expect(s.installing).toBe(false);
+    expect(s.progress).toBeNull();
+  });
+
+  it("still checks on the same code path when the install is not packaged", async () => {
+    // The other half of the gate: this must be a Store rule, not a switch that
+    // quietly turned update checks off for everyone.
+    tauri.getUpdateCapability.mockResolvedValue("self-update");
+    await useUpdateStore.getState().check(false);
+    expect(tauri.checkForUpdate).toHaveBeenCalledTimes(1);
+    expect(useUpdateStore.getState().info).toEqual(AVAILABLE);
+  });
+});
+
+describe("loadCapability", () => {
+  it("learns the capability without checking for updates", async () => {
+    // Its own action because `check()` is no longer a reliable way to learn
+    // this: with `updateCheckMode: "never"` it returns before fetching
+    // anything, which would leave a Store install rendering the full update UI
+    // in Settings.
+    useSettingsStore.getState().set("updateCheckMode", "never");
+    await useUpdateStore.getState().loadCapability();
+    expect(useUpdateStore.getState().capability).toBe("store-managed");
+    expect(tauri.checkForUpdate).not.toHaveBeenCalled();
+  });
+
+  it("probes once per session", async () => {
+    await useUpdateStore.getState().loadCapability();
+    await useUpdateStore.getState().loadCapability();
+    expect(tauri.getUpdateCapability).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the capability null when the probe fails", async () => {
+    // Fails toward showing the ordinary update UI, on purpose: the surface only
+    // has to be gone where the probe SUCCEEDS and says store-managed, and
+    // `check()` re-probes before it could reach the network anyway.
+    tauri.getUpdateCapability.mockRejectedValue(new Error("no ipc"));
+    await useUpdateStore.getState().loadCapability();
+    expect(useUpdateStore.getState().capability).toBeNull();
+  });
+});

--- a/src/features/update/useUpdateStore.ts
+++ b/src/features/update/useUpdateStore.ts
@@ -57,6 +57,16 @@ export interface UpdateState {
   check: (manual: boolean) => Promise<void>;
   install: () => Promise<void>;
   openReleasePage: () => Promise<void>;
+  /**
+   * Fetch the install's update capability once, without checking for updates.
+   *
+   * Its own action because the capability decides whether an update surface is
+   * rendered AT ALL (#360), and `check()` is no longer a reliable way to learn
+   * it: with `updateCheckMode: "never"` that function returns before it fetches
+   * anything, which would leave a Store install rendering the full update UI.
+   * A local IPC call, never the network.
+   */
+  loadCapability: () => Promise<void>;
   loadCurrentVersion: () => Promise<void>;
   openPanel: () => void;
   closePanel: () => void;
@@ -90,6 +100,35 @@ function loadLastChecked(): number | null {
  */
 export function checkAllowed(mode: UpdateCheckMode, manual: boolean): boolean {
   return manual ? mode !== "never" : mode === "auto";
+}
+
+/**
+ * Does something OTHER than this app own updates on this install?
+ *
+ * Today that is exactly the Microsoft Store (MSIX), and it is a stronger
+ * statement than any `notify` variant makes (#360). A notify install checks,
+ * then defers the *install* to a package manager. A store-managed install does
+ * not check, is not told, and is offered nothing: Store policy 10.2.5 requires
+ * that a Store product be updated only through the Store, and the v0.4.0
+ * submission failed certification on the notification alone — the startup check
+ * found a newer GitHub release and the panel auto-opened with a "View release"
+ * button onto an `.msi`. The report's location was "In App, soon after launch".
+ *
+ * PURE and exported for the same reason `checkAllowed` is: it is read by
+ * `check()`, by `UpdateChip` and by Settings, and the three must not each
+ * re-spell the condition. Written as a predicate over the capability rather than
+ * `=== "store-managed"` at three call sites so that a second externally-managed
+ * channel (a future winget/`msstore` variant) is one edit here.
+ *
+ * `null` — capability not loaded yet — answers `false`, and that is deliberate:
+ * `check()` loads the capability before it can reach the network, so the "not
+ * yet known" window belongs to nothing that could leak. Answering `true` there
+ * would hide the update UI for a frame on every ordinary install.
+ */
+export function updatesManagedExternally(
+  capability: UpdateCapability | null,
+): boolean {
+  return capability === "store-managed";
 }
 
 /**
@@ -144,6 +183,19 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
       if (!capability) {
         capability = await getUpdateCapability();
       }
+      // The SECOND gate, and the one certification cares about (#360). A
+      // Microsoft Store install must not check, must not be told, and must not
+      // be offered a release page — policy 10.2.5. It sits here, above the
+      // fetch, rather than beside the `updateCheckMode` gate above, because it
+      // needs the capability and because it is not a preference: no setting can
+      // turn it off, which is why `status` goes back to `idle` and no error is
+      // raised even for a manual call. The backend refuses too
+      // (`AppError::UpdatesManagedExternally`); this is what keeps the request
+      // from being made at all.
+      if (updatesManagedExternally(capability)) {
+        set({ capability, status: "idle", info: null, panelOpen: false });
+        return;
+      }
       // Read from the same snapshot the gate used, so a channel switch
       // mid-check cannot produce a result attributed to the other channel.
       const info = await checkForUpdate(settings.updateChannel);
@@ -180,6 +232,14 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
 
   async install() {
     if (get().installing) return;
+    // Unreachable through the UI — the panel offers "Install & restart" only for
+    // `self-update`, and a store-managed install never gets a panel at all — but
+    // this is the one action that would actually write to the package, so it
+    // refuses on its own rather than trusting two layers of rendering (#360).
+    // A self-update over an MSIX does not fail cleanly: Windows refuses to
+    // launch a package whose files were tampered with, so the outcome is an app
+    // that will not start.
+    if (updatesManagedExternally(get().capability)) return;
     set({ installing: true, error: null, message: null, progress: 0 });
     try {
       const { check } = await import("@tauri-apps/plugin-updater");
@@ -232,6 +292,20 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
       // Without this the rejection was unhandled at the onClick call site and
       // the user saw nothing happen.
       set({ status: "error", error: appErrorMessage(e) });
+    }
+  },
+
+  async loadCapability() {
+    if (get().capability) return;
+    try {
+      set({ capability: await getUpdateCapability() });
+    } catch {
+      // Leave null. Consumers read it through `updatesManagedExternally`, which
+      // answers `false` for null — so a failed probe shows the ordinary update
+      // UI rather than hiding it. That is the right way round: the surface only
+      // has to be *gone* on an install where the probe SUCCEEDS and says
+      // store-managed, and `check()` re-probes before it could reach the
+      // network anyway.
     }
   },
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -62,6 +62,17 @@ export type AppError =
   /** An op needed a bisect in progress and found none (#93). */
   | { kind: "NoBisect"; message?: string }
   /**
+   * The backend refused an update check because something else owns updates on
+   * this install — a Microsoft Store (MSIX) package (#360).
+   *
+   * A BACKSTOP, not a state the UI is expected to render: every shipped surface
+   * is gated ahead of it (`useUpdateStore.check` returns early, and Settings
+   * renders no check button on such an install), so reaching a banner means a
+   * new call site forgot the gate. It gets prose anyway — a banner reading
+   * "UpdatesManagedExternally" is exactly how #212 happened.
+   */
+  | { kind: "UpdatesManagedExternally"; message?: string }
+  /**
    * The user cancelled a running network op (#234). The outcome they asked for,
    * not a failure — every catch arm suppresses the banner for it and just clears
    * the spinner. Distinct from `Network` because a SIGKILLed git's last words
@@ -232,6 +243,12 @@ function appErrorDetail(e: AppError): string {
   // empty-repository box).
   if (e.kind === "Unborn") {
     return "This repository has no commits yet, so there is nothing to show here. Make the first commit and this fills in.";
+  }
+  // A unit variant too, and unreachable through any shipped surface — but a
+  // banner is the only thing that could ever show it, so it says what owns
+  // updates instead of naming the enum (#360).
+  if (e.kind === "UpdatesManagedExternally") {
+    return "This install is updated by the Microsoft Store, so PlatypusGit does not check for updates itself.";
   }
   // SshKeyExists carries a PATH. Rendered raw the banner would be a file name
   // with no hint that the app refused on purpose rather than failed.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -741,16 +741,22 @@ export interface UpdateInfo {
  * self-updating a Scoop install would run the per-machine `.msi` and leave the
  * machine with two copies of the app — see the Rust enum for the full story.
  *
- * `notify-store` is a Microsoft Store (MSIX) install. It is the only variant
- * with no command to offer: the package is read-only, Windows refuses to launch
- * a tampered one, and the Store does the upgrade unprompted.
+ * `store-managed` is a Microsoft Store (MSIX) install, and it is the one value
+ * that is not advice about installing — it means this install has NO update
+ * surface at all: no check, no chip, no panel, no release link (#360). Store
+ * policy 10.2.5 requires that a Store product be updated only through the
+ * Store, and the v0.4.0 submission failed certification on the NOTIFICATION
+ * alone — the startup check found a newer GitHub release and the panel opened
+ * offering it. Every reader of this value has to gate on it, not just the one
+ * that installs; `updatesManagedExternally` in `features/update/useUpdateStore`
+ * is the predicate to use.
  */
 export type UpdateCapability =
   | "self-update"
   | "notify"
   | "notify-apt"
   | "notify-scoop"
-  | "notify-store";
+  | "store-managed";
 
 /**
  * "Commit as" identity. Mirrors Rust `AuthorOverride` (git/types.rs) — it sets

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -48,7 +48,11 @@ import {
 } from "@/lib/tauri";
 import { relativeTime } from "@/lib/derive";
 import { appErrorMessage } from "@/lib/errors";
-import { useUpdateStore } from "@/features/update/useUpdateStore";
+import { STORE_MANAGED_NOTE } from "@/features/update/packageHint";
+import {
+  updatesManagedExternally,
+  useUpdateStore,
+} from "@/features/update/useUpdateStore";
 import type {
   CliPathState,
   CliShimStatus,
@@ -763,11 +767,18 @@ function UpdatesSection() {
   const currentVersion = useUpdateStore((s) => s.currentVersion);
   const lastCheckedAt = useUpdateStore((s) => s.lastCheckedAt);
   const loadCurrentVersion = useUpdateStore((s) => s.loadCurrentVersion);
+  const loadCapability = useUpdateStore((s) => s.loadCapability);
+  const capability = useUpdateStore((s) => s.capability);
   const off = settings.updateCheckMode === "never";
+  const storeManaged = updatesManagedExternally(capability);
 
   React.useEffect(() => {
     void loadCurrentVersion();
-  }, [loadCurrentVersion]);
+    // Loaded HERE and not left to `check()` (#360): on a Microsoft Store install
+    // this section must render no update controls at all, and with
+    // `updateCheckMode: "never"` no check ever runs to discover that.
+    void loadCapability();
+  }, [loadCurrentVersion, loadCapability]);
 
   let statusNode: React.ReactNode = null;
   if (status === "up-to-date") {
@@ -794,6 +805,36 @@ function UpdatesSection() {
     );
   } else if (status === "error" && error) {
     statusNode = <span style={{ color: "var(--git-removed)" }}>{error}</span>;
+  }
+
+  // A Microsoft Store install gets the version and nothing else (#360).
+  //
+  // Not a disabled version of the normal section, and not a hidden one either.
+  // Disabled controls would still be three statements ABOUT updates from
+  // outside the Store — "Automatically asks GitHub", a release channel, a
+  // "Check for updates" button — which is what policy 10.2.5 is about; the
+  // v0.4.0 submission failed on a notification, having installed nothing.
+  // Removing the section entirely would leave the user who came here looking
+  // for their version with no answer and no explanation of why the setting
+  // other installs have is missing. So: the version, and one line naming who
+  // does the updating.
+  //
+  // `updateCheckMode` and `updateChannel` keep their persisted values
+  // untouched. They are portable preferences (#254 exports them) and this
+  // install is simply not consulting them — the same reasoning that leaves the
+  // channel control enabled when checks are off.
+  if (storeManaged) {
+    return (
+      <div data-testid="settings-updates">
+        <Section title="Updates">
+          <Row
+            label="Current version"
+            hint={<div data-testid="update-store-managed">{STORE_MANAGED_NOTE}</div>}
+            control={<Mono>{currentVersion || "…"}</Mono>}
+          />
+        </Section>
+      </div>
+    );
   }
 
   return (

--- a/src/screens/Settings.updates.test.tsx
+++ b/src/screens/Settings.updates.test.tsx
@@ -21,6 +21,9 @@ function mockRestOfSettings() {
     source: "package",
     pathState: "onPath",
   }));
+  // The section probes this on mount now (#360) — it decides whether ANY update
+  // control is rendered. Ordinary install by default; the Store block overrides.
+  mockInvoke("get_update_capability", () => "self-update");
   mockInvoke("diagnostics_report", () => ({
     logPath: "/tmp/platypusgit.log",
     logExists: false,
@@ -119,6 +122,58 @@ describe("Settings → Updates: the check preference", () => {
     await pickMode("Only when I ask");
     expect(useSettingsStore.getState().updateCheckMode).toBe("manual");
     await waitFor(() => expect(checkButton()).not.toBeDisabled());
+  });
+});
+
+describe("Settings → Updates: a Microsoft Store install", () => {
+  // Store policy 10.2.5 and the v0.4.0 certification failure (#360). The report
+  // named "In App, soon after launch" — the startup panel — but this screen is
+  // the other half: three controls that are all statements about updating from
+  // outside the Store. Disabling them would not help; they would still say
+  // "Automatically asks GitHub" beside a "Check for updates" button.
+  beforeEach(() => {
+    mockInvoke("get_update_capability", () => "store-managed");
+  });
+
+  it("renders the version and the Store note, and no update controls", async () => {
+    render(<SettingsScreen />);
+    expect(
+      await screen.findByTestId("update-store-managed"),
+    ).toHaveTextContent(/microsoft store/i);
+    // The version is still here: this section is where someone comes to find
+    // it, and removing the whole thing would answer that question with silence.
+    expect(screen.getByTestId("settings-updates")).toHaveTextContent("0.1.0");
+    // Every control is GONE, not disabled.
+    expect(screen.queryByTestId("update-check-mode")).toBeNull();
+    expect(screen.queryByTestId("update-channel")).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /check for updates/i }),
+    ).toBeNull();
+    expect(screen.queryByTestId("update-last-checked")).toBeNull();
+  });
+
+  it("names no command, download or release page", async () => {
+    render(<SettingsScreen />);
+    const section = await screen.findByTestId("settings-updates");
+    // The note says who updates this install and stops. "Where to get the new
+    // one" is the sentence that failed certification.
+    expect(section.textContent).not.toMatch(/github|download|release|winget/i);
+  });
+
+  it("makes no update check while rendering", async () => {
+    render(<SettingsScreen />);
+    await screen.findByTestId("update-store-managed");
+    expect(checked).toEqual([]);
+  });
+
+  it("leaves the persisted preferences untouched", async () => {
+    // They are portable preferences (#254 exports them). This install is simply
+    // not consulting them — the same call the channel row already makes when
+    // checks are off.
+    useSettingsStore.getState().set("updateCheckMode", "manual");
+    render(<SettingsScreen />);
+    await screen.findByTestId("update-store-managed");
+    expect(useSettingsStore.getState().updateCheckMode).toBe("manual");
   });
 });
 


### PR DESCRIPTION
Makes the app comply with the certification failure in #360.

## The finding

The v0.4.0 Microsoft Store submission was rejected under policy **10.2.5 Security — Installing and Updating Store Apps**:

> The product updates outside the Store. Please ensure that the product and in-app products are updated only through the Store and resubmit.
>
> **Location where update is found: In App, soon after launch**

The app installed nothing — `NotifyStore` already kept a packaged install off the self-update path. What failed was the **notification**: two seconds after launch the startup check asked GitHub for the newest release, found one, and auto-opened `UpdatePanel` with a **"View release"** button onto the `.msi` download. Telling a Store user a newer version exists elsewhere is the violation, whoever installs it.

## The change

`StoreManaged` (was `NotifyStore`) now means *no update surface at all* — no request, no chip, no panel, no release link, no Settings control.

| Where | What it does |
| --- | --- |
| `update::may_check_for_updates` | the rule, as one pure function |
| `commands::update::check_for_update` | refuses with `AppError::UpdatesManagedExternally` **before** the fetch |
| `useUpdateStore.check()` | returns early after the capability probe — this is what stops the request being made |
| `UpdateChip` / `Settings → Updates` | render nothing to click |

The frontend gate is the one that matters operationally (nothing reaches the network); the backend one is the backstop, so a call site added later fails closed instead of failing certification. `install()` refuses too — unreachable through the UI, but it is the one action that would write to the package.

**Settings shows the version and one sentence, not disabled controls.** A greyed-out "Check for updates" beside "Automatically asks GitHub" is still three statements about updating from outside the Store; removing the section entirely would leave someone looking for their version with nothing. `updateCheckMode` and `updateChannel` keep their persisted values (they are portable preferences, #254) — this install simply does not consult them.

**Notify installs are untouched.** They still check and then defer the *install* to a package manager; telling a `.deb` user that `apt upgrade` has something for them is the whole point of #187. `every_other_install_still_checks` is what says so.

`check_for_update_asks_the_gate_before_it_fetches` pins the gate **above** the fetch in source text, because `is_msix_packaged` is a compile-time `false` everywhere a test can run: a gate moved below it would still compile, still pass every other test, and still fail certification.

Nothing about the *package* changes — no manifest, identity or `msix-pack.sh` edits. The resubmission is a rebuild of the same package shape with this behaviour in it.

## Verification

- `cargo test` — 84 test binaries green, no failures (`tests/update.rs` 40, up from 37)
- `pnpm test` — 317 files, 3026 tests green (includes `test/appErrors.test.ts`'s Rust↔TS enum 1:1 gate and `test/docs.test.ts`)
- `pnpm tsc --noEmit` — clean
- `pnpm test:e2e:docker run --spec e2e/specs/settings.e2e.ts` — 8 passing, driving the real binary; the Updates section still renders normally on a non-Store install

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)
