### PR TITLE
feat(history): show the actual commit timestamp, not just "3w ago" (#354)

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -646,6 +646,46 @@ therefore belongs in `features/`, not `design/`.
   `MAX_BARREN_PAGES`, or it walks the whole repository. New client-side log
   filters inherit that trap.
 
+## How a commit date is written (#354)
+
+- **`lib/commitDate.ts` is the ONE place a timestamp becomes text.** History
+  rows and detail, Reflog, Compare and the repository browser all read from it,
+  so the same instant cannot be described three ways. `relativeTime` in
+  `lib/derive.ts` stays where it is — it is one of the forms composed here, not
+  a surface of its own. A new date surface calls `commitDateText` +
+  `commitDateTitle`; it does not grow its own template. The one deliberate
+  exception is History's "copy visible commits" export, which writes
+  `toISOString()` on purpose — that text is machine-readable output, not a
+  reading surface, and must not follow a UI preference.
+- **The `dateFormat` preference picks the text AND the column width.** The Date
+  column is fixed-width monospace, and `2026-08-14 13:42` does not fit the 90px
+  `3w ago` needs, so `DATE_COL_W` (in `design/graph-geometry.ts`) sizes the
+  column per format. `PGCommitRow` and History's column header both read it
+  through `useDateColumnWidth()` and hand the SAME number to `commitRowGrid` —
+  reading it in one and threading a prop through the other is what would let the
+  header drift off the rows under it. `relative` is 90px, the pre-#354 width, so
+  a default install is pixel-identical to what it was.
+- **The hover title is mode-independent, and it is on the CELL.** Every mode
+  hangs the full stamp (`fullTimestamp` — seconds and the zone offset) off the
+  date cell, so the exact time is always one hover away and picking "Relative"
+  never means the exact time is unreachable. A row-wide `title` would follow the
+  pointer across the message and sha columns and shadow the titles those use for
+  their own truncated text.
+- **Commit details shows a stamp unconditionally** — not the column format. It
+  has the room, and "see the date on a commit" was half of what #354 asked for;
+  gating it behind a non-default preference would answer only half. Inline it is
+  `preciseTime` (seconds, no zone) beside the relative form; the zone is what
+  the hover adds, so the title is never a copy of the line under it.
+- **Local time, and it says so.** `CommitInfo` carries unix seconds only — the
+  author's own UTC offset is not on the wire — so every stamp renders in the
+  reader's zone and `fullTimestamp` names that zone, which is what makes a
+  timestamp copied out of a tooltip comparable with one from a terminal.
+  Matching `git log`'s author-timezone display needs a backend change first
+  (`CommitInfo` in Rust and TS, plus `libgit2.rs`).
+- An unknown persisted format normalizes to `relative` in the store's `load()`,
+  for the density reason one column over: `undefined` reaching the grid resolves
+  every `Npx` template to `auto` and collapses the column on every row at once.
+
 ## `git notes` in the commit detail panel (#253)
 
 - **Notes hang off the SELECTED commit, never the log page.** `CommitNotes`

--- a/src/design/git-components.date.test.tsx
+++ b/src/design/git-components.date.test.tsx
@@ -1,0 +1,106 @@
+// The Date column, after #354.
+//
+// Two things have to hold at once, and they are the two that break silently:
+//
+//   * the hover text is on the DATE CELL, not the row — a title on the row
+//     would fire anywhere along it, including over the message, and would
+//     shadow the truncated-path titles the other columns use;
+//   * the row's grid and History's column header agree on the column's width.
+//     They share `commitRowGrid`, but only because BOTH read the width from
+//     the same hook — that is what this file pins for the row half.
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, render } from "@testing-library/react";
+
+import { PGCommitDetail, PGCommitRow } from "./git-components";
+import { DATE_COL_W, commitRowGrid, graphWidth } from "./graph-geometry";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+
+const TITLE = "2026-08-14 13:42:07 +02:00 (3w ago)";
+
+function renderRow(props?: { date?: string; dateTitle?: string }) {
+  const { container } = render(
+    <PGCommitRow
+      graphW={graphWidth(0)}
+      sha="abc1234"
+      message="feat: something"
+      author="Tester"
+      date="3w ago"
+      dateTitle={TITLE}
+      {...props}
+    />,
+  );
+  const row = container.querySelector<HTMLElement>('[data-testid="commit-row"]')!;
+  const cell = container.querySelector<HTMLElement>('[data-testid="commit-date"]')!;
+  return { row, cell };
+}
+
+beforeEach(() => {
+  useSettingsStore.getState().set("dateFormat", "relative");
+});
+
+describe("PGCommitRow date cell", () => {
+  it("hangs the full timestamp off the date cell", () => {
+    const { cell } = renderRow();
+    expect(cell.textContent).toBe("3w ago");
+    expect(cell.title).toBe(TITLE);
+  });
+
+  // The tooltip is the whole point of the default mode, so a caller that
+  // forgets it must not leave a stale one behind — and must not render the
+  // literal "undefined" that a `title={undefined}` cast would.
+  it("carries no title when the caller passes none", () => {
+    const { cell } = renderRow({ dateTitle: undefined });
+    expect(cell.title).toBe("");
+  });
+
+  it("keeps the relative column width by default", () => {
+    const { row } = renderRow();
+    expect(row.style.gridTemplateColumns).toBe(
+      commitRowGrid(graphWidth(0), DATE_COL_W.relative),
+    );
+    // The pre-#354 template, byte for byte: the default log is unchanged.
+    expect(row.style.gridTemplateColumns).toBe(commitRowGrid(graphWidth(0)));
+  });
+
+  it("widens the column with the chosen format, live", () => {
+    const { row } = renderRow();
+    act(() => {
+      useSettingsStore.getState().set("dateFormat", "both");
+    });
+    expect(row.style.gridTemplateColumns).toBe(commitRowGrid(graphWidth(0), DATE_COL_W.both));
+  });
+
+  // Reflog renders no lanes and drops the graph column entirely; the date
+  // column still has to follow the format there.
+  it("widens the column with no graph column at all", () => {
+    useSettingsStore.getState().set("dateFormat", "absolute");
+    const { container } = render(
+      <PGCommitRow graphW={0} sha="abc1234" message="checkout" author="" date="2026-08-14 13:42" />,
+    );
+    const row = container.querySelector<HTMLElement>('[data-testid="commit-row"]')!;
+    expect(row.style.gridTemplateColumns).toBe(commitRowGrid(0, DATE_COL_W.absolute));
+  });
+});
+
+describe("PGCommitDetail date", () => {
+  it("shows the date it is given and hangs the full timestamp off it", () => {
+    const { container } = render(
+      <PGCommitDetail
+        sha="abc1234"
+        subject="feat: something"
+        author="Tester"
+        date="2026-08-14 13:42:07 · 3w ago"
+        dateTitle={TITLE}
+      />,
+    );
+    const cell = container.querySelector<HTMLElement>('[data-testid="commit-detail-date"]')!;
+    // Seconds inline — the panel has room and this is #354's "date on the
+    // commit details" half.
+    expect(cell.textContent).toContain("2026-08-14 13:42:07");
+    expect(cell.textContent).toContain("3w ago");
+    // The hover adds what the line leaves out: the zone.
+    expect(cell.title).toBe(TITLE);
+    expect(cell.title).toContain("+02:00");
+    expect(cell.textContent).not.toContain("+02:00");
+  });
+});

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -13,7 +13,10 @@ import {
   PGCheckbox,
   PGSelect,
 } from "./primitives";
-import { useDensityStep } from "@/features/settings/useSettingsStore";
+import {
+  useDateColumnWidth,
+  useDensityStep,
+} from "@/features/settings/useSettingsStore";
 import {
   NO_HEAD_DECOR,
   type HeadDecor,
@@ -1548,6 +1551,14 @@ export interface PGCommitRowProps {
   message: string;
   author: string;
   date: string;
+  /**
+   * Hover text for the date cell — the full timestamp (#354).
+   *
+   * On the CELL, not the row: a row-wide title would follow the pointer across
+   * the message and sha columns too, and would shadow the titles those columns
+   * use for their own truncated text.
+   */
+  dateTitle?: string;
   refs?: CommitRef[];
   selected?: boolean;
   /** Row identity, handed back to the shared handlers below. */
@@ -1602,6 +1613,7 @@ export const PGCommitRow = React.memo(function PGCommitRow({
   message,
   author,
   date,
+  dateTitle,
   refs,
   selected,
   oid,
@@ -1616,6 +1628,10 @@ export const PGCommitRow = React.memo(function PGCommitRow({
 }: PGCommitRowProps) {
   const [hover, setHover] = React.useState(false);
   const step = useDensityStep();
+  // Read here rather than passed in, for the same reason as the density step:
+  // every commit row in the app must agree with History's column header, and a
+  // prop threaded through two screens is a prop one of them forgets.
+  const dateW = useDateColumnWidth();
   const h = rowHeight ?? COMMIT_ROW_BASE_H + step;
   // One gate for every mark, so "this row is not HEAD" is checked once.
   const d = isHead && !headDecor.bare ? headDecor : NO_HEAD_DECOR;
@@ -1652,7 +1668,7 @@ export const PGCommitRow = React.memo(function PGCommitRow({
       onMouseLeave={() => setHover(false)}
       style={{
         display: "grid",
-        gridTemplateColumns: commitRowGrid(graphW),
+        gridTemplateColumns: commitRowGrid(graphW, dateW),
         alignItems: "center",
         height: h,
         background,
@@ -1777,7 +1793,21 @@ export const PGCommitRow = React.memo(function PGCommitRow({
           {author}
         </span>
       </div>
-      <span style={{ color: "var(--fg-3)", fontSize: "var(--fs-11)" }}>{date}</span>
+      <span
+        data-testid="commit-date"
+        title={dateTitle}
+        style={{
+          color: "var(--fg-3)",
+          fontSize: "var(--fs-11)",
+          // The stamp formats fill the column; clip rather than spill into the
+          // next column if a future format outgrows its width.
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {date}
+      </span>
     </div>
   );
 });
@@ -1799,6 +1829,8 @@ export interface PGCommitDetailProps {
   author: string;
   email?: string;
   date: string;
+  /** Hover text for the date — the full timestamp (#354). See PGCommitRowProps. */
+  dateTitle?: string;
   parents?: string[];
   branch?: string;
   tags?: string[];
@@ -1813,6 +1845,7 @@ export function PGCommitDetail({
   author,
   email,
   date,
+  dateTitle,
   parents = [],
   branch,
   tags = [],
@@ -1908,7 +1941,7 @@ export function PGCommitDetail({
           {author}
           {email && <span style={{ color: "var(--fg-3)" }}>&lt;{email}&gt;</span>}
         </span>
-        <span>
+        <span data-testid="commit-detail-date" title={dateTitle}>
           <PGIcon
             name="clock"
             size={10}

--- a/src/design/graph-geometry.test.ts
+++ b/src/design/graph-geometry.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { DATE_FORMATS } from "@/lib/commitDate";
 import {
+  DATE_COL_W,
   GRAPH_MAX_W,
   GRAPH_PAD,
   LANE_W,
@@ -59,5 +61,37 @@ describe("graph geometry", () => {
     // same as graphWidth(0)=24, a real one-lane log.
     expect(commitRowGrid(0)).toBe("70px 1fr 150px 90px");
     expect(commitRowGrid(0).split(" ")).toHaveLength(4);
+  });
+
+  // The Date column's width follows the user's date format (#354): a
+  // "2026-08-14 13:42" stamp is 16 monospace characters and does not fit the
+  // 90px a "3w ago" needs. The header and every row call THIS function with
+  // the same width, which is what keeps them from drifting apart.
+  it("defaults the date column to the relative width", () => {
+    expect(DATE_COL_W.relative).toBe(90);
+    expect(commitRowGrid(152)).toBe(commitRowGrid(152, DATE_COL_W.relative));
+  });
+
+  it("widens the date column for the stamp formats", () => {
+    expect(DATE_COL_W.absolute).toBeGreaterThan(DATE_COL_W.relative);
+    expect(DATE_COL_W.both).toBeGreaterThan(DATE_COL_W.absolute);
+    expect(commitRowGrid(152, DATE_COL_W.absolute)).toBe(
+      `152px 70px 1fr 150px ${DATE_COL_W.absolute}px`,
+    );
+    expect(commitRowGrid(0, DATE_COL_W.both)).toBe(`70px 1fr 150px ${DATE_COL_W.both}px`);
+  });
+
+  // Fixed-width monospace: the widest string the mode can produce has to fit,
+  // or the stamp is clipped mid-minute on every row at once.
+  it("gives every format room for the widest string it can render", () => {
+    const CH = 7.25; // --fs-12 monospace advance, measured
+    const widest = {
+      relative: "12mo ago".length,
+      absolute: "2026-08-14 13:42".length,
+      both: "2026-08-14 13:42 (12mo ago)".length,
+    };
+    for (const mode of DATE_FORMATS) {
+      expect(DATE_COL_W[mode]).toBeGreaterThanOrEqual(Math.ceil(widest[mode] * CH));
+    }
   });
 });

--- a/src/design/graph-geometry.ts
+++ b/src/design/graph-geometry.ts
@@ -7,6 +7,8 @@
 // viewport and clips by default, so there was no overflow, no scrollbar, and no
 // warning (issue #68 G1). One module, one source of truth.
 
+import type { DateFormat } from "@/lib/commitDate";
+
 /** Left pad before the first lane centre, and the right pad after the last. */
 export const GRAPH_PAD = 12;
 /** Horizontal distance between adjacent lane centres. */
@@ -30,10 +32,30 @@ export const maxVisibleCol = (): number =>
   Math.floor((GRAPH_MAX_W - GRAPH_PAD * 2) / LANE_W);
 
 /**
+ * Width of the Date column per date format (#354).
+ *
+ * Fixed-width monospace, so each entry is sized to the widest string its mode
+ * can produce — `12mo ago`, `2026-08-14 13:42`, or both together — with a
+ * little slack. `relative` is 90, the pre-#354 width, so the default log is
+ * pixel-identical to what it was.
+ */
+export const DATE_COL_W: Record<DateFormat, number> = {
+  relative: 90,
+  absolute: 124,
+  both: 200,
+};
+
+/**
  * Grid template shared by PGCommitRow and History's column header, so the two
  * cannot drift. `graphW === 0` drops the graph column entirely — that is
  * Reflog, which renders no lanes; it is NOT the same as `graphWidth(0)`, the
  * 24px a genuine one-lane log needs.
+ *
+ * `dateW` is the same drift argument one column over: the Date column grows
+ * with the user's date format, and the header and the rows must be told the
+ * same number. It defaults to the relative width so a caller with no notion of
+ * the setting (tests, any surface that only ever shows "3w ago") gets exactly
+ * the old template.
  */
-export const commitRowGrid = (graphW: number): string =>
-  graphW > 0 ? `${graphW}px 70px 1fr 150px 90px` : `70px 1fr 150px 90px`;
+export const commitRowGrid = (graphW: number, dateW: number = DATE_COL_W.relative): string =>
+  graphW > 0 ? `${graphW}px 70px 1fr 150px ${dateW}px` : `70px 1fr 150px ${dateW}px`;

--- a/src/features/settings/useSettingsStore.export.test.ts
+++ b/src/features/settings/useSettingsStore.export.test.ts
@@ -67,6 +67,10 @@ const PORTABLE = [
   // is plain data with no secrets in it.
   "customActions",
   "customThemes",
+  // How a commit date is written (#354). Portable: it is a reading preference
+  // — the same reasoning as commitBodyMarkdown — and says nothing about this
+  // machine. The zone it renders in is the reader's own, not a stored value.
+  "dateFormat",
   "defaultPullMode",
   "diffContextLines",
   "diffContextMode",

--- a/src/features/settings/useSettingsStore.test.ts
+++ b/src/features/settings/useSettingsStore.test.ts
@@ -329,6 +329,61 @@ describe("logo theme slots", () => {
 const rowStep = () =>
   document.documentElement.style.getPropertyValue("--row-step");
 
+// ═════════════════════════════════════════════════════════════════════════════
+// DATE FORMAT (#354)
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("dateFormat", () => {
+  // Relative by default: the pre-#354 log, unchanged for anyone who never
+  // opens Settings. The hover tooltip is what gives them the exact time.
+  it("defaults to relative", async () => {
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().dateFormat).toBe("relative");
+  });
+
+  it("persists a chosen format", async () => {
+    const { useSettingsStore } = await freshStore();
+    useSettingsStore.getState().set("dateFormat", "both");
+    const raw = JSON.parse(localStorage.getItem(STORAGE_KEY)!) as Record<string, unknown>;
+    expect(raw.dateFormat).toBe("both");
+    const again = await freshStore();
+    expect(again.useSettingsStore.getState().dateFormat).toBe("both");
+  });
+
+  // The format picks the Date column's WIDTH as well as its text, so an
+  // unknown value would size the column from `undefined` — every row's grid
+  // resolving to `auto` at once, which is the density trap one column over.
+  it("falls back to relative for an unknown or wrongly-typed persisted value", async () => {
+    for (const bad of ["iso", "Relative", "", true, 0, null] as unknown[]) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ dateFormat: bad }));
+      const { useSettingsStore } = await freshStore();
+      expect(useSettingsStore.getState().dateFormat, String(bad)).toBe("relative");
+    }
+  });
+
+  it("reset() returns to relative", async () => {
+    const { useSettingsStore } = await freshStore();
+    useSettingsStore.getState().set("dateFormat", "absolute");
+    useSettingsStore.getState().reset();
+    expect(useSettingsStore.getState().dateFormat).toBe("relative");
+  });
+
+  it("useDateColumnWidth reports the width the chosen format needs", async () => {
+    const { useSettingsStore, useDateColumnWidth } = await freshStore();
+    const { DATE_COL_W } = await import("@/design/graph-geometry");
+    const { renderHook } = await import("@testing-library/react");
+    const { act } = await import("react");
+
+    const { result } = renderHook(() => useDateColumnWidth());
+    expect(result.current).toBe(DATE_COL_W.relative);
+
+    await act(async () => {
+      useSettingsStore.getState().set("dateFormat", "both");
+    });
+    expect(result.current).toBe(DATE_COL_W.both);
+  });
+});
+
 describe("uiDensity CSS hook", () => {
   it("applies --row-step from the persisted density at load", async () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ uiDensity: "comfortable" }));

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -1,5 +1,7 @@
 import { create } from "zustand";
 import type { PullMode } from "@/lib/tauri";
+import { type DateFormat, isDateFormat } from "@/lib/commitDate";
+import { DATE_COL_W } from "@/design/graph-geometry";
 import type { UpdateChannel, UpdateRefsMode } from "@/lib/types";
 import type { SavedIdentity } from "@/features/commits/identity/identityList";
 import type { CustomAction } from "@/features/actions/customActions";
@@ -805,6 +807,16 @@ interface PersistedState {
   themePreference: ThemePreference;
   customThemes: ThemeDef[];
   uiDensity: "compact" | "comfortable";
+  /**
+   * How a commit date is written wherever one is shown (#354) — relative
+   * ("3w ago"), the absolute stamp, or both. The hover tooltip carries the
+   * full timestamp in every mode, so this is about what is on screen without
+   * hovering, not about whether the exact time is reachable at all.
+   *
+   * It also sizes the History/Reflog Date column (`DATE_COL_W`), which is why
+   * an unknown value has to normalize rather than pass through.
+   */
+  dateFormat: DateFormat;
   /** Webview zoom factor — 1 is 100%. See applyZoom. */
   uiZoom: number;
   /**
@@ -1030,6 +1042,7 @@ const DEFAULTS: PersistedState = {
   themePreference: { ...DEFAULT_THEME_PREFERENCE },
   customThemes: [],
   uiDensity: "compact",
+  dateFormat: "relative",
   uiZoom: 1,
   headMarks: ["bar", "tint", "ring"],
   headWeight: DEFAULT_HEAD_WEIGHT,
@@ -1402,6 +1415,10 @@ function coerceSettings(
   // invalid substitution makes every `calc(Npx + var(--row-step))` compute to
   // `auto` — collapsing the height of every row in the app at once.
   out.uiDensity = normalizeDensity(out.uiDensity);
+  // Same failure one column over: the date format picks the Date column's
+  // WIDTH as well as its text, so an unknown mode would emit `undefinedpx` in
+  // the row grid and collapse the column on every row at once.
+  if (!isDateFormat(out.dateFormat)) out.dateFormat = DEFAULTS.dateFormat;
   // HEAD marks: prefer a stored list, else carry over the pre-#118 single
   // `headIndicator` enum, else — if the payload spoke about marks at all but
   // said something unusable — the default, and otherwise whatever `base` had.
@@ -1985,4 +2002,26 @@ export type { Appearance } from "./systemAppearance";
  */
 export function useDensityStep(): number {
   return DENSITY_STEP_PX[normalizeDensity(useSettingsStore((s) => s.uiDensity))];
+}
+
+/**
+ * The user's date format (#354), for the surfaces that render a commit date.
+ *
+ * A hook rather than a `getState()` read so switching the format in Settings
+ * re-renders the log behind it, the same way density does.
+ */
+export function useDateFormat(): DateFormat {
+  const mode = useSettingsStore((s) => s.dateFormat);
+  return isDateFormat(mode) ? mode : DEFAULTS.dateFormat;
+}
+
+/**
+ * Width the Date column needs for the active format.
+ *
+ * PGCommitRow and History's column header both call this, then hand the SAME
+ * number to `commitRowGrid` — which is what keeps the header aligned with the
+ * rows under it when the format changes.
+ */
+export function useDateColumnWidth(): number {
+  return DATE_COL_W[useDateFormat()];
 }

--- a/src/lib/commitDate.test.ts
+++ b/src/lib/commitDate.test.ts
@@ -1,0 +1,140 @@
+// How a commit timestamp reads on screen (#354). The Date column used to say
+// only "3w ago", which cannot answer "was this before or after the release?".
+//
+// Everything here is pure, but "local time" is not: `absoluteTime` formats in
+// whatever zone the process is in. The exact-string tests pin TZ to UTC — the
+// one zone present on every machine and in every CI container — and the
+// zone-dependent half is tested through `tzOffsetLabel`, which takes the offset
+// as a NUMBER and so needs no tzdata at all.
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  DATE_FORMATS,
+  absoluteTime,
+  commitDateText,
+  commitDateTitle,
+  fullTimestamp,
+  isDateFormat,
+  preciseTime,
+  tzOffsetLabel,
+} from "./commitDate";
+
+// 2026-08-14T13:42:07Z
+const TS = 1786714927;
+
+const ORIGINAL_TZ = process.env.TZ;
+beforeAll(() => {
+  process.env.TZ = "UTC";
+});
+afterAll(() => {
+  process.env.TZ = ORIGINAL_TZ;
+});
+
+describe("tzOffsetLabel", () => {
+  // getTimezoneOffset() is minutes to ADD to local time to reach UTC, so its
+  // sign is the opposite of the one people write. Getting this backwards would
+  // label every European commit "-02:00" — plausible enough to ship unnoticed.
+  it("inverts the getTimezoneOffset sign", () => {
+    expect(tzOffsetLabel(-120)).toBe("+02:00"); // CEST
+    expect(tzOffsetLabel(300)).toBe("-05:00"); // EST
+  });
+
+  it("pads and keeps half-hour and quarter-hour zones", () => {
+    expect(tzOffsetLabel(-330)).toBe("+05:30"); // India
+    expect(tzOffsetLabel(-345)).toBe("+05:45"); // Nepal
+    expect(tzOffsetLabel(-540)).toBe("+09:00"); // Japan
+  });
+
+  it("writes UTC as +00:00, never -00:00", () => {
+    expect(tzOffsetLabel(0)).toBe("+00:00");
+  });
+});
+
+describe("absoluteTime", () => {
+  it("is zero-padded and sortable, to the minute", () => {
+    expect(absoluteTime(TS)).toBe("2026-08-14 13:42");
+  });
+
+  // A one-digit month/day/hour must not shorten the string: the Date column is
+  // fixed-width monospace, and a ragged stamp is what a naive template gives.
+  it("pads single-digit fields", () => {
+    expect(absoluteTime(Date.UTC(2026, 0, 5, 4, 3, 9) / 1000)).toBe("2026-01-05 04:03");
+  });
+
+  it("has the same width for every instant", () => {
+    const widths = new Set(
+      [0, TS, Date.UTC(1999, 11, 31, 23, 59) / 1000].map((t) => absoluteTime(t).length),
+    );
+    expect(widths).toEqual(new Set([16]));
+  });
+});
+
+describe("preciseTime", () => {
+  // Seconds, no zone: what commit details shows INLINE. Two commits made in
+  // the same minute have to be tellable apart there, but the zone is noise on
+  // a line the reader is already reading in their own clock — it lives one
+  // hover away instead, in `fullTimestamp`.
+  it("adds seconds to the absolute stamp", () => {
+    expect(preciseTime(TS)).toBe("2026-08-14 13:42:07");
+    expect(preciseTime(TS)).toBe(`${absoluteTime(TS)}:07`);
+  });
+
+  it("pads a single-digit second", () => {
+    expect(preciseTime(Date.UTC(2026, 0, 5, 4, 3, 9) / 1000)).toBe("2026-01-05 04:03:09");
+  });
+});
+
+describe("fullTimestamp", () => {
+  // Seconds AND the zone: this is the string that has to settle "which of these
+  // two commits came first", so it must be unambiguous on its own.
+  it("carries seconds and the zone offset", () => {
+    expect(fullTimestamp(TS)).toBe("2026-08-14 13:42:07 +00:00");
+    expect(fullTimestamp(TS)).toBe(`${preciseTime(TS)} +00:00`);
+  });
+});
+
+describe("commitDateText", () => {
+  const now = (TS + 60 * 60 * 24 * 21) * 1000; // three weeks later
+
+  it("shows only the relative form in relative mode", () => {
+    expect(commitDateText(TS, "relative", now)).toBe("3w ago");
+  });
+
+  it("shows only the stamp in absolute mode", () => {
+    expect(commitDateText(TS, "absolute", now)).toBe("2026-08-14 13:42");
+  });
+
+  it("shows the stamp with the relative form in parentheses in both mode", () => {
+    expect(commitDateText(TS, "both", now)).toBe("2026-08-14 13:42 (3w ago)");
+  });
+
+  // A persisted preference this build has never heard of must still render a
+  // date — an empty Date column is worse than the wrong format.
+  it("falls back to relative for an unknown mode", () => {
+    expect(commitDateText(TS, "wat" as never, now)).toBe("3w ago");
+  });
+});
+
+describe("commitDateTitle", () => {
+  const now = (TS + 60 * 60 * 24 * 21) * 1000;
+
+  // The hover text is mode-independent on purpose: whatever the column shows,
+  // the tooltip is the full answer, so "show me the exact time" never needs a
+  // trip to Settings.
+  it("carries the full stamp and the relative form", () => {
+    expect(commitDateTitle(TS, now)).toBe("2026-08-14 13:42:07 +00:00 (3w ago)");
+  });
+});
+
+describe("isDateFormat", () => {
+  it("accepts exactly the three modes", () => {
+    expect(DATE_FORMATS).toEqual(["relative", "absolute", "both"]);
+    for (const mode of DATE_FORMATS) expect(isDateFormat(mode)).toBe(true);
+  });
+
+  it("rejects anything else", () => {
+    for (const bad of ["", "Relative", "iso", 3, null, undefined, {}]) {
+      expect(isDateFormat(bad)).toBe(false);
+    }
+  });
+});

--- a/src/lib/commitDate.ts
+++ b/src/lib/commitDate.ts
@@ -1,0 +1,110 @@
+// How a commit timestamp is written on screen (#354).
+//
+// THE one place that turns `CommitInfo.timestamp` into text. Every date surface
+// — History rows and detail, Reflog, Compare, the repository browser — reads
+// from here, so the log column, the tooltip and the detail line cannot describe
+// the same instant three different ways. `relativeTime` in ./derive stays where
+// it is: it is one of the forms composed here, not a surface of its own.
+//
+// Local time, deliberately. The offset the author committed under is not
+// carried across IPC (`CommitInfo` has only unix seconds), and the question
+// this feature exists to answer — "did this land before or after that?" — is
+// asked in the reader's own clock. `fullTimestamp` therefore names the zone it
+// used, so a stamp copied out of a tooltip is unambiguous.
+import { relativeTime } from "./derive";
+
+/**
+ * What the Date column shows. The user's choice, persisted as `dateFormat` in
+ * settings; `relative` is the default and the fallback.
+ */
+export type DateFormat = "relative" | "absolute" | "both";
+
+/** Every mode, in the order the Settings control offers them. */
+export const DATE_FORMATS: readonly DateFormat[] = ["relative", "absolute", "both"] as const;
+
+/** Is this a mode this build knows? Guards a hand-edited or newer-build value. */
+export function isDateFormat(value: unknown): value is DateFormat {
+  return typeof value === "string" && (DATE_FORMATS as readonly string[]).includes(value);
+}
+
+const pad2 = (n: number): string => String(n).padStart(2, "0");
+
+/**
+ * A zone offset the way people write it — `+02:00`, `-05:30`.
+ *
+ * Takes the value `Date#getTimezoneOffset` returns, which is minutes to ADD to
+ * local time to reach UTC: its sign is the opposite of the printed one, which
+ * is why this is a named function with its own tests rather than a template.
+ */
+export function tzOffsetLabel(offsetMinutes: number): string {
+  const total = -offsetMinutes;
+  const sign = total < 0 ? "-" : "+";
+  const abs = Math.abs(total);
+  return `${sign}${pad2(Math.floor(abs / 60))}:${pad2(abs % 60)}`;
+}
+
+/**
+ * `2026-08-14 13:42` — local, zero-padded, sortable.
+ *
+ * ISO-ish rather than locale-formatted: this sits in a fixed-width monospace
+ * column, where every stamp must occupy the same 16 characters, and a
+ * developer tool should not make the reader guess whether `08/14` is August or
+ * February.
+ */
+export function absoluteTime(unixSeconds: number): string {
+  const d = new Date(unixSeconds * 1000);
+  return (
+    `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}` +
+    ` ${pad2(d.getHours())}:${pad2(d.getMinutes())}`
+  );
+}
+
+/**
+ * `2026-08-14 13:42:07` — the stamp with seconds, for surfaces with room.
+ *
+ * Seconds matter on a detail surface: two commits a few seconds apart read as
+ * the same instant without them. The zone does not appear here — the reader is
+ * already in it — and is one hover away in `fullTimestamp`.
+ */
+export function preciseTime(unixSeconds: number): string {
+  return `${absoluteTime(unixSeconds)}:${pad2(new Date(unixSeconds * 1000).getSeconds())}`;
+}
+
+/**
+ * `2026-08-14 13:42:07 +00:00` — the unambiguous form, for hover text.
+ *
+ * The zone is what makes it decisive beyond this window: a stamp with no zone
+ * cannot be compared with one pasted from a terminal or read off a CI log.
+ */
+export function fullTimestamp(unixSeconds: number): string {
+  return `${preciseTime(unixSeconds)} ${tzOffsetLabel(
+    new Date(unixSeconds * 1000).getTimezoneOffset(),
+  )}`;
+}
+
+/** What the Date column shows, for the user's chosen `mode`. */
+export function commitDateText(
+  unixSeconds: number,
+  mode: DateFormat,
+  now: number = Date.now(),
+): string {
+  switch (mode) {
+    case "absolute":
+      return absoluteTime(unixSeconds);
+    case "both":
+      return `${absoluteTime(unixSeconds)} (${relativeTime(unixSeconds, now)})`;
+    default:
+      // Includes "relative" and anything a newer build might have written.
+      return relativeTime(unixSeconds, now);
+  }
+}
+
+/**
+ * The hover text — always the full answer, whatever the column shows.
+ *
+ * Mode-independent on purpose: "what time exactly?" is then one hover away in
+ * every mode, and nobody has to visit Settings to read one commit's timestamp.
+ */
+export function commitDateTitle(unixSeconds: number, now: number = Date.now()): string {
+  return `${fullTimestamp(unixSeconds)} (${relativeTime(unixSeconds, now)})`;
+}

--- a/src/screens/Compare.tsx
+++ b/src/screens/Compare.tsx
@@ -41,7 +41,9 @@ import {
   sideKey,
   sideLabel,
 } from "@/features/compare/compareSides";
-import { relativeTime, shortSha } from "@/lib/derive";
+import { shortSha } from "@/lib/derive";
+import { commitDateText, commitDateTitle } from "@/lib/commitDate";
+import { useDateFormat } from "@/features/settings/useSettingsStore";
 import type { CommitInfo } from "@/lib/types";
 
 /**
@@ -49,6 +51,7 @@ import type { CommitInfo } from "@/lib/types";
  * draws a graph lane, and these lists carry no layout to draw one from.
  */
 function CompareCommitRow({ commit }: { commit: CommitInfo }) {
+  const dateFormat = useDateFormat();
   return (
     <div
       data-pg-row=""
@@ -88,7 +91,10 @@ function CompareCommitRow({ commit }: { commit: CommitInfo }) {
           fontSize: "var(--fs-10)",
         }}
       >
-        {commit.author} · {relativeTime(commit.timestamp)}
+        {commit.author} ·{" "}
+        <span title={commitDateTitle(commit.timestamp)}>
+          {commitDateText(commit.timestamp, dateFormat)}
+        </span>
       </span>
     </div>
   );

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -42,7 +42,12 @@ import { useRepoStore } from "@/features/repo/useRepoStore";
 import { ShallowNotice } from "@/features/repo/ShallowNotice";
 import { openCreateTag } from "@/features/tags/useCreateTagStore";
 import { useNavStore } from "@/features/nav/useNavStore";
-import { useDensityStep, useSettingsStore } from "@/features/settings/useSettingsStore";
+import {
+  useDateColumnWidth,
+  useDateFormat,
+  useDensityStep,
+  useSettingsStore,
+} from "@/features/settings/useSettingsStore";
 import { resolveHeadDecor } from "@/features/settings/headMarks";
 import { CommitDiffPanel } from "@/features/diff/CommitDiffPanel";
 import { useIgnoreWhitespace } from "@/features/diff/WhitespaceToggle";
@@ -58,6 +63,11 @@ import {
 import { diffCommit } from "@/lib/tauri";
 import { appErrorMessage } from "@/lib/errors";
 import { currentBranch, mapCommitRefs, relativeTime, shortSha } from "@/lib/derive";
+import {
+  commitDateText,
+  commitDateTitle,
+  preciseTime,
+} from "@/lib/commitDate";
 import {
   clickSelection,
   emptySelection,
@@ -328,6 +338,11 @@ export function HistoryScreen() {
     loadMoreCommits,
   ]);
 
+  // The Date column's text and its width come from the same setting (#354).
+  // The header below reads the width from here so it cannot drift from the
+  // rows, which read it inside PGCommitRow.
+  const dateFormat = useDateFormat();
+  const dateW = useDateColumnWidth();
   const graphW = graphWidth(maxCol);
   const graphClamped = isGraphClamped(maxCol);
   const hiddenLanes = graphClamped ? maxCol - maxVisibleCol() : 0;
@@ -775,7 +790,7 @@ export function HistoryScreen() {
         data-testid="commit-header"
         style={{
           display: "grid",
-          gridTemplateColumns: commitRowGrid(graphW),
+          gridTemplateColumns: commitRowGrid(graphW, dateW),
           height: "calc(24px + var(--row-step))",
           background: "var(--bg-2)",
           borderBottom: "1px solid var(--border-0)",
@@ -841,7 +856,8 @@ export function HistoryScreen() {
               sha={c.shortOid}
               message={c.summary}
               author={c.author || "unknown"}
-              date={relativeTime(c.timestamp)}
+              date={commitDateText(c.timestamp, dateFormat)}
+              dateTitle={commitDateTitle(c.timestamp)}
               refs={refsByOid.get(c.oid)}
               selected={selectedSet.has(c.oid)}
               isHead={c.oid === headOid}
@@ -899,7 +915,12 @@ export function HistoryScreen() {
           }
           author={current.author || "unknown"}
           email={current.email}
-          date={relativeTime(current.timestamp)}
+          // Not the Date-column format: the detail panel has room, and "see the
+          // date on a commit" was half of #354's request — so the stamp is here
+          // unconditionally, with the relative form beside it for the reading
+          // the column normally gives. The zone stays in the hover text.
+          date={`${preciseTime(current.timestamp)} · ${relativeTime(current.timestamp)}`}
+          dateTitle={commitDateTitle(current.timestamp)}
           parents={current.parents.map(shortSha)}
         />
         {/* Notes hang off the commit, not off the log page: read lazily for

--- a/src/screens/Reflog.tsx
+++ b/src/screens/Reflog.tsx
@@ -17,7 +17,8 @@ import {
   DirtyTreeDialog,
   type DirtyChoice,
 } from "@/features/reflog/DirtyTreeDialog";
-import { relativeTime } from "@/lib/derive";
+import { commitDateText, commitDateTitle, preciseTime } from "@/lib/commitDate";
+import { useDateFormat } from "@/features/settings/useSettingsStore";
 import { appErrorMessage } from "@/lib/errors";
 import { PGPane, FocusableScroll, usePaneList } from "@/features/keymap";
 import type { FileDiff, ReflogOp } from "@/lib/types";
@@ -46,6 +47,7 @@ function opLabel(op: ReflogOp): string {
 }
 
 export function ReflogScreen() {
+  const dateFormat = useDateFormat();
   const repo = useRepoStore((s) => s.current);
   const status = useRepoStore((s) => s.status);
   const entries = useReflogStore((s) => s.entries);
@@ -254,7 +256,8 @@ export function ReflogScreen() {
               sha={e.shortOid}
               message={`${opLabel(e.op)}: ${e.message || "(no message)"}`}
               author=""
-              date={relativeTime(e.timestamp)}
+              date={commitDateText(e.timestamp, dateFormat)}
+              dateTitle={commitDateTitle(e.timestamp)}
               selected={selectedOid === e.oid}
               oid={e.oid}
               onRowClick={onRowClick}
@@ -290,7 +293,13 @@ export function ReflogScreen() {
                   }}
                 >
                   {selectedEntry.oid} &middot;{" "}
-                  {new Date(selectedEntry.timestamp * 1000).toLocaleString()}
+                  {/* Was `toLocaleString()`, which said something different
+                      from the row right beside it — and something different
+                      again per machine. Same stamp as History's commit detail
+                      now (#354); the zone is in the hover. */}
+                  <span title={commitDateTitle(selectedEntry.timestamp)}>
+                    {preciseTime(selectedEntry.timestamp)}
+                  </span>
                 </div>
               </div>
               <PGButton variant="primary" onClick={openActionDialog}>

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -30,7 +30,11 @@ import {
 } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
-import { useDensityStep, useSettingsStore } from "@/features/settings/useSettingsStore";
+import {
+  useDateFormat,
+  useDensityStep,
+  useSettingsStore,
+} from "@/features/settings/useSettingsStore";
 import { useWindowedList } from "@/lib/useWindowedList";
 import {
   currentBranch,
@@ -39,9 +43,9 @@ import {
   isTextualDiff,
   isUnstaged,
   isUntracked,
-  relativeTime,
   statusMark,
 } from "@/lib/derive";
+import { commitDateText, commitDateTitle } from "@/lib/commitDate";
 import { LfsDiffNotice } from "@/features/lfs/LfsDiffNotice";
 import { ImageDiffOrEmpty, ImageDiffView } from "@/features/diff/ImageDiffView";
 import { diffImageSides } from "@/features/diff/useImagePreviews";
@@ -161,6 +165,7 @@ export function RepoBrowserScreen() {
   const listFilesAtRev = useRepoStore((s) => s.listFilesAtRev);
   const readFileContentAtRev = useRepoStore((s) => s.readFileContentAtRev);
   const diffContextLines = useSettingsStore((s) => s.diffContextLines);
+  const dateFormat = useDateFormat();
   const ignoreWhitespace = useIgnoreWhitespace();
   const hunkActionsDisabled = useHunkActionsDisabledReason();
   const platform = usePlatform();
@@ -1441,13 +1446,14 @@ export function RepoBrowserScreen() {
                       {c.shortOid}
                     </span>
                     <span
+                      title={commitDateTitle(c.timestamp)}
                       style={{
                         color: "var(--fg-3)",
                         fontSize: "var(--fs-10)",
                         fontFamily: "var(--font-mono)",
                       }}
                     >
-                      {relativeTime(c.timestamp)}
+                      {commitDateText(c.timestamp, dateFormat)}
                     </span>
                   </div>
                   <div

--- a/src/screens/Settings.dateFormat.test.tsx
+++ b/src/screens/Settings.dateFormat.test.tsx
@@ -1,0 +1,81 @@
+// Settings ▸ Appearance ▸ Date format (#354).
+//
+// The formatting itself is pinned in lib/commitDate.test.ts and the column
+// width in design/graph-geometry.test.ts. This file asserts the only part
+// neither of those can: that the preference is REACHABLE, that the control
+// reflects what is stored, and that the row says what it does — including the
+// two things that hold in every mode (hover, and the detail panel), so nobody
+// picks "Relative" believing the exact time is now unreachable.
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { mockInvoke } from "@/test/invokeMock";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { SettingsScreen } from "./Settings";
+
+/** The rest of the Settings screen loads too; give it what it asks for. */
+function mockRestOfSettings() {
+  mockInvoke("cli_shim_status", () => ({
+    installed: true,
+    shimPath: "/usr/local/bin/pgit",
+    target: "/usr/bin/platypusgit",
+    source: "package",
+    pathState: "onPath",
+  }));
+  mockInvoke("get_update_capability", () => "self-update");
+  mockInvoke("diagnostics_report", () => ({
+    logPath: "/tmp/platypusgit.log",
+    logExists: false,
+    logSizeBytes: 0,
+    environment: "host os=macos arch=aarch64 git=2.43.0",
+    version: "0.1.0",
+  }));
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  mockRestOfSettings();
+  useSettingsStore.getState().set("dateFormat", "relative");
+});
+
+const button = (name: string) => screen.getByRole("button", { name });
+
+describe("Settings → Appearance: the date format", () => {
+  it("offers the three formats and shows which one is stored", () => {
+    render(<SettingsScreen />);
+    expect(button("Relative").getAttribute("aria-pressed")).toBe("true");
+    expect(button("Absolute").getAttribute("aria-pressed")).toBe("false");
+    expect(button("Both").getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("persists a pick and moves the pressed state with it", async () => {
+    render(<SettingsScreen />);
+    await userEvent.click(button("Both"));
+    expect(useSettingsStore.getState().dateFormat).toBe("both");
+    expect(button("Both").getAttribute("aria-pressed")).toBe("true");
+    expect(button("Relative").getAttribute("aria-pressed")).toBe("false");
+  });
+
+  // The row carries a live sample, so the difference between the three is read
+  // off the screen rather than guessed from the word.
+  it("previews the chosen format on a real timestamp", async () => {
+    render(<SettingsScreen />);
+    const sample = () => screen.getByTestId("settings-date-format-sample").textContent ?? "";
+    expect(sample()).toBe("3w ago");
+
+    await userEvent.click(button("Absolute"));
+    expect(sample()).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/);
+
+    await userEvent.click(button("Both"));
+    expect(sample()).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2} \(3w ago\)$/);
+  });
+
+  // "Relative" must not read as "the exact time is gone".
+  it("says the full timestamp is always available", () => {
+    render(<SettingsScreen />);
+    const hint = screen.getByTestId("settings-date-format-hint").textContent ?? "";
+    expect(hint).toMatch(/hover/i);
+    expect(hint).toMatch(/commit details/i);
+  });
+});

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -47,6 +47,7 @@ import {
   type PullMode,
 } from "@/lib/tauri";
 import { relativeTime } from "@/lib/derive";
+import { commitDateText, type DateFormat } from "@/lib/commitDate";
 import { appErrorMessage } from "@/lib/errors";
 import { STORE_MANAGED_NOTE } from "@/features/update/packageHint";
 import {
@@ -1145,6 +1146,11 @@ function ImportReport({
 // APPEARANCE SECTION — theme picker + color editor + import/export
 // ═════════════════════════════════════════════════════════════════════════════
 
+// Three weeks ago, so the sample says something in every format: "now" would
+// preview the relative form as "0s ago" and teach nothing about the choice.
+const DATE_SAMPLE_NOW = Date.now();
+const DATE_SAMPLE_TS = Math.floor(DATE_SAMPLE_NOW / 1000) - 60 * 60 * 24 * 21;
+
 function AppearanceSection({ active }: { active: ThemeDef }) {
   const s = useSettingsStore();
   const fileInputRef = React.useRef<HTMLInputElement>(null);
@@ -1367,6 +1373,36 @@ function AppearanceSection({ active }: { active: ThemeDef }) {
             options={[
               { value: "compact", label: "Compact" },
               { value: "comfortable", label: "Comfortable" },
+            ]}
+          />
+        }
+      />
+
+      <Row
+        label="Date format"
+        hint={
+          <span data-testid="settings-date-format-hint">
+            How a commit date is written in History, Reflog, Compare and the
+            repository browser — right now:{" "}
+            <span
+              data-testid="settings-date-format-sample"
+              style={{ fontFamily: "var(--font-mono)", color: "var(--fg-1)" }}
+            >
+              {commitDateText(DATE_SAMPLE_TS, s.dateFormat, DATE_SAMPLE_NOW)}
+            </span>
+            . Hovering a date always shows the full timestamp, whichever format
+            you pick, and commit details always shows it in full.
+          </span>
+        }
+        control={
+          <PGButtonGroup
+            size="sm"
+            value={s.dateFormat}
+            onChange={(v) => s.set("dateFormat", v as DateFormat)}
+            options={[
+              { value: "relative", label: "Relative" },
+              { value: "absolute", label: "Absolute" },
+              { value: "both", label: "Both" },
             ]}
           />
         }


### PR DESCRIPTION
Closes #354.

The Date column could only say how long ago a commit was made, which cannot answer "did this land before or after that?".

## What this adds

- **Settings ▸ Appearance ▸ Date format** — `Relative` (`3w ago`, the default), `Absolute` (`2026-08-14 13:42`) or `Both` (`2026-08-14 13:42 (3w ago)`). It applies to History, Reflog, Compare and the repository browser, and the row carries a live sample of the format it is offering rather than making you guess from the word.
- **Hover always gives the full stamp**, in every mode, zone offset included: `2026-08-14 13:42:07 +02:00 (3w ago)`. Picking "Relative" therefore never means the exact time is unreachable — which is the GitHub behaviour the issue asked for.
- **Commit details shows a stamp inline**, unconditionally — `2026-08-14 13:42:07 · 3w ago`. That was the second half of the request, and gating it behind a non-default preference would have answered only the first.

A default install is unchanged: same text, same 90px column, byte-identical grid template (pinned by a test).

## Notes for review

- **`lib/commitDate.ts` is now the one place a timestamp becomes text.** `relativeTime` stays in `lib/derive.ts` — it is one of the forms composed there, not a surface of its own. New date surfaces call `commitDateText` + `commitDateTitle`.
- **The format picks the column WIDTH as well as the text.** The Date column is fixed-width monospace and a 16-character stamp does not fit the 90px `3w ago` needs, so `DATE_COL_W` sizes it per format. `PGCommitRow` and History's header both read it through `useDateColumnWidth()` and hand the *same* number to `commitRowGrid`; threading a prop through one of them is how a header drifts off the rows under it.
- **Local time, and the hover says which zone.** `CommitInfo` carries unix seconds only — the author's own UTC offset is not on the wire — so matching `git log`'s author-timezone display would need a backend change (`CommitInfo` in Rust and TS, plus `libgit2.rs`). Happy to follow up separately if that is wanted.
- **Reflog's detail date joins the same formatter.** It used `toLocaleString()`, which read differently from the row beside it and differently again per machine. History's "copy visible commits" export keeps `toISOString()` on purpose: machine-readable output, not a reading surface.
- The tooltip is on the date **cell**, not the row — a row-wide `title` would follow the pointer across the message and sha columns and shadow the titles those use for their own truncated text.

## Verification

- `pnpm test` — 320 files, 3060 tests, all passing (26 new: formatter, grid widths, store persistence/normalisation, the row and detail cells, the Settings row).
- `pnpm tsc --noEmit` clean; `pnpm vite build` clean.
- `pnpm test:e2e:docker run --spec settings --spec reflog --spec smoke` — 13 passing. Those are the surfaces touched: the Appearance section (the density test clicks a button group right beside the new one), the Reflog detail, and the commit rows plus the "never scrolls sideways" invariant.
- The new preference joins the settings export as portable — the key-set snapshot guard in `useSettingsStore.export.test.ts` caught it and forced the call, which is what it is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
