### PR TITLE
docs: README says 0.5.x, not 0.1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ re-check any cell in a minute. A cell that has gone stale is a bug worth
 
 </details>
 
-**Where we are behind.** We are 0.1.x and the youngest tool on this list:
+**Where we are behind.** We are 0.5.x and the youngest tool on this list:
 installers that warn on first launch, no in-app update on macOS, and changed
 images shown as "binary" rather than a preview — the full list is under
 [Status](#status). Two of the gaps are deliberate rather than unfinished: no
@@ -209,7 +209,7 @@ copy of [`scripts/install-pgit.sh`](./scripts/install-pgit.sh) and
 
 ## Status
 
-**Active development, versioned 0.1.x** — expect frequent releases and rough
+**Active development, versioned 0.5.x** — expect frequent releases and rough
 edges. Most core git operations work end to end (the feature list above is what
 is implemented, not a roadmap). Known gaps, stated plainly:
 


### PR DESCRIPTION
Two spots in the README still claimed `0.1.x` while the current release is v0.5.0 — the "where we are behind" note under the comparison table (`README.md:127`) and the Status heading (`README.md:212`).

The other `0.1.x` mentions in the tree (`docs/dev/distribution.md`, `site/src/data/features.ts`) are historical — they describe what someone already on 0.1.x upgrades from — so they stay as written.

`test/comparison.test.ts` and `test/docs.test.ts` (the two suites that parse the README) pass: 16 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
