### PR TITLE
fix(e2e): re-resolve every waitForDisplayed, so a re-render cannot kill a wait (#364)

### DIFF
--- a/.claude/skills/e2e-testing/SKILL.md
+++ b/.claude/skills/e2e-testing/SKILL.md
@@ -57,10 +57,15 @@ beyond headlessness.
 
 ## Suite-speed guards (wdio.conf.ts `before` hook — don't remove)
 
-Two conf-level guards eliminate the historical "suite suddenly takes minutes" flakes. Both live in the `before` hook; removing either brings a stall class back:
+Two conf-level guards eliminate the historical "suite suddenly takes minutes"
+flakes, and a third removes the dead-handle wait class (#364 — see
+`installStaleProofWaits`, and note it must be installed before the first `$()`).
+All three live in the `before` hook; removing any brings its failure class back:
 
 1. **`browser.tauri.switchWindow("main")`** — sets the service's session-wide "user switched windows" flag, which makes its per-command focus check (`ensureActiveWindowFocus`) skip forever. Unskipped, that check runs a direct-eval script before EVERY find/click that polls 5s for `window.__wdio_original_core__` whenever the page is unarmed. Single-window app: focus management has nothing to manage.
 2. **`browser.setTimeout({ script: … })` — 2.5s on macOS, 8s on Linux.** The driver's default W3C script timeout is 30s. An `execute()` that lands while a `browser.refresh()` navigation is mid-document-swap gets its completion handler silently dropped; the driver waits the FULL script timeout, then the caller retries — so a loss costs the TIMEOUT, not the work. The cap is only the belt: `refreshAndSettle` (below) removes the roll itself. Linux was uncapped until #194 because a timed-out-but-completed script gets retried and double-ran side-effectful helpers (merge-conflict desync); `executeOnce` closed that, so the cap is now safe there. 8s is measured — with the mid-swap executes gone the slowest in-page script anywhere in the suite is 12ms in local Docker and 190ms on a real CI runner (`E2E_SCRIPT_TIMING=1` prints the per-spec p50/p90/p99/max; `E2E_SCRIPT_TIMEOUT_MS` overrides the cap).
+
+3. **`installStaleProofWaits()`** — overwrites `waitForDisplayed` so each poll re-resolves the selector. `isDisplayed` caches `elementId` and never re-runs the selector, and a detached node answers "not displayed" without raising stale, so a re-render landing between the find and the visibility check leaves the wait polling a dead node for its whole budget with the element on screen. That is the #364 flake class, across every shard, and a bigger timeout cannot fix it. Element overrides attach at element-creation time, so this must run before the first `$()` — `test/e2eWaitGate.test.ts` pins that, `harness.e2e.ts` pins the behaviour.
 
 `armDriverBridge()` (`e2e/support/app.ts`) hands `window.__TAURI__.core` (e2e builds only, via `src-tauri/tauri.e2e.conf.json`) to the driver's direct-eval channel. With guard 1 active it's belt-and-braces (only `browser.tauri.*` calls need it), but keep the pattern: it doubles as the post-refresh settle gate.
 
@@ -156,7 +161,13 @@ Fixtures live in `e2e/support/tempRepo.ts` (`basicRepo`, `dirtyRepo`, `branchyRe
   several are mounted (the Rebase plan mounts one picker per row). It replaced
   `jsSelectValue`, which existed because WebKitGTK under xvfb accepted the
   `<option>` click WITHOUT firing a React-visible change event (bit PR #40 on
-  CI) — a trap that no longer has a subject.
+  CI) — a trap that no longer has a subject. **Both of its steps retry now
+  (#364)**: a React commit between "the option exists" and "click the option"
+  unmounts the portal (`option "…" vanished before the click`, 4 sightings) and
+  one between the trigger's mousedown and the portal mounting loses the open
+  (`… never appeared`, 2). Retrying is safe only because a miss dispatches
+  nothing — keep any new step in that helper side-effect-free on the
+  not-found path.
 - Root commit's "Interactive rebase from here" silently no-ops.
 - `remoteRepo()` pairs a work repo with a local bare `origin`. `makeBehind`
   rewinds `refs/remotes/origin/main` so fetch has something to discover —
@@ -228,6 +239,38 @@ follow-up selector unambiguous — pure CSS scoped to the destination's pane
 (`[data-pg-pane="commitDiff.files"] [data-pg-row][data-path="b.txt"]`), not
 `*=`-text that some other screen also satisfies.
 
+**The dead-handle half of that is now fixed for the whole suite (#364); the
+ambiguous-selector half is still yours.** `installStaleProofWaits()`
+(`e2e/support/app.ts`, installed by the conf's `before` hook) overwrites
+`waitForDisplayed` so every poll re-resolves the selector with a fresh
+WebDriver find — session-wide, because there are 227 call sites and a helper
+only fixes the ones that adopt it. It cost a whole table of specs before that:
+`commit.e2e`'s clean-state wait (its `PGEmpty` is unmounted and remounted by
+every refresh, since `CommitPanel` gates it on `!loading`), `remote.e2e`'s
+renamed-remote row, `settings.e2e` after a reload — all on a starved CI runner,
+never locally. What still needs care:
+
+- **Re-resolution rescues a swapped node, not a wrong selector.** A wait that
+  binds to the OUTGOING screen's row will now happily re-resolve to that same
+  row for as long as it exists. Scope to the destination anyway.
+- Three shapes stay on the original implementation and can still go dead:
+  `reverse` waits (a detached node reports what they want — fine), a non-string
+  selector, and an element taken out of a `$$` list (identified by INDEX, so
+  re-running the selector alone would silently wait on the first match).
+- Don't reach for `waitForSelector` just to dodge this — it polls in page,
+  which is the #194 stall after a navigation. `waitForDisplayed` is a legal
+  settle gate precisely because it is a find.
+- `test/e2eWaitGate.test.ts` pins the install; `harness.e2e.ts` pins the
+  behaviour, with a *control* test proving a raw handle still goes dead. A
+  failing control means webdriverio started refetching and the override can go.
+
+**Wait on state, not on rendered prose.** Six waits matched
+`div*=Working tree clean` — a `PGEmpty` title, so a copy edit could redden the
+required gate, and `div*=` resolves to whichever innermost div contains the
+phrase, which is never the element you meant. Use `WORKING_TREE_CLEAN`
+(`[data-testid="working-tree-clean"]`); add a testid rather than a phrase for
+the next one.
+
 **A readiness signal that is also true of "not started yet" is not a readiness
 signal.** `merge-window` waited for Apply to be *disabled* to mean "the next
 file's fresh model is unresolved", but `canApply`'s `allResolved` is
@@ -252,6 +295,46 @@ the seeded-and-unresolved model produces. Same fix, same reason, as the
    happens, check that the `before`/`beforeTest` hooks and the `e2e-focus`
    capability (`src-tauri/tauri.e2e.conf.json`) are intact, and that the
    binary was rebuilt after any capability change. CI (xvfb) is immune.
+
+## A red CI gate on a tree that looks fine (#364)
+
+**Two API calls settle "is it me?" before anything else costs you a merge
+window:**
+
+```bash
+gh run list --workflow e2e.yml --branch main --limit 12 \
+  --json databaseId,conclusion,createdAt
+gh run view <red-id> --log-failed | grep -E "✖|Error: "
+```
+
+A byte-identical failure on a recent red `main` run is proof it is not your
+diff — no scratch branch to push, nothing to clean up. `main` goes red
+intermittently (measured: 3 failures in 40 `push: main` runs; the `cancelled`
+ones are `concurrency` collapsing a merge burst, not a signal), so one is often
+already there. Only when main's recent runs are all green, fall back to pushing
+your exact tree to a scratch branch and `gh workflow run e2e.yml --ref <it>`.
+
+Then read the shape of the failure:
+
+- **A wait that gives up while the screen is right, on a sub-test that wanders
+  between runs**, is the #364 class — a real logic regression fails the same
+  assertion every time. That class is fixed at the command level now (see the
+  dead-handle section above), so a NEW sighting deserves the diff audit, not a
+  re-run.
+- `[e2e] <spec>: N driver scripts, M stalled` is a speed-INDEPENDENT diff of app
+  behaviour between two runs. Identical counts on the specs you did not touch is
+  strong evidence of no behavioural change — far better than comparing wall
+  clock on a noisy runner.
+- `[e2e] RETRY: <spec> failed on attempt 1` means `specFileRetries: 1` absorbed
+  a failure. **A green gate with that line in it is still a signal** — the
+  floor exists for a starved runner losing the app itself
+  (`app never rendered Welcome screen`), not to paper over your change. It is
+  also emitted as a `::warning` and into the job summary, so look there first.
+- Audit your own diff regardless of how confident you are it is a flake. Every
+  time that audit has been run here it found something real, usually somewhere
+  else entirely (a blocking call added to a startup or spawn path is the
+  classic). Also: `e2e/wdio.conf.ts` passes no `appArgs`, so the e2e binary gets
+  EMPTY argv — any CLI-parsing change is inert in e2e by construction.
 
 ## Before committing
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -169,6 +169,88 @@ Rules that keep the gates honest:
   run`. With neither set, `specs` keeps its plain glob — byte-for-byte the old
   behaviour.
 
+## A red `e2e-linux` that is not a regression (#364)
+
+The required gate went red on trees that were provably fine, often enough that
+"look for the same failure on a recent `main` run, re-run CI, watch it go green"
+became routine — which is exactly how a real regression gets waved through.
+Measured over 40 `push: main` e2e runs at the time: 28 success, 3 failure, 9
+cancelled (the cancellations are `concurrency` collapsing a merge burst, not a
+signal). Specs across every shard were involved: `commit.e2e` (three different
+sub-tests on the clean-state wait), `settings.e2e` after a reload, `remote.e2e`'s
+renamed-remote row, `history-ops`'s ref selector.
+
+**It was one mechanism, not one bug per spec.** `waitForDisplayed` is
+`waitUntil(() => isDisplayed())` over an element HANDLE, and `isDisplayed`
+resolves its selector exactly once — the first poll caches `elementId`, and no
+later poll re-runs the selector (`hasElementId`, webdriverio 9.31.5). If a
+re-render detaches that node between the find and the visibility check (two
+separate round trips), every remaining poll interrogates a node that is no
+longer in the document: `checkVisibility()` answers `false`, the
+`getComputedStyle` probe returns an empty declaration instead of throwing, so no
+`stale element reference` is ever raised and WebdriverIO's error handler never
+refetches. The wait then burns its whole budget on a dead node with the element
+it wanted on screen the entire time — and a bigger timeout cannot help.
+`waitForExist` never had the bug: `isExisting` re-runs the selector every poll.
+
+Losing that race needs a re-render inside two round trips, so a starved CI
+runner loses it and a quiet laptop does not. **The tell is a wait that gives up
+while the screen is right, on a sub-test that wanders between runs** — a real
+logic regression fails the same assertion every time.
+
+What is in the tree now:
+
+- **`installStaleProofWaits()`** (`e2e/support/app.ts`, installed by the conf's
+  `before` hook) overwrites `waitForDisplayed` so each poll re-resolves the
+  selector with a fresh WebDriver find. Session-wide on purpose: there are 227
+  call sites and a helper only fixes the ones that adopt it. Re-resolution is a
+  find and NOT an in-page `querySelector` poll, or it would reinstate the #194
+  mid-document-swap stall in all 227 at once. `reverse` waits, non-string
+  selectors and `$$`-indexed handles stay on the original implementation — see
+  the helper's doc for why each would break.
+- **`test/e2eWaitGate.test.ts`** pins the install, the single override, and the
+  find-not-script rule as static facts; **`e2e/specs/harness.e2e.ts`** pins the
+  behaviour, including a *control* test proving a raw handle still goes dead. If
+  that control ever fails, a webdriverio release has started refetching and the
+  override can be deleted rather than carried.
+- **Waits are on state, not rendered prose.** Six waits matched
+  `div*=Working tree clean` — a `PGEmpty` title, so a copy edit could redden the
+  required gate, and a `div*=` XPath resolves to whichever innermost div
+  contains the phrase. They use `WORKING_TREE_CLEAN`
+  (`[data-testid="working-tree-clean"]`) now.
+- **`jsPickOption` retries both of its steps.** It waits for an option to
+  EXIST and then clicks it in a second round trip; a React commit in between
+  unmounts the listbox portal (`option "…" vanished before the click`, four
+  sightings) or replaces the trigger before the portal mounts (`… never
+  appeared`, two). The miss is side-effect-free — the script dispatches nothing
+  when the selector does not match — which is what makes the retry safe.
+- **`specFileRetries: 1` + `specFileRetriesDeferred: true`** is a floor, not a
+  fix. It covers what no wait can: a starved runner losing the app itself
+  (`app never rendered Welcome screen`, seen in workers that then passed) used
+  to fail the whole required check. Safe because every spec file builds its own
+  fixtures in `before*` and disposes them in `after*` — not the #35 hazard,
+  which was a *script* retry re-running effects inside one attempt. **Never
+  silent:** `onWorkerEnd` prints the requeue, emits a `::warning` annotation and
+  writes a line to the job summary, so a spec that needed a retry on your PR is
+  still a signal on a green gate. Read those lines.
+
+**Diagnosing the next one — two API calls, before anything else:**
+
+```bash
+gh run list --workflow e2e.yml --branch main --limit 12 \
+  --json databaseId,conclusion,createdAt
+gh run view <red-id> --log-failed | grep -E "✖|Error: "
+```
+
+A byte-identical failure sitting on a recent red `main` run is proof it is not
+your diff, with no scratch branch to push and nothing to clean up. `main` goes
+red intermittently, so one is often already there. Also speed-independent, and
+better than eyeballing wall clock on a noisy runner: the per-spec
+`[e2e] <spec>: N driver scripts, M stalled` line is a diff of app *behaviour*
+between two runs — identical counts on the specs you did not touch is strong
+evidence of no behavioural change. Audit your own diff regardless; the audit
+has found real (unrelated) problems every time it was run.
+
 ## Dependency advisories in the dev toolchain (#346)
 
 Every Dependabot alert this repo has open against the root `pnpm` project is

--- a/e2e/specs/commit.e2e.ts
+++ b/e2e/specs/commit.e2e.ts
@@ -1,6 +1,12 @@
 import { browser, $, expect } from "@wdio/globals";
 import { dirtyRepo, TempRepo } from "../support/tempRepo";
-import { changeRow, openRepo, resetApp, switchScreen } from "../support/app";
+import {
+  changeRow,
+  openRepo,
+  resetApp,
+  switchScreen,
+  WORKING_TREE_CLEAN,
+} from "../support/app";
 
 describe("commit", () => {
   let repo: TempRepo;
@@ -44,9 +50,10 @@ describe("commit", () => {
     });
     await commitBtn.click();
 
-    // UI as wait condition: CommitPanel returns to its empty state once the
-    // commit lands (PGEmpty title "Working tree clean", rendered in a <div>).
-    await $("div*=Working tree clean").waitForDisplayed({
+    // UI as wait condition: CommitPanel returns to its clean-tree empty state
+    // once the commit lands. The wait is on that state's own testid, not on
+    // the PGEmpty title as rendered text (#364).
+    await $(WORKING_TREE_CLEAN).waitForDisplayed({
       timeout: 20_000,
       timeoutMsg: "commit panel did not return to clean state",
     });
@@ -66,7 +73,7 @@ describe("commit", () => {
     );
     await $('[data-testid="commit-message"]').setValue("feat: typo in mesage");
     await $('[data-testid="commit-button"]').click();
-    await $("div*=Working tree clean").waitForDisplayed({
+    await $(WORKING_TREE_CLEAN).waitForDisplayed({
       timeout: 20_000,
       timeoutMsg: "commit panel did not return to clean state",
     });
@@ -83,7 +90,7 @@ describe("commit", () => {
     await messageBox.setValue("feat: typo in message");
     await $('[data-testid="commit-button"]').click();
 
-    await $("div*=Working tree clean").waitForDisplayed({
+    await $(WORKING_TREE_CLEAN).waitForDisplayed({
       timeout: 20_000,
       timeoutMsg: "commit panel did not return to clean state after amending",
     });
@@ -131,7 +138,7 @@ describe("commit", () => {
 
     // The escape hatch on the refusal itself.
     await $('[data-testid="hook-skip"]').click();
-    await $("div*=Working tree clean").waitForDisplayed({
+    await $(WORKING_TREE_CLEAN).waitForDisplayed({
       timeout: 20_000,
       timeoutMsg: "committing without hooks did not return the panel to clean",
     });

--- a/e2e/specs/harness.e2e.ts
+++ b/e2e/specs/harness.e2e.ts
@@ -1,5 +1,110 @@
-import { browser, expect } from "@wdio/globals";
+import { browser, $, expect } from "@wdio/globals";
 import { buildExecuteOnceScript, executeOnce } from "../support/app";
+
+/** A detached node's marker, unique to this file so no app selector can hit it. */
+const SWAPPED = '[data-pg-harness-swap="1"]';
+
+/** Mount a fresh marker node, REPLACING any previous one.
+ *
+ *  Deliberately `remove()` + `appendChild` rather than editing in place: that
+ *  is what React does when a conditional branch flips (`CommitPanel` unmounts
+ *  its clean-tree `PGEmpty` on every refresh, because it gates the branch on
+ *  `!loading`), and a node identity change is the whole subject here. */
+const mountMarker = () =>
+  executeOnce((sel: string) => {
+    document.querySelector(sel)?.remove();
+    const el = document.createElement("div");
+    el.setAttribute("data-pg-harness-swap", "1");
+    el.textContent = "harness marker";
+    document.body.appendChild(el);
+    return true;
+  }, SWAPPED);
+
+const removeMarker = () =>
+  executeOnce((sel: string) => {
+    document.querySelector(sel)?.remove();
+    return true;
+  }, SWAPPED);
+
+/**
+ * Self-test for the stale-handle wait guard (issue #364).
+ *
+ * `isDisplayed` resolves its selector exactly once and caches `elementId`; a
+ * detached node then answers "not displayed" without raising stale, so
+ * WebdriverIO never refetches and `waitForDisplayed` polls a dead node for its
+ * whole budget. That is the mechanism behind every #364 sighting — a wait that
+ * gives up while the screen is right — and `installStaleProofWaits` (installed
+ * by the conf's `before` hook) removes it by re-resolving per poll.
+ *
+ * Both facts are pinned here because both can change under us: a webdriverio
+ * release that makes `isDisplayed` refetch would make the control test fail,
+ * which is the signal to delete the override rather than keep carrying it.
+ */
+describe("harness: stale-handle waits", () => {
+  afterEach(async () => {
+    await removeMarker();
+  });
+
+  it("control: a handle bound to a swapped-out node reports not-displayed, and never refetches", async () => {
+    await mountMarker();
+    const handle = await $(SWAPPED);
+    // Binds `handle.elementId` to the node that exists right now.
+    expect(await handle.isDisplayed()).toBe(true);
+
+    // The swap: same selector, different DOM node — a re-render, in one step.
+    await mountMarker();
+
+    // The bug class, deterministically. No stale error is raised (which is why
+    // WebdriverIO's error handler never refetches), and no amount of waiting
+    // would change the answer.
+    expect(await handle.isDisplayed()).toBe(false);
+    // ...while the element the caller asked for is on screen the whole time.
+    expect(await $(SWAPPED).isDisplayed()).toBe(true);
+  });
+
+  it("waitForDisplayed re-resolves, so a swapped node no longer kills the wait", async () => {
+    await mountMarker();
+    const handle = await $(SWAPPED);
+    expect(await handle.isDisplayed()).toBe(true);
+    await mountMarker();
+
+    // The same dead handle the control test just proved is stuck. Without the
+    // override this is a guaranteed 3s timeout; with it, the poll re-runs the
+    // selector and matches the live node.
+    expect(await handle.waitForDisplayed({ timeout: 3_000 })).toBe(true);
+  });
+
+  it("still fails when the element is genuinely gone", async () => {
+    // The override must not turn a real absence into a pass — the whole point
+    // of the gate is that a wait still reports a broken screen.
+    await removeMarker();
+    // try/catch rather than `expect(...).rejects`: `expect` here is
+    // expect-webdriverio, which awaits a promise argument for its own element
+    // matchers, so the plain-promise shape is not worth depending on.
+    let message = "";
+    try {
+      await $(SWAPPED).waitForDisplayed({
+        timeout: 1_000,
+        timeoutMsg: "absent, as expected",
+      });
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toContain("absent, as expected");
+  });
+
+  it("reverse waits still see a removed node as gone", async () => {
+    // `reverse` stays on the original implementation (a dead handle already
+    // answers what it is waiting for), so pin that it kept working.
+    await mountMarker();
+    const handle = await $(SWAPPED);
+    expect(await handle.isDisplayed()).toBe(true);
+    await removeMarker();
+    expect(
+      await handle.waitForDisplayed({ reverse: true, timeout: 3_000 }),
+    ).toBe(true);
+  });
+});
 
 /**
  * Self-test for the executeOnce retry guard (issue #35).

--- a/e2e/specs/keymap.e2e.ts
+++ b/e2e/specs/keymap.e2e.ts
@@ -13,7 +13,7 @@ import {
 import {
   openRepo, resetApp, jsChord, jsDoubleShift, jsKey, jsPickOption,
   focusedPaneId, paletteDialog, paletteInput, changeRow, stagedRow,
-  scrollCommitListTo, switchScreen,
+  scrollCommitListTo, switchScreen, WORKING_TREE_CLEAN,
 } from "../support/app";
 
 const CHEAT_SHEET = "h2*=Keyboard shortcuts";
@@ -319,7 +319,7 @@ describe("keymap — rider preset (default)", () => {
     repo = basicRepo();
     await openRepo(repo.path);
     await jsChord("Mod+K");
-    await waitScreen("div*=Working tree clean", "Commit (clean)");
+    await waitScreen(WORKING_TREE_CLEAN, "Commit (clean)");
     repo.write("fresh.txt", "fresh\n");
     await jsChord("Mod+Alt+Y");
     await changeRow("fresh.txt").waitForDisplayed({

--- a/e2e/specs/stash.e2e.ts
+++ b/e2e/specs/stash.e2e.ts
@@ -8,6 +8,7 @@ import {
   resetApp,
   stubNativeDialogs,
   switchScreen,
+  WORKING_TREE_CLEAN,
 } from "../support/app";
 
 describe("stash", () => {
@@ -34,7 +35,7 @@ describe("stash", () => {
     await stubNativeDialogs({ promptText: "e2e stash" });
     await $("button*=Stash").click();
 
-    await $("div*=Working tree clean").waitForDisplayed({
+    await $(WORKING_TREE_CLEAN).waitForDisplayed({
       timeout: 20_000,
       timeoutMsg: "commit panel did not return to clean state after stash",
     });
@@ -78,7 +79,7 @@ describe("stash", () => {
       promptQueue: ["before rename", "renamed by e2e"],
     });
     await $("button*=Stash").click();
-    await $("div*=Working tree clean").waitForDisplayed({
+    await $(WORKING_TREE_CLEAN).waitForDisplayed({
       timeout: 20_000,
       timeoutMsg: "commit panel did not return to clean state after stash",
     });

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -60,6 +60,120 @@ export async function armDriverBridge(): Promise<void> {
   );
 }
 
+/** Options `waitForDisplayed` accepts. Not exported by webdriverio, and the
+ *  exported `WaitForOptions` is missing the three visibility flags, so the
+ *  override below would silently drop them. */
+type WaitForDisplayedParams = {
+  timeout?: number;
+  interval?: number;
+  timeoutMsg?: string;
+  reverse?: boolean;
+  withinViewport?: boolean;
+  contentVisibilityAuto?: boolean;
+  opacityProperty?: boolean;
+  visibilityProperty?: boolean;
+};
+
+/** Make every `waitForDisplayed` in the suite re-resolve its selector on each
+ *  poll, so a re-render that swaps the node cannot kill the wait (issue #364).
+ *
+ *  # The bug this removes
+ *
+ *  `waitForDisplayed` is `waitUntil(() => this.isDisplayed())` over an element
+ *  HANDLE, and `isDisplayed` resolves the selector exactly once
+ *  (`hasElementId`, webdriverio 9.31.5): the first poll caches `elementId` and
+ *  no later poll re-runs the selector. So if React detaches that node between
+ *  the find and the visibility check — two separate round trips — every
+ *  remaining poll interrogates a node that is no longer in the document:
+ *
+ *  - `checkVisibility()` on a detached node returns `false`, honestly;
+ *  - the `getComputedStyle` probe returns an empty declaration rather than
+ *    throwing, so the "stale element reference" branch is never taken;
+ *  - no stale error means `elementErrorHandler` has nothing to catch and never
+ *    refetches.
+ *
+ *  The wait then polls a dead node for its ENTIRE budget with the element it
+ *  wanted on screen the whole time, and fails with the caller's `timeoutMsg`.
+ *  Raising the timeout cannot help: once the handle is bound to a detached
+ *  node, no amount of waiting re-resolves it. `waitForExist` does not have the
+ *  bug — `isExisting` re-runs the selector on every poll (and revalidates
+ *  `elementId` afterwards), which is exactly the shape reproduced here.
+ *
+ *  # Why it is a CI-only failure
+ *
+ *  Losing the find-vs-swap race needs a re-render to land inside those two
+ *  round trips, so a starved runner loses it and a quiet laptop does not. It
+ *  produced the whole of #364: `commit.e2e.ts`'s four waits for the clean
+ *  state (whose `PGEmpty` is unmounted and remounted by every refresh, because
+ *  `CommitPanel` gates it on `!loading`), `remote.e2e.ts`'s renamed-remote row,
+ *  `settings.e2e.ts` after a reload. One mechanism, one fix — and the tell is
+ *  a wait that gives up while the screen is right, on a sub-test that wanders
+ *  between runs.
+ *
+ *  # Why an override rather than a helper
+ *
+ *  A helper only fixes the sites that adopt it, and there are 227 of them; the
+ *  228th would reintroduce the class. Overriding the command fixes every
+ *  existing site and every future one, and keeps specs reading as plain
+ *  WebdriverIO. `test/e2eWaitGate.test.ts` pins that the conf installs it.
+ *
+ *  Re-resolution is a WebDriver find (`this.parent.$(selector)`), NOT an
+ *  in-page `document.querySelector` poll — see `refreshAndSettle`: an
+ *  in-page poll right after a navigation is the #194 stall, and
+ *  `waitForDisplayed` is a legal settle gate precisely because it is a find.
+ *  Going through `this.parent` keeps a scoped `dialog.$("label*=…")` scoped.
+ *
+ *  Element overrides are attached when an element object is created, so this
+ *  must run in the conf's `before` hook, ahead of the first `$()`. */
+export async function installStaleProofWaits(): Promise<void> {
+  await browser.overwriteCommand(
+    "waitForDisplayed",
+    async function (
+      this: WebdriverIO.Element,
+      origFn: (opts?: WaitForDisplayedParams) => Promise<true>,
+      opts: WaitForDisplayedParams = {},
+    ): Promise<true> {
+      const selector = this.selector;
+      // Three shapes stay on the original implementation.
+      //
+      // `reverse` already tolerates a detached node — "gone" is the answer it
+      // is waiting for, and a dead handle reports exactly that, so
+      // re-resolving would change the meaning of a passing wait rather than
+      // rescue it. A non-string selector (a function, a custom strategy) has
+      // no selector to re-run. And an element taken out of a `$$` list is
+      // identified by its INDEX within that list: re-running the selector
+      // alone would silently wait on the FIRST match instead of the one the
+      // caller is holding.
+      if (opts.reverse || typeof selector !== "string" || this.index !== undefined) {
+        return origFn.call(this, opts);
+      }
+      const timeout = opts.timeout ?? browser.options.waitforTimeout ?? 15_000;
+      const interval = opts.interval ?? browser.options.waitforInterval ?? 500;
+      const timeoutMsg =
+        opts.timeoutMsg ??
+        `element ("${selector}") still not displayed after ${timeout}ms`;
+      // Forwarded explicitly rather than by spread: an `interval`/`timeout`
+      // reaching isDisplayed would be ignored, but a dropped visibility flag
+      // would quietly change what "displayed" means.
+      const params = {
+        withinViewport: opts.withinViewport ?? false,
+        contentVisibilityAuto: opts.contentVisibilityAuto ?? true,
+        opacityProperty: opts.opacityProperty ?? true,
+        visibilityProperty: opts.visibilityProperty ?? true,
+      };
+      await browser.waitUntil(
+        // A fresh handle per poll: `$()` leaves `elementId` unset, so
+        // `isDisplayed` resolves the selector again instead of reusing a node
+        // that may have been swapped out since the last poll.
+        () => this.parent.$(selector).isDisplayed(params),
+        { timeout, interval, timeoutMsg },
+      );
+      return true;
+    },
+    true,
+  );
+}
+
 /** macOS focus self-heal (issue #32).
  *
  * The e2e debug binary is unbundled and doesn't reliably win foreground
@@ -800,52 +914,88 @@ export async function jsPickOption(
   opts?: { within?: string; text?: string },
 ): Promise<void> {
   // executeOnce: a driver-retry re-run would toggle the list shut again, and
-  // the not-found throws all happen before any dispatch.
-  const opened = await executeOnce(
-    (sel: string, within: string | null, text: string | null) => {
-      let scope: ParentNode = document;
-      if (within) {
-        const hosts = Array.from(document.querySelectorAll(within));
-        const host = text
-          ? hosts.find((h) => h.textContent?.includes(text))
-          : hosts[0];
-        if (!host) return false;
-        scope = host;
-      }
-      const el = scope.querySelector(sel) as HTMLElement | null;
-      if (!el) return false;
-      if (el.getAttribute("aria-expanded") === "true") return true;
-      el.focus();
-      el.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
-      return true;
-    },
-    selector,
-    opts?.within ?? null,
-    opts?.text ?? null,
-  );
-  if (!opened) {
-    throw new Error(
-      `jsPickOption: trigger not found: ${selector}` +
-        (opts?.within ? ` (within ${opts.within}${opts.text ? `, text: ${opts.text}` : ""})` : ""),
+  // the not-found throws all happen before any dispatch. The `aria-expanded`
+  // check is what makes this safe to call more than once (see the loop below):
+  // an already-open trigger is left alone rather than toggled shut.
+  const open = () =>
+    executeOnce(
+      (sel: string, within: string | null, text: string | null) => {
+        let scope: ParentNode = document;
+        if (within) {
+          const hosts = Array.from(document.querySelectorAll(within));
+          const host = text
+            ? hosts.find((h) => h.textContent?.includes(text))
+            : hosts[0];
+          if (!host) return false;
+          scope = host;
+        }
+        const el = scope.querySelector(sel) as HTMLElement | null;
+        if (!el) return false;
+        if (el.getAttribute("aria-expanded") === "true") return true;
+        el.focus();
+        el.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+        return true;
+      },
+      selector,
+      opts?.within ?? null,
+      opts?.text ?? null,
     );
-  }
+  const where =
+    selector +
+    (opts?.within ? ` (within ${opts.within}${opts.text ? `, text: ${opts.text}` : ""})` : "");
 
   // The listbox is a portal rendered one React commit after the mousedown, so
   // poll for the option rather than looking once (the `waitForMenuItem` rule).
   const option = `[data-pg-listbox] [data-pg-option][data-value="${value}"]`;
-  await $(option).waitForExist({
-    timeout: 10_000,
-    timeoutMsg: `option "${value}" never appeared for ${selector}`,
-  });
-  const clicked = await executeOnce((sel: string) => {
-    const el = document.querySelector(sel) as HTMLElement | null;
-    if (!el) return false;
-    el.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
-    el.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true }));
-    el.click();
-    return true;
-  }, option);
-  if (!clicked) throw new Error(`jsPickOption: option "${value}" vanished before the click`);
+  // Two open attempts, not one (issue #364). `option "feature" never appeared
+  // for [data-testid="history-ref-select"]` hit shard 3 twice, always on a
+  // starved runner: the mousedown lands on a trigger that a React commit
+  // replaces immediately after, so the toggle is applied to a node that is
+  // already on its way out and the portal never mounts. Re-opening once
+  // recovers that; a trigger that is genuinely absent, or a listbox that
+  // genuinely lacks the option, still fails — just after 2 × 6s instead of 10s.
+  let listed = false;
+  for (let attempt = 1; attempt <= 2 && !listed; attempt++) {
+    if (!(await open())) throw new Error(`jsPickOption: trigger not found: ${where}`);
+    listed = await $(option)
+      .waitForExist({ timeout: 6_000 })
+      .then(
+        () => true,
+        () => false,
+      );
+  }
+  if (!listed) {
+    throw new Error(`option "${value}" never appeared for ${where}`);
+  }
+  // Poll the click instead of firing it once (issue #364). The wait above
+  // proves the option EXISTED; the click is a second round trip, and a React
+  // commit landing in between unmounts the listbox portal — which is exactly
+  // how `option "feature" vanished before the click` failed shard 3 on
+  // history-ops, four times, always on a starved runner and never locally.
+  //
+  // Retrying is safe *because* the miss is side-effect-free: the script
+  // dispatches nothing when the selector does not match, so a returned `false`
+  // means nothing happened and the next attempt is the first one. Each poll is
+  // a fresh `executeOnce` token, so each attempt really runs (the token only
+  // suppresses the DRIVER re-running one attempt, which is still what #35
+  // needs it for).
+  //
+  await browser.waitUntil(
+    () =>
+      executeOnce((sel: string) => {
+        const el = document.querySelector(sel) as HTMLElement | null;
+        if (!el) return false;
+        el.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+        el.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true }));
+        el.click();
+        return true;
+      }, option),
+    {
+      timeout: 10_000,
+      interval: 100,
+      timeoutMsg: `jsPickOption: option "${value}" kept vanishing before the click`,
+    },
+  );
   // The listbox closing is the only in-page signal that the commit landed.
   await $("[data-pg-listbox]").waitForExist({
     reverse: true,
@@ -1248,6 +1398,15 @@ export function waitForSelector(
     { timeout, timeoutMsg },
   );
 }
+
+/** `CommitPanel`'s clean-tree empty state (#364).
+ *
+ *  A testid, not the `div*=Working tree clean` text match six waits used to
+ *  use. Two reasons, and the second is the one that cost CI time: matching
+ *  rendered PROSE pins a required gate to copy this app is free to reword, and
+ *  a `div*=` XPath resolves to whichever innermost div happens to contain the
+ *  phrase — so the wait was never explicit about the element it bound to. */
+export const WORKING_TREE_CLEAN = '[data-testid="working-tree-clean"]';
 
 /** The docked terminal panel's host element (#243). */
 export const TERMINAL_VIEW = '[data-testid="terminal-view"]';

--- a/e2e/wdio.conf.ts
+++ b/e2e/wdio.conf.ts
@@ -1,7 +1,12 @@
+import { appendFileSync } from "node:fs";
 import path from "node:path";
 import type { TauriCapabilities } from "@wdio/tauri-service";
 import { $, browser } from "@wdio/globals";
-import { armDriverBridge, ensureMacAppFocus } from "./support/app";
+import {
+  armDriverBridge,
+  ensureMacAppFocus,
+  installStaleProofWaits,
+} from "./support/app";
 import {
   formatScriptTiming,
   recordScriptDuration,
@@ -147,6 +152,17 @@ export const config: WebdriverIO.Config = {
     // disables it regardless), so force activation ourselves and assert the
     // page actually reports visible+focused before any spec runs.
     await ensureMacAppFocus();
+    // Guard 3 (issue #364): make every `waitForDisplayed` re-resolve its
+    // selector on each poll. `isDisplayed` caches `elementId` and never
+    // re-runs the selector, and a detached node answers "not displayed"
+    // without raising stale — so a re-render landing between the find and the
+    // visibility check leaves the wait polling a dead node for its whole
+    // budget while the element it wanted is on screen. That is the entire
+    // #364 flake class, and a bigger timeout cannot fix it. The full
+    // mechanism, and why this is an override rather than a helper, is in
+    // `installStaleProofWaits`. Must run before the first `$()` below:
+    // element overrides attach at element-creation time.
+    await installStaleProofWaits();
     // On a fresh session the webview may still be booting; openRepo() starts
     // with a browser.refresh(), which must not fire mid-boot. Wait for the
     // Welcome screen once here so every repo-opening spec is safe from the
@@ -206,6 +222,59 @@ export const config: WebdriverIO.Config = {
   afterCommand: (commandName) => {
     if (SCRIPT_COMMANDS.has(commandName)) {
       recordScriptDuration(Date.now() - scriptStartedAt);
+    }
+  },
+  // One retry per spec FILE — the floor under the required gate, not a fix
+  // (issue #364).
+  //
+  // The fixes are the guards in `before` and the waits themselves; this covers
+  // what no wait can. A starved runner also loses the app itself — the
+  // `app never rendered Welcome screen` companion line, seen in workers that
+  // then passed — and one such loss failed the whole required check, which
+  // taught everyone to read a red required check as noise. That is the more
+  // expensive failure mode of the two.
+  //
+  // Safe here because every spec file builds its own fixtures: temp repos are
+  // created in `beforeEach`/`before` and disposed in the matching `after*`, so
+  // a re-run starts from the same state the first attempt did. (Not the same
+  // hazard as #35's script retries, which re-ran a script whose side effects
+  // had already landed inside one attempt — `executeOnce` owns that.)
+  //
+  // `Deferred` puts the retry at the END of this shard's queue instead of
+  // immediately: a spec that lost a race to whatever else the runner was doing
+  // gets to re-run under different conditions, and a genuinely broken spec
+  // still fails, just later.
+  //
+  // A retry that hides a real regression is the risk, so a requeue is never
+  // silent — `onWorkerEnd` below prints it, annotates the run and writes it to
+  // the job summary. Read those lines: a spec that needed a retry on your PR
+  // is a signal even when the gate is green.
+  specFileRetries: 1,
+  specFileRetriesDeferred: true,
+  // Name every retried spec file, loudly, at the moment it is requeued.
+  //
+  // `retries` is the count REMAINING (the launcher's own `_endHandler` comment
+  // says so; the type's "number of retries used" is wrong), so a nonzero
+  // exit code with retries left is exactly "this failed and will be run
+  // again". Printing here rather than in `onComplete` means the line appears
+  // whether or not the retry then passes.
+  onWorkerEnd: (cid, exitCode, specFiles, retries) => {
+    if (exitCode === 0 || retries <= 0) return;
+    const names = specFiles.map((s) => path.basename(s)).join(", ");
+    const line = `[e2e] RETRY: ${names} failed on attempt 1 (worker ${cid}) — requeued, ${retries} retry left`;
+    console.log(line);
+    // GitHub annotation + job summary: the log of a green four-shard run is
+    // not somewhere anyone looks, and a masked flake has to be visible from
+    // the run page or it is not really reported. Both are no-ops locally.
+    console.log(`::warning title=e2e spec retried::${names} failed on its first attempt (worker ${cid})`);
+    const summary = process.env.GITHUB_STEP_SUMMARY;
+    if (summary) {
+      try {
+        appendFileSync(summary, `- :repeat: **e2e retry** — \`${names}\` failed on attempt 1 (worker ${cid})\n`);
+      } catch {
+        // Summary file unavailable (not on Actions, or read-only mount). The
+        // console lines above already carry the finding.
+      }
     }
   },
   framework: "mocha",

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -1257,7 +1257,15 @@ export function CommitPanelScreen() {
     !noSignature
   ) {
     return (
-      <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
+      // The testid is the e2e hook for "this panel is in its clean state"
+      // (#364). Six waits used to match the PGEmpty TITLE as rendered prose
+      // (`div*=Working tree clean`), which couples a required CI gate to a
+      // string this file is free to reword — and says nothing about which
+      // element the wait is bound to. Keep it if the copy changes.
+      <div
+        data-testid="working-tree-clean"
+        style={{ flex: 1, display: "flex", minHeight: 0 }}
+      >
         <PGEmpty
           icon="check"
           title="Working tree clean"

--- a/test/e2eWaitGate.test.ts
+++ b/test/e2eWaitGate.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @vitest-environment node
+ */
+// The stale-handle wait gate (issue #364).
+//
+// `waitForDisplayed` is `waitUntil(() => isDisplayed())` over an element
+// HANDLE, and `isDisplayed` resolves its selector exactly once — the first
+// poll caches `elementId` and no later poll re-runs the selector. A detached
+// node then reports "not displayed" without raising stale, so WebdriverIO's
+// error handler never refetches and the wait polls a dead node for its ENTIRE
+// budget with the element it wanted on screen the whole time. Raising the
+// timeout cannot help.
+//
+// That is one mechanism behind a whole table of "flaky" specs — the clean-state
+// waits in commit.e2e, the renamed-remote row, settings after a reload — and it
+// only bites when a re-render lands between the find and the visibility check,
+// which is why it is a CI-only failure on a starved runner.
+//
+// The fix is session-wide: `installStaleProofWaits()` overwrites the command so
+// every poll re-resolves the selector. Session-wide is the point — 227 call
+// sites, and a helper only fixes the ones that adopt it. But a session-wide fix
+// installed from one line in one hook is also a fix that can be deleted in one
+// line, with nothing failing until CI goes red weeks later. So the install is
+// pinned here, as a static fact, at `pnpm test` speed.
+//
+// The behaviour itself (a swapped node no longer kills the wait, a genuinely
+// absent element still fails) is pinned in e2e/specs/harness.e2e.ts, which is
+// the only place that can actually drive a browser.
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const read = (rel: string) =>
+  readFileSync(resolve(process.cwd(), rel), "utf8");
+
+/** Source with comments blanked out — this file's own prose, and the long doc
+ *  comments in e2e/, name every symbol below and would satisfy a naive
+ *  `includes`. Newlines preserved so line numbers still mean something. */
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, " "))
+    .replace(/\/\/[^\n]*/g, (m) => m.replace(/[^\n]/g, " "));
+}
+
+const conf = stripComments(read("e2e/wdio.conf.ts"));
+const app = stripComments(read("e2e/support/app.ts"));
+
+describe("e2e stale-handle wait gate", () => {
+  it("installs the re-resolving waits from the conf's before hook", () => {
+    expect(conf).toContain("installStaleProofWaits");
+    // In `before`, not in some later hook: element overrides attach when an
+    // element object is created, so an install after the first `$()` would
+    // leave those elements — including the conf's own Welcome-screen wait — on
+    // the unfixed command.
+    const before = conf.slice(conf.indexOf("before: async"), conf.indexOf("after: async"));
+    expect(before).toContain("await installStaleProofWaits()");
+  });
+
+  it("keeps the command override to that single helper", () => {
+    // A second overwrite of the same command silently wins or silently loses
+    // depending on install order, and either way the behaviour pinned by
+    // harness.e2e.ts stops describing what the suite runs.
+    expect(conf).not.toContain("overwriteCommand");
+    expect(app.match(/overwriteCommand\(/g)).toHaveLength(1);
+    const helper = app.slice(app.indexOf("export async function installStaleProofWaits"));
+    expect(helper.slice(0, helper.indexOf("\n}\n"))).toContain("overwriteCommand");
+  });
+
+  it("re-resolves with a WebDriver find, never an in-page poll", () => {
+    // The #194 rule still applies inside the fix: `waitForDisplayed` is a legal
+    // settle gate after a refresh *because* it is a find, and re-implementing
+    // it over `document.querySelector` would put the mid-document-swap stall
+    // back into every one of the 227 sites at once.
+    const helper = app.slice(app.indexOf("export async function installStaleProofWaits"));
+    const body = helper.slice(0, helper.indexOf("\n}\n"));
+    expect(body).toContain("this.parent.$(selector)");
+    expect(body).not.toMatch(/browser\.execute|executeOnce\(|querySelector/);
+  });
+
+  it("keeps one clean-state selector instead of matching rendered prose", () => {
+    // `div*=Working tree clean` pinned a required CI gate to a PGEmpty title,
+    // and resolved to whichever innermost div happened to contain the phrase.
+    const specs = read("e2e/specs/commit.e2e.ts") + read("e2e/specs/stash.e2e.ts") + read("e2e/specs/keymap.e2e.ts");
+    expect(stripComments(specs)).not.toContain("Working tree clean");
+    expect(app).toContain('WORKING_TREE_CLEAN = \'[data-testid="working-tree-clean"]\'');
+    expect(read("src/screens/CommitPanel.tsx")).toContain(
+      'data-testid="working-tree-clean"',
+    );
+  });
+
+  it("keeps the spec-file retry floor, and keeps it loud", () => {
+    // The floor absorbs what no wait can — a starved runner losing the app
+    // itself ("app never rendered Welcome screen"), which used to fail the
+    // whole required check. A SILENT retry would be worse than none: it would
+    // hide a real regression behind a green gate. So the requeue has to be
+    // reported where someone will see it.
+    expect(conf).toContain("specFileRetries: 1");
+    expect(conf).toContain("specFileRetriesDeferred: true");
+    const hook = conf.slice(conf.indexOf("onWorkerEnd:"));
+    const body = hook.slice(0, hook.indexOf("\n  framework:"));
+    expect(body).toContain("::warning");
+    expect(body).toContain("GITHUB_STEP_SUMMARY");
+  });
+});


### PR DESCRIPTION
Closes #364.

The required `e2e-linux` gate went red on trees that were provably fine, across
enough specs and shards that a red e2e stopped being information. The routine
response — find the same failure on a recent `main` run, re-run CI, watch it go
green — is exactly how a real regression gets waved through.

## It was one mechanism, not one bug per spec

`waitForDisplayed` is `waitUntil(() => isDisplayed())` over an element HANDLE,
and `isDisplayed` resolves its selector exactly once: the first poll caches
`elementId` and no later poll re-runs the selector (`hasElementId`, webdriverio
9.31.5). If a re-render detaches that node between the find and the visibility
check — two separate round trips — every remaining poll interrogates a node
that is no longer in the document:

- `checkVisibility()` answers `false`, honestly;
- the `getComputedStyle` probe returns an empty declaration rather than
  throwing, so the "stale element reference" branch is never taken;
- no stale error means `elementErrorHandler` has nothing to catch and never
  refetches.

The wait then burns its whole budget on a dead node with the element it wanted
on screen the entire time. **A bigger timeout cannot fix that**, which is why
`history-ops` had already been raised from 15s to 25s for the same symptom.
`waitForExist` never had the bug — `isExisting` re-runs the selector every poll.

Losing the race needs a re-render inside two round trips, so a starved CI runner
loses it and a quiet laptop does not. The tell is a wait that gives up while the
screen is right, on a sub-test that wanders between runs.

`commit.e2e.ts` shows the whole chain: `CommitPanel` gates its clean-tree
`PGEmpty` on `!loading`, `refreshAll` flips `loading` true→false, and a commit
moves refs — so the fs watcher fires a SECOND `refreshAll` right behind the
commit's own. The node really is destroyed and recreated, twice, right where
four waits were looking.

## What this changes

- **`installStaleProofWaits()`** (`e2e/support/app.ts`, installed by the conf's
  `before` hook as guard 3) overwrites `waitForDisplayed` so every poll
  re-resolves the selector with a fresh WebDriver find. Session-wide on
  purpose: there are 227 call sites, and a helper only fixes the ones that
  adopt it. Re-resolution goes through `this.parent.$()` — a find, NOT an
  in-page `querySelector` poll, which would reinstate the #194
  mid-document-swap stall in all 227 at once — and through the same parent, so
  a scoped `dialog.$("label*=…")` stays scoped. `reverse` waits, non-string
  selectors and `$$`-indexed handles stay on the original implementation; the
  doc says why each would otherwise break.
- **`harness.e2e.ts` pins the behaviour, control test first.** A raw handle
  bound to a swapped node still reports not-displayed with no stale error
  (deterministic, no timing); the same dead handle now survives a
  `waitForDisplayed`; a genuinely absent element still fails; `reverse` still
  sees a removed node as gone. If that control ever fails, webdriverio has
  started refetching and this override can be deleted rather than carried.
- **`test/e2eWaitGate.test.ts`** pins the install, the single override and the
  find-not-script rule as static facts, at `pnpm test` speed — a session-wide
  fix installed from one line is a fix that can be deleted in one line, with
  nothing failing until CI reddens weeks later.
- **Waits are on state, not rendered prose.** Six waits matched
  `div*=Working tree clean` — a `PGEmpty` title, so a copy edit could redden a
  required gate, and `div*=` resolves to whichever innermost div contains the
  phrase. They use `WORKING_TREE_CLEAN`
  (`[data-testid="working-tree-clean"]`) now.
- **`jsPickOption` retries both of its steps.** A React commit between "the
  option exists" and the click unmounts the listbox portal (`option "…"
  vanished before the click`, 4 sightings); one between the trigger's mousedown
  and the portal mounting loses the open (`… never appeared`, 2). Retrying is
  safe *because* a miss dispatches nothing, and the open script already
  declines to toggle an expanded trigger.
- **`specFileRetries: 1` + `specFileRetriesDeferred: true`** as a floor, not a
  fix. It covers what no wait can: a starved runner losing the app itself
  (`app never rendered Welcome screen`, seen in workers that then passed) used
  to fail the entire required check. Safe because every spec file builds its
  own fixtures in `before*` and disposes them in `after*` — not the #35 hazard,
  which was a *script* retry re-running effects inside one attempt.
  **Never silent:** `onWorkerEnd` prints the requeue, emits a `::warning`
  annotation and appends to the job summary, so a spec that needed a retry on
  your PR is still a signal on a green gate.

## Notes for review

- **The idle-signal direction is deliberately not taken.** Exposing a
  test-visible "app is idle" global would put a testing surface into shipped
  code to buy what re-resolution already buys — the waits in question already
  have honest UI conditions; they were failing on handle identity, not on
  knowing when to look.
- **Shard count is not the starvation lever.** Each shard is its own runner and
  `maxInstances` is 1, so raising or lowering the shard count changes how much
  work a runner does, not how contended it is while doing it. The lever would
  be a larger runner. Recorded rather than changed.
- **`refreshAll` unmounting the clean state is a real UX flicker**, separate
  from this fix: on a clean tree every ref-moving fs event flips the commit
  panel to the empty three-pane layout and back, and on a slow filesystem that
  window is long. Left out on purpose — folding a render-semantics change into
  the flake fix would make it impossible to tell which one earned the green.
  Filed as a follow-up.

## Verification

- `pnpm test:e2e:docker` (full suite, fresh snapshot) — **29 of 29 spec files
  passing in 2:04**, no failures and no retry lines. The four new harness tests
  pass on WebKitGTK 605.1.15, the same engine CI runs, so the control test is
  measured evidence of the mechanism rather than an argument about it.
- Re-ran `harness`, `commit`, `stash`, `keymap`, `history-ops` against the
  final tree after the last edit — 5 of 5 spec files, 24s.
- `pnpm test` — 321 files, 3065 tests passing. `pnpm tsc --noEmit` and
  `pnpm exec tsc -p e2e/tsconfig.json --noEmit` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
