### PR TITLE
chore: set the real Buy Me a Coffee link for funding

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,4 @@
-# Buy Me a Coffee handle — replace REPLACE_ME with the real handle.
-buy_me_a_coffee: REPLACE_ME
+# GitHub renders these as the repo's "Sponsor" button. Buy Me a Coffee takes the
+# handle, not the full URL — the site's own link lives in site/src/data/site.ts
+# (`buyMeACoffee`) and the two must name the same page.
+buy_me_a_coffee: jonassaa

--- a/README.md
+++ b/README.md
@@ -254,6 +254,14 @@ Contributions welcome — including documentation and triage. Start with
 [good first issue](https://github.com/jonassaa/platypusgit/labels/good%20first%20issue),
 and please read the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
+## Support
+
+platypusgit is free and open source and always will be — no paid tier, no
+license to buy, no account. If it saves you time, you can
+[buy me a coffee](https://buymeacoffee.com/jonassaa); starring the repo, filing
+good bug reports and telling another developer about it help just as much. The
+[support page](https://www.platypusgit.com/support/) lists the lot.
+
 ## License
 
 [GNU General Public License v3.0](./LICENSE).

--- a/site/README.md
+++ b/site/README.md
@@ -40,8 +40,10 @@ the copy actually happens in CI.
 
 ## Configuration
 
-All external links live in `src/data/site.ts`. Set the real **Buy Me a Coffee**
-URL there (`buyMeACoffee`) and in `../.github/FUNDING.yml` (`buy_me_a_coffee` handle).
+All external links live in `src/data/site.ts`. The **Buy Me a Coffee** link is
+written twice on purpose — `buyMeACoffee` here (the site's Support page) and
+`../.github/FUNDING.yml` (the repo's Sponsor button, which takes the bare
+handle, not a URL). Change one and change the other.
 
 Feature/changelog content lives in `src/data/features.ts`.
 

--- a/site/src/data/site.ts
+++ b/site/src/data/site.ts
@@ -6,7 +6,7 @@ export const site = {
   repo: 'https://github.com/jonassaa/platypusgit',
   releases: 'https://github.com/jonassaa/platypusgit/releases',
   releasesLatest: 'https://github.com/jonassaa/platypusgit/releases/latest',
-  buyMeACoffee: 'https://buymeacoffee.com/REPLACE_ME', // TODO: user supplies real URL
+  buyMeACoffee: 'https://buymeacoffee.com/jonassaa', // kept in sync with ../.github/FUNDING.yml
   license: 'GPL-3.0-only',
   author: 'Jonas Aasberg',
 };


### PR DESCRIPTION
The marketing-site work (#…) landed the funding wiring with a `REPLACE_ME`
placeholder in the two files that hold the link, waiting on the real handle.
This fills it in.

- `.github/FUNDING.yml` — `buy_me_a_coffee: jonassaa`, which turns on the
  repo's **Sponsor** button.
- `site/src/data/site.ts` — `buyMeACoffee: 'https://buymeacoffee.com/jonassaa'`,
  what the site's Support page CTA points at.
- `README.md` — a short **Support** section, so the ask exists where most
  people meet the project, not only on the site.
- `site/README.md` — the config note now describes a link that is set and must
  stay in sync, rather than a TODO.

**Why the link is written twice:** GitHub's `FUNDING.yml` takes the bare handle,
the site needs a full URL. There is no single place to put it, so both files now
carry a comment naming the other.

The `REPLACE_ME` strings left in `docs/superpowers/{specs,plans}/` are the
historical design records for that work and are deliberately untouched.

## Verification

- `pnpm test` — 320 files / 3060 tests pass (covers `test/privacy.test.ts`,
  which reads `README.md`, and the doc invariants).
- `pnpm --dir site build` — 6 pages built; `site/dist/support/index.html`
  contains `https://buymeacoffee.com/jonassaa` and no placeholder.
- No `src/` or `src-tauri/` change, so no e2e surface is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)