### PR TITLE
fix(git): validate the two remaining branch-creating paths

### DIFF
--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -5305,6 +5305,7 @@ impl GitBackend for Libgit2Backend {
     }
     fn stash_branch(&self, repo_id: &RepoId, index: usize, branch: &str) -> AppResult<()> {
         self.with_repo_mut(repo_id, |repo| {
+            crate::git::tag::validate_branch_name(branch)?;
             let stash_oid = {
                 let mut found = None;
                 repo.stash_foreach(|i, _msg, oid| {
@@ -6591,6 +6592,9 @@ impl GitBackend for Libgit2Backend {
         branch: WorktreeBranch,
     ) -> AppResult<WorktreeInfo> {
         let name = crate::git::worktree::name_for_path(path)?;
+        if let WorktreeBranch::New(b) = &branch {
+            crate::git::tag::validate_branch_name(b)?;
+        }
         if path.exists() {
             return Err(AppError::InvalidArgument(format!(
                 "{} already exists",

--- a/src-tauri/src/git/tag.rs
+++ b/src-tauri/src/git/tag.rs
@@ -76,7 +76,9 @@ pub(crate) fn validate_ref_component(name: &str, noun: &str) -> AppResult<()> {
     let bad = |why: &str| Err(AppError::InvalidRef(format!("{name}: {why}")));
 
     if name.is_empty() {
-        return bad(&format!("a {noun} needs a name"));
+        // Not `bad`: that prefixes the name, and the name is the empty string,
+        // so the banner would read ": a branch needs a name".
+        return Err(AppError::InvalidRef(format!("a {noun} needs a name")));
     }
     // An option, not a ref, to every git command that would receive it.
     if name.starts_with('-') {
@@ -85,13 +87,15 @@ pub(crate) fn validate_ref_component(name: &str, noun: &str) -> AppResult<()> {
     if name.starts_with('/') || name.ends_with('/') || name.contains("//") {
         return bad(&format!("a {noun} name cannot have an empty path component"));
     }
-    // A leading '.' is refused for the same reason "/." is: `check_refname_component`
-    // rejects a component beginning with a dot, and the leading one is not covered
-    // by the "/." test. `git check-ref-format refs/tags/.hidden` refuses it too.
-    if name.starts_with('.')
-        || name.ends_with('.')
-        || name.ends_with(".lock")
-        || name.contains("/.")
+    // Per COMPONENT, not per whole name: `check_refname_component` refuses any
+    // slash-separated component that begins with a dot or ends with ".lock", so
+    // `.hidden`, `a/.b` and `foo.lock/bar` are all out — the last one slips past
+    // a whole-name `ends_with(".lock")` test, and `git branch foo.lock/bar`
+    // refuses it. The trailing-dot rule is the whole name's ("foo." is refused).
+    if name.ends_with('.')
+        || name
+            .split('/')
+            .any(|c| c.starts_with('.') || c.ends_with(".lock"))
     {
         return bad(&format!("invalid {noun} name"));
     }
@@ -416,6 +420,34 @@ mod tests {
                 "{bad:?} should have been refused"
             );
         }
+    }
+
+    #[test]
+    fn refuses_a_lock_component_anywhere_in_the_name() {
+        // `git branch foo.lock/bar` and `git check-ref-format refs/heads/foo.lock/bar`
+        // both refuse it: the rule is per component, not per whole name.
+        for bad in ["foo.lock/bar", "a/b.lock/c", "a/.b/c"] {
+            assert!(
+                validate_branch_name(bad).is_err(),
+                "{bad:?} should have been refused"
+            );
+            assert!(
+                validate_tag_name(bad).is_err(),
+                "{bad:?} should have been refused for a tag too"
+            );
+        }
+    }
+
+    #[test]
+    fn the_empty_name_message_does_not_start_with_a_bare_colon() {
+        // `bad` prefixes the name, and here the name is "" — the banner would
+        // read ": a branch needs a name".
+        let AppError::InvalidRef(msg) = validate_branch_name("").expect_err("empty is invalid")
+        else {
+            panic!("expected InvalidRef");
+        };
+        assert!(!msg.starts_with(':'), "message reads {msg:?}");
+        assert!(msg.contains("branch needs a name"), "message reads {msg:?}");
     }
 
     #[test]

--- a/src-tauri/tests/stash_branch.rs
+++ b/src-tauri/tests/stash_branch.rs
@@ -1,5 +1,6 @@
 mod support;
 
+use platypusgit_lib::error::AppError;
 use platypusgit_lib::git::{types::StashSaveOptions, GitBackend};
 use support::fs::{read_file, write_file};
 use support::TempRepo;
@@ -28,4 +29,31 @@ fn stash_branch_creates_branch_applies_stash_and_drops_it() {
     assert_eq!(head.name, "from-stash");
     assert_eq!(backend.stashes(&handle.id).unwrap().len(), 0);
     assert_eq!(read_file(tr.path(), "README.md"), "dirty\n");
+}
+
+#[test]
+fn stash_branch_rejects_an_invalid_branch_name() {
+    // "Branch from stash…" is a free-text prompt like the create-branch one
+    // (#214), so it gets the same refusal rather than raw libgit2 text.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    write_file(tr.path(), "README.md", "dirty\n");
+    backend
+        .stash_save(
+            &handle.id,
+            StashSaveOptions {
+                message: Some("wip".into()),
+                include_untracked: false,
+                keep_index: false,
+            },
+        )
+        .unwrap();
+
+    let err = backend.stash_branch(&handle.id, 0, "foo bar").unwrap_err();
+    assert!(matches!(err, AppError::InvalidRef(_)), "got {err:?}");
+
+    // The stash is still there to try again with, and no branch was written.
+    assert_eq!(backend.stashes(&handle.id).unwrap().len(), 1);
+    let branches = backend.branches(&handle.id).unwrap();
+    assert!(!branches.iter().any(|b| b.name.contains("foo")));
 }

--- a/src-tauri/tests/worktrees.rs
+++ b/src-tauri/tests/worktrees.rs
@@ -564,3 +564,26 @@ fn the_refusal_reports_a_blocked_holder_so_the_ui_can_hide_the_offer() {
         other => panic!("expected BranchHeldByWorktree, got {other:?}"),
     }
 }
+
+#[test]
+fn add_refuses_an_invalid_new_branch_name_and_creates_nothing() {
+    // The dialog's new-branch field is free text, so it gets the same refusal
+    // create_branch got in #214 rather than a stringified libgit2 message.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let (_hold, path) = worktree_target("bad-branch");
+
+    let err = backend
+        .worktree_add(&handle.id, &path, WorktreeBranch::New("foo bar".to_string()))
+        .expect_err("an invalid branch name must be refused");
+    assert!(matches!(err, AppError::InvalidRef(_)), "got {err:?}");
+
+    // Refused before anything was written to disk or to the ref store.
+    assert!(!path.exists(), "{} should not have been created", path.display());
+    assert!(backend.worktrees(&handle.id).unwrap().is_empty());
+    assert!(!backend
+        .branches(&handle.id)
+        .unwrap()
+        .iter()
+        .any(|b| b.name.contains("foo")));
+}


### PR DESCRIPTION
Recovers a commit that never reached `main`.

PR #228 (the fix for #214) squash-merged at 05:51 on 2026-08-26. The
follow-up commit — written at 07:45 the same morning, after review of that
PR — was committed locally in the session's worktree and never pushed. It has
been sitting in `.claude/worktrees/pr228` ever since, invisible to `main`.

Cherry-picked onto today's `main`; one positional conflict in
`src-tauri/tests/worktrees.rs` (main appended the #356/#358 worktree tests
where this test lands) resolved by keeping both.

## What was missing

#214's fix covered `create_branch` and `rename_branch`. Two other paths create
a branch from a free-text field and still surface raw libgit2 text:

- **"Branch from stash…"** (`stash_branch`)
- **the worktree dialog's new-branch input** (`worktree_add` with `WorktreeBranch::New`)

Both now call `validate_branch_name`, refusing before anything is written.

Plus two corrections to the shared validator:

- The dot and `.lock` rules are per slash-separated component, not per whole
  name. `foo.lock/bar` passed validation and was then refused by libgit2 —
  `git check-ref-format refs/heads/foo.lock/bar` refuses it too, so the doc
  comment's "a name we accept is one git can hold" was false.
- The empty name rendered as `": a branch needs a name"`, because `bad`
  prefixes the name and the name is `""`. Reachable from Reflog's
  `createBranchAt(oid, "")`.

## Verification

Audited today's tree: all four `repo.branch(...)` creation sites
(`create_branch`, `rename_branch`, `stash_branch`, `worktree_add`) now
validate, so "the two remaining" is still the complete set — no new
unvalidated branch-creating path has landed since August.

- `cargo test` — full suite green, including the four new tests
  (`refuses_a_lock_component_anywhere_in_the_name`,
  `the_empty_name_message_does_not_start_with_a_bare_colon`,
  `stash_branch_rejects_an_invalid_branch_name`,
  `add_refuses_an_invalid_new_branch_name_and_creates_nothing`).
- `pnpm tsc --noEmit` — clean.
- `pnpm test` — 321 files, 3065 tests passed.

No e2e run: this is a backend refusal path with no UI surface change, and no
spec drives an invalid branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
