### PR TITLE
fix(commit): keep the clean-tree panel mounted across a refresh

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1062,6 +1062,32 @@ in one or two of the ten and nothing said which.
   which must cover it. The shell root's `overflow: hidden` does not clip it,
   because it grows into the content area rather than out of the window.
 
+#### `statusLoaded` — "have we ever read this repo?" (#368)
+
+A third question the same boolean was being asked. `loading` means "a refresh is
+in flight"; `statusLoaded` is a per-repo latch set by the first completed status
+read (`refreshAll` AND `refreshStatus` — both land a status) and never cleared
+except by `emptySlice()`, i.e. by opening a repository. `frozenSlice` keeps it,
+unlike the in-flight flags: a parked slice still holds the status that was read.
+
+- **An empty-state that would be a LIE before the first read gates on this, not
+  on `!loading`.** The commit panel's `PGEmpty` ("Working tree clean") used to
+  ask `!loading`, so a clean repository swapped to the three-pane STAGED/UNSTAGED
+  layout with two empty file lists for the whole of every `refreshAll` and
+  swapped back — "your changes vanished" for as long as the filesystem is slow,
+  twice over after a commit (the watcher's `"all"` plan fires a second refresh),
+  and a fresh DOM node each time, which is what turned a WebdriverIO
+  handle-caching quirk into a red required gate (#364). A refresh has the
+  PREVIOUS status in the store the entire time it runs; there is nothing to
+  hide.
+- **A spinner-in-place-of-empty is a different, legitimate use of `loading`** and
+  was left alone: History (`!commits.length && loading` → skeleton), RepoBrowser
+  (`tree.length === 0 && loading` → skeleton), Reflog/Submodules/Worktrees
+  (`items.length === 0 && !loading` → `PGEmpty`), Welcome (`disabled={loading}`).
+  None of them swap a populated layout for a different one mid-refresh — they
+  only choose between "loading" and "empty" when there is genuinely nothing on
+  screen.
+
 ### Settings: one validator, two untrusted sources (#254)
 
 `useSettingsStore` reads a payload it does not control from two places — the

--- a/src/features/repo/repoSlice.ts
+++ b/src/features/repo/repoSlice.ts
@@ -124,6 +124,23 @@ export interface RepoSlice {
   /** True while an additional page is being fetched. */
   loadingMore: boolean;
   loading: boolean;
+  /**
+   * Whether a status read for THIS repository has ever completed (#368).
+   *
+   * Not the same question as `loading`. `loading` answers "is a refresh in
+   * flight?", and flips true for the whole of every `refreshAll`; this latches
+   * once and stays latched, because a refresh has the PREVIOUS status in the
+   * store the entire time it runs. A surface that must not read empty lists as
+   * data ("Working tree clean") wants this one — gating on `!loading` made the
+   * commit panel swap to the empty three-pane layout and back on every refresh.
+   *
+   * Per-repo, and therefore here: repo A having been read says nothing about
+   * repo B, and a tab switch that inherited a `true` would let the incoming
+   * tab claim a clean tree off A's emptied lists. Kept by `frozenSlice` on
+   * purpose — the parked slice still holds the status that was read, so it is
+   * still read. Cleared only by `emptySlice()`, i.e. by opening a repository.
+   */
+  statusLoaded: boolean;
   error: AppError | null;
   repoState: GitRepoState;
   /**
@@ -238,6 +255,7 @@ export function emptySlice(): RepoSlice {
     searchCursor: null,
     loadingMore: false,
     loading: false,
+    statusLoaded: false,
     error: null,
     repoState: "Clean",
     rebaseStatus: DEFAULT_REBASE_STATUS,

--- a/src/features/repo/useRepoStore.statusLoaded.test.ts
+++ b/src/features/repo/useRepoStore.statusLoaded.test.ts
@@ -1,0 +1,117 @@
+// "Have we ever read this repository's status?" (#368) — the question the
+// CommitPanel's clean-tree empty state actually needs, and which `loading` was
+// standing in for.
+//
+// `loading` answers "is a refresh in flight?", which flips true on every full
+// refresh; `statusLoaded` latches once and stays latched, because a refresh has
+// the PREVIOUS status in the store the whole time it runs.
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { useRepoStore } from "./useRepoStore";
+import { emptySlice, frozenSlice } from "./repoSlice";
+
+/** A promise plus the handle to settle it, so a test can hold a read open. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function mockRefreshAll() {
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => null);
+  mockInvoke("bisect_status", () => null);
+  mockInvoke("head_info", () => null);
+  mockInvoke("shallow_info", () => ({
+    shallow: false,
+    boundaryCount: 0,
+    singleBranch: false,
+  }));
+}
+
+const statusLoaded = () => useRepoStore.getState().statusLoaded;
+
+beforeEach(() => {
+  resetInvokeMock();
+  useRepoStore.setState({
+    ...emptySlice(),
+    current: { id: "repo-1", path: "/tmp/repo-1", head: "main" },
+  });
+  mockRefreshAll();
+});
+
+describe("statusLoaded", () => {
+  it("starts false — an unread repository is not a clean one", () => {
+    expect(emptySlice().statusLoaded).toBe(false);
+    expect(statusLoaded()).toBe(false);
+  });
+
+  it("is set by a completed refreshAll", async () => {
+    await useRepoStore.getState().refreshAll();
+    expect(statusLoaded()).toBe(true);
+  });
+
+  it("is set by a completed refreshStatus", async () => {
+    // The index ops refresh through this one, so a repo whose first status read
+    // came from a stage/unstage is just as loaded as one that ran a full
+    // refresh.
+    mockInvoke("get_status", () => []);
+    await useRepoStore.getState().refreshStatus();
+    expect(statusLoaded()).toBe(true);
+  });
+
+  it("stays true for the whole of a later refresh", async () => {
+    await useRepoStore.getState().refreshAll();
+
+    const held = deferred<unknown[]>();
+    mockInvoke("list_remotes", () => held.promise);
+    const refreshing = useRepoStore.getState().refreshAll();
+
+    // This is the bug in one assertion: `loading` says "busy", but the status
+    // in the store is still the status the user is looking at.
+    expect(useRepoStore.getState().loading).toBe(true);
+    expect(statusLoaded()).toBe(true);
+
+    held.resolve([]);
+    await refreshing;
+    expect(statusLoaded()).toBe(true);
+  });
+
+  it("stays false when the refresh fails", async () => {
+    // A refresh that could not read status has not loaded one, so the panel
+    // must not start claiming a clean tree off the empty list it degraded to.
+    mockInvoke("get_status", () => {
+      throw new Error("boom");
+    });
+
+    await useRepoStore.getState().refreshAll();
+
+    expect(useRepoStore.getState().error).not.toBeNull();
+    expect(statusLoaded()).toBe(false);
+  });
+
+  it("survives being parked on an inactive tab", () => {
+    // Unlike `loading`, this is not an in-flight marker: the parked slice still
+    // holds the status that was read, so it still counts as read.
+    const parked = frozenSlice({ ...emptySlice(), loading: true, statusLoaded: true });
+    expect(parked.statusLoaded).toBe(true);
+  });
+
+  it("is cleared for a freshly opened repository", () => {
+    // `applyOpenedRepo` starts from `emptySlice()`, so opening repo B must not
+    // inherit repo A's answer.
+    useRepoStore.setState({ statusLoaded: true });
+    useRepoStore.getState().closeRepo();
+    expect(statusLoaded()).toBe(false);
+  });
+});

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -1094,6 +1094,11 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         headInfo,
         shallowInfo: shallow,
         loading: false,
+        // Only on the success path, and never reset (#368): a refresh that
+        // could not read status has not loaded one, and a LATER refresh must
+        // not un-answer "have we read this repository?" — that is what made
+        // the commit panel flicker when it asked `loading` instead.
+        statusLoaded: true,
       });
       // Keep an active search in sync with the refreshed history.
       const activeFilter = get().commitFilter;
@@ -1119,7 +1124,11 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
         // Same degrade-don't-fail policy as `refreshAll`.
         bisectStatusFn(repo.id).catch(() => DEFAULT_BISECT_STATUS),
       ]);
-      setFor(repo.id, { status, repoState, bisectStatus });
+      // `statusLoaded` for the same reason `refreshAll` sets it (#368): this is
+      // the other path that lands a status, and a repository whose first read
+      // came from a stage/unstage is just as read as one that ran a full
+      // refresh.
+      setFor(repo.id, { status, repoState, bisectStatus, statusLoaded: true });
     } catch (e) {
       setErrorFor(repo.id, e);
     }

--- a/src/screens/CommitPanel.amend.test.tsx
+++ b/src/screens/CommitPanel.amend.test.tsx
@@ -45,6 +45,11 @@ function setup(
     commits: [],
     logRef: null,
     loading: false,
+    // A repository whose status HAS been read (#368) — what the clean-tree
+    // empty state gates on now. `loading: false` used to stand in for it, and
+    // no longer does: it only says no refresh is running, which is also true of
+    // a repository nobody has read yet.
+    statusLoaded: true,
   } as never);
   mockInvoke("get_diff", () => ({
     path: "a.ts",

--- a/src/screens/CommitPanel.cleanTree.test.tsx
+++ b/src/screens/CommitPanel.cleanTree.test.tsx
@@ -1,0 +1,110 @@
+// A refresh is not a fresh repository (#368).
+//
+// `refreshAll` sets `loading: true` for the whole duration of its ten backend
+// reads, and the clean-tree empty state used to be gated on `!loading`. So a
+// clean repository swapped to the three-pane STAGED/UNSTAGED layout with two
+// empty file lists on every full refresh and swapped back when it finished —
+// which reads as "your changes vanished", not "still loading", and churns the
+// DOM node the e2e waits bind to (#364). The filesystem watcher asks for a
+// full refresh whenever refs move, so a commit produces two of these in a row.
+//
+// The honest half of the old guard is kept, as `statusLoaded`: before the FIRST
+// status read, empty lists do not mean a clean tree and the panel must not
+// claim one.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+
+import { CommitPanelScreen } from "./CommitPanel";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { emptySlice } from "@/features/repo/repoSlice";
+import { mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+
+/** A promise plus the handle to settle it, so a test can hold a read open. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+const repo = { id: "repo-1", path: "/tmp/repo-1", head: "refs/heads/main" };
+
+/** Every read `refreshAll` fires, answering for a repository with a clean tree. */
+function mockCleanRepo() {
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => ({
+    inProgress: false,
+    nextIndex: 0,
+    total: 0,
+    pauseReason: null,
+  }));
+  mockInvoke("bisect_status", () => null);
+  mockInvoke("head_info", () => null);
+  mockInvoke("shallow_info", () => ({
+    shallow: false,
+    boundaryCount: 0,
+    singleBranch: false,
+  }));
+  mockInvoke("get_identity", () => ({
+    name: { value: "Ada", scope: "global" },
+    email: { value: "ada@example.com", scope: "global" },
+    globalConfigPath: "/home/ada/.gitconfig",
+    localConfigPath: null,
+  }));
+}
+
+beforeEach(() => {
+  resetInvokeMock();
+  useRepoStore.setState({ ...emptySlice(), current: repo });
+  mockCleanRepo();
+});
+
+describe("the clean-tree panel across a refresh (#368)", () => {
+  it("does not claim a clean tree before the first status read", async () => {
+    // Nothing has been read yet: empty lists mean "we don't know", and saying
+    // "Working tree clean" here would be a lie. This is the reason the guard
+    // exists at all, and it has to survive the fix.
+    render(<CommitPanelScreen />);
+
+    expect(screen.queryByTestId("working-tree-clean")).toBeNull();
+  });
+
+  it("keeps the empty state mounted while a full refresh runs", async () => {
+    await act(async () => {
+      await useRepoStore.getState().refreshAll();
+    });
+    render(<CommitPanelScreen />);
+    const node = screen.getByTestId("working-tree-clean");
+
+    // A second refresh, held open on one of its reads — exactly what the
+    // watcher's `"all"` plan does behind a commit, and what a repo on WSL's
+    // /mnt/c stretches into tens of seconds.
+    const held = deferred<unknown[]>();
+    mockInvoke("list_remotes", () => held.promise);
+    let refreshing!: Promise<void>;
+    act(() => {
+      refreshing = useRepoStore.getState().refreshAll();
+    });
+
+    expect(useRepoStore.getState().loading).toBe(true);
+    // The same node, not merely a node: a remount is what turned a WebdriverIO
+    // handle-caching quirk into a red required gate.
+    expect(screen.getByTestId("working-tree-clean")).toBe(node);
+    expect(screen.queryByTestId("changes-list")).toBeNull();
+
+    await act(async () => {
+      held.resolve([]);
+      await refreshing;
+    });
+
+    expect(screen.getByTestId("working-tree-clean")).toBe(node);
+  });
+});

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -143,7 +143,8 @@ export function CommitPanelScreen() {
   const status = useRepoStore((s) => s.status);
   const branches = useRepoStore((s) => s.branches);
   const remotes = useRepoStore((s) => s.remotes);
-  const loading = useRepoStore((s) => s.loading);
+  // `statusLoaded`, not `loading` (#368) — see the clean-tree branch below.
+  const statusLoaded = useRepoStore((s) => s.statusLoaded);
   const stage = useRepoStore((s) => s.stage);
   const unstage = useRepoStore((s) => s.unstage);
   const commitAction = useRepoStore((s) => s.commit);
@@ -1248,8 +1249,19 @@ export function CommitPanelScreen() {
   // exactly as it was, so this cannot fire on the attempt itself — but an
   // external change that empties the tree while the identity form is open must
   // not swallow the form the user is typing into.
+  //
+  // `statusLoaded` is the guard against the OTHER lie: before the first status
+  // read, empty lists mean "we don't know yet", not "clean". It used to be
+  // `!loading`, which answers a different question — "is a refresh in flight?"
+  // — and `refreshAll` holds that true for ten backend reads, so a clean
+  // repository swapped to the three-pane layout with two empty file lists on
+  // every refresh and back again (#368). That reads as "your changes vanished",
+  // it lasts as long as the filesystem is slow, and it churns the DOM node the
+  // e2e waits bind to (#364). `statusLoaded` latches on the first completed
+  // read and never un-latches: a refresh always has the previous status in the
+  // store while it runs.
   if (
-    !loading &&
+    statusLoaded &&
     staged.length === 0 &&
     unstaged.length === 0 &&
     !amend &&


### PR DESCRIPTION
On a clean working tree the Commit panel flipped to the empty three-pane
layout and back on **every** full refresh, because the clean-tree `PGEmpty`
was gated on `!loading` — and `refreshAll` holds `loading: true` for the
duration of ten backend reads.

Two lies came out of one guard:

- **During a refresh** the panel showed empty STAGED / UNSTAGED lists, which
  reads as "your changes vanished", for as long as the filesystem is slow.
- **Before any read**, with `loading: false`, it claimed "Working tree clean"
  for a repository whose status had never been fetched.

`!loading` answers "is a refresh in flight?". The question the branch actually
needs is "have we ever read this repository?" — a refresh has the *previous*
status in the store the whole time it runs.

## What changed

A per-repo `statusLoaded` that latches on the first completed status read and
never un-latches. It joins both `RepoSlice` and `emptySlice()`, so
`REPO_SLICE_KEYS` (derived at runtime from `emptySlice()`) covers it and a tab
switch cannot leak one repository's answer into another's. Set on the success
path of `refreshAll` and on `refreshStatus` — the only two writers of `status`
in the store. `loading` itself is untouched.

## Verification

Both new test files were run against the **unfixed** tree first: 8 failed, with
the CommitPanel case showing `staged-list` / `STAGED / 0` where
`working-tree-clean` should be — the bug verbatim. The `emptySlice()` entry was
proven load-bearing the same way: without it, "cleared for a freshly opened
repository" fails with a stale `true` leaking across tabs.

- `pnpm test` — 323 files, 3074 passing
- `pnpm tsc --noEmit` — clean
- e2e in Docker on this branch: `commit.e2e.ts` 3 passing, `status-stage.e2e.ts`
  7 passing (this changes render semantics on the `working-tree-clean` anchor
  that six #364 waits bind to, so both were run against the real binary)

## Audit of the other `loading` gates

No other surface has this bug. `History.tsx` and `RepoBrowser.tsx` both gate
inside a `length === 0` check — the legitimate "choose between a skeleton and an
empty state when there is nothing there" shape, which swaps nothing on a refresh
over populated data.

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)
