### PR TITLE
fix(cancel): close the window-, keyboard- and timer-shaped gaps

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -522,7 +522,9 @@ screens/             One per activity-bar item + deep views: RepoBrowser,
 features/            Components + Zustand store colocated per feature:
 ├── repo/            useRepoStore (ONE repo's live state — the active tab's),
 │                    repoSlice (RepoSlice / REPO_SLICE_KEYS / emptySlice),
-│                    repoActivity, shallowNoticeText (PURE, per-surface
+│                    repoActivity, autoFetch (the timer AND the deadline that
+│                    belongs to timer-started fetches alone — #263),
+│                    shallowNoticeText (PURE, per-surface
 │                    sentences) + ShallowNotice (the strip; History, FileHistory,
 │                    Blame and Compare mount it — test/shallowSurfaces.test.ts
 │                    fails the build for a fifth that forgets),

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -219,6 +219,29 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
 - **Check `is_cancelled()` after the child exits, always.** A cancel landing as
   git dies of its own accord must still win: the request is what decides the
   outcome, not who got there first.
+- **Closing the app's window cancels everything in flight** (`cancel_all`, wired
+  to `WindowEvent::CloseRequested` in `lib.rs`). `kill_on_drop(true)` is the
+  backstop for a DROPPED future, and quitting drops nothing: `tao::EventLoop::run`
+  is `-> !` and ends in `std::process::exit` on macOS, Linux and Windows alike,
+  which runs no destructor on any stack. Measured before the fix: a
+  `kill_on_drop` child was **still alive 500 ms after its parent's
+  `process::exit(0)`** — so a `git clone` outlived the app and carried on
+  populating the destination the Clone dialog had already reported as never
+  created. Two rules on the handler: it is **gated on `window.label() == "main"`**
+  (`cancel::close_cancels_everything`), because `on_window_event` is app-global
+  and closing the `merge` resolver must not stop a fetch; and it sends
+  **`SIGTERM` only, never the escalation**, because git's own
+  `remove_lock_file_on_signal` / `remove_junk_on_signal` is the only cleanup
+  still possible once our process is gone. `tests/cancel_on_close.rs` pins all
+  three, the last of them by greping `lib.rs` — the closure needs a Tauri runtime
+  no `cargo test` has. **`CloseRequested` is not every way out**: tao emits it
+  from `windowShouldClose:` only, so ⌘Q on macOS
+  (`applicationWillTerminate` → `LoopDestroyed`) never reaches it. So the app is
+  built with `build()` + `App::run(cb)` — the documented expansion of
+  `Builder::run(context)` — and `RunEvent::Exit`/`ExitRequested` calls
+  `cancel_all` too. Being reached twice on the ordinary close path is free:
+  `cancel_all` never escalates, and a finished op is already out of the
+  registry.
 - **A cancelled clone removes its partial destination**, and puts back an empty
   directory the user had picked. Even with `SIGTERM` giving git a chance to run
   its own cleanup, the leftovers (a `SIGKILL` escalation, or Windows) fail the
@@ -249,10 +272,13 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   `/dev/null`.** It always discarded stdout; `wait_with_output` was there to
   drain both concurrently and avoid a deadlock. With one pipe to read, nulling
   the other removes the hazard rather than managing it.
-- **Cancellation still works because the `select!` is inside the read loop.**
-  The wait used to be one `wait_with_output`; it is now many reads, and each one
-  races the cancel token `biased`-first. A stalled fetch sits in exactly that
-  read.
+- **Cancellation still works because a stalled fetch sits in that read loop.**
+  The wait used to be one `wait_with_output`; it is now many reads, and a stalled
+  transfer sits in exactly one of them. #296 raced each read against a cancel
+  token with `select!`; #263 removed that, because returning early DROPS the
+  `Child` and `kill_on_drop` is a `SIGKILL`. The kill is out-of-band now (by
+  pid, from the cancelling task), and the read returns because the pipe closed
+  underneath it.
 - **Rebase reports through a sink on the trait, not an `AppHandle` on the
   backend.** `rebase_start_with_progress` / `rebase_continue_with_progress` take
   a `RebaseProgressSink`; the old names remain as default methods delegating

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1006,6 +1006,27 @@ cancellable in the backend but unstoppable from the UI for two releases.
   escapable only by clicking again. `cancelRequested` clears when the last
   `activity` entry goes, so the next stalled op starts from the polite signal.
   See `docs/dev/backend.md` for the signal half.
+- **Cancel has a keyboard route too** (#263). The status bar's button was the
+  only one, which made the thing a user needs most when the app looks hung the
+  one thing they cannot reach without a pointer. `action:cancel-network` in the
+  palette is gated on the SAME `isCancellable(primaryActivity(...))` the button
+  is, carries the same two labels, and names the op it would stop in its
+  `detail` — a bare "Cancel" in a palette is a row nobody dares press. Two
+  surfaces, one gate: they cannot drift into offering different things.
+- **The auto-fetch timer is the ONE thing in the app with a deadline**
+  (`features/repo/autoFetch.ts`, #263). #260 rejected a global network timeout
+  and was right to: one short enough to rescue a stalled host is short enough to
+  kill a legitimately slow clone, and only the person watching can tell those
+  apart. That argument covers everything the USER started — and nothing the
+  timer did. Nobody is watching those, and the skip-while-running guard (which
+  exists so a stalled remote cannot grow a pile of stuck `git fetch` processes)
+  means one stalled auto-fetch turns auto-fetch off for the rest of the session.
+  So `startAutoFetch` arms a 2-minute deadline, and **only a tick that itself
+  started the fetch arms one**: a tick that finds `activity.fetch` already set —
+  which is exactly what somebody else's fetch looks like — returns without
+  arming anything, and the armed timer is cleared when its own op settles and
+  re-checks `startedAt` and the repository before firing. The cancel it fires is
+  `Scope::Repo`-wide like every other, so it clears the whole pile.
 - **`setActivity` is guarded on the repository, like `setFor`.** `activity` is a
   per-repo slice field and an op outlives a tab switch: a fetch on A finishing
   after the user moved to B used to clear B's entry, taking B's spinner and

--- a/e2e/specs/cancel.e2e.ts
+++ b/e2e/specs/cancel.e2e.ts
@@ -1,0 +1,162 @@
+// Cancelling a stalled network op, through the real UI (#263 item 3).
+//
+// `src-tauri/tests/net_cancel.rs` covers the backend well: it stalls a real
+// `git`, cancels the scope and asserts the error and the cleaned-up
+// destination. What it cannot cover is the wiring in between — that the Clone
+// dialog's one button really reaches `cancelClone`, and that the status bar
+// really renders a Cancel beside a running fetch and really reaches
+// `cancelNetworkOps`. Both are the kind of thing that regresses silently: a
+// Cancel button that stops being rendered looks fine in a screenshot, and every
+// unit test in the tree would stay green.
+//
+// The stall is deterministic and needs no network — see `stalledGitRemote`.
+//
+// What is deliberately NOT asserted here: the intermediate "Force stop" /
+// "Cancelling…" labels. The polite SIGTERM kills a git that is blocked on a
+// read in a few milliseconds, so that state is real but far too short-lived to
+// poll for; `ActivityStatus.test.tsx` and `useCreateStore.cancel.test.ts` pin
+// it where it can be observed. What these specs pin is the part only the real
+// binary can answer: the click reached the backend, git actually stopped, and
+// the user was not shown a failure for asking.
+
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { browser, $, expect } from "@wdio/globals";
+
+import {
+  basicRepo,
+  stalledGitRemote,
+  type StalledRemote,
+  type TempRepo,
+} from "../support/tempRepo";
+import { openRepo, resetApp } from "../support/app";
+
+describe("cancelling a stalled network op", () => {
+  let stalled: StalledRemote | undefined;
+  let repo: TempRepo | undefined;
+  let dest: string | undefined;
+
+  afterEach(async () => {
+    await resetApp();
+    // The listener goes LAST: disposing it first would close the sockets and
+    // let a still-running git fail on its own, which would hide a cancel that
+    // never landed.
+    repo?.dispose();
+    repo = undefined;
+    if (dest) rmSync(dest, { recursive: true, force: true });
+    dest = undefined;
+    stalled?.dispose();
+    stalled = undefined;
+  });
+
+  it("the Clone dialog's own button stops a clone and takes the destination with it", async () => {
+    stalled = await stalledGitRemote();
+    dest = mkdtempSync(join(tmpdir(), "pgit-cancel-clone-"));
+
+    await $('[data-testid="welcome-clone"]').waitForDisplayed({
+      timeout: 30_000,
+      timeoutMsg: "Welcome screen never showed the Clone button",
+    });
+    await $('[data-testid="welcome-clone"]').click();
+
+    const urlInput = $('[data-testid="clone-url"]');
+    await urlInput.waitForDisplayed({
+      timeout: 30_000,
+      timeoutMsg: "Clone dialog never opened",
+    });
+    await urlInput.setValue(stalled.url);
+    await $('[data-testid="clone-parent"]').setValue(dest);
+    // After the URL, so it wins over deriveRepoName's auto-fill.
+    await $('[data-testid="clone-name"]').setValue("stalled");
+    await $('[data-testid="clone-resolved"]').waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg:
+        "resolved path preview never appeared — did setValue's change event reach React state?",
+    });
+
+    await $('[data-testid="clone-submit"]').click();
+
+    // One button, two jobs: its label is the dialog's own statement that a clone
+    // is really in flight. Re-resolved on every poll — the dialog re-renders on
+    // each progress tick, and a handle taken before one of those is dead.
+    await browser.waitUntil(
+      async () => (await $('[data-testid="clone-cancel"]').getText()) === "Cancel clone",
+      {
+        timeout: 30_000,
+        timeoutMsg:
+          "the clone never went busy — the Cancel button still reads as the dialog's close button",
+      },
+    );
+
+    await $('[data-testid="clone-cancel"]').click();
+
+    // Back to "Cancel" — i.e. `busy` is false again — is the dialog saying the
+    // clone unwound. Against a remote that never answers, that can only happen
+    // because the backend killed git: nothing else was ever going to return.
+    await browser.waitUntil(
+      async () => (await $('[data-testid="clone-cancel"]').getText()) === "Cancel",
+      {
+        timeout: 30_000,
+        timeoutMsg:
+          "the clone never unwound after Cancel — it is still running against the stalled remote",
+      },
+    );
+
+    // A cancel is the outcome the user asked for, not a failure to report at
+    // them. `git`'s dying words ("the remote end hung up unexpectedly") reaching
+    // this slot is the regression this asserts against.
+    expect(await $('[data-testid="clone-error"]').isExisting()).toBe(false);
+
+    // repo truth: the partial destination is gone. Left there, the next attempt
+    // fails `validate_clone_target` with "already exists and is not empty" — a
+    // cancel button whose real effect is to poison the destination.
+    expect(existsSync(join(dest, "stalled"))).toBe(false);
+  });
+
+  it("the status bar's Cancel stops a fetch that is hanging on a silent remote", async () => {
+    stalled = await stalledGitRemote();
+    repo = basicRepo();
+    repo.git("remote", "add", "origin", stalled.url);
+    await openRepo(repo.path);
+
+    await $("button*=Fetch").click(); // titlebar → fetchAll
+
+    // The status line is what tells the user something is running; the Cancel
+    // beside it is the only way out, and `activity-cancel` is a state hook
+    // rather than the button's prose (which a copy edit could move).
+    await $('[data-testid="activity-label"]').waitForDisplayed({
+      timeout: 30_000,
+      timeoutMsg: "the fetch never raised a status line",
+    });
+    await $('[data-testid="activity-cancel"]').waitForDisplayed({
+      timeout: 30_000,
+      timeoutMsg: "a running fetch showed no Cancel — the only way out of a stall",
+    });
+
+    await $('[data-testid="activity-cancel"]').click();
+
+    // The line going away IS the op unwinding: `withAuthRetry` clears the entry
+    // in its `finally`, which only runs once `fetch_all` returned. Against a
+    // remote that never answers it can only return because git was killed.
+    await $('[data-testid="activity-label"]').waitForExist({
+      reverse: true,
+      timeout: 30_000,
+      timeoutMsg:
+        "the status line never cleared — the cancelled fetch is still running",
+    });
+
+    // No banner: `setErrorFor` drops `Cancelled` so the user's own Cancel click
+    // is not answered with a red "early EOF".
+    expect(await $('[role="alert"]').isExisting()).toBe(false);
+
+    // repo truth. A fetch stalled on a network READ holds no lock, so this is a
+    // guard rather than a proof — but it is the exact file whose survival is
+    // what #263 is about, and the thing the NEXT fetch would die on.
+    expect(existsSync(join(repo.path, ".git", "FETCH_HEAD.lock"))).toBe(false);
+    // And nothing was fetched: no remote-tracking ref appeared out of a
+    // connection that never carried a byte.
+    expect(repo.git("branch", "-r").trim()).toBe("");
+  });
+});

--- a/e2e/support/tempRepo.ts
+++ b/e2e/support/tempRepo.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { createServer, type Server, type Socket } from "node:net";
 import {
   chmodSync,
   mkdtempSync,
@@ -72,6 +73,58 @@ export class TempRepo {
       return false;
     }
   }
+}
+
+/**
+ * A git remote that connects and then says nothing, forever (#263 item 3).
+ *
+ * The deterministic stall, with no network involved: a loopback listener that
+ * ACCEPTS the connection and never answers is exactly the failure a cancel
+ * button exists for, and the one case a timeout-free `git` sits in until
+ * something kills it. The spec process and the app share a network namespace
+ * (one container, see `docker-compose.e2e.yml`), so `127.0.0.1` here is
+ * `127.0.0.1` there.
+ *
+ * `git://` on purpose: it is a built-in transport, so nothing depends on which
+ * remote helpers the image ships, and the URL needs no path that exists.
+ *
+ * Two details are load-bearing, both learned in `src-tauri/tests/net_cancel.rs`:
+ *
+ * - **The accepted sockets are held, not dropped.** Closing one makes git see
+ *   EOF and fail fast, and the test would then be about a broken connection
+ *   instead of a stalled one — a green test of the wrong thing.
+ * - **Every socket swallows its own errors.** Cancelling kills git mid-connection,
+ *   which arrives here as `ECONNRESET`; an unhandled `error` event on a socket
+ *   is a throw that takes the whole wdio worker down.
+ */
+export interface StalledRemote {
+  /** A git URL that connects and then hangs until something kills the client. */
+  readonly url: string;
+  dispose: () => void;
+}
+
+export async function stalledGitRemote(): Promise<StalledRemote> {
+  const held: Socket[] = [];
+  const server: Server = createServer((sock) => {
+    sock.on("error", () => {});
+    held.push(sock);
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("stalledGitRemote: listener has no TCP port");
+  }
+  return {
+    url: `git://127.0.0.1:${address.port}/stalled.git`,
+    dispose: () => {
+      for (const sock of held) sock.destroy();
+      held.length = 0;
+      server.close();
+    },
+  };
 }
 
 export function makeTempRepo(): TempRepo {

--- a/src-tauri/src/cancel.rs
+++ b/src-tauri/src/cancel.rs
@@ -223,6 +223,57 @@ pub fn cancel(scope: &Scope) -> usize {
     signalled
 }
 
+/// The label of the window whose close ends the app.
+///
+/// Set in `tauri.conf.json`; the merge resolver is a second window labelled
+/// `merge` (`src/features/merge/openMergeWindow.ts`).
+pub const MAIN_WINDOW_LABEL: &str = "main";
+
+/// Whether closing the window called `label` should cancel everything in flight.
+///
+/// `on_window_event` is app-global — it fires for the merge resolver too — so
+/// without this gate, finishing a conflict resolution would kill the fetch
+/// running behind it. A pure function so the rule is testable without a Tauri
+/// runtime; the wiring itself is greped by `tests/cancel_on_close.rs`.
+pub fn close_cancels_everything(label: &str) -> bool {
+    label == MAIN_WINDOW_LABEL
+}
+
+/// Cancel every op in flight, whatever its scope. Answers how many were
+/// signalled.
+///
+/// For exactly one caller: the app's own window closing (#263). Cancellation's
+/// backstop for a dropped future is `kill_on_drop(true)`, and quitting does not
+/// drop anything — `tao::EventLoop::run` ends in `std::process::exit`, which
+/// runs no destructors on any stack. Measured: a `kill_on_drop` child was still
+/// alive 500 ms after its parent's `process::exit(0)`. So without this, a
+/// `git clone` outlives the app and finishes populating the destination the
+/// Clone dialog was told never got created.
+///
+/// **Always the polite signal, even for an entry that was already cancelled
+/// once.** `cancel()` escalates on a second ask because the user clicking again
+/// says the first did not work; there is no second click on the way out, and
+/// nobody left to notice. What there IS is git's own `SIGTERM` handling
+/// (`remove_lock_file_on_signal`, and `remove_junk_on_signal` in `clone`) — the
+/// only cleanup still possible once our process is gone. A `SIGKILL` here would
+/// strand `.git/FETCH_HEAD.lock` and half a clone with nothing running that
+/// could remove either.
+///
+/// Fire-and-forget, like `cancel()`: it signals and returns. The app is about to
+/// exit and must not wait on a git that is slow to die.
+pub fn cancel_all() -> usize {
+    let mut live = registry().lock().unwrap_or_else(|e| e.into_inner());
+    let mut signalled = 0;
+    for entry in live.iter_mut() {
+        entry.cancel_requested = true;
+        if let Some(pid) = entry.pid {
+            kill_tree(pid, false);
+        }
+        signalled += 1;
+    }
+    signalled
+}
+
 /// Kill `pid` and everything spawned into its process group.
 ///
 /// # Why the process group

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -89,9 +89,9 @@ pub fn run() {
     // The notice is printed unconditionally for a debug launch, and names the
     // already-running case, because that case cannot be detected from here: the
     // single-instance plugin forwards this invocation's intent and exits inside
-    // `Builder::run()` below, so a `pgit --debug` against a running app would
-    // otherwise return an immediate, silent, log-free 0. stderr, not stdout —
-    // stdout is where the log itself is about to go.
+    // the builder below (`build()`, then `run()`), so a `pgit --debug` against a
+    // running app would otherwise return an immediate, silent, log-free 0.
+    // stderr, not stdout — stdout is where the log itself is about to go.
     let debug_launch = matches!(parsed, cli::Parsed::DebugLaunch(_));
     if debug_launch {
         eprintln!(
@@ -393,12 +393,19 @@ pub fn run() {
             commands::terminal::term_resize,
             commands::terminal::term_close,
         ])
-        // A shell must not outlive the window that hosts it (#243). Called
-        // explicitly rather than left to a `Drop`: the state is behind an `Arc`
-        // that every reader thread holds, so its drop runs at a time nobody
-        // controls — and an orphaned interactive shell is not a leak the user
-        // can see, only one their process list can.
+        // Nothing the user started may outlive the window they started it from.
+        //
+        // Both arms below are cleanups the app must perform ITSELF, because the
+        // way this process ends runs no destructors: `tao::EventLoop::run` is
+        // `-> !` and finishes with `std::process::exit`, on every platform. A
+        // `Drop` impl, a `kill_on_drop` child, an in-flight future — none of
+        // them unwind.
         .on_window_event(|window, event| {
+            // A shell must not outlive the window that hosts it (#243). Called
+            // explicitly rather than left to a `Drop`: the state is behind an
+            // `Arc` that every reader thread holds, so its drop runs at a time
+            // nobody controls — and an orphaned interactive shell is not a leak
+            // the user can see, only one their process list can.
             if matches!(event, tauri::WindowEvent::Destroyed) {
                 use tauri::Manager as _;
                 if let Some(terminals) =
@@ -407,7 +414,54 @@ pub fn run() {
                     terminals.close_all();
                 }
             }
+            // Neither may a network op (#263). `kill_on_drop(true)` is the
+            // documented backstop for a DROPPED future, and quitting drops
+            // nothing: measured, a `kill_on_drop` child was still alive 500 ms
+            // after its parent's `process::exit(0)`. So a `git clone` escaped
+            // the app and carried on populating the destination the Clone
+            // dialog had already reported as never created.
+            //
+            // `CloseRequested`, not `Destroyed`: it fires while the process is
+            // still alive and there is still something that can signal git.
+            //
+            // Gated on the label because this handler is app-global — the merge
+            // resolver is a second window, and closing it must not stop a fetch
+            // running behind it. `cancel_all` sends SIGTERM only, so git gets to
+            // run its own lock-file and clone-junk cleanup on the way out; see
+            // `cancel.rs`.
+            if matches!(event, tauri::WindowEvent::CloseRequested { .. })
+                && cancel::close_cancels_everything(window.label())
+            {
+                let signalled = cancel::cancel_all();
+                if signalled > 0 {
+                    log::info!("window closing — cancelled {signalled} network op(s) in flight");
+                }
+            }
         })
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        // The OTHER ways out (#263). `CloseRequested` above is emitted from
+        // tao's `windowShouldClose:` and nowhere else, so it covers the window's
+        // own close button and NOT ⌘Q: on macOS `applicationWillTerminate` goes
+        // straight to `LoopDestroyed`, which arrives here as `RunEvent::Exit`.
+        // Without this, quitting with a keystroke still leaves a `git clone`
+        // running against a destination the app has already forgotten.
+        //
+        // Being reached twice on the ordinary close path costs nothing:
+        // `cancel_all` is always the polite SIGTERM, never the escalation, and a
+        // registration that has already unwound is no longer in the registry.
+        //
+        // `Builder::run(context)` is documented as `build(context)?` followed by
+        // `App::run(|_, _| {})`, so this is the same call with a callback.
+        .run(|_app, event| {
+            if matches!(
+                event,
+                tauri::RunEvent::Exit | tauri::RunEvent::ExitRequested { .. }
+            ) {
+                let signalled = cancel::cancel_all();
+                if signalled > 0 {
+                    log::info!("app exiting — cancelled {signalled} network op(s) in flight");
+                }
+            }
+        });
 }

--- a/src-tauri/tests/cancel_on_close.rs
+++ b/src-tauri/tests/cancel_on_close.rs
@@ -1,0 +1,189 @@
+//! Closing the window stops what is in flight (#263 item 2).
+//!
+//! ## The leak this exists for, as measured
+//!
+//! Cancellation's backstop for a dropped future is `kill_on_drop(true)`, and a
+//! drop is exactly what closing the app does NOT do: `tao::EventLoop::run` is
+//! `-> !` and ends in `std::process::exit(exit_code)` on macOS, Linux and
+//! Windows alike (tao 0.35.3, `platform_impl/{macos,linux,windows}/event_loop.rs`),
+//! and `process::exit` runs no destructors on any stack. Measured directly
+//! before this test file was written: a `tokio::process::Command` child spawned
+//! with `kill_on_drop(true)` and held by a task was **still alive 500 ms after
+//! its parent called `process::exit(0)`**. So a `git clone` outlives the app and
+//! carries on populating the destination the Clone dialog was told never got
+//! created — the case `commands/create.rs` already carried a comment about.
+//!
+//! The fix is not a better backstop, it is asking first: a `CloseRequested`
+//! handler that cancels everything registered while there is still a process
+//! alive to do it.
+//!
+//! ## Its own test binary
+//!
+//! `cancel_all` addresses the process-wide registry with no scope to narrow it,
+//! so it reaches every op ANY test in the same process has registered. In the
+//! lib's own `mod tests` it would cancel its neighbours; here it shares a
+//! process only with the tests below, which serialize on one lock.
+
+use std::sync::{Mutex, MutexGuard};
+
+use platypusgit_lib::cancel::{self, Scope};
+
+/// Every test here either calls `cancel_all` or registers something it could
+/// reach, so they all take this.
+fn all_scopes_lock() -> MutexGuard<'static, ()> {
+    static LOCK: Mutex<()> = Mutex::new(());
+    LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// The gate that keeps the resolver window out of it.
+///
+/// The merge resolver is a second `WebviewWindow` (label `merge`, see
+/// `src/features/merge/openMergeWindow.ts`) and `on_window_event` is app-global:
+/// without this, finishing a conflict resolution would kill the fetch running
+/// behind it.
+#[test]
+fn only_the_main_window_closing_ends_the_app() {
+    assert!(
+        cancel::close_cancels_everything("main"),
+        "closing the app's own window must cancel what is in flight"
+    );
+    assert!(
+        !cancel::close_cancels_everything("merge"),
+        "closing the merge resolver must not stop a fetch running behind it"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn closing_the_window_reaches_every_scope_at_once() {
+    let _serialized = all_scopes_lock();
+
+    // A clone and a repository op, which is the pair no single `cancel(scope)`
+    // call can reach: `Scope::Clone` and `Scope::Repo` are different scopes by
+    // construction, and on the way out there is no scope left to name.
+    let clone_reg = cancel::register(Scope::Clone);
+    let repo_reg = cancel::register(Scope::repo(std::path::Path::new("/tmp/on-close")));
+    let mut cloning = spawn_own_group("sleep", "30");
+    let mut fetching = spawn_own_group("sleep", "30");
+    assert!(clone_reg.attach(cloning.id()));
+    assert!(repo_reg.attach(fetching.id()));
+
+    assert_eq!(cancel::cancel_all(), 2, "both ops must be signalled");
+
+    assert!(clone_reg.is_cancelled());
+    assert!(repo_reg.is_cancelled());
+    use std::os::unix::process::ExitStatusExt as _;
+    assert_eq!(
+        cloning.wait().expect("wait clone").signal(),
+        Some(libc::SIGTERM),
+        "the clone must actually be signalled, not merely marked — a marked-only \
+         entry is the leak: the app exits and git carries on cloning"
+    );
+    assert_eq!(
+        fetching.wait().expect("wait fetch").signal(),
+        Some(libc::SIGTERM)
+    );
+}
+
+/// On the way out the polite signal is the ONLY one worth sending.
+///
+/// `cancel()` escalates to `SIGKILL` on a second ask because the user clicking
+/// again says the first did not work. There is no second click here and nobody
+/// left to notice: what there is instead is git's own `SIGTERM` handling —
+/// `remove_lock_file_on_signal` and, in `clone`, `remove_junk_on_signal` — which
+/// is the only thing that can still tidy up once our process is gone. A
+/// `SIGKILL` on quit would strand `.git/FETCH_HEAD.lock` and half a clone with
+/// nothing running that could remove either.
+#[cfg(unix)]
+#[test]
+fn closing_the_window_asks_politely_even_after_a_cancel_click() {
+    use std::io::BufRead as _;
+    use std::os::unix::process::CommandExt as _;
+    let _serialized = all_scopes_lock();
+
+    let scope = Scope::repo(std::path::Path::new("/tmp/on-close-polite"));
+    let registration = cancel::register(scope.clone());
+    // Ignores SIGTERM, standing in for a git that does not die on the polite
+    // ask — surviving is what proves the signal was not SIGKILL.
+    let mut child = platypusgit_lib::proc::program("sh")
+        .arg("-c")
+        .arg("trap '' TERM; echo ready; while :; do sleep 1; done")
+        .process_group(0)
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn the SIGTERM-ignoring child");
+    let mut ready = String::new();
+    std::io::BufReader::new(child.stdout.take().expect("stdout"))
+        .read_line(&mut ready)
+        .expect("read the ready handshake");
+    assert_eq!(ready.trim(), "ready");
+    assert!(registration.attach(child.id()));
+
+    // The user clicked Cancel once, then closed the window — the state where
+    // `cancel()` itself WOULD escalate.
+    assert_eq!(cancel::cancel(&scope), 1);
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    cancel::cancel_all();
+    std::thread::sleep(std::time::Duration::from_millis(300));
+
+    assert!(
+        child.try_wait().expect("try_wait").is_none(),
+        "closing the window must send SIGTERM, never SIGKILL — a killed git \
+         cannot run remove_lock_file_on_signal, and there is no app left to \
+         clean up after it"
+    );
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+/// Spawn a child in its own process group, the way `proc::git_async` does — via
+/// `proc::program`, because `tests/spawn_no_window.rs` fails the build on a raw
+/// `Command::new` outside `proc.rs`.
+#[cfg(unix)]
+fn spawn_own_group(program: &str, arg: &str) -> std::process::Child {
+    use std::os::unix::process::CommandExt as _;
+    platypusgit_lib::proc::program(program)
+        .arg(arg)
+        .process_group(0)
+        .spawn()
+        .unwrap_or_else(|e| panic!("spawn {program} {arg}: {e}"))
+}
+
+/// The wiring itself, which no unit test can reach: `on_window_event` takes a
+/// closure the Tauri runtime calls, and there is no runtime in a `cargo test`.
+///
+/// A grep, and honestly so — the same shape as `tests/spawn_no_window.rs` and
+/// `test/docs.test.ts`. It cannot prove the handler runs; it can prove nobody
+/// deleted it, or quietly dropped the label gate and started cancelling a fetch
+/// every time the resolver window closes.
+#[test]
+fn the_close_handler_is_wired_and_gated_on_the_main_window() {
+    let src = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/lib.rs"),
+    )
+    .expect("read src/lib.rs");
+
+    assert!(
+        src.contains("WindowEvent::CloseRequested"),
+        "lib.rs must handle CloseRequested — without it a git clone outlives the \
+         app (see this file's module docs for the measurement)"
+    );
+    assert!(
+        src.contains("cancel::cancel_all()"),
+        "the CloseRequested handler must cancel every op in flight"
+    );
+    assert!(
+        src.contains("cancel::close_cancels_everything(window.label())"),
+        "the cancel must be gated on the window label, or closing the merge \
+         resolver kills a fetch running behind it"
+    );
+    // `CloseRequested` is emitted from tao's `windowShouldClose:` and nowhere
+    // else, so it covers the window's own close button and NOT ⌘Q: on macOS
+    // `applicationWillTerminate` goes straight to `LoopDestroyed`, which arrives
+    // as `RunEvent::Exit`. Without this second hook, quitting with a keystroke
+    // still leaks the clone.
+    assert!(
+        src.contains("tauri::RunEvent::Exit"),
+        "the exit path must cancel too — ⌘Q never emits a window CloseRequested"
+    );
+}

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -38,6 +38,7 @@ import {
   useRepoStore,
 } from "@/features/repo/useRepoStore";
 import { useFsWatch } from "@/features/repo/useFsWatch";
+import { startAutoFetch } from "@/features/repo/autoFetch";
 import { ActivityStatus } from "@/features/repo/ActivityStatus";
 import { LoadingStatus } from "@/features/repo/LoadingStatus";
 import { primaryActivity } from "@/features/repo/repoActivity";
@@ -236,23 +237,15 @@ export function AppShell() {
   // App-global subscription inside; the watch itself follows this repository.
   useFsWatch(repo?.id ?? null);
 
+  // Auto-fetch on a timer, and the deadline that belongs to timer-started
+  // fetches alone (#234, #263). The policy — which fetches may be killed on a
+  // clock and which may never be — lives in `startAutoFetch` rather than in this
+  // effect body, so it can be tested without rendering the shell.
   const autoFetchEnabled = useSettingsStore((s) => s.autoFetchEnabled);
   const autoFetchMinutes = useSettingsStore((s) => s.autoFetchMinutes);
   React.useEffect(() => {
     if (!repo || !autoFetchEnabled) return;
-    const id = window.setInterval(
-      () => {
-        // Skip the tick while a fetch is still running (#234). A remote that
-        // stalls outlives the interval, and every tick used to start ANOTHER
-        // `git fetch` against it — a pile of stuck processes the user never
-        // asked for, growing until the app is quit. Nothing is lost by skipping:
-        // the next tick fetches, and a fetch is idempotent.
-        if (useRepoStore.getState().activity.fetch) return;
-        useRepoStore.getState().fetchAll();
-      },
-      Math.max(1, autoFetchMinutes) * 60_000,
-    );
-    return () => window.clearInterval(id);
+    return startAutoFetch(autoFetchMinutes);
   }, [repo, autoFetchEnabled, autoFetchMinutes]);
 
   // Single global keymap listener — resolves chord → action → handler or

--- a/src/design/chrome.tsx
+++ b/src/design/chrome.tsx
@@ -400,11 +400,18 @@ export function PGStatusItem({
   label,
   tone = "default",
   onClick,
+  testId,
 }: {
   icon?: IconName | string;
   label?: ReactNode;
   tone?: "default" | "accent" | "success" | "warn" | "danger";
   onClick?: () => void;
+  /**
+   * A stable hook for the e2e suite. Threaded explicitly rather than spread
+   * from `...rest`, like every other design-system row: a status item's own
+   * label is prose, and a spec that waits on prose dies to a copy edit.
+   */
+  testId?: string;
 }) {
   const tones = {
     default: "var(--fg-2)",
@@ -415,6 +422,7 @@ export function PGStatusItem({
   };
   return (
     <div
+      data-testid={testId}
       onClick={onClick}
       style={{
         display: "flex",

--- a/src/features/palette/commands.test.ts
+++ b/src/features/palette/commands.test.ts
@@ -158,6 +158,49 @@ describe("buildCommands", () => {
     expect(push).not.toHaveBeenCalled();
   });
 
+  // Cancelling a stalled network op without a mouse (#263 item 4). The status
+  // bar's Cancel button was the only route to `cancelNetworkOps`, so a keyboard
+  // user watching a fetch hang had to reach for the pointer.
+  describe("cancel the running network op", () => {
+    const act = (label: string) => ({ label, startedAt: 1_000 });
+
+    it("is absent while nothing is running", () => {
+      expect(ids()).not.toContain("action:cancel-network");
+    });
+
+    it("appears while a fetch is running and cancels it", () => {
+      const cancelNetworkOps = vi.fn();
+      setRepo({ activity: { fetch: act("Fetching origin…") }, cancelNetworkOps });
+      const item = buildCommands().find((i) => i.id === "action:cancel-network");
+      expect(item).toBeTruthy();
+      // Names what it would stop — there can be several ops in flight, and a
+      // bare "Cancel" in a palette is a row nobody dares press.
+      expect(item!.detail).toBe("Fetching origin…");
+      item!.run();
+      expect(cancelNetworkOps).toHaveBeenCalled();
+    });
+
+    it("stays away from an op the backend cannot stop", () => {
+      // Same gate as the status bar's button (`isCancellable`): a rebase replay
+      // is libgit2 work inside one blocking call with nothing to signal, so a
+      // row offering to cancel it would be a row that does nothing.
+      setRepo({ activity: { rebase: act("Rebasing…") } });
+      expect(ids()).not.toContain("action:cancel-network");
+    });
+
+    it("relabels itself once a cancel has been asked for", () => {
+      // The second ask escalates SIGTERM → SIGKILL (#263), so the first one has
+      // to have visibly changed something — here as in the status bar.
+      setRepo({ activity: { fetch: act("Fetching origin…") } });
+      const before = buildCommands().find((i) => i.id === "action:cancel-network");
+      expect(before!.label).toBe("Cancel network operation");
+
+      setRepo({ activity: { fetch: act("Fetching origin…") }, cancelRequested: true });
+      const after = buildCommands().find((i) => i.id === "action:cancel-network");
+      expect(after!.label).toBe("Force stop network operation");
+    });
+  });
+
   it("omits stash-pop when there are no stashes", () => {
     expect(ids()).not.toContain("action:stash-pop-latest");
   });

--- a/src/features/palette/commands.ts
+++ b/src/features/palette/commands.ts
@@ -21,6 +21,7 @@ import { usePaletteStore } from "./usePaletteStore";
 import { createBranchInputStep, switchRepoStep } from "./steps";
 import { currentBranch, isConflicted, relativeTime } from "@/lib/derive";
 import { headUpstream, resolveConflictsOp } from "@/features/repo/ops";
+import { isCancellable, primaryActivity } from "@/features/repo/repoActivity";
 import type { ActionId } from "@/features/keymap";
 import type { BranchInfo, CommitInfo, FileStatus } from "@/lib/types";
 import type { PaletteItem, PaletteStep } from "./types";
@@ -820,6 +821,39 @@ export function buildCommands(): PaletteItem[] {
         });
       }
     }
+  }
+
+  // -- cancelling a stalled network op (#263 item 4) --
+  //
+  // The status bar's Cancel button was the only route to `cancelNetworkOps`, so
+  // the one thing a user needs when the app appears to have hung required a
+  // mouse. Gated on an op actually running, the way `Resolve conflicts…` below
+  // is: a row that only ever answers "nothing to cancel" is noise the rest of
+  // the time, and a Cancel row that does nothing is worse than none.
+  //
+  // The gate is `isCancellable` — the same one the status bar uses — so the two
+  // surfaces cannot drift into offering different things. It is the set of ops
+  // that go through `run_git_authenticated`, i.e. exactly what
+  // `cancel_network_op` can reach.
+  const running = primaryActivity(repo.activity);
+  if (running && isCancellable(running.key)) {
+    items.push({
+      type: "command", id: "action:cancel-network",
+      search: "Cancel stop abort network operation fetch pull push force",
+      // Two labels, for the same reason the status bar has two: the first ask
+      // is a SIGTERM, which is what lets git remove its own lock files, and only
+      // a SECOND one escalates to SIGKILL. So the first has to visibly change
+      // something, or an impatient repeat strands `.git/FETCH_HEAD.lock`.
+      label: repo.cancelRequested
+        ? "Force stop network operation"
+        : "Cancel network operation",
+      // What is actually stuck. More than one op can be in flight, and this row
+      // cancels the repository's whole scope — naming the one the status bar is
+      // showing is the least surprising thing it can say.
+      detail: running.state.label,
+      icon: "x", danger: true,
+      run: direct(() => void repo.cancelNetworkOps()),
+    });
   }
 
   // -- conflict resolution --

--- a/src/features/repo/ActivityStatus.test.tsx
+++ b/src/features/repo/ActivityStatus.test.tsx
@@ -128,6 +128,14 @@ describe("Cancel", () => {
     expect(screen.queryByText("Cancel")).toBeNull();
   });
 
+  // The e2e suite drives this button against the real binary (#263 item 3), and
+  // "Cancel" is prose — a copy edit here would silently turn that spec's wait
+  // into one that never resolves. The hook is state, not words.
+  it("carries a stable hook for the e2e suite to find", () => {
+    show({ fetch: running("Fetching origin…") });
+    expect(screen.getByTestId("activity-cancel")).toHaveTextContent("Cancel");
+  });
+
   it("cancels the repository's network ops when clicked", async () => {
     mockInvoke("cancel_network_op", () => 1);
     show({ fetch: running("Fetching origin…") });

--- a/src/features/repo/ActivityStatus.tsx
+++ b/src/features/repo/ActivityStatus.tsx
@@ -143,6 +143,7 @@ export function ActivityStatus() {
           clicking again.
         */
         <PGStatusItem
+          testId="activity-cancel"
           icon="x"
           label={cancelRequested ? "Force stop" : "Cancel"}
           tone="danger"

--- a/src/features/repo/autoFetch.test.ts
+++ b/src/features/repo/autoFetch.test.ts
@@ -1,0 +1,160 @@
+// The auto-fetch timer, and the deadline that belongs to it alone (#263 item 5).
+//
+// #260 rejected a global network timeout, and that reasoning holds for anything
+// the USER started: a timeout short enough to rescue a stalled host is short
+// enough to kill a legitimately slow clone, and only the user can tell those
+// apart. It does not cover the ops the TIMER started — nobody is watching those,
+// and the skip-while-running guard means one stalled fetch blocks auto-fetch
+// FOREVER rather than piling up.
+//
+// So these tests pin both halves: the deadline reaches a fetch the timer started
+// and stalled, and it can never reach a fetch anyone else started.
+
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { AUTO_FETCH_DEADLINE_MS, startAutoFetch } from "./autoFetch";
+import { useRepoStore } from "./useRepoStore";
+import { emptySlice } from "./repoSlice";
+
+function mockRefreshAll() {
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => null);
+}
+
+const calls = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+/** A fetch that never answers — the stalled remote, with no network involved. */
+const stalls = () => new Promise<void>(() => {});
+
+let stop: (() => void) | null = null;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  resetInvokeMock();
+  useRepoStore.setState({
+    ...emptySlice(),
+    current: { id: "repo-1", path: "/tmp/repo-1", head: "main" },
+  });
+  mockRefreshAll();
+  mockInvoke("cancel_network_op", () => 1);
+});
+
+afterEach(() => {
+  stop?.();
+  stop = null;
+  vi.useRealTimers();
+});
+
+describe("the timer", () => {
+  it("fetches on every tick", async () => {
+    mockInvoke("fetch_all", () => null);
+    stop = startAutoFetch(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(calls("fetch_all")).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(calls("fetch_all")).toHaveLength(2);
+  });
+
+  it("skips a tick while a fetch is already running", async () => {
+    mockInvoke("fetch_all", stalls);
+    stop = startAutoFetch(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // One stalled fetch, not a growing pile of them (#234).
+    expect(calls("fetch_all")).toHaveLength(1);
+  });
+
+  it("stops ticking once disposed", async () => {
+    mockInvoke("fetch_all", () => null);
+    stop = startAutoFetch(1);
+    stop();
+    stop = null;
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(calls("fetch_all")).toHaveLength(0);
+  });
+});
+
+describe("the deadline", () => {
+  it("cancels a timer-started fetch that is still running when it expires", async () => {
+    mockInvoke("fetch_all", stalls);
+    stop = startAutoFetch(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(calls("cancel_network_op")).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(AUTO_FETCH_DEADLINE_MS);
+
+    // Addressed at the repository, which is what makes it a scope cancel rather
+    // than the Clone dialog's clone.
+    expect(calls("cancel_network_op")).toHaveLength(1);
+    expect(calls("cancel_network_op")[0].args).toMatchObject({ repoId: "repo-1" });
+  });
+
+  it("leaves a fetch that finished in time alone", async () => {
+    mockInvoke("fetch_all", () => null);
+    stop = startAutoFetch(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(AUTO_FETCH_DEADLINE_MS);
+
+    expect(calls("cancel_network_op")).toHaveLength(0);
+  });
+
+  it("never reaches a fetch the user started", async () => {
+    mockInvoke("fetch_all", stalls);
+    stop = startAutoFetch(1);
+
+    // The user's own fetch, stalled, with no tick having started anything: the
+    // timer then SKIPS (a fetch is running), so there is nothing to arm a
+    // deadline. This is the case #260 rejected a timeout for — a slow op the
+    // user is watching and can cancel themselves.
+    void useRepoStore.getState().fetchAll();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(calls("fetch_all")).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(AUTO_FETCH_DEADLINE_MS * 2);
+    expect(calls("cancel_network_op")).toHaveLength(0);
+  });
+
+  it("is disarmed when the timer is", async () => {
+    mockInvoke("fetch_all", stalls);
+    stop = startAutoFetch(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    stop();
+    stop = null;
+
+    await vi.advanceTimersByTimeAsync(AUTO_FETCH_DEADLINE_MS);
+    expect(calls("cancel_network_op")).toHaveLength(0);
+  });
+
+  it("does not fire into a repository the user has switched to", async () => {
+    mockInvoke("fetch_all", stalls);
+    stop = startAutoFetch(1);
+    await vi.advanceTimersByTimeAsync(60_000);
+    const startedAt = useRepoStore.getState().activity.fetch!.startedAt;
+
+    // repo-2, with a fetch of its own carrying the SAME `startedAt` —
+    // millisecond wall-clock is not an identity, and `cancelNetworkOps`
+    // addresses whichever repository is open now. Without the repository guard
+    // this deadline would cancel repo-2's fetch, which nobody put a clock on.
+    useRepoStore.setState({
+      ...emptySlice(),
+      current: { id: "repo-2", path: "/tmp/repo-2", head: "main" },
+      activity: { fetch: { label: "Fetching all remotes…", startedAt } },
+    });
+
+    await vi.advanceTimersByTimeAsync(AUTO_FETCH_DEADLINE_MS);
+    expect(calls("cancel_network_op")).toHaveLength(0);
+  });
+});

--- a/src/features/repo/autoFetch.ts
+++ b/src/features/repo/autoFetch.ts
@@ -1,0 +1,121 @@
+/**
+ * The auto-fetch timer, and the one deadline in the app (#234, #263 item 5).
+ *
+ * Its own module rather than an effect body in `AppShell`, for the same reason
+ * `repoActivity` is not inside `useRepoStore`: the interesting part is a
+ * *policy* — which fetches may be killed on a clock and which may never be —
+ * and a policy that lives inside a `useEffect` cannot be tested without
+ * rendering the whole shell.
+ *
+ * ## Why there is a deadline here and nowhere else
+ *
+ * #260 considered a global timeout on network ops and rejected it, correctly: a
+ * timeout short enough to rescue a host that accepts the TCP connection and
+ * then says nothing is also short enough to kill a legitimately slow clone of a
+ * large repository, and only the person watching it can tell those two apart.
+ * Every interactive op keeps that deal — no timeout, a Cancel button instead.
+ *
+ * The argument does not cover the fetches the TIMER started. Nobody is watching
+ * those, so for them a stall is indistinguishable from a hang; and the
+ * skip-while-running guard below (which exists so a stalled remote cannot grow
+ * a pile of stuck `git fetch` processes) means ONE stalled auto-fetch turns
+ * auto-fetch off for the rest of the session. A deadline scoped to timer-started
+ * fetches unsticks that without touching the interactive deal.
+ *
+ * ## What makes it impossible for a user's fetch to inherit
+ *
+ * Nothing arms a deadline except a tick that itself started the fetch. A tick
+ * that finds `activity.fetch` already set — which is precisely what a fetch
+ * somebody else started looks like — returns without arming anything. And the
+ * armed timer is disarmed the moment the fetch it belongs to settles, then
+ * checks the entry's `startedAt` before firing, so a later, unrelated fetch
+ * cannot be mistaken for the one the deadline was armed for.
+ *
+ * The cancel itself is `cancel::Scope::Repo`-wide, as every cancel in this app
+ * is: it reaches every network op on the repository, which is the whole point of
+ * scope keying (#260) and the only thing that can clear the stacked-auto-fetch
+ * pile. So a fetch the user started *while a timer fetch was already stalled*
+ * does share the stalled op's fate — but it was already sharing its scope, and
+ * that pile is exactly what "Cancel" next to a stuck status line has to mean.
+ */
+
+import { useRepoStore } from "./useRepoStore";
+
+/**
+ * How long a timer-started fetch may run before it is cancelled.
+ *
+ * Two minutes is far longer than any healthy fetch and far shorter than a
+ * session: the point is not to be a timeout, it is to make sure the *next* tick
+ * has something to do. A stalled auto-fetch is unstuck within one deadline
+ * rather than never.
+ */
+export const AUTO_FETCH_DEADLINE_MS = 2 * 60_000;
+
+/**
+ * Start fetching every `minutes` minutes. Returns a disposer that stops the
+ * timer AND disarms any deadline it has armed.
+ *
+ * `Math.max(1, …)` mirrors the settings clamp: a zero here would be a fetch
+ * every tick of the event loop.
+ */
+export function startAutoFetch(minutes: number): () => void {
+  /** The deadline armed for the fetch this timer most recently started. */
+  let armed: number | null = null;
+  const disarm = () => {
+    if (armed !== null) {
+      window.clearTimeout(armed);
+      armed = null;
+    }
+  };
+
+  const tick = () => {
+    const store = useRepoStore.getState();
+    const repo = store.current;
+    if (!repo) return;
+    // Skip the tick while a fetch is still running (#234). A remote that stalls
+    // outlives the interval, and every tick used to start ANOTHER `git fetch`
+    // against it — a pile of stuck processes the user never asked for, growing
+    // until the app is quit. Nothing is lost by skipping: the next tick fetches,
+    // and a fetch is idempotent.
+    //
+    // This is also the line that keeps the deadline off other people's fetches:
+    // an entry that is already here belongs to somebody else's op, and this
+    // function returns before arming anything.
+    if (store.activity.fetch) return;
+
+    const running = store.fetchAll();
+    // `withAuthRetry` opens the indicator synchronously, before its first
+    // await, so the entry this tick just created is already readable here.
+    // Absent means the op was over before it began (no repository), and there
+    // is nothing to put a deadline on.
+    const startedAt = useRepoStore.getState().activity.fetch?.startedAt;
+    if (startedAt === undefined) return;
+
+    const deadline = window.setTimeout(() => {
+      if (armed === deadline) armed = null;
+      const live = useRepoStore.getState();
+      // The op outlives a tab switch but its `activity` entry does not, and
+      // `cancelNetworkOps` addresses whichever repository is open NOW — firing
+      // after a switch would cancel the other tab's ops instead of this one's.
+      if (live.current?.id !== repo.id) return;
+      // Still the very fetch this deadline was armed for, and still running.
+      if (live.activity.fetch?.startedAt !== startedAt) return;
+      void live.cancelNetworkOps();
+    }, AUTO_FETCH_DEADLINE_MS);
+    disarm();
+    armed = deadline;
+
+    // The load-bearing half of "a user's fetch cannot inherit this": the
+    // deadline dies with the op it was armed for, whatever the outcome.
+    void running.finally(() => {
+      window.clearTimeout(deadline);
+      if (armed === deadline) armed = null;
+    });
+  };
+
+  const interval = window.setInterval(tick, Math.max(1, minutes) * 60_000);
+  return () => {
+    window.clearInterval(interval);
+    disarm();
+  };
+}


### PR DESCRIPTION
Item 1 (SIGTERM to the child's process group, SIGKILL on a second click) was
already in `cancel.rs`. This is the rest.

## 2 — closing the window did not cancel

**Confirmed, not assumed.** `tao::EventLoop::run` is `-> !` and ends in
`std::process::exit` in all three `platform_impl/{macos,linux,windows}`
backends, so no destructor on any stack runs and `kill_on_drop(true)` can never
fire. Measured with a throwaway probe: a `kill_on_drop` child was still alive
500 ms after its parent's `process::exit(0)`.

So a `git clone` outlived the app and carried on populating the destination the
Clone dialog had already reported as never created.

`cancel_all()` now runs from `WindowEvent::CloseRequested`, gated on
`close_cancels_everything(window.label())` (`"main"`) so closing the merge
resolver cannot stop a fetch behind it. SIGTERM only, never the escalation —
git's own `remove_lock_file_on_signal` is the only cleanup left once we are gone.

**Beyond the brief, flagged deliberately:** tao emits `CloseRequested` only from
`windowShouldClose:`, so ⌘Q never reaches it — `applicationWillTerminate` goes
straight to `LoopDestroyed`, arriving as `RunEvent::Exit`. A keystroke quit would
still have leaked the clone. `lib.rs` therefore ends in
`.build(ctx).expect(…).run(|_, event| …)`, the documented expansion of
`Builder::run(ctx)` (`self.build(context)?.run(|_, _| {})`), matching `Exit` /
`ExitRequested`. Being reached twice on the ordinary path is free.

## 4 — cancelling needed a mouse

A command-palette row gated on the **same** `isCancellable(primaryActivity(…))`
the status bar uses, with two labels mirroring the two-click SIGTERM→SIGKILL
affordance.

## 5 — auto-fetch had no deadline

A 2-minute deadline scoped strictly to timer-started fetches, in a new
`features/repo/autoFetch.ts`. Nothing arms a deadline except a tick that itself
started the fetch; a tick that finds `activity.fetch` set returns before arming,
and the armed timer re-checks `startedAt` *and* the repository id before firing.
Interactive fetches are untouched — #260's reasoning against a global timeout
stands, and this is not one.

## 3 — e2e for both cancel surfaces

`stalledGitRemote()` in `e2e/support/tempRepo.ts`: a loopback listener whose
accepted sockets are **held** (dropping them makes git fail fast on EOF — a green
test of the wrong thing) and which swallows its own `ECONNRESET` (an unhandled
socket error takes the wdio worker down). No network needed.

## Verification

- `cargo test` — 85 suites, 1160 passing; `cancel_on_close.rs` 4 passing,
  `net_cancel.rs` still 4 passing
- `pnpm test` — 322 files, 3078 passing; `pnpm tsc --noEmit` clean; e2e tsc clean
- e2e in Docker on this branch: `cancel.e2e.ts` 2 passing against the real binary
- Mutation-checked rather than assumed: flipping `kill_tree(pid, false)` → `true`
  reddens 2 of 4; removing the skip-while-running guard reddens 3 of the
  auto-fetch tests, the repo-id guard 1, the cancel call 1

Also corrected a now-stale bullet in `docs/dev/backend.md` claiming cancellation
worked via a `select!` inside the read loop — #260 removed that `select!`.

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)
