### PR TITLE
feat(actions): give a custom action a context and somewhere to show up

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -535,11 +535,17 @@ features/            Components + Zustand store colocated per feature:
 │                    validation, and how a result is reported — a FAILURE is
 │                    always shown whatever the setting says, because an action
 │                    that exits non-zero silently is indistinguishable from one
-│                    that never ran), runAction (spawn → report → refresh, with
-│                    a RepoActivity entry so a slow user program is visible),
-│                    CustomActionsSettings. Deliberately does NOT re-implement
-│                    the command parser — that lives beside the spawn in Rust,
-│                    and a second one would be a second place to drift
+│                    that never ran; plus the SURFACES model —
+│                    ACTION_SURFACES / showsOn / actionsFor / coerceCustomActions
+│                    — and the three ActionContext builders repoContext /
+│                    fileContext / commitContext, which are what finally fill
+│                    $FILE, $FILES and $SHA), runAction (spawn → report →
+│                    refresh, with a RepoActivity entry so a slow user program
+│                    is visible), CustomActionsSettings. Deliberately does NOT
+│                    re-implement the command parser — that lives beside the
+│                    spawn in Rust, and a second one would be a second place to
+│                    drift. The menu entries themselves are
+│                    design/context-menu.tsx::customActionItems(surface, ctx)
 ├── nav/             useNavStore — cross-screen intents + DeepViewHeader
 ├── branches/        BranchChip, BranchPicker, orderBranches (PURE, #135 — THE
 │                    one branch ordering; every branch list goes through it),

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1495,6 +1495,56 @@ not worked around: a second mechanism for the same job would also fire on `ls`.
   `DeleteFailure[]`; the store refreshes the file list before it reports them,
   and `refreshAll()` first / error last in the catch arm.
 
+### Custom actions: where a user command shows up (#225)
+
+- **`surfaces` is the whole answer, and it is a SET** — `"repo" | "file" |
+  "commit"` (`features/actions/customActions.ts::ACTION_SURFACES`), in that
+  canonical order however the toggles were clicked, so two actions placed the
+  same way compare equal and a settings export diffs cleanly. `"repo"` IS the
+  command palette: the app's repo-level surface, where every op that is not
+  about one file or one commit already lives. Toggles, not a `PGSelect` — the
+  useful actions are on two surfaces at once.
+- **An absent `surfaces` means the palette, everywhere it is read.** Every
+  action persisted by the feature's first half has no such key and was a palette
+  action, so that is what it stays. The rule lives in `normalizeSurfaces` /
+  `DEFAULT_SURFACES` (so `showsOn`, `actionsFor` and the Settings row all agree
+  without asking) *and* in `coerceCustomActions`, which `coerceSettings` calls
+  to write the field in on load. Both halves are load-bearing: `customActions`
+  is object-valued, so the scalar type-guard in `coerceSettings` never looked at
+  the list — it arrives from localStorage exactly as it was written.
+- **An action ticked into no surface cannot be saved.** `isSavableAction`
+  refuses it, so the cause stays on screen (three empty toggles) rather than the
+  app silently putting a surface back. A list that reaches `coerceCustomActions`
+  with an empty one came from a hand-edited file, and *that* is repaired to the
+  palette — a persisted action nobody can reach is worse than one in the wrong
+  place.
+- **One menu builder, three call sites**:
+  `design/context-menu.tsx::customActionItems(surface, context)`, wired into
+  `fileMenuItems` (above the danger block, next to the other "run something
+  outside the app" entries), `multiFileMenuItems` (same place) and
+  `commitMenuItems` (last). The leading divider is INSIDE the returned block, so
+  a surface with no actions contributes nothing — an empty separated block reads
+  as a menu that failed to render.
+- **The context comes from the three builders, never assembled inline** —
+  `repoContext` / `fileContext` / `commitContext` in `customActions.ts`. They
+  are what finally fill `$FILE`, `$FILES` and `$SHA`; before them the advertised
+  placeholders could never resolve. A multi-select passes EVERY selected path,
+  because `$FILES` is the one placeholder that expands to several whole
+  arguments. `repo` stays `""` in all three: `run_custom_action` overwrites it
+  with the repository it resolves, which is also the child's cwd, so a value
+  here could only ever be a second source of truth that disagrees.
+- **Deliberately absent from three menus.** `commitMultiMenuItems` — `$SHA` is
+  singular and the substitution has no list form, so "the first of five,
+  silently" is not an answer. And the menus that REPLACE the file menu
+  (conflicted, embedded, submodule rows) get no file-surface action, the same
+  call `externalDiffItem` made: they are not the file menu with entries removed.
+- **`runAction` reaches `pgAlert` / `pgFlash` by module, not through
+  `@/design`.** The barrel re-exports `context-menu.tsx`, which now imports
+  `runAction` — the barrel would close that into a cycle. Same reason `pgFlash`
+  lives in `ui-helpers.tsx` for `features/keymap`.
+- The parser stays in Rust. `customActions.ts` fills a context and filters a
+  list; it never turns a command string into argv.
+
 ## Drag and drop
 
 - **Pointer events, never HTML5 drag-and-drop** — WebDriver can't synthesize an

--- a/src/design/context-menu.customActions.test.tsx
+++ b/src/design/context-menu.customActions.test.tsx
@@ -1,0 +1,227 @@
+// Where a custom action shows up (#225, second half).
+//
+// The first half put user-defined commands in the command palette and nowhere
+// else, which left `$FILE`, `$FILES` and `$SHA` advertised in Settings and
+// unfillable in practice — nothing ever populated an `ActionContext` beyond the
+// repository and the branch. This pins the other three quarters of that: which
+// surface each action is offered on, and that each surface sends the context
+// its placeholders are named after.
+//
+// The argv, the parsing and the substitution are the backend's (`custom_action.rs`
+// plus its Rust tests); what only this layer can get wrong is sending the WRONG
+// CONTEXT — a commit menu that forgets the sha, or a multi-select that sends one
+// file where the user selected five. Both fail silently: the placeholder expands
+// to an empty argument and the program fails somewhere far from the cause.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  commitMenuItems,
+  commitMultiMenuItems,
+  fileMenuItems,
+  multiFileMenuItems,
+  type ContextMenuItem,
+} from "./context-menu";
+import { pgFlashClear } from "./ui-helpers";
+import { buildCommands } from "@/features/palette/commands";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import type { ActionSurface, CustomAction } from "@/features/actions/customActions";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+
+const action = (id: string, surfaces: ActionSurface[]): CustomAction => ({
+  id,
+  name: `Run ${id}`,
+  command: "tool $FILE",
+  // Both off so a click is exactly one `run_custom_action` and nothing else:
+  // the output dialog and the refresh have their own tests, and neither is what
+  // this file is about.
+  showOutput: false,
+  refreshAfter: false,
+  surfaces,
+});
+
+const labels = (items: ContextMenuItem[]) =>
+  items.filter((i) => !i.divider && !i.__menuTitle).map((i) => String(i.label));
+
+function click(items: ContextMenuItem[], label: string) {
+  const found = items.find((i) => String(i.label) === label);
+  expect(found, `no menu item labelled ${label}`).toBeDefined();
+  return found!.onClick?.();
+}
+
+const actionCalls = () =>
+  getInvokeCalls().filter((c) => c.cmd === "run_custom_action");
+
+beforeEach(() => {
+  resetInvokeMock();
+  localStorage.clear();
+  useSettingsStore.getState().reset();
+  useRepoStore.setState({
+    current: { id: "r1", path: "/repo", head: "main" },
+    headInfo: { branch: "main", headOid: "deadbeef" },
+    status: [],
+    allFiles: [],
+    branches: [],
+    tags: [],
+    stashes: [],
+    remotes: [],
+    commits: [],
+    loading: false,
+    error: null,
+    repoState: "Clean",
+    activity: {},
+  } as never);
+  mockInvoke("run_custom_action", () => ({
+    code: 0,
+    stdout: "",
+    stderr: "",
+    argv: ["tool"],
+  }));
+});
+
+afterEach(() => {
+  pgFlashClear();
+  vi.restoreAllMocks();
+});
+
+const setActions = (list: CustomAction[]) =>
+  useSettingsStore.getState().set("customActions", list);
+
+describe("a custom action on the file context menu", () => {
+  it("is offered only when the action opted into the file surface", () => {
+    setActions([action("f", ["file"]), action("r", ["repo"])]);
+    const items = labels(fileMenuItems({ path: "src/a.ts" }));
+    expect(items).toContain("Run f");
+    expect(items).not.toContain("Run r");
+  });
+
+  it("sends the row's path as the file selection", async () => {
+    setActions([action("f", ["file"])]);
+    await click(fileMenuItems({ path: "src/a.ts" }), "Run f");
+    expect(actionCalls()).toEqual([
+      {
+        cmd: "run_custom_action",
+        args: {
+          repoId: "r1",
+          command: "tool $FILE",
+          context: {
+            // Never the frontend's to choose — the backend overwrites it with
+            // the repository it resolves, which is also the child's cwd.
+            repo: "",
+            files: ["src/a.ts"],
+            sha: null,
+            branch: "main",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("sends every selected path from a multi-select, for the $FILES form", async () => {
+    // The failure this catches is silent: one path where five were selected
+    // still runs the program, just on the wrong thing.
+    setActions([action("f", ["file"])]);
+    await click(
+      multiFileMenuItems({
+        stagedPaths: ["a.ts"],
+        unstagedPaths: ["b.ts", "c.ts"],
+      }),
+      "Run f",
+    );
+    expect(actionCalls()[0]?.args).toMatchObject({
+      context: { files: ["a.ts", "b.ts", "c.ts"], sha: null },
+    });
+  });
+
+  it("leaves the menu untouched when no action wants the file surface", () => {
+    // Specifically: no orphan divider. An empty separated block looks like a
+    // menu that failed to render its own entries.
+    const before = fileMenuItems({ path: "a.ts" });
+    setActions([action("r", ["repo"])]);
+    expect(fileMenuItems({ path: "a.ts" })).toHaveLength(before.length);
+  });
+
+  it("sits above the danger block on both file menus", () => {
+    // The house shape: Discard / Delete stay the LAST thing in a file menu, so
+    // a mis-click near the bottom cannot land on a destructive entry that has
+    // quietly moved. A user command is not a danger entry and must not push one
+    // out of that position, so it goes directly under the other "run something
+    // outside the app" entries instead.
+    setActions([action("f", ["file"])]);
+    const after = (items: ContextMenuItem[], label: string) =>
+      labels(items).slice(labels(items).indexOf(label) + 1);
+
+    expect(after(fileMenuItems({ path: "a.ts" }), "Run f")).toEqual([
+      "Discard changes",
+      "Ignore this file",
+    ]);
+    expect(
+      after(
+        multiFileMenuItems({ stagedPaths: [], unstagedPaths: ["b.ts"] }),
+        "Run f",
+      ),
+    ).toEqual(["Discard changes in 1 file…"]);
+  });
+
+  it("is absent from the menus that replace the file menu entirely", () => {
+    // Same call `externalDiffItem` made: a conflicted row gets the conflict
+    // menu and a submodule row gets the submodule menu. Neither is a file menu
+    // with extras removed, so neither grows a file-surface action.
+    setActions([action("f", ["file"])]);
+    for (const items of [
+      fileMenuItems({ path: "a.ts", conflicted: true }),
+      fileMenuItems({ path: "vendor/lib", submodule: true }),
+    ]) {
+      expect(labels(items)).not.toContain("Run f");
+    }
+  });
+});
+
+describe("a custom action on the commit context menu", () => {
+  it("is offered only when the action opted into the commit surface", () => {
+    setActions([action("c", ["commit"]), action("f", ["file"])]);
+    const items = labels(commitMenuItems({ sha: "abc1234" }));
+    expect(items).toContain("Run c");
+    expect(items).not.toContain("Run f");
+  });
+
+  it("sends the commit's sha and no files", async () => {
+    setActions([action("c", ["commit"])]);
+    await click(commitMenuItems({ sha: "abc1234" }), "Run c");
+    expect(actionCalls()[0]?.args).toMatchObject({
+      context: { repo: "", files: [], sha: "abc1234", branch: "main" },
+    });
+  });
+
+  it("stays off a multi-commit selection", () => {
+    // `$SHA` is singular and the substitution has no list form for it, so the
+    // honest answer for a selection of five is not "the first one" — it is that
+    // this menu does not offer actions at all.
+    setActions([action("c", ["commit"])]);
+    expect(labels(commitMultiMenuItems(["abc1234", "def5678"]))).not.toContain(
+      "Run c",
+    );
+  });
+});
+
+describe("a custom action in the command palette", () => {
+  it("is listed only when the action opted into the repo surface", () => {
+    setActions([action("r", ["repo"]), action("f", ["file"])]);
+    const ids = buildCommands().map((i) => i.id);
+    expect(ids).toContain("custom-action:r");
+    expect(ids).not.toContain("custom-action:f");
+  });
+
+  it("still lists an action saved before surfaces existed", () => {
+    // THE MIGRATION, at the surface it has to hold at: an action persisted by
+    // the first half has no `surfaces` key and was a palette action. It stays
+    // one, and it does NOT appear in the two new menus.
+    const legacy = { ...action("old", ["repo"]) } as Partial<CustomAction>;
+    delete legacy.surfaces;
+    setActions([legacy as CustomAction]);
+    expect(buildCommands().map((i) => i.id)).toContain("custom-action:old");
+    expect(labels(fileMenuItems({ path: "a.ts" }))).not.toContain("Run old");
+    expect(labels(commitMenuItems({ sha: "abc1234" }))).not.toContain("Run old");
+  });
+});

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -12,6 +12,7 @@ import { headAncestryOf } from "@/features/commits/headAncestry";
 import { runRebasePlanNow } from "@/features/commits/runRebasePlan";
 import { combinedSquashMessage } from "@/features/commits/squashMessage";
 import type {
+  ActionContext,
   BranchInfo,
   CommitInfo,
   DiffToolTarget,
@@ -37,6 +38,14 @@ import { absoluteInWorkdir, relativeToWorkdir } from "@/lib/paths";
 // closing a cycle back through this file (which imports chordFor from there).
 import { pgFlash } from "./ui-helpers";
 import { describeFastForward } from "@/features/branches/fastForward";
+import {
+  actionsFor,
+  commitContext,
+  fileContext,
+  type ActionSurface,
+} from "@/features/actions/customActions";
+import { runAction } from "@/features/actions/runAction";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
 
 export interface ContextMenuItem {
   label?: ReactNode;
@@ -658,6 +667,11 @@ export function commitMenuItems(commit: { sha?: string; subject?: string } | nul
         pgFlash("copied subject");
       },
     },
+    // The user's own commands, last (#225). Deliberately not on
+    // `commitMultiMenuItems`: `$SHA` is singular and the substitution has no
+    // list form for it, so the honest answer for a selection of five is that
+    // this menu does not offer actions — not "the first one, silently".
+    ...customActionItems("commit", commitContext(headBranch(), commit?.sha ?? null)),
   ];
 }
 
@@ -978,6 +992,54 @@ export function externalDiffItem(
       void useRepoStore.getState().openInDifftool(target, usable);
     },
   };
+}
+
+/**
+ * The user's own commands, on one context menu (#225).
+ *
+ * The second half of custom actions: the first shipped the parser, the Settings
+ * list and the palette entry, which left `$FILE`, `$FILES` and `$SHA`
+ * advertised and unfillable — nothing populated an `ActionContext` past the
+ * repository and the branch. A menu is where a file or a commit is already
+ * named, so it is where those placeholders can finally mean something.
+ *
+ * Each action says which surfaces it wants (`surfaces`), so this is a filter,
+ * not a broadcast: an action nobody placed on the file menu never appears
+ * there. The leading divider is INSIDE the returned block, so a surface with no
+ * actions contributes nothing at all — an empty separated block reads as a menu
+ * that failed to render its own entries.
+ *
+ * `context` carries only what the SURFACE knows. `repo` stays empty on purpose:
+ * `run_custom_action` overwrites it with the repository it resolves, which is
+ * also the child process's cwd, so a second source of truth here could only
+ * ever disagree with the one that matters.
+ */
+export function customActionItems(
+  surface: ActionSurface,
+  context: ActionContext,
+): ContextMenuItem[] {
+  // Every placeholder is about an open repository, and `runAction` declines
+  // without one — so an entry offered here would be one that does nothing.
+  if (!useRepoStore.getState().current) return [];
+  const actions = actionsFor(useSettingsStore.getState().customActions, surface);
+  if (!actions.length) return [];
+  return [
+    { divider: true },
+    ...actions.map(
+      (a): ContextMenuItem => ({
+        // The palette's icon for the same action, so one command looks like one
+        // command wherever it is reached from.
+        icon: "terminal",
+        label: a.name,
+        onClick: () => void runAction(a, context),
+      }),
+    ),
+  ];
+}
+
+/** The branch a menu-built `ActionContext` reports as `$BRANCH`. */
+function headBranch(): string | null {
+  return useRepoStore.getState().headInfo?.branch ?? null;
 }
 
 export function worktreeMenuItems(
@@ -1833,6 +1895,15 @@ export function fileMenuItems(
         if (path) useRepoStore.getState().openInTerminal(path);
       },
     },
+    // The user's own commands (#225), directly under the other "run something
+    // outside the app on this file" entries — and ABOVE the danger block, which
+    // stays the last thing in this menu on every surface that has one.
+    //
+    // Only on the ordinary file menu. A conflicted, embedded or submodule row
+    // returned its own menu further up; those are not the file menu with extras
+    // removed, so they do not grow a file-surface action either — the same call
+    // `externalDiffItem` made.
+    ...customActionItems("file", fileContext(headBranch(), [path])),
     { divider: true },
     // An untracked file has no copy in the index or in history, so deleting it
     // is for good — say so, and never do it on a single click the way a
@@ -2080,6 +2151,11 @@ export function multiFileMenuItems(
       },
     );
   }
+
+  // Every selected path, which is what `$FILES` is for — the one placeholder
+  // that expands to several whole arguments. Sending only the first would run
+  // the program on the wrong thing without saying so.
+  items.push(...customActionItems("file", fileContext(headBranch(), all)));
 
   // The untracked half of the selection, which is what Delete acts on. Filtered
   // against the selection for the same reason `promptStashPaths` filters: the

--- a/src/features/actions/CustomActionsSettings.test.tsx
+++ b/src/features/actions/CustomActionsSettings.test.tsx
@@ -1,0 +1,116 @@
+// Choosing where a custom action shows up (#225, second half).
+//
+// The list, the parser refusal and the placeholder substitution all have their
+// own tests. What only this control can get wrong is the SURFACE choice: an
+// action saved with no surface at all exists in Settings and can never be run,
+// and an action whose toggles say one thing while the stored list says another
+// disappears from the menu its owner just placed it on.
+import { beforeEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { CustomActionsSettings } from "./CustomActionsSettings";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+
+const stored = () => useSettingsStore.getState().customActions;
+
+beforeEach(() => {
+  localStorage.clear();
+  useSettingsStore.getState().reset();
+});
+
+async function startNewAction(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByTestId("custom-action-add"));
+  await user.type(screen.getByTestId("custom-action-name-input"), "Open");
+  await user.type(screen.getByTestId("custom-action-command-input"), "code $FILE");
+}
+
+describe("the surface toggles on a custom action", () => {
+  it("starts a new action in the palette and nowhere else", async () => {
+    const user = userEvent.setup();
+    render(<CustomActionsSettings />);
+    await startNewAction(user);
+    await user.click(screen.getByTestId("custom-action-save"));
+
+    expect(stored()).toHaveLength(1);
+    expect(stored()[0].surfaces).toEqual(["repo"]);
+  });
+
+  it("places an action on the file menu without taking it out of the palette", async () => {
+    const user = userEvent.setup();
+    render(<CustomActionsSettings />);
+    await startNewAction(user);
+    await user.click(screen.getByTestId("custom-action-surface-file"));
+    await user.click(screen.getByTestId("custom-action-save"));
+
+    expect(stored()[0].surfaces).toEqual(["repo", "file"]);
+  });
+
+  it("stores the surfaces in catalog order however they are clicked", async () => {
+    const user = userEvent.setup();
+    render(<CustomActionsSettings />);
+    await startNewAction(user);
+    // Back-to-front on purpose: two actions ticked the same way must compare
+    // equal, which is what lets a settings export diff cleanly.
+    await user.click(screen.getByTestId("custom-action-surface-commit"));
+    await user.click(screen.getByTestId("custom-action-surface-file"));
+    await user.click(screen.getByTestId("custom-action-surface-repo"));
+    await user.click(screen.getByTestId("custom-action-save"));
+
+    expect(stored()[0].surfaces).toEqual(["file", "commit"]);
+  });
+
+  it("refuses to save an action that would show up nowhere", async () => {
+    // Not silently putting a surface back: the cause stays on screen — three
+    // empty toggles — instead of the app overruling the click that emptied them.
+    const user = userEvent.setup();
+    render(<CustomActionsSettings />);
+    await startNewAction(user);
+    await user.click(screen.getByTestId("custom-action-surface-repo"));
+
+    expect(screen.getByTestId("custom-action-save")).toBeDisabled();
+    await user.click(screen.getByTestId("custom-action-save"));
+    expect(stored()).toEqual([]);
+  });
+
+  it("says where a saved action shows up, on its row", async () => {
+    useSettingsStore.getState().set("customActions", [
+      {
+        id: "a1",
+        name: "Open",
+        command: "code $FILE",
+        showOutput: false,
+        refreshAfter: false,
+        surfaces: ["file", "commit"],
+      },
+    ]);
+    render(<CustomActionsSettings />);
+    expect(screen.getByTestId("custom-action-row")).toHaveTextContent(
+      "File menu, Commit menu",
+    );
+  });
+
+  it("shows an action saved before surfaces existed as a palette action", async () => {
+    // The migration, where its owner looks for it. `coerceCustomActions` fills
+    // the field in on load; the row must not render a blank "shows up nowhere".
+    const user = userEvent.setup();
+    useSettingsStore.getState().set("customActions", [
+      {
+        id: "a1",
+        name: "Open",
+        command: "code $FILE",
+        showOutput: false,
+        refreshAfter: false,
+      } as never,
+    ]);
+    render(<CustomActionsSettings />);
+    expect(screen.getByTestId("custom-action-row")).toHaveTextContent(
+      "Command palette",
+    );
+
+    // And the editor opens with that same answer ticked, rather than empty.
+    await user.click(screen.getByTestId("custom-action-edit"));
+    await user.click(screen.getByTestId("custom-action-save"));
+    expect(stored()[0].surfaces).toEqual(["repo"]);
+  });
+});

--- a/src/features/actions/CustomActionsSettings.tsx
+++ b/src/features/actions/CustomActionsSettings.tsx
@@ -12,12 +12,17 @@ import { PGButton, PGInput, PGToggle } from "@/design";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 
 import {
+  ACTION_SURFACES,
   PLACEHOLDERS,
+  SURFACE_LABELS,
   blankAction,
   isSavableAction,
   normalizeAction,
+  normalizeSurfaces,
   removeAction,
+  showsOn,
   upsertAction,
+  type ActionSurface,
   type CustomAction,
 } from "./customActions";
 
@@ -44,7 +49,8 @@ export function CustomActionsSettings() {
           lineHeight: 1.5,
         }}
       >
-        Your own commands, in the command palette. The command is a program and
+        Your own commands, wherever you put them — the command palette, the file
+        context menu, the commit context menu. The command is a program and
         its arguments —{" "}
         <strong>not a shell line</strong>: quotes group arguments, and{" "}
         <code style={{ fontFamily: "var(--font-mono)" }}>| &gt; ; &amp;&amp;</code>{" "}
@@ -89,6 +95,12 @@ export function CustomActionsSettings() {
                 }}
               >
                 {a.command}
+              </div>
+              {/* Where it shows up, on the row rather than only inside the
+                  editor: "why is this not in my file menu" is the question a
+                  list that only shows names cannot answer. */}
+              <div style={{ fontSize: "var(--fs-11)", color: "var(--fg-3)" }}>
+                {surfaceSummary(a)}
               </div>
             </div>
             <PGButton
@@ -174,12 +186,33 @@ function ActionEditor({
           style={{ flex: "2 1 240px", minWidth: 0 }}
         />
       </div>
+      {/* Where it shows up (#225). Toggles rather than a PGSelect because the
+          answer is a SET, not a choice — an action can sensibly be on the file
+          menu and in the palette at once, and most useful ones are. */}
+      <div style={{ display: "flex", gap: 16, alignItems: "center", flexWrap: "wrap" }}>
+        <span style={{ fontSize: "var(--fs-11)", color: "var(--fg-3)" }}>
+          Shows up in:
+        </span>
+        {ACTION_SURFACES.map((surface) => (
+          <PGToggle
+            key={surface}
+            checked={showsOn(draft, surface)}
+            onChange={() => onChange(toggleSurface(draft, surface))}
+            label={
+              <span style={{ fontSize: "var(--fs-11)" }}>
+                {SURFACE_LABELS[surface]}
+              </span>
+            }
+            testId={`custom-action-surface-${surface}`}
+          />
+        ))}
+      </div>
       <div style={{ display: "flex", gap: 16, alignItems: "center", flexWrap: "wrap" }}>
         <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
           <PGToggle
             checked={draft.showOutput}
             onChange={(v) => onChange({ ...draft, showOutput: v })}
-            data-testid="custom-action-show-output"
+            testId="custom-action-show-output"
           />
           <span style={{ fontSize: "var(--fs-11)" }}>
             Show output (a failure is always shown)
@@ -189,16 +222,18 @@ function ActionEditor({
           <PGToggle
             checked={draft.refreshAfter}
             onChange={(v) => onChange({ ...draft, refreshAfter: v })}
-            data-testid="custom-action-refresh-after"
+            testId="custom-action-refresh-after"
           />
           <span style={{ fontSize: "var(--fs-11)" }}>Refresh when it exits</span>
         </label>
         <PGButton
           size="xs"
           variant="primary"
-          // Name and command non-blank, and nothing more: whether the command
-          // PARSES is the backend's question, and its refusal names what is
-          // wrong. A second parser here would be a second place to drift.
+          // Name and command non-blank, and at least one surface. Whether the
+          // command PARSES is still the backend's question — its refusal names
+          // what is wrong, and a second parser here would be a second place to
+          // drift. The surface check is the opposite case: it CAN be answered
+          // here, and an action placed nowhere is one that can never be run.
           disabled={!isSavableAction(draft)}
           onClick={onSave}
           data-testid="custom-action-save"
@@ -211,4 +246,27 @@ function ActionEditor({
       </div>
     </div>
   );
+}
+
+/**
+ * Flip one surface on the draft.
+ *
+ * Rebuilt through `normalizeSurfaces` rather than pushed onto: the stored order
+ * is canonical, so two actions ticked the same way compare equal however their
+ * owners clicked — which is what lets a settings export diff cleanly.
+ */
+function toggleSurface(draft: CustomAction, surface: ActionSurface): CustomAction {
+  const on = showsOn(draft, surface);
+  const next = normalizeSurfaces(draft.surfaces).filter((s) => s !== surface);
+  return {
+    ...draft,
+    surfaces: normalizeSurfaces(on ? next : [...next, surface]),
+  };
+}
+
+/** Where a saved action shows up, for its row. */
+function surfaceSummary(a: CustomAction): string {
+  return normalizeSurfaces(a.surfaces)
+    .map((s) => SURFACE_LABELS[s])
+    .join(", ");
 }

--- a/src/features/actions/customActions.test.ts
+++ b/src/features/actions/customActions.test.ts
@@ -8,14 +8,18 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  actionsFor,
   blankAction,
+  commitContext,
   describeResult,
+  fileContext,
   isSavableAction,
   newActionId,
   normalizeAction,
   removeAction,
   repoContext,
   shouldShowOutput,
+  showsOn,
   upsertAction,
   type CustomAction,
 } from "./customActions";
@@ -26,6 +30,7 @@ const action = (over: Partial<CustomAction> = {}): CustomAction => ({
   command: "code -g $FILE",
   showOutput: false,
   refreshAfter: true,
+  surfaces: ["repo"],
   ...over,
 });
 
@@ -116,5 +121,83 @@ describe("the context sent for a repo-level invocation", () => {
 
   it("tolerates a detached HEAD", () => {
     expect(repoContext(null).branch).toBeNull();
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// WHERE AN ACTION SHOWS UP (#225, second half)
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("surfaces", () => {
+  it("defaults a new action to the palette alone", () => {
+    expect(blankAction().surfaces).toEqual(["repo"]);
+  });
+
+  it("treats an action with no surfaces field as a palette action", () => {
+    // THE MIGRATION. Every action persisted before this feature existed has no
+    // `surfaces` key, and it was a palette action — so that is what it stays.
+    const legacy = { ...action(), surfaces: undefined } as unknown as CustomAction;
+    expect(normalizeAction(legacy).surfaces).toEqual(["repo"]);
+  });
+
+  it("drops unknown surfaces and duplicates, in a canonical order", () => {
+    const messy = {
+      ...action(),
+      surfaces: ["commit", "file", "commit", "branch"],
+    } as unknown as CustomAction;
+    expect(normalizeAction(messy).surfaces).toEqual(["file", "commit"]);
+  });
+
+  it("reads a surface off an action", () => {
+    const a = action({ surfaces: ["file", "commit"] });
+    expect(showsOn(a, "file")).toBe(true);
+    expect(showsOn(a, "commit")).toBe(true);
+    expect(showsOn(a, "repo")).toBe(false);
+  });
+
+  it("filters a list to one surface, in list order", () => {
+    const list = [
+      action({ id: "a", surfaces: ["repo"] }),
+      action({ id: "b", surfaces: ["file"] }),
+      action({ id: "c", surfaces: ["repo", "file"] }),
+    ];
+    expect(actionsFor(list, "file").map((a) => a.id)).toEqual(["b", "c"]);
+    expect(actionsFor(list, "commit")).toEqual([]);
+  });
+
+  it("refuses to save an action that would show up nowhere", () => {
+    // An action reachable from no surface is one that can never be run: it
+    // exists in Settings and does nothing. Disabling Save says so where the
+    // three empty toggles are, rather than silently putting one back.
+    expect(isSavableAction(action({ surfaces: [] }))).toBe(false);
+    expect(isSavableAction(action({ surfaces: ["commit"] }))).toBe(true);
+  });
+});
+
+describe("the context sent for a file selection", () => {
+  it("carries the selected paths and still leaves repo to the backend", () => {
+    const ctx = fileContext("main", ["src/a.ts", "src/b.ts"]);
+    expect(ctx.repo).toBe("");
+    expect(ctx.files).toEqual(["src/a.ts", "src/b.ts"]);
+    expect(ctx.branch).toBe("main");
+    expect(ctx.sha).toBeNull();
+  });
+
+  it("drops blank paths rather than sending an empty $FILE", () => {
+    expect(fileContext(null, ["", "  ", "a.ts"]).files).toEqual(["a.ts"]);
+  });
+});
+
+describe("the context sent for a commit", () => {
+  it("carries the sha and no files", () => {
+    const ctx = commitContext("main", "abc1234");
+    expect(ctx.sha).toBe("abc1234");
+    expect(ctx.files).toEqual([]);
+    expect(ctx.repo).toBe("");
+    expect(ctx.branch).toBe("main");
+  });
+
+  it("sends null rather than an empty sha", () => {
+    expect(commitContext(null, "").sha).toBeNull();
   });
 });

--- a/src/features/actions/customActions.ts
+++ b/src/features/actions/customActions.ts
@@ -6,14 +6,50 @@
 // place for "what actually runs" to drift, and the one that matters is the one
 // next to the spawn.
 //
-// This file is the list, its validation, and what the palette shows.
+// This file is the list, its validation, WHERE each action shows up
+// (`ActionSurface`), and the `ActionContext` each surface hands it.
 
 import type { ActionContext } from "@/lib/types";
+
+/**
+ * Where an action shows up.
+ *
+ * The issue's own three (#225): "repo-level, file context menu, commit context
+ * menu". `repo` is the command palette — the app's repo-level surface, where
+ * every op that is not about one file or one commit already lives.
+ */
+export type ActionSurface = (typeof ACTION_SURFACES)[number];
+
+/**
+ * The surfaces, in the order they are offered and stored.
+ *
+ * One list, so the Settings toggles, the normalizer and the canonical order a
+ * saved action is written in cannot drift apart.
+ */
+export const ACTION_SURFACES = ["repo", "file", "commit"] as const;
+
+/** What each surface is called where the user picks it. */
+export const SURFACE_LABELS: Record<ActionSurface, string> = {
+  repo: "Command palette",
+  file: "File menu",
+  commit: "Commit menu",
+};
+
+/**
+ * What an action shows up on when it does not say.
+ *
+ * THE MIGRATION for #225's first half: every action persisted before this
+ * existed was a palette action and nothing else, so an absent `surfaces` means
+ * exactly that. Anything else would silently move a saved action — either into
+ * menus its owner never asked for, or out of the palette they have been running
+ * it from.
+ */
+export const DEFAULT_SURFACES: readonly ActionSurface[] = ["repo"];
 
 /** One user-defined command. */
 export interface CustomAction {
   id: string;
-  /** What appears in the palette. */
+  /** What appears in the palette and on the menus it is placed on. */
   name: string;
   /** Program + arguments, with placeholders. Parsed by the backend, not here. */
   command: string;
@@ -21,6 +57,11 @@ export interface CustomAction {
   showOutput: boolean;
   /** Refresh the repository when it exits — for actions that change the tree. */
   refreshAfter: boolean;
+  /**
+   * Where it shows up. Never empty for a saved action — see
+   * `normalizeSurfaces` and `isSavableAction`.
+   */
+  surfaces: ActionSurface[];
 }
 
 /** The placeholders the backend substitutes, for the Settings hint. */
@@ -40,24 +81,115 @@ export function blankAction(): CustomAction {
     command: "",
     showOutput: true,
     refreshAfter: true,
+    surfaces: [...DEFAULT_SURFACES],
   };
 }
 
+/**
+ * Coerce a stored or hand-edited surface list into a usable one.
+ *
+ * Unknown entries are dropped rather than kept: they name a surface this build
+ * has no menu for, and carrying them would make `showsOn` answer questions
+ * about a place that does not exist. Duplicates collapse, and the result is in
+ * `ACTION_SURFACES` order so two actions ticked the same way compare equal —
+ * which is what lets the settings export diff cleanly.
+ *
+ * A value that is not a list at all is the pre-#225-second-half shape, and
+ * gets `DEFAULT_SURFACES`. A list that is empty AFTER filtering stays empty:
+ * the caller decides whether that is a draft to refuse (`isSavableAction`) or
+ * a persisted value to repair (`coerceCustomActions`), and those are different
+ * answers.
+ */
+export function normalizeSurfaces(value: unknown): ActionSurface[] {
+  if (!Array.isArray(value)) return [...DEFAULT_SURFACES];
+  return ACTION_SURFACES.filter((s) => value.includes(s));
+}
+
 export function normalizeAction(a: CustomAction): CustomAction {
-  return { ...a, name: a.name.trim(), command: a.command.trim() };
+  return {
+    ...a,
+    name: a.name.trim(),
+    command: a.command.trim(),
+    surfaces: normalizeSurfaces(a.surfaces),
+  };
+}
+
+/** Whether `a` is offered on `surface`. */
+export function showsOn(a: CustomAction, surface: ActionSurface): boolean {
+  return normalizeSurfaces(a.surfaces).includes(surface);
+}
+
+/** The actions offered on `surface`, in list order. */
+export function actionsFor(
+  list: readonly CustomAction[],
+  surface: ActionSurface,
+): CustomAction[] {
+  return list.filter((a) => showsOn(a, surface));
+}
+
+/**
+ * Repair a persisted or imported action list.
+ *
+ * Its own normalizer for the same reason `customThemes` and `themePreference`
+ * have one: `coerceSettings`' type-guard compares against
+ * `typeof DEFAULTS[key]`, and every object-valued setting is `"object"` — so
+ * the whole list arrives from localStorage exactly as it was written, unread.
+ * That is where an action saved before `surfaces` existed lands.
+ *
+ * Same rules as the rest of the settings coercion: an entry that is not an
+ * action at all is dropped, and a field that is present but unusable falls back
+ * to the documented safe value. An action ticked into NO surface is exactly
+ * that case — it can only come from a hand-edited file, since the editor
+ * refuses to save one — and the safe repair is the palette, which is where an
+ * action nobody placed has always lived.
+ *
+ * Returns null when the value is not a list at all, so the caller falls back to
+ * its own default the way `normalizeHeadMarks` lets it.
+ */
+export function coerceCustomActions(value: unknown): CustomAction[] | null {
+  if (!Array.isArray(value)) return null;
+  const out: CustomAction[] = [];
+  for (const raw of value) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+    const o = raw as Record<string, unknown>;
+    // The id has to survive: it is what `upsertAction` and the palette entry
+    // are keyed by, and an action without one can neither be edited nor removed.
+    if (typeof o.id !== "string" || !o.id) continue;
+    if (typeof o.name !== "string" || typeof o.command !== "string") continue;
+    const surfaces = normalizeSurfaces(o.surfaces);
+    out.push(
+      normalizeAction({
+        id: o.id,
+        name: o.name,
+        command: o.command,
+        // Absent reads as ON for both, which is what `blankAction` chose: an
+        // action that silently shows nothing and silently refreshes nothing is
+        // the pair of surprises this feature was written to avoid.
+        showOutput: o.showOutput !== false,
+        refreshAfter: o.refreshAfter !== false,
+        surfaces: surfaces.length ? surfaces : [...DEFAULT_SURFACES],
+      }),
+    );
+  }
+  return out;
 }
 
 /**
  * Whether an action is worth saving.
  *
- * Name and command non-blank, and nothing else. Whether the command PARSES is
- * the backend's question — it owns the parser, and its refusal names what is
- * wrong ("unclosed quote", "trailing backslash"). Re-implementing that check
- * here would create exactly the drift this file's header warns about.
+ * Name and command non-blank, and at least one surface. Whether the command
+ * PARSES is the backend's question — it owns the parser, and its refusal names
+ * what is wrong ("unclosed quote", "trailing backslash"). Re-implementing that
+ * check here would create exactly the drift this file's header warns about.
  */
 export function isSavableAction(a: CustomAction): boolean {
   const n = normalizeAction(a);
-  return n.name !== "" && n.command !== "";
+  // A surface is required for the opposite reason the parse check is absent:
+  // this one CAN be answered here, and the answer matters — an action placed
+  // nowhere is one that exists in Settings and can never be run. Refusing the
+  // save leaves the cause on screen (three empty toggles) instead of quietly
+  // putting a surface back that the user just unticked.
+  return n.name !== "" && n.command !== "" && n.surfaces.length > 0;
 }
 
 export function upsertAction(
@@ -106,5 +238,38 @@ export function describeResult(action: CustomAction, code: number | null): strin
 export function repoContext(branch: string | null): ActionContext {
   // `repo` is filled in by the BACKEND from the repository it resolves, so the
   // frontend cannot point a child process at a directory of its choosing.
+  // `run_custom_action` overwrites whatever arrives here, so filling it in on
+  // this side would be a second source of truth for where a repository lives
+  // that nothing ever reads — and the two builders below inherit that.
   return { repo: "", files: [], sha: null, branch };
+}
+
+/**
+ * The context an action gets from a file selection — `$FILE` and `$FILES`.
+ *
+ * Blank paths are dropped rather than passed through: `$FILE` expands to the
+ * FIRST file, so one empty string at the head of the list turns a real
+ * invocation into `code -g ""`, which fails somewhere far from the cause.
+ */
+export function fileContext(
+  branch: string | null,
+  files: readonly string[],
+): ActionContext {
+  return {
+    ...repoContext(branch),
+    files: files.filter((p) => !!p && !!p.trim()),
+  };
+}
+
+/**
+ * The context an action gets from one commit — `$SHA`.
+ *
+ * Null rather than `""` for a missing sha, so the backend expands `$SHA` to an
+ * empty argument by its own documented rule instead of by accident.
+ */
+export function commitContext(
+  branch: string | null,
+  sha: string | null,
+): ActionContext {
+  return { ...repoContext(branch), sha: sha || null };
 }

--- a/src/features/actions/runAction.ts
+++ b/src/features/actions/runAction.ts
@@ -3,7 +3,12 @@
 // Separate from the palette entry and from Settings so "what happens when an
 // action runs" is one place: spawn, report, refresh.
 
-import { pgAlert, pgFlash } from "@/design";
+// Reached by module, not through the `@/design` barrel. `design/index.ts`
+// re-exports `context-menu.tsx`, which now imports THIS file for the file and
+// commit menu entries — the barrel would close that into an import cycle. The
+// same reason `pgFlash` was moved out to `ui-helpers.tsx` for features/keymap.
+import { pgAlert } from "@/design/dialog";
+import { pgFlash } from "@/design/ui-helpers";
 import { setActivity, useRepoStore } from "@/features/repo/useRepoStore";
 import { appErrorMessage } from "@/lib/errors";
 import { runCustomAction } from "@/lib/tauri";

--- a/src/features/palette/commands.ts
+++ b/src/features/palette/commands.ts
@@ -16,6 +16,7 @@ import { orderBranchesGrouped } from "@/features/branches/orderBranches";
 import { activePins } from "@/features/branches/pins";
 import { summarizeFastForward } from "@/features/branches/fastForward";
 import { openCreateTag } from "@/features/tags/useCreateTagStore";
+import { actionsFor } from "@/features/actions/customActions";
 import { runAction } from "@/features/actions/runAction";
 import { usePaletteStore } from "./usePaletteStore";
 import { createBranchInputStep, switchRepoStep } from "./steps";
@@ -292,8 +293,17 @@ export function buildCommands(): PaletteItem[] {
   // team runs fifty times a day should be reachable the same way `Fetch all
   // remotes` is, not buried in a menu. Only with a repository open — every
   // placeholder is about one.
+  //
+  // The palette IS the `repo` surface — the app's repo-level place, where every
+  // op that is not about one file or one commit already lives. So an action
+  // placed only on the file or commit menu is not listed here; one saved before
+  // surfaces existed has no `surfaces` key, reads as `repo`, and stays exactly
+  // where its owner has been running it from.
   if (repo.current) {
-    for (const action of useSettingsStore.getState().customActions) {
+    for (const action of actionsFor(
+      useSettingsStore.getState().customActions,
+      "repo",
+    )) {
       items.push({
         type: "command",
         id: `custom-action:${action.id}`,

--- a/src/features/settings/useSettingsStore.test.ts
+++ b/src/features/settings/useSettingsStore.test.ts
@@ -430,3 +430,74 @@ describe("uiDensity CSS hook", () => {
     expect(document.documentElement.dataset.density).toBe("compact");
   });
 });
+
+// ═════════════════════════════════════════════════════════════════════════════
+// CUSTOM ACTIONS — the surfaces migration (#225, second half)
+// ═════════════════════════════════════════════════════════════════════════════
+//
+// `customActions` is object-valued, so `coerceSettings`' scalar type-guard
+// (which compares against `typeof DEFAULTS[key]`) never looks at it — the whole
+// list arrives from localStorage exactly as it was written. That is precisely
+// where an action saved before `surfaces` existed lands, and getting this wrong
+// means someone's action silently disappears from the palette they have been
+// running it from.
+describe("useSettingsStore custom actions", () => {
+  const legacy = {
+    id: "act-1",
+    name: "Open in editor",
+    command: "code -g $FILE",
+    showOutput: false,
+    refreshAfter: true,
+  };
+
+  it("keeps an action saved before surfaces existed in the palette", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ customActions: [legacy] }));
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().customActions).toEqual([
+      { ...legacy, surfaces: ["repo"] },
+    ]);
+  });
+
+  it("repairs an action a hand-edited file ticked into no surface at all", async () => {
+    // The editor refuses to save one, so this can only come from a file — and
+    // an action reachable from nowhere is one that can never be run. The
+    // palette is where an action nobody placed has always lived.
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ customActions: [{ ...legacy, surfaces: [] }] }),
+    );
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().customActions[0].surfaces).toEqual(["repo"]);
+  });
+
+  it("keeps a stored surface list, canonically ordered and free of unknowns", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        customActions: [{ ...legacy, surfaces: ["commit", "branch", "file"] }],
+      }),
+    );
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().customActions[0].surfaces).toEqual([
+      "file",
+      "commit",
+    ]);
+  });
+
+  it("drops an unusable entry rather than the whole list", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ customActions: [legacy, null, { name: "no id" }, 7] }),
+    );
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().customActions.map((a) => a.id)).toEqual([
+      "act-1",
+    ]);
+  });
+
+  it("falls back to no actions when the stored value is not a list", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ customActions: "code" }));
+    const { useSettingsStore } = await freshStore();
+    expect(useSettingsStore.getState().customActions).toEqual([]);
+  });
+});

--- a/src/features/settings/useSettingsStore.ts
+++ b/src/features/settings/useSettingsStore.ts
@@ -4,7 +4,10 @@ import { type DateFormat, isDateFormat } from "@/lib/commitDate";
 import { DATE_COL_W } from "@/design/graph-geometry";
 import type { UpdateChannel, UpdateRefsMode } from "@/lib/types";
 import type { SavedIdentity } from "@/features/commits/identity/identityList";
-import type { CustomAction } from "@/features/actions/customActions";
+import {
+  coerceCustomActions,
+  type CustomAction,
+} from "@/features/actions/customActions";
 import {
   DEFAULT_HEAD_WEIGHT,
   HEAD_WEIGHTS,
@@ -1462,6 +1465,13 @@ function coerceSettings(
   // Backfill logo colors for custom themes saved before the slots existed, drop
   // anything unusable, and keep the ids so `activeThemeId` still resolves.
   out.customThemes = normalizeCustomThemes(out.customThemes, base.customThemes);
+
+  // Custom actions (#225). Object-valued, so the scalar type-guard above
+  // never looked at them: the list arrives from localStorage — or from a
+  // shared settings file — exactly as it was written. This is where an
+  // action saved before `surfaces` existed is carried forward as a palette
+  // action, which is the only surface it ever had.
+  out.customActions = coerceCustomActions(out.customActions) ?? base.customActions;
 
   // THEME PREFERENCE (#236). Runs after `customThemes` so both the repair and
   // the seed can see the theme list this payload actually brings.


### PR DESCRIPTION
The second half of #225. #342 shipped the parser, the Settings list and the
palette entry — which left `$FILE`, `$FILES` and `$SHA` **advertised in the
Settings hint and unfillable**: `repoContext()` returned
`{ repo: "", files: [], sha: null, branch }` and nothing else ever built an
`ActionContext`. A feature that advertises placeholders it never fills is worse
than not shipping them.

## What changed

- **`ActionSurface`** (`"repo" | "file" | "commit"`), derived from
  `ACTION_SURFACES` so the list and the type cannot drift, with per-action
  toggles in Settings.
- **`fileContext` / `commitContext`** beside `repoContext`. `repo` deliberately
  stays `""` in all three: `run_custom_action` overwrites it with the repository
  it resolves — which is also the child's cwd — so a second source of truth here
  could only ever disagree with the one that matters.
- **Context-menu surfaces** on the single-file, multi-file and commit menus.
  Multi-select produces the `$FILES` list form; sending only the first path would
  run the program on the wrong thing without saying so.

The Rust parser stays the single source of truth for command → argv. No second
parser, no `Command::new` outside `proc.rs`, no Rust touched at all.

## Migration

**An absent `surfaces` key reads as `["repo"]`** — the palette, and only the
palette. Every action persisted by #342 had no such key and was a palette action,
so that is exactly where it stays.

The rule lives in two places on purpose: `normalizeSurfaces` applies it in
memory, and `coerceCustomActions` writes it in on load. The second half turned
out to be load-bearing for a reason beyond this change — `customActions` is
object-valued, so `coerceSettings`' scalar type-guard (which compares against
`typeof DEFAULTS[key]`) **never looked at it**. The list was arriving from
localStorage, or from a shared settings file, completely unvalidated. It is now.

An empty surface list cannot be *saved* (the cause stays on screen as three empty
toggles rather than the app overruling the click); an empty one arriving from a
hand-edited file *is* repaired to the palette — unreachable is worse than
misplaced.

## Deliberately not done

- **No actions on a multi-commit selection.** `$SHA` is singular and the Rust
  substitution has no list form for it, so "the first of five, silently" is not an
  answer. Pinned by a test.
- **No file-surface actions on conflicted / embedded / submodule rows** — those
  menus *replace* the file menu rather than trim it. Same call `externalDiffItem`
  made. Pinned by a test.
- **No keybinding for actions.** The issue mentions it; it is a separate surface
  (`keymap/actions.ts`) and is left for a follow-up. Issue #225 therefore stays
  open after this merges.

## Verification

- `pnpm test` — 323 files, 3097 passing; `pnpm tsc --noEmit` clean
- e2e in Docker on this branch: `status-stage.e2e.ts` 7 passing, which drives
  both file context menus
- The "actions sit above the danger block" invariant was documented in
  `frontend.md` but never asserted. It is now a test, verified failing first by
  moving the push below the danger block. Menu order before/after the review fix
  was diffed and is byte-identical on both file menus.

Incidental fix: `PGToggle` takes `testId`, not `data-testid`. The two existing
toggles in `CustomActionsSettings.tsx` passed the latter, which TS accepts on
hyphenated JSX attributes and React drops — those hooks rendered nothing.

Part of #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)
