### PR TITLE
feat(forge): host → many forge accounts, with an active one per host

### DIFF
--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -150,7 +150,11 @@ forge/           GitHub/GitLab PR/MR integration (#92). Trait = URL builders +
 │                kept (self-hosted APIs); no parseable remote → None (a state)
 ├── token.rs     Secret (no Display/Serialize, Debug prints Secret(***)), redact;
 │                storage via the git credential helper under
-│                <host>.platypusgit-forge.invalid — see backend.md
+│                <host>.platypusgit-forge.invalid — see backend.md.
+│                credential_username(account) picks the SLOT within a host
+│                (#233): None is the pre-#233 bare `platypusgit-forge`
+│                username, Some(id) appends `:id`, so two accounts on one
+│                host hold two tokens
 ├── http.rs      The ONLY impure file: one ureq agent, https_only + timeout +
 │                4MB cap; 401/403 → ForgeAuth, everything scrub_credentials'd
 ├── github.rs    REST v3 (api.github.com; /api/v3 for Enterprise)
@@ -472,7 +476,10 @@ commands/        Thin Tauri handlers, one file per area:
 ├── forge.rs     forge_detect, forge_sign_in/sign_out/token_status/validate_token,
 │                forge_list_pull_requests, forge_pull_request_checks,
 │                forge_create_pull_request, forge_checkout_pull_request. Owns
-│                ForgeTokens + blocking_forge (redacts tokens from errors)
+│                ForgeTokens + blocking_forge (redacts tokens from errors).
+│                Every token-using command takes an `account` slot (#233),
+│                absent/null = the pre-#233 slot, and ForgeTokens is keyed
+│                (host, account) so signing out of one leaves the other
 ├── reflog.rs    get_reflog, checkout_detached
 ├── submodule.rs list_submodules, submodule_init/sync/update (update is
 │                credentialed via net::run_git_authenticated)
@@ -600,9 +607,14 @@ features/            Components + Zustand store colocated per feature:
 │                    half, open the host's add-key page, generate)
 ├── create/          Clone + Init dialogs (PGModal), useCreateStore,
 │                    deriveRepoName. Clone shells out with the prompt-less env
-├── forge/           useForgeStore (hostKinds+logins under pg-forge-hosts, NEVER
-│                    a token), forgeLabels (prNoun/prNumberLabel/localBranchFor),
-│                    PullRequestRow, CreatePullRequestDialog, ForgeSettings
+├── forge/           useForgeStore (hostKinds + accounts under pg-forge-hosts,
+│                    NEVER a token), forgeAccounts (PURE — host → MANY accounts
+│                    with one active, the credential-slot id, and parseHosts's
+│                    migration off the old singular host→login map: the
+│                    migrated account keeps id null, which IS the pre-#233
+│                    credential slot), forgeLabels (prNoun/prNumberLabel/
+│                    localBranchFor), PullRequestRow, CreatePullRequestDialog,
+│                    ForgeSettings (one row per account + an add row)
 ├── compare/         compareSides (PURE — nav imports the TYPE from here),
 │                    useCompareStore (own store; RepoSlice untouched),
 │                    CompareSidePicker

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -45,6 +45,15 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   key would overwrite the push credential; RFC 6761 means no remote can ever
   ask for it. (A custom `protocol=` was rejected — osxkeychain silently
   `exit(0)`s on unknown protocols.)
+- **A host holds MANY accounts (#233).** The host key stays shared (it is what
+  keeps the API token off the transport credential), so the ACCOUNT is carried
+  by `username=`: `credential_username(None)` is the bare `platypusgit-forge` a
+  pre-#233 build stored every token under and must stay byte-identical, and
+  `Some(id)` appends `:<id>`. The id is opaque, not the login — a forge login
+  can be renamed while the token stays valid, and a login-keyed entry would
+  orphan it. `ForgeTokens` is keyed `(host, account)` and `forge_sign_out`
+  erases ONE slot, so signing out of the work account leaves the personal one
+  signed in. Frontend side: `features/forge/forgeAccounts.ts`.
 - `git credential` runs with cwd = the OS temp dir, so a repo-local
   `credential.helper` cannot redirect token reads or writes.
 - `store_token` **round-trips** (approve → fill → compare) and raises

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -426,6 +426,51 @@ right shape, but `signCommits` is a global tri-state (#61 D6) and the signing
 chain resolves its key from git config — a field nothing reads would be dead
 weight that later needs migrating.
 
+## Forge accounts are host → MANY (#233)
+
+The identity half above is about git's `user.name`/`user.email`. The forge side
+had its own one-account-per-host constraint: `pg-forge-hosts` persisted
+`logins: Record<string, string>`, host → login, **singular**, so two GitHub
+accounts were not expressible at all.
+
+`features/forge/forgeAccounts.ts` is the pure module that replaced it:
+`accounts: Record<string, ForgeAccount[]>` with `ForgeAccount = {id, login,
+active}`.
+
+- **`id` is a credential-SLOT name, not the login.** It is what the backend
+  appends to `username=` (`platypusgit-forge:<id>`), which is what lets one host
+  hold two tokens. A login is the wrong key: a forge login can be renamed while
+  the token stays valid, and the entry would then be orphaned.
+- **`id: null` is the pre-#233 slot**, the bare `platypusgit-forge` username a
+  released build already wrote real tokens under. `parseHosts` migrates the old
+  `logins` map onto `id: null` and nothing else — any other id points at a slot
+  that has never held anything, and a user who never signed out would come back
+  signed out. Nothing ever mints `null`; it only arrives from migration.
+  `activeAccountId` also answers `null` for a host with NO accounts, which is
+  the same slot: cleared localStorage with the keychain intact still finds its
+  token.
+- **The active account is a flag on the row, not a `host → id` pointer.** A
+  pointer can dangle (naming a removed account) and is ambiguous (`null` meaning
+  both "the legacy slot" and "nothing recorded"). `parseHosts` normalises "none
+  flagged" and "two flagged" to exactly one, so every host with accounts has an
+  active one by construction.
+- **Every token-using call names the slot** — `forgeTokenStatus`,
+  `forgeValidateToken`, `forgeListPullRequests`, `forgePullRequestChecks`,
+  `forgeCreatePullRequest`, `forgeSignIn`, `forgeSignOut`. Signing out, and an
+  empty-slot `refreshTokenStatus`, remove ONE account and promote a survivor;
+  they must never evict the other account on the same host.
+- `signIn` always mints a fresh slot, because the login is the forge's answer
+  and is not known before validating. If the login turns out to already have a
+  row (re-authenticating an expired token), `upsertAccount` collapses onto it
+  and the displaced slot's dead token is erased best-effort.
+
+`ForgeSettings` renders one row per account plus one add row — the token field
+hides behind an explicit "Add account" once a host has one, because a password
+box sitting permanently open under every signed-in host is noise.
+
+**A saved identity does not reference a forge account yet.** It is the natural
+follow-on the issue names, and the map had to become host → many first.
+
 ## The commit-message composer (#252)
 
 `src/features/commits/message/` is **THE** commit-message composition surface —

--- a/src-tauri/src/commands/forge.rs
+++ b/src-tauri/src/commands/forge.rs
@@ -7,6 +7,11 @@
 //!    command that reads a token out.
 //! 2. **Every blocking `ureq` call is wrapped in `spawn_blocking`**, like every
 //!    libgit2 call, so an API round trip cannot block the async runtime.
+//!
+//! Every token-using command also takes an `account` slot (#233): a host can
+//! hold several accounts, and the caller says which one this call is for.
+//! Absent / `null` is the pre-#233 slot — the one an already-signed-in user's
+//! token is stored under — so an old caller keeps working unchanged.
 
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -26,43 +31,59 @@ use crate::{
     state::AppState,
 };
 
-/// Per-host token cache, so a list refresh does not shell out to
-/// `git credential fill` on every call.
+/// Cache key: one forge host plus the account slot within it (#233).
 ///
 /// Keyed by the FORGE host as the user typed it (`github.com`), not by the
 /// namespaced credential host — the namespacing is `forge::token`'s business.
+/// `None` is the pre-#233 slot; two accounts on one host are two entries, so a
+/// refresh for the work account can never hand back the personal token.
+type TokenKey = (String, Option<String>);
+
+fn token_key(host: &str, account: Option<&str>) -> TokenKey {
+    (host.to_string(), account.map(str::to_string))
+}
+
+/// Per-account token cache, so a list refresh does not shell out to
+/// `git credential fill` on every call.
 #[derive(Default)]
-pub struct ForgeTokens(pub Mutex<HashMap<String, Secret>>);
+pub struct ForgeTokens(pub Mutex<HashMap<TokenKey, Secret>>);
 
 impl ForgeTokens {
-    fn get(&self, host: &str) -> Option<Secret> {
-        self.0.lock().ok()?.get(host).cloned()
+    fn get(&self, host: &str, account: Option<&str>) -> Option<Secret> {
+        self.0.lock().ok()?.get(&token_key(host, account)).cloned()
     }
 
-    fn put(&self, host: &str, token: Secret) {
+    fn put(&self, host: &str, account: Option<&str>, token: Secret) {
         if let Ok(mut map) = self.0.lock() {
-            map.insert(host.to_string(), token);
+            map.insert(token_key(host, account), token);
         }
     }
 
-    fn forget(&self, host: &str) {
+    /// Forget ONE slot. Signing out of the work account must leave the personal
+    /// account on the same host signed in.
+    fn forget(&self, host: &str, account: Option<&str>) {
         if let Ok(mut map) = self.0.lock() {
-            map.remove(host);
+            map.remove(&token_key(host, account));
         }
     }
 }
 
-/// The token for `host`, from memory or from the credential helper.
+/// The token for one account on `host`, from memory or from the credential
+/// helper.
 ///
 /// "Not signed in" is `ForgeAuth`, the same error a rejected token produces, so
 /// the frontend has exactly one shape to route to Settings.
-async fn token_for(tokens: &ForgeTokens, host: &str) -> AppResult<Secret> {
-    if let Some(t) = tokens.get(host) {
+async fn token_for(
+    tokens: &ForgeTokens,
+    host: &str,
+    account: Option<&str>,
+) -> AppResult<Secret> {
+    if let Some(t) = tokens.get(host, account) {
         return Ok(t);
     }
-    match token::load_token(host).await? {
+    match token::load_token(host, account).await? {
         Some(t) => {
-            tokens.put(host, t.clone());
+            tokens.put(host, account, t.clone());
             Ok(t)
         }
         None => Err(AppError::ForgeAuth(host.to_string())),
@@ -116,16 +137,22 @@ pub async fn forge_detect(
     Ok(remote::detect(&remotes, &host_kinds))
 }
 
-/// Validate a token against the forge, then store it.
+/// Validate a token against the forge, then store it in one account slot.
 ///
 /// Validation FIRST, deliberately: storing on submit would persist a typo into
 /// the user's keychain and then fail every later call with a stale secret.
+///
+/// `account` names the slot (#233). Absent / `null` is the pre-#233 slot, which
+/// is what an already-signed-in user's token is stored under; a second account
+/// on the same host arrives with an id the frontend minted, so neither token
+/// overwrites the other.
 #[tauri::command]
 pub async fn forge_sign_in(
     tokens: State<'_, ForgeTokens>,
     host: String,
     kind: ForgeKind,
     token: String,
+    account: Option<String>,
 ) -> AppResult<ForgeIdentity> {
     let secret = Secret::new(token);
     if secret.is_empty() {
@@ -144,23 +171,27 @@ pub async fn forge_sign_in(
 
     // Cache before storing: if the helper is missing, the session still works and
     // `store_token`'s error explains why it will not survive a restart.
-    tokens.put(&host, secret.clone());
-    token::store_token(&host, &secret).await?;
+    let slot = account.as_deref();
+    tokens.put(&host, slot, secret.clone());
+    token::store_token(&host, slot, &secret).await?;
     Ok(identity)
 }
 
-/// Whether `host` has a token. No network call — Settings renders often.
+/// Whether one account slot on `host` has a token. No network call — Settings
+/// renders often.
 #[tauri::command]
 pub async fn forge_token_status(
     tokens: State<'_, ForgeTokens>,
     host: String,
+    account: Option<String>,
 ) -> AppResult<ForgeTokenStatus> {
-    let signed_in = if tokens.get(&host).is_some() {
+    let slot = account.as_deref();
+    let signed_in = if tokens.get(&host, slot).is_some() {
         true
     } else {
-        match token::load_token(&host).await? {
+        match token::load_token(&host, slot).await? {
             Some(t) => {
-                tokens.put(&host, t);
+                tokens.put(&host, slot, t);
                 true
             }
             None => false,
@@ -179,8 +210,9 @@ pub async fn forge_validate_token(
     tokens: State<'_, ForgeTokens>,
     host: String,
     kind: ForgeKind,
+    account: Option<String>,
 ) -> AppResult<ForgeIdentity> {
-    let secret = token_for(&tokens, &host).await?;
+    let secret = token_for(&tokens, &host, account.as_deref()).await?;
     let url = forge_for(kind).identity_url(&host)?;
     blocking_forge(host.clone(), secret, move |t| {
         let forge = forge_for(kind);
@@ -191,14 +223,19 @@ pub async fn forge_validate_token(
     .await
 }
 
-/// Forget the token for `host`.
+/// Forget the token in ONE of `host`'s account slots (#233).
+///
+/// Per-account on purpose: the other account on the same host keeps its token,
+/// in the cache and in the credential helper.
 #[tauri::command]
 pub async fn forge_sign_out(
     tokens: State<'_, ForgeTokens>,
     host: String,
+    account: Option<String>,
 ) -> AppResult<()> {
-    tokens.forget(&host);
-    token::erase_token(&host).await
+    let slot = account.as_deref();
+    tokens.forget(&host, slot);
+    token::erase_token(&host, slot).await
 }
 
 /// Open pull requests / merge requests for `forge`.
@@ -206,8 +243,9 @@ pub async fn forge_sign_out(
 pub async fn forge_list_pull_requests(
     tokens: State<'_, ForgeTokens>,
     forge: ForgeRepo,
+    account: Option<String>,
 ) -> AppResult<Vec<PullRequest>> {
-    let secret = token_for(&tokens, &forge.host).await?;
+    let secret = token_for(&tokens, &forge.host, account.as_deref()).await?;
     let kind = forge.kind;
     let url = forge_for(kind).list_url(&forge)?;
     blocking_forge(forge.host.clone(), secret, move |t| {
@@ -226,8 +264,9 @@ pub async fn forge_pull_request_checks(
     tokens: State<'_, ForgeTokens>,
     forge: ForgeRepo,
     sha: String,
+    account: Option<String>,
 ) -> AppResult<ChecksSummary> {
-    let secret = token_for(&tokens, &forge.host).await?;
+    let secret = token_for(&tokens, &forge.host, account.as_deref()).await?;
     let kind = forge.kind;
     let url = forge_for(kind).checks_url(&forge, &sha)?;
     blocking_forge(forge.host.clone(), secret, move |t| {
@@ -245,6 +284,7 @@ pub async fn forge_create_pull_request(
     tokens: State<'_, ForgeTokens>,
     forge: ForgeRepo,
     request: NewPullRequest,
+    account: Option<String>,
 ) -> AppResult<PullRequest> {
     if request.title.trim().is_empty() {
         return Err(AppError::InvalidArgument("a title is required".into()));
@@ -254,7 +294,7 @@ pub async fn forge_create_pull_request(
             "the source and target branch are the same".into(),
         ));
     }
-    let secret = token_for(&tokens, &forge.host).await?;
+    let secret = token_for(&tokens, &forge.host, account.as_deref()).await?;
     let kind = forge.kind;
     let url = forge_for(kind).create_url(&forge)?;
     let body = forge_for(kind).create_body(&request);

--- a/src-tauri/src/forge/token.rs
+++ b/src-tauri/src/forge/token.rs
@@ -81,7 +81,37 @@ pub fn redact(text: &str, secret: &Secret) -> String {
 }
 
 /// Username every forge-token credential entry is stored under.
+///
+/// For the pre-#233 slot this is the whole username. A named account appends
+/// its slot id — see [`credential_username`].
 pub const CREDENTIAL_USERNAME: &str = "platypusgit-forge";
+
+/// The `username=` one host's account is stored against.
+///
+/// # Why the username, and not the host, carries the account (#233)
+///
+/// git credential helpers key on `protocol` + `host` + `username`. The host key
+/// is already load-bearing (see the module docs: it is what keeps an API token
+/// off the git-transport credential for the same host), so a second account on
+/// the same forge has to differ somewhere else — and the username is the only
+/// remaining part of the key.
+///
+/// `None` is the slot a pre-#233 build wrote under: the bare
+/// `platypusgit-forge`. It MUST stay byte-identical, or every already-signed-in
+/// user comes back signed out of a host they never left. An empty id means the
+/// same thing — `undefined`, `null` and `""` all reach here as "unspecified"
+/// from the frontend, and letting `""` mint a third distinct slot would strand a
+/// token in it.
+///
+/// The id is deliberately opaque rather than the login: a forge login can be
+/// renamed while the token stays valid, and a login-keyed entry would orphan the
+/// token on a rename.
+pub fn credential_username(account: Option<&str>) -> String {
+    match account.filter(|a| !a.is_empty()) {
+        None => CREDENTIAL_USERNAME.to_string(),
+        Some(id) => format!("{CREDENTIAL_USERNAME}:{id}"),
+    }
+}
 
 /// The `host=` a forge token for `host` is stored against. See the module docs.
 pub fn credential_host(host: &str) -> String {
@@ -108,16 +138,21 @@ fn credential_cwd() -> PathBuf {
     std::env::temp_dir()
 }
 
-/// Build the credential-protocol payload for one host, with or without the
-/// password. `None` is a `fill`/`reject` query; `Some` is an `approve` write.
-fn credential_input(host: &str, token: Option<&Secret>) -> AppResult<String> {
+/// Build the credential-protocol payload for one host + account slot, with or
+/// without the password. `None` token is a `fill`/`reject` query; `Some` is an
+/// `approve` write.
+fn credential_input(host: &str, account: Option<&str>, token: Option<&Secret>) -> AppResult<String> {
     let key_host = credential_host(host);
-    if !credential_line_safe(&key_host) || !credential_line_safe(CREDENTIAL_USERNAME) {
+    // The username now carries the account slot, so it is user-influenced the
+    // same way the host is: check the value that actually goes on the wire.
+    let key_user = credential_username(account);
+    if !credential_line_safe(&key_host) || !credential_line_safe(&key_user) {
         return Err(AppError::InvalidArgument(
-            "host contains a newline, which git's credential protocol cannot carry".into(),
+            "the host or account contains a newline, which git's credential protocol cannot carry"
+                .into(),
         ));
     }
-    let mut input = format!("protocol=https\nhost={key_host}\nusername={CREDENTIAL_USERNAME}\n");
+    let mut input = format!("protocol=https\nhost={key_host}\nusername={key_user}\n");
     if let Some(t) = token {
         if !credential_line_safe(t.expose()) {
             return Err(AppError::InvalidArgument(
@@ -201,19 +236,19 @@ fn password_from_fill(stdout: &str) -> Option<Secret> {
     None
 }
 
-/// Read the stored token for `host`, or `None`.
+/// Read the stored token for `host`'s `account` slot, or `None`.
 ///
 /// An empty `password=` reads as absent: a helper (or a stray `GIT_ASKPASS`)
 /// answering with an empty string must not look like a stored empty token.
-pub async fn load_token(host: &str) -> AppResult<Option<Secret>> {
-    let input = credential_input(host, None)?;
+pub async fn load_token(host: &str, account: Option<&str>) -> AppResult<Option<Secret>> {
+    let input = credential_input(host, account, None)?;
     match run_credential("fill", &input, true).await? {
         Some(stdout) => Ok(password_from_fill(&stdout)),
         None => Ok(None),
     }
 }
 
-/// Store the token for `host`, then prove it stuck.
+/// Store the token for `host`'s `account` slot, then prove it stuck.
 ///
 /// D5 could treat storage as best-effort — the credential had already worked for
 /// the operation the user asked for. A forge token cannot: if it silently
@@ -221,11 +256,11 @@ pub async fn load_token(host: &str) -> AppResult<Option<Secret>> {
 /// through `fill` and reports `ForgeTokenStore` with the remedy when the token
 /// does not come back. The caller keeps it in memory regardless, so the feature
 /// still works for this session.
-pub async fn store_token(host: &str, token: &Secret) -> AppResult<()> {
-    let input = credential_input(host, Some(token))?;
+pub async fn store_token(host: &str, account: Option<&str>, token: &Secret) -> AppResult<()> {
+    let input = credential_input(host, account, Some(token))?;
     run_credential("approve", &input, false).await?;
 
-    match load_token(host).await? {
+    match load_token(host, account).await? {
         Some(stored) if stored == *token => Ok(()),
         _ => Err(AppError::ForgeTokenStore(format!(
             "git did not keep the token for {host}. Configure a credential helper \
@@ -236,9 +271,9 @@ pub async fn store_token(host: &str, token: &Secret) -> AppResult<()> {
     }
 }
 
-/// Forget the token for `host`.
-pub async fn erase_token(host: &str) -> AppResult<()> {
-    let input = credential_input(host, None)?;
+/// Forget the token in `host`'s `account` slot. Leaves every other slot alone.
+pub async fn erase_token(host: &str, account: Option<&str>) -> AppResult<()> {
+    let input = credential_input(host, account, None)?;
     run_credential("reject", &input, false).await?;
     Ok(())
 }

--- a/src-tauri/tests/forge_token.rs
+++ b/src-tauri/tests/forge_token.rs
@@ -6,7 +6,8 @@
 //! verified manually and reported in the PR body.
 
 use platypusgit_lib::forge::token::{
-    credential_host, credential_line_safe, redact, Secret, CREDENTIAL_USERNAME,
+    credential_host, credential_line_safe, credential_username, redact, Secret,
+    CREDENTIAL_USERNAME,
 };
 
 #[test]
@@ -98,4 +99,62 @@ fn credential_values_with_a_newline_are_refused_not_escaped() {
     assert!(!credential_line_safe("x\0y"));
     assert!(credential_line_safe("ghp_ordinary-token_123=="));
     assert!(credential_line_safe("github.com.platypusgit-forge.invalid"));
+}
+
+// ── Per-account credential slots (#233, forge half) ──────────────────────────
+
+#[test]
+fn the_legacy_slot_username_is_byte_identical_to_what_shipped() {
+    // THE migration invariant. A pre-#233 build stored every forge token under
+    // the bare `platypusgit-forge` username; `None` has to keep resolving to
+    // exactly that string, or every already-signed-in user comes back signed
+    // out of a host they never left.
+    assert_eq!(credential_username(None), "platypusgit-forge");
+    assert_eq!(credential_username(None), CREDENTIAL_USERNAME);
+}
+
+#[test]
+fn each_account_gets_its_own_username_on_the_same_host() {
+    // Two GitHub accounts is the whole point: the host key stays shared (it is
+    // what keeps a forge token off the transport credential), and the username
+    // is what separates the two tokens.
+    let work = credential_username(Some("acc-1"));
+    let personal = credential_username(Some("acc-2"));
+    assert_ne!(work, personal);
+    assert_ne!(work, credential_username(None));
+    // No `{work}` in the panic message. CodeQL's `rust/cleartext-logging` taints
+    // anything a `credential_*` fn returns into a format macro and calls it a
+    // leaked secret — high severity, on a PR about credentials, which is exactly
+    // the alert nobody should be taught to scroll past. It is a false positive:
+    // this is a storage SLOT id (`platypusgit-forge:acc-1`), never a token, and
+    // no token is in scope here. Dropping the message costs nothing, because the
+    // assert_eq below names the exact value it should have had.
+    assert!(work.starts_with(CREDENTIAL_USERNAME));
+    assert_eq!(work, "platypusgit-forge:acc-1");
+}
+
+#[test]
+fn an_empty_account_id_means_the_legacy_slot() {
+    // `undefined`, `null` and `""` all reach Rust as "unspecified" from JS.
+    // Letting `""` mint a third, distinct slot would strand a token in it.
+    assert_eq!(credential_username(Some("")), credential_username(None));
+}
+
+#[test]
+fn an_account_id_with_a_newline_cannot_reach_the_credential_protocol() {
+    // Same injection shape as the token: `username=x\nhost=evil.example` would
+    // store the token against a different host. The account id is ours, but it
+    // round-trips through localStorage, which is user-writable.
+    assert!(!credential_line_safe(&credential_username(Some("x\nhost=evil.example"))));
+    assert!(!credential_line_safe(&credential_username(Some("x\rhost=evil"))));
+    assert!(credential_line_safe(&credential_username(Some("acc-mfx12k-2"))));
+}
+
+#[test]
+fn the_account_slot_never_changes_the_host_key() {
+    // The `.invalid` namespacing is what keeps an API token from overwriting a
+    // push credential; splitting per account must not reintroduce that.
+    for host in ["github.com", "gitlab.com", "ghe.example.com:8443"] {
+        assert!(credential_host(host).ends_with(".platypusgit-forge.invalid"));
+    }
 }

--- a/src/features/forge/ForgeSettings.test.tsx
+++ b/src/features/forge/ForgeSettings.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 
 import { ForgeSettings } from "./ForgeSettings";
 import { useForgeStore } from "./useForgeStore";
+import type { ForgeAccount } from "./forgeAccounts";
 import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
 import { WithDialogs, acceptDialog, dialogTitle, dismissDialog } from "@/test/dialog";
 import type { ForgeDetection } from "@/lib/types";
@@ -24,11 +25,15 @@ const SELF_HOSTED: ForgeDetection = {
   kind: null,
 };
 
+function acct(over: Partial<ForgeAccount> = {}): ForgeAccount {
+  return { id: "acc-1", login: "jonassaa", active: true, ...over };
+}
+
 beforeEach(() => {
   resetInvokeMock();
   localStorage.clear();
   useForgeStore.getState().reset();
-  useForgeStore.setState({ hostKinds: {}, logins: {} });
+  useForgeStore.setState({ hostKinds: {}, accounts: {} });
 });
 
 describe("ForgeSettings", () => {
@@ -127,10 +132,13 @@ describe("ForgeSettings", () => {
   });
 
   it("re-checks a stored token on demand", async () => {
-    useForgeStore.setState({ logins: { "github.com": "jonassaa" }, detection: GH });
+    useForgeStore.setState({
+      accounts: { "github.com": [acct()] },
+      detection: GH,
+    });
     mockInvoke("forge_validate_token", () => ({ login: "somebody-else", name: null }));
     render(<ForgeSettings />);
-    await userEvent.click(screen.getByTestId("forge-recheck-github.com"));
+    await userEvent.click(screen.getByTestId("forge-recheck-github.com-acc-1"));
     await waitFor(() =>
       expect(
         screen.getByTestId("forge-signed-in-github.com"),
@@ -139,36 +147,42 @@ describe("ForgeSettings", () => {
   });
 
   it("confirms before removing a token, and honours cancel", async () => {
-    useForgeStore.setState({ logins: { "github.com": "jonassaa" }, detection: GH });
+    useForgeStore.setState({
+      accounts: { "github.com": [acct()] },
+      detection: GH,
+    });
     mockInvoke("forge_sign_out", () => null);
     render(
       <WithDialogs>
         <ForgeSettings />
       </WithDialogs>,
     );
-    await userEvent.click(screen.getByTestId("forge-remove-github.com"));
+    await userEvent.click(screen.getByTestId("forge-remove-github.com-acc-1"));
     await waitFor(() =>
-      expect(dialogTitle()).toContain("Remove the GitHub token for github.com?"),
+      expect(dialogTitle()).toContain("Remove the GitHub token for jonassaa"),
     );
     await dismissDialog();
     expect(getInvokeCalls().map((c) => c.cmd)).not.toContain("forge_sign_out");
-    expect(useForgeStore.getState().logins["github.com"]).toBe("jonassaa");
+    expect(useForgeStore.getState().accounts["github.com"]).toHaveLength(1);
   });
 
   it("removes the token once confirmed", async () => {
-    useForgeStore.setState({ logins: { "github.com": "jonassaa" }, detection: GH });
+    useForgeStore.setState({
+      accounts: { "github.com": [acct()] },
+      detection: GH,
+    });
     mockInvoke("forge_sign_out", () => null);
     render(
       <WithDialogs>
         <ForgeSettings />
       </WithDialogs>,
     );
-    await userEvent.click(screen.getByTestId("forge-remove-github.com"));
+    await userEvent.click(screen.getByTestId("forge-remove-github.com-acc-1"));
     await waitFor(() => expect(dialogTitle()).toContain("Remove"));
     await acceptDialog();
     await waitFor(() => {
       expect(getInvokeCalls().map((c) => c.cmd)).toContain("forge_sign_out");
-      expect(useForgeStore.getState().logins["github.com"]).toBeUndefined();
+      expect(useForgeStore.getState().accounts["github.com"]).toBeUndefined();
     });
     // Back to offering a token, not stuck claiming to be signed in.
     expect(
@@ -179,11 +193,125 @@ describe("ForgeSettings", () => {
   it("lists a host the user configured even with no repository open", () => {
     useForgeStore.setState({
       hostKinds: { "git.example.com": "GitLab" },
-      logins: { "git.example.com": "aasberg" },
+      accounts: { "git.example.com": [acct({ login: "aasberg" })] },
     });
     render(<ForgeSettings />);
     expect(
       screen.getByTestId("forge-signed-in-git.example.com"),
     ).toHaveTextContent("GitLab — signed in as aasberg");
+  });
+});
+
+describe("ForgeSettings — several accounts on one host (#233)", () => {
+  const twoAccounts = {
+    "github.com": [
+      acct({ id: "acc-work", login: "work" }),
+      acct({ id: "acc-personal", login: "personal", active: false }),
+    ],
+  };
+
+  it("shows every account on the host, not just the active one", () => {
+    useForgeStore.setState({ accounts: twoAccounts, detection: GH });
+    render(<ForgeSettings />);
+    expect(screen.getByTestId("forge-account-github.com-acc-work")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("forge-account-github.com-acc-personal"),
+    ).toBeInTheDocument();
+  });
+
+  it("marks which account the host actually uses", () => {
+    useForgeStore.setState({ accounts: twoAccounts, detection: GH });
+    render(<ForgeSettings />);
+    // Two logins with no "which one am I?" is the confusion the whole feature
+    // exists to remove.
+    expect(screen.getByTestId("forge-account-github.com-acc-work")).toHaveTextContent(
+      "Active",
+    );
+    expect(
+      screen.getByTestId("forge-account-github.com-acc-personal"),
+    ).not.toHaveTextContent("Active");
+  });
+
+  it("switches the active account", async () => {
+    useForgeStore.setState({ accounts: twoAccounts, detection: GH, repoId: "r1" });
+    mockInvoke("forge_detect", () => GH);
+    mockInvoke("forge_token_status", () => ({
+      host: "github.com",
+      signedIn: true,
+      login: null,
+    }));
+    mockInvoke("forge_list_pull_requests", () => []);
+    render(<ForgeSettings />);
+    await userEvent.click(screen.getByTestId("forge-use-github.com-acc-personal"));
+    await waitFor(() =>
+      expect(
+        useForgeStore.getState().accounts["github.com"].find((a) => a.active)?.id,
+      ).toBe("acc-personal"),
+    );
+  });
+
+  it("offers no switch on the account already in use", () => {
+    useForgeStore.setState({ accounts: twoAccounts, detection: GH });
+    render(<ForgeSettings />);
+    expect(
+      screen.queryByTestId("forge-use-github.com-acc-work"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the token field behind an explicit Add account once signed in", async () => {
+    // A password box sitting open under every signed-in host is noise; a
+    // signed-OUT host still gets the field directly (the tests above).
+    useForgeStore.setState({ accounts: twoAccounts, detection: GH });
+    render(<ForgeSettings />);
+    expect(screen.queryByTestId("forge-token-github.com")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByTestId("forge-add-github.com"));
+    expect(screen.getByTestId("forge-token-github.com")).toBeInTheDocument();
+  });
+
+  it("signing out of one account leaves the other on screen", async () => {
+    useForgeStore.setState({ accounts: twoAccounts, detection: GH });
+    mockInvoke("forge_sign_out", () => null);
+    render(
+      <WithDialogs>
+        <ForgeSettings />
+      </WithDialogs>,
+    );
+    await userEvent.click(screen.getByTestId("forge-remove-github.com-acc-work"));
+    await waitFor(() => expect(dialogTitle()).toContain("Remove"));
+    await acceptDialog();
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("forge-account-github.com-acc-work"),
+      ).not.toBeInTheDocument(),
+    );
+    // The eviction the singular host → login map could not avoid.
+    expect(
+      screen.getByTestId("forge-account-github.com-acc-personal"),
+    ).toBeInTheDocument();
+  });
+
+  it("names the account in the removal confirmation", async () => {
+    useForgeStore.setState({ accounts: twoAccounts, detection: GH });
+    mockInvoke("forge_sign_out", () => null);
+    render(
+      <WithDialogs>
+        <ForgeSettings />
+      </WithDialogs>,
+    );
+    await userEvent.click(screen.getByTestId("forge-remove-github.com-acc-personal"));
+    // "Remove the token for github.com?" would be a lie with two accounts on it.
+    await waitFor(() => expect(dialogTitle()).toContain("personal"));
+    await dismissDialog();
+  });
+
+  it("renders the pre-#233 account, whose slot id is null", () => {
+    useForgeStore.setState({
+      accounts: { "github.com": [acct({ id: null, login: "migrated" })] },
+      detection: GH,
+    });
+    render(<ForgeSettings />);
+    expect(
+      screen.getByTestId("forge-account-github.com-default"),
+    ).toHaveTextContent("migrated");
   });
 });

--- a/src/features/forge/ForgeSettings.tsx
+++ b/src/features/forge/ForgeSettings.tsx
@@ -1,21 +1,46 @@
-// The forge-account control, rendered inside the Settings screen (#92).
+// The forge-account control, rendered inside the Settings screen (#92, #233).
 //
 // State lives in `useForgeStore`, NOT `useSettingsStore`: that store is the
 // preferences store (appearance, diff, pull mode), and a list of signed-in hosts
 // is not a preference. Per-feature Zustand is the stated convention.
 //
+// A host has MANY accounts (#233), so this renders one row per account plus one
+// row for adding another — and the active account is marked, because two logins
+// with no "which one am I?" is exactly the confusion the feature exists to
+// remove. Removing an account touches ONE credential slot: the other account on
+// the same host keeps its token.
+//
 // SECURITY: the token is component state and is handed straight to
 // `forge_sign_in`. It is never put in the store (a devtools snapshot or a future
 // persistence middleware would pick it up), never logged, and no command can
-// read one back out.
+// read one back out. An account id is a credential-slot name, never a secret.
 
 import React from "react";
 
-import { PGButton, PGIcon, PGInput, PGSelect, pgConfirm, pgFlash } from "@/design";
+import {
+  PGBadge,
+  PGButton,
+  PGIcon,
+  PGInput,
+  PGSelect,
+  pgConfirm,
+  pgFlash,
+} from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import type { ForgeKind } from "@/lib/types";
+import type { ForgeAccount } from "./forgeAccounts";
 import { forgeLabel } from "./forgeLabels";
 import { useForgeStore } from "./useForgeStore";
+
+/**
+ * A slot id as a testid / React key fragment.
+ *
+ * The pre-#233 slot's id is `null` — see `forgeAccounts.ts` — and `null` makes a
+ * useless key.
+ */
+function slotKey(id: string | null): string {
+  return id ?? "default";
+}
 
 /** Where a user goes to mint the token, per forge. */
 const TOKEN_DOC: Record<ForgeKind, string> = {
@@ -26,7 +51,7 @@ const TOKEN_DOC: Record<ForgeKind, string> = {
 export function ForgeSettings() {
   const repoId = useRepoStore((s) => s.current?.id ?? null);
   const detection = useForgeStore((s) => s.detection);
-  const logins = useForgeStore((s) => s.logins);
+  const accounts = useForgeStore((s) => s.accounts);
   const hostKinds = useForgeStore((s) => s.hostKinds);
   const authBusy = useForgeStore((s) => s.authBusy);
   const signedIn = useForgeStore((s) => s.signedIn);
@@ -47,15 +72,15 @@ export function ForgeSettings() {
     const set = new Set<string>();
     if (detection) set.add(detection.host);
     Object.keys(hostKinds).forEach((h) => set.add(h));
-    Object.keys(logins).forEach((h) => set.add(h));
+    Object.keys(accounts).forEach((h) => set.add(h));
     return [...set].sort();
-  }, [detection, hostKinds, logins]);
+  }, [detection, hostKinds, accounts]);
 
   return (
     <div data-testid="settings-forge">
       <Section
         title="Integrations"
-        subtitle="Pull and merge requests. A forge API token is a separate credential from the one git pushes with — it is stored under its own key and never replaces it."
+        subtitle="Pull and merge requests. A forge API token is a separate credential from the one git pushes with — it is stored under its own key and never replaces it. A host can hold several accounts; the active one is what pull requests are listed and opened as."
       >
         {hosts.length === 0 && (
           <Row
@@ -65,10 +90,10 @@ export function ForgeSettings() {
           />
         )}
         {hosts.map((host) => (
-          <HostRow
+          <HostSection
             key={host}
             host={host}
-            login={logins[host] ?? null}
+            accounts={accounts[host] ?? []}
             kind={hostKinds[host] ?? builtinKindFor(host)}
             busy={authBusy}
             isCurrent={detection?.host === host}
@@ -103,31 +128,181 @@ function builtinKindFor(host: string): ForgeKind | undefined {
   return undefined;
 }
 
-function HostRow({
+/** Every account on one host, then the row that adds another. */
+function HostSection({
   host,
-  login,
+  accounts,
   kind,
   busy,
   isCurrent,
   currentSignedIn,
 }: {
   host: string;
-  login: string | null;
+  accounts: ForgeAccount[];
   kind: ForgeKind | undefined;
   busy: boolean;
   isCurrent: boolean;
   currentSignedIn: boolean;
 }) {
-  const [token, setToken] = React.useState("");
   const [pickedKind, setPickedKind] = React.useState<ForgeKind>(kind ?? "GitHub");
-
-  // A self-hosted host has no login yet AND no known forge — asking which one it
-  // is has to come before asking for a token, or the token goes to the wrong API.
+  // A self-hosted host has no known forge — asking which one it is has to come
+  // before asking for a token, or the token goes to the wrong API.
   const needsKind = !kind;
   const effectiveKind = kind ?? pickedKind;
-  // A stored login is the strongest "signed in" signal we have without a network
-  // call; the current host also has a live presence check.
-  const isSignedIn = !!login || (isCurrent && currentSignedIn);
+
+  return (
+    <>
+      {accounts.map((account) => (
+        <AccountRow
+          key={slotKey(account.id)}
+          host={host}
+          account={account}
+          kind={effectiveKind}
+          busy={busy}
+          isCurrent={isCurrent}
+        />
+      ))}
+      <AddAccountRow
+        host={host}
+        hasAccounts={accounts.length > 0}
+        needsKind={needsKind}
+        effectiveKind={effectiveKind}
+        pickedKind={pickedKind}
+        setPickedKind={setPickedKind}
+        busy={busy}
+        // Only read when the host has no accounts: a live token with no account
+        // record (cleared localStorage, keychain intact) is worth saying out
+        // loud, because pull requests keep working while Settings shows nothing.
+        hasUnnamedToken={isCurrent && currentSignedIn}
+      />
+    </>
+  );
+}
+
+function AccountRow({
+  host,
+  account,
+  kind,
+  busy,
+  isCurrent,
+}: {
+  host: string;
+  account: ForgeAccount;
+  kind: ForgeKind;
+  busy: boolean;
+  isCurrent: boolean;
+}) {
+  const key = slotKey(account.id);
+
+  const remove = async () => {
+    if (
+      !(await pgConfirm({
+        title: `Remove the ${forgeLabel(kind)} token for ${account.login} on ${host}?`,
+        body: "Pull and merge requests open as this account stop loading until you add a token again. Any other account on this host, and your git push credential, are separate credentials and are not touched.",
+        danger: true,
+        confirmLabel: "Remove token",
+      }))
+    ) {
+      return;
+    }
+    await useForgeStore.getState().signOut(host, account.id);
+    pgFlash(`Removed the token for ${account.login} on ${host}`);
+  };
+
+  return (
+    <Row
+      label={account.login}
+      testId={`forge-account-${host}-${key}`}
+      hint={
+        <span
+          // The active account answers "is this host signed in", so it keeps the
+          // per-host testid the rest of the app and the e2e suite look for.
+          data-testid={account.active ? `forge-signed-in-${host}` : undefined}
+        >
+          <PGIcon
+            name="check"
+            size={11}
+            style={{ color: "var(--git-added)", marginRight: 4 }}
+          />
+          {forgeLabel(kind)} — signed in as{" "}
+          <code style={{ fontFamily: "var(--font-mono)" }}>{account.login}</code>
+          {" on "}
+          {host}
+        </span>
+      }
+      badge={
+        account.active ? (
+          <PGBadge tone="accent" style={{ marginLeft: 8 }}>
+            Active
+          </PGBadge>
+        ) : null
+      }
+      control={
+        <div style={{ display: "flex", gap: 6 }}>
+          {!account.active && (
+            <PGButton
+              size="sm"
+              variant="default"
+              onClick={() =>
+                void useForgeStore.getState().switchAccount(host, account.id)
+              }
+              disabled={busy}
+              data-testid={`forge-use-${host}-${key}`}
+            >
+              Use
+            </PGButton>
+          )}
+          <PGButton
+            size="sm"
+            variant={account.active && isCurrent ? "default" : "ghost"}
+            onClick={() =>
+              void useForgeStore.getState().validate(host, kind, account.id)
+            }
+            disabled={busy}
+            data-testid={`forge-recheck-${host}-${key}`}
+          >
+            Re-check
+          </PGButton>
+          <PGButton
+            size="sm"
+            variant="ghost"
+            onClick={() => void remove()}
+            disabled={busy}
+            data-testid={`forge-remove-${host}-${key}`}
+          >
+            Remove token
+          </PGButton>
+        </div>
+      }
+    />
+  );
+}
+
+function AddAccountRow({
+  host,
+  hasAccounts,
+  needsKind,
+  effectiveKind,
+  pickedKind,
+  setPickedKind,
+  busy,
+  hasUnnamedToken,
+}: {
+  host: string;
+  hasAccounts: boolean;
+  needsKind: boolean;
+  effectiveKind: ForgeKind;
+  pickedKind: ForgeKind;
+  setPickedKind: (k: ForgeKind) => void;
+  busy: boolean;
+  hasUnnamedToken: boolean;
+}) {
+  const [token, setToken] = React.useState("");
+  // A password box sitting permanently open under every signed-in host is
+  // noise; a host with nothing signed in still gets the field directly, because
+  // that IS the thing to do there.
+  const [open, setOpen] = React.useState(false);
+  const showField = !hasAccounts || open;
 
   const submit = async () => {
     const value = token.trim();
@@ -136,74 +311,31 @@ function HostRow({
     const ok = await useForgeStore.getState().signIn(host, effectiveKind, value);
     // Clear the field either way: a rejected token must not sit in the DOM.
     setToken("");
-    if (ok) pgFlash(`Signed in to ${host}`);
-  };
-
-  const remove = async () => {
-    if (
-      !(await pgConfirm({
-        title: `Remove the ${forgeLabel(effectiveKind)} token for ${host}?`,
-        body: "Pull and merge requests for this host stop loading until you add a token again. Your git push credential is a separate credential and is not touched.",
-        danger: true,
-        confirmLabel: "Remove token",
-      }))
-    ) {
-      return;
+    if (ok) {
+      setOpen(false);
+      pgFlash(`Signed in to ${host}`);
     }
-    await useForgeStore.getState().signOut(host);
-    pgFlash(`Removed the token for ${host}`);
   };
 
   return (
     <Row
       label={host}
       hint={
-        isSignedIn ? (
-          <span data-testid={`forge-signed-in-${host}`}>
-            <PGIcon
-              name="check"
-              size={11}
-              style={{ color: "var(--git-added)", marginRight: 4 }}
-            />
-            {forgeLabel(effectiveKind)} — signed in
-            {login ? (
-              <>
-                {" as "}
-                <code style={{ fontFamily: "var(--font-mono)" }}>{login}</code>
-              </>
-            ) : null}
-          </span>
+        hasAccounts ? (
+          "Add another account on this host — a work login and a personal one can both be signed in, and you pick which one is active."
         ) : (
           <span data-testid={`forge-signed-out-${host}`}>
             {needsKind
               ? "platypusgit cannot tell a self-hosted GitHub from a GitLab by its URL — pick the forge, then paste a token."
               : TOKEN_DOC[effectiveKind]}
+            {hasUnnamedToken
+              ? " A token is already stored for this host but not the account it belongs to — sign in again to name it."
+              : ""}
           </span>
         )
       }
       control={
-        isSignedIn ? (
-          <div style={{ display: "flex", gap: 6 }}>
-            <PGButton
-              size="sm"
-              variant="default"
-              onClick={() => void useForgeStore.getState().validate(host, effectiveKind)}
-              disabled={busy}
-              data-testid={`forge-recheck-${host}`}
-            >
-              Re-check
-            </PGButton>
-            <PGButton
-              size="sm"
-              variant="ghost"
-              onClick={() => void remove()}
-              disabled={busy}
-              data-testid={`forge-remove-${host}`}
-            >
-              Remove token
-            </PGButton>
-          </div>
-        ) : (
+        showField ? (
           <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
             {needsKind && (
               <PGSelect
@@ -241,6 +373,16 @@ function HostRow({
               Sign in
             </PGButton>
           </div>
+        ) : (
+          <PGButton
+            size="sm"
+            variant="default"
+            onClick={() => setOpen(true)}
+            disabled={busy}
+            data-testid={`forge-add-${host}`}
+          >
+            Add account
+          </PGButton>
         )
       }
     />
@@ -311,13 +453,19 @@ function Row({
   label,
   hint,
   control,
+  badge,
+  testId,
 }: {
   label: string;
   hint?: React.ReactNode;
   control: React.ReactNode;
+  /** Sits beside the label — "Active", not a second line of prose. */
+  badge?: React.ReactNode;
+  testId?: string;
 }) {
   return (
     <div
+      data-testid={testId}
       style={{
         display: "flex",
         alignItems: "flex-start",
@@ -329,6 +477,8 @@ function Row({
       <div style={{ flex: 1, minWidth: 0 }}>
         <div
           style={{
+            display: "flex",
+            alignItems: "center",
             fontSize: "var(--fs-13)",
             color: "var(--fg-0)",
             fontWeight: 500,
@@ -336,6 +486,7 @@ function Row({
           }}
         >
           {label}
+          {badge}
         </div>
         {hint && (
           <div

--- a/src/features/forge/forgeAccounts.test.ts
+++ b/src/features/forge/forgeAccounts.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  activeAccount,
+  activeAccountId,
+  newAccountId,
+  parseHosts,
+  removeAccount,
+  setActiveAccount,
+  upsertAccount,
+  type ForgeAccount,
+} from "./forgeAccounts";
+
+/** The blob a pre-#233 build wrote: one login per host, singular. */
+function legacyBlob(logins: Record<string, string>, hostKinds = {}) {
+  return JSON.stringify({ hostKinds, logins });
+}
+
+function account(over: Partial<ForgeAccount> = {}): ForgeAccount {
+  return { id: "acc-1", login: "alice", active: false, ...over };
+}
+
+describe("parseHosts — migration from the singular logins map", () => {
+  it("keeps a signed-in account signed in, in the LEGACY credential slot", () => {
+    // This is the whole migration. `id: null` is not cosmetic: it is what tells
+    // the backend to read the token from `username=platypusgit-forge`, where a
+    // pre-#233 build put it. Any other id looks in a slot that holds nothing,
+    // and the user is silently signed out of a host they never left.
+    const hosts = parseHosts(legacyBlob({ "github.com": "jonassaa" }));
+    expect(hosts.accounts["github.com"]).toEqual([
+      { id: null, login: "jonassaa", active: true },
+    ]);
+  });
+
+  it("migrates every host in the map, not just the first", () => {
+    const hosts = parseHosts(
+      legacyBlob({ "github.com": "jonassaa", "gitlab.com": "aasberg" }),
+    );
+    expect(hosts.accounts["github.com"]?.[0]?.login).toBe("jonassaa");
+    expect(hosts.accounts["gitlab.com"]?.[0]?.login).toBe("aasberg");
+    expect(activeAccountId(hosts.accounts, "gitlab.com")).toBeNull();
+  });
+
+  it("carries hostKinds across untouched", () => {
+    const hosts = parseHosts(
+      legacyBlob({ "git.example.com": "aasberg" }, { "git.example.com": "GitLab" }),
+    );
+    expect(hosts.hostKinds).toEqual({ "git.example.com": "GitLab" });
+  });
+
+  it("migrates nothing from an empty logins map", () => {
+    expect(parseHosts(legacyBlob({}))).toEqual({ hostKinds: {}, accounts: {} });
+  });
+
+  it("drops a login that is not a non-empty string", () => {
+    const raw = JSON.stringify({
+      logins: { "github.com": "", "gitlab.com": 7, "git.example.com": null },
+    });
+    expect(parseHosts(raw).accounts).toEqual({});
+  });
+});
+
+describe("parseHosts — the cases the old parser already tolerated", () => {
+  it("returns empty for an absent blob", () => {
+    expect(parseHosts(null)).toEqual({ hostKinds: {}, accounts: {} });
+  });
+
+  it("returns empty for a corrupt blob rather than throwing", () => {
+    expect(parseHosts("{not json")).toEqual({ hostKinds: {}, accounts: {} });
+  });
+
+  it("returns empty for a blob that parses to a non-object", () => {
+    expect(parseHosts("42")).toEqual({ hostKinds: {}, accounts: {} });
+    expect(parseHosts("null")).toEqual({ hostKinds: {}, accounts: {} });
+    expect(parseHosts('"a string"')).toEqual({ hostKinds: {}, accounts: {} });
+  });
+
+  it("returns empty for a blob with neither key", () => {
+    expect(parseHosts("{}")).toEqual({ hostKinds: {}, accounts: {} });
+  });
+
+  it("ignores a hostKinds that is not an object", () => {
+    expect(parseHosts(JSON.stringify({ hostKinds: "GitHub" })).hostKinds).toEqual({});
+  });
+});
+
+describe("parseHosts — the new shape", () => {
+  it("round-trips what saveHosts writes", () => {
+    const raw = JSON.stringify({
+      hostKinds: { "github.com": "GitHub" },
+      accounts: {
+        "github.com": [
+          { id: null, login: "work", active: false },
+          { id: "acc-2", login: "personal", active: true },
+        ],
+      },
+    });
+    expect(parseHosts(raw).accounts["github.com"]).toEqual([
+      { id: null, login: "work", active: false },
+      { id: "acc-2", login: "personal", active: true },
+    ]);
+  });
+
+  it("makes the first account active when the blob flags none", () => {
+    const raw = JSON.stringify({
+      accounts: {
+        "github.com": [
+          { id: "acc-1", login: "work" },
+          { id: "acc-2", login: "personal" },
+        ],
+      },
+    });
+    // "No active account" would mean every API call falls back to the legacy
+    // slot — i.e. a host with two accounts would use neither.
+    expect(parseHosts(raw).accounts["github.com"]).toEqual([
+      { id: "acc-1", login: "work", active: true },
+      { id: "acc-2", login: "personal", active: false },
+    ]);
+  });
+
+  it("keeps exactly one active account when the blob flags two", () => {
+    const raw = JSON.stringify({
+      accounts: {
+        "github.com": [
+          { id: "acc-1", login: "work", active: true },
+          { id: "acc-2", login: "personal", active: true },
+        ],
+      },
+    });
+    const list = parseHosts(raw).accounts["github.com"];
+    expect(list.filter((a) => a.active)).toHaveLength(1);
+    expect(list[0].active).toBe(true);
+  });
+
+  it("drops entries that are not usable accounts, keeping the rest", () => {
+    const raw = JSON.stringify({
+      accounts: {
+        "github.com": [
+          null,
+          "alice",
+          { login: 3 },
+          { id: 5, login: "bob" },
+          { id: "acc-9", login: "carol", active: true },
+        ],
+      },
+    });
+    expect(parseHosts(raw).accounts["github.com"]).toEqual([
+      { id: "acc-9", login: "carol", active: true },
+    ]);
+  });
+
+  it("drops a duplicate id rather than storing two rows for one slot", () => {
+    const raw = JSON.stringify({
+      accounts: {
+        "github.com": [
+          { id: "acc-1", login: "work", active: true },
+          { id: "acc-1", login: "stale", active: false },
+        ],
+      },
+    });
+    expect(parseHosts(raw).accounts["github.com"]).toHaveLength(1);
+  });
+
+  it("drops a host whose account list is not an array, or ends up empty", () => {
+    const raw = JSON.stringify({ accounts: { "github.com": "alice", "gitlab.com": [] } });
+    expect(parseHosts(raw).accounts).toEqual({});
+  });
+
+  it("prefers accounts over logins when a blob somehow carries both", () => {
+    // A downgrade-then-upgrade writes the old key back. The new key is the one
+    // that can express two accounts, so it wins where both name the same host —
+    // and a host only the old key knows is still migrated.
+    const raw = JSON.stringify({
+      logins: { "github.com": "stale", "gitlab.com": "aasberg" },
+      accounts: { "github.com": [{ id: "acc-1", login: "current", active: true }] },
+    });
+    const { accounts } = parseHosts(raw);
+    expect(accounts["github.com"]).toEqual([
+      { id: "acc-1", login: "current", active: true },
+    ]);
+    expect(accounts["gitlab.com"]).toEqual([
+      { id: null, login: "aasberg", active: true },
+    ]);
+  });
+});
+
+describe("activeAccount / activeAccountId", () => {
+  it("answers with the flagged account", () => {
+    const accounts = {
+      "github.com": [
+        account({ id: "acc-1", login: "work" }),
+        account({ id: "acc-2", login: "personal", active: true }),
+      ],
+    };
+    expect(activeAccount(accounts, "github.com")?.login).toBe("personal");
+    expect(activeAccountId(accounts, "github.com")).toBe("acc-2");
+  });
+
+  it("falls back to the legacy slot for a host with no accounts at all", () => {
+    // localStorage cleared, keychain intact: the honest guess is the slot a
+    // pre-#233 build used, which is also where a single stored token lives.
+    expect(activeAccount({}, "github.com")).toBeNull();
+    expect(activeAccountId({}, "github.com")).toBeNull();
+  });
+});
+
+describe("upsertAccount", () => {
+  it("appends a new account and makes it the active one", () => {
+    const list = [account({ id: "acc-1", login: "work", active: true })];
+    const next = upsertAccount(list, { id: "acc-2", login: "personal" });
+    expect(next).toEqual([
+      { id: "acc-1", login: "work", active: false },
+      { id: "acc-2", login: "personal", active: true },
+    ]);
+  });
+
+  it("replaces the entry with the same id in place", () => {
+    const list = [
+      account({ id: "acc-1", login: "work", active: true }),
+      account({ id: "acc-2", login: "personal" }),
+    ];
+    const next = upsertAccount(list, { id: "acc-1", login: "renamed" });
+    expect(next.map((a) => a.login)).toEqual(["renamed", "personal"]);
+    expect(next[0].active).toBe(true);
+  });
+
+  it("collapses a second sign-in for a login that already has a slot", () => {
+    // Pasting a fresh token for an account whose old one expired must not leave
+    // the host showing the same login twice.
+    const list = [account({ id: null, login: "alice", active: true })];
+    const next = upsertAccount(list, { id: "acc-7", login: "alice" });
+    expect(next).toEqual([{ id: "acc-7", login: "alice", active: true }]);
+  });
+});
+
+describe("setActiveAccount", () => {
+  it("moves the flag without reordering or evicting anything", () => {
+    const list = [
+      account({ id: "acc-1", login: "work", active: true }),
+      account({ id: "acc-2", login: "personal" }),
+    ];
+    expect(setActiveAccount(list, "acc-2")).toEqual([
+      { id: "acc-1", login: "work", active: false },
+      { id: "acc-2", login: "personal", active: true },
+    ]);
+  });
+
+  it("can activate the legacy slot, whose id is null", () => {
+    const list = [
+      account({ id: null, login: "work" }),
+      account({ id: "acc-2", login: "personal", active: true }),
+    ];
+    expect(setActiveAccount(list, null)[0].active).toBe(true);
+  });
+
+  it("leaves the list alone when the id is not in it", () => {
+    const list = [account({ id: "acc-1", login: "work", active: true })];
+    expect(setActiveAccount(list, "nope")).toEqual(list);
+  });
+});
+
+describe("removeAccount", () => {
+  it("removes only the named slot and promotes a survivor to active", () => {
+    const list = [
+      account({ id: "acc-1", login: "work", active: true }),
+      account({ id: "acc-2", login: "personal" }),
+    ];
+    // Signing out of one account must not sign the user out of the other — the
+    // bug the singular `delete logins[host]` could not avoid.
+    expect(removeAccount(list, "acc-1")).toEqual([
+      { id: "acc-2", login: "personal", active: true },
+    ]);
+  });
+
+  it("removes the legacy slot by its null id", () => {
+    const list = [
+      account({ id: null, login: "work", active: true }),
+      account({ id: "acc-2", login: "personal" }),
+    ];
+    expect(removeAccount(list, null).map((a) => a.id)).toEqual(["acc-2"]);
+  });
+
+  it("keeps the active flag where it is when another account goes", () => {
+    const list = [
+      account({ id: "acc-1", login: "work", active: true }),
+      account({ id: "acc-2", login: "personal" }),
+    ];
+    expect(removeAccount(list, "acc-2")).toEqual([
+      { id: "acc-1", login: "work", active: true },
+    ]);
+  });
+});
+
+describe("newAccountId", () => {
+  it("never collides and is never the legacy slot", () => {
+    const ids = new Set([newAccountId(), newAccountId(), newAccountId()]);
+    expect(ids.size).toBe(3);
+    for (const id of ids) expect(id).toBeTruthy();
+  });
+
+  it("is safe to carry in git's line-based credential protocol", () => {
+    // The id becomes part of `username=` in the credential protocol, which the
+    // backend refuses if it carries a newline. Generating one that cannot be
+    // stored would fail at the last step of a sign-in.
+    expect(newAccountId()).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+});

--- a/src/features/forge/forgeAccounts.ts
+++ b/src/features/forge/forgeAccounts.ts
@@ -1,0 +1,229 @@
+// Forge accounts: host → MANY, with one active (#233, forge half).
+//
+// ## What changed and why the id matters
+//
+// Until now `pg-forge-hosts` persisted `logins: Record<string, string>` — one
+// login per host, singular. Two GitHub accounts (the mundane work/personal
+// split this issue is about) were not expressible at all, because the forge
+// token they authenticate with was stored under a single per-host credential
+// key.
+//
+// So an account is now a SLOT, and `id` is the slot's name. It is the
+// discriminator the backend appends to the credential username
+// (`platypusgit-forge:<id>`), which is what lets one host hold two tokens
+// without either overwriting the other.
+//
+// **`id: null` is the pre-#233 slot** — the bare `platypusgit-forge` username a
+// released build already wrote real tokens under. Migration therefore lands the
+// existing login on `id: null` and nothing else: any other id would point at a
+// slot that has never held anything, and a user who never signed out would come
+// back signed out. Nothing ever mints `null` for a new account; it only ever
+// arrives from migration and is only ever read.
+//
+// ## Why the active account is a flag, not a pointer
+//
+// A `Record<host, accountId>` pointer has two states this does not: dangling
+// (naming an account that was removed) and ambiguous (`null` meaning both "the
+// legacy slot" and "nothing recorded"). A flag on the row cannot dangle, and
+// `parseHosts` normalises "none flagged" and "two flagged" to exactly one, so
+// every host with accounts has an active one by construction.
+//
+// Nothing here touches a token. The id is a storage slot name, never a secret,
+// and no command returns a token to compare against.
+
+import type { ForgeKind } from "@/lib/types";
+
+/** One signed-in forge account. */
+export interface ForgeAccount {
+  /**
+   * Credential-slot discriminator, or `null` for the pre-#233 slot.
+   *
+   * Deliberately NOT the login: a forge login can be renamed while the token
+   * stays valid, and a renamed login would orphan the stored token.
+   */
+  id: string | null;
+  /** Who the slot's token authenticates as. Display only. */
+  login: string;
+  /** Whether API calls for this host use this account. Exactly one per host. */
+  active: boolean;
+}
+
+/** The whole `pg-forge-hosts` blob. */
+export interface PersistedHosts {
+  /** Host → forge, for self-hosted instances a URL cannot classify. */
+  hostKinds: Record<string, ForgeKind>;
+  /** Host → its accounts, so "signed in as X" needs no network call at startup. */
+  accounts: Record<string, ForgeAccount[]>;
+}
+
+/** One localStorage key for the whole account map. */
+export const HOSTS_KEY = "pg-forge-hosts";
+
+const EMPTY: PersistedHosts = { hostKinds: {}, accounts: {} };
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function nonEmptyString(v: unknown): v is string {
+  return typeof v === "string" && v !== "";
+}
+
+/**
+ * Coerce one host's stored value into a usable account list.
+ *
+ * Every rule here exists because the blob is user-writable state that survives
+ * across versions: an entry that is not an object, has no login, or repeats a
+ * slot id is dropped rather than rendered as a broken row.
+ */
+export function normalizeAccounts(value: unknown): ForgeAccount[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string | null>();
+  const list: ForgeAccount[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) continue;
+    if (!nonEmptyString(entry.login)) continue;
+    const id =
+      entry.id === null || entry.id === undefined
+        ? null
+        : nonEmptyString(entry.id)
+          ? entry.id
+          : undefined;
+    if (id === undefined) continue;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    list.push({ id, login: entry.login, active: entry.active === true });
+  }
+  return withOneActive(list);
+}
+
+/** Exactly one active account, or none when the list is empty. */
+function withOneActive(list: ForgeAccount[]): ForgeAccount[] {
+  if (list.length === 0) return list;
+  const i = list.findIndex((a) => a.active);
+  const active = i === -1 ? 0 : i;
+  return list.map((a, n) => (a.active === (n === active) ? a : { ...a, active: n === active }));
+}
+
+/**
+ * Read the blob, migrating the pre-#233 `logins` map.
+ *
+ * Pure and takes the raw string, so the migration is testable without touching
+ * localStorage. Every failure mode the old parser tolerated — absent, corrupt,
+ * missing keys — still yields a working empty state rather than an exception:
+ * a bad blob must never stop the feature from working.
+ */
+export function parseHosts(raw: string | null): PersistedHosts {
+  if (!raw) return { ...EMPTY };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ...EMPTY };
+  }
+  if (!isRecord(parsed)) return { ...EMPTY };
+
+  const hostKinds = isRecord(parsed.hostKinds)
+    ? (parsed.hostKinds as Record<string, ForgeKind>)
+    : {};
+
+  const accounts: Record<string, ForgeAccount[]> = {};
+
+  // The old key first, so the new one can overwrite a host both describe: only
+  // `accounts` can express two accounts, so it is the more informed of the two.
+  if (isRecord(parsed.logins)) {
+    for (const [host, login] of Object.entries(parsed.logins)) {
+      if (!nonEmptyString(login)) continue;
+      // `id: null` — the slot a released build actually stored the token in.
+      accounts[host] = [{ id: null, login, active: true }];
+    }
+  }
+  if (isRecord(parsed.accounts)) {
+    for (const [host, value] of Object.entries(parsed.accounts)) {
+      const list = normalizeAccounts(value);
+      if (list.length > 0) accounts[host] = list;
+      else delete accounts[host];
+    }
+  }
+
+  return { hostKinds, accounts };
+}
+
+/** The account API calls for `host` use, or null when the host has none. */
+export function activeAccount(
+  accounts: Record<string, ForgeAccount[]>,
+  host: string,
+): ForgeAccount | null {
+  return (accounts[host] ?? []).find((a) => a.active) ?? null;
+}
+
+/**
+ * The slot id to hand the backend for `host`.
+ *
+ * `null` for a host with no accounts is not a gap: it names the pre-#233 slot,
+ * which is where a token lives when the account list was lost (cleared
+ * localStorage, a fresh profile) but the credential helper still holds one.
+ */
+export function activeAccountId(
+  accounts: Record<string, ForgeAccount[]>,
+  host: string,
+): string | null {
+  return activeAccount(accounts, host)?.id ?? null;
+}
+
+let seq = 0;
+
+/**
+ * A fresh slot id.
+ *
+ * Time-based, like `newIdentityId`, so two accounts added in one session cannot
+ * collide. Restricted to characters git's line-based credential protocol can
+ * carry — the id ends up inside `username=`, and the backend refuses a value
+ * with a newline in it.
+ */
+export function newAccountId(): string {
+  seq += 1;
+  return `acc-${Date.now().toString(36)}-${seq}`;
+}
+
+/**
+ * Add or replace an account, and make it the active one.
+ *
+ * Matching is by id first, then by login: pasting a fresh token for an account
+ * whose old one expired arrives as a NEW slot, and leaving the stale row would
+ * show the same login twice. The caller erases the token of any slot this
+ * collapses — see `useForgeStore.signIn`.
+ */
+export function upsertAccount(
+  list: readonly ForgeAccount[],
+  entry: { id: string | null; login: string },
+): ForgeAccount[] {
+  const next: ForgeAccount = { id: entry.id, login: entry.login, active: true };
+  const known = list.some((a) => a.id === entry.id);
+  const kept = list.filter((a) => a.id === entry.id || a.login !== entry.login);
+  const merged = known ? kept.map((a) => (a.id === entry.id ? next : a)) : [...kept, next];
+  // The account just signed in wins the flag, not whichever row held it before.
+  return setActiveAccount(merged, entry.id);
+}
+
+/** Point the host at another account. A miss is a no-op, never a wipe. */
+export function setActiveAccount(
+  list: readonly ForgeAccount[],
+  id: string | null,
+): ForgeAccount[] {
+  if (!list.some((a) => a.id === id)) return [...list];
+  return list.map((a) => (a.active === (a.id === id) ? a : { ...a, active: a.id === id }));
+}
+
+/**
+ * Drop one slot, promoting a survivor when the active one went.
+ *
+ * Signing out of one account must not sign the user out of the others on the
+ * same host — the failure the singular `delete logins[host]` could not avoid.
+ */
+export function removeAccount(
+  list: readonly ForgeAccount[],
+  id: string | null,
+): ForgeAccount[] {
+  return withOneActive(list.filter((a) => a.id !== id).map((a) => ({ ...a })));
+}

--- a/src/features/forge/useForgeStore.test.ts
+++ b/src/features/forge/useForgeStore.test.ts
@@ -3,7 +3,13 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
 import type { ForgeDetection, PullRequest } from "@/lib/types";
 import { useAuthStore } from "@/features/auth/useAuthStore";
+import type { ForgeAccount } from "./forgeAccounts";
 import { useForgeStore } from "./useForgeStore";
+
+/** One signed-in account, active unless said otherwise. */
+function acct(over: Partial<ForgeAccount> = {}): ForgeAccount {
+  return { id: "acc-1", login: "jonassaa", active: true, ...over };
+}
 
 /** Answer everything `useRepoStore.refreshAll` fans out to. */
 function mockRefreshAll() {
@@ -71,7 +77,7 @@ function reset() {
     selected: null,
     checks: {},
     hostKinds: {},
-    logins: {},
+    accounts: {},
     loading: false,
     creating: false,
     checkingOut: false,
@@ -157,7 +163,7 @@ describe("detect + gate", () => {
   it("passes the persisted host-kind map to detection", async () => {
     localStorage.setItem(
       "pg-forge-hosts",
-      JSON.stringify({ hostKinds: { "git.example.com": "GitLab" }, logins: {} }),
+      JSON.stringify({ hostKinds: { "git.example.com": "GitLab" }, accounts: {} }),
     );
     useForgeStore.setState({ hostKinds: { "git.example.com": "GitLab" } });
     mockInvoke("forge_detect", () => ({ ...SELF_HOSTED, kind: "GitLab" }));
@@ -453,20 +459,64 @@ describe("create", () => {
 describe("accounts", () => {
   beforeEach(reset);
 
-  it("signIn stores the login and the host's kind, and never the token", async () => {
+  it("signIn stores the account and the host's kind, and never the token", async () => {
     mockInvoke("forge_sign_in", () => ({ login: "jonassaa", name: "Jonas" }));
     expect(
       await useForgeStore.getState().signIn("github.com", "GitHub", "ghp_secret"),
     ).toBe(true);
     const s = useForgeStore.getState();
-    expect(s.logins["github.com"]).toBe("jonassaa");
+    expect(s.accounts["github.com"]?.[0]).toMatchObject({
+      login: "jonassaa",
+      active: true,
+    });
     expect(s.hostKinds["github.com"]).toBe("GitHub");
     // Nothing in the store, and nothing in localStorage, may hold the token.
     expect(JSON.stringify(s)).not.toContain("ghp_secret");
     expect(localStorage.getItem("pg-forge-hosts")).not.toContain("ghp_secret");
   });
 
-  it("signIn reports a rejected token and stores no login", async () => {
+  it("signIn names the credential slot it wants the token stored in", async () => {
+    // The slot id is what lets a second account on the same host have its own
+    // token instead of overwriting the first one's.
+    mockInvoke("forge_sign_in", () => ({ login: "jonassaa", name: null }));
+    await useForgeStore.getState().signIn("github.com", "GitHub", "ghp_x");
+    const call = getInvokeCalls().find((c) => c.cmd === "forge_sign_in");
+    const id = useForgeStore.getState().accounts["github.com"][0].id;
+    expect(id).toBeTruthy();
+    expect(call?.args.account).toBe(id);
+  });
+
+  it("keeps BOTH accounts when a second login signs in to the same host", async () => {
+    // The whole point of #233's forge half: work and personal on github.com.
+    useForgeStore.setState({
+      accounts: { "github.com": [acct({ id: "acc-work", login: "work" })] },
+    });
+    mockInvoke("forge_sign_in", () => ({ login: "personal", name: null }));
+    await useForgeStore.getState().signIn("github.com", "GitHub", "ghp_2");
+    const list = useForgeStore.getState().accounts["github.com"];
+    expect(list.map((a) => a.login)).toEqual(["work", "personal"]);
+    // The one you just signed in to is the one you meant to use.
+    expect(list.find((a) => a.active)?.login).toBe("personal");
+  });
+
+  it("collapses a re-sign-in for a login that already has a slot, erasing the old one", async () => {
+    // Pasting a fresh token for an expired one must not leave two "work" rows —
+    // and the token in the slot it replaces must not linger in the keychain.
+    useForgeStore.setState({
+      accounts: { "github.com": [acct({ id: null, login: "work" })] },
+    });
+    mockInvoke("forge_sign_in", () => ({ login: "work", name: null }));
+    mockInvoke("forge_sign_out", () => null);
+    await useForgeStore.getState().signIn("github.com", "GitHub", "ghp_new");
+    const list = useForgeStore.getState().accounts["github.com"];
+    expect(list).toHaveLength(1);
+    expect(list[0].login).toBe("work");
+    expect(list[0].id).not.toBeNull();
+    const out = getInvokeCalls().find((c) => c.cmd === "forge_sign_out");
+    expect(out?.args).toEqual({ host: "github.com", account: null });
+  });
+
+  it("signIn reports a rejected token and stores no account", async () => {
     mockInvoke("forge_sign_in", () => {
       throw { kind: "ForgeAuth", message: "github.com" };
     });
@@ -474,9 +524,22 @@ describe("accounts", () => {
       await useForgeStore.getState().signIn("github.com", "GitHub", "bad"),
     ).toBe(false);
     const s = useForgeStore.getState();
-    expect(s.logins["github.com"]).toBeUndefined();
+    expect(s.accounts["github.com"]).toBeUndefined();
     expect(s.error).toContain("github.com");
     expect(s.authBusy).toBe(false);
+  });
+
+  it("a rejected second token leaves the first account untouched", async () => {
+    useForgeStore.setState({
+      accounts: { "github.com": [acct({ id: "acc-work", login: "work" })] },
+    });
+    mockInvoke("forge_sign_in", () => {
+      throw { kind: "ForgeAuth", message: "github.com" };
+    });
+    await useForgeStore.getState().signIn("github.com", "GitHub", "bad");
+    expect(useForgeStore.getState().accounts["github.com"]).toEqual([
+      { id: "acc-work", login: "work", active: true },
+    ]);
   });
 
   it("signIn surfaces a token-store failure so it is not silently lost", async () => {
@@ -494,41 +557,137 @@ describe("accounts", () => {
     expect(useForgeStore.getState().error).toContain("credential helper");
   });
 
-  it("validate drops a login the forge no longer accepts", async () => {
+  it("validate re-probes ONE slot and renames just that account", async () => {
     useForgeStore.setState({
-      logins: { "github.com": "jonassaa" },
-      forge: {
-        host: "github.com",
-        owner: "o",
-        name: "r",
-        kind: "GitHub",
+      accounts: {
+        "github.com": [
+          acct({ id: "acc-1", login: "work" }),
+          acct({ id: "acc-2", login: "personal", active: false }),
+        ],
       },
+    });
+    mockInvoke("forge_validate_token", () => ({ login: "renamed", name: null }));
+    await useForgeStore.getState().validate("github.com", "GitHub", "acc-2");
+    const call = getInvokeCalls().find((c) => c.cmd === "forge_validate_token");
+    expect(call?.args.account).toBe("acc-2");
+    expect(
+      useForgeStore.getState().accounts["github.com"].map((a) => a.login),
+    ).toEqual(["work", "renamed"]);
+  });
+
+  it("validate drops ONLY the account the forge no longer accepts", async () => {
+    useForgeStore.setState({
+      accounts: {
+        "github.com": [
+          acct({ id: "acc-1", login: "work" }),
+          acct({ id: "acc-2", login: "personal", active: false }),
+        ],
+      },
+      forge: { host: "github.com", owner: "o", name: "r", kind: "GitHub" },
       signedIn: true,
     });
     mockInvoke("forge_validate_token", () => {
       throw { kind: "ForgeAuth", message: "github.com" };
     });
-    await useForgeStore.getState().validate("github.com", "GitHub");
-    const s = useForgeStore.getState();
-    expect(s.logins["github.com"]).toBeUndefined();
-    expect(s.signedIn).toBe(false);
+    await useForgeStore.getState().validate("github.com", "GitHub", "acc-1");
+    const list = useForgeStore.getState().accounts["github.com"];
+    // The other account on the same host is still signed in — the eviction the
+    // singular `logins` map could not avoid.
+    expect(list).toEqual([{ id: "acc-2", login: "personal", active: true }]);
   });
 
-  it("signOut clears the login, the list and the checks cache", async () => {
+  it("signOut clears one account, the list and the checks cache", async () => {
     useForgeStore.setState({
-      logins: { "github.com": "jonassaa" },
+      accounts: { "github.com": [acct({ id: "acc-1" })] },
       forge: { host: "github.com", owner: "o", name: "r", kind: "GitHub" },
       signedIn: true,
       pulls: [pr()],
       checks: { 118: { state: "Success", total: 1, label: "success" } },
     });
     mockInvoke("forge_sign_out", () => null);
-    await useForgeStore.getState().signOut("github.com");
+    await useForgeStore.getState().signOut("github.com", "acc-1");
     const s = useForgeStore.getState();
-    expect(s.logins["github.com"]).toBeUndefined();
+    expect(s.accounts["github.com"]).toBeUndefined();
     expect(s.signedIn).toBe(false);
     expect(s.pulls).toEqual([]);
     expect(s.checks).toEqual({});
+    const call = getInvokeCalls().find((c) => c.cmd === "forge_sign_out");
+    expect(call?.args.account).toBe("acc-1");
+  });
+
+  it("signOut does NOT evict the other account on the same host", async () => {
+    useForgeStore.setState({
+      repoId: "r1",
+      accounts: {
+        "github.com": [
+          acct({ id: "acc-1", login: "work" }),
+          acct({ id: "acc-2", login: "personal", active: false }),
+        ],
+      },
+      detection: GH_DETECTION,
+      forge: { host: "github.com", owner: "o", name: "r", kind: "GitHub" },
+      signedIn: true,
+    });
+    mockInvoke("forge_sign_out", () => null);
+    mockInvoke("forge_detect", () => GH_DETECTION);
+    mockInvoke("forge_token_status", () => ({
+      host: "github.com",
+      signedIn: true,
+      login: null,
+    }));
+    mockInvoke("forge_list_pull_requests", () => []);
+    await useForgeStore.getState().signOut("github.com", "acc-1");
+    expect(useForgeStore.getState().accounts["github.com"]).toEqual([
+      { id: "acc-2", login: "personal", active: true },
+    ]);
+  });
+
+  it("switchAccount points the host at another account and re-detects", async () => {
+    useForgeStore.setState({
+      repoId: "r1",
+      detection: GH_DETECTION,
+      accounts: {
+        "github.com": [
+          acct({ id: "acc-1", login: "work" }),
+          acct({ id: "acc-2", login: "personal", active: false }),
+        ],
+      },
+    });
+    mockInvoke("forge_detect", () => GH_DETECTION);
+    mockInvoke("forge_token_status", () => ({
+      host: "github.com",
+      signedIn: true,
+      login: null,
+    }));
+    mockInvoke("forge_list_pull_requests", () => []);
+    await useForgeStore.getState().switchAccount("github.com", "acc-2");
+    const list = useForgeStore.getState().accounts["github.com"];
+    expect(list.find((a) => a.active)?.id).toBe("acc-2");
+    // Persisted immediately: which account a host uses must survive a restart.
+    expect(localStorage.getItem("pg-forge-hosts")).toContain("acc-2");
+    // The list on screen belongs to the account that just went inactive.
+    const status = getInvokeCalls().find((c) => c.cmd === "forge_token_status");
+    expect(status?.args.account).toBe("acc-2");
+  });
+
+  it("refreshTokenStatus drops only the active account when its slot is empty", async () => {
+    useForgeStore.setState({
+      accounts: {
+        "github.com": [
+          acct({ id: "acc-1", login: "work" }),
+          acct({ id: "acc-2", login: "personal", active: false }),
+        ],
+      },
+    });
+    mockInvoke("forge_token_status", () => ({
+      host: "github.com",
+      signedIn: false,
+      login: null,
+    }));
+    await useForgeStore.getState().refreshTokenStatus("github.com");
+    expect(useForgeStore.getState().accounts["github.com"]).toEqual([
+      { id: "acc-2", login: "personal", active: true },
+    ]);
   });
 
   it("setHostKind persists and re-runs detection", async () => {
@@ -546,6 +705,83 @@ describe("accounts", () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(getInvokeCalls().map((c) => c.cmd)).toContain("forge_detect");
+  });
+});
+
+describe("every token-using call names the active account", () => {
+  beforeEach(() => {
+    reset();
+    useForgeStore.setState({
+      repoId: "r1",
+      detection: GH_DETECTION,
+      forge: {
+        host: "github.com",
+        owner: "jonassaa",
+        name: "platypusgit",
+        kind: "GitHub",
+      },
+      signedIn: true,
+      accounts: {
+        "github.com": [
+          acct({ id: "acc-1", login: "work", active: false }),
+          acct({ id: "acc-2", login: "personal" }),
+        ],
+      },
+    });
+  });
+
+  it("detect asks about the active slot, not the host as a whole", async () => {
+    mockInvoke("forge_detect", () => GH_DETECTION);
+    mockInvoke("forge_token_status", () => ({
+      host: "github.com",
+      signedIn: false,
+      login: null,
+    }));
+    await useForgeStore.getState().detect("r1");
+    const call = getInvokeCalls().find((c) => c.cmd === "forge_token_status");
+    expect(call?.args.account).toBe("acc-2");
+  });
+
+  it("refresh lists the active account's requests", async () => {
+    mockInvoke("forge_list_pull_requests", () => [pr()]);
+    await useForgeStore.getState().refresh();
+    const call = getInvokeCalls().find((c) => c.cmd === "forge_list_pull_requests");
+    expect(call?.args.account).toBe("acc-2");
+  });
+
+  it("loadChecks uses the active account", async () => {
+    useForgeStore.setState({ pulls: [pr()] });
+    mockInvoke("forge_pull_request_checks", () => ({
+      state: "Success",
+      total: 1,
+      label: "success",
+    }));
+    await useForgeStore.getState().loadChecks(118);
+    const call = getInvokeCalls().find((c) => c.cmd === "forge_pull_request_checks");
+    expect(call?.args.account).toBe("acc-2");
+  });
+
+  it("create opens the request as the active account", async () => {
+    mockInvoke("forge_create_pull_request", () => pr({ number: 121 }));
+    await useForgeStore.getState().create({
+      title: "t",
+      body: "",
+      sourceBranch: "feat/x",
+      targetBranch: "main",
+      draft: false,
+    });
+    const call = getInvokeCalls().find((c) => c.cmd === "forge_create_pull_request");
+    expect(call?.args.account).toBe("acc-2");
+  });
+
+  it("falls back to the pre-#233 slot when the host has no account list", async () => {
+    // Cleared localStorage with the keychain intact: null is the slot a released
+    // build actually stored the token in, so this still finds it.
+    useForgeStore.setState({ accounts: {} });
+    mockInvoke("forge_list_pull_requests", () => []);
+    await useForgeStore.getState().refresh();
+    const call = getInvokeCalls().find((c) => c.cmd === "forge_list_pull_requests");
+    expect(call?.args.account).toBeNull();
   });
 });
 

--- a/src/features/forge/useForgeStore.ts
+++ b/src/features/forge/useForgeStore.ts
@@ -8,6 +8,12 @@
 // The store never holds a token. `signIn` hands one straight to the backend and
 // keeps only the login it comes back with; nothing in this file can read a token
 // out, because no command returns one.
+//
+// Accounts are host → MANY, with one active per host (#233). The shape, the
+// migration from the old singular `logins` map, and why an account id is an
+// opaque credential-slot name rather than the login all live in
+// `forgeAccounts.ts`. Every token-using call names the active slot, so a host
+// with a work and a personal account uses the one the user picked.
 
 import { create } from "zustand";
 
@@ -38,30 +44,26 @@ import type {
   PullRequest,
 } from "@/lib/types";
 import { localBranchFor } from "./forgeLabels";
-
-/** One localStorage key for the whole account map. */
-const HOSTS_KEY = "pg-forge-hosts";
-
-interface PersistedHosts {
-  /** Host → forge, for self-hosted instances a URL cannot classify. */
-  hostKinds: Record<string, ForgeKind>;
-  /** Host → login, so "signed in as X" needs no network call at startup. */
-  logins: Record<string, string>;
-}
+import {
+  activeAccountId,
+  HOSTS_KEY,
+  newAccountId,
+  parseHosts,
+  removeAccount,
+  setActiveAccount,
+  upsertAccount,
+  type ForgeAccount,
+  type PersistedHosts,
+} from "./forgeAccounts";
 
 function loadHosts(): PersistedHosts {
-  const empty: PersistedHosts = { hostKinds: {}, logins: {} };
   try {
-    const raw = localStorage.getItem(HOSTS_KEY);
-    if (!raw) return empty;
-    const parsed = JSON.parse(raw) as Partial<PersistedHosts>;
-    return {
-      hostKinds: parsed.hostKinds ?? {},
-      logins: parsed.logins ?? {},
-    };
+    // `parseHosts` owns the defensive read AND the migration off the old
+    // singular `logins` map — pure, so both are testable without localStorage.
+    return parseHosts(localStorage.getItem(HOSTS_KEY));
   } catch {
-    // A corrupt blob must not stop the feature from working; start clean.
-    return empty;
+    // A localStorage that throws (private mode) must not stop the feature.
+    return { hostKinds: {}, accounts: {} };
   }
 }
 
@@ -106,7 +108,8 @@ export interface ForgeState {
   selected: number | null;
   checks: Record<number, ChecksSummary>;
   hostKinds: Record<string, ForgeKind>;
-  logins: Record<string, string>;
+  /** Host → its signed-in accounts. Exactly one per host is active. */
+  accounts: Record<string, ForgeAccount[]>;
   loading: boolean;
   creating: boolean;
   checkingOut: boolean;
@@ -130,9 +133,12 @@ export interface ForgeState {
   create: (input: NewPullRequest) => Promise<PullRequest | null>;
   setHostKind: (host: string, kind: ForgeKind) => void;
   refreshTokenStatus: (host: string) => Promise<void>;
+  /** Take a token, mint it a slot, and make that account the host's active one. */
   signIn: (host: string, kind: ForgeKind, token: string) => Promise<boolean>;
-  validate: (host: string, kind: ForgeKind) => Promise<void>;
-  signOut: (host: string) => Promise<void>;
+  validate: (host: string, kind: ForgeKind, account: string | null) => Promise<void>;
+  signOut: (host: string, account: string | null) => Promise<void>;
+  /** Point a host at one of its other accounts. */
+  switchAccount: (host: string, account: string | null) => Promise<void>;
   clearError: () => void;
   reset: () => void;
 }
@@ -145,289 +151,372 @@ function toForge(d: ForgeDetection | null): ForgeRepo | null {
 
 const initial = loadHosts();
 
-export const useForgeStore = create<ForgeState>((set, get) => ({
-  repoId: null,
-  detection: null,
-  forge: null,
-  signedIn: false,
-  pulls: [],
-  selected: null,
-  checks: {},
-  hostKinds: initial.hostKinds,
-  logins: initial.logins,
-  loading: false,
-  creating: false,
-  checkingOut: false,
-  authBusy: false,
-  error: null,
-  createOpen: false,
-  createdUrl: null,
+export const useForgeStore = create<ForgeState>((set, get) => {
+  /**
+   * Commit one host's account list to state AND localStorage.
+   *
+   * One writer, because every path that changes an account has to persist it —
+   * an account map that only lives in memory silently reverts on restart, and
+   * that reads as "it signed me out again". A host with no accounts left drops
+   * out of the map entirely rather than persisting an empty array.
+   */
+  const writeAccounts = (
+    host: string,
+    list: ForgeAccount[],
+    hostKinds?: Record<string, ForgeKind>,
+  ): void => {
+    const accounts = { ...get().accounts };
+    if (list.length === 0) delete accounts[host];
+    else accounts[host] = list;
+    set({ accounts });
+    saveHosts({ hostKinds: hostKinds ?? get().hostKinds, accounts });
+  };
 
-  gate() {
-    const s = get();
-    if (!s.repoId) return "no-repo";
-    if (!s.detection) return "no-forge";
-    if (!s.detection.kind) return "unknown-host";
-    if (!s.signedIn) return "signed-out";
-    return "ready";
-  },
+  return {
+    repoId: null,
+    detection: null,
+    forge: null,
+    signedIn: false,
+    pulls: [],
+    selected: null,
+    checks: {},
+    hostKinds: initial.hostKinds,
+    accounts: initial.accounts,
+    loading: false,
+    creating: false,
+    checkingOut: false,
+    authBusy: false,
+    error: null,
+    createOpen: false,
+    createdUrl: null,
 
-  async detect(repoId) {
-    if (!repoId) {
-      get().reset();
-      return;
-    }
-    set({ repoId, error: null });
-    try {
-      const detection = await forgeDetect(repoId, get().hostKinds);
-      const forge = toForge(detection);
-      set({ detection, forge, pulls: [], selected: null, checks: {} });
-      if (!forge) {
-        set({ signedIn: false });
+    gate() {
+      const s = get();
+      if (!s.repoId) return "no-repo";
+      if (!s.detection) return "no-forge";
+      if (!s.detection.kind) return "unknown-host";
+      if (!s.signedIn) return "signed-out";
+      return "ready";
+    },
+
+    async detect(repoId) {
+      if (!repoId) {
+        get().reset();
         return;
       }
-      // Presence only — no network, so entering the screen never costs an
-      // authenticated request just to render an empty state.
-      const status = await forgeTokenStatus(forge.host);
-      set({ signedIn: status.signedIn });
-      if (status.signedIn) await get().refresh();
-    } catch (e) {
-      set({ error: appErrorMessage(e) });
-    }
-  },
-
-  async refresh() {
-    const { forge } = get();
-    if (!forge) return;
-    set({ loading: true, error: null });
-    try {
-      const pulls = await forgeListPullRequests(forge);
-      set({
-        pulls,
-        loading: false,
-        signedIn: true,
-        // Drop a selection that is no longer open.
-        selected: pulls.some((p) => p.number === get().selected)
-          ? get().selected
-          : (pulls[0]?.number ?? null),
-      });
-    } catch (e) {
-      // A rejected/absent token is `ForgeAuth`; fall back to the signed-out
-      // gate so the screen offers the fix instead of a bare banner.
-      const signedOut = isForgeAuthError(e);
-      set({
-        loading: false,
-        pulls: [],
-        signedIn: signedOut ? false : get().signedIn,
-        error: signedOut ? null : appErrorMessage(e),
-      });
-    }
-  },
-
-  select(n) {
-    set({ selected: n });
-  },
-
-  async loadChecks(n) {
-    const { forge, pulls, checks } = get();
-    if (!forge) return;
-    if (checks[n]) return;
-    const pr = pulls.find((p) => p.number === n);
-    if (!pr?.sha) return;
-    try {
-      const summary = await forgePullRequestChecks(forge, pr.sha);
-      set({ checks: { ...get().checks, [n]: summary } });
-    } catch {
-      // A missing CI verdict is not worth a banner — the row simply shows none.
-    }
-  },
-
-  async openInBrowser(pr) {
-    try {
-      // Goes through `open_url`, i.e. through opener::safe_url — https-only,
-      // parsed, no shell. There is deliberately no second path.
-      await openUrl(pr.url);
-    } catch (e) {
-      set({ error: appErrorMessage(e) });
-    }
-  },
-
-  async checkout(pr, force = false) {
-    const { forge, detection, repoId } = get();
-    if (!forge || !detection || !repoId) return "error";
-    set({ checkingOut: true, error: null });
-
-    // Fetching a request's head ref is an ordinary git-transport operation, so it
-    // needs the SAME credential challenge/retry every other network op uses
-    // (#61 D5) — reusing `withAuthRetry` rather than growing a second retry path.
-    // The forge API token is not a transport credential and is never offered here.
-    //
-    // `withAuthRetry` resolves as soon as it RAISES a challenge, so "neither
-    // branch ran" is the auth-pending signal: `run` sets ok, `onError` sets the
-    // failure kinds, and an auth failure leaves the initial value in place.
-    let outcome: CheckoutOutcome = "auth-pending";
-    await withAuthRetry(
-      repoId,
-      async (creds) => {
-        await forgeCheckoutPullRequest(
-          {
-            repoId,
-            remoteName: detection.remote,
-            kind: forge.kind,
-            number: pr.number,
-            localBranch: localBranchFor(pr, forge.kind),
-            force,
-          },
-          creds,
-        );
-        // Inside the retried closure, per the network-op convention: the retry
-        // path has no other way to reflect the new branch.
-        await useRepoStore.getState().refreshAll();
-        outcome = "ok";
-      },
-      (e) => {
-        // The caller confirms and retries with force — the store must not open a
-        // dialog itself, or it stops being unit-testable.
-        if (isBranchExistsError(e)) {
-          outcome = "branch-exists";
+      set({ repoId, error: null });
+      try {
+        const detection = await forgeDetect(repoId, get().hostKinds);
+        const forge = toForge(detection);
+        set({ detection, forge, pulls: [], selected: null, checks: {} });
+        if (!forge) {
+          set({ signedIn: false });
           return;
         }
-        outcome = "error";
+        // Presence only — no network, so entering the screen never costs an
+        // authenticated request just to render an empty state. Asked about the
+        // ACTIVE slot: "does this host have a token" is not the question when the
+        // host has two accounts and only one of them is signed in.
+        const status = await forgeTokenStatus(
+          forge.host,
+          activeAccountId(get().accounts, forge.host),
+        );
+        set({ signedIn: status.signedIn });
+        if (status.signedIn) await get().refresh();
+      } catch (e) {
         set({ error: appErrorMessage(e) });
-      },
-      // `checkingOut` drives this panel's own button; the `activity` entry is
-      // what reaches the status bar and the Cancel button (#296). Fetching a
-      // pull request's head ref is an ordinary transfer and can stall like one.
-      { key: "forge", label: `Checking out #${pr.number}…` },
-    );
-    set({ checkingOut: false });
-    return outcome;
-  },
-
-  openCreate() {
-    set({ createOpen: true, createdUrl: null, error: null });
-  },
-
-  closeCreate() {
-    set({ createOpen: false });
-  },
-
-  async create(input) {
-    const { forge } = get();
-    if (!forge) return null;
-    set({ creating: true, error: null, createdUrl: null });
-    try {
-      const created = await forgeCreatePullRequest(forge, input);
-      set({
-        creating: false,
-        createOpen: false,
-        createdUrl: created.url,
-        pulls: [created, ...get().pulls.filter((p) => p.number !== created.number)],
-        selected: created.number,
-      });
-      return created;
-    } catch (e) {
-      set({ creating: false, error: appErrorMessage(e) });
-      return null;
-    }
-  },
-
-  setHostKind(host, kind) {
-    const hostKinds = { ...get().hostKinds, [host]: kind };
-    set({ hostKinds });
-    saveHosts({ hostKinds, logins: get().logins });
-    // Re-run detection so the screen picks the kind up without a manual refresh.
-    void get().detect(get().repoId);
-  },
-
-  async refreshTokenStatus(host) {
-    try {
-      const status = await forgeTokenStatus(host);
-      if (get().forge?.host === host) set({ signedIn: status.signedIn });
-      if (!status.signedIn && get().logins[host]) {
-        const logins = { ...get().logins };
-        delete logins[host];
-        set({ logins });
-        saveHosts({ hostKinds: get().hostKinds, logins });
       }
-    } catch (e) {
-      set({ error: appErrorMessage(e) });
-    }
-  },
+    },
 
-  async signIn(host, kind, token) {
-    set({ authBusy: true, error: null });
-    try {
-      const identity = await forgeSignIn(host, kind, token);
-      const logins = { ...get().logins, [host]: identity.login };
-      // Signing in to a host also settles what forge it is.
+    async refresh() {
+      const { forge } = get();
+      if (!forge) return;
+      set({ loading: true, error: null });
+      try {
+        const pulls = await forgeListPullRequests(
+          forge,
+          activeAccountId(get().accounts, forge.host),
+        );
+        set({
+          pulls,
+          loading: false,
+          signedIn: true,
+          // Drop a selection that is no longer open.
+          selected: pulls.some((p) => p.number === get().selected)
+            ? get().selected
+            : (pulls[0]?.number ?? null),
+        });
+      } catch (e) {
+        // A rejected/absent token is `ForgeAuth`; fall back to the signed-out
+        // gate so the screen offers the fix instead of a bare banner.
+        const signedOut = isForgeAuthError(e);
+        set({
+          loading: false,
+          pulls: [],
+          signedIn: signedOut ? false : get().signedIn,
+          error: signedOut ? null : appErrorMessage(e),
+        });
+      }
+    },
+
+    select(n) {
+      set({ selected: n });
+    },
+
+    async loadChecks(n) {
+      const { forge, pulls, checks } = get();
+      if (!forge) return;
+      if (checks[n]) return;
+      const pr = pulls.find((p) => p.number === n);
+      if (!pr?.sha) return;
+      try {
+        const summary = await forgePullRequestChecks(
+          forge,
+          pr.sha,
+          activeAccountId(get().accounts, forge.host),
+        );
+        set({ checks: { ...get().checks, [n]: summary } });
+      } catch {
+        // A missing CI verdict is not worth a banner — the row simply shows none.
+      }
+    },
+
+    async openInBrowser(pr) {
+      try {
+        // Goes through `open_url`, i.e. through opener::safe_url — https-only,
+        // parsed, no shell. There is deliberately no second path.
+        await openUrl(pr.url);
+      } catch (e) {
+        set({ error: appErrorMessage(e) });
+      }
+    },
+
+    async checkout(pr, force = false) {
+      const { forge, detection, repoId } = get();
+      if (!forge || !detection || !repoId) return "error";
+      set({ checkingOut: true, error: null });
+
+      // Fetching a request's head ref is an ordinary git-transport operation, so it
+      // needs the SAME credential challenge/retry every other network op uses
+      // (#61 D5) — reusing `withAuthRetry` rather than growing a second retry path.
+      // The forge API token is not a transport credential and is never offered here.
+      //
+      // `withAuthRetry` resolves as soon as it RAISES a challenge, so "neither
+      // branch ran" is the auth-pending signal: `run` sets ok, `onError` sets the
+      // failure kinds, and an auth failure leaves the initial value in place.
+      let outcome: CheckoutOutcome = "auth-pending";
+      await withAuthRetry(
+        repoId,
+        async (creds) => {
+          await forgeCheckoutPullRequest(
+            {
+              repoId,
+              remoteName: detection.remote,
+              kind: forge.kind,
+              number: pr.number,
+              localBranch: localBranchFor(pr, forge.kind),
+              force,
+            },
+            creds,
+          );
+          // Inside the retried closure, per the network-op convention: the retry
+          // path has no other way to reflect the new branch.
+          await useRepoStore.getState().refreshAll();
+          outcome = "ok";
+        },
+        (e) => {
+          // The caller confirms and retries with force — the store must not open a
+          // dialog itself, or it stops being unit-testable.
+          if (isBranchExistsError(e)) {
+            outcome = "branch-exists";
+            return;
+          }
+          outcome = "error";
+          set({ error: appErrorMessage(e) });
+        },
+        // `checkingOut` drives this panel's own button; the `activity` entry is
+        // what reaches the status bar and the Cancel button (#296). Fetching a
+        // pull request's head ref is an ordinary transfer and can stall like one.
+        { key: "forge", label: `Checking out #${pr.number}…` },
+      );
+      set({ checkingOut: false });
+      return outcome;
+    },
+
+    openCreate() {
+      set({ createOpen: true, createdUrl: null, error: null });
+    },
+
+    closeCreate() {
+      set({ createOpen: false });
+    },
+
+    async create(input) {
+      const { forge } = get();
+      if (!forge) return null;
+      set({ creating: true, error: null, createdUrl: null });
+      try {
+        const created = await forgeCreatePullRequest(
+          forge,
+          input,
+          activeAccountId(get().accounts, forge.host),
+        );
+        set({
+          creating: false,
+          createOpen: false,
+          createdUrl: created.url,
+          pulls: [created, ...get().pulls.filter((p) => p.number !== created.number)],
+          selected: created.number,
+        });
+        return created;
+      } catch (e) {
+        set({ creating: false, error: appErrorMessage(e) });
+        return null;
+      }
+    },
+
+    setHostKind(host, kind) {
       const hostKinds = { ...get().hostKinds, [host]: kind };
-      set({ authBusy: false, logins, hostKinds });
-      saveHosts({ hostKinds, logins });
-      if (get().detection?.host === host) await get().detect(get().repoId);
-      return true;
-    } catch (e) {
-      set({ authBusy: false, error: appErrorMessage(e) });
-      return false;
-    }
-  },
+      set({ hostKinds });
+      saveHosts({ hostKinds, accounts: get().accounts });
+      // Re-run detection so the screen picks the kind up without a manual refresh.
+      void get().detect(get().repoId);
+    },
 
-  async validate(host, kind) {
-    set({ authBusy: true, error: null });
-    try {
-      const identity = await forgeValidateToken(host, kind);
-      const logins = { ...get().logins, [host]: identity.login };
-      set({ authBusy: false, logins, signedIn: get().forge?.host === host ? true : get().signedIn });
-      saveHosts({ hostKinds: get().hostKinds, logins });
-    } catch (e) {
-      const logins = { ...get().logins };
-      delete logins[host];
-      saveHosts({ hostKinds: get().hostKinds, logins });
+    async refreshTokenStatus(host) {
+      try {
+        const slot = activeAccountId(get().accounts, host);
+        const status = await forgeTokenStatus(host, slot);
+        if (get().forge?.host === host) set({ signedIn: status.signedIn });
+        // An empty slot forgets THAT account only. Dropping every account on the
+        // host — what the singular `logins` map had to do — would sign the user
+        // out of a second account whose token is perfectly fine.
+        if (!status.signedIn && (get().accounts[host] ?? []).length > 0) {
+          writeAccounts(host, removeAccount(get().accounts[host] ?? [], slot));
+        }
+      } catch (e) {
+        set({ error: appErrorMessage(e) });
+      }
+    },
+
+    async signIn(host, kind, token) {
+      set({ authBusy: true, error: null });
+      // A fresh slot every time, so a second token for the same host cannot
+      // overwrite the first account's. Which login it turns out to be is the
+      // forge's answer, not something we can know before validating.
+      const slot = newAccountId();
+      try {
+        const identity = await forgeSignIn(host, kind, token, slot);
+        const before = get().accounts[host] ?? [];
+        // Re-authenticating an account whose token expired arrives as a new slot;
+        // `upsertAccount` collapses it onto the login's existing row, and the slot
+        // it displaced still holds a dead token, so erase it. Best-effort: the
+        // sign-in succeeded, and a helper that cannot erase must not fail it.
+        const displaced = before.filter((a) => a.login === identity.login && a.id !== slot);
+        const accounts = upsertAccount(before, { id: slot, login: identity.login });
+        // Signing in to a host also settles what forge it is.
+        const hostKinds = { ...get().hostKinds, [host]: kind };
+        set({ authBusy: false, hostKinds });
+        writeAccounts(host, accounts, hostKinds);
+        for (const old of displaced) {
+          try {
+            await forgeSignOut(host, old.id);
+          } catch {
+            // The account row is already gone; a stale keychain entry is not
+            // worth failing a successful sign-in over.
+          }
+        }
+        if (get().detection?.host === host) await get().detect(get().repoId);
+        return true;
+      } catch (e) {
+        set({ authBusy: false, error: appErrorMessage(e) });
+        return false;
+      }
+    },
+
+    async validate(host, kind, account) {
+      set({ authBusy: true, error: null });
+      const isActive = activeAccountId(get().accounts, host) === account;
+      try {
+        const identity = await forgeValidateToken(host, kind, account);
+        // Rename in place: re-checking the personal account must not steal the
+        // active flag from the work one.
+        const accounts = (get().accounts[host] ?? []).map((a) =>
+          a.id === account ? { ...a, login: identity.login } : a,
+        );
+        set({
+          authBusy: false,
+          signedIn:
+            isActive && get().forge?.host === host ? true : get().signedIn,
+        });
+        writeAccounts(host, accounts);
+      } catch (e) {
+        // Only the slot the forge rejected goes. The other account on the same
+        // host is still signed in.
+        writeAccounts(host, removeAccount(get().accounts[host] ?? [], account));
+        set({
+          authBusy: false,
+          signedIn:
+            isActive && get().forge?.host === host ? false : get().signedIn,
+          error: appErrorMessage(e),
+        });
+      }
+    },
+
+    async signOut(host, account) {
+      set({ authBusy: true, error: null });
+      try {
+        await forgeSignOut(host, account);
+      } catch (e) {
+        set({ error: appErrorMessage(e) });
+      }
+      const remaining = removeAccount(get().accounts[host] ?? [], account);
+      writeAccounts(host, remaining);
+      const isCurrent = get().forge?.host === host;
       set({
         authBusy: false,
-        logins,
-        signedIn: get().forge?.host === host ? false : get().signedIn,
-        error: appErrorMessage(e),
+        signedIn: isCurrent ? false : get().signedIn,
+        pulls: isCurrent ? [] : get().pulls,
+        checks: {},
       });
-    }
-  },
+      // A survivor was just promoted to active, so the host is not signed out at
+      // all — re-probe with the account that now applies rather than leaving the
+      // screen claiming a gate that is no longer true. `detect(null)` RESETS, so
+      // the repo has to still be open.
+      if (isCurrent && remaining.length > 0 && get().repoId) {
+        await get().detect(get().repoId);
+      }
+    },
 
-  async signOut(host) {
-    set({ authBusy: true, error: null });
-    try {
-      await forgeSignOut(host);
-    } catch (e) {
-      set({ error: appErrorMessage(e) });
-    }
-    const logins = { ...get().logins };
-    delete logins[host];
-    saveHosts({ hostKinds: get().hostKinds, logins });
-    set({
-      authBusy: false,
-      logins,
-      signedIn: get().forge?.host === host ? false : get().signedIn,
-      pulls: get().forge?.host === host ? [] : get().pulls,
-      checks: {},
-    });
-  },
+    async switchAccount(host, account) {
+      const list = get().accounts[host] ?? [];
+      if (!list.some((a) => a.id === account)) return;
+      writeAccounts(host, setActiveAccount(list, account));
+      // The requests on screen belong to the account that just went inactive.
+      if (get().detection?.host === host) {
+        set({ pulls: [], selected: null, checks: {} });
+        await get().detect(get().repoId);
+      }
+    },
 
-  clearError() {
-    set({ error: null });
-  },
+    clearError() {
+      set({ error: null });
+    },
 
-  reset() {
-    set({
-      repoId: null,
-      detection: null,
-      forge: null,
-      signedIn: false,
-      pulls: [],
-      selected: null,
-      checks: {},
-      loading: false,
-      error: null,
-      createOpen: false,
-      createdUrl: null,
-    });
-  },
-}));
+    reset() {
+      set({
+        repoId: null,
+        detection: null,
+        forge: null,
+        signedIn: false,
+        pulls: [],
+        selected: null,
+        checks: {},
+        loading: false,
+        error: null,
+        createOpen: false,
+        createdUrl: null,
+      });
+    },
+  };
+});

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1570,6 +1570,11 @@ export async function cloneRepo(
 // `Credentials` above: it authenticates an HTTP header for a host's API, not
 // git's askpass prompt for one remote. The two share no type and no storage —
 // see `src-tauri/src/forge/token.rs`. Nothing here ever returns a token.
+//
+// Every token-using call takes an `account`: the credential SLOT on that host
+// (#233), because a host can hold several accounts. `null` is the pre-#233 slot,
+// which is where an already-signed-in user's token lives — see
+// `features/forge/forgeAccounts.ts`. It is a storage-slot name, never a secret.
 
 /**
  * What forge, if any, this repository's remotes point at.
@@ -1594,32 +1599,42 @@ export function forgeSignIn(
   host: string,
   kind: ForgeKind,
   token: string,
+  account: string | null,
 ): Promise<ForgeIdentity> {
-  return invoke<ForgeIdentity>("forge_sign_in", { host, kind, token });
+  return invoke<ForgeIdentity>("forge_sign_in", { host, kind, token, account });
 }
 
-/** Whether `host` has a stored token. Does NOT hit the network. */
-export function forgeTokenStatus(host: string): Promise<ForgeTokenStatus> {
-  return invoke<ForgeTokenStatus>("forge_token_status", { host });
+/** Whether one account slot on `host` has a stored token. Does NOT hit the network. */
+export function forgeTokenStatus(
+  host: string,
+  account: string | null,
+): Promise<ForgeTokenStatus> {
+  return invoke<ForgeTokenStatus>("forge_token_status", { host, account });
 }
 
-/** Re-probe the stored token and report who it belongs to. */
+/** Re-probe one slot's stored token and report who it belongs to. */
 export function forgeValidateToken(
   host: string,
   kind: ForgeKind,
+  account: string | null,
 ): Promise<ForgeIdentity> {
-  return invoke<ForgeIdentity>("forge_validate_token", { host, kind });
+  return invoke<ForgeIdentity>("forge_validate_token", { host, kind, account });
 }
 
-/** Forget the token for `host`. */
-export function forgeSignOut(host: string): Promise<void> {
-  return invoke<void>("forge_sign_out", { host });
+/**
+ * Forget the token in ONE of `host`'s account slots.
+ *
+ * Per-account: the other account on the same host keeps its token.
+ */
+export function forgeSignOut(host: string, account: string | null): Promise<void> {
+  return invoke<void>("forge_sign_out", { host, account });
 }
 
 export function forgeListPullRequests(
   forge: ForgeRepo,
+  account: string | null,
 ): Promise<PullRequest[]> {
-  return invoke<PullRequest[]>("forge_list_pull_requests", { forge });
+  return invoke<PullRequest[]>("forge_list_pull_requests", { forge, account });
 }
 
 /**
@@ -1630,15 +1645,17 @@ export function forgeListPullRequests(
 export function forgePullRequestChecks(
   forge: ForgeRepo,
   sha: string,
+  account: string | null,
 ): Promise<ChecksSummary> {
-  return invoke<ChecksSummary>("forge_pull_request_checks", { forge, sha });
+  return invoke<ChecksSummary>("forge_pull_request_checks", { forge, sha, account });
 }
 
 export function forgeCreatePullRequest(
   forge: ForgeRepo,
   request: NewPullRequest,
+  account: string | null,
 ): Promise<PullRequest> {
-  return invoke<PullRequest>("forge_create_pull_request", { forge, request });
+  return invoke<PullRequest>("forge_create_pull_request", { forge, request, account });
 }
 
 /**

--- a/src/screens/Pulls.test.tsx
+++ b/src/screens/Pulls.test.tsx
@@ -77,7 +77,7 @@ function seedForge(partial: Partial<ReturnType<typeof useForgeStore.getState>>) 
     selected: null as number | null,
     checks: {},
     hostKinds: {},
-    logins: {},
+    accounts: {},
     loading: false,
     creating: false,
     checkingOut: false,


### PR DESCRIPTION
The forge half of #233. The identity half shipped in #335 / #340; this is the
constraint called out in the issue's own comment thread:

> `useForgeStore.ts:42-60` persists `logins: Record<string, string>`, host →
> login, **singular**. Two GitHub accounts is not expressible today even before
> identities exist.

## Old vs new persisted shape (`pg-forge-hosts`)

```jsonc
// BEFORE — one login per host
{ "hostKinds": { "github.com": "GitHub" },
  "logins":    { "github.com": "jonassaa" } }

// AFTER — host → many, exactly one active
{ "hostKinds": { "github.com": "GitHub" },
  "accounts":  { "github.com": [
      { "id": null,       "login": "work",     "active": false },
      { "id": "acc-mfx-2","login": "personal", "active": true  } ] } }
```

## Why the slot lives in the credential username

The persisted map was not the only constraint. A token is stored under one
credential key per host, so "add a second account" would have overwritten the
first token and "switch active" would have been a lie. The host key must stay
shared — it is what keeps an API token off the git-transport credential for the
same host — so the slot moved into the `username=` field, the only remaining part
of the key: `credential_username(None) == "platypusgit-forge"`,
`Some(id) == "platypusgit-forge:<id>"`.

The id is opaque rather than the login because a forge login can be renamed while
the token stays valid, and a login-keyed entry would orphan it.

`active` is a flag rather than a `host → id` pointer because a pointer can dangle
and is ambiguous (`null` meaning both "the legacy slot" and "nothing recorded").
`parseHosts` normalises "none flagged" and "two flagged" to exactly one.

## Migration — the part that had to be right

The old `logins[host]` lands on **`id: null` and nothing else**, which is
byte-identical to the `platypusgit-forge` username a released build already wrote
real tokens under. Any other id would point at a slot that has never held
anything, and a user who never signed out would come back signed out. Nothing
ever *mints* `null`; it only arrives from migration. `""`, `null` and `undefined`
all collapse to that same slot rather than minting a third.

`parseHosts` is pure and takes the raw string, so it is testable without
localStorage. 30 tests cover: legacy single host, multiple hosts, empty `logins`,
a login that is not a non-empty string, absent blob, corrupt JSON, a blob parsing
to `42` / `null` / `"string"`, `{}`, non-object `hostKinds`, none-flagged,
two-flagged, duplicate id, non-array account list, and both keys present at once.

## Blast radius

`lib.rs`, `error.rs` and `src/lib/types.ts` are **untouched** — no new Tauri
command, no `invoke_handler!` change, no new `AppError` variant, no TS-union
drift. Every token-using command gained an `account: Option<String>` where absent
means the pre-#233 slot. No command returns a token. `credential_input` now
line-safety-checks the *computed* username, so an account id carrying `\n` cannot
inject `host=`.

## Verification

- `pnpm test` — 322 files, 3116 passing; `pnpm tsc --noEmit` clean; e2e tsc clean
- `cargo test` — 84 suites, 1161 passing, including
  `the_legacy_slot_username_is_byte_identical_to_what_shipped` and
  `an_account_id_with_a_newline_cannot_reach_the_credential_protocol`
- e2e in Docker on this branch: `pulls.e2e.ts` 5 passing

## Two things to weigh

- **`var(--row-step)`:** the account rows reuse `ForgeSettings`' local `Row`,
  whose fixed padding matches `screens/Settings.tsx`' own `Row`. Making only the
  forge rows density-aware would leave them a different height from their siblings
  in the same panel — it belongs on both helpers at once, or neither. Flagged
  rather than silently skipped.
- **Not built:** a saved identity *referencing* a forge account. It is expressible
  for the first time now, but two questions need settling first — whether applying
  an identity also switches the host's active forge account (which would silently
  change what a Pulls refresh lists), and what a dangling reference renders as.

Part of #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)
