### PR TITLE
feat(release): submit the msixbundle to the Microsoft Store from CI

### DIFF
--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -78,6 +78,11 @@ gh api repos/jonassaa/platypusgit/releases/latest --jq .tag_name   # must be the
   `workflow_dispatch` run wrote it**, and that is what users will see.
 - `winget-publish` green means nothing was submitted when `WINGET_TOKEN` is
   unset (it is). Expected — not "winget shipped".
+- `msstore-publish` green means the same when any `MSSTORE_*` credential is
+  unset, and *also* means "skipped" once they are set but the Store already
+  holds this version (which is what makes a dispatch re-cut safe). Read the log.
+  Certification then runs for hours in Partner Center — the job never waits for
+  it, so green is "submitted", never "live".
 
 ## Traps
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,10 @@ name: release
 #
 # `bump-cask` and `updater-manifest` are gated on prerelease == false (see their
 # `if:`), so a prerelease attaches the four bundles but touches NEITHER the
-# Homebrew cask NOR latest.json. Verifying the cask BEFORE promoting therefore
+# Homebrew cask NOR latest.json. `msstore-publish` sits on that same gate, so a
+# prerelease is never submitted to the Microsoft Store either — which matters
+# more there than anywhere else, because a submitted version cannot be
+# resubmitted. Verifying the cask BEFORE promoting therefore
 # means running this workflow by workflow_dispatch against the tag while it is
 # still a prerelease — accepting that the cask then points at the new version
 # for as long as you wait before flipping the flag.
@@ -1166,6 +1169,170 @@ jobs:
           release-tag: ${{ needs.version.outputs.tag }}
           installers-regex: 'PlatypusGit_x64\.msi$'
           token: ${{ secrets.WINGET_TOKEN }}
+
+  # The Microsoft Store submission. The `msix` job above already built and
+  # attached the bundle; this job hands that same asset to Partner Center
+  # through the Store submission API, driven by the Microsoft Store Developer
+  # CLI (`msstore`).
+  #
+  # SELF-DISABLING UNTIL THE ENTRA APP EXISTS, the same shape as
+  # winget-publish. The FIRST submission cannot be automated at all — it needs
+  # an ID-verified human, a reserved Store name and a written justification for
+  # the `runFullTrust` restricted capability (spec §G) — and the credentials
+  # this job needs can only be created after an account exists. So the presence
+  # of the credentials IS the signal "the manual submission happened", and
+  # without them the job no-ops loudly instead of failing. The check is a STEP,
+  # not the job's `if:`, because the `secrets` context is not available in a
+  # job-level condition — gating there would evaluate to false forever.
+  #
+  # WINDOWS on purpose. Every Microsoft example runs this on windows-latest and
+  # the action's non-Windows support is undocumented; the job downloads one
+  # asset and makes one API call, so the runner-minute multiplier is noise
+  # against the risk of finding out the hard way during a release.
+  #
+  # IDEMPOTENT on purpose. A workflow_dispatch re-cut against an existing tag
+  # would otherwise resubmit a version the Store already holds, which it
+  # rejects — and dispatch is the ONLY path that reaches here for a PROMOTED
+  # prerelease, because the `published` event was a prerelease and the gate
+  # below skipped it. Narrowing the gate to `release` would mean a promoted
+  # prerelease never reaches the Store at all, so the job stays dispatchable
+  # and checks for itself whether there is anything to do.
+  #
+  # It deliberately does NOT run `msstore submission poll`. That blocks until
+  # PUBLISHED or FAILED, and Store certification for an update runs for hours:
+  # a job parked on a Windows runner waiting for a human process is a 6-hour
+  # timeout, not a gate. Partner Center emails the outcome.
+  #
+  # Spec: docs/superpowers/specs/2026-08-27-msix-store-spec.md (Follow-ups).
+  # Setup: docs/dev/distribution.md > "Submitting to the Store from CI".
+  msstore-publish:
+    needs: [version, msix]
+    runs-on: windows-latest
+    if: ${{ (github.event_name == 'release' && github.event.release.prerelease == false) || github.event_name == 'workflow_dispatch' }}
+    steps:
+      # A PARTIAL setup warns rather than passing silently: four secrets and one
+      # variable have to agree, and "I set three of them" is the likely mistake.
+      - name: Is the Store submission set up yet?
+        id: gate
+        shell: pwsh
+        env:
+          MSSTORE_TENANT_ID: ${{ secrets.MSSTORE_TENANT_ID }}
+          MSSTORE_SELLER_ID: ${{ secrets.MSSTORE_SELLER_ID }}
+          MSSTORE_CLIENT_ID: ${{ secrets.MSSTORE_CLIENT_ID }}
+          MSSTORE_CLIENT_SECRET: ${{ secrets.MSSTORE_CLIENT_SECRET }}
+          MSSTORE_PRODUCT_ID: ${{ vars.MSSTORE_PRODUCT_ID }}
+        run: |
+          $names = 'MSSTORE_TENANT_ID', 'MSSTORE_SELLER_ID', 'MSSTORE_CLIENT_ID',
+                   'MSSTORE_CLIENT_SECRET', 'MSSTORE_PRODUCT_ID'
+          $missing = $names | Where-Object { -not [Environment]::GetEnvironmentVariable($_) }
+          if (-not $missing) {
+              'have_creds=true' | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+              return
+          }
+          'have_creds=false' | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          if ($missing.Count -lt $names.Count) {
+              Write-Host "::warning::Store submission is half-configured — unset: $($missing -join ', ')"
+          } else {
+              Write-Host 'Store submission credentials are not set — skipping the Store submission.'
+          }
+          Write-Host 'Run scripts/msstore-wizard.sh — its step 9 walks the Entra ID'
+          Write-Host 'app setup and prints the exact commands that turn this job on.'
+
+      # The same asset users install, rather than a job artifact — so what the
+      # Store certifies is provably the published bundle, and a
+      # workflow_dispatch against an existing tag works identically.
+      - name: Download the release .msixbundle
+        if: steps.gate.outputs.have_creds == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release download "$TAG" \
+            --repo jonassaa/platypusgit \
+            --pattern PlatypusGit.msixbundle \
+            --clobber
+          ls -la PlatypusGit.msixbundle
+
+      - name: Setup the Microsoft Store Developer CLI
+        if: steps.gate.outputs.have_creds == 'true'
+        uses: microsoft/microsoft-store-apppublisher@v1.1
+
+      # `msstore reconfigure` takes credentials ONLY as flags — there is no env
+      # form — so this is the one place in the repo where a secret rides on
+      # argv. Actions masks them in the log and the runner is ephemeral. Never
+      # add `--verbose` to a step that carries them.
+      - name: Configure Partner Center credentials
+        if: steps.gate.outputs.have_creds == 'true'
+        shell: pwsh
+        env:
+          MSSTORE_TENANT_ID: ${{ secrets.MSSTORE_TENANT_ID }}
+          MSSTORE_SELLER_ID: ${{ secrets.MSSTORE_SELLER_ID }}
+          MSSTORE_CLIENT_ID: ${{ secrets.MSSTORE_CLIENT_ID }}
+          MSSTORE_CLIENT_SECRET: ${{ secrets.MSSTORE_CLIENT_SECRET }}
+        run: |
+          msstore reconfigure `
+            --tenantId $env:MSSTORE_TENANT_ID `
+            --sellerId $env:MSSTORE_SELLER_ID `
+            --clientId $env:MSSTORE_CLIENT_ID `
+            --clientSecret $env:MSSTORE_CLIENT_SECRET
+          if ($LASTEXITCODE -ne 0) { throw "msstore reconfigure failed ($LASTEXITCODE)" }
+
+      # Substring, not a JSON path: the shape of this payload is Partner
+      # Center's, and a four-part version string is specific enough that a match
+      # anywhere in it means "already submitted". `submission get` returns the
+      # pending draft when there is one and the last published submission
+      # otherwise, so a version still in certification also counts as done.
+      - name: Does the Store already have this version?
+        id: submitted
+        if: steps.gate.outputs.have_creds == 'true'
+        shell: pwsh
+        env:
+          MSSTORE_PRODUCT_ID: ${{ vars.MSSTORE_PRODUCT_ID }}
+          MSIX_VERSION: ${{ needs.version.outputs.version }}.0
+        run: |
+          # Keep control of a non-zero exit so the hint below actually prints:
+          # under the default 'Stop', pwsh throws on the native call first.
+          $ErrorActionPreference = 'Continue'
+          $submission = msstore submission get $env:MSSTORE_PRODUCT_ID | Out-String
+          if ($LASTEXITCODE -ne 0) {
+              Write-Host $submission
+              throw "msstore submission get failed ($LASTEXITCODE) — if this is an auth error, the MSSTORE_CLIENT_SECRET has probably expired (see docs/dev/distribution.md)"
+          }
+          if ($submission -match [regex]::Escape($env:MSIX_VERSION)) {
+              'already=true' | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+              Write-Host "The Store already carries $env:MSIX_VERSION — nothing to submit."
+          } else {
+              'already=false' | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          }
+
+      # `msstore publish` DELETES any pending draft and recreates it from the
+      # last published submission. Nothing here edits submission metadata, so
+      # that is harmless — but anything added later that patches the listing
+      # (release notes, say) must run AFTER this step, via
+      # `publish --noCommit` + `submission update` + `submission publish`, or
+      # its edits are silently discarded.
+      - name: Submit the bundle to the Store
+        if: steps.gate.outputs.have_creds == 'true' && steps.submitted.outputs.already == 'false'
+        shell: pwsh
+        env:
+          MSSTORE_PRODUCT_ID: ${{ vars.MSSTORE_PRODUCT_ID }}
+        run: |
+          $ErrorActionPreference = 'Continue'
+          msstore publish PlatypusGit.msixbundle -id $env:MSSTORE_PRODUCT_ID
+          if ($LASTEXITCODE -ne 0) { throw "msstore publish failed ($LASTEXITCODE)" }
+
+      - name: Report the submission status
+        if: steps.gate.outputs.have_creds == 'true' && steps.submitted.outputs.already == 'false'
+        shell: pwsh
+        env:
+          MSSTORE_PRODUCT_ID: ${{ vars.MSSTORE_PRODUCT_ID }}
+        run: |
+          $ErrorActionPreference = 'Continue'
+          msstore submission status $env:MSSTORE_PRODUCT_ID
+          Write-Host 'Submitted. Certification runs in Partner Center and emails the outcome;'
+          Write-Host 'this job does not wait for it.'
 
   # Confirm the LIVE host actually serves what we just pushed. The gate above
   # cannot see any of this: DNS, the Pages build, HTTPS, propagation.

--- a/docs/dev/distribution.md
+++ b/docs/dev/distribution.md
@@ -848,6 +848,82 @@ rejects a bundle carrying the development identity. Both guards exist because
 that fallback is exactly what would otherwise be attached to a public release,
 install fine everywhere, and be rejected only at upload.
 
+### Submitting to the Store from CI
+
+`release.yml`'s **`msstore-publish`** job downloads the release's
+`PlatypusGit.msixbundle` and hands it to Partner Center through the Store
+submission API, driven by the [Microsoft Store Developer
+CLI](https://learn.microsoft.com/en-us/windows/apps/publish/msstore-dev-cli/commands)
+(`msstore`). It is gated on `prerelease == false` like every other channel
+publish, so a prerelease builds the bundle and submits nothing.
+
+Five values turn it on — four secrets and one variable, the same split as
+everywhere else in this doc (a secret is a credential; a public identifier is a
+variable):
+
+```bash
+gh secret set MSSTORE_TENANT_ID       # no --body: gh prompts, so the value
+gh secret set MSSTORE_SELLER_ID       # never reaches argv or shell history
+gh secret set MSSTORE_CLIENT_ID
+gh secret set MSSTORE_CLIENT_SECRET
+gh variable set MSSTORE_PRODUCT_ID --body '9N…'   # it is in the listing URL
+```
+
+`scripts/msstore-wizard.sh` step 9 walks where each one comes from. **The Entra
+ID app needs the `Manager` role** in Partner Center (Account settings > User
+management > Microsoft Entra applications); a lesser role authenticates fine and
+then fails the submission call, which reads as a broken pipeline rather than a
+permissions mistake made weeks earlier.
+
+**The job no-ops loudly until all five are set** — the same self-disabling shape
+as `winget-publish`, and for the same reason: the FIRST submission cannot be
+automated (ID-verified human, reserved name, `runFullTrust` justification — §G),
+so credentials existing *is* the signal that it happened. A half-configured set
+emits a `::warning::` naming what is missing rather than passing in silence. The
+check is a step, not the job's `if:`, because the `secrets` context is not
+available in a job-level condition.
+
+Six things about this that are not guessable from the docs:
+
+- **`.msixbundle` works, though the CLI's own documentation says it does not.**
+  `--inputFile` is documented as taking `.msix` or `.msixupload`; the source
+  (`MSIXProjectPublisher.cs`) declares `[".msix", ".msixbundle", ".msixupload"]`
+  and validates by extension, so the bundle is passed as the positional
+  argument. Verify against the source, not the flag reference, before concluding
+  the bundle needs repacking.
+- **The action was renamed.** It is `microsoft/microsoft-store-apppublisher@v1.1`.
+  `microsoft/setup-msstore-cli` is the same repository under its old name and
+  `microsoft/store-submission` is a different, deprecated action.
+- **`msstore publish` destroys any pending draft** and recreates it from the last
+  published submission. Nothing here edits listing metadata, so that is
+  harmless — but anything added later that patches the listing (Store release
+  notes, say) has to run `publish --noCommit` → `submission update` →
+  `submission publish`, in that order, or its edits are discarded silently.
+- **The job does not poll.** `msstore submission poll` blocks until PUBLISHED or
+  FAILED and Store certification for an update runs for hours; a job parked on a
+  Windows runner waiting for a human process is a six-hour timeout, not a gate.
+  Partner Center emails the outcome.
+- **It is idempotent on purpose**, because `workflow_dispatch` is the only path
+  that reaches the Store for a *promoted* prerelease (the `published` event was a
+  prerelease and the gate skipped it), and a dispatch re-cut against an existing
+  tag would otherwise resubmit a version the Store already holds and be rejected.
+  The pre-check greps the current submission for the four-part version and skips
+  when it is already there — a version still in certification counts as done.
+  Narrowing the gate to `release` instead would mean a promoted prerelease never
+  reaches the Store at all.
+- **The client secret expires.** Entra caps the lifetime at 24 months and
+  defaults to less; when it lapses the job fails on its first API call with an
+  auth error. Record the expiry date here when you create it. The CLI also
+  accepts a certificate (`--certificateThumbprint` / `--certificateFilePath`),
+  which has the same problem in a different shape.
+
+It runs on `windows-latest` because every Microsoft example does and the action's
+non-Windows support is undocumented — the job downloads one asset and makes one
+API call, so the runner-minute multiplier is not worth finding that out during a
+release. Two things it deliberately leaves alone: the listing metadata (the
+description, screenshots and release notes stay whatever the previous submission
+set) and the `msix` job's own prerelease behaviour.
+
 ## One shipped advisory we cannot fix: `glib` 0.18.5 (#346)
 
 `glib` 0.18.5 carries GHSA-wrw7-89jp-8q8g — unsoundness in the `Iterator` and

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -139,15 +139,20 @@ The body is not just release notes: `updater-manifest` embeds it verbatim into
 ### 4. What CI then does
 
 `version` (gate) → four build jobs (`macos-universal`, `windows`, `msix`,
-`linux`) → five channel publishes, each gated on `prerelease == false`
-(`bump-cask`, `bump-scoop`, `updater-manifest`, `apt-publish`, `winget-publish`)
-→ two live installs that verify the channel really serves the new version
-(`scoop-verify-live`, `apt-verify-live`).
+`linux`) → six channel publishes, each gated on `prerelease == false`
+(`bump-cask`, `bump-scoop`, `updater-manifest`, `apt-publish`, `winget-publish`,
+`msstore-publish`) → two live installs that verify the channel really serves the
+new version (`scoop-verify-live`, `apt-verify-live`).
 
-`winget-publish` self-disables when `WINGET_TOKEN` is unset: the job goes green
-having submitted nothing. That is expected today — do not read it as "winget
-shipped". `scripts/winget-wizard.sh` makes the first submission by hand and its
-last step stores the secret.
+**Two of the six self-disable, and a green job there means "submitted
+nothing".** `winget-publish` when `WINGET_TOKEN` is unset — expected today, do
+not read it as "winget shipped"; `scripts/winget-wizard.sh` makes the first
+submission by hand and its last step stores the secret. `msstore-publish` when
+any of `MSSTORE_TENANT_ID` / `_SELLER_ID` / `_CLIENT_ID` / `_CLIENT_SECRET` or
+the `MSSTORE_PRODUCT_ID` variable is unset; `scripts/msstore-wizard.sh` step 9
+sets those up. `msstore-publish` also skips — green, having done nothing —
+when the Store already holds this version, which is what makes a
+`workflow_dispatch` re-cut safe. Read its log, not its colour.
 
 The live verifications mean most post-publish checking is automated. Three things
 are not:

--- a/scripts/msstore-wizard.sh
+++ b/scripts/msstore-wizard.sh
@@ -1,10 +1,14 @@
 #!/bin/sh
 # One-time setup for the platypusgit Microsoft Store listing.
 #
-# Walks the eight steps that live OUTSIDE this git repository — in Partner Center
-# and behind a government ID check — and that therefore no code review can see.
-# Those are exactly the steps that get half-done and then debugged months later
-# as a mystery submission rejection.
+# Walks the nine steps that live OUTSIDE this git repository — in Partner Center,
+# in Microsoft Entra ID, and behind a government ID check — and that therefore no
+# code review can see. Those are exactly the steps that get half-done and then
+# debugged months later as a mystery submission rejection.
+#
+# Step 9 is the one that outlives the others: it turns release.yml's
+# `msstore-publish` job on, so EVERY LATER RELEASE submits itself. Steps 1-8 are
+# done once and then never again.
 #
 #   sh scripts/msstore-wizard.sh            # walk the steps
 #   sh scripts/msstore-wizard.sh --dry-run  # print them, change nothing
@@ -101,7 +105,7 @@ done
 
 [ -f "$MANIFEST" ] || die "manifest not found: $MANIFEST"
 
-# `gh` is OPTIONAL here, unlike the other two wizards: seven of the eight steps
+# `gh` is OPTIONAL here, unlike the other two wizards: seven of the nine steps
 # are a browser and a phone camera, and requiring an authenticated CLI to read a
 # checklist would be a bad trade. It is used only to look up the release asset.
 HAVE_GH=no
@@ -123,7 +127,7 @@ fi
 
 # ─── 1. the account ──────────────────────────────────────────────────────────
 
-step "1/8  The developer account"
+step "1/9  The developer account"
 
 say "ALREADY HAVE A MICROSOFT DEVELOPER ACCOUNT? Skip this step entirely."
 say "Microsoft's own FAQ: 'this flow is only for new individual developers"
@@ -152,7 +156,7 @@ confirm "Account ready (existing or newly verified)?" || say "Skipped."
 
 # ─── 2. the name ─────────────────────────────────────────────────────────────
 
-step "2/8  Reserve the product name '$PRODUCT'"
+step "2/9  Reserve the product name '$PRODUCT'"
 
 say "In Partner Center: Apps and games > New product > MSIX or PWA app."
 say ""
@@ -163,7 +167,7 @@ confirm "Name reserved?" || say "Skipped."
 
 # ─── 3. the identity ─────────────────────────────────────────────────────────
 
-step "3/8  Copy the assigned package identity"
+step "3/9  Copy the assigned package identity"
 
 say "In the product: Product management > Product identity."
 say ""
@@ -215,7 +219,7 @@ fi
 
 # ─── 4. age ratings ──────────────────────────────────────────────────────────
 
-step "4/8  Age ratings (IARC questionnaire)"
+step "4/9  Age ratings (IARC questionnaire)"
 
 say "Policy 11.11: every question must be answered, and you are responsible for"
 say "the answers being accurate. A developer tool answers 'no' to essentially"
@@ -225,7 +229,7 @@ confirm "Questionnaire completed?" || say "Skipped."
 
 # ─── 5. restricted capabilities ──────────────────────────────────────────────
 
-step "5/8  Justify the restricted capability"
+step "5/9  Justify the restricted capability"
 
 say "The manifest declares:  <rescap:Capability Name=\"runFullTrust\" />"
 say ""
@@ -243,7 +247,7 @@ confirm "Justification entered?" || say "Skipped."
 
 # ─── 6. the description ──────────────────────────────────────────────────────
 
-step "6/8  Write the description — git goes in the FIRST line"
+step "6/9  Write the description — git goes in the FIRST line"
 
 say "Policy 10.2.4 permits depending on non-integrated software to deliver"
 say "primary functionality ONLY IF the dependency is disclosed AT THE BEGINNING"
@@ -260,7 +264,7 @@ confirm "Description written with the dependency first?" || say "Skipped."
 
 # ─── 7. the privacy policy ───────────────────────────────────────────────────
 
-step "7/8  Privacy policy URL"
+step "7/9  Privacy policy URL"
 
 say "Properties > Privacy policy URL:"
 say ""
@@ -273,7 +277,7 @@ confirm "URL entered?" || say "Skipped."
 
 # ─── 8. the upload ───────────────────────────────────────────────────────────
 
-step "8/8  Upload the msixbundle"
+step "8/9  Upload the msixbundle"
 
 say "Packages > upload PlatypusGit.msixbundle from the GitHub release."
 say "release.yml's 'msix' job builds and attaches it; you do not build it by hand."
@@ -297,6 +301,73 @@ say "Do NOT sign the bundle first. The Store re-signs it, which is the whole"
 say "reason this channel costs nothing."
 confirm "Uploaded?" || say "Skipped."
 
+# ─── 9. automate every later submission ──────────────────────────────────────
+
+step "9/9  Turn on automatic submissions for every later release"
+
+say "This is the step that outlives the wizard. Once these five values exist,"
+say "release.yml's 'msstore-publish' job submits the msixbundle by itself and"
+say "step 8 never has to be done by hand again."
+say ""
+say "FIRST, in Microsoft Entra ID (https://entra.microsoft.com):"
+say "  Identity > Applications > App registrations > New registration."
+say "  Any name; no redirect URI is needed. This app IS the release pipeline's"
+say "  identity — it is not a user and it does not sign in anywhere."
+say ""
+say "THEN, back in Partner Center:"
+say "  Account settings > User management > Microsoft Entra applications >"
+say "  add that app, and give it the MANAGER role."
+say ""
+say "The role is the trap. A lesser role authenticates fine and then fails the"
+say "submission call, so the failure reads as a broken pipeline rather than a"
+say "permissions mistake made weeks earlier."
+say ""
+say "FOUR values to collect:"
+say "  Tenant ID       Entra > Identity > Overview"
+say "  Client ID       the app registration's 'Application (client) ID'"
+say "  Client secret   the app registration > Certificates & secrets."
+say "                  SHOWN ONCE — copy it before leaving the page."
+say "  Seller ID       Partner Center > Account settings > Identifiers"
+say "                  (also labelled 'Publisher ID')"
+say ""
+say "Store them as repository secrets. Note there is NO --body: gh reads each"
+say "value from a hidden prompt, so it never reaches argv, the screen, or shell"
+say "history."
+say ""
+say "  gh secret set MSSTORE_TENANT_ID"
+say "  gh secret set MSSTORE_SELLER_ID"
+say "  gh secret set MSSTORE_CLIENT_ID"
+say "  gh secret set MSSTORE_CLIENT_SECRET"
+say ""
+
+if confirm "Enter the Store product ID now, and I will print its command?"; then
+    product_id="$(ask 'Store product ID (the 9N... from the listing URL):' PRODUCT_ID)"
+
+    case "$product_id" in
+        9*) ;;
+        *) warn "" ; warn "WARNING: a Store product ID normally begins '9'. Got: $product_id" ;;
+    esac
+
+    say ""
+    say "  gh variable set MSSTORE_PRODUCT_ID --body '$product_id'"
+    say ""
+    say "A VARIABLE, not a secret — it is in the listing's public URL, and the"
+    say "same reasoning as MSIX_IDENTITY_NAME applies."
+else
+    say "  gh variable set MSSTORE_PRODUCT_ID --body '<the 9N... id>'"
+fi
+
+say ""
+say "THE CLIENT SECRET EXPIRES. Entra caps the lifetime at 24 months and"
+say "defaults to less. When it lapses, msstore-publish fails on its first API"
+say "call — write the expiry date into docs/dev/distribution.md next to the"
+say "identity variables so the failure is recognisable rather than mysterious."
+say ""
+say "Nothing was written by this wizard. Until all five values are set the job"
+say "no-ops loudly instead of failing, so a release cut before you finish this"
+say "step still succeeds — it just does not reach the Store."
+confirm "Credentials stored?" || say "Skipped — msstore-publish stays off until they are."
+
 # ─── what you should have now ────────────────────────────────────────────────
 
 step "Done — what you should have now"
@@ -311,6 +382,9 @@ say "  5. runFullTrust justified."
 say "  6. A description whose FIRST line names the git dependency."
 say "  7. $PRIVACY_URL set as the privacy policy URL."
 say "  8. PlatypusGit.msixbundle uploaded, unsigned."
+say "  9. MSSTORE_TENANT_ID / _SELLER_ID / _CLIENT_ID / _CLIENT_SECRET stored as"
+say "     repository secrets and MSSTORE_PRODUCT_ID as a variable, so that no"
+say "     later release needs step 8 at all."
 say ""
 say "Then: Submit for certification, and record what the first submission"
 say "teaches. One claim in particular is UNVERIFIED and this is where it gets"


### PR DESCRIPTION
Automates the Microsoft Store channel, which was the last one still needing a
human in the loop for every release. This is the spec's own deferred follow-up
(`docs/superpowers/specs/2026-08-27-msix-store-spec.md`), which was gated on
"one submission done by hand" — now satisfied.

The `msix` job already builds and attaches `PlatypusGit.msixbundle`. The new
`msstore-publish` job takes that published asset and submits it through the
Store submission API via the Microsoft Store Developer CLI.

## What's here

- **`msstore-publish` in `release.yml`** — on the same `prerelease == false`
  gate as the other five channel publishes.
  - **Self-disabling** until `MSSTORE_TENANT_ID` / `_SELLER_ID` / `_CLIENT_ID` /
    `_CLIENT_SECRET` (secrets) and `MSSTORE_PRODUCT_ID` (variable) exist, the
    same shape as `winget-publish` and for the same reason: the first submission
    cannot be automated at all, so the credentials existing *is* the signal that
    it happened. A half-configured set emits a `::warning::` naming what is
    missing rather than passing silently. The check is a step, not the job's
    `if:` — the `secrets` context is unavailable in a job-level condition.
  - **Idempotent**, because `workflow_dispatch` has to stay in the gate: it is
    the only path that reaches the Store for a *promoted* prerelease, and a
    dispatch re-cut against an existing tag would otherwise resubmit a version
    the Store already holds and be rejected.
  - **Does not poll for certification** — that blocks for hours and would park a
    Windows runner on a human process.
- **`msstore-wizard.sh` step 9** — the Entra ID app, the `Manager` role that is
  the trap, and the exact `gh` commands that turn the job on. It prints them
  rather than running them (step 3's contract) and never reads the client
  secret; the `gh secret set` lines deliberately carry no `--body`, so values go
  through gh's hidden prompt instead of argv.
- **Docs** — the setup and its six non-guessable traps in `distribution.md`,
  plus the channel-job lists in `releasing.md` and the `releasing` skill, which
  both now say that green there can mean "submitted nothing".

## The trap worth reading twice

The CLI's flag reference says `--inputFile` takes `.msix` or `.msixupload`,
which would mean repacking the bundle. The source disagrees with the docs:
`MSIXProjectPublisher.cs` declares `[".msix", ".msixbundle", ".msixupload"]` and
validates by extension, so the bundle goes in as the positional argument. That
is recorded in `distribution.md` so the next person doesn't repack on the
strength of the flag reference.

## Verification

- `pnpm test` — 3068 tests / 321 files green, after the last edit.
- Workflow parses; job graph is `needs: [version, msix]`, seven steps, every
  step `if:` resolving against a real step id.
- `sh -n scripts/msstore-wizard.sh` clean, and `--dry-run` walks all nine steps.
- The five `pwsh` step bodies were extracted and balance-checked (braces,
  parens, quotes, no whitespace after a continuation backtick). They were **not**
  run through the PowerShell parser — `pwsh` is refused in a worktree-isolated
  session. Worth one command before the next release if you want it machine-checked.

## Not in this PR

Store listing metadata. Description, screenshots and release notes stay whatever
the previous submission set; automating release notes needs
`publish --noCommit` → `submission update` → `submission publish`, in that order,
because `msstore publish` destroys a pending draft. The ordering trap is written
down in both the job and the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
