### PR TITLE
fix(git): emit `\ No newline at end of file` in synthesized patches

### DIFF
--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -676,6 +676,48 @@ again. `commands/repo.rs::delete_untracked_files` is therefore thin.
   are unlinked as links (with a `remove_dir` fallback for the Windows
   directory-symlink case), never followed.
 
+## Partial staging synthesizes real patch text (#61 D7)
+
+`patch_text_for_lines` is the single synthesizer behind `stage_lines`,
+`unstage_lines`, `discard_lines`, `patch_text_for_hunk` (whole-hunk unstage and
+discard) and `stage_hunk`'s untracked-**creation** route — the one case
+`ApplyLocation::Index` cannot serve, because libgit2 needs an index entry that
+does not exist yet. What it produces is piped to a real `git apply`, so it is
+patch text in the format git parses, not a rendering.
+
+- **`\ No newline at end of file` is DATA, not decoration.** git2 hands the
+  marker back as a line of its own, whose `content` is the marker text, under
+  three origins: `=` (`CONTEXT_EOFNL`) after a context line, `>` (`ADD_EOFNL`)
+  after a `-` line, `<` (`DEL_EOFNL`) after a `+` line. The origin names describe
+  the *transition* (`ADD_EOFNL` = "old has no LF at end, new does"), so reading
+  them as "which side" is backwards; the position is what carries the meaning,
+  and it is always *the line whose own record lacks the `\n`*. So the synthesizer
+  drops all three and regenerates the marker from `content.ends_with('\n')`,
+  which is the same predicate xdiff itself used to emit it.
+- **Dropping the marker and fabricating the `\n` is not a cosmetic bug.** On the
+  creation route `git apply --cached` exits 0 and stages a blob one byte longer
+  than the file on disk — so the row the user just staged reappears as modified
+  immediately, with no error anywhere. On a tracked file the patch is simply
+  rejected: `git apply failed: error: patch failed: <file>:<line>`.
+- **The marker belongs to a SIDE, and the selection can move a line between
+  sides.** A record with no trailing newline ends its side of the *original*
+  diff, but the emitted patch is a subset: an unselected `-` becomes context
+  (`Apply`), an unselected `+` becomes context (`Reverse`), and either can end up
+  with the other side continuing past it. So the marker is decided against the
+  emitted body — `last_old` / `last_new`, the last line each side actually ends
+  on — and a line the side carries on past gets a genuine `\n` instead.
+- **A context line that ends only ONE side is emitted as a `-`/`+` pair.** No
+  context line can say "newline here but not there"; git spells that as a removal
+  without the newline followed by a re-addition with one. The pair costs the same
+  one old line and one new line the context line did, so the `@@` counts computed
+  while choosing markers stay correct.
+- CRLF needs nothing special and must keep needing nothing: a `\r\n` record
+  already ends in `\n`, so no marker is involved. That is why the predicate is
+  `ends_with('\n')` and never `trim_end()`, which would eat the `\r`.
+- `src-tauri/tests/no_trailing_newline.rs` pins all of it, and every assertion is
+  on real bytes — the index blob against the worktree file, or the worktree file
+  itself. "The command returned `Ok`" is exactly what the creation-route bug did.
+
 ## `blame.ignoreRevsFile` — where libgit2 cannot follow (#253)
 
 - **libgit2's blame has no ignore-revs support of any kind.**

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -1520,6 +1520,27 @@ fn changed_line_count(
     Ok(n)
 }
 
+/// git's own spelling of "the last line of this side has no newline", including
+/// the `\n` that terminates the marker line itself. `git apply` reads it; a
+/// patch that omits it asserts a trailing newline the file does not have.
+const NO_NEWLINE_MARKER: &str = "\\ No newline at end of file\n";
+
+/// Emit one body line whose record does NOT end in `\n`, terminating it so the
+/// patch stays line-oriented.
+///
+/// `ends_file` says whether the missing newline is real for the side this marker
+/// puts the line on. When the side carries on past this line, the newline is not
+/// missing there at all — the line simply is not the last one — so the marker
+/// must be withheld and the `\n` is genuine.
+fn push_unterminated(body: &mut String, marker: char, content: &str, ends_file: bool) {
+    body.push(marker);
+    body.push_str(content);
+    body.push('\n');
+    if ends_file {
+        body.push_str(NO_NEWLINE_MARKER);
+    }
+}
+
 /// Build a unified-diff patch containing only the selected changed lines of one
 /// hunk (#61 D7).
 ///
@@ -1533,6 +1554,12 @@ fn changed_line_count(
 /// context** (we are not removing it, so it exists on both sides), and an
 /// **unselected `+` is dropped** (it exists on neither side of this partial
 /// patch). For `Reverse` those two rules swap.
+///
+/// A file whose last line has no trailing newline is the trap here: the result
+/// goes to a real `git apply`, so the `\ No newline at end of file` marker is
+/// part of the data, not decoration. Fabricating the newline instead stages a
+/// blob one byte longer than the file on disk (so the row the user just staged
+/// comes straight back as modified) or makes `git apply` reject the patch.
 fn patch_text_for_lines(
     diff: &git2::Diff,
     delta_index: usize,
@@ -1590,7 +1617,10 @@ fn patch_text_for_lines(
         PatchDirection::Reverse => '+',
     };
 
-    let mut body = String::new();
+    // Pass one: decide the marker every kept line ends up with. The bodies are
+    // NOT serialized yet, because whether a record's missing newline is real
+    // depends on where the line lands after the selection — see below.
+    let mut kept: Vec<(char, String)> = Vec::new();
     let mut old_count: u32 = 0;
     let mut new_count: u32 = 0;
     let mut changed_seen: usize = 0;
@@ -1599,6 +1629,12 @@ fn patch_text_for_lines(
     for line_i in 0..line_count {
         let line = patch.line_in_hunk(hunk_index, line_i).map_err(AppError::from)?;
         let origin = line.origin();
+        // `=`/`>`/`<` (CONTEXT_EOFNL / ADD_EOFNL / DEL_EOFNL) are git2's way of
+        // handing back the `\ No newline at end of file` marker as a line of its
+        // own, carrying the marker text as its content. They are dropped here and
+        // regenerated in pass two: which SIDE the missing newline belongs to is a
+        // property of the marker each line ends up with, and the selection can
+        // move a line from one side to the other.
         if !matches!(origin, '+' | '-' | ' ') {
             continue;
         }
@@ -1630,10 +1666,49 @@ fn patch_text_for_lines(
             '+' => new_count += 1,
             _ => {}
         }
-        body.push(marker);
-        body.push_str(content);
-        if !content.ends_with('\n') {
-            body.push('\n');
+        kept.push((marker, content.to_string()));
+    }
+
+    // Pass two. A record git2 hands back without a trailing `\n` is, by
+    // construction, the last line of whichever side(s) it belongs to in the
+    // ORIGINAL diff — but this patch is a subset, so the question to answer per
+    // line is "does the side I am on still end here?". These are the two ends of
+    // the patch we are actually emitting.
+    let last_old = kept.iter().rposition(|(m, _)| matches!(m, ' ' | '-'));
+    let last_new = kept.iter().rposition(|(m, _)| matches!(m, ' ' | '+'));
+
+    let mut body = String::new();
+    for (i, (marker, content)) in kept.iter().enumerate() {
+        if content.ends_with('\n') {
+            body.push(*marker);
+            body.push_str(content);
+            continue;
+        }
+        let ends_old = Some(i) == last_old;
+        let ends_new = Some(i) == last_new;
+        match marker {
+            '-' => push_unterminated(&mut body, '-', content, ends_old),
+            '+' => push_unterminated(&mut body, '+', content, ends_new),
+            // A context line is on BOTH sides, so it only gets the marker when
+            // both sides end on it — which is exactly what git's `=` means.
+            _ => match (ends_old, ends_new) {
+                (true, true) => push_unterminated(&mut body, ' ', content, true),
+                // One side ends here and the other carries on past it, so the
+                // line has a newline on one side and not the other. A context
+                // line cannot say that; git spells it as a removal followed by
+                // a re-addition, and the pair costs the same one old line and
+                // one new line the context line did — so the counts above stay
+                // right.
+                (true, false) => {
+                    push_unterminated(&mut body, '-', content, true);
+                    push_unterminated(&mut body, '+', content, false);
+                }
+                (false, true) => {
+                    push_unterminated(&mut body, '-', content, false);
+                    push_unterminated(&mut body, '+', content, true);
+                }
+                (false, false) => push_unterminated(&mut body, ' ', content, false),
+            },
         }
     }
 

--- a/src-tauri/tests/no_trailing_newline.rs
+++ b/src-tauri/tests/no_trailing_newline.rs
@@ -1,0 +1,491 @@
+//! A file whose last line has no trailing newline, staged/unstaged/discarded by
+//! hunk or by line.
+//!
+//! `patch_text_for_lines` synthesizes patch text that is piped to a real
+//! `git apply`, and git spells "this side's last line has no newline" with a
+//! `\ No newline at end of file` marker line. git2 hands that marker back as a
+//! line of its own — origin `=` (CONTEXT_EOFNL), `>` (ADD_EOFNL) or `<`
+//! (DEL_EOFNL) — after the record whose bytes lack the `\n`.
+//!
+//! Every assertion here is on real BYTES: the index blob against the worktree
+//! file, or the worktree file itself. A patch that fabricates the newline can
+//! still make `git apply --cached` exit 0 — and then the file the user just
+//! staged reappears as modified, because the blob in the index is one byte
+//! longer than the file on disk.
+
+mod support;
+
+use std::path::{Path, PathBuf};
+
+use platypusgit_lib::git::types::{DiffKind, DiffLineKind};
+use platypusgit_lib::git::GitBackend;
+
+use support::{fs::write_file, TempRepo};
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+/// The staged (index) blob for `path`, as raw bytes.
+fn staged_bytes(tr: &TempRepo, path: &str) -> Vec<u8> {
+    let repo = git2::Repository::open(tr.path()).unwrap();
+    let index = repo.index().unwrap();
+    let entry = index
+        .get_path(Path::new(path), 0)
+        .expect("path is in the index");
+    let blob = repo.find_blob(entry.id).unwrap();
+    blob.content().to_vec()
+}
+
+/// The worktree file's raw bytes.
+fn worktree_bytes(tr: &TempRepo, path: &str) -> Vec<u8> {
+    std::fs::read(tr.path().join(path)).expect("read worktree file")
+}
+
+/// Commit `body` at `path` verbatim — `TempRepo::with_initial_commit` is fixed
+/// to README.md, and these fixtures need the committed side to keep (or lack) a
+/// trailing newline exactly as written.
+fn commit_verbatim(tr: &TempRepo, path: &str, body: &str) {
+    write_file(tr.path(), path, body);
+    let mut index = tr.repo.index().unwrap();
+    index.add_path(Path::new(path)).unwrap();
+    index.write().unwrap();
+    let tree_oid = index.write_tree().unwrap();
+    let tree = tr.repo.find_tree(tree_oid).unwrap();
+    let sig = git2::Signature::now("Test User", "test@example.com").unwrap();
+    let parent = tr.repo.head().ok().and_then(|h| h.peel_to_commit().ok());
+    let parents: Vec<&git2::Commit> = parent.as_ref().map(|c| vec![c]).unwrap_or_default();
+    tr.repo
+        .commit(Some("HEAD"), &sig, &sig, "fixture", &tree, &parents)
+        .unwrap();
+}
+
+/// After staging, the index blob and the worktree file must be byte-identical —
+/// which is the same thing as "the row leaves the unstaged list".
+fn assert_index_matches_worktree(
+    tr: &TempRepo,
+    backend: &platypusgit_lib::git::libgit2::Libgit2Backend,
+    handle: &platypusgit_lib::git::types::RepoHandle,
+    path: &str,
+) {
+    let staged = staged_bytes(tr, path);
+    let wt = worktree_bytes(tr, path);
+    assert_eq!(
+        String::from_utf8_lossy(&staged),
+        String::from_utf8_lossy(&wt),
+        "index blob and worktree must be byte-identical after staging \
+         (staged {} bytes, worktree {} bytes)",
+        staged.len(),
+        wt.len()
+    );
+
+    let wt_diff = backend
+        .diff(&handle.id, &PathBuf::from(path), DiffKind::WorktreeToIndex, 3, false)
+        .expect("worktree diff");
+    assert!(
+        wt_diff.hunks.is_empty(),
+        "the file must not reappear as modified right after being staged: {:?}",
+        wt_diff.hunks
+    );
+}
+
+// ─── the untracked-creation route through stage_hunk ─────────────────────────
+
+#[test]
+fn stage_hunk_on_an_untracked_file_with_no_trailing_newline_stages_the_exact_bytes() {
+    // stage_hunk's creation route builds patch text by hand (libgit2's
+    // ApplyLocation::Index cannot take a file the index has never heard of) and
+    // pipes it to `git apply --cached`. A fabricated trailing newline puts a
+    // blob in the index that is one byte longer than the file on disk.
+    let tr = TempRepo::fresh();
+    commit_verbatim(&tr, "base.txt", "base\n");
+    write_file(tr.path(), "new.txt", "a\nb\nc");
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .stage_hunk(&handle.id, Path::new("new.txt"), 0, 3)
+        .expect("stage_hunk on an untracked file with no trailing newline");
+
+    assert_eq!(
+        String::from_utf8(staged_bytes(&tr, "new.txt")).unwrap(),
+        "a\nb\nc",
+        "the staged blob must not gain a trailing newline the file never had"
+    );
+    assert_index_matches_worktree(&tr, &backend, &handle, "new.txt");
+}
+
+#[test]
+fn stage_lines_on_an_untracked_file_keeps_the_last_selected_line_unterminated() {
+    // Selecting a prefix of the lines: the last line that reaches the index is
+    // "b\n", which DOES end in a newline — so no marker belongs on this patch at
+    // all, and the blob keeps its newline.
+    let tr = TempRepo::fresh();
+    commit_verbatim(&tr, "base.txt", "base\n");
+    write_file(tr.path(), "new.txt", "a\nb\nc");
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .stage_lines(&handle.id, &PathBuf::from("new.txt"), 0, &[0, 1], 3)
+        .expect("stage_lines on an untracked file");
+
+    assert_eq!(
+        String::from_utf8(staged_bytes(&tr, "new.txt")).unwrap(),
+        "a\nb\n"
+    );
+}
+
+#[test]
+fn stage_lines_on_an_untracked_file_with_every_index_stages_the_exact_bytes() {
+    // Selecting every changed line of a creation hunk must equal staging the
+    // whole file — including the last line's missing newline.
+    let tr = TempRepo::fresh();
+    commit_verbatim(&tr, "base.txt", "base\n");
+    write_file(tr.path(), "new.txt", "a\nb\nc");
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .stage_lines(&handle.id, &PathBuf::from("new.txt"), 0, &[0, 1, 2], 3)
+        .expect("stage_lines with every index");
+
+    assert_eq!(
+        String::from_utf8(staged_bytes(&tr, "new.txt")).unwrap(),
+        "a\nb\nc"
+    );
+    assert_index_matches_worktree(&tr, &backend, &handle, "new.txt");
+}
+
+// ─── tracked files: one test per EOFNL origin ────────────────────────────────
+
+#[test]
+fn stage_lines_adding_an_unterminated_last_line() {
+    // git2 origin `<` (DEL_EOFNL): the marker follows the `+` line, because the
+    // NEW side is the one that ends without a newline.
+    //   old: "one\ntwo\nthree\n"      new: "one\ntwo\nthree\nfour"
+    //   ...  -three / \ No newline?  no: three keeps its newline, four does not.
+    let tr = TempRepo::fresh();
+    commit_verbatim(&tr, "f.txt", "one\ntwo\nthree\n");
+    write_file(tr.path(), "f.txt", "one\ntwo\nthree\nfour");
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .stage_lines(&handle.id, &PathBuf::from("f.txt"), 0, &[0], 3)
+        .expect("stage_lines on the unterminated added line");
+
+    assert_eq!(
+        String::from_utf8(staged_bytes(&tr, "f.txt")).unwrap(),
+        "one\ntwo\nthree\nfour",
+        "the added last line must reach the index without a newline"
+    );
+    assert_index_matches_worktree(&tr, &backend, &handle, "f.txt");
+}
+
+#[test]
+fn stage_lines_deleting_an_unterminated_last_line() {
+    // git2 origin `>` (ADD_EOFNL): the marker follows the `-` line, because the
+    // OLD side is the one that ends without a newline. Fabricating the newline
+    // there makes `git apply --cached` reject the patch outright — the index has
+    // no "last\n" to remove.
+    let tr = TempRepo::fresh();
+    commit_verbatim(&tr, "f.txt", "one\ntwo\nlast");
+    write_file(tr.path(), "f.txt", "one\ntwo\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .stage_lines(&handle.id, &PathBuf::from("f.txt"), 0, &[0], 3)
+        .expect("stage_lines on the unterminated deleted line");
+
+    assert_eq!(
+        String::from_utf8(staged_bytes(&tr, "f.txt")).unwrap(),
+        "one\ntwo\n"
+    );
+    assert_index_matches_worktree(&tr, &backend, &handle, "f.txt");
+}
+
+#[test]
+fn stage_lines_with_an_unterminated_context_line() {
+    // git2 origin `=` (CONTEXT_EOFNL): BOTH sides end without a newline, so the
+    // marker follows a context line. The change is above it, so the marker is
+    // the only thing that tells `git apply` the file it is patching does not end
+    // in a newline.
+    let tr = TempRepo::fresh();
+    commit_verbatim(&tr, "f.txt", "one\ntwo\nthree");
+    write_file(tr.path(), "f.txt", "one\nTWO\nthree");
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .stage_lines(&handle.id, &PathBuf::from("f.txt"), 0, &[0, 1], 3)
+        .expect("stage_lines under an unterminated context line");
+
+    assert_eq!(
+        String::from_utf8(staged_bytes(&tr, "f.txt")).unwrap(),
+        "one\nTWO\nthree"
+    );
+    assert_index_matches_worktree(&tr, &backend, &handle, "f.txt");
+}
+
+#[test]
+fn stage_lines_when_both_sides_end_unterminated_on_the_changed_line() {
+    // Both `>` and `<` in one hunk: the last line changes and neither side ends
+    // in a newline, so git emits a marker after the `-` AND after the `+`.
+    let tr = TempRepo::fresh();
+    commit_verbatim(&tr, "f.txt", "one\ntwo\nthree");
+    write_file(tr.path(), "f.txt", "one\ntwo\nTHREE");
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .stage_lines(&handle.id, &PathBuf::from("f.txt"), 0, &[0, 1], 3)
+        .expect("stage_lines across both markers");
+
+    assert_eq!(
+        String::from_utf8(staged_bytes(&tr, "f.txt")).unwrap(),
+        "one\ntwo\nTHREE"
+    );
+    assert_index_matches_worktree(&tr, &backend, &handle, "f.txt");
+}
+
+#[test]
+fn stage_hunk_on_a_tracked_file_that_ends_without_a_newline() {
+    // The whole-hunk route is `patch_text_for_lines` with everything selected,
+    // so it shares the defect and has to share the fix.
+    let tr = TempRepo::fresh();
+    commit_verbatim(&tr, "f.txt", "one\ntwo\nthree");
+    write_file(tr.path(), "f.txt", "one\ntwo\nTHREE");
+    let (backend, handle) = tr.open_with_backend();
+
+    // Tracked + non-creating, so stage_hunk applies via libgit2 rather than the
+    // synthesized patch. Unstaging it again is what runs the synthesizer.
+    backend
+        .stage_hunk(&handle.id, Path::new("f.txt"), 0, 3)
+        .expect("stage_hunk");
+    assert_index_matches_worktree(&tr, &backend, &handle, "f.txt");
+
+    backend
+        .unstage_hunk(&handle.id, Path::new("f.txt"), 0, 3)
+        .expect("unstage_hunk on a file with no trailing newline");
+    assert_eq!(
+        String::from_utf8(staged_bytes(&tr, "f.txt")).unwrap(),
+        "one\ntwo\nthree",
+        "unstaging must put the committed bytes back, newline-less last line included"
+    );
+}
+
+#[test]
+fn discard_hunk_on_a_file_that_ends_without_a_newline() {
+    // `patch_text_for_hunk` is `patch_text_for_lines` with everything selected,
+    // so whole-hunk discard runs the same synthesizer — and this one rewrites the
+    // user's worktree, so a rejected patch is a Discard button that does nothing.
+    let tr = TempRepo::fresh();
+    commit_verbatim(&tr, "f.txt", "one\ntwo\nthree");
+    write_file(tr.path(), "f.txt", "one\ntwo\nTHREE");
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .discard_hunk(&handle.id, Path::new("f.txt"), 0, 3)
+        .expect("discard_hunk on a file with no trailing newline");
+
+    assert_eq!(
+        String::from_utf8(worktree_bytes(&tr, "f.txt")).unwrap(),
+        "one\ntwo\nthree",
+        "the committed bytes must come back exactly, newline-less last line included"
+    );
+}
+
+// ─── unstage_lines / discard_lines ───────────────────────────────────────────
+//
+// These run the synthesizer in `Reverse`, where the two markers swap roles: the
+// patch's NEW side is the file being changed, so a `<` on a `+` line describes
+// what is on disk and a `>` on a `-` line describes what it is going back to.
+//
+// The fixture keeps the newline-less change in a hunk of its OWN, away from the
+// edit further up. `patch_text_for_lines` emits in hunk order, and a hunk that
+// mixes a selected `-` with an unselected `+` re-inserts the removed line above
+// the kept one — a real property of the transformation, unrelated to newlines,
+// which would otherwise be what these assertions were measuring.
+
+/// 20 numbered lines, the last of them with no trailing newline. `last` is the
+/// text of line 20 and `third` the text of line 3, so a caller can move exactly
+/// those two and get two hunks at context 3.
+fn twenty_lines(third: &str, last: &str) -> String {
+    let mut s = String::new();
+    for i in 1..=19 {
+        if i == 3 {
+            s.push_str(third);
+            s.push('\n');
+        } else {
+            s.push_str(&format!("line {i}\n"));
+        }
+    }
+    s.push_str(last);
+    s
+}
+
+#[test]
+fn unstage_lines_on_a_file_that_ends_without_a_newline() {
+    let tr = TempRepo::fresh();
+    commit_verbatim(&tr, "f.txt", &twenty_lines("line 3", "line 20"));
+    write_file(tr.path(), "f.txt", &twenty_lines("LINE 3", "LINE 20"));
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .stage(&handle.id, &[PathBuf::from("f.txt")])
+        .expect("stage the whole file");
+    assert_index_matches_worktree(&tr, &backend, &handle, "f.txt");
+
+    // Hunk 1 is the last-line rewrite: -line 20 (0) / +LINE 20 (1), and it is the
+    // one carrying both `\ No newline at end of file` markers.
+    backend
+        .unstage_lines(&handle.id, &PathBuf::from("f.txt"), 1, &[0, 1], 3)
+        .expect("unstage_lines across the newline markers");
+
+    assert_eq!(
+        String::from_utf8(staged_bytes(&tr, "f.txt")).unwrap(),
+        twenty_lines("LINE 3", "line 20"),
+        "only the last line should have been unstaged, and it keeps no newline"
+    );
+}
+
+#[test]
+fn discard_lines_on_a_file_that_ends_without_a_newline() {
+    let tr = TempRepo::fresh();
+    commit_verbatim(&tr, "f.txt", &twenty_lines("line 3", "line 20"));
+    write_file(tr.path(), "f.txt", &twenty_lines("LINE 3", "LINE 20"));
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .discard_lines(&handle.id, &PathBuf::from("f.txt"), 1, &[0, 1], 3)
+        .expect("discard_lines across the newline markers");
+
+    assert_eq!(
+        String::from_utf8(worktree_bytes(&tr, "f.txt")).unwrap(),
+        twenty_lines("LINE 3", "line 20"),
+        "the discarded last line must come back without a trailing newline"
+    );
+}
+
+#[test]
+fn discarding_only_the_removal_moves_the_marker_to_the_line_that_stays() {
+    // Both sides end without a newline and the last line was rewritten:
+    //   -three (no newline) / +THREE (no newline).
+    // Discarding ONLY the removal restores "three" while keeping "THREE", so the
+    // file being written ends on "THREE" — and "three" is no longer last, so it
+    // needs a real newline. Get that backwards and the marker claims the file
+    // ends at "three"; `git apply` then rejects the patch or writes the wrong
+    // bytes. This is the case the three EOFNL origins exist to distinguish.
+    let tr = TempRepo::fresh();
+    commit_verbatim(&tr, "f.txt", "one\ntwo\nthree");
+    write_file(tr.path(), "f.txt", "one\ntwo\nTHREE");
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .discard_lines(&handle.id, &PathBuf::from("f.txt"), 0, &[0], 3)
+        .expect("discard only the removal");
+
+    assert_eq!(
+        String::from_utf8(worktree_bytes(&tr, "f.txt")).unwrap(),
+        "one\ntwo\nthree\nTHREE",
+        "the restored line gains the newline it now needs; only the last line lacks one"
+    );
+}
+
+#[test]
+fn discard_lines_restoring_a_deleted_unterminated_last_line() {
+    let tr = TempRepo::fresh();
+    commit_verbatim(&tr, "f.txt", "one\ntwo\nlast");
+    write_file(tr.path(), "f.txt", "one\ntwo\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .discard_lines(&handle.id, &PathBuf::from("f.txt"), 0, &[0], 3)
+        .expect("discard_lines restoring the unterminated line");
+
+    assert_eq!(
+        String::from_utf8(worktree_bytes(&tr, "f.txt")).unwrap(),
+        "one\ntwo\nlast",
+        "the restored file must end exactly as it was committed"
+    );
+}
+
+// ─── partial selections, where the marker's SIDE is what changes ─────────────
+
+#[test]
+fn staging_only_the_added_line_keeps_the_old_unterminated_line_intact() {
+    // old: "one\ntwo\nthree" (no newline)   new: "one\ntwo\nthree\nfour" (no newline)
+    // Appending to a file that did not end in a newline makes git rewrite the
+    // previous last line: -three(no newline) +three +four(no newline).
+    // Staging ONLY `+four` turns the unselected `-three` into a line that is now
+    // last on the OLD side but no longer last on the NEW side — the one shape a
+    // plain context line cannot express.
+    let tr = TempRepo::fresh();
+    commit_verbatim(&tr, "f.txt", "one\ntwo\nthree");
+    write_file(tr.path(), "f.txt", "one\ntwo\nthree\nfour");
+    let (backend, handle) = tr.open_with_backend();
+
+    // Sanity-check the index space this test depends on.
+    let diff = backend
+        .diff(&handle.id, &PathBuf::from("f.txt"), DiffKind::WorktreeToIndex, 3, false)
+        .expect("diff");
+    let changed: Vec<String> = diff.hunks[0]
+        .lines
+        .iter()
+        .filter_map(|l| match l.kind {
+            DiffLineKind::Addition => Some(format!("+{}", l.content.trim_end_matches('\n'))),
+            DiffLineKind::Deletion => Some(format!("-{}", l.content.trim_end_matches('\n'))),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(changed, vec!["-three", "+three", "+four"], "fixture shape");
+
+    backend
+        .stage_lines(&handle.id, &PathBuf::from("f.txt"), 0, &[2], 3)
+        .expect("stage only the appended line");
+
+    assert_eq!(
+        String::from_utf8(staged_bytes(&tr, "f.txt")).unwrap(),
+        "one\ntwo\nthree\nfour",
+        "the kept line needs its newline back, and only the new last line lacks one"
+    );
+    assert_index_matches_worktree(&tr, &backend, &handle, "f.txt");
+}
+
+// ─── CRLF ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn crlf_line_endings_survive_line_staging() {
+    // A CRLF record already ends in '\n', so no marker is involved — pin it, so
+    // a fix that reaches for `trim_end()` instead of `ends_with('\n')` cannot
+    // quietly eat the '\r'.
+    let tr = TempRepo::fresh();
+    tr.repo.config().unwrap().set_bool("core.autocrlf", false).unwrap();
+    commit_verbatim(&tr, "f.txt", "one\r\ntwo\r\nthree\r\n");
+    write_file(tr.path(), "f.txt", "one\r\nTWO\r\nthree\r\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .stage_lines(&handle.id, &PathBuf::from("f.txt"), 0, &[0, 1], 3)
+        .expect("stage_lines on a CRLF file");
+
+    assert_eq!(
+        String::from_utf8(staged_bytes(&tr, "f.txt")).unwrap(),
+        "one\r\nTWO\r\nthree\r\n"
+    );
+    assert_index_matches_worktree(&tr, &backend, &handle, "f.txt");
+}
+
+#[test]
+fn crlf_without_a_final_newline_survives_line_staging() {
+    // Both traps at once: CRLF endings AND a last line with no terminator, so
+    // the final record is "three" with neither '\r' nor '\n'.
+    let tr = TempRepo::fresh();
+    tr.repo.config().unwrap().set_bool("core.autocrlf", false).unwrap();
+    commit_verbatim(&tr, "f.txt", "one\r\ntwo\r\nthree");
+    write_file(tr.path(), "f.txt", "one\r\nTWO\r\nthree");
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .stage_lines(&handle.id, &PathBuf::from("f.txt"), 0, &[0, 1], 3)
+        .expect("stage_lines on a CRLF file with no trailing newline");
+
+    assert_eq!(
+        String::from_utf8(staged_bytes(&tr, "f.txt")).unwrap(),
+        "one\r\nTWO\r\nthree"
+    );
+    assert_index_matches_worktree(&tr, &backend, &handle, "f.txt");
+}


### PR DESCRIPTION
Found by a code audit of the #212 checklist item *"Staging a hunk in a file with
CRLF / no trailing newline"*. It is a **data-correctness** bug, not a cosmetic one.

## The bug

`patch_text_for_lines` dropped git2's EOFNL origins and then fabricated the
newline they existed to deny:

```rust
if !matches!(origin, '+' | '-' | ' ') { continue; }   // drops '=', '>', '<'
...
if !content.ends_with('\n') { body.push('\n'); }       // invents one
```

`grep -rn "No newline at end of file" src-tauri/` returned **zero hits** — the
marker was never emitted anywhere in the backend. The synthesized text goes to a
real `git apply`, so:

- **Untracked-creation route:** staging a file with no trailing newline staged a
  blob one byte longer than the file on disk, and the row the user just staged
  came straight back as *modified*. It returned `Ok`.
- **Tracked file:** selecting lines in the last hunk produced
  `patch does not apply` in the banner.

`patch_text_for_hunk` delegates to the same function, so whole-hunk unstage and
discard shared it.

## The origins are named for the transition, not the position

Probed against git2 rather than taken from the docs — the names are a trap:

| origin | emitted after | meaning |
|---|---|---|
| `=` CONTEXT_EOFNL | a context line | both sides lack it |
| `>` ADD_EOFNL | a **`-`** line | the OLD side lacks it |
| `<` DEL_EOFNL | a **`+`** line | the NEW side lacks it |

`ADD_EOFNL` following a *removal* is the one that bites. Copying the markers
through on the assumption the name describes the line they follow would have put
the marker on the wrong side — a different corruption, wearing a fix's clothes.

## Why they are regenerated rather than copied

The patch is a **subset**: an unselected `-` becomes context under `Apply`, an
unselected `+` becomes context under `Reverse`, and either side can then carry on
past a line that ended it in the original diff. So the question is not "did git2
hand me a marker" but "does the side I am on still end *here*".

Pass one decides each kept line's marker; pass two resolves `last_old` / `last_new`
— the last line each side actually ends on in the emitted body — and emits the
marker only where the missing newline is real. A line the side continues past
gets a genuine `\n`.

A context line that ends only **one** side cannot express "newline here but not
there", so it is emitted as a `-`/`+` pair, which is git's own spelling of that
state. The pair costs one old line and one new line — exactly what the context
line cost — so the `@@` counts stay correct.

## Verification

RED first, verbatim, against the pre-fix tree — both predicted shapes reproduced:

```
assertion `left == right` failed: the staged blob must not gain a trailing newline the file never had
  left: "a\nb\nc\n"
 right: "a\nb\nc"

stage_lines on the unterminated deleted line: Git("git apply failed: error: patch
failed: f.txt:1\nerror: f.txt: patch does not apply")
```

`14 failed, 2 passed` — the two that passed both ways are deliberate regression
pins (CRLF-with-newline, and a prefix whose last staged line does end in `\n`).

All five callers covered — `stage_lines`, `unstage_lines`, `discard_lines`,
`stage_hunk`'s untracked-creation route, and `patch_text_for_hunk` through both
`unstage_hunk` and `discard_hunk` — plus CRLF. Every assertion is on real bytes
(index blob vs worktree file), and each staging test also asserts the file does
not reappear as modified, since the creation-route bug returned `Ok`.

- `cargo test` — 1176 passing, 0 failing; `no_trailing_newline.rs` 16 passing
- `pnpm test` — 326 files, 3122 passing
- e2e in Docker on this branch: `status-stage.e2e.ts` 7 passing

## Noted, not fixed

Under `Reverse`, a hunk mixing a selected `-` with an unselected `+` re-inserts
the removed line *above* the kept one, because emission follows hunk order. That
is a pre-existing ordering property orthogonal to newlines; it is documented in
the test file rather than worked around silently, and deserves its own issue.

Refs #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
