### PR TITLE
fix(auth): let the credential prompt claim Escape and report cancels

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1467,6 +1467,36 @@ not worked around: a second mechanism for the same job would also fire on `ls`.
   token burns an authentication attempt on a credential we know is empty. Both
   `rememberCredential` call sites guard on `creds` for the same reason.
 
+### The credential prompt is a NESTED dialog (#212)
+
+It is raised BY another surface — the Clone dialog, a push, an auto-fetch — and
+is answered before that surface can go on. Two consequences, and they are the
+same rule stated twice:
+
+- **It paints above the other dialogs and it takes Escape first.**
+  `PGModal`'s `layer="nested"` (`MODAL_Z` in `design/modal.tsx`: base 100,
+  nested 150) and the matching first branch of `app.closeOverlay`. Same
+  z-index would have tie-broken on DOM order, and AppShell mounts
+  `<CredentialDialog />` BEFORE `<CloneDialog />` — so the prompt sat behind
+  the Clone dialog's own backdrop, and the Escape that seemed to dismiss the
+  prompt actually closed the Clone dialog under it. That orphaned the clone:
+  `runClone` drops `busy` before prompting (so the dialog stays dismissable),
+  the retry sets it back without reopening, and `openClone()` refuses to reopen
+  while busy — minutes of clone with no progress bar, no percentage and no
+  Cancel, and a failure that then reported nowhere at all. Keep the two orders
+  in step; a third modal layer belongs in `MODAL_Z`, not in a call site.
+- **Dismissal is "no answer", never an answer** — the rule
+  `pgConfirm`/`pgPrompt`/`pgChoose` already follow. `useAuthStore` splits the
+  two exits: `answer()` clears the prompt because the credential is on its way
+  to `retry`, `dismiss()` clears it and fires the challenge's `onDismiss`.
+  Without that split a cancelled Sign in was SILENT: `withAuthRetry` had
+  swallowed the auth error to raise the prompt and `attempt`'s `finally` had
+  already taken the activity label down, so a push that did not happen looked
+  exactly like one that did. `onDismiss` reports the failure that raised the
+  prompt — the banner via `onError` for `withAuthRetry`'s six call sites, the
+  dialog's own `error` for the clone. Raising a prompt is still not a failure
+  and still reports nothing; only dismissing one is.
+
 ## File lists
 
 - Row glyph + tint from `lib/fileIcon.ts` (`fileIconSpec(path)`); add a

--- a/src/design/modal.tsx
+++ b/src/design/modal.tsx
@@ -1,5 +1,20 @@
 import React from "react";
 
+/**
+ * The two stacking layers a modal can sit on (#212).
+ *
+ * `base` is where every dialog lives. `nested` is for a modal raised BY one of
+ * those and answered before it — the credential prompt over the Clone dialog —
+ * which MUST paint above it: two dialogs on the same z-index tie-break on DOM
+ * order, and AppShell mounts the credential dialog first, so the prompt ended
+ * up behind the Clone dialog's own backdrop, unclickable.
+ *
+ * Between the update panel (`zIndex` 50, an anchored dropdown) and the cheat
+ * sheet (1000, a full-screen overlay). `app.closeOverlay` walks the same order
+ * for Escape — keep the two in step.
+ */
+export const MODAL_Z = { base: 100, nested: 150 } as const;
+
 interface Props {
   children: React.ReactNode;
   /** Backdrop click. Ignored entirely when `dismissable` is false. */
@@ -11,6 +26,9 @@ interface Props {
    * the work with no way to reach it again.
    */
   dismissable?: boolean;
+  /** See [`MODAL_Z`]. Defaults to `base`; only a dialog raised over another
+   *  dialog needs `nested`. */
+  layer?: keyof typeof MODAL_Z;
 }
 
 // Escape is deliberately NOT handled here. It's the keymap's job — wire it
@@ -23,6 +41,7 @@ export function PGModal({
   onCancel,
   width = 480,
   dismissable = true,
+  layer = "base",
 }: Props) {
   return (
     <div
@@ -38,7 +57,7 @@ export function PGModal({
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        zIndex: 100,
+        zIndex: MODAL_Z[layer],
       }}
     >
       <div

--- a/src/features/auth/CredentialDialog.test.tsx
+++ b/src/features/auth/CredentialDialog.test.tsx
@@ -2,6 +2,7 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { PGModal } from "@/design";
 import { CredentialDialog } from "./CredentialDialog";
 import { useAuthStore, type AuthChallengeRequest } from "./useAuthStore";
 import { useSshKeyStore } from "./useSshKeyStore";
@@ -193,6 +194,53 @@ describe("CredentialDialog", () => {
     fireEvent.click(screen.getByTestId("credential-cancel"));
     expect(retry).not.toHaveBeenCalled();
     expect(useAuthStore.getState().challenge).toBeNull();
+  });
+
+  // #212. Cancel is an ANSWERLESS exit, the way pgConfirm/pgPrompt read a
+  // dismissal — and the op that raised the prompt has to hear about it, or a
+  // cancelled Push is indistinguishable from a successful one.
+  it("dismissing tells the op that raised the prompt", () => {
+    const onDismiss = vi.fn();
+    raise({ onDismiss });
+    render(<CredentialDialog />);
+
+    fireEvent.click(screen.getByTestId("credential-cancel"));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("answering the prompt is not a dismissal", async () => {
+    const onDismiss = vi.fn();
+    const retry = raise({ onDismiss });
+    render(<CredentialDialog />);
+    type("credential-secret", "ghp_token");
+
+    fireEvent.click(screen.getByTestId("credential-submit"));
+
+    await waitFor(() => expect(retry).toHaveBeenCalled());
+    // Submitting clears the dialog too — that must not be read as "cancelled"
+    // and report the very failure the retry is busy fixing.
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  // #212. It is raised BY another dialog (Clone) and answered before that
+  // dialog is usable again, so it has to paint over it. Same z-index would
+  // tie-break on DOM order, and AppShell mounts this one FIRST — which put the
+  // prompt behind the Clone dialog's own backdrop.
+  it("paints above the dialog that raised it", () => {
+    raise();
+    const base = render(<PGModal onCancel={() => {}}>base</PGModal>);
+    render(<CredentialDialog />);
+
+    const zOf = (el: Element | null | undefined) =>
+      Number(getComputedStyle(el as Element).zIndex);
+    const baseZ = zOf(base.container.querySelector('[role="dialog"]'));
+    const promptZ = zOf(
+      screen.getByTestId("credential-dialog").closest('[role="dialog"]'),
+    );
+
+    expect(baseZ).toBeGreaterThan(0);
+    expect(promptZ).toBeGreaterThan(baseZ);
   });
 
   it("cannot submit an empty secret", () => {

--- a/src/features/auth/CredentialDialog.tsx
+++ b/src/features/auth/CredentialDialog.tsx
@@ -11,10 +11,18 @@ import { useSshKeyStore } from "./useSshKeyStore";
  *
  * The secret is component state and is never written to the store, so nothing
  * sensitive outlives this component. Cancelling retries nothing — the original
- * error surfaces through the normal banner path.
+ * error surfaces through the normal banner path, via the challenge's
+ * `onDismiss` (#212). That is why answering goes through `answer()` and
+ * cancelling through `dismiss()`: both clear the prompt, and only one of them
+ * means "this op failed".
+ *
+ * Rendered on the `nested` modal layer: it is raised BY another dialog (Clone)
+ * and must paint over it. Escape reaches it through `app.closeOverlay`, which
+ * walks the same stacking order.
  */
 export function CredentialDialog() {
   const challenge = useAuthStore((s) => s.challenge);
+  const answer = useAuthStore((s) => s.answer);
   const dismiss = useAuthStore((s) => s.dismiss);
   const resetSshKeys = useSshKeyStore((s) => s.reset);
 
@@ -78,13 +86,19 @@ export function CredentialDialog() {
         : { secret };
     const doRetry = challenge.retry;
     // Clear before awaiting: the dialog's job is done, and leaving it mounted
-    // over a long fetch reads as if nothing happened.
-    dismiss();
+    // over a long fetch reads as if nothing happened. `answer`, not `dismiss` —
+    // the credential is on its way to the retry, so this is not a cancellation
+    // and must not report the failure the retry is about to fix.
+    answer();
     await doRetry(creds, remember);
   };
 
   return (
-    <PGModal onCancel={dismiss} width={isSsh ? 520 : 460}>
+    <PGModal
+      onCancel={() => void dismiss()}
+      width={isSsh ? 520 : 460}
+      layer="nested"
+    >
       <div
         data-testid="credential-dialog"
         style={{ display: "flex", flexDirection: "column", gap: 12 }}
@@ -176,7 +190,7 @@ export function CredentialDialog() {
         <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
           <PGButton
             variant="ghost"
-            onClick={dismiss}
+            onClick={() => void dismiss()}
             data-testid="credential-cancel"
           >
             {challenge.kind === "SshKey" && !secretLeads ? "Close" : "Cancel"}

--- a/src/features/auth/useAuthStore.ts
+++ b/src/features/auth/useAuthStore.ts
@@ -22,13 +22,36 @@ export interface AuthChallengeRequest {
    * only stops the dialog having to invent one.
    */
   retry: (creds: Credentials | undefined, remember: boolean) => Promise<void>;
+  /**
+   * The prompt was closed with no answer — Cancel, Escape or the backdrop
+   * (#212).
+   *
+   * Supplied by whoever raised it, for the same reason `retry` is: the store
+   * does not know what was being attempted. Without it a dismissal was
+   * SILENT — `withAuthRetry` had already cleared the activity label and
+   * swallowed the original error, so a cancelled push left no banner, no
+   * spinner and no status line, and looked exactly like a push that worked.
+   *
+   * The rule `pgConfirm`/`pgPrompt`/`pgChoose` follow: a dismissal is "no
+   * answer", never an answer — so it reports the failure that raised the
+   * prompt rather than retrying anything.
+   */
+  onDismiss?: () => void | Promise<void>;
 }
 
 interface AuthStoreState {
   /** At most one challenge at a time: a second would fight the first for focus. */
   challenge: AuthChallengeRequest | null;
   raise: (c: AuthChallengeRequest) => void;
-  dismiss: () => void;
+  /**
+   * The dialog has taken the credential and is handing it to `retry`. Clears
+   * the prompt WITHOUT firing `onDismiss` — an answered prompt is not a
+   * cancelled one, and reporting the original failure here would raise a
+   * banner about the very error the retry is in the middle of fixing.
+   */
+  answer: () => void;
+  /** Closed with no answer. Clears the prompt and fires `onDismiss`. */
+  dismiss: () => Promise<void>;
 }
 
 /**
@@ -39,8 +62,17 @@ interface AuthStoreState {
  * global store where a devtools snapshot or a future persistence middleware
  * could pick it up.
  */
-export const useAuthStore = create<AuthStoreState>((set) => ({
+export const useAuthStore = create<AuthStoreState>((set, get) => ({
   challenge: null,
   raise: (challenge) => set({ challenge }),
-  dismiss: () => set({ challenge: null }),
+  answer: () => set({ challenge: null }),
+  // Cleared BEFORE `onDismiss` runs, and read from the store rather than from a
+  // closure: the callback reports a failure, which can re-render anything, and
+  // a challenge still standing then would be a prompt for an op nobody is
+  // waiting on. Reading it first also makes a second dismiss a no-op.
+  dismiss: async () => {
+    const pending = get().challenge;
+    set({ challenge: null });
+    await pending?.onDismiss?.();
+  },
 }));

--- a/src/features/create/useCreateStore.auth.test.ts
+++ b/src/features/create/useCreateStore.auth.test.ts
@@ -129,6 +129,26 @@ describe("clone credential retry", () => {
     expect(calls("remember_credential")[0].args.host).toBe("github.com");
   });
 
+  // #212. Dismissing the prompt leaves the Clone dialog open with its form
+  // intact — but silent, so nothing said the clone had not started. The
+  // failure that raised the prompt is the honest thing to show there.
+  it("reports the original failure in the dialog when the prompt is dismissed", async () => {
+    armClone();
+    await useCreateStore.getState().runClone({
+      url: "https://github.com/me/private.git",
+      parentDir: "/dev",
+      name: "private",
+      options: PLAIN,
+    });
+
+    await useAuthStore.getState().dismiss();
+
+    expect(useCreateStore.getState().error).toContain("Authentication required");
+    // Still the user's dialog, still theirs to retry: form populated, not busy.
+    expect(useCreateStore.getState().open).toBe("clone");
+    expect(useCreateStore.getState().busy).toBe(false);
+  });
+
   it("surfaces a non-auth failure in the dialog without prompting", async () => {
     mockInvoke("clone_repo", () => {
       throw { kind: "Network", message: "could not resolve host" };

--- a/src/features/create/useCreateStore.ts
+++ b/src/features/create/useCreateStore.ts
@@ -157,10 +157,19 @@ export const useCreateStore = create<CreateState>((set, get) => ({
       // Drop `busy` before prompting. `close()` refuses to close while busy, so
       // staying busy would leave the Clone dialog undismissable if the user
       // cancels the credential prompt.
+      //
+      // What it does NOT do any more is leave the dialog open to Escape: the
+      // credential prompt takes that chord first (`app.closeOverlay`), so
+      // dismissing the prompt no longer closes the dialog under it and orphans
+      // the clone with no progress bar and no Cancel button (#212).
       set({ busy: false, progress: null, error: null });
       useAuthStore.getState().raise({
         host,
         kind,
+        // Cancelled the prompt: nothing was cloned, and the dialog is still up
+        // with the form the user typed. Say why it stopped rather than leaving
+        // it looking like the clone simply never started.
+        onDismiss: () => set({ error: appErrorMessage(e) }),
         retry: async (creds, remember) => {
           set({ busy: true, cancelRequested: false, error: null, progress: null });
           try {

--- a/src/features/keymap/actions.test.ts
+++ b/src/features/keymap/actions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { ACTIONS, ALL_ACTION_IDS } from "./actions";
+import { useAuthStore } from "@/features/auth/useAuthStore";
 import { useCreateStore } from "@/features/create/useCreateStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { usePaletteStore } from "@/features/palette/usePaletteStore";
@@ -59,6 +60,7 @@ describe("default runners", () => {
     useNavStore.setState({ intent: null });
     usePaletteStore.setState({ open: false });
     useOverlayStore.setState({ cheatSheetOpen: false });
+    useAuthStore.setState({ challenge: null });
   });
 
   it("nav.* runners fire a switch-screen intent", () => {
@@ -110,6 +112,31 @@ describe("default runners", () => {
     expect(ACTIONS["app.closeOverlay"].run?.()).toBe(true);
     expect(useCreateStore.getState().open).toBe("clone");
     useCreateStore.setState({ open: "none", busy: false });
+  });
+
+  it("app.closeOverlay dismisses the credential prompt before the dialog under it (#212)", async () => {
+    useOverlayStore.setState({ cheatSheetOpen: false });
+    // What the clone-with-a-private-remote flow looks like mid-prompt: the
+    // Clone dialog is still open behind the credential dialog, and not busy —
+    // `runClone` drops `busy` before prompting so the dialog stays dismissable.
+    useCreateStore.setState({ open: "clone", busy: false });
+    useAuthStore.getState().raise({
+      host: "github.com",
+      kind: "Https",
+      retry: async () => {},
+    });
+
+    expect(ACTIONS["app.closeOverlay"].run?.()).toBe(true);
+
+    // The topmost overlay is the one that closes.
+    expect(useAuthStore.getState().challenge).toBeNull();
+    // ...and the clone the prompt belongs to keeps its dialog, so answering
+    // it a second time still has a progress bar and a Cancel button to show.
+    expect(useCreateStore.getState().open).toBe("clone");
+
+    // A second Escape then closes the dialog itself.
+    expect(ACTIONS["app.closeOverlay"].run?.()).toBe(true);
+    expect(useCreateStore.getState().open).toBe("none");
   });
 
   it("app.closeOverlay also closes the update panel", () => {

--- a/src/features/keymap/actions.ts
+++ b/src/features/keymap/actions.ts
@@ -9,6 +9,7 @@
 // A runner returns `false` to decline (nothing to do), letting the key fall
 // through to the browser.
 
+import { useAuthStore } from "@/features/auth/useAuthStore";
 import { useCreateStore } from "@/features/create/useCreateStore";
 import { useCreateTagStore } from "@/features/tags/useCreateTagStore";
 import { useForgeStore } from "@/features/forge/useForgeStore";
@@ -301,6 +302,19 @@ export const ACTIONS: Record<ActionId, ActionDef> = {
     run: () => {
       if (useOverlayStore.getState().cheatSheetOpen) {
         useOverlayStore.getState().closeCheatSheet();
+        return true;
+      }
+      // The credential prompt sits on PGModal's `nested` layer (MODAL_Z in
+      // design/modal.tsx), above every other dialog: it is raised BY one of
+      // them — a clone, a push — and is answered before that dialog is usable
+      // again. So it takes Escape first, or the chord closes the Clone dialog
+      // out from under a prompt that dialog is still waiting on: the clone
+      // then runs with `open === "none"`, no progress bar and no Cancel
+      // button, and `openClone()` refuses to reopen it while busy (#212).
+      // Dismissing is an ANSWERLESS exit and reports the original failure —
+      // see `useAuthStore`.
+      if (useAuthStore.getState().challenge) {
+        void useAuthStore.getState().dismiss();
         return true;
       }
       // Between the cheat sheet (zIndex 1000, topmost) and the update panel

--- a/src/features/repo/useRepoStore.pushAuth.test.ts
+++ b/src/features/repo/useRepoStore.pushAuth.test.ts
@@ -134,6 +134,40 @@ describe.each([
     expect(calls("remember_credential")).toHaveLength(0);
   });
 
+  // #212. Cancelling the prompt used to return the app to exactly its prior
+  // state: no banner, no spinner, no status line — nothing at all to
+  // distinguish "your push did not happen" from "your push worked".
+  it("reports the original failure when the prompt is dismissed", async () => {
+    mockInvoke(cmd, httpsChallenge);
+
+    await run();
+    // Raising the prompt is not yet a failure, so the banner is still clear.
+    expect(useRepoStore.getState().error).toBeNull();
+
+    await useAuthStore.getState().dismiss();
+
+    expect(useRepoStore.getState().error).toEqual({
+      kind: "Auth",
+      message: { host: "github.com", kind: "Https" },
+    });
+  });
+
+  it("reports nothing when the prompt is answered and the retry works", async () => {
+    let attempts = 0;
+    mockInvoke(cmd, () => {
+      attempts += 1;
+      if (attempts === 1) httpsChallenge();
+      return null;
+    });
+
+    await run();
+    await useAuthStore
+      .getState()
+      .challenge!.retry({ username: "ada", secret: "token" }, false);
+
+    expect(useRepoStore.getState().error).toBeNull();
+  });
+
   it("surfaces a non-auth failure without prompting", async () => {
     mockInvoke(cmd, () => {
       throw { kind: "Network", message: "Could not resolve host: github.com" };

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -673,9 +673,17 @@ export function applyRebaseProgress(p: RebaseProgress) {
  * `CredentialDialog` does not answer.
  *
  * The first attempt is always prompt-less, so the common case (a credential
- * helper or ssh-agent already answers) behaves exactly as it did before. A
- * cancelled dialog never calls `onError`, leaving the original error already
- * reported by the caller's own catch.
+ * helper or ssh-agent already answers) behaves exactly as it did before.
+ *
+ * **A dismissed prompt reports the original failure** (#212). It used to return
+ * silently on the theory that "the caller's own catch already reported it" —
+ * but there is no such catch: this function swallowed the auth error to raise
+ * the challenge, and `attempt`'s `finally` had already taken the activity label
+ * down. Cancelling Sign in therefore left no banner, no spinner and no status
+ * line, so a push that did not happen looked exactly like one that did. The
+ * dismissal is routed to `onError` with the very error that raised the prompt,
+ * which is the same banner the user would have seen with no credential flow at
+ * all. Raising the prompt is still NOT a failure and still reports nothing.
  *
  * Exported so a network op owned by ANOTHER feature store can reuse it rather
  * than growing a second retry path — `useForgeStore.checkout` fetches a pull
@@ -719,6 +727,8 @@ export async function withAuthRetry(
     useAuthStore.getState().raise({
       host,
       kind,
+      // The op did not happen, and nothing else is left to say so.
+      onDismiss: () => onError(e),
       retry: async (creds, remember) => {
         try {
           await attempt(creds);


### PR DESCRIPTION
Two findings from the #212 audit, in the same chain. Writing the failing test
surfaced a **third** that neither had named — and it inverts the fix.

## The credential prompt was never on top

`CredentialDialog` is a `PGModal` at z-index 100, exactly like `CloneDialog`, and
`AppShell` mounts it **first**. Equal z-index ties break on DOM order, so the
prompt painted *behind* the Clone dialog's 45%-black backdrop — unclickable. The
RED output said it plainly:

```
expected 100 to be greater than 100
```

That explains the reported symptom exactly: pressing Escape unmounted the Clone
dialog, and that was the only way to *reach* the prompt at all. **Claiming Escape
without fixing the paint order would have made it strictly worse** — an
unanswerable prompt with no way past it.

So the fix is one rule expressed in two places, kept in step by comments on both
sides:

- `src/design/modal.tsx` — a `layer` prop over `MODAL_Z = { base: 100, nested: 150 }`.
  `nested` means "raised BY another dialog and answered before it", and sits in
  the documented gap between the update panel (50, an anchored dropdown) and the
  cheat sheet (1000, full-screen).
- `src/features/keymap/actions.ts` — `app.closeOverlay` walks that same order:
  cheat sheet → credential prompt → create dialogs → create-tag → update panel.
  Extended, not special-cased.

Dismissing now leaves the Clone dialog open, not busy, form populated — which is
what the original `busy: false` comment was protecting. A second Escape closes it.

Two other overlay claims were checked and are unaffected: `PGSelect` registers
`app.closeOverlay` via `useAction` and a component handler beats the default
runner, so an open dropdown still closes first; the palette's Escape is a local
`onKeyDown` that returns early on `defaultPrevented`.

## A dismissed prompt was completely silent

`withAuthRetry` raised the challenge and returned **without calling `onError`**,
and `attempt`'s `finally` had already cleared the activity label. Click Push →
Cancel → the app returned to exactly its prior state: no banner, no spinner, no
status line. Nothing distinguished it from a push that worked.

`CredentialDialog`'s docstring already promised the right behaviour ("the original
error surfaces through the normal banner path"); `withAuthRetry`'s was the false
one — it claimed the caller's own catch reported it, but no such catch exists,
because `withAuthRetry` swallowed the error to raise the challenge. **The code
changed; that docstring was rewritten to state what now happens.**

`useAuthStore` now has two exits instead of one:

- `answer()` — the dialog has taken the credential and is handing it to `retry`.
  Clears the prompt, fires nothing. Reporting the original failure here would
  raise a banner about the very error the retry is fixing.
- `dismiss()` — closed with no answer. Clears the prompt, *then* fires the
  challenge's new optional `onDismiss`.

`onDismiss` is supplied by whoever raised the challenge, exactly as `retry` is, so
the store stays ignorant of the op: `withAuthRetry` passes `() => onError(e)` with
the error that raised the prompt, and `runClone` passes the Clone dialog's own
error slot. The challenge is read and cleared *before* the callback runs, so a
second dismiss is a no-op and no prompt is left standing while a failure
re-renders.

This is the rule `pgConfirm`/`pgPrompt`/`pgChoose` already follow: a dismissal is
"no answer", never an answer.

## Verification

`src/features/repo/useRepoStore.pushAuth.test.ts` is **additions-only** — the
pre-existing assertion that a *raised* challenge writes no error is correct and
still passes untouched. The new tests assert on the *dismissal*, a distinct event.
`useForgeStore`, `useLfsStore` and `useSubmodulesStore` inherit the behaviour
through `withAuthRetry`; no second auth path.

Six tests RED first, across `actions.test.ts`, `CredentialDialog.test.tsx`,
`useRepoStore.pushAuth.test.ts` and `useCreateStore.auth.test.ts`.

- `pnpm test` — 326 files, 3131 passing; `pnpm tsc --noEmit` clean; e2e tsc clean
- e2e in Docker on this branch: `create.e2e.ts` 2 passing

## Noted, not fixed

`runClone`'s `onDismiss` writes its error unguarded, matching the retry catch arm
beside it. The palette renders at z-index 200, above the prompt, so a user could
in principle open "New repository" over an open prompt and land the clone's error
in the Init dialog. Left alone rather than adding a check the surrounding code
does not have — worth revisiting only if the palette's stacking is.

Refs #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
