### PR TITLE
fix(diff): say something when a file has no hunks

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -81,6 +81,50 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
     the webview already knows, and until it fires there simply are no
     dimensions (never `0 × 0`). The backdrop is a checkerboard built from
     `--bg-1`/`--bg-2` so transparency reads in both themes (#236).
+- **A textual diff with ZERO hunks is ordinary, and every surface says so.**
+  Two everyday changes produce a `FileDiff` whose `hunks` is empty: an EMPTY
+  ADDED file (a `.gitkeep` — git writes `new file mode` and no `@@` range), and
+  a MODE-ONLY change (`chmod +x` — `old mode`/`new mode`, no range either).
+  `diff_to_file_diffs` pushes one `FileDiff` per delta in the file callback, and
+  a hunk is only ever opened from the line callback, so the entry arrives with
+  `0 / 0` and nothing to lay out. Before this, `CommitDiffPanel` and the
+  DiffViewer had no branch for it and rendered a blank pane — and
+  `CommitDiffPanel` is what History, CommitDiff and Compare mount, i.e. the
+  screen the app launches on. All four surfaces now print
+  `PGEmpty icon="file" title="No diff"` / "File is tracked but no hunks were
+  produced." for exactly this condition (RepoBrowser keeps its own "No diff
+  available" — its gate is the wider "no diff AND no file content", not this
+  one). The wording is shared on purpose: `isTextualDiff`'s doc comment is the
+  rule, and a file that reads differently depending on which pane you opened it
+  in is the bug.
+  - **The same emptiness reaches the copy menu**, and `diffCopyMenuItems` gates
+    "Copy file diff as text" on `hasCopyableDiffText(diff)` — the rule its own
+    docstring already stated for the other two entries. Unguarded it put `""` on
+    the clipboard and flashed "copied diff", which reads as a working feature.
+    A binary diff has no file-content lines either, so one gate covers both.
+    * **The gate is cheap and the TEXT is lazy**, and that split is the point.
+      `fileDiffToText` walks every line of every hunk and allocates a string per
+      line; the commit-diff paths set no `max_size`, so a checked-in minified
+      blob arrives whole. Building the text to decide whether to SHOW an entry
+      would hitch every right-click on exactly the diffs that are already the
+      weak point — so `hasCopyableDiffText` (`lib/diffCopy.ts`, beside the
+      builder so the two cannot drift) short-circuits at the first content line,
+      and `fileDiffToText` runs in `onClick`.
+    * **Not `hunks.length > 0`.** A hunk is created by the line callback that
+      carries its `@@` header, and that header is itself a `HunkHeader` LINE
+      which `isFileContent` drops — so a hunk holding nothing but its own header
+      passes that test and would offer an entry copying a bare `@@` range with
+      no code. The row model already filters the same way
+      (`h.lines.filter(isFileContent)`), so a header-only hunk renders zero rows
+      too: "has file content" is the predicate both sides mean.
+  - **Follow-up: a mode-only change is legible as "no diff", not as what it is.**
+    Saying "mode changed 100644 → 100755" needs `old_mode`/`new_mode` on
+    `FileDiff` (`git/types.rs`), filled at BOTH construction sites
+    (`libgit2.rs::diff_to_file_diffs` and `diff()`) off
+    `delta.old_file().mode()`/`new_file().mode()`, then a TS field and a line in
+    the shared empty state. Deliberately out of scope of the empty-state fix: it
+    is a backend type change threaded through two diff builders, not a rendering
+    branch, and the blank pane was the user-visible half.
 - **Diff CODE is selectable; diff CHROME is not.** `body` is `user-select: none`
   (native desktop feel), so each row's code cell opts back in with
   `.pg-selectable` (`index.css`) while the line-number cells and the `+`/`−`

--- a/src/design/context-menu.diffcopy.test.tsx
+++ b/src/design/context-menu.diffcopy.test.tsx
@@ -134,4 +134,82 @@ describe("diffCopyMenuItems", () => {
       "Copy file diff as text",
     ]);
   });
+
+  // A textual diff with no hunks is an everyday thing — an empty added file, a
+  // mode-only `chmod +x` — and `fileDiffToText` has nothing to build from. The
+  // entry used to be pushed unconditionally, so it copied "" and flashed
+  // "copied diff": the same rule the two entries above already follow.
+  const empty: FileDiff = { ...diff, additions: 0, deletions: 0, hunks: [] };
+
+  it("offers no whole-file entry when the file has no hunks", () => {
+    expect(labels(diffCopyMenuItems({ diff: empty }))).toEqual([]);
+  });
+
+  it("still offers the dragged text on a file with no hunks", () => {
+    selectText("some code");
+    expect(labels(diffCopyMenuItems({ diff: empty }))).toEqual(["Copy"]);
+  });
+
+  // The case that separates "has hunks" from "has something to copy". A hunk is
+  // only ever created by the line callback that carries its `@@` header, and
+  // that header arrives as a `HunkHeader` LINE — which `isFileContent` drops. So
+  // a hunk holding nothing but its own header is the shape the builder has to
+  // survive, and `hunks.length > 0` would offer an entry that copies a bare
+  // `@@` range and no code.
+  const headerOnly: FileDiff = {
+    ...diff,
+    additions: 0,
+    deletions: 0,
+    hunks: [
+      {
+        header: "@@ -1,1 +1,1 @@",
+        oldStart: 1,
+        oldLines: 1,
+        newStart: 1,
+        newLines: 1,
+        lines: [
+          {
+            kind: { kind: "HunkHeader" },
+            oldLineno: null,
+            newLineno: null,
+            content: "@@ -1,1 +1,1 @@\n",
+          },
+        ],
+      },
+    ],
+  };
+
+  it("offers no whole-file entry when the hunks hold no file content", () => {
+    expect(labels(diffCopyMenuItems({ diff: headerOnly }))).toEqual([]);
+  });
+
+  // The regression guard. `fileDiffToText` walks every line of every hunk and
+  // allocates a string per line; a checked-in minified blob is a real audited
+  // case here, and the commit-diff paths set no `max_size`. Deciding whether to
+  // SHOW the entry must not pay that cost on every right-click — the text is
+  // built when the reader actually clicks Copy.
+  it("does not walk the whole diff just to decide whether to offer the entry", () => {
+    let reads = 0;
+    const lines = diff.hunks[0].lines;
+    const counted = new Proxy(lines, {
+      get(t, k, r) {
+        if (typeof k === "string" && /^\d+$/.test(k)) reads++;
+        return Reflect.get(t, k, r);
+      },
+    });
+    const big: FileDiff = {
+      ...diff,
+      hunks: [{ ...diff.hunks[0], lines: counted }],
+    };
+
+    const items = diffCopyMenuItems({ diff: big });
+    expect(labels(items)).toEqual(["Copy file diff as text"]);
+    // Stops at the first line that is file content, rather than reading all four.
+    expect(reads).toBeLessThan(lines.length);
+
+    // ...and clicking still copies the whole thing.
+    const before = reads;
+    void click(items, "Copy file diff as text");
+    expect(reads).toBeGreaterThan(before);
+  });
 });

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -18,7 +18,11 @@ import type {
   DiffToolTarget,
   FileDiff,
 } from "@/lib/types";
-import { fileDiffToText, selectedLinesToText } from "@/lib/diffCopy";
+import {
+  fileDiffToText,
+  hasCopyableDiffText,
+  selectedLinesToText,
+} from "@/lib/diffCopy";
 import { orderBranchesGrouped } from "@/features/branches/orderBranches";
 import { activePins, pinItem } from "@/features/branches/pins";
 import { openMergeWindow } from "@/features/merge/openMergeWindow";
@@ -418,14 +422,25 @@ export function diffCopyMenuItems(
     });
   }
 
-  items.push({
-    icon: "copy",
-    label: "Copy file diff as text",
-    onClick: () => {
-      navigator.clipboard?.writeText(fileDiffToText(diff));
-      pgFlash("copied diff");
-    },
-  });
+  // GATED, exactly as `dragged` and `lineCount` above are. A textual diff with
+  // no hunks is ordinary — an empty added file, a mode-only `chmod +x` — and so
+  // is a binary one; there is nothing to build from in either case, and the
+  // entry used to copy "" and flash "copied diff".
+  //
+  // The predicate is the cheap one and the TEXT stays lazy: `fileDiffToText`
+  // walks every line and allocates a string per line, so building it here would
+  // hitch every right-click on precisely the huge diffs that are already the
+  // weak point. It runs when the reader actually clicks Copy.
+  if (hasCopyableDiffText(diff)) {
+    items.push({
+      icon: "copy",
+      label: "Copy file diff as text",
+      onClick: () => {
+        navigator.clipboard?.writeText(fileDiffToText(diff));
+        pgFlash("copied diff");
+      },
+    });
+  }
 
   return items;
 }

--- a/src/features/diff/CommitDiffPanel.emptyHunks.test.tsx
+++ b/src/features/diff/CommitDiffPanel.emptyHunks.test.tsx
@@ -1,0 +1,97 @@
+// A textual diff with ZERO hunks still has to say something.
+//
+// Two everyday changes produce a `FileDiff` with no hunks at all: an empty added
+// file (a `.gitkeep`), and a mode-only change (`chmod +x`) — git prints
+// `old mode`/`new mode` and no `@@` range, so the delta reaches the frontend
+// with `0 / 0` and an empty `hunks`. The file row is there, and before this the
+// pane beside it was blank white space with nothing to read and nothing to
+// click. This panel is what History, CommitDiff and Compare render, i.e. the
+// screen the app launches on.
+//
+// The sentence is the one `CommitPanel` already prints for the same condition —
+// `isTextualDiff`'s doc comment is explicit that the surfaces must agree, and a
+// reader who sees one wording on the commit panel and another on a commit's
+// diff learns the two panes disagree about the file.
+
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CommitDiffPanel } from "./CommitDiffPanel";
+import type { FileDiff } from "@/lib/types";
+
+const props = {
+  diffs: [] as FileDiff[],
+  error: null,
+  header: "abc1234 → HEAD",
+  paneIdPrefix: "empty-hunks",
+  loading: false,
+};
+
+/** What a `chmod +x` or an empty added file arrives as. */
+const noHunks = (path: string): FileDiff => ({
+  path,
+  oldPath: null,
+  binary: false,
+  additions: 0,
+  deletions: 0,
+  hunks: [],
+  lfs: null,
+});
+
+const withHunk: FileDiff = {
+  path: "changed.ts",
+  oldPath: null,
+  binary: false,
+  additions: 1,
+  deletions: 0,
+  hunks: [
+    {
+      header: "@@ -1,1 +1,2 @@",
+      oldStart: 1,
+      oldLines: 1,
+      newStart: 1,
+      newLines: 2,
+      lines: [
+        { kind: { kind: "Context" }, oldLineno: 1, newLineno: 1, content: "kept" },
+        {
+          kind: { kind: "Addition" },
+          oldLineno: null,
+          newLineno: 2,
+          content: "added line",
+        },
+      ],
+    },
+  ],
+};
+
+describe("CommitDiffPanel, a file with no hunks", () => {
+  it("explains the empty pane instead of rendering nothing", () => {
+    render(<CommitDiffPanel {...props} diffs={[noHunks("scripts/build.sh")]} />);
+    expect(screen.getByText("No diff")).toBeInTheDocument();
+    expect(
+      screen.getByText("File is tracked but no hunks were produced."),
+    ).toBeInTheDocument();
+  });
+
+  it("still lists the file, so the row and the pane agree", () => {
+    render(<CommitDiffPanel {...props} diffs={[noHunks("scripts/build.sh")]} />);
+    expect(document.querySelector('[data-path="scripts/build.sh"]')).not.toBeNull();
+  });
+
+  it("says nothing of the sort for a file that does have hunks", () => {
+    render(<CommitDiffPanel {...props} diffs={[withHunk]} />);
+    expect(screen.queryByText("No diff")).toBeNull();
+  });
+
+  it("leaves a binary file to its own notice, not this one", () => {
+    // `isTextualDiff` is false there, and the branch above it already renders a
+    // preview or "Binary file — no textual diff.". Two empty states at once
+    // would be worse than the blank pane this replaces.
+    render(
+      <CommitDiffPanel
+        {...props}
+        diffs={[{ ...noHunks("logo.png"), binary: true }]}
+      />,
+    );
+    expect(screen.queryByText("No diff")).toBeNull();
+  });
+});

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  PGEmpty,
   PGFoldSeparator,
   PGIcon,
   PGResizeHandle,
@@ -636,6 +637,16 @@ export function CommitDiffPanel({
                 }
               />
             </>
+          )}
+          {/* Textual, but the row model has nothing to lay out: an empty added
+              file, or a mode-only change (`chmod +x`), which git prints as
+              `old mode`/`new mode` with no `@@` range at all. The file row shows
+              `0 / 0` and this pane was blank white space. Same sentence as
+              `CommitPanel`'s — the surfaces have to agree about a file. */}
+          {current && isTextualDiff(current) && current.hunks.length === 0 && (
+            <PGEmpty icon="file" title="No diff">
+              File is tracked but no hunks were produced.
+            </PGEmpty>
           )}
           {win.topPad > 0 && (
             <div data-pg-spacer="top" style={{ height: `${win.topPad}px` }} />

--- a/src/lib/diffCopy.ts
+++ b/src/lib/diffCopy.ts
@@ -46,6 +46,31 @@ export function fileDiffToText(diff: FileDiff): string {
 }
 
 /**
+ * Is there anything for {@link fileDiffToText} to put on the clipboard?
+ *
+ * The cheap half of that question, and it lives HERE so the two cannot drift:
+ * a caller that offers "copy the file" has to ask the same module that would
+ * build the text, exactly as `selectedLinesToText` shares `isFileContent` with
+ * the row model rather than re-deriving the numbering.
+ *
+ * Short-circuits at the first file-content line. That matters: `fileDiffToText`
+ * walks every line of every hunk and allocates a string per line, and the
+ * commit-diff paths set no `max_size`, so a checked-in minified blob arrives
+ * whole. Building the text merely to decide whether to SHOW a menu entry would
+ * pay that cost on every right-click; this reads one line.
+ *
+ * Deliberately not `hunks.length > 0`: a hunk is created by the line callback
+ * carrying its `@@` header, and that header is itself a `HunkHeader` LINE which
+ * `isFileContent` drops — so a hunk holding nothing but its own header would
+ * pass that test and yield a bare `@@` range with no code. Nor is this exactly
+ * `fileDiffToText(diff) !== ""`, which is true for a multi-hunk headers-only
+ * patch (the joined newlines); there is nothing worth copying there either.
+ */
+export function hasCopyableDiffText(diff: FileDiff): boolean {
+  return diff.hunks.some((h) => h.lines.some(isFileContent));
+}
+
+/**
  * Just the selected changed lines, as bare code — no `+`/`-` prefix and no line
  * numbers, so the result pastes into a source file as-is. That is the same
  * promise the on-screen selection makes, where the gutters are `user-select:

--- a/src/screens/DiffViewer.emptyHunks.test.tsx
+++ b/src/screens/DiffViewer.emptyHunks.test.tsx
@@ -1,0 +1,103 @@
+// The DiffViewer's half of the zero-hunk empty state.
+//
+// Same condition as `features/diff/CommitDiffPanel.emptyHunks.test.tsx` and the
+// same sentence: a textual diff whose `hunks` is empty — an empty added file, or
+// a mode-only `chmod +x`, which git prints as `old mode`/`new mode` with no `@@`
+// range at all. The row shows `0 / 0` and this pane used to show nothing.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { DiffViewerScreen } from "./DiffViewer";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { WithDialogs } from "@/test/dialog";
+import type { FileDiff, FileStatus } from "@/lib/types";
+
+const modified = (path: string): FileStatus =>
+  ({
+    path,
+    worktree: { kind: "Modified" },
+    index: { kind: "Unmodified" },
+    additions: 0,
+    deletions: 0,
+    embedded: false,
+  }) as unknown as FileStatus;
+
+const noHunks = (path: string): FileDiff => ({
+  path,
+  oldPath: null,
+  binary: false,
+  additions: 0,
+  deletions: 0,
+  hunks: [],
+  lfs: null,
+});
+
+function setup(diff: FileDiff) {
+  resetInvokeMock();
+  useSettingsStore.setState({ ignoreWhitespaceInDiff: false });
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
+    status: [modified(diff.path)],
+    branches: [],
+    remotes: [],
+    commits: [],
+    loading: false,
+  } as never);
+  mockInvoke("get_status", () => [modified(diff.path)]);
+  mockInvoke("get_diff", () => diff);
+  mockInvoke("read_file_content", () => null);
+  mockInvoke("read_file_content_at_rev", () => null);
+  mockInvoke("read_image_preview", () => null);
+}
+
+describe("DiffViewer, a file with no hunks", () => {
+  beforeEach(() => resetInvokeMock());
+
+  it("explains the empty pane instead of rendering nothing", async () => {
+    setup(noHunks("scripts/build.sh"));
+    render(
+      <WithDialogs>
+        <DiffViewerScreen />
+      </WithDialogs>,
+    );
+
+    // Queried fresh inside the wait, never held across one: the syntax reads
+    // resolve and re-render this pane, so a node `findByText` handed back can be
+    // detached by the time the assertion reads it (the CI-only failure
+    // `DiffViewer.imagepreview.test.tsx` documents at length).
+    await waitFor(() =>
+      expect(screen.getByText("No diff")).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText("File is tracked but no hunks were produced."),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the binary notice for a binary file, rather than this one", async () => {
+    setup({ ...noHunks("doc.pdf"), binary: true });
+    render(
+      <WithDialogs>
+        <DiffViewerScreen />
+      </WithDialogs>,
+    );
+
+    // Both conditions inside ONE `waitFor`, and neither is optional — the same
+    // shape, for the same reasons, as `DiffViewer.imagepreview.test.tsx`.
+    //
+    // The count alone is the wrong signal: `getInvokeCalls()` records a call
+    // when it is DISPATCHED, so "both reads issued" is not "both results
+    // rendered", and a separate assertion after it reads the pane mid-swap
+    // under CI load. The DOM alone is wrong in the other direction: this pane
+    // renders `title="Binary file"` WHILE the previews load, so waiting on that
+    // text alone passes before either read has landed.
+    await waitFor(() => {
+      expect(
+        getInvokeCalls().filter((c) => c.cmd === "read_image_preview").length,
+      ).toBe(2);
+      expect(screen.getByText("Binary file")).toBeInTheDocument();
+      expect(screen.queryByText("No diff")).toBeNull();
+    });
+  });
+});

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -633,6 +633,18 @@ export function DiffViewerScreen() {
               />
             </>
           )}
+          {/* Textual, but the row model has nothing to lay out: an empty added
+              file, or a mode-only change (`chmod +x`), which git prints as
+              `old mode`/`new mode` with no `@@` range at all. The file row shows
+              `0 / 0` and this pane was blank white space. Not gated on `mode` —
+              neither renderer has anything to draw. Same sentence as
+              `CommitPanel`'s and `CommitDiffPanel`'s: `isTextualDiff`'s whole
+              point is that a file cannot read differently per pane. */}
+          {!diffLoading && isTextualDiff(diff) && diff && diff.hunks.length === 0 && (
+            <PGEmpty icon="file" title="No diff">
+              File is tracked but no hunks were produced.
+            </PGEmpty>
+          )}
           {!diffLoading && isTextualDiff(diff) && diff && mode === "unified" && (
             <>
             <DiffFindBar find={find} />


### PR DESCRIPTION
Two findings from the #212 audit, both about a file whose diff has no hunks.

## A zero-hunk file rendered a blank pane on the launch screen

`CommitDiffPanel` and `DiffViewer` had no `hunks.length === 0` branch, while
`CommitPanel` and `RepoBrowser` both did. `CommitDiffPanel` is what History,
CommitDiff and Compare render — the screen the app launches on.

Two ways to get there, both confirmed against real git (each prints a delta with
**no `@@` range**, `0 0` in `--numstat`):

- an **empty added file** (a `.gitkeep`)
- a **mode-only change** (`chmod +x`)

`diff_to_file_diffs` pushes one `FileDiff` per delta in the *file* callback, while
a hunk is only ever opened from the *line* callback — so the entry arrives with
empty `hunks`. The row showed `0 / 0` and the pane beside it was blank white
space. No message, nothing to click.

`isTextualDiff`'s own doc comment states the invariant this broke: *"Every surface
must agree, or the same file reads differently depending on which pane you opened
it in."* Three surfaces now render the same sentence verbatim. **RepoBrowser
deliberately keeps its own wording** — its gate is the wider "no diff *and* no
file content" in a pane that also renders plain file contents.

**Scope, chosen deliberately:** the empty state only. Making a mode-only change
*legible* ("mode changed 100644 → 100755") means a field on `FileDiff` in
`types.rs` filled at **both** construction sites (`diff_to_file_diffs` and
`diff()`), plus the `lfs.rs` test helper and a TS field — a backend type change
threaded through two diff builders, not a rendering branch. The blank pane was the
user-visible half and it is fixed for both causes; the follow-up is written up in
`docs/dev/frontend.md` with the exact call sites so it need not be re-derived.

## "Copy file diff as text" copied `""` and flashed success

The entry was pushed unconditionally, unlike the two conditional entries above it.
The builder's own docstring three lines up states the rule it broke: *"an entry
that copied an empty string would be worse than no entry."*

Gated on a new `hasCopyableDiffText` in `diffCopy.ts`, beside `fileDiffToText` so
the gate and the builder cannot drift:

```ts
export function hasCopyableDiffText(diff: FileDiff): boolean {
  return diff.hunks.some((h) => h.lines.some(isFileContent));
}
```

**Not `hunks.length > 0`**, and not `fileDiffToText(diff) !== ""`. A hunk is
created with `lines: Vec::new()` and the *same* callback invocation then pushes
the line that carried it — origin `'H'`, a `HunkHeader`, which `isFileContent`
drops. So a hunk holding only its own header is a structurally permitted shape,
and `hunks.length > 0` would put the entry back for it, copying a bare
`@@ -1,1 +1,1 @@` and no code. `fileDiffToText` pushes `h.header` unconditionally,
so a multi-hunk headers-only patch joins to `"\n"` — truthy, and still nothing
worth copying.

This is also the notion the row model already uses
(`h.lines.filter(isFileContent)` in `diffRows.ts`), so a header-only hunk renders
zero rows and the menu now agrees with what the pane shows. Binary diffs are
covered by the same gate — they were silently copying `""` too.

The text stays lazy: `fileDiffToText` runs inside `onClick`, not while building
the menu. An earlier revision gated on the built string, which walked every line
of every hunk on **every right-click** — a real cost on exactly the large diffs
the audit's blob-size finding is about.

## Verification

Every case RED first. The perf regression is now a standing guard — a `Proxy` over
`hunks[0].lines` counts numeric index reads, asserts menu-building reads *fewer*
than all of them, and asserts clicking Copy reads more:

```
FAIL … > does not walk the whole diff just to decide whether to offer the entry
AssertionError: expected 4 to be less than 4
```

- `pnpm test` — 328 files, 3132 passing; `pnpm tsc --noEmit` clean
- e2e in Docker on this branch: `diff-nav.e2e.ts` 2 passing

One thing worth recording: the first `DiffViewer` test passed in isolation and
failed in the full suite — the detached-node race this repo already documents in
`DiffViewer.imagepreview.test.tsx`. Fixed with that file's own recorded pattern
rather than a longer timeout. Running only the single file would have shipped a
CI-only flake.

Refs #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
