### PR TITLE
fix(errors): stop showing users the AppError enum's own spelling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,11 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
   updated in the same commit — and a UNIT variant needs prose in
   `appErrorDetail`, or a banner shows the enum's own spelling.
   `test/appErrors.test.ts` fails the build for both. (`docs/dev/backend.md`)
+- **One error banner — `PGErrorBanner`** from `@/design`. A user never reads a
+  `kind`: the bold prefix is written prose or nothing (`errorBannerLabel` is
+  `Partial` on purpose), and the text is `pre-wrap` so git's multi-line advice
+  survives. `test/appErrors.test.ts` + `error-banner.test.tsx` fail the build
+  for a new surface that spells the enum. (`docs/dev/frontend.md`)
 - **Never `Command::new` outside `src-tauri/src/proc.rs`** — a guard test
   fails the build. Use the `proc::git*`/`proc::program*` constructors.
   (`docs/dev/backend.md`)

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -19,7 +19,11 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   (leads with the kind); `appErrorMessage` for a BANNER (never shows the enum
   spelling). `toAppError` (one definition) wraps for the five stores whose
   `error` field is an `AppError`; plain-string stores call `appErrorMessage`
-  directly.
+  directly. The banner half of that promise is enforced on the SURFACE too —
+  both banners used to bolt `{error.kind}` back on in front of
+  `appErrorMessage`, which is how "NoSignature:" reached a first-run user
+  anyway. One `PGErrorBanner` now, guarded from two directions; see
+  `docs/dev/frontend.md`.
 - **Neither formatter may throw or assume `message` is a string.** `invoke`
   logs a failure BEFORE rethrowing, so a logger exception replaces the original
   rejection — `isAuthError` fails to narrow and no credential prompt is raised.
@@ -152,6 +156,24 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   caller would stack a dialog on the prompt. `useForgeStore.checkout` returns a
   `CheckoutOutcome` (`ok`/`branch-exists`/`auth-pending`/`error`) for exactly
   this; `useCreateStore` hand-rolls the shape for clone.
+- **A pull's failure is not always a network failure (#212).**
+  `map_git_failure` has only two outcomes, because stderr is all it has — right
+  for fetch and push, wrong for the single most ordinary thing that happens to
+  a pull. `pull` therefore runs its result through
+  `net::map_conflicted_pull`, which reconsiders a `Network` verdict **by
+  reading the INDEX**, never the text: git writes `CONFLICT (content): …` to
+  STDOUT and the runner nulls stdout, so the banner used to show git's *fetch
+  summary* under the word "Network" — mislabelled AND undescribed. A conflicted
+  entry is what the resolver operates on and is the same answer for
+  `--no-rebase` and `--rebase`, whose stderr phrasings share nothing. It cannot
+  swallow a real network failure: `git pull` refuses before contacting the
+  remote when the index has unmerged entries, and only `Network` is
+  reconsidered — `Auth` keeps its identity or the credential prompt never
+  opens, `Cancelled` keeps its identity or a user who pressed Cancel is shown a
+  failure they did not have. The status read is best-effort; refining a failure
+  must never replace it. `tests/pull_conflicts.rs` carries the measured git
+  output. Still `Network`, and its own change: `--ff-only`'s "fatal: Not
+  possible to fast-forward, aborting." (a divergence refusal, not a conflict).
 - **Scrub before surfacing:** `map_git_failure` runs `scrub_credentials` first,
   on both branches — git echoes remote URLs, and userinfo ends at the LAST `@`
   (splitting on the first leaks a password containing `@`).

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1250,6 +1250,54 @@ update checks back on for someone who turned them off.
   does NOT (forwards `title` only). Row components need explicit prop threading
   for new attributes.
 
+### One error banner, and it never spells the enum (#212)
+
+`PGErrorBanner` (`src/design/error-banner.tsx`) is the dismissible red strip an
+`AppError` is reported on. AppShell and Reflog render it; a panel that shows a
+failure inline (Submodules, Worktrees, LFS) keeps its own layout around
+`appErrorMessage` and is fine as it is.
+
+Three rules, each of which shipped broken in the two hand-rolled copies it
+replaced:
+
+- **The bold prefix is written prose or nothing** — never `error.kind`. Both
+  banners used to lead with the discriminant, so a fresh machine's first commit
+  read `NoSignature: git needs a name and an email address…` and a failed push
+  read `Network: …` — the exact defect #212 is about, one line downstream of
+  `appErrorMessage`, which exists to prevent it. `errorBannerLabel`
+  (`src/lib/errors.ts`) is a **`Partial`** map on purpose: a missing entry means
+  NO label, so a variant added tomorrow is safe by default. A total `Record`
+  would put the same obligation on every future variant and fail the same way
+  the day someone forgot. Two entries earn themselves today, both because the
+  backend keeps them terse and the sentence is remediation advice
+  (`EmbeddedRepo`, `DubiousOwnership`).
+- **`white-space: pre-wrap`.** A rejected non-fast-forward push is
+  `! [rejected] …` plus git's four-line `hint:` paragraph; `ProgressReader`
+  keeps all of it and a collapsed banner ran the fix into the line above it.
+  The `max-height: 30vh` + `overflow-y: auto` goes on the TEXT, not the strip —
+  a `remote:` banner is unbounded and must not grow until it owns the window,
+  but scrolling the strip would carry the dismiss button out of reach on
+  exactly the errors that most need dismissing. `align-items: flex-start`, or
+  the button floats into the middle of the paragraph.
+- **Remediation travels with the text**, in `errorBannerText`, not in the
+  component: every surface that renders an `AppError` gets the advice, and the
+  advice is testable without a DOM.
+
+Guarded by `src/design/error-banner.test.tsx` (renders the component for every
+variant in the real Rust enum) plus two assertions in `test/appErrors.test.ts`
+(no label may be a kind's own spelling; no shipped `src/` file may interpolate
+a `.kind` into JSX text). End to end, `remote.e2e.ts`'s rejected-push case
+pins that git's `hint:` paragraph still arrives as SEPARATE LINES — jsdom can
+only see the style property, and only a real webview lays the text out. That
+spec previously asserted `toContain("Network")`, so the required CI gate was
+holding the defect in place: an e2e assertion on an `AppError`'s kind is
+always a bug, and `grep`ping `e2e/` for the variant names in `error.rs` found
+exactly one.
+
+Still open, deliberately: the banner reports a rejected push but offers no
+"Pull first / Force-push with lease" button — that is a design change, not a
+legibility fix.
+
 ### A row's trailing action buttons get FIXED slots
 
 `PGWorktreeRow` is the worked example (`git-components.worktreeRow.test.tsx`

--- a/e2e/specs/remote.e2e.ts
+++ b/e2e/specs/remote.e2e.ts
@@ -173,16 +173,50 @@ describe("remote operations", () => {
     );
   });
 
-  it("rejected non-fast-forward push surfaces the error banner", async () => {
+  // The banner is the ONLY thing a rejected push produces, so what it says is
+  // the whole feature. This used to assert `toContain("Network")` — pinning the
+  // enum's own spelling, which the banner led with, which is the defect #212 is
+  // about. The required gate was holding the bug in place. What is worth
+  // pinning instead is what a user can act on: git's reason, and the hint
+  // paragraph that names the fix, still shaped as lines.
+  it("rejected non-fast-forward push shows git's reason and its advice", async () => {
     pair = remoteRepo();
     makeDiverged(pair);
     await openRepo(pair.repo.path);
     const bareBefore = pair.bareGit("rev-parse", "main").trim();
     await $("button*=Push").click(); // titlebar, force=None
-    await $('[role="alert"]').waitForDisplayed({
+    await $('[data-testid="error-banner"]').waitForDisplayed({
       timeout: 20_000, timeoutMsg: "error banner never appeared for rejected push",
     });
-    expect(await $('[role="alert"]').getText()).toContain("Network");
+    // Scoped to the text, so the dismiss button's label is not in the string
+    // (`getText()` on the strip returns "…details.dismiss").
+    const banner = await $('[data-testid="banner-text"]').getText();
+
+    // 1. git's own reason survives the trip through `map_git_failure` and the
+    //    progress reader's tail.
+    expect(banner).toContain("non-fast-forward");
+
+    // 2. ...and so does the advice, AS SEPARATE LINES. This is the whole of the
+    //    `white-space: pre-wrap` fix (#212): without it git's hint paragraph
+    //    arrives as one run-on red line with "use 'git pull' before pushing
+    //    again" buried mid-sentence. Nothing else guards it end to end — a
+    //    component test can assert the style property, but only a real webview
+    //    lays the text out, and `progress::DEFAULT_TAIL_LINES` deciding to keep
+    //    fewer lines would break this and nothing else.
+    //    `>= 3` rather than the exact 4 this git prints: the wording of the
+    //    paragraph is git's, and it has gained and lost a line across releases.
+    const hints = banner.split("\n").filter((l) => l.startsWith("hint:"));
+    expect(hints.length).toBeGreaterThanOrEqual(3);
+    expect(hints.join(" ")).toContain("git pull");
+
+    // 3. and the strip leads with written prose or with nothing — never the
+    //    discriminant. `Network` has no entry in `ERROR_BANNER_LABELS`, so the
+    //    label element must not exist at all; the string check documents the
+    //    exact regression, and is safe here because this fixture's remote is a
+    //    local bare repo, so no git output can mention a network.
+    expect(await $('[data-testid="banner-label"]').isExisting()).toBe(false);
+    expect(banner).not.toContain("Network");
+
     expect(pair.bareGit("rev-parse", "main").trim()).toBe(bareBefore);
   });
 });

--- a/src-tauri/src/commands/branches.rs
+++ b/src-tauri/src/commands/branches.rs
@@ -5,7 +5,7 @@ use crate::{
     error::{AppError, AppResult},
     git::types::{
         BranchInfo, BulkFastForward, FastForward, NetOp, NetProgress, PullMode, PushForce,
-        RemoteInfo, RepoId, StashInfo, TagInfo, TagTarget,
+        RemoteInfo, RepoId, StashInfo, StatusFlag, TagInfo, TagTarget,
     },
     state::AppState,
 };
@@ -344,7 +344,7 @@ pub async fn pull(
         PullMode::Merge => "--no-rebase",
         PullMode::Rebase => "--rebase",
     };
-    run_git_progress(
+    let outcome = run_git_progress(
         &app,
         &path,
         &repo_id,
@@ -354,7 +354,39 @@ pub async fn pull(
         &["pull", "--progress", mode_flag, remote.as_str(), branch.as_str()],
         credentials.as_ref(),
     )
-    .await
+    .await;
+    // A pull is the one network op that also MERGES, so it is the one whose
+    // failure may have nothing to do with the network (#212). The index says
+    // which it was — git's own conflict output goes to stdout, which the runner
+    // discards. See `net::map_conflicted_pull`.
+    match outcome {
+        Ok(()) => Ok(()),
+        Err(e) => Err(crate::commands::net::map_conflicted_pull(
+            e,
+            &conflicted_paths(&state, &repo_id).await,
+        )),
+    }
+}
+
+/// Paths the index reports as conflicted — best effort, on a failure path.
+///
+/// Best effort on purpose: this runs only to REFINE a failure that already
+/// happened, so a status read that itself fails costs a better label, never the
+/// original error.
+async fn conflicted_paths(state: &State<'_, AppState>, repo_id: &RepoId) -> Vec<String> {
+    let backend = state.backend.clone();
+    let id = repo_id.clone();
+    match tokio::task::spawn_blocking(move || backend.status(&id)).await {
+        Ok(Ok(files)) => files
+            .into_iter()
+            .filter(|f| {
+                matches!(f.worktree, StatusFlag::Conflicted)
+                    || matches!(f.index, StatusFlag::Conflicted)
+            })
+            .map(|f| f.path)
+            .collect(),
+        _ => Vec::new(),
+    }
 }
 
 /// Fetch a branch's remote, then advance the branch to its upstream (#246).

--- a/src-tauri/src/commands/net.rs
+++ b/src-tauri/src/commands/net.rs
@@ -88,6 +88,51 @@ pub fn map_git_failure(stderr: &str) -> AppError {
     }
 }
 
+/// How many conflicted paths a message names before it starts counting.
+///
+/// Three fits a banner; forty is a wall, and the resolver lists them all anyway.
+const MAX_NAMED_CONFLICTS: usize = 3;
+
+/// Reconsider a failed pull that turns out to have left CONFLICTS (#212).
+///
+/// `map_git_failure` can only answer "auth" or "network", because stderr is all
+/// it has. That is the right answer for a fetch or a push — and the wrong one
+/// for the single most ordinary thing that happens to a pull, which is the
+/// remote and the local branch touching the same lines. The user was shown
+/// "Network:" over git's *fetch summary*, with the conflict itself nowhere on
+/// screen: git writes "CONFLICT (content): …" to STDOUT, and the runner sends
+/// stdout to `/dev/null` (see `run_git_authenticated_with_progress`, which
+/// keeps exactly one pipe to drain by hand on purpose).
+///
+/// So the verdict comes from the INDEX, not from text: a conflicted entry is
+/// what the resolver operates on, it is the same answer for `--no-rebase` and
+/// `--rebase` — whose stderr phrasings share nothing — and no wording a remote
+/// chooses can fake it.
+///
+/// **This cannot swallow a real network failure.** `git pull` refuses before it
+/// contacts the remote when the index has unmerged entries ("error: Pulling is
+/// not possible because you have unmerged files."), so "the pull failed AND the
+/// index has conflicts" cannot describe a fetch that never reached its remote.
+/// And only a `Network` verdict is reconsidered here: `Auth` keeps its identity
+/// or the credential prompt never opens, `Cancelled` keeps its identity or a
+/// user who pressed Cancel is shown a failure they did not have.
+///
+/// Pinned by `tests/pull_conflicts.rs`, which carries the measured git output.
+pub fn map_conflicted_pull(err: AppError, conflicted: &[String]) -> AppError {
+    if conflicted.is_empty() || !matches!(err, AppError::Network(_)) {
+        return err;
+    }
+    let which = if conflicted.len() <= MAX_NAMED_CONFLICTS {
+        conflicted.join(", ")
+    } else {
+        format!("{} files", conflicted.len())
+    };
+    AppError::ConflictsDetected(format!(
+        "The pull could not merge cleanly — conflicts in {which}. \
+         Resolve the conflicts, then finish the merge or rebase."
+    ))
+}
+
 /// Run `git -C cwd <args>`, mapping a non-zero exit through `map_git_failure`.
 ///
 /// Cancellable (#234, #263): the op registers under `cancel::Scope::Repo(cwd)`

--- a/src-tauri/tests/pull_conflicts.rs
+++ b/src-tauri/tests/pull_conflicts.rs
@@ -1,0 +1,173 @@
+//! A conflicting pull is not a network failure (#212).
+//!
+//! `map_git_failure` has exactly two outcomes — `Auth` when
+//! `classify_auth_failure` recognises the stderr, `Network` for everything
+//! else — and `pull` goes through it. So the single most ordinary thing that
+//! can happen to a pull, the remote and the local branch touching the same
+//! lines, was reported in red as a **network** error. Everything the user
+//! needs is already there (`refreshAll` has run, `OperationBar` offers
+//! "Resolve conflicts"); only the label lied, and a label that lies about the
+//! CATEGORY of a failure is worse than a vague one — it sends the user to
+//! check their wifi.
+//!
+//! ## Why the classifier reads the index and not the stderr
+//!
+//! Measured against git 2.50, `git pull --no-rebase` writes ALL of its conflict
+//! evidence to stdout:
+//!
+//! ```text
+//! stdout: Auto-merging f.txt
+//! stdout: CONFLICT (content): Merge conflict in f.txt
+//! stdout: Automatic merge failed; fix conflicts and then commit the result.
+//! stderr: From /tmp/origin
+//! stderr:  * branch            main       -> FETCH_HEAD
+//! ```
+//!
+//! and `run_git_authenticated_with_progress` sends stdout to `/dev/null` on
+//! purpose — having exactly one pipe to drain by hand is what removes the
+//! deadlock that `wait_with_output` was there to avoid. So the banner's text
+//! was git's *fetch summary*, under the word "Network": the failure was not
+//! merely mislabelled, it was undescribed. Grepping the stderr cannot fix that,
+//! because the words are not in it.
+//!
+//! The index can. A conflicted entry is the ground truth for "this is a
+//! conflict" — it is literally what the resolver operates on — and it is the
+//! same answer for `--no-rebase` and for `--rebase`, whose stderr phrasings
+//! have nothing in common.
+//!
+//! ## Why this cannot swallow a real network failure
+//!
+//! Two guards, and the first is git's own behaviour. `git pull` refuses BEFORE
+//! it contacts the remote when the index has unmerged entries:
+//!
+//! ```text
+//! $ git pull https://nonexistent.invalid/x.git main
+//! error: Pulling is not possible because you have unmerged files.
+//! fatal: Exiting because of an unresolved conflict.
+//! ```
+//!
+//! (verified against git 2.50, exit 128, no network access attempted). So
+//! "the pull failed AND the index has conflicts" cannot describe a fetch that
+//! could not reach its remote — the fetch never ran.
+//!
+//! The second guard is in the function: only a `Network` verdict is
+//! reconsidered. `Auth` keeps its identity or the credential prompt never
+//! opens, and `Cancelled` keeps its identity or a user who pressed Cancel is
+//! shown a failure they did not have.
+
+mod support;
+
+use platypusgit_lib::commands::net::map_conflicted_pull;
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::auth::{AuthChallenge, AuthKind};
+use platypusgit_lib::git::types::StatusFlag;
+use platypusgit_lib::git::GitBackend;
+use support::with_conflicting_merge;
+
+/// The paths a real conflicted repository reports — not a hand-written list,
+/// so the test breaks if `status` ever stops flagging a conflict.
+fn conflicted_paths() -> Vec<String> {
+    let tr = with_conflicting_merge();
+    let (backend, handle) = tr.open_with_backend();
+    let paths: Vec<String> = backend
+        .status(&handle.id)
+        .expect("status")
+        .into_iter()
+        .filter(|f| {
+            matches!(f.worktree, StatusFlag::Conflicted)
+                || matches!(f.index, StatusFlag::Conflicted)
+        })
+        .map(|f| f.path)
+        .collect();
+    assert_eq!(paths, vec!["README.md".to_string()], "fixture drifted");
+    paths
+}
+
+/// The stderr a conflicting merge-pull actually leaves behind: the fetch
+/// summary, and not one word about a conflict.
+const FETCH_SUMMARY: &str =
+    "From /tmp/origin\n * branch            main       -> FETCH_HEAD\n   23c3acd..b4fbbc1  main       -> origin/main";
+
+#[test]
+fn a_pull_that_left_conflicts_is_reported_as_conflicts() {
+    let paths = conflicted_paths();
+    let err = map_conflicted_pull(AppError::Network(FETCH_SUMMARY.into()), &paths);
+    match err {
+        AppError::ConflictsDetected(msg) => {
+            // Names the file, because "there are conflicts" without a path is
+            // one step short of useful in a repository of any size.
+            assert!(msg.contains("README.md"), "{msg}");
+        }
+        other => panic!("expected ConflictsDetected, got {other:?}"),
+    }
+}
+
+#[test]
+fn the_conflict_message_never_carries_gits_fetch_summary() {
+    // The old banner's entire text. It described the successful HALF of the
+    // operation, which is why it read as nonsense next to the word "error".
+    let paths = conflicted_paths();
+    let err = map_conflicted_pull(AppError::Network(FETCH_SUMMARY.into()), &paths);
+    let text = format!("{err}");
+    assert!(!text.contains("FETCH_HEAD"), "{text}");
+}
+
+#[test]
+fn a_clean_failure_stays_a_network_error() {
+    // The genuine article: DNS did not resolve, nothing was merged, the index
+    // is clean. Re-labelling this would be the mirror-image bug.
+    let err = map_conflicted_pull(
+        AppError::Network("fatal: unable to access 'https://x/y': Could not resolve host: x".into()),
+        &[],
+    );
+    assert!(matches!(err, AppError::Network(_)), "got {err:?}");
+}
+
+#[test]
+fn a_network_failure_mentioning_conflict_stays_a_network_error() {
+    // The word means nothing here — only the index does. A remote is free to
+    // print anything at all in a `remote:` banner.
+    let err = map_conflicted_pull(
+        AppError::Network("remote: merge conflict resolution service unavailable".into()),
+        &[],
+    );
+    assert!(matches!(err, AppError::Network(_)), "got {err:?}");
+}
+
+#[test]
+fn an_auth_failure_keeps_its_identity() {
+    // `Auth` is what raises the credential prompt and re-runs the closure.
+    // Re-labelling it would replace a retry with a dead end.
+    let paths = conflicted_paths();
+    let err = map_conflicted_pull(
+        AppError::Auth(AuthChallenge {
+            host: Some("github.com".into()),
+            kind: AuthKind::Https,
+        }),
+        &paths,
+    );
+    assert!(matches!(err, AppError::Auth(_)), "got {err:?}");
+}
+
+#[test]
+fn a_cancelled_pull_keeps_its_identity() {
+    // `isCancelledError` suppresses the banner entirely — the outcome the user
+    // asked for is not a failure to report.
+    let paths = conflicted_paths();
+    let err = map_conflicted_pull(AppError::Cancelled, &paths);
+    assert!(matches!(err, AppError::Cancelled), "got {err:?}");
+}
+
+#[test]
+fn many_conflicted_files_are_counted_rather_than_listed() {
+    // A forty-path banner is a wall, and the resolver lists them all anyway.
+    let many: Vec<String> = (0..40).map(|i| format!("src/f{i}.ts")).collect();
+    let err = map_conflicted_pull(AppError::Network("whatever".into()), &many);
+    match err {
+        AppError::ConflictsDetected(msg) => {
+            assert!(msg.contains("40"), "{msg}");
+            assert!(!msg.contains("src/f39.ts"), "{msg}");
+        }
+        other => panic!("expected ConflictsDetected, got {other:?}"),
+    }
+}

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -5,6 +5,7 @@ import {
   PGActivityBar,
   PGButton,
   PGDialogHost,
+  PGErrorBanner,
   PGIconButton,
   PGStatusBar,
   PGStatusItem,
@@ -76,12 +77,6 @@ import { UpdatePanel } from "@/features/update/UpdatePanel";
 import { useUpdateStore } from "@/features/update/useUpdateStore";
 import { warmSyntax } from "@/lib/syntax";
 import { BranchPicker } from "@/features/branches/BranchPicker";
-import {
-  DUBIOUS_OWNERSHIP_HELP,
-  EMBEDDED_REPO_HELP,
-  appErrorMessage,
-  dubiousOwnershipPath,
-} from "@/lib/errors";
 import {
   currentBranch,
   isConflicted,
@@ -468,54 +463,11 @@ export function AppShell() {
           its three call sites — a context-menu item builder and a palette step —
           are not React components. Renders nothing until one opens it. */}
       <CreateTagDialog />
-      {error && (
-        <div
-          role="alert"
-          style={{
-            padding: "8px 14px",
-            fontSize: "var(--fs-12)",
-            fontFamily: "var(--font-mono)",
-            color: "var(--git-removed)",
-            background: "oklch(0.68 0.18 25 / 0.1)",
-            borderBottom: "1px solid oklch(0.68 0.18 25 / 0.35)",
-            display: "flex",
-            alignItems: "center",
-            gap: 8,
-          }}
-        >
-          {/* The backend keeps EmbeddedRepo and DubiousOwnership terse like
-              the rest of the enum; the actionable half of the story lives in
-              the UI. A dismissed trust prompt must not leave the user staring
-              at libgit2's sentence with nothing to do about it. */}
-          <strong>
-            {error.kind === "EmbeddedRepo"
-              ? "Embedded repository"
-              : error.kind === "DubiousOwnership"
-                ? "Repository owned by another user"
-                : error.kind}
-            :
-          </strong>
-          <span style={{ flex: 1 }}>
-            {error.kind === "EmbeddedRepo"
-              ? `${appErrorMessage(error).replace(/^embedded repository: /, "")} — ${EMBEDDED_REPO_HELP}`
-              : error.kind === "DubiousOwnership"
-                ? `${dubiousOwnershipPath(error)} — ${DUBIOUS_OWNERSHIP_HELP}`
-                : appErrorMessage(error)}
-          </span>
-          <button
-            onClick={clearError}
-            style={{
-              background: "transparent",
-              border: "none",
-              color: "inherit",
-              cursor: "pointer",
-              fontSize: "var(--fs-11)",
-            }}
-          >
-            dismiss
-          </button>
-        </div>
-      )}
+      {/* One banner, shared with Reflog (#212). It leads with written prose or
+          with nothing — never with the enum's own spelling — and preserves the
+          newlines in git's multi-line advice. The remediation the two terse
+          variants need travels with the text, in `errorBannerText`. */}
+      {error && <PGErrorBanner error={error} onDismiss={clearError} />}
       {/* Below the banner (which is transient) and above the screens (which
           all need to know): the standing "a merge/rebase is open" signal, and
           the only route to the resolver now that the Conflicts tab is gone. */}

--- a/src/design/error-banner.test.tsx
+++ b/src/design/error-banner.test.tsx
@@ -1,0 +1,138 @@
+// PGErrorBanner — the one surface an `AppError` is reported on (#212).
+//
+// Two defects lived in the markup this component replaces, and both are pinned
+// here because neither was visible to a test of `appErrorMessage` alone:
+//
+//  1. The banner printed the ENUM's spelling. `appErrorMessage` was written so
+//     it never would — `docs/dev/backend.md` says as much — and then both
+//     banners bolted `{error.kind}` back on in front of it. A fresh machine's
+//     first commit read "NoSignature: git needs a name and an email address…",
+//     a failed push read "Network: …". `test/appErrors.test.ts` could not see
+//     it: it asked the formatter, and the formatter was innocent.
+//
+//  2. Multi-line git output collapsed into one run-on line. A rejected
+//     non-fast-forward push is `! [rejected] … (fetch first)` plus git's
+//     four-line `hint:` paragraph; `ProgressReader` keeps all of it
+//     (`DEFAULT_TAIL_LINES`) and the banner then threw the shape away, so the
+//     hint that names the fix ran into the line above it.
+//
+// The first assertion runs over the REAL Rust enum, so a variant added tomorrow
+// is covered whether or not anyone remembers this file.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import type { AppError } from "@/lib/errors";
+import { PGErrorBanner } from "./error-banner";
+
+/** Every variant of Rust's `AppError`, parsed the way `appErrors.test.ts`
+ *  parses it — the enum declaration is where a variant comes into existence. */
+function rustVariants(): string[] {
+  const src = readFileSync(
+    resolve(process.cwd(), "src-tauri/src/error.rs"),
+    "utf8",
+  );
+  const start = src.indexOf("pub enum AppError {");
+  const block = src.slice(start, src.indexOf("\n}", start));
+  const names = [...block.matchAll(/^ {4}([A-Z][A-Za-z0-9]*)(\(|,)/gm)].map(
+    (m) => m[1],
+  );
+  expect(names.length, "parsed no AppError variants").toBeGreaterThan(20);
+  return names;
+}
+
+/** A sentence that shares no substring with any variant's spelling, so a hit
+ *  below can only have come from the discriminant. */
+const PROSE = "the sentence a human is supposed to read";
+
+const banner = (error: AppError) =>
+  render(<PGErrorBanner error={error} onDismiss={() => {}} />);
+
+describe("PGErrorBanner", () => {
+  it("never puts a variant's own spelling on screen", () => {
+    for (const kind of rustVariants()) {
+      const { unmount } = banner({ kind, message: PROSE } as AppError);
+      const text = screen.getByRole("alert").textContent ?? "";
+      expect(text, `${kind} leaked its enum spelling into the banner`).not.toContain(
+        kind,
+      );
+      // ...and said SOMETHING. Several variants answer with prose of their own
+      // rather than the payload (`Unborn`, `NoSignature`, `StaleStash`), which
+      // is the point of `appErrorDetail` — so this asserts a sentence exists,
+      // not which sentence it is.
+      const said = screen.getByTestId("banner-text").textContent ?? "";
+      expect(said.length, `${kind} rendered an empty banner`).toBeGreaterThan(10);
+      unmount();
+    }
+  });
+
+  it("leads with a written category only where somebody wrote one", () => {
+    // Two variants keep a bold prefix because the backend keeps them terse and
+    // the category is the fastest way to recognise the situation.
+    banner({ kind: "EmbeddedRepo", message: "embedded repository: vendor/lib/" });
+    expect(screen.getByTestId("banner-label").textContent).toContain(
+      "Embedded repository",
+    );
+  });
+
+  it("has no label at all for a variant whose sentence stands alone", () => {
+    banner({ kind: "Network", message: "fatal: could not resolve host" });
+    expect(screen.queryByTestId("banner-label")).toBeNull();
+    expect(screen.getByRole("alert").textContent).toContain(
+      "could not resolve host",
+    );
+  });
+
+  it("carries the remediation prose for an embedded repository", () => {
+    banner({ kind: "EmbeddedRepo", message: "embedded repository: vendor/lib/" });
+    const text = screen.getByRole("alert").textContent ?? "";
+    expect(text).toContain("vendor/lib/");
+    expect(text).toContain(".gitignore");
+    // The backend's own prefix is the enum's vocabulary, not the user's.
+    expect(text).not.toContain("embedded repository:");
+  });
+
+  it("carries the remediation prose for a dubious-ownership refusal", () => {
+    banner({
+      kind: "DubiousOwnership",
+      message: "repository is owned by another user: /mnt/c/dev/x",
+    });
+    const text = screen.getByRole("alert").textContent ?? "";
+    expect(text).toContain("/mnt/c/dev/x");
+    expect(text).toContain("safe.directory");
+  });
+
+  it("keeps every line of git's multi-line output", () => {
+    // Verbatim from a rejected non-fast-forward push. The `hint:` paragraph is
+    // the half that says what to do, and it is the half a collapsed banner ran
+    // together with the line above it.
+    const push = [
+      " ! [rejected]        main -> main (fetch first)",
+      "error: failed to push some refs to 'origin'",
+      "hint: Updates were rejected because the remote contains work that you do",
+      "hint: not have locally. This is usually caused by another repository",
+      "hint: pushing to the same ref.",
+    ].join("\n");
+    banner({ kind: "Network", message: push });
+    const body = screen.getByTestId("banner-text");
+    expect(body.textContent).toBe(push);
+    // `pre-wrap`, not `pre`: the newlines survive AND a long line still wraps
+    // inside the strip rather than scrolling the whole app sideways.
+    expect(body.style.whiteSpace).toBe("pre-wrap");
+  });
+
+  it("dismisses", async () => {
+    const onDismiss = vi.fn();
+    render(
+      <PGErrorBanner
+        error={{ kind: "Git", message: "boom" }}
+        onDismiss={onDismiss}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+});

--- a/src/design/error-banner.tsx
+++ b/src/design/error-banner.tsx
@@ -1,0 +1,93 @@
+// PGErrorBanner (#212) — the red strip an `AppError` is reported on.
+//
+// One component because there were two copies of this markup (AppShell's and
+// Reflog's) and they had drifted in the two ways that mattered:
+//
+//   - Both led with `{error.kind}`, so the user read the Rust enum's own
+//     spelling ("NoSignature:", "Network:", "Git:") in front of the sentence
+//     `appErrorMessage` exists to produce. The label is now written prose or
+//     nothing at all — see `errorBannerLabel`.
+//   - Neither preserved newlines, so git's multi-line advice (a rejected push
+//     is `! [rejected] …` plus a four-line `hint:` paragraph, all of which the
+//     backend keeps — `progress::DEFAULT_TAIL_LINES`) arrived as one run-on
+//     line with the fix buried in the middle of it. The clone dialog's error
+//     slot had `pre-wrap` from the start; this is the same treatment.
+//
+// Not every `AppError` surface is this: a panel that shows a failure inline
+// (Submodules, Worktrees, LFS) renders `appErrorMessage` in its own layout and
+// is fine as it is. This is for the dismissible strip.
+
+import {
+  errorBannerLabel,
+  errorBannerText,
+  type AppError,
+} from "@/lib/errors";
+
+export function PGErrorBanner({
+  error,
+  onDismiss,
+  compact = false,
+}: {
+  error: AppError;
+  onDismiss: () => void;
+  /** Tighter padding for a banner inside a screen rather than under the tab
+   *  bar. The only thing the two call sites ever disagreed about. */
+  compact?: boolean;
+}) {
+  const label = errorBannerLabel(error);
+  return (
+    <div
+      role="alert"
+      data-testid="error-banner"
+      style={{
+        padding: compact ? "6px 12px" : "8px 14px",
+        fontSize: "var(--fs-12)",
+        fontFamily: "var(--font-mono)",
+        color: "var(--git-removed)",
+        background: "oklch(0.68 0.18 25 / 0.1)",
+        borderBottom: "1px solid oklch(0.68 0.18 25 / 0.35)",
+        display: "flex",
+        // `flex-start`, not `center`: a multi-line message would otherwise
+        // float the dismiss button into the middle of the paragraph.
+        alignItems: "flex-start",
+        gap: 8,
+      }}
+    >
+      {label && (
+        // The testids deliberately do not start with "error-banner": a
+        // WebdriverIO `[data-testid="error-banner"]*=text` selector compiles to
+        // a SUBSTRING attribute match plus an innermost-only filter, so a child
+        // sharing the stem makes the container match nothing, silently. Same
+        // reason `hook-output`'s body is `hook-body`.
+        <strong data-testid="banner-label">{label}:</strong>
+      )}
+      <span
+        data-testid="banner-text"
+        style={{
+          flex: 1,
+          whiteSpace: "pre-wrap",
+          // git's `hint:` paragraphs are bounded (twenty lines) but a remote's
+          // `remote:` banner is not, so the TEXT scrolls rather than the strip:
+          // scrolling the strip would carry the dismiss button out of reach on
+          // exactly the errors that most need dismissing.
+          maxHeight: "30vh",
+          overflowY: "auto",
+        }}
+      >
+        {errorBannerText(error)}
+      </span>
+      <button
+        onClick={onDismiss}
+        style={{
+          background: "transparent",
+          border: "none",
+          color: "inherit",
+          cursor: "pointer",
+          fontSize: "var(--fs-11)",
+        }}
+      >
+        dismiss
+      </button>
+    </div>
+  );
+}

--- a/src/design/index.ts
+++ b/src/design/index.ts
@@ -10,6 +10,7 @@ export * from "./ui-helpers";
 export * from "./empty-state";
 export * from "./hook-output";
 export * from "./error-boundary";
+export * from "./error-banner";
 export * from "./modal";
 export * from "./use-prevent-browser-context-menu";
 export * from "./resizable";

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -526,3 +526,70 @@ export function isSshKeygenUnavailableError(e: unknown): boolean {
 
 export const SSH_KEYGEN_UNAVAILABLE_HELP =
   "Generating a key needs ssh-keygen, which ships with OpenSSH (and with Git for Windows). Install it and reopen this dialog, or create the key from a terminal with `ssh-keygen -t ed25519`.";
+
+/**
+ * The short bold category a banner may lead with — WRITTEN PROSE or nothing.
+ *
+ * `Partial`, and that is the whole design (#212). The banner used to read
+ *
+ *     {kind === "EmbeddedRepo" ? "Embedded repository"
+ *       : kind === "DubiousOwnership" ? "Repository owned by another user"
+ *       : kind}
+ *
+ * so two variants got a label somebody wrote and the other thirty printed the
+ * Rust enum's own spelling: "NoSignature:", "Network:", "Git:", "Auth:". The
+ * fix is not a bigger map — a total `Record` would put the same obligation on
+ * every future variant and default to the same failure the day someone forgot.
+ * It is that a MISSING entry means NO LABEL: `appErrorMessage` already returns
+ * a whole sentence, so the default banner is that sentence and nothing else.
+ *
+ * An entry therefore has to earn itself. These two do, for one reason: the
+ * backend keeps them terse on purpose (`embedded repository: vendor/lib/`) and
+ * the prose that follows is remediation advice, so without the category the
+ * strip opens on a bare path. Everywhere else the label would only restate the
+ * sentence beside it.
+ *
+ * `Partial<Record<AppError["kind"], string>>` also makes a typo'd or removed
+ * variant a compile error, and `test/appErrors.test.ts` fails the build if any
+ * entry is ever set to the kind's own spelling.
+ */
+const ERROR_BANNER_LABELS: Partial<Record<AppError["kind"], string>> = {
+  EmbeddedRepo: "Embedded repository",
+  DubiousOwnership: "Repository owned by another user",
+};
+
+/** The banner's bold prefix, or `null` when the sentence stands on its own. */
+export function errorBannerLabel(e: AppError): string | null {
+  try {
+    return ERROR_BANNER_LABELS[e.kind] ?? null;
+  } catch {
+    // Same contract as `appErrorMessage`: this runs in render, so an exotic
+    // payload costs a label, never the screen.
+    return null;
+  }
+}
+
+/**
+ * The whole sentence a banner shows — `appErrorMessage` plus the remediation
+ * the two terse variants need.
+ *
+ * The split of duties is the one the rest of this file already makes: the Rust
+ * error carries the identifier (a path), the words live next to the UI that can
+ * act on them. It lives HERE rather than in the banner component so both are
+ * true at once — every surface that renders an `AppError` gets the advice, and
+ * the advice is testable without a DOM.
+ */
+export function errorBannerText(e: AppError): string {
+  try {
+    if (e.kind === "EmbeddedRepo") {
+      const path = appErrorMessage(e).replace(/^embedded repository: /, "");
+      return `${path} — ${EMBEDDED_REPO_HELP}`;
+    }
+    if (e.kind === "DubiousOwnership") {
+      return `${dubiousOwnershipPath(e)} — ${DUBIOUS_OWNERSHIP_HELP}`;
+    }
+    return appErrorMessage(e);
+  } catch {
+    return appErrorMessage(e);
+  }
+}

--- a/src/screens/Reflog.tsx
+++ b/src/screens/Reflog.tsx
@@ -3,6 +3,7 @@ import {
   PGButton,
   PGCommitRow,
   PGEmpty,
+  PGErrorBanner,
   PGIconButton,
   PGToolbar,
   PGSpinner,
@@ -19,7 +20,6 @@ import {
 } from "@/features/reflog/DirtyTreeDialog";
 import { commitDateText, commitDateTitle, preciseTime } from "@/lib/commitDate";
 import { useDateFormat } from "@/features/settings/useSettingsStore";
-import { appErrorMessage } from "@/lib/errors";
 import { PGPane, FocusableScroll, usePaneList } from "@/features/keymap";
 import type { FileDiff, ReflogOp } from "@/lib/types";
 
@@ -179,35 +179,7 @@ export function ReflogScreen() {
       }}
     >
       {error && (
-        <div
-          role="alert"
-          style={{
-            padding: "6px 12px",
-            fontSize: "var(--fs-12)",
-            fontFamily: "var(--font-mono)",
-            color: "var(--git-removed)",
-            background: "oklch(0.68 0.18 25 / 0.1)",
-            borderBottom: "1px solid oklch(0.68 0.18 25 / 0.35)",
-            display: "flex",
-            alignItems: "center",
-            gap: 8,
-          }}
-        >
-          <strong>{error.kind}:</strong>
-          <span style={{ flex: 1 }}>{appErrorMessage(error)}</span>
-          <button
-            onClick={clearError}
-            style={{
-              background: "transparent",
-              border: "none",
-              color: "inherit",
-              cursor: "pointer",
-              fontSize: "var(--fs-11)",
-            }}
-          >
-            dismiss
-          </button>
-        </div>
+        <PGErrorBanner error={error} onDismiss={clearError} compact />
       )}
       <PGToolbar
         right={

--- a/test/appErrors.test.ts
+++ b/test/appErrors.test.ts
@@ -22,11 +22,15 @@
 // does NOT check is whether the prose is any good — only that somebody wrote
 // some.
 
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { appErrorMessage } from "../src/lib/errors";
+import {
+  appErrorMessage,
+  errorBannerLabel,
+  type AppError,
+} from "../src/lib/errors";
 
 const read = (rel: string) => readFileSync(resolve(process.cwd(), rel), "utf8");
 
@@ -121,3 +125,120 @@ describe("AppError stays 1:1 with the frontend union", () => {
     }
   });
 });
+
+/**
+ * SHIPPED frontend source: every `.ts`/`.tsx` under `src/` that is not a test
+ * and not the jsdom harness. Same walk (and the same reason for it) as
+ * `test/nativeSelect.test.ts` — the property is about what the webview renders,
+ * and a test's own prose names the very thing it asserts the absence of.
+ */
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "test") continue;
+      out.push(...sourceFiles(p));
+    } else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+/** Comments stripped first, so prose explaining the rule cannot break it. */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+}
+
+// The banner half of the same promise, and the hole the tests above could not
+// see (#212 follow-up).
+//
+// `appErrorMessage` was written so a banner NEVER shows the enum's spelling —
+// `docs/dev/backend.md` says so in as many words. Both banners then bolted the
+// kind back on in front of it:
+//
+//     <strong>{error.kind}:</strong><span>{appErrorMessage(error)}</span>
+//
+// So a fresh machine's first commit read "NoSignature: git needs a name and an
+// email address…", a failed push read "Network: …", and a refused merge read
+// "Git: …" — the exact defect #212 names, reintroduced one line downstream of
+// the function that exists to prevent it. Everything above stayed green because
+// it only ever asked `appErrorMessage`, never the surface.
+//
+// Two assertions close it. The first is over the REAL enum, so a variant added
+// tomorrow is covered without anyone remembering this file exists; the second
+// forbids the markup that caused it, anywhere in shipped `src/`.
+describe("a banner never shows the enum's own spelling", () => {
+  const variants = rustVariants();
+
+  it("gives every variant either written prose or no label at all", () => {
+    const leaked = variants
+      .map((v) => ({
+        name: v.name,
+        // `as unknown as AppError`: the names come from the Rust file at run
+        // time, so they are plain strings as far as the type-checker knows.
+        label: errorBannerLabel({
+          kind: v.name,
+          message: "some prose",
+        } as unknown as AppError),
+      }))
+      // `null` is the deliberate default: the sentence stands on its own and
+      // there is nothing bold in front of it. A label is opt-in PROSE, so the
+      // one thing it may never be is the discriminant it was written to hide.
+      .filter(
+        ({ name, label }) =>
+          label !== null && (label === name || label.includes(name)),
+      );
+    expect(
+      leaked,
+      "AppError variants whose banner label is the enum's own spelling. " +
+        "`errorBannerLabel` returns a human category or null — never `e.kind`. " +
+        "Write a short label in ERROR_BANNER_LABELS, or leave the variant out " +
+        "and let the sentence carry the banner on its own.",
+    ).toEqual([]);
+  });
+
+  it("has no surface interpolating a kind into JSX text", () => {
+    const files = sourceFiles(resolve(process.cwd(), "src"));
+    // A broken walk would make the assertion below vacuous.
+    expect(files.length).toBeGreaterThan(100);
+    const offenders: string[] = [];
+    for (const file of files) {
+      const code = stripComments(readFileSync(file, "utf8"));
+      if (RENDERS_A_KIND.some((re) => re.test(code))) {
+        offenders.push(relative(process.cwd(), file));
+      }
+    }
+    expect(
+      offenders,
+      "Files rendering a `.kind` discriminant as JSX text. Render an " +
+        "`AppError` with `PGErrorBanner` from `@/design` — the discriminant is " +
+        "for narrowing and for the log file, never for a user.",
+    ).toEqual([]);
+  });
+});
+
+/**
+ * The two spellings that actually shipped, as source patterns.
+ *
+ * Narrow on purpose. `kind` is an ordinary discriminant all over this tree
+ * (graph lanes, palette entries, dialog requests), and it is passed as a PROP
+ * (`kind={ln.kind}`) and built into keys (`` key={`${b.kind}:${b.name}`} ``)
+ * dozens of times — all legitimate, none of it text a user reads. So these
+ * match only a JSX *text child*:
+ *
+ *   `<strong>{error.kind}:</strong>`            — Reflog's banner
+ *   `{a ? "…" : b ? "…" : error.kind}`          — AppShell's banner
+ *
+ * Stated honestly, in the shape `spawn_no_window.rs` uses: this greps, and a
+ * determined third spelling (a `const label = error.kind` hoisted out of the
+ * JSX) would slip past it. `error-banner.test.tsx` is the assertion that
+ * cannot be dodged — it renders the real component for every variant in the
+ * real enum. This one exists to stop the CHEAP mistake, which is the one that
+ * happened twice.
+ */
+const RENDERS_A_KIND = [
+  />\s*\{\s*[A-Za-z_$][\w$.]*\.kind\s*\}/,
+  /\{[^{}]*\?[^{}]*:\s*[A-Za-z_$][\w$.]*\.kind\s*\}/,
+];


### PR DESCRIPTION
Three findings from the #212 audit. Error legibility is that issue's recurring
theme — *"is the error actionable or does it just say 'failed'?"*.

## 1. Every banner led with the raw `AppError` enum name

`AppShell.tsx` special-cased two variants and printed the Rust spelling for the
other thirty; `Reflog.tsx` did the same with no special cases at all. Users saw
**`NoSignature:`**, **`Network:`**, **`Git:`**, **`Auth:`**.

That contradicts the rule in `docs/dev/backend.md` — *"`appErrorMessage` for a
BANNER (never shows the enum spelling)"* — by bolting the kind back on in front of
the very function written to avoid it. `test/appErrors.test.ts` could not see it,
which is why it shipped.

Both hand-rolled banners are now one `PGErrorBanner` in `src/design/`.
`errorBannerLabel` is a **`Partial`** map on purpose: a missing entry means *no
bold prefix at all*, so the safe outcome is the one you get by doing nothing. A
total `Record` would put the same obligation on every future variant and fail the
day someone forgets.

Two entries earn themselves today — `EmbeddedRepo` and `DubiousOwnership` —
because the backend keeps those terse (`embedded repository: vendor/lib/`) and the
prose that follows is remediation advice, so without a category the strip opens on
a bare path. Everywhere else the label only restated the sentence beside it.
Reflog *gains* the remediation prose it never had, since that composition moved
into `errorBannerText`.

## 2. A conflicting pull was reported as a network error — and the audit
##    under-called it

The audit said the banner showed git's merge output under the wrong label.
Measured against git 2.50, that is not what happens: `git pull --no-rebase` writes
`Auto-merging` / `CONFLICT (content):` / `Automatic merge failed…` entirely to
**stdout**, and `run_git_authenticated_with_progress` nulls stdout
(`net.rs:188`). So the banner showed git's *fetch summary* — `From /tmp/origin`,
`* branch main -> FETCH_HEAD` — under the word "Network". Not merely mislabelled:
**undescribed**. No amount of stderr grepping could have fixed it; the words are
not there.

`net::map_conflicted_pull(err, &conflicted)` reconsiders a `Network` verdict when
the index has conflicted entries. That is ground truth — it is literally what the
resolver operates on — and it gives the same answer for `--rebase` and
`--no-rebase`, whose stderr phrasings share nothing.

Two things stop it swallowing a real network failure:

- **git's own ordering.** Verified: `git pull https://nonexistent.invalid/x.git main`
  with unmerged files present exits 128 with *"Pulling is not possible because you
  have unmerged files"* — **before** touching the network. So "pull failed AND the
  index has conflicts" cannot describe an unreachable remote.
- **Only `Network` is reconsidered.** `Auth` keeps its identity or the credential
  prompt never opens; `Cancelled` keeps its identity or a user who pressed Cancel
  gets a failure they did not have. Both pinned by tests.

The status read in `conflicted_paths` is best-effort — refining a failure must
never replace it.

## 3. Multi-line git output collapsed into one run-on red line

`white-space: pre-wrap` on the text, plus `align-items: flex-start`. The
`max-height: 30vh` + `overflow-y: auto` goes on the **text**, not the strip:
scrolling the strip would carry the dismiss button out of reach on exactly the
errors that most need dismissing.

## Guard tests — the gap that let this ship

- `test/appErrors.test.ts` (+2): over the **real Rust enum**, no variant's banner
  label may be its own spelling; and no shipped `src/` file may interpolate a
  `.kind` into JSX *text*. The second is two narrow regexes that caught exactly
  `AppShell.tsx` and `Reflog.tsx` and nothing else — `kind={ln.kind}` props and
  `` key={`${b.kind}:…`} `` are legitimate and untouched. Its docstring states the
  limit honestly.
- `src/design/error-banner.test.tsx`: renders `PGErrorBanner` for **every variant
  in `error.rs`** and asserts the DOM never contains the spelling.
- `src-tauri/tests/pull_conflicts.rs`: 7 tests, carrying the measured git output
  in the file header.

## The e2e that was pinning the bug

`remote.e2e.ts` asserted the banner contained `"Network"` — the enum spelling this
change removes. Replaced with a strictly stronger case, *"rejected non-fast-forward
push shows git's reason and its advice"*: `non-fast-forward` survives, the `hint:`
lines survive **as separate lines**, and `banner-label` does not exist.

The line-split hint count is the load-bearing part — it fails if `pre-wrap` is
lost **and** if `progress::DEFAULT_TAIL_LINES` is ever lowered enough to eat the
paragraph. Neither is visible to jsdom; a component test can assert
`style.whiteSpace`, but only a real webview lays text out. `>= 3` rather than
`=== 4` because the wording is git's and the paragraph has changed across
releases, with `join(" ")` re-asserting the actionable sentence so a truncated
banner cannot pass vacuously.

The whole `e2e/` tree was swept for the other 36 variant names: the only other hit
is a comment in `cancel.e2e.ts`; every other banner assertion tests presence or
absence, not content.

## Verification

- `pnpm test` — 327 files, 3131 passing; `pnpm tsc --noEmit` clean; e2e tsc clean
- `cargo test` — 86 binaries, 1167 passing; `pull_conflicts.rs` 7 passing
- e2e in Docker on this branch: `remote.e2e.ts` 10 passing, `merge-conflict.e2e.ts`
  5 passing, `settings.e2e.ts` 8 passing

## Left for follow-up

- **An actionable push affordance** (explicitly out of scope here): the banner
  reports a rejected push but offers no "Pull first / Force-push with lease".
- **`--ff-only` divergence is still `Network`.** `fatal: Not possible to
  fast-forward, aborting.` is a refusal, not a conflict, so `map_conflicted_pull`
  correctly leaves it alone — but "Network" is still the wrong category for it.
  Noted in `docs/dev/backend.md` as its own change. This is also why
  `settings.e2e.ts:169` still passes unchanged.

Refs #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
