### PR TITLE
test(diff): wait on the rendered preview, not the invoke count

### DIFF
--- a/src/screens/DiffViewer.imagepreview.test.tsx
+++ b/src/screens/DiffViewer.imagepreview.test.tsx
@@ -113,18 +113,29 @@ describe("DiffViewer, binary file", () => {
       </WithDialogs>,
     );
 
-    // Both reads must LAND before this is meaningful, and the node must be
-    // queried fresh afterwards. `expect(await findByText(...))` was neither: the
-    // resolving preview re-renders this pane, so the node findByText returned
-    // was detached by the time the assertion read it — "element could not be
-    // found in the document", CI-only, once in ~4 runs of the full suite.
-    // Same wait the HEAD-and-worktree test above uses.
-    await waitFor(() =>
+    // BOTH conditions inside ONE `waitFor`, and neither is optional.
+    //
+    // The count alone is not enough, and waiting on it and then asserting the
+    // DOM separately is what made this flaky: `getInvokeCalls()` records a call
+    // when it is DISPATCHED, so "both reads issued" is not "both results
+    // rendered". Under CI load the assertions ran while the resolving preview's
+    // state update had not been flushed and the pane was mid-swap — "Unable to
+    // find an element with the text: Binary file", green locally, red in CI.
+    //
+    // The DOM alone is not enough either, in the other direction: this pane
+    // renders `title="Binary file"` WHILE the previews are still loading, so a
+    // bare wait on that text passes immediately, before either read has landed,
+    // and would keep passing if the preview were broken outright.
+    //
+    // Retrying both together is also what fixes the older detached-node bug
+    // (`expect(await findByText(...))` held a node across a re-render): every
+    // poll re-queries, so no node is carried over.
+    await waitFor(() => {
       expect(
         getInvokeCalls().filter((c) => c.cmd === "read_image_preview").length,
-      ).toBe(2),
-    );
-    expect(screen.getByText("Binary file")).toBeInTheDocument();
-    expect(screen.queryByTestId("image-diff")).toBeNull();
+      ).toBe(2);
+      expect(screen.getByText("Binary file")).toBeInTheDocument();
+      expect(screen.queryByTestId("image-diff")).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
`DiffViewer.imagepreview.test.tsx > keeps the empty state for a binary that is
not an image` fails intermittently in CI and passes locally.

## Evidence it is pre-existing, not a regression

It went red on **#379**, which touches `docs/dev/backend.md`,
`src-tauri/src/git/libgit2.rs` and `src-tauri/tests/no_trailing_newline.rs` —
**zero `src/` files**. CI tests the merge commit, so the frontend under test there
is exactly `main`'s, and the test exists verbatim on `main`. It went red on #381
in the same minute, in a test that had copied this file's wait pattern.

Locally the full suite passes 3/3 in that worktree. It only manifests under CI's
contention, which is why `main` has been green while four PRs' runs overlapping
was enough to expose it.

## The defect

```ts
await waitFor(() =>
  expect(getInvokeCalls().filter(c => c.cmd === "read_image_preview").length).toBe(2),
);
expect(screen.getByText("Binary file")).toBeInTheDocument();
```

`getInvokeCalls()` records a call when it is **dispatched**, not when it resolves.
So "both reads issued" is not "both results rendered" — under load the
synchronous assertion ran before React had flushed the resolving preview's state
update, with the pane mid-swap.

The previous fix here cured the right symptom (a detached node held across a
re-render by `expect(await findByText(...))`) but waited on the wrong event.

## The fix, and why both halves are needed

Both conditions go inside **one** `waitFor`, which retries the whole block:

- **The count alone is insufficient** — that is the bug above.
- **The DOM alone is insufficient in the other direction.** This pane renders
  `title="Binary file"` *while the previews are still loading*, so a bare wait on
  that text passes immediately, before either read has landed, and would keep
  passing if the preview were broken outright. That is exactly what the original
  count-wait was protecting, and dropping it would have traded a flaky test for a
  vacuous one.

Retrying both together also re-fixes the detached-node problem for free: every
poll re-queries, so no node is carried across a re-render.

## Verification

Mutation-checked rather than assumed — the count is still genuinely enforced:

```
$ sed -i 's/).toBe(2);/).toBe(3);/' …
AssertionError: expected 2 to be 3 // Object.is equality
 Test Files  1 failed (1)
```

Restored, then green again. Full suite: 327 files, 3173 passing. `tsc --noEmit`
clean.

The sibling test in this file at line ~91 uses the same count-wait but then
asserts on the recorded **invoke calls**, not on the DOM, so it is not exposed to
this race and is left alone.

Refs #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
