### PR TITLE
ci(release): build the msix architectures in parallel

### DIFF
--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -114,9 +114,9 @@ bare link instead of your notes, and `pub_date` is stamped at run time. Only a
 direct publish gets the real body in. Two full builds, ~12 min each.
 
 **Prerelease identifiers do not build.** `scripts/msix-pack.sh` requires
-three-part `X.Y.Z` and exits 2 on anything else, and the `msix` job has no
-prerelease gate — so `v0.4.0-rc.1` fails that job and leaves a red release with
-three of four bundles. `update.rs` parses such a tag fine; the limit is
+three-part `X.Y.Z` and exits 2 on anything else, and neither `msix-build` (which
+runs it, once per arch) nor `msix` has a prerelease gate — so `v0.4.0-rc.1`
+fails both matrix legs and leaves a red release with three of four bundles. `update.rs` parses such a tag fine; the limit is
 packaging. **A prerelease here is a stable-shaped `X.Y.Z` flagged in the GitHub
 UI.**
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,9 +330,10 @@ jobs:
           fi
           echo "msi_sig=$sig" >> "$GITHUB_OUTPUT"
 
-  # The Microsoft Store package.
+  # The Microsoft Store package — TWO jobs: a per-architecture build matrix and
+  # the bundle step that joins them.
   #
-  # A SEPARATE job from `windows` on purpose, on three counts: it builds twice
+  # SEPARATE from `windows` on purpose, on three counts: it builds twice
   # (x64 + arm64), it needs NO signing key at all — the Store re-signs, which is
   # the whole economics of this channel — and it must not be able to break the
   # .msi or the portable zip if makeappx or the manifest is wrong. Nothing here
@@ -340,10 +341,31 @@ jobs:
   # never even CHECKS (update::capability returns StoreManaged — policy 10.2.5),
   # so there is no signature to read and no manifest to point at.
   #
+  # THE TWO BUILDS RUN IN PARALLEL, and that is the difference between this
+  # channel finishing with the others and holding the release open on its own.
+  # Back to back in one job they measured 493s (x64) + 410s (arm64) on v0.5.0,
+  # inside a 17m job — against 10m for `windows`, 12m for `macos-universal` and
+  # 9m for `linux`, i.e. msix alone was the release's long pole. Nothing is
+  # shared between them but the source tree: different `--target`, different
+  # target directory, no updater signature, no release asset. The `.msix`
+  # packages travel to `msix` as artifacts because `makeappx bundle` needs both
+  # of them on ONE machine, which is the only reason this is not a single job.
+  #
   # Spec: docs/superpowers/specs/2026-08-27-msix-store-spec.md §B
-  msix:
+  msix-build:
     needs: version
     runs-on: windows-latest
+    strategy:
+      # NOT fail-fast. When one architecture breaks, whether the other one broke
+      # too is the first thing you need to know — and a cancelled sibling turns
+      # that into a second eight-minute run to find out.
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            target: x86_64-pc-windows-msvc
+          - arch: arm64
+            target: aarch64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v7
         with:
@@ -363,12 +385,17 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
+          targets: ${{ matrix.target }}
 
+      # `key` is what keeps the two legs in SEPARATE cache entries. Without it
+      # both compute the same key from the same job id and lockfile, race to save
+      # under it, and each leg then restores a cache carrying the other's target
+      # directory — larger every run and never a hit for the arch that needs one.
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          key: ${{ matrix.arch }}
 
       - name: Inject version ${{ needs.version.outputs.version }}
         shell: bash
@@ -388,11 +415,8 @@ jobs:
       # TAURI_SIGNING_PRIVATE_KEY nor an exception to the hard-error rule that
       # key exists for. The msstore config sets webviewInstallMode to `skip`,
       # because a package runs no bootstrapper.
-      - name: Build x64
-        run: pnpm tauri build --no-bundle --target x86_64-pc-windows-msvc --config src-tauri/tauri.msstore.conf.json
-
-      - name: Build arm64
-        run: pnpm tauri build --no-bundle --target aarch64-pc-windows-msvc --config src-tauri/tauri.msstore.conf.json
+      - name: Build ${{ matrix.arch }}
+        run: pnpm tauri build --no-bundle --target ${{ matrix.target }} --config src-tauri/tauri.msstore.conf.json
 
       # `makeappx.exe` ships with the Windows 10 SDK, and the SDK IS on the
       # runner — but its `bin\<version>\x64` directory is NOT on PATH, so the
@@ -443,7 +467,7 @@ jobs:
       # rather than `secrets`; set them from Partner Center > Product identity:
       #   gh variable set MSIX_IDENTITY_NAME --body '<Publisher>.<name>'
       #   gh variable set MSIX_PUBLISHER     --body 'CN=<guid>'
-      - name: Stage and pack both architectures
+      - name: Stage and pack ${{ matrix.arch }}
         shell: bash
         env:
           MSIX_IDENTITY_NAME: ${{ vars.MSIX_IDENTITY_NAME }}
@@ -455,12 +479,84 @@ jobs:
           : "${MSIX_IDENTITY_NAME:?repository variable is unset — copy it from Partner Center > Product identity}"
           : "${MSIX_PUBLISHER:?repository variable is unset — the whole CN=... string from Partner Center}"
           v="${{ needs.version.outputs.version }}"
-          sh scripts/msix-pack.sh --version "$v" --arch x64 \
-            --exe src-tauri/target/x86_64-pc-windows-msvc/release/platypusgit.exe \
-            --out msix-x64
-          sh scripts/msix-pack.sh --version "$v" --arch arm64 \
-            --exe src-tauri/target/aarch64-pc-windows-msvc/release/platypusgit.exe \
-            --out msix-arm64
+          sh scripts/msix-pack.sh --version "$v" --arch ${{ matrix.arch }} \
+            --exe src-tauri/target/${{ matrix.target }}/release/platypusgit.exe \
+            --out msix-${{ matrix.arch }}
+
+      # The ONLY thing that crosses to the `msix` job. Named `msix-<arch>` to
+      # match the file it carries: the bundle's inner package names are
+      # `msix-x64.msix` / `msix-arm64.msix`, and that is what the shape gate
+      # asserts on.
+      #
+      # `retention-days` well short of the 90-day default (these are throwaway
+      # intermediates) but not 1: re-running a failed `msix` job pulls artifacts
+      # from the ORIGINAL run, so a week is what buys you a re-run on Monday for
+      # a release cut on Friday without redoing both builds.
+      - name: Upload the ${{ matrix.arch }} package
+        uses: actions/upload-artifact@v7
+        with:
+          name: msix-${{ matrix.arch }}
+          path: msix-${{ matrix.arch }}.msix
+          if-no-files-found: error
+          retention-days: 7
+
+  # Joins the two architectures into the single .msixbundle the Store takes.
+  # Deliberately does NOT check out the repo, install Node or build anything —
+  # it downloads two packages and calls makeappx, which is why splitting the
+  # builds out costs about half a minute rather than a second full setup.
+  msix:
+    needs: [version, msix-build]
+    runs-on: windows-latest
+    steps:
+      # Two NAMED downloads into one directory, not a `msix-*` wildcard: with
+      # `name`, the artifact's contents land directly in `path`, so both packages
+      # end up flat in msix-bundle/ — exactly the layout `makeappx bundle /d`
+      # wants, with no staging copy. Everything in that directory goes INTO the
+      # bundle, so naming them is also what stops a future artifact in this
+      # workflow from silently shipping inside the .msixbundle.
+      - name: Collect the x64 package
+        uses: actions/download-artifact@v8
+        with:
+          name: msix-x64
+          path: msix-bundle
+
+      - name: Collect the arm64 package
+        uses: actions/download-artifact@v8
+        with:
+          name: msix-arm64
+          path: msix-bundle
+
+      # BYTE-IDENTICAL to `msix-build`'s copy above, deliberately — see that one
+      # for why the SDK's bin directory has to be found at all and why
+      # `$GITHUB_PATH` is the only thing that carries it to a later step. Both
+      # jobs need it because both call the SDK: that one packs, this one
+      # bundles. This job never invokes makepri, but demanding it here anyway is
+      # what keeps the copies from drifting — and they live in the same
+      # directory, so requiring both costs nothing. (Not a composite action:
+      # the runbook re-runs this workflow against OLD tags by
+      # workflow_dispatch, and a `uses: ./.github/actions/…` resolves against
+      # the checked-out tag, which would not have the file.)
+      - name: Put the Windows SDK's makeappx and makepri on PATH
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $root = 'C:\Program Files (x86)\Windows Kits\10\bin'
+          if (-not (Test-Path $root)) { throw "no Windows 10 SDK at $root" }
+          $sdk = Get-ChildItem $root -Directory |
+              Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
+              Where-Object {
+                  $x64 = Join-Path $_.FullName 'x64'
+                  (Test-Path (Join-Path $x64 'makeappx.exe')) -and
+                  (Test-Path (Join-Path $x64 'makepri.exe'))
+              } |
+              Sort-Object { [version]$_.Name } -Descending |
+              Select-Object -First 1
+          if (-not $sdk) {
+              throw "no SDK version in $root has both x64\makeappx.exe and x64\makepri.exe"
+          }
+          $bin = Join-Path $sdk.FullName 'x64'
+          Write-Host "makeappx + makepri found in: $bin"
+          $bin | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
 
       # `/bv` is NOT optional: without it makeappx stamps the bundle 0.0.0.0,
       # which is a lower version than anything already in the Store and is
@@ -479,8 +575,13 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $v = '${{ needs.version.outputs.version }}'
-          New-Item -ItemType Directory -Force -Path msix-bundle | Out-Null
-          Copy-Item msix-x64.msix, msix-arm64.msix msix-bundle/
+          # Everything in msix-bundle/ ends up IN the bundle, and the directory
+          # is filled by a job that ran elsewhere — so assert what landed there
+          # before makeappx ships it.
+          $pkgs = @(Get-ChildItem msix-bundle -File)
+          if ($pkgs.Count -ne 2) {
+              throw "msix-bundle must hold exactly the 2 arch packages, found $($pkgs.Count): $($pkgs.Name -join ', ')"
+          }
           & makeappx.exe bundle /d msix-bundle /bv "$v.0" /p PlatypusGit.msixbundle /o
           if ($LASTEXITCODE -ne 0) { throw "makeappx bundle failed ($LASTEXITCODE)" }
 

--- a/docs/dev/distribution.md
+++ b/docs/dev/distribution.md
@@ -715,9 +715,10 @@ Settings control.*
 
 ### `makeappx` builds it; `winapp` is only for the local loop
 
-`release.yml`'s **`msix`** job: two `--no-bundle` builds (x64 + arm64) →
-`scripts/msix-pack.sh` per arch (which stages the payload, then runs `makepri`
-and `makeappx pack`) → `makeappx bundle` → shape gate → attach.
+`release.yml`'s **`msix-build`** matrix, one leg per arch: a `--no-bundle` build
+→ `scripts/msix-pack.sh` (which stages the payload, then runs `makepri` and
+`makeappx pack`) → upload `msix-<arch>.msix` as an artifact. Then the **`msix`**
+job: download both → `makeappx bundle` → shape gate → attach.
 
 - **Not `winapp pack` in CI.** `winapp` documents Windows 11 as a prerequisite
   and `windows-latest` is Windows Server. `makeappx` ships with the Windows SDK
@@ -726,6 +727,31 @@ and `makeappx pack`) → `makeappx bundle` → shape gate → attach.
   and the portable zip down with it. It references no `TAURI_SIGNING_*` secret:
   `--no-bundle` produces no updater artifact, and nothing here feeds
   `latest.json` because a Store install never self-updates.
+- **The two architectures build in PARALLEL, and that is why there are two
+  jobs.** Back to back in one job they measured 493s + 410s on v0.5.0, inside a
+  17m job — against 10m for `windows`, 12m for `macos-universal` and 9m for
+  `linux`. This channel alone held the release open. Split, both legs measured
+  ~575s and the bundle job 6s, so the wall clock is one build rather than two.
+  The legs share nothing but the source tree (different `--target`, different
+  target directory, no signing key, no release asset); the only reason `msix` is
+  not folded back in is that `makeappx bundle` needs both packages on ONE
+  machine, so they travel as artifacts. Three things worth knowing:
+  - **It costs runner-minutes to save wall clock.** Build scripts and
+    proc-macros compile for the HOST, so in one job the second build reused
+    them — which is why arm64 was the *faster* of the two at 410s and why each
+    leg now costs ~575s on its own.
+  - **`Swatinem/rust-cache` needs `key: ${{ matrix.arch }}`.** The entry is
+    named `v0-rust-<key>-<job>-<os>-…`, so without a `key` both legs of one
+    matrix job compute the *same* name, race to save under it, and each then
+    restores a cache carrying the other's target directory. Expect a miss on a
+    real release either way: the job name is in that key, so only `msix-build`
+    can write it, and release runs happen on a tag ref — which reads its own
+    scope and the default branch's, never another tag's. Budget the cold
+    number (~11.5m a leg, measured), not the warm one.
+  - **Everything in the download directory goes *into* the bundle** — hence the
+    count check before `makeappx bundle`, and named downloads rather than a
+    `msix-*` wildcard, so a future artifact in this workflow cannot end up
+    inside the `.msixbundle`.
 - **`makeappx bundle` needs `/bv`.** Without it the bundle is stamped `0.0.0.0`,
   which is lower than anything already in the Store and is rejected as a
   downgrade. The inner packages carry the real version; the bundle must be told

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -10,7 +10,7 @@ this file is about the *number* and the *order of operations*.
 `package.json`, `src-tauri/Cargo.toml` and `src-tauri/tauri.conf.json` all read
 `0.0.0` in the tree and **that is correct — do not "fix" it**. `release.yml`
 injects the tag-derived version into all three at build time (`v0.4.0` → `0.4.0`),
-in every one of the four build jobs. The tag is the single source of truth.
+in every one of the build jobs. The tag is the single source of truth.
 
 This is the one part of the versioning story that has never gone wrong, and it is
 worth naming why: there are no bump commits, no release-prep PR, and no way for
@@ -138,11 +138,21 @@ The body is not just release notes: `updater-manifest` embeds it verbatim into
 
 ### 4. What CI then does
 
-`version` (gate) → four build jobs (`macos-universal`, `windows`, `msix`,
-`linux`) → six channel publishes, each gated on `prerelease == false`
+`version` (gate) → the build jobs (`macos-universal`, `windows`, `linux`, and
+`msix-build` ×2 → `msix`) → six channel publishes, each gated on `prerelease == false`
 (`bump-cask`, `bump-scoop`, `updater-manifest`, `apt-publish`, `winget-publish`,
 `msstore-publish`) → two live installs that verify the channel really serves the
 new version (`scoop-verify-live`, `apt-verify-live`).
+
+**The Store package is two jobs, and only the second one attaches anything.**
+`msix-build` is a 2-arch matrix (x64, arm64) that builds and packs one `.msix`
+each and uploads it as an artifact; `msix` downloads both, runs `makeappx
+bundle`, gates the shape and attaches `PlatypusGit.msixbundle`. They were a
+single job until the two back-to-back builds made msix the release's long pole —
+17m against 9–12m for every other build job on v0.5.0. Read a red `msix-build`
+as "one architecture failed" (it is not fail-fast, so the other leg still tells
+you whether the break is arch-specific) and a red `msix` as "both built, the
+bundle did not".
 
 **Two of the six self-disable, and a green job there means "submitted
 nothing".** `winget-publish` when `WINGET_TOKEN` is unset — expected today, do
@@ -216,9 +226,9 @@ your notes. Only a direct full-release publish gets the real body into
 chase — and it is the strongest argument for publishing direct.
 
 **Prerelease identifiers do not build.** `scripts/msix-pack.sh` requires a
-three-part `X.Y.Z` and exits 2 on anything else, and the `msix` job has no
-prerelease gate — so a `v0.4.0-rc.1` tag fails that job and produces a red
-release with three of the four bundles. `update.rs` parses such a tag fine (it
+three-part `X.Y.Z` and exits 2 on anything else, and neither `msix-build` (which
+runs it) nor `msix` has a prerelease gate — so a `v0.4.0-rc.1` tag fails both
+legs of the matrix and produces a red release with three of the four bundles. `update.rs` parses such a tag fine (it
 uses the `semver` crate's `cmp_precedence`), so the limitation is packaging, not
 the app. **The de facto rule, and the one to keep until someone needs otherwise:
 a prerelease is a stable-shaped `X.Y.Z` number flagged in the GitHub UI.** If


### PR DESCRIPTION
## Why

`msix` was the release's long pole. On the v0.5.0 run it took **17m** against 10m for `windows`, 12m for `macos-universal` and 9m for `linux` — because it ran the two Store builds back to back in one job:

| step | v0.5.0 |
|---|---|
| Build x64 | 493s |
| Build arm64 | 410s |
| everything else in the job | ~120s |

Every other channel had finished while the release still waited on this one. On the v0.6.0 run, `msix` was the last build job still going.

## What

`msix` becomes two jobs:

- **`msix-build`** — a 2-arch matrix (`x64` / `arm64`). One `--no-bundle` build, one `scripts/msix-pack.sh`, one `msix-<arch>.msix` uploaded as an artifact.
- **`msix`** — downloads both packages, `makeappx bundle`, the existing shape gate, attach.

The legs share nothing but the source tree: different `--target`, different target directory, no signing key, no release asset. The only reason this is two jobs rather than one is that `makeappx bundle` needs both packages on **one** machine.

**The `msix` job keeps its name**, so `msstore-publish`'s `needs: [version, msix]` and every reference in the runbook still point at the job that produces the bundle.

Measured cold, both legs take ~11.5m and the bundle job 6s — so msix finishes with the other build jobs instead of holding the release open for another seven minutes.

It buys that with runner-minutes, which is worth stating plainly: build scripts and proc-macros compile for the **host**, so in one job the second build reused them. That is exactly why arm64 was the *faster* of the two at 410s, and why each leg now pays ~575s on its own.

### Details worth reviewing

- **`key: ${{ matrix.arch }}` on `Swatinem/rust-cache`.** The entry is named `v0-rust-<key>-<job>-<os>-…` (confirmed in the dry-run logs: `v0-rust-x64-msix-build-Windows_NT-x64-…`), so without a `key` both legs compute the same name, race to save under it, and each restores a cache carrying the other's target directory.
- **`fail-fast: false`.** When one arch breaks, whether the other broke too is the first thing you need to know; a cancelled sibling turns that into a second eight-minute run to find out.
- **Named downloads, not a `msix-*` wildcard.** Everything in the download directory goes *into* the bundle, so the two artifacts are fetched by name and a count check runs before `makeappx bundle` — a future artifact in this workflow cannot silently end up inside the `.msixbundle`.
- **The SDK-PATH step is byte-identical in both jobs**, because both call the SDK: one packs, the other bundles. Deliberately duplicated rather than factored into a composite action — the runbook re-runs this workflow against **old** tags by `workflow_dispatch`, and a `uses: ./.github/actions/…` resolves against the checked-out tag, which would not have the file.
- The `msix` job does no checkout and installs no Node or Rust — it downloads two files and calls makeappx, which is why the split costs about half a minute rather than a second full setup.

## Verification

`release.yml` only fires on a release publish, and a `workflow_dispatch` workflow has to live on the default branch to be dispatchable — so there was no way to exercise this before a real release cut. A temporary push-triggered workflow ran **both jobs copied verbatim** (asserted structurally identical to `release.yml`'s, minus the attach step) behind a fake `9.9.9` version. It is not part of this PR's diff.

- Dry run 1 — https://github.com/jonassaa/platypusgit/actions/runs/33756103732 ✅ cold cache, both legs 577s / 574s in parallel, bundle job 6s
- Dry run 2 — https://github.com/jonassaa/platypusgit/actions/runs/33757856224 ✅ rebased onto #390, so this is also the first time #390's `makepri` step and `resources.pri` shape gate have run through the **release** path at all
- `pnpm test`: 3216 passed (331 files)

### One thing the rebase caught

Rebasing onto #390 **auto-merged `release.yml` with no conflict** but left this PR's second copy of the SDK-PATH step on the pre-#390 version — the exact silent drift #390 was written to prevent. Fixed: all three copies (`msix-build`, `msix`, and `tests.yml`'s `msix-pack`) are byte-identical again, asserted before pushing.

Docs updated: `docs/dev/releasing.md`, `docs/dev/distribution.md`, `.claude/skills/releasing/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
