### PR TITLE
ci: prune the Actions cache, and path-filter CodeQL

### DIFF
--- a/.github/workflows/cache-prune.yml
+++ b/.github/workflows/cache-prune.yml
@@ -1,0 +1,69 @@
+name: cache-prune
+
+# Keeps the Actions cache under GitHub's 10 GB ceiling.
+#
+# Over the ceiling GitHub evicts least-recently-used entries, and the jobs that
+# lose are the ones that run least often — the release builds. Measured on the
+# v0.6.0 release with usage at 10.73 GB, `macos-universal` and `msix` both
+# logged "No cache found" while `linux` and `windows` got a partial match; a
+# cold Rust build is 577s against 259s warm, so the full quota was costing about
+# five minutes on each of those jobs, every release.
+#
+# DAILY, not weekly, because of the refill rate: CodeQL leaves a ~96 MB overlay
+# database per commit on `main`, and every lockfile bump strands a
+# multi-hundred-MB rust-cache generation. A week of that is more than the
+# headroom this buys.
+#
+# The rules and the reasoning live in scripts/prune-actions-caches.mjs.
+
+on:
+  schedule:
+    - cron: '41 4 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List what would be deleted without deleting it'
+        type: boolean
+        default: false
+
+# `actions: write` is what deletes a cache; `pull-requests: read` is what
+# distinguishes an open PR's cache from a merged one's. Nothing here reads or
+# writes repository content beyond the checkout.
+permissions:
+  contents: read
+  actions: write
+  pull-requests: read
+
+concurrency:
+  group: cache-prune
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # No setup-node step on purpose: the runner image ships node, the script
+      # is dependency-free by design, and a `cache: pnpm` here would have this
+      # job writing to the very cache it is pruning.
+      - name: Prune
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node scripts/prune-actions-caches.mjs \
+            ${{ inputs.dry_run && '--dry-run' || '' }} \
+            --repo "$GITHUB_REPOSITORY"
+
+      - name: Report remaining usage
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # The usage endpoint is eventually consistent and can still report the
+          # pre-delete total right after a prune, so the authoritative number is
+          # the sum of what the listing now returns.
+          gh api "repos/$GITHUB_REPOSITORY/actions/caches?per_page=100" --paginate \
+            --jq '[.actions_caches[] | .size_in_bytes] | add // 0' \
+            | awk '{ printf "cache now: %d MB of 10240 MB\n", $1/1024/1024 }' \
+            | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,162 @@
+name: codeql
+
+# CodeQL, moved off GitHub's DEFAULT SETUP so it can be path-filtered.
+#
+# Default setup analyses every configured language on every run and offers no
+# way to say "this diff cannot affect Rust". The bill was concrete: PR #391
+# touched `release.yml` and three markdown files, and `Analyze (rust)` still
+# ran for 9m20s — the slowest check in the repo, paid by docs-only PRs. The
+# same three analyses live here, with a filter in front of them.
+#
+# ⚠️ DEFAULT SETUP AND THIS FILE CANNOT BOTH BE ON. GitHub refuses results from
+# an advanced configuration while default setup is enabled, so this workflow
+# fails until default setup is turned off (Settings → Advanced Security → Code
+# scanning → CodeQL default setup, or
+# `gh api -X PATCH repos/jonassaa/platypusgit/code-scanning/default-setup
+#  -f state=not-configured`). Turning default setup back ON later disables this
+# workflow's results, not the workflow — it will keep running and keep failing.
+#
+# Languages: `actions`, `javascript-typescript`, `rust`. That is the same set
+# default setup had — it listed `javascript`/`typescript` and
+# `javascript-typescript` separately, which collapse to one analysis.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  # Security tooling should not go quiet because nobody pushed. A weekly run
+  # also re-analyses with whatever queries shipped since the last commit.
+  schedule:
+    - cron: '17 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Which languages can this diff possibly affect?
+  #
+  # PULL REQUESTS ONLY, and that asymmetry is deliberate rather than a
+  # limitation copied from tests.yml. A push to `main` is the run whose results
+  # become the branch's code-scanning state; skipping a language there would
+  # leave `main` described by an older commit's analysis. PR runs are advisory,
+  # so that is where the 9m of Rust is worth skipping. On push, schedule and
+  # dispatch the fallback `||` picks up the empty string of a skipped step and
+  # every language runs.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      languages: ${{ steps.filter.outputs.languages || '["actions","javascript-typescript","rust"]' }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - id: filter
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          changed=$(git diff --name-only "$BASE_SHA"...HEAD)
+          echo "Changed files:"
+          echo "$changed" | sed 's/^/  /'
+
+          langs=()
+
+          # `actions` analyses workflow and action definitions themselves.
+          if echo "$changed" | grep -qE '^\.github/(workflows|actions)/'; then
+            langs+=('"actions"')
+          fi
+
+          # Everything the JS/TS extractor reads. `scripts/` is in because it
+          # holds .mjs run by CI, `site/` because it is a real TS app, and the
+          # root config files because a change there redirects what gets built.
+          if echo "$changed" | grep -qE '^(src/|e2e/|test/|site/|scripts/|index\.html$|package\.json$|pnpm-lock\.yaml$|vite\.config\.ts$|tsconfig[a-z.]*\.json$)'; then
+            langs+=('"javascript-typescript"')
+          fi
+
+          # Deliberately the WHOLE of src-tauri/, icons and fixtures included.
+          # A narrower filter here trades a security analysis for a couple of
+          # minutes, which is the wrong side of that trade.
+          if echo "$changed" | grep -qE '^src-tauri/'; then
+            langs+=('"rust"')
+          fi
+
+          # Join with commas without leaving a trailing one on an empty array.
+          IFS=,
+          echo "languages=[${langs[*]-}]" >> "$GITHUB_OUTPUT"
+          unset IFS
+          echo "Languages to analyse: [${langs[*]-}]"
+
+  analyze:
+    needs: changes
+    # An empty matrix vector is a workflow ERROR, not an empty job set, so the
+    # "nothing to analyse" case has to be caught here rather than by the matrix.
+    if: needs.changes.outputs.languages != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      packages: read
+      security-events: write
+    strategy:
+      # One language failing must not cancel the analysis of the others — the
+      # alerts they would have produced are the point of the run.
+      fail-fast: false
+      matrix:
+        language: ${{ fromJSON(needs.changes.outputs.languages) }}
+    steps:
+      - uses: actions/checkout@v7
+
+      # `build-mode: none` for all three: none of these extractors needs a
+      # compiled artefact, and Rust in particular must NOT build here — that
+      # would trade the 9m this workflow exists to save for a cargo build. If a
+      # future language needs one, the init step fails and names it.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}
+
+  # The house gate pattern (see docs/dev/testing.md): one always-running job
+  # that reports for the whole workflow, so a branch ruleset can require a check
+  # that a path filter is allowed to skip. Nothing requires it today — if that
+  # changes, require THIS job, never `analyze`, or a filtered PR blocks forever.
+  codeql:
+    needs: [changes, analyze]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gate
+        env:
+          RESULT: ${{ needs.analyze.result }}
+          LANGS: ${{ needs.changes.outputs.languages }}
+        run: |
+          set -euo pipefail
+          echo "languages: $LANGS"
+          case "$RESULT" in
+            success)
+              echo "CodeQL analysed $LANGS" ;;
+            skipped)
+              # Only legitimate when the filter found nothing to analyse.
+              if [ "$LANGS" = "[]" ]; then
+                echo "No language affected by this diff — nothing to analyse."
+              else
+                echo "analyze was skipped but the filter asked for $LANGS" >&2
+                exit 1
+              fi ;;
+            *)
+              echo "analyze: $RESULT" >&2
+              exit 1 ;;
+          esac

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,12 +72,18 @@ jobs:
           # the table skipped its own guard and reported green (issue 189, then
           # #210 — a README-only PR ran no suite at all).
           #
+          # `scripts/` is here for the same reason: `pruneCaches.test.ts`
+          # imports `scripts/prune-actions-caches.mjs` and pins which caches it
+          # is allowed to DELETE. Without this line, editing the pruner alone
+          # would skip the only suite that checks it — and the failure mode is
+          # deleting the cache of the release currently building.
+          #
           # `src-tauri/icons/msix/` is the newest entry and the same story
           # (#390): `msixIcons.test.ts` decodes those PNGs and fails if one has
           # an opaque corner. Re-rendering the ladder is the ONLY change that
           # can break it, and without this it is the one change that would not
           # run it.
-          if echo "$changed" | grep -qE '^(src/|e2e/|test/|src-tauri/icons/msix/|index\.html$|package\.json$|pnpm-lock\.yaml$|vite\.config\.ts$|tsconfig[a-z.]*\.json$|CLAUDE\.md$|README\.md$|CONTRIBUTING\.md$|docs/dev/|site/src/data/comparison\.json$|\.github/workflows/(tests|e2e)\.yml$)'; then
+          if echo "$changed" | grep -qE '^(src/|e2e/|test/|scripts/|src-tauri/icons/msix/|index\.html$|package\.json$|pnpm-lock\.yaml$|vite\.config\.ts$|tsconfig[a-z.]*\.json$|CLAUDE\.md$|README\.md$|CONTRIBUTING\.md$|docs/dev/|site/src/data/comparison\.json$|\.github/workflows/(tests|e2e)\.yml$)'; then
             echo "js=true" >> "$GITHUB_OUTPUT"
             echo "-> frontend sources touched, running the unit suite"
           else

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -69,13 +69,18 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
 
 ## What CI runs
 
-Two workflows, both on PRs to `main`, pushes to `main`, and `workflow_dispatch`:
+Three workflows on PRs to `main`, pushes to `main`, and `workflow_dispatch`:
 
 - `.github/workflows/tests.yml` — `unit` job (`pnpm tsc --noEmit`, `pnpm test`,
   and `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — the ONLY e2e typecheck,
   since the root tsconfig excludes `e2e/`) + `rust` job (`cargo test`; installs
   the Tauri `-dev` packages to link, no xvfb).
 - `.github/workflows/e2e.yml` — the webview suite (see sharding below).
+- `.github/workflows/codeql.yml` — code scanning, plus a weekly schedule.
+
+...and one that runs on a schedule only: `.github/workflows/cache-prune.yml`.
+Neither of the last two gates anything; both exist because CI *time* is a cost
+the other two pay.
 
 Rules that keep the gates honest:
 
@@ -97,6 +102,45 @@ Rules that keep the gates honest:
   on `main` can differ from what the PR tested — the push run is the only
   thing that ever tests `main` itself. `concurrency: cancel-in-progress`
   collapses merge bursts. Revisit only if runner minutes become the constraint.
+
+## Two workflows that are not gates — they exist to buy CI time back
+
+**`cache-prune.yml` — the Actions cache has a 10 GB ceiling, and going over it
+costs the release five minutes a job.** Over the ceiling GitHub evicts
+least-recently-used entries, so the jobs that lose are the ones that run least
+often. Measured on the v0.6.0 release at 10.73 GB usage, `macos-universal` and
+`msix` both logged `No cache found.` while `linux` and `windows` got only a
+partial match — and a cold Rust build is 577s against 259s warm. Nothing was
+broken; the quota was full of caches nothing would ever read again.
+
+It runs **daily**, not weekly, because of the refill rate: CodeQL leaves a
+~96 MB overlay database per commit on `main`, and every toolchain or lockfile
+change strands a multi-hundred-MB rust-cache generation. The first real run
+freed 4 GB. The rules live in `scripts/prune-actions-caches.mjs`; the two that
+matter are pinned by `test/pruneCaches.test.ts`, because this is the one script
+here whose job is to delete things:
+
+- **A tag cache's ref arrives as `refs/heads/refs/tags/v0.6.0`** — `refs/heads/`
+  glued onto an already-qualified ref. Read naively that is a *branch* named
+  `refs/tags/v0.6.0`, which exists nowhere, so a "does this branch still exist"
+  rule deletes the caches of the release that is building right now.
+- **The newest generation is not the biggest.** On this repo the current
+  `v0-rust-build-Linux-x64` entry was 828 MB and the superseded one 1662 MB,
+  because a fresh entry is written from a partial restore. Sort by
+  `created_at`, never by size.
+
+**`codeql.yml` — CodeQL was moved off default setup so it can be
+path-filtered.** Default setup analyses every configured language on every run:
+PR #391 touched `release.yml` and three markdown files and still paid 9m20s for
+`Analyze (rust)`, the slowest check in the repo. The filter runs on
+`pull_request` ONLY — a push to `main` is the run whose results become the
+branch's code-scanning state, so skipping a language there would leave `main`
+described by an older commit's analysis.
+
+> ⚠️ **Default setup and `codeql.yml` cannot both be on.** GitHub refuses
+> results from an advanced configuration while default setup is enabled. If
+> code scanning ever goes quiet, check that setting first — re-enabling default
+> setup does not disable this workflow, it just makes it fail.
 
 ## The e2e gate is sharded (issue 189)
 

--- a/scripts/prune-actions-caches.mjs
+++ b/scripts/prune-actions-caches.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+//
+// Keep the repository's Actions cache under GitHub's 10 GB ceiling.
+//
+// WHY THIS EXISTS. Over the ceiling, GitHub evicts least-recently-used entries,
+// and the jobs that lose are the ones that run least often — the release
+// builds. Measured on the v0.6.0 release, with usage at 10.73 GB:
+//
+//   macos-universal  No cache found.
+//   msix             No cache found.
+//   linux            Restored ... full match: false.
+//   windows          Restored ... full match: false.
+//
+// A cold Rust build measured 577s against 259s warm, so eviction was costing
+// roughly five minutes on each of those jobs, every release. Nothing was
+// broken; the quota was simply full of caches nothing would ever read again.
+//
+// WHAT IT DELETES. Four rules, each logged with its reason:
+//
+//   dead-branch   the cache's ref is a branch that no longer exists
+//   closed-pr     refs/pull/<n>/merge where the PR is no longer open
+//   old-tag       a release tag's caches, except the newest tag's — a tag ref
+//                 can only be read by runs on that same tag, and a
+//                 workflow_dispatch re-run of release.yml happens on the
+//                 DEFAULT BRANCH, so these are unreachable the moment the next
+//                 tag exists
+//   stale-gen     older generations of the same cache family (see FAMILIES) —
+//                 rust-cache and friends key on content hashes, so every
+//                 toolchain or lockfile change strands the previous
+//                 multi-hundred-MB entry as, at best, a partial restore-key
+//                 match
+//
+// It never deletes the newest generation of anything, and never touches a
+// cache on a ref it cannot prove is dead. `test/pruneCaches.test.ts` pins both
+// of those, because the cost of a wrong answer here is silently deleting the
+// cache of the release that is building right now.
+//
+// Usage: node scripts/prune-actions-caches.mjs [--dry-run] [--repo owner/name]
+// Requires `gh` authenticated with `actions: write` on the repo.
+
+import { execFileSync } from 'node:child_process'
+import { appendFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+
+/**
+ * Cache families that keep only their newest N generations.
+ *
+ * `strip` is how many trailing dash-separated segments are the varying part of
+ * the key, so removing them yields the family name:
+ *
+ *   v0-rust-build-Linux-x64-0b9fd15e-84d09117  ->  v0-rust-build-Linux-x64
+ *   node-cache-Linux-x64-pnpm-4b7e04be…        ->  node-cache-Linux-x64-pnpm
+ *   codeql-overlay-base-database-1-<h>-javascript-2.26.4-<sha>-<run>-1
+ *                                              ->  codeql-…-javascript-2.26.4
+ *
+ * `keep` is how many of the newest to spare. Rust keeps 1: a superseded
+ * generation is only ever reachable as a partial restore-key match, and the
+ * measured cost of holding one was 1.6 GB across two jobs. CodeQL and node keep
+ * 2 — they are ~100 MB and ~80 MB, cheap insurance against a bad newest entry.
+ */
+export const FAMILIES = [
+    { match: /^v0-rust-/, strip: 2, keep: 1 },
+    { match: /^codeql-/, strip: 3, keep: 2 },
+    { match: /^node-cache-/, strip: 1, keep: 2 },
+]
+
+/**
+ * The `ref` GitHub reports on a cache is not a plain ref: a tag arrives as
+ * `refs/heads/refs/tags/v0.6.0`, i.e. with `refs/heads/` glued onto the front
+ * of an already-qualified ref. Unwrap before deciding anything — reading that
+ * as a BRANCH named `refs/tags/v0.6.0` finds no such branch and deletes the
+ * live release's caches.
+ */
+export function classifyRef(ref) {
+    if (ref.startsWith('refs/pull/')) {
+        return { kind: 'pr', name: ref.split('/')[2] }
+    }
+    const inner = ref.replace(/^refs\/heads\//, '')
+    if (inner.startsWith('refs/tags/')) {
+        return { kind: 'tag', name: inner.slice('refs/tags/'.length) }
+    }
+    return { kind: 'branch', name: inner }
+}
+
+/**
+ * Which tag's caches are still worth keeping.
+ *
+ * Derived from the cache list itself rather than from `repos/:repo/tags`, whose
+ * ordering is not documented as newest-first — and a wrong answer there deletes
+ * the caches of the release currently building. The tag that most recently
+ * WROTE a cache is, by construction, the one whose jobs last ran.
+ */
+export function newestCachedTag(caches) {
+    let best = null
+    for (const cache of caches) {
+        const ref = classifyRef(cache.ref)
+        if (ref.kind !== 'tag') continue
+        if (!best || new Date(cache.created_at) > new Date(best.at)) {
+            best = { name: ref.name, at: cache.created_at }
+        }
+    }
+    return best?.name ?? null
+}
+
+/**
+ * Decide what to delete. Pure: no network, no clock, no filesystem.
+ *
+ * @param caches      the `actions_caches` array as GitHub returns it
+ * @param liveBranches Set of branch names that still exist on the remote
+ * @param openPrs     Set of open PR numbers, as strings
+ * @returns [{ cache, reason }] — every entry that should be deleted
+ */
+export function planPrune(caches, { liveBranches, openPrs }) {
+    const doomed = new Map() // id -> {cache, reason}
+    const condemn = (cache, reason) => {
+        if (!doomed.has(cache.id)) doomed.set(cache.id, { cache, reason })
+    }
+
+    const newestTag = newestCachedTag(caches)
+
+    for (const cache of caches) {
+        const ref = classifyRef(cache.ref)
+        if (ref.kind === 'pr' && !openPrs.has(ref.name)) {
+            condemn(cache, `closed-pr (#${ref.name})`)
+        } else if (ref.kind === 'tag' && ref.name !== newestTag) {
+            condemn(cache, `old-tag (${ref.name}, newest is ${newestTag})`)
+        } else if (ref.kind === 'branch' && !liveBranches.has(ref.name)) {
+            condemn(cache, `dead-branch (${ref.name})`)
+        }
+    }
+
+    // Generation pruning runs over the SURVIVORS only: a cache already condemned
+    // for a dead ref must not occupy a keep-slot its family owes to a live one.
+    const families = new Map()
+    for (const cache of caches) {
+        if (doomed.has(cache.id)) continue
+        const rule = FAMILIES.find((f) => f.match.test(cache.key))
+        if (!rule) continue
+        const parts = cache.key.split('-')
+        if (parts.length <= rule.strip) continue
+        // Scoped by ref: `main`'s copy of a family and a tag's copy live in
+        // different cache scopes and cannot substitute for each other.
+        const family = `${cache.ref}::${parts.slice(0, -rule.strip).join('-')}`
+        if (!families.has(family)) families.set(family, { rule, entries: [] })
+        families.get(family).entries.push(cache)
+    }
+
+    for (const [family, { rule, entries }] of families) {
+        if (entries.length <= rule.keep) continue
+        entries.sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
+        for (const cache of entries.slice(rule.keep)) {
+            condemn(cache, `stale-gen (${family.split('::')[1]}, keeping ${rule.keep})`)
+        }
+    }
+
+    return [...doomed.values()]
+}
+
+// --- CLI ---------------------------------------------------------------------
+
+const gh = (...a) => execFileSync('gh', a, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 })
+const ghJson = (...a) => JSON.parse(gh(...a))
+const MB = (b) => Math.round(b / 1024 / 1024)
+const lines = (s) => s.split('\n').filter(Boolean)
+
+function main() {
+    const args = process.argv.slice(2)
+    const dryRun = args.includes('--dry-run')
+    const repoFlag = args.indexOf('--repo')
+    const repo = repoFlag === -1 ? process.env.GITHUB_REPOSITORY : args[repoFlag + 1]
+
+    if (!repo) {
+        console.error('No repository: pass --repo owner/name or set GITHUB_REPOSITORY.')
+        process.exit(2)
+    }
+
+    // `--slurp` is load-bearing with `--paginate`: without it gh emits ONE JSON
+    // document per page, so a second page turns the output into `{…}{…}` and
+    // JSON.parse throws. It cannot be combined with `--jq` (gh rejects the
+    // pair), which is why the flattening happens here instead.
+    const caches = ghJson(
+        'api',
+        '--paginate',
+        '--slurp',
+        `repos/${repo}/actions/caches?per_page=100`,
+    ).flatMap((page) => page.actions_caches ?? [])
+
+    const liveBranches = new Set(
+        lines(gh('api', '--paginate', `repos/${repo}/branches?per_page=100`, '--jq', '.[].name')),
+    )
+    const openPrs = new Set(
+        lines(
+            gh('api', '--paginate', `repos/${repo}/pulls?state=open&per_page=100`, '--jq', '.[].number'),
+        ),
+    )
+
+    const doomed = planPrune(caches, { liveBranches, openPrs })
+    const before = caches.reduce((n, c) => n + c.size_in_bytes, 0)
+    const freed = doomed.reduce((n, { cache }) => n + cache.size_in_bytes, 0)
+
+    console.log(`${caches.length} caches, ${MB(before)} MB total`)
+    console.log(`${doomed.length} to delete, ${MB(freed)} MB`)
+
+    let failed = 0
+    for (const { cache, reason } of doomed) {
+        const label = `${MB(cache.size_in_bytes)}MB ${reason} ${cache.key}`
+        if (dryRun) {
+            console.log(`would delete: ${label}`)
+            continue
+        }
+        try {
+            gh('api', '-X', 'DELETE', `repos/${repo}/actions/caches/${cache.id}`)
+            console.log(`deleted: ${label}`)
+        } catch (err) {
+            // A cache can disappear between the listing and the delete (another
+            // run evicted it, or its branch was pruned). That is the outcome we
+            // wanted, so warn and keep going rather than failing the prune.
+            failed++
+            console.warn(`could not delete ${cache.id} (${cache.key}): ${err.message.split('\n')[0]}`)
+        }
+    }
+
+    if (process.env.GITHUB_STEP_SUMMARY) {
+        const rows = [...doomed]
+            .sort((a, b) => b.cache.size_in_bytes - a.cache.size_in_bytes)
+            .map(({ cache, reason }) => `| ${MB(cache.size_in_bytes)} MB | ${reason} | \`${cache.key}\` |`)
+        const summary = [
+            `### Actions cache prune${dryRun ? ' (dry run)' : ''}`,
+            '',
+            `**Before:** ${caches.length} entries, ${MB(before)} MB`,
+            `**${dryRun ? 'Would free' : 'Freed'}:** ${MB(freed)} MB across ${doomed.length} entries`,
+            `**After:** ~${MB(before - freed)} MB against GitHub's 10240 MB ceiling`,
+            '',
+            ...(rows.length
+                ? ['| Size | Reason | Key |', '| --- | --- | --- |', ...rows]
+                : ['Nothing to prune.']),
+        ].join('\n')
+        appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`)
+    }
+
+    // A failed delete is reported, never fatal: the next run retries it, and a
+    // red scheduled job nobody is waiting on is a notification people learn to
+    // ignore. A throw above (bad auth, API down) still exits non-zero.
+    if (failed) console.log(`${failed} delete(s) did not apply; the next run retries them.`)
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) main()

--- a/test/pruneCaches.test.ts
+++ b/test/pruneCaches.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Guards for `scripts/prune-actions-caches.mjs` — the only script in this repo
+ * whose job is to DELETE things.
+ *
+ * The failure that matters is not "it pruned too little"; it is pruning the
+ * cache of the release that is building right now, which turns a 6-minute job
+ * into an 11-minute one and leaves no trace of why. Two shapes make that easy
+ * to get wrong and are pinned here:
+ *
+ *   1. GitHub reports a tag cache's ref as `refs/heads/refs/tags/v0.6.0` —
+ *      `refs/heads/` glued onto an already-qualified ref. Read naively that is
+ *      a BRANCH named `refs/tags/v0.6.0`, which exists nowhere, so every rule
+ *      that asks "does this branch still exist" condemns the live release.
+ *   2. Generation pruning must keep the NEWEST entry. The newest is not the
+ *      biggest: measured on this repo, the current generation of
+ *      `v0-rust-build-Linux-x64` was 828 MB while the superseded one was
+ *      1662 MB, because a fresh entry is written from a partial restore.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyRef,
+  newestCachedTag,
+  planPrune,
+  // @ts-expect-error — plain .mjs with JSDoc types, no .d.ts
+} from "../scripts/prune-actions-caches.mjs";
+
+type Cache = {
+  id: number;
+  ref: string;
+  key: string;
+  size_in_bytes: number;
+  created_at: string;
+};
+
+let nextId = 1;
+const cache = (ref: string, key: string, created_at: string, mb = 100): Cache => ({
+  id: nextId++,
+  ref,
+  key,
+  size_in_bytes: mb * 1024 * 1024,
+  created_at,
+});
+
+const plan = (caches: Cache[], live: string[] = ["main"], prs: string[] = []) =>
+  planPrune(caches, {
+    liveBranches: new Set(live),
+    openPrs: new Set(prs),
+  }) as { cache: Cache; reason: string }[];
+
+const deletedKeys = (...args: Parameters<typeof plan>) =>
+  plan(...args)
+    .map((d) => d.cache.key)
+    .sort();
+
+describe("classifyRef", () => {
+  it("unwraps the doubled prefix GitHub puts on a tag cache", () => {
+    expect(classifyRef("refs/heads/refs/tags/v0.6.0")).toEqual({
+      kind: "tag",
+      name: "v0.6.0",
+    });
+  });
+
+  it("reads a branch and a pull ref", () => {
+    expect(classifyRef("refs/heads/main")).toEqual({ kind: "branch", name: "main" });
+    expect(classifyRef("refs/heads/fix/some-thing")).toEqual({
+      kind: "branch",
+      name: "fix/some-thing",
+    });
+    expect(classifyRef("refs/pull/391/merge")).toEqual({ kind: "pr", name: "391" });
+  });
+});
+
+describe("newestCachedTag", () => {
+  it("is the tag that most recently wrote a cache, not the highest version", () => {
+    const caches = [
+      cache("refs/heads/refs/tags/v0.10.0", "k1", "2026-01-01T00:00:00Z"),
+      cache("refs/heads/refs/tags/v0.9.0", "k2", "2026-06-01T00:00:00Z"),
+      cache("refs/heads/main", "k3", "2026-07-01T00:00:00Z"),
+    ];
+    expect(newestCachedTag(caches)).toBe("v0.9.0");
+  });
+
+  it("is null when no tag has a cache", () => {
+    expect(newestCachedTag([cache("refs/heads/main", "k", "2026-01-01T00:00:00Z")])).toBeNull();
+  });
+});
+
+describe("planPrune", () => {
+  it("keeps the newest tag's caches and drops older tags'", () => {
+    const caches = [
+      cache("refs/heads/refs/tags/v0.5.0", "v0-rust-linux-Linux-x64-aaa-bbb", "2026-08-01T00:00:00Z"),
+      cache("refs/heads/refs/tags/v0.6.0", "v0-rust-linux-Linux-x64-ccc-ddd", "2026-09-01T00:00:00Z"),
+    ];
+    expect(deletedKeys(caches)).toEqual(["v0-rust-linux-Linux-x64-aaa-bbb"]);
+  });
+
+  it("never condemns the live release because its ref is not a branch", () => {
+    // The regression this exists for: with `refs/heads/` stripped naively,
+    // `refs/tags/v0.6.0` looks like a missing branch.
+    const caches = [cache("refs/heads/refs/tags/v0.6.0", "v0-rust-msix-x-1-2", "2026-09-01T00:00:00Z")];
+    expect(plan(caches, ["main"])).toEqual([]);
+  });
+
+  it("drops caches for a branch that no longer exists, and keeps live ones", () => {
+    const caches = [
+      cache("refs/heads/gone", "v0-rust-build-Linux-x64-a-b", "2026-09-01T00:00:00Z"),
+      cache("refs/heads/alive", "v0-rust-build-Linux-x64-c-d", "2026-09-01T00:00:00Z"),
+      cache("refs/heads/main", "v0-rust-build-Linux-x64-e-f", "2026-09-01T00:00:00Z"),
+    ];
+    expect(deletedKeys(caches, ["main", "alive"])).toEqual(["v0-rust-build-Linux-x64-a-b"]);
+  });
+
+  it("drops a closed PR's caches and keeps an open one's", () => {
+    const caches = [
+      cache("refs/pull/1/merge", "node-cache-Linux-x64-pnpm-a", "2026-09-01T00:00:00Z"),
+      cache("refs/pull/2/merge", "node-cache-Linux-x64-pnpm-b", "2026-09-01T00:00:00Z"),
+    ];
+    expect(deletedKeys(caches, ["main"], ["2"])).toEqual(["node-cache-Linux-x64-pnpm-a"]);
+  });
+
+  it("keeps the NEWEST rust generation even when an older one is far larger", () => {
+    const caches = [
+      cache("refs/heads/main", "v0-rust-build-Linux-x64-old-84d0", "2026-09-01T12:09:35Z", 1662),
+      cache("refs/heads/main", "v0-rust-build-Linux-x64-new-84d0", "2026-09-03T13:19:24Z", 828),
+    ];
+    expect(deletedKeys(caches)).toEqual(["v0-rust-build-Linux-x64-old-84d0"]);
+  });
+
+  it("scopes a family by ref, so main's copy and a tag's do not evict each other", () => {
+    const caches = [
+      cache("refs/heads/main", "v0-rust-linux-Linux-x64-a-b", "2026-09-01T00:00:00Z"),
+      cache("refs/heads/refs/tags/v0.6.0", "v0-rust-linux-Linux-x64-c-d", "2026-09-03T00:00:00Z"),
+    ];
+    expect(plan(caches)).toEqual([]);
+  });
+
+  it("keeps two codeql generations and two node generations", () => {
+    const codeql = (sha: string, at: string) =>
+      cache("refs/heads/main", `codeql-overlay-base-database-1-h-javascript-2.26.4-${sha}-99-1`, at);
+    const caches = [
+      codeql("aaa", "2026-09-01T00:00:00Z"),
+      codeql("bbb", "2026-09-02T00:00:00Z"),
+      codeql("ccc", "2026-09-03T00:00:00Z"),
+    ];
+    // Newest two survive; the oldest goes.
+    expect(deletedKeys(caches)).toEqual([
+      "codeql-overlay-base-database-1-h-javascript-2.26.4-aaa-99-1",
+    ]);
+  });
+
+  it("leaves keys it does not recognise entirely alone", () => {
+    const caches = [
+      cache("refs/heads/main", "some-third-party-cache-1", "2026-09-01T00:00:00Z"),
+      cache("refs/heads/main", "some-third-party-cache-2", "2026-09-02T00:00:00Z"),
+      cache("refs/heads/main", "some-third-party-cache-3", "2026-09-03T00:00:00Z"),
+    ];
+    expect(plan(caches)).toEqual([]);
+  });
+
+  it("condemns a dead ref's cache once, not twice", () => {
+    const caches = [
+      cache("refs/heads/gone", "v0-rust-build-Linux-x64-a-b", "2026-09-01T00:00:00Z"),
+      cache("refs/heads/gone", "v0-rust-build-Linux-x64-c-d", "2026-09-02T00:00:00Z"),
+    ];
+    const result = plan(caches, ["main"]);
+    expect(result).toHaveLength(2);
+    expect(result.every((d) => d.reason.startsWith("dead-branch"))).toBe(true);
+  });
+});


### PR DESCRIPTION
Two changes to what CI *costs*. Neither is a gate.

## 1. The Actions cache was over GitHub's 10 GB ceiling

Usage was **10.73 GB**, so GitHub was evicting least-recently-used entries — and the jobs that lose are the ones that run least often. From the v0.6.0 release log:

| job | cache result |
|---|---|
| `macos-universal` | **No cache found.** |
| `msix` | **No cache found.** |
| `linux` | partial (`full match: false`) |
| `windows` | partial (`full match: false`) |

A cold Rust build measured **577s against 259s warm**, so a full quota was costing about **five minutes on each of those jobs, every release**. Nothing was broken; the quota was simply full of caches nothing would ever read again.

`cache-prune.yml` runs `scripts/prune-actions-caches.mjs` **daily** — daily rather than weekly because of the refill rate: CodeQL leaves a ~96 MB overlay database per commit on `main`, and every toolchain or lockfile change strands a multi-hundred-MB rust-cache generation.

Four rules, each logged with its reason: `dead-branch`, `closed-pr`, `old-tag`, `stale-gen`. A dry run against the live repo plans **4061 MB across 11 entries** (9 stale CodeQL databases + 2 superseded rust generations), leaving ~5.9 GB.

### The two ways to get this catastrophically wrong

This is the only script here whose job is to delete things, so `test/pruneCaches.test.ts` pins both. **Each was verified against a deliberately broken script before being trusted** — stubbing the tag unwrap fails 5 tests, flipping the sort direction fails 2:

- **A tag cache's ref arrives as `refs/heads/refs/tags/v0.6.0`** — `refs/heads/` glued onto an already-qualified ref. Read naively that is a *branch* named `refs/tags/v0.6.0`, which exists nowhere, so a "does this branch still exist" rule deletes the caches of the release building right now.
- **The newest generation is not the biggest.** On this repo the current `v0-rust-build-Linux-x64` entry was 828 MB and the superseded one 1662 MB, because a fresh entry is written from a partial restore. Sort by `created_at`, never by size.

## 2. CodeQL moves off default setup so it can be path-filtered

Default setup analyses every configured language on every run. **PR #391 touched `release.yml` and three markdown files and still paid 9m20s for `Analyze (rust)`** — the slowest check in the repo, billed to docs-only PRs. Same three languages (`actions`, `javascript-typescript`, `rust`), now behind a filter.

Verified against the real filter logic:

| diff | analyses run |
|---|---|
| docs only | *(none — job skipped)* |
| workflow only (the #391 shape) | `actions` |
| `src-tauri/` only | `rust` |
| `scripts/` only | `javascript-typescript` |

**The filter runs on `pull_request` ONLY**, and that asymmetry is deliberate: a push to `main` is the run whose results become the branch's code-scanning state, so skipping a language there would leave `main` described by an older commit's analysis. PR runs are advisory, which is where the 9m is worth skipping.

It follows the house `changes` + always-running-gate pattern from `docs/dev/testing.md`, so a ruleset could require the `codeql` gate later without a filtered PR blocking forever.

> ⚠️ **Default setup has been turned off** (`state: not-configured`) — GitHub refuses results from an advanced configuration while it is enabled. The previous config is recorded in `docs/dev/testing.md` and in the workflow header. Re-enabling default setup later does **not** disable this workflow; it just makes it fail.

## Also

`scripts/` joins `tests.yml`'s `js` filter, for the reason that section already documents: `pruneCaches.test.ts` reads the pruner, so without it the one change that can break the pruner is the one change that skips its test.

## Verification

- `pnpm test`: **3229 passed (332 files)**
- `pnpm tsc --noEmit`: clean
- Pruner dry run against the live repo: 11 entries / 4061 MB, inspected entry by entry
- Both destructive-path guards proven against deliberately broken versions
- This PR's own `codeql` run is the first live test of the advanced workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
