### PR TITLE
fix(commit): refuse a whitespace-only message under verbatim cleanup

### DIFF
--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -1101,6 +1101,16 @@ Commit-side hooks run in `Libgit2Backend::commit`, one per name, through
     pre-commit → read index → write tree → prepare-commit-msg → commit-msg
     → build/sign/move ref → post-commit
 
+- **An empty message is refused before any of it** (#387). `commit` returns
+  `InvalidArgument` for a message that is blank once trimmed — git's own
+  "Aborting commit due to empty commit message", made a guarantee of the method
+  rather than of whichever screen is driving it, and placed ahead of the hooks so
+  a refusal never runs somebody's `pre-commit`. Whitespace-only counts as empty:
+  that is a shade stricter than `git commit --cleanup=verbatim -m "   "`, which
+  really does record three spaces, but every caller here has already trimmed the
+  message's end (the composer's one deliberate deviation from git), so blanks
+  can only mean the text was lost on the way. Pinned by
+  `tests/stage_commit.rs::commit_refuses_{an_empty,a_whitespace_only}_message`.
 - **`pre-commit` runs before the index is read, and outside `with_repo`.** A hook
   that runs `git add` (lint-staged: reformat, restage) mutates the on-disk index,
   and only a read that happens afterwards sees it. Running it outside the lock

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -565,6 +565,18 @@ const composer = useCommitComposer({ repoId, branch, ticketPattern, message, set
   - The one deviation from git: no trailing newline, in any mode, because the
     backend stores the message verbatim and `buildMessage` trims the end
     regardless.
+  - **The gate asks the SEND path's question, not a similar one.** `canCommit`
+    keys on `buildMessage(composer.cleaned, trailers)` — one memo, the same
+    value that is sent — because "cleaned is non-empty" and "what we send is
+    non-empty" are not the same question: under `commit.cleanup=verbatim`
+    nothing is stripped, so a box of spaces survived cleanup and then trimmed to
+    `""` on the way out, and Commit lit up for a message the backend received as
+    empty (#387). The fix is deliberately NOT a `trim()` in `canCommit` — that
+    is a second cleanup policy, and the two would drift. `buildMessage` returns
+    `""` rather than a lone trailer block for the same reason: a co-author is an
+    addition to a message, never a substitute for one. The backend refuses an
+    empty message too (`docs/dev/backend.md`, the hook chain) — this gate is the
+    convenience, not the guarantee.
   - Pinned by 134 differential cases against real `git commit` (all five modes,
     `-m` and a scripted editor) — re-run that comparison before changing
     anything here rather than reasoning from the docs.

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -4557,6 +4557,26 @@ impl GitBackend for Libgit2Backend {
             Ok(())
         }
 
+        // An empty commit message is refused HERE, not only in the panel that
+        // usually asks (#387). git aborts on one ("Aborting commit due to empty
+        // commit message") and every caller of this method is a caller that
+        // meant to write history, so the guarantee belongs on this side of the
+        // IPC boundary rather than in whichever screen happens to be driving.
+        //
+        // Whitespace-only counts as empty. That is fractionally stricter than
+        // `git commit --cleanup=verbatim -m "   "`, which really does record
+        // three spaces — but every path that reaches this method has already
+        // trimmed the end of the message (the composer's one deliberate
+        // deviation from git), so a message that is nothing but blanks can only
+        // mean the text was lost on the way here.
+        //
+        // Before the hooks: a refusal must not have run anybody's `pre-commit`.
+        if opts.message.trim().is_empty() {
+            return Err(AppError::InvalidArgument(
+                "the commit message is empty".to_string(),
+            ));
+        }
+
         let repo_path = self.repo_path(repo_id)?;
 
         // `pre-commit` runs BEFORE the index is read, and OUTSIDE `with_repo`.

--- a/src-tauri/tests/stage_commit.rs
+++ b/src-tauri/tests/stage_commit.rs
@@ -2,6 +2,7 @@ mod support;
 
 use std::path::PathBuf;
 
+use platypusgit_lib::error::AppError;
 use platypusgit_lib::git::GitBackend;
 use platypusgit_lib::git::types::CommitOptions;
 
@@ -242,6 +243,91 @@ fn commit_without_signoff_leaves_message_untouched() {
 
     let tip = tr.repo.head().unwrap().peel_to_commit().unwrap();
     assert_eq!(tip.message().unwrap(), "update readme");
+}
+
+/// git aborts on an empty commit message, and so must we — the frontend's
+/// gate is a convenience, not the guarantee (#387).
+#[test]
+fn commit_refuses_an_empty_message() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "README.md", "hello world\n");
+    let (backend, handle) = tr.open_with_backend();
+    backend
+        .stage(&handle.id, &[PathBuf::from("README.md")])
+        .unwrap();
+
+    let err = backend
+        .commit(
+            &handle.id,
+            CommitOptions {
+                message: String::new(),
+                amend: false,
+                author_override: None,
+                signoff: false,
+                sign: None,
+                no_verify: false,
+            },
+        )
+        .expect_err("an empty message must be refused");
+    assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+
+    // Refused before anything was created, and the staged work is still there.
+    let log = backend.log(&handle.id, None, 10).unwrap();
+    assert_eq!(log.len(), 1, "nothing may be committed");
+}
+
+/// A message of nothing but spaces is the same empty message wearing a
+/// disguise: every path that sends one trims its end on the way out, so it
+/// reaches here as "" or not at all (#387).
+#[test]
+fn commit_refuses_a_whitespace_only_message() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "README.md", "hello world\n");
+    let (backend, handle) = tr.open_with_backend();
+    backend
+        .stage(&handle.id, &[PathBuf::from("README.md")])
+        .unwrap();
+
+    let err = backend
+        .commit(
+            &handle.id,
+            CommitOptions {
+                message: "  \t\n \n".into(),
+                amend: false,
+                author_override: None,
+                signoff: false,
+                sign: None,
+                no_verify: false,
+            },
+        )
+        .expect_err("a whitespace-only message must be refused");
+    assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+}
+
+/// Amending is the same commit op and gets the same guard — `git commit
+/// --amend` with an empty message aborts too.
+#[test]
+fn amend_refuses_an_empty_message() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    let err = backend
+        .commit(
+            &handle.id,
+            CommitOptions {
+                message: "   ".into(),
+                amend: true,
+                author_override: None,
+                signoff: false,
+                sign: None,
+                no_verify: false,
+            },
+        )
+        .expect_err("an empty amend message must be refused");
+    assert!(matches!(err, AppError::InvalidArgument(_)), "got {err:?}");
+
+    let log = backend.log(&handle.id, None, 10).unwrap();
+    assert_eq!(log[0].summary, "initial", "the tip must be untouched");
 }
 
 #[test]

--- a/src/screens/CommitPanel.compose.test.tsx
+++ b/src/screens/CommitPanel.compose.test.tsx
@@ -308,6 +308,46 @@ describe("a message the user typed is `git commit -m`", () => {
 });
 
 // ═════════════════════════════════════════════════════════════════════════════
+// commit.cleanup = verbatim (#387)
+// ═════════════════════════════════════════════════════════════════════════════
+
+// Verbatim means verbatim: the cleanup keeps every space, so `cleaned` is a
+// poor question for the gate to ask. What is SENT is `cleaned` with its end
+// trimmed — this app's one deviation from git — so a box holding nothing but
+// spaces is an empty commit message however verbatim the mode. The gate and
+// the send path have to ask that one question, or Commit lights up for a
+// message the backend receives as "".
+describe("commit.cleanup=verbatim", () => {
+  it("keeps Commit off for a box holding nothing but spaces and tabs", async () => {
+    setup({ template: template({ cleanup: "verbatim" }) });
+    await screen.findByTestId("commit-type");
+    type("   \t \n  \t\n");
+    expect(screen.getByTestId<HTMLButtonElement>("commit-button").disabled).toBe(true);
+  });
+
+  it("does not let a co-author trailer stand in for the message", async () => {
+    setup({ template: template({ cleanup: "verbatim" }) });
+    await screen.findByTestId("commit-type");
+    type("   ");
+    fireEvent.change(screen.getByTestId("commit-coauthors"), {
+      target: { value: "Ada <ada@x.com>" },
+    });
+    // A trailer is an addition to a message, never a substitute for one.
+    expect(screen.getByTestId<HTMLButtonElement>("commit-button").disabled).toBe(true);
+  });
+
+  it("still commits whitespace that has words around it, untouched", async () => {
+    setup({ template: template({ cleanup: "verbatim" }) });
+    await screen.findByTestId("commit-type");
+    type("  subject   \n\n\n# kept\n");
+    expect(screen.getByTestId<HTMLButtonElement>("commit-button").disabled).toBe(false);
+    fireEvent.click(screen.getByTestId("commit-button"));
+    await waitFor(() => expect(commitCall()).toBeDefined());
+    expect(commitCall()!.args.message).toBe("  subject   \n\n\n# kept");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
 // TICKET PREFIX
 // ═════════════════════════════════════════════════════════════════════════════
 

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -1103,12 +1103,23 @@ export function CommitPanelScreen() {
   // Only the first line counts against the subject budget; everything below it
   // is body text nobody truncates.
   const subjectLength = composer.subjectLength;
-  // The CLEANED message decides, not the raw box: a template whose comment lines
-  // are all that is left is what git calls an empty commit message, and Commit
-  // has to be disabled for it rather than writing one. A hand-typed `#123 fix`
+  // The message a commit would actually STORE: git's cleanup applied to the box
+  // (in the mode git would use), then `buildMessage` — the same value the send
+  // path uses, computed once. The gate has to ask THIS question rather than a
+  // similar one about `composer.cleaned`, because the two can disagree: under
+  // `commit.cleanup=verbatim` nothing is stripped, so a box of spaces survives
+  // cleanup non-empty and then trims to "" on the way out — Commit lit up for a
+  // message the backend received as empty (#387).
+  const outgoingMessage = React.useMemo(
+    () => buildMessage(composer.cleaned, coAuthorTrailers(coAuthors)),
+    [composer.cleaned, coAuthors],
+  );
+  // Which also covers what the cleanup itself removes: a template whose comment
+  // lines are all that is left is what git calls an empty commit message, and
+  // Commit is disabled for it rather than writing one. A hand-typed `#123 fix`
   // is NOT that — nothing is stripped there, so it stays committable.
   const canCommit =
-    (amend || staged.length > 0) && !!composer.cleaned && !authorInvalid;
+    (amend || staged.length > 0) && !!outgoingMessage && !authorInvalid;
   const canCommitAndPush = canCommit && !!headBranch && !!defaultRemote;
   const committerLine = identityLine(committerIdentity);
   const committerFrom = identityOrigin(committerIdentity);
@@ -1120,14 +1131,15 @@ export function CommitPanelScreen() {
     if (committingRef.current) return null;
     committingRef.current = true;
     try {
-      // git's own cleanup, in the mode git would use: whitespace only for a
-      // message the user typed (this box is `git commit -m`, where `#123 fix`
+      // The message `canCommit` was computed from — one value, so what the
+      // button allows and what the backend receives cannot drift. The cleanup
+      // behind it is git's own, in the mode git would use: whitespace only for
+      // a message the user typed (this box is `git commit -m`, where `#123 fix`
       // is an ordinary subject), plus comment stripping once commit.template
       // has seeded it. Applied here rather than in the backend so the box can
       // show what it removes before anyone presses Commit.
-      const full = buildMessage(composer.cleaned, coAuthorTrailers(coAuthors));
       const result = await commitAction(
-        full,
+        outgoingMessage,
         amend,
         signoff,
         authorIdentity,
@@ -2133,8 +2145,19 @@ export function coAuthorTrailers(raw: string): string[] {
   return out;
 }
 
+/**
+ * The exact message a commit will store: the cleaned box with its end trimmed,
+ * plus any co-author trailers.
+ *
+ * This is the ONE question `canCommit` and the send path both ask (#387) — an
+ * empty answer means an empty commit message, whatever cleanup mode produced
+ * it. Hence the guard below: a trailer is an addition to a message, never a
+ * substitute for one, and letting one carry an empty message through would put
+ * a commit whose subject is `Co-Authored-By:` into history.
+ */
 function buildMessage(message: string, coAuthors: string[] = []): string {
   const trimmed = message.trimEnd();
+  if (!trimmed) return "";
   // Trailers go in their own block after one blank line — that separation is
   // what `git interpret-trailers` (and GitHub) key on. Skip any the message
   // already spells out, so hand-written and generated trailers can't double up.


### PR DESCRIPTION
With `commit.cleanup = verbatim`, a message of only spaces or tabs passed every
gate and reached the backend as `""`. Verbatim strips nothing, so
`composer.cleaned` stayed non-empty and Commit was enabled — then
`buildMessage`'s `trimEnd()` reduced the message to `""` on the way out.

## The fix

**The gate now asks the SEND path's question.** `canCommit` keys on
`buildMessage(composer.cleaned, coAuthorTrailers(coAuthors))` — one memo,
reused by `doCommit`, so what the button allows and what the backend receives
are the same value by construction.

Deliberately *not* a `trim()` in `canCommit`: git's cleanup decides both what is
sent and whether Commit is enabled, and a second cleanup policy in the gate is
exactly how the two drift. `verbatim` still means verbatim — a message with
words in it keeps every leading space, blank run and `#` line.

`buildMessage` now returns `""` rather than a lone trailer block when the
message is empty: a co-author trailer is an addition to a message, never a
substitute for one, and without that a whitespace-only box plus a co-author
would have satisfied the new gate with a commit whose subject was
`Co-Authored-By:`.

**The backend refuses a blank message outright.** `Libgit2Backend::commit`
returns the existing `InvalidArgument` variant (no new `AppError`, so no TS
union or `appErrorDetail` change) before the hook chain starts, so a refusal
never runs somebody's `pre-commit`. Whitespace-only counts as empty — a shade
stricter than `git commit --cleanup=verbatim -m "   "`, which really does record
three spaces, but every caller here has already trimmed the message's end (the
composer's one deliberate deviation from git), so blanks can only mean the text
was lost on the way.

## Tests (written first, watched fail)

- `CommitPanel.compose.test.tsx` — a new `commit.cleanup=verbatim` block: a box
  of spaces/tabs keeps Commit off, a co-author cannot stand in for the message,
  and whitespace *around words* still commits untouched (the guard against
  over-fixing — it passed before and after).
- `stage_commit.rs` — `commit_refuses_an_empty_message`,
  `commit_refuses_a_whitespace_only_message`, `amend_refuses_an_empty_message`,
  each asserting `InvalidArgument` and that nothing was created.

Docs updated in `docs/dev/frontend.md` (the composer section) and
`docs/dev/backend.md` (the hook chain).

## Verification

- `pnpm test` — 331 files, 3219 tests passed
- `pnpm tsc --noEmit` — clean
- `cargo test` — 1196 passed, 0 failed, 1 ignored

Closes #387
