### PR TITLE
fix(git): reload the index before staging writes it back

### DIFF
--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -668,6 +668,48 @@ re-validation. That action stashes BEFORE it calls the backend, so any of those
 returning early would leave the user's work in a stash they never made. Only the
 refused take also raises a banner; a decline is a choice, not a failure.
 
+## The cached index goes stale — `fresh_index`, not `repo.index()` (#386)
+
+`with_repo` hands back a *cached* `git2::Repository`, and libgit2 keeps that
+repository's index in memory. `repo.index()` therefore returns the snapshot from
+whenever **this process** last touched it, not what is on disk. Every whole-file
+staging op is a read-modify-write of the entire index, so writing that snapshot
+back reverts anything staged in between — and this app has unusually many things
+that stage in between: the built-in terminal (#243) is in the window, `cd`-ed to
+the repo; a `pre-commit` that reformats and restages is explicitly supported; a
+second window can drive the same repo.
+
+`libgit2.rs::fresh_index` is the one answer (`repo.index()` + `read(false)`, so
+it costs a stat when nothing changed). Use it anywhere the index is written back
+or read to DECIDE something. Its call sites are `commit`, `stage`, `unstage`,
+`discard` and `delete_untracked`.
+
+- **Measured, not argued.** #386 was filed as *plausible* — one site reloaded,
+  four did not — and every one of the four lost data. `tests/index_staleness.rs`
+  is the reproduction and all six of its cases fail if the reload is removed:
+  `stage`/`unstage` reverted an externally staged file to untracked, and
+  `discard`/`delete_untracked` **deleted it from the worktree**. Those two are
+  the same cause wearing its worst face: a path missing from a stale index reads
+  as *untracked*, and untracked is the branch that unlinks instead of restoring.
+- **The refresh belongs above the branch, not inside it.** `unstage`'s
+  `reset_default` reaches for the repository's cached index *internally*, so
+  refreshing only in the unborn-HEAD arm fixes the arm that was already the less
+  common one. Same for `discard`, where `checkout_index(None, …)` writes the
+  cached index back even when the discarded path is unrelated to the clobbered
+  one — discarding `README.md` was enough to unstage someone else's `git add`.
+- **`fresh_index` must stay INSIDE the caller's `with_repo` closure.**
+  Refreshing under one lock acquisition and writing under another is the stash
+  TOCTOU rebuilt by hand.
+- **It closes the window we own, not the one we do not.** Against a writer
+  racing us right now, git's `index.lock` is the only arbiter; the fix narrows
+  "stale since this tab opened" to "stale for microseconds". Say that, rather
+  than claiming the ops are now concurrency-safe.
+- **The hunk/line ops were checked and are NOT affected.** `stage_hunk` and
+  friends either shell out to `git apply --cached` (which reads the on-disk
+  index) or go through libgit2's `ApplyLocation::Index`, which re-reads on its
+  own — verified by probe, not assumed, so a future change there has a stated
+  baseline to disagree with.
+
 ## Deleting an untracked file (#245)
 
 `GitBackend::delete_untracked` is on the trait despite being an unlink rather
@@ -1110,7 +1152,8 @@ Commit-side hooks run in `Libgit2Backend::commit`, one per name, through
   index in memory — so reading the index after the hook still returned the
   pre-hook snapshot, and a reformatting hook's work was silently dropped.
   `tests/hooks.rs::a_pre_commit_that_restages_is_honoured` found this and pins
-  it; it fails if either the read or the reload moves.
+  it; it fails if either the read or the reload moves. It is now
+  `libgit2.rs::fresh_index`, shared with the staging ops — see below.
 - **A non-zero `pre-commit`, `prepare-commit-msg` or `commit-msg` creates
   nothing** — no object, no ref move — the same guarantee the signing chain
   makes, for the same reason. The index is deliberately **not** rolled back: a

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -1155,6 +1155,45 @@ fn is_listed_submodule(submodule_paths: &std::collections::HashSet<String>, path
     submodule_paths.contains(path.trim_end_matches('/'))
 }
 
+/// The repository's index, reloaded from disk when it changed underneath us.
+///
+/// **Use this, not `repo.index()`, anywhere the index is read to decide
+/// something or written back.** `with_repo` hands back a CACHED
+/// `git2::Repository`, and libgit2 caches its index in memory, so `repo.index()`
+/// alone returns the snapshot from whenever *this process* last touched it. The
+/// staging ops are read-modify-writes of the WHOLE index, so writing that
+/// snapshot back silently reverts whatever something else staged in between.
+///
+/// This app has more of those "something else"s than most GUIs: the built-in
+/// terminal (#243) sits in the window `cd`-ed to the repository, a `pre-commit`
+/// hook that reformats and restages is an explicitly supported case (see
+/// `commit`), and a second window can drive the same repo.
+///
+/// Measured, not assumed — `tests/index_staleness.rs` is the reproduction, and
+/// all four staging call sites lost data without this call (`commit`, the fifth,
+/// had it already): `stage` and `unstage` reverted an externally staged file to
+/// untracked,
+/// `discard` **deleted** it from the worktree (a stale index reads it as
+/// untracked, and untracked is the delete branch), and `delete_untracked` did
+/// the same while its whole job is to refuse a tracked path. `stage_hunk` and
+/// friends were checked and are NOT affected: they either shell out to
+/// `git apply`, or go through libgit2's apply-to-index, which re-reads.
+///
+/// `read(false)` reloads only when the on-disk index actually changed, so it
+/// costs a stat in the common case — the same call and the same reasoning as
+/// the one in `commit`, which has been load-bearing there since hooks landed.
+///
+/// It closes the window we own (our own stale cache), not the one we do not:
+/// against a writer racing us *right now*, git's `index.lock` is the only
+/// arbiter. Which is why this must stay INSIDE the caller's single `with_repo`
+/// closure — refreshing under one lock acquisition and writing under another
+/// would open a fresh check-then-act gap of our own making.
+fn fresh_index(repo: &Repository) -> AppResult<git2::Index> {
+    let mut index = repo.index()?;
+    index.read(false)?;
+    Ok(index)
+}
+
 /// Whether the index tracks `rel` at ANY stage.
 ///
 /// Stage 0 is the ordinary merged entry, but a **conflicted** path has no stage-0
@@ -4134,7 +4173,9 @@ impl GitBackend for Libgit2Backend {
                     None => Ok(()),
                 };
             }
-            let mut index = repo.index()?;
+            // `fresh_index`, not `repo.index()`: this writes the whole index
+            // back, so a cached snapshot would revert an outside `git add`.
+            let mut index = fresh_index(repo)?;
             for p in stageable {
                 // `add_path` treats paths as repo-relative; it handles creates and modifications.
                 // For deletions from the worktree, we need `remove_path` instead.
@@ -4150,6 +4191,14 @@ impl GitBackend for Libgit2Backend {
     }
     fn unstage(&self, repo_id: &RepoId, paths: &[PathBuf]) -> AppResult<()> {
         self.with_repo(repo_id, |repo| {
+            // Both branches below write the whole index back, and both go
+            // through the repository's CACHED one — `reset_default` reaches for
+            // it internally, which is exactly why this refresh sits above the
+            // branch rather than inside the unborn arm. `fresh_index` hands back
+            // a handle to the same `git_index`, so refreshing it here is what
+            // `reset_default` then reads. See `fresh_index`.
+            let mut index = fresh_index(repo)?;
+
             // Resetting paths to HEAD is the equivalent of `git reset HEAD -- paths`.
             // If HEAD is unborn, just clear the entries from the index.
             let head = match repo.head() {
@@ -4163,7 +4212,6 @@ impl GitBackend for Libgit2Backend {
                     repo.reset_default(Some(commit.as_object()), paths)?;
                 }
                 None => {
-                    let mut index = repo.index()?;
                     for p in paths {
                         let _ = index.remove_path(p);
                     }
@@ -4199,7 +4247,13 @@ impl GitBackend for Libgit2Backend {
             // and returns Ok(()) — which is how discard used to report success
             // while leaving the file untouched. Split the batch: restore what
             // the index knows, delete what it doesn't.
-            let index = repo.index()?;
+            //
+            // `fresh_index` because that split is a DELETE decision: a path
+            // `git add`ed outside this process is missing from a cached index,
+            // reads as untracked, and gets removed from the worktree instead of
+            // restored. It also refreshes what `checkout_index` below writes
+            // back. See `fresh_index`.
+            let index = fresh_index(repo)?;
             let mut restore: Vec<&PathBuf> = Vec::new();
             let mut delete: Vec<PathBuf> = Vec::new();
             for p in discardable {
@@ -4262,7 +4316,12 @@ impl GitBackend for Libgit2Backend {
                 .workdir()
                 .ok_or_else(|| AppError::InvalidPath("bare repository has no workdir".into()))?
                 .to_path_buf();
-            let index = repo.index()?;
+            // `fresh_index`: the tracked check below is a refusal, and a cached
+            // index cannot refuse what it has not been told about. A file
+            // `git add`ed in the built-in terminal is tracked on disk and absent
+            // from our snapshot, so without this the one path this function
+            // exists to protect is the one it deletes. See `fresh_index`.
+            let index = fresh_index(repo)?;
 
             // ── Phase 1: validate everything, delete nothing ─────────────────
             //
@@ -4632,15 +4691,14 @@ impl GitBackend for Libgit2Backend {
 
             // Read the index HERE, after `pre-commit` — see the note above.
             //
-            // And `read(false)` is not optional. `with_repo` hands back a CACHED
-            // `git2::Repository`, and libgit2 caches its index in memory, so
-            // `index()` alone returns the snapshot from before the hook ran — a
-            // `pre-commit` that reformats and restages would silently commit the
-            // unformatted content. `read(false)` reloads only if the on-disk
-            // index actually changed, so it costs a stat in the common case.
-            // Pinned by `a_pre_commit_that_restages_is_honoured`.
-            let mut index = repo.index()?;
-            index.read(false)?;
+            // And it must be `fresh_index`, not `repo.index()`: the cached
+            // snapshot is the one from before the hook ran, so a `pre-commit`
+            // that reformats and restages would silently commit the unformatted
+            // content. This was the FIRST site to prove the staleness (pinned by
+            // `a_pre_commit_that_restages_is_honoured`); the staging ops later
+            // proved it too, which is why the reload is a named helper rather
+            // than a line that only happens to exist here.
+            let mut index = fresh_index(repo)?;
             let tree_oid = index.write_tree()?;
             let tree = repo.find_tree(tree_oid)?;
 

--- a/src-tauri/tests/index_staleness.rs
+++ b/src-tauri/tests/index_staleness.rs
@@ -1,0 +1,232 @@
+//! Issue #386 — **the index may have changed since we last read it.**
+//!
+//! `with_repo` hands out a CACHED `git2::Repository` and libgit2 keeps that
+//! repository's index in memory, so `repo.index()` returns whatever snapshot
+//! *this process* last saw. Every op below then writes the whole index back, or
+//! decides whether to delete a file from it. A snapshot taken before something
+//! else staged a file is a snapshot that unstages it again on the next write.
+//!
+//! The issue was filed as PLAUSIBLE — one call site (`commit`) reloaded, four
+//! did not, and whether that was actually observable depended on git2 internals
+//! nobody had exercised. **It is observable.** Every test in this file failed
+//! before `fresh_index` (`git/libgit2.rs`) and the measured damage was:
+//!
+//! | op                | before                                      |
+//! |-------------------|---------------------------------------------|
+//! | `stage`           | `b.txt` back to `??` — staging reverted     |
+//! | `unstage`         | `b.txt` back to `??` — staging reverted     |
+//! | `unstage` (unborn)| `b.txt` back to `??` — staging reverted     |
+//! | `discard`         | `b.txt` **deleted from the worktree**       |
+//! | `delete_untracked`| `b.txt` **deleted from the worktree**       |
+//!
+//! The two deletions are the same root cause wearing its worst face: a path
+//! missing from a stale index reads as *untracked*, and untracked is the branch
+//! that removes the file rather than restoring it — `delete_untracked` deleting
+//! precisely the tracked path it exists to refuse.
+//!
+//! "Something else" is not hypothetical here. The built-in terminal (#243) sits
+//! in the window `cd`-ed to the repository, a `pre-commit` hook that reformats
+//! and restages is explicitly supported (`CommitPanel`'s `hookRejection`), and a
+//! second window can drive the same repo. So the outside writer in every test is
+//! a real `git` invocation against the same worktree — `git_in`, not a second
+//! libgit2 handle, because a second handle would not prove anything about the
+//! index file that git actually writes.
+//!
+//! What these tests do NOT claim: that we are safe against a writer racing us
+//! *right now*. Nothing short of git's `index.lock` arbitrates that. They pin
+//! the window we own — the one that stays open for as long as a tab is.
+
+mod support;
+
+use std::path::PathBuf;
+
+use platypusgit_lib::error::AppError;
+use platypusgit_lib::git::GitBackend;
+
+use support::{fs::write_file, git_in, TempRepo};
+
+/// `git status --porcelain`, read with the real CLI so the assertion is about
+/// the index FILE and not about another cache of it.
+fn porcelain(tr: &TempRepo) -> String {
+    git_in(tr.path(), &["status", "--porcelain"])
+}
+
+/// Staged-by-someone-else, in git's own two-column spelling: index side `A`,
+/// worktree side clean.
+fn staged_add(status: &str, path: &str) -> bool {
+    status.lines().any(|l| l == format!("A  {path}"))
+}
+
+#[test]
+fn stage_does_not_revert_a_file_staged_outside_this_process() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "a.txt", "a\n");
+    write_file(tr.path(), "b.txt", "b\n");
+    write_file(tr.path(), "c.txt", "c\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    // Populate the cached index the way the app does — a real staging write.
+    backend
+        .stage(&handle.id, &[PathBuf::from("a.txt")])
+        .expect("stage a.txt");
+
+    // The terminal in the other pane.
+    git_in(tr.path(), &["add", "b.txt"]);
+
+    // Back in the UI: stage a third file. This is a whole-index write.
+    backend
+        .stage(&handle.id, &[PathBuf::from("c.txt")])
+        .expect("stage c.txt");
+
+    let status = porcelain(&tr);
+    assert!(
+        staged_add(&status, "b.txt"),
+        "stage reverted a file staged outside this process:\n{status}"
+    );
+    assert!(staged_add(&status, "a.txt"), "a.txt lost:\n{status}");
+    assert!(staged_add(&status, "c.txt"), "c.txt not staged:\n{status}");
+}
+
+#[test]
+fn unstage_does_not_revert_a_file_staged_outside_this_process() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "a.txt", "a\n");
+    write_file(tr.path(), "b.txt", "b\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .stage(&handle.id, &[PathBuf::from("a.txt")])
+        .expect("stage a.txt");
+    git_in(tr.path(), &["add", "b.txt"]);
+
+    backend
+        .unstage(&handle.id, &[PathBuf::from("a.txt")])
+        .expect("unstage a.txt");
+
+    let status = porcelain(&tr);
+    // This is the `reset_default` branch, which reaches for the repository's
+    // cached index *internally* — so it also pins that refreshing through a
+    // separate `Index` handle reaches the same `git_index`.
+    assert!(
+        staged_add(&status, "b.txt"),
+        "unstage reverted a file staged outside this process:\n{status}"
+    );
+    assert!(
+        status.lines().any(|l| l == "?? a.txt"),
+        "a.txt should be unstaged:\n{status}"
+    );
+}
+
+#[test]
+fn unstage_on_an_unborn_head_does_not_revert_an_outside_stage() {
+    // No HEAD to reset to, so `unstage` takes its other branch: clear the
+    // entries from the index by hand and write it back. Same clobber.
+    let tr = TempRepo::fresh();
+    write_file(tr.path(), "a.txt", "a\n");
+    write_file(tr.path(), "b.txt", "b\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .stage(&handle.id, &[PathBuf::from("a.txt")])
+        .expect("stage a.txt");
+    git_in(tr.path(), &["add", "b.txt"]);
+
+    backend
+        .unstage(&handle.id, &[PathBuf::from("a.txt")])
+        .expect("unstage a.txt");
+
+    let status = porcelain(&tr);
+    assert!(
+        staged_add(&status, "b.txt"),
+        "unstage (unborn HEAD) reverted an outside stage:\n{status}"
+    );
+}
+
+#[test]
+fn discard_restores_a_file_staged_outside_this_process_instead_of_deleting_it() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "a.txt", "a\n");
+    write_file(tr.path(), "b.txt", "b\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .stage(&handle.id, &[PathBuf::from("a.txt")])
+        .expect("stage a.txt");
+    // b.txt becomes TRACKED outside this process.
+    git_in(tr.path(), &["add", "b.txt"]);
+    // Now edit it and ask the app to throw the edit away. "Discard" on a
+    // tracked path means `git checkout -- b.txt`; it must never mean `rm`.
+    write_file(tr.path(), "b.txt", "edited\n");
+
+    backend
+        .discard(&handle.id, &[PathBuf::from("b.txt")])
+        .expect("discard b.txt");
+
+    assert!(
+        tr.path().join("b.txt").exists(),
+        "discard DELETED a file that a stale index did not know was tracked"
+    );
+    assert_eq!(
+        std::fs::read_to_string(tr.path().join("b.txt")).unwrap(),
+        "b\n",
+        "discard should restore the staged content"
+    );
+}
+
+#[test]
+fn discard_of_one_path_does_not_revert_an_outside_stage_of_another() {
+    // `checkout_index` writes the index back too, so discarding an unrelated
+    // path was enough to unstage someone else's work.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "a.txt", "a\n");
+    write_file(tr.path(), "b.txt", "b\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .stage(&handle.id, &[PathBuf::from("a.txt")])
+        .expect("stage a.txt");
+    git_in(tr.path(), &["add", "b.txt"]);
+
+    write_file(tr.path(), "README.md", "clobbered\n");
+    backend
+        .discard(&handle.id, &[PathBuf::from("README.md")])
+        .expect("discard README.md");
+
+    let status = porcelain(&tr);
+    assert!(
+        staged_add(&status, "b.txt"),
+        "discarding an unrelated path reverted an outside stage:\n{status}"
+    );
+}
+
+#[test]
+fn delete_untracked_refuses_a_path_staged_outside_this_process() {
+    // The refusal this function is built around: a tracked file that slipped
+    // into the selection must survive. A stale index cannot refuse what it has
+    // never been told about, so this deleted the one path it exists to protect.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "a.txt", "a\n");
+    write_file(tr.path(), "b.txt", "b\n");
+    let (backend, handle) = tr.open_with_backend();
+
+    backend
+        .stage(&handle.id, &[PathBuf::from("a.txt")])
+        .expect("stage a.txt");
+    git_in(tr.path(), &["add", "b.txt"]);
+
+    // Its phase 1 validates the whole batch before touching disk, so a tracked
+    // path is an outright refusal — not a per-path failure, and not a partial
+    // delete. That is only reachable when the check reads the CURRENT index.
+    let err = backend
+        .delete_untracked(&handle.id, &[PathBuf::from("b.txt")])
+        .expect_err("a tracked path must be refused");
+
+    assert!(
+        matches!(err, AppError::InvalidPath(ref m) if m.contains("tracked")),
+        "wrong refusal for a tracked path: {err:?}"
+    );
+    assert!(
+        tr.path().join("b.txt").exists(),
+        "delete_untracked deleted a tracked file"
+    );
+}


### PR DESCRIPTION
## Outcome: **it reproduces.** This is silent data loss on a core flow.

#386 was filed as *plausible* on purpose — the asymmetry was certain (one `index.read(false)` in `libgit2.rs`, four staging ops without it), the user-visible outcome was not. I reproduced it before touching anything. All four sites lose data, and two of them lose it by **deleting a file from the worktree**.

### The reproduction

The shape the issue suggested, with the outside writer being a real `git` invocation against the same temp repo (`support::git_in`) — not a second libgit2 handle, because only the real CLI proves anything about the index file git actually writes:

```
backend.stage(a.txt)      # populates + writes the cached index
git add b.txt             # the built-in terminal, in the other pane
backend.<op>(…)           # back in the UI
git status --porcelain    # what happened to b.txt?
```

Measured, on `main`, before the fix:

| op | `b.txt` after |
| --- | --- |
| `stage` (a third file) | `??` — the outside staging reverted |
| `unstage` (`reset_default` branch) | `??` — reverted |
| `unstage` (unborn HEAD branch) | `??` — reverted |
| `discard` (of `b.txt`) | **deleted from the worktree** |
| `discard` (of an unrelated `README.md`) | `??` — reverted |
| `delete_untracked` (of `b.txt`) | **deleted from the worktree**, `Ok([])` |

The two deletions are the same root cause wearing its worst face: a path missing from a stale index reads as *untracked*, and untracked is the branch that unlinks rather than restores. `delete_untracked` deleted precisely the tracked path its whole two-phase validation exists to refuse — it returned `Ok([])`, so nothing was even reported.

The unrelated-`README.md` row is the one I did not expect: `checkout_index(None, …)` writes the cached index back too, so discarding *any* file was enough to unstage someone else's `git add`.

### The fix

One named `fresh_index(repo)` helper (`repo.index()` + `read(false)`) carrying the reload and the reasoning, at all four sites. `commit` now uses it instead of its own inline copy, so there is one documented answer rather than a line that happens to exist in one place.

Two things I was careful about:

- **No new TOCTOU.** `fresh_index` stays *inside* each caller's single `with_repo` closure. Refreshing under one lock acquisition and writing under another would rebuild the stash TOCTOU by hand.
- **Honest scope of the guarantee.** This closes the window we own — our own cache, stale for as long as a tab is open — and narrows it to microseconds. It does **not** make these ops safe against a writer racing us right now; git's `index.lock` is the only arbiter of that. The comment and the doc say so rather than claiming more.

### What is *not* affected (checked, not assumed)

`stage_hunk` / `unstage_hunk` / `discard_hunk` / the `*_lines` family: they either shell out to `git apply --cached` (reads the on-disk index) or go through libgit2's `ApplyLocation::Index`, which re-reads on its own. I probed `stage_hunk` with the same fixture and the outside stage survived. Recorded in `docs/dev/backend.md` so a future change there has a stated baseline.

### Verification

- `cargo test --manifest-path src-tauri/Cargo.toml` — **1199 passed, 0 failed** (+6 new).
- `pnpm test` — **3216 passed, 331 files** (docs touched, so the doc-invariant project ran).
- Red→green proof: with the `read(false)` removed from `fresh_index` and nothing else changed, **all 6 of `tests/index_staleness.rs` fail**; with it, all 6 pass.
- No e2e run — three sibling agents are in parallel worktrees and only one cold container build may run at a time. CI's required `e2e-linux` covers it.

### For a reviewer to second-guess

1. **`unstage`'s refresh sits above the branch, not in the unborn arm.** `reset_default` reaches for the repository's cached index *internally*, so refreshing through a separate `Index` handle only works because `git_repository_index` hands back the same `git_index`. That is asserted, not assumed — `unstage_does_not_revert_a_file_staged_outside_this_process` drives the `reset_default` branch specifically and fails without the refresh.
2. **A behaviour change on a broken index.** `read(false)` can now fail where `repo.index()` alone would have succeeded, so an unreadable index turns a `stage` into an error instead of a write. I think refusing to clobber an index we cannot read is right, but it is a change.
3. **`commit`'s comment was rewritten** to point at the helper. Behaviour is byte-identical; `tests/hooks.rs::a_pre_commit_that_restages_is_honoured` still passes and still pins it.
4. **Cost.** One extra `stat` per staging op when the index has not changed. Not measured as a regression; `status` already refreshes on every poll via `update_index(true)`.

Closes #386
