### PR TITLE
fix(diff): cap every diff path, and say "too large" not "binary"

### DIFF
--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -349,6 +349,32 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   does not match `README.md`, so one test over both trees would be skipped by
   exactly the change it polices. See `docs/dev/testing.md`.
 
+## One blob ceiling, on every diff path (#131, made universal by #385)
+
+- **`MAX_WORKDIR_BLOB` (5 MB, `libgit2.rs`) is now set at every diff-options
+  site**, not just `diff_ref_to_workdir`'s. It used to be one capped path and
+  three uncapped ones: `diff` (one file — the commit panel's workhorse),
+  `diff_commit` and `diff_commits` inherited libgit2's 512 MB default, so
+  clicking a checked-in 80 MB `bundle.min.js` xdiff'd the whole file, allocated
+  a `String` per line in `diff_to_file_diffs`, and shipped the lot across IPC as
+  one JSON payload. `diff_stash`'s two builders are capped for the same reason —
+  a stash holds whatever the worktree held.
+- **Over the ceiling the answer is `FileDiff.oversized { size, limit }`, not
+  just "binary".** libgit2's own answer to `max_size` is `GIT_DIFF_FLAG_BINARY`,
+  which is a dishonest thing to show a user about a text file; `binary` keeps
+  its meaning (it stays true, and the image-preview branch still runs off it)
+  and this says WHY. The limit travels with the size so the sentence the user
+  reads is built from the value that was applied — see `docs/dev/frontend.md`.
+- **The size is read INSIDE the print callback, never before it.** libgit2 fills
+  `git_diff_file.size` in place while loading the patch (an ODB header read for
+  a tree side, a stat for a workdir one), so `delta.new_file().size()` is 0 for
+  a tree delta until then. Same load-order trap the `binary` seeding in
+  `diff_to_file_diffs` already documents; `oversized_delta` carries the note.
+- **Line STATS are deliberately not capped.** `diff_line_stats` feeds the file
+  rows' `+/−` counts, and capping it would silently change those numbers.
+  `src-tauri/tests/diff_blob_ceiling.rs` covers the four diff entry points and
+  the control case: an ordinary text file must still diff exactly as before.
+
 ## Image previews: the only reader that returns BYTES (#224)
 
 - **`read_image_preview` is the fourth file reader**, and the only one that can

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -54,6 +54,30 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   type back — silent truncation is worse than the overflow.
 - **Gate text rendering on `isTextualDiff(diff)`, not `!diff.binary`** (#93) —
   an LFS pointer is honestly text; the surfaces render `LfsDiffNotice` instead.
+- **"Binary" is a LIE about a file we simply declined to read (#385).** The
+  backend now caps EVERY diff path at `MAX_WORKDIR_BLOB` (it used to cap exactly
+  one, and `diff`/`diff_commit`/`diff_commits` — the commit panel's own
+  workhorses — inherited libgit2's 512 MB default). libgit2's answer to
+  `max_size` is to flag the delta BINARY, so without a second signal a
+  checked-in `bundle.min.js` reaches the surfaces indistinguishable from a PNG
+  and reads as "Binary file — no textual diff.": untrue about a text file, and
+  it hides the one fact that explains the pane. So the delta carries
+  `oversized: { size, limit }` and `oversizedDiffNotice` (`lib/derive.ts`) turns
+  it into the shared sentence — "File too large to diff" / "40 MB — over the
+  5.0 MB limit, so it was not read."
+  * **The LIMIT comes off the wire.** A frontend constant would be a second copy
+    of a policy that lives in `libgit2.rs`, free to drift from the one that was
+    actually applied. `test/diffOversized.test.ts` greps the four surfaces for
+    the helper AND for a hardcoded ceiling, and counts the backend's `max_size`
+    call sites — the bug was a policy split, not a rendering one.
+  * **`isTextualDiff` excludes it too**, belt and braces: the backend only ever
+    sets `oversized` on a delta libgit2 already called binary, so that arm
+    cannot fire alone today. It is there so "we did not read this blob" can
+    never come to mean "render its hunks".
+  * **No "show it anyway" override yet** — deliberately out of scope of the fix,
+    and tracked as #396: the ceiling had to become one policy before an escape
+    hatch from it could mean anything, and the row model has to survive the
+    result first (`windowVariable` reduces over every height on every scroll).
 - **The complement of `isTextualDiff` is not automatically a dead end** (#224).
   When the binary is an IMAGE, all five diff surfaces render the shared
   `ImageDiffView` (`features/diff/`) — old beside new, each with pixel

--- a/src-tauri/src/git/lfs.rs
+++ b/src-tauri/src/git/lfs.rs
@@ -304,6 +304,7 @@ mod tests {
                 lines,
             }],
             lfs: None,
+            oversized: None,
         }
     }
 

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -30,6 +30,7 @@ use super::{
         DiffLine, DiffLineKind, FastForward, FileContent, FileDiff, FileStatus, HeadInfo, ImagePreview,
         LfsStatus,
         LogFilter, LogPage,
+        OversizedBlob,
         RebaseAction, RebaseProgress, RebaseProgressSink, RebaseStatus, RebaseStep, RebaseSummary,
         ReflogEntry, ReflogOp, RemoteInfo,
         RepoHandle, RepoId, RepoState, ResetMode, ShallowInfo, StashInfo, StashSaveOptions,
@@ -1922,6 +1923,9 @@ fn diff_to_file_diffs(diff: &git2::Diff) -> AppResult<Vec<FileDiff>> {
             deletions: 0,
             hunks: Vec::new(),
             lfs: None,
+            // Same load-order trap as `binary` above: sizes are filled in
+            // during `print`, so this is decided in the callback, not here.
+            oversized: None,
         });
     }
 
@@ -1951,6 +1955,10 @@ fn diff_to_file_diffs(diff: &git2::Diff) -> AppResult<Vec<FileDiff>> {
         }
         if d.flags().contains(git2::DiffFlags::BINARY) {
             out[idx].binary = true;
+            // A blob over `MAX_WORKDIR_BLOB` is flagged binary by libgit2 and
+            // arrives here indistinguishable from a PNG. Record the size so the
+            // UI can say which it is (#385).
+            out[idx].oversized = out[idx].oversized.or_else(|| oversized_delta(&d));
             return true;
         }
         if let Some(h) = hunk {
@@ -2064,11 +2072,29 @@ enum UntrackedMode {
 /// reviewer reads either.
 const MAX_UNTRACKED_FILES: usize = 200;
 
-/// Per-blob ceiling for the same op. Larger blobs report as binary, which is
-/// what libgit2 does for anything over `DiffOptions::max_size` anyway — this
-/// just sets it far below the 512MB default, because a 5MB "text" file is a
-/// generated artifact, not something anyone diffs in a GUI.
-const MAX_WORKDIR_BLOB: i64 = 5 * 1024 * 1024;
+/// Per-blob ceiling for EVERY diff path (#131 set it, #385 made it universal).
+/// Larger blobs report as binary, which is what libgit2 does for anything over
+/// `DiffOptions::max_size` anyway — this just sets it far below the 512MB
+/// default, because a 5MB "text" file is a generated artifact, not something
+/// anyone diffs in a GUI.
+///
+/// `pub` so an integration test can assert the limit the UI is told about is
+/// the limit that was applied.
+pub const MAX_WORKDIR_BLOB: i64 = 5 * 1024 * 1024;
+
+/// Did libgit2 skip this delta because a side is over the ceiling? (#385)
+///
+/// Read from the DELTA rather than from a separate blob lookup: libgit2 fills
+/// `git_diff_file.size` in place while loading the patch (an ODB header read
+/// for a tree side, a stat for a workdir one), and every caller of this asks
+/// from inside a `print`/`foreach` callback — i.e. after the load. Reading it
+/// before the load would see zeros for a tree delta, which is the trap the
+/// `binary` seeding a few lines below already documents.
+fn oversized_delta(delta: &git2::DiffDelta<'_>) -> Option<OversizedBlob> {
+    let limit = MAX_WORKDIR_BLOB as u64;
+    let size = delta.old_file().size().max(delta.new_file().size());
+    (size > limit).then_some(OversizedBlob { size, limit })
+}
 
 /// Every stash entry as `(oid, reflog message)`, newest first (#133).
 ///
@@ -3545,6 +3571,13 @@ impl GitBackend for Libgit2Backend {
             opts.disable_pathspec_match(true);
             opts.context_lines(context_lines);
             opts.ignore_whitespace(ignore_whitespace);
+            // One path, but one path is all it takes: a checked-in
+            // `bundle.min.js` is a single click in the commit panel, and
+            // without this libgit2's 512MB default let it xdiff the whole file
+            // and serialise a String per line through IPC (#385). Same ceiling
+            // as `diff_ref_to_workdir` — one policy, not one capped path and
+            // three uncapped ones.
+            opts.max_size(MAX_WORKDIR_BLOB);
             // Include untracked files as if their full content were a new addition
             // so the diff viewer shows file contents for newly created files.
             if matches!(kind, DiffKind::WorktreeToIndex | DiffKind::WorktreeToHead) {
@@ -3581,6 +3614,7 @@ impl GitBackend for Libgit2Backend {
             let mut current_path: Option<String> = None;
             let mut old_path: Option<String> = None;
             let mut binary = false;
+            let mut oversized: Option<OversizedBlob> = None;
             let mut additions: u32 = 0;
             let mut deletions: u32 = 0;
             let mut hunks: Vec<DiffHunk> = Vec::new();
@@ -3601,6 +3635,10 @@ impl GitBackend for Libgit2Backend {
                 }
                 if delta.flags().contains(git2::DiffFlags::BINARY) {
                     binary = true;
+                    // Why it is "binary": a real PNG, or a text blob we
+                    // declined to read (#385). Only the size can tell them
+                    // apart, and it is populated by now (see `oversized_delta`).
+                    oversized = oversized.or_else(|| oversized_delta(&delta));
                     return true;
                 }
                 let origin = line.origin();
@@ -3613,6 +3651,7 @@ impl GitBackend for Libgit2Backend {
                     'H' | 'F' => return true,
                     'B' => {
                         binary = true;
+                        oversized = oversized.or_else(|| oversized_delta(&delta));
                         return true;
                     }
                     _ => {}
@@ -3684,6 +3723,7 @@ impl GitBackend for Libgit2Backend {
                 deletions,
                 hunks,
                 lfs: None,
+                oversized,
             };
             crate::git::lfs::annotate(&mut file_diff);
             Ok(file_diff)
@@ -4039,6 +4079,10 @@ impl GitBackend for Libgit2Backend {
             let mut opts = DiffOptions::new();
             opts.context_lines(context_lines);
             opts.ignore_whitespace(ignore_whitespace);
+            // One ceiling for every diff path (#385) — this one fans out over a
+            // whole comparison, so a single checked-in artifact would otherwise
+            // dominate the payload.
+            opts.max_size(MAX_WORKDIR_BLOB);
             let mut diff =
                 repo.diff_tree_to_tree(Some(&from_tree), Some(&to_tree), Some(&mut opts))?;
 
@@ -4069,6 +4113,9 @@ impl GitBackend for Libgit2Backend {
             let mut opts = DiffOptions::new();
             opts.context_lines(context_lines);
             opts.ignore_whitespace(ignore_whitespace);
+            // One ceiling for every diff path (#385): this feeds every commit
+            // the user clicks in the log.
+            opts.max_size(MAX_WORKDIR_BLOB);
             let mut diff = repo.diff_tree_to_tree(
                 from_tree.as_ref(),
                 Some(&to_tree),
@@ -5624,6 +5671,9 @@ impl GitBackend for Libgit2Backend {
             let mut opts = DiffOptions::new();
             opts.context_lines(context_lines);
             opts.ignore_whitespace(ignore_whitespace);
+            // One ceiling for every diff path (#385) — a stash holds whatever
+            // the worktree held, generated artifacts included.
+            opts.max_size(MAX_WORKDIR_BLOB);
             // base → stash, so the stashed work reads as ADDITIONS.
             let mut diff = repo.diff_tree_to_tree(
                 Some(&base.tree()?),
@@ -5645,6 +5695,7 @@ impl GitBackend for Libgit2Backend {
                 let mut u_opts = DiffOptions::new();
                 u_opts.context_lines(context_lines);
                 u_opts.ignore_whitespace(ignore_whitespace);
+                u_opts.max_size(MAX_WORKDIR_BLOB);
                 let u_diff =
                     repo.diff_tree_to_tree(None, Some(&untracked.tree()?), Some(&mut u_opts))?;
                 files.extend(diff_to_file_diffs(&u_diff)?);

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -226,6 +226,13 @@ pub trait GitBackend: Send + Sync {
     /// not the hunks git would apply, so a hunk index taken from such a diff
     /// must never be fed to `stage_hunk`/`unstage_hunk`/`discard_hunk` — see
     /// the note on those.
+    ///
+    /// **Per-blob size is capped at `MAX_WORKDIR_BLOB`, as it now is on every
+    /// diff path (#385).** One path is still one enormous path: a checked-in
+    /// `bundle.min.js` is a single click in the commit panel. Over the ceiling
+    /// the blob is never read and `FileDiff.oversized` carries the size and the
+    /// limit, so the UI can say "too large to diff" rather than the "binary"
+    /// that libgit2's own answer to `max_size` would otherwise imply.
     fn diff(
         &self,
         repo_id: &RepoId,
@@ -368,8 +375,9 @@ pub trait GitBackend: Send + Sync {
     /// reads one file; this walks the whole tree. Over `MAX_UNTRACKED_FILES`
     /// untracked entries the untracked side is dropped entirely and the count
     /// comes back as `WorkdirDiff::untracked_omitted` for the UI to report.
-    /// Per-blob size is capped too (`MAX_WORKDIR_BLOB`), so one enormous file
-    /// reports as binary rather than being serialised.
+    /// Per-blob size is capped too (`MAX_WORKDIR_BLOB`) — the cap started here
+    /// and is now on every diff path (#385), reported as `FileDiff.oversized`
+    /// rather than left to read as "binary".
     fn diff_ref_to_workdir(
         &self,
         repo_id: &RepoId,

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -369,6 +369,31 @@ pub struct FileDiff {
     /// The hunks are left intact: this is derived FROM them, by parsing the
     /// pointer out of the diff's own `+`/`-` lines, so it costs no extra I/O.
     pub lfs: Option<LfsDiff>,
+    /// Set when a side of this delta is over `MAX_WORKDIR_BLOB` and the diff
+    /// engine therefore never looked at it (#385).
+    ///
+    /// libgit2's answer to `max_size` is to flag the file BINARY, which is a
+    /// dishonest thing to show a user about a checked-in `bundle.min.js` — it
+    /// is text, we simply declined to diff six megabytes of it. `binary` keeps
+    /// its own meaning (it stays true, and the image-preview branch still runs
+    /// off it); this says WHY, so the surfaces can name the real reason and the
+    /// size instead of saying "binary file".
+    pub oversized: Option<OversizedBlob>,
+}
+
+/// Why a diff has no text: the blob was bigger than the ceiling (#385).
+///
+/// Carries the limit as well as the size so the sentence the user reads is
+/// built from the value that was actually applied — a frontend constant would
+/// be a second copy of the policy, free to drift from the one in `libgit2.rs`.
+/// Same shape as `ImagePreview::TooLarge`, for the same reason.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OversizedBlob {
+    /// The larger of the two sides, in bytes.
+    pub size: u64,
+    /// The ceiling that was applied, in bytes.
+    pub limit: u64,
 }
 
 /// The two sides of an LFS pointer change. Either side is `None` for an added or

--- a/src-tauri/tests/diff_blob_ceiling.rs
+++ b/src-tauri/tests/diff_blob_ceiling.rs
@@ -1,0 +1,185 @@
+//! One blob-size ceiling for every diff path (#385).
+//!
+//! `MAX_WORKDIR_BLOB` used to be set at exactly one site —
+//! `diff_ref_to_workdir` — while the three functions that actually feed the
+//! commit panel and every commit diff (`diff`, `diff_commit`, `diff_commits`)
+//! inherited libgit2's 512 MB default. Clicking a checked-in 80 MB
+//! `bundle.min.js` xdiff'd the whole thing, allocated a `String` per line, and
+//! shipped the lot across IPC as one JSON payload.
+//!
+//! The ceiling is now the same at all four, and the answer is HONEST: a blob
+//! over the ceiling comes back with `oversized: Some(..)` carrying the size and
+//! the limit, so the UI can say "too large to diff" instead of the dishonest
+//! "Binary file" a bare `max_size` would produce for a text file.
+
+mod support;
+
+use std::path::{Path, PathBuf};
+
+use platypusgit_lib::git::libgit2::MAX_WORKDIR_BLOB;
+use platypusgit_lib::git::types::{DiffKind, FileDiff};
+use platypusgit_lib::git::GitBackend;
+use support::TempRepo;
+
+/// Comfortably over the 5 MB ceiling, and unambiguously TEXT: plain ASCII with
+/// newlines, so libgit2's own binary sniff (a NUL in the first 8000 bytes) has
+/// nothing to find. Without a ceiling this is exactly the file that diffs.
+fn oversized_text() -> String {
+    let line = "the quick brown fox jumps over the lazy dog; padding padding\n";
+    debug_assert_eq!(line.len(), 61);
+    // ~6.7 MB.
+    line.repeat(110_000)
+}
+
+/// The same content, one line longer — a modification of a file already over
+/// the ceiling.
+fn oversized_text_plus_one() -> String {
+    let mut s = oversized_text();
+    s.push_str("one more line\n");
+    s
+}
+
+fn find<'a>(diffs: &'a [FileDiff], path: &str) -> &'a FileDiff {
+    diffs
+        .iter()
+        .find(|d| d.path == path)
+        .unwrap_or_else(|| panic!("{path} in diff; got {:?}", diffs.iter().map(|d| &d.path).collect::<Vec<_>>()))
+}
+
+/// The shared shape of "we did not look at this blob".
+fn assert_oversized(fd: &FileDiff, at_least: u64) {
+    let over = fd
+        .oversized
+        .as_ref()
+        .unwrap_or_else(|| panic!("{} reported as oversized", fd.path));
+    assert!(
+        over.size >= at_least,
+        "{}: reported size {} covers the real blob ({at_least})",
+        fd.path,
+        over.size
+    );
+    assert_eq!(
+        over.limit, MAX_WORKDIR_BLOB as u64,
+        "the limit the UI names is the one that was applied"
+    );
+    assert!(
+        fd.binary,
+        "{}: libgit2 marks an over-ceiling blob binary, and the surfaces' \
+         `binary` branch is what routes to the notice",
+        fd.path
+    );
+    assert!(
+        fd.hunks.is_empty(),
+        "{}: the whole point is that no line was serialised",
+        fd.path
+    );
+    assert_eq!((fd.additions, fd.deletions), (0, 0));
+}
+
+#[test]
+fn diff_commit_reports_an_oversized_blob_instead_of_diffing_it() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let big = oversized_text();
+    support::fs::write_file(tr.path(), "bundle.min.js", &big);
+    support::fs::write_file(tr.path(), "small.txt", "one\ntwo\n");
+    tr.commit_all("add a generated artifact");
+    let (backend, handle) = tr.open_with_backend();
+    let tip = backend.log(&handle.id, None, 1).unwrap()[0].oid.clone();
+
+    let diffs = backend.diff_commit(&handle.id, &tip, 3, false).unwrap();
+
+    assert_oversized(find(&diffs, "bundle.min.js"), big.len() as u64);
+    // The control: a small text file in the SAME commit still diffs normally,
+    // so the ceiling is a per-blob decision, not a per-diff one.
+    let small = find(&diffs, "small.txt");
+    assert!(small.oversized.is_none());
+    assert!(small.additions >= 2, "small file still diffs");
+}
+
+#[test]
+fn diff_commits_reports_an_oversized_blob_instead_of_diffing_it() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let base = backend.log(&handle.id, None, 1).unwrap()[0].oid.clone();
+    let big = oversized_text();
+    support::fs::write_file(tr.path(), "bundle.min.js", &big);
+    tr.commit_all("add a generated artifact");
+    let tip = backend.log(&handle.id, None, 1).unwrap()[0].oid.clone();
+
+    let diffs = backend
+        .diff_commits(&handle.id, &base, &tip, 3, false)
+        .unwrap();
+
+    assert_oversized(find(&diffs, "bundle.min.js"), big.len() as u64);
+}
+
+#[test]
+fn diff_single_file_reports_an_oversized_worktree_blob() {
+    // The commit panel's own workhorse: one path, worktree against HEAD.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let big = oversized_text();
+    support::fs::write_file(tr.path(), "bundle.min.js", &big);
+    tr.commit_all("add a generated artifact");
+    support::fs::write_file(tr.path(), "bundle.min.js", &oversized_text_plus_one());
+    let (backend, handle) = tr.open_with_backend();
+
+    let fd = backend
+        .diff(
+            &handle.id,
+            Path::new("bundle.min.js"),
+            DiffKind::WorktreeToHead,
+            3,
+            false,
+        )
+        .unwrap();
+
+    assert_oversized(&fd, big.len() as u64);
+}
+
+#[test]
+fn diff_single_file_reports_an_oversized_staged_blob() {
+    // IndexToHead — the staged side of the same panel, a tree-to-index diff and
+    // therefore a different libgit2 code path from the worktree one above.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    let big = oversized_text();
+    support::fs::write_file(tr.path(), "bundle.min.js", &big);
+    backend
+        .stage(&handle.id, &[PathBuf::from("bundle.min.js")])
+        .unwrap();
+
+    let fd = backend
+        .diff(
+            &handle.id,
+            Path::new("bundle.min.js"),
+            DiffKind::IndexToHead,
+            3,
+            false,
+        )
+        .unwrap();
+
+    assert_oversized(&fd, big.len() as u64);
+}
+
+#[test]
+fn an_ordinary_text_file_is_never_reported_as_oversized() {
+    // The regression that matters most: the ceiling must not change what a
+    // normal diff looks like.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    support::fs::write_file(tr.path(), "README.md", "hello\nworld\n");
+
+    let fd = backend
+        .diff(
+            &handle.id,
+            Path::new("README.md"),
+            DiffKind::WorktreeToHead,
+            3,
+            false,
+        )
+        .unwrap();
+
+    assert!(fd.oversized.is_none());
+    assert!(!fd.binary);
+    assert_eq!(fd.additions, 1);
+}

--- a/src/features/diff/CommitDiffPanel.oversized.test.tsx
+++ b/src/features/diff/CommitDiffPanel.oversized.test.tsx
@@ -1,0 +1,101 @@
+// "Binary file" is a LIE about a checked-in `bundle.min.js` (#385).
+//
+// The backend caps every diff path at `MAX_WORKDIR_BLOB`, and libgit2's answer
+// to that cap is to flag the file BINARY — so a capped text file would arrive
+// at the surfaces indistinguishable from a PNG and read as "Binary file — no
+// textual diff." That tells the user the wrong thing about their file AND hides
+// the one fact that would explain it: the size.
+//
+// The delta therefore carries `oversized: { size, limit }`, and every surface
+// prints the same sentence off it (`oversizedDiffNotice`, `lib/derive.ts`) —
+// same rule as the empty-hunks state next door: a file must not read
+// differently depending on which pane you opened it in.
+
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CommitDiffPanel } from "./CommitDiffPanel";
+import { isTextualDiff, oversizedDiffNotice } from "@/lib/derive";
+import type { FileDiff } from "@/lib/types";
+
+const props = {
+  diffs: [] as FileDiff[],
+  error: null,
+  header: "abc1234 → HEAD",
+  paneIdPrefix: "oversized",
+  loading: false,
+};
+
+/** What a blob over the ceiling arrives as: binary per libgit2, plus the why. */
+const oversized = (path: string): FileDiff => ({
+  path,
+  oldPath: null,
+  binary: true,
+  additions: 0,
+  deletions: 0,
+  hunks: [],
+  lfs: null,
+  oversized: { size: 42_000_000, limit: 5 * 1024 * 1024 },
+});
+
+/** A real binary — no size story to tell, so the old sentence stands. */
+const realBinary: FileDiff = {
+  path: "logo.png",
+  oldPath: null,
+  binary: true,
+  additions: 0,
+  deletions: 0,
+  hunks: [],
+  lfs: null,
+  oversized: null,
+};
+
+describe("a diff the backend was too big to read", () => {
+  it("names the real reason and the size, not 'binary'", () => {
+    render(<CommitDiffPanel {...props} diffs={[oversized("bundle.min.js")]} />);
+    const text = document.body.textContent ?? "";
+    expect(text).toContain("File too large to diff");
+    expect(text).toContain("40 MB");
+    expect(text).toContain("5.0 MB");
+    // The dishonest sentence is the whole point of the change.
+    expect(text).not.toContain("Binary file");
+  });
+
+  it("still says 'binary' for a file that really is binary", () => {
+    render(<CommitDiffPanel {...props} diffs={[realBinary]} />);
+    const text = document.body.textContent ?? "";
+    expect(text).toContain("Binary file — no textual diff.");
+    expect(text).not.toContain("File too large to diff");
+  });
+
+  it("does not offer the no-hunks empty state as well", () => {
+    // Both conditions are true at once — an oversized delta has no hunks — and
+    // two empty states stacked in one pane is worse than either alone.
+    render(<CommitDiffPanel {...props} diffs={[oversized("dump.csv")]} />);
+    expect(screen.queryByText("No diff")).toBeNull();
+  });
+});
+
+describe("oversizedDiffNotice / isTextualDiff", () => {
+  it("is null for everything that is not over the ceiling", () => {
+    expect(oversizedDiffNotice(null)).toBeNull();
+    expect(oversizedDiffNotice(realBinary)).toBeNull();
+    expect(oversizedDiffNotice({ ...realBinary, binary: false })).toBeNull();
+  });
+
+  it("builds the sentence from the limit ON THE WIRE, not a local constant", () => {
+    // A frontend copy of the policy is free to drift from the one that was
+    // applied; the number the user reads has to be the one the backend used.
+    const notice = oversizedDiffNotice({
+      ...realBinary,
+      oversized: { size: 3 * 1024 * 1024, limit: 1024 * 1024 },
+    });
+    expect(notice?.detail).toContain("3.0 MB");
+    expect(notice?.detail).toContain("1.0 MB");
+  });
+
+  it("keeps an oversized diff out of the text renderers", () => {
+    expect(isTextualDiff(oversized("bundle.min.js"))).toBe(false);
+    // Belt and braces: even if a future backend stopped flagging it binary.
+    expect(isTextualDiff({ ...oversized("bundle.min.js"), binary: false })).toBe(false);
+  });
+});

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -40,7 +40,7 @@ import type { FindMark } from "@/lib/diffFind";
 import { DiffFindBar } from "./DiffFindBar";
 import { useDiffFind } from "./useDiffFind";
 import type { DiffToolTarget, FileDiff } from "@/lib/types";
-import { isTextualDiff } from "@/lib/derive";
+import { isTextualDiff, oversizedDiffNotice } from "@/lib/derive";
 import { LfsDiffNotice } from "@/features/lfs/LfsDiffNotice";
 import { ImageDiffView } from "./ImageDiffView";
 import { diffImageSides } from "./useImagePreviews";
@@ -226,6 +226,9 @@ export function CommitDiffPanel({
   // Fall back to the first file so the diff pane is populated immediately when
   // a new diff arrives, before the selection-sync effect runs.
   const current = shown.find((d) => d.path === selected) ?? shown[0] ?? null;
+  // Non-null only for a blob the backend declined to read (#385); the sentence
+  // is shared with the other diff surfaces.
+  const oversized = oversizedDiffNotice(current);
 
   // Right-click to copy. This panel is the read-only diff behind Compare,
   // CommitDiff and History, so there is no line selection to offer — the dragged
@@ -631,7 +634,12 @@ export function CommitDiffPanel({
                   // adding "Binary file" under it would say it twice.
                   current.lfs ? null : (
                     <div style={{ color: "var(--fg-3)", fontSize: "var(--fs-12)" }}>
-                      Binary file — no textual diff.
+                      {/* An over-ceiling blob is flagged binary by libgit2, and
+                          calling a 40 MB `bundle.min.js` "binary" is a lie the
+                          user cannot act on — name the real reason (#385). */}
+                      {oversized
+                        ? `${oversized.title}: ${oversized.detail}`
+                        : "Binary file — no textual diff."}
                     </div>
                   )
                 }

--- a/src/lib/derive.ts
+++ b/src/lib/derive.ts
@@ -1,3 +1,4 @@
+import { formatBytes } from "./bytes";
 import type {
   BranchInfo,
   CommitInfo,
@@ -51,15 +52,45 @@ export function isConflicted(s: FileStatus): boolean {
 /**
  * Should this diff be rendered as text at all? (#93)
  *
- * Two ways it should not: libgit2 called the blob binary, or it is a git-LFS
- * **pointer** change. The second is why this exists as a helper rather than a
- * `!diff.binary` test at each of the four diff surfaces — a pointer IS text, so
- * `binary` is honestly false, and rendering its hunks claims "2 lines changed"
- * for a multi-megabyte asset. Every surface must agree, or the same file reads
- * differently depending on which pane you opened it in.
+ * Three ways it should not: libgit2 called the blob binary, it is a git-LFS
+ * **pointer** change, or it is over the backend's blob ceiling (#385). The
+ * second is why this exists as a helper rather than a `!diff.binary` test at
+ * each of the four diff surfaces — a pointer IS text, so `binary` is honestly
+ * false, and rendering its hunks claims "2 lines changed" for a multi-megabyte
+ * asset. Every surface must agree, or the same file reads differently depending
+ * on which pane you opened it in.
+ *
+ * `oversized` is belt and braces: the backend only ever sets it on a delta
+ * libgit2 already flagged binary, so this arm cannot fire alone today. It is
+ * here so that "we did not read this blob" can never mean "render its hunks",
+ * whichever half of the pair a future change touches.
  */
 export function isTextualDiff(diff: FileDiff | null | undefined): boolean {
-  return !!diff && !diff.binary && !diff.lfs;
+  return !!diff && !diff.binary && !diff.lfs && !diff.oversized;
+}
+
+/**
+ * The honest reason a large file has no diff, and its size (#385).
+ *
+ * The backend caps every diff path at `MAX_WORKDIR_BLOB`, and libgit2's answer
+ * to that cap is to flag the file BINARY — so without this a checked-in
+ * `bundle.min.js` read as "Binary file — no textual diff.", which is simply not
+ * true about a text file. One helper rather than a sentence per surface, for
+ * the reason `isTextualDiff`'s own doc comment gives: a file must not read
+ * differently depending on which pane you opened it in.
+ *
+ * The limit comes off the wire, never from a constant here — a second copy of
+ * the policy is free to drift from the one that was applied.
+ */
+export function oversizedDiffNotice(
+  diff: FileDiff | null | undefined,
+): { title: string; detail: string } | null {
+  const over = diff?.oversized;
+  if (!over) return null;
+  return {
+    title: "File too large to diff",
+    detail: `${formatBytes(over.size)} — over the ${formatBytes(over.limit)} limit, so it was not read.`,
+  };
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -317,6 +317,24 @@ export interface FileDiff {
    * rendering on `isTextualDiff` (`lib/derive.ts`) rather than on `binary` alone.
    */
   lfs?: LfsDiff | null;
+  /**
+   * Set when the blob was over the backend's ceiling and never diffed (#385).
+   *
+   * libgit2 answers `max_size` by flagging the file BINARY, so `binary` is true
+   * here too and the image-preview branch still runs — but "Binary file" is a
+   * dishonest thing to tell someone about a checked-in `bundle.min.js`. This
+   * says the real reason, and `oversizedDiffNotice` (`lib/derive.ts`) turns it
+   * into the sentence every surface prints.
+   */
+  oversized?: OversizedBlob | null;
+}
+
+/** Why a diff has no text: the blob was bigger than the ceiling (#385). */
+export interface OversizedBlob {
+  /** The larger of the two sides, in bytes. */
+  size: number;
+  /** The ceiling that was applied, in bytes — the backend owns the policy. */
+  limit: number;
 }
 
 /** The two sides of an LFS pointer change; either is null for an add/delete. */

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -57,6 +57,7 @@ import {
   isTextualDiff,
   isUnstaged,
   isUntracked,
+  oversizedDiffNotice,
   sideAdditions,
   sideDeletions,
   statusMark,
@@ -227,6 +228,9 @@ export function CommitPanelScreen() {
   const [diff, setDiff] = React.useState<FileDiff | null>(null);
   const [diffLoading, setDiffLoading] = React.useState(false);
   const [diffError, setDiffError] = React.useState<string | null>(null);
+  // Non-null only when the backend declined to read the blob because of its
+  // size (#385) — the surfaces must not call a 40 MB text file "binary".
+  const oversized = oversizedDiffNotice(diff);
 
   // Folder rows (tree mode only) get the batch menu over everything beneath
   // them — stage / unstage / discard all — same as a multi-row selection.
@@ -1589,9 +1593,11 @@ export function CommitPanelScreen() {
               repoId={repo?.id ?? null}
               path={diff.path}
               sides={commitPanelImageSides}
-              title="Binary file"
+              title={oversized?.title ?? "Binary file"}
             >
-              Binary diffs aren&apos;t shown.
+              {/* Over the ceiling this is usually a checked-in artifact, i.e.
+                  text — "binary" would be the wrong answer (#385). */}
+              {oversized?.detail ?? "Binary diffs aren't shown."}
             </ImageDiffOrEmpty>
           )}
           {!diffLoading && !diffError && diff?.lfs && (

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -29,7 +29,7 @@ import {
   useDiffGaps,
   useExpandedGaps,
 } from "@/features/diff/useDiffGaps";
-import { isTextualDiff, statusMark } from "@/lib/derive";
+import { isTextualDiff, oversizedDiffNotice, statusMark } from "@/lib/derive";
 import { LfsDiffNotice } from "@/features/lfs/LfsDiffNotice";
 import { ImageDiffOrEmpty, ImageDiffView } from "@/features/diff/ImageDiffView";
 import { diffImageSides } from "@/features/diff/useImagePreviews";
@@ -83,6 +83,9 @@ export function DiffViewerScreen() {
   const [diff, setDiff] = React.useState<FileDiff | null>(null);
   const [diffLoading, setDiffLoading] = React.useState(false);
   const [diffError, setDiffError] = React.useState<string | null>(null);
+  // Non-null only when the backend declined to read the blob because of its
+  // size (#385) — the surfaces must not call a 40 MB text file "binary".
+  const oversized = oversizedDiffNotice(diff);
   // The file list may take everything the split allows, as long as the diff it
   // is a list OF keeps enough width to read a line of code (#162).
   const layout = useElementSize();
@@ -610,8 +613,12 @@ export function DiffViewerScreen() {
                 new: { kind: "worktree" },
                 oldPath: diff.oldPath,
               })}
-              title="Binary file"
-            />
+              title={oversized?.title ?? "Binary file"}
+            >
+              {/* Only the size can say WHY libgit2 called it binary; over the
+                  ceiling it is usually a text file we declined to read (#385). */}
+              {oversized?.detail}
+            </ImageDiffOrEmpty>
           )}
           {/* An LFS pointer is TEXT, so `binary` is honestly false — without this
               the pane would render "2 lines changed" for a multi-megabyte asset

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -43,6 +43,7 @@ import {
   isTextualDiff,
   isUnstaged,
   isUntracked,
+  oversizedDiffNotice,
   statusMark,
 } from "@/lib/derive";
 import { commitDateText, commitDateTitle } from "@/lib/commitDate";
@@ -179,6 +180,9 @@ export function RepoBrowserScreen() {
   const [diff, setDiff] = React.useState<FileDiff | null>(null);
   const [diffLoading, setDiffLoading] = React.useState(false);
   const [previewError, setPreviewError] = React.useState<string | null>(null);
+  // Non-null only when the backend declined to read the blob because of its
+  // size (#385) — the surfaces must not call a 40 MB text file "binary".
+  const oversized = oversizedDiffNotice(diff);
   const [fileContent, setFileContent] = React.useState<FileContent | null>(null);
   const [filterMode, setFilterMode] = React.useState<
     "all" | "changes" | "conflicts"
@@ -1274,9 +1278,11 @@ export function RepoBrowserScreen() {
                   new: { kind: "worktree" },
                   oldPath: diff.oldPath,
                 })}
-                title="Binary file"
+                title={oversized?.title ?? "Binary file"}
               >
-                Binary diffs aren&apos;t shown.
+                {/* Over the ceiling this is usually a checked-in artifact, i.e.
+                    text — "binary" would be the wrong answer (#385). */}
+                {oversized?.detail ?? "Binary diffs aren't shown."}
               </ImageDiffOrEmpty>
             )}
             {selectedFile && !diffLoading && diff?.lfs && (

--- a/test/diffOversized.test.ts
+++ b/test/diffOversized.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment node
+ */
+// "A file too large to diff says so, on every surface." (#385)
+//
+// Same shape, and the same reasoning, as `diffCaretSurfaces.test.ts`,
+// `diffFindSurfaces.test.ts` and `diffCopyMenu.test.ts` next door.
+//
+// The backend caps every diff path at `MAX_WORKDIR_BLOB`, and libgit2's answer
+// to that cap is to flag the delta BINARY — so a capped `bundle.min.js` arrives
+// at the surfaces indistinguishable from a PNG and, without this, reads as
+// "Binary file". That is not true about a text file, and it hides the one fact
+// that explains the pane: the size.
+//
+// The seam is `oversizedDiffNotice` (`lib/derive.ts`), which turns the delta's
+// `oversized: { size, limit }` into the sentence. A surface that renders the
+// binary empty state and does NOT consult it prints the dishonest one — and
+// `isTextualDiff`'s doc comment is explicit that a file must not read
+// differently depending on which pane you opened it in.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/** Every file that renders diff rows — the same four as the caret/find guards. */
+const DIFF_SURFACES = [
+  "src/screens/CommitPanel.tsx",
+  "src/screens/DiffViewer.tsx",
+  "src/screens/RepoBrowser.tsx",
+  "src/features/diff/CommitDiffPanel.tsx",
+];
+
+const read = (p: string) => readFileSync(resolve(process.cwd(), p), "utf8");
+
+describe("the honest 'too large to diff' answer reaches every diff surface", () => {
+  it.each(DIFF_SURFACES)("%s asks why the delta has no text", (file) => {
+    expect(read(file)).toContain("oversizedDiffNotice(");
+  });
+
+  it.each(DIFF_SURFACES)("%s does not hardcode the ceiling", (file) => {
+    // The limit the user reads comes off the wire — a frontend copy of the
+    // policy is free to drift from the one `libgit2.rs` actually applied.
+    expect(read(file)).not.toMatch(/5\s*\*\s*1024\s*\*\s*1024/);
+  });
+
+  // The complement: "Binary file" must still be reachable, or a real PNG would
+  // start claiming it is too large. Every surface keeps it as the fallback.
+  it.each(DIFF_SURFACES)("%s keeps the binary wording for a real binary", (file) => {
+    expect(read(file)).toContain("Binary file");
+  });
+});
+
+describe("the backend applies one ceiling, not one capped path and three uncapped", () => {
+  // The bug this fixes was a POLICY split, not a rendering one: `max_size` was
+  // set at exactly one of the diff builders. Counting the call sites is the
+  // cheapest way to keep a new diff op from quietly inheriting libgit2's 512 MB
+  // default — bump the number when you add one, deliberately.
+  it("sets max_size at every diff-options site in libgit2.rs", () => {
+    const src = read("src-tauri/src/git/libgit2.rs");
+    const caps = src.match(/max_size\(MAX_WORKDIR_BLOB\)/g) ?? [];
+    expect(caps.length).toBe(6);
+  });
+});


### PR DESCRIPTION
Closes #385

## What was wrong

`max_size` was set at exactly one of the diff builders (`diff_ref_to_workdir`). The three that actually feed the commit panel and every commit diff inherited libgit2's 512 MB default:

- `diff` — one file, the commit panel's own workhorse
- `diff_commit` — every commit clicked in the log
- `diff_commits` — the compare screen

`diff_stash`'s two builders were uncapped for the same reason. Clicking a checked-in 80 MB `bundle.min.js` xdiff'd the whole file, allocated a `String` per line in `diff_to_file_diffs`, shipped the lot across IPC as one JSON payload, and then had `windowVariable` reduce over every row on every scroll event.

## What this does

**1. One policy.** All six diff-options sites now set `MAX_WORKDIR_BLOB` (5 MB).

**2. The degradation is honest.** The issue asked whether the ceiling should degrade into the existing "binary" path or its own state. Shipping it as the binary path would have been two lines — and would have told a user that their `bundle.min.js` is binary, hiding the one fact that explains the pane: the size.

So the delta carries `FileDiff.oversized { size, limit }`. `binary` keeps its own meaning (it stays true, and the `ImageDiffView` preview branch still runs off it); the new field says *why*. `oversizedDiffNotice` (`lib/derive.ts`) turns it into one sentence shared by all four diff surfaces, next to `isTextualDiff` — whose own doc comment is the rule that a file must not read differently depending on which pane you opened it in.

| | before | after |
|---|---|---|
| 40 MB `bundle.min.js` | "Binary file — no textual diff." (after a multi-second hang and an 80 MB IPC payload) | **File too large to diff** — 40 MB — over the 5.0 MB limit, so it was not read. |
| `logo.png` | image preview, or "Binary file — no textual diff." | unchanged |

The limit travels on the wire rather than being a frontend constant: a second copy of the policy is free to drift from the one `libgit2.rs` actually applied.

**3. Deliberately not here.** No "show it anyway" override — filed as #396, because the ceiling had to become one policy before an escape hatch from it could mean anything. And no cap on `diff_line_stats`: it feeds the file rows' `+/−` counts, and capping it would silently change those numbers.

## Two things a reviewer should second-guess

- **Where the size is read.** `oversized_delta` reads `delta.old_file().size()` / `new_file().size()` *inside* the print callback, never before it — libgit2 fills `git_diff_file.size` in place while loading the patch, so a tree delta reads 0 beforehand. This is the same load-order trap the `binary` seeding in `diff_to_file_diffs` already documents. `src-tauri/tests/diff_blob_ceiling.rs` covers tree-to-tree, tree-to-index and tree-to-workdir separately for exactly this reason.
- **`isTextualDiff` now also excludes `oversized`.** Belt and braces: the backend only ever sets it on a delta libgit2 already flagged binary, so the arm cannot fire alone today. It is there so "we did not read this blob" can never come to mean "render its hunks".

## Tests

TDD, and the red was measured rather than assumed: with the four `opts.max_size(...)` lines commented out, 4 of the 5 Rust tests fail (`bundle.min.js reported as oversized`) and the ordinary-text-file control still passes.

- `src-tauri/tests/diff_blob_ceiling.rs` — 5 tests: `diff_commit`, `diff_commits`, `diff` worktree-side, `diff` index-side, and the control that an ordinary text file diffs exactly as before.
- `src/features/diff/CommitDiffPanel.oversized.test.tsx` — the surface says the honest thing, still says "binary" for a real binary, does not stack the no-hunks empty state on top, and builds the sentence from the wire limit.
- `test/diffOversized.test.ts` — the house guard-test shape (cf. `diffCaretSurfaces`): all four surfaces consult the helper, none hardcodes the ceiling, all keep the binary wording reachable, and the backend's `max_size` call sites are counted so a new diff op cannot quietly inherit 512 MB.

Full runs after the last edit: `pnpm test` 333 files / 3235 tests passed; `pnpm tsc --noEmit` clean; `cargo test` 1198 passed, 0 failed.

Docs: the lesson is in `docs/dev/backend.md` (new "One blob ceiling, on every diff path" section) and `docs/dev/frontend.md` (diff-surfaces list), per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
