### PR TITLE
test(commit): wait for the diff pane to answer ArrowDown

### DIFF
--- a/src/screens/CommitPanel.dnd.test.tsx
+++ b/src/screens/CommitPanel.dnd.test.tsx
@@ -289,7 +289,35 @@ describe("CommitPanel drag vs the diff pane's line cursor (#91 × #122)", () => 
 
     // Space means nothing until the line cursor is on a line, so move it first
     // (#122's own precondition — ArrowDown is list.down for this pane).
-    expect(press("ArrowDown")).toBe(true);
+    //
+    // The press is INSIDE the wait, not after it (#384). The row and the
+    // handler that answers ArrowDown land on different beats: the row is in the
+    // COMMIT, while `usePaneList` re-registers `list.down` with the loaded
+    // `count` in a passive EFFECT, which React flushes in a separately
+    // scheduled task. `findByTestId` can resolve from a MutationObserver
+    // microtask fired during that commit, so a starved runner resumes with the
+    // row on screen and the pane still holding its mount-time closure —
+    // `guard` sees `count === 0`, declines, and `dispatch` returns false.
+    // Waiting for the REGISTRATION instead would be vacuous: `commit.diff` is
+    // in the `list.down` registry from mount, long before the diff loads. (The
+    // sibling CommitPanel.lineFocus.test.tsx buys the same flush with
+    // `settleDiff()`, whose `act(async …)` loop is what makes it safe there.)
+    //
+    // Retrying the press is safe by construction, not by assumption: ArrowDown
+    // is bound, so dispatch never reaches the side-effectful speed-search
+    // fallback; `list.down` is pane-scoped with no default runner, so the
+    // global `def.run` branch cannot fire; out-of-scope handlers are skipped
+    // without being called; and `guard` returns false WITHOUT calling
+    // `onSelect` on an empty list. An unhandled press moves nothing.
+    //
+    // Keep the wait's body to the press alone: `waitFor` stops at the first
+    // callback that does not throw, so exactly one press is HANDLED, and a
+    // handled press does move the cursor. A second assertion in here would
+    // press again and stage the wrong line.
+    await waitFor(() => expect(press("ArrowDown")).toBe(true));
+    // Deliberately not in a wait: `press` dispatches inside `act`, which
+    // flushes the cursor's re-render and the `diff.toggleLine` re-registration
+    // synchronously before returning. A retry here would stage a second line.
     expect(press(" ")).toBe(true);
 
     await waitFor(() => expect(lineStageCalls().length).toBe(1));


### PR DESCRIPTION
Closes #384 — this is the second and last of the two flakes it names. The first
(`DiffViewer.imagepreview.test.tsx`) landed in #383; verified on `origin/main`
before starting (merge commit `8a3da0f` is an ancestor, and the test now puts
both conditions inside one `waitFor`).

## The mechanism, proven rather than guessed

`CommitPanel.dnd.test.tsx` awaited `findByTestId("diff-line-changed")` — the
rendered ROW — then synchronously asserted that dispatching ArrowDown was
handled. Those are two different signals on two different beats:

- the row is in the React **commit**;
- `usePaneList` re-registers `list.down` with the loaded `count` in a passive
  **effect**, which React flushes in a separately scheduled task.

`findByTestId` can resolve from a MutationObserver microtask fired during that
commit, so a starved runner resumes with the row on screen and the pane still
holding its mount-time closure. `guard` sees `count === 0`, declines, and
`dispatch` returns `false` — `AssertionError: expected false to be true`.

Two probes established this (both temporary, not in the diff):

- Resuming from a bare MutationObserver — RTL's `asyncWrapper` minus its
  `setTimeout(0)` bridge, which is exactly the state CI reports — makes the OLD
  assertion fail with the issue's byte-identical message **5/5**, and the NEW
  one pass **5/5**, staging `selected: [0]`.
- At that same moment the registry already reads
  `list.down -> ["commit.diff", "commit.files"]`. **`commit.diff` is registered
  from mount**, before the diff has loaded at all.

## Why not "wait for the registration"

The issue offered that as the side-effect-free alternative. It would be
**vacuous here** — the registration exists long before the diff loads, so the
wait passes immediately and the test keeps racing. That is the same trap the
imagepreview half had in the other direction (`title="Binary file"` renders
*while* the previews load). The honest signal is "the pane ANSWERS".

## Confirming, not assuming, that an unhandled press is inert

The issue asked for this to be checked. **Confirmed**, by reading
`useKeymapStore.dispatch` and then by measurement:

- ArrowDown is bound, so `dispatch` never reaches `speedFallback` — the one
  genuinely side-effectful branch (it appends to the speed-search query, and it
  only runs for a chord with *no* binding).
- `list.down` is `scope: "pane"` with no `run`, so the
  `!handled && def.scope === "global" && def.run` default-runner branch cannot
  fire.
- Out-of-scope handlers (`commit.files`) are `continue`d without being called.
- `usePaneList`'s `guard` returns `false` **without calling `onSelect`** when
  `count === 0`.
- `eventToChord` is pure, and `resolveChord`'s only write (`lastShiftAt`) is a
  no-op for a non-Shift key when it is already 0.

Measured: a probe that forced 3 declined retries still staged line 0, with zero
`stage_paths` calls and an empty speed-search query.

The complementary hazard is real, though, and is written into the test: a
*handled* press DOES move the cursor. `waitFor` stops at the first callback that
does not throw, so exactly one press is handled — but a second assertion added
inside that wait would press again and stage the wrong line. The comment says so.

`press(" ")` stays outside the wait deliberately: `press` dispatches inside
`act`, which flushes the cursor's re-render and the `diff.toggleLine`
re-registration synchronously.

## Evidence

- **Deterministic repro:** old 5/5 red, new 5/5 green (probe above).
- **Repeated runs of the spec, quiet:** 30/30 green. The machine was not
  actually quiet — load average 12.2 on 14 cores from sibling sessions.
- **Repeated runs under artificial load:** 30/30 green, 16 extra CPU hogs, load
  average peaking at 61.
- **Honest negative:** the OLD code also stayed 30/30 green under that same
  load (peak 74). CPU starvation alone does not flip the task ordering on this
  host, which is why the deterministic probe — not a load test — is the
  evidence that the fix addresses the reported mechanism.
- `pnpm test` — **331 files, 3216 tests, all passing**
- `pnpm tsc --noEmit` — clean
- `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — clean

No Docker e2e run (sibling worktrees are active; the required `e2e-linux` check
covers it). This is a test-only change — **no product bug was found hiding
behind the flake**. The `count === 0` decline is documented behaviour ("decline
on empty lists so the key falls through"), and a human keypress cannot beat an
effect flush the way a synchronous test assertion can.

## Does the shape appear elsewhere?

Scanned all 313 unit test files for an awaited wait immediately followed by a
synchronous `expect` of a **different kind** of signal (multi-line waits
included, by paren-matching to the end of the statement). 323 such sites; 15
cross the DOM/non-DOM boundary. After this fix, **none of the remaining 14 can
produce an intermittent red**:

- 9 assert an **absence or a non-change** (`toBeNull`, `toEqual([])`,
  `not.toHaveBeenCalled`, or a value the test itself set before render). Those
  can only ever pass vacuously — a false green, never a flaky red.
- 5 assert something that is **already true when the wait resolves**, because
  the state change is upstream of the render and lands inside an act-wrapped
  `fireEvent`/`render` (`ShallowNotice:123`, `Compare:217/310`,
  `AppShell.tabs:247`, `History.scope:92`).

Nothing mechanical left to fix, so nothing extra is bundled here. Two of the
absence assertions are genuinely *weak* and pass vacuously —
`MergeWindow.imagepreview.test.tsx:107` and `CommitPanel.compose.test.tsx:344`
both assert "no such invoke happened" right after a wait on a dispatched invoke.
That is an under-assertion, a different bug class from #384, and worth its own
issue rather than this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
