### PR TITLE
docs(ci): only the macOS cache miss was eviction

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -113,6 +113,22 @@ often. Measured on the v0.6.0 release at 10.73 GB usage, `macos-universal` and
 partial match — and a cold Rust build is 577s against 259s warm. Nothing was
 broken; the quota was full of caches nothing would ever read again.
 
+**Only `macos-universal` there was eviction, and the difference is the useful
+part.** A release runs on a TAG ref, which can read its own scope and the
+default branch's — and nothing else. A tag-triggered release therefore *saves*
+to the tag's scope, which the next tag cannot read, so **the only thing that
+ever warms a release job on `main` is a `workflow_dispatch` run of
+`release.yml`**. One such run on 2026-08-31 saved main-scoped caches for
+`linux`, `windows` and `macos-universal`; by 2026-09-03 the macOS entry was
+gone while its two siblings survived (largest, least recently used). `msix` in
+that same run logged `No cache found.` and then failed, and rust-cache does not
+save on a failed job — so it never had a main-scoped entry to lose.
+
+The practical reading: pruning buys the headroom for a warm release cache to
+*survive*, but it cannot create one. If a release build looks cold after a
+prune, the question is whether a successful `workflow_dispatch` run has ever
+written that job's key on `main` — not whether the quota is full.
+
 It runs **daily**, not weekly, because of the refill rate: CodeQL leaves a
 ~96 MB overlay database per commit on `main`, and every toolchain or lockfile
 change strands a multi-hundred-MB rust-cache generation. The first real run

--- a/scripts/prune-actions-caches.mjs
+++ b/scripts/prune-actions-caches.mjs
@@ -11,9 +11,15 @@
 //   linux            Restored ... full match: false.
 //   windows          Restored ... full match: false.
 //
-// A cold Rust build measured 577s against 259s warm, so eviction was costing
-// roughly five minutes on each of those jobs, every release. Nothing was
-// broken; the quota was simply full of caches nothing would ever read again.
+// A cold Rust build measured 577s against 259s warm. Nothing was broken; the
+// quota was simply full of caches nothing would ever read again.
+//
+// Only the macOS miss there was eviction — it had a main-scoped entry on
+// 2026-08-31 and had lost it by 2026-09-03 while its siblings survived. `msix`
+// never had one to lose. Pruning buys the headroom for a warm release cache to
+// SURVIVE; it cannot create one, because a tag-triggered release saves to the
+// tag's own scope and only a workflow_dispatch run writes to `main`. See
+// docs/dev/testing.md.
 //
 // WHAT IT DELETES. Four rules, each logged with its reason:
 //


### PR DESCRIPTION
Follow-up to #392, which read all four release cache misses as one story. Checking the run that actually wrote those caches says otherwise, and the difference is the part worth keeping in the doc.

## What the evidence says

A release runs on a **tag ref**, which can read its own scope and the default branch's — and nothing else. So a tag-triggered release *saves* to the tag's scope, which the next tag cannot read. **The only thing that ever warms a release job on `main` is a `workflow_dispatch` run of `release.yml`.**

There has been exactly one such successful run, on 2026-08-31 (run `33361994127`, on `main`):

| job | 2026-08-31 (dispatch on `main`) | main-scoped entry on 2026-09-03 |
|---|---|---|
| `linux` | restored, succeeded → saved | still present |
| `windows` | restored, succeeded → saved | still present |
| `macos-universal` | restored, succeeded → saved | **gone** |
| `msix` | `No cache found.`, then **failed** | never existed |

- **`macos-universal` was evicted** — it saved an entry in that run and had lost it three days later while its two siblings from the same run survived. Largest, least recently used.
- **`msix` was not.** rust-cache does not save on a failed job, so there was never a main-scoped entry to lose.

## Why this matters more than the tidiness

The corrected version answers the next question. A release build that is *still* cold after a prune is not a quota problem, and looking at the quota will not reveal it — the question is whether a successful dispatch run has ever written that job's key on `main`.

Pruning buys the headroom for a warm release cache to **survive**. It cannot create one.

Nothing about #392's behaviour changes: the prune rules, the workflow and the tests are untouched. This corrects the prose in `docs/dev/testing.md` and the header comment in `scripts/prune-actions-caches.mjs`.

`pnpm test`: 3232 passed (332 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
