### PR TITLE
fix(startup): open on a drawn dark window, not a white flash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,15 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
 - **Tauri permissions:** shared set in `capabilities/default.json`; privileged
   ones (updater, e2e) stay in their scoped capability files.
   (`docs/dev/distribution.md`)
+- **The main window starts HIDDEN** (`"visible": false`) and the frontend shows
+  it on React's first commit (`src/lib/revealWindow.tsx`) — that is what makes
+  the app open already-drawn instead of flashing white. Delete the reveal and
+  you ship a process with no UI, and **e2e cannot catch it**: WebDriver attaches
+  to the webview, not the window, so the suite passes green against an invisible
+  app. `test/startupPaint.test.ts` plus a `SHOW_WINDOW_FALLBACK_MS` thread in
+  `lib.rs` are the guards; the window and document background colours track
+  `--bg-0` and fail the build when they drift. Startup slowness is NOT the
+  bundle — the 1.4 MB entry compiles in ~15ms. (`docs/dev/distribution.md`)
 
 ## Things deliberately NOT in codebase
 

--- a/docs/dev/distribution.md
+++ b/docs/dev/distribution.md
@@ -224,10 +224,12 @@ makes no request whatever the channel is set to.
 ## Permissions (Tauri 2)
 
 - Shared permissions in `src-tauri/capabilities/default.json`: `core:default`,
-  window minimize/toggle-maximize/close/start-dragging/set-title, webview
-  create-webview-window + set-webview-zoom (the `view.zoom*` chords),
+  window minimize/toggle-maximize/close/start-dragging/set-title/**show**,
+  webview create-webview-window + set-webview-zoom (the `view.zoom*` chords),
   `dialog:default` + `dialog:allow-open`, `os:default`, `log:default`. Scoped
-  `windows: ["main", "merge"]`.
+  `windows: ["main", "merge"]`. `allow-show` is not optional decoration — the
+  main window is created hidden and the frontend is what shows it; see
+  "The window starts hidden" below.
 - **Self-update permissions are narrower:** `updater:default` +
   `process:allow-restart` live in `src-tauri/capabilities/updater.json` with
   `windows: ["main"]` — the merge resolver must not be able to swap the binary
@@ -241,6 +243,74 @@ makes no request whatever the channel is set to.
 - New plugin: `cargo add tauri-plugin-X`, `pnpm add @tauri-apps/plugin-X`,
   register `.plugin(tauri_plugin_X::init())` in `lib.rs`, add its permissions
   to the capability file.
+
+## The window starts hidden, and the first paint is dark
+
+The app used to open with a white flash on macOS and Windows. Two independent
+causes, both at the window layer rather than in anything React does:
+
+1. **Nothing set a background colour.** With no `backgroundColor` on the window
+   config and no inline background in `index.html`, both the window layer and
+   the webview layer default to **white**. The sequence was: OS window appears
+   white → `index-*.css` loads → `body { background: var(--bg-0) }` finally
+   paints dark. CSS cannot reach the frames before it has loaded, so this is not
+   fixable in the stylesheet.
+2. **Windows/Linux additionally showed the native frame being stripped.**
+   `lib.rs` calls `set_decorations(false)` in `setup` (macOS keeps its frame for
+   `titleBarStyle: "Overlay"`), so the window was created decorated, shown, and
+   then lost its title bar — a shape change on top of the white.
+
+### What it is NOT: the JS bundle
+
+Measured before changing anything, because "it spends time setting up the
+titlebar" sounds like parse cost: V8 compiles the 1.41 MB entry chunk in
+**14–18 ms**. Code splitting the app would do nothing measurable for startup.
+Don't reach for `manualChunks` to fix a launch complaint — the flash is window
+plumbing, and the *time-to-usable* cost is the boot invoke batch (nine calls
+queueing on the per-repo mutex, ~350–430 ms each; see `docs/dev/backend.md`).
+
+`@xterm/xterm` *is* statically in that entry chunk, so lazy-loading it is a
+legitimate size/memory change. It is not a startup change.
+
+### The fix, and the trade it makes
+
+- `backgroundColor: "#0d1013"` on the main window (`tauri.conf.json`) covers the
+  window **and** webview layers. `openMergeWindow.ts` passes the same value.
+- An inline `background` on `<html>` plus `<meta name="color-scheme">` in
+  `index.html` covers the document's paint before any stylesheet lands.
+- `"visible": false` on the main window, revealed by the frontend on React's
+  first commit (`src/lib/revealWindow.tsx`). This is what makes the app open
+  *already drawn* rather than showing a correctly-coloured empty frame — and it
+  is what makes cause (2) invisible for free, since the decoration strip now
+  happens while nobody can see the window.
+
+`#0d1013` is `--bg-0` of the default dark theme (`oklch(0.17 0.008 260)`)
+converted to sRGB. It is dark unconditionally, matching the choice `:root`
+already makes for the pre-hydration window; a light-theme user never sees it,
+because the window is revealed only after the real theme is on the DOM.
+
+**A splash screen was considered and rejected.** The pre-paint gap is a few
+hundred milliseconds; a splash would replace a white flash with a logo flash and
+add a visual state, which makes startup *feel* longer, not shorter.
+
+### Two traps
+
+- **`"decorations": false` cannot be moved into a per-platform config file.**
+  Tauri merges `tauri.windows.conf.json` / `tauri.linux.conf.json` with
+  `json_patch::merge` — RFC 7396 semantics, which **replace arrays wholesale**.
+  A platform file containing `windows: [{ "decorations": false }]` discards
+  title, size and min-size. Either duplicate the whole window object per
+  platform (three copies, guaranteed drift) or leave it in `setup`, which is
+  what we do.
+- **E2E cannot catch a window that is never shown.** WebDriver attaches to the
+  webview, not the window, so the entire suite passes green against an app with
+  no visible UI. That blind spot is why the wiring is asserted statically in
+  `test/startupPaint.test.ts`, and why `lib.rs` keeps a
+  `SHOW_WINDOW_FALLBACK_MS` thread that shows the window anyway if the frontend
+  never gets there (a module-scope throw, a bundle that fails to load). A
+  visible broken window is a bug report; an invisible one is a ghost process.
+  Note `SHOW_WINDOW_FALLBACK_MS` is about the *window* — unrelated to
+  `src-tauri/src/reveal.rs`, which reveals files in the OS file manager.
 
 ## App icons — one master, transparent, regenerated (#206)
 

--- a/index.html
+++ b/index.html
@@ -1,9 +1,26 @@
 <!doctype html>
-<html lang="en">
+<!-- The inline background is NOT a duplicate of index.css's `body` rule, and it
+     is not decoration: it is the colour of the only paint that happens before
+     any stylesheet has loaded. Without it the webview paints its default white,
+     which is the flash this app used to open with. The window layer is covered
+     separately by `backgroundColor` in src-tauri/tauri.conf.json — both layers
+     have to agree, and both track `--bg-0` of the default dark theme
+     (oklch(0.17 0.008 260) == #0d1013). `test/startupPaint.test.ts` fails the
+     build if they drift apart or go missing.
+
+     Dark, unconditionally, even though light themes exist: the CSS `:root`
+     palette already defaults to dark for the same pre-hydration window, so this
+     only agrees with a choice the design system had already made. A light-theme
+     user does not see it regardless — the window is created hidden and revealed
+     after the real theme is on the DOM (see src/lib/revealWindow.tsx). -->
+<html lang="en" style="background: #0d1013">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Tells the engine to paint its own canvas, scrollbars and form controls
+         dark from the first frame, rather than white-then-dark. -->
+    <meta name="color-scheme" content="dark light" />
     <title>platypusgit</title>
   </head>
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -13,6 +13,7 @@
     "core:window:allow-close",
     "core:window:allow-start-dragging",
     "core:window:allow-set-title",
+    "core:window:allow-show",
     "core:webview:allow-create-webview-window",
     "core:webview:allow-set-webview-zoom",
     "dialog:default",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,13 @@ use std::sync::{Arc, Mutex};
 
 use crate::{git::libgit2::Libgit2Backend, state::AppState};
 
+/// How long to wait for the frontend to show the main window before doing it
+/// here instead. See the backstop in `setup` for what this is defending
+/// against; `src/lib/revealWindow.tsx` is the code expected to win the race.
+///
+/// Unrelated to `reveal.rs`, which reveals FILES in the OS file manager.
+const SHOW_WINDOW_FALLBACK_MS: u64 = 4000;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -141,6 +148,14 @@ pub fn run() {
                 }
             }
             if let Some(win) = app.get_webview_window("main") {
+                // `show()` first: the window is created hidden (see the setup
+                // hook) and neither unminimize nor set_focus reveals a hidden
+                // window. Without this, a `pgit …` landing in the sub-second gap
+                // before the frontend's own reveal would focus a window that is
+                // not on screen — the user's second launch would look like it
+                // did nothing. A no-op once the window is up, which is the
+                // normal case.
+                let _ = win.show();
                 let _ = win.unminimize();
                 let _ = win.set_focus();
             }
@@ -175,7 +190,7 @@ pub fn run() {
     let builder = builder.plugin(tauri_plugin_wdio_webdriver::init());
 
     builder
-        .setup(|_app| {
+        .setup(|app| {
             log::info!(
                 "platypusgit starting v{}",
                 env!("CARGO_PKG_VERSION")
@@ -215,13 +230,61 @@ pub fn run() {
             // macOS uses titleBarStyle: Overlay (set in tauri.conf.json) to keep native
             // traffic lights while letting our content extend under them. On Windows /
             // Linux we hide the OS frame entirely and render PGWindowControls ourselves.
+            //
+            // Stripping the frame HERE, at runtime, rather than declaring
+            // `"decorations": false` in the config, used to be visible: the window
+            // was created decorated and shown immediately, so Windows users saw a
+            // native title bar appear and then vanish. It is invisible now only
+            // because the window is created hidden (`"visible": false`) and nothing
+            // reveals it until the frontend says so — this runs long before that.
+            // Do not make the window visible at creation again without moving this
+            // into the config first; per-platform config files cannot do it cleanly,
+            // because Tauri merges them with RFC 7396 semantics, which REPLACE the
+            // `windows` array rather than merging into it.
             #[cfg(not(target_os = "macos"))]
             {
                 use tauri::Manager;
-                if let Some(win) = _app.get_webview_window("main") {
+                if let Some(win) = app.get_webview_window("main") {
                     if let Err(e) = win.set_decorations(false) {
                         log::error!("failed to disable window decorations: {e}");
                     }
+                }
+            }
+
+            // Show-the-window backstop for the hidden window
+            // (see src/lib/revealWindow.tsx).
+            //
+            // The frontend reveals the window on React's first commit, which is what
+            // makes the app open already-drawn instead of flashing white. The failure
+            // mode of that trade is severe and silent: if the bundle throws at module
+            // scope, or fails to load at all, nothing ever calls `show()` and
+            // platypusgit becomes a process with no window — no UI, no error, just a
+            // dock icon. Showing it anyway after a timeout turns that into the far
+            // better bug: a visible window that is empty or carries the error
+            // boundary's screen.
+            //
+            // Firing this on a healthy-but-slow start is harmless — `show()` on an
+            // already-visible window is a no-op, and the frontend's own reveal is
+            // whichever comes first.
+            {
+                use tauri::Manager;
+                if let Some(win) = app.get_webview_window("main") {
+                    std::thread::spawn(move || {
+                        std::thread::sleep(std::time::Duration::from_millis(
+                            SHOW_WINDOW_FALLBACK_MS,
+                        ));
+                        // Err (rather than Ok(true)) counts as "not known to be
+                        // visible" on purpose: the whole point is to err towards a
+                        // window the user can see.
+                        if !matches!(win.is_visible(), Ok(true)) {
+                            log::warn!(
+                                "frontend did not reveal the window within {SHOW_WINDOW_FALLBACK_MS}ms; showing it anyway"
+                            );
+                            if let Err(e) = win.show() {
+                                log::error!("failed to reveal the window: {e}");
+                            }
+                        }
+                    });
                 }
             }
             Ok(())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,9 @@
         "fullscreen": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "trafficLightPosition": { "x": 12, "y": 20 }
+        "trafficLightPosition": { "x": 12, "y": 20 },
+        "visible": false,
+        "backgroundColor": "#0d1013"
       }
     ],
     "security": {

--- a/src/features/merge/openMergeWindow.ts
+++ b/src/features/merge/openMergeWindow.ts
@@ -93,6 +93,16 @@ export async function openMergeWindow(repoId: string, path?: string): Promise<vo
     minWidth: 900,
     minHeight: 500,
     title: path ? `Resolve: ${path}` : "Resolve conflicts",
+    // Same reason the main window carries it in tauri.conf.json: without it
+    // both the window and webview layers default to white, and opening the
+    // resolver flashes a white rectangle before the dark UI arrives. Kept as
+    // the literal `--bg-0` of the default dark theme; `startupPaint.test.ts`
+    // fails the build if this and the main window's value drift apart.
+    //
+    // Left VISIBLE, unlike the main window: this one opens in response to a
+    // click, where a window that appears instantly (correctly coloured, then
+    // filled) beats one that appears a beat after the click that asked for it.
+    backgroundColor: "#0d1013",
   });
   // Any exit path (Apply-through-last-file, Esc, OS close button) must leave
   // the main window showing disk truth — but only for the repository this

--- a/src/lib/revealWindow.test.tsx
+++ b/src/lib/revealWindow.test.tsx
@@ -1,0 +1,87 @@
+// The window is created hidden, so this module is the difference between an app
+// that opens and an app that does not. Two behaviours are load-bearing and
+// neither is obvious from reading the call site:
+//
+//   1. it shows the window on mount, and
+//   2. it never throws — a failure here must not be able to take down the very
+//      render that was about to become visible.
+//
+// The static half of the guard (that main.tsx actually mounts this, outside the
+// error boundary) lives in test/startupPaint.test.ts, because it is a fact about
+// a file rather than about behaviour.
+
+import { render } from "@testing-library/react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { RevealOnFirstPaint, revealWindow } from "./revealWindow";
+
+const show = vi.mocked(getCurrentWindow().show);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  show.mockReset();
+  show.mockResolvedValue(undefined);
+});
+
+describe("revealWindow", () => {
+  it("shows the current window", async () => {
+    await revealWindow();
+    expect(show).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows a failure instead of throwing", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    show.mockRejectedValueOnce(new Error("no such window"));
+
+    // The assertion IS that this resolves. A rejection here would surface as an
+    // unhandled rejection inside a layout effect.
+    await expect(revealWindow()).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe("RevealOnFirstPaint", () => {
+  it("renders nothing and reveals on mount", () => {
+    const { container } = render(<RevealOnFirstPaint />);
+    // Nothing in the DOM: it is a side effect wearing a component's clothes, so
+    // it can sit outside the error boundary without affecting layout.
+    expect(container.innerHTML).toBe("");
+    expect(show).toHaveBeenCalled();
+  });
+
+  it("reveals even when the app it sits beside throws", () => {
+    // The scenario the placement exists for: a sibling subtree explodes during
+    // render. React still commits this component, so the window still appears —
+    // carrying whatever the error boundary decided to draw.
+    const Boom = () => {
+      throw new Error("app failed to render");
+    };
+    class Boundary extends React.Component<
+      { children: React.ReactNode },
+      { failed: boolean }
+    > {
+      state = { failed: false };
+      static getDerivedStateFromError() {
+        return { failed: true };
+      }
+      render() {
+        return this.state.failed ? "broken" : this.props.children;
+      }
+    }
+
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <>
+        <RevealOnFirstPaint />
+        <Boundary>
+          <Boom />
+        </Boundary>
+      </>,
+    );
+
+    expect(show).toHaveBeenCalled();
+    err.mockRestore();
+  });
+});

--- a/src/lib/revealWindow.tsx
+++ b/src/lib/revealWindow.tsx
@@ -1,0 +1,57 @@
+// Reveals the window once there is something worth looking at.
+//
+// The main window is created with `"visible": false` (src-tauri/tauri.conf.json)
+// so that the several hundred milliseconds between process start and React's
+// first commit are spent behind nothing at all, instead of behind an empty
+// frame. This module is the other half of that trade: the window MUST be shown,
+// or the app is a process with no UI.
+//
+// Why an effect and not a `requestAnimationFrame` after `createRoot().render()`:
+// a hidden window may never get a frame callback at all. Compositors throttle
+// or stop ticking for windows nobody can see (the same suspend policy Tauri's
+// `backgroundThrottling` config exists to talk about), so a reveal that waits
+// for a paint can wait forever — deadlocking on the very state it is trying to
+// leave. A layout effect fires on commit, driven by the JS task queue, which
+// runs regardless of visibility. The DOM and the render-blocking stylesheet are
+// both in place by then, so the first frame the user actually sees is the
+// finished UI.
+//
+// There is a backstop in Rust as well (`lib.rs`, the reveal fallback thread):
+// if this code never runs — a throw at module scope, a bundle that fails to
+// load — the window is shown anyway after a timeout. A visible broken window is
+// a bug report; an invisible one is a ghost process.
+
+import React from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+/**
+ * Show the current window, whichever window this bundle is running in.
+ *
+ * Idempotent and non-throwing on purpose: it runs for the merge resolver too
+ * (which is created already visible, making this a no-op), and a failure here
+ * must not be able to take down the render that was about to become visible.
+ */
+export async function revealWindow(): Promise<void> {
+  try {
+    await getCurrentWindow().show();
+  } catch (err) {
+    // Nothing to fall back to from here — Rust's timeout owns that case.
+    console.warn("failed to reveal the window", err);
+  }
+}
+
+/**
+ * Renders nothing; reveals the window on first commit.
+ *
+ * Mount it as a SIBLING of the error boundary rather than inside it. Inside, a
+ * throw from the app would swap this component out for the boundary's fallback
+ * and the effect would never run, leaving the "something went wrong" screen
+ * inside a window nobody can see — the one case where being visible matters
+ * most.
+ */
+export function RevealOnFirstPaint(): null {
+  React.useLayoutEffect(() => {
+    void revealWindow();
+  }, []);
+  return null;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { attachConsole } from "@tauri-apps/plugin-log";
 import App from "./App";
 import { PGErrorBoundary } from "./design/error-boundary";
 import { MergeWindow } from "./features/merge/MergeWindow";
+import { RevealOnFirstPaint } from "./lib/revealWindow";
 import { startSystemAppearanceWatch } from "./features/settings/useSettingsStore";
 import "./index.css";
 
@@ -28,6 +29,11 @@ const isMergeWindow =
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
+    {/* The window is created hidden, so SOMETHING has to show it. Deliberately
+        a sibling of the boundary rather than a child: a throw from the app
+        below must not be able to swallow the reveal and leave the "something
+        went wrong" screen in a window nobody can see. */}
+    <RevealOnFirstPaint />
     {/* Outermost, so a throw anywhere still leaves a window that says what
         happened instead of an empty one. */}
     <PGErrorBoundary>

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -42,6 +42,10 @@ vi.mock("@tauri-apps/api/window", () => {
     isMaximized: vi.fn().mockResolvedValue(false),
     onResized: vi.fn().mockResolvedValue(() => {}),
     setTitle: vi.fn().mockResolvedValue(undefined),
+    // The main window is created hidden and revealed on first commit
+    // (lib/revealWindow.tsx). Anything that mounts the app's root tree calls
+    // this, so it belongs in the shared mock rather than in one spec.
+    show: vi.fn().mockResolvedValue(undefined),
     // The OS appearance source (#236). `null` is the honest default here:
     // nothing under test runs against a real window, and "the window cannot
     // tell us" is the branch that has to keep working.

--- a/test/startupPaint.test.ts
+++ b/test/startupPaint.test.ts
@@ -1,0 +1,170 @@
+/**
+ * @vitest-environment node
+ */
+// The app must not open with a white flash, and must not open with no window
+// at all.
+//
+// Both properties rest on values that live in four different files and have no
+// compiler relationship to each other:
+//
+//   - `--bg-0` in src/index.css              — what the CSS eventually paints
+//   - `backgroundColor` in tauri.conf.json   — the WINDOW layer, before any document
+//   - the inline `background` in index.html  — the DOCUMENT, before any stylesheet
+//   - `backgroundColor` in openMergeWindow   — the same, for the second window
+//
+// Nothing else notices when one of them changes. Re-theme the default palette,
+// or drop the config key while debugging something else, and the app quietly
+// goes back to flashing white on every launch — the exact bug this set of
+// values was introduced to remove, with no test failing and nothing to read in
+// a diff.
+//
+// The other half is worse. The main window is created with `"visible": false`
+// and is shown by the frontend (src/lib/revealWindow.tsx). Delete that call and
+// platypusgit becomes a process with no UI. **E2E cannot catch this**: WebDriver
+// attaches to the webview, not to the window, so the whole suite passes green
+// against an app that never appears on screen. That is why the wiring is
+// asserted here, statically, rather than left to an integration test.
+//
+// Lives in `test/` rather than `src/` for the reason docs.test.ts does: it
+// asserts things about src-tauri/ and index.html, and is not a frontend test.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const read = (p: string) => readFileSync(resolve(root, p), "utf8");
+
+const tauriConf = JSON.parse(read("src-tauri/tauri.conf.json"));
+const indexHtml = read("index.html");
+const indexCss = read("src/index.css");
+const mergeWindow = read("src/features/merge/openMergeWindow.ts");
+const mainTsx = read("src/main.tsx");
+
+const mainWindow = tauriConf.app.windows.find(
+  (w: { title?: string }) => w.title === "PlatypusGit",
+);
+
+/** `#rrggbb` → [r, g, b]. */
+function hexToRgb(hex: string): [number, number, number] {
+  const m = /^#([0-9a-f]{6})$/i.exec(hex.trim());
+  if (!m) throw new Error(`not a 6-digit hex colour: ${hex}`);
+  const n = parseInt(m[1], 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+/**
+ * `oklch(L C H)` → sRGB [r, g, b].
+ *
+ * Hand-rolled rather than pulled from a colour library, matching the trade
+ * msixIcons.test.ts documents: one dependency for one assertion is the wrong
+ * trade, and this is the standard OKLab matrix pair, not a judgement call.
+ */
+function oklchToRgb(L: number, C: number, Hdeg: number): [number, number, number] {
+  const H = (Hdeg * Math.PI) / 180;
+  const a = C * Math.cos(H);
+  const b = C * Math.sin(H);
+  const l = (L + 0.3963377774 * a + 0.2158037573 * b) ** 3;
+  const m = (L - 0.1055613458 * a - 0.0638541728 * b) ** 3;
+  const s = (L - 0.0894841775 * a - 1.291485548 * b) ** 3;
+  const linear = [
+    4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s,
+  ];
+  return linear.map((c) => {
+    const v = c <= 0.0031308 ? 12.92 * c : 1.055 * Math.pow(c, 1 / 2.4) - 0.055;
+    return Math.max(0, Math.min(255, Math.round(v * 255)));
+  }) as [number, number, number];
+}
+
+describe("the app's first paint is dark, not white", () => {
+  it("gives the main window a background colour at the WINDOW layer", () => {
+    // Without this the OS window itself is white while the webview starts up,
+    // which no amount of CSS can reach.
+    expect(mainWindow?.backgroundColor).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+
+  it("gives index.html an inline background, for the paint before any CSS", () => {
+    // A stylesheet is a separate request; the document paints before it lands.
+    const html = /<html[^>]*style="[^"]*background:\s*(#[0-9a-f]{6})/i.exec(indexHtml);
+    expect(
+      html,
+      "index.html's <html> element needs an inline `background: #rrggbb`",
+    ).not.toBeNull();
+    expect(html![1].toLowerCase()).toBe(mainWindow.backgroundColor.toLowerCase());
+  });
+
+  it("declares a dark color-scheme, so the engine's own chrome starts dark", () => {
+    expect(indexHtml).toMatch(
+      /<meta\s+name="color-scheme"\s+content="dark[^"]*"/i,
+    );
+  });
+
+  it("opens the merge resolver on the same colour", () => {
+    const merge = /backgroundColor:\s*"(#[0-9a-f]{6})"/i.exec(mergeWindow);
+    expect(merge, "openMergeWindow needs a backgroundColor").not.toBeNull();
+    expect(merge![1].toLowerCase()).toBe(mainWindow.backgroundColor.toLowerCase());
+  });
+
+  it("keeps that colour tracking --bg-0 of the default dark theme", () => {
+    // The window/document background exists to be INDISTINGUISHABLE from the
+    // first styled paint. If the palette moves and these do not, the flash
+    // comes back as a dark-grey-to-other-dark-grey jump instead of white — less
+    // ugly, still wrong, and much harder to notice by hand.
+    const decl = /--bg-0:\s*oklch\(([\d.]+)\s+([\d.]+)\s+([\d.]+)\)/.exec(indexCss);
+    expect(decl, "src/index.css must declare --bg-0 as oklch(L C H)").not.toBeNull();
+    const [, L, C, H] = decl!;
+    const expected = oklchToRgb(Number(L), Number(C), Number(H));
+    const actual = hexToRgb(mainWindow.backgroundColor);
+    // ±2 per channel: enough slack for rounding and for a nudge to the palette
+    // that is genuinely invisible, tight enough that a real theme change fails.
+    for (let i = 0; i < 3; i++) {
+      expect(
+        Math.abs(actual[i] - expected[i]),
+        `channel ${"rgb"[i]}: config has ${actual[i]}, --bg-0 renders ${expected[i]}`,
+      ).toBeLessThanOrEqual(2);
+    }
+  });
+});
+
+describe("the hidden main window always gets shown", () => {
+  it("is created hidden", () => {
+    // Not an accident to be tidied away: the reveal below is what replaces it.
+    expect(mainWindow?.visible).toBe(false);
+  });
+
+  it("grants the window:show permission the reveal needs", () => {
+    const caps = JSON.parse(read("src-tauri/capabilities/default.json"));
+    expect(caps.permissions).toContain("core:window:allow-show");
+  });
+
+  it("mounts the reveal from main.tsx", () => {
+    expect(mainTsx).toMatch(/from\s+"\.\/lib\/revealWindow"/);
+    expect(mainTsx).toMatch(/<RevealOnFirstPaint\s*\/>/);
+  });
+
+  it("mounts the reveal OUTSIDE the error boundary", () => {
+    // Inside, a throw from the app swaps the reveal out for the boundary's
+    // fallback before its effect runs — so the "something went wrong" screen
+    // renders into a window that is never shown, which is the single worst
+    // outcome available here.
+    const reveal = mainTsx.indexOf("<RevealOnFirstPaint");
+    const boundary = mainTsx.indexOf("<PGErrorBoundary");
+    expect(reveal).toBeGreaterThan(-1);
+    expect(boundary).toBeGreaterThan(-1);
+    expect(
+      reveal,
+      "<RevealOnFirstPaint /> must be a sibling before <PGErrorBoundary>, not a child",
+    ).toBeLessThan(boundary);
+  });
+
+  it("keeps a Rust-side backstop for a frontend that never gets there", () => {
+    // A bundle that throws at module scope never reveals anything, and the
+    // config says the window starts hidden. Something has to break that tie.
+    const libRs = read("src-tauri/src/lib.rs");
+    expect(libRs).toMatch(/SHOW_WINDOW_FALLBACK_MS/);
+    expect(libRs).toMatch(/is_visible\(\)/);
+    expect(libRs).toMatch(/win\.show\(\)/);
+  });
+});


### PR DESCRIPTION
The app opened with a white flash on macOS and Windows, and launch *felt* like
it was spending time building the custom titlebar. Measured first, then fixed.

## What the flash actually was

Two independent causes, both at the window layer — nothing to do with React.

1. **Nothing set a background colour.** With no `backgroundColor` on the window
   config and no inline background in `index.html`, both the window layer and
   the webview layer default to **white**. The sequence was: OS window appears
   white → `index-*.css` loads → `body { background: var(--bg-0) }` finally
   paints dark. CSS can't reach either layer before it has loaded, so this was
   never fixable in the stylesheet.
2. **Windows/Linux additionally showed the native frame being stripped.**
   `set_decorations(false)` runs in the `setup` hook (macOS keeps its frame for
   `titleBarStyle: "Overlay"`), so the window was created decorated, shown, and
   then lost its title bar — a shape change on top of the white.

## What it was NOT: the JS bundle

Worth recording, because "it spends time setting up the titlebar" sounds like
parse cost. **V8 compiles the 1.41 MB entry chunk in 14–18 ms.** Code splitting
the app would do nothing measurable for startup, so please don't reach for
`manualChunks` the next time launch gets a complaint.

(`@xterm/xterm` — a whole terminal emulator — *is* statically in that entry
chunk. Lazy-loading it is a legitimate size/memory change, just not a startup
one. Left alone here.)

The real *time-to-usable* cost is separate and untouched by this PR: the nine
boot invokes queue on the per-repo mutex and all land at ~350–430 ms, which the
app's own invoke-latency warnings have been recording all along.

## The fix

- `backgroundColor: "#0d1013"` on the main window, the same value inline on
  `<html>`, plus `<meta name="color-scheme">`. `openMergeWindow` passes it too,
  so the resolver doesn't flash either. `#0d1013` is `--bg-0` of the default
  dark theme (`oklch(0.17 0.008 260)`) converted to sRGB.
- `"visible": false` on the main window, revealed by the frontend on React's
  first commit (`src/lib/revealWindow.tsx`). The app now appears **already
  drawn** instead of as a correctly-coloured empty frame — and this makes
  cause (2) invisible for free, since the decoration strip happens while nobody
  can see the window.

**A splash screen was considered and rejected.** The pre-paint gap is a few
hundred milliseconds; a splash replaces a white flash with a logo flash and adds
a visual state, which makes startup feel longer, not shorter.

## Why the guards are load-bearing

A hidden window that never gets shown is a process with no UI — and **e2e cannot
catch it**: WebDriver attaches to the webview, not the window, so the whole
suite passes green against an app that never appears on screen. So:

- `test/startupPaint.test.ts` asserts the wiring statically (reveal is mounted,
  and mounted *outside* the error boundary — inside, a throw would swap it out
  and render "something went wrong" into an invisible window), and asserts the
  window/document colours stay in step with `--bg-0` (±2 per channel, with the
  OKLab conversion inline rather than a new dependency).
- `lib.rs` keeps a `SHOW_WINDOW_FALLBACK_MS` (4 s) thread that shows the window
  anyway if the frontend never gets there — a module-scope throw, a bundle that
  fails to load. A visible broken window is a bug report; an invisible one is a
  ghost process.
- `show()` joins the single-instance handler: neither `unminimize` nor
  `set_focus` reveals a hidden window, so a fast second `pgit …` could
  previously have focused a window that wasn't on screen yet.

## One trap documented

`"decorations": false` deliberately stays in `setup` rather than moving into
`tauri.windows.conf.json`. Tauri merges per-platform configs with
`json_patch::merge` — **RFC 7396, which replaces arrays wholesale** — so a
platform file containing `windows: [{ "decorations": false }]` silently discards
title, size and min-size. The alternative is three copies of the window object.

## Verification

- `pnpm test` — 336 files / 3265 tests pass (re-run after the last edit).
- `cargo test` — 89 test binaries, 0 failures.
- `pnpm tsc --noEmit` and the e2e tsconfig gate — both clean.
- `pnpm test:e2e:docker` — `smoke` (3 passing) and `merge-window` (2 passing) on
  WebKitGTK, against a snapshot rebuilt after the final edit. `smoke` passing
  matters beyond the assertions: it proves the page loads and JS executes with a
  hidden window on WebKitGTK, which is the platform where a compositor could
  have deferred page load and deadlocked the reveal.
- A native macOS launch: no backstop warning fired, and `CGWindowListCopyWindowInfo`
  reported the window on screen at `layer=0 alpha=1.0` — i.e. the frontend
  reveal beat the 4 s fallback.
- Confirmed Vite ships the inline background verbatim in `dist/index.html` (the
  guard test reads the source; what ships is the build output).

Does not close any issue — this came from a direct report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
