### PR TITLE
feat(distribution): build an arm64 Linux .deb and publish it to the APT repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,8 @@ name: release
 # and attaches them to that same release:
 #   - macOS  universal .dmg   (PlatypusGit_universal.dmg)
 #   - Windows x64 .msi         (PlatypusGit_x64.msi)
-#   - Linux  amd64 .deb + .AppImage (PlatypusGit_amd64.deb / .AppImage)
+#   - Linux  amd64 + arm64 .deb and .AppImage
+#     (PlatypusGit_amd64.deb / _arm64.deb / _amd64.AppImage / _arm64.AppImage)
 #
 # Nothing releases on a plain push to main — you control when "latest" moves by
 # choosing when to publish. Mark a release as a "prerelease" to build + attach
@@ -651,12 +652,38 @@ jobs:
           files: PlatypusGit.msixbundle
           fail_on_unmatched_files: true
 
+  # Both Linux architectures (#266). arm64 is a matrix entry rather than a
+  # cross-compile: `ubuntu-*-arm` runners are free for public repositories, and a
+  # native build sidesteps the whole cross-linking story for webkit2gtk.
+  #
+  # BOTH LEGS PIN 22.04, and they have to move together. The runner image's glibc
+  # is the FLOOR of what the .deb and the AppImage will load on — 22.04 is 2.35,
+  # 24.04 is 2.39 — so building arm64 on a newer image than amd64 would ship an
+  # arm64 package that installs cleanly on Debian 12 and then dies in the loader.
+  # The apt gate catches it (it runs `pgit --help` in debian:bookworm, glibc
+  # 2.36), which is exactly why that assertion is worth having, but the cheaper
+  # fix is not to create the mismatch.
+  #
+  # NO JOB OUTPUTS. A matrix job's `outputs` are merged across legs and the last
+  # leg to finish wins, so `needs.linux.outputs.deb_sig` would be a coin flip
+  # between two architectures' signatures — and latest.json would hand half the
+  # world a payload whose signature does not verify. The signatures travel as
+  # artifacts instead, one per architecture, the same way `msix-build` hands its
+  # packages to `msix`.
   linux:
     needs: version
-    runs-on: ubuntu-22.04
-    outputs:
-      appimage_sig: ${{ steps.sig.outputs.appimage_sig }}
-      deb_sig: ${{ steps.sig.outputs.deb_sig }}
+    strategy:
+      # NOT fail-fast, for the reason spelled out on msix-build: when one
+      # architecture breaks, whether the other broke too is the first thing you
+      # need to know.
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -687,10 +714,14 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      # `key` keeps the two legs in SEPARATE cache entries — see msix-build for
+      # what happens without it (both legs compute the same key, race to save
+      # under it, and each restores the other's target directory).
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+          key: ${{ matrix.arch }}
 
       - name: Inject version ${{ needs.version.outputs.version }}
         run: |
@@ -710,13 +741,30 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: pnpm tauri build
 
+      # The stable names carry the ARCHITECTURE, not the runner's idea of it:
+      # tauri names the .deb `platypusgit_<version>_<arch>.deb` and the AppImage
+      # `platypusgit_<version>_aarch64.AppImage`, two different spellings of the
+      # same machine. `matrix.arch` is the one the download page, latest.json and
+      # the pool all agree on.
       - name: Rename bundles to stable names
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
           set -euo pipefail
           deb_dir="src-tauri/target/release/bundle/deb"
           appimage_dir="src-tauri/target/release/bundle/appimage"
-          cp "$(ls "$deb_dir"/*.deb | head -n1)" "$deb_dir/PlatypusGit_amd64.deb"
-          cp "$(ls "$appimage_dir"/*.AppImage | head -n1)" "$appimage_dir/PlatypusGit_amd64.AppImage"
+          cp "$(ls "$deb_dir"/*.deb | head -n1)" "$deb_dir/PlatypusGit_${ARCH}.deb"
+          cp "$(ls "$appimage_dir"/*.AppImage | head -n1)" "$appimage_dir/PlatypusGit_${ARCH}.AppImage"
+          # The bundler builds for the host and nothing asserts that anywhere
+          # else, so a matrix entry pointing at the wrong runner would attach an
+          # amd64 payload under an arm64 name and the first symptom would be a
+          # user's "cannot execute binary file". dpkg says what it actually is.
+          got="$(dpkg-deb -f "$deb_dir/PlatypusGit_${ARCH}.deb" Architecture)"
+          if [ "$got" != "$ARCH" ]; then
+            echo "Built a '$got' .deb on the '$ARCH' matrix leg — check runs-on" >&2
+            exit 1
+          fi
+          echo "deb architecture: $got"
 
       # Attach BEFORE reading the signature — see the windows job for why.
       - name: Attach bundles to release
@@ -724,8 +772,8 @@ jobs:
         with:
           tag_name: ${{ needs.version.outputs.tag }}
           files: |
-            src-tauri/target/release/bundle/deb/PlatypusGit_amd64.deb
-            src-tauri/target/release/bundle/appimage/PlatypusGit_amd64.AppImage
+            src-tauri/target/release/bundle/deb/PlatypusGit_${{ matrix.arch }}.deb
+            src-tauri/target/release/bundle/appimage/PlatypusGit_${{ matrix.arch }}.AppImage
           fail_on_unmatched_files: true
 
       # BOTH Linux bundles are updater artifacts, so both get a signature.
@@ -736,10 +784,15 @@ jobs:
       #
       # minisign signs CONTENT, not filenames, so the stable-name `cp` above
       # leaves both signatures valid for the renamed copies we attach.
+      #
+      # Written to FILES rather than to $GITHUB_OUTPUT — see the job comment: a
+      # matrix job's outputs collapse to one leg's values, and the wrong one is
+      # not a build failure, it is an unverifiable update on every machine of the
+      # other architecture.
       - name: Read updater signatures
-        id: sig
         run: |
           set -euo pipefail
+          mkdir -p sigs
           # Called directly (never in a $(...) subshell) so `exit 1` aborts the
           # job rather than just the substitution.
           emit() {
@@ -754,10 +807,26 @@ jobs:
               echo "Updater signature file $file is empty" >&2
               exit 1
             fi
-            echo "$name=$sig" >> "$GITHUB_OUTPUT"
+            printf '%s' "$sig" > "sigs/$name"
           }
-          emit appimage_sig src-tauri/target/release/bundle/appimage '*.AppImage.sig'
-          emit deb_sig      src-tauri/target/release/bundle/deb      '*.deb.sig'
+          emit appimage src-tauri/target/release/bundle/appimage '*.AppImage.sig'
+          emit deb      src-tauri/target/release/bundle/deb      '*.deb.sig'
+          ls -la sigs
+
+      # The only thing that crosses to `updater-manifest`. Named by architecture
+      # because that is what the download pattern globs on.
+      #
+      # `retention-days` short of the 90-day default (throwaway intermediates)
+      # but not 1: re-running a failed `updater-manifest` pulls artifacts from
+      # the ORIGINAL run, so a week buys a Monday re-run of a Friday release
+      # without rebuilding both architectures.
+      - name: Upload the ${{ matrix.arch }} updater signatures
+        uses: actions/upload-artifact@v7
+        with:
+          name: linux-sigs-${{ matrix.arch }}
+          path: sigs/
+          if-no-files-found: error
+          retention-days: 7
 
   # Pin the Homebrew cask to this release: rewrite version + sha256 in
   # jonassaa/homebrew-platypusgit and commit straight to that tap's main.
@@ -1041,11 +1110,36 @@ jobs:
   # `update::capability` has always gated Linux self-update behind the APPIMAGE
   # env var (a .deb install gets `notify` and never invokes the plugin). Same
   # reasoning for `windows-x86_64` -> msi, the only Windows bundle we ship.
+  #
+  # ARCH IS THE RUST SPELLING, not Debian's. The plugin builds `{os}-{arch}` from
+  # `std::env::consts::ARCH`, so the arm64 keys are `linux-aarch64…` while the
+  # same machine's package is `PlatypusGit_arm64.deb`. Two names for one
+  # architecture, and mixing them up publishes a manifest that no client ever
+  # matches — which looks exactly like "no update available" rather than an
+  # error.
   updater-manifest:
     needs: [version, windows, linux]
     runs-on: ubuntu-latest
     if: ${{ (github.event_name == 'release' && github.event.release.prerelease == false) || github.event_name == 'workflow_dispatch' }}
     steps:
+      # `linux` is a matrix job, so its signatures cannot travel as job outputs —
+      # see the comment on that job. One step per architecture, each naming its
+      # artifact and its destination, the way `msix` collects its two packages:
+      # a `pattern:` download would work, but the directory it lands things in is
+      # then a property of how many artifacts matched, and a missing one would be
+      # discovered as an absent file rather than as a failed download.
+      - name: Download the amd64 updater signatures
+        uses: actions/download-artifact@v8
+        with:
+          name: linux-sigs-amd64
+          path: sigs/amd64
+
+      - name: Download the arm64 updater signatures
+        uses: actions/download-artifact@v8
+        with:
+          name: linux-sigs-arm64
+          path: sigs/arm64
+
       - name: Build latest.json
         # Values reach the shell as env vars, never as `${{ }}` interpolated
         # into the script body — RELEASE_BODY is user-authored text.
@@ -1053,21 +1147,31 @@ jobs:
           VERSION: ${{ needs.version.outputs.version }}
           TAG: ${{ needs.version.outputs.tag }}
           MSI_SIG: ${{ needs.windows.outputs.msi_sig }}
-          APPIMAGE_SIG: ${{ needs.linux.outputs.appimage_sig }}
-          DEB_SIG: ${{ needs.linux.outputs.deb_sig }}
           RELEASE_BODY: ${{ github.event.release.body }}
           RELEASE_PUBLISHED_AT: ${{ github.event.release.published_at }}
         run: |
           set -euo pipefail
           # An empty signature publishes `"signature": ""`, which every client
           # rejects at install time — fail loudly instead (same guard shape as
-          # bump-cask's sha256 check).
-          for name in MSI_SIG APPIMAGE_SIG DEB_SIG; do
-            if [ -z "${!name}" ]; then
-              echo "Empty updater signature ($name) — refusing to publish latest.json" >&2
-              exit 1
-            fi
+          # bump-cask's sha256 check). Checked directly, never inside a `$(...)`,
+          # so `exit 1` ends the job rather than the substitution.
+          if [ -z "${MSI_SIG}" ]; then
+            echo "Empty updater signature (MSI_SIG) — refusing to publish latest.json" >&2
+            exit 1
+          fi
+          for arch in amd64 arm64; do
+            for kind in appimage deb; do
+              f="sigs/${arch}/${kind}"
+              if [ ! -s "$f" ]; then
+                echo "Missing or empty $f — did the ${arch} linux leg finish?" >&2
+                exit 1
+              fi
+            done
           done
+          APPIMAGE_SIG_AMD64="$(cat sigs/amd64/appimage)"
+          DEB_SIG_AMD64="$(cat sigs/amd64/deb)"
+          APPIMAGE_SIG_ARM64="$(cat sigs/arm64/appimage)"
+          DEB_SIG_ARM64="$(cat sigs/arm64/deb)"
           base="https://github.com/jonassaa/platypusgit/releases/download/${TAG}"
           # Real release notes; fall back to a link for workflow_dispatch runs
           # (no release payload) or an empty body.
@@ -1087,20 +1191,27 @@ jobs:
             --arg pub_date "$pub_date" \
             --arg msi_sig "$MSI_SIG" \
             --arg msi_url "${base}/PlatypusGit_x64.msi" \
-            --arg appimage_sig "$APPIMAGE_SIG" \
+            --arg appimage_sig "$APPIMAGE_SIG_AMD64" \
             --arg appimage_url "${base}/PlatypusGit_amd64.AppImage" \
-            --arg deb_sig "$DEB_SIG" \
+            --arg deb_sig "$DEB_SIG_AMD64" \
             --arg deb_url "${base}/PlatypusGit_amd64.deb" \
+            --arg appimage_sig_arm "$APPIMAGE_SIG_ARM64" \
+            --arg appimage_url_arm "${base}/PlatypusGit_arm64.AppImage" \
+            --arg deb_sig_arm "$DEB_SIG_ARM64" \
+            --arg deb_url_arm "${base}/PlatypusGit_arm64.deb" \
             '{
               version: $version,
               notes: $notes,
               pub_date: $pub_date,
               platforms: {
-                "windows-x86_64":        { signature: $msi_sig,      url: $msi_url },
-                "windows-x86_64-msi":    { signature: $msi_sig,      url: $msi_url },
-                "linux-x86_64":          { signature: $appimage_sig, url: $appimage_url },
-                "linux-x86_64-appimage": { signature: $appimage_sig, url: $appimage_url },
-                "linux-x86_64-deb":      { signature: $deb_sig,      url: $deb_url }
+                "windows-x86_64":         { signature: $msi_sig,          url: $msi_url },
+                "windows-x86_64-msi":     { signature: $msi_sig,          url: $msi_url },
+                "linux-x86_64":           { signature: $appimage_sig,     url: $appimage_url },
+                "linux-x86_64-appimage":  { signature: $appimage_sig,     url: $appimage_url },
+                "linux-x86_64-deb":       { signature: $deb_sig,          url: $deb_url },
+                "linux-aarch64":          { signature: $appimage_sig_arm, url: $appimage_url_arm },
+                "linux-aarch64-appimage": { signature: $appimage_sig_arm, url: $appimage_url_arm },
+                "linux-aarch64-deb":      { signature: $deb_sig_arm,      url: $deb_url_arm }
               }
             }' > latest.json
           echo "--- latest.json ---"
@@ -1171,20 +1282,57 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           path: apt
 
-      # The same asset users download, rather than a job artifact — so what
+      # Emulating the arm64 client for the pre-push gate below. It is the only
+      # way to run that container on this runner, and the gate has to share a job
+      # with the push it protects — a separate arm64 job could only check the
+      # index after it was already public.
+      #
+      # `apt-verify-live` needs none of this: it runs after the push, so it can
+      # be a matrix over native runners.
+      - name: Enable arm64 containers
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      # The same assets users download, rather than job artifacts — so what
       # lands in the pool is provably the published bundle, and a
       # workflow_dispatch against an existing tag works identically.
-      - name: Download the release .deb
+      #
+      # `--pattern` twice rather than a glob: `PlatypusGit_*.deb` would also
+      # match an asset added later, and pooling a .deb nobody named here is how a
+      # repository grows an architecture by accident.
+      #
+      # Every architecture is REQUIRED, and the check comes first so the reason
+      # is a sentence rather than `gh`'s "no assets match the file pattern". A
+      # workflow_dispatch against a tag cut before #266 lands here, because
+      # workflow_dispatch runs main's copy of this file against an older tag's
+      # assets — and publishing what that tag does have would put an
+      # `Architectures: amd64` index in front of arm64 clients that had one.
+      - name: Download the release .deb files
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.version.outputs.tag }}
         run: |
           set -euo pipefail
+          assets="$(gh release view "$TAG" --repo jonassaa/platypusgit \
+            --json assets --jq '.assets[].name')"
+          missing=
+          for arch in amd64 arm64; do
+            printf '%s\n' "$assets" | grep -qx "PlatypusGit_${arch}.deb" \
+              || missing="$missing PlatypusGit_${arch}.deb"
+          done
+          if [ -n "$missing" ]; then
+            echo "Release $TAG is missing:$missing" >&2
+            echo "Every architecture the repository advertises has to be publishable together." >&2
+            echo "If this is a tag from before the arm64 build (#266), it cannot be published to apt by this workflow." >&2
+            exit 1
+          fi
           gh release download "$TAG" \
             --repo jonassaa/platypusgit \
             --pattern PlatypusGit_amd64.deb \
+            --pattern PlatypusGit_arm64.deb \
             --clobber
-          ls -la PlatypusGit_amd64.deb
+          ls -la PlatypusGit_amd64.deb PlatypusGit_arm64.deb
 
       - name: Build + sign the index
         env:
@@ -1203,27 +1351,39 @@ jobs:
           scripts/apt-repo-publish.sh \
             --repo apt \
             --deb PlatypusGit_amd64.deb \
+            --deb PlatypusGit_arm64.deb \
             --version "$VERSION"
 
-      # THE GATE. A real `apt-get install` from this exact index, in a clean
-      # debian:bookworm, running the same installer the download page tells
-      # people to pipe into a shell.
+      # THE GATE, ONCE PER ARCHITECTURE. A real `apt-get install` from this exact
+      # index, in a clean debian:bookworm of that architecture, running the same
+      # installer the download page tells people to pipe into a shell.
+      #
+      # Both legs are required. One run proves one architecture — the client
+      # writes `Architectures:` from its own `dpkg --print-architecture`, so an
+      # amd64-only gate says nothing at all about whether `binary-arm64` was
+      # published, signed, or built for the machine it claims.
       #
       # --expect-git additionally asserts Depends: git resolved and that
       # Provides:/Section: landed in the control data. A workflow_dispatch
       # against a tag built BEFORE those keys existed will fail here, by design:
       # such a package installs without git and breaks at runtime, so it should
-      # not reach the repository.
-      - name: Gate — install it in a container before publishing
+      # not reach the repository. A dispatch against a tag from before arm64
+      # existed fails one step earlier, at the download, for the same reason.
+      - name: Gate — install both architectures in containers before publishing
         env:
           VERSION: ${{ needs.version.outputs.version }}
         run: |
           set -euo pipefail
-          scripts/apt-repo-smoke.sh \
-            --repo apt \
-            --version "$VERSION" \
-            --installer scripts/install-platypusgit.sh \
-            --expect-git
+          for arch in amd64 arm64; do
+            echo "::group::apt gate — $arch"
+            scripts/apt-repo-smoke.sh \
+              --repo apt \
+              --version "$VERSION" \
+              --arch "$arch" \
+              --installer scripts/install-platypusgit.sh \
+              --expect-git
+            echo "::endgroup::"
+          done
 
       - name: Commit & push to the apt repository
         env:
@@ -1470,15 +1630,28 @@ jobs:
   # readiness loop doubles as the retry — hence the long --wait rather than a
   # sleep. A failure here means users cannot install even though the index is
   # correct, which is worth failing the run for.
+  # One leg per architecture, each on a runner that IS that architecture — no
+  # qemu, unlike the pre-push gate, because this runs after the push and is free
+  # to be two jobs. Not fail-fast: "did arm64 publish and amd64 not" is the
+  # question this job exists to answer, and a cancelled sibling withholds half
+  # the answer.
   apt-verify-live:
     needs: [version, apt-publish]
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.version.outputs.tag }}
 
-      - name: Install from apt.platypusgit.com
+      - name: Install ${{ matrix.arch }} from apt.platypusgit.com
         env:
           VERSION: ${{ needs.version.outputs.version }}
         run: |
@@ -1486,6 +1659,7 @@ jobs:
           scripts/apt-repo-smoke.sh \
             --url https://apt.platypusgit.com \
             --version "$VERSION" \
+            --arch ${{ matrix.arch }} \
             --installer scripts/install-platypusgit.sh \
             --expect-git \
             --wait 900

--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ sudo apt update && sudo apt upgrade platypusgit                      # update
 ```
 
 The script adds a signed APT repository at `apt.platypusgit.com` and installs
-`platypusgit` from it — amd64 only so far
-([#266](https://github.com/jonassaa/platypusgit/issues/266)), and it says why
+`platypusgit` from it — amd64 and arm64. On any other architecture it says why
 and stops rather than quietly substituting a package format you did not ask
 for. It is POSIX `sh`, never reads stdin, takes
 `--dry-run`, and is a build-time copy of
@@ -78,8 +77,10 @@ one-liner above, which upgrades and moves the install onto the repository in the
 same step. On any other distribution take the AppImage: it installs no `pgit`,
 but it does update itself in place.
 
-[`.deb`](https://github.com/jonassaa/platypusgit/releases/latest/download/PlatypusGit_amd64.deb) ·
-[`.AppImage`](https://github.com/jonassaa/platypusgit/releases/latest/download/PlatypusGit_amd64.AppImage) ·
+[`.deb` amd64](https://github.com/jonassaa/platypusgit/releases/latest/download/PlatypusGit_amd64.deb) ·
+[`.deb` arm64](https://github.com/jonassaa/platypusgit/releases/latest/download/PlatypusGit_arm64.deb) ·
+[`.AppImage` amd64](https://github.com/jonassaa/platypusgit/releases/latest/download/PlatypusGit_amd64.AppImage) ·
+[`.AppImage` arm64](https://github.com/jonassaa/platypusgit/releases/latest/download/PlatypusGit_arm64.AppImage) ·
 [`.dmg`](https://github.com/jonassaa/platypusgit/releases/latest/download/PlatypusGit_universal.dmg) ·
 [`.msi`](https://github.com/jonassaa/platypusgit/releases/latest/download/PlatypusGit_x64.msi) ·
 [all releases](https://github.com/jonassaa/platypusgit/releases)
@@ -216,7 +217,7 @@ is implemented, not a roadmap). Known gaps, stated plainly:
 - macOS builds are ad-hoc signed and not notarized; the Windows `.msi` is not code-signed.
 - No `winget` package yet — that one really does wait on the code signing above, which is what separates it from Scoop ([#187](https://github.com/jonassaa/platypusgit/issues/187)). Windows installs from the `.msi` or in one line from Scoop; the `.msi` self-updates from then on, Scoop owns updates on its own installs, and so does the Linux AppImage.
 - No in-app update on macOS: Homebrew owns upgrades there, and a `.dmg` drag-install is told a new version exists rather than fetching it.
-- The APT repository is amd64 only ([#266](https://github.com/jonassaa/platypusgit/issues/266)), and there is no `.rpm` or AUR package, so every other Linux takes the AppImage. Scoop is x64 only for the same reason.
+- The APT repository serves amd64 and arm64 only, and there is no `.rpm` or AUR package, so every other Linux takes the AppImage. Scoop is x64 only.
 - Changed images are reported as binary rather than previewed side by side ([#224](https://github.com/jonassaa/platypusgit/issues/224)).
 - Standalone GUI only: no icon overlays or context menus inside Finder and Explorer themselves, which is a different thing from the app's own reveal-in-file-manager action. Mercurial is out of scope too.
 

--- a/docs/dev/distribution.md
+++ b/docs/dev/distribution.md
@@ -496,10 +496,49 @@ the *why*; this is the operational summary.
 3. **Idempotency is decided on `Packages`, never on the tree.** `apt-ftparchive
    release` stamps a `Date:`, so `Release` always differs. The job compares the
    freshly generated `Packages` and, if identical, leaves the whole tree alone.
-4. **The smoke client must be `--platform linux/amd64`.** We ship amd64 only, so
-   an arm64 client (the default on an Apple Silicon Mac) verifies the signature,
-   fetches `Packages`, and then says "Unable to locate package" — which reads as
-   a broken repository rather than a wrong architecture.
+4. **The smoke client must BE the architecture under test.** `--arch` picks both
+   the `binary-<arch>` index it waits on and the `--platform` it runs the client
+   under, because a mismatch there verifies the signature, fetches `Packages`,
+   and then says "Unable to locate package" — which reads as a broken repository
+   rather than a wrong client. It is also why one run is not a gate for a
+   two-architecture repository: see below.
+
+### Two architectures (#266)
+
+The repository serves **amd64 and arm64**. The layout was built for it — the
+pool has always been `dists/stable/main/binary-<arch>/` — so adding one was a
+directory, not a migration.
+
+- **`release.yml`'s `linux` job is a matrix**, `ubuntu-22.04` and
+  `ubuntu-22.04-arm`. Native builds, not a cross-compile: `ubuntu-*-arm` runners
+  are free for public repositories, and cross-linking webkit2gtk is a project of
+  its own. **Both legs pin 22.04 and have to move together** — the runner image's
+  glibc is the floor of what the bundles load on (22.04 is 2.35, 24.04 is 2.39),
+  so a newer image on one leg ships a package that installs on Debian 12 and then
+  dies in the loader.
+- **A matrix job cannot carry the updater signatures in its `outputs`.** Those
+  are merged across legs and the last to finish wins, so
+  `needs.linux.outputs.deb_sig` would be a coin flip between two architectures —
+  and the wrong one is not a build failure, it is an unverifiable update for
+  every machine of the other architecture. They travel as artifacts
+  (`linux-sigs-<arch>`), the same way `msix-build` hands packages to `msix`.
+- **`latest.json` spells the architecture Rust's way.** The plugin builds
+  `{os}-{arch}` from `std::env::consts::ARCH`, so the keys are `linux-aarch64`,
+  `linux-aarch64-appimage`, `linux-aarch64-deb` — while the same machine's assets
+  and pool entries say `arm64`. Mixing the two publishes a manifest no client
+  matches, which presents as "no update available" rather than as an error.
+- **`apt-repo-publish.sh` derives the architecture set from the pool**, and reads
+  each package's own `Architecture` field with `dpkg-deb -f` rather than trusting
+  the `PlatypusGit_<arch>.deb` filename. `KEEP` is applied **per architecture**,
+  so ten still means ten releases rather than five of each.
+- **The pre-push gate runs twice**, once per architecture, which is why
+  `apt-publish` sets up qemu: the gate has to share a job with the push it
+  protects, so the arm64 client is emulated there. `apt-verify-live` runs after
+  the push and is therefore a matrix over native runners instead.
+- **`install-platypusgit.sh` still writes `Architectures:` from
+  `dpkg --print-architecture`**, which is what made this a no-op for everyone
+  already installed: an amd64 box keeps asking for amd64 instead of starting to
+  fetch a second index it has no use for.
 
 ### Deliberate non-expiry
 
@@ -583,17 +622,28 @@ docker run --rm -v "$PWD/fixtures:/out" debian:bookworm sh -c '...gen-key...'
 
 export APT_GPG_PRIVATE_KEY="$(cat fixtures/test-private.asc)"
 export APT_GPG_PASSPHRASE=testpass
-scripts/apt-repo-publish.sh --repo /tmp/aptrepo --deb PlatypusGit_amd64.deb \
-    --version 0.0.17 --docker
+scripts/apt-repo-publish.sh --repo /tmp/aptrepo --version 0.0.17 --docker \
+    --deb PlatypusGit_amd64.deb --deb PlatypusGit_arm64.deb
 
-scripts/apt-repo-smoke.sh --repo /tmp/aptrepo --version 0.0.17 \
-    --installer scripts/install-platypusgit.sh
+for arch in amd64 arm64; do
+    scripts/apt-repo-smoke.sh --repo /tmp/aptrepo --version 0.0.17 \
+        --arch "$arch" --installer scripts/install-platypusgit.sh
+done
 ```
+
+Both smoke legs work on an Apple Silicon Mac — the amd64 client is the emulated
+one there, which is the same shape as CI, where the arm64 one is.
 
 Drop `--installer` for the isolation mode (a hand-written sources file), which
 answers "is the index broken, or is the installer broken?". Add `--expect-git`
 when the `.deb` was built after the `Depends: git` change. To prove the gate can
 fail, corrupt a byte of `InRelease` and re-run — expect `BADSIG` and exit 100.
+
+You do not need a real `.deb` to exercise any of this. A package with the right
+control fields and two shell scripts at `/usr/bin/pgit` and
+`/usr/bin/platypusgit` satisfies every assertion the gate makes, which is how
+the two-architecture path was verified before a single arm64 Tauri build
+existed.
 
 ### Release-time notes
 
@@ -606,10 +656,16 @@ fail, corrupt a byte of `InRelease` and re-run — expect `BADSIG` and exit 100.
 - **A prerelease never reaches apt.** Same gate as `bump-cask` and
   `updater-manifest`: the `.deb` is attached to the GitHub release and stays
   invisible to `apt upgrade`. That is correct, and it is not a bug report.
-- The pool keeps the **newest 10** releases and logs what it pruned. Older
+- The pool keeps the **newest 10 releases per architecture** and logs what it
+  pruned — ~228 MB across the two, against a 1 GB published-Pages cap. Older
   `.deb`s remain on GitHub Releases.
 - A `workflow_dispatch` against a tag built **before** the `Depends: git` change
   fails the pre-push gate, by design.
+- A `workflow_dispatch` against a tag built **before arm64** (#266) fails at the
+  download, also by design and with a message that says so. `workflow_dispatch`
+  runs `main`'s copy of `release.yml` against an older tag's assets, and
+  publishing only what that tag has would put an `Architectures: amd64` index in
+  front of arm64 clients that already had one.
 
 ### The manual setup
 

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -172,9 +172,11 @@ gh api repos/jonassaa/platypusgit/releases/latest --jq .tag_name   # must be the
 ```
 
 - **The pointer**, above — nothing in CI checks it.
-- **Seven assets attached**: `latest.json`, `PlatypusGit_universal.dmg`,
+- **Nine assets attached**: `latest.json`, `PlatypusGit_universal.dmg`,
   `PlatypusGit_x64.msi`, `PlatypusGit_x64_portable.zip`, `PlatypusGit.msixbundle`,
-  `PlatypusGit_amd64.deb`, `PlatypusGit_amd64.AppImage`.
+  `PlatypusGit_amd64.deb`, `PlatypusGit_amd64.AppImage`, `PlatypusGit_arm64.deb`,
+  `PlatypusGit_arm64.AppImage` — the two Linux architectures are separate matrix
+  legs (#266), so a missing pair points at one leg, not at the whole job.
 - **`latest.json`'s `notes` is your release body, not a bare link.** A link means
   a `workflow_dispatch` run wrote it (see the promotion trap) and users will see
   that link instead of your notes.

--- a/scripts/apt-repo-publish.sh
+++ b/scripts/apt-repo-publish.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
 # Build and sign the platypusgit APT repository (#187).
 #
-# Adds one .deb to the pool, prunes the pool to the newest N, regenerates the
-# whole index from whatever the pool now holds, and signs it. Called by
-# release.yml's `apt-publish` job against a checkout of
+# Adds one .deb PER ARCHITECTURE to the pool, prunes each architecture to the
+# newest N, regenerates the whole index from whatever the pool now holds, and
+# signs it. Called by release.yml's `apt-publish` job against a checkout of
 # jonassaa/apt-platypusgit, and by a developer against a scratch directory.
 #
-#   scripts/apt-repo-publish.sh --repo <dir> --deb <file> --version 0.0.18
+#   scripts/apt-repo-publish.sh --repo <dir> --version 0.0.18 \
+#       --deb PlatypusGit_amd64.deb --deb PlatypusGit_arm64.deb
 #
 # STATELESS BY DESIGN. There is no database: the pool directory IS the state and
 # git IS the history, so the index is a pure function of the pool. That is what
@@ -14,6 +15,15 @@
 # and this script then reproduces the same index and says so instead of
 # committing a no-op. `aptly` and `reprepro` both keep a second source of truth
 # that can desync from the pool; this has none to desync.
+#
+# THE ARCHITECTURE SET IS DERIVED, NEVER CONFIGURED (#266). Every `binary-<arch>`
+# directory, and the `Architectures:` line in `Release`, comes from the pool's
+# own filenames — so publishing an arm64 `.deb` creates its directory, and an
+# architecture that leaves the pool entirely takes its directory with it. A
+# constant would be a second source of truth for exactly the thing "stateless"
+# exists to avoid, and the failure mode is the ugly one: an `Architectures:`
+# line promising an index that is not there makes `apt update` warn on every
+# client that asked for it.
 #
 # Runs on Linux (needs apt-ftparchive from apt-utils, and gnupg). macOS has
 # neither, so `--docker` re-execs the whole thing inside debian:bookworm with
@@ -35,43 +45,56 @@
 # Spec: docs/superpowers/specs/2026-08-26-apt-repository-spec.md
 set -eu
 
-# Repository shape. These four strings are the layout; changing any of them is a
-# breaking change for every client that already has a .sources file.
+# Repository shape. These three strings are the layout; changing any of them is a
+# breaking change for every client that already has a .sources file. The
+# architecture is deliberately NOT one of them — see the header.
 SUITE=stable
 COMPONENT=main
-ARCH=amd64
 PKG=platypusgit
 
 ORIGIN=platypusgit
 LABEL=platypusgit
 DESCRIPTION="platypusgit APT repository"
 
-# How many .deb files stay in the pool. Every GitHub Pages deploy re-uploads the
-# whole tree, so the pool's size is paid on every publish, not once; and the
-# published-site cap is 1 GB against ~11.4 MB per package. Ten is ~114 MB, and
-# GitHub Releases still holds every historical .deb for anyone who needs one.
+# How many .deb files stay in the pool PER ARCHITECTURE. Every GitHub Pages
+# deploy re-uploads the whole tree, so the pool's size is paid on every publish,
+# not once; and the published-site cap is 1 GB against ~11.4 MB per package. Ten
+# per architecture is ~114 MB each — ~228 MB for the two we build — and GitHub
+# Releases still holds every historical .deb for anyone who needs one.
+#
+# Per-architecture rather than overall so that KEEP still means "ten releases".
+# Counted across the whole pool, adding arm64 would have silently halved the
+# history the repository serves.
 KEEP=10
 
 REPO_DIR=
-DEB=
+# Newline-separated, because POSIX sh has no arrays and the parse loop below is
+# already using the positional parameters. Paths may contain spaces; a path
+# containing a NEWLINE is the one thing this cannot carry, and nothing produces
+# one.
+DEBS=
 VERSION=
 IN_DOCKER=no
 DOCKER_IMAGE=debian:bookworm
 
 usage() {
     cat <<'USAGE'
-Usage: apt-repo-publish.sh --repo DIR --deb FILE --version X.Y.Z [options]
+Usage: apt-repo-publish.sh --repo DIR --deb FILE [--deb FILE ...] --version X.Y.Z [options]
 
-Adds one .deb to an APT repository tree, prunes, regenerates the index and
-signs it. Idempotent: a second run with the same pool changes nothing.
+Adds one .deb per architecture to an APT repository tree, prunes, regenerates
+the index and signs it. Idempotent: a second run with the same pool changes
+nothing.
 
 Required:
   --repo DIR       the repository tree (a checkout of apt-platypusgit)
-  --deb FILE       the .deb to publish
-  --version X.Y.Z  the version that .deb carries
+  --deb FILE       a .deb to publish; repeat once per architecture. The
+                   architecture is read out of the package, never guessed from
+                   the filename
+  --version X.Y.Z  the version those .deb files carry
 
 Options:
-  --keep N         .deb files to retain in the pool (default 10)
+  --keep N         .deb files to retain in the pool, per architecture
+                   (default 10)
   --docker         re-exec inside debian:bookworm; for macOS, where neither
                    apt-ftparchive nor gpg exists
   --image NAME     image for --docker (default debian:bookworm)
@@ -88,10 +111,17 @@ say() { printf '%s\n' "$*"; }
 warn() { printf '%s\n' "$*" >&2; }
 die() { warn "apt-repo-publish: $*"; exit 1; }
 
+# The separator DEBS is built with, and what `IFS` is set to when iterating it.
+# Every such loop restores the normal IFS for its BODY and puts the newline-only
+# one back at the bottom, because a body running with IFS=newline splits command
+# substitutions wrongly — which is a silent misparse, not an error.
+NL='
+'
+
 while [ $# -gt 0 ]; do
     case "$1" in
         --repo) [ $# -ge 2 ] || die "--repo needs a value"; REPO_DIR="$2"; shift 2 ;;
-        --deb) [ $# -ge 2 ] || die "--deb needs a value"; DEB="$2"; shift 2 ;;
+        --deb) [ $# -ge 2 ] || die "--deb needs a value"; DEBS="${DEBS}${DEBS:+$NL}$2"; shift 2 ;;
         --version) [ $# -ge 2 ] || die "--version needs a value"; VERSION="$2"; shift 2 ;;
         --keep) [ $# -ge 2 ] || die "--keep needs a value"; KEEP="$2"; shift 2 ;;
         --docker) IN_DOCKER=yes; shift ;;
@@ -103,10 +133,18 @@ while [ $# -gt 0 ]; do
 done
 
 [ -n "$REPO_DIR" ] || die "--repo is required"
-[ -n "$DEB" ] || die "--deb is required"
+[ -n "$DEBS" ] || die "--deb is required (repeat it once per architecture)"
 [ -n "$VERSION" ] || die "--version is required"
 [ -d "$REPO_DIR" ] || die "not a directory: $REPO_DIR"
-[ -f "$DEB" ] || die "not a file: $DEB"
+
+OLDIFS=$IFS
+IFS=$NL
+for deb in $DEBS; do
+    IFS=$OLDIFS
+    [ -f "$deb" ] || die "not a file: $deb"
+    IFS=$NL
+done
+IFS=$OLDIFS
 
 case "$KEEP" in
     ''|*[!0-9]*) die "--keep must be a positive integer, got '$KEEP'" ;;
@@ -118,41 +156,74 @@ esac
 #
 # The private key travels as an environment variable, so it never appears in
 # `docker inspect`'s command line. The repo is mounted read-write (it is the
-# output); the .deb and this script read-only.
+# output); the .deb files and this script read-only.
+#
+# No --platform: an amd64 `.deb` is just a file to dpkg-deb and apt-ftparchive,
+# so an arm64 container indexes it correctly. Only the SMOKE client has to match
+# the package's architecture, and that is a different script.
 # ---------------------------------------------------------------------------
 if [ "$IN_DOCKER" = yes ]; then
     command -v docker > /dev/null 2>&1 || die "--docker needs docker on PATH"
     self="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
     repo_abs="$(cd "$REPO_DIR" && pwd)"
-    deb_abs="$(cd "$(dirname "$DEB")" && pwd)/$(basename "$DEB")"
-    say "apt-repo-publish: re-execing in $DOCKER_IMAGE"
-    exec docker run --rm \
-        -v "$repo_abs:/repo" \
-        -v "$deb_abs:/pkg.deb:ro" \
+
+    # `$@` becomes the docker argument list, one `-v` per .deb. Each host path
+    # is quoted into its own `-v`, so a directory with a space in it survives;
+    # the container-internal names are /pkg-1.deb, /pkg-2.deb, … precisely so
+    # that the inner shell has nothing awkward to re-quote.
+    set -- --rm -v "$repo_abs:/repo"
+    inner=
+    n=0
+    OLDIFS=$IFS
+    IFS=$NL
+    for deb in $DEBS; do
+        IFS=$OLDIFS
+        n=$((n + 1))
+        deb_abs="$(cd "$(dirname "$deb")" && pwd)/$(basename "$deb")"
+        set -- "$@" -v "$deb_abs:/pkg-$n.deb:ro"
+        inner="$inner /pkg-$n.deb"
+        IFS=$NL
+    done
+    IFS=$OLDIFS
+
+    set -- "$@" \
         -v "$self:/apt-repo-publish.sh:ro" \
         -e APT_GPG_PRIVATE_KEY \
         -e APT_GPG_PASSPHRASE \
-        -e APT_GPG_KEY_ID \
+        -e APT_GPG_KEY_ID
+
+    say "apt-repo-publish: re-execing in $DOCKER_IMAGE with $n .deb file(s)"
+    # shellcheck disable=SC2086 # $inner is a list of container-internal paths
+    # this script chose itself; word splitting is exactly what is wanted.
+    exec docker run "$@" \
         "$DOCKER_IMAGE" \
         sh -c 'set -eu
+               version="$1"; keep="$2"; shift 2
                export DEBIAN_FRONTEND=noninteractive
                apt-get update -qq
                apt-get install -y -qq --no-install-recommends apt-utils gnupg > /dev/null
-               exec sh /apt-repo-publish.sh --repo /repo --deb /pkg.deb \
-                    --version "$1" --keep "$2"' \
-        sh "$VERSION" "$KEEP"
+               args=""
+               for d in "$@"; do args="$args --deb $d"; done
+               exec sh /apt-repo-publish.sh --repo /repo \
+                   --version "$version" --keep "$keep" $args' \
+        sh "$VERSION" "$KEEP" $inner
 fi
 
 command -v apt-ftparchive > /dev/null 2>&1 \
     || die "apt-ftparchive not found (apt-utils). On macOS, pass --docker."
 command -v gpg > /dev/null 2>&1 \
     || die "gpg not found. On macOS, pass --docker."
+# Part of `dpkg`, so it is present wherever the two above are — demanded by name
+# so that if it ever is not, the failure says which tool rather than surfacing as
+# a package with an empty architecture.
+command -v dpkg-deb > /dev/null 2>&1 \
+    || die "dpkg-deb not found (dpkg). On macOS, pass --docker."
 
 POOL_DIR="$REPO_DIR/pool/$COMPONENT/$(printf '%s' "$PKG" | cut -c1)/$PKG"
 DIST_DIR="$REPO_DIR/dists/$SUITE"
-BIN_DIR="$DIST_DIR/$COMPONENT/binary-$ARCH"
+COMPONENT_DIR="$DIST_DIR/$COMPONENT"
 
-mkdir -p "$POOL_DIR" "$BIN_DIR"
+mkdir -p "$POOL_DIR" "$COMPONENT_DIR"
 
 # ---------------------------------------------------------------------------
 # Key material.
@@ -163,8 +234,10 @@ mkdir -p "$POOL_DIR" "$BIN_DIR"
 # GNUPGHOME, hence the 0700.
 # ---------------------------------------------------------------------------
 TMP_GNUPG=
+TMP_WORK=
 cleanup() {
     [ -n "$TMP_GNUPG" ] && rm -rf "$TMP_GNUPG"
+    [ -n "$TMP_WORK" ] && rm -rf "$TMP_WORK"
     return 0
 }
 trap cleanup EXIT INT TERM
@@ -195,59 +268,168 @@ gpg --batch --yes --export "$KEY_ID" > "$REPO_DIR/key.gpg"
 gpg --batch --yes --armor --export "$KEY_ID" > "$REPO_DIR/key.asc"
 
 # ---------------------------------------------------------------------------
-# Pool: add, then prune.
+# Pool: add, then prune — one .deb and one prune window per architecture.
+#
+# The architecture is READ OUT OF THE PACKAGE, never parsed from the filename.
+# The release assets are named `PlatypusGit_<arch>.deb` by a `cp` in
+# release.yml, which makes the filename a convention a human can get wrong;
+# `dpkg-deb -f` is the package itself saying what it is, and a mislabelled pool
+# entry is invisible until an arm64 machine installs an amd64 binary.
+#
+# TWO PASSES: every .deb is read and checked before any of them is copied, so a
+# bad argument list leaves the pool exactly as it found it. One pass would pool
+# the first package and then refuse the second, which is the worst of both — a
+# failed run that still changed the tree it is about to be re-run against.
 # ---------------------------------------------------------------------------
-target="$POOL_DIR/${PKG}_${VERSION}_${ARCH}.deb"
-cp "$DEB" "$target"
-say "apt-repo-publish: pooled $(basename "$target")"
+# Split in two so that `die` is never reached from inside a `$(...)`, where its
+# `exit 1` would end the subshell and leave the caller carrying on with an empty
+# architecture. Same trap release.yml's signature-reading `emit()` is written
+# around.
+deb_arch() {
+    dpkg-deb -f "$1" Architecture 2> /dev/null | tr -d '[:space:]'
+}
+check_arch() {
+    case "$1" in
+        '') die "no Architecture field in $2 — is it a .deb?" ;;
+        *[!a-z0-9-]*) die "implausible architecture '$1' in $2" ;;
+    esac
+}
+
+seen_arches=
+OLDIFS=$IFS
+IFS=$NL
+for deb in $DEBS; do
+    IFS=$OLDIFS
+    arch="$(deb_arch "$deb")"
+    check_arch "$arch" "$deb"
+    # Two packages of the same architecture would write the same pool filename,
+    # so the second would replace the first and the run would report success
+    # having published one architecture fewer than it was handed.
+    case " $seen_arches " in
+        *" $arch "*) die "two --deb files are both $arch; pass one per architecture" ;;
+    esac
+    seen_arches="$seen_arches${seen_arches:+ }$arch"
+    IFS=$NL
+done
+
+for deb in $DEBS; do
+    IFS=$OLDIFS
+    arch="$(deb_arch "$deb")"
+    check_arch "$arch" "$deb"
+    target="$POOL_DIR/${PKG}_${VERSION}_${arch}.deb"
+    cp "$deb" "$target"
+    say "apt-repo-publish: pooled $(basename "$target")"
+    IFS=$NL
+done
+IFS=$OLDIFS
+
+# Every filename in the pool was written by the loop above as
+# <pkg>_<version>_<arch>.deb, so the last underscore-separated field IS the
+# architecture — no second source of truth to drift.
+# shellcheck disable=SC2012 # `ls` is safe here: none of those names contains
+# whitespace, and `find` gives no ordering, which the prune loop needs.
+pool_arches() {
+    ls "$POOL_DIR"/*.deb 2> /dev/null \
+        | sed -n 's|.*_\([^_/]*\)\.deb$|\1|p' \
+        | sort -u
+}
 
 # `sort -V` orders by the version embedded in the filename. It is not dpkg's
 # comparison algorithm and the two can disagree on exotic versions; release tags
 # are plain X.Y.Z (release.yml strips a leading v), where they agree.
 # `head -n -N` is GNU coreutils, which is what Debian and the runners have.
+#
+# Pruned PER ARCHITECTURE. Across the whole pool, `--keep 10` with two
+# architectures would mean five releases of each, and the first arm64 publish
+# would quietly delete half of amd64's history.
 pruned=0
-# shellcheck disable=SC2012 # `ls` is safe here: every filename in this
-# directory was written by this script as <pkg>_<version>_<arch>.deb, so none
-# contains whitespace — and `find` gives no ordering, which is the whole point.
-for old in $(ls "$POOL_DIR"/*.deb 2>/dev/null | sort -V | head -n -"$KEEP"); do
-    rm -f "$old"
-    say "apt-repo-publish: pruned $(basename "$old") (keeping newest $KEEP)"
-    pruned=$((pruned + 1))
+for arch in $(pool_arches); do
+    # shellcheck disable=SC2012 # see pool_arches
+    for old in $(ls "$POOL_DIR"/*_"$arch".deb 2> /dev/null | sort -V | head -n -"$KEEP"); do
+        rm -f "$old"
+        say "apt-repo-publish: pruned $(basename "$old") (keeping newest $KEEP per architecture)"
+        pruned=$((pruned + 1))
+    done
 done
 if [ "$pruned" -eq 0 ]; then
     say "apt-repo-publish: nothing to prune"
 fi
 
+# One space-separated list, used for the loop below and verbatim as the
+# `Architectures:` line. `sort -u` makes it deterministic, which matters because
+# Release is compared against nothing but is read by humans.
+ARCHES="$(pool_arches | tr '\n' ' ')"
+ARCHES="${ARCHES% }"
+[ -n "$ARCHES" ] || die "the pool holds no .deb files — nothing to index"
+say "apt-repo-publish: architectures in the pool: $ARCHES"
+
 # ---------------------------------------------------------------------------
 # Packages, and the no-op short-circuit.
 #
-# Generated to a temp file and compared BEFORE anything else is touched.
+# Generated to temp files and compared BEFORE anything else is touched.
 # `apt-ftparchive release` stamps a Date: field, so Release differs on every run
 # by construction — comparing the tree would never short-circuit. Packages is
 # deterministic, so it is the honest thing to compare, and an unchanged pool
 # therefore leaves the whole tree untouched and `git diff --quiet` clean.
 #
+# EVERY architecture has to be unchanged for the short-circuit to fire, and a
+# `binary-<arch>` directory for an architecture the pool no longer holds counts
+# as a change: leaving it would keep a stale Packages listed inside a freshly
+# signed Release, which is the shape of index corruption that reads to a client
+# as a hash mismatch it can do nothing about.
+#
 # Run from the repo root so `Filename:` is repo-relative, which is how apt
 # resolves it.
 # ---------------------------------------------------------------------------
-tmp_pkgs="$(mktemp)"
-( cd "$REPO_DIR" && apt-ftparchive --arch "$ARCH" packages "pool" ) > "$tmp_pkgs"
+TMP_WORK="$(mktemp -d)"
 
-[ -s "$tmp_pkgs" ] || { rm -f "$tmp_pkgs"; die "apt-ftparchive produced an empty Packages"; }
+changed=no
+for arch in $ARCHES; do
+    ( cd "$REPO_DIR" && apt-ftparchive --arch "$arch" packages "pool" ) > "$TMP_WORK/$arch"
+    [ -s "$TMP_WORK/$arch" ] || die "apt-ftparchive produced an empty Packages for $arch"
+    if ! cmp -s "$TMP_WORK/$arch" "$COMPONENT_DIR/binary-$arch/Packages" 2> /dev/null; then
+        changed=yes
+    fi
+done
 
-if [ -f "$BIN_DIR/Packages" ] && cmp -s "$tmp_pkgs" "$BIN_DIR/Packages"; then
-    rm -f "$tmp_pkgs"
-    say "apt-repo-publish: Packages unchanged — already up to date, index left alone"
+# Directories for architectures that are no longer in the pool.
+stale=
+for dir in "$COMPONENT_DIR"/binary-*; do
+    [ -d "$dir" ] || continue
+    dir_arch="${dir##*/binary-}"
+    case " $ARCHES " in
+        *" $dir_arch "*) continue ;;
+    esac
+    stale="$stale$NL$dir"
+    changed=yes
+done
+
+if [ "$changed" = no ]; then
+    say "apt-repo-publish: Packages unchanged for every architecture — index left alone"
     exit 0
 fi
 
-mv "$tmp_pkgs" "$BIN_DIR/Packages"
-chmod 0644 "$BIN_DIR/Packages"
-# -n omits the filename and timestamp from the gzip header. Without it every run
-# produces different bytes for identical content, and the short-circuit above
-# would be dead code.
-gzip -n -9 -c "$BIN_DIR/Packages" > "$BIN_DIR/Packages.gz"
-say "apt-repo-publish: wrote $(grep -c '^Package:' "$BIN_DIR/Packages") package(s) to the index"
+OLDIFS=$IFS
+IFS=$NL
+for dir in $stale; do
+    IFS=$OLDIFS
+    rm -rf "$dir"
+    say "apt-repo-publish: removed $(basename "$dir") — no such architecture in the pool"
+    IFS=$NL
+done
+IFS=$OLDIFS
+
+for arch in $ARCHES; do
+    bin_dir="$COMPONENT_DIR/binary-$arch"
+    mkdir -p "$bin_dir"
+    mv "$TMP_WORK/$arch" "$bin_dir/Packages"
+    chmod 0644 "$bin_dir/Packages"
+    # -n omits the filename and timestamp from the gzip header. Without it every
+    # run produces different bytes for identical content, and the short-circuit
+    # above would be dead code.
+    gzip -n -9 -c "$bin_dir/Packages" > "$bin_dir/Packages.gz"
+    say "apt-repo-publish: $arch — $(grep -c '^Package:' "$bin_dir/Packages") package(s) indexed"
+done
 
 # ---------------------------------------------------------------------------
 # Release, InRelease, Release.gpg.
@@ -276,7 +458,7 @@ apt-ftparchive \
     -o "APT::FTPArchive::Release::Label=$LABEL" \
     -o "APT::FTPArchive::Release::Suite=$SUITE" \
     -o "APT::FTPArchive::Release::Codename=$SUITE" \
-    -o "APT::FTPArchive::Release::Architectures=$ARCH" \
+    -o "APT::FTPArchive::Release::Architectures=$ARCHES" \
     -o "APT::FTPArchive::Release::Components=$COMPONENT" \
     -o "APT::FTPArchive::Release::Description=$DESCRIPTION" \
     release "$DIST_DIR" > "$tmp_rel"

--- a/scripts/apt-repo-seed/index.html
+++ b/scripts/apt-repo-seed/index.html
@@ -66,7 +66,7 @@
   <p class="lead">
     The signed Debian/Ubuntu package repository for
     <a href="https://www.platypusgit.com/">platypusgit</a>, a developer-focused
-    git desktop app. amd64, one suite (<code>stable</code>).
+    git desktop app. amd64 and arm64, one suite (<code>stable</code>).
   </p>
 
   <h2>Install</h2>
@@ -81,12 +81,12 @@
 curl -fsSL https://apt.platypusgit.com/key.gpg \
   | sudo tee /etc/apt/keyrings/platypusgit.gpg &gt; /dev/null
 sudo chmod 0644 /etc/apt/keyrings/platypusgit.gpg
-sudo tee /etc/apt/sources.list.d/platypusgit.sources &gt; /dev/null &lt;&lt;'EOF'
+sudo tee /etc/apt/sources.list.d/platypusgit.sources &gt; /dev/null &lt;&lt;EOF
 Types: deb
 URIs: https://apt.platypusgit.com
 Suites: stable
 Components: main
-Architectures: amd64
+Architectures: $(dpkg --print-architecture)
 Signed-By: /etc/apt/keyrings/platypusgit.gpg
 EOF
 sudo apt update &amp;&amp; sudo apt install platypusgit</pre>
@@ -116,10 +116,11 @@ sudo apt update &amp;&amp; sudo apt install platypusgit</pre>
 
   <h2>What is in here</h2>
   <pre>dists/stable/InRelease                      signed index
-dists/stable/main/binary-amd64/Packages     the package list
+dists/stable/main/binary-amd64/Packages     the package list, amd64
+dists/stable/main/binary-arm64/Packages     the package list, arm64
 pool/main/p/platypusgit/                   the .deb files</pre>
   <p>
-    The pool keeps the ten most recent releases. Older versions stay available
+    The pool keeps the ten most recent releases per architecture. Older versions stay available
     as
     <a href="https://github.com/jonassaa/platypusgit/releases">GitHub release
     assets</a> — nothing is deleted there.

--- a/scripts/apt-repo-smoke.sh
+++ b/scripts/apt-repo-smoke.sh
@@ -33,6 +33,7 @@ set -eu
 
 PKG=platypusgit
 SUITE=stable
+COMPONENT=main
 PORT=8000
 
 # The path both this script and src-tauri/src/update.rs care about. The
@@ -45,13 +46,20 @@ KEYRING_PATH=/etc/apt/keyrings/platypusgit.gpg
 CLIENT_IMAGE=debian:bookworm
 SERVE_IMAGE=python:3-slim
 
-# The repository ships amd64 only, so the client must BE amd64 or apt will fetch
-# the index, verify it, and then report "Unable to locate package" — which is
-# what happens by default on an Apple Silicon Mac, where debian:bookworm runs
-# arm64. Pinned rather than inferred: on an amd64 CI runner this is a no-op, and
-# on a developer's Mac it is the difference between a real test and a confusing
-# one. Change it when an arm64 .deb actually exists (#266).
-PLATFORM=linux/amd64
+# ONE RUN PROVES ONE ARCHITECTURE. The client must BE the architecture under
+# test or apt fetches the index, verifies it, and then reports "Unable to locate
+# package" — which reads as a broken repository rather than a wrong client. That
+# is what happens by default on an Apple Silicon Mac, where debian:bookworm runs
+# arm64.
+#
+# So the architecture is pinned rather than inferred, and `--platform` follows it
+# unless it is given explicitly. Callers that publish several architectures run
+# this once per architecture (release.yml's `apt-publish` does); running it once
+# and calling the repository proven is the mistake this pairing exists to make
+# hard.
+ARCH=amd64
+PLATFORM=
+PLATFORM_EXPLICIT=no
 
 REPO_DIR=
 VERSION=
@@ -85,14 +93,17 @@ Options:
                      use minutes for a live check, Pages publishes async)
   --installer PATH   install by running this script (the real one-liner) instead
                      of a hand-written sources file
+  --arch ARCH        the architecture to prove installable (default amd64). One
+                     run proves one architecture: it reads that architecture's
+                     Packages and installs in a client of that architecture
   --expect-git       also assert Depends: git resolved, and that Section: vcs and
                      Provides/Replaces/Conflicts are in the control data. Only true of a
                      .deb built after that config change, so it is opt-in.
   --client-image IMG default debian:bookworm
   --serve-image IMG  default python:3-slim
-  --platform P       docker platform for the client (default linux/amd64; the
-                     repository ships amd64 only, and an arm64 client would fetch
-                     the index and then fail to locate the package)
+  --platform P       docker platform for the client (default linux/<arch>).
+                     amd64 and arm64 are spelled the same by docker and by
+                     Debian, so this is an escape hatch for one that is not
   -h, --help         this text
 USAGE
 }
@@ -108,10 +119,11 @@ while [ $# -gt 0 ]; do
         --wait) [ $# -ge 2 ] || die "--wait needs a value"; WAIT_SECS="$2"; shift 2 ;;
         --version) [ $# -ge 2 ] || die "--version needs a value"; VERSION="$2"; shift 2 ;;
         --installer) [ $# -ge 2 ] || die "--installer needs a value"; INSTALLER="$2"; shift 2 ;;
+        --arch) [ $# -ge 2 ] || die "--arch needs a value"; ARCH="$2"; shift 2 ;;
         --expect-git) EXPECT_GIT=yes; shift ;;
         --client-image) [ $# -ge 2 ] || die "--client-image needs a value"; CLIENT_IMAGE="$2"; shift 2 ;;
         --serve-image) [ $# -ge 2 ] || die "--serve-image needs a value"; SERVE_IMAGE="$2"; shift 2 ;;
-        --platform) [ $# -ge 2 ] || die "--platform needs a value"; PLATFORM="$2"; shift 2 ;;
+        --platform) [ $# -ge 2 ] || die "--platform needs a value"; PLATFORM="$2"; PLATFORM_EXPLICIT=yes; shift 2 ;;
         -h|--help) usage; exit 0 ;;
         --) shift; break ;;
         *) die "unknown option '$1' (try --help)" ;;
@@ -122,6 +134,12 @@ done
 case "$WAIT_SECS" in
     ''|*[!0-9]*) die "--wait must be a positive integer, got '$WAIT_SECS'" ;;
 esac
+case "$ARCH" in
+    ''|*[!a-z0-9-]*) die "--arch must be a Debian architecture name, got '$ARCH'" ;;
+esac
+if [ "$PLATFORM_EXPLICIT" = no ]; then
+    PLATFORM="linux/$ARCH"
+fi
 
 if [ -n "$EXTERNAL_URL" ] && [ -n "$REPO_DIR" ]; then
     die "--repo and --url are alternatives, not both"
@@ -132,6 +150,11 @@ if [ -z "$EXTERNAL_URL" ]; then
     [ -f "$REPO_DIR/dists/$SUITE/InRelease" ] \
         || die "$REPO_DIR has no dists/$SUITE/InRelease — run apt-repo-publish.sh first"
     [ -f "$REPO_DIR/key.gpg" ] || die "$REPO_DIR has no key.gpg"
+    # Named here rather than discovered as "Unable to locate package" eight
+    # container-minutes later. A gate that says "you asked for arm64 and this
+    # tree has no arm64 index" is the difference between a typo and a hunt.
+    [ -f "$REPO_DIR/dists/$SUITE/$COMPONENT/binary-$ARCH/Packages" ] \
+        || die "$REPO_DIR has no $COMPONENT/binary-$ARCH index — was a $ARCH .deb published?"
 fi
 if [ -n "$INSTALLER" ]; then
     [ -f "$INSTALLER" ] || die "not a file: $INSTALLER"
@@ -221,15 +244,20 @@ ok "repository reachable at $PG_BASE_URL (after ${i}s)"
 #
 # So wait for the expected version to actually be LISTED. In local mode the pool
 # was just built, so this returns on the first try and costs nothing.
+#
+# Read from THIS architecture's index, not from a fixed one: with two of them
+# published, `binary-amd64` answering is no evidence at all that `binary-arm64`
+# is there — and the arm64 leg would then wait on the wrong file, pass, and
+# install nothing.
 i=0
-until curl -fsS "$PG_BASE_URL/dists/stable/main/binary-amd64/Packages" 2> /dev/null \
+until curl -fsS "$PG_BASE_URL/dists/stable/main/binary-$PG_ARCH/Packages" 2> /dev/null \
     | grep -qx "Version: $PG_EXPECT_VERSION"; do
     i=$((i + 1))
     [ "$i" -lt "$PG_WAIT_SECS" ] \
-        || fail "index at $PG_BASE_URL never listed version $PG_EXPECT_VERSION after ${PG_WAIT_SECS}s"
+        || fail "$PG_ARCH index at $PG_BASE_URL never listed version $PG_EXPECT_VERSION after ${PG_WAIT_SECS}s"
     sleep 1
 done
-ok "index lists version $PG_EXPECT_VERSION (after ${i}s)"
+ok "$PG_ARCH index lists version $PG_EXPECT_VERSION (after ${i}s)"
 
 # --- install ---------------------------------------------------------------
 
@@ -247,7 +275,7 @@ Types: deb
 URIs: $PG_BASE_URL
 Suites: stable
 Components: main
-Architectures: amd64
+Architectures: $PG_ARCH
 Signed-By: $PG_KEYRING_PATH
 SOURCES
     apt-get update -qq
@@ -289,6 +317,16 @@ got="$(awk '/^Version:/ { print $2; exit }' /tmp/status)"
 [ "$got" = "$PG_EXPECT_VERSION" ] \
     || fail "installed version is '$got', expected '$PG_EXPECT_VERSION'"
 ok "dpkg reports version $got"
+
+# The assertion the whole --arch pairing exists for. In installer mode the
+# sources file was written from the container's own `dpkg --print-architecture`,
+# so this compares what the client asked for against what the repository served
+# — the one thing a second architecture can get wrong without any other symptom
+# until someone's machine runs the wrong binary.
+got_arch="$(awk '/^Architecture:/ { print $2; exit }' /tmp/status)"
+[ "$got_arch" = "$PG_ARCH" ] \
+    || fail "installed architecture is '$got_arch', expected '$PG_ARCH'"
+ok "dpkg reports architecture $got_arch"
 
 [ -x /usr/bin/pgit ] || fail "/usr/bin/pgit is missing or not executable"
 ok "/usr/bin/pgit is executable"
@@ -359,12 +397,13 @@ else
     say "apt-repo-smoke: installing from the live $EXTERNAL_URL (waiting up to ${WAIT_SECS}s)"
 fi
 
-say "apt-repo-smoke: installing in $CLIENT_IMAGE on $PLATFORM (mode: $MODE)"
+say "apt-repo-smoke: installing $ARCH in $CLIENT_IMAGE on $PLATFORM (mode: $MODE)"
 set -- \
     --rm --network "$NETWORK_ARG" --platform "$PLATFORM" \
     -v "$WORK/client.sh:/client.sh:ro" \
     -e "PG_WAIT_SECS=$WAIT_SECS" \
     -e "PG_BASE_URL=$BASE_URL" \
+    -e "PG_ARCH=$ARCH" \
     -e "PG_EXPECT_VERSION=$VERSION" \
     -e "PG_EXPECT_GIT=$EXPECT_GIT" \
     -e "PG_MODE=$MODE" \

--- a/scripts/install-platypusgit.sh
+++ b/scripts/install-platypusgit.sh
@@ -16,9 +16,9 @@
 # reads stdin — stdin is the script itself, so there are no prompts and every
 # choice is a flag or an environment variable.
 #
-# Debian and Ubuntu only, amd64 only. Anything else is told so and pointed at
-# the AppImage rather than quietly handed a different package format than the
-# one this script advertises.
+# Debian and Ubuntu only, on the architectures we build (amd64 and arm64).
+# Anything else is told so and pointed at the AppImage rather than quietly handed
+# a different package format than the one this script advertises.
 #
 # Spec: docs/superpowers/specs/2026-08-26-apt-repository-spec.md
 set -eu
@@ -29,7 +29,11 @@ DEFAULT_APT_URL=https://apt.platypusgit.com
 
 SUITE=stable
 COMPONENT=main
-WANT_ARCH=amd64
+# The architectures release.yml's `linux` matrix builds and apt-publish pools
+# (#266). Kept as a list rather than a single value so adding the next one is a
+# word here — the sources file below is written from the DETECTED architecture,
+# not from this list, so an existing amd64 install is unaffected by a widening.
+SUPPORTED_ARCHES="amd64 arm64"
 
 # `Signed-By:` points at the keyring, so these two paths travel together.
 #
@@ -69,8 +73,8 @@ Options:
 Environment:
   PLATYPUSGIT_APT_URL   same as --apt-url
 
-Debian/Ubuntu on amd64. On any other system this script tells you so and stops;
-use the AppImage instead — it also updates itself in-app.
+Debian/Ubuntu on amd64 or arm64. On any other system this script tells you so and
+stops; use the AppImage instead — it also updates itself in-app.
 USAGE
 }
 
@@ -103,7 +107,7 @@ done
 APT_URL="${APT_URL%/}"
 [ -n "$APT_URL" ] || die "--apt-url cannot be empty"
 
-# ─── is this even a Debian-family amd64 box? ─────────────────────────────────
+# ─── is this even a Debian-family box we build for? ─────────────────────────
 
 # Detect-then-refuse, never substitute. A script that advertises an apt install
 # and silently drops an AppImage somewhere is the kind of surprise that costs
@@ -143,17 +147,21 @@ detect_arch() {
 }
 
 ARCH="$(detect_arch)"
-# Widening this is #266 (build + publish an arm64 .deb). Until then, a sentence
-# beats apt reporting "Unable to locate package" after a successful update.
-if [ "$ARCH" != "$WANT_ARCH" ]; then
-    warn "install-platypusgit: platypusgit is not built for '$ARCH' yet — only $WANT_ARCH."
-    warn "install-platypusgit: adding the repository would leave apt with nothing to install."
-    warn ""
-    warn "Use the AppImage if one exists for your machine, or build from source:"
-    warn ""
-    warn "    $APPIMAGE_URL"
-    exit 1
-fi
+# A sentence beats apt reporting "Unable to locate package" after a successful
+# update — adding a repository that cannot serve this machine is worse than not
+# adding it, because the failure then looks like a broken repository.
+case " $SUPPORTED_ARCHES " in
+    *" $ARCH "*) ;;
+    *)
+        warn "install-platypusgit: platypusgit is not built for '$ARCH' — only $SUPPORTED_ARCHES."
+        warn "install-platypusgit: adding the repository would leave apt with nothing to install."
+        warn ""
+        warn "Use the AppImage if one exists for your machine, or build from source:"
+        warn ""
+        warn "    $APPIMAGE_URL"
+        exit 1
+        ;;
+esac
 
 # ─── how we fetch, and how we get root ───────────────────────────────────────
 
@@ -235,9 +243,14 @@ $SUDO install -m 0644 "$tmp_key" "$KEYRING_PATH"
 say "install-platypusgit: signing key -> $KEYRING_PATH"
 
 # deb822 rather than a one-line entry: supported since apt 1.1 (Debian 9,
-# Ubuntu 16.04), and readable by whoever inherits the machine. `Architectures:`
-# is explicit so that when an arm64 build exists, an amd64 box keeps asking for
-# amd64 instead of warning on every update about an index it cannot use.
+# Ubuntu 16.04), and readable by whoever inherits the machine.
+#
+# `Architectures:` is written from the DETECTED architecture, not from
+# SUPPORTED_ARCHES, and that is what made adding arm64 (#266) a no-op for
+# everyone already installed: an amd64 box keeps asking for amd64 rather than
+# starting to fetch a second index it has no use for. It is also why widening
+# the list above needs no migration — the sources file describes the machine,
+# not the repository.
 printf '%s\n' "$SOURCES_BODY" | $SUDO tee "$SOURCES_PATH" > /dev/null
 say "install-platypusgit: sources -> $SOURCES_PATH"
 

--- a/site/src/data/site.ts
+++ b/site/src/data/site.ts
@@ -17,7 +17,7 @@ export const site = {
 export const downloads = [
   { key: 'macos', label: 'macOS', anchor: '/download/#macos', note: 'Apple Silicon & Intel · .dmg', available: true },
   { key: 'windows', label: 'Windows', anchor: '/download/#windows', note: 'Windows 10 & 11 · Store, .msi or Scoop', available: true },
-  { key: 'linux', label: 'Linux', anchor: '/download/#linux', note: '.deb & AppImage', available: true },
+  { key: 'linux', label: 'Linux', anchor: '/download/#linux', note: 'x86_64 & arm64 · .deb & AppImage', available: true },
 ] as const;
 
 // Direct download links to the stable-named assets the release workflow
@@ -28,7 +28,19 @@ export const assets = {
   windowsMsi: releaseAsset('PlatypusGit_x64.msi'),
   linuxDeb: releaseAsset('PlatypusGit_amd64.deb'),
   linuxAppImage: releaseAsset('PlatypusGit_amd64.AppImage'),
+  linuxDebArm64: releaseAsset('PlatypusGit_arm64.deb'),
+  linuxAppImageArm64: releaseAsset('PlatypusGit_arm64.AppImage'),
 };
+
+// The Linux architectures release.yml's `linux` matrix builds (#266), in the
+// order the download page lists them. The `file` suffix is the Debian spelling
+// (it is what the release assets and the apt pool use); `label` is what a reader
+// recognises, which is not the same string — `uname -m` on the same machine says
+// `x86_64`/`aarch64`, and latest.json's updater keys use those.
+export const linuxArches = [
+  { key: 'amd64', label: 'x86_64 (Intel/AMD)', deb: assets.linuxDeb, appImage: assets.linuxAppImage },
+  { key: 'arm64', label: 'arm64 (aarch64)', deb: assets.linuxDebArm64, appImage: assets.linuxAppImageArm64 },
+] as const;
 
 // The Scoop bucket (#187, Windows half). Its own repo, like the Homebrew tap and
 // the apt repo — but unlike the apt repo it needs no host of its own, because

--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -3,7 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import CTAButton from '../components/CTAButton.astro';
 import CodeBlock from '../components/CodeBlock.astro';
 import OsIcon from '../components/OsIcon.astro';
-import { site, assets, apt, scoop, msStore } from '../data/site.ts';
+import { site, assets, apt, linuxArches, scoop, msStore } from '../data/site.ts';
 import { descriptions, softwareApplicationSchema, ORIGIN } from '../data/seo.ts';
 
 // The two installer URLs. Built from `site` in astro.config.mjs rather than
@@ -26,12 +26,12 @@ const aptManual = `sudo install -d -m 0755 /etc/apt/keyrings
 curl -fsSL ${apt.url}/key.gpg \\
   | sudo tee /etc/apt/keyrings/platypusgit.gpg > /dev/null
 sudo chmod 0644 /etc/apt/keyrings/platypusgit.gpg
-sudo tee /etc/apt/sources.list.d/platypusgit.sources > /dev/null <<'EOF'
+sudo tee /etc/apt/sources.list.d/platypusgit.sources > /dev/null <<EOF
 Types: deb
 URIs: ${apt.url}
 Suites: stable
 Components: main
-Architectures: amd64
+Architectures: $(dpkg --print-architecture)
 Signed-By: /etc/apt/keyrings/platypusgit.gpg
 EOF
 sudo apt update && sudo apt install ${apt.pkg}`;
@@ -102,7 +102,7 @@ const platforms = [
     label: 'Linux',
     iconSize: 20,
     blurb: 'One-line apt install, or a portable AppImage.',
-    specs: ['webkit2gtk 4.1 required', 'x86_64', 'apt handles updates'],
+    specs: ['webkit2gtk 4.1 required', 'x86_64 & arm64', 'apt handles updates'],
   },
 ] as const;
 ---
@@ -454,32 +454,53 @@ const platforms = [
                 </details>
               </article>
 
+              {/* Both architectures get their own button, filename and commands
+                  rather than one set with "substitute your architecture" in
+                  prose. The whole point of naming the file is that it can be
+                  copied; a reader on a Pi who has to edit the line first is a
+                  reader who can get it wrong. */}
               <article class="card">
                 <h3>AppImage</h3>
                 <p class="card-lead">Fedora, Arch, and anything not Debian-based.</p>
-                <CTAButton href={assets.linuxAppImage} external>Download .AppImage</CTAButton>
-                <p class="filename mono">PlatypusGit_amd64.AppImage</p>
-                <CodeBlock code={'chmod +x PlatypusGit_amd64.AppImage\n./PlatypusGit_amd64.AppImage'} lang="bash" />
+                {linuxArches.map((a) => (
+                  <div class="arch">
+                    <p class="arch-head mono">{a.label}</p>
+                    <CTAButton href={a.appImage} external>Download .AppImage</CTAButton>
+                    <p class="filename mono">PlatypusGit_{a.key}.AppImage</p>
+                    <CodeBlock
+                      code={`chmod +x PlatypusGit_${a.key}.AppImage\n./PlatypusGit_${a.key}.AppImage`}
+                      lang="bash"
+                    />
+                  </div>
+                ))}
                 <p class="card-note">
                   Download, make it executable, run — nothing is installed.
                   <strong>This is the only Linux build that updates itself:</strong> an AppImage can
                   replace its own file, so platypusgit offers the update in-app, which is exactly what the
                   <code>.deb</code> cannot do. Because nothing is installed and no hook executes, the
                   <a href="#cli"><code>pgit</code></a> command is a separate one-liner.
+                  Not sure which one you want? <code>uname -m</code> prints
+                  <code>x86_64</code> or <code>aarch64</code>.
                 </p>
               </article>
 
               <article class="card">
                 <h3>Debian package, by hand</h3>
                 <p class="card-lead">For an air-gapped box, or a one-off.</p>
-                <CTAButton href={assets.linuxDeb} external>Download .deb</CTAButton>
-                <p class="filename mono">PlatypusGit_amd64.deb</p>
-                <CodeBlock code={'sudo apt install ./PlatypusGit_amd64.deb'} lang="bash" />
+                {linuxArches.map((a) => (
+                  <div class="arch">
+                    <p class="arch-head mono">{a.label}</p>
+                    <CTAButton href={a.deb} external>Download .deb</CTAButton>
+                    <p class="filename mono">PlatypusGit_{a.key}.deb</p>
+                    <CodeBlock code={`sudo apt install ./PlatypusGit_${a.key}.deb`} lang="bash" />
+                  </div>
+                ))}
                 <p class="card-note">
                   The same package the repository serves, installed straight from the file. Updates are
                   then manual — repeat the download for every release, because apt has no repository to
                   upgrade from. platypusgit notices, and offers you the one-liner above rather than
-                  pretending <code>apt upgrade</code> will work.
+                  pretending <code>apt upgrade</code> will work. <code>dpkg --print-architecture</code>
+                  names the one your machine takes.
                 </p>
               </article>
             </>
@@ -772,6 +793,14 @@ const platforms = [
   .card-note a, .matrix-note a { color: var(--accent); }
   .filename { font-size: 11.5px; color: var(--fg-3); margin: var(--s-4) 0 0; }
   .card :global(.cta) { margin-top: var(--s-2); }
+
+  /* One block per Linux architecture (#266). A rule between them rather than a
+     heading level: the card already has an h3, and the two blocks are siblings
+     of equal weight, not sections under it. */
+  .arch + .arch { margin-top: var(--s-6); padding-top: var(--s-6);
+    border-top: 1px solid var(--border-0); }
+  .arch-head { font-size: 12px; font-weight: 600; letter-spacing: 0.02em;
+    color: var(--fg-2); margin: 0 0 var(--s-4); }
   /* A download button and a command are a sequence — get the file, then run the
      thing that consumes it — so they need air between them in either order. */
   .card :global(.codeblock) + :global(.cta) { margin-top: var(--s-5); }

--- a/test/linuxArches.test.ts
+++ b/test/linuxArches.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * The Linux architecture set is written down in five places that cannot see each
+ * other, and adding the second one (#266) is what turned that from a fact into a
+ * contract:
+ *
+ *   1. `release.yml`'s `linux` matrix — what actually gets BUILT.
+ *   2. `apt-publish`'s `--deb`/`--pattern` flags and its per-architecture gate —
+ *      what reaches the repository, and what is proven installable first.
+ *   3. `updater-manifest`'s `latest.json` keys — who is offered a self-update.
+ *   4. `install-platypusgit.sh`'s `SUPPORTED_ARCHES` — who the one-liner serves.
+ *   5. `site/src/data/site.ts`'s `linuxArches` — what the download page offers.
+ *
+ * Every drift between them is SILENT in a different way, and none of them fails
+ * a build:
+ *
+ *   - build it but not pool it: an asset nobody can `apt install`.
+ *   - pool it but not widen the installer: the one-liner refuses a package the
+ *     repository is serving.
+ *   - pool it but not gate it: the first proof it installs is a user's machine.
+ *   - build it but leave it out of latest.json: those installs never see an
+ *     update again, and report nothing wrong.
+ *   - build it but not link it: nobody finds it.
+ *
+ * So this suite reads all five and asserts they name the same architectures. It
+ * lives in `test/` for the same reason `shardSpecs.test.ts` does — it is a fact
+ * about the tree and about `.github/`, not about the frontend.
+ */
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+const RELEASE_YML = path.join(REPO_ROOT, ".github", "workflows", "release.yml");
+const INSTALLER = path.join(REPO_ROOT, "scripts", "install-platypusgit.sh");
+const SITE_DATA = path.join(REPO_ROOT, "site", "src", "data", "site.ts");
+
+const releaseYml = readFileSync(RELEASE_YML, "utf8");
+const installer = readFileSync(INSTALLER, "utf8");
+const siteData = readFileSync(SITE_DATA, "utf8");
+
+/**
+ * Debian's architecture name to the one Rust's `std::env::consts::ARCH` uses,
+ * which is what the updater plugin builds its `{os}-{arch}` lookup key from. Two
+ * names for one machine: the assets and the pool say `arm64`, `latest.json` says
+ * `aarch64`. Pinned here because getting it wrong publishes a manifest no client
+ * ever matches — which presents as "no update available", not as an error.
+ */
+const RUST_ARCH: Record<string, string> = {
+  amd64: "x86_64",
+  arm64: "aarch64",
+};
+
+/** The architectures the `linux` job's matrix actually builds. */
+function matrixArches(): string[] {
+  // Narrow to the `linux:` job first: `msix-build` has an `arch:` matrix too,
+  // and matching across the whole file would silently mix Windows' x64/arm64
+  // into the Linux set.
+  const job = releaseYml.match(/^ {2}linux:\n(?: {3,}.*\n| *\n)*/m);
+  if (!job) {
+    throw new Error(
+      "no `linux:` job found in .github/workflows/release.yml — the job was " +
+        "renamed or reindented, so this suite can no longer read its matrix",
+    );
+  }
+  const arches = [...job[0].matchAll(/^ +- arch: (\S+)$/gm)].map((m) => m[1]);
+  if (arches.length === 0) {
+    throw new Error(
+      "the `linux:` job has no `- arch:` matrix entries — if the matrix was " +
+        "replaced, this suite's five-way contract needs rewriting, not deleting",
+    );
+  }
+  return arches.sort();
+}
+
+/** The architectures `install-platypusgit.sh` will add the repository for. */
+function installerArches(): string[] {
+  const m = installer.match(/^SUPPORTED_ARCHES="([^"]+)"$/m);
+  if (!m) {
+    throw new Error(
+      "no SUPPORTED_ARCHES= line in scripts/install-platypusgit.sh — the " +
+        "installer's architecture gate moved",
+    );
+  }
+  return m[1].trim().split(/\s+/).sort();
+}
+
+/** The architectures the download page offers. */
+function siteArches(): string[] {
+  const block = siteData.match(/export const linuxArches = \[([\s\S]*?)\] as const;/);
+  if (!block) {
+    throw new Error(
+      "no `linuxArches` array in site/src/data/site.ts — the download page's " +
+        "architecture list moved",
+    );
+  }
+  return [...block[1].matchAll(/\{ key: '([^']+)'/g)].map((m) => m[1]).sort();
+}
+
+describe("the Linux architecture set", () => {
+  const arches = matrixArches();
+
+  it("builds at least amd64 and arm64", () => {
+    // A guard against the matrix being read as empty or half-read, which would
+    // make every set comparison below vacuously true.
+    expect(arches).toEqual(["amd64", "arm64"]);
+  });
+
+  it("gives every architecture its own runner", () => {
+    // Two legs on one runner would build the same bundle twice and attach it
+    // under two names — an arm64 asset that is quietly an amd64 binary.
+    const job = releaseYml.match(/^ {2}linux:\n(?: {3,}.*\n| *\n)*/m)![0];
+    const runners = [...job.matchAll(/^ +runner: (\S+)$/gm)].map((m) => m[1]);
+    expect(runners).toHaveLength(arches.length);
+    expect(new Set(runners).size).toBe(arches.length);
+  });
+
+  it("is the same set the one-line installer accepts", () => {
+    expect(installerArches()).toEqual(arches);
+  });
+
+  it("is the same set the download page offers", () => {
+    expect(siteArches()).toEqual(arches);
+  });
+
+  it("attaches a .deb and an .AppImage per architecture", () => {
+    // The attach step is templated on `matrix.arch`, so what this checks is that
+    // the stable names still carry the architecture at all — a rename back to a
+    // fixed `PlatypusGit_amd64.deb` would attach one leg's bundle twice.
+    expect(releaseYml).toContain(
+      "src-tauri/target/release/bundle/deb/PlatypusGit_${{ matrix.arch }}.deb",
+    );
+    expect(releaseYml).toContain(
+      "src-tauri/target/release/bundle/appimage/PlatypusGit_${{ matrix.arch }}.AppImage",
+    );
+  });
+
+  it("pools and gates every architecture in apt-publish", () => {
+    for (const arch of arches) {
+      expect(releaseYml).toContain(`--pattern PlatypusGit_${arch}.deb`);
+      expect(releaseYml).toContain(`--deb PlatypusGit_${arch}.deb`);
+    }
+    // The gate loop names them itself — one run of apt-repo-smoke.sh proves one
+    // architecture, so an architecture missing from this list is published
+    // without ever having been installed.
+    const gate = releaseYml.match(/^ +for arch in (.+); do$/m);
+    expect(gate?.[1].trim().split(/\s+/).sort()).toEqual(arches);
+  });
+
+  it("publishes updater keys for every architecture, in the Rust spelling", () => {
+    for (const arch of arches) {
+      const rust = RUST_ARCH[arch];
+      expect(
+        rust,
+        `no Rust architecture name recorded for '${arch}' — add it to RUST_ARCH, ` +
+          "because latest.json's keys are not the Debian spelling",
+      ).toBeTruthy();
+      for (const key of [`linux-${rust}`, `linux-${rust}-appimage`, `linux-${rust}-deb`]) {
+        expect(releaseYml).toContain(`"${key}":`);
+      }
+      // And the URL those keys point at is the DEBIAN-named asset.
+      expect(releaseYml).toContain(`PlatypusGit_${arch}.AppImage`);
+      expect(releaseYml).toContain(`PlatypusGit_${arch}.deb`);
+    }
+  });
+
+  it("collects one signature artifact per architecture", () => {
+    // The reason the signatures are artifacts at all: a matrix job's outputs
+    // collapse to one leg's values. A download step missing an architecture
+    // leaves `latest.json` unable to be built, which is the safe failure — a
+    // SHARED artifact name would be the unsafe one.
+    expect(releaseYml).toContain("name: linux-sigs-${{ matrix.arch }}");
+    for (const arch of arches) {
+      expect(releaseYml).toContain(`name: linux-sigs-${arch}`);
+      expect(releaseYml).toContain(`path: sigs/${arch}`);
+    }
+  });
+
+  it("verifies the live repository from every architecture after publishing", () => {
+    const job = releaseYml.match(/^ {2}apt-verify-live:\n(?: {3,}.*\n| *\n)*/m);
+    expect(job, "no `apt-verify-live:` job found in release.yml").toBeTruthy();
+    const verified = [...job![0].matchAll(/^ +- arch: (\S+)$/gm)].map((m) => m[1]).sort();
+    expect(verified).toEqual(arches);
+  });
+});


### PR DESCRIPTION
Closes #266.

The `linux` release job becomes a matrix over `ubuntu-22.04` and
`ubuntu-22.04-arm`, and the APT repository grows a second `binary-<arch>`
directory — which the layout was built for (#187 laid it out multi-arch on
purpose), so this is a directory rather than a migration.

## What changed

| | |
| --- | --- |
| `release.yml` | `linux` is a matrix; signatures travel as per-arch artifacts; `latest.json` gains the three `linux-aarch64*` keys; `apt-publish` pools and gates both architectures; `apt-verify-live` becomes a native two-arch matrix |
| `apt-repo-publish.sh` | `--deb` once per architecture, architecture read out of the package, `binary-<arch>` set derived from the pool, `KEEP` applied per architecture |
| `apt-repo-smoke.sh` | `--arch` drives both the index it waits on and the client platform, and it now asserts the installed architecture |
| `install-platypusgit.sh` | accepts amd64 and arm64 |
| download page, README, apt landing page, `distribution.md`, `releasing.md` | both architectures, and the reasoning behind the pinning choices |
| `test/linuxArches.test.ts` | new guard |

## Three decisions worth reviewing

**Both legs pin 22.04, and have to move together.** The runner image's glibc is
the floor of what the bundles load on (22.04 is 2.35, 24.04 is 2.39). Building
arm64 on 24.04 — which the issue suggested — would ship a package that installs
cleanly on Debian 12 and then dies in the loader. The apt gate catches it, but
the cheaper fix is not to create the mismatch.

**The signatures are artifacts, not job outputs.** A matrix job's `outputs` are
merged across legs with the last to finish winning, so
`needs.linux.outputs.deb_sig` would be a coin flip between two architectures.
The wrong one is not a build failure — it is an unverifiable update on every
machine of the other architecture. Same shape as `msix-build` → `msix`.

**`apt-publish` sets up qemu; `apt-verify-live` does not.** The pre-push gate has
to share a job with the push it protects, so its arm64 client is emulated. The
live check runs after the push and is free to be a matrix over native runners.

## Verification

Locally, with fixture `.deb`s built for both architectures (a real Tauri build
is not needed to exercise any of this — the gate's assertions are satisfied by
correct control fields and two stub executables):

- two `binary-*` indexes, `Architectures: amd64 arm64`, both signed
- the no-op short-circuit still fires with two architectures present
- both smoke legs pass, each installing and running the right architecture
- six refusal paths: two `.deb`s of one architecture, an index that is not
  there, an unsupported architecture, the arm64 sources file, and the stale
  `binary-*` directory sweep

In CI, on a temporary dry-run workflow spliced out of `release.yml` (deleted
before merge, since `release.yml` has no CI gate and `workflow_dispatch` needs
the file on `main`):

- `ubuntu-22.04-arm` resolves and builds the app natively
- the arm64 `.deb` reports `Architecture: arm64`
- the real arm64 package installs and runs `pgit --help` in an arm64
  `debian:bookworm` under qemu on an amd64 runner — which is both the glibc
  floor check and the proof that `apt-publish`'s second gate leg works

`test/linuxArches.test.ts` pins the architecture set across the five files that
name it and cannot see each other, and was verified to fail on six planted
violations. Full suite green (3274 tests), `tsc` clean, `site/` builds.

## Not included

No new spec under `docs/superpowers/specs/` — #266 is itself a complete spec
(inventory, plan, rationale, cost), so a second document would only restate it.
The living operational doc, `docs/dev/distribution.md`, has a new
"Two architectures" section instead.

No changelog entry: per `docs/dev/releasing.md` the changelog lands on `main` as
its own PR at release-cut time.
