### PR TITLE
feat(windows): open repositories in several windows, not just tabs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,8 +214,16 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
   `spawn_blocking`; per-repo ops serialize on an inner mutex. Verify and mutate
   under ONE lock acquisition (stash TOCTOU). (`docs/dev/backend.md`)
 - **Tauri permissions:** shared set in `capabilities/default.json`; privileged
-  ones (updater, e2e) stay in their scoped capability files.
+  ones (updater, e2e) stay in their scoped capability files. A new window label
+  must match a pattern in that file's `windows` list (`pg-*` since #256) or the
+  window silently has no permissions at all.
   (`docs/dev/distribution.md`)
+- **There can be several repository windows** (`main`, `pg-1`, …) — so anything
+  that is "the one live X on the ACTIVE repository" is keyed by WINDOW LABEL,
+  never global, and anything the backend emits to "the app" picks a window
+  instead of broadcasting. Two windows on one repository get two `RepoId`s on
+  purpose; per-window session state hangs off `openReposKey`.
+  (`docs/dev/frontend.md`)
 - **The main window starts HIDDEN** (`"visible": false`) and the frontend shows
   it on React's first commit (`src/lib/revealWindow.tsx`) — that is what makes
   the app open already-drawn instead of flashing white. Delete the reveal and

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -44,10 +44,37 @@ terminal.rs      Live pty sessions for the built-in terminal (#243). Shape of
 update.rs        Update discovery: semver compare, dev-build (0.0.0) short-circuit
                  before any network call, GitHub release parsing, ureq w/ timeout +
                  https_only. Logic only — handlers live in commands/update.rs
+windows.rs       Repository windows (#256) — the app can have several, each
+                 running the whole frontend with its own tab strip. Labels ARE
+                 the identity: main (from tauri.conf.json), pg-1/pg-2/… for
+                 siblings (next_label hands out the lowest FREE number, so a
+                 closed window's storage key is reused rather than a
+                 high-water mark left behind), and "merge" — a window, but
+                 deliberately NOT a repository window, so is_repo_window says
+                 no to it. Each window opens its OWN RepoId for a repository,
+                 which is what makes two windows on one repository safe with
+                 no refcounting: closing a tab in one evicts nothing the other
+                 is using, and terminals and rebase state (both keyed by
+                 RepoId) stay per-window for free. WindowRegistry answers the
+                 three questions a webview cannot answer about ANOTHER window:
+                 route() decides where a forwarded `pgit <path>` lands (the
+                 window that already has it → the last-focused one → the
+                 first), on_window_destroyed releases what a closed window
+                 held (process exit used to cover that and no longer does),
+                 and the same function decides CLOSE-VERSUS-QUIT without a
+                 flag or an event ordering: a window destroyed while another
+                 survives is forgotten (WINDOW_CLOSED_EVENT is emitted to that
+                 survivor), and one destroyed with no survivor is remembered,
+                 because there is nobody to tell. path_key mirrors the
+                 frontend's repoPathKey exactly, trailing-separator exceptions
+                 included
 watcher.rs       Filesystem watching so the working copy is live (#239).
                  notify-debouncer-mini around a RecommendedWatcher, ONE live
-                 watch (WatchState) on the ACTIVE repository — a second
-                 watch_repo REPLACES rather than stacks. The value is in what
+                 watch PER WINDOW (WatchState is keyed by window label since
+                 #256) on that window's ACTIVE repository — a second
+                 watch_repo from the same window REPLACES rather than stacks,
+                 and one from another window no longer evicts it, which it did
+                 for as long as the slot was global. The value is in what
                  it DROPS: classify() sorts each path into Noise / Ref / State
                  / Worktree, and only Ref asks for the expensive log refresh,
                  so a file save cannot repaint history. `.lock` files are
@@ -434,6 +461,16 @@ commands/        Thin Tauri handlers, one file per area:
 │                gigabyte-sized IPC message
 ├── update.rs    check_for_update, get_update_capability, open_url — thin
 │                handlers for src-tauri/src/update.rs (same basename, two files)
+├── windows.rs   register_window_repos, next_window_label (#256) — thin over
+│                src-tauri/src/windows.rs (same basename, two files).
+│                register_window_repos is called on every tab-strip persist,
+│                alongside the window's own session write, because both answers
+│                it feeds are only as fresh as their last write. The WINDOW is
+│                injected by Tauri, never passed as an argument: a label from
+│                the frontend would let one window register another's holdings
+│                or stop its watch. There is deliberately no focus-a-window
+│                command — the single-instance handler focuses in Rust, and a
+│                new window reveals itself (src/lib/revealWindow.tsx)
 ├── watch.rs     watch_repo, watch_stop (#239) — thin over src-tauri/src/
 │                watcher.rs. watch_repo resolves the workdir through the
 │                backend rather than taking a path argument: a path from the
@@ -441,7 +478,9 @@ commands/        Thin Tauri handlers, one file per area:
 │                repository lives, and this one registers an OS-level
 │                recursive watch on whatever it is handed. watch_stop is
 │                idempotent, so the frontend can call it on a setting change
-│                without tracking whether anything was running
+│                without tracking whether anything was running. Both take a
+│                Window since #256, so a watch belongs to the window that
+│                asked for it
 ├── terminal.rs  term_open, term_write, term_resize, term_close (#243) — thin
 │                over src-tauri/src/terminal.rs (same basename, two files).
 │                term_open resolves the workdir through the backend rather than
@@ -592,12 +631,31 @@ features/            Components + Zustand store colocated per feature:
 │                    speed-search), useHunkNav (F7/⇧F7 + open-at-first-change),
 │                    useDiffLineFocus (per-line cursor + Space),
 │                    useSpeedSearchStore, PGPane / FocusableScroll / CheatSheet
+├── windows/         Repository windows (#256) — tabs are for switching, windows
+│                    are for comparing. windowKind.ts is the pure half: label
+│                    rules, the per-window storage key (main keeps the bare
+│                    `pg-open-repos` it has written since #90 so an upgrading
+│                    session restores unchanged; a sibling gets
+│                    `pg-open-repos:<label>`), and the `pg-windows` restore
+│                    record. openAppWindow seeds a new window through STORAGE
+│                    rather than the URL — the seed is written under the new
+│                    label's key before the window exists, so it arrives by the
+│                    ordinary restoreSession path with no cross-window IPC —
+│                    and passes the chrome tauri.conf.json cannot give a
+│                    runtime window (macOS overlay titlebar, decorations:false
+│                    elsewhere) AT CREATION, never stripped afterwards.
+│                    useWindowLifecycle restores the siblings (primary only,
+│                    once), remembers a sibling's physical bounds, and forgets
+│                    a window the backend says was closed rather than quit
 ├── merge/           Merge resolver window (label "merge"): mergeModel (diff3),
 │                    resultEditor (CM6, tracked conflict regions), MergeWindow /
 │                    MergeBody / SidePane, openMergeWindow (path optional),
 │                    FileList (no open repo in this window — IPC wrappers, never
 │                    useRepoStore). Applies via save_resolution, emits
-│                    merge://resolved → main refreshes
+│                    merge://resolved → main refreshes, and merge://holding —
+│                    which repository it is on — so a window that did NOT open
+│                    it can still tell whether closing a tab would break it
+│                    (#256)
 ├── update/          useUpdateStore (discovery, semver-aware dismiss,
 │                    self-update; the updateCheckMode gate + lastCheckedAt live
 │                    HERE, not at the AppShell call site — see

--- a/docs/dev/distribution.md
+++ b/docs/dev/distribution.md
@@ -225,19 +225,35 @@ makes no request whatever the channel is set to.
 
 - Shared permissions in `src-tauri/capabilities/default.json`: `core:default`,
   window minimize/toggle-maximize/close/start-dragging/set-title/**show**,
-  webview create-webview-window + set-webview-zoom (the `view.zoom*` chords),
-  `dialog:default` + `dialog:allow-open`, `os:default`, `log:default`. Scoped
-  `windows: ["main", "merge"]`. `allow-show` is not optional decoration — the
-  main window is created hidden and the frontend is what shows it; see
+  set-size/set-position + outer-size/outer-position (a repository window
+  remembers where it was — #256), webview create-webview-window +
+  set-webview-zoom (the `view.zoom*` chords), `dialog:default` +
+  `dialog:allow-open`, `os:default`, `log:default`. Scoped
+  `windows: ["main", "merge", "pg-*"]`. `allow-show` is not optional decoration
+  — every window is created hidden and the frontend is what shows it; see
   "The window starts hidden" below.
+- **A window label that matches no pattern in that list has NO permissions at
+  all**, and fails silently — no error, just an app window where nothing works.
+  `pg-*` is what covers the repository windows #256 creates at runtime
+  (`pg-1`, `pg-2`, …), and it is why those labels are a deterministic shape
+  rather than an opaque id. A new kind of window means a new pattern here, in
+  the same commit.
 - **Self-update permissions are narrower:** `updater:default` +
   `process:allow-restart` live in `src-tauri/capabilities/updater.json` with
-  `windows: ["main"]` — the merge resolver must not be able to swap the binary
-  or relaunch mid-conflict. Keep new privileged permissions out of the shared
-  capability unless both windows genuinely need them.
+  `windows: ["main", "pg-*"]` — the merge resolver must not be able to swap the
+  binary or relaunch mid-conflict, and it is the ONLY window left out. A sibling
+  repository window is the whole app and carries the same chip and panel, so
+  omitting `pg-*` would have shipped an Install button that fails with a
+  permission error, and would have left a user who closed the main window with
+  no update surface at all. (N windows still cost one check: the throttle is
+  `lastCheckedAt` in localStorage, which every window shares.) Keep new
+  privileged permissions out of the shared capability unless every window
+  genuinely needs them.
 - **E2E-only permissions** (`core:window:allow-set-focus` +
   `wdio-webdriver:default`) live in the inline `e2e-focus` capability in
-  `src-tauri/tauri.e2e.conf.json`, loaded only via `--config`; the
+  `src-tauri/tauri.e2e.conf.json`, loaded only via `--config` — scoped to the
+  same three patterns, so a sibling window gets the focus self-heal and the
+  bridge that `multi-window.e2e.ts` drives it through; the
   `tauri-plugin-wdio-webdriver` crate is an optional dep behind the `e2e` cargo
   feature — never compiled into or permitted in dev/production builds.
 - New plugin: `cargo add tauri-plugin-X`, `pnpm add @tauri-apps/plugin-X`,

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1074,7 +1074,12 @@ that is only partly here — which is the whole reason the notice exists.
 - **Closing a tab the merge resolver is using:** confirm → close the resolver →
   evict (`mergeWindowHoldsRepo`/`closeMergeWindow`, which waits for the window
   label to disappear — `close()` resolves on delivery, not on gone). An
-  unattributable live resolver counts as a match on purpose.
+  unattributable live resolver counts as a match on purpose. Since #256 the
+  resolver also announces the repository it is on (`merge://holding`), because
+  it may have been opened by a *different* repository window: each window opens
+  its own `RepoId`, so closing a tab in the window that did not open the
+  resolver cannot break it, and without the announcement that window would
+  confirm — and then close a resolver it had no business closing.
 - **Danger-op error paths refresh first, set error last** (see `mergeBranch`):
   `refreshAll` starts with `set({ error: null })` and React batches same-tick
   sets, so the opposite order wipes the banner. A failed git op must still
@@ -1094,6 +1099,77 @@ that is only partly here — which is the whole reason the notice exists.
   against the repository's own remote list, longest match first. The older
   `branchMenuItems` Pull/Push entries still use the split; they predate the
   helper and were left alone rather than changed under this feature's tests.
+
+### Multiple windows (#256)
+
+Tabs are for *switching*; windows are for *comparing*. Both exist, and the tab
+model is unchanged — every window has a full tab strip. The design doc is
+`docs/superpowers/specs/2026-09-04-multiple-windows-spec.md`; these are the rules
+a change in this area has to keep.
+
+- **A window's LABEL is its identity.** `main` (from `tauri.conf.json`),
+  `pg-1`/`pg-2`/… for siblings, `merge` for the resolver — which is a window but
+  never a repository window. `features/windows/windowKind.ts` and
+  `src-tauri/src/windows.rs` hold the same rules on their own side of the IPC
+  boundary; changing one means changing the other. Labels are deterministic
+  rather than opaque ids because they are storage keys, a capability glob
+  (`pg-*` in `capabilities/default.json`) has to match them, and an e2e spec has
+  to name one to `browser.tauri.switchWindow(…)`.
+- **Nothing about the store model changes.** A second webview gets its own copy
+  of every Zustand store, so `useRepoStore` still holds exactly one repository's
+  state — that window's active tab's.
+- **Two windows on one repository get two `RepoId`s**, and that is the decision
+  everything else rests on. Closing a tab in one window evicts nothing the other
+  is using; terminals and rebase state, both keyed by `RepoId`, stay per-window
+  with no refcounting. The price is that same-repository work in two windows does
+  not serialize on one inner mutex — already the app's reality, since
+  `watcher.rs` opens its own second `git2::Repository` on the same repository and
+  a terminal beside the app has always been allowed.
+- **Per-window state must be keyed by the window's label**, on both sides. The
+  bug this rule exists for was invisible: `WatchState` was one global slot, so
+  the second window's `watch_repo` silently evicted the first window's watcher
+  and that window went back to being stale — the exact failure #239 removed,
+  restored by the second window. Anything else that is "one live X on the ACTIVE
+  repository" inherits this.
+- **`main` keeps writing the bare `pg-open-repos` key.** Namespacing every
+  window would have emptied every existing user's tab strip once, on upgrade.
+  Siblings write `pg-open-repos:<label>`; `openReposKey` is the only place that
+  mapping exists.
+- **A new window is seeded through STORAGE, not the URL or an event.**
+  `openAppWindow` writes the seed under the new label's key *before* the window
+  exists, so it arrives through the ordinary `restoreSession()` path — nothing to
+  replay if the window reloads, and no cross-window IPC to get wrong.
+- **Close versus quit** decides whether a window comes back, and the rule needs
+  no flag: a window destroyed while another repository window survives is
+  forgotten; one destroyed with no survivor is remembered. Rust implements it by
+  emitting `window://closed` to a survivor — with no survivor there is nobody to
+  tell, which is exactly the quit case. The visible consequence: on macOS ⌘Q with
+  three windows restores three, and on Windows/Linux, where quitting *is* closing
+  the windows one at a time, the last window standing is what comes back. That is
+  what VS Code does, and it beats both alternatives (resurrect windows the user
+  deliberately closed; or restore nothing).
+- **Only the primary window takes the first-launch CLI intent**, and the
+  forwarded `cli-launch` event is routed to ONE window rather than broadcast — see
+  `windows.rs::route`. A broadcast would have every window open the repository.
+- **Routing an event backend-side is only half of it: the listener has to name
+  its window too** (`listenToThisWindow`, `features/windows/windowEvents.ts`).
+  A plain JS `listen()` registers `EventTarget::Any`, and Tauri's listener filter
+  short-circuits on it — `*target == EventTarget::Any || filter(…)` in
+  `event/listener.rs` — so an `Any` listener matches EVERY emit, `emit_to("main", …)`
+  included. The backend's routing decision is simply undone in the webview, and
+  every window opens the forwarded repository. It costs nothing to get right and
+  is invisible until there are two windows, which is why
+  `useCliLaunch.test.tsx` asserts a sibling window ignores an emit addressed to
+  `main`, and `test/eventMock.ts` reproduces the `Any`-matches-everything rule so
+  that assertion cannot pass vacuously. Scoping does NOT cost you broadcasts —
+  `app.emit` runs with no filter at all, so `fs://changed` and `net://progress`
+  still arrive everywhere.
+- **Window chrome needed nothing.** `PGWindowControls`, the title effect,
+  `RevealOnFirstPaint` and the appearance watch all already ask `getCurrentWindow()`.
+  The one thing a runtime window does not inherit is `tauri.conf.json`'s
+  titlebar config, so `openAppWindow` passes it explicitly — **at creation**,
+  never stripped afterwards, because `lib.rs` records that stripping the frame
+  after the fact was visible on Windows as a title bar that appeared and vanished.
 
 ### Progress and loading state (#296)
 

--- a/docs/superpowers/plans/2026-09-04-multiple-windows.md
+++ b/docs/superpowers/plans/2026-09-04-multiple-windows.md
@@ -1,0 +1,94 @@
+# Multiple windows — implementation plan (#256)
+
+Spec: `docs/superpowers/specs/2026-09-04-multiple-windows-spec.md`
+
+One PR. The pieces are small individually but land together: half of them are
+correctness fixes that only matter *because* the other half exists (a per-window
+watcher is pointless without a second window, and a second window is broken
+without it).
+
+## 1. Backend — `src-tauri/src/windows.rs` (new)
+
+- `REPO_WINDOW_PREFIX = "pg-"`, `MAIN_WINDOW = "main"`, `MERGE_WINDOW = "merge"`.
+- `is_repo_window(label)` — `main` or `pg-*`. The merge resolver is not one.
+- `WindowRegistry` (managed state):
+  - `repos: Mutex<HashMap<String, Vec<WindowRepo>>>` — label → `{ id, path }`.
+  - `focused: Mutex<Option<String>>` — last repository window to take focus.
+  - `register(label, repos)`, `take(label) -> Vec<WindowRepo>`, `note_focus(label)`.
+  - `route(&self, path, live: &[String]) -> Option<String>` — pure routing: a
+    live window holding `path`, else the last-focused live one, else the first
+    live one sorted. Unit-tested without a Tauri app.
+  - `next_label(&self, live: &[String]) -> String` — lowest free `pg-N`.
+- Commands (`commands/windows.rs`): `register_window_repos`, `next_window_label`,
+  `focus_window`.
+
+## 2. Backend — wiring in `lib.rs`
+
+- `.manage(WindowRegistry::default())`.
+- `.on_window_event` → `Focused(true)` records focus; `Destroyed` runs
+  `windows::on_window_destroyed`: take the registry entry, `backend.close` each
+  `RepoId`, `terminal` close each, `watcher.stop(label)`, then — only if another
+  repository window survives — `emit_to(survivor, "window://closed", label)`.
+- single-instance handler: route the intent with `registry.route(...)`,
+  `emit_to(target, "cli-launch", intent)`, and show/unminimize/focus **that**
+  window instead of hard-coded `main`.
+
+## 3. Backend — per-window watcher
+
+`watcher::WatchState` gains a label-keyed map of slots (`stop(label)`,
+`start(label, …)`, `watching(label)`), and `commands::watch::watch_repo` /
+`unwatch_repo` take `window: tauri::Window`. Payloads are unchanged, so the
+frontend's `repoId` filter still does the tab-switch race guard.
+
+## 4. Capabilities
+
+`capabilities/default.json`: add `"pg-*"` to `windows`, plus the permissions a
+sibling window needs that `main` never did — `set-position`, `set-size`,
+`outer-position`, `outer-size`, `scale-factor`, `set-focus`, `unminimize`,
+`is-maximized`, `maximize`.
+
+## 5. Frontend — `src/features/windows/` (new)
+
+- `windowKind.ts` (pure): `MAIN_LABEL`, `isRepoWindowLabel`, `openReposKey(label)`
+  (main → `pg-open-repos`, sibling → `pg-open-repos:<label>`), and the
+  `pg-windows` registry codec (`loadWindowRecords` / `saveWindowRecords`,
+  tolerant of junk exactly like `loadOpenRepos`).
+- `openAppWindow.ts`: `openAppWindow({ seedPaths, bounds })` — asks the backend
+  for the next label, writes the seed set into that label's storage key BEFORE
+  creating the window (so the new window restores into it with no IPC), then
+  `new WebviewWindow(label, …)` with the platform-correct decorations, cascaded
+  bounds, and the same `backgroundColor` as `main`.
+- `restoreWindows.ts`: primary-only. Recreates sibling windows from `pg-windows`.
+- `useWindowBounds.ts`: sibling-only; debounced `tauri://move` / `tauri://resize`
+  writeback into the record.
+- `useWindowLifecycle.ts`: mounts the above and the `window://closed` listener
+  that prunes a forgotten sibling's records.
+
+## 6. Frontend — tabs become per-window
+
+- `tabs.ts`: `loadOpenRepos` / `saveOpenRepos` take a storage key.
+- `useTabsStore`: `persist()` uses this window's key and also calls
+  `registerWindowRepos` so the backend registry stays honest;
+  `moveTabToNewWindow(path)` = seed a new window, then `close(path)` here.
+- `useCliLaunch`: only the primary window takes the first-launch intent; the
+  forwarded event is already targeted.
+
+## 7. Frontend — the actions
+
+`window.new`, `window.newWithRepo`, `window.moveTabOut` in the keymap catalog
+(category *Repository*), `Mod+Shift+N` for the first; tab context-menu entries
+for the last two.
+
+## 8. Docs + tests
+
+- `docs/dev/architecture.md` — `windows.rs`, `commands/windows.rs`, the three new
+  commands, `features/windows/`.
+- `docs/dev/frontend.md` — the multi-window model, per-window storage keys, the
+  close-vs-quit rule.
+- `CLAUDE.md` — one rule line: per-window state must be keyed by window label.
+- Vitest: window-label/key derivation, `pg-windows` codec, per-window tab
+  persistence, `moveTabToNewWindow`, primary-only launch intent.
+- Rust: `route`, `next_label`, registry take/close, per-window watch slots.
+- E2E: `multi-window.e2e.ts` — open a second window, assert it has its own tab
+  strip and repository, close it. Driven with `browser.tauri.switchWindow("pg-1")`,
+  which is why the labels are deterministic.

--- a/docs/superpowers/specs/2026-09-04-multiple-windows-spec.md
+++ b/docs/superpowers/specs/2026-09-04-multiple-windows-spec.md
@@ -1,0 +1,160 @@
+# Multiple windows, not just tabs (#256)
+
+Status: approved (2026-09-04)
+
+## Problem
+
+Repositories open as tabs in one window (#90). Tabs are for *switching*; windows
+are for *comparing* — porting a change between two repos, watching a build in
+one while working in another, one repository per monitor. A tab strip cannot do
+any of those, and this is a multi-monitor-heavy audience.
+
+Upstream demand is the same story: GitHub Desktop's "support multiple windows"
+has 223 reactions, Fork's has 16.
+
+## Non-goals
+
+- **Not** a redesign of the tab model. Tabs stay exactly as they are; windows are
+  added alongside, and every window has a full tab strip.
+- **Not** a second UI mode. A window is the whole app: same shell, same screens,
+  same keymap, same settings.
+- **Not** cross-window drag of tabs. "Move tab to new window" is a menu/command
+  action; dragging a tab out of the strip onto the desktop is a follow-up.
+- **Not** per-window settings. Settings, recents and the keymap stay global.
+
+## The shape
+
+### One bundle, N windows
+
+The merge resolver already proves the pattern: a second Tauri window running the
+same bundle, routed by a query param in `src/main.tsx`. Repository windows need
+no param at all — anything that is not `?window=merge` is the full app. What
+distinguishes one repository window from another is its **label**:
+
+- `main` — the window Tauri creates from `tauri.conf.json`. Always exists first.
+- `pg-1`, `pg-2`, … — sibling windows, created at runtime; the number is the
+  lowest one not currently taken.
+- `merge` — the resolver, unchanged.
+
+Labels are deterministic and short on purpose: they are the key for per-window
+storage, they are what a capability glob has to match, and they are what an e2e
+spec passes to `browser.tauri.switchWindow(...)`.
+
+### Each window owns its own repositories
+
+`useRepoStore` holds exactly one repository's state and `useTabsStore` holds the
+open set — both are module-level Zustand stores, so a second webview gets a
+second, independent copy for free. Nothing about the frontend state model
+changes.
+
+The backend is the shared half, and the decision that makes everything else
+simple is: **two windows on one repository get two `RepoId`s.** `open_repo`
+mints a fresh id per open, and we keep it that way rather than sharing one
+handle. That means:
+
+- Window A closing a tab evicts *its* `RepoId` only. Window B is untouched — the
+  cross-window corruption the issue worried about cannot happen because there is
+  nothing shared to corrupt.
+- Terminal sessions (keyed by `RepoId`) and rebase state (keyed by `RepoId`) stay
+  per-window without any refcounting.
+- Same-repository operations in two windows do not serialize on one inner mutex.
+  That is acceptable and already the app's reality: `watcher.rs` opens its own
+  second `git2::Repository` on the same repository for exactly this reason
+  ("git is built for concurrent processes"), and the app has always tolerated a
+  terminal running git beside it. The verify-and-mutate invariants that matter
+  are already written defensively against external mutation — `stash_drop_at`
+  takes an `expect_oid` and re-checks it under the lock.
+
+The price is a second `git2::Repository` per window per repository, which is the
+same price the watcher already pays.
+
+### Per-window backend state
+
+Three pieces of `AppState` were implicitly single-window and become per-window:
+
+| State | Was | Becomes |
+|---|---|---|
+| `watcher::WatchState` | one live watch, on "the" active repository | one live watch **per window label**; the `fs://changed` payload already carries `repoId`, so the frontend filter is unchanged |
+| `CliLaunchState` | take-once, whoever asks first | taken by the primary window only |
+| the `cli-launch` event | `app.emit` — broadcast, so every window would open the repository | `emit_to` one chosen window |
+
+A fourth is new: a **window registry** (`src-tauri/src/windows.rs`) mapping a
+window label to the repositories it currently holds (`RepoId` + path). It exists
+for three jobs, all of which need an answer only the backend can give:
+
+1. **Launch routing.** `pgit ~/foo` in a running app must focus the window that
+   already has `~/foo` open, else the last-focused window. The registry is where
+   "who has it" lives, and a `Focused(true)` window event is where "last focused"
+   comes from.
+2. **Window close cleanup.** Closing one window while the process keeps running
+   has to evict that window's repositories and pty sessions and stop its watch —
+   otherwise every closed window leaks a `git2::Repository` and a shell for the
+   rest of the session. Process exit used to cover this; with several windows it
+   no longer does.
+3. **Deciding whether a close was a close or a quit** (below).
+
+### Session restore, and the close-vs-quit rule
+
+Each window persists its own open set. `main` keeps writing the existing
+`pg-open-repos` key — an upgrading user's session restores exactly as before —
+and a sibling writes `pg-open-repos:<label>`. A separate `pg-windows` key lists
+the sibling labels (and their remembered bounds) so `main` can recreate them at
+launch; each recreated window then restores its own set, lazily, exactly as
+today.
+
+Distinguishing "the user closed this one window" from "the user quit the app" is
+the one genuinely awkward question, because both destroy windows. The rule that
+needs no flags and no event ordering:
+
+> **A window destroyed while another repository window is still alive is
+> forgotten. A window destroyed with none left is remembered.**
+
+Rust implements it directly: on `WindowEvent::Destroyed`, if any repository
+window remains, it emits `window://closed` **to one of the survivors**, which
+prunes that label from `pg-windows` and drops its storage. If nothing survives,
+there is nobody to emit to and nothing is pruned — which is precisely the quit
+case.
+
+The consequence, spelled out because it is a behaviour someone will ask about:
+on macOS, ⌘Q with three windows open restores three windows. On Windows and
+Linux, where quitting *is* closing the windows one at a time, the last window
+standing is what comes back. That is what VS Code does, and it beats the two
+alternatives (restore windows the user deliberately closed; or restore nothing).
+
+Bounds are remembered for **sibling** windows only. `main` keeps the launch
+geometry it has today — restoring its position is a separate change with its own
+blast radius, and the multi-monitor case the issue names is about the *extra*
+windows.
+
+### Window chrome
+
+Nothing to do. Every piece of window chrome already asks for *its own* window:
+`PGWindowControls`, the window title effect in `AppShell`, `RevealOnFirstPaint`
+and the system-appearance watch all go through `getCurrentWindow()`. A sibling
+window gets its own traffic lights / minimise-maximise-close, its own
+`repo — branch — PlatypusGit` title (#219), and its own theme subscription.
+
+Two settings are the exception, because they live in `tauri.conf.json` and a
+runtime-created window does not inherit it: the macOS `titleBarStyle: "Overlay"`
++ traffic-light position, and the non-macOS `decorations: false`. Both are passed
+explicitly at creation, chosen off `platform()`. Deliberately at creation rather
+than stripped afterwards — the comment in `lib.rs` records that stripping the
+frame after the fact was *visible* on Windows.
+
+## User-facing surface
+
+- **New window** (`Mod+Shift+N`) — an empty window on Welcome.
+- **New window with this repository** — seeds the new window with the active tab's
+  repository; the current window keeps its tab.
+- **Move tab to new window** — same, but the tab leaves this window.
+- All three in the command palette (category *Repository*), the last two also on
+  the tab context menu.
+- **Close window** is the OS close button. No app-level chrome for it.
+
+## What this does not solve
+
+- Dragging a tab between two existing windows.
+- Restoring `main`'s own position and size.
+- A window list / "bring all to front" menu.
+
+These are follow-ups, not part of #256.

--- a/e2e/specs/multi-window.e2e.ts
+++ b/e2e/specs/multi-window.e2e.ts
@@ -1,0 +1,222 @@
+// Multiple windows (docs/superpowers/specs/2026-09-04-multiple-windows-spec.md,
+// #256): a second Tauri window running the whole app, with its own tab strip
+// and its own repository.
+//
+// MULTI-WINDOW: like merge-window.e2e.ts, this spec drives a SECOND Tauri
+// window through the embedded wdio driver — `browser.tauri.switchWindow("pg-1")`.
+// The label is deterministic by design (`next_window_label` hands out the lowest
+// free `pg-<n>`), which is what makes it nameable from here at all.
+//
+// PLATFORM: written for the HEADLESS Linux/WebKitGTK run (CI +
+// `pnpm test:e2e:docker`). The macOS-native caveat merge-window.e2e.ts records
+// applies here for the same reason: WKWebView's foreground-focus self-heal
+// cannot keep a consistent active window across a second window's
+// open/transition/close.
+//
+// NOT covered here, because the e2e binary gets EMPTY argv by construction
+// (`e2e/wdio.conf.ts` passes no `appArgs`): which window a forwarded `pgit …`
+// lands in. That rule is `WindowRegistry::route`, unit-tested in
+// src-tauri/src/windows.rs.
+
+import { browser, $, expect } from "@wdio/globals";
+import {
+  activeRepoTabPath,
+  armDriverBridge,
+  ensureMacAppFocus,
+  jsClickMenuItem,
+  jsContextMenu,
+  openPalette,
+  openRepo,
+  paletteDialog,
+  paletteInput,
+  repoTab,
+  repoTabCount,
+  resetApp,
+  seedOpenRepos,
+  waitRepoLoaded,
+} from "../support/app";
+import { basicRepo, branchyRepo, TempRepo } from "../support/tempRepo";
+
+/** The label every sibling window in this spec gets: the app hands out the
+ *  lowest free `pg-<n>`, and `main` is the only other window up. */
+const SIBLING = "pg-1";
+
+/** Assert which repository the active tab is on.
+ *
+ *  Matched on the SUFFIX, exactly as `repoTab` is: the backend answers `open`
+ *  with the canonicalised workdir, and on macOS a temp path arrives back as
+ *  `/private/var/...` where the fixture spelled it `/var/...`. The last segment
+ *  is unique across this spec's fixtures, so it is an identity match without
+ *  depending on symlink resolution. */
+async function expectActiveTab(repo: TempRepo): Promise<void> {
+  const name = repo.path.split("/").filter(Boolean).pop() as string;
+  const active = await activeRepoTabPath();
+  expect(active ?? "").toMatch(new RegExp(`${name}$`));
+}
+
+/** The tab strip's selector for one repository, suffix-matched for the reason
+ *  above. */
+function tabSelector(repo: TempRepo): string {
+  const name = repo.path.split("/").filter(Boolean).pop() as string;
+  return `[data-testid="repo-tab"][data-path$="${name}"]`;
+}
+
+/** Click the palette row whose visible label contains `text`.
+ *  (Copied from palette.e2e.ts — spec files never cross-import.) */
+async function clickPaletteRow(text: string): Promise<void> {
+  const row = $(paletteDialog).$(`[data-pal-index]*=${text}`);
+  await row.waitForDisplayed({
+    timeout: 10_000,
+    timeoutMsg: `palette row "${text}" never appeared`,
+  });
+  await row.click();
+}
+
+/** Attach the driver to the sibling window. Re-arms the bridge and heals focus
+ *  because this is a DIFFERENT document (per the e2e-testing re-arm rule). */
+async function switchToSibling(): Promise<void> {
+  await browser.waitUntil(
+    async () => {
+      try {
+        await browser.tauri.switchWindow(SIBLING);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { timeout: 20_000, timeoutMsg: `${SIBLING} never became switchable` },
+  );
+  await armDriverBridge();
+  await ensureMacAppFocus();
+}
+
+async function switchToMain(): Promise<void> {
+  await browser.tauri.switchWindow("main");
+  await armDriverBridge();
+}
+
+/** Close the sibling through the Tauri API — `window.close()` does not close a
+ *  Tauri window. Tolerant: a test may already have closed it. */
+async function closeSibling(): Promise<void> {
+  try {
+    await browser.tauri.switchWindow(SIBLING);
+    await browser.execute(() => {
+      const w = window as unknown as Record<string, any>;
+      void w.__TAURI__?.window?.getCurrentWindow?.().close();
+    });
+  } catch {
+    /* no sibling window — fine */
+  }
+  await switchToMain();
+}
+
+describe("repository windows", () => {
+  let repo: TempRepo | null = null;
+  let other: TempRepo | null = null;
+
+  afterEach(async () => {
+    await closeSibling();
+    await resetApp();
+    repo?.dispose();
+    repo = null;
+    other?.dispose();
+    other = null;
+  });
+
+  it("opens an empty second window from the palette", async () => {
+    repo = basicRepo();
+    await openRepo(repo.path);
+    await waitRepoLoaded();
+
+    await openPalette();
+    await $(paletteInput).setValue("New window");
+    await clickPaletteRow("New window");
+
+    await switchToSibling();
+    // A whole second app, on Welcome: "new window" is deliberately EMPTY, not
+    // a copy of what the first window was showing.
+    await $("div*=Welcome to PlatypusGit").waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "the new window never rendered the app",
+    });
+
+    // …and the first window is untouched.
+    await switchToMain();
+    await expectActiveTab(repo);
+  });
+
+  it("opens THIS repository in a new window, keeping the tab here", async () => {
+    repo = basicRepo();
+    await openRepo(repo.path);
+    await waitRepoLoaded();
+
+    await jsContextMenu('[data-testid="repo-tab"]');
+    await jsClickMenuItem("Open in new window");
+
+    await switchToSibling();
+    await waitRepoLoaded();
+    // The new window opened the repository itself, through its own seeded
+    // session — nothing was handed to it over an event.
+    await expectActiveTab(repo);
+
+    await switchToMain();
+    await expectActiveTab(repo);
+    expect(await repoTabCount()).toBe(1);
+  });
+
+  it("moves a tab out: it leaves this window and arrives in the other", async () => {
+    repo = basicRepo();
+    other = branchyRepo();
+    // Two tabs, seeded the way repo-tabs.e2e.ts does — this spec is about what
+    // happens to a tab, not about how it got opened.
+    await seedOpenRepos([repo.path, other.path], repo.path);
+    await waitRepoLoaded();
+    expect(await repoTabCount()).toBe(2);
+
+    await jsContextMenu(tabSelector(other));
+    await jsClickMenuItem("Move to new window");
+
+    // Gone from here…
+    await repoTab(other.path).waitForExist({
+      reverse: true,
+      timeout: 20_000,
+      timeoutMsg: "the moved tab stayed in the window it left",
+    });
+    expect(await repoTabCount()).toBe(1);
+    await expectActiveTab(repo);
+
+    // …and it is what the new window is showing.
+    await switchToSibling();
+    await waitRepoLoaded();
+    await expectActiveTab(other);
+    expect(await repoTabCount()).toBe(1);
+  });
+
+  it("a window the user closes does not come back", async () => {
+    repo = basicRepo();
+    await openRepo(repo.path);
+    await waitRepoLoaded();
+
+    await jsContextMenu('[data-testid="repo-tab"]');
+    await jsClickMenuItem("Open in new window");
+    await switchToSibling();
+    await waitRepoLoaded();
+
+    await closeSibling();
+
+    // The close-versus-quit rule: a window destroyed while another survives is
+    // forgotten, and the survivor is the one told to forget it. Asserted on the
+    // restore record itself, because "it did not come back" is otherwise only
+    // observable across a restart the suite cannot do.
+    await browser.waitUntil(
+      async () => (await browser.execute(() => localStorage.getItem("pg-windows"))) === "[]",
+      {
+        timeout: 20_000,
+        timeoutMsg: "the closed window was still in the restore set",
+      },
+    );
+    expect(
+      await browser.execute(() => localStorage.getItem("pg-open-repos:pg-1")),
+    ).toBeNull();
+  });
+});

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -4,7 +4,8 @@
   "description": "Default permissions for platypusgit",
   "windows": [
     "main",
-    "merge"
+    "merge",
+    "pg-*"
   ],
   "permissions": [
     "core:default",
@@ -14,6 +15,10 @@
     "core:window:allow-start-dragging",
     "core:window:allow-set-title",
     "core:window:allow-show",
+    "core:window:allow-set-size",
+    "core:window:allow-set-position",
+    "core:window:allow-outer-size",
+    "core:window:allow-outer-position",
     "core:webview:allow-create-webview-window",
     "core:webview:allow-set-webview-zoom",
     "dialog:default",

--- a/src-tauri/capabilities/updater.json
+++ b/src-tauri/capabilities/updater.json
@@ -1,9 +1,10 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "updater",
-  "description": "Self-update: check/download/install a signed release, then relaunch. Scoped to the main window ONLY — the merge resolver window (label \"merge\") has no business swapping the binary out from under an in-progress conflict resolution, let alone restarting the process.",
+  "description": "Self-update: check/download/install a signed release, then relaunch. Scoped to the REPOSITORY windows (\"main\" and the \"pg-*\" siblings #256 adds) and never to the merge resolver window (label \"merge\"), which has no business swapping the binary out from under an in-progress conflict resolution, let alone restarting the process. A sibling repository window IS the whole app \u2014 it carries the same update chip and panel \u2014 so leaving it out would have shipped an Install button that fails with a permission error, and would have left a user who closed the main window with no update surface at all. The check itself is throttled through the shared `lastCheckedAt` in localStorage, so N windows still cost one check.",
   "windows": [
-    "main"
+    "main",
+    "pg-*"
   ],
   "permissions": [
     "updater:default",

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -20,4 +20,5 @@ pub mod submodule;
 pub mod terminal;
 pub mod update;
 pub mod watch;
+pub mod windows;
 pub mod worktree;

--- a/src-tauri/src/commands/watch.rs
+++ b/src-tauri/src/commands/watch.rs
@@ -1,14 +1,18 @@
 //! Start and stop the filesystem watcher (#239).
 //!
 //! Two commands and no state of their own — [`crate::watcher::WatchState`] owns
-//! the single live watch. The frontend calls `watch_repo` when a repository
-//! becomes the active tab and `watch_stop` when the setting is turned off or
-//! the last repository closes; a second `watch_repo` replaces rather than
-//! stacks, so a tab switch needs no matching stop.
+//! the live watches, one per window (#256). The frontend calls `watch_repo`
+//! when a repository becomes the active tab and `watch_stop` when the setting
+//! is turned off or the last repository closes; a second `watch_repo` replaces
+//! rather than stacks, so a tab switch needs no matching stop.
+//!
+//! Both take a `Window` — injected by Tauri, never passed from the frontend —
+//! so the frontend's call sites are unchanged and one window cannot stop
+//! another's watch.
 
 use std::path::PathBuf;
 
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, State, Window};
 
 use crate::{
     error::{AppError, AppResult},
@@ -26,6 +30,7 @@ use crate::{
 #[tauri::command]
 pub async fn watch_repo(
     app: AppHandle,
+    window: Window,
     state: State<'_, AppState>,
     watch: State<'_, WatchState>,
     repo_id: String,
@@ -38,13 +43,14 @@ pub async fn watch_repo(
     // `start` opens a libgit2 handle and registers the watch — both blocking,
     // both fast, and neither touching the shared per-repo mutex. See the
     // module note in `watcher.rs` for why this does not go through it.
-    watch.inner().start(app, repo_id, workdir)
+    let label = window.label().to_string();
+    watch.inner().start(app, label, repo_id, workdir)
 }
 
-/// Stop watching. Idempotent — the frontend calls this on a setting change
-/// without knowing whether anything was running.
+/// Stop THIS window's watch. Idempotent — the frontend calls this on a setting
+/// change without knowing whether anything was running.
 #[tauri::command]
-pub async fn watch_stop(watch: State<'_, WatchState>) -> AppResult<()> {
-    watch.inner().stop();
+pub async fn watch_stop(window: Window, watch: State<'_, WatchState>) -> AppResult<()> {
+    watch.inner().stop(window.label());
     Ok(())
 }

--- a/src-tauri/src/commands/windows.rs
+++ b/src-tauri/src/commands/windows.rs
@@ -1,0 +1,40 @@
+//! Multiple windows (#256) — the two questions a webview cannot answer about
+//! itself. The registry and the reasoning live in [`crate::windows`].
+
+use tauri::Window;
+
+use crate::{
+    error::AppResult,
+    windows::{self, WindowRegistry, WindowRepo},
+};
+
+/// Tell the backend which repositories this window's tab strip holds.
+///
+/// Called on every persist of the tab strip — the same moment the frontend
+/// writes its own session — because both answers this feeds are only as fresh as
+/// their last write: routing a `pgit <path>` to the window that has it open, and
+/// evicting the right repositories when the window goes away.
+///
+/// The window argument is injected by Tauri; a label passed from the frontend
+/// would let one window register another's holdings.
+#[tauri::command]
+pub fn register_window_repos(
+    window: Window,
+    registry: tauri::State<'_, WindowRegistry>,
+    repos: Vec<WindowRepo>,
+) -> AppResult<()> {
+    registry.register(window.label(), repos);
+    Ok(())
+}
+
+/// The label the next sibling window should use — the lowest free `pg-<n>`.
+///
+/// Handed out by the backend rather than computed in the webview because it has
+/// to be free across ALL windows, and only the app knows which labels are live.
+/// Racy by nature (two clicks in two windows in the same tick), and cheap to
+/// make safe: `WebviewWindow` creation fails on a duplicate label, and the
+/// caller asks again.
+#[tauri::command]
+pub fn next_window_label(app: tauri::AppHandle) -> AppResult<String> {
+    Ok(windows::next_label(&windows::live_repo_windows(&app)))
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ pub mod state;
 pub mod terminal;
 pub mod update;
 pub mod watcher;
+pub mod windows;
 
 use std::sync::{Arc, Mutex};
 
@@ -139,15 +140,39 @@ pub fn run() {
         builder = builder.plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
             use tauri::{Emitter, Manager};
             let args: Vec<String> = argv.into_iter().skip(1).collect();
+            let live = windows::live_repo_windows(app);
+            // Which window gets it (#256). Was `app.emit` — a broadcast, which
+            // with one window meant "the window" and with several would mean
+            // "every window opens this repository". The rule is in
+            // `WindowRegistry::route`: whoever already has it, else the
+            // last-focused window, else the first.
+            let mut target = windows::MAIN_WINDOW.to_string();
             if let cli::Parsed::Launch(Some(intent)) | cli::Parsed::DebugLaunch(Some(intent)) =
                 cli::parse_args(&args, std::path::Path::new(&cwd))
             {
                 let intent = cli::resolve_repo_root(intent);
-                if let Err(e) = app.emit("cli-launch", &intent) {
-                    log::error!("failed to emit cli-launch: {e}");
+                let registry = app.state::<windows::WindowRegistry>();
+                if let Some(label) = intent
+                    .path
+                    .as_deref()
+                    .map(|p| p.to_string_lossy().into_owned())
+                    .and_then(|p| registry.route(&p, &live))
+                    .or_else(|| registry.preferred(&live))
+                {
+                    target = label;
                 }
+                if let Err(e) = app.emit_to(target.as_str(), "cli-launch", &intent) {
+                    log::error!("failed to emit cli-launch to {target}: {e}");
+                }
+            } else if let Some(label) = app
+                .state::<windows::WindowRegistry>()
+                .preferred(&live)
+            {
+                // A bare `pgit` with no path: nothing to forward, but the user
+                // still asked for the app — surface the window they last used.
+                target = label;
             }
-            if let Some(win) = app.get_webview_window("main") {
+            if let Some(win) = app.get_webview_window(&target) {
                 // `show()` first: the window is created hidden (see the setup
                 // hook) and neither unminimize nor set_focus reveals a hidden
                 // window. Without this, a `pgit …` landing in the sub-second gap
@@ -289,7 +314,32 @@ pub fn run() {
             }
             Ok(())
         })
+        // Multiple windows (#256). Both arms are about the OTHER windows: with
+        // one window there was nobody to route a launch to and nothing to
+        // release that process exit would not have released anyway.
+        .on_window_event(|window, event| {
+            use tauri::Manager;
+            match event {
+                // Which window the user touched last, for `pgit` routing.
+                tauri::WindowEvent::Focused(true) => {
+                    window
+                        .app_handle()
+                        .state::<windows::WindowRegistry>()
+                        .note_focus(window.label());
+                }
+                // One window going away no longer means the process is going
+                // away: release what it held, and decide whether it is
+                // remembered next launch.
+                tauri::WindowEvent::Destroyed => {
+                    windows::on_window_destroyed(window.app_handle(), window.label());
+                }
+                _ => {}
+            }
+        })
         .manage(AppState::new(backend))
+        // Which repositories each window holds, and where a forwarded `pgit …`
+        // should land (#256).
+        .manage(windows::WindowRegistry::default())
         // Per-host forge API tokens, cached for this process only (#92). NOT the
         // git-transport credential path — see forge/token.rs for why the two
         // must never share storage.
@@ -439,6 +489,8 @@ pub fn run() {
             commands::update::check_for_update,
             commands::update::get_update_capability,
             commands::custom_action::run_custom_action,
+            commands::windows::register_window_repos,
+            commands::windows::next_window_label,
             commands::watch::watch_repo,
             commands::watch::watch_stop,
             commands::update::open_url,

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -36,6 +36,7 @@
 //! libgit2 handles on one repository are ordinary — git is built for concurrent
 //! processes — and this one only ever asks read-only questions.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Duration;
@@ -182,14 +183,28 @@ pub fn summarize(repo_id: &str, kinds: &[PathKind]) -> Option<FsChange> {
     })
 }
 
-/// The one live watcher. `None` when nothing is being watched.
+/// The live watchers — **one slot per window** (#256).
 ///
-/// A single slot rather than a map: only the active tab's repository is
-/// watched, so a second `watch_repo` REPLACES rather than adds. Dropping the
-/// previous `Debouncer` is what unregisters it from the OS.
+/// Only the active tab's repository is watched, so within a window a second
+/// `watch_repo` REPLACES rather than adds, and dropping the previous
+/// `Debouncer` is what unregisters it from the OS. That was a single global
+/// slot until multiple windows existed, at which point it became a bug you
+/// could not see: window B's `watch_repo` evicted window A's watcher, and A
+/// went quietly back to being stale — the exact failure this module was written
+/// to remove, restored by the second window.
+///
+/// Keyed by window LABEL rather than by `RepoId` because the invariant is
+/// per-window ("the active tab's repository"), and because a window that goes
+/// away has to be able to stop its watch without knowing which repository it
+/// ended up on (`windows::on_window_destroyed`).
+///
+/// The `FsChange` payload is unchanged: it still carries the `repoId` it came
+/// from, and events are still app-global, so the frontend's "drop an event that
+/// arrived after a tab switch" filter keeps working per window without knowing
+/// this map exists.
 #[derive(Default)]
 pub struct WatchState {
-    active: Mutex<Option<Active>>,
+    active: Mutex<HashMap<String, Active>>,
 }
 
 struct Active {
@@ -199,27 +214,43 @@ struct Active {
 }
 
 impl WatchState {
-    /// Which repository is being watched, if any. For tests and diagnostics.
-    pub fn watching(&self) -> Option<String> {
+    /// Which repository `label` is watching, if any. For tests and diagnostics.
+    pub fn watching(&self, label: &str) -> Option<String> {
         self.active
             .lock()
             .ok()
-            .and_then(|g| g.as_ref().map(|a| a.repo_id.clone()))
+            .and_then(|g| g.get(label).map(|a| a.repo_id.clone()))
     }
 
-    /// Stop whatever is being watched. Idempotent.
-    pub fn stop(&self) {
+    /// How many windows are watching. Tests and diagnostics.
+    pub fn watch_count(&self) -> usize {
+        self.active.lock().map(|g| g.len()).unwrap_or(0)
+    }
+
+    /// Stop `label`'s watch. Idempotent — the frontend calls this on a setting
+    /// change without knowing whether anything was running, and
+    /// `windows::on_window_destroyed` calls it for a window that may never have
+    /// watched anything.
+    pub fn stop(&self, label: &str) {
         if let Ok(mut guard) = self.active.lock() {
-            *guard = None;
+            guard.remove(label);
         }
     }
 
-    /// Watch `workdir`, replacing any existing watch.
+    /// Watch `workdir` for `label`, replacing that window's existing watch.
     ///
-    /// The previous watcher is dropped BEFORE the new one is registered, so two
-    /// watchers never hold the same directory — on macOS that would double
-    /// every event for as long as both lived.
-    pub fn start(&self, app: AppHandle, repo_id: String, workdir: PathBuf) -> AppResult<()> {
+    /// The previous watcher is dropped BEFORE the new one is registered, so one
+    /// window never holds the same directory twice — on macOS that would double
+    /// every event for as long as both lived. Two DIFFERENT windows watching one
+    /// directory is a separate matter and is allowed: each needs its own events,
+    /// and each filters them by its own `repoId`.
+    pub fn start(
+        &self,
+        app: AppHandle,
+        label: String,
+        repo_id: String,
+        workdir: PathBuf,
+    ) -> AppResult<()> {
         let repo = git2::Repository::open(&workdir)?;
         let gitdir = repo.path().to_path_buf();
         let commondir = repo.commondir().to_path_buf();
@@ -228,8 +259,8 @@ impl WatchState {
             .active
             .lock()
             .map_err(|_| AppError::Internal("watch state poisoned".to_string()))?;
-        // Drop the old one first — see the doc comment.
-        *guard = None;
+        // Drop this window's old one first — see the doc comment.
+        guard.remove(&label);
 
         let handler = Handler {
             app,
@@ -246,10 +277,13 @@ impl WatchState {
             .watch(&workdir, RecursiveMode::Recursive)
             .map_err(|e| AppError::Io(format!("could not watch {}: {e}", workdir.display())))?;
 
-        *guard = Some(Active {
-            repo_id,
-            _debouncer: debouncer,
-        });
+        guard.insert(
+            label,
+            Active {
+                repo_id,
+                _debouncer: debouncer,
+            },
+        );
         Ok(())
     }
 }
@@ -321,5 +355,77 @@ impl notify_debouncer_mini::DebounceEventHandler for Handler {
         if let Some(change) = summarize(&self.repo_id, &kinds) {
             let _ = self.app.emit(FS_CHANGED_EVENT, &change);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A real `Debouncer` that watches nothing. Cheap, and it keeps `Active`'s
+    /// shape honest — the point of these tests is the MAP, and a fake slot type
+    /// would stop testing the thing that broke.
+    fn idle_active(repo_id: &str) -> Active {
+        Active {
+            repo_id: repo_id.to_string(),
+            _debouncer: new_debouncer(DEBOUNCE, |_: DebounceEventResult| {})
+                .expect("a debouncer that watches nothing"),
+        }
+    }
+
+    fn watching_of(state: &WatchState, label: &str, repo_id: &str) {
+        state
+            .active
+            .lock()
+            .unwrap()
+            .insert(label.to_string(), idle_active(repo_id));
+    }
+
+    #[test]
+    fn a_second_window_does_not_evict_the_first_windows_watch() {
+        // The bug this map exists for, and one you could not see: with a single
+        // global slot, window B's `watch_repo` dropped window A's watcher and A
+        // went quietly back to being stale — the exact failure #239 removed,
+        // restored by the second window.
+        let state = WatchState::default();
+        watching_of(&state, "main", "r-api");
+        watching_of(&state, "pg-1", "r-web");
+
+        assert_eq!(state.watching("main").as_deref(), Some("r-api"));
+        assert_eq!(state.watching("pg-1").as_deref(), Some("r-web"));
+        assert_eq!(state.watch_count(), 2);
+    }
+
+    #[test]
+    fn one_window_still_replaces_its_own_watch_rather_than_stacking() {
+        // Within a window the invariant is unchanged: only the ACTIVE tab's
+        // repository is watched, so a tab switch needs no matching stop.
+        let state = WatchState::default();
+        watching_of(&state, "main", "r-api");
+        watching_of(&state, "main", "r-web");
+        assert_eq!(state.watching("main").as_deref(), Some("r-web"));
+        assert_eq!(state.watch_count(), 1);
+    }
+
+    #[test]
+    fn stopping_one_window_leaves_the_others_watching() {
+        let state = WatchState::default();
+        watching_of(&state, "main", "r-api");
+        watching_of(&state, "pg-1", "r-web");
+
+        state.stop("pg-1");
+
+        assert_eq!(state.watching("pg-1"), None);
+        assert_eq!(state.watching("main").as_deref(), Some("r-api"));
+    }
+
+    #[test]
+    fn stopping_a_window_that_never_watched_anything_is_a_no_op() {
+        // `windows::on_window_destroyed` calls this for every window it tears
+        // down, and the frontend calls it on a setting change without knowing
+        // whether anything was running.
+        let state = WatchState::default();
+        state.stop("pg-4");
+        assert_eq!(state.watch_count(), 0);
     }
 }

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -1,0 +1,413 @@
+//! Repository windows — the registry behind "multiple windows, not just tabs"
+//! (#256).
+//!
+//! Repositories open as tabs, and tabs are for *switching*. Windows are for
+//! *comparing*: two repositories side by side, one per monitor, a build running
+//! in one while you work in the other. Since #256 the app can have several
+//! windows, each running the whole frontend with its own tab strip.
+//!
+//! ## Labels are the identity
+//!
+//! * `main` — the window `tauri.conf.json` declares. Always the first one.
+//! * `pg-1`, `pg-2`, … — siblings, created at runtime; the number is the lowest
+//!   one not currently taken, so labels stay short and predictable.
+//! * `merge` — the conflict resolver (`features/merge/`), which is a window but
+//!   NOT a repository window: it drives one repository handed to it by whoever
+//!   opened it, and none of the bookkeeping here applies to it.
+//!
+//! Deterministic labels are not cosmetic. They key the frontend's per-window
+//! storage, a capability glob (`pg-*`) has to match them, and an e2e spec has to
+//! name one to `browser.tauri.switchWindow(…)`.
+//!
+//! ## Why the backend has to know anything at all
+//!
+//! Each window's *state* is entirely its own — a second webview gets a second
+//! copy of every Zustand store for free, and two windows on one repository get
+//! two `RepoId`s, so there is no shared handle to corrupt. Three questions still
+//! have no answer inside a single webview, and this module is where they live:
+//!
+//! 1. **Which window should a `pgit …` launch go to?** [`WindowRegistry::route`]
+//!    — the window that already has that repository open, else the last-focused
+//!    one, else the first. A webview cannot see another window's tabs.
+//!    ⚠️ Routing here is only half of it: a plain JS `listen()` registers
+//!    `EventTarget::Any`, which Tauri matches against EVERY emit — including an
+//!    `emit_to` naming one window. The frontend listener has to name its own
+//!    window (`listenToThisWindow`, src/features/windows/windowEvents.ts) or
+//!    this decision is quietly undone in the webview.
+//! 2. **What happens when one window closes?** Its repositories, its pty
+//!    sessions and its filesystem watch have to go with it. Process exit used to
+//!    cover that; with several windows it no longer does, and a closed window
+//!    would otherwise leak a `git2::Repository` and a shell for the rest of the
+//!    session. See [`on_window_destroyed`].
+//! 3. **Was that a close, or a quit?** Both destroy windows, and the answer
+//!    decides whether the window comes back next launch. The rule needs no flag
+//!    and no event ordering: a window destroyed **while another repository
+//!    window is still alive** is forgotten, and one destroyed with none left is
+//!    remembered. `on_window_destroyed` implements it by emitting
+//!    [`WINDOW_CLOSED_EVENT`] to a *survivor* — when there is no survivor there
+//!    is nobody to tell, which is exactly the quit case.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager};
+
+use crate::git::types::RepoId;
+
+/// The window `tauri.conf.json` declares.
+pub const MAIN_WINDOW: &str = "main";
+/// The conflict resolver. A window, but not a repository window.
+pub const MERGE_WINDOW: &str = "merge";
+/// Every sibling window's label starts with this.
+pub const REPO_WINDOW_PREFIX: &str = "pg-";
+
+/// Emitted to a SURVIVING repository window when another one is destroyed, so
+/// the frontend can drop that label's persisted session. Never emitted when
+/// nothing survives — see the module note on close-versus-quit.
+pub const WINDOW_CLOSED_EVENT: &str = "window://closed";
+
+/// True for `main` and for `pg-<n>`, false for the resolver and for anything
+/// else a future feature might open.
+pub fn is_repo_window(label: &str) -> bool {
+    if label == MAIN_WINDOW {
+        return true;
+    }
+    match label.strip_prefix(REPO_WINDOW_PREFIX) {
+        // `parse` rather than `is_ascii_digit`: it rejects `pg-` (empty),
+        // `pg-01x`, and anything that would not round-trip through
+        // `next_label`.
+        Some(rest) => rest.parse::<u32>().is_ok(),
+        None => false,
+    }
+}
+
+/// One repository a window currently holds. `id` is null while the tab is still
+/// pending — the frontend registers the tab strip as it is, not only once every
+/// tab has opened, so routing works before the last tab has loaded.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WindowRepo {
+    pub id: Option<String>,
+    pub path: String,
+}
+
+/// The frontend's `repoPathKey` (src/features/repo/tabs.ts), on this side.
+///
+/// A path arrives from several producers that disagree about the trailing
+/// separator, and routing compares one against another. Kept deliberately
+/// identical to the frontend's rule, including its two exceptions: a path that
+/// is only separators, and a Windows drive root, are left alone rather than
+/// trimmed into a different path.
+fn path_key(path: &str) -> &str {
+    let trimmed = path.trim_end_matches(['/', '\\']);
+    if trimmed.is_empty() || trimmed.ends_with(':') {
+        return path;
+    }
+    trimmed
+}
+
+/// Which repositories each window holds, and which window the user touched last.
+#[derive(Default)]
+pub struct WindowRegistry {
+    repos: Mutex<HashMap<String, Vec<WindowRepo>>>,
+    focused: Mutex<Option<String>>,
+}
+
+impl WindowRegistry {
+    /// Replace what `label` holds. Called on every tab-strip change, so it is a
+    /// whole-set write rather than an add/remove pair — the frontend's tab list
+    /// is the truth and there is no diff worth computing.
+    pub fn register(&self, label: &str, repos: Vec<WindowRepo>) {
+        if let Ok(mut map) = self.repos.lock() {
+            map.insert(label.to_string(), repos);
+        }
+    }
+
+    /// Remove and return what `label` held. Used exactly once, by
+    /// [`on_window_destroyed`], so the eviction cannot run twice.
+    pub fn take(&self, label: &str) -> Vec<WindowRepo> {
+        self.repos
+            .lock()
+            .ok()
+            .and_then(|mut map| map.remove(label))
+            .unwrap_or_default()
+    }
+
+    /// What `label` holds right now. Diagnostics and tests.
+    pub fn holdings(&self, label: &str) -> Vec<WindowRepo> {
+        self.repos
+            .lock()
+            .ok()
+            .and_then(|map| map.get(label).cloned())
+            .unwrap_or_default()
+    }
+
+    pub fn note_focus(&self, label: &str) {
+        if !is_repo_window(label) {
+            return;
+        }
+        if let Ok(mut f) = self.focused.lock() {
+            *f = Some(label.to_string());
+        }
+    }
+
+    /// Where a `pgit <path>` launch should land, given the windows that are
+    /// currently alive.
+    ///
+    /// Order: the window that already has `path` open, else the last-focused
+    /// live window, else the first live label in sort order (`main` sorts before
+    /// every `pg-n`, which is the right default). `None` only when no repository
+    /// window is alive at all.
+    ///
+    /// `live` is passed in rather than read from an `AppHandle` so the rule is
+    /// testable without a Tauri app — this is the part with the branches.
+    pub fn route(&self, path: &str, live: &[String]) -> Option<String> {
+        if live.is_empty() {
+            return None;
+        }
+        let key = path_key(path);
+        if let Ok(map) = self.repos.lock() {
+            // Sorted so a repository open in two windows routes to the same one
+            // every time; an arbitrary HashMap order would make `pgit` feel
+            // random.
+            let mut holders: Vec<&String> = live
+                .iter()
+                .filter(|label| {
+                    map.get(*label)
+                        .is_some_and(|repos| repos.iter().any(|r| path_key(&r.path) == key))
+                })
+                .collect();
+            holders.sort();
+            if let Some(found) = holders.first() {
+                return Some((*found).clone());
+            }
+        }
+        self.preferred(live)
+    }
+
+    /// Where "the app" is, with no repository in the question: the last-focused
+    /// live window, else the first live label in sort order. What a bare `pgit`
+    /// surfaces, and `route`'s own fallback.
+    pub fn preferred(&self, live: &[String]) -> Option<String> {
+        if let Ok(f) = self.focused.lock() {
+            if let Some(label) = f.as_ref() {
+                if live.iter().any(|l| l == label) {
+                    return Some(label.clone());
+                }
+            }
+        }
+        let mut sorted: Vec<&String> = live.iter().collect();
+        sorted.sort();
+        sorted.first().map(|l| (*l).clone())
+    }
+}
+
+/// The lowest free `pg-<n>`, given the labels already in use.
+///
+/// Reuse rather than a counter: labels are storage keys, and a monotonically
+/// growing one leaves `pg-open-repos:pg-37` behind forever. Starts at 1 —
+/// `pg-0` would read as "the zeroth window" next to `main`.
+pub fn next_label(live: &[String]) -> String {
+    for n in 1u32.. {
+        let candidate = format!("{REPO_WINDOW_PREFIX}{n}");
+        if !live.iter().any(|l| l == &candidate) {
+            return candidate;
+        }
+    }
+    unreachable!("u32 exhausted while naming a window")
+}
+
+/// Every repository window currently alive, by label. Excludes the resolver.
+pub fn live_repo_windows(app: &AppHandle) -> Vec<String> {
+    let mut labels: Vec<String> = app
+        .webview_windows()
+        .keys()
+        .filter(|l| is_repo_window(l))
+        .cloned()
+        .collect();
+    labels.sort();
+    labels
+}
+
+/// Tear down one window's backend state, and decide whether it is remembered.
+///
+/// Called from `lib.rs`'s window-event handler on `Destroyed`. Everything the
+/// window held is released here: its repositories (each window opens its own
+/// `RepoId`, so this evicts nothing another window is using), the pty sessions
+/// keyed by those ids, and its filesystem watch.
+///
+/// The eviction runs on its own thread. Dropping a `git2::Repository` takes the
+/// backend's repo map lock, and this handler runs on the event loop — the thread
+/// that also has to finish tearing the window down.
+pub fn on_window_destroyed(app: &AppHandle, label: &str) {
+    if !is_repo_window(label) {
+        return;
+    }
+    let repos = app.state::<WindowRegistry>().take(label);
+    app.state::<crate::watcher::WatchState>().stop(label);
+
+    if !repos.is_empty() {
+        let backend = app.state::<crate::state::AppState>().backend.clone();
+        let terminals: Arc<crate::terminal::TerminalState> =
+            app.state::<Arc<crate::terminal::TerminalState>>().inner().clone();
+        std::thread::spawn(move || {
+            for repo in repos {
+                let Some(id) = repo.id else { continue };
+                terminals.close(&id);
+                if let Err(e) = backend.close(&RepoId(id.clone())) {
+                    log::warn!("closing {id} after its window went away failed: {e}");
+                }
+            }
+        });
+    }
+
+    if let Some(target) = survivor_to_notify(label, &live_repo_windows(app)) {
+        if let Err(e) = app.emit_to(target.as_str(), WINDOW_CLOSED_EVENT, label) {
+            log::warn!("failed to announce the close of {label}: {e}");
+        }
+    }
+}
+
+/// Close, or quit? — the whole rule, as a function of two lists.
+///
+/// A survivor means the user closed this one window: it is told, and forgets
+/// the closed window's session. No survivor means the app is on its way out,
+/// there is nobody to tell, and the session is left alone to be restored. That
+/// asymmetry is the entire mechanism; there is no "are we exiting" flag and
+/// nothing depends on the order Tauri destroys windows in.
+///
+/// The survivor is the first label in sort order rather than an arbitrary one,
+/// so `main` is preferred while it is up and a sibling takes over when the user
+/// closed `main` first — deterministic either way, which matters because the
+/// chosen window is the only one that will act on the event.
+fn survivor_to_notify(destroyed: &str, live: &[String]) -> Option<String> {
+    let mut survivors: Vec<&String> = live.iter().filter(|l| *l != destroyed).collect();
+    survivors.sort();
+    survivors.first().map(|l| (*l).clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn repo(path: &str) -> WindowRepo {
+        WindowRepo {
+            id: Some(format!("id-for-{path}")),
+            path: path.to_string(),
+        }
+    }
+
+    #[test]
+    fn labels_the_app_owns() {
+        assert!(is_repo_window("main"));
+        assert!(is_repo_window("pg-1"));
+        assert!(is_repo_window("pg-42"));
+        assert!(!is_repo_window("merge"));
+        assert!(!is_repo_window("pg-"));
+        assert!(!is_repo_window("pg-x"));
+        assert!(!is_repo_window("pg-1x"));
+        assert!(!is_repo_window("something"));
+    }
+
+    #[test]
+    fn next_label_takes_the_lowest_free_number() {
+        assert_eq!(next_label(&["main".into()]), "pg-1");
+        assert_eq!(next_label(&["main".into(), "pg-1".into()]), "pg-2");
+        // Reuse, not a high-water mark: closing pg-1 frees the name again.
+        assert_eq!(next_label(&["main".into(), "pg-2".into()]), "pg-1");
+    }
+
+    #[test]
+    fn routes_to_the_window_that_already_has_the_repository() {
+        let reg = WindowRegistry::default();
+        reg.register("main", vec![repo("/dev/api")]);
+        reg.register("pg-1", vec![repo("/dev/web")]);
+        let live = vec!["main".to_string(), "pg-1".to_string()];
+        assert_eq!(reg.route("/dev/web", &live).as_deref(), Some("pg-1"));
+        assert_eq!(reg.route("/dev/api", &live).as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn a_trailing_separator_is_the_same_repository() {
+        let reg = WindowRegistry::default();
+        reg.register("pg-1", vec![repo("/dev/web")]);
+        let live = vec!["main".to_string(), "pg-1".to_string()];
+        assert_eq!(reg.route("/dev/web/", &live).as_deref(), Some("pg-1"));
+    }
+
+    #[test]
+    fn falls_back_to_the_last_focused_window_then_the_first() {
+        let reg = WindowRegistry::default();
+        reg.register("main", vec![repo("/dev/api")]);
+        reg.register("pg-1", vec![repo("/dev/web")]);
+        let live = vec!["main".to_string(), "pg-1".to_string()];
+        // Nobody holds it.
+        assert_eq!(reg.route("/dev/other", &live).as_deref(), Some("main"));
+        reg.note_focus("pg-1");
+        assert_eq!(reg.route("/dev/other", &live).as_deref(), Some("pg-1"));
+        // A focus record for a window that has since closed is ignored.
+        assert_eq!(
+            reg.route("/dev/other", &["main".to_string()]).as_deref(),
+            Some("main")
+        );
+    }
+
+    #[test]
+    fn the_resolver_never_takes_focus_or_a_launch() {
+        let reg = WindowRegistry::default();
+        reg.note_focus("merge");
+        let live = vec!["main".to_string()];
+        assert_eq!(reg.route("/dev/other", &live).as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn no_live_window_routes_nowhere() {
+        let reg = WindowRegistry::default();
+        assert_eq!(reg.route("/dev/api", &[]), None);
+    }
+
+    #[test]
+    fn one_window_left_alive_is_told_so_it_can_forget_the_closed_one() {
+        let live = vec!["main".to_string(), "pg-1".to_string()];
+        assert_eq!(survivor_to_notify("pg-1", &live).as_deref(), Some("main"));
+        // The user closed `main` first: a sibling takes over as the pruner, so
+        // closing the rest of the windows still forgets them.
+        assert_eq!(survivor_to_notify("main", &live).as_deref(), Some("pg-1"));
+    }
+
+    #[test]
+    fn the_last_window_out_is_remembered() {
+        // The quit case, and the only thing that distinguishes it: there is
+        // nobody left to tell, so nothing prunes the session and every window
+        // that was up comes back.
+        assert_eq!(survivor_to_notify("main", &["main".to_string()]), None);
+        assert_eq!(survivor_to_notify("main", &[]), None);
+    }
+
+    #[test]
+    fn the_resolver_is_never_a_survivor() {
+        // A resolver left open while the last repository window closes must not
+        // make a quit look like a close — the session would be pruned and the
+        // user's windows would not come back. `live_repo_windows` is what keeps
+        // it out of the list `survivor_to_notify` ever sees.
+        let live: Vec<String> = ["main", "merge"]
+            .into_iter()
+            .filter(|l| is_repo_window(l))
+            .map(str::to_string)
+            .collect();
+        assert_eq!(live, vec!["main".to_string()]);
+        assert_eq!(survivor_to_notify("main", &live), None);
+    }
+
+    #[test]
+    fn taking_a_window_empties_it_once() {
+        let reg = WindowRegistry::default();
+        reg.register("pg-1", vec![repo("/dev/web")]);
+        assert_eq!(reg.take("pg-1").len(), 1);
+        assert_eq!(reg.take("pg-1").len(), 0);
+        assert_eq!(reg.holdings("pg-1").len(), 0);
+    }
+}

--- a/src-tauri/tauri.e2e.conf.json
+++ b/src-tauri/tauri.e2e.conf.json
@@ -6,9 +6,16 @@
         "default",
         {
           "identifier": "e2e-focus",
-          "description": "E2E-only: enable the WebDriver bridge (tauri-plugin-wdio-webdriver, gated behind the `e2e` cargo feature) and let the wdio harness force window focus (ensureMacAppFocus in e2e/support/app.ts). The unbundled debug binary doesn't reliably win foreground focus at launch; without focus WKWebView reports the page hidden and isDisplayed() lies. This capability is ONLY loaded via tauri.e2e.conf.json, so wdio-webdriver:default never reaches dev/production builds.",
-          "windows": ["main", "merge"],
-          "permissions": ["core:window:allow-set-focus", "wdio-webdriver:default"]
+          "description": "E2E-only: enable the WebDriver bridge (tauri-plugin-wdio-webdriver, gated behind the `e2e` cargo feature) and let the wdio harness force window focus (ensureMacAppFocus in e2e/support/app.ts). The unbundled debug binary doesn't reliably win foreground focus at launch; without focus WKWebView reports the page hidden and isDisplayed() lies. `pg-*` covers the repository windows #256 adds at runtime \u2014 a sibling window needs the same focus self-heal and bridge the main one does, and a label matching no pattern here silently has neither. This capability is ONLY loaded via tauri.e2e.conf.json, so wdio-webdriver:default never reaches dev/production builds.",
+          "windows": [
+            "main",
+            "merge",
+            "pg-*"
+          ],
+          "permissions": [
+            "core:window:allow-set-focus",
+            "wdio-webdriver:default"
+          ]
         }
       ]
     }

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -71,7 +71,8 @@ import { CreateTagDialog } from "@/features/tags/CreateTagDialog";
 import { OperationBar } from "@/features/repo/OperationBar";
 import { useSubmodulesStore } from "@/features/submodules/useSubmodulesStore";
 import { useWorktreesStore } from "@/features/worktrees/useWorktreesStore";
-import { openMergeWindow } from "@/features/merge/openMergeWindow";
+import { openMergeWindow, watchMergeHolding } from "@/features/merge/openMergeWindow";
+import { useWindowLifecycle } from "@/features/windows";
 import { UpdateChip } from "@/features/update/UpdateChip";
 import { UpdatePanel } from "@/features/update/UpdatePanel";
 import { useUpdateStore } from "@/features/update/useUpdateStore";
@@ -170,6 +171,15 @@ const ACTIVITY_ITEMS: ActivityBarItem[] = [
 export function AppShell() {
   usePreventBrowserContextMenu();
   useCliLaunch();
+  // Multiple windows (#256): restore the siblings at launch, remember where
+  // this one is, forget one the user closed.
+  useWindowLifecycle();
+  React.useEffect(() => {
+    // Which repository the resolver is on — see `openMergeWindow.ts`. Mounted
+    // here so every repository window has been listening since it started, not
+    // since it first asked.
+    watchMergeHolding();
+  }, []);
   const repo = useRepoStore((s) => s.current);
   const error = useRepoStore((s) => s.error);
   const clearError = useRepoStore((s) => s.clearError);

--- a/src/features/cli/useCliLaunch.test.tsx
+++ b/src/features/cli/useCliLaunch.test.tsx
@@ -2,7 +2,7 @@ import { render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { mockInvoke } from "@/test/invokeMock";
-import { emitMockEvent } from "@/test/eventMock";
+import { emitMockEvent, emitMockEventTo } from "@/test/eventMock";
 import { useTabsStore } from "@/features/repo/useTabsStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useCliLaunch } from "./useCliLaunch";
@@ -71,5 +71,67 @@ describe("useCliLaunch", () => {
         screen: "history",
       }),
     );
+  });
+});
+
+describe("useCliLaunch — which window (#256)", () => {
+  it("a sibling window does NOT take the first-launch intent", async () => {
+    // `take_launch_intent` is take-once. With several windows racing to mount,
+    // an ungated take would land `pgit ~/repo` in whichever asked first — a
+    // restored window on the second monitor as often as the one in front of
+    // the user. The forwarded event is a separate path and is routed backend
+    // side, so it still reaches exactly one window.
+    vi.resetModules();
+    vi.doMock("@tauri-apps/api/window", () => ({
+      getCurrentWindow: () => ({
+        label: "pg-1",
+        outerPosition: vi.fn().mockResolvedValue({ x: 0, y: 0 }),
+        outerSize: vi.fn().mockResolvedValue({ width: 1200, height: 800 }),
+        setTitle: vi.fn().mockResolvedValue(undefined),
+        show: vi.fn().mockResolvedValue(undefined),
+        theme: vi.fn().mockResolvedValue(null),
+        onThemeChanged: vi.fn().mockResolvedValue(() => {}),
+      }),
+    }));
+    const taken = vi.fn(() => ({ path: "/tmp/repo", screen: null }));
+    mockInvoke("take_launch_intent", taken);
+
+    const sibling = await import("./useCliLaunch");
+    const tabs = await import("@/features/repo/useTabsStore");
+    const siblingOpen = vi.fn().mockResolvedValue(undefined);
+    tabs.useTabsStore.setState({ openRepo: siblingOpen as never });
+
+    function SiblingProbe() {
+      sibling.useCliLaunch();
+      return null;
+    }
+    render(<SiblingProbe />);
+
+    await waitFor(() => expect(taken).not.toHaveBeenCalled());
+    expect(siblingOpen).not.toHaveBeenCalled();
+
+    // A forwarded launch routed to ANOTHER window must not land here. This is
+    // the half that a plain `listen()` gets wrong: an untargeted listener
+    // matches every emit, including one addressed to a single window, so
+    // `WindowRegistry::route`'s decision would be undone in the webview and
+    // every window would open the repository.
+    emitMockEventTo("main", "cli-launch", { path: "/tmp/main-only", screen: null });
+    expect(siblingOpen).not.toHaveBeenCalled();
+
+    // …one routed to THIS window does.
+    emitMockEventTo(
+      "pg-1",
+      "cli-launch",
+      { path: "/tmp/other", screen: null },
+    );
+    await waitFor(() => expect(siblingOpen).toHaveBeenCalledWith("/tmp/other"));
+
+    // And a genuine broadcast still reaches every window, so nothing that uses
+    // `app.emit` (fs://changed, net://progress) is affected by the scoping.
+    emitMockEvent("cli-launch", { path: "/tmp/broadcast", screen: null });
+    await waitFor(() => expect(siblingOpen).toHaveBeenCalledWith("/tmp/broadcast"));
+
+    vi.doUnmock("@tauri-apps/api/window");
+    vi.resetModules();
   });
 });

--- a/src/features/cli/useCliLaunch.ts
+++ b/src/features/cli/useCliLaunch.ts
@@ -1,10 +1,10 @@
 import React from "react";
-import { listen } from "@tauri-apps/api/event";
 
 import { takeLaunchIntent } from "@/lib/tauri";
 import type { LaunchIntent } from "@/lib/types";
 import { useTabsStore } from "@/features/repo/useTabsStore";
 import { useNavStore } from "@/features/nav/useNavStore";
+import { isPrimaryWindow, listenToThisWindow } from "@/features/windows";
 
 async function handleIntent(intent: LaunchIntent | null): Promise<void> {
   if (!intent) return;
@@ -24,14 +24,28 @@ async function handleIntent(intent: LaunchIntent | null): Promise<void> {
 }
 
 /**
- * CLI launch plumbing, mounted once in AppShell. Pulls the first-launch
- * intent (take-once command), then listens for `cli-launch` events forwarded
- * by the single-instance plugin when the user runs `pgit …` again.
+ * CLI launch plumbing, mounted once per window in AppShell. Pulls the
+ * first-launch intent (take-once command), then listens for `cli-launch`
+ * events forwarded by the single-instance plugin when the user runs `pgit …`
+ * again.
+ *
+ * Two things are scoped to a single window since #256. The first-launch intent
+ * is taken by the PRIMARY window only: `take_launch_intent` is take-once, so
+ * with several windows racing to mount, `pgit ~/repo` would land in whichever
+ * one happened to ask first — a restored window on the second monitor, as
+ * often as the one in front of the user. And the forwarded event is no longer
+ * a broadcast: the backend routes it to the window that already has that
+ * repository open, else the last-focused one, so this listener fires in exactly
+ * one window (`src-tauri/src/windows.rs`).
  */
 export function useCliLaunch(): void {
   React.useEffect(() => {
-    void takeLaunchIntent().then(handleIntent);
-    const unlisten = listen<LaunchIntent>("cli-launch", (e) => {
+    if (isPrimaryWindow()) void takeLaunchIntent().then(handleIntent);
+    // Scoped to THIS window, not a plain `listen`: an untargeted listener
+    // matches every emit, so the backend's routing would be undone here and
+    // every window would open the forwarded repository. See
+    // `features/windows/windowEvents.ts`.
+    const unlisten = listenToThisWindow<LaunchIntent>("cli-launch", (e) => {
       void handleIntent(e.payload);
     });
     return () => {

--- a/src/features/keymap/actions.ts
+++ b/src/features/keymap/actions.ts
@@ -33,6 +33,7 @@ import {
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useTabsStore } from "@/features/repo/useTabsStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
+import { openAppWindow } from "@/features/windows";
 import { useUpdateStore } from "@/features/update/useUpdateStore";
 import { createBranchInputStep, switchRepoStep } from "@/features/palette/steps";
 import { useFocusStore } from "./useFocusStore";
@@ -119,7 +120,10 @@ export type ActionId =
   | "tab.moveLeft"
   | "tab.moveRight"
   | "tab.select"
-  | "tab.switch";
+  | "tab.switch"
+  | "window.new"
+  | "window.newWithRepo"
+  | "window.moveTabOut";
 
 export interface ActionDef {
   id: ActionId;
@@ -580,6 +584,52 @@ export const ACTIONS: Record<ActionId, ActionDef> = {
     scope: "global",
     run: () => {
       usePaletteStore.getState().pushStep(switchRepoStep());
+      return true;
+    },
+  },
+
+  // ── repository windows (#256) ────────────────────────────────────────────
+  // Tabs are for switching, windows are for comparing. All three are ordinary
+  // catalog actions rather than AppShell wiring, so they reach the palette and
+  // the cheat sheet for free — and `window.new` is the only one with a default
+  // chord, because the other two are about a specific tab and read better from
+  // the tab's own context menu.
+  "window.new": {
+    id: "window.new",
+    title: "New window",
+    category: "Repository",
+    scope: "global",
+    run: () => {
+      void openAppWindow();
+      return true;
+    },
+  },
+  "window.newWithRepo": {
+    id: "window.newWithRepo",
+    title: "Open this repository in a new window",
+    category: "Repository",
+    scope: "global",
+    run: () => {
+      const path = useTabsStore.getState().activePath;
+      if (!path) return false;
+      void useTabsStore.getState().openInNewWindow(path);
+      return true;
+    },
+  },
+  "window.moveTabOut": {
+    id: "window.moveTabOut",
+    title: "Move this repository to a new window",
+    category: "Repository",
+    scope: "global",
+    run: () => {
+      const { activePath, tabs } = useTabsStore.getState();
+      if (!activePath) return false;
+      // Moving the ONLY tab out would close this window's last tab to open an
+      // identical window next to it — a no-op the user has to clean up. The
+      // "open in a new window" action is the one that makes sense there, and it
+      // is one row away in the same palette.
+      if (tabs.length < 2) return false;
+      void useTabsStore.getState().moveTabToNewWindow(activePath);
       return true;
     },
   },

--- a/src/features/keymap/presets.ts
+++ b/src/features/keymap/presets.ts
@@ -184,6 +184,22 @@ const COMMON = {
   "tab.moveLeft": ["Mod+Shift+ArrowLeft"],
   "tab.moveRight": ["Mod+Shift+ArrowRight"],
   "tab.switch": ["Mod+E"],
+  // Windows (#256). No free letter says "window": ⌘⇧N — the chord every other
+  // app uses for one — is New repository here and has been since the keymap
+  // shipped, and ⌘⇧W reads as *close* window everywhere, which is the worst
+  // possible thing for a chord that opens one. So the family is keyed on D for
+  // **d**etach, the one verb that fits all three.
+  //
+  // ⌘⇧G and ⌘⇧B carry no meaning; they are simply keys nothing else claims.
+  // That is on purpose rather than a placeholder: both actions are context-menu
+  // and palette actions first (they are about a NAMED tab, which is what the
+  // menu gives them and a chord cannot), every preset must bind every action,
+  // and an unmemorable chord is better than one that collides with muscle
+  // memory — ⌘⇧P, ⌘⇧F, ⌘⇧R, ⌘⇧V and ⌘⇧X are all spoken for elsewhere in the
+  // world, for the reasons the platypusgit preset's own comment lists.
+  "window.new": ["Mod+Shift+D"],
+  "window.newWithRepo": ["Mod+Shift+G"],
+  "window.moveTabOut": ["Mod+Shift+B"],
 } satisfies Partial<Record<ActionId, string[]>>;
 
 export const RIDER_PRESET: KeymapPreset = {

--- a/src/features/merge/MergeWindow.tsx
+++ b/src/features/merge/MergeWindow.tsx
@@ -344,6 +344,22 @@ export function MergeWindow() {
     };
   }, []);
 
+  // Say which repository this window is on, whenever it changes (#256).
+  //
+  // Every repository window needs the answer, and only this window has it: the
+  // `repoId` lives in this window's URL and no other webview can read it back.
+  // Before multiple windows existed, the one window that could open a resolver
+  // was also the one that had to guard against evicting its repository, so it
+  // could just remember what it had asked for. Now the resolver may have been
+  // opened by a window that is not the one closing a tab — and since each
+  // window opens its OWN `RepoId` for a repository, closing a tab in a
+  // different window cannot hurt this one. Broadcasting the id is what lets the
+  // guard tell those two cases apart instead of confirming in both.
+  React.useEffect(() => {
+    if (!repoId) return;
+    void emit("merge://holding", { repoId });
+  }, [repoId]);
+
   // --- Chord table: window-level keydown, capture phase (beats CM keymap) --
   // Rebuilt each render so the listener always sees latest closures.
   const actions = React.useRef<Record<string, () => void>>({});

--- a/src/features/merge/openMergeWindow.ts
+++ b/src/features/merge/openMergeWindow.ts
@@ -2,22 +2,49 @@
 // own data over IPC; the only cross-window state is events.
 
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
-import { emit } from "@tauri-apps/api/event";
+import { emit, listen } from "@tauri-apps/api/event";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 
 /**
  * Which repository a live resolver window is working on, as far as THIS webview
- * knows — the window carries its `repoId` in its own URL, and main has no way to
- * read that back. `attributed` is false when a live window was not opened by this
- * page instance (main reloaded while the resolver stayed up), which callers must
- * treat as "it might be any repository".
+ * knows. `attributed` is false when a live window was not opened by this page
+ * instance and has not announced itself either, which callers must treat as
+ * "it might be any repository".
+ *
+ * Two producers set it. This module, when it opens or retargets the window —
+ * and the resolver itself, over `merge://holding`. The second exists because
+ * since #256 there can be several repository windows: the resolver may have
+ * been opened by a window that is not the one now closing a tab, and each
+ * window opens its own `RepoId`, so "some resolver is up" stopped being a good
+ * enough reason to confirm. The announcement is what lets a window that did not
+ * open it still compare ids.
  */
 let liveMerge: { repoId: string; attributed: boolean } | null = null;
+
+// Never unsubscribed — its lifetime is the window's, like the appearance watch.
+// Guarded so a hot reload does not stack listeners.
+let holdingWatch: Promise<() => void> | null = null;
+
+/**
+ * Start listening for the resolver's "I am on this repository" announcement.
+ *
+ * Idempotent, and mounted from `AppShell` rather than started lazily: the
+ * announcement is emitted when the resolver opens, and the window that needs to
+ * have heard it is whichever one later closes a tab. A listener registered at
+ * that moment would already have missed it.
+ */
+export function watchMergeHolding(): void {
+  if (holdingWatch) return;
+  holdingWatch = listen<{ repoId: string }>("merge://holding", (e) => {
+    if (e.payload?.repoId) liveMerge = { repoId: e.payload.repoId, attributed: true };
+  });
+}
 
 /** Test-only: forget which repository a live resolver is on, the state a fresh
  *  page load starts from. Same shape as `__resetDialogs`. */
 export function __resetMergeAttribution(): void {
   liveMerge = null;
+  holdingWatch = null;
 }
 
 /**
@@ -30,6 +57,7 @@ export function __resetMergeAttribution(): void {
  * far cheaper than breaking a conflict resolution in progress.
  */
 export async function mergeWindowHoldsRepo(repoId: string): Promise<boolean> {
+  watchMergeHolding();
   const existing = await WebviewWindow.getByLabel("merge");
   if (!existing) {
     liveMerge = null;

--- a/src/features/palette/commands.test.ts
+++ b/src/features/palette/commands.test.ts
@@ -552,3 +552,58 @@ describe("fileItems", () => {
     expect(order).toEqual(["close", "pick:src/a.txt"]);
   });
 });
+
+describe("repository windows (#256)", () => {
+  // The palette is a CURATED list, not a projection of the action catalog —
+  // adding an action to `ACTIONS` does not put it here. That gap is what an
+  // e2e run found ("palette row 'New window' never appeared") after the
+  // actions, the chords and the tab menu were all already wired.
+  it("always offers a new window, with no repository open", () => {
+    useTabsStore.setState({ tabs: [], activePath: null });
+    expect(ids()).toContain("action:new-window");
+    // The two that name THIS repository need one.
+    expect(ids()).not.toContain("action:repo-new-window");
+    expect(ids()).not.toContain("action:move-tab-window");
+  });
+
+  it("offers 'open in a new window' as soon as a repository is open", () => {
+    useTabsStore.setState({
+      tabs: [newTab("/dev/api", { status: "open", repoId: "r-api" })],
+      activePath: "/dev/api",
+    });
+    expect(ids()).toContain("action:repo-new-window");
+    // Moving the ONLY tab out would close this window's last tab to open an
+    // identical window beside it.
+    expect(ids()).not.toContain("action:move-tab-window");
+  });
+
+  it("offers 'move to a new window' once there is a tab to leave behind", () => {
+    useTabsStore.setState({
+      tabs: [
+        newTab("/dev/api", { status: "open", repoId: "r-api" }),
+        newTab("/dev/web", { status: "open", repoId: "r-web" }),
+      ],
+      activePath: "/dev/api",
+    });
+    expect(ids()).toContain("action:move-tab-window");
+  });
+
+  it("moves the ACTIVE tab, read at click time", () => {
+    const moveTabToNewWindow = vi.fn();
+    useTabsStore.setState({
+      tabs: [
+        newTab("/dev/api", { status: "open", repoId: "r-api" }),
+        newTab("/dev/web", { status: "open", repoId: "r-web" }),
+      ],
+      activePath: "/dev/api",
+      moveTabToNewWindow: moveTabToNewWindow as never,
+    });
+    const item = buildCommands().find((i) => i.id === "action:move-tab-window");
+    // Re-read from the store rather than closed over: the palette list is built
+    // when it opens, and the user can switch tabs before pressing Enter.
+    useTabsStore.setState({ activePath: "/dev/web" });
+    item!.run();
+    expect(moveTabToNewWindow).toHaveBeenCalledWith("/dev/web");
+  });
+});
+

--- a/src/features/palette/commands.ts
+++ b/src/features/palette/commands.ts
@@ -2,6 +2,7 @@
 import { pgConfirm, pgFlash } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useCreateStore } from "@/features/create/useCreateStore";
+import { openAppWindow } from "@/features/windows";
 import { useLfsStore } from "@/features/lfs/useLfsStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
@@ -364,6 +365,44 @@ export function buildCommands(): PaletteItem[] {
     run: step(() => switchRepoStep()),
   });
   const tabs = useTabsStore.getState();
+
+  // -- repository windows (#256) --
+  // "New window" is always listed: an empty window is a starting point, not
+  // something you need a repository to reach. The other two name the ACTIVE
+  // repository, so they appear only when there is one — and moving out needs a
+  // second tab to be left behind, or the window closes its last tab to open an
+  // identical one beside it.
+  items.push({
+    type: "command", id: "action:new-window",
+    search: "New window open second monitor side by side",
+    label: "New window", icon: "plus", actionId: "window.new",
+    run: direct(() => void openAppWindow()),
+  });
+  if (tabs.activePath) {
+    items.push({
+      type: "command", id: "action:repo-new-window",
+      search: "Open repository in new window second monitor compare",
+      label: "Open this repository in a new window", icon: "repo",
+      actionId: "window.newWithRepo",
+      run: direct(() => {
+        const path = useTabsStore.getState().activePath;
+        if (path) void useTabsStore.getState().openInNewWindow(path);
+      }),
+    });
+  }
+  if (tabs.activePath && tabs.tabs.length > 1) {
+    items.push({
+      type: "command", id: "action:move-tab-window",
+      search: "Move repository tab to new window detach",
+      label: "Move this repository to a new window", icon: "repo",
+      actionId: "window.moveTabOut",
+      run: direct(() => {
+        const path = useTabsStore.getState().activePath;
+        if (path) void useTabsStore.getState().moveTabToNewWindow(path);
+      }),
+    });
+  }
+
   if (tabs.activePath) {
     items.push({
       type: "command", id: "action:close-repo-tab",

--- a/src/features/repo/RepoTabs.tsx
+++ b/src/features/repo/RepoTabs.tsx
@@ -128,6 +128,25 @@ export function tabMenuItems(
       onClick: move(1),
     },
     { divider: true },
+    // Windows (#256). Here rather than only in the palette because both actions
+    // are about THIS tab, and the menu is the one surface that already says
+    // which tab that is. "Move to a new window" needs a second tab to move away
+    // from — moving the only one out would close this window's last tab to open
+    // an identical window beside it.
+    {
+      label: "Open in new window",
+      icon: "copy",
+      shortcut: chordFor("window.newWithRepo"),
+      onClick: () => void tabs().openInNewWindow(path),
+    },
+    {
+      label: "Move to new window",
+      icon: "chevronRight",
+      shortcut: chordFor("window.moveTabOut"),
+      disabled: total < 2,
+      onClick: () => void tabs().moveTabToNewWindow(path),
+    },
+    { divider: true },
     {
       label: "Close",
       icon: "x",

--- a/src/features/repo/tabs.ts
+++ b/src/features/repo/tabs.ts
@@ -6,9 +6,10 @@
 //
 // `useTabsStore` is the thin store on top; `RepoTabs` is the strip.
 
+import { OPEN_REPOS_KEY } from "@/features/windows/windowKind";
+
 import type { RepoSlice } from "./repoSlice";
 
-const OPEN_REPOS_KEY = "pg-open-repos";
 /** Bound on the persisted open set. Generous — it exists so a corrupted or
  *  runaway value can't make startup pathological, not to police workflow. */
 const OPEN_LIMIT = 20;
@@ -211,15 +212,22 @@ export function labelTabs(tabs: RepoTab[]): string[] {
 // with separate meanings: recents are where you have BEEN, the open set is
 // where you ARE. Opening a repository still pushes a recent, so the two stay
 // consistent without one becoming the other.
+//
+// Both take a `key`, because since #256 the open set is PER WINDOW: `main`
+// keeps writing the bare `pg-open-repos` it has written since #90 and a sibling
+// window writes `pg-open-repos:<label>` (`features/windows/windowKind.ts` owns
+// that mapping). The default keeps every caller that means "this window" —
+// which, in a single-window build, was every caller — reading the same key it
+// always did.
 
 export interface OpenRepos {
   paths: string[];
   active: string | null;
 }
 
-export function loadOpenRepos(): OpenRepos {
+export function loadOpenRepos(key: string = OPEN_REPOS_KEY): OpenRepos {
   try {
-    const raw = localStorage.getItem(OPEN_REPOS_KEY);
+    const raw = localStorage.getItem(key);
     if (!raw) return { paths: [], active: null };
     const parsed = JSON.parse(raw) as unknown;
     if (!parsed || typeof parsed !== "object") return { paths: [], active: null };
@@ -246,7 +254,13 @@ export function loadOpenRepos(): OpenRepos {
   }
 }
 
-export function saveOpenRepos(tabs: RepoTab[], active: string | null): void {
+/** `tabs` is read for its paths only, so a caller seeding a window it has not
+ *  opened yet can pass bare `{ path }` records (`openAppWindow`). */
+export function saveOpenRepos(
+  tabs: Pick<RepoTab, "path">[],
+  active: string | null,
+  key: string = OPEN_REPOS_KEY,
+): void {
   try {
     const paths = tabs.map((t) => repoPathKey(t.path)).slice(0, OPEN_LIMIT);
     const activeKey = active ? repoPathKey(active) : null;
@@ -254,7 +268,7 @@ export function saveOpenRepos(tabs: RepoTab[], active: string | null): void {
       paths,
       active: activeKey && paths.includes(activeKey) ? activeKey : (paths[0] ?? null),
     };
-    localStorage.setItem(OPEN_REPOS_KEY, JSON.stringify(value));
+    localStorage.setItem(key, JSON.stringify(value));
   } catch {
     // quota errors are non-fatal — the session just won't restore
   }

--- a/src/features/repo/useTabsStore.mergeGuard.test.tsx
+++ b/src/features/repo/useTabsStore.mergeGuard.test.tsx
@@ -23,7 +23,9 @@ import {
 import {
   __resetMergeAttribution,
   openMergeWindow,
+  watchMergeHolding,
 } from "@/features/merge/openMergeWindow";
+import { emitMockEvent } from "@/test/eventMock";
 import { emptySlice } from "./repoSlice";
 import { newTab } from "./tabs";
 import { useRepoStore } from "./useRepoStore";
@@ -173,5 +175,44 @@ describe("closing a tab with the merge resolver open", () => {
     expect(dialogIsOpen()).toBe(false);
     expect(closeRepoCalls().map((c) => c.args.repoId)).toEqual(["r-api"]);
     expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual(["/dev/web"]);
+  });
+});
+
+describe("the resolver's own announcement (#256)", () => {
+  // With several repository windows, "a resolver is up" stopped being a good
+  // enough reason to confirm: the window closing a tab may not be the one that
+  // opened the resolver, and every window opens its OWN RepoId — so its close
+  // cannot break the resolver. `merge://holding` is what lets the guard tell
+  // the two cases apart. Fired via the store's real close path, so the
+  // assertion is on the behaviour the user sees, not on the predicate.
+  it("does not confirm when the resolver names a DIFFERENT repository", async () => {
+    render(<PGDialogHost />);
+    armLiveMergeWindow();
+    // This window never opened the resolver — the attribution comes from the
+    // announcement alone. AppShell starts this listener at mount, long before
+    // any tab is closed, which is the point: a listener registered at close
+    // time would already have missed the announcement.
+    watchMergeHolding();
+    emitMockEvent("merge://holding", { repoId: "r-web" });
+
+    await useTabsStore.getState().close("/dev/api");
+
+    expect(dialogIsOpen()).toBe(false);
+    expect(closeRepoCalls().map((c) => c.args.repoId)).toEqual(["r-api"]);
+    expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual(["/dev/web"]);
+  });
+
+  it("still confirms when the announcement names THIS repository", async () => {
+    render(<PGDialogHost />);
+    armLiveMergeWindow();
+    watchMergeHolding();
+    emitMockEvent("merge://holding", { repoId: "r-api" });
+
+    const closing = useTabsStore.getState().close("/dev/api");
+    await waitFor(() => expect(dialogIsOpen()).toBe(true));
+    await dismissDialog();
+    await closing;
+
+    expect(closeRepoCalls()).toHaveLength(0);
   });
 });

--- a/src/features/repo/useTabsStore.ts
+++ b/src/features/repo/useTabsStore.ts
@@ -31,7 +31,13 @@ import {
   closeMergeWindow,
   mergeWindowHoldsRepo,
 } from "@/features/merge/openMergeWindow";
-import { closeRepo as closeRepoIpc, getStatus, termClose } from "@/lib/tauri";
+import {
+  closeRepo as closeRepoIpc,
+  getStatus,
+  registerWindowRepos,
+  termClose,
+} from "@/lib/tauri";
+import { openAppWindow, openReposKey, windowLabel } from "@/features/windows";
 import { useTerminalStore } from "@/features/terminal/useTerminalStore";
 import type { RepoHandle } from "@/lib/types";
 import { isConflicted, isStaged, isUnstaged } from "@/lib/derive";
@@ -97,6 +103,16 @@ interface TabsState {
   /** Recreate the persisted open set as pending tabs and activate the persisted
    *  active one. Lazy: only that one repository is actually opened. */
   restoreSession: () => Promise<void>;
+  /**
+   * Open `path` in a NEW window (#256), leaving this window as it is.
+   *
+   * Tabs are for switching, windows are for comparing — this is the second
+   * half. The new window opens its own `RepoId` for the repository, so the two
+   * windows share nothing that one could break for the other.
+   */
+  openInNewWindow: (path: string) => Promise<void>;
+  /** Same, but the tab leaves this window. */
+  moveTabToNewWindow: (path: string) => Promise<void>;
   /** Display labels, parent-disambiguated for colliding names. */
   labels: () => string[];
 }
@@ -109,7 +125,25 @@ function countsOf(slice: RepoSlice): { dirty: number; conflicts: number } {
 }
 
 export const useTabsStore = create<TabsState>((set, get) => {
-  const persist = () => saveOpenRepos(get().tabs, get().activePath);
+  /**
+   * Which storage key this window's open set lives under (#256). Read once —
+   * a window's label cannot change — and `main` still writes the bare
+   * `pg-open-repos` it has written since #90, so an upgrading user's session
+   * restores exactly as before.
+   */
+  const storageKey = openReposKey(windowLabel());
+
+  const persist = () => {
+    saveOpenRepos(get().tabs, get().activePath, storageKey);
+    // The backend half of the same write. It answers two questions no webview
+    // can answer about another window: where a forwarded `pgit <path>` should
+    // land, and what to evict when this window is closed. Fire-and-forget —
+    // a registry that is one write behind costs a mis-routed launch, which is
+    // not worth failing a tab switch over.
+    void registerWindowRepos(
+      get().tabs.map((t) => ({ id: t.repoId, path: t.path })),
+    ).catch(() => {});
+  };
 
   /** Freeze the live slice into the tab at `path` (it is about to lose it). */
   const snapshotInto = (path: string) => {
@@ -419,13 +453,30 @@ export const useTabsStore = create<TabsState>((set, get) => {
 
     async restoreSession() {
       if (get().tabs.length > 0) return;
-      const { paths, active } = loadOpenRepos();
+      const { paths, active } = loadOpenRepos(storageKey);
       if (paths.length === 0) return;
       set({ tabs: paths.map((p) => newTab(p)) });
       const target = active ?? paths[0];
       // Lazy on purpose: five persisted repositories cost ONE open at launch,
       // not five. The rest open when first activated.
       await get().activate(target);
+    },
+
+    async openInNewWindow(path) {
+      const tab = findTab(get().tabs, path);
+      await openAppWindow({ seedPaths: [tab?.path ?? path] });
+    },
+
+    async moveTabToNewWindow(path) {
+      const tab = findTab(get().tabs, path);
+      if (!tab) return;
+      const label = await openAppWindow({ seedPaths: [tab.path] });
+      // Only close the tab once the window it is moving to actually exists.
+      // A failed creation that had already closed the tab would lose the
+      // repository from both windows — the one place in this store where a
+      // failure could take work away rather than leave it where it was.
+      if (!label) return;
+      await get().close(tab.path);
     },
 
     labels() {

--- a/src/features/repo/useTabsStore.windows.test.ts
+++ b/src/features/repo/useTabsStore.windows.test.ts
@@ -1,0 +1,206 @@
+// Per-window tab state (#256). The tab model is unchanged; what is new is that
+// a window's open set is ITS open set, and that a tab can leave for a window of
+// its own.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { __resetWindowClaims, openReposKey } from "@/features/windows";
+import { emptySlice } from "./repoSlice";
+import { useRepoStore } from "./useRepoStore";
+import { useTabsStore } from "./useTabsStore";
+
+const HANDLES: Record<string, { id: string; path: string; head: string }> = {
+  "/dev/api": { id: "r-api", path: "/dev/api", head: "main" },
+  "/dev/web": { id: "r-web", path: "/dev/web", head: "trunk" },
+};
+
+function armBackend() {
+  mockInvoke("open_repo", (args) => {
+    const h = HANDLES[args.path as string];
+    if (!h) throw { kind: "InvalidPath", message: args.path };
+    return h;
+  });
+  mockInvoke("close_repo", () => undefined);
+  mockInvoke("term_close", () => undefined);
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => []);
+  mockInvoke("list_tags", () => []);
+  mockInvoke("list_stashes", () => []);
+  mockInvoke("list_remotes", () => []);
+  mockInvoke("get_log_page", () => ({ commits: [], nextCursor: null }));
+  mockInvoke("repo_state", () => "Clean");
+  mockInvoke("rebase_status", () => null);
+  mockInvoke("list_all_files", () => []);
+  mockInvoke("register_window_repos", () => undefined);
+  mockInvoke("next_window_label", () => "pg-1");
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  resetInvokeMock();
+  armBackend();
+  // Which labels this webview has already handed out is module state, exactly
+  // like the resolver's attribution — a leak between tests would make the
+  // second one silently assert on `pg-2`.
+  __resetWindowClaims();
+  useTabsStore.setState({
+    tabs: [],
+    activePath: null,
+    activationSeq: 0,
+    activating: null,
+  });
+  useRepoStore.setState(emptySlice());
+});
+
+const calls = (cmd: string) => getInvokeCalls().filter((c) => c.cmd === cmd);
+
+describe("the backend registry stays in step with the strip", () => {
+  it("registers this window's repositories on every persist", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+
+    const last = calls("register_window_repos").at(-1);
+    // Both id and path: the id is what an eviction needs, the path is what
+    // routing a `pgit <path>` compares against.
+    expect(last?.args.repos).toEqual([
+      { id: "r-api", path: "/dev/api" },
+      { id: "r-web", path: "/dev/web" },
+    ]);
+  });
+
+  it("registers a still-pending tab too, so routing works before it opens", async () => {
+    useTabsStore.setState({ tabs: [{ ...newPending("/dev/web") }] });
+    await useTabsStore.getState().openRepo("/dev/api");
+    const last = calls("register_window_repos").at(-1);
+    expect(last?.args.repos).toContainEqual({ id: null, path: "/dev/web" });
+  });
+
+  it("a registry write that fails never fails the tab switch", async () => {
+    mockInvoke("register_window_repos", () => {
+      throw { kind: "Internal", message: "no" };
+    });
+    await useTabsStore.getState().openRepo("/dev/api");
+    expect(useTabsStore.getState().activePath).toBe("/dev/api");
+  });
+});
+
+function newPending(path: string) {
+  return {
+    path,
+    repoId: null,
+    status: "pending" as const,
+    screen: "history",
+    slice: null,
+    dirty: 0,
+    conflicts: 0,
+  };
+}
+
+describe("opening a repository in a new window", () => {
+  it("seeds the new window's own storage key and keeps this window's tab", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openInNewWindow("/dev/api");
+
+    // Seeded through STORAGE, before the window exists — see openAppWindow.
+    expect(JSON.parse(localStorage.getItem(openReposKey("pg-1")) as string)).toEqual({
+      paths: ["/dev/api"],
+      active: "/dev/api",
+    });
+    // "Open in" a new window, not "move to" one.
+    expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual(["/dev/api"]);
+  });
+
+  it("records the new window so a launch after a quit brings it back", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openInNewWindow("/dev/api");
+    expect(JSON.parse(localStorage.getItem("pg-windows") as string)).toEqual([
+      { label: "pg-1", bounds: { x: 32, y: 32, width: 1200, height: 800 } },
+    ]);
+  });
+});
+
+describe("moving a repository to a new window", () => {
+  it("seeds the new window and closes the tab here", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+
+    await useTabsStore.getState().moveTabToNewWindow("/dev/web");
+
+    expect(JSON.parse(localStorage.getItem(openReposKey("pg-1")) as string)).toEqual({
+      paths: ["/dev/web"],
+      active: "/dev/web",
+    });
+    expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual(["/dev/api"]);
+    // The tab left, so its repository is evicted here — the new window opens
+    // its OWN RepoId for the same path.
+    expect(calls("close_repo").map((c) => c.args.repoId)).toContain("r-web");
+  });
+
+  it("keeps the tab when the window could not be created", async () => {
+    mockInvoke("next_window_label", () => {
+      throw { kind: "Internal", message: "no label" };
+    });
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().openRepo("/dev/web");
+
+    await useTabsStore.getState().moveTabToNewWindow("/dev/web");
+
+    // The one place in this store where a failure could take work away rather
+    // than leave it where it was.
+    expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual([
+      "/dev/api",
+      "/dev/web",
+    ]);
+  });
+
+  it("does nothing for a tab that is not open here", async () => {
+    await useTabsStore.getState().openRepo("/dev/api");
+    await useTabsStore.getState().moveTabToNewWindow("/dev/nowhere");
+    expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual(["/dev/api"]);
+    expect(localStorage.getItem(openReposKey("pg-1"))).toBeNull();
+  });
+});
+
+describe("a sibling window", () => {
+  it("persists and restores under its OWN key, leaving main's session alone", async () => {
+    // The store reads its label once, at creation, so a sibling needs a fresh
+    // module graph with a different window mock.
+    vi.resetModules();
+    vi.doMock("@tauri-apps/api/window", () => ({
+      getCurrentWindow: () => ({
+        label: "pg-1",
+        outerPosition: vi.fn().mockResolvedValue({ x: 0, y: 0 }),
+        outerSize: vi.fn().mockResolvedValue({ width: 1200, height: 800 }),
+        setTitle: vi.fn().mockResolvedValue(undefined),
+        show: vi.fn().mockResolvedValue(undefined),
+        theme: vi.fn().mockResolvedValue(null),
+        onThemeChanged: vi.fn().mockResolvedValue(() => {}),
+      }),
+    }));
+    localStorage.setItem(
+      "pg-open-repos",
+      JSON.stringify({ paths: ["/dev/api"], active: "/dev/api" }),
+    );
+    localStorage.setItem(
+      "pg-open-repos:pg-1",
+      JSON.stringify({ paths: ["/dev/web"], active: "/dev/web" }),
+    );
+
+    const sibling = await import("./useTabsStore");
+    await sibling.useTabsStore.getState().restoreSession();
+
+    expect(sibling.useTabsStore.getState().tabs.map((t) => t.path)).toEqual(["/dev/web"]);
+    // main's set is untouched by a sibling's writes.
+    expect(JSON.parse(localStorage.getItem("pg-open-repos") as string)).toEqual({
+      paths: ["/dev/api"],
+      active: "/dev/api",
+    });
+    expect(JSON.parse(localStorage.getItem("pg-open-repos:pg-1") as string)).toEqual({
+      paths: ["/dev/web"],
+      active: "/dev/web",
+    });
+    vi.doUnmock("@tauri-apps/api/window");
+    vi.resetModules();
+  });
+});

--- a/src/features/windows/index.ts
+++ b/src/features/windows/index.ts
@@ -1,0 +1,36 @@
+// Multiple windows (#256). See `docs/superpowers/specs/2026-09-04-multiple-windows-spec.md`.
+
+export {
+  MAIN_LABEL,
+  MERGE_LABEL,
+  REPO_WINDOW_PREFIX,
+  OPEN_REPOS_KEY,
+  WINDOWS_KEY,
+  WINDOW_CLOSED_EVENT,
+  WINDOW_LIMIT,
+  CASCADE_STEP,
+  cascadeFrom,
+  forgetWindow,
+  isRepoWindowLabel,
+  loadWindowRecords,
+  openReposKey,
+  rememberWindow,
+  saveWindowRecords,
+  type WindowBounds,
+  type WindowRecord,
+} from "./windowKind";
+export {
+  openAppWindow,
+  currentBounds,
+  chromeOptions,
+  releaseWindowLabel,
+  __resetWindowClaims,
+} from "./openAppWindow";
+export { listenToThisWindow } from "./windowEvents";
+export {
+  isPrimaryWindow,
+  restoreWindows,
+  useWindowLifecycle,
+  windowLabel,
+  __resetWindowRestore,
+} from "./useWindowLifecycle";

--- a/src/features/windows/openAppWindow.ts
+++ b/src/features/windows/openAppWindow.ts
@@ -1,0 +1,247 @@
+// Creating a repository window (#256).
+//
+// The merge resolver (`features/merge/openMergeWindow.ts`) is the precedent: a
+// second Tauri window running this same bundle. A repository window differs in
+// two ways. It carries no query param — `main.tsx` routes only `?window=merge`,
+// and everything else is the full app — and it is seeded through STORAGE rather
+// than through the URL: the seed is written under the new window's own
+// open-repositories key before the window exists, so the new window restores
+// into it through its ordinary session-restore path, with no cross-window IPC
+// and nothing to replay if it reloads.
+
+import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { PhysicalPosition, PhysicalSize } from "@tauri-apps/api/dpi";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { warn as logWarn } from "@tauri-apps/plugin-log";
+
+import { getPlatform } from "@/lib/platform";
+import { describeError } from "@/lib/errors";
+import { nextWindowLabel } from "@/lib/tauri";
+import { saveOpenRepos } from "@/features/repo/tabs";
+import {
+  cascadeFrom,
+  forgetWindow,
+  isRepoWindowLabel,
+  openReposKey,
+  rememberWindow,
+  REPO_WINDOW_PREFIX,
+  type WindowBounds,
+  type WindowRecord,
+} from "./windowKind";
+
+/**
+ * Labels this webview has already asked for.
+ *
+ * `next_window_label` answers from the windows Tauri knows about, and a window
+ * is not in that list the instant its constructor returns — the creation is a
+ * message. So two "New window" clicks in quick succession both get `pg-1`, and
+ * the second one loses: its `WebviewWindow` fails on the duplicate label, and
+ * on the way there it has already overwritten the first window's seed.
+ *
+ * Remembering what we asked for closes that window without a lock or a retry:
+ * the backend's answer is a floor, and a label we have already claimed is
+ * skipped. Released when the window is closed, so labels stay reusable across a
+ * long session.
+ */
+const claimed = new Set<string>();
+
+/** Take the lowest free label at or above the backend's answer. */
+function claimLabel(fromBackend: string): string {
+  let label = fromBackend;
+  if (claimed.has(label)) {
+    // Only a well-formed `pg-<n>` can be bumped; anything else is passed
+    // through so the failure is the backend's answer, not a label we invented.
+    const n = Number(label.slice(REPO_WINDOW_PREFIX.length));
+    if (isRepoWindowLabel(label) && Number.isInteger(n)) {
+      let next = n;
+      do {
+        next += 1;
+        label = `${REPO_WINDOW_PREFIX}${next}`;
+      } while (claimed.has(label));
+    }
+  }
+  claimed.add(label);
+  return label;
+}
+
+/** Let a label be handed out again once its window is gone. */
+export function releaseWindowLabel(label: string): void {
+  claimed.delete(label);
+}
+
+/** Test seam — the claim set is module state, like the resolver's attribution. */
+export function __resetWindowClaims(): void {
+  claimed.clear();
+}
+
+/** The literal `--bg-0` of the default dark theme, as the main window and the
+ *  resolver both carry it. Without it both the window and webview layers
+ *  default to white and a new window flashes a white rectangle before the dark
+ *  UI arrives — see the startup-paint rule in CLAUDE.md. */
+export const WINDOW_BACKGROUND = "#0d1013";
+
+/** The geometry `tauri.conf.json` gives `main`, so a second window is the same
+ *  window rather than a smaller one. */
+const DEFAULTS = { width: 1200, height: 800, minWidth: 800, minHeight: 600 };
+
+/**
+ * Where the current window is, in physical pixels — the anchor a new window
+ * cascades off, and what a sibling writes back as it is moved. Null when it
+ * cannot be read, which every caller reads as "let the OS decide".
+ */
+export async function currentBounds(): Promise<WindowBounds | null> {
+  try {
+    const win = getCurrentWindow();
+    const [pos, size] = await Promise.all([win.outerPosition(), win.outerSize()]);
+    return { x: pos.x, y: pos.y, width: size.width, height: size.height };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Chrome the runtime has to pass explicitly, because a window created at
+ * runtime does not inherit `tauri.conf.json`'s.
+ *
+ * macOS keeps the native traffic lights and lets content run under them
+ * (`overlay` + the same traffic-light offset `main` uses). Windows and Linux
+ * drop the OS frame entirely and render `PGWindowControls` instead.
+ *
+ * Passed at CREATION rather than applied afterwards on purpose. `lib.rs` records
+ * what stripping the frame after the fact cost on Windows: the window was
+ * created decorated and shown, and the native title bar appeared and then
+ * vanished.
+ */
+export async function chromeOptions(): Promise<Record<string, unknown>> {
+  const platform = await getPlatform();
+  if (platform === "macos") {
+    return {
+      titleBarStyle: "overlay",
+      hiddenTitle: true,
+      trafficLightPosition: { x: 12, y: 20 },
+    };
+  }
+  return { decorations: false };
+}
+
+/**
+ * Put the window where it was, in PHYSICAL pixels.
+ *
+ * Deliberately NOT `WebviewWindowOptions`' `x`/`y`/`width`/`height`, which are
+ * LOGICAL units: the bounds we remember are physical (see `WindowBounds`), and
+ * handing physical numbers to a logical option is wrong by the scale factor —
+ * on a 2× display a window would come back at twice its size, on the wrong part
+ * of the wrong monitor. `setPosition`/`setSize` take the unit explicitly, so
+ * there is nothing to convert and no scale factor to guess at for a monitor the
+ * window has not landed on yet.
+ *
+ * Runs while the window is still hidden (see the creation call), so there is no
+ * visible jump from the default geometry to this one. Failure is a nicety lost,
+ * never an error: the window is already open and usable wherever the OS put it.
+ */
+async function applyBounds(
+  win: WebviewWindow,
+  bounds: WindowBounds | null,
+): Promise<void> {
+  if (!bounds) return;
+  try {
+    await win.setPosition(new PhysicalPosition(bounds.x, bounds.y));
+    await win.setSize(new PhysicalSize(bounds.width, bounds.height));
+  } catch (e) {
+    logWarn(`could not place window ${win.label}: ${describeError(e)}`);
+  }
+}
+
+export interface NewWindowOptions {
+  /** Repositories the new window opens with, in tab order. Empty → Welcome. */
+  seedPaths?: string[];
+  /** Which of them is active. Defaults to the first. */
+  seedActive?: string | null;
+  /**
+   * Recreate a window that already exists in the restore set, at its remembered
+   * place. Mutually exclusive with the seed fields: a restored window's
+   * repositories are already sitting under its own storage key, which is the
+   * whole point of seeding through storage.
+   */
+  restore?: WindowRecord;
+}
+
+/**
+ * Open a repository window and return its label, or null if it could not be
+ * opened.
+ *
+ * For a NEW window the ordering is load-bearing:
+ *
+ * 1. ask the backend for a free label — only it can see every live window;
+ * 2. write the seed under that label's key, BEFORE the window exists, so the
+ *    new window's own `restoreSession()` finds it;
+ * 3. remember the window, so a launch after a quit brings it back;
+ * 4. create it.
+ *
+ * A creation failure rolls (2) and (3) back. A remembered window that was never
+ * created would be resurrected at the next launch, which is a strange way for a
+ * failed click to come back.
+ */
+export async function openAppWindow(
+  options: NewWindowOptions = {},
+): Promise<string | null> {
+  const restoring = options.restore;
+  let label: string;
+  let bounds: WindowBounds | null;
+
+  if (restoring) {
+    label = restoring.label;
+    bounds = restoring.bounds;
+    // Claimed as well: a restore happens at launch, and a "New window" clicked
+    // before Tauri has registered the restored ones must not be handed one of
+    // their labels.
+    claimed.add(label);
+  } else {
+    try {
+      label = claimLabel(await nextWindowLabel());
+    } catch (e) {
+      logWarn(`could not name a new window: ${describeError(e)}`);
+      return null;
+    }
+    const seedPaths = options.seedPaths ?? [];
+    bounds = cascadeFrom(await currentBounds());
+    saveOpenRepos(
+      seedPaths.map((path) => ({ path })),
+      options.seedActive ?? seedPaths[0] ?? null,
+      openReposKey(label),
+    );
+    rememberWindow(label, bounds);
+  }
+
+  try {
+    const win = new WebviewWindow(label, {
+      url: "/",
+      title: "PlatypusGit",
+      ...DEFAULTS,
+      ...(await chromeOptions()),
+      // Hidden, exactly like `main`: `RevealOnFirstPaint` shows it once React
+      // has committed, so the window appears already drawn instead of as an
+      // empty frame. The resolver is the deliberate exception — it opens in
+      // response to a click on a control that is right there, where appearing
+      // instantly beats appearing complete.
+      visible: false,
+      backgroundColor: WINDOW_BACKGROUND,
+    });
+    void win.once("tauri://error", (e) => {
+      logWarn(`window ${label} failed to open: ${JSON.stringify(e.payload)}`);
+    });
+    await applyBounds(win, bounds);
+    return label;
+  } catch (e) {
+    logWarn(`could not open a window: ${describeError(e)}`);
+    // Undo the seed and the record — but only for a window this call invented.
+    // Forgetting a RESTORED one would delete a session the user still has,
+    // because a restore failure is usually "that label is somehow already
+    // taken", not "that window is gone".
+    if (!restoring) {
+      forgetWindow(label);
+      releaseWindowLabel(label);
+    }
+    return null;
+  }
+}

--- a/src/features/windows/useWindowLifecycle.test.tsx
+++ b/src/features/windows/useWindowLifecycle.test.tsx
@@ -1,0 +1,200 @@
+// The window's own lifecycle (#256): what comes back at launch, and what is
+// forgotten when the user closes one window rather than quitting.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+
+import { getInvokeCalls, mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import { emitMockEvent } from "@/test/eventMock";
+import { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+import {
+  loadWindowRecords,
+  openReposKey,
+  saveWindowRecords,
+  WINDOW_CLOSED_EVENT,
+} from "./windowKind";
+import { __resetWindowClaims, openAppWindow } from "./openAppWindow";
+import { __resetWindowRestore, useWindowLifecycle } from "./useWindowLifecycle";
+
+function Harness() {
+  useWindowLifecycle();
+  return null;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  resetInvokeMock();
+  __resetWindowRestore();
+  __resetWindowClaims();
+  mockInvoke("next_window_label", () => "pg-9");
+});
+
+/** The shared `WebviewWindow` mock is a class; wrap it so a test can see the
+ *  labels a restore asked for without changing the shared mock's shape. */
+vi.mock("@tauri-apps/api/webviewWindow", async () => {
+  class FakeWebviewWindow {
+    static getByLabel = vi.fn().mockResolvedValue(null);
+    static made: string[] = [];
+    static instances: FakeWebviewWindow[] = [];
+    label: string;
+    constructor(label: string) {
+      this.label = label;
+      FakeWebviewWindow.made.push(label);
+      FakeWebviewWindow.instances.push(this);
+    }
+    once = vi.fn().mockResolvedValue(() => {});
+    setPosition = vi.fn().mockResolvedValue(undefined);
+    setSize = vi.fn().mockResolvedValue(undefined);
+    setFocus = vi.fn().mockResolvedValue(undefined);
+    close = vi.fn().mockResolvedValue(undefined);
+  }
+  return { WebviewWindow: FakeWebviewWindow };
+});
+
+const made = () => (WebviewWindow as unknown as { made: string[] }).made;
+const instances = () =>
+  (WebviewWindow as unknown as { instances: Record<string, ReturnType<typeof vi.fn>>[] })
+    .instances;
+
+beforeEach(() => {
+  made().length = 0;
+  instances().length = 0;
+});
+
+describe("restoring the other windows at launch", () => {
+  it("recreates every persisted sibling, at the label it had", async () => {
+    saveWindowRecords([
+      { label: "pg-1", bounds: { x: 10, y: 20, width: 900, height: 700 } },
+      { label: "pg-2", bounds: null },
+    ]);
+    render(<Harness />);
+    await waitFor(() => expect(made()).toEqual(["pg-1", "pg-2"]));
+    // A restore reuses the label, so it must NOT ask for a new one — a fresh
+    // label would strand the window's persisted repositories under the old key.
+    expect(getInvokeCalls().filter((c) => c.cmd === "next_window_label")).toEqual([]);
+  });
+
+  it("restores nothing when the last quit left one window", async () => {
+    render(<Harness />);
+    await waitFor(() => expect(made()).toEqual([]));
+  });
+
+  it("runs once per process, not once per mount", async () => {
+    saveWindowRecords([{ label: "pg-1", bounds: null }]);
+    const first = render(<Harness />);
+    await waitFor(() => expect(made()).toEqual(["pg-1"]));
+    first.unmount();
+    render(<Harness />);
+    // A remount (React StrictMode, a hot reload) must not open a second copy
+    // of every window.
+    await waitFor(() => expect(made()).toEqual(["pg-1"]));
+  });
+});
+
+describe("forgetting a window the user closed", () => {
+  it("drops the record and the session when the backend says one closed", async () => {
+    saveWindowRecords([{ label: "pg-1", bounds: null }, { label: "pg-2", bounds: null }]);
+    localStorage.setItem(
+      openReposKey("pg-2"),
+      JSON.stringify({ paths: ["/dev/web"], active: "/dev/web" }),
+    );
+    render(<Harness />);
+    await waitFor(() => expect(made()).toHaveLength(2));
+
+    emitMockEvent(WINDOW_CLOSED_EVENT, "pg-2");
+
+    expect(loadWindowRecords().map((r) => r.label)).toEqual(["pg-1"]);
+    expect(localStorage.getItem(openReposKey("pg-2"))).toBeNull();
+  });
+
+  it("ignores a payload that is not a label", async () => {
+    saveWindowRecords([{ label: "pg-1", bounds: null }]);
+    render(<Harness />);
+    await waitFor(() => expect(made()).toHaveLength(1));
+
+    emitMockEvent(WINDOW_CLOSED_EVENT, { label: "pg-1" });
+    emitMockEvent(WINDOW_CLOSED_EVENT, null);
+
+    expect(loadWindowRecords().map((r) => r.label)).toEqual(["pg-1"]);
+  });
+});
+
+describe("naming a window", () => {
+  it("does not hand the same label to two clicks in the same tick", async () => {
+    // `next_window_label` answers from the windows Tauri knows about, and a
+    // window is not in that list the instant its constructor returns. Two fast
+    // clicks both got `pg-1`: the second failed on the duplicate label, having
+    // already overwritten the first window's seed on the way there.
+    mockInvoke("next_window_label", () => "pg-1");
+    const labels = await Promise.all([
+      openAppWindow({ seedPaths: ["/dev/api"] }),
+      openAppWindow({ seedPaths: ["/dev/web"] }),
+    ]);
+    expect(labels).toEqual(["pg-1", "pg-2"]);
+    expect(made()).toEqual(["pg-1", "pg-2"]);
+    // Each window kept its own seed.
+    expect(
+      JSON.parse(localStorage.getItem(openReposKey("pg-1")) as string).paths,
+    ).toEqual(["/dev/api"]);
+    expect(
+      JSON.parse(localStorage.getItem(openReposKey("pg-2")) as string).paths,
+    ).toEqual(["/dev/web"]);
+  });
+
+  it("frees a label again once its window is closed", async () => {
+    mockInvoke("next_window_label", () => "pg-1");
+    await openAppWindow({ seedPaths: ["/dev/api"] });
+    render(<Harness />);
+
+    emitMockEvent(WINDOW_CLOSED_EVENT, "pg-1");
+
+    // A long session that opens and closes windows keeps reusing pg-1 rather
+    // than climbing.
+    expect(await openAppWindow({ seedPaths: ["/dev/web"] })).toBe("pg-1");
+  });
+
+  it("claims a restored window's label, so a click cannot take it", async () => {
+    saveWindowRecords([{ label: "pg-1", bounds: null }]);
+    render(<Harness />);
+    await waitFor(() => expect(made()).toEqual(["pg-1"]));
+
+    mockInvoke("next_window_label", () => "pg-1");
+    expect(await openAppWindow({ seedPaths: ["/dev/api"] })).toBe("pg-2");
+  });
+});
+
+describe("where a restored window comes back", () => {
+  it("places it in PHYSICAL pixels, not through the logical creation options", async () => {
+    // `WebviewWindowOptions`' x/y/width/height are LOGICAL units and the
+    // remembered bounds are physical, so passing them straight through is wrong
+    // by the scale factor — on a 2x display the window returns at twice its
+    // size, on the wrong part of the wrong monitor. Invisible on a 1x screen,
+    // which is exactly why it is pinned here.
+    saveWindowRecords([
+      { label: "pg-1", bounds: { x: 1440, y: 300, width: 1800, height: 1200 } },
+    ]);
+    render(<Harness />);
+    await waitFor(() => expect(made()).toEqual(["pg-1"]));
+
+    const win = instances()[0];
+    await waitFor(() => expect(win.setPosition).toHaveBeenCalled());
+    const pos = win.setPosition.mock.calls[0][0] as { x: number; y: number; type: string };
+    const size = win.setSize.mock.calls[0][0] as {
+      width: number;
+      height: number;
+      type: string;
+    };
+    expect(pos).toMatchObject({ x: 1440, y: 300 });
+    expect(size).toMatchObject({ width: 1800, height: 1200 });
+    // The unit is the whole point of the assertion.
+    expect(pos.type).toBe("Physical");
+    expect(size.type).toBe("Physical");
+  });
+
+  it("lets the OS place a window with no remembered bounds", async () => {
+    saveWindowRecords([{ label: "pg-1", bounds: null }]);
+    render(<Harness />);
+    await waitFor(() => expect(made()).toEqual(["pg-1"]));
+    expect(instances()[0].setPosition).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/windows/useWindowLifecycle.ts
+++ b/src/features/windows/useWindowLifecycle.ts
@@ -1,0 +1,126 @@
+// The window's own lifecycle (#256): bring the other windows back at launch,
+// remember where this one is, and forget one the user closed.
+//
+// Mounted once from `AppShell`, so it runs in every repository window and in
+// none of the resolver's. Each of the three jobs is scoped to the window that
+// can actually do it — see the comments on each.
+
+import React from "react";
+import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+import { listenToThisWindow } from "./windowEvents";
+
+import { openAppWindow, currentBounds, releaseWindowLabel } from "./openAppWindow";
+import {
+  forgetWindow,
+  loadWindowRecords,
+  MAIN_LABEL,
+  rememberWindow,
+  WINDOW_CLOSED_EVENT,
+} from "./windowKind";
+
+/** How long a drag or a resize has to settle before the new bounds are written.
+ *  A move emits an event per frame; writing localStorage per frame is the kind
+ *  of thing that shows up as a stutter on a window being dragged. */
+const BOUNDS_DEBOUNCE_MS = 400;
+
+/** This window's label. Read once — it cannot change. */
+export function windowLabel(): string {
+  try {
+    return getCurrentWindow().label;
+  } catch {
+    // jsdom, and any host where the Tauri window is not reachable. Behaving as
+    // the primary window is the right default: it is what a single-window build
+    // was.
+    return MAIN_LABEL;
+  }
+}
+
+/** The window that restores the others, takes the first-launch CLI intent, and
+ *  is the one `tauri.conf.json` declares. */
+export function isPrimaryWindow(): boolean {
+  return windowLabel() === MAIN_LABEL;
+}
+
+/**
+ * Recreate the sibling windows persisted at the last quit.
+ *
+ * Primary-only, and once per process: a sibling running this too would have
+ * every window try to restore every other window. Sequential rather than
+ * parallel because each creation asks the backend for the next free label, and
+ * two overlapping asks get the same answer.
+ */
+export async function restoreWindows(): Promise<string[]> {
+  const records = loadWindowRecords();
+  const opened: string[] = [];
+  for (const record of records) {
+    const label = await openAppWindow({ restore: record });
+    if (label) opened.push(label);
+  }
+  return opened;
+}
+
+let restored = false;
+
+/** Test seam: the module-level "already restored" latch, reset between tests
+ *  the same way `__resetMergeAttribution` resets the resolver's. */
+export function __resetWindowRestore(): void {
+  restored = false;
+}
+
+export function useWindowLifecycle(): void {
+  // 1. Restore. Primary only, once.
+  React.useEffect(() => {
+    if (!isPrimaryWindow() || restored) return;
+    restored = true;
+    void restoreWindows();
+  }, []);
+
+  // 2. Forget a window the user closed.
+  //
+  // The backend picks ONE survivor to tell — whichever sorts first among the
+  // live windows: `main` when it is up, a sibling when the user closed `main`
+  // first — so the listener is scoped to this window rather than answering
+  // every window's mail. A window destroyed with no survivor at all is the quit
+  // case, and nothing is emitted, which is exactly how the session is kept for
+  // the next launch.
+  React.useEffect(() => {
+    const unlisten = listenToThisWindow<string>(WINDOW_CLOSED_EVENT, (e) => {
+      if (typeof e.payload !== "string") return;
+      forgetWindow(e.payload);
+      // The label is free again — a long session that opens and closes windows
+      // should keep reusing `pg-1` rather than climbing.
+      releaseWindowLabel(e.payload);
+    });
+    return () => {
+      void unlisten.then((f) => f());
+    };
+  }, []);
+
+  // 3. Remember where this window is. Siblings only: `main`'s geometry is the
+  //    one `tauri.conf.json` gives it, and restoring that is a separate change
+  //    with its own blast radius (see the spec).
+  React.useEffect(() => {
+    const label = windowLabel();
+    if (label === MAIN_LABEL) return;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let cancelled = false;
+    const write = () => {
+      timer = null;
+      void currentBounds().then((bounds) => {
+        if (!cancelled && bounds) rememberWindow(label, bounds);
+      });
+    };
+    const schedule = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(write, BOUNDS_DEBOUNCE_MS);
+    };
+    const subs = [listen("tauri://move", schedule), listen("tauri://resize", schedule)];
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+      for (const s of subs) void s.then((f) => f());
+    };
+  }, []);
+}

--- a/src/features/windows/windowEvents.ts
+++ b/src/features/windows/windowEvents.ts
@@ -1,0 +1,39 @@
+// Listening for an event that was sent to THIS window (#256).
+//
+// ## Why a plain `listen()` is not enough
+//
+// The JS `listen(event, handler)` registers with `EventTarget::Any`, and
+// Tauri's listener filter short-circuits on it:
+//
+//     *target == EventTarget::Any || filter(...)      // event/listener.rs
+//
+// so an `Any` listener matches EVERY emit, including a Rust
+// `emit_to("main", …)` that names one window. With one window that distinction
+// never mattered. With several it is the whole feature: a forwarded
+// `pgit ~/repo` routed to one window would be received by all of them, and
+// every window would open the repository — which is exactly the behaviour
+// `WindowRegistry::route` exists to replace.
+//
+// Passing this window's own label as the target fixes it in both directions,
+// because `emit_to`'s own filter (`filter_target`, manager/mod.rs) matches an
+// `AnyLabel` emit against an `AnyLabel` listener by label:
+//
+//   - a global `app.emit(…)` still arrives — `emit` runs with no filter at all,
+//     so broadcasts like `fs://changed` and `net://progress` are unaffected;
+//   - an `emit_to(<other label>, …)` no longer does.
+
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+import { windowLabel } from "./useWindowLifecycle";
+
+/**
+ * Subscribe to `event`, but only for emits addressed to this window (plus
+ * genuine broadcasts). Same signature as `listen` so a call site swaps in
+ * place.
+ */
+export function listenToThisWindow<T>(
+  event: string,
+  handler: (e: { payload: T }) => void,
+): Promise<UnlistenFn> {
+  return listen<T>(event, handler, { target: windowLabel() });
+}

--- a/src/features/windows/windowKind.test.ts
+++ b/src/features/windows/windowKind.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  cascadeFrom,
+  forgetWindow,
+  isRepoWindowLabel,
+  loadWindowRecords,
+  MAIN_LABEL,
+  openReposKey,
+  rememberWindow,
+  saveWindowRecords,
+  WINDOWS_KEY,
+  WINDOW_LIMIT,
+} from "./windowKind";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("window labels", () => {
+  it("recognises the app's own windows and nothing else", () => {
+    expect(isRepoWindowLabel("main")).toBe(true);
+    expect(isRepoWindowLabel("pg-1")).toBe(true);
+    expect(isRepoWindowLabel("pg-12")).toBe(true);
+    // The resolver is a window, but not a repository window.
+    expect(isRepoWindowLabel("merge")).toBe(false);
+    expect(isRepoWindowLabel("pg-")).toBe(false);
+    expect(isRepoWindowLabel("pg-x")).toBe(false);
+    expect(isRepoWindowLabel("pg-1x")).toBe(false);
+  });
+});
+
+describe("per-window storage keys", () => {
+  it("leaves main on the key it has written since #90", () => {
+    // The upgrade case: namespacing every window would have emptied every
+    // existing user's tab strip exactly once, on the build that shipped this.
+    expect(openReposKey(MAIN_LABEL)).toBe("pg-open-repos");
+  });
+
+  it("namespaces every sibling", () => {
+    expect(openReposKey("pg-1")).toBe("pg-open-repos:pg-1");
+    expect(openReposKey("pg-2")).toBe("pg-open-repos:pg-2");
+  });
+});
+
+describe("the restore record", () => {
+  it("round-trips", () => {
+    saveWindowRecords([{ label: "pg-1", bounds: { x: 10, y: 20, width: 900, height: 700 } }]);
+    expect(loadWindowRecords()).toEqual([
+      { label: "pg-1", bounds: { x: 10, y: 20, width: 900, height: 700 } },
+    ]);
+  });
+
+  it("reads junk as nothing to restore rather than throwing", () => {
+    // Same contract as loadOpenRepos: the alternative is an app that will not
+    // start until someone clears localStorage by hand.
+    localStorage.setItem(WINDOWS_KEY, "not json");
+    expect(loadWindowRecords()).toEqual([]);
+    localStorage.setItem(WINDOWS_KEY, JSON.stringify({ label: "pg-1" }));
+    expect(loadWindowRecords()).toEqual([]);
+    localStorage.setItem(WINDOWS_KEY, JSON.stringify([1, "pg-2", null]));
+    expect(loadWindowRecords()).toEqual([]);
+  });
+
+  it("never restores main — it is what does the restoring", () => {
+    localStorage.setItem(
+      WINDOWS_KEY,
+      JSON.stringify([{ label: "main", bounds: null }, { label: "pg-1", bounds: null }]),
+    );
+    expect(loadWindowRecords().map((r) => r.label)).toEqual(["pg-1"]);
+  });
+
+  it("drops duplicates and anything that is not a window label", () => {
+    localStorage.setItem(
+      WINDOWS_KEY,
+      JSON.stringify([
+        { label: "pg-1", bounds: null },
+        { label: "pg-1", bounds: null },
+        { label: "merge", bounds: null },
+        { label: "whatever", bounds: null },
+      ]),
+    );
+    expect(loadWindowRecords().map((r) => r.label)).toEqual(["pg-1"]);
+  });
+
+  it("caps how many windows a corrupted record can open at launch", () => {
+    saveWindowRecords(
+      Array.from({ length: 40 }, (_, i) => ({ label: `pg-${i + 1}`, bounds: null })),
+    );
+    expect(loadWindowRecords()).toHaveLength(WINDOW_LIMIT);
+  });
+
+  it("treats incomplete or zero-area bounds as no remembered place", () => {
+    localStorage.setItem(
+      WINDOWS_KEY,
+      JSON.stringify([
+        { label: "pg-1", bounds: { x: 1, y: 2 } },
+        { label: "pg-2", bounds: { x: 1, y: 2, width: 0, height: 700 } },
+        { label: "pg-3", bounds: { x: 1, y: 2, width: Number.NaN, height: 700 } },
+      ]),
+    );
+    // The RECORD survives — only the geometry is dropped, so the window still
+    // comes back, just wherever the OS puts it.
+    expect(loadWindowRecords()).toEqual([
+      { label: "pg-1", bounds: null },
+      { label: "pg-2", bounds: null },
+      { label: "pg-3", bounds: null },
+    ]);
+  });
+});
+
+describe("remembering and forgetting a window", () => {
+  it("adds a window once and updates its bounds in place", () => {
+    rememberWindow("pg-1", { x: 0, y: 0, width: 900, height: 700 });
+    rememberWindow("pg-1", { x: 40, y: 50, width: 900, height: 700 });
+    expect(loadWindowRecords()).toEqual([
+      { label: "pg-1", bounds: { x: 40, y: 50, width: 900, height: 700 } },
+    ]);
+  });
+
+  it("a null on an update means 'no new measurement', not 'forget where it was'", () => {
+    rememberWindow("pg-1", { x: 40, y: 50, width: 900, height: 700 });
+    rememberWindow("pg-1", null);
+    expect(loadWindowRecords()[0].bounds).toEqual({ x: 40, y: 50, width: 900, height: 700 });
+  });
+
+  it("refuses to record main or the resolver", () => {
+    rememberWindow(MAIN_LABEL, null);
+    rememberWindow("merge", null);
+    expect(loadWindowRecords()).toEqual([]);
+  });
+
+  it("forgetting drops the record AND the window's open repositories", () => {
+    rememberWindow("pg-1", null);
+    localStorage.setItem(openReposKey("pg-1"), JSON.stringify({ paths: ["/a"], active: "/a" }));
+    forgetWindow("pg-1");
+    expect(loadWindowRecords()).toEqual([]);
+    expect(localStorage.getItem(openReposKey("pg-1"))).toBeNull();
+  });
+
+  it("forgetting main can never delete the primary session", () => {
+    localStorage.setItem(openReposKey(MAIN_LABEL), JSON.stringify({ paths: ["/a"], active: "/a" }));
+    forgetWindow(MAIN_LABEL);
+    expect(localStorage.getItem(openReposKey(MAIN_LABEL))).not.toBeNull();
+  });
+});
+
+describe("cascade", () => {
+  it("offsets down and right, so a new window is visibly a second one", () => {
+    expect(cascadeFrom({ x: 100, y: 100, width: 900, height: 700 }, 32)).toEqual({
+      x: 132,
+      y: 132,
+      width: 900,
+      height: 700,
+    });
+  });
+
+  it("cannot walk a window off the top-left", () => {
+    expect(cascadeFrom({ x: -80, y: -80, width: 900, height: 700 }, 32)).toEqual({
+      x: 0,
+      y: 0,
+      width: 900,
+      height: 700,
+    });
+  });
+
+  it("no anchor means let the OS place it", () => {
+    expect(cascadeFrom(null)).toBeNull();
+  });
+});

--- a/src/features/windows/windowKind.ts
+++ b/src/features/windows/windowKind.ts
@@ -1,0 +1,200 @@
+// Multiple windows (#256) — the pure half. Labels, per-window storage keys, and
+// the `pg-windows` record. No IPC, no React, no `WebviewWindow`: everything here
+// is a function of its arguments, which is what makes the awkward parts (an
+// upgrading user's session, a corrupted record, a label nobody owns) testable
+// without a second webview.
+//
+// `openAppWindow.ts` creates windows on top of this; `useWindowLifecycle.ts`
+// restores and prunes them. The backend half is `src-tauri/src/windows.rs`,
+// which owns the same label rules for the questions a webview cannot answer.
+
+/** The window `tauri.conf.json` declares. Always the first one to exist. */
+export const MAIN_LABEL = "main";
+/** The conflict resolver — a window, but not a repository window. */
+export const MERGE_LABEL = "merge";
+/** Sibling windows: `pg-1`, `pg-2`, … Kept in step with `windows.rs`. */
+export const REPO_WINDOW_PREFIX = "pg-";
+
+/** Where the sibling-window list lives. */
+export const WINDOWS_KEY = "pg-windows";
+
+/** Emitted by the backend to a SURVIVING window when another one is destroyed.
+ *  Kept in step with `WINDOW_CLOSED_EVENT` in `src-tauri/src/windows.rs`; the
+ *  close-versus-quit rule it encodes is written up there. */
+export const WINDOW_CLOSED_EVENT = "window://closed";
+/** `main`'s open set, unchanged since #90 — see `openReposKey`. */
+export const OPEN_REPOS_KEY = "pg-open-repos";
+
+/** Bound on how many windows are restored at launch. Same spirit as tabs.ts's
+ *  `OPEN_LIMIT`: a corrupted or runaway record must not make startup open
+ *  windows until the machine gives up. */
+export const WINDOW_LIMIT = 8;
+
+export function isRepoWindowLabel(label: string): boolean {
+  if (label === MAIN_LABEL) return true;
+  if (!label.startsWith(REPO_WINDOW_PREFIX)) return false;
+  return /^[0-9]+$/.test(label.slice(REPO_WINDOW_PREFIX.length));
+}
+
+/**
+ * Where a window's open repository set is persisted.
+ *
+ * `main` keeps the bare `pg-open-repos` key it has written since #90, so an
+ * upgrading user's session restores exactly as it did before windows existed —
+ * a suffix for every window would have silently emptied everyone's tab strip
+ * once on upgrade. Siblings, which no previous build could have written, are
+ * namespaced.
+ */
+export function openReposKey(label: string): string {
+  return label === MAIN_LABEL ? OPEN_REPOS_KEY : `${OPEN_REPOS_KEY}:${label}`;
+}
+
+/**
+ * Where a sibling window is, in PHYSICAL pixels.
+ *
+ * Physical rather than logical because the point of remembering a window's
+ * place is the multi-monitor case, and two monitors can have different scale
+ * factors — a logical position is only meaningful next to the scale factor of
+ * the screen it was read on, and a window moved between them would come back on
+ * the wrong one.
+ */
+export interface WindowBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** One sibling window in the restore set. `main` is never in it: it is not
+ *  restored, it is what does the restoring. */
+export interface WindowRecord {
+  label: string;
+  bounds: WindowBounds | null;
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+function readBounds(raw: unknown): WindowBounds | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (
+    !isFiniteNumber(r.x) ||
+    !isFiniteNumber(r.y) ||
+    !isFiniteNumber(r.width) ||
+    !isFiniteNumber(r.height)
+  ) {
+    return null;
+  }
+  // A zero-area window is not a window. Treated as "no remembered bounds"
+  // rather than dropped, so the record itself survives.
+  if (r.width < 1 || r.height < 1) return null;
+  return { x: r.x, y: r.y, width: r.width, height: r.height };
+}
+
+/**
+ * The sibling windows to bring back, tolerant of anything in the slot.
+ *
+ * Same contract as `loadOpenRepos`: junk reads as "nothing to restore" rather
+ * than throwing, because the alternative is an app that will not start until
+ * someone clears localStorage by hand. `main` is filtered out defensively — a
+ * record naming it would make the primary window try to create itself.
+ */
+export function loadWindowRecords(storage: Storage = localStorage): WindowRecord[] {
+  try {
+    const raw = storage.getItem(WINDOWS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    const seen = new Set<string>();
+    const out: WindowRecord[] = [];
+    for (const entry of parsed) {
+      if (!entry || typeof entry !== "object") continue;
+      const label = (entry as Record<string, unknown>).label;
+      if (typeof label !== "string") continue;
+      if (label === MAIN_LABEL || !isRepoWindowLabel(label)) continue;
+      if (seen.has(label)) continue;
+      seen.add(label);
+      out.push({ label, bounds: readBounds((entry as Record<string, unknown>).bounds) });
+      if (out.length >= WINDOW_LIMIT) break;
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+export function saveWindowRecords(
+  records: WindowRecord[],
+  storage: Storage = localStorage,
+): void {
+  try {
+    storage.setItem(WINDOWS_KEY, JSON.stringify(records.slice(0, WINDOW_LIMIT)));
+  } catch {
+    // Quota errors are non-fatal — the extra windows just won't come back.
+  }
+}
+
+/** Add `label` to the restore set, or update the bounds it already has. */
+export function rememberWindow(
+  label: string,
+  bounds: WindowBounds | null,
+  storage: Storage = localStorage,
+): void {
+  if (label === MAIN_LABEL || !isRepoWindowLabel(label)) return;
+  const records = loadWindowRecords(storage);
+  const i = records.findIndex((r) => r.label === label);
+  if (i < 0) records.push({ label, bounds });
+  // A null on an update means "no new measurement", not "forget where it was":
+  // the record is written on creation before the window has any bounds to read.
+  else records[i] = { label, bounds: bounds ?? records[i].bounds };
+  saveWindowRecords(records, storage);
+}
+
+/**
+ * Drop `label` from the restore set AND its open-repository set.
+ *
+ * Called when a window is closed while others survive — see the close-versus-
+ * quit rule in `windows.rs`. Dropping the repository set too is what keeps
+ * localStorage from accumulating one dead `pg-open-repos:pg-n` per window the
+ * user ever opened.
+ */
+export function forgetWindow(label: string, storage: Storage = localStorage): void {
+  if (label === MAIN_LABEL || !isRepoWindowLabel(label)) return;
+  saveWindowRecords(
+    loadWindowRecords(storage).filter((r) => r.label !== label),
+    storage,
+  );
+  try {
+    storage.removeItem(openReposKey(label));
+  } catch {
+    // Same as above: a storage that refuses writes just keeps a stale key.
+  }
+}
+
+/**
+ * Where a new window goes when it has no remembered place: down and right of
+ * the window that opened it, so it is obviously a second window rather than one
+ * hiding exactly behind the first.
+ *
+ * Clamped to a positive coordinate. A cascade off a window near the bottom-right
+ * of a screen would otherwise walk a new window off it, and there is no
+ * cross-platform way to ask "which screen, how big" that is worth the
+ * complexity here — the OS will place a window with no position itself, which
+ * is what `null` asks for.
+ */
+export const CASCADE_STEP = 32;
+
+export function cascadeFrom(
+  from: WindowBounds | null,
+  step = CASCADE_STEP,
+): WindowBounds | null {
+  if (!from) return null;
+  return {
+    x: Math.max(0, from.x + step),
+    y: Math.max(0, from.y + step),
+    width: from.width,
+    height: from.height,
+  };
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1373,6 +1373,26 @@ export async function commitNotes(
   return invoke<CommitNote[]>("commit_notes", { repoId, oid });
 }
 
+/**
+ * Tell the backend which repositories this window's tab strip holds (#256).
+ *
+ * Called on every tab-strip persist, alongside the window's own session write.
+ * The backend uses it for the two questions a webview cannot answer about
+ * another window: where a forwarded `pgit <path>` should land, and what to
+ * evict when this window is closed. The window is identified by Tauri, not by
+ * an argument.
+ */
+export async function registerWindowRepos(
+  repos: { id: string | null; path: string }[],
+): Promise<void> {
+  return invoke<void>("register_window_repos", { repos });
+}
+
+/** The label the next sibling window should take — the lowest free `pg-<n>`. */
+export async function nextWindowLabel(): Promise<string> {
+  return invoke<string>("next_window_label");
+}
+
 export async function takeLaunchIntent(): Promise<LaunchIntent | null> {
   return invoke<LaunchIntent | null>("take_launch_intent");
 }

--- a/src/test/eventMock.ts
+++ b/src/test/eventMock.ts
@@ -3,20 +3,38 @@
 
 type Handler = (event: { payload: unknown }) => void;
 
-const listeners = new Map<string, Set<Handler>>();
+/** A listener's target, as `@tauri-apps/api/event` spells it. `undefined` is
+ *  the default `EventTarget::Any` — see `features/windows/windowEvents.ts` for
+ *  why a window ever passes one. */
+type Target = string | { kind: string; label?: string } | undefined;
+
+interface Entry {
+  handler: Handler;
+  target: Target;
+}
+
+const listeners = new Map<string, Set<Entry>>();
+
+function labelOf(target: Target): string | null {
+  if (typeof target === "string") return target;
+  if (target && typeof target === "object") return target.label ?? null;
+  return null;
+}
 
 export async function listen(
   event: string,
   handler: Handler,
+  options?: { target?: Target },
 ): Promise<() => void> {
   let set = listeners.get(event);
   if (!set) {
     set = new Set();
     listeners.set(event, set);
   }
-  set.add(handler);
+  const entry: Entry = { handler, target: options?.target };
+  set.add(entry);
   return () => {
-    set.delete(handler);
+    set.delete(entry);
   };
 }
 
@@ -25,8 +43,29 @@ export async function listen(
 // no-op is enough — tests assert IPC/DOM effects, not the emit itself.
 export async function emit(_event: string, _payload?: unknown): Promise<void> {}
 
+/** A broadcast: `app.emit` in Rust. Reaches every listener, targeted or not —
+ *  Tauri's `emit` runs with no filter. */
 export function emitMockEvent(event: string, payload: unknown): void {
-  listeners.get(event)?.forEach((h) => h({ payload }));
+  listeners.get(event)?.forEach((e) => e.handler({ payload }));
+}
+
+/**
+ * An addressed emit: `app.emit_to(label, …)` in Rust.
+ *
+ * Reaches a listener that named this label, and — faithfully to Tauri — one
+ * that named no target at all, because an `EventTarget::Any` listener matches
+ * every emit. That second half is the trap `listenToThisWindow` exists for, so
+ * the mock has to reproduce it or a test for the fix would pass either way.
+ */
+export function emitMockEventTo(
+  label: string,
+  event: string,
+  payload: unknown,
+): void {
+  listeners.get(event)?.forEach((e) => {
+    const listenerLabel = labelOf(e.target);
+    if (listenerLabel === null || listenerLabel === label) e.handler({ payload });
+  });
 }
 
 export function resetEventMock(): void {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -36,6 +36,15 @@ vi.mock("@tauri-apps/plugin-os", () => ({
 
 vi.mock("@tauri-apps/api/window", () => {
   const win = {
+    // Multiple windows (#256): every window asks for its OWN label, and the
+    // label decides which storage key its tab strip persists under. `main` is
+    // the right default here — it is what a single-window build was, so every
+    // pre-#256 test keeps reading the key it always read.
+    label: "main",
+    // Physical bounds, read when a new window cascades off this one and when a
+    // sibling writes back where it was moved to.
+    outerPosition: vi.fn().mockResolvedValue({ x: 0, y: 0 }),
+    outerSize: vi.fn().mockResolvedValue({ width: 1200, height: 800 }),
     minimize: vi.fn(),
     toggleMaximize: vi.fn(),
     close: vi.fn(),
@@ -68,6 +77,8 @@ vi.mock("@tauri-apps/api/webviewWindow", () => {
       this.label = label;
     }
     once = vi.fn().mockResolvedValue(() => {});
+    setPosition = vi.fn().mockResolvedValue(undefined);
+    setSize = vi.fn().mockResolvedValue(undefined);
     setFocus = vi.fn().mockResolvedValue(undefined);
     close = vi.fn().mockResolvedValue(undefined);
   }

--- a/test/startupPaint.test.ts
+++ b/test/startupPaint.test.ts
@@ -10,7 +10,8 @@
 //   - `--bg-0` in src/index.css              — what the CSS eventually paints
 //   - `backgroundColor` in tauri.conf.json   — the WINDOW layer, before any document
 //   - the inline `background` in index.html  — the DOCUMENT, before any stylesheet
-//   - `backgroundColor` in openMergeWindow   — the same, for the second window
+//   - `backgroundColor` in openMergeWindow   — the same, for the resolver window
+//   - `backgroundColor` in openAppWindow     — the same, for a repository window
 //
 // Nothing else notices when one of them changes. Re-theme the default palette,
 // or drop the config key while debugging something else, and the app quietly
@@ -39,6 +40,7 @@ const tauriConf = JSON.parse(read("src-tauri/tauri.conf.json"));
 const indexHtml = read("index.html");
 const indexCss = read("src/index.css");
 const mergeWindow = read("src/features/merge/openMergeWindow.ts");
+const appWindow = read("src/features/windows/openAppWindow.ts");
 const mainTsx = read("src/main.tsx");
 
 const mainWindow = tauriConf.app.windows.find(
@@ -105,6 +107,28 @@ describe("the app's first paint is dark, not white", () => {
     const merge = /backgroundColor:\s*"(#[0-9a-f]{6})"/i.exec(mergeWindow);
     expect(merge, "openMergeWindow needs a backgroundColor").not.toBeNull();
     expect(merge![1].toLowerCase()).toBe(mainWindow.backgroundColor.toLowerCase());
+  });
+
+  it("opens a second REPOSITORY window on the same colour (#256)", () => {
+    // Same trade as the resolver's, and the same reason it has to be asserted
+    // here: a runtime-created window inherits nothing from tauri.conf.json, so
+    // the value is a fourth copy with no compiler relationship to the other
+    // three. This one names its colour, so both halves are checked — the
+    // constant's value, and that it is what actually reaches the window.
+    const decl = /WINDOW_BACKGROUND\s*=\s*"(#[0-9a-f]{6})"/i.exec(appWindow);
+    expect(decl, "openAppWindow needs a WINDOW_BACKGROUND constant").not.toBeNull();
+    expect(decl![1].toLowerCase()).toBe(mainWindow.backgroundColor.toLowerCase());
+    expect(
+      appWindow,
+      "the window creation must actually pass WINDOW_BACKGROUND",
+    ).toMatch(/backgroundColor:\s*WINDOW_BACKGROUND/);
+  });
+
+  it("creates a second repository window HIDDEN, like the main one", () => {
+    // The other half of the same trade — see the reveal suite below. A window
+    // created visible flashes an empty frame; RevealOnFirstPaint runs in every
+    // window, so a sibling gets the same already-drawn open the main one does.
+    expect(appWindow).toMatch(/visible:\s*false/);
   });
 
   it("keeps that colour tracking --bg-0 of the default dark theme", () => {


### PR DESCRIPTION
Closes #256.

Repositories opened as tabs in one window. Tabs are for *switching*; windows are
for *comparing* — porting a change between two repos, watching a build in one
while working in another, one repository per monitor. This adds windows
alongside tabs; the tab model is unchanged and every window has a full strip.

Spec: `docs/superpowers/specs/2026-09-04-multiple-windows-spec.md`
Plan: `docs/superpowers/plans/2026-09-04-multiple-windows.md`

## What you get

- **New window** (`Mod+Shift+D`) — empty, on Welcome.
- **Open this repository in a new window** — the current window keeps its tab.
- **Move this repository to a new window** — the tab leaves.
- All three in the command palette; the last two also on the tab's context menu.
- Windows come back at the next launch, where they were.

## The decisions worth reviewing

**Two windows on one repository get two `RepoId`s.** `open_repo` already mints
one per open, and keeping it that way is what makes everything else simple:
closing a tab in one window evicts nothing the other is using, and terminals and
rebase state (both keyed by `RepoId`) stay per-window with no refcounting. The
cost is that same-repository work in two windows does not serialize on one inner
mutex — already this app's reality, since `watcher.rs` opens its own second
`git2::Repository` on the same repository for the same reason.

**Close versus quit, without a flag.** A window destroyed while another
repository window survives is forgotten; one destroyed with none left is
remembered. Rust implements it by emitting `window://closed` *to a survivor* —
with no survivor there is nobody to tell, which is exactly the quit case. So on
macOS ⌘Q with three windows restores three, and on Windows/Linux the last window
standing is what comes back. That is what VS Code does.

**Labels are deterministic** (`main`, `pg-1`, `pg-2`, `merge`). They are storage
keys, a capability glob has to match them, and an e2e spec has to name one.

**`main` keeps writing the bare `pg-open-repos` key.** Namespacing every window
would have emptied every existing user's tab strip once, on upgrade.

## Three bugs found while building it, each invisible with one window

- **`WatchState` was a single global slot.** The second window's `watch_repo`
  silently evicted the first window's watcher and that window went back to being
  stale — the exact failure #239 removed, restored by the second window. Now
  keyed by window label.
- **Backend routing was being undone in the webview.** A plain JS `listen()`
  registers `EventTarget::Any`, and Tauri's filter short-circuits on it, so an
  `Any` listener matches *every* emit — including `emit_to("main", …)`. Every
  window would still have opened a forwarded `pgit ~/repo`. Fixed with
  `listenToThisWindow`; the test fails without it, and `test/eventMock.ts` now
  reproduces the `Any`-matches-everything rule so it cannot pass vacuously.
- **Remembered bounds were physical, `WebviewWindowOptions` x/y/w/h are
  logical.** On a 2× display a restored window came back at twice its size on the
  wrong part of the wrong monitor. Now placed with `setPosition`/`setSize`, which
  name the unit.

Two more gaps the guards caught: the palette is a *curated* list, so the new
actions did not reach it until added explicitly (found by the e2e run), and
`updater.json` was scoped to `main`, which would have shipped a sibling window an
Install button that fails — and left a user who closed `main` with no update
surface at all.

## Verification

- `cargo test` — green (350 lib + every integration binary), 11 new tests.
- `pnpm test` — 3310 passing, 339 files.
- `pnpm test:e2e:docker` — **full** suite, 31/31 spec files, including the new
  `multi-window.e2e.ts` driving a real second window via
  `browser.tauri.switchWindow("pg-1")`.
- `pnpm tsc --noEmit` + `pnpm exec tsc -p e2e/tsconfig.json --noEmit`.

Docs updated: `docs/dev/architecture.md` (the new module, commands and feature
directory), `docs/dev/frontend.md` (a *Multiple windows* section), 
`docs/dev/distribution.md` (the `pg-*` capability rule), and one rule line in
`CLAUDE.md`.

## Not in scope

Dragging a tab between two existing windows, restoring `main`'s own geometry, and
a window list menu. All noted in the spec as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
