### PR TITLE
feat(diff): let the user diff a blob the ceiling refused

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,12 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
   selection split: code cell `.pg-selectable`, line numbers and `+`/`−` marker
   `user-select: none`. A selection cannot leave the rendered window, so copying a
   long range goes through `lib/diffCopy.ts` (`diff.copy` / the right-click menu),
-  and `Mod+C` must keep declining to the native copy. (`docs/dev/frontend.md`)
+  and `Mod+C` must keep declining to the native copy. The over-ceiling notice's
+  SENTENCE and its ACTION are both shared (`oversizedDiffNotice` +
+  `OversizedDiffAction`/`useDiffAnyway`) — a pane that grows its own is how a
+  file starts behaving differently depending on where you opened it; the blob
+  ceiling is `blob_ceiling`, raised per file and never removed.
+  (`docs/dev/frontend.md`, `docs/dev/backend.md`)
 - **One commit-message composition surface** — `features/commits/message/`
   (`useCommitComposer` + `CommitMessageBar`). A new way to compose message text
   joins it; it never grows a second surface beside it. The box stays plain text

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -375,6 +375,71 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
   `src-tauri/tests/diff_blob_ceiling.rs` covers the four diff entry points and
   the control case: an ordinary text file must still diff exactly as before.
 
+### ...and the user's way past it (#396)
+
+The ceiling is a guess about intent — "a 5 MB text file is a generated
+artifact, not something anyone diffs in a GUI" — and it is usually right. When
+it is wrong it is completely wrong: a generated `schema.sql`, a `.csv` fixture,
+a vendored lockfile, a minified bundle whose one changed line is the thing being
+reviewed. So it is overridable, and these are the four properties that keep the
+escape hatch from becoming the uncapped path #385 removed.
+
+- **The ceiling is a FUNCTION, not a constant, at all six `max_size` sites.**
+  `blob_ceiling(raise: bool)` returns `MAX_WORKDIR_BLOB` or `MAX_BLOB_OVERRIDE`
+  (64 MB) and nothing else, so there is no spelling of "no limit" to reach for.
+  Each of the five diff ops has a `*_over_ceiling` sibling taking
+  `raise_for: &[PathBuf]`; the plain name is a one-line trait default that
+  forwards with `&[]`, which is what keeps the ~57 existing call sites (and
+  every test) unchanged. Over the raised ceiling the delta comes back
+  `oversized` again, with the RAISED limit in it — `oversized_delta` takes the
+  ceiling that was applied for exactly that reason.
+- **The wire carries PATHS, never a size.** `raiseFor: Option<Vec<String>>` on
+  the five diff commands, through the one `raised_paths` converter. The
+  alternative — an `Option<u64>` ceiling from the frontend — would put a copy of
+  the policy in the UI, free to drift from the one applied, which is the same
+  mistake the `oversized { size, limit }` shape exists to avoid.
+- **A raise is a PATHSPEC as well as a limit, so the multi-file ops run TWO
+  builds** (`with_raised`, `scope_to_raised`). libgit2's `max_size` is
+  diff-WIDE, so "raise it for this one path" cannot be said in one build: either
+  the whole diff gets the raised ceiling — and reads every huge blob in the
+  commit, the footgun a per-file hatch exists to avoid — or the raise is scoped
+  by a pathspec, which narrows the ANSWER. So the base build answers for every
+  file at the default ceiling and a second, pathspec'd build re-reads only the
+  waived paths, merged in by path. The extra pass costs one tree walk, not one
+  blob read: the base build never reads a blob over the ceiling, which is what
+  being over it means. Both sides of a rename go in the list, or `find_similar`
+  gets half a pair.
+- **The answer is the WHOLE diff, and that is load-bearing.** Returning just the
+  waived subset — the first shape this had — meant a caller could only pass its
+  waivers on the click that granted them. Every surface's diff fetch re-runs on a
+  status refresh (`CommitPanel`'s dependency list says so in as many words), so
+  the refusal came back on its own, seconds after the user's 6.7 MB read landed.
+  Measured in `e2e/specs/diff-oversized.e2e.ts`, which is why that spec waits on
+  the refusal STAYING gone rather than merely being gone.
+- **`OversizedBlob.raised` says which ceiling a delta lost to**, derived from
+  the applied limit rather than passed alongside it. The UI needs it and cannot
+  work it out: it holds no copy of either ceiling, and a list of waived paths is
+  not the answer — after a fresh fetch the path is still in that list while the
+  refusal is the DEFAULT ceiling's, so the action belongs back on screen.
+- **Blob size is the first wall; LINE COUNT is the second.** A 40 MB CSV
+  rewritten wholesale is about a million `DiffLine`s: a nine-figure JSON payload
+  for the webview to parse, a million row objects for `flattenDiffRows`, and a
+  `heights` array `windowVariable` reduces over on every scroll event. An
+  override that hands the user a frozen window is worse than the refusal it
+  replaced, so a raised diff caps its lines at `MAX_DIFF_LINES` (100k) and
+  reports `FileDiff::truncated { shown, total }`. The cap is reached ONLY
+  through `diff_lines_cap`, i.e. only under a raise: nothing the app opens on
+  its own initiative starts truncating. `additions`/`deletions` keep counting
+  past the cap — the file row must stay true even when the pane cannot show all
+  of it — and the cap is checked before the `String` allocation, which is what
+  it actually saves. It is keyed on the CEILING (`diff_lines_cap(ceiling)`), so
+  the two builds above cannot disagree about which of them may truncate.
+- `src-tauri/tests/diff_blob_override.rs` pins all of it, including the three
+  negatives that matter: an empty `raise_for` is byte-for-byte the default, a
+  raise naming a DIFFERENT path leaves this one refused, and an un-waived
+  artifact in the same commit keeps the default ceiling — which is what says its
+  blob was never loaded.
+
 ## Image previews: the only reader that returns BYTES (#224)
 
 - **`read_image_preview` is the fourth file reader**, and the only one that can

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -74,10 +74,57 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
     sets `oversized` on a delta libgit2 already called binary, so that arm
     cannot fire alone today. It is there so "we did not read this blob" can
     never come to mean "render its hunks".
-  * **No "show it anyway" override yet** — deliberately out of scope of the fix,
-    and tracked as #396: the ceiling had to become one policy before an escape
-    hatch from it could mean anything, and the row model has to survive the
-    result first (`windowVariable` reduces over every height on every scroll).
+- **The notice grows an ACTION, and no surface owns it (#396).** #385 left the
+  sentence naming a limit with nothing to do about it, which is the shape that
+  invites the question. `OversizedDiffAction`
+  (`features/diff/OversizedDiffNotice.tsx`) is the one button, rendered by all
+  four surfaces — through `PGEmpty`'s `action` slot for the three that use
+  `ImageDiffOrEmpty`, and inside `CommitDiffPanel`'s `fallback` for the fourth.
+  A pane that grew its own is how a file comes to behave differently depending
+  on where you opened it, which is the rule `isTextualDiff`'s doc comment
+  already states.
+  * **The click records a WAIVER; the surface's ordinary fetch carries it.**
+    `useDiffAnyway(resetKey)` (`features/diff/`) is just that state, and every
+    diff fetch passes `raiseFor` — the backend answers with the whole diff and
+    those paths read at the raised ceiling, so there is no second fetch shape
+    and nothing to splice.
+  * **A hook that fetched the waived path ITSELF does not work**, and this is
+    the trap worth remembering. Every one of these surfaces re-runs its diff
+    fetch on a status refresh — `CommitPanel`'s dependency list says so on
+    purpose, `status` identity included — so a waived read that lived outside
+    that fetch was replaced by the refusal seconds after it landed, with the
+    user watching. `raiseFor` therefore belongs in the fetch effect's deps, and
+    `e2e/specs/diff-oversized.e2e.ts` waits on the refusal STAYING gone.
+  * **Per file, per view, never a setting.** The waivers are component state
+    (store state for Compare, because the store owns `diffs`), dropped whenever
+    `resetKey` changes — the selected path (plus side, in the commit panel: two
+    sides of one file are two diffs), or the commit/target being shown. A
+    remembered "always diff huge files" is a considered refusal turned into a
+    footgun the user forgot they armed, and here it costs megabytes.
+  * **A blob over even the RAISED ceiling stops offering the button** —
+    `diffAnywayExhausted`, off the delta's own `oversized.raised`. Not off the
+    waived-path list: a fresh fetch's refusal is the DEFAULT ceiling's while the
+    path is still in that list, and keying on the list hid the button for the
+    rest of the session.
+  * **`CommitDiffPanel` is presentational, so its CALLER answers the click.**
+    `onDiffAnyway` omitted means the notice renders with nothing under it, which
+    is the right thing for a surface with nowhere to send the re-read — and
+    `test/diffOversized.test.ts` checks that all three owners (CommitDiff,
+    History, Compare) wire it, because a panel silently offering no button is
+    the pre-#396 dead end again.
+  * **A waived read can come back SHORTENED**, and `TruncatedDiffNotice` says
+    so above the rows. Raising the ceiling gets the blob read; it does not make
+    a million rows something a diff pane can lay out, so the backend caps the
+    lines (`FileDiff.truncated { shown, total }`, counts off the wire like the
+    limit). An unmentioned cap reads as a diff that simply ends — the silent
+    wrong answer this whole area exists to avoid.
+  * **Still worth doing when the cap starts to bite:** `windowVariable` walks
+    `heights` from index 0 and reduces over it twice on every scroll event, so a
+    capped 100k-row diff costs ~O(n) per event. A prefix sum over `heights`
+    would make it O(log n) and would help every large diff, not just a waived
+    one. Not done here: the cap already bounds a waived diff to what the app
+    renders happily today, so this is a scroll-smoothness improvement rather
+    than a precondition.
 - **The complement of `isTextualDiff` is not automatically a dead end** (#224).
   When the binary is an IMAGE, all five diff surfaces render the shared
   `ImageDiffView` (`features/diff/`) — old beside new, each with pixel

--- a/e2e/specs/diff-oversized.e2e.ts
+++ b/e2e/specs/diff-oversized.e2e.ts
@@ -1,0 +1,147 @@
+// "Yes, really, show me." — the blob ceiling, and the way past it (#385, #396).
+//
+// The backend declines to diff a blob over `MAX_WORKDIR_BLOB` (5 MB), and #385
+// made it say so honestly rather than calling a checked-in `generated.sql`
+// "binary". What that fix deliberately left out was any way to act on it, so
+// leaving the app was the only route past a ceiling that is a GUESS about
+// intent — and when the guess is wrong it is completely wrong.
+//
+// This is the end-to-end half that neither the Rust integration tests nor the
+// component tests can reach: that a real 6.7 MB blob in a real repository comes
+// back refused, that the click sends `raiseFor` across IPC in the shape the
+// command expects (a camelCase arg deserialising into `Option<Vec<String>>` is
+// exactly the kind of thing only a real invoke proves), and that the pane then
+// renders the hunks it previously refused.
+
+import { browser, $, expect } from "@wdio/globals";
+import { oversizedBlobRepo, type TempRepo } from "../support/tempRepo";
+import { changeRow, openRepo, resetApp, switchScreen } from "../support/app";
+
+/** The commit panel's own diff scroller, so no other pane can satisfy a find. */
+const diffScroll = '[aria-label="Diff"]';
+
+/**
+ * Wait for one line of diff text to be on screen.
+ *
+ * `getText()` on the scroller rather than a text selector: WebdriverIO's `*=`
+ * compiles only against a tag name or an attribute selector, so
+ * `.pg-selectable*=…` is rejected by WebKit as invalid CSS. `getText` is a
+ * protocol-level command, so it refetches rather than going dead on a
+ * re-render.
+ */
+async function waitForDiffText(needle: string, msg: string): Promise<void> {
+  await browser.waitUntil(
+    async () => (await $(diffScroll).getText()).includes(needle),
+    { timeout: 30_000, timeoutMsg: msg },
+  );
+}
+
+describe("the diff blob ceiling", () => {
+  let repo: TempRepo;
+
+  beforeEach(async () => {
+    // The store reads status at `openRepo`, so the dirty file must exist first —
+    // the fixture writes it before returning.
+    repo = oversizedBlobRepo();
+    await openRepo(repo.path);
+    await switchScreen("commit");
+    await changeRow("generated.sql").waitForDisplayed({
+      timeout: 30_000,
+      timeoutMsg: "commit screen never listed the oversized file",
+    });
+  });
+
+  afterEach(async () => {
+    await resetApp();
+    repo.dispose();
+  });
+
+  it("refuses the blob honestly, then diffs it when the user insists", async () => {
+    await changeRow("generated.sql").click();
+
+    // The refusal names the real reason and the size. "Binary file" here would
+    // be the #385 bug — this file is ASCII, we simply declined to read 6.7 MB.
+    const notice = $('div*=File too large to diff');
+    await notice.waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "the oversized notice never appeared for a 6.7 MB text file",
+    });
+    // Sanity that we are looking at the refusal and not a real binary's state.
+    expect(await $("body").getText()).not.toContain("Binary diffs aren't shown.");
+
+    // ...and now the half #396 adds: something to do about it.
+    const button = $('[data-testid="diff-anyway"]');
+    await button.waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg: "the notice named a limit with nothing to act on",
+    });
+    await button.click();
+
+    // The pane renders what it previously refused. One line was added to the
+    // fixture, so the waived read is a handful of rows, not six figures — the
+    // `INSERT` is the only content in the file that is not the padding line.
+    await waitForDiffText(
+      "INSERT INTO t VALUES (1);",
+      "the waived read never produced the hunk it was asked for",
+    );
+
+    // The refusal is gone, and so is the button: there is nothing left to waive.
+    //
+    // A `waitUntil`, not a bare assert, and this is the whole reason the second
+    // test below exists: `CommitPanel`'s diff effect re-runs on every status
+    // refresh (its own comment says so — `status` is a dependency on purpose),
+    // so the waiver has to ride along on that fetch. When it did not, this pane
+    // flipped back to the refusal on its own, milliseconds after the diff
+    // arrived — which is exactly what a user would have seen.
+    await browser.waitUntil(
+      async () =>
+        !(await $('[data-testid="diff-anyway"]').isExisting()) &&
+        !(await $("body").getText()).includes("File too large to diff"),
+      {
+        timeout: 15_000,
+        timeoutMsg: "the refusal came back after the waived read landed",
+      },
+    );
+
+    // Repo truth as acceptance: nothing about this is a mutation, so what there
+    // is to assert is that reading a 6.7 MB blob did not touch the tree — both
+    // fixture files still modified, nothing staged, nothing rewritten.
+    const porcelain = repo
+      .git("status", "--porcelain")
+      .split("\n")
+      // Trimmed per line: `.trim()` on the whole output eats the leading space
+      // that porcelain's index column IS, which is what makes " M" unstaged.
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .sort();
+    expect(porcelain).toEqual(["M generated.sql", "M notes.txt"]);
+  });
+
+  it("re-refuses after the selection moves away and back", async () => {
+    // The waiver is per file, never remembered. It rides along on the SAME
+    // file's fetches — that is what keeps a status refresh from throwing the
+    // waived read away — and is dropped when the selection moves, so coming back
+    // costs a click rather than another silent 6.7 MB read. A waiver that
+    // outlived the selection would be an "always diff huge files" setting
+    // nobody asked for.
+    await changeRow("generated.sql").click();
+    await $('[data-testid="diff-anyway"]').waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "the action never appeared on first selection",
+    });
+    await $('[data-testid="diff-anyway"]').click();
+    await waitForDiffText("INSERT INTO t VALUES (1);", "the waived read never landed");
+
+    // Move the selection to the ordinary file, then back. The waiver is keyed on
+    // the selection, so it is dropped on the way out — no silent 6.7 MB re-read
+    // on the way back in.
+    await changeRow("notes.txt").click();
+    await waitForDiffText("two", "the other file's diff never rendered");
+    await changeRow("generated.sql").click();
+
+    await $('[data-testid="diff-anyway"]').waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "the ceiling did not re-apply on a fresh fetch",
+    });
+  });
+});

--- a/e2e/support/tempRepo.ts
+++ b/e2e/support/tempRepo.ts
@@ -509,3 +509,30 @@ export function bisectRepo(): TempRepo {
   }
   return r;
 }
+
+/**
+ * One tracked file over the backend's blob ceiling, modified by a single line.
+ *
+ * The ceiling is `MAX_WORKDIR_BLOB` (5 MB, `libgit2.rs`), so this is ~6.7 MB of
+ * plain ASCII — unambiguously TEXT, which is the whole point: libgit2's answer
+ * to `max_size` is to flag the delta BINARY, and "Binary file" is a lie about a
+ * checked-in generated artifact (#385). Real content, not a sparse file: the
+ * backend has to actually decline to read it.
+ *
+ * The modification is ONE line, so the diff read at the RAISED ceiling comes
+ * back small — a few context lines around one addition — which is what makes
+ * the override observable in a spec without a six-figure row count (#396).
+ */
+export function oversizedBlobRepo(): TempRepo {
+  const line = "the quick brown fox jumps over the lazy dog; padding padding\n";
+  const body = line.repeat(110_000); // ~6.7 MB, comfortably over the 5 MB cap
+  const r = new TempRepo();
+  r.commitFile("generated.sql", body, "feat: add a generated schema");
+  r.write("generated.sql", `${body}INSERT INTO t VALUES (1);\n`);
+  // A second, ordinary dirty file, so a spec can move the selection off the big
+  // one and back — the waiver is per file and per view, and that is the only way
+  // to exercise it without leaving the screen.
+  r.commitFile("notes.txt", "one\n", "feat: add notes");
+  r.write("notes.txt", "one\ntwo\n");
+  return r;
+}

--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -8,6 +8,19 @@ use crate::{
     state::AppState,
 };
 
+/// The wire's `raiseFor` as paths (#396).
+///
+/// One converter for all four diff commands so they cannot disagree about what
+/// an absent or empty list means: nothing was waived, and the default ceiling
+/// applies. The stash's own diff command uses it too.
+pub(crate) fn raised_paths(raise_for: Option<Vec<String>>) -> Vec<PathBuf> {
+    raise_for
+        .unwrap_or_default()
+        .into_iter()
+        .map(PathBuf::from)
+        .collect()
+}
+
 #[tauri::command]
 pub async fn stage_hunk(
     state: State<'_, AppState>,
@@ -132,14 +145,23 @@ pub async fn get_diff(
     // Viewing option only — see the `diff` doc on GitBackend. Optional so an
     // older caller (or a test) that omits it keeps the exact git default.
     ignore_whitespace: Option<bool>,
+    // The user's explicit "show it anyway" (#396): paths whose blob ceiling was
+    // waived by a click on the notice. Optional so every ordinary caller is
+    // unchanged, and a LIST of paths rather than a size, because the ceiling is
+    // backend policy — a frontend copy of it would be free to drift from the one
+    // that was applied.
+    raise_for: Option<Vec<String>>,
 ) -> AppResult<FileDiff> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
     let path = PathBuf::from(path);
     let iw = ignore_whitespace.unwrap_or(false);
-    tokio::task::spawn_blocking(move || backend.diff(&repo_id, &path, kind, context_lines, iw))
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+    let raise = raised_paths(raise_for);
+    tokio::task::spawn_blocking(move || {
+        backend.diff_over_ceiling(&repo_id, &path, kind, context_lines, iw, &raise)
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
 #[tauri::command]
@@ -192,12 +214,19 @@ pub async fn diff_commits(
     to_oid: String,
     context_lines: u32,
     ignore_whitespace: Option<bool>,
+    // The user's explicit "show it anyway" (#396): paths whose blob ceiling was
+    // waived by a click on the notice. Optional so every ordinary caller is
+    // unchanged, and a LIST of paths rather than a size, because the ceiling is
+    // backend policy — a frontend copy of it would be free to drift from the one
+    // that was applied.
+    raise_for: Option<Vec<String>>,
 ) -> AppResult<Vec<FileDiff>> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
     let iw = ignore_whitespace.unwrap_or(false);
+    let raise = raised_paths(raise_for);
     tokio::task::spawn_blocking(move || {
-        backend.diff_commits(&repo_id, &from_oid, &to_oid, context_lines, iw)
+        backend.diff_commits_over_ceiling(&repo_id, &from_oid, &to_oid, context_lines, iw, &raise)
     })
     .await
     .map_err(|e| AppError::Internal(e.to_string()))?
@@ -210,13 +239,22 @@ pub async fn diff_commit(
     oid: String,
     context_lines: u32,
     ignore_whitespace: Option<bool>,
+    // The user's explicit "show it anyway" (#396): paths whose blob ceiling was
+    // waived by a click on the notice. Optional so every ordinary caller is
+    // unchanged, and a LIST of paths rather than a size, because the ceiling is
+    // backend policy — a frontend copy of it would be free to drift from the one
+    // that was applied.
+    raise_for: Option<Vec<String>>,
 ) -> AppResult<Vec<FileDiff>> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
     let iw = ignore_whitespace.unwrap_or(false);
-    tokio::task::spawn_blocking(move || backend.diff_commit(&repo_id, &oid, context_lines, iw))
-        .await
-        .map_err(|e| AppError::Internal(e.to_string()))?
+    let raise = raised_paths(raise_for);
+    tokio::task::spawn_blocking(move || {
+        backend.diff_commit_over_ceiling(&repo_id, &oid, context_lines, iw, &raise)
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
 }
 
 /// Diff the tree at `revspec` against the working tree (#131).
@@ -231,13 +269,27 @@ pub async fn diff_ref_to_workdir(
     context_lines: u32,
     ignore_whitespace: Option<bool>,
     include_untracked: Option<bool>,
+    // The user's explicit "show it anyway" (#396): paths whose blob ceiling was
+    // waived by a click on the notice. Optional so every ordinary caller is
+    // unchanged, and a LIST of paths rather than a size, because the ceiling is
+    // backend policy — a frontend copy of it would be free to drift from the one
+    // that was applied.
+    raise_for: Option<Vec<String>>,
 ) -> AppResult<WorkdirDiff> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
     let iw = ignore_whitespace.unwrap_or(false);
     let untracked = include_untracked.unwrap_or(false);
+    let raise = raised_paths(raise_for);
     tokio::task::spawn_blocking(move || {
-        backend.diff_ref_to_workdir(&repo_id, &revspec, context_lines, iw, untracked)
+        backend.diff_ref_to_workdir_over_ceiling(
+            &repo_id,
+            &revspec,
+            context_lines,
+            iw,
+            untracked,
+            &raise,
+        )
     })
     .await
     .map_err(|e| AppError::Internal(e.to_string()))?

--- a/src-tauri/src/commands/stash.rs
+++ b/src-tauri/src/commands/stash.rs
@@ -125,16 +125,20 @@ pub async fn stash_diff(
     context_lines: u32,
     ignore_whitespace: bool,
     include_untracked: bool,
+    // The user's explicit "show it anyway" (#396) — see `raised_paths`.
+    raise_for: Option<Vec<String>>,
 ) -> AppResult<Vec<FileDiff>> {
     let backend = state.backend.clone();
     let repo_id = RepoId(repo_id);
+    let raise = crate::commands::diff::raised_paths(raise_for);
     tokio::task::spawn_blocking(move || {
-        backend.stash_diff(
+        backend.stash_diff_over_ceiling(
             &repo_id,
             &oid,
             context_lines,
             ignore_whitespace,
             include_untracked,
+            &raise,
         )
     })
     .await

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -111,13 +111,14 @@ impl GitBackend for CliBackend {
     ) -> AppResult<Vec<CommitInfo>> {
         Err(AppError::NotImplemented)
     }
-    fn diff(
+    fn diff_over_ceiling(
         &self,
         _repo_id: &RepoId,
         _path: &Path,
         _kind: DiffKind,
         _context_lines: u32,
         _ignore_whitespace: bool,
+        _raise_for: &[PathBuf],
     ) -> AppResult<FileDiff> {
         Err(AppError::NotImplemented)
     }
@@ -154,32 +155,35 @@ impl GitBackend for CliBackend {
     ) -> AppResult<Option<ImagePreview>> {
         Err(AppError::NotImplemented)
     }
-    fn diff_commits(
+    fn diff_commits_over_ceiling(
         &self,
         _repo_id: &RepoId,
         _from_oid: &str,
         _to_oid: &str,
         _context_lines: u32,
         _ignore_whitespace: bool,
+        _raise_for: &[PathBuf],
     ) -> AppResult<Vec<FileDiff>> {
         Err(AppError::NotImplemented)
     }
-    fn diff_commit(
+    fn diff_commit_over_ceiling(
         &self,
         _repo_id: &RepoId,
         _oid: &str,
         _context_lines: u32,
         _ignore_whitespace: bool,
+        _raise_for: &[PathBuf],
     ) -> AppResult<Vec<FileDiff>> {
         Err(AppError::NotImplemented)
     }
-    fn diff_ref_to_workdir(
+    fn diff_ref_to_workdir_over_ceiling(
         &self,
         _repo_id: &RepoId,
         _revspec: &str,
         _context_lines: u32,
         _ignore_whitespace: bool,
         _include_untracked: bool,
+        _raise_for: &[PathBuf],
     ) -> AppResult<WorkdirDiff> {
         Err(AppError::NotImplemented)
     }
@@ -378,13 +382,14 @@ impl GitBackend for CliBackend {
     ) -> AppResult<()> {
         Err(AppError::NotImplemented)
     }
-    fn stash_diff(
+    fn stash_diff_over_ceiling(
         &self,
         _repo_id: &RepoId,
         _oid: &str,
         _context_lines: u32,
         _ignore_whitespace: bool,
         _include_untracked: bool,
+        _raise_for: &[PathBuf],
     ) -> AppResult<Vec<FileDiff>> {
         Err(AppError::NotImplemented)
     }

--- a/src-tauri/src/git/lfs.rs
+++ b/src-tauri/src/git/lfs.rs
@@ -305,6 +305,7 @@ mod tests {
             }],
             lfs: None,
             oversized: None,
+            truncated: None,
         }
     }
 

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -35,7 +35,7 @@ use super::{
         ReflogEntry, ReflogOp, RemoteInfo,
         RepoHandle, RepoId, RepoState, ResetMode, ShallowInfo, StashInfo, StashSaveOptions,
         StatusFlag,
-        SubmoduleInfo, TagInfo, TagTarget, UnsupportedReason, WorkdirDiff, WorktreeBranch, WorktreeInfo,
+        SubmoduleInfo, TagInfo, TagTarget, TruncatedDiff, UnsupportedReason, WorkdirDiff, WorktreeBranch, WorktreeInfo,
         REFSPEC_ALL,
     },
     GitBackend,
@@ -1887,7 +1887,18 @@ fn side_line_stats(
 /// origin, binary flag, add/del counts, hunks). Renames must already be
 /// resolved by the caller (`find_similar`). Shared by every tree-to-tree diff
 /// op so hunk grouping stays identical.
-fn diff_to_file_diffs(diff: &git2::Diff) -> AppResult<Vec<FileDiff>> {
+///
+/// `ceiling` is the per-blob limit the caller applied, reported back on any
+/// delta that hit it. `line_cap` bounds the lines serialised PER FILE — `None`
+/// for an ordinary diff, `Some(MAX_DIFF_LINES)` once the user waived the
+/// ceiling; see `diff_lines_cap`. Over the cap the counting continues, so
+/// `additions`/`deletions` and `TruncatedDiff::total` still describe the whole
+/// diff — only the `DiffLine`s stop.
+fn diff_to_file_diffs(
+    diff: &git2::Diff,
+    ceiling: i64,
+    line_cap: Option<usize>,
+) -> AppResult<Vec<FileDiff>> {
     let num_deltas = diff.deltas().len();
     let mut out: Vec<FileDiff> = Vec::with_capacity(num_deltas);
     // Each delta's new-file path, kept as a Path for the callback to compare
@@ -1926,8 +1937,14 @@ fn diff_to_file_diffs(diff: &git2::Diff) -> AppResult<Vec<FileDiff>> {
             // Same load-order trap as `binary` above: sizes are filled in
             // during `print`, so this is decided in the callback, not here.
             oversized: None,
+            // Only known once the last line has been counted.
+            truncated: None,
         });
     }
+
+    // Lines counted per file, whether or not they were kept — the numerator of
+    // `TruncatedDiff` comes off `hunks`, the denominator off this.
+    let mut line_totals: Vec<usize> = vec![0; out.len()];
 
     // ONE print pass for the whole diff. `git_diff_print` generates each
     // delta's patch — full blob load + xdiff — as it goes, so printing inside a
@@ -1955,10 +1972,12 @@ fn diff_to_file_diffs(diff: &git2::Diff) -> AppResult<Vec<FileDiff>> {
         }
         if d.flags().contains(git2::DiffFlags::BINARY) {
             out[idx].binary = true;
-            // A blob over `MAX_WORKDIR_BLOB` is flagged binary by libgit2 and
-            // arrives here indistinguishable from a PNG. Record the size so the
-            // UI can say which it is (#385).
-            out[idx].oversized = out[idx].oversized.or_else(|| oversized_delta(&d));
+            // A blob over the ceiling is flagged binary by libgit2 and arrives
+            // here indistinguishable from a PNG. Record the size so the UI can
+            // say which it is (#385).
+            out[idx].oversized = out[idx]
+                .oversized
+                .or_else(|| oversized_delta(&d, ceiling));
             return true;
         }
         if let Some(h) = hunk {
@@ -1992,6 +2011,14 @@ fn diff_to_file_diffs(diff: &git2::Diff) -> AppResult<Vec<FileDiff>> {
             'H' | 'F' => DiffLineKind::HunkHeader,
             _ => DiffLineKind::Context,
         };
+        line_totals[idx] += 1;
+        // Over the cap: keep walking (the counts above and `line_totals` are
+        // the file's real numbers, and the UI reports both) but stop building
+        // `String`s nobody will be shown. Checked BEFORE `from_utf8`, so the
+        // allocation is what the cap actually saves (#396).
+        if line_cap.is_some_and(|cap| line_totals[idx] > cap) {
+            return true;
+        }
         if let Some(h) = current.as_mut() {
             h.lines.push(DiffLine {
                 kind,
@@ -2010,14 +2037,30 @@ fn diff_to_file_diffs(diff: &git2::Diff) -> AppResult<Vec<FileDiff>> {
         }
     }
 
-    for file_diff in &mut out {
+    for (file_diff, total) in out.iter_mut().zip(line_totals) {
         // Derived from the diff just built — no extra I/O (#93). Both commit-diff
         // paths come through here, so they cannot disagree with `diff()` about what
         // an LFS pointer diff is.
         crate::git::lfs::annotate(file_diff);
+        file_diff.truncated = truncation(file_diff, total, line_cap);
     }
 
     Ok(out)
+}
+
+/// `TruncatedDiff` for one file, or `None` when it came back whole (#396).
+///
+/// Shared by the two collectors — `diff_to_file_diffs` and `diff`'s own inline
+/// one — so a truncated file reports itself identically whichever op produced
+/// it. `shown` is counted off the hunks rather than tracked separately: it is
+/// then the number of rows the surfaces will actually lay out, by construction.
+fn truncation(fd: &FileDiff, total: usize, line_cap: Option<usize>) -> Option<TruncatedDiff> {
+    let cap = line_cap?;
+    if total <= cap {
+        return None;
+    }
+    let shown = fd.hunks.iter().map(|h| h.lines.len()).sum();
+    Some(TruncatedDiff { shown, total })
 }
 
 /// Run `git apply [extra_args...] -` with `patch_text` piped to stdin.
@@ -2082,6 +2125,122 @@ const MAX_UNTRACKED_FILES: usize = 200;
 /// the limit that was applied.
 pub const MAX_WORKDIR_BLOB: i64 = 5 * 1024 * 1024;
 
+/// The ceiling the user's own "show it anyway" raises to (#396).
+///
+/// `MAX_WORKDIR_BLOB` is a guess about intent — "a 5 MB text file is a
+/// generated artifact, not something anyone diffs in a GUI" — and when it is
+/// wrong it is completely wrong: a generated `schema.sql`, a `.csv` fixture, a
+/// vendored lockfile, a minified bundle whose one changed line is the thing
+/// being reviewed. So the refusal is overridable, per file and per view.
+///
+/// It is a HIGHER ceiling, not the absence of one. libgit2's default is 512 MB
+/// and xdiff is superlinear in the blob, so an uncapped override would just
+/// move the wall to somewhere with no message on it — which is exactly what
+/// #385 removed. This is the largest blob worth waiting on in a GUI; over it
+/// the delta comes back `oversized` again, with THIS limit in the sentence.
+pub const MAX_BLOB_OVERRIDE: i64 = 64 * 1024 * 1024;
+
+/// Diff lines one file may return once its ceiling has been waived (#396).
+///
+/// The blob size is the first wall and the line count is the second, and the
+/// second is the one the frontend cannot survive: a 40 MB CSV rewritten
+/// wholesale is on the order of a million `DiffLine`s, which is a nine-figure
+/// JSON payload for the webview to parse, a million row objects for
+/// `flattenDiffRows`, and a `heights` array that `windowVariable` reduces over
+/// on every scroll event. An override that hands the user a frozen window is
+/// worse than the refusal it replaced, so the lines stop here and
+/// `FileDiff::truncated` says how many there really were.
+///
+/// Deliberately reached ONLY through `diff_lines_cap`, i.e. only when the user
+/// waived the ceiling: an ordinary diff is under `MAX_WORKDIR_BLOB` and keeps
+/// coming back whole, so no file the app opens by itself starts truncating.
+pub const MAX_DIFF_LINES: usize = 100_000;
+
+/// The per-blob ceiling to apply to one diff (#385, #396).
+///
+/// `raise` is true only for a path the user explicitly asked to see anyway.
+///
+/// Two constants and nothing else, which is the point: there is no spelling of
+/// "no limit" to reach for here, so the override can only ever be a DIFFERENT
+/// ceiling. The multi-file ops pick between the same two through `with_raised`.
+fn blob_ceiling(raise: bool) -> i64 {
+    if raise {
+        MAX_BLOB_OVERRIDE
+    } else {
+        MAX_WORKDIR_BLOB
+    }
+}
+
+/// Narrow a whole-tree diff to the paths whose ceiling the user waived (#396).
+///
+/// A raise is per FILE, and the ops that answer it — `diff_commit`,
+/// `diff_commits`, `diff_ref_to_workdir`, `stash_diff` — each fan out over many.
+/// Without this, "show me that 40 MB CSV" would also read the 60 MB
+/// `bundle.min.js` sitting in the same commit, which is the footgun a per-file
+/// escape hatch exists to avoid. The frontend already holds the deltas and
+/// names them literally (both sides of a rename, so `find_similar` can still
+/// pair them), so `disable_pathspec_match` turns the entries into exact paths
+/// rather than glob patterns.
+///
+/// A no-op for an empty list, which is what every ordinary diff passes.
+fn scope_to_raised(opts: &mut DiffOptions, raise_for: &[PathBuf]) {
+    if raise_for.is_empty() {
+        return;
+    }
+    for path in raise_for {
+        opts.pathspec(path);
+    }
+    opts.disable_pathspec_match(true);
+}
+
+/// Was `ceiling` the raised one? Derived, so the two constants have one test.
+fn is_raised(ceiling: i64) -> bool {
+    ceiling > MAX_WORKDIR_BLOB
+}
+
+/// The line cap that goes with a given ceiling (#396).
+///
+/// `None` for an ordinary diff: it is under `MAX_WORKDIR_BLOB`, so capping it
+/// could only ever truncate something the app was happy to render yesterday.
+fn diff_lines_cap(ceiling: i64) -> Option<usize> {
+    is_raised(ceiling).then_some(MAX_DIFF_LINES)
+}
+
+/// The WHOLE diff, with the paths the user waived read at the raised ceiling
+/// (#396).
+///
+/// **Two builds, deliberately.** libgit2's `max_size` is a diff-WIDE option, so
+/// "raise it for this one path" cannot be said in a single build: either the
+/// whole diff gets the raised ceiling — and reads every huge blob in the commit,
+/// which is the footgun a per-file escape hatch exists to avoid — or the raise
+/// is scoped by a pathspec, which narrows the ANSWER to those paths. So the base
+/// build answers for every file at the default ceiling and a second, pathspec'd
+/// build re-reads only the waived ones.
+///
+/// The second build is where all the megabytes are paid for, and only there: the
+/// base build never reads a blob over the ceiling — that is what being over it
+/// means — so the extra pass costs one more tree walk, not one more blob read.
+///
+/// Returning the whole list rather than the waived subset is what lets a caller
+/// pass its waivers on EVERY fetch. That matters more than it sounds: a status
+/// refresh re-runs a surface's diff fetch, and with subset semantics the waived
+/// read the user waited seconds for was silently replaced by the refusal again.
+fn with_raised(
+    raise_for: &[PathBuf],
+    build: impl Fn(i64, &[PathBuf]) -> AppResult<Vec<FileDiff>>,
+) -> AppResult<Vec<FileDiff>> {
+    let mut files = build(MAX_WORKDIR_BLOB, &[])?;
+    if raise_for.is_empty() {
+        return Ok(files);
+    }
+    for raised in build(MAX_BLOB_OVERRIDE, raise_for)? {
+        if let Some(slot) = files.iter_mut().find(|d| d.path == raised.path) {
+            *slot = raised;
+        }
+    }
+    Ok(files)
+}
+
 /// Did libgit2 skip this delta because a side is over the ceiling? (#385)
 ///
 /// Read from the DELTA rather than from a separate blob lookup: libgit2 fills
@@ -2090,10 +2249,18 @@ pub const MAX_WORKDIR_BLOB: i64 = 5 * 1024 * 1024;
 /// from inside a `print`/`foreach` callback — i.e. after the load. Reading it
 /// before the load would see zeros for a tree delta, which is the trap the
 /// `binary` seeding a few lines below already documents.
-fn oversized_delta(delta: &git2::DiffDelta<'_>) -> Option<OversizedBlob> {
-    let limit = MAX_WORKDIR_BLOB as u64;
+/// `limit` is the ceiling that was actually applied to THIS diff, not the
+/// default: after a "show it anyway" the sentence the user reads has to name the
+/// raised one, or a 120 MB blob would report itself as over 5 MB and the button
+/// would look like it did nothing (#396).
+fn oversized_delta(delta: &git2::DiffDelta<'_>, limit: i64) -> Option<OversizedBlob> {
+    // Derived, not passed: `blob_ceiling` returns one of exactly two constants,
+    // so the limit that was applied already says which one it was — and one
+    // source of truth cannot disagree with itself.
+    let raised = is_raised(limit);
+    let limit = limit as u64;
     let size = delta.old_file().size().max(delta.new_file().size());
-    (size > limit).then_some(OversizedBlob { size, limit })
+    (size > limit).then_some(OversizedBlob { size, limit, raised })
 }
 
 /// Every stash entry as `(oid, reflog message)`, newest first (#133).
@@ -3552,14 +3719,19 @@ impl GitBackend for Libgit2Backend {
         })
     }
 
-    fn diff(
+    fn diff_over_ceiling(
         &self,
         repo_id: &RepoId,
         path: &Path,
         kind: DiffKind,
         context_lines: u32,
         ignore_whitespace: bool,
+        raise_for: &[PathBuf],
     ) -> AppResult<FileDiff> {
+        // One path in, one path out, so the pathspec below already scopes the
+        // raise — this only has to decide whether the user asked for THIS file.
+        let ceiling = blob_ceiling(raise_for.iter().any(|p| p == path));
+        let line_cap = diff_lines_cap(ceiling);
         self.with_repo(repo_id, |repo| {
             // Without this the diff comes back valid but empty — a blank panel
             // with no explanation. See `is_embedded_repo`.
@@ -3576,8 +3748,9 @@ impl GitBackend for Libgit2Backend {
             // without this libgit2's 512MB default let it xdiff the whole file
             // and serialise a String per line through IPC (#385). Same ceiling
             // as `diff_ref_to_workdir` — one policy, not one capped path and
-            // three uncapped ones.
-            opts.max_size(MAX_WORKDIR_BLOB);
+            // three uncapped ones — raised only for a path the user explicitly
+            // asked to see anyway (#396).
+            opts.max_size(ceiling);
             // Include untracked files as if their full content were a new addition
             // so the diff viewer shows file contents for newly created files.
             if matches!(kind, DiffKind::WorktreeToIndex | DiffKind::WorktreeToHead) {
@@ -3618,6 +3791,9 @@ impl GitBackend for Libgit2Backend {
             let mut additions: u32 = 0;
             let mut deletions: u32 = 0;
             let mut hunks: Vec<DiffHunk> = Vec::new();
+            // Counted whether or not the line is kept, so `truncation` has the
+            // file's real length to report (#396).
+            let mut total_lines: usize = 0;
 
             diff.print(DiffFormat::Patch, |delta, hunk, line| {
                 // Paths are read once, on the first callback — building the
@@ -3638,24 +3814,44 @@ impl GitBackend for Libgit2Backend {
                     // Why it is "binary": a real PNG, or a text blob we
                     // declined to read (#385). Only the size can tell them
                     // apart, and it is populated by now (see `oversized_delta`).
-                    oversized = oversized.or_else(|| oversized_delta(&delta));
+                    oversized = oversized.or_else(|| oversized_delta(&delta, ceiling));
                     return true;
                 }
                 let origin = line.origin();
-                let content = std::str::from_utf8(line.content())
-                    .unwrap_or("")
-                    .trim_end_matches('\n')
-                    .to_string();
 
                 match origin {
                     'H' | 'F' => return true,
                     'B' => {
                         binary = true;
-                        oversized = oversized.or_else(|| oversized_delta(&delta));
+                        oversized = oversized.or_else(|| oversized_delta(&delta, ceiling));
                         return true;
                     }
                     _ => {}
                 }
+
+                // Classified — and COUNTED — before the cap, so `additions` and
+                // `deletions` describe the whole change even when the pane can
+                // only be shown part of it (#396).
+                let kind = match origin {
+                    '+' => {
+                        additions += 1;
+                        DiffLineKind::Addition
+                    }
+                    '-' => {
+                        deletions += 1;
+                        DiffLineKind::Deletion
+                    }
+                    _ => DiffLineKind::Context,
+                };
+                total_lines += 1;
+                if line_cap.is_some_and(|cap| total_lines > cap) {
+                    return true;
+                }
+
+                let content = std::str::from_utf8(line.content())
+                    .unwrap_or("")
+                    .trim_end_matches('\n')
+                    .to_string();
 
                 if let Some(h) = hunk {
                     // Compare the stored header (newline-stripped) against the
@@ -3694,18 +3890,6 @@ impl GitBackend for Libgit2Backend {
                     return true;
                 };
 
-                let kind = match origin {
-                    '+' => {
-                        additions += 1;
-                        DiffLineKind::Addition
-                    }
-                    '-' => {
-                        deletions += 1;
-                        DiffLineKind::Deletion
-                    }
-                    _ => DiffLineKind::Context,
-                };
-
                 current_hunk.lines.push(DiffLine {
                     kind,
                     old_lineno: line.old_lineno(),
@@ -3724,8 +3908,10 @@ impl GitBackend for Libgit2Backend {
                 hunks,
                 lfs: None,
                 oversized,
+                truncated: None,
             };
             crate::git::lfs::annotate(&mut file_diff);
+            file_diff.truncated = truncation(&file_diff, total_lines, line_cap);
             Ok(file_diff)
         })
     }
@@ -4056,13 +4242,14 @@ impl GitBackend for Libgit2Backend {
         })
     }
 
-    fn diff_commits(
+    fn diff_commits_over_ceiling(
         &self,
         repo_id: &RepoId,
         from_oid: &str,
         to_oid: &str,
         context_lines: u32,
         ignore_whitespace: bool,
+        raise_for: &[PathBuf],
     ) -> AppResult<Vec<FileDiff>> {
         self.with_repo(repo_id, |repo| {
             // `resolve_commit`, not a bare `?`: both sides are USER-TYPED
@@ -4076,30 +4263,34 @@ impl GitBackend for Libgit2Backend {
             let from_tree = repo.find_commit(from)?.tree()?;
             let to_tree = repo.find_commit(to)?.tree()?;
 
-            let mut opts = DiffOptions::new();
-            opts.context_lines(context_lines);
-            opts.ignore_whitespace(ignore_whitespace);
-            // One ceiling for every diff path (#385) — this one fans out over a
-            // whole comparison, so a single checked-in artifact would otherwise
-            // dominate the payload.
-            opts.max_size(MAX_WORKDIR_BLOB);
-            let mut diff =
-                repo.diff_tree_to_tree(Some(&from_tree), Some(&to_tree), Some(&mut opts))?;
+            with_raised(raise_for, |ceiling, raise_for| {
+                let mut opts = DiffOptions::new();
+                opts.context_lines(context_lines);
+                opts.ignore_whitespace(ignore_whitespace);
+                // One ceiling for every diff path (#385) — this one fans out
+                // over a whole comparison, so a single checked-in artifact
+                // would otherwise dominate the payload.
+                opts.max_size(ceiling);
+                scope_to_raised(&mut opts, raise_for);
+                let mut diff =
+                    repo.diff_tree_to_tree(Some(&from_tree), Some(&to_tree), Some(&mut opts))?;
 
-            let mut find_opts = DiffFindOptions::new();
-            find_opts.renames(true).copies(false);
-            diff.find_similar(Some(&mut find_opts)).ok();
+                let mut find_opts = DiffFindOptions::new();
+                find_opts.renames(true).copies(false);
+                diff.find_similar(Some(&mut find_opts)).ok();
 
-            diff_to_file_diffs(&diff)
+                diff_to_file_diffs(&diff, ceiling, diff_lines_cap(ceiling))
+            })
         })
     }
 
-    fn diff_commit(
+    fn diff_commit_over_ceiling(
         &self,
         repo_id: &RepoId,
         oid: &str,
         context_lines: u32,
         ignore_whitespace: bool,
+        raise_for: &[PathBuf],
     ) -> AppResult<Vec<FileDiff>> {
         self.with_repo(repo_id, |repo| {
             let commit = repo.revparse_single(oid)?.peel_to_commit()?;
@@ -4110,33 +4301,37 @@ impl GitBackend for Libgit2Backend {
                 Err(_) => None,
             };
 
-            let mut opts = DiffOptions::new();
-            opts.context_lines(context_lines);
-            opts.ignore_whitespace(ignore_whitespace);
-            // One ceiling for every diff path (#385): this feeds every commit
-            // the user clicks in the log.
-            opts.max_size(MAX_WORKDIR_BLOB);
-            let mut diff = repo.diff_tree_to_tree(
-                from_tree.as_ref(),
-                Some(&to_tree),
-                Some(&mut opts),
-            )?;
+            with_raised(raise_for, |ceiling, raise_for| {
+                let mut opts = DiffOptions::new();
+                opts.context_lines(context_lines);
+                opts.ignore_whitespace(ignore_whitespace);
+                // One ceiling for every diff path (#385): this feeds every
+                // commit the user clicks in the log.
+                opts.max_size(ceiling);
+                scope_to_raised(&mut opts, raise_for);
+                let mut diff = repo.diff_tree_to_tree(
+                    from_tree.as_ref(),
+                    Some(&to_tree),
+                    Some(&mut opts),
+                )?;
 
-            let mut find_opts = DiffFindOptions::new();
-            find_opts.renames(true).copies(false);
-            diff.find_similar(Some(&mut find_opts)).ok();
+                let mut find_opts = DiffFindOptions::new();
+                find_opts.renames(true).copies(false);
+                diff.find_similar(Some(&mut find_opts)).ok();
 
-            diff_to_file_diffs(&diff)
+                diff_to_file_diffs(&diff, ceiling, diff_lines_cap(ceiling))
+            })
         })
     }
 
-    fn diff_ref_to_workdir(
+    fn diff_ref_to_workdir_over_ceiling(
         &self,
         repo_id: &RepoId,
         revspec: &str,
         context_lines: u32,
         ignore_whitespace: bool,
         include_untracked: bool,
+        raise_for: &[PathBuf],
     ) -> AppResult<WorkdirDiff> {
         self.with_repo(repo_id, |repo| {
             // `resolve_tree` so a tag, a branch, a commit or a tree all work —
@@ -4144,16 +4339,20 @@ impl GitBackend for Libgit2Backend {
             // a bad spec is `InvalidRef`, not a stringified libgit2 message.
             let tree = resolve_tree(repo, revspec)?;
 
-            // One builder, three call shapes, so the knobs cannot drift between
-            // the counting pass and the real one.
-            let build = |untracked: UntrackedMode| -> AppResult<git2::Diff<'_>> {
+            // One builder, four call shapes, so the knobs cannot drift between
+            // the counting pass, the real one, and the raised re-read (#396).
+            let build = |untracked: UntrackedMode,
+                         ceiling: i64,
+                         raise_for: &[PathBuf]|
+             -> AppResult<git2::Diff<'_>> {
                 let mut opts = DiffOptions::new();
                 opts.context_lines(context_lines);
                 opts.ignore_whitespace(ignore_whitespace);
                 // This op fans out over the WHOLE tree, unlike `diff`, which
                 // pathspecs one file first. Cap per-blob size so a single huge
                 // artifact reports as binary instead of being serialised.
-                opts.max_size(MAX_WORKDIR_BLOB);
+                opts.max_size(ceiling);
+                scope_to_raised(&mut opts, raise_for);
                 match untracked {
                     UntrackedMode::Off => {}
                     // `include_ignored` stays off in both, so `.gitignore`d
@@ -4177,7 +4376,7 @@ impl GitBackend for Libgit2Backend {
             // pass is the same directory walk without the content, so this costs
             // a second walk and never a second read of the files we then drop.
             let (mode, untracked_omitted) = if include_untracked {
-                let counted = build(UntrackedMode::NamesOnly)?;
+                let counted = build(UntrackedMode::NamesOnly, MAX_WORKDIR_BLOB, &[])?;
                 let untracked = counted
                     .deltas()
                     .filter(|d| d.status() == git2::Delta::Untracked)
@@ -4191,14 +4390,16 @@ impl GitBackend for Libgit2Backend {
                 (UntrackedMode::Off, 0)
             };
 
-            let mut diff = build(mode)?;
-
-            let mut find_opts = DiffFindOptions::new();
-            find_opts.renames(true).copies(false);
-            diff.find_similar(Some(&mut find_opts)).ok();
+            let files = with_raised(raise_for, |ceiling, raise_for| {
+                let mut diff = build(mode, ceiling, raise_for)?;
+                let mut find_opts = DiffFindOptions::new();
+                find_opts.renames(true).copies(false);
+                diff.find_similar(Some(&mut find_opts)).ok();
+                diff_to_file_diffs(&diff, ceiling, diff_lines_cap(ceiling))
+            })?;
 
             Ok(WorkdirDiff {
-                files: diff_to_file_diffs(&diff)?,
+                files,
                 untracked_omitted,
             })
         })
@@ -5651,13 +5852,14 @@ impl GitBackend for Libgit2Backend {
         self.stash_finish_rename(repo_id, index, &before_pairs, &new_oid, message)
     }
 
-    fn stash_diff(
+    fn stash_diff_over_ceiling(
         &self,
         repo_id: &RepoId,
         oid: &str,
         context_lines: u32,
         ignore_whitespace: bool,
         include_untracked: bool,
+        raise_for: &[PathBuf],
     ) -> AppResult<Vec<FileDiff>> {
         self.with_repo(repo_id, |repo| {
             let commit = resolve_commit(repo, oid)?;
@@ -5668,22 +5870,25 @@ impl GitBackend for Libgit2Backend {
                 .parent(0)
                 .map_err(|_| AppError::InvalidRef(oid.to_string()))?;
 
-            let mut opts = DiffOptions::new();
-            opts.context_lines(context_lines);
-            opts.ignore_whitespace(ignore_whitespace);
-            // One ceiling for every diff path (#385) — a stash holds whatever
-            // the worktree held, generated artifacts included.
-            opts.max_size(MAX_WORKDIR_BLOB);
-            // base → stash, so the stashed work reads as ADDITIONS.
-            let mut diff = repo.diff_tree_to_tree(
-                Some(&base.tree()?),
-                Some(&commit.tree()?),
-                Some(&mut opts),
-            )?;
-            let mut find_opts = DiffFindOptions::new();
-            find_opts.renames(true).copies(false);
-            diff.find_similar(Some(&mut find_opts)).ok();
-            let mut files = diff_to_file_diffs(&diff)?;
+            let mut files = with_raised(raise_for, |ceiling, raise_for| {
+                let mut opts = DiffOptions::new();
+                opts.context_lines(context_lines);
+                opts.ignore_whitespace(ignore_whitespace);
+                // One ceiling for every diff path (#385) — a stash holds
+                // whatever the worktree held, generated artifacts included.
+                opts.max_size(ceiling);
+                scope_to_raised(&mut opts, raise_for);
+                // base → stash, so the stashed work reads as ADDITIONS.
+                let mut diff = repo.diff_tree_to_tree(
+                    Some(&base.tree()?),
+                    Some(&commit.tree()?),
+                    Some(&mut opts),
+                )?;
+                let mut find_opts = DiffFindOptions::new();
+                find_opts.renames(true).copies(false);
+                diff.find_similar(Some(&mut find_opts)).ok();
+                diff_to_file_diffs(&diff, ceiling, diff_lines_cap(ceiling))
+            })?;
 
             // The `git stash -u` payload lives in a THIRD parent, which no
             // tree-level diff of the stash commit can reach. That parent's tree
@@ -5692,13 +5897,16 @@ impl GitBackend for Libgit2Backend {
             // overlap with the tracked side above.
             if include_untracked && commit.parent_count() > 2 {
                 let untracked = commit.parent(2)?;
-                let mut u_opts = DiffOptions::new();
-                u_opts.context_lines(context_lines);
-                u_opts.ignore_whitespace(ignore_whitespace);
-                u_opts.max_size(MAX_WORKDIR_BLOB);
-                let u_diff =
-                    repo.diff_tree_to_tree(None, Some(&untracked.tree()?), Some(&mut u_opts))?;
-                files.extend(diff_to_file_diffs(&u_diff)?);
+                files.extend(with_raised(raise_for, |ceiling, raise_for| {
+                    let mut u_opts = DiffOptions::new();
+                    u_opts.context_lines(context_lines);
+                    u_opts.ignore_whitespace(ignore_whitespace);
+                    u_opts.max_size(ceiling);
+                    scope_to_raised(&mut u_opts, raise_for);
+                    let u_diff =
+                        repo.diff_tree_to_tree(None, Some(&untracked.tree()?), Some(&mut u_opts))?;
+                    diff_to_file_diffs(&u_diff, ceiling, diff_lines_cap(ceiling))
+                })?);
             }
             Ok(files)
         })

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -233,6 +233,8 @@ pub trait GitBackend: Send + Sync {
     /// the blob is never read and `FileDiff.oversized` carries the size and the
     /// limit, so the UI can say "too large to diff" rather than the "binary"
     /// that libgit2's own answer to `max_size` would otherwise imply.
+    /// `raise_for` is the user's explicit "show it anyway" (#396) — see
+    /// `diff_over_ceiling`, which this forwards to with an empty list.
     fn diff(
         &self,
         repo_id: &RepoId,
@@ -240,6 +242,33 @@ pub trait GitBackend: Send + Sync {
         kind: DiffKind,
         context_lines: u32,
         ignore_whitespace: bool,
+    ) -> AppResult<FileDiff> {
+        self.diff_over_ceiling(repo_id, path, kind, context_lines, ignore_whitespace, &[])
+    }
+    /// `diff`, with the per-blob ceiling RAISED for the listed paths (#396).
+    ///
+    /// The ceiling is a guess about intent and it is usually right, but when it
+    /// is wrong it is completely wrong — a generated `schema.sql`, a `.csv`
+    /// fixture, a vendored lockfile, a minified bundle whose one changed line is
+    /// the thing being reviewed. This is the way past it: per file, per view,
+    /// never a setting, because a remembered "always diff huge files" is a
+    /// refusal turned into a footgun the user forgot they armed.
+    ///
+    /// **A raised ceiling is a DIFFERENT ceiling, not the absence of one.** The
+    /// listed paths are diffed at `MAX_BLOB_OVERRIDE` and their lines capped at
+    /// `MAX_DIFF_LINES` (reported as `FileDiff::truncated`); a path still over
+    /// that comes back `oversized` again, naming the raised limit. Everything
+    /// not listed keeps `MAX_WORKDIR_BLOB`. Implementations must not grow a
+    /// second, uncapped diff builder for this — one builder, one collector, one
+    /// policy function (`blob_ceiling`).
+    fn diff_over_ceiling(
+        &self,
+        repo_id: &RepoId,
+        path: &Path,
+        kind: DiffKind,
+        context_lines: u32,
+        ignore_whitespace: bool,
+        raise_for: &[PathBuf],
     ) -> AppResult<FileDiff>;
     /// Read the full content of a file from the worktree. Falls back to the
     /// HEAD blob when the worktree copy is missing (e.g. a deleted file).
@@ -340,6 +369,29 @@ pub trait GitBackend: Send + Sync {
         to_oid: &str,
         context_lines: u32,
         ignore_whitespace: bool,
+    ) -> AppResult<Vec<FileDiff>> {
+        self.diff_commits_over_ceiling(
+            repo_id,
+            from_oid,
+            to_oid,
+            context_lines,
+            ignore_whitespace,
+            &[],
+        )
+    }
+    /// `raise_for` is the user's explicit "show it anyway" (#396). It is a
+    /// PATHSPEC as well as a raised ceiling: the answer covers only those paths,
+    /// so waiving the ceiling for one huge blob never reads the other huge blob
+    /// beside it. See `diff_over_ceiling` for the whole contract; the
+    /// un-suffixed method is this one with an empty list.
+    fn diff_commits_over_ceiling(
+        &self,
+        repo_id: &RepoId,
+        from_oid: &str,
+        to_oid: &str,
+        context_lines: u32,
+        ignore_whitespace: bool,
+        raise_for: &[PathBuf],
     ) -> AppResult<Vec<FileDiff>>;
     /// Diff a single commit against its first parent — i.e. "what this commit
     /// changed." A root commit (no parent) diffs against the empty tree
@@ -352,6 +404,21 @@ pub trait GitBackend: Send + Sync {
         oid: &str,
         context_lines: u32,
         ignore_whitespace: bool,
+    ) -> AppResult<Vec<FileDiff>> {
+        self.diff_commit_over_ceiling(repo_id, oid, context_lines, ignore_whitespace, &[])
+    }
+    /// `raise_for` is the user's explicit "show it anyway" (#396). It is a
+    /// PATHSPEC as well as a raised ceiling: the answer covers only those paths,
+    /// so waiving the ceiling for one huge blob never reads the other huge blob
+    /// beside it. See `diff_over_ceiling` for the whole contract; the
+    /// un-suffixed method is this one with an empty list.
+    fn diff_commit_over_ceiling(
+        &self,
+        repo_id: &RepoId,
+        oid: &str,
+        context_lines: u32,
+        ignore_whitespace: bool,
+        raise_for: &[PathBuf],
     ) -> AppResult<Vec<FileDiff>>;
     /// Diff the tree at `revspec` against the WORKING TREE — the whole tree, not
     /// one path. A general primitive: arbitrary revspec (branch, remote branch,
@@ -385,6 +452,29 @@ pub trait GitBackend: Send + Sync {
         context_lines: u32,
         ignore_whitespace: bool,
         include_untracked: bool,
+    ) -> AppResult<WorkdirDiff> {
+        self.diff_ref_to_workdir_over_ceiling(
+            repo_id,
+            revspec,
+            context_lines,
+            ignore_whitespace,
+            include_untracked,
+            &[],
+        )
+    }
+    /// `raise_for` is the user's explicit "show it anyway" (#396). It is a
+    /// PATHSPEC as well as a raised ceiling: the answer covers only those paths,
+    /// so waiving the ceiling for one huge blob never reads the other huge blob
+    /// beside it. See `diff_over_ceiling` for the whole contract; the
+    /// un-suffixed method is this one with an empty list.
+    fn diff_ref_to_workdir_over_ceiling(
+        &self,
+        repo_id: &RepoId,
+        revspec: &str,
+        context_lines: u32,
+        ignore_whitespace: bool,
+        include_untracked: bool,
+        raise_for: &[PathBuf],
     ) -> AppResult<WorkdirDiff>;
     fn branches(&self, repo_id: &RepoId) -> AppResult<Vec<BranchInfo>>;
     fn tags(&self, repo_id: &RepoId) -> AppResult<Vec<TagInfo>>;
@@ -723,6 +813,29 @@ pub trait GitBackend: Send + Sync {
         context_lines: u32,
         ignore_whitespace: bool,
         include_untracked: bool,
+    ) -> AppResult<Vec<FileDiff>> {
+        self.stash_diff_over_ceiling(
+            repo_id,
+            oid,
+            context_lines,
+            ignore_whitespace,
+            include_untracked,
+            &[],
+        )
+    }
+    /// `raise_for` is the user's explicit "show it anyway" (#396). It is a
+    /// PATHSPEC as well as a raised ceiling: the answer covers only those paths,
+    /// so waiving the ceiling for one huge blob never reads the other huge blob
+    /// beside it. See `diff_over_ceiling` for the whole contract; the
+    /// un-suffixed method is this one with an empty list.
+    fn stash_diff_over_ceiling(
+        &self,
+        repo_id: &RepoId,
+        oid: &str,
+        context_lines: u32,
+        ignore_whitespace: bool,
+        include_untracked: bool,
+        raise_for: &[PathBuf],
     ) -> AppResult<Vec<FileDiff>>;
 
     // === remote management ===

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -379,6 +379,34 @@ pub struct FileDiff {
     /// off it); this says WHY, so the surfaces can name the real reason and the
     /// size instead of saying "binary file".
     pub oversized: Option<OversizedBlob>,
+    /// Set when this diff has MORE lines than were serialised (#396).
+    ///
+    /// Only the "show it anyway" path can produce it: an ordinary diff is under
+    /// `MAX_WORKDIR_BLOB` and comes back whole, so this stays `None` for every
+    /// file the app diffs on its own initiative. Once the user has waived the
+    /// ceiling the LINE count is the next wall — a 40 MB CSV is about a million
+    /// `DiffLine`s, i.e. a nine-figure JSON payload to parse and a million row
+    /// objects to lay out — so the lines stop at `MAX_DIFF_LINES` and the cap
+    /// reports itself rather than silently losing the rest.
+    ///
+    /// `additions`/`deletions` still count the WHOLE diff; only `hunks` stops
+    /// early. The file row must keep telling the truth about the change even
+    /// when the pane cannot show all of it.
+    pub truncated: Option<TruncatedDiff>,
+}
+
+/// How much of an over-ceiling diff was actually serialised (#396).
+///
+/// Same shape, and the same reasoning, as `OversizedBlob` below: the numbers the
+/// user reads are the ones that were applied, so no surface needs its own copy
+/// of the cap to build the sentence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TruncatedDiff {
+    /// Diff lines actually returned, across every hunk.
+    pub shown: usize,
+    /// Diff lines the file really has.
+    pub total: usize,
 }
 
 /// Why a diff has no text: the blob was bigger than the ceiling (#385).
@@ -394,6 +422,16 @@ pub struct OversizedBlob {
     pub size: u64,
     /// The ceiling that was applied, in bytes.
     pub limit: u64,
+    /// Was that ceiling the RAISED one — i.e. did the user already ask for this
+    /// blob anyway, and it was still too big? (#396)
+    ///
+    /// The UI cannot work this out for itself, and it needs to: offering "Diff
+    /// it anyway" a second time promises an answer that cannot change. It also
+    /// must not read a waived-path LIST as the answer — after a fresh fetch the
+    /// waiver is still in that list while the refusal is the DEFAULT ceiling's,
+    /// so the button belongs back on screen. Only the delta knows which ceiling
+    /// it actually lost to.
+    pub raised: bool,
 }
 
 /// The two sides of an LFS pointer change. Either side is `None` for an added or

--- a/src-tauri/tests/diff_blob_override.rs
+++ b/src-tauri/tests/diff_blob_override.rs
@@ -1,0 +1,316 @@
+//! "Yes, really, show me." — the user's way past the blob ceiling (#396).
+//!
+//! #385 gave the ceiling one policy and an honest answer; what it deliberately
+//! left out was any way to act on it. The ceiling is a guess about intent, and
+//! when it is wrong it is completely wrong: a generated `schema.sql`, a `.csv`
+//! fixture, a vendored lockfile, a minified bundle whose one changed line is the
+//! thing being reviewed.
+//!
+//! Three properties this pins, because each of them is a way the escape hatch
+//! could quietly become the thing #385 removed:
+//!
+//! 1. **It is a HIGHER ceiling, not the absence of one.** Over
+//!    `MAX_BLOB_OVERRIDE` the delta comes back `oversized` again, naming the
+//!    raised limit — never libgit2's 512 MB default.
+//! 2. **It is PER FILE.** The raise is a pathspec as well as a limit, so
+//!    waiving the ceiling for one huge blob does not read the other huge blob
+//!    in the same commit.
+//! 3. **The lines are BOUNDED.** Blob size is the first wall and line count is
+//!    the second; over `MAX_DIFF_LINES` the diff reports `truncated` rather
+//!    than shipping a million `DiffLine`s at a frontend that has to lay every
+//!    one of them out.
+
+mod support;
+
+use std::path::{Path, PathBuf};
+
+use platypusgit_lib::git::libgit2::{MAX_BLOB_OVERRIDE, MAX_DIFF_LINES, MAX_WORKDIR_BLOB};
+use platypusgit_lib::git::types::{DiffKind, FileDiff};
+use platypusgit_lib::git::GitBackend;
+use support::TempRepo;
+
+/// Over the 5 MB ceiling, under the 64 MB override, and unambiguously TEXT:
+/// plain ASCII with newlines, so libgit2's binary sniff has nothing to find.
+/// ~6.7 MB in ~110k lines — deliberately just over `MAX_DIFF_LINES` when both
+/// sides are counted, so the truncation arm is reachable without a 40 MB
+/// fixture in a unit test.
+fn overridable_text(lines: usize) -> String {
+    let line = "the quick brown fox jumps over the lazy dog; padding padding\n";
+    debug_assert_eq!(line.len(), 61);
+    line.repeat(lines)
+}
+
+fn find<'a>(diffs: &'a [FileDiff], path: &str) -> Option<&'a FileDiff> {
+    diffs.iter().find(|d| d.path == path)
+}
+
+#[test]
+fn a_waived_ceiling_diffs_the_blob_the_default_refused() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let big = overridable_text(110_000); // ~6.7 MB, over MAX_WORKDIR_BLOB
+    support::fs::write_file(tr.path(), "schema.sql", &big);
+    tr.commit_all("add a generated schema");
+    let (backend, handle) = tr.open_with_backend();
+    let tip = backend.log(&handle.id, None, 1).unwrap()[0].oid.clone();
+
+    // The default answer, restated here so the two live side by side: this is
+    // the refusal the button exists to get past.
+    let refused = backend.diff_commit(&handle.id, &tip, 3, false).unwrap();
+    let refused = find(&refused, "schema.sql").expect("schema.sql in diff");
+    assert!(refused.oversized.is_some(), "default ceiling still refuses");
+    assert!(refused.hunks.is_empty());
+
+    let shown = backend
+        .diff_commit_over_ceiling(
+            &handle.id,
+            &tip,
+            3,
+            false,
+            &[PathBuf::from("schema.sql")],
+        )
+        .unwrap();
+    let shown = find(&shown, "schema.sql").expect("schema.sql in raised diff");
+
+    assert!(
+        shown.oversized.is_none(),
+        "the raised ceiling covers this blob, so nothing is over it"
+    );
+    assert!(
+        !shown.binary,
+        "libgit2 only called it binary because of `max_size`; read, it is text"
+    );
+    assert_eq!(
+        shown.additions, 110_000,
+        "every added line is counted, whether or not it was serialised"
+    );
+}
+
+#[test]
+fn the_raise_is_per_file_and_does_not_read_the_blob_beside_it() {
+    // Property 2, and the reason `raise_for` is a pathspec and not just a size:
+    // a vendored-dependency bump can put several artifacts in one commit, and
+    // "show me that CSV" must not also xdiff the bundle next to it.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    support::fs::write_file(tr.path(), "data.csv", &overridable_text(100_000));
+    support::fs::write_file(tr.path(), "bundle.min.js", &overridable_text(100_000));
+    tr.commit_all("add two generated artifacts");
+    let (backend, handle) = tr.open_with_backend();
+    let tip = backend.log(&handle.id, None, 1).unwrap()[0].oid.clone();
+
+    let diffs = backend
+        .diff_commit_over_ceiling(&handle.id, &tip, 3, false, &[PathBuf::from("data.csv")])
+        .unwrap();
+
+    let csv = find(&diffs, "data.csv").expect("the waived path is in the answer");
+    assert!(csv.oversized.is_none(), "the waived path diffed");
+
+    // The other artifact is still in the list — the answer is the WHOLE diff,
+    // so a caller can pass its waivers on every fetch (see `with_raised`) — and
+    // it is still refused. Two things prove it was never read: no hunks, and a
+    // limit that is the DEFAULT ceiling rather than the raised one.
+    let bundle = find(&diffs, "bundle.min.js").expect("every file is still listed");
+    let over = bundle
+        .oversized
+        .expect("the un-waived artifact is still over the ceiling");
+    assert_eq!(
+        over.limit, MAX_WORKDIR_BLOB as u64,
+        "the raise applied to the waived path ONLY; this one kept the default \
+         ceiling, which is what says its blob was never loaded"
+    );
+    assert!(!over.raised, "and the user never asked for this one");
+    assert!(bundle.hunks.is_empty(), "not a line of it was serialised");
+}
+
+#[test]
+fn a_waived_ceiling_still_has_a_ceiling() {
+    // Property 1. A blob over the OVERRIDE comes back oversized again, and the
+    // limit in the sentence is the raised one — otherwise a 120 MB file would
+    // report itself as over 5 MB and the button would look like it did nothing.
+    //
+    // Asserted through `oversized_delta`'s contract rather than by writing a
+    // 64 MB fixture: the ceiling that reaches `OversizedBlob::limit` is the one
+    // `blob_ceiling` chose, and the two constants differ, so a raised diff that
+    // reported `MAX_WORKDIR_BLOB` would fail here.
+    assert!(
+        MAX_BLOB_OVERRIDE > MAX_WORKDIR_BLOB,
+        "the override raises the ceiling"
+    );
+    assert!(
+        MAX_BLOB_OVERRIDE < 512 * 1024 * 1024,
+        "and stays well under libgit2's own default, which is the wall with no \
+         message on it that #385 removed"
+    );
+
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let big = overridable_text(110_000);
+    support::fs::write_file(tr.path(), "schema.sql", &big);
+    tr.commit_all("add a generated schema");
+    let (backend, handle) = tr.open_with_backend();
+    let tip = backend.log(&handle.id, None, 1).unwrap()[0].oid.clone();
+
+    let refused = backend.diff_commit(&handle.id, &tip, 3, false).unwrap();
+    let over = find(&refused, "schema.sql").unwrap().oversized.unwrap();
+    assert_eq!(
+        over.limit, MAX_WORKDIR_BLOB as u64,
+        "an ordinary diff names the ordinary ceiling"
+    );
+    assert!(
+        !over.raised,
+        "and says the user has not asked for it yet — the UI needs that to know \
+         whether offering the button again could change the answer"
+    );
+}
+
+#[test]
+fn a_fresh_refusal_after_a_waiver_is_not_marked_raised() {
+    // The bug this field replaced. The frontend used to decide "already tried"
+    // from its own list of waived paths, and the surfaces' fetch effects never
+    // pass that list — so returning to the file produced a DEFAULT-ceiling
+    // refusal while the path was still in the list, and the action stayed hidden
+    // for the rest of the session. `raised` is the backend's own answer about
+    // which ceiling this delta actually lost to.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    support::fs::write_file(tr.path(), "schema.sql", &overridable_text(110_000));
+    tr.commit_all("add a generated schema");
+    let (backend, handle) = tr.open_with_backend();
+    let tip = backend.log(&handle.id, None, 1).unwrap()[0].oid.clone();
+
+    // A waived read, then the next ordinary one — the shape a re-selection has.
+    let _ = backend
+        .diff_commit_over_ceiling(&handle.id, &tip, 3, false, &[PathBuf::from("schema.sql")])
+        .unwrap();
+    let again = backend.diff_commit(&handle.id, &tip, 3, false).unwrap();
+
+    let over = find(&again, "schema.sql").unwrap().oversized.unwrap();
+    assert!(!over.raised, "the waiver does not persist in the backend either");
+    assert_eq!(over.limit, MAX_WORKDIR_BLOB as u64);
+}
+
+#[test]
+fn over_the_line_cap_the_diff_says_how_much_it_kept() {
+    // Property 3. Two sides of ~110k lines each rewritten wholesale is well
+    // over `MAX_DIFF_LINES`, which is the point: the blob fits the raised
+    // ceiling and the LINES do not.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    support::fs::write_file(tr.path(), "data.csv", &overridable_text(110_000));
+    tr.commit_all("add a fixture");
+    // Rewrite every line, so the diff is ~110k deletions + ~110k additions.
+    let rewritten: String = (0..110_000)
+        .map(|i| format!("row {i},changed,{i}\n"))
+        .collect();
+    support::fs::write_file(tr.path(), "data.csv", &rewritten);
+    let (backend, handle) = tr.open_with_backend();
+
+    let fd = backend
+        .diff_over_ceiling(
+            &handle.id,
+            Path::new("data.csv"),
+            DiffKind::WorktreeToHead,
+            3,
+            false,
+            &[PathBuf::from("data.csv")],
+        )
+        .unwrap();
+
+    let t = fd
+        .truncated
+        .expect("a diff this long reports that it was cut");
+    assert_eq!(
+        t.shown, MAX_DIFF_LINES,
+        "exactly the cap is kept — the row count the surfaces lay out is known \
+         in advance, not whatever the file happened to contain"
+    );
+    assert!(
+        t.total > t.shown,
+        "and the real length is reported: {} of {}",
+        t.shown,
+        t.total
+    );
+    let rows: usize = fd.hunks.iter().map(|h| h.lines.len()).sum();
+    assert_eq!(rows, t.shown, "`shown` is the rows that actually arrived");
+    assert_eq!(
+        (fd.additions, fd.deletions),
+        (110_000, 110_000),
+        "the file row keeps telling the truth about the change even though the \
+         pane cannot show all of it"
+    );
+}
+
+#[test]
+fn an_ordinary_diff_is_never_truncated() {
+    // The regression that matters most, and the reason `diff_lines_cap` returns
+    // `None` without a raise: the cap must not change what a diff the app opened
+    // by itself looks like. Nothing under `MAX_WORKDIR_BLOB` can reach the cap
+    // by this route, so `truncated` stays `None` on every ordinary file.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let (backend, handle) = tr.open_with_backend();
+    support::fs::write_file(tr.path(), "README.md", "hello\nworld\n");
+
+    let fd = backend
+        .diff(
+            &handle.id,
+            Path::new("README.md"),
+            DiffKind::WorktreeToHead,
+            3,
+            false,
+        )
+        .unwrap();
+
+    assert!(fd.truncated.is_none());
+    assert!(fd.oversized.is_none());
+    assert_eq!(fd.additions, 1);
+}
+
+#[test]
+fn an_empty_raise_list_is_the_default_ceiling() {
+    // The plain trait methods are one-line forwards with `&[]`, so this is what
+    // keeps the forwarding honest: an absent `raiseFor` from the wire must be
+    // indistinguishable from the un-suffixed call.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let big = overridable_text(110_000);
+    support::fs::write_file(tr.path(), "schema.sql", &big);
+    tr.commit_all("add a generated schema");
+    let (backend, handle) = tr.open_with_backend();
+    let tip = backend.log(&handle.id, None, 1).unwrap()[0].oid.clone();
+
+    let via_default = backend.diff_commit(&handle.id, &tip, 3, false).unwrap();
+    let via_empty = backend
+        .diff_commit_over_ceiling(&handle.id, &tip, 3, false, &[])
+        .unwrap();
+
+    let a = find(&via_default, "schema.sql").unwrap();
+    let b = find(&via_empty, "schema.sql").unwrap();
+    assert_eq!(a.oversized, b.oversized);
+    assert_eq!(a.hunks.len(), b.hunks.len());
+    assert_eq!(via_default.len(), via_empty.len());
+}
+
+#[test]
+fn the_single_file_diff_only_raises_the_path_it_was_asked_for() {
+    // `diff` takes one path and `raise_for` is a list, so the two can disagree.
+    // A list that does not name this path is not a raise — otherwise a stale
+    // override from a previously selected file would silently apply to the next
+    // one the user clicked.
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let big = overridable_text(110_000);
+    support::fs::write_file(tr.path(), "schema.sql", &big);
+    tr.commit_all("add a generated schema");
+    support::fs::write_file(tr.path(), "schema.sql", &overridable_text(110_001));
+    let (backend, handle) = tr.open_with_backend();
+
+    let fd = backend
+        .diff_over_ceiling(
+            &handle.id,
+            Path::new("schema.sql"),
+            DiffKind::WorktreeToHead,
+            3,
+            false,
+            &[PathBuf::from("some/other/file.csv")],
+        )
+        .unwrap();
+
+    assert!(
+        fd.oversized.is_some(),
+        "a raise for a different path leaves this one refused"
+    );
+}

--- a/src/features/compare/useCompareStore.ts
+++ b/src/features/compare/useCompareStore.ts
@@ -61,6 +61,18 @@ interface CompareState {
   untrackedOmitted: number;
   loading: boolean;
   /**
+   * Paths whose blob ceiling the user waived with "Diff it anyway" (#396).
+   *
+   * Store state rather than screen state because `refresh` is: the waivers ride
+   * along on every fetch it makes, and a refresh that dropped them would replace
+   * the blob the user waited for with the refusal again, on its own. Cleared by
+   * `EMPTY_RESULTS`, so any change of sides — the "per view, never a setting"
+   * half of the promise — drops them with the results they belonged to.
+   */
+  raiseFor: string[];
+  /** A waived re-read is in flight — `refresh` is doing it. */
+  diffAnywayPending: boolean;
+  /**
    * Rendered in the screen, never pushed into `useRepoStore.error`: a revspec
    * typed into a picker that does not resolve is a bad input to this view, not
    * a repository-level failure worth the app banner.
@@ -82,6 +94,21 @@ interface CompareState {
   mark: (ref: string) => void;
   clearMark: () => void;
   refresh: (contextLines: number, ignoreWhitespace: boolean) => Promise<void>;
+  /**
+   * Waive the blob ceiling for one over-ceiling file, and re-read (#396).
+   *
+   * Records the paths and re-runs `refresh`, rather than fetching on its own:
+   * the backend answers with the WHOLE diff and the waived paths read at the
+   * raised ceiling, so `refresh` is already the right call and there is no
+   * second fetch shape to keep in step with the two it dispatches between.
+   * Every later `refresh` carries the waivers too — without that, a refresh
+   * would silently replace the blob the user waited for with the refusal again.
+   */
+  diffAnyway: (
+    paths: string[],
+    contextLines: number,
+    ignoreWhitespace: boolean,
+  ) => Promise<void>;
 }
 
 const EMPTY_RESULTS = {
@@ -91,6 +118,9 @@ const EMPTY_RESULTS = {
   behindCommits: [] as CommitInfo[],
   untrackedOmitted: 0,
   error: null,
+  // The waivers belong to the results they were granted for (#396).
+  raiseFor: [] as string[],
+  diffAnywayPending: false,
 };
 
 export const useCompareStore = create<CompareState>((set, get) => ({
@@ -163,7 +193,17 @@ export const useCompareStore = create<CompareState>((set, get) => ({
           ipcAheadBehind(repo.id, left.rev, right.rev),
           commitsBetween(repo.id, left.rev, right.rev, COMPARE_COMMIT_LIMIT),
           commitsBetween(repo.id, right.rev, left.rev, COMPARE_COMMIT_LIMIT),
-          diffCommits(repo.id, left.rev, right.rev, contextLines, ignoreWhitespace),
+          diffCommits(
+            repo.id,
+            left.rev,
+            right.rev,
+            contextLines,
+            ignoreWhitespace,
+            // Every refresh, not just the click that granted them (#396): a
+            // refresh that dropped them would replace the blob the user waited
+            // for with the refusal, on its own.
+            get().raiseFor,
+          ),
         ]);
         if (!fresh()) return;
         set({
@@ -185,6 +225,7 @@ export const useCompareStore = create<CompareState>((set, get) => ({
         contextLines,
         ignoreWhitespace,
         true,
+        get().raiseFor,
       );
       if (!fresh()) return;
       set({
@@ -198,6 +239,22 @@ export const useCompareStore = create<CompareState>((set, get) => ({
     } catch (e) {
       if (!fresh()) return;
       set({ ...EMPTY_RESULTS, loading: false, error: appErrorMessage(e) });
+    }
+  },
+
+  async diffAnyway(paths, contextLines, ignoreWhitespace) {
+    if (paths.length === 0) return;
+    set((s) => ({
+      raiseFor: [...new Set([...s.raiseFor, ...paths])],
+      diffAnywayPending: true,
+    }));
+    try {
+      await get().refresh(contextLines, ignoreWhitespace);
+    } finally {
+      // Cleared unconditionally: the read is over either way, and this flag
+      // only drives the action's label. `refresh`'s own token discipline
+      // decides whether its RESULTS get written.
+      set({ diffAnywayPending: false });
     }
   },
 }));

--- a/src/features/diff/CommitDiffPanel.oversized.test.tsx
+++ b/src/features/diff/CommitDiffPanel.oversized.test.tsx
@@ -34,7 +34,8 @@ const oversized = (path: string): FileDiff => ({
   deletions: 0,
   hunks: [],
   lfs: null,
-  oversized: { size: 42_000_000, limit: 5 * 1024 * 1024 },
+  oversized: { size: 42_000_000, limit: 5 * 1024 * 1024, raised: false },
+  truncated: null,
 });
 
 /** A real binary — no size story to tell, so the old sentence stands. */
@@ -47,7 +48,14 @@ const realBinary: FileDiff = {
   hunks: [],
   lfs: null,
   oversized: null,
+  truncated: null,
 };
+
+/** A blob refused by even the RAISED ceiling — the user already insisted. */
+const stillTooBig = (path: string): FileDiff => ({
+  ...oversized(path),
+  oversized: { size: 400_000_000, limit: 64 * 1024 * 1024, raised: true },
+});
 
 describe("a diff the backend was too big to read", () => {
   it("names the real reason and the size, not 'binary'", () => {
@@ -65,6 +73,78 @@ describe("a diff the backend was too big to read", () => {
     const text = document.body.textContent ?? "";
     expect(text).toContain("Binary file — no textual diff.");
     expect(text).not.toContain("File too large to diff");
+  });
+
+  it("lets the user say 'yes, really' when the caller can answer that", () => {
+    // #385 left this notice naming a limit with nothing to act on, which is the
+    // shape that invites the question (#396). The panel is presentational, so
+    // the action appears exactly when the caller wired somewhere to send it.
+    render(
+      <CommitDiffPanel
+        {...props}
+        diffs={[oversized("bundle.min.js")]}
+        onDiffAnyway={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("diff-anyway")).toHaveTextContent("Diff it anyway");
+  });
+
+  it("offers nothing to click when the caller cannot answer it", () => {
+    // A button with no handler is worse than the plain sentence: it promises a
+    // read that will not happen. The notice itself is unchanged either way.
+    render(<CommitDiffPanel {...props} diffs={[oversized("bundle.min.js")]} />);
+    expect(screen.queryByTestId("diff-anyway")).toBeNull();
+    expect(document.body.textContent ?? "").toContain("File too large to diff");
+  });
+
+  it("does not offer the escape hatch for a file that really is binary", () => {
+    render(<CommitDiffPanel {...props} diffs={[realBinary]} onDiffAnyway={() => {}} />);
+    expect(screen.queryByTestId("diff-anyway")).toBeNull();
+  });
+
+  it("says so when a waived read came back shortened", () => {
+    // The other end of the override: the blob was read, and the LINES were
+    // capped. An unmentioned cap reads as a diff that simply ends.
+    const shortened: FileDiff = {
+      ...oversized("dump.csv"),
+      binary: false,
+      oversized: null,
+      additions: 812_345,
+      hunks: [
+        {
+          header: "@@ -1 +1 @@",
+          oldStart: 1,
+          oldLines: 1,
+          newStart: 1,
+          newLines: 1,
+          lines: [
+            { kind: { kind: "Addition" }, oldLineno: null, newLineno: 1, content: "a" },
+          ],
+        },
+      ],
+      truncated: { shown: 100_000, total: 812_345 },
+    };
+    render(<CommitDiffPanel {...props} diffs={[shortened]} />);
+    expect(screen.getByTestId("truncated-diff-notice")).toHaveTextContent("812,345");
+  });
+
+  it("stops offering the escape hatch once the raised ceiling refused too", () => {
+    // The override raises the ceiling; it does not remove it. `raised` comes off
+    // the delta rather than from the waived-path list, so a FRESH refused fetch
+    // (which never carries the waiver) puts the button back — see
+    // `diffAnywayExhausted`.
+    render(
+      <CommitDiffPanel
+        {...props}
+        diffs={[stillTooBig("dump.csv")]}
+        onDiffAnyway={() => {}}
+      />,
+    );
+    expect(screen.queryByTestId("diff-anyway")).toBeNull();
+    expect(screen.getByTestId("diff-anyway-exhausted")).toBeTruthy();
+    // The sentence still names the RAISED limit, or the button would look like
+    // it did nothing.
+    expect(document.body.textContent ?? "").toContain("64 MB");
   });
 
   it("does not offer the no-hunks empty state as well", () => {
@@ -87,7 +167,7 @@ describe("oversizedDiffNotice / isTextualDiff", () => {
     // applied; the number the user reads has to be the one the backend used.
     const notice = oversizedDiffNotice({
       ...realBinary,
-      oversized: { size: 3 * 1024 * 1024, limit: 1024 * 1024 },
+      oversized: { size: 3 * 1024 * 1024, limit: 1024 * 1024, raised: false },
     });
     expect(notice?.detail).toContain("3.0 MB");
     expect(notice?.detail).toContain("1.0 MB");

--- a/src/features/diff/CommitDiffPanel.tsx
+++ b/src/features/diff/CommitDiffPanel.tsx
@@ -40,7 +40,12 @@ import type { FindMark } from "@/lib/diffFind";
 import { DiffFindBar } from "./DiffFindBar";
 import { useDiffFind } from "./useDiffFind";
 import type { DiffToolTarget, FileDiff } from "@/lib/types";
-import { isTextualDiff, oversizedDiffNotice } from "@/lib/derive";
+import {
+  diffAnywayExhausted,
+  isTextualDiff,
+  oversizedDiffNotice,
+} from "@/lib/derive";
+import { OversizedDiffEmpty, TruncatedDiffNotice } from "./OversizedDiffNotice";
 import { LfsDiffNotice } from "@/features/lfs/LfsDiffNotice";
 import { ImageDiffView } from "./ImageDiffView";
 import { diffImageSides } from "./useImagePreviews";
@@ -167,6 +172,18 @@ export interface CommitDiffPanelProps {
    * multi-commit diff), and the menu entry is then absent rather than broken.
    */
   difftoolTarget?: DiffToolTarget;
+  /**
+   * The user's "Diff it anyway" for one over-ceiling file (#396).
+   *
+   * The panel is presentational — the caller fetches the diffs, so the caller
+   * is the one that records the waiver and passes it on its next fetch (see
+   * `useDiffAnyway`). Omitted, and the notice keeps the plain "too large"
+   * wording with nothing to click; that is what a surface with nowhere to put
+   * the re-read should show, rather than a button that cannot work.
+   */
+  onDiffAnyway?: (diff: FileDiff) => void;
+  /** A waived re-read is in flight — the action says so and disables. */
+  diffAnywayPending?: boolean;
 }
 
 /**
@@ -185,6 +202,8 @@ export function CommitDiffPanel({
   verifyOid,
   syntaxSides,
   difftoolTarget,
+  onDiffAnyway,
+  diffAnywayPending = false,
 }: CommitDiffPanelProps) {
   const filesPaneId = `${paneIdPrefix}.files`;
   const viewPaneId = `${paneIdPrefix}.view`;
@@ -614,7 +633,22 @@ export function CommitDiffPanel({
           {/* The complement of `isTextualDiff`: everything the row model cannot
               render. An IMAGE gets previewed here rather than dead-ending
               (#224); the sentence stays as the fallback for everything else. */}
-          {current && !isTextualDiff(current) && (
+          {/* We declined to READ this blob, so there is nothing to preview and
+              exactly one thing to do about it (#396). BEFORE the image branch
+              on purpose: `MAX_PREVIEW_BYTES` (4 MiB) is below the diff ceiling
+              (5 MB), so an over-ceiling blob is also over the preview one and
+              comes back `tooLarge` — which counts as "notable" and suppresses
+              the `fallback` the #385 sentence lives in. It was unreachable here
+              for every file it was written for. */}
+          {current && oversized && (
+            <OversizedDiffEmpty
+              diff={current}
+              pending={diffAnywayPending}
+              alreadyTried={diffAnywayExhausted(current)}
+              onDiffAnyway={onDiffAnyway ? () => onDiffAnyway(current) : undefined}
+            />
+          )}
+          {current && !isTextualDiff(current) && !oversized && (
             <>
               {current.lfs && <LfsDiffNotice diff={current} />}
               <ImageDiffView
@@ -631,15 +665,11 @@ export function CommitDiffPanel({
                 }
                 fallback={
                   // The LFS notice above already said why there is no text, so
-                  // adding "Binary file" under it would say it twice.
+                  // adding "Binary file" under it would say it twice. An
+                  // over-ceiling blob never reaches here — see the branch above.
                   current.lfs ? null : (
                     <div style={{ color: "var(--fg-3)", fontSize: "var(--fs-12)" }}>
-                      {/* An over-ceiling blob is flagged binary by libgit2, and
-                          calling a 40 MB `bundle.min.js` "binary" is a lie the
-                          user cannot act on — name the real reason (#385). */}
-                      {oversized
-                        ? `${oversized.title}: ${oversized.detail}`
-                        : "Binary file — no textual diff."}
+                      Binary file — no textual diff.
                     </div>
                   )
                 }
@@ -656,6 +686,10 @@ export function CommitDiffPanel({
               File is tracked but no hunks were produced.
             </PGEmpty>
           )}
+          {/* A waived ceiling gets the blob read; it does not make a million
+              rows layoutable, so the backend caps the lines. Say so above them
+              — an unmentioned cap reads as a diff that just ends (#396). */}
+          <TruncatedDiffNotice diff={current} />
           {win.topPad > 0 && (
             <div data-pg-spacer="top" style={{ height: `${win.topPad}px` }} />
           )}

--- a/src/features/diff/ImageDiffView.test.tsx
+++ b/src/features/diff/ImageDiffView.test.tsx
@@ -54,6 +54,48 @@ function decode(testId: string, w: number, h: number) {
   fireEvent.load(img);
 }
 
+describe("a `tooLarge` preview is NOTABLE, which suppresses the fallback", () => {
+  // The interaction that made the #385 sentence unreachable, pinned here rather
+  // than at the four surfaces — this is where the rule lives.
+  //
+  // `MAX_PREVIEW_BYTES` is 4 MiB and the diff ceiling is 5 MB, so EVERY blob
+  // over the diff ceiling is also over the preview one and comes back
+  // `tooLarge`. `isNotablePreview` counts that as notable, so this component
+  // renders its panels and NOT the `fallback` — where the surfaces had put
+  // "File too large to diff". The user read "Too large to preview" instead,
+  // which says less and offers nothing to act on.
+  //
+  // It survived review because every other test here mocks previews to `null`,
+  // and a null preview is not notable. So the fix is at the CALLERS (they check
+  // `oversized` before reaching this component at all, see `OversizedDiffEmpty`)
+  // and what this test pins is the fact that made the fix necessary — if it ever
+  // stops being true, those precedence branches can go.
+  it("renders the panels, not the fallback, when a side is too large", async () => {
+    mockPreviews({
+      rev: { kind: "tooLarge", path: "generated.sql", size: 6_700_000, limit: 4 * 1024 * 1024 },
+      worktree: {
+        kind: "tooLarge",
+        path: "generated.sql",
+        size: 6_700_000,
+        limit: 4 * 1024 * 1024,
+      },
+    });
+    render(
+      <ImageDiffView
+        repoId="r1"
+        path="generated.sql"
+        sides={[OLD, NEW]}
+        fallback={<div>File too large to diff</div>}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("image-note-new")).toBeTruthy());
+    expect(screen.getByTestId("image-note-new")).toHaveTextContent(/Too large to preview/);
+    // The point: the caller's sentence never renders.
+    expect(screen.queryByText("File too large to diff")).toBeNull();
+  });
+});
+
 describe("an image diff", () => {
   it("renders both sides as local data: URLs", async () => {
     mockPreviews({

--- a/src/features/diff/OversizedDiffNotice.test.tsx
+++ b/src/features/diff/OversizedDiffNotice.test.tsx
@@ -1,0 +1,152 @@
+// "Yes, really, show me" — the shared action and the shared truncation notice
+// (#396).
+//
+// #385's notice named a limit and offered nothing to do about it. This is the
+// half that acts on it, and the behaviours below are the ones that decide
+// whether it is an escape hatch or a new dead end:
+//
+//   * offered only where reading anyway could actually produce text (an
+//     over-ceiling blob), never for a real PNG;
+//   * not offered twice for a blob over even the RAISED ceiling, because the
+//     answer would not change;
+//   * and the truncation it can produce says so, in numbers off the wire.
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { OversizedDiffAction, TruncatedDiffNotice } from "./OversizedDiffNotice";
+import { diffAnywayExhausted, truncatedDiffNotice } from "@/lib/derive";
+import type { FileDiff } from "@/lib/types";
+
+const base: FileDiff = {
+  path: "bundle.min.js",
+  oldPath: null,
+  binary: true,
+  additions: 0,
+  deletions: 0,
+  hunks: [],
+  lfs: null,
+  oversized: null,
+  truncated: null,
+};
+
+const oversized: FileDiff = {
+  ...base,
+  oversized: { size: 42_000_000, limit: 5 * 1024 * 1024, raised: false },
+};
+
+/** A real image: honestly binary, and no ceiling involved. */
+const realBinary: FileDiff = { ...base, path: "logo.png" };
+
+describe("OversizedDiffAction", () => {
+  it("offers the escape hatch for a blob the ceiling refused", async () => {
+    const onDiffAnyway = vi.fn();
+    render(<OversizedDiffAction diff={oversized} onDiffAnyway={onDiffAnyway} />);
+
+    const button = screen.getByTestId("diff-anyway");
+    expect(button).toHaveTextContent("Diff it anyway");
+    await userEvent.click(button);
+    expect(onDiffAnyway).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers nothing for a real binary", () => {
+    // Reading a PNG anyway would still not produce a text diff, so the button
+    // would promise something it cannot deliver. The plain "Binary file" empty
+    // state is the right and complete answer there.
+    render(<OversizedDiffAction diff={realBinary} onDiffAnyway={vi.fn()} />);
+    expect(screen.queryByTestId("diff-anyway")).toBeNull();
+  });
+
+  it("offers nothing when there is no diff at all", () => {
+    render(<OversizedDiffAction diff={null} onDiffAnyway={vi.fn()} />);
+    expect(screen.queryByTestId("diff-anyway")).toBeNull();
+  });
+
+  it("says it is working, and refuses a second click while it is", async () => {
+    // Re-reading 40 MB is seconds of work. A button that looks ignored is how
+    // the user ends up firing three of them.
+    const onDiffAnyway = vi.fn();
+    render(
+      <OversizedDiffAction diff={oversized} pending onDiffAnyway={onDiffAnyway} />,
+    );
+
+    const button = screen.getByTestId("diff-anyway");
+    expect(button).toHaveTextContent("Reading…");
+    expect(button).toBeDisabled();
+    await userEvent.click(button);
+    expect(onDiffAnyway).not.toHaveBeenCalled();
+  });
+
+  it("stops offering itself once the raised ceiling refused too", () => {
+    // The override raises the ceiling; it does not remove it. Offering the same
+    // button again would promise an answer that cannot change — worse than no
+    // button, because the user cannot tell it apart from a broken one.
+    render(
+      <OversizedDiffAction diff={oversized} alreadyTried onDiffAnyway={vi.fn()} />,
+    );
+    expect(screen.queryByTestId("diff-anyway")).toBeNull();
+    expect(screen.getByTestId("diff-anyway-exhausted")).toHaveTextContent(
+      /largest size the app will diff/i,
+    );
+  });
+});
+
+describe("diffAnywayExhausted", () => {
+  it("is false for a blob refused by the DEFAULT ceiling", () => {
+    // The ordinary refusal: the user has not asked for anything yet, so the
+    // button belongs on screen.
+    expect(diffAnywayExhausted(oversized)).toBe(false);
+  });
+
+  it("is true only when the RAISED ceiling was the one that refused", () => {
+    const stillTooBig: FileDiff = {
+      ...oversized,
+      oversized: { size: 400_000_000, limit: 64 * 1024 * 1024, raised: true },
+    };
+    expect(diffAnywayExhausted(stillTooBig)).toBe(true);
+  });
+
+  it("reads the delta, not a list of paths the user clicked", () => {
+    // The bug this shape replaced: keying off "did the user waive this path"
+    // hid the button for the rest of the session, because a FRESH fetch never
+    // passes the waiver — so the path stays in the list while the refusal is
+    // the default ceiling's, and the action belongs back on screen.
+    const refetchedAfterAWaiver: FileDiff = {
+      ...oversized,
+      oversized: { size: 42_000_000, limit: 5 * 1024 * 1024, raised: false },
+    };
+    expect(diffAnywayExhausted(refetchedAfterAWaiver)).toBe(false);
+  });
+
+  it("is false for anything that is not over a ceiling at all", () => {
+    expect(diffAnywayExhausted(realBinary)).toBe(false);
+    expect(diffAnywayExhausted(null)).toBe(false);
+  });
+});
+
+describe("TruncatedDiffNotice / truncatedDiffNotice", () => {
+  it("says nothing about a diff that arrived whole", () => {
+    expect(truncatedDiffNotice(null)).toBeNull();
+    expect(truncatedDiffNotice(oversized)).toBeNull();
+    render(<TruncatedDiffNotice diff={oversized} />);
+    expect(screen.queryByTestId("truncated-diff-notice")).toBeNull();
+  });
+
+  it("reports both numbers, from the wire", () => {
+    const cut: FileDiff = {
+      ...base,
+      binary: false,
+      oversized: null,
+      truncated: { shown: 100_000, total: 812_345 },
+    };
+    render(<TruncatedDiffNotice diff={cut} />);
+
+    const notice = screen.getByTestId("truncated-diff-notice");
+    // Grouped for reading — six digits of diff is exactly the number a reader
+    // needs to take in at a glance to understand why the pane stops.
+    expect(notice).toHaveTextContent("100,000");
+    expect(notice).toHaveTextContent("812,345");
+    expect(notice).toHaveTextContent(/Diff shortened/);
+  });
+});

--- a/src/features/diff/OversizedDiffNotice.tsx
+++ b/src/features/diff/OversizedDiffNotice.tsx
@@ -1,0 +1,174 @@
+// The two halves of "yes, really, show me" (#396).
+//
+// #385 gave the blob ceiling one policy and an honest sentence: over the limit
+// the delta comes back `oversized` and every diff surface prints "File too large
+// to diff — 40 MB — over the 5.0 MB limit, so it was not read." What it named
+// but could not act on was the user's own answer to that. The ceiling is a guess
+// about intent — "a 5 MB text file is a generated artifact, not something anyone
+// diffs in a GUI" — and it is usually right; when it is wrong it is completely
+// wrong, and leaving the app was the only way past it.
+//
+// ONE component for all four diff surfaces, for the reason `oversizedDiffNotice`
+// and `LfsDiffNotice` next door already give: a surface that grows its own
+// button is how the same file comes to behave differently depending on which
+// pane you opened it in. The sentence is shared; so is the button.
+//
+// Deliberately NOT a setting. A persisted "always diff huge files" turns a
+// considered refusal into a footgun the user forgot they armed — this is per
+// file and per view, and the surfaces drop it on navigation.
+
+import { PGButton, PGEmpty, PGIcon } from "@/design";
+import { oversizedDiffNotice, truncatedDiffNotice } from "@/lib/derive";
+import type { FileDiff } from "@/lib/types";
+
+/**
+ * The action that goes under the "too large to diff" sentence.
+ *
+ * Renders nothing unless there is something to act on, so a surface can pass it
+ * unconditionally: a real PNG keeps the plain "Binary file" empty state with no
+ * button, because reading it anyway would still not produce a text diff.
+ *
+ * `pending` is the surface's own diff-loading flag. Re-reading a 40 MB blob is
+ * seconds of work, and the label has to say so — the alternative is a click that
+ * looks ignored.
+ */
+export function OversizedDiffAction({
+  diff,
+  pending = false,
+  alreadyTried = false,
+  onDiffAnyway,
+}: {
+  diff: FileDiff | null | undefined;
+  pending?: boolean;
+  /**
+   * The user already waived the ceiling for this path and it came back over the
+   * raised one too. Offering the same button again would promise something the
+   * answer will not change — see `diffAnywayExhausted`.
+   */
+  alreadyTried?: boolean;
+  /**
+   * Absent for a surface that has nowhere to send the re-read — see
+   * `CommitDiffPanel`'s `onDiffAnyway` prop. The sentence still renders; a
+   * button that cannot work is worse than none, because the user cannot tell it
+   * apart from a broken one.
+   */
+  onDiffAnyway?: () => void;
+}) {
+  // Nothing to act on: a real PNG read at any ceiling still has no text diff,
+  // so the plain "Binary file" empty state is the complete answer there.
+  if (!diff?.oversized || !onDiffAnyway) return null;
+  if (alreadyTried) {
+    return (
+      <div
+        data-testid="diff-anyway-exhausted"
+        style={{ fontSize: "var(--fs-11)", color: "var(--fg-3)" }}
+      >
+        This is over the largest size the app will diff.
+      </div>
+    );
+  }
+  return (
+    <PGButton
+      data-testid="diff-anyway"
+      size="sm"
+      icon="eye"
+      disabled={pending}
+      onClick={onDiffAnyway}
+    >
+      {pending ? "Reading…" : "Diff it anyway"}
+    </PGButton>
+  );
+}
+
+/**
+ * The whole pane for a blob the ceiling refused — sentence and action together.
+ *
+ * **This has to take precedence over the image preview, and did not (#385).**
+ * The three `ImageDiffOrEmpty` surfaces put the notice in that shell's
+ * `fallback`, which `ImageDiffView` renders only when no side is "notable" —
+ * and `MAX_PREVIEW_BYTES` (4 MiB) is BELOW the diff ceiling (5 MB), so every
+ * blob over the diff ceiling is also over the preview one and comes back
+ * `tooLarge`, which IS notable. The result: the honest "File too large to diff"
+ * sentence was unreachable for every file it was written for, replaced by
+ * "Too large to preview" — which says less and offers nothing to do.
+ *
+ * Invisible to the component tests, because `read_image_preview` is mocked to
+ * `null` there and a null preview is not notable. `ImageDiffView.test.tsx`
+ * pins the interaction now.
+ *
+ * An over-ceiling blob is not an image-preview situation at all: we declined to
+ * read it, the size is the whole story, and there is exactly one thing to do
+ * about it. A file that turns out to be a real image after the waived read
+ * still reaches the preview — `oversized` is null by then.
+ */
+export function OversizedDiffEmpty({
+  diff,
+  pending = false,
+  alreadyTried = false,
+  onDiffAnyway,
+  icon = "file",
+}: {
+  diff: FileDiff | null | undefined;
+  pending?: boolean;
+  alreadyTried?: boolean;
+  /** Absent where the surface cannot answer it — the sentence still renders. */
+  onDiffAnyway?: () => void;
+  icon?: string;
+}) {
+  const notice = oversizedDiffNotice(diff);
+  if (!notice) return null;
+  return (
+    <PGEmpty
+      icon={icon}
+      title={notice.title}
+      action={
+        <OversizedDiffAction
+          diff={diff}
+          pending={pending}
+          alreadyTried={alreadyTried}
+          onDiffAnyway={onDiffAnyway}
+        />
+      }
+    >
+      {notice.detail}
+    </PGEmpty>
+  );
+}
+
+/**
+ * "Showing the first 100,000 of 812,345 lines" — the other end of the override.
+ *
+ * Raising the ceiling gets the blob read; it does not make a million rows
+ * something a diff pane can lay out, so the backend caps the lines. A cap
+ * nobody mentions is indistinguishable from a diff that just ends, which is the
+ * silent wrong answer this area exists to avoid — so the pane says it, above the
+ * rows, in the same place `LfsDiffNotice` says its piece.
+ */
+export function TruncatedDiffNotice({ diff }: { diff: FileDiff | null | undefined }) {
+  const cut = truncatedDiffNotice(diff);
+  if (!cut) return null;
+  return (
+    <div
+      data-testid="truncated-diff-notice"
+      style={{
+        margin: "8px 12px",
+        padding: "8px 10px",
+        border: "1px solid var(--border-0)",
+        borderRadius: "var(--r-3)",
+        background: "var(--bg-1)",
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        fontSize: "var(--fs-11)",
+        color: "var(--fg-2)",
+      }}
+    >
+      <PGIcon name="warn" size={13} style={{ color: "var(--git-modified)", flexShrink: 0 }} />
+      <span>
+        <strong style={{ color: "var(--fg-0)", fontWeight: 600 }}>{cut.title}</strong>
+        {" — "}
+        {cut.detail}
+      </span>
+    </div>
+  );
+}

--- a/src/features/diff/useDiffAnyway.test.tsx
+++ b/src/features/diff/useDiffAnyway.test.tsx
@@ -1,0 +1,108 @@
+// The waiver's shape and its lifetime (#396).
+//
+// The click records a waiver; the surface's ordinary diff fetch carries it. That
+// division is the whole design, and it is what the first version got wrong — a
+// hook that fetched the waived path itself and spliced it in lost the result to
+// the next status refresh, because the refresh re-ran the surface's own fetch
+// without the waiver. So what is worth pinning here is exactly two things: which
+// paths a click waives, and when the waivers are dropped.
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { raisedPathsFor, useDiffAnyway } from "./useDiffAnyway";
+import type { FileDiff } from "@/lib/types";
+
+const file = (path: string): FileDiff => ({
+  path,
+  oldPath: null,
+  binary: true,
+  additions: 0,
+  deletions: 0,
+  hunks: [],
+  lfs: null,
+  oversized: { size: 42_000_000, limit: 5 * 1024 * 1024, raised: false },
+  truncated: null,
+});
+
+describe("raisedPathsFor", () => {
+  it("waives the one path an ordinary delta has", () => {
+    expect(raisedPathsFor(file("data.csv"))).toEqual(["data.csv"]);
+  });
+
+  it("waives BOTH sides of a rename", () => {
+    // The backend turns the list into a pathspec, and a rename is two tree
+    // entries — naming only the new side hands `find_similar` half the pair and
+    // turns the rename into an add.
+    const renamed = { ...file("new.csv"), oldPath: "old.csv" };
+    expect(raisedPathsFor(renamed)).toEqual(["new.csv", "old.csv"]);
+  });
+
+  it("does not double up when the paths are the same", () => {
+    const same = { ...file("data.csv"), oldPath: "data.csv" };
+    expect(raisedPathsFor(same)).toEqual(["data.csv"]);
+  });
+});
+
+describe("useDiffAnyway", () => {
+  function setup(resetKey: unknown = "a.txt") {
+    return renderHook(({ key }: { key: unknown }) => useDiffAnyway(key), {
+      initialProps: { key: resetKey },
+    });
+  }
+
+  it("starts with nothing waived", () => {
+    // The ceiling applies until the user says otherwise — the default is the
+    // refusal, and this is what makes it so.
+    expect(setup().result.current.raiseFor).toEqual([]);
+  });
+
+  it("waives the clicked path, and nothing else", () => {
+    const hook = setup();
+    act(() => hook.result.current.diffAnyway(file("data.csv")));
+    expect(hook.result.current.raiseFor).toEqual(["data.csv"]);
+  });
+
+  it("accumulates within one view, without repeats", () => {
+    // A commit diff can hold several over-ceiling artifacts, and each is its own
+    // decision. The list is a set: re-clicking must not make the pathspec grow.
+    const hook = setup("commit-a");
+    act(() => hook.result.current.diffAnyway(file("data.csv")));
+    act(() => hook.result.current.diffAnyway(file("bundle.min.js")));
+    act(() => hook.result.current.diffAnyway(file("data.csv")));
+    expect(hook.result.current.raiseFor).toEqual(["data.csv", "bundle.min.js"]);
+  });
+
+  it("keeps the waiver while the view stays put", () => {
+    // The bug that made this shape necessary: a status refresh re-runs the
+    // surface's diff fetch, so the waiver has to survive re-renders that are
+    // not navigations — otherwise the diff the user waited seconds for is
+    // replaced by the refusal on its own.
+    const hook = setup("commit-a");
+    act(() => hook.result.current.diffAnyway(file("data.csv")));
+    act(() => hook.rerender({ key: "commit-a" }));
+    expect(hook.result.current.raiseFor).toEqual(["data.csv"]);
+  });
+
+  it("drops every waiver when the view points somewhere else", () => {
+    // The "per view, never a setting" half. A waiver that survived a change of
+    // file or commit would be a remembered "always diff huge files" by accident
+    // — a considered refusal turned into a footgun the user forgot they armed,
+    // and here that costs a multi-megabyte read nobody asked for.
+    const hook = setup("commit-a");
+    act(() => hook.result.current.diffAnyway(file("data.csv")));
+    expect(hook.result.current.raiseFor).toEqual(["data.csv"]);
+
+    act(() => hook.rerender({ key: "commit-b" }));
+    expect(hook.result.current.raiseFor).toEqual([]);
+  });
+
+  it("keeps a stable `diffAnyway` identity across renders", () => {
+    // The surfaces hand it to a memoized diff panel; a new function every render
+    // would re-render the whole diff pane on every keystroke elsewhere.
+    const hook = setup();
+    const first = hook.result.current.diffAnyway;
+    act(() => hook.rerender({ key: "a.txt" }));
+    expect(hook.result.current.diffAnyway).toBe(first);
+  });
+});

--- a/src/features/diff/useDiffAnyway.ts
+++ b/src/features/diff/useDiffAnyway.ts
@@ -1,0 +1,74 @@
+// Which files the user has said "yes, really, show me" about (#396).
+//
+// The click on the notice's action does not fetch anything itself. It records a
+// WAIVER, and the surface's ordinary diff fetch — which already knows the repo,
+// the revisions, the context width and the whitespace flag — carries it. That is
+// the whole design, and it is what the first version got wrong: a hook that
+// fetched the waived path separately and spliced it in lost the result to the
+// next status refresh, because the refresh re-ran the surface's own fetch
+// WITHOUT the waiver. The user clicked, waited seconds for 40 MB to be read, and
+// watched the refusal come back on its own.
+//
+// So the backend's diff ops answer with the whole diff and the waived paths read
+// at the raised ceiling (`with_raised`, `libgit2.rs`), and every fetch passes
+// `raiseFor`. What is left here is the state and its lifetime:
+//
+//   * **Per file.** `raiseFor` holds only paths the user actually clicked, both
+//     sides of a rename, and the backend raises the ceiling for those alone —
+//     waiving one 40 MB blob never reads the 60 MB one beside it.
+//   * **Per view, never a setting.** Component state, dropped whenever
+//     `resetKey` changes — the selected file, or the commit being shown. A
+//     remembered "always diff huge files" is a considered refusal turned into a
+//     footgun the user forgot they armed, so navigating away and back costs
+//     another click rather than another silent 40 MB read.
+
+import React from "react";
+import type { FileDiff } from "@/lib/types";
+
+/**
+ * The paths to waive for one delta: its own, plus the side it was renamed from.
+ *
+ * Both, because the backend turns the list into a pathspec and a rename is two
+ * tree entries — naming only the new side would hand `find_similar` half the
+ * pair and turn the rename into an add.
+ */
+export function raisedPathsFor(diff: FileDiff): string[] {
+  return diff.oldPath && diff.oldPath !== diff.path
+    ? [diff.path, diff.oldPath]
+    : [diff.path];
+}
+
+export interface DiffAnyway {
+  /**
+   * Paths whose ceiling the user has waived in this view. Pass it to the diff
+   * fetch — on EVERY fetch, including the ones a refresh triggers, or the waived
+   * read is thrown away by the next one.
+   */
+  raiseFor: string[];
+  /** Record the waiver for one delta. The fetch effect does the reading. */
+  diffAnyway: (diff: FileDiff) => void;
+}
+
+/**
+ * `resetKey` is whatever identifies the diff on screen — the selected file for a
+ * single-file surface, the commit or compare target for a multi-file one. When
+ * it changes the waivers go with it.
+ */
+export function useDiffAnyway(resetKey: unknown): DiffAnyway {
+  const [raiseFor, setRaiseFor] = React.useState<string[]>([]);
+
+  // Derived during render rather than in an effect: an effect would let one
+  // frame commit the previous view's waivers against the new subject, and for a
+  // waiver that frame is a megabyte-scale read.
+  const prevKey = React.useRef(resetKey);
+  if (prevKey.current !== resetKey) {
+    prevKey.current = resetKey;
+    if (raiseFor.length > 0) setRaiseFor([]);
+  }
+
+  const diffAnyway = React.useCallback((diff: FileDiff) => {
+    setRaiseFor((prev) => [...new Set([...prev, ...raisedPathsFor(diff)])]);
+  }, []);
+
+  return { raiseFor, diffAnyway };
+}

--- a/src/lib/derive.ts
+++ b/src/lib/derive.ts
@@ -94,6 +94,51 @@ export function oversizedDiffNotice(
 }
 
 /**
+ * Was this blob refused even though the user already asked for it anyway? (#396)
+ *
+ * The escape hatch raises the ceiling; it does not remove it. A blob over even
+ * the raised one comes back `oversized` a second time — with the raised limit in
+ * the sentence, which `oversizedDiffNotice` already reports correctly. What must
+ * not happen is offering the same button again: the answer cannot change, and a
+ * button that visibly does nothing is worse than no button.
+ *
+ * Reads the DELTA, deliberately not the surface's list of waived paths. The list
+ * says what the user asked for, not what the backend answered — after a fresh
+ * fetch (which never passes the waiver, so returning to a file costs a click
+ * rather than megabytes) the path is still in the list while the refusal is the
+ * DEFAULT ceiling's, and the action belongs back on screen. Keying off the list
+ * hid the button for the rest of the session instead.
+ */
+export function diffAnywayExhausted(diff: FileDiff | null | undefined): boolean {
+  return !!diff?.oversized?.raised;
+}
+
+/**
+ * The lines that did not fit, once the user asked for a diff anyway (#396).
+ *
+ * Blob size is the first wall and the line count is the second: a 40 MB CSV is
+ * about a million rows, which is a nine-figure JSON payload to parse and a
+ * million row objects to lay out. The backend caps the lines and reports the
+ * real length, and this is the one sentence that says so — a truncation nobody
+ * mentions is indistinguishable from a diff that ends early, which is the
+ * silent-wrong-answer this whole area exists to avoid.
+ *
+ * Counts come off the wire for the same reason the ceiling does: the cap is
+ * backend policy, and a copy of it here would be free to drift.
+ */
+export function truncatedDiffNotice(
+  diff: FileDiff | null | undefined,
+): { title: string; detail: string } | null {
+  const cut = diff?.truncated;
+  if (!cut) return null;
+  const fmt = (n: number) => n.toLocaleString();
+  return {
+    title: "Diff shortened",
+    detail: `Showing the first ${fmt(cut.shown)} of ${fmt(cut.total)} lines — the rest was not sent.`,
+  };
+}
+
+/**
  * Never committed and never staged — git holds no copy of it.
  *
  * Discarding one deletes it outright rather than restoring it, so the UI has to

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -397,6 +397,11 @@ export async function listRemotes(repoId: string): Promise<RemoteInfo[]> {
  * context. Hunk indices from such a diff do NOT line up with the ones
  * stageHunk/discardHunk expect, so callers must disable hunk-level actions
  * while it is on (#61 D2).
+ *
+ * `raiseFor` is the user's explicit "Diff it anyway" (#396): the paths whose
+ * blob ceiling was waived by a click on the notice. Both sides of a rename
+ * belong in it. The wire carries PATHS, never a size — the ceiling is backend
+ * policy, and a copy of it here would be free to drift from the one applied.
  */
 export async function getDiff(
   repoId: string,
@@ -404,6 +409,7 @@ export async function getDiff(
   kind: DiffKind = "WorktreeToIndex",
   contextLines = 3,
   ignoreWhitespace = false,
+  raiseFor: string[] = [],
 ): Promise<FileDiff> {
   return invoke<FileDiff>("get_diff", {
     repoId,
@@ -411,6 +417,7 @@ export async function getDiff(
     kind,
     contextLines,
     ignoreWhitespace,
+    raiseFor,
   });
 }
 
@@ -431,6 +438,7 @@ export async function diffCommits(
   toOid: string,
   contextLines = 3,
   ignoreWhitespace = false,
+  raiseFor: string[] = [],
 ): Promise<FileDiff[]> {
   return invoke<FileDiff[]>("diff_commits", {
     repoId,
@@ -438,6 +446,7 @@ export async function diffCommits(
     toOid,
     contextLines,
     ignoreWhitespace,
+    raiseFor,
   });
 }
 
@@ -445,18 +454,25 @@ export async function diffCommits(
  * A single commit's own diff — against its first parent. Root commit (no
  * parent) diffs against the empty tree (all-added); a merge commit diffs
  * against its first parent. This is "what this commit changed."
+ *
+ * `raiseFor` is the user's explicit "Diff it anyway" (#396): the paths whose
+ * blob ceiling was waived by a click on the notice. Both sides of a rename
+ * belong in it. The wire carries PATHS, never a size — the ceiling is backend
+ * policy, and a copy of it here would be free to drift from the one applied.
  */
 export async function diffCommit(
   repoId: string,
   oid: string,
   contextLines = 3,
   ignoreWhitespace = false,
+  raiseFor: string[] = [],
 ): Promise<FileDiff[]> {
   return invoke<FileDiff[]>("diff_commit", {
     repoId,
     oid,
     contextLines,
     ignoreWhitespace,
+    raiseFor,
   });
 }
 
@@ -471,6 +487,11 @@ export async function diffCommit(
  * The untracked side is BOUNDED — over the backend's ceiling it is dropped
  * whole and the count comes back as `untrackedOmitted`. Render that; a short
  * file list with no explanation is the failure the cap exists to prevent.
+ *
+ * `raiseFor` is the user's explicit "Diff it anyway" (#396): the paths whose
+ * blob ceiling was waived by a click on the notice. Both sides of a rename
+ * belong in it. The wire carries PATHS, never a size — the ceiling is backend
+ * policy, and a copy of it here would be free to drift from the one applied.
  */
 export async function diffRefToWorkdir(
   repoId: string,
@@ -478,6 +499,7 @@ export async function diffRefToWorkdir(
   contextLines = 3,
   ignoreWhitespace = false,
   includeUntracked = false,
+  raiseFor: string[] = [],
 ): Promise<WorkdirDiff> {
   return invoke<WorkdirDiff>("diff_ref_to_workdir", {
     repoId,
@@ -485,6 +507,7 @@ export async function diffRefToWorkdir(
     contextLines,
     ignoreWhitespace,
     includeUntracked,
+    raiseFor,
   });
 }
 
@@ -941,6 +964,8 @@ export async function stashRename(
  * `includeUntracked` folds in the `git stash -u` payload, which lives in a
  * THIRD parent that no tree-level diff of the stash commit can reach. Inert on
  * an entry that has none — see `StashInfo.untracked`.
+ *
+ * `raiseFor` is the user's explicit "Diff it anyway" (#396) — see `getDiff`.
  */
 export async function stashDiff(
   repoId: string,
@@ -948,6 +973,7 @@ export async function stashDiff(
   contextLines = 3,
   ignoreWhitespace = false,
   includeUntracked = true,
+  raiseFor: string[] = [],
 ): Promise<FileDiff[]> {
   return invoke<FileDiff[]>("stash_diff", {
     repoId,
@@ -955,6 +981,7 @@ export async function stashDiff(
     contextLines,
     ignoreWhitespace,
     includeUntracked,
+    raiseFor,
   });
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -327,6 +327,19 @@ export interface FileDiff {
    * into the sentence every surface prints.
    */
   oversized?: OversizedBlob | null;
+  /**
+   * Set when this diff has MORE lines than were sent (#396).
+   *
+   * Only the "Diff it anyway" path can produce it: an ordinary diff is under the
+   * ceiling and arrives whole. Once the user has waived the ceiling the line
+   * count is the next wall — a 40 MB CSV is about a million rows to lay out —
+   * so the backend caps the lines and reports the real length instead.
+   * `truncatedDiffNotice` (`lib/derive.ts`) turns it into the sentence.
+   *
+   * `additions`/`deletions` still describe the WHOLE diff, so the file row keeps
+   * telling the truth even when the pane cannot show all of it.
+   */
+  truncated?: TruncatedDiff | null;
 }
 
 /** Why a diff has no text: the blob was bigger than the ceiling (#385). */
@@ -335,6 +348,24 @@ export interface OversizedBlob {
   size: number;
   /** The ceiling that was applied, in bytes — the backend owns the policy. */
   limit: number;
+  /**
+   * Was that the RAISED ceiling — i.e. did the user already ask for this blob
+   * anyway, and it is still too big? (#396)
+   *
+   * Off the wire because the frontend deliberately holds no copy of either
+   * ceiling, and because the waived-path list is not the answer: after a fresh
+   * fetch the waiver is still in that list while the refusal is the default
+   * ceiling's, and the action belongs back on screen.
+   */
+  raised: boolean;
+}
+
+/** How much of an over-ceiling diff was actually sent (#396). */
+export interface TruncatedDiff {
+  /** Diff lines that arrived, across every hunk. */
+  shown: number;
+  /** Diff lines the file really has — the backend counted them all. */
+  total: number;
 }
 
 /** The two sides of an LFS pointer change; either is null for an add/delete. */

--- a/src/screens/CommitDiff.tsx
+++ b/src/screens/CommitDiff.tsx
@@ -4,6 +4,7 @@ import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { CommitDiffPanel } from "@/features/diff/CommitDiffPanel";
+import { useDiffAnyway } from "@/features/diff/useDiffAnyway";
 import { useIgnoreWhitespace } from "@/features/diff/WhitespaceToggle";
 import { DeepViewHeader } from "@/features/nav/DeepViewHeader";
 import { diffCommit, diffCommits, diffRefToWorkdir, stashDiff } from "@/lib/tauri";
@@ -171,41 +172,81 @@ export function CommitDiffScreen() {
     }
   }, [intent, clearIntent]);
 
+  // The user's own way past the blob ceiling (#396), keyed on the target: the
+  // waivers ride along on EVERY fetch below, so a refetch of the same target
+  // (a context-width change, a refresh) keeps the blob the user asked for, and
+  // moving to another target drops them.
+  const anyway = useDiffAnyway(target);
+
+  // ONE dispatch for the four target kinds, so a waived read cannot drift from
+  // the fetch that produced the diff it is re-reading (#396) — a stash whose
+  // waiver quietly went through `diffCommits` would diff the wrong trees.
+  // Keyed on the repo ID, not the repo object: `useRepoStore.current` is
+  // replaced by a refresh, and an object dep here would re-fetch the whole
+  // commit diff — loading flash and all — every time anything refreshed.
+  const repoId = repo?.id ?? null;
+  const fetchDiffs = React.useCallback(
+    (): Promise<FileDiff[]> => {
+      if (!repoId || !target) return Promise.resolve([]);
+      const raiseFor = anyway.raiseFor;
+      switch (target.kind) {
+        case "commit-self":
+          return diffCommit(
+            repoId,
+            target.oid,
+            diffContextLines,
+            ignoreWhitespace,
+            raiseFor,
+          );
+        case "stash-diff":
+          // Its own first parent, resolved in the backend — NOT `diffCommits`
+          // against HEAD, which mixed the stash with everything landed since.
+          return stashDiff(
+            repoId,
+            target.oid,
+            diffContextLines,
+            ignoreWhitespace,
+            true,
+            raiseFor,
+          );
+        case "stash-vs-wt":
+          // The shared #131 primitive, reused rather than duplicated. The
+          // untracked flag is off — see `untrackedNote`.
+          return diffRefToWorkdir(
+            repoId,
+            target.oid,
+            diffContextLines,
+            ignoreWhitespace,
+            false,
+            raiseFor,
+          ).then((d) => d.files);
+        default:
+          return diffCommits(
+            repoId,
+            target.kind === "commit-vs-commit" ? target.from : target.oid,
+            target.kind === "commit-vs-commit" ? target.to : "HEAD",
+            diffContextLines,
+            ignoreWhitespace,
+            raiseFor,
+          );
+      }
+    },
+    [repoId, target, diffContextLines, ignoreWhitespace, anyway.raiseFor],
+  );
+
   React.useEffect(() => {
-    if (!repo || !target) return;
+    if (!repoId || !target) return;
     let cancelled = false;
     setLoading(true);
     setError(null);
-    const fetch: Promise<FileDiff[]> =
-      target.kind === "commit-self"
-        ? diffCommit(repo.id, target.oid, diffContextLines, ignoreWhitespace)
-        : target.kind === "stash-diff"
-          ? // Its own first parent, resolved in the backend — NOT `diffCommits`
-            // against HEAD, which mixed the stash with everything landed since.
-            stashDiff(repo.id, target.oid, diffContextLines, ignoreWhitespace, true)
-          : target.kind === "stash-vs-wt"
-            ? // The shared #131 primitive, reused rather than duplicated. The
-              // untracked flag is off — see `untrackedNote`.
-              diffRefToWorkdir(
-                repo.id,
-                target.oid,
-                diffContextLines,
-                ignoreWhitespace,
-                false,
-              ).then((d) => d.files)
-            : diffCommits(
-                repo.id,
-                target.kind === "commit-vs-commit" ? target.from : target.oid,
-                target.kind === "commit-vs-commit" ? target.to : "HEAD",
-                diffContextLines,
-                ignoreWhitespace,
-              );
-    fetch
+    fetchDiffs()
       .then((d) => { if (!cancelled) setDiffs(d); })
       .catch((e) => { if (!cancelled) { setDiffs([]); setError(appErrorMessage(e)); } })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, [repo?.id, target, diffContextLines, ignoreWhitespace]);
+  }, [repoId, target, fetchDiffs]);
+
+
 
   if (!target) {
     return (
@@ -243,6 +284,8 @@ export function CommitDiffScreen() {
         error={error}
         header={targetHeader(target)}
         paneIdPrefix="commitDiff"
+        onDiffAnyway={anyway.diffAnyway}
+        diffAnywayPending={loading}
         emptyLabel={
           target.kind === "commit-self" ? "No changes in this commit." : "No changes."
         }

--- a/src/screens/CommitPanel.tsx
+++ b/src/screens/CommitPanel.tsx
@@ -57,12 +57,18 @@ import {
   isTextualDiff,
   isUnstaged,
   isUntracked,
+  diffAnywayExhausted,
   oversizedDiffNotice,
   sideAdditions,
   sideDeletions,
   statusMark,
 } from "@/lib/derive";
 import { LfsDiffNotice } from "@/features/lfs/LfsDiffNotice";
+import {
+  OversizedDiffEmpty,
+  TruncatedDiffNotice,
+} from "@/features/diff/OversizedDiffNotice";
+import { useDiffAnyway } from "@/features/diff/useDiffAnyway";
 import { NoSignaturePrompt } from "@/features/commits/identity/NoSignaturePrompt";
 import {
   identityLine,
@@ -231,6 +237,10 @@ export function CommitPanelScreen() {
   // Non-null only when the backend declined to read the blob because of its
   // size (#385) — the surfaces must not call a 40 MB text file "binary".
   const oversized = oversizedDiffNotice(diff);
+  // ...and the user's own way past that refusal (#396). Keyed on the selected
+  // file AND side, because the two sides of one file are two different diffs:
+  // the waiver survives a refresh of the same one (or the diff the user waited
+  // for would vanish on its own) and is dropped the moment the selection moves.
 
   // Folder rows (tree mode only) get the batch menu over everything beneath
   // them — stage / unstage / discard all — same as a multi-row selection.
@@ -687,6 +697,10 @@ export function CommitPanelScreen() {
   // itself on the outgoing side's row model (issue 188).
   const selKey = `${selected?.path ?? ""}:${selected?.side ?? ""}`;
   const [diffFor, setDiffFor] = React.useState<string | null>(null);
+  // The user's own way past the blob ceiling (#396) — see the note beside
+  // `oversized` above. Keyed on `selKey`, not just the path: the two sides of
+  // one file are two different diffs.
+  const anyway = useDiffAnyway(selKey);
 
   React.useEffect(() => {
     if (!selected || !repo) {
@@ -709,7 +723,14 @@ export function CommitPanelScreen() {
     }
     let cancelled = false;
     setDiffLoading(true);
-    getDiff(repo.id, selected.path, kind, diffContextLines, ignoreWhitespace)
+    getDiff(
+      repo.id,
+      selected.path,
+      kind,
+      diffContextLines,
+      ignoreWhitespace,
+      anyway.raiseFor,
+    )
       .then((d) => {
         if (!cancelled) {
           setDiff(d);
@@ -744,6 +765,9 @@ export function CommitPanelScreen() {
     repo,
     diffContextLines,
     ignoreWhitespace,
+    // And the waiver, so the status refresh above re-reads the blob the user
+    // asked for instead of silently replacing their diff with the refusal (#396).
+    anyway.raiseFor,
   ]);
 
   // A line selection stops meaning the same thing once the file, the side, or
@@ -1588,16 +1612,27 @@ export function CommitPanelScreen() {
           {/* The two sides the diff was computed from — IndexToHead for a
               staged row, WorktreeToIndex otherwise — so an image previews the
               same pair the hunks describe (#224). */}
-          {!diffLoading && !diffError && diff && diff.binary && (
+          {/* We declined to READ this blob, so there is nothing to preview and
+              exactly one thing to do about it — and this must come BEFORE the
+              image branch, because the preview ceiling (4 MiB) is below the
+              diff one and reports `tooLarge`, which suppresses the fallback the
+              sentence used to live in (#385/#396). */}
+          {!diffLoading && !diffError && oversized && (
+            <OversizedDiffEmpty
+              diff={diff}
+              pending={diffLoading}
+              alreadyTried={diffAnywayExhausted(diff)}
+              onDiffAnyway={() => diff && anyway.diffAnyway(diff)}
+            />
+          )}
+          {!diffLoading && !diffError && diff && diff.binary && !oversized && (
             <ImageDiffOrEmpty
               repoId={repo?.id ?? null}
               path={diff.path}
               sides={commitPanelImageSides}
-              title={oversized?.title ?? "Binary file"}
+              title="Binary file"
             >
-              {/* Over the ceiling this is usually a checked-in artifact, i.e.
-                  text — "binary" would be the wrong answer (#385). */}
-              {oversized?.detail ?? "Binary diffs aren't shown."}
+              Binary diffs aren&apos;t shown.
             </ImageDiffOrEmpty>
           )}
           {!diffLoading && !diffError && diff?.lfs && (
@@ -1616,6 +1651,10 @@ export function CommitPanelScreen() {
                 File is tracked but no hunks were produced.
               </PGEmpty>
             )}
+          {/* A waived ceiling gets the blob read; it does not make a million
+              rows layoutable, so the backend caps the lines. Say so above them
+              — an unmentioned cap reads as a diff that just ends (#396). */}
+          {!diffLoading && !diffError && <TruncatedDiffNotice diff={diff} />}
           {!diffLoading && !diffError && isTextualDiff(diff) && diff && diff.hunks.length > 0 &&
             diffMode === "unified" && (
               <PGWindowedDiff

--- a/src/screens/Compare.tsx
+++ b/src/screens/Compare.tsx
@@ -21,6 +21,7 @@ import {
 import { useElementSize } from "@/lib/useElementSize";
 import { DeepViewHeader } from "@/features/nav/DeepViewHeader";
 import { CommitDiffPanel } from "@/features/diff/CommitDiffPanel";
+import { raisedPathsFor } from "@/features/diff/useDiffAnyway";
 import { useIgnoreWhitespace } from "@/features/diff/WhitespaceToggle";
 import { FocusableScroll, PGPane } from "@/features/keymap";
 import { useRepoStore } from "@/features/repo/useRepoStore";
@@ -187,6 +188,11 @@ export function CompareScreen() {
   const setRight = useCompareStore((s) => s.setRight);
   const swap = useCompareStore((s) => s.swap);
   const refresh = useCompareStore((s) => s.refresh);
+  // The user's own way past the blob ceiling (#396). The store owns it because
+  // the store owns `diffs` — the waived read answers with a pathspec'd subset
+  // that has to be spliced into the list, not replace it.
+  const diffAnywayPending = useCompareStore((s) => s.diffAnywayPending);
+  const diffAnywayAction = useCompareStore((s) => s.diffAnyway);
 
   // First visit for this repository — or a tab switch since the last one — gets
   // the app's own `git diff`: the current branch against what is on disk. An
@@ -420,6 +426,14 @@ export function CompareScreen() {
           header={header}
           paneIdPrefix="compare"
           emptyLabel="No differences."
+          onDiffAnyway={(d) =>
+            void diffAnywayAction(
+              raisedPathsFor(d),
+              diffContextLines,
+              ignoreWhitespace,
+            )
+          }
+          diffAnywayPending={diffAnywayPending}
           // `SideSource` already has a `worktree` kind, so whole-file mode works
           // on both shapes with no new plumbing.
           syntaxSides={{

--- a/src/screens/DiffViewer.tsx
+++ b/src/screens/DiffViewer.tsx
@@ -29,7 +29,17 @@ import {
   useDiffGaps,
   useExpandedGaps,
 } from "@/features/diff/useDiffGaps";
-import { isTextualDiff, oversizedDiffNotice, statusMark } from "@/lib/derive";
+import {
+  diffAnywayExhausted,
+  isTextualDiff,
+  oversizedDiffNotice,
+  statusMark,
+} from "@/lib/derive";
+import {
+  OversizedDiffEmpty,
+  TruncatedDiffNotice,
+} from "@/features/diff/OversizedDiffNotice";
+import { useDiffAnyway } from "@/features/diff/useDiffAnyway";
 import { LfsDiffNotice } from "@/features/lfs/LfsDiffNotice";
 import { ImageDiffOrEmpty, ImageDiffView } from "@/features/diff/ImageDiffView";
 import { diffImageSides } from "@/features/diff/useImagePreviews";
@@ -86,6 +96,11 @@ export function DiffViewerScreen() {
   // Non-null only when the backend declined to read the blob because of its
   // size (#385) — the surfaces must not call a 40 MB text file "binary".
   const oversized = oversizedDiffNotice(diff);
+  // ...and the user's own way past that refusal (#396). Keyed on the selected
+  // path: the waiver survives a refresh of the SAME file (or the diff the user
+  // waited for would vanish on its own) and is dropped the moment the selection
+  // moves, so coming back costs a click rather than another silent read.
+  const anyway = useDiffAnyway(selectedPath);
   // The file list may take everything the split allows, as long as the diff it
   // is a list OF keeps enough width to read a line of code (#162).
   const layout = useElementSize();
@@ -137,7 +152,14 @@ export function DiffViewerScreen() {
     }
     let cancelled = false;
     setDiffLoading(true);
-    getDiff(repo.id, current.path, "WorktreeToHead", diffContextLines, ignoreWhitespace)
+    getDiff(
+      repo.id,
+      current.path,
+      "WorktreeToHead",
+      diffContextLines,
+      ignoreWhitespace,
+      anyway.raiseFor,
+    )
       .then((d) => {
         if (!cancelled) setDiff(d);
       })
@@ -154,7 +176,14 @@ export function DiffViewerScreen() {
     return () => {
       cancelled = true;
     };
-  }, [current?.path, current?.embedded, repo, diffContextLines, ignoreWhitespace]);
+  }, [
+    current?.path,
+    current?.embedded,
+    repo,
+    diffContextLines,
+    ignoreWhitespace,
+    anyway.raiseFor,
+  ]);
 
   // This screen compares the worktree against HEAD; an embedded repo has no
   // text to read on either side.
@@ -604,7 +633,20 @@ export function DiffViewerScreen() {
           )}
           {/* An image previews here instead of dead-ending (#224); everything
               else keeps the empty state. Same sides the syntax hook reads. */}
-          {!diffLoading && diff?.binary && (
+          {/* We declined to READ this blob, so there is nothing to preview and
+              exactly one thing to do about it — and this must come BEFORE the
+              image branch, because the preview ceiling (4 MiB) is below the
+              diff one and reports `tooLarge`, which suppresses the fallback the
+              sentence used to live in (#385/#396). */}
+          {!diffLoading && oversized && (
+            <OversizedDiffEmpty
+              diff={diff}
+              pending={diffLoading}
+              alreadyTried={diffAnywayExhausted(diff)}
+              onDiffAnyway={() => diff && anyway.diffAnyway(diff)}
+            />
+          )}
+          {!diffLoading && diff?.binary && !oversized && (
             <ImageDiffOrEmpty
               repoId={repo?.id ?? null}
               path={diff.path}
@@ -613,12 +655,8 @@ export function DiffViewerScreen() {
                 new: { kind: "worktree" },
                 oldPath: diff.oldPath,
               })}
-              title={oversized?.title ?? "Binary file"}
-            >
-              {/* Only the size can say WHY libgit2 called it binary; over the
-                  ceiling it is usually a text file we declined to read (#385). */}
-              {oversized?.detail}
-            </ImageDiffOrEmpty>
+              title="Binary file"
+            />
           )}
           {/* An LFS pointer is TEXT, so `binary` is honestly false — without this
               the pane would render "2 lines changed" for a multi-megabyte asset
@@ -652,6 +690,11 @@ export function DiffViewerScreen() {
               File is tracked but no hunks were produced.
             </PGEmpty>
           )}
+          {/* A waived ceiling gets the blob read; it does not make a million
+              rows something this pane can lay out, so the backend caps the
+              lines. Say so above them — a cap nobody mentions is
+              indistinguishable from a diff that just ends (#396). */}
+          {!diffLoading && <TruncatedDiffNotice diff={diff} />}
           {!diffLoading && isTextualDiff(diff) && diff && mode === "unified" && (
             <>
             <DiffFindBar find={find} />

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -50,6 +50,7 @@ import {
 } from "@/features/settings/useSettingsStore";
 import { resolveHeadDecor } from "@/features/settings/headMarks";
 import { CommitDiffPanel } from "@/features/diff/CommitDiffPanel";
+import { useDiffAnyway } from "@/features/diff/useDiffAnyway";
 import { useIgnoreWhitespace } from "@/features/diff/WhitespaceToggle";
 import { PGPane, FocusableScroll, useAction, usePaneList } from "@/features/keymap";
 import {
@@ -445,6 +446,12 @@ export function HistoryScreen() {
   const inlineOid =
     sel.keys.length > 1 ? null : (primarySelectedKey(sel) ?? order[cursorIdx] ?? null);
   // Cancellable + debounced so rapid ↑/↓ through the log doesn't flood libgit2.
+  // The user's own way past the blob ceiling (#396), keyed on the commit whose
+  // diff is on screen: the waivers ride along on the fetch below, so a refetch
+  // of the SAME commit keeps the blob the user asked for, and walking the log
+  // drops them.
+  const anyway = useDiffAnyway(inlineOid);
+
   React.useEffect(() => {
     if (!repo || !inlineOid) {
       setInlineDiffs([]);
@@ -456,7 +463,13 @@ export function HistoryScreen() {
     setInlineLoading(true);
     setInlineError(null);
     const handle = window.setTimeout(() => {
-      diffCommit(repo.id, inlineOid, diffContextLines, ignoreWhitespace)
+      diffCommit(
+        repo.id,
+        inlineOid,
+        diffContextLines,
+        ignoreWhitespace,
+        anyway.raiseFor,
+      )
         .then((d) => { if (!cancelled) setInlineDiffs(d); })
         .catch((e) => {
           if (!cancelled) { setInlineDiffs([]); setInlineError(appErrorMessage(e)); }
@@ -464,7 +477,8 @@ export function HistoryScreen() {
         .finally(() => { if (!cancelled) setInlineLoading(false); });
     }, INLINE_DIFF_DEBOUNCE_MS);
     return () => { cancelled = true; window.clearTimeout(handle); };
-  }, [repo?.id, inlineOid, diffContextLines, ignoreWhitespace]);
+  }, [repo?.id, inlineOid, diffContextLines, ignoreWhitespace, anyway.raiseFor]);
+
 
   const exportVisible = React.useCallback(() => {
     const lines = visible.map(
@@ -942,6 +956,8 @@ export function HistoryScreen() {
       error={inlineError}
       header={diffHeader}
       paneIdPrefix="history.diff"
+      onDiffAnyway={anyway.diffAnyway}
+      diffAnywayPending={inlineLoading}
       // The inline panel shows the selected commit's own diff; a multi-selection
       // renders MultiCommitDetail instead, so this is always one commit (#61 D6).
       verifyOid={current?.oid}

--- a/src/screens/RepoBrowser.tsx
+++ b/src/screens/RepoBrowser.tsx
@@ -38,6 +38,7 @@ import {
 import { useWindowedList } from "@/lib/useWindowedList";
 import {
   currentBranch,
+  diffAnywayExhausted,
   isConflicted,
   isStaged,
   isTextualDiff,
@@ -49,6 +50,11 @@ import {
 import { commitDateText, commitDateTitle } from "@/lib/commitDate";
 import { LfsDiffNotice } from "@/features/lfs/LfsDiffNotice";
 import { ImageDiffOrEmpty, ImageDiffView } from "@/features/diff/ImageDiffView";
+import {
+  OversizedDiffEmpty,
+  TruncatedDiffNotice,
+} from "@/features/diff/OversizedDiffNotice";
+import { useDiffAnyway } from "@/features/diff/useDiffAnyway";
 import { diffImageSides } from "@/features/diff/useImagePreviews";
 import {
   clickSelection,
@@ -183,6 +189,10 @@ export function RepoBrowserScreen() {
   // Non-null only when the backend declined to read the blob because of its
   // size (#385) — the surfaces must not call a 40 MB text file "binary".
   const oversized = oversizedDiffNotice(diff);
+  // ...and the user's own way past that refusal (#396). Keyed on the selected
+  // path: the waiver survives a refresh of the SAME file (or the diff the user
+  // waited for would vanish on its own) and is dropped the moment the selection
+  // moves, so coming back costs a click rather than another silent read.
   const [fileContent, setFileContent] = React.useState<FileContent | null>(null);
   const [filterMode, setFilterMode] = React.useState<
     "all" | "changes" | "conflicts"
@@ -663,6 +673,8 @@ export function RepoBrowserScreen() {
 
   // Derive the FileStatus entry that corresponds to the selected path key.
   // PGFileTree keys are path-prefixed by PG_FILETREE in the form "/a/b/c".
+  // Declared here rather than beside `oversized` above because it keys on the
+  // selection, which is derived below. See #396.
   const selectedFile = React.useMemo<FileStatus | null>(() => {
     if (!selected) return null;
     if (browsingRev) return findStatusByTreeKey(selected, revFiles) ?? null;
@@ -674,6 +686,9 @@ export function RepoBrowserScreen() {
     selectedFile.worktree.kind === "Unmodified" &&
     selectedFile.index.kind === "Unmodified";
   const selectedIsEmbedded = !!selectedFile?.embedded;
+  // The user's own way past the blob ceiling (#396) — see the note beside
+  // `oversized` above. Keyed on the selected path.
+  const anyway = useDiffAnyway(selectedFile?.path ?? null);
 
   // This pane's diff pane went unhighlighted and unwindowed through the first
   // three slices of #104 — it is a fourth diff surface that is easy to miss. It
@@ -909,6 +924,7 @@ export function RepoBrowserScreen() {
         "WorktreeToHead",
         diffContextLines,
         ignoreWhitespace,
+        anyway.raiseFor,
       )
         .then((d) => {
           if (!cancelled) setDiff(d);
@@ -928,7 +944,7 @@ export function RepoBrowserScreen() {
     return () => {
       cancelled = true;
     };
-  }, [selectedFile?.path, selectedFile?.embedded, selectedIsUnmodified, repo, browsingRev, rev, readFileContentAtRev, diffContextLines, ignoreWhitespace]);
+  }, [selectedFile?.path, selectedFile?.embedded, selectedIsUnmodified, repo, browsingRev, rev, readFileContentAtRev, diffContextLines, ignoreWhitespace, anyway.raiseFor]);
 
   const breadcrumbItems = React.useMemo(() => {
     const root = repo?.path.split("/").filter(Boolean).pop() ?? "repository";
@@ -1250,6 +1266,11 @@ export function RepoBrowserScreen() {
                 {previewError}
               </PGEmpty>
             )}
+            {/* A waived ceiling gets the blob read; it does not make a million
+                rows layoutable, so the backend caps the lines. Say so above
+                them — an unmentioned cap reads as a diff that just ends
+                (#396). */}
+            {selectedFile && !diffLoading && <TruncatedDiffNotice diff={diff} />}
             {selectedFile && !diffLoading && isTextualDiff(diff) && diff && (
               <PGWindowedDiff
                 rows={diffRows}
@@ -1269,7 +1290,20 @@ export function RepoBrowserScreen() {
             {/* This pane compares WorktreeToHead, the same two sides its syntax
                 hook reads — so an image previews here instead of dead-ending
                 (#224). */}
-            {selectedFile && !diffLoading && diff?.binary && (
+            {/* We declined to READ this blob, so there is nothing to preview
+                and exactly one thing to do about it — and this must come BEFORE
+                the image branch, because the preview ceiling (4 MiB) is below
+                the diff one and reports `tooLarge`, which suppresses the
+                fallback the sentence used to live in (#385/#396). */}
+            {selectedFile && !diffLoading && oversized && (
+              <OversizedDiffEmpty
+                diff={diff}
+                pending={diffLoading}
+                alreadyTried={diffAnywayExhausted(diff)}
+                onDiffAnyway={() => diff && anyway.diffAnyway(diff)}
+              />
+            )}
+            {selectedFile && !diffLoading && diff?.binary && !oversized && (
               <ImageDiffOrEmpty
                 repoId={repo?.id ?? null}
                 path={diff.path}
@@ -1278,11 +1312,9 @@ export function RepoBrowserScreen() {
                   new: { kind: "worktree" },
                   oldPath: diff.oldPath,
                 })}
-                title={oversized?.title ?? "Binary file"}
+                title="Binary file"
               >
-                {/* Over the ceiling this is usually a checked-in artifact, i.e.
-                    text — "binary" would be the wrong answer (#385). */}
-                {oversized?.detail ?? "Binary diffs aren't shown."}
+                Binary diffs aren&apos;t shown.
               </ImageDiffOrEmpty>
             )}
             {selectedFile && !diffLoading && diff?.lfs && (

--- a/test/diffOversized.test.ts
+++ b/test/diffOversized.test.ts
@@ -32,6 +32,16 @@ const DIFF_SURFACES = [
 
 const read = (p: string) => readFileSync(resolve(process.cwd(), p), "utf8");
 
+/**
+ * Source with its comments removed.
+ *
+ * These files explain themselves at length, and several of the assertions below
+ * forbid SHIPPING a string, not mentioning it — a guard that cannot tell the
+ * two apart makes the prose the thing you have to work around.
+ */
+const codeOnly = (src: string) =>
+  src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+
 describe("the honest 'too large to diff' answer reaches every diff surface", () => {
   it.each(DIFF_SURFACES)("%s asks why the delta has no text", (file) => {
     expect(read(file)).toContain("oversizedDiffNotice(");
@@ -50,14 +60,109 @@ describe("the honest 'too large to diff' answer reaches every diff surface", () 
   });
 });
 
+describe("the honest 'we shortened this' answer reaches every diff surface", () => {
+  // The other end of the escape hatch (#396). Waiving the ceiling gets the blob
+  // READ; it does not make a million rows something a diff pane can lay out, so
+  // the backend caps the lines. A surface that renders the rows and never
+  // mentions the cap shows a diff that appears to simply end — the silent wrong
+  // answer this whole area exists to avoid.
+  it.each(DIFF_SURFACES)("%s says when the diff was shortened", (file) => {
+    expect(read(file)).toContain("TruncatedDiffNotice");
+  });
+
+  it.each(DIFF_SURFACES)("%s does not hardcode the line cap", (file) => {
+    // Same reasoning as the ceiling above: the numbers the user reads come off
+    // the wire, because the cap is the backend's policy.
+    expect(read(file)).not.toMatch(/100[_,]?000/);
+  });
+});
+
+describe("'Diff it anyway' is offered by every diff surface, and owned by none", () => {
+  // #385 left the notice NAMING a limit with no way to act on it, which is the
+  // shape that invites the question. The action is shared for exactly the reason
+  // the sentence is (see `isTextualDiff`'s doc comment): a surface that grows
+  // its own button is how the same file comes to behave differently depending
+  // on which pane you opened it in.
+  it.each(DIFF_SURFACES)("%s offers the shared action", (file) => {
+    // `OversizedDiffEmpty` is the whole pane — sentence, copy and the shared
+    // `OversizedDiffAction` inside it. The surfaces render THAT rather than
+    // assembling the three themselves, and it deliberately takes precedence
+    // over the image-preview branch: the preview ceiling is BELOW the diff one,
+    // so an over-ceiling blob always reports `tooLarge`, which suppressed the
+    // fallback the #385 sentence used to live in.
+    expect(read(file)).toContain("OversizedDiffEmpty");
+  });
+
+  it.each(DIFF_SURFACES)("%s puts it ahead of the image preview", (file) => {
+    // The regression that made the #385 sentence unreachable. Rendering the
+    // image shell first means `tooLarge` wins and the user reads "Too large to
+    // preview" — which says less and offers nothing to click.
+    const src = read(file);
+    const oversizedAt = src.indexOf("OversizedDiffEmpty\n");
+    const imageAt = src.search(/<ImageDiff(OrEmpty|View)\n/);
+    expect(oversizedAt).toBeGreaterThan(-1);
+    if (imageAt > -1) expect(oversizedAt).toBeLessThan(imageAt);
+  });
+
+  it.each(DIFF_SURFACES)("%s does not build its own", (file) => {
+    // A local button would drift in label, in disabled state, and in whether it
+    // is offered a second time for a blob over even the raised ceiling. Read
+    // past the comments — naming the feature in prose is how these files
+    // explain themselves; SHIPPING the label is the thing being forbidden.
+    expect(codeOnly(read(file))).not.toMatch(/Diff it anyway/);
+  });
+
+  // `CommitDiffPanel` is presentational — its caller fetches the diffs, so its
+  // caller is the only thing that can answer a waived re-read. A screen that
+  // mounts the panel without wiring this shows the notice with nothing under
+  // it, which is exactly the pre-#396 dead end.
+  const COMMIT_DIFF_OWNERS = [
+    "src/screens/CommitDiff.tsx",
+    "src/screens/History.tsx",
+    "src/screens/Compare.tsx",
+  ];
+  it.each(COMMIT_DIFF_OWNERS)("%s gives the panel somewhere to send it", (file) => {
+    expect(read(file)).toContain("onDiffAnyway=");
+  });
+});
+
 describe("the backend applies one ceiling, not one capped path and three uncapped", () => {
   // The bug this fixes was a POLICY split, not a rendering one: `max_size` was
   // set at exactly one of the diff builders. Counting the call sites is the
   // cheapest way to keep a new diff op from quietly inheriting libgit2's 512 MB
   // default — bump the number when you add one, deliberately.
-  it("sets max_size at every diff-options site in libgit2.rs", () => {
+  //
+  // Since #396 the ceiling is a FUNCTION of whether the user waived it, so what
+  // this counts is that every site still goes through that one decision:
+  // `ceiling` (the value the op computed once) or a direct `blob_ceiling(..)`.
+  // A site naming a constant again would be a second policy.
+  it("routes every diff-options site through the one ceiling function", () => {
     const src = read("src-tauri/src/git/libgit2.rs");
-    const caps = src.match(/max_size\(MAX_WORKDIR_BLOB\)/g) ?? [];
-    expect(caps.length).toBe(6);
+    const sites = src.match(/\.max_size\([^)]*\)?\)/g) ?? [];
+    expect(sites.length).toBe(6);
+    for (const site of sites) {
+      expect(site).toMatch(/\.max_size\((ceiling|blob_ceiling\()/);
+    }
+  });
+
+  it("scopes a raised ceiling to the waived paths, at every multi-file diff", () => {
+    const src = read("src-tauri/src/git/libgit2.rs");
+    // A raised ceiling with no pathspec would waive it for EVERY blob in the
+    // diff — so "show me that 40 MB CSV" would also read the 60 MB bundle in
+    // the same commit, which is the footgun a per-file escape hatch exists to
+    // avoid (#396). Every builder that can see more than one delta pairs the
+    // two; `diff` is exempt because it pathspecs its single path already.
+    const scoped = src.match(/scope_to_raised\(&mut \w+, raise_for\)/g) ?? [];
+    expect(scoped.length).toBe(5);
+  });
+
+  it("keeps the override a different ceiling, not the absence of one", () => {
+    // The thing #385 removed was an uncapped diff path. `blob_ceiling` returns
+    // one of two constants, so there is no way to ask for "no limit" — a
+    // regression here would most likely look like an `Option<u64>` straight off
+    // the wire, which is why the wire carries paths instead.
+    const src = read("src-tauri/src/git/libgit2.rs");
+    expect(src).toMatch(/fn blob_ceiling\(raise: bool\) -> i64/);
+    expect(src).toContain("MAX_BLOB_OVERRIDE");
   });
 });


### PR DESCRIPTION
Closes #396.

#385 gave the blob ceiling one policy and an honest answer; what it deliberately left out was any way to say **"yes, really, show me."** The notice named a limit and offered nothing to act on, which is the shape that invites the question.

## The shape

- **The ceiling is a function, not a constant**, at all six `max_size` sites: `blob_ceiling(raise)` returns `MAX_WORKDIR_BLOB` (5 MB) or `MAX_BLOB_OVERRIDE` (64 MB) and nothing else, so there is no spelling of "no limit" to reach for — which is precisely what #385 removed. Over the raised one the delta is `oversized` again, naming the raised limit.
- **Each diff op gains a `*_over_ceiling` sibling** taking `raise_for: &[PathBuf]`. The plain name stays as a one-line trait default forwarding `&[]`, which is what keeps ~57 existing call sites and every Rust test unchanged rather than churning them.
- **The wire carries PATHS, never a size** — one deviation from the issue, deliberately. A frontend copy of the ceiling would be free to drift from the one applied; that is the same mistake `oversized { size, limit }` already exists to avoid, and `oversizedDiffNotice`'s doc comment says so.
- **A raise is a pathspec as well as a limit**, so the multi-file ops run two builds (`with_raised`): libgit2's `max_size` is diff-wide, and waiving one 40 MB blob must not read the 60 MB one beside it. The extra pass costs one tree walk, not one blob read.
- **Blob size is the first wall; line count is the second.** A 40 MB CSV is ~1M `DiffLine`s — a nine-figure JSON payload to parse and a million row objects to lay out. A raised diff caps at `MAX_DIFF_LINES` (100k) and reports `truncated { shown, total }`; `additions`/`deletions` keep counting the whole change. This is the issue's "hard row cap with a labelled truncation".
- **One shared action** (`OversizedDiffAction` / `OversizedDiffEmpty`) on all four surfaces, for the reason the sentence is shared. Per file, per view, never a setting.

## Two things the e2e found that reading the code did not

**1. The waiver has to ride on the ordinary fetch.** My first version had the click fetch the waived path itself and splice in the subset. Every diff surface re-runs its fetch on a status refresh — `CommitPanel`'s dependency list says so on purpose — so the refusal came back *on its own*, seconds after the user's 6.7 MB read landed. Hence the ops answer with the **whole** diff and every fetch passes `raiseFor`; the new spec waits on the refusal *staying* gone.

**2. A #385 gap: the sentence was unreachable.** `MAX_PREVIEW_BYTES` (4 MiB) is **below** the diff ceiling (5 MB), so every over-ceiling blob also comes back `tooLarge` from the image preview — which `isNotablePreview` counts as notable, suppressing the `fallback` the sentence lived in. "File too large to diff" never rendered on any of the four surfaces, for every file it was written for; users saw "Too large to preview" instead. Invisible to the component tests because they mock `read_image_preview` to `null`, and a null preview is not notable. Fixed by giving the oversized branch precedence, with the interaction pinned in `ImageDiffView.test.tsx`.

## Not done, deliberately

A prefix sum over `heights`. `windowVariable` still walks from index 0 and reduces twice per scroll event, so a capped 100k-row diff costs ~O(n) per event — but the cap bounds a waived diff to what the app already renders happily today, so this is a scroll-smoothness improvement for *all* large diffs rather than a precondition for the button. Recorded in `docs/dev/frontend.md`.

Raising `MAX_WORKDIR_BLOB` itself stays out of scope, per the issue.

## Verification

All on the final tree, after the last edit:

- `pnpm test` — **3316 passed** (338 files)
- `cargo test` — **90 test binaries, 0 failures** (incl. new `src-tauri/tests/diff_blob_override.rs`, 8 tests)
- `pnpm test:e2e:docker full` — **31/31 spec files passed** (incl. new `e2e/specs/diff-oversized.e2e.ts`, which drives a real 6.7 MB blob end to end)
- `pnpm tsc --noEmit` and `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — clean

`test/diffOversized.test.ts` grew guards for the new invariants: every surface offers the shared action, puts it ahead of the image preview, hardcodes neither the ceiling nor the line cap, and ships no local copy of the label; all three `CommitDiffPanel` owners wire `onDiffAnyway`; and the backend still routes every `max_size` through the one ceiling function and scopes every multi-file raise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
