### PR TITLE
feat(actions): give a custom action a keyboard shortcut (#225)

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1041,6 +1041,25 @@ that is only partly here — which is the whole reason the notice exists.
   in the diff pane). Register pane handlers as declining (`() => false`) when
   idle, or they swallow the chord. Prefer a second catalog entry over
   overloading one id (`presets.test.ts` enforces the asymmetry).
+- **A chord that is DATA, not a catalog entry, goes through `userBindings`**
+  (#225) — the dispatcher's one seam for a binding the user typed. A custom
+  action has no `ActionId` and must not be given one: that union is closed and
+  `presets.test.ts` checks every member is bound in every preset. So the keymap
+  store takes `chord → { title, run }` and knows nothing about custom actions;
+  `features/actions/useCustomActionChords` (mounted in AppShell, next to the
+  listener) fills it from Settings. **Offered LAST**, after every built-in on
+  that chord has declined, so a setting can never take a key away from the app —
+  the ordering is what makes that true even for a hand-edited file. The cheat
+  sheet renders the table straight from the store, so a chord that fires is a
+  chord that is listed.
+- **Recording a shortcut is a dispatcher MODE (`beginCapture`), not a
+  listener.** The global keydown listener is capture-phase on `window` and is
+  registered first, so nothing registered later — wherever it sits — can stop it:
+  a field with its own listener would record ⌘K *and* commit. While a capture is
+  set, every chord goes to it (`preventDefault` **and** `stopPropagation`) and
+  nothing runs. The stopper only clears its own callback, so a field unmounting
+  late cannot kill the recording that replaced it — a capture nobody clears eats
+  every key in the app.
 - **A pane action sharing a chord with a GLOBAL one makes BINDING ORDER
   load-bearing** (#158): a global with a default runner never declines, so the
   pane entry must come first in the preset table (`COMMON` is spread before the
@@ -1917,6 +1936,48 @@ same rule stated twice:
   lives in `ui-helpers.tsx` for `features/keymap`.
 - The parser stays in Rust. `customActions.ts` fills a context and filters a
   list; it never turns a command string into argv.
+
+### Custom actions: a shortcut is the PALETTE invocation (#225)
+
+- **`boundChord(a)` is the one gate on whether a shortcut is live**
+  (`features/actions/actionChords.ts`), asked by the dispatcher's table, the
+  cheat sheet, the palette chip and the Settings row alike. Three things have to
+  hold, and each is its own kind of wrong:
+  1. **The chord is bindable** — `chordRefusal` in `customActions.ts`. It
+     carries ⌘/Ctrl or is a function key; `Alt` alone does not count (⌥ with a
+     character key TYPES on macOS), and a bare key would fire while arrowing
+     through a file list *and* swallow that letter from the speed-search
+     fallback. Requiring an accelerator is also what lets a custom chord
+     dispatch inside text inputs with no further rule — it cannot type a
+     character, which is the catalog's own reasoning for modifier chords.
+     **`Mod+Alt+<letter>` is refused**: that is AltGr on Windows and Linux, the
+     rule `presets.test.ts` already enforces for shipped bindings — and it bites
+     harder here, because a custom chord runs with the caret in the commit
+     message box.
+  2. **The action is on the palette.** A key press carries no selection, so
+     `$FILE` and `$SHA` — filled by the menu that named a file or a commit —
+     have nothing behind a chord. A shortcut therefore IS the palette
+     invocation, with the repository context, and an action off the palette
+     cannot have one. The stored chord SURVIVES unticking `repo` (parked, not
+     cleared): re-ticking gives it back rather than asking the user to remember
+     what it was.
+  3. **No built-in owns the chord** — checked against the union of ALL presets,
+     not the active one, because presets are switchable and the collision would
+     be silent (the built-in always wins). A chip or a cheat-sheet row
+     advertising a key that does something else is worse than no shortcut.
+- **`coerceCustomActions` keeps a chord it cannot use.** What fires is
+  `boundChord`'s question, asked fresh every time; dropping the value on load
+  would empty the field that displays it. Same reasoning as parking a chord on a
+  surface change.
+- **Settings refuses the collision up front** (`ChordField` +
+  `chordConflict`), naming what already owns the key — a built-in action and its
+  preset, or the other custom action. The dispatcher's ordering makes the app
+  safe; this is what stops the user recording a shortcut that would simply never
+  fire. A refused press KEEPS recording: the next one is the correction.
+- The chord lives on the action, in `customActions`, so it is in the settings
+  file and hand-editable like everything else. `actionChords.ts` is the only
+  half of the feature that imports the keymap — `customActions.ts` stays a list
+  and its validation, and `presets.ts` imports nothing from either.
 
 ## Drag and drop
 

--- a/src/AppShell.tsx
+++ b/src/AppShell.tsx
@@ -38,6 +38,7 @@ import {
   applyRebaseProgress,
   useRepoStore,
 } from "@/features/repo/useRepoStore";
+import { useCustomActionChords } from "@/features/actions/useCustomActionChords";
 import { useFsWatch } from "@/features/repo/useFsWatch";
 import { startAutoFetch } from "@/features/repo/autoFetch";
 import { ActivityStatus } from "@/features/repo/ActivityStatus";
@@ -268,6 +269,11 @@ export function AppShell() {
     window.addEventListener("keydown", onKey, true);
     return () => window.removeEventListener("keydown", onKey, true);
   }, []);
+
+  // The chords that are DATA rather than catalog entries — a user-defined
+  // action's shortcut (#225). Next to the listener that consumes them, and the
+  // only place they are fed in, so the table always matches Settings.
+  useCustomActionChords();
 
   // Check for a newer release shortly after launch — non-blocking, and silent
   // on failure (offline, rate-limited). Manual re-check lives in Settings.

--- a/src/design/context-menu.customActions.test.tsx
+++ b/src/design/context-menu.customActions.test.tsx
@@ -39,6 +39,7 @@ const action = (id: string, surfaces: ActionSurface[]): CustomAction => ({
   showOutput: false,
   refreshAfter: false,
   surfaces,
+  chord: "",
 });
 
 const labels = (items: ContextMenuItem[]) =>

--- a/src/features/actions/ChordField.test.tsx
+++ b/src/features/actions/ChordField.test.tsx
@@ -1,0 +1,219 @@
+// Recording a custom action's shortcut (#225).
+//
+// The dispatcher's half — which chord wins, and that recording eats every key —
+// is tested in `useKeymapStore.userBindings.test.tsx`. What only this field can
+// get wrong is the answer it gives back: a chord it should have refused, a
+// refusal with no reason on screen, or a shortcut stored on an action that can
+// never run it.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { useKeymapStore } from "@/features/keymap/useKeymapStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+
+import { CustomActionsSettings } from "./CustomActionsSettings";
+import { CHORD_IS_ALTGR, CHORD_NEEDS_ACCELERATOR } from "./customActions";
+
+const stored = () => useSettingsStore.getState().customActions;
+
+/** Press a key at the recorder — the dispatcher's job in the real app. */
+const press = (chord: string) =>
+  act(() => {
+    useKeymapStore.getState().capture?.(chord);
+  });
+
+const note = () => screen.getByTestId("custom-action-chord-note").textContent;
+
+beforeEach(() => {
+  localStorage.clear();
+  useSettingsStore.getState().reset();
+  useKeymapStore.setState({ capture: null });
+});
+
+async function startNewAction(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByTestId("custom-action-add"));
+  await user.type(screen.getByTestId("custom-action-name-input"), "Deploy");
+  await user.type(screen.getByTestId("custom-action-command-input"), "deploy $REPO");
+}
+
+describe("recording a shortcut", () => {
+  it("stores the chord it recorded, and saves it with the action", async () => {
+    const user = userEvent.setup();
+    render(<CustomActionsSettings />);
+    await startNewAction(user);
+
+    await user.click(screen.getByTestId("custom-action-chord-record"));
+    expect(useKeymapStore.getState().capture).toBeTypeOf("function");
+    press("Mod+Shift+X");
+    await user.click(screen.getByTestId("custom-action-save"));
+
+    expect(stored()[0].chord).toBe("Mod+Shift+X");
+  });
+
+  it("hands the keyboard back once it has a chord", async () => {
+    const user = userEvent.setup();
+    render(<CustomActionsSettings />);
+    await startNewAction(user);
+    await user.click(screen.getByTestId("custom-action-chord-record"));
+    press("Mod+Shift+X");
+    expect(useKeymapStore.getState().capture).toBe(null);
+  });
+
+  it("cancels on Escape without changing the shortcut", async () => {
+    const user = userEvent.setup();
+    render(<CustomActionsSettings />);
+    await startNewAction(user);
+    await user.click(screen.getByTestId("custom-action-chord-record"));
+    press("Escape");
+
+    expect(useKeymapStore.getState().capture).toBe(null);
+    expect(screen.getByTestId("custom-action-chord-value")).toHaveTextContent(
+      "None",
+    );
+  });
+
+  it("stops when the button is pressed again", async () => {
+    const user = userEvent.setup();
+    render(<CustomActionsSettings />);
+    await startNewAction(user);
+    await user.click(screen.getByTestId("custom-action-chord-record"));
+    await user.click(screen.getByTestId("custom-action-chord-record"));
+    expect(useKeymapStore.getState().capture).toBe(null);
+  });
+
+  it("stops when the field goes away, never leaving a dead capture", async () => {
+    // A capture nobody stops eats every key in the app — so the recorder is
+    // torn down by the effect's own cleanup, not by any exit path remembering.
+    const user = userEvent.setup();
+    const view = render(<CustomActionsSettings />);
+    await startNewAction(user);
+    await user.click(screen.getByTestId("custom-action-chord-record"));
+    view.unmount();
+    expect(useKeymapStore.getState().capture).toBe(null);
+  });
+});
+
+describe("what the field refuses", () => {
+  it("a bare key, saying what a shortcut needs, and keeps recording", async () => {
+    const user = userEvent.setup();
+    render(<CustomActionsSettings />);
+    await startNewAction(user);
+    await user.click(screen.getByTestId("custom-action-chord-record"));
+    press("G");
+
+    expect(note()).toBe(CHORD_NEEDS_ACCELERATOR);
+    // Still listening: the next press is almost certainly the correction.
+    expect(useKeymapStore.getState().capture).toBeTypeOf("function");
+    press("Mod+Shift+X");
+    expect(screen.getByTestId("custom-action-chord-value")).toHaveTextContent(
+      /X/,
+    );
+  });
+
+  it("Mod+Alt+<letter>, because that is AltGr on Windows", async () => {
+    const user = userEvent.setup();
+    render(<CustomActionsSettings />);
+    await startNewAction(user);
+    await user.click(screen.getByTestId("custom-action-chord-record"));
+    press("Mod+Alt+E");
+    expect(note()).toBe(CHORD_IS_ALTGR);
+  });
+
+  it("a chord the app already uses, naming the action that owns it", async () => {
+    const user = userEvent.setup();
+    render(<CustomActionsSettings />);
+    await startNewAction(user);
+    await user.click(screen.getByTestId("custom-action-chord-record"));
+    press("Mod+K");
+
+    // A built-in always wins the key, so the refusal has to happen HERE — a
+    // chord accepted now would simply never fire.
+    expect(note()).toContain("Go to Commit");
+    expect(stored()).toEqual([]);
+  });
+
+  it("a chord another custom action already fires, naming it", async () => {
+    useSettingsStore.getState().set("customActions", [
+      {
+        id: "a1",
+        name: "Sync",
+        command: "sync",
+        showOutput: false,
+        refreshAfter: false,
+        surfaces: ["repo"],
+        chord: "Mod+Shift+X",
+      },
+    ]);
+    const user = userEvent.setup();
+    render(<CustomActionsSettings />);
+    await startNewAction(user);
+    await user.click(screen.getByTestId("custom-action-chord-record"));
+    press("Mod+Shift+X");
+
+    expect(note()).toContain("Sync");
+  });
+});
+
+describe("a shortcut needs the palette", () => {
+  it("is unavailable while the action is off the palette, and says why", async () => {
+    const user = userEvent.setup();
+    render(<CustomActionsSettings />);
+    await startNewAction(user);
+    await user.click(screen.getByTestId("custom-action-surface-repo"));
+
+    expect(screen.getByTestId("custom-action-chord-record")).toBeDisabled();
+    expect(note()).toContain("command palette");
+  });
+
+  it("keeps a recorded chord through a trip off the palette", async () => {
+    // Unticking must not silently discard what the user recorded.
+    const user = userEvent.setup();
+    render(<CustomActionsSettings />);
+    await startNewAction(user);
+    await user.click(screen.getByTestId("custom-action-chord-record"));
+    press("Mod+Shift+X");
+    await user.click(screen.getByTestId("custom-action-surface-repo"));
+    await user.click(screen.getByTestId("custom-action-surface-repo"));
+
+    expect(screen.getByTestId("custom-action-chord-value")).toHaveTextContent(
+      /X/,
+    );
+  });
+});
+
+describe("the saved row", () => {
+  it("shows a shortcut that fires", async () => {
+    useSettingsStore.getState().set("customActions", [
+      {
+        id: "a1",
+        name: "Deploy",
+        command: "deploy",
+        showOutput: false,
+        refreshAfter: false,
+        surfaces: ["repo"],
+        chord: "Mod+Shift+X",
+      },
+    ]);
+    render(<CustomActionsSettings />);
+    expect(screen.getByTestId("custom-action-row-chord")).toBeInTheDocument();
+  });
+
+  it("shows nothing for a shortcut that cannot fire", async () => {
+    // A row advertising a dead shortcut is the surprise to avoid most.
+    useSettingsStore.getState().set("customActions", [
+      {
+        id: "a1",
+        name: "Deploy",
+        command: "deploy",
+        showOutput: false,
+        refreshAfter: false,
+        surfaces: ["file"],
+        chord: "Mod+Shift+X",
+      },
+    ]);
+    render(<CustomActionsSettings />);
+    expect(screen.queryByTestId("custom-action-row-chord")).toBeNull();
+  });
+});

--- a/src/features/actions/ChordField.tsx
+++ b/src/features/actions/ChordField.tsx
@@ -1,0 +1,138 @@
+// Recording a custom action's shortcut (#225).
+//
+// A record-the-key field rather than a text box asking for `"Mod+Shift+G"`: the
+// chord syntax is an internal spelling (`Mod` is ⌘ on macOS and Ctrl
+// everywhere else, letters come from `e.code` so layouts do not matter), and
+// asking a user to type it would be asking them to learn it.
+//
+// The recording itself belongs to the dispatcher — see `beginCapture`. A
+// listener of this component's own could never win: the global one runs in the
+// capture phase on `window` and is registered first, so ⌘K would be recorded
+// AND commit.
+
+import * as React from "react";
+
+import { PGButton } from "@/design";
+import { formatChord } from "@/features/keymap/chord";
+import { useKeymapStore } from "@/features/keymap/useKeymapStore";
+
+import { chordConflict, describeConflict } from "./actionChords";
+import { chordRefusal, showsOn, type CustomAction } from "./customActions";
+
+/** Why the field is unavailable, or null when it is not. */
+function dormantReason(draft: CustomAction): string | null {
+  // A shortcut runs the action the way the palette does, so it needs the
+  // palette. Said here rather than enforced by silently clearing the chord —
+  // the stored value survives, and re-ticking gives it back.
+  return showsOn(draft, "repo")
+    ? null
+    : "A shortcut runs the action from the command palette — tick it to use one.";
+}
+
+export function ChordField({
+  draft,
+  actions,
+  onChange,
+}: {
+  draft: CustomAction;
+  /** The saved list, for detecting a chord another action already took. */
+  actions: readonly CustomAction[];
+  onChange: (next: CustomAction) => void;
+}) {
+  const [recording, setRecording] = React.useState(false);
+  const [refusal, setRefusal] = React.useState<string | null>(null);
+  const dormant = dormantReason(draft);
+  // One line under the row, in priority order: why the last press was refused,
+  // why the field is unavailable, or what to do now.
+  const note =
+    refusal ??
+    dormant ??
+    (recording ? "Press a shortcut, or Esc to cancel." : null);
+
+  // The recorder is torn down by the effect's cleanup, so leaving the editor
+  // mid-recording (Cancel, a re-render that unmounts the row) can never leave
+  // the dispatcher swallowing every key.
+  React.useEffect(() => {
+    if (!recording) return;
+    return useKeymapStore.getState().beginCapture((chord) => {
+      if (chord === "Escape") {
+        setRecording(false);
+        setRefusal(null);
+        return;
+      }
+      const unusable = chordRefusal(chord);
+      if (unusable) {
+        // Keep recording: the next press is almost certainly the correction,
+        // and dropping out of the mode would make the user click again to
+        // make it.
+        setRefusal(unusable);
+        return;
+      }
+      const clash = chordConflict(chord, actions, draft.id);
+      if (clash) {
+        setRefusal(`${formatChord(chord)} — ${describeConflict(clash)}`);
+        return;
+      }
+      onChange({ ...draft, chord });
+      setRefusal(null);
+      setRecording(false);
+    });
+  }, [recording, actions, draft, onChange]);
+
+  return (
+    <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+      <span style={{ fontSize: "var(--fs-11)", color: "var(--fg-3)" }}>
+        Shortcut:
+      </span>
+      <span
+        data-testid="custom-action-chord-value"
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: "var(--fs-11)",
+          color: dormant && draft.chord ? "var(--fg-3)" : "var(--fg-1)",
+          minWidth: 60,
+        }}
+      >
+        {/* Only ever a chord or "None". The recording prompt goes in the note
+            below instead, so this column keeps its width and the buttons beside
+            it do not jump every time the state changes. */}
+        {draft.chord ? formatChord(draft.chord) : "None"}
+      </span>
+      <PGButton
+        size="xs"
+        variant="outline"
+        disabled={!!dormant}
+        onClick={() => {
+          setRefusal(null);
+          setRecording((r) => !r);
+        }}
+        data-testid="custom-action-chord-record"
+      >
+        {/* "Stop", not "Cancel": the editor has a Cancel of its own, and two
+            buttons with one word between them is a coin toss. */}
+        {recording ? "Stop" : draft.chord ? "Change" : "Set shortcut"}
+      </PGButton>
+      {!!draft.chord && !recording && (
+        <PGButton
+          size="xs"
+          variant="ghost"
+          onClick={() => {
+            setRefusal(null);
+            onChange({ ...draft, chord: "" });
+          }}
+          data-testid="custom-action-chord-clear"
+        >
+          Clear
+        </PGButton>
+      )}
+      {note && (
+        <span
+          data-testid="custom-action-chord-note"
+          style={{ fontSize: "var(--fs-11)", color: "var(--fg-3)" }}
+        >
+          {note}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/features/actions/CustomActionsSettings.test.tsx
+++ b/src/features/actions/CustomActionsSettings.test.tsx
@@ -82,6 +82,7 @@ describe("the surface toggles on a custom action", () => {
         showOutput: false,
         refreshAfter: false,
         surfaces: ["file", "commit"],
+        chord: "",
       },
     ]);
     render(<CustomActionsSettings />);

--- a/src/features/actions/CustomActionsSettings.tsx
+++ b/src/features/actions/CustomActionsSettings.tsx
@@ -9,7 +9,11 @@
 import * as React from "react";
 
 import { PGButton, PGInput, PGToggle } from "@/design";
+import { formatChord } from "@/features/keymap/chord";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
+
+import { boundChord } from "./actionChords";
+import { ChordField } from "./ChordField";
 
 import {
   ACTION_SURFACES,
@@ -60,7 +64,11 @@ export function CustomActionsSettings() {
           {PLACEHOLDERS.join(" ")}
         </code>
         . They run in the repository&rsquo;s directory and are never given a
-        token or credential.
+        token or credential. A palette action can also take a keyboard
+        shortcut, which runs it against the repository — a key press names no
+        file or commit, so <code style={{ fontFamily: "var(--font-mono)" }}>$FILE</code>{" "}
+        and <code style={{ fontFamily: "var(--font-mono)" }}>$SHA</code> come
+        from the menus.
       </div>
 
       {actions.length === 0 && !draft && (
@@ -74,6 +82,7 @@ export function CustomActionsSettings() {
           <ActionEditor
             key={a.id}
             draft={draft}
+            actions={actions}
             onChange={setDraft}
             onSave={save}
             onCancel={() => setDraft(null)}
@@ -101,6 +110,21 @@ export function CustomActionsSettings() {
                   list that only shows names cannot answer. */}
               <div style={{ fontSize: "var(--fs-11)", color: "var(--fg-3)" }}>
                 {surfaceSummary(a)}
+                {/* Only a chord that would actually FIRE — `boundChord`, the
+                    same gate the dispatcher asks. A row advertising a shortcut
+                    that does nothing is the surprise this feature has to avoid
+                    most. */}
+                {boundChord(a) && (
+                  <>
+                    {" · "}
+                    <span
+                      style={{ fontFamily: "var(--font-mono)" }}
+                      data-testid="custom-action-row-chord"
+                    >
+                      {formatChord(boundChord(a))}
+                    </span>
+                  </>
+                )}
               </div>
             </div>
             <PGButton
@@ -126,6 +150,7 @@ export function CustomActionsSettings() {
       {draft && !actions.some((a) => a.id === draft.id) && (
         <ActionEditor
           draft={draft}
+          actions={actions}
           onChange={setDraft}
           onSave={save}
           onCancel={() => setDraft(null)}
@@ -151,11 +176,13 @@ export function CustomActionsSettings() {
 
 function ActionEditor({
   draft,
+  actions,
   onChange,
   onSave,
   onCancel,
 }: {
   draft: CustomAction;
+  actions: readonly CustomAction[];
   onChange: (a: CustomAction) => void;
   onSave: () => void;
   onCancel: () => void;
@@ -207,6 +234,7 @@ function ActionEditor({
           />
         ))}
       </div>
+      <ChordField draft={draft} actions={actions} onChange={onChange} />
       <div style={{ display: "flex", gap: 16, alignItems: "center", flexWrap: "wrap" }}>
         <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
           <PGToggle

--- a/src/features/actions/actionChords.ts
+++ b/src/features/actions/actionChords.ts
@@ -1,0 +1,104 @@
+// A custom action's keyboard shortcut (#225) — what fires, and what a chord is
+// not allowed to collide with.
+//
+// Split out of `customActions.ts` because this is the one part of the feature
+// that has to know the KEYMAP: everything else there is a list and its
+// validation. The dependency runs one way — `presets.ts` is plain data and
+// imports nothing from this feature.
+
+import { ACTIONS } from "@/features/keymap/actions";
+import { BUILTIN_PRESETS } from "@/features/keymap/presets";
+
+import {
+  isBindableChord,
+  normalizeChord,
+  showsOn,
+  type CustomAction,
+} from "./customActions";
+
+/** Why a chord cannot be used. */
+export type ChordConflict =
+  | { kind: "builtin"; title: string; preset: string }
+  | { kind: "custom"; name: string };
+
+/**
+ * The built-in action bound to `chord`, in ANY preset.
+ *
+ * Every preset, not just the active one, on purpose: presets are switchable, so
+ * a chord vetted against one alone would start colliding the day its owner
+ * tries the other keymap — and the collision would be silent, because the
+ * built-in wins. Checking the union costs the user a handful of chords and buys
+ * "a shortcut that works keeps working".
+ */
+export function builtinChordOwner(
+  chord: string,
+): { title: string; preset: string } | null {
+  if (!chord) return null;
+  for (const preset of BUILTIN_PRESETS) {
+    for (const [id, chords] of Object.entries(preset.bindings)) {
+      if (chords?.includes(chord)) {
+        return {
+          title: ACTIONS[id as keyof typeof ACTIONS]?.title ?? id,
+          preset: preset.name,
+        };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * The chord that actually fires for `a`, or `""`.
+ *
+ * ONE gate, so the dispatcher, the cheat sheet, the palette chip and the
+ * Settings row can never disagree about whether a shortcut is live. Three
+ * things have to be true:
+ *
+ * 1. **It is a chord a shortcut may take** — `isBindableChord`.
+ * 2. **The action is on the palette.** A shortcut runs the action the way the
+ *    palette runs it, with the repository context, because a key press carries
+ *    no selection: `$FILE` and `$SHA` are filled by the menu that named a file
+ *    or a commit, and there is no such menu behind a chord. The stored value
+ *    survives unticking `repo` rather than being cleared, so re-ticking gives
+ *    the shortcut back instead of asking the user to remember what it was.
+ * 3. **No built-in owns the chord.** The dispatcher offers every catalog
+ *    binding first, so such a chord could never fire — and a palette chip or a
+ *    cheat-sheet row advertising a key that does something else is worse than
+ *    no shortcut at all. Settings refuses to record one; this is what also
+ *    covers a hand-edited settings file.
+ */
+export function boundChord(a: CustomAction): string {
+  const chord = normalizeChord(a.chord);
+  if (!isBindableChord(chord)) return "";
+  if (!showsOn(a, "repo")) return "";
+  return builtinChordOwner(chord) ? "" : chord;
+}
+
+/**
+ * Why `chord` cannot be given to the action `selfId`, or null when it can.
+ *
+ * Says nothing about whether the chord is BINDABLE (`chordRefusal`) — that is a
+ * property of the chord alone and the field asks it separately, so the two
+ * refusals can say different things.
+ */
+export function chordConflict(
+  chord: string,
+  list: readonly CustomAction[],
+  selfId: string,
+): ChordConflict | null {
+  const c = normalizeChord(chord);
+  if (!c) return null;
+  const builtin = builtinChordOwner(c);
+  if (builtin) return { kind: "builtin", ...builtin };
+  // Only against chords that would actually fire: an action whose shortcut is
+  // dormant because it left the palette is not competing for the key.
+  const other = list.find((a) => a.id !== selfId && boundChord(a) === c);
+  return other ? { kind: "custom", name: other.name } : null;
+}
+
+/** The refusal, in prose. */
+export function describeConflict(c: ChordConflict): string {
+  return c.kind === "builtin"
+    ? `${c.preset} already uses this for ${c.title}.`
+    : `${c.name} already uses this.`;
+}

--- a/src/features/actions/chords.test.ts
+++ b/src/features/actions/chords.test.ts
@@ -1,0 +1,216 @@
+// A custom action's keyboard shortcut (#225) — what may be bound, what fires,
+// and what the app refuses to let a chord collide with.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import { DOUBLE_SHIFT } from "@/features/keymap/chord";
+import { RIDER_PRESET } from "@/features/keymap/presets";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+
+import {
+  boundChord,
+  builtinChordOwner,
+  chordConflict,
+  describeConflict,
+} from "./actionChords";
+import {
+  CHORD_IS_ALTGR,
+  CHORD_NEEDS_ACCELERATOR,
+  blankAction,
+  chordRefusal,
+  coerceCustomActions,
+  isBindableChord,
+  normalizeAction,
+  normalizeChord,
+  type CustomAction,
+} from "./customActions";
+import { runAction } from "./runAction";
+import { buildUserBindings } from "./useCustomActionChords";
+
+// The table is a SEAM: what it must get right is which chord maps to which
+// action and when the key is declined — not what running one does, which
+// `runAction` is tested for on its own.
+vi.mock("./runAction", () => ({ runAction: vi.fn(async () => true) }));
+
+const action = (over: Partial<CustomAction> = {}): CustomAction => ({
+  id: "a",
+  name: "Sync worktree",
+  command: "sync $REPO",
+  showOutput: false,
+  refreshAfter: false,
+  surfaces: ["repo"],
+  chord: "",
+  ...over,
+});
+
+// Free in BOTH presets — the union is what `chordConflict` checks.
+const FREE = "Mod+Shift+X";
+
+describe("what may be bound", () => {
+  it("takes a chord carrying the platform accelerator", () => {
+    expect(chordRefusal("Mod+Shift+X")).toBe(null);
+    expect(chordRefusal("Ctrl+Shift+X")).toBe(null);
+    expect(isBindableChord("Mod+G")).toBe(true);
+  });
+
+  it("takes a function key on its own — nothing types one", () => {
+    expect(chordRefusal("F6")).toBe(null);
+    expect(chordRefusal("Shift+F6")).toBe(null);
+    expect(chordRefusal("F13")).toBe(CHORD_NEEDS_ACCELERATOR);
+  });
+
+  it("refuses a bare key: it would fire while arrowing through a list", () => {
+    expect(chordRefusal("G")).toBe(CHORD_NEEDS_ACCELERATOR);
+    expect(chordRefusal("Shift+G")).toBe(CHORD_NEEDS_ACCELERATOR);
+    expect(chordRefusal("ArrowDown")).toBe(CHORD_NEEDS_ACCELERATOR);
+  });
+
+  it("refuses Alt alone — ⌥ with a character key TYPES on macOS", () => {
+    expect(chordRefusal("Alt+E")).toBe(CHORD_NEEDS_ACCELERATOR);
+  });
+
+  it("refuses Mod+Alt+<letter>: that is AltGr on Windows", () => {
+    // The rule presets.test.ts already enforces for shipped bindings. It
+    // matters MORE here: a custom chord runs with the caret in a text field,
+    // so ⌘⌥E would fire every time a Norwegian keyboard asks for €.
+    expect(chordRefusal("Mod+Alt+E")).toBe(CHORD_IS_ALTGR);
+    expect(chordRefusal("Ctrl+Alt+E")).toBe(CHORD_IS_ALTGR);
+    // Not a letter — no AltGr sequence produces it, so it stays available.
+    expect(chordRefusal("Mod+Alt+ArrowUp")).toBe(null);
+  });
+
+  it("refuses DoubleShift — the palette's own chord, in both presets", () => {
+    expect(isBindableChord(DOUBLE_SHIFT)).toBe(false);
+  });
+
+  it("reads a missing or non-string chord as unbound", () => {
+    expect(normalizeChord(undefined)).toBe("");
+    expect(normalizeChord(42)).toBe("");
+    expect(normalizeChord("  Mod+Shift+X  ")).toBe("Mod+Shift+X");
+    expect(blankAction().chord).toBe("");
+  });
+});
+
+describe("what actually fires", () => {
+  it("is the stored chord when the action is on the palette", () => {
+    expect(boundChord(action({ chord: FREE }))).toBe(FREE);
+  });
+
+  it("is nothing when the chord could never be recorded", () => {
+    expect(boundChord(action({ chord: "G" }))).toBe("");
+  });
+
+  it("is nothing off the palette — a key press names no file or commit", () => {
+    // `$FILE` and `$SHA` are filled by the menu that named them; a chord has no
+    // such menu, so a shortcut is the PALETTE invocation and needs the palette.
+    const menuOnly = action({ chord: FREE, surfaces: ["file"] });
+    expect(boundChord(menuOnly)).toBe("");
+  });
+
+  it("keeps the stored chord through a surface change rather than clearing it", () => {
+    // Unticking the palette must not lose what the user recorded — re-ticking
+    // gives the shortcut back instead of asking them to remember it.
+    const parked = normalizeAction(action({ chord: FREE, surfaces: ["file"] }));
+    expect(parked.chord).toBe(FREE);
+    expect(boundChord({ ...parked, surfaces: ["repo"] })).toBe(FREE);
+  });
+
+  it("is nothing when a built-in owns the chord", () => {
+    // The dispatcher offers every catalog binding first, so this could never
+    // fire — and a palette chip advertising ⌘K would be advertising Go to
+    // Commit.
+    expect(boundChord(action({ chord: "Mod+K" }))).toBe("");
+  });
+});
+
+describe("coercion", () => {
+  it("reads an action stored before shortcuts existed", () => {
+    const legacy = { ...action(), chord: undefined } as unknown as CustomAction;
+    expect(coerceCustomActions([legacy])?.[0].chord).toBe("");
+  });
+
+  it("keeps a stored chord that cannot fire instead of dropping it", () => {
+    // What FIRES is `boundChord`'s question, asked fresh. Dropping the value
+    // here would empty the field that shows it.
+    const list = coerceCustomActions([{ ...action(), chord: "Mod+K" }]);
+    expect(list?.[0].chord).toBe("Mod+K");
+    expect(boundChord(list![0])).toBe("");
+  });
+});
+
+describe("collisions", () => {
+  it("names the built-in that already owns a chord", () => {
+    const owner = builtinChordOwner("Mod+K");
+    expect(owner?.title).toBe("Go to Commit");
+    expect(owner?.preset).toBe(RIDER_PRESET.name);
+    expect(builtinChordOwner(FREE)).toBe(null);
+  });
+
+  it("checks EVERY preset, not just the active one", () => {
+    // Ctrl+V is the palette in rider only. Vetting against one preset alone
+    // would hand it out, and it would go silently dead the day its owner
+    // switched keymaps — the built-in always wins.
+    expect(builtinChordOwner("Ctrl+V")).not.toBe(null);
+    // ...and the other direction: a chord only the platypusgit preset binds.
+    expect(builtinChordOwner("Mod+3")).not.toBe(null);
+  });
+
+  it("refuses a chord another custom action already fires", () => {
+    const list = [action({ id: "other", name: "Deploy", chord: FREE })];
+    const clash = chordConflict(FREE, list, "mine");
+    expect(clash).toEqual({ kind: "custom", name: "Deploy" });
+    expect(describeConflict(clash!)).toContain("Deploy");
+  });
+
+  it("does not count an action's own chord against it", () => {
+    const list = [action({ id: "mine", chord: FREE })];
+    expect(chordConflict(FREE, list, "mine")).toBe(null);
+  });
+
+  it("does not count a chord that cannot fire anyway", () => {
+    // Parked off the palette: it is not competing for the key.
+    const list = [action({ id: "other", chord: FREE, surfaces: ["file"] })];
+    expect(chordConflict(FREE, list, "mine")).toBe(null);
+  });
+});
+
+describe("the dispatcher's table", () => {
+  beforeEach(() => {
+    vi.mocked(runAction).mockClear();
+    useRepoStore.setState({ current: null });
+  });
+
+  it("holds only chords that fire", () => {
+    const map = buildUserBindings([
+      action({ id: "a", name: "Live", chord: FREE }),
+      action({ id: "b", name: "No chord" }),
+      action({ id: "c", name: "Parked", chord: "F6", surfaces: ["file"] }),
+    ]);
+    expect([...map.keys()]).toEqual([FREE]);
+    expect(map.get(FREE)?.title).toBe("Live");
+  });
+
+  it("gives a duplicated chord to the first claimant", () => {
+    // Only reachable from a hand-edited file — the editor refuses the second.
+    const map = buildUserBindings([
+      action({ id: "a", name: "First", chord: FREE }),
+      action({ id: "b", name: "Second", chord: FREE }),
+    ]);
+    expect(map.get(FREE)?.title).toBe("First");
+  });
+
+  it("declines with no repository open, so the key falls through", () => {
+    const map = buildUserBindings([action({ chord: FREE })]);
+    expect(map.get(FREE)?.run()).toBe(false);
+  });
+
+  it("claims the key and runs the action when there is a repository", () => {
+    useRepoStore.setState({
+      current: { id: "r1", path: "/tmp/r", name: "r" },
+    } as unknown as Parameters<typeof useRepoStore.setState>[0]);
+    const bound = action({ chord: FREE });
+    const map = buildUserBindings([bound]);
+    expect(map.get(FREE)?.run()).toBe(true);
+    expect(runAction).toHaveBeenCalledWith(bound);
+  });
+});

--- a/src/features/actions/customActions.test.ts
+++ b/src/features/actions/customActions.test.ts
@@ -31,6 +31,7 @@ const action = (over: Partial<CustomAction> = {}): CustomAction => ({
   showOutput: false,
   refreshAfter: true,
   surfaces: ["repo"],
+  chord: "",
   ...over,
 });
 

--- a/src/features/actions/customActions.ts
+++ b/src/features/actions/customActions.ts
@@ -9,6 +9,7 @@
 // This file is the list, its validation, WHERE each action shows up
 // (`ActionSurface`), and the `ActionContext` each surface hands it.
 
+import { DOUBLE_SHIFT } from "@/features/keymap/chord";
 import type { ActionContext } from "@/lib/types";
 
 /**
@@ -62,6 +63,12 @@ export interface CustomAction {
    * `normalizeSurfaces` and `isSavableAction`.
    */
   surfaces: ActionSurface[];
+  /**
+   * Its keyboard shortcut, in the keymap's own chord syntax
+   * (`"Mod+Shift+G"`, `"F6"`), or `""` for none. See `boundChord` for when a
+   * stored chord actually fires.
+   */
+  chord: string;
 }
 
 /** The placeholders the backend substitutes, for the Settings hint. */
@@ -82,8 +89,71 @@ export function blankAction(): CustomAction {
     showOutput: true,
     refreshAfter: true,
     surfaces: [...DEFAULT_SURFACES],
+    chord: "",
   };
 }
+
+/** Function keys, which are bindable on their own — nothing types one. */
+const FUNCTION_KEY = /^F(?:[1-9]|1[0-2])$/;
+
+/** Said when a chord carries nothing that stops it typing a character. */
+export const CHORD_NEEDS_ACCELERATOR =
+  "A shortcut needs ⌘ or Ctrl, or a function key.";
+
+/** Said for the one modifier combination a keyboard produces by itself. */
+export const CHORD_IS_ALTGR =
+  "Ctrl+Alt with a letter is AltGr on Windows — it would fire while typing.";
+
+/**
+ * Why `chord` cannot be a user-defined action's shortcut, or null when it can.
+ *
+ * Two rules, both about a shortcut that must not go off by itself:
+ *
+ * 1. **It carries ⌘/Ctrl, or it is a function key.** A bare `G` would fire
+ *    while arrowing through a file list and would swallow that letter from the
+ *    speed-search fallback — the dispatcher suppresses bare chords inside text
+ *    inputs, but a list is not a text input, and "typing in a list stopped
+ *    working" is not a bug anyone would trace back to Settings. `Alt` alone
+ *    does not count: on macOS ⌥ with a character key TYPES a character (⌥E is a
+ *    dead key), so the chord would fight the caret in exactly the commit
+ *    message box. This is also what lets a custom chord dispatch inside inputs
+ *    with no further rule, the same reasoning the catalog's modifier chords
+ *    already run on.
+ * 2. **Not ⌘/Ctrl+Alt+letter.** That is AltGr on Windows and Linux, so
+ *    `Mod+Alt+E` is what a Norwegian keyboard sends for `€`. `presets.test.ts`
+ *    fails the build for a preset that adds one; a chord the user records is
+ *    the same hazard, made worse by the fact that a custom chord runs with the
+ *    caret in a text field.
+ *
+ * `DoubleShift` falls to rule 1, which is the right answer twice over: it is
+ * the palette's chord in both presets, and every custom action is IN the
+ * palette.
+ */
+export function chordRefusal(chord: string): string | null {
+  if (!chord || chord === DOUBLE_SHIFT) return CHORD_NEEDS_ACCELERATOR;
+  const segs = chord.split("+");
+  const base = segs[segs.length - 1];
+  const mods = segs.slice(0, -1);
+  if (FUNCTION_KEY.test(base)) return null;
+  if (!mods.includes("Mod") && !mods.includes("Ctrl")) {
+    return CHORD_NEEDS_ACCELERATOR;
+  }
+  if (mods.includes("Alt") && /^[A-Za-z]$/.test(base)) return CHORD_IS_ALTGR;
+  return null;
+}
+
+/** Whether `chord` is one a user-defined action may take. */
+export function isBindableChord(chord: string): boolean {
+  return chordRefusal(chord) === null;
+}
+
+/** Coerce a stored or hand-edited chord. Anything unusable reads as unbound. */
+export function normalizeChord(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+// Whether a stored chord actually FIRES is `boundChord`, in `actionChords.ts`
+// — it has to know the keymap, and this file deliberately does not.
 
 /**
  * Coerce a stored or hand-edited surface list into a usable one.
@@ -111,6 +181,7 @@ export function normalizeAction(a: CustomAction): CustomAction {
     name: a.name.trim(),
     command: a.command.trim(),
     surfaces: normalizeSurfaces(a.surfaces),
+    chord: normalizeChord(a.chord),
   };
 }
 
@@ -168,6 +239,11 @@ export function coerceCustomActions(value: unknown): CustomAction[] | null {
         showOutput: o.showOutput !== false,
         refreshAfter: o.refreshAfter !== false,
         surfaces: surfaces.length ? surfaces : [...DEFAULT_SURFACES],
+        // Kept as written even when it is unbindable or already taken: what
+        // FIRES is `boundChord`'s question, asked fresh every time, and
+        // silently dropping a chord here would lose the value the user typed
+        // while leaving the field that shows it empty. #225.
+        chord: normalizeChord(o.chord),
       }),
     );
   }

--- a/src/features/actions/useCustomActionChords.ts
+++ b/src/features/actions/useCustomActionChords.ts
@@ -1,0 +1,62 @@
+// Custom actions on the keyboard (#225) — the wiring between the settings list
+// and the dispatcher.
+//
+// The dependency runs actions → keymap, like every other feature: the keymap
+// store exposes a table of chords that are data (`UserBinding`) and knows
+// nothing about custom actions; this file is what fills it.
+
+import * as React from "react";
+
+import {
+  useKeymapStore,
+  type UserBinding,
+} from "@/features/keymap/useKeymapStore";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useSettingsStore } from "@/features/settings/useSettingsStore";
+
+import { boundChord } from "./actionChords";
+import { type CustomAction } from "./customActions";
+import { runAction } from "./runAction";
+
+/**
+ * The chord table for `list`.
+ *
+ * Only chords that would actually fire (`boundChord`), and the first action to
+ * claim one keeps it — the editor refuses a duplicate, so a second can only
+ * come from a hand-edited file, and one action running is a better answer than
+ * two or an arbitrary one.
+ */
+export function buildUserBindings(
+  list: readonly CustomAction[],
+): Map<string, UserBinding> {
+  const map = new Map<string, UserBinding>();
+  for (const action of list) {
+    const chord = boundChord(action);
+    if (!chord || map.has(chord)) continue;
+    map.set(chord, {
+      title: action.name,
+      run: () => {
+        // The same guard `runAction` makes, asked synchronously so the chord
+        // can DECLINE: every placeholder is about an open repository, and a
+        // dispatcher that swallowed the key here would leave it doing nothing
+        // instead of falling through.
+        if (!useRepoStore.getState().current) return false;
+        void runAction(action);
+        return true;
+      },
+    });
+  }
+  return map;
+}
+
+/**
+ * Keep the dispatcher's user bindings in step with Settings.
+ *
+ * Mounted once, in `AppShell`, next to the global keydown listener it feeds.
+ */
+export function useCustomActionChords(): void {
+  const actions = useSettingsStore((s) => s.customActions);
+  React.useEffect(() => {
+    useKeymapStore.getState().setUserBindings(buildUserBindings(actions));
+  }, [actions]);
+}

--- a/src/features/keymap/CheatSheet.test.tsx
+++ b/src/features/keymap/CheatSheet.test.tsx
@@ -8,6 +8,7 @@ import { useKeymapStore } from "./useKeymapStore";
 describe("CheatSheet", () => {
   beforeEach(() => {
     useKeymapStore.getState().setPreset("rider");
+    useKeymapStore.setState({ userBindings: new Map() });
   });
 
   it("renders nothing when closed", () => {
@@ -28,5 +29,26 @@ describe("CheatSheet", () => {
     useOverlayStore.setState({ cheatSheetOpen: true });
     render(<CheatSheet />);
     expect(screen.getByText(/Rider/)).toBeTruthy();
+  });
+
+  // User-defined shortcuts (#225) are rendered from the dispatcher's OWN table,
+  // so a chord that fires is a chord the sheet lists — the same reason the rest
+  // of the sheet is derived from the catalog and the preset.
+  it("lists a custom action's shortcut", () => {
+    useOverlayStore.setState({ cheatSheetOpen: true });
+    useKeymapStore.setState({
+      userBindings: new Map([
+        ["Mod+Shift+X", { title: "Deploy", run: () => true }],
+      ]),
+    });
+    render(<CheatSheet />);
+    expect(screen.getByTestId("cheat-sheet-custom")).toBeTruthy();
+    expect(screen.getByText("Deploy")).toBeTruthy();
+  });
+
+  it("has no custom section when nothing is bound", () => {
+    useOverlayStore.setState({ cheatSheetOpen: true });
+    render(<CheatSheet />);
+    expect(screen.queryByTestId("cheat-sheet-custom")).toBeNull();
   });
 });

--- a/src/features/keymap/CheatSheet.tsx
+++ b/src/features/keymap/CheatSheet.tsx
@@ -28,10 +28,40 @@ function formatBindings(chords: string[]): string {
   return chords.map((c) => formatChord(c)).join(" / ");
 }
 
+/** One reference row. Shared so a custom action's row cannot drift from a
+ *  built-in one — they are the same thing to the person reading the sheet. */
+function Row({ title, keys }: { title: string; keys: string }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        gap: 24,
+        padding: "3px 0",
+      }}
+    >
+      <span>{title}</span>
+      <span
+        style={{
+          color: "var(--fg-1)",
+          fontFamily: "var(--font-mono, monospace)",
+        }}
+      >
+        {keys}
+      </span>
+    </div>
+  );
+}
+
 export function CheatSheet() {
   const open = useOverlayStore((s) => s.cheatSheetOpen);
   const close = useOverlayStore((s) => s.closeCheatSheet);
   const presetId = useKeymapStore((s) => s.activePresetId);
+  // User-defined shortcuts (#225) belong on the same sheet as everything else —
+  // straight from the dispatcher's own table, so a chord that fires is a chord
+  // that is listed. They are not catalog actions and have no preset binding, so
+  // they get their own section rather than a category.
+  const userBindings = useKeymapStore((s) => s.userBindings);
   if (!open) return null;
   const preset = presetById(presetId);
 
@@ -93,29 +123,33 @@ export function CheatSheet() {
                 {cat}
               </div>
               {ids.map((id) => (
-                <div
+                <Row
                   key={id}
-                  style={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    gap: 24,
-                    padding: "3px 0",
-                  }}
-                >
-                  <span>{ACTIONS[id].title}</span>
-                  <span
-                    style={{
-                      color: "var(--fg-1)",
-                      fontFamily: "var(--font-mono, monospace)",
-                    }}
-                  >
-                    {formatBindings(preset.bindings[id] ?? [])}
-                  </span>
-                </div>
+                  title={ACTIONS[id].title}
+                  keys={formatBindings(preset.bindings[id] ?? [])}
+                />
               ))}
             </div>
           );
         })}
+        {userBindings.size > 0 && (
+          <div style={{ marginBottom: 16 }} data-testid="cheat-sheet-custom">
+            <div
+              style={{
+                color: "var(--fg-2)",
+                fontSize: 11,
+                letterSpacing: ".05em",
+                textTransform: "uppercase",
+                marginBottom: 6,
+              }}
+            >
+              Custom actions
+            </div>
+            {[...userBindings].map(([chord, binding]) => (
+              <Row key={chord} title={binding.title} keys={formatChord(chord)} />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/features/keymap/useKeymapStore.ts
+++ b/src/features/keymap/useKeymapStore.ts
@@ -89,6 +89,23 @@ interface HandlerEntry {
   paneIds?: readonly string[];
 }
 
+/**
+ * A chord that is DATA rather than a catalog entry — today, a user-defined
+ * action's shortcut (#225).
+ *
+ * The seam exists because a custom action has no `ActionId` and cannot be given
+ * one: `ActionId` is a closed union that `presets.test.ts` checks is bound in
+ * every preset, and a value the user typed in Settings has no business in it.
+ * So the keymap keeps taking chords as data, and the feature that owns the
+ * actions fills this in (`features/actions/useCustomActionChords`).
+ */
+export interface UserBinding {
+  /** What it is called — the cheat sheet renders from this, so it stays live. */
+  title: string;
+  /** Returns `false` to decline, exactly like a catalog runner. */
+  run: () => boolean | void;
+}
+
 export interface RegisterOpts {
   /** One pane, or several — a screen whose chord answers from any of the panes
    *  it owns (F7 hunk nav from either the file list or the diff view) needs ONE
@@ -109,7 +126,23 @@ interface KeymapState {
   lastShiftAt: number;
   /** Panes that opted into speed-search (usePaneList with searchText). */
   speedPanes: Set<string>;
+  /** Chord → user-defined binding. Offered after every built-in; see `dispatch`. */
+  userBindings: ReadonlyMap<string, UserBinding>;
+  /** While set, EVERY chord goes here instead of running — shortcut recording. */
+  capture: ((chord: string) => void) | null;
   setPreset: (id: string) => void;
+  /** Replace the whole user-binding table (the owner rebuilds it wholesale). */
+  setUserBindings: (bindings: ReadonlyMap<string, UserBinding>) => void;
+  /**
+   * Route the next chords to `fn` instead of running them; returns the stopper.
+   *
+   * Recording a shortcut cannot be done with a listener of its own: the global
+   * dispatcher runs in the CAPTURE phase on `window` and is registered first,
+   * so a later listener — wherever it sits — never gets to stop it. The field
+   * would record ⌘K and commit at the same time. So the dispatcher itself holds
+   * the mode.
+   */
+  beginCapture: (fn: (chord: string) => void) => () => void;
   register: (
     id: ActionId,
     handler: ActionHandler,
@@ -147,6 +180,24 @@ export const useKeymapStore = create<KeymapState>((set, get) => {
     return eventToChord(e);
   }
 
+  /**
+   * Run the user-defined binding for `chord`, if there is one (#225).
+   *
+   * No text-input rule of its own, deliberately: a bindable user chord always
+   * carries a real modifier or is a function key (`isBindableChord`), so it
+   * cannot type a character, which is the same reason the catalog's modifier
+   * chords already dispatch with the caret in a field.
+   *
+   * The terminal check is NOT the same kind of rule and is kept: in there the
+   * shell owns the keyboard, and a user command is not one of the two escapes.
+   */
+  function runUserBinding(chord: string, e: KeyboardEvent): boolean {
+    const binding = get().userBindings.get(chord);
+    if (!binding) return false;
+    if (inTerminal(e.target)) return false;
+    return binding.run() !== false;
+  }
+
   // Speed-search fallback: a keydown no binding claimed, carrying a single
   // printable character (or Backspace) without Mod/Ctrl/Alt, aimed at a
   // non-editable target, feeds the focused pane's query when that pane opted
@@ -174,6 +225,22 @@ export const useKeymapStore = create<KeymapState>((set, get) => {
     handlers: new Map(),
     lastShiftAt: 0,
     speedPanes: new Set(),
+    userBindings: new Map(),
+    capture: null,
+
+    setUserBindings(bindings) {
+      set({ userBindings: bindings });
+    },
+
+    beginCapture(fn) {
+      set({ capture: fn });
+      return () => {
+        // Only clear our own: two fields cannot record at once, but a stale
+        // stopper firing after the next one started would leave the app with a
+        // dead capture that eats every key.
+        if (get().capture === fn) set({ capture: null });
+      };
+    },
 
     setPreset(id) {
       try {
@@ -215,8 +282,26 @@ export const useKeymapStore = create<KeymapState>((set, get) => {
     dispatch(e) {
       const chord = resolveChord(e);
       if (!chord) return false;
+
+      // Recording a shortcut owns the keyboard outright — before any binding is
+      // consulted, or the chord being recorded would also RUN. `stopPropagation`
+      // as well as `preventDefault`: this listener is on `window` in the capture
+      // phase, so stopping here is what keeps the key out of the field's own
+      // input and out of every handler beneath it.
+      const capture = get().capture;
+      if (capture) {
+        e.preventDefault();
+        e.stopPropagation();
+        capture(chord);
+        return true;
+      }
+
       const ids = get().reverse.get(chord);
       if (!ids || ids.length === 0) {
+        if (runUserBinding(chord, e)) {
+          e.preventDefault();
+          return true;
+        }
         if (speedFallback(e)) {
           e.preventDefault();
           return true;
@@ -263,6 +348,15 @@ export const useKeymapStore = create<KeymapState>((set, get) => {
           e.preventDefault();
           return true;
         }
+      }
+
+      // A user-defined shortcut is offered LAST, once every built-in bound to
+      // this chord has declined. A setting can never shadow one of the app's
+      // own shortcuts — Settings refuses such a chord up front, and this is what
+      // makes that true even for a hand-edited file.
+      if (runUserBinding(chord, e)) {
+        e.preventDefault();
+        return true;
       }
       return false;
     },

--- a/src/features/keymap/useKeymapStore.userBindings.test.tsx
+++ b/src/features/keymap/useKeymapStore.userBindings.test.tsx
@@ -1,0 +1,188 @@
+// Chords that are DATA rather than catalog entries (#225) — a user-defined
+// action's shortcut — and the recording mode the Settings field runs on.
+//
+// The property these tests exist for: a setting can never take a key away from
+// the app. Settings refuses such a chord up front; this is the half that holds
+// even for a hand-edited file.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { useNavStore } from "@/features/nav/useNavStore";
+import { useTabsStore } from "@/features/repo/useTabsStore";
+
+import { useFocusStore } from "./useFocusStore";
+import { useKeymapStore, type UserBinding } from "./useKeymapStore";
+
+const key = (
+  over: Partial<KeyboardEvent>,
+  target: EventTarget = document.body,
+) =>
+  ({
+    key: "x",
+    code: "KeyX",
+    metaKey: true,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: true,
+    preventDefault() {},
+    stopPropagation() {},
+    target,
+    ...over,
+  }) as unknown as KeyboardEvent;
+
+const bind = (chord: string, run: UserBinding["run"], title = "Deploy") =>
+  useKeymapStore.getState().setUserBindings(new Map([[chord, { title, run }]]));
+
+beforeEach(() => {
+  useKeymapStore.setState({
+    handlers: new Map(),
+    lastShiftAt: 0,
+    userBindings: new Map(),
+    capture: null,
+  });
+  useKeymapStore.getState().setPreset("rider");
+  useFocusStore.setState({
+    focused: null,
+    panes: new Map(),
+    order: [],
+    barId: null,
+    pendingContentFocus: false,
+  });
+  useNavStore.setState({ intent: null });
+  useTabsStore.setState({ tabs: [], activePath: null });
+});
+
+describe("a user-defined shortcut", () => {
+  it("fires for its chord", () => {
+    const run = vi.fn();
+    bind("Mod+Shift+X", run);
+    expect(useKeymapStore.getState().dispatch(key({}))).toBe(true);
+    expect(run).toHaveBeenCalledOnce();
+  });
+
+  it("prevents the default, so the webview never sees the key", () => {
+    const preventDefault = vi.fn();
+    bind("Mod+Shift+X", () => true);
+    useKeymapStore.getState().dispatch(key({ preventDefault }));
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
+
+  it("fires with the caret in a text field", () => {
+    // No input rule of its own is needed: a bindable user chord always carries
+    // ⌘/Ctrl or is a function key, so it cannot type a character — the same
+    // reasoning the catalog's modifier chords already run on.
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    const run = vi.fn();
+    bind("Mod+Shift+X", run);
+    useKeymapStore.getState().dispatch(key({}, input));
+    expect(run).toHaveBeenCalledOnce();
+    input.remove();
+  });
+
+  it("declines when its runner does, leaving the key to the browser", () => {
+    bind("Mod+Shift+X", () => false);
+    expect(useKeymapStore.getState().dispatch(key({}))).toBe(false);
+  });
+
+  it("never fires inside the built-in terminal — the shell owns those keys", () => {
+    const term = document.createElement("div");
+    term.setAttribute("data-testid", "terminal-view");
+    const child = document.createElement("textarea");
+    term.appendChild(child);
+    document.body.appendChild(term);
+    const run = vi.fn();
+    bind("Mod+Shift+X", run);
+    expect(useKeymapStore.getState().dispatch(key({}, child))).toBe(false);
+    expect(run).not.toHaveBeenCalled();
+    term.remove();
+  });
+});
+
+describe("a user-defined shortcut never shadows a built-in", () => {
+  it("loses the chord to the catalog action bound to it", () => {
+    const run = vi.fn();
+    bind("Mod+K", run);
+    // ⌘K is Go to Commit in the rider preset.
+    const handled = useKeymapStore
+      .getState()
+      .dispatch(key({ key: "k", code: "KeyK", shiftKey: false }));
+    expect(handled).toBe(true);
+    expect(useNavStore.getState().intent).toEqual({
+      kind: "switch-screen",
+      screen: "commit",
+    });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("gets the chord only once every built-in on it has declined", () => {
+    // ⌘Tab is tab.next, which declines with fewer than two tabs open. The user
+    // binding is offered after that refusal, not before it.
+    const run = vi.fn();
+    bind("Mod+Tab", run);
+    const handled = useKeymapStore
+      .getState()
+      .dispatch(key({ key: "Tab", code: "Tab", shiftKey: false }));
+    expect(handled).toBe(true);
+    expect(run).toHaveBeenCalledOnce();
+  });
+});
+
+describe("recording a shortcut", () => {
+  it("takes every chord instead of running it", () => {
+    const seen: string[] = [];
+    const run = vi.fn();
+    bind("Mod+Shift+X", run);
+    useKeymapStore.getState().beginCapture((c) => seen.push(c));
+
+    // A chord that IS bound, and one that could never be: recording sees both,
+    // which is what lets the field refuse a bare key by name.
+    useKeymapStore.getState().dispatch(key({}));
+    useKeymapStore.getState().dispatch(
+      key({ key: "g", code: "KeyG", metaKey: false, shiftKey: false }),
+    );
+
+    expect(seen).toEqual(["Mod+Shift+X", "G"]);
+    expect(run).not.toHaveBeenCalled();
+    expect(useNavStore.getState().intent).toBe(null);
+  });
+
+  it("stops the event as well as preventing it", () => {
+    // The dispatcher listens on `window` in the CAPTURE phase and is registered
+    // first, so stopping here is the only thing that keeps the recorded key out
+    // of the field's own input and every handler beneath it.
+    const stopPropagation = vi.fn();
+    const preventDefault = vi.fn();
+    useKeymapStore.getState().beginCapture(() => {});
+    useKeymapStore.getState().dispatch(key({ stopPropagation, preventDefault }));
+    expect(stopPropagation).toHaveBeenCalledOnce();
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
+
+  it("ignores a lone modifier — it is not a chord", () => {
+    const seen: string[] = [];
+    useKeymapStore.getState().beginCapture((c) => seen.push(c));
+    useKeymapStore.getState().dispatch(key({ key: "Shift", code: "ShiftLeft" }));
+    expect(seen).toEqual([]);
+  });
+
+  it("hands the keyboard back when it stops", () => {
+    const stop = useKeymapStore.getState().beginCapture(() => {});
+    stop();
+    expect(useKeymapStore.getState().capture).toBe(null);
+    const run = vi.fn();
+    bind("Mod+Shift+X", run);
+    useKeymapStore.getState().dispatch(key({}));
+    expect(run).toHaveBeenCalledOnce();
+  });
+
+  it("a stale stopper cannot cancel the recording that replaced it", () => {
+    // Otherwise a field unmounting late would leave the app eating every key.
+    const stopFirst = useKeymapStore.getState().beginCapture(() => {});
+    const second = vi.fn();
+    useKeymapStore.getState().beginCapture(second);
+    stopFirst();
+    useKeymapStore.getState().dispatch(key({}));
+    expect(second).toHaveBeenCalledWith("Mod+Shift+X");
+  });
+});

--- a/src/features/palette/CommandPalette.tsx
+++ b/src/features/palette/CommandPalette.tsx
@@ -4,7 +4,7 @@ import { PGIcon, PGSearchInput } from "@/design";
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useNavStore } from "@/features/nav/useNavStore";
 import { usePaletteStore } from "./usePaletteStore";
-import { chordFor, useKeymapStore } from "@/features/keymap";
+import { chordFor, formatChord, useKeymapStore } from "@/features/keymap";
 import { branchItems, buildCommands, commitItems, fileItems } from "./commands";
 import { fuzzyMatch } from "./fuzzyMatch";
 import { frecencyScore, bumpFrecency, loadFrecency, recentIds } from "./frecency";
@@ -309,7 +309,11 @@ export function CommandPalette() {
   const renderRow = (row: ScoredRow, flatIndex: number) => {
     const { item, labelIndices } = row;
     const active = flatIndex === activeIndex;
-    const chord = item.actionId ? chordFor(item.actionId) : "";
+    const chord = item.chord
+      ? formatChord(item.chord)
+      : item.actionId
+        ? chordFor(item.actionId)
+        : "";
     return (
       <div
         key={item.id}

--- a/src/features/palette/commands.test.ts
+++ b/src/features/palette/commands.test.ts
@@ -89,6 +89,32 @@ describe("buildCommands", () => {
     expect(byId.get("action:refresh")?.actionId).toBe("repo.refresh");
   });
 
+  it("gives a custom action's row its own chord chip (#225)", async () => {
+    // A user-defined shortcut is a value in Settings, not a preset binding, so
+    // the row carries the chord itself — through `boundChord`, the same gate
+    // the dispatcher asks, so the chip cannot advertise a dead key.
+    const { useSettingsStore } = await import(
+      "@/features/settings/useSettingsStore"
+    );
+    useSettingsStore.setState({ customActions: [
+      {
+        id: "a1", name: "Deploy", command: "deploy $REPO",
+        showOutput: false, refreshAfter: false, surfaces: ["repo"],
+        chord: "Mod+Shift+X",
+      },
+      {
+        id: "a2", name: "Parked", command: "parked $REPO",
+        showOutput: false, refreshAfter: false, surfaces: ["repo"],
+        chord: "Mod+K",
+      },
+    ] });
+    const byId = new Map(buildCommands().map((i) => [i.id, i]));
+    expect(byId.get("custom-action:a1")?.chord).toBe("Mod+Shift+X");
+    // ⌘K belongs to the catalog; the chip must not claim it.
+    expect(byId.get("custom-action:a2")?.chord).toBe("");
+    useSettingsStore.setState({ customActions: [] });
+  });
+
   it("includes clone/init rows wired to the keymap (chip derives live, not hardcoded)", () => {
     const byId = new Map(buildCommands().map((i) => [i.id, i]));
     expect(byId.get("action:clone")?.actionId).toBe("repo.clone");

--- a/src/features/palette/commands.ts
+++ b/src/features/palette/commands.ts
@@ -17,6 +17,7 @@ import { orderBranchesGrouped } from "@/features/branches/orderBranches";
 import { activePins } from "@/features/branches/pins";
 import { summarizeFastForward } from "@/features/branches/fastForward";
 import { openCreateTag } from "@/features/tags/useCreateTagStore";
+import { boundChord } from "@/features/actions/actionChords";
 import { actionsFor } from "@/features/actions/customActions";
 import { runAction } from "@/features/actions/runAction";
 import { usePaletteStore } from "./usePaletteStore";
@@ -312,6 +313,11 @@ export function buildCommands(): PaletteItem[] {
         search: `${action.name} custom action ${action.command}`,
         label: action.name,
         icon: "terminal",
+        // The row carries its own chord rather than an `actionId`: a
+        // user-defined shortcut is a value in Settings, not a preset binding
+        // (#225). `boundChord` is the one gate on whether it fires, so the chip
+        // and the dispatcher cannot disagree.
+        chord: boundChord(action),
         run: direct(() => void runAction(action)),
       });
     }

--- a/src/features/palette/types.ts
+++ b/src/features/palette/types.ts
@@ -24,6 +24,12 @@ export interface PaletteItem {
    */
   actionId?: import("@/features/keymap").ActionId;
   /**
+   * A literal chord, for a row whose shortcut is not a catalog action — a
+   * user-defined action (#225), whose binding is a value in Settings rather
+   * than a preset entry. Rendered the same way `actionId` is.
+   */
+  chord?: string;
+  /**
    * Executes the item. May act directly, push a param step, or fire a nav
    * intent. The component closes the palette *before* calling run() only for
    * non-step items — see CommandPalette.activate.

--- a/src/features/settings/useSettingsStore.test.ts
+++ b/src/features/settings/useSettingsStore.test.ts
@@ -453,8 +453,10 @@ describe("useSettingsStore custom actions", () => {
   it("keeps an action saved before surfaces existed in the palette", async () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ customActions: [legacy] }));
     const { useSettingsStore } = await freshStore();
+    // ...and reads it as having no shortcut (#225): `chord` arrived with the
+    // same load, and an absent one is unbound, never a key that starts firing.
     expect(useSettingsStore.getState().customActions).toEqual([
-      { ...legacy, surfaces: ["repo"] },
+      { ...legacy, surfaces: ["repo"], chord: "" },
     ]);
   });
 


### PR DESCRIPTION
Closes #225.

The last piece of the issue's ask — "they appear in the command palette like
everything else, and they can take a keybinding". The palette half shipped with
the feature; this is the keybinding.

A chord lives on the action, in `customActions`, so it is in the settings file
and hand-editable like everything else it stores.

**Why the keymap takes it as data, not as an `ActionId`:** that union is closed
and `presets.test.ts` checks every member is bound in every preset, so a value
the user typed in Settings has no business in it. The dispatcher grows one seam
— `userBindings: chord → { title, run }` — which knows nothing about custom
actions; `useCustomActionChords` (mounted in AppShell, next to the listener)
fills it from Settings, and the cheat sheet renders it straight from the store,
so a chord that fires is a chord that is listed.

**A user chord is offered LAST**, after every built-in on that chord has
declined. A setting can never take a key away from the app, and the ordering is
what makes that true even for a hand-edited file.

`boundChord` is the single gate on whether a shortcut is live — asked by the
dispatcher's table, the cheat sheet, the palette chip and the Settings row
alike. Three things have to hold:

- **The chord is bindable.** ⌘/Ctrl or a function key; `Alt` alone does not
  count (⌥ with a character key TYPES on macOS), and a bare key would fire
  while arrowing through a file list *and* swallow that letter from the
  speed-search fallback. Requiring an accelerator is also what lets a custom
  chord dispatch inside text inputs with no further rule. `Mod+Alt+<letter>` is
  refused: that is AltGr on Windows and Linux — the rule `presets.test.ts`
  already enforces for shipped bindings, and it bites harder here, because a
  custom chord runs with the caret in the commit message box.
- **The action is on the palette.** A key press carries no selection, so `$FILE`
  and `$SHA` — filled by the menu that named a file or a commit — have nothing
  behind a chord. A shortcut therefore IS the palette invocation, with the
  repository context. The stored chord survives unticking `repo` (parked, not
  cleared): re-ticking gives it back rather than asking the user to remember it.
- **No built-in owns the chord**, checked against the union of ALL presets
  rather than the active one — presets are switchable, and the collision would
  be silent because the built-in wins. A palette chip advertising ⌘K would be
  advertising Go to Commit.

Settings refuses the collision up front and names what already owns the key (the
built-in action and its preset, or the other custom action), so nobody records a
shortcut that would simply never fire. A refused press keeps recording — the
next one is the correction.

**Why recording is a dispatcher mode (`beginCapture`) rather than a listener:**
the global keydown listener is capture-phase on `window` and registered first, so
nothing registered later can stop it — a field with its own listener would record
⌘K *and* commit. While a capture is set every chord goes to it
(`preventDefault` and `stopPropagation`) and nothing runs; the stopper clears
only its own callback, so a field unmounting late cannot kill the recording that
replaced it.

`coerceCustomActions` reads an absent `chord` as unbound and keeps one it cannot
use: what fires is `boundChord`'s question, asked fresh, and dropping the value
on load would empty the field that displays it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
