### PR TITLE
feat(branches): move branches between folders, fold them in the picker

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -945,7 +945,9 @@ that is only partly here — which is the whole reason the notice exists.
   #135's default-branch pin is the app guessing what belongs on top; a user pin
   is an instruction, and an instruction that loses to a guess is not a pin. With
   no pins the order is exactly #135's, which is why its tests are untouched.
-- **Pins are HOISTED OUT of the folder tree, not sorted to the front of it.**
+- **Pins are HOISTED OUT of the folder tree, not sorted to the front of it**
+  (`branchTree.ts::branchTreeRowsWithPins` — the rule lives there because both
+  the Branches screen and the titlebar picker render through it).
   Grouping runs after ordering and only moves rows into folders, so a pinned
   `feat/foo` would otherwise be the first row INSIDE `feat` — invisible whenever
   that folder is collapsed, which is the case pinning exists for. Hoisted rows
@@ -986,13 +988,18 @@ that is only partly here — which is the whole reason the notice exists.
 - **A filter flattens the tree to its matches, showing full names.** Hiding a
   hit behind a folded folder is the one thing a search box must never do, and a
   bare `bar` with no `feat/foo` above it names nothing.
-- **Fold state is the EXCEPTIONS, per repository, outside the store.**
+- **Fold state is the EXCEPTIONS, per repository, outside `useRepoStore`.**
   `useBranchFolders` persists the set of COLLAPSED paths in localStorage keyed by
   repository path (`pg-branch-folders-v1`), pruning a repository's entry once it
   is empty. Not in `useRepoStore`: that holds one repository's live git state and
-  every field must join `RepoSlice`, whereas this has to outlive the tab. It is
-  re-read on every repository change, or one tab's folds would be written back
-  under another tab's path.
+  every field must join `RepoSlice`, whereas this has to outlive the tab.
+- **The folds are ONE zustand store, for the reason the pins are** — since the
+  titlebar picker grew folders (#244) two surfaces render the tree at once, and
+  with a copy of the state per hook the last one to write silently dropped the
+  other's folds. Keyed by repository path and selected on read, so a tab switch
+  cannot apply one repository's folds to another's branches. A test that seeds
+  the key must `reloadCollapsedFolders()`, and so must one that needs a case's
+  folds gone — `localStorage.clear()` alone no longer resets it.
 - **Folding the folder the selection sits in moves the selection onto it.**
   Otherwise `flatIndex` goes to -1 and the next ArrowDown restarts at the top.
   ← on a folder folds it and on anything else climbs to `parentFolderPath`.
@@ -1004,10 +1011,53 @@ that is only partly here — which is the whole reason the notice exists.
   branch it cannot ask about is reported unmerged, the safe direction. The
   confirm names every branch in a scrolling list — "8 branches" is not something
   anyone can check before clicking Delete.
-- **Drag and drop is deliberately NOT wired to folder rows yet.** When it is, a
-  branch dragged onto or out of a folder resolves through `resolveDrop.ts` like
-  every other drop, with a keyboard equivalent — see the drag-and-drop rules
-  below.
+- **Dragging a branch onto a folder is `git branch -m` and nothing else.** A
+  folder is not a git object, it is the `/` in the name, so the only meaning a
+  drop can have is a rename — and only the LEAF travels, like a file dragged
+  between directories (`feat/deep/c` onto `release` is `release/c`, never
+  `release/deep/c`). `resolveBranchMoveDrop` (`features/dnd/resolveDrop.ts`)
+  owns every legality question: null for a no-op (dropped on the folder it
+  already sits in), a `rejected` reason for a remote-tracking ref or a name
+  that is taken. The drop then CONFIRMS, like the graph's drops do — a stray
+  pointer release must not rename a branch.
+- **The "out of a folder" target only exists mid-gesture.** The refs table is
+  one grid with no root header to aim at, so `BranchFolderDropBar` appears for
+  the duration of the drag and vanishes again, the way `StageDropBar` does for
+  the Files screen. It is shown only for a drag it can actually serve — a local
+  branch currently inside a folder — because a permanently dead target is worse
+  than none. The folder rows are where a remote drag gets its explanation.
+- **The keyboard equivalent is "Move to folder…"** in `branchMenuItems`, so it
+  reaches every branch surface and not just this screen. It prompts for the
+  folder (empty = top level) and routes the answer through the SAME resolver as
+  the drop, which is what keeps the two gestures from disagreeing about a
+  collision. Typing the destination is the confirmation, so it asks once where
+  the drop asks twice — the shape "Rename…" beside it already has.
+- **A pin follows a renamed branch** (`useBranchPins.rename`, called from
+  `useRepoStore.renameBranch` after the rename succeeds). A pin matches the
+  name exactly, so without this, dragging a pinned branch into a folder would
+  silently unpin it. Mapped in place, never re-appended: the array's order is
+  the pin order.
+- **Folders are in the titlebar `BranchPicker` too, off the same fold set.**
+  One repository has one notion of which folders are folded, so the picker
+  reads and writes `useBranchFolders` under the same repository path — and each
+  SECTION trees on its own, which is why folding `origin` cannot fold the local
+  `feat` beside it. A folder row there is not checkout-able: Enter toggles it,
+  → opens it, ← folds it or climbs out. The documented resting rule extends
+  rather than bends — the cursor rests on HEAD's row, or, when HEAD is folded
+  away, on the folder holding it, so a stray Enter is still a no-op. Rows carry
+  `data-picker-row` for anything indexed by position (the cursor, the scroll,
+  the actions menu) and branch rows keep `data-branch-row` plus a
+  `data-branch-name` with the FULL name, since a row's label is only the
+  segments it owns.
+- **Acting on a row claims the picker's cursor.** Enter, → and ← all change the
+  row set — a fold adds or removes rows — and the resting rule would otherwise
+  re-park the cursor on HEAD the instant a folder opens, yanking it out from
+  under the key that just opened it. For the same class of reason the
+  length-clamp effect uses the `setActiveIndex(i => …)` updater form: it runs in
+  the same commit as the resting effect, and reading `activeIndex` out of the
+  render closure would overwrite the position that effect just chose (typing a
+  query shrinks the list and re-parks the cursor at once, which is exactly when
+  the two collide).
 
 ## Navigation model
 
@@ -1938,7 +1988,8 @@ same rule stated twice:
   drop returns a reason (shown on the ghost), never silence.
 - **Every drag has a keyboard equivalent** — staging → Space/checkbox, reorder →
   Mod+Shift+↑/↓ and chevrons, repository tabs → Mod+Shift+←/→ and the tab menu's
-  Move left/right, graph ops → menus/palette/Branches. A new gesture without one
+  Move left/right, graph ops → menus/palette/Branches, a branch into or out of a
+  folder (#244) → the branch menu's "Move to folder…". A new gesture without one
   is not done. Escape cancels, from one capture-phase listener.
 - **`useRowReorder` takes an `axis`** (`"y"` default, `"x"` for the repository
   tab strip, #238). The axis is a table of accessors — `clientX`/`clientY`,

--- a/src/design/context-menu.moveToFolder.test.tsx
+++ b/src/design/context-menu.moveToFolder.test.tsx
@@ -1,0 +1,142 @@
+// "Move to folder…" on a branch's context menu (#244).
+//
+// This is the KEYBOARD equivalent of dragging a branch onto a folder row, which
+// the drag-and-drop rules require every drag to have. It routes through the same
+// `resolveBranchMoveDrop` the drop does, so the two gestures can never disagree
+// about what is legal — that shared path is the thing worth pinning here.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, waitFor } from "@testing-library/react";
+
+import { branchMenuItems, type ContextMenuItem } from "./context-menu";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import {
+  WithDialogs,
+  acceptDialog,
+  dialogBody,
+  dismissDialog,
+  resetDialogs,
+} from "@/test/dialog";
+import type { BranchInfo } from "@/lib/types";
+
+const LABEL = "Move to folder…";
+
+const entry = (items: ContextMenuItem[]) =>
+  items.find((i) => typeof i.label === "string" && i.label === LABEL);
+
+const branch = (over: Partial<BranchInfo> & { name: string }): BranchInfo => ({
+  isHead: false,
+  isRemote: false,
+  upstream: null,
+  ahead: 0,
+  behind: 0,
+  tip: "0".repeat(40),
+  tipTime: 0,
+  isDefault: false,
+  ...over,
+});
+
+let renameBranch: ReturnType<typeof vi.fn>;
+
+/** Open the entry's prompt, then answer it with `folder` (or dismiss). */
+async function move(
+  name: string,
+  folder: string | null,
+  opts: { current?: boolean } = {},
+) {
+  const item = entry(branchMenuItems({ name, current: opts.current, upstream: null }));
+  let pending: unknown;
+  act(() => {
+    pending = item?.onClick?.();
+  });
+  await waitFor(() => expect(document.querySelector("[data-pg-dialog]")).toBeTruthy());
+  if (folder === null) await dismissDialog();
+  else await acceptDialog(folder);
+  await act(async () => {
+    await pending;
+  });
+}
+
+beforeEach(() => {
+  resetDialogs();
+  renameBranch = vi.fn();
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
+    branches: [
+      branch({ name: "main", isDefault: true, isHead: true }),
+      branch({ name: "bugfix" }),
+      branch({ name: "feat/alpha" }),
+      branch({ name: "feat/beta" }),
+      branch({ name: "origin/feat/alpha", isRemote: true }),
+      branch({ name: "origin/feat/beta", isRemote: true }),
+    ],
+    renameBranch,
+  } as never);
+  render(<WithDialogs>{null}</WithDialogs>);
+});
+
+describe("branchMenuItems move-to-folder entry", () => {
+  it("renames the branch into the folder that was typed", async () => {
+    await move("bugfix", "feat");
+    expect(renameBranch).toHaveBeenCalledWith("bugfix", "feat/bugfix");
+  });
+
+  it("moves a branch to the top level on an empty answer", async () => {
+    await move("feat/alpha", "");
+    expect(renameBranch).toHaveBeenCalledWith("feat/alpha", "alpha");
+  });
+
+  // Dismissal is never an answer — it is not "move it to the top level".
+  it("does nothing when the prompt is dismissed", async () => {
+    await move("feat/alpha", null);
+    expect(renameBranch).not.toHaveBeenCalled();
+  });
+
+  it("tolerates stray slashes around the folder", async () => {
+    await move("bugfix", "/feat/");
+    expect(renameBranch).toHaveBeenCalledWith("bugfix", "feat/bugfix");
+  });
+
+  it("does nothing when the branch already sits there", async () => {
+    await move("feat/alpha", "feat");
+    expect(renameBranch).not.toHaveBeenCalled();
+  });
+
+  // The same rejection the drop shows on its ghost, from the same resolver.
+  it("refuses a destination name that is taken", async () => {
+    await move("feat/beta", "");
+    expect(renameBranch).toHaveBeenCalledWith("feat/beta", "beta");
+    renameBranch.mockClear();
+
+    useRepoStore.setState({
+      branches: [
+        ...useRepoStore.getState().branches,
+        branch({ name: "beta" }),
+      ],
+    } as never);
+    await move("feat/beta", "");
+    expect(renameBranch).not.toHaveBeenCalled();
+  });
+
+  it("names the folders the repository already has, so the answer is guessable", async () => {
+    const item = entry(branchMenuItems({ name: "bugfix", upstream: null }));
+    let pending: unknown;
+    act(() => {
+      pending = item?.onClick?.();
+    });
+    await waitFor(() => expect(document.querySelector("[data-pg-dialog]")).toBeTruthy());
+    // Local folders only: a remote-tracking ref is not somewhere a branch can
+    // be moved to.
+    expect(dialogBody()).toContain("feat");
+    expect(dialogBody()).not.toContain("origin/feat");
+    await dismissDialog();
+    await act(async () => {
+      await pending;
+    });
+  });
+
+  it("offers the current branch the same move — a rename is a rename", async () => {
+    await move("main", "release", { current: true });
+    expect(renameBranch).toHaveBeenCalledWith("main", "release/main");
+  });
+});

--- a/src/design/context-menu.tsx
+++ b/src/design/context-menu.tsx
@@ -24,6 +24,11 @@ import {
   selectedLinesToText,
 } from "@/lib/diffCopy";
 import { orderBranchesGrouped } from "@/features/branches/orderBranches";
+import { branchFolderPaths } from "@/features/branches/branchTree";
+// The MODULE, not the `features/dnd` barrel: the barrel re-exports
+// `StageDropBar`, which imports `@/design` — going through it would close a
+// cycle back through this file. `resolveDrop.ts` itself imports only its types.
+import { resolveBranchMoveDrop } from "@/features/dnd/resolveDrop";
 import { activePins, pinItem } from "@/features/branches/pins";
 import { openMergeWindow } from "@/features/merge/openMergeWindow";
 import {
@@ -1393,6 +1398,48 @@ export function branchMenuItems(
           mono: true,
         });
         if (to && to !== name) useRepoStore.getState().renameBranch(name, to);
+      },
+    },
+    {
+      icon: "folder",
+      // The keyboard equivalent of dragging a branch onto a folder row (#244),
+      // and the only way to do it from the other branch surfaces. Typing the
+      // destination IS the confirmation, which is why this asks once where the
+      // drop asks twice — the same shape "Rename…" above already has.
+      label: "Move to folder…",
+      disabled: !name,
+      onClick: async () => {
+        if (!name) return;
+        const store = useRepoStore.getState();
+        const locals = store.branches.filter((b) => !b.isRemote);
+        const folders = branchFolderPaths(locals);
+        const cut = name.lastIndexOf("/");
+        const next = await pgPrompt({
+          title: `Move ${name}`,
+          body: folders.length
+            ? `Folder to move it into — empty moves it to the top level. This repository has ${folders.join(", ")}.`
+            : "Folder to move it into — empty moves it to the top level.",
+          initialValue: cut < 0 ? "" : name.slice(0, cut),
+          placeholder: "feat/deep",
+          confirmLabel: "Move",
+          mono: true,
+        });
+        // Empty submission means the top level; dismissal means no answer.
+        if (next === null) return;
+        const folder = next.trim().replace(/^\/+/, "").replace(/\/+$/, "");
+        const move = resolveBranchMoveDrop(
+          { kind: "ref", ref: name, isHead: isCurrent, label: name },
+          folder ? { kind: "folder", path: folder } : { kind: "root" },
+          { local: locals.map((b) => b.name) },
+        );
+        // Null = it already sits there. One legality path with the drop, so
+        // the two gestures can never disagree about a collision.
+        if (!move) return;
+        if (move.kind === "rejected") {
+          pgFlash(move.reason);
+          return;
+        }
+        useRepoStore.getState().renameBranch(move.from, move.to);
       },
     },
     {

--- a/src/features/branches/BranchFolderDropBar.tsx
+++ b/src/features/branches/BranchFolderDropBar.tsx
@@ -1,0 +1,92 @@
+/**
+ * The "out of a folder" half of the branch-folder drag (#244).
+ *
+ * Dropping a branch ONTO a folder row has an obvious target; dropping it back
+ * out has none — the Branches screen is one grid with no root header to aim at.
+ * So the target appears for the duration of the gesture and vanishes again,
+ * exactly like `StageDropBar` does for the Files screen. The list keeps every
+ * pixel it had.
+ *
+ * Shown only for a drag this bar can actually serve: a LOCAL branch that is
+ * currently inside a folder. A remote-tracking ref, or a branch already at the
+ * top level, would make it a dead target — the folder rows are where those
+ * drags get their explanation.
+ */
+
+import React from "react";
+import { PGIcon } from "@/design";
+import {
+  resolveBranchMoveDrop,
+  useDragActive,
+  useDropZone,
+  type BranchMove,
+  type DragPayload,
+} from "@/features/dnd";
+
+export interface BranchFolderDropBarProps {
+  /** Every local branch name — the resolver's legality context. */
+  local: readonly string[];
+  onMove: (move: { from: string; to: string }) => void;
+  onReject: (reason: string) => void;
+}
+
+export function BranchFolderDropBar({
+  local,
+  onMove,
+  onReject,
+}: BranchFolderDropBarProps) {
+  const accepts = React.useCallback(
+    (p: DragPayload) =>
+      p.kind === "ref" && p.ref.includes("/") && local.includes(p.ref),
+    [local],
+  );
+  // Subscribes to the payload's null ⇄ non-null flip only — twice per gesture.
+  const active = useDragActive(accepts);
+  const { ref, isOver } = useDropZone({
+    id: "branches.drop.root",
+    accepts,
+    // A rename can still collide at the top level (`feat/main` → `main`), so
+    // this resolves rather than accepting blindly, and the ghost says why.
+    resolve: (el, p) => {
+      const drop = resolveBranchMoveDrop(p, { kind: "root" }, { local });
+      if (!drop) return null;
+      // The mark belongs on the BAR, not on whatever child the pointer landed
+      // on — `[data-pg-drop-over]` paints the element it is written to.
+      const zone = (el.closest("[data-pg-drop-id]") as HTMLElement | null) ?? el;
+      if (drop.kind === "rejected") return { key: "", el: zone, reason: drop.reason };
+      return { key: JSON.stringify(drop), el: zone };
+    },
+    onDrop: (_p, key) => {
+      if (!key) return;
+      const drop = JSON.parse(key) as BranchMove;
+      if (drop.kind === "move") onMove({ from: drop.from, to: drop.to });
+    },
+    onReject: (_p, reason) => onReject(reason),
+  });
+
+  if (!active) return null;
+  return (
+    <div
+      ref={ref}
+      data-testid="branch-root-drop"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 6,
+        height: 34,
+        margin: 6,
+        borderRadius: "var(--r-3)",
+        border: `1px dashed ${isOver ? "var(--accent)" : "var(--border-1)"}`,
+        background: "var(--bg-2)",
+        color: isOver ? "var(--accent)" : "var(--fg-2)",
+        fontSize: "var(--fs-11)",
+        fontFamily: "var(--font-mono)",
+        flexShrink: 0,
+      }}
+    >
+      <PGIcon name="chevronLeft" size={12} />
+      Move out of its folder
+    </div>
+  );
+}

--- a/src/features/branches/BranchPicker.folders.test.tsx
+++ b/src/features/branches/BranchPicker.folders.test.tsx
@@ -1,0 +1,248 @@
+// Folders in the titlebar branch picker (#244).
+//
+// The grouping itself is tested in `branchTree.test.ts`; this covers what the
+// popover adds on top of it — that a folder row is not checkout-able, where the
+// resting cursor lands when HEAD is folded away (Enter acts on that row, so it
+// is a correctness question), and that the folds are the SAME per-repository
+// set the Branches screen writes.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { BranchPicker } from "./BranchPicker";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useBranchPins } from "./useBranchPins";
+import {
+  BRANCH_FOLDERS_KEY,
+  reloadCollapsedFolders,
+} from "./useBranchFolders";
+import { resetInvokeMock } from "@/test/invokeMock";
+import type { BranchInfo } from "@/lib/types";
+
+const branch = (over: Partial<BranchInfo> & { name: string }): BranchInfo => ({
+  isHead: false,
+  isRemote: false,
+  upstream: null,
+  ahead: 0,
+  behind: 0,
+  tip: "0".repeat(40),
+  tipTime: 0,
+  isDefault: false,
+  ...over,
+});
+
+const BRANCHES = [
+  branch({ name: "main", tipTime: 10, isDefault: true }),
+  branch({ name: "feat/alpha", tipTime: 900, isHead: true }),
+  branch({ name: "feat/beta", tipTime: 800 }),
+  branch({ name: "chore/deps", tipTime: 700 }),
+  branch({ name: "release/1.0/rc", tipTime: 600 }),
+  branch({ name: "origin/feat/alpha", tipTime: 500, isRemote: true }),
+  branch({ name: "origin/feat/beta", tipTime: 400, isRemote: true }),
+];
+
+let anchor: HTMLElement;
+let checkoutBranch: ReturnType<typeof vi.fn>;
+
+function setup(branches = BRANCHES) {
+  checkoutBranch = vi.fn();
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/feat/alpha" },
+    branches,
+    checkoutBranch,
+  } as never);
+  return render(<BranchPicker anchor={anchor} open onClose={() => {}} />);
+}
+
+/** Every rendered row, in order: a folder as `path/`, a branch as its name. */
+const rows = () =>
+  Array.from(document.querySelectorAll("[data-picker-row]")).map((el) => {
+    const folder = el.getAttribute("data-picker-folder");
+    return folder === null ? el.getAttribute("data-branch-name") : `${folder}/`;
+  });
+
+const activeRow = () => {
+  const el = document.querySelector('[data-picker-row][data-active="true"]');
+  if (!el) return undefined;
+  const folder = el.getAttribute("data-picker-folder");
+  return folder === null ? el.getAttribute("data-branch-name") : `${folder}/`;
+};
+
+const folderRow = (path: string) =>
+  document.querySelector(`[data-picker-folder="${path}"]`) as HTMLElement;
+
+const press = (key: string) =>
+  fireEvent.keyDown(screen.getByPlaceholderText("Switch to branch…"), { key });
+
+/** Fold `paths` for `/repo` the way a previous session would have. */
+const storeFolds = (...paths: string[]) => {
+  localStorage.setItem(BRANCH_FOLDERS_KEY, JSON.stringify({ "/repo": paths }));
+  reloadCollapsedFolders();
+};
+
+const storedFolds = () =>
+  (JSON.parse(localStorage.getItem(BRANCH_FOLDERS_KEY) ?? "{}") as Record<
+    string,
+    string[]
+  >)["/repo"] ?? [];
+
+beforeEach(() => {
+  resetInvokeMock();
+  localStorage.clear();
+  // The folds are a shared store, so a fold made by one case would otherwise
+  // outlive it — clearing the key is not enough.
+  reloadCollapsedFolders();
+  useBranchPins.setState({ byRepo: {} });
+  anchor = document.createElement("div");
+  document.body.appendChild(anchor);
+});
+
+afterEach(() => {
+  anchor.remove();
+});
+
+describe("BranchPicker folders", () => {
+  it("groups each section on `/` and compresses lone chains", () => {
+    setup();
+
+    expect(rows()).toEqual([
+      "main",
+      "feat/",
+      "feat/alpha",
+      "feat/beta",
+      // Neither groups anything, so both keep their full names and no folder.
+      "chore/deps",
+      "release/1.0/rc",
+      // The remote section trees on its own — `origin` holds exactly one
+      // segment's worth of children, so the chain compresses into one row.
+      "origin/feat/",
+      "origin/feat/alpha",
+      "origin/feat/beta",
+    ]);
+  });
+
+  it("hides the branches under a folder the repository has folded", () => {
+    storeFolds("feat");
+    setup();
+
+    expect(rows()).toEqual([
+      "main",
+      "feat/",
+      "chore/deps",
+      "release/1.0/rc",
+      "origin/feat/",
+      "origin/feat/alpha",
+      "origin/feat/beta",
+    ]);
+  });
+
+  it("folds and unfolds on click, without checking anything out", () => {
+    setup();
+
+    fireEvent.click(folderRow("feat"));
+    expect(rows()).not.toContain("feat/alpha");
+    expect(checkoutBranch).not.toHaveBeenCalled();
+    // Written where the Branches screen reads it — one repository, one set.
+    expect(storedFolds()).toEqual(["feat"]);
+
+    fireEvent.click(folderRow("feat"));
+    expect(rows()).toContain("feat/alpha");
+    expect(storedFolds()).toEqual([]);
+  });
+
+  it("checks out a branch row on click, as it always did", () => {
+    setup();
+
+    fireEvent.click(
+      document.querySelector('[data-branch-name="feat/beta"]') as HTMLElement,
+    );
+    expect(checkoutBranch).toHaveBeenCalledWith("feat/beta");
+  });
+
+  it("rests on the current branch when its folder is open", () => {
+    setup();
+    expect(activeRow()).toBe("feat/alpha");
+  });
+
+  // Enter acts on the resting row. With HEAD folded away the only harmless
+  // place to rest is the folder holding it — Enter there opens the folder.
+  it("rests on the folder holding the current branch when it is folded away", () => {
+    storeFolds("feat");
+    setup();
+
+    expect(activeRow()).toBe("feat/");
+    press("Enter");
+    expect(checkoutBranch).not.toHaveBeenCalled();
+    expect(rows()).toContain("feat/alpha");
+    expect(activeRow()).toBe("feat/");
+  });
+
+  it("expands with ArrowRight and folds with ArrowLeft", () => {
+    storeFolds("feat");
+    setup();
+
+    expect(activeRow()).toBe("feat/");
+    press("ArrowRight");
+    expect(rows()).toContain("feat/alpha");
+    press("ArrowLeft");
+    expect(rows()).not.toContain("feat/alpha");
+  });
+
+  it("climbs out of a folder with ArrowLeft from a branch inside it", () => {
+    setup();
+
+    expect(activeRow()).toBe("feat/alpha");
+    press("ArrowLeft");
+    expect(activeRow()).toBe("feat/");
+    // ...and again folds the folder it just climbed to.
+    press("ArrowLeft");
+    expect(rows()).not.toContain("feat/alpha");
+  });
+
+  it("walks folder rows with the arrow keys like any other row", () => {
+    setup();
+
+    press("ArrowUp");
+    expect(activeRow()).toBe("feat/");
+    press("ArrowUp");
+    expect(activeRow()).toBe("main");
+  });
+
+  it("flattens to full names while a query is typed", () => {
+    setup();
+
+    fireEvent.change(screen.getByPlaceholderText("Switch to branch…"), {
+      target: { value: "feat" },
+    });
+
+    // No folder row at all: a hit hidden behind a fold is the one thing a
+    // search box must never do.
+    expect(rows()).toEqual([
+      "feat/alpha",
+      "feat/beta",
+      "origin/feat/alpha",
+      "origin/feat/beta",
+    ]);
+    expect(activeRow()).toBe("feat/alpha");
+  });
+
+  it("keeps a pinned branch out of the tree so a fold cannot hide it", () => {
+    useBranchPins.getState().toggle("/repo", "feat/beta");
+    storeFolds("feat");
+    // A third `feat/…` so the folder survives the hoist: with only `alpha`
+    // left under it, the chain would rightly compress back into one row.
+    setup([...BRANCHES, branch({ name: "feat/gamma", tipTime: 850 })]);
+
+    // Hoisted to the top under its FULL name, and still on screen with `feat`
+    // folded — which is the case pinning exists for.
+    expect(rows()).toEqual([
+      "feat/beta",
+      "main",
+      "feat/",
+      "chore/deps",
+      "release/1.0/rc",
+      "origin/feat/",
+      "origin/feat/alpha",
+      "origin/feat/beta",
+    ]);
+  });
+});

--- a/src/features/branches/BranchPicker.test.tsx
+++ b/src/features/branches/BranchPicker.test.tsx
@@ -34,9 +34,13 @@ function setup(branches: BranchInfo[]) {
   return render(<BranchPicker anchor={anchor} open onClose={() => {}} />);
 }
 
+// The FULL name off the row, not the label inside it: since #244 the picker
+// groups on `/`, so a row shows only the segments it owns (`origin/main` renders
+// as `main` under an `origin` folder). Every expectation below is unchanged by
+// that — grouping nests rows, it never reorders them.
 const rowNames = () =>
   Array.from(document.querySelectorAll("[data-branch-row]")).map((el) =>
-    el.querySelector("span")?.textContent,
+    el.getAttribute("data-branch-name"),
   );
 
 const activeName = () =>

--- a/src/features/branches/BranchPicker.tsx
+++ b/src/features/branches/BranchPicker.tsx
@@ -11,6 +11,13 @@ import {
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import type { BranchInfo } from "@/lib/types";
 import { orderBranches } from "./orderBranches";
+import {
+  branchLeafRows,
+  branchTreeRowsWithPins,
+  parentFolderPath,
+  type BranchTreeRow,
+} from "./branchTree";
+import { useBranchFolders } from "./useBranchFolders";
 import { usePinSet } from "./usePinSet";
 
 interface BranchPickerProps {
@@ -20,13 +27,21 @@ interface BranchPickerProps {
 }
 
 type Row = BranchInfo & { kind: "local" | "remote" };
+type TreeRow = BranchTreeRow<Row>;
 
 const WIDTH = 400;
 const MAX_HEIGHT = 480;
+/** Pixels a nesting level indents a row by — the Branches screen's step. */
+const INDENT = 14;
 
 export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
   const branches = useRepoStore((s) => s.branches);
+  const repoPath = useRepoStore((s) => s.current?.path ?? null);
   const pins = usePinSet();
+  // The SAME fold set the Branches screen writes (#244), keyed by repository:
+  // one repository has one notion of which folders are folded, and a picker
+  // that disagreed with the screen would be a second answer to one question.
+  const folders = useBranchFolders(repoPath);
   const checkoutBranch = useRepoStore((s) => s.checkoutBranch);
   const createAndSwitchBranch = useRepoStore((s) => s.createAndSwitchBranch);
   const [query, setQuery] = React.useState("");
@@ -71,7 +86,30 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
     [branches, query, pins],
   );
 
-  const flat = React.useMemo(() => [...local, ...remote], [local, remote]);
+  // Filter, order, then GROUP — grouping last, so it only ever moves ordered
+  // rows into folders (#244). Each section trees on its own, which is why
+  // folding `origin` cannot fold the local `feat` beside it: the paths differ.
+  const filtering = query.length > 0;
+  const localRows = React.useMemo<TreeRow[]>(
+    () =>
+      filtering
+        ? branchLeafRows(local)
+        : branchTreeRowsWithPins(local, pins, folders.collapsed),
+    [local, filtering, pins, folders.collapsed],
+  );
+  const remoteRows = React.useMemo<TreeRow[]>(
+    () =>
+      filtering
+        ? branchLeafRows(remote)
+        : branchTreeRowsWithPins(remote, pins, folders.collapsed),
+    [remote, filtering, pins, folders.collapsed],
+  );
+
+  /** Every rendered row, in render order — what the cursor indexes into. */
+  const flat = React.useMemo(
+    () => [...localRows, ...remoteRows],
+    [localRows, remoteRows],
+  );
 
   // True once the user has aimed the cursor themselves (arrows or hover). The
   // resting rule below must then stop moving it, or a late `list_branches`
@@ -80,6 +118,17 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
   const aim = (next: number) => {
     aimed.current = true;
     setActiveIndex(next);
+  };
+  /**
+   * Claim the cursor without moving it.
+   *
+   * Enter, → and ← all act on the row the cursor is ON, and a fold changes the
+   * row set — so the resting rule would re-park the cursor on HEAD the instant
+   * a folder opens, yanking it out from under the key that just opened it.
+   * Acting on a row is the user aiming at it (#244).
+   */
+  const claim = () => {
+    aimed.current = true;
   };
 
   React.useEffect(() => {
@@ -118,13 +167,36 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
       setActiveIndex(0);
       return;
     }
-    const head = flat.findIndex((r) => r.kind === "local" && r.isHead);
-    setActiveIndex(head >= 0 ? head : 0);
-  }, [open, query, flat]);
+    const head = flat.findIndex(
+      (r) => r.kind === "branch" && r.branch.kind === "local" && r.branch.isHead,
+    );
+    if (head >= 0) {
+      setActiveIndex(head);
+      return;
+    }
+    // HEAD can be folded away (#244). Then the cursor rests on the FOLDER
+    // holding it — the first match is the outermost rendered one, since a
+    // collapsed folder renders none of its children. Enter there opens the
+    // folder instead of checking anything out, which keeps the rule the
+    // resting position exists for: a stray Enter must be a no-op.
+    const headName = branches.find((b) => !b.isRemote && b.isHead)?.name;
+    const holding = headName
+      ? flat.findIndex(
+          (r) => r.kind === "folder" && headName.startsWith(`${r.path}/`),
+        )
+      : -1;
+    setActiveIndex(holding >= 0 ? holding : 0);
+  }, [open, query, flat, branches]);
 
+  // Clamp a cursor left past the end by a shrinking list. The UPDATER form is
+  // load-bearing: the resting effect above runs in the same commit, and a
+  // clamp reading `activeIndex` out of this render's closure would overwrite
+  // the position that effect just chose with a stale one. (Typing a query
+  // shrinks the list and re-parks the cursor at once — which is exactly when
+  // the two effects collide.)
   React.useEffect(() => {
-    if (activeIndex >= flat.length) setActiveIndex(Math.max(0, flat.length - 1));
-  }, [flat.length, activeIndex]);
+    setActiveIndex((i) => (i >= flat.length ? Math.max(0, flat.length - 1) : i));
+  }, [flat.length]);
 
   // Keep the cursor visible. The resting position can start below the fold in a
   // long list, and arrowing past the visible area never scrolled either. These
@@ -132,8 +204,10 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
   // Optional call: jsdom has no scrollIntoView, and this is presentation only.
   React.useEffect(() => {
     if (!open) return;
+    // `[data-picker-row]` and not `[data-branch-row]`: folder rows are part of
+    // the cursor's order, so anything indexed by position has to count them.
     const rows =
-      popoverRef.current?.querySelectorAll<HTMLElement>("[data-branch-row]");
+      popoverRef.current?.querySelectorAll<HTMLElement>("[data-picker-row]");
     rows?.[activeIndex]?.scrollIntoView?.({ block: "nearest" });
   }, [open, activeIndex, flat.length]);
 
@@ -172,6 +246,28 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
     onClose();
   };
 
+  // The popover stays open across a fold: folding is navigation, not an answer.
+  const toggleFolder = (path: string) => {
+    if (folders.collapsed.has(path)) folders.expand([path]);
+    else folders.collapse([path]);
+  };
+
+  /** Move the cursor onto a folder row by path, if it is rendered. */
+  const aimAtFolder = (path: string) => {
+    const i = flat.findIndex((r) => r.kind === "folder" && r.path === path);
+    if (i >= 0) aim(i);
+  };
+
+  const activate = (row: TreeRow) => {
+    if (row.kind === "folder") {
+      // Folding the folder the cursor sits in would otherwise leave it on a
+      // row that is still rendered — it is the folder — so nothing to fix up.
+      toggleFolder(row.path);
+      return;
+    }
+    checkout(row.branch);
+  };
+
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Escape") {
       e.preventDefault();
@@ -195,31 +291,124 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
         return;
       }
       const row = flat[activeIndex];
-      if (row) checkout(row);
+      if (!row) return;
+      claim();
+      activate(row);
+      return;
+    }
+    // → opens a folded folder, and on a branch keeps opening its actions menu.
+    // ← folds an open folder, and on anything else climbs to the folder the
+    // row sits in — the same pair the Branches screen's tree answers.
+    if (e.key === "ArrowLeft") {
+      const row = flat[activeIndex];
+      if (!row) return;
+      e.preventDefault();
+      claim();
+      if (row.kind === "folder" && !folders.collapsed.has(row.path)) {
+        folders.collapse([row.path]);
+        return;
+      }
+      const parent = parentFolderPath(flat, activeIndex);
+      if (parent) aimAtFolder(parent);
       return;
     }
     if (e.key === "ArrowRight") {
       const row = flat[activeIndex];
       if (!row) return;
       e.preventDefault();
-      const rowEls = popoverRef.current?.querySelectorAll<HTMLElement>("[data-branch-row]");
+      claim();
+      if (row.kind === "folder") {
+        if (folders.collapsed.has(row.path)) folders.expand([row.path]);
+        return;
+      }
+      const rowEls =
+        popoverRef.current?.querySelectorAll<HTMLElement>("[data-picker-row]");
       const rowEl = rowEls?.[activeIndex];
       const r = rowEl?.getBoundingClientRect() ?? anchor.getBoundingClientRect();
       const x = r.right - 24;
       const y = r.bottom;
-      if (row.kind === "local") openLocal(x, y, row);
-      else openRemote(x, y, row);
+      if (row.branch.kind === "local") openLocal(x, y, row.branch);
+      else openRemote(x, y, row.branch);
       return;
     }
   };
 
-  const renderRow = (r: Row, idx: number) => {
+  const renderFolder = (row: Extract<TreeRow, { kind: "folder" }>, idx: number) => {
+    const active = idx === activeIndex;
+    return (
+      <div
+        key={`folder:${row.path}`}
+        data-picker-row
+        data-picker-folder={row.path}
+        data-active={active ? "true" : "false"}
+        // The whole row folds, like the Branches screen's folder rows: a branch
+        // folder is not a git object, so folding is the only reason it is here.
+        onClick={() => {
+          aim(idx);
+          toggleFolder(row.path);
+        }}
+        onMouseEnter={() => aim(idx)}
+        title={`${row.path}/`}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          height: "calc(26px + var(--row-step))",
+          padding: "0 10px",
+          paddingLeft: 10 + row.depth * INDENT,
+          background: active ? "var(--bg-selection)" : "transparent",
+          cursor: "pointer",
+          fontFamily: "var(--font-mono)",
+          fontSize: "var(--fs-12)",
+          // A folder row is a control, not text: a stray drag across it must
+          // not select "feat (12)".
+          userSelect: "none",
+        }}
+      >
+        <PGIcon
+          name={row.collapsed ? "chevronRight" : "chevronDown"}
+          size={10}
+          style={{ color: "var(--fg-3)", flexShrink: 0 }}
+        />
+        <PGIcon
+          name={row.collapsed ? "folder" : "folderOpen"}
+          size={12}
+          style={{ color: "var(--fg-2)", flexShrink: 0 }}
+        />
+        <span
+          style={{
+            flex: 1,
+            minWidth: 0,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            color: "var(--fg-0)",
+          }}
+        >
+          {row.label}
+        </span>
+        <span style={{ color: "var(--fg-3)", fontSize: "var(--fs-10)" }}>
+          ({row.count})
+        </span>
+      </div>
+    );
+  };
+
+  const renderBranch = (
+    row: Extract<TreeRow, { kind: "branch" }>,
+    idx: number,
+  ) => {
+    const r = row.branch;
     const active = idx === activeIndex;
     const handler = r.kind === "local" ? onLocalCtx : onRemoteCtx;
     return (
       <div
         key={`${r.kind}:${r.name}`}
         data-branch-row
+        data-picker-row
+        // The full name, whatever the row's label shows: the tree renders only
+        // the segments a row owns, and the tests and the drag both need the ref.
+        data-branch-name={r.name}
         data-active={active ? "true" : "false"}
         onClick={() => checkout(r)}
         onContextMenu={(e) => handler(e, r)}
@@ -230,6 +419,9 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
           gap: 6,
           height: "calc(26px + var(--row-step))",
           padding: "0 10px",
+          // Indented like the screen's tree, plus the width of the chevron a
+          // folder row spends there, so nested names line up under the label.
+          paddingLeft: 10 + row.depth * INDENT + (row.depth > 0 ? 16 : 0),
           background: active ? "var(--bg-selection)" : "transparent",
           cursor: r.kind === "local" && r.isHead ? "default" : "pointer",
           fontFamily: "var(--font-mono)",
@@ -252,7 +444,7 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
             color: r.isHead ? "var(--accent)" : "var(--fg-0)",
           }}
         >
-          {r.name}
+          {row.label}
         </span>
         {r.isHead && (
           <span
@@ -305,6 +497,9 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
       </div>
     );
   };
+
+  const renderRow = (row: TreeRow, idx: number) =>
+    row.kind === "folder" ? renderFolder(row, idx) : renderBranch(row, idx);
 
   const sectionHeader = (label: string, count: number) => (
     <div
@@ -384,13 +579,13 @@ export function BranchPicker({ anchor, open, onClose }: BranchPickerProps) {
               {local.length > 0 && (
                 <>
                   {sectionHeader("Local", local.length)}
-                  {local.map((r, i) => renderRow(r, i))}
+                  {localRows.map((r, i) => renderRow(r, i))}
                 </>
               )}
               {remote.length > 0 && (
                 <>
                   {sectionHeader("Remote", remote.length)}
-                  {remote.map((r, i) => renderRow(r, local.length + i))}
+                  {remoteRows.map((r, i) => renderRow(r, localRows.length + i))}
                 </>
               )}
             </>

--- a/src/features/branches/branchTree.ts
+++ b/src/features/branches/branchTree.ts
@@ -162,6 +162,52 @@ export function branchTreeRows<T extends { name: string }>(
 }
 
 /**
+ * One ungrouped row per branch, under its FULL name — what a filter renders.
+ *
+ * A filter flattens the tree to its matches, as filters should: hiding a hit
+ * behind a folded folder is the one thing a search box must never do, and a
+ * bare `bar` with no `feat/foo` above it names nothing.
+ */
+export function branchLeafRows<T extends { name: string }>(
+  branches: readonly T[],
+): BranchTreeRow<T>[] {
+  return branches.map((branch) => ({
+    kind: "branch",
+    path: branch.name,
+    label: branch.name,
+    depth: 0,
+    branch,
+  }));
+}
+
+/**
+ * The display rows for an already filtered and ordered list, with the pinned
+ * branches (#238) HOISTED OUT of the tree rather than sorted to the front of
+ * it.
+ *
+ * Grouping only moves ordered rows into folders, so a pinned `feat/foo` would
+ * otherwise be the first row INSIDE `feat` — invisible whenever that folder is
+ * collapsed, which is the case pinning exists for. Hoisted rows render at depth
+ * 0 under their full names and are REMOVED from the tree rather than duplicated
+ * into it.
+ *
+ * Both surfaces that render the tree go through this, so the Branches screen
+ * and the titlebar picker can never disagree about one list.
+ */
+export function branchTreeRowsWithPins<T extends { name: string }>(
+  ordered: readonly T[],
+  pins: ReadonlySet<string>,
+  collapsed: ReadonlySet<string>,
+): BranchTreeRow<T>[] {
+  if (pins.size === 0) return branchTreeRows(ordered, collapsed);
+  const pinned = ordered.filter((b) => pins.has(b.name));
+  const rest = ordered.filter((b) => !pins.has(b.name));
+  // `ordered` is already pins-first, so the hoisted block and the tree below
+  // it stay one continuous order.
+  return [...branchLeafRows(pinned), ...branchTreeRows(rest, collapsed)];
+}
+
+/**
  * Every folder path the tree would render, expanded or not — what "collapse
  * all" writes. A compressed chain is ONE path (`feat/foo`), never one per
  * segment, or collapsing all would leave rows keyed on folders that don't exist.

--- a/src/features/branches/useBranchFolders.test.ts
+++ b/src/features/branches/useBranchFolders.test.ts
@@ -2,8 +2,11 @@
 // other per-surface view preferences: localStorage, best-effort, never fatal.
 
 import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
 import {
   readCollapsedFolders,
+  reloadCollapsedFolders,
+  useBranchFolders,
   writeCollapsedFolders,
   BRANCH_FOLDERS_KEY,
 } from "./useBranchFolders";
@@ -93,5 +96,70 @@ describe("collapsed branch folders", () => {
     writeCollapsedFolders("/repos/a", new Set(["feat", "chore"]));
 
     expect(readCollapsedFolders("/repos/b")).toEqual(new Set(["fix"]));
+  });
+});
+
+// Two surfaces render the tree at once — the Branches screen and the titlebar
+// picker (#244) — so the folds have to be ONE live set. With a copy per hook,
+// the last one to write would silently drop the other's folds.
+describe("useBranchFolders", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    reloadCollapsedFolders();
+  });
+
+  it("shows one surface's fold to the other immediately", () => {
+    const screen = renderHook(() => useBranchFolders("/repos/a"));
+    const picker = renderHook(() => useBranchFolders("/repos/a"));
+
+    act(() => picker.result.current.collapse(["feat"]));
+
+    expect([...screen.result.current.collapsed]).toEqual(["feat"]);
+    expect(readCollapsedFolders("/repos/a")).toEqual(new Set(["feat"]));
+  });
+
+  it("does not let one surface's write drop the other's folds", () => {
+    const screen = renderHook(() => useBranchFolders("/repos/a"));
+    const picker = renderHook(() => useBranchFolders("/repos/a"));
+
+    act(() => picker.result.current.collapse(["feat"]));
+    act(() => screen.result.current.collapse(["release"]));
+
+    expect([...picker.result.current.collapsed].sort()).toEqual([
+      "feat",
+      "release",
+    ]);
+  });
+
+  it("keeps two open repositories apart", () => {
+    const a = renderHook(() => useBranchFolders("/repos/a"));
+    const b = renderHook(() => useBranchFolders("/repos/b"));
+
+    act(() => a.result.current.toggle("feat"));
+
+    expect([...a.result.current.collapsed]).toEqual(["feat"]);
+    expect([...b.result.current.collapsed]).toEqual([]);
+  });
+
+  it("keeps the set's reference stable while the folds do not change", () => {
+    const a = renderHook(() => useBranchFolders("/repos/a"));
+    const first = a.result.current.collapsed;
+
+    // Another repository's write must not rebuild this one's Set — the Branches
+    // screen memoizes its whole row list on the reference.
+    const b = renderHook(() => useBranchFolders("/repos/b"));
+    act(() => b.result.current.collapse(["fix"]));
+    a.rerender();
+
+    expect(a.result.current.collapsed).toBe(first);
+  });
+
+  it("has nowhere to write for a repository that is not open", () => {
+    const none = renderHook(() => useBranchFolders(null));
+
+    act(() => none.result.current.collapse(["feat"]));
+
+    expect([...none.result.current.collapsed]).toEqual([]);
+    expect(localStorage.getItem(BRANCH_FOLDERS_KEY)).toBeNull();
   });
 });

--- a/src/features/branches/useBranchFolders.ts
+++ b/src/features/branches/useBranchFolders.ts
@@ -4,19 +4,24 @@
 //
 // NOT in `useRepoStore`. That store holds exactly one repository's live git
 // state and every field of it has to join `RepoSlice`; this is a view
-// preference that must OUTLIVE the tab, so it is keyed by repository path
-// here and re-read whenever the active repository changes.
+// preference that must OUTLIVE the tab, so it is keyed by repository path here
+// and selected by the open repository on read. It IS a zustand store rather
+// than per-hook state, because two surfaces render the tree at once — see
+// `useFoldStore` below.
 //
 // The stored value is the set of COLLAPSED folders, so the default is expanded:
 // a folder that appears after a fetch shows up without anyone having asked, and
 // a repository the user expanded again leaves no entry behind.
 
 import React from "react";
+import { create } from "zustand";
 
 /** One key for every repository's state — see `useForgeStore`'s host map. */
 export const BRANCH_FOLDERS_KEY = "pg-branch-folders-v1";
 
 type Store = Record<string, string[]>;
+
+const EMPTY: string[] = [];
 
 function readStore(): Store {
   try {
@@ -30,7 +35,14 @@ function readStore(): Store {
   }
 }
 
-/** The folders `repoPath` has collapsed. Empty for an unknown or absent repo. */
+/**
+ * The folders `repoPath` has collapsed, read straight off disk. Empty for an
+ * unknown or absent repository.
+ *
+ * The live set comes from the store below; this is the pure reader the storage
+ * tests pin the parse hardening through — a corrupt or hand-edited payload has
+ * to degrade to "nothing collapsed", never to a screen that throws on mount.
+ */
 export function readCollapsedFolders(repoPath: string | null): Set<string> {
   if (!repoPath) return new Set();
   const entry = readStore()[repoPath];
@@ -67,55 +79,78 @@ export interface BranchFolders {
   expand: (paths: readonly string[]) => void;
 }
 
+/**
+ * The live fold map, shared by every surface that renders the tree.
+ *
+ * A STORE and not per-hook `useState`, for the reason `useBranchPins` is one:
+ * two consumers are mounted at once — the Branches screen and the titlebar
+ * picker (#244) — and with private copies the last one to write would silently
+ * drop the other's folds. Keying by repository path rather than tracking a
+ * "current" repository is what keeps a tab switch from applying one
+ * repository's folds to another's branches.
+ */
+const useFoldStore = create<{ byRepo: Store }>(() => ({ byRepo: readStore() }));
+
+/** Re-read localStorage. Only a fresh app start needs this; tests use it. */
+export function reloadCollapsedFolders(): void {
+  useFoldStore.setState({ byRepo: readStore() });
+}
+
 export function useBranchFolders(repoPath: string | null): BranchFolders {
-  const [collapsed, setCollapsed] = React.useState<ReadonlySet<string>>(() =>
-    readCollapsedFolders(repoPath),
+  // Subscribes to this repository's stored ARRAY, so the memoized Set is
+  // rebuilt only when a fold actually changes — `Branches.tsx` memoizes its
+  // whole row list on the reference.
+  const entry = useFoldStore((s) => (repoPath ? s.byRepo[repoPath] : undefined));
+  const collapsed = React.useMemo<ReadonlySet<string>>(
+    () => new Set(entry ?? EMPTY),
+    [entry],
   );
 
-  // Re-read on every tab switch. Without this the outgoing repository's folds
-  // would be applied to the incoming one — and then written back under ITS
-  // path on the next click.
-  React.useEffect(() => {
-    setCollapsed(readCollapsedFolders(repoPath));
-  }, [repoPath]);
-
-  // Side effects stay OUT of the state updater: these are single user
-  // gestures, so deriving the next set from the rendered one is safe, and a
-  // localStorage write inside an updater would run twice under StrictMode.
-  const apply = React.useCallback(
-    (next: Set<string>) => {
-      setCollapsed(next);
+  // Every mutation reads the set out of the STORE, never out of the render
+  // that produced the callback: a fold can be applied after an await (the
+  // Branches screen opens the destination folder once a move's rename has
+  // landed), and the rendered set may be several folds old by then.
+  //
+  // The in-memory map is the truth and the write is best-effort: a browser that
+  // refuses localStorage still folds correctly for the session, it just won't
+  // remember. `writeCollapsedFolders` keeps owning the stored SHAPE.
+  const mutate = React.useCallback(
+    (fn: (next: Set<string>) => void) => {
+      if (!repoPath) return;
+      const byRepo = { ...useFoldStore.getState().byRepo };
+      const next = new Set(byRepo[repoPath] ?? EMPTY);
+      fn(next);
+      if (next.size === 0) delete byRepo[repoPath];
+      else byRepo[repoPath] = [...next];
+      useFoldStore.setState({ byRepo });
       writeCollapsedFolders(repoPath, next);
     },
     [repoPath],
   );
 
   const toggle = React.useCallback(
-    (path: string) => {
-      const next = new Set(collapsed);
-      if (next.has(path)) next.delete(path);
-      else next.add(path);
-      apply(next);
-    },
-    [collapsed, apply],
+    (path: string) =>
+      mutate((next) => {
+        if (next.has(path)) next.delete(path);
+        else next.add(path);
+      }),
+    [mutate],
   );
 
   const collapse = React.useCallback(
-    (paths: readonly string[]) => {
-      const next = new Set(collapsed);
-      for (const p of paths) next.add(p);
-      apply(next);
-    },
-    [collapsed, apply],
+    (paths: readonly string[]) =>
+      mutate((next) => {
+        for (const p of paths) next.add(p);
+      }),
+    [mutate],
   );
 
   const expand = React.useCallback(
-    (paths: readonly string[]) => {
-      const next = new Set(collapsed);
-      for (const p of paths) next.delete(p);
-      apply(next);
-    },
-    [collapsed, apply],
+    (paths: readonly string[]) =>
+      mutate((next) => {
+        for (const p of paths) next.delete(p);
+      }),
+    [mutate],
   );
 
   return { collapsed, toggle, collapse, expand };

--- a/src/features/branches/useBranchPins.test.ts
+++ b/src/features/branches/useBranchPins.test.ts
@@ -74,6 +74,38 @@ describe("useBranchPins", () => {
     expect(pinnedIn("/a")).toBe(first);
   });
 
+  // A pin matches the name exactly, so a rename — including a branch dragged
+  // into a folder (#244) — has to carry the pin with it.
+  it("follows a renamed branch, keeping its place in the order", () => {
+    useBranchPins.getState().toggle("/a", "main");
+    useBranchPins.getState().toggle("/a", "foo");
+    useBranchPins.getState().toggle("/a", "other");
+    useBranchPins.getState().rename("/a", "foo", "feat/foo");
+    expect(pinnedIn("/a")).toEqual(["main", "feat/foo", "other"]);
+    expect(raw()).toEqual({ "/a": ["main", "feat/foo", "other"] });
+  });
+
+  it("does not pin a branch that was not pinned before the rename", () => {
+    useBranchPins.getState().toggle("/a", "main");
+    useBranchPins.getState().rename("/a", "foo", "feat/foo");
+    expect(pinnedIn("/a")).toEqual(["main"]);
+  });
+
+  it("never doubles up when the new name was already pinned", () => {
+    useBranchPins.getState().toggle("/a", "foo");
+    useBranchPins.getState().toggle("/a", "feat/foo");
+    useBranchPins.getState().rename("/a", "foo", "feat/foo");
+    expect(pinnedIn("/a")).toEqual(["feat/foo"]);
+  });
+
+  it("ignores a rename with nothing to do", () => {
+    useBranchPins.getState().toggle("/a", "foo");
+    useBranchPins.getState().rename("/a", "foo", "foo");
+    useBranchPins.getState().rename(null, "foo", "bar");
+    useBranchPins.getState().rename("/a", "foo", "");
+    expect(pinnedIn("/a")).toEqual(["foo"]);
+  });
+
   it("survives a corrupt payload", () => {
     localStorage.setItem(BRANCH_PINS_KEY, "{not json");
     reload();

--- a/src/features/branches/useBranchPins.ts
+++ b/src/features/branches/useBranchPins.ts
@@ -57,6 +57,15 @@ interface BranchPinsState {
   byRepo: PinMap;
   /** Pin `name` in `repoPath`, or unpin it if it is already pinned. */
   toggle: (repoPath: string | null, name: string) => void;
+  /**
+   * Follow a renamed branch, keeping its pin and its position in the order.
+   *
+   * A pin matches the branch name exactly, so without this a rename — and
+   * since #244 that includes dragging a branch into a folder — would silently
+   * unpin it. The pin is an instruction about a branch, and a renamed branch
+   * is the same branch.
+   */
+  rename: (repoPath: string | null, from: string, to: string) => void;
   /** Re-read localStorage. Only a fresh app start needs this; tests use it. */
   reload: () => void;
 }
@@ -75,6 +84,21 @@ export const useBranchPins = create<BranchPinsState>((set, get) => ({
     // all removed leaves no entry behind.
     if (next.length === 0) delete byRepo[repoPath];
     else byRepo[repoPath] = next;
+    set({ byRepo });
+    persist(byRepo);
+  },
+
+  rename(repoPath, from, to) {
+    if (!repoPath || !from || !to || from === to) return;
+    const current = get().byRepo[repoPath] ?? EMPTY;
+    if (!current.includes(from)) return;
+    const byRepo = { ...get().byRepo };
+    // Mapped in place rather than removed and appended: the array's order is
+    // the pin order (#238), and a rename is not a re-pin. A `to` that was
+    // somehow already pinned would double up, so it is dropped first.
+    byRepo[repoPath] = current
+      .filter((n) => n === from || n !== to)
+      .map((n) => (n === from ? to : n));
     set({ byRepo });
     persist(byRepo);
   },

--- a/src/features/dnd/resolveDrop.test.ts
+++ b/src/features/dnd/resolveDrop.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "vitest";
 import {
+  resolveBranchMoveDrop,
   resolveGraphDrop,
   resolveStagingDrop,
+  type BranchMoveContext,
+  type BranchMoveTarget,
   type GraphContext,
   type GraphDropTarget,
 } from "./resolveDrop";
@@ -150,5 +153,92 @@ describe("resolveGraphDrop", () => {
     expect(
       resolveGraphDrop(ref("feature", false), refTarget("develop"), detached)?.kind,
     ).toBe("rejected");
+  });
+});
+
+describe("resolveBranchMoveDrop", () => {
+  const folder = (path: string): BranchMoveTarget => ({ kind: "folder", path });
+  const root: BranchMoveTarget = { kind: "root" };
+  const ctx: BranchMoveContext = {
+    local: ["main", "bugfix", "feat/a", "feat/b", "feat/deep/c", "release/x"],
+  };
+
+  it("moves a top-level branch into a folder", () => {
+    expect(resolveBranchMoveDrop(ref("bugfix", false), folder("feat"), ctx)).toEqual({
+      kind: "move",
+      from: "bugfix",
+      to: "feat/bugfix",
+    });
+  });
+
+  it("moves a branch from one folder to another", () => {
+    expect(resolveBranchMoveDrop(ref("feat/a", false), folder("release"), ctx)).toEqual({
+      kind: "move",
+      from: "feat/a",
+      to: "release/a",
+    });
+  });
+
+  it("moves a branch into a nested folder", () => {
+    expect(
+      resolveBranchMoveDrop(ref("bugfix", false), folder("feat/deep"), ctx),
+    ).toEqual({ kind: "move", from: "bugfix", to: "feat/deep/bugfix" });
+  });
+
+  it("moves a branch out to the top level", () => {
+    expect(resolveBranchMoveDrop(ref("feat/a", false), root, ctx)).toEqual({
+      kind: "move",
+      from: "feat/a",
+      to: "a",
+    });
+  });
+
+  // Only the leaf travels, like a file dragged between directories: the folder
+  // it came out of is not part of its new name.
+  it("carries only the last segment out of a deep folder", () => {
+    expect(
+      resolveBranchMoveDrop(ref("feat/deep/c", false), folder("release"), ctx),
+    ).toEqual({ kind: "move", from: "feat/deep/c", to: "release/c" });
+  });
+
+  // The current branch renames like any other — `git branch -m <new>` is
+  // exactly this — so the gesture is not gated on it.
+  it("moves the current branch", () => {
+    expect(resolveBranchMoveDrop(ref("main", true), folder("feat"), ctx)).toEqual({
+      kind: "move",
+      from: "main",
+      to: "feat/main",
+    });
+  });
+
+  it("is a no-op on the folder the branch already sits in", () => {
+    expect(resolveBranchMoveDrop(ref("feat/a", false), folder("feat"), ctx)).toBeNull();
+  });
+
+  it("is a no-op dropping a top-level branch onto the top level", () => {
+    expect(resolveBranchMoveDrop(ref("bugfix", false), root, ctx)).toBeNull();
+  });
+
+  it("rejects a name the repository already uses", () => {
+    expect(
+      resolveBranchMoveDrop(ref("bugfix", false), folder("release"), {
+        local: [...ctx.local, "release/bugfix"],
+      }),
+    ).toEqual({ kind: "rejected", reason: "release/bugfix already exists" });
+  });
+
+  // A remote-tracking ref is not a branch git can move. Reported rather than
+  // ignored, so the gesture explains itself mid-drag instead of going dead.
+  it("rejects a remote-tracking branch", () => {
+    expect(
+      resolveBranchMoveDrop(ref("origin/feat/a", false), folder("release"), ctx)?.kind,
+    ).toBe("rejected");
+  });
+
+  it("ignores payloads that are not refs", () => {
+    expect(resolveBranchMoveDrop(commit(HEAD_OID), folder("feat"), ctx)).toBeNull();
+    expect(
+      resolveBranchMoveDrop(files("unstaged", ["a.txt"]), folder("feat"), ctx),
+    ).toBeNull();
   });
 });

--- a/src/features/dnd/resolveDrop.ts
+++ b/src/features/dnd/resolveDrop.ts
@@ -106,3 +106,62 @@ export function resolveGraphDrop(
     )} first`,
   };
 }
+
+// ─── Branch folders ──────────────────────────────────────────────────────────
+
+/**
+ * Where a dragged branch was dropped: into a folder of the branch tree (#244),
+ * or back out to the top level.
+ */
+export type BranchMoveTarget =
+  | { kind: "folder"; path: string }
+  | { kind: "root" };
+
+export type BranchMove =
+  | { kind: "move"; from: string; to: string }
+  | { kind: "rejected"; reason: string };
+
+export interface BranchMoveContext {
+  /**
+   * Every LOCAL branch name in the repository. It answers both halves of
+   * legality at once: what may be dragged at all (a remote-tracking ref is not
+   * a branch git can move) and what the destination name would collide with.
+   */
+  local: readonly string[];
+}
+
+/** The last segment of a branch name — the part that travels between folders. */
+function leafOf(name: string): string {
+  const parts = name.split("/");
+  return parts[parts.length - 1] || name;
+}
+
+/**
+ * What dropping a branch on a folder means: a RENAME.
+ *
+ * A branch folder is not a git object — it is the `/` in a name — so moving a
+ * branch between folders is `git branch -m` and nothing else. Only the leaf
+ * travels, like a file dragged between directories: `feat/deep/c` dropped on
+ * `release` becomes `release/c`, not `release/deep/c`.
+ *
+ * Null means "nothing to do" (the payload is not a branch, or it already sits
+ * where it was dropped); a `rejected` result is a gesture with a meaning we
+ * refuse, so the reason can be shown on the ghost mid-drag.
+ */
+export function resolveBranchMoveDrop(
+  src: DragPayload,
+  target: BranchMoveTarget,
+  ctx: BranchMoveContext,
+): BranchMove | null {
+  if (src.kind !== "ref") return null;
+  // Not in the local list = a remote-tracking ref or a tag pill. Renaming
+  // either is not what the gesture looks like it does.
+  if (!ctx.local.includes(src.ref))
+    return { kind: "rejected", reason: "Only local branches can move between folders" };
+  const leaf = leafOf(src.ref);
+  const to = target.kind === "folder" ? `${target.path}/${leaf}` : leaf;
+  if (to === src.ref) return null;
+  if (ctx.local.includes(to))
+    return { kind: "rejected", reason: `${to} already exists` };
+  return { kind: "move", from: src.ref, to };
+}

--- a/src/features/repo/useRepoStore.ts
+++ b/src/features/repo/useRepoStore.ts
@@ -122,6 +122,7 @@ import {
 } from "@/lib/tauri";
 import { isFilterEmpty } from "@/features/commits/logFilter";
 import { remoteOfUpstream } from "@/features/branches/fastForward";
+import { useBranchPins } from "@/features/branches/useBranchPins";
 import { useSettingsStore } from "@/features/settings/useSettingsStore";
 import { useRecentsStore } from "./useRecentsStore";
 import {
@@ -1699,6 +1700,11 @@ export const useRepoStore = create<RepoStoreState>((set, get) => {
     if (!repo) return;
     try {
       await renameBranch(repo.id, from, to);
+      // A pin matches the name exactly, so the pin has to follow the branch —
+      // otherwise renaming a pinned branch (or dragging it into a folder,
+      // #244) silently unpins it. After the rename only: a failed one must
+      // leave the pin on the name that still exists.
+      useBranchPins.getState().rename(repo.path, from, to);
       await get().refreshAll();
     } catch (e) {
       setErrorFor(repo.id, e);

--- a/src/screens/Branches.dnd.test.tsx
+++ b/src/screens/Branches.dnd.test.tsx
@@ -1,0 +1,276 @@
+// Dragging a branch between folders (#244).
+//
+// A branch folder is not a git object — it is the `/` in the name — so this
+// gesture is `git branch -m` and nothing else. The decision table itself is
+// tested in `features/dnd/resolveDrop.test.ts`; this covers the wiring it
+// cannot see: which element starts a drag, which one accepts it, that the drop
+// confirms before renaming anything, and that the keyboard can do the same
+// thing without a pointer.
+//
+// jsdom has no PointerEvent; a MouseEvent typed as one keeps clientX/clientY.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { BranchesScreen } from "./Branches";
+import { useRepoStore } from "@/features/repo/useRepoStore";
+import { useKeymapStore, useFocusStore } from "@/features/keymap";
+import { useDragStore } from "@/features/dnd";
+import { reloadCollapsedFolders } from "@/features/branches/useBranchFolders";
+import { mockInvoke, resetInvokeMock } from "@/test/invokeMock";
+import {
+  WithDialogs,
+  acceptDialog,
+  dismissDialog,
+  resetDialogs,
+} from "@/test/dialog";
+import type { BranchInfo } from "@/lib/types";
+
+const mkBranch = (over: Partial<BranchInfo> & { name: string }): BranchInfo => ({
+  isHead: false,
+  isRemote: false,
+  upstream: null,
+  ahead: 0,
+  behind: 0,
+  tip: "0".repeat(40),
+  tipTime: 0,
+  isDefault: false,
+  ...over,
+});
+
+const BRANCHES = [
+  mkBranch({ name: "main", tipTime: 10, isDefault: true, isHead: true }),
+  mkBranch({ name: "bugfix", tipTime: 950 }),
+  mkBranch({ name: "feat/alpha", tipTime: 900 }),
+  mkBranch({ name: "feat/beta", tipTime: 800 }),
+  mkBranch({ name: "release/one", tipTime: 700 }),
+  mkBranch({ name: "release/two", tipTime: 600 }),
+  mkBranch({ name: "origin/feat/alpha", tipTime: 500, isRemote: true }),
+  mkBranch({ name: "origin/feat/beta", tipTime: 400, isRemote: true }),
+];
+
+function pointer(type: string, x: number, y: number): MouseEvent {
+  return new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+    clientX: x,
+    clientY: y,
+  });
+}
+
+function drag(from: Element, to: Element) {
+  act(() => {
+    from.dispatchEvent(pointer("pointerdown", 10, 10));
+    to.dispatchEvent(pointer("pointermove", 90, 40));
+    to.dispatchEvent(pointer("pointermove", 91, 41));
+    to.dispatchEvent(pointer("pointerup", 91, 41));
+  });
+}
+
+/** Arm and move a drag WITHOUT releasing it, so mid-gesture state is readable. */
+function dragOver(from: Element, to: Element) {
+  act(() => {
+    from.dispatchEvent(pointer("pointerdown", 10, 10));
+    to.dispatchEvent(pointer("pointermove", 90, 40));
+    to.dispatchEvent(pointer("pointermove", 91, 41));
+  });
+}
+
+function endDrag(to: Element) {
+  act(() => {
+    to.dispatchEvent(pointer("pointerup", 91, 41));
+  });
+}
+
+const branchRow = (name: string) =>
+  document.querySelector(`[data-branch-name="${name}"]`) as HTMLElement;
+const folderRow = (path: string) =>
+  document.querySelector(`[data-folder="${path}"]`) as HTMLElement;
+const ghost = () => document.querySelector('[data-testid="drag-ghost"]');
+
+function setup(branches = BRANCHES) {
+  const renameBranch = vi.fn(async () => {});
+  useRepoStore.setState({
+    current: { id: "repo-1", path: "/repo", head: "refs/heads/main" },
+    status: [],
+    branches,
+    remotes: [],
+    tags: [],
+    stashes: [],
+    commits: [],
+    loading: false,
+    checkoutBranch: async () => {},
+    renameBranch,
+  } as never);
+  mockInvoke("get_status", () => []);
+  mockInvoke("list_branches", () => branches);
+  render(
+    <WithDialogs>
+      <BranchesScreen />
+    </WithDialogs>,
+  );
+  useFocusStore.setState({ focused: "branches.list" });
+  return { renameBranch };
+}
+
+describe("Branches folder drag", () => {
+  beforeEach(() => {
+    resetInvokeMock();
+    resetDialogs();
+    localStorage.clear();
+    reloadCollapsedFolders();
+    useDragStore.setState({ payload: null, overId: null });
+    useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
+    useKeymapStore.getState().setPreset("rider");
+    useFocusStore.setState({
+      focused: null,
+      panes: new Map(),
+      order: [],
+      barId: null,
+      pendingContentFocus: false,
+    });
+  });
+
+  it("renames a branch into the folder it is dropped on, after confirming", async () => {
+    const { renameBranch } = setup();
+
+    drag(branchRow("bugfix"), folderRow("feat"));
+
+    await waitFor(() => expect(screen.getByTestId("dialog-title")).toBeTruthy());
+    expect(screen.getByTestId("dialog-title").textContent).toContain(
+      "Move bugfix to feat/bugfix",
+    );
+    await acceptDialog();
+    expect(renameBranch).toHaveBeenCalledWith("bugfix", "feat/bugfix");
+  });
+
+  // The store reports a failed rename on the banner and leaves the old name in
+  // place. Selecting the name it was going to have would strand the inspector
+  // and the keyboard list on a row that does not exist.
+  it("leaves the selection alone when the rename fails", async () => {
+    setup();
+    const before = document.querySelector("[data-selected]");
+    // A rename that changes nothing is what a failure looks like from here.
+    useRepoStore.setState({ renameBranch: async () => {} } as never);
+
+    drag(branchRow("bugfix"), folderRow("feat"));
+    await waitFor(() => expect(screen.getByTestId("dialog-title")).toBeTruthy());
+    await acceptDialog();
+
+    expect(document.querySelector("[data-selected]")).toBe(before);
+    expect(branchRow("feat/bugfix")).toBeNull();
+  });
+
+  it("touches nothing when the confirm is dismissed", async () => {
+    const { renameBranch } = setup();
+
+    drag(branchRow("bugfix"), folderRow("release"));
+
+    await waitFor(() => expect(screen.getByTestId("dialog-title")).toBeTruthy());
+    await dismissDialog();
+    expect(renameBranch).not.toHaveBeenCalled();
+  });
+
+  // Only the leaf travels, like a file dragged between directories.
+  it("carries only the last segment from one folder to another", async () => {
+    const { renameBranch } = setup();
+
+    drag(branchRow("feat/alpha"), folderRow("release"));
+
+    await waitFor(() => expect(screen.getByTestId("dialog-title")).toBeTruthy());
+    await acceptDialog();
+    expect(renameBranch).toHaveBeenCalledWith("feat/alpha", "release/alpha");
+  });
+
+  it("does nothing when a branch is dropped on the folder it already sits in", () => {
+    const { renameBranch } = setup();
+
+    drag(branchRow("feat/alpha"), folderRow("feat"));
+
+    expect(screen.queryByTestId("dialog-title")).toBeNull();
+    expect(renameBranch).not.toHaveBeenCalled();
+  });
+
+  it("refuses a remote-tracking branch, and says so on the ghost", () => {
+    const { renameBranch } = setup();
+
+    dragOver(branchRow("origin/feat/alpha"), folderRow("release"));
+    expect(ghost()?.textContent).toContain("local branches");
+    expect(ghost()?.getAttribute("data-drop")).toBe("no");
+    endDrag(folderRow("release"));
+
+    expect(screen.queryByTestId("dialog-title")).toBeNull();
+    expect(renameBranch).not.toHaveBeenCalled();
+  });
+
+  it("refuses a move whose destination name is taken", () => {
+    const { renameBranch } = setup([
+      ...BRANCHES,
+      mkBranch({ name: "release/alpha", tipTime: 100 }),
+    ]);
+
+    dragOver(branchRow("feat/alpha"), folderRow("release"));
+    expect(ghost()?.textContent).toContain("release/alpha already exists");
+    endDrag(folderRow("release"));
+
+    expect(renameBranch).not.toHaveBeenCalled();
+  });
+
+  it("marks the folder under the pointer as the live drop target", () => {
+    setup();
+
+    dragOver(branchRow("bugfix"), folderRow("feat"));
+    expect(folderRow("feat").hasAttribute("data-pg-drop-over")).toBe(true);
+    endDrag(folderRow("feat"));
+    expect(folderRow("feat").hasAttribute("data-pg-drop-over")).toBe(false);
+  });
+
+  // The grid has no root header to aim at, so the "out of a folder" target
+  // exists only for the duration of the gesture — like `StageDropBar`.
+  describe("the top-level drop bar", () => {
+    it("is absent until a nested local branch is dragged", () => {
+      setup();
+      expect(screen.queryByTestId("branch-root-drop")).toBeNull();
+
+      dragOver(branchRow("feat/alpha"), folderRow("release"));
+      expect(screen.getByTestId("branch-root-drop")).toBeTruthy();
+      endDrag(folderRow("release"));
+      expect(screen.queryByTestId("branch-root-drop")).toBeNull();
+    });
+
+    it("stays away for a branch that is already at the top level", () => {
+      setup();
+      dragOver(branchRow("bugfix"), folderRow("feat"));
+      expect(screen.queryByTestId("branch-root-drop")).toBeNull();
+      endDrag(folderRow("feat"));
+    });
+
+    it("stays away for a remote branch, which cannot be moved at all", () => {
+      setup();
+      dragOver(branchRow("origin/feat/alpha"), folderRow("release"));
+      expect(screen.queryByTestId("branch-root-drop")).toBeNull();
+      endDrag(folderRow("release"));
+    });
+
+    it("moves a branch out of its folder", async () => {
+      const { renameBranch } = setup();
+
+      act(() => {
+        branchRow("feat/alpha").dispatchEvent(pointer("pointerdown", 10, 10));
+        branchRow("feat/alpha").dispatchEvent(pointer("pointermove", 90, 40));
+      });
+      const bar = screen.getByTestId("branch-root-drop");
+      act(() => {
+        bar.dispatchEvent(pointer("pointermove", 91, 41));
+        bar.dispatchEvent(pointer("pointerup", 91, 41));
+      });
+
+      await waitFor(() => expect(screen.getByTestId("dialog-title")).toBeTruthy());
+      expect(screen.getByTestId("dialog-title").textContent).toContain(
+        "Move feat/alpha to alpha",
+      );
+      await acceptDialog();
+      expect(renameBranch).toHaveBeenCalledWith("feat/alpha", "alpha");
+    });
+  });
+});

--- a/src/screens/Branches.folders.test.tsx
+++ b/src/screens/Branches.folders.test.tsx
@@ -11,7 +11,10 @@ import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useKeymapStore, useFocusStore } from "@/features/keymap";
 import { mockInvoke, resetInvokeMock } from "@/test/invokeMock";
 import { WithDialogs, resetDialogs } from "@/test/dialog";
-import { BRANCH_FOLDERS_KEY } from "@/features/branches/useBranchFolders";
+import {
+  BRANCH_FOLDERS_KEY,
+  reloadCollapsedFolders,
+} from "@/features/branches/useBranchFolders";
 import type { BranchInfo } from "@/lib/types";
 
 const mkBranch = (over: Partial<BranchInfo> & { name: string }): BranchInfo => ({
@@ -93,6 +96,9 @@ describe("Branches folder tree", () => {
     resetInvokeMock();
     resetDialogs();
     localStorage.clear();
+    // The folds are a shared store (two surfaces render the tree), so clearing
+    // the key is not enough to keep one case's folds out of the next.
+    reloadCollapsedFolders();
     useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
     useKeymapStore.getState().setPreset("rider");
     useFocusStore.setState({

--- a/src/screens/Branches.pins.test.tsx
+++ b/src/screens/Branches.pins.test.tsx
@@ -12,7 +12,10 @@ import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useKeymapStore, useFocusStore } from "@/features/keymap";
 import { mockInvoke, resetInvokeMock } from "@/test/invokeMock";
 import { WithDialogs, resetDialogs } from "@/test/dialog";
-import { BRANCH_FOLDERS_KEY } from "@/features/branches/useBranchFolders";
+import {
+  BRANCH_FOLDERS_KEY,
+  reloadCollapsedFolders,
+} from "@/features/branches/useBranchFolders";
 import { useBranchPins } from "@/features/branches/useBranchPins";
 import type { BranchInfo } from "@/lib/types";
 
@@ -78,6 +81,9 @@ beforeEach(() => {
   resetInvokeMock();
   resetDialogs();
   localStorage.clear();
+  // The folds are a shared store (two surfaces render the tree), so clearing
+  // the key is not enough to keep one case's folds out of the next.
+  reloadCollapsedFolders();
   useBranchPins.setState({ byRepo: {} });
   useKeymapStore.setState({ handlers: new Map(), lastShiftAt: 0 });
   useKeymapStore.getState().setPreset("rider");
@@ -105,6 +111,7 @@ describe("pinned branches on the Branches screen", () => {
     // The case pinning exists for: without the hoist the row would be the first
     // one INSIDE `feat`, and a collapsed `feat` would hide it entirely.
     localStorage.setItem(BRANCH_FOLDERS_KEY, JSON.stringify({ "/repo": ["feat"] }));
+    reloadCollapsedFolders();
     useBranchPins.setState({ byRepo: { "/repo": ["feat/beta"] } });
     setup();
 

--- a/src/screens/Branches.tsx
+++ b/src/screens/Branches.tsx
@@ -29,13 +29,23 @@ import { useRepoStore } from "@/features/repo/useRepoStore";
 import { orderBranches } from "@/features/branches/orderBranches";
 import {
   branchFolderPaths,
-  branchTreeRows,
+  branchLeafRows,
+  branchTreeRowsWithPins,
   branchesInFolder,
   parentFolderPath,
   type BranchTreeRow,
 } from "@/features/branches/branchTree";
 import { useBranchFolders } from "@/features/branches/useBranchFolders";
+import { BranchFolderDropBar } from "@/features/branches/BranchFolderDropBar";
 import { usePinSet } from "@/features/branches/usePinSet";
+import {
+  resolveBranchMoveDrop,
+  useDragSource,
+  useDropZone,
+  type BranchMove,
+  type DragPayload,
+  type DropResolution,
+} from "@/features/dnd";
 import {
   deleteMergedCandidates,
   findMergedBranches,
@@ -304,31 +314,19 @@ export function BranchesScreen() {
   // behind a folded folder is the one thing a search box must never do. Rows
   // then show their FULL names, because a bare `bar` with no `feat/foo` above
   // it names nothing.
+  // Pinned branches are hoisted OUT of the tree rather than sorted to the
+  // front of it (#238) — the rule, and the reason for it, live in
+  // `branchTreeRowsWithPins`, which the titlebar picker renders through too.
+  // The default branch escapes the hoist today only because `main` has no `/`
+  // and is therefore already a root-level leaf.
   const filtering = filter.length > 0;
-  const displayRows = React.useMemo<BranchTreeRow<BranchRow>[]>(() => {
-    const flat = (b: BranchRow) => ({
-      kind: "branch" as const,
-      path: b.name,
-      label: b.name,
-      depth: 0,
-      branch: b,
-    });
-    if (filtering) return rows.map(flat);
-    // Pinned branches are HOISTED OUT of the tree (#238), not just sorted to
-    // the front of it. Grouping only moves ordered rows into folders, so a
-    // pinned `feat/foo` would otherwise be the first row INSIDE `feat` — and
-    // invisible whenever that folder is collapsed, which is the case pinning
-    // exists for. The default branch escapes this today only because `main`
-    // has no `/` and is therefore already a root-level leaf.
-    //
-    // They render at depth 0 under their FULL names (a bare `foo` with no
-    // `feat/` above it names nothing) and are REMOVED from the tree rather
-    // than duplicated into it. `rows` is already ordered pins-first, so the
-    // hoisted block and the tree below it are in one continuous order.
-    const pinned = rows.filter((b) => pins.has(b.name));
-    const rest = rows.filter((b) => !pins.has(b.name));
-    return [...pinned.map(flat), ...branchTreeRows(rest, folders.collapsed)];
-  }, [rows, filtering, folders.collapsed, pins]);
+  const displayRows = React.useMemo<BranchTreeRow<BranchRow>[]>(
+    () =>
+      filtering
+        ? branchLeafRows(rows)
+        : branchTreeRowsWithPins(rows, pins, folders.collapsed),
+    [rows, filtering, folders.collapsed, pins],
+  );
 
   const visibleTags = React.useMemo(() => {
     if (view === "stashes") return [];
@@ -381,6 +379,92 @@ export function BranchesScreen() {
     if (folders.collapsed.has(path)) folders.expand([path]);
     else collapseFolder(path);
   };
+
+  // ─── Moving a branch between folders (#244) ─────────────────────────────────
+  //
+  // A branch folder is not a git object — it is the `/` in the name — so
+  // dragging a branch into one is `git branch -m` and nothing else. Which drops
+  // are legal is decided entirely by `resolveBranchMoveDrop`; this half does the
+  // DOM work and calls the op, the same split the graph's drops keep.
+  const localNames = React.useMemo(
+    () => branches.filter((b) => !b.isRemote).map((b) => b.name),
+    [branches],
+  );
+
+  const applyBranchMove = async (move: { from: string; to: string }) => {
+    const ok = await pgConfirm({
+      title: `Move ${move.from} to ${move.to}?`,
+      body: 'A folder is the "/" in a branch name, so this renames the branch. Its commits, reflog and upstream tracking are unchanged, and the remote branch it tracks keeps the name it has.',
+      confirmLabel: "Move",
+    });
+    if (!ok) return;
+    await useRepoStore.getState().renameBranch(move.from, move.to);
+    // The store reports a failed rename on the banner and leaves the old name
+    // in place, so the new one is only worth selecting if it now exists — the
+    // branch list is already refreshed by the time that call resolves.
+    if (!useRepoStore.getState().branches.some((b) => b.name === move.to)) return;
+    // Land the selection where the branch now lives, and open whatever was
+    // folded over it: a move you cannot see the result of reads as a branch
+    // that vanished.
+    const holding = [...folders.collapsed].filter((p) =>
+      move.to.startsWith(`${p}/`),
+    );
+    if (holding.length) folders.expand(holding);
+    setSelection({ kind: "branch", name: move.to });
+  };
+
+  const branchDragSource = useDragSource(
+    React.useCallback(
+      (target: HTMLElement): DragPayload | null => {
+        const rowEl = target.closest("[data-branch-name]") as HTMLElement | null;
+        const name = rowEl?.getAttribute("data-branch-name");
+        if (!name) return null;
+        // A remote row IS draggable on purpose: the resolver refuses it with a
+        // reason on the ghost, which beats a row that silently does nothing.
+        return {
+          kind: "ref",
+          ref: name,
+          isHead: !!branches.find((b) => b.name === name && !b.isRemote)?.isHead,
+          label: name,
+        };
+      },
+      [branches],
+    ),
+  );
+
+  const resolveFolderDrop = React.useCallback(
+    (el: HTMLElement, p: DragPayload): DropResolution | null => {
+      const folderEl = el.closest("[data-folder]") as HTMLElement | null;
+      const path = folderEl?.getAttribute("data-folder");
+      if (!folderEl || !path) return null;
+      const drop = resolveBranchMoveDrop(
+        p,
+        { kind: "folder", path },
+        { local: localNames },
+      );
+      if (!drop) return null;
+      if (drop.kind === "rejected")
+        return { key: "", el: folderEl, reason: drop.reason };
+      // The key round-trips the decision so `onDrop` does not resolve twice —
+      // by the time the confirm answers, the pointer is long gone.
+      return { key: JSON.stringify(drop), el: folderEl };
+    },
+    [localNames],
+  );
+
+  const folderZone = useDropZone({
+    id: "branches.folders",
+    accepts: (p) => p.kind === "ref",
+    resolve: resolveFolderDrop,
+    onDrop: (_p, key) => {
+      if (!key) return;
+      const drop = JSON.parse(key) as BranchMove;
+      if (drop.kind === "move") void applyBranchMove(drop);
+    },
+    // The ghost carried the reason mid-gesture; this is for the user who let go
+    // without reading it, so a refused drop is never silence.
+    onReject: (_p, reason) => pgFlash(reason),
+  });
 
   usePaneList({
     paneId: "branches.list",
@@ -523,7 +607,15 @@ export function BranchesScreen() {
           }}
         >
           <FocusableScroll ariaLabel="Refs list" style={{ flex: 1 }}>
-          <div style={{ minWidth: totalWidth }}>
+          {/* One delegated drag source and one delegated drop zone for the
+              whole table (#244): the rows stay plain markup carrying
+              `data-branch-name` / `data-folder`, and no per-row closure is
+              threaded through them. */}
+          <div
+            ref={folderZone.ref}
+            {...branchDragSource}
+            style={{ minWidth: totalWidth }}
+          >
             <div
               style={{
                 display: "grid",
@@ -715,6 +807,8 @@ export function BranchesScreen() {
                 onContextMenu={(e) => onBranchCtx(e, b)}
                 data-pg-row=""
                 data-testid="branch-row"
+                // What the delegated drag source reads off the row (#244).
+                data-branch-name={b.name}
                 data-selected={
                   selection?.kind === "branch" && selection.name === b.name
                     ? ""
@@ -1031,6 +1125,13 @@ export function BranchesScreen() {
             ))}
           </div>
           </FocusableScroll>
+          {/* The "out of a folder" target, which the grid has no room for
+              permanently — see BranchFolderDropBar. */}
+          <BranchFolderDropBar
+            local={localNames}
+            onMove={(m) => void applyBranchMove(m)}
+            onReject={(reason) => pgFlash(reason)}
+          />
         </PGPane>
 
         <PGResizeHandle


### PR DESCRIPTION
Finishes the two pieces #303 deliberately left open on #244.

## Drag a branch between folders

A branch folder is not a git object — it is the `/` in the name — so a drop onto
a folder row is `git branch -m` and nothing else. Only the leaf travels, like a
file dragged between directories (`feat/deep/c` onto `release` is `release/c`).

- `resolveBranchMoveDrop` (`features/dnd/resolveDrop.ts`) owns every legality
  question: `null` for a no-op (dropped on the folder it already sits in), a
  `rejected` reason shown on the ghost for a remote-tracking ref or a
  destination name that is taken.
- The drop **confirms** before renaming, the same shape the graph's merge and
  rebase drops have — a stray pointer release must not rename a branch.
- The "out of a folder" half has nowhere permanent to live in a one-grid table,
  so `BranchFolderDropBar` appears for the duration of the gesture the way
  `StageDropBar` does, and only for a drag it can serve (a local branch that is
  actually inside a folder). A permanently dead target is worse than none.
- **Keyboard equivalent:** "Move to folder…" on the branch menu, so it reaches
  every branch surface and not just this screen. It routes its answer through
  the same resolver as the drop, which is what stops the two from disagreeing
  about a collision. Empty answer = top level.

## Folders in the titlebar picker

Same `branchTreeRows`, off the **same** per-repository fold set — one repository
has one notion of which folders are folded. Each section trees on its own, so
folding `origin` cannot fold the local `feat` beside it.

A folder row there is not checkout-able: Enter toggles it, → opens it, ← folds
it or climbs out. The documented resting rule extends rather than bends — the
cursor rests on HEAD's row, or, when HEAD is folded away, on the folder holding
it, so a stray Enter is still a no-op.

## Three fixes that fell out of it, here on purpose

- **A pin now follows a renamed branch** (`useBranchPins.rename`). A pin matches
  the name exactly, so a rename silently unpinned it — this fixes the existing
  menu Rename too, not just the new drag.
- **The folds are one store.** They were per-hook React state on a shared
  localStorage key; with two surfaces rendering the tree at once, the last one
  to write dropped the other's folds. Now one zustand store (the reason the pins
  already are), read through the store on every mutation rather than off the
  render that produced the callback — a fold can be applied after an `await`.
- **The picker's length-clamp effect** read `activeIndex` out of its render
  closure and could overwrite the resting effect's choice in the same commit.
  The extra folder row made that reachable just by typing a query.

## The rules this had to keep

Grouping still runs **last** and never sorts, so #135's order and #238's pins
hold. The hoist rule moved into `branchTreeRowsWithPins` so both surfaces render
through one implementation. Every expectation in the picker's #135 tests is
unchanged — only the helper reading a row's *name*, which a tree no longer
spells in the label.

## Verification

- `pnpm test` — 345 files, **3421** tests (47 new).
- `pnpm tsc --noEmit` and the `e2e/` typecheck gate.
- e2e in Docker against the real binary: `branches.e2e.ts` (4 passing, including
  the 61-branch picker fixture) and `merge-conflict.e2e.ts` (5 passing), which
  context-menus a picker row.

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)
