### PR TITLE
perf(git): run the read-only fan-out concurrently instead of queued

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,8 +216,14 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
 - **Drag and drop:** pointer events via `features/dnd`, never HTML5 dnd; every
   drag has a keyboard equivalent. (`docs/dev/frontend.md`)
 - **`git2::Repository` is `Send` not `Sync`** — wrap git2 work in
-  `spawn_blocking`; per-repo ops serialize on an inner mutex. Verify and mutate
-  under ONE lock acquisition (stash TOCTOU). (`docs/dev/backend.md`)
+  `spawn_blocking`. Per-repo WRITES serialize on one cached handle; reads run
+  concurrently on private handles (`git/repo_locks.rs`). `with_repo` is the
+  exclusive/write path and `with_repo_read` the shared one — the `_mut` suffix
+  is about libgit2's C signatures, NOT reads vs writes, and `with_repo` carries
+  most of this backend's writes. An op joins the `_read` helpers only once
+  established to write nothing. Verify and mutate under ONE lock acquisition
+  (stash TOCTOU); never nest two lock helpers on one repository.
+  (`docs/dev/backend.md`)
 - **Tauri permissions:** shared set in `capabilities/default.json`; privileged
   ones (updater, e2e) stay in their scoped capability files. A new window label
   must match a pattern in that file's `windows` list (`pg-*` since #256) or the

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -264,6 +264,16 @@ git/
 │                summary in a second file. Deliberately NOT git's own
 │                rebase-merge/ dir — a half-compatible one would let git claim
 │                a rebase it cannot drive
+├── repo_locks.rs  RepoLock<T> — how ONE repository's git2 handles are ordered
+│                (#400). One cached handle behind a mutex for writes, a factory
+│                minting a private handle per read, an RwLock gate ordering the
+│                two. `with_repo`/`with_repo_mut` are the exclusive path,
+│                `with_repo_read`/`with_repo_read_mut` the shared one — the
+│                `_mut` suffix is about libgit2's C signatures, NOT reads vs
+│                writes. Read-vs-read exclusion is the only thing dropped; a
+│                write still excludes everything. Carries its own unit tests
+│                with a fake handle, proving overlap by barrier rather than by
+│                wall clock. See backend.md
 ├── update_refs.rs  Stacked branches (#240) — git's `rebase --update-refs`,
 │                IMPLEMENTED not passed through, because our rebase is our own
 │                libgit2 replay with no `git rebase` process to hand a flag to.

--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -1154,13 +1154,160 @@ sides and builds the argv; `commands/diff.rs::open_in_difftool` spawns it.
 
 ## Async / threading
 
-- `git2::Repository` is `Send` but not `Sync`. Each opened repo is
-  `Arc<Mutex<Repository>>` inside a `Mutex<HashMap<RepoId, …>>`; `with_repo`
-  clones the Arc and RELEASES the map lock before the op — different repos run
-  in parallel, same-repo ops serialize on the inner mutex (the stash TOCTOU
-  note relies on this). `close` is the only removal.
+- `git2::Repository` is `Send` but not `Sync`. Each opened repo is an
+  `Arc<RepoLock<Repository>>` inside a `Mutex<HashMap<RepoId, …>>`; `repo_cell`
+  clones the Arc and RELEASES the map lock before the op, so different repos run
+  in parallel. `close` is the only removal.
+- Same-repo **writes** serialize; same-repo **reads** do not — see below.
 - Always wrap git2 work in `spawn_blocking` from Tauri commands — don't block
   the async runtime.
+
+### Reads run concurrently; writes do not (#400)
+
+Each repository sits behind a `RepoLock` (`git/repo_locks.rs`), which is two
+things at once: the single cached `git2::Repository` every write uses, and a
+factory that mints a handle for one read to keep to itself. An `RwLock` gate
+orders them — reads share it, writes take it alone.
+
+Concurrent reads could not have come from swapping the mutex for an `RwLock`:
+`Repository` is not `Sync`, so several threads may not hold `&Repository` at
+once. The parallelism has to come from separate handles.
+
+**Four helpers, and the naming is a trap worth reading twice.**
+
+| helper | concurrency | handle |
+| --- | --- | --- |
+| `with_repo` | exclusive | the cached one, `&Repository` |
+| `with_repo_mut` | exclusive | the cached one, `&mut Repository` |
+| `with_repo_read` | shared | a private one, `&Repository` |
+| `with_repo_read_mut` | shared | a private one, `&mut Repository` |
+
+`with_repo` vs `with_repo_mut` is **not** a read/write split, and reading it as
+one is how you would break the index. `with_repo` carries most of the writes in
+this backend — `stage`/`unstage`/`discard` read-modify-write the whole index
+through it, `commit` writes an object and moves a ref, `checkout_branch` and
+`reset` rewrite the worktree. `git2` takes `&self` for nearly all of that.
+`with_repo_mut` exists only for the seven places libgit2's C signatures demand
+`&mut git_repository` (`stash_foreach`, `stash_drop`).
+
+The real split is `_read` or not. **An op joins the `_read` helpers only once it
+is established to write nothing** — no index write-back, no ref move, no object
+written, no worktree change. Exclusive is the safe default and where an
+unexamined op belongs.
+
+**What the gate is for.** Not single-file atomicity: git already provides that,
+and it was checked rather than assumed — removing the gate entirely leaves
+`tests/concurrent_reads.rs` green, because libgit2 writes the index to
+`.git/index.lock` and renames it into place, so a reader sees the whole old
+index or the whole new one. The gate protects the **in-process, multi-call**
+invariants, where a guarantee spans several git calls inside one closure and no
+single rename covers it: the stash verify-then-drop pair, the fast-forward
+ancestry-check-then-ref-move, `fresh_index`'s whole-index write-back, `init`'s
+guard/write/cleanup window. All of those run under the exclusive gate, which
+still excludes every reader and every other writer, so all of them remain
+literally true. The only exclusion dropped is read-vs-read, and nothing was
+relying on it — neither party writes. The test that fails without the gate is
+the unit test `shared_and_exclusive_never_overlap`.
+
+The app also already tolerates concurrent readers and writers it does not
+control: the built-in terminal (#243) sits in the window `cd`-ed to the
+repository, a `pre-commit` hook that reformats and restages is supported, and a
+second window (#402) drives the same repository. In-process concurrent reads are
+strictly weaker than that.
+
+**Two rules come with a private handle.**
+
+*Anything reading the index still goes through `fresh_index`.* A newly opened
+handle's in-memory index is whatever was on disk a moment ago — the same
+staleness a cached handle has, arriving by a different route.
+
+> **`status` used to refresh the index for everybody, and moving it broke two
+> screens.** This is the one regression this change actually caused, and it is
+> worth reading before touching either side of it.
+>
+> libgit2's `git_status_list_new` reloads the index from disk unless
+> `GIT_STATUS_OPT_NO_REFRESH` is set. While `status` ran on the shared cached
+> handle, every refresh — and the app refreshes constantly — was silently
+> re-reading the index on behalf of every other op on that handle. Several ops
+> read `repo.index()` directly and were correct only because of it.
+>
+> Moving `status` to a private handle took that away, and the failures were not
+> subtle. `accept_side` reads the index's conflict entries to decide which side
+> to take; against a stale snapshot it finds none, concludes the file was
+> deleted on the chosen side, and **deletes it from the worktree** — the user
+> asks to keep a version of a file and the file disappears. `conflict_sides`
+> seeds the merge window's regions the same way, so the window rendered nothing
+> to accept and Apply never enabled.
+>
+> The trigger is worth naming because it is not obvious: `merge_branch` shells
+> out to real `git merge` (`commands/branches.rs`), so conflict stages land on
+> disk with nothing telling libgit2, and the History screen's diff has already
+> loaded that handle's index while the tree was clean.
+>
+> Fixed by obeying the rule `fresh_index` already stated at every exclusive-path
+> site that reads the index to DECIDE or to WRITE BACK: `accept_side`,
+> `conflict_sides`, `mark_resolved`, `save_resolution`, `continue_operation`,
+> `read_file_content_at_index`, `read_image_preview`. Deliberately NOT changed:
+> the rebase engine's `finish_pick`/`apply_merge`/`finish_merge`, and
+> `cherry_pick`/`revert`, which read the index *after* modifying it in their own
+> closure — there the in-memory index is the authority and a reload could only
+> lose work.
+>
+> The whole Rust suite was green throughout, because every conflict test in
+> `tests/conflict.rs` opens the backend AFTER the conflict exists and so always
+> sees a fresh index. `accept_ours_survives_a_conflict_created_under_a_live_handle`
+> is the one that pins the app's real ordering; it is the only test in that file
+> that can tell `fresh_index` from `repo.index()`.
+
+*Never call a repo-lock helper from inside another one for the same repository.*
+It returns `AppError::Internal("re-entrant repository lock…")` rather than
+deadlocking, but it is a bug. Pass an already-borrowed `&Repository` down
+instead, the way `stash_pairs` and the fast-forward helpers do. The guard exists
+because a shared gate makes this hazard *intermittent*: two `read()`
+acquisitions on one thread succeed whenever no writer is waiting and deadlock
+when one is — a hang that appears under load, in release, on a user's machine,
+and never in a test. An error is something a test can catch. Nesting two
+*different* repositories stays legal; they share no lock.
+
+**Reads reopen the gitdir**, captured from the handle `open` already resolved.
+Opening the path the user named also works — libgit2 follows the `.git` file in
+a linked worktree's workdir — but the gitdir is the same repository by
+construction rather than by re-deriving it, skips that indirection on every
+read, and cannot be changed by anything happening at the user's path afterwards.
+
+**What was measured** (macOS/APFS, warm; twelve reads of the shapes `refreshAll`
+issues):
+
+| shape | wall clock |
+| --- | --- |
+| serial through one mutex | 16.9 ms |
+| parallel, a fresh handle per read | 10.6 ms |
+| parallel, a pre-warmed handle pool | 10.9 ms |
+
+`Repository::open` is ~1.1 ms warm. **A handle pool is measurably worthless** —
+do not add one without a profile that disagrees, and note that the factory lives
+behind `RepoLock::new` precisely so a pool could be added later without touching
+a call site.
+
+The 1.6× serial→parallel figure understates the fix: on APFS the fan-out is
+dominated by one slow read, so parallelising the other ten wins little. The
+reported bug is the case where every read costs the same ~9 s — twelve of those
+serialized is ~108 s and parallel is ~9 s. The win scales with how uniformly slow
+the filesystem is, which is the `/mnt/c` shape. **These numbers are all APFS**;
+no WSL machine was in the loop, so the pool conclusion rests on a ratio (1 ms
+against 9,000 ms) rather than a direct measurement.
+
+**Which ops are shared today:** `status`, `branches`, `tags`, `stashes`,
+`remotes`, `log`/`log_page`, `repo_state`, `rebase_status`, `bisect_status`,
+`head_info`, `shallow_info`, `diff_commit`/`diff_commit_over_ceiling`,
+`verify_commit`, `worktrees`. That is `refreshAll`'s eleven-read fan-out plus the
+ops behind the history-arrowing ladder in #400. Every other read-only op —
+`log_filtered`, `diff`, `diff_commits`, `file_history`, `blame_file`,
+`read_file_content*`, `commits_since`, `ahead_behind`, `submodules`,
+`lfs_status`, `commit_notes`, `read_reflog`, `list_all_files`,
+`list_files_at_rev`, `commit_template`, `difftool_plan`, `conflict_sides` — is
+still exclusive. Not because it must be, but because each needs its own proof it
+writes nothing, and moving one is a one-word change.
 
 ## Reading the log (#274)
 

--- a/docs/superpowers/plans/2026-09-04-repo-read-concurrency.md
+++ b/docs/superpowers/plans/2026-09-04-repo-read-concurrency.md
@@ -1,0 +1,1400 @@
+# Concurrent read-only git ops Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let read-only backend git ops run concurrently on their own
+`git2::Repository` handles, so a slow filesystem's per-op cost stops being
+multiplied by queue depth (#400).
+
+**Architecture:** A new `git/repo_locks.rs` owns one idea — how a repository's
+handles are ordered. `RepoLock<T>` pairs an `RwLock<()>` gate with the cached
+handle behind its `Mutex<T>` and a factory that mints a handle for a reader to
+keep to itself. Writes take the gate exclusively and use the cached handle,
+exactly as today; reads share the gate and get a fresh handle. `libgit2.rs`
+gains `with_repo_read`/`with_repo_read_mut` beside the untouched
+`with_repo`/`with_repo_mut`, and fourteen read-only ops move across.
+
+**Tech Stack:** Rust, `git2` 0.21, `std::sync::{Mutex, RwLock}`, `cargo test`
+against real temp repositories.
+
+**Spec:** `docs/superpowers/specs/2026-09-04-repo-read-concurrency-spec.md`
+
+## Global Constraints
+
+- **Every IPC-crossing fn returns `AppResult<T>`.** New failures reuse the
+  existing `AppError::Internal(String)` variant (`src-tauri/src/error.rs:66`) —
+  no new variant, so the TS `AppError` union and `appErrorDetail` need no change
+  and `test/appErrors.test.ts` stays green.
+- **Never `Command::new` outside `src-tauri/src/proc.rs`.** A guard test fails
+  the build. No task here spawns anything.
+- **`git2::Repository` is `Send` but not `Sync`.** Never hand `&Repository` to
+  two threads. Concurrency comes from *separate handles*, never shared access.
+- **`with_repo` and `with_repo_mut` keep byte-for-byte today's semantics.** They
+  are the write path. Do not change their signatures, and do not migrate a call
+  site this plan does not name.
+- **Toolchain:** `~/.cargo/bin/cargo`, `~/Library/pnpm/pnpm`. Run all commands
+  from the worktree root; `cargo` needs `--manifest-path src-tauri/Cargo.toml`
+  or `cd src-tauri` first.
+- **Rust CI gate is `cargo test` only** — no clippy, no fmt. Do not run
+  `cargo fmt` over the crate; it is broadly unformatted already and would bury
+  the diff.
+- **Commit style:** `perf(git): …` / `test: …` / `docs: …`, imperative subject
+  under 72 chars, `Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| Create `src-tauri/src/git/repo_locks.rs` | `RepoLock<T>` — the whole ordering primitive, plus its re-entrancy guard and unit tests. Generic over the handle so it is testable without libgit2. |
+| Modify `src-tauri/src/git/mod.rs:1-23` | Declare `pub mod repo_locks;`, alphabetically among the existing module list. |
+| Modify `src-tauri/src/git/libgit2.rs:79-137` | `repos` map holds `Arc<RepoLock<Repository>>`; `repo_cell` returns it; add `with_repo_read`/`with_repo_read_mut`; add the `open_read_handle` factory helper. |
+| Modify `src-tauri/src/git/libgit2.rs:3116-3155` (`open`) | Capture the gitdir and build the `RepoLock` with its factory. The only insert site in the file. |
+| Modify `src-tauri/src/git/libgit2.rs` (14 call sites) | Move the migrated read ops onto the shared helpers. |
+| Create `src-tauri/tests/concurrent_reads.rs` | Integration proof: concurrent reads agree with serial ones; reads work on a linked worktree and a bare repository. |
+| Modify `docs/dev/architecture.md` | List `git/repo_locks.rs` in the backend tree. |
+| Modify `docs/dev/backend.md` | The read/write split, the gitdir reopen, the re-entrancy rule, the measurements. |
+| Modify `CLAUDE.md` | The "per-repo ops serialize on an inner mutex" convention line is now wrong. |
+
+---
+
+### Task 1: `RepoLock<T>` — the ordering primitive
+
+**Files:**
+- Create: `src-tauri/src/git/repo_locks.rs`
+- Modify: `src-tauri/src/git/mod.rs:1-23`
+- Test: `src-tauri/src/git/repo_locks.rs` (inline `#[cfg(test)] mod tests`, the
+  pattern `git/mod.rs:998` already uses)
+
+**Interfaces:**
+- Consumes: `crate::error::{AppError, AppResult}`.
+- Produces:
+  - `pub struct RepoLock<T>`
+  - `pub fn RepoLock::<T>::new<F>(handle: T, open: F) -> Self where F: Fn() -> AppResult<T> + Send + Sync + 'static`
+  - `pub fn RepoLock::<T>::exclusive<F, R>(&self, f: F) -> AppResult<R> where F: FnOnce(&mut T) -> AppResult<R>`
+  - `pub fn RepoLock::<T>::shared<F, R>(&self, f: F) -> AppResult<R> where F: FnOnce(&T) -> AppResult<R>`
+  - `pub fn RepoLock::<T>::shared_mut<F, R>(&self, f: F) -> AppResult<R> where F: FnOnce(&mut T) -> AppResult<R>`
+
+- [ ] **Step 1: Declare the module**
+
+In `src-tauri/src/git/mod.rs`, add to the module list (it is alphabetical apart
+from a couple of strays — put it after `rebase_state`):
+
+```rust
+pub mod repo_locks;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `src-tauri/src/git/repo_locks.rs` containing ONLY the test module for
+now, so the tests fail to compile against a missing type — that is the red bar.
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Barrier, Condvar, Mutex as StdMutex};
+    use std::time::Duration;
+
+    /// A stand-in for `git2::Repository`: carries a serial number so a test can
+    /// tell two handles apart, and counts how many were made.
+    #[derive(Debug)]
+    struct FakeHandle(usize);
+
+    /// A lock whose factory hands out numbered handles, and the mint count.
+    fn lock() -> (Arc<RepoLock<FakeHandle>>, Arc<AtomicUsize>) {
+        let made = Arc::new(AtomicUsize::new(0));
+        let m = Arc::clone(&made);
+        let l = RepoLock::new(FakeHandle(0), move || {
+            Ok(FakeHandle(m.fetch_add(1, Ordering::SeqCst) + 1))
+        });
+        (Arc::new(l), made)
+    }
+
+    /// Eight readers must be inside `shared` AT ONCE.
+    ///
+    /// Deterministic on both sides, which is why there is no wall-clock
+    /// assertion here: each reader announces arrival and then waits for the
+    /// count to reach eight. If `shared` serialized, reader one would hold the
+    /// lock while waiting for seven readers that cannot enter, the bounded wait
+    /// would expire, and the assertion fails. It cannot flake into passing.
+    #[test]
+    fn shared_acquisitions_overlap() {
+        const N: usize = 8;
+        let (l, _made) = lock();
+        let state = Arc::new((StdMutex::new(0usize), Condvar::new()));
+        let peak = Arc::new(AtomicUsize::new(0));
+
+        let mut threads = Vec::new();
+        for _ in 0..N {
+            let l = Arc::clone(&l);
+            let state = Arc::clone(&state);
+            let peak = Arc::clone(&peak);
+            threads.push(std::thread::spawn(move || {
+                l.shared(|_handle| {
+                    let (count, cv) = &*state;
+                    let mut c = count.lock().unwrap();
+                    *c += 1;
+                    peak.fetch_max(*c, Ordering::SeqCst);
+                    cv.notify_all();
+                    // Wait for everyone, but bounded so a serialized lock fails
+                    // the test instead of hanging the suite.
+                    while *c < N {
+                        let (guard, timeout) =
+                            cv.wait_timeout(c, Duration::from_secs(10)).unwrap();
+                        c = guard;
+                        if timeout.timed_out() {
+                            break;
+                        }
+                    }
+                    Ok(())
+                })
+                .expect("shared");
+            }));
+        }
+        for t in threads {
+            t.join().expect("join");
+        }
+        assert_eq!(
+            peak.load(Ordering::SeqCst),
+            N,
+            "all {N} readers must be inside `shared` at once; peak concurrency was lower, \
+             so reads are still serializing",
+        );
+    }
+
+    /// Every `shared` call gets a handle of its own — the property that makes
+    /// concurrent reads sound at all, given `Repository` is not `Sync`.
+    #[test]
+    fn each_shared_call_mints_its_own_handle() {
+        let (l, made) = lock();
+        let first = l.shared(|h| Ok(h.0)).expect("first");
+        let second = l.shared(|h| Ok(h.0)).expect("second");
+        assert_ne!(first, second, "two reads must not share one handle");
+        assert_eq!(made.load(Ordering::SeqCst), 2, "one handle minted per read");
+    }
+
+    /// The cached handle is the write handle, and it is the SAME one every time.
+    #[test]
+    fn exclusive_reuses_the_cached_handle() {
+        let (l, made) = lock();
+        l.exclusive(|h| {
+            h.0 = 42;
+            Ok(())
+        })
+        .expect("write");
+        let seen = l.exclusive(|h| Ok(h.0)).expect("read back");
+        assert_eq!(seen, 42, "writes must see the one cached handle");
+        assert_eq!(
+            made.load(Ordering::SeqCst),
+            0,
+            "a write must not mint a handle",
+        );
+    }
+
+    /// A reader and a writer must not overlap — the exclusion every TOCTOU
+    /// comment in `libgit2.rs` rests on.
+    #[test]
+    fn shared_and_exclusive_never_overlap() {
+        let (l, _made) = lock();
+        let inside = Arc::new(AtomicUsize::new(0));
+        let overlapped = Arc::new(AtomicUsize::new(0));
+        let start = Arc::new(Barrier::new(2));
+
+        let mut threads = Vec::new();
+        for is_writer in [true, false] {
+            let l = Arc::clone(&l);
+            let inside = Arc::clone(&inside);
+            let overlapped = Arc::clone(&overlapped);
+            let start = Arc::clone(&start);
+            threads.push(std::thread::spawn(move || {
+                start.wait();
+                for _ in 0..200 {
+                    let body = |_: &mut FakeHandle| {
+                        if inside.fetch_add(1, Ordering::SeqCst) != 0 {
+                            overlapped.fetch_add(1, Ordering::SeqCst);
+                        }
+                        std::thread::yield_now();
+                        inside.fetch_sub(1, Ordering::SeqCst);
+                        Ok(())
+                    };
+                    if is_writer {
+                        l.exclusive(body).expect("exclusive");
+                    } else {
+                        l.shared_mut(body).expect("shared");
+                    }
+                }
+            }));
+        }
+        for t in threads {
+            t.join().expect("join");
+        }
+        assert_eq!(
+            overlapped.load(Ordering::SeqCst),
+            0,
+            "a read overlapped a write; the gate is not excluding them",
+        );
+    }
+
+    /// A factory failure is the op's failure, not a panic.
+    #[test]
+    fn a_factory_error_propagates() {
+        let l: RepoLock<FakeHandle> =
+            RepoLock::new(FakeHandle(0), || Err(AppError::Internal("no handle".into())));
+        let err = l.shared(|_| Ok(())).expect_err("must fail");
+        assert!(
+            matches!(err, AppError::Internal(ref m) if m.contains("no handle")),
+            "got {err:?}",
+        );
+    }
+
+    /// Nesting the same lock is refused with an error rather than deadlocking.
+    ///
+    /// All four pairings, because the hazard is asymmetric: mutex re-entry
+    /// (write-in-write) is a guaranteed hang today, while read-in-read only
+    /// hangs when a writer happens to queue between the two acquisitions —
+    /// which is the intermittent failure this guard exists to convert into
+    /// something a test can see.
+    #[test]
+    fn nesting_the_same_lock_is_refused() {
+        let (l, _made) = lock();
+
+        let cases: Vec<(&str, Box<dyn Fn() -> AppResult<()>>)> = vec![
+            (
+                "shared in shared",
+                Box::new({
+                    let l = Arc::clone(&l);
+                    move || {
+                        let inner = Arc::clone(&l);
+                        l.shared(move |_| inner.shared(|_| Ok(())))
+                    }
+                }),
+            ),
+            (
+                "exclusive in exclusive",
+                Box::new({
+                    let l = Arc::clone(&l);
+                    move || {
+                        let inner = Arc::clone(&l);
+                        l.exclusive(move |_| inner.exclusive(|_| Ok(())))
+                    }
+                }),
+            ),
+            (
+                "shared in exclusive",
+                Box::new({
+                    let l = Arc::clone(&l);
+                    move || {
+                        let inner = Arc::clone(&l);
+                        l.exclusive(move |_| inner.shared(|_| Ok(())))
+                    }
+                }),
+            ),
+            (
+                "exclusive in shared",
+                Box::new({
+                    let l = Arc::clone(&l);
+                    move || {
+                        let inner = Arc::clone(&l);
+                        l.shared(move |_| inner.exclusive(|_| Ok(())))
+                    }
+                }),
+            ),
+        ];
+
+        for (name, case) in cases {
+            let err = case().expect_err(&format!("{name} must be refused, not hang"));
+            assert!(
+                matches!(err, AppError::Internal(ref m) if m.contains("re-entrant")),
+                "{name}: got {err:?}",
+            );
+        }
+    }
+
+    /// Two DIFFERENT repositories nested on one thread stay legal — they share
+    /// no lock, so there is no deadlock to prevent, and an op on repo A calling
+    /// into repo B is a shape the app is allowed to have.
+    #[test]
+    fn nesting_two_different_locks_is_allowed() {
+        let (a, _ma) = lock();
+        let (b, _mb) = lock();
+        let inner = Arc::clone(&b);
+        let out = a
+            .shared(move |_| inner.shared(|h| Ok(h.0)))
+            .expect("nesting two different locks must be allowed");
+        assert!(out > 0, "the inner lock's handle should have been minted");
+    }
+
+    /// The guard unwinds with the closure, so a refused nesting does not leave
+    /// the thread permanently marked as holding the lock.
+    #[test]
+    fn a_refused_nesting_leaves_the_lock_usable() {
+        let (l, _made) = lock();
+        let inner = Arc::clone(&l);
+        let _ = l.shared(move |_| inner.shared(|_| Ok(())));
+        l.shared(|_| Ok(())).expect("the lock must still be usable");
+        l.exclusive(|_| Ok(())).expect("and still writable");
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `cd src-tauri && ~/.cargo/bin/cargo test --lib repo_locks 2>&1 | tail -20`
+
+Expected: FAIL to compile — `cannot find type RepoLock in this scope`.
+
+- [ ] **Step 4: Write the implementation**
+
+Prepend to `src-tauri/src/git/repo_locks.rs`, above the test module:
+
+```rust
+//! How one repository's `git2::Repository` handles are ordered (#400).
+//!
+//! The backend used to keep exactly one handle per repository behind one
+//! mutex, so every op on a repository — read or write — ran one at a time.
+//! That is correct and it is also why a slow filesystem hurt so much: eleven
+//! reads issued together by `refreshAll` waited for each other, and the user
+//! paid their SUM rather than the slowest of them. On a `/mnt/c` repository
+//! under WSL, where each read costs seconds of `stat` traffic across the VM
+//! boundary, that turned ~9s into ~108s (#400).
+//!
+//! Concurrent reads cannot be had by swapping the mutex for an `RwLock`:
+//! `git2::Repository` is `Send` but NOT `Sync`, so several threads may not
+//! hold `&Repository` at once, and the type system is right to refuse it. The
+//! parallelism has to come from separate HANDLES.
+//!
+//! So this type keeps two things: the one cached handle every write runs on,
+//! behind the mutex it has always had, and a factory that mints a handle for a
+//! reader to keep to itself. A gate orders the two against each other.
+//!
+//! **What this drops is read-vs-read exclusion, and nothing else.** Every
+//! ordering guarantee written down in `libgit2.rs` is a guarantee about a
+//! WRITE — the stash TOCTOU pair, the fast-forward ancestry check, the
+//! whole-index write-back in `fresh_index`. All of them run under `exclusive`,
+//! which still excludes every reader and every other writer, so all of them
+//! stay literally true. Two readers cannot violate any of them: neither one
+//! writes.
+//!
+//! Generic over the handle so the concurrency above can be tested without
+//! libgit2 in the picture — see the tests at the bottom of this file, which
+//! prove overlap and exclusion by counting, not by timing.
+
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, RwLock};
+
+use crate::error::{AppError, AppResult};
+
+/// Distinguishes one `RepoLock` from another for the re-entrancy guard.
+/// A counter rather than the lock's address: an id cannot be recycled by a
+/// later allocation landing where a dropped lock used to be.
+static NEXT_LOCK_ID: AtomicU64 = AtomicU64::new(0);
+
+thread_local! {
+    /// Which `RepoLock`s this thread is currently inside.
+    ///
+    /// A vector, not a flag: nesting two DIFFERENT repositories is legal and
+    /// must stay legal — it shares no lock, so there is no deadlock to prevent.
+    static HELD: RefCell<Vec<u64>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Marks this thread as holding one lock, and unmarks it on the way out.
+struct Reentry(u64);
+
+impl Reentry {
+    /// Refuse a nested acquisition of a lock this thread already holds.
+    ///
+    /// Nesting is a deadlock either way — but the two shapes fail
+    /// differently, and that is the reason this guard exists. Re-entering the
+    /// exclusive path hangs every time, so it shows up the first time anyone
+    /// runs it. Re-entering the SHARED path succeeds whenever no writer is
+    /// waiting and hangs when one is: a bug that passes in tests, passes in
+    /// review, and hangs on a user's machine under load. Converting it into an
+    /// error makes it something a test can catch.
+    fn enter(id: u64) -> AppResult<Self> {
+        HELD.with(|held| {
+            let mut held = held.borrow_mut();
+            if held.contains(&id) {
+                return Err(AppError::Internal(
+                    "re-entrant repository lock: a git op ran inside another op on the \
+                     same repository, which would deadlock"
+                        .into(),
+                ));
+            }
+            held.push(id);
+            Ok(Reentry(id))
+        })
+    }
+}
+
+impl Drop for Reentry {
+    fn drop(&mut self) {
+        HELD.with(|held| {
+            let mut held = held.borrow_mut();
+            if let Some(i) = held.iter().rposition(|id| *id == self.0) {
+                held.remove(i);
+            }
+        });
+    }
+}
+
+/// One repository's handles, and the order they run in.
+pub struct RepoLock<T> {
+    id: u64,
+    /// Orders reads against writes: reads share it, writes take it alone.
+    gate: RwLock<()>,
+    /// The one cached handle every write runs on.
+    exclusive: Mutex<T>,
+    /// Mints a handle for one reader to keep to itself.
+    ///
+    /// A factory rather than a pool, and that was measured rather than
+    /// assumed: `Repository::open` costs ~1.1ms warm, and a pre-warmed pool
+    /// of handles finished a twelve-read fan-out in 10.9ms against 10.6ms for
+    /// opening one per read — the pool is on the wrong side of noise. Keeping
+    /// it behind this field means a pool can be added later, if a `/mnt/c`
+    /// profile ever justifies one, without touching a single call site.
+    open: Box<dyn Fn() -> AppResult<T> + Send + Sync>,
+}
+
+impl<T> RepoLock<T> {
+    /// `handle` is the cached handle writes will use; `open` mints the ones
+    /// readers get.
+    pub fn new<F>(handle: T, open: F) -> Self
+    where
+        F: Fn() -> AppResult<T> + Send + Sync + 'static,
+    {
+        Self {
+            id: NEXT_LOCK_ID.fetch_add(1, Ordering::Relaxed),
+            gate: RwLock::new(()),
+            exclusive: Mutex::new(handle),
+            open: Box::new(open),
+        }
+    }
+
+    /// Run `f` alone: no other read and no other write on this repository.
+    ///
+    /// This is what every mutating op uses, and it is the behaviour the
+    /// backend has always had. Verify-then-mutate inside one call is atomic
+    /// against everything else in the process, which is what the stash TOCTOU
+    /// rule and the fast-forward ancestry check both rest on.
+    pub fn exclusive<F, R>(&self, f: F) -> AppResult<R>
+    where
+        F: FnOnce(&mut T) -> AppResult<R>,
+    {
+        let _reentry = Reentry::enter(self.id)?;
+        let _gate = self
+            .gate
+            .write()
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        let mut handle = self
+            .exclusive
+            .lock()
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        f(&mut handle)
+    }
+
+    /// Run `f` on a handle of its own, alongside any number of other readers.
+    ///
+    /// Read-only ops only. Writes still go through `exclusive` — a write here
+    /// would run concurrently with other reads and with nothing stopping a
+    /// second write from interleaving, which is exactly the whole-index
+    /// clobber `fresh_index` was written to prevent.
+    pub fn shared<F, R>(&self, f: F) -> AppResult<R>
+    where
+        F: FnOnce(&T) -> AppResult<R>,
+    {
+        self.shared_mut(|handle| f(&*handle))
+    }
+
+    /// `shared`, for a read that needs `&mut` to satisfy libgit2.
+    ///
+    /// `&mut` under a SHARED gate is not the contradiction it looks like: the
+    /// handle was minted for this call and dies with it, so no one else can
+    /// observe it. The `&mut` is about C signatures — `git_stash_foreach` and
+    /// friends take a mutable `git_repository` — not about mutating anything.
+    pub fn shared_mut<F, R>(&self, f: F) -> AppResult<R>
+    where
+        F: FnOnce(&mut T) -> AppResult<R>,
+    {
+        let _reentry = Reentry::enter(self.id)?;
+        let _gate = self
+            .gate
+            .read()
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        let mut handle = (self.open)()?;
+        f(&mut handle)
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd src-tauri && ~/.cargo/bin/cargo test --lib repo_locks 2>&1 | tail -20`
+
+Expected: PASS, 8 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/git/repo_locks.rs src-tauri/src/git/mod.rs
+git commit -m "perf(git): add RepoLock, a per-repo gate over one write handle and many read handles"
+```
+
+---
+
+### Task 2: Wire `RepoLock` into the backend, with no op migrated yet
+
+The point of stopping here is that the whole suite must stay green while every
+op is still exclusive. That isolates "the plumbing is right" from "this op is
+really a read", so a later failure has one possible cause instead of two.
+
+**Files:**
+- Modify: `src-tauri/src/git/libgit2.rs:79-137` (struct, `new`, `repo_cell`, `with_repo`, `with_repo_mut`)
+- Modify: `src-tauri/src/git/libgit2.rs:3116-3155` (`open`)
+- Test: the existing suite — `src-tauri/tests/*.rs`
+
+**Interfaces:**
+- Consumes: `RepoLock::{new, exclusive, shared, shared_mut}` from Task 1.
+- Produces:
+  - `fn Libgit2Backend::repo_cell(&self, &RepoId) -> AppResult<Arc<RepoLock<Repository>>>`
+  - `fn Libgit2Backend::with_repo_read<F, T>(&self, &RepoId, F) -> AppResult<T> where F: FnOnce(&Repository) -> AppResult<T>`
+  - `fn Libgit2Backend::with_repo_read_mut<F, T>(&self, &RepoId, F) -> AppResult<T> where F: FnOnce(&mut Repository) -> AppResult<T>`
+  - `fn open_read_handle(gitdir: &Path, report_as: &Path) -> AppResult<Repository>` (free fn)
+
+- [ ] **Step 1: Change the map's value type**
+
+`src-tauri/src/git/libgit2.rs:80` — replace:
+
+```rust
+    repos: Mutex<HashMap<RepoId, Arc<Mutex<Repository>>>>,
+```
+
+with:
+
+```rust
+    repos: Mutex<HashMap<RepoId, Arc<RepoLock<Repository>>>>,
+```
+
+Add the import near the other `crate::git` uses at the top of the file:
+
+```rust
+use crate::git::repo_locks::RepoLock;
+```
+
+- [ ] **Step 2: Add the read-handle factory helper**
+
+Add as a free function next to `fresh_index` (around
+`src-tauri/src/git/libgit2.rs:1192`):
+
+```rust
+/// Another handle on the same repository, for one read to keep to itself
+/// (#400).
+///
+/// Opens the GITDIR, not the workdir, and that is load-bearing:
+/// `Repository::open` on a workdir re-runs discovery, which resolves a linked
+/// worktree to the wrong repository (its gitdir is
+/// `<main>/.git/worktrees/<name>/`, not `<main>/.git/`) and has nothing to
+/// discover at all for a bare one. The gitdir here is the one the successful
+/// `open` already resolved, so it is exact for both.
+///
+/// `report_as` is the path the USER named, kept only for the error message —
+/// a `DubiousOwnership` naming an internal `.git/worktrees/…` path would be
+/// about a directory they never chose.
+fn open_read_handle(gitdir: &Path, report_as: &Path) -> AppResult<Repository> {
+    Repository::open(gitdir).map_err(|e| ownership::map_open_error(report_as, &e))
+}
+```
+
+Check the `ownership` import is in scope at the top of the file; `open` already
+calls `ownership::map_open_error`, so it is.
+
+- [ ] **Step 3: Point the four helpers at `RepoLock`**
+
+Replace `repo_cell`, `with_repo` and `with_repo_mut` at
+`src-tauri/src/git/libgit2.rs:107-137`. Keep the existing `repo_cell` doc
+comment — it is still true and still worth reading — and append the new
+paragraph:
+
+```rust
+    /// Clone the repo's own lock out of the map and RELEASE the map lock
+    /// before running `f`. The map guard used to stay alive for the whole
+    /// operation, so every git op in the process — any repository, any window —
+    /// serialized on one mutex: a 500-commit log walk in one tab blocked a
+    /// status refresh in another, and `refreshAll`'s parallel commands ran
+    /// strictly one after another. Different repos now genuinely run in
+    /// parallel.
+    ///
+    /// Same-repo ops used to serialize on the inner mutex too. They no longer
+    /// all do: `RepoLock` runs writes one at a time on the cached handle and
+    /// lets reads run together on handles of their own (#400). What still
+    /// holds — and what the stash TOCTOU note relies on — is that a write
+    /// excludes everything.
+    fn repo_cell(&self, repo_id: &RepoId) -> AppResult<Arc<RepoLock<Repository>>> {
+        let map = self
+            .repos
+            .lock()
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        map.get(repo_id)
+            .cloned()
+            .ok_or_else(|| AppError::UnknownRepo(repo_id.0.clone()))
+    }
+
+    /// An op that runs ALONE on this repository — no other read, no other
+    /// write.
+    ///
+    /// The default, and where an op belongs unless it has been established to
+    /// write nothing. Despite the name this is very much the WRITE path:
+    /// `stage`, `unstage`, `discard` and `delete_untracked` read-modify-write
+    /// the whole index through it, `commit` writes an object and moves a ref
+    /// through it, and `checkout_branch`/`reset`/the rebase engine mutate the
+    /// worktree through it. `git2` takes `&self` for most of that, which is
+    /// why the borrow says nothing about it.
+    fn with_repo<F, T>(&self, repo_id: &RepoId, f: F) -> AppResult<T>
+    where
+        F: FnOnce(&Repository) -> AppResult<T>,
+    {
+        self.repo_cell(repo_id)?.exclusive(|repo| f(repo))
+    }
+
+    /// `with_repo`, for the seven ops libgit2 makes take `&mut Repository`
+    /// (`stash_foreach`, `stash_drop`).
+    fn with_repo_mut<F, T>(&self, repo_id: &RepoId, f: F) -> AppResult<T>
+    where
+        F: FnOnce(&mut Repository) -> AppResult<T>,
+    {
+        self.repo_cell(repo_id)?.exclusive(f)
+    }
+
+    /// A READ-ONLY op, on a handle of its own, alongside other reads (#400).
+    ///
+    /// Only for an op that writes nothing — no index write-back, no ref move,
+    /// no object written, no worktree change. A write here would interleave
+    /// with other writes with nothing to stop it.
+    ///
+    /// Two rules come with the private handle:
+    ///
+    /// - **Anything reading the index still goes through `fresh_index`.** The
+    ///   handle is newly opened rather than cached, so its in-memory index is
+    ///   whatever was on disk a moment ago — the same staleness `with_repo`
+    ///   has, arriving by a different route.
+    /// - **Never call one of these from inside another repo-lock closure for
+    ///   the same repository.** It is refused with `Internal` rather than
+    ///   deadlocking, but it is still a bug. The existing helpers that take an
+    ///   already-borrowed `&Repository` (`stash_pairs`, the fast-forward pair)
+    ///   are the pattern to follow.
+    fn with_repo_read<F, T>(&self, repo_id: &RepoId, f: F) -> AppResult<T>
+    where
+        F: FnOnce(&Repository) -> AppResult<T>,
+    {
+        self.repo_cell(repo_id)?.shared(f)
+    }
+
+    /// `with_repo_read`, for a read that needs `&mut` to satisfy libgit2 —
+    /// `stashes` and its `stash_foreach`. The handle belongs to this call
+    /// alone, so the mutable borrow is invisible to anyone else.
+    fn with_repo_read_mut<F, T>(&self, repo_id: &RepoId, f: F) -> AppResult<T>
+    where
+        F: FnOnce(&mut Repository) -> AppResult<T>,
+    {
+        self.repo_cell(repo_id)?.shared_mut(f)
+    }
+```
+
+Note `with_repo` wraps as `|repo| f(repo)` because `exclusive` hands out
+`&mut Repository` and `f` wants `&Repository`.
+
+- [ ] **Step 4: Build the lock in `open`**
+
+`src-tauri/src/git/libgit2.rs:3151` — replace:
+
+```rust
+        map.insert(id.clone(), Arc::new(Mutex::new(repo)));
+```
+
+with (insert above the `let mut map = …` block, since `repo` is borrowed for
+`gitdir` before being moved):
+
+```rust
+        // Reads get handles of their own (#400), minted from the gitdir this
+        // open already resolved rather than by re-running discovery — see
+        // `open_read_handle`. Captured here because this is the only place
+        // that knows both paths.
+        let gitdir = repo.path().to_path_buf();
+        let report_as = path.to_path_buf();
+        let lock = RepoLock::new(repo, move || open_read_handle(&gitdir, &report_as));
+
+        let mut map = self
+            .repos
+            .lock()
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        map.insert(id.clone(), Arc::new(lock));
+```
+
+The existing `let workdir = repo.workdir()…` block must stay ABOVE this, since
+it borrows `repo`.
+
+- [ ] **Step 5: Check it compiles, and the whole suite still passes**
+
+Run: `cd src-tauri && ~/.cargo/bin/cargo test --all-targets 2>&1 | tail -30`
+
+Expected: PASS. Every op is still exclusive, so this is a pure refactor — any
+failure here is the plumbing, not an op's read/write classification. Two
+warnings about `with_repo_read`/`with_repo_read_mut` being unused are expected
+and go away in Task 3.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src-tauri/src/git/libgit2.rs
+git commit -m "perf(git): hold each repository behind a RepoLock, all ops still exclusive"
+```
+
+---
+
+### Task 3: Migrate the fourteen read-only ops
+
+Fifteen trait methods, fourteen edit sites: `log` and `diff_commit` are trait
+defaults (`git/mod.rs:108`, `git/mod.rs:401`) that delegate to `log_page` and
+`diff_commit_over_ceiling`, so they come along for free.
+
+**Files:**
+- Modify: `src-tauri/src/git/libgit2.rs` (14 sites, listed below)
+- Test: the existing suite
+
+**Interfaces:**
+- Consumes: `with_repo_read` / `with_repo_read_mut` from Task 2.
+- Produces: no new API. Fifteen trait methods change concurrency class only;
+  every signature and every return value is untouched.
+
+- [ ] **Step 1: Swap the helper at each of the fourteen sites**
+
+Each is a one-word change, `with_repo` → `with_repo_read`. Line numbers are
+from before Task 2's edits, so re-grep rather than trusting them; the function
+names are the reliable anchors.
+
+`refreshAll`'s fan-out — the clustered burst in the issue:
+
+| fn | current call |
+| --- | --- |
+| `status` | `self.with_repo(repo_id, \|repo\| {` |
+| `branches` | `self.with_repo(repo_id, \|repo\| {` |
+| `tags` | `self.with_repo(repo_id, \|repo\| {` |
+| `stashes` | `self.with_repo_mut(repo_id, \|repo\| {` → **`with_repo_read_mut`** |
+| `remotes` | `self.with_repo(repo_id, \|repo\| {` |
+| `log_page` | `self.with_repo(repo_id, \|repo\| {` |
+| `repo_state` | `self.with_repo(repo_id, \|repo\| {` |
+| `rebase_status` | `self.with_repo(repo_id, \|repo\| {` |
+| `bisect_status` | `self.with_repo(repo_id, crate::git::bisect::status)` |
+| `head_info` | `self.with_repo(repo_id, \|repo\| {` |
+| `shallow_info` | `self.with_repo(repo_id, \|repo\| {` |
+
+The history-arrowing ladder:
+
+| fn | current call |
+| --- | --- |
+| `diff_commit_over_ceiling` | `self.with_repo(repo_id, \|repo\| {` |
+| `verify_commit` | `let (full_oid, signed) = self.with_repo(repo_id, \|repo\| {` |
+| `worktrees` | `self.with_repo(repo_id, \|repo\| {` |
+
+- [ ] **Step 2: Note the two that shell out, in a comment**
+
+`verify_commit` and `bisect_status` both spawn (`gpg`/`ssh-keygen` via
+`git show`, and `git rev-list --bisect-vars`). Add above `verify_commit`'s
+newly-shared call:
+
+```rust
+        // `with_repo_read`, not `with_repo`: this resolves a revision and reads
+        // a signature, writing nothing — and it is the op that made the #400
+        // ladder a ladder. Held exclusively, the `git show` below stalled every
+        // unrelated read in the process for as long as gpg took, once per
+        // commit the user arrowed onto.
+```
+
+And above `bisect_status`'s:
+
+```rust
+        // Read-only, and it shells out to `git rev-list --bisect-vars` for its
+        // progress numbers — so holding this exclusively blocked every other
+        // read for the length of a subprocess (#400).
+```
+
+- [ ] **Step 3: Run the whole suite**
+
+Run: `cd src-tauri && ~/.cargo/bin/cargo test --all-targets 2>&1 | tail -30`
+
+Expected: PASS. This is the load-bearing verification in the whole plan: around
+ninety integration test files drive these ops, and Task 1's re-entrancy guard
+turns any latent nesting — a migrated read reachable from inside another lock —
+into a hard `Internal` failure instead of an intermittent hang. A green run is
+real evidence, not just absence of evidence.
+
+If something fails, the cause is almost certainly one of two things: the op
+writes after all (put it back on `with_repo` and say so in the spec), or it is
+called from inside another closure (the error message says "re-entrant").
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/git/libgit2.rs
+git commit -m "perf(git): run the read-only fan-out concurrently instead of queued"
+```
+
+---
+
+### Task 4: Integration proof against real repositories
+
+Task 1 proves the lock. This proves the wiring: that a real fan-out agrees with
+a serial one, and that the gitdir reopen is right for the two repository shapes
+where opening the workdir would not be.
+
+**Files:**
+- Create: `src-tauri/tests/concurrent_reads.rs`
+- Test: itself
+
+**Interfaces:**
+- Consumes: `platypusgit_lib::git::{libgit2::Libgit2Backend, types::RepoId, GitBackend}`;
+  `support::{TempRepo, fs::write_file}` (`src-tauri/tests/support/mod.rs`).
+- Produces: nothing other tasks use.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src-tauri/tests/concurrent_reads.rs`:
+
+```rust
+//! Read-only ops run concurrently and still agree with themselves (#400).
+//!
+//! The unit tests in `git/repo_locks.rs` prove the lock overlaps readers and
+//! excludes writers, with a fake handle and no libgit2. What they cannot prove
+//! is that the handles this backend mints are the RIGHT handles — which is the
+//! whole risk in reopening a repository from its gitdir rather than reusing
+//! one cached object.
+
+mod support;
+
+use std::sync::{Arc, Barrier};
+
+use platypusgit_lib::git::{libgit2::Libgit2Backend, GitBackend};
+use support::{fs::write_file, TempRepo};
+
+/// The eleven-read fan-out, issued together, must answer exactly what it
+/// answers one at a time.
+#[test]
+fn a_concurrent_fan_out_agrees_with_a_serial_one() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "untracked.txt", "x\n");
+    let backend = Arc::new(Libgit2Backend::new());
+    let h = backend.open(tr.path()).expect("open");
+
+    // Serially first, so there is something to compare against.
+    let want_status = backend.status(&h.id).expect("status").len();
+    let want_branches = backend.branches(&h.id).expect("branches").len();
+    let want_log = backend.log(&h.id, None, 10).expect("log").len();
+    let want_head = backend.head_info(&h.id).expect("head_info");
+
+    // Then all at once, with a barrier so they really are simultaneous rather
+    // than merely spawned.
+    const N: usize = 8;
+    let start = Arc::new(Barrier::new(N));
+    let mut threads = Vec::new();
+    for i in 0..N {
+        let backend = Arc::clone(&backend);
+        let id = h.id.clone();
+        let start = Arc::clone(&start);
+        threads.push(std::thread::spawn(move || {
+            start.wait();
+            match i % 4 {
+                0 => assert_eq!(
+                    backend.status(&id).expect("status").len(),
+                    want_status,
+                    "concurrent status disagreed",
+                ),
+                1 => assert_eq!(
+                    backend.branches(&id).expect("branches").len(),
+                    want_branches,
+                    "concurrent branches disagreed",
+                ),
+                2 => assert_eq!(
+                    backend.log(&id, None, 10).expect("log").len(),
+                    want_log,
+                    "concurrent log disagreed",
+                ),
+                _ => assert_eq!(
+                    backend.head_info(&id).expect("head_info").branch,
+                    want_head.branch,
+                    "concurrent head_info disagreed",
+                ),
+            }
+        }));
+    }
+    for t in threads {
+        t.join().expect("a concurrent read panicked");
+    }
+
+    // And the other reads in the fan-out at least answer without error, on
+    // their own private handles.
+    backend.tags(&h.id).expect("tags");
+    backend.stashes(&h.id).expect("stashes");
+    backend.remotes(&h.id).expect("remotes");
+    backend.repo_state(&h.id).expect("repo_state");
+    backend.rebase_status(&h.id).expect("rebase_status");
+    backend.shallow_info(&h.id).expect("shallow_info");
+    backend.worktrees(&h.id).expect("worktrees");
+}
+
+/// A read on a LINKED WORKTREE must read that worktree, not the main one.
+///
+/// This is the test that pins `open_read_handle` to the gitdir. A linked
+/// worktree's gitdir is `<main>/.git/worktrees/<name>/`, so reopening by
+/// re-running discovery on the workdir — or, worse, reusing the main
+/// repository's path — would silently answer about the wrong checkout. The
+/// dirty file exists only here, so a leak is visible rather than theoretical.
+#[test]
+fn a_read_on_a_linked_worktree_reads_that_worktree() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let wt_dir = tr.dir.path().join("wt");
+    tr.repo
+        .worktree("side", &wt_dir, None)
+        .expect("add worktree");
+    write_file(&wt_dir, "only-in-the-worktree.txt", "x\n");
+
+    let backend = Libgit2Backend::new();
+    let h = backend.open(&wt_dir).expect("open worktree");
+
+    let status = backend.status(&h.id).expect("status");
+    assert!(
+        status
+            .iter()
+            .any(|s| s.path == "only-in-the-worktree.txt"),
+        "a read on the linked worktree must see its own untracked file, got {:?}",
+        status.iter().map(|s| &s.path).collect::<Vec<_>>(),
+    );
+
+    // The main checkout is clean, and a handle opened for the worktree must not
+    // start answering about it.
+    let main = backend.open(tr.path()).expect("open main");
+    assert!(
+        backend.status(&main.id).expect("main status").is_empty(),
+        "the main checkout should still be clean",
+    );
+}
+
+/// Reads keep working when the repository has no worktree at all.
+#[test]
+fn reads_work_on_a_bare_repository() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    git2::Repository::init_bare(dir.path()).expect("init bare");
+
+    let backend = Libgit2Backend::new();
+    let h = backend.open(dir.path()).expect("open bare");
+
+    // No commits and no workdir, but the reads must answer rather than panic
+    // or resolve to some other repository.
+    assert!(backend.branches(&h.id).expect("branches").is_empty());
+    assert!(backend.tags(&h.id).expect("tags").is_empty());
+    backend.repo_state(&h.id).expect("repo_state");
+    backend.head_info(&h.id).expect("head_info");
+}
+
+/// A read never observes a torn index while a write is running.
+///
+/// `stage` write-modify-writes the WHOLE index; if the gate let a read in
+/// mid-write, `status` could see neither the old index nor the new one. Loops
+/// so the interleaving gets many chances rather than one.
+#[test]
+fn a_read_never_sees_a_torn_index() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    for i in 0..20 {
+        write_file(tr.path(), &format!("f{i}.txt"), "x\n");
+    }
+    let backend = Arc::new(Libgit2Backend::new());
+    let h = backend.open(tr.path()).expect("open");
+
+    let writer = {
+        let backend = Arc::clone(&backend);
+        let id = h.id.clone();
+        std::thread::spawn(move || {
+            for i in 0..20 {
+                let p = std::path::PathBuf::from(format!("f{i}.txt"));
+                backend.stage(&id, &[p]).expect("stage");
+            }
+        })
+    };
+
+    let reader = {
+        let backend = Arc::clone(&backend);
+        let id = h.id.clone();
+        std::thread::spawn(move || {
+            for _ in 0..200 {
+                // Every path is either staged or not; the total never changes,
+                // and a torn read would lose or duplicate one.
+                let status = backend.status(&id).expect("status");
+                assert_eq!(
+                    status.len(),
+                    20,
+                    "status saw {} of 20 paths — a torn index",
+                    status.len(),
+                );
+            }
+        })
+    };
+
+    writer.join().expect("writer panicked");
+    reader.join().expect("reader panicked");
+}
+```
+
+- [ ] **Step 2: Run it to verify it passes**
+
+Run: `cd src-tauri && ~/.cargo/bin/cargo test --test concurrent_reads 2>&1 | tail -30`
+
+Expected: PASS, 4 tests.
+
+If `a_read_on_a_linked_worktree_reads_that_worktree` fails, `open_read_handle`
+is opening the wrong path — that is the test doing its job.
+
+If `a_read_never_sees_a_torn_index` fails, the gate is not excluding reads from
+writes. Check that `with_repo` still routes to `exclusive`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src-tauri/tests/concurrent_reads.rs
+git commit -m "test(git): pin concurrent reads, the worktree reopen and index tearing"
+```
+
+---
+
+### Task 5: Documentation
+
+`CLAUDE.md` currently states a convention this change makes false, so that one
+is a correctness fix rather than politeness.
+
+**One claim in an earlier draft of this task was wrong and is corrected here.**
+It said `test/docs.test.ts` fails the build when a backend module is missing
+from the tree in `docs/dev/architecture.md`. It does not. The assertion is
+`!doc.includes(name)` over CLAUDE.md plus every `docs/dev/*.md` concatenated, so
+it only asks whether the FILENAME is mentioned somewhere in the doc set — a
+mention in `backend.md` satisfies it, which was verified by deleting the
+architecture.md entry and watching all 3370 tests stay green. The architecture
+tree entry is still required by CLAUDE.md's own rule that the tree is the map of
+the codebase; it is just not machine-enforced at that granularity.
+
+**Files:**
+- Modify: `docs/dev/architecture.md` (backend tree)
+- Modify: `docs/dev/backend.md`
+- Modify: `CLAUDE.md` (the `git2::Repository` convention bullet)
+- Test: `pnpm test` (vitest project `docs`)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Add the module to the backend tree**
+
+In `docs/dev/architecture.md`, in the `src-tauri/src/git/` listing, add an
+entry beside its neighbours (match the surrounding format exactly — find
+`rebase_state.rs` and put it after):
+
+```
+- `repo_locks.rs` — `RepoLock<T>`: how one repository's handles are ordered.
+  One cached handle behind a mutex for writes, a factory minting a private
+  handle per read, and an `RwLock` gate ordering the two. Read-vs-read
+  exclusion is the only thing it drops; a write still excludes everything
+  (#400). Carries its own unit tests, with a fake handle and no timing
+  assertions.
+```
+
+- [ ] **Step 2: Document the split in `docs/dev/backend.md`**
+
+Find the section covering `git2::Repository` being `Send` not `Sync` and the
+per-repo mutex (search for "not `Sync`" or "TOCTOU"). Add:
+
+```markdown
+### Reads run concurrently; writes do not (#400)
+
+Each repository sits behind a `RepoLock` (`git/repo_locks.rs`), which is two
+things at once: the single cached `git2::Repository` every write uses, and a
+factory that mints a handle for one read to keep to itself. An `RwLock` gate
+orders them — reads share it, writes take it alone.
+
+**Four helpers, and the naming is a trap worth reading twice.**
+
+| helper | concurrency | handle |
+| --- | --- | --- |
+| `with_repo` | exclusive | the cached one, `&Repository` |
+| `with_repo_mut` | exclusive | the cached one, `&mut Repository` |
+| `with_repo_read` | shared | a private one, `&Repository` |
+| `with_repo_read_mut` | shared | a private one, `&mut Repository` |
+
+`with_repo` vs `with_repo_mut` is **not** a read/write split, and reading it as
+one is how you would break the index. `with_repo` carries most of the writes in
+this backend — `stage`/`unstage`/`discard` read-modify-write the whole index
+through it, `commit` writes an object and moves a ref, `checkout_branch` and
+`reset` rewrite the worktree. `git2` takes `&self` for nearly all of that.
+`with_repo_mut` exists only for the seven places libgit2's C signatures demand
+`&mut git_repository` (`stash_foreach`, `stash_drop`).
+
+The real split is `_read` or not. **An op joins the `_read` helpers only once
+it is established to write nothing** — no index write-back, no ref move, no
+object written, no worktree change. Exclusive is the safe default and where an
+unexamined op belongs.
+
+**Why this is safe.** Every ordering guarantee written down in `libgit2.rs` is
+a guarantee about a write: the stash TOCTOU pair (verify and drop under one
+acquisition), the fast-forward ancestry check and ref move, `fresh_index`'s
+whole-index write-back, `init`'s guard/write/cleanup window. All of them run
+under the exclusive gate, which still excludes every reader and every other
+writer, so all of them remain literally true. The only exclusion dropped is
+read-vs-read, and nothing was relying on it — neither party writes.
+
+The app also already tolerates concurrent readers and writers it does not
+control: the built-in terminal (#243) sits in the window `cd`-ed to the
+repository, a `pre-commit` hook that reformats and restages is supported, and
+a second window (#402) drives the same repository. In-process concurrent reads
+are strictly weaker than that.
+
+**Two rules come with a private handle.**
+
+*Anything reading the index still goes through `fresh_index`.* A newly opened
+handle's in-memory index is whatever was on disk a moment ago — the same
+staleness a cached handle has, arriving by a different route.
+
+*Never call a repo-lock helper from inside another one for the same
+repository.* It returns `AppError::Internal("re-entrant repository lock…")`
+rather than deadlocking, but it is a bug. Pass an already-borrowed
+`&Repository` down instead, the way `stash_pairs` and the fast-forward helpers
+do. The guard exists because a shared gate makes this hazard *intermittent*:
+two `read()` acquisitions on one thread succeed whenever no writer is waiting
+and deadlock when one is — a hang that appears under load, in release, on a
+user's machine, and never in a test. An error is something a test can catch.
+Nesting two *different* repositories stays legal; they share no lock.
+
+**Reads reopen the gitdir, not the workdir.** `Repository::open` on a workdir
+re-runs discovery, which resolves a linked worktree to the wrong repository
+(its gitdir is `<main>/.git/worktrees/<name>/`) and has nothing to discover for
+a bare one. `open` captures the gitdir it already resolved and the read handles
+use that. `tests/concurrent_reads.rs` pins both shapes.
+
+**What was measured** (macOS/APFS, warm; twelve reads of the shapes
+`refreshAll` issues):
+
+| shape | wall clock |
+| --- | --- |
+| serial through one mutex | 16.9 ms |
+| parallel, a fresh handle per read | 10.6 ms |
+| parallel, a pre-warmed handle pool | 10.9 ms |
+
+`Repository::open` is ~1.1 ms warm. **A handle pool is measurably worthless**
+— do not add one without a profile that disagrees, and note that the factory
+lives behind `RepoLock::new` precisely so a pool could be added later without
+touching a call site.
+
+The 1.6× serial→parallel figure understates the fix: on APFS the fan-out is
+dominated by one slow read, so parallelising the other ten wins little. The
+reported bug is the case where every read costs the same ~9 s — twelve of those
+serialized is ~108 s and parallel is ~9 s. The win scales with how uniformly
+slow the filesystem is, which is the `/mnt/c` shape.
+
+**Which ops are shared today:** `status`, `branches`, `tags`, `stashes`,
+`remotes`, `log`/`log_page`, `repo_state`, `rebase_status`, `bisect_status`,
+`head_info`, `shallow_info`, `diff_commit`/`diff_commit_over_ceiling`,
+`verify_commit`, `worktrees`. That is `refreshAll`'s eleven-read fan-out plus
+the ops behind the history-arrowing ladder in #400. Every other read-only op is
+still exclusive — not because it must be, but because each needs its own proof
+it writes nothing, and moving one is a one-word change.
+```
+
+- [ ] **Step 3: Fix the now-false convention line in `CLAUDE.md`**
+
+Find the bullet reading:
+
+```markdown
+- **`git2::Repository` is `Send` not `Sync`** — wrap git2 work in
+  `spawn_blocking`; per-repo ops serialize on an inner mutex. Verify and mutate
+  under ONE lock acquisition (stash TOCTOU). (`docs/dev/backend.md`)
+```
+
+Replace with:
+
+```markdown
+- **`git2::Repository` is `Send` not `Sync`** — wrap git2 work in
+  `spawn_blocking`. Per-repo WRITES serialize on one cached handle; reads run
+  concurrently on private handles (`git/repo_locks.rs`), so `with_repo` is the
+  exclusive/write path and `with_repo_read` the shared one — the `_mut` suffix
+  is about libgit2's signatures, NOT about reads vs writes. An op joins the
+  `_read` helpers only once established to write nothing. Verify and mutate
+  under ONE lock acquisition (stash TOCTOU); never nest two lock helpers on one
+  repository. (`docs/dev/backend.md`)
+```
+
+- [ ] **Step 4: Run the doc invariants**
+
+Run: `~/Library/pnpm/pnpm test 2>&1 | tail -25`
+
+Expected: PASS, including the `docs` project. A "Backend modules absent…"
+failure means `repo_locks.rs` is not named anywhere in CLAUDE.md or
+`docs/dev/*.md` — note that this checks mention, not tree placement, so it will
+NOT catch a missing architecture.md entry on its own.
+
+Note: `test/imageDiffView` has a measured ~1-in-111 flake. A red `unit` on a
+diff that touches no frontend code is that — re-run rather than investigate.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/dev/architecture.md docs/dev/backend.md CLAUDE.md
+git commit -m "docs(git): record the read/write lock split and what was measured"
+```
+
+---
+
+### Task 6: Full verification and integration
+
+**Files:** none — this task only runs things and integrates.
+
+- [ ] **Step 1: The whole Rust suite, after the last edit**
+
+Run: `cd src-tauri && ~/.cargo/bin/cargo test --all-targets 2>&1 | tail -20`
+
+Expected: PASS. A green count from before Task 5 is not evidence for this tree;
+the last verification has to come after the last edit.
+
+- [ ] **Step 2: Frontend gates**
+
+Run: `~/Library/pnpm/pnpm tsc --noEmit && ~/Library/pnpm/pnpm test 2>&1 | tail -20`
+
+Expected: PASS. No `src/` file changed, so this is a guard against the doc
+invariants and nothing else.
+
+- [ ] **Step 3: Rebuild the e2e snapshot and run the specs that touch these ops**
+
+`src-tauri/` changed, so the snapshot is stale and must be rebuilt first.
+**One cold container build at a time across all worktrees.**
+
+```bash
+~/Library/pnpm/pnpm test:e2e:docker build
+~/Library/pnpm/pnpm test:e2e:docker run --spec e2e/specs/commit.e2e.ts
+~/Library/pnpm/pnpm test:e2e:docker run --spec e2e/specs/history-ops.e2e.ts
+~/Library/pnpm/pnpm test:e2e:docker run --spec e2e/specs/worktrees.e2e.ts
+```
+
+Expected: PASS. These three drive the migrated ops end to end — the refresh
+fan-out, the history ladder, and the worktree reads. CI runs the full suite.
+
+Note: `history-ops` and `commit` are both in the known CI-only flake class. A
+red here that names a wandering sub-test, and reproduces on a recent red `main`
+run, is not this change.
+
+- [ ] **Step 4: Squash and open the PR**
+
+The PR squashes to one commit, so squash locally first for a clean message.
+**Pin `main`'s SHA before `reset --soft`** — a concurrent PR landing between the
+fetch and the reset would otherwise be reverted by this branch.
+
+```bash
+git fetch origin
+MAIN=$(git rev-parse origin/main)
+git reset --soft "$MAIN"
+git add -A
+git commit -F .git/PR_MSG
+git push -u origin perf/repo-handle-pool
+```
+
+Commit message / PR body:
+
+```
+perf(git): run the read-only fan-out concurrently instead of queued
+
+Read-only ops all took the same exclusive per-repo lock, so the eleven
+reads `refreshAll` issues together waited for each other and the user
+paid their SUM. On a /mnt/c repository under WSL, where each costs
+seconds of stat traffic across the VM boundary, that turned ~9s into
+~108s, and arrowing through history laddered to 45s.
+
+Each repository now sits behind a `RepoLock`: one cached handle for
+writes, a private handle minted per read, an `RwLock` gate ordering the
+two. Fifteen read-only ops move onto the shared path.
+
+**Why:** concurrent reads cannot come from swapping the mutex for an
+`RwLock` — `git2::Repository` is `Send` but not `Sync`, so the
+parallelism has to come from separate handles.
+
+The only exclusion dropped is read-vs-read. Every ordering guarantee
+written down in libgit2.rs is about a WRITE — the stash TOCTOU pair, the
+fast-forward ancestry check, fresh_index's whole-index write-back — and
+all of them still run under a gate that excludes everything, so all of
+them stay literally true.
+
+No handle pool: measured at 10.9ms against 10.6ms for opening one per
+read, with `Repository::open` at ~1.1ms. The factory sits behind
+`RepoLock::new` so a pool can be added later without touching a call
+site.
+
+Nested locking on one repository now returns `Internal` instead of
+deadlocking, because a shared gate makes that hazard intermittent —
+two read acquisitions on a thread hang only when a writer queues
+between them.
+
+Closes #400
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+```
+
+- [ ] **Step 5: Check the PR's closing keywords, then merge when green**
+
+`gh` has attached closing keywords to the wrong issue before, so verify rather
+than trust the body text:
+
+```bash
+gh pr view <N> --json closingIssuesReferences,mergeable,mergeStateStatus
+```
+
+Expected: `closingIssuesReferences` names **only** #400. Merge with
+`gh pr merge <N> --squash` as soon as GitHub reports the PR mergeable — no
+rebase needed, `required_linear_history` is satisfied by the squash itself.
+
+Read the run *conclusion* rather than trusting a watcher's exit code, which has
+reported 0 on a failed run.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+| --- | --- |
+| `RepoLock<T>`, three entry points | 1 |
+| Re-entrancy guard returning `Internal` | 1 (impl + tests), 5 (docs) |
+| `repos` map holds the lock; gitdir reopen | 2 |
+| `with_repo_read` / `with_repo_read_mut` | 2 |
+| `with_repo`/`with_repo_mut` unchanged semantics | 2 (routed to `exclusive`), verified by the suite in 2 |
+| The fifteen migrated ops | 3 |
+| Unit tests: overlap, exclusion, own handle, factory error, nesting, poison | 1 |
+| Integration: concurrent agreement, worktree, bare, torn index | 4 |
+| Existing suite as the regression net | 3 (step 3), 6 (step 1) |
+| `architecture.md` / `backend.md` / `CLAUDE.md` | 5 |
+
+Two gaps found and closed while reviewing:
+
+1. The spec's test list includes "a panic inside `exclusive` poisons the handle
+   into `Internal`". Task 1's tests do not cover it — a `#[test]` that panics
+   inside a closure aborts under `panic = "abort"` and is awkward under unwind,
+   and the behaviour is `std::sync::Mutex`'s, already exercised by the existing
+   `map_err(|e| AppError::Internal(...))` idiom throughout the file. Dropped
+   deliberately rather than left as an unwritten step; the spec's list is
+   otherwise implemented in full.
+2. The spec says reopen failures map through `ownership::map_open_error`. Task 2
+   Step 2 does that, and adds the `report_as` parameter the spec did not
+   mention, so a `DubiousOwnership` error names the path the user chose rather
+   than an internal `.git/worktrees/…` one.
+
+**Placeholder scan:** none. Every code step carries the actual code; every run
+step carries the actual command and the expected result.
+
+**Type consistency:** `RepoLock::{new, exclusive, shared, shared_mut}` are
+named identically in Tasks 1 and 2. `with_repo_read`/`with_repo_read_mut` are
+named identically in Tasks 2 and 3 and in the Task 5 documentation.
+`open_read_handle(gitdir, report_as)` is defined and called in Task 2 only.
+`FakeHandle` is local to Task 1's tests.

--- a/docs/superpowers/specs/2026-09-04-repo-read-concurrency-spec.md
+++ b/docs/superpowers/specs/2026-09-04-repo-read-concurrency-spec.md
@@ -1,0 +1,308 @@
+# Concurrent read-only git ops (#400)
+
+Read-only backend ops serialize on the per-repo mutex, so a slow filesystem's
+per-op cost gets multiplied by queue depth. `refreshAll` fans out eleven reads
+at once; on a `/mnt/c` repository under WSL each costs ~9s of `stat` traffic,
+and because they queue the user waits for the sum rather than the slowest.
+
+The fix: give read-only ops a `git2::Repository` handle of their own so they run
+concurrently, while writes keep the single cached handle and the exclusive lock
+they have today.
+
+## What the issue got wrong, and why it matters
+
+#400 reads the problem as "`with_repo` is a read and `with_repo_mut` is a
+write", and proposes splitting the trait's read and write paths on that line.
+That is not what those two helpers are.
+
+`with_repo` carries genuine writes. `stage`, `unstage`, `discard` and
+`delete_untracked` all read-modify-write the **whole index** through it — which
+is the entire reason `fresh_index` exists and the reason
+`tests/index_staleness.rs` was written. `commit` writes an object and moves a
+ref through it. `checkout_branch`, `reset` and the rebase engine's
+`start_pick`/`finish_pick` all mutate the worktree through it.
+
+The real distinction is narrower and duller: `with_repo_mut` exists **only**
+because libgit2's `stash_foreach` and `stash_drop` take `&mut git_repository`.
+Seven call sites. Nothing else.
+
+So the consequence for the design is decisive: the read path cannot be a
+*reinterpretation* of `with_repo`. Silently making `with_repo` shared would let
+two `stage` calls interleave their whole-index writes — the exact data loss
+`fresh_index` was written to prevent. The read path has to be **new and
+opt-in**, with every unmigrated call site keeping today's semantics by
+construction.
+
+## Measurements
+
+The issue asks for two things to be measured rather than assumed. Both were,
+with a throwaway test against this repository (macOS, APFS, warm page cache).
+
+**Is opening a handle cheap?** Ten consecutive `Repository::open` calls on a
+repository with real history and packed refs:
+
+```
+2.08ms, 1.32ms, 1.30ms, 1.16ms, 1.06ms, 1.06ms, 1.06ms, 1.07ms, 1.09ms, 0.94ms
+```
+
+~1.1ms steady state. For comparison, one `statuses()` on the same repository is
+6.3ms warm and 14.8ms cold, and a 200-commit revwalk is 2.3ms warm.
+
+**Does a handle pool beat opening one per read?** Twelve reads of the shapes
+`refreshAll` issues, on twelve threads:
+
+| shape | wall clock |
+| --- | --- |
+| serial through one shared mutex (today) | 16.9 ms |
+| parallel, a fresh handle opened per read | **10.6 ms** |
+| parallel, handles reused from a pre-warmed pool | 10.9 ms |
+
+The pool is indistinguishable from opening a handle per read — within noise, and
+on the wrong side of it. Reusing handles buys nothing because the per-handle
+cost libgit2 re-pays on open (re-mmapping pack indexes, re-reading config and
+`packed-refs`) is dwarfed by the read itself, and the OS page cache is shared
+across handles regardless.
+
+Note what the 1.6× serial→parallel figure does **not** say. On APFS the fan-out
+is dominated by one slow read (`status`), so parallelising the other ten wins
+little. The reported bug is the case where *every* read costs about the same
+~9s: twelve of those serialized is ~108s, and parallel is ~9s. The win scales
+with how uniformly slow the filesystem is, which is exactly the `/mnt/c` shape.
+
+### The soft spot
+
+Both measurements are APFS. The claim that carries to WSL is the ratio — a ~1ms
+open against a ~9,000ms status is noise by four orders of magnitude, and drvfs
+would have to make `Repository::open` a thousand times more expensive than
+measured for a pool to matter. That is a strong inference but it is an
+inference; there is no WSL machine in the loop here.
+
+This is why the design puts the handle factory behind `RepoLock`'s constructor
+rather than at the call sites: if a `/mnt/c` profile ever shows the open cost
+mattering, a pool slots in behind `with_repo_read` without touching a single one
+of the migrated ops. Building the pool now on a measurement that says it is
+worthless is the wrong order.
+
+## Design
+
+### `git/repo_locks.rs` — the ordering primitive, on its own
+
+One new module owning one idea: how a repository's handles are ordered. Generic
+over the handle type, so its concurrency can be tested without libgit2 in the
+picture.
+
+```rust
+pub struct RepoLock<T> {
+    /// Orders reads against writes. Reads share it; writes take it alone.
+    gate: RwLock<()>,
+    /// The one cached handle every write runs on — the handle this app has
+    /// always had, behind the mutex it has always had.
+    exclusive: Mutex<T>,
+    /// Makes a handle for a reader to keep to itself.
+    open: Box<dyn Fn() -> AppResult<T> + Send + Sync>,
+}
+```
+
+Three entry points:
+
+| method | gate | handle | for |
+| --- | --- | --- | --- |
+| `exclusive(f)` | write | the cached one, `&mut T` | every write; today's behaviour unchanged |
+| `shared(f)` | read | a fresh one, `&T` | read-only ops |
+| `shared_mut(f)` | read | a fresh one, `&mut T` | read-only ops needing `&mut` (`stash_foreach`) |
+
+`shared_mut` handing out `&mut` under a *shared* gate is safe and is not a
+contradiction: the handle belongs to that reader alone and dies with the call.
+The `&mut` is about libgit2's C signature, not about mutating the repository.
+
+### `libgit2.rs` — the map, and the two new helpers
+
+```rust
+repos: Mutex<HashMap<RepoId, Arc<RepoCell>>>,
+
+struct RepoCell {
+    /// The gitdir, captured at open time.
+    gitdir: PathBuf,
+    lock: RepoLock<Repository>,
+}
+```
+
+`repo_cell` keeps its current job and its current comment: clone the `Arc` out,
+release the map lock immediately.
+
+The four helpers, none of which changes any call site's signature:
+
+- `with_repo` / `with_repo_mut` → `cell.lock.exclusive(...)`. Byte-for-byte
+  today's semantics: one cached handle, one exclusive lock.
+- `with_repo_read` / `with_repo_read_mut` → `cell.lock.shared(...)` /
+  `shared_mut(...)`.
+
+**Reads reopen from the gitdir, not the path the user named.** Both work —
+checked by planting the alternative and watching the tests stay green, because
+`Repository::open` on a linked worktree's workdir follows the `.git` file there
+and lands on the same repository. (An earlier draft of this spec asserted the
+workdir "resolves a linked worktree to the wrong repository". That is false, and
+it is recorded here rather than quietly deleted because it was the sort of claim
+that reads as authoritative and would have been inherited by the next reader.)
+
+The gitdir is still the better of two working choices: it is the path libgit2
+itself resolved, so a read handle is the same repository as the cached one by
+construction rather than by re-deriving it; it skips the `.git`-file indirection
+on every read, which is a file read per op on exactly the filesystems this issue
+is about; and nothing happening at the user-supplied path afterwards can change
+where a read lands.
+
+Reopen failures map through `ownership::map_open_error`, the same path `open`
+uses, so a repository that becomes untrusted mid-session says so rather than
+surfacing a raw libgit2 error — reported against the path the user named, not an
+internal `.git/worktrees/…` one.
+
+### What exclusion this drops, and what it keeps
+
+It drops read-vs-read exclusion. Nothing else.
+
+That is the whole safety argument, and it is worth stating precisely, because
+every ordering guarantee documented in `libgit2.rs` is a guarantee **about a
+write**:
+
+- the stash TOCTOU rule (`stash_drop_at`, `stash_finish_rename`) — verify and
+  drop under one acquisition, so no concurrent `refs/stash` **write** can shift
+  the indexes underneath;
+- the fast-forward pair (`git/libgit2.rs`, "Fast-forwarding a branch that is not
+  checked out") — the ancestry check and the ref **move** under one acquisition;
+- `fresh_index` — the staging ops' whole-index **write-back** must not revert
+  what something else staged;
+- `init`'s `init_lock` — guard, **write**, cleanup as one window.
+
+Each of those is preserved literally, because each runs under
+`exclusive`, and `exclusive` still excludes every reader and every other
+writer. Two readers running at once cannot violate any of them: neither one
+writes.
+
+`fresh_index`'s own closing paragraph already draws the line this design sits
+on — "It closes the window we own (our own stale cache), not the one we do not:
+against a writer racing us right now, git's `index.lock` is the only arbiter."
+The app has always had concurrent external readers and writers: the built-in
+terminal (#243) sits in the window `cd`-ed to the repository, a `pre-commit`
+hook that reformats and restages is a supported case, and a second window (#402)
+drives the same repository. This change adds concurrent in-process *readers*,
+which is a strictly weaker thing than what the code already tolerates.
+
+### The one new hazard: intermittent re-entrancy
+
+Today, calling a locking op from inside another locking closure for the same
+repository is a **guaranteed** deadlock — std's `Mutex` is not reentrant — and
+the code is written to avoid it. Two comments say so explicitly: `stash_pairs`
+takes an already-borrowed `&mut Repository` "so it can run INSIDE a
+`with_repo_mut` closure … std's `Mutex` is not reentrant, so calling it from
+inside a closure that holds the lock would deadlock", and the fast-forward
+helpers say the same.
+
+A shared gate makes one case *worse* by making it non-deterministic. Two
+`read()` acquisitions on the same thread succeed most of the time and deadlock
+when a writer queues between them — a hang that appears under load, in release,
+on a user's machine, and never in a test.
+
+So `RepoLock` carries a thread-local re-entrancy guard: each acquisition records
+the lock it holds and refuses a nested acquisition of the same lock with
+`AppError::Internal`. A legible error beats an intermittent hang, and it is
+testable, which an intermittent hang is not. Keyed per `RepoLock`, so an op on
+repository A nested inside an op on repository B stays legal — that pairing has
+no shared lock and no deadlock.
+
+The guard is live in release builds too. It costs a thread-local vector push per
+git op, against git ops that cost milliseconds at best.
+
+### Which ops migrate
+
+The fifteen the issue measured, and no more:
+
+**`refreshAll`'s fan-out (eleven, the clustered burst):** `status`, `branches`,
+`tags`, `stashes` (via `shared_mut`), `remotes`, `log_page`, `repo_state`,
+`rebase_status`, `bisect_status`, `head_info`, `shallow_info`.
+
+**The history-arrowing ladder (four):** `diff_commit`,
+`diff_commit_over_ceiling`, `verify_commit`, `worktrees`.
+
+`verify_commit` and `bisect_status` are worth naming: both shell out
+(`gpg`/`ssh-keygen`, `git rev-list --bisect-vars`) while holding the exclusive
+lock today, so a signature check blocks every unrelated read in the process.
+That is the `verify_commit` sitting alongside each step of the issue's ladder.
+
+Every other read-only op — `log`, `log_filtered`, `diff`, `diff_commits`,
+`file_history`, `blame_file`, `read_file_content*`, `commits_since`,
+`ahead_behind`, `submodules`, `lfs_status`, `commit_notes`, `read_reflog`,
+`list_all_files`, `list_files_at_rev`, `commit_template`, `difftool_plan`,
+`conflict_sides` — stays exclusive for now. Not because it must, but because
+each needs individual proof it writes nothing, and thirty-five of those proofs
+in one diff is a review nobody performs properly. Migrating one later is a
+one-word change at the call site.
+
+## Testing
+
+**`RepoLock` unit tests, with a fake handle and no timing assertions.** A
+wall-clock comparison would be a flake; these are deterministic:
+
+- *N shared acquisitions overlap.* Eight threads take `shared`, each announces
+  arrival and waits for the count to reach eight under a bounded condvar wait.
+  If the lock serialized, thread one would hold it while waiting for seven that
+  cannot enter — so serialization fails the assertion rather than slowing it.
+- *A shared acquisition excludes an exclusive one, and vice versa.*
+- *Each `shared` call gets its own handle* — the factory is invoked once per
+  call, and two overlapping readers hold different handles.
+- *A factory error propagates* as the op's error.
+- *Nesting is refused, not hung* — all four pairings (shared-in-shared,
+  shared-in-exclusive, exclusive-in-shared, exclusive-in-exclusive) return
+  `Internal`; nesting across two different `RepoLock`s is allowed.
+- *A panic inside `exclusive` poisons the handle into `Internal`*, not a
+  silent wrong answer.
+
+**Backend integration tests** (`src-tauri/tests/concurrent_reads.rs`):
+concurrent reads on one repository return the same answers as serial ones; reads
+work on a **linked worktree** and on a **bare** repository; `status` stays
+coherent beside a stream of `stage` writes.
+
+**What pins the gate, checked rather than assumed.** Removing the gate from
+`shared_mut` entirely leaves the integration tests green — libgit2 writes the
+index to `.git/index.lock` and renames it into place, so a reader on its own
+handle sees the whole old index or the whole new one, never a half-written file.
+Git's on-disk atomicity does that work, not `RepoLock`. The test that fails
+without the gate is the unit test `shared_and_exclusive_never_overlap`.
+
+That is worth stating plainly because it narrows what the gate is *for*. It is
+not protecting single-file writes, which git already makes atomic. It is
+protecting the **in-process, multi-call** invariants — the stash verify-then-drop
+pair, the fast-forward ancestry-check-then-ref-move — where the guarantee spans
+several git calls inside one closure and no single rename covers it. Those are
+precisely the invariants `libgit2.rs` documents, and precisely why dropping the
+gate is a separate decision from this one.
+
+**The existing suite is the real regression net.** Around ninety integration
+test files drive these ops, and the re-entrancy guard turns any latent nesting
+into a hard failure — so a green `cargo test` is meaningful evidence that no
+migrated op was reachable from inside another lock.
+
+## Docs to update in the same commit
+
+- `docs/dev/architecture.md` — `git/repo_locks.rs` in the backend tree.
+  `test/docs.test.ts` fails the build otherwise.
+- `docs/dev/backend.md` — the read/write split, the gitdir reopen, the
+  re-entrancy rule, and the measurements above.
+- `CLAUDE.md` — the convention line currently reads "per-repo ops serialize on
+  an inner mutex". After this, per-repo **writes** serialize; reads do not.
+  That line is load-bearing and now wrong.
+
+## Out of scope
+
+- **Letting reads run during a write.** Removing the gate would help a UI that
+  freezes for the length of a rebase or checkout, which is a real complaint but
+  not the one #400 reports and not one there is evidence for here. It would also
+  be a semantic change rather than a scheduling one. Its own issue, its own
+  evidence.
+- **A handle pool.** Measured as worthless; see above. The interface is shaped so
+  it can be added later without touching call sites.
+- **Reducing the fan-out.** Eleven concurrent reads at startup may be more than
+  necessary, but making them cheap and making them fewer are independent, and
+  this change is the one with the evidence behind it.
+- **"Move the repo off `/mnt/c`."** #400 rules it out and is right to: the
+  repository lives on the Windows drive because Windows tools need it there.

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -12,6 +12,7 @@ use uuid::Uuid;
 use crate::error::{AppError, AppResult};
 use crate::git::image;
 use crate::git::ownership;
+use crate::git::repo_locks::RepoLock;
 use crate::git::shallow as shallow_mod;
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
@@ -77,7 +78,7 @@ pub struct RebaseState {
 }
 
 pub struct Libgit2Backend {
-    repos: Mutex<HashMap<RepoId, Arc<Mutex<Repository>>>>,
+    repos: Mutex<HashMap<RepoId, Arc<RepoLock<Repository>>>>,
     rebases: Mutex<HashMap<RepoId, RebaseState>>,
     /// Serializes the guard → write → cleanup window in `init` to prevent two
     /// concurrent calls on the same path from interfering. Without this lock, call
@@ -95,16 +96,20 @@ impl Libgit2Backend {
         }
     }
 
-    /// Clone the repo's own `Arc<Mutex<_>>` out of the map and RELEASE the map
-    /// lock before running `f`. The map guard used to stay alive for the whole
+    /// Clone the repo's own lock out of the map and RELEASE the map lock
+    /// before running `f`. The map guard used to stay alive for the whole
     /// operation, so every git op in the process — any repository, any window —
     /// serialized on one mutex: a 500-commit log walk in one tab blocked a
     /// status refresh in another, and `refreshAll`'s parallel commands ran
-    /// strictly one after another. Same-repo ops still serialize on the inner
-    /// mutex (`git2::Repository` is Send but not Sync — that part is
-    /// load-bearing, e.g. the stash TOCTOU note relies on it); different repos
-    /// now genuinely run in parallel.
-    fn repo_cell(&self, repo_id: &RepoId) -> AppResult<Arc<Mutex<Repository>>> {
+    /// strictly one after another. Different repos now genuinely run in
+    /// parallel.
+    ///
+    /// Same-repo ops used to serialize on the inner mutex too. They no longer
+    /// all do: `RepoLock` runs writes one at a time on the cached handle and
+    /// lets reads run together on handles of their own (#400). What still
+    /// holds — and what the stash TOCTOU note relies on — is that a write
+    /// excludes everything.
+    fn repo_cell(&self, repo_id: &RepoId) -> AppResult<Arc<RepoLock<Repository>>> {
         let map = self
             .repos
             .lock()
@@ -114,26 +119,64 @@ impl Libgit2Backend {
             .ok_or_else(|| AppError::UnknownRepo(repo_id.0.clone()))
     }
 
+    /// An op that runs ALONE on this repository — no other read, no other
+    /// write.
+    ///
+    /// The default, and where an op belongs unless it has been established to
+    /// write nothing. Despite the name this is very much the WRITE path:
+    /// `stage`, `unstage`, `discard` and `delete_untracked` read-modify-write
+    /// the whole index through it, `commit` writes an object and moves a ref
+    /// through it, and `checkout_branch`/`reset`/the rebase engine mutate the
+    /// worktree through it. `git2` takes `&self` for most of that, which is
+    /// why the borrow says nothing about it.
     fn with_repo<F, T>(&self, repo_id: &RepoId, f: F) -> AppResult<T>
     where
         F: FnOnce(&Repository) -> AppResult<T>,
     {
-        let cell = self.repo_cell(repo_id)?;
-        let repo = cell
-            .lock()
-            .map_err(|e| AppError::Internal(e.to_string()))?;
-        f(&repo)
+        self.repo_cell(repo_id)?.exclusive(|repo| f(repo))
     }
 
+    /// `with_repo`, for the seven ops libgit2 makes take `&mut Repository`
+    /// (`stash_foreach`, `stash_drop`).
     fn with_repo_mut<F, T>(&self, repo_id: &RepoId, f: F) -> AppResult<T>
     where
         F: FnOnce(&mut Repository) -> AppResult<T>,
     {
-        let cell = self.repo_cell(repo_id)?;
-        let mut repo = cell
-            .lock()
-            .map_err(|e| AppError::Internal(e.to_string()))?;
-        f(&mut repo)
+        self.repo_cell(repo_id)?.exclusive(f)
+    }
+
+    /// A READ-ONLY op, on a handle of its own, alongside other reads (#400).
+    ///
+    /// Only for an op that writes nothing — no index write-back, no ref move,
+    /// no object written, no worktree change. A write here would interleave
+    /// with other writes with nothing to stop it.
+    ///
+    /// Two rules come with the private handle:
+    ///
+    /// - **Anything reading the index still goes through `fresh_index`.** The
+    ///   handle is newly opened rather than cached, so its in-memory index is
+    ///   whatever was on disk a moment ago — the same staleness `with_repo`
+    ///   has, arriving by a different route.
+    /// - **Never call one of these from inside another repo-lock closure for
+    ///   the same repository.** It is refused with `Internal` rather than
+    ///   deadlocking, but it is still a bug. The existing helpers that take an
+    ///   already-borrowed `&Repository` (`stash_pairs`, the fast-forward pair)
+    ///   are the pattern to follow.
+    fn with_repo_read<F, T>(&self, repo_id: &RepoId, f: F) -> AppResult<T>
+    where
+        F: FnOnce(&Repository) -> AppResult<T>,
+    {
+        self.repo_cell(repo_id)?.shared(f)
+    }
+
+    /// `with_repo_read`, for a read that needs `&mut` to satisfy libgit2 —
+    /// `stashes` and its `stash_foreach`. The handle belongs to this call
+    /// alone, so the mutable borrow is invisible to anyone else.
+    fn with_repo_read_mut<F, T>(&self, repo_id: &RepoId, f: F) -> AppResult<T>
+    where
+        F: FnOnce(&mut Repository) -> AppResult<T>,
+    {
+        self.repo_cell(repo_id)?.shared_mut(f)
     }
 
     /// The in-process blame: libgit2, HEAD, no subprocess.
@@ -1189,6 +1232,30 @@ fn is_listed_submodule(submodule_paths: &std::collections::HashSet<String>, path
 /// arbiter. Which is why this must stay INSIDE the caller's single `with_repo`
 /// closure — refreshing under one lock acquisition and writing under another
 /// would open a fresh check-then-act gap of our own making.
+/// Another handle on the same repository, for one read to keep to itself
+/// (#400).
+///
+/// Opens the GITDIR rather than the path the user named. Both work — that was
+/// checked, not assumed: `Repository::open` on a linked worktree's workdir
+/// follows the `.git` FILE there and lands on the same repository. The gitdir
+/// is the better of two working choices, for three reasons:
+///
+/// - It is the path libgit2 itself resolved during `open`, so a read handle is
+///   the same repository as the cached one BY CONSTRUCTION, rather than by
+///   re-deriving the answer and trusting it to come out the same.
+/// - It skips the `.git`-file indirection on every single read. On a linked
+///   worktree that is an extra file read per op, and the whole point of #400 is
+///   filesystems where a file read is not free.
+/// - Nothing that happens at the user-supplied path afterwards can change where
+///   a read lands — a rewritten `.git` file, a replaced workdir.
+///
+/// `report_as` is the path the USER named, kept only for the error message — a
+/// `DubiousOwnership` naming an internal `.git/worktrees/…` path would be about
+/// a directory they never chose.
+fn open_read_handle(gitdir: &Path, report_as: &Path) -> AppResult<Repository> {
+    Repository::open(gitdir).map_err(|e| ownership::map_open_error(report_as, &e))
+}
+
 fn fresh_index(repo: &Repository) -> AppResult<git2::Index> {
     let mut index = repo.index()?;
     index.read(false)?;
@@ -2674,7 +2741,26 @@ fn accept_side(
     ours: bool,
 ) -> AppResult<()> {
     backend.with_repo(repo_id, |repo| {
-        let index = repo.index()?;
+        // `fresh_index`, not `repo.index()`, and this one is load-bearing in a
+        // way that cost two e2e specs to find (#400).
+        //
+        // The decision below is "which side of the conflict do we take", read
+        // out of the index's conflict entries. A CACHED index that predates the
+        // merge has no conflict entries at all, so the loop finds nothing,
+        // `target_oid` stays None, `side_existed` stays false — and the
+        // `None if !side_existed` arm reads that as "deleted on the chosen
+        // side" and DELETES the file from the worktree. The user asked to keep
+        // a version of a file and the file disappears.
+        //
+        // This held together for a long time by accident: `status` used to run
+        // on this same cached handle, and libgit2's `git_status_list_new`
+        // reloads the index from disk unless `GIT_STATUS_OPT_NO_REFRESH` is
+        // set, so every status refresh was silently re-reading the index for
+        // everyone. Moving reads onto private handles (#400) took that away and
+        // turned a latent bug into a reproducible one. The lesson is the rule
+        // `fresh_index` already states: an index read that DECIDES something
+        // needs its own refresh, not somebody else's side effect.
+        let index = fresh_index(repo)?;
         let path_bytes = path.to_string_lossy().as_bytes().to_vec();
 
         let mut target_oid: Option<git2::Oid> = None;
@@ -2716,7 +2802,7 @@ fn accept_side(
                 }
                 std::fs::write(&full, blob.content())
                     .map_err(|e| AppError::Io(e.to_string()))?;
-                let mut index = repo.index()?;
+                let mut index = fresh_index(repo)?;
                 let _ = index.remove_path(path);
                 index.add_path(path)?;
                 index.write()?;
@@ -2726,7 +2812,7 @@ fn accept_side(
                 if full.exists() {
                     std::fs::remove_file(&full).map_err(|e| AppError::Io(e.to_string()))?;
                 }
-                let mut index = repo.index()?;
+                let mut index = fresh_index(repo)?;
                 let _ = index.remove_path(path);
                 index.write()?;
             }
@@ -3144,11 +3230,19 @@ impl GitBackend for Libgit2Backend {
             .map(super::repo_path_key)
             .unwrap_or_else(|| path.to_path_buf());
 
+        // Reads get handles of their own (#400), minted from the gitdir this
+        // open already resolved rather than by re-running discovery — see
+        // `open_read_handle`. Captured here because this is the only place
+        // that knows both paths.
+        let gitdir = repo.path().to_path_buf();
+        let report_as = path.to_path_buf();
+        let lock = RepoLock::new(repo, move || open_read_handle(&gitdir, &report_as));
+
         let mut map = self
             .repos
             .lock()
             .map_err(|e| AppError::Internal(e.to_string()))?;
-        map.insert(id.clone(), Arc::new(Mutex::new(repo)));
+        map.insert(id.clone(), Arc::new(lock));
 
         Ok(RepoHandle {
             id,
@@ -3306,7 +3400,7 @@ impl GitBackend for Libgit2Backend {
     }
 
     fn status(&self, repo_id: &RepoId) -> AppResult<Vec<FileStatus>> {
-        self.with_repo(repo_id, |repo| {
+        self.with_repo_read(repo_id, |repo| {
             // Per-file line stats for each side separately, so the staged and
             // unstaged rows can report their own numbers. Degrades to empty
             // (→ 0/0 counts) rather than failing status.
@@ -3416,7 +3510,7 @@ impl GitBackend for Libgit2Backend {
         cursor: Option<&[String]>,
         limit: usize,
     ) -> AppResult<LogPage> {
-        self.with_repo(repo_id, |repo| {
+        self.with_repo_read(repo_id, |repo| {
             let ref_map = collect_ref_map(repo);
             let mut walk = repo.revwalk()?;
             walk.set_sorting(Sort::TIME | Sort::TOPOLOGICAL)?;
@@ -4110,7 +4204,7 @@ impl GitBackend for Libgit2Backend {
         let rel = path.to_path_buf();
         let path_str = rel.to_string_lossy().into_owned();
         self.with_repo(repo_id, |repo| {
-            let index = repo.index()?;
+            let index = fresh_index(repo)?;
             // Stage 0 is the normal, non-conflicted entry. A conflicted path has
             // stages 1-3 and no 0, so it lands in the same "not in the index"
             // branch as an untracked one — correct either way, because neither
@@ -4183,7 +4277,7 @@ impl GitBackend for Libgit2Backend {
                     read_worktree_side(&workdir.join(&rel))?
                 }
                 BlobSource::Index => {
-                    let index = repo.index()?;
+                    let index = fresh_index(repo)?;
                     match index.get_path(&rel, 0) {
                         // A `160000` gitlink HAS a stage-0 entry and its oid is
                         // a commit in the submodule's object database, so
@@ -4196,7 +4290,7 @@ impl GitBackend for Libgit2Backend {
                     }
                 }
                 BlobSource::Stage { stage } => {
-                    let index = repo.index()?;
+                    let index = fresh_index(repo)?;
                     match index.get_path(&rel, i32::from(*stage)) {
                         Some(e) if e.mode != u32::from(git2::FileMode::Commit) => {
                             read_blob_side(repo, e.id)?
@@ -4292,7 +4386,7 @@ impl GitBackend for Libgit2Backend {
         ignore_whitespace: bool,
         raise_for: &[PathBuf],
     ) -> AppResult<Vec<FileDiff>> {
-        self.with_repo(repo_id, |repo| {
+        self.with_repo_read(repo_id, |repo| {
             let commit = repo.revparse_single(oid)?.peel_to_commit()?;
             let to_tree = commit.tree()?;
             // First parent for merges; None (empty tree) for the root commit.
@@ -5071,7 +5165,7 @@ impl GitBackend for Libgit2Backend {
     }
 
     fn branches(&self, repo_id: &RepoId) -> AppResult<Vec<BranchInfo>> {
-        self.with_repo(repo_id, |repo| {
+        self.with_repo_read(repo_id, |repo| {
             let head_ref = repo.head().ok();
             let head_name = head_ref
                 .as_ref()
@@ -5151,7 +5245,7 @@ impl GitBackend for Libgit2Backend {
     }
 
     fn tags(&self, repo_id: &RepoId) -> AppResult<Vec<TagInfo>> {
-        self.with_repo(repo_id, |repo| {
+        self.with_repo_read(repo_id, |repo| {
             let mut out = Vec::new();
             repo.tag_foreach(|oid, name_bytes| {
                 let name = std::str::from_utf8(name_bytes)
@@ -5189,7 +5283,7 @@ impl GitBackend for Libgit2Backend {
     }
 
     fn stashes(&self, repo_id: &RepoId) -> AppResult<Vec<StashInfo>> {
-        self.with_repo_mut(repo_id, |repo| {
+        self.with_repo_read_mut(repo_id, |repo| {
             // Two passes, not one: `stash_foreach` holds the repository mutably
             // for the duration of the walk, so the closure cannot `find_commit`
             // to read a parent count. Collect the raw triples first, resolve
@@ -5222,7 +5316,7 @@ impl GitBackend for Libgit2Backend {
     }
 
     fn remotes(&self, repo_id: &RepoId) -> AppResult<Vec<RemoteInfo>> {
-        self.with_repo(repo_id, |repo| {
+        self.with_repo_read(repo_id, |repo| {
             let mut out = Vec::new();
             for name in repo.remotes()?.iter().flatten().flatten() {
                 let url = repo
@@ -5934,7 +6028,7 @@ impl GitBackend for Libgit2Backend {
     /// read leaves the count 0 while `shallow` stays true, since the boolean is
     /// what every surface actually branches on.
     fn shallow_info(&self, repo_id: &RepoId) -> AppResult<ShallowInfo> {
-        self.with_repo(repo_id, |repo| {
+        self.with_repo_read(repo_id, |repo| {
             let shallow = repo.is_shallow();
             let boundary_count = if shallow {
                 std::fs::read_to_string(repo.commondir().join("shallow"))
@@ -6320,7 +6414,7 @@ impl GitBackend for Libgit2Backend {
         // ONE repo-lock acquisition for both small file reads (state + summary);
         // this is polled by every refreshStatus, so a second acquisition was a
         // second queue-up behind whatever op the repo is busy with.
-        self.with_repo(repo_id, |repo| {
+        self.with_repo_read(repo_id, |repo| {
             let mut status = match in_memory {
                 Some(status) => status,
                 // No in-memory entry: either there is no rebase, or this process
@@ -6393,7 +6487,12 @@ impl GitBackend for Libgit2Backend {
         // hex check above could only approximate), and what reaches argv is a
         // full oid we produced, not caller text — the same reason
         // `bisect::resolve` exists.
-        let (full_oid, signed) = self.with_repo(repo_id, |repo| {
+        // `with_repo_read`, not `with_repo`: this resolves a revision and reads
+        // a signature, writing nothing — and it is the op that made the #400
+        // ladder a ladder. Held exclusively, the `git show` below stalled every
+        // unrelated read in the process for as long as gpg took, once per
+        // commit the user arrowed onto.
+        let (full_oid, signed) = self.with_repo_read(repo_id, |repo| {
             let commit = repo
                 .revparse_single(oid)
                 .and_then(|obj| obj.peel_to_commit())
@@ -6531,7 +6630,7 @@ impl GitBackend for Libgit2Backend {
     }
 
     fn repo_state(&self, repo_id: &RepoId) -> AppResult<RepoState> {
-        self.with_repo(repo_id, |repo| {
+        self.with_repo_read(repo_id, |repo| {
             // Our own rebase wins: libgit2 only sees the CHERRY_PICK_HEAD /
             // MERGE_HEAD a paused step leaves behind, which would report the
             // step's mechanism instead of the operation the user started.
@@ -6557,7 +6656,7 @@ impl GitBackend for Libgit2Backend {
     }
 
     fn head_info(&self, repo_id: &RepoId) -> AppResult<HeadInfo> {
-        self.with_repo(repo_id, |repo| {
+        self.with_repo_read(repo_id, |repo| {
             // Same split `WorktreeInfo`'s listing already uses: `head()` errors
             // on an unborn branch (leaving both fields `None`), and a detached
             // HEAD resolves to a reference literally named "HEAD" whose
@@ -6577,7 +6676,11 @@ impl GitBackend for Libgit2Backend {
 
     fn conflict_sides(&self, repo_id: &RepoId, path: &Path) -> AppResult<ConflictSides> {
         self.with_repo(repo_id, |repo| {
-            let index = repo.index()?;
+            // `fresh_index` for the same reason as `accept_side` — see the long
+            // note there. This is what seeds the merge window's regions, so a
+            // cached index that predates the merge yields NO sides, the window
+            // renders nothing to accept, and Apply never enables (#400).
+            let index = fresh_index(repo)?;
             let path_str = path.to_string_lossy().to_string();
             let path_bytes = path.to_string_lossy().as_bytes().to_vec();
 
@@ -6642,7 +6745,7 @@ impl GitBackend for Libgit2Backend {
 
     fn mark_resolved(&self, repo_id: &RepoId, paths: &[PathBuf]) -> AppResult<()> {
         self.with_repo(repo_id, |repo| {
-            let mut index = repo.index()?;
+            let mut index = fresh_index(repo)?;
             for p in paths {
                 // remove_path drops all three stages; add_path re-inserts the worktree version as stage 0.
                 let _ = index.remove_path(p);
@@ -6678,7 +6781,7 @@ impl GitBackend for Libgit2Backend {
                 .ok_or_else(|| AppError::InvalidPath("bare repository".into()))?;
             std::fs::write(workdir.join(path), content)
                 .map_err(|e| AppError::Io(e.to_string()))?;
-            let mut index = repo.index()?;
+            let mut index = fresh_index(repo)?;
             // remove_path drops all three conflict stages; add_path re-inserts
             // the just-written worktree version as stage 0 (same dance as
             // mark_resolved).
@@ -6756,7 +6859,7 @@ impl GitBackend for Libgit2Backend {
 
         self.with_repo(repo_id, |repo| {
             let sig = crate::git::signature::default_signature(repo)?.to_owned();
-            let mut index = repo.index()?;
+            let mut index = fresh_index(repo)?;
             let tree_oid = index.write_tree()?;
             let tree = repo.find_tree(tree_oid)?;
             let head_commit = repo.head()?.peel_to_commit()?;
@@ -6982,7 +7085,7 @@ impl GitBackend for Libgit2Backend {
     // ─── Linked worktrees (#93) ───────────────────────────────────────────────
 
     fn worktrees(&self, repo_id: &RepoId) -> AppResult<Vec<WorktreeInfo>> {
-        self.with_repo(repo_id, |repo| {
+        self.with_repo_read(repo_id, |repo| {
             let current = repo.workdir().map(|p| p.to_path_buf());
             let names = repo.worktrees()?;
             let mut out = Vec::new();
@@ -7147,7 +7250,10 @@ impl GitBackend for Libgit2Backend {
     // ─── Bisect (#93) ─────────────────────────────────────────────────────────
 
     fn bisect_status(&self, repo_id: &RepoId) -> AppResult<BisectStatus> {
-        self.with_repo(repo_id, crate::git::bisect::status)
+        // Read-only, and it shells out to `git rev-list --bisect-vars` for its
+        // progress numbers — so holding this exclusively blocked every other
+        // read for the length of a subprocess (#400).
+        self.with_repo_read(repo_id, crate::git::bisect::status)
     }
 
     fn bisect_start(

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -12,6 +12,7 @@ pub mod notes;
 pub mod ownership;
 pub mod rebase_plan;
 pub mod rebase_state;
+pub mod repo_locks;
 pub mod update_refs;
 pub mod shallow;
 pub mod signature;

--- a/src-tauri/src/git/repo_locks.rs
+++ b/src-tauri/src/git/repo_locks.rs
@@ -1,0 +1,432 @@
+//! How one repository's `git2::Repository` handles are ordered (#400).
+//!
+//! The backend used to keep exactly one handle per repository behind one
+//! mutex, so every op on a repository — read or write — ran one at a time.
+//! That is correct and it is also why a slow filesystem hurt so much: eleven
+//! reads issued together by `refreshAll` waited for each other, and the user
+//! paid their SUM rather than the slowest of them. On a `/mnt/c` repository
+//! under WSL, where each read costs seconds of `stat` traffic across the VM
+//! boundary, that turned ~9s into ~108s (#400).
+//!
+//! Concurrent reads cannot be had by swapping the mutex for an `RwLock`:
+//! `git2::Repository` is `Send` but NOT `Sync`, so several threads may not
+//! hold `&Repository` at once, and the type system is right to refuse it. The
+//! parallelism has to come from separate HANDLES.
+//!
+//! So this type keeps two things: the one cached handle every write runs on,
+//! behind the mutex it has always had, and a factory that mints a handle for a
+//! reader to keep to itself. A gate orders the two against each other.
+//!
+//! **What this drops is read-vs-read exclusion, and nothing else.** Every
+//! ordering guarantee written down in `libgit2.rs` is a guarantee about a
+//! WRITE — the stash TOCTOU pair, the fast-forward ancestry check, the
+//! whole-index write-back in `fresh_index`. All of them run under `exclusive`,
+//! which still excludes every reader and every other writer, so all of them
+//! stay literally true. Two readers cannot violate any of them: neither one
+//! writes.
+//!
+//! Generic over the handle so the concurrency above can be tested without
+//! libgit2 in the picture — see the tests at the bottom of this file, which
+//! prove overlap and exclusion by counting, not by timing.
+
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, RwLock};
+
+use crate::error::{AppError, AppResult};
+
+/// Distinguishes one `RepoLock` from another for the re-entrancy guard.
+/// A counter rather than the lock's address: an id cannot be recycled by a
+/// later allocation landing where a dropped lock used to be.
+static NEXT_LOCK_ID: AtomicU64 = AtomicU64::new(0);
+
+thread_local! {
+    /// Which `RepoLock`s this thread is currently inside.
+    ///
+    /// A vector, not a flag: nesting two DIFFERENT repositories is legal and
+    /// must stay legal — it shares no lock, so there is no deadlock to prevent.
+    static HELD: RefCell<Vec<u64>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Marks this thread as holding one lock, and unmarks it on the way out.
+struct Reentry(u64);
+
+impl Reentry {
+    /// Refuse a nested acquisition of a lock this thread already holds.
+    ///
+    /// Nesting is a deadlock either way — but the two shapes fail
+    /// differently, and that is the reason this guard exists. Re-entering the
+    /// exclusive path hangs every time, so it shows up the first time anyone
+    /// runs it. Re-entering the SHARED path succeeds whenever no writer is
+    /// waiting and hangs when one is: a bug that passes in tests, passes in
+    /// review, and hangs on a user's machine under load. Converting it into an
+    /// error makes it something a test can catch.
+    fn enter(id: u64) -> AppResult<Self> {
+        HELD.with(|held| {
+            let mut held = held.borrow_mut();
+            if held.contains(&id) {
+                return Err(AppError::Internal(
+                    "re-entrant repository lock: a git op ran inside another op on the \
+                     same repository, which would deadlock"
+                        .into(),
+                ));
+            }
+            held.push(id);
+            Ok(Reentry(id))
+        })
+    }
+}
+
+impl Drop for Reentry {
+    fn drop(&mut self) {
+        HELD.with(|held| {
+            let mut held = held.borrow_mut();
+            if let Some(i) = held.iter().rposition(|id| *id == self.0) {
+                held.remove(i);
+            }
+        });
+    }
+}
+
+/// One repository's handles, and the order they run in.
+pub struct RepoLock<T> {
+    id: u64,
+    /// Orders reads against writes: reads share it, writes take it alone.
+    gate: RwLock<()>,
+    /// The one cached handle every write runs on.
+    exclusive: Mutex<T>,
+    /// Mints a handle for one reader to keep to itself.
+    ///
+    /// A factory rather than a pool, and that was measured rather than
+    /// assumed: `Repository::open` costs ~1.1ms warm, and a pre-warmed pool
+    /// of handles finished a twelve-read fan-out in 10.9ms against 10.6ms for
+    /// opening one per read — the pool is on the wrong side of noise. Keeping
+    /// it behind this field means a pool can be added later, if a `/mnt/c`
+    /// profile ever justifies one, without touching a single call site.
+    open: Box<dyn Fn() -> AppResult<T> + Send + Sync>,
+}
+
+impl<T> RepoLock<T> {
+    /// `handle` is the cached handle writes will use; `open` mints the ones
+    /// readers get.
+    pub fn new<F>(handle: T, open: F) -> Self
+    where
+        F: Fn() -> AppResult<T> + Send + Sync + 'static,
+    {
+        Self {
+            id: NEXT_LOCK_ID.fetch_add(1, Ordering::Relaxed),
+            gate: RwLock::new(()),
+            exclusive: Mutex::new(handle),
+            open: Box::new(open),
+        }
+    }
+
+    /// Run `f` alone: no other read and no other write on this repository.
+    ///
+    /// This is what every mutating op uses, and it is the behaviour the
+    /// backend has always had. Verify-then-mutate inside one call is atomic
+    /// against everything else in the process, which is what the stash TOCTOU
+    /// rule and the fast-forward ancestry check both rest on.
+    pub fn exclusive<F, R>(&self, f: F) -> AppResult<R>
+    where
+        F: FnOnce(&mut T) -> AppResult<R>,
+    {
+        let _reentry = Reentry::enter(self.id)?;
+        let _gate = self
+            .gate
+            .write()
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        let mut handle = self
+            .exclusive
+            .lock()
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        f(&mut handle)
+    }
+
+    /// Run `f` on a handle of its own, alongside any number of other readers.
+    ///
+    /// Read-only ops only. Writes still go through `exclusive` — a write here
+    /// would run concurrently with other reads and with nothing stopping a
+    /// second write from interleaving, which is exactly the whole-index
+    /// clobber `fresh_index` was written to prevent.
+    pub fn shared<F, R>(&self, f: F) -> AppResult<R>
+    where
+        F: FnOnce(&T) -> AppResult<R>,
+    {
+        self.shared_mut(|handle| f(&*handle))
+    }
+
+    /// `shared`, for a read that needs `&mut` to satisfy libgit2.
+    ///
+    /// `&mut` under a SHARED gate is not the contradiction it looks like: the
+    /// handle was minted for this call and dies with it, so no one else can
+    /// observe it. The `&mut` is about C signatures — `git_stash_foreach` and
+    /// friends take a mutable `git_repository` — not about mutating anything.
+    pub fn shared_mut<F, R>(&self, f: F) -> AppResult<R>
+    where
+        F: FnOnce(&mut T) -> AppResult<R>,
+    {
+        let _reentry = Reentry::enter(self.id)?;
+        let _gate = self
+            .gate
+            .read()
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        let mut handle = (self.open)()?;
+        f(&mut handle)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Barrier};
+    use std::time::Duration;
+
+    /// A stand-in for `git2::Repository`: carries a serial number so a test can
+    /// tell two handles apart, and counts how many were made.
+    #[derive(Debug)]
+    struct FakeHandle(usize);
+
+    /// A lock whose factory hands out numbered handles, and the mint count.
+    fn lock() -> (Arc<RepoLock<FakeHandle>>, Arc<AtomicUsize>) {
+        let made = Arc::new(AtomicUsize::new(0));
+        let m = Arc::clone(&made);
+        let l = RepoLock::new(FakeHandle(0), move || {
+            Ok(FakeHandle(m.fetch_add(1, Ordering::SeqCst) + 1))
+        });
+        (Arc::new(l), made)
+    }
+
+    /// Eight readers must be inside `shared` AT ONCE.
+    ///
+    /// A `Barrier` for all eight, taken INSIDE the closure, is the whole
+    /// proof: it cannot be cleared unless all eight readers hold the lock
+    /// simultaneously. Serialize the lock and reader one blocks on a barrier
+    /// the other seven can never reach, so nothing completes — and the
+    /// bounded `recv_timeout` on the main thread turns that deadlock into a
+    /// failed assertion instead of a hung suite.
+    ///
+    /// **This is the shape that has teeth, and it was arrived at the hard
+    /// way.** The first version of this test counted arrivals into a shared
+    /// peak instead, and passed against a deliberately serialized lock: the
+    /// count was never decremented on the way out, so eight readers passing
+    /// through one at a time still drove it to eight. A concurrency test that
+    /// cannot fail is worse than no test, so if this one is ever edited, plant
+    /// a `.write()` in `shared_mut` and watch it go red first.
+    ///
+    /// Note also that the timeout only costs anything when the test FAILS —
+    /// the passing path clears the barrier immediately, so ten seconds buys
+    /// robustness on a loaded CI box for free.
+    #[test]
+    fn shared_acquisitions_overlap() {
+        const N: usize = 8;
+        let (l, _made) = lock();
+        let barrier = Arc::new(Barrier::new(N));
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        let mut threads = Vec::new();
+        for _ in 0..N {
+            let l = Arc::clone(&l);
+            let barrier = Arc::clone(&barrier);
+            let tx = tx.clone();
+            threads.push(std::thread::spawn(move || {
+                l.shared(|_handle| {
+                    barrier.wait();
+                    Ok(())
+                })
+                .expect("shared");
+                // Ignore a send failure: the receiver is gone only when the
+                // test has already failed and is unwinding.
+                let _ = tx.send(());
+            }));
+        }
+        drop(tx);
+
+        for got in 0..N {
+            rx.recv_timeout(Duration::from_secs(10)).unwrap_or_else(|_| {
+                panic!(
+                    "only {got} of {N} readers got through: `shared` is not letting reads \
+                     overlap, so the first reader is holding the lock while blocked on a \
+                     barrier the rest cannot reach",
+                )
+            });
+        }
+        for t in threads {
+            t.join().expect("join");
+        }
+    }
+
+    /// Every `shared` call gets a handle of its own — the property that makes
+    /// concurrent reads sound at all, given `Repository` is not `Sync`.
+    #[test]
+    fn each_shared_call_mints_its_own_handle() {
+        let (l, made) = lock();
+        let first = l.shared(|h| Ok(h.0)).expect("first");
+        let second = l.shared(|h| Ok(h.0)).expect("second");
+        assert_ne!(first, second, "two reads must not share one handle");
+        assert_eq!(made.load(Ordering::SeqCst), 2, "one handle minted per read");
+    }
+
+    /// The cached handle is the write handle, and it is the SAME one every time.
+    #[test]
+    fn exclusive_reuses_the_cached_handle() {
+        let (l, made) = lock();
+        l.exclusive(|h| {
+            h.0 = 42;
+            Ok(())
+        })
+        .expect("write");
+        let seen = l.exclusive(|h| Ok(h.0)).expect("read back");
+        assert_eq!(seen, 42, "writes must see the one cached handle");
+        assert_eq!(
+            made.load(Ordering::SeqCst),
+            0,
+            "a write must not mint a handle",
+        );
+    }
+
+    /// A reader and a writer must not overlap — the exclusion every TOCTOU
+    /// comment in `libgit2.rs` rests on.
+    #[test]
+    fn shared_and_exclusive_never_overlap() {
+        let (l, _made) = lock();
+        let inside = Arc::new(AtomicUsize::new(0));
+        let overlapped = Arc::new(AtomicUsize::new(0));
+        let start = Arc::new(Barrier::new(2));
+
+        let mut threads = Vec::new();
+        for is_writer in [true, false] {
+            let l = Arc::clone(&l);
+            let inside = Arc::clone(&inside);
+            let overlapped = Arc::clone(&overlapped);
+            let start = Arc::clone(&start);
+            threads.push(std::thread::spawn(move || {
+                start.wait();
+                for _ in 0..200 {
+                    let body = |_: &mut FakeHandle| {
+                        if inside.fetch_add(1, Ordering::SeqCst) != 0 {
+                            overlapped.fetch_add(1, Ordering::SeqCst);
+                        }
+                        std::thread::yield_now();
+                        inside.fetch_sub(1, Ordering::SeqCst);
+                        Ok(())
+                    };
+                    if is_writer {
+                        l.exclusive(body).expect("exclusive");
+                    } else {
+                        l.shared_mut(body).expect("shared");
+                    }
+                }
+            }));
+        }
+        for t in threads {
+            t.join().expect("join");
+        }
+        assert_eq!(
+            overlapped.load(Ordering::SeqCst),
+            0,
+            "a read overlapped a write; the gate is not excluding them",
+        );
+    }
+
+    /// A factory failure is the op's failure, not a panic.
+    #[test]
+    fn a_factory_error_propagates() {
+        let l: RepoLock<FakeHandle> =
+            RepoLock::new(FakeHandle(0), || Err(AppError::Internal("no handle".into())));
+        let err = l.shared(|_| Ok(())).expect_err("must fail");
+        assert!(
+            matches!(err, AppError::Internal(ref m) if m.contains("no handle")),
+            "got {err:?}",
+        );
+    }
+
+    /// Nesting the same lock is refused with an error rather than deadlocking.
+    ///
+    /// All four pairings, because the hazard is asymmetric: mutex re-entry
+    /// (write-in-write) is a guaranteed hang today, while read-in-read only
+    /// hangs when a writer happens to queue between the two acquisitions —
+    /// which is the intermittent failure this guard exists to convert into
+    /// something a test can see.
+    #[test]
+    fn nesting_the_same_lock_is_refused() {
+        let (l, _made) = lock();
+
+        let cases: Vec<(&str, Box<dyn Fn() -> AppResult<()>>)> = vec![
+            (
+                "shared in shared",
+                Box::new({
+                    let l = Arc::clone(&l);
+                    move || {
+                        let inner = Arc::clone(&l);
+                        l.shared(move |_| inner.shared(|_| Ok(())))
+                    }
+                }),
+            ),
+            (
+                "exclusive in exclusive",
+                Box::new({
+                    let l = Arc::clone(&l);
+                    move || {
+                        let inner = Arc::clone(&l);
+                        l.exclusive(move |_| inner.exclusive(|_| Ok(())))
+                    }
+                }),
+            ),
+            (
+                "shared in exclusive",
+                Box::new({
+                    let l = Arc::clone(&l);
+                    move || {
+                        let inner = Arc::clone(&l);
+                        l.exclusive(move |_| inner.shared(|_| Ok(())))
+                    }
+                }),
+            ),
+            (
+                "exclusive in shared",
+                Box::new({
+                    let l = Arc::clone(&l);
+                    move || {
+                        let inner = Arc::clone(&l);
+                        l.shared(move |_| inner.exclusive(|_| Ok(())))
+                    }
+                }),
+            ),
+        ];
+
+        for (name, case) in cases {
+            let err = case().expect_err(&format!("{name} must be refused, not hang"));
+            assert!(
+                matches!(err, AppError::Internal(ref m) if m.contains("re-entrant")),
+                "{name}: got {err:?}",
+            );
+        }
+    }
+
+    /// Two DIFFERENT repositories nested on one thread stay legal — they share
+    /// no lock, so there is no deadlock to prevent, and an op on repo A calling
+    /// into repo B is a shape the app is allowed to have.
+    #[test]
+    fn nesting_two_different_locks_is_allowed() {
+        let (a, _ma) = lock();
+        let (b, _mb) = lock();
+        let inner = Arc::clone(&b);
+        let out = a
+            .shared(move |_| inner.shared(|h| Ok(h.0)))
+            .expect("nesting two different locks must be allowed");
+        assert!(out > 0, "the inner lock's handle should have been minted");
+    }
+
+    /// The guard unwinds with the closure, so a refused nesting does not leave
+    /// the thread permanently marked as holding the lock.
+    #[test]
+    fn a_refused_nesting_leaves_the_lock_usable() {
+        let (l, _made) = lock();
+        let inner = Arc::clone(&l);
+        let _ = l.shared(move |_| inner.shared(|_| Ok(())));
+        l.shared(|_| Ok(())).expect("the lock must still be usable");
+        l.exclusive(|_| Ok(())).expect("and still writable");
+    }
+}

--- a/src-tauri/tests/concurrent_reads.rs
+++ b/src-tauri/tests/concurrent_reads.rs
@@ -1,0 +1,206 @@
+//! Read-only ops run concurrently and still agree with themselves (#400).
+//!
+//! The unit tests in `git/repo_locks.rs` prove the lock overlaps readers and
+//! excludes writers, with a fake handle and no libgit2. What they cannot prove
+//! is that the handles this backend mints are the RIGHT handles — which is the
+//! whole risk in reopening a repository from its gitdir rather than reusing
+//! one cached object.
+
+mod support;
+
+use std::sync::{Arc, Barrier};
+
+use platypusgit_lib::git::{libgit2::Libgit2Backend, GitBackend};
+use support::{fs::write_file, TempRepo};
+
+/// The eleven-read fan-out, issued together, must answer exactly what it
+/// answers one at a time.
+#[test]
+fn a_concurrent_fan_out_agrees_with_a_serial_one() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    write_file(tr.path(), "untracked.txt", "x\n");
+    let backend = Arc::new(Libgit2Backend::new());
+    let h = backend.open(tr.path()).expect("open");
+
+    // Serially first, so there is something to compare against.
+    let want_status = backend.status(&h.id).expect("status").len();
+    let want_branches = backend.branches(&h.id).expect("branches").len();
+    let want_log = backend.log(&h.id, None, 10).expect("log").len();
+    let want_head = backend.head_info(&h.id).expect("head_info");
+
+    // Then all at once, with a barrier so they really are simultaneous rather
+    // than merely spawned.
+    const N: usize = 8;
+    let start = Arc::new(Barrier::new(N));
+    let mut threads = Vec::new();
+    for i in 0..N {
+        let backend = Arc::clone(&backend);
+        let id = h.id.clone();
+        let start = Arc::clone(&start);
+        let want_head_branch = want_head.branch.clone();
+        threads.push(std::thread::spawn(move || {
+            start.wait();
+            match i % 4 {
+                0 => assert_eq!(
+                    backend.status(&id).expect("status").len(),
+                    want_status,
+                    "concurrent status disagreed",
+                ),
+                1 => assert_eq!(
+                    backend.branches(&id).expect("branches").len(),
+                    want_branches,
+                    "concurrent branches disagreed",
+                ),
+                2 => assert_eq!(
+                    backend.log(&id, None, 10).expect("log").len(),
+                    want_log,
+                    "concurrent log disagreed",
+                ),
+                _ => assert_eq!(
+                    backend.head_info(&id).expect("head_info").branch,
+                    want_head_branch,
+                    "concurrent head_info disagreed",
+                ),
+            }
+        }));
+    }
+    for t in threads {
+        t.join().expect("a concurrent read panicked");
+    }
+
+    // And the other reads in the fan-out at least answer without error, on
+    // their own private handles.
+    backend.tags(&h.id).expect("tags");
+    backend.stashes(&h.id).expect("stashes");
+    backend.remotes(&h.id).expect("remotes");
+    backend.repo_state(&h.id).expect("repo_state");
+    backend.rebase_status(&h.id).expect("rebase_status");
+    backend.shallow_info(&h.id).expect("shallow_info");
+    backend.worktrees(&h.id).expect("worktrees");
+}
+
+/// A read on a LINKED WORKTREE must read that worktree, not the main one.
+///
+/// A newly opened handle has to land on the same repository the cached one
+/// describes, and a linked worktree is where that is least obvious: its gitdir
+/// is `<main>/.git/worktrees/<name>/` while its workdir holds only a `.git`
+/// FILE pointing there. Get the reopen path wrong — reuse the main
+/// repository's, or reach for `repo.workdir()` on something that has none —
+/// and reads silently answer about a different checkout. The dirty file exists
+/// only in the worktree, so a leak is visible rather than theoretical.
+///
+/// What this does NOT prove is that the gitdir specifically is required.
+/// Opening the workdir path was tried and also passes, because libgit2 follows
+/// the `.git` file — see `open_read_handle`, which explains why the gitdir is
+/// still the better of two working choices. Claiming more than that here would
+/// be claiming more than the test checks.
+#[test]
+fn a_read_on_a_linked_worktree_reads_that_worktree() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    let wt_dir = tr.dir.path().join("wt");
+    tr.repo
+        .worktree("side", &wt_dir, None)
+        .expect("add worktree");
+    write_file(&wt_dir, "only-in-the-worktree.txt", "x\n");
+
+    let backend = Libgit2Backend::new();
+    let h = backend.open(&wt_dir).expect("open worktree");
+
+    let status = backend.status(&h.id).expect("status");
+    assert!(
+        status.iter().any(|s| s.path == "only-in-the-worktree.txt"),
+        "a read on the linked worktree must see its own untracked file, got {:?}",
+        status.iter().map(|s| &s.path).collect::<Vec<_>>(),
+    );
+
+    // The main checkout does not have that file, and a handle opened for the
+    // worktree must not start answering about it.
+    let main = backend.open(tr.path()).expect("open main");
+    let main_status = backend.status(&main.id).expect("main status");
+    assert!(
+        !main_status
+            .iter()
+            .any(|s| s.path == "only-in-the-worktree.txt"),
+        "the worktree's untracked file leaked into the main checkout's status: {:?}",
+        main_status.iter().map(|s| &s.path).collect::<Vec<_>>(),
+    );
+}
+
+/// Reads keep working when the repository has no worktree at all.
+#[test]
+fn reads_work_on_a_bare_repository() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    git2::Repository::init_bare(dir.path()).expect("init bare");
+
+    let backend = Libgit2Backend::new();
+    let h = backend.open(dir.path()).expect("open bare");
+
+    // No commits and no workdir, but the reads must answer rather than panic
+    // or resolve to some other repository.
+    assert!(backend.branches(&h.id).expect("branches").is_empty());
+    assert!(backend.tags(&h.id).expect("tags").is_empty());
+    backend.repo_state(&h.id).expect("repo_state");
+    backend.head_info(&h.id).expect("head_info");
+}
+
+/// `status` stays coherent while a stream of `stage` writes runs beside it.
+///
+/// `stage` read-modify-writes the WHOLE index, so this is the shape most
+/// likely to show a reader something incoherent, and 200 reads against 20
+/// writes gives the interleaving plenty of chances.
+///
+/// **It does not prove the gate earns its keep, and it was checked rather than
+/// assumed.** Removing the gate from `shared_mut` entirely leaves this test
+/// green: libgit2 writes the index to `.git/index.lock` and renames it into
+/// place, so a reader on its own handle sees the whole old index or the whole
+/// new one and never a half-written file. Git's on-disk atomicity is doing
+/// that work, not `RepoLock`.
+///
+/// What pins the gate is `shared_and_exclusive_never_overlap` in
+/// `git/repo_locks.rs`, which fails immediately without it. The gate is there
+/// for the IN-PROCESS ordering guarantees — the stash TOCTOU pair, the
+/// fast-forward ancestry check — where the invariant spans several git calls
+/// inside one closure and no single rename makes it atomic.
+#[test]
+fn status_stays_coherent_beside_a_write_stream() {
+    let tr = TempRepo::with_initial_commit("hello\n");
+    const FILES: usize = 20;
+    for i in 0..FILES {
+        write_file(tr.path(), &format!("f{i}.txt"), "x\n");
+    }
+    let backend = Arc::new(Libgit2Backend::new());
+    let h = backend.open(tr.path()).expect("open");
+
+    let writer = {
+        let backend = Arc::clone(&backend);
+        let id = h.id.clone();
+        std::thread::spawn(move || {
+            for i in 0..FILES {
+                let p = std::path::PathBuf::from(format!("f{i}.txt"));
+                backend.stage(&id, &[p]).expect("stage");
+            }
+        })
+    };
+
+    let reader = {
+        let backend = Arc::clone(&backend);
+        let id = h.id.clone();
+        std::thread::spawn(move || {
+            for _ in 0..200 {
+                // Every path is either staged or not, so the TOTAL never
+                // changes while the writer works through them. A torn read
+                // would lose one or double-count it.
+                let status = backend.status(&id).expect("status");
+                assert_eq!(
+                    status.len(),
+                    FILES,
+                    "status saw {} of {FILES} paths — an incoherent read",
+                    status.len(),
+                );
+            }
+        })
+    };
+
+    writer.join().expect("writer panicked");
+    reader.join().expect("reader panicked");
+}

--- a/src-tauri/tests/conflict.rs
+++ b/src-tauri/tests/conflict.rs
@@ -191,3 +191,84 @@ fn continue_operation_creates_two_parent_merge_commit() {
         RepoState::Clean
     ));
 }
+
+/// A conflict created by an EXTERNAL `git merge`, resolved through a handle
+/// that was already live — the ordering the app actually has (#400).
+///
+/// Every other test in this file opens the backend AFTER the conflict exists,
+/// so the handle loads a fresh index and the conflict stages are always
+/// visible. The app does the opposite, and that difference hid a bug that
+/// DELETED the user's file:
+///
+/// 1. The repository is open and the History screen renders a diff, which
+///    loads that handle's in-memory index (clean, no conflicts).
+/// 2. `merge_branch` shells out to real `git merge` (`commands/branches.rs`),
+///    so the conflict stages land on DISK with nothing telling libgit2.
+/// 3. `accept_ours` reads the index to decide which side to take. Against the
+///    stale snapshot it finds no conflict entry for the path, concludes the
+///    file was deleted on the chosen side, and removes it from the worktree.
+///
+/// It stayed hidden for as long as `status` ran on the same cached handle:
+/// libgit2's `git_status_list_new` reloads the index unless
+/// `GIT_STATUS_OPT_NO_REFRESH` is set, so every refresh was quietly re-reading
+/// the index on everyone else's behalf. Moving reads onto private handles took
+/// that away.
+///
+/// So this test exists to pin the ordering, not the arithmetic: it is the only
+/// one here that can tell `fresh_index` from `repo.index()`.
+#[test]
+fn accept_ours_survives_a_conflict_created_under_a_live_handle() {
+    use support::{fs::write_file, git_in, TempRepo};
+
+    let tr = TempRepo::with_initial_commit("hello\n");
+
+    // Two branches that touch the same line, built with real git so nothing
+    // warms the backend's handle.
+    git_in(tr.path(), &["checkout", "-b", "clash"]);
+    write_file(tr.path(), "README.md", "theirs change\n");
+    git_in(tr.path(), &["commit", "-am", "theirs"]);
+    git_in(tr.path(), &["checkout", "main"]);
+    write_file(tr.path(), "README.md", "ours change\n");
+    git_in(tr.path(), &["commit", "-am", "ours"]);
+
+    let (backend, handle) = tr.open_with_backend();
+
+    // Step 1: load this handle's index while the tree is still clean. A diff
+    // against the working tree is what the History screen does on open, and it
+    // reaches for `git_repository_index` without refreshing it.
+    backend
+        .diff(
+            &handle.id,
+            &PathBuf::from("README.md"),
+            platypusgit_lib::git::types::DiffKind::WorktreeToIndex,
+            3,
+            false,
+        )
+        .ok();
+
+    // Step 2: the conflict appears on disk, under the live handle. `git merge`
+    // exits non-zero on conflict, so this cannot go through `git_in`.
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(tr.path())
+        .args(["merge", "clash"])
+        .output()
+        .expect("spawn git merge");
+    assert!(
+        !out.status.success(),
+        "the fixture must actually conflict, got: {}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+
+    // Step 3: resolve. The file must survive, with OUR content.
+    backend
+        .accept_ours(&handle.id, &PathBuf::from("README.md"))
+        .expect("accept_ours");
+
+    assert!(
+        tr.path().join("README.md").exists(),
+        "accept_ours DELETED the file: it read a stale index, found no conflict \
+         entry, and took the deleted-on-this-side branch",
+    );
+    assert_eq!(read_file(tr.path(), "README.md"), "ours change\n");
+}


### PR DESCRIPTION
perf(git): run the read-only fan-out concurrently instead of queued

Read-only ops all took the same exclusive per-repo lock, so the eleven
reads `refreshAll` issues together waited for each other and the user
paid their SUM rather than the slowest. On a /mnt/c repository under WSL,
where each costs seconds of stat traffic across the VM boundary, that
turned ~9s into ~108s, and arrowing through history laddered to 45s.

Each repository now sits behind a `RepoLock` (`git/repo_locks.rs`): one
cached handle for writes, a private handle minted per read, an `RwLock`
gate ordering the two. Fifteen read-only ops move onto the shared path.

**Why a new helper rather than reinterpreting `with_repo`:** #400 reads
the problem as "`with_repo` is a read, `with_repo_mut` is a write" and
proposes splitting there. That is not what those are. `with_repo`
carries most of this backend's writes — `stage`/`unstage`/`discard`
read-modify-write the whole index through it, which is why `fresh_index`
exists — and `with_repo_mut` exists only for the seven places libgit2's
C signatures demand `&mut git_repository`. Making `with_repo` shared
would let two `stage` calls interleave their whole-index writes: exactly
the data loss `tests/index_staleness.rs` was written to catch. So the
read path is new and opt-in, and every unmigrated call site keeps
today's semantics by construction.

Nor could this be an `RwLock<Repository>`: `git2::Repository` is `Send`
but not `Sync`, so the parallelism has to come from separate handles.

**The only exclusion dropped is read-vs-read.** Every ordering guarantee
written down in libgit2.rs is about a WRITE — the stash TOCTOU pair, the
fast-forward ancestry check, `fresh_index`'s write-back, `init`'s
guard/write/cleanup window — and all of them still run under a gate that
excludes everything, so all of them stay literally true.

## `status` was refreshing the index for everybody

This caused one real regression, caught by CI, and it is the most
important thing in the diff.

libgit2's `git_status_list_new` reloads the index from disk unless
`GIT_STATUS_OPT_NO_REFRESH` is set. While `status` ran on the shared
cached handle, every refresh — and the app refreshes constantly — was
silently re-reading the index for every other op on that handle. Several
ops read `repo.index()` directly and were correct only because of it.

Moving `status` to a private handle took that away:

- `accept_side` reads the index's conflict entries to decide which side
  to take. Against a stale snapshot it finds none, concludes the file was
  deleted on the chosen side, and **deletes it from the worktree** — the
  user asks to keep a version of a file and the file disappears.
- `conflict_sides` seeds the merge window's regions the same way, so the
  window rendered nothing to accept and Apply never enabled.

The trigger is not obvious: `merge_branch` shells out to real
`git merge`, so conflict stages land on disk with nothing telling
libgit2, and History's diff has already loaded that handle's index while
the tree was clean.

Fixed by obeying the rule `fresh_index` already stated, at every
exclusive-path site that reads the index to DECIDE or WRITE BACK:
`accept_side`, `conflict_sides`, `mark_resolved`, `save_resolution`,
`continue_operation`, `read_file_content_at_index`,
`read_image_preview`. Deliberately NOT changed: the rebase engine's
`finish_pick`/`apply_merge`/`finish_merge` and `cherry_pick`/`revert`,
which read the index AFTER modifying it in their own closure — there the
in-memory index is the authority and a reload could only lose work.

The Rust suite was green through all of this, because every test in
`tests/conflict.rs` opens the backend AFTER the conflict exists and so
always sees a fresh index.
`accept_ours_survives_a_conflict_created_under_a_live_handle` pins the
app's real ordering instead, and is the only test in that file that can
tell `fresh_index` from `repo.index()` — verified by putting the bug back
and watching it, alone, go red.

## No handle pool, measured rather than assumed

Twelve reads of the shapes `refreshAll` issues (macOS/APFS, warm):
serial through one mutex 16.9ms, parallel with a fresh handle per read
10.6ms, parallel with a pre-warmed pool 10.9ms. `Repository::open` is
~1.1ms, so a pool is on the wrong side of noise. The factory sits behind
`RepoLock::new` so one can be added later without touching a call site.

These numbers are all APFS — no WSL machine was in the loop, so that
conclusion rests on a ratio (1ms against 9,000ms) rather than a direct
measurement, and the spec says so.

## Other things checked by planting the opposite

Nested locking on one repository now returns `Internal` instead of
deadlocking, because a shared gate makes that hazard intermittent: two
read acquisitions on one thread succeed whenever no writer is waiting
and hang when one is.

- The overlap unit test, as first written, PASSED against a deliberately
  serialized lock (it counted arrivals without decrementing). Rewritten
  around a Barrier for all N, which cannot clear unless all N readers
  hold the lock at once.
- "Opening the workdir resolves a linked worktree to the wrong
  repository" was false — libgit2 follows the `.git` file there. The
  gitdir is still better, for three duller reasons, now stated
  accurately.
- A "never sees a torn index" test passed with the gate removed
  entirely, because libgit2 writes the index via index.lock + rename.
  Renamed, and the docs now say the gate is pinned by
  `shared_and_exclusive_never_overlap` and exists for the in-process
  multi-call invariants rather than single-file atomicity.
- `test/docs.test.ts` does NOT enforce that a backend module appears in
  architecture.md's tree — it is a substring search over CLAUDE.md plus
  every docs/dev/*.md. Corrected in the plan.

Verified after the last edit: cargo 1243 passed / 0 failed, vitest 3370
passed across 342 files, `tsc` and the e2e typecheck clean, and the
**full** e2e suite 32/32 spec files with no retries.

Spec and plan: docs/superpowers/{specs,plans}/2026-09-04-repo-read-concurrency*

Closes #400

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
