### PR TITLE
chore(deps): migrate to ureq 3

### DIFF
--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -70,6 +70,25 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
 - `LfsUnavailable` and `NoBisect` are STATES, not failures (disable + explain /
   refresh). `DirtyWorktree` is reused for `git worktree remove`'s refusal → the
   second, type-the-name confirm.
+- **The forge agent turns `http_status_as_error` OFF, and that is not a
+  stylistic choice.** `ureq` 3's default is to collapse a 4xx/5xx into
+  `Error::StatusCode(code)` and DROP the response with it — which throws away
+  the forge's own `message` field, the difference between a banner reading
+  "forge error: 422" and one reading "a pull request already exists for
+  owner:branch". So `forge/http.rs` takes the status as an ordinary response
+  and `error_for` classifies it: 401/403 to `ForgeAuth(host)` (routes to
+  Settings, never to the git-transport credential dialog), 404 to the
+  scopes hint, everything else to `HTTP <code>: <message>`. `update.rs` leaves
+  the default alone on purpose — GitHub's release endpoints have no error body
+  worth showing, so there the status IS the message.
+- Both agents spell `max_redirects(5)` out rather than inherit it: `ureq` 2
+  defaulted to 5 and 3 defaults to 10. `https_only(true)` is the one that
+  matters on a redirect — without it a redirect could downgrade an
+  authenticated API call to plaintext http with the token still in the header.
+  (`ureq` 3 also stops forwarding auth headers across hosts by default; that is
+  a second belt, not a replacement.) And the forge body cap is now an ERROR
+  over the limit rather than `ureq` 2's silent truncation, which only ever
+  surfaced as unparseable JSON somewhere further along.
 
 ## Interactive rebase engine
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -410,6 +410,18 @@ proven by `pnpm test`. It needs a real Docker e2e run.
   `major.minor.patch` or it reads a selector as a version; and `it.each`'s
   `$major` renders as `undefined`, which is why the floor cases are a plain
   loop.
+- **`forge::http`'s in-file tests** pin the one thing about the outbound forge
+  agent that is invisible from outside and silent when wrong. `ureq` 3's
+  default is to collapse a 4xx/5xx into `Error::StatusCode(code)` and drop the
+  response with it; let that default back in and `error_for` never runs, so a
+  401 arrives as a transport failure, becomes `Network`, and the UI pops the
+  git-transport credential dialog for a token that lives in Settings. The
+  tests read the agent's own `Config` (`http_status_as_error`, `https_only`,
+  `max_redirects`, the global timeout) and drive `error_for` against a real
+  `Response<Body>` built with `ureq::Body::builder()` — no network, and no
+  source-text matching either. They live in `forge/http.rs` rather than in
+  `tests/forge_api.rs` because the functions they cover are private, which is
+  itself the point: nothing outside the module may build a forge request.
 - **`test/privacy.test.ts`** pins the promise the README advertises (#226): no
   analytics package in `package.json` or anywhere in `pnpm-lock.yaml`
   (transitive is the arrival nobody reviews), no network call or analytics

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5670,18 +5670,31 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "af5546be8f5378d5414f83733f5c9a2526f4645829edbc1c41790aeef1b38e8b"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "flate2",
  "log",
- "once_cell",
+ "percent-encoding",
  "rustls",
  "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabc3e92916c89c95b20eef7b06b00b066bc217ef9ea3a4ac9bf1a7e35261e10"
+dependencies = [
+ "base64 0.23.1",
+ "http",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -5714,6 +5727,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -5995,15 +6014,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.8",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,7 +40,7 @@ tauri-plugin-wdio-webdriver = { version = "1.2.0", optional = true }
 tauri-plugin-single-instance = "2.4.2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
-ureq = "2"
+ureq = "3"
 # Already in the tree transitively; declared directly so `open_url` can really
 # parse a URL instead of prefix-matching one.
 url = "2"

--- a/src-tauri/src/forge/http.rs
+++ b/src-tauri/src/forge/http.rs
@@ -15,7 +15,6 @@
 //! forge-specific surface (URL builders + parsers) pure and testable with no
 //! network.
 
-use std::io::Read;
 use std::time::Duration;
 
 use url::Url;
@@ -23,23 +22,40 @@ use url::Url;
 use crate::error::{AppError, AppResult};
 use crate::git::auth::scrub_credentials;
 
-/// Total budget for one API call. `ureq` 2.x defaults every timeout to `None`,
-/// so a host that completes the TLS handshake and then stalls would pin the
+/// Total budget for one API call. `ureq` defaults every timeout to `None`, so a
+/// host that completes the TLS handshake and then stalls would pin the
 /// `spawn_blocking` thread forever with no cancel.
 const HTTP_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Largest body we will read. A 50-item PR page is a few hundred KB at worst.
 const MAX_BODY: u64 = 4 * 1024 * 1024;
 
+/// What a call hands back. `ureq` 3 responds with the `http` crate's types
+/// rather than one of its own, so this names the pair once instead of spelling
+/// the generic at four call sites.
+type Response = ureq::http::Response<ureq::Body>;
+
 fn agent() -> ureq::Agent {
-    // `https_only` matters beyond the initial request: the agent follows up to 5
-    // redirects by default, and without it a redirect could downgrade an
-    // authenticated API call to plaintext http — with the token in the header.
-    ureq::AgentBuilder::new()
-        .timeout(HTTP_TIMEOUT)
+    // `https_only` matters beyond the initial request: the agent follows
+    // redirects, and without it a redirect could downgrade an authenticated API
+    // call to plaintext http — with the token in the header. (`ureq` 3 also
+    // stops forwarding auth headers across hosts by default, which is a second
+    // belt on the same trouser; `https_only` is still the one that decides the
+    // scheme.)
+    //
+    // `http_status_as_error(false)` is what keeps a 4xx READABLE. `ureq` 3
+    // turns a non-2xx into `Error::StatusCode(code)` and drops the response
+    // with it — but the forge's own `message` field is the whole difference
+    // between "forge error: 422" and "a pull request already exists for
+    // owner:branch". So a status stays an ordinary response here and
+    // `error_for` is what classifies it.
+    ureq::Agent::config_builder()
+        .timeout_global(Some(HTTP_TIMEOUT))
         .https_only(true)
-        .redirects(5)
+        .max_redirects(5)
+        .http_status_as_error(false)
         .build()
+        .new_agent()
 }
 
 /// Host of `url`, for an error that must name where authentication failed
@@ -52,13 +68,16 @@ fn host_of(url: &str) -> String {
 }
 
 /// Read a response body, capped.
-fn read_capped(resp: ureq::Response) -> AppResult<String> {
-    let mut buf = String::new();
-    resp.into_reader()
-        .take(MAX_BODY)
-        .read_to_string(&mut buf)
-        .map_err(|e| AppError::Network(scrub_credentials(&e.to_string())))?;
-    Ok(buf)
+///
+/// A body over the cap is an error rather than a silent truncation — which is
+/// what `ureq` 2's `take()` did, and truncated JSON only ever surfaced as an
+/// unparseable body somewhere further along.
+fn read_capped(mut resp: Response) -> AppResult<String> {
+    resp.body_mut()
+        .with_config()
+        .limit(MAX_BODY)
+        .read_to_string()
+        .map_err(|e| AppError::Network(scrub_credentials(&e.to_string())))
 }
 
 /// Turn a non-2xx response into a typed error.
@@ -68,7 +87,8 @@ fn read_capped(resp: ureq::Response) -> AppResult<String> {
 /// pull request already exists for owner:branch". Everything shown goes through
 /// `scrub_credentials`; the CALLER additionally applies `token::redact`, so a
 /// forge that echoes the token cannot put it in a banner.
-fn error_for(url: &str, code: u16, resp: ureq::Response) -> AppError {
+fn error_for(url: &str, resp: Response) -> AppError {
+    let code = resp.status().as_u16();
     if code == 401 || code == 403 {
         return AppError::ForgeAuth(host_of(url));
     }
@@ -124,24 +144,30 @@ fn message_from_body(body: &str) -> Option<String> {
     None
 }
 
-/// Map a `ureq` transport failure (DNS, TLS, timeout) to `Network`.
-fn transport_error(e: ureq::Transport) -> AppError {
+/// Map a `ureq` failure to `Network`.
+///
+/// With `http_status_as_error` off, every `Err` out of this module is a
+/// transport-level failure — DNS, TLS, timeout, a refused plaintext redirect —
+/// so there is no status case left to sort out here. A status arrives as an
+/// ordinary response and goes to `error_for`.
+fn transport_error(e: ureq::Error) -> AppError {
     AppError::Network(scrub_credentials(&e.to_string()))
 }
 
 /// Blocking authenticated GET. Call inside `spawn_blocking`.
 pub fn get_json(url: &str, header: (&str, &str)) -> AppResult<String> {
     let (name, value) = header;
-    match agent()
+    let resp = agent()
         .get(url)
-        .set(name, value)
-        .set("User-Agent", "platypusgit")
-        .set("Accept", "application/json")
+        .header(name, value)
+        .header("User-Agent", "platypusgit")
+        .header("Accept", "application/json")
         .call()
-    {
-        Ok(resp) => read_capped(resp),
-        Err(ureq::Error::Status(code, resp)) => Err(error_for(url, code, resp)),
-        Err(ureq::Error::Transport(t)) => Err(transport_error(t)),
+        .map_err(transport_error)?;
+    if resp.status().is_success() {
+        read_capped(resp)
+    } else {
+        Err(error_for(url, resp))
     }
 }
 
@@ -158,16 +184,129 @@ pub fn post_json(
     let (name, value) = header;
     let payload = serde_json::to_string(body)
         .map_err(|e| AppError::Internal(format!("could not encode the request body: {e}")))?;
-    match agent()
+    let resp = agent()
         .post(url)
-        .set(name, value)
-        .set("User-Agent", "platypusgit")
-        .set("Accept", "application/json")
-        .set("Content-Type", "application/json")
-        .send_string(&payload)
-    {
-        Ok(resp) => read_capped(resp),
-        Err(ureq::Error::Status(code, resp)) => Err(error_for(url, code, resp)),
-        Err(ureq::Error::Transport(t)) => Err(transport_error(t)),
+        .header(name, value)
+        .header("User-Agent", "platypusgit")
+        .header("Accept", "application/json")
+        .header("Content-Type", "application/json")
+        .send(payload.as_str())
+        .map_err(transport_error)?;
+    if resp.status().is_success() {
+        read_capped(resp)
+    } else {
+        Err(error_for(url, resp))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a response the way the forge would, so `error_for` is exercised
+    /// against a real `Response<Body>` rather than a stand-in.
+    fn resp(code: u16, body: &str) -> Response {
+        ureq::http::Response::builder()
+            .status(code)
+            .body(ureq::Body::builder().data(body))
+            .expect("build a test response")
+    }
+
+    /// The regression this pins: `ureq` 3 collapses a 4xx/5xx into
+    /// `Error::StatusCode(code)` BY DEFAULT and drops the response with it. Let
+    /// that default back in and `error_for` never runs — a 401 arrives as a
+    /// transport failure, becomes `Network`, and the UI pops the git-transport
+    /// credential dialog for a forge token that lives in Settings.
+    #[test]
+    fn a_forge_status_is_a_response_to_read_not_an_error_to_swallow() {
+        let cfg = agent().config().clone();
+        assert!(
+            !cfg.http_status_as_error(),
+            "the forge agent must hand a 4xx back as a response; see error_for"
+        );
+        // The rest of the shape, in the same breath — each one is load-bearing
+        // and none of it is observable from the outside without a network.
+        assert!(cfg.https_only(), "a redirect must not downgrade to plaintext");
+        assert_eq!(cfg.max_redirects(), 5);
+        assert_eq!(cfg.timeouts().global, Some(HTTP_TIMEOUT));
+    }
+
+    #[test]
+    fn unauthorized_and_forbidden_name_the_host_and_route_to_settings() {
+        for code in [401, 403] {
+            match error_for("https://example.com/api/v4/x", resp(code, "{}")) {
+                AppError::ForgeAuth(host) => assert_eq!(host, "example.com"),
+                other => panic!("{code} became {other:?}, not ForgeAuth"),
+            }
+        }
+    }
+
+    #[test]
+    fn a_url_with_no_host_still_produces_a_readable_auth_error() {
+        match error_for("not a url", resp(401, "{}")) {
+            AppError::ForgeAuth(host) => assert_eq!(host, "the forge"),
+            other => panic!("expected ForgeAuth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_404_carries_the_scopes_hint_and_the_forges_own_words() {
+        let body = r#"{"message":"Not Found"}"#;
+        match error_for("https://example.com/repos/o/n", resp(404, body)) {
+            AppError::Forge(m) => {
+                assert!(m.contains("the token's scopes"), "{m}");
+                assert!(m.contains("Not Found"), "{m}");
+            }
+            other => panic!("expected Forge, got {other:?}"),
+        }
+    }
+
+    /// The whole reason the body is read at all: "HTTP 422" is not actionable
+    /// and "A pull request already exists for o:feat" is.
+    #[test]
+    fn a_github_validation_error_keeps_its_per_field_message() {
+        let body = r#"{"message":"Validation Failed",
+                       "errors":[{"message":"A pull request already exists for o:feat."}]}"#;
+        match error_for("https://example.com/repos/o/n/pulls", resp(422, body)) {
+            AppError::Forge(m) => {
+                assert!(m.starts_with("HTTP 422: Validation Failed"), "{m}");
+                assert!(m.contains("already exists for o:feat"), "{m}");
+            }
+            other => panic!("expected Forge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_gitlab_error_field_is_read_too() {
+        match error_for("https://example.com/api/v4/x", resp(400, r#"{"error":"bad ref"}"#)) {
+            AppError::Forge(m) => assert!(m.contains("bad ref"), "{m}"),
+            other => panic!("expected Forge, got {other:?}"),
+        }
+    }
+
+    /// A forge that answers with an HTML error page must not lose the status.
+    #[test]
+    fn an_unparseable_body_falls_back_to_the_status_alone() {
+        match error_for("https://example.com/x", resp(502, "<html>bad gateway</html>")) {
+            AppError::Forge(m) => assert_eq!(m, "HTTP 502: HTTP 502"),
+            other => panic!("expected Forge, got {other:?}"),
+        }
+    }
+
+    /// The cap is an ERROR now, not `ureq` 2's silent truncation — truncated
+    /// JSON only ever surfaced as an unparseable body somewhere further along.
+    #[test]
+    fn a_body_over_the_cap_is_refused_rather_than_truncated() {
+        let huge = "x".repeat(MAX_BODY as usize + 1);
+        match read_capped(resp(200, &huge)) {
+            Err(AppError::Network(_)) => {}
+            Ok(s) => panic!("read {} bytes over the cap instead of failing", s.len()),
+            Err(other) => panic!("expected Network, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_body_under_the_cap_reads_whole() {
+        assert_eq!(read_capped(resp(200, "{\"ok\":1}")).unwrap(), "{\"ok\":1}");
     }
 }

--- a/src-tauri/src/update.rs
+++ b/src-tauri/src/update.rs
@@ -17,7 +17,7 @@ pub const REPO_SLUG: &str = "jonassaa/platypusgit";
 /// rewrites it from the tag, so a binary reporting this is never a real install.
 pub const DEV_VERSION: &str = "0.0.0";
 
-/// Total budget for the discovery GET. `ureq` 2.x defaults every timeout to
+/// Total budget for the discovery GET. `ureq` defaults every timeout to
 /// `None`, so a host that completes the TLS handshake and then stalls pins the
 /// `spawn_blocking` thread forever and Settings' "Check for updates" button
 /// becomes a permanently disabled spinner with no cancel.
@@ -457,19 +457,28 @@ pub fn pick_newest(releases: &[ReleaseMeta]) -> Option<&ReleaseMeta> {
 /// Unauthenticated (60 req/hr/IP is ample for our cadence — and dev/e2e builds
 /// never get here, see `discover`).
 fn get_body(url: &str) -> AppResult<String> {
-    // `https_only` matters because the agent follows up to 5 redirects by
-    // default — without it a redirect could downgrade us to plaintext http.
-    let agent = ureq::AgentBuilder::new()
-        .timeout(HTTP_TIMEOUT)
+    // `https_only` matters because the agent follows redirects — without it a
+    // redirect could downgrade us to plaintext http. The redirect budget is
+    // spelled out rather than left to the crate: `ureq` 2 defaulted to 5 and 3
+    // defaults to 10, and neither number is a thing this call wants to inherit.
+    let agent = ureq::Agent::config_builder()
+        .timeout_global(Some(HTTP_TIMEOUT))
         .https_only(true)
-        .build();
-    let resp = agent
+        .max_redirects(5)
+        .build()
+        .new_agent();
+    // A non-2xx stays an error here, unlike `forge/http.rs`: GitHub's release
+    // endpoints have no error body worth showing a user, so the status is the
+    // whole message.
+    let mut resp = agent
         .get(url)
-        .set("User-Agent", "platypusgit-updater")
-        .set("Accept", "application/vnd.github+json")
+        .header("User-Agent", "platypusgit-updater")
+        .header("Accept", "application/vnd.github+json")
         .call()
         .map_err(|e| AppError::Network(e.to_string()))?;
-    resp.into_string()
+    // Capped at 10 MB by default, same as `ureq` 2's `into_string`.
+    resp.body_mut()
+        .read_to_string()
         .map_err(|e| AppError::Network(e.to_string()))
 }
 

--- a/src-tauri/tests/no_telemetry.rs
+++ b/src-tauri/tests/no_telemetry.rs
@@ -160,7 +160,8 @@ const ALLOWED_HOSTS: &[(&str, &str)] = &[
     (
         "example.com",
         "RFC 2606 reserved. Fixtures for git's own stderr in the inline tests of \
-         `src/commands/create.rs` and `src/git/auth.rs`. Cannot resolve.",
+         `src/commands/create.rs` and `src/git/auth.rs`, and the forge URLs in \
+         `src/forge/http.rs`'s inline tests. Cannot resolve.",
     ),
     (
         "example.invalid",


### PR DESCRIPTION
Replaces Dependabot #410, which bumped the version and nothing else. `ureq` 3
is an API rewrite, so that PR could never have compiled:
`AgentBuilder::new().timeout(d)` is now
`Agent::config_builder().timeout_global(Some(d))`, `.set(k, v)` is
`.header(k, v)`, and a response is the `http` crate's `Response<Body>` rather
than one of ureq's own.

### The one change that is behaviour, not syntax

**`http_status_as_error`.** ureq 3 collapses a 4xx/5xx into
`Error::StatusCode(code)` by default and *drops the response with it*.
`forge/http.rs` needs that body twice over:

- the forge's own `message` field is the difference between a banner reading
  "forge error: 422" and one reading "a pull request already exists for
  owner:branch", and
- `error_for` is what turns 401/403 into `ForgeAuth(host)`, which routes the
  user to Settings. Let the default back in and a 401 arrives as a transport
  failure, becomes `Network`, and the UI pops the **git-transport credential
  dialog** for a token that lives in Settings.

So the forge agent turns the default off and classifies the status itself.
`update.rs` leaves it on — GitHub's release endpoints have no error body worth
showing a user, so there the status *is* the message.

### Two smaller shifts, both now spelled out rather than inherited

- `max_redirects(5)` is explicit in both agents. ureq 2 defaulted to 5 and 3
  defaults to 10, and neither number is one these calls want to inherit.
  `https_only(true)` is unchanged and still the setting that stops a redirect
  downgrading an authenticated call to plaintext http with the token in the
  header. (ureq 3 also stops forwarding auth headers across hosts by default —
  a second belt, not a replacement.)
- The forge body cap is an **error** over the limit now, instead of ureq 2's
  silent `take()` truncation — which only ever surfaced as unparseable JSON
  somewhere further along. `update.rs`'s `read_to_string` keeps the same 10 MB
  default cap `into_string` had.

### Tests

Nine new tests in `forge/http.rs`, covering the half of this that no existing
test could see — the agent's `Config` (status-as-error off, https-only,
redirect budget, global timeout) and `error_for` driven against a real
`Response<Body>` built with `ureq::Body::builder()`:

| case | expected |
| --- | --- |
| 401 / 403 | `ForgeAuth` naming the host |
| a URL with no host | `ForgeAuth("the forge")`, not a panic |
| 404 | the scopes hint plus the forge's own words |
| 422 GitHub validation | keeps the per-field message |
| GitLab `error` field | read too |
| an HTML error page | falls back to the status alone |
| a body over the cap | refused, not truncated |

Still no network anywhere in the suite. Each assertion was checked against a
planted violation — dropping `http_status_as_error(false)`, dropping
`https_only(true)`, dropping `.limit(MAX_BODY)` and disabling the 401 branch
each fail exactly the test that claims to cover them.

Their fixture URLs use RFC 2606's `example.com` rather than a real forge host:
`no_telemetry.rs`'s hostname allow-list is a source-text scan over all of
`src/` and does not care that a literal is only a test fixture. The right
answer to that guard is a name that cannot resolve, not a new entry on the
list, so its `example.com` reason now names this file too.

### Lock

`ureq` 2.12.1 → 3.4.1, adding `ureq-proto` and `utf8-zero` and dropping the
`webpki-roots` 0.26 shim. Same rustls/ring TLS stack as before.

### Verification

- `cargo test` — 1252 passed / 0 failed across 91 suites (main's 1243 plus the
  nine added here)
- `cargo check --all-targets` — no errors
- `pnpm test` — 3472 passed / 3472

🤖 Generated with [Claude Code](https://claude.com/claude-code)
