### PR TITLE
feat(palette): offer the built-in terminal in the command palette

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1801,6 +1801,18 @@ default** — a terminal nobody asked for should not spawn a shell for every
 repository they open, and a `.zshrc` that runs nvm would then be paid for on
 every tab, invisibly.
 
+**Two routes in, and the second one had to be added by hand.** `terminal.toggle`
+(`` Ctrl+` ``/`` Mod+` ``) shipped with #243; the palette row did not, because
+**the palette is a CURATED list and not a projection of `ACTIONS`** — putting an
+action in the catalog gives it a chord and a cheat-sheet entry and nothing else.
+So the feature spent releases reachable only by a chord, which is the same gap
+an e2e run found for "New window" (#256), and the vitest layer cannot see it:
+asserting on `buildCommands()`'s array passes for an action that has no row.
+Anything user-facing added to `ACTIONS` from now on gets a row in
+`features/palette/commands.ts` in the same commit, and the row's label is read
+from the store when the list is BUILT (`Show terminal` / `Hide terminal`) while
+its id stays put, because `PaletteItem.id` is the frecency key.
+
 Four rules that are easy to break:
 
 - **Sizing is MEASURED, never observed.** WebKitGTK has no `ResizeObserver`, so

--- a/e2e/specs/terminal.e2e.ts
+++ b/e2e/specs/terminal.e2e.ts
@@ -15,8 +15,12 @@ import { basicRepo, TempRepo } from "../support/tempRepo";
 import {
   TERMINAL_VIEW,
   jsChord,
+  jsKey,
   jsTypeInTerminal,
+  openPalette,
   openRepo,
+  paletteDialog,
+  paletteInput,
   resetApp,
   terminalText,
 } from "../support/app";
@@ -89,5 +93,45 @@ describe("the built-in terminal", () => {
       timeoutMsg: "the terminal panel did not come back",
     });
     await expect(await terminalText()).toContain(marker);
+  });
+
+  // The palette route, and it is here rather than in `palette.e2e.ts` because
+  // only a real webview can answer it: the row is built from `buildCommands()`,
+  // and vitest asserting on that ARRAY is exactly the shape of test that passed
+  // for months while `terminal.toggle` had a chord, a cheat-sheet entry and no
+  // palette row at all. "Row never appeared" is an e2e-only finding here — it
+  // was for "New window" (#256).
+  it("opens from the command palette, and the row then offers the way back", async () => {
+    repo = basicRepo();
+    await openRepo(repo.path);
+
+    await openPalette();
+    await $(paletteInput).setValue("terminal");
+    const show = $(paletteDialog).$("[data-pal-index]*=Show terminal");
+    await show.waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg: 'palette row "Show terminal" never appeared',
+    });
+    await show.click();
+
+    await $(TERMINAL_VIEW).waitForDisplayed({
+      timeout: 20_000,
+      timeoutMsg: "the terminal panel never appeared after the palette row",
+    });
+
+    // The label is state, not a fixed string: with the panel up, the same row
+    // is the way out. Asserted through the real palette because the flip is
+    // read from the store when the list is BUILT, so a stale build would show
+    // "Show terminal" over an open panel.
+    await openPalette();
+    await $(paletteInput).setValue("terminal");
+    await $(paletteDialog)
+      .$("[data-pal-index]*=Hide terminal")
+      .waitForDisplayed({
+        timeout: 10_000,
+        timeoutMsg:
+          'the palette still offered "Show terminal" with the panel open',
+      });
+    await jsKey(paletteInput, "Escape");
   });
 });

--- a/src/features/palette/commands.test.ts
+++ b/src/features/palette/commands.test.ts
@@ -10,6 +10,7 @@ import {
 import { useRepoStore } from "@/features/repo/useRepoStore";
 import { useRecentsStore } from "@/features/repo/useRecentsStore";
 import { useTabsStore } from "@/features/repo/useTabsStore";
+import { useTerminalStore } from "@/features/terminal/useTerminalStore";
 import { newTab } from "@/features/repo/tabs";
 import { useCreateStore } from "@/features/create/useCreateStore";
 import { paletteInitial, usePaletteStore } from "./usePaletteStore";
@@ -655,6 +656,67 @@ describe("repository windows (#256)", () => {
     useTabsStore.setState({ activePath: "/dev/web" });
     item!.run();
     expect(moveTabToNewWindow).toHaveBeenCalledWith("/dev/web");
+  });
+});
+
+describe("the built-in terminal (#243)", () => {
+  const row = () =>
+    buildCommands().find((i) => i.id === "action:toggle-terminal");
+
+  // One test below swaps `toggle` for a collector, which replaces the store's
+  // real action for good — the same trap `realPushStep` exists for above.
+  const realToggle = useTerminalStore.getState().toggle;
+
+  beforeEach(() => {
+    resetStores();
+    useTerminalStore.setState({ open: false, toggle: realToggle });
+  });
+
+  it("offers the terminal with a repository open", () => {
+    expect(row()?.label).toBe("Show terminal");
+  });
+
+  it("is absent with no repository — the panel cannot appear without one", () => {
+    useRepoStore.setState({ current: null } as never);
+    expect(ids()).not.toContain("action:toggle-terminal");
+  });
+
+  it("names what will happen, on a row id that does not move", () => {
+    // The id is the frecency key: flipping it with the panel would teach the
+    // ranker two half-learned rows for one command.
+    useTerminalStore.setState({ open: true });
+    expect(row()?.label).toBe("Hide terminal");
+    expect(row()?.id).toBe("action:toggle-terminal");
+  });
+
+  it("takes its shortcut chip from the live keymap, not a hardcoded chord", () => {
+    expect(row()?.actionId).toBe("terminal.toggle");
+    expect(row()?.chord).toBeUndefined();
+  });
+
+  it("toggles the panel and closes the palette", () => {
+    const order: string[] = [];
+    usePaletteStore.setState({
+      closePalette: () => {
+        order.push("close");
+      },
+    } as never);
+    useTerminalStore.setState({
+      toggle: () => {
+        order.push("toggle");
+      },
+    } as never);
+    row()!.run();
+    expect(order).toEqual(["close", "toggle"]);
+  });
+
+  it("reads the store at click time, not when the palette was built", () => {
+    // The list is built when the palette opens; the chord can toggle the panel
+    // before the user presses Enter, and the row must still flip it from there.
+    const item = row()!;
+    useTerminalStore.setState({ open: true });
+    item.run();
+    expect(useTerminalStore.getState().open).toBe(false);
   });
 });
 

--- a/src/features/palette/commands.ts
+++ b/src/features/palette/commands.ts
@@ -12,6 +12,7 @@ import { prNoun, prNumberLabel } from "@/features/forge/forgeLabels";
 import { useSubmodulesStore } from "@/features/submodules/useSubmodulesStore";
 import { useWorktreesStore } from "@/features/worktrees/useWorktreesStore";
 import { useTabsStore } from "@/features/repo/useTabsStore";
+import { useTerminalStore } from "@/features/terminal/useTerminalStore";
 import { openCompare } from "@/features/compare/useCompareStore";
 import { WORKDIR } from "@/features/compare/compareSides";
 import { orderBranchesGrouped } from "@/features/branches/orderBranches";
@@ -463,6 +464,36 @@ export function buildCommands(): PaletteItem[] {
           }
         })();
       }),
+    });
+  }
+
+  // -- the built-in terminal (#243) --
+  //
+  // Listed by hand, because the palette is a CURATED list and not a projection
+  // of the action catalog: `terminal.toggle` has existed in `ACTIONS` with a
+  // chord and a cheat-sheet entry since #243 and still never appeared here —
+  // the same gap an e2e run found for "New window". Without this row the panel
+  // has exactly one route in, and a user who has not pressed `?` cannot find
+  // out it exists.
+  //
+  // Only with a repository open. The shell opens in the ACTIVE repository's
+  // working directory, and `TerminalPanel` renders nothing at all without one,
+  // so the row would otherwise toggle a panel that cannot appear.
+  //
+  // The LABEL says what will happen; the ID does not move. `PaletteItem.id` is
+  // the frecency key, so an id that flipped with the panel would split one
+  // command's ranking across two half-learned rows.
+  if (repo.current) {
+    items.push({
+      type: "command",
+      id: "action:toggle-terminal",
+      search: "Terminal shell console command line prompt toggle show hide",
+      label: useTerminalStore.getState().open
+        ? "Hide terminal"
+        : "Show terminal",
+      icon: "terminal",
+      actionId: "terminal.toggle",
+      run: direct(() => useTerminalStore.getState().toggle()),
     });
   }
 


### PR DESCRIPTION
Adds a command-palette row for the built-in terminal. Until now the panel had exactly one route in — the `` Ctrl+` `` chord — because the palette is a **curated list, not a projection of `ACTIONS`**: `terminal.toggle` has had a binding and a cheat-sheet entry since #243, and no palette row. That is the same gap an e2e run found for "New window" (#256).

## The row

```
Show terminal / Hide terminal      ⌃`
```

- **Label is state, id is not.** The label is read from `useTerminalStore` when the list is built, so it names what will happen. The id stays `action:toggle-terminal` — `PaletteItem.id` is the frecency key, and an id that flipped with the panel would split one command's ranking across two half-learned rows.
- **Chord chip comes from `actionId`**, never a hardcoded string, so the chip and the dispatcher cannot disagree after a rebind.
- **Listed only with a repository open.** The shell opens in the active repository's working directory and `TerminalPanel` renders nothing at all without one, so the row would otherwise toggle a panel that cannot appear.

## Tests

Six vitest cases in `commands.test.ts` (presence, absence without a repo, the label flip on a stable id, `actionId` not `chord`, close-then-toggle ordering, and reading the store at click time rather than at build time). I planted the violation to check they bite: with the row's gate disabled, 5 of the 6 fail — the sixth asserts absence and correctly still passes.

One e2e case in `terminal.e2e.ts` — clicks the row, asserts the panel appears, then reopens the palette and asserts the row now reads "Hide terminal". It is there rather than in `palette.e2e.ts` because only a real webview can catch this class: asserting on `buildCommands()`'s array is exactly the shape of test that passed for months while the row was missing.

## Verification

- `pnpm test` — 353 files, 3541 tests, all passing (re-run after the last edit, which touched `docs/dev/frontend.md`, itself under test).
- `pnpm tsc --noEmit` and `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — clean.
- `pnpm test:e2e:docker full --spec e2e/specs/terminal.e2e.ts` — 2 passing, snapshot rebuilt for this tree.
- `pnpm test:e2e:docker run --spec e2e/specs/palette.e2e.ts` — 8 passing.

## Docs

`docs/dev/frontend.md`'s terminal section now records the lesson: the palette is curated, so anything user-facing added to `ACTIONS` gets a row in the same commit, and vitest cannot see the gap.

## Noted, not changed

Neither route focuses xterm — nothing in the app calls `term.focus()`, so after opening you still click into the pane before typing. Pre-existing behaviour of the chord, identical through the row; happy to fix it separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
