### PR TITLE
fix(diff): say so when an image preview will not decode

### DIFF
--- a/docs/dev/backend.md
+++ b/docs/dev/backend.md
@@ -480,6 +480,27 @@ escape hatch from becoming the uncapped path #385 removed.
   `\x89PNG` is `NotAnImage`, `BM` needs its reserved field zero, an ICONDIR
   needs a non-zero image count. A repository is untrusted input, and a broken
   `<img>` is worse than a sentence.
+- **A sniff is not a validation — `integrity` is, and it has to live here.** The
+  header of a file whose data was cut off is intact, so `sniff` answers `Image`
+  for an aborted download, a bad merge or a half-written `git lfs smudge`. **A
+  webview does not report that as an error.** Measured in Blink 152: a PNG cut
+  to 60% of its length, and one whose IDAT was overwritten at the same total
+  length, both fire `load`, both report `naturalWidth/Height` from the intact
+  header, and one paints 60% of the picture while the other paints nothing —
+  `error` fires only when there is no decodable header at all. So no frontend
+  signal can catch this class, and `git/image.rs::integrity` — which holds the
+  WHOLE blob, the only place that does — refuses it as
+  `UnsupportedReason::Truncated` before it can reach an `<img>`.
+  **It reports only what the bytes PROVE**, because a false "truncated" hides an
+  image that would have displayed: PNG's chunk chain must reach a whole `IEND`;
+  a JPEG with no `FF D9` anywhere is proven short (that marker cannot occur in
+  stuffed scan data — though its presence proves nothing, since an EXIF
+  thumbnail carries one, so a photo cut after its thumbnail reads as complete);
+  WebP, BMP and ICO each declare their own length. CRCs are NOT verified
+  (decoders in the wild ignore them) and **GIF is deliberately not checked at
+  all** — one unframed `0x3B` trailer byte cannot prove anything. All of it is
+  pinned in `image.rs`'s tests, including a sweep that cuts a real encoder's PNG
+  at every offset and asserts each one still sniffs as an image.
 - **SVG is recognised and REFUSED**, as its own `UnsupportedReason::Svg` so the
   UI can say so rather than looking broken. It is the one format on the list
   that is not inert (script, `<foreignObject>`, external `href`/`url()`,

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -152,6 +152,14 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
     the webview already knows, and until it fires there simply are no
     dimensions (never `0 × 0`). The backdrop is a checkerboard built from
     `--bg-1`/`--bg-2` so transparency reads in both themes (#236).
+  * **A side the webview refuses to decode says so** (#212). `image.rs` sniffs a
+    header, not a whole file, so a truncated or corrupt blob whose magic number
+    survived still arrives as `kind: "image"` and the `<img>` is the first thing
+    to disagree. Its `onError` retires that side to a sentence, keeping the byte
+    caption (which came from the backend and is still true) and leaving the
+    other side alone: a corrupt new version must not hide a readable old one.
+    The failed set is keyed and cleared exactly like `dims`, so the next
+    selection starts clean rather than printing the previous file's failure.
 - **A textual diff with ZERO hunks is ordinary, and every surface says so.**
   Two everyday changes produce a `FileDiff` whose `hunks` is empty: an EMPTY
   ADDED file (a `.gitkeep` — git writes `new file mode` and no `@@` range), and

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -152,14 +152,33 @@ Part of the `docs/dev/` set (`architecture`, `testing`, `frontend`, `backend`,
     the webview already knows, and until it fires there simply are no
     dimensions (never `0 × 0`). The backdrop is a checkerboard built from
     `--bg-1`/`--bg-2` so transparency reads in both themes (#236).
-  * **A side the webview refuses to decode says so** (#212). `image.rs` sniffs a
-    header, not a whole file, so a truncated or corrupt blob whose magic number
-    survived still arrives as `kind: "image"` and the `<img>` is the first thing
-    to disagree. Its `onError` retires that side to a sentence, keeping the byte
-    caption (which came from the backend and is still true) and leaving the
-    other side alone: a corrupt new version must not hide a readable old one.
-    The failed set is keyed and cleared exactly like `dims`, so the next
-    selection starts clean rather than printing the previous file's failure.
+  * **A side the webview refuses to decode says so** (#212), and the split
+    between this and the backend is the whole point. **`onError` fires for far
+    less than it looks like it does.** Measured in Blink 152: a truncated PNG
+    and one with an overwritten IDAT both fire `load`, report the intact
+    header's dimensions and paint a partial or blank picture; `error` arrives
+    only when nothing decodable is there at all. So a *truncated* file is caught
+    in the backend (`git/image.rs::integrity` → `reason: "truncated"`, see
+    `docs/dev/backend.md`) and never reaches an `<img>`, and this `onError` is
+    the backstop for the case only the engine can know: a STRUCTURALLY COMPLETE
+    file this webview will not display. Its sentence says exactly that and
+    guesses at no cause — the app runs on three engines whose format coverage
+    differs, so "your file is corrupt" would be a lie on two of them.
+    The failing side keeps its byte caption (which came from the backend and is
+    still true) and leaves the other side alone: one bad version must not hide a
+    readable one.
+  * **`dims` and the decode failure are keyed to the BYTES they describe**, not
+    reset by an effect. Both are `Record<sideKey, …>` carrying the `data` string
+    they were measured from, and each panel compares that against the preview it
+    is currently rendering. That is why there is no reset effect: a reset keyed
+    on `[path, previewKey]` was narrower than what `useImagePreviews` treats as
+    identity (it ignores `repoId` and each side's `source`, and stands in
+    `data.length` for the data), so the same path at a different revision with
+    an equal byte length kept the previous file's state — a wrong caption, or a
+    failure notice printed over a good image. Deriving it instead is also
+    immune to the order in which a passive effect and the browser's `error`
+    task happen to run, and cannot let one side's new bytes clear the other
+    side's live failure.
 - **A textual diff with ZERO hunks is ordinary, and every surface says so.**
   Two everyday changes produce a `FileDiff` whose `hunks` is empty: an EMPTY
   ADDED file (a `.gitkeep` — git writes `new file mode` and no `@@` range), and

--- a/src-tauri/src/git/image.rs
+++ b/src-tauri/src/git/image.rs
@@ -204,6 +204,124 @@ fn svg_root(text: &str) -> bool {
     after.is_empty() || after.starts_with(|c: char| c.is_whitespace() || c == '>' || c == '/')
 }
 
+/// Whether a blob that already SNIFFED as an image carries all of its data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Integrity {
+    /// Every structure the file declares for itself is present.
+    Complete,
+    /// The file ends before its own declared structure does. Proven, not
+    /// guessed — see [`integrity`].
+    Truncated,
+}
+
+/// Decide whether `bytes` hold the WHOLE image their header promises.
+///
+/// [`sniff`] reads a header, so a file whose header survived and whose data was
+/// cut off — an aborted download, a bad merge, a half-written `git lfs smudge`
+/// — still answers [`Sniffed::Image`]. A webview does not report that as an
+/// error: it decodes the prefix, fires `load`, reports the dimensions from the
+/// intact header and paints the rows it got. So the panel would caption a
+/// half-blank picture `64 × 64` and say nothing, which is the outcome this
+/// module's doc rules out. Only the whole byte string can tell, and only here.
+///
+/// # Only what the bytes PROVE
+///
+/// A false "truncated" hides an image that would have displayed fine, which is
+/// worse than the broken preview it replaces. So every rule is a proof carried
+/// by the file's own declared structure, and anything ambiguous answers
+/// [`Integrity::Complete`]:
+///
+/// * **PNG** is self-delimiting: walk the chunk chain and require a whole
+///   `IEND`. A chunk that runs past the end is proof.
+/// * **JPEG** stuffs a literal `FF` inside a scan as `FF 00`, so a raw `FF D9`
+///   cannot occur in entropy-coded data — its ABSENCE proves the scan never
+///   ended. Its presence proves nothing (an EXIF thumbnail carries its own
+///   `FF D9`), so a photo cut after its thumbnail reads as complete.
+///   Under-reporting is the safe direction.
+/// * **WebP, BMP and ICO** each declare their own length; a file shorter than
+///   its own declaration is short by arithmetic.
+/// * **GIF** is deliberately NOT checked. Its trailer is a single unframed
+///   `0x3B` byte, and bytes after it are legal enough that absence would not be
+///   proof — only a guess, and a guess belongs nowhere near this answer.
+pub fn integrity(bytes: &[u8], media_type: &str) -> Integrity {
+    let complete = match media_type {
+        "image/png" => png_reaches_iend(bytes),
+        "image/jpeg" => has_jpeg_eoi(bytes),
+        // RIFF's size field counts the bytes AFTER it, i.e. from byte 8 on.
+        "image/webp" => holds_declared_len(bytes, 4, 8),
+        "image/bmp" => holds_declared_len(bytes, 2, 0),
+        "image/x-icon" => ico_declared_end(bytes).is_some_and(|end| bytes.len() >= end),
+        _ => true,
+    };
+    if complete {
+        Integrity::Complete
+    } else {
+        Integrity::Truncated
+    }
+}
+
+/// Walk `len|type|data|crc` from the signature and require a complete `IEND`.
+///
+/// CRCs are deliberately not verified: decoders in the wild ignore them, so a
+/// mismatch would flag files that display, and this answer only reports proof.
+fn png_reaches_iend(b: &[u8]) -> bool {
+    let mut at = 8usize; // past the 8-byte signature
+    loop {
+        let Some(header) = b.get(at..).filter(|r| r.len() >= 8) else {
+            return false;
+        };
+        let len = u32::from_be_bytes([header[0], header[1], header[2], header[3]]) as usize;
+        let is_iend = &header[4..8] == b"IEND";
+        // 4 length + 4 type + data + 4 CRC.
+        let Some(end) = at.checked_add(12).and_then(|n| n.checked_add(len)) else {
+            return false;
+        };
+        if end > b.len() {
+            return false;
+        }
+        if is_iend {
+            return true;
+        }
+        at = end;
+    }
+}
+
+/// `FF D9` anywhere past the SOI. See [`integrity`] for why absence is proof.
+fn has_jpeg_eoi(b: &[u8]) -> bool {
+    b.get(2..)
+        .is_some_and(|rest| rest.windows(2).any(|w| w == [0xFF, 0xD9]))
+}
+
+/// True when the file is at least as long as the little-endian `u32` it carries
+/// at `at`, plus `extra`. A declared zero means "unknown" and answers true —
+/// some encoders leave BMP's size field empty and the file is fine.
+fn holds_declared_len(b: &[u8], at: usize, extra: usize) -> bool {
+    let Some(field) = b.get(at..at + 4) else {
+        return false;
+    };
+    let declared = u32::from_le_bytes([field[0], field[1], field[2], field[3]]) as usize;
+    if declared == 0 {
+        return true;
+    }
+    declared.checked_add(extra).is_some_and(|n| b.len() >= n)
+}
+
+/// The end of the last image an ICONDIR points at — every entry declares its
+/// own offset and size, so the directory names the file's true length.
+fn ico_declared_end(b: &[u8]) -> Option<usize> {
+    let count = u16::from_le_bytes([b[4], b[5]]) as usize;
+    // The directory itself has to be there before its entries mean anything.
+    let mut end = 6usize.checked_add(count.checked_mul(16)?)?;
+    for i in 0..count {
+        let at = 6usize.checked_add(i.checked_mul(16)?)?;
+        let entry = b.get(at..at + 16)?;
+        let size = u32::from_le_bytes([entry[8], entry[9], entry[10], entry[11]]) as usize;
+        let offset = u32::from_le_bytes([entry[12], entry[13], entry[14], entry[15]]) as usize;
+        end = end.max(offset.checked_add(size)?);
+    }
+    Some(end)
+}
+
 /// Where git-lfs stores object `oid` under a storage directory.
 ///
 /// `<storage>/objects/aa/bb/<oid>` — git-lfs's own fan-out, two levels of two
@@ -268,6 +386,165 @@ mod tests {
         let mut v = vec![0, 0, 1, 0, 1, 0];
         v.extend_from_slice(&[0u8; 16]);
         v
+    }
+
+    /// A whole 8×1 PNG: signature, IHDR, one IDAT, IEND. Built rather than
+    /// embedded so a truncation can be expressed as "cut N bytes off THIS".
+    fn whole_png() -> Vec<u8> {
+        fn chunk(kind: &[u8; 4], data: &[u8]) -> Vec<u8> {
+            let mut v = (data.len() as u32).to_be_bytes().to_vec();
+            v.extend_from_slice(kind);
+            v.extend_from_slice(data);
+            // The CRC is never verified (see `integrity`), so a placeholder
+            // keeps this fixture honest about what the walk actually reads.
+            v.extend_from_slice(&[0, 0, 0, 0]);
+            v
+        }
+        let mut ihdr = Vec::new();
+        ihdr.extend_from_slice(&8u32.to_be_bytes());
+        ihdr.extend_from_slice(&1u32.to_be_bytes());
+        ihdr.extend_from_slice(&[8, 6, 0, 0, 0]);
+        let mut v = b"\x89PNG\r\n\x1a\n".to_vec();
+        v.extend_from_slice(&chunk(b"IHDR", &ihdr));
+        v.extend_from_slice(&chunk(b"IDAT", &[0x78, 0x9c, 0x01, 0x02, 0x03]));
+        v.extend_from_slice(&chunk(b"IEND", &[]));
+        v
+    }
+
+    #[test]
+    fn a_whole_png_is_complete() {
+        assert_eq!(integrity(&whole_png(), "image/png"), Integrity::Complete);
+    }
+
+    /// The case the frontend cannot see: every one of these still SNIFFS as a
+    /// PNG, because the signature and IHDR are intact.
+    #[test]
+    fn a_png_cut_anywhere_after_its_header_is_truncated() {
+        let whole = whole_png();
+        for cut in 16..whole.len() {
+            let part = &whole[..cut];
+            assert_eq!(sniff(part), Sniffed::Image("image/png"), "cut at {cut}");
+            assert_eq!(integrity(part, "image/png"), Integrity::Truncated, "cut at {cut}");
+        }
+    }
+
+    /// Trailing bytes after `IEND` are not our business — the image is whole.
+    #[test]
+    fn a_png_with_bytes_after_iend_is_still_complete() {
+        let mut v = whole_png();
+        v.extend_from_slice(b"whatever a tool appended");
+        assert_eq!(integrity(&v, "image/png"), Integrity::Complete);
+    }
+
+    /// A chunk that CLAIMS more data than the file holds is the shape a cut
+    /// inside the length field itself produces.
+    #[test]
+    fn a_png_chunk_longer_than_the_file_is_truncated() {
+        let mut v = b"\x89PNG\r\n\x1a\n".to_vec();
+        v.extend_from_slice(&u32::MAX.to_be_bytes());
+        v.extend_from_slice(b"IHDR");
+        v.extend_from_slice(&[0u8; 13]);
+        assert_eq!(integrity(&v, "image/png"), Integrity::Truncated);
+    }
+
+    /// A 1×1 RGBA PNG straight out of a real encoder (zlib-compressed IDAT,
+    /// real CRCs). The synthetic fixture above pins the chunk WALK; this pins
+    /// that the walk agrees with what an encoder actually writes.
+    const REAL_PNG: [u8; 70] = [
+        137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8,
+        6, 0, 0, 0, 31, 21, 196, 137, 0, 0, 0, 13, 73, 68, 65, 84, 120, 156, 99, 248, 207, 192,
+        240, 31, 0, 5, 0, 1, 255, 137, 153, 61, 29, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+    ];
+
+    #[test]
+    fn a_real_encoders_png_is_complete() {
+        assert_eq!(sniff(&REAL_PNG), Sniffed::Image("image/png"));
+        assert_eq!(integrity(&REAL_PNG, "image/png"), Integrity::Complete);
+    }
+
+    /// The measured worst case: a webview fires `load` for this, reports the
+    /// header's dimensions and paints a BLANK picture, so nothing downstream
+    /// can tell. Overwriting the tail leaves the signature and IHDR intact and
+    /// destroys the chunk chain, which is what the walk catches.
+    #[test]
+    fn a_png_whose_tail_was_overwritten_is_truncated() {
+        let mut v = REAL_PNG.to_vec();
+        for b in v.iter_mut().skip(45) {
+            *b = 0x41;
+        }
+        assert_eq!(v.len(), REAL_PNG.len(), "same length, so only structure tells");
+        assert_eq!(sniff(&v), Sniffed::Image("image/png"));
+        assert_eq!(integrity(&v, "image/png"), Integrity::Truncated);
+    }
+
+    #[test]
+    fn a_jpeg_needs_its_end_of_image_marker() {
+        let mut whole = jpeg();
+        whole.extend_from_slice(&[0x11, 0x22, 0xFF, 0xD9]);
+        assert_eq!(integrity(&whole, "image/jpeg"), Integrity::Complete);
+        assert_eq!(integrity(&jpeg(), "image/jpeg"), Integrity::Truncated);
+    }
+
+    /// `FF D9` cannot occur in stuffed scan data, so a scan carrying `FF 00`
+    /// and no EOI is proven short rather than accidentally matching.
+    #[test]
+    fn stuffed_scan_bytes_do_not_fake_an_end_of_image() {
+        let mut v = jpeg();
+        v.extend_from_slice(&[0xFF, 0x00, 0xD9, 0xFF, 0x00]);
+        assert_eq!(integrity(&v, "image/jpeg"), Integrity::Truncated);
+    }
+
+    #[test]
+    fn a_webp_shorter_than_its_riff_size_is_truncated() {
+        let mut v = b"RIFF".to_vec();
+        v.extend_from_slice(&64u32.to_le_bytes()); // 64 bytes must follow byte 8
+        v.extend_from_slice(b"WEBPVP8 ");
+        v.extend_from_slice(&[0u8; 8]);
+        assert_eq!(sniff(&v), Sniffed::Image("image/webp"));
+        assert_eq!(integrity(&v, "image/webp"), Integrity::Truncated);
+        v.extend_from_slice(&[0u8; 56]);
+        assert_eq!(integrity(&v, "image/webp"), Integrity::Complete);
+    }
+
+    #[test]
+    fn a_bmp_shorter_than_its_declared_size_is_truncated() {
+        let mut v = bmp();
+        v.extend_from_slice(&[0u8; 40]); // 66 bytes; the header declares 70
+        assert_eq!(integrity(&v, "image/bmp"), Integrity::Truncated);
+        v.extend_from_slice(&[0u8; 4]);
+        assert_eq!(integrity(&v, "image/bmp"), Integrity::Complete);
+    }
+
+    /// Some encoders leave BMP's size field zero. Unknown is not proof.
+    #[test]
+    fn a_bmp_declaring_no_size_is_left_alone() {
+        let mut v = b"BM".to_vec();
+        v.extend_from_slice(&0u32.to_le_bytes()); // no declared size
+        v.extend_from_slice(&0u32.to_le_bytes());
+        v.extend_from_slice(&54u32.to_le_bytes());
+        v.extend_from_slice(&[0u8; 12]);
+        assert_eq!(sniff(&v), Sniffed::Image("image/bmp"));
+        assert_eq!(integrity(&v, "image/bmp"), Integrity::Complete);
+    }
+
+    #[test]
+    fn an_ico_shorter_than_its_directory_promises_is_truncated() {
+        let mut v = vec![0, 0, 1, 0, 1, 0];
+        let mut entry = vec![16, 16, 0, 0, 1, 0, 32, 0];
+        entry.extend_from_slice(&128u32.to_le_bytes()); // size
+        entry.extend_from_slice(&22u32.to_le_bytes()); // offset
+        v.extend_from_slice(&entry);
+        assert_eq!(sniff(&v), Sniffed::Image("image/x-icon"));
+        assert_eq!(integrity(&v, "image/x-icon"), Integrity::Truncated);
+        v.extend_from_slice(&[0u8; 128]);
+        assert_eq!(integrity(&v, "image/x-icon"), Integrity::Complete);
+    }
+
+    /// GIF is deliberately unchecked — see `integrity`. Pinned so that
+    /// "we could also check GIF" is a decision someone makes on purpose.
+    #[test]
+    fn a_gif_is_never_called_truncated() {
+        assert_eq!(integrity(&gif(), "image/gif"), Integrity::Complete);
     }
 
     #[test]

--- a/src-tauri/src/git/libgit2.rs
+++ b/src-tauri/src/git/libgit2.rs
@@ -2413,14 +2413,26 @@ fn read_blob_side(repo: &Repository, oid: git2::Oid) -> AppResult<BlobSide> {
 fn describe_bytes(path: String, bytes: &[u8]) -> ImagePreview {
     let size = bytes.len() as u64;
     match image::sniff(bytes) {
-        image::Sniffed::Image(media_type) => ImagePreview::Image {
-            path,
-            media_type: media_type.to_string(),
-            size,
-            // Base64 HERE rather than in the frontend: it is what a `data:` URL
-            // takes, so the string crosses IPC once and is concatenated into an
-            // `src` with no decode and no second copy on the other side.
-            data: BASE64.encode(bytes),
+        // A header is not a file. This is the only place holding the WHOLE
+        // blob, and a webview reports a cut-off image as a successful load
+        // rather than an error, so a truncated one has to be caught here or
+        // not at all.
+        image::Sniffed::Image(media_type) => match image::integrity(bytes, media_type) {
+            image::Integrity::Truncated => ImagePreview::Unsupported {
+                path,
+                size,
+                reason: UnsupportedReason::Truncated,
+            },
+            image::Integrity::Complete => ImagePreview::Image {
+                path,
+                media_type: media_type.to_string(),
+                size,
+                // Base64 HERE rather than in the frontend: it is what a `data:`
+                // URL takes, so the string crosses IPC once and is concatenated
+                // into an `src` with no decode and no second copy on the other
+                // side.
+                data: BASE64.encode(bytes),
+            },
         },
         image::Sniffed::Svg => ImagePreview::Unsupported {
             path,

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -524,6 +524,11 @@ pub enum UnsupportedReason {
     NotAnImage,
     /// Recognised as SVG and refused on purpose. See `git/image.rs`.
     Svg,
+    /// The header sniffed as an image but the file ends before its own declared
+    /// structure does. Handing these bytes to an `<img>` renders a partial or
+    /// blank picture under a confident caption and reports no error, so the
+    /// blob is refused here instead — `image::integrity`.
+    Truncated,
 }
 
 /// One side of an image preview (#224).

--- a/src/features/diff/ImageDiffView.test.tsx
+++ b/src/features/diff/ImageDiffView.test.tsx
@@ -40,13 +40,47 @@ function mockPreviews(by: Partial<Record<string, ImagePreview | null>>) {
   });
 }
 
+/** Answer from the WHOLE request — the path and the revspec, not just the kind. */
+function mockPreviewsBy(
+  answer: (req: { path: string; revspec?: string }) => ImagePreview | null,
+) {
+  mockInvoke("read_image_preview", (args) =>
+    answer({
+      path: String(args.path),
+      revspec: (args.source as { revspec?: string }).revspec,
+    }),
+  );
+}
+
+/** The `old` side stepped back one commit — a different blob at the same path. */
+const OLD_PREV: ImageSide = {
+  key: "old",
+  label: "Old",
+  tone: "removed",
+  source: { kind: "rev", revspec: "HEAD~1" },
+};
+
+/** A `new`-keyed side reading one specific revision. */
+const revSide = (revspec: string): ImageSide => ({
+  key: "new",
+  label: "New",
+  tone: "added",
+  source: { kind: "rev", revspec },
+});
+
 function renderPair(fallback?: React.ReactNode) {
   return render(
     <ImageDiffView repoId="r1" path="logo.png" sides={[OLD, NEW]} fallback={fallback} />,
   );
 }
 
-/** The browser giving up on the bytes: the event a truncated blob really fires. */
+/**
+ * The engine giving up on bytes whose STRUCTURE is sound.
+ *
+ * Not what a truncated blob fires — measured in Blink 152, a cut PNG fires
+ * `load` and paints part of itself, which is why truncation is caught in the
+ * backend instead (git/image.rs::integrity).
+ */
 function failDecode(testId: string) {
   fireEvent.error(screen.getByTestId(testId));
 }
@@ -282,6 +316,34 @@ describe("everything that is not a previewable image", () => {
     expect(screen.queryByText("Binary diffs aren't shown.")).toBeNull();
   });
 
+  it("names a truncated file, and never hands its bytes to an <img>", async () => {
+    // The backend proved this from the file's own structure. It has to: a
+    // webview decodes the prefix, fires `load`, reports the header's
+    // dimensions and paints part of the picture, so no frontend signal
+    // exists to catch it (measured — see git/image.rs::integrity).
+    const cut: ImagePreview = {
+      kind: "unsupported",
+      path: "logo.png",
+      size: 5448,
+      reason: "truncated",
+    };
+    mockPreviews({ rev: cut, worktree: cut });
+    render(
+      <ImageDiffOrEmpty repoId="r1" path="logo.png" sides={[OLD, NEW]} title="Binary file">
+        Binary diffs aren&apos;t shown.
+      </ImageDiffOrEmpty>,
+    );
+
+    const note = await screen.findByTestId("image-note-new");
+    expect(note.textContent).toContain("Truncated image");
+    // The byte count is worth showing: it is what DID arrive.
+    expect(note.textContent).toContain("5.3 KB");
+    // The whole point — a partial picture under a confident caption is the
+    // outcome this state exists to prevent.
+    expect(screen.queryByTestId("image-preview-new")).toBeNull();
+    expect(screen.queryByText("Binary diffs aren't shown.")).toBeNull();
+  });
+
   it("falls back to the empty state when the read fails outright", async () => {
     mockInvoke("read_image_preview", () => {
       throw { kind: "Git", message: "object not found" };
@@ -315,12 +377,14 @@ describe("a single side", () => {
   });
 });
 
-describe("a blob that sniffs as an image but will not decode", () => {
-  // `image.rs` reads a header, not a whole file, so a truncated PNG with an
-  // intact magic number arrives here as `kind: "image"` and the browser is the
-  // first thing to find out otherwise. Before #212's audit item this rendered
-  // the broken-image glyph and nothing else.
-  it("replaces the broken image with a sentence, and keeps the size", async () => {
+describe("a complete image this engine will not display", () => {
+  // NOT the truncated case — that is refused in the backend, because a webview
+  // reports a cut-off image as a successful `load` (see the `truncated` test
+  // above and git/image.rs::integrity). What reaches `onError` is a file whose
+  // structure is sound and whose format this particular engine lacks: an
+  // exotic BMP or ICO variant, an animated WebP feature. Before #212's audit
+  // item that rendered the broken-image glyph and said nothing.
+  it("replaces the undisplayable image with a sentence, and keeps the size", async () => {
     mockPreviews({ worktree: png({ size: 1024 }) });
     render(<ImageDiffView repoId="r1" path="logo.png" sides={[NEW]} />);
 
@@ -328,7 +392,12 @@ describe("a blob that sniffs as an image but will not decode", () => {
     failDecode("image-preview-new");
 
     await waitFor(() => expect(screen.queryByTestId("image-preview-new")).toBeNull());
-    expect(screen.getByTestId("image-note-new").textContent).toContain("could not be decoded");
+    const note = screen.getByTestId("image-note-new").textContent;
+    expect(note).toContain("could not be displayed");
+    // It must NOT guess at a cause. Three engines ship this app and their
+    // format coverage differs, so "truncated or corrupt" would be a lie on the
+    // machines where the same file opens fine.
+    expect(note).not.toMatch(/corrupt|truncated/i);
     // The byte count came from the backend, not from the decoder, so it is
     // still true and still worth showing.
     expect(screen.getByTestId("image-caption-new").textContent).toBe("1.0 KB");
@@ -349,7 +418,12 @@ describe("a blob that sniffs as an image but will not decode", () => {
   });
 
   it("gives the next selection a clean slate", async () => {
-    mockPreviews({ worktree: png({ size: 1024 }) });
+    // The recovering file must be DIFFERENT bytes. Reusing the same base64
+    // would assert the opposite of the truth: identical bytes really do fail
+    // identically, and only jsdom's refusal to decode anything would hide it.
+    mockPreviewsBy(({ path }) =>
+      png({ path, data: path === "broken.png" ? "QkFE" : "R09PRA" }),
+    );
     const one: ImageSide[] = [NEW];
     const { rerender } = render(<ImageDiffView repoId="r1" path="broken.png" sides={one} />);
     await screen.findByTestId("image-preview-new");
@@ -357,16 +431,69 @@ describe("a blob that sniffs as an image but will not decode", () => {
     await waitFor(() => expect(screen.getByTestId("image-note-new")).toBeTruthy());
 
     rerender(<ImageDiffView repoId="r1" path="fine.png" sides={one} />);
-    // A sticky failure would print "could not be decoded" over a perfectly
+    // A sticky failure would print "could not be displayed" over a perfectly
     // good image, which is the same class of bug as a stale caption.
     await waitFor(() => expect(screen.getByTestId("image-preview-new")).toBeTruthy());
     expect(screen.queryByTestId("image-note-new")).toBeNull();
+  });
+
+  // The half the reset effect never had a test for. Its key was
+  // `[path, previewKey]`, and `previewKey` could be DELETED outright without
+  // failing anything in the suite; worse, it read `repoId` and each side's
+  // `source` not at all, while `useImagePreviews` keys its read on both. So
+  // this is the reachable stale case: one path, a different REVISION, and two
+  // blobs of equal byte length — what a metadata-only edit produces, and what
+  // `data.length` cannot tell apart.
+  it("drops a failure when the revision changes under one path", async () => {
+    mockPreviewsBy(({ revspec }) =>
+      png({ data: revspec === "HEAD~1" ? "QkFE" : "R09P" }),
+    );
+    const { rerender } = render(
+      <ImageDiffView repoId="r1" path="logo.png" sides={[revSide("HEAD~1")]} />,
+    );
+    await screen.findByTestId("image-preview-new");
+    failDecode("image-preview-new");
+    await waitFor(() => expect(screen.getByTestId("image-note-new")).toBeTruthy());
+
+    rerender(<ImageDiffView repoId="r1" path="logo.png" sides={[revSide("HEAD")]} />);
+    // Same path, same byte length, a different image. A stale failure would
+    // print "could not be displayed" over a file that displays fine.
+    await waitFor(() => expect(screen.getByTestId("image-preview-new")).toBeTruthy());
+    expect(screen.queryByTestId("image-note-new")).toBeNull();
+  });
+
+  it("does not let one side's new bytes clear the other side's failure", async () => {
+    mockPreviewsBy(({ revspec }) =>
+      png({ data: revspec === "HEAD" ? "T0xE" : revspec ? "T0xEMg" : "TkVX" }),
+    );
+    const { rerender } = render(
+      <ImageDiffView repoId="r1" path="logo.png" sides={[OLD, NEW]} />,
+    );
+    await screen.findByTestId("image-preview-new");
+    failDecode("image-preview-new");
+    await waitFor(() => expect(screen.getByTestId("image-note-new")).toBeTruthy());
+
+    // The OLD side's blob changes — the user steps to the previous commit, or
+    // an "LFS fetch" lands. One reset key covering BOTH sides cleared the new
+    // side's live failure here, remounting an `<img>` whose decode cannot
+    // succeed: the sentence blinked out and back, twice per change.
+    rerender(<ImageDiffView repoId="r1" path="logo.png" sides={[OLD_PREV, NEW]} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("image-preview-old").getAttribute("src")).toContain("T0xEMg"),
+    );
+    expect(screen.getByTestId("image-note-new")).toBeTruthy();
+    expect(screen.queryByTestId("image-preview-new")).toBeNull();
   });
 });
 
 describe("re-selection", () => {
   it("re-reads when the path changes and drops the previous dimensions", async () => {
-    mockPreviews({ worktree: png({ size: 1024 }) });
+    // Two genuinely different files. Answering both paths with the SAME base64
+    // would assert nothing: identical bytes are the same image, and 64 × 64
+    // stays true for them — which is why this now has to differ to be a test.
+    mockPreviewsBy(({ path }) =>
+      png({ path, size: 1024, data: path === "a.png" ? "QUFB" : "QkJC" }),
+    );
     const one: ImageSide[] = [NEW];
     const { rerender } = render(
       <ImageDiffView repoId="r1" path="a.png" sides={one} />,

--- a/src/features/diff/ImageDiffView.test.tsx
+++ b/src/features/diff/ImageDiffView.test.tsx
@@ -46,6 +46,11 @@ function renderPair(fallback?: React.ReactNode) {
   );
 }
 
+/** The browser giving up on the bytes: the event a truncated blob really fires. */
+function failDecode(testId: string) {
+  fireEvent.error(screen.getByTestId(testId));
+}
+
 /** jsdom never decodes an image, so the dimensions arrive the way a real one's do. */
 function decode(testId: string, w: number, h: number) {
   const img = screen.getByTestId(testId) as HTMLImageElement;
@@ -307,6 +312,55 @@ describe("a single side", () => {
     await screen.findByTestId("image-preview-file");
     expect(screen.queryByTestId("image-diff-onesided")).toBeNull();
     expect(screen.queryByTestId("image-diff-delta")).toBeNull();
+  });
+});
+
+describe("a blob that sniffs as an image but will not decode", () => {
+  // `image.rs` reads a header, not a whole file, so a truncated PNG with an
+  // intact magic number arrives here as `kind: "image"` and the browser is the
+  // first thing to find out otherwise. Before #212's audit item this rendered
+  // the broken-image glyph and nothing else.
+  it("replaces the broken image with a sentence, and keeps the size", async () => {
+    mockPreviews({ worktree: png({ size: 1024 }) });
+    render(<ImageDiffView repoId="r1" path="logo.png" sides={[NEW]} />);
+
+    await screen.findByTestId("image-preview-new");
+    failDecode("image-preview-new");
+
+    await waitFor(() => expect(screen.queryByTestId("image-preview-new")).toBeNull());
+    expect(screen.getByTestId("image-note-new").textContent).toContain("could not be decoded");
+    // The byte count came from the backend, not from the decoder, so it is
+    // still true and still worth showing.
+    expect(screen.getByTestId("image-caption-new").textContent).toBe("1.0 KB");
+  });
+
+  it("fails only the side that failed", async () => {
+    mockPreviews({ rev: png({ size: 2048 }), worktree: png({ size: 1024 }) });
+    renderPair();
+
+    await screen.findByTestId("image-preview-old");
+    failDecode("image-preview-new");
+
+    await waitFor(() => expect(screen.queryByTestId("image-preview-new")).toBeNull());
+    // A corrupt new version must not take the readable old one down with it.
+    // Seeing what the file used to be is most of the value of the comparison.
+    expect(screen.getByTestId("image-preview-old")).toBeTruthy();
+    expect(screen.queryByTestId("image-note-old")).toBeNull();
+  });
+
+  it("gives the next selection a clean slate", async () => {
+    mockPreviews({ worktree: png({ size: 1024 }) });
+    const one: ImageSide[] = [NEW];
+    const { rerender } = render(<ImageDiffView repoId="r1" path="broken.png" sides={one} />);
+    await screen.findByTestId("image-preview-new");
+    failDecode("image-preview-new");
+    await waitFor(() => expect(screen.getByTestId("image-note-new")).toBeTruthy());
+
+    rerender(<ImageDiffView repoId="r1" path="fine.png" sides={one} />);
+    // A sticky failure would print "could not be decoded" over a perfectly
+    // good image, which is the same class of bug as a stale caption.
+    await waitFor(() => expect(screen.getByTestId("image-preview-new")).toBeTruthy());
+    expect(screen.queryByTestId("image-note-new")).toBeNull();
   });
 });
 

--- a/src/features/diff/ImageDiffView.tsx
+++ b/src/features/diff/ImageDiffView.tsx
@@ -89,18 +89,37 @@ function noteFor(p: ImagePreview | null): { icon: string; text: string } | null 
   }
 }
 
+/**
+ * What a side shows once the browser has REFUSED the bytes we handed it.
+ *
+ * `image.rs` sniffs a header, not a whole file, so a truncated or corrupt blob
+ * with an intact magic number still comes back `kind: "image"`. Without this
+ * the panel rendered a broken `<img>` glyph and said nothing, which is the one
+ * outcome this module's own doc rules out (#212).
+ */
+const UNDECODABLE = {
+  icon: "warn",
+  text: "This image could not be decoded. The file may be truncated or corrupt.",
+} as const;
+
 function ImagePanel({
   side,
   preview,
   dims,
   onDims,
+  failed,
+  onFail,
 }: {
   side: ImageSide;
   preview: ImagePreview | null;
   dims: ImageDims | null;
   onDims: (key: string, d: ImageDims) => void;
+  failed: boolean;
+  onFail: (key: string) => void;
 }) {
-  const note = noteFor(preview);
+  // A side that failed to decode keeps its size caption (the byte count is
+  // still true) and trades the picture for a sentence.
+  const note = failed ? UNDECODABLE : noteFor(preview);
   return (
     <div
       data-testid={`image-panel-${side.key}`}
@@ -146,7 +165,7 @@ function ImagePanel({
           justifyContent: "center",
         }}
       >
-        {preview?.kind === "image" ? (
+        {preview?.kind === "image" && !failed ? (
           <img
             data-testid={`image-preview-${side.key}`}
             // A `data:` URL over bytes the backend already read. Local, always:
@@ -159,6 +178,7 @@ function ImagePanel({
                 h: e.currentTarget.naturalHeight,
               })
             }
+            onError={() => onFail(side.key)}
             // The box only ever SHRINKS an image (`max-*`, never a width), so
             // a 16×16 favicon renders at 16×16 and a screenshot is scaled down.
             // Deliberately no `image-rendering: pixelated`: it would only ever
@@ -221,6 +241,10 @@ export function ImageDiffView({ repoId, path, sides, fallback = null }: ImageDif
   const enabled = !!repoId && !!path;
   const { previews, loading } = useImagePreviews({ repoId, path, sides, enabled });
   const [dims, setDims] = React.useState<Record<string, ImageDims>>({});
+  // Sides whose bytes the browser refused to decode. Keyed the same way as
+  // `dims`, and cleared by the same effect, because both describe the blobs
+  // currently loaded rather than the file.
+  const [failed, setFailed] = React.useState<Record<string, boolean>>({});
   const onDims = React.useCallback(
     (key: string, d: ImageDims) =>
       setDims((prev) =>
@@ -228,10 +252,17 @@ export function ImageDiffView({ repoId, path, sides, fallback = null }: ImageDif
       ),
     [],
   );
+  const onFail = React.useCallback(
+    (key: string) => setFailed((prev) => (prev[key] ? prev : { ...prev, [key]: true })),
+    [],
+  );
   // Measured dimensions belong to the blobs currently loaded; a new selection
   // must not caption its image with the previous one's size.
   const previewKey = previews.map((p) => (p?.kind === "image" ? p.data.length : 0)).join(",");
-  React.useEffect(() => setDims({}), [path, previewKey]);
+  React.useEffect(() => {
+    setDims({});
+    setFailed({});
+  }, [path, previewKey]);
 
   if (loading) {
     return (
@@ -278,6 +309,8 @@ export function ImageDiffView({ repoId, path, sides, fallback = null }: ImageDif
             preview={previews[i] ?? null}
             dims={dims[side.key] ?? null}
             onDims={onDims}
+            failed={!!failed[side.key]}
+            onFail={onFail}
           />
         ))}
       </div>

--- a/src/features/diff/ImageDiffView.tsx
+++ b/src/features/diff/ImageDiffView.tsx
@@ -22,7 +22,7 @@
 // `ResizeObserver` (WebKitGTK has none) and nothing to scroll by offset.
 
 import React from "react";
-import { PGEmpty, PGIcon, PGSkeleton } from "@/design";
+import { PGEmpty, PGIcon, PGSkeleton, type IconName } from "@/design";
 import { formatBytes } from "@/lib/bytes";
 import {
   describeDelta,
@@ -59,8 +59,19 @@ const toneColor = (tone: ImageSide["tone"]) =>
       ? "var(--git-added)"
       : "var(--fg-2)";
 
+/**
+ * One panel's sentence and the glyph beside it.
+ *
+ * `icon` is `IconName`, NOT `string`: `PGIconProps.name` widens to
+ * `IconName | string` so a typo type-checks into a dashed square, and
+ * `test/iconSet.test.ts` only scans `name="…"`/`icon="…"` ATTRIBUTES — an icon
+ * named in an object literal like these escapes both gates unless it is typed
+ * here.
+ */
+type PanelNote = { icon: IconName; text: string };
+
 /** The sentence a non-image side gets inside a panel. */
-function noteFor(p: ImagePreview | null): { icon: string; text: string } | null {
+function noteFor(p: ImagePreview | null): PanelNote | null {
   if (!p) return null;
   switch (p.kind) {
     case "image":
@@ -77,30 +88,56 @@ function noteFor(p: ImagePreview | null): { icon: string; text: string } | null 
         // rendering THAT would put text where an image belongs.
         text: `LFS object not fetched — ${formatBytes(p.size)}. Run “LFS fetch” to preview it.`,
       };
-    case "unsupported":
-      return p.reason === "svg"
-        ? {
+    case "unsupported": {
+      switch (p.reason) {
+        case "svg":
+          return {
             icon: "warn",
             // Refusing SVG is a decision, not a gap — see git/image.rs. Saying
             // nothing here would read as a bug.
             text: "SVG previews are disabled — an SVG can carry script and remote references.",
-          }
-        : { icon: "file", text: "Not an image we can preview." };
+          };
+        case "truncated":
+          return {
+            icon: "warn",
+            // The backend proved this from the file's own structure, so the
+            // sentence can name the cause. A webview could not: it decodes the
+            // prefix, fires `load` and paints part of a picture (see
+            // `git/image.rs::integrity`).
+            text: `Truncated image — ${formatBytes(p.size)} present, and the file ends mid-way through its image data.`,
+          };
+        case "notAnImage":
+          return { icon: "file", text: "Not an image we can preview." };
+      }
+      // A new reason must get its own sentence here: showing nothing and
+      // saying nothing is the one outcome this surface is written against.
+      const unreachedReason: never = p.reason;
+      return unreachedReason;
+    }
   }
 }
 
 /**
- * What a side shows once the browser has REFUSED the bytes we handed it.
+ * What a side shows once THIS ENGINE has refused bytes the backend vouched for.
  *
- * `image.rs` sniffs a header, not a whole file, so a truncated or corrupt blob
- * with an intact magic number still comes back `kind: "image"`. Without this
- * the panel rendered a broken `<img>` glyph and said nothing, which is the one
- * outcome this module's own doc rules out (#212).
+ * Narrow on purpose, and narrower than it looks. `onError` does NOT fire for a
+ * truncated or damaged file: measured in Blink 152, a PNG cut to 60% and one
+ * with an overwritten IDAT both fire `load`, report the intact header's
+ * dimensions and paint a partial or blank picture. Those are refused in the
+ * backend instead (`UnsupportedReason::Truncated`) and never get here. What is
+ * left for `onError` is the one thing only the engine knows: a structurally
+ * complete file this webview will not display — an exotic BMP or ICO variant,
+ * an animated WebP feature.
+ *
+ * So the sentence names no cause. The app runs on WKWebView, WebView2 and
+ * WebKitGTK, whose format coverage differs, and telling someone their asset is
+ * corrupt when it opens fine on a colleague's machine is the same dishonesty
+ * `git/image.rs`'s doc is written against (#212).
  */
 const UNDECODABLE = {
   icon: "warn",
-  text: "This image could not be decoded. The file may be truncated or corrupt.",
-} as const;
+  text: "This image could not be displayed — its format is not supported here.",
+} as const satisfies PanelNote;
 
 function ImagePanel({
   side,
@@ -113,12 +150,15 @@ function ImagePanel({
   side: ImageSide;
   preview: ImagePreview | null;
   dims: ImageDims | null;
-  onDims: (key: string, d: ImageDims) => void;
+  onDims: (key: string, data: string, d: ImageDims) => void;
   failed: boolean;
-  onFail: (key: string) => void;
+  onFail: (key: string, data: string) => void;
 }) {
-  // A side that failed to decode keeps its size caption (the byte count is
-  // still true) and trades the picture for a sentence.
+  // A side that failed to decode keeps its size caption (the byte count came
+  // from the backend, not from the decoder) and trades the picture for a
+  // sentence. `failed` is only ever true for an image preview — the parent
+  // derives it from the bytes this panel is rendering — so it cannot shadow
+  // the more specific sentence a `tooLarge` or `lfsMissing` side has earned.
   const note = failed ? UNDECODABLE : noteFor(preview);
   return (
     <div
@@ -173,12 +213,12 @@ function ImagePanel({
             src={previewDataUrl(preview)}
             alt={`${side.label} version of ${preview.path}`}
             onLoad={(e) =>
-              onDims(side.key, {
+              onDims(side.key, preview.data, {
                 w: e.currentTarget.naturalWidth,
                 h: e.currentTarget.naturalHeight,
               })
             }
-            onError={() => onFail(side.key)}
+            onError={() => onFail(side.key, preview.data)}
             // The box only ever SHRINKS an image (`max-*`, never a width), so
             // a 16×16 favicon renders at 16×16 and a screenshot is scaled down.
             // Deliberately no `image-rendering: pixelated`: it would only ever
@@ -240,30 +280,41 @@ export function ImageDiffView({ repoId, path, sides, fallback = null }: ImageDif
   // not selected": no path, no read.
   const enabled = !!repoId && !!path;
   const { previews, loading } = useImagePreviews({ repoId, path, sides, enabled });
-  const [dims, setDims] = React.useState<Record<string, ImageDims>>({});
-  // Sides whose bytes the browser refused to decode. Keyed the same way as
-  // `dims`, and cleared by the same effect, because both describe the blobs
-  // currently loaded rather than the file.
-  const [failed, setFailed] = React.useState<Record<string, boolean>>({});
+  // Both of these describe BYTES, not a file, so both record which bytes they
+  // came from and are read back by comparison rather than cleared by an effect.
+  //
+  // A reset effect is what this used to be, keyed on `[path, previewKey]`. That
+  // key was narrower than the one `useImagePreviews` reads on: it ignores
+  // `repoId` and each side's `source`, and stands in `data.length` for the
+  // data. So the same path at a different revision, at an equal byte length,
+  // kept the previous blob's state — a caption for the wrong image, or a
+  // failure notice printed over a good one. Deriving instead also settles two
+  // things a reset could not: it never races the browser's `error` task
+  // against a passive effect, and one side's new bytes cannot clear the other
+  // side's live failure.
+  const [dims, setDims] = React.useState<Record<string, { data: string; d: ImageDims }>>({});
+  const [failedData, setFailedData] = React.useState<Record<string, string>>({});
   const onDims = React.useCallback(
-    (key: string, d: ImageDims) =>
-      setDims((prev) =>
-        prev[key]?.w === d.w && prev[key]?.h === d.h ? prev : { ...prev, [key]: d },
-      ),
+    (key: string, data: string, d: ImageDims) =>
+      setDims((prev) => {
+        const at = prev[key];
+        return at?.data === data && at.d.w === d.w && at.d.h === d.h
+          ? prev
+          : { ...prev, [key]: { data, d } };
+      }),
     [],
   );
   const onFail = React.useCallback(
-    (key: string) => setFailed((prev) => (prev[key] ? prev : { ...prev, [key]: true })),
+    (key: string, data: string) =>
+      setFailedData((prev) => (prev[key] === data ? prev : { ...prev, [key]: data })),
     [],
   );
-  // Measured dimensions belong to the blobs currently loaded; a new selection
-  // must not caption its image with the previous one's size.
-  const previewKey = previews.map((p) => (p?.kind === "image" ? p.data.length : 0)).join(",");
-  React.useEffect(() => {
-    setDims({});
-    setFailed({});
-  }, [path, previewKey]);
-
+  /** The measurement for a side, only if it was taken from these exact bytes. */
+  const dimsFor = (key: string, p: ImagePreview | null): ImageDims | null =>
+    p?.kind === "image" && dims[key]?.data === p.data ? dims[key].d : null;
+  /** Did THESE bytes fail? A non-image side can never be in this state. */
+  const failedFor = (key: string, p: ImagePreview | null): boolean =>
+    p?.kind === "image" && failedData[key] === p.data;
   if (loading) {
     return (
       <div data-testid="image-diff-loading" style={{ padding: 12 }} aria-busy="true">
@@ -275,10 +326,10 @@ export function ImageDiffView({ repoId, path, sides, fallback = null }: ImageDif
 
   const delta = describeDelta(
     previews[0]?.kind === "image"
-      ? { size: previews[0].size, dims: dims[sides[0].key] }
+      ? { size: previews[0].size, dims: dimsFor(sides[0].key, previews[0]) }
       : null,
     previews[1]?.kind === "image"
-      ? { size: previews[1].size, dims: dims[sides[1].key] }
+      ? { size: previews[1].size, dims: dimsFor(sides[1].key, previews[1]) }
       : null,
   );
   // "Added" / "Removed" only when there genuinely are two sides and one of them
@@ -307,9 +358,9 @@ export function ImageDiffView({ repoId, path, sides, fallback = null }: ImageDif
             key={side.key}
             side={side}
             preview={previews[i] ?? null}
-            dims={dims[side.key] ?? null}
+            dims={dimsFor(side.key, previews[i] ?? null)}
             onDims={onDims}
-            failed={!!failed[side.key]}
+            failed={failedFor(side.key, previews[i] ?? null)}
             onFail={onFail}
           />
         ))}

--- a/src/lib/imagePreview.ts
+++ b/src/lib/imagePreview.ts
@@ -34,11 +34,16 @@ export function previewDataUrl(p: Extract<ImagePreview, { kind: "image" }>): str
  * is the honest answer: a broken `<img>` is worse than a sentence.
  *
  * An SVG refusal IS notable, because it is a decision rather than a gap and has
- * to be able to say so; rendering nothing would read as a bug.
+ * to be able to say so; rendering nothing would read as a bug. So is a
+ * `truncated` blob: it is an image the repository was SUPPOSED to hold, and
+ * "nothing here" would be the wrong answer about a file that is damaged.
+ *
+ * `notAnImage` is therefore the only reason that stays quiet, and a new one
+ * defaults to notable on purpose — `noteFor` makes a sentence compulsory.
  */
 export function isNotablePreview(p: ImagePreview | null | undefined): boolean {
   if (!p) return false;
-  if (p.kind === "unsupported") return p.reason === "svg";
+  if (p.kind === "unsupported") return p.reason !== "notAnImage";
   return true;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -452,8 +452,12 @@ export type ImagePreview =
       kind: "unsupported";
       path: string;
       size: number;
-      /** `svg` is a deliberate refusal, not a gap — see `git/image.rs`. */
-      reason: "notAnImage" | "svg";
+      /**
+       * `svg` is a deliberate refusal, not a gap, and `truncated` is a blob
+       * whose header sniffed as an image but whose data ends early — a webview
+       * would paint part of it and report no error. See `git/image.rs`.
+       */
+      reason: "notAnImage" | "svg" | "truncated";
     }
   /** An LFS pointer whose object has not been fetched into `.git/lfs`. */
   | { kind: "lfsMissing"; path: string; oid: string; size: number };


### PR DESCRIPTION
Finding 8 from the code audit in #212: *"A corrupt or undecodable image renders a broken `<img>` with no fallback."*

## The problem

`image.rs` sniffs the first 512 bytes, so a truncated or corrupt image whose magic number is intact comes back as `kind: "image"`. `ImageDiffView` then hands those bytes to an `<img>` that has an `onLoad` handler and no `onError`. When the webview refuses to decode them, the panel shows the browser's broken-image glyph and says nothing, which is exactly what `image.rs`'s module doc rules out: *"a broken `<img>` is worse than a sentence."*

Every other non-previewable state here already says something specific (too large, LFS not fetched, SVG refused). This was the one that said nothing.

## The change

- `onError` on the preview `<img>` retires that side to the same note treatment the other states use: "This image could not be decoded. The file may be truncated or corrupt."
- The byte caption stays. It came from the backend, not from the decoder, so it is still true.
- The failed set is per side and is keyed and cleared exactly like `dims`, so a corrupt new version still shows the readable old one, and the next selection starts clean rather than printing the previous file's failure over a good image.

All four diff surfaces inherit it, since they all render this one component.

## Tests

Three cases in `ImageDiffView.test.tsx`, driving the real `error` event: the sentence replaces the image and keeps the caption; only the failing side fails; a new path clears the failure. All three fail on `main` and pass with the change (verified by reverting the component and re-running).

## Checks

- `pnpm vitest run` — 355 files / 3542 tests, all passing (includes the `docs` project)
- `pnpm tsc --noEmit` — clean
- `pnpm vite build` — clean
- `cargo check --manifest-path src-tauri/Cargo.toml` — clean
- `cargo test --manifest-path src-tauri/Cargo.toml` — all green (no Rust changed; run to confirm nothing moved)

`docs/dev/frontend.md` gains a bullet under the `ImageDiffView` section describing the new state.

No e2e spec was run: there is no fixture with a deliberately corrupt image, and adding one to drive a decode failure through the real webview would be a larger change than the fix. Happy to add it if you would rather have it covered there.