### PR TITLE
feat(design): replace the hand-drawn icon set with lucide-react

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,12 @@ Each rule's full story (why, traps, tests that pin it) is in the named doc.
   add `src/components/ui/`. Never hardcode the accent hue — CSS vars/theme
   tokens only. New list-row surfaces opt into UI density (`var(--row-step)`).
   (`docs/dev/frontend.md`)
+- **Icons are `lucide-react` behind `PGIcon`** — `src/design/icons.tsx` is the
+  ONLY file that may import it, and `PGIcon`'s `strokeWidth` is on a 16-unit
+  grid (scaled to lucide's 24), so changing that scale re-weights every icon at
+  once. `name` is `IconName | string` so a typo type-checks and renders a dashed
+  square; `test/iconSet.test.ts` fails the build for a stray import AND for a
+  call-site literal the union does not declare. (`docs/dev/frontend.md`)
 - **Zustand per feature.** `useRepoStore` holds exactly ONE repository's state
   (the active tab's); a new per-repo field must join `RepoSlice`/`emptySlice`
   or tab switches leak state. Danger-op catch arms: `refreshAll()` first,

--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1649,6 +1649,48 @@ update checks back on for someone who turned them off.
   does NOT (forwards `title` only). Row components need explicit prop threading
   for new attributes.
 
+### The icon set is lucide, behind one seam
+
+Every glyph in the app comes from `lucide-react`, and `src/design/icons.tsx` is
+the **only** file that imports it. Surfaces render `<PGIcon name="…" />` with a
+name from the `IconName` union; `ICONS` is the `Record<IconName, LucideIcon>`
+that resolves it. `test/iconSet.test.ts` fails the build if anything else
+imports `lucide-react` — that one seam is why the set could be swapped at all
+(it was hand-drawn SVG paths until then, and no feature had reached past
+`PGIcon` to the paths).
+
+Three things are load-bearing:
+
+- **`strokeWidth` is expressed on a 16-unit grid, not lucide's 24.** A stroke's
+  rendered thickness is `strokeWidth * size / grid`, so `PGIcon` scales the
+  width it hands lucide by `24/16`. That is what keeps `strokeWidth={1.5}`
+  rendering at the weight the hand-drawn set had, at every `size` — including
+  the `size={10} strokeWidth={2.5}` checkbox glyphs in `primitives.tsx`. Change
+  the scale and every icon in the app gets lighter or heavier at once.
+- **`name` is `IconName | string`, so a typo type-checks.** It has to stay wide
+  because a name can arrive from data (`lib/fileIcon.ts` resolves one per path),
+  and an unknown name renders a visible dashed square rather than collapsing
+  the row. The cost is that `icon="refhesh"` compiles: `Reflog.tsx` shipped
+  `icon="refresh"` against a union that had no `refresh` and nothing failed, so
+  `test/iconSet.test.ts` also checks every string-literal icon name at a call
+  site against the union.
+- **lucide adds `aria-hidden="true"`** to an icon with no children and no a11y
+  prop, and *merges* rather than replaces `className` (the svg keeps its
+  `lucide-<kebab-name>` class). Icon-only controls are therefore still named by
+  the `title` on the button, never by the glyph.
+
+Lucide has a full git vocabulary, which is why it is the set here: `GitBranch`,
+`GitMerge`, `GitFork`, `GitPullRequest`, `GitCommitHorizontal`,
+`GitMergeConflict`, plus `Folder`/`FolderOpen` and `FolderGit2` for submodules.
+Radix Icons was evaluated and rejected for this — 318 glyphs with no folder and
+no branch/merge/tag/terminal at all, which would have made ~17 of the app's
+names generic approximations.
+
+The diff-layout toggle in `History.tsx` shows the layout **currently** in
+effect: `panelBottom` (`PanelBottom`) when the diff panel is below the log,
+`panelRight` (`PanelRight`) when it is beside it, with `aria-pressed` tracking
+`beside`.
+
 ### One error banner, and it never spells the enum (#212)
 
 `PGErrorBanner` (`src/design/error-banner.tsx`) is the dismissible red strip an

--- a/src/design/icons.tsx
+++ b/src/design/icons.tsx
@@ -1,4 +1,109 @@
-import type { CSSProperties, ReactNode } from "react";
+/**
+ * The app's icon set.
+ *
+ * Glyphs come from `lucide-react`. This module is the ONLY place that imports
+ * it: every surface renders `<PGIcon name="…" />` with a name from
+ * {@link IconName}, so swapping the underlying set again is a one-file change
+ * and a name that nobody draws is caught by the type checker rather than by a
+ * blank gap in the UI.
+ *
+ * Two things are deliberate:
+ *
+ * - **Stroke width is expressed on a 16 grid.** The hand-drawn set this
+ *   replaced used a 16-unit viewBox at `strokeWidth: 1.5`; lucide draws on a
+ *   24-unit grid. A stroke's rendered thickness is `strokeWidth * size / grid`,
+ *   so the width handed to lucide is scaled by {@link STROKE_GRID_SCALE}
+ *   (24/16). `strokeWidth={1.5}` therefore renders at exactly the weight it
+ *   always did, at every `size` — including the size-10 checkbox glyphs that
+ *   ask for 2.5.
+ * - **An unknown name renders a visible dashed square**, not nothing. A typo'd
+ *   name is then obvious on screen instead of silently collapsing the row.
+ */
+import type { CSSProperties } from "react";
+import type { LucideIcon } from "lucide-react";
+import {
+  Archive,
+  ArrowDownToLine,
+  ArrowUpDown,
+  ArrowUpFromLine,
+  Bell,
+  BookMarked,
+  Check,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronUp,
+  Circle,
+  CircleSmall,
+  CircleX,
+  Clock,
+  CloudDownload,
+  Combine,
+  Copy,
+  Database,
+  Download,
+  Ellipsis,
+  ExternalLink,
+  Eye,
+  File,
+  FileArchive,
+  FileBraces,
+  FileCode,
+  FileCog,
+  FileDiff,
+  FileDigit,
+  FileImage,
+  FileLock,
+  FileSliders,
+  FileTerminal,
+  FileText,
+  FileType,
+  FoldVertical,
+  Folder,
+  FolderGit2,
+  FolderOpen,
+  FolderSymlink,
+  Funnel,
+  GitBranch,
+  GitCommitHorizontal,
+  GitFork,
+  GitGraph,
+  GitMerge,
+  GitMergeConflict,
+  GitPullRequest,
+  GripVertical,
+  Info,
+  Keyboard,
+  Link,
+  List,
+  ListTree,
+  Lock,
+  Minus,
+  PanelBottom,
+  PanelRight,
+  Pause,
+  Pencil,
+  Pin,
+  Play,
+  Plus,
+  RefreshCw,
+  RotateCcwClock,
+  RotateCw,
+  Search,
+  Settings,
+  Split,
+  Star,
+  Tag,
+  Terminal,
+  Trash,
+  TriangleAlert,
+  Undo2,
+  UnfoldVertical,
+  Upload,
+  User,
+  Wrench,
+  X,
+} from "lucide-react";
 
 export type IconName =
   | "repo" | "branch" | "commit" | "merge" | "fork" | "tag" | "pullRequest"
@@ -9,7 +114,7 @@ export type IconName =
   | "plus" | "minus" | "check" | "x"
   | "chevronRight" | "chevronDown" | "chevronUp" | "chevronLeft"
   | "search" | "settings" | "filter" | "sort" | "more"
-  | "pull" | "push" | "fetch" | "sync" | "stash" | "rebase"
+  | "pull" | "push" | "fetch" | "sync" | "refresh" | "stash" | "rebase"
   | "dot" | "circle" | "warn" | "error" | "info" | "clock"
   | "user" | "eye" | "terminal" | "history" | "kbd"
   | "download" | "upload" | "link" | "lock"
@@ -17,292 +122,136 @@ export type IconName =
   | "edit" | "trash" | "conflict" | "squash" | "drag" | "bell"
   | "diff" | "undo" | "fix" | "expandAll" | "collapseAll"
   | "viewTree" | "viewList"
+  // Pane placement — which edge a panel is docked to. The diff-layout toggle
+  // shows the layout that is CURRENTLY in effect.
+  | "panelBottom" | "panelRight"
   // #93 — submodules, linked worktrees, bisect, LFS.
   | "submodule" | "worktree" | "bisect" | "lfs";
 
-const ICONS: Record<IconName, ReactNode> = {
-  repo: <>
-    <path d="M3 2.5A1.5 1.5 0 0 1 4.5 1h8A1.5 1.5 0 0 1 14 2.5V13a1 1 0 0 1-1 1H5a2 2 0 0 1-2-2V2.5z" />
-    <path d="M3 12a2 2 0 0 1 2-2h8" />
-  </>,
-  branch: <>
-    <circle cx="4" cy="3.5" r="1.5" />
-    <circle cx="4" cy="12.5" r="1.5" />
-    <circle cx="12" cy="6" r="1.5" />
-    <path d="M4 5v6M4 8c0-2 3-2 5-2" />
-  </>,
-  commit: <>
-    <circle cx="8" cy="8" r="3" />
-    <path d="M1 8h4M11 8h4" />
-  </>,
-  merge: <>
-    <circle cx="4" cy="3.5" r="1.5" />
-    <circle cx="4" cy="12.5" r="1.5" />
-    <circle cx="12" cy="8" r="1.5" />
-    <path d="M4 5v6M4 6c0 3 3.5 2 6.5 2" />
-  </>,
-  fork: <>
-    <circle cx="4" cy="3.5" r="1.5" />
-    <circle cx="12" cy="3.5" r="1.5" />
-    <circle cx="8" cy="12.5" r="1.5" />
-    <path d="M4 5c0 3 4 3 4 6M12 5c0 3-4 3-4 6" />
-  </>,
-  // Pull / merge request (#92): a source lane arrowing into a target lane.
-  pullRequest: <>
-    <circle cx="4" cy="12.5" r="1.5" />
-    <circle cx="12" cy="3.5" r="1.5" />
-    <circle cx="12" cy="12.5" r="1.5" />
-    <path d="M4 11V5.5M12 5v6M4 5.5l-2 2M4 5.5l2 2" />
-  </>,
-  tag: <>
-    <path d="M1.5 2.5h6l7 7-6 6-7-7v-6z" />
-    <circle cx="4.5" cy="5.5" r="1" />
-  </>,
-  folder: <path d="M1.5 4a1 1 0 0 1 1-1h3l1.5 1.5H13.5a1 1 0 0 1 1 1V12a1 1 0 0 1-1 1h-11a1 1 0 0 1-1-1V4z" />,
-  folderOpen: <path d="M1.5 5a1 1 0 0 1 1-1h3l1.5-1.5h6a1 1 0 0 1 1 1V6M1.5 6h13l-1.5 6.5a1 1 0 0 1-1 .5h-9a1 1 0 0 1-1-.5L1.5 6z" />,
-  file: <>
-    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
-    <path d="M9 1.5v4h4" />
-  </>,
-  fileCode: <>
-    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
-    <path d="M9 1.5v4h4M6 9l-1.5 1.5L6 12M10 9l1.5 1.5L10 12" />
-  </>,
-  // ── File-type category glyphs ───────────────────────────────────────────
-  // All share the `file` page outline so a mixed list reads as one family;
-  // the mark inside the page is what distinguishes the category.
-  fileData: <>
-    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
-    <path d="M9 1.5v4h4M6.5 8.5c-1 0-1 1.25-1 1.25s0 1.25 1 1.25M9.5 8.5c1 0 1 1.25 1 1.25s0 1.25-1 1.25" />
-  </>,
-  fileDoc: <>
-    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
-    <path d="M9 1.5v4h4M4.5 8.5h5M4.5 10.5h5M4.5 12.5h3" />
-  </>,
-  fileStyle: <>
-    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
-    <path d="M9 1.5v4h4M8 8.5c-1.5 1.6-2.25 2.6-2.25 3.35a2.25 2.25 0 0 0 4.5 0C10.25 11.1 9.5 10.1 8 8.5z" />
-  </>,
-  fileImage: <>
-    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
-    <path d="M9 1.5v4h4M2 12.5l3-3 2.5 2.5M9 10l1.5-1.5 2.5 2.5" />
-    <circle cx="6" cy="7.5" r=".9" />
-  </>,
-  fileShell: <>
-    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
-    <path d="M9 1.5v4h4M4.5 8.5l2 1.75-2 1.75M8 12.25h3" />
-  </>,
-  fileConfig: <>
-    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
-    <path d="M9 1.5v4h4" />
-    <circle cx="7.5" cy="10.5" r="1.6" />
-    <path d="M7.5 7.6v1.3M7.5 12.1v1.3M4.9 9v0M10.1 12v0M4.9 12v0M10.1 9v0" />
-  </>,
-  fileLock: <>
-    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
-    <path d="M9 1.5v4h4" />
-    <rect x="5" y="10" width="6" height="3.5" rx=".75" />
-    <path d="M6.25 10V9a1.75 1.75 0 0 1 3.5 0v1" />
-  </>,
-  fileArchive: <>
-    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
-    <path d="M9 1.5v4h4M6.5 2v1M8 3.5v1M6.5 5v1M8 6.5v1M6.5 8v1" />
-    <rect x="6" y="10" width="2.5" height="3" rx=".5" />
-  </>,
-  fileBinary: <>
-    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
-    <path d="M9 1.5v4h4M5 8.75l1-.5v3.5M4.75 11.75h2.5" />
-    <rect x="8.75" y="8.25" width="2.5" height="3.5" rx="1.25" />
-  </>,
-  fileGit: <>
-    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
-    <path d="M9 1.5v4h4" />
-    <circle cx="5.5" cy="8.5" r="1" />
-    <circle cx="5.5" cy="12.5" r="1" />
-    <circle cx="10" cy="9.75" r="1" />
-    <path d="M5.5 9.5v2M5.5 11c0-1.5 1.5-1.25 3.5-1.25" />
-  </>,
-  plus: <path d="M8 3v10M3 8h10" />,
-  minus: <path d="M3 8h10" />,
-  check: <path d="M3 8.5l3.5 3.5L13 5.5" />,
-  x: <path d="M4 4l8 8M12 4l-8 8" />,
-  chevronRight: <path d="M6 3l5 5-5 5" />,
-  chevronDown: <path d="M3 6l5 5 5-5" />,
-  chevronUp: <path d="M3 10l5-5 5 5" />,
-  chevronLeft: <path d="M10 3l-5 5 5 5" />,
-  search: <>
-    <circle cx="7" cy="7" r="4.5" />
-    <path d="M10.5 10.5l3 3" />
-  </>,
-  settings: <>
-    <path d="M6.76 3.16 L6.58 1.66 L9.42 1.66 L9.24 3.16 L10.55 3.7 L11.48 2.51 L13.49 4.52 L12.3 5.45 L12.84 6.76 L14.34 6.58 L14.34 9.42 L12.84 9.24 L12.3 10.55 L13.49 11.48 L11.48 13.49 L10.55 12.3 L9.24 12.84 L9.42 14.34 L6.58 14.34 L6.76 12.84 L5.45 12.3 L4.52 13.49 L2.51 11.48 L3.7 10.55 L3.16 9.24 L1.66 9.42 L1.66 6.58 L3.16 6.76 L3.7 5.45 L2.51 4.52 L4.52 2.51 L5.45 3.7 Z" />
-    <circle cx="8" cy="8" r="2" />
-  </>,
-  filter: <path d="M2 3h12l-4.5 5.5V13l-3-1V8.5L2 3z" />,
-  sort: <path d="M4 3v10M4 13l-2-2M4 13l2-2M12 3v10M12 3l-2 2M12 3l2 2" />,
-  more: <>
-    <circle cx="3" cy="8" r="1" />
-    <circle cx="8" cy="8" r="1" />
-    <circle cx="13" cy="8" r="1" />
-  </>,
-  pull: <path d="M8 3v8M4 7l4 4 4-4M3 13h10" />,
-  push: <path d="M8 13V5M4 9l4-4 4 4M3 3h10" />,
-  fetch: <>
-    <circle cx="8" cy="8" r="5" />
-    <path d="M8 5v3l2 2" />
-  </>,
-  sync: <>
-    <path d="M 3.3 6.29 A 5 5 0 0 1 12.7 6.29" />
-    <path d="M 11.02 5.2 L 12.7 6.29 L 13.28 4.38" />
-    <path d="M 12.7 9.71 A 5 5 0 0 1 3.3 9.71" />
-    <path d="M 4.98 10.8 L 3.3 9.71 L 2.72 11.62" />
-  </>,
-  stash: <>
-    <path d="M2 5h12M3 8h10M5 11h6" />
-    <rect x="4" y="2" width="8" height="1" />
-  </>,
-  rebase: <>
-    <circle cx="4" cy="3" r="1.2" />
-    <circle cx="4" cy="8" r="1.2" />
-    <circle cx="4" cy="13" r="1.2" />
-    <circle cx="12" cy="8" r="1.2" />
-    <path d="M4 4.2v2.6M4 9.2v2.6M5.2 8H10.8" />
-  </>,
-  dot: <circle cx="8" cy="8" r="3" fill="currentColor" stroke="none" />,
-  circle: <circle cx="8" cy="8" r="5" />,
-  warn: <>
-    <path d="M8 2l7 12H1L8 2z" />
-    <path d="M8 6v4M8 12v.01" />
-  </>,
-  error: <>
-    <circle cx="8" cy="8" r="6" />
-    <path d="M5 5l6 6M11 5l-6 6" />
-  </>,
-  info: <>
-    <circle cx="8" cy="8" r="6" />
-    <path d="M8 5v0M8 8v4" />
-  </>,
-  clock: <>
-    <circle cx="8" cy="8" r="6" />
-    <path d="M8 5v3l2 2" />
-  </>,
-  user: <>
-    <circle cx="8" cy="5" r="2.5" />
-    <path d="M3 14c0-3 2.5-5 5-5s5 2 5 5" />
-  </>,
-  eye: <>
-    <path d="M1 8s2.5-5 7-5 7 5 7 5-2.5 5-7 5-7-5-7-5z" />
-    <circle cx="8" cy="8" r="2" />
-  </>,
-  terminal: <>
-    <rect x="1.5" y="2.5" width="13" height="11" />
-    <path d="M4 6l2 2-2 2M8 10h3" />
-  </>,
-  history: <>
-    <circle cx="8" cy="8" r="6" />
-    <path d="M8 5v3l2 2M2 8h1M8 2v1" />
-  </>,
-  kbd: <>
-    <rect x="1.5" y="4" width="13" height="8" />
-    <path d="M4 8h0M7 8h0M10 8h0M4 10h6" />
-  </>,
-  download: <path d="M8 2v9M4 7l4 4 4-4M2 14h12" />,
-  upload: <path d="M8 11V2M4 6l4-4 4 4M2 14h12" />,
-  link: <path d="M7 9a3 3 0 0 0 4 0l2-2a3 3 0 0 0-4-4l-1 1M9 7a3 3 0 0 0-4 0l-2 2a3 3 0 0 0 4 4l1-1" />,
-  lock: <>
-    <rect x="2.5" y="7" width="11" height="7" />
-    <path d="M5 7V4.5a3 3 0 0 1 6 0V7" />
-  </>,
-  play: <path d="M4 3l9 5-9 5V3z" />,
-  pause: <>
-    <rect x="4" y="3" width="3" height="10" />
-    <rect x="9" y="3" width="3" height="10" />
-  </>,
-  star: <path d="M8 1l2 5 5 .5-4 3.5 1 5-4-2.5-4 2.5 1-5-4-3.5 5-.5z" />,
-  pin: <>
-    <path d="M6 2h4l-.5 4 2 2.5H4.5L6.5 6z" />
-    <path d="M8 8.5V14" />
-  </>,
-  copy: <>
-    <rect x="4" y="4" width="10" height="10" />
-    <path d="M2 10V2h8v2" />
-  </>,
-  external: <>
-    <path d="M6 2H2v12h12V10" />
-    <path d="M8 8l6-6M9 2h5v5" />
-  </>,
-  edit: <path d="M2 14l2-5 8-8 3 3-8 8-5 2z" />,
-  trash: <path d="M2.5 4.5h11M5 4.5V3a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v1.5M4 4.5V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.5" />,
-  conflict: <path d="M8 1v5M8 10v0M8 6L4 14h8L8 6z" />,
-  squash: <>
-    <circle cx="8" cy="4" r="1.2" />
-    <circle cx="8" cy="8" r="1.2" />
-    <circle cx="8" cy="12" r="1.2" />
-    <path d="M4 4h3M4 8h3M4 12h3" />
-  </>,
-  drag: <>
-    <circle cx="5" cy="4" r=".8" fill="currentColor" stroke="none" />
-    <circle cx="5" cy="8" r=".8" fill="currentColor" stroke="none" />
-    <circle cx="5" cy="12" r=".8" fill="currentColor" stroke="none" />
-    <circle cx="11" cy="4" r=".8" fill="currentColor" stroke="none" />
-    <circle cx="11" cy="8" r=".8" fill="currentColor" stroke="none" />
-    <circle cx="11" cy="12" r=".8" fill="currentColor" stroke="none" />
-  </>,
-  bell: <path d="M4 12V8a4 4 0 0 1 8 0v4M2.5 12h11M7 14h2" />,
-  // Aliases used by context menus
-  diff: <>
-    <path d="M3 1.5h6l4 4V13.5a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-11a1 1 0 0 1 1-1z" />
-    <path d="M9 1.5v4h4M5 8h6M5 11h4" />
-  </>,
-  undo: <path d="M6 5L3 8l3 3M3 8h7a3 3 0 0 1 0 6H8" />,
-  fix: <path d="M10 2l4 4-2 2-4-4 2-2zM8 4L2 10v4h4l6-6" />,
-  // Chevrons pointing away from center = unfold (expand all).
-  expandAll: <path d="M4.5 6L8 2.5 11.5 6M4.5 10L8 13.5 11.5 10" />,
-  // Chevrons pointing toward center = fold (collapse all).
-  collapseAll: <path d="M4.5 3L8 6.5 11.5 3M4.5 13L8 9.5 11.5 13" />,
+const ICONS: Record<IconName, LucideIcon> = {
+  // ── Repository objects ──────────────────────────────────────────────────
+  repo: BookMarked,
+  branch: GitBranch,
+  commit: GitCommitHorizontal,
+  merge: GitMerge,
+  fork: GitFork,
+  tag: Tag,
+  pullRequest: GitPullRequest,
+
+  // ── Files and folders ───────────────────────────────────────────────────
+  folder: Folder,
+  folderOpen: FolderOpen,
+  file: File,
+  fileCode: FileCode,
+  // All file-type glyphs keep lucide's page outline so a mixed list reads as
+  // one family; the mark inside the page distinguishes the category.
+  fileData: FileBraces,
+  fileDoc: FileText,
+  fileStyle: FileType,
+  fileImage: FileImage,
+  fileShell: FileTerminal,
+  fileConfig: FileCog,
+  fileLock: FileLock,
+  fileArchive: FileArchive,
+  fileBinary: FileDigit,
+  // Git's own dotfiles (.gitignore, .gitattributes, .mailmap) are a page of
+  // rules — sliders, kept distinct from the cog that marks build config.
+  fileGit: FileSliders,
+
+  // ── Primitives ──────────────────────────────────────────────────────────
+  plus: Plus,
+  minus: Minus,
+  check: Check,
+  x: X,
+  chevronRight: ChevronRight,
+  chevronDown: ChevronDown,
+  chevronUp: ChevronUp,
+  chevronLeft: ChevronLeft,
+  search: Search,
+  settings: Settings,
+  filter: Funnel,
+  sort: ArrowUpDown,
+  more: Ellipsis,
+
+  // ── Network and history ops ─────────────────────────────────────────────
+  // pull/push are arrows meeting a baseline (the local checkout); fetch only
+  // brings refs down, so it stays a cloud.
+  pull: ArrowDownToLine,
+  push: ArrowUpFromLine,
+  fetch: CloudDownload,
+  sync: RefreshCw,
+  refresh: RotateCw,
+  stash: Archive,
+  rebase: GitGraph,
+
+  // ── Status ──────────────────────────────────────────────────────────────
+  // lucide's `Dot` renders a ~2px speck at size 14 — invisible in the status bar.
+  dot: CircleSmall,
+  circle: Circle,
+  warn: TriangleAlert,
+  error: CircleX,
+  info: Info,
+  clock: Clock,
+
+  // ── Chrome ──────────────────────────────────────────────────────────────
+  user: User,
+  eye: Eye,
+  terminal: Terminal,
+  history: RotateCcwClock,
+  kbd: Keyboard,
+  download: Download,
+  upload: Upload,
+  link: Link,
+  lock: Lock,
+  play: Play,
+  pause: Pause,
+  star: Star,
+  copy: Copy,
+  external: ExternalLink,
+  pin: Pin,
+  edit: Pencil,
+  trash: Trash,
+
+  // ── Rebase / merge vocabulary ───────────────────────────────────────────
+  conflict: GitMergeConflict,
+  squash: Combine,
+  drag: GripVertical,
+  bell: Bell,
+  diff: FileDiff,
+  undo: Undo2,
+  fix: Wrench,
+  // Chevrons pointing away from centre = unfold; toward centre = fold.
+  expandAll: UnfoldVertical,
+  collapseAll: FoldVertical,
   // View-mode pair: an indented hierarchy vs a flat stack of rows.
-  viewTree: <>
-    <path d="M2.5 2.5v9.5M2.5 5.5h3M2.5 9h3M2.5 12.5h3" />
-    <path d="M7 2.5h6.5M7 5.5h6.5M7 9h6.5M7 12.5h6.5" />
-  </>,
-  viewList: <>
-    <circle cx="3" cy="4" r=".9" fill="currentColor" stroke="none" />
-    <circle cx="3" cy="8" r=".9" fill="currentColor" stroke="none" />
-    <circle cx="3" cy="12" r=".9" fill="currentColor" stroke="none" />
-    <path d="M6 4h8M6 8h8M6 12h8" />
-  </>,
-  // #93. A repository inside a repository — the outer frame with an inner one
-  // pinned to its corner, which is what a gitlink is.
-  submodule: <>
-    <path d="M1.5 2.5h8a1 1 0 0 1 1 1v3" />
-    <path d="M1.5 2.5v9a1 1 0 0 0 1 1h4" />
-    <rect x="7.5" y="7.5" width="7" height="6" rx="1" />
-    <path d="M9.5 10.5h3" />
-  </>,
-  // Two checkouts of one history: a shared trunk splitting into two panels.
-  worktree: <>
-    <path d="M2.5 3.5v9M2.5 6h4M2.5 11h4" />
-    <rect x="7" y="3" width="7" height="5" rx="1" />
-    <rect x="7" y="9.5" width="7" height="4" rx="1" />
-  </>,
-  // Halving a range: a span with its midpoint marked.
-  bisect: <>
-    <path d="M2 12.5h12" />
-    <path d="M2 12.5V9M14 12.5V9" />
-    <circle cx="8" cy="12.5" r="1.8" fill="currentColor" stroke="none" />
-    <path d="M8 8V2.5M6 4.5L8 2.5l2 2" />
-  </>,
-  // Large-file storage: a stack with an arrow going out to it.
-  lfs: <>
-    <path d="M2.5 5c0-1 2.5-2 5.5-2s5.5 1 5.5 2-2.5 2-5.5 2S2.5 6 2.5 5z" />
-    <path d="M2.5 5v6c0 1 2.5 2 5.5 2s5.5-1 5.5-2V5" />
-    <path d="M2.5 8c0 1 2.5 2 5.5 2s5.5-1 5.5-2" />
-  </>,
+  viewTree: ListTree,
+  viewList: List,
+
+  // ── Pane placement ──────────────────────────────────────────────────────
+  panelBottom: PanelBottom,
+  panelRight: PanelRight,
+
+  // ── #93 ─────────────────────────────────────────────────────────────────
+  // A repository nested inside a repository is what a gitlink is.
+  submodule: FolderGit2,
+  // A linked worktree is a second checkout pointing at one history.
+  worktree: FolderSymlink,
+  // Halving a range until the culprit is cornered.
+  bisect: Split,
+  // Large files kept outside the object database.
+  lfs: Database,
 };
+
+/**
+ * Multiplier from the 16-unit grid `strokeWidth` is expressed on to lucide's
+ * 24-unit grid. See the module comment.
+ */
+const STROKE_GRID_SCALE = 24 / 16;
 
 export interface PGIconProps {
   name: IconName | string;
   size?: number;
+  /** Stroke width on a 16-unit grid; scaled to lucide's 24-unit grid. */
   strokeWidth?: number;
   style?: CSSProperties;
   className?: string;
@@ -317,8 +266,8 @@ export function PGIcon({
   style,
   className,
 }: PGIconProps) {
-  const content = ICONS[name as IconName];
-  if (!content) {
+  const Glyph = ICONS[name as IconName];
+  if (!Glyph) {
     // Visible placeholder (dashed square) instead of a silent blank gap, so a
     // typo'd or missing icon name is obvious. Warn once per name in dev.
     if (import.meta.env?.DEV && !warnedIcons.has(name)) {
@@ -344,19 +293,11 @@ export function PGIcon({
     );
   }
   return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={strokeWidth}
-      strokeLinecap="round"
-      strokeLinejoin="round"
+    <Glyph
+      size={size}
+      strokeWidth={strokeWidth * STROKE_GRID_SCALE}
       className={className}
       style={{ flexShrink: 0, ...style }}
-    >
-      {content}
-    </svg>
+    />
   );
 }

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -1707,7 +1707,7 @@ function HistoryToolbarRight({
         onClick={(e) => openAt(e.clientX, e.clientY + 4, null)}
       />
       <PGIconButton
-        icon="diff"
+        icon={diffLayout === "below" ? "panelBottom" : "panelRight"}
         size="md"
         title={
           diffLayout === "below"

--- a/test/iconSet.test.ts
+++ b/test/iconSet.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @vitest-environment node
+ */
+// Guards the two properties that make the icon set swappable and typo-proof.
+//
+// 1. `lucide-react` is imported by `src/design/icons.tsx` and NOTHING else.
+//    That one file is the whole seam: the set behind `PGIcon` was hand-drawn
+//    SVG paths before it was lucide, and the swap was a one-file change only
+//    because no other surface had reached past `PGIcon` to the library. A
+//    direct `import { GitBranch } from "lucide-react"` somewhere in a feature
+//    is what quietly ends that.
+//
+// 2. Every icon name written as a STRING LITERAL at a call site is a member of
+//    `IconName`. `PGIconProps.name` is `IconName | string` on purpose — the
+//    fallback glyph has to be reachable at runtime for a name that arrives from
+//    data — but that widening also means the type checker cannot see a typo in
+//    `icon="refhesh"`. It renders a dashed square instead, which is easy to
+//    ship without noticing: `Reflog.tsx` shipped `icon="refresh"` against a
+//    union that had no `refresh`, and nothing failed.
+//
+// Lives at the repo root rather than under `src/`, because it reads the SOURCE
+// TEXT of the tree instead of rendering anything — a node test in the `docs`
+// vitest project, like `nativeSelect.test.ts` and `docs.test.ts` beside it.
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SRC = resolve(process.cwd(), "src");
+const ICONS_FILE = join(SRC, "design", "icons.tsx");
+
+/** SHIPPED source only — the same walk `nativeSelect.test.ts` uses. Test files
+ *  are excluded because a test may legitimately name a bogus icon to assert the
+ *  fallback glyph renders. */
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "test") continue;
+      out.push(...sourceFiles(p));
+    } else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+/** The members of the `IconName` union, read out of its declaration. */
+function declaredIconNames(): Set<string> {
+  const src = readFileSync(ICONS_FILE, "utf8");
+  const start = src.indexOf("export type IconName =");
+  expect(start).toBeGreaterThanOrEqual(0);
+  const end = src.indexOf(";", start);
+  expect(end).toBeGreaterThan(start);
+  const union = src.slice(start, end);
+  return new Set([...union.matchAll(/"([a-zA-Z]+)"/g)].map((m) => m[1]!));
+}
+
+describe("the icon set", () => {
+  const files = sourceFiles(SRC);
+  const names = declaredIconNames();
+
+  it("finds source files and declared names at all", () => {
+    // A broken walk or a failed parse would make every assertion below vacuous.
+    expect(files.length).toBeGreaterThan(100);
+    expect(names.size).toBeGreaterThan(60);
+  });
+
+  it("imports lucide-react only from src/design/icons.tsx", () => {
+    const importers: string[] = [];
+    for (const file of files) {
+      if (/from\s+["']lucide-react["']/.test(readFileSync(file, "utf8"))) {
+        importers.push(relative(SRC, file));
+      }
+    }
+    expect(importers).toEqual(["design/icons.tsx"]);
+  });
+
+  it("maps every declared name to a glyph", () => {
+    // `Record<IconName, LucideIcon>` already makes a missing entry a type
+    // error; this catches the record being emptied or stubbed out wholesale.
+    const src = readFileSync(ICONS_FILE, "utf8");
+    const body = src.slice(src.indexOf("const ICONS"), src.indexOf("const STROKE_GRID_SCALE"));
+    for (const name of names) {
+      expect(body, `ICONS is missing "${name}"`).toMatch(
+        new RegExp(`\\b${name}:\\s*[A-Z]`),
+      );
+    }
+  });
+
+  it("uses no icon name that IconName does not declare", () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const code = readFileSync(file, "utf8");
+      const used = new Set<string>();
+      // `icon="…"` — PGIconButton, PGButton, PGEmpty, PGStatusItem, context
+      // menu items, settings page `meta`, the nav registry.
+      for (const m of code.matchAll(/\bicon="([a-zA-Z]+)"/g)) used.add(m[1]!);
+      // `<PGIcon … name="…" />` — PGIcon has no children, so the first `/>`
+      // after the tag closes it.
+      for (const el of code.matchAll(/<PGIcon\b[\s\S]*?\/>/g)) {
+        const m = /\bname="([a-zA-Z]+)"/.exec(el[0]);
+        if (m) used.add(m[1]!);
+      }
+      for (const name of used) {
+        if (!names.has(name)) offenders.push(`${relative(SRC, file)}: "${name}"`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("declares the pane-placement pair the diff-layout toggle switches between", () => {
+    expect(names.has("panelBottom")).toBe(true);
+    expect(names.has("panelRight")).toBe(true);
+  });
+});


### PR DESCRIPTION
Replaces the hand-drawn SVG icon set with a real icon library.

## What changed

Every glyph now comes from `lucide-react` behind the existing `PGIcon` seam, so
all **126 call sites across 54 files** and `lib/fileIcon.ts` are untouched —
only `src/design/icons.tsx` changed shape, from a `Record<IconName, ReactNode>`
of hand-drawn paths to a `Record<IconName, LucideIcon>`.

**Panel icons for the diff-layout toggle** (`History.tsx`), which is what
prompted this: the toggle rendered the same generic `diff` glyph in both states.
It now shows the layout *currently* in effect — `PanelBottom` when the diff
panel is below the log, `PanelRight` when it is beside it, with `aria-pressed`
tracking `beside`.

**One bug fixed along the way:** `Reflog.tsx:187` asked for `icon="refresh"`
against a union that never declared it, so it had been rendering the
unknown-name fallback square. `refresh` is now a real name (`RotateCw`).

## Why lucide and not Radix Icons

Radix was the starting point (via shadcn.io/icons). It ships 318 glyphs with
**no folder icon and no branch / merge / fork / pull-request / tag / terminal at
all** — its only VCS glyphs are `CommitIcon` and `GitHubLogoIcon`. That would
have turned ~17 of this app's 78 names into generic approximations (branch as a
share graph, folders as boxes) in a git client whose north star is usability.

lucide has the full git vocabulary — `GitBranch`, `GitMerge`, `GitFork`,
`GitPullRequest`, `GitCommitHorizontal`, `GitMergeConflict`, `FolderGit2` for
submodules, `FolderSymlink` for linked worktrees — is stroke-based so the app's
visual weight carries over unchanged, and was **already in `package.json`,
unused**. No dependency was added. (It is also the first set listed on
shadcn.io/icons.)

## Preserving the visual weight

`PGIcon.strokeWidth` stays expressed on a **16-unit grid** and is scaled by
`24/16` before it reaches lucide, because rendered thickness is
`strokeWidth * size / grid`. Every icon therefore keeps exactly the weight it
had at every size — including the `size={10} strokeWidth={2.5}` checkbox glyphs
in `primitives.tsx`.

`dot` maps to `CircleSmall`, not lucide's `Dot`, which renders a ~2px speck that
disappears in the status bar. That was caught by rendering all 81 glyphs to a
contact sheet and looking at them, not by a test.

lucide's defaults match the old wrapper exactly (`fill: none`,
`stroke: currentColor`, round caps and joins), and it *merges* rather than
replaces `className`, so callers' classes survive and the svg keeps its
`lucide-<kebab-name>` class. It also adds `aria-hidden="true"` to decorative
icons, which the hand-drawn set did not — a small a11y improvement, and
icon-only controls are still named by the `title` on the button.

## New guard test

`test/iconSet.test.ts` pins the seam that made this a one-file swap:

1. Nothing but `icons.tsx` may import `lucide-react`.
2. Every string-literal icon name at a call site must be a member of
   `IconName`. The type checker cannot do this itself — `name` is
   `IconName | string` on purpose, so the runtime fallback stays reachable for
   names that arrive from data — and that widening is exactly how the `refresh`
   typo shipped.

Both assertions were verified by planting the violations and confirming they
fail with the offending file named, then reverting.

## Verification

- `pnpm tsc --noEmit` — clean.
- `pnpm test` — **356 files / 3544 tests green** (the one `ImageDiffView` red on
  an intermediate run is the known ~1-in-111 flake; re-ran green, and the diff
  never touches `features/diff`).
- All 81 glyphs rendered to a headless-Chrome contact sheet at sizes 14 / 32 /
  10 and inspected, including the unknown-name fallback and the toggle pair.
- `history-diff.e2e.ts` and `settings.e2e.ts` in Docker — 9 passing each.
  The two icon-adjacent assertions both still read the commit-graph svg
  (`svg circle` for lane geometry, first-`svg` height for the UI-density
  measurement), which is what would have broken had an icon svg landed ahead
  of the graph in the row.
- **Bundle: +9.4 kB raw / +4.4 kB gzip** on the entry chunk (1,516.48 -> 1,525.87
  kB), measured by building this tree and then the same tree with main's
  `icons.tsx` restored. lucide tree-shakes correctly: only the 81 imported
  glyphs are in the chunk, none of the other 1,730 (grepped for `banana`,
  `anvil`, `rocket`, `croissant`, `telescope` — all absent).
- Checked that every `icon=` / `<PGIcon name=>` literal already on `origin/main`
  is in the union, so the merge commit cannot violate the new guard.
