### PR TITLE
fix(design): run the activity bar to the window's bottom edge

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1064,6 +1064,17 @@ that is only partly here — which is the whole reason the notice exists.
 - Activity bar = primary switcher, History first. **Launch always lands on
   History** — no screen restore (`pg-screen` is gone); restored tabs start on
   History too.
+- **The rail sizes itself (`height: 100%`), not its content.** Settings is
+  pinned to the bottom edge by a `flex: 1` spacer, and a spacer only claims
+  space in a box that has some: AppShell renders `PGActivityBar` inside a
+  `PGPane` div, so the bar is a BLOCK child of a full-height box, not the flex
+  item of the shell's row it was before #11. Losing the explicit height is why
+  the rail's `--bg-titlebar` background and right border once stopped
+  mid-window, just under the gear (`box-sizing: border-box` keeps the border
+  and padding inside that 100% instead of overflowing onto the status bar).
+  Same trap for any pane whose child pins something with a spacer — wrapping it
+  in a `PGPane` changes what its height resolves against. `chrome.test.tsx`
+  pins the mechanism; jsdom does no layout, so nothing here is a pixel gate.
 - **Repositories are tabs (#90).** Opening a repository ANYWHERE goes through
   `useTabsStore.openRepo` (focus-existing-or-add). `useRepoStore.openRepo` no
   longer exists; the low-level half is `openRepoAt`.

--- a/src/design/chrome.test.tsx
+++ b/src/design/chrome.test.tsx
@@ -8,6 +8,7 @@ vi.mock("@/lib/platform", () => ({
 }));
 
 import {
+  PGActivityBar,
   PGSidebarGroup,
   PGSidebarRow,
   PGTabStrip,
@@ -127,6 +128,57 @@ describe("PGTabStrip", () => {
     const { container } = render(<PGTabStrip tabs={stripTabs(1)} />);
     const rows = Array.from(container.querySelectorAll('[data-testid="repo-tab"]'));
     expect(tracked.calls).toEqual([rows[1]]);
+  });
+});
+
+describe("PGActivityBar", () => {
+  const items = [
+    { id: "history", icon: "history", label: "History" },
+    { id: "commit", icon: "commit", label: "Commit" },
+  ];
+
+  // The rail is rendered inside a `PGPane` div (AppShell), i.e. as a BLOCK
+  // child of a full-height box — so its own height must be 100%, not auto.
+  // With auto height the `flex: 1` spacer has nothing to claim: the rail's
+  // background and right border stop just under the gear, mid-window, and
+  // Settings sits directly below the last screen icon instead of at the
+  // bottom edge. jsdom does no layout, so what is pinned here is the
+  // mechanism, not the pixels.
+  it("fills its container height so the spacer can pin Settings", () => {
+    const { container } = render(
+      <PGActivityBar value="history" items={items} />,
+    );
+    const bar = container.querySelector<HTMLElement>("[data-pg-activity-bar]");
+    expect(bar).not.toBeNull();
+    expect(bar!.style.height).toBe("100%");
+    // The border and padding must fit INSIDE that 100%, or the rail overflows
+    // its pane by 13px and paints over the status bar.
+    expect(bar!.style.boxSizing).toBe("border-box");
+  });
+
+  it("puts a flex spacer between the last screen icon and Settings", () => {
+    const { container } = render(
+      <PGActivityBar value="history" items={items} />,
+    );
+    const bar = container.querySelector<HTMLElement>("[data-pg-activity-bar]")!;
+    const spacer = bar.querySelector<HTMLElement>("[data-pg-activity-spacer]");
+    expect(spacer).not.toBeNull();
+    // jsdom expands the `flex: 1` shorthand it serializes back.
+    expect(spacer!.style.flex).toBe("1 1 0%");
+
+    const kids = Array.from(bar.children);
+    const settings = bar.querySelector<HTMLElement>(
+      '[data-activity="settings"]',
+    )!;
+    // Settings is last, and the spacer is what precedes it.
+    const settingsSlot = kids.findIndex((k) => k.contains(settings));
+    expect(settingsSlot).toBe(kids.length - 1);
+    expect(kids[settingsSlot - 1]).toBe(spacer);
+    // ...and every screen icon comes before the spacer.
+    const last = bar.querySelector<HTMLElement>('[data-activity="commit"]')!;
+    expect(kids.findIndex((k) => k.contains(last))).toBeLessThan(
+      settingsSlot - 1,
+    );
   });
 });
 

--- a/src/design/chrome.tsx
+++ b/src/design/chrome.tsx
@@ -471,14 +471,23 @@ export function PGActivityBar({
 }) {
   return (
     <div
+      data-pg-activity-bar=""
       style={{
         width: 44,
+        // The rail fills its container, not its content: the `flex: 1` spacer
+        // below is what pins Settings to the bottom edge, and a spacer in an
+        // auto-height box has nothing to claim. AppShell wraps the bar in a
+        // `PGPane` div, so the bar is a BLOCK child (height: auto) and not the
+        // flex item it was before #11 — without this the rail's background and
+        // right border stopped just under the gear, mid-window.
+        height: "100%",
         background: "var(--bg-titlebar)",
         borderRight: "1px solid var(--border-0)",
         display: "flex",
         flexDirection: "column",
         padding: "6px 0",
         flexShrink: 0,
+        boxSizing: "border-box",
       }}
     >
       {items.map((it, idx) => {
@@ -538,7 +547,9 @@ export function PGActivityBar({
           </PGTooltip>
         );
       })}
-      <div style={{ flex: 1 }} />
+      {/* Pins Settings to the bottom edge — only works because the rail
+          itself is full height (see `height` above). */}
+      <div data-pg-activity-spacer="" style={{ flex: 1 }} />
       <PGTooltip content="Settings" placement="right">
         <button
           onClick={onSettingsClick}


### PR DESCRIPTION
The activity rail was visibly cut off mid-window: its `--bg-titlebar`
background and right border stopped just under the Settings gear, and the gear
sat directly below the last screen icon instead of at the bottom edge.

## Why

#11 wrapped `PGActivityBar` in a `PGPane` div. That turned the bar from a flex
item of the shell's flex row (stretched to full height by `align-items:
stretch`) into a **block** child, whose height is its *content* height — so the
`flex: 1` spacer that pins Settings had nothing to claim.

`height: 100%` on the rail restores both the full-height background/border and
the pinned gear, and works whether the wrapper is a block or a flex container.
`box-sizing: border-box` keeps the 1px border and 6px padding *inside* that
100% rather than overflowing 13px onto the status bar.

## Verification

- Real pixels, headless Chrome against the actual component in the actual
  `PGPane` wrapper, three variants side by side: pre-fix (rail ends under the
  gear, screen background bleeding to the left edge), `height: 100%` inside a
  block wrapper (fixed on its own), and as shipped. The middle case is why the
  fix lives on the component and not at the AppShell call site.
- `pnpm test` — 356 files / 3552 tests green.
- `pnpm tsc --noEmit` — clean.
- New `PGActivityBar` block in `chrome.test.tsx` pins the mechanism, and was
  proven to bite: removing `height: 100%` fails the first test, removing the
  spacer fails the second.
