### PR TITLE
fix(design): keep a segmented control's labels on one line

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1659,6 +1659,18 @@ update checks back on for someone who turned them off.
 - `PGButton`/`PGInput` spread `...rest` onto their DOM node; `PGIconButton`
   does NOT (forwards `title` only). Row components need explicit prop threading
   for new attributes.
+- **A control that sits in a toolbar declares `white-space: nowrap`.**
+  `PGToolbar` is a fixed-height (36px) flex row that does NOT wrap, so a narrow
+  window makes flexbox squeeze every shrinkable item in it. A label with a
+  space in it then breaks at that space and stacks two lines inside a
+  22px-high button, bulging the toolbar — which is what History's "This branch"
+  scope did. `nowrap` fixes both halves at once: it stops the break, and
+  because a flex item's automatic minimum size is its min-content size, it also
+  stops the squeeze, so the control holds its width rather than being clipped.
+  `PGButton` and `PGButtonGroup` carry it; `primitives.buttonGroup.test.tsx`
+  pins the group's (jsdom has no layout, so the property IS the test). What
+  yields instead is whatever can ellipsize — `PGSelect` and `PGSearchInput`
+  both do.
 
 ### The icon set is lucide, behind one seam
 

--- a/src/design/primitives.buttonGroup.test.tsx
+++ b/src/design/primitives.buttonGroup.test.tsx
@@ -1,0 +1,65 @@
+// PGButtonGroup — a segmented control's labels must never wrap.
+//
+// The group is a flex item in PGToolbar's row: `display: flex`, no wrap, a
+// fixed 36px height. Narrow the window and flexbox squeezes every shrinkable
+// item in that row, so a two-word label ("This branch" in History's All / This
+// branch scope, "Existing branch" in WorktreeAddDialog, "Comfortable" beside
+// "Compact" in Settings) broke at its space and stacked two lines inside a
+// 22px-high button, bulging the toolbar out of its own height.
+//
+// `white-space: nowrap` is also what stops the squeeze itself: it raises each
+// button's min-content width, and a flex item's automatic minimum size is its
+// min-content size, so the group holds its width instead of being clipped. The
+// same property is already on PGButton for the same reason.
+//
+// jsdom has no layout, so a wrap cannot be observed here — this pins the
+// property that produces the behaviour. The pixels were verified separately
+// with a headless screenshot of the History toolbar from 1174px down to 380px.
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { PGButtonGroup } from "./primitives";
+
+/** History's scope selector, verbatim — the reported case. */
+const SCOPE = [
+  { value: "all", label: "All" },
+  { value: "branch", label: "This branch" },
+];
+
+describe("PGButtonGroup", () => {
+  it("never lets an option label wrap", () => {
+    render(<PGButtonGroup value="all" options={SCOPE} />);
+    for (const opt of SCOPE) {
+      const btn = screen.getByRole("button", { name: opt.label });
+      expect(btn.style.whiteSpace).toBe("nowrap");
+    }
+  });
+
+  it("keeps a multi-word label in one element, unbroken", () => {
+    // A label split across two nodes could still wrap between them however the
+    // white-space declaration reads.
+    render(<PGButtonGroup value="branch" options={SCOPE} />);
+    const btn = screen.getByRole("button", { name: "This branch" });
+    expect(btn.textContent).toBe("This branch");
+  });
+
+  it("holds the rule for the wider groups too", () => {
+    // Branches' five-option filter is the widest group in a toolbar, and the
+    // narrow-column ones sit in dialogs and Settings cards.
+    const wide = [
+      { value: "all", label: "All" },
+      { value: "local", label: "Local" },
+      { value: "remote", label: "Remote" },
+      { value: "tags", label: "Tags" },
+      { value: "stashes", label: "Stashes" },
+      { value: "existing", label: "Existing branch" },
+    ];
+    render(<PGButtonGroup value="all" options={wide} />);
+    for (const opt of wide) {
+      expect(
+        screen.getByRole("button", { name: opt.label }).style.whiteSpace
+      ).toBe("nowrap");
+    }
+  });
+});

--- a/src/design/primitives.tsx
+++ b/src/design/primitives.tsx
@@ -245,6 +245,7 @@ export function PGButtonGroup({ options, value, onChange, size = "md" }: PGButto
               display: "inline-flex",
               alignItems: "center",
               gap: 5,
+              whiteSpace: "nowrap",
               transition: "background var(--t-fast), color var(--t-fast)",
             }}
           >


### PR DESCRIPTION
History's **All / This branch** scope selector broke into two lines ("This" /
"branch") as soon as the window — or the log pane — got narrow, bulging out of
the toolbar's fixed 36px height.

## Root cause

`PGButtonGroup`'s option buttons carried no `white-space` rule. The group is a
flex item in `PGToolbar`'s row (`display: flex`, no wrap, `height: 36`), so
narrowing the window makes flexbox shrink every shrinkable item in that row —
and below the label's intrinsic width the label wraps at its space, inside a
22px-high button.

## Fix

One declaration on the group's option buttons, the same one `PGButton` already
carries (`primitives.tsx:122`):

```diff
   gap: 5,
+  whiteSpace: "nowrap",
```

That closes both halves: it stops the break, and since a flex item's automatic
minimum size is its min-content size, the group also stops being squeezed — so
it holds its full label rather than getting clipped. What yields instead is
whatever can ellipsize, which is what `PGSelect` and `PGSearchInput` already do.

## Verification

- Headless screenshots of the real History toolbar at 1174 / 900 / 760 / 640 /
  560 / 480 / 380px. Before: wrapped at 760px and below. After: one line at
  every width.
- The other groups too — Branches' five-option filter (the widest in a
  toolbar), `WorktreeAddDialog`'s "New branch / Existing branch", Settings'
  "Compact / Comfortable" — one line down to 240px.
- `src/design/primitives.buttonGroup.test.tsx` pins the property (jsdom has no
  layout, so the declaration *is* the test). Verified as a real gate: deleting
  the line again fails 2 of its 3 tests.
- `pnpm test` 3555 passed / 357 files, `pnpm tsc --noEmit` clean.

One consequence worth naming: at extreme narrowness (≲480px of toolbar) the
right-hand icon buttons now get pushed out of view slightly sooner, because the
selector keeps the width the wrap used to give away. The toolbar already clipped
there before this change; keeping the control legible is the better trade, and
the search input is what absorbs the shrinking above that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
