### PR TITLE
fix(ui): keep the commit-detail clock on the timestamp's line

### DIFF
--- a/docs/dev/frontend.md
+++ b/docs/dev/frontend.md
@@ -1670,8 +1670,22 @@ imports `lucide-react` — that one seam is why the set could be swapped at all
 (it was hand-drawn SVG paths until then, and no feature had reached past
 `PGIcon` to the paths).
 
-Three things are load-bearing:
+Four things are load-bearing:
 
+- **An icon beside text goes in a flex row — never inline flow with
+  `vertical-align` on the glyph.** `src/index.css` opens with
+  `@import "tailwindcss"`, and Tailwind's Preflight blockifies every replaced
+  element (`img, svg, video, … { display: block; vertical-align: middle }`). A
+  `PGIcon` in an inline formatting context is therefore a *block* box: it takes
+  a line of its own, and `verticalAlign` on it is inert, because that property
+  only aligns inline-level boxes. This is not theoretical — the commit-detail
+  meta row shipped `<span><PGIcon name="clock" style={{ verticalAlign:
+  "middle" }} />{date}</span>` and drew the clock *above* the timestamp at every
+  panel width, while the author cell 8 lines above it looked right for the only
+  reason that matters: it was `display: flex; alignItems: center; gap: 4`. That
+  flex row is the app's idiom (it is why the other ~125 call sites are fine), so
+  match it; `git-components.date.test.tsx` pins the date cell's shape against
+  the author cell's, since jsdom has no layout and cannot see the wrap itself.
 - **`strokeWidth` is expressed on a 16-unit grid, not lucide's 24.** A stroke's
   rendered thickness is `strokeWidth * size / grid`, so `PGIcon` scales the
   width it hands lucide by `24/16`. That is what keeps `strokeWidth={1.5}`

--- a/src/design/git-components.date.test.tsx
+++ b/src/design/git-components.date.test.tsx
@@ -103,4 +103,38 @@ describe("PGCommitDetail date", () => {
     expect(cell.title).toContain("+02:00");
     expect(cell.textContent).not.toContain("+02:00");
   });
+
+  it("puts the clock glyph on the stamp's own line, the way the author cell does", () => {
+    // Tailwind's Preflight (`@import "tailwindcss"`, src/index.css:1) blockifies
+    // every replaced element — `svg { display: block }` — so a PGIcon sitting in
+    // INLINE flow beside text takes a line of its own, and `vertical-align`
+    // cannot pull it back: it only aligns inline-level boxes. The cell therefore
+    // has to be a flex row, exactly like the author cell beside it, which is why
+    // that one always looked right and this one rendered the clock ABOVE the
+    // time. jsdom has no layout, so what this pins is the mechanism.
+    const { container } = render(
+      <PGCommitDetail
+        sha="abc1234"
+        subject="feat: something"
+        author="Tester"
+        email="tester@example.com"
+        date="2026-08-14 13:42:07 · 3w ago"
+        dateTitle={TITLE}
+        parents={["def5678"]}
+      />,
+    );
+    const cell = container.querySelector<HTMLElement>('[data-testid="commit-detail-date"]')!;
+    expect(cell.style.display).toBe("flex");
+    expect(cell.style.alignItems).toBe("center");
+
+    // One pattern for the whole meta row, not two: the author cell is the
+    // working example, so a future edit that changes one has to change both.
+    const [authorCell] = Array.from(cell.parentElement!.children) as HTMLElement[];
+    expect(authorCell.style.display).toBe("flex");
+    expect(cell.style.display).toBe(authorCell.style.display);
+    expect(cell.style.alignItems).toBe(authorCell.style.alignItems);
+
+    // And the glyph no longer asks to be aligned in a flow it is not part of.
+    expect(cell.querySelector("svg")!.style.verticalAlign).toBe("");
+  });
 });

--- a/src/design/git-components.tsx
+++ b/src/design/git-components.tsx
@@ -1941,12 +1941,17 @@ export function PGCommitDetail({
           {author}
           {email && <span style={{ color: "var(--fg-3)" }}>&lt;{email}&gt;</span>}
         </span>
-        <span data-testid="commit-detail-date" title={dateTitle}>
-          <PGIcon
-            name="clock"
-            size={10}
-            style={{ verticalAlign: "middle", marginRight: 3 }}
-          />
+        {/* A flex row, not inline flow with `vertical-align` on the glyph:
+            Tailwind's Preflight blockifies replaced elements (`svg { display:
+            block }`), so an icon beside text in inline flow takes a line of its
+            own and the clock rendered ABOVE the stamp. Same shape as the author
+            cell above — one pattern for the whole row. */}
+        <span
+          data-testid="commit-detail-date"
+          title={dateTitle}
+          style={{ display: "flex", alignItems: "center", gap: 4 }}
+        >
+          <PGIcon name="clock" size={10} />
           {date}
         </span>
         {parents.length > 0 && (


### PR DESCRIPTION
The commit panel's meta row drew the clock glyph **above** the timestamp
instead of beside it:

```
JA Jonas Aasberg <jonas.aasberg@clave.no>  🕐          parent: e1ce98c
                                           2026-09-07 13:37:47 · 2 min ago
```

It happened at **every** panel width — 420px through 1000px, with 300px of
free space to spare — so it was never a wrap.

## Root cause

`src/index.css` opens with `@import "tailwindcss"`, and Tailwind's Preflight
blockifies every replaced element:

```css
img, svg, video, canvas, audio, iframe, embed, object {
  display: block;
  vertical-align: middle;
}
```

The date cell put the icon in **inline flow** and tried to align it with
`verticalAlign: "middle"`. A block box takes a line of its own, and
`vertical-align` only aligns inline-level boxes — so the declaration was
inert and the glyph could never share the line.

The author cell 8 lines above it looked right for the only reason that
matters: it is `display: flex; alignItems: center; gap: 4`. That flex row is
the app's idiom for icon-beside-text, which is why the other ~125 `PGIcon`
call sites are unaffected — I swept them, and the only other `verticalAlign`
in `src/` is a `<span>` with an explicit `display: inline-block`, which
Preflight does not touch.

## The fix

Make the date cell the same flex row as the author cell beside it, and drop
the inert `verticalAlign`. One pattern for the whole row.

## Verification

- `git-components.date.test.tsx` gains a test that pins the date cell's
  shape **against the author cell's**, so the two cannot diverge again.
  jsdom has no layout and cannot see the wrap itself, so what it pins is the
  mechanism. Confirmed failing before the fix, passing after.
- Real pixels: headless-Chrome screenshots of the component at nine panel
  widths, before and after. Clock is inline at every width, and the whole
  meta row is a single line from 700px up.
- `pnpm test` — 356 files / 3553 tests green. `pnpm tsc --noEmit` clean.
- No e2e run: frontend-only, and nothing in `e2e/` touches this cell (the
  `commit-detail-date` testid is referenced only by the unit test). The
  change alters no text content.

The durable lesson — an icon beside text goes in a flex row, never inline
flow with `vertical-align`, because Preflight blockifies svg — is written
into the icon-set section of `docs/dev/frontend.md`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
